### PR TITLE
safety/scenarios: fail closed on invalid proximity-hold fields (#4177)

### DIFF
--- a/robot_sf/nav/map_config.py
+++ b/robot_sf/nav/map_config.py
@@ -301,6 +301,10 @@ class SinglePedestrianDefinition:
             self.hold_until_robot_within_m,
             "hold_until_robot_within_m",
         )
+        if self.hold_ref_point is None:
+            raise ValueError(
+                f"Pedestrian '{self.id}': hold_until_robot_within_m requires hold_ref_point"
+            )
         if self.trajectory is None:
             raise ValueError(
                 f"Pedestrian '{self.id}': hold_until_robot_within_m requires a trajectory so the "
@@ -316,7 +320,13 @@ class SinglePedestrianDefinition:
                 f"Pedestrian '{self.id}': hold_ref_point must be a 2-item tuple/list, "
                 f"got {self.hold_ref_point!r}"
             )
-        self.hold_ref_point = (float(self.hold_ref_point[0]), float(self.hold_ref_point[1]))
+        point = (float(self.hold_ref_point[0]), float(self.hold_ref_point[1]))
+        if not isfinite(point[0]) or not isfinite(point[1]):
+            raise ValueError(
+                f"Pedestrian '{self.id}': hold_ref_point coordinates must be finite, "
+                f"got {self.hold_ref_point!r}"
+            )
+        self.hold_ref_point = point
 
     def _normalize_hold_timeout(self) -> None:
         """Validate and normalize the optional proximity-hold fail-open timeout."""
@@ -338,6 +348,8 @@ class SinglePedestrianDefinition:
             raise ValueError(
                 f"Pedestrian '{self.id}': {field_name} must be a positive number, got: {value!r}"
             ) from None
+        if not isfinite(coerced):
+            raise ValueError(f"Pedestrian '{self.id}': {field_name} must be finite, got: {value!r}")
         if coerced <= 0:
             raise ValueError(f"Pedestrian '{self.id}': {field_name} must be > 0, got: {value!r}")
         return coerced

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -1721,7 +1721,24 @@ def _coerce_point(value: Any, label: str) -> tuple[float, float]:
     """
     if not isinstance(value, (list, tuple)) or len(value) != 2:
         raise ValueError(f"'{label}' must be a 2-item list or tuple, got: {value!r}")
-    return (float(value[0]), float(value[1]))
+    point = (float(value[0]), float(value[1]))
+    if not math.isfinite(point[0]) or not math.isfinite(point[1]):
+        raise ValueError(f"'{label}' coordinates must be finite, got: {value!r}")
+    return point
+
+
+def _coerce_positive_finite_float(value: object, label: str) -> float:
+    """Coerce a scenario scalar that must be finite and strictly positive.
+
+    Returns:
+        float: Validated scenario scalar.
+    """
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"'{label}' must be finite, got: {value!r}")
+    if parsed <= 0.0:
+        raise ValueError(f"'{label}' must be > 0, got: {value!r}")
+    return parsed
 
 
 def _parse_wait_overrides(
@@ -1949,7 +1966,11 @@ def _resolve_hold_overrides(
     """
     if "hold_until_robot_within_m" in entry:
         value = entry.get("hold_until_robot_within_m")
-        hold_within = float(value) if value is not None else None
+        hold_within = (
+            _coerce_positive_finite_float(value, "hold_until_robot_within_m")
+            if value is not None
+            else None
+        )
     else:
         hold_within = ped.hold_until_robot_within_m
 
