### PR TITLE
benchmark: promote ScenarioBelief contrast runner (#3556)

### DIFF
--- a/configs/benchmarks/scenario_belief_drop_vs_retain_issue_3556_near_safe.yaml
+++ b/configs/benchmarks/scenario_belief_drop_vs_retain_issue_3556_near_safe.yaml
@@ -1,0 +1,122 @@
+# Issue #3556 ScenarioBelief drop-vs-retain smoke launch packet.
+#
+# This packet is an opt-in real-runner smoke contract, not a benchmark result.
+# The three arms differ only by the ScenarioBelief `belief_mode` knob consumed by
+# robot_sf.benchmark.map_runner through the stream_gap policy hook.
+
+schema_version: scenario-belief-drop-vs-retain-launch-packet.v1
+issue: 3556
+evidence_status: smoke_candidate
+no_benchmark_result_claim: true
+follows:
+  - issue: 3471
+  - issue: 3553
+  - issue: 3635
+
+claim_gate:
+  target_claim: >-
+    In the real benchmark runner, dropping out-of-field-of-view uncertain agents from
+    stream_gap is less safe than conservative retention when the oracle arm is near-safe.
+  no_claim_until_run: true
+  no_paper_grade_claim: true
+
+scenario_family: configs/scenarios/sets/issue_3556_near_safe_occlusion_bearing_crossing.yaml
+seed_set: issue_3556_s3_smoke
+seed_sets:
+  issue_3556_s3_smoke:
+    purpose: >-
+      CPU-local smoke seed fixture for runner wiring and screening propagation only.
+      It is not a seed-sufficiency claim.
+    seeds:
+      - 363501
+      - 363502
+      - 363503
+
+belief_uncertainty_source:
+  kind: field_of_view
+  fov_degrees: 120.0
+  max_range_m: 8.0
+  note: >-
+    Agents outside the configured field of view are marked low-confidence by the
+    ScenarioBelief hook. The uncertainty source is configurable visibility logic,
+    not a calibrated perception model.
+
+belief_modes:
+  oracle:
+    algo: stream_gap
+    belief_mode: oracle
+    belief_fov_degrees: 120.0
+  uncertain_retained:
+    algo: stream_gap
+    belief_mode: uncertain_retained
+    belief_fov_degrees: 120.0
+  uncertain_dropped:
+    algo: stream_gap
+    belief_mode: uncertain_dropped
+    belief_fov_degrees: 120.0
+
+runner_arms:
+  - arm_id: oracle
+    label: oracle_certain_all_agents
+    scenario_family: configs/scenarios/sets/issue_3556_near_safe_occlusion_bearing_crossing.yaml
+    seed_set: issue_3556_s3_smoke
+    algo: stream_gap
+    algo_config:
+      belief_mode: oracle
+      belief_fov_degrees: 120.0
+    expected_gate_enabled: false
+    expected_planner_visibility: all_agents_retained
+  - arm_id: uncertain_retained
+    label: out_of_view_low_confidence_retained
+    scenario_family: configs/scenarios/sets/issue_3556_near_safe_occlusion_bearing_crossing.yaml
+    seed_set: issue_3556_s3_smoke
+    algo: stream_gap
+    algo_config:
+      belief_mode: uncertain_retained
+      belief_fov_degrees: 120.0
+    expected_gate_enabled: false
+    expected_planner_visibility: low_confidence_agents_retained
+  - arm_id: uncertain_dropped
+    label: out_of_view_low_confidence_dropped
+    scenario_family: configs/scenarios/sets/issue_3556_near_safe_occlusion_bearing_crossing.yaml
+    seed_set: issue_3556_s3_smoke
+    algo: stream_gap
+    algo_config:
+      belief_mode: uncertain_dropped
+      belief_fov_degrees: 120.0
+    expected_gate_enabled: true
+    expected_planner_visibility: low_confidence_agents_dropped
+
+screening:
+  oracle_near_safe_collision_rate_threshold: 0.25
+  required_decision_labels:
+    - revise
+    - retention_dominates
+    - inconclusive
+    - inconclusive_oracle_unsafe
+    - blocked_no_near_safe_family
+  required_report_fields:
+    - scenario_set
+    - seeds
+    - fov_degrees
+    - screening
+    - decision
+
+metric_surface:
+  primary:
+    - success
+    - collisions
+    - near_misses
+    - min_separation
+  note: >-
+    The real runner emits collision, near-miss, clearance, success, progress, and runtime
+    fields; no scripted unsafe-commit metric is promoted by this smoke packet.
+
+validation:
+  - "Run --preflight-only to verify scenario, seed, arm, and screening contracts."
+  - "Run a CPU-local 1-scenario smoke through the real map runner before scaling."
+  - "Classify fallback or degraded rows as limitations, never success evidence."
+out_of_scope:
+  - full benchmark campaign
+  - Slurm or GPU submission
+  - paper or dissertation claim edits

--- a/configs/scenarios/sets/issue_3556_near_safe_occlusion_bearing_crossing.yaml
+++ b/configs/scenarios/sets/issue_3556_near_safe_occlusion_bearing_crossing.yaml
@@ -1,0 +1,7 @@
+schema_version: robot_sf.scenario_matrix.v1
+includes:
+  - ../single/issue_3556_near_safe_occlusion_bearing_crossing.yaml
+select_scenarios:
+  - issue_3556_near_safe_occlusion_bearing_crossing
+map_search_paths:
+  - ../../../maps/svg_maps

--- a/configs/scenarios/single/issue_3556_near_safe_occlusion_bearing_crossing.yaml
+++ b/configs/scenarios/single/issue_3556_near_safe_occlusion_bearing_crossing.yaml
@@ -1,0 +1,71 @@
+schema_version: robot_sf.scenario_matrix.v1
+scenarios:
+  - name: issue_3556_near_safe_occlusion_bearing_crossing
+    scenario_family: near_safe_occlusion_bearing_crossing
+    map_file: ../../../maps/svg_maps/francis2023/francis2023_blind_corner.svg
+    simulation_config:
+      max_episode_steps: 240
+      ped_density: 0.0
+    observation_visibility:
+      enabled: true
+      fov_degrees: 120.0
+      max_range_m: 8.0
+      static_occlusion: true
+    single_pedestrians:
+      - id: h1
+        goal_poi: poi_h1_goal
+        metadata:
+          role: occluded_crossing_pedestrian
+          safety_relevance: crosses_robot_route_after_blind_corner
+    robot_config: {}
+    metadata:
+      purpose: >-
+        Near-safe occlusion-bearing crossing candidate for the issue #3556 real-runner
+        ScenarioBelief drop-vs-retain smoke contrast.
+      issue: 3556
+      source_issue: 3471
+      predecessor_surface: 3635
+      evidence_status: proposal
+      benchmark_evidence: false
+      family: near_safe_occlusion_bearing_crossing
+      archetype: blind_corner_crossing
+      flow: perpendicular
+      occlusion_bearing: true
+      claim_boundary: >-
+        Scenario definition and smoke-scale launch metadata only. It does not report
+        benchmark results or promote a safety claim.
+      near_safe_precondition: oracle_clears_most_episodes_before_contrast_claim
+      scenario_belief_contract:
+        required_modes:
+          - oracle
+          - uncertain_retained
+          - uncertain_dropped
+        uncertainty_source: field_of_view
+        out_of_fov_agents: retained_except_uncertain_dropped_arm
+      generation_profile:
+        schema_version: scenario_generation_params.v1
+        seed_signature: 363501,363502,363503
+        parameters:
+          id: issue_3556_near_safe_occlusion_bearing_crossing
+          density: low
+          flow: cross
+          obstacle: blind_corner
+          groups: 0.0
+          speed_var: low
+          goal_topology: point
+          robot_context: embedded
+          repeats: 1
+          preset: manual_blind_corner_visibility_contract
+      initial_difficulty:
+        schema_version: scenario_initial_difficulty.v1
+        score: 0.52
+        band: medium
+        components:
+          density: 0.18
+          flow: 0.3
+          obstacle: 0.24
+          speed_var: 0.0
+          goal_topology: 0.0
+          groups: 0.0
+          crowding: 0.0
+          n_agents: 1

--- a/robot_sf/benchmark/scenario_belief_screening.py
+++ b/robot_sf/benchmark/scenario_belief_screening.py
@@ -74,7 +74,8 @@ def build_input_screening_report(
         if not isinstance(visibility, Mapping):
             continue
         enabled = bool(visibility.get("enabled", False))
-        scenario_fov = float(visibility.get("fov_degrees", fov_degrees))
+        raw_fov = visibility.get("fov_degrees")
+        scenario_fov = float(raw_fov if raw_fov is not None else fov_degrees)
         has_limited_view = enabled and scenario_fov < 360.0
         has_static_occlusion = bool(visibility.get("static_occlusion", False))
         pedestrians = scenario.get("single_pedestrians")
@@ -150,11 +151,11 @@ def classify_screened_decision(
             "mode_is_discriminating": False,
         }
 
-    oracle_collision_rate = float(oracle["collision_rate"])
-    retained_collision_rate = float(retained["collision_rate"])
-    dropped_collision_rate = float(dropped["collision_rate"])
-    retained_near_misses = int(retained["total_near_misses"])
-    dropped_near_misses = int(dropped["total_near_misses"])
+    oracle_collision_rate = float(oracle.get("collision_rate", 0.0))
+    retained_collision_rate = float(retained.get("collision_rate", 0.0))
+    dropped_collision_rate = float(dropped.get("collision_rate", 0.0))
+    retained_near_misses = int(retained.get("total_near_misses", 0))
+    dropped_near_misses = int(dropped.get("total_near_misses", 0))
     coll_delta = dropped_collision_rate - retained_collision_rate
     nm_delta = dropped_near_misses - retained_near_misses
     worse = coll_delta > 0 or nm_delta > 0

--- a/robot_sf/benchmark/scenario_belief_screening.py
+++ b/robot_sf/benchmark/scenario_belief_screening.py
@@ -1,0 +1,258 @@
+"""Screen ScenarioBelief drop-vs-retain benchmark evidence for issue #3556.
+
+Plain-language summary: this module decides whether a small real-runner
+ScenarioBelief contrast is interpretable before anyone treats it as safety
+evidence. It is pure report logic: it inspects pinned scenarios, seeds, mode
+rows, and oracle safety thresholds without launching benchmark episodes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+REQUIRED_BELIEF_MODES = ("oracle", "uncertain_retained", "uncertain_dropped")
+DECISION_LABELS = (
+    "revise",
+    "retention_dominates",
+    "inconclusive",
+    "inconclusive_oracle_unsafe",
+    "blocked_no_near_safe_family",
+)
+
+
+def _scenario_id(scenario: Mapping[str, Any]) -> str | None:
+    """Return the stable scenario identifier used in benchmark reports."""
+    for key in ("name", "id", "scenario_id"):
+        value = scenario.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _check(passed: bool, detail: str) -> dict[str, Any]:
+    """Build a compact JSON-serializable screening check.
+
+    Returns:
+        Mapping with boolean pass status and a human-readable detail string.
+    """
+    return {"passed": bool(passed), "detail": detail}
+
+
+def build_input_screening_report(
+    *,
+    scenarios: Iterable[Mapping[str, Any]],
+    seeds: list[int],
+    fov_degrees: float,
+    required_modes: tuple[str, ...] = REQUIRED_BELIEF_MODES,
+    scenario_set: Path | str | None = None,
+    launch_packet: Path | str | None = None,
+) -> dict[str, Any]:
+    """Screen static #3556 campaign inputs before benchmark episodes run.
+
+    Returns:
+        JSON-serializable report with ``ready`` and named checks. This report is
+        intentionally limited to static inputs; it does not require episode rows.
+    """
+    scenario_list = [dict(scenario) for scenario in scenarios]
+    scenario_ids = [_scenario_id(scenario) for scenario in scenario_list]
+    unique_ids = sorted({sid for sid in scenario_ids if sid})
+    seeds_pinned = (
+        isinstance(seeds, list)
+        and bool(seeds)
+        and all(isinstance(seed, int) and not isinstance(seed, bool) for seed in seeds)
+        and len(set(seeds)) == len(seeds)
+    )
+    modes_pinned = tuple(required_modes) == REQUIRED_BELIEF_MODES
+
+    out_of_fov_candidates = []
+    for scenario in scenario_list:
+        visibility = scenario.get("observation_visibility")
+        if not isinstance(visibility, Mapping):
+            continue
+        enabled = bool(visibility.get("enabled", False))
+        scenario_fov = float(visibility.get("fov_degrees", fov_degrees))
+        has_limited_view = enabled and scenario_fov < 360.0
+        has_static_occlusion = bool(visibility.get("static_occlusion", False))
+        pedestrians = scenario.get("single_pedestrians")
+        has_pedestrians = isinstance(pedestrians, list) and bool(pedestrians)
+        if has_limited_view and has_static_occlusion and has_pedestrians:
+            out_of_fov_candidates.append(_scenario_id(scenario) or "<unnamed>")
+
+    checks = {
+        "scenario_ids_pinned": _check(
+            len(unique_ids) == len(scenario_list) and bool(unique_ids),
+            f"{len(unique_ids)} unique scenario id(s) pinned"
+            if len(unique_ids) == len(scenario_list) and unique_ids
+            else "scenario set must resolve at least one uniquely named scenario",
+        ),
+        "seeds_pinned": _check(
+            seeds_pinned,
+            f"{len(seeds)} unique integer seed(s) pinned"
+            if seeds_pinned
+            else "seeds must be a non-empty unique integer list",
+        ),
+        "belief_modes_pinned": _check(
+            modes_pinned,
+            f"required modes pinned: {list(required_modes)}"
+            if modes_pinned
+            else f"required modes must be {list(REQUIRED_BELIEF_MODES)}",
+        ),
+        "out_of_fov_sidecar_contract": _check(
+            bool(out_of_fov_candidates),
+            "scenario exposes static occlusion, limited FOV, and explicit pedestrians"
+            if out_of_fov_candidates
+            else "scenario must expose limited-FOV occlusion-bearing pedestrians",
+        ),
+    }
+    failed = [name for name, check in checks.items() if not check["passed"]]
+    return {
+        "schema_version": "scenario-belief-screening-inputs.v1",
+        "issue": 3556,
+        "ready": not failed,
+        "scenario_set": str(scenario_set) if scenario_set is not None else None,
+        "launch_packet": str(launch_packet) if launch_packet is not None else None,
+        "scenario_ids": unique_ids,
+        "seeds": list(seeds),
+        "required_modes": list(required_modes),
+        "fov_degrees": fov_degrees,
+        "checks": checks,
+        "failed_checks": failed,
+        "claim_boundary": (
+            "Static screening only: no benchmark episodes rolled and no safety claim promoted."
+        ),
+    }
+
+
+def classify_screened_decision(
+    by_mode: Mapping[str, Mapping[str, Any]],
+    *,
+    oracle_near_safe_threshold: float,
+) -> dict[str, Any]:
+    """Classify a three-mode result using #3556 allowed decision labels.
+
+    Returns:
+        Decision payload containing the label, reason, threshold, and deltas.
+    """
+    oracle = dict(by_mode.get("oracle", {}))
+    retained = dict(by_mode.get("uncertain_retained", {}))
+    dropped = dict(by_mode.get("uncertain_dropped", {}))
+    if not (oracle.get("episodes") and retained.get("episodes") and dropped.get("episodes")):
+        return {
+            "decision": "blocked_no_near_safe_family",
+            "reason": "one or more modes produced no episode rows",
+            "screening_status": "missing_mode_rows",
+            "oracle_near_safe": False,
+            "oracle_near_safe_threshold": oracle_near_safe_threshold,
+            "mode_is_discriminating": False,
+        }
+
+    oracle_collision_rate = float(oracle["collision_rate"])
+    retained_collision_rate = float(retained["collision_rate"])
+    dropped_collision_rate = float(dropped["collision_rate"])
+    retained_near_misses = int(retained["total_near_misses"])
+    dropped_near_misses = int(dropped["total_near_misses"])
+    coll_delta = dropped_collision_rate - retained_collision_rate
+    nm_delta = dropped_near_misses - retained_near_misses
+    worse = coll_delta > 0 or nm_delta > 0
+    oracle_unsafe = oracle_collision_rate > oracle_near_safe_threshold
+
+    if oracle_unsafe:
+        decision = "inconclusive_oracle_unsafe"
+        reason = (
+            f"oracle baseline itself unsafe (collision_rate {oracle_collision_rate}); "
+            "effect not cleanly attributable"
+        )
+        screening_status = "oracle_unsafe"
+    elif worse:
+        decision = "revise"
+        reason = (
+            "dropping uncertain agents raised collisions "
+            f"({retained_collision_rate}->{dropped_collision_rate}) and/or near-misses "
+            f"(+{nm_delta}) vs retention, with near-safe oracle ({oracle_collision_rate}); "
+            "revise/block dropping default"
+        )
+        screening_status = "near_safe_discriminating"
+    elif coll_delta == 0 and nm_delta == 0:
+        decision = "inconclusive"
+        reason = "no measurable safety difference matrix"
+        screening_status = "near_safe_nondiscriminating"
+    else:
+        decision = "retention_dominates"
+        reason = "dropping did not increase unsafe outcomes here"
+        screening_status = "near_safe_nonworsening"
+
+    return {
+        "decision": decision,
+        "reason": reason,
+        "screening_status": screening_status,
+        "oracle_collision_rate": round(oracle_collision_rate, 4),
+        "oracle_near_safe": not oracle_unsafe,
+        "oracle_near_safe_threshold": oracle_near_safe_threshold,
+        "mode_is_discriminating": worse,
+        "collision_rate_delta_dropped_minus_retained": round(coll_delta, 4),
+        "near_miss_delta_dropped_minus_retained": nm_delta,
+    }
+
+
+def build_screening_report(
+    *,
+    scenarios: Iterable[Mapping[str, Any]],
+    seeds: list[int],
+    by_mode: Mapping[str, Mapping[str, Any]],
+    oracle_near_safe_threshold: float,
+    fov_degrees: float,
+    required_modes: tuple[str, ...] = REQUIRED_BELIEF_MODES,
+    scenario_set: Path | str | None = None,
+    launch_packet: Path | str | None = None,
+) -> dict[str, Any]:
+    """Build the final #3556 screening report after mode rows exist.
+
+    Returns:
+        JSON-serializable screening report for campaign output.
+    """
+    input_report = build_input_screening_report(
+        scenarios=scenarios,
+        seeds=seeds,
+        fov_degrees=fov_degrees,
+        required_modes=required_modes,
+        scenario_set=scenario_set,
+        launch_packet=launch_packet,
+    )
+    missing_modes = [
+        mode for mode in required_modes if not dict(by_mode.get(mode, {})).get("episodes")
+    ]
+    mode_rows_check = _check(
+        not missing_modes,
+        "all three configured arms produced episode rows"
+        if not missing_modes
+        else f"missing episode rows for mode(s): {missing_modes}",
+    )
+    decision = classify_screened_decision(
+        by_mode, oracle_near_safe_threshold=oracle_near_safe_threshold
+    )
+    checks = dict(input_report["checks"])
+    checks["mode_rows_complete"] = mode_rows_check
+    failed = [name for name, check in checks.items() if not check["passed"]]
+    return {
+        "schema_version": "scenario-belief-screening-report.v1",
+        "issue": 3556,
+        "ready": not failed and decision["decision"] != "blocked_no_near_safe_family",
+        "scenario_set": input_report["scenario_set"],
+        "launch_packet": input_report["launch_packet"],
+        "scenario_ids": input_report["scenario_ids"],
+        "seeds": input_report["seeds"],
+        "required_modes": input_report["required_modes"],
+        "fov_degrees": input_report["fov_degrees"],
+        "checks": checks,
+        "failed_checks": failed,
+        "decision": decision,
+        "allowed_decision_labels": list(DECISION_LABELS),
+        "claim_boundary": (
+            "Screening report for bounded real-runner smoke or campaign output. It does not "
+            "promote a paper-grade safety claim."
+        ),
+    }

--- a/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
+++ b/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
@@ -1,28 +1,11 @@
 #!/usr/bin/env python3
-"""Run the ScenarioBelief drop-vs-retain safety contrast through the REAL benchmark runner (#3556).
+"""Run ScenarioBelief drop-vs-retain safety contrast through the real runner.
 
-Plain-language summary: #3471 (PR #3553) showed, in a controlled scripted scenario, that *dropping*
-uncertain (out-of-field-of-view) agents from the ``stream_gap`` planner is less safe than *retaining*
-them. PR #3561 wired the three belief modes into the real benchmark runner. This script closes #3556:
-it runs the ``oracle`` / ``uncertain_retained`` / ``uncertain_dropped`` contrast through
-``robot_sf.benchmark.map_runner.run_map_batch`` on a predeclared crossing scenario family + seed
-matrix, computes episode-level safety metrics from the real benchmark records, and classifies the
-result (``revise`` / ``retention_dominates`` / ``inconclusive`` / ``inconclusive_oracle_unsafe``).
-
-The three modes differ only in the ``belief_mode`` algo-config knob; everything else is identical so
-the contrast is attributable to dropping vs retaining out-of-FOV agents.
-
-Before any episode is rolled, a CPU-only fail-closed readiness gate
-(:func:`check_campaign_readiness`, also runnable via ``--preflight-only``) verifies the campaign's
-own inputs and contracts (modes pinned, seed matrix pinned, scenario set present, run geometry
-positive, the uncertainty-consuming planner key, and the oracle-near-safety screening
-precondition). A failed gate aborts with no compute burned. This gate guards *this* real runner;
-the controlled-scenario predecessor (#3471) is gated separately by
-``scripts/validation/preflight_scenario_belief_runner_readiness_issue_3556.py``.
-
-Evidence boundary: real-benchmark-runner evidence on a bounded crossing family. The FOV uncertainty
-source is a configurable rule, not a calibrated perception model; no paper-grade claim until the
-predeclared matrix is run at the seed-sufficiency budget and reviewed via a claim card.
+Plain-language summary: issue #3471 showed in a controlled scenario that
+dropping uncertain out-of-field-of-view agents from ``stream_gap`` can be less
+safe than retaining them. Issue #3556 promotes that contrast to an opt-in real
+benchmark-runner mode with explicit screening and provenance, without promoting
+the result to a paper-grade claim.
 """
 
 from __future__ import annotations
@@ -37,6 +20,13 @@ import numpy as np
 import yaml
 
 from robot_sf.benchmark.map_runner import run_map_batch
+from robot_sf.benchmark.scenario_belief_screening import (
+    build_input_screening_report,
+    build_screening_report,
+)
+from robot_sf.benchmark.scenario_belief_screening import (
+    classify_screened_decision as _classify_screened_decision,
+)
 from robot_sf.planner.scenario_belief_adapter import SUPPORTED_UNCERTAINTY_PLANNER_KEYS
 from robot_sf.training.scenario_loader import load_scenarios
 
@@ -45,27 +35,23 @@ SCHEMA_VERSION = "belief-mode-safety-campaign.v1"
 ISSUE = 3556
 SCHEMA_PATH = "robot_sf/benchmark/schemas/episode.schema.v1.json"
 
-#: Belief modes -> planner uncertainty gate (oracle/retained keep agents; dropped drops them).
 MODES = ("oracle", "uncertain_retained", "uncertain_dropped")
-#: The planner algo the campaign drives; it must be the uncertainty-consuming one.
 CAMPAIGN_ALGO = "stream_gap"
-#: Contrast pair plus near-safe oracle baseline; each is individually load-bearing.
 REQUIRED_MODES = ("oracle", "uncertain_retained", "uncertain_dropped")
-#: A planner key guaranteed not to consume the uncertainty sidecar, used to prove fail-closed.
 _UNSUPPORTED_PROBE_KEY = "campaign_preflight_unsupported_probe"
-DEFAULT_SCENARIO_SET = "configs/scenarios/sets/issue_3635_near_safe_occlusion_bearing_crossing.yaml"
-DEFAULT_SEED_SET = "issue_3635_s3_contract_only"
+DEFAULT_SCENARIO_SET = "configs/scenarios/sets/issue_3556_near_safe_occlusion_bearing_crossing.yaml"
+DEFAULT_SEED_SET = "issue_3556_s3_smoke"
 DEFAULT_SEEDS = [363501, 363502, 363503]
-DEFAULT_LAUNCH_PACKET = "configs/benchmarks/scenario_belief_drop_vs_retain_issue_3556.yaml"
-DEFAULT_FOV = 120.0
-NEAR_MISS_NOTE = (
-    "real benchmark near_misses + collisions + min_clearance (no scripted unsafe-commit)"
+DEFAULT_LAUNCH_PACKET = (
+    "configs/benchmarks/scenario_belief_drop_vs_retain_issue_3556_near_safe.yaml"
 )
+DEFAULT_FOV = 120.0
 NEAR_SAFE_ORACLE_COLLISION_RATE = 0.25
+NEAR_MISS_NOTE = "real benchmark near_misses + collisions + min_clearance"
 
 
 def load_campaign_scenarios(set_path: Path, seeds: list[int]) -> list[dict[str, Any]]:
-    """Load the scenario family with absolute map paths and the predeclared seed matrix applied."""
+    """Load the predeclared scenario family and apply the pinned seed matrix."""
     scenarios = load_scenarios(set_path, base_dir=set_path)
     prepared: list[dict[str, Any]] = []
     for scenario in scenarios:
@@ -79,7 +65,7 @@ def load_campaign_scenarios(set_path: Path, seeds: list[int]) -> list[dict[str, 
 
 
 def write_algo_config(mode: str, out_dir: Path, *, fov_degrees: float) -> Path:
-    """Write the stream_gap algo config for a belief mode; return its path."""
+    """Write a per-mode stream_gap algorithm config consumed by map_runner."""
     config = {
         "algo": CAMPAIGN_ALGO,
         "allow_testing_algorithms": True,
@@ -87,7 +73,7 @@ def write_algo_config(mode: str, out_dir: Path, *, fov_degrees: float) -> Path:
         "belief_fov_degrees": fov_degrees,
     }
     path = out_dir / f"algo_{mode}.yaml"
-    path.write_text(yaml.safe_dump(config, sort_keys=False))
+    path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
     return path
 
 
@@ -101,7 +87,7 @@ def run_mode(
     dt: float,
     workers: int,
 ) -> list[dict[str, Any]]:
-    """Run all scenarios x seeds for one belief mode through the real runner; return episode records."""
+    """Run all scenarios x seeds for one belief mode through ``run_map_batch``."""
     algo_path = write_algo_config(mode, out_dir, fov_degrees=fov_degrees)
     episodes_path = out_dir / f"episodes_{mode}.jsonl"
     if episodes_path.exists():
@@ -119,15 +105,16 @@ def run_mode(
         resume=False,
         benchmark_profile="experimental",
     )
-    return [json.loads(line) for line in episodes_path.read_text().splitlines() if line.strip()]
+    if not episodes_path.exists():
+        return []
+    return [json.loads(line) for line in episodes_path.read_text(encoding="utf-8").splitlines()]
 
 
 def _metric(record: dict[str, Any], key: str, default: float = 0.0) -> float:
-    """Read a metric from an episode record's metrics block."""
+    """Read a numeric metric from a benchmark episode record."""
     metrics = record.get("metrics") if isinstance(record.get("metrics"), dict) else {}
-    value = metrics.get(key)
     try:
-        return float(value)
+        return float(metrics.get(key, default))
     except (TypeError, ValueError):
         return default
 
@@ -137,14 +124,14 @@ def aggregate(records: list[dict[str, Any]]) -> dict[str, Any]:
     n = len(records)
     if n == 0:
         return {"episodes": 0}
-    collisions = [_metric(r, "total_collision_count") for r in records]
-    near_misses = [_metric(r, "near_misses") for r in records]
-    min_clear = [_metric(r, "min_clearance", default=float("nan")) for r in records]
-    success = [_metric(r, "success") for r in records]
-    valid_clear = [c for c in min_clear if not np.isnan(c)]
+    collisions = [_metric(record, "total_collision_count") for record in records]
+    near_misses = [_metric(record, "near_misses") for record in records]
+    min_clear = [_metric(record, "min_clearance", default=float("nan")) for record in records]
+    success = [_metric(record, "success") for record in records]
+    valid_clear = [value for value in min_clear if not np.isnan(value)]
     return {
         "episodes": n,
-        "collision_rate": round(sum(1 for c in collisions if c > 0) / n, 4),
+        "collision_rate": round(sum(1 for count in collisions if count > 0) / n, 4),
         "total_collisions": int(sum(collisions)),
         "total_near_misses": int(sum(near_misses)),
         "mean_min_clearance": round(float(np.mean(valid_clear)), 4) if valid_clear else None,
@@ -154,111 +141,20 @@ def aggregate(records: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def classify_decision(by_mode: dict[str, dict[str, Any]]) -> dict[str, Any]:
-    """Classify the dropped-vs-retained safety contrast for a maintainer decision."""
-    oracle = by_mode.get("oracle", {})
-    retained = by_mode.get("uncertain_retained", {})
-    dropped = by_mode.get("uncertain_dropped", {})
-    if not (oracle.get("episodes") and retained.get("episodes") and dropped.get("episodes")):
-        return {"decision": "blocked", "reason": "one or more modes produced no episodes"}
-
-    coll_delta = dropped["collision_rate"] - retained["collision_rate"]
-    nm_delta = dropped["total_near_misses"] - retained["total_near_misses"]
-    worse = coll_delta > 0 or nm_delta > 0
-    # "Near-safe oracle" makes the effect attributable to dropping, not scenario difficulty.
-    oracle_unsafe = oracle["collision_rate"] > 0.25
-
-    if worse and not oracle_unsafe:
-        decision, reason = (
-            "revise",
-            (
-                f"dropping uncertain agents raised collisions ({retained['collision_rate']}->"
-                f"{dropped['collision_rate']}) and/or near-misses (+{nm_delta}) vs retention, with a "
-                f"near-safe oracle ({oracle['collision_rate']}); revise/block the dropping default"
-            ),
-        )
-    elif worse and oracle_unsafe:
-        decision, reason = (
-            "inconclusive_oracle_unsafe",
-            (
-                f"dropping looks worse but the oracle baseline is itself unsafe "
-                f"(collision_rate {oracle['collision_rate']}); effect not cleanly attributable"
-            ),
-        )
-    elif coll_delta == 0 and nm_delta == 0:
-        decision, reason = "inconclusive", "no measurable safety difference at this matrix"
-    else:
-        decision, reason = "retention_dominates", "dropping did not increase unsafe outcomes here"
-    return {
-        "decision": decision,
-        "reason": reason,
-        "collision_rate_delta_dropped_minus_retained": round(coll_delta, 4),
-        "near_miss_delta_dropped_minus_retained": nm_delta,
-    }
+    """Backward-compatible classifier entry point."""
+    return classify_screened_decision(by_mode)
 
 
 def classify_screened_decision(by_mode: dict[str, dict[str, Any]]) -> dict[str, Any]:
-    """Classify contrast while exposing #3556 scenario-screening gates.
-
-    The campaign must not interpret a dropped-vs-retained contrast unless the
-    oracle baseline is near-safe and the dropped mode differs from retention.
-    """
-    oracle = by_mode.get("oracle", {})
-    retained = by_mode.get("uncertain_retained", {})
-    dropped = by_mode.get("uncertain_dropped", {})
-    if not (oracle.get("episodes") and retained.get("episodes") and dropped.get("episodes")):
-        return {
-            "decision": "blocked",
-            "reason": "one or more modes produced no episodes",
-            "screening_status": "missing_episodes",
-            "oracle_near_safe": False,
-            "mode_is_discriminating": False,
-        }
-
-    coll_delta = dropped["collision_rate"] - retained["collision_rate"]
-    nm_delta = dropped["total_near_misses"] - retained["total_near_misses"]
-    worse = coll_delta > 0 or nm_delta > 0
-    oracle_collision_rate = float(oracle["collision_rate"])
-    oracle_unsafe = oracle_collision_rate > NEAR_SAFE_ORACLE_COLLISION_RATE
-
-    if oracle_unsafe:
-        decision = "inconclusive_oracle_unsafe"
-        reason = (
-            "oracle baseline is itself unsafe "
-            f"(collision_rate {oracle_collision_rate}); effect not cleanly attributable"
-        )
-        screening_status = "oracle_unsafe"
-    elif worse:
-        decision = "revise"
-        reason = (
-            f"dropping uncertain agents raised collisions ({retained['collision_rate']}->"
-            f"{dropped['collision_rate']}) and/or near-misses (+{nm_delta}) vs retention, "
-            f"with a near-safe oracle ({oracle_collision_rate}); revise/block dropping default"
-        )
-        screening_status = "near_safe_discriminating"
-    elif coll_delta == 0 and nm_delta == 0:
-        decision = "inconclusive"
-        reason = "no measurable safety difference at this matrix"
-        screening_status = "near_safe_nondiscriminating"
-    else:
-        decision = "retention_dominates"
-        reason = "dropping did not increase unsafe outcomes here"
-        screening_status = "near_safe_nonworsening"
-
-    return {
-        "decision": decision,
-        "reason": reason,
-        "screening_status": screening_status,
-        "oracle_collision_rate": round(oracle_collision_rate, 4),
-        "oracle_near_safe": not oracle_unsafe,
-        "oracle_near_safe_threshold": NEAR_SAFE_ORACLE_COLLISION_RATE,
-        "mode_is_discriminating": worse,
-        "collision_rate_delta_dropped_minus_retained": round(coll_delta, 4),
-        "near_miss_delta_dropped_minus_retained": nm_delta,
-    }
+    """Classify the contrast with #3556 allowed decision labels."""
+    return _classify_screened_decision(
+        by_mode,
+        oracle_near_safe_threshold=NEAR_SAFE_ORACLE_COLLISION_RATE,
+    )
 
 
 def _relative_repo_path(path: Path) -> str:
-    """Return a stable repo-relative path when the path is inside this checkout."""
+    """Return a stable repo-relative path when possible."""
     resolved = path.resolve()
     try:
         return resolved.relative_to(REPO_ROOT.resolve()).as_posix()
@@ -273,10 +169,9 @@ def check_launch_packet_arm_contract(  # noqa: C901, PLR0912, PLR0915
     seeds: list[int],
     fov_degrees: float,
 ) -> tuple[bool, str]:
-    """Validate the committed #3635 launch packet arm matrix without rolling episodes."""
+    """Validate committed launch-packet arm metadata without rolling episodes."""
     if not packet_path.exists():
         return False, f"launch packet not found: {packet_path}"
-
     with packet_path.open(encoding="utf-8") as handle:
         packet = yaml.safe_load(handle)
     if not isinstance(packet, dict):
@@ -295,29 +190,29 @@ def check_launch_packet_arm_contract(  # noqa: C901, PLR0912, PLR0915
     seed_set_name = packet.get("seed_set")
     seed_sets = packet.get("seed_sets")
     if not isinstance(seed_set_name, str):
-        failures.append("top-level seed_set must name the pinned #3635 seed set")
+        failures.append("top-level seed_set name must be pinned")
     if not isinstance(seed_sets, dict) or seed_set_name not in seed_sets:
         failures.append(f"seed_sets must define {seed_set_name!r}")
     else:
         seed_entry = seed_sets[seed_set_name]
         if not isinstance(seed_entry, dict) or seed_entry.get("seeds") != seeds:
-            failures.append(f"seed set {seed_set_name!r} must pin seeds {seeds!r}")
+            failures.append(f"seed set {seed_set_name!r} must pin {seeds}")
 
     belief_modes = packet.get("belief_modes")
     if not isinstance(belief_modes, dict):
-        failures.append("belief_modes must be a mapping keyed by required mode")
+        failures.append("belief_modes must be a mapping")
     else:
         mode_keys = set(belief_modes)
         if mode_keys != expected_modes:
             failures.append(
-                f"belief_modes must equal {sorted(expected_modes)} (got {sorted(mode_keys)})"
+                f"belief_modes must contain exactly {sorted(expected_modes)} "
+                f"(got {sorted(mode_keys)})"
             )
 
     arms = packet.get("runner_arms")
     if not isinstance(arms, list):
         failures.append("runner_arms must be a list")
         arms = []
-
     arm_ids = {arm.get("arm_id") for arm in arms if isinstance(arm, dict)}
     if arm_ids != expected_modes:
         failures.append(
@@ -379,50 +274,25 @@ def check_campaign_readiness(
     workers: int,
     launch_packet: Path | None = None,
 ) -> dict[str, Any]:
-    """Fail-closed CPU-only readiness gate for the REAL belief-mode campaign inputs.
-
-    This gates the campaign that this module actually runs (``run_map_batch`` over the three
-    belief modes) -- not a predecessor controlled-scenario runner. It verifies the campaign's own
-    inputs and contracts so a real run never burns compute on an unpinned matrix or a planner that
-    cannot consume the uncertainty sidecar. It does **not** roll episodes or interpret outcomes.
-
-    Checks (all must pass for ``ready``):
-
-    * the three belief modes the drop-vs-retain contrast + near-safe oracle baseline need are
-      pinned (``MODES``);
-    * the seed matrix is a non-empty list of unique integers (not a silent fallback);
-    * the scenario set file exists;
-    * the controlled run geometry (fov / horizon / dt / workers) is strictly positive;
-    * the campaign algo is the uncertainty-consuming planner key and an unsupported key is *not*
-      in the supported set (the adapter's fail-closed guarantee);
-    * the oracle-near-safety precondition holds as a contract: ``NEAR_SAFE_ORACLE_COLLISION_RATE``
-      is a probability and ``classify_screened_decision`` refuses to interpret an unsafe-oracle
-      matrix (synthetic input, no episode roll).
-
-    Returns:
-        A JSON-serializable report ``{"ready": bool, "checks": [...], "failed_checks": [...]}``.
-    """
+    """Fail-closed CPU-only readiness gate over #3556 real-runner inputs."""
     checks: list[dict[str, Any]] = []
 
     def add(name: str, passed: bool, detail: str) -> None:
         checks.append({"name": name, "passed": bool(passed), "detail": detail})
 
-    # 1. Belief modes pinned: exactly the contrast pair + oracle baseline.
     mode_set = set(MODES)
-    missing_modes = [m for m in REQUIRED_MODES if m not in mode_set]
     add(
         "belief_modes_pinned",
-        not missing_modes and mode_set == set(REQUIRED_MODES),
+        mode_set == set(REQUIRED_MODES),
         f"pinned exactly {sorted(REQUIRED_MODES)}"
-        if not missing_modes and mode_set == set(REQUIRED_MODES)
-        else f"MODES must equal {sorted(REQUIRED_MODES)} (got {sorted(mode_set)})",
+        if mode_set == set(REQUIRED_MODES)
+        else f"MODES must equal {sorted(REQUIRED_MODES)}",
     )
 
-    # 2. Seed matrix explicitly pinned: non-empty, integer, unique.
     seeds_ok = (
         isinstance(seeds, list)
-        and len(seeds) > 0
-        and all(isinstance(s, int) and not isinstance(s, bool) for s in seeds)
+        and bool(seeds)
+        and all(isinstance(seed, int) and not isinstance(seed, bool) for seed in seeds)
         and len(set(seeds)) == len(seeds)
     )
     add(
@@ -430,24 +300,48 @@ def check_campaign_readiness(
         seeds_ok,
         f"{len(seeds)} unique integer seeds pinned"
         if seeds_ok
-        else "seeds must be a non-empty list of unique integers",
+        else "seeds must be non-empty list of unique integers",
     )
 
-    # 3. Scenario set exists.
+    set_exists = set_path.exists()
     add(
         "scenario_set_exists",
-        set_path.exists(),
+        set_exists,
         f"scenario set present at {set_path}"
-        if set_path.exists()
+        if set_exists
         else f"scenario set not found: {set_path}",
     )
 
-    # 4. Committed launch packet arms stay aligned with runtime preflight knobs.
+    if set_exists:
+        try:
+            screening_scenarios = load_campaign_scenarios(set_path, seeds)
+            screening_inputs = build_input_screening_report(
+                scenarios=screening_scenarios,
+                seeds=seeds,
+                fov_degrees=fov_degrees,
+                required_modes=REQUIRED_MODES,
+                scenario_set=set_path,
+                launch_packet=launch_packet,
+            )
+            screening_ok = bool(screening_inputs["ready"])
+            screening_detail = (
+                "scenario IDs, seeds, modes, and out-of-FOV sidecar contract pinned"
+                if screening_ok
+                else f"screening input checks failed: {screening_inputs['failed_checks']}"
+            )
+        except (OSError, TypeError, ValueError, yaml.YAMLError) as exc:
+            screening_ok = False
+            screening_detail = f"failed to load scenario screening inputs: {exc}"
+    else:
+        screening_ok = False
+        screening_detail = "scenario set missing; screening inputs unavailable"
+    add("scenario_belief_screening_inputs", screening_ok, screening_detail)
+
     if launch_packet is None:
         add(
             "launch_packet_arm_contract",
             True,
-            "launch packet arm contract not requested for direct readiness call",
+            "launch packet arm contract not requested for this readiness call",
         )
     else:
         arm_contract_ok, arm_contract_detail = check_launch_packet_arm_contract(
@@ -458,17 +352,14 @@ def check_campaign_readiness(
         )
         add("launch_packet_arm_contract", arm_contract_ok, arm_contract_detail)
 
-    # 5. Controlled run geometry strictly positive.
     geometry = {"fov_degrees": fov_degrees, "horizon": horizon, "dt": dt, "workers": workers}
-    bad_geometry = [f"{k}={v} must be > 0" for k, v in geometry.items() if not v > 0]
+    bad_geometry = [f"{key}={value} must be > 0" for key, value in geometry.items() if value <= 0]
     add(
         "run_geometry_positive",
         not bad_geometry,
         "fov/horizon/dt/workers all > 0" if not bad_geometry else "; ".join(bad_geometry),
     )
 
-    # 5. Planner uncertainty contract: the campaign algo consumes uncertainty; an unsupported key
-    #    is provably outside the supported set (the adapter fails closed on it).
     planner_ok = (
         CAMPAIGN_ALGO in SUPPORTED_UNCERTAINTY_PLANNER_KEYS
         and _UNSUPPORTED_PROBE_KEY not in SUPPORTED_UNCERTAINTY_PLANNER_KEYS
@@ -478,13 +369,9 @@ def check_campaign_readiness(
         planner_ok,
         f"campaign algo {CAMPAIGN_ALGO!r} consumes uncertainty; unsupported keys fail closed"
         if planner_ok
-        else f"campaign algo {CAMPAIGN_ALGO!r} is not in supported set "
-        f"{sorted(SUPPORTED_UNCERTAINTY_PLANNER_KEYS)}",
+        else f"campaign algo {CAMPAIGN_ALGO!r} not in supported set",
     )
 
-    # 6. Oracle-near-safety precondition contract (synthetic; no episode roll). The threshold must
-    #    be a probability, and the screening classifier must refuse to interpret an unsafe-oracle
-    #    matrix even when the dropped mode looks worse.
     threshold_ok = 0.0 < NEAR_SAFE_ORACLE_COLLISION_RATE < 1.0
     unsafe_rate = min(1.0, NEAR_SAFE_ORACLE_COLLISION_RATE + 0.5)
     synthetic_unsafe = {
@@ -504,11 +391,10 @@ def check_campaign_readiness(
         f"unsafe oracle (rate {unsafe_rate}) blocks interpretation at threshold "
         f"{NEAR_SAFE_ORACLE_COLLISION_RATE}"
         if contract_ok
-        else f"oracle-near-safety contract violated: threshold_ok={threshold_ok}, "
-        f"decision={screened.get('decision')}",
+        else f"oracle-near-safety contract violated: {screened}",
     )
 
-    failed = [c["name"] for c in checks if not c["passed"]]
+    failed = [check["name"] for check in checks if not check["passed"]]
     return {
         "schema_version": "belief-mode-campaign-readiness.v1",
         "issue": ISSUE,
@@ -517,8 +403,8 @@ def check_campaign_readiness(
         "checks": checks,
         "failed_checks": failed,
         "claim_boundary": (
-            "Input-pinning and fail-closed readiness gate for the real campaign runner; does not "
-            "run the benchmark matrix, roll episodes, or interpret drop-vs-retain outcomes."
+            "Input-pinning fail-closed readiness gate for the real campaign runner; "
+            "does not roll episodes or interpret drop-vs-retain outcomes."
         ),
     }
 
@@ -533,11 +419,7 @@ def run_campaign(
     dt: float,
     workers: int,
 ) -> dict[str, Any]:
-    """Run all three belief modes through the real runner and assemble the classified report.
-
-    Fails closed: if the campaign inputs/contracts are not ready, raises ``RuntimeError`` before
-    any episode is rolled so no compute is burned on an invalid matrix.
-    """
+    """Run all three belief modes and assemble the screened report."""
     readiness = check_campaign_readiness(
         set_path,
         seeds,
@@ -565,23 +447,34 @@ def run_campaign(
             workers=workers,
         )
         by_mode[mode] = aggregate(records)
+
+    screening = build_screening_report(
+        scenarios=scenarios,
+        seeds=seeds,
+        by_mode=by_mode,
+        oracle_near_safe_threshold=NEAR_SAFE_ORACLE_COLLISION_RATE,
+        fov_degrees=fov_degrees,
+        required_modes=REQUIRED_MODES,
+        scenario_set=set_path,
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "issue": ISSUE,
-        "evidence_tier": "nominal_benchmark",
+        "evidence_tier": "smoke_evidence",
         "claim_boundary": (
-            "Real benchmark-runner evidence on a bounded crossing family; FOV uncertainty source is "
-            "not a calibrated perception model; not paper-grade until the predeclared matrix is run "
-            "at seed-sufficiency budget with claim-card review."
+            "Real benchmark-runner smoke on bounded crossing family; FOV uncertainty source is "
+            "not a calibrated perception model; not nominal or paper-grade until full "
+            "predeclared matrix, seed-sufficiency budget, and claim-card review."
         ),
         "runner": "robot_sf.benchmark.map_runner.run_map_batch",
         "scenario_set": str(set_path),
-        "scenario_names": [s.get("name") for s in scenarios],
-        "seeds": seeds,
+        "scenario_names": [scenario.get("name") for scenario in scenarios],
+        "seeds": list(seeds),
         "fov_degrees": fov_degrees,
         "metric_note": NEAR_MISS_NOTE,
         "by_mode": by_mode,
-        "decision": classify_screened_decision(by_mode),
+        "screening": screening,
+        "decision": screening["decision"],
     }
 
 
@@ -596,7 +489,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help=(
             "Optional launch packet to validate against runtime scenario/seed knobs. "
-            "Defaults to the committed #3635 packet only for the default scenario set and seeds."
+            "Defaults to the committed #3556 near-safe packet for default inputs."
         ),
     )
     parser.add_argument(
@@ -610,24 +503,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--preflight-only",
         action="store_true",
-        help=(
-            "Run only the CPU-only fail-closed readiness gate over the campaign inputs and exit "
-            "(0 = ready, 1 = a readiness check failed). Rolls no episodes."
-        ),
+        help="Run only the CPU-only readiness gate. Rolls no episodes.",
     )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entry point: gate inputs, then run the real-runner belief-mode safety campaign.
-
-    Returns ``1`` (and rolls no episodes) when the fail-closed readiness gate fails, otherwise
-    ``0`` after the campaign report is emitted. ``--preflight-only`` stops after the gate.
-    """
+    """CLI entry point."""
     args = parse_args(argv)
     launch_packet = args.launch_packet
-    if launch_packet is None and (
-        _relative_repo_path(args.scenario_set) == DEFAULT_SCENARIO_SET
+    if (
+        launch_packet is None
+        and _relative_repo_path(args.scenario_set) == DEFAULT_SCENARIO_SET
         and args.seeds == DEFAULT_SEEDS
     ):
         launch_packet = Path(DEFAULT_LAUNCH_PACKET)
@@ -658,7 +545,9 @@ def main(argv: list[str] | None = None) -> int:
     print(json.dumps(report, indent=2, sort_keys=True))
     if args.report_json is not None:
         args.report_json.parent.mkdir(parents=True, exist_ok=True)
-        args.report_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        args.report_json.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
         print(f"\nwrote {args.report_json}")
     return 0
 

--- a/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
+++ b/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
@@ -107,7 +107,18 @@ def run_mode(
     )
     if not episodes_path.exists():
         return []
-    return [json.loads(line) for line in episodes_path.read_text(encoding="utf-8").splitlines()]
+    episodes = []
+    for line_number, line in enumerate(
+        episodes_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if not line.strip():
+            continue
+        try:
+            episodes.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Error parsing JSONL on line {line_number} in {episodes_path}: {exc}") from exc
+    return episodes
 
 
 def _metric(record: dict[str, Any], key: str, default: float = 0.0) -> float:
@@ -128,7 +139,7 @@ def aggregate(records: list[dict[str, Any]]) -> dict[str, Any]:
     near_misses = [_metric(record, "near_misses") for record in records]
     min_clear = [_metric(record, "min_clearance", default=float("nan")) for record in records]
     success = [_metric(record, "success") for record in records]
-    valid_clear = [value for value in min_clear if not np.isnan(value)]
+    valid_clear = [value for value in min_clear if np.isfinite(value)]
     return {
         "episodes": n,
         "collision_rate": round(sum(1 for count in collisions if count > 0) / n, 4),

--- a/tests/benchmark/test_issue_3635_scenario_belief_near_safe_family.py
+++ b/tests/benchmark/test_issue_3635_scenario_belief_near_safe_family.py
@@ -118,10 +118,8 @@ def test_issue_3635_runner_default_targets_new_family_and_applies_seed_matrix() 
     """The #3556 runner default resolves the #3635 family and bounded seed fixture."""
     payload = _load_yaml(BENCHMARK_CONFIG)
     expected_family = SCENARIO_SET.relative_to(REPO_ROOT).as_posix()
-    assert campaign.DEFAULT_SCENARIO_SET == expected_family
     assert payload["scenario_family"] == expected_family
-    assert campaign.DEFAULT_SEED_SET == payload["seed_set"]
-    assert campaign.DEFAULT_SEEDS == payload["seed_sets"][payload["seed_set"]]["seeds"]
+    assert payload["seed_sets"][payload["seed_set"]]["seeds"] == campaign.DEFAULT_SEEDS
 
     scenarios = campaign.load_campaign_scenarios(SCENARIO_SET, campaign.DEFAULT_SEEDS)
     assert len(scenarios) == 1

--- a/tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py
+++ b/tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py
@@ -29,11 +29,9 @@ def _ready_kwargs() -> dict[str, float | int]:
     return {"fov_degrees": 120.0, "horizon": 300, "dt": 0.1, "workers": 4}
 
 
-def _scenario_set(tmp_path) -> Path:
-    """Create a placeholder scenario-set file so the existence check passes."""
-    path = tmp_path / "scenario_set.yaml"
-    path.write_text("scenarios: []\n")
-    return path
+def _scenario_set(_tmp_path) -> Path:
+    """Return the checked-in occlusion-bearing #3556 scenario set."""
+    return _MODULE.REPO_ROOT / _MODULE.DEFAULT_SCENARIO_SET
 
 
 def _mode(collision_rate: float, near_misses: int) -> dict[str, float | int]:

--- a/tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py
+++ b/tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py
@@ -24,6 +24,39 @@ run_campaign = _MODULE.run_campaign
 main = _MODULE.main
 
 
+def test_run_mode_reports_malformed_jsonl_line(tmp_path, monkeypatch) -> None:
+    """Malformed runner JSONL names the file and offending line."""
+
+    def _write_bad_jsonl(*_args, **_kwargs) -> None:
+        (tmp_path / "episodes_oracle.jsonl").write_text('{"ok": true}\n{bad\n', encoding="utf-8")
+
+    monkeypatch.setattr(_MODULE, "run_map_batch", _write_bad_jsonl)
+
+    with pytest.raises(ValueError, match="line 2"):
+        _MODULE.run_mode(
+            mode="oracle",
+            scenarios=[],
+            out_dir=tmp_path,
+            fov_degrees=120.0,
+            horizon=10,
+            dt=0.1,
+            workers=1,
+        )
+
+
+def test_aggregate_ignores_nonfinite_min_clearance() -> None:
+    """Infinite clearances should not poison aggregate clearance summaries."""
+
+    report = _MODULE.aggregate(
+        [
+            {"metrics": {"total_collision_count": 0, "near_misses": 0, "min_clearance": float("inf")}},
+            {"metrics": {"total_collision_count": 0, "near_misses": 0, "min_clearance": 0.5}},
+        ]
+    )
+
+    assert report["worst_min_clearance"] == 0.5
+
+
 def _ready_kwargs() -> dict[str, float | int]:
     """Valid, strictly-positive campaign run geometry for readiness checks."""
     return {"fov_degrees": 120.0, "horizon": 300, "dt": 0.1, "workers": 4}

--- a/tests/benchmark/test_scenario_belief_screening.py
+++ b/tests/benchmark/test_scenario_belief_screening.py
@@ -124,6 +124,28 @@ def test_screened_decision_uses_only_issue_allowed_labels() -> None:
     assert revise["decision"] == "revise"
 
 
+def test_input_screening_treats_null_scenario_fov_as_default() -> None:
+    """Explicit null FOV in scenario visibility falls back to run FOV."""
+
+    report = build_input_screening_report(
+        scenarios=[
+            {
+                "name": "null-fov-scenario",
+                "observation_visibility": {
+                    "enabled": True,
+                    "fov_degrees": None,
+                    "static_occlusion": True,
+                },
+                "single_pedestrians": [{"id": "ped"}],
+            }
+        ],
+        seeds=[1, 2, 3],
+        fov_degrees=120.0,
+    )
+
+    assert report["checks"]["out_of_fov_sidecar_contract"]["passed"] is True
+
+
 def test_runner_preflight_checks_launch_packet_and_screening_inputs() -> None:
     """The runner preflight now gates the #3556 launch packet and screening module."""
     payload = _load_yaml(BENCHMARK_CONFIG)

--- a/tests/benchmark/test_scenario_belief_screening.py
+++ b/tests/benchmark/test_scenario_belief_screening.py
@@ -1,0 +1,189 @@
+"""Tests for issue #3556 ScenarioBelief screening report contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+from robot_sf.benchmark.scenario_belief_screening import (
+    build_input_screening_report,
+    build_screening_report,
+    classify_screened_decision,
+)
+from robot_sf.benchmark.scenario_schema import (
+    validate_scenario_list,
+    validate_scenario_matrix_metadata,
+)
+from robot_sf.training.scenario_loader import load_scenarios
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCENARIO_SET = (
+    REPO_ROOT / "configs/scenarios/sets/issue_3556_near_safe_occlusion_bearing_crossing.yaml"
+)
+BENCHMARK_CONFIG = (
+    REPO_ROOT / "configs/benchmarks/scenario_belief_drop_vs_retain_issue_3556_near_safe.yaml"
+)
+CAMPAIGN_SCRIPT = REPO_ROOT / "scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py"
+
+
+def _load_campaign_module():
+    spec = importlib.util.spec_from_file_location(
+        "run_belief_mode_safety_campaign_issue_3556", CAMPAIGN_SCRIPT
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+campaign = _load_campaign_module()
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _mode(collision_rate: float, near_misses: int) -> dict[str, float | int]:
+    return {
+        "episodes": 3,
+        "collision_rate": collision_rate,
+        "total_near_misses": near_misses,
+    }
+
+
+def test_issue_3556_scenario_config_loads_and_exposes_occlusion_contract() -> None:
+    """The #3556 scenario pair is a loadable opt-in real-runner smoke surface."""
+    manifest = _load_yaml(SCENARIO_SET)
+    scenarios = [dict(scenario) for scenario in load_scenarios(SCENARIO_SET)]
+
+    assert validate_scenario_matrix_metadata(manifest) == []
+    assert validate_scenario_list(scenarios) == []
+    assert [scenario["name"] for scenario in scenarios] == [
+        "issue_3556_near_safe_occlusion_bearing_crossing"
+    ]
+    scenario = scenarios[0]
+    assert scenario["metadata"]["issue"] == 3556
+    assert scenario["metadata"]["benchmark_evidence"] is False
+    assert scenario["observation_visibility"]["enabled"] is True
+    assert scenario["observation_visibility"]["static_occlusion"] is True
+    assert scenario["single_pedestrians"][0]["metadata"]["role"] == "occluded_crossing_pedestrian"
+
+
+def test_screening_input_report_requires_out_of_fov_sidecar_contract() -> None:
+    """Static screening verifies scenario IDs, seeds, modes, and occlusion-bearing FOV."""
+    scenarios = campaign.load_campaign_scenarios(SCENARIO_SET, campaign.DEFAULT_SEEDS)
+    report = build_input_screening_report(
+        scenarios=scenarios,
+        seeds=campaign.DEFAULT_SEEDS,
+        fov_degrees=120.0,
+        scenario_set=SCENARIO_SET,
+        launch_packet=BENCHMARK_CONFIG,
+    )
+
+    assert report["ready"] is True
+    assert report["scenario_ids"] == ["issue_3556_near_safe_occlusion_bearing_crossing"]
+    assert report["checks"]["out_of_fov_sidecar_contract"]["passed"] is True
+
+    no_visibility = [dict(scenarios[0], observation_visibility={"enabled": False})]
+    blocked = build_input_screening_report(
+        scenarios=no_visibility,
+        seeds=campaign.DEFAULT_SEEDS,
+        fov_degrees=120.0,
+    )
+    assert blocked["ready"] is False
+    assert "out_of_fov_sidecar_contract" in blocked["failed_checks"]
+
+
+def test_screened_decision_uses_only_issue_allowed_labels() -> None:
+    """Missing rows and unsafe oracle both use issue #3556 decision labels."""
+    missing = classify_screened_decision({}, oracle_near_safe_threshold=0.25)
+    assert missing["decision"] == "blocked_no_near_safe_family"
+
+    unsafe_oracle = classify_screened_decision(
+        {
+            "oracle": _mode(1.0, 3),
+            "uncertain_retained": _mode(0.0, 0),
+            "uncertain_dropped": _mode(1.0, 3),
+        },
+        oracle_near_safe_threshold=0.25,
+    )
+    assert unsafe_oracle["decision"] == "inconclusive_oracle_unsafe"
+
+    revise = classify_screened_decision(
+        {
+            "oracle": _mode(0.0, 0),
+            "uncertain_retained": _mode(0.0, 0),
+            "uncertain_dropped": _mode(0.0, 2),
+        },
+        oracle_near_safe_threshold=0.25,
+    )
+    assert revise["decision"] == "revise"
+
+
+def test_runner_preflight_checks_launch_packet_and_screening_inputs() -> None:
+    """The runner preflight now gates the #3556 launch packet and screening module."""
+    payload = _load_yaml(BENCHMARK_CONFIG)
+    assert payload["issue"] == 3556
+    assert payload["scenario_family"] == campaign.DEFAULT_SCENARIO_SET
+    assert payload["seed_set"] == campaign.DEFAULT_SEED_SET
+    assert payload["seed_sets"][campaign.DEFAULT_SEED_SET]["seeds"] == campaign.DEFAULT_SEEDS
+
+    ok, detail = campaign.check_launch_packet_arm_contract(
+        BENCHMARK_CONFIG,
+        set_path=SCENARIO_SET,
+        seeds=campaign.DEFAULT_SEEDS,
+        fov_degrees=120.0,
+    )
+    assert ok, detail
+
+    readiness = campaign.check_campaign_readiness(
+        SCENARIO_SET,
+        campaign.DEFAULT_SEEDS,
+        fov_degrees=120.0,
+        horizon=240,
+        dt=0.1,
+        workers=1,
+        launch_packet=BENCHMARK_CONFIG,
+    )
+    assert readiness["ready"] is True
+    assert "scenario_belief_screening_inputs" not in readiness["failed_checks"]
+    assert {check["name"] for check in readiness["checks"]} >= {
+        "scenario_belief_screening_inputs",
+        "launch_packet_arm_contract",
+        "oracle_near_safety_contract",
+    }
+
+
+def test_final_screening_report_propagates_decision_and_provenance() -> None:
+    """Campaign reports carry one durable screening surface beside aggregate rows."""
+    scenarios = campaign.load_campaign_scenarios(SCENARIO_SET, campaign.DEFAULT_SEEDS)
+    by_mode = {
+        "oracle": _mode(0.0, 0),
+        "uncertain_retained": _mode(0.0, 0),
+        "uncertain_dropped": _mode(0.0, 2),
+    }
+    report = build_screening_report(
+        scenarios=scenarios,
+        seeds=campaign.DEFAULT_SEEDS,
+        by_mode=by_mode,
+        oracle_near_safe_threshold=0.25,
+        fov_degrees=120.0,
+        scenario_set=SCENARIO_SET,
+        launch_packet=BENCHMARK_CONFIG,
+    )
+
+    assert report["ready"] is True
+    assert report["decision"]["decision"] == "revise"
+    assert report["decision"]["oracle_near_safe_threshold"] == 0.25
+    assert report["scenario_ids"] == ["issue_3556_near_safe_occlusion_bearing_crossing"]
+    assert set(report["allowed_decision_labels"]) == {
+        "revise",
+        "retention_dominates",
+        "inconclusive",
+        "inconclusive_oracle_unsafe",
+        "blocked_no_near_safe_family",
+    }


### PR DESCRIPTION
## Reviewer-critical summary

What changed: wires issue #3556's ScenarioBelief drop-vs-retain contrast into the real `map_runner` path as an opt-in near-safe smoke mode: a #3556 scenario set, launch packet, pure screening module, runner report propagation, and focused tests.

Why now: live maintainer guidance on 2026-07-02 requested extending the existing `scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py` surface rather than adding another guard-only PR. This is a progression slice: the new capability is a reusable `robot_sf.benchmark.scenario_belief_screening` report plus #3556 default launch packet for real-runner smoke execution.

Claim boundary: smoke evidence only. The local CPU smoke produced `inconclusive` with a near-safe oracle on one scenario/one seed/short horizon; no full benchmark campaign, seed-sufficiency claim, default planner change, paper-grade claim, or dissertation claim is promoted.

Required validation: focused unit tests, Ruff, default preflight, real-runner CPU smoke, and final PR readiness.

Remaining blocker: full-scale paired-seed comparison and seed-sufficiency analysis remain Slurm/out-of-scope work after review.

## Contract delta

New schema/config fields:
- `configs/benchmarks/scenario_belief_drop_vs_retain_issue_3556_near_safe.yaml` defines `scenario_family`, `seed_set`, `belief_modes`, `runner_arms`, and `screening.required_decision_labels` for #3556.
- `robot_sf.benchmark.scenario_belief_screening` emits `scenario-belief-screening-inputs.v1` and `scenario-belief-screening-report.v1` payloads.
- Runner reports now include `screening` beside `by_mode`, and `decision` is sourced from `screening["decision"]`.

New fail-closed blockers:
- Missing/duplicate scenario IDs or seeds fail preflight.
- Missing limited-FOV/static-occlusion pedestrian surface fails preflight.
- Missing mode rows classify `blocked_no_near_safe_family`.
- Unsafe oracle arm remains `inconclusive_oracle_unsafe`.

Compatibility impact:
- Default #3556 runner packet now points to the new #3556 near-safe smoke config instead of the older #3635 contract packet.
- The older #3635 packet remains explicitly test-covered as a legacy launch contract.

## Linked issue

- Closes part of #3556: https://github.com/ll7/robot_sf_ll7/issues/3556

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_scenario_belief_screening.py tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py tests/benchmark/test_issue_3635_scenario_belief_near_safe_family.py tests/benchmark/test_scenario_belief_policy_hook_issue_3556.py -q` - passed, 31 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py robot_sf/benchmark/scenario_belief_screening.py tests/benchmark/test_scenario_belief_screening.py tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py tests/benchmark/test_issue_3635_scenario_belief_near_safe_family.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py --preflight-only` - passed, `ready=true`, no failed checks.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py --scenario-set configs/scenarios/sets/issue_3556_near_safe_occlusion_bearing_crossing.yaml --seeds 363501 --horizon 30 --workers 1 --out-dir output/issue_3556_belief_mode_smoke_final --report-json output/issue_3556_belief_mode_smoke_final/summary.json` - passed. Summary: `evidence_tier=smoke_evidence`, `screening.ready=true`, `decision=inconclusive`, modes `oracle, uncertain_retained, uncertain_dropped`, seed `363501`.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue_3556_pr_body.md scripts/dev/pr_ready_check.sh` - passed on clean committed head `8bb664c35763369e40d78c70317c30181ab803a8`; readiness stamp `output/validation/pr_ready/issue-3556-benchmark-promote-scenariobelief-drop-vs-retain-safety-contrast-to-the-r.json`.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No change to planner defaults.
- No issue comment/state-table update because this task explicitly set `comment_issue_or_pr: false`; this PR body records the delivered slice and remaining work instead of adding another issue comment stream.

<details>
<summary>Governance and race checks</summary>

- Late-guidance guard: re-read issue #3556 with comments immediately before PR open; no comments newer than task start were present.
- Dedupe guard: no open PR covers issue #3556 or the exact ScenarioBelief drop-vs-retain scope.
- Fragmentation guard: two recent #3556-related #3635 guard/packet PRs merged in the last 24h (#4037, #4042), but this PR is exempt as a progression slice adding the named real-runner screening/config/report capability.
- Transient queue state: no target host, packet lineage pointer, or private routing state is encoded in tracked files.
- Artifact policy: worktree-local `output/issue_3556_belief_mode_smoke_final/` is validation evidence only and is not committed.

</details>
