### PR TITLE
Issue #4230: pre-register h600 hybrid-roster config

### DIFF
--- a/configs/benchmarks/alyassi_comparability_map_v1.yaml
+++ b/configs/benchmarks/alyassi_comparability_map_v1.yaml
@@ -47,6 +47,7 @@ planner_key_mapping:
   guarded_ppo_relaxed_v2: guarded-ppo-relaxed-v2
   hybrid_portfolio: hybrid-portfolio
   hybrid_rule_v3_fast_progress_static_escape: hybrid-rule-v3-fast-progress-static-escape
+  hybrid_rule_v3_fast_progress_static_escape_continuous: hybrid-rule-v3-fast-progress-static-escape-continuous
   mppi_social: mppi-social
   orca: orca
   ppo: ppo
@@ -61,6 +62,7 @@ planner_key_mapping:
   social_navigation_pyenvs_orca: social-navigation-pyenvs-orca
   social_navigation_pyenvs_socialforce: social-navigation-pyenvs-socialforce
   scenario_adaptive_hybrid_orca_v1: scenario-adaptive-hybrid-orca-v1
+  scenario_adaptive_hybrid_orca_v2_collision_guard: scenario-adaptive-hybrid-orca-v2-collision-guard
   socnav_bench: socnav-bench
   socnav_sampling: socnav-sampling
   stream_gap: stream-gap

--- a/configs/benchmarks/paper_experiment_matrix_v1_h600_hybrid_roster.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_h600_hybrid_roster.yaml
@@ -1,0 +1,94 @@
+# Issue #4230 pre-registration config for the missing h600 hybrid roster.
+# This is configuration/protocol only: no campaign outputs or h600 ranking claims.
+name: paper_experiment_matrix_v1_h600_hybrid_roster
+paper_facing: false
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+
+amv_profile:
+  name: amv-paper-v1
+  contract_version: "1"
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case: [delivery_robot, shared_space_micromobility]
+    context: [sidewalk, shared_space]
+    speed_regime: [walking_speed, scooter_speed]
+    maneuver_type: [overtake, crossing, bottleneck]
+
+seed_policy:
+  mode: seed-set
+  # `eval` is fixed in seed_sets_v1.yaml as [111, 112, 113].
+  seed_set: eval
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+
+workers: 2
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: false
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+
+kinematics_matrix:
+  - differential_drive
+
+export_publication_bundle: false
+include_videos_in_publication: false
+overwrite_publication_bundle: false
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: diagnostic-h600-hybrid-roster-preregistered
+
+preregistration:
+  issue: 4230
+  parent_issue: 3810
+  feeds_issue: 4195
+  claim_boundary: no h600 ranking or F-C4(ii) claim before the issue #4195 gate
+  source_h600_jobs: [13268, 13273]
+  expected_scenario_matrix_hash: c10df617a87c
+  hypothesis: >
+    Constraint-first hybrid planners land at or above the ORCA/PPO h600 baselines;
+    failure to do so is a horizon finding, not an invalid run.
+
+planners:
+  - key: scenario_adaptive_hybrid_orca_v1
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
+    benchmark_profile: experimental
+
+  - key: scenario_adaptive_hybrid_orca_v2_collision_guard
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v2_collision_guard.yaml
+    benchmark_profile: experimental
+
+  - key: hybrid_rule_v3_fast_progress_static_escape
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
+    benchmark_profile: experimental
+
+  - key: hybrid_rule_v3_fast_progress_static_escape_continuous
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape_continuous.yaml
+    benchmark_profile: experimental

--- a/configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
+++ b/configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
@@ -1,5 +1,6 @@
 name: hybrid_rule_v3_fast_progress_static_escape
 algo: hybrid_rule_local_planner
+allow_testing_algorithms: true
 base_config_path: configs/algos/hybrid_rule_v3_teb_like_rollout.yaml
 params:
   max_linear_speed: 3.0

