### PR TITLE
Add diagnostic social preference label config for issue #4228

### DIFF
--- a/configs/diagnostics/social_preference_labels.yaml
+++ b/configs/diagnostics/social_preference_labels.yaml
@@ -1,0 +1,209 @@
+schema_version: social-preference-labels.v1
+profile_id: social_preference_labels_diagnostic_v1
+claim_boundary: >
+  Diagnostic-only social preference label configuration. This is not a reward
+  function, not an SPLC implementation, and not calibrated or validated human
+  preference evidence.
+source_literature:
+  - id: splc_2026_arxiv_2607_01925
+    role: motivation_only
+    url: https://arxiv.org/abs/2607.01925
+    caveat: >
+      The SPLC paper motivates preference-informed diagnostics, but this
+      repository config does not implement SPLC and does not claim learned or
+      validated social preferences.
+allowed_preferred_directions:
+  - maximize
+  - minimize
+  - avoid
+  - target_band
+availability_policy:
+  missing_required_trace_fields: not_available
+  missing_metric_key: not_available
+  fallback_or_degraded_row: diagnostic_only
+labels:
+  - id: clearance
+    display_name: Clearance preference
+    description: Minimum robot-pedestrian surface clearance over an episode.
+    metric_family: safety_proxemics
+    unit: m
+    preferred_direction: maximize
+    diagnostic_thresholds:
+      status: placeholder_default_not_human_calibrated
+      bands:
+        poor: "< 0.0"
+        caution: "[0.0, 0.5)"
+        acceptable: ">= 0.5"
+      provenance: aligned_to_existing_collision_near_miss_threshold_contract_not_preference_data
+    required_trace_fields:
+      - robot_trajectory
+      - pedestrian_trajectories
+      - metric_parameters.threshold_profile
+    candidate_metric_keys:
+      - min_clearance
+      - mean_clearance
+      - social_proxemic_min_clearance_m
+      - metrics.social_acceptability.social_proxemic_min_clearance_m
+    computation_status: diagnostic_config_only
+    notes: >
+      Preferred direction only. Threshold bands follow existing clearance safety
+      contracts and are not human preference calibration.
+  - id: ttc_margin
+    display_name: Time-to-collision margin preference
+    description: Time-to-collision margin for closing robot-pedestrian interactions.
+    metric_family: safety_ttc
+    unit: s
+    preferred_direction: maximize
+    diagnostic_thresholds:
+      status: placeholder_default_not_human_calibrated
+      bands:
+        poor: "< 0.5"
+        caution: "[0.5, 1.0)"
+        acceptable: ">= 1.0"
+      provenance: diagnostic_placeholder_until_ttc_contract_is_exported_for_target_traces
+    required_trace_fields:
+      - robot_trajectory
+      - pedestrian_trajectories
+      - robot_velocity_history
+      - pedestrian_velocity_history
+      - dt
+    candidate_metric_keys:
+      - near_misses_ttc
+      - near_miss_ttc__min_ttc_s
+      - time_to_collision_min
+    computation_status: diagnostic_config_only
+    notes: >
+      Use only when TTC fields are emitted by an explicit trace or metric path;
+      missing TTC data remains not_available.
+  - id: pedestrian_displacement
+    display_name: Pedestrian displacement preference
+    description: Pedestrian trajectory deviation or acceleration change associated with robot interaction.
+    metric_family: pedestrian_impact
+    unit: mixed
+    preferred_direction: minimize
+    diagnostic_thresholds:
+      status: placeholder_default_not_human_calibrated
+      bands:
+        acceptable: "lower relative to scenario baseline"
+        caution: "higher than comparable scenario baseline"
+        poor: "sustained elevated pedestrian deviation proxy"
+      provenance: diagnostic_relative_placeholder_not_preference_data
+    required_trace_fields:
+      - pedestrian_trajectories
+      - near_interaction_samples
+      - far_interaction_samples
+      - dt
+    candidate_metric_keys:
+      - ped_impact_accel_delta_mean
+      - ped_impact_turn_rate_delta_mean
+      - pedestrian_path_deviation_proxy_m
+    computation_status: diagnostic_config_only
+    notes: >
+      Existing pedestrian-impact metrics are exploratory proxies and do not
+      identify intent, discomfort, or human preference without additional evidence.
+  - id: path_blocking
+    display_name: Path blocking preference
+    description: Robot occupancy of likely pedestrian path corridors or route intent.
+    metric_family: path_corridor_interaction
+    unit: event_count_or_s
+    preferred_direction: avoid
+    diagnostic_thresholds:
+      status: placeholder_default_not_human_calibrated
+      bands:
+        acceptable: "no detected blocking episode"
+        caution: "short diagnostic blocking episode"
+        poor: "sustained diagnostic blocking episode"
+      provenance: blocked_until_route_or_corridor_trace_contract_exists
+    required_trace_fields:
+      - pedestrian_route_or_corridor_estimate
+      - robot_occupancy_over_time
+      - interaction_intervals
+      - dt
+    candidate_metric_keys: []
+    computation_status: not_available
+    notes: >
+      No canonical path-corridor occupancy metric is currently available; retain
+      this label as a visible missing trace contract.
+  - id: oscillation
+    display_name: Oscillation preference
+    description: Robot heading, velocity, or command reversals that indicate unstable local navigation.
+    metric_family: motion_quality
+    unit: mixed
+    preferred_direction: minimize
+    diagnostic_thresholds:
+      status: placeholder_default_not_human_calibrated
+      bands:
+        acceptable: "lower relative to scenario baseline"
+        caution: "elevated reversal or jerk proxy"
+        poor: "sustained unstable reversal or jerk proxy"
+      provenance: diagnostic_relative_placeholder_not_preference_data
+    required_trace_fields:
+      - robot_trajectory
+      - robot_velocity_history
+      - robot_heading_history
+      - dt
+    candidate_metric_keys:
+      - jerk_mean
+      - curvature_mean
+      - path_irregularity
+      - socnavbench_path_irregularity
+    computation_status: diagnostic_config_only
+    notes: >
+      Existing smoothness metrics are motion-quality proxies; they are not a
+      learned social preference score.
+  - id: detour_burden
+    display_name: Detour burden preference
+    description: Extra robot or pedestrian path length and time attributable to an interaction.
+    metric_family: path_efficiency
+    unit: ratio_or_m_or_s
+    preferred_direction: minimize
+    diagnostic_thresholds:
+      status: placeholder_default_not_human_calibrated
+      bands:
+        acceptable: "lower relative to scenario baseline"
+        caution: "moderate extra path or time burden"
+        poor: "large extra path or time burden"
+      provenance: diagnostic_relative_placeholder_not_preference_data
+    required_trace_fields:
+      - robot_trajectory
+      - pedestrian_trajectories
+      - straight_line_or_route_baseline
+      - reached_goal_step
+      - dt
+    candidate_metric_keys:
+      - path_efficiency
+      - socnavbench_path_length_ratio
+      - pedestrian_path_deviation_proxy_m
+      - time_to_goal_ideal_ratio
+    computation_status: diagnostic_config_only
+    notes: >
+      Interpret robot and pedestrian burden separately when both channels are
+      available; do not collapse to scalar preference utility.
+  - id: recovery_smoothness
+    display_name: Recovery smoothness preference
+    description: Smoothness of robot recovery after near-conflict, yielding, or avoidance.
+    metric_family: post_conflict_motion_quality
+    unit: mixed
+    preferred_direction: minimize
+    diagnostic_thresholds:
+      status: placeholder_default_not_human_calibrated
+      bands:
+        acceptable: "lower post-conflict jerk or acceleration discontinuity"
+        caution: "elevated post-conflict correction"
+        poor: "abrupt or repeated post-conflict correction"
+      provenance: diagnostic_placeholder_until_conflict_window_export_exists
+    required_trace_fields:
+      - robot_trajectory
+      - robot_velocity_history
+      - robot_acceleration_history
+      - near_conflict_intervals
+      - yielding_or_avoidance_events
+      - dt
+    candidate_metric_keys:
+      - jerk_mean
+      - acceleration_max
+      - jerk_abs_max
+    computation_status: diagnostic_config_only
+    notes: >
+      Current metrics can support coarse motion-quality diagnostics, but
+      conflict-window attribution remains a follow-up trace export contract.

