### PR TITLE
Issue #4267: Harden Package A transfer renderer labeling guard

### DIFF
--- a/scripts/tools/build_package_a_transfer_report.py
+++ b/scripts/tools/build_package_a_transfer_report.py
@@ -48,6 +48,30 @@ class SurfaceFamilies:
     benchmark: tuple[str, ...]
     heldout: tuple[str, ...]
 
+    @property
+    def benchmark_labeling_mode(self) -> str:
+        """Return how benchmark-set rows are identified for reporting."""
+        if self.benchmark:
+            return "explicit_benchmark_set_families"
+        if self.heldout:
+            return "inferred_by_excluding_heldout_families"
+        return "undeclared"
+
+    @property
+    def benchmark_labeling_warning(self) -> str | None:
+        """Return the warning shown when benchmark-set labeling is inferred."""
+        if self.benchmark:
+            return None
+        if self.heldout:
+            return (
+                "benchmark-set families are not declared; benchmark_set rows are inferred as "
+                "the complement of heldout_family_evaluation.scenario_families"
+            )
+        return (
+            "benchmark-set and held-out scenario families are both undeclared; renderer cannot "
+            "label transfer surfaces"
+        )
+
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
@@ -83,6 +107,11 @@ def _empty_table_rows() -> list[dict[str, str]]:
 def _table_rows(result_store: Path | None, families: SurfaceFamilies) -> list[dict[str, str]]:
     if result_store is None:
         return _empty_table_rows()
+    if not families.benchmark and not families.heldout:
+        raise ValueError(
+            "held-out partition manifest must declare benchmark_set_evaluation.scenario_families "
+            "or heldout_family_evaluation.scenario_families before rendering transfer surfaces"
+        )
 
     frame = read_parquet_frame(result_store / "episodes.parquet")
     if "snqi" not in frame.columns:
