### PR TITLE
Fix safety_wrapper fail-open ineligible branches (#4180)

### DIFF
--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -789,12 +789,12 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                         previous_ped_positions=previous_trace_ped_pos,
                         step_idx=step_idx,
                     )
-                policy_command = (
-                    corrected_command[0],
-                    corrected_command[1],
-                    *tuple(policy_command[2:]),
-                )
-                safety_wrapper_trace.append(wrapper_record)
+                    policy_command = (
+                        corrected_command[0],
+                        corrected_command[1],
+                        *tuple(policy_command[2:]),
+                    )
+                    safety_wrapper_trace.append(wrapper_record)
             if cbf_runtime.enabled:
                 if step_is_native:
                     if cbf_runtime.fail_on_native_action:

--- a/tests/benchmark/test_safety_wrapper_runtime.py
+++ b/tests/benchmark/test_safety_wrapper_runtime.py
@@ -390,12 +390,16 @@ def test_run_map_episode_records_wrapper_metadata_when_enabled(monkeypatch) -> N
     record = _run_episode_with_policy(
         monkeypatch,
         _policy_builder,
-        safety_wrapper={"enabled": True, "arm_key": "wrapper_on"},
+        safety_wrapper={"enabled": True, "arm_key": "wrapper_on", "record_step_trace": True},
     )
 
     summary = record["algorithm_metadata"]["safety_wrapper"]
     assert summary["schema_version"] == SAFETY_WRAPPER_EPISODE_SUMMARY_SCHEMA
+    assert summary["step_count"] == 1
+    assert summary["eligible_step_count"] == 1
     assert summary["intervened_step_count"] == 1
+    assert len(summary["step_trace"]) == 1
+    assert summary["step_trace"][0]["eligible_for_wrapper"] is True
     assert record["metrics"]["wrapper_intervention_rate"] == 1.0
 
     ledger = build_event_ledger(record)
@@ -439,3 +443,70 @@ def test_run_map_episode_fails_closed_for_unsupported_command_when_wrapper_enabl
             unsupported_policy_builder,
             safety_wrapper={"enabled": True, "arm_key": "wrapper_on"},
         )
+
+
+def test_run_map_episode_records_fail_open_native_action_as_ineligible(monkeypatch) -> None:
+    """Fail-open native env actions keep original command and record provenance."""
+
+    def native_policy_builder(*_args, **_kwargs):
+        def policy(_obs):
+            return np.array([0.1, 0.0], dtype=float)
+
+        policy._last_step_native = True
+        return policy, {"algorithm": "unit"}
+
+    record = _run_episode_with_policy(
+        monkeypatch,
+        native_policy_builder,
+        safety_wrapper={
+            "enabled": True,
+            "arm_key": "wrapper_on",
+            "fail_on_native_action": False,
+            "record_step_trace": True,
+        },
+    )
+
+    summary = record["algorithm_metadata"]["safety_wrapper"]
+    assert summary["step_count"] == 1
+    assert summary["eligible_step_count"] == 0
+    assert summary["intervened_step_count"] == 0
+    assert len(summary["step_trace"]) == 1
+    step_record = summary["step_trace"][0]
+    assert step_record["eligible_for_wrapper"] is False
+    assert step_record["ineligible_reason"] == "native_environment_action"
+    assert step_record["context"] is None
+    assert record["metrics"]["wrapper_intervention_rate"] == 0.0
+
+
+def test_run_map_episode_records_fail_open_unsupported_command_as_ineligible(
+    monkeypatch,
+) -> None:
+    """Fail-open unsupported command shapes record provenance without wrapper rewrite."""
+
+    def unsupported_policy_builder(*_args, **_kwargs):
+        def policy(_obs):
+            return {"command_kind": "unsupported"}
+
+        return policy, {"algorithm": "unit"}
+
+    record = _run_episode_with_policy(
+        monkeypatch,
+        unsupported_policy_builder,
+        safety_wrapper={
+            "enabled": True,
+            "arm_key": "wrapper_on",
+            "fail_on_unsupported_command": False,
+            "record_step_trace": True,
+        },
+    )
+
+    summary = record["algorithm_metadata"]["safety_wrapper"]
+    assert summary["step_count"] == 1
+    assert summary["eligible_step_count"] == 0
+    assert summary["intervened_step_count"] == 0
+    assert len(summary["step_trace"]) == 1
+    step_record = summary["step_trace"][0]
+    assert step_record["eligible_for_wrapper"] is False
+    assert step_record["ineligible_reason"] == "unsupported_command_shape"
+    assert step_record["context"] is None
+    assert record["metrics"]["wrapper_intervention_rate"] == 0.0


### PR DESCRIPTION
## Reviewer-critical summary
What changed: `map_runner_episode.py` now keeps the safety-wrapper command rewrite and wrapper trace append inside the eligible absolute-command branch. Fail-open native-action and unsupported-command branches append one ineligible provenance record and leave the original `policy_command` untouched.

Why now: issue #4180 reports a runtime-safety fail-open path where ineligible safety-wrapper branches could still fall through to eligible-branch locals and raise `UnboundLocalError`.

