### PR TITLE
Issue #4232: pre-register uncertainty-envelope claim evidence scope

### DIFF
--- a/configs/benchmarks/issue_4232_uncertainty_envelope_claim_packet.yaml
+++ b/configs/benchmarks/issue_4232_uncertainty_envelope_claim_packet.yaml
@@ -1,0 +1,228 @@
+# Issue #4232 uncertainty-envelope claim evidence pre-registration packet.
+#
+# This packet defines the evidence scope required before making performance,
+# safety, paper, or dissertation claims about the pedestrian uncertainty
+# envelope added by issue #4141 / PR #4229. It is not benchmark evidence and
+# must not be used to promote claims by itself.
+schema_version: uncertainty-envelope-claim-packet.v1
+name: issue_4232_uncertainty_envelope_claim_packet
+issue: 4232
+parent_runtime_issue: 4141
+runtime_completion_pr: 4229
+evidence_status: pre_registered_no_evidence
+claim_boundary: >-
+  Benchmark evidence planning packet only. Runtime support exists from PR #4229,
+  but this packet does not establish safety, performance, conformal-calibration,
+  dissertation, paper, real-world, deployment, or generalized planner-superiority
+  claims.
+execution_boundary:
+  run_benchmark: false
+  compute_submit_authorized: false
+  local_submission_allowed: false
+  slurm_job_id: not_submitted
+  target_host: not_applicable
+claim_modes:
+  allowed_after_evidence:
+    - diagnostic_alpha_effect
+    - bounded_mpc_family_safety_tradeoff
+  forbidden_without_followup:
+    - conformal_coverage_guarantee
+    - real_world_safety_claim
+    - deployment_certification
+    - generalized_planner_superiority
+    - paper_or_dissertation_claim
+evidence_tiers:
+  tier0_runtime_smoke:
+    status: implementation_integrity_only
+    source_pr: 4229
+    claim_allowed: false
+  tier1_cpu_diagnostic_alpha_sweep:
+    status: diagnostic_effect_size_screening_only
+    claim_allowed: false
+  tier2_private_slurm_benchmark_campaign:
+    status: candidate_benchmark_evidence_if_row_status_denominators_pass
+    claim_allowed: bounded_after_review
+  tier3_claim_map_or_paper_integration:
+    status: maintainer_signoff_required
+    claim_allowed: bounded_after_explicit_claim_boundary_review
+scenario_surface:
+  matrix_path: configs/scenarios/classic_interactions_francis2023.yaml
+  scope: pedestrian_interaction_safety_sensitive_subset_or_full_matrix
+  selection_policy: predeclared_before_run
+  max_episode_steps: 600
+  dt: 0.1
+  kinematics_matrix:
+    - differential_drive
+seed_policy:
+  mode: fixed-list
+  seed_set_name: issue_4232_eval_s3_diagnostic_seed_set
+  seeds:
+    - 111
+    - 112
+    - 113
+  repeat_policy: every_planner_scenario_alpha_arm_pair
+planner_families:
+  - planner_id: prediction_mpc
+    family: mpc
+    base_config_path: configs/algos/prediction_mpc_cv_uncertainty_envelope.yaml
+    claim_modes:
+      - envelope_effect
+  - planner_id: prediction_mpc_cbf
+    family: mpc
+    base_config_path: configs/algos/prediction_mpc_cv_cbf_dynamic_parabolic_v1.yaml
+    claim_modes:
+      - envelope_effect
+  - planner_id: nmpc_social
+    family: mpc
+    base_config_path: configs/algos/nmpc_social_exploratory.yaml
+    claim_modes:
+      - envelope_effect
+alpha_arms:
+  - key: envelope_off_alpha_0
+    pedestrian_uncertainty_envelope_enabled: false
+    pedestrian_uncertainty_alpha_mps: 0.0
+    purpose: control_baseline
+    scenario_surface_ref: scenario_surface
+    seed_set_ref: seed_policy
+    max_episode_steps: 600
+    dt: 0.1
+    kinematics_matrix:
+      - differential_drive
+    applies_to_planner_families: all_declared_mpc_families
+  - key: envelope_on_alpha_0
+    pedestrian_uncertainty_envelope_enabled: true
+    pedestrian_uncertainty_alpha_mps: 0.0
+    purpose: regression_equivalence
+    scenario_surface_ref: scenario_surface
+    seed_set_ref: seed_policy
+    max_episode_steps: 600
+    dt: 0.1
+    kinematics_matrix:
+      - differential_drive
+    applies_to_planner_families: all_declared_mpc_families
+  - key: envelope_on_alpha_0p05
+    pedestrian_uncertainty_envelope_enabled: true
+    pedestrian_uncertainty_alpha_mps: 0.05
+    purpose: diagnostic_nonzero_alpha_low
+    scenario_surface_ref: scenario_surface
+    seed_set_ref: seed_policy
+    max_episode_steps: 600
+    dt: 0.1
+    kinematics_matrix:
+      - differential_drive
+    applies_to_planner_families: all_declared_mpc_families
+  - key: envelope_on_alpha_0p10
+    pedestrian_uncertainty_envelope_enabled: true
+    pedestrian_uncertainty_alpha_mps: 0.10
+    purpose: diagnostic_nonzero_alpha_mid
+    scenario_surface_ref: scenario_surface
+    seed_set_ref: seed_policy
+    max_episode_steps: 600
+    dt: 0.1
+    kinematics_matrix:
+      - differential_drive
+    applies_to_planner_families: all_declared_mpc_families
+  - key: envelope_on_alpha_0p20
+    pedestrian_uncertainty_envelope_enabled: true
+    pedestrian_uncertainty_alpha_mps: 0.20
+    purpose: diagnostic_nonzero_alpha_high
+    scenario_surface_ref: scenario_surface
+    seed_set_ref: seed_policy
+    max_episode_steps: 600
+    dt: 0.1
+    kinematics_matrix:
+      - differential_drive
+    applies_to_planner_families: all_declared_mpc_families
+metrics:
+  primary:
+    - collision_rate
+    - near_miss_rate
+    - minimum_clearance
+    - social_proxemic_minimum_clearance
+    - success_rate
+    - timeout_share
+    - progress_to_goal
+    - path_efficiency
+    - planner_infeasible_rate
+    - fallback_rate
+    - projection_rate
+    - runtime_per_episode
+  secondary_diagnostic:
+    - snqi_diagnostic_only
+    - comfort_exposure
+    - social_proxemic_intrusion_fraction
+    - pedestrian_impact_proxy
+    - envelope_activation_count
+    - effective_radius_used_by_planner
+stop_rules:
+  - id: alpha_zero_equivalence
+    rule: >-
+      Stop if envelope_on_alpha_0 differs materially from envelope_off_alpha_0
+      under identical seeds unless the difference is explained by known
+      identity or plumbing behavior.
+  - id: nonzero_alpha_fallback_only
+    rule: Stop if nonzero alpha produces only fallback, degraded, failed, or unavailable rows.
+  - id: safety_runtime_tradeoff_revision
+    rule: >-
+      Revise if alpha improves clearance but collapses success or runtime beyond
+      a predeclared tolerance.
+  - id: claim_review_entry
+    rule: >-
+      Continue to claim review only if paired nonzero-alpha arms show
+      interpretable safety or comfort changes with row-status-valid denominators.
+row_status_policy:
+  allowed_values:
+    - successful_evidence
+    - diagnostic_only
+    - fallback
+    - degraded
+    - not_available
+    - failed
+    - blocked
+  benchmark_strength_success_values:
+    - successful_evidence
+  ineligible_benchmark_strength_values:
+    - diagnostic_only
+    - fallback
+    - degraded
+    - not_available
+    - failed
+    - blocked
+  fallback_policy: >-
+    Fallback, degraded, adapter-unavailable, diagnostic-only, failed, and
+    blocked rows remain visible in denominator reports but cannot count as
+    successful benchmark-strength evidence.
+artifact_provenance:
+  require_public_commit_hash: true
+  require_packet_sha256: true
+  require_scenario_matrix_sha256: true
+  require_resolved_seed_manifest: true
+  require_planner_alpha_roster: true
+  require_row_status_audit: true
+  raw_artifacts_git_policy: keep_out_of_git
+outputs:
+  compact_review_bundle: docs/context/evidence/issue_4232_uncertainty_envelope_claim_evidence_2026-07
+  required_review_artifacts:
+    - README.md
+    - metadata.json
+    - pre_registration_packet.json
+    - alpha_arm_metric_table.csv
+    - paired_alpha_delta_table.csv
+    - row_status_audit.csv
+    - envelope_activation_diagnostics.json
+    - envelope_activation_diagnostics.md
+    - runtime_cost_report.csv
+    - claim_boundary.md
+    - claim_readiness.md
+    - SHA256SUMS
+  prohibited_git_artifacts:
+    - raw_episode_jsonl
+    - videos
+    - slurm_logs
+    - checkpoints
+    - model_caches
+claim_update_conditions:
+  claim_map_update_allowed: after_tier2_evidence_and_maintainer_claim_boundary_review
+  benchmark_report_update_allowed: after_tier2_evidence_and_row_status_audit
+  paper_or_dissertation_update_allowed: separate_pr_after_explicit_maintainer_signoff
+  conformal_calibration_claim_allowed: false

