### PR TITLE
Issue #4165: report proxemic layer ablation deltas

### DIFF
--- a/robot_sf/benchmark/proxemic_ablation_report.py
+++ b/robot_sf/benchmark/proxemic_ablation_report.py
@@ -1,0 +1,395 @@
+"""Paired proxemic-layer ablation reporting helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+USABLE_ROW_STATUSES = frozenset({"native", "adapter", "success", "completed", "ok"})
+BLOCKED_ROW_STATUSES = frozenset({"fallback", "degraded", "failed", "not_available", "blocked"})
+PAIR_KEYS = ("scenario_id", "seed")
+REPORT_METRICS = (
+    "intrusion_rate",
+    "minimum_clearance",
+    "path_efficiency",
+    "runtime_seconds",
+)
+REPORT_CAVEATS = ("success", "collision")
+
+_FIELD_ALIASES: dict[str, tuple[str, ...]] = {
+    "intrusion_rate": (
+        "intrusion_rate",
+        "proxemic_intrusion_rate",
+        "social_space_intrusion_rate",
+        "metrics.intrusion_rate",
+        "metrics.proxemic_intrusion_rate",
+        "metrics.social_space_intrusion_rate",
+    ),
+    "minimum_clearance": (
+        "minimum_clearance",
+        "min_clearance",
+        "min_distance",
+        "clearing_distance_min",
+        "metrics.minimum_clearance",
+        "metrics.min_clearance",
+        "metrics.min_distance",
+        "metrics.clearing_distance_min",
+    ),
+    "path_efficiency": (
+        "path_efficiency",
+        "metrics.path_efficiency",
+    ),
+    "runtime_seconds": (
+        "runtime_seconds",
+        "wall_time_seconds",
+        "episode_runtime_seconds",
+        "episode_sec",
+        "metrics.runtime_seconds",
+        "metrics.wall_time_seconds",
+        "metrics.episode_runtime_seconds",
+        "metrics.episode_sec",
+    ),
+    "success": (
+        "success",
+        "metrics.success",
+    ),
+    "collision": (
+        "collision",
+        "collisions",
+        "metrics.collision",
+        "metrics.collisions",
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ArmSummary:
+    """Aggregate metric summary for one paired arm."""
+
+    arm: str
+    rows: int
+    intrusion_rate: float
+    minimum_clearance: float
+    path_efficiency: float
+    runtime_seconds: float
+    success_rate: float
+    collision_rate: float
+
+
+def load_records(path: Path) -> list[dict[str, Any]]:
+    """Load JSON or JSONL episode rows.
+
+    Returns:
+        Episode row dictionaries.
+    """
+
+    if not path.exists():
+        raise FileNotFoundError(f"episode rows not found: {path}")
+
+    if path.suffix == ".jsonl":
+        rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+    else:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        rows = loaded.get("episodes", loaded) if isinstance(loaded, Mapping) else loaded
+
+    if not isinstance(rows, list):
+        raise ValueError(f"episode rows must be a list or object with 'episodes': {path}")
+    if not all(isinstance(row, Mapping) for row in rows):
+        raise ValueError(f"episode rows must contain JSON objects: {path}")
+    return [dict(row) for row in rows]
+
+
+def load_yaml_file(path: Path) -> dict[str, Any]:
+    """Load a YAML mapping from ``path``.
+
+    Returns:
+        Parsed YAML mapping.
+    """
+
+    if not path.exists():
+        raise FileNotFoundError(f"config not found: {path}")
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, Mapping):
+        raise ValueError(f"config must be a YAML mapping: {path}")
+    return dict(loaded)
+
+
+def build_proxemic_ablation_report(
+    *,
+    baseline_records: Sequence[Mapping[str, Any]],
+    proxemic_records: Sequence[Mapping[str, Any]],
+    smoke_config_path: Path,
+    proxemic_config_path: Path,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    """Build a fail-closed paired proxemic-layer ablation report.
+
+    Returns:
+        Machine-readable report dictionary.
+    """
+
+    smoke_config = load_yaml_file(repo_root / smoke_config_path)
+    proxemic_config = load_yaml_file(repo_root / proxemic_config_path)
+    blockers: list[str] = []
+
+    baseline_index = _index_rows("baseline_classical", baseline_records, blockers)
+    proxemic_index = _index_rows("proxemic_costmap_on", proxemic_records, blockers)
+    shared_keys = sorted(set(baseline_index) & set(proxemic_index))
+    if not shared_keys:
+        blockers.append("no paired rows share scenario_id and seed")
+
+    paired_baseline = [baseline_index[key] for key in shared_keys]
+    paired_proxemic = [proxemic_index[key] for key in shared_keys]
+    _validate_metric_fields("baseline_classical", paired_baseline, blockers)
+    _validate_metric_fields("proxemic_costmap_on", paired_proxemic, blockers)
+
+    report_status = "blocked" if blockers else "ready"
+    baseline_summary = _summarize_arm("baseline_classical", paired_baseline)
+    proxemic_summary = _summarize_arm("proxemic_costmap_on", paired_proxemic)
+
+    deltas = {
+        "intrusion_rate_delta": proxemic_summary.intrusion_rate - baseline_summary.intrusion_rate,
+        "minimum_clearance_delta": (
+            proxemic_summary.minimum_clearance - baseline_summary.minimum_clearance
+        ),
+        "path_efficiency_delta": proxemic_summary.path_efficiency
+        - baseline_summary.path_efficiency,
+        "runtime_overhead_seconds": proxemic_summary.runtime_seconds
+        - baseline_summary.runtime_seconds,
+        "runtime_overhead_ratio": _safe_ratio(
+            proxemic_summary.runtime_seconds,
+            baseline_summary.runtime_seconds,
+        ),
+        "success_rate_delta": proxemic_summary.success_rate - baseline_summary.success_rate,
+        "collision_rate_delta": proxemic_summary.collision_rate - baseline_summary.collision_rate,
+    }
+
+    return {
+        "issue": 4165,
+        "report_status": report_status,
+        "claim_boundary": "paired_cpu_smoke_or_fixture_report_only",
+        "paired_key_fields": list(PAIR_KEYS),
+        "paired_rows": len(shared_keys),
+        "blocked_reasons": blockers,
+        "arms": {
+            "baseline_classical": _arm_summary_dict(baseline_summary),
+            "proxemic_costmap_on": _arm_summary_dict(proxemic_summary),
+        },
+        "deltas": deltas,
+        "success_collision_caveats": {
+            "baseline_success_rate": baseline_summary.success_rate,
+            "proxemic_success_rate": proxemic_summary.success_rate,
+            "baseline_collision_rate": baseline_summary.collision_rate,
+            "proxemic_collision_rate": proxemic_summary.collision_rate,
+            "interpretation": (
+                "Diagnostic paired smoke deltas only; fallback/degraded rows block readiness and "
+                "are not treated as successful benchmark evidence."
+            ),
+        },
+        "parameter_provenance": {
+            "smoke_config": _config_provenance(repo_root / smoke_config_path, smoke_config),
+            "proxemic_config": _config_provenance(
+                repo_root / proxemic_config_path, proxemic_config
+            ),
+        },
+        "out_of_scope": [
+            "full benchmark campaign",
+            "Slurm or GPU submission",
+            "paper-facing claim update",
+        ],
+    }
+
+
+def write_report_artifacts(report: Mapping[str, Any], output_dir: Path) -> None:
+    """Write machine-readable and Markdown report artifacts."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "summary.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "README.md").write_text(format_markdown_report(report), encoding="utf-8")
+
+
+def format_markdown_report(report: Mapping[str, Any]) -> str:
+    """Format a compact Markdown summary for context evidence.
+
+    Returns:
+        Markdown report text.
+    """
+
+    deltas = report["deltas"]
+    provenance = report["parameter_provenance"]["proxemic_config"]
+    lines = [
+        "# Issue #4165 proxemic-layer ablation report",
+        "",
+        f"Status: `{report['report_status']}`",
+        "",
+        "This is a paired CPU smoke or fixture report only. It is not a full benchmark campaign "
+        "and does not promote paper-facing claims.",
+        "",
+        "| Field | Delta |",
+        "| --- | ---: |",
+        f"| intrusion_rate_delta | {deltas['intrusion_rate_delta']:.6g} |",
+        f"| minimum_clearance_delta | {deltas['minimum_clearance_delta']:.6g} |",
+        f"| path_efficiency_delta | {deltas['path_efficiency_delta']:.6g} |",
+        f"| runtime_overhead_seconds | {deltas['runtime_overhead_seconds']:.6g} |",
+        f"| runtime_overhead_ratio | {deltas['runtime_overhead_ratio']:.6g} |",
+        f"| success_rate_delta | {deltas['success_rate_delta']:.6g} |",
+        f"| collision_rate_delta | {deltas['collision_rate_delta']:.6g} |",
+        "",
+        "## Parameter Provenance",
+        "",
+        f"- proxemic config: `{provenance['path']}`",
+        f"- proxemic config sha256: `{provenance['sha256']}`",
+        "",
+        "## Blockers",
+        "",
+    ]
+    blockers = report["blocked_reasons"]
+    lines.extend(f"- {blocker}" for blocker in blockers)
+    if not blockers:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _index_rows(
+    arm: str,
+    records: Sequence[Mapping[str, Any]],
+    blockers: list[str],
+) -> dict[tuple[str, str], Mapping[str, Any]]:
+    index: dict[tuple[str, str], Mapping[str, Any]] = {}
+    for idx, record in enumerate(records):
+        status = str(record.get("row_status", record.get("status", "native"))).lower()
+        if status in BLOCKED_ROW_STATUSES or status not in USABLE_ROW_STATUSES:
+            blockers.append(f"{arm} row {idx} has non-usable row_status={status!r}")
+        key = _pair_key(record)
+        if key is None:
+            blockers.append(f"{arm} row {idx} missing pair key fields: {', '.join(PAIR_KEYS)}")
+            continue
+        if key in index:
+            blockers.append(f"{arm} has duplicate pair key scenario_id={key[0]!r} seed={key[1]!r}")
+        index[key] = record
+    return index
+
+
+def _pair_key(record: Mapping[str, Any]) -> tuple[str, str] | None:
+    missing = [field for field in PAIR_KEYS if field not in record]
+    if missing:
+        return None
+    return (str(record["scenario_id"]), str(record["seed"]))
+
+
+def _validate_metric_fields(
+    arm: str,
+    records: Sequence[Mapping[str, Any]],
+    blockers: list[str],
+) -> None:
+    for idx, record in enumerate(records):
+        missing = [metric for metric in REPORT_METRICS if _extract_float(record, metric) is None]
+        missing.extend(metric for metric in REPORT_CAVEATS if _get_alias(record, metric) is None)
+        if missing:
+            blockers.append(f"{arm} paired row {idx} missing metrics: {', '.join(missing)}")
+
+
+def _summarize_arm(arm: str, records: Sequence[Mapping[str, Any]]) -> ArmSummary:
+    return ArmSummary(
+        arm=arm,
+        rows=len(records),
+        intrusion_rate=_mean(_required_values(records, "intrusion_rate")),
+        minimum_clearance=_mean(_required_values(records, "minimum_clearance")),
+        path_efficiency=_mean(_required_values(records, "path_efficiency")),
+        runtime_seconds=_mean(_required_values(records, "runtime_seconds")),
+        success_rate=_mean(_bool_values(records, "success")),
+        collision_rate=_mean(_bool_values(records, "collision")),
+    )
+
+
+def _required_values(records: Sequence[Mapping[str, Any]], metric: str) -> list[float]:
+    return [value for record in records if (value := _extract_float(record, metric)) is not None]
+
+
+def _bool_values(records: Sequence[Mapping[str, Any]], field: str) -> list[float]:
+    values: list[float] = []
+    for record in records:
+        raw = _get_alias(record, field)
+        if raw is None:
+            continue
+        if isinstance(raw, bool):
+            values.append(float(raw))
+        else:
+            values.append(float(raw) > 0.0)
+    return values
+
+
+def _extract_float(record: Mapping[str, Any], metric: str) -> float | None:
+    raw = _get_alias(record, metric)
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def _get_alias(record: Mapping[str, Any], metric: str) -> Any | None:
+    for alias in _FIELD_ALIASES[metric]:
+        value = _get_nested(record, alias)
+        if value is not None:
+            return value
+    return None
+
+
+def _get_nested(record: Mapping[str, Any], dotted: str) -> Any | None:
+    current: Any = record
+    for part in dotted.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _mean(values: Iterable[float]) -> float:
+    value_list = list(values)
+    if not value_list:
+        return 0.0
+    return sum(value_list) / len(value_list)
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float:
+    if denominator == 0.0:
+        return 0.0
+    return numerator / denominator
+
+
+def _arm_summary_dict(summary: ArmSummary) -> dict[str, float | int | str]:
+    return {
+        "arm": summary.arm,
+        "rows": summary.rows,
+        "intrusion_rate": summary.intrusion_rate,
+        "minimum_clearance": summary.minimum_clearance,
+        "path_efficiency": summary.path_efficiency,
+        "runtime_seconds": summary.runtime_seconds,
+        "success_rate": summary.success_rate,
+        "collision_rate": summary.collision_rate,
+    }
+
+
+def _config_provenance(path: Path, parsed: Mapping[str, Any]) -> dict[str, Any]:
+    data = path.read_bytes()
+    return {
+        "path": str(path),
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "parameters": dict(parsed),
+    }

