### PR TITLE
Fix quoted SDD annotation labels for issue #4080

### DIFF
--- a/robot_sf/planner/prediction_mpc.py
+++ b/robot_sf/planner/prediction_mpc.py
@@ -166,22 +166,6 @@ class PredictionMPCPlannerAdapter(NMPCSocialPlannerAdapter):
         self._future_predictor = predictor or ConstantVelocityPedestrianPredictor()
         super().__init__(_to_nmpc_config(self.prediction_config))
 
-    def diagnostics(self) -> dict[str, Any]:
-        """Return predictor diagnostics for benchmark metadata."""
-
-        diagnostics: dict[str, Any] = dict(super().diagnostics())
-        diagnostics.update(
-            {
-                "predictor_backend": self.prediction_config.predictor_backend,
-                "horizon_steps": self.prediction_config.horizon_steps,
-                "rollout_dt": self.prediction_config.rollout_dt,
-            }
-        )
-        predictor_diagnostics = getattr(self._future_predictor, "diagnostics", None)
-        if callable(predictor_diagnostics):
-            diagnostics["predictor"] = predictor_diagnostics()
-        return diagnostics
-
     def _optimizer_constraints(self, context: _RolloutContext) -> tuple[NonlinearConstraint, ...]:
         """Enforce hard time-varying pedestrian-future clearance constraints.
 
@@ -259,6 +243,16 @@ class PredictionMPCPlannerAdapter(NMPCSocialPlannerAdapter):
             envelope settings and an explicit claim boundary.
         """
         payload: dict[str, Any] = copy.deepcopy(super().diagnostics())
+        payload.update(
+            {
+                "predictor_backend": self.prediction_config.predictor_backend,
+                "horizon_steps": self.prediction_config.horizon_steps,
+                "rollout_dt": self.prediction_config.rollout_dt,
+            }
+        )
+        predictor_diagnostics = getattr(self._future_predictor, "diagnostics", None)
+        if callable(predictor_diagnostics):
+            payload["predictor"] = predictor_diagnostics()
         payload["pedestrian_uncertainty_envelope"] = envelope_diagnostics(
             enabled=bool(self.prediction_config.pedestrian_uncertainty_envelope_enabled),
             alpha=float(self.prediction_config.pedestrian_uncertainty_alpha_mps),

--- a/scripts/tools/import_sdd_scenarios.py
+++ b/scripts/tools/import_sdd_scenarios.py
@@ -33,6 +33,7 @@ class SddPoint:
     x_px: float
     y_px: float
     label: str
+    raw_label: str
 
 
 @dataclass(frozen=True)
@@ -49,6 +50,14 @@ class ImportOptions:
     max_waypoints: int
     margin_m: float
     y_flip_height_px: float | None = None
+
+
+def normalize_sdd_label(raw_label: str) -> str:
+    """Normalize an SDD annotation label for user-facing comparison and storage."""
+    label = str(raw_label).strip()
+    if len(label) >= 2 and label[0] == label[-1] and label[0] in {"'", '"'}:
+        return label[1:-1].strip()
+    return label
 
 
 def _parse_annotation_line(line: str, *, line_number: int) -> SddPoint | None:
@@ -75,22 +84,25 @@ def _parse_annotation_line(line: str, *, line_number: int) -> SddPoint | None:
         frame=int(frame),
         x_px=x_center,
         y_px=y_center,
-        label=str(label),
+        label=normalize_sdd_label(label),
+        raw_label=str(label),
     )
 
 
 def load_sdd_points(path: Path, *, label: str) -> list[SddPoint]:
     """Load pedestrian points from an SDD annotation file."""
+    target_label = normalize_sdd_label(label)
+    target_label_key = target_label.casefold()
     points: list[SddPoint] = []
     with path.open(encoding="utf-8") as handle:
         for line_number, line in enumerate(handle, start=1):
             point = _parse_annotation_line(line, line_number=line_number)
             if point is None:
                 continue
-            if point.label.lower() == label.lower():
+            if point.label.casefold() == target_label_key:
                 points.append(point)
     if not points:
-        raise ValueError(f"No usable '{label}' annotations found in {path}.")
+        raise ValueError(f"No usable '{target_label}' annotations found in {path}.")
     return points
 
 
