### PR TITLE
Issue #3190: integrate context-note freshness docs proof

### DIFF
--- a/scripts/validation/check_docs_proof_consistency.py
+++ b/scripts/validation/check_docs_proof_consistency.py
@@ -44,6 +44,8 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from scripts.tools import check_context_note_freshness
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
@@ -661,6 +663,33 @@ def _evidence_catalog_coverage_diagnostics(
     ]
 
 
+def _context_note_freshness_diagnostics(
+    *,
+    repo_root: Path,
+    max_age_days: int,
+    strict: bool,
+) -> list[Diagnostic]:
+    """Return context-note freshness findings as docs/proof diagnostics."""
+    findings = check_context_note_freshness.check_freshness(
+        repo_root=repo_root,
+        catalog_path=_CONTEXT_CATALOG,
+        context_dir=_TOP_LEVEL_CONTEXT_DIR,
+        index_path=_CONTEXT_INDEX,
+        max_age_days=max_age_days,
+    )
+    diagnostics: list[Diagnostic] = []
+    for finding in findings:
+        if finding.severity == "warning" and not strict:
+            continue
+        diagnostics.append(
+            Diagnostic(
+                path=Path(finding.path),
+                message=f"context note freshness {finding.rule}: {finding.message}",
+            )
+        )
+    return diagnostics
+
+
 def _validation_phrase_diagnostics(path: Path, text: str) -> list[Diagnostic]:
     """Flag notes that claim no validation ran while also listing executed commands."""
     if not _is_within_dir(path, _TOP_LEVEL_CONTEXT_DIR):
@@ -813,6 +842,29 @@ def _parse_args() -> argparse.Namespace:
             "even when the selected diff does not include that file."
         ),
     )
+    parser.add_argument(
+        "--check-context-note-freshness",
+        action="store_true",
+        dest="check_context_note_freshness",
+        help=(
+            "Run the context-note freshness checker. Superseded replacement errors fail by "
+            "default; stale current notes and orphan notes fail only with "
+            "--strict-context-note-freshness."
+        ),
+    )
+    parser.add_argument(
+        "--strict-context-note-freshness",
+        action="store_true",
+        dest="strict_context_note_freshness",
+        help="Treat context-note freshness warnings as docs/proof errors.",
+    )
+    parser.add_argument(
+        "--context-note-max-age-days",
+        type=int,
+        default=180,
+        help="Maximum age for current dated context notes in freshness checks.",
+    )
+
     return parser.parse_args()
 
 
