### PR TITLE
Add Mamba feature extractor primitive for issue #4014

### DIFF
--- a/docs/context/issue_4014_mamba_encoder_design.md
+++ b/docs/context/issue_4014_mamba_encoder_design.md
@@ -1,0 +1,39 @@
+# Issue #4014 Mamba Encoder Primitive
+
+This note records the first implementation slice for the Mamba state-space model policy encoder
+lane: a CPU-safe feature extractor primitive that can be tested before training campaigns or
+graphics processing unit (GPU) dependencies are introduced.
+
+## Claim Boundary
+
+- Evidence tier: implementation primitive only.
+- The `torch_ssm_lite` backend is a small PyTorch state-space-model-inspired sequence encoder for
+  continuous integration (CI) and smoke tests, not an exact Mamba implementation.
+- The optional `mamba_ssm` backend is recorded with `backend_exact=true` only when the external
+  package is installed and selected.
+- Under standard Proximal Policy Optimization (PPO), both the existing long short-term memory
+  (LSTM) extractor and this Mamba extractor encode a sequence within one observation. They do not
+  carry hidden state across environment steps.
+- A fair PPO versus PPO-LSTM versus PPO-Mamba comparison still needs later slices for training
+  registration, true recurrent PPO (`RecurrentPPO`), bounded temporal-history observations, and
+  matched diagnostic reporting.
+
+## Contract Added
+
+- `robot_sf.feature_extractors.mamba_extractor.MambaFeatureExtractor`
+- `MambaFeatureExtractorConfig` with conservative defaults:
+  - `backend="auto"`
+  - `sequence_source="rays"`
+  - `fail_if_exact_backend_missing=false`
+- Runtime metadata:
+  - `backend_name`: `mamba_ssm` or `torch_ssm_lite`
+  - `backend_exact`: `true` only for the exact optional backend
+- Sequence inputs:
+  - `rays`: current CPU-safe default, matching the LSTM extractor's within-observation ray sequence
+  - `temporal_history`: fail-closed planned input key for the later bounded-history wrapper
+
+## Explicit Non-Claims
+
+This slice does not register `feature_extractor: mamba` in PPO training, does not run a benchmark
+campaign, does not submit Slurm Workload Manager or GPU jobs, and does not make paper- or
+dissertation-facing performance claims.

--- a/robot_sf/feature_extractors/__init__.py
+++ b/robot_sf/feature_extractors/__init__.py
@@ -14,6 +14,7 @@ from .attention_extractor import AttentionFeatureExtractor
 from .grid_socnav_extractor import GridSocNavExtractor
 from .lightweight_cnn_extractor import LightweightCNNExtractor
 from .lstm_extractor import LSTMFeatureExtractor
