### PR TITLE
feat: add false-positive replay report for issue #3300

### DIFF
--- a/configs/benchmarks/issue_3300_false_positive_nominal_smoke.yaml
+++ b/configs/benchmarks/issue_3300_false_positive_nominal_smoke.yaml
@@ -1,0 +1,15 @@
+name: issue_3300_false_positive_nominal_smoke
+scenario_matrix: configs/scenarios/planner_sanity_matrix_v1.yaml
+workers: 1
+horizon: 5
+dt: 0.1
+record_forces: false
+resume: false
+export_publication_bundle: false
+seed_policy:
+  mode: fixed-list
+  seeds: [0]
+planners:
+  - key: goal
+    algo: goal
+    benchmark_profile: baseline-safe

--- a/configs/benchmarks/issue_3300_false_positive_perturbed_smoke.yaml
+++ b/configs/benchmarks/issue_3300_false_positive_perturbed_smoke.yaml
@@ -1,0 +1,16 @@
+name: issue_3300_false_positive_perturbed_smoke
+scenario_matrix: configs/scenarios/planner_sanity_matrix_v1.yaml
+workers: 1
+horizon: 5
+dt: 0.1
+record_forces: false
+resume: false
+export_publication_bundle: false
+observation_noise: configs/benchmarks/observation_noise/issue_3300_false_positive_actor_injection_v1.yaml
+seed_policy:
+  mode: fixed-list
+  seeds: [0]
+planners:
+  - key: goal
+    algo: goal
+    benchmark_profile: baseline-safe

--- a/configs/benchmarks/observation_noise/issue_3300_false_positive_actor_injection_v1.yaml
+++ b/configs/benchmarks/observation_noise/issue_3300_false_positive_actor_injection_v1.yaml
@@ -1,0 +1,7 @@
+observation_noise:
+  enabled: true
+  profile: issue_3300_false_positive_actor_injection_v1
+  seed: 3300
+  pedestrian_false_positive_prob: 1.0
+  pedestrian_false_positive_radius_m: 3.0
+  pedestrian_false_positive_radius: 0.35

--- a/robot_sf/benchmark/false_positive_replay_report.py
+++ b/robot_sf/benchmark/false_positive_replay_report.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import math
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -331,7 +332,25 @@ def _has_predeclared_delta(report: Mapping[str, Any]) -> bool:
 
 
 def _pair_key(row: Mapping[str, Any], pair_keys: Sequence[str]) -> tuple[tuple[str, Any], ...]:
-    return tuple((key, _get_nested(row, key)) for key in pair_keys)
+    values: list[tuple[str, Any]] = []
+    for key in pair_keys:
+        if key == "planner_identity":
+            value = _planner_identity(row)
+        else:
+            value = _get_nested(row, key)
+        if not isinstance(value, str | int | float | bool) and value is not None:
+            value = json.dumps(value, sort_keys=True, separators=(",", ":"))
+        values.append((key, value))
+    return tuple(values)
+
+
+def _planner_identity(row: Mapping[str, Any]) -> str:
+    """Return stable planner identity while preserving valid falsy identifiers."""
+    for key in ("planner_key", "planner", "algo", "scenario_params.algo"):
+        value = _get_nested(row, key)
+        if value is not None:
+            return str(value)
+    return "unknown"
 
 
 def _metric_value(row: Mapping[str, Any], field: str) -> Any:
@@ -405,6 +424,7 @@ def _number(value: Any) -> float:
     if isinstance(value, bool):
         return 1.0 if value else 0.0
     try:
-        return float(value)
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else 0.0
     except (TypeError, ValueError):
         return 0.0

