### PR TITLE
Issue #4164: consume goal posterior in planner comparison

### DIFF
--- a/configs/benchmarks/issue_4164_goal_intention_smoke.yaml
+++ b/configs/benchmarks/issue_4164_goal_intention_smoke.yaml
@@ -10,6 +10,8 @@ posterior_config:
 scenarios:
   - id: crossing_conflict_eastbound
     pedestrian_ids: [crossing_ped_0]
+    robot_start: [0.0, 2.0]
+    robot_goal: [4.0, 2.0]
     positions:
       - [1.0, 2.0]
     velocities:
@@ -18,6 +20,9 @@ scenarios:
       - [8.0, 2.0]
   - id: crossing_conflict_northbound
     pedestrian_ids: [crossing_ped_1]
+    robot_start: [3.0, 0.0]
+    robot_goal: [3.0, 4.0]
+    robot_heading: 1.5707963267948966
     positions:
       - [4.0, 1.0]
     velocities:

--- a/robot_sf/planner/hybrid_rule_local_planner.py
+++ b/robot_sf/planner/hybrid_rule_local_planner.py
@@ -256,6 +256,17 @@ class HybridRuleLocalPlannerConfig:
     static_safety_gate_penalty: float = 12.0
     static_safety_gate_all_sources: bool = False
 
+    # Issue #4164 opt-in posterior-consumption path. The channel currently
+    # carries confidence, not candidate goal coordinates, so this planner
+    # combines confidence with current pedestrian position/velocity only.
+    goal_posterior_avoidance_enabled: bool = False
+    goal_posterior_min_confidence: float = 0.55
+    goal_posterior_near_distance: float = 2.5
+    goal_posterior_crossing_lateral_margin: float = 0.75
+    goal_posterior_yield_speed: float = 0.15
+    goal_posterior_turn_rate: float = 0.55
+    goal_posterior_score_bonus: float = 2.0
+
     # Experimental AMV synthetic-actuation scoring for issue #1807. These
     # values intentionally mirror the diagnostic profile shape used by issue
     # #1556; they are not calibrated hardware limits.
@@ -608,9 +619,189 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
     def _candidate_source_priority(self, source: str) -> int:
         """Return a source priority for preserving specialized duplicate commands."""
         return {
+            "goal_posterior_yield_left": 40,
+            "goal_posterior_yield_right": 40,
             "corridor_subgoal": 30,
             "route_guide": 20,
         }.get(source, 10)
+
+    def _goal_posterior_metadata(self) -> dict[str, Any]:
+        """Return issue #4164 posterior-consumption configuration metadata."""
+        return {
+            "enabled": bool(self.config.goal_posterior_avoidance_enabled),
+            "status": "ok" if self.config.goal_posterior_avoidance_enabled else "disabled",
+            "min_confidence": float(self.config.goal_posterior_min_confidence),
+            "near_distance": float(self.config.goal_posterior_near_distance),
+            "crossing_lateral_margin": float(self.config.goal_posterior_crossing_lateral_margin),
+            "yield_speed": float(self.config.goal_posterior_yield_speed),
+            "turn_rate": float(self.config.goal_posterior_turn_rate),
+            "score_bonus": float(self.config.goal_posterior_score_bonus),
+            "fallback_or_degraded": False,
+        }
+
+    def _planner_goal_posterior_channel(self, observation: dict[str, Any]) -> dict[str, Any] | None:
+        """Return planner goal-posterior channel from observation or info wrapper."""
+        channel = observation.get("planner_goal_posterior_channel")
+        if isinstance(channel, dict):
+            return channel
+        info = observation.get("info")
+        if isinstance(info, dict):
+            channel = info.get("planner_goal_posterior_channel")
+            if isinstance(channel, dict):
+                return channel
+        return None
+
+    def _goal_posterior_signal(  # noqa: C901
+        self,
+        observation: dict[str, Any],
+        state: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Build a bounded crossing-risk signal from posterior metadata.
+
+        Returns:
+            Diagnostic signal consumed by candidate generation, scoring, and
+            decision reports.
+        """
+        diagnostics: dict[str, Any] = {
+            "enabled": bool(self.config.goal_posterior_avoidance_enabled),
+            "consumed": False,
+            "active": False,
+            "blocker": None,
+            "source": "planner_goal_posterior_channel",
+        }
+        if not bool(self.config.goal_posterior_avoidance_enabled):
+            diagnostics["blocker"] = "planner_disabled"
+            return diagnostics
+        channel = self._planner_goal_posterior_channel(observation)
+        if channel is None:
+            diagnostics["blocker"] = "channel_missing"
+            return diagnostics
+        diagnostics["consumed"] = True
+        if not bool(channel.get("enabled", False)):
+            diagnostics["blocker"] = "channel_disabled"
+            return diagnostics
+        summaries = channel.get("pedestrian_goal_posteriors")
+        if not isinstance(summaries, dict) or not summaries:
+            diagnostics["blocker"] = "posterior_empty"
+            return diagnostics
+
+        ped_pos = np.asarray(state["ped_pos"], dtype=float)
+        ped_vel = np.asarray(state["ped_vel"], dtype=float)
+        if ped_pos.ndim != 2 or ped_pos.shape[1] != 2 or ped_pos.shape[0] == 0:
+            diagnostics["blocker"] = "pedestrian_state_unavailable"
+            return diagnostics
+        if ped_vel.ndim != 2 or ped_vel.shape[1] != 2:
+            ped_vel = np.zeros_like(ped_pos)
+
+        robot_pos = np.asarray(state["robot_pos"], dtype=float)
+        heading = float(state["heading"])
+        forward = np.array([np.cos(heading), np.sin(heading)], dtype=float)
+        left = np.array([-forward[1], forward[0]], dtype=float)
+
+        candidates: list[dict[str, Any]] = []
+        for index, (pedestrian_id, summary) in enumerate(summaries.items()):
+            if index >= ped_pos.shape[0] or not isinstance(summary, dict):
+                continue
+            confidence = summary.get("top_goal_confidence")
+            if not isinstance(confidence, int | float | np.integer | np.floating):
+                continue
+            confidence = float(confidence)
+            if not np.isfinite(confidence):
+                continue
+            if confidence < float(self.config.goal_posterior_min_confidence):
+                continue
+            rel = ped_pos[index] - robot_pos
+            forward_distance = float(np.dot(rel, forward))
+            lateral_offset = float(np.dot(rel, left))
+            ped_speed = float(np.linalg.norm(ped_vel[index])) if index < ped_vel.shape[0] else 0.0
+            if forward_distance < 0.0 or forward_distance > float(
+                self.config.goal_posterior_near_distance
+            ):
+                continue
+            if abs(lateral_offset) > float(self.config.goal_posterior_crossing_lateral_margin):
+                continue
+            candidates.append(
+                {
+                    "pedestrian_index": int(index),
+                    "pedestrian_id": str(summary.get("pedestrian_id", pedestrian_id)),
+                    "top_goal_id": summary.get("top_goal_id"),
+                    "top_goal_confidence": confidence,
+                    "forward_distance": forward_distance,
+                    "lateral_offset": lateral_offset,
+                    "pedestrian_speed": ped_speed,
+                }
+            )
+
+        if not candidates:
+            diagnostics["blocker"] = "no_high_confidence_crossing_risk"
+            return diagnostics
+        candidates.sort(
+            key=lambda item: (
+                -float(item["top_goal_confidence"]),
+                abs(float(item["lateral_offset"])),
+                float(item["forward_distance"]),
+            )
+        )
+        selected = candidates[0]
+        turn_sign = -1.0 if float(selected["lateral_offset"]) >= 0.0 else 1.0
+        diagnostics.update(
+            {
+                "active": True,
+                "blocker": None,
+                "selected": selected,
+                "candidate_count": len(candidates),
+                "turn_sign": turn_sign,
+            }
+        )
+        return diagnostics
+
+    def _goal_posterior_candidates(
+        self,
+        goal_posterior: dict[str, Any] | None,
+        *,
+        speed_cap: float,
+        bounds: tuple[float, float, float, float],
+    ) -> list[HybridRuleCandidate]:
+        """Return posterior-aware yield candidates when crossing signal is active."""
+        if not isinstance(goal_posterior, dict) or not bool(goal_posterior.get("active")):
+            return []
+        v_min, v_max, w_min, w_max = bounds
+        turn_sign = float(goal_posterior.get("turn_sign", 1.0))
+        angular = float(
+            np.clip(
+                turn_sign * float(self.config.goal_posterior_turn_rate),
+                w_min,
+                w_max,
+            )
+        )
+        linear = float(
+            np.clip(
+                min(float(self.config.goal_posterior_yield_speed), float(speed_cap)),
+                v_min,
+                v_max,
+            )
+        )
+        source = "goal_posterior_yield_left" if angular >= 0.0 else "goal_posterior_yield_right"
+        return [HybridRuleCandidate(linear, angular, source)]
+
+    def _goal_posterior_score_term(
+        self,
+        *,
+        candidate: HybridRuleCandidate,
+        goal_posterior: dict[str, Any] | None,
+    ) -> float:
+        """Return additive score term for posterior-aware candidates."""
+        if not isinstance(goal_posterior, dict) or not bool(goal_posterior.get("active")):
+            return 0.0
+        if not candidate.source.startswith("goal_posterior_yield_"):
+            return 0.0
+        selected = goal_posterior.get("selected")
+        confidence = 1.0
+        if isinstance(selected, dict):
+            raw_confidence = selected.get("top_goal_confidence", 1.0)
+            if isinstance(raw_confidence, int | float | np.integer | np.floating):
+                confidence = float(np.clip(float(raw_confidence), 0.0, 1.0))
+        return float(self.config.goal_posterior_score_bonus) * confidence
 
     def _route_point(self, route_corridor: dict[str, Any] | None, key: str) -> np.ndarray | None:
         """Read one finite ``(x, y)`` point from route-corridor diagnostics.
@@ -1041,6 +1232,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         *,
         route_corridor: dict[str, Any] | None = None,
         corridor_subgoal: dict[str, Any] | None = None,
+        goal_posterior: dict[str, Any] | None = None,
     ) -> list[HybridRuleCandidate]:
         """Generate deterministic DWA, path-following, and safety candidates.
 
@@ -1107,6 +1299,13 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         if corridor_subgoal is not None:
             corridor_subgoal["candidate_count"] = len(subgoal_candidates)
         candidates.extend(subgoal_candidates)
+        candidates.extend(
+            self._goal_posterior_candidates(
+                goal_posterior,
+                speed_cap=speed_cap,
+                bounds=(v_min, v_max, w_min, w_max),
+            )
+        )
 
         candidates.extend(
             [
@@ -1838,7 +2037,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         route_progress = float(np.dot(end_pos - start_pos, route_dir))
         return float(np.clip(route_progress / max(max_progress, _EPS), -1.0, 1.0))
 
-    def _evaluate_candidate(  # noqa: C901, PLR0915
+    def _evaluate_candidate(  # noqa: C901, PLR0913, PLR0915
         self,
         *,
         candidate: HybridRuleCandidate,
@@ -1849,6 +2048,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         progress_windows: dict[str, float] | None = None,
         route_corridor: dict[str, Any] | None = None,
         strict_static_clearance: bool = False,
+        goal_posterior: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Filter and score one candidate command.
 
@@ -2146,6 +2346,10 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             else 0.0,
             "route_guide_commitment": route_guide_commitment,
             "static_safety_gate_penalty": static_safety_gate_penalty,
+            "goal_posterior_avoidance": self._goal_posterior_score_term(
+                candidate=candidate,
+                goal_posterior=goal_posterior,
+            ),
             "proxemic_cost": proxemic_cost_norm,
             **corridor_subgoal_terms,
             **actuation_terms,
@@ -2175,6 +2379,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             * terms["corridor_subgoal_clearance_margin"]
             + float(self.config.corridor_subgoal_continuity_weight)
             * terms["corridor_subgoal_continuity"]
+            + terms["goal_posterior_avoidance"]
             - float(self.config.actuation_clip_risk_weight) * terms["actuation_clip_risk"]
             - float(self.config.proxemic_costmap_weight) * terms["proxemic_cost"]
             - float(self.config.freezing_weight) * terms["freezing_penalty"]
@@ -2261,7 +2466,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             row["continuous_static_collision"] = bool(evaluation.get("continuous_static_collision"))
         return row
 
-    def _evaluate_candidates_for_plan(
+    def _evaluate_candidates_for_plan(  # noqa: PLR0913
         self,
         *,
         candidates: list[HybridRuleCandidate],
@@ -2272,6 +2477,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         progress_windows: dict[str, float],
         route_corridor: dict[str, Any] | None = None,
         corridor_subgoal: dict[str, Any] | None = None,
+        goal_posterior: dict[str, Any] | None = None,
     ) -> tuple[
         list[dict[str, Any]],
         Counter[str],
@@ -2301,6 +2507,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
                 progress_windows=progress_windows,
                 route_corridor=route_corridor,
                 strict_static_clearance=bool(corridor_subgoal and corridor_subgoal.get("active")),
+                goal_posterior=goal_posterior,
             )
             if bool(evaluation.get("accepted")):
                 accepted.append(evaluation)
@@ -2362,6 +2569,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         nearest_ped = self._nearest_ped_distance(robot_pos, state["ped_pos"])
         speed_cap = self._human_speed_cap(nearest_ped)
         self._clearance_context = self._build_clearance_context(observation)
+        goal_posterior = self._goal_posterior_signal(observation, state)
         corridor_subgoal = self._corridor_subgoal_activation(
             route_corridor=route_corridor,
             progress_windows=progress_windows,
@@ -2381,6 +2589,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             speed_cap,
             route_corridor=route_corridor,
             corridor_subgoal=corridor_subgoal_for_candidates,
+            goal_posterior=goal_posterior,
         )
         (
             accepted,
@@ -2397,6 +2606,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             progress_windows=progress_windows,
             route_corridor=route_corridor,
             corridor_subgoal=corridor_subgoal_for_candidates,
+            goal_posterior=goal_posterior,
         )
 
         self._rejection_counts.update(rejection_counts)
@@ -2466,6 +2676,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             route_corridor=route_corridor,
             corridor_subgoal=corridor_subgoal_for_candidates,
             route_trace_recovery=route_trace_recovery,
+            goal_posterior=goal_posterior,
             actuation_diagnostics=actuation_diagnostics,
             static_safety_gate=static_safety_gate,
             rejected_examples=rejected_examples,
@@ -2507,6 +2718,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         route_corridor: dict[str, Any] | None = None,
         corridor_subgoal: dict[str, Any] | None = None,
         route_trace_recovery: dict[str, Any] | None = None,
+        goal_posterior: dict[str, Any] | None = None,
         actuation_diagnostics: dict[str, Any] | None = None,
         static_safety_gate: dict[str, Any] | None = None,
         rejected_examples: list[dict[str, Any]] | None = None,
@@ -2547,6 +2759,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             "route_corridor": route_corridor,
             "corridor_subgoal": corridor_subgoal,
             "route_trace_recovery": route_trace_recovery,
+            "goal_posterior_avoidance": goal_posterior,
             "selected_actuation_diagnostics": actuation_diagnostics,
             "selected_static_safety_gate": static_safety_gate,
         }
@@ -2558,6 +2771,7 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
             "value_scorer": self._value_scorer_metadata(),
             "proxemic_costmap": self._proxemic_costmap_metadata(),
             "actuation_scoring": self._actuation_scoring_metadata(),
+            "goal_posterior_avoidance": self._goal_posterior_metadata(),
             "steps": int(self._step_index),
             "selected_source_counts": dict(sorted(self._selected_source_counts.items())),
             "rejection_counts": dict(sorted(self._rejection_counts.items())),

--- a/robot_sf/planner/topology_guided_local_policy.py
+++ b/robot_sf/planner/topology_guided_local_policy.py
@@ -1111,6 +1111,7 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
         *,
         route_corridor: dict[str, Any] | None = None,
         corridor_subgoal: dict[str, Any] | None = None,
+        goal_posterior: dict[str, Any] | None = None,
     ) -> list[HybridRuleCandidate]:
         """Add a selected-hypothesis command to the base hybrid-rule candidate set.
 
@@ -1122,6 +1123,7 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
             speed_cap,
             route_corridor=route_corridor,
             corridor_subgoal=corridor_subgoal,
+            goal_posterior=goal_posterior,
         )
         topology_candidate = self._topology_hypothesis_candidate(
             state=state,

--- a/scripts/benchmark/run_goal_posterior_planner_input_smoke_issue_4164.py
+++ b/scripts/benchmark/run_goal_posterior_planner_input_smoke_issue_4164.py
@@ -1,28 +1,36 @@
-"""CPU smoke comparison for issue #4164 goal-posterior planner input.
+"""CPU smoke comparison for issue #4164 goal-posterior planner consumption.
 
-This script exercises the opt-in planner metadata channel with and without the
-Bayesian goal posterior enabled. It is diagnostic wiring evidence only, not a
-full benchmark campaign or calibrated intention-prediction claim.
+This script runs a bounded deterministic closed-loop proxy with and without the
+opt-in goal-posterior channel. It is smoke evidence that one planner consumes
+posterior metadata during action selection; it is not a full benchmark campaign,
+planner-performance claim, or calibrated human-intention claim.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import time
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import yaml
 
+from robot_sf.planner.hybrid_rule_local_planner import (
+    HybridRuleLocalPlannerAdapter,
+    HybridRuleLocalPlannerConfig,
+)
 from robot_sf.prediction.goal_intention import (
     GoalPosteriorConfig,
     planner_goal_posterior_channel_from_state,
 )
 
 CLAIM_BOUNDARY = (
-    "diagnostic CPU smoke for opt-in planner input wiring; no full benchmark campaign, "
-    "no calibrated human-intention claim, no planner-performance claim"
+    "smoke evidence: hybrid_rule_local_planner consumes goal-posterior metadata in a "
+    "bounded CPU closed-loop proxy; no full benchmark campaign, no calibrated "
+    "human-intention claim, no planner-performance claim"
 )
 
 
@@ -55,6 +63,80 @@ def _scenario_rows(config: dict[str, Any]) -> list[dict[str, Any]]:
     return scenarios
 
 
+def _as_xy_rows(value: Any, *, field_name: str) -> np.ndarray:
+    rows = np.asarray(value, dtype=float)
+    if rows.ndim == 1:
+        rows = rows.reshape(1, -1)
+    if rows.ndim != 2 or rows.shape[1] != 2 or not np.all(np.isfinite(rows)):
+        raise ValueError(f"{field_name} must be finite xy rows")
+    return rows
+
+
+def _channel_for_scenario(
+    *,
+    enabled: bool,
+    scenario: dict[str, Any],
+    posterior_config: GoalPosteriorConfig,
+) -> dict[str, Any]:
+    positions = _as_xy_rows(scenario["positions"], field_name="positions")
+    velocities = _as_xy_rows(scenario["velocities"], field_name="velocities")
+    goals = _as_xy_rows(scenario["goals"], field_name="goals")
+    pedestrian_ids = scenario.get("pedestrian_ids")
+    return planner_goal_posterior_channel_from_state(
+        enabled=enabled,
+        positions=positions.tolist(),
+        velocities=velocities.tolist(),
+        goals=goals.tolist(),
+        pedestrian_ids=pedestrian_ids,
+        config=posterior_config,
+    )
+
+
+def _observation(
+    *,
+    robot: np.ndarray,
+    heading: float,
+    goal: np.ndarray,
+    speed: float,
+    ped_positions: np.ndarray,
+    ped_velocities: np.ndarray,
+    channel: dict[str, Any] | None,
+) -> dict[str, Any]:
+    obs: dict[str, Any] = {
+        "robot": {
+            "position": robot.copy(),
+            "heading": np.asarray([heading], dtype=float),
+            "speed": np.asarray([speed], dtype=float),
+            "radius": np.asarray([0.25], dtype=float),
+        },
+        "goal": {"current": goal.copy(), "next": goal.copy()},
+        "pedestrians": {
+            "positions": ped_positions.copy(),
+            "velocities": ped_velocities.copy(),
+            "count": np.asarray([ped_positions.shape[0]], dtype=float),
+            "radius": 0.25,
+        },
+        "sim": {"timestep": 0.2},
+    }
+    if channel is not None:
+        obs["info"] = {"planner_goal_posterior_channel": channel}
+    return obs
+
+
+def _planner(enabled: bool) -> HybridRuleLocalPlannerAdapter:
+    return HybridRuleLocalPlannerAdapter(
+        HybridRuleLocalPlannerConfig(
+            goal_posterior_avoidance_enabled=enabled,
+            goal_posterior_min_confidence=0.5,
+            goal_posterior_near_distance=3.0,
+            goal_posterior_crossing_lateral_margin=1.0,
+            goal_posterior_yield_speed=0.05,
+            goal_posterior_turn_rate=0.7,
+            goal_posterior_score_bonus=20.0,
+        )
+    )
+
+
 def _run_arm(
     *,
     enabled: bool,
@@ -62,40 +144,81 @@ def _run_arm(
     posterior_config: GoalPosteriorConfig,
 ) -> dict[str, Any]:
     start = time.perf_counter()
-    channel = planner_goal_posterior_channel_from_state(
+    planner = _planner(enabled)
+    channel = _channel_for_scenario(
         enabled=enabled,
-        positions=scenario["positions"],
-        velocities=scenario["velocities"],
-        goals=scenario["goals"],
-        pedestrian_ids=scenario.get("pedestrian_ids"),
-        config=posterior_config,
+        scenario=scenario,
+        posterior_config=posterior_config,
     )
-    runtime_s = time.perf_counter() - start
-    posteriors = channel["pedestrian_goal_posteriors"]
+    ped_positions = _as_xy_rows(scenario["positions"], field_name="positions")
+    ped_velocities = _as_xy_rows(scenario["velocities"], field_name="velocities")
+    robot = np.asarray(scenario.get("robot_start", [0.0, 0.0]), dtype=float)
+    goal = np.asarray(scenario.get("robot_goal", [4.0, 0.0]), dtype=float)
+    heading = float(scenario.get("robot_heading", 0.0))
+    speed = float(scenario.get("robot_speed", 0.0))
+    dt = 0.2
+    trajectory: list[list[float]] = [[float(robot[0]), float(robot[1])]]
+    commands: list[list[float]] = []
+    sources: list[str] = []
+    selected_terms: list[dict[str, float]] = []
+    posterior_diagnostics: list[dict[str, Any] | None] = []
+    initial_distance = float(np.linalg.norm(goal - robot))
+
+    for _step in range(int(scenario.get("closed_loop_steps", 4))):
+        obs = _observation(
+            robot=robot,
+            heading=heading,
+            goal=goal,
+            speed=speed,
+            ped_positions=ped_positions,
+            ped_velocities=ped_velocities,
+            channel=channel,
+        )
+        linear, angular = planner.plan(obs)
+        decision = planner.last_decision() or {}
+        commands.append([float(linear), float(angular)])
+        sources.append(str(decision.get("selected_source", "unknown")))
+        selected_terms.append(dict(decision.get("selected_terms", {})))
+        posterior_diagnostics.append(decision.get("goal_posterior_avoidance"))
+        heading += float(angular) * dt
+        robot = robot + np.asarray([math.cos(heading), math.sin(heading)]) * float(linear) * dt
+        speed = float(linear)
+        trajectory.append([float(robot[0]), float(robot[1])])
+
+    final_distance = float(np.linalg.norm(goal - robot))
+    diagnostics = planner.diagnostics()
+    fallback_count = int(diagnostics.get("fallback_count", 0))
+    degraded_exclusions = {
+        "fallback_count": fallback_count,
+        "fallback_or_degraded": bool(fallback_count),
+        "posterior_blockers": [
+            item.get("blocker")
+            for item in posterior_diagnostics
+            if isinstance(item, dict) and item.get("blocker")
+        ],
+    }
     return {
-        "enabled": enabled,
-        "runtime_s": runtime_s,
-        "channel_present": bool(channel["enabled"]) and bool(posteriors),
-        "pedestrian_count": len(scenario["positions"]),
-        "top_goal_ids": {
-            pedestrian_id: summary["top_goal_id"] for pedestrian_id, summary in posteriors.items()
-        },
-        "top_goal_confidences": {
-            pedestrian_id: summary["top_goal_confidence"]
-            for pedestrian_id, summary in posteriors.items()
-        },
-        "blockers": {
-            pedestrian_id: summary["blocker"]
-            for pedestrian_id, summary in posteriors.items()
-            if summary["blocker"] is not None
-        },
-        "channel": channel,
+        "channel_present": enabled,
+        "planner_consumed_channel": any(
+            bool(item.get("consumed")) for item in posterior_diagnostics if isinstance(item, dict)
+        ),
+        "posterior_active": any(
+            bool(item.get("active")) for item in posterior_diagnostics if isinstance(item, dict)
+        ),
+        "commands": commands,
+        "selected_sources": sources,
+        "selected_terms": selected_terms,
+        "trajectory": trajectory,
+        "route_progress": initial_distance - final_distance,
+        "final_goal_distance": final_distance,
+        "planner_diagnostics": diagnostics,
+        "degraded_exclusions": degraded_exclusions,
+        "runtime_s": time.perf_counter() - start,
     }
 
 
 def build_report(config_path: Path) -> dict[str, Any]:
-    """Return diagnostic with/without planner-input channel comparison."""
-
+    """Return diagnostic with/without planner-consumption comparison."""
     config = _load_config(config_path)
     posterior_config = _posterior_config(config)
     scenario_reports = []
@@ -110,17 +233,30 @@ def build_report(config_path: Path) -> dict[str, Any]:
             scenario=scenario,
             posterior_config=posterior_config,
         )
+        command_source_changed = (
+            without_channel["selected_sources"] != with_channel["selected_sources"]
+        )
+        trajectory_changed = without_channel["trajectory"] != with_channel["trajectory"]
         scenario_reports.append(
             {
                 "scenario_id": scenario["id"],
-                "planner_path": "metadata_channel",
+                "planner_path": "hybrid_rule_local_planner.goal_posterior_avoidance",
                 "without_goal_posterior": without_channel,
                 "with_goal_posterior": with_channel,
-                "runtime_overhead_s": (with_channel["runtime_s"] - without_channel["runtime_s"]),
+                "command_source_changed": command_source_changed,
+                "trajectory_changed": trajectory_changed,
+                "route_progress_delta": (
+                    with_channel["route_progress"] - without_channel["route_progress"]
+                ),
+                "runtime_overhead_s": with_channel["runtime_s"] - without_channel["runtime_s"],
+                "fallback_or_degraded_exclusions": {
+                    "without": without_channel["degraded_exclusions"],
+                    "with": with_channel["degraded_exclusions"],
+                },
             }
         )
     return {
-        "schema_version": "issue_4164_goal_posterior_planner_input_smoke.v1",
+        "schema_version": "issue_4164_goal_posterior_planner_consumption_smoke.v1",
         "config_path": str(config_path),
         "claim_boundary": CLAIM_BOUNDARY,
         "posterior_config": {
@@ -134,8 +270,7 @@ def build_report(config_path: Path) -> dict[str, Any]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the issue #4164 CPU smoke report CLI."""
-
+    """Run issue #4164 CPU smoke report CLI."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--config",
@@ -148,7 +283,6 @@ def main(argv: list[str] | None = None) -> int:
         default=Path("output/benchmarks/issue_4164_goal_intention_smoke.json"),
     )
     args = parser.parse_args(argv)
-
     report = build_report(args.config)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/benchmark/test_goal_posterior_planner_input_smoke_issue_4164.py
+++ b/tests/benchmark/test_goal_posterior_planner_input_smoke_issue_4164.py
@@ -1,4 +1,4 @@
-"""Tests for issue #4164 goal-posterior planner-input smoke report."""
+"""Tests for issue #4164 goal-posterior planner-consumption smoke report."""
 
 from __future__ import annotations
 
@@ -20,26 +20,34 @@ build_report = _MODULE.build_report
 main = _MODULE.main
 
 
-def test_goal_posterior_smoke_report_has_paired_enabled_rows() -> None:
-    """Smoke report includes paired disabled/enabled rows."""
-
+def test_goal_posterior_smoke_report_has_planner_consumption_rows() -> None:
+    """Smoke report includes paired planner-consumption effects."""
     report = build_report(_CONFIG_PATH)
 
-    assert report["schema_version"] == "issue_4164_goal_posterior_planner_input_smoke.v1"
+    assert report["schema_version"] == "issue_4164_goal_posterior_planner_consumption_smoke.v1"
     assert "no full benchmark campaign" in report["claim_boundary"]
     assert len(report["scenarios"]) == 2
     for scenario in report["scenarios"]:
-        assert scenario["without_goal_posterior"]["channel_present"] is False
-        assert scenario["with_goal_posterior"]["channel_present"] is True
-        assert scenario["with_goal_posterior"]["top_goal_ids"]
-        assert scenario["with_goal_posterior"]["blockers"] == {}
+        without = scenario["without_goal_posterior"]
+        with_posterior = scenario["with_goal_posterior"]
+
+        assert scenario["planner_path"] == "hybrid_rule_local_planner.goal_posterior_avoidance"
+        assert without["planner_consumed_channel"] is False
+        assert with_posterior["planner_consumed_channel"] is True
+        assert with_posterior["posterior_active"] is True
+        assert scenario["command_source_changed"] or scenario["trajectory_changed"]
+        assert isinstance(scenario["route_progress_delta"], float)
+        assert scenario["fallback_or_degraded_exclusions"]["with"]["fallback_or_degraded"] is False
+        assert with_posterior["selected_sources"]
+        assert any(
+            source.startswith("goal_posterior_yield_")
+            for source in with_posterior["selected_sources"]
+        )
 
 
 def test_goal_posterior_smoke_main_writes_json(tmp_path: Path) -> None:
     """Smoke CLI writes compact JSON evidence."""
-
     output_path = tmp_path / "smoke.json"
-
     exit_code = main(
         [
             "--config",
@@ -52,4 +60,4 @@ def test_goal_posterior_smoke_main_writes_json(tmp_path: Path) -> None:
     assert exit_code == 0
     payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert payload["posterior_config"]["config_hash"]
-    assert len(payload["scenarios"]) == 2
+    assert payload["scenarios"][0]["with_goal_posterior"]["planner_consumed_channel"] is True

--- a/tests/planner/test_hybrid_rule_local_planner.py
+++ b/tests/planner/test_hybrid_rule_local_planner.py
@@ -151,6 +151,57 @@ def test_hybrid_rule_v0_returns_diagnostics_for_open_space() -> None:
     assert diagnostics["selected_source_counts"]
 
 
+def test_goal_posterior_channel_can_change_selected_command_from_info() -> None:
+    """Opt-in issue #4164 path consumes info channel during action selection."""
+    base = HybridRuleLocalPlannerAdapter(HybridRuleLocalPlannerConfig())
+    obs = _obs(
+        goal=(4.0, 0.0),
+        ped_positions=[(1.0, 0.2)],
+        ped_velocities=[(0.0, 0.8)],
+    )
+    base_command = base.plan(obs)
+
+    config = HybridRuleLocalPlannerConfig(
+        goal_posterior_avoidance_enabled=True,
+        goal_posterior_min_confidence=0.5,
+        goal_posterior_near_distance=2.0,
+        goal_posterior_crossing_lateral_margin=0.5,
+        goal_posterior_yield_speed=0.05,
+        goal_posterior_turn_rate=0.7,
+        goal_posterior_score_bonus=20.0,
+    )
+    planner = HybridRuleLocalPlannerAdapter(config)
+    posterior_obs = _obs(
+        goal=(4.0, 0.0),
+        ped_positions=[(1.0, 0.2)],
+        ped_velocities=[(0.0, 0.8)],
+    )
+    posterior_obs["info"] = {
+        "planner_goal_posterior_channel": {
+            "enabled": True,
+            "pedestrian_goal_posteriors": {
+                "crossing_ped_0": {
+                    "pedestrian_id": "crossing_ped_0",
+                    "top_goal_id": "crossing_ped_0_route_goal",
+                    "top_goal_confidence": 0.9,
+                    "blocker": None,
+                }
+            },
+        }
+    }
+
+    posterior_command = planner.plan(posterior_obs)
+    diagnostics = planner.diagnostics()
+    last = diagnostics["last_decision"]
+
+    assert posterior_command != base_command
+    assert last["selected_source"].startswith("goal_posterior_yield_")
+    assert last["goal_posterior_avoidance"]["consumed"] is True
+    assert last["goal_posterior_avoidance"]["active"] is True
+    assert last["selected_terms"]["goal_posterior_avoidance"] > 0.0
+    assert diagnostics["goal_posterior_avoidance"]["enabled"] is True
+
+
 def test_tentabot_value_scorer_v0_exposes_clean_room_diagnostics() -> None:
     """The Tentabot-style spike should be guarded and explicit about provenance."""
     config = build_hybrid_rule_local_planner_config(

--- a/tests/planner/test_hybrid_rule_local_planner.py
+++ b/tests/planner/test_hybrid_rule_local_planner.py
@@ -1725,7 +1725,7 @@ def test_hybrid_rule_rejection_diagnostics_include_moving_and_source_counts(monk
         lambda state, speed_cap, **kwargs: [stop, rotate, blocked_forward],
     )
 
-    def evaluate_candidate(
+    def evaluate_candidate(  # noqa: PLR0913
         *,
         candidate,
         observation,
@@ -1735,6 +1735,7 @@ def test_hybrid_rule_rejection_diagnostics_include_moving_and_source_counts(monk
         progress_windows,
         route_corridor=None,
         strict_static_clearance=False,
+        goal_posterior=None,
     ):
         """Return controlled candidate evaluations for rejection diagnostics."""
         if candidate == blocked_forward:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `hybrid_rule_local_planner` now has an opt-in `goal_posterior_avoidance` path that reads `planner_goal_posterior_channel` from the observation or `info` wrapper, adds named posterior-aware yield candidates during action selection, and records consumed/active/blocker diagnostics in `last_decision`.

Why now: issue #4164 carry-forward from merged PR #4236 said the channel was write-only and the next slice must make one planner consume it in closed-loop comparison.

Claim boundary: smoke evidence only. This proves one planner path consumes the metadata and can change command source, trajectory, and route progress in a bounded CPU crossing-conflict proxy. It is not a full benchmark campaign, calibrated human-intention claim, planner-performance claim, paper/dissertation edit, or Slurm/GPU result.

Required validation: focused planner-consumption tests, existing posterior tests, Ruff checks, and the issue #4164 CPU smoke report.

Remaining blocker: broader benchmark evidence is still open under #4164; this PR intentionally stops at diagnostic smoke evidence.

## Contract delta

- New planner config fields on `HybridRuleLocalPlannerConfig`, all default-off: `goal_posterior_avoidance_enabled`, `goal_posterior_min_confidence`, `goal_posterior_near_distance`, `goal_posterior_crossing_lateral_margin`, `goal_posterior_yield_speed`, `goal_posterior_turn_rate`, `goal_posterior_score_bonus`.
- No change to `info["planner_goal_posterior_channel"]` schema and no reimplementation of metadata plumbing.
- New selected command sources may appear only when enabled: `goal_posterior_yield_left` / `goal_posterior_yield_right`.
- New planner diagnostics: `diagnostics()["goal_posterior_avoidance"]` and `last_decision["goal_posterior_avoidance"]`.
- Compatibility impact: default behavior remains disabled, so existing configs do not consume the channel unless explicitly opted in.
- Fail-closed/degraded reporting: disabled, missing, disabled-channel, empty posterior, unavailable pedestrian state, or no high-confidence crossing risk are recorded as blockers rather than silently treated as success.

## Linked Issues

- Relates #4164

## Scope summary

- Added bounded posterior-consumption behavior to one planner path: `hybrid_rule_local_planner.goal_posterior_avoidance`.
- Updated the issue #4164 smoke config with explicit crossing robot start/goal paths.
- Reworked the issue #4164 smoke script to run posterior off/on closed-loop proxy arms and report command-source changes, trajectory effects, route progress delta, and fallback/degraded exclusions.
- Added focused tests for direct planner consumption from `info["planner_goal_posterior_channel"]` and the smoke report.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no calibrated-intention claim, no posterior metadata schema/plumbing rewrite.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/planner/hybrid_rule_local_planner.py scripts/benchmark/run_goal_posterior_planner_input_smoke_issue_4164.py tests/planner/test_hybrid_rule_local_planner.py tests/benchmark/test_goal_posterior_planner_input_smoke_issue_4164.py`  
  Result: passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/planner/test_hybrid_rule_local_planner.py::test_goal_posterior_channel_can_change_selected_command_from_info tests/benchmark/test_goal_posterior_planner_input_smoke_issue_4164.py -q`  
  Result: 3 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/prediction/test_goal_intention.py tests/planner/test_hybrid_rule_local_planner.py::test_goal_posterior_channel_can_change_selected_command_from_info tests/benchmark/test_goal_posterior_planner_input_smoke_issue_4164.py -q`  
  Result: 10 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/run_goal_posterior_planner_input_smoke_issue_4164.py --config configs/benchmarks/issue_4164_goal_intention_smoke.yaml --output output/benchmarks/issue_4164_goal_intention_smoke.json`  
  Result: passed; local ignored JSON reports both scenarios changed command source and trajectory, with fallback count 0 in posterior-enabled arms.

## Evidence summary

- `crossing_conflict_eastbound`: source changed from `dynamic_window` to `goal_posterior_yield_right`, trajectory changed, route progress delta `-0.172907`, fallback/degraded false.
- `crossing_conflict_northbound`: source changed from `dynamic_window` to `goal_posterior_yield_left` on the first step, trajectory changed, route progress delta `0.108049`, fallback/degraded false.

## Domain-Aware Approval

Domain-aware approval concerns experimental validity and is pending reviewer. This PR changes planner-consumption behavior and reports diagnostic smoke evidence only; it must not be treated as benchmark-strength or paper-facing evidence without reviewer approval.

- Required PR: required for diagnostic planner-comparison smoke evidence validity review.
- Domains reviewed: planner-consumption behavior, diagnostic smoke comparison, fallback/degraded exclusions.
- Status: pending reviewer approval.
- Approval or blocker note: awaiting Claude or maintainer domain review; full PR gate owns approval before merge.
- Target claim/hypothesis: one planner path consumes `planner_goal_posterior_channel`.
- Comparator or split/evidence validity: paired posterior disabled compared with posterior enabled CPU smoke proxy using the same `hybrid_rule_local_planner` and issue #4164 crossing-conflict config.
- Fallback/degraded exclusions: reported per arm; posterior-enabled fallback count 0.
- Claim boundary: diagnostic smoke evidence only.
- Implementation integrity vs experimental validity: default-off implementation; no planner-performance or calibrated-intention claim.

## Downstream Propagation

- Parent issue updated: no. `comment_issue_or_pr=false` in the task authorization, and the PR body is the durable propagation surface for this slice.
- Claim map / benchmark report updated: no, diagnostic smoke evidence only.
- Leaderboard / artifact catalog updated: no, no benchmark-strength result or durable artifact.
- Registry or config index updated: no, existing issue smoke config was updated in place.
- Context index / memory note updated: no, the scope is represented by this PR and issue #4164.
- Follow-up issue opened deferred propagation: no.

<details>
<summary>Appendix: template fields and review notes</summary>

## Stack / Dependency

- Base dependency: `origin/main`
- Required prior PRs: #4236 already merged
- Stack follow-up issues: #4164 remains open
- Safe review independently: yes
- Review dependency reason: this is the successor consumption slice after #4236 metadata exposure.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: blocker-resolution for write-only posterior metadata; first planner-consumption path.
- Comparator or baseline, applicable: same planner with posterior consumption disabled compared with enabled.
- Evidence tier: targeted smoke / diagnostic probe.
- Result classification: diagnostic-only.
- Decision stop rule, applicable: stop at proof that one planner consumes channel and reports action/trajectory/progress effects.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #4164.
- New research/benchmark/metric/paper-facing analysis tool, any: no.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes.
- Did intervention change command source, selected command, trajectory, route progress? yes in smoke report.
- Did scenario actually contain targeted failure mode? bounded crossing-conflict proxy only.
- Result route: continue to broader benchmark if needed.
- Follow-up question issue weak, negative, non-transfer results: issue #4164 remains open.

## Risks / Rollout

- Compatibility risks: low; new behavior is opt-in and default-off.
- Failure modes: channel lacks goal coordinates, so this slice uses confidence plus current pedestrian motion and records blockers when risk signal is unavailable.
- Rollback fallback plan: disable `goal_posterior_avoidance_enabled` or revert this commit.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: issue #4164 comments, especially 2026-07-03 active successor slice.
- Any assumptions need preserved: the planner intentionally does not change posterior channel schema.

## Follow-Up Issues

- Deferred work: broader benchmark campaign and calibrated-intention claims remain out of scope and stay tracked by #4164.
- Issues opened follow-up: none.

## Reviewer Notes

- Verify closely: the channel may arrive under `observation["planner_goal_posterior_channel"]` or `observation["info"]["planner_goal_posterior_channel"]`.
- Known limitations: local `output/` JSON is ignored smoke evidence, not a durable benchmark artifact.

</details>