@@ -1963,12 +1984,21 @@ def _resolve_hold_overrides(
 
     if "hold_timeout_s" in entry:
         timeout_value = entry.get("hold_timeout_s")
-        hold_timeout_s = float(timeout_value) if timeout_value is not None else None
+        hold_timeout_s = (
+            _coerce_positive_finite_float(timeout_value, "hold_timeout_s")
+            if timeout_value is not None
+            else None
+        )
     else:
         hold_timeout_s = ped.hold_timeout_s
 
     if hold_within is not None and hold_ref_point is None and default_hold_ref_point is not None:
         hold_ref_point = default_hold_ref_point
+    if hold_within is not None and hold_ref_point is None:
+        raise ValueError(
+            f"Pedestrian '{ped.id}': hold_until_robot_within_m requires hold_ref_point "
+            "or scenario public_requirement.event_contract.conflict_point"
+        )
 
     return hold_within, hold_ref_point, hold_timeout_s
 

--- a/tests/benchmark/test_issue_3977_safe_braking_scenario.py
+++ b/tests/benchmark/test_issue_3977_safe_braking_scenario.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 
 import numpy as np
 import pytest
 
 from robot_sf.gym_env.robot_env import RobotEnv
+from robot_sf.nav.map_config import SinglePedestrianDefinition
 from robot_sf.ped_npc.ped_behavior import SinglePedestrianBehavior
 from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
 
@@ -26,6 +28,122 @@ def _single_pedestrian(config):
     map_def = next(iter(config.map_pool.map_defs.values()))
     assert len(map_def.single_pedestrians) == 1
     return map_def.single_pedestrians[0]
+
+
+def _safe_braking_pedestrian_entry(scenario: dict) -> dict:
+    pedestrians = scenario["single_pedestrians"]
+    assert len(pedestrians) == 1
+    return pedestrians[0]
+
+
+def test_safe_braking_proximity_hold_accepts_explicit_ref_point() -> None:
+    """Scenario load preserves explicit hold_ref_point without event metadata."""
+    scenario = deepcopy(_load_safe_braking_scenario())
+    scenario["metadata"].pop("public_requirement")
+
+    config = build_robot_config_from_scenario(scenario, scenario_path=SINGLE_SCENARIO)
+    ped = _single_pedestrian(config)
+
+    assert ped.hold_until_robot_within_m == pytest.approx(5.5)
+    assert ped.hold_ref_point == (14.0, 14.0)
+    assert ped.hold_timeout_s == pytest.approx(6.0)
+
+
+def test_safe_braking_proximity_hold_defaults_ref_point_from_conflict_point() -> None:
+    """Scenario load defaults hold_ref_point from event-contract conflict_point."""
+    scenario = deepcopy(_load_safe_braking_scenario())
+    _safe_braking_pedestrian_entry(scenario).pop("hold_ref_point")
+
+    config = build_robot_config_from_scenario(scenario, scenario_path=SINGLE_SCENARIO)
+    ped = _single_pedestrian(config)
+
+    assert ped.hold_ref_point == (14.0, 14.0)
+
+
+def test_safe_braking_proximity_hold_rejects_missing_ref_point() -> None:
+    """A configured hold radius without any usable reference point fails closed."""
+    scenario = deepcopy(_load_safe_braking_scenario())
+    _safe_braking_pedestrian_entry(scenario).pop("hold_ref_point")
+    scenario["metadata"]["public_requirement"]["event_contract"].pop("conflict_point")
+
+    with pytest.raises(ValueError, match="hold_until_robot_within_m requires hold_ref_point"):
+        build_robot_config_from_scenario(scenario, scenario_path=SINGLE_SCENARIO)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("hold_until_robot_within_m", float("nan")),
+        ("hold_until_robot_within_m", float("inf")),
+        ("hold_until_robot_within_m", float("-inf")),
+        ("hold_timeout_s", float("nan")),
+        ("hold_timeout_s", float("inf")),
+        ("hold_timeout_s", float("-inf")),
+        ("hold_ref_point", [float("nan"), 14.0]),
+        ("hold_ref_point", [14.0, float("inf")]),
+    ],
+)
+def test_safe_braking_proximity_hold_rejects_nan_and_inf(field: str, value: object) -> None:
+    """Scenario load rejects non-finite proximity-hold fields."""
+    scenario = deepcopy(_load_safe_braking_scenario())
+    _safe_braking_pedestrian_entry(scenario)[field] = value
+
+    with pytest.raises(ValueError, match="finite"):
+        build_robot_config_from_scenario(scenario, scenario_path=SINGLE_SCENARIO)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("hold_until_robot_within_m", -1.0),
+        ("hold_timeout_s", -1.0),
+    ],
+)
+def test_safe_braking_proximity_hold_rejects_negative_values(field: str, value: float) -> None:
+    """Scenario load rejects negative hold radius and timeout values."""
+    scenario = deepcopy(_load_safe_braking_scenario())
+    _safe_braking_pedestrian_entry(scenario)[field] = value
+
+    with pytest.raises(ValueError, match="must be > 0"):
+        build_robot_config_from_scenario(scenario, scenario_path=SINGLE_SCENARIO)
+
+
+def test_proximity_hold_definition_rejects_missing_ref_point() -> None:
+    """Direct pedestrian definitions also reject hold radius without ref point."""
+    with pytest.raises(ValueError, match="requires hold_ref_point"):
+        SinglePedestrianDefinition(
+            id="crosser",
+            start=(0.0, 0.0),
+            trajectory=[(1.0, 0.0), (2.0, 0.0)],
+            hold_until_robot_within_m=5.5,
+        )
+
+
+@pytest.mark.parametrize("hold_ref_point", [(float("nan"), 0.0), (2.0, float("inf"))])
+def test_proximity_hold_definition_rejects_non_finite_ref_point(hold_ref_point) -> None:
+    """Direct pedestrian definitions reject non-finite hold_ref_point coordinates."""
+    with pytest.raises(ValueError, match="coordinates must be finite"):
+        SinglePedestrianDefinition(
+            id="crosser",
+            start=(0.0, 0.0),
+            trajectory=[(1.0, 0.0), (2.0, 0.0)],
+            hold_until_robot_within_m=5.5,
+            hold_ref_point=hold_ref_point,
+        )
+
+
+@pytest.mark.parametrize("hold_timeout_s", [float("nan"), float("inf")])
+def test_proximity_hold_definition_rejects_non_finite_timeout(hold_timeout_s: float) -> None:
+    """Direct pedestrian definitions reject non-finite hold_timeout_s values."""
+    with pytest.raises(ValueError, match="hold_timeout_s must be finite"):
+        SinglePedestrianDefinition(
+            id="crosser",
+            start=(0.0, 0.0),
+            trajectory=[(1.0, 0.0), (2.0, 0.0)],
+            hold_until_robot_within_m=5.5,
+            hold_ref_point=(2.0, 0.0),
+            hold_timeout_s=hold_timeout_s,
+        )
 
 
 def test_safe_braking_scenario_manifest_loads_with_public_requirement_contract() -> None:

--- a/tests/test_single_pedestrian_behavior.py
+++ b/tests/test_single_pedestrian_behavior.py
@@ -261,6 +261,17 @@ def test_hold_ref_point_requires_hold_radius():
         )
 
 
+def test_hold_radius_requires_hold_ref_point():
+    """hold_until_robot_within_m without a hold_ref_point is rejected."""
+    with pytest.raises(ValueError, match="requires hold_ref_point"):
+        SinglePedestrianDefinition(
+            id="crosser",
+            start=(0.0, 0.0),
+            trajectory=[(1.0, 0.0), (2.0, 0.0)],
+            hold_until_robot_within_m=5.5,
+        )
+
+
 def test_hold_radius_must_be_positive():
     """A non-positive hold radius is rejected."""
     with pytest.raises(ValueError, match="hold_until_robot_within_m must be > 0"):
@@ -270,4 +281,40 @@ def test_hold_radius_must_be_positive():
             trajectory=[(1.0, 0.0), (2.0, 0.0)],
             hold_until_robot_within_m=0.0,
             hold_ref_point=(2.0, 0.0),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("hold_until_robot_within_m", float("nan")),
+        ("hold_until_robot_within_m", float("inf")),
+        ("hold_timeout_s", float("-inf")),
+    ],
+)
+def test_proximity_hold_scalars_must_be_finite(field: str, value: float):
+    """Proximity-hold radius and timeout reject non-finite values."""
+    kwargs = {
+        "id": "crosser",
+        "start": (0.0, 0.0),
+        "trajectory": [(1.0, 0.0), (2.0, 0.0)],
+        "hold_until_robot_within_m": 5.5,
+        "hold_ref_point": (2.0, 0.0),
+    }
+    kwargs[field] = value
+
+    with pytest.raises(ValueError, match="must be finite"):
+        SinglePedestrianDefinition(**kwargs)
+
+
+@pytest.mark.parametrize("hold_ref_point", [(float("nan"), 0.0), (2.0, float("inf"))])
+def test_hold_ref_point_coordinates_must_be_finite(hold_ref_point):
+    """Proximity-hold reference point rejects non-finite coordinates."""
+    with pytest.raises(ValueError, match="coordinates must be finite"):
+        SinglePedestrianDefinition(
+            id="crosser",
+            start=(0.0, 0.0),
+            trajectory=[(1.0, 0.0), (2.0, 0.0)],
+            hold_until_robot_within_m=5.5,
+            hold_ref_point=hold_ref_point,
         )