--- a/robot_sf/benchmark/false_positive_replay_report.py
+++ b/robot_sf/benchmark/false_positive_replay_report.py
@@ -1,0 +1,410 @@
+"""Issue #3300 false-positive actor-injection replay report helpers."""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.robustness_delta import (
+    build_robustness_delta_report,
+    load_episode_jsonl,
+    write_report_json,
+)
+
+SCHEMA_VERSION = "false_positive_actor_injection_replay.v1"
+ISSUE = 3300
+CLAIM_BOUNDARY = (
+    "CPU-local observation-quality replay smoke for false-positive actor injection. "
+    "Diagnostic only; not a full benchmark campaign, hardware sensor model, or paper-facing claim."
+)
+
+CLASS_OBSERVED = "observed"
+CLASS_SCENARIO_TOO_WEAK = "scenario_too_weak"
+CLASS_BLOCKED_UNAVAILABLE = "blocked_unavailable"
+CLASS_TRACE_ONLY_DIAGNOSTIC = "trace_only_diagnostic"
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_PREDECLARED_METRICS = (
+    "min_distance_m",
+    "clearance_m",
+    "near_miss",
+    "collision",
+    "route_progress",
+    "route_complete",
+    "runtime_s",
+    "stop_step",
+    "yield_step",
+)
+
+
+def build_false_positive_replay_report(
+    *,
+    nominal_jsonl: Path,
+    perturbed_jsonl: Path,
+    replay_mode: str = "executable",
+    nominal_rows: Sequence[Mapping[str, Any]] | None = None,
+    perturbed_rows: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a paired false-positive actor-injection replay report.
+
+    Args:
+        nominal_jsonl: Nominal replay episode JSONL.
+        perturbed_jsonl: False-positive actor-injection replay episode JSONL.
+        replay_mode: ``executable`` for live replay evidence or ``trace_derived`` for
+            trace-only diagnostics.
+        nominal_rows: Optional parsed nominal rows for tests.
+        perturbed_rows: Optional parsed perturbed rows for tests.
+
+    Returns:
+        JSON-serializable report with per-episode deltas and diagnostic classification.
+    """
+    clean_rows = (
+        list(nominal_rows) if nominal_rows is not None else load_episode_jsonl(nominal_jsonl)
+    )
+    noisy_rows = (
+        list(perturbed_rows) if perturbed_rows is not None else load_episode_jsonl(perturbed_jsonl)
+    )
+    delta_report = build_robustness_delta_report(
+        nominal_jsonl=nominal_jsonl,
+        perturbed_jsonl=perturbed_jsonl,
+        nominal_rows=clean_rows,
+        perturbed_rows=noisy_rows,
+    )
+    per_episode_deltas = _paired_episode_deltas(
+        clean_rows,
+        noisy_rows,
+        delta_report["pairing"]["pair_keys"],
+    )
+    injection_summary = _injection_summary(noisy_rows)
+    report: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "issue": ISSUE,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "replay_mode": replay_mode,
+        "inputs": {
+            "nominal_jsonl": nominal_jsonl.as_posix(),
+            "perturbed_jsonl": perturbed_jsonl.as_posix(),
+        },
+        "pairing": delta_report["pairing"],
+        "planner_rows": delta_report["planner_rows"],
+        "per_episode_deltas": per_episode_deltas,
+        "injection_summary": injection_summary,
+    }
+    report["classification"] = classify_false_positive_replay(report)
+    return report
+
+
+def classify_false_positive_replay(report: Mapping[str, Any]) -> dict[str, Any]:
+    """Classify #3300 replay result without promoting benchmark claims.
+
+    Returns:
+        A JSON-serializable label and reason pair.
+    """
+    replay_mode = str(report.get("replay_mode", "executable"))
+    if replay_mode == "trace_derived":
+        return {
+            "label": CLASS_TRACE_ONLY_DIAGNOSTIC,
+            "reason": "report was built from trace-derived diagnostics, not executable replay",
+        }
+
+    injection_summary = _mapping(report.get("injection_summary"))
+    if int(injection_summary.get("pedestrians_added", 0) or 0) <= 0:
+        return {
+            "label": CLASS_BLOCKED_UNAVAILABLE,
+            "reason": "no perturbed episode recorded pedestrians_added > 0",
+        }
+
+    if _has_predeclared_delta(report):
+        return {
+            "label": CLASS_OBSERVED,
+            "reason": "false-positive injection changed at least one predeclared replay outcome",
+        }
+
+    return {
+        "label": CLASS_SCENARIO_TOO_WEAK,
+        "reason": "false-positive injection occurred but pinned smoke outcomes did not change",
+    }
+
+
+def format_false_positive_replay_markdown(report: Mapping[str, Any]) -> str:
+    """Render a compact Markdown issue #3300 replay report.
+
+    Returns:
+        Markdown report text.
+    """
+    classification = _mapping(report.get("classification"))
+    injection = _mapping(report.get("injection_summary"))
+    pairing = _mapping(report.get("pairing"))
+    lines = [
+        "# Issue #3300 False-Positive Actor-Injection Replay",
+        "",
+        "## Claim Boundary",
+        str(report.get("claim_boundary", CLAIM_BOUNDARY)),
+        "",
+        "## Classification",
+        f"- Label: `{classification.get('label', '')}`",
+        f"- Reason: {classification.get('reason', '')}",
+        f"- Replay mode: `{report.get('replay_mode', '')}`",
+        "",
+        "## Pairing",
+        f"- Paired rows: `{pairing.get('paired_rows', 0)}`",
+        f"- Unmatched nominal rows: `{pairing.get('unmatched_nominal_rows', 0)}`",
+        f"- Unmatched perturbed rows: `{pairing.get('unmatched_perturbed_rows', 0)}`",
+        "",
+        "## Injection Summary",
+        f"- Pedestrians added: `{injection.get('pedestrians_added', 0)}`",
+        f"- Steps with noise: `{injection.get('steps_with_noise', 0)}`",
+        f"- Perturbation profiles: `{', '.join(injection.get('profiles', []))}`",
+        f"- Perturbation hashes: `{', '.join(injection.get('hashes', []))}`",
+        "",
+        "## Episode Deltas",
+        "",
+        "| planner | scenario | seed | pedestrians added | changed fields |",
+        "|---|---|---:|---:|---|",
+    ]
+    for row in report.get("per_episode_deltas", []):
+        if not isinstance(row, Mapping):
+            continue
+        changed = ", ".join(str(field) for field in row.get("changed_fields", []))
+        lines.append(
+            "| {planner} | {scenario} | {seed} | {added} | {changed} |".format(
+                planner=row.get("planner_key", ""),
+                scenario=row.get("scenario_id", ""),
+                seed=row.get("seed", ""),
+                added=row.get("pedestrians_added", 0),
+                changed=changed or "none",
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Caveats",
+            "- CPU replay smoke only.",
+            "- False-positive effects are reported separately from other observation noise.",
+            "- No full benchmark campaign, Slurm/GPU submission, or paper-facing claim.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_false_positive_replay_markdown(report: Mapping[str, Any], path: Path) -> None:
+    """Write Markdown issue #3300 report."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(format_false_positive_replay_markdown(report), encoding="utf-8")
+
+
+def write_false_positive_replay_json(report: Mapping[str, Any], path: Path) -> None:
+    """Write JSON issue #3300 report."""
+    write_report_json(report, path)
+
+
+def write_false_positive_replay_csv(report: Mapping[str, Any], path: Path) -> None:
+    """Write per-episode false-positive actor-injection delta CSV."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "planner_key",
+        "scenario_id",
+        "seed",
+        "pedestrians_added",
+        "steps_with_noise",
+        "nominal_actor_count",
+        "perturbed_actor_count",
+        "changed_fields",
+        "metric_delta",
+        "selected_action_nominal",
+        "selected_action_perturbed",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, lineterminator="\n")
+        writer.writeheader()
+        for row in report.get("per_episode_deltas", []):
+            if not isinstance(row, Mapping):
+                continue
+            actor_counts = _mapping(row.get("observed_actor_counts"))
+            action = _mapping(row.get("selected_action"))
+            writer.writerow(
+                {
+                    "planner_key": row.get("planner_key"),
+                    "scenario_id": row.get("scenario_id"),
+                    "seed": row.get("seed"),
+                    "pedestrians_added": row.get("pedestrians_added"),
+                    "steps_with_noise": row.get("steps_with_noise"),
+                    "nominal_actor_count": actor_counts.get("nominal"),
+                    "perturbed_actor_count": actor_counts.get("perturbed"),
+                    "changed_fields": ";".join(
+                        str(field) for field in row.get("changed_fields", [])
+                    ),
+                    "metric_delta": json.dumps(row.get("metric_delta", {}), sort_keys=True),
+                    "selected_action_nominal": action.get("nominal"),
+                    "selected_action_perturbed": action.get("perturbed"),
+                }
+            )
+
+
+def _paired_episode_deltas(
+    nominal_rows: Sequence[Mapping[str, Any]],
+    perturbed_rows: Sequence[Mapping[str, Any]],
+    pair_keys: Sequence[str],
+) -> list[dict[str, Any]]:
+    nominal_index = {_pair_key(row, pair_keys): row for row in nominal_rows}
+    perturbed_index = {_pair_key(row, pair_keys): row for row in perturbed_rows}
+    deltas: list[dict[str, Any]] = []
+    for key in sorted(set(nominal_index) & set(perturbed_index)):
+        nominal = nominal_index[key]
+        perturbed = perturbed_index[key]
+        metric_delta = _metric_delta(nominal, perturbed)
+        action_delta = _action_delta(nominal, perturbed)
+        changed_fields = sorted([field for field, value in metric_delta.items() if value != 0])
+        if action_delta["changed"]:
+            changed_fields.append("selected_action")
+        deltas.append(
+            {
+                "planner_key": _first_present(
+                    perturbed, nominal, "planner_key", "planner_identity"
+                ),
+                "scenario_id": _first_present(perturbed, nominal, "scenario_id"),
+                "seed": _first_present(perturbed, nominal, "seed"),
+                "pedestrians_added": _noise_stat(perturbed, "pedestrians_added"),
+                "steps_with_noise": _noise_stat(perturbed, "steps_with_noise"),
+                "observed_actor_counts": {
+                    "nominal": _actor_count(nominal),
+                    "perturbed": _actor_count(perturbed),
+                },
+                "metric_delta": metric_delta,
+                "selected_action": action_delta,
+                "changed_fields": changed_fields,
+            }
+        )
+    return deltas
+
+
+def _injection_summary(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    stats = {"pedestrians_added": 0, "steps_with_noise": 0}
+    profiles: set[str] = set()
+    hashes: set[str] = set()
+    for row in rows:
+        stats["pedestrians_added"] += _noise_stat(row, "pedestrians_added")
+        stats["steps_with_noise"] += _noise_stat(row, "steps_with_noise")
+        profile = _noise_profile(row)
+        if profile:
+            profiles.add(profile)
+        noise_hash = row.get("observation_noise_hash")
+        if noise_hash:
+            hashes.add(str(noise_hash))
+    return {**stats, "profiles": sorted(profiles), "hashes": sorted(hashes)}
+
+
+def _metric_delta(nominal: Mapping[str, Any], perturbed: Mapping[str, Any]) -> dict[str, float]:
+    deltas: dict[str, float] = {}
+    for field in _PREDECLARED_METRICS:
+        clean = _metric_value(nominal, field)
+        noisy = _metric_value(perturbed, field)
+        if clean is None and noisy is None:
+            continue
+        deltas[field] = _number(noisy) - _number(clean)
+    return deltas
+
+
+def _action_delta(nominal: Mapping[str, Any], perturbed: Mapping[str, Any]) -> dict[str, Any]:
+    clean = _selected_action(nominal)
+    noisy = _selected_action(perturbed)
+    return {"nominal": clean, "perturbed": noisy, "changed": clean != noisy}
+
+
+def _has_predeclared_delta(report: Mapping[str, Any]) -> bool:
+    for row in report.get("planner_rows", []):
+        if not isinstance(row, Mapping):
+            continue
+        if _number(row.get("success_delta")) != 0.0 or _number(row.get("collision_delta")) != 0.0:
+            return True
+    for row in report.get("per_episode_deltas", []):
+        if not isinstance(row, Mapping):
+            continue
+        if row.get("changed_fields"):
+            return True
+    return False
+
+
+def _pair_key(row: Mapping[str, Any], pair_keys: Sequence[str]) -> tuple[tuple[str, Any], ...]:
+    return tuple((key, _get_nested(row, key)) for key in pair_keys)
+
+
+def _metric_value(row: Mapping[str, Any], field: str) -> Any:
+    for prefix in ("metrics", "outcome", "summary"):
+        value = _get_nested(row, f"{prefix}.{field}")
+        if value is not None:
+            return value
+    return _get_nested(row, field)
+
+
+def _noise_stat(row: Mapping[str, Any], field: str) -> int:
+    stats = row.get("observation_noise_stats")
+    if isinstance(stats, Mapping):
+        return int(_number(stats.get(field)))
+    return 0
+
+
+def _actor_count(row: Mapping[str, Any]) -> int | None:
+    for field in (
+        "observed_actor_count",
+        "actor_count",
+        "pedestrian_count",
+        "observation.pedestrians.count",
+        "pedestrians.count",
+    ):
+        value = _get_nested(row, field)
+        if value is not None:
+            return int(_number(value))
+    return None
+
+
+def _noise_profile(row: Mapping[str, Any]) -> str | None:
+    spec = row.get("observation_noise")
+    if isinstance(spec, Mapping) and spec.get("profile"):
+        return str(spec["profile"])
+    profile = row.get("observation_noise_profile")
+    return str(profile) if profile else None
+
+
+def _selected_action(row: Mapping[str, Any]) -> Any:
+    for field in ("selected_action", "action", "actions.selected", "planner_action"):
+        value = _get_nested(row, field)
+        if value is not None:
+            return value
+    return None
+
+
+def _first_present(first_row: Mapping[str, Any], second_row: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        for row in (first_row, second_row):
+            value = _get_nested(row, key)
+            if value is not None:
+                return value
+    return None
+
+
+def _get_nested(row: Mapping[str, Any], path: str) -> Any:
+    current: Any = row
+    for part in path.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _number(value: Any) -> float:
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0

--- a/scripts/benchmark/build_false_positive_replay_report_issue_3300.py
+++ b/scripts/benchmark/build_false_positive_replay_report_issue_3300.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Build issue #3300 false-positive actor-injection replay artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from robot_sf.benchmark.false_positive_replay_report import (
+    build_false_positive_replay_report,
+    write_false_positive_replay_csv,
+    write_false_positive_replay_json,
+    write_false_positive_replay_markdown,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--nominal-jsonl", type=Path, required=True)
+    parser.add_argument("--perturbed-jsonl", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--output-csv", type=Path, required=True)
+    parser.add_argument("--output-md", type=Path, required=True)
+    parser.add_argument(
+        "--replay-mode",
+        choices=("executable", "trace_derived"),
+        default="executable",
+        help="Classify executable replay separately from trace-only diagnostics.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Build JSON, CSV, and Markdown false-positive replay reports."""
+    args = build_parser().parse_args(argv)
+    report = build_false_positive_replay_report(
+        nominal_jsonl=args.nominal_jsonl,
+        perturbed_jsonl=args.perturbed_jsonl,
+        replay_mode=args.replay_mode,
+    )
+    write_false_positive_replay_json(report, args.output_json)
+    write_false_positive_replay_csv(report, args.output_csv)
+    write_false_positive_replay_markdown(report, args.output_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_false_positive_actor_injection_replay.py
+++ b/tests/benchmark/test_false_positive_actor_injection_replay.py
@@ -1,0 +1,199 @@
+"""Tests issue #3300 false-positive actor-injection replay report."""
+
+from __future__ import annotations
+
+import json
+import runpy
+from pathlib import Path
+
+from robot_sf.benchmark.false_positive_replay_report import (
+    CLASS_BLOCKED_UNAVAILABLE,
+    CLASS_OBSERVED,
+    CLASS_SCENARIO_TOO_WEAK,
+    CLASS_TRACE_ONLY_DIAGNOSTIC,
+    build_false_positive_replay_report,
+    classify_false_positive_replay,
+)
+from robot_sf.benchmark.observation_noise import (
+    apply_observation_noise,
+    make_observation_noise_rng,
+    normalize_observation_noise_spec,
+    observation_noise_hash,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = (
+    REPO_ROOT / "scripts" / "benchmark" / "build_false_positive_replay_report_issue_3300.py"
+)
+
+
+def _row(
+    *,
+    route_complete: bool = True,
+    collision: bool = False,
+    progress: float = 1.0,
+    action: str = "go",
+    noise: bool = False,
+    pedestrians_added: int = 0,
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "planner_key": "goal",
+        "algo": "goal",
+        "scenario_id": "planner_sanity_simple",
+        "seed": 0,
+        "kinematics": "differential_drive",
+        "observation_mode": "pedestrians",
+        "metrics": {
+            "route_complete": route_complete,
+            "collision": collision,
+            "route_progress": progress,
+            "runtime_s": 1.5,
+        },
+        "selected_action": action,
+        "observed_actor_count": 2,
+    }
+    if noise:
+        spec = normalize_observation_noise_spec(
+            {
+                "profile": "issue_3300_false_positive_actor_injection_v1",
+                "seed": 3300,
+                "pedestrian_false_positive_prob": 1.0,
+                "pedestrian_false_positive_radius_m": 3.0,
+                "pedestrian_false_positive_radius": 0.35,
+            }
+        )
+        row.update(
+            {
+                "observation_noise": spec,
+                "observation_noise_hash": observation_noise_hash(spec),
+                "observation_noise_stats": {
+                    "steps_with_noise": 5 if pedestrians_added else 0,
+                    "pedestrians_added": pedestrians_added,
+                },
+                "observed_actor_count": 2 + pedestrians_added,
+            }
+        )
+    return row
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_false_positive_observation_noise_adds_pedestrian_deterministically() -> None:
+    """Enabled #3300 profile injects a synthetic pedestrian into compatible observation."""
+    spec = normalize_observation_noise_spec(
+        {
+            "profile": "issue_3300_false_positive_actor_injection_v1",
+            "seed": 3300,
+            "pedestrian_false_positive_prob": 1.0,
+            "pedestrian_false_positive_radius_m": 3.0,
+            "pedestrian_false_positive_radius": 0.35,
+        }
+    )
+    obs = {
+        "robot": {"position": [1.0, 2.0]},
+        "pedestrians": {"positions": [[2.0, 2.0]], "velocities": [[0.0, 0.0]], "count": 1},
+    }
+    rng_a = make_observation_noise_rng(spec, seed=0, scenario_id="planner_sanity_simple")
+    rng_b = make_observation_noise_rng(spec, seed=0, scenario_id="planner_sanity_simple")
+
+    noisy_a, stats_a = apply_observation_noise(obs, spec, rng_a)
+    noisy_b, stats_b = apply_observation_noise(obs, spec, rng_b)
+
+    assert stats_a["pedestrians_added"] == 1
+    assert stats_a["steps_with_noise"] == 1
+    assert noisy_a["pedestrians"]["count"] == 2
+    assert noisy_a["pedestrians"]["positions"] == noisy_b["pedestrians"]["positions"]
+    assert stats_a == stats_b
+
+
+def test_incompatible_observation_classifies_blocked_unavailable(tmp_path: Path) -> None:
+    """No compatible pedestrian observation must not silently become replay success."""
+    nominal = tmp_path / "nominal.jsonl"
+    perturbed = tmp_path / "perturbed.jsonl"
+    _write_jsonl(nominal, [_row()])
+    _write_jsonl(perturbed, [_row(noise=True, pedestrians_added=0)])
+
+    report = build_false_positive_replay_report(nominal_jsonl=nominal, perturbed_jsonl=perturbed)
+
+    assert report["classification"]["label"] == CLASS_BLOCKED_UNAVAILABLE
+    assert report["injection_summary"]["pedestrians_added"] == 0
+
+
+def test_report_records_profile_hash_per_episode_deltas_and_observed_class(tmp_path: Path) -> None:
+    """Replay report records profile hash, per-episode deltas, and observed changes."""
+    nominal = tmp_path / "nominal.jsonl"
+    perturbed = tmp_path / "perturbed.jsonl"
+    _write_jsonl(nominal, [_row(route_complete=True, progress=1.0, action="go")])
+    _write_jsonl(
+        perturbed,
+        [_row(route_complete=False, progress=0.6, action="yield", noise=True, pedestrians_added=3)],
+    )
+
+    report = build_false_positive_replay_report(nominal_jsonl=nominal, perturbed_jsonl=perturbed)
+
+    assert report["classification"]["label"] == CLASS_OBSERVED
+    assert report["injection_summary"]["pedestrians_added"] == 3
+    assert report["injection_summary"]["profiles"] == [
+        "issue_3300_false_positive_actor_injection_v1"
+    ]
+    assert report["injection_summary"]["hashes"]
+    episode = report["per_episode_deltas"][0]
+    assert episode["pedestrians_added"] == 3
+    assert episode["metric_delta"]["route_progress"] == -0.4
+    assert "route_complete" in episode["changed_fields"]
+    assert "selected_action" in episode["changed_fields"]
+
+
+def test_classifier_distinguishes_scenario_too_weak_and_trace_only(tmp_path: Path) -> None:
+    """Classifier keeps no-effect executable smoke separate from trace diagnostics."""
+    nominal = tmp_path / "nominal.jsonl"
+    perturbed = tmp_path / "perturbed.jsonl"
+    _write_jsonl(nominal, [_row()])
+    _write_jsonl(perturbed, [_row(noise=True, pedestrians_added=1)])
+
+    report = build_false_positive_replay_report(nominal_jsonl=nominal, perturbed_jsonl=perturbed)
+    trace_report = {**report, "replay_mode": "trace_derived"}
+
+    assert report["classification"]["label"] == CLASS_SCENARIO_TOO_WEAK
+    assert classify_false_positive_replay(trace_report)["label"] == CLASS_TRACE_ONLY_DIAGNOSTIC
+
+
+def test_cli_writes_json_csv_and_markdown(tmp_path: Path) -> None:
+    """CLI emits the reviewable issue #3300 artifact trio."""
+    nominal = tmp_path / "nominal.jsonl"
+    perturbed = tmp_path / "perturbed.jsonl"
+    output_json = tmp_path / "summary.json"
+    output_csv = tmp_path / "robustness_delta.csv"
+    output_md = tmp_path / "false_positive_replay_report.md"
+    _write_jsonl(nominal, [_row()])
+    _write_jsonl(perturbed, [_row(noise=True, pedestrians_added=1)])
+
+    script = runpy.run_path(str(SCRIPT_PATH))
+    exit_code = script["main"](
+        [
+            "--nominal-jsonl",
+            str(nominal),
+            "--perturbed-jsonl",
+            str(perturbed),
+            "--output-json",
+            str(output_json),
+            "--output-csv",
+            str(output_csv),
+            "--output-md",
+            str(output_md),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "false_positive_actor_injection_replay.v1"
+    assert payload["classification"]["label"] == CLASS_SCENARIO_TOO_WEAK
+    assert "pedestrians_added" in output_csv.read_text(encoding="utf-8")
+    markdown = output_md.read_text(encoding="utf-8")
+    assert "Issue #3300 False-Positive Actor-Injection Replay" in markdown
+    assert "No full benchmark campaign" in markdown

--- a/tests/benchmark/test_false_positive_actor_injection_replay.py
+++ b/tests/benchmark/test_false_positive_actor_injection_replay.py
@@ -149,6 +149,47 @@ def test_report_records_profile_hash_per_episode_deltas_and_observed_class(tmp_p
     assert "selected_action" in episode["changed_fields"]
 
 
+def test_report_pairs_multiple_planners_without_identity_collision(tmp_path: Path) -> None:
+    """Planner identity must be part of episode pairing when planners share seeds."""
+    nominal = tmp_path / "nominal.jsonl"
+    perturbed = tmp_path / "perturbed.jsonl"
+    clean_a = _row(action="go")
+    clean_b = _row(action="stop")
+    noisy_a = _row(action="yield", noise=True, pedestrians_added=1)
+    noisy_b = _row(action="stop", noise=True, pedestrians_added=1)
+    clean_b["planner_key"] = "alt"
+    clean_b["algo"] = "alt"
+    noisy_b["planner_key"] = "alt"
+    noisy_b["algo"] = "alt"
+    _write_jsonl(nominal, [clean_a, clean_b])
+    _write_jsonl(perturbed, [noisy_a, noisy_b])
+
+    report = build_false_positive_replay_report(nominal_jsonl=nominal, perturbed_jsonl=perturbed)
+
+    assert [row["planner_key"] for row in report["per_episode_deltas"]] == ["alt", "goal"]
+    assert [row["selected_action"]["changed"] for row in report["per_episode_deltas"]] == [
+        False,
+        True,
+    ]
+
+
+def test_report_treats_nonfinite_numeric_metrics_as_no_delta(tmp_path: Path) -> None:
+    """NaN and infinity inputs should not masquerade as observed metric changes."""
+    nominal = tmp_path / "nominal.jsonl"
+    perturbed = tmp_path / "perturbed.jsonl"
+    clean = _row()
+    noisy = _row(noise=True, pedestrians_added=1)
+    clean["metrics"]["route_progress"] = float("nan")
+    noisy["metrics"]["route_progress"] = float("inf")
+    _write_jsonl(nominal, [clean])
+    _write_jsonl(perturbed, [noisy])
+
+    report = build_false_positive_replay_report(nominal_jsonl=nominal, perturbed_jsonl=perturbed)
+
+    assert report["per_episode_deltas"][0]["metric_delta"]["route_progress"] == 0.0
+    assert "route_progress" not in report["per_episode_deltas"][0]["changed_fields"]
+
+
 def test_classifier_distinguishes_scenario_too_weak_and_trace_only(tmp_path: Path) -> None:
     """Classifier keeps no-effect executable smoke separate from trace diagnostics."""
     nominal = tmp_path / "nominal.jsonl"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds issue #3300 false-positive actor-injection observation-quality replay reporting: a deterministic noise profile, nominal/perturbed CPU smoke configs, a report builder CLI, per-episode metric/action deltas, provenance fields, and classification labels.

Why now: issue #3300 has an implementation-plan comment asking for the replay/report slice after adjacent observation-noise work landed.

Claim boundary: diagnostic CPU replay smoke only. This does not run or claim a full benchmark campaign, hardware sensor realism, or paper/dissertation evidence.

Required validation: focused unit tests for actor injection/report classification, direct fixture JSONL CLI smoke, Ruff on touched Python, and final PR readiness.

Remaining blocker: empirical live replay over existing repository episodes still needs reviewer/Claude follow-up if the smoke configs do not expose a planner observation with actionable false-positive response changes. This maps to open #3300 checklist items for executable false-positive actor-injection replay, live-vs-trace classification, replay metadata/caveats, and exact missing-prerequisite recording.

## Contract delta

- New observation-noise profile: `configs/benchmarks/observation_noise/issue_3300_false_positive_actor_injection_v1.yaml`.
- New paired smoke configs:
  - `configs/benchmarks/issue_3300_false_positive_nominal_smoke.yaml`
  - `configs/benchmarks/issue_3300_false_positive_perturbed_smoke.yaml`
- New report schema: `false_positive_actor_injection_replay.v1`.
- New classifier labels: `observed`, `scenario_too_weak`, `blocked_unavailable`, `trace_only_diagnostic`.
- New fail-closed blocker: executable replay classifies `blocked_unavailable` when perturbed episodes do not record `pedestrians_added > 0`.
- Compatibility impact: additive only; no existing benchmark schema or nominal metric semantics are changed.

## Issue

Closes no issue automatically. Supports #3300.

## Scope summary

- Reuses existing observation-noise injection logic and robustness pairing.
- Adds #3300-specific per-episode deltas, actor-count/provenance summary, Markdown/JSON/CSV artifact output, and tests.
- The progression capability added here is executable false-positive actor-injection replay reporting and classification, not another guard-only checker.

## Validation

- `uv run pytest tests/benchmark/test_false_positive_actor_injection_replay.py tests/benchmark/test_observation_noise.py -q` - passed, 10 passed.
- `uv run ruff check robot_sf/benchmark/false_positive_replay_report.py scripts/benchmark/build_false_positive_replay_report_issue_3300.py tests/benchmark/test_false_positive_actor_injection_replay.py` - passed.
- `uv run python scripts/benchmark/build_false_positive_replay_report_issue_3300.py --nominal-jsonl <fixture> --perturbed-jsonl <fixture> --output-json <tmp>/summary.json --output-csv <tmp>/robustness_delta.csv --output-md <tmp>/report.md` - passed; summary classified `observed` with `pedestrians_added=1`.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed interim dirty-tree readiness; 1735 passed, 2 skipped.
- `PR_READY_PR_BODY_FILE=<run-artifact>/PR_BODY.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; 1735 passed, 2 skipped in core lane and 4327 passed, 7 skipped in optional-extra lane; clean-tree final stamp recorded for `d42e63ea5818578c1505f1ae8d69b3328a817e06`.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No issue comment/state-table mutation from this run because `comment_issue_or_pr` is not authorized; this PR body is the durable propagation surface for the delivered slice.

<details>
<summary>Governance appendix</summary>

Artifact policy: generated smoke outputs remain temporary under ignored locations; this PR adds only small config/code/test files.

Fragmentation guard: no #3300 PRs merged in the last 24h were found before implementation. This PR is also exempt as a progression slice because it adds the nameable capability "executable false-positive actor-injection replay reporting and classification."

Late guidance guard: reran `gh issue view 3300 --repo ll7/robot_sf_ll7 --comments` immediately before opening. Latest maintainer comment was 2026-07-02T15:19:20Z, before this run started at 2026-07-02T17:34:05Z; no late guidance was missed.

</details>
