### PR TITLE
Issue #3950: add pedestrian-model sensitivity smoke

### DIFF
--- a/configs/benchmarks/issue_3950_ped_model_sensitivity_smoke.yaml
+++ b/configs/benchmarks/issue_3950_ped_model_sensitivity_smoke.yaml
@@ -1,0 +1,18 @@
+name: issue_3950_ped_model_sensitivity_smoke
+paper_facing: false
+scenario_matrix: configs/scenarios/single/planner_sanity_simple.yaml
+workers: 1
+horizon: 30
+dt: 0.1
+record_forces: false
+resume: false
+planner:
+  key: goal
+  algo: goal
+  benchmark_profile: baseline-safe
+development_models:
+  - social_force_default
+  - hsfm_total_force_v1
+evaluation_models:
+  - social_force_default
+  - hsfm_total_force_v1

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -17,6 +17,10 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+  - path: docs/context/evidence/issue_3950_pedestrian_model_sensitivity
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_4163_rare_event_smoke/summary.json
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_3950_pedestrian_model_sensitivity/README.md
+++ b/docs/context/evidence/issue_3950_pedestrian_model_sensitivity/README.md
@@ -1,0 +1,14 @@
+# Issue #3950 Pedestrian-Model Sensitivity Smoke
+
+This is a CPU-only diagnostic smoke report. It does not train a policy and does not make paper-facing claims.
+
+Claim boundary: CPU diagnostic sensitivity harness. No new training. Development-model axis is declared policy provenance unless backed by a training artifact.
+
+The development-model axis is declared policy provenance unless a training artifact explicitly supports it. The evaluation-model axis is the active `simulation_config.pedestrian_model` selector.
+
+| Development model | Evaluation model | Episodes | Success incidence | Collision incidence | Status |
+| --- | --- | ---: | ---: | ---: | --- |
+| social_force_default | social_force_default | 3 | 0.000000 | 0.000000 | ok |
+| social_force_default | hsfm_total_force_v1 | 3 | 0.000000 | 0.000000 | ok |
+| hsfm_total_force_v1 | social_force_default | 3 | 0.000000 | 0.000000 | ok |
+| hsfm_total_force_v1 | hsfm_total_force_v1 | 3 | 0.000000 | 0.000000 | ok |

--- a/docs/context/evidence/issue_3950_pedestrian_model_sensitivity/sensitivity_matrix.csv
+++ b/docs/context/evidence/issue_3950_pedestrian_model_sensitivity/sensitivity_matrix.csv
@@ -1,0 +1,5 @@
+development_model,evaluation_model,planner_key,algo,episodes,success_incidence,collision_incidence,fallback_degraded_rows,status
+social_force_default,social_force_default,goal,goal,3,0.0,0.0,0,ok
+social_force_default,hsfm_total_force_v1,goal,goal,3,0.0,0.0,0,ok
+hsfm_total_force_v1,social_force_default,goal,goal,3,0.0,0.0,0,ok
+hsfm_total_force_v1,hsfm_total_force_v1,goal,goal,3,0.0,0.0,0,ok

--- a/docs/context/evidence/issue_3950_pedestrian_model_sensitivity/summary.json
+++ b/docs/context/evidence/issue_3950_pedestrian_model_sensitivity/summary.json
@@ -1,0 +1,55 @@
+{
+  "cells": [
+    {
+      "algo": "goal",
+      "collision_incidence": 0.0,
+      "development_model": "social_force_default",
+      "episodes": 3,
+      "evaluation_model": "social_force_default",
+      "fallback_degraded_rows": 0,
+      "planner_key": "goal",
+      "status": "ok",
+      "success_incidence": 0.0
+    },
+    {
+      "algo": "goal",
+      "collision_incidence": 0.0,
+      "development_model": "social_force_default",
+      "episodes": 3,
+      "evaluation_model": "hsfm_total_force_v1",
+      "fallback_degraded_rows": 0,
+      "planner_key": "goal",
+      "status": "ok",
+      "success_incidence": 0.0
+    },
+    {
+      "algo": "goal",
+      "collision_incidence": 0.0,
+      "development_model": "hsfm_total_force_v1",
+      "episodes": 3,
+      "evaluation_model": "social_force_default",
+      "fallback_degraded_rows": 0,
+      "planner_key": "goal",
+      "status": "ok",
+      "success_incidence": 0.0
+    },
+    {
+      "algo": "goal",
+      "collision_incidence": 0.0,
+      "development_model": "hsfm_total_force_v1",
+      "episodes": 3,
+      "evaluation_model": "hsfm_total_force_v1",
+      "fallback_degraded_rows": 0,
+      "planner_key": "goal",
+      "status": "ok",
+      "success_incidence": 0.0
+    }
+  ],
+  "claim_boundary": "CPU diagnostic sensitivity harness. No new training. Development-model axis is declared policy provenance unless backed by a training artifact.",
+  "issue": 3950,
+  "models": [
+    "hsfm_total_force_v1",
+    "social_force_default"
+  ],
+  "schema_version": "ped_model_sensitivity.v1"
+}

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -102,6 +102,10 @@ from robot_sf.benchmark.observation_noise import (
 )
 from robot_sf.benchmark.obstacle_sampling import sample_obstacle_points
 from robot_sf.benchmark.path_utils import compute_shortest_path_length
