### PR TITLE
Issue #3501: preregister safety wrapper factorial smoke

### DIFF
--- a/configs/benchmarks/issue_3501_safety_wrapper_factorial_preregistration_cpu_smoke.yaml
+++ b/configs/benchmarks/issue_3501_safety_wrapper_factorial_preregistration_cpu_smoke.yaml
@@ -1,0 +1,67 @@
+# Issue #3501 safety-wrapper on/off factorial pre-registration CPU smoke.
+#
+# This is a no-submit public contract for the first executable slice after the
+# runtime binding gate. It freezes one CPU smoke family before any queue
+# campaign: same planner policy, same scenario family, same seed, and only the
+# safety_wrapper runtime config differs between wrapper_off and wrapper_on.
+schema_version: robot_sf.issue_3501_safety_wrapper_factorial_preregistration.v1
+issue: 3501
+study_id: issue_3501_safety_wrapper_factorial_preregistration_cpu_smoke_v1
+status: pre_registered_cpu_smoke_only
+benchmark_evidence: false
+claim_boundary: >
+  Pre-registration and CPU harness contract only. Planned rows may prove the
+  paired wrapper off/on design is well formed, but they are not benchmark
+  evidence, mitigation-effectiveness evidence, deployment-safety evidence, or
+  paper/dissertation claim support until a later campaign executes and emits a
+  durable evidence packet.
+out_of_scope:
+  - full benchmark campaign execution
+  - Slurm or GPU submission
+  - mitigation-effectiveness claims
+  - paper or dissertation claim edits
+source_contracts:
+  ablation_design: configs/research/safety_wrapper_ablation_v1.yaml
+  runtime_validator: robot_sf/benchmark/safety_wrapper_runtime.py::validate_runtime_config
+  planner_source: configs/benchmarks/paper_experiment_matrix_v1.yaml::planners[].key
+campaign_authorization:
+  compute_submit_authorized: false
+  no_slurm_submission_in_this_pr: true
+  no_gpu_submission_in_this_pr: true
+scenario_family:
+  key: francis2023_blind_corner_cpu_smoke
+  scenario_matrix: configs/scenarios/single/francis2023_blind_corner.yaml
+  scenario_ids:
+    - francis2023_blind_corner
+  seeds: [111]
+policy:
+  planner_key: orca
+  planner_source: configs/benchmarks/paper_experiment_matrix_v1.yaml::planners[].key
+  policy_config:
+    planner: orca
+    mode: cpu_smoke
+wrapper_arms:
+  - key: wrapper_off
+    baseline: true
+    safety_wrapper:
+      enabled: false
+      arm_key: wrapper_off
+  - key: wrapper_on
+    baseline: false
+    safety_wrapper:
+      enabled: true
+      arm_key: wrapper_on
+      pedestrian_caution_radius_m: 2.0
+      capped_speed_m_s: 0.5
+      ttc_veto_threshold_s: 1.0
+      clearance_veto_m: 0.3
+pairing_key_fields:
+  - study_id
+  - planner
+  - scenario_family
+  - scenario_id
+  - seed
+required_before_submit:
+  - this pre-registration config is merged on origin/main
+  - harness planned-row check passes without threshold or policy drift
+  - downstream queue run records software commit and wrapper config hash