--- a/scripts/benchmark/build_proxemic_layer_ablation_report_issue_4165.py
+++ b/scripts/benchmark/build_proxemic_layer_ablation_report_issue_4165.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Build the issue #4165 paired proxemic-layer ablation report."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from robot_sf.benchmark.proxemic_ablation_report import (
+    build_proxemic_ablation_report,
+    load_records,
+    write_report_artifacts,
+)
+
+DEFAULT_SMOKE_CONFIG = Path("configs/benchmarks/issue_4165_proxemic_costmap_smoke.yaml")
+DEFAULT_PROXEMIC_CONFIG = Path("configs/planners/proxemic_costmap_v1.yaml")
+DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_4165_proxemic_ablation_report")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-episodes", type=Path, required=True)
+    parser.add_argument("--proxemic-episodes", type=Path, required=True)
+    parser.add_argument("--smoke-config", type=Path, default=DEFAULT_SMOKE_CONFIG)
+    parser.add_argument("--proxemic-config", type=Path, default=DEFAULT_PROXEMIC_CONFIG)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the report builder."""
+
+    args = parse_args(argv)
+    report = build_proxemic_ablation_report(
+        baseline_records=load_records(args.baseline_episodes),
+        proxemic_records=load_records(args.proxemic_episodes),
+        smoke_config_path=args.smoke_config,
+        proxemic_config_path=args.proxemic_config,
+        repo_root=args.repo_root,
+    )
+    write_report_artifacts(report, args.output_dir)
+    print(args.output_dir / "summary.json")
+    return 1 if report["report_status"] == "blocked" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_proxemic_ablation_report_issue_4165.py
+++ b/tests/benchmark/test_proxemic_ablation_report_issue_4165.py
@@ -1,0 +1,148 @@
+"""Tests for issue #4165 proxemic ablation reporting."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.benchmark.proxemic_ablation_report import (
+    build_proxemic_ablation_report,
+    load_records,
+    write_report_artifacts,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_builds_paired_proxemic_delta_report_with_parameter_provenance(tmp_path: Path) -> None:
+    """Report includes paired deltas and proxemic parameter provenance."""
+
+    smoke_config, proxemic_config = _write_configs(tmp_path)
+    baseline_rows = [
+        _row("crossing_easy", 1, intrusion_rate=0.30, clearance=0.55, efficiency=0.80, runtime=1.0),
+        _row("crossing_hard", 2, intrusion_rate=0.50, clearance=0.45, efficiency=0.70, runtime=1.2),
+    ]
+    proxemic_rows = [
+        _row("crossing_easy", 1, intrusion_rate=0.20, clearance=0.70, efficiency=0.78, runtime=1.1),
+        _row("crossing_hard", 2, intrusion_rate=0.40, clearance=0.50, efficiency=0.68, runtime=1.4),
+    ]
+
+    report = build_proxemic_ablation_report(
+        baseline_records=baseline_rows,
+        proxemic_records=proxemic_rows,
+        smoke_config_path=smoke_config.relative_to(tmp_path),
+        proxemic_config_path=proxemic_config.relative_to(tmp_path),
+        repo_root=tmp_path,
+    )
+
+    assert report["report_status"] == "ready"
+    assert report["paired_rows"] == 2
+    assert report["deltas"]["intrusion_rate_delta"] == pytest.approx(-0.1)
+    assert report["deltas"]["minimum_clearance_delta"] == pytest.approx(0.1)
+    assert report["deltas"]["path_efficiency_delta"] == pytest.approx(-0.02)
+    assert report["deltas"]["runtime_overhead_seconds"] == pytest.approx(0.15)
+    assert report["parameter_provenance"]["proxemic_config"]["parameters"]["enabled"] is True
+    assert len(report["parameter_provenance"]["proxemic_config"]["sha256"]) == 64
+
+
+def test_blocks_fallback_rows_and_missing_delta_fields(tmp_path: Path) -> None:
+    """Fallback rows and missing required metrics block readiness."""
+
+    smoke_config, proxemic_config = _write_configs(tmp_path)
+    baseline_rows = [
+        _row("crossing_easy", 1, intrusion_rate=0.30, clearance=0.55, efficiency=0.80, runtime=1.0)
+    ]
+    proxemic_rows = [
+        {
+            "scenario_id": "crossing_easy",
+            "seed": 1,
+            "row_status": "fallback",
+            "metrics": {"path_efficiency": 0.78, "episode_sec": 1.1},
+        }
+    ]
+
+    report = build_proxemic_ablation_report(
+        baseline_records=baseline_rows,
+        proxemic_records=proxemic_rows,
+        smoke_config_path=smoke_config.relative_to(tmp_path),
+        proxemic_config_path=proxemic_config.relative_to(tmp_path),
+        repo_root=tmp_path,
+    )
+
+    assert report["report_status"] == "blocked"
+    assert any("row_status='fallback'" in reason for reason in report["blocked_reasons"])
+    assert any("missing metrics" in reason for reason in report["blocked_reasons"])
+
+
+def test_load_records_accepts_json_and_jsonl_and_writes_report(tmp_path: Path) -> None:
+    """Rows load from JSON/JSONL and report artifacts are written."""
+
+    json_path = tmp_path / "rows.json"
+    jsonl_path = tmp_path / "rows.jsonl"
+    rows = [
+        _row("crossing_easy", 1, intrusion_rate=0.30, clearance=0.55, efficiency=0.80, runtime=1.0)
+    ]
+    json_path.write_text(json.dumps({"episodes": rows}), encoding="utf-8")
+    jsonl_path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+    assert load_records(json_path) == rows
+    assert load_records(jsonl_path) == rows
+
+    smoke_config, proxemic_config = _write_configs(tmp_path)
+    report = build_proxemic_ablation_report(
+        baseline_records=rows,
+        proxemic_records=rows,
+        smoke_config_path=smoke_config.relative_to(tmp_path),
+        proxemic_config_path=proxemic_config.relative_to(tmp_path),
+        repo_root=tmp_path,
+    )
+    output_dir = tmp_path / "report"
+    write_report_artifacts(report, output_dir)
+
+    assert json.loads((output_dir / "summary.json").read_text(encoding="utf-8"))["issue"] == 4165
+    assert "intrusion_rate_delta" in (output_dir / "README.md").read_text(encoding="utf-8")
+
+
+def _row(
+    scenario_id: str,
+    seed: int,
+    *,
+    intrusion_rate: float,
+    clearance: float,
+    efficiency: float,
+    runtime: float,
+) -> dict[str, object]:
+    """Build one fixture row."""
+
+    return {
+        "scenario_id": scenario_id,
+        "seed": seed,
+        "row_status": "native",
+        "metrics": {
+            "proxemic_intrusion_rate": intrusion_rate,
+            "min_distance": clearance,
+            "path_efficiency": efficiency,
+            "episode_sec": runtime,
+            "success": True,
+            "collisions": 0,
+        },
+    }
+
+
+def _write_configs(tmp_path: Path) -> tuple[Path, Path]:
+    """Write fixture configs."""
+
+    smoke_config = tmp_path / "smoke.yaml"
+    proxemic_config = tmp_path / "proxemic.yaml"
+    smoke_config.write_text(
+        "issue: 4165\narms:\n  baseline_classical: {}\n  proxemic_costmap_on: {}\n",
+        encoding="utf-8",
+    )
+    proxemic_config.write_text(
+        "enabled: true\npersonal_radius: 0.45\nsocial_radius: 1.2\n",
+        encoding="utf-8",
+    )
+    return smoke_config, proxemic_config


