### PR TITLE
Issue #3574: add mean-matched heterogeneous population ablation harness

### DIFF
--- a/robot_sf/benchmark/heterogeneous_population_ablation.py
+++ b/robot_sf/benchmark/heterogeneous_population_ablation.py
@@ -291,7 +291,8 @@ def _smoke_conditions(smoke_report: Mapping[str, Any]) -> Mapping[str, Any]:
     condition_payloads = {
         name: value
         for name, value in smoke_report.items()
-        if isinstance(value, Mapping) and name != "delta_mixed_minus_homogeneous"
+        if isinstance(value, Mapping)
+        and name not in {"delta_mixed_minus_homogeneous", "metadata", "config", "environment"}
     }
     if len(condition_payloads) != 2:
         raise ValueError("smoke_report must contain exactly two condition arms")
@@ -310,7 +311,7 @@ def _normalize_composition(composition: Mapping[str, float]) -> dict[str, float]
     total = sum(normalized.values())
     if not math.isclose(total, 1.0, rel_tol=0.0, abs_tol=1e-6):
         raise ValueError(f"composition fractions must sum to 1.0 (got {total})")
-    return normalized
+    return {name: value / total for name, value in normalized.items()}
 
 
 def _coerce_archetype_spec(
@@ -320,9 +321,14 @@ def _coerce_archetype_spec(
     if isinstance(value, ArchetypePopulationSpec):
         spec = value
     elif isinstance(value, Mapping):
+        try:
+            desired_speed_factor = float(value["desired_speed_factor"])
+            radius_m = float(value["radius_m"])
+        except KeyError as exc:
+            raise ValueError(f"archetype spec {name!r} missing key: {exc.args[0]}") from exc
         spec = ArchetypePopulationSpec(
-            desired_speed_factor=float(value["desired_speed_factor"]),
-            radius_m=float(value["radius_m"]),
+            desired_speed_factor=desired_speed_factor,
+            radius_m=radius_m,
             response_law=(
                 None if value.get("response_law") is None else str(value.get("response_law"))
             ),

--- a/robot_sf/benchmark/heterogeneous_population_ablation.py
+++ b/robot_sf/benchmark/heterogeneous_population_ablation.py
@@ -1,0 +1,381 @@
+"""Mean-matched heterogeneous-population ablation harness for issue #3574.
+
+The harness is intentionally pure analysis/export tooling. It constructs paired
+population arms that share the same population-mean speed factor and pedestrian
+radius while preserving a heterogeneous mixture arm, and it can attach
+per-archetype metric breakdowns when per-pedestrian control traces are present.
+It does not run benchmark campaigns or promote heterogeneous-population claims.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from robot_sf.benchmark.heterogeneous_population_metrics import (
+    assess_control_trace_readiness,
+    per_archetype_metrics_from_control_trace,
+)
+from robot_sf.ped_npc.ped_archetypes import allocate_archetype_counts, assign_archetype_labels
+
+HETEROGENEOUS_POPULATION_ABLATION_SCHEMA = "heterogeneous_population_ablation_harness.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class ArchetypePopulationSpec:
+    """Parameter slice used by the mean-matched population generator."""
+
+    desired_speed_factor: float
+    radius_m: float
+    response_law: str | None = None
+
+
+def build_mean_matched_population_pair(
+    *,
+    population_size: int,
+    composition: Mapping[str, float],
+    archetypes: Mapping[str, ArchetypePopulationSpec | Mapping[str, Any]],
+    seed: int | None = None,
+    homogeneous_archetype: str = "mean_matched_homogeneous",
+) -> dict[str, Any]:
+    """Build heterogeneous and mean-matched homogeneous population arms.
+
+    The heterogeneous arm keeps the requested mixture. The homogeneous arm uses a
+    single synthetic archetype whose speed factor and radius equal the mixture's
+    weighted means, so later paired runs can isolate heterogeneity from a simple
+    population-mean shift.
+
+    Returns:
+        Versioned JSON-serializable report with paired population records.
+    """
+
+    if population_size <= 0:
+        raise ValueError("population_size must be positive")
+    composition_values = _normalize_composition(composition)
+    specs = {name: _coerce_archetype_spec(name, value) for name, value in archetypes.items()}
+    _validate_composition_keys(composition_values, specs)
+
+    mean_speed_factor = _weighted_mean(
+        composition_values,
+        {name: spec.desired_speed_factor for name, spec in specs.items()},
+        "desired_speed_factor",
+    )
+    mean_radius_m = _weighted_mean(
+        composition_values,
+        {name: spec.radius_m for name, spec in specs.items()},
+        "radius_m",
+    )
+
+    heterogeneous_labels = assign_archetype_labels(
+        population_size,
+        dict(composition_values),
+        seed=seed,
+    )
+    heterogeneous_counts = allocate_archetype_counts(population_size, dict(composition_values))
+    heterogeneous_records = [
+        _population_record(
+            simulator_index=index,
+            archetype=label,
+            spec=specs[str(label)],
+        )
+        for index, label in enumerate(heterogeneous_labels)
+    ]
+    homogeneous_spec = ArchetypePopulationSpec(
+        desired_speed_factor=mean_speed_factor,
+        radius_m=mean_radius_m,
+        response_law="mean_matched",
+    )
+    homogeneous_records = [
+        _population_record(
+            simulator_index=index,
+            archetype=homogeneous_archetype,
+            spec=homogeneous_spec,
+        )
+        for index in range(population_size)
+    ]
+
+    return {
+        "schema_version": HETEROGENEOUS_POPULATION_ABLATION_SCHEMA,
+        "status": "analysis_harness_only",
+        "claim_boundary": (
+            "Constructs paired population inputs and trace-derived summaries only; "
+            "does not run a benchmark campaign or establish a heterogeneity claim."
+        ),
+        "seed": seed,
+        "population_size": population_size,
+        "mean_matched_parameters": {
+            "desired_speed_factor": mean_speed_factor,
+            "radius_m": mean_radius_m,
+        },
+        "arms": {
+            "heterogeneous": {
+                "composition": dict(sorted(composition_values.items())),
+                "counts": dict(sorted(heterogeneous_counts.items())),
+                "records": heterogeneous_records,
+            },
+            "mean_matched_homogeneous": {
+                "composition": {homogeneous_archetype: 1.0},
+                "counts": {homogeneous_archetype: population_size},
+                "records": homogeneous_records,
+            },
+        },
+    }
+
+
+def build_per_archetype_ablation_report(
+    *,
+    control_traces_by_arm: Mapping[str, Mapping[str, Any] | None],
+    metric_key: str,
+    higher_is_safer: bool = True,
+    cvar_alpha: float = 0.1,
+    reducer: str = "mean",
+) -> dict[str, Any]:
+    """Build per-archetype metric reports for each available ablation arm.
+
+    Missing or incomplete trace payloads are represented as blocked diagnostics
+    instead of being treated as successful evidence.
+
+    Returns:
+        Versioned per-arm report with ready metrics or fail-closed blockers.
+    """
+
+    metric_key = str(metric_key).strip()
+    if not metric_key:
+        raise ValueError("metric_key must be non-empty")
+
+    arms: dict[str, Any] = {}
+    for arm_name in sorted(control_traces_by_arm):
+        control_trace = control_traces_by_arm[arm_name]
+        if control_trace is None:
+            arms[arm_name] = {
+                "status": "blocked",
+                "ready": False,
+                "blockers": ["pedestrian_control_trace missing"],
+            }
+            continue
+
+        readiness = assess_control_trace_readiness(control_trace, metric_key)
+        if not readiness.ready:
+            arms[arm_name] = readiness.to_dict()
+            continue
+
+        arms[arm_name] = {
+            "status": "ready",
+            "ready": True,
+            "metrics": per_archetype_metrics_from_control_trace(
+                control_trace,
+                metric_key,
+                higher_is_safer=higher_is_safer,
+                cvar_alpha=cvar_alpha,
+                reducer=reducer,
+            ),
+        }
+
+    return {
+        "schema_version": HETEROGENEOUS_POPULATION_ABLATION_SCHEMA,
+        "evidence_kind": "trace_metric_breakdown",
+        "metric_key": metric_key,
+        "higher_is_safer": higher_is_safer,
+        "cvar_alpha": cvar_alpha,
+        "pedestrian_metric_reducer": reducer,
+        "arms": arms,
+    }
+
+
+def audit_smoke_mean_match(
+    smoke_report: Mapping[str, Any],
+    *,
+    metric_key: str = "avg_speed",
+    tolerance: float = 1e-9,
+) -> dict[str, Any]:
+    """Audit whether an existing smoke report has equal aggregate population means.
+
+    This is a compatibility bridge for the three-seed issue #3206 smoke artifact:
+    it records that the artifact is usable as a mean-matched smoke input while
+    preserving its existing per-archetype ``not_computable`` limitation.
+
+    Returns:
+        Versioned audit payload describing aggregate mean-match readiness.
+    """
+
+    if tolerance < 0:
+        raise ValueError("tolerance must be non-negative")
+    conditions = _smoke_conditions(smoke_report)
+
+    arm_metrics: dict[str, float] = {}
+    blockers: list[str] = []
+    for condition_name in sorted(conditions):
+        metric_value, condition_blockers = _smoke_condition_metric(
+            conditions[condition_name],
+            condition_name=condition_name,
+            metric_key=metric_key,
+        )
+        blockers.extend(condition_blockers)
+        if metric_value is not None:
+            arm_metrics[condition_name] = metric_value
+
+    if len(arm_metrics) != 2:
+        status = "blocked"
+        absolute_delta = None
+        mean_matched = False
+    else:
+        first, second = sorted(arm_metrics)
+        absolute_delta = abs(arm_metrics[first] - arm_metrics[second])
+        mean_matched = absolute_delta <= tolerance
+        status = "ready" if mean_matched else "blocked"
+        if not mean_matched:
+            blockers.append(
+                f"{metric_key} means differ by {absolute_delta:.12g}, tolerance {tolerance:.12g}"
+            )
+
+    return {
+        "schema_version": HETEROGENEOUS_POPULATION_ABLATION_SCHEMA,
+        "source_schema_version": smoke_report.get("schema_version"),
+        "status": status,
+        "metric_key": metric_key,
+        "tolerance": tolerance,
+        "mean_matched": mean_matched,
+        "absolute_delta": absolute_delta,
+        "arm_means": dict(sorted(arm_metrics.items())),
+        "blockers": blockers,
+        "claim_boundary": (
+            "Smoke audit only. Existing three-seed artifact can check aggregate "
+            "mean matching but cannot establish per-archetype or benchmark claims."
+        ),
+    }
+
+
+def _smoke_condition_metric(
+    condition: Any,
+    *,
+    condition_name: str,
+    metric_key: str,
+) -> tuple[float | None, list[str]]:
+    """Return aggregate metric mean and local blockers for one smoke arm."""
+
+    if not isinstance(condition, Mapping):
+        raise ValueError(f"smoke_report.conditions[{condition_name!r}] must be mapping")
+    metrics = condition.get("metrics") if "metrics" in condition else condition
+    if not isinstance(metrics, Mapping):
+        raise ValueError(f"smoke_report.conditions[{condition_name!r}].metrics must be mapping")
+
+    blockers: list[str] = []
+    metric_payload = metrics.get(metric_key)
+    if not isinstance(metric_payload, Mapping) or "mean" not in metric_payload:
+        blockers.append(f"{condition_name}: missing metrics.{metric_key}.mean")
+        return None, blockers
+
+    value = float(metric_payload["mean"])
+    if not math.isfinite(value):
+        raise ValueError(f"{condition_name}: metrics.{metric_key}.mean must be finite")
+
+    distributional_status = condition.get("distributional_disruption", {})
+    if isinstance(distributional_status, Mapping):
+        status = str(distributional_status.get("status", "")).strip()
+        if status and status != "ready":
+            blockers.append(f"{condition_name}: per-archetype breakdown {status}")
+    return value, blockers
+
+
+def _smoke_conditions(smoke_report: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return two condition payloads from detailed or aggregate smoke artifacts."""
+
+    conditions = smoke_report.get("conditions")
+    if isinstance(conditions, Mapping):
+        if len(conditions) != 2:
+            raise ValueError("smoke_report.conditions must contain exactly two arms")
+        return conditions
+
+    condition_payloads = {
+        name: value
+        for name, value in smoke_report.items()
+        if isinstance(value, Mapping) and name != "delta_mixed_minus_homogeneous"
+    }
+    if len(condition_payloads) != 2:
+        raise ValueError("smoke_report must contain exactly two condition arms")
+    return condition_payloads
+
+
+def _normalize_composition(composition: Mapping[str, float]) -> dict[str, float]:
+    if not composition:
+        raise ValueError("composition must be non-empty")
+    normalized = {str(name).strip(): float(value) for name, value in composition.items()}
+    for name, value in normalized.items():
+        if not name:
+            raise ValueError("composition archetype names must be non-empty")
+        if not math.isfinite(value) or value <= 0.0:
+            raise ValueError(f"composition fraction {name!r} must be finite > 0")
+    total = sum(normalized.values())
+    if not math.isclose(total, 1.0, rel_tol=0.0, abs_tol=1e-6):
+        raise ValueError(f"composition fractions must sum to 1.0 (got {total})")
+    return normalized
+
+
+def _coerce_archetype_spec(
+    name: str,
+    value: ArchetypePopulationSpec | Mapping[str, Any],
+) -> ArchetypePopulationSpec:
+    if isinstance(value, ArchetypePopulationSpec):
+        spec = value
+    elif isinstance(value, Mapping):
+        spec = ArchetypePopulationSpec(
+            desired_speed_factor=float(value["desired_speed_factor"]),
+            radius_m=float(value["radius_m"]),
+            response_law=(
+                None if value.get("response_law") is None else str(value.get("response_law"))
+            ),
+        )
+    else:
+        raise TypeError(f"archetype spec {name!r} must be ArchetypePopulationSpec or mapping")
+
+    if not math.isfinite(spec.desired_speed_factor) or spec.desired_speed_factor <= 0.0:
+        raise ValueError(f"archetype {name!r} desired_speed_factor must be finite > 0")
+    if not math.isfinite(spec.radius_m) or spec.radius_m <= 0.0:
+        raise ValueError(f"archetype {name!r} radius_m must be finite > 0")
+    return spec
+
+
+def _validate_composition_keys(
+    composition: Mapping[str, float],
+    specs: Mapping[str, ArchetypePopulationSpec],
+) -> None:
+    missing = sorted(name for name in composition if name not in specs)
+    if missing:
+        raise ValueError(f"composition references unknown archetypes: {missing}")
+
+
+def _weighted_mean(
+    composition: Mapping[str, float],
+    values: Mapping[str, float],
+    parameter_name: str,
+) -> float:
+    weighted_value = sum(composition[name] * values[name] for name in composition)
+    if not math.isfinite(weighted_value):
+        raise ValueError(f"weighted {parameter_name} mean must be finite")
+    return float(weighted_value)
+
+
+def _population_record(
+    *,
+    simulator_index: int,
+    archetype: str,
+    spec: ArchetypePopulationSpec,
+) -> dict[str, Any]:
+    return {
+        "simulator_index": simulator_index,
+        "archetype": str(archetype),
+        "desired_speed_factor": float(spec.desired_speed_factor),
+        "radius_m": float(spec.radius_m),
+        "response_law": spec.response_law,
+    }
+
+
+__all__ = [
+    "HETEROGENEOUS_POPULATION_ABLATION_SCHEMA",
+    "ArchetypePopulationSpec",
+    "audit_smoke_mean_match",
+    "build_mean_matched_population_pair",
+    "build_per_archetype_ablation_report",
+]

--- a/tests/benchmark/test_heterogeneous_population_ablation.py
+++ b/tests/benchmark/test_heterogeneous_population_ablation.py
@@ -84,6 +84,30 @@ def test_mean_matched_population_pair_rejects_unknown_archetype() -> None:
         )
 
 
+def test_mean_matched_population_pair_reports_missing_archetype_spec_key() -> None:
+    """Mapping specs fail with a descriptive missing-key error."""
+
+    with pytest.raises(ValueError, match="missing key: radius_m"):
+        build_mean_matched_population_pair(
+            population_size=4,
+            composition={"cautious": 1.0},
+            archetypes={"cautious": {"desired_speed_factor": 0.7}},
+        )
+
+
+def test_mean_matched_population_pair_normalizes_tolerance_slop() -> None:
+    """Tiny composition roundoff is normalized before mean calculations."""
+
+    report = build_mean_matched_population_pair(
+        population_size=10,
+        composition={"cautious": 0.1, "standard": 0.2, "hurried": 0.7000001},
+        archetypes=_archetypes(),
+    )
+
+    expected = (0.1 * 0.7 + 0.2 * 1.0 + 0.7000001 * 1.4) / 1.0000001
+    assert report["mean_matched_parameters"]["desired_speed_factor"] == pytest.approx(expected)
+
+
 def test_per_archetype_ablation_report_blocks_missing_control_trace() -> None:
     """Missing traces stay blocked diagnostics, not claim-supporting metrics."""
 
@@ -114,6 +138,23 @@ def test_per_archetype_ablation_report_uses_trace_metrics_when_ready() -> None:
     assert metrics["worst_archetype_by_mean"] == "hurried"
     assert metrics["per_archetype"]["cautious"]["mean"] == pytest.approx(0.9)
     assert metrics["per_archetype"]["hurried"]["mean"] == pytest.approx(0.4)
+
+
+def test_smoke_mean_match_fallback_ignores_metadata_mappings() -> None:
+    """Fallback smoke parsing should not confuse metadata maps for condition arms."""
+
+    audit = audit_smoke_mean_match(
+        {
+            "schema_version": "smoke.v1",
+            "metadata": {"run": "ignored"},
+            "config": {"also": "ignored"},
+            "homogeneous_standard": {"mean_min_clearance": {"mean": 1.0}},
+            "heterogeneous_mixed": {"mean_min_clearance": {"mean": 1.0}},
+        },
+        metric_key="mean_min_clearance",
+    )
+
+    assert audit["status"] == "ready"
 
 
 def test_issue_3206_three_seed_smoke_audits_as_mean_matched_but_not_per_archetype_ready() -> None:

--- a/tests/benchmark/test_heterogeneous_population_ablation.py
+++ b/tests/benchmark/test_heterogeneous_population_ablation.py
@@ -1,0 +1,148 @@
+"""Mean-matched heterogeneous-population ablation harness tests for issue #3574."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.heterogeneous_population_ablation import (
+    HETEROGENEOUS_POPULATION_ABLATION_SCHEMA,
+    ArchetypePopulationSpec,
+    audit_smoke_mean_match,
+    build_mean_matched_population_pair,
+    build_per_archetype_ablation_report,
+)
+
+
+def _archetypes() -> dict[str, ArchetypePopulationSpec]:
+    return {
+        "cautious": ArchetypePopulationSpec(desired_speed_factor=0.7, radius_m=0.35),
+        "standard": ArchetypePopulationSpec(desired_speed_factor=1.0, radius_m=0.30),
+        "hurried": ArchetypePopulationSpec(desired_speed_factor=1.4, radius_m=0.25),
+    }
+
+
+def _control_trace() -> dict[str, object]:
+    return {
+        "schema_version": "pedestrian-control-trace.v1",
+        "pedestrians": [
+            {
+                "id": "ped_cautious",
+                "archetype": "cautious",
+                "steps": [
+                    {"step": 0, "clearance_m": 1.0},
+                    {"step": 1, "clearance_m": 0.8},
+                ],
+            },
+            {
+                "id": "ped_hurried",
+                "archetype": "hurried",
+                "steps": [
+                    {"step": 0, "clearance_m": 0.5},
+                    {"step": 1, "clearance_m": 0.3},
+                ],
+            },
+        ],
+    }
+
+
+def test_mean_matched_population_pair_preserves_weighted_speed_and_radius() -> None:
+    """The homogeneous arm uses the heterogeneous mixture's exact parameter means."""
+
+    report = build_mean_matched_population_pair(
+        population_size=12,
+        composition={"cautious": 0.25, "standard": 0.5, "hurried": 0.25},
+        archetypes=_archetypes(),
+        seed=3574,
+    )
+
+    assert report["schema_version"] == HETEROGENEOUS_POPULATION_ABLATION_SCHEMA
+    assert report["status"] == "analysis_harness_only"
+    assert report["mean_matched_parameters"]["desired_speed_factor"] == pytest.approx(1.025)
+    assert report["mean_matched_parameters"]["radius_m"] == pytest.approx(0.3)
+    assert report["arms"]["heterogeneous"]["counts"] == {
+        "cautious": 3,
+        "hurried": 3,
+        "standard": 6,
+    }
+    homogeneous_records = report["arms"]["mean_matched_homogeneous"]["records"]
+    assert {record["archetype"] for record in homogeneous_records} == {"mean_matched_homogeneous"}
+    assert {record["desired_speed_factor"] for record in homogeneous_records} == {1.025}
+    assert {record["radius_m"] for record in homogeneous_records} == {0.3}
+
+
+def test_mean_matched_population_pair_rejects_unknown_archetype() -> None:
+    """Unknown mixture entries fail before producing misleading arm records."""
+
+    with pytest.raises(ValueError, match="unknown archetypes"):
+        build_mean_matched_population_pair(
+            population_size=4,
+            composition={"unknown": 1.0},
+            archetypes=_archetypes(),
+        )
+
+
+def test_per_archetype_ablation_report_blocks_missing_control_trace() -> None:
+    """Missing traces stay blocked diagnostics, not claim-supporting metrics."""
+
+    report = build_per_archetype_ablation_report(
+        control_traces_by_arm={"heterogeneous": None},
+        metric_key="clearance_m",
+    )
+
+    assert report["arms"]["heterogeneous"] == {
+        "status": "blocked",
+        "ready": False,
+        "blockers": ["pedestrian_control_trace missing"],
+    }
+
+
+def test_per_archetype_ablation_report_uses_trace_metrics_when_ready() -> None:
+    """Ready traces feed the existing per-archetype metric harness per arm."""
+
+    report = build_per_archetype_ablation_report(
+        control_traces_by_arm={"heterogeneous": _control_trace()},
+        metric_key="clearance_m",
+        higher_is_safer=True,
+        cvar_alpha=0.5,
+    )
+
+    metrics = report["arms"]["heterogeneous"]["metrics"]
+    assert metrics["source"] == "pedestrian_control_trace"
+    assert metrics["worst_archetype_by_mean"] == "hurried"
+    assert metrics["per_archetype"]["cautious"]["mean"] == pytest.approx(0.9)
+    assert metrics["per_archetype"]["hurried"]["mean"] == pytest.approx(0.4)
+
+
+def test_issue_3206_three_seed_smoke_audits_as_mean_matched_but_not_per_archetype_ready() -> None:
+    """Existing three-seed smoke artifact proves aggregate mean matching only."""
+
+    aggregate_report = json.loads(
+        Path(
+            "docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/"
+            "aggregate_by_condition.json"
+        ).read_text(encoding="utf-8")
+    )
+    detailed_report = json.loads(
+        Path(
+            "docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/"
+            "smoke_report.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    audit = audit_smoke_mean_match(aggregate_report)
+
+    assert audit["schema_version"] == HETEROGENEOUS_POPULATION_ABLATION_SCHEMA
+    assert audit["status"] == "ready"
+    assert audit["mean_matched"] is True
+    assert audit["absolute_delta"] == pytest.approx(0.0)
+    assert audit["arm_means"] == {
+        "homogeneous_standard": pytest.approx(0.9795916847173137),
+        "mixed_balanced": pytest.approx(0.9795916847173137),
+    }
+    assert (
+        detailed_report["per_archetype_distributional_status"]
+        == "not_computable_from_current_smoke"
+    )


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a pure `heterogeneous_population_ablation_harness.v1` analysis module for issue #3574 that constructs paired heterogeneous and mean-matched homogeneous population arms with the same population-mean speed factor and pedestrian radius, and builds per-archetype arm reports from existing pedestrian control traces.

Why now: prior #3574 slices landed metric primitives and trace support; this progression slice adds a nameable new capability toward the issue implementation plan: a reusable mean-matched population generator plus trace-backed per-archetype ablation report assembler.

Claim boundary: this PR is harness/export tooling only. It validates against the existing three-seed #3206 smoke artifacts and synthetic traces, but does not run a full benchmark campaign, does not submit Slurm/GPU work, and does not edit paper/dissertation or benchmark claims.

Required validation: focused tests for mean matching, fail-closed missing traces, per-archetype trace metrics, the #3206 three-seed smoke mean-match audit, and the dependent pedestrian archetype helper tests; final PR readiness wrapper with this PR body.

Remaining blocker: existing #3206 smoke artifacts still lack per-pedestrian control traces, so they can prove aggregate mean matching only; per-archetype smoke metrics remain not computable until trace-bearing runs exist.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3574

## Contract delta

New schema field/surface:

- `heterogeneous_population_ablation_harness.v1`
- `ArchetypePopulationSpec(desired_speed_factor, radius_m, response_law)`
- `build_mean_matched_population_pair(...)`
- `build_per_archetype_ablation_report(...)`
- `audit_smoke_mean_match(...)`

New fail-closed blockers:

- invalid, non-positive, non-finite, unknown, or non-normalized population composition fails before records are emitted;
- missing pedestrian control trace becomes a blocked per-arm diagnostic, not claim evidence;
- incomplete control traces reuse the existing readiness blocker payload;
- smoke artifacts with unequal aggregate means or missing mean metrics report blocked status.

Compatibility impact: additive only. No existing simulator behavior, benchmark runner, schema, or tracked queue-routing state is changed.

## Scope summary

- Added `robot_sf/benchmark/heterogeneous_population_ablation.py`.
- Added `tests/benchmark/test_heterogeneous_population_ablation.py`.
- Reused existing smoke artifacts under `docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Validation

- `uv run pytest tests/benchmark/test_heterogeneous_population_ablation.py tests/benchmark/test_heterogeneous_population_metrics.py tests/benchmark/test_pedestrian_control_trace.py` - passed, 39 tests.
- `uv run ruff format robot_sf/benchmark/heterogeneous_population_ablation.py tests/benchmark/test_heterogeneous_population_ablation.py && uv run ruff check robot_sf/benchmark/heterogeneous_population_ablation.py tests/benchmark/test_heterogeneous_population_ablation.py` - passed.
- `uv run pytest tests/ped_npc/test_ped_archetypes.py` - passed, 26 tests.
- `git diff --cached --check` - passed.
- `uv run python -m py_compile robot_sf/benchmark/heterogeneous_population_ablation.py` - passed.
- `PYTEST_NUM_WORKERS=8 MIN_COVERAGE=70 PR_READY_MODE=final PR_READY_PR_BODY_FILE=... BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; readiness stamp `output/validation/pr_ready/issue-3574-analysis-mean-matched-heterogeneous-population-ablation-harness-per-arch.json`, head `25aea7e24e3737c2dba00ef7de22b1a75317e80c`.

## State propagation

No issue comment is added because this run was authorized with `comment_issue_or_pr: false`. The PR body is the durable propagation surface for this low-churn progression slice; it states the delivered capability and remaining blocker.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: recent merged #3574 PRs found were #3595, #3633, #3672, and #3836, with the latest merged on 2026-06-29, not within the last 24 hours of this run. This PR is also a progression slice that adds a nameable new capability, not a micro-guard.

Queue-routing state: no target-host, packet-lineage, or transient queue state is encoded in tracked files.

Artifact policy: no generated benchmark outputs are committed. Existing compact tracked #3206 evidence artifacts are read as fixtures.

</details>