--- a/docs/context/issue_4228_social_preference_labels.md
+++ b/docs/context/issue_4228_social_preference_labels.md
@@ -1,0 +1,47 @@
+# Issue 4228 Social Preference Labels
+
+This note defines the first diagnostic configuration surface for social preference labels in
+Robot SF. It records what the labels mean, where they can connect to existing metrics, and why this
+slice does not claim SPLC implementation, reward learning, or calibrated human preference evidence.
+
+## Motivation
+
+The SPLC paper, "Social Preference Learning for Crowd Robot Navigation" (arXiv:2607.01925),
+motivates a bridge from hand-authored safety and comfort predicates toward preference-informed
+social-compliance analysis. For this repository, issue #4228 is only that bridge's diagnostic
+configuration layer.
+
+## Repository Boundary
+
+The config at `configs/diagnostics/social_preference_labels.yaml` is diagnostic-only. It is not a
+reward function, not an offline reinforcement learning input, not a replacement for Social
+Navigation Quality Index (SNQI), and not calibrated human social preference evidence. The SPLC
+paper is cited as literature motivation only.
+
+Missing required trace fields and missing metric keys fail closed as `not_available`. Fallback or
+degraded rows remain diagnostic-only and cannot be used as benchmark-strengthening evidence.
+
+## Relationship To Existing Metrics
+
+The v1 label layer points at existing metric families where possible:
+
+| Label | Interpretation | Candidate metric keys | Missing or limited trace contract |
+| --- | --- | --- | --- |
+| `clearance` | Prefer larger robot-pedestrian surface clearance. | `min_clearance`, `mean_clearance`, social proxemic clearance keys. | Uses existing collision and near-miss threshold provenance, not preference calibration. |
+| `ttc_margin` | Prefer larger time-to-collision margin and fewer near-critical intervals. | `near_misses_ttc`, `near_miss_ttc__min_ttc_s`, `time_to_collision_min`. | Requires positions, velocities, and `dt` in traces where TTC is emitted. |
+| `pedestrian_displacement` | Prefer lower pedestrian deviation or acceleration change near the robot. | `ped_impact_accel_delta_mean`, `ped_impact_turn_rate_delta_mean`, `pedestrian_path_deviation_proxy_m`. | Current values are exploratory proxies, not measured discomfort or intent. |
+| `path_blocking` | Prefer avoiding robot occupancy of likely pedestrian path corridors. | None yet. | Needs pedestrian route or corridor estimates and robot occupancy intervals. |
+| `oscillation` | Prefer lower heading, velocity, or path instability. | `jerk_mean`, `curvature_mean`, path irregularity keys. | Motion quality proxy only; no learned social utility. |
+| `detour_burden` | Prefer lower extra robot or pedestrian path length and time burden. | `path_efficiency`, path ratio, pedestrian deviation, time-to-goal ratio keys. | Robot and pedestrian burden should remain separate when both are available. |
+| `recovery_smoothness` | Prefer smoother robot recovery after near-conflict or yielding. | `jerk_mean`, acceleration and jerk extrema. | Needs conflict-window or yielding-event trace fields for attribution. |
+
+## Follow-Up Path
+
+Useful next slices are:
+
+- compute labels from existing episode traces when the required fields are present;
+- emit explicit `not_available` label columns for missing trace contracts;
+- compare diagnostic labels with current social proxemic, Time-to-Collision (TTC), comfort, and
+  pedestrian-impact metrics;
+- explore preference-pair generation offline, still without reward replacement;
+- consider reward-model or offline reinforcement learning work only after separate validation.

