### PR TITLE
refactor: migrate rule/grid policy builders (#3384)

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -126,6 +126,7 @@ from robot_sf.benchmark.map_runner_policies import goal as _goal_policy_builder
 from robot_sf.benchmark.map_runner_policies import group_avoidance as _group_avoidance_builder
 from robot_sf.benchmark.map_runner_policies import hybrid_global_rl as _hybrid_global_rl_builder
 from robot_sf.benchmark.map_runner_policies import registry as _policy_builder_registry
+from robot_sf.benchmark.map_runner_policies import rule_and_grid as _rule_and_grid_builder
 from robot_sf.benchmark.map_runner_policies import safety_barrier as _safety_barrier_builder
 from robot_sf.benchmark.map_runner_policy_actions import (
     ppo_action_to_unicycle as _ppo_action_to_unicycle_impl,
@@ -234,16 +235,11 @@ from robot_sf.planner.hybrid_portfolio import (
     HybridPortfolioAdapter,
     build_hybrid_portfolio_build_config,
 )
-from robot_sf.planner.hybrid_rule_local_planner import (
-    HybridRuleLocalPlannerAdapter,
-    build_hybrid_rule_local_planner_config,
-)
 from robot_sf.planner.kinematics_model import resolve_benchmark_kinematics_model
 from robot_sf.planner.lidar_occupancy import (  # noqa: F401
     LidarOccupancyPlannerAdapter,
     build_lidar_occupancy_config,
 )
-from robot_sf.planner.lidar_occupancy_grid import build_lidar_grid_route_adapter
 from robot_sf.planner.mppi_social import (
     MPPISocialPlannerAdapter,
     build_mppi_social_config,
@@ -251,10 +247,6 @@ from robot_sf.planner.mppi_social import (
 from robot_sf.planner.nmpc_social import (
     NMPCSocialPlannerAdapter,
     build_nmpc_social_config,
-)
-from robot_sf.planner.policy_stack_v1 import (
-    PolicyStackV1Adapter,
-    build_policy_stack_v1_build_config,
 )
 from robot_sf.planner.predictive_mppi import (
     PredictiveMPPIAdapter,
@@ -295,10 +287,6 @@ from robot_sf.planner.socnav import (
     TrivialReferencePlannerAdapter,
 )
 from robot_sf.planner.stream_gap import StreamGapPlannerAdapter, build_stream_gap_config
-from robot_sf.planner.topology_guided_local_policy import (
-    TopologyGuidedHybridRulePlannerAdapter,
-    build_topology_guided_local_policy_config,
-)
 from robot_sf.training.scenario_loader import load_scenarios
 
 if TYPE_CHECKING:
@@ -996,6 +984,7 @@ _POLICY_BUILDERS: dict[str, _policy_builder_registry.PolicyBuilder] = {
         _group_avoidance_builder.GROUP_AVOIDANCE_ALGO_KEYS,
         _group_avoidance_builder.build,
     ),
+    **dict.fromkeys(_rule_and_grid_builder.RULE_AND_GRID_KEYS, _rule_and_grid_builder.build),
     **dict.fromkeys(_safety_barrier_builder.ADAPTER_ALGO_KEYS, _safety_barrier_builder.build),
     **dict.fromkeys(
         _hybrid_global_rl_builder.HYBRID_GLOBAL_RL_KEYS, _hybrid_global_rl_builder.build
@@ -1069,74 +1058,6 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             limitations=(
                 "Diagnostic adapter template only; do not use as benchmark planner evidence."
             ),
-        )
-
-    if algo_key == "policy_stack_v1":
-        stack_cfg = build_policy_stack_v1_build_config(algo_config)
-        adapter = PolicyStackV1Adapter(
-            config=stack_cfg.policy_stack,
-            risk_dwa=RiskDWAPlannerAdapter(config=stack_cfg.risk_dwa),
-        )
-        return _build_adapter_policy(
-            algo_key=algo_key,
-            algo_config=algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="PolicyStackV1Adapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-        )
-
-    if algo_key in {
-        "hybrid_rule_local_planner",
-        "hybrid_rule_v0_minimal",
-        "actuation_aware_hybrid_rule_v0",
-    }:
-        adapter = HybridRuleLocalPlannerAdapter(
-            config=build_hybrid_rule_local_planner_config(algo_config)
-        )
-        return _build_adapter_policy(
-            algo_key=algo_key,
-            algo_config=algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="HybridRuleLocalPlannerAdapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-        )
-
-    if algo_key == "topology_guided_hybrid_rule_v0":
-        adapter = TopologyGuidedHybridRulePlannerAdapter(
-            config=build_topology_guided_local_policy_config(algo_config)
-        )
-        meta["topology_guided_hybrid_rule"] = {
-            "diagnostic_only": True,
-            "claim_boundary": "diagnostic_only",
-            "hypothesis_source": "masked_occupancy_grid_routes",
-            "wrapped_planner": "HybridRuleLocalPlannerAdapter",
-        }
-        return _build_adapter_policy(
-            algo_key=algo_key,
-            algo_config=algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="TopologyGuidedHybridRulePlannerAdapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            limitations="diagnostic_only_topology_hypothesis_selector",
-        )
-
-    if algo_key in {"lidar_grid_route", "lidar_occupancy_grid_route"}:
-        adapter = build_lidar_grid_route_adapter(algo_config)
-        return _build_adapter_policy(
-            algo_key="lidar_grid_route",
-            algo_config=algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="LidarOccupancyGridRouteAdapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            limitations="lidar_ego_occupancy_grid_route_testing_only",
         )
 
     if algo_key == "stream_gap":

--- a/robot_sf/benchmark/map_runner_policies/rule_and_grid.py
+++ b/robot_sf/benchmark/map_runner_policies/rule_and_grid.py
@@ -1,0 +1,135 @@
+"""Builders for rule-stack and lidar-grid map-runner policy families.
+
+This is a behavior-preserving continuation of the ``_build_policy``
+decomposition tracked by #3384. The migrated branches only depend on neutral
+planner modules and ``map_runner_policy_common.build_adapter_policy``, so they
+can live outside ``map_runner.py`` without introducing a cycle.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.map_runner_policy_common import build_adapter_policy
+from robot_sf.planner.hybrid_rule_local_planner import (
+    HybridRuleLocalPlannerAdapter,
+    build_hybrid_rule_local_planner_config,
+)
+from robot_sf.planner.lidar_occupancy_grid import build_lidar_grid_route_adapter
+from robot_sf.planner.policy_stack_v1 import (
+    PolicyStackV1Adapter,
+    build_policy_stack_v1_build_config,
+)
+from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter
+from robot_sf.planner.topology_guided_local_policy import (
+    TopologyGuidedHybridRulePlannerAdapter,
+    build_topology_guided_local_policy_config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+POLICY_STACK_KEYS = frozenset({"policy_stack_v1"})
+HYBRID_RULE_KEYS = frozenset(
+    {
+        "hybrid_rule_local_planner",
+        "hybrid_rule_v0_minimal",
+        "actuation_aware_hybrid_rule_v0",
+    }
+)
+TOPOLOGY_GUIDED_KEYS = frozenset({"topology_guided_hybrid_rule_v0"})
+LIDAR_GRID_ROUTE_KEYS = frozenset({"lidar_grid_route", "lidar_occupancy_grid_route"})
+
+RULE_AND_GRID_KEYS = (
+    POLICY_STACK_KEYS | HYBRID_RULE_KEYS | TOPOLOGY_GUIDED_KEYS | LIDAR_GRID_ROUTE_KEYS
+)
+
+
+def build(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    robot_kinematics: str | None = None,
+    robot_command_mode: str | None = None,
+    adapter_impact_eval: bool = False,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build migrated rule-stack and lidar-grid policy metadata.
+
+    Returns:
+        Policy callable and enriched metadata dictionary.
+    """
+    if algo_key not in RULE_AND_GRID_KEYS:
+        supported = ", ".join(sorted(RULE_AND_GRID_KEYS))
+        raise ValueError(
+            f"Unsupported rule/grid policy builder key '{algo_key}'. Expected: {supported}"
+        )
+
+    del adapter_impact_eval
+    normalized_robot_command_mode = (
+        str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
+    )
+    meta: dict[str, Any] = {"algorithm": algo_key}
+
+    if algo_key == "policy_stack_v1":
+        stack_cfg = build_policy_stack_v1_build_config(algo_config)
+        adapter = PolicyStackV1Adapter(
+            config=stack_cfg.policy_stack,
+            risk_dwa=RiskDWAPlannerAdapter(config=stack_cfg.risk_dwa),
+        )
+        return build_adapter_policy(
+            algo_key=algo_key,
+            algo_config=algo_config,
+            meta=meta,
+            adapter=adapter,
+            adapter_name="PolicyStackV1Adapter",
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+        )
+
+    if algo_key in HYBRID_RULE_KEYS:
+        adapter = HybridRuleLocalPlannerAdapter(
+            config=build_hybrid_rule_local_planner_config(algo_config)
+        )
+        return build_adapter_policy(
+            algo_key=algo_key,
+            algo_config=algo_config,
+            meta=meta,
+            adapter=adapter,
+            adapter_name="HybridRuleLocalPlannerAdapter",
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+        )
+
+    if algo_key == "topology_guided_hybrid_rule_v0":
+        adapter = TopologyGuidedHybridRulePlannerAdapter(
+            config=build_topology_guided_local_policy_config(algo_config)
+        )
+        meta["topology_guided_hybrid_rule"] = {
+            "diagnostic_only": True,
+            "claim_boundary": "diagnostic_only",
+            "hypothesis_source": "masked_occupancy_grid_routes",
+            "wrapped_planner": "HybridRuleLocalPlannerAdapter",
+        }
+        return build_adapter_policy(
+            algo_key=algo_key,
+            algo_config=algo_config,
+            meta=meta,
+            adapter=adapter,
+            adapter_name="TopologyGuidedHybridRulePlannerAdapter",
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            limitations="diagnostic_only_topology_hypothesis_selector",
+        )
+
+    adapter = build_lidar_grid_route_adapter(algo_config)
+    return build_adapter_policy(
+        algo_key="lidar_grid_route",
+        algo_config=algo_config,
+        meta=meta,
+        adapter=adapter,
+        adapter_name="LidarOccupancyGridRouteAdapter",
+        robot_kinematics=robot_kinematics,
+        normalized_robot_command_mode=normalized_robot_command_mode,
+        limitations="lidar_ego_occupancy_grid_route_testing_only",
+    )

--- a/tests/benchmark/test_map_runner_rule_and_grid_registry.py
+++ b/tests/benchmark/test_map_runner_rule_and_grid_registry.py
@@ -1,0 +1,31 @@
+"""Regression tests for #3384 rule/grid policy-builder registry migration."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark import map_runner
+from robot_sf.benchmark.map_runner_policies import rule_and_grid
+
+
+@pytest.mark.parametrize(
+    "algo_key",
+    [
+        "policy_stack_v1",
+        "hybrid_rule_local_planner",
+        "hybrid_rule_v0_minimal",
+        "actuation_aware_hybrid_rule_v0",
+        "topology_guided_hybrid_rule_v0",
+        "lidar_grid_route",
+        "lidar_occupancy_grid_route",
+    ],
+)
+def test_rule_and_grid_keys_resolve_through_registry_bridge(algo_key: str) -> None:
+    """Migrated rule/grid keys should be owned by the registry builder."""
+    assert map_runner._POLICY_BUILDERS[algo_key] is rule_and_grid.build
+
+
+@pytest.mark.parametrize("algo_key", ["stream_gap", "gap_prediction", "trivial_reference"])
+def test_deferred_rule_gap_keys_remain_legacy_dispatch(algo_key: str) -> None:
+    """Later #3384 slices still own helper-dependent rule/gap branches."""
+    assert algo_key not in map_runner._POLICY_BUILDERS

--- a/tests/planner/test_policy_stack_v1.py
+++ b/tests/planner/test_policy_stack_v1.py
@@ -286,13 +286,15 @@ def test_policy_stack_map_runner_registration(monkeypatch: pytest.MonkeyPatch) -
                 }
             }
 
-    monkeypatch.setattr("robot_sf.benchmark.map_runner.PolicyStackV1Adapter", _DummyStack)
     monkeypatch.setattr(
-        "robot_sf.benchmark.map_runner.build_policy_stack_v1_build_config",
+        "robot_sf.benchmark.map_runner_policies.rule_and_grid.PolicyStackV1Adapter", _DummyStack
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner_policies.rule_and_grid.build_policy_stack_v1_build_config",
         lambda cfg: SimpleNamespace(policy_stack=cfg, risk_dwa=SimpleNamespace()),
     )
     monkeypatch.setattr(
-        "robot_sf.benchmark.map_runner.RiskDWAPlannerAdapter",
+        "robot_sf.benchmark.map_runner_policies.rule_and_grid.RiskDWAPlannerAdapter",
         lambda config: SimpleNamespace(config=config),
     )
 


### PR DESCRIPTION
## Reviewer-critical summary

What changed: migrated the next rule/grid policy families from `map_runner._build_policy` into the registry bridge via `robot_sf/benchmark/map_runner_policies/rule_and_grid.py`: `policy_stack_v1`, `hybrid_rule_local_planner` aliases, `topology_guided_hybrid_rule_v0`, and `lidar_grid_route` aliases.

Why now: PR #4153 landed the neutral bridge helpers, so these adapter-backed families can move without importing back into the monolith.

Claim boundary: behavior-preserving refactor only. No planner logic, metadata semantics, fallback behavior, benchmark interpretation, or claim surface changed.

Required validation: focused CPU unit coverage for map-runner utilities, policy stack, lidar grid route, hybrid rule planner, new registry ownership tests, Ruff, and diff checks. Full benchmark campaign was not run.

Remaining blocker: `trivial_reference`, `stream_gap`, and `gap_prediction` remain inline because they need additional helper movement and belief-mode handling in a later #3384 slice.

Refs #3384.

## Contract delta

New schema fields: none.

New fail-closed blockers: none.

Compatibility impact: `_build_policy` remains import-compatible from `robot_sf.benchmark.map_runner`. The migrated keys now resolve through `_POLICY_BUILDERS` before legacy fallback. Existing tests that monkeypatch `policy_stack_v1` construction now patch the new builder owner.

New capability toward #3384: registry-owned `rule_and_grid` builder module for seven rule/grid keys, reducing `_build_policy` by the moved branch block while preserving metadata and limitations.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_rule_and_grid_registry.py tests/planner/test_policy_stack_v1.py::test_policy_stack_map_runner_registration tests/benchmark/test_lidar_grid_route_contract.py::test_lidar_grid_route_map_runner_policy_exposes_adapter_runtime -q` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_utils.py tests/planner/test_policy_stack_v1.py tests/benchmark/test_lidar_grid_route_contract.py tests/planner/test_hybrid_rule_local_planner.py tests/benchmark/test_map_runner_rule_and_grid_registry.py -q` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policies/rule_and_grid.py tests/benchmark/test_map_runner_rule_and_grid_registry.py tests/planner/test_policy_stack_v1.py` - passed
- `git diff --check` - passed
- `PR_READY_PR_BODY_FILE=/tmp/issue3384_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; stamp `output/validation/pr_ready/issue-3384-refactor-continue-map-runner-policy-registry-migration-post-4153-bridge.json`

## Out of scope

No full benchmark campaign run. No Slurm/GPU submission. No paper/dissertation claim edits. No transient queue-routing state added to tracked files.

<details>
<summary>Governance appendix</summary>

## Linked Issues

- Refs #3384

## Stack / Dependency

- Base dependency: PR #4153 bridge already merged to `origin/main`
- Required prior PRs: #4153
- Safe review independently: yes
- Review dependency reason: the bridge helper signature is already on `origin/main`, and this PR only consumes it.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - technical-debt refactor only
- Comparator or baseline, applicable: NA
- Evidence tier: NA - support refactor; validation is code-quality proof, not research evidence
- Result classification: NA - support refactor
- Decision stop rule, applicable: migrated keys resolve through registry and focused tests stay green
- Parent issue, claim map, registry, context note, synthesis surface update: #3384 issue remains parent; no claim map update
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support refactor

## Domain-Aware Approval

- Approval concerns experimental validity waived / pending / blocked / not required: not required - no domain evidence claim
- Approver/review source waiver: NA - no evidence claim
- Validity checklist: NA - no benchmark or paper-facing claim
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA - no experimental comparator or evidence-validity claim
- Fallback/degraded exclusions: NA
- Claim boundary: behavior-preserving refactor only
- Implementation integrity vs experimental validity: implementation integrity checked by focused unit tests and Ruff

## Falsification / Non-Transfer Check

- Did mechanism activate? NA - no research mechanism
- Did intervention change command source, selected command, trajectory, route progress? No intended change
- Did scenario actually contain targeted failure mode? NA
- Result route: continue #3384 migration
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action

- Rerun needed: no for this slice
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: continue with later #3384 slices for helper-dependent rule/gap keys
- Proposed child issue existing follow-up: #3384 remaining migration plan

## Runtime / Performance

- Baseline runtime: NA - no runtime performance claim
- Changed runtime: NA - no runtime performance claim
- Representative command: focused pytest commands above
- Hot-path call count profile anchor: NA - no hot-path claim
- Cache-hit reuse counter: NA - no caching claimed
- Rollback failure criterion: migrated policy keys fail to instantiate, metadata/limitations drift, or focused tests regress

## Risks / Rollout

- Compatibility risks: private monkeypatch paths for migrated constructors move from `map_runner` to `map_runner_policies.rule_and_grid`
- Failure modes: missed import ownership or metadata drift in migrated adapter branches
- Rollback fallback plan: revert this PR to restore inline branch ownership

## Docs / Provenance

- Updated docs: none
- Relevant design provenance notes: #3384 owner implementation plan comment dated 2026-07-02
- Any assumptions need to preserved: stream/gap/trivial-reference remain deferred because they need additional helper movement

## Downstream Propagation

- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: no benchmark, registry index, claim-map, or paper-facing propagation is needed. Issue comment propagation was not performed because `comment_issue_or_pr` authorization is false; this PR body records delivered slice and remaining work.

## Follow-Up Issues

- Deferred work: migrate `trivial_reference`, `stream_gap`, `gap_prediction`, and later learned/MPPI/SocNav/external families per #3384 plan
- Issues opened follow-up: none

## Reviewer Notes

- Verify closely: metadata keys for `topology_guided_hybrid_rule_v0` and limitations for `lidar_grid_route` are copied unchanged.
- Known limitations: no before/after campaign smoke; this is unit-test-backed refactor scope only.

</details>
