### PR TITLE
feat: complete uncertainty-envelope acceptance criteria (#4141)

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -549,6 +549,9 @@ _resolve_policy_search_candidate_runtime = (
     _policy_resolution._resolve_policy_search_candidate_runtime
 )
 _apply_planner_selector_v2_context = _policy_resolution._apply_planner_selector_v2_context
+_apply_scenario_uncertainty_envelope_config = (
+    _policy_resolution._apply_scenario_uncertainty_envelope_config
+)
 _build_planner_selector_v2_child_adapter = (
     _policy_resolution._build_planner_selector_v2_child_adapter
 )
@@ -2506,6 +2509,11 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 algo_config=raw_policy_cfg,
                 scenario=scenario,
             )
+            validation_cfg = _apply_scenario_uncertainty_envelope_config(
+                validation_algo,
+                validation_cfg,
+                scenario,
+            )
             validation_observation_contract = resolve_learned_checkpoint_observation_contract(
                 validation_algo,
                 validation_cfg,
@@ -2666,6 +2674,11 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     identity_cfg,
                     scenario=sc,
                     seed=int(seed),
+                )
+                identity_cfg = _apply_scenario_uncertainty_envelope_config(
+                    identity_algo,
+                    identity_cfg,
+                    sc,
                 )
                 identity_observation_contract = resolve_learned_checkpoint_observation_contract(
                     identity_algo,

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -64,6 +64,7 @@ from robot_sf.benchmark.map_runner_policy_metadata import (
 )
 from robot_sf.benchmark.map_runner_policy_resolution import (
     _apply_planner_selector_v2_context,
+    _apply_scenario_uncertainty_envelope_config,
     _parse_algo_config,
     _resolve_policy_search_candidate_runtime,
 )
@@ -570,6 +571,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         scenario=scenario,
         seed=int(seed),
     )
