### PR TITLE
social-nav: add TAGA-like group avoidance wrapper (#3972)

### DIFF
--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -48,6 +48,7 @@ _BASELINE_CATEGORY_BY_CANONICAL: dict[str, str] = {
     "predictive_mppi": "learning",
     "risk_dwa": "classical",
     "risk_surface_dwa": "classical",
+    "taga_group_avoidance": "diagnostic",
     "hybrid_rule_local_planner": "classical",
     "adaptive_proxemic_selector_v0": "diagnostic",
     "adaptive_proxemic_selector_v1": "diagnostic",
@@ -107,6 +108,7 @@ _POLICY_SEMANTICS_BY_CANONICAL: dict[str, str] = {
     "predictive_mppi": "predictive_sequence_optimizer",
     "risk_dwa": "risk_aware_dynamic_window",
     "risk_surface_dwa": "deterministic_local_risk_surface_dwa",
+    "taga_group_avoidance": "diagnostic_taga_like_group_avoidance_wrapper",
     "hybrid_rule_local_planner": "hybrid_rule_deterministic_local_planner",
     "adaptive_proxemic_selector_v0": "diagnostic_fixed_proxemic_profile_selector",
     "adaptive_proxemic_selector_v1": "diagnostic_neutral_default_proxemic_profile_selector",
@@ -183,6 +185,15 @@ _OBSERVATION_SPEC_BY_CANONICAL: dict[str, dict[str, Any]] = {
         "notes": (
             "Exploratory deterministic risk-surface producer consumes structured SocNav state, "
             "derives an ego-frame occupancy-compatible risk grid, and wraps risk_dwa."
+        ),
+    },
+    "taga_group_avoidance": {
+        "default_mode": "socnav_state",
+        "supported_modes": ("socnav_state",),
+        "inputs": ("robot_state", "goal", "social_groups"),
+        "notes": (
+            "Diagnostic TAGA-like tangent-subgoal wrapper consumes declared social-group "
+            "o-space geometry through env binding and otherwise emits goal-like commands."
         ),
     },
     "mppi_social": _DEFAULT_OBSERVATION_SPEC,
@@ -866,6 +877,17 @@ _KINEMATICS_PROFILE_BY_CANONICAL: dict[str, dict[str, Any]] = {
         "projection_documented": True,
         "testing_only_adapter": True,
         "prototype_only": True,
+    },
+    "taga_group_avoidance": {
+        "planner_command_space": "unicycle_vw",
+        "supports_native_commands": False,
+        "supports_adapter_commands": True,
+        "default_execution_mode": "adapter",
+        "default_adapter_name": "TangentSubgoalGroupAvoidanceAdapter",
+        "benchmark_command_space": "unicycle_vw",
+        "projection_policy": "goal_like_tangent_subgoal_to_unicycle_vw",
+        "projection_documented": True,
+        "diagnostic_reference_only": True,
     },
     "hybrid_rule_local_planner": {
         "planner_command_space": "unicycle_vw",

--- a/robot_sf/benchmark/algorithm_readiness.py
+++ b/robot_sf/benchmark/algorithm_readiness.py
@@ -234,6 +234,16 @@ _ALGORITHMS: tuple[AlgorithmReadiness, ...] = (
         requires_explicit_opt_in=True,
     ),
     AlgorithmReadiness(
+        canonical_name="taga_group_avoidance",
+        tier="experimental",
+        aliases=("taga_group_avoidance", "group_avoidance"),
+        note=(
+            "TAGA-like tangent-subgoal wrapper around the goal baseline using declared "
+            "social-group o-space metadata; diagnostic group-intrusion surface only."
+        ),
+        requires_explicit_opt_in=True,
+    ),
+    AlgorithmReadiness(
         canonical_name="risk_surface_dwa",
         tier="experimental",
         aliases=("risk_surface_dwa", "risk_surface_dwa_v0"),

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -123,6 +123,7 @@ from robot_sf.benchmark.map_runner_policies import adapters as _adapter_policy_b
 from robot_sf.benchmark.map_runner_policies import adaptive_proxemic as _adaptive_proxemic_builder
 from robot_sf.benchmark.map_runner_policies import diffusion_policy as _diffusion_policy_builder
 from robot_sf.benchmark.map_runner_policies import goal as _goal_policy_builder
+from robot_sf.benchmark.map_runner_policies import group_avoidance as _group_avoidance_builder
 from robot_sf.benchmark.map_runner_policies import hybrid_global_rl as _hybrid_global_rl_builder
 from robot_sf.benchmark.map_runner_policies import registry as _policy_builder_registry
 from robot_sf.benchmark.map_runner_policies import safety_barrier as _safety_barrier_builder
@@ -990,6 +991,10 @@ _POLICY_BUILDERS: dict[str, _policy_builder_registry.PolicyBuilder] = {
     **dict.fromkeys(
         _diffusion_policy_builder.DIFFUSION_POLICY_KEYS,
         _diffusion_policy_builder.build,
+    ),
+    **dict.fromkeys(
+        _group_avoidance_builder.GROUP_AVOIDANCE_ALGO_KEYS,
+        _group_avoidance_builder.build,
     ),
     **dict.fromkeys(_safety_barrier_builder.ADAPTER_ALGO_KEYS, _safety_barrier_builder.build),
     **dict.fromkeys(

--- a/robot_sf/benchmark/map_runner_policies/group_avoidance.py
+++ b/robot_sf/benchmark/map_runner_policies/group_avoidance.py
@@ -1,0 +1,66 @@
+"""Builder for TAGA-like social-group avoidance map-runner policy."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.map_runner_policy_common import build_adapter_policy
+from robot_sf.planner.group_avoidance import (
+    CLAIM_BOUNDARY,
+    TangentSubgoalGroupAvoidanceAdapter,
+    build_group_avoidance_config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+GROUP_AVOIDANCE_ALGO_KEYS = frozenset({"taga_group_avoidance", "group_avoidance"})
+
+
+def build(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    robot_kinematics: str | None = None,
+    robot_command_mode: str | None = None,
+    adapter_impact_eval: bool = False,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build the diagnostic TAGA-like tangent-subgoal wrapper.
+
+    Returns:
+        tuple: Policy callable and enriched metadata.
+    """
+
+    del adapter_impact_eval
+    normalized_robot_command_mode = (
+        str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
+    )
+    config = build_group_avoidance_config(algo_config)
+    adapter = TangentSubgoalGroupAvoidanceAdapter(config=config)
+    meta: dict[str, Any] = {
+        "group_avoidance": {
+            "schema_version": "taga-like-group-avoidance.v1",
+            "status": "enabled",
+            "diagnostic_only": True,
+            "wrapped_algo": config.wrapped_algo,
+            "trigger_mode": config.trigger_mode,
+            "safety_margin_m": config.safety_margin_m,
+            "tangent_clearance_m": config.tangent_clearance_m,
+            "tangent_side": config.tangent_side,
+            "claim_boundary": CLAIM_BOUNDARY,
+        }
+    }
+    return build_adapter_policy(
+        algo_key=algo_key,
+        algo_config=algo_config,
+        meta=meta,
+        adapter=adapter,
+        adapter_name="TangentSubgoalGroupAvoidanceAdapter",
+        robot_kinematics=robot_kinematics,
+        normalized_robot_command_mode=normalized_robot_command_mode,
+        limitations="diagnostic group-space wrapper; group-intrusion only, not safety evidence",
+    )
+
+
+__all__ = ["GROUP_AVOIDANCE_ALGO_KEYS", "build"]

--- a/robot_sf/planner/group_avoidance.py
+++ b/robot_sf/planner/group_avoidance.py
@@ -1,0 +1,277 @@
+"""TAGA-like group-avoidance wrapper for scenario-declared social groups.
+
+The adapter is diagnostic and opt-in. It uses group metadata declared on the
+map to steer a goal-like command toward a tangent subgoal when the robot is near
+or inside a group's o-space. It does not claim collision-safety improvement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import acos, atan2, cos, isfinite, sin
+from typing import Any
+
+import numpy as np
+from shapely.geometry import Point, Polygon
+
+from robot_sf.common.math_utils import wrap_angle_pi
+
+CLAIM_BOUNDARY = "diagnostic group-space avoidance only; not a collision-safety guarantee"
+SCHEMA_VERSION = "taga-like-group-avoidance.v1"
+
+
+@dataclass(frozen=True)
+class GroupAvoidanceConfig:
+    """Configuration for the TAGA-like tangent-subgoal wrapper."""
+
+    wrapped_algo: str = "goal"
+    safety_margin_m: float = 0.4
+    tangent_clearance_m: float = 0.2
+    tangent_side: str = "auto"
+    trigger_mode: str = "boundary_clearance"
+    max_speed: float = 1.0
+
+
+def build_group_avoidance_config(config: dict[str, Any] | None) -> GroupAvoidanceConfig:
+    """Build and validate group-avoidance wrapper configuration.
+
+    Returns:
+        GroupAvoidanceConfig: Normalized wrapper configuration.
+    """
+
+    payload = dict(config or {})
+    wrapped_algo = str(payload.get("wrapped_algo", "goal")).strip().lower()
+    if wrapped_algo not in {"goal", "simple", "goal_policy", "simple_policy"}:
+        raise ValueError("taga_group_avoidance supports only wrapped_algo='goal' in this slice")
+
+    tangent_side = str(payload.get("tangent_side", "auto")).strip().lower()
+    if tangent_side not in {"auto", "left", "right"}:
+        raise ValueError("tangent_side must be one of: auto, left, right")
+
+    trigger_mode = str(payload.get("trigger_mode", "boundary_clearance")).strip().lower()
+    if trigger_mode != "boundary_clearance":
+        raise ValueError("trigger_mode must be 'boundary_clearance'")
+
+    cfg = GroupAvoidanceConfig(
+        wrapped_algo="goal",
+        safety_margin_m=float(payload.get("safety_margin_m", 0.4)),
+        tangent_clearance_m=float(payload.get("tangent_clearance_m", 0.2)),
+        tangent_side=tangent_side,
+        trigger_mode=trigger_mode,
+        max_speed=float(payload.get("max_speed", 1.0)),
+    )
+    if not isfinite(cfg.safety_margin_m) or cfg.safety_margin_m < 0.0:
+        raise ValueError("safety_margin_m must be finite and non-negative")
+    if not isfinite(cfg.tangent_clearance_m) or cfg.tangent_clearance_m < 0.0:
+        raise ValueError("tangent_clearance_m must be finite and non-negative")
+    if not isfinite(cfg.max_speed) or cfg.max_speed < 0.0:
+        raise ValueError("max_speed must be finite and non-negative")
+    return cfg
+
+
+class TangentSubgoalGroupAvoidanceAdapter:
+    """Thin TAGA-like tangent-subgoal wrapper around a goal command."""
+
+    def __init__(self, config: GroupAvoidanceConfig | None = None) -> None:
+        """Initialize adapter state and runtime diagnostics."""
+
+        self.config = config or GroupAvoidanceConfig()
+        self._group_specs: list[dict[str, Any]] = []
+        self._trigger_count = 0
+        self._last_selected_group_id: str | None = None
+        self._last_subgoal: tuple[float, float] | None = None
+
+    def bind_env(self, env: Any) -> None:
+        """Cache JSON-safe social-group geometry from the benchmark environment."""
+
+        simulator = getattr(env, "simulator", None)
+        self._group_specs = _group_specs_from_source(simulator)
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return episode diagnostics for result provenance."""
+
+        return {
+            "group_avoidance": {
+                "schema_version": SCHEMA_VERSION,
+                "diagnostic_only": True,
+                "wrapped_algo": self.config.wrapped_algo,
+                "trigger_count": self._trigger_count,
+                "last_selected_group_id": self._last_selected_group_id,
+                "last_subgoal": list(self._last_subgoal)
+                if self._last_subgoal is not None
+                else None,
+                "group_count": len(self._group_specs),
+                "claim_boundary": CLAIM_BOUNDARY,
+            }
+        }
+
+    def plan(self, obs: dict[str, Any]) -> tuple[float, float]:
+        """Return a goal-like command, detouring to a tangent subgoal near groups."""
+
+        robot_pos, heading, goal_pos = _extract_robot_goal(obs)
+        selected = self._nearest_triggering_group(robot_pos)
+        if selected is None:
+            self._last_selected_group_id = None
+            self._last_subgoal = None
+            return _goal_command(robot_pos, heading, goal_pos, self.config.max_speed)
+
+        subgoal = self._tangent_subgoal(
+            robot_pos=robot_pos,
+            goal_pos=goal_pos,
+            centroid=selected.centroid,
+            effective_radius=selected.radius
+            + self.config.safety_margin_m
+            + self.config.tangent_clearance_m,
+        )
+        self._trigger_count += 1
+        self._last_selected_group_id = selected.group_id
+        self._last_subgoal = (float(subgoal[0]), float(subgoal[1]))
+        return _goal_command(robot_pos, heading, subgoal, self.config.max_speed)
+
+    def _nearest_triggering_group(self, robot_pos: np.ndarray) -> _GroupGeometry | None:
+        nearest: _GroupGeometry | None = None
+        nearest_clearance = float("inf")
+        for spec in self._group_specs:
+            group = _GroupGeometry.from_spec(spec)
+            if group is None:
+                continue
+            clearance = group.boundary_clearance(robot_pos)
+            if clearance < nearest_clearance:
+                nearest = group
+                nearest_clearance = clearance
+        if nearest is None or nearest_clearance > self.config.safety_margin_m:
+            return None
+        return nearest
+
+    def _tangent_subgoal(
+        self,
+        *,
+        robot_pos: np.ndarray,
+        goal_pos: np.ndarray,
+        centroid: np.ndarray,
+        effective_radius: float,
+    ) -> np.ndarray:
+        vec = robot_pos - centroid
+        distance = float(np.linalg.norm(vec))
+        radius = max(float(effective_radius), 1e-6)
+        if distance <= radius + 1e-9:
+            direction = goal_pos - centroid
+            if float(np.linalg.norm(direction)) < 1e-9:
+                direction = np.array([1.0, 0.0], dtype=float)
+            unit = _unit(direction)
+            left = np.array([-unit[1], unit[0]], dtype=float)
+            right = -left
+            side_vec = left if self.config.tangent_side != "right" else right
+            return centroid + side_vec * radius
+
+        unit_to_robot = vec / distance
+        perp = np.array([-unit_to_robot[1], unit_to_robot[0]], dtype=float)
+        alpha = acos(float(np.clip(radius / distance, -1.0, 1.0)))
+        left = centroid + radius * (cos(alpha) * unit_to_robot + sin(alpha) * perp)
+        right = centroid + radius * (cos(alpha) * unit_to_robot - sin(alpha) * perp)
+        if self.config.tangent_side == "left":
+            return left
+        if self.config.tangent_side == "right":
+            return right
+        left_score = float(np.linalg.norm(left - goal_pos))
+        right_score = float(np.linalg.norm(right - goal_pos))
+        return left if left_score <= right_score else right
+
+
+@dataclass(frozen=True)
+class _GroupGeometry:
+    group_id: str | None
+    centroid: np.ndarray
+    radius: float
+    polygon: Polygon | None
+
+    @classmethod
+    def from_spec(cls, spec: dict[str, Any]) -> _GroupGeometry | None:
+        try:
+            centroid = np.asarray(spec.get("centroid"), dtype=float).reshape(-1)[:2]
+            radius = float(spec.get("radius", 0.0))
+        except (TypeError, ValueError):
+            return None
+        if centroid.size < 2 or not np.all(np.isfinite(centroid)) or not isfinite(radius):
+            return None
+        poly_points = spec.get("o_space_polygon")
+        polygon = None
+        if isinstance(poly_points, list) and len(poly_points) >= 3:
+            try:
+                polygon = Polygon([(float(x), float(y)) for x, y in poly_points])
+            except (TypeError, ValueError):
+                polygon = None
+            if polygon is not None and (polygon.is_empty or not polygon.is_valid):
+                polygon = None
+        return cls(
+            group_id=str(spec.get("group_id")) if spec.get("group_id") is not None else None,
+            centroid=centroid.astype(float),
+            radius=max(radius, 0.0),
+            polygon=polygon,
+        )
+
+    def boundary_clearance(self, robot_pos: np.ndarray) -> float:
+        """Return signed clearance from group o-space boundary."""
+
+        if self.polygon is not None:
+            point = Point(float(robot_pos[0]), float(robot_pos[1]))
+            distance = float(self.polygon.exterior.distance(point))
+            return -distance if self.polygon.contains(point) else distance
+        return float(np.linalg.norm(robot_pos - self.centroid) - self.radius)
+
+
+def _extract_robot_goal(obs: dict[str, Any]) -> tuple[np.ndarray, float, np.ndarray]:
+    robot = obs.get("robot") if isinstance(obs.get("robot"), dict) else {}
+    goal = obs.get("goal") if isinstance(obs.get("goal"), dict) else {}
+    robot_pos = np.asarray(
+        robot.get("position", obs.get("robot_position", [0.0, 0.0])), dtype=float
+    )
+    heading_source = robot.get("heading", obs.get("robot_heading", [0.0]))
+    heading = float(np.asarray(heading_source, dtype=float).reshape(-1)[0])
+    goal_pos = np.asarray(goal.get("current", obs.get("goal_current", [0.0, 0.0])), dtype=float)
+    return robot_pos.reshape(-1)[:2], heading, goal_pos.reshape(-1)[:2]
+
+
+def _group_specs_from_source(source: Any) -> list[dict[str, Any]]:
+    groups = getattr(source, "social_groups", None) or []
+    specs: list[dict[str, Any]] = []
+    for group in groups:
+        as_spec = getattr(group, "as_spec", None)
+        if callable(as_spec):
+            specs.append(as_spec())
+        elif isinstance(group, dict):
+            specs.append(dict(group))
+    return specs
+
+
+def _goal_command(
+    robot_pos: np.ndarray,
+    heading: float,
+    goal_pos: np.ndarray,
+    max_speed: float,
+) -> tuple[float, float]:
+    vec = goal_pos - robot_pos
+    distance = float(np.linalg.norm(vec))
+    if distance < 1e-6:
+        return 0.0, 0.0
+    desired_heading = atan2(float(vec[1]), float(vec[0]))
+    heading_error = wrap_angle_pi(desired_heading - heading)
+    angular = float(np.clip(heading_error, -1.0, 1.0))
+    linear = float(np.clip(distance, 0.0, max_speed * max(0.0, 1.0 - abs(heading_error) / np.pi)))
+    return linear, angular
+
+
+def _unit(vec: np.ndarray) -> np.ndarray:
+    norm = float(np.linalg.norm(vec))
+    if norm < 1e-9:
+        return np.array([1.0, 0.0], dtype=float)
+    return vec / norm
+
+
+__all__ = [
+    "CLAIM_BOUNDARY",
+    "SCHEMA_VERSION",
+    "GroupAvoidanceConfig",
+    "TangentSubgoalGroupAvoidanceAdapter",
+    "build_group_avoidance_config",
+]

--- a/tests/benchmark/test_map_runner_group_avoidance_policy.py
+++ b/tests/benchmark/test_map_runner_group_avoidance_policy.py
@@ -1,0 +1,76 @@
+"""Map-runner wiring tests for the TAGA-like group-avoidance policy."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from robot_sf.benchmark.algorithm_readiness import get_algorithm_readiness
+from robot_sf.benchmark.map_runner import _build_policy
+from robot_sf.nav.map_config import SocialGroupDefinition
+
+
+def _fake_env() -> SimpleNamespace:
+    group = SocialGroupDefinition(
+        group_id="conversation_a",
+        type="conversation",
+        members=("ped_a", "ped_b"),
+        formation="face_to_face",
+        centroid=(2.0, 0.0),
+        radius=0.8,
+    )
+    return SimpleNamespace(simulator=SimpleNamespace(social_groups=[group]))
+
+
+def test_build_policy_registers_taga_group_avoidance_with_provenance() -> None:
+    """Map-runner builds the opt-in wrapper and exposes runtime diagnostics."""
+
+    policy, meta = _build_policy(
+        "taga_group_avoidance",
+        {
+            "wrapped_algo": "goal",
+            "safety_margin_m": 0.5,
+            "tangent_clearance_m": 0.2,
+            "tangent_side": "left",
+        },
+        robot_kinematics="differential_drive",
+    )
+
+    assert meta["algorithm"] == "taga_group_avoidance"
+    assert meta["group_avoidance"]["schema_version"] == "taga-like-group-avoidance.v1"
+    assert meta["group_avoidance"]["diagnostic_only"] is True
+    assert "not a collision-safety guarantee" in meta["group_avoidance"]["claim_boundary"]
+    assert meta["planner_kinematics"]["adapter_name"] == "TangentSubgoalGroupAvoidanceAdapter"
+    assert hasattr(policy, "_planner_bind_env")
+    assert hasattr(policy, "_planner_stats")
+
+    policy._planner_bind_env(_fake_env())
+    command = policy(
+        {
+            "robot": {"position": [1.0, 0.0], "heading": [0.0]},
+            "goal": {"current": [5.0, 0.0]},
+        }
+    )
+    diagnostics = policy._planner_stats()["group_avoidance"]
+
+    assert command[0] >= 0.0
+    assert diagnostics["trigger_count"] == 1
+    assert diagnostics["last_selected_group_id"] == "conversation_a"
+
+
+def test_group_avoidance_readiness_requires_explicit_opt_in() -> None:
+    """Readiness metadata classifies the wrapper as experimental opt-in."""
+
+    readiness = get_algorithm_readiness("group_avoidance")
+
+    assert readiness.canonical_name == "taga_group_avoidance"
+    assert readiness.tier == "experimental"
+    assert readiness.requires_explicit_opt_in is True
+
+
+def test_build_policy_group_avoidance_rejects_non_goal_wrapped_algo() -> None:
+    """Map-runner policy construction fails closed for unsupported wrapping."""
+
+    with pytest.raises(ValueError, match="wrapped_algo='goal'"):
+        _build_policy("group_avoidance", {"wrapped_algo": "orca"})

--- a/tests/planner/test_group_avoidance.py
+++ b/tests/planner/test_group_avoidance.py
@@ -1,0 +1,136 @@
+"""Tests for the TAGA-like group-avoidance wrapper."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from robot_sf.nav.map_config import SocialGroupDefinition
+from robot_sf.planner.group_avoidance import (
+    GroupAvoidanceConfig,
+    TangentSubgoalGroupAvoidanceAdapter,
+    build_group_avoidance_config,
+)
+
+
+def _obs(*, robot=(0.0, 0.0), heading=0.0, goal=(10.0, 0.0)) -> dict[str, object]:
+    return {
+        "robot": {"position": list(robot), "heading": [heading]},
+        "goal": {"current": list(goal)},
+    }
+
+
+def _env_with_group(group: SocialGroupDefinition) -> SimpleNamespace:
+    return SimpleNamespace(simulator=SimpleNamespace(social_groups=[group]))
+
+
+def _conversation_group() -> SocialGroupDefinition:
+    return SocialGroupDefinition(
+        group_id="conversation_a",
+        type="conversation",
+        members=("ped_a", "ped_b"),
+        formation="face_to_face",
+        centroid=(2.0, 0.0),
+        radius=0.8,
+    )
+
+
+def test_group_avoidance_defers_to_goal_outside_safety_margin() -> None:
+    """Adapter returns the wrapped goal command when no group is close."""
+
+    adapter = TangentSubgoalGroupAvoidanceAdapter(
+        GroupAvoidanceConfig(safety_margin_m=0.3, tangent_clearance_m=0.1, max_speed=1.0)
+    )
+    adapter.bind_env(_env_with_group(_conversation_group()))
+
+    command = adapter.plan(_obs(robot=(-2.0, 0.0), goal=(10.0, 0.0)))
+
+    assert command == pytest.approx((1.0, 0.0))
+    assert adapter.diagnostics()["group_avoidance"]["trigger_count"] == 0
+
+
+def test_group_avoidance_selects_deterministic_tangent_subgoal_near_group() -> None:
+    """Adapter selects a tangent subgoal outside the configured group buffer."""
+
+    adapter = TangentSubgoalGroupAvoidanceAdapter(
+        GroupAvoidanceConfig(
+            safety_margin_m=0.5,
+            tangent_clearance_m=0.2,
+            tangent_side="left",
+            max_speed=1.0,
+        )
+    )
+    adapter.bind_env(_env_with_group(_conversation_group()))
+
+    command = adapter.plan(_obs(robot=(1.0, 0.0), goal=(5.0, 0.0)))
+    diagnostics = adapter.diagnostics()["group_avoidance"]
+
+    assert diagnostics["trigger_count"] == 1
+    assert diagnostics["last_selected_group_id"] == "conversation_a"
+    subgoal = np.asarray(diagnostics["last_subgoal"], dtype=float)
+    assert np.linalg.norm(subgoal - np.asarray([2.0, 0.0])) == pytest.approx(1.5)
+    assert abs(command[1]) > 0.01
+
+
+def test_group_avoidance_auto_tangent_selection_is_stable() -> None:
+    """Auto tangent selection is deterministic for the same observation."""
+
+    adapter = TangentSubgoalGroupAvoidanceAdapter(
+        GroupAvoidanceConfig(safety_margin_m=0.5, tangent_clearance_m=0.2)
+    )
+    adapter.bind_env(_env_with_group(_conversation_group()))
+
+    adapter.plan(_obs(robot=(0.0, -0.2), goal=(5.0, 1.5)))
+    first = adapter.diagnostics()["group_avoidance"]["last_subgoal"]
+    adapter.plan(_obs(robot=(0.0, -0.2), goal=(5.0, 1.5)))
+    second = adapter.diagnostics()["group_avoidance"]["last_subgoal"]
+
+    assert second == pytest.approx(first)
+
+
+def test_group_avoidance_invalid_wrapped_algo_fails_closed() -> None:
+    """Unsupported wrapped planners fail before benchmark execution."""
+
+    with pytest.raises(ValueError, match="wrapped_algo='goal'"):
+        build_group_avoidance_config({"wrapped_algo": "orca"})
+
+
+def test_group_avoidance_config_validation_fails_closed() -> None:
+    """Invalid tangent mode, trigger mode, and numeric bounds are rejected."""
+
+    with pytest.raises(ValueError, match="tangent_side"):
+        build_group_avoidance_config({"tangent_side": "middle"})
+    with pytest.raises(ValueError, match="trigger_mode"):
+        build_group_avoidance_config({"trigger_mode": "distance"})
+    with pytest.raises(ValueError, match="safety_margin_m"):
+        build_group_avoidance_config({"safety_margin_m": -0.1})
+    with pytest.raises(ValueError, match="tangent_clearance_m"):
+        build_group_avoidance_config({"tangent_clearance_m": -0.1})
+    with pytest.raises(ValueError, match="max_speed"):
+        build_group_avoidance_config({"max_speed": -0.1})
+
+
+def test_group_avoidance_accepts_dict_backed_group_specs() -> None:
+    """Adapter can bind plain JSON-safe group dictionaries from compatible sources."""
+
+    adapter = TangentSubgoalGroupAvoidanceAdapter(GroupAvoidanceConfig(safety_margin_m=0.5))
+    env = SimpleNamespace(
+        simulator=SimpleNamespace(
+            social_groups=[
+                {
+                    "group_id": "conversation_dict",
+                    "centroid": [2.0, 0.0],
+                    "radius": 0.8,
+                }
+            ]
+        )
+    )
+    adapter.bind_env(env)
+
+    adapter.plan(_obs(robot=(1.0, 0.0), goal=(5.0, 0.0)))
+    diagnostics = adapter.diagnostics()["group_avoidance"]
+
+    assert diagnostics["group_count"] == 1
+    assert diagnostics["last_selected_group_id"] == "conversation_dict"


### PR DESCRIPTION
Reviewer-critical summary

What changed: Added an opt-in `taga_group_avoidance` / `group_avoidance` map-runner policy that wraps the goal baseline with a TAGA-like tangent-subgoal detour around declared social-group o-space metadata from #4143.

Why now: #4143 merged the group metadata and group-space metrics foundations; the 2026-07-03 maintainer comment narrows this successor slice to the planner wrapper only.

Claim boundary: This is diagnostic group-space planning behavior only. It may reduce group-space intrusion in selected scenarios, but it is not a collision-safety guarantee and does not establish benchmark or paper claims.

Required validation: Focused unit tests and CPU smoke only. No full benchmark campaign is included in this PR.

Remaining blocker: A later empirical slice should run the headless comparison and report group intrusion plus collision safety-gate metrics before any stronger claim is made.

Contract delta

- New opt-in planner keys: `taga_group_avoidance`, `group_avoidance`.
- New policy config fields: `wrapped_algo`, `safety_margin_m`, `tangent_clearance_m`, `tangent_side`, `trigger_mode`, `max_speed`.
- Compatibility impact: `wrapped_algo` intentionally fail-closes unless it resolves to the goal/simple baseline in this first slice.
- New metadata/provenance: `group_avoidance` block with `schema_version=taga-like-group-avoidance.v1`, diagnostic flag, claim boundary, trigger count, selected group id, and last subgoal diagnostics.
- Algorithm readiness: experimental and `requires_explicit_opt_in=True`.
- Planner contract: adapter-mode unicycle `v, omega` output; consumes robot state, goal, and bound social-group metadata.

Issue: #3972

Scope summary

- Implemented the TAGA-like tangent-subgoal group-avoidance wrapper using the merged `env.simulator.social_groups` metadata surface.
- Registered the wrapper through the map-runner policy builder registry.
- Added algorithm metadata/readiness provenance.
- Added focused planner and map-runner policy tests.

Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/planner/group_avoidance.py robot_sf/benchmark/map_runner_policies/group_avoidance.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/algorithm_readiness.py robot_sf/benchmark/algorithm_metadata.py tests/planner/test_group_avoidance.py tests/benchmark/test_map_runner_group_avoidance_policy.py` PASS.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/ -k "group_intrusion or group_avoidance or taga" -q` PASS: 16 passed.
- CPU smoke: `_build_policy('taga_group_avoidance', ...)`, bind fake env with one social group, plan once near o-space; PASS with `trigger_count=1`, `last_selected_group_id='conversation_a'`, command `(0.687167041810999, 0.9827937232473287)`.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3972/pr_body.md scripts/dev/pr_ready_check.sh` PASS; stamp `output/validation/pr_ready/issue-3972-social-nav-taga-like-group-avoidance-wrapper-successor-to-4143.json` for head `7f84e259ec223a8126bea98c8bbbb7ccf675c400`.

Out of scope

- No full benchmark campaign run.
- No headless comparison run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No re-implementation or re-validation of #4143 group metadata/metrics.

Downstream propagation

No issue comment was added because this dispatch explicitly disallows `comment_issue_or_pr`. The PR body is the durable state surface for this low-churn successor slice: wrapper delivered, comparison evidence remains future work.

<details>
<summary>Freshness and fragmentation checks</summary>

- Late issue refresh before PR open: no maintainer comments newer than the 2026-07-03 active-slice comment were found.
- Open PR dedupe for issue #3972 / TAGA / group-avoidance scope: none found.
- Fragmentation guard: only #4143 was identified as a merged #3972 foundation PR; this PR is a progression slice adding the nameable new `taga_group_avoidance` capability, not another micro-guard.
- Transient queue state: no host or packet lineage state was added to tracked files.

</details>



Closure discipline update (gate 2026-07-03): Deferred headless comparison and collision safety-gate metrics remain tracked by open parent issue #3972 acceptance items; this PR is a wrapper-only successor slice and intentionally does not close #3972.
