### PR TITLE
data: register Alyassi Table 7 dataset assets for #4224

### DIFF
--- a/docs/context/issue_4224_external_dataset_registry.md
+++ b/docs/context/issue_4224_external_dataset_registry.md
@@ -1,0 +1,43 @@
+# Issue #4224 External Dataset Registry
+
+Plain-language summary: this note records the source, access, and claim boundary for five external
+dataset assets registered from Alyassi et al. 2025 Table 7. The PR only adds metadata and local
+provenance checks; it does not download, redistribute, ingest, or benchmark any raw dataset.
+
+Related issue: [#4224](https://github.com/ll7/robot_sf_ll7/issues/4224)
+
+Verification date: 2026-07-03.
+
+## Asset Verification
+
+| asset_id | official source URL | license or terms URL | access mode | scripted download permitted | expected local layout | consuming issues |
+| --- | --- | --- | --- | --- | --- | --- |
+| `atc-pedestrian` | `https://dil.atr.jp/crest2010_HRI/ATC_dataset/` | `https://dil.atr.jp/crest2010_HRI/ATC_dataset/` | `clickthrough_manual` | No. The registry keeps `auto_download_allowed=False` until stable terms and URL approval are recorded. | `atc_pedestrian/` with `atc-*.csv` or other trajectory `.csv`, plus `README*`, `LICENSE*`, or `TERMS*`. | #2918, #3161, #3971, #3813, #3950 |
+| `eth-ucy-trajectories` | `https://vision.ee.ethz.ch/datasets/` | `https://vision.ee.ethz.ch/datasets/` | `clickthrough_manual` | No. ETH and UCY terms are not encoded as an automated redistribution or download permission. | `eth_ucy_trajectories/` with `obsmat.txt`, `.vsp`, or trajectory `.txt`, plus `README*`, `LICENSE*`, or `TERMS*`. | #2844, #4013 |
+| `ind-crossings` | `https://levelxdata.com/ind-dataset/` | `https://levelxdata.com/ind-dataset/` | `research_request_byo` | No. The page requires terms acceptance and confirms non-redistribution; local bring-your-own staging only. | `ind_crossings/` with `*_tracks.csv` or other inD `.csv`, plus `README*`, `LICENSE*`, or `TERMS*`. | #3161 |
+| `crowdbot` | `https://www.epfl.ch/labs/lasa/crowdbot-dataset/` | `https://www.epfl.ch/labs/lasa/crowdbot-dataset/` | `research_request_byo` | No. Research/DataPort access terms must be preserved locally before staging. | `crowdbot/` with `.bag`, `.csv`, or `.json` recordings/metadata, plus `README*`, `LICENSE*`, or `TERMS*`. | #3977 |
+| `scand-demos` | `https://dataverse.tdl.org/dataset.xhtml?persistentId=doi:10.18738/T8/0PRYRH` | `https://dataverse.tdl.org/dataset.xhtml?persistentId=doi:10.18738/T8/0PRYRH` | `clickthrough_manual` | No. The DataVerse release is large and file selection plus terms should be handled manually first. | `scand_demos/` with `.bag`, `.csv`, or `.json` recordings/metadata, plus `README*`, `LICENSE*`, or `TERMS*`. | #1470, #1496 |
+
+## Claim Boundary
+
+External-data registry only. Registering an asset does not mean data has been downloaded, staged,
+license-approved for redistribution, ingested, or used to support a benchmark, paper, dissertation,
+or planner claim.
+
+These assets are alternatives or complements to the blocked Stanford Drone Dataset provenance route
+tracked in #4079. This note does not resolve Stanford Drone Dataset canonical equivalence.
+
+## Follow-Up
+
+After a maintainer obtains a dataset under verified terms, stage it locally with:
+
+```bash
+uv run python scripts/tools/manage_external_data.py stage <asset-id> \
+  --source <local-staged-path> \
+  --manifest-out output/external_data/manifests/<asset-id>.provenance.json
+uv run python scripts/tools/manage_external_data.py --json provenance-check <asset-id> \
+  --manifest output/external_data/manifests/<asset-id>.provenance.json
+```
+
+Only pin `expected_tree_sha256` after reviewing that the staged tree corresponds to the official
+asset and no raw data is tracked by git.

--- a/scripts/tools/manage_external_data.py
+++ b/scripts/tools/manage_external_data.py
@@ -113,6 +113,11 @@ class AssetSpec:
     required_paths: tuple[RequiredPath, ...]
     related_issues: tuple[int, ...]
     auto_download_allowed: bool = False
+    license_url: str | None = None
+    expected_tree_sha256: str | None = None
+    expected_tree_sha256_status: Literal["pending_first_staging", "pinned"] = (
+        "pending_first_staging"
+    )
     # Optional pointer to a checksum/availability staging manifest. When set, this asset carries a
     # pinned-checksum policy and proxy-vs-dataset-backed availability states (see the SDD asset).
     staging_manifest_path: Path | None = None
@@ -264,6 +269,290 @@ ASSETS: tuple[AssetSpec, ...] = (
         ),
         related_issues=(1585, 1559),
     ),