--- a/configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape_continuous.yaml
+++ b/configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape_continuous.yaml
@@ -1,5 +1,6 @@
 name: hybrid_rule_v3_fast_progress_static_escape_continuous
 algo: hybrid_rule_local_planner
+allow_testing_algorithms: true
 base_config_path: configs/algos/hybrid_rule_v3_teb_like_rollout.yaml
 params:
   max_linear_speed: 3.0

--- a/configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
+++ b/configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
@@ -1,5 +1,6 @@
 name: scenario_adaptive_hybrid_orca_v1
 algo: hybrid_rule_local_planner
+allow_testing_algorithms: true
 base_config_path: configs/algos/hybrid_rule_v3_teb_like_rollout.yaml
 params:
   max_linear_speed: 3.0

--- a/configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v2_collision_guard.yaml
+++ b/configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v2_collision_guard.yaml
@@ -1,5 +1,6 @@
 name: scenario_adaptive_hybrid_orca_v2_collision_guard
 algo: hybrid_rule_local_planner
+allow_testing_algorithms: true
 base_config_path: configs/algos/hybrid_rule_v3_teb_like_rollout.yaml
 params:
   max_linear_speed: 3.0

--- a/docs/context/issue_4230_h600_hybrid_roster_preregistration.md
+++ b/docs/context/issue_4230_h600_hybrid_roster_preregistration.md
@@ -1,0 +1,61 @@
+# Issue #4230 H600 Hybrid-Roster Pre-Registration
+
+This note pre-registers the missing horizon 600 (`h600`) hybrid-roster benchmark slice before any
+Slurm submission or benchmark interpretation. It is protocol evidence only: it does not report
+campaign results, planner rankings, or paper/dissertation claims.
+
+## Scope
+
+- Issue: <https://github.com/ll7/robot_sf_ll7/issues/4230>
+- Parent issue: #3810
+- Feeds: #4195 F-C4(ii) promotion gate
+- Config: `configs/benchmarks/paper_experiment_matrix_v1_h600_hybrid_roster.yaml`
+- Source h600 comparison jobs: `13268` and `13273`
+- Required scenario matrix hash: `c10df617a87c`
+- Seeds: `eval` seed set from `configs/benchmarks/seed_sets_v1.yaml`, expanding to `[111, 112, 113]`
+- Claim boundary: no h600 ranking, F-C4(ii), paper, dissertation, or release claim before the
+  #4195 aggregation/interpretation gate accepts the comparable rows.
+
+## Pre-Registered Roster
+
+The four arms are the verified h500 hybrid/scenario-adaptive leaders from the h500 candidate
+comparison and policy-search registry:
+
+| Planner key | Candidate config |
+| --- | --- |
+| `scenario_adaptive_hybrid_orca_v1` | `configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml` |
+| `scenario_adaptive_hybrid_orca_v2_collision_guard` | `configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v2_collision_guard.yaml` |
+| `hybrid_rule_v3_fast_progress_static_escape` | `configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml` |
+| `hybrid_rule_v3_fast_progress_static_escape_continuous` | `configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape_continuous.yaml` |
+
+Roster provenance:
+
+- `docs/context/issue_1454_s10_h500_candidate_comparison.md` records these four rows above ORCA and
+  PPO on the h500 candidate comparison surface.
+- `docs/context/policy_search/candidate_registry.yaml` records all four as implemented runnable
+  hybrid-rule candidates.
+- `configs/benchmarks/issue_1454_s10_scenario_horizons_h500_candidates.yaml` carries the same h500
+  benchmark-admitted candidate family.
+
+## Hypothesis
+
+Constraint-first hybrid planners should land at or above the ORCA/PPO h600 baselines. If they do
+not, the result is a real long-horizon finding that should revise the F-C4(ii) interpretation rather
+than invalidate the campaign.
+
+## No-Submit CPU Preflight
+
+Run this before private queue submission:
+
+```bash
+scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/run_camera_ready_benchmark.py \
+  --config configs/benchmarks/paper_experiment_matrix_v1_h600_hybrid_roster.yaml \
+  --output-root output/issue_4230_h600_hybrid_roster_cpu_smoke \
+  --label issue4230-h600-hybrid-smoke \
+  --mode preflight \
+  --log-level WARNING
+```
+
+The preflight is disposable local proof only. It must verify config loading, scenario-matrix hash
+`c10df617a87c`, AMV/comparability artifact generation, seed surface `[111, 112, 113]`, and candidate
+config resolution without Slurm/GPU submission.

