### PR TITLE
Fix diffusion_policy sampler device handling (#4181)

### DIFF
--- a/robot_sf/planner/diffusion_policy.py
+++ b/robot_sf/planner/diffusion_policy.py
@@ -85,6 +85,27 @@ def _require_torch() -> None:
         )
 
 
+def _build_generator(device: Any) -> Any:
+    """Create a sampling generator on the configured runtime device.
+
+    Returns:
+        Any: PyTorch generator bound to the configured device.
+    """
+    _require_torch()
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError(
+            "DiffusionPolicyAdapter configured device 'cuda' is not available in this "
+            "PyTorch runtime."
+        )
+    try:
+        return torch.Generator(device=device)
+    except RuntimeError as exc:
+        raise RuntimeError(
+            "DiffusionPolicyAdapter cannot create a sampler generator for configured "
+            f"device '{device}'."
+        ) from exc
+
+
 def build_diffusion_policy_config(
     config: dict[str, Any] | DiffusionPolicyConfig,
 ) -> DiffusionPolicyConfig:
@@ -243,13 +264,25 @@ class DiffusionActionSampler(nn.Module if nn is not None else object):  # type: 
             Any: Tensor of bounded candidate actions.
         """
         _require_torch()
+        device = condition.device
+        dtype = condition.dtype
         if deterministic:
-            actions = torch.zeros((num_samples, self.action_dim), dtype=torch.float32)
+            actions = torch.zeros((num_samples, self.action_dim), dtype=dtype, device=device)
         else:
-            actions = torch.randn((num_samples, self.action_dim), generator=generator)
+            actions = torch.randn(
+                (num_samples, self.action_dim),
+                dtype=dtype,
+                device=device,
+                generator=generator,
+            )
         condition_batch = condition.unsqueeze(0).expand(num_samples, -1)
         for step in reversed(range(denoising_steps)):
-            t = torch.full((num_samples, 1), float(step + 1) / float(denoising_steps))
+            t = torch.full(
+                (num_samples, 1),
+                float(step + 1) / float(denoising_steps),
+                dtype=dtype,
+                device=device,
+            )
             eps = self.net(torch.cat([actions, t, condition_batch], dim=-1))
             actions = actions - eps / float(denoising_steps)
             actions = self._bounded(actions)
@@ -333,7 +366,7 @@ class DiffusionPolicyAdapter:
         self.config = build_diffusion_policy_config(config)
         self._validate_runtime_source()
         self._device = torch.device(self.config.device)
-        self._generator = torch.Generator(device="cpu")
+        self._generator = _build_generator(self._device)
         self._previous_action = (0.0, 0.0)
         self._last_candidates: np.ndarray | None = None
         self._last_guidance: dict[str, Any] = {"status": "not_run"}
@@ -403,6 +436,7 @@ class DiffusionPolicyAdapter:
                 "evidence_tier": EVIDENCE_TIER,
                 "denoising_steps": self.config.denoising_steps,
                 "num_action_samples": self.config.num_action_samples,
+                "device": str(self._device),
                 "allow_untrained_smoke": self.config.allow_untrained_smoke,
                 "guidance": {
                     "enabled": bool(self.selector.guidance.get("enabled", True)),

--- a/tests/planner/test_diffusion_policy.py
+++ b/tests/planner/test_diffusion_policy.py
@@ -10,6 +10,7 @@ torch = pytest.importorskip("torch")
 from robot_sf.planner import diffusion_policy as diffusion_module  # noqa: E402
 from robot_sf.planner.diffusion_policy import (  # noqa: E402
     CLAIM_BOUNDARY,
+    DiffusionActionSampler,
     DiffusionGuidanceSelector,
     DiffusionPolicyAdapter,
     RobotPedestrianGraphEncoder,
@@ -140,6 +141,85 @@ def test_sampler_returns_finite_bounded_action_and_reproducible_reset() -> None:
     assert first == pytest.approx(second)
     assert 0.0 <= first[0] <= 0.8
     assert -0.7 <= first[1] <= 0.7
+
+
+def test_sampler_uses_condition_device_for_temporary_tensors() -> None:
+    """Sampler temporaries stay on the condition tensor device."""
+    sampler = DiffusionActionSampler(
+        condition_dim=4,
+        action_dim=2,
+        max_linear_speed=0.8,
+        max_angular_speed=0.7,
+    )
+    condition = torch.zeros(4, dtype=torch.float32, device=torch.device("cpu"))
+
+    actions = sampler.sample(
+        condition,
+        num_samples=3,
+        denoising_steps=2,
+        generator=torch.Generator(device=condition.device),
+        deterministic=True,
+    )
+
+    assert actions.device == condition.device
+    assert actions.dtype == condition.dtype
+
+
+def test_random_sampling_uses_adapter_owned_cpu_generator() -> None:
+    """The adapter-owned generator works with random CPU sampling."""
+    adapter = DiffusionPolicyAdapter(
+        {
+            "allow_untrained_smoke": True,
+            "deterministic": False,
+            "device": "cpu",
+            "seed": 4181,
+            "num_action_samples": 3,
+        }
+    )
+
+    selected = adapter.plan(_observation())
+    payload = adapter.diagnostics()["diffusion_policy"]
+
+    assert np.isfinite(selected).all()
+    assert payload["device"] == "cpu"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_cuda_plan_uses_configured_device_when_available() -> None:
+    """CUDA smoke test guards against mixed-device sampler tensors."""
+    adapter = DiffusionPolicyAdapter(
+        {
+            "allow_untrained_smoke": True,
+            "device": "cuda",
+            "seed": 4181,
+            "num_action_samples": 2,
+        }
+    )
+
+    selected = adapter.plan(_observation())
+
+    assert np.isfinite(selected).all()
+    assert adapter.diagnostics()["diffusion_policy"]["device"] == "cuda"
+
+
+def test_unavailable_cuda_device_fails_closed_with_configured_device(monkeypatch) -> None:
+    """CPU-only runtimes name the unsupported configured device."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="configured device 'cuda' is not available"):
+        DiffusionPolicyAdapter({"allow_untrained_smoke": True, "device": "cuda"})
+
+
+def test_generator_creation_failure_names_configured_device(monkeypatch) -> None:
+    """Unsupported PyTorch generator devices surface the configured device."""
+
+    def _raise_generator_error(*_args, **_kwargs):
+        raise RuntimeError("unsupported generator")
+
+    monkeypatch.setattr(diffusion_module.torch, "Generator", _raise_generator_error)
+
+    with pytest.raises(RuntimeError, match="configured device 'cpu'"):
+        DiffusionPolicyAdapter({"allow_untrained_smoke": True, "device": "cpu"})
 
 
 def test_guidance_changes_selected_candidate() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `DiffusionActionSampler.sample(...)` now creates `actions` and timestep tensors on `condition.device` with `condition.dtype`, and `DiffusionPolicyAdapter` creates its sampling generator for the configured runtime device instead of always using CPU.

