### PR TITLE
Issue #3481: add HSFM anisotropic FoV fixture slice

### DIFF
--- a/robot_sf/sim/pedestrian_model_variants.py
+++ b/robot_sf/sim/pedestrian_model_variants.py
@@ -9,8 +9,14 @@ import numpy as np
 SOCIAL_FORCE_DEFAULT = "social_force_default"
 HSFM_TOTAL_FORCE_V1 = "hsfm_total_force_v1"
 HSFM_TTC_PREDICTIVE_V1 = "hsfm_ttc_predictive_v1"
+HSFM_ANISOTROPIC_FOV_V1 = "hsfm_anisotropic_fov_v1"
 SUPPORTED_PEDESTRIAN_MODELS = frozenset(
-    {SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1, HSFM_TTC_PREDICTIVE_V1}
+    {
+        SOCIAL_FORCE_DEFAULT,
+        HSFM_TOTAL_FORCE_V1,
+        HSFM_TTC_PREDICTIVE_V1,
+        HSFM_ANISOTROPIC_FOV_V1,
+    }
 )
 
 PYSF_POSITION_SLICE = slice(0, 2)
@@ -147,6 +153,115 @@ def _repulsion_direction(
     if velocity_norm > epsilon:
         return away_from_closing_velocity / velocity_norm
     return np.zeros(2, dtype=float)
+
+
+def _outside_fov_cone(
+    forward_vector: np.ndarray,
+    offset: np.ndarray,
+    *,
+    cone_half_angle_rad: float,
+    epsilon: float,
+) -> bool:
+    """Return whether an offset falls outside the heading cone."""
+    distance = float(np.linalg.norm(offset))
+    if distance <= epsilon:
+        return False
+    direction = offset / distance
+    cos_angle = float(np.clip(np.dot(forward_vector, direction), -1.0, 1.0))
+    return float(np.arccos(cos_angle)) > cone_half_angle_rad
+
+
+def _validate_anisotropic_fov_inputs(
+    positions: np.ndarray,
+    headings: np.ndarray,
+    *,
+    cone_half_angle_rad: float,
+    rear_weight: float,
+    epsilon: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return finite FoV input arrays or raise a clear validation error."""
+    position_array = np.asarray(positions, dtype=float)
+    heading_array = np.asarray(headings, dtype=float)
+    if position_array.ndim != 2 or position_array.shape[1] != 2:
+        raise ValueError("positions must have shape (N, 2)")
+    if heading_array.shape != (position_array.shape[0],):
+        raise ValueError("headings must have shape (N,) matching positions")
+    if not np.all(np.isfinite(position_array)) or not np.all(np.isfinite(heading_array)):
+        raise ValueError("positions and headings must be finite")
+    if not np.isfinite(cone_half_angle_rad) or not 0.0 <= cone_half_angle_rad <= np.pi:
+        raise ValueError("cone_half_angle_rad must be finite and within [0, pi]")
+    if not np.isfinite(rear_weight) or not 0.0 <= rear_weight <= 1.0:
+        raise ValueError("rear_weight must be finite and within [0, 1]")
+    if not np.isfinite(epsilon) or epsilon <= 0:
+        raise ValueError("epsilon must be finite and > 0")
+    return position_array, heading_array
+
+
+def anisotropic_fov_weights(
+    positions: np.ndarray,
+    headings: np.ndarray,
+    *,
+    cone_half_angle_rad: float,
+    rear_weight: float,
+    epsilon: float = 1e-9,
+) -> np.ndarray:
+    """Return per-pair FoV attenuation weights for actors outside each heading cone."""
+    position_array, heading_array = _validate_anisotropic_fov_inputs(
+        positions,
+        headings,
+        cone_half_angle_rad=cone_half_angle_rad,
+        rear_weight=rear_weight,
+        epsilon=epsilon,
+    )
+
+    pedestrian_count = position_array.shape[0]
+    weights = np.ones((pedestrian_count, pedestrian_count), dtype=float)
+    forward_vectors = np.column_stack((np.cos(heading_array), np.sin(heading_array)))
+
+    for i in range(pedestrian_count):
+        for j in range(pedestrian_count):
+            if i == j:
+                continue
+            if _outside_fov_cone(
+                forward_vectors[i],
+                position_array[j] - position_array[i],
+                cone_half_angle_rad=cone_half_angle_rad,
+                epsilon=epsilon,
+            ):
+                weights[i, j] = float(rear_weight)
+
+    return weights
+
+
+def anisotropic_fov_total_force(
+    positions: np.ndarray,
+    headings: np.ndarray,
+    total_forces: np.ndarray,
+    *,
+    cone_half_angle_rad: float,
+    rear_weight: float,
+    epsilon: float = 1e-9,
+) -> np.ndarray:
+    """Apply diagnostic FoV attenuation to aggregated forces behind each heading.
+
+    Returns:
+        Force array with one attenuation factor per pedestrian row.
+    """
+    force_array = np.asarray(total_forces, dtype=float)
+    position_array = np.asarray(positions, dtype=float)
+    if force_array.shape != position_array.shape:
+        raise ValueError("total_forces must have shape (N, 2) matching positions")
+    weights = anisotropic_fov_weights(
+        position_array,
+        headings,
+        cone_half_angle_rad=cone_half_angle_rad,
+        rear_weight=rear_weight,
+        epsilon=epsilon,
+    )
+    if position_array.shape[0] == 0:
+        return force_array.copy()
+    per_actor_weight = np.min(weights, axis=1)
+    return force_array * np.expand_dims(per_actor_weight, axis=-1)
 
 
 def ttc_predictive_repulsion(

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -6,6 +6,7 @@ from math import ceil, isfinite
 from robot_sf.ped_npc.adversial_ped_force import AdversarialPedForceConfig
 from robot_sf.ped_npc.ped_robot_force import PedRobotForceConfig
 from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_ANISOTROPIC_FOV_V1,
     HSFM_TTC_PREDICTIVE_V1,
     normalize_pedestrian_model,
 )
@@ -60,6 +61,50 @@ def _pedestrian_model_ttc_config(
     return ttc_config
 
 
+@dataclass(frozen=True)
+class AnisotropicFovConfig:
+    """Opt-in anisotropic field-of-view attenuation parameters."""
+
+    enabled: bool = False
+    cone_half_angle_rad: float = 1.5707963267948966
+    rear_weight: float = 0.1
+
+    def __post_init__(self) -> None:
+        """Validate finite bounded FoV parameters."""
+        if (
+            not isfinite(self.cone_half_angle_rad)
+            or not 0 <= self.cone_half_angle_rad <= 3.141592653589793
+        ):
+            raise ValueError("anisotropic_fov.cone_half_angle_rad must be within [0, pi]")
+        if not isfinite(self.rear_weight) or not 0 <= self.rear_weight <= 1:
+            raise ValueError("anisotropic_fov.rear_weight must be within [0, 1]")
+
+
+def _normalize_anisotropic_fov_config(
+    value: AnisotropicFovConfig | dict,
+) -> AnisotropicFovConfig:
+    """Return validated anisotropic FoV config."""
+    if isinstance(value, AnisotropicFovConfig):
+        return value
+    if isinstance(value, dict):
+        return AnisotropicFovConfig(**value)
+    raise ValueError("anisotropic_fov must be an AnisotropicFovConfig or dict")
+
+
+def _pedestrian_model_anisotropic_fov_config(
+    pedestrian_model: str,
+    fov_config: AnisotropicFovConfig,
+) -> AnisotropicFovConfig:
+    """Enable anisotropic FoV provenance when selected via pedestrian model.
+
+    Returns:
+        Updated FoV config with ``enabled=True`` when the selector activates it.
+    """
+    if pedestrian_model == HSFM_ANISOTROPIC_FOV_V1 and not fov_config.enabled:
+        return replace(fov_config, enabled=True)
+    return fov_config
+
+
 @dataclass
 class SimulationSettings:
     """
@@ -80,6 +125,9 @@ class SimulationSettings:
 
     ttc_predictive_force: TtcPredictiveForceConfig = field(default_factory=TtcPredictiveForceConfig)
     """TTC predictive force settings used by ``hsfm_ttc_predictive_v1``."""
+
+    anisotropic_fov: AnisotropicFovConfig = field(default_factory=AnisotropicFovConfig)
+    """Anisotropic field-of-view settings used by ``hsfm_anisotropic_fov_v1``."""
 
     difficulty: int = 0
     """Difficulty level"""
@@ -160,6 +208,11 @@ class SimulationSettings:
         self.ttc_predictive_force = _pedestrian_model_ttc_config(
             self.pedestrian_model,
             self.ttc_predictive_force,
+        )
+        self.anisotropic_fov = _normalize_anisotropic_fov_config(self.anisotropic_fov)
+        self.anisotropic_fov = _pedestrian_model_anisotropic_fov_config(
+            self.pedestrian_model,
+            self.anisotropic_fov,
         )
         # Check that the maximum number of pedestrians per group is positive
         if self.max_peds_per_group <= 0:

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -52,8 +52,10 @@ from robot_sf.ped_npc.ped_robot_force import PedRobotForce, PedRobotForceConfig
 from robot_sf.ped_npc.ped_zone import sample_zone
 from robot_sf.robot.robot_state import Robot
 from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_ANISOTROPIC_FOV_V1,
     HSFM_TOTAL_FORCE_V1,
     HSFM_TTC_PREDICTIVE_V1,
+    anisotropic_fov_total_force,
     normalize_pedestrian_model,
     step_hsfm_total_force,
     ttc_predictive_repulsion,
@@ -250,7 +252,11 @@ class Simulator:
 
     def _step_pedestrians(self, ped_forces: np.ndarray, groups: list[list[int]]) -> None:
         """Advance pedestrians through the configured pedestrian-model implementation."""
-        if self.pedestrian_model not in {HSFM_TOTAL_FORCE_V1, HSFM_TTC_PREDICTIVE_V1}:
+        if self.pedestrian_model not in {
+            HSFM_TOTAL_FORCE_V1,
+            HSFM_TTC_PREDICTIVE_V1,
+            HSFM_ANISOTROPIC_FOV_V1,
+        }:
             self.pysf_sim.peds.step(ped_forces, groups)
             self.ped_headings = self._headings_from_current_ped_velocities()
             return
@@ -276,6 +282,15 @@ class Simulator:
                     force_scale=ttc_config.force_scale,
                     max_force=ttc_config.max_force,
                 )
+        elif self.pedestrian_model == HSFM_ANISOTROPIC_FOV_V1:
+            fov_config = self.config.anisotropic_fov
+            ped_forces = anisotropic_fov_total_force(
+                current_state[:, PYSF_POSITION_SLICE],
+                self.ped_headings,
+                ped_forces,
+                cone_half_angle_rad=fov_config.cone_half_angle_rad,
+                rear_weight=fov_config.rear_weight,
+            )
         next_state, self.ped_headings = step_hsfm_total_force(
             current_state,
             ped_forces,

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -32,8 +32,8 @@ from robot_sf.nav.svg_map_parser import convert_map
 from robot_sf.robot.bicycle_drive import BicycleDriveSettings
 from robot_sf.robot.differential_drive import DifferentialDriveSettings
 from robot_sf.robot.holonomic_drive import HolonomicDriveSettings
-from robot_sf.sim.pedestrian_model_variants import HSFM_TTC_PREDICTIVE_V1
-from robot_sf.sim.sim_config import TtcPredictiveForceConfig
+from robot_sf.sim.pedestrian_model_variants import HSFM_ANISOTROPIC_FOV_V1, HSFM_TTC_PREDICTIVE_V1
+from robot_sf.sim.sim_config import AnisotropicFovConfig, TtcPredictiveForceConfig
 
 _MAP_REGISTRY_ENV = "ROBOT_SF_MAP_REGISTRY"
 _MAP_REGISTRY_PATH = Path("maps/registry.yaml")
@@ -2086,10 +2086,21 @@ def _set_simulation_override_attr(
         if overrides.get("pedestrian_model") == HSFM_TTC_PREDICTIVE_V1:
             ttc_force_overrides["enabled"] = True
         setattr(config.sim_config, attr, TtcPredictiveForceConfig(**ttc_force_overrides))
+    elif attr == "anisotropic_fov" and isinstance(overrides[attr], Mapping):
+        fov_overrides = dict(overrides[attr])
+        if overrides.get("pedestrian_model") == HSFM_ANISOTROPIC_FOV_V1:
+            fov_overrides["enabled"] = True
+        setattr(config.sim_config, attr, AnisotropicFovConfig(**fov_overrides))
     elif attr == "pedestrian_model" and overrides[attr] == HSFM_TTC_PREDICTIVE_V1:
         setattr(config.sim_config, attr, overrides[attr])
         config.sim_config.ttc_predictive_force = replace(
             config.sim_config.ttc_predictive_force,
+            enabled=True,
+        )
+    elif attr == "pedestrian_model" and overrides[attr] == HSFM_ANISOTROPIC_FOV_V1:
+        setattr(config.sim_config, attr, overrides[attr])
+        config.sim_config.anisotropic_fov = replace(
+            config.sim_config.anisotropic_fov,
             enabled=True,
         )
     elif attr == "pedestrian_uncertainty_envelope_enabled":
@@ -2137,6 +2148,7 @@ def _apply_simulation_overrides(
         "goal_radius",
         "pedestrian_model",
         "ttc_predictive_force",
+        "anisotropic_fov",
         "route_spawn_distribution",
         "route_spawn_jitter_frac",
         "route_spawn_seed",

--- a/tests/sim/test_hsfm_total_force_model.py
+++ b/tests/sim/test_hsfm_total_force_model.py
@@ -8,9 +8,12 @@ import numpy as np
 import pytest
 
 from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_ANISOTROPIC_FOV_V1,
     HSFM_TOTAL_FORCE_V1,
     HSFM_TTC_PREDICTIVE_V1,
     SOCIAL_FORCE_DEFAULT,
+    anisotropic_fov_total_force,
+    anisotropic_fov_weights,
     heading_from_total_force,
     normalize_pedestrian_model,
     step_hsfm_total_force,
@@ -23,7 +26,7 @@ from robot_sf.training.scenario_loader import build_robot_config_from_scenario
 class _FakePedState:
     def __init__(self, state: np.ndarray) -> None:
         self.state = state
-        self.max_speeds = np.array([10.0], dtype=float)
+        self.max_speeds = np.full(state.shape[0], 10.0, dtype=float)
         self.updated_state: np.ndarray | None = None
         self.updated_groups: list[list[int]] | None = None
 
@@ -45,6 +48,42 @@ def test_heading_from_total_force_uses_combined_force_vector() -> None:
 def test_heading_from_total_force_preserves_heading_for_zero_force() -> None:
     """A zero total-force vector keeps the previous heading stable."""
     assert heading_from_total_force(1.23, np.zeros(2)) == pytest.approx(1.23)
+
+
+def test_anisotropic_fov_weights_attenuate_behind_heading() -> None:
+    """The opt-in FoV helper down-weights actors outside the heading cone."""
+    positions = np.array([[0.0, 0.0], [1.0, 0.0], [-1.0, 0.0]], dtype=float)
+    headings = np.array([0.0, np.pi, 0.0], dtype=float)
+
+    weights = anisotropic_fov_weights(
+        positions,
+        headings,
+        cone_half_angle_rad=np.pi / 2,
+        rear_weight=0.1,
+    )
+
+    assert weights[0, 1] == pytest.approx(1.0)
+    assert weights[0, 2] == pytest.approx(0.1)
+    assert weights[1, 0] == pytest.approx(1.0)
+    assert weights[1, 2] == pytest.approx(1.0)
+
+
+def test_anisotropic_fov_total_force_attenuates_rear_actor_fixture() -> None:
+    """Diagnostic fixture: a rear actor reduces the aggregate force for that pedestrian."""
+    positions = np.array([[0.0, 0.0], [-1.0, 0.0]], dtype=float)
+    headings = np.array([0.0, 0.0], dtype=float)
+    total_forces = np.array([[2.0, 0.0], [2.0, 0.0]], dtype=float)
+
+    adjusted = anisotropic_fov_total_force(
+        positions,
+        headings,
+        total_forces,
+        cone_half_angle_rad=np.pi / 2,
+        rear_weight=0.25,
+    )
+
+    assert adjusted[0].tolist() == pytest.approx([0.5, 0.0])
+    assert adjusted[1].tolist() == pytest.approx([2.0, 0.0])
 
 
 def test_step_hsfm_total_force_caps_velocity_and_updates_heading_from_force() -> None:
@@ -95,6 +134,9 @@ def test_pedestrian_model_selector_normalizes_and_rejects_unknown_values() -> No
     assert SimulationSettings(pedestrian_model=HSFM_TTC_PREDICTIVE_V1).pedestrian_model == (
         HSFM_TTC_PREDICTIVE_V1
     )
+    assert SimulationSettings(pedestrian_model=HSFM_ANISOTROPIC_FOV_V1).pedestrian_model == (
+        HSFM_ANISOTROPIC_FOV_V1
+    )
     assert normalize_pedestrian_model(None) == SOCIAL_FORCE_DEFAULT
     with pytest.raises(ValueError, match="Unsupported pedestrian_model"):
         SimulationSettings(pedestrian_model="unknown_model")
@@ -108,3 +150,53 @@ def test_scenario_simulation_config_can_select_hsfm_total_force(tmp_path) -> Non
     )
 
     assert config.sim_config.pedestrian_model == HSFM_TOTAL_FORCE_V1
+
+
+def test_scenario_anisotropic_fov_selector_marks_config_enabled(tmp_path) -> None:
+    """Selecting the FoV model records active anisotropic provenance."""
+    config = build_robot_config_from_scenario(
+        {
+            "simulation_config": {
+                "pedestrian_model": HSFM_ANISOTROPIC_FOV_V1,
+                "anisotropic_fov": {"cone_half_angle_rad": 1.0, "rear_weight": 0.25},
+            }
+        },
+        scenario_path=tmp_path / "scenario.yaml",
+    )
+
+    assert config.sim_config.pedestrian_model == HSFM_ANISOTROPIC_FOV_V1
+    assert config.sim_config.anisotropic_fov.enabled is True
+    assert config.sim_config.anisotropic_fov.cone_half_angle_rad == pytest.approx(1.0)
+    assert config.sim_config.anisotropic_fov.rear_weight == pytest.approx(0.25)
+
+
+def test_simulator_hsfm_anisotropic_fov_one_step_smoke_is_finite_and_deterministic() -> None:
+    """The FoV selector applies deterministic rear attenuation before HSFM stepping."""
+    state = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.5],
+            [-1.0, 0.0, 0.0, 0.0, -10.0, 0.0, 0.5],
+        ],
+        dtype=float,
+    )
+    peds = _FakePedState(state)
+    sim = object.__new__(Simulator)
+    sim.pedestrian_model = HSFM_ANISOTROPIC_FOV_V1
+    sim.pysf_sim = SimpleNamespace(peds=peds)
+    sim.config = SimulationSettings(
+        pedestrian_model=HSFM_ANISOTROPIC_FOV_V1,
+        anisotropic_fov={"cone_half_angle_rad": np.pi / 2, "rear_weight": 0.25},
+        time_per_step_in_secs=0.1,
+    )
+    sim.ped_headings = np.array([0.0, 0.0], dtype=float)
+
+    sim._step_pedestrians(np.array([[2.0, 0.0], [2.0, 0.0]], dtype=float), [[0], [1]])
+
+    assert peds.updated_groups == [[0], [1]]
+    assert peds.updated_state is state
+    assert np.all(np.isfinite(state))
+    assert np.all(np.isfinite(sim.ped_headings))
+    assert state[0, 2] == pytest.approx(0.05)
+    assert state[0, 0] == pytest.approx(0.005)
+    assert state[1, 2] == pytest.approx(0.2)
+    assert state[1, 0] == pytest.approx(-0.98)


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds opt-in `hsfm_anisotropic_fov_v1`, an `anisotropic_fov` config block, scenario-loader support, and deterministic unit/fixture coverage for anisotropic field-of-view attenuation in the HSFM total-force path.

Why now: issue #3481 remains open after #4202; the latest parent comment says TTC is complete and anisotropic FoV/alignment plus lateral-sliding/freeze fixtures remain uncovered. This PR delivers the next nameable progression capability: an opt-in anisotropic FoV fixture slice.

Claim boundary: diagnostic/prototype force-law fixture only. It does not change the default pedestrian model, does not claim calibrated realism, does not promote benchmark-strength evidence, and does not make paper/dissertation claims.

Required validation: focused simulator tests plus Ruff on touched paths; final PR readiness was requested for simulator-runtime changes.

Remaining blocker: the current PySocialForce seam exposes aggregated total forces, so this slice attenuates aggregated HSFM total force by per-actor FoV rather than isolating only pedestrian-pedestrian pairwise repulsion. Narrow-passage lateral-sliding and bottleneck freeze/deadlock benchmark evidence remain follow-up work.

## Contract delta

- New selector: `hsfm_anisotropic_fov_v1`.
- New config: `SimulationSettings.anisotropic_fov` / YAML `simulation_config.anisotropic_fov` with:
  - `enabled: bool = false`, auto-enabled when the selector is used.
  - `cone_half_angle_rad: float = pi / 2`, validated within `[0, pi]`.
  - `rear_weight: float = 0.1`, validated within `[0, 1]`.
