### PR TITLE
Issue #4216: record post-guard LiCCA full-suite closure probe

### DIFF
--- a/docs/context/evidence/issue_4216_licca_full_suite_env_failures/post_guard_closure_20260703.json
+++ b/docs/context/evidence/issue_4216_licca_full_suite_env_failures/post_guard_closure_20260703.json
@@ -1,0 +1,54 @@
+{
+  "issue": 4216,
+  "evidence_type": "post_guard_full_suite_closure_probe",
+  "status": "blocked",
+  "claim_boundary": "Post-guard suite output reached 100% without a failure traceback for the 15 job-9858988 LiCCA residue nodes, but the pytest process did not exit; this is diagnostic closure evidence, not a successful full-suite gate.",
+  "source_inventory": {
+    "path": "docs/context/evidence/issue_4216_licca_full_suite_env_failures/failure_inventory.json",
+    "source_job": "9858988",
+    "failure_count": 15,
+    "failure_classes": {
+      "base_ref_assumption": 9,
+      "github_runner_introspection": 3,
+      "shared_node_wallclock": 3
+    }
+  },
+  "post_guard_probe": {
+    "date": "2026-07-03",
+    "base_commit": "022f60c69749861a578d1bc0a6ca87e0e39d2040",
+    "command": "PYTEST_NUM_WORKERS=8 ROBOT_SF_TEST_ENV=licca uv run pytest -q",
+    "scope": "repository full test suite with the LiCCA/shared-HPC guard marker enabled",
+    "observed_stdout": {
+      "reached_100_percent": true,
+      "failure_traceback_seen": false,
+      "error_summary_seen": false,
+      "final_pytest_summary_seen": false
+    },
+    "exit": {
+      "exit_code": 143,
+      "reason": "manual SIGTERM after pytest reached 100% and then produced no new output while a nested pytest child remained alive"
+    },
+    "process_snapshot": {
+      "nested_pytest_child_remained": true,
+      "gpu_device_handles_seen": true,
+      "ptrace_stack_capture": "unavailable: host ptrace policy blocked gdb attach"
+    }
+  },
+  "comparison_to_job_9858988": {
+    "job_9858988_failures": 15,
+    "post_guard_failure_tracebacks_seen_for_inventory_nodes": 0,
+    "post_guard_environment_conditional_failures_remaining": "not established; no failure traceback appeared, but full-suite process exit was blocked by teardown hang",
+    "residual_blocker": "Identify and close the post-100% nested pytest teardown hang before treating the LiCCA full-suite row as green."
+  },
+  "artifact_policy": {
+    "large_or_transient_logs_committed": false,
+    "raw_snapshots": "local-only debugging inputs; not committed and not a durable dependency",
+    "local_raw_snapshot_checksums": {
+      "post_guard_full_suite_log_sha256": "daf321db9ffd18fa377725cc95b073fcb9e1910e74044340ae99a31b32a06383",
+      "hang_process_snapshot_sha256": "0f749d0eb5b2fb5360d5971e517e5a518af9da3e6b0f0889cc594717b09843b1",
+      "gdb_attach_attempt_sha256": "734ba920970bc38353a56fc79116cc8fd0cc21c5e1334e0d2b71d501ae53bc32"
+    },
+    "compute_submission": false,
+    "slurm_or_gpu_campaign": false
+  }
+}


### PR DESCRIPTION
## Reviewer-critical summary

Changed: added `docs/context/evidence/issue_4216_licca_full_suite_env_failures/post_guard_closure_20260703.json`, a compact post-#4237 closure probe for issue #4216.

Why now: PR #4237 merged the LiCCA/shared-HPC guards and left the empirical post-guard residue check as the remaining closure step.

Claim boundary: this is diagnostic closure evidence, not a green full-suite claim. The full-suite output reached 100% with no failure traceback or error summary for the 15 job-9858988 residue nodes, but pytest did not exit; a nested pytest child remained alive and held GPU device handles, so the row is blocked by teardown hang.

Required validation: treat the #4216 guard behavior as covered by targeted tests below, and treat the full-suite row as blocked until the post-100% teardown hang is isolated and fixed.

Remaining blocker: identify why the nested pytest child survives after the suite reaches 100%, then rerun the same `ROBOT_SF_TEST_ENV=licca` full-suite row to get an actual exit code and final pytest summary.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4216

## Contract delta

New schema fields: none.

New fail-closed blockers: records the post-guard full-suite row as blocked when pytest reaches 100% but does not exit and no final pytest summary is emitted.

Compatibility impact: docs/evidence only; no runtime code, test guard, CI coverage, or benchmark contract changed.

## Scope

- Added one compact tracked evidence JSON under the existing #4216 evidence directory.
- Compared the post-guard probe against the job-9858988 15-node inventory already committed by #4237.
- Kept raw full-suite logs and process snapshots local-only; they are summarized by checksum in the tracked JSON and are not durable dependencies.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Validation

- `jq . docs/context/evidence/issue_4216_licca_full_suite_env_failures/post_guard_closure_20260703.json >/dev/null` - passed.
- `uv run python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog` - passed.
- `uv run pytest tests/support/test_environment_guards.py -q` - passed, `5 passed`.
- `uv run pytest tests/dev/test_pr_ready_preflight.py tests/dev/test_ci_uv_sync_diag.py tests/test_visualization_performance.py -q` - passed, `22 passed`.
- `ROBOT_SF_TEST_ENV=licca uv run pytest tests/support/test_environment_guards.py tests/dev/test_pr_ready_preflight.py tests/dev/test_ci_uv_sync_diag.py tests/test_visualization_performance.py -q` - passed, `27 passed`.
- `GITHUB_ACTIONS=true ROBOT_SF_TEST_ENV=licca uv run pytest tests/support/test_environment_guards.py -q` - passed, `5 passed`.
- `PYTEST_NUM_WORKERS=8 ROBOT_SF_TEST_ENV=licca uv run pytest -q` - reached `[100%]` with no failure traceback or error summary, then hung without final pytest summary; manually terminated with exit code 143. This is the residual blocker recorded by this PR.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` - failed on pre-existing `docs/context/catalog.yaml` entries pointing at ignored `output/` artifacts; after removing the new artifact's own `output/` reference, the remaining errors were unrelated catalog debt.

## Downstream propagation

No issue comment was added because this run is not authorized to comment on issues or PRs. This PR body is the canonical propagation surface for this slice.

<details>
<summary>Appendix: artifact policy and late-guidance checks</summary>

- Raw validation logs/process snapshots are local-only debugging inputs and were not committed.
- The tracked JSON records checksums for the local raw snapshots and explicitly marks them non-durable.
- No open PR covered #4216 immediately before PR creation.
- Issue #4216 was reread with comments immediately before PR creation; no maintainer comments newer than the run start were present.
- Fragmentation guard: only #4237 was a #4216 PR merged in the last 24 hours, so this closure-probe slice is not blocked as another micro-guard.

</details>