Why now: issue #4181 is a post-merge follow-up from #4156 for a likely CUDA mismatch when concatenating sampler tensors with CUDA condition batches.

Claim boundary: runtime device correctness only for the diagnostic diffusion-policy path. This does not claim trained-policy quality, benchmark evidence, or any change to the `allow_untrained_smoke` evidence boundary.

Required validation: focused diffusion-policy tests and changed-file lint/format checks. No full benchmark campaign, no Slurm/GPU submission, and no paper/dissertation claim edits.

Remaining blocker: none for this scoped device-consistency slice. Full PR gate and merge authority are delegated to Claude Code on `imech156-u` per task handoff.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: `DiffusionPolicyAdapter(device="cuda")` now raises a clear runtime error when the installed PyTorch runtime has no CUDA device available; unsupported generator devices are wrapped with a diagnostic naming the configured device.
- Compatibility impact: CPU behavior and deterministic reset behavior are preserved. Diagnostics now include `diffusion_policy.device` so reviewers can confirm the runtime device used by the adapter.

<details>
<summary>PR template appendix</summary>

## Summary

Keep diffusion-policy sampler tensors and sampler RNG on the configured runtime device.

## Linked Issues

- Closes https://github.com/ll7/robot_sf_ll7/issues/4181
- Relates to #4156
- Relates to #4010

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: scoped bugfix against current `origin/main`.