### PR DESCRIPTION
## Reviewer-critical summary

What changed: proximity-hold scenario loading now rejects non-finite coordinates/scalars, rejects non-positive hold radius/timeout values consistently with the existing dataclass contract, and fails closed when a configured hold radius has neither explicit `hold_ref_point` nor event-contract `conflict_point`.

Why now: issue #4177 is the safety-validation follow-up to #4149; it hardens invalid scenario fields without changing valid safe-braking runtime behavior.

Claim boundary: validation hardening only. This PR makes no new scenario-performance, benchmark-strength, paper, or dissertation safety claim.

Required validation: focused unit tests for the scenario load paths and existing runtime release guards; no full benchmark campaign required.

Remaining blocker: none for this scoped validation slice. Claude Code on `imech156-u` owns the full PR gate, improvement cycle, and merge authority after PR open.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: `hold_until_robot_within_m`, `hold_timeout_s`, and `hold_ref_point` components must be finite; hold radius and timeout must be `> 0` (preserves existing `SinglePedestrianDefinition` zero-value rejection); a hold radius requires an explicit `hold_ref_point` or scenario event-contract `conflict_point`.
- Compatibility impact: valid #3977/#4149 safe-braking configs continue to load and the existing robot-proximity and timeout release tests pass. Invalid authored configs now raise `ValueError` at config/scenario load time instead of silently degrading.

## Summary

Fail closed on invalid proximity-hold fields for issue #4177 while preserving valid safe-braking behavior.

## Linked Issues

- Closes #4177
- Issue link: https://github.com/ll7/robot_sf_ll7/issues/4177

## Stack / Dependency

- Base dependency: origin/main after #4149 foundations were merged
- Required prior PRs: #4149
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: scoped validation-hardening follow-up only

## What Changed

- Added finite coordinate validation to scenario-loader `_coerce_point(...)` for `hold_ref_point` and other scenario point overrides using that helper.
- Added proximity-hold scalar parsing that rejects NaN/Inf and non-positive radius/timeout values before constructing pedestrian overrides.
- Added a scenario-loader `ValueError` when `hold_until_robot_within_m` is configured without explicit `hold_ref_point` or default event-contract `conflict_point`.
- Added `SinglePedestrianDefinition` backstops for finite `hold_ref_point`, finite hold scalars, and missing reference points.
- Added regression tests for explicit reference point, default-from-conflict-point, missing-reference failure, NaN/Inf failure, negative-value failure, and existing valid runtime release behavior.