@@ -351,6 +380,7 @@ def render_report(
     baseline_rows = [row for row in table_rows if row["surface"] == "benchmark_set"]
     heldout_rows = [row for row in table_rows if row["surface"] == "heldout_family"]
     transfer_rows = _transfer_delta_rows(table_rows)
+    surface_labeling_warning = families.benchmark_labeling_warning
 
     _write_csv(output_dir / "baseline_table.csv", TABLE_FIELDS, baseline_rows)
     _write_csv(output_dir / "heldout_family_table.csv", TABLE_FIELDS, heldout_rows)
@@ -372,6 +402,12 @@ def render_report(
                 "# Leakage Audit",
                 "",
                 f"- Partition manifest: `{heldout_partition_manifest}`",
+                f"- Benchmark-set labeling mode: `{families.benchmark_labeling_mode}`",
+                (
+                    f"- Surface-labeling warning: {surface_labeling_warning}"
+                    if surface_labeling_warning
+                    else "- Surface-labeling warning: none"
+                ),
                 f"- Benchmark-set families: {', '.join(families.benchmark) or 'none declared'}",
                 f"- Held-out families: {', '.join(families.heldout) or 'none declared'}",
                 "- Status: manifest validation delegated to the Package A decision packet.",

--- a/tests/tools/test_build_package_a_transfer_report.py
+++ b/tests/tools/test_build_package_a_transfer_report.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import csv
+import importlib.util
 import json
 from pathlib import Path
 
+import pytest
 import yaml
 
-from scripts.tools.build_package_a_transfer_report import main, render_report
+from scripts.tools.build_package_a_transfer_report import (
+    _surface_families,
+    _table_rows,
+    main,
+    render_report,
+)
 from scripts.tools.campaign_result_store import write_result_store
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -16,6 +23,12 @@ READINESS_MANIFEST = REPO_ROOT / "configs" / "benchmarks" / "issue_3078_package_
 PARTITION_MANIFEST = (
     REPO_ROOT / "configs" / "benchmarks" / "issue_2128_heldout_family_transfer_partitions.yaml"
 )
+PARQUET_ENGINES = ("pyarrow", "fastparquet", "duckdb")
+
+
+def _skip_without_parquet_engine() -> None:
+    if not any(importlib.util.find_spec(engine) for engine in PARQUET_ENGINES):
+        pytest.skip("requires parquet engine: pyarrow, fastparquet, duckdb")
 
 
 def _seed_report(path: Path) -> Path:
@@ -108,6 +121,8 @@ def test_renderer_writes_blocked_skeleton_without_campaign_inputs(tmp_path: Path
 
 def test_renderer_builds_transfer_tables_and_keeps_fallback_visible(tmp_path: Path) -> None:
     """Valid local evidence produces deterministic tables with non-promotable rows visible."""
+    _skip_without_parquet_engine()
+
     output_dir = tmp_path / "report"
     result_store = _result_store(tmp_path / "result-store")
     seed_report = _seed_report(tmp_path / "seed_sufficiency_analysis.json")
@@ -137,6 +152,28 @@ def test_renderer_builds_transfer_tables_and_keeps_fallback_visible(tmp_path: Pa
     ]
     claim_card = yaml.safe_load((output_dir / "claim_card.yaml").read_text())
     assert claim_card["non_promotable_row_status_counts"] == {"fallback": 1}
+    leakage_audit = (output_dir / "leakage_audit.md").read_text()
+    assert "Benchmark-set labeling mode: `inferred_by_excluding_heldout_families`" in leakage_audit
+    assert "benchmark-set families are not declared" in leakage_audit
+
+
+def test_renderer_fails_closed_when_transfer_surface_families_undeclared(tmp_path: Path) -> None:
+    """Partition manifests without any surface families cannot label transfer rows."""
+    partition_manifest = tmp_path / "partitions.yaml"
+    partition_manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "test.transfer_partitions.v1",
+                "benchmark_set_evaluation": {"description": "intentionally empty"},
+                "heldout_family_evaluation": {"description": "intentionally empty"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    families = _surface_families(partition_manifest)
+    with pytest.raises(ValueError, match="must declare benchmark_set_evaluation"):
+        _table_rows(tmp_path / "unused-result-store", families)
 
 
 def test_renderer_fails_closed_for_invalid_supplied_result_store(tmp_path: Path) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: hardens the Package A transfer-report renderer so benchmark-set labeling is explicit in `leakage_audit.md` and fails closed when neither benchmark-set nor held-out scenario-family lists are declared; adds a parquet-engine skip guard to only the parquet-backed renderer test.

Why now: issue #4267 is the post-#4262 gate follow-up for two small robustness gaps in the transfer-report renderer and its lean-environment tests.

Claim boundary: diagnostic tooling only. This PR does not change Package A benchmark semantics, transfer metrics, row-status eligibility, fallback/degraded row visibility, campaign execution, or any paper/dissertation claim.

Required validation: focused renderer tests in default and analytics-capable modes plus Ruff checks.

Remaining blocker: none for this robustness slice. Full Package A campaigns and claim promotion remain out of scope.

## Contract delta

- New renderer output contract: `leakage_audit.md` now records `Benchmark-set labeling mode`.
- New explicit warning: when `benchmark_set_evaluation.scenario_families` is empty but `heldout_family_evaluation.scenario_families` exists, benchmark-set rows are labeled by complement and the audit says so.
- New fail-closed blocker: when both benchmark-set and held-out `scenario_families` are empty, renderer table construction raises a clear `ValueError` instead of labeling all non-held-out rows as benchmark-set.
- Compatibility impact: existing manifests that declare held-out families keep rendering; their audit now includes the inferred-complement warning. Manifests declaring benchmark-set families remain explicit. Only manifests declaring neither surface family fail closed.

## Linked Issues

- Closes #4267
- Relates #3078

## Scope Summary

- Updated `scripts/tools/build_package_a_transfer_report.py` to centralize benchmark-set labeling mode/warning on `SurfaceFamilies`, write that mode into `leakage_audit.md`, and fail closed before parquet reads when both transfer surfaces are undeclared.
- Updated `tests/tools/test_build_package_a_transfer_report.py` with a per-test parquet-engine guard for the parquet-backed renderer test, an assertion that the audit records inferred complement labeling, and a lean-safe fail-closed test for undeclared transfer surfaces.

## Validation / Proof

- `uv run ruff format --check scripts/tools/build_package_a_transfer_report.py tests/tools/test_build_package_a_transfer_report.py` -> passed, `2 files already formatted`
- `uv run ruff check scripts/tools/build_package_a_transfer_report.py tests/tools/test_build_package_a_transfer_report.py` -> passed, `All checks passed!`
- `uv run pytest tests/tools/test_build_package_a_transfer_report.py -q` -> passed, `4 passed in 0.83s`
- `uv run --extra analytics pytest tests/tools/test_build_package_a_transfer_report.py -q` -> passed, `4 passed in 0.83s`

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream Propagation

- Parent issue updated: no; this run was not authorized to comment on issues or PRs.
- Claim map / benchmark report updated: NA; diagnostic tooling guard only, no benchmark claim or metric delta.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no.
- Not applicable because: state propagation is carried in this PR body; no separate issue comment was made because `comment_issue_or_pr` is false for this task.

## Freshness / Dedupe

- Full issue body and comments were read before implementation.
- Late guidance check was rerun before PR open; no maintainer comment newer than the start time (`2026-07-03T13:14:29+02:00`) was present.
- Open PR dedupe search for issue #4267 / exact scope returned no open PR.
- Fragmentation guard: only #4262 matched as merged in the last 24h for this scope, so this PR is a progression slice adding the named capability "explicit transfer-surface labeling contract plus fail-closed undeclared-family guard."

<details>
<summary>Governance appendix</summary>

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - support tooling guard for renderer robustness from #4267; no research claim.
- Comparator or baseline, applicable: NA - no experimental comparator.
- Evidence tier: NA - support tooling guard; proof is focused renderer tests and Ruff checks.
- Result classification: NA - no research result.
- Decision stop rule, applicable: NA - no empirical decision; focused renderer tests and Ruff checks are listed above.
- Parent issue, claim map, registry, context note, synthesis surface update: #4267.
- New research/benchmark/metric/paper-facing analysis tool, any: NA; support renderer hardening only.

## Domain-Aware Approval

- Approval status: not required.
- Approver/review source waiver: NA; no benchmark interpretation or paper-facing claim changes.
- Target claim/hypothesis: NA - no research claim.
- Comparator split/evidence validity: NA - no experimental comparator or benchmark interpretation.
- Fallback/degraded exclusions: fallback/degraded rows remain visible and non-promotable; no fallback row hidden or reclassified.
- Claim boundary: diagnostic-only renderer output.
- Implementation integrity vs experimental validity: implementation-only guard; validation is focused unit/integration tests, not experimental validity evidence.

## Risks / Rollout

- Compatibility risks: manifests with neither benchmark-set nor held-out families now fail closed when rendering rows.
- Failure modes: downstream callers depending on undeclared-family complement labeling must update manifests to declare at least one transfer surface.
- Rollback fallback plan: revert this PR to restore prior permissive labeling, but that would reintroduce the #4267 silent-labeling risk.

## Follow-Up Issues

- Deferred work: full Package A campaigns, transfer metric changes, and claim promotion remain out of scope.
- Issues opened follow-up: none.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transfer report generation now fails safely when required scenario-family declarations are missing, preventing incomplete audit output.
  * The audit report now includes clearer labeling details and warnings when benchmark-set families are inferred or undeclared.

* **Tests**
  * Expanded coverage for audit content and closed-failure behavior.
  * Added a fallback to skip certain tests when no supported Parquet engine is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->