### PR TITLE
Add guarded-PPO workers=1 tuning-compare config (#4200)

### DIFF
--- a/configs/benchmarks/paper_experiment_matrix_v1_guarded_ppo_tuning_compare_workers1.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_guarded_ppo_tuning_compare_workers1.yaml
@@ -1,0 +1,85 @@
+name: paper_experiment_matrix_v1_guarded_ppo_tuning_compare_workers1
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+
+amv_profile:
+  name: amv-paper-v1
+  contract_version: "1"
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case: [delivery_robot, shared_space_micromobility]
+    context: [sidewalk, shared_space]
+    speed_regime: [walking_speed, scooter_speed]
+    maneuver_type: [overtake, crossing, bottleneck]
+
+seed_policy:
+  mode: seed-set
+  seed_set: eval
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+
+workers: 1
+horizon: 100
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+
+kinematics_matrix:
+  - differential_drive
+
+export_publication_bundle: false
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+
+planners:
+  - key: ppo
+    algo: ppo
+    planner_group: experimental
+    algo_config: configs/baselines/ppo_15m_grid_socnav.yaml
+    benchmark_profile: experimental
+    adapter_impact_eval: true
+    workers: 1
+
+  - key: guarded_ppo
+    algo: guarded_ppo
+    planner_group: experimental
+    algo_config: configs/algos/guarded_ppo_camera_ready.yaml
+    benchmark_profile: experimental
+    workers: 1
+
+  - key: guarded_ppo_relaxed_v1
+    algo: guarded_ppo
+    planner_group: experimental
+    algo_config: configs/algos/guarded_ppo_relaxed_v1.yaml
+    benchmark_profile: experimental
+    workers: 1
+
+  - key: guarded_ppo_relaxed_v2
+    algo: guarded_ppo
+    planner_group: experimental
+    algo_config: configs/algos/guarded_ppo_relaxed_v2.yaml
+    benchmark_profile: experimental
+    workers: 1

--- a/tests/benchmark/test_guarded_ppo_tuning_compare_workers1_config.py
+++ b/tests/benchmark/test_guarded_ppo_tuning_compare_workers1_config.py
@@ -1,0 +1,101 @@
+"""Validation for the guarded-PPO tuning-compare workers=1 benchmark config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from robot_sf.benchmark.algorithm_readiness import get_algorithm_readiness
+from robot_sf.benchmark.camera_ready_campaign import load_campaign_config
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE_CONFIG = (
+    ROOT / "configs/benchmarks/paper_experiment_matrix_v1_guarded_ppo_tuning_compare.yaml"
+)
+TARGET_CONFIG = (
+    ROOT / "configs/benchmarks/paper_experiment_matrix_v1_guarded_ppo_tuning_compare_workers1.yaml"
+)
+H600_PROBE_CONFIG = (
+    ROOT / "configs/benchmarks/paper_experiment_matrix_v1_issue_791_horizon600_probe.yaml"
+)
+WORKER_NEUTRAL_FIELDS = {"name", "workers", "planners"}
+PLANNER_WORKER_NEUTRAL_FIELDS = {"workers"}
+
+
+def _load_yaml(path: Path) -> dict:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_workers1_config_preserves_tuning_compare_matrix_contract() -> None:
+    """Workers=1 config keeps the tuning-compare scientific surface unchanged."""
+    source_payload = _load_yaml(SOURCE_CONFIG)
+    target_payload = _load_yaml(TARGET_CONFIG)
+
+    assert (
+        target_payload["name"] == "paper_experiment_matrix_v1_guarded_ppo_tuning_compare_workers1"
+    )
+    assert target_payload["workers"] == 1
+
+    source_scientific_fields = {
+        key: value for key, value in source_payload.items() if key not in WORKER_NEUTRAL_FIELDS
+    }
+    target_scientific_fields = {
+        key: value for key, value in target_payload.items() if key not in WORKER_NEUTRAL_FIELDS
+    }
+    assert target_scientific_fields == source_scientific_fields
+
+    source_planners = source_payload["planners"]
+    target_planners = target_payload["planners"]
+    assert [planner["key"] for planner in target_planners] == [
+        "ppo",
+        "guarded_ppo",
+        "guarded_ppo_relaxed_v1",
+        "guarded_ppo_relaxed_v2",
+    ]
+    assert [
+        (planner["key"], planner["algo"], planner["algo_config"]) for planner in target_planners
+    ] == [(planner["key"], planner["algo"], planner["algo_config"]) for planner in source_planners]
+
+    for source_planner, target_planner in zip(source_planners, target_planners, strict=True):
+        assert {
+            key: value
+            for key, value in target_planner.items()
+            if key not in PLANNER_WORKER_NEUTRAL_FIELDS
+        } == source_planner
+        assert target_planner["workers"] == 1
+
+
+def test_workers1_config_matches_h600_single_worker_override_convention() -> None:
+    """Every learned PPO-family row carries the h600-style planner-local workers override."""
+    h600_payload = _load_yaml(H600_PROBE_CONFIG)
+    target_payload = _load_yaml(TARGET_CONFIG)
+
+    h600_ppo = next(planner for planner in h600_payload["planners"] if planner["key"] == "ppo")
+    assert h600_ppo["workers"] == 1
+
+    for planner in target_payload["planners"]:
+        assert planner["workers"] == h600_ppo["workers"] == 1
+
+
+def test_workers1_config_loads_and_resolves_all_planners() -> None:
+    """Loader accepts the config and keeps all planner rows explicitly single-worker."""
+    cfg = load_campaign_config(TARGET_CONFIG)
+
+    assert cfg.name == "paper_experiment_matrix_v1_guarded_ppo_tuning_compare_workers1"
+    assert cfg.workers == 1
+    assert [planner.key for planner in cfg.planners] == [
+        "ppo",
+        "guarded_ppo",
+        "guarded_ppo_relaxed_v1",
+        "guarded_ppo_relaxed_v2",
+    ]
+
+    for planner in cfg.planners:
+        readiness = get_algorithm_readiness(planner.algo)
+        assert readiness is not None
+        assert planner.algo_config_path is not None
+        assert planner.algo_config_path.exists()
+        assert planner.workers_override == 1


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Adds `configs/benchmarks/paper_experiment_matrix_v1_guarded_ppo_tuning_compare_workers1.yaml`, a workers=1 variant of the guarded-PPO tuning-compare benchmark matrix, plus a focused config-validation test.

Why now: Issue #4200 says the downstream guarded-PPO tuning-compare campaign row is blocked because the existing matrix defaults to two workers while the h600 probe lineage proved the single-worker execution setting avoids the CUDA-in-fork initialization failure.

Claim boundary: This PR only adds and validates config shape/loading. It does not run a benchmark campaign, submit Slurm/GPU work, promote evidence, edit paper/dissertation claims, or interpret results.

Required validation: Static/config tests prove the new YAML preserves the source matrix scientific surface, explicitly pins every learned PPO-family row to `workers: 1`, follows the h600 planner-local override convention, loads through `load_campaign_config(...)`, resolves planner readiness, and points at existing algorithm config paths.

Remaining blocker: A real benchmark campaign still has to be launched and interpreted by the downstream owner after this config lands on `origin/main`.

## Contract delta

- New config: `configs/benchmarks/paper_experiment_matrix_v1_guarded_ppo_tuning_compare_workers1.yaml`.
- Schema fields: no new schema fields.
- Fail-closed blockers: no new runtime fail-closed blockers; the test prevents any target planner row from silently inheriting a higher top-level worker count.
- Compatibility impact: additive config and additive test only; existing guarded-PPO tuning-compare matrix remains unchanged.
- New capability: a named workers=1 guarded-PPO tuning-compare matrix config that can be selected by downstream benchmark launchers without changing the original matrix.

## Issue

Refs #4200.

## Validation

- `uv run pytest tests/benchmark/test_guarded_ppo_tuning_compare_workers1_config.py -q` - passed, 3 tests.
- `uv run pytest tests/benchmark/test_h600_extended_roster_config.py tests/benchmark/test_guarded_ppo_tuning_compare_workers1_config.py -q` - passed, 6 tests.
- `uv run ruff check tests/benchmark/test_guarded_ppo_tuning_compare_workers1_config.py` - passed.

## Follow-Up Issues

None - issue #4200 explicitly scopes this slice to config plus validation only; campaign execution remains outside this PR and is intentionally left to the downstream benchmark owner after merge.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no W&B artifact publication, no leaderboard/report update, and no paper/dissertation claim edits.

## Downstream propagation

No separate issue comment was added by this PR opener. The PR body is the durable low-churn status surface for this slice: delivered config + test, with campaign execution still remaining after merge.

<details>
<summary>Appendix: race and governance checks</summary>

- Live issue #4200 was reread immediately before PR creation; latest maintainer comment remained `2026-07-03T03:45:33Z`.
- Open PR dedupe found no existing PR for issue #4200 or the exact guarded-PPO workers=1 tuning-compare config scope.
- Fragmentation guard: no recent merged PRs were found for issue #4200, and this is a progression slice adding a nameable new config capability rather than a micro-guard.
- Transient queue-routing state, target-host state, and packet lineage were not encoded in tracked files.

</details>
