### PR TITLE
Issue #3481: add HSFM TTC-predictive pedestrian force selector

### DIFF
--- a/configs/research/hsfm_ttc_predictive_forces_issue_3481.yaml
+++ b/configs/research/hsfm_ttc_predictive_forces_issue_3481.yaml
@@ -1,0 +1,29 @@
+# HSFM + TTC predictive pedestrian-force prototype (issue #3481).
+#
+# This config records the opt-in simulator selector and modeling parameters for
+# the Phase 2 prototype. It is diagnostic/prototype metadata only, not a
+# calibrated pedestrian-realism claim or benchmark campaign definition.
+schema_version: hsfm-ttc-predictive-forces.v1
+issue: 3481
+evidence_tier: diagnostic_prototype
+claim_boundary: >-
+  Opt-in simulator force-law prototype. The default pedestrian model remains
+  unchanged. This file does not claim real-world behavioral realism, planner
+  ranking movement, or paper-facing evidence.
+pedestrian_model: hsfm_ttc_predictive_v1
+ttc_predictive_force:
+  enabled: true
+  tau0_s: 1.0
+  horizon_s: 3.0
+  force_scale: 1.0
+  max_force: 5.0
+  include_ped_ped: true
+  include_robot_proxy: false
+validation_scope:
+  focused_tests:
+    - tests/sim/test_hsfm_total_force_model.py
+    - tests/sim/test_ttc_predictive_pedestrian_model.py
+  excluded:
+    - full_benchmark_campaign
+    - slurm_or_gpu_submission
+    - paper_or_dissertation_claim_update

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -141,6 +141,11 @@ Social-Navigation-PyEnvs adapter-backed behavior variants. Current status is one
 `benchmark_valid_candidate`, one `diagnostic_only`, and four `not_available` rows; diagnostic and
 unavailable rows are not benchmark-success evidence.
 
+Recent HSFM + TTC predictive force prototype:
+[issue_3481_hsfm_ttc_predictive_forces.md](issue_3481_hsfm_ttc_predictive_forces.md)
+records the opt-in `hsfm_ttc_predictive_v1` selector, TTC parameter contract, diagnostic evidence
+boundary, and explicit no-benchmark/no-paper-claim scope.
+
 Recent heavy forecast-model study/preflight: [forecast_heavy_model_study_2026-06-20.md](forecast_heavy_model_study_2026-06-20.md)
 records the analysis-only inventory of heavy predictor families (transformer, AgentFormer-like,
 CVAE, diffusion) with literature-derived compute/latency/uncertainty/integration estimates, the

