### PR TITLE
Issue #4015: add hybrid global/RL local planner adapter

### DIFF
--- a/configs/algos/hybrid_global_rl_sac_issue_4015_smoke.yaml
+++ b/configs/algos/hybrid_global_rl_sac_issue_4015_smoke.yaml
@@ -1,0 +1,16 @@
+# Diagnostic-only route-conditioned SAC local planner config for issue #4015.
+algo: hybrid_global_rl
+local_policy_algo: sac
+local_policy_config:
+  fallback_to_goal: false
+  obs_mode: dict
+  action_space: unicycle
+waypoint_provider: grid_route
+allow_goal_fallback: false
+fail_closed_on_missing_waypoint: true
+max_linear_speed: 1.0
+max_angular_speed: 1.0
+grid_route:
+  max_linear_speed: 0.9
+  max_angular_speed: 1.2
+  waypoint_lookahead_cells: 5

--- a/docs/context/issue_4015_hybrid_global_rl_design.md
+++ b/docs/context/issue_4015_hybrid_global_rl_design.md
@@ -1,0 +1,25 @@
+# Issue #4015 Hybrid Global/RL Local Planner Design
+
+This first slice adds a route-conditioned learned local planner adapter: an existing global
+waypoint provider rewrites the local goal passed to an existing reinforcement learning (RL) local
+policy.
+
+## Scope
+
+- Adds `HybridGlobalRLLocalAdapter` as an adapter/interface lane, not a new global planner.
+- Uses `GridRoutePlannerAdapter` as the initial waypoint provider.
+- Supports `SACPlanner` and `PPOPlanner` as existing learned local policy wrappers.
+- Registers `hybrid_global_rl` and aliases through the map-runner policy-builder registry.
+
+## Claim Boundary
+
+Evidence status: `diagnostic-only`. This PR proves route waypoint injection, fail-closed behavior,
+action conversion, and map-runner construction. It is not benchmark evidence and makes no robustness
+claim.
+
+## Remaining Work
+
+- Run a representative route/occupancy scenario with a real learned local policy checkpoint.
+- Produce a paired-seed diagnostic comparison against the same end-to-end RL policy without route
+  conditioning.
+- Add the analysis report that excludes fallback/degraded rows from benchmark-strength evidence.

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -38,6 +38,7 @@ _BASELINE_CATEGORY_BY_CANONICAL: dict[str, str] = {
     "gensafenav_gst_predictor_rand_guarded": "learning",
     "ppo": "learning",
     "sac": "learning",
+    "hybrid_global_rl": "diagnostic",
     "guarded_ppo": "learning",
     "socnav_sampling": "classical",
     "sacadrl": "learning",
@@ -97,6 +98,7 @@ _POLICY_SEMANTICS_BY_CANONICAL: dict[str, str] = {
     "dr_mpc": "upstream_dr_mpc_residual_mpc_wrapper",
     "ppo": "policy_network_inference",
     "sac": "policy_network_inference",
+    "hybrid_global_rl": "route_conditioned_policy_network_inference",
     "guarded_ppo": "guarded_policy_network_inference",
     "socnav_sampling": "heuristic_sampling_adapter",
     "sacadrl": "learned_value_adapter",
@@ -225,6 +227,15 @@ _OBSERVATION_SPEC_BY_CANONICAL: dict[str, dict[str, Any]] = {
             "PPO checkpoint inference uses sensor-fusion by default; BC/materialized "
             "checkpoints may opt into the SocNav structured observation stack they were "
             "trained with."
+        ),
+    },
+    "hybrid_global_rl": {
+        "default_mode": "sensor_fusion_state",
+        "supported_modes": ("sensor_fusion_state", "socnav_state"),
+        "inputs": ("robot_state", "goal", "route_waypoint", "pedestrians"),
+        "notes": (
+            "Route-conditioned learned local planner rewrites goal.current/goal_current "
+            "to a short-horizon waypoint before invoking an existing PPO or SAC policy."
         ),
     },
     "guarded_ppo": {
@@ -779,6 +790,17 @@ _KINEMATICS_PROFILE_BY_CANONICAL: dict[str, dict[str, Any]] = {
         "supports_native_commands": True,
         "supports_adapter_commands": False,
         "default_execution_mode": "native",
+    },
+    "hybrid_global_rl": {
+        "planner_command_space": "mixed_vw_or_vxy",
+        "supports_native_commands": False,
+        "supports_adapter_commands": True,
+        "default_execution_mode": "adapter",
+        "default_adapter_name": "HybridGlobalRLLocalAdapter",
+        "benchmark_command_space": "unicycle_vw",
+        "projection_policy": "route_waypoint_conditioned_rl_action_to_unicycle_vw",
+        "projection_documented": True,
+        "diagnostic_reference_only": True,
     },
     "guarded_ppo": {
         "planner_command_space": "mixed_vw_or_vxy",

--- a/robot_sf/benchmark/algorithm_readiness.py
+++ b/robot_sf/benchmark/algorithm_readiness.py
@@ -292,6 +292,21 @@ _ALGORITHMS: tuple[AlgorithmReadiness, ...] = (
         requires_explicit_opt_in=True,
     ),
     AlgorithmReadiness(
+        canonical_name="hybrid_global_rl",
+        tier="experimental",
+        aliases=(
+            "hybrid_global_rl",
+            "global_rl_local",
+            "route_conditioned_rl",
+            "hybrid_route_rl",
+        ),
+        note=(
+            "Diagnostic-only route-conditioned learned local planner; not benchmark evidence "
+            "until paired route-scenario comparison is recorded."
+        ),
+        requires_explicit_opt_in=True,
+    ),
+    AlgorithmReadiness(
         canonical_name="topology_guided_hybrid_rule_v0",
         tier="experimental",
         aliases=("topology_guided_hybrid_rule_v0", "topology_hypothesis_dwa_v0"),

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -122,6 +122,7 @@ from robot_sf.benchmark.map_runner_observations import obs_to_ppo_format as _obs
 from robot_sf.benchmark.map_runner_policies import adapters as _adapter_policy_builders
 from robot_sf.benchmark.map_runner_policies import adaptive_proxemic as _adaptive_proxemic_builder
 from robot_sf.benchmark.map_runner_policies import goal as _goal_policy_builder
+from robot_sf.benchmark.map_runner_policies import hybrid_global_rl as _hybrid_global_rl_builder
 from robot_sf.benchmark.map_runner_policies import registry as _policy_builder_registry
 from robot_sf.benchmark.map_runner_policies import safety_barrier as _safety_barrier_builder
 from robot_sf.benchmark.map_runner_policy_actions import (
@@ -986,6 +987,9 @@ _POLICY_BUILDERS: dict[str, _policy_builder_registry.PolicyBuilder] = {
         _adaptive_proxemic_builder.build,
     ),
     **dict.fromkeys(_safety_barrier_builder.ADAPTER_ALGO_KEYS, _safety_barrier_builder.build),
+    **dict.fromkeys(
+        _hybrid_global_rl_builder.HYBRID_GLOBAL_RL_KEYS, _hybrid_global_rl_builder.build
+    ),
 }
 
 

--- a/robot_sf/benchmark/map_runner_policies/hybrid_global_rl.py
+++ b/robot_sf/benchmark/map_runner_policies/hybrid_global_rl.py
@@ -1,0 +1,65 @@
+"""Builder for route-conditioned learned local planner policies."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.map_runner_policy_common import build_adapter_policy
+from robot_sf.planner.hybrid_global_rl import (
+    HybridGlobalRLLocalAdapter,
+    build_hybrid_global_rl_config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+HYBRID_GLOBAL_RL_KEYS = frozenset(
+    {"hybrid_global_rl", "global_rl_local", "route_conditioned_rl", "hybrid_route_rl"}
+)
+
+
+def build(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    robot_kinematics: str | None = None,
+    robot_command_mode: str | None = None,
+    adapter_impact_eval: bool = False,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build route-conditioned learned local planner policy metadata.
+
+    Returns:
+        Policy callable and enriched map-runner metadata.
+    """
+
+    if algo_key not in HYBRID_GLOBAL_RL_KEYS:
+        supported = ", ".join(sorted(HYBRID_GLOBAL_RL_KEYS))
+        raise ValueError(
+            f"Unsupported hybrid_global_rl algo_key {algo_key!r}; expected {supported}"
+        )
+    del adapter_impact_eval
+    normalized_robot_command_mode = (
+        str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
+    )
+    config = build_hybrid_global_rl_config(algo_config)
+    adapter = HybridGlobalRLLocalAdapter(config=config)
+    meta: dict[str, Any] = {
+        "algorithm": algo_key,
+        "hybrid_global_rl": {
+            "status": "enabled",
+            "waypoint_provider": config.waypoint_provider,
+            "local_policy_algo": config.local_policy_algo,
+            "allow_goal_fallback": config.allow_goal_fallback,
+            "claim_boundary": "diagnostic-only route-conditioned RL local planner",
+        },
+    }
+    return build_adapter_policy(
+        algo_key=algo_key,
+        algo_config=algo_config,
+        meta=meta,
+        adapter=adapter,
+        adapter_name="HybridGlobalRLLocalAdapter",
+        robot_kinematics=robot_kinematics,
+        normalized_robot_command_mode=normalized_robot_command_mode,
+        limitations="diagnostic_only_not_benchmark_evidence",
+    )

--- a/robot_sf/planner/hybrid_global_rl.py
+++ b/robot_sf/planner/hybrid_global_rl.py
@@ -234,11 +234,14 @@ class HybridGlobalRLLocalAdapter:
             )
 
         goal = conditioned.get("goal")
-        if isinstance(goal, dict) and "current" in goal:
+        if goal is None:
+            goal = {}
+            conditioned["goal"] = goal
+        if isinstance(goal, dict):
             goal["current"] = list(waypoint_list)
         if "goal_current" in conditioned:
             conditioned["goal_current"] = list(waypoint_list)
-        if not (isinstance(goal, dict) and "current" in goal) and "goal_current" not in conditioned:
+        if not isinstance(goal, dict) and "goal_current" not in conditioned:
             conditioned["goal_current"] = list(waypoint_list)
         return conditioned
 
@@ -253,7 +256,9 @@ class HybridGlobalRLLocalAdapter:
         goal = observation.get("goal")
         candidate: Any | None = None
         if isinstance(goal, dict):
-            candidate = goal.get("current") or goal.get("next")
+            candidate = goal.get("current")
+            if candidate is None:
+                candidate = goal.get("next")
         if candidate is None:
             candidate = observation.get("goal_current")
         if candidate is None:

--- a/robot_sf/planner/hybrid_global_rl.py
+++ b/robot_sf/planner/hybrid_global_rl.py
@@ -1,0 +1,344 @@
+"""Route-conditioned learned local planner adapter.
+
+This module implements the first issue #4015 slice: a global route waypoint
+provider rewrites the local goal seen by an existing learned local policy. It
+does not add a new global planner algorithm or train a new RL policy.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from math import atan2, cos, sin
+from typing import Any, Protocol
+
+import numpy as np
+
+from robot_sf.baselines.ppo import PPOPlanner
+from robot_sf.baselines.sac import SACPlanner
+from robot_sf.planner.grid_route import GridRoutePlannerAdapter, build_grid_route_config
+from robot_sf.planner.risk_dwa import _wrap_angle
+
+
+@dataclass(frozen=True)
+class HybridGlobalRLLocalConfig:
+    """Configuration for route-conditioned learned local policy execution."""
+
+    local_policy_algo: str = "sac"
+    local_policy_config: dict[str, Any] = field(default_factory=dict)
+    waypoint_provider: str = "grid_route"
+    grid_route: dict[str, Any] = field(default_factory=dict)
+    allow_goal_fallback: bool = False
+    fail_closed_on_missing_waypoint: bool = True
+    preserve_final_goal: bool = True
+    waypoint_max_distance_from_robot: float = 3.0
+    max_linear_speed: float = 1.0
+    max_angular_speed: float = 1.0
+
+
+@dataclass(frozen=True)
+class WaypointDecision:
+    """Waypoint selection result used to condition the learned local policy."""
+
+    status: str
+    waypoint: tuple[float, float] | None
+    source: str
+    reason: str | None = None
+    route_geometry: dict[str, Any] | None = None
+
+
+class WaypointProvider(Protocol):
+    """Provider interface for route-conditioning waypoints."""
+
+    def waypoint(self, observation: dict[str, Any]) -> WaypointDecision:
+        """Return the short-horizon waypoint for ``observation``."""
+
+
+class GridRouteWaypointProvider:
+    """Waypoint provider backed by the existing occupancy-grid route planner."""
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        """Initialize the provider from grid-route configuration."""
+
+        self.adapter = GridRoutePlannerAdapter(config=build_grid_route_config(config))
+
+    def waypoint(self, observation: dict[str, Any]) -> WaypointDecision:
+        """Return grid-route waypoint diagnostics without issuing a command."""
+
+        route_geometry = self.adapter.route_geometry(observation)
+        waypoint = self.adapter.route_waypoint(observation)
+        if waypoint is None:
+            return WaypointDecision(
+                status="missing",
+                waypoint=None,
+                source="grid_route",
+                reason="route_waypoint_unavailable",
+                route_geometry=route_geometry,
+            )
+        waypoint_arr = np.asarray(waypoint, dtype=float).reshape(-1)
+        if waypoint_arr.size < 2 or not np.all(np.isfinite(waypoint_arr[:2])):
+            return WaypointDecision(
+                status="missing",
+                waypoint=None,
+                source="grid_route",
+                reason="route_waypoint_nonfinite",
+                route_geometry=route_geometry,
+            )
+        return WaypointDecision(
+            status="ok",
+            waypoint=(float(waypoint_arr[0]), float(waypoint_arr[1])),
+            source="grid_route",
+            route_geometry=route_geometry,
+        )
+
+
+class HybridGlobalRLLocalAdapter:
+    """Adapter that feeds route-conditioned observations to an RL local policy."""
+
+    def __init__(
+        self,
+        *,
+        config: HybridGlobalRLLocalConfig | None = None,
+        waypoint_provider: WaypointProvider | None = None,
+        local_policy: Any | None = None,
+    ):
+        """Initialize the route-conditioned local planner adapter."""
+
+        self.config = config or HybridGlobalRLLocalConfig()
+        if self.config.waypoint_provider != "grid_route" and waypoint_provider is None:
+            raise ValueError("Only waypoint_provider='grid_route' is supported by issue #4015 PR 1")
+        self.waypoint_provider = waypoint_provider or GridRouteWaypointProvider(
+            self.config.grid_route
+        )
+        self.local_policy = local_policy or self._build_local_policy()
+        self._last_diagnostics: dict[str, Any] = {"status": "not_started"}
+
+    def _build_local_policy(self) -> Any:
+        """Instantiate the configured learned local policy wrapper.
+
+        Returns:
+            Existing SAC or PPO local policy wrapper.
+        """
+
+        algo = self.config.local_policy_algo.strip().lower()
+        if algo == "sac":
+            return SACPlanner(self.config.local_policy_config, seed=None)
+        if algo == "ppo":
+            return PPOPlanner(self.config.local_policy_config, seed=None)
+        raise ValueError(f"Unsupported local_policy_algo {self.config.local_policy_algo!r}")
+
+    def reset(self, *, seed: int | None = None) -> None:
+        """Reset diagnostics and propagate reset to the local policy."""
+
+        self._last_diagnostics = {"status": "reset"}
+        reset = getattr(self.local_policy, "reset", None)
+        if callable(reset):
+            reset(seed=seed)
+
+    def close(self) -> None:
+        """Close the wrapped local policy if it exposes a close hook."""
+
+        close = getattr(self.local_policy, "close", None)
+        if callable(close):
+            close()
+
+    def bind_env(self, env: Any) -> None:
+        """Bind benchmark environment to the wrapped policy when supported."""
+
+        bind_env = getattr(self.local_policy, "bind_env", None)
+        if callable(bind_env):
+            bind_env(env)
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return last route-conditioning decision and local policy metadata."""
+
+        diagnostics = dict(self._last_diagnostics)
+        get_metadata = getattr(self.local_policy, "get_metadata", None)
+        if callable(get_metadata):
+            diagnostics["local_policy_metadata"] = get_metadata()
+        return diagnostics
+
+    def plan(self, observation: dict[str, Any]) -> tuple[float, float]:
+        """Run the route-conditioned learned local planner.
+
+        Returns:
+            Bounded unicycle command as ``(linear_velocity, angular_velocity)``.
+        """
+
+        decision = self.waypoint_provider.waypoint(observation)
+        if decision.waypoint is None:
+            if not self.config.allow_goal_fallback and self.config.fail_closed_on_missing_waypoint:
+                self._last_diagnostics = self._diagnostics_payload(
+                    decision=decision,
+                    conditioned=False,
+                    action_conversion_mode="not_run",
+                    fallback_status="fail_closed",
+                )
+                raise RuntimeError("hybrid_global_rl route waypoint unavailable")
+            conditioned_observation = deepcopy(observation)
+            fallback_status = "goal_fallback"
+            waypoint = self._extract_final_goal(conditioned_observation)
+        else:
+            waypoint = decision.waypoint
+            conditioned_observation = self._inject_waypoint_goal(observation, waypoint)
+            fallback_status = "none"
+
+        action = self.local_policy.step(conditioned_observation)
+        linear, angular, conversion_mode = self._action_to_unicycle(action, conditioned_observation)
+        self._last_diagnostics = self._diagnostics_payload(
+            decision=decision,
+            conditioned=decision.waypoint is not None,
+            action_conversion_mode=conversion_mode,
+            fallback_status=fallback_status,
+            injected_waypoint=waypoint,
+        )
+        return linear, angular
+
+    def _diagnostics_payload(
+        self,
+        *,
+        decision: WaypointDecision,
+        conditioned: bool,
+        action_conversion_mode: str,
+        fallback_status: str,
+        injected_waypoint: tuple[float, float] | None = None,
+    ) -> dict[str, Any]:
+        """Build JSON-ready diagnostics for the last planner decision.
+
+        Returns:
+            Structured metadata payload suitable for episode diagnostics.
+        """
+
+        return {
+            "status": "ok" if conditioned or fallback_status == "goal_fallback" else "failed",
+            "waypoint_source": decision.source,
+            "waypoint_status": decision.status,
+            "waypoint_reason": decision.reason,
+            "waypoint": list(injected_waypoint) if injected_waypoint is not None else None,
+            "route_geometry": decision.route_geometry,
+            "fallback_status": fallback_status,
+            "action_conversion_mode": action_conversion_mode,
+            "claim_boundary": "diagnostic-only route-conditioned local-policy adapter",
+        }
+
+    def _inject_waypoint_goal(
+        self, observation: dict[str, Any], waypoint: tuple[float, float]
+    ) -> dict[str, Any]:
+        """Return observation copy with local goal rewritten to ``waypoint``."""
+
+        conditioned = deepcopy(observation)
+        waypoint_list = [float(waypoint[0]), float(waypoint[1])]
+        if self.config.preserve_final_goal:
+            conditioned.setdefault(
+                "hybrid_global_rl_final_goal", self._extract_final_goal(observation)
+            )
+
+        goal = conditioned.get("goal")
+        if isinstance(goal, dict) and "current" in goal:
+            goal["current"] = list(waypoint_list)
+        if "goal_current" in conditioned:
+            conditioned["goal_current"] = list(waypoint_list)
+        if not (isinstance(goal, dict) and "current" in goal) and "goal_current" not in conditioned:
+            conditioned["goal_current"] = list(waypoint_list)
+        return conditioned
+
+    @staticmethod
+    def _extract_final_goal(observation: dict[str, Any]) -> tuple[float, float] | None:
+        """Extract the current final/local goal from known observation shapes.
+
+        Returns:
+            Two-dimensional goal coordinates when present and finite.
+        """
+
+        goal = observation.get("goal")
+        candidate: Any | None = None
+        if isinstance(goal, dict):
+            candidate = goal.get("current") or goal.get("next")
+        if candidate is None:
+            candidate = observation.get("goal_current")
+        if candidate is None:
+            return None
+        arr = np.asarray(candidate, dtype=float).reshape(-1)
+        if arr.size < 2 or not np.all(np.isfinite(arr[:2])):
+            return None
+        return (float(arr[0]), float(arr[1]))
+
+    def _action_to_unicycle(
+        self, action: dict[str, Any], observation: dict[str, Any]
+    ) -> tuple[float, float, str]:
+        """Convert wrapped local-policy action to bounded unicycle command.
+
+        Returns:
+            Linear velocity, angular velocity, and conversion-mode label.
+        """
+
+        if "v" in action or "omega" in action:
+            return (
+                self._clip(float(action.get("v", 0.0)), self.config.max_linear_speed),
+                self._clip(float(action.get("omega", 0.0)), self.config.max_angular_speed),
+                "unicycle",
+            )
+
+        if "vx" in action or "vy" in action:
+            vx = float(action.get("vx", 0.0))
+            vy = float(action.get("vy", 0.0))
+            heading = self._extract_heading(observation)
+            forward = vx * cos(heading) + vy * sin(heading)
+            desired_heading = atan2(vy, vx) if abs(vx) > 1e-12 or abs(vy) > 1e-12 else heading
+            angular = _wrap_angle(desired_heading - heading)
+            return (
+                self._clip(forward, self.config.max_linear_speed),
+                self._clip(angular, self.config.max_angular_speed),
+                "world_velocity_to_unicycle",
+            )
+
+        raise ValueError("Local policy action must contain v/omega or vx/vy")
+
+    @staticmethod
+    def _extract_heading(observation: dict[str, Any]) -> float:
+        """Extract robot heading from common observation shapes.
+
+        Returns:
+            Robot heading in radians, defaulting to zero when absent.
+        """
+
+        robot = observation.get("robot")
+        if isinstance(robot, dict) and "heading" in robot:
+            return float(robot["heading"])
+        if "robot_heading" in observation:
+            return float(observation["robot_heading"])
+        return 0.0
+
+    @staticmethod
+    def _clip(value: float, limit: float) -> float:
+        """Clip scalar symmetrically by non-negative ``limit``.
+
+        Returns:
+            Clipped scalar.
+        """
+
+        return float(np.clip(value, -abs(float(limit)), abs(float(limit))))
+
+
+def build_hybrid_global_rl_config(data: dict[str, Any] | None) -> HybridGlobalRLLocalConfig:
+    """Build hybrid global/RL-local adapter config from a plain mapping.
+
+    Returns:
+        Typed adapter configuration.
+    """
+
+    payload = dict(data or {})
+    return HybridGlobalRLLocalConfig(
+        local_policy_algo=str(payload.get("local_policy_algo", "sac")),
+        local_policy_config=dict(payload.get("local_policy_config", {})),
+        waypoint_provider=str(payload.get("waypoint_provider", "grid_route")),
+        grid_route=dict(payload.get("grid_route", {})),
+        allow_goal_fallback=bool(payload.get("allow_goal_fallback", False)),
+        fail_closed_on_missing_waypoint=bool(payload.get("fail_closed_on_missing_waypoint", True)),
+        preserve_final_goal=bool(payload.get("preserve_final_goal", True)),
+        waypoint_max_distance_from_robot=float(
+            payload.get("waypoint_max_distance_from_robot", 3.0)
+        ),
+        max_linear_speed=float(payload.get("max_linear_speed", 1.0)),
+        max_angular_speed=float(payload.get("max_angular_speed", 1.0)),
+    )

--- a/tests/benchmark/test_map_runner_hybrid_global_rl.py
+++ b/tests/benchmark/test_map_runner_hybrid_global_rl.py
@@ -1,0 +1,58 @@
+# ruff: noqa: D103
+"""Tests for map-runner hybrid global/RL-local policy registration."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.map_runner import _build_policy
+from robot_sf.benchmark.map_runner_policies.hybrid_global_rl import HYBRID_GLOBAL_RL_KEYS
+
+
+def test_hybrid_global_rl_builder_registers_aliases(monkeypatch) -> None:
+    class _DummyAdapter:
+        def __init__(self, *, config):
+            self.config = config
+
+        def plan(self, observation):
+            return 0.0, 0.0
+
+        def diagnostics(self):
+            return {"status": "ok", "waypoint_status": "ok"}
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner_policies.hybrid_global_rl.HybridGlobalRLLocalAdapter",
+        _DummyAdapter,
+    )
+
+    for algo in HYBRID_GLOBAL_RL_KEYS:
+        policy, meta = _build_policy(
+            algo,
+            {
+                "local_policy_config": {
+                    "fallback_to_goal": False,
+                    "obs_mode": "dict",
+                    "action_space": "unicycle",
+                }
+            },
+        )
+
+        assert callable(policy)
+        assert meta["algorithm"] == algo
+        assert meta["hybrid_global_rl"]["status"] == "enabled"
+        assert meta["planner_kinematics"]["limitations"] == "diagnostic_only_not_benchmark_evidence"
+
+
+def test_hybrid_global_rl_builder_missing_sac_checkpoint_fails_closed() -> None:
+    with pytest.raises(ValueError, match="local-only model artifact|model_id"):
+        _build_policy(
+            "hybrid_global_rl",
+            {
+                "allow_goal_fallback": False,
+                "local_policy_config": {
+                    "fallback_to_goal": False,
+                    "obs_mode": "dict",
+                    "action_space": "unicycle",
+                },
+            },
+        )

--- a/tests/planner/test_hybrid_global_rl.py
+++ b/tests/planner/test_hybrid_global_rl.py
@@ -1,0 +1,150 @@
+# ruff: noqa: D103
+"""Tests for route-conditioned learned local planner adapter."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+from robot_sf.planner.hybrid_global_rl import (
+    HybridGlobalRLLocalAdapter,
+    HybridGlobalRLLocalConfig,
+    WaypointDecision,
+)
+
+
+class _WaypointProvider:
+    def __init__(self, waypoint: tuple[float, float] | None):
+        self._waypoint = waypoint
+
+    def waypoint(self, observation: dict[str, Any]) -> WaypointDecision:
+        return WaypointDecision(
+            status="ok" if self._waypoint is not None else "missing",
+            waypoint=self._waypoint,
+            source="test_provider",
+            reason=None if self._waypoint is not None else "test_missing",
+            route_geometry={"route_path_cell_count": 2} if self._waypoint is not None else None,
+        )
+
+
+class _LocalPolicy:
+    def __init__(self, action: dict[str, float] | None = None):
+        self.action = action or {"v": 0.4, "omega": 0.1}
+        self.seen: list[dict[str, Any]] = []
+        self.reset_seed: int | None = None
+        self.closed = False
+
+    def step(self, observation: dict[str, Any]) -> dict[str, float]:
+        self.seen.append(observation)
+        return self.action
+
+    def reset(self, *, seed: int | None = None) -> None:
+        self.reset_seed = seed
+
+    def close(self) -> None:
+        self.closed = True
+
+    def get_metadata(self) -> dict[str, Any]:
+        return {"status": "ok"}
+
+
+def test_route_waypoint_is_injected_into_nested_goal_current() -> None:
+    local_policy = _LocalPolicy()
+    adapter = HybridGlobalRLLocalAdapter(
+        waypoint_provider=_WaypointProvider((1.5, 0.25)),
+        local_policy=local_policy,
+    )
+
+    command = adapter.plan({"goal": {"current": [9.0, 0.0]}, "robot": {"heading": 0.0}})
+
+    assert command == (0.4, 0.1)
+    assert local_policy.seen[0]["goal"]["current"] == [1.5, 0.25]
+    assert local_policy.seen[0]["hybrid_global_rl_final_goal"] == (9.0, 0.0)
+    assert adapter.diagnostics()["waypoint"] == [1.5, 0.25]
+
+
+def test_route_waypoint_is_injected_into_flat_goal_current() -> None:
+    local_policy = _LocalPolicy()
+    adapter = HybridGlobalRLLocalAdapter(
+        waypoint_provider=_WaypointProvider((0.75, -0.5)),
+        local_policy=local_policy,
+    )
+
+    adapter.plan({"goal_current": [3.0, 4.0], "robot_heading": 0.0})
+
+    assert local_policy.seen[0]["goal_current"] == [0.75, -0.5]
+    assert local_policy.seen[0]["hybrid_global_rl_final_goal"] == (3.0, 4.0)
+
+
+def test_missing_waypoint_fails_closed_by_default() -> None:
+    adapter = HybridGlobalRLLocalAdapter(
+        waypoint_provider=_WaypointProvider(None),
+        local_policy=_LocalPolicy(),
+    )
+
+    with pytest.raises(RuntimeError, match="route waypoint unavailable"):
+        adapter.plan({"goal_current": [3.0, 4.0]})
+
+    diagnostics = adapter.diagnostics()
+    assert diagnostics["fallback_status"] == "fail_closed"
+    assert diagnostics["waypoint_status"] == "missing"
+
+
+def test_missing_waypoint_can_use_explicit_goal_fallback() -> None:
+    local_policy = _LocalPolicy()
+    adapter = HybridGlobalRLLocalAdapter(
+        config=HybridGlobalRLLocalConfig(allow_goal_fallback=True),
+        waypoint_provider=_WaypointProvider(None),
+        local_policy=local_policy,
+    )
+
+    assert adapter.plan({"goal_current": [3.0, 4.0]}) == (0.4, 0.1)
+
+    assert local_policy.seen[0]["goal_current"] == [3.0, 4.0]
+    assert adapter.diagnostics()["fallback_status"] == "goal_fallback"
+
+
+def test_world_velocity_action_converts_to_bounded_unicycle() -> None:
+    local_policy = _LocalPolicy(action={"vx": 2.0, "vy": 2.0})
+    adapter = HybridGlobalRLLocalAdapter(
+        config=HybridGlobalRLLocalConfig(max_linear_speed=0.5, max_angular_speed=0.25),
+        waypoint_provider=_WaypointProvider((1.0, 1.0)),
+        local_policy=local_policy,
+    )
+
+    linear, angular = adapter.plan({"goal_current": [3.0, 4.0], "robot_heading": 0.0})
+
+    assert linear == 0.5
+    assert angular == 0.25
+    assert adapter.diagnostics()["action_conversion_mode"] == "world_velocity_to_unicycle"
+
+
+def test_reset_and_close_propagate_to_local_policy() -> None:
+    local_policy = _LocalPolicy()
+    adapter = HybridGlobalRLLocalAdapter(
+        waypoint_provider=_WaypointProvider((1.0, 1.0)),
+        local_policy=local_policy,
+    )
+
+    adapter.reset(seed=17)
+    adapter.close()
+
+    assert local_policy.reset_seed == 17
+    assert local_policy.closed is True
+    assert adapter.diagnostics()["status"] == "reset"
+
+
+def test_unicycle_action_is_bounded() -> None:
+    local_policy = _LocalPolicy(action={"v": 2.0, "omega": -2.0})
+    adapter = HybridGlobalRLLocalAdapter(
+        config=HybridGlobalRLLocalConfig(max_linear_speed=0.7, max_angular_speed=0.3),
+        waypoint_provider=_WaypointProvider((1.0, 1.0)),
+        local_policy=local_policy,
+    )
+
+    linear, angular = adapter.plan({"goal_current": [3.0, 4.0]})
+
+    assert math.isclose(linear, 0.7)
+    assert math.isclose(angular, -0.3)

--- a/tests/planner/test_hybrid_global_rl.py
+++ b/tests/planner/test_hybrid_global_rl.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import math
 from typing import Any
 
+import numpy as np
 import pytest
 
 from robot_sf.planner.hybrid_global_rl import (
@@ -63,6 +64,37 @@ def test_route_waypoint_is_injected_into_nested_goal_current() -> None:
     assert local_policy.seen[0]["goal"]["current"] == [1.5, 0.25]
     assert local_policy.seen[0]["hybrid_global_rl_final_goal"] == (9.0, 0.0)
     assert adapter.diagnostics()["waypoint"] == [1.5, 0.25]
+
+
+def test_route_waypoint_handles_array_goal_without_ambiguous_truth_value() -> None:
+    local_policy = _LocalPolicy()
+    adapter = HybridGlobalRLLocalAdapter(
+        waypoint_provider=_WaypointProvider((1.5, 0.25)),
+        local_policy=local_policy,
+    )
+
+    adapter.plan(
+        {
+            "goal": {"current": np.asarray([9.0, 0.0], dtype=float)},
+            "robot": {"heading": 0.0},
+        }
+    )
+
+    assert local_policy.seen[0]["goal"]["current"] == [1.5, 0.25]
+    assert local_policy.seen[0]["hybrid_global_rl_final_goal"] == (9.0, 0.0)
+
+
+def test_route_waypoint_initializes_missing_goal_dict() -> None:
+    local_policy = _LocalPolicy()
+    adapter = HybridGlobalRLLocalAdapter(
+        waypoint_provider=_WaypointProvider((1.5, 0.25)),
+        local_policy=local_policy,
+    )
+
+    adapter.plan({"goal": None, "robot": {"heading": 0.0}})
+
+    assert local_policy.seen[0]["goal"]["current"] == [1.5, 0.25]
+    assert "goal_current" not in local_policy.seen[0]
 
 
 def test_route_waypoint_is_injected_into_flat_goal_current() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds the first issue #4015 implementation slice: `HybridGlobalRLLocalAdapter`, which obtains a short-horizon waypoint from the existing `GridRoutePlannerAdapter`, rewrites `goal.current` / `goal_current`, then calls an existing SAC or PPO local policy wrapper.

Why now: the live issue comment defines PR 1 as the reversible planner-adapter skeleton plus waypoint injection and map-runner registration. This is a nameable new capability toward the implementation plan, not another guardrail/checker micro-PR.

Claim boundary: diagnostic-only adapter/interface contract. This PR does not claim route robustness, benchmark improvement, or paper/dissertation evidence.

Required validation: route-goal injection and fail-closed behavior tests, map-runner builder/alias tests, focused lint, and full `pr_ready_check`.

Remaining blocker: #4015 should remain open until a representative route/occupancy run with a real learned policy checkpoint and paired diagnostic comparison against the same end-to-end RL policy are recorded.

## Contract delta

- New algorithm aliases: `hybrid_global_rl`, `global_rl_local`, `route_conditioned_rl`, `hybrid_route_rl`.
- New adapter: `HybridGlobalRLLocalAdapter` in `robot_sf/planner/hybrid_global_rl.py`.
- New config fields: `local_policy_algo`, `local_policy_config`, `waypoint_provider`, `grid_route`, `allow_goal_fallback`, `fail_closed_on_missing_waypoint`, `preserve_final_goal`, `waypoint_max_distance_from_robot`, `max_linear_speed`, `max_angular_speed`.
- New fail-closed blocker: missing route waypoint raises by default when `allow_goal_fallback=false` and `fail_closed_on_missing_waypoint=true`.
- Compatibility impact: map-runner policy registry can now build this diagnostic adapter family; algorithm metadata marks it experimental/diagnostic-only with mixed RL action conversion to `unicycle_vw`.

## Summary

Implements the PR-1 route-conditioned learned local planner slice for #4015 and registers it through the decomposed map-runner policy-builder path.

## Linked Issues

- Relates `#4015`

## Stack / Dependency

- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: #4015 remains the parent follow-up
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed

- Added `HybridGlobalRLLocalAdapter` plus `GridRouteWaypointProvider` and typed config/decision dataclasses.
- Added map-runner builder registration and algorithm readiness/metadata for the new diagnostic family and aliases.
- Added a diagnostic SAC smoke config and a short design note.
- Added focused planner tests and map-runner builder tests.

## Why Matters

- Added value: establishes the modular global-waypoint + RL-local planner lane requested by #4015.
- Expected impact: enables the next empirical slice to run a real learned local checkpoint with route-conditioned goals.
- Why worth merging now: it creates the adapter contract and fail-closed diagnostics needed before benchmark-style comparison work.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: unblocks #4015 route-conditioned learned local planner diagnostics.
- Comparator or baseline, applicable: same learned local policy without route conditioning, deferred to next empirical slice.
- Evidence tier: diagnostic probe / adapter contract only.
- Result classification: diagnostic-only.
- Decision stop rule, applicable: do not close #4015 until representative route run and paired comparison are recorded.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #4015; design note `docs/context/issue_4015_hybrid_global_rl_design.md`.
- New research/benchmark/metric/paper-facing analysis tool, any: none.

## Domain-Aware Approval

- Approval concerns experimental validity waived / pending / blocked / not required: pending for empirical benchmark claims; not required for this diagnostic adapter contract.
- Approver/review source waiver: none.
- Validity checklist: adapter tests prove contract behavior, not planner performance.
- Target claim/hypothesis: adapter can route-condition an existing learned local policy input.
- Comparator split/evidence validity: deferred.
- Fallback/degraded exclusions: missing route waypoint fails closed by default; explicit goal fallback is diagnostic-only.
- Claim boundary: diagnostic-only; not paper-grade or benchmark evidence.
- Implementation integrity vs experimental validity: implementation integrity covered by tests/readiness; experimental validity remains future work.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes in unit tests via waypoint injection test doubles.
- Did intervention change command source, selected command, trajectory, route progress? command source is existing local policy after route-conditioned observation; trajectory/route progress not measured here.
- Did scenario actually contain targeted failure mode? NA, no scenario campaign run.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: #4015 next empirical comparison.

## Next Empirical Action

- Rerun needed: yes, representative route/occupancy scenario with real learned checkpoint.
- Extractor analysis tool needed: yes, paired diagnostic report remains deferred by #4015.
- Artifact missing unavailable: durable learned-policy checkpoint/config for representative run not exercised in this PR.
- Stop / revise / continue decision: continue.
- Proposed child issue existing follow-up: #4015.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/planner/test_hybrid_global_rl.py tests/benchmark/test_map_runner_hybrid_global_rl.py -q` -> passed, 9 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/planner/hybrid_global_rl.py robot_sf/benchmark/map_runner_policies/hybrid_global_rl.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/algorithm_metadata.py robot_sf/benchmark/algorithm_readiness.py tests/planner/test_hybrid_global_rl.py tests/benchmark/test_map_runner_hybrid_global_rl.py` -> passed.
- `python -m compileall -q robot_sf/planner/hybrid_global_rl.py robot_sf/benchmark/map_runner_policies/hybrid_global_rl.py` -> passed.
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh` -> passed; freshness stamp `output/validation/pr_ready/issue-4015-planner-modular-hybrid-global-planner-rl-local-planner-lane.json`, head `e8775a15153c54974fefbf724c52073dac6ad7cb`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> fresh/clean.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout

- Compatibility risks: new algorithm metadata/registering aliases could affect policy resolution for those names only.
- Failure modes: missing waypoint or missing durable learned-policy checkpoint fails closed before benchmark execution is overstated.
- Rollback fallback plan: remove the `hybrid_global_rl` registry/metadata entries and adapter module.

## Docs / Provenance

- Updated docs: `docs/context/issue_4015_hybrid_global_rl_design.md`.
- Relevant design provenance notes: live issue #4015 comment updated `2026-07-02T09:58:36Z`.
- Any assumptions need to preserved: first slice uses `GridRoutePlannerAdapter`; no new global planner or RL training.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): yes, algorithm readiness/metadata and map-runner registry updated.
- Context index / memory note updated (yes/no/NA): no, design note linked from PR body.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: `comment_issue_or_pr=false` in task authorization, so no issue comment/state-table update was made. This PR body is the authorized propagation surface for the delivered slice and remaining work.

## Follow-Up Issues

- Deferred work: representative route/occupancy run with real learned policy checkpoint; paired diagnostic comparison; diagnostic report excluding fallback/degraded rows as evidence.
- Issues opened follow-up: none; #4015 remains open.

## Reviewer Notes

- Please verify fail-closed behavior for missing route waypoints and missing durable checkpoint inputs.
- Late-guidance check: issue/comment latest update was `2026-07-02T09:58:36Z`; no maintainer comments newer than this work start were present before PR open.

<details>
<summary>Process Appendix</summary>

- Fragmentation guard: no open duplicate PR found; no merged #4015 guard/checker/packet-refresh PRs found in the last 24h. This is a progression slice because it adds the new `hybrid_global_rl` adapter capability.
- No transient queue-routing state, target-host state, or packet lineage pointers were added to tracked files.
- No compute submission, merge, release, or deletion performed.

</details>
