### PR TITLE
Issue #4142: harden DPCBF passthrough gate

### DIFF
--- a/configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml
+++ b/configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml
@@ -3,9 +3,7 @@
 # Claim boundary: predeclared diagnostic comparison inputs only. Running the
 # full dense dynamic-obstacle campaign, Slurm/GPU submission, and any
 # paper-facing safety-performance claim are out of scope for this PR.
-# Canonical invocation:
-# `uv run python -m robot_sf.benchmark.cli run --config
-# configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml`.
+# Canonical invocation: `uv run python -m robot_sf.benchmark.cli run --config configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml`.
 schema_version: robot_sf.issue_4142_dpcbf_dense_comparison.v1
 scenario_manifest: configs/scenarios/sets/issue_4142_dense_dynamic_cbf_v1.yaml
 algorithm: prediction_mpc_cv

--- a/configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml
+++ b/configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml
@@ -3,8 +3,9 @@
 # Claim boundary: predeclared diagnostic comparison inputs only. Running the
 # full dense dynamic-obstacle campaign, Slurm/GPU submission, and any
 # paper-facing safety-performance claim are out of scope for this PR.
-# Canonical invocation: use this packet as the stable experiment config,
-# for example with `--config configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml`.
+# Canonical invocation:
+# `uv run python -m robot_sf.benchmark.cli run --config
+# configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml`.
 schema_version: robot_sf.issue_4142_dpcbf_dense_comparison.v1
 scenario_manifest: configs/scenarios/sets/issue_4142_dense_dynamic_cbf_v1.yaml
 algorithm: prediction_mpc_cv

--- a/tests/planner/test_cbf_safety_filter.py
+++ b/tests/planner/test_cbf_safety_filter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import struct
+
 import pytest
 
 from robot_sf.planner.cbf_safety_filter import (
@@ -50,6 +52,12 @@ def _public_context() -> CBFFilterContext:
             ),
         ),
     )
+
+
+def _float_bits(value: float) -> bytes:
+    """Return the exact IEEE-754 representation used by Python floats."""
+
+    return struct.pack("!d", value)
 
 
 def test_public_apply_cbf_filter_disabled_returns_original_command() -> None:
@@ -119,7 +127,7 @@ def test_public_apply_cbf_filter_dynamic_parabolic_no_obstacles_passes_through()
 
 
 def test_public_apply_cbf_filter_dynamic_parabolic_feasible_nominal_passes_through() -> None:
-    """DPCBF should not snap feasible nominal commands to the search grid."""
+    """DPCBF keeps already-feasible nominal commands bit-identical."""
 
     context = CBFFilterContext(
         robot_position_m=(0.0, 0.0),
@@ -129,16 +137,21 @@ def test_public_apply_cbf_filter_dynamic_parabolic_feasible_nominal_passes_throu
             CBFObstacleState(position_m=(10.0, 5.0), velocity_mps=(0.0, 0.0), radius_m=0.3),
         ),
     )
+    nominal_linear = 0.817
+    nominal_angular = 0.1
     result = apply_cbf_safety_filter(
-        0.817,
-        0.1,
+        nominal_linear,
+        nominal_angular,
         context,
         CBFSafetyFilterConfig(enabled=True, variant=CBF_VARIANT_DYNAMIC_PARABOLIC),
     )
 
     assert result["qp_status"] == "pass_through"
     assert result["intervened"] is False
-    assert result["filtered_linear_velocity"] == pytest.approx(0.817)
+    assert result["filtered_linear_velocity"] == nominal_linear
+    assert result["filtered_angular_velocity"] == nominal_angular
+    assert _float_bits(result["filtered_linear_velocity"]) == _float_bits(nominal_linear)
+    assert _float_bits(result["filtered_angular_velocity"]) == _float_bits(nominal_angular)
 
 
 def test_public_apply_cbf_filter_dynamic_parabolic_projects_closing_command() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: strengthened the DPCBF feasible-nominal regression so already-feasible commands must pass through with exact Python float bits for both linear and angular velocity, and replaced the dense-comparison packet's `--config` fragment with a concrete canonical benchmark CLI invocation.

Why now: issue #4142's 2026-07-02 campaign gate says dense comparison must not run until the no-op passthrough condition, cached obstacle constants, and canonical command are reviewable. `origin/main` already contains the DPCBF fast path and cached obstacle constants from #4168; this slice makes those campaign-gating contracts explicit and test-backed.

Claim boundary: campaign-gating regression/config slice only. This PR does not run or interpret the dense comparison campaign and makes no safety-performance, paper-facing, or dissertation claim.

Required validation: focused CPU tests for DPCBF planner passthrough and runtime binding, lint/format on the touched test, YAML parse of the research packet, and final PR-ready wrapper once this body is supplied.

Remaining blocker: the full dense dynamic-obstacle comparison still remains out of scope and must be run/reviewed separately before issue #4142 can claim empirical comparison evidence.

## Contract delta

New schema fields: none.

New fail-closed blockers: none.

Compatibility impact: none for runtime behavior. The existing DPCBF production path is unchanged; the test now rejects any future grid-snap of an already-feasible nominal command. The research config comment now names the canonical `robot_sf.benchmark.cli run --config configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml` invocation.

## Summary

Relates to #4142.

This PR delivers a small progression slice for the DPCBF campaign gate: exact passthrough regression coverage and a concrete canonical run command in `configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml`.

## Linked Issues

- Relates `#4142`

## Stack / Dependency

