### PR TITLE
docs: normalize issue #4266 public-requirement scenario metadata

### DIFF
--- a/configs/scenarios/single/issue_3977_emergency_reaction.yaml
+++ b/configs/scenarios/single/issue_3977_emergency_reaction.yaml
@@ -47,5 +47,12 @@ scenarios:
           trigger_radius_m: 0.75
           robot_trigger_radius_m: 5.5
           validated_robot_speed_m_s: [1.0, 2.0, 3.0]
+      archetype: public_requirement_emergency_reaction
+      flow: sudden_crossing
+      behavior: proximity_released_obstacle
+      purpose: >
+        Deterministic emergency-reaction scenario proxy for issue #3977;
+        records authored sudden conflict relevance only, not validated public
+        acceptance, benchmark-gate, or safety-certification evidence.
     seeds:
       - 3977

--- a/configs/scenarios/single/issue_3977_visibility_and_intent.yaml
+++ b/configs/scenarios/single/issue_3977_visibility_and_intent.yaml
@@ -44,13 +44,13 @@ scenarios:
           trigger_radius_m: 1.8
           trigger: runtime_robot_proximity_release
           hold_release_radius_m: 6.0
-        archetype: public_requirement_visibility_and_intent
-        flow: turning_near_pedestrian
-        behavior: proximity_released_start_stop
-        purpose: >
-          Deterministic visibility-and-intent scenario proxy for issue #3977;
-          records an authored condition where robot intent should be legible near
-          a pedestrian, not validated public acceptance or safety-certification
-          evidence.
+      archetype: public_requirement_visibility_and_intent
+      flow: turning_near_pedestrian
+      behavior: proximity_released_start_stop
+      purpose: >
+        Deterministic visibility-and-intent scenario proxy for issue #3977;
+        records an authored condition where robot intent should be legible near
+        a pedestrian, not validated public acceptance or safety-certification
+        evidence.
     seeds:
       - 3977

