### PR TITLE
Issue #3556: add ScenarioBelief seed-sufficiency screening handoff

### DIFF
--- a/robot_sf/benchmark/scenario_belief_screening.py
+++ b/robot_sf/benchmark/scenario_belief_screening.py
@@ -42,6 +42,47 @@ def _check(passed: bool, detail: str) -> dict[str, Any]:
     return {"passed": bool(passed), "detail": detail}
 
 
+def build_seed_sufficiency_handoff(
+    *,
+    campaign_output_root: Path | str = "output/issue_3556_belief_mode_campaign",
+    output_dir: Path | str = "output/issue_3556_seed_sufficiency",
+    campaign_id: str = "issue_3556",
+    advisory_seed_threshold: int | None = None,
+) -> dict[str, Any]:
+    """Build the follow-up command for escalating smoke output to seed sufficiency.
+
+    The command is provenance for the next empirical step only. The screening
+    module remains pure and does not inspect campaign artifacts or promote the
+    current smoke seed fixture to seed-sufficient evidence.
+
+    Returns:
+        JSON-serializable handoff status, command argv, and claim boundary.
+    """
+    command = [
+        "uv",
+        "run",
+        "python",
+        "scripts/tools/analyze_seed_sufficiency.py",
+        "--campaign-output-root",
+        str(campaign_output_root),
+        "--campaign-id",
+        campaign_id,
+        "--output-dir",
+        str(output_dir),
+    ]
+    if advisory_seed_threshold is not None:
+        command.extend(["--advisory-seed-threshold", str(advisory_seed_threshold)])
+
+    return {
+        "status": "handoff_only",
+        "command": command,
+        "claim_boundary": (
+            "Exporter only: run after durable campaign outputs exist; this field is not "
+            "seed-sufficiency evidence."
+        ),
+    }
+
+
 def build_input_screening_report(
     *,
     scenarios: Iterable[Mapping[str, Any]],
@@ -120,6 +161,9 @@ def build_input_screening_report(
         "seeds": list(seeds),
         "required_modes": list(required_modes),
         "fov_degrees": fov_degrees,
+        "seed_sufficiency_handoff": build_seed_sufficiency_handoff(
+            advisory_seed_threshold=len(seeds) if seeds_pinned else None
+        ),
         "checks": checks,
         "failed_checks": failed,
         "claim_boundary": (
@@ -248,6 +292,7 @@ def build_screening_report(
         "seeds": input_report["seeds"],
         "required_modes": input_report["required_modes"],
         "fov_degrees": input_report["fov_degrees"],
+        "seed_sufficiency_handoff": input_report["seed_sufficiency_handoff"],
         "checks": checks,
         "failed_checks": failed,
         "decision": decision,

--- a/tests/benchmark/test_scenario_belief_screening.py
+++ b/tests/benchmark/test_scenario_belief_screening.py
@@ -10,6 +10,7 @@ import yaml
 from robot_sf.benchmark.scenario_belief_screening import (
     build_input_screening_report,
     build_screening_report,
+    build_seed_sufficiency_handoff,
     classify_screened_decision,
 )
 from robot_sf.benchmark.scenario_schema import (
@@ -87,6 +88,22 @@ def test_screening_input_report_requires_out_of_fov_sidecar_contract() -> None:
     assert report["ready"] is True
     assert report["scenario_ids"] == ["issue_3556_near_safe_occlusion_bearing_crossing"]
     assert report["checks"]["out_of_fov_sidecar_contract"]["passed"] is True
+    handoff = report["seed_sufficiency_handoff"]
+    assert handoff["status"] == "handoff_only"
+    assert handoff["command"] == [
+        "uv",
+        "run",
+        "python",
+        "scripts/tools/analyze_seed_sufficiency.py",
+        "--campaign-output-root",
+        "output/issue_3556_belief_mode_campaign",
+        "--campaign-id",
+        "issue_3556",
+        "--output-dir",
+        "output/issue_3556_seed_sufficiency",
+        "--advisory-seed-threshold",
+        "3",
+    ]
 
     no_visibility = [dict(scenarios[0], observation_visibility={"enabled": False})]
     blocked = build_input_screening_report(
@@ -122,6 +139,33 @@ def test_screened_decision_uses_only_issue_allowed_labels() -> None:
         oracle_near_safe_threshold=0.25,
     )
     assert revise["decision"] == "revise"
+
+
+def test_seed_sufficiency_handoff_command_is_export_only() -> None:
+    """Seed-sufficiency escalation is a command export, not smoke evidence."""
+    handoff = build_seed_sufficiency_handoff(
+        campaign_output_root="output/custom_campaigns",
+        output_dir="output/custom_seed_sufficiency",
+        campaign_id="issue_3556_near_safe",
+        advisory_seed_threshold=20,
+    )
+
+    assert handoff["status"] == "handoff_only"
+    assert handoff["command"] == [
+        "uv",
+        "run",
+        "python",
+        "scripts/tools/analyze_seed_sufficiency.py",
+        "--campaign-output-root",
+        "output/custom_campaigns",
+        "--campaign-id",
+        "issue_3556_near_safe",
+        "--output-dir",
+        "output/custom_seed_sufficiency",
+        "--advisory-seed-threshold",
+        "20",
+    ]
+    assert "not seed-sufficiency evidence" in handoff["claim_boundary"]
 
 
 def test_input_screening_treats_null_scenario_fov_as_default() -> None:
@@ -202,6 +246,7 @@ def test_final_screening_report_propagates_decision_and_provenance() -> None:
     assert report["decision"]["decision"] == "revise"
     assert report["decision"]["oracle_near_safe_threshold"] == 0.25
     assert report["scenario_ids"] == ["issue_3556_near_safe_occlusion_bearing_crossing"]
+    assert report["seed_sufficiency_handoff"]["status"] == "handoff_only"
     assert set(report["allowed_decision_labels"]) == {
         "revise",
         "retention_dominates",


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a pure `seed_sufficiency_handoff` report field to the issue #3556 ScenarioBelief screening reports, plus focused tests that pin the exported `uv run python scripts/tools/analyze_seed_sufficiency.py` command.

Why now: the July 2 maintainer plan asked for a seed-sufficiency handoff command exporter so the small near-safe smoke can be escalated without changing the evidence schema.

Claim boundary: this is report/schema plumbing only. It does not run a full benchmark campaign, does not submit Slurm/GPU work, and does not make paper/dissertation or calibrated-perception claim edits.

Required validation: focused #3556 screening/runner tests, ruff on the touched runner/module/test surfaces, and repo PR readiness from the committed branch.

Remaining blocker: durable seed-sufficiency evidence still requires running the exported command after durable campaign outputs exist.

## Contract delta

- New report field: `seed_sufficiency_handoff`.
- New helper: `build_seed_sufficiency_handoff(...)`.
- New fail-closed blockers: none.
- Compatibility impact: additive JSON field only; existing decision labels and readiness checks are unchanged.
- New capability toward #3556: report-level seed-sufficiency handoff exporter for the ScenarioBelief near-safe screening contract.

## Linked Issue

Refs #3556

Issue URL: https://github.com/ll7/robot_sf_ll7/issues/3556

## Validation / Proof

- `uv run pytest tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py tests/benchmark/test_scenario_belief_screening.py -q` - passed, 18 tests.
- `uv run ruff check scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py robot_sf/benchmark/scenario_belief_screening.py tests/benchmark/test_scenario_belief_screening.py` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3556/pr_body.md scripts/dev/pr_ready_check.sh` - passed; stamp `output/validation/pr_ready/issue-3556-add-scenariobelief-near-safe-screening-report.json`, head `42655e6c17b9473d6786c3c9cbe06050b5d4b158`.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No planner default changes.
- No paper/dissertation or calibrated-perception claim edits.
- No suppression of oracle-unsafe results.

## Downstream Propagation

- Parent issue updated: no, `comment_issue_or_pr` authorization is false for this run.
- Claim map / benchmark report updated: no, no benchmark result changed.
- Leaderboard / artifact catalog updated: no, no durable campaign artifact produced.
- Registry or config index updated: no, no registry/config ownership changed.
- Context index / memory note updated: no, this is an additive report schema field with focused tests.
- Follow-up issue opened deferred propagation: no, existing issue #3556 remains the parent for the empirical escalation.
- Not applicable because: the PR body records the delivered slice and remaining blocker; no external issue comment was authorized.

<details>
<summary>Governance Appendix</summary>

Research Result Guidance:
- Target claim / hypothesis / blocker this should affect: removes a report-schema blocker for escalating #3556 near-safe smoke outputs to seed-sufficiency analysis.
- Comparator or baseline: NA, no empirical comparison is run here.
- Evidence tier: targeted support/schema test.
- Result classification: blocker-resolution.
- Decision stop rule: exported command is only usable after durable campaign outputs exist.
- Parent issue / synthesis surface: #3556.

Falsification / Non-Transfer Check:
- Did mechanism activate? NA, no campaign was run.
- Result route: continue; next empirical action remains campaign output plus seed-sufficiency analysis.

Next Empirical Action:
- Rerun needed: yes, outside this PR, after durable real-runner outputs exist.
- Extractor analysis tool needed: no new tool; exported command uses `scripts/tools/analyze_seed_sufficiency.py`.
- Artifact missing unavailable: durable #3556 campaign output root.
- Stop / revise / continue decision: continue once durable outputs exist.

Risks / Rollout:
- Compatibility risks: low; additive field.
- Failure modes: downstream consumers that hard-code exact report keys should ignore the new field or update snapshots.
- Rollback fallback plan: remove the helper, field, and tests.

Reviewer Notes:
- Verify the command is treated as handoff-only and not as evidence that the three-seed smoke is seed-sufficient.

</details>