--- a/docs/ped_metrics/metrics_spec.md
+++ b/docs/ped_metrics/metrics_spec.md
@@ -207,6 +207,16 @@ the structured block into scalar columns such as `human_discomfort_exposure_m_s`
 `intrusion_duration_s`, `time_to_yield_s`, `robot_yield_distance_m`, and
 `pedestrian_path_deviation_proxy_m`.
 
+### Diagnostic Social Preference Labels
+
+`configs/diagnostics/social_preference_labels.yaml` defines `social-preference-labels.v1`, a
+diagnostic annotation contract layered over existing safety, Time-to-Collision (TTC), proxemic,
+pedestrian-impact, path-efficiency, and smoothness metrics. These labels are not a new headline
+benchmark score, not learned rewards, and not calibrated human preference evidence. Missing trace
+fields and missing metric keys remain `not_available`; see
+`docs/context/issue_4228_social_preference_labels.md` for the issue #4228 boundary and follow-up
+path.
+
 ### Motion Quality Metrics
 
 #### Smoothness (Jerk)

--- a/robot_sf/benchmark/social_preference_labels.py
+++ b/robot_sf/benchmark/social_preference_labels.py
@@ -1,0 +1,242 @@
+"""Validation helpers for diagnostic social preference label configs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SOCIAL_PREFERENCE_LABEL_SCHEMA_VERSION = "social-preference-labels.v1"
+REQUIRED_LABEL_IDS = frozenset(
+    {
+        "clearance",
+        "ttc_margin",
+        "pedestrian_displacement",
+        "path_blocking",
+        "oscillation",
+        "detour_burden",
+        "recovery_smoothness",
+    }
+)
+REQUIRED_LABEL_FIELDS = frozenset(
+    {
+        "id",
+        "description",
+        "metric_family",
+        "unit",
+        "preferred_direction",
+        "diagnostic_thresholds",
+        "required_trace_fields",
+        "candidate_metric_keys",
+        "notes",
+    }
+)
+
+
+class SocialPreferenceLabelConfigError(ValueError):
+    """Raised when a social preference label config violates the v1 contract."""
+
+
+def load_social_preference_label_config(path: Path) -> dict[str, Any]:
+    """Load and validate a social preference label YAML config.
+
+    Returns:
+        The validated YAML payload as a dictionary.
+    """
+
+    with Path(path).open("r", encoding="utf-8") as stream:
+        payload = yaml.safe_load(stream)
+    return validate_social_preference_label_config(payload)
+
+
+def validate_social_preference_label_config(payload: Mapping[str, Any] | Any) -> dict[str, Any]:
+    """Validate the diagnostic social preference label config contract.
+
+    Returns:
+        The validated payload as a dictionary.
+    """
+
+    if not isinstance(payload, Mapping):
+        raise SocialPreferenceLabelConfigError("config payload must be a mapping")
+    _validate_top_level_contract(payload)
+    labels = _validate_labels(payload.get("labels"), _allowed_direction_set(payload))
+    _validate_required_label_ids(labels)
+    return dict(payload)
+
+
+def label_availability(label: Mapping[str, Any], available_fields: set[str]) -> str:
+    """Return diagnostic availability for one label and a set of available trace fields."""
+
+    if label.get("computation_status") == "not_available":
+        return "not_available"
+    required_fields = label.get("required_trace_fields")
+    if not isinstance(required_fields, list):
+        raise SocialPreferenceLabelConfigError("label required_trace_fields must be a list")
+    missing_fields = [field for field in required_fields if field not in available_fields]
+    return "not_available" if missing_fields else "diagnostic_available"
+
+
+def _validate_top_level_contract(payload: Mapping[str, Any]) -> None:
+    if payload.get("schema_version") != SOCIAL_PREFERENCE_LABEL_SCHEMA_VERSION:
+        raise SocialPreferenceLabelConfigError(
+            f"schema_version must be {SOCIAL_PREFERENCE_LABEL_SCHEMA_VERSION}"
+        )
+
+    claim_boundary = payload.get("claim_boundary")
+    if not isinstance(claim_boundary, str) or not claim_boundary.strip():
+        raise SocialPreferenceLabelConfigError("claim_boundary is required")
+    _require_boundary_language(claim_boundary)
+
+    _validate_source_literature(payload.get("source_literature"))
+
+
+def _allowed_direction_set(payload: Mapping[str, Any]) -> set[str]:
+    allowed_directions = payload.get("allowed_preferred_directions")
+    if not isinstance(allowed_directions, list) or not allowed_directions:
+        raise SocialPreferenceLabelConfigError(
+            "allowed_preferred_directions must be a non-empty list"
+        )
+
+    allowed_direction_set = set()
+    for direction in allowed_directions:
+        if not isinstance(direction, str) or not direction:
+            raise SocialPreferenceLabelConfigError("preferred directions must be non-empty strings")
+        allowed_direction_set.add(direction)
+    return allowed_direction_set
+
+
+def _validate_labels(labels: Any, allowed_directions: set[str]) -> list[Mapping[str, Any]]:
+    if not isinstance(labels, list) or not labels:
+        raise SocialPreferenceLabelConfigError("labels must be a non-empty list")
+
+    validated_labels: list[Mapping[str, Any]] = []
+    for index, label in enumerate(labels):
+        if not isinstance(label, Mapping):
+            raise SocialPreferenceLabelConfigError(f"label {index} must be a mapping")
+        _validate_label_fields(index, label)
+        _validate_label_direction(label, allowed_directions)
+        _validate_label_thresholds(label)
+        _validate_label_trace_fields(label)
+        _validate_label_candidate_metrics(label)
+        validated_labels.append(label)
+    return validated_labels
+
+
+def _validate_required_label_ids(labels: list[Mapping[str, Any]]) -> None:
+    label_ids = [label["id"] for label in labels]
+    duplicate_ids = sorted({label_id for label_id in label_ids if label_ids.count(label_id) > 1})
+    if duplicate_ids:
+        raise SocialPreferenceLabelConfigError(f"duplicate label ids: {', '.join(duplicate_ids)}")
+
+    missing_required = sorted(REQUIRED_LABEL_IDS.difference(label_ids))
+    if missing_required:
+        raise SocialPreferenceLabelConfigError(
+            f"missing required label ids: {', '.join(missing_required)}"
+        )
+
+
+def _require_boundary_language(claim_boundary: str) -> None:
+    normalized = claim_boundary.casefold()
+    required_phrases = ("diagnostic", "not a reward", "not calibrated")
+    missing = [phrase for phrase in required_phrases if phrase not in normalized]
+    if missing:
+        raise SocialPreferenceLabelConfigError(
+            "claim_boundary must explicitly state diagnostic, not-reward, and not-calibrated status"
+        )
+
+
+def _validate_source_literature(source_literature: Any) -> None:
+    if not isinstance(source_literature, list) or not source_literature:
+        raise SocialPreferenceLabelConfigError("source_literature must be a non-empty list")
+    for entry in source_literature:
+        if not isinstance(entry, Mapping):
+            raise SocialPreferenceLabelConfigError("source_literature entries must be mappings")
+        if entry.get("role") != "motivation_only":
+            raise SocialPreferenceLabelConfigError(
+                "source_literature entries must use role motivation_only"
+            )
+        if not entry.get("url"):
+            raise SocialPreferenceLabelConfigError("source_literature entries require url")
+
+
+def _validate_label_fields(index: int, label: Mapping[str, Any]) -> None:
+    missing_fields = sorted(REQUIRED_LABEL_FIELDS.difference(label))
+    if missing_fields:
+        raise SocialPreferenceLabelConfigError(
+            f"label {index} missing required fields: {', '.join(missing_fields)}"
+        )
+
+    label_id = label["id"]
+    if not isinstance(label_id, str) or not _is_lowercase_snake_case(label_id):
+        raise SocialPreferenceLabelConfigError(f"label {index} id must be lowercase snake_case")
+
+    for field_name in ("description", "metric_family", "unit", "notes"):
+        value = label[field_name]
+        if not isinstance(value, str) or not value.strip():
+            raise SocialPreferenceLabelConfigError(
+                f"label {label_id} {field_name} must be a non-empty string"
+            )
+
+
+def _validate_label_direction(label: Mapping[str, Any], allowed_directions: set[str]) -> None:
+    label_id = str(label["id"])
+    preferred_direction = label["preferred_direction"]
+    if preferred_direction not in allowed_directions:
+        raise SocialPreferenceLabelConfigError(
+            f"label {label_id} preferred_direction {preferred_direction!r} is not allowed"
+        )
+
+
+def _validate_label_thresholds(label: Mapping[str, Any]) -> None:
+    label_id = str(label["id"])
+    diagnostic_thresholds = label["diagnostic_thresholds"]
+    if not isinstance(diagnostic_thresholds, Mapping):
+        raise SocialPreferenceLabelConfigError(
+            f"label {label_id} diagnostic_thresholds must be a mapping"
+        )
+
+    status = diagnostic_thresholds.get("status")
+    if status != "placeholder_default_not_human_calibrated":
+        raise SocialPreferenceLabelConfigError(
+            f"label {label_id} threshold status must be placeholder_default_not_human_calibrated"
+        )
+
+
+def _validate_label_trace_fields(label: Mapping[str, Any]) -> None:
+    _require_string_list(str(label["id"]), label["required_trace_fields"], "required_trace_fields")
+
+
+def _validate_label_candidate_metrics(label: Mapping[str, Any]) -> None:
+    label_id = str(label["id"])
+    candidate_metric_keys = label["candidate_metric_keys"]
+    if not isinstance(candidate_metric_keys, list):
+        raise SocialPreferenceLabelConfigError(
+            f"label {label_id} candidate_metric_keys must be a list"
+        )
+    for metric_key in candidate_metric_keys:
+        if not isinstance(metric_key, str) or not metric_key:
+            raise SocialPreferenceLabelConfigError(
+                f"label {label_id} candidate_metric_keys must contain non-empty strings"
+            )
+    if not candidate_metric_keys and label.get("computation_status") != "not_available":
+        raise SocialPreferenceLabelConfigError(
+            f"label {label_id} without candidate_metric_keys must be not_available"
+        )
+
+
+def _require_string_list(label_id: str, value: Any, field_name: str) -> None:
+    if not isinstance(value, list) or not value:
+        raise SocialPreferenceLabelConfigError(f"label {label_id} {field_name} must be a list")
+    for item in value:
+        if not isinstance(item, str) or not item:
+            raise SocialPreferenceLabelConfigError(
+                f"label {label_id} {field_name} must contain non-empty strings"
+            )
+
+
+def _is_lowercase_snake_case(value: str) -> bool:
+    return value[0].islower() and all(
+        char.islower() or char.isdigit() or char == "_" for char in value
+    )

--- a/robot_sf/benchmark/social_preference_labels.py
+++ b/robot_sf/benchmark/social_preference_labels.py
@@ -23,6 +23,7 @@ REQUIRED_LABEL_IDS = frozenset(
 REQUIRED_LABEL_FIELDS = frozenset(
     {
         "id",
+        "display_name",
         "description",
         "metric_family",
         "unit",
@@ -30,6 +31,7 @@ REQUIRED_LABEL_FIELDS = frozenset(
         "diagnostic_thresholds",
         "required_trace_fields",
         "candidate_metric_keys",
+        "computation_status",
         "notes",
     }
 )
@@ -172,7 +174,14 @@ def _validate_label_fields(index: int, label: Mapping[str, Any]) -> None:
     if not isinstance(label_id, str) or not _is_lowercase_snake_case(label_id):
         raise SocialPreferenceLabelConfigError(f"label {index} id must be lowercase snake_case")
 
-    for field_name in ("description", "metric_family", "unit", "notes"):
+    for field_name in (
+        "display_name",
+        "description",
+        "metric_family",
+        "unit",
+        "computation_status",
+        "notes",
+    ):
         value = label[field_name]
         if not isinstance(value, str) or not value.strip():
             raise SocialPreferenceLabelConfigError(
@@ -237,6 +246,8 @@ def _require_string_list(label_id: str, value: Any, field_name: str) -> None:
 
 
 def _is_lowercase_snake_case(value: str) -> bool:
+    if not value:
+        return False
     return value[0].islower() and all(
         char.islower() or char.isdigit() or char == "_" for char in value
     )

--- a/tests/benchmark/test_social_preference_labels_config.py
+++ b/tests/benchmark/test_social_preference_labels_config.py
@@ -1,0 +1,140 @@
+"""Tests for the diagnostic social preference label config contract."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.social_preference_labels import (
+    REQUIRED_LABEL_IDS,
+    SocialPreferenceLabelConfigError,
+    label_availability,
+    load_social_preference_label_config,
+    validate_social_preference_label_config,
+)
+
+CONFIG_PATH = Path("configs/diagnostics/social_preference_labels.yaml")
+
+
+@pytest.fixture
+def valid_payload() -> dict:
+    """Return the repository social preference label config."""
+
+    return load_social_preference_label_config(CONFIG_PATH)
+
+
+def test_social_preference_label_config_loads_with_required_labels(valid_payload: dict) -> None:
+    """The checked-in config includes the seven issue #4228 labels."""
+
+    label_ids = {label["id"] for label in valid_payload["labels"]}
+
+    assert REQUIRED_LABEL_IDS.issubset(label_ids)
+    assert len(label_ids) == len(valid_payload["labels"])
+    assert "diagnostic" in valid_payload["claim_boundary"].casefold()
+    assert "not a reward" in valid_payload["claim_boundary"].casefold()
+
+
+def test_duplicate_label_ids_fail_closed(valid_payload: dict) -> None:
+    """Duplicate label IDs are rejected."""
+
+    payload = deepcopy(valid_payload)
+    payload["labels"].append(deepcopy(payload["labels"][0]))
+
+    with pytest.raises(SocialPreferenceLabelConfigError, match="duplicate label ids"):
+        validate_social_preference_label_config(payload)
+
+
+def test_invalid_preferred_direction_fails_closed(valid_payload: dict) -> None:
+    """Preferred directions must come from the config enum."""
+
+    payload = deepcopy(valid_payload)
+    payload["labels"][0]["preferred_direction"] = "increase"
+
+    with pytest.raises(SocialPreferenceLabelConfigError, match="preferred_direction"):
+        validate_social_preference_label_config(payload)
+
+
+def test_missing_claim_boundary_fails_closed(valid_payload: dict) -> None:
+    """The config must keep an explicit diagnostic claim boundary."""
+
+    payload = deepcopy(valid_payload)
+    payload["claim_boundary"] = ""
+
+    with pytest.raises(SocialPreferenceLabelConfigError, match="claim_boundary"):
+        validate_social_preference_label_config(payload)
+
+
+def test_missing_required_label_field_fails_closed(valid_payload: dict) -> None:
+    """Labels must keep the fields needed by downstream checkers."""
+
+    payload = deepcopy(valid_payload)
+    del payload["labels"][0]["required_trace_fields"]
+
+    with pytest.raises(SocialPreferenceLabelConfigError, match="missing required fields"):
+        validate_social_preference_label_config(payload)
+
+
+def test_threshold_status_must_remain_diagnostic(valid_payload: dict) -> None:
+    """Thresholds cannot silently become calibrated preference claims."""
+
+    payload = deepcopy(valid_payload)
+    payload["labels"][0]["diagnostic_thresholds"]["status"] = "calibrated"
+
+    with pytest.raises(SocialPreferenceLabelConfigError, match="threshold status"):
+        validate_social_preference_label_config(payload)
+
+
+def test_empty_candidate_metric_keys_require_not_available(valid_payload: dict) -> None:
+    """Labels without metric keys must expose not_available status."""
+
+    payload = deepcopy(valid_payload)
+    path_blocking = next(label for label in payload["labels"] if label["id"] == "path_blocking")
+    path_blocking["computation_status"] = "diagnostic_config_only"
+
+    with pytest.raises(SocialPreferenceLabelConfigError, match="without candidate_metric_keys"):
+        validate_social_preference_label_config(payload)
+
+
+def test_label_availability_uses_not_available_for_missing_trace_fields(
+    valid_payload: dict,
+) -> None:
+    """Missing trace fields produce not_available instead of a zero-like value."""
+
+    clearance = next(label for label in valid_payload["labels"] if label["id"] == "clearance")
+
+    assert label_availability(clearance, {"robot_trajectory"}) == "not_available"
+    assert (
+        label_availability(
+            clearance,
+            {
+                "robot_trajectory",
+                "pedestrian_trajectories",
+                "metric_parameters.threshold_profile",
+            },
+        )
+        == "diagnostic_available"
+    )
+
+
+def test_not_available_labels_stay_unavailable_even_with_fields(valid_payload: dict) -> None:
+    """Labels marked unavailable do not become available from fields alone."""
+
+    path_blocking = next(
+        label for label in valid_payload["labels"] if label["id"] == "path_blocking"
+    )
+
+    assert (
+        label_availability(path_blocking, set(path_blocking["required_trace_fields"]))
+        == "not_available"
+    )
+
+
+def test_splc_source_is_motivation_only(valid_payload: dict) -> None:
+    """SPLC literature references cannot claim implemented-method status."""
+
+    roles = {entry["role"] for entry in valid_payload["source_literature"]}
+
+    assert roles == {"motivation_only"}
+    assert "implemented_method" not in roles

