### PR TITLE
Issue #4010 add checkpoint-backed diffusion smoke contract

### DIFF
--- a/configs/algos/diffusion_policy_issue_4010_smoke.yaml
+++ b/configs/algos/diffusion_policy_issue_4010_smoke.yaml
@@ -1,6 +1,10 @@
 # Diagnostic-only smoke configuration for issue #4010.
-# This untrained mode is allowed only so map-runner wiring and contracts can be tested.
-allow_untrained_smoke: true
+# Fill checkpoint_path and normalizer_path from the CPU smoke trainer manifest
+# before using this with map_runner. Without those artifacts the adapter fails
+# closed instead of falling back to untrained weights.
+checkpoint_path: null
+normalizer_path: null
+allow_untrained_smoke: false
 deterministic: true
 seed: 4010
 device: cpu

--- a/robot_sf/benchmark/map_runner_policies/diffusion_policy.py
+++ b/robot_sf/benchmark/map_runner_policies/diffusion_policy.py
@@ -78,10 +78,10 @@ def build(
             "status": "ok",
             "evidence_tier": EVIDENCE_TIER,
             "allow_untrained_smoke": config.allow_untrained_smoke,
-            "checkpoint_status": "untrained_smoke"
-            if config.allow_untrained_smoke
-            else "checkpoint_loaded",
-            "normalizer_status": "not_required" if config.allow_untrained_smoke else "loaded",
+            "checkpoint_status": "checkpoint_loaded"
+            if config.checkpoint_path
+            else "untrained_smoke",
+            "normalizer_status": "loaded" if config.checkpoint_path else "not_required",
             "claim_boundary": CLAIM_BOUNDARY,
         },
         "planner_kinematics": {

--- a/robot_sf/benchmark/map_runner_policies/diffusion_policy.py
+++ b/robot_sf/benchmark/map_runner_policies/diffusion_policy.py
@@ -81,6 +81,7 @@ def build(
             "checkpoint_status": "untrained_smoke"
             if config.allow_untrained_smoke
             else "checkpoint_loaded",
+            "normalizer_status": "not_required" if config.allow_untrained_smoke else "loaded",
             "claim_boundary": CLAIM_BOUNDARY,
         },
         "planner_kinematics": {

--- a/robot_sf/planner/diffusion_policy.py
+++ b/robot_sf/planner/diffusion_policy.py
@@ -439,11 +439,9 @@ class DiffusionPolicyAdapter:
                 "device": str(self._device),
                 "allow_untrained_smoke": self.config.allow_untrained_smoke,
                 "checkpoint_status": (
-                    "untrained_smoke" if self.config.allow_untrained_smoke else "checkpoint_loaded"
+                    "checkpoint_loaded" if self.config.checkpoint_path else "untrained_smoke"
                 ),
-                "normalizer_status": (
-                    "not_required" if self.config.allow_untrained_smoke else "loaded"
-                ),
+                "normalizer_status": "loaded" if self.config.checkpoint_path else "not_required",
                 "guidance": {
                     "enabled": bool(self.selector.guidance.get("enabled", True)),
                     "terms": ["smooth_previous_action", "current_clearance_proxy"],

--- a/robot_sf/planner/diffusion_policy.py
+++ b/robot_sf/planner/diffusion_policy.py
@@ -438,6 +438,12 @@ class DiffusionPolicyAdapter:
                 "num_action_samples": self.config.num_action_samples,
                 "device": str(self._device),
                 "allow_untrained_smoke": self.config.allow_untrained_smoke,
+                "checkpoint_status": (
+                    "untrained_smoke" if self.config.allow_untrained_smoke else "checkpoint_loaded"
+                ),
+                "normalizer_status": (
+                    "not_required" if self.config.allow_untrained_smoke else "loaded"
+                ),
                 "guidance": {
                     "enabled": bool(self.selector.guidance.get("enabled", True)),
                     "terms": ["smooth_previous_action", "current_clearance_proxy"],
@@ -459,6 +465,11 @@ class DiffusionPolicyAdapter:
             checkpoint = Path(self.config.checkpoint_path).expanduser()
             if not checkpoint.is_file():
                 raise FileNotFoundError(f"Diffusion policy checkpoint not found: {checkpoint}")
+            if not self.config.normalizer_path:
+                raise RuntimeError(
+                    "diffusion_policy checkpoint_path requires normalizer_path for "
+                    "issue #4010 smoke checkpoint provenance."
+                )
         elif not self.config.allow_untrained_smoke:
             raise RuntimeError(
                 "diffusion_policy requires checkpoint_path unless allow_untrained_smoke=true. "

--- a/robot_sf/training/diffusion_policy.py
+++ b/robot_sf/training/diffusion_policy.py
@@ -319,6 +319,23 @@ def _build_manifest(
             "normalizer_path": normalizer_path.name,
             "checkpoint_format": "encoder_sampler_state_dict",
             "normalizer_schema_version": normalizer["schema_version"],
+            "map_runner_load_contract": {
+                "allow_untrained_smoke": False,
+                "requires_checkpoint_path": True,
+                "requires_normalizer_path": True,
+                "algo_config_fragment": {
+                    "checkpoint_path": checkpoint_path.name,
+                    "normalizer_path": normalizer_path.name,
+                    "allow_untrained_smoke": False,
+                    "deterministic": True,
+                    "seed": config.seed,
+                    "max_pedestrians": config.max_pedestrians,
+                    "denoising_steps": config.denoising_steps,
+                    "num_action_samples": config.num_action_samples,
+                    "max_linear_speed": config.max_linear_speed,
+                    "max_angular_speed": config.max_angular_speed,
+                },
+            },
         },
         "training": {
             "status": "completed",

--- a/scripts/training/train_diffusion_policy.py
+++ b/scripts/training/train_diffusion_policy.py
@@ -1,0 +1,8 @@
+"""Run the issue #4010 CPU-scale diffusion-policy training smoke."""
+
+from __future__ import annotations
+
+from robot_sf.training.diffusion_policy import main
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/planner/test_diffusion_policy.py
+++ b/tests/planner/test_diffusion_policy.py
@@ -79,6 +79,15 @@ def test_checkpoint_does_not_skip_normalizer_validation(tmp_path) -> None:
         )
 
 
+def test_checkpoint_requires_normalizer_path(tmp_path) -> None:
+    """Smoke checkpoint loads require explicit normalizer provenance."""
+    checkpoint = tmp_path / "checkpoint.pt"
+    checkpoint.write_bytes(b"placeholder")
+
+    with pytest.raises(RuntimeError, match="requires normalizer_path"):
+        DiffusionPolicyAdapter({"checkpoint_path": str(checkpoint)})
+
+
 def test_encoder_returns_finite_masked_tensors() -> None:
     """The graph encoder pads visible pedestrians and marks valid nodes."""
     adapter = DiffusionPolicyAdapter(

--- a/tests/training/test_diffusion_policy_actor.py
+++ b/tests/training/test_diffusion_policy_actor.py
@@ -133,6 +133,44 @@ def test_training_script_entrypoint_writes_manifest_path(tmp_path) -> None:
     assert manifest_path.exists()
 
 
+def test_checkpoint_status_uses_loaded_artifacts_even_when_smoke_flag_true(tmp_path) -> None:
+    """Diagnostics report loaded artifacts whenever checkpoint-backed config is used."""
+    config = DiffusionPolicyTrainingSmokeConfig(
+        training_steps=2,
+        batch_size=3,
+        max_pedestrians=2,
+        max_linear_speed=0.6,
+        max_angular_speed=0.5,
+        artifact_prefix="map_runner_smoke_flag",
+    )
+    artifacts = run_training_smoke(config, output_dir=tmp_path)
+
+    policy, meta = _build_policy(
+        "diffusion_policy",
+        {
+            "allow_untrained_smoke": True,
+            "checkpoint_path": str(artifacts.checkpoint_path),
+            "normalizer_path": str(artifacts.normalizer_path),
+            "deterministic": True,
+            "seed": 4010,
+            "max_pedestrians": config.max_pedestrians,
+            "max_linear_speed": config.max_linear_speed,
+            "max_angular_speed": config.max_angular_speed,
+            "num_action_samples": config.num_action_samples,
+            "denoising_steps": config.denoising_steps,
+        },
+        robot_kinematics="differential_drive",
+    )
+    policy(_map_runner_obs())
+    stats = policy._planner_stats()
+
+    assert meta["diffusion_policy"]["allow_untrained_smoke"] is True
+    assert meta["diffusion_policy"]["checkpoint_status"] == "checkpoint_loaded"
+    assert meta["diffusion_policy"]["normalizer_status"] == "loaded"
+    assert stats["diffusion_policy"]["checkpoint_status"] == "checkpoint_loaded"
+    assert stats["diffusion_policy"]["normalizer_status"] == "loaded"
+
+
 def test_map_runner_loads_smoke_checkpoint_not_untrained_weights(tmp_path) -> None:
     """Map-runner can build diffusion policy from the trained smoke checkpoint."""
     config = DiffusionPolicyTrainingSmokeConfig(

--- a/tests/training/test_diffusion_policy_actor.py
+++ b/tests/training/test_diffusion_policy_actor.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 
 import pytest
 
@@ -85,6 +87,50 @@ def test_training_smoke_writes_checkpoint_normalizer_manifest(tmp_path) -> None:
     assert manifest["artifacts"]["normalizer_path"] == artifacts.normalizer_path.name
     assert manifest["training"]["status"] == "completed"
     assert manifest["evidence_tier"] == "diagnostic-only"
+    load_contract = manifest["artifacts"]["map_runner_load_contract"]
+    assert load_contract["allow_untrained_smoke"] is False
+    assert load_contract["requires_checkpoint_path"] is True
+    assert load_contract["requires_normalizer_path"] is True
+    assert (
+        load_contract["algo_config_fragment"]["checkpoint_path"] == artifacts.checkpoint_path.name
+    )
+    assert (
+        load_contract["algo_config_fragment"]["normalizer_path"] == artifacts.normalizer_path.name
+    )
+
+
+def test_training_script_entrypoint_writes_manifest_path(tmp_path) -> None:
+    """Canonical script command writes smoke manifest for issue #4010."""
+    config_path = tmp_path / "smoke.yaml"
+    output_dir = tmp_path / "artifacts"
+    config_path.write_text(
+        "diffusion_policy_training_smoke:\n"
+        "  schema_version: diffusion_policy_training_smoke.v1\n"
+        "  training_steps: 1\n"
+        "  batch_size: 2\n"
+        "  max_pedestrians: 2\n"
+        "  artifact_prefix: cli_smoke\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/training/train_diffusion_policy.py",
+            "--config",
+            str(config_path),
+            "--output-dir",
+            str(output_dir),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    manifest_path = output_dir / "cli_smoke.manifest.json"
+    assert payload == {"manifest_path": str(manifest_path)}
+    assert manifest_path.exists()
 
 
 def test_map_runner_loads_smoke_checkpoint_not_untrained_weights(tmp_path) -> None:
@@ -121,5 +167,9 @@ def test_map_runner_loads_smoke_checkpoint_not_untrained_weights(tmp_path) -> No
     assert 0.0 <= command[0] <= config.max_linear_speed
     assert -config.max_angular_speed <= command[1] <= config.max_angular_speed
     assert meta["diffusion_policy"]["allow_untrained_smoke"] is False
+    assert meta["diffusion_policy"]["checkpoint_status"] == "checkpoint_loaded"
+    assert meta["diffusion_policy"]["normalizer_status"] == "loaded"
     assert stats["diffusion_policy"]["allow_untrained_smoke"] is False
+    assert stats["diffusion_policy"]["checkpoint_status"] == "checkpoint_loaded"
+    assert stats["diffusion_policy"]["normalizer_status"] == "loaded"
     assert stats["diffusion_policy"]["evidence_tier"] == "diagnostic-only"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds the canonical `scripts/training/train_diffusion_policy.py` CPU smoke entry point, makes the tracked diffusion-policy algo config fail closed until a smoke checkpoint and normalizer are supplied, and records the map-runner checkpoint/normalizer load contract in the generated smoke manifest and runtime diagnostics.

Why now: #4010 already has the adapter and initial smoke artifacts from #4156/#4217; this is the next progression slice because it turns the smoke artifact into an explicit checkpoint-backed load contract instead of another untrained-wiring guard.

Claim boundary: diagnostic-only Robot SF-native diffusion-policy smoke path. This is not COLSON reproduction, not benchmark evidence, and not paper/dissertation evidence.

Required validation: focused CPU smoke tests, map-runner checkpoint-load test, CLI smoke command, and Ruff on touched files.

Remaining blocker: no representative benchmark campaign or GPU/Slurm training has run; full PR gate and improvement cycle are delegated to Claude Code on `imech156-u` per task handoff.

## Contract delta

New behavior/schema surface:
- `scripts/training/train_diffusion_policy.py --config ... --output-dir ...` is now the canonical CPU smoke command and prints the generated `manifest_path` JSON.
- `training_manifest.json` now includes `artifacts.map_runner_load_contract` with checkpoint path, normalizer path, `allow_untrained_smoke: false`, and the config fragment needed for map-runner loading.
- `DiffusionPolicyAdapter.diagnostics()` and map-runner PR metadata now expose `checkpoint_status` and `normalizer_status`.

New fail-closed blocker:
- Supplying `checkpoint_path` without `normalizer_path` now fails closed. Explicit `allow_untrained_smoke: true` remains available only for diagnostic wiring tests.

Compatibility impact:
- The tracked `configs/algos/diffusion_policy_issue_4010_smoke.yaml` no longer permits untrained fallback by default. Callers must fill paths from the CPU smoke manifest before using it with map-runner.

Issue: closes no issue; contributes to https://github.com/ll7/robot_sf_ll7/issues/4010.

Scope summary:
- Added a script entry point for the existing CPU smoke trainer.
- Added manifest provenance for checkpoint+normalizer map-runner loading.
- Added runtime metadata and tests proving map-runner uses the smoke checkpoint path, not untrained weights.

Validation:
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_diffusion_policy_actor.py tests/benchmark/test_map_runner_diffusion_policy.py tests/planner/test_diffusion_policy.py -q` -> passed, 26 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/training/train_diffusion_policy.py robot_sf/planner/diffusion_policy.py robot_sf/training/diffusion_policy.py robot_sf/benchmark/map_runner_policies/diffusion_policy.py tests/training/test_diffusion_policy_actor.py tests/planner/test_diffusion_policy.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/training/train_diffusion_policy.py --config configs/training/diffusion_policy/issue_4010_smoke.yaml --output-dir output/diffusion_policy/issue_4010_cli_validation` -> passed; wrote checkpoint, normalizer, manifest under ignored `output/`.

Out of scope:
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

<details>
<summary>Governance and freshness notes</summary>

Late issue check: re-read #4010 immediately before commit/PR; latest comment remained 2026-07-02T15:29:57Z, no maintainer comments newer than this run start.

Duplicate/fragmentation guard: no open PR covered #4010. Two issue #4010 PRs merged in the last 24h (#4156 and #4217), so this PR is intentionally a progression slice with the nameable new capability: checkpoint-backed CPU smoke contract plus canonical CLI and map-runner normalizer/load metadata.

State propagation: no issue comment is posted because `comment_issue_or_pr` authorization is false for this run. This PR body is the single remote-visible status surface for the delivered slice.

Artifact policy: generated smoke outputs stayed ignored under `output/diffusion_policy/issue_4010_cli_validation`; no generated checkpoint, normalizer, or manifest is committed.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line training runner for diffusion policy smoke runs.
  * Smoke run outputs now include a manifest with load-time requirements and artifact details.
  * Runtime and status information now report whether a checkpoint and normalizer were loaded or not required.

* **Bug Fixes**
  * Prevented runs from using a checkpoint without the matching normalizer.
  * Smoke configuration now defaults to a stricter, fully specified setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
