### PR TITLE
Issue #3968: tighten Social Mini-Game suite metadata contract

### DIFF
--- a/configs/scenarios/sets/social_mini_games_v0.yaml
+++ b/configs/scenarios/sets/social_mini_games_v0.yaml
@@ -44,6 +44,8 @@ scenario_overrides_by_name:
           - near_miss
   francis2023_blind_corner:
     metadata:
+      density: single_interaction
+      groups: 0.0
       smg:
         schema_version: robot_sf.social_mini_game.v1
         case: blind_corner
@@ -57,6 +59,8 @@ scenario_overrides_by_name:
           - late_yield
   francis2023_perpendicular_traffic:
     metadata:
+      density: medium
+      groups: 0.0
       smg:
         schema_version: robot_sf.social_mini_game.v1
         case: perpendicular_crossing

--- a/tests/benchmark/test_social_mini_game_scenarios.py
+++ b/tests/benchmark/test_social_mini_game_scenarios.py
@@ -22,6 +22,7 @@ REQUIRED_SMG_FIELDS = {
     "symmetry",
     "expected_failure_modes",
 }
+REQUIRED_INTERACTION_METADATA_FIELDS = {"archetype", "density", "flow", "groups"}
 EXPECTED_CASES = {
     "doorway",
     "narrow_sidewalk",
@@ -48,7 +49,10 @@ def test_social_mini_game_metadata_contract() -> None:
     cases: set[str] = set()
     assert len(scenarios) == len(EXPECTED_CASES)
     for scenario in scenarios:
-        smg = (scenario.get("metadata") or {}).get("smg")
+        metadata = scenario.get("metadata") or {}
+        assert REQUIRED_INTERACTION_METADATA_FIELDS <= set(metadata), scenario.get("name")
+
+        smg = metadata.get("smg")
         assert isinstance(smg, dict), scenario.get("name")
         assert REQUIRED_SMG_FIELDS <= set(smg), scenario.get("name")
         assert smg["schema_version"] == "robot_sf.social_mini_game.v1"


### PR DESCRIPTION
## Reviewer-critical summary

Closes #3968.

What changed: this post-metadata slice completes the Social Mini-Game (SMG) suite's interaction metadata contract by adding `density` and `groups` metadata to the reused Francis blind-corner and perpendicular-traffic rows in `configs/scenarios/sets/social_mini_games_v0.yaml`, then extending the SMG suite test to require uniform interaction metadata on all seven selected rows.

Why now: the merged foundation already added the SMG suite manifest, curb-ramp scenario/map, and CPU smoke test. This PR is the smallest integration slice left after that foundation: it closes the remaining metadata population gap surfaced by `validate-config` warnings for reused scenarios.

Claim boundary: scenario metadata and CPU construction only. No full benchmark campaign was run, no Slurm/GPU submission was made, and no paper/dissertation claim edits or metric semantics are introduced. `expected_failure_modes` remains descriptive metadata only.

Required validation: focused matrix validation, the SMG scenario test, the repository SMG/social-mini-game pytest selector, and final PR readiness wrapper.

Remaining blocker: none for this metadata/test slice. Existing `ped_density` comparability warnings remain because the reused scenarios intentionally preserve their source scenario pedestrian setup.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: `tests/benchmark/test_social_mini_game_scenarios.py` now fails if any selected SMG suite row lacks `metadata.archetype`, `metadata.density`, `metadata.flow`, or `metadata.groups`, in addition to the existing `metadata.smg` contract.
- Compatibility impact: no loader behavior, planner behavior, scoring, event ledger, or campaign script changes. Existing scenario names and selected suite order are unchanged.

## Scope summary

- Populates missing interaction metadata on reused SMG suite rows:
  - `francis2023_blind_corner`: `density: single_interaction`, `groups: 0.0`
  - `francis2023_perpendicular_traffic`: `density: medium`, `groups: 0.0`
- Keeps all existing scenario geometry, seeds, and SMG descriptive metadata intact.
- Adds test coverage for uniform interaction metadata across the seven-row SMG suite.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run robot_sf_bench validate-config --matrix configs/scenarios/sets/social_mini_games_v0.yaml` — pass; 7 scenarios, 0 errors; missing metadata.density warnings removed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_social_mini_game_scenarios.py -q` — pass; 3 passed.
- `scripts/dev/ruff_fix_format.sh tests/benchmark/test_social_mini_game_scenarios.py` — pass; all checks passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/ -k "smg or social_mini_game" -q` — pass; 16 passed, 1 unrelated pytest deprecation warning.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` — pass before PR open with this body file.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No new metric semantics or planner behavior changes.

## State propagation

No separate issue comment was added because this run has `comment_issue_or_pr: false`. The PR body is the durable propagation surface for this low-churn issue slice.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: one #3968 PR merged in the last 24 hours at start, below the two-PR guardrail threshold. This PR is also a progression slice because it adds a nameable contract capability: uniform interaction metadata enforcement for the SMG suite.

Late-guidance check: the live issue thread was re-read through the GitHub REST issue and comments endpoints immediately before PR opening. The only issue comment remains `4863845592`, created and updated `2026-07-02T08:41:47Z`, so no maintainer guidance newer than this run was missed.

</details>

