### PR TITLE
Issue #4247: pin canonical SNQI weights

### DIFF
--- a/configs/benchmarks/paper_experiment_matrix_v1.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1.yaml
@@ -24,7 +24,7 @@ snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
 snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
 snqi_contract:
   enabled: true
-  enforcement: warn
+  enforcement: enforce
   rank_alignment_warn_threshold: 0.5
   rank_alignment_fail_threshold: 0.3
   outcome_separation_warn_threshold: 0.05

--- a/configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s10.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s10.yaml
@@ -23,7 +23,7 @@ snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
 snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
 snqi_contract:
   enabled: true
-  enforcement: warn
+  enforcement: enforce
   rank_alignment_warn_threshold: 0.5
   rank_alignment_fail_threshold: 0.3
   outcome_separation_warn_threshold: 0.05

--- a/configs/benchmarks/paper_experiment_matrix_v1_release_smoke.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_release_smoke.yaml
@@ -23,7 +23,7 @@ snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
 snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
 snqi_contract:
   enabled: true
-  enforcement: warn
+  enforcement: enforce
   rank_alignment_warn_threshold: 0.5
   rank_alignment_fail_threshold: 0.3
   outcome_separation_warn_threshold: 0.05

--- a/configs/benchmarks/releases/paper_experiment_matrix_v1_release_smoke_v0_1.yaml
+++ b/configs/benchmarks/releases/paper_experiment_matrix_v1_release_smoke_v0_1.yaml
@@ -4,7 +4,7 @@ release_id: paper_experiment_matrix_v1_smoke_v0_1_0
 release_tag: paper-benchmark-smoke-v0.1.0
 maturity: pre-1.0
 canonical_campaign_config: ../paper_experiment_matrix_v1_release_smoke.yaml
-campaign_config_sha256: "702771d32751787da97cd58284f9aae585814ee8700ea6b9788a12cf9abe1bc8"
+campaign_config_sha256: "60620b8f28ceb65b6468b343ab1988f87b1187c86ad534bdf2513d48d008ba5e"
 expected_paper_profile_version: paper-matrix-v1
 expected_paper_interpretation_profile: baseline-ready-core
 

--- a/configs/benchmarks/releases/paper_experiment_matrix_v1_release_v0_1.yaml
+++ b/configs/benchmarks/releases/paper_experiment_matrix_v1_release_v0_1.yaml
@@ -4,7 +4,7 @@ release_id: paper_experiment_matrix_v1_v0_1_0
 release_tag: paper-benchmark-v0.1.0
 maturity: pre-1.0
 canonical_campaign_config: ../paper_experiment_matrix_v1.yaml
-campaign_config_sha256: "fa031be7b1e4dd08212d1c97e57cecf2d67f8c35d8a15ac3b80c818f494cf134"
+campaign_config_sha256: "0ad4d441edf57a93c02cfad5e49e466c943a55d34a48b1eb9682920d724454ee"
 expected_paper_profile_version: paper-matrix-v1
 expected_paper_interpretation_profile: baseline-ready-core
 

--- a/configs/benchmarks/snqi_weight_sets_camera_ready.yaml
+++ b/configs/benchmarks/snqi_weight_sets_camera_ready.yaml
@@ -1,0 +1,18 @@
+schema_version: snqi-weight-sets.camera-ready.v1
+decision_record: ll7/diss#331
+decision_date: 2026-07-03
+canonical_set: camera_ready_v3
+weight_sets:
+  camera_ready_v1:
+    role: sensitivity_probe
+    path: configs/benchmarks/snqi_weights_camera_ready_v1.json
+    label: camera_ready_v1_sensitivity_probe
+  camera_ready_v2:
+    role: sensitivity_probe
+    path: configs/benchmarks/snqi_weights_camera_ready_v2.json
+    label: camera_ready_v2_sensitivity_probe
+  camera_ready_v3:
+    role: canonical
+    path: configs/benchmarks/snqi_weights_camera_ready_v3.json
+    label: camera_ready_v3_canonical
+    sha256: 71a67c3c02faff166f8c96bef8bcf898533981ca2b2c4493829988520fb1aeb2

--- a/robot_sf/benchmark/camera_ready/_config.py
+++ b/robot_sf/benchmark/camera_ready/_config.py
@@ -29,7 +29,7 @@ _PAPER_KINEMATICS_BY_PROFILE = {
     "paper-cross-kinematics-v1": ("differential_drive", "bicycle_drive", "holonomic"),
 }
 _AMV_COVERAGE_ENFORCEMENT = {"warn", "error"}