--- a/docs/context/issue_3481_hsfm_ttc_predictive_forces.md
+++ b/docs/context/issue_3481_hsfm_ttc_predictive_forces.md
@@ -1,0 +1,59 @@
+# Issue #3481: Headed Social Force Model + Time-To-Collision Predictive Pedestrian Forces
+
+This note records the Phase 2 prototype contract for issue
+[#3481](https://github.com/ll7/robot_sf_ll7/issues/3481): an opt-in Headed Social Force Model
+(HSFM) selector with Time-To-Collision (TTC) predictive pedestrian-pedestrian repulsion. It is
+diagnostic evidence only, not a calibrated realism claim.
+
+## Selector Keys
+
+- `social_force_default`: existing PySocialForce stepping path.
+- `hsfm_total_force_v1`: Phase 1 opt-in total-force HSFM stepping path.
+- `hsfm_ttc_predictive_v1`: Phase 2 opt-in total-force path plus pedestrian-pedestrian
+  time-to-collision predictive repulsion.
+
+The default pedestrian model is unchanged.
+
+## TTC Force Contract
+
+Pure helpers in `robot_sf/sim/pedestrian_model_variants.py` compute pairwise time collision from
+relative position, relative velocity, and summed pedestrian radii:
+
+```text
+||p_ij + v_ij t|| <= r_i + r_j
+```
+
+Pairs with no positive root inside `horizon_s` return `inf`. Active pairs add a bounded repulsion
+term weight:
+
+```text
+force_scale * exp(-ttc / tau0_s)
+```
+
+The per-actor sum is capped by `max_force`.
+
+## Parameters
+
+`SimulationSettings.ttc_predictive_force` stores the opt-in surface:
+
+- `tau0_s > 0`
+- `horizon_s > 0`
+- `force_scale >= 0`
+- `max_force > 0`
+- `include_ped_ped=True`
+- `include_robot_proxy=False`
+
+Robot-proxy TTC coupling intentionally fails closed when enabled because this slice does not add a
+stable robot-state injection point for pedestrian stepping.
+
+Tracked prototype metadata lives in
+`configs/research/hsfm_ttc_predictive_forces_issue_3481.yaml`.
+
+## Evidence Boundary
+
+Focused simulator tests cover finite TTC values, inactive separating pairs, monotonic force growth
+for shorter collision times, force capping, selector validation, and deterministic one-step smoke
+for `hsfm_ttc_predictive_v1`.
+
+This slice did not run a full benchmark campaign, submit Slurm/GPU work, perform external
+calibration, or edit paper/dissertation claims.

--- a/robot_sf/sim/pedestrian_model_variants.py
+++ b/robot_sf/sim/pedestrian_model_variants.py
@@ -8,7 +8,10 @@ import numpy as np
 
 SOCIAL_FORCE_DEFAULT = "social_force_default"
 HSFM_TOTAL_FORCE_V1 = "hsfm_total_force_v1"
-SUPPORTED_PEDESTRIAN_MODELS = frozenset({SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1})
+HSFM_TTC_PREDICTIVE_V1 = "hsfm_ttc_predictive_v1"
+SUPPORTED_PEDESTRIAN_MODELS = frozenset(
+    {SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1, HSFM_TTC_PREDICTIVE_V1}
+)
 
 PYSF_POSITION_SLICE = slice(0, 2)
 PYSF_VELOCITY_SLICE = slice(2, 4)
@@ -42,6 +45,169 @@ def heading_from_total_force(
     if float(np.linalg.norm(total_force)) <= epsilon:
         return float(previous_heading)
     return float(atan2(float(total_force[1]), float(total_force[0])))
+
+
+def _validate_ttc_inputs(
+    positions: np.ndarray,
+    velocities: np.ndarray,
+    radii: np.ndarray,
+    *,
+    horizon_s: float,
+    epsilon: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    position_array = np.asarray(positions, dtype=float)
+    velocity_array = np.asarray(velocities, dtype=float)
+    radius_array = np.asarray(radii, dtype=float)
+
+    if position_array.ndim != 2 or position_array.shape[1] != 2:
+        raise ValueError("positions must have shape (N, 2)")
+    if velocity_array.shape != position_array.shape:
+        raise ValueError("velocities must have shape (N, 2) matching positions")
+    if radius_array.shape != (position_array.shape[0],):
+        raise ValueError("radii must have shape (N,) matching positions")
+    if not (
+        np.all(np.isfinite(position_array))
+        and np.all(np.isfinite(velocity_array))
+        and np.all(np.isfinite(radius_array))
+    ):
+        raise ValueError("positions, velocities, and radii must be finite")
+    if np.any(radius_array < 0):
+        raise ValueError("radii must be non-negative")
+    if not np.isfinite(horizon_s) or horizon_s <= 0:
+        raise ValueError("horizon_s must be finite and > 0")
+    if not np.isfinite(epsilon) or epsilon <= 0:
+        raise ValueError("epsilon must be finite and > 0")
+
+    return position_array, velocity_array, radius_array
+
+
+def pairwise_time_to_collision(
+    positions: np.ndarray,
+    velocities: np.ndarray,
+    radii: np.ndarray,
+    *,
+    horizon_s: float,
+    epsilon: float = 1e-9,
+) -> np.ndarray:
+    """Return pairwise TTC in seconds, or ``inf`` when no collision is within horizon."""
+
+    position_array, velocity_array, radius_array = _validate_ttc_inputs(
+        positions,
+        velocities,
+        radii,
+        horizon_s=horizon_s,
+        epsilon=epsilon,
+    )
+    pedestrian_count = position_array.shape[0]
+    ttc = np.full((pedestrian_count, pedestrian_count), np.inf, dtype=float)
+
+    for i in range(pedestrian_count):
+        for j in range(pedestrian_count):
+            if i == j:
+                continue
+
+            relative_position = position_array[j] - position_array[i]
+            relative_velocity = velocity_array[j] - velocity_array[i]
+            combined_radius = radius_array[i] + radius_array[j]
+
+            a = float(np.dot(relative_velocity, relative_velocity))
+            b = 2.0 * float(np.dot(relative_position, relative_velocity))
+            c = float(np.dot(relative_position, relative_position) - combined_radius**2)
+
+            if c <= 0.0:
+                ttc[i, j] = 0.0
+                continue
+            if a <= epsilon or b >= 0.0:
+                continue
+
+            discriminant = b * b - 4.0 * a * c
+            if discriminant < 0.0:
+                continue
+
+            root = (-b - float(np.sqrt(discriminant))) / (2.0 * a)
+            if epsilon < root <= horizon_s:
+                ttc[i, j] = root
+
+    return ttc
+
+
+def _repulsion_direction(
+    relative_position: np.ndarray,
+    relative_velocity: np.ndarray,
+    *,
+    epsilon: float,
+) -> np.ndarray:
+    away = -relative_position
+    norm = float(np.linalg.norm(away))
+    if norm > epsilon:
+        return away / norm
+
+    away_from_closing_velocity = -relative_velocity
+    velocity_norm = float(np.linalg.norm(away_from_closing_velocity))
+    if velocity_norm > epsilon:
+        return away_from_closing_velocity / velocity_norm
+    return np.zeros(2, dtype=float)
+
+
+def ttc_predictive_repulsion(
+    positions: np.ndarray,
+    velocities: np.ndarray,
+    radii: np.ndarray,
+    *,
+    tau0_s: float,
+    horizon_s: float,
+    force_scale: float,
+    max_force: float,
+    epsilon: float = 1e-9,
+) -> np.ndarray:
+    """Compute bounded TTC-scaled pedestrian-pedestrian predictive repulsion.
+
+    Returns:
+        Per-pedestrian predictive force array with shape ``(N, 2)``.
+    """
+
+    if not np.isfinite(tau0_s) or tau0_s <= 0:
+        raise ValueError("tau0_s must be finite and > 0")
+    if not np.isfinite(force_scale) or force_scale < 0:
+        raise ValueError("force_scale must be finite and >= 0")
+    if not np.isfinite(max_force) or max_force <= 0:
+        raise ValueError("max_force must be finite and > 0")
+
+    position_array, velocity_array, radius_array = _validate_ttc_inputs(
+        positions,
+        velocities,
+        radii,
+        horizon_s=horizon_s,
+        epsilon=epsilon,
+    )
+    ttc = pairwise_time_to_collision(
+        position_array,
+        velocity_array,
+        radius_array,
+        horizon_s=horizon_s,
+        epsilon=epsilon,
+    )
+    repulsion = np.zeros_like(position_array, dtype=float)
+
+    for i in range(position_array.shape[0]):
+        for j in range(position_array.shape[0]):
+            if i == j or not np.isfinite(ttc[i, j]):
+                continue
+
+            relative_position = position_array[j] - position_array[i]
+            relative_velocity = velocity_array[j] - velocity_array[i]
+            direction = _repulsion_direction(
+                relative_position,
+                relative_velocity,
+                epsilon=epsilon,
+            )
+            repulsion[i] += direction * float(force_scale) * float(np.exp(-ttc[i, j] / tau0_s))
+
+    norms = np.linalg.norm(repulsion, axis=-1)
+    factors = np.ones_like(norms, dtype=float)
+    np.divide(max_force, norms, out=factors, where=norms > max_force)
+    np.minimum(factors, 1.0, out=factors)
+    return repulsion * np.expand_dims(factors, axis=-1)
 
 
 def step_hsfm_total_force(

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -1,11 +1,63 @@
 """Configuration dataclasses for simulator timing and pedestrian behavior."""
 
-from dataclasses import dataclass, field
-from math import ceil
+from dataclasses import dataclass, field, replace
+from math import ceil, isfinite
 
 from robot_sf.ped_npc.adversial_ped_force import AdversarialPedForceConfig
 from robot_sf.ped_npc.ped_robot_force import PedRobotForceConfig
-from robot_sf.sim.pedestrian_model_variants import normalize_pedestrian_model
+from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_TTC_PREDICTIVE_V1,
+    normalize_pedestrian_model,
+)
+
+
+@dataclass(frozen=True)
+class TtcPredictiveForceConfig:
+    """Opt-in TTC predictive pedestrian force parameters."""
+
+    enabled: bool = False
+    tau0_s: float = 1.0
+    horizon_s: float = 3.0
+    force_scale: float = 1.0
+    max_force: float = 5.0
+    include_ped_ped: bool = True
+    include_robot_proxy: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate finite positive predictive-force parameters."""
+        if not isfinite(self.tau0_s) or self.tau0_s <= 0:
+            raise ValueError("ttc_predictive_force.tau0_s must be > 0")
+        if not isfinite(self.horizon_s) or self.horizon_s <= 0:
+            raise ValueError("ttc_predictive_force.horizon_s must be > 0")
+        if not isfinite(self.force_scale) or self.force_scale < 0:
+            raise ValueError("ttc_predictive_force.force_scale must be >= 0")
+        if not isfinite(self.max_force) or self.max_force <= 0:
+            raise ValueError("ttc_predictive_force.max_force must be > 0")
+
+
+def _normalize_ttc_predictive_force_config(
+    value: TtcPredictiveForceConfig | dict,
+) -> TtcPredictiveForceConfig:
+    """Return a validated TTC predictive force config."""
+    if isinstance(value, TtcPredictiveForceConfig):
+        return value
+    if isinstance(value, dict):
+        return TtcPredictiveForceConfig(**value)
+    raise ValueError("ttc_predictive_force must be a TtcPredictiveForceConfig")
+
+
+def _pedestrian_model_ttc_config(
+    pedestrian_model: str,
+    ttc_config: TtcPredictiveForceConfig,
+) -> TtcPredictiveForceConfig:
+    """Enable TTC provenance when the predictive pedestrian-model selector is active.
+
+    Returns:
+        The original or selector-adjusted TTC predictive force config.
+    """
+    if pedestrian_model == HSFM_TTC_PREDICTIVE_V1 and not ttc_config.enabled:
+        return replace(ttc_config, enabled=True)
+    return ttc_config
 
 
 @dataclass
@@ -25,6 +77,9 @@ class SimulationSettings:
 
     pedestrian_model: str = "social_force_default"
     """Pedestrian dynamics model selector."""
+
+    ttc_predictive_force: TtcPredictiveForceConfig = field(default_factory=TtcPredictiveForceConfig)
+    """TTC predictive force settings used by ``hsfm_ttc_predictive_v1``."""
 
     difficulty: int = 0
     """Difficulty level"""
@@ -93,6 +148,13 @@ class SimulationSettings:
         if self.peds_speed_mult <= 0:
             raise ValueError("Pedestrian speed mustn't be negative or zero!")
         self.pedestrian_model = normalize_pedestrian_model(self.pedestrian_model)
+        self.ttc_predictive_force = _normalize_ttc_predictive_force_config(
+            self.ttc_predictive_force
+        )
+        self.ttc_predictive_force = _pedestrian_model_ttc_config(
+            self.pedestrian_model,
+            self.ttc_predictive_force,
+        )
         # Check that the maximum number of pedestrians per group is positive
         if self.max_peds_per_group <= 0:
             raise ValueError("Maximum pedestrians per group mustn't be negative or zero!")

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -53,8 +53,10 @@ from robot_sf.ped_npc.ped_zone import sample_zone
 from robot_sf.robot.robot_state import Robot
 from robot_sf.sim.pedestrian_model_variants import (
     HSFM_TOTAL_FORCE_V1,
+    HSFM_TTC_PREDICTIVE_V1,
     normalize_pedestrian_model,
     step_hsfm_total_force,
+    ttc_predictive_repulsion,
 )
 
 PYSF_POSITION_SLICE = slice(0, 2)
@@ -248,7 +250,7 @@ class Simulator:
 
     def _step_pedestrians(self, ped_forces: np.ndarray, groups: list[list[int]]) -> None:
         """Advance pedestrians through the configured pedestrian-model implementation."""
-        if self.pedestrian_model != HSFM_TOTAL_FORCE_V1:
+        if self.pedestrian_model not in {HSFM_TOTAL_FORCE_V1, HSFM_TTC_PREDICTIVE_V1}:
             self.pysf_sim.peds.step(ped_forces, groups)
             self.ped_headings = self._headings_from_current_ped_velocities()
             return
@@ -257,6 +259,23 @@ class Simulator:
         if max_speeds is None:
             raise RuntimeError("PySocialForce max_speeds are unavailable for HSFM total-force step")
         current_state = self.pysf_sim.peds.state
+        if self.pedestrian_model == HSFM_TTC_PREDICTIVE_V1:
+            ttc_config = self.config.ttc_predictive_force
+            if ttc_config.include_robot_proxy:
+                raise RuntimeError(
+                    "TTC robot proxy coupling is not implemented for pedestrian stepping"
+                )
+            if ttc_config.include_ped_ped:
+                radii = np.full(current_state.shape[0], self.config.ped_radius, dtype=float)
+                ped_forces = np.asarray(ped_forces, dtype=float) + ttc_predictive_repulsion(
+                    current_state[:, PYSF_POSITION_SLICE],
+                    current_state[:, PYSF_VELOCITY_SLICE],
+                    radii,
+                    tau0_s=ttc_config.tau0_s,
+                    horizon_s=ttc_config.horizon_s,
+                    force_scale=ttc_config.force_scale,
+                    max_force=ttc_config.max_force,
+                )
         next_state, self.ped_headings = step_hsfm_total_force(
             current_state,
             ped_forces,

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -7,7 +7,7 @@ import math
 import os
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -32,6 +32,8 @@ from robot_sf.nav.svg_map_parser import convert_map
 from robot_sf.robot.bicycle_drive import BicycleDriveSettings
 from robot_sf.robot.differential_drive import DifferentialDriveSettings
 from robot_sf.robot.holonomic_drive import HolonomicDriveSettings
+from robot_sf.sim.pedestrian_model_variants import HSFM_TTC_PREDICTIVE_V1
+from robot_sf.sim.sim_config import TtcPredictiveForceConfig
 
 _MAP_REGISTRY_ENV = "ROBOT_SF_MAP_REGISTRY"
 _MAP_REGISTRY_PATH = Path("maps/registry.yaml")
@@ -2073,6 +2075,27 @@ def _apply_single_pedestrian_override(
     )
 
 
+def _set_simulation_override_attr(
+    config: RobotSimulationConfig,
+    attr: str,
+    overrides: Mapping[str, Any],
+) -> None:
+    """Apply one scenario-level simulation override attribute."""
+    if attr == "ttc_predictive_force" and isinstance(overrides[attr], Mapping):
+        ttc_force_overrides = dict(overrides[attr])
+        if overrides.get("pedestrian_model") == HSFM_TTC_PREDICTIVE_V1:
+            ttc_force_overrides["enabled"] = True
+        setattr(config.sim_config, attr, TtcPredictiveForceConfig(**ttc_force_overrides))
+    elif attr == "pedestrian_model" and overrides[attr] == HSFM_TTC_PREDICTIVE_V1:
+        setattr(config.sim_config, attr, overrides[attr])
+        config.sim_config.ttc_predictive_force = replace(
+            config.sim_config.ttc_predictive_force,
+            enabled=True,
+        )
+    else:
+        setattr(config.sim_config, attr, overrides[attr])
+
+
 def _apply_simulation_overrides(
     config: RobotSimulationConfig,
     overrides: Mapping[str, Any] | None,
@@ -2100,6 +2123,7 @@ def _apply_simulation_overrides(
         "ped_radius",
         "goal_radius",
         "pedestrian_model",
+        "ttc_predictive_force",
         "route_spawn_distribution",
         "route_spawn_jitter_frac",
         "route_spawn_seed",
@@ -2108,7 +2132,7 @@ def _apply_simulation_overrides(
         "archetype_seed",
     ):
         if attr in overrides:
-            setattr(config.sim_config, attr, overrides[attr])
+            _set_simulation_override_attr(config, attr, overrides)
 
 
 def _apply_map_pool(

--- a/tests/sim/test_hsfm_total_force_model.py
+++ b/tests/sim/test_hsfm_total_force_model.py
@@ -9,6 +9,7 @@ import pytest
 
 from robot_sf.sim.pedestrian_model_variants import (
     HSFM_TOTAL_FORCE_V1,
+    HSFM_TTC_PREDICTIVE_V1,
     SOCIAL_FORCE_DEFAULT,
     heading_from_total_force,
     normalize_pedestrian_model,
@@ -90,6 +91,9 @@ def test_pedestrian_model_selector_normalizes_and_rejects_unknown_values() -> No
     assert SimulationSettings().pedestrian_model == SOCIAL_FORCE_DEFAULT
     assert SimulationSettings(pedestrian_model=HSFM_TOTAL_FORCE_V1).pedestrian_model == (
         HSFM_TOTAL_FORCE_V1
+    )
+    assert SimulationSettings(pedestrian_model=HSFM_TTC_PREDICTIVE_V1).pedestrian_model == (
+        HSFM_TTC_PREDICTIVE_V1
     )
     assert normalize_pedestrian_model(None) == SOCIAL_FORCE_DEFAULT
     with pytest.raises(ValueError, match="Unsupported pedestrian_model"):

--- a/tests/sim/test_ttc_predictive_pedestrian_model.py
+++ b/tests/sim/test_ttc_predictive_pedestrian_model.py
@@ -1,0 +1,323 @@
+"""Tests for the opt-in HSFM + TTC predictive pedestrian force variant."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_TTC_PREDICTIVE_V1,
+    pairwise_time_to_collision,
+    ttc_predictive_repulsion,
+)
+from robot_sf.sim.sim_config import SimulationSettings, TtcPredictiveForceConfig
+from robot_sf.sim.simulator import Simulator
+from robot_sf.training.scenario_loader import build_robot_config_from_scenario
+
+
+class _FakePedState:
+    def __init__(self, state: np.ndarray) -> None:
+        self.state = state
+        self.max_speeds = np.full(state.shape[0], 10.0, dtype=float)
+        self.updated_state: np.ndarray | None = None
+        self.updated_groups: list[list[int]] | None = None
+
+    def update(self, state: np.ndarray, groups: list[list[int]]) -> None:
+        self.updated_state = state.copy()
+        self.updated_groups = groups
+
+
+def test_pairwise_time_to_collision_finite_for_closing_and_inf_for_separating() -> None:
+    """Closing pedestrians report TTC; separating pedestrians are inactive."""
+    positions = np.array([[0.0, 0.0], [2.0, 0.0]], dtype=float)
+    radii = np.array([0.2, 0.2], dtype=float)
+
+    closing = np.array([[0.5, 0.0], [-0.5, 0.0]], dtype=float)
+    separating = -closing
+
+    ttc = pairwise_time_to_collision(positions, closing, radii, horizon_s=5.0)
+    assert ttc[0, 1] == pytest.approx(1.6)
+    assert ttc[1, 0] == pytest.approx(1.6)
+
+    separating_ttc = pairwise_time_to_collision(positions, separating, radii, horizon_s=5.0)
+    assert np.isinf(separating_ttc[0, 1])
+    assert np.isinf(separating_ttc[1, 0])
+
+
+def test_pairwise_time_to_collision_rejects_invalid_inputs() -> None:
+    """TTC math fails closed on malformed or non-finite inputs."""
+    positions = np.array([[0.0, 0.0], [2.0, 0.0]], dtype=float)
+    velocities = np.array([[0.5, 0.0], [-0.5, 0.0]], dtype=float)
+    radii = np.array([0.2, 0.2], dtype=float)
+
+    with pytest.raises(ValueError, match="positions"):
+        pairwise_time_to_collision(np.zeros((2, 3)), velocities, radii, horizon_s=5.0)
+    with pytest.raises(ValueError, match="velocities"):
+        pairwise_time_to_collision(positions, np.zeros((3, 2)), radii, horizon_s=5.0)
+    with pytest.raises(ValueError, match="radii"):
+        pairwise_time_to_collision(positions, velocities, np.array([0.2]), horizon_s=5.0)
+    with pytest.raises(ValueError, match="finite"):
+        pairwise_time_to_collision(
+            np.array([[0.0, 0.0], [np.nan, 0.0]]),
+            velocities,
+            radii,
+            horizon_s=5.0,
+        )
+    with pytest.raises(ValueError, match="non-negative"):
+        pairwise_time_to_collision(positions, velocities, np.array([0.2, -0.1]), horizon_s=5.0)
+    with pytest.raises(ValueError, match="horizon_s"):
+        pairwise_time_to_collision(positions, velocities, radii, horizon_s=0.0)
+    with pytest.raises(ValueError, match="epsilon"):
+        pairwise_time_to_collision(positions, velocities, radii, horizon_s=5.0, epsilon=0.0)
+
+
+def test_pairwise_time_to_collision_returns_inf_when_paths_miss() -> None:
+    """Closing relative motion that misses the summed radii stays inactive."""
+    ttc = pairwise_time_to_collision(
+        np.array([[0.0, 0.0], [2.0, 1.0]], dtype=float),
+        np.array([[0.5, 0.0], [-0.5, 0.0]], dtype=float),
+        np.array([0.2, 0.2], dtype=float),
+        horizon_s=5.0,
+    )
+
+    assert np.isinf(ttc[0, 1])
+    assert np.isinf(ttc[1, 0])
+
+
+def test_ttc_predictive_repulsion_grows_as_collision_time_decreases() -> None:
+    """Nearer TTC produces stronger bounded repulsion."""
+    positions = np.array([[0.0, 0.0], [2.0, 0.0]], dtype=float)
+    radii = np.array([0.2, 0.2], dtype=float)
+    slow_closing = np.array([[0.25, 0.0], [-0.25, 0.0]], dtype=float)
+    fast_closing = np.array([[0.75, 0.0], [-0.75, 0.0]], dtype=float)
+
+    slow_force = ttc_predictive_repulsion(
+        positions,
+        slow_closing,
+        radii,
+        tau0_s=1.0,
+        horizon_s=5.0,
+        force_scale=2.0,
+        max_force=10.0,
+    )
+    fast_force = ttc_predictive_repulsion(
+        positions,
+        fast_closing,
+        radii,
+        tau0_s=1.0,
+        horizon_s=5.0,
+        force_scale=2.0,
+        max_force=10.0,
+    )
+
+    assert np.linalg.norm(fast_force[0]) > np.linalg.norm(slow_force[0])
+    assert fast_force[0, 0] < 0.0
+    assert fast_force[1, 0] > 0.0
+
+
+def test_ttc_predictive_repulsion_zero_for_no_collision_and_respects_cap() -> None:
+    """No-collision actors stay inactive; active force is capped per actor."""
+    positions = np.array([[0.0, 0.0], [2.0, 0.0]], dtype=float)
+    radii = np.array([0.2, 0.2], dtype=float)
+    separating = np.array([[-0.5, 0.0], [0.5, 0.0]], dtype=float)
+
+    zero_force = ttc_predictive_repulsion(
+        positions,
+        separating,
+        radii,
+        tau0_s=1.0,
+        horizon_s=5.0,
+        force_scale=100.0,
+        max_force=0.25,
+    )
+    assert np.allclose(zero_force, 0.0)
+
+    capped_force = ttc_predictive_repulsion(
+        positions,
+        -separating,
+        radii,
+        tau0_s=10.0,
+        horizon_s=5.0,
+        force_scale=100.0,
+        max_force=0.25,
+    )
+    assert np.max(np.linalg.norm(capped_force, axis=-1)) <= 0.25 + 1e-9
+
+
+def test_ttc_predictive_repulsion_handles_overlapping_degenerate_directions() -> None:
+    """Overlapping actors use velocity fallback or zero vector without non-finite force."""
+    positions = np.array([[0.0, 0.0], [0.0, 0.0]], dtype=float)
+    radii = np.array([0.2, 0.2], dtype=float)
+
+    velocity_fallback_force = ttc_predictive_repulsion(
+        positions,
+        np.array([[1.0, 0.0], [0.0, 0.0]], dtype=float),
+        radii,
+        tau0_s=1.0,
+        horizon_s=5.0,
+        force_scale=1.0,
+        max_force=5.0,
+    )
+    assert np.all(np.isfinite(velocity_fallback_force))
+    assert velocity_fallback_force[0, 0] > 0.0
+
+    zero_force = ttc_predictive_repulsion(
+        positions,
+        np.zeros((2, 2), dtype=float),
+        radii,
+        tau0_s=1.0,
+        horizon_s=5.0,
+        force_scale=1.0,
+        max_force=5.0,
+    )
+    assert np.allclose(zero_force, 0.0)
+
+
+def test_ttc_predictive_repulsion_rejects_invalid_parameters() -> None:
+    """Predictive-force parameters fail closed before simulator integration."""
+    positions = np.array([[0.0, 0.0], [2.0, 0.0]], dtype=float)
+    velocities = np.array([[0.5, 0.0], [-0.5, 0.0]], dtype=float)
+    radii = np.array([0.2, 0.2], dtype=float)
+
+    with pytest.raises(ValueError, match="tau0_s"):
+        ttc_predictive_repulsion(
+            positions,
+            velocities,
+            radii,
+            tau0_s=0.0,
+            horizon_s=5.0,
+            force_scale=1.0,
+            max_force=5.0,
+        )
+    with pytest.raises(ValueError, match="force_scale"):
+        ttc_predictive_repulsion(
+            positions,
+            velocities,
+            radii,
+            tau0_s=1.0,
+            horizon_s=5.0,
+            force_scale=-1.0,
+            max_force=5.0,
+        )
+    with pytest.raises(ValueError, match="max_force"):
+        ttc_predictive_repulsion(
+            positions,
+            velocities,
+            radii,
+            tau0_s=1.0,
+            horizon_s=5.0,
+            force_scale=1.0,
+            max_force=0.0,
+        )
+
+
+def test_ttc_config_validates_and_scenario_can_select_predictive_model(tmp_path) -> None:
+    """Scenario config can opt into the TTC predictive selector and parameters."""
+    with pytest.raises(ValueError, match="tau0_s"):
+        TtcPredictiveForceConfig(tau0_s=0.0)
+    with pytest.raises(ValueError, match="force_scale"):
+        TtcPredictiveForceConfig(force_scale=-0.1)
+    with pytest.raises(ValueError, match="Unsupported pedestrian_model"):
+        SimulationSettings(pedestrian_model="unknown_model")
+
+    config = build_robot_config_from_scenario(
+        {
+            "simulation_config": {
+                "pedestrian_model": HSFM_TTC_PREDICTIVE_V1,
+                "ttc_predictive_force": {"tau0_s": 0.75, "force_scale": 1.5},
+            }
+        },
+        scenario_path=tmp_path / "scenario.yaml",
+    )
+
+    assert config.sim_config.pedestrian_model == HSFM_TTC_PREDICTIVE_V1
+    assert config.sim_config.ttc_predictive_force.enabled is True
+    assert config.sim_config.ttc_predictive_force.tau0_s == pytest.approx(0.75)
+    assert config.sim_config.ttc_predictive_force.force_scale == pytest.approx(1.5)
+
+
+def test_scenario_predictive_selector_marks_default_ttc_config_enabled(tmp_path) -> None:
+    """Selecting the predictive model alone still records active TTC provenance."""
+    config = build_robot_config_from_scenario(
+        {"simulation_config": {"pedestrian_model": HSFM_TTC_PREDICTIVE_V1}},
+        scenario_path=tmp_path / "scenario.yaml",
+    )
+
+    assert config.sim_config.pedestrian_model == HSFM_TTC_PREDICTIVE_V1
+    assert config.sim_config.ttc_predictive_force.enabled is True
+
+
+def test_scenario_predictive_selector_overrides_stale_disabled_ttc_flag(tmp_path) -> None:
+    """The selector is the activation surface, so provenance cannot stay disabled."""
+    config = build_robot_config_from_scenario(
+        {
+            "simulation_config": {
+                "pedestrian_model": HSFM_TTC_PREDICTIVE_V1,
+                "ttc_predictive_force": {"enabled": False},
+            }
+        },
+        scenario_path=tmp_path / "scenario.yaml",
+    )
+
+    assert config.sim_config.pedestrian_model == HSFM_TTC_PREDICTIVE_V1
+    assert config.sim_config.ttc_predictive_force.enabled is True
+
+
+def test_hsfm_ttc_predictive_one_step_smoke_is_finite_and_deterministic() -> None:
+    """The new selector adds a finite deterministic TTC force before HSFM stepping."""
+    state = np.array(
+        [
+            [0.0, 0.0, 0.5, 0.0, 10.0, 0.0, 0.5],
+            [2.0, 0.0, -0.5, 0.0, -10.0, 0.0, 0.5],
+        ],
+        dtype=float,
+    )
+    peds = _FakePedState(state)
+    sim = object.__new__(Simulator)
+    sim.pedestrian_model = HSFM_TTC_PREDICTIVE_V1
+    sim.pysf_sim = SimpleNamespace(peds=peds)
+    sim.config = SimulationSettings(
+        pedestrian_model=HSFM_TTC_PREDICTIVE_V1,
+        ttc_predictive_force=TtcPredictiveForceConfig(
+            tau0_s=10.0,
+            horizon_s=5.0,
+            force_scale=1.0,
+            max_force=2.0,
+        ),
+    )
+    sim.ped_headings = np.array([0.0, np.pi], dtype=float)
+
+    sim._step_pedestrians(np.zeros((2, 2), dtype=float), [[0], [1]])
+
+    assert peds.updated_groups == [[0], [1]]
+    assert peds.updated_state is not None
+    assert np.all(np.isfinite(peds.updated_state))
+    assert np.all(np.isfinite(sim.ped_headings))
+    assert peds.updated_state[0, 0] < 0.05
+    assert peds.updated_state[1, 0] > 1.95
+
+
+def test_hsfm_ttc_predictive_robot_proxy_fails_closed() -> None:
+    """Robot-proxy TTC coupling is explicit future work, not silent behavior."""
+    peds = _FakePedState(
+        np.array(
+            [
+                [0.0, 0.0, 0.5, 0.0, 10.0, 0.0, 0.5],
+                [2.0, 0.0, -0.5, 0.0, -10.0, 0.0, 0.5],
+            ],
+            dtype=float,
+        )
+    )
+    sim = object.__new__(Simulator)
+    sim.pedestrian_model = HSFM_TTC_PREDICTIVE_V1
+    sim.pysf_sim = SimpleNamespace(peds=peds)
+    sim.config = SimulationSettings(
+        pedestrian_model=HSFM_TTC_PREDICTIVE_V1,
+        ttc_predictive_force=TtcPredictiveForceConfig(include_robot_proxy=True),
+    )
+    sim.ped_headings = np.array([0.0, np.pi], dtype=float)
+
+    with pytest.raises(RuntimeError, match="robot proxy coupling is not implemented"):
+        sim._step_pedestrians(np.zeros((2, 2), dtype=float), [[0], [1]])


### PR DESCRIPTION
## Reviewer-critical Summary

What changed: Adds `hsfm_ttc_predictive_v1`, an opt-in Headed Social Force Model (HSFM) pedestrian selector that reuses the Phase 1 total-force stepping path and adds bounded Time-To-Collision (TTC) pedestrian-pedestrian predictive repulsion.

Why now: Issue #3481 Phase 2 follows the merged HSFM selector path from PR #4144; this is the nameable TTC-predictive capability slice, not another guardrail-only micro-PR.

Claim boundary: Diagnostic/prototype simulator behavior only. This PR does not claim calibrated pedestrian realism, planner ranking movement, or paper-facing evidence.

Required validation: focused simulator tests for TTC math, selector/config validation, fail-closed robot-proxy handling, and deterministic one-step smoke; final PR readiness gate.

Remaining blocker: pedestrian-robot TTC coupling and narrow-passage/bottleneck benchmark evidence remain follow-up work.

## Contract Delta

New schema/config fields:

- `SimulationSettings.ttc_predictive_force: TtcPredictiveForceConfig`
- `TtcPredictiveForceConfig.enabled`
- `TtcPredictiveForceConfig.tau0_s`
- `TtcPredictiveForceConfig.horizon_s`
- `TtcPredictiveForceConfig.force_scale`
- `TtcPredictiveForceConfig.max_force`
- `TtcPredictiveForceConfig.include_ped_ped`
- `TtcPredictiveForceConfig.include_robot_proxy`

New selector:

- `hsfm_ttc_predictive_v1`

New fail-closed blockers:

- Unsupported `pedestrian_model` values still raise `ValueError`.
- Non-finite or out-of-range TTC parameters raise `ValueError`.
- `include_robot_proxy=True` raises at simulator step time because this slice does not add a stable robot-state injection point for pedestrian stepping.

Compatibility impact:

- `social_force_default` remains the default PySocialForce path.
- `hsfm_total_force_v1` remains the Phase 1 total-force path.
- TTC predictive forces are opt-in through `hsfm_ttc_predictive_v1`.

## Summary

Implements the Phase 2 TTC-predictive pedestrian force term for #3481 as an opt-in extension of the landed HSFM selector path.

## Linked Issues

- Relates `#3481`

## What Changed

- Added pure TTC helpers for pairwise time-to-collision and bounded predictive pedestrian-pedestrian repulsion.
- Added `TtcPredictiveForceConfig` and scenario-loader wiring for `ttc_predictive_force`.
- Integrated `hsfm_ttc_predictive_v1` into simulator pedestrian stepping by adding TTC force before the HSFM total-force update.
- Added diagnostic prototype metadata and a context note with the no-benchmark/no-paper-claim boundary.
- Added focused simulator tests for TTC math, config validation, selector behavior, fail-closed robot-proxy handling, and deterministic one-step smoke.

## Validation / Proof

- `uv run pytest tests/sim/test_hsfm_total_force_model.py tests/sim/test_ttc_predictive_pedestrian_model.py -q` — passed, 18 tests.
- `uv run ruff check robot_sf/sim robot_sf/training/scenario_loader.py tests/sim/test_hsfm_total_force_model.py tests/sim/test_ttc_predictive_pedestrian_model.py` — passed.
- `uv run ruff format --check robot_sf/sim/pedestrian_model_variants.py robot_sf/sim/sim_config.py robot_sf/sim/simulator.py robot_sf/training/scenario_loader.py tests/sim/test_hsfm_total_force_model.py tests/sim/test_ttc_predictive_pedestrian_model.py` — passed.
- `uv run python -m py_compile robot_sf/sim/pedestrian_model_variants.py robot_sf/sim/sim_config.py robot_sf/sim/simulator.py robot_sf/training/scenario_loader.py tests/sim/test_ttc_predictive_pedestrian_model.py` — passed.
- `uv run python - <<'PY' ... yaml.safe_load('configs/research/hsfm_ttc_predictive_forces_issue_3481.yaml') ... PY` — passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/validation/pr_ready/issue_3481_pr_body.md scripts/dev/pr_ready_check.sh` — passed; final stamp `output/validation/pr_ready/issue-3481-research-hsfm-ttc-predictive-pedestrian-forces-phase-2.json`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: Adds the issue #3481 Phase 2 force-law prototype needed before later narrow-passage and bottleneck evidence can be gathered.
- Comparator or baseline, applicable: `social_force_default` and `hsfm_total_force_v1` remain available; this PR does not run a benchmark comparison.
- Evidence tier: targeted smoke / diagnostic prototype.
- Result classification: diagnostic-only capability slice.
- Decision stop rule, applicable: Stop at opt-in selector, parameter validation, deterministic simulator smoke, and explicit no-claim boundary.
- Parent issue, claim map, registry, context note, synthesis surface update: `docs/context/issue_3481_hsfm_ttc_predictive_forces.md` plus `docs/context/INDEX.md`.
- New research/benchmark/metric/paper-facing analysis tool, any: NA, this is a simulator behavior prototype and not an analysis tool.

## Domain-Aware Approval

- Required for PR: required, because this is a research-labeled simulator-force implementation with diagnostic evidence wording.
- Domains reviewed: simulation realism, pedestrian force-law prototype, benchmark-claim boundary.
- Status: waived for this implementation slice.
- Approval or blocker note: Maintainer issue guidance authorizes a smallest code/test slice and explicitly excludes benchmark campaigns and paper/dissertation claim edits; this PR keeps that boundary.
- Target claim/hypothesis: capability exists and is executable, not that it improves realism or planner outcomes.
- Comparator or split/evidence validity: no comparator result claimed.
- Fallback/degraded exclusions: no fallback/degraded benchmark rows produced.
- Claim boundary: diagnostic/prototype only.
- Implementation integrity vs experimental validity: implementation is tested through focused simulator checks; experimental validity remains future work.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, focused one-step smoke exercises the selector and TTC force path.
- Did intervention change command source, selected command, trajectory, route progress? selected pedestrian stepping path only; planner trajectory not evaluated.
- Did scenario actually contain targeted failure mode? no, this PR uses controlled simulator/unit smoke, not narrow-passage or bottleneck benchmark fixtures.
- Result route: continue with follow-up benchmark-sensitive fixtures/campaigns.
- Follow-up question issue weak, negative, non-transfer results: issue #3481 remains open for benchmark evidence and pedestrian-robot coupling follow-up.

## Next Empirical Action

- Rerun needed: yes, later narrow-passage and bottleneck diagnostic fixtures/campaigns.
- Extractor analysis tool needed: no for this slice.
- Artifact missing unavailable: benchmark evidence not produced by design.
- Stop / revise / continue decision: continue after review with empirical fixture/campaign follow-up.
- Proposed child issue existing follow-up: issue #3481 remains the parent tracking surface.

## Risks / Rollout

- Compatibility risks: scenario configs can now set a nested `ttc_predictive_force`; invalid values fail early.
- Failure modes: overly large force settings can alter pedestrian stepping sharply, bounded by `max_force`; robot-proxy coupling is intentionally not silent.
- Rollback fallback plan: use `social_force_default` or `hsfm_total_force_v1`; revert this commit if the opt-in selector causes regressions.

## Docs / Provenance

- Updated docs: `docs/context/issue_3481_hsfm_ttc_predictive_forces.md`, `docs/context/INDEX.md`.
- Relevant design provenance notes: issue #3481 maintainer comment from 2026-07-02.
- Any assumptions need to preserved: TTC is pedestrian-pedestrian only in this slice; `include_robot_proxy` is a fail-closed future seam.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no; comments disabled by task authorization. This PR body is the propagation surface for this low-churn capability slice.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): yes, tracked prototype config added under `configs/research/`.
- Context index / memory note updated (yes/no/NA): yes, `docs/context/INDEX.md`.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark, leaderboard, paper-facing, or claim-map result is produced.

<details>
<summary>Appendix: scope and governance notes</summary>

Fragmentation guard: no open PR covers issue #3481; no issue #3481 guardrail/checker/packet-refresh PRs merged in the last 24 hours were found. This PR is exempt regardless because it adds the nameable `hsfm_ttc_predictive_v1` capability from the issue implementation plan.

Late-guidance guard: issue #3481 was checked before implementation; it must be checked again immediately before PR open for maintainer comments newer than the start time.

Forbidden actions: no compute submission, merge, release, delete, full benchmark campaign, Slurm/GPU submission, or paper/dissertation claim edit.

</details>
