### PR TITLE
Issue #4017 constrained RL reward wrapper

### DIFF
--- a/docs/context/issue_4017_constrained_rl_design.md
+++ b/docs/context/issue_4017_constrained_rl_design.md
@@ -1,0 +1,41 @@
+# Issue 4017 Constrained Reinforcement Learning Design
+
+This note defines the first constrained reinforcement learning slice for social navigation:
+extract existing RobotEnv safety metadata as costs, apply a Lagrangian reward penalty during
+training, and keep claims at design-and-unit-test scope until a later training smoke and diagnostic
+comparison run.
+
+## Claim Boundary
+
+- Evidence status: diagnostic design slice only.
+- This PR does not train a policy, run a benchmark campaign, submit Slurm or GPU jobs, or make a
+  paper-facing safety claim.
+- The constrained reward wrapper preserves the raw task reward and attaches constraint diagnostics
+  so a later Stable-Baselines3 callback can update multipliers after completed vectorized episodes.
+- Fallback or degraded benchmark execution is not used as evidence for this slice.
+
+## Contract
+
+The first supported safety-cost sources are read from `RobotEnv.step()` `info` metadata:
+
+- `collision_any`: top-level collision flag or pedestrian, obstacle, or robot collision metadata.
+- `pedestrian_collision`: pedestrian collision metadata.
+- `robot_or_obstacle`: robot or obstacle collision metadata.
+- `near_miss`: finite non-negative `near_misses` scalar.
+- `comfort_exposure`: finite non-negative `comfort_exposure` scalar.
+- `ttc_risk`: inverse finite positive `time_to_collision`.
+
+Unknown sources fail closed during constraint-spec construction. Non-finite or negative scalar
+metadata is clamped to zero cost rather than propagating invalid values through training rewards.
+
+The wrapper adds these step diagnostics:
+
+- `constraint_costs`
+- `constraint_multipliers`
+- `raw_task_reward`
+- `constrained_reward`
+
+On terminal or truncated steps, the wrapper also adds `constraint_episode` with costs, budgets,
+violations, multiplier values before any update, and episode step count. Multipliers are not updated
+inside `step()`; later training callbacks must call the explicit update method from completed
+episode diagnostics to avoid vectorized-environment update races.

--- a/docs/context/issue_4017_constrained_rl_design.md
+++ b/docs/context/issue_4017_constrained_rl_design.md
@@ -23,7 +23,7 @@ The first supported safety-cost sources are read from `RobotEnv.step()` `info` m
 - `robot_or_obstacle`: robot or obstacle collision metadata.
 - `near_miss`: finite non-negative `near_misses` scalar.
 - `comfort_exposure`: finite non-negative `comfort_exposure` scalar.
-- `ttc_risk`: inverse finite positive `time_to_collision`.
+- `ttc_risk`: bounded inverse finite positive `time_to_collision`.
 
 Unknown sources fail closed during constraint-spec construction. Non-finite or negative scalar
 metadata is clamped to zero cost rather than propagating invalid values through training rewards.

--- a/robot_sf/training/constrained_reward_wrapper.py
+++ b/robot_sf/training/constrained_reward_wrapper.py
@@ -1,0 +1,90 @@
+"""Gymnasium reward wrapper for PPO-Lagrangian constrained training."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from gymnasium import Wrapper
+
+from robot_sf.training.safety_constraints import (
+    LagrangeMultiplierState,
+    SafetyConstraintSpec,
+    step_safety_costs,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class ConstrainedRewardWrapper(Wrapper):
+    """Apply Lagrangian safety-cost penalties while preserving raw task reward diagnostics."""
+
+    def __init__(
+        self,
+        env: Any,
+        constraints: Sequence[SafetyConstraintSpec],
+        *,
+        multiplier_state: LagrangeMultiplierState | None = None,
+    ) -> None:
+        """Initialize the wrapper around a Gymnasium-compatible environment."""
+        super().__init__(env)
+        self.constraints = tuple(constraints)
+        if not self.constraints:
+            raise ValueError("ConstrainedRewardWrapper requires at least one constraint")
+        self.multiplier_state = multiplier_state or LagrangeMultiplierState.from_specs(
+            self.constraints
+        )
+
+    def reset(self, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
+        """Reset wrapped environment and clear partial episode costs.
+
+        Returns:
+            Wrapped environment reset observation and info.
+        """
+        self.multiplier_state.reset_episode_costs(self.constraints)
+        return self.env.reset(**kwargs)
+
+    def step(self, action: Any) -> tuple[Any, float, bool, bool, dict[str, Any]]:
+        """Apply the constrained reward transform to one environment step.
+
+        Returns:
+            Gymnasium step tuple with constrained reward and added diagnostics.
+        """
+        observation, raw_reward, terminated, truncated, info = self.env.step(action)
+        info = dict(info)
+        costs = step_safety_costs(info, self.constraints)
+        multipliers = dict(self.multiplier_state.values)
+        penalty = sum(multipliers.get(name, 0.0) * cost for name, cost in costs.items())
+        constrained_reward = float(raw_reward) - penalty
+        self.multiplier_state.observe_step(costs)
+
+        info["constraint_costs"] = costs
+        info["constraint_multipliers"] = multipliers
+        info["raw_task_reward"] = float(raw_reward)
+        info["constrained_reward"] = constrained_reward
+
+        if terminated or truncated:
+            info["constraint_episode"] = self.multiplier_state.episode_summary(self.constraints)
+            self.multiplier_state.reset_episode_costs(self.constraints)
+
+        return observation, constrained_reward, terminated, truncated, info
+
+    def update_multipliers_from_episode(
+        self,
+        episode_costs: dict[str, float],
+        *,
+        episode_steps: int | None = None,
+    ) -> dict[str, float]:
+        """Update Lagrange multipliers from externally collected episode diagnostics.
+
+        Returns:
+            Updated multiplier values keyed by constraint name.
+        """
+        return self.multiplier_state.update_after_episode(
+            self.constraints,
+            episode_costs=episode_costs,
+            episode_steps=episode_steps,
+        )
+
+
+__all__ = ["ConstrainedRewardWrapper"]

--- a/robot_sf/training/constrained_reward_wrapper.py
+++ b/robot_sf/training/constrained_reward_wrapper.py
@@ -31,6 +31,12 @@ class ConstrainedRewardWrapper(Wrapper):
         self.constraints = tuple(constraints)
         if not self.constraints:
             raise ValueError("ConstrainedRewardWrapper requires at least one constraint")
+        seen_names: set[str] = set()
+        for spec in self.constraints:
+            normalized_name = spec.name.casefold()
+            if normalized_name in seen_names:
+                raise ValueError(f"Duplicate constraint name: {spec.name}")
+            seen_names.add(normalized_name)
         self.multiplier_state = multiplier_state or LagrangeMultiplierState.from_specs(
             self.constraints
         )

--- a/robot_sf/training/safety_constraints.py
+++ b/robot_sf/training/safety_constraints.py
@@ -1,0 +1,219 @@
+"""Safety-cost extraction and Lagrange multiplier state for constrained training."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from math import isfinite
+from typing import Any
+
+SUPPORTED_SAFETY_COST_SOURCES = frozenset(
+    {
+        "collision_any",
+        "pedestrian_collision",
+        "robot_or_obstacle",
+        "near_miss",
+        "comfort_exposure",
+        "ttc_risk",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SafetyConstraintSpec:
+    """Configuration for one episodic safety-cost budget."""
+
+    name: str
+    budget_per_episode: float
+    source_key: str
+    multiplier_init: float = 1.0
+    multiplier_lr: float = 0.05
+    multiplier_max: float = 50.0
+    normalize_by_episode_steps: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate the constraint spec fail-closed before training starts."""
+        if not self.name:
+            raise ValueError("SafetyConstraintSpec.name must be non-empty")
+        if self.source_key not in SUPPORTED_SAFETY_COST_SOURCES:
+            raise ValueError(f"Unsupported safety-cost source: {self.source_key}")
+        _require_non_negative_finite(self.budget_per_episode, "budget_per_episode")
+        _require_non_negative_finite(self.multiplier_init, "multiplier_init")
+        _require_non_negative_finite(self.multiplier_lr, "multiplier_lr")
+        _require_non_negative_finite(self.multiplier_max, "multiplier_max")
+        if self.multiplier_init > self.multiplier_max:
+            raise ValueError("multiplier_init must be <= multiplier_max")
+
+
+@dataclass
+class LagrangeMultiplierState:
+    """Mutable Lagrange multiplier and episode-cost accumulator state."""
+
+    values: dict[str, float]
+    episode_costs: dict[str, float] = field(default_factory=dict)
+    completed_episodes: int = 0
+    episode_steps: int = 0
+
+    @classmethod
+    def from_specs(cls, specs: Sequence[SafetyConstraintSpec]) -> LagrangeMultiplierState:
+        """Build multiplier state initialized from constraint specs.
+
+        Returns:
+            New state with multiplier values and zeroed episode cost accumulators.
+        """
+        return cls(
+            values={spec.name: spec.multiplier_init for spec in specs},
+            episode_costs={spec.name: 0.0 for spec in specs},
+        )
+
+    def observe_step(self, costs: Mapping[str, float]) -> None:
+        """Accumulate one step of extracted safety costs."""
+        for name, cost in costs.items():
+            self.episode_costs[name] = self.episode_costs.get(name, 0.0) + _finite_non_negative(
+                cost
+            )
+        self.episode_steps += 1
+
+    def episode_summary(
+        self,
+        specs: Sequence[SafetyConstraintSpec],
+    ) -> dict[str, dict[str, float] | int]:
+        """Return current episode costs, budgets, violations, and multipliers.
+
+        Returns:
+            Serializable episode diagnostics for callbacks and manifests.
+        """
+        costs = dict(self.episode_costs)
+        budgets = {spec.name: spec.budget_per_episode for spec in specs}
+        violations: dict[str, float] = {}
+        for spec in specs:
+            observed_cost = costs.get(spec.name, 0.0)
+            if spec.normalize_by_episode_steps and self.episode_steps > 0:
+                observed_cost /= self.episode_steps
+            violations[spec.name] = observed_cost - spec.budget_per_episode
+        return {
+            "costs": costs,
+            "budgets": budgets,
+            "violations": violations,
+            "multipliers_before_update": dict(self.values),
+            "episode_steps": self.episode_steps,
+        }
+
+    def update_after_episode(
+        self,
+        specs: Sequence[SafetyConstraintSpec],
+        *,
+        episode_costs: Mapping[str, float] | None = None,
+        episode_steps: int | None = None,
+    ) -> dict[str, float]:
+        """Update multipliers from completed episode costs and clip to configured bounds.
+
+        Returns:
+            Updated multiplier values keyed by constraint name.
+        """
+        costs = self.episode_costs if episode_costs is None else episode_costs
+        steps = self.episode_steps if episode_steps is None else episode_steps
+        for spec in specs:
+            observed_cost = _finite_non_negative(costs.get(spec.name, 0.0))
+            if spec.normalize_by_episode_steps and steps > 0:
+                observed_cost /= steps
+            next_value = self.values.get(spec.name, spec.multiplier_init) + spec.multiplier_lr * (
+                observed_cost - spec.budget_per_episode
+            )
+            self.values[spec.name] = min(spec.multiplier_max, max(0.0, next_value))
+        self.completed_episodes += 1
+        return dict(self.values)
+
+    def reset_episode_costs(self, specs: Sequence[SafetyConstraintSpec]) -> None:
+        """Reset per-episode cost accumulators after terminal diagnostics are emitted."""
+        self.episode_costs = {spec.name: 0.0 for spec in specs}
+        self.episode_steps = 0
+
+
+def step_safety_costs(
+    info: Mapping[str, Any],
+    specs: Sequence[SafetyConstraintSpec],
+) -> dict[str, float]:
+    """Extract configured safety costs from one environment ``info`` payload.
+
+    Returns:
+        Safety cost scalar for each configured constraint name.
+    """
+    return {spec.name: _source_cost(info, spec.source_key) for spec in specs}
+
+
+def _source_cost(info: Mapping[str, Any], source_key: str) -> float:
+    """Return one supported safety-cost scalar from RobotEnv step metadata.
+
+    Returns:
+        Non-negative cost for the requested source.
+    """
+    meta = info.get("meta")
+    meta_mapping = meta if isinstance(meta, Mapping) else {}
+    if source_key == "collision_any":
+        return float(
+            bool(info.get("collision"))
+            or bool(meta_mapping.get("is_pedestrian_collision"))
+            or bool(meta_mapping.get("is_obstacle_collision"))
+            or bool(meta_mapping.get("is_robot_collision"))
+        )
+    if source_key == "pedestrian_collision":
+        return float(bool(meta_mapping.get("is_pedestrian_collision")))
+    if source_key == "robot_or_obstacle":
+        return float(
+            bool(meta_mapping.get("is_robot_collision"))
+            or bool(meta_mapping.get("is_obstacle_collision"))
+        )
+    if source_key == "near_miss":
+        return _finite_non_negative(meta_mapping.get("near_misses"))
+    if source_key == "comfort_exposure":
+        return _finite_non_negative(meta_mapping.get("comfort_exposure"))
+    if source_key == "ttc_risk":
+        time_to_collision = _finite_positive(meta_mapping.get("time_to_collision"))
+        return 0.0 if time_to_collision is None else 1.0 / time_to_collision
+    raise ValueError(f"Unsupported safety-cost source: {source_key}")
+
+
+def _finite_non_negative(value: Any) -> float:
+    """Coerce finite non-negative floats and clamp invalid values to zero.
+
+    Returns:
+        Finite non-negative float, or zero for invalid input.
+    """
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not isfinite(result):
+        return 0.0
+    return max(0.0, result)
+
+
+def _finite_positive(value: Any) -> float | None:
+    """Coerce finite positive floats, returning ``None`` for invalid values.
+
+    Returns:
+        Positive finite float, or ``None`` when no positive value is available.
+    """
+    result = _finite_non_negative(value)
+    if result <= 0.0:
+        return None
+    return result
+
+
+def _require_non_negative_finite(value: Any, field_name: str) -> None:
+    """Raise if ``value`` is not finite and non-negative."""
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be finite and non-negative") from exc
+    if not isfinite(result) or result < 0.0:
+        raise ValueError(f"{field_name} must be finite and non-negative")
+
+
+__all__ = [
+    "SUPPORTED_SAFETY_COST_SOURCES",
+    "LagrangeMultiplierState",
+    "SafetyConstraintSpec",
+    "step_safety_costs",
+]

--- a/robot_sf/training/safety_constraints.py
+++ b/robot_sf/training/safety_constraints.py
@@ -17,6 +17,7 @@ SUPPORTED_SAFETY_COST_SOURCES = frozenset(
         "ttc_risk",
     }
 )
+MIN_TTC_SECONDS_FOR_RISK_COST = 1e-4
 
 
 @dataclass(frozen=True)
@@ -113,6 +114,12 @@ class LagrangeMultiplierState:
         """
         costs = self.episode_costs if episode_costs is None else episode_costs
         steps = self.episode_steps if episode_steps is None else episode_steps
+        if episode_costs is not None and episode_steps is None:
+            if any(spec.normalize_by_episode_steps for spec in specs):
+                raise ValueError(
+                    "episode_steps must be provided when external episode_costs are used with "
+                    "step-normalized constraints"
+                )
         for spec in specs:
             observed_cost = _finite_non_negative(costs.get(spec.name, 0.0))
             if spec.normalize_by_episode_steps and steps > 0:
@@ -170,7 +177,9 @@ def _source_cost(info: Mapping[str, Any], source_key: str) -> float:
         return _finite_non_negative(meta_mapping.get("comfort_exposure"))
     if source_key == "ttc_risk":
         time_to_collision = _finite_positive(meta_mapping.get("time_to_collision"))
-        return 0.0 if time_to_collision is None else 1.0 / time_to_collision
+        if time_to_collision is None:
+            return 0.0
+        return 1.0 / max(MIN_TTC_SECONDS_FOR_RISK_COST, time_to_collision)
     raise ValueError(f"Unsupported safety-cost source: {source_key}")
 
 
@@ -212,6 +221,7 @@ def _require_non_negative_finite(value: Any, field_name: str) -> None:
 
 
 __all__ = [
+    "MIN_TTC_SECONDS_FOR_RISK_COST",
     "SUPPORTED_SAFETY_COST_SOURCES",
     "LagrangeMultiplierState",
     "SafetyConstraintSpec",

--- a/tests/training/test_constrained_reward_wrapper.py
+++ b/tests/training/test_constrained_reward_wrapper.py
@@ -1,0 +1,109 @@
+"""Tests for the constrained reward wrapper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from gymnasium import Env, spaces
+
+from robot_sf.training.constrained_reward_wrapper import ConstrainedRewardWrapper
+from robot_sf.training.safety_constraints import SafetyConstraintSpec
+
+
+class _DummyEnv(Env):
+    """Small deterministic environment for wrapper behavior tests."""
+
+    metadata = {"render_modes": []}
+
+    def __init__(self, *, terminal: bool = False) -> None:
+        """Initialize a one-step test environment."""
+        super().__init__()
+        self.observation_space = spaces.Box(low=0.0, high=1.0, shape=(1,), dtype=np.float32)
+        self.action_space = spaces.Discrete(1)
+        self.terminal = terminal
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[np.ndarray, dict[str, Any]]:
+        """Return the deterministic initial observation."""
+        super().reset(seed=seed)
+        return np.array([0.0], dtype=np.float32), {}
+
+    def step(self, action: Any) -> tuple[np.ndarray, float, bool, bool, dict[str, Any]]:
+        """Return a fixed reward and near-miss cost payload."""
+        del action
+        return (
+            np.array([0.5], dtype=np.float32),
+            2.0,
+            self.terminal,
+            False,
+            {"meta": {"near_misses": 2.0}},
+        )
+
+
+def _near_miss_spec() -> SafetyConstraintSpec:
+    return SafetyConstraintSpec(
+        name="near_miss",
+        source_key="near_miss",
+        budget_per_episode=0.5,
+        multiplier_init=0.25,
+        multiplier_lr=0.1,
+        multiplier_max=1.0,
+    )
+
+
+def test_wrapper_preserves_observation_and_termination_outputs() -> None:
+    """Observation and terminal flags pass through unchanged."""
+    env = ConstrainedRewardWrapper(_DummyEnv(terminal=True), [_near_miss_spec()])
+
+    observation, reward, terminated, truncated, info = env.step(0)
+
+    assert observation.shape == (1,)
+    assert reward == 1.5
+    assert terminated is True
+    assert truncated is False
+    assert info["raw_task_reward"] == 2.0
+
+
+def test_constrained_reward_decreases_when_cost_multiplier_is_positive() -> None:
+    """Positive safety costs reduce the training reward."""
+    env = ConstrainedRewardWrapper(_DummyEnv(), [_near_miss_spec()])
+
+    _, reward, _, _, info = env.step(0)
+
+    assert reward < info["raw_task_reward"]
+    assert info["constrained_reward"] == reward
+    assert info["constraint_costs"] == {"near_miss": 2.0}
+    assert info["constraint_multipliers"] == {"near_miss": 0.25}
+
+
+def test_episode_cost_summary_appears_on_terminal_info() -> None:
+    """Terminal steps include episode cost, budget, and violation diagnostics."""
+    env = ConstrainedRewardWrapper(_DummyEnv(terminal=True), [_near_miss_spec()])
+
+    _, _, _, _, info = env.step(0)
+
+    episode = info["constraint_episode"]
+    assert episode["costs"] == {"near_miss": 2.0}
+    assert episode["budgets"] == {"near_miss": 0.5}
+    assert episode["violations"] == {"near_miss": 1.5}
+    assert episode["multipliers_before_update"] == {"near_miss": 0.25}
+
+
+def test_multiplier_update_is_explicit_not_step_side_effect() -> None:
+    """Vectorized training callbacks update multipliers explicitly after episodes."""
+    env = ConstrainedRewardWrapper(_DummyEnv(terminal=True), [_near_miss_spec()])
+
+    _, _, _, _, info = env.step(0)
+    assert env.multiplier_state.values == {"near_miss": 0.25}
+
+    updated = env.update_multipliers_from_episode(
+        info["constraint_episode"]["costs"],
+        episode_steps=info["constraint_episode"]["episode_steps"],
+    )
+
+    assert updated == {"near_miss": 0.4}

--- a/tests/training/test_constrained_reward_wrapper.py
+++ b/tests/training/test_constrained_reward_wrapper.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pytest
 from gymnasium import Env, spaces
 
 from robot_sf.training.constrained_reward_wrapper import ConstrainedRewardWrapper
@@ -79,6 +80,18 @@ def test_constrained_reward_decreases_when_cost_multiplier_is_positive() -> None
     assert info["constrained_reward"] == reward
     assert info["constraint_costs"] == {"near_miss": 2.0}
     assert info["constraint_multipliers"] == {"near_miss": 0.25}
+
+
+def test_wrapper_rejects_duplicate_constraint_names_case_insensitively() -> None:
+    """Constraint names key multiplier state, so duplicates must fail closed."""
+    duplicate = SafetyConstraintSpec(
+        name="Near_Miss",
+        source_key="near_miss",
+        budget_per_episode=0.5,
+    )
+
+    with pytest.raises(ValueError, match="Duplicate constraint name"):
+        ConstrainedRewardWrapper(_DummyEnv(), [_near_miss_spec(), duplicate])
 
 
 def test_episode_cost_summary_appears_on_terminal_info() -> None:

--- a/tests/training/test_safety_constraints.py
+++ b/tests/training/test_safety_constraints.py
@@ -83,3 +83,29 @@ def test_multiplier_update_clips_to_bounds() -> None:
 
     assert updated == {"collision": 1.0}
     assert state.completed_episodes == 1
+
+
+def test_normalized_external_episode_costs_require_episode_steps() -> None:
+    """Externally supplied costs must include steps for step-normalized constraints."""
+    specs = [
+        _spec(
+            "near_miss",
+            "near_miss",
+            budget_per_episode=0.5,
+            normalize_by_episode_steps=True,
+        )
+    ]
+    state = LagrangeMultiplierState.from_specs(specs)
+
+    with pytest.raises(ValueError, match="episode_steps must be provided"):
+        state.update_after_episode(specs, episode_costs={"near_miss": 1.0})
+
+
+def test_ttc_risk_cost_is_bounded_for_tiny_positive_values() -> None:
+    """TTC risk source should not create unbounded rewards for tiny positive TTC."""
+    costs = step_safety_costs(
+        {"meta": {"time_to_collision": 1e-12}},
+        [_spec("ttc", "ttc_risk")],
+    )
+
+    assert costs == {"ttc": 10000.0}

--- a/tests/training/test_safety_constraints.py
+++ b/tests/training/test_safety_constraints.py
@@ -1,0 +1,85 @@
+"""Tests for constrained-RL safety-cost extraction."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from robot_sf.training.safety_constraints import (
+    LagrangeMultiplierState,
+    SafetyConstraintSpec,
+    step_safety_costs,
+)
+
+
+def _spec(name: str, source_key: str, **overrides: float) -> SafetyConstraintSpec:
+    return SafetyConstraintSpec(
+        name=name,
+        source_key=source_key,
+        budget_per_episode=overrides.pop("budget_per_episode", 0.0),
+        **overrides,
+    )
+
+
+def test_collision_any_uses_top_level_collision_flag() -> None:
+    """Top-level RobotEnv collision flag counts as one collision cost."""
+    costs = step_safety_costs(
+        {"collision": True, "meta": {}}, [_spec("collision", "collision_any")]
+    )
+
+    assert costs == {"collision": 1.0}
+
+
+def test_collision_any_uses_pedestrian_collision_metadata() -> None:
+    """Pedestrian collision metadata counts even if top-level flag is missing."""
+    costs = step_safety_costs(
+        {"meta": {"is_pedestrian_collision": True}},
+        [_spec("collision", "collision_any")],
+    )
+
+    assert costs == {"collision": 1.0}
+
+
+@pytest.mark.parametrize("value", [None, float("nan"), -1.0, "not-a-number"])
+def test_near_miss_clamps_invalid_or_missing_values_to_zero(value: object) -> None:
+    """Invalid near-miss metadata is fail-closed to zero cost, not NaN propagation."""
+    costs = step_safety_costs(
+        {"meta": {"near_misses": value}},
+        [_spec("near_miss", "near_miss")],
+    )
+
+    assert costs == {"near_miss": 0.0}
+
+
+@pytest.mark.parametrize("meta", [{}, {"comfort_exposure": None}, {"comfort_exposure": math.nan}])
+def test_comfort_exposure_handles_absent_and_non_finite_values(meta: dict[str, object]) -> None:
+    """Comfort exposure extraction tolerates absent or non-finite metadata."""
+    costs = step_safety_costs({"meta": meta}, [_spec("comfort", "comfort_exposure")])
+
+    assert costs == {"comfort": 0.0}
+
+
+def test_unknown_cost_source_fails_closed() -> None:
+    """Unknown cost sources are rejected before training starts."""
+    with pytest.raises(ValueError, match="Unsupported safety-cost source"):
+        SafetyConstraintSpec(name="unknown", source_key="unknown", budget_per_episode=0.0)
+
+
+def test_multiplier_update_clips_to_bounds() -> None:
+    """Lagrange multiplier updates are clipped to the configured range."""
+    specs = [
+        _spec(
+            "collision",
+            "collision_any",
+            multiplier_init=0.1,
+            multiplier_lr=10.0,
+            multiplier_max=1.0,
+        )
+    ]
+    state = LagrangeMultiplierState.from_specs(specs)
+
+    updated = state.update_after_episode(specs, episode_costs={"collision": 10.0})
+
+    assert updated == {"collision": 1.0}
+    assert state.completed_episodes == 1


### PR DESCRIPTION
## Reviewer-critical summary

What changed: implements the issue #4017 PR-1 slice by adding safety-cost extraction from existing `RobotEnv.step()` metadata, a Lagrange multiplier state container, and a `ConstrainedRewardWrapper` that applies `raw_task_reward - sum(lambda_i * safety_cost_i)` while preserving diagnostics.

Why now: the live issue plan asks for the PPO-Lagrangian constrained reinforcement learning lane to start with this wrapper contract before adding the training script and diagnostic comparison.

Claim boundary: diagnostic design and unit-test evidence only. This PR does not train a policy, run a benchmark campaign, submit Slurm/GPU jobs, or make paper/dissertation safety claims.

Required validation: targeted training tests and lint for the new constrained-reward contract; final PR readiness was run with this body file.

Remaining blocker: issue #4017 should stay open until a later slice adds the PPO-Lagrangian training script, smoke run, unconstrained baseline, paired diagnostic comparison, and caveated report.

## Contract delta

New schema/API fields:

- `SafetyConstraintSpec`: `name`, `budget_per_episode`, `source_key`, `multiplier_init`, `multiplier_lr`, `multiplier_max`, `normalize_by_episode_steps`.
- `LagrangeMultiplierState`: mutable `values`, `episode_costs`, `completed_episodes`, and `episode_steps` with explicit episode-update helpers.
- `ConstrainedRewardWrapper` step diagnostics: `constraint_costs`, `constraint_multipliers`, `raw_task_reward`, `constrained_reward`.
- Terminal or truncated step diagnostic: `constraint_episode` with costs, budgets, violations, multipliers before update, and episode step count.

New fail-closed blockers:

- Unknown safety-cost `source_key` values raise `ValueError` during spec construction.
- Negative or non-finite budgets, multiplier learning rates, initial multipliers, or max multipliers raise `ValueError`.

Compatibility impact:

- Existing environment reward semantics are unchanged unless a caller explicitly wraps the environment.
- Multiplier updates are not performed inside `step()`; vectorized Stable-Baselines3 training callbacks must call the explicit update helper after completed episode diagnostics.
- No metric semantics are redefined; costs are extracted from existing step metadata only.

Issue: Closes part of https://github.com/ll7/robot_sf_ll7/issues/4017, but does not close the issue.

Validation:

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_safety_constraints.py tests/training/test_constrained_reward_wrapper.py -q` -> 15 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_safety_constraints.py tests/training/test_constrained_reward_wrapper.py tests/training/test_observation_wrappers.py -q` -> 21 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/safety_constraints.py robot_sf/training/constrained_reward_wrapper.py tests/training/test_safety_constraints.py tests/training/test_constrained_reward_wrapper.py` -> passed.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

State propagation: no separate issue comment is posted from this run because `comment_issue_or_pr` was not authorized. This PR body is the durable state surface for the slice delivered and remaining work.

<details>
<summary>Governance appendix</summary>

- Live issue comments were rechecked immediately before publication; no newer maintainer guidance changed the PR-1 scope.
- Duplicate/open PR search for issue #4017 and the exact constrained-RL scope returned no open coverage.
- Fragmentation guard did not block this slice: no recent merged PRs for #4017 were found in the last 24 hours, and this PR adds the nameable new capability `ConstrainedRewardWrapper`.
- No transient queue-routing state, target-host state, or packet lineage pointer is tracked in this PR.
- Fallback/degraded execution is not counted as evidence.

</details>