- New pure helpers: `anisotropic_fov_weights()` and `anisotropic_fov_total_force()`.
- Compatibility impact: `social_force_default`, `hsfm_total_force_v1`, and `hsfm_ttc_predictive_v1` remain opt-in-compatible and unchanged by default.
- Fail-closed behavior: unsupported selector names still raise; invalid FoV config values raise during config construction/scenario loading.

## Issue

Closes no issue. Progresses #3481: https://github.com/ll7/robot_sf_ll7/issues/3481

## Scope summary

In scope: opt-in anisotropic FoV selector/config/scenario surface and deterministic CPU fixture coverage.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no calibrated-realism claim, no default pedestrian-model replacement.

## Validation

- `uv run pytest tests/sim/test_hsfm_total_force_model.py tests/sim/test_ttc_predictive_pedestrian_model.py -q` -> passed, `22 passed`.
- `uv run ruff check robot_sf/sim/pedestrian_model_variants.py robot_sf/sim/sim_config.py robot_sf/sim/simulator.py robot_sf/training/scenario_loader.py tests/sim/test_hsfm_total_force_model.py tests/sim/test_ttc_predictive_pedestrian_model.py` -> passed.
- `PR_READY_PR_BODY_FILE=$ARTIFACT_DIR/PR_BODY.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; clean-tree stamp at `output/validation/pr_ready/issue-3481-add-hsfm-anisotropic-fov-fixture-slice.json`, core lane `1770 passed`, optional-extra lane completed, final freshness `fresh: true`.

## Downstream propagation

Issue #3481 is high-churn enough that the PR body records the slice and remaining work; no issue comment was posted from this worker because authorization explicitly sets `comment_issue_or_pr: false`.

<details>
<summary>Appendix</summary>

Forbidden actions confirmed: no compute submission, no merge, no release, no delete.

Fragmentation guard: only #4202 is visible as a merged #3481 PR in the last 24h, so the two-or-more micro-guard threshold does not block this progression slice. This PR adds the nameable capability `hsfm_anisotropic_fov_v1` rather than another checker-only micro-guard.

Late-guidance handling: live issue comments were read at start through REST because `gh issue view --comments` is blocked by GitHub classic-project GraphQL deprecation. Issue #3481 was re-read immediately before PR creation via REST; no maintainer comments newer than the run start were present. Latest comment remains `2026-07-03T04:10:45Z`.

</details>
