### PR TITLE
refactor: migrate gap reference policy builders (#3384)

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -123,6 +123,7 @@ from robot_sf.benchmark.map_runner_policies import adapters as _adapter_policy_b
 from robot_sf.benchmark.map_runner_policies import adaptive_proxemic as _adaptive_proxemic_builder
 from robot_sf.benchmark.map_runner_policies import diffusion_policy as _diffusion_policy_builder
 from robot_sf.benchmark.map_runner_policies import distributional_rl as _distributional_rl_builder
+from robot_sf.benchmark.map_runner_policies import gap_reference as _gap_reference_builder
 from robot_sf.benchmark.map_runner_policies import goal as _goal_policy_builder
 from robot_sf.benchmark.map_runner_policies import group_avoidance as _group_avoidance_builder
 from robot_sf.benchmark.map_runner_policies import hybrid_global_rl as _hybrid_global_rl_builder
@@ -192,14 +193,6 @@ from robot_sf.benchmark.result_provenance import (
 from robot_sf.benchmark.result_provenance import (
     write_result_provenance_manifest as _write_result_provenance_manifest,
 )
-from robot_sf.benchmark.scenario_belief_policy_hook import (
-    BELIEF_MODES,
-    DEFAULT_FOV_DEGREES,
-    DEFAULT_MAX_PEDESTRIANS,
-    DEFAULT_MAX_RANGE_M,
-    DEFAULT_PED_RADIUS,
-    BeliefModeStreamGapAdapter,
-)
 from robot_sf.benchmark.scenario_schema import validate_scenario_list
 from robot_sf.benchmark.schema_validator import load_schema
 from robot_sf.benchmark.tracking_precision_contract import (
@@ -214,10 +207,7 @@ from robot_sf.benchmark.utils import (
 )
 from robot_sf.common.math_utils import wrap_angle_pi as _normalize_heading
 from robot_sf.gym_env.environment_factory import make_robot_env
-from robot_sf.planner.gap_prediction import (
-    GapAwarePredictionAdapter,
-    build_gap_prediction_config,
-)
+from robot_sf.planner.gap_prediction import GapAwarePredictionAdapter  # noqa: F401
 from robot_sf.planner.grid_route import (  # noqa: F401
     GridRoutePlannerAdapter,
     build_grid_route_config,
@@ -285,9 +275,8 @@ from robot_sf.planner.socnav import (
     SocialForcePlannerAdapter,
     SocNavBenchSamplingAdapter,
     SocNavPlannerConfig,
-    TrivialReferencePlannerAdapter,
 )
-from robot_sf.planner.stream_gap import StreamGapPlannerAdapter, build_stream_gap_config
+from robot_sf.planner.stream_gap import StreamGapPlannerAdapter  # noqa: F401
 from robot_sf.training.scenario_loader import load_scenarios
 
 if TYPE_CHECKING:
@@ -991,6 +980,7 @@ _POLICY_BUILDERS: dict[str, _policy_builder_registry.PolicyBuilder] = {
     ),
     **dict.fromkeys(_rule_and_grid_builder.RULE_AND_GRID_KEYS, _rule_and_grid_builder.build),
     **dict.fromkeys(_safety_barrier_builder.ADAPTER_ALGO_KEYS, _safety_barrier_builder.build),
+    **dict.fromkeys(_gap_reference_builder.GAP_REFERENCE_KEYS, _gap_reference_builder.build),
     **dict.fromkeys(
         _hybrid_global_rl_builder.HYBRID_GLOBAL_RL_KEYS, _hybrid_global_rl_builder.build
     ),
@@ -1047,72 +1037,6 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             robot_kinematics=robot_kinematics,
             normalized_robot_command_mode=normalized_robot_command_mode,
             limitations=registered_adapter_spec.limitations,
-        )
-
-    if algo_key in {"trivial_reference", "reference_adapter"}:
-        adapter = TrivialReferencePlannerAdapter(config=_build_socnav_config(algo_config))
-        meta["algorithm"] = "trivial_reference"
-        return _build_adapter_policy(
-            algo_key="trivial_reference",
-            algo_config=algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="TrivialReferencePlannerAdapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            limitations=(
-                "Diagnostic adapter template only; do not use as benchmark planner evidence."
-            ),
-        )
-
-    if algo_key == "stream_gap":
-        belief_mode = str(algo_config.get("belief_mode") or "").strip().lower() or None
-        stream_gap_config = algo_config
-        limitations: str | None = None
-        if belief_mode in BELIEF_MODES:
-            # The mode owns the uncertainty gate; gate ON only for the dropping mode.
-            stream_gap_config = {
-                **algo_config,
-                "uncertainty_gating_enabled": BELIEF_MODES[belief_mode]["gate"],
-            }
-            limitations = f"scenario_belief_mode={belief_mode}_diagnostic"
-        adapter: Any = StreamGapPlannerAdapter(config=build_stream_gap_config(stream_gap_config))
-        if belief_mode in BELIEF_MODES:
-            adapter = BeliefModeStreamGapAdapter(
-                adapter,
-                mode=belief_mode,
-                fov_degrees=float(algo_config.get("belief_fov_degrees", DEFAULT_FOV_DEGREES)),
-                max_range_m=algo_config.get("belief_max_range_m", DEFAULT_MAX_RANGE_M),
-                ped_radius=float(algo_config.get("belief_ped_radius", DEFAULT_PED_RADIUS)),
-                max_pedestrians=int(
-                    algo_config.get("belief_max_pedestrians", DEFAULT_MAX_PEDESTRIANS)
-                ),
-            )
-        return _build_adapter_policy(
-            algo_key=algo_key,
-            algo_config=stream_gap_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="StreamGapPlannerAdapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            limitations=limitations,
-        )
-
-    if algo_key == "gap_prediction":
-        allow_fallback = bool(algo_config.get("allow_fallback", False))
-        adapter = GapAwarePredictionAdapter(
-            config=build_gap_prediction_config(algo_config),
-            allow_fallback=allow_fallback,
-        )
-        return _build_adapter_policy(
-            algo_key=algo_key,
-            algo_config=algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="GapAwarePredictionAdapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
         )
 
     if algo_key == "mppi_social":

--- a/robot_sf/benchmark/map_runner_policies/gap_reference.py
+++ b/robot_sf/benchmark/map_runner_policies/gap_reference.py
@@ -77,7 +77,7 @@ def build(
             adapter_name="TrivialReferencePlannerAdapter",
             robot_kinematics=robot_kinematics,
             normalized_robot_command_mode=normalized_robot_command_mode,
-            limitations="Diagnostic adapter template only; do not use benchmark planner evidence.",
+            limitations="Diagnostic adapter template only; do not use as benchmark planner evidence.",
         )
 
     if algo_key == "stream_gap":

--- a/robot_sf/benchmark/map_runner_policies/gap_reference.py
+++ b/robot_sf/benchmark/map_runner_policies/gap_reference.py
@@ -1,0 +1,141 @@
+"""Builders for gap and reference adapter map-runner policy families.
+
+Behavior-preserving continuation of the ``_build_policy`` decomposition
+tracked in #3384. These branches only depend on neutral map-runner helpers and
+planner modules, so they can live in the registry without importing the
+monolithic ``map_runner`` module.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.map_runner_policy_common import build_adapter_policy
+from robot_sf.benchmark.map_runner_policy_resolution import _build_socnav_config
+from robot_sf.benchmark.scenario_belief_policy_hook import (
+    BELIEF_MODES,
+    DEFAULT_FOV_DEGREES,
+    DEFAULT_MAX_PEDESTRIANS,
+    DEFAULT_MAX_RANGE_M,
+    DEFAULT_PED_RADIUS,
+    BeliefModeStreamGapAdapter,
+)
+from robot_sf.planner.gap_prediction import (
+    GapAwarePredictionAdapter,
+    build_gap_prediction_config,
+)
+from robot_sf.planner.socnav import TrivialReferencePlannerAdapter
+from robot_sf.planner.stream_gap import StreamGapPlannerAdapter, build_stream_gap_config
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+TRIVIAL_REFERENCE_KEYS = frozenset({"trivial_reference", "reference_adapter"})
+STREAM_GAP_KEYS = frozenset({"stream_gap"})
+GAP_PREDICTION_KEYS = frozenset({"gap_prediction"})
+GAP_REFERENCE_KEYS = TRIVIAL_REFERENCE_KEYS | STREAM_GAP_KEYS | GAP_PREDICTION_KEYS
+
+
+def _map_runner_compat_attr(name: str, default: Any) -> Any:
+    """Return old ``map_runner`` private test hook when monkeypatched."""
+    map_runner_module = sys.modules.get("robot_sf.benchmark.map_runner")
+    if map_runner_module is None:
+        return default
+    return getattr(map_runner_module, name, default)
+
+
+def build(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    robot_kinematics: str | None = None,
+    robot_command_mode: str | None = None,
+    adapter_impact_eval: bool = False,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float] | dict[str, Any]], dict[str, Any]]:
+    """Build one migrated reference/gap policy family.
+
+    Returns:
+        Policy callable and algorithm metadata.
+    """
+    del adapter_impact_eval
+
+    normalized_robot_command_mode = (
+        str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
+    )
+    meta: dict[str, Any] = {"algorithm": algo_key}
+
+    if algo_key in TRIVIAL_REFERENCE_KEYS:
+        adapter = TrivialReferencePlannerAdapter(config=_build_socnav_config(algo_config))
+        meta["algorithm"] = "trivial_reference"
+        return build_adapter_policy(
+            algo_key="trivial_reference",
+            algo_config=algo_config,
+            meta=meta,
+            adapter=adapter,
+            adapter_name="TrivialReferencePlannerAdapter",
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            limitations="Diagnostic adapter template only; do not use benchmark planner evidence.",
+        )
+
+    if algo_key == "stream_gap":
+        belief_mode = str(algo_config.get("belief_mode") or "").strip().lower() or None
+        stream_gap_config = algo_config
+        limitations: str | None = None
+        if belief_mode in BELIEF_MODES:
+            # Belief mode owns the uncertainty gate; only dropping mode enables it.
+            stream_gap_config = {
+                **algo_config,
+                "uncertainty_gating_enabled": BELIEF_MODES[belief_mode]["gate"],
+            }
+            limitations = f"scenario_belief_mode={belief_mode}_diagnostic"
+        stream_gap_adapter_cls = _map_runner_compat_attr(
+            "StreamGapPlannerAdapter",
+            StreamGapPlannerAdapter,
+        )
+        adapter: Any = stream_gap_adapter_cls(config=build_stream_gap_config(stream_gap_config))
+        if belief_mode in BELIEF_MODES:
+            adapter = BeliefModeStreamGapAdapter(
+                adapter,
+                mode=belief_mode,
+                fov_degrees=float(algo_config.get("belief_fov_degrees", DEFAULT_FOV_DEGREES)),
+                max_range_m=algo_config.get("belief_max_range_m", DEFAULT_MAX_RANGE_M),
+                ped_radius=float(algo_config.get("belief_ped_radius", DEFAULT_PED_RADIUS)),
+                max_pedestrians=int(
+                    algo_config.get("belief_max_pedestrians", DEFAULT_MAX_PEDESTRIANS)
+                ),
+            )
+        return build_adapter_policy(
+            algo_key=algo_key,
+            algo_config=algo_config,
+            meta=meta,
+            adapter=adapter,
+            adapter_name="StreamGapPlannerAdapter",
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            limitations=limitations,
+        )
+
+    if algo_key == "gap_prediction":
+        gap_prediction_adapter_cls = _map_runner_compat_attr(
+            "GapAwarePredictionAdapter",
+            GapAwarePredictionAdapter,
+        )
+        allow_fallback = bool(algo_config.get("allow_fallback", False))
+        adapter = gap_prediction_adapter_cls(
+            config=build_gap_prediction_config(algo_config),
+            allow_fallback=allow_fallback,
+        )
+        return build_adapter_policy(
+            algo_key=algo_key,
+            algo_config=algo_config,
+            meta=meta,
+            adapter=adapter,
+            adapter_name="GapAwarePredictionAdapter",
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+        )
+
+    raise ValueError(f"Unsupported gap/reference policy builder key: {algo_key}")

--- a/tests/benchmark/test_map_runner_rule_and_grid_registry.py
+++ b/tests/benchmark/test_map_runner_rule_and_grid_registry.py
@@ -1,11 +1,11 @@
-"""Regression tests for #3384 rule/grid policy-builder registry migration."""
+"""Regression tests for #3384 rule/grid and gap policy-builder registry migrations."""
 
 from __future__ import annotations
 
 import pytest
 
 from robot_sf.benchmark import map_runner
-from robot_sf.benchmark.map_runner_policies import rule_and_grid
+from robot_sf.benchmark.map_runner_policies import gap_reference, rule_and_grid
 
 
 @pytest.mark.parametrize(
@@ -21,11 +21,14 @@ from robot_sf.benchmark.map_runner_policies import rule_and_grid
     ],
 )
 def test_rule_and_grid_keys_resolve_through_registry_bridge(algo_key: str) -> None:
-    """Migrated rule/grid keys should be owned by the registry builder."""
+    """Migrated rule/grid keys are owned by the registry builder."""
     assert map_runner._POLICY_BUILDERS[algo_key] is rule_and_grid.build
 
 
-@pytest.mark.parametrize("algo_key", ["stream_gap", "gap_prediction", "trivial_reference"])
-def test_deferred_rule_gap_keys_remain_legacy_dispatch(algo_key: str) -> None:
-    """Later #3384 slices still own helper-dependent rule/gap branches."""
-    assert algo_key not in map_runner._POLICY_BUILDERS
+@pytest.mark.parametrize(
+    "algo_key",
+    ["stream_gap", "gap_prediction", "trivial_reference", "reference_adapter"],
+)
+def test_gap_reference_keys_resolve_through_registry_bridge(algo_key: str) -> None:
+    """Migrated gap/reference keys are owned by the registry builder."""
+    assert map_runner._POLICY_BUILDERS[algo_key] is gap_reference.build


### PR DESCRIPTION
## Reviewer-critical summary

What changed: migrated the `trivial_reference` / `reference_adapter`, `stream_gap`, and `gap_prediction` policy-builder families out of `robot_sf/benchmark/map_runner.py::_build_policy` into the registry-backed `robot_sf/benchmark/map_runner_policies/gap_reference.py` builder.

Why now: issue #3384's live implementation plan calls for continuing the post-#4212 registry migration with the next behavior-preserving builder families. This is a progression slice, not a guardrail-only micro-PR.

Claim boundary: behavior-preserving refactor only. The old private `map_runner.GapAwarePredictionAdapter` and `map_runner.StreamGapPlannerAdapter` monkeypatch hooks remain available for existing tests, while the registry now owns the actual dispatch for these keys.

Required validation: focused unit and planner tests for registry dispatch, existing map-runner utility contracts, stream-gap view integrity, and gap-prediction planner behavior.

Remaining blocker: `_build_policy` still contains later inline families, including MPPI/MPC, learned PPO/SAC/DRL-VO/guarded PPO, SocNav/ORCA/HRVO, external model adapters, and hybrid selector families. Intermediate PR; `Refs #3384`, not `Closes #3384`.

## Contract delta

New schema fields: none.

New fail-closed blockers: none.

Compatibility impact: `_build_policy(...)` import and call surface is unchanged. Existing `map_runner` private monkeypatch names for `GapAwarePredictionAdapter` and `StreamGapPlannerAdapter` remain available for current tests. Registry ownership expands to `stream_gap`, `gap_prediction`, `trivial_reference`, and `reference_adapter`.

## Scope summary

Refs #3384.

- Added `robot_sf/benchmark/map_runner_policies/gap_reference.py` for the gap/reference adapter families.
- Registered the migrated keys in `_POLICY_BUILDERS` before fallback dispatch.
- Removed the corresponding inline branches from `map_runner.py`.
- Updated the existing #3384 registry regression test to assert the newly migrated keys are registry-owned.

## Validation

- `uv run ruff check --fix robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policies/gap_reference.py tests/benchmark/test_map_runner_rule_and_grid_registry.py && uv run ruff format robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policies/gap_reference.py tests/benchmark/test_map_runner_rule_and_grid_registry.py && uv run pytest tests/benchmark/test_map_runner_rule_and_grid_registry.py tests/benchmark/test_map_runner_utils.py tests/planner/test_policy_stack_v1.py tests/benchmark/test_issue_3635_scenario_belief_near_safe_family.py -q` — passed.
- `uv run pytest tests/planner/test_gap_prediction_planner.py tests/benchmark/test_map_runner_view_integrity.py -q` — passed.
- `git diff --check` — passed.
- `uv sync --all-extras` — completed to satisfy final readiness dependencies.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=<agent-run>/PR_BODY.md scripts/dev/pr_ready_check.sh` — passed; stamp `output/validation/pr_ready/issue-3384-refactor-migrate-next-policy-builder-families-onto-the-registry-post-421.json` for head `49eae735b8a3ef396f193a14fa191787c0c3a730`.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## State propagation

No issue comment was posted because this run was authorized with `comment_issue_or_pr: false`. This PR body is the durable handoff surface for the delivered slice and remaining #3384 work.

<details>
<summary>Governance appendix</summary>

- Live issue thread was read via `gh api` because `gh issue view --comments` failed on GitHub classic Projects field deprecation.
- No issue comments were newer than the 2026-07-03T07:09:20Z start time.
- No open PR matched this exact #3384 gap/reference slice immediately before PR creation.
- Fragmentation guard reviewed: #4212 and #4153 recently merged for #3384, but this PR adds the nameable new capability "gap/reference policy-builder registry migration" and is not a guardrail/checker/packet-refresh micro-PR.
- No transient queue-routing state, target-host state, or packet lineage was encoded in tracked files.

</details>