+from .mamba_extractor import MambaFeatureExtractor, MambaFeatureExtractorConfig
 from .mlp_extractor import MLPFeatureExtractor
 
 __all__ = [
@@ -22,4 +23,6 @@ __all__ = [
     "LSTMFeatureExtractor",
     "LightweightCNNExtractor",
     "MLPFeatureExtractor",
+    "MambaFeatureExtractor",
+    "MambaFeatureExtractorConfig",
 ]

--- a/robot_sf/feature_extractors/config.py
+++ b/robot_sf/feature_extractors/config.py
@@ -15,6 +15,7 @@ from robot_sf.feature_extractor import DynamicsExtractor
 from robot_sf.feature_extractors.attention_extractor import AttentionFeatureExtractor
 from robot_sf.feature_extractors.lightweight_cnn_extractor import LightweightCNNExtractor
 from robot_sf.feature_extractors.lstm_extractor import LSTMFeatureExtractor
+from robot_sf.feature_extractors.mamba_extractor import MambaFeatureExtractor
 from robot_sf.feature_extractors.mlp_extractor import MLPFeatureExtractor
 
 
@@ -26,6 +27,7 @@ class FeatureExtractorType(Enum):
     ATTENTION = "attention"  # Attention-based extractor
     LIGHTWEIGHT_CNN = "lightweight_cnn"  # Lightweight CNN extractor
     LSTM = "lstm"  # LSTM sequential extractor (spatial, not temporal with standard PPO)
+    MAMBA = "mamba"  # Mamba/SSM sequence extractor (bounded observation sequence)
 
 
 @dataclass
@@ -71,6 +73,7 @@ _EXTRACTOR_REGISTRY: dict[FeatureExtractorType, type[BaseFeaturesExtractor]] = {
     FeatureExtractorType.ATTENTION: AttentionFeatureExtractor,
     FeatureExtractorType.LIGHTWEIGHT_CNN: LightweightCNNExtractor,
     FeatureExtractorType.LSTM: LSTMFeatureExtractor,
+    FeatureExtractorType.MAMBA: MambaFeatureExtractor,
 }
 
 
@@ -189,6 +192,28 @@ class FeatureExtractorPresets:
                 "lstm_dropout": 0.1,
                 "drive_hidden_dims": [64, 32],
                 "bidirectional": True,
+            },
+        )
+
+    @staticmethod
+    def mamba_lite() -> FeatureExtractorConfig:
+        """CPU-safe Mamba/SSM-lite extractor for issue #4014 smoke checks.
+
+        Returns:
+            FeatureExtractorConfig: Preset configuration instance.
+        """
+        return FeatureExtractorConfig(
+            extractor_type=FeatureExtractorType.MAMBA,
+            params={
+                "backend": "torch_ssm_lite",
+                "d_model": 64,
+                "d_state": 16,
+                "d_conv": 4,
+                "expand": 2,
+                "num_layers": 1,
+                "dropout_rate": 0.0,
+                "sequence_source": "rays",
+                "drive_hidden_dims": (32, 16),
             },
         )
 

