### PR TITLE
Fix issue #4178 docs-proof diff scoping for code PRs

### DIFF
--- a/scripts/dev/check_docs_proof_consistency_diff.sh
+++ b/scripts/dev/check_docs_proof_consistency_diff.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Diff-scoped PR handoff check:
+# - docs/context-only diffs include README, INDEX, and catalog paths explicitly,
+#   preserving strict docs proof and context-catalog diagnostics.
+# - non-docs or mixed code diffs run changed-file proof only, so unrelated
+#   historical docs/context/catalog.yaml debt does not block code-only readiness.
+# - full evidence catalog hygiene remains explicit via
+#   scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog.
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./common_setup.sh
 source "$SCRIPT_DIR/common_setup.sh"

--- a/scripts/validation/check_docs_proof_consistency.py
+++ b/scripts/validation/check_docs_proof_consistency.py
@@ -9,9 +9,16 @@ Modes
 -----
 Default (no flags):
   Checks files in the branch diff / worktree edits against ``origin/main``.
+  Context-catalog schema/provenance diagnostics run only when
+  ``docs/context/catalog.yaml`` is selected by the diff or explicit paths, so
+  code-only diffs do not fail on pre-existing catalog debt.
 
 ``--path <repo-rel-path>``:
   Checks only the explicitly named file(s).
+
+``--check-context-catalog``:
+  Forces strict ``docs/context/catalog.yaml`` diagnostics in addition to the
+  selected changed-file checks.
 
 ``--check-evidence-catalog``:
   Full evidence/catalog check — scans every tracked file under
@@ -727,10 +734,16 @@ def _file_diagnostics(path: Path, text: str) -> list[Diagnostic]:
     return diagnostics
 
 
+def _should_check_context_catalog(changed_files: Sequence[ChangedFile]) -> bool:
+    """Return whether selected files require strict context catalog diagnostics."""
+    return any(changed.path == _CONTEXT_CATALOG for changed in changed_files)
+
+
 def _collect_diagnostics(
     changed_files: Iterable[ChangedFile],
     *,
     repo_root: Path,
+    force_context_catalog: bool = False,
 ) -> list[Diagnostic]:
     """Collect all docs/proof consistency diagnostics for the selected file set."""
     diagnostics: list[Diagnostic] = []
@@ -751,7 +764,8 @@ def _collect_diagnostics(
                 context_index_text=_read_text(context_index),
             )
         )
-    diagnostics.extend(_context_catalog_diagnostics(_CONTEXT_CATALOG, repo_root=repo_root))
+    if force_context_catalog or _should_check_context_catalog(changed_list):
+        diagnostics.extend(_context_catalog_diagnostics(_CONTEXT_CATALOG, repo_root=repo_root))
 
     for changed in changed_list:
         full_path = repo_root / changed.path
@@ -788,6 +802,15 @@ def _parse_args() -> argparse.Namespace:
             "Run a full evidence/catalog coverage check: scan all tracked files under"
             f" {_EVIDENCE_DIR.as_posix()} and report evidence bundles with no entry in"
             f" {_CONTEXT_CATALOG.as_posix()}. Does not use the git diff."
+        ),
+    )
+    parser.add_argument(
+        "--check-context-catalog",
+        action="store_true",
+        dest="check_context_catalog",
+        help=(
+            f"Force strict {_CONTEXT_CATALOG.as_posix()} schema/provenance diagnostics "
+            "even when the selected diff does not include that file."
         ),
     )
     return parser.parse_args()
@@ -833,7 +856,11 @@ def main() -> int:
     except ValueError as exc:
         print(f"ERROR {exc}", file=sys.stderr)
         return 2
-    diagnostics = _collect_diagnostics(changed_files, repo_root=repo_root)
+    diagnostics = _collect_diagnostics(
+        changed_files,
+        repo_root=repo_root,
+        force_context_catalog=args.check_context_catalog,
+    )
 
     if args.json:
         payload = [

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -17,6 +17,7 @@ from scripts.validation.check_docs_proof_consistency import (
     _evidence_catalog_coverage_diagnostics,
     _parse_name_status,
     _selected_files,
+    _should_check_context_catalog,
 )
 
 
@@ -404,6 +405,73 @@ def test_explicit_path_outside_repo_is_rejected(tmp_path: Path) -> None:
             argparse.Namespace(path=[str(outside_path)], base="HEAD"),
             repo_root=repo_root,
         )