+    AssetSpec(
+        asset_id="atc-pedestrian",
+        title="ATC shopping-mall pedestrian tracking trajectories",
+        expected_local_path=REPO_ROOT / "output" / "external_data" / "atc_pedestrian",
+        shared_root_subpath=Path("atc_pedestrian"),
+        source_url="https://dil.atr.jp/crest2010_HRI/ATC_dataset/",
+        source_note=(
+            "Official ATR ATC pedestrian tracking dataset page for Brscic et al. 2013. "
+            "The source describes 92 days of shopping-mall trajectories in daily CSV files."
+        ),
+        license_note=(
+            "ATR research-use terms apply; Robot SF does not redistribute ATC bytes. "
+            "Keep a local copy of the source terms or README with staged data."
+        ),
+        access_note=(
+            "Manual direct acquisition from the official ATR page. Scripted download remains "
+            "disabled until a maintainer records stable terms and URL approval."
+        ),
+        required_paths=(
+            RequiredPath(
+                pattern="**/atc-*.csv",
+                kind="file",
+                description="Official ATC daily trajectory CSV file.",
+                group="trajectory",
+            ),
+            RequiredPath(
+                pattern="**/*.csv",
+                kind="file",
+                description="ATC trajectory CSV file when staged without original filename.",
+                group="trajectory",
+            ),
+            RequiredPath(
+                pattern="**/README*",
+                kind="file",
+                description="Dataset README, terms, or local staging note.",
+                group="license_or_readme",
+            ),
+            RequiredPath(
+                pattern="**/LICENSE*",
+                kind="file",
+                description="Dataset license or terms copy.",
+                group="license_or_readme",
+            ),
+            RequiredPath(
+                pattern="**/TERMS*",
+                kind="file",
+                description="Dataset terms copy.",
+                group="license_or_readme",
+            ),
+        ),
+        related_issues=(2918, 3161, 3971, 3813, 3950),
+        license_url="https://dil.atr.jp/crest2010_HRI/ATC_dataset/",
+    ),
+    AssetSpec(
+        asset_id="eth-ucy-trajectories",
+        title="ETH/UCY pedestrian trajectory benchmarks",
+        expected_local_path=REPO_ROOT / "output" / "external_data" / "eth_ucy_trajectories",
+        shared_root_subpath=Path("eth_ucy_trajectories"),
+        source_url="https://vision.ee.ethz.ch/datasets/",
+        source_note=(
+            "ETH BIWI Walking Pedestrians official page plus UCY Crowds-by-Example "
+            "manual staging for the standard ETH/Hotel/Univ/Zara trajectory benchmark set."
+        ),
+        license_note=(
+            "Dataset-specific ETH and UCY terms must be preserved locally; Robot SF does "
+            "not redistribute the combined ETH/UCY trajectory files."
+        ),
+        access_note=(
+            "Manual acquisition from official ETH and UCY sources or maintainer-approved "
+            "mirrors. Scripted download remains disabled pending explicit terms review."
+        ),
+        required_paths=(
+            RequiredPath(
+                pattern="**/obsmat.txt",
+                kind="file",
+                description="ETH/Hotel trajectory observation matrix.",
+                group="trajectory",
+            ),
+            RequiredPath(
+                pattern="**/*.vsp",
+                kind="file",
+                description="UCY Crowds-by-Example trajectory sequence file.",
+                group="trajectory",
+            ),
+            RequiredPath(
+                pattern="**/*.txt",
+                kind="file",
+                description="Trajectory text file from ETH/UCY staging.",
+                group="trajectory",
+            ),
+            RequiredPath(
+                pattern="**/README*",
+                kind="file",
+                description="Dataset README, terms, or local staging note.",
+                group="license_or_readme",
+            ),
+            RequiredPath(
+                pattern="**/LICENSE*",
+                kind="file",
+                description="Dataset license or terms copy.",
+                group="license_or_readme",
+            ),
+            RequiredPath(
+                pattern="**/TERMS*",
+                kind="file",
+                description="Dataset terms copy.",
+                group="license_or_readme",
+            ),
+        ),
+        related_issues=(2844, 4013),
+        license_url="https://vision.ee.ethz.ch/datasets/",
+    ),
+    AssetSpec(
+        asset_id="ind-crossings",
+        title="inD intersection drone trajectories",
+        expected_local_path=REPO_ROOT / "output" / "external_data" / "ind_crossings",
+        shared_root_subpath=Path("ind_crossings"),
+        source_url="https://levelxdata.com/ind-dataset/",
+        source_note=(
+            "Official leveLXData inD page for naturalistic road-user trajectories at "
+            "German intersections, including pedestrians and crossing interactions."
+        ),
+        license_note=(
+            "Free for non-commercial use after terms acceptance; terms prohibit "
+            "redistributing the dataset or modified versions. Stage local BYO copies only."
+        ),
+        access_note=(
+            "Research-request/BYO asset through leveLXData. No automated download or "
+            "redistribution path is encoded."
+        ),
+        required_paths=(
+            RequiredPath(
+                pattern="**/*_tracks.csv",
+                kind="file",
+                description="inD tracks CSV file.",
+                group="trajectory",
+            ),
+            RequiredPath(
+                pattern="**/*.csv",
+                kind="file",
+                description="inD trajectory or metadata CSV file.",
+                group="trajectory",
+            ),
+            RequiredPath(
+                pattern="**/README*",
+                kind="file",
+                description="Dataset README, terms, or local staging note.",
+                group="license_or_readme",
+            ),
+            RequiredPath(
+                pattern="**/LICENSE*",
+                kind="file",
+                description="Dataset license or terms copy.",
+                group="license_or_readme",
+            ),
+            RequiredPath(
+                pattern="**/TERMS*",
+                kind="file",
+                description="Dataset terms copy.",
+                group="license_or_readme",
+            ),
+        ),
+        related_issues=(3161,),
+        license_url="https://levelxdata.com/ind-dataset/",
+    ),
+    AssetSpec(
+        asset_id="crowdbot",
+        title="CrowdBot robot-in-crowd dataset",
+        expected_local_path=REPO_ROOT / "output" / "external_data" / "crowdbot",
+        shared_root_subpath=Path("crowdbot"),
+        source_url="https://www.epfl.ch/labs/lasa/crowdbot-dataset/",
+        source_note=(
+            "Official EPFL LASA CrowdBot dataset page for Qolo robot navigation in "
+            "Lausanne crowds; the published dataset reference points to IEEE DataPort."
+        ),
+        license_note=(
+            "Research access depends on the official CrowdBot/IEEE DataPort terms. "
+            "Do not redistribute raw sensor data through Robot SF."
+        ),
+        access_note=(
+            "Research-request/BYO asset. Stage only a locally obtained copy with the "
+            "terms preserved; scripted download is disabled."
+        ),
+        required_paths=(
+            RequiredPath(
+                pattern="**/*.bag",
+                kind="file",
+                description="CrowdBot ROS bag recording.",
+                group="recording",
+            ),
+            RequiredPath(
+                pattern="**/*.csv",
+                kind="file",
+                description="CrowdBot exported track, annotation, or metadata table.",
+                group="recording",
+            ),
+            RequiredPath(
+                pattern="**/*.json",
+                kind="file",
+                description="CrowdBot metadata or annotation JSON.",
+                group="recording",
+            ),
+            RequiredPath(
+                pattern="**/README*",
+                kind="file",
+                description="Dataset README, terms, or local staging note.",
+                group="license_or_readme",
+            ),
+            RequiredPath(
+                pattern="**/LICENSE*",
+                kind="file",
+                description="Dataset license or terms copy.",
+                group="license_or_readme",
+            ),
+            RequiredPath(
+                pattern="**/TERMS*",
+                kind="file",
+                description="Dataset terms copy.",
+                group="license_or_readme",
+            ),
+        ),
+        related_issues=(3977,),
+        license_url="https://www.epfl.ch/labs/lasa/crowdbot-dataset/",
+    ),
+    AssetSpec(
+        asset_id="scand-demos",
+        title="SCAND socially compliant navigation demonstrations",
+        expected_local_path=REPO_ROOT / "output" / "external_data" / "scand_demos",
+        shared_root_subpath=Path("scand_demos"),
+        source_url="https://dataverse.tdl.org/dataset.xhtml?persistentId=doi:10.18738/T8/0PRYRH",
+        source_note=(
+            "Texas Data Repository SCAND release for Socially CompliAnt Navigation "
+            "Dataset demonstrations from Karnan et al. 2022."
+        ),
+        license_note=(
+            "Use the Texas Data Repository dataset terms and citation metadata. Robot SF "
+            "does not redistribute raw SCAND bags or sensor logs."
+        ),
+        access_note=(
+            "Manual DataVerse acquisition; the dataset is large, so select files through "
+            "the official interface. Scripted download is disabled until terms and exact "
+            "file selection are pinned."
+        ),
+        required_paths=(
+            RequiredPath(
+                pattern="**/*.bag",
+                kind="file",
+                description="SCAND ROS bag demonstration recording.",
+                group="recording",
+            ),
+            RequiredPath(
+                pattern="**/*.csv",
+                kind="file",
+                description="SCAND exported trajectory, command, or metadata table.",
+                group="recording",
+            ),
+            RequiredPath(
+                pattern="**/*.json",
+                kind="file",
+                description="SCAND metadata or annotation JSON.",
+                group="recording",
+            ),
+            RequiredPath(
+                pattern="**/README*",
+                kind="file",
+                description="Dataset README, terms, or local staging note.",
+                group="license_or_readme",
+            ),
+            RequiredPath(
+                pattern="**/LICENSE*",
+                kind="file",
+                description="Dataset license or terms copy.",
+                group="license_or_readme",
+            ),
+            RequiredPath(
+                pattern="**/TERMS*",
+                kind="file",
+                description="Dataset terms copy.",
+                group="license_or_readme",
+            ),
+        ),
+        related_issues=(1470, 1496),
+        license_url="https://dataverse.tdl.org/dataset.xhtml?persistentId=doi:10.18738/T8/0PRYRH",
+    ),
 )
 
 