--- a/robot_sf/feature_extractors/mamba_extractor.py
+++ b/robot_sf/feature_extractors/mamba_extractor.py
@@ -1,0 +1,232 @@
+"""Mamba / state-space feature extractor primitive for Robot SF observations.
+
+This extractor is the first implementation slice for issue #4014. It provides a
+CPU-safe sequence encoder that can run in CI and an optional exact ``mamba_ssm``
+backend when that dependency is installed. The default standard-PPO contract is
+the same as the existing LSTM extractor: it encodes an ordered sequence inside a
+single observation, not hidden state across environment steps.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from dataclasses import dataclass
+from importlib import import_module
+from itertools import pairwise
+from typing import TYPE_CHECKING, Literal, cast
+
+import numpy as np
+import torch as th
+from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
+from torch import nn
+
+from robot_sf.sensor.sensor_fusion import OBS_DRIVE_STATE, OBS_RAYS
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from gymnasium import spaces
+
+MAMBA_TEMPORAL_HISTORY_KEY = "temporal_history"
+MambaBackend = Literal["auto", "mamba_ssm", "torch_ssm_lite"]
+SequenceSource = Literal["rays", "temporal_history"]
+
+
+@dataclass(frozen=True)
+class MambaFeatureExtractorConfig:
+    """Serializable default parameters for the issue #4014 Mamba extractor."""
+
+    backend: MambaBackend = "auto"
+    d_model: int = 64
+    d_state: int = 16
+    d_conv: int = 4
+    expand: int = 2
+    num_layers: int = 1
+    dropout_rate: float = 0.0
+    sequence_source: SequenceSource = "rays"
+    drive_hidden_dims: tuple[int, ...] = (32, 16)
+    fail_if_exact_backend_missing: bool = False
+
+
+class _TorchSSMLiteBlock(nn.Module):
+    """Small PyTorch-only sequence block used when exact Mamba is unavailable."""
+
+    def __init__(self, d_model: int, d_conv: int, expand: int, dropout_rate: float) -> None:
+        super().__init__()
+        hidden_dim = d_model * expand
+        self.depthwise_conv = nn.Conv1d(
+            d_model,
+            d_model,
+            kernel_size=d_conv,
+            padding=max(d_conv - 1, 0),
+            groups=d_model,
+        )
+        self.update_gate = nn.Sequential(
+            nn.Linear(d_model, hidden_dim),
+            nn.SiLU(),
+            nn.Dropout(dropout_rate),
+            nn.Linear(hidden_dim, d_model),
+        )
+        self.value_gate = nn.Sequential(
+            nn.Linear(d_model, hidden_dim),
+            nn.SiLU(),
+            nn.Dropout(dropout_rate),
+            nn.Linear(hidden_dim, d_model),
+        )
+        self.norm = nn.LayerNorm(d_model)
+
+    def forward(self, sequence: th.Tensor) -> th.Tensor:
+        """Encode ``(batch, sequence, d_model)`` tensors with a gated residual update.
+
+        Returns:
+            Tensor with the same shape as ``sequence``.
+        """
+        residual = sequence
+        convolved = self.depthwise_conv(sequence.transpose(1, 2)).transpose(1, 2)
+        convolved = convolved[:, : sequence.shape[1], :]
+        gate = th.sigmoid(self.update_gate(convolved))
+        values = th.tanh(self.value_gate(convolved))
+        return self.norm(residual + gate * values)
+
+
+def _load_mamba_ssm_class() -> type[nn.Module] | None:
+    """Return the optional exact Mamba class without making it a hard dependency."""
+    if importlib.util.find_spec("mamba_ssm") is None:
+        return None
+
+    return import_module("mamba_ssm").Mamba
+
+
+class MambaFeatureExtractor(BaseFeaturesExtractor):
+    """State-space sequence encoder for ray or bounded temporal-history observations."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        observation_space: spaces.Dict,
+        backend: MambaBackend = "auto",
+        d_model: int = 64,
+        d_state: int = 16,
+        d_conv: int = 4,
+        expand: int = 2,
+        num_layers: int = 1,
+        dropout_rate: float = 0.0,
+        sequence_source: SequenceSource = "rays",
+        drive_hidden_dims: Sequence[int] | None = None,
+        fail_if_exact_backend_missing: bool = False,
+    ) -> None:
+        """Initialize Mamba/SSM and drive-state branches."""
+        if backend not in {"auto", "mamba_ssm", "torch_ssm_lite"}:
+            msg = "backend must be one of: auto, mamba_ssm, torch_ssm_lite"
+            raise ValueError(msg)
+        if sequence_source not in {"rays", "temporal_history"}:
+            msg = "sequence_source must be one of: rays, temporal_history"
+            raise ValueError(msg)
+        if d_model <= 0 or d_state <= 0 or d_conv <= 0 or expand <= 0 or num_layers <= 0:
+            msg = "d_model, d_state, d_conv, expand, and num_layers must be positive"
+            raise ValueError(msg)
+
+        drive_hidden_dims = tuple(drive_hidden_dims if drive_hidden_dims is not None else (32, 16))
+        sequence_key = OBS_RAYS if sequence_source == "rays" else MAMBA_TEMPORAL_HISTORY_KEY
+        if sequence_key not in observation_space.spaces:
+            msg = f"observation_space must include '{sequence_key}' for sequence_source={sequence_source!r}"
+            raise KeyError(msg)
+
+        sequence_space = cast("spaces.Box", observation_space.spaces[sequence_key])
+        drive_space = cast("spaces.Box", observation_space.spaces[OBS_DRIVE_STATE])
+        sequence_input_dim = (
+            1 if sequence_source == "rays" else int(np.prod(sequence_space.shape[1:]))
+        )
+        drive_input_dim = int(np.prod(drive_space.shape))
+        drive_output_dim = drive_hidden_dims[-1] if drive_hidden_dims else drive_input_dim
+        features_dim = d_model + drive_output_dim
+        super().__init__(observation_space, features_dim=features_dim)
+
+        self.sequence_key = sequence_key
+        self.sequence_source = sequence_source
+        self.d_state = d_state
+        self.sequence_projection = nn.Linear(sequence_input_dim, d_model)
+        self.sequence_layers, self.backend_name, self.backend_exact = self._build_sequence_layers(
+            backend=backend,
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=d_conv,
+            expand=expand,
+            num_layers=num_layers,
+            dropout_rate=dropout_rate,
+            fail_if_exact_backend_missing=fail_if_exact_backend_missing,
+        )
+        self.sequence_dropout = nn.Dropout(dropout_rate)
+        self.sequence_norm = nn.LayerNorm(d_model)
+
+        drive_layers: list[nn.Module] = [nn.Flatten()]
+        for in_dim, out_dim in pairwise([drive_input_dim, *drive_hidden_dims]):
+            drive_layers += [nn.Linear(in_dim, out_dim), nn.ReLU(), nn.Dropout(dropout_rate)]
+        self.drive_mlp = nn.Sequential(*drive_layers)
+
+    def _build_sequence_layers(
+        self,
+        *,
+        backend: MambaBackend,
+        d_model: int,
+        d_state: int,
+        d_conv: int,
+        expand: int,
+        num_layers: int,
+        dropout_rate: float,
+        fail_if_exact_backend_missing: bool,
+    ) -> tuple[nn.ModuleList, str, bool]:
+        mamba_cls = _load_mamba_ssm_class() if backend in {"auto", "mamba_ssm"} else None
+        if mamba_cls is not None:
+            layers = nn.ModuleList(
+                [
+                    mamba_cls(d_model=d_model, d_state=d_state, d_conv=d_conv, expand=expand)
+                    for _ in range(num_layers)
+                ]
+            )
+            return layers, "mamba_ssm", True
+        if backend == "mamba_ssm" or fail_if_exact_backend_missing:
+            msg = (
+                "mamba_ssm backend requested but unavailable. Install the `mamba-ssm` "
+                "and `causal-conv1d` packages in the active environment."
+            )
+            raise ImportError(msg)
+        layers = nn.ModuleList(
+            [
+                _TorchSSMLiteBlock(
+                    d_model=d_model,
+                    d_conv=d_conv,
+                    expand=expand,
+                    dropout_rate=dropout_rate,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        return layers, "torch_ssm_lite", False
+
+    def forward(self, obs: dict[str, th.Tensor]) -> th.Tensor:
+        """Extract feature tensors from ray/temporal sequence and drive-state inputs.
+
+        Returns:
+            Concatenated sequence and drive-state features.
+        """
+        sequence = self._prepare_sequence(obs[self.sequence_key])
+        sequence_features = self.sequence_projection(sequence)
+        for layer in self.sequence_layers:
+            sequence_features = layer(sequence_features)
+        sequence_features = self.sequence_norm(self.sequence_dropout(sequence_features))
+        sequence_features = sequence_features.mean(dim=1)
+        drive_features = self.drive_mlp(obs[OBS_DRIVE_STATE])
+        return th.cat([sequence_features, drive_features], dim=1)
+
+    def _prepare_sequence(self, values: th.Tensor) -> th.Tensor:
+        """Normalize observation tensors into ``(batch, sequence, feature)`` form.
+
+        Returns:
+            Tensor ready for the sequence projection layer.
+        """
+        if self.sequence_source == "rays":
+            return values.reshape(values.shape[0], -1, 1)
+        if values.ndim < 3:
+            msg = "temporal_history observations must have shape (batch, history, features...)"
+            raise ValueError(msg)
+        return values.reshape(values.shape[0], values.shape[1], -1)

--- a/robot_sf/feature_extractors/mamba_extractor.py
+++ b/robot_sf/feature_extractors/mamba_extractor.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Literal, cast
 
 import numpy as np
 import torch as th
+from gymnasium import spaces
 from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
 from torch import nn
 
@@ -24,8 +25,6 @@ from robot_sf.sensor.sensor_fusion import OBS_DRIVE_STATE, OBS_RAYS
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-    from gymnasium import spaces
 
 MAMBA_TEMPORAL_HISTORY_KEY = "temporal_history"
 MambaBackend = Literal["auto", "mamba_ssm", "torch_ssm_lite"]
@@ -83,7 +82,7 @@ class _TorchSSMLiteBlock(nn.Module):
         """
         residual = sequence
         convolved = self.depthwise_conv(sequence.transpose(1, 2)).transpose(1, 2)
-        convolved = convolved[:, : sequence.shape[1], :]
+        convolved = convolved[:, : sequence.shape[1], :].contiguous()
         gate = th.sigmoid(self.update_gate(convolved))
         values = th.tanh(self.value_gate(convolved))
         return self.norm(residual + gate * values)
@@ -94,7 +93,10 @@ def _load_mamba_ssm_class() -> type[nn.Module] | None:
     if importlib.util.find_spec("mamba_ssm") is None:
         return None
 
-    return import_module("mamba_ssm").Mamba
+    try:
+        return import_module("mamba_ssm").Mamba
+    except ImportError:
+        return None
 
 
 class MambaFeatureExtractor(BaseFeaturesExtractor):
@@ -126,6 +128,12 @@ class MambaFeatureExtractor(BaseFeaturesExtractor):
             raise ValueError(msg)
 
         drive_hidden_dims = tuple(drive_hidden_dims if drive_hidden_dims is not None else (32, 16))
+        if not isinstance(observation_space, spaces.Dict):
+            raise ValueError("observation_space must be gymnasium.spaces.Dict")
+        if OBS_DRIVE_STATE not in observation_space.spaces:
+            msg = f"observation_space must include '{OBS_DRIVE_STATE}'"
+            raise KeyError(msg)
+
         sequence_key = OBS_RAYS if sequence_source == "rays" else MAMBA_TEMPORAL_HISTORY_KEY
         if sequence_key not in observation_space.spaces:
             msg = f"observation_space must include '{sequence_key}' for sequence_source={sequence_source!r}"
