### PR TITLE
Issue #3557: parameterize episode uncertainty representations

### DIFF
--- a/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
+++ b/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
@@ -117,7 +117,9 @@ def run_mode(
         try:
             episodes.append(json.loads(line))
         except json.JSONDecodeError as exc:
-            raise ValueError(f"Error parsing JSONL on line {line_number} in {episodes_path}: {exc}") from exc
+            raise ValueError(
+                f"Error parsing JSONL on line {line_number} in {episodes_path}: {exc}"
+            ) from exc
     return episodes
 
 

--- a/scripts/validation/run_scenario_belief_episode_safety_issue_3471.py
+++ b/scripts/validation/run_scenario_belief_episode_safety_issue_3471.py
@@ -38,7 +38,7 @@ import numpy as np
 from robot_sf.gym_env.unified_config import RobotSimulationConfig
 from robot_sf.planner.scenario_belief_adapter import project_scenario_belief_for_planner
 from robot_sf.planner.stream_gap import StreamGapPlannerAdapter, StreamGapPlannerConfig
-from robot_sf.representation import scenario_belief_from_simulator_oracle
+from robot_sf.representation import Estimate2D, scenario_belief_from_simulator_oracle
 
 SCHEMA_VERSION = "scenario-belief-episode-safety.v1"
 ISSUE = 3471
@@ -54,6 +54,30 @@ MODES: dict[str, dict[str, bool]] = {
 
 #: Existence confidence assigned to the degraded corridor agent (below the 0.5 gate threshold).
 _DEGRADED_EXISTENCE = 0.2
+
+#: Position confidence assigned to the conformal-radius proxy (below the 0.5 gate threshold).
+_DEGRADED_POSITION_CONFIDENCE = 0.2
+
+#: Position variance assigned to the inflated-envelope proxy (above the 1.0 gate threshold).
+_INFLATED_POSITION_VARIANCE = 4.0
+
+UNCERTAINTY_REPRESENTATIONS: dict[str, dict[str, str]] = {
+    "belief_drop": {
+        "gate_field": "uncertainty_min_existence_probability",
+        "description": "lower corridor-agent existence probability below the stream_gap gate",
+    },
+    "conformal_radius": {
+        "gate_field": "uncertainty_min_position_confidence",
+        "description": (
+            "lower corridor-agent position confidence as a controlled episode-level "
+            "conformal-radius proxy"
+        ),
+    },
+    "envelope_inflation": {
+        "gate_field": "uncertainty_max_position_variance",
+        "description": "inflate corridor-agent position variance above the stream_gap envelope gate",
+    },
+}
 
 #: The four stream_gap uncertainty-gate thresholds the #3558 sweep is allowed to override.
 GATE_THRESHOLD_FIELDS = (
@@ -140,12 +164,43 @@ def _make_simulator(state: ScenarioState, params: EpisodeParams) -> SimpleNamesp
     )
 
 
-def build_belief_for_mode(state: ScenarioState, mode: str, params: EpisodeParams) -> Any:
+def _degrade_agent_for_representation(agent: Any, uncertainty_representation: str) -> Any:
+    """Apply one issue #3557 uncertainty representation to an agent belief."""
+    if uncertainty_representation == "belief_drop":
+        return replace(agent, existence_probability=_DEGRADED_EXISTENCE)
+    if uncertainty_representation == "conformal_radius":
+        return replace(
+            agent,
+            position=replace(agent.position, confidence=_DEGRADED_POSITION_CONFIDENCE),
+        )
+    if uncertainty_representation == "envelope_inflation":
+        return replace(
+            agent,
+            position=Estimate2D.point(
+                agent.position.mean_xy,
+                confidence=agent.position.confidence,
+                variance=_INFLATED_POSITION_VARIANCE,
+                frame_id=agent.position.frame_id,
+                units=agent.position.units,
+                covariance_units=agent.position.covariance_units,
+            ),
+        )
+    raise ValueError(f"unknown uncertainty representation: {uncertainty_representation}")
+
+
+def build_belief_for_mode(
+    state: ScenarioState,
+    mode: str,
+    params: EpisodeParams,
+    uncertainty_representation: str = "belief_drop",
+) -> Any:
     """Build the ScenarioBelief for ``mode`` from the current ground-truth state.
 
-    The dropped/retained modes degrade the corridor agent's existence confidence below the gate
-    threshold; oracle leaves it certain.
+    The dropped/retained modes degrade the corridor agent through the selected uncertainty
+    representation; oracle leaves it certain.
     """
+    if uncertainty_representation not in UNCERTAINTY_REPRESENTATIONS:
+        raise ValueError(f"unknown uncertainty representation: {uncertainty_representation}")
     simulator = _make_simulator(state, params)
     belief = scenario_belief_from_simulator_oracle(
         simulator, env_config=RobotSimulationConfig(), max_pedestrians=4
@@ -163,7 +218,7 @@ def build_belief_for_mode(state: ScenarioState, mode: str, params: EpisodeParams
             np.linalg.norm(np.asarray(agents[i].position.mean_xy, dtype=float) - corridor_true)
         ),
     )
-    agents[idx] = replace(agents[idx], existence_probability=_DEGRADED_EXISTENCE)
+    agents[idx] = _degrade_agent_for_representation(agents[idx], uncertainty_representation)
     return replace(belief, agents=tuple(agents))
 
 
@@ -219,6 +274,7 @@ def run_episode(
     seed: int,
     params: EpisodeParams,
     gate_thresholds: dict[str, float] | None = None,
+    uncertainty_representation: str = "belief_drop",
 ) -> dict[str, Any]:
     """Roll one controlled episode under ``mode`` and return episode-level safety metrics.
 
@@ -243,7 +299,7 @@ def run_episode(
     fail_closed = False
 
     for step in range(params.max_steps):
-        belief = build_belief_for_mode(state, mode, params)
+        belief = build_belief_for_mode(state, mode, params, uncertainty_representation)
         projection = project_scenario_belief_for_planner(belief, planner_key=PLANNER_KEY)
         status = projection.compatibility.get("status")
         if status == "fail_closed":
@@ -281,6 +337,7 @@ def run_episode(
     progress = max(0.0, (initial_goal_dist - final_goal_dist) / initial_goal_dist)
     return {
         "mode": mode,
+        "uncertainty_representation": uncertainty_representation,
         "seed": seed,
         "collision": collision,
         "min_separation": round(min_sep, 4),
@@ -347,18 +404,43 @@ def classify_decision(by_mode: dict[str, dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def run_matrix(seeds: list[int], params: EpisodeParams) -> dict[str, Any]:
+def run_matrix(
+    seeds: list[int],
+    params: EpisodeParams,
+    uncertainty_representation: str = "belief_drop",
+) -> dict[str, Any]:
     """Run all modes across the seed matrix and assemble the classified report."""
+    if uncertainty_representation not in UNCERTAINTY_REPRESENTATIONS:
+        raise ValueError(f"unknown uncertainty representation: {uncertainty_representation}")
     episodes: dict[str, list[dict[str, Any]]] = {}
     by_mode: dict[str, dict[str, Any]] = {}
     for mode in MODES:
-        rows = [run_episode(mode, seed, params) for seed in seeds]
+        rows = [
+            run_episode(
+                mode,
+                seed,
+                params,
+                uncertainty_representation=uncertainty_representation,
+            )
+            for seed in seeds
+        ]
         episodes[mode] = rows
         by_mode[mode] = _aggregate(rows)
     return {
         "schema_version": SCHEMA_VERSION,
         "issue": ISSUE,
+        "followup_issue": 3557,
         "evidence_tier": "diagnostic",
+        "uncertainty_representation": uncertainty_representation,
+        "uncertainty_representation_contract": {
+            "available_representations": sorted(UNCERTAINTY_REPRESENTATIONS),
+            "selected": UNCERTAINTY_REPRESENTATIONS[uncertainty_representation],
+            "claim_boundary": (
+                "Harness-level representation parameterization only; each run remains a "
+                "controlled #3471 episode contrast and is not a cross-representation "
+                "generalization claim."
+            ),
+        },
         "claim_boundary": (
             "Controlled crossing scenario with the real stream_gap planner + ScenarioBelief "
             "uncertainty gate; not the full benchmark environment, not paper-grade, no trained "
@@ -392,6 +474,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--seeds", type=int, nargs="+", default=None)
     parser.add_argument("--max-steps", type=int, default=None)
+    parser.add_argument(
+        "--uncertainty-representation",
+        choices=sorted(UNCERTAINTY_REPRESENTATIONS),
+        default="belief_drop",
+        help=(
+            "Issue #3557 harness parameter. Selects the ScenarioBelief uncertainty "
+            "representation applied to the corridor agent."
+        ),
+    )
     parser.add_argument("--output-json", type=Path, default=None)
     return parser.parse_args(argv)
 
@@ -407,7 +498,11 @@ def main(argv: list[str] | None = None) -> int:
         seeds = args.seeds
     if args.max_steps is not None:
         params = replace(params, max_steps=args.max_steps)
-    report = run_matrix(seeds, params)
+    report = run_matrix(
+        seeds,
+        params,
+        uncertainty_representation=args.uncertainty_representation,
+    )
     report["generated_at_utc"] = datetime.now(UTC).isoformat()
 
     compact = {k: v for k, v in report.items() if k != "episodes"}

--- a/tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py
+++ b/tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py
@@ -49,7 +49,13 @@ def test_aggregate_ignores_nonfinite_min_clearance() -> None:
 
     report = _MODULE.aggregate(
         [
-            {"metrics": {"total_collision_count": 0, "near_misses": 0, "min_clearance": float("inf")}},
+            {
+                "metrics": {
+                    "total_collision_count": 0,
+                    "near_misses": 0,
+                    "min_clearance": float("inf"),
+                }
+            },
             {"metrics": {"total_collision_count": 0, "near_misses": 0, "min_clearance": 0.5}},
         ]
     )

--- a/tests/validation/test_run_scenario_belief_episode_safety_issue_3471.py
+++ b/tests/validation/test_run_scenario_belief_episode_safety_issue_3471.py
@@ -7,6 +7,7 @@ import numpy as np
 from robot_sf.planner.scenario_belief_adapter import project_scenario_belief_for_planner
 from scripts.validation.run_scenario_belief_episode_safety_issue_3471 import (
     MODES,
+    UNCERTAINTY_REPRESENTATIONS,
     EpisodeParams,
     _is_commit,
     build_belief_for_mode,
@@ -45,6 +46,46 @@ def test_episode_is_deterministic():
     a.pop("runtime_sec")
     b.pop("runtime_sec")
     assert a == b
+
+
+def test_default_representation_preserves_known_issue_3471_contrast():
+    """Default ``belief_drop`` keeps the known #3471 fixture contract."""
+    implicit = run_matrix([101, 102], _FAST)
+    explicit = run_matrix([101, 102], _FAST, uncertainty_representation="belief_drop")
+    implicit.pop("episodes")
+    explicit.pop("episodes")
+    assert implicit == explicit
+
+
+def test_each_uncertainty_representation_runs_and_is_reported():
+    """Issue #3557 harness parameterizes representation without promoting a claim."""
+    for representation in UNCERTAINTY_REPRESENTATIONS:
+        row = run_episode(
+            "uncertain_dropped",
+            seed=101,
+            params=_FAST,
+            uncertainty_representation=representation,
+        )
+        assert row["uncertainty_representation"] == representation
+
+        report = run_matrix([101], _FAST, uncertainty_representation=representation)
+        assert report["followup_issue"] == 3557
+        assert report["uncertainty_representation"] == representation
+        assert (
+            "not a cross-representation generalization claim"
+            in (report["uncertainty_representation_contract"]["claim_boundary"])
+        )
+        assert set(report["by_mode"]) == set(MODES)
+
+
+def test_unknown_uncertainty_representation_fails_closed():
+    """Unknown representation names fail closed instead of silently reusing belief_drop."""
+    try:
+        run_matrix([101], _FAST, uncertainty_representation="unknown")
+    except ValueError as exc:
+        assert "unknown uncertainty representation" in str(exc)
+    else:
+        raise AssertionError("unknown uncertainty representation was accepted")
 
 
 def test_retained_matches_oracle():


### PR DESCRIPTION
## Reviewer-critical summary

What changed: extended the #3471 episode safety harness with `--uncertainty-representation` and three controlled ScenarioBelief representations: `belief_drop`, `conformal_radius`, and `envelope_inflation`.

Why now: issue #3557 needs the harness parameterization before any representation sweep or empirical generalization claim can be evaluated.

Claim boundary: harness-level diagnostic output only. This PR does not run a full benchmark campaign, does not submit Slurm/GPU work, and does not edit paper/dissertation claims.

Required validation: focused harness tests plus representative short CLI runs proving the output schema records representation, modes, issue linkage, and claim boundary.

Remaining blocker: no cross-representation safety-effect claim is made here; a later empirical sweep must decide whether effects generalize.

## Contract delta

New schema/report fields:
- `followup_issue: 3557`
- `uncertainty_representation`
- `uncertainty_representation_contract.available_representations`
- `uncertainty_representation_contract.selected`
- `uncertainty_representation_contract.claim_boundary`

New fail-closed behavior:
- unknown `--uncertainty-representation` values raise `ValueError` / argparse choice errors instead of silently falling back to `belief_drop`.

Compatibility impact:
- default behavior remains `belief_drop`, preserving the existing #3471 harness contrast.
- existing callers that do not pass the new option keep current behavior.

## Summary

Parameterized `scripts/validation/run_scenario_belief_episode_safety_issue_3471.py` over the uncertainty representation applied to the controlled corridor agent. Added tests that the default preserves the known #3471 fixture contrast, each representation runs and is reported, and unknown representations fail closed.

## Linked Issues

- Relates to #3557
- Follow-up to #3471

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_run_scenario_belief_episode_safety_issue_3471.py -q` -> passed, 13 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation -k "scenario_belief or uncertainty_source" -q` -> passed, 30 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/run_scenario_belief_episode_safety_issue_3471.py tests/validation/test_run_scenario_belief_episode_safety_issue_3471.py` -> passed.
- Representative CLI short runs wrote ignored local reports under `output/validation/issue_3557/` for `belief_drop`, `conformal_radius`, and `envelope_inflation`; each reported `followup_issue: 3557`, all three modes, and the harness-level claim boundary.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream Propagation

Parent issue updated: no. `comment_issue_or_pr` is not authorized for this run, and this PR body carries the durable handoff state for the delivered slice. No tracked state file was updated because this PR changes harness behavior only and does not encode transient queue-routing state.

Claim map / benchmark report updated: no, because this PR makes no benchmark or paper-facing claim.

Leaderboard / artifact catalog updated: no.

Registry or config index updated: no.

Context index / memory note updated: no.

Follow-up issue opened deferred propagation: no.

<details>
<summary>Research Template Appendix</summary>

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: unblocks issue #3557 representation-level episode harness execution.
- Comparator or baseline, applicable: default `belief_drop` #3471 controlled fixture.
- Evidence tier: diagnostic probe.
- Result classification: harness capability only; not a research result.
- Decision stop rule, applicable: preserve default #3471 behavior and fail closed for unknown representation keys.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3557; no claim map update.
- New research/benchmark/metric/paper-facing analysis tool, any: existing #3471 validation harness extended; representative use was short controlled fixture CLI runs.

## Domain-Aware Approval

- Required for this PR: yes - evidence-validity-sensitive diagnostic harness wording.
- Domains reviewed: ScenarioBelief episode harness, stream_gap uncertainty gate, diagnostic claim boundary.
- Status: waived.
- Approver/review source or waiver: maintainer issue scope requested harness-level results only; full representation sweep is explicitly out of scope.
- Validity checklist:
- Target claim/hypothesis: no target safety-effect claim promoted; this only parameterizes the harness for issue #3557.
- Comparator or split/evidence validity: default `belief_drop` remains the #3471 fixture comparator; new representations are short controlled harness smoke paths.
- Fallback/degraded exclusions: no fallback or degraded benchmark execution is counted as evidence; output is local diagnostic harness output only.
- Claim boundary: not a full benchmark, not paper-grade, no cross-representation generalization claim.
- Implementation integrity vs experimental validity: tests cover parameter routing and default compatibility; empirical validity remains future #3557 work.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, the runner applies each representation to the corridor agent and reports the selected representation.
- Did intervention change command source, selected command, trajectory, route progress? not claimed beyond controlled short CLI smoke output.
- Did scenario actually contain targeted failure mode? the existing #3471 controlled fixture is used.
- Result route: continue with empirical sweep outside this PR.
- Follow-up question issue weak, negative, non-transfer results: issue #3557 remains open for empirical generalization.

## Next Empirical Action

- Rerun needed: yes, a real representation sweep remains out of scope.
- Extractor analysis tool needed: no new extractor in this slice.
- Artifact missing unavailable: durable benchmark artifacts are not required for this harness change.
- Stop / revise / continue decision: continue to empirical sweep.
- Proposed child issue existing follow-up: #3557.

## Risks / Rollout

- Compatibility risks: low; default remains `belief_drop`.
- Failure modes: representation proxy semantics are controlled-harness proxies, not calibrated sensor models.
- Rollback fallback plan: revert this PR to restore single-representation harness.

## Reviewer Notes

- Review representation-to-gate mapping carefully: `belief_drop` -> existence probability, `conformal_radius` -> position confidence, `envelope_inflation` -> position variance.
- Generated `output/validation/issue_3557/*.json` files are ignored local validation artifacts, not durable benchmark evidence.

</details>