## What Changed

- Added `_build_generator(...)` so the diffusion-policy adapter creates its `torch.Generator` for the configured device and fails early with a clear message when CUDA is configured but unavailable.
- Updated sampler allocation for deterministic actions, random actions, and timestep tensors to inherit `condition.device` and `condition.dtype`.
- Added regression tests for CPU sampler device inheritance, random CPU sampling with the adapter-owned generator, guarded CUDA `plan()` execution, and CPU-only CUDA-unavailable diagnostics.

## Why Matters

- Added value: prevents mixed CPU/CUDA tensors in the diffusion-policy sampler path.
- Expected impact: `DiffusionPolicyConfig.device` is respected by sampler temporaries and generator construction.
- Why worth merging now: closes the post-#4156 runtime device mismatch before broader diffusion-policy experimentation depends on the path.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - runtime bugfix, no research claim.
- Comparator or baseline, applicable: pre-change sampler created CPU `actions`, CPU timestep tensors, and a CPU generator even when configured for CUDA.
- Evidence tier: NA - runtime bugfix.
- Result classification: NA - runtime bugfix.
- Decision stop rule, applicable: focused tests prove sampler temporaries share the condition device and guarded CUDA `plan()` completes when CUDA is available.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #4181.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no analysis tool added.

## Domain-Aware Approval

- Approver/review source waiver: not required - runtime bugfix, no benchmark or paper claim promoted.
- Validity checklist: runtime tensor-device contract only.
- Target claim/hypothesis: diffusion-policy sampler tensors respect configured device.
- Comparator split/evidence validity: targeted unit and smoke tests.
- Fallback/degraded exclusions: CUDA-unavailable path fails closed; no fallback benchmark success claimed.
- Claim boundary: diagnostic runtime correctness only.
- Implementation integrity vs experimental validity: implementation tested; no experimental validity claim.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, tests exercise sampler allocation and adapter `plan()`.
- Did intervention change command source, selected command, trajectory, route progress? no intended semantic change beyond device placement.
- Did scenario actually contain targeted failure mode? unit-level tensor-device contract and CUDA guarded smoke cover the mismatch surface.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: none.

## Next Empirical Action

- Rerun needed: no for this scoped slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with downstream PR gate.
- Proposed child issue existing follow-up: none.

## Validation / Proof

- `uv run pytest tests/planner/test_diffusion_policy.py -q` -> passed, including guarded CUDA smoke on `imech036`.
- `uv run ruff check robot_sf/planner/diffusion_policy.py tests/planner/test_diffusion_policy.py` -> passed.
- `uv run pytest tests -k "diffusion_policy" -q` -> passed, including benchmark diffusion-policy tests and guarded CUDA smoke; one known PytestRemovedIn10Warning from `tests/test_scenario_generator.py`.
- `uv run ruff format --check robot_sf/planner/diffusion_policy.py tests/planner/test_diffusion_policy.py` -> passed.
- `git diff --check` -> passed.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout

- Compatibility risks: CUDA generator support depends on the installed PyTorch runtime; unsupported devices now fail closed with a clearer error.
- Failure modes: non-CPU/non-CUDA torch generator devices may still be unsupported by PyTorch and will raise the wrapped configured-device diagnostic.
- Rollback fallback plan: revert this commit to return to the previous CPU-only generator and CPU sampler temporaries.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: issue #4181 live body and 2026-07-03 maintainer implementation-plan comment.
- Any assumptions need to preserved: preserve `allow_untrained_smoke` diagnostic claim boundary; this is not trained-policy evidence.

## Downstream Propagation

- Parent issue updated (yes/no/NA): NA - issue comments are not authorized for this run; this PR links/closes #4181 and serves as the compact propagation surface.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: runtime bugfix only; no benchmark, registry, claim-map, or paper-facing propagation is needed.

## Follow-Up Issues

- Deferred work: none.
- Issues opened follow-up: none.

## Reviewer Notes

- Anything reviewer verify closely: generator device construction and sampler tensor allocation in `robot_sf/planner/diffusion_policy.py`.
- Any known limitations: no full benchmark campaign run; CUDA regression is guarded and only runs on CUDA-capable hosts.

</details>