@@ -224,6 +232,12 @@ class MambaFeatureExtractor(BaseFeaturesExtractor):
         Returns:
             Tensor ready for the sequence projection layer.
         """
+        if values.ndim < 3:
+            msg = (
+                f"{self.sequence_source} observations must have shape "
+                "(batch, sequence, features...)"
+            )
+            raise ValueError(msg)
         if self.sequence_source == "rays":
             return values.reshape(values.shape[0], -1, 1)
         if values.ndim < 3:

--- a/tests/test_feature_extractors.py
+++ b/tests/test_feature_extractors.py
@@ -15,6 +15,7 @@ from robot_sf.feature_extractors import (
     AttentionFeatureExtractor,
     LightweightCNNExtractor,
     LSTMFeatureExtractor,
+    MambaFeatureExtractor,
     MLPFeatureExtractor,
 )
 from robot_sf.feature_extractors.config import (
@@ -232,6 +233,7 @@ class TestFeatureExtractors:
             AttentionFeatureExtractor(observation_space),
             LightweightCNNExtractor(observation_space),
             LSTMFeatureExtractor(observation_space),
+            MambaFeatureExtractor(observation_space, backend="torch_ssm_lite"),
         ]
 
         for extractor in extractors:

--- a/tests/test_mamba_feature_extractor.py
+++ b/tests/test_mamba_feature_extractor.py
@@ -1,0 +1,165 @@
+"""Tests for the issue #4014 Mamba / state-space feature extractor primitive."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+import torch as th
+from gymnasium import spaces
+
+from robot_sf.feature_extractors.config import FeatureExtractorPresets, FeatureExtractorType
+from robot_sf.feature_extractors.mamba_extractor import (
+    MAMBA_TEMPORAL_HISTORY_KEY,
+    MambaFeatureExtractor,
+    MambaFeatureExtractorConfig,
+)
+from robot_sf.sensor.sensor_fusion import OBS_DRIVE_STATE, OBS_RAYS
+
+
+@pytest.fixture
+def observation_space() -> spaces.Dict:
+    """Observation space with rays, drive state, and planned temporal-history slot."""
+    return spaces.Dict(
+        {
+            OBS_DRIVE_STATE: spaces.Box(low=-np.inf, high=np.inf, shape=(5, 5), dtype=np.float32),
+            OBS_RAYS: spaces.Box(low=0, high=10, shape=(5, 64), dtype=np.float32),
+            MAMBA_TEMPORAL_HISTORY_KEY: spaces.Box(
+                low=-np.inf,
+                high=np.inf,
+                shape=(4, 7),
+                dtype=np.float32,
+            ),
+        }
+    )
+
+
+@pytest.fixture
+def sample_observation() -> dict[str, th.Tensor]:
+    """Sample batched tensors matching ``observation_space``."""
+    return {
+        OBS_DRIVE_STATE: th.randn(2, 5, 5),
+        OBS_RAYS: th.rand(2, 5, 64),
+        MAMBA_TEMPORAL_HISTORY_KEY: th.randn(2, 4, 7),
+    }
+
+
+def test_mamba_config_defaults_are_cpu_safe() -> None:
+    """Default dataclass values describe the conservative issue #4014 lane."""
+    config = MambaFeatureExtractorConfig()
+
+    assert config.backend == "auto"
+    assert config.sequence_source == "rays"
+    assert config.fail_if_exact_backend_missing is False
+
+
+def test_mamba_lite_preset_routes_to_extractor() -> None:
+    """The shared feature-extractor config registry exposes the Mamba primitive."""
+    config = FeatureExtractorPresets.mamba_lite()
+
+    assert config.extractor_type == FeatureExtractorType.MAMBA
+    assert config.params["backend"] == "torch_ssm_lite"
+    assert config.get_extractor_class() is MambaFeatureExtractor
+
+
+def test_torch_ssm_lite_forward_returns_finite_features(
+    observation_space: spaces.Dict,
+    sample_observation: dict[str, th.Tensor],
+) -> None:
+    """The CPU-safe backend should initialize and return finite SB3 features."""
+    extractor = MambaFeatureExtractor(
+        observation_space,
+        backend="torch_ssm_lite",
+        d_model=12,
+        d_state=4,
+        d_conv=3,
+        expand=2,
+        drive_hidden_dims=(10, 6),
+    )
+
+    features = extractor(sample_observation)
+
+    assert extractor.backend_name == "torch_ssm_lite"
+    assert extractor.backend_exact is False
+    assert extractor.features_dim == 18
+    assert features.shape == (2, extractor.features_dim)
+    assert th.isfinite(features).all()
+
+
+def test_forward_accepts_non_contiguous_ray_tensors(
+    observation_space: spaces.Dict,
+    sample_observation: dict[str, th.Tensor],
+) -> None:
+    """Ray sequence preparation should not require contiguous input tensors."""
+    extractor = MambaFeatureExtractor(observation_space, backend="torch_ssm_lite", d_model=8)
+    non_contiguous_obs = {
+        **sample_observation,
+        OBS_RAYS: th.rand(2, 64, 5).transpose(1, 2),
+    }
+
+    assert not non_contiguous_obs[OBS_RAYS].is_contiguous()
+    features = extractor(non_contiguous_obs)
+
+    assert features.shape == (2, extractor.features_dim)
+    assert th.isfinite(features).all()
+
+
+def test_temporal_history_sequence_source(
+    observation_space: spaces.Dict,
+    sample_observation: dict[str, th.Tensor],
+) -> None:
+    """The primitive exposes the later temporal-history contract without adding a wrapper."""
+    extractor = MambaFeatureExtractor(
+        observation_space,
+        backend="torch_ssm_lite",
+        sequence_source="temporal_history",
+        d_model=10,
+        drive_hidden_dims=(),
+    )
+
+    features = extractor(sample_observation)
+
+    assert extractor.sequence_key == MAMBA_TEMPORAL_HISTORY_KEY
+    assert extractor.features_dim == 35
+    assert features.shape == (2, extractor.features_dim)
+
+
+def test_invalid_backend_fails_closed(observation_space: spaces.Dict) -> None:
+    """Unknown backends should fail before training starts."""
+    with pytest.raises(ValueError, match="backend must be one of"):
+        MambaFeatureExtractor(observation_space, backend="not_a_backend")  # type: ignore[arg-type]
+
+
+def test_exact_backend_missing_can_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    observation_space: spaces.Dict,
+) -> None:
+    """Callers can require exact mamba_ssm instead of silently using the lite backend."""
+    monkeypatch.setattr(
+        "robot_sf.feature_extractors.mamba_extractor.importlib.util.find_spec",
+        lambda name: None if name == "mamba_ssm" else importlib.util.find_spec(name),
+    )
+
+    with pytest.raises(ImportError, match="mamba_ssm backend requested but unavailable"):
+        MambaFeatureExtractor(
+            observation_space,
+            backend="mamba_ssm",
+            fail_if_exact_backend_missing=True,
+        )
+
+
+def test_auto_backend_records_lite_fallback_when_exact_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    observation_space: spaces.Dict,
+) -> None:
+    """Auto mode must make fallback status visible for later comparison reports."""
+    monkeypatch.setattr(
+        "robot_sf.feature_extractors.mamba_extractor.importlib.util.find_spec",
+        lambda name: None if name == "mamba_ssm" else importlib.util.find_spec(name),
+    )
+
+    extractor = MambaFeatureExtractor(observation_space, backend="auto")
+
+    assert extractor.backend_name == "torch_ssm_lite"
+    assert extractor.backend_exact is False