-_SNQI_CONTRACT_ENFORCEMENT = {"warn", "error"}
+_SNQI_CONTRACT_ENFORCEMENT = {"warn", "error", "enforce"}
 
 
 def _normalize_observation_mode(raw: Any, *, label: str) -> str | None:

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -1492,12 +1492,14 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
     snqi_hard_fail = (
         cfg.paper_facing
         and cfg.snqi_contract.enabled
-        and cfg.snqi_contract.enforcement == "error"
+        and cfg.snqi_contract.enforcement in {"error", "enforce"}
         and contract_eval.status == "fail"
     )
     if snqi_hard_fail:
         warnings.append(
-            "SNQI contract status=fail with snqi_contract.enforcement=error; campaign marked with hard contract warning."
+            "SNQI contract status=fail with "
+            f"snqi_contract.enforcement={cfg.snqi_contract.enforcement}; "
+            "campaign marked with hard contract warning."
         )
     elif (
         cfg.paper_facing
@@ -1836,7 +1838,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
 
     if snqi_hard_fail:
         raise RuntimeError(
-            "SNQI contract failed with enforcement=error; "
+            f"SNQI contract failed with enforcement={cfg.snqi_contract.enforcement}; "
             f"rank_alignment={contract_eval.rank_alignment_spearman:.4f}, "
             f"outcome_separation={contract_eval.outcome_separation:.4f}. "
             f"See diagnostics: {_repo_relative(snqi_diagnostics_json_path)}"

--- a/tests/benchmark/test_issue_4247_snqi_canonical_contract.py
+++ b/tests/benchmark/test_issue_4247_snqi_canonical_contract.py
@@ -1,0 +1,99 @@
+"""Regression tests for issue #4247 canonical SNQI weight governance."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.camera_ready_campaign import load_campaign_config
+from robot_sf.benchmark.snqi.compute import WEIGHT_NAMES
+from robot_sf.benchmark.snqi.weights_validation import validate_weights_mapping
+
+ROOT = Path(__file__).resolve().parents[2]
+WEIGHT_SET_REGISTRY = ROOT / "configs/benchmarks/snqi_weight_sets_camera_ready.yaml"
+CANONICAL_WEIGHTS = ROOT / "configs/benchmarks/snqi_weights_camera_ready_v3.json"
+EXPECTED_V3_SHA256 = "71a67c3c02faff166f8c96bef8bcf898533981ca2b2c4493829988520fb1aeb2"
+CANONICAL_CAMPAIGN_CONFIGS = (
+    ROOT / "configs/benchmarks/paper_experiment_matrix_v1.yaml",
+    ROOT / "configs/benchmarks/paper_experiment_matrix_v1_release_smoke.yaml",
+    ROOT / "configs/benchmarks/paper_experiment_matrix_v1_extended_seeds_s10.yaml",
+)
+
+
+def _load_weight_set_registry() -> dict[str, object]:
+    """Load the camera-ready SNQI weight-set registry."""
+    return yaml.safe_load(WEIGHT_SET_REGISTRY.read_text(encoding="utf-8"))
+
+
+def test_camera_ready_v3_canonical_weight_vector_hash_is_frozen() -> None:
+    """The author-ruling canonical vector remains the checked-in v3 file."""
+    digest = hashlib.sha256(CANONICAL_WEIGHTS.read_bytes()).hexdigest()
+    weights = validate_weights_mapping(json.loads(CANONICAL_WEIGHTS.read_text(encoding="utf-8")))
+
+    assert digest == EXPECTED_V3_SHA256
+    assert set(weights) == set(WEIGHT_NAMES)
+
+
+def test_camera_ready_weight_registry_labels_v1_v2_as_sensitivity_probes() -> None:
+    """Historical camera-ready vectors stay loadable only as labeled probes."""
+    registry = _load_weight_set_registry()
+    assert registry["canonical_set"] == "camera_ready_v3"
+
+    weight_sets = registry["weight_sets"]
+    for set_id in ("camera_ready_v1", "camera_ready_v2"):
+        entry = weight_sets[set_id]
+        assert entry["role"] == "sensitivity_probe"
+        assert entry["label"].endswith("_sensitivity_probe")
+        weights_path = ROOT / entry["path"]
+        weights = validate_weights_mapping(json.loads(weights_path.read_text(encoding="utf-8")))
+        assert set(weights) == set(WEIGHT_NAMES)
+
+    canonical = weight_sets["camera_ready_v3"]
+    assert canonical["role"] == "canonical"
+    assert canonical["path"] == "configs/benchmarks/snqi_weights_camera_ready_v3.json"
+    assert canonical["sha256"] == EXPECTED_V3_SHA256
+
+
+@pytest.mark.parametrize("config_path", CANONICAL_CAMPAIGN_CONFIGS)
+def test_canonical_camera_ready_configs_pin_v3_and_enforce_snqi_contract(
+    config_path: Path,
+) -> None:
+    """Canonical camera-ready benchmark gates use v3 weights and hard SNQI enforcement."""
+    cfg = load_campaign_config(config_path)
+
+    assert cfg.snqi_weights_path == CANONICAL_WEIGHTS
+    assert cfg.snqi_contract.enforcement == "enforce"
+
+
+def test_snqi_contract_enforce_mode_loads_as_hard_enforcement(tmp_path: Path) -> None:
+    """Config loader accepts the author-ruling enforce mode."""
+    scenario_path = tmp_path / "matrix.yaml"
+    scenario_path.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: issue_4247_enforce",
+                f"scenario_matrix: {scenario_path.as_posix()}",
+                "snqi_contract:",
+                "  enabled: true",
+                "  enforcement: enforce",
+                "planners:",
+                "  - key: goal",
+                "    algo: goal",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_campaign_config(config_path)
+
+    assert cfg.snqi_contract.enforcement == "enforce"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Issue #4247 pins the camera-ready Social Navigation Quality Index (SNQI) canonical weight set to `camera_ready_v3`, records `camera_ready_v1` and `camera_ready_v2` as labeled sensitivity probes, and flips the canonical benchmark gate SNQI contract from `warn` to `enforce`.

Why now: this is the robot_sf follow-through for the 2026-07-03 author ruling recorded in `ll7/diss#331`.

Claim boundary: config and governance only. The checked-in v3 vector is unchanged and still hashes to `71a67c3c02faff166f8c96bef8bcf898533981ca2b2c4493829988520fb1aeb2`; this PR makes no result, benchmark, paper, or dissertation claim.

Required validation: identity/hash test for the canonical vector, enforce-mode loader/runtime contract, sensitivity-probe loadability, release-manifest hash validation, and repository PR readiness.

Remaining blocker: no full benchmark campaign was run; Claude Code on `imech156-u` owns the full PR gate, improvement cycle, and merge authority after this PR opens.

## Contract delta

- New config registry: `configs/benchmarks/snqi_weight_sets_camera_ready.yaml`.
- New canonical set: `camera_ready_v3`.
- New labeled probe status: `camera_ready_v1_sensitivity_probe`, `camera_ready_v2_sensitivity_probe`.
- SNQI contract enforcement enum now accepts `enforce`; `enforce` is treated as hard failure behavior like legacy `error`.
- Canonical benchmark configs now set `snqi_contract.enforcement: enforce`.
- Release manifest `campaign_config_sha256` values were updated only because the canonical configs changed from `warn` to `enforce`.
- Compatibility impact: legacy `warn` and `error` remain accepted; no SNQI weights or baseline numbers changed.

## Linked Issues

- Closes #4247

## What Changed

- Added a camera-ready SNQI weight-set registry with the 2026-07-03 decision provenance.
- Updated canonical paper/release benchmark configs to use hard SNQI enforcement.
- Updated camera-ready campaign governance so `enforce` is a hard SNQI contract mode.
- Added regression tests for v3 hash identity, enforce-mode loading, canonical config pinning, and v1/v2 probe loadability.

## Validation / Proof

- `uv run pytest tests/benchmark/test_issue_4247_snqi_canonical_contract.py -q` -> passed, 6 passed.
- `uv run pytest tests/benchmark/test_release_protocol.py -q` -> passed, 20 passed.
- `uv run pytest tests/benchmark/test_camera_ready_campaign.py -q -k "snqi_contract or snqi_error or snqi_warn"` -> passed, 4 passed.
- `uv run ruff check robot_sf/benchmark/camera_ready/_config.py robot_sf/benchmark/camera_ready_campaign.py tests/benchmark/test_issue_4247_snqi_canonical_contract.py` -> passed.
- `uv run ruff format --check robot_sf/benchmark/camera_ready/_config.py robot_sf/benchmark/camera_ready_campaign.py tests/benchmark/test_issue_4247_snqi_canonical_contract.py` -> passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed on dirty tree before commit: 1764 passed, 2 skipped.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-4247/PR_BODY.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed with clean committed-HEAD stamp for `dda3222d048ae4895c6e8c12f585d333608c0660`.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> fresh, clean tree.

## Explicitly Out Of Scope

- No full benchmark campaign run.
- No Slurm or GPU submission.
- No paper, dissertation, leaderboard, or result-claim edits.
- No metric/result recalibration; the frozen vector already equals v3.

## Downstream Propagation

- Parent issue updated: no. This run is not authorized to comment on issues or PRs, so the compact state propagation is recorded here in the PR body instead of adding a comment stream to #4247.
- Claim map / benchmark report updated: no, because this PR makes no empirical claim.
- Leaderboard / artifact catalog updated: no, because no campaign artifacts were produced.
- Registry or config index updated: yes, via `configs/benchmarks/snqi_weight_sets_camera_ready.yaml`.
- Context index / memory note updated: no, because the tracked config/test contract is the durable state for this low-churn issue slice.

<details>
<summary>Governance notes</summary>

Fragmentation guard: no open PR covers #4247, and the issue has no comments. Search did not show two or more #4247 guardrail/checker/packet-refresh PRs merged in the last 24 hours. This PR is a progression slice because it adds the nameable `enforce` SNQI contract mode and canonical weight-set registry.

Late guidance check: issue #4247 was re-read immediately before PR creation. The issue had no comments and `updated_at=2026-07-03T09:03:47Z`, so there were no maintainer comments newer than start time `2026-07-03T09:06:26Z`.

</details>
