### PR TITLE
docs(data): record SocNavBench ETH traversible generation for issue #1498

### DIFF
--- a/docs/context/issue_1498_state.yaml
+++ b/docs/context/issue_1498_state.yaml
@@ -1,0 +1,26 @@
+issue: 1498
+state_surface: socnavbench_s3dis_eth_external_data
+entries:
+  - recorded_at_utc: "2026-07-02T19:20:41Z"
+    status: staged_verified_ready_for_eth_first
+    generated_file:
+      path: "/home/luttkule/external_data/socnavbench/sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl"
+      size_bytes: 107227
+      sha256: "02d450ee57bdab7aa357457085b3ddac6501ea8ec99324f2f02aecaed82562a6"
+      derived_output_policy: forbidden_without_sign_off
+    source_inputs:
+      mesh_path: "/home/luttkule/external_data/socnavbench/sd3dis/stanford_building_parser_dataset/mesh/ETH"
+      upstream_code_commit: "2724ea85ff22ca61a88ee95285dfc3fa056656c6"
+    validation:
+      manage_external_data_check:
+        command: "ROBOT_SF_EXTERNAL_DATA_ROOT=/home/luttkule/external_data uv run python scripts/tools/manage_external_data.py --json check socnavbench-s3dis-eth"
+        status: available
+        ok: true
+      eth_first_preflight:
+        command: "uv run python scripts/tools/validate_socnav_map_batch.py --socnav-root /home/luttkule/external_data/socnavbench --batch-id eth_first --preflight --report-json /tmp/issue1498_pre_after.json"
+        status: ready
+        conversion_ready: true
+        missing_required: []
+    notes:
+      - "Generated locally from staged SocNavBench ETH mesh assets; no dataset bytes are tracked."
+      - "No full benchmark campaign, SLURM/GPU submission, or paper/dissertation claim update was run."


### PR DESCRIPTION
## Reviewer-critical summary
What changed: generated the SocNavBench/S3DIS ETH traversible cache file locally from the staged ETH mesh and recorded the durable state in `docs/context/issue_1498_state.yaml`.

Why now: issue #1498 was unblocked on 2026-07-02 by private asset staging; upstream does not provide ETH `traversibles/ETH/data.pkl`, so the remaining step was one local SocNavBench mesh-load cache generation.

Claim boundary: the local asset cache now has `/home/luttkule/external_data/socnavbench/sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl` with SHA-256 `02d450ee57bdab7aa357457085b3ddac6501ea8ec99324f2f02aecaed82562a6`, and the repo check/preflight see the asset as available/ready. No dataset bytes or derived pickle are committed or published.

Required validation: `manage_external_data.py check socnavbench-s3dis-eth` must report `status: available`, and `validate_socnav_map_batch.py --batch-id eth_first --preflight` must report `status: ready` with `conversion_ready: true`.

Remaining blocker: none for the ETH traversible source gate on this host. Downstream #1134 conversion/import work remains out of scope.

Closes #1498

## Contract delta
- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: none; this PR records external-data state only.
- State propagation: updated the single durable issue state surface `docs/context/issue_1498_state.yaml` instead of adding an issue comment because `comment_issue_or_pr` is not authorized.

## Validation
- `ROBOT_SF_EXTERNAL_DATA_ROOT=/home/luttkule/external_data uv run python scripts/tools/manage_external_data.py --json check socnavbench-s3dis-eth` -> exit 0; `status=available`, `ok=true`, `missing_required_paths=[]`.
- `uv run python scripts/tools/validate_socnav_map_batch.py --socnav-root /home/luttkule/external_data/socnavbench --batch-id eth_first --preflight --report-json /tmp/issue1498_pre_final.json` -> exit 0; `status=ready`, `conversion_ready=true`, `missing_required=[]`.
- `uv run python - <<'PY' ... yaml.safe_load('docs/context/issue_1498_state.yaml') ... PY` -> exit 0; YAML parses and records `staged_verified_ready_for_eth_first`.
- `sha256sum /home/luttkule/external_data/socnavbench/sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl` -> `02d450ee57bdab7aa357457085b3ddac6501ea8ec99324f2f02aecaed82562a6`.

## Out of scope
No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no dataset byte commit, and no publication of derived output.

<details>
<summary>Appendix: generation notes</summary>

- Generated on the authorized host from the staged private cache under `/home/luttkule/external_data/socnavbench`.
- Used upstream SocNavBench code at commit `2724ea85ff22ca61a88ee95285dfc3fa056656c6` with local compatibility shims for Python 3.12 (`configparser.SafeConfigParser`, `numpy.int`) and temporary `/tmp` native Assimp libraries.
- The generated pickle remains local/private under the external-data cache; the PR tracks only path, size, checksum, and validation state.
- Late issue check before PR open found no maintainer comments newer than start and no duplicate open PR.

</details>