+
+
+def _write_catalog_with_output_pointer(repo_root: Path) -> None:
+    """Create catalog debt that should only fail strict catalog modes."""
+    (repo_root / "robot_sf").mkdir()
+    (repo_root / "robot_sf/example.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (repo_root / "docs/context/evidence").mkdir(parents=True)
+    evidence = repo_root / "docs/context/evidence/report.md"
+    evidence.write_text("[artifact](output/reports/run.json)\n", encoding="utf-8")
+    catalog = repo_root / "docs/context/catalog.yaml"
+    catalog.write_text(
+        """
+version: 1
+entries:
+  - path: docs/context/evidence/report.md
+    status: evidence
+    freshness: evidence
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_code_only_diff_skips_context_catalog_debt(tmp_path: Path) -> None:
+    """Code-only selected files should not surface unrelated catalog debt."""
+    repo_root = tmp_path
+    _write_catalog_with_output_pointer(repo_root)
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("robot_sf/example.py"))],
+        repo_root=repo_root,
+    )
+
+    assert diagnostics == []
+    assert not _should_check_context_catalog(
+        [ChangedFile(status="M", path=Path("robot_sf/example.py"))]
+    )
+
+
+def test_selected_context_catalog_keeps_strict_catalog_diagnostics(tmp_path: Path) -> None:
+    """Selecting the context catalog keeps strict catalog provenance checks."""
+    repo_root = tmp_path
+    _write_catalog_with_output_pointer(repo_root)
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("docs/context/catalog.yaml"))],
+        repo_root=repo_root,
+    )
+
+    assert _should_check_context_catalog(
+        [ChangedFile(status="M", path=Path("docs/context/catalog.yaml"))]
+    )
+    assert any("ignored output/ artifacts" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_force_context_catalog_keeps_strict_catalog_diagnostics(tmp_path: Path) -> None:
+    """Explicit full context-catalog mode checks catalog debt even for code diffs."""
+    repo_root = tmp_path
+    _write_catalog_with_output_pointer(repo_root)
+
+    diagnostics = _collect_diagnostics(
+        [ChangedFile(status="M", path=Path("robot_sf/example.py"))],
+        repo_root=repo_root,
+        force_context_catalog=True,
+    )
+
+    assert any("ignored output/ artifacts" in diagnostic.message for diagnostic in diagnostics)
 
 
 def test_context_catalog_reports_missing_status_and_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `check_docs_proof_consistency.py` now keeps its default mode diff-scoped for context-catalog diagnostics. `docs/context/catalog.yaml` schema/provenance checks run only when that file is selected by the diff/explicit paths, or when the new `--check-context-catalog` flag is used. The shell wrapper header now documents the split, and regression tests cover code-only diffs plus strict catalog modes.

Why now: issue #4178 reports that code-only PR readiness can fail on pre-existing `docs/context/catalog.yaml` debt. I reproduced that before the fix with `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` and direct JSON checker output; both failed on existing catalog rows that point at ignored `output/` artifacts.

Claim boundary: this PR separates baseline catalog debt from code-only diff readiness. It does not repair existing catalog rows and does not weaken strict catalog/evidence checks when catalog proof is selected explicitly.

Required validation: focused checker tests, the diff wrapper, direct JSON default mode, explicit strict catalog mode, full evidence-catalog mode, and final PR readiness.

Remaining blocker: existing `docs/context/catalog.yaml` rows still fail strict context-catalog diagnostics when `docs/context/catalog.yaml` is selected or `--check-context-catalog` is passed; tracked by the still-open archival/catalog debt lane #3190.

## Contract delta

New CLI field:

- `scripts/validation/check_docs_proof_consistency.py --check-context-catalog` forces strict `docs/context/catalog.yaml` schema/provenance diagnostics even when the selected diff does not include the catalog.

New fail-closed behavior preserved:

- `--check-context-catalog` fails on current catalog output-artifact debt.
- Selecting `docs/context/catalog.yaml` via `--path` or docs-context-only wrapper paths still fails on that same debt.
- `--check-evidence-catalog` remains independent of git diff and still scans tracked evidence bundles for catalog coverage.

Compatibility impact:

- Default checker and wrapper behavior no longer fail code-only or mixed code diffs on unrelated historical catalog debt.
- No catalog rows, evidence files, benchmark outputs, schema data, model provenance, or paper/dissertation claims changed.

Issue: #4178.

## Validation

- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` before fix: exit 1; failed on four existing `docs/context/catalog.yaml` output-artifact diagnostics.
- `uv run --active python scripts/validation/check_docs_proof_consistency.py --base origin/main --json` before fix: exit 1; same four existing catalog diagnostics.
- `uv run --active pytest tests/validation/test_check_docs_proof_consistency.py -q`: pass, 37 passed.
- `uv run --active ruff check scripts/validation/check_docs_proof_consistency.py tests/validation/test_check_docs_proof_consistency.py`: pass.
- `bash -n scripts/dev/check_docs_proof_consistency_diff.sh && python -m py_compile scripts/validation/check_docs_proof_consistency.py`: pass.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`: pass, `OK docs/proof consistency check passed for 3 changed file(s).`
- `uv run --active python scripts/validation/check_docs_proof_consistency.py --base origin/main --json`: pass, `[]`.
- `uv run --active python scripts/validation/check_docs_proof_consistency.py --base origin/main --check-context-catalog --json`: expected strict failure, four existing catalog output-artifact diagnostics.
- `uv run --active python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog --json`: pass, `[]`.
- `uv run --active pytest tests/validation -k "docs_proof or proof_consistency or catalog" -q`: pass, 44 passed.
- `uv run --active ruff check scripts/validation/check_docs_proof_consistency.py tests/validation -q`: pass.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`: pass, 1752 passed, 2 skipped; dirty-tree interim stamp before commit.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, and no repair of unrelated existing catalog debt.

<details>
<summary>Governance and propagation notes</summary>

Issue: https://github.com/ll7/robot_sf_ll7/issues/4178

New capability for the fragmentation guard: diff-scoped default context-catalog checking with an explicit strict `--check-context-catalog` mode.

State propagation: no separate issue comment is posted from this PR because this run is not authorized to comment on issues or PRs. The PR body is the single remote-visible status surface for the delivered slice and remaining blocker.

Artifact classification: only ignored validation artifacts under `output/validation/` and coverage output were generated locally. They are not committed and are not durable evidence dependencies.

Existing catalog rows changed: none.

</details>