--- a/tests/benchmark/test_social_preference_labels_config.py
+++ b/tests/benchmark/test_social_preference_labels_config.py
@@ -15,7 +15,12 @@ from robot_sf.benchmark.social_preference_labels import (
     validate_social_preference_label_config,
 )
 
-CONFIG_PATH = Path("configs/diagnostics/social_preference_labels.yaml")
+CONFIG_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "diagnostics"
+    / "social_preference_labels.yaml"
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds the `social-preference-labels.v1` diagnostic configuration surface for issue #4228, plus a pure loader/validator, focused fail-closed tests, and a short documentation note/cross-reference.

Why now: issue #4228 is a bounded CPU-only config/test slice. No matching open or merged PR was found during start and pre-PR freshness checks.

Claim boundary: this PR defines diagnostic labels only. It does not implement SPLC, train offline reinforcement learning, replace rewards, calibrate human preferences, compute/export labels from traces, run a benchmark campaign, submit Slurm/GPU work, or edit paper/dissertation claims.

Required validation: focused config/schema load tests and targeted Ruff checks for the new validator/test files.

Remaining blocker: label computation/export remains deferred until trace fields and metric keys are available per label. `path_blocking` is intentionally visible as `not_available` because no canonical path-corridor occupancy metric exists yet.