--- a/tests/benchmark/test_h600_hybrid_roster_config.py
+++ b/tests/benchmark/test_h600_hybrid_roster_config.py
@@ -1,0 +1,165 @@
+"""Pre-registration contract for issue #4230 h600 hybrid roster."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.algorithm_readiness import (
+    get_algorithm_readiness,
+    require_algorithm_allowed,
+)
+from robot_sf.benchmark.camera_ready._preflight import _load_campaign_scenarios
+from robot_sf.benchmark.camera_ready._util import _hash_payload
+from robot_sf.benchmark.camera_ready_campaign import load_campaign_config
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs/benchmarks/paper_experiment_matrix_v1_h600_hybrid_roster.yaml"
+BASE_H600_CONFIG_PATH = (
+    REPO_ROOT / "configs/benchmarks/paper_experiment_matrix_v1_issue_791_horizon600_probe.yaml"
+)
+SEED_SETS_PATH = REPO_ROOT / "configs/benchmarks/seed_sets_v1.yaml"
+EXPECTED_PLANNERS = [
+    "scenario_adaptive_hybrid_orca_v1",
+    "scenario_adaptive_hybrid_orca_v2_collision_guard",
+    "hybrid_rule_v3_fast_progress_static_escape",
+    "hybrid_rule_v3_fast_progress_static_escape_continuous",
+]
+EXPECTED_CANDIDATE_CONFIGS = {
+    "scenario_adaptive_hybrid_orca_v1": (
+        "configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml"
+    ),
+    "scenario_adaptive_hybrid_orca_v2_collision_guard": (
+        "configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v2_collision_guard.yaml"
+    ),
+    "hybrid_rule_v3_fast_progress_static_escape": (
+        "configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml"
+    ),
+    "hybrid_rule_v3_fast_progress_static_escape_continuous": (
+        "configs/policy_search/candidates/"
+        "hybrid_rule_v3_fast_progress_static_escape_continuous.yaml"
+    ),
+}
+SCIENTIFIC_SURFACE_FIELDS = (
+    "scenario_matrix",
+    "comparability_mapping",
+    "amv_profile",
+    "seed_policy",
+    "snqi_weights",
+    "snqi_baseline",
+    "snqi_contract",
+    "horizon",
+    "dt",
+    "record_forces",
+    "resume",
+    "stop_on_failure",
+    "bootstrap_samples",
+    "bootstrap_confidence",
+    "bootstrap_seed",
+    "kinematics_matrix",
+    "export_publication_bundle",
+    "include_videos_in_publication",
+    "overwrite_publication_bundle",
+)
+DISALLOWED_ACCIDENTAL_BASELINES = {
+    "goal",
+    "social_force",
+    "orca",
+    "ppo",
+    "prediction_planner",
+    "socnav_sampling",
+    "sacadrl",
+    "gap_prediction",
+}
+
+
+def _load_yaml(path: Path) -> dict[str, object]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_h600_hybrid_roster_preserves_h600_surface_contract() -> None:
+    """New roster must differ from the h600 probe only by identity and planners."""
+    config = _load_yaml(CONFIG_PATH)
+    base_config = _load_yaml(BASE_H600_CONFIG_PATH)
+
+    assert config["name"] == "paper_experiment_matrix_v1_h600_hybrid_roster"
+    for field in SCIENTIFIC_SURFACE_FIELDS:
+        assert config[field] == base_config[field], field
+
+    seed_sets = _load_yaml(SEED_SETS_PATH)
+    assert seed_sets["eval"] == [111, 112, 113]
+    assert config["paper_facing"] is False
+    assert config["paper_interpretation_profile"] == "diagnostic-h600-hybrid-roster-preregistered"
+    assert config["preregistration"]["expected_scenario_matrix_hash"] == "c10df617a87c"
+
+
+def test_h600_hybrid_roster_uses_exact_verified_four_arm_roster() -> None:
+    """Planner roster is the pre-registered h500 hybrid/scenario-adaptive top family."""
+    config = _load_yaml(CONFIG_PATH)
+    comparability = _load_yaml(REPO_ROOT / config["comparability_mapping"])
+    planners = config["planners"]
+    assert isinstance(planners, list)
+
+    assert [planner["key"] for planner in planners] == EXPECTED_PLANNERS
+    assert not (set(EXPECTED_PLANNERS) & DISALLOWED_ACCIDENTAL_BASELINES)
+    assert not ({planner["key"] for planner in planners} & DISALLOWED_ACCIDENTAL_BASELINES)
+
+    for planner in planners:
+        key = planner["key"]
+        assert planner == {
+            "key": key,
+            "algo": "hybrid_rule_local_planner",
+            "planner_group": "experimental",
+            "algo_config": EXPECTED_CANDIDATE_CONFIGS[key],
+            "benchmark_profile": "experimental",
+        }
+        candidate_path = REPO_ROOT / EXPECTED_CANDIDATE_CONFIGS[key]
+        assert candidate_path.is_file()
+        candidate_payload = _load_yaml(candidate_path)
+        assert candidate_payload["algo"] == "hybrid_rule_local_planner"
+        assert candidate_payload["allow_testing_algorithms"] is True
+        assert key in comparability["planner_key_mapping"]
+
+
+def test_h600_hybrid_roster_loads_and_keeps_expected_hash() -> None:
+    """Campaign loader accepts the config and resolves the h600 scenario surface."""
+    cfg = load_campaign_config(CONFIG_PATH)
+
+    assert cfg.name == "paper_experiment_matrix_v1_h600_hybrid_roster"
+    assert cfg.horizon == 600
+    assert cfg.dt == pytest.approx(0.1)
+    assert cfg.seed_policy.mode == "seed-set"
+    assert cfg.seed_policy.seed_set == "eval"
+    assert [planner.key for planner in cfg.planners] == EXPECTED_PLANNERS
+
+    scenarios = _load_campaign_scenarios(cfg)
+    assert len(scenarios) == 48
+    assert _hash_payload(scenarios) == "c10df617a87c"
+
+
+def test_h600_hybrid_roster_keeps_hybrid_rule_explicit_opt_in() -> None:
+    """The roster remains experimental and executable only through explicit candidate opt-in."""
+    readiness = get_algorithm_readiness("hybrid_rule_local_planner")
+
+    assert readiness is not None
+    assert readiness.tier == "experimental"
+    assert readiness.requires_explicit_opt_in is True
+    with pytest.raises(ValueError, match="allow_testing_algorithms"):
+        require_algorithm_allowed(
+            algo="hybrid_rule_local_planner",
+            benchmark_profile="experimental",
+            ppo_paper_ready=False,
+        )
+    assert (
+        require_algorithm_allowed(
+            algo="hybrid_rule_local_planner",
+            benchmark_profile="experimental",
+            ppo_paper_ready=False,
+            allow_testing_algorithms=True,
+        )
+        == readiness
+    )


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds the issue #4230 pre-registration slice for
`paper_experiment_matrix_v1_h600_hybrid_roster`: the h600 hybrid-roster config, four-arm roster
provenance, config validation tests, explicit hybrid-rule execution opt-ins, and a no-submit CPU
preflight proof path.

Why now: #4230 identifies the missing h600 constraint-first hybrid roster needed before any private
queue submission or #4195 interpretation update.

Claim boundary: this PR makes no h600 ranking, F-C4(ii), paper, dissertation, or release claim. It
does not include full benchmark campaign results, Slurm/GPU submission, aggregation, or h600
interpretation updates.

Required validation: focused config tests, related camera-ready regression tests, YAML parse checks,
Ruff on touched Python, and the no-submit `--mode preflight` CPU path.

Remaining blocker: after merge, the exact merged config still needs private queue submission and the
#4195 aggregation/interpretation gate before any claim movement.

## Contract delta

- New config: `configs/benchmarks/paper_experiment_matrix_v1_h600_hybrid_roster.yaml`.
- New pre-registration note: `docs/context/issue_4230_h600_hybrid_roster_preregistration.md`.
- New test: `tests/benchmark/test_h600_hybrid_roster_config.py`.
- Roster: exactly four h500 hybrid/scenario-adaptive arms:
  `scenario_adaptive_hybrid_orca_v1`,
  `scenario_adaptive_hybrid_orca_v2_collision_guard`,
  `hybrid_rule_v3_fast_progress_static_escape`,
  `hybrid_rule_v3_fast_progress_static_escape_continuous`.
- Preserved h600 surface: `scenario_matrix` hash `c10df617a87c`, `eval` seed set `[111, 112, 113]`,
  horizon `600`, `dt: 0.1`, differential-drive kinematics, AMV profile, SNQI contract, bootstrap
  settings, and publication bundle disabled.
- Readiness impact: the four existing candidate YAMLs now carry `allow_testing_algorithms: true`, so
  `hybrid_rule_local_planner` remains experimental/explicit-opt-in but can execute through these
  registered candidates.
- Comparability impact: `alyassi_comparability_map_v1.yaml` now includes the two missing planner-key
  mappings for the h500 top-four hybrid roster.
- New fail-closed blockers: tests fail if the roster drifts, baseline/PPO/prediction rows leak in,
  candidate config files disappear, opt-in is removed, the scenario hash changes, or the
  comparability map lacks a roster key.
- Compatibility impact: no benchmark runner behavior or schema change; existing configs retain their
  current surface except for candidate opt-in metadata and two planner-key map entries.

## Linked issue

Refs #4230. (First slice: pre-registration config + CPU smoke only; campaign artifacts and #4195 interpretation remain open — see gate findings comment.)

## Scope summary

In scope:

- h600 hybrid-roster pre-registration config.
- Verified four-arm roster provenance from the h500 candidate surface.
- Pre-registration note and no-submit CPU preflight command.
- Config validation tests and related compatibility checks.

Out of scope:

- No full benchmark campaign run.
- No Slurm/GPU/private queue submission.
- No result aggregation.
- No h600 interpretation updates.
- No paper/dissertation/release claim edits.
- No raw output tree copied into git.

## Validation command results

- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_h600_hybrid_roster_config.py -q`
  - Exit code: 0
  - Result: 4 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_camera_ready_campaign.py tests/benchmark/test_h600_hybrid_roster_config.py -q`
  - Exit code: 0
  - Result: passed.
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_issue_1454_s10_robustness_configs.py tests/benchmark/test_h600_hybrid_roster_config.py -q`
  - Exit code: 0
  - Result: 9 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check tests/benchmark/test_h600_hybrid_roster_config.py scripts/tools/run_camera_ready_benchmark.py`
  - Exit code: 0
  - Result: all checks passed.
- YAML parse check for the new config, comparability map, and four candidate YAMLs.
  - Exit code: 0
  - Result: all parsed as mappings.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_h600_hybrid_roster.yaml --output-root output/issue_4230_h600_hybrid_roster_cpu_smoke --label issue4230-h600-hybrid-smoke-final --mode preflight --log-level WARNING`
  - Exit code: 0
  - Result: preflight artifacts generated under ignored `output/`; matrix summary has scenario hash
    `c10df617a87c`, resolved seeds `(111, 112, 113)`, and the four expected planner rows.

<details>
<summary>Readiness and propagation appendix</summary>

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: blocker-resolution for #4230 h600
  hybrid-roster campaign pre-registration; no claim movement.
- Comparator or baseline, applicable: existing h600 jobs `13268` and `13273` define the comparison
  surface; this PR does not compare results.
- Evidence tier: targeted smoke / pre-registration config proof.
- Result classification: blocker-resolution, diagnostic-only until campaign and #4195 gate.
- Decision stop rule, applicable: do not submit privately until this config/test/preflight slice is
  merged.
- Parent issue, claim map, registry, context note, synthesis surface update:
  `docs/context/issue_4230_h600_hybrid_roster_preregistration.md`; #4195 remains the interpretation
  gate.
- New research/benchmark/metric/paper-facing analysis tool, any: none.

## Domain-Aware Approval

- Required PR: yes - benchmark pre-registration and targeted smoke proof touch an evidence-sensitive campaign surface.
- Domains reviewed: h600 benchmark config integrity, roster provenance, preflight/claim boundary.
- Status: blocked pending post-PR reviewer/Claude Code gate; this PR does not claim domain approval.
- Approval or blocker note: reviewer must confirm the pre-registered roster and explicit hybrid-rule opt-ins before private queue submission.
- Validity checklist: config/test/preflight only; no result interpretation.
- Target claim/hypothesis: pre-registered only.
- Comparator or split/evidence validity: h600 comparison validity is pinned by matching config fields, seed set, and scenario hash.
- Fallback/degraded exclusions: no fallback/degraded benchmark rows are accepted as evidence here.
- Claim boundary: no h600 ranking or F-C4(ii) claim before #4195.
- Implementation integrity vs experimental validity: tests prove config integrity; experimental validity still requires follow-up campaign evidence.

## Falsification / Non-Transfer Check

- Did mechanism activate? NA, no campaign run.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue after merge to private submission.
- Follow-up question issue weak, negative, non-transfer results: #4195 interpretation gate.

## Next Empirical Action

- Rerun needed: yes, submit the merged config through private queue after merge.
- Extractor analysis tool needed: yes, use the existing #4195 aggregation path after campaign
  completion.
- Artifact missing unavailable: campaign artifacts absent by design.
- Stop / revise / continue decision: continue after merge.
- Proposed child issue existing follow-up: #4195 aggregation/interpretation follow-up.

## Risks / Rollout

- Compatibility risks: candidate opt-in metadata broadens these four existing candidate YAMLs from
  parse-only to executable under the current readiness guard; they remain experimental.
- Failure modes: future config drift could break h600 comparability; tests pin the main drift
  surfaces.
- Rollback fallback plan: revert this PR before private submission; no durable campaign artifacts
  depend on it yet.

## Docs / Provenance

- Updated docs: `docs/context/issue_4230_h600_hybrid_roster_preregistration.md`.
- Relevant design provenance notes: #4230 issue body and maintainer implementation-plan comment.
- Any assumptions preserved: the h500 top-four roster matches the maintainer-provided expected
  candidate family.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): no, out of scope until campaign results exist.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): comparability map updated for roster keys.
- Context index / memory note updated (yes/no/NA): no, new note is linked from this PR.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: issue/PR commenting is not authorized for this run
  (`comment_issue_or_pr: false`), and this PR body is the durable state-propagation surface for this
  low-churn pre-registration slice.

## Follow-Up Issues

- Deferred work: private queue submission, compact campaign evidence, #4195 aggregation, and
  interpretation update.
- Issues opened follow-up: none.

## Reviewer Notes

- Please verify the candidate opt-in metadata is acceptable on the four existing policy-search
  candidate YAMLs; without it, the current readiness guard blocks `hybrid_rule_local_planner`
  execution.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, and no claim edits.

</details>