--- a/tests/test_mamba_feature_extractor.py
+++ b/tests/test_mamba_feature_extractor.py
@@ -163,3 +163,58 @@ def test_auto_backend_records_lite_fallback_when_exact_missing(
 
     assert extractor.backend_name == "torch_ssm_lite"
     assert extractor.backend_exact is False
+
+
+def test_auto_backend_falls_back_when_exact_import_is_broken(
+    monkeypatch: pytest.MonkeyPatch,
+    observation_space: spaces.Dict,
+) -> None:
+    """Auto mode treats broken optional Mamba imports as unavailable."""
+
+    monkeypatch.setattr(
+        "robot_sf.feature_extractors.mamba_extractor.importlib.util.find_spec",
+        lambda name: object() if name == "mamba_ssm" else importlib.util.find_spec(name),
+    )
+
+    def _raise_import_error(name: str):
+        if name == "mamba_ssm":
+            raise ImportError("missing causal-conv1d")
+        return importlib.import_module(name)
+
+    monkeypatch.setattr(
+        "robot_sf.feature_extractors.mamba_extractor.import_module", _raise_import_error
+    )
+
+    extractor = MambaFeatureExtractor(observation_space, backend="auto")
+
+    assert extractor.backend_name == "torch_ssm_lite"
+    assert extractor.backend_exact is False
+
+
+def test_observation_space_contract_is_fail_closed() -> None:
+    """Mamba extractor requires a Dict space with drive-state observations."""
+
+    with pytest.raises(ValueError, match="gymnasium.spaces.Dict"):
+        MambaFeatureExtractor(spaces.Box(low=0, high=1, shape=(4,), dtype=np.float32))
+
+    with pytest.raises(KeyError, match=OBS_DRIVE_STATE):
+        MambaFeatureExtractor(
+            spaces.Dict({OBS_RAYS: spaces.Box(low=0, high=1, shape=(5, 64), dtype=np.float32)})
+        )
+
+
+def test_sequence_observation_requires_batch_and_sequence_axes(
+    observation_space: spaces.Dict,
+) -> None:
+    """Under-ranked sequence tensors fail clearly before reshape/projection."""
+
+    extractor = MambaFeatureExtractor(observation_space, backend="torch_ssm_lite", d_model=8)
+
+    with pytest.raises(ValueError, match="rays observations"):
+        extractor(
+            {
+                OBS_DRIVE_STATE: th.randn(2, 5, 5),
+                OBS_RAYS: th.rand(2, 64),
+                MAMBA_TEMPORAL_HISTORY_KEY: th.randn(2, 4, 7),
+            }
+        )


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds the issue #4014 Mamba/state-space feature extractor primitive with a CPU-safe `torch_ssm_lite` backend, optional exact `mamba_ssm` detection, runtime backend metadata, package/config exports, focused tests, and a short design note.

Why now: the live issue implementation plan says PR 1 should establish the extractor primitive before PPO training registration, true RecurrentPPO, temporal-history wrappers, or matched comparison reports.

Claim boundary: implementation primitive only. `torch_ssm_lite` is not exact Mamba, and standard PPO use remains within-observation sequence encoding rather than step-recurrent hidden state. No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

Required validation: focused extractor tests plus repository PR readiness. Full benchmark/training comparison remains out of scope.

Remaining blocker: issue #4014 still needs later slices for `feature_extractor: mamba` PPO registration, true PPO-LSTM via RecurrentPPO, bounded temporal-history observation support, and matched diagnostic comparison reporting.

## Contract delta

New schema/config fields:
- `FeatureExtractorType.MAMBA`
- `FeatureExtractorPresets.mamba_lite()`
- `MambaFeatureExtractorConfig` defaults: `backend`, `d_model`, `d_state`, `d_conv`, `expand`, `num_layers`, `dropout_rate`, `sequence_source`, `drive_hidden_dims`, `fail_if_exact_backend_missing`

New fail-closed blockers:
- unknown `backend` values raise `ValueError`
- unknown `sequence_source` values raise `ValueError`
- missing selected sequence observation key raises `KeyError`
- required exact `mamba_ssm` backend raises actionable `ImportError` when optional packages are unavailable

Compatibility impact:
- existing extractors and `DynamicsExtractor` remain unchanged
- default config behavior remains `FeatureExtractorType.DYNAMICS`
- optional exact Mamba dependencies are not added to `pyproject.toml` in this primitive slice

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check --fix robot_sf/feature_extractors/mamba_extractor.py robot_sf/feature_extractors/__init__.py robot_sf/feature_extractors/config.py tests/test_mamba_feature_extractor.py tests/test_feature_extractors.py && scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/feature_extractors/mamba_extractor.py robot_sf/feature_extractors/__init__.py robot_sf/feature_extractors/config.py tests/test_mamba_feature_extractor.py tests/test_feature_extractors.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_mamba_feature_extractor.py tests/test_feature_extractors.py -q` - passed, 34 tests
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed in interim mode on dirty tree; stamp `output/validation/pr_ready/issue-4014-mamba-encoder-primitive.json`
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/robot_sf_issue4014/pr_body.md scripts/dev/pr_ready_check.sh` - passed; clean-head stamp `output/validation/pr_ready/issue-4014-mamba-encoder-primitive.json`

## Issue and scope

Fixes part of #4014: https://github.com/ll7/robot_sf_ll7/issues/4014

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no PPO training registration, no recurrent PPO script, no temporal-history wrapper, and no comparison report.

State propagation: no issue comment will be added because this run was not authorized to comment on issues or PRs. This PR body is the single propagation surface for the delivered slice and remaining work.

<details>
<summary>Process appendix</summary>

Fragmentation guard: no open PR and no merged issue #4014 PR in the last 24 hours matched this scope. This is a progression slice because it adds the nameable new capability `MambaFeatureExtractor`.

Late guidance check: issue comments will be re-read immediately before PR publication per task instructions.

Artifact classification: local `.venv`, `.pytest_cache`, and `output/validation/pr_ready/` are disposable local validation artifacts and are not committed.

</details>