@@ -828,6 +880,27 @@ def _selected_files(args: argparse.Namespace, repo_root: Path) -> list[ChangedFi
     return _changed_files(str(args.base), repo_root)
 
 
+def _emit_diagnostics(
+    diagnostics: list[Diagnostic],
+    *,
+    json_output: bool,
+    success_message: str,
+) -> int:
+    """Print diagnostics in requested format and return process exit code."""
+    if json_output:
+        payload = [
+            {"path": diagnostic.path.as_posix(), "message": diagnostic.message}
+            for diagnostic in diagnostics
+        ]
+        print(json.dumps(payload, indent=2))
+    elif diagnostics:
+        for diagnostic in diagnostics:
+            print(f"ERROR {diagnostic.path.as_posix()}: {diagnostic.message}")
+    else:
+        print(success_message)
+    return 1 if diagnostics else 0
+
+
 def main() -> int:
     """Run the docs/proof consistency checker."""
     args = _parse_args()
@@ -835,21 +908,27 @@ def main() -> int:
 
     if args.check_evidence_catalog:
         diagnostics = _evidence_catalog_coverage_diagnostics(repo_root=repo_root)
-        if args.json:
-            payload = [
-                {"path": diagnostic.path.as_posix(), "message": diagnostic.message}
-                for diagnostic in diagnostics
-            ]
-            print(json.dumps(payload, indent=2))
-        elif diagnostics:
-            for diagnostic in diagnostics:
-                print(f"ERROR {diagnostic.path.as_posix()}: {diagnostic.message}")
-        else:
-            print(
+        return _emit_diagnostics(
+            diagnostics,
+            json_output=args.json,
+            success_message=(
                 "OK evidence/catalog coverage check passed:"
                 f" all tracked {_EVIDENCE_DIR.as_posix()} bundles have catalog entries."
-            )
-        return 1 if diagnostics else 0
+            ),
+        )
+
+    if args.check_context_note_freshness:
+        diagnostics = _context_note_freshness_diagnostics(
+            repo_root=repo_root,
+            max_age_days=args.context_note_max_age_days,
+            strict=args.strict_context_note_freshness,
+        )
+        mode = "strict" if args.strict_context_note_freshness else "non-strict"
+        return _emit_diagnostics(
+            diagnostics,
+            json_output=args.json,
+            success_message=f"OK context-note freshness check passed in {mode} mode.",
+        )
 
     try:
         changed_files = _selected_files(args, repo_root)

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -13,12 +13,65 @@ from scripts.validation.check_docs_proof_consistency import (
     _collect_diagnostics,
     _context_catalog_diagnostics,
     _context_index_link_diagnostics,
+    _context_note_freshness_diagnostics,
     _context_readme_link_diagnostics,
     _evidence_catalog_coverage_diagnostics,
     _parse_name_status,
     _selected_files,
     _should_check_context_catalog,
 )
+
+
+def _run_git(repo_root: Path, *args: str, env: dict[str, str] | None = None) -> None:
+    """Run a git command for a temporary repository fixture."""
+    subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _commit_all(repo_root: Path, message: str, *, iso_date: str) -> None:
+    """Commit all fixture changes with a deterministic timestamp."""
+    env = {
+        "GIT_AUTHOR_DATE": iso_date,
+        "GIT_COMMITTER_DATE": iso_date,
+        "GIT_AUTHOR_NAME": "Test Author",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test Author",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    _run_git(repo_root, "add", ".")
+    _run_git(repo_root, "commit", "-m", message, env=env)
+
+
+def _freshness_repo(tmp_path: Path, catalog_entries: str) -> Path:
+    """Create minimal git repo for context-note freshness integration tests."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _run_git(repo_root, "init")
+    _run_git(repo_root, "config", "user.name", "Test Author")
+    _run_git(repo_root, "config", "user.email", "test@example.com")
+    context_dir = repo_root / "docs/context"
+    context_dir.mkdir(parents=True)
+    (context_dir / "README.md").write_text("# Context\n", encoding="utf-8")
+    (context_dir / "INDEX.md").write_text("# Index\n", encoding="utf-8")
+    (context_dir / "catalog.yaml").write_text(
+        "version: 1\n"
+        "entries:\n"
+        "  - path: docs/context/README.md\n"
+        "    status: current\n"
+        "    freshness: maintained\n"
+        "  - path: docs/context/INDEX.md\n"
+        "    status: current\n"
+        "    freshness: maintained\n"
+        f"{catalog_entries}",
+        encoding="utf-8",
+    )
+    return repo_root
 
 
 def test_missing_context_note_index_link_is_reported() -> None:
@@ -589,6 +642,75 @@ entries:
     )
 
     assert any("replacement is required" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_context_note_freshness_reports_superseded_errors(tmp_path: Path) -> None:
+    """Docs-proof freshness integration fails superseded rows without replacements."""
+    repo_root = _freshness_repo(
+        tmp_path,
+        "  - path: docs/context/old.md\n    status: superseded\n    freshness: dated\n",
+    )
+    (repo_root / "docs/context/old.md").write_text("# Old\n", encoding="utf-8")
+    _commit_all(repo_root, "superseded fixture", iso_date="2026-01-01T00:00:00+00:00")
+
+    diagnostics = _context_note_freshness_diagnostics(
+        repo_root=repo_root,
+        max_age_days=180,
+        strict=False,
+    )
+
+    assert any("superseded_replacement" in diagnostic.message for diagnostic in diagnostics)
+    assert any(diagnostic.path == Path("docs/context/old.md") for diagnostic in diagnostics)
+
+
+def test_context_note_freshness_non_strict_ignores_orphan_warnings(tmp_path: Path) -> None:
+    """Docs-proof non-strict mode preserves freshness warning-only compatibility."""
+    repo_root = _freshness_repo(tmp_path, "")
+    (repo_root / "docs/context/orphan.md").write_text("# Orphan\n", encoding="utf-8")
+    _commit_all(repo_root, "orphan fixture", iso_date="2026-01-01T00:00:00+00:00")
+
+    diagnostics = _context_note_freshness_diagnostics(
+        repo_root=repo_root,
+        max_age_days=180,
+        strict=False,
+    )
+
+    assert diagnostics == []
+
+
+def test_context_note_freshness_strict_reports_orphan_warnings(tmp_path: Path) -> None:
+    """Docs-proof strict freshness mode promotes orphan warnings to failures."""
+    repo_root = _freshness_repo(tmp_path, "")
+    (repo_root / "docs/context/orphan.md").write_text("# Orphan\n", encoding="utf-8")
+    _commit_all(repo_root, "orphan fixture", iso_date="2026-01-01T00:00:00+00:00")
+
+    diagnostics = _context_note_freshness_diagnostics(
+        repo_root=repo_root,
+        max_age_days=180,
+        strict=True,
+    )
+
+    assert any("orphan_context_note" in diagnostic.message for diagnostic in diagnostics)
+    assert any(diagnostic.path == Path("docs/context/orphan.md") for diagnostic in diagnostics)
+
+
+def test_context_note_freshness_strict_reports_stale_current_notes(tmp_path: Path) -> None:
+    """Docs-proof strict freshness mode promotes stale current-note warnings."""
+    repo_root = _freshness_repo(
+        tmp_path,
+        "  - path: docs/context/dated.md\n    status: current\n    freshness: dated\n",
+    )
+    (repo_root / "docs/context/dated.md").write_text("# Dated\n", encoding="utf-8")
+    _commit_all(repo_root, "dated fixture", iso_date="2025-01-01T00:00:00+00:00")
+
+    diagnostics = _context_note_freshness_diagnostics(
+        repo_root=repo_root,
+        max_age_days=180,
+        strict=True,
+    )
+
+    assert any("stale_current_dated" in diagnostic.message for diagnostic in diagnostics)
+    assert any(diagnostic.path == Path("docs/context/dated.md") for diagnostic in diagnostics)
 
 
 def test_context_catalog_evidence_rejects_output_pointer(tmp_path: Path) -> None:


### PR DESCRIPTION
Reviewer-critical summary

What changed: adds an opt-in `--check-context-note-freshness` mode to `scripts/validation/check_docs_proof_consistency.py`, wiring the existing context-note freshness checker into docs-proof validation. The mode fails on superseded notes without valid replacements by default, preserves warning-only compatibility for stale current notes and orphan notes, and adds `--strict-context-note-freshness` to promote those warnings to docs-proof failures. Tests cover superseded-without-replacement, stale current notes, and orphan detection.

Why now: Issue #3190 already has checker and archival-planner slices merged, but ready-queue routing asked for the remaining checker behavior to be available through docs-proof validation. This PR is a progression slice with a nameable new capability: docs-proof context-note freshness integration. It does not apply the review-gated archival sweep.

Claim boundary: this proves validation wiring and strict/non-strict behavior only. It does not claim the current orphan/stale backlog is fixed and does not move, delete, archive, or recatalog context notes.

Required validation: focused checker/docs-proof tests, lint/format, diff-scoped docs-proof, live checker/planner smoke commands, and repository PR readiness.

Remaining blocker: the live issue thread still says the actual archival sweep needs a maintainer-approved move list. Current planner output reports 5 high-confidence superseded candidates, but this PR intentionally does not apply them.

Contract delta

- New docs-proof CLI flag: `--check-context-note-freshness`.
- New docs-proof CLI flag: `--strict-context-note-freshness`.
- New docs-proof CLI flag: `--context-note-max-age-days`, default `180`.
- New fail-closed behavior: superseded catalog rows without valid replacement metadata fail when the new freshness mode is enabled.
- New strict-mode behavior: stale current dated notes and orphan context notes fail only when `--strict-context-note-freshness` is enabled.
- Compatibility impact: default `check_docs_proof_consistency.py` and `scripts/dev/check_docs_proof_consistency_diff.sh` behavior is unchanged, so existing code-only and docs-diff readiness paths do not start failing on the current orphan backlog.

Issue

Refs #3190.

Scope summary

- In scope: docs-proof integration for existing context-note freshness checker, JSON-compatible diagnostics through the existing docs-proof JSON output, strict/non-strict warning handling, focused tests.
- Out of scope: deleting notes, auto-archiving notes, applying archival moves outside an approved list, broad catalog cleanup, Slurm/GPU submission, full benchmark campaigns, paper/dissertation claim edits.

Validation

- `uv run python -m pytest tests/validation/test_check_docs_proof_consistency.py tests/tools/test_check_context_note_freshness.py tests/tools/test_plan_context_note_archival.py -q` — passed, 70 passed.
- `uv run ruff check scripts/validation/check_docs_proof_consistency.py tests/validation/test_check_docs_proof_consistency.py scripts/tools/check_context_note_freshness.py tests/tools/test_check_context_note_freshness.py tests/tools/test_plan_context_note_archival.py` — passed.
- `uv run ruff format --check scripts/validation/check_docs_proof_consistency.py tests/validation/test_check_docs_proof_consistency.py scripts/tools/check_context_note_freshness.py tests/tools/test_check_context_note_freshness.py tests/tools/test_plan_context_note_archival.py` — passed.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` — passed for 2 changed files.
- `git diff --check` — passed.
- `uv run python scripts/validation/check_docs_proof_consistency.py --check-context-note-freshness --json` — passed, exit 0, 0 hard findings.
- `uv run python scripts/validation/check_docs_proof_consistency.py --check-context-note-freshness --strict-context-note-freshness --json` — expected exit 1 on existing warning backlog, 449 strict findings.
- `uv run python scripts/tools/check_context_note_freshness.py --max-age-days 180 --max-human-findings 8` — passed, exit 0, 449 orphan warnings.
- `uv run python scripts/tools/plan_context_note_archival.py --max-age-days 180 --max-human-moves 8` — passed, exit 0, 5 high-confidence superseded candidates.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on dirty interim tree, 1764 passed, 2 skipped.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=... BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed at clean HEAD `d1676bff`, 1764 passed, 2 skipped.

Downstream propagation

No issue comment or issue-state update is made by this run because `comment_issue_or_pr` authorization is false. This PR body is the single remote-visible state surface for the delivered slice.

<details>
<summary>Appendix: live issue and fragmentation checks</summary>

- No open PR was found for issue #3190 or the exact context-note freshness scope before implementation.
- Recent merged issue-specific PRs include #4152 on 2026-07-02; fewer than two issue-specific guardrail/checker/packet-refresh PRs were merged for #3190 in the last 24 hours at start, so the fragmentation guard did not block this progression slice.
- Live issue comments as of the pre-PR freshness check remain authoritative that the archival sweep itself is review-gated on a maintainer-approved move list.
- No transient queue-routing state, target-host state, or packet-lineage pointer is encoded in tracked files.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

</details>