## Why Matters

- Added value: invalid safety-scenario hold fields fail closed at load time.
- Expected impact: authors get immediate `ValueError` for malformed proximity-hold configs; valid configs retain existing runtime behavior.
- Why worth merging now: ready-queue #4177 is a low-effort high-safety follow-up to the newly merged proximity-hold scenario behavior.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #4177 validation blocker for malformed proximity-hold fields.
- Comparator or baseline, applicable: pre-change loader accepted NaN/Inf and missing-reference cases too late or silently.
- Evidence tier: NA - validation hardening only
- Result classification: NA - validation hardening only
- Decision stop rule, applicable: five requested validation cases covered and existing runtime release tests still pass.
- Parent issue, claim map, registry, context note, synthesis surface update: #4177 only; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - validation hardening only.

## Domain-Aware Approval

- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: no benchmark or paper-facing claim changed.
- Validity checklist: targeted config-load validation only; fallback/degraded benchmark evidence not involved.
- Target claim/hypothesis: invalid proximity-hold fields fail closed.
- Comparator split/evidence validity: focused tests mutate the #3977 safe-braking scenario and direct dataclass construction path.
- Fallback/degraded exclusions: no benchmark rows; runtime fail-open off-trajectory behavior intentionally unchanged.
- Claim boundary: validation hardening only.
- Implementation integrity vs experimental validity: implementation checked by focused tests, not by benchmark interpretation.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? no valid-runtime semantic changes intended.
- Did scenario actually contain targeted failure mode? yes, tests inject the invalid field classes into the safe-braking scenario copy.
- Result route: stop
- Follow-up question issue weak, negative, non-transfer results: none

## Next Empirical Action

- Rerun needed: no for this scoped slice
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: stop; hand off to full PR gate owner
- Proposed child issue existing follow-up: none

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/scenario_loader.py robot_sf/nav/map_config.py tests/benchmark/test_issue_3977_safe_braking_scenario.py tests/test_single_pedestrian_behavior.py` -> pass
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3977_safe_braking_scenario.py tests/test_single_pedestrian_behavior.py -q` -> pass, 42 tests
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark -k "safe_braking or public_requirement" -q` -> pass, 19 tests
- `PR_READY_PR_BODY_FILE=<this body> PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> pass before PR open

## Risks / Rollout

- Compatibility risks: authored configs that previously used NaN/Inf, non-positive radius/timeout, or missing reference points now fail at load time.
- Failure modes: direct construction without a hold reference now raises earlier when a hold radius is configured.
- Rollback fallback plan: revert this validation-only commit if an intentionally invalid fixture is discovered; valid safe-braking behavior is covered by tests.

## Docs / Provenance

- Updated docs: none
- Relevant design provenance notes: issue #4177 owner comment, 2026-07-02 17:47 UTC
- Any assumptions need to preserved: `0.0` remains rejected for radius/timeout to preserve existing `SinglePedestrianDefinition` semantics; finite ref point not on trajectory remains runtime fail-open and is not hardened here.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: no benchmark, registry, claim-map, paper-facing, or durable artifact state changed. No issue comment was posted because this run has `comment_issue_or_pr: false`; the PR body is the handoff surface.

## Follow-Up Issues

- Deferred work: none
- Issues opened follow-up: none

<details>
<summary>Governance appendix</summary>

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No transient queue-routing state encoded in tracked files.
- Fragmentation guard: duplicate PR searches for #4177/proximity-hold terms found no open or merged #4177 PRs; this PR adds the nameable capability “invalid proximity-hold config fail-closed validation.”

</details>

## Reviewer Notes

- Review closely that `_coerce_point(...)` is shared by other scenario point overrides; this intentionally enforces finite coordinates rather than allowing NaN/Inf points.
- Known limitations: no full benchmark campaign; validation is scoped to load-time hardening and existing runtime regression tests.