--- a/scripts/validation/check_issue_4232_uncertainty_envelope_claim_packet.py
+++ b/scripts/validation/check_issue_4232_uncertainty_envelope_claim_packet.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Validate the issue #4232 uncertainty-envelope claim pre-registration packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_PACKET = Path("configs/benchmarks/issue_4232_uncertainty_envelope_claim_packet.yaml")
+SCHEMA_VERSION = "uncertainty-envelope-claim-packet.v1"
+MPC_FAMILIES = {"mpc", "prediction_mpc", "prediction_mpc_cbf", "nmpc_social"}
+REQUIRED_FORBIDDEN_CLAIMS = {
+    "conformal_coverage_guarantee",
+    "real_world_safety_claim",
+    "deployment_certification",
+    "generalized_planner_superiority",
+    "paper_or_dissertation_claim",
+}
+REQUIRED_INELIGIBLE_ROW_STATUSES = {
+    "diagnostic_only",
+    "fallback",
+    "degraded",
+    "not_available",
+    "failed",
+    "blocked",
+}
+RAW_ARTIFACT_MARKERS = {
+    "raw_episode_jsonl",
+    "videos",
+    "slurm_logs",
+    "checkpoints",
+    "model_caches",
+}
+
+
+class PacketError(ValueError):
+    """Raised when the pre-registration packet would fail closed."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise PacketError(message)
+
+
+def _require_mapping(payload: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    value = payload.get(key)
+    _require(isinstance(value, Mapping), f"{key} must be mapping")
+    return value
+
+
+def _require_sequence(payload: Mapping[str, Any], key: str) -> Sequence[Any]:
+    value = payload.get(key)
+    _require(
+        isinstance(value, Sequence) and not isinstance(value, str) and len(value) > 0,
+        f"{key} must be non-empty sequence",
+    )
+    return value
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise PacketError("packet must be YAML mapping")
+    return payload
+
+
+def _require_claim_boundary(packet: Mapping[str, Any]) -> None:
+    boundary = str(packet.get("claim_boundary", "")).lower()
+    for phrase in (
+        "planning packet only",
+        "does not establish safety",
+        "performance",
+        "conformal",
+        "dissertation",
+        "paper",
+        "real-world",
+        "deployment",
+        "generalized planner",
+    ):
+        _require(phrase in boundary, f"claim_boundary must mention {phrase!r}")
+
+    claim_modes = _require_mapping(packet, "claim_modes")
+    forbidden = set(claim_modes.get("forbidden_without_followup") or [])
+    _require(
+        REQUIRED_FORBIDDEN_CLAIMS <= forbidden,
+        "claim_modes.forbidden_without_followup missing required claim exclusions",
+    )
+
+
+def _require_execution_boundary(packet: Mapping[str, Any]) -> None:
+    execution = _require_mapping(packet, "execution_boundary")
+    _require(execution.get("run_benchmark") is False, "run_benchmark must be false")
+    _require(
+        execution.get("compute_submit_authorized") is False,
+        "compute_submit_authorized must be false",
+    )
+    _require(
+        execution.get("local_submission_allowed") is False,
+        "local_submission_allowed must be false",
+    )
+    _require(
+        str(execution.get("slurm_job_id", "")).lower() == "not_submitted",
+        "slurm_job_id must be not_submitted",
+    )
+
+
+def _require_scenario_and_seeds(packet: Mapping[str, Any]) -> None:
+    surface = _require_mapping(packet, "scenario_surface")
+    _require(
+        surface.get("matrix_path") == "configs/scenarios/classic_interactions_francis2023.yaml",
+        "scenario_surface.matrix_path must pin classic_interactions_francis2023.yaml",
+    )
+    _require(
+        surface.get("selection_policy") == "predeclared_before_run",
+        "scenario selection must be predeclared before run",
+    )
+    _require(surface.get("max_episode_steps") == 600, "max_episode_steps must be 600")
+    _require(surface.get("dt") == 0.1, "scenario_surface.dt must be 0.1")
+    kinematics = list(_require_sequence(surface, "kinematics_matrix"))
+    _require("differential_drive" in kinematics, "differential_drive kinematics required")
+
+    seed_policy = _require_mapping(packet, "seed_policy")
+    _require(seed_policy.get("mode") == "fixed-list", "seed_policy.mode must be fixed-list")
+    seeds = list(_require_sequence(seed_policy, "seeds"))
+    _require(all(isinstance(seed, int) for seed in seeds), "all seeds must be integers")
+    _require(len(seeds) == len(set(seeds)), "seeds must be unique")
+
+
+def _require_planners(packet: Mapping[str, Any]) -> int:
+    planners = _require_sequence(packet, "planner_families")
+    for planner in planners:
+        _require(isinstance(planner, Mapping), "planner entries must be mappings")
+        planner_id = str(planner.get("planner_id", ""))
+        _require(planner_id != "", "planner_id is required")
+        _require(str(planner.get("base_config_path", "")) != "", f"{planner_id} config required")
+        family = str(planner.get("family", "")).lower()
+        claim_modes = set(planner.get("claim_modes") or [])
+        if "envelope_effect" in claim_modes:
+            _require(
+                family in MPC_FAMILIES or planner_id in MPC_FAMILIES,
+                f"{planner_id} cannot enter envelope-effect claims unless MPC-family",
+            )
+    return len(planners)
+
+
+def _require_alpha_arms(packet: Mapping[str, Any]) -> int:
+    surface = _require_mapping(packet, "scenario_surface")
+    expected_kinematics = list(surface.get("kinematics_matrix") or [])
+    arms = _require_sequence(packet, "alpha_arms")
+    keys: set[str] = set()
+    nonzero_alpha = False
+
+    for arm in arms:
+        _require(isinstance(arm, Mapping), "alpha arm entries must be mappings")
+        key = str(arm.get("key", ""))
+        _require(key != "", "alpha arm key is required")
+        _require(key not in keys, f"duplicate alpha arm key: {key}")
+        keys.add(key)
+        enabled = arm.get("pedestrian_uncertainty_envelope_enabled")
+        _require(isinstance(enabled, bool), f"{key} enabled flag must be boolean")
+        alpha = arm.get("pedestrian_uncertainty_alpha_mps")
+        _require(isinstance(alpha, int | float), f"{key} alpha must be numeric")
+        _require(alpha >= 0.0, f"{key} alpha must be non-negative")
+        nonzero_alpha = nonzero_alpha or alpha > 0.0
+        _require(arm.get("scenario_surface_ref") == "scenario_surface", f"{key} scenario mismatch")
+        _require(arm.get("seed_set_ref") == "seed_policy", f"{key} seed policy mismatch")
+        _require(
+            arm.get("max_episode_steps") == surface.get("max_episode_steps"),
+            f"{key} max_episode_steps mismatch",
+        )
+        _require(arm.get("dt") == surface.get("dt"), f"{key} dt mismatch")
+        _require(
+            list(arm.get("kinematics_matrix") or []) == expected_kinematics,
+            f"{key} kinematics mismatch",
+        )
+
+    _require("envelope_off_alpha_0" in keys, "missing envelope_off_alpha_0 control arm")
+    _require("envelope_on_alpha_0" in keys, "missing envelope_on_alpha_0 regression arm")
+    _require(nonzero_alpha, "at least one nonzero alpha arm is required")
+    return len(arms)
+
+
+def _require_metrics_and_stop_rules(packet: Mapping[str, Any]) -> None:
+    metrics = _require_mapping(packet, "metrics")
+    primary = set(_require_sequence(metrics, "primary"))
+    for metric in (
+        "collision_rate",
+        "near_miss_rate",
+        "minimum_clearance",
+        "success_rate",
+        "runtime_per_episode",
+        "fallback_rate",
+    ):
+        _require(metric in primary, f"primary metric missing: {metric}")
+    secondary = set(_require_sequence(metrics, "secondary_diagnostic"))
+    _require("snqi_diagnostic_only" in secondary, "SNQI must be diagnostic-only")
+    _require(
+        "effective_radius_used_by_planner" in secondary,
+        "envelope activation diagnostic missing",
+    )
+
+    stop_rules = _require_sequence(packet, "stop_rules")
+    stop_ids = {str(rule.get("id", "")) for rule in stop_rules if isinstance(rule, Mapping)}
+    for stop_id in (
+        "alpha_zero_equivalence",
+        "nonzero_alpha_fallback_only",
+        "safety_runtime_tradeoff_revision",
+        "claim_review_entry",
+    ):
+        _require(stop_id in stop_ids, f"stop rule missing: {stop_id}")
+
+
+def _require_row_status_and_outputs(packet: Mapping[str, Any]) -> None:
+    row_status = _require_mapping(packet, "row_status_policy")
+    success_values = set(row_status.get("benchmark_strength_success_values") or [])
+    _require(success_values == {"successful_evidence"}, "only successful_evidence can be success")
+    ineligible = set(row_status.get("ineligible_benchmark_strength_values") or [])
+    _require(
+        REQUIRED_INELIGIBLE_ROW_STATUSES <= ineligible,
+        "fallback/degraded/unavailable rows must be ineligible benchmark evidence",
+    )
+    fallback_policy = str(row_status.get("fallback_policy", "")).lower()
+    _require(
+        "cannot count as successful benchmark-strength evidence" in fallback_policy,
+        "fallback policy must exclude fallback/degraded rows from success evidence",
+    )
+
+    outputs = _require_mapping(packet, "outputs")
+    bundle = str(outputs.get("compact_review_bundle", ""))
+    _require(
+        bundle.startswith("docs/context/evidence/issue_4232_"),
+        "compact_review_bundle must be a durable docs/context/evidence path",
+    )
+    required_artifacts = set(outputs.get("required_review_artifacts") or [])
+    for artifact in (
+        "metadata.json",
+        "pre_registration_packet.json",
+        "row_status_audit.csv",
+        "claim_readiness.md",
+        "SHA256SUMS",
+    ):
+        _require(artifact in required_artifacts, f"required review artifact missing: {artifact}")
+    prohibited = set(outputs.get("prohibited_git_artifacts") or [])
+    _require(
+        RAW_ARTIFACT_MARKERS <= prohibited,
+        "raw JSONL/videos/logs/checkpoints/caches must be prohibited git artifacts",
+    )
+    for artifact in required_artifacts:
+        lower = str(artifact).lower()
+        _require(not lower.endswith(".jsonl"), "raw episode JSONL must not be review artifact")
+        _require("video" not in lower, "videos must not be review artifacts")
+        _require("slurm" not in lower and "log" not in lower, "logs must not be review artifacts")
+        _require("checkpoint" not in lower, "checkpoints must not be review artifacts")
+
+
+def _require_provenance_and_claim_gates(packet: Mapping[str, Any]) -> None:
+    provenance = _require_mapping(packet, "artifact_provenance")
+    for key in (
+        "require_public_commit_hash",
+        "require_packet_sha256",
+        "require_scenario_matrix_sha256",
+        "require_resolved_seed_manifest",
+        "require_planner_alpha_roster",
+        "require_row_status_audit",
+    ):
+        _require(provenance.get(key) is True, f"artifact_provenance.{key} must be true")
+    _require(
+        provenance.get("raw_artifacts_git_policy") == "keep_out_of_git",
+        "raw artifacts must stay out of git",
+    )
+
+    gates = _require_mapping(packet, "claim_update_conditions")
+    _require(
+        "maintainer_claim_boundary_review" in str(gates.get("claim_map_update_allowed", "")),
+        "claim map update must require maintainer claim-boundary review",
+    )
+    _require(
+        "separate_pr" in str(gates.get("paper_or_dissertation_update_allowed", "")),
+        "paper/dissertation updates must require separate PR",
+    )
+    _require(
+        gates.get("conformal_calibration_claim_allowed") is False,
+        "conformal calibration claims must be disallowed",
+    )
+
+
+def validate_packet(packet: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the issue #4232 pre-registration packet and return a summary."""
+    _require(packet.get("schema_version") == SCHEMA_VERSION, "schema_version mismatch")
+    _require(packet.get("issue") == 4232, "issue must be 4232")
+    _require(packet.get("parent_runtime_issue") == 4141, "parent_runtime_issue must be 4141")
+    _require(packet.get("runtime_completion_pr") == 4229, "runtime_completion_pr must be 4229")
+    _require(
+        packet.get("evidence_status") == "pre_registered_no_evidence",
+        "evidence_status must remain pre_registered_no_evidence",
+    )
+
+    _require_claim_boundary(packet)
+    _require_execution_boundary(packet)
+    _require_scenario_and_seeds(packet)
+    planner_count = _require_planners(packet)
+    alpha_arm_count = _require_alpha_arms(packet)
+    _require_metrics_and_stop_rules(packet)
+    _require_row_status_and_outputs(packet)
+    _require_provenance_and_claim_gates(packet)
+
+    return {
+        "ok": True,
+        "issue": 4232,
+        "evidence_status": packet.get("evidence_status"),
+        "planner_count": planner_count,
+        "alpha_arm_count": alpha_arm_count,
+        "compute_submit_authorized": False,
+        "run_benchmark": False,
+    }
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
+    parser.add_argument("--json", action="store_true", help="Emit JSON summary.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the command-line packet checker."""
+    args = _parse_args(argv)
+    try:
+        summary = validate_packet(_load_yaml(args.packet))
+    except PacketError as exc:
+        if args.json:
+            print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True))
+        else:
+            print(f"BLOCK: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(
+            "PASS: issue #4232 uncertainty-envelope claim packet is pre-registered and claim-gated."
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/validation/test_check_issue_4232_uncertainty_envelope_claim_packet.py
+++ b/tests/validation/test_check_issue_4232_uncertainty_envelope_claim_packet.py
@@ -1,0 +1,124 @@
+"""Tests for issue #4232 uncertainty-envelope claim pre-registration packet."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKET = REPO_ROOT / "configs/benchmarks/issue_4232_uncertainty_envelope_claim_packet.yaml"
+SCRIPT = REPO_ROOT / "scripts/validation/check_issue_4232_uncertainty_envelope_claim_packet.py"
+
+_SPEC = importlib.util.spec_from_file_location("_issue_4232_claim_packet_check", SCRIPT)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def _load_packet() -> dict:
+    return yaml.safe_load(PACKET.read_text(encoding="utf-8"))
+
+
+def _assert_rejected(packet: dict, message: str) -> None:
+    with pytest.raises(_MODULE.PacketError, match=message):
+        _MODULE.validate_packet(packet)
+
+
+def test_issue_4232_packet_passes_pre_registration_contract() -> None:
+    """The checked-in packet defines claim scope without creating evidence claims."""
+    summary = _MODULE.validate_packet(_load_packet())
+
+    assert summary == {
+        "ok": True,
+        "issue": 4232,
+        "evidence_status": "pre_registered_no_evidence",
+        "planner_count": 3,
+        "alpha_arm_count": 5,
+        "compute_submit_authorized": False,
+        "run_benchmark": False,
+    }
+
+
+def test_issue_4232_packet_rejects_missing_alpha_zero_regression_arm() -> None:
+    """The alpha=0 enabled arm is required to prove regression equivalence."""
+    packet = _load_packet()
+    packet["alpha_arms"] = [
+        arm for arm in packet["alpha_arms"] if arm["key"] != "envelope_on_alpha_0"
+    ]
+
+    _assert_rejected(packet, "missing envelope_on_alpha_0 regression arm")
+
+
+def test_issue_4232_packet_rejects_negative_alpha() -> None:
+    """Alpha arms must be non-negative physical inflation speeds."""
+    packet = _load_packet()
+    packet["alpha_arms"][2]["pedestrian_uncertainty_alpha_mps"] = -0.1
+
+    _assert_rejected(packet, "alpha must be non-negative")
+
+
+def test_issue_4232_packet_rejects_mismatched_seed_surface() -> None:
+    """Paired alpha arms must share the same scenario surface and seed policy."""
+    packet = _load_packet()
+    packet["alpha_arms"][2]["seed_set_ref"] = "different_seed_policy"
+
+    _assert_rejected(packet, "seed policy mismatch")
+
+
+def test_issue_4232_packet_rejects_non_mpc_envelope_effect_claim() -> None:
+    """Non-MPC planners cannot enter envelope-effect claims in this packet."""
+    packet = _load_packet()
+    packet["planner_families"].append(
+        {
+            "planner_id": "orca",
+            "family": "reactive",
+            "base_config_path": "configs/algos/orca.yaml",
+            "claim_modes": ["envelope_effect"],
+        }
+    )
+
+    _assert_rejected(packet, "cannot enter envelope-effect claims unless MPC-family")
+
+
+def test_issue_4232_packet_allows_non_mpc_diagnostic_only_planner() -> None:
+    """Non-MPC planners are allowed only when marked outside envelope-effect claims."""
+    packet = _load_packet()
+    packet["planner_families"].append(
+        {
+            "planner_id": "orca",
+            "family": "reactive",
+            "base_config_path": "configs/algos/orca.yaml",
+            "claim_modes": ["diagnostic_only"],
+        }
+    )
+
+    summary = _MODULE.validate_packet(packet)
+    assert summary["planner_count"] == 4
+
+
+def test_issue_4232_packet_rejects_missing_forbidden_claim_language() -> None:
+    """The packet must keep conformal, deployment, and paper claims forbidden."""
+    packet = _load_packet()
+    packet["claim_modes"]["forbidden_without_followup"].remove("conformal_coverage_guarantee")
+
+    _assert_rejected(packet, "missing required claim exclusions")
+
+
+def test_issue_4232_packet_rejects_fallback_as_success_evidence() -> None:
+    """Fallback/degraded execution cannot count as benchmark-strength evidence."""
+    packet = _load_packet()
+    packet["row_status_policy"]["benchmark_strength_success_values"].append("fallback")
+
+    _assert_rejected(packet, "only successful_evidence can be success")
+
+
+def test_issue_4232_packet_rejects_raw_artifacts_as_review_outputs() -> None:
+    """Pre-registration must not put raw run products in durable docs evidence."""
+    packet = _load_packet()
+    packet["outputs"]["required_review_artifacts"].append("episodes.jsonl")
+
+    _assert_rejected(packet, "raw episode JSONL must not be review artifact")


### PR DESCRIPTION
Reviewer-critical summary

What changed: adds a public pre-registration packet for issue #4232 plus a static validator and focused tests for the uncertainty-envelope claim-evidence scope.

Why now: PR #4229 completed runtime acceptance only; this PR records what evidence must exist before any uncertainty-envelope performance, safety, paper, or dissertation claim.

Claim boundary: this is evidence planning only. It does not run a benchmark, submit Slurm/GPU work, establish calibrated safety, edit paper/dissertation claims, or reinterpret #4229 smoke output as benchmark evidence.

Required validation: the packet must pass the issue #4232 checker and fail closed when required alpha arms, claim exclusions, paired seed/surface constraints, MPC-family claim limits, raw artifact exclusions, or fallback/degraded exclusions are removed.

Remaining blocker: actual diagnostic and benchmark campaign evidence still needs a separate execution slice before any claim-map, benchmark-report, paper, or dissertation update.

Contract delta

New schema fields:
- `configs/benchmarks/issue_4232_uncertainty_envelope_claim_packet.yaml` defines issue lineage, execution boundary, allowed/forbidden claim modes, evidence tiers, scenario surface, fixed seeds, MPC-family planner roster, paired alpha arms, metrics, stop rules, row-status policy, artifact provenance, compact review outputs, and claim-update gates.
- `scripts/validation/check_issue_4232_uncertainty_envelope_claim_packet.py` validates the packet as `uncertainty-envelope-claim-packet.v1`.

New fail-closed blockers:
- missing `envelope_off_alpha_0` or `envelope_on_alpha_0`;
- negative alpha values;
- mismatched scenario/seed/horizon/timestep/kinematics across paired alpha arms;
- non-MPC planners entering envelope-effect claims unless marked diagnostic-only;
- missing forbidden claim language for conformal, real-world safety, deployment, generalized planner superiority, or paper/dissertation claims;
- treating fallback/degraded/not-available/failed/blocked rows as benchmark-strength success evidence;
- declaring raw JSONL, videos, logs, checkpoints, or caches as durable review outputs.

Compatibility impact: no runtime behavior changes; this adds a static benchmark-claim planning contract and tests only.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4232

## Domain-Aware Approval

- Required for PR: required
- Domains reviewed: evidence classification and benchmark interpretation gating.
- Status: waived
- Approval or blocker note: waiver based on maintainer issue #4232 implementation plan requesting a pre-registration packet and static validation before evidence production; no empirical result, benchmark conclusion, figure eligibility, or paper-facing claim is introduced by this PR.
- Validity checklist:
  - Target claim/hypothesis: no uncertainty-envelope performance or safety claim is made.
  - Comparator or split/evidence validity: paired alpha/control design is pre-registered only; no campaign output is interpreted.
  - Fallback/degraded exclusions: fallback, degraded, unavailable, failed, blocked, and diagnostic-only rows are excluded from benchmark-strength success evidence.
  - Claim boundary: no conformal calibration, real-world safety, deployment, generalized superiority, paper, or dissertation claim.
  - Implementation integrity vs experimental validity: tests prove packet gate behavior, not empirical envelope validity.

Validation:
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_4232_uncertainty_envelope_claim_packet.py --json` -> pass (`ok: true`, `alpha_arm_count: 5`, `planner_count: 3`, no benchmark run, no compute submit)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_issue_4232_uncertainty_envelope_claim_packet.py -q` -> pass (9 passed)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_issue_4232_uncertainty_envelope_claim_packet.py tests/validation/test_check_issue_4232_uncertainty_envelope_claim_packet.py` -> pass
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/check_issue_4232_uncertainty_envelope_claim_packet.py tests/validation/test_check_issue_4232_uncertainty_envelope_claim_packet.py` -> pass
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue4232_pr_body.md scripts/dev/pr_ready_check.sh` -> pass; freshness stamp `output/validation/pr_ready/issue-4232-pre-register-uncertainty-envelope-claim-evidence-scope.json`, head `b0bf7acc0e34bdb24b28fbf012dfb7ab4948ef1d`

Out of scope:
- no full benchmark campaign run;
- no Slurm/GPU submission;
- no paper/dissertation claim edits;
- no calibrated or conformal safety claim;
- no issue comment/state propagation because this run is not authorized to comment, and tracked transient queue-routing state is explicitly out of scope.

<details>
<summary>Governance and freshness notes</summary>

- Late issue refresh: before opening, issue #4232 and comments were reread through the GitHub REST API because `gh issue view --comments` is blocked by GitHub's deprecated Projects Classic GraphQL field. The latest comment observed was maintainer comment `4874374497`, updated `2026-07-03T08:37:50Z`; no newer guidance was observed.
- Duplicate check: no open PR matched issue #4232 or the pre-registration scope.
- Fragmentation guard: one related merged PR was observed in the last 24h, #4229, which is the parent runtime acceptance PR and not a #4232 guardrail/checker/packet-refresh series. This PR adds a nameable new capability for #4232: a pre-registration packet plus fail-closed validator.
- Raw outputs and campaign artifacts remain out of git; the packet only names the future compact `docs/context/evidence/` review bundle shape.

</details>