+from robot_sf.benchmark.ped_model_sensitivity import (
+    attach_pedestrian_model_fields,
+    build_pedestrian_model_provenance,
+)
 from robot_sf.benchmark.pedestrian_control_trace import (
     attach_pedestrian_control_trace,
 )
@@ -1418,6 +1422,12 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
             "effective_view": view_integrity,
         },
     }
+    pedestrian_model_provenance = build_pedestrian_model_provenance(
+        sim_config=config.sim_config,
+        policy_cfg=policy_cfg,
+        algorithm_metadata=algo_meta,
+    )
+    attach_pedestrian_model_fields(record, pedestrian_model_provenance)
     record.update(static_deadlock_fields)
     if benchmark_track is not None:
         record["benchmark_track"] = benchmark_track

--- a/robot_sf/benchmark/ped_model_sensitivity.py
+++ b/robot_sf/benchmark/ped_model_sensitivity.py
@@ -1,0 +1,316 @@
+"""Pedestrian-model sensitivity provenance and CPU smoke report helpers."""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.utils import _config_hash
+from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_TOTAL_FORCE_V1,
+    SOCIAL_FORCE_DEFAULT,
+    normalize_pedestrian_model,
+)
+
+SCHEMA_VERSION = "ped_model_sensitivity.v1"
+PEDESTRIAN_MODEL_SCHEMA_VERSION = "pedestrian-model.v1"
+CLAIM_BOUNDARY = (
+    "CPU diagnostic sensitivity harness. No new training. Development-model axis is "
+    "declared policy provenance unless backed by a training artifact."
+)
+DEFAULT_MODELS = (SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1)
+
+CSV_COLUMNS = (
+    "development_model",
+    "evaluation_model",
+    "planner_key",
+    "algo",
+    "episodes",
+    "success_incidence",
+    "collision_incidence",
+    "fallback_degraded_rows",
+    "status",
+)
+
+
+def resolve_development_pedestrian_model(
+    policy_cfg: Mapping[str, Any] | None,
+    *,
+    algorithm_metadata: Mapping[str, Any] | None = None,
+) -> str:
+    """Return declared policy development pedestrian model or ``unknown``."""
+
+    for source in (policy_cfg, algorithm_metadata):
+        if not isinstance(source, Mapping):
+            continue
+        for key in (
+            "development_pedestrian_model",
+            "development_model",
+            "human_model_variant",
+        ):
+            value = source.get(key)
+            if value is not None and str(value).strip():
+                return str(value).strip()
+    return "unknown"
+
+
+def build_pedestrian_model_provenance(
+    *,
+    sim_config: Any,
+    policy_cfg: Mapping[str, Any] | None,
+    algorithm_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build additive pedestrian-model provenance for one benchmark episode row.
+
+    Returns:
+        Nested provenance payload suitable for the benchmark episode record.
+    """
+
+    evaluation_model = normalize_pedestrian_model(getattr(sim_config, "pedestrian_model", None))
+    development_model = resolve_development_pedestrian_model(
+        policy_cfg, algorithm_metadata=algorithm_metadata
+    )
+    selector_payload = {
+        "development_model": development_model,
+        "evaluation_model": evaluation_model,
+        "source": "simulation_config.pedestrian_model",
+    }
+    return {
+        "schema_version": PEDESTRIAN_MODEL_SCHEMA_VERSION,
+        **selector_payload,
+        "selector_config_hash": _config_hash(selector_payload),
+        "fallback_degraded_status": _fallback_degraded_status(algorithm_metadata),
+        "claim_boundary": "diagnostic_cpu_sensitivity_no_training",
+    }
+
+
+def attach_pedestrian_model_fields(record: dict[str, Any], provenance: Mapping[str, Any]) -> None:
+    """Attach nested and flattened pedestrian-model fields to an episode row."""
+
+    record["pedestrian_model"] = dict(provenance)
+    record["development_pedestrian_model"] = str(provenance["development_model"])
+    record["evaluation_pedestrian_model"] = str(provenance["evaluation_model"])
+
+
+def load_jsonl_records(path: str | Path) -> list[dict[str, Any]]:
+    """Read benchmark JSONL episode records from ``path``.
+
+    Returns:
+        Parsed episode records in file order.
+    """
+
+    records: list[dict[str, Any]] = []
+    with Path(path).open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            payload = json.loads(stripped)
+            if not isinstance(payload, dict):
+                raise ValueError(f"Expected JSON object record in {path}")
+            records.append(payload)
+    return records
+
+
+def build_sensitivity_summary(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    development_models: Sequence[str],
+    evaluation_models: Sequence[str],
+    planner_key: str,
+    algo: str,
+) -> dict[str, Any]:
+    """Aggregate episode rows into a deterministic development x evaluation matrix.
+
+    Returns:
+        Summary payload containing the issue metadata and one cell for each requested model pair.
+    """
+
+    normalized_development = [_normalize_matrix_model(model) for model in development_models]
+    normalized_evaluation = [_normalize_matrix_model(model) for model in evaluation_models]
+    record_list = [dict(record) for record in records]
+    cells: list[dict[str, Any]] = []
+    for development_model in normalized_development:
+        for evaluation_model in normalized_evaluation:
+            matching = [
+                record
+                for record in record_list
+                if str(record.get("development_pedestrian_model", "unknown")) == development_model
+                and str(record.get("evaluation_pedestrian_model", "unknown")) == evaluation_model
+            ]
+            cells.append(
+                _summarize_cell(
+                    matching,
+                    development_model=development_model,
+                    evaluation_model=evaluation_model,
+                    planner_key=planner_key,
+                    algo=algo,
+                )
+            )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 3950,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "models": sorted(set(normalized_development) | set(normalized_evaluation)),
+        "cells": cells,
+    }
+
+
+def write_sensitivity_report(summary: Mapping[str, Any], output_dir: str | Path) -> dict[str, str]:
+    """Write summary JSON, matrix CSV, and Markdown README for a sensitivity report.
+
+    Returns:
+        Mapping of artifact labels to written filesystem paths.
+    """
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = out_dir / "summary.json"
+    csv_path = out_dir / "sensitivity_matrix.csv"
+    readme_path = out_dir / "README.md"
+
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS, lineterminator="\n")
+        writer.writeheader()
+        for cell in summary.get("cells", []):
+            writer.writerow({column: cell.get(column) for column in CSV_COLUMNS})
+    readme_path.write_text(_render_readme(summary), encoding="utf-8")
+    return {
+        "summary_json": str(summary_path),
+        "sensitivity_matrix_csv": str(csv_path),
+        "readme": str(readme_path),
+    }
+
+
+def _normalize_matrix_model(model: str) -> str:
+    if str(model).strip() == "unknown":
+        return "unknown"
+    return normalize_pedestrian_model(str(model))
+
+
+def _summarize_cell(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    development_model: str,
+    evaluation_model: str,
+    planner_key: str,
+    algo: str,
+) -> dict[str, Any]:
+    episodes = len(records)
+    fallback_degraded_rows = sum(1 for record in records if _record_is_fallback_or_degraded(record))
+    if episodes == 0:
+        return {
+            "development_model": development_model,
+            "evaluation_model": evaluation_model,
+            "planner_key": planner_key,
+            "algo": algo,
+            "episodes": 0,
+            "success_incidence": None,
+            "collision_incidence": None,
+            "fallback_degraded_rows": 0,
+            "status": "unavailable",
+        }
+    successes = sum(1 for record in records if _record_success(record))
+    collisions = sum(1 for record in records if _record_collision(record))
+    return {
+        "development_model": development_model,
+        "evaluation_model": evaluation_model,
+        "planner_key": planner_key,
+        "algo": algo,
+        "episodes": episodes,
+        "success_incidence": successes / episodes,
+        "collision_incidence": collisions / episodes,
+        "fallback_degraded_rows": fallback_degraded_rows,
+        "status": "ok" if fallback_degraded_rows == 0 else "degraded",
+    }
+
+
+def _record_success(record: Mapping[str, Any]) -> bool:
+    outcome = record.get("outcome")
+    if isinstance(outcome, Mapping) and "success" in outcome:
+        return bool(outcome["success"])
+    metrics = record.get("metrics")
+    if isinstance(metrics, Mapping) and "success" in metrics:
+        return float(metrics["success"]) > 0.0
+    return str(record.get("status")) == "success"
+
+
+def _record_collision(record: Mapping[str, Any]) -> bool:
+    outcome = record.get("outcome")
+    if isinstance(outcome, Mapping) and "collision" in outcome:
+        return bool(outcome["collision"])
+    metrics = record.get("metrics")
+    if isinstance(metrics, Mapping) and "collisions" in metrics:
+        return float(metrics["collisions"]) > 0.0
+    return str(record.get("termination_reason")) == "collision"
+
+
+def _record_is_fallback_or_degraded(record: Mapping[str, Any]) -> bool:
+    pedestrian_model = record.get("pedestrian_model")
+    if isinstance(pedestrian_model, Mapping):
+        status = pedestrian_model.get("fallback_degraded_status")
+        if status not in {None, "native"}:
+            return True
+    return _fallback_degraded_status(record.get("algorithm_metadata")) != "native"
+
+
+def _fallback_degraded_status(metadata: Mapping[str, Any] | None) -> str:
+    if not isinstance(metadata, Mapping):
+        return "native"
+    candidates = [
+        metadata.get("status"),
+        metadata.get("execution_mode"),
+        metadata.get("availability_status"),
+    ]
+    runtime = metadata.get("planner_runtime")
+    if isinstance(runtime, Mapping):
+        candidates.extend(
+            [
+                runtime.get("status"),
+                runtime.get("execution_mode"),
+                runtime.get("availability_status"),
+            ]
+        )
+    for candidate in candidates:
+        if str(candidate).strip().lower() in {"fallback", "degraded", "not_available", "failed"}:
+            return str(candidate).strip().lower()
+    return "native"
+
+
+def _render_readme(summary: Mapping[str, Any]) -> str:
+    rows = [
+        "| Development model | Evaluation model | Episodes | Success incidence | "
+        "Collision incidence | Status |",
+        "| --- | --- | ---: | ---: | ---: | --- |",
+    ]
+    for cell in summary.get("cells", []):
+        rows.append(
+            "| {development_model} | {evaluation_model} | {episodes} | {success} | "
+            "{collision} | {status} |".format(
+                development_model=cell.get("development_model"),
+                evaluation_model=cell.get("evaluation_model"),
+                episodes=cell.get("episodes"),
+                success=_format_rate(cell.get("success_incidence")),
+                collision=_format_rate(cell.get("collision_incidence")),
+                status=cell.get("status"),
+            )
+        )
+    return (
+        "# Issue #3950 Pedestrian-Model Sensitivity Smoke\n\n"
+        "This is a CPU-only diagnostic smoke report. It does not train a policy and does not "
+        "make paper-facing claims.\n\n"
+        f"Claim boundary: {summary.get('claim_boundary', CLAIM_BOUNDARY)}\n\n"
+        "The development-model axis is declared policy provenance unless a training artifact "
+        "explicitly supports it. The evaluation-model axis is the active "
+        "`simulation_config.pedestrian_model` selector.\n\n" + "\n".join(rows) + "\n"
+    )
+
+
+def _format_rate(value: Any) -> str:
+    if value is None:
+        return "NA"
+    return f"{float(value):.6f}"

--- a/scripts/benchmark/run_ped_model_sensitivity_issue_3950.py
+++ b/scripts/benchmark/run_ped_model_sensitivity_issue_3950.py
@@ -1,0 +1,165 @@
+"""Run the issue #3950 CPU pedestrian-model sensitivity smoke harness."""
+
+from __future__ import annotations
+
+import argparse
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.map_runner import run_map_batch
+from robot_sf.benchmark.ped_model_sensitivity import (
+    DEFAULT_MODELS,
+    build_sensitivity_summary,
+    load_jsonl_records,
+    write_sensitivity_report,
+)
+from robot_sf.benchmark.runner import load_scenario_matrix
+from robot_sf.sim.pedestrian_model_variants import normalize_pedestrian_model
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True, help="Smoke harness YAML config.")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Report output directory.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run configured sensitivity cells and write compact report artifacts."""
+
+    args = parse_args(argv)
+    config = _load_config(args.config)
+    output_dir = _resolve_path(args.output_dir)
+    run_dir = _resolve_path(
+        config.get(
+            "run_artifact_dir",
+            "output/benchmarks/issue_3950_ped_model_sensitivity_runs",
+        )
+    )
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    development_models = _models_from_config(config, "development_models")
+    evaluation_models = _models_from_config(config, "evaluation_models")
+    planner = dict(config.get("planner") or {})
+    planner_key = str(planner.get("key", "goal"))
+    algo = str(planner.get("algo", "goal"))
+    scenario_matrix = _resolve_path(config["scenario_matrix"])
+    base_scenarios = _resolve_loaded_scenario_paths(
+        load_scenario_matrix(scenario_matrix),
+        base_dir=scenario_matrix.parent,
+    )
+
+    records: list[dict[str, Any]] = []
+    for development_model in development_models:
+        for evaluation_model in evaluation_models:
+            cell_scenarios = _scenario_set_for_evaluation_model(base_scenarios, evaluation_model)
+            algo_config_path = _write_cell_algo_config(
+                run_dir=run_dir,
+                development_model=development_model,
+                planner=planner,
+            )
+            result_path = run_dir / f"{development_model}__{evaluation_model}.jsonl"
+            run_map_batch(
+                cell_scenarios,
+                result_path,
+                "robot_sf/benchmark/schemas/episode.schema.v1.json",
+                horizon=int(config.get("horizon", 30)),
+                dt=float(config.get("dt", 0.1)),
+                record_forces=bool(config.get("record_forces", False)),
+                algo=algo,
+                algo_config_path=str(algo_config_path),
+                benchmark_profile=str(planner.get("benchmark_profile", "baseline-safe")),
+                workers=int(config.get("workers", 1)),
+                resume=bool(config.get("resume", False)),
+            )
+            records.extend(load_jsonl_records(result_path))
+
+    summary = build_sensitivity_summary(
+        records,
+        development_models=development_models,
+        evaluation_models=evaluation_models,
+        planner_key=planner_key,
+        algo=algo,
+    )
+    write_sensitivity_report(summary, output_dir)
+    return 0
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    config_path = _resolve_path(path)
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise TypeError(f"Expected mapping config in {config_path}")
+    if "scenario_matrix" not in payload:
+        raise ValueError("Pedestrian-model sensitivity config requires 'scenario_matrix'")
+    return payload
+
+
+def _resolve_path(path: str | Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return REPO_ROOT / candidate
+
+
+def _models_from_config(config: dict[str, Any], key: str) -> list[str]:
+    raw = config.get(key, list(DEFAULT_MODELS))
+    if not isinstance(raw, list) or not raw:
+        raise ValueError(f"{key} must be a non-empty list")
+    return [normalize_pedestrian_model(str(model)) for model in raw]
+
+
+def _scenario_set_for_evaluation_model(
+    base_scenarios: list[dict[str, Any]],
+    evaluation_model: str,
+) -> list[dict[str, Any]]:
+    scenarios = deepcopy(base_scenarios)
+    for scenario in scenarios:
+        sim_config = scenario.setdefault("simulation_config", {})
+        if not isinstance(sim_config, dict):
+            raise TypeError("scenario simulation_config must be a mapping when present")
+        sim_config["pedestrian_model"] = evaluation_model
+    return scenarios
+
+
+def _resolve_loaded_scenario_paths(
+    scenarios: list[dict[str, Any]],
+    *,
+    base_dir: Path,
+) -> list[dict[str, Any]]:
+    """Resolve scenario-local paths before passing mutated dicts to ``run_map_batch``."""
+
+    resolved = deepcopy(scenarios)
+    for scenario in resolved:
+        raw_map_file = scenario.get("map_file")
+        if isinstance(raw_map_file, str) and raw_map_file.strip():
+            map_path = Path(raw_map_file)
+            if not map_path.is_absolute():
+                candidate = (base_dir / map_path).resolve()
+                if candidate.exists():
+                    scenario["map_file"] = str(candidate)
+    return resolved
+
+
+def _write_cell_algo_config(
+    *,
+    run_dir: Path,
+    development_model: str,
+    planner: dict[str, Any],
+) -> Path:
+    payload = dict(planner.get("algo_config") or {})
+    payload["development_pedestrian_model"] = development_model
+    path = run_dir / f"algo_{development_model}.yaml"
+    path.write_text(yaml.safe_dump(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_ped_model_sensitivity.py
+++ b/tests/benchmark/test_ped_model_sensitivity.py
@@ -1,0 +1,207 @@
+"""Tests for issue #3950 pedestrian-model sensitivity reporting."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from robot_sf.benchmark.ped_model_sensitivity import (
+    build_pedestrian_model_provenance,
+    build_sensitivity_summary,
+    load_jsonl_records,
+    resolve_development_pedestrian_model,
+    write_sensitivity_report,
+)
+from robot_sf.sim.pedestrian_model_variants import HSFM_TOTAL_FORCE_V1, SOCIAL_FORCE_DEFAULT
+
+
+def test_episode_provenance_records_development_and_evaluation_models() -> None:
+    """Episode provenance separates declared development and active evaluation model."""
+
+    provenance = build_pedestrian_model_provenance(
+        sim_config=SimpleNamespace(pedestrian_model=HSFM_TOTAL_FORCE_V1),
+        policy_cfg={"development_pedestrian_model": SOCIAL_FORCE_DEFAULT},
+        algorithm_metadata={},
+    )
+
+    assert provenance["development_model"] == SOCIAL_FORCE_DEFAULT
+    assert provenance["evaluation_model"] == HSFM_TOTAL_FORCE_V1
+    assert provenance["source"] == "simulation_config.pedestrian_model"
+    assert provenance["claim_boundary"] == "diagnostic_cpu_sensitivity_no_training"
+    assert provenance["fallback_degraded_status"] == "native"
+    assert isinstance(provenance["selector_config_hash"], str)
+
+
+def test_episode_provenance_uses_unknown_for_missing_development_model() -> None:
+    """Existing policies must not be assigned guessed training pedestrian provenance."""
+
+    provenance = build_pedestrian_model_provenance(
+        sim_config=SimpleNamespace(pedestrian_model=SOCIAL_FORCE_DEFAULT),
+        policy_cfg={},
+        algorithm_metadata={},
+    )
+
+    assert provenance["development_model"] == "unknown"
+    assert provenance["evaluation_model"] == SOCIAL_FORCE_DEFAULT
+
+
+def test_development_model_resolver_uses_algorithm_metadata_fallback() -> None:
+    """Human-model metadata can declare provenance when policy config omits it."""
+
+    assert (
+        resolve_development_pedestrian_model(
+            None,
+            algorithm_metadata={"human_model_variant": "upstream_hsfm"},
+        )
+        == "upstream_hsfm"
+    )
+
+
+def test_load_jsonl_records_reads_objects_and_rejects_non_objects(tmp_path: Path) -> None:
+    """JSONL loader keeps blank lines harmless and fails closed on malformed rows."""
+
+    records_path = tmp_path / "records.jsonl"
+    records_path.write_text('{"a": 1}\n\n{"b": 2}\n', encoding="utf-8")
+    assert load_jsonl_records(records_path) == [{"a": 1}, {"b": 2}]
+
+    bad_path = tmp_path / "bad.jsonl"
+    bad_path.write_text("[1, 2]\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Expected JSON object"):
+        load_jsonl_records(bad_path)
+
+
+def test_sensitivity_summary_emits_four_cells_and_unavailable_missing_rows() -> None:
+    """2x2 matrix keeps missing cells explicit instead of silently dropping them."""
+
+    records = [
+        _record(SOCIAL_FORCE_DEFAULT, SOCIAL_FORCE_DEFAULT, success=True, collision=False),
+        _record(SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1, success=False, collision=True),
+        _record(HSFM_TOTAL_FORCE_V1, SOCIAL_FORCE_DEFAULT, success=True, collision=False),
+    ]
+
+    summary = build_sensitivity_summary(
+        records,
+        development_models=[SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1],
+        evaluation_models=[SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1],
+        planner_key="goal",
+        algo="goal",
+    )
+
+    assert summary["schema_version"] == "ped_model_sensitivity.v1"
+    assert len(summary["cells"]) == 4
+    by_key = {
+        (cell["development_model"], cell["evaluation_model"]): cell for cell in summary["cells"]
+    }
+    assert by_key[(SOCIAL_FORCE_DEFAULT, SOCIAL_FORCE_DEFAULT)]["success_incidence"] == 1.0
+    assert by_key[(SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1)]["collision_incidence"] == 1.0
+    assert by_key[(HSFM_TOTAL_FORCE_V1, HSFM_TOTAL_FORCE_V1)]["status"] == "unavailable"
+    assert by_key[(HSFM_TOTAL_FORCE_V1, HSFM_TOTAL_FORCE_V1)]["episodes"] == 0
+
+
+def test_sensitivity_summary_handles_unknown_and_metric_only_rows() -> None:
+    """Aggregation handles unknown development provenance and metric-only records."""
+
+    summary = build_sensitivity_summary(
+        [
+            {
+                "development_pedestrian_model": "unknown",
+                "evaluation_pedestrian_model": SOCIAL_FORCE_DEFAULT,
+                "metrics": {"success": 1.0, "collisions": 1.0},
+                "algorithm_metadata": {"status": "fallback"},
+            }
+        ],
+        development_models=["unknown"],
+        evaluation_models=[SOCIAL_FORCE_DEFAULT],
+        planner_key="goal",
+        algo="goal",
+    )
+
+    cell = summary["cells"][0]
+    assert cell["success_incidence"] == 1.0
+    assert cell["collision_incidence"] == 1.0
+    assert cell["fallback_degraded_rows"] == 1
+    assert cell["status"] == "degraded"
+
+
+def test_sensitivity_summary_rejects_unknown_evaluation_model() -> None:
+    """Unsupported evaluation pedestrian models fail closed."""
+
+    with pytest.raises(ValueError, match="Unsupported pedestrian_model"):
+        build_sensitivity_summary(
+            [],
+            development_models=[SOCIAL_FORCE_DEFAULT],
+            evaluation_models=["bogus_model"],
+            planner_key="goal",
+            algo="goal",
+        )
+
+
+def test_report_writers_are_deterministic(tmp_path: Path) -> None:
+    """Report writer emits stable JSON, CSV, and Markdown surfaces."""
+
+    summary = build_sensitivity_summary(
+        [_record(SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1, success=True, collision=False)],
+        development_models=[SOCIAL_FORCE_DEFAULT],
+        evaluation_models=[HSFM_TOTAL_FORCE_V1],
+        planner_key="goal",
+        algo="goal",
+    )
+
+    paths = write_sensitivity_report(summary, tmp_path)
+
+    loaded = json.loads(Path(paths["summary_json"]).read_text(encoding="utf-8"))
+    assert loaded == summary
+    with Path(paths["sensitivity_matrix_csv"]).open("r", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows == [
+        {
+            "development_model": SOCIAL_FORCE_DEFAULT,
+            "evaluation_model": HSFM_TOTAL_FORCE_V1,
+            "planner_key": "goal",
+            "algo": "goal",
+            "episodes": "1",
+            "success_incidence": "1.0",
+            "collision_incidence": "0.0",
+            "fallback_degraded_rows": "0",
+            "status": "ok",
+        }
+    ]
+    readme = Path(paths["readme"]).read_text(encoding="utf-8")
+    assert "CPU-only diagnostic smoke report" in readme
+    assert "No new training" in readme
+
+
+def test_report_writer_renders_unavailable_rates_as_na(tmp_path: Path) -> None:
+    """Markdown report renders missing cells without numeric placeholders."""
+
+    summary = build_sensitivity_summary(
+        [],
+        development_models=[SOCIAL_FORCE_DEFAULT],
+        evaluation_models=[HSFM_TOTAL_FORCE_V1],
+        planner_key="goal",
+        algo="goal",
+    )
+
+    paths = write_sensitivity_report(summary, tmp_path)
+
+    readme = Path(paths["readme"]).read_text(encoding="utf-8")
+    assert "| social_force_default | hsfm_total_force_v1 | 0 | NA | NA | unavailable |" in readme
+
+
+def _record(
+    development_model: str,
+    evaluation_model: str,
+    *,
+    success: bool,
+    collision: bool,
+) -> dict[str, object]:
+    return {
+        "development_pedestrian_model": development_model,
+        "evaluation_pedestrian_model": evaluation_model,
+        "outcome": {"success": success, "collision": collision},
+        "algorithm_metadata": {},
+    }


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Adds benchmark episode-row pedestrian-model provenance and a CPU-only issue #3950 sensitivity harness for `social_force_default` and `hsfm_total_force_v1`.

Why now: PR #4144 landed the simulator-side `simulation_config.pedestrian_model` selector; this PR delivers the next progression capability, the train/dev-model vs eval-model diagnostic harness.

Claim boundary: Diagnostic CPU smoke only. No full benchmark campaign, no training run, no Slurm/GPU submission, and no paper/dissertation claim edits.

Required validation: Focused HSFM/pedestrian-model tests, benchmark sensitivity tests, CPU smoke harness, lint, and PR readiness.

Remaining blocker: None for this first harness slice. Broader learned-policy sensitivity claims still require real training or policy artifact provenance outside this PR.

## Contract delta

- New episode-row fields: `pedestrian_model`, `development_pedestrian_model`, `evaluation_pedestrian_model`.
- New report schema: `ped_model_sensitivity.v1`.
- New fail-closed blockers: unsupported pedestrian model names raise; malformed harness config raises before report generation.
- Compatibility impact: additive row metadata only; default simulator model remains `social_force_default`; raw JSONL artifacts stay ignored under `output/`.

<details>
<summary>PR details</summary>

## Linked Issues

- Closes #3950

## Stack / Dependency

- Base dependency: `origin/main` including merged PR #4144
- Required prior PRs: #4144
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason: #4144 supplied the simulator selector; this PR consumes it in benchmark provenance and the smoke harness.

## What Changed

- Added `robot_sf.benchmark.ped_model_sensitivity` for episode provenance, 2x2 aggregation, and deterministic report writing.
- Attached development/evaluation pedestrian-model metadata to every map-runner episode row.
- Added `scripts/benchmark/run_ped_model_sensitivity_issue_3950.py`.
- Added `configs/benchmarks/issue_3950_ped_model_sensitivity_smoke.yaml`.
- Added compact diagnostic evidence under `docs/context/evidence/issue_3950_pedestrian_model_sensitivity/`.
- Added focused tests for provenance, aggregation, fail-closed unknown model handling, and deterministic writers.

## Why Matters

- Added value: Benchmarks can distinguish policy development-model provenance from active evaluation pedestrian dynamics.
- Expected impact: Unblocks a low-cost diagnostic axis for train-vs-test pedestrian-model sensitivity without implying retraining.
- Why worth merging now: Completes the remaining harness/provenance part after the runtime selector landed.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: Blocker-resolution for issue #3950 diagnostic pedestrian-model sensitivity protocol.
- Comparator or baseline, applicable: `social_force_default` vs `hsfm_total_force_v1` evaluation model, declared development model crossed over the same two labels.
- Evidence tier: NA - implementation-integrity smoke only; no benchmark-result claim.
- Result classification: NA - diagnostic harness proof only; no benchmark-result claim.
- Decision stop rule, applicable: Harness emits all four cells with success/collision incidence and no fallback/degraded rows.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3950; compact evidence at `docs/context/evidence/issue_3950_pedestrian_model_sensitivity/`.
- New research/benchmark/metric/paper-facing analysis tool, any: representative use included via committed smoke config and evidence files.

## Domain-Aware Approval

- Required PR: yes, because targeted-smoke and diagnostic-only evidence language is present.
- Domains reviewed: benchmark episode-row provenance, pedestrian-model sensitivity harness, diagnostic evidence report.
- Status: waived; this PR proves implementation integrity only and does not promote benchmark or paper-facing conclusions.
- Approver/review source waiver: Reviewer can verify claim boundary and smoke evidence directly.
- Validity checklist:
  - Target claim/hypothesis: diagnostic harness availability, not learned-policy transfer.
  - Comparator or split/evidence validity: same cheap `goal` policy smoke across two evaluation models.
  - Fallback/degraded exclusions: report includes `fallback_degraded_rows`; smoke has zero fallback/degraded rows.
  - Claim boundary: CPU diagnostic, no training, no paper-facing claim.
  - Implementation integrity vs experimental validity: proves harness and metadata integrity only.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes; each cell has three smoke episodes.
- Did intervention change command source, selected command, trajectory, route progress? unknown/not claimed; report only records success/collision incidence.
- Did scenario actually contain targeted failure mode? no; planner sanity scenario is a cheap harness proof, not sensitivity evidence.
- Result route: continue only in a later empirical slice with real policy artifact/training provenance.
- Follow-up question issue weak, negative, non-transfer results: none opened.

## Next Empirical Action

- Rerun needed: no for this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: no for diagnostic harness proof.
- Stop / revise / continue decision: continue only if a later issue scopes real trained-policy provenance or a full campaign.
- Proposed child issue existing follow-up: none opened.

## Validation / Proof

- `uv run pytest tests/sim/test_hsfm_total_force_model.py tests/benchmark/test_ped_model_sensitivity.py -q` -> passed.
- `uv run pytest tests/benchmark -k 'pedestrian_model or sensitivity' -q` -> passed.
- `uv run ruff check robot_sf/sim robot_sf/benchmark scripts/benchmark tests/sim tests/benchmark` -> passed.
- `uv run python scripts/benchmark/run_ped_model_sensitivity_issue_3950.py --config configs/benchmarks/issue_3950_ped_model_sensitivity_smoke.yaml --output-dir docs/context/evidence/issue_3950_pedestrian_model_sensitivity` -> passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=... PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> passed on clean tree for `bc74a66ee609e86291ede9385e7b9dd9560816f7`.

## Performance Evidence

- Baseline runtime: NA, no performance/caching claim.
- Changed runtime: NA, no performance/caching claim.
- Representative command: `uv run python scripts/benchmark/run_ped_model_sensitivity_issue_3950.py --config configs/benchmarks/issue_3950_ped_model_sensitivity_smoke.yaml --output-dir docs/context/evidence/issue_3950_pedestrian_model_sensitivity`
- Hot-path call count profile anchor: NA, no performance/caching claim.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: harness fails to emit four cells or episode rows stop recording evaluation/development pedestrian model fields.

## Risks / Rollout

- Compatibility risks: Low; row fields are additive and schema permits extra properties.
- Failure modes: Misdeclared development model remains possible when no training artifact is provided; this is explicitly labeled declared provenance.
- Rollback fallback plan: Revert the episode metadata attachment and harness files.

## Docs / Provenance

- Updated docs: `docs/context/evidence/issue_3950_pedestrian_model_sensitivity/README.md`
- Relevant design provenance notes: issue #3950 comments dated 2026-07-02.
- Any assumptions need to preserved: Development-model axis is declared policy provenance unless backed by a training artifact.

## Downstream Propagation

- Parent issue updated: no
- Claim map / benchmark report updated: NA
- Leaderboard / artifact catalog updated: NA
- Registry or config index updated: NA
- Context index / memory note updated: NA
- Follow-up issue opened deferred propagation: no
- Not applicable because: user authorization set `comment_issue_or_pr=false`; this PR body carries compact status propagation instead of adding an issue comment.

## Follow-Up Issues

- Deferred work: full benchmark campaign, Slurm/GPU training, learned-policy train-vs-test claim promotion.
- Issues opened follow-up: none, covered by explicit maintainer/user waiver for this bounded first harness slice.

## Reviewer Notes

- Verify that `development_pedestrian_model` is explicit declared provenance, not inferred training provenance.
- Verify raw run JSONL artifacts are ignored under `output/`, while committed evidence is only the compact report.

</details>
