### PR TITLE
Issue #4010 add diffusion policy training smoke artifacts

### DIFF
--- a/configs/training/diffusion_policy/issue_4010_smoke.yaml
+++ b/configs/training/diffusion_policy/issue_4010_smoke.yaml
@@ -1,0 +1,17 @@
+# CPU-only diagnostic smoke for issue #4010 diffusion-policy training.
+# Artifacts prove checkpoint, normalizer, and map-runner load contracts only.
+diffusion_policy_training_smoke:
+  schema_version: diffusion_policy_training_smoke.v1
+  seed: 4010
+  training_steps: 8
+  batch_size: 8
+  learning_rate: 0.001
+  max_pedestrians: 4
+  hidden_dim: 64
+  action_dim: 2
+  denoising_steps: 4
+  num_action_samples: 4
+  max_linear_speed: 1.0
+  max_angular_speed: 1.0
+  output_dir: output/diffusion_policy/issue_4010_smoke
+  artifact_prefix: diffusion_policy_issue_4010_smoke

--- a/robot_sf/benchmark/map_runner_policies/diffusion_policy.py
+++ b/robot_sf/benchmark/map_runner_policies/diffusion_policy.py
@@ -78,6 +78,9 @@ def build(
             "status": "ok",
             "evidence_tier": EVIDENCE_TIER,
             "allow_untrained_smoke": config.allow_untrained_smoke,
+            "checkpoint_status": "untrained_smoke"
+            if config.allow_untrained_smoke
+            else "checkpoint_loaded",
             "claim_boundary": CLAIM_BOUNDARY,
         },
         "planner_kinematics": {
@@ -100,5 +103,9 @@ def build(
         adapter_name="DiffusionPolicyAdapter",
         robot_kinematics=robot_kinematics,
         normalized_robot_command_mode=normalized_robot_command_mode,
-        limitations="diagnostic_only_untrained_smoke_not_benchmark_evidence",
+        limitations=(
+            "diagnostic_only_untrained_smoke_not_benchmark_evidence"
+            if config.allow_untrained_smoke
+            else "diagnostic_only_smoke_checkpoint_not_benchmark_evidence"
+        ),
     )

--- a/robot_sf/training/diffusion_policy.py
+++ b/robot_sf/training/diffusion_policy.py
@@ -1,0 +1,375 @@
+"""CPU smoke training utilities for issue #4010 diffusion policy.
+
+This module intentionally trains only on a tiny deterministic synthetic fixture.
+The artifacts prove the checkpoint/normalizer/load contract, not navigation
+quality or COLSON reproduction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+
+from robot_sf.planner.diffusion_policy import (
+    CLAIM_BOUNDARY,
+    EVIDENCE_TIER,
+    DiffusionActionSampler,
+    RobotPedestrianGraphEncoder,
+)
+
+try:  # pragma: no cover - exercised only in environments without torch installed.
+    import torch
+    from torch import nn
+except ImportError:  # pragma: no cover
+    torch = None  # type: ignore[assignment]
+    nn = None  # type: ignore[assignment]
+
+
+SMOKE_MANIFEST_SCHEMA_VERSION = "diffusion_policy_smoke_manifest.v1"
+SMOKE_CONFIG_SCHEMA_VERSION = "diffusion_policy_training_smoke.v1"
+
+
+@dataclass(frozen=True)
+class DiffusionPolicyTrainingSmokeConfig:
+    """Configuration for the CPU-only diffusion-policy smoke trainer."""
+
+    schema_version: str = SMOKE_CONFIG_SCHEMA_VERSION
+    seed: int = 4010
+    training_steps: int = 8
+    batch_size: int = 8
+    learning_rate: float = 0.001
+    max_pedestrians: int = 4
+    hidden_dim: int = 64
+    action_dim: int = 2
+    denoising_steps: int = 4
+    num_action_samples: int = 4
+    max_linear_speed: float = 1.0
+    max_angular_speed: float = 1.0
+    output_dir: str = "output/diffusion_policy/issue_4010_smoke"
+    artifact_prefix: str = "diffusion_policy_issue_4010_smoke"
+
+    def __post_init__(self) -> None:
+        """Validate the intentionally narrow smoke-training contract."""
+        if self.schema_version != SMOKE_CONFIG_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported diffusion smoke schema_version: {self.schema_version}")
+        if self.training_steps <= 0:
+            raise ValueError("training_steps must be positive")
+        if self.batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        if self.learning_rate <= 0.0:
+            raise ValueError("learning_rate must be positive")
+        if self.max_pedestrians <= 0:
+            raise ValueError("max_pedestrians must be positive")
+        if self.hidden_dim <= 0:
+            raise ValueError("hidden_dim must be positive")
+        if self.action_dim != 2:
+            raise ValueError("issue #4010 smoke training supports action_dim=2 only")
+        if self.denoising_steps <= 0:
+            raise ValueError("denoising_steps must be positive")
+        if self.num_action_samples <= 0:
+            raise ValueError("num_action_samples must be positive")
+
+
+@dataclass(frozen=True)
+class DiffusionPolicySmokeArtifacts:
+    """Paths and manifest payload produced by the smoke trainer."""
+
+    checkpoint_path: Path
+    normalizer_path: Path
+    manifest_path: Path
+    manifest: dict[str, Any]
+
+
+def load_smoke_config(path: Path) -> DiffusionPolicyTrainingSmokeConfig:
+    """Load a smoke-training YAML config.
+
+    Args:
+        path: YAML path containing either the config fields directly or under
+            ``diffusion_policy_training_smoke``.
+
+    Returns:
+        Validated smoke-training configuration.
+    """
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError("Diffusion policy smoke config must be a YAML mapping")
+    raw_config = payload.get("diffusion_policy_training_smoke", payload)
+    if not isinstance(raw_config, dict):
+        raise ValueError("diffusion_policy_training_smoke must be a YAML mapping")
+    return DiffusionPolicyTrainingSmokeConfig(**raw_config)
+
+
+def run_training_smoke(
+    config: DiffusionPolicyTrainingSmokeConfig,
+    *,
+    output_dir: Path | None = None,
+) -> DiffusionPolicySmokeArtifacts:
+    """Run the CPU smoke trainer and write checkpoint, normalizer, and manifest.
+
+    Args:
+        config: Validated smoke-training config.
+        output_dir: Optional test override for generated artifacts.
+
+    Returns:
+        Paths and parsed manifest for the generated smoke artifacts.
+    """
+    _require_torch()
+    _seed_everything(config.seed)
+
+    artifact_dir = (output_dir or Path(config.output_dir)).expanduser()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    encoder = RobotPedestrianGraphEncoder(
+        max_pedestrians=config.max_pedestrians,
+        hidden_dim=config.hidden_dim,
+    )
+    sampler = DiffusionActionSampler(
+        condition_dim=encoder.output_dim,
+        action_dim=config.action_dim,
+        max_linear_speed=config.max_linear_speed,
+        max_angular_speed=config.max_angular_speed,
+        hidden_dim=config.hidden_dim,
+    )
+    optimizer = torch.optim.Adam(
+        [*encoder.parameters(), *sampler.parameters()],
+        lr=config.learning_rate,
+    )
+    loss_fn = nn.MSELoss()
+
+    fixture = _build_synthetic_fixture(config)
+    feature_tensor = torch.stack([item[0] for item in fixture])
+    mask_tensor = torch.stack([item[1] for item in fixture])
+    target_actions = torch.stack([item[2] for item in fixture])
+    normalizer = _build_normalizer(feature_tensor, mask_tensor)
+
+    losses: list[float] = []
+    generator = torch.Generator(device=torch.device("cpu"))
+    generator.manual_seed(config.seed)
+    for step in range(config.training_steps):
+        indices = torch.arange(config.batch_size) % len(fixture)
+        indices = torch.roll(indices, shifts=step)
+        features = feature_tensor[indices]
+        masks = mask_tensor[indices]
+        targets = target_actions[indices]
+        conditions = encoder(features, masks)
+        noise = torch.randn(targets.shape, generator=generator)
+        timestep = torch.full((targets.shape[0], 1), 0.5, dtype=targets.dtype)
+        prediction = sampler.net(torch.cat([targets + noise, timestep, conditions], dim=-1))
+        loss = loss_fn(prediction, noise)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        losses.append(float(loss.detach().cpu()))
+
+    checkpoint_path = artifact_dir / f"{config.artifact_prefix}.pt"
+    normalizer_path = artifact_dir / f"{config.artifact_prefix}.normalizer.json"
+    manifest_path = artifact_dir / f"{config.artifact_prefix}.manifest.json"
+
+    torch.save(
+        {
+            "encoder": encoder.state_dict(),
+            "sampler": sampler.state_dict(),
+            "schema_version": SMOKE_MANIFEST_SCHEMA_VERSION,
+            "config": asdict(config),
+        },
+        checkpoint_path,
+    )
+    normalizer_path.write_text(json.dumps(normalizer, indent=2, sort_keys=True), encoding="utf-8")
+
+    manifest = _build_manifest(
+        config=config,
+        checkpoint_path=checkpoint_path,
+        normalizer_path=normalizer_path,
+        losses=losses,
+        normalizer=normalizer,
+    )
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    return DiffusionPolicySmokeArtifacts(
+        checkpoint_path=checkpoint_path,
+        normalizer_path=normalizer_path,
+        manifest_path=manifest_path,
+        manifest=manifest,
+    )
+
+
+def _require_torch() -> None:
+    """Fail closed when smoke training dependencies are unavailable."""
+    if torch is None or nn is None:
+        raise RuntimeError("Diffusion policy smoke training requires PyTorch.")
+
+
+def _seed_everything(seed: int) -> None:
+    """Seed NumPy and PyTorch for reproducible smoke artifacts."""
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+
+def _build_synthetic_fixture(
+    config: DiffusionPolicyTrainingSmokeConfig,
+) -> list[tuple[Any, Any, Any]]:
+    """Create deterministic crossing-style observations and bounded target actions.
+
+    Returns:
+        Synthetic graph feature, mask, and action-target tuples.
+    """
+    encoder = RobotPedestrianGraphEncoder(
+        max_pedestrians=config.max_pedestrians,
+        hidden_dim=config.hidden_dim,
+    )
+    rng = np.random.default_rng(config.seed)
+    fixture: list[tuple[Any, Any, Any]] = []
+    for index in range(max(config.batch_size, 6)):
+        side = -1.0 if index % 2 else 1.0
+        distance = 0.55 + 0.08 * index
+        observation = {
+            "robot": {
+                "position": [0.0, 0.0],
+                "velocity": [0.05, 0.0],
+                "goal": [2.0, 0.15 * side],
+                "heading": 0.0,
+                "radius": 0.3,
+            },
+            "agents": [
+                {
+                    "position": [distance, 0.18 * side],
+                    "velocity": [-0.05, -0.02 * side],
+                    "radius": 0.25,
+                },
+                {
+                    "position": [distance + 0.3, -0.22 * side],
+                    "velocity": [0.0, 0.03 * side],
+                    "radius": 0.25,
+                },
+            ],
+            "dt": 0.1,
+        }
+        features, mask = encoder.encode_observation(observation)
+        linear = np.clip(0.45 + 0.05 * rng.normal(), 0.0, config.max_linear_speed)
+        angular = np.clip(0.25 * side, -config.max_angular_speed, config.max_angular_speed)
+        target = torch.tensor([linear, angular], dtype=torch.float32)
+        fixture.append((features, mask, target))
+    return fixture
+
+
+def _build_normalizer(feature_tensor: Any, mask_tensor: Any) -> dict[str, Any]:
+    """Build a small JSON normalizer from valid graph-node features.
+
+    Returns:
+        JSON-serializable normalizer payload.
+    """
+    valid = feature_tensor[mask_tensor]
+    mean = valid.mean(dim=0)
+    std = valid.std(dim=0, unbiased=False).clamp(min=1e-6)
+    return {
+        "schema_version": "diffusion_policy_normalizer.v1",
+        "feature_order": [
+            "rel_or_goal_x",
+            "rel_or_goal_y",
+            "vx",
+            "vy",
+            "radius_or_cos_heading",
+            "distance_or_sin_heading",
+            "role_radius_or_is_pedestrian",
+            "is_robot",
+        ],
+        "mean": [float(value) for value in mean.tolist()],
+        "std": [float(value) for value in std.tolist()],
+        "sample_count": int(valid.shape[0]),
+    }
+
+
+def _build_manifest(
+    *,
+    config: DiffusionPolicyTrainingSmokeConfig,
+    checkpoint_path: Path,
+    normalizer_path: Path,
+    losses: list[float],
+    normalizer: dict[str, Any],
+) -> dict[str, Any]:
+    """Build provenance manifest for generated smoke artifacts.
+
+    Returns:
+        JSON-serializable smoke artifact manifest.
+    """
+    config_payload = asdict(config)
+    return {
+        "schema_version": SMOKE_MANIFEST_SCHEMA_VERSION,
+        "issue": 4010,
+        "artifact_kind": "diffusion_policy_cpu_training_smoke",
+        "evidence_tier": EVIDENCE_TIER,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "provenance": {
+            "git_commit": _git_value(["rev-parse", "HEAD"]),
+            "git_dirty": bool(_git_value(["status", "--short"])),
+            "config_hash": _stable_hash(config_payload),
+            "training_data": "deterministic synthetic crossing fixture; not benchmark evidence",
+        },
+        "config": config_payload,
+        "artifacts": {
+            "checkpoint_path": checkpoint_path.name,
+            "normalizer_path": normalizer_path.name,
+            "checkpoint_format": "encoder_sampler_state_dict",
+            "normalizer_schema_version": normalizer["schema_version"],
+        },
+        "training": {
+            "status": "completed",
+            "steps": config.training_steps,
+            "initial_loss": losses[0],
+            "final_loss": losses[-1],
+            "losses": losses,
+        },
+        "out_of_scope": [
+            "no full benchmark campaign",
+            "no Slurm or GPU submission",
+            "no paper or dissertation claim edits",
+        ],
+    }
+
+
+def _stable_hash(payload: dict[str, Any]) -> str:
+    """Return stable short hash for JSON-serializable payload."""
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def _git_value(args: list[str]) -> str:
+    """Return compact git command output for manifest provenance."""
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+    return completed.stdout.strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the issue #4010 CPU smoke trainer from a YAML config.
+
+    Returns:
+        Process-style exit code.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    args = parser.parse_args(argv)
+    artifacts = run_training_smoke(load_smoke_config(args.config), output_dir=args.output_dir)
+    sys.stdout.write(json.dumps({"manifest_path": str(artifacts.manifest_path)}, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/training/test_diffusion_policy_actor.py
+++ b/tests/training/test_diffusion_policy_actor.py
@@ -1,0 +1,125 @@
+"""CPU smoke tests for issue #4010 diffusion-policy training artifacts."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("torch")
+
+from robot_sf.benchmark.map_runner import _build_policy
+from robot_sf.training.diffusion_policy import (
+    SMOKE_MANIFEST_SCHEMA_VERSION,
+    DiffusionPolicyTrainingSmokeConfig,
+    load_smoke_config,
+    run_training_smoke,
+)
+
+
+def _map_runner_obs() -> dict[str, object]:
+    return {
+        "robot": {
+            "position": [0.0, 0.0],
+            "velocity": [0.0, 0.0],
+            "goal": [2.0, 0.0],
+            "heading": [0.0],
+            "radius": [0.3],
+        },
+        "pedestrians": {
+            "positions": [[0.7, 0.1], [1.1, -0.2]],
+            "velocities": [[-0.1, 0.0], [0.0, 0.1]],
+            "radii": [0.25, 0.25],
+            "count": [2],
+        },
+        "dt": [0.1],
+    }
+
+
+def test_smoke_config_rejects_non_cpu_scale_values() -> None:
+    """The smoke trainer validates the narrow first-slice action contract."""
+    with pytest.raises(ValueError, match="training_steps"):
+        DiffusionPolicyTrainingSmokeConfig(training_steps=0)
+    with pytest.raises(ValueError, match="action_dim=2"):
+        DiffusionPolicyTrainingSmokeConfig(action_dim=3)
+
+
+def test_load_smoke_config_accepts_nested_yaml(tmp_path) -> None:
+    """Tracked YAML config shape maps to the smoke-training dataclass."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "diffusion_policy_training_smoke:\n"
+        "  schema_version: diffusion_policy_training_smoke.v1\n"
+        "  training_steps: 1\n"
+        "  batch_size: 2\n",
+        encoding="utf-8",
+    )
+
+    config = load_smoke_config(config_path)
+
+    assert config.training_steps == 1
+    assert config.batch_size == 2
+
+
+def test_training_smoke_writes_checkpoint_normalizer_manifest(tmp_path) -> None:
+    """CPU smoke writes the three artifacts required by the issue #4010 contract."""
+    config = DiffusionPolicyTrainingSmokeConfig(
+        training_steps=2,
+        batch_size=3,
+        max_pedestrians=2,
+        artifact_prefix="unit_smoke",
+    )
+
+    artifacts = run_training_smoke(config, output_dir=tmp_path)
+
+    assert artifacts.checkpoint_path.is_file()
+    assert artifacts.normalizer_path.is_file()
+    assert artifacts.manifest_path.is_file()
+    normalizer = json.loads(artifacts.normalizer_path.read_text(encoding="utf-8"))
+    manifest = json.loads(artifacts.manifest_path.read_text(encoding="utf-8"))
+    assert normalizer["schema_version"] == "diffusion_policy_normalizer.v1"
+    assert normalizer["sample_count"] > 0
+    assert manifest["schema_version"] == SMOKE_MANIFEST_SCHEMA_VERSION
+    assert manifest["issue"] == 4010
+    assert manifest["artifacts"]["checkpoint_path"] == artifacts.checkpoint_path.name
+    assert manifest["artifacts"]["normalizer_path"] == artifacts.normalizer_path.name
+    assert manifest["training"]["status"] == "completed"
+    assert manifest["evidence_tier"] == "diagnostic-only"
+
+
+def test_map_runner_loads_smoke_checkpoint_not_untrained_weights(tmp_path) -> None:
+    """Map-runner can build diffusion policy from the trained smoke checkpoint."""
+    config = DiffusionPolicyTrainingSmokeConfig(
+        training_steps=2,
+        batch_size=3,
+        max_pedestrians=2,
+        max_linear_speed=0.6,
+        max_angular_speed=0.5,
+        artifact_prefix="map_runner_smoke",
+    )
+    artifacts = run_training_smoke(config, output_dir=tmp_path)
+
+    policy, meta = _build_policy(
+        "diffusion_policy",
+        {
+            "checkpoint_path": str(artifacts.checkpoint_path),
+            "normalizer_path": str(artifacts.normalizer_path),
+            "deterministic": True,
+            "seed": 4010,
+            "max_pedestrians": config.max_pedestrians,
+            "max_linear_speed": config.max_linear_speed,
+            "max_angular_speed": config.max_angular_speed,
+            "num_action_samples": config.num_action_samples,
+            "denoising_steps": config.denoising_steps,
+        },
+        robot_kinematics="differential_drive",
+    )
+
+    command = policy(_map_runner_obs())
+    stats = policy._planner_stats()
+
+    assert 0.0 <= command[0] <= config.max_linear_speed
+    assert -config.max_angular_speed <= command[1] <= config.max_angular_speed
+    assert meta["diffusion_policy"]["allow_untrained_smoke"] is False
+    assert stats["diffusion_policy"]["allow_untrained_smoke"] is False
+    assert stats["diffusion_policy"]["evidence_tier"] == "diagnostic-only"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Adds a CPU-only diffusion-policy training smoke entry point, tracked smoke config, checkpoint plus normalizer manifest emission, and a map-runner load test that builds the planner from the generated smoke checkpoint rather than untrained weights.

Why now: #4156 established the runtime adapter and map-runner builder; this is the next progression slice toward issue #4010's maintainer plan.

Claim boundary: Diagnostic-only smoke evidence. This PR proves the artifact/load contract and finite bounded commands on a tiny synthetic fixture. It does not claim navigation quality, COLSON reproduction, benchmark performance, or paper/dissertation evidence.

Required validation: focused CPU tests for the smoke trainer, diffusion planner, map-runner diffusion policy, Ruff on changed training/benchmark/test surfaces, tracked smoke config CLI run, and PR-ready wrapper freshness.

Remaining blocker: Full benchmark campaign, GPU/Slurm training, recurrent PPO comparison, multi-modal diagnostic fixture reporting, and paper-grade claims remain out of scope.

## Contract delta

- New config: `configs/training/diffusion_policy/issue_4010_smoke.yaml` with `diffusion_policy_training_smoke.v1`.
- New smoke artifact manifest schema emitted at runtime: `diffusion_policy_smoke_manifest.v1`.
- New normalizer JSON schema emitted at runtime: `diffusion_policy_normalizer.v1`.
- New fail-closed blockers: invalid smoke config values, missing PyTorch, missing checkpoint/normalizer files through the existing adapter path.
- Compatibility impact: existing untrained-smoke map-runner behavior remains available only when `allow_untrained_smoke: true`; checkpoint-backed construction now records `checkpoint_status: checkpoint_loaded` and a diagnostic checkpoint limitation instead of the untrained-smoke limitation.

## Linked Issues

- Relates to `#4010`

## What Changed

- Added `robot_sf.training.diffusion_policy` with a deterministic CPU smoke trainer that writes:
  - adapter-compatible checkpoint (`encoder` and `sampler` state dicts),
  - normalizer JSON,
  - provenance manifest with config hash, git commit, dirty flag, diagnostic-only claim boundary, and out-of-scope notes.
- Added the tracked smoke config under `configs/training/diffusion_policy/issue_4010_smoke.yaml`.
- Added tests for config validation, artifact emission, manifest contents, and map-runner load from the smoke checkpoint.
- Updated diffusion map-runner metadata to distinguish untrained smoke from loaded smoke checkpoint mode.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #4010 first training-lane blocker: diffusion-policy smoke artifacts can be produced and loaded by map-runner.
- Comparator or baseline, applicable: NA for this slice; no policy-quality comparison.
- Evidence tier: NA - implementation smoke only; no research result or benchmark claim is promoted.
- Result classification: NA - no research result; this is a smoke artifact/load contract.
- Decision stop rule, applicable: stop before claims; continue only to the next empirical slice after smoke checkpoint load is reviewable.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #4010; no claim-map update because this is not benchmark evidence.
- New research/benchmark/metric/paper-facing analysis tool, any: NA.

## Domain-Aware Approval

- Required PR: required for diagnostic-only smoke evidence; no benchmark or paper-facing claim promotion.
- Domains reviewed: diffusion-policy smoke artifact/load contract.
- Status: waived for claim promotion; no benchmark or paper-facing claim is made.
- Approver/review source waiver: PR body claim boundary and issue #4010 maintainer plan.
- Approval or blocker note: waived because this PR only validates smoke artifact plumbing and explicitly defers claim promotion to #4010 follow-up work.
- Validity checklist:
- Target claim/hypothesis: smoke artifact/load contract only.
- Comparator or split/evidence validity: NA; no comparator.
- Fallback/degraded exclusions: untrained smoke remains explicit; checkpoint-backed map-runner test uses generated checkpoint and normalizer.
- Claim boundary: diagnostic-only, not benchmark evidence.
- Implementation integrity vs experimental validity: implementation smoke validated; experimental validity deferred.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, CPU smoke training writes checkpoint/normalizer/manifest and map-runner loads the checkpoint.
- Did intervention change command source, selected command, trajectory, route progress? command source can now be checkpoint-backed smoke weights; trajectory/route progress not evaluated.
- Did scenario actually contain targeted failure mode? NA; synthetic fixture only validates artifact/load contract.
- Result route: continue to next empirical slice, no claim promotion.
- Follow-up question issue weak, negative, non-transfer results: no new issue opened; remaining work stays under #4010.

## Next Empirical Action

- Rerun needed: yes, for a representative scenario smoke run beyond this artifact/load contract.
- Extractor analysis tool needed: no for this slice.
- Artifact missing unavailable: no durable trained model artifact is committed; smoke artifacts are generated locally from tracked config.
- Stop / revise / continue decision: continue with #4010 follow-up for representative scenario and multi-modal diagnostic fixture.
- Proposed child issue existing follow-up: #4010.

## Validation / Proof

- `uv run pytest tests/training/test_diffusion_policy_actor.py tests/planner/test_diffusion_policy.py tests/benchmark/test_map_runner_diffusion_policy.py -q` -> passed, 24 tests.
- `uv run pytest tests/training/test_diffusion_policy_actor.py tests/benchmark -k "diffusion_policy" -q` -> passed, 7 tests, 2887 deselected.
- `uv run python -m robot_sf.training.diffusion_policy --config configs/training/diffusion_policy/issue_4010_smoke.yaml --output-dir output/validation/issue_4010_smoke_cli_rerun` -> passed, manifest path printed.
- `uv run ruff check robot_sf/training robot_sf/benchmark tests/training/test_diffusion_policy_actor.py` -> passed.
- Late issue refresh: `gh issue view 4010 --repo ll7/robot_sf_ll7 --comments` failed on GitHub classic Projects GraphQL deprecation; REST fallback read issue plus all comments. Latest comment remains `2026-07-02T15:29:57Z`, before this work started, so no late maintainer guidance was missed.

## Performance Impact

- Baseline runtime: NA; no campaign/runtime performance claim.
- Changed runtime: NA; no campaign/runtime performance claim.
- Representative command: `uv run python -m robot_sf.training.diffusion_policy --config configs/training/diffusion_policy/issue_4010_smoke.yaml --output-dir output/validation/issue_4010_smoke_cli_rerun`
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: smoke checkpoint no longer loads through map-runner or commands are non-finite/out of configured bounds.

## Risks / Rollout

- Compatibility risks: generated checkpoints assume the current diffusion adapter hidden width; config keeps that default explicit.
- Failure modes: smoke fixture can prove artifact plumbing while saying nothing about navigation quality.
- Rollback fallback plan: revert this PR; #4156 untrained diagnostic runtime path remains independent.

## Docs / Provenance

- Updated docs: NA; tracked config and manifest schema are self-contained.
- Relevant design provenance notes: issue #4010 and #4156.
- Any assumptions need to preserved: smoke artifacts are generated locally and remain ignored under `output/`; only the reproducible config and code are tracked.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark, registry, claim-map, or paper-facing result is introduced. For state propagation, this high-churn issue already has multiple recent PRs; this PR body is the single durable propagation surface for this slice rather than adding another issue comment stream.

## Follow-Up Issues

- Deferred work: representative scenario smoke run, multi-modal diagnostic fixture report, baseline comparator manifest execution, GPU/Slurm training campaign if later authorized; tracked by #4010.
- Issues opened follow-up: #4010 remains open for this staged lane.

## Reviewer Notes

- Check `tests/training/test_diffusion_policy_actor.py::test_map_runner_loads_smoke_checkpoint_not_untrained_weights`; it is the critical regression test for the post-#4156 artifact/load contract.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Governance notes</summary>

Fragmentation guard: recent issue #4010 work includes #4156, but this is a progression slice with a nameable new capability: CPU training smoke plus checkpoint/normalizer manifest and checkpoint-backed map-runner load.

Forbidden actions confirmed: no compute submission, no merge, no release, no deletion.

</details>
