### PR TITLE
Enforce hybrid global RL waypoint distance (#4182)

### DIFF
--- a/robot_sf/planner/hybrid_global_rl.py
+++ b/robot_sf/planner/hybrid_global_rl.py
@@ -189,15 +189,25 @@ class HybridGlobalRLLocalAdapter:
             waypoint_distance_from_robot = None
         else:
             waypoint = decision.waypoint
-            robot_position = self._extract_robot_position(observation)
             waypoint_distance_from_robot = None
-            if robot_position is not None:
+            waypoint_array = np.asarray(waypoint, dtype=float)
+            if waypoint_array.shape != (2,) or not np.all(np.isfinite(waypoint_array)):
+                decision = WaypointDecision(
+                    status="rejected",
+                    waypoint=decision.waypoint,
+                    source=decision.source,
+                    reason="route_waypoint_non_finite",
+                    route_geometry=decision.route_geometry,
+                )
+
+            robot_position = self._extract_robot_position(observation)
+            if decision.status != "rejected" and robot_position is not None:
                 waypoint_distance_from_robot = hypot(
                     float(waypoint[0]) - robot_position[0],
                     float(waypoint[1]) - robot_position[1],
                 )
 
-            if robot_position is None:
+            if decision.status != "rejected" and robot_position is None:
                 decision = WaypointDecision(
                     status="rejected",
                     waypoint=decision.waypoint,
@@ -205,7 +215,10 @@ class HybridGlobalRLLocalAdapter:
                     reason="route_waypoint_robot_position_missing",
                     route_geometry=decision.route_geometry,
                 )
-            elif waypoint_distance_from_robot > self.config.waypoint_max_distance_from_robot:
+            if (
+                waypoint_distance_from_robot is not None
+                and waypoint_distance_from_robot > self.config.waypoint_max_distance_from_robot
+            ):
                 decision = WaypointDecision(
                     status="rejected",
                     waypoint=decision.waypoint,

--- a/robot_sf/planner/hybrid_global_rl.py
+++ b/robot_sf/planner/hybrid_global_rl.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from math import atan2, cos, sin
+from math import atan2, cos, hypot, isfinite, sin
 from typing import Any, Protocol
 
 import numpy as np
@@ -34,6 +34,13 @@ class HybridGlobalRLLocalConfig:
     waypoint_max_distance_from_robot: float = 3.0
     max_linear_speed: float = 1.0
     max_angular_speed: float = 1.0
+
+    def __post_init__(self) -> None:
+        """Validate the advertised route-waypoint distance contract."""
+
+        max_distance = float(self.waypoint_max_distance_from_robot)
+        if not isfinite(max_distance) or max_distance <= 0.0:
+            raise ValueError("waypoint_max_distance_from_robot must be finite and positive")
 
 
 @dataclass(frozen=True)
@@ -178,19 +185,68 @@ class HybridGlobalRLLocalAdapter:
             conditioned_observation = deepcopy(observation)
             fallback_status = "goal_fallback"
             waypoint = self._extract_final_goal(conditioned_observation)
+            conditioned = False
+            waypoint_distance_from_robot = None
         else:
             waypoint = decision.waypoint
-            conditioned_observation = self._inject_waypoint_goal(observation, waypoint)
-            fallback_status = "none"
+            robot_position = self._extract_robot_position(observation)
+            waypoint_distance_from_robot = None
+            if robot_position is not None:
+                waypoint_distance_from_robot = hypot(
+                    float(waypoint[0]) - robot_position[0],
+                    float(waypoint[1]) - robot_position[1],
+                )
+
+            if robot_position is None:
+                decision = WaypointDecision(
+                    status="rejected",
+                    waypoint=decision.waypoint,
+                    source=decision.source,
+                    reason="route_waypoint_robot_position_missing",
+                    route_geometry=decision.route_geometry,
+                )
+            elif waypoint_distance_from_robot > self.config.waypoint_max_distance_from_robot:
+                decision = WaypointDecision(
+                    status="rejected",
+                    waypoint=decision.waypoint,
+                    source=decision.source,
+                    reason="route_waypoint_too_far",
+                    route_geometry=decision.route_geometry,
+                )
+
+            if decision.status == "rejected":
+                if (
+                    not self.config.allow_goal_fallback
+                    and self.config.fail_closed_on_missing_waypoint
+                ):
+                    self._last_diagnostics = self._diagnostics_payload(
+                        decision=decision,
+                        conditioned=False,
+                        action_conversion_mode="not_run",
+                        fallback_status="fail_closed",
+                        waypoint_distance_from_robot=waypoint_distance_from_robot,
+                    )
+                    raise RuntimeError(
+                        f"hybrid_global_rl route waypoint rejected: {decision.reason}"
+                    )
+                conditioned_observation = deepcopy(observation)
+                fallback_status = "goal_fallback"
+                waypoint = self._extract_final_goal(conditioned_observation)
+                conditioned = False
+            else:
+                conditioned_observation = self._inject_waypoint_goal(observation, waypoint)
+                fallback_status = "none"
+                conditioned = True
 
         action = self.local_policy.step(conditioned_observation)
         linear, angular, conversion_mode = self._action_to_unicycle(action, conditioned_observation)
         self._last_diagnostics = self._diagnostics_payload(
             decision=decision,
-            conditioned=decision.waypoint is not None,
+            conditioned=conditioned,
             action_conversion_mode=conversion_mode,
             fallback_status=fallback_status,
             injected_waypoint=waypoint,
+            waypoint_distance_from_robot=waypoint_distance_from_robot,
         )
         return linear, angular
 
@@ -202,6 +258,7 @@ class HybridGlobalRLLocalAdapter:
         action_conversion_mode: str,
         fallback_status: str,
         injected_waypoint: tuple[float, float] | None = None,
+        waypoint_distance_from_robot: float | None = None,
     ) -> dict[str, Any]:
         """Build JSON-ready diagnostics for the last planner decision.
 
@@ -215,6 +272,8 @@ class HybridGlobalRLLocalAdapter:
             "waypoint_status": decision.status,
             "waypoint_reason": decision.reason,
             "waypoint": list(injected_waypoint) if injected_waypoint is not None else None,
+            "waypoint_distance_from_robot": waypoint_distance_from_robot,
+            "waypoint_max_distance_from_robot": self.config.waypoint_max_distance_from_robot,
             "route_geometry": decision.route_geometry,
             "fallback_status": fallback_status,
             "action_conversion_mode": action_conversion_mode,
@@ -261,6 +320,25 @@ class HybridGlobalRLLocalAdapter:
                 candidate = goal.get("next")
         if candidate is None:
             candidate = observation.get("goal_current")
+        if candidate is None:
+            return None
+        arr = np.asarray(candidate, dtype=float).reshape(-1)
+        if arr.size < 2 or not np.all(np.isfinite(arr[:2])):
+            return None
+        return (float(arr[0]), float(arr[1]))
+
+    @staticmethod
+    def _extract_robot_position(observation: dict[str, Any]) -> tuple[float, float] | None:
+        """Extract robot position from supported dict observation shapes.
+
+        Returns:
+            Two-dimensional finite robot position, or ``None`` when unavailable.
+        """
+
+        candidate: Any | None = observation.get("robot_position")
+        robot = observation.get("robot")
+        if candidate is None and isinstance(robot, dict):
+            candidate = robot.get("position")
         if candidate is None:
             return None
         arr = np.asarray(candidate, dtype=float).reshape(-1)

--- a/tests/planner/test_hybrid_global_rl.py
+++ b/tests/planner/test_hybrid_global_rl.py
@@ -58,7 +58,9 @@ def test_route_waypoint_is_injected_into_nested_goal_current() -> None:
         local_policy=local_policy,
     )
 
-    command = adapter.plan({"goal": {"current": [9.0, 0.0]}, "robot": {"heading": 0.0}})
+    command = adapter.plan(
+        {"goal": {"current": [9.0, 0.0]}, "robot": {"heading": 0.0, "position": [0.0, 0.0]}}
+    )
 
     assert command == (0.4, 0.1)
     assert local_policy.seen[0]["goal"]["current"] == [1.5, 0.25]
@@ -76,7 +78,7 @@ def test_route_waypoint_handles_array_goal_without_ambiguous_truth_value() -> No
     adapter.plan(
         {
             "goal": {"current": np.asarray([9.0, 0.0], dtype=float)},
-            "robot": {"heading": 0.0},
+            "robot": {"heading": 0.0, "position": [0.0, 0.0]},
         }
     )
 
@@ -91,7 +93,7 @@ def test_route_waypoint_initializes_missing_goal_dict() -> None:
         local_policy=local_policy,
     )
 
-    adapter.plan({"goal": None, "robot": {"heading": 0.0}})
+    adapter.plan({"goal": None, "robot": {"heading": 0.0, "position": [0.0, 0.0]}})
 
     assert local_policy.seen[0]["goal"]["current"] == [1.5, 0.25]
     assert "goal_current" not in local_policy.seen[0]
@@ -104,10 +106,96 @@ def test_route_waypoint_is_injected_into_flat_goal_current() -> None:
         local_policy=local_policy,
     )
 
-    adapter.plan({"goal_current": [3.0, 4.0], "robot_heading": 0.0})
+    adapter.plan({"goal_current": [3.0, 4.0], "robot_position": [0.0, 0.0], "robot_heading": 0.0})
 
     assert local_policy.seen[0]["goal_current"] == [0.75, -0.5]
     assert local_policy.seen[0]["hybrid_global_rl_final_goal"] == (3.0, 4.0)
+
+
+def test_route_waypoint_within_configured_distance_is_accepted() -> None:
+    local_policy = _LocalPolicy()
+    adapter = HybridGlobalRLLocalAdapter(
+        config=HybridGlobalRLLocalConfig(waypoint_max_distance_from_robot=2.0),
+        waypoint_provider=_WaypointProvider((1.5, 0.0)),
+        local_policy=local_policy,
+    )
+
+    adapter.plan({"goal_current": [3.0, 4.0], "robot_position": [0.0, 0.0]})
+
+    diagnostics = adapter.diagnostics()
+    assert local_policy.seen[0]["goal_current"] == [1.5, 0.0]
+    assert diagnostics["waypoint_status"] == "ok"
+    assert diagnostics["fallback_status"] == "none"
+    assert diagnostics["waypoint_reason"] is None
+    assert math.isclose(diagnostics["waypoint_distance_from_robot"], 1.5)
+    assert diagnostics["waypoint_max_distance_from_robot"] == 2.0
+
+
+def test_route_waypoint_beyond_configured_distance_fails_closed_by_default() -> None:
+    local_policy = _LocalPolicy()
+    adapter = HybridGlobalRLLocalAdapter(
+        config=HybridGlobalRLLocalConfig(waypoint_max_distance_from_robot=1.0),
+        waypoint_provider=_WaypointProvider((1.5, 0.0)),
+        local_policy=local_policy,
+    )
+
+    with pytest.raises(RuntimeError, match="route_waypoint_too_far"):
+        adapter.plan({"goal_current": [3.0, 4.0], "robot_position": [0.0, 0.0]})
+
+    diagnostics = adapter.diagnostics()
+    assert local_policy.seen == []
+    assert diagnostics["status"] == "failed"
+    assert diagnostics["waypoint_status"] == "rejected"
+    assert diagnostics["waypoint_reason"] == "route_waypoint_too_far"
+    assert diagnostics["fallback_status"] == "fail_closed"
+    assert math.isclose(diagnostics["waypoint_distance_from_robot"], 1.5)
+    assert diagnostics["waypoint_max_distance_from_robot"] == 1.0
+
+
+def test_route_waypoint_beyond_configured_distance_can_use_goal_fallback() -> None:
+    local_policy = _LocalPolicy()
+    adapter = HybridGlobalRLLocalAdapter(
+        config=HybridGlobalRLLocalConfig(
+            allow_goal_fallback=True,
+            waypoint_max_distance_from_robot=1.0,
+        ),
+        waypoint_provider=_WaypointProvider((1.5, 0.0)),
+        local_policy=local_policy,
+    )
+
+    assert adapter.plan({"goal_current": [3.0, 4.0], "robot_position": [0.0, 0.0]}) == (
+        0.4,
+        0.1,
+    )
+
+    diagnostics = adapter.diagnostics()
+    assert local_policy.seen[0]["goal_current"] == [3.0, 4.0]
+    assert diagnostics["status"] == "ok"
+    assert diagnostics["waypoint_status"] == "rejected"
+    assert diagnostics["waypoint_reason"] == "route_waypoint_too_far"
+    assert diagnostics["fallback_status"] == "goal_fallback"
+    assert diagnostics["waypoint"] == [3.0, 4.0]
+
+
+def test_route_waypoint_missing_robot_position_fails_closed_by_default() -> None:
+    adapter = HybridGlobalRLLocalAdapter(
+        waypoint_provider=_WaypointProvider((1.5, 0.0)),
+        local_policy=_LocalPolicy(),
+    )
+
+    with pytest.raises(RuntimeError, match="route_waypoint_robot_position_missing"):
+        adapter.plan({"goal_current": [3.0, 4.0]})
+
+    diagnostics = adapter.diagnostics()
+    assert diagnostics["waypoint_status"] == "rejected"
+    assert diagnostics["waypoint_reason"] == "route_waypoint_robot_position_missing"
+    assert diagnostics["fallback_status"] == "fail_closed"
+
+
+@pytest.mark.parametrize("max_distance", [0.0, -1.0, math.inf, math.nan])
+def test_waypoint_max_distance_from_robot_must_be_finite_positive(max_distance: float) -> None:
+    with pytest.raises(ValueError, match="waypoint_max_distance_from_robot"):
+        HybridGlobalRLLocalConfig(waypoint_max_distance_from_robot=max_distance)
 
 
 def test_missing_waypoint_fails_closed_by_default() -> None:
@@ -146,7 +234,9 @@ def test_world_velocity_action_converts_to_bounded_unicycle() -> None:
         local_policy=local_policy,
     )
 
-    linear, angular = adapter.plan({"goal_current": [3.0, 4.0], "robot_heading": 0.0})
+    linear, angular = adapter.plan(
+        {"goal_current": [3.0, 4.0], "robot_position": [0.0, 0.0], "robot_heading": 0.0}
+    )
 
     assert linear == 0.5
     assert angular == 0.25
@@ -176,7 +266,7 @@ def test_unicycle_action_is_bounded() -> None:
         local_policy=local_policy,
     )
 
-    linear, angular = adapter.plan({"goal_current": [3.0, 4.0]})
+    linear, angular = adapter.plan({"goal_current": [3.0, 4.0], "robot_position": [0.0, 0.0]})
 
     assert math.isclose(linear, 0.7)
     assert math.isclose(angular, -0.3)

--- a/tests/planner/test_hybrid_global_rl.py
+++ b/tests/planner/test_hybrid_global_rl.py
@@ -177,6 +177,22 @@ def test_route_waypoint_beyond_configured_distance_can_use_goal_fallback() -> No
     assert diagnostics["waypoint"] == [3.0, 4.0]
 
 
+def test_route_waypoint_non_finite_fails_closed_before_distance_check() -> None:
+    adapter = HybridGlobalRLLocalAdapter(
+        waypoint_provider=_WaypointProvider((float("nan"), 0.0)),
+        local_policy=_LocalPolicy(),
+    )
+
+    with pytest.raises(RuntimeError, match="route_waypoint_non_finite"):
+        adapter.plan({"goal_current": [3.0, 4.0], "robot_position": [0.0, 0.0]})
+
+    diagnostics = adapter.diagnostics()
+    assert diagnostics["waypoint_status"] == "rejected"
+    assert diagnostics["waypoint_reason"] == "route_waypoint_non_finite"
+    assert diagnostics["fallback_status"] == "fail_closed"
+    assert diagnostics["waypoint_distance_from_robot"] is None
+
+
 def test_route_waypoint_missing_robot_position_fails_closed_by_default() -> None:
     adapter = HybridGlobalRLLocalAdapter(
         waypoint_provider=_WaypointProvider((1.5, 0.0)),


### PR DESCRIPTION
## Reviewer-critical summary
What changed: `hybrid_global_rl` now enforces `HybridGlobalRLLocalConfig.waypoint_max_distance_from_robot` before route-waypoint injection, validates the config as finite-positive, and records over-distance/missing-position diagnostics.

Why now: issue #4182 is a gate-filed follow-up from #4161/#4015 where the config field existed but was not enforced, so route-conditioned local-policy evidence could silently use an arbitrarily distant route waypoint.

Claim boundary: this is a runtime contract/test fix only. It does not claim benchmark improvement and keeps the adapter classified as diagnostic-only route-conditioned local-policy behavior.

Required validation: focused planner/map-runner tests plus full local PR readiness. Validation passed locally; see commands below.

Remaining blocker: none for this contract slice. No full benchmark campaign was run, no Slurm/GPU submission was made, and no paper/dissertation claim edits were made.

## Contract delta
- Schema/config: `waypoint_max_distance_from_robot` is now required to be finite and positive; invalid values fail at `HybridGlobalRLLocalConfig` construction.
- Runtime behavior: route waypoints are accepted only when `observation["robot"]["position"]` or `observation["robot_position"]` yields a finite 2D robot position and the waypoint distance is within the configured max.
- New fail-closed blockers: missing robot position for a returned route waypoint, and route waypoint distance greater than `waypoint_max_distance_from_robot`.
- Diagnostics: rejected over-distance waypoints report `waypoint_reason="route_waypoint_too_far"`, `waypoint_distance_from_robot`, `waypoint_max_distance_from_robot`, and `fallback_status` as `fail_closed` or `goal_fallback`.
- Compatibility impact: callers that provide a route waypoint without robot position now fail closed by default unless explicit goal fallback is enabled. This is intentional to preserve route-conditioned evidence semantics.

## Issue
- Closes #4182
- Related: #4161, #4015

## Scope summary
- Enforced the advertised max-distance gate in `HybridGlobalRLLocalAdapter.plan()` before `_inject_waypoint_goal()`.
- Added `_extract_robot_position()` for supported dict observation shapes.
- Extended focused tests for within-limit acceptance, over-distance fail-closed, over-distance fallback labeling, missing robot position fail-closed, and finite-positive config validation.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/planner/hybrid_global_rl.py tests/planner/test_hybrid_global_rl.py` -> passed; 2 files left unchanged on rerun.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/planner/hybrid_global_rl.py tests/planner/test_hybrid_global_rl.py tests/benchmark/test_map_runner_hybrid_global_rl.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/planner/test_hybrid_global_rl.py -q` -> passed; 17 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/planner/test_hybrid_global_rl.py tests/benchmark/test_map_runner_hybrid_global_rl.py -q` -> passed; 19 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests -k "hybrid_global_rl or waypoint" -q` -> passed; 58 passed, 1 warning.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed interim dirty-tree readiness; 1752 passed, 2 skipped.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` with this body file -> required final freshness check before open.

## Explicit out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No issue/PR comments posted by this agent because `comment_issue_or_pr` authorization is false; this PR body records state propagation instead.

<details>
<summary>Governance appendix</summary>

## Fragmentation / dedupe
- Open PR dedupe before implementation: no open PR matched #4182, `waypoint_max_distance_from_robot`, or `hybrid_global_rl` scope.
- Merged PR fragmentation guard: no issue-4182 PRs merged in the last 24h, so no consolidation block applies.
- Late issue guidance check immediately before PR prep: issue updated at `2026-07-03T02:35:40Z`; no newer maintainer comments were present.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: closes config/runtime contract blocker for route-conditioned local-policy adapter diagnostics.
- Comparator or baseline, applicable: pre-change adapter parsed but did not enforce `waypoint_max_distance_from_robot`.
- Evidence tier: NA - runtime contract fix with tests; no research or benchmark evidence claim.
- Result classification: NA - blocker resolved at code-contract level only.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #4182 and this PR.

## Domain-Aware Approval
- Approval status: not required.
- Approver/review source waiver: code-contract fix only; no benchmark, metric, paper-facing, or research-result claim is introduced.
- Validity checklist: NA - no experimental validity claim.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: fallback/degraded benchmark evidence is not claimed; fallback diagnostics are label-only.
- Claim boundary: runtime adapter contract and tests only.
- Implementation integrity vs experimental validity: implementation covered by targeted tests; experimental validity not claimed.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, tests cover accepted/rejected/fallback paths.
- Result route: continue via review; no benchmark transfer claimed.

## Next Empirical Action
- Rerun needed: no for this code contract slice.
- Stop / revise / continue decision: continue to review.

## Risks / Rollout
- Compatibility risks: route-conditioned callers lacking robot position now fail closed by default.
- Failure modes: unsupported observation shapes can trigger `route_waypoint_robot_position_missing` until explicit support is added.
- Rollback fallback plan: revert this PR or enable explicit goal fallback for diagnostic-only local runs that cannot provide robot position.

## Docs / Provenance
- Updated docs: none; code/tests only.
- Relevant design provenance notes: issue #4182 maintainer implementation plan.
- Any assumptions preserved: only dict observation shapes already used by this adapter/local policies are supported here.

## Downstream Propagation
- Parent issue updated: no, comments not authorized in task input.
- Claim map / benchmark report updated: NA, no benchmark or claim edit.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no.
- Not applicable because: this PR is a code/test contract fix; state is captured in this PR body for reviewer handoff.

## Follow-Up Issues
- Deferred work: none identified for issue #4182 contract slice.
- Issues opened follow-up: none.

## Reviewer Notes
- Please verify the intentional compatibility change: route waypoint plus missing robot position now fails closed by default.
- Generated artifacts from validation are ignored local files under `output/coverage/` and `output/validation/pr_ready/`; none are committed.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter waypoint handling so plans now respect a maximum robot-to-waypoint distance.
  * Improved diagnostics to report waypoint distance and distance limits when available.
  * Added support for reading robot position from multiple observation formats.

* **Bug Fixes**
  * Planning now fails closed when robot position is missing or a waypoint is too far away, with clearer diagnostic output.
  * Added an option to fall back to the final goal when a waypoint is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->