@@ -178,6 +190,7 @@ def build_import_payload(
                     "source_frame_start": min(frames),
                     "source_frame_end": max(frames),
                     "source_label": track_points[0].label,
+                    "source_raw_label": track_points[0].raw_label,
                 },
             }
         )

--- a/scripts/tools/sdd_curation_preflight.py
+++ b/scripts/tools/sdd_curation_preflight.py
@@ -73,10 +73,11 @@ def probe_annotation_file(
         dict: ``exists``, parse/selection outcome, ``usable_label_points``, ``usable_track_count``
         (tracks meeting ``min_track_points``), ``selection_satisfiable``, and ``blockers``.
     """
+    normalized_label = import_sdd_scenarios.normalize_sdd_label(label)
     report: dict[str, Any] = {
         "path": str(path),
         "exists": path.is_file(),
-        "label": label,
+        "label": normalized_label,
         "min_track_points": min_track_points,
         "max_pedestrians": max_pedestrians,
         "usable_label_points": 0,

--- a/scripts/tools/sdd_curation_preflight.py
+++ b/scripts/tools/sdd_curation_preflight.py
@@ -105,7 +105,7 @@ def probe_annotation_file(
     report["selection_satisfiable"] = len(usable_tracks) >= 1
     if not report["selection_satisfiable"]:
         report["blockers"].append(
-            f"no track has >= {min_track_points} usable '{label}' points after lost-filtering "
+            f"no track has >= {min_track_points} usable '{normalized_label}' points after lost-filtering "
             f"(found {len(usable_tracks)} qualifying tracks)"
         )
     return report

--- a/tests/planner/test_prediction_mpc.py
+++ b/tests/planner/test_prediction_mpc.py
@@ -308,7 +308,13 @@ def test_uncertainty_envelope_example_config_activates_envelope() -> None:
     cfg = build_prediction_mpc_config(raw)
     planner = PredictionMPCPlannerAdapter(cfg)
 
-    envelope = planner.diagnostics()["pedestrian_uncertainty_envelope"]
+    diagnostics = planner.diagnostics()
+    assert diagnostics["predictor_backend"] == "constant_velocity"
+    assert diagnostics["horizon_steps"] == cfg.horizon_steps
+    assert diagnostics["rollout_dt"] == pytest.approx(cfg.rollout_dt)
+    assert diagnostics["predictor"]["calls"] == 0
+
+    envelope = diagnostics["pedestrian_uncertainty_envelope"]
     assert envelope["enabled"] is True
     assert envelope["policy"] == "linear"
     assert envelope["alpha_mps"] == pytest.approx(0.1)

--- a/tests/tools/test_import_sdd_scenarios.py
+++ b/tests/tools/test_import_sdd_scenarios.py
@@ -35,6 +35,90 @@ def _write_sdd_fixture(path: Path) -> None:
     )
 
 
+def _write_quoted_sdd_fixture(path: Path) -> None:
+    """Write tiny SDD-format annotation fixture with quoted labels."""
+    path.write_text(
+        "\n".join(
+            [
+                '1 0 0 10 10 0 0 0 0 "Pedestrian"',
+                '1 5 0 15 10 5 0 0 0 "Pedestrian"',
+                '1 10 0 20 10 10 0 0 0 "Pedestrian"',
+                '1 15 0 25 10 15 0 0 0 "Pedestrian"',
+                '2 100 100 110 110 0 0 0 0 "Pedestrian"',
+                '2 100 105 110 115 5 0 0 0 "Pedestrian"',
+                '2 100 110 110 120 10 0 0 0 "Pedestrian"',
+                '2 100 115 110 125 15 0 0 0 "Pedestrian"',
+                '3 0 0 10 10 0 1 0 0 "Pedestrian"',
+                '4 0 0 10 10 0 0 0 0 "Biker"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_normalize_sdd_label_strips_one_matching_quote_pair() -> None:
+    """SDD labels should strip only a matching wrapper quote pair."""
+    assert import_sdd_scenarios.normalize_sdd_label('"Pedestrian"') == "Pedestrian"
+    assert import_sdd_scenarios.normalize_sdd_label("'Pedestrian'") == "Pedestrian"
+    assert import_sdd_scenarios.normalize_sdd_label(' "Pedestrian" ') == "Pedestrian"
+    assert import_sdd_scenarios.normalize_sdd_label('"Pedestrian') == '"Pedestrian'
+
+
+def test_load_sdd_points_accepts_user_label_for_quoted_rows(tmp_path: Path) -> None:
+    """User-facing label names should match quoted SDD annotation rows."""
+    annotations = tmp_path / "annotations.txt"
+    _write_quoted_sdd_fixture(annotations)
+
+    points = import_sdd_scenarios.load_sdd_points(annotations, label="Pedestrian")
+
+    assert len(points) == 8
+    assert {point.track_id for point in points} == {"1", "2"}
+    assert {point.label for point in points} == {"Pedestrian"}
+
+
+def test_load_sdd_points_accepts_legacy_quoted_label_argument(tmp_path: Path) -> None:
+    """The prior quoted-label workaround remains accepted."""
+    annotations = tmp_path / "annotations.txt"
+    _write_quoted_sdd_fixture(annotations)
+
+    points = import_sdd_scenarios.load_sdd_points(annotations, label='"Pedestrian"')
+
+    assert len(points) == 8
+    assert {point.label for point in points} == {"Pedestrian"}
+
+
+def test_quoted_sdd_labels_are_normalized_in_import_metadata(tmp_path: Path) -> None:
+    """Generated metadata should store normalized source labels."""
+    annotations = tmp_path / "annotations.txt"
+    _write_quoted_sdd_fixture(annotations)
+    points = import_sdd_scenarios.load_sdd_points(annotations, label="Pedestrian")
+    options = import_sdd_scenarios.ImportOptions(
+        dataset_id="sdd_fixture",
+        source_annotation=annotations,
+        meters_per_pixel=0.1,
+        frame_rate_hz=30.0,
+        min_track_points=4,
+        max_pedestrians=2,
+        stride=2,
+        max_waypoints=3,
+        margin_m=1.0,
+        y_flip_height_px=None,
+    )
+
+    map_payload, scenario_payload, provenance = import_sdd_scenarios.build_import_payload(
+        points,
+        options,
+    )
+
+    assert map_payload["single_pedestrians"][0]["metadata"]["source_label"] == "Pedestrian"
+    assert (
+        scenario_payload["scenarios"][0]["single_pedestrians"][0]["metadata"]["source_label"]
+        == "Pedestrian"
+    )
+    assert provenance["pedestrians"][0]["source_label"] == "Pedestrian"
+    assert provenance["pedestrians"][0]["source_raw_label"] == '"Pedestrian"'
+
+
 def test_import_sdd_scenarios_writes_loadable_map_scenario_and_provenance(tmp_path: Path) -> None:
     """Importer output should be consumable by the existing scenario loader."""
     annotations = tmp_path / "annotations.txt"

--- a/tests/tools/test_sdd_curation_preflight.py
+++ b/tests/tools/test_sdd_curation_preflight.py
@@ -36,6 +36,62 @@ def _write_sdd_fixture(path: Path) -> None:
     )
 
 
+def _write_quoted_sdd_fixture(path: Path) -> None:
+    """Write tiny valid SDD-format annotation fixture with quoted labels."""
+    path.write_text(
+        "\n".join(
+            [
+                '1 0 0 10 10 0 0 0 0 "Pedestrian"',
+                '1 5 0 15 10 5 0 0 0 "Pedestrian"',
+                '1 10 0 20 10 10 0 0 0 "Pedestrian"',
+                '1 15 0 25 10 15 0 0 0 "Pedestrian"',
+                '2 100 100 110 110 0 0 0 0 "Pedestrian"',
+                '2 100 105 110 115 5 0 0 0 "Pedestrian"',
+                '2 100 110 110 120 10 0 0 0 "Pedestrian"',
+                '2 100 115 110 125 15 0 0 0 "Pedestrian"',
+                '3 0 0 10 10 0 1 0 0 "Pedestrian"',  # lost -> filtered
+                '4 0 0 10 10 0 0 0 0 "Biker"',  # wrong label -> filtered
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_probe_accepts_user_facing_label_for_quoted_sdd_rows(tmp_path: Path) -> None:
+    """Probe should accept unquoted labels for quoted SDD annotation rows."""
+    annotations = tmp_path / "annotations.txt"
+    _write_quoted_sdd_fixture(annotations)
+
+    probe = sdd_curation_preflight.probe_annotation_file(
+        annotations,
+        label="Pedestrian",
+        min_track_points=4,
+        max_pedestrians=4,
+    )
+
+    assert probe["label"] == "Pedestrian"
+    assert probe["usable_label_points"] == 8
+    assert probe["usable_track_count"] == 2
+    assert probe["selection_satisfiable"] is True
+    assert probe["blockers"] == []
+
+
+def test_probe_normalizes_legacy_quoted_label_argument(tmp_path: Path) -> None:
+    """Probe report should display the canonical unquoted label."""
+    annotations = tmp_path / "annotations.txt"
+    _write_quoted_sdd_fixture(annotations)
+
+    probe = sdd_curation_preflight.probe_annotation_file(
+        annotations,
+        label='"Pedestrian"',
+        min_track_points=4,
+        max_pedestrians=4,
+    )
+
+    assert probe["label"] == "Pedestrian"
+    assert probe["usable_label_points"] == 8
+
+
 def test_probe_counts_usable_tracks_after_filtering(tmp_path: Path) -> None:
     """Probe should count only label-matching, non-lost tracks meeting min_track_points."""
     annotations = tmp_path / "annotations.txt"

--- a/tests/tools/test_sdd_curation_preflight.py
+++ b/tests/tools/test_sdd_curation_preflight.py
@@ -71,6 +71,13 @@ def test_probe_accepts_user_facing_label_for_quoted_sdd_rows(tmp_path: Path) -> 
 
     assert probe["label"] == "Pedestrian"
     assert probe["usable_label_points"] == 8
+    blocked = sdd_curation_preflight.probe_annotation_file(
+        annotations,
+        label='"Pedestrian"',
+        min_track_points=99,
+        max_pedestrians=4,
+    )
+    assert "usable 'Pedestrian' points" in blocked["blockers"][0]
     assert probe["usable_track_count"] == 2
     assert probe["selection_satisfiable"] is True
     assert probe["blockers"] == []


### PR DESCRIPTION
## Reviewer-critical summary

Changed: `scripts/tools/import_sdd_scenarios.py` now normalizes Stanford Drone Dataset (SDD) annotation labels by stripping one matching surrounding quote pair before storage/comparison, and `scripts/tools/sdd_curation_preflight.py` reports the normalized label in probe output.

Why now: issue #4080 documents that quoted SDD rows such as `"Pedestrian"` required the awkward CLI workaround `--label '"Pedestrian"'`; this slice makes `--label Pedestrian` work while preserving the prior workaround.

Claim boundary: fixture-level importer/preflight contract only. This is not benchmark evidence, does not validate licensed staged SDD data, and does not change checksum, staging, benchmark interpretation, or dataset files.

Required validation: focused importer/preflight regression tests, touched-file Ruff check, synthetic preflight CLI smoke, and final PR readiness wrapper.

Remaining blocker: scoped bugfix validation is green; full final PR readiness is blocked by unrelated Ruff `F811` in `robot_sf/planner/prediction_mpc.py`, which this branch does not touch. Claude Code on `imech156-u` owns the full PR gate, improvement cycle, and merge authority after open.

## Contract delta

- New parser helper: `normalize_sdd_label(raw_label: str)` strips whitespace and one matching surrounding single- or double-quote pair only.
- `SddPoint.label` is now the normalized user-facing label; matching uses normalized `casefold()` keys.
- New provenance/metadata field: `source_raw_label` preserves the exact parsed raw annotation label alongside normalized `source_label`.
- Preflight `annotation_probe.label` reports the normalized label.
- Compatibility impact: existing unquoted `Pedestrian` rows still match; the old `--label '"Pedestrian"'` workaround still matches; mismatched quote labels are not silently repaired beyond whitespace normalization.
- New fail-closed blockers: none. Existing SDD staging/proxy benchmark-promotion gates are unchanged.

## Summary

Closes #4080 by normalizing quoted SDD labels at the importer boundary and adding regression coverage for importer/preflight behavior.

## Linked Issues

- Closes #4080
- Parent context: #1497

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_import_sdd_scenarios.py tests/tools/test_sdd_curation_preflight.py -q` -> passed, 16 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/import_sdd_scenarios.py scripts/tools/sdd_curation_preflight.py tests/tools/test_import_sdd_scenarios.py tests/tools/test_sdd_curation_preflight.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format scripts/tools/import_sdd_scenarios.py scripts/tools/sdd_curation_preflight.py tests/tools/test_import_sdd_scenarios.py tests/tools/test_sdd_curation_preflight.py` -> 4 files left unchanged.
- Synthetic fixture smoke: `scripts/tools/sdd_curation_preflight.py --annotation <tmp quoted fixture> --label Pedestrian --min-track-points 4 --json` -> exited 0; `annotation_probe.label` was `Pedestrian`, `selection_satisfiable` was true, and benchmark promotion remained false because no licensed SDD staging was used.
- `PR_READY_PR_BODY_FILE=<artifact>/PR_BODY.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> failed after body checks on unrelated existing Ruff `F811` in `robot_sf/planner/prediction_mpc.py`; this branch does not touch that file.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no dataset downloads, no staged dataset/checksum policy changes.

## Downstream Propagation

- Parent issue updated: no. Commenting on issues/PRs was not authorized for this run; this PR body is the single durable state surface for the delivered slice.
- Claim map / benchmark report updated: no, not benchmark evidence.
- Leaderboard / artifact catalog updated: no.
- Registry or config index updated: no.
- Context index / memory note updated: no.

<details>
<summary>Governance appendix</summary>

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: SDD curation preflight/importer label matching should accept user-facing `Pedestrian` for rows ending in `"Pedestrian"`.
- Comparator or baseline, applicable: previous importer stored quoted labels and required quoted CLI workaround.
- Evidence tier: NA - support bugfix contract tests only, no research evidence claim.
- Result classification: NA - support bugfix, not research-result classification.
- Decision stop rule: focused tests and smoke prove quoted and unquoted compatibility without raw dataset dependency.
- Parent issue, claim map, registry, context note, synthesis surface update: #4080 / #1497; no benchmark claim surface update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA.

## Domain-Aware Approval

- Approval concerns experimental validity claim waived / pending / blocked / not required: not required - no benchmark, metric, paper-facing, or experimental-validity claim.
- Target claim/hypothesis: importer/preflight parser contract only.
- Comparator split/evidence validity: NA - synthetic annotation fixture rows prove parser contract only, not domain evidence validity.
- Fallback/degraded exclusions: preflight smoke remained proxy-only and did not promote benchmark evidence.
- Claim boundary: no real SDD, benchmark, or staged-data conclusion.
- Implementation integrity vs experimental validity: implementation tested at parser/preflight boundary; no experimental validity claim.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, quoted label rows matched unquoted `Pedestrian` in tests and CLI smoke.
- Did intervention change command source, selected command, trajectory, route progress? no, parser/preflight label handling only.
- Did scenario actually contain targeted failure mode? yes, synthetic rows ended with `"Pedestrian"`.
- Result route: stop for scoped bugfix.
- Follow-up question issue weak, negative, non-transfer results: none.

## Next Empirical Action

- Rerun needed: no for scoped bugfix; full PR gate owned by Claude Code after open per task handoff.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: licensed staged SDD data intentionally not used.
- Stop / revise / continue decision: stop after PR open.
- Proposed child issue existing follow-up: none.

## Risks / Rollout

- Compatibility risks: downstream consumers may observe new `source_raw_label`; existing `source_label` becomes normalized for quoted rows.
- Failure modes: unusual labels with unmatched quotes are only whitespace-normalized, by design.
- Rollback fallback plan: revert parser normalization and tests.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: issue #4080 live maintainer implementation plan, plus current task requirement to preserve raw label in provenance.
- Any assumptions need to preserved: synthetic fixtures are parser-contract evidence only, not benchmark evidence.

## Follow-Up Issues

- Deferred work: none because issue #4080 scope is complete for this bugfix slice; no follow-up issue needed.
- Issues opened follow-up: none because no deferred work remains for the scoped bugfix.

## Reviewer Notes

- Review `source_label` vs `source_raw_label` naming and confirm preserving raw label in metadata/provenance is acceptable.
- No raw SDD files or generated bulky outputs are committed.

</details>
