### PR TITLE
build: self-heal stale python-rvo2 CMake cache (#4192)

### DIFF
--- a/tests/build/test_python_rvo2_cmake_cache.py
+++ b/tests/build/test_python_rvo2_cmake_cache.py
@@ -1,0 +1,153 @@
+"""Tests for the vendored python-rvo2 CMake cache self-heal helpers."""
+
+# ruff: noqa: D103
+
+from __future__ import annotations
+
+import importlib.util
+import stat
+from pathlib import Path
+
+_HELPER_PATH = (
+    Path(__file__).resolve().parents[2] / "third_party" / "python-rvo2" / "_rvo2_cmake_build.py"
+)
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location("_rvo2_cmake_build_test", _HELPER_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cmake_build = _load_helper()
+
+
+def _write_cache(build_dir: Path, cmake: Path) -> Path:
+    build_dir.mkdir(parents=True)
+    cache_path = build_dir / "CMakeCache.txt"
+    cache_path.write_text(f"CMAKE_COMMAND:INTERNAL={cmake}\n", encoding="utf-8")
+    return cache_path
+
+
+def _make_executable(path: Path) -> Path:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def test_read_cached_cmake_command_parses_internal_cache_entry(tmp_path: Path) -> None:
+    cache_path = _write_cache(tmp_path / "build" / "RVO2", Path("/missing/cmake"))
+
+    assert cmake_build.read_cached_cmake_command(cache_path) == Path("/missing/cmake")
+
+
+def test_cmake_cache_is_stale_when_cached_executable_is_missing(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build" / "RVO2"
+    _write_cache(build_dir, tmp_path / "missing" / "cmake")
+
+    assert cmake_build.cmake_cache_is_stale(build_dir) is True
+
+
+def test_cmake_cache_is_not_stale_when_cached_executable_exists(tmp_path: Path) -> None:
+    cmake = _make_executable(tmp_path / "cmake")
+    build_dir = tmp_path / "build" / "RVO2"
+    _write_cache(build_dir, cmake)
+
+    assert cmake_build.cmake_cache_is_stale(build_dir) is False
+
+
+def test_remove_stale_cmake_build_dir_deletes_stale_cache(tmp_path: Path) -> None:
+    build_dir = tmp_path / "build" / "RVO2"
+    _write_cache(build_dir, tmp_path / "missing" / "cmake")
+    (build_dir / "generated").write_text("stale", encoding="utf-8")
+
+    assert cmake_build.remove_stale_cmake_build_dir(build_dir) is True
+    assert not build_dir.exists()
+
+
+def test_remove_stale_cmake_build_dir_preserves_valid_cache(tmp_path: Path) -> None:
+    cmake = _make_executable(tmp_path / "cmake")
+    build_dir = tmp_path / "build" / "RVO2"
+    _write_cache(build_dir, cmake)
+    marker = build_dir / "generated"
+    marker.write_text("keep", encoding="utf-8")
+
+    assert cmake_build.remove_stale_cmake_build_dir(build_dir) is False
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_resolve_cmake_executable_honors_environment_override(tmp_path: Path, monkeypatch) -> None:
+    cmake = _make_executable(tmp_path / "cmake")
+    monkeypatch.setenv("ROBOT_SF_CMAKE", str(cmake))
+
+    assert cmake_build.resolve_cmake_executable() == str(cmake)
+
+
+def test_configure_and_build_removes_stale_cache_before_configure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    build_dir = tmp_path / "build" / "RVO2"
+    _write_cache(build_dir, tmp_path / "missing" / "cmake")
+    cmake = _make_executable(tmp_path / "cmake")
+    calls: list[tuple[list[str], Path]] = []
+
+    def fake_check_call(args, cwd):
+        calls.append((args, cwd))
+        if args[1] == "../..":
+            (Path(cwd) / "CMakeCache.txt").write_text(
+                f"CMAKE_COMMAND:INTERNAL={cmake}\n", encoding="utf-8"
+            )
+
+    monkeypatch.setenv("ROBOT_SF_CMAKE", str(cmake))
+    monkeypatch.setattr(cmake_build.subprocess, "check_call", fake_check_call)
+
+    cmake_build.configure_and_build_rvo2(build_dir)
+
+    assert calls == [
+        ([str(cmake), "../..", "-DCMAKE_CXX_FLAGS=-fPIC"], build_dir),
+        ([str(cmake), "--build", "."], build_dir),
+    ]
+
+
+def test_configure_and_build_clean_directory_configures_then_builds(
+    tmp_path: Path, monkeypatch
+) -> None:
+    build_dir = tmp_path / "build" / "RVO2"
+    cmake = _make_executable(tmp_path / "cmake")
+    calls: list[list[str]] = []
+
+    def fake_check_call(args, cwd):
+        calls.append(args)
+        if args[1] == "../..":
+            (Path(cwd) / "CMakeCache.txt").write_text(
+                f"CMAKE_COMMAND:INTERNAL={cmake}\n", encoding="utf-8"
+            )
+
+    monkeypatch.setenv("ROBOT_SF_CMAKE", str(cmake))
+    monkeypatch.setattr(cmake_build.subprocess, "check_call", fake_check_call)
+
+    cmake_build.configure_and_build_rvo2(build_dir)
+
+    assert calls == [
+        [str(cmake), "../..", "-DCMAKE_CXX_FLAGS=-fPIC"],
+        [str(cmake), "--build", "."],
+    ]
+
+
+def test_configure_and_build_valid_existing_cache_builds_without_reconfigure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    cmake = _make_executable(tmp_path / "cmake")
+    build_dir = tmp_path / "build" / "RVO2"
+    _write_cache(build_dir, cmake)
+    calls: list[list[str]] = []
+
+    monkeypatch.setenv("ROBOT_SF_CMAKE", str(cmake))
+    monkeypatch.setattr(cmake_build.subprocess, "check_call", lambda args, cwd: calls.append(args))
+
+    cmake_build.configure_and_build_rvo2(build_dir)
+
+    assert calls == [[str(cmake), "--build", "."]]

--- a/third_party/python-rvo2/_rvo2_cmake_build.py
+++ b/third_party/python-rvo2/_rvo2_cmake_build.py
@@ -1,0 +1,83 @@
+"""Helpers for the vendored python-rvo2 CMake build wrapper."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+_CMAKE_COMMAND_PREFIX = "CMAKE_COMMAND:INTERNAL="
+_SYSTEM_CMAKE_CANDIDATES = (
+    Path("/usr/bin/cmake"),
+    Path("/usr/local/bin/cmake"),
+    Path("/opt/homebrew/bin/cmake"),
+)
+
+
+def _is_executable(path: Path) -> bool:
+    return path.is_file() and os.access(path, os.X_OK)
+
+
+def read_cached_cmake_command(cache_path: Path) -> Path | None:
+    """Return the cached CMake command path when ``CMakeCache.txt`` records one."""
+    if not cache_path.exists():
+        return None
+
+    for line in cache_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.startswith(_CMAKE_COMMAND_PREFIX):
+            command = line[len(_CMAKE_COMMAND_PREFIX) :].strip()
+            return Path(command) if command else None
+    return None
+
+
+def cmake_cache_is_stale(build_dir: Path) -> bool:
+    """Return true when the cached CMake executable is recorded but missing."""
+    cached_command = read_cached_cmake_command(build_dir / "CMakeCache.txt")
+    return cached_command is not None and not cached_command.exists()
+
+
+def remove_stale_cmake_build_dir(build_dir: Path) -> bool:
+    """Delete ``build_dir`` when its cache references a missing CMake executable.
+
+    Returns:
+        True when the build directory was deleted, otherwise False.
+    """
+    if not cmake_cache_is_stale(build_dir):
+        return False
+
+    shutil.rmtree(build_dir)
+    return True
+
+
+def resolve_cmake_executable() -> str:
+    """Return a resolvable CMake executable, preferring persistent system paths."""
+    for env_var in ("ROBOT_SF_CMAKE", "CMAKE_EXECUTABLE"):
+        configured = os.environ.get(env_var)
+        if configured:
+            path = Path(configured)
+            if _is_executable(path):
+                return str(path)
+            raise RuntimeError(f"{env_var} points to a non-executable CMake path: {configured}")
+
+    for candidate in _SYSTEM_CMAKE_CANDIDATES:
+        if _is_executable(candidate):
+            return str(candidate)
+
+    cmake = shutil.which("cmake")
+    if cmake:
+        return cmake
+
+    raise RuntimeError("Could not find a CMake executable. Install cmake or set ROBOT_SF_CMAKE.")
+
+
+def configure_and_build_rvo2(build_dir: Path) -> None:
+    """Self-heal stale CMake state, then configure and build the vendored RVO2 library."""
+    build_dir = build_dir.resolve()
+    remove_stale_cmake_build_dir(build_dir)
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    cmake = resolve_cmake_executable()
+    if not (build_dir / "CMakeCache.txt").exists():
+        subprocess.check_call([cmake, "../..", "-DCMAKE_CXX_FLAGS=-fPIC"], cwd=build_dir)
+    subprocess.check_call([cmake, "--build", "."], cwd=build_dir)

--- a/third_party/python-rvo2/setup.py
+++ b/third_party/python-rvo2/setup.py
@@ -1,6 +1,12 @@
+from pathlib import Path
+import sys
+
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 from Cython.Build import cythonize
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _rvo2_cmake_build import configure_and_build_rvo2
 
 
 def _macos_sdkroot() -> str | None:
@@ -52,18 +58,8 @@ class BuildRvo2Ext(_build_ext):
 
     def run(self):
         # Build RVO2
-        import os
-        import os.path
-        import subprocess
-
         _ensure_macos_sdk()
-        build_dir = os.path.abspath('build/RVO2')
-        if not os.path.exists(build_dir):
-            os.makedirs(build_dir)
-        if not os.path.exists(os.path.join(build_dir, 'CMakeCache.txt')):
-            subprocess.check_call(['cmake', '../..', '-DCMAKE_CXX_FLAGS=-fPIC'],
-                                  cwd=build_dir)
-        subprocess.check_call(['cmake', '--build', '.'], cwd=build_dir)
+        configure_and_build_rvo2(Path("build/RVO2"))
 
         _build_ext.run(self)
 


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `third_party/python-rvo2/setup.py` now delegates its CMake build step to a testable helper that detects a stale `build/RVO2/CMakeCache.txt` when `CMAKE_COMMAND:INTERNAL=` points at a missing executable, removes the stale build directory, recreates it, and reconfigures before building.

Why now: issue #4192 identifies an ephemeral CMake path wedge that can break future editable installs even though `CMakeCache.txt` exists.

Claim boundary: build-tooling fix only for the vendored `python-rvo2` wrapper; no MIT-ACL fork source patches, Robot SF ORCA behavior changes, benchmark planner claims, paper/dissertation claim edits, full benchmark campaign, Slurm/GPU submission, release, or merge.

Required validation: stale-cache unit simulation, clean editable build/import smoke, stale-cache editable build/import smoke, and final PR readiness.

Remaining blocker: none known for this slice. Claude Code on `imech156-u` owns the full PR gate and improvement cycle after PR open.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: `resolve_cmake_executable()` raises `RuntimeError` before subprocess execution when no executable CMake can be found or an explicit CMake override points at a non-executable path.
- Compatibility impact: clean builds still configure when `CMakeCache.txt` is absent and build afterward; valid existing CMake caches are preserved and build without reconfigure; stale caches with missing cached CMake are removed and rebuilt.
- Persistent CMake preference: explicit `ROBOT_SF_CMAKE` / `CMAKE_EXECUTABLE`, then `/usr/bin/cmake`, `/usr/local/bin/cmake`, `/opt/homebrew/bin/cmake`, then `shutil.which("cmake")` fallback.

<details>
<summary>PR details</summary>

## Summary

Self-heals vendored `python-rvo2` stale CMake cache state by extracting side-effect-free helper logic and using a resolved CMake executable consistently for configure and build.

## Linked Issues

- Closes #4192
- Issue link: https://github.com/ll7/robot_sf_ll7/issues/4192

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed

- Added `third_party/python-rvo2/_rvo2_cmake_build.py` with cache parsing, stale-cache detection/removal, CMake executable resolution, and configure/build orchestration.
- Updated `BuildRvo2Ext.run()` to call the helper instead of duplicating CMake subprocess logic in `setup.py`.
- Added `tests/build/test_python_rvo2_cmake_cache.py` regression coverage for stale, valid, clean, and override cases without running the C++ build in unit tests.

## Why Matters

- Added value: prevents stale ephemeral build-env CMake paths from wedging future `python-rvo2` installs.
- Expected impact: more robust local/CI editable installs for ORCA dependency setup.
- Why worth merging now: the ready-queue issue has complete diagnosis and acceptance criteria, and this is a narrow build-tooling fix.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - support/build-tooling blocker resolution only.
- Comparator or baseline, applicable: stale `CMakeCache.txt` previously skipped configure and could re-enter a missing cached CMake path during build.
- Support validation category: local build-tooling smoke and unit regression proof.
- Research result classification: not applicable; this PR makes no research result claim.
- Decision stop rule, applicable: targeted stale-cache simulation and real editable install/import smokes pass.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #4192 only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper.

## Domain-Aware Approval

- approval concerns experimental validity waived / pending / blocked / not required: not required.
- Approver/review source waiver: build-tooling only; no research or benchmark interpretation.
- Validity checklist: NA.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: NA.
- Claim boundary: no benchmark planner claim attached.
- Implementation integrity vs experimental validity: implementation only affects vendored build wrapper.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, in unit simulation and stale-cache editable install smoke.
- Did intervention change command source, selected command, trajectory, route progress? command source only; CMake executable is resolved once and reused for configure/build.
- Did scenario actually contain targeted failure mode? yes, stale smoke wrote `CMAKE_COMMAND:INTERNAL=/tmp/definitely-missing-cmake/cmake`.
- Result route: stop.
- Follow-up question issue weak, negative, non-transfer results: none.

## Next Empirical Action

- Rerun needed: no for this slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: stop; hand to PR gate.
- Proposed child issue existing follow-up: none.

## Validation / Proof

- `uv run pytest tests/build/test_python_rvo2_cmake_cache.py -q` -> pass, 9 passed.
- `uv run ruff check third_party/python-rvo2/_rvo2_cmake_build.py tests/build/test_python_rvo2_cmake_cache.py` -> pass.
- `uv run ruff format --check third_party/python-rvo2/_rvo2_cmake_build.py tests/build/test_python_rvo2_cmake_cache.py` -> pass.
- `rm -rf third_party/python-rvo2/build && uv pip install --python .venv/bin/python -e third_party/python-rvo2 && .venv/bin/python -c "import rvo2; print('rvo2 import ok')"` -> pass, printed `rvo2 import ok`.
- `mkdir -p third_party/python-rvo2/build/RVO2 && printf 'CMAKE_COMMAND:INTERNAL=/tmp/definitely-missing-cmake/cmake\n' > third_party/python-rvo2/build/RVO2/CMakeCache.txt && uv pip install --python .venv/bin/python -e third_party/python-rvo2 && .venv/bin/python -c "import rvo2; print('rvo2 import ok stale-cache recovery')"` -> pass, printed `rvo2 import ok stale-cache recovery`.
- Cache postcondition after stale smoke: `CMAKE_COMMAND:INTERNAL=/usr/bin/cmake`, not the missing `/tmp/...` path.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> pass in dirty-tree mode before final commit.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=... BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> pass; clean-tree freshness stamp for `dcb2722ab857b4cc76a2e618419596d9ad729d74` recorded at `output/validation/pr_ready/issue-4192-build-python-rvo2-self-heal.json`.

Note: the issue suggested `uv run pip install -e ...`, but on `imech156-u` that invoked externally managed system pip. I used `uv pip install --python .venv/bin/python -e ...` to validate the same editable build inside the bootstrapped worktree virtualenv.

## Performance Measurement

- Baseline runtime: NA, no performance claim.
- Changed runtime: NA, no performance claim.
- Representative command: editable `python-rvo2` install/import smoke commands above.
- Hot-path call count profile anchor: NA, no runtime hot-path claim.
- Cache-hit reuse counter: NA, no caching/reuse claim; this is CMake cache validity handling, not runtime caching.
- Rollback failure criterion: editable `python-rvo2` clean or stale-cache install/import smoke fails.

## Risks / Rollout

- Compatibility risks: malformed caches are left for CMake to diagnose; only missing recorded `CMAKE_COMMAND` paths are treated as stale.
- Failure modes: missing or invalid explicit CMake override now fails before subprocess invocation with a clear `RuntimeError`.
- Rollback fallback plan: revert this PR to restore previous setup wrapper behavior.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: issue #4192 implementation instructions.
- Any assumptions need to preserved: `ROBOT_SF_CMAKE` and `CMAKE_EXECUTABLE` are executable path overrides; if neither is set, persistent system CMake is preferred before PATH fallback.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a low-churn build-tooling PR and the prompt did not authorize issue/PR comments (`comment_issue_or_pr: false`); PR body carries the status propagation for reviewer handoff.

## Follow-Up Issues

- Deferred work: none.
- Issues opened follow-up: none.

## Reviewer Notes

- Review the `setup.py` source-dir `sys.path` insertion closely; it is intentionally needed so PEP 517 build isolation can import the helper during setup metadata generation.
- `tests/build/` is covered by a broad `build` ignore rule, so this PR force-adds only the single regression test file requested by the issue.
- Late issue check immediately before PR opening found no comments beyond the issue body and no open PR covering #4192.

</details>