@@ -402,9 +691,12 @@ def check_asset(asset_id: str, *, source_path: Path | None = None) -> dict[str, 
         "external_data_root_env": EXTERNAL_DATA_ROOT_ENV,
         "external_data_root": str(ext_root) if ext_root else None,
         "source_url": asset.source_url,
+        "license_url": asset.license_url,
         "license_note": asset.license_note,
         "access_note": asset.access_note,
         "auto_download_allowed": asset.auto_download_allowed,
+        "expected_tree_sha256": asset.expected_tree_sha256,
+        "expected_tree_sha256_status": asset.expected_tree_sha256_status,
         "required_paths": [
             {
                 "pattern": required.pattern,
@@ -445,7 +737,7 @@ def check_asset(asset_id: str, *, source_path: Path | None = None) -> dict[str, 
 
     report["missing_required_paths"] = missing
     report["matched_required_paths"] = [
-        path.relative_to(root).as_posix() for path in sorted(matched_paths)
+        path.relative_to(root).as_posix() for path in sorted(set(matched_paths))
     ]
     if missing:
         report["status"] = "incomplete"
@@ -510,8 +802,11 @@ def stage_asset(
         "title": asset.title,
         "source_url": asset.source_url,
         "source_note": asset.source_note,
+        "license_url": asset.license_url,
         "license_note": asset.license_note,
         "access_note": asset.access_note,
+        "expected_tree_sha256": asset.expected_tree_sha256,
+        "expected_tree_sha256_status": asset.expected_tree_sha256_status,
         "local_path": str(source_root),
         "availability": _asset_availability_record(
             asset,
@@ -574,13 +869,20 @@ def _provenance_paths_cover_requirements(asset: AssetSpec, matched_paths: list[A
             for candidate in candidates
             for pattern in literal_patterns
         ) or any(
-            fnmatch.fnmatch(candidate, pattern)
+            _provenance_glob_matches(candidate, pattern)
             for candidate in candidates
             for pattern in glob_patterns
         )
         if not satisfied:
             return False
     return True
+
+
+def _provenance_glob_matches(candidate: str, pattern: str) -> bool:
+    """Return whether a manifest path satisfies a required glob pattern."""
+    return fnmatch.fnmatch(candidate, pattern) or (
+        pattern.startswith("**/") and fnmatch.fnmatch(candidate, pattern[3:])
+    )
 
 
 def _missing_provenance_metadata(asset: AssetSpec, manifest: dict[str, Any]) -> list[str]:
@@ -641,7 +943,10 @@ def check_provenance_manifest(asset_id: str, manifest_path: Path) -> dict[str, A
 
     report["missing_metadata"] = missing
     report["source_url"] = manifest.get("source_url")
+    report["license_url"] = manifest.get("license_url")
     report["license_note"] = manifest.get("license_note")
+    report["expected_tree_sha256"] = manifest.get("expected_tree_sha256")
+    report["expected_tree_sha256_status"] = manifest.get("expected_tree_sha256_status")
     report["tree_sha256"] = manifest.get("tree_sha256")
     report["matched_required_paths"] = manifest.get("matched_required_paths", [])
     if missing:
@@ -1397,9 +1702,12 @@ def _asset_summary(asset: AssetSpec, *, include_status: bool) -> dict[str, Any]:
         "external_data_root_env": EXTERNAL_DATA_ROOT_ENV,
         "external_data_root": str(ext_root) if ext_root else None,
         "source_url": asset.source_url,
+        "license_url": asset.license_url,
         "license_note": asset.license_note,
         "access_note": asset.access_note,
         "auto_download_allowed": asset.auto_download_allowed,
+        "expected_tree_sha256": asset.expected_tree_sha256,
+        "expected_tree_sha256_status": asset.expected_tree_sha256_status,
         "related_issues": list(asset.related_issues),
     }
     if include_status:
@@ -1420,7 +1728,13 @@ def _print_asset_summary(payload: dict[str, Any]) -> None:
         print(f"  action: {payload['action']}")
     print(f"  expected path: {payload['expected_local_path']}")
     print(f"  source: {payload['source_url']}")
+    if payload["license_url"]:
+        print(f"  license url: {payload['license_url']}")
     print(f"  license/access: {payload['license_note']} {payload['access_note']}")
+    checksum_text = payload["expected_tree_sha256_status"]
+    if payload["expected_tree_sha256"]:
+        checksum_text += f" ({payload['expected_tree_sha256']})"
+    print(f"  checksum: {checksum_text}")
     print(
         f"  download: {'allowed' if payload['auto_download_allowed'] else 'manual/license-gated'}"
     )

--- a/tests/tools/test_manage_external_data.py
+++ b/tests/tools/test_manage_external_data.py
@@ -41,6 +41,25 @@ def _write_socnavbench_eth_fixture(path: Path) -> None:
     (traversible_dir / "data.pkl").write_bytes(b"synthetic fixture, not official data")
 
 
+def _write_atc_fixture(path: Path) -> None:
+    """Create minimal ATC-shaped fixture; not official data."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "atc-20121024.csv").write_text(
+        "time,person_id,x,y,z,velocity,angle,facing_angle\n0,1,0,0,0,0,0,0\n",
+        encoding="utf-8",
+    )
+    (path / "README.md").write_text("Synthetic fixture for registry tests.\n", encoding="utf-8")
+
+
+def _write_ind_fixture(path: Path) -> None:
+    """Create minimal inD-shaped fixture; not official data."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "00_tracks.csv").write_text(
+        "trackId,frame,xCenter,yCenter\n1,0,0,0\n", encoding="utf-8"
+    )
+    (path / "TERMS.txt").write_text("Synthetic terms placeholder for tests.\n", encoding="utf-8")
+
+
 def test_registry_covers_initial_required_asset_groups() -> None:
     """The first slice should cover SDD, SocNavBench, and AMV provenance assets."""
     asset_ids = {asset.asset_id for asset in manage_external_data.list_assets()}
@@ -49,6 +68,31 @@ def test_registry_covers_initial_required_asset_groups() -> None:
     assert "socnavbench-s3dis-eth" in asset_ids
     assert "socnavbench-control" in asset_ids
     assert "amv-calibration" in asset_ids
+
+
+def test_registry_covers_alyassi_table_7_asset_slice() -> None:
+    """Issue #4224 registers the Alyassi Table 7 dataset candidates as manual assets."""
+    expected = {
+        "atc-pedestrian",
+        "eth-ucy-trajectories",
+        "ind-crossings",
+        "crowdbot",
+        "scand-demos",
+    }
+    assets = {asset.asset_id: asset for asset in manage_external_data.list_assets()}
+
+    assert expected <= set(assets)
+    for asset_id in expected:
+        asset = assets[asset_id]
+        assert asset.source_url
+        assert asset.license_url
+        assert asset.license_note
+        assert asset.access_note
+        assert asset.shared_root_subpath.as_posix()
+        assert asset.related_issues
+        assert asset.auto_download_allowed is False
+        assert asset.expected_tree_sha256 is None
+        assert asset.expected_tree_sha256_status == "pending_first_staging"
 
 
 def test_missing_license_gated_asset_fails_closed(tmp_path: Path) -> None:
@@ -97,6 +141,25 @@ def test_external_data_root_overrides_asset_paths(
     assert (
         manage_external_data.resolve_asset_local_path_by_id("amv-calibration")
         == shared_root / "amv_calibration"
+    )
+    assert (
+        manage_external_data.resolve_asset_local_path_by_id("atc-pedestrian")
+        == shared_root / "atc_pedestrian"
+    )
+    assert (
+        manage_external_data.resolve_asset_local_path_by_id("eth-ucy-trajectories")
+        == shared_root / "eth_ucy_trajectories"
+    )
+    assert (
+        manage_external_data.resolve_asset_local_path_by_id("ind-crossings")
+        == shared_root / "ind_crossings"
+    )
+    assert (
+        manage_external_data.resolve_asset_local_path_by_id("crowdbot") == shared_root / "crowdbot"
+    )
+    assert (
+        manage_external_data.resolve_asset_local_path_by_id("scand-demos")
+        == shared_root / "scand_demos"
     )
 
 
@@ -173,10 +236,116 @@ def test_cli_list_and_check_report_external_data_root(
     assert check_payload["source_path"] == str((shared_root / "sdd").resolve())
 
 
+def test_cli_list_and_explain_include_alyassi_metadata() -> None:
+    """List/explain JSON expose license/access/checksum-pending metadata."""
+    list_result = subprocess.run(
+        [sys.executable, "scripts/tools/manage_external_data.py", "--json", "list"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    list_payload = json.loads(list_result.stdout)
+    atc_entry = next(entry for entry in list_payload if entry["asset_id"] == "atc-pedestrian")
+
+    assert atc_entry["license_url"] == "https://dil.atr.jp/crest2010_HRI/ATC_dataset/"
+    assert atc_entry["expected_tree_sha256"] is None
+    assert atc_entry["expected_tree_sha256_status"] == "pending_first_staging"
+    assert atc_entry["auto_download_allowed"] is False
+
+    explain_result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tools/manage_external_data.py",
+            "--json",
+            "explain",
+            "scand-demos",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    explain_payload = json.loads(explain_result.stdout)
+
+    assert explain_payload["asset_id"] == "scand-demos"
+    assert explain_payload["license_url"].startswith("https://dataverse.tdl.org/")
+    assert explain_payload["expected_tree_sha256_status"] == "pending_first_staging"
+    assert explain_payload["required_paths"]
+
+
 def test_download_for_gated_asset_is_rejected() -> None:
     """Download must fail closed when redistribution/download terms are not encoded."""
     with pytest.raises(manage_external_data.ExternalDataError, match="license-gated"):
         manage_external_data.download_asset("sdd")
+
+
+def test_alyassi_table_7_downloads_are_rejected() -> None:
+    """Issue #4224 assets are registry/manual-staging only, not auto-downloadable."""
+    for asset_id in (
+        "atc-pedestrian",
+        "eth-ucy-trajectories",
+        "ind-crossings",
+        "crowdbot",
+        "scand-demos",
+    ):
+        with pytest.raises(manage_external_data.ExternalDataError, match="license-gated"):
+            manage_external_data.download_asset(asset_id)
+
+
+def test_alyassi_table_7_missing_check_fails_closed(tmp_path: Path) -> None:
+    """Missing local Table 7 assets report manual acquisition action."""
+    report = manage_external_data.check_asset("atc-pedestrian", source_path=tmp_path / "missing")
+
+    assert report["ok"] is False
+    assert report["status"] == "missing"
+    assert report["availability"]["state"] == "missing"
+    assert report["expected_tree_sha256"] is None
+    assert report["expected_tree_sha256_status"] == "pending_first_staging"
+    assert "official acquisition" in report["action"]
+
+
+def test_stage_writes_manifest_for_alyassi_direct_style_asset(tmp_path: Path) -> None:
+    """ATC fixture staging records checksum metadata without raw content leakage."""
+    _init_git_repo(tmp_path, gitignore="external/atc/\n")
+    source_root = tmp_path / "external" / "atc"
+    _write_atc_fixture(source_root)
+    manifest_path = tmp_path / "manifests" / "atc.provenance.json"
+
+    manifest = manage_external_data.stage_asset(
+        "atc-pedestrian",
+        source_path=source_root,
+        manifest_out=manifest_path,
+        repo_root=tmp_path,
+    )
+
+    assert manifest_path.is_file()
+    assert manifest["asset_id"] == "atc-pedestrian"
+    assert manifest["license_url"]
+    assert manifest["tree_sha256"]
+    assert manifest["expected_tree_sha256"] is None
+    assert manifest["expected_tree_sha256_status"] == "pending_first_staging"
+    assert manifest["sample_files"]
+    assert all("0,1,0,0" not in json.dumps(sample) for sample in manifest["sample_files"])
+    assert manage_external_data.check_provenance_manifest("atc-pedestrian", manifest_path)["ok"]
+
+
+def test_stage_writes_manifest_for_alyassi_byo_asset(tmp_path: Path) -> None:
+    """BYO/research-request assets still get local provenance when staged."""
+    _init_git_repo(tmp_path, gitignore="external/ind/\n")
+    source_root = tmp_path / "external" / "ind"
+    _write_ind_fixture(source_root)
+    manifest_path = tmp_path / "manifests" / "ind.provenance.json"
+
+    manifest = manage_external_data.stage_asset(
+        "ind-crossings",
+        source_path=source_root,
+        manifest_out=manifest_path,
+        repo_root=tmp_path,
+    )
+
+    assert manifest["asset_id"] == "ind-crossings"
+    assert manifest["license_url"] == "https://levelxdata.com/ind-dataset/"
+    assert manifest["matched_required_paths"] == ["00_tracks.csv", "TERMS.txt"]
+    assert manage_external_data.check_provenance_manifest("ind-crossings", manifest_path)["ok"]
 
 
 def test_stage_rejects_unignored_repo_local_raw_data(tmp_path: Path) -> None:


### PR DESCRIPTION
**Reviewer-Critical Summary**

What changed: registers five Alyassi 2025 Table 7 external-data assets in `scripts/tools/manage_external_data.py`: ATC, ETH-UCY, inD, CrowdBot, and SCAND. Each asset has source URL, license/terms URL, access and license notes, stable shared-root subpath, required-path groups, related issue links, disabled auto-download, and `expected_tree_sha256_status="pending_first_staging"`.

Why now: issue #4224 asks for a metadata/provenance slice so maintainers can stage these datasets later without raw bytes or ad hoc registry forks.

Claim boundary: external-data registry only. This PR does not mean any dataset was downloaded, staged, license-approved for redistribution, ingested, benchmarked, or used for a paper/dissertation claim.

Required validation: focused external-data registry tests plus CLI list/explain/check coverage and final PR readiness wrapper.

Remaining blocker: maintainers still need to obtain each dataset under its own terms, stage local bytes, run provenance-check, and only then pin any `expected_tree_sha256`.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4224

**Contract Delta**

- New registry fields on `AssetSpec`: `license_url`, `expected_tree_sha256`, and `expected_tree_sha256_status`.
- New assets: `atc-pedestrian`, `eth-ucy-trajectories`, `ind-crossings`, `crowdbot`, `scand-demos`.
- `list`, `explain`, `check`, `stage`, and `provenance-check` JSON now surface license URL and checksum-pending metadata.
- `explain` human output now prints license URL and checksum status when available.
- Required-path reporting deduplicates overlapping group matches; provenance glob matching treats `**/foo` as matching root-level `foo`.
- Compatibility impact: defaulted `AssetSpec` fields preserve existing assets. All new assets have `auto_download_allowed=False`; `download` continues to fail closed.

**Validation**

- `uv run pytest tests/tools/test_manage_external_data.py -q` -> passed, 29 tests.
- `uv run ruff check scripts/tools/manage_external_data.py tests/tools/test_manage_external_data.py` -> passed.
- `uv run ruff format --check scripts/tools/manage_external_data.py tests/tools/test_manage_external_data.py` -> passed.
- `uv run python scripts/tools/manage_external_data.py --json list` -> passed; all five new assets reported `status="missing"`, `auto_download_allowed=false`, `expected_tree_sha256_status="pending_first_staging"`.
- `uv run python scripts/tools/manage_external_data.py --json explain <asset>` for all five new asset IDs -> passed.
- `uv run python scripts/tools/manage_external_data.py --json check atc-pedestrian || test $? -eq 2` -> passed; missing local bytes fail closed with official-acquisition action.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no data download, no raw dataset staging, no extraction pipeline, and no auto-download implementation.

State propagation: no issue comment is posted from this slice because `comment_issue_or_pr=false` in the task authorization. The PR body is the durable handoff surface for this low-churn issue.

Late guidance check: immediately before PR open, issue #4224 still had one maintainer comment, created 2026-07-03T07:35:34Z; no newer maintainer guidance was present.

<details>
<summary>Scope and governance appendix</summary>

Fragmentation guard: no open PR and no merged PR in the last 24 hours were found for issue #4224 or the exact Alyassi Table 7 registry scope, so this is a progression slice adding a nameable new capability: the public external-data registry contract for five Table 7 assets.

Artifact policy: generated validation JSON outputs stayed under `/tmp`; no raw external data, benchmark outputs, model files, or `output/` artifacts are committed.

Source verification note: `docs/context/issue_4224_external_dataset_registry.md` records official source/license URLs, access mode, scripted-download decision, expected local layout, consuming issues, and claim boundary.
</details>