Claim boundary: this PR fixes only the map-runner episode-loop safety-wrapper control flow and adds adversarial fixture coverage. It does not change safety-wrapper thresholds, episode metrics semantics, benchmark claims, or paper/dissertation claim surfaces.

Required validation: focused safety-wrapper runtime tests, touched-file ruff, and full clean-head PR readiness.

Remaining blocker: none for this scoped issue slice. Claude Code on `imech156-u` owns full PR gate, improvement cycle, and merge authority after open.

## Contract delta
- New schema fields: none.
- New fail-closed blockers: none.
- Fail-open behavior fixed: native environment action and unsupported command shape ineligible paths now fail closed with provenance in the trace sense: exactly one ineligible `safety_wrapper_runtime_step.v1` record, `eligible_for_wrapper=false`, stable `ineligible_reason`, no wrapper rewrite.
- Compatibility impact: default `fail_on_native_action=true` and `fail_on_unsupported_command=true` behavior remains fail-closed by exception. Eligible absolute commands still rewrite `(linear, angular)` and append exactly one wrapper record.

## Linked Issues
- Fixes #4180
- Refs #4137
- Refs #3501

## Scope Summary
- Confines `corrected_command` and `wrapper_record` usage to the eligible safety-wrapper branch in `robot_sf/benchmark/map_runner_episode.py`.
- Extends `tests/benchmark/test_safety_wrapper_runtime.py` with adversarial fail-open native-action and unsupported-command fixtures plus trace-cardinality assertions for the eligible path.

## Validation / Proof
- `uv run pytest tests/benchmark/test_safety_wrapper_runtime.py -q` -> pass, 25 passed.
- `uv run ruff check robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_safety_wrapper_runtime.py` -> pass.
- `uv run python scripts/dev/run_compact_validation.py --timeout-seconds 1800 --json -- bash -lc 'BASE_REF=origin/main scripts/dev/pr_ready_check.sh'` -> pass, exit 0, summary: `.git/codex-agent-runs/active/compact-validation/validation-20260703T033126Z-2611077.summary.json`.
- Final clean-head readiness with this PR body: pass, exit 0, summary: `.git/codex-agent-runs/active/compact-validation/validation-20260703T033630Z-2614800.summary.json`.

## Explicit Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No safety-wrapper threshold or metric-semantics changes.

## Downstream Propagation
- Parent issue updated: no, `comment_issue_or_pr=false` authorization for this task.
- Claim map / benchmark report updated: NA, no benchmark or paper-facing claim change.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no.
- Not applicable because: this is a scoped runtime-safety bug fix plus regression tests, not an evidence-producing benchmark update. No tracked transient queue-routing state was added.

<details>
<summary>Governance appendix</summary>

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for issue #4180 runtime safety semantics.
- Comparator or baseline, applicable: current `origin/main` fail-open ineligible branches can reference eligible-branch locals.
- Evidence tier: NA - runtime safety regression proof, no research or benchmark result claim.
- Result classification: NA - runtime safety bug fix, no research result claim.
- Decision stop rule, applicable: adversarial fail-open fixtures continue without `UnboundLocalError`, emit exactly one ineligible record, default fail-closed fixtures still raise, eligible fixture still records exactly one wrapper record.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #4180 via PR link only; direct issue comment not authorized.
- New research/benchmark/metric/paper-facing analysis tool, any: NA.

## Domain-Aware Approval
- Approval concerns experimental validity and waived / pending / blocked / not required: not required; no experimental-validity claim.
- Fallback/degraded exclusions: ineligible fail-open wrapper paths are recorded as ineligible/degraded trace evidence, not eligible wrapper intervention success.
- Claim boundary: runtime safety control-flow and tests only.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, regression tests exercise native-action and unsupported-command fail-open branches.
- Did intervention change command source, selected command, trajectory, route progress? no intended change for ineligible fail-open paths; original command is preserved.
- Did scenario actually contain targeted failure mode? yes, targeted fixtures reproduce the ineligible command categories.
- Result route: stop for this scoped bug.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for this scoped fix.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: stop scoped issue slice; hand off PR gate to Claude Code on `imech156-u`.

## Risks / Rollout
- Compatibility risks: low; default fail-closed behavior and eligible rewrite behavior are covered by tests.
- Failure modes: future edits could accidentally move rewrite code back outside the eligible branch; adversarial tests guard this.
- Rollback fallback plan: revert this PR if unexpected map-runner safety-wrapper regressions appear.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #4180 and predecessor PRs #4137/#3501.
- Any assumptions need preserved: fail-open means continue episode with original command but classify wrapper evidence as ineligible, not eligible intervention.

## Follow-Up Issues
- Deferred work: NA - no follow-up issue required for this scoped runtime safety fix.
- Issues opened follow-up: NA - maintainer waiver: out-of-scope items are task-prohibited and no residual implementation work remains for this PR.

## Reviewer Notes
- Verify closely: indentation/control-flow in `map_runner_episode.py` around the safety-wrapper block.
- Known limitations: no full benchmark campaign run; this is targeted runtime-safety proof only.

</details>