- Base dependency: `origin/main`
- Required prior PRs: `#4168` landed the DPCBF arm, fast path, and cached constants
- Stack follow-up issues: dense comparison remains on `#4142`
- Safe review independently: yes
- Review dependency reason, any: this PR is a regression/config hardening slice on top of the merged DPCBF arm

## What Changed

- Added exact IEEE-754 bit assertions for DPCBF feasible-nominal passthrough in `tests/planner/test_cbf_safety_filter.py`.
- Updated the issue #4142 dense-comparison research packet comment with the canonical benchmark CLI command.

## Why Matters

- Added value: prevents the regression called out in the 2026-07-02 gate where a feasible nominal command could be snapped to a nearby search-grid value.
- Expected impact: campaign gate is easier to review before any dense comparison run.
- Why worth merging now: it is a small reversible slice that records the no-op passthrough contract before later empirical work.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: blocker-resolution for issue #4142 campaign gating.
- Comparator or baseline, applicable: `origin/main` DPCBF regression coverage.
- Evidence tier: NA - no research result; validation is targeted regression proof only.
- Result classification: NA - support/gate regression only.
- Decision stop rule, applicable: merge only if focused DPCBF planner/runtime tests and final readiness wrapper pass.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #4142 stays open for dense comparison evidence.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no new analysis tool.

## Domain-Aware Approval

- Approval concerns experimental validity waived / pending / blocked / not required: not required.
- Approver/review source waiver: this PR does not interpret benchmark results.
- Validity checklist: NA - no evidence classification, dense campaign, or benchmark interpretation.
- Target claim/hypothesis: no-op passthrough gate.
- Comparator split/evidence validity: NA - regression validation only, no empirical comparator claim.
- Fallback/degraded exclusions: no campaign rows produced.
- Claim boundary: campaign-gating code/config slice.
- Implementation integrity vs experimental validity: implementation integrity only.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, the DPCBF pure-function path is exercised.
- Did intervention change command source, selected command, trajectory, route progress? selected command must remain unchanged for the feasible-nominal case.
- Did scenario actually contain targeted failure mode? yes, the test uses an off-path obstacle and a nominal speed not aligned to the DPCBF grid.
- Result route: NA - no research result.
- Follow-up question issue weak, negative, non-transfer results: #4142 dense comparison remains.

## Next Empirical Action

- Rerun needed: yes, dense comparison remains out of scope.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: dense comparison output not generated by this PR.
- Stop / revise / continue decision: continue after this gate lands.
- Proposed child issue existing follow-up: #4142.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/planner/test_cbf_safety_filter.py -q` passed: 15 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_cbf_safety_filter_runtime.py -q` passed: 29 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/planner/test_cbf_safety_filter.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check tests/planner/test_cbf_safety_filter.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python - <<'PY' ... yaml.safe_load(...) ... PY` passed for `configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml`.
- `git diff --check` passed.
- `PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-4142/PR_BODY.md scripts/dev/pr_ready_check.sh` pending at PR open time in this body.

Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance / Resource Impact

- Baseline runtime: planner test file passed in about 6.3s on the focused local validation.
- Changed runtime: planner test file passed in about 5.4s after the change.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/planner/test_cbf_safety_filter.py -q`
- Hot-path call count profile anchor: NA - no production hot-path code changed.
- Cache-hit reuse counter: NA for this PR; cached obstacle constants already exist on `origin/main` and are verified by source inspection.
- Rollback failure criterion: exact feasible-nominal DPCBF passthrough regression or invalid research-packet YAML.

## Risks / Rollout

- Compatibility risks: minimal; production code is unchanged.
- Failure modes: future DPCBF refactor could break exact passthrough and fail the strengthened test.
- Rollback fallback plan: revert this test/config-only commit.

## Docs / Provenance

- Updated docs: `configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml` comment only.
- Relevant design provenance notes: issue #4142 comments, especially the 2026-07-02 campaign gate note.
- Any assumptions need to preserved: `origin/main` already includes the DPCBF fast path and obstacle-constant cache from #4168.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: authorization explicitly sets `comment_issue_or_pr: false`; this PR body is the single durable state surface for this low-churn gate slice. The issue remains open for the actual dense comparison.

## Follow-Up Issues

- Deferred work: run and review the dense dynamic-obstacle comparison under #4142.
- Issues opened follow-up: none.

## Reviewer Notes

- The production DPCBF path is intentionally unchanged because `origin/main` already contains the nominal-feasible fast path and `_precompute_dynamic_parabolic_obstacles` cache. This PR makes the gate explicit and prevents regression.
- Known limitations: no campaign output, no Slurm/GPU run, and no benchmark-strength result.

<details>
<summary>Freshness and dedupe notes</summary>

- Start time: 2026-07-03T07:58:19Z.
- Latest issue #4142 comment before PR-open freshness check: 2026-07-02T17:32:55Z, so there was no maintainer guidance newer than start time.
- Open-PR dedupe check found no open PR covering #4142 or this DPCBF passthrough/config scope.
- Fragmentation guard: only one issue-#4142 PR (`#4168`) merged in the prior 24h, and this slice adds a nameable progression capability: exact feasible-nominal passthrough gate coverage plus canonical run-command clarity.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated an example command in the research config comments to show the recommended way to run the benchmark.

* **Tests**
  * Tightened a safety-filter test to verify exact, bit-level output matching for passing commands.
  * Improved coverage for nominal cases by checking both linear and angular values remain unchanged when no intervention is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->