### PR TITLE
scenarios: add emergency-reaction family (#3977)

### DIFF
--- a/configs/scenarios/route_overrides/issue_3977/emergency_reaction.yaml
+++ b/configs/scenarios/route_overrides/issue_3977/emergency_reaction.yaml
@@ -1,0 +1,7 @@
+route_payload:
+  robot_routes:
+    - spawn_id: 0
+      goal_id: 0
+      waypoints:
+        - [7.0, 14.0]
+        - [25.5, 14.0]

--- a/configs/scenarios/sets/issue_3977_public_requirements.yaml
+++ b/configs/scenarios/sets/issue_3977_public_requirements.yaml
@@ -1,3 +1,4 @@
 include:
   - ../single/issue_3977_safe_braking.yaml
   - ../single/issue_3977_visibility_and_intent.yaml
+  - ../single/issue_3977_emergency_reaction.yaml

--- a/configs/scenarios/single/issue_3977_emergency_reaction.yaml
+++ b/configs/scenarios/single/issue_3977_emergency_reaction.yaml
@@ -1,0 +1,51 @@
+scenarios:
+  - name: issue_3977_emergency_reaction_sudden_obstacle_proxy
+    scenario_family: public_requirement_emergency_reaction
+    map_file: ../../../maps/svg_maps/francis2023/francis2023_intersection_no_gesture.svg
+    route_overrides_file: ../route_overrides/issue_3977/emergency_reaction.yaml
+    simulation_config:
+      max_episode_steps: 80
+      ped_density: 0.0
+    single_pedestrians:
+      - id: h1
+        goal: null
+        trajectory:
+          - [14.0, 22.0]
+          - [14.0, 17.5]
+          - [14.0, 14.0]
+          - [14.0, 6.0]
+        speed_m_s: 2.0
+        # Proximity release reuses the validated public-requirement runtime
+        # machinery: actor waits off-corridor, then enters the robot corridor
+        # once the robot is close enough for a sudden-obstacle proxy event.
+        hold_until_robot_within_m: 5.5
+        hold_ref_point: [14.0, 14.0]
+        hold_timeout_s: 6.0
+        note: "Public-requirement emergency-reaction proxy: sudden obstacle enters corridor."
+        metadata:
+          intent_conditioned_behavior:
+            intent_label: sudden_obstacle_proxy_enters_corridor
+            intent_phases:
+              - waiting_off_corridor
+              - proximity_released
+              - crossing_robot_corridor
+    metadata:
+      public_requirement:
+        schema_version: public-requirement-scenario.v1
+        category: emergency_reaction
+        requirement_label: Emergency reaction when an obstacle suddenly becomes conflict-relevant
+        source: schomakers_2024_public_requirements
+        claim_boundary: authored_scenario_proxy_not_human_subject_evidence
+        event_contract:
+          type: sudden_obstacle_proxy
+          actor_id: h1
+          release_condition: robot_proximity_hold
+          hold_ref_point: [14.0, 14.0]
+          hold_until_robot_within_m: 5.5
+          hold_timeout_s: 6.0
+          conflict_point: [14.0, 14.0]
+          trigger_radius_m: 0.75
+          robot_trigger_radius_m: 5.5
+          validated_robot_speed_m_s: [1.0, 2.0, 3.0]
+    seeds:
+      - 3977

--- a/tests/benchmark/test_issue_3977_emergency_reaction_scenario.py
+++ b/tests/benchmark/test_issue_3977_emergency_reaction_scenario.py
@@ -1,0 +1,141 @@
+"""Tests issue #3977 emergency-reaction public-requirement scenario slice."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from robot_sf.gym_env.robot_env import RobotEnv
+from robot_sf.ped_npc.ped_behavior import SinglePedestrianBehavior
+from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCENARIO_SET = REPO_ROOT / "configs/scenarios/sets/issue_3977_public_requirements.yaml"
+SINGLE_SCENARIO = REPO_ROOT / "configs/scenarios/single/issue_3977_emergency_reaction.yaml"
+
+
+def _load_emergency_reaction_scenario() -> dict:
+    scenarios = load_scenarios(SCENARIO_SET)
+    matches = [
+        scenario
+        for scenario in scenarios
+        if scenario["name"] == "issue_3977_emergency_reaction_sudden_obstacle_proxy"
+    ]
+    assert len(matches) == 1
+    return dict(matches[0])
+
+
+def _single_pedestrian(config):
+    map_def = next(iter(config.map_pool.map_defs.values()))
+    assert len(map_def.single_pedestrians) == 1
+    return map_def.single_pedestrians[0]
+
+
+def test_emergency_reaction_contract_loads_through_scenario_set() -> None:
+    """Scenario set now includes one bounded emergency-reaction family."""
+    scenarios = load_scenarios(SCENARIO_SET)
+    categories = {
+        scenario["metadata"]["public_requirement"]["category"]
+        for scenario in scenarios
+        if "public_requirement" in scenario.get("metadata", {})
+    }
+    assert {"safe_braking", "visibility_and_intent", "emergency_reaction"} <= categories
+
+    scenario = _load_emergency_reaction_scenario()
+    public_requirement = scenario["metadata"]["public_requirement"]
+    contract = public_requirement["event_contract"]
+
+    assert scenario["scenario_family"] == "public_requirement_emergency_reaction"
+    assert public_requirement["schema_version"] == "public-requirement-scenario.v1"
+    assert public_requirement["category"] == "emergency_reaction"
+    assert (
+        public_requirement["claim_boundary"] == "authored_scenario_proxy_not_human_subject_evidence"
+    )
+    assert contract["type"] == "sudden_obstacle_proxy"
+    assert contract["actor_id"] == "h1"
+    assert contract["release_condition"] == "robot_proximity_hold"
+    assert contract["conflict_point"] == [14.0, 14.0]
+    assert contract["trigger_radius_m"] == pytest.approx(0.75)
+    assert contract["robot_trigger_radius_m"] == pytest.approx(5.5)
+    assert contract["validated_robot_speed_m_s"] == [1.0, 2.0, 3.0]
+
+
+def test_emergency_reaction_builds_deterministic_proxy_geometry() -> None:
+    """Scenario generation preserves the authored sudden-obstacle proxy geometry."""
+    scenario = _load_emergency_reaction_scenario()
+    config = build_robot_config_from_scenario(scenario, scenario_path=SINGLE_SCENARIO)
+    ped = _single_pedestrian(config)
+
+    assert ped.id == "h1"
+    assert ped.start == (14.0, 26.0)
+    assert ped.trajectory == [(14.0, 22.0), (14.0, 17.5), (14.0, 14.0), (14.0, 6.0)]
+    assert ped.speed_m_s == pytest.approx(2.0)
+    assert ped.start_delay_s == pytest.approx(0.0)
+    assert ped.hold_until_robot_within_m == pytest.approx(5.5)
+    assert ped.hold_ref_point == (14.0, 14.0)
+    assert ped.hold_timeout_s == pytest.approx(6.0)
+
+    map_def = next(iter(config.map_pool.map_defs.values()))
+    robot_route = map_def.robot_routes[0]
+    assert robot_route.waypoints == [(7.0, 14.0), (25.5, 14.0)]
+    assert tuple(
+        scenario["metadata"]["public_requirement"]["event_contract"]["conflict_point"]
+    ) in (ped.trajectory or [])
+
+
+def test_emergency_reaction_short_headless_smoke_episode(monkeypatch) -> None:
+    """Emergency-reaction scenario steps headlessly without benchmark campaigns."""
+    monkeypatch.setenv("SDL_VIDEODRIVER", "dummy")
+    scenario = _load_emergency_reaction_scenario()
+    config = build_robot_config_from_scenario(scenario, scenario_path=SINGLE_SCENARIO)
+    env = RobotEnv(config, debug=False)
+
+    try:
+        env.reset(seed=3977)
+        action = np.zeros(env.action_space.shape, dtype=env.action_space.dtype)
+        for _ in range(5):
+            env.step(action)
+        ped_positions = np.asarray(env.simulator.ped_pos, dtype=float)
+        assert ped_positions.shape[0] == 1
+    finally:
+        env.close()
+
+
+@pytest.mark.parametrize("robot_speed_m_s", [1.0, 2.0, 3.0])
+def test_emergency_reaction_releases_by_robot_proximity_at_required_speeds(
+    monkeypatch, robot_speed_m_s: float
+) -> None:
+    """Runtime proof: 1-3 m/s robot approaches engage the emergency proxy contract."""
+    monkeypatch.setenv("SDL_VIDEODRIVER", "dummy")
+    scenario = _load_emergency_reaction_scenario()
+    config = build_robot_config_from_scenario(scenario, scenario_path=SINGLE_SCENARIO)
+    env = RobotEnv(config, debug=False)
+
+    try:
+        env.reset(seed=3977)
+        behavior = next(
+            b for b in env.simulator.peds_behaviors if isinstance(b, SinglePedestrianBehavior)
+        )
+        runtime = behavior._runtimes[0]
+        dt = float(config.sim_config.time_per_step_in_secs)
+        step_index = {"value": 0}
+
+        def robot_pose_provider():
+            x = min(14.0, 7.0 + robot_speed_m_s * step_index["value"] * dt)
+            return [((x, 14.0), 0.0)]
+
+        behavior.set_robot_pose_provider(robot_pose_provider)
+        action = np.zeros(env.action_space.shape, dtype=env.action_space.dtype)
+
+        for step in range(180):
+            step_index["value"] = step
+            env.step(action)
+            if runtime.hold_released_by is not None:
+                break
+
+        assert runtime.hold_released_by == "robot_proximity"
+        assert float(env.simulator.ped_pos[0][1]) < 17.5
+    finally:
+        env.close()

--- a/tests/benchmark/test_issue_3977_emergency_reaction_scenario.py
+++ b/tests/benchmark/test_issue_3977_emergency_reaction_scenario.py
@@ -120,17 +120,17 @@ def test_emergency_reaction_releases_by_robot_proximity_at_required_speeds(
         )
         runtime = behavior._runtimes[0]
         dt = float(config.sim_config.time_per_step_in_secs)
-        step_index = {"value": 0}
+        step_index = 0
 
         def robot_pose_provider():
-            x = min(14.0, 7.0 + robot_speed_m_s * step_index["value"] * dt)
+            x = min(14.0, 7.0 + robot_speed_m_s * step_index * dt)
             return [((x, 14.0), 0.0)]
 
         behavior.set_robot_pose_provider(robot_pose_provider)
         action = np.zeros(env.action_space.shape, dtype=env.action_space.dtype)
 
         for step in range(180):
-            step_index["value"] = step
+            step_index = step
             env.step(action)
             if runtime.hold_released_by is not None:
                 break


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds the third public-requirement family for issue #3977, `emergency_reaction`, as a single authored sudden-obstacle proxy scenario plus route override, manifest include, and focused runtime tests.

Why now: safe braking and visibility/intent families already landed; this is the next nameable progression slice and not another guardrail-only PR.

Claim boundary: authored scenario proxy and headless runtime engagement only. This does not claim public acceptance, safety certification, benchmark-strength evidence, or human-subject validity.

Required validation: focused scenario loading/runtime tests and the issue-provided public-requirement selector; final PR readiness wrapper run with this body file.

Remaining blocker: speed-limit family is still out of scope for this PR and remains the next public-requirement family slice.

## Contract delta

New scenario contract:
- `configs/scenarios/single/issue_3977_emergency_reaction.yaml`
- `scenario_family: public_requirement_emergency_reaction`
- `metadata.public_requirement.category: emergency_reaction`
- `metadata.public_requirement.event_contract.type: sudden_obstacle_proxy`
- `event_contract.release_condition: robot_proximity_hold`
- `event_contract.validated_robot_speed_m_s: [1.0, 2.0, 3.0]`

Compatibility impact: no new schema parser, benchmark metric, success/collision semantics, or fail-closed blocker is introduced. The scenario reuses the existing single-pedestrian trajectory override and proximity-hold runtime fields validated by prior #3977 slices.

## Issue

Issue: https://github.com/ll7/robot_sf_ll7/issues/3977

Scope summary: one emergency-reaction public-requirement scenario family only, with event contract metadata and runtime tests proving proximity-release engagement at 1, 2, and 3 m/s.

## Validation

- `uv run pytest tests/benchmark/test_issue_3977_emergency_reaction_scenario.py tests/benchmark/test_issue_3977_safe_braking_scenario.py tests/benchmark/test_issue_3977_visibility_and_intent_scenario.py -q` -> passed, 36 passed.
- `uv run pytest tests/ -k "public_requirement or safe_braking or emergency_reaction or speed_limit" -q` -> passed, 36 passed, one pre-existing pytest deprecation warning from `tests/test_scenario_generator.py`.
- `uv run ruff check tests/benchmark/test_issue_3977_emergency_reaction_scenario.py` -> passed.
- `PR_READY_PR_BODY_FILE=<artifact>/pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; stamp `output/validation/pr_ready/issue-3977-scenarios-emergency-reaction-family-third-public-requirement-family.json` at commit `7f6998884bb6ecbe166f3b607cd2fe140a53ccd3`.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no speed-limit family implementation, no weather or low-friction proxy, no merge/release gate changes.

## Downstream propagation

No issue comment/state-table update from this agent because `comment_issue_or_pr` is not authorized for this run. The PR body is the durable state surface for this delivered slice; issue #3977 remains open for the remaining speed-limit family work.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: recent #3977 merged PRs delivered named progression slices (`safe_braking`, proximity-release runtime proof, and `visibility_and_intent`). This PR adds the next named capability, `emergency_reaction`, rather than another guardrail/checker/packet-refresh slice.

Artifact classification: no generated benchmark artifacts are committed. Local `.venv`, pytest cache, and validation outputs are disposable worktree-local artifacts.

Late-guidance check: immediately before PR creation, issue #3977 comments will be refreshed and any maintainer comments newer than the start of this run will be incorporated or explicitly noted.

</details>
