### PR TITLE
Issue #3813: add sustained-flow revival gate

### DIFF
--- a/robot_sf/benchmark/sustained_flow_revival_gate.py
+++ b/robot_sf/benchmark/sustained_flow_revival_gate.py
@@ -162,7 +162,12 @@ def _interaction_exposure_complete(report: Mapping[str, Any]) -> bool:
     for run in runs or ():
         available_fields.update(_string_sequence(run.get("available_columns")))
         available_fields.update(_string_sequence(run.get("computed_fields")))
-    if available_fields and not set(REQUIRED_INTERACTION_EXPOSURE_FIELDS) <= available_fields:
+    # Fail closed: a report that only asserts a "complete" status string without
+    # positively declaring the required exposure fields (via available_columns/
+    # computed_fields at top level or per run) is treated as INCOMPLETE, so a
+    # degraded upstream artifact cannot pass the gate to revive/stop. Absent
+    # field-listing is not proof of completeness.
+    if not set(REQUIRED_INTERACTION_EXPOSURE_FIELDS) <= available_fields:
         return False
 
     return True

--- a/robot_sf/benchmark/sustained_flow_revival_gate.py
+++ b/robot_sf/benchmark/sustained_flow_revival_gate.py
@@ -1,0 +1,230 @@
+"""Revival gate for issue #3813 sustained-flow follow-up work.
+
+The gate consumes h600 interaction-exposure evidence from issue #3810 and decides whether
+sustained-flow work should be revived, stopped as not load-bearing, or deferred until the
+evidence is complete enough to judge.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SUSTAINED_FLOW_REVIVAL_GATE_SCHEMA_VERSION = "issue_3813.sustained_flow_revival_gate.v1"
+
+DECISION_REVIVE = "revive_sustained_flow"
+DECISION_STOP = "stop_not_load_bearing"
+DECISION_DEFER = "defer_needs_more_evidence"
+REVIVAL_GATE_DECISIONS = (DECISION_REVIVE, DECISION_STOP, DECISION_DEFER)
+
+DEFAULT_H600_INTERACTION_EXPOSURE_EVIDENCE = Path(
+    "docs/context/evidence/issue_3810_h600_interpretation_2026-07/"
+    "interaction_exposure_diagnostics.json"
+)
+
+REQUIRED_INTERACTION_EXPOSURE_FIELDS = (
+    "interaction_exposure_share",
+    "robot_motion_share_before_first_clearance",
+    "first_clearance_step",
+    "low_exposure_success",
+)
+
+_COMPLETE_EXPOSURE_STATUSES = {"computed", "ok", "complete"}
+
+
+@dataclass(frozen=True, slots=True)
+class SustainedFlowRevivalGateReport:
+    """Machine-readable issue #3813 revival-gate decision."""
+
+    schema_version: str
+    issue: int
+    source_issue: int
+    decision: str
+    evidence_status: str
+    interaction_exposure_evidence_path: str
+    claim_impact_evidence_path: str | None
+    required_interaction_exposure_fields: tuple[str, ...]
+    affected_rows: tuple[dict[str, Any], ...]
+    claim_decisions_changed: bool | None
+    blocking_reasons: tuple[str, ...]
+    claim_boundary: str
+    next_action: str
+
+    @property
+    def ready_for_revived_implementation(self) -> bool:
+        """Return whether the gate authorizes new sustained-flow implementation work."""
+
+        return self.decision == DECISION_REVIVE
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation of the report."""
+
+        payload = asdict(self)
+        payload["ready_for_revived_implementation"] = self.ready_for_revived_implementation
+        return payload
+
+
+class SustainedFlowRevivalGateError(ValueError):
+    """Raised when the revival-gate inputs are structurally invalid."""
+
+
+def build_sustained_flow_revival_gate_report(
+    interaction_exposure: Mapping[str, Any],
+    *,
+    interaction_exposure_evidence_path: str | Path = DEFAULT_H600_INTERACTION_EXPOSURE_EVIDENCE,
+    claim_impact: Mapping[str, Any] | None = None,
+    claim_impact_evidence_path: str | Path | None = None,
+) -> SustainedFlowRevivalGateReport:
+    """Classify whether issue #3813 sustained-flow work should be revived.
+
+    Args:
+        interaction_exposure: Parsed h600 interaction-exposure diagnostic evidence.
+        interaction_exposure_evidence_path: Provenance path for the diagnostic evidence.
+        claim_impact: Optional parsed report describing whether wait-it-out exclusions or
+            caveats change claim decisions.
+        claim_impact_evidence_path: Provenance path for ``claim_impact`` when supplied.
+
+    Returns:
+        A stable report with one of the three issue-authorized gate decisions.
+    """
+
+    if not isinstance(interaction_exposure, Mapping):
+        raise SustainedFlowRevivalGateError("interaction exposure evidence must be a mapping")
+    if claim_impact is not None and not isinstance(claim_impact, Mapping):
+        raise SustainedFlowRevivalGateError("claim impact evidence must be a mapping")
+
+    blocking_reasons: list[str] = []
+    if not _interaction_exposure_complete(interaction_exposure):
+        blocking_reasons.append("interaction-exposure diagnostics missing computed required fields")
+
+    affected_rows = _affected_rows(interaction_exposure, claim_impact)
+    if not affected_rows:
+        blocking_reasons.append("affected planner/scenario rows not supplied")
+
+    claim_decisions_changed = _claim_decisions_changed(interaction_exposure, claim_impact)
+    if claim_decisions_changed is None:
+        blocking_reasons.append("claim-decision impact not supplied")
+
+    if blocking_reasons:
+        decision = DECISION_DEFER
+        evidence_status = "diagnostic-only-incomplete"
+        next_action = (
+            "retain h600 rows with interaction-exposure fields plus claim-impact comparison"
+        )
+    elif claim_decisions_changed:
+        decision = DECISION_REVIVE
+        evidence_status = "diagnostic-gate-complete"
+        next_action = "start opt-in sustained-flow scenario schema prototype"
+    else:
+        decision = DECISION_STOP
+        evidence_status = "diagnostic-gate-complete"
+        next_action = "record sustained-flow as not load-bearing for current h600 evidence"
+
+    return SustainedFlowRevivalGateReport(
+        schema_version=SUSTAINED_FLOW_REVIVAL_GATE_SCHEMA_VERSION,
+        issue=3813,
+        source_issue=3810,
+        decision=decision,
+        evidence_status=evidence_status,
+        interaction_exposure_evidence_path=Path(interaction_exposure_evidence_path).as_posix(),
+        claim_impact_evidence_path=(
+            Path(claim_impact_evidence_path).as_posix()
+            if claim_impact_evidence_path is not None
+            else None
+        ),
+        required_interaction_exposure_fields=REQUIRED_INTERACTION_EXPOSURE_FIELDS,
+        affected_rows=affected_rows,
+        claim_decisions_changed=claim_decisions_changed,
+        blocking_reasons=tuple(blocking_reasons),
+        claim_boundary=(
+            "Revival gate only; no sustained-flow runtime implementation, benchmark campaign, "
+            "default benchmark conclusion, or paper-facing claim is changed."
+        ),
+        next_action=next_action,
+    )
+
+
+def _interaction_exposure_complete(report: Mapping[str, Any]) -> bool:
+    missing_fields = set(_string_sequence(report.get("missing_required_fields")))
+    if missing_fields:
+        return False
+
+    runs = _run_mappings(report)
+    if runs is not None and not _runs_complete(runs):
+        return False
+    if runs is None and str(report.get("status", "")).strip() not in _COMPLETE_EXPOSURE_STATUSES:
+        return False
+
+    available_fields = set(_string_sequence(report.get("available_columns")))
+    available_fields.update(_string_sequence(report.get("computed_fields")))
+    for run in runs or ():
+        available_fields.update(_string_sequence(run.get("available_columns")))
+        available_fields.update(_string_sequence(run.get("computed_fields")))
+    if available_fields and not set(REQUIRED_INTERACTION_EXPOSURE_FIELDS) <= available_fields:
+        return False
+
+    return True
+
+
+def _run_mappings(report: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...] | None:
+    runs = report.get("runs")
+    if not isinstance(runs, Sequence) or isinstance(runs, (str, bytes)):
+        return None
+    return tuple(run for run in runs if isinstance(run, Mapping))
+
+
+def _runs_complete(runs: tuple[Mapping[str, Any], ...]) -> bool:
+    if not runs:
+        return False
+    for run in runs:
+        if set(_string_sequence(run.get("missing_required_fields"))):
+            return False
+        status = str(run.get("status", "")).strip()
+        if status and status not in _COMPLETE_EXPOSURE_STATUSES:
+            return False
+    return True
+
+
+def _affected_rows(
+    interaction_exposure: Mapping[str, Any],
+    claim_impact: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], ...]:
+    for source in (claim_impact, interaction_exposure):
+        if source is None:
+            continue
+        for key in (
+            "affected_rows",
+            "affected_planner_scenario_rows",
+            "affected_planner_rows",
+        ):
+            rows = source.get(key)
+            if isinstance(rows, Sequence) and not isinstance(rows, (str, bytes)):
+                return tuple(dict(row) for row in rows if isinstance(row, Mapping))
+    return ()
+
+
+def _claim_decisions_changed(
+    interaction_exposure: Mapping[str, Any],
+    claim_impact: Mapping[str, Any] | None,
+) -> bool | None:
+    for source in (claim_impact, interaction_exposure):
+        if source is None:
+            continue
+        for key in ("claim_decisions_changed", "claim_decision_changed"):
+            value = source.get(key)
+            if isinstance(value, bool):
+                return value
+        decision_delta = source.get("claim_decision_delta")
+        if isinstance(decision_delta, Mapping):
+            changed = decision_delta.get("changed")
+            if isinstance(changed, bool):
+                return changed
+    return None
+
+
+def _string_sequence(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    return tuple(str(item) for item in value)

--- a/scripts/validation/report_issue_3813_sustained_flow_revival_gate.py
+++ b/scripts/validation/report_issue_3813_sustained_flow_revival_gate.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Report issue #3813 sustained-flow revival gate from issue #3810 h600 evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.sustained_flow_revival_gate import (
+    DEFAULT_H600_INTERACTION_EXPOSURE_EVIDENCE,
+    build_sustained_flow_revival_gate_report,
+)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--interaction-exposure",
+        type=Path,
+        default=DEFAULT_H600_INTERACTION_EXPOSURE_EVIDENCE,
+        help="Issue #3810 h600 interaction-exposure diagnostics JSON.",
+    )
+    parser.add_argument(
+        "--claim-impact",
+        type=Path,
+        default=None,
+        help=(
+            "Optional JSON report stating affected rows and whether wait-it-out exclusions "
+            "or caveats change claim decisions."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Emit full JSON report.")
+    return parser.parse_args(argv)
+
+
+def _load_json(path: Path) -> dict:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the sustained-flow revival gate CLI."""
+
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    interaction_exposure = _load_json(args.interaction_exposure)
+    claim_impact = _load_json(args.claim_impact) if args.claim_impact is not None else None
+    report = build_sustained_flow_revival_gate_report(
+        interaction_exposure,
+        interaction_exposure_evidence_path=args.interaction_exposure,
+        claim_impact=claim_impact,
+        claim_impact_evidence_path=args.claim_impact,
+    )
+    payload = report.to_payload()
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(
+            f"decision={payload['decision']} "
+            f"evidence_status={payload['evidence_status']} "
+            f"blocking_reasons={len(payload['blocking_reasons'])}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_issue_3813_sustained_flow_revival_gate.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_revival_gate.py
@@ -1,0 +1,111 @@
+"""Tests for issue #3813 sustained-flow revival gate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.sustained_flow_revival_gate import (
+    DECISION_DEFER,
+    DECISION_REVIVE,
+    DECISION_STOP,
+    DEFAULT_H600_INTERACTION_EXPOSURE_EVIDENCE,
+    REQUIRED_INTERACTION_EXPOSURE_FIELDS,
+    build_sustained_flow_revival_gate_report,
+)
+from scripts.validation.report_issue_3813_sustained_flow_revival_gate import main as gate_main
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _complete_exposure() -> dict:
+    return {
+        "status": "computed",
+        "computed_fields": list(REQUIRED_INTERACTION_EXPOSURE_FIELDS),
+        "runs": [
+            {
+                "job_id": "13268",
+                "run_label": "confirm",
+                "status": "computed",
+                "computed_fields": list(REQUIRED_INTERACTION_EXPOSURE_FIELDS),
+            }
+        ],
+    }
+
+
+def _claim_impact(*, changed: bool) -> dict:
+    return {
+        "claim_decisions_changed": changed,
+        "affected_rows": [
+            {
+                "planner_key": "goal",
+                "scenario_id": "warehouse_static_obstacles",
+                "reason": "low exposure success row would be caveated",
+            }
+        ],
+    }
+
+
+def test_tracked_h600_evidence_defers_until_exposure_fields_exist() -> None:
+    """Current tracked #3810 evidence is incomplete, so the gate fails closed."""
+
+    exposure_path = REPO_ROOT / DEFAULT_H600_INTERACTION_EXPOSURE_EVIDENCE
+    exposure = json.loads(exposure_path.read_text(encoding="utf-8"))
+    report = build_sustained_flow_revival_gate_report(
+        exposure,
+        interaction_exposure_evidence_path=DEFAULT_H600_INTERACTION_EXPOSURE_EVIDENCE,
+    )
+    payload = report.to_payload()
+    assert payload["decision"] == DECISION_DEFER
+    assert payload["ready_for_revived_implementation"] is False
+    assert (
+        "interaction-exposure diagnostics missing computed required fields"
+        in payload["blocking_reasons"]
+    )
+    assert "claim-decision impact not supplied" in payload["blocking_reasons"]
+    assert payload["interaction_exposure_evidence_path"].endswith(
+        "interaction_exposure_diagnostics.json"
+    )
+
+
+def test_complete_load_bearing_evidence_revives_sustained_flow() -> None:
+    """Complete exposure plus changed claim decisions revives the opt-in design lane."""
+
+    report = build_sustained_flow_revival_gate_report(
+        _complete_exposure(),
+        claim_impact=_claim_impact(changed=True),
+        claim_impact_evidence_path="docs/context/evidence/claim_impact.json",
+    )
+    assert report.decision == DECISION_REVIVE
+    assert report.ready_for_revived_implementation is True
+    assert report.blocking_reasons == ()
+    assert report.affected_rows[0]["planner_key"] == "goal"
+
+
+def test_complete_non_load_bearing_evidence_stops_sustained_flow() -> None:
+    """Complete exposure with unchanged claim decisions stops speculative scenario work."""
+
+    report = build_sustained_flow_revival_gate_report(
+        _complete_exposure(),
+        claim_impact=_claim_impact(changed=False),
+    )
+    assert report.decision == DECISION_STOP
+    assert report.ready_for_revived_implementation is False
+    assert report.blocking_reasons == ()
+
+
+def test_cli_reports_default_tracked_gate_decision(capsys) -> None:
+    """CLI emits the checked-in default gate report without running benchmarks."""
+
+    exit_code = gate_main(
+        [
+            "--interaction-exposure",
+            str(REPO_ROOT / DEFAULT_H600_INTERACTION_EXPOSURE_EVIDENCE),
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["schema_version"] == "issue_3813.sustained_flow_revival_gate.v1"
+    assert payload["decision"] == DECISION_DEFER

--- a/tests/benchmark/test_issue_3813_sustained_flow_revival_gate.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_revival_gate.py
@@ -68,6 +68,29 @@ def test_tracked_h600_evidence_defers_until_exposure_fields_exist() -> None:
     )
 
 
+def test_thin_status_without_declared_fields_fails_closed() -> None:
+    """A bare 'computed' status with no declared exposure fields must DEFER.
+
+    Guards against a degraded upstream artifact that only labels itself complete
+    (without positively declaring the required interaction-exposure fields)
+    silently passing the gate to revive/stop.
+    """
+
+    for thin in ({"status": "computed"}, {"runs": [{"status": "computed"}]}):
+        report = build_sustained_flow_revival_gate_report(
+            thin,
+            claim_impact=_claim_impact(changed=True),
+            claim_impact_evidence_path="docs/context/evidence/claim_impact.json",
+        )
+        payload = report.to_payload()
+        assert payload["decision"] == DECISION_DEFER
+        assert payload["ready_for_revived_implementation"] is False
+        assert (
+            "interaction-exposure diagnostics missing computed required fields"
+            in payload["blocking_reasons"]
+        )
+
+
 def test_complete_load_bearing_evidence_revives_sustained_flow() -> None:
     """Complete exposure plus changed claim decisions revives the opt-in design lane."""
 


### PR DESCRIPTION
## Reviewer-critical summary
What changed: Adds a small issue #3813 sustained-flow revival-gate report and CLI that consume issue #3810 h600 interaction-exposure evidence and classify `revive_sustained_flow`, `stop_not_load_bearing`, or `defer_needs_more_evidence`.

Why now: The latest issue comment on 2026-07-02 explicitly parks further sustained-flow implementation behind this h600 revival gate. This PR is the nameable progression capability for that Phase 1 gate, not another static scaffold guard.

Boundary: The checked-in #3810 h600 exposure artifact currently lacks required computed exposure fields and claim-impact rows, so the default report returns `defer_needs_more_evidence`. No sustained-flow runtime implementation, no scenario schema prototype, no benchmark campaign, no Slurm/GPU submission, and no paper/dissertation claim edits are included.

Required validation: Focused unit tests cover all three gate decisions plus the default tracked h600 evidence path; the CLI emits the fail-closed default report.

Remaining blocker: A complete h600 claim-impact input is still needed: affected planner/scenario rows and whether wait-it-out exclusions or caveats change claim decisions.

## Contract delta
- New schema: `issue_3813.sustained_flow_revival_gate.v1`.
- New decision labels: `revive_sustained_flow`, `stop_not_load_bearing`, `defer_needs_more_evidence`.
- New required exposure fields: `interaction_exposure_share`, `robot_motion_share_before_first_clearance`, `first_clearance_step`, `low_exposure_success`.
- New fail-closed blockers: missing computed interaction-exposure fields, missing affected planner/scenario rows, missing claim-decision impact.
- Compatibility impact: additive only; existing sustained-flow scaffold/preflight behavior and default benchmark conclusions are unchanged.

<details>
<summary>Governance appendix</summary>

## Linked Issues
- Relates to `#3813`
- Consumes tracked diagnostic evidence from `#3810`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: `#3813`
- Safe review independently: yes
- Review dependency reason, any: Additive report/CLI/test slice; no benchmark runtime path is changed.

## What Changed
- Added `robot_sf.benchmark.sustained_flow_revival_gate` with a pure report builder and stable JSON payload.
- Added `scripts/validation/report_issue_3813_sustained_flow_revival_gate.py` CLI.
- Added focused tests for default tracked h600 defer behavior and synthetic complete revive/stop fixtures.

## Why Matters
- Added value: Converts the parked #3813 revival condition into a reviewable, fail-closed decision packet.
- Expected impact: Future scenario/runtime work can proceed only after h600 evidence proves sustained-flow is load-bearing.
- Why worth merging now: It closes the Phase 1 gate surface without expanding into speculative sustained-flow implementation.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Whether #3813 sustained-flow work should revive after #3810 h600 interaction-exposure evidence.
- Comparator or baseline, applicable: h600 evidence with and without wait-it-out exclusions or caveats, when supplied by a future complete claim-impact report.
- Evidence category: revival-gate report over tracked diagnostic input.
- Result type: blocker-resolution gate report.
- Decision stop rule, applicable: `revive_sustained_flow` only when interaction-exposure fields, affected rows, and changed claim decisions are all present; `stop_not_load_bearing` when complete evidence shows no decision change; otherwise `defer_needs_more_evidence`.
- Parent issue, claim map, registry, context note, synthesis surface update: #3813 remains open; no claim map or benchmark report conclusion changed.
- New research/benchmark/metric/paper-facing analysis tool, any: yes, small decision report over tracked diagnostic input. Representative use is the default CLI over `docs/context/evidence/issue_3810_h600_interpretation_2026-07/interaction_exposure_diagnostics.json`, which returns `defer_needs_more_evidence`.

## Domain-Aware Approval
- Required PR: yes - evidence-gate report over benchmark diagnostic artifacts.
- Domains reviewed: benchmark evidence gate, interaction-exposure diagnostics, sustained-flow revival decision.
- Status: waived.
- Approver/review source waiver: maintainer ready-queue authorization for issue #3813 slice; Claude Code owns full PR gate, improvement cycle, and merge authority after open.
- Approval or blocker note: waived for PR opening; this PR does not promote benchmark results.
- Validity checklist:
- Target claim/hypothesis: revival gate only, not sustained-flow efficacy.
- Comparator or split/evidence validity: default tracked evidence is incomplete and stays deferred.
- Fallback/degraded exclusions: incomplete or degraded evidence is a blocker, not success.
- Claim boundary: no runtime, benchmark campaign, Slurm/GPU, or paper-facing claim change.
- Implementation integrity vs experimental validity: tests prove gate classification behavior, not experimental sustained-flow validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, default tracked h600 evidence fails closed to `defer_needs_more_evidence`.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? unknown; this PR consumes evidence metadata only.
- Result route: continue only after complete h600 claim-impact evidence exists.
- Follow-up question issue weak, negative, non-transfer results: #3813 remains open for complete h600 claim-impact evidence and any later scenario/runtime work only if the gate revives.

## Next Empirical Action
- Rerun needed: yes, upstream #3810/h600 evidence needs computed interaction-exposure and claim-impact comparison before revival.
- Extractor analysis tool needed: yes, to provide affected planner/scenario rows and claim decision changes.
- Artifact missing unavailable: complete claim-impact input for wait-it-out exclusions/caveats.
- Stop / revise / continue decision: defer now; continue evidence closure before any sustained-flow implementation.
- Proposed child issue existing follow-up: #3813 tracks remaining gated implementation phases.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_revival_gate.py -q` -> passed, 4 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/sustained_flow_revival_gate.py scripts/validation/report_issue_3813_sustained_flow_revival_gate.py tests/benchmark/test_issue_3813_sustained_flow_revival_gate.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/report_issue_3813_sustained_flow_revival_gate.py --json` -> passed; decision `defer_needs_more_evidence`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_revival_gate.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/scenario_certification/test_sustained_flow_preflight.py -q` -> passed, 37 tests.

## Performance / Hot Path
- Baseline runtime: NA; no hot runtime path changed.
- Changed runtime: NA; CLI/report only.
- Representative command: `uv run python scripts/validation/report_issue_3813_sustained_flow_revival_gate.py --json`.
- Hot-path call count profile anchor: NA; no benchmark runner hot path changed.
- Cache-hit reuse counter: NA; no caching claimed.
- Rollback failure criterion: gate misclassifies incomplete #3810 exposure evidence as revive/stop instead of deferring.

## Risks / Rollout
- Compatibility risks: Low; additive module and CLI only.
- Failure modes: Future claim-impact reports may use unanticipated field names; current parser supports explicit stable fields and otherwise defers.
- Rollback fallback plan: Revert the additive report/CLI/tests.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: latest #3813 maintainer implementation-plan comment from 2026-07-02; tracked #3810 h600 evidence under `docs/context/evidence/issue_3810_h600_interpretation_2026-07/`.
- Any assumptions need to preserved: Claim-impact input is assumed to expose `claim_decisions_changed` plus affected rows, or equivalent stable fields parsed by the report builder.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: user authorization disallows issue/PR comments; this PR body is the single propagation surface for the delivered slice and #3813 remains open.

## Follow-Up Issues
- Deferred work: complete h600 interaction-exposure and claim-impact evidence; only if the gate returns `revive_sustained_flow`, continue to scenario schema prototype, sustained-load metric, runner integration, and sanity tests.
- Existing follow-up issue: #3813.
- Issues opened follow-up: none; #3813 remains the tracking issue.

## Reviewer Notes
- Anything reviewer should verify closely: default checked-in #3810 evidence must remain `defer_needs_more_evidence` because required fields and claim-impact evidence are missing.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no sustained-flow runtime implementation.

</details>