New capability: versioned diagnostic social preference label config and validator for the seven required dimensions: `clearance`, `ttc_margin`, `pedestrian_displacement`, `path_blocking`, `oscillation`, `detour_burden`, and `recovery_smoothness`.

Issue: closes #4228.

## Contract delta

New schema/config fields:

- `schema_version: social-preference-labels.v1`
- `profile_id`
- `claim_boundary`
- `source_literature` with `role: motivation_only`
- `allowed_preferred_directions`
- `availability_policy`
- `labels[]` entries with `id`, `display_name`, `description`, `metric_family`, `unit`, `preferred_direction`, `diagnostic_thresholds`, `required_trace_fields`, `candidate_metric_keys`, `computation_status`, and `notes`

New fail-closed blockers:

- invalid schema version
- missing diagnostic/not-reward/not-calibrated claim boundary
- duplicate or missing required label IDs
- invalid preferred direction
- missing required label fields
- threshold status not marked `placeholder_default_not_human_calibrated`
- empty `candidate_metric_keys` without `computation_status: not_available`
- source literature claiming anything other than `motivation_only`

Compatibility impact:

- additive config, docs, and helper only;
- no runtime planner, reward, benchmark aggregation, training, export, or episode schema behavior changed;
- missing trace fields resolve to `not_available`, not zero or success.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_social_preference_labels_config.py -q`
  - exit code 0; `10 passed`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/social_preference_labels.py tests/benchmark/test_social_preference_labels_config.py`
  - exit code 0; `All checks passed!`
- `test -f configs/diagnostics/social_preference_labels.yaml && test -f docs/context/issue_4228_social_preference_labels.md && test -f docs/ped_metrics/metrics_spec.md && git diff --cached --check`
  - exit code 0 before commit

## State propagation

No separate issue comment was added. This low-churn issue has no existing comment stream beyond the implementation-plan comment, and this PR body is the durable state surface for the delivered slice and remaining work.

<details>
<summary>Appendix: freshness and scope checks</summary>

- Read `AGENTS.md`, `.agents/skills/README.md`, and the required local skills.
- Ran `git fetch --prune origin` before work.
- Read issue #4228 body and comments; maintainer comment from 2026-07-03 08:34:34Z drove the implementation.
- Re-ran live issue check immediately before PR creation; no newer maintainer guidance was present.
- Checked open PRs for `4228 OR "diagnostic social preference label"`: none.
- Checked recently merged PRs for `4228`: none.
- Fragmentation guard: no prior issue #4228 guardrail/checker/packet-refresh PRs found in the last 24 hours; this PR adds the nameable new capability above.
- No transient queue-routing state, target host state, or packet lineage was encoded in tracked files.
- Out of scope confirmed: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

</details>