--- a/robot_sf/benchmark/safety_wrapper_factorial_preregistration.py
+++ b/robot_sf/benchmark/safety_wrapper_factorial_preregistration.py
@@ -1,0 +1,356 @@
+"""Pre-registration harness for issue #3501 wrapper on/off factorial smoke rows.
+
+The harness is deliberately CPU-only and no-submit: it validates a tracked
+pre-registration config, checks the wrapper arms through the runtime validator,
+and emits deterministic planned rows. It does not execute benchmark episodes.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.safety_wrapper_runtime import runtime_config_from_mapping
+
+SCHEMA_VERSION = "robot_sf.issue_3501_safety_wrapper_factorial_preregistration.v1"
+EXPECTED_WRAPPER_ARMS = ("wrapper_off", "wrapper_on")
+PAIRING_KEY_FIELDS = ("study_id", "planner", "scenario_family", "scenario_id", "seed")
+
+
+def load_factorial_preregistration_config(path: str | Path) -> dict[str, Any]:
+    """Load and validate an issue #3501 factorial pre-registration config.
+
+    Returns:
+        Validated configuration payload.
+    """
+
+    config_path = Path(path)
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"factorial pre-registration config must be mapping: {config_path}")
+    return validate_factorial_preregistration_config(payload, config_path=config_path)
+
+
+def validate_factorial_preregistration_config(
+    config: Mapping[str, Any],
+    *,
+    config_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Validate the no-submit wrapper on/off CPU-smoke factorial contract.
+
+    Returns:
+        Shallow-normalized configuration payload.
+    """
+
+    normalized = dict(config)
+    if normalized.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {SCHEMA_VERSION!r}")
+    if int(normalized.get("issue", 0)) != 3501:
+        raise ValueError("issue must be 3501")
+    if normalized.get("benchmark_evidence") is not False:
+        raise ValueError("benchmark_evidence must be false for pre-registration")
+    _reject_transient_routing_state(normalized)
+    _validate_source_paths(normalized, config_path=config_path)
+    _validate_scenario_family(normalized.get("scenario_family"), config_path=config_path)
+    _validate_policy(normalized.get("policy"), config_path=config_path)
+    _validate_wrapper_arms(normalized.get("wrapper_arms"))
+    if tuple(normalized.get("pairing_key_fields") or ()) != PAIRING_KEY_FIELDS:
+        raise ValueError(f"pairing_key_fields must be {list(PAIRING_KEY_FIELDS)!r}")
+    return normalized
+
+
+def build_preregistration_plan(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Build deterministic planned rows for the paired CPU-smoke factorial.
+
+    Returns:
+        Planned-row packet with pair-check summary.
+    """
+
+    validated = validate_factorial_preregistration_config(config)
+    scenario_family = validated["scenario_family"]
+    policy = copy.deepcopy(validated["policy"])
+    policy_fingerprint = _stable_hash(policy)
+    arms = _normalized_arms(validated["wrapper_arms"])
+    rows: list[dict[str, Any]] = []
+
+    for scenario_id in scenario_family["scenario_ids"]:
+        for seed in scenario_family["seeds"]:
+            for arm in arms:
+                rows.append(
+                    {
+                        "study_id": str(validated["study_id"]),
+                        "planner": str(policy["planner_key"]),
+                        "policy": copy.deepcopy(policy),
+                        "policy_fingerprint": policy_fingerprint,
+                        "scenario_family": str(scenario_family["key"]),
+                        "scenario_matrix": str(scenario_family["scenario_matrix"]),
+                        "scenario_id": str(scenario_id),
+                        "seed": int(seed),
+                        "wrapper_arm": str(arm["key"]),
+                        "baseline": bool(arm["baseline"]),
+                        "safety_wrapper": copy.deepcopy(arm["safety_wrapper"]),
+                        "safety_wrapper_runtime_config": copy.deepcopy(
+                            arm["safety_wrapper_runtime_config"]
+                        ),
+                    }
+                )
+
+    pair_check = check_planned_rows(rows)
+    return {
+        "schema_version": "robot_sf.issue_3501_safety_wrapper_factorial_plan.v1",
+        "source_schema_version": SCHEMA_VERSION,
+        "issue": 3501,
+        "study_id": str(validated["study_id"]),
+        "status": "planned_rows_cpu_smoke_only",
+        "benchmark_evidence": False,
+        "claim_boundary": str(validated["claim_boundary"]),
+        "pairing_key_fields": list(PAIRING_KEY_FIELDS),
+        "row_count": len(rows),
+        "pair_check": pair_check,
+        "rows": rows,
+    }
+
+
+def check_planned_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Check that each planned pair differs only by wrapper arm/config.
+
+    Returns:
+        Pair-completeness report.
+    """
+
+    grouped: dict[tuple[Any, ...], dict[str, list[Mapping[str, Any]]]] = {}
+    invalid_rows: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        missing = [field for field in (*PAIRING_KEY_FIELDS, "wrapper_arm") if field not in row]
+        if missing:
+            invalid_rows.append({"row_index": index, "fields": missing})
+            continue
+        wrapper_arm = str(row["wrapper_arm"])
+        key = tuple(row[field] for field in PAIRING_KEY_FIELDS)
+        grouped.setdefault(key, {}).setdefault(wrapper_arm, []).append(row)
+
+    incomplete_pairs: list[dict[str, Any]] = []
+    policy_mismatches: list[dict[str, Any]] = []
+    for key, by_arm in grouped.items():
+        if set(by_arm) != set(EXPECTED_WRAPPER_ARMS) or any(
+            len(arm_rows) != 1 for arm_rows in by_arm.values()
+        ):
+            incomplete_pairs.append(
+                {
+                    "pairing_key": dict(zip(PAIRING_KEY_FIELDS, key, strict=True)),
+                    "wrapper_arms": sorted(by_arm),
+                }
+            )
+            continue
+        off_row = by_arm["wrapper_off"][0]
+        on_row = by_arm["wrapper_on"][0]
+        if off_row.get("policy_fingerprint") != on_row.get("policy_fingerprint"):
+            policy_mismatches.append(
+                {
+                    "pairing_key": dict(zip(PAIRING_KEY_FIELDS, key, strict=True)),
+                    "field": "policy_fingerprint",
+                }
+            )
+
+    complete = bool(rows) and not invalid_rows and not incomplete_pairs and not policy_mismatches
+    return {
+        "complete": complete,
+        "row_count": len(rows),
+        "pair_count": len(grouped),
+        "expected_wrapper_arms": list(EXPECTED_WRAPPER_ARMS),
+        "invalid_rows": invalid_rows,
+        "incomplete_pairs": incomplete_pairs,
+        "policy_mismatches": policy_mismatches,
+    }
+
+
+def write_preregistration_plan(plan: Mapping[str, Any], output_dir: str | Path) -> Path:
+    """Write a deterministic planned-row JSON artifact.
+
+    Returns:
+        Path to the written JSON plan.
+    """
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / "issue_3501_safety_wrapper_factorial_preregistration_plan.json"
+    path.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _validate_source_paths(
+    config: Mapping[str, Any],
+    *,
+    config_path: str | Path | None,
+) -> None:
+    source_contracts = config.get("source_contracts")
+    if not isinstance(source_contracts, Mapping):
+        raise ValueError("source_contracts must be mapping")
+    for key in ("ablation_design", "runtime_validator", "planner_source"):
+        value = source_contracts.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"source_contracts.{key} must be non-empty string")
+
+    if config_path is None:
+        return
+    for key in ("ablation_design", "planner_source"):
+        path_text = str(source_contracts[key]).split("::", maxsplit=1)[0]
+        if not _resolve_existing_path(path_text, config_path=Path(config_path)).exists():
+            raise ValueError(f"source_contracts.{key} path does not exist: {path_text}")
+
+
+def _validate_scenario_family(value: Any, *, config_path: str | Path | None) -> None:
+    if not isinstance(value, Mapping):
+        raise ValueError("scenario_family must be mapping")
+    for key in ("key", "scenario_matrix"):
+        if not isinstance(value.get(key), str) or not value[key].strip():
+            raise ValueError(f"scenario_family.{key} must be non-empty string")
+    scenario_ids = value.get("scenario_ids")
+    if (
+        not isinstance(scenario_ids, Sequence)
+        or isinstance(scenario_ids, (str, bytes))
+        or not scenario_ids
+        or not all(isinstance(item, str) and item.strip() for item in scenario_ids)
+    ):
+        raise ValueError("scenario_family.scenario_ids must be non-empty string list")
+    seeds = value.get("seeds")
+    if (
+        not isinstance(seeds, Sequence)
+        or isinstance(seeds, (str, bytes))
+        or not seeds
+        or not all(isinstance(seed, int) and not isinstance(seed, bool) for seed in seeds)
+    ):
+        raise ValueError("scenario_family.seeds must be non-empty integer list")
+    if len(set(seeds)) != len(seeds):
+        raise ValueError("scenario_family.seeds must be unique and paired across arms")
+    if config_path is not None:
+        scenario_path = _resolve_existing_path(
+            str(value["scenario_matrix"]),
+            config_path=Path(config_path),
+        )
+        if not scenario_path.exists():
+            raise ValueError(
+                f"scenario_family.scenario_matrix path does not exist: {scenario_path}"
+            )
+
+
+def _validate_policy(value: Any, *, config_path: str | Path | None) -> None:
+    if not isinstance(value, Mapping):
+        raise ValueError("policy must be mapping")
+    for key in ("planner_key", "planner_source", "policy_config"):
+        if key not in value:
+            raise ValueError(f"policy.{key} is required")
+    if not isinstance(value["planner_key"], str) or not value["planner_key"].strip():
+        raise ValueError("policy.planner_key must be non-empty string")
+    if not isinstance(value["planner_source"], str) or not value["planner_source"].strip():
+        raise ValueError("policy.planner_source must be non-empty string")
+    if not isinstance(value["policy_config"], Mapping):
+        raise ValueError("policy.policy_config must be mapping")
+    if config_path is not None:
+        planner_keys = _load_declared_planner_keys(
+            str(value["planner_source"]),
+            config_path=Path(config_path),
+        )
+        if str(value["planner_key"]) not in planner_keys:
+            raise ValueError(
+                f"policy.planner_key {value['planner_key']!r} not declared by planner_source"
+            )
+
+
+def _validate_wrapper_arms(value: Any) -> None:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError("wrapper_arms must be list")
+    if not all(isinstance(arm, Mapping) for arm in value):
+        raise ValueError("each wrapper_arms entry must be mapping")
+    by_key = {str(arm.get("key")): arm for arm in value}
+    if tuple(by_key) != EXPECTED_WRAPPER_ARMS:
+        raise ValueError(f"wrapper_arms must be ordered {list(EXPECTED_WRAPPER_ARMS)!r}")
+    baselines = [key for key, arm in by_key.items() if bool(arm.get("baseline", False))]
+    if baselines != ["wrapper_off"]:
+        raise ValueError("wrapper_off must be the only baseline arm")
+    for key, arm in by_key.items():
+        wrapper = arm.get("safety_wrapper")
+        if not isinstance(wrapper, Mapping):
+            raise ValueError(f"{key}.safety_wrapper must be mapping")
+        runtime = runtime_config_from_mapping(wrapper)
+        if asdict(runtime)["arm_key"] != key:
+            raise ValueError(f"{key}.safety_wrapper.arm_key must match wrapper arm key")
+
+
+def _normalized_arms(arms: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for arm in arms:
+        runtime = runtime_config_from_mapping(arm["safety_wrapper"])
+        normalized.append(
+            {
+                "key": str(arm["key"]),
+                "baseline": bool(arm.get("baseline", False)),
+                "safety_wrapper": copy.deepcopy(dict(arm["safety_wrapper"])),
+                "safety_wrapper_runtime_config": asdict(runtime),
+            }
+        )
+    return normalized
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _resolve_existing_path(path_text: str, *, config_path: Path) -> Path:
+    candidate = Path(path_text)
+    if candidate.is_absolute():
+        return candidate
+    cwd_candidate = Path.cwd() / candidate
+    if cwd_candidate.exists():
+        return cwd_candidate
+    for parent in config_path.resolve().parents:
+        parent_candidate = parent / candidate
+        if parent_candidate.exists():
+            return parent_candidate
+    return cwd_candidate
+
+
+def _load_declared_planner_keys(path_text: str, *, config_path: Path) -> set[str]:
+    source_path = _resolve_existing_path(
+        path_text.split("::", maxsplit=1)[0], config_path=config_path
+    )
+    if not source_path.exists():
+        raise ValueError(f"policy.planner_source path does not exist: {source_path}")
+    payload = yaml.safe_load(source_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"policy.planner_source must be mapping: {source_path}")
+    planners = payload.get("planners")
+    if not isinstance(planners, Sequence) or isinstance(planners, (str, bytes)):
+        raise ValueError(f"policy.planner_source missing planners list: {source_path}")
+    return {
+        str(planner["key"])
+        for planner in planners
+        if isinstance(planner, Mapping) and isinstance(planner.get("key"), str)
+    }
+
+
+def _reject_transient_routing_state(config: Mapping[str, Any]) -> None:
+    forbidden_keys = {"target_host", "packet_lineage", "queue_route", "submit_host"}
+    found = sorted(forbidden_keys & set(config))
+    if found:
+        raise ValueError(f"transient queue-routing state is forbidden in tracked config: {found}")
+
+
+__all__ = [
+    "EXPECTED_WRAPPER_ARMS",
+    "PAIRING_KEY_FIELDS",
+    "SCHEMA_VERSION",
+    "build_preregistration_plan",
+    "check_planned_rows",
+    "load_factorial_preregistration_config",
+    "validate_factorial_preregistration_config",
+    "write_preregistration_plan",
+]

--- a/scripts/benchmark/build_issue3501_safety_wrapper_factorial_preregistration.py
+++ b/scripts/benchmark/build_issue3501_safety_wrapper_factorial_preregistration.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Build issue #3501 safety-wrapper factorial pre-registration planned rows."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from robot_sf.benchmark.safety_wrapper_factorial_preregistration import (
+    build_preregistration_plan,
+    load_factorial_preregistration_config,
+    write_preregistration_plan,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = (
+    "configs/benchmarks/issue_3501_safety_wrapper_factorial_preregistration_cpu_smoke.yaml"
+)
+
+
+def _git_head() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5,
+    )
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed CLI namespace.
+    """
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=DEFAULT_CONFIG, help="Tracked pre-registration YAML.")
+    parser.add_argument(
+        "--out",
+        default="output/issue_3501_safety_wrapper_factorial_preregistration",
+        help="Output directory for deterministic planned-row JSON.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the planned-row builder.
+
+    Returns:
+        Process exit code.
+    """
+
+    args = parse_args()
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        config_path = REPO_ROOT / config_path
+    config = load_factorial_preregistration_config(config_path)
+    plan = build_preregistration_plan(config)
+    plan["git_head"] = _git_head()
+    out_path = write_preregistration_plan(plan, REPO_ROOT / args.out)
+    print(out_path.relative_to(REPO_ROOT))
+    print(f"pair_check.complete={plan['pair_check']['complete']}")
+    print(f"row_count={plan['row_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark/build_issue3501_safety_wrapper_factorial_preregistration.py
+++ b/scripts/benchmark/build_issue3501_safety_wrapper_factorial_preregistration.py
@@ -63,7 +63,11 @@ def main() -> int:
     plan = build_preregistration_plan(config)
     plan["git_head"] = _git_head()
     out_path = write_preregistration_plan(plan, REPO_ROOT / args.out)
-    print(out_path.relative_to(REPO_ROOT))
+    try:
+        display_path = out_path.relative_to(REPO_ROOT)
+    except ValueError:
+        display_path = out_path
+    print(display_path)
     print(f"pair_check.complete={plan['pair_check']['complete']}")
     print(f"row_count={plan['row_count']}")
     return 0

--- a/tests/benchmark/test_safety_wrapper_factorial_preregistration.py
+++ b/tests/benchmark/test_safety_wrapper_factorial_preregistration.py
@@ -1,0 +1,175 @@
+"""Tests for issue #3501 safety-wrapper factorial pre-registration harness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.safety_wrapper_factorial_preregistration import (
+    EXPECTED_WRAPPER_ARMS,
+    build_preregistration_plan,
+    check_planned_rows,
+    load_factorial_preregistration_config,
+    validate_factorial_preregistration_config,
+    write_preregistration_plan,
+)
+
+CONFIG_PATH = Path(
+    "configs/benchmarks/issue_3501_safety_wrapper_factorial_preregistration_cpu_smoke.yaml"
+)
+
+
+def _config() -> dict[str, object]:
+    return load_factorial_preregistration_config(CONFIG_PATH)
+
+
+def test_preregistration_plan_has_paired_off_on_rows_with_identical_policy() -> None:
+    """The CPU-smoke row pair differs only by wrapper arm/config."""
+
+    plan = build_preregistration_plan(_config())
+
+    assert plan["benchmark_evidence"] is False
+    assert plan["status"] == "planned_rows_cpu_smoke_only"
+    assert plan["row_count"] == 2
+    assert plan["pair_check"]["complete"] is True
+    assert plan["pair_check"]["expected_wrapper_arms"] == list(EXPECTED_WRAPPER_ARMS)
+
+    rows = plan["rows"]
+    assert {row["wrapper_arm"] for row in rows} == {"wrapper_off", "wrapper_on"}
+    assert {row["planner"] for row in rows} == {"orca"}
+    assert {row["scenario_family"] for row in rows} == {"francis2023_blind_corner_cpu_smoke"}
+    assert {row["scenario_id"] for row in rows} == {"francis2023_blind_corner"}
+    assert {row["seed"] for row in rows} == {111}
+    assert len({row["policy_fingerprint"] for row in rows}) == 1
+
+
+def test_wrapper_on_thresholds_are_checked_by_runtime_validator() -> None:
+    """Threshold drift fails closed through validate_runtime_config."""
+
+    config = _config()
+    config["wrapper_arms"][1]["safety_wrapper"]["ttc_veto_threshold_s"] = 1.25
+
+    with pytest.raises(ValueError, match="predeclared ablation config"):
+        build_preregistration_plan(config)
+
+
+def test_wrapper_off_on_arm_identity_must_match_enabled_flag() -> None:
+    """Swapping arm identity fails before any planned rows are emitted."""
+
+    config = _config()
+    config["wrapper_arms"][0]["safety_wrapper"]["arm_key"] = "wrapper_on"
+
+    with pytest.raises(ValueError, match="enabled=False requires arm_key='wrapper_off'"):
+        build_preregistration_plan(config)
+
+
+def test_pair_check_rejects_policy_drift_within_wrapper_pair() -> None:
+    """A paired contrast is invalid if policy identity changes across arms."""
+
+    plan = build_preregistration_plan(_config())
+    rows = list(plan["rows"])
+    rows[1] = dict(rows[1])
+    rows[1]["policy_fingerprint"] = "different-policy"
+
+    report = check_planned_rows(rows)
+
+    assert report["complete"] is False
+    assert report["policy_mismatches"] == [
+        {
+            "pairing_key": {
+                "study_id": "issue_3501_safety_wrapper_factorial_preregistration_cpu_smoke_v1",
+                "planner": "orca",
+                "scenario_family": "francis2023_blind_corner_cpu_smoke",
+                "scenario_id": "francis2023_blind_corner",
+                "seed": 111,
+            },
+            "field": "policy_fingerprint",
+        }
+    ]
+
+
+def test_pair_check_reports_invalid_and_incomplete_rows() -> None:
+    """Planned rows must contain wrapper arm and complete off/on pairs."""
+
+    invalid_report = check_planned_rows(
+        [
+            {
+                "study_id": "study",
+                "planner": "orca",
+                "scenario_family": "family",
+                "scenario_id": "scenario",
+                "seed": 111,
+            }
+        ]
+    )
+    assert invalid_report["complete"] is False
+    assert invalid_report["invalid_rows"] == [{"row_index": 0, "fields": ["wrapper_arm"]}]
+
+    incomplete_report = check_planned_rows(
+        [
+            {
+                "study_id": "study",
+                "planner": "orca",
+                "policy_fingerprint": "same",
+                "scenario_family": "family",
+                "scenario_id": "scenario",
+                "seed": 111,
+                "wrapper_arm": "wrapper_off",
+            }
+        ]
+    )
+    assert incomplete_report["complete"] is False
+    assert incomplete_report["incomplete_pairs"] == [
+        {
+            "pairing_key": {
+                "study_id": "study",
+                "planner": "orca",
+                "scenario_family": "family",
+                "scenario_id": "scenario",
+                "seed": 111,
+            },
+            "wrapper_arms": ["wrapper_off"],
+        }
+    ]
+
+
+def test_write_preregistration_plan_outputs_deterministic_json(tmp_path: Path) -> None:
+    """The CLI helper writes the reviewable planned-row packet."""
+
+    plan = build_preregistration_plan(_config())
+    path = write_preregistration_plan(plan, tmp_path)
+
+    assert path.name == "issue_3501_safety_wrapper_factorial_preregistration_plan.json"
+    assert path.read_text(encoding="utf-8").endswith("\n")
+    assert '"pair_check"' in path.read_text(encoding="utf-8")
+
+
+def test_config_rejects_transient_queue_routing_state() -> None:
+    """Tracked config must not encode target host or packet lineage state."""
+
+    config = _config()
+    config["target_host"] = "imech156-u"
+
+    with pytest.raises(ValueError, match="transient queue-routing state"):
+        validate_factorial_preregistration_config(config, config_path=CONFIG_PATH)
+
+
+def test_config_rejects_missing_source_contract_path() -> None:
+    """Source contracts must point at tracked public files."""
+
+    config = _config()
+    config["source_contracts"]["ablation_design"] = "configs/research/missing_3501.yaml"
+
+    with pytest.raises(ValueError, match="source_contracts.ablation_design path does not exist"):
+        validate_factorial_preregistration_config(config, config_path=CONFIG_PATH)
+
+
+def test_config_rejects_planner_not_declared_by_source() -> None:
+    """CPU-smoke planner identity must resolve against the declared planner source."""
+
+    config = _config()
+    config["policy"]["planner_key"] = "missing_planner"
+
+    with pytest.raises(ValueError, match="not declared by planner_source"):
+        validate_factorial_preregistration_config(config, config_path=CONFIG_PATH)

--- a/tests/benchmark/test_safety_wrapper_factorial_preregistration.py
+++ b/tests/benchmark/test_safety_wrapper_factorial_preregistration.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -143,6 +145,28 @@ def test_write_preregistration_plan_outputs_deterministic_json(tmp_path: Path) -
     assert path.name == "issue_3501_safety_wrapper_factorial_preregistration_plan.json"
     assert path.read_text(encoding="utf-8").endswith("\n")
     assert '"pair_check"' in path.read_text(encoding="utf-8")
+
+
+def test_cli_accepts_output_directory_outside_repo(tmp_path: Path) -> None:
+    """The CLI can write validation output outside the repository."""
+    out_dir = tmp_path / "issue3501-plan"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/benchmark/build_issue3501_safety_wrapper_factorial_preregistration.py",
+            "--config",
+            str(CONFIG_PATH),
+            "--out",
+            str(out_dir),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "pair_check.complete=True" in completed.stdout
+    assert (out_dir / "issue_3501_safety_wrapper_factorial_preregistration_plan.json").is_file()
 
 
 def test_config_rejects_transient_queue_routing_state() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a no-submit #3501 CPU-smoke pre-registration config plus a harness/CLI that validates and emits paired `wrapper_off`/`wrapper_on` planned rows.

Why now: #4137 merged the runtime validator; this slice freezes the next reversible public contract before any queue campaign so the paired run cannot silently drift on policy, family, seed, or wrapper thresholds.

Claim boundary: planned-row contract only. This is not benchmark evidence, not mitigation-effectiveness evidence, not deployment-safety evidence, and not paper/dissertation claim support.

Required validation: focused safety-wrapper tests, harness smoke, lint/format, and final PR readiness.

Remaining blocker: downstream paired campaign execution/reporting is still open; no full benchmark campaign, no Slurm/GPU submission, and no paper/dissertation claim edits are included here.

## Contract delta

- New schema surface: `robot_sf.issue_3501_safety_wrapper_factorial_preregistration.v1` in `configs/benchmarks/issue_3501_safety_wrapper_factorial_preregistration_cpu_smoke.yaml`.
- New planned-row packet: `robot_sf.issue_3501_safety_wrapper_factorial_plan.v1`, emitted by `scripts/benchmark/build_issue3501_safety_wrapper_factorial_preregistration.py`.
- New fail-closed blockers: benchmark_evidence must be false; transient queue-routing fields such as `target_host` are rejected; source paths must resolve; the CPU-smoke planner must exist in the declared planner source; wrapper arms must be ordered `wrapper_off` then `wrapper_on`; each arm must pass `validate_runtime_config`; paired rows must share the same policy fingerprint.
- Compatibility impact: additive only. No existing benchmark runner behavior changes; no runtime wrapper defaults change; no campaign execution path is invoked.

## Issue

Closes no issue. Progresses https://github.com/ll7/robot_sf_ll7/issues/3501.

## Scope summary

- Adds a tracked CPU-smoke pre-registration for one ORCA paired contrast on `francis2023_blind_corner` seed `111`.
- Adds `robot_sf.benchmark.safety_wrapper_factorial_preregistration` for validating the config and emitting deterministic planned rows.
- Adds a CLI smoke builder for the planned-row JSON under ignored `output/`.
- Adds focused tests for pair completeness, threshold drift rejection, arm identity rejection, policy drift rejection, transient queue state rejection, and planner-source reconciliation.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_safety_wrapper_factorial_preregistration.py -q` -> 9 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_safety_wrapper_factorial_preregistration.py tests/benchmark/test_safety_wrapper_ablation_manifest.py tests/benchmark/test_safety_wrapper_runtime.py -q` -> 57 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_issue3501_safety_wrapper_factorial_preregistration.py --out output/validation/issue_3501_preregistration_smoke` -> `pair_check.complete=True`, `row_count=2`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/safety_wrapper_factorial_preregistration.py scripts/benchmark/build_issue3501_safety_wrapper_factorial_preregistration.py tests/benchmark/test_safety_wrapper_factorial_preregistration.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/safety_wrapper_factorial_preregistration.py scripts/benchmark/build_issue3501_safety_wrapper_factorial_preregistration.py tests/benchmark/test_safety_wrapper_factorial_preregistration.py` -> passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr3501_body.md scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh` -> passed; clean-tree stamp at `output/validation/pr_ready/issue-3501-safety-wrapper-on-off-factorial-pre-registration-slice-configs-harness.json`, 1766 core tests passed and 4519 optional-lane tests passed.

## Out of scope

No full benchmark campaign run. No Slurm/GPU submission. No paper/dissertation claim edits. No target-host or queue-routing state added to tracked files.

## State propagation

Issue comments are not authorized for this task (`comment_issue_or_pr: false`). This PR body is the propagation surface for the delivered slice, remaining work, and claim boundary.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: recent #3501 support slices merged on 2026-07-02, but this is a progression slice adding a nameable new capability: a paired CPU-smoke pre-registration harness backed by `validate_runtime_config`, not another checker-only guardrail.

Artifact classification: generated planned-row JSON under `output/validation/issue_3501_preregistration_smoke/` is ignored validation output and is not committed. No raw episode JSONL, videos, checkpoints, Slurm logs, or benchmark artifacts are committed.

Late-guidance check: refreshed immediately before opening the PR with `gh issue view 3501 --repo ll7/robot_sf_ll7 --comments`; thread length unchanged from start artifact, no newer maintainer guidance found.

</details>