### PR DESCRIPTION
Reviewer-critical summary

- What changed: adds a CPU-only paired proxemic-layer ablation report builder and issue-specific CLI for `baseline_classical` vs `proxemic_costmap_on` fixture or smoke rows.
- Why now: issue #4165 still has the Phase 4 reporting acceptance item open after the proxemic layer implementation merged in #4185.
- Claim boundary: paired smoke/fixture reporting contract only; no full benchmark campaign evidence and no paper-facing claim promotion.
- Required validation: focused proxemic report tests, CLI smoke over paired fixture rows, and final PR readiness.
- Remaining blocker: real smoke/campaign rows still need to be generated separately before empirical conclusions can be drawn.

Contract delta

- New schema fields emitted in `summary.json`: `intrusion_rate_delta`, `minimum_clearance_delta`, `path_efficiency_delta`, `runtime_overhead_seconds`, `runtime_overhead_ratio`, `success_rate_delta`, `collision_rate_delta`, `success_collision_caveats`, and `parameter_provenance`.
- New fail-closed blockers: missing paired `scenario_id`/`seed` rows, fallback/degraded/non-usable row statuses, missing required delta metrics, and missing success/collision caveat fields.
- Compatibility impact: additive script/module only; default planner behavior and proxemic metrics are unchanged.

Issue: #4165

Scope summary: bounded reporting slice for proxemic-layer on/off deltas over fixture or smoke outputs, including intrusion-rate, clearance, efficiency, runtime, success/collision caveats, and proxemic parameter provenance.

Validation:
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_proxemic_ablation_report_issue_4165.py -q` - passed, 3 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/proxemic_ablation_report.py scripts/benchmark/build_proxemic_layer_ablation_report_issue_4165.py tests/benchmark/test_proxemic_ablation_report_issue_4165.py` - passed.
- `uv run python scripts/benchmark/build_proxemic_layer_ablation_report_issue_4165.py --baseline-episodes <tmp>/baseline.json --proxemic-episodes <tmp>/proxemic.json --output-dir <tmp>/report` - passed; wrote ready `summary.json` with required deltas and proxemic config hash.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=<tmp-pr-body> scripts/dev/pr_ready_check.sh` - passed after merging latest `origin/main`; freshness stamp: `output/validation/pr_ready/issue-4165-report-proxemic-layer-ablation-deltas.json`, head `4cd59fd3d8bf626d1ac55cf57b8205d8594b9946`, clean tree.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: progression slice; adds a nameable new capability, the paired proxemic ablation report builder/CLI. Only one recent merged #4165 PR was found (#4185), and no open duplicate PR covered this scope at start or immediately before opening.

Late guidance: re-read issue #4165 immediately before PR open; no comments newer than start were present.

Downstream propagation: PR body records the delivered slice and remaining empirical-row work. No issue comment is added because the user authorization forbids issue/PR comments.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating paired benchmark comparison reports between two episode runs.
  * Added a command-line tool to build and publish the report artifacts.
  * Reports now include summary metrics, deltas, blocker details, and configuration provenance.

* **Bug Fixes**
  * Marks reports as blocked when matching rows are missing or required metrics/status values are unusable.
  * Handles multiple metric field names and nested field paths.
  * Avoids divide-by-zero when calculating runtime overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->