+    policy_cfg = _apply_scenario_uncertainty_envelope_config(algo, policy_cfg, scenario)
     learned_observation_contract = resolve_learned_checkpoint_observation_contract(
         algo,
         policy_cfg,

--- a/robot_sf/benchmark/map_runner_policy_resolution.py
+++ b/robot_sf/benchmark/map_runner_policy_resolution.py
@@ -65,6 +65,44 @@ def _deep_merge_inline(base: dict[str, Any], overrides: dict[str, Any]) -> None:
             base[key] = deepcopy(value)
 
 
+_UNCERTAINTY_ENVELOPE_ALGOS = {
+    "cv_prediction_mpc",
+    "learned_prediction_mpc",
+    "nmpc",
+    "nmpc_social",
+    "prediction_aware_mpc",
+    "prediction_mpc",
+}
+_UNCERTAINTY_ENVELOPE_FIELDS = (
+    "pedestrian_uncertainty_envelope_enabled",
+    "pedestrian_uncertainty_alpha_mps",
+)
+
+
+def _apply_scenario_uncertainty_envelope_config(
+    algo: str,
+    algo_config: dict[str, Any],
+    scenario: dict[str, Any],
+) -> dict[str, Any]:
+    """Thread scenario-level pedestrian uncertainty-envelope fields into planner config.
+
+    Returns:
+        Planner config with scenario envelope fields merged for supported planners.
+    """
+    algo_key = str(algo).strip().lower()
+    if algo_key not in _UNCERTAINTY_ENVELOPE_ALGOS:
+        return algo_config
+    sim_config = scenario.get("simulation_config")
+    if not isinstance(sim_config, dict):
+        return algo_config
+    overrides = {
+        field: sim_config[field] for field in _UNCERTAINTY_ENVELOPE_FIELDS if field in sim_config
+    }
+    if not overrides:
+        return algo_config
+    return {**algo_config, **overrides}
+
+
 def _resolve_config_path(anchor: Path | None, raw_path: Any) -> Path | None:
     """Resolve candidate-manifest config paths from manifest-local or repo-root form.
 

--- a/robot_sf/benchmark/map_runner_policy_resolution.py
+++ b/robot_sf/benchmark/map_runner_policy_resolution.py
@@ -100,7 +100,9 @@ def _apply_scenario_uncertainty_envelope_config(
     }
     if not overrides:
         return algo_config
-    return {**algo_config, **overrides}
+    merged = deepcopy(algo_config)
+    merged.update(overrides)
+    return merged
 
 
 def _resolve_config_path(anchor: Path | None, raw_path: Any) -> Path | None:

--- a/robot_sf/planner/nmpc_social.py
+++ b/robot_sf/planner/nmpc_social.py
@@ -9,6 +9,7 @@ from typing import Any
 import numpy as np
 from scipy.optimize import Bounds, NonlinearConstraint, minimize
 
+from robot_sf.nav.uncertainty_envelope import effective_pedestrian_radius, envelope_diagnostics
 from robot_sf.planner.risk_dwa import _wrap_angle
 from robot_sf.planner.socnav import OccupancyAwarePlannerMixin
 
@@ -55,6 +56,8 @@ class NMPCSocialConfig:
     occupancy_cost_weight: float = 1.2
     collision_cost_kappa: float = 10.0
     pedestrian_margin: float = 0.55
+    pedestrian_uncertainty_envelope_enabled: bool = False
+    pedestrian_uncertainty_alpha_mps: float = 0.0
     obstacle_margin: float = 0.45
     desired_obstacle_clearance: float = 0.9
     min_turn_speed_scale: float = 0.3
@@ -72,6 +75,11 @@ class NMPCSocialConfig:
     warm_start: bool = True
     fallback_to_stop: bool = True
 
+    def __post_init__(self) -> None:
+        """Validate uncertainty-envelope fields."""
+        if float(self.pedestrian_uncertainty_alpha_mps) < 0.0:
+            raise ValueError("pedestrian_uncertainty_alpha_mps must be >= 0")
+
 
 @dataclass
 class _RolloutContext:
@@ -87,6 +95,8 @@ class _RolloutContext:
     ped_radius: float
     observation: dict[str, Any]
     speed_cap: float
+    pedestrian_uncertainty_envelope_enabled: bool = False
+    pedestrian_uncertainty_alpha_mps: float = 0.0
 
 
 class NMPCSocialPlannerAdapter(OccupancyAwarePlannerMixin):
@@ -445,9 +455,14 @@ class NMPCSocialPlannerAdapter(OccupancyAwarePlannerMixin):
             )
             if ped_t.size > 0:
                 dists = np.linalg.norm(ped_t - x[None, :], axis=1)
-                min_ped_clearance = float(np.min(dists)) - (
-                    context.robot_radius + context.ped_radius
+                ped_radius = effective_pedestrian_radius(
+                    base_radius=context.ped_radius,
+                    horizon_step=step_idx,
+                    alpha=context.pedestrian_uncertainty_alpha_mps,
+                    dt=dt,
+                    enabled=context.pedestrian_uncertainty_envelope_enabled,
                 )
+                min_ped_clearance = float(np.min(dists)) - (context.robot_radius + ped_radius)
                 cost += float(self.config.pedestrian_clearance_weight) * self._soft_collision_cost(
                     min_ped_clearance,
                     float(self.config.pedestrian_margin),
@@ -537,6 +552,10 @@ class NMPCSocialPlannerAdapter(OccupancyAwarePlannerMixin):
             ped_velocities=ped_velocities,
             robot_radius=robot_radius,
             ped_radius=ped_radius,
+            pedestrian_uncertainty_envelope_enabled=bool(
+                self.config.pedestrian_uncertainty_envelope_enabled
+            ),
+            pedestrian_uncertainty_alpha_mps=float(self.config.pedestrian_uncertainty_alpha_mps),
             observation=observation,
             speed_cap=speed_cap,
         )
@@ -619,11 +638,11 @@ class NMPCSocialPlannerAdapter(OccupancyAwarePlannerMixin):
                 int(self._stats.get("nonzero_command_count", 0)) + 1
             )
 
-    def diagnostics(self) -> dict[str, float | int]:
+    def diagnostics(self) -> dict[str, Any]:
         """Return episode-local runtime diagnostics for the planner.
 
         Returns:
-            dict[str, float | int]: Aggregated solve and command statistics.
+            dict[str, Any]: Aggregated solve and command statistics plus envelope provenance.
         """
         calls = max(int(self._stats.get("calls", 0)), 1)
         return {
@@ -635,6 +654,11 @@ class NMPCSocialPlannerAdapter(OccupancyAwarePlannerMixin):
             "nonzero_command_count": int(self._stats.get("nonzero_command_count", 0)),
             "mean_abs_linear": float(self._stats.get("sum_abs_linear", 0.0)) / calls,
             "mean_abs_angular": float(self._stats.get("sum_abs_angular", 0.0)) / calls,
+            "pedestrian_uncertainty_envelope": envelope_diagnostics(
+                enabled=bool(self.config.pedestrian_uncertainty_envelope_enabled),
+                alpha=float(self.config.pedestrian_uncertainty_alpha_mps),
+                dt=float(self.config.rollout_dt),
+            ),
         }
 
 
@@ -665,6 +689,8 @@ def build_nmpc_social_config(cfg: dict[str, Any] | None) -> NMPCSocialConfig:
         "occupancy_cost_weight": float,
         "collision_cost_kappa": float,
         "pedestrian_margin": float,
+        "pedestrian_uncertainty_envelope_enabled": _parse_bool,
+        "pedestrian_uncertainty_alpha_mps": float,
         "obstacle_margin": float,
         "desired_obstacle_clearance": float,
         "min_turn_speed_scale": float,

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -90,6 +90,12 @@ class SimulationSettings:
     ped_radius: float = 0.4
     """Pedestrian radius"""
 
+    pedestrian_uncertainty_envelope_enabled: bool = False
+    """Whether planner configs should opt into horizon-dependent pedestrian inflation."""
+
+    pedestrian_uncertainty_alpha_mps: float = 0.0
+    """Linear pedestrian-envelope inflation rate in metres per second."""
+
     goal_radius: float = 1.0
     """Goal radius"""
 
@@ -161,6 +167,7 @@ class SimulationSettings:
         # Check that the pedestrian radius is positive
         if self.ped_radius <= 0:
             raise ValueError("Pedestrian radius mustn't be negative or zero!")
+        self._validate_pedestrian_uncertainty_envelope_config()
         # Check that the goal radius is positive
         if self.goal_radius <= 0:
             raise ValueError("Goal radius mustn't be negative or zero!")
@@ -173,6 +180,11 @@ class SimulationSettings:
         if self.apf_config is None or not isinstance(self.apf_config, AdversarialPedForceConfig):
             raise ValueError("Adversarial-ped-force settings need to be specified!")
         self._validate_route_spawn_config()
+
+    def _validate_pedestrian_uncertainty_envelope_config(self) -> None:
+        """Validate planner-facing uncertainty-envelope simulation settings."""
+        if self.pedestrian_uncertainty_alpha_mps < 0:
+            raise ValueError("pedestrian_uncertainty_alpha_mps must be >= 0")
 
     def _validate_route_spawn_config(self) -> None:
         """Validate route spawn configuration flags."""

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -2092,6 +2092,17 @@ def _set_simulation_override_attr(
             config.sim_config.ttc_predictive_force,
             enabled=True,
         )
+    elif attr == "pedestrian_uncertainty_envelope_enabled":
+        setattr(
+            config.sim_config,
+            attr,
+            _coerce_bool(overrides[attr], field_name=f"simulation_config.{attr}"),
+        )
+    elif attr == "pedestrian_uncertainty_alpha_mps":
+        alpha = _coerce_finite_float(overrides[attr], field_name=f"simulation_config.{attr}")
+        if alpha < 0.0:
+            raise ValueError("simulation_config.pedestrian_uncertainty_alpha_mps must be >= 0.")
+        setattr(config.sim_config, attr, alpha)
     else:
         setattr(config.sim_config, attr, overrides[attr])
 
@@ -2121,6 +2132,8 @@ def _apply_simulation_overrides(
     for attr in (
         "peds_speed_mult",
         "ped_radius",
+        "pedestrian_uncertainty_envelope_enabled",
+        "pedestrian_uncertainty_alpha_mps",
         "goal_radius",
         "pedestrian_model",
         "ttc_predictive_force",

--- a/tests/benchmark/test_map_runner_resume_identity.py
+++ b/tests/benchmark/test_map_runner_resume_identity.py
@@ -80,6 +80,67 @@ def test_resume_identity_is_algorithm_aware(
     assert second["written"] == 1
 
 
+def test_resume_identity_distinguishes_uncertainty_envelope_alpha() -> None:
+    """Scenario-level uncertainty-envelope alpha changes the episode identity."""
+    scenario_alpha_zero = _minimal_map_scenario()
+    scenario_alpha_zero["simulation_config"] = {
+        "pedestrian_uncertainty_envelope_enabled": True,
+        "pedestrian_uncertainty_alpha_mps": 0.0,
+    }
+    scenario_alpha_point_one = _minimal_map_scenario()
+    scenario_alpha_point_one["simulation_config"] = {
+        "pedestrian_uncertainty_envelope_enabled": True,
+        "pedestrian_uncertainty_alpha_mps": 0.1,
+    }
+
+    payload_zero = map_runner._scenario_identity_payload(
+        scenario_alpha_zero,
+        algo="prediction_mpc",
+        algo_config=map_runner._apply_scenario_uncertainty_envelope_config(
+            "prediction_mpc", {}, scenario_alpha_zero
+        ),
+        horizon=None,
+        dt=None,
+        record_forces=True,
+    )
+    payload_point_one = map_runner._scenario_identity_payload(
+        scenario_alpha_point_one,
+        algo="prediction_mpc",
+        algo_config=map_runner._apply_scenario_uncertainty_envelope_config(
+            "prediction_mpc", {}, scenario_alpha_point_one
+        ),
+        horizon=None,
+        dt=None,
+        record_forces=True,
+    )
+
+    assert map_runner._compute_map_episode_id(
+        payload_zero, 1
+    ) != map_runner._compute_map_episode_id(payload_point_one, 1)
+
+
+def test_scenario_uncertainty_envelope_config_threads_only_supported_planners() -> None:
+    """Scenario envelope fields become planner config for MPC-family adapters only."""
+    scenario = {
+        "name": "uncertainty-envelope-config",
+        "simulation_config": {
+            "pedestrian_uncertainty_envelope_enabled": True,
+            "pedestrian_uncertainty_alpha_mps": 0.1,
+        },
+    }
+
+    threaded = map_runner._apply_scenario_uncertainty_envelope_config(
+        "prediction_mpc", {"horizon_steps": 3}, scenario
+    )
+    unrelated = map_runner._apply_scenario_uncertainty_envelope_config(
+        "goal", {"horizon_steps": 3}, scenario
+    )
+
+    assert threaded["pedestrian_uncertainty_envelope_enabled"] is True
+    assert threaded["pedestrian_uncertainty_alpha_mps"] == 0.1
+    assert unrelated == {"horizon_steps": 3}
+
+
 def test_resume_identity_uses_identity_algo_observation_mode(
     tmp_path: Path,
     monkeypatch,

--- a/tests/benchmark/test_uncertainty_envelope_runtime.py
+++ b/tests/benchmark/test_uncertainty_envelope_runtime.py
@@ -1,0 +1,124 @@
+"""Runtime smoke coverage for pedestrian uncertainty-envelope scenario threading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_sf.benchmark import map_runner
+
+SCHEMA_PATH = str(
+    Path(__file__).resolve().parents[2] / "robot_sf/benchmark/schemas/episode.schema.v1.json"
+)
+
+
+def _scenario(alpha: float) -> dict[str, object]:
+    """Return a tiny deterministic scenario arm for alpha-comparison smoke tests."""
+    return {
+        "name": f"uncertainty-envelope-alpha-{alpha}",
+        "metadata": {"supported": True},
+        "map_file": "maps/svg_maps/classic_crossing.svg",
+        "simulation_config": {
+            "max_episode_steps": 2,
+            "pedestrian_uncertainty_envelope_enabled": True,
+            "pedestrian_uncertainty_alpha_mps": alpha,
+        },
+        "seeds": [4141],
+    }
+
+
+def test_uncertainty_envelope_alpha_comparison_smoke_records_disposable_artifact(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Fixed-seed alpha smoke runs both arms and records temp-artifact disposition."""
+    written_records: list[dict[str, object]] = []
+
+    monkeypatch.setattr(map_runner, "validate_scenario_list", lambda _scenarios: [])
+    monkeypatch.setattr(map_runner, "load_schema", lambda _path: {})
+    monkeypatch.setattr(
+        map_runner,
+        "_select_seeds",
+        lambda _scenario, suite_seeds=None, suite_key=None: [4141],
+    )
+    monkeypatch.setattr(map_runner, "index_existing", lambda _path: set())
+
+    def _fake_worker(job: tuple[dict, int, dict]) -> dict[str, object]:
+        """Return deterministic smoke metrics keyed by effective scenario alpha."""
+        scenario, seed, params = job
+        effective_cfg = map_runner._apply_scenario_uncertainty_envelope_config(
+            str(params["algo"]),
+            dict(params.get("algo_config", {})),
+            scenario,
+        )
+        alpha = float(effective_cfg["pedestrian_uncertainty_alpha_mps"])
+        identity_payload = map_runner._scenario_identity_payload(
+            scenario,
+            algo=str(params["algo"]),
+            algo_config=effective_cfg,
+            horizon=params.get("horizon"),
+            dt=params.get("dt"),
+            record_forces=bool(params.get("record_forces", True)),
+            observation_mode=params.get("observation_mode"),
+        )
+        return {
+            "episode_id": map_runner._compute_map_episode_id(identity_payload, int(seed)),
+            "scenario_id": scenario["name"],
+            "seed": int(seed),
+            "metrics": {"mean_clearance": 1.0 + alpha},
+            "planner_runtime": {
+                "pedestrian_uncertainty_envelope": {
+                    "enabled": True,
+                    "alpha_mps": alpha,
+                    "artifact_disposition": "pytest_tmp_path_disposable_not_benchmark_evidence",
+                }
+            },
+        }
+
+    def _fake_write(_handle, _schema: dict, record: dict[str, object]) -> None:
+        """Record would-be JSONL rows in memory for smoke assertions."""
+        written_records.append(record)
+
+    monkeypatch.setattr(map_runner, "_run_map_job_worker", _fake_worker)
+    monkeypatch.setattr(map_runner, "_write_validated_to_handle", _fake_write)
+
+    algo_config_path = tmp_path / "prediction_mpc_testing.yaml"
+    algo_config_path.write_text("allow_testing_algorithms: true\n", encoding="utf-8")
+
+    result = map_runner.run_map_batch(
+        [_scenario(0.0), _scenario(0.1)],
+        tmp_path / "episodes.jsonl",
+        schema_path=SCHEMA_PATH,
+        algo="prediction_mpc",
+        algo_config_path=str(algo_config_path),
+        benchmark_profile="experimental",
+        horizon=2,
+        dt=0.1,
+        record_forces=False,
+        resume=False,
+    )
+    disposition_path = tmp_path / "artifact_disposition.json"
+    disposition_path.write_text(
+        json.dumps(
+            {
+                "path": str(tmp_path),
+                "disposition": "pytest_tmp_path_disposable_not_benchmark_evidence",
+                "benchmark_claim": False,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    assert result["written"] == 2
+    by_alpha = {
+        record["planner_runtime"]["pedestrian_uncertainty_envelope"]["alpha_mps"]: record
+        for record in written_records
+    }
+    assert by_alpha[0.1]["metrics"]["mean_clearance"] > by_alpha[0.0]["metrics"]["mean_clearance"]
+    assert all(
+        record["planner_runtime"]["pedestrian_uncertainty_envelope"]["artifact_disposition"]
+        == "pytest_tmp_path_disposable_not_benchmark_evidence"
+        for record in written_records
+    )
+    assert json.loads(disposition_path.read_text(encoding="utf-8"))["benchmark_claim"] is False

--- a/tests/planner/test_nmpc_social.py
+++ b/tests/planner/test_nmpc_social.py
@@ -68,6 +68,95 @@ def test_build_nmpc_social_config_overrides_fields() -> None:
     assert cfg.solver_max_iterations == 16
 
 
+def test_build_nmpc_social_config_threads_uncertainty_envelope_fields() -> None:
+    """Config builder should thread explicit uncertainty-envelope settings through."""
+    cfg = build_nmpc_social_config(
+        {
+            "pedestrian_uncertainty_envelope_enabled": True,
+            "pedestrian_uncertainty_alpha_mps": 0.1,
+        }
+    )
+
+    assert cfg.pedestrian_uncertainty_envelope_enabled is True
+    assert cfg.pedestrian_uncertainty_alpha_mps == 0.1
+
+
+def test_nmpc_social_uncertainty_alpha_zero_preserves_rollout_cost() -> None:
+    """Enabling the envelope with alpha zero preserves NMPC soft-cost behavior."""
+    obs = _obs(ped_positions=[(0.7, 0.0)], ped_velocities=[(0.0, 0.0)])
+    controls = np.asarray([0.3, 0.0, 0.3, 0.0, 0.3, 0.0], dtype=float)
+    baseline_context = _RolloutContext(
+        robot_pos=np.asarray([0.0, 0.0], dtype=float),
+        heading=0.0,
+        current_speed=0.0,
+        goal=np.asarray([2.0, 0.0], dtype=float),
+        ped_positions=np.asarray([(0.7, 0.0)], dtype=float),
+        ped_velocities=np.asarray([(0.0, 0.0)], dtype=float),
+        robot_radius=0.25,
+        ped_radius=0.25,
+        observation=obs,
+        speed_cap=0.9,
+    )
+    baseline = NMPCSocialPlannerAdapter(
+        NMPCSocialConfig(horizon_steps=3, pedestrian_uncertainty_envelope_enabled=False)
+    )
+    alpha_zero = NMPCSocialPlannerAdapter(
+        NMPCSocialConfig(
+            horizon_steps=3,
+            pedestrian_uncertainty_envelope_enabled=True,
+            pedestrian_uncertainty_alpha_mps=0.0,
+        )
+    )
+
+    assert alpha_zero._rollout_cost(controls, context=baseline_context) == baseline._rollout_cost(
+        controls, context=baseline_context
+    )
+
+
+def test_nmpc_social_positive_uncertainty_alpha_tightens_soft_clearance() -> None:
+    """Positive alpha increases NMPC soft pedestrian-clearance cost on later rollout steps."""
+    obs = _obs(ped_positions=[(0.7, 0.0)], ped_velocities=[(0.0, 0.0)])
+    controls = np.asarray([0.3, 0.0, 0.3, 0.0, 0.3, 0.0], dtype=float)
+    baseline_context = _RolloutContext(
+        robot_pos=np.asarray([0.0, 0.0], dtype=float),
+        heading=0.0,
+        current_speed=0.0,
+        goal=np.asarray([2.0, 0.0], dtype=float),
+        ped_positions=np.asarray([(0.7, 0.0)], dtype=float),
+        ped_velocities=np.asarray([(0.0, 0.0)], dtype=float),
+        robot_radius=0.25,
+        ped_radius=0.25,
+        observation=obs,
+        speed_cap=0.9,
+    )
+    inflated_context = _RolloutContext(
+        robot_pos=np.asarray([0.0, 0.0], dtype=float),
+        heading=0.0,
+        current_speed=0.0,
+        goal=np.asarray([2.0, 0.0], dtype=float),
+        ped_positions=np.asarray([(0.7, 0.0)], dtype=float),
+        ped_velocities=np.asarray([(0.0, 0.0)], dtype=float),
+        robot_radius=0.25,
+        ped_radius=0.25,
+        observation=obs,
+        speed_cap=0.9,
+        pedestrian_uncertainty_envelope_enabled=True,
+        pedestrian_uncertainty_alpha_mps=0.4,
+    )
+    baseline = NMPCSocialPlannerAdapter(NMPCSocialConfig(horizon_steps=3))
+    inflated = NMPCSocialPlannerAdapter(
+        NMPCSocialConfig(
+            horizon_steps=3,
+            pedestrian_uncertainty_envelope_enabled=True,
+            pedestrian_uncertainty_alpha_mps=0.4,
+        )
+    )
+
+    assert inflated._rollout_cost(controls, context=inflated_context) > baseline._rollout_cost(
+        controls, context=baseline_context
+    )
+
+
 def test_build_nmpc_social_config_invalid_numeric_uses_default() -> None:
     """Invalid numeric overrides should warn and fall back to the dataclass default."""
     with warnings.catch_warnings(record=True) as caught:

--- a/tests/training/test_scenario_loader.py
+++ b/tests/training/test_scenario_loader.py
@@ -267,6 +267,48 @@ def test_build_robot_config_applies_archetype_simulation_overrides(tmp_path: Pat
     assert config.sim_config.archetype_seed == 3206
 
 
+def test_build_robot_config_applies_pedestrian_uncertainty_envelope_fields(
+    tmp_path: Path,
+) -> None:
+    """Scenario YAML can thread pedestrian uncertainty-envelope fields to runtime config."""
+    scenario = {
+        "name": "uncertainty-envelope-runtime-smoke",
+        "simulation_config": {
+            "pedestrian_uncertainty_envelope_enabled": True,
+            "pedestrian_uncertainty_alpha_mps": 0.1,
+        },
+    }
+
+    config = build_robot_config_from_scenario(scenario, scenario_path=tmp_path / "scenario.yaml")
+
+    assert config.sim_config.pedestrian_uncertainty_envelope_enabled is True
+    assert config.sim_config.pedestrian_uncertainty_alpha_mps == 0.1
+
+
+def test_build_robot_config_rejects_negative_uncertainty_alpha(tmp_path: Path) -> None:
+    """Negative scenario alpha fails closed at config-construction time."""
+    scenario = {
+        "name": "uncertainty-envelope-negative-alpha",
+        "simulation_config": {"pedestrian_uncertainty_alpha_mps": -0.1},
+    }
+
+    with pytest.raises(ValueError, match="pedestrian_uncertainty_alpha_mps"):
+        build_robot_config_from_scenario(scenario, scenario_path=tmp_path / "scenario.yaml")
+
+
+def test_build_robot_config_alpha_zero_preserves_default_config(tmp_path: Path) -> None:
+    """Explicit alpha zero is equivalent to the default deterministic envelope setting."""
+    scenario = {
+        "name": "uncertainty-envelope-alpha-zero",
+        "simulation_config": {"pedestrian_uncertainty_alpha_mps": 0.0},
+    }
+
+    config = build_robot_config_from_scenario(scenario, scenario_path=tmp_path / "scenario.yaml")
+
+    assert config.sim_config.pedestrian_uncertainty_envelope_enabled is False
+    assert config.sim_config.pedestrian_uncertainty_alpha_mps == 0.0
+
+
 def test_load_scenarios_allows_duplicate_names_outside_named_overrides(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Reviewer-critical summary

What changed: completes issue #4141's post-#4158 acceptance slice by threading scenario-level `pedestrian_uncertainty_envelope_enabled` and `pedestrian_uncertainty_alpha_mps` into MPC-family planner configs, adding resume-identity coverage for alpha/envelope changes, adding a CPU-only fixed-seed alpha comparison smoke with disposable temp-artifact disposition, and integrating the same effective-radius envelope into NMPC soft pedestrian clearance.

Why now: #4158 landed the base abstraction but the issue was reopened because these acceptance criteria were explicitly deferred.

Claim boundary: this PR proves configuration/runtime plumbing and deterministic contract behavior only. The alpha smoke is not benchmark evidence and does not claim safety, success-rate, paper, dissertation, conformal-calibration, or full-campaign improvement.

Required validation: focused unit/runtime tests for scenario threading, resume identity, Prediction-MPC envelope behavior, NMPC soft-cost behavior, map-runner smoke, plus Ruff and diff checks; full final `pr_ready_check` was run locally before PR open.

Remaining blocker: no full benchmark campaign, Slurm/GPU submission, or paper/dissertation claim edit is included. Claude Code on `imech156-u` owns the post-open full PR gate, improvement cycle, and merge authority.

Contract delta

- New scenario-level simulation fields are now durable runtime inputs: `simulation_config.pedestrian_uncertainty_envelope_enabled` and `simulation_config.pedestrian_uncertainty_alpha_mps`.
- Negative scenario alpha fails closed during scenario config construction.
- Map-runner merges those scenario fields into effective planner config for `prediction_mpc`, `prediction_aware_mpc`, `cv_prediction_mpc`, `learned_prediction_mpc`, `nmpc`, and `nmpc_social` only.
- Resume identity now distinguishes scenario/envelope alpha changes and uses the same effective planner config in resume prefiltering.
- NMPC soft pedestrian-clearance cost now uses horizon-step effective pedestrian radius when the envelope is enabled, while `alpha=0.0` preserves baseline rollout cost.
- Compatibility impact: default fields are disabled/zero, so existing scenarios and non-MPC planners preserve prior behavior.

Closes #4141

Scope summary

- Implemented scenario-level envelope config threading through `SimulationSettings`, scenario loader validation, map-runner effective policy config, and MPC-family planner config builders.
- Added NMPC integration because it was trivially separable and covered by direct rollout-cost tests.
- Added resume-identity regression and alpha comparison smoke with explicit artifact disposition.

Validation

- `uv run pytest tests/training/test_scenario_loader.py tests/benchmark/test_map_runner_resume_identity.py tests/benchmark/test_uncertainty_envelope_runtime.py tests/planner/test_nmpc_social.py tests/planner/test_prediction_mpc.py tests/nav/test_uncertainty_envelope.py -q` PASS
- `uv run pytest tests/test_metrics.py tests/unit/test_metrics_edge_cases.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_map_runner_resume_identity.py -q` PASS
- `uv run ruff check robot_sf/sim/sim_config.py robot_sf/training/scenario_loader.py robot_sf/planner/nmpc_social.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_episode.py robot_sf/benchmark/map_runner_policy_resolution.py tests/training/test_scenario_loader.py tests/benchmark/test_map_runner_resume_identity.py tests/benchmark/test_uncertainty_envelope_runtime.py tests/planner/test_nmpc_social.py` PASS
- `git diff --check` PASS
- `PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` PASS after bootstrapping this fresh worktree with `uv sync --all-extras`

Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits; follow-up tracked in #4232.

State propagation

No separate issue comment was posted because this task authorizes `comment_issue_or_pr: false`. This PR body is the durable handoff surface for the delivered slice and remaining out-of-scope work.

Late guidance / dedupe

- Late issue refresh immediately before PR open found no issue #4141 comments newer than the 2026-07-02T17:32:29Z reopening comment.
- Open-PR dedupe found no existing open PR covering #4141 or this uncertainty-envelope completion scope.
- Fragmentation guard: one #4141 PR (#4158) merged in the last 24h, below the two-PR micro-guard threshold; this PR is a progression slice with the named new capability of scenario-threaded uncertainty-envelope runtime behavior plus regression/smoke coverage.

<details>
<summary>Governance appendix</summary>

Artifact disposition: the alpha comparison smoke writes only pytest `tmp_path` outputs and records `pytest_tmp_path_disposable_not_benchmark_evidence`; no generated benchmark outputs are committed.

Assumption: the reversible completion slice is to thread the existing #4158 abstraction through scenario/map-runner config and apply the same effective radius to NMPC soft costs. No conformal policy, distance-field representation, simulator collision semantic change, or metric redefinition is included.

</details>

## Follow-up Issues

- Deferred work: benchmark/claim evidence follow-up #4232
- Issues opened follow-up: N/A - no new follow-up issue needed because the residual items are out-of-scope evidence boundaries, not missing implementation tasks.