--- a/docs/context/issue_3977_public_requirement_scenarios.md
+++ b/docs/context/issue_3977_public_requirement_scenarios.md
@@ -1,0 +1,51 @@
+# Issue #3977 Public-Requirement Scenario Context
+
+[Issue #3977](https://github.com/ll7/robot_sf_ll7/issues/3977) added four deterministic
+scenario proxies for public-requirement diagnostics. They are authored fixtures that exercise
+loader, metadata, and detector contracts; they are not public-acceptance evidence, safety
+certification evidence, benchmark gates, or paper/dissertation claim evidence.
+
+## Scenario Families
+
+The Phase-1 scenario set is tracked by
+[`configs/scenarios/sets/issue_3977_public_requirements.yaml`](../../configs/scenarios/sets/issue_3977_public_requirements.yaml)
+and currently includes:
+
+| Family | Scenario file | Diagnostic condition |
+| --- | --- | --- |
+| Safe braking | [`issue_3977_safe_braking.yaml`](../../configs/scenarios/single/issue_3977_safe_braking.yaml) | A pedestrian steps into the robot path after a proximity release. |
+| Visibility and intent | [`issue_3977_visibility_and_intent.yaml`](../../configs/scenarios/single/issue_3977_visibility_and_intent.yaml) | A pedestrian starts or stops near a robot turn where intent should be legible. |
+| Emergency reaction | [`issue_3977_emergency_reaction.yaml`](../../configs/scenarios/single/issue_3977_emergency_reaction.yaml) | A sudden obstacle proxy becomes conflict-relevant near the robot corridor. |
+| Speed limit | [`issue_3977_speed_limit.yaml`](../../configs/scenarios/single/issue_3977_speed_limit.yaml) | A route-following scenario exposes an authored sidewalk speed cap. |
+
+## Metadata Contract
+
+Each scenario uses one scenario-level `metadata` block with:
+
+- `metadata.public_requirement.schema_version == public-requirement-scenario.v1`
+- `metadata.public_requirement.claim_boundary == authored_scenario_proxy_not_human_subject_evidence`
+- `metadata.public_requirement.event_contract.type`
+- `metadata.archetype`
+- `metadata.flow`
+- `metadata.behavior`
+- `metadata.purpose`
+
+Sibling scenario files should keep those descriptive fields as siblings of
+`metadata.public_requirement`, matching `issue_3977_safe_braking.yaml` and
+`issue_3977_speed_limit.yaml`. The focused loader test in
+[`tests/scenarios/test_issue_3977_public_requirement_scenarios.py`](../../tests/scenarios/test_issue_3977_public_requirement_scenarios.py)
+guards the manifest and metadata shape.
+
+## Detector Contract
+
+The diagnostic detector output schema is `public-requirement-events.v1`. The authored event types
+covered by this Phase-1 set are:
+
+- `pedestrian_steps_in_front`
+- `turn_or_start_stop_near_pedestrian`
+- `sudden_obstacle_proxy`
+- `speed_limit_monitor`
+
+These events are deterministic contract probes. They may support local debugging and regression
+tests, but they do not establish public-requirement satisfaction, safety certification, release
+readiness, benchmark ranking, or manuscript-facing conclusions.

--- a/tests/scenarios/test_issue_3977_public_requirement_scenarios.py
+++ b/tests/scenarios/test_issue_3977_public_requirement_scenarios.py
@@ -25,10 +25,14 @@ def test_issue_3977_public_requirement_manifest_loads_four_families() -> None:
     assert categories == EXPECTED_CATEGORIES
 
     for scenario in scenarios:
-        contract = scenario["metadata"]["public_requirement"]
+        metadata = scenario["metadata"]
+        contract = metadata["public_requirement"]
         assert contract["schema_version"] == "public-requirement-scenario.v1"
         assert contract["claim_boundary"] == "authored_scenario_proxy_not_human_subject_evidence"
         assert isinstance(contract["event_contract"]["type"], str)
+        for descriptive_key in ("archetype", "flow", "behavior", "purpose"):
+            assert isinstance(metadata[descriptive_key], str)
+            assert descriptive_key not in contract
         build_robot_config_from_scenario(scenario, scenario_path=SCENARIO_SET)
 
 


### PR DESCRIPTION
## Reviewer-critical summary

What changed: added `docs/context/issue_3977_public_requirement_scenarios.md` and normalized the #3977 visibility/intent and emergency-reaction YAML metadata so `archetype`, `flow`, `behavior`, and `purpose` are scenario-level `metadata` siblings of `public_requirement`, matching safe-braking and speed-limit.

Why now: issue #4266 is the post-#4263 hygiene follow-up for the missing Phase-1 context note and sibling YAML metadata shape drift.

Claim boundary: this is a documentation and scenario-metadata normalization slice only. It does not change scenario semantics, detector behavior, benchmark metrics, release gates, safety-certification evidence, public-acceptance evidence, or paper/dissertation claims.

Required validation: focused scenario YAML loading and metadata-contract tests plus the public-requirement selector; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

Remaining blocker: none for this slice. Full PR gate, improvement cycle, and merge authority are handed off to Claude Code on `imech156-u` per issue instructions.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: `metadata.public_requirement` no longer carries descriptive keys for `issue_3977_visibility_and_intent.yaml`; `issue_3977_emergency_reaction.yaml` now exposes the same scenario-level descriptive metadata keys as the other #3977 public-requirement scenarios.
- Scenario semantics: unchanged; proximity-release, event-contract, and speed-limit assertions remain intact.
- State propagation: no separate issue comment was posted because this run is not authorized to comment on issues or PRs (`comment_issue_or_pr: false`). This PR body is the durable status surface for the delivered slice.

## Issue

Closes #4266.

## Scope summary

- Added the Phase-1 public-requirement scenario context note for #3977.
- Normalized `issue_3977_visibility_and_intent.yaml` metadata nesting.
- Added missing scenario-level descriptive metadata to `issue_3977_emergency_reaction.yaml`.
- Extended `tests/scenarios/test_issue_3977_public_requirement_scenarios.py` to assert the descriptive keys are scenario-level metadata and absent from `metadata.public_requirement`.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenarios/test_issue_3977_public_requirement_scenarios.py -q` -> 3 passed in 0.81s.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/ -k "public_requirement or safe_braking or emergency_reaction or speed_limit" -q --disable-warnings` -> 47 passed, 10897 deselected, 1 warning in 13.59s.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/scenarios/test_issue_3977_public_requirement_scenarios.py` -> All checks passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check tests/scenarios/test_issue_3977_public_requirement_scenarios.py` -> 1 file already formatted.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python - <<'PY' ... metadata shape probe ... PY` -> `metadata-shape-ok 4`.
- `git diff --check origin/main...HEAD` -> passed.

## Out of scope

No new scenario families, no release gates, no safety-certification claims, no campaign execution, no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Freshness and guardrails</summary>

- Live issue #4266 reread immediately before PR opening: last issue/comment update was 2026-07-03T11:13:35Z, with no newer maintainer guidance found during the freshness pass.
- Duplicate PR check: no open PR found for issue #4266 or the same public-requirement metadata/context scope.
- Fragmentation guard: not triggered; only #4263 appeared as a recent merged #4266-related hit, below the two-or-more merged guardrail threshold.
- Transient queue-routing state was not encoded in tracked files.

</details>
