### PR TITLE
feat: add learned prediction MPC smoke lane (#4013)

### DIFF
--- a/configs/algos/learned_prediction_mpc_issue_4013_smoke.yaml
+++ b/configs/algos/learned_prediction_mpc_issue_4013_smoke.yaml
@@ -1,0 +1,22 @@
+# Learned short-horizon prediction MPC smoke config for issue #4013.
+# Diagnostic only: no trained checkpoint is loaded and no benchmark claim is implied.
+allow_testing_algorithms: true
+allow_untrained_smoke: true
+fallback_to_constant_velocity: false
+checkpoint_path: null
+model_id: null
+normalizer_path: null
+device: cpu
+model_type: mlp
+max_pedestrians: 16
+history_steps: 4
+horizon_steps: 4
+rollout_dt: 0.2
+hidden_dim: 64
+max_linear_speed: 0.9
+max_angular_speed: 1.1
+goal_tolerance: 0.25
+pedestrian_safety_margin: 0.35
+solver_max_iterations: 16
+warm_start: true
+fallback_to_stop: true

--- a/docs/context/issue_4013_learned_model_based_planner_design.md
+++ b/docs/context/issue_4013_learned_model_based_planner_design.md
@@ -1,0 +1,35 @@
+# Issue 4013 Learned Prediction MPC Design Slice
+
+Plain-language summary: this slice adds a small state-based pedestrian predictor that can feed the
+existing prediction-aware model predictive control (MPC) local planner, so future work can train the
+predictor and compare closed-loop navigation without reopening the retired large world-model track.
+
+## Claim Boundary
+
+- Evidence status: diagnostic-only implementation scaffold.
+- Implemented capability: `learned_prediction_mpc` and aliases construct a `PredictionMPCPlannerAdapter`
+  with a learned short-horizon pedestrian predictor backend.
+- Not claimed: no trained predictor, no full benchmark campaign, no paper-facing navigation claim, no
+  DreamerV3/PlaNet/TD-MPC2-style latent world model.
+- Fallback/degraded rows: `fallback_to_constant_velocity=true` is explicitly labeled
+  `diagnostic_constant_velocity_fallback` and is not benchmark evidence.
+
+## Runtime Contract
+
+- Predictor input: current Robot SF social-navigation observation fields for robot state, goal, and
+  pedestrian positions/velocities.
+- Predictor output: pedestrian future positions in world coordinates as `PredictedPedestrianFutures`.
+- Horizon: short-horizon only; the smoke config uses four steps at `0.2` seconds.
+- Default artifact behavior: missing `checkpoint_path`/`model_id` fails closed.
+- Diagnostic smoke behavior: `allow_untrained_smoke=true` builds a deterministic tiny MLP with zeroed
+  weights and labels predictions `diagnostic_untrained_smoke`.
+- World-model boundary: metadata reports `not_full_world_model=true`; the method is a state predictor
+  plus MPC constraints, not a generative navigation world model.
+
+## Remaining Work
+
+- Train a real short-horizon predictor on a smoke dataset and publish checkpoint, normalizer,
+  manifest, and metrics.
+- Load the trained checkpoint without fallback and run a smoke scenario.
+- Compare against `cv_prediction_mpc` and a model-free baseline with paired seeds.
+- Exclude or separately count fallback/degraded rows before making benchmark or paper-facing claims.

--- a/docs/context/issue_4013_learned_model_based_planner_design.md
+++ b/docs/context/issue_4013_learned_model_based_planner_design.md
@@ -1,4 +1,4 @@
-# Issue 4013 Learned Prediction MPC Design Slice
+# Issue #4013 — Learned Prediction MPC Design Slice
 
 Plain-language summary: this slice adds a small state-based pedestrian predictor that can feed the
 existing prediction-aware model predictive control (MPC) local planner, so future work can train the

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -72,6 +72,7 @@ _BASELINE_CATEGORY_BY_CANONICAL: dict[str, str] = {
     "teb": "classical",
     "nmpc_social": "classical",
     "prediction_mpc": "classical",
+    "learned_prediction_mpc": "learning",
 }
 
 _POLICY_SEMANTICS_BY_CANONICAL: dict[str, str] = {
@@ -129,6 +130,7 @@ _POLICY_SEMANTICS_BY_CANONICAL: dict[str, str] = {
     "teb": "corridor_commitment_local_planner",
     "nmpc_social": "nonlinear_model_predictive_local_planner",
     "prediction_mpc": "prediction_aware_model_predictive_local_planner",
+    "learned_prediction_mpc": "learned_short_horizon_prediction_mpc_local_planner",
 }
 
 _DEFAULT_OBSERVATION_SPEC: dict[str, Any] = {
@@ -215,6 +217,15 @@ _OBSERVATION_SPEC_BY_CANONICAL: dict[str, dict[str, Any]] = {
             "Consumes structured SocNav state. The constant-velocity backend derives "
             "time-varying pedestrian futures from tracked pedestrian positions and "
             "ego-frame pedestrian velocities rotated into world coordinates."
+        ),
+    },
+    "learned_prediction_mpc": {
+        "default_mode": "socnav_state",
+        "supported_modes": ("socnav_state",),
+        "inputs": ("robot_state", "goal", "pedestrians", "learned_pedestrian_futures"),
+        "notes": (
+            "Consumes deployable SocNav state with a small short-horizon pedestrian predictor; "
+            "diagnostic-only until a trained checkpoint and comparison evidence exist."
         ),
     },
     "ppo": {
@@ -1036,6 +1047,16 @@ _KINEMATICS_PROFILE_BY_CANONICAL: dict[str, dict[str, Any]] = {
         "default_adapter_name": "PredictionMPCPlannerAdapter",
         "benchmark_command_space": "unicycle_vw",
         "projection_policy": "constant_velocity_time_varying_pedestrian_constraints",
+        "projection_documented": True,
+    },
+    "learned_prediction_mpc": {
+        "planner_command_space": "unicycle_vw",
+        "supports_native_commands": False,
+        "supports_adapter_commands": True,
+        "default_execution_mode": "adapter",
+        "default_adapter_name": "PredictionMPCPlannerAdapter",
+        "benchmark_command_space": "unicycle_vw",
+        "projection_policy": "learned_short_horizon_time_varying_pedestrian_constraints",
         "projection_documented": True,
     },
 }

--- a/robot_sf/benchmark/algorithm_readiness.py
+++ b/robot_sf/benchmark/algorithm_readiness.py
@@ -422,6 +422,21 @@ _ALGORITHMS: tuple[AlgorithmReadiness, ...] = (
         ),
         requires_explicit_opt_in=True,
     ),
+    AlgorithmReadiness(
+        canonical_name="learned_prediction_mpc",
+        tier="experimental",
+        aliases=(
+            "learned_prediction_mpc",
+            "learned_short_horizon_mpc",
+            "model_based_local_planner",
+            "learned_prediction_planner",
+        ),
+        note=(
+            "Diagnostic learned short-horizon pedestrian prediction MPC lane; not a full "
+            "navigation world model and not benchmark evidence without a trained checkpoint."
+        ),
+        requires_explicit_opt_in=True,
+    ),
 )
 
 _ALIAS_INDEX: dict[str, AlgorithmReadiness] = {

--- a/robot_sf/benchmark/policy_builders.py
+++ b/robot_sf/benchmark/policy_builders.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from robot_sf.planner.learned_prediction_mpc import (
+    LEARNED_PREDICTION_MPC_ALIASES,
+    build_learned_prediction_mpc_adapter,
+)
 from robot_sf.planner.prediction_mpc import (
     PredictionMPCPlannerAdapter,
     build_prediction_mpc_config,
@@ -75,7 +79,24 @@ def _build_prediction_mpc_policy_spec(algo_config: dict[str, Any]) -> AdapterPol
     )
 
 
+def _build_learned_prediction_mpc_policy_spec(algo_config: dict[str, Any]) -> AdapterPolicySpec:
+    """Build learned short-horizon prediction MPC algorithm config.
+
+    Returns:
+        AdapterPolicySpec: Map-runner adapter construction payload.
+    """
+
+    return AdapterPolicySpec(
+        algo_key="learned_prediction_mpc",
+        algo_config=algo_config,
+        adapter=build_learned_prediction_mpc_adapter(algo_config),
+        adapter_name="PredictionMPCPlannerAdapter",
+        limitations="diagnostic_learned_short_horizon_prediction_mpc_not_benchmark_evidence",
+    )
+
+
 _ADAPTER_POLICY_BUILDERS: dict[str, Callable[[dict[str, Any]], AdapterPolicySpec]] = {
+    **dict.fromkeys(LEARNED_PREDICTION_MPC_ALIASES, _build_learned_prediction_mpc_policy_spec),
     "cv_prediction_mpc": _build_prediction_mpc_policy_spec,
     "prediction_aware_mpc": _build_prediction_mpc_policy_spec,
     "prediction_mpc": _build_prediction_mpc_policy_spec,

--- a/robot_sf/planner/learned_prediction_mpc.py
+++ b/robot_sf/planner/learned_prediction_mpc.py
@@ -1,0 +1,53 @@
+"""Learned-prediction MPC planner construction helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from robot_sf.planner.learned_short_horizon_predictor import (
+    LearnedShortHorizonPedestrianPredictor,
+    build_learned_short_horizon_predictor_config,
+)
+from robot_sf.planner.prediction_mpc import (
+    PredictionMPCConfig,
+    PredictionMPCPlannerAdapter,
+    build_prediction_mpc_config,
+)
+
+LEARNED_PREDICTION_MPC_ALIASES = frozenset(
+    {
+        "learned_prediction_mpc",
+        "learned_short_horizon_mpc",
+        "model_based_local_planner",
+        "learned_prediction_planner",
+    }
+)
+
+
+def build_learned_prediction_mpc_adapter(
+    algo_config: dict[str, Any] | None,
+) -> PredictionMPCPlannerAdapter:
+    """Build prediction MPC with a learned short-horizon pedestrian predictor.
+
+    Returns:
+        PredictionMPCPlannerAdapter: Adapter wired to the learned predictor backend.
+    """
+
+    raw = dict(algo_config or {})
+    prediction_config = build_prediction_mpc_config(
+        {
+            **raw,
+            "predictor_backend": "learned_short_horizon",
+        }
+    )
+    predictor_config = build_learned_short_horizon_predictor_config(raw)
+    mpc_config = PredictionMPCConfig(
+        **{
+            **prediction_config.__dict__,
+            "horizon_steps": predictor_config.horizon_steps,
+            "rollout_dt": predictor_config.rollout_dt,
+            "predictor_backend": "learned_short_horizon",
+        }
+    )
+    predictor = LearnedShortHorizonPedestrianPredictor(predictor_config)
+    return PredictionMPCPlannerAdapter(config=mpc_config, predictor=predictor)

--- a/robot_sf/planner/learned_short_horizon_predictor.py
+++ b/robot_sf/planner/learned_short_horizon_predictor.py
@@ -1,0 +1,398 @@
+"""Learned short-horizon pedestrian prediction backend for prediction MPC."""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from robot_sf.models.registry import resolve_model_path
+from robot_sf.planner.nmpc_social import _parse_bool
+from robot_sf.planner.prediction_mpc import (
+    ConstantVelocityPedestrianPredictor,
+    PredictedPedestrianFutures,
+)
+
+
+@dataclass(frozen=True)
+class LearnedShortHorizonPredictorConfig:
+    """Configuration for the lightweight learned pedestrian predictor."""
+
+    checkpoint_path: str | None = None
+    model_id: str | None = None
+    normalizer_path: str | None = None
+    device: str = "cpu"
+    max_pedestrians: int = 16
+    history_steps: int = 4
+    horizon_steps: int = 6
+    rollout_dt: float = 0.2
+    hidden_dim: int = 128
+    model_type: str = "mlp"
+    fallback_to_constant_velocity: bool = False
+    allow_untrained_smoke: bool = False
+
+
+class _TinyMlp:
+    """Lazy PyTorch MLP wrapper so module import remains cheap."""
+
+    def __init__(self, *, input_dim: int, output_dim: int, hidden_dim: int, device: str) -> None:
+        """Initialize the tiny state predictor network."""
+
+        torch, nn = _load_torch()
+        self.torch = torch
+        self.module = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.Tanh(),
+            nn.Linear(hidden_dim, output_dim),
+        ).to(device)
+
+    def zero_initialize(self) -> None:
+        """Make untrained-smoke predictions deterministic and stationary."""
+
+        for param in self.module.parameters():
+            param.data.zero_()
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        """Load checkpoint weights into the wrapped module."""
+
+        self.module.load_state_dict(state_dict)
+
+    def predict_numpy(self, features: np.ndarray) -> np.ndarray:
+        """Run a single feature vector through the model.
+
+        Returns:
+            np.ndarray: Flattened model output vector.
+        """
+
+        torch = self.torch
+        self.module.eval()
+        device = next(self.module.parameters()).device
+        with torch.no_grad():
+            tensor = torch.as_tensor(features[None, :], dtype=torch.float32, device=device)
+            output = self.module(tensor).detach().cpu().numpy()
+        return np.asarray(output[0], dtype=float)
+
+
+class LearnedShortHorizonPedestrianPredictor:
+    """State-based learned predictor conforming to ``PedestrianFuturePredictor``."""
+
+    def __init__(self, config: LearnedShortHorizonPredictorConfig) -> None:
+        """Initialize a fail-closed or diagnostic learned predictor."""
+
+        self.config = config
+        self._cv_predictor = ConstantVelocityPedestrianPredictor()
+        self._calls = 0
+        self._last_source = "not_run"
+        self._checkpoint_path = self._resolve_checkpoint_path(config)
+        self._model: _TinyMlp | None = None
+        if self._checkpoint_path is not None:
+            self._model = self._build_model()
+            self._load_checkpoint(self._checkpoint_path)
+            self._evidence_tier = "checkpoint_loaded"
+        elif config.allow_untrained_smoke:
+            self._model = self._build_model()
+            self._model.zero_initialize()
+            self._evidence_tier = "diagnostic_untrained_smoke"
+        elif config.fallback_to_constant_velocity:
+            self._evidence_tier = "diagnostic_constant_velocity_fallback"
+        else:
+            raise ValueError(
+                "learned short-horizon predictor requires checkpoint_path or model_id; "
+                "set allow_untrained_smoke=true only for diagnostic smoke tests."
+            )
+
+    def predict(
+        self,
+        observation: dict[str, Any],
+        *,
+        horizon_steps: int,
+        dt: float,
+    ) -> PredictedPedestrianFutures:
+        """Return predicted pedestrian futures in world coordinates."""
+
+        self._calls += 1
+        if self._checkpoint_path is None and self.config.fallback_to_constant_velocity:
+            futures = self._cv_predictor.predict(observation, horizon_steps=horizon_steps, dt=dt)
+            self._last_source = "diagnostic_constant_velocity_fallback"
+            return PredictedPedestrianFutures(
+                positions_world=futures.positions_world,
+                mask=futures.mask,
+                dt=futures.dt,
+                source=self._last_source,
+            )
+
+        ped_positions, ped_velocities_world = self._pedestrian_state_world(observation)
+        count = min(ped_positions.shape[0], max(int(self.config.max_pedestrians), 0))
+        horizon = max(1, min(int(horizon_steps), int(self.config.horizon_steps)))
+        if count == 0:
+            self._last_source = self._evidence_tier
+            return PredictedPedestrianFutures(
+                positions_world=np.zeros((0, horizon, 2), dtype=float),
+                mask=np.zeros((0,), dtype=float),
+                dt=float(dt),
+                source=self._last_source,
+            )
+
+        features = self._features(observation, ped_positions, ped_velocities_world)
+        if self._model is None:
+            raise RuntimeError("learned predictor model is unavailable outside fallback mode")
+        output = self._model.predict_numpy(features)
+        deltas = output.reshape(self.config.max_pedestrians, self.config.horizon_steps, 2)
+        futures = np.zeros((count, horizon, 2), dtype=float)
+        for step_idx in range(horizon):
+            tau = float(step_idx + 1) * float(dt)
+            learned_delta = deltas[:count, step_idx, :]
+            futures[:, step_idx, :] = (
+                ped_positions[:count] + ped_velocities_world[:count] * tau + learned_delta
+            )
+        self._last_source = self._evidence_tier
+        return PredictedPedestrianFutures(
+            positions_world=futures,
+            mask=np.ones((count,), dtype=float),
+            dt=float(dt),
+            source=self._last_source,
+        )
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return claim-boundary metadata for benchmark rows."""
+
+        return {
+            "backend": "learned_short_horizon",
+            "model_type": self.config.model_type,
+            "evidence_tier": self._evidence_tier,
+            "diagnostic_only": self._evidence_tier.startswith("diagnostic_"),
+            "not_full_world_model": True,
+            "checkpoint_path": str(self._checkpoint_path) if self._checkpoint_path else None,
+            "calls": self._calls,
+            "last_source": self._last_source,
+            "max_pedestrians": self.config.max_pedestrians,
+            "horizon_steps": self.config.horizon_steps,
+        }
+
+    def reset(self) -> None:
+        """Reset per-episode diagnostics."""
+
+        self._calls = 0
+        self._last_source = "not_run"
+
+    def _resolve_checkpoint_path(self, config: LearnedShortHorizonPredictorConfig) -> Path | None:
+        """Resolve configured checkpoint or model registry ID.
+
+        Returns:
+            Path | None: Local checkpoint path, or ``None`` when no artifact is configured.
+        """
+
+        if config.checkpoint_path:
+            path = Path(config.checkpoint_path)
+            if not path.exists():
+                raise FileNotFoundError(f"learned predictor checkpoint not found: {path}")
+            return path
+        if config.model_id:
+            return resolve_model_path(config.model_id, allow_download=False)
+        return None
+
+    def _build_model(self) -> _TinyMlp:
+        """Build the configured small predictor network.
+
+        Returns:
+            _TinyMlp: Tiny PyTorch MLP wrapper.
+        """
+
+        if self.config.model_type.strip().lower() != "mlp":
+            raise ValueError(
+                "learned short-horizon predictor currently supports model_type='mlp' only"
+            )
+        input_dim = 4 + 2 + int(self.config.max_pedestrians) * 4
+        output_dim = int(self.config.max_pedestrians) * int(self.config.horizon_steps) * 2
+        return _TinyMlp(
+            input_dim=input_dim,
+            output_dim=output_dim,
+            hidden_dim=int(self.config.hidden_dim),
+            device=self.config.device,
+        )
+
+    def _load_checkpoint(self, checkpoint_path: Path) -> None:
+        """Load a PyTorch state dict checkpoint."""
+
+        torch, _ = _load_torch()
+        payload = torch.load(checkpoint_path, map_location=self.config.device)
+        state_dict = payload.get("state_dict", payload) if isinstance(payload, dict) else payload
+        if not isinstance(state_dict, dict):
+            raise ValueError(
+                f"learned predictor checkpoint has unsupported format: {checkpoint_path}"
+            )
+        self._model.load_state_dict(state_dict)
+
+    def _features(
+        self,
+        observation: dict[str, Any],
+        ped_positions: np.ndarray,
+        ped_velocities_world: np.ndarray,
+    ) -> np.ndarray:
+        """Encode current state into a fixed-size feature vector.
+
+        Returns:
+            np.ndarray: Fixed-width predictor feature vector.
+        """
+
+        robot = observation.get("robot", {})
+        goal = observation.get("goal", {})
+        robot_pos = _as_xy(robot.get("position", [0.0, 0.0]))
+        heading = float(_as_1d(robot.get("heading", [0.0]), pad=1)[0])
+        speed = float(_as_1d(robot.get("speed", [0.0]), pad=1)[0])
+        goal_pos = _as_xy(goal.get("current", goal.get("next", [0.0, 0.0])))
+
+        features = np.zeros((4 + 2 + int(self.config.max_pedestrians) * 4,), dtype=float)
+        features[:4] = np.asarray([robot_pos[0], robot_pos[1], heading, speed], dtype=float)
+        features[4:6] = goal_pos - robot_pos
+        offset = 6
+        count = min(ped_positions.shape[0], int(self.config.max_pedestrians))
+        for idx in range(count):
+            features[offset : offset + 2] = ped_positions[idx] - robot_pos
+            features[offset + 2 : offset + 4] = ped_velocities_world[idx]
+            offset += 4
+        return features
+
+    def _pedestrian_state_world(self, observation: dict[str, Any]) -> tuple[np.ndarray, np.ndarray]:
+        """Extract pedestrian positions and rotate ego-frame velocities into world frame.
+
+        Returns:
+            tuple[np.ndarray, np.ndarray]: Pedestrian positions and world-frame velocities.
+        """
+
+        ped_state = observation.get("pedestrians", {})
+        robot = observation.get("robot", {})
+        robot_heading = float(_as_1d(robot.get("heading", [0.0]), pad=1)[0])
+        positions = _as_xy_matrix(ped_state.get("positions", []))
+        velocities_ego = _as_xy_matrix(ped_state.get("velocities", []))
+        count = int(_as_1d(ped_state.get("count", [positions.shape[0]]), pad=1)[0])
+        count = max(0, min(count, positions.shape[0]))
+        positions = positions[:count]
+        if velocities_ego.shape[0] < count:
+            velocities_ego = np.zeros_like(positions)
+        else:
+            velocities_ego = velocities_ego[:count]
+        cos_h = float(np.cos(robot_heading))
+        sin_h = float(np.sin(robot_heading))
+        velocities_world = np.empty_like(velocities_ego)
+        velocities_world[:, 0] = cos_h * velocities_ego[:, 0] - sin_h * velocities_ego[:, 1]
+        velocities_world[:, 1] = sin_h * velocities_ego[:, 0] + cos_h * velocities_ego[:, 1]
+        return positions, velocities_world
+
+
+def build_learned_short_horizon_predictor_config(
+    cfg: dict[str, Any] | None,
+) -> LearnedShortHorizonPredictorConfig:
+    """Build predictor config from algorithm YAML mapping.
+
+    Returns:
+        LearnedShortHorizonPredictorConfig: Parsed predictor configuration.
+    """
+
+    raw = dict(cfg or {})
+    defaults = LearnedShortHorizonPredictorConfig()
+    converters = {
+        "checkpoint_path": _optional_str,
+        "model_id": _optional_str,
+        "normalizer_path": _optional_str,
+        "device": str,
+        "max_pedestrians": int,
+        "history_steps": int,
+        "horizon_steps": int,
+        "rollout_dt": float,
+        "hidden_dim": int,
+        "model_type": str,
+        "fallback_to_constant_velocity": _parse_bool,
+        "allow_untrained_smoke": _parse_bool,
+    }
+    kwargs: dict[str, Any] = {}
+    for field in fields(LearnedShortHorizonPredictorConfig):
+        value = raw.get(field.name, getattr(defaults, field.name))
+        try:
+            kwargs[field.name] = converters[field.name](value)
+        except (TypeError, ValueError):
+            default_value = getattr(defaults, field.name)
+            warnings.warn(
+                (
+                    f"Invalid learned predictor config value '{field.name}': {value!r}; "
+                    f"falling back default {default_value!r}."
+                ),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            kwargs[field.name] = default_value
+    return LearnedShortHorizonPredictorConfig(**kwargs)
+
+
+def _optional_str(value: Any) -> str | None:
+    """Normalize optional string values from YAML.
+
+    Returns:
+        str | None: Stripped string value, or ``None`` for empty inputs.
+    """
+
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _load_torch() -> tuple[Any, Any]:
+    """Load PyTorch lazily so ordinary planner imports stay dependency-light.
+
+    Returns:
+        tuple[Any, Any]: Imported ``torch`` module and ``torch.nn`` module.
+    """
+
+    try:
+        torch = importlib.import_module("torch")
+        nn = importlib.import_module("torch.nn")
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "learned short-horizon predictor requires torch for checkpoint or smoke mode"
+        ) from exc
+    return torch, nn
+
+
+def _as_1d(value: Any, *, pad: int) -> np.ndarray:
+    """Return one-dimensional float array padded to ``pad`` length.
+
+    Returns:
+        np.ndarray: One-dimensional padded float array.
+    """
+
+    arr = np.asarray(value, dtype=float).reshape(-1)
+    if arr.size < pad:
+        arr = np.pad(arr, (0, pad - arr.size), mode="constant")
+    return arr
+
+
+def _as_xy(value: Any) -> np.ndarray:
+    """Return first two numeric values as an ``xy`` vector.
+
+    Returns:
+        np.ndarray: Two-element float vector.
+    """
+
+    return _as_1d(value, pad=2)[:2].astype(float)
+
+
+def _as_xy_matrix(value: Any) -> np.ndarray:
+    """Return ``(N, 2)`` float matrix or an empty matrix for invalid inputs.
+
+    Returns:
+        np.ndarray: Two-column float matrix.
+    """
+
+    arr = np.asarray(value, dtype=float)
+    if arr.size == 0:
+        return np.zeros((0, 2), dtype=float)
+    if arr.ndim == 1 and arr.size % 2 == 0:
+        arr = arr.reshape(-1, 2)
+    if arr.ndim != 2 or arr.shape[-1] != 2:
+        return np.zeros((0, 2), dtype=float)
+    return arr.astype(float)

--- a/robot_sf/planner/learned_short_horizon_predictor.py
+++ b/robot_sf/planner/learned_short_horizon_predictor.py
@@ -83,6 +83,12 @@ class LearnedShortHorizonPedestrianPredictor:
     def __init__(self, config: LearnedShortHorizonPredictorConfig) -> None:
         """Initialize a fail-closed or diagnostic learned predictor."""
 
+        if config.max_pedestrians <= 0:
+            raise ValueError("max_pedestrians must be strictly positive")
+        if config.horizon_steps <= 0:
+            raise ValueError("horizon_steps must be strictly positive")
+        if config.hidden_dim <= 0:
+            raise ValueError("hidden_dim must be strictly positive")
         self.config = config
         self._cv_predictor = ConstantVelocityPedestrianPredictor()
         self._calls = 0
@@ -299,7 +305,7 @@ def build_learned_short_horizon_predictor_config(
         "checkpoint_path": _optional_str,
         "model_id": _optional_str,
         "normalizer_path": _optional_str,
-        "device": str,
+        "device": lambda value: str(value).strip() if value else "cpu",
         "max_pedestrians": int,
         "history_steps": int,
         "horizon_steps": int,

--- a/robot_sf/planner/prediction_mpc.py
+++ b/robot_sf/planner/prediction_mpc.py
@@ -135,7 +135,8 @@ class PredictionMPCPlannerAdapter(NMPCSocialPlannerAdapter):
     ) -> None:
         """Initialize the adapter with strict constant-velocity prediction by default."""
         self.prediction_config = config or PredictionMPCConfig()
-        if self.prediction_config.predictor_backend.strip().lower() not in {
+        backend = self.prediction_config.predictor_backend.strip().lower()
+        if predictor is None and backend not in {
             "constant_velocity",
             "cv",
         }:
@@ -151,6 +152,22 @@ class PredictionMPCPlannerAdapter(NMPCSocialPlannerAdapter):
             )
         self._future_predictor = predictor or ConstantVelocityPedestrianPredictor()
         super().__init__(_to_nmpc_config(self.prediction_config))
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return predictor diagnostics for benchmark metadata."""
+
+        diagnostics: dict[str, Any] = dict(super().diagnostics())
+        diagnostics.update(
+            {
+                "predictor_backend": self.prediction_config.predictor_backend,
+                "horizon_steps": self.prediction_config.horizon_steps,
+                "rollout_dt": self.prediction_config.rollout_dt,
+            }
+        )
+        predictor_diagnostics = getattr(self._future_predictor, "diagnostics", None)
+        if callable(predictor_diagnostics):
+            diagnostics["predictor"] = predictor_diagnostics()
+        return diagnostics
 
     def _optimizer_constraints(self, context: _RolloutContext) -> tuple[NonlinearConstraint, ...]:
         """Enforce hard time-varying pedestrian-future clearance constraints.

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -297,6 +297,41 @@ def test_build_policy_prediction_mpc_alias_registers_same_adapter() -> None:
     assert meta["algorithm"] == "prediction_mpc"
 
 
+def test_build_policy_learned_prediction_mpc_registers_diagnostic_adapter() -> None:
+    """Learned prediction MPC aliases use prediction-MPC adapter diagnostics."""
+
+    pytest.importorskip("torch")
+    policy, meta = _build_policy(
+        "learned_prediction_mpc",
+        {
+            "allow_testing_algorithms": True,
+            "allow_untrained_smoke": True,
+            "max_pedestrians": 2,
+            "horizon_steps": 2,
+            "hidden_dim": 8,
+            "solver_max_iterations": 4,
+        },
+        robot_kinematics="differential_drive",
+    )
+
+    adapter = policy._planner_adapter
+
+    assert adapter.prediction_config.predictor_backend == "learned_short_horizon"
+    assert meta["planner_kinematics"]["adapter_name"] == "PredictionMPCPlannerAdapter"
+    assert (
+        meta["planner_kinematics"]["projection_policy"]
+        == "learned_short_horizon_time_varying_pedestrian_constraints"
+    )
+    assert meta["canonical_algorithm"] == "learned_prediction_mpc"
+    assert meta["baseline_category"] == "learning"
+    assert meta["observation_spec"]["inputs"] == [
+        "robot_state",
+        "goal",
+        "pedestrians",
+        "learned_pedestrian_futures",
+    ]
+
+
 def test_resolve_policy_search_candidate_runtime_merges_base_and_scenario_override(
     tmp_path: Path,
 ) -> None:

--- a/tests/planner/test_learned_short_horizon_predictor.py
+++ b/tests/planner/test_learned_short_horizon_predictor.py
@@ -1,0 +1,128 @@
+"""Tests for the learned short-horizon pedestrian predictor."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robot_sf.planner.learned_prediction_mpc import build_learned_prediction_mpc_adapter
+from robot_sf.planner.learned_short_horizon_predictor import (
+    LearnedShortHorizonPedestrianPredictor,
+    LearnedShortHorizonPredictorConfig,
+    build_learned_short_horizon_predictor_config,
+)
+
+
+def _obs(*, heading: float = 0.0) -> dict[str, object]:
+    """Build compact SocNav observation for learned predictor tests."""
+
+    return {
+        "robot": {
+            "position": np.asarray([0.0, 0.0], dtype=float),
+            "heading": np.asarray([heading], dtype=float),
+            "speed": np.asarray([0.0], dtype=float),
+        },
+        "goal": {"current": np.asarray([2.0, 0.0], dtype=float)},
+        "pedestrians": {
+            "positions": np.asarray([[1.0, 2.0]], dtype=float),
+            "velocities": np.asarray([[1.0, 0.0]], dtype=float),
+            "count": np.asarray([1.0], dtype=float),
+        },
+    }
+
+
+def test_learned_predictor_config_parses_yaml_values() -> None:
+    """YAML-style scalar values map into the learned predictor config."""
+
+    cfg = build_learned_short_horizon_predictor_config(
+        {
+            "allow_untrained_smoke": "true",
+            "max_pedestrians": "4",
+            "horizon_steps": "3",
+            "rollout_dt": "0.1",
+            "hidden_dim": "16",
+        }
+    )
+
+    assert cfg.allow_untrained_smoke is True
+    assert cfg.max_pedestrians == 4
+    assert cfg.horizon_steps == 3
+    assert cfg.rollout_dt == 0.1
+    assert cfg.hidden_dim == 16
+
+
+def test_learned_predictor_missing_checkpoint_fails_closed() -> None:
+    """Learned predictor requires an artifact unless diagnostic mode is explicit."""
+
+    with pytest.raises(ValueError, match="requires checkpoint_path or model_id"):
+        LearnedShortHorizonPedestrianPredictor(LearnedShortHorizonPredictorConfig())
+
+
+def test_learned_predictor_missing_checkpoint_path_fails_closed(tmp_path) -> None:
+    """Missing configured checkpoint path is a hard setup error."""
+
+    with pytest.raises(FileNotFoundError, match="checkpoint not found"):
+        LearnedShortHorizonPedestrianPredictor(
+            LearnedShortHorizonPredictorConfig(checkpoint_path=str(tmp_path / "missing.pt"))
+        )
+
+
+def test_untrained_smoke_predictor_is_deterministic_and_diagnostic() -> None:
+    """Untrained smoke mode returns deterministic diagnostic futures."""
+
+    pytest.importorskip("torch")
+    predictor = LearnedShortHorizonPedestrianPredictor(
+        LearnedShortHorizonPredictorConfig(
+            allow_untrained_smoke=True,
+            max_pedestrians=2,
+            horizon_steps=2,
+            hidden_dim=8,
+        )
+    )
+
+    futures = predictor.predict(_obs(heading=np.pi / 2.0), horizon_steps=2, dt=0.5)
+
+    np.testing.assert_allclose(futures.positions_world[0, 0], np.asarray([1.0, 2.5]))
+    np.testing.assert_allclose(futures.positions_world[0, 1], np.asarray([1.0, 3.0]))
+    assert futures.source == "diagnostic_untrained_smoke"
+    diagnostics = predictor.diagnostics()
+    assert diagnostics["diagnostic_only"] is True
+    assert diagnostics["not_full_world_model"] is True
+    assert diagnostics["calls"] == 1
+
+
+def test_fallback_predictor_marks_constant_velocity_non_evidence() -> None:
+    """Explicit fallback stays labeled diagnostic rather than success evidence."""
+
+    predictor = LearnedShortHorizonPedestrianPredictor(
+        LearnedShortHorizonPredictorConfig(fallback_to_constant_velocity=True)
+    )
+
+    futures = predictor.predict(_obs(), horizon_steps=1, dt=0.5)
+
+    np.testing.assert_allclose(futures.positions_world[0, 0], np.asarray([1.5, 2.0]))
+    assert futures.source == "diagnostic_constant_velocity_fallback"
+    assert predictor.diagnostics()["diagnostic_only"] is True
+
+
+def test_learned_prediction_mpc_adapter_exposes_predictor_diagnostics() -> None:
+    """Learned MPC adapter wires predictor into existing prediction-MPC constraints."""
+
+    pytest.importorskip("torch")
+    planner = build_learned_prediction_mpc_adapter(
+        {
+            "allow_untrained_smoke": True,
+            "max_pedestrians": 2,
+            "horizon_steps": 2,
+            "hidden_dim": 8,
+            "solver_max_iterations": 4,
+        }
+    )
+
+    futures = planner._future_predictor.predict(_obs(), horizon_steps=2, dt=0.2)
+    diagnostics = planner.diagnostics()
+
+    assert planner.prediction_config.predictor_backend == "learned_short_horizon"
+    assert futures.source == "diagnostic_untrained_smoke"
+    assert diagnostics["predictor"]["backend"] == "learned_short_horizon"
+    assert diagnostics["predictor"]["diagnostic_only"] is True

--- a/tests/planner/test_learned_short_horizon_predictor.py
+++ b/tests/planner/test_learned_short_horizon_predictor.py
@@ -37,6 +37,7 @@ def test_learned_predictor_config_parses_yaml_values() -> None:
     cfg = build_learned_short_horizon_predictor_config(
         {
             "allow_untrained_smoke": "true",
+            "device": None,
             "max_pedestrians": "4",
             "horizon_steps": "3",
             "rollout_dt": "0.1",
@@ -45,10 +46,23 @@ def test_learned_predictor_config_parses_yaml_values() -> None:
     )
 
     assert cfg.allow_untrained_smoke is True
+    assert cfg.device == "cpu"
     assert cfg.max_pedestrians == 4
     assert cfg.horizon_steps == 3
     assert cfg.rollout_dt == 0.1
     assert cfg.hidden_dim == 16
+
+
+def test_learned_predictor_config_rejects_non_positive_dimensions() -> None:
+    """Non-positive model dimensions fail before obscure tensor errors."""
+
+    for field in ("max_pedestrians", "horizon_steps", "hidden_dim"):
+        config = LearnedShortHorizonPredictorConfig(
+            allow_untrained_smoke=True,
+            **{field: 0},
+        )
+        with pytest.raises(ValueError, match=f"{field} must be strictly positive"):
+            LearnedShortHorizonPedestrianPredictor(config)
 
 
 def test_learned_predictor_missing_checkpoint_fails_closed() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds the first learned-prediction MPC implementation slice for #4013: a small state-based learned short-horizon pedestrian predictor, a `learned_prediction_mpc` adapter path plus aliases, algorithm metadata/readiness registration, a diagnostic smoke config, focused tests, and a design note.

Why now: the live issue owner comment explicitly asked for PR 1 as an implementation lane, not another monitor/gate-only micro-guard.

Claim boundary: diagnostic scaffold scaffold. The untrained smoke mode is labeled `diagnostic_untrained_smoke`; constant-velocity fallback is labeled `diagnostic_constant_velocity_fallback`; neither is benchmark evidence or a paper/dissertation claim.

Required validation: focused planner/metadata tests, Ruff lint/format, and final `pr_ready_check` on the clean committed head.

Remaining blocker: #4013 still needs a trained short-horizon predictor checkpoint, normalizer/manifest/metrics, smoke scenario execution without fallback, and paired comparison against `cv_prediction_mpc` plus a model-free baseline.

## Contract delta

New schema/metadata fields and keys:
- New algorithm key: `learned_prediction_mpc`.
- New aliases: `learned_short_horizon_mpc`, `model_based_local_planner`, `learned_prediction_planner`.
- New predictor diagnostics: `backend`, `evidence_tier`, `diagnostic_only`, `not_full_world_model`, `checkpoint_path`, `calls`, `last_source`, `max_pedestrians`, `horizon_steps`.
- New smoke config: `configs/algos/learned_prediction_mpc_issue_4013_smoke.yaml`.

New fail-closed blockers:
- Missing `checkpoint_path`/`model_id` raises unless `allow_untrained_smoke=true` or `fallback_to_constant_velocity=true` is explicitly configured.
- Missing checkpoint file raises `FileNotFoundError`.
- Unknown learned model type raises; only `mlp` is accepted in this slice.

Compatibility impact:
- Existing `prediction_mpc`, `prediction_aware_mpc`, and `cv_prediction_mpc` behavior remains unchanged.
- `PredictionMPCPlannerAdapter` now accepts an injected non-CV predictor while preserving fail-closed rejection for unknown backends without an injected predictor.
- Torch is loaded lazily so ordinary planner imports and core tests do not require Torch until checkpoint or smoke predictor construction.

## Scope summary

Closes no issue. Implements PR 1 only for https://github.com/ll7/robot_sf_ll7/issues/4013.

In scope:
- learned short-horizon predictor backend conforming to `PedestrianFuturePredictor`;
- existing prediction-MPC adapter integration and map-runner registration;
- diagnostic smoke config and design note;
- focused tests for fail-closed setup, diagnostic smoke/fallback labeling, metadata registration, and existing prediction-MPC diagnostics preservation.

Out of scope:
- no full benchmark campaign run;
- no Slurm/GPU submission;
- no paper/dissertation claim edits;
- no trained checkpoint, normalizer, model manifest, or predictor training pipeline;
- no DreamerV3/PlaNet/TD-MPC2/full world-model implementation.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/planner/test_learned_short_horizon_predictor.py tests/planner/test_prediction_mpc.py tests/benchmark/test_map_runner_utils.py::test_build_policy_learned_prediction_mpc_registers_diagnostic_adapter tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_algorithm_readiness_contract.py -q` -> passed, `61 passed`.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/planner/learned_short_horizon_predictor.py robot_sf/planner/learned_prediction_mpc.py robot_sf/planner/prediction_mpc.py robot_sf/benchmark/policy_builders.py robot_sf/benchmark/algorithm_metadata.py robot_sf/benchmark/algorithm_readiness.py tests/planner/test_learned_short_horizon_predictor.py tests/benchmark/test_map_runner_utils.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check ...` -> passed.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-4013/pr_body.md scripts/dev/pr_ready_check.sh` -> passed on clean head `acee1a12c`; core lane `1737 passed`, optional predictive lane `4223 passed, 7 skipped`, freshness stamp `output/validation/pr_ready/issue-4013-learned-prediction-mpc-smoke.json`.

## Domain-Aware Approval

- Required PR: yes - diagnostic scaffold evidence-validity wording is present
- Domains reviewed: evidence classification, experimental comparison
- Status: waived
- Approver/review source waiver: waived because this PR makes no benchmark, paper, dissertation, or planner-comparison evidence claim; reviewer should treat this as implementation integrity only
- Approval or blocker note: waived because this PR makes no benchmark, paper, dissertation, or planner-comparison evidence claim
- Validity checklist:
  - Target claim/hypothesis: #4013 remains diagnostic scaffold; no trained-predictor or navigation-quality claim moves in this PR
  - Comparator or split/evidence validity: targeted smoke and contract tests only; no paired comparison against `cv_prediction_mpc` or model-free baseline yet
  - Fallback/degraded exclusions: untrained smoke and constant-velocity fallback are explicitly diagnostic and excluded from benchmark evidence
  - Claim boundary: not a full world model, not benchmark evidence, not paper/dissertation evidence
  - Implementation integrity vs experimental validity: tests prove fail-closed setup, metadata registration, and diagnostic labels; they do not prove experimental validity

## Downstream propagation

Not applicable as benchmark evidence because this PR is a diagnostic implementation scaffold only. The durable state surface is this PR body plus `docs/context/issue_4013_learned_model_based_planner_design.md`; no extra issue comment is needed for high-churn issue state unless requested.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: no open duplicate PR found; no issue-4013 merged PRs found in the last 24 hours. This is a progression slice adding a nameable new capability: `learned_prediction_mpc`.

Artifact classification: no generated benchmark outputs or model artifacts are committed. `output/coverage` and `output/validation/pr_ready` remain ignored local validation outputs.

Late-guidance check: issue #4013 will be re-read immediately before opening the PR; any newer maintainer guidance after this run start will be incorporated or called out.

</details>
