### PR TITLE
Issue #4016: prove QR-DQN trainer adapter handoff

### DIFF
--- a/tests/training/test_train_distributional_rl_dry_run.py
+++ b/tests/training/test_train_distributional_rl_dry_run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from robot_sf.baselines.distributional_rl import DistributionalRLPlanner
 from scripts.training.train_distributional_rl import (
     load_distributional_rl_training_config,
     run_distributional_rl_training,
@@ -76,3 +77,29 @@ def test_distributional_rl_cpu_smoke_trains_and_writes_trace(tmp_path: Path) -> 
     assert manifest["dry_run"] is False
     assert manifest["final_loss"] is not None
     assert Path(result["training_trace_path"]).read_text(encoding="utf-8").strip()
+
+
+def test_distributional_rl_smoke_checkpoint_loads_runtime_adapter(tmp_path: Path) -> None:
+    """Trainer output is directly loadable by the map-runner runtime adapter."""
+
+    config = load_distributional_rl_training_config(_write_config(tmp_path, total_timesteps=8))
+    result = run_distributional_rl_training(config, dry_run=False)
+
+    planner = DistributionalRLPlanner(
+        {
+            "checkpoint_path": result["checkpoint_path"],
+            "risk_objective": "cvar_lower",
+            "risk_alpha": 0.5,
+        }
+    )
+
+    action = planner.step({"goal_position": [1.0, 0.0], "robot_position": [0.0, 0.0]})
+    manifest = json.loads(Path(result["manifest_path"]).read_text(encoding="utf-8"))
+
+    assert set(action) == {"v", "omega"}
+    assert manifest["checkpoint_path"] == result["checkpoint_path"]
+    assert planner.get_metadata()["evidence_tier"] == "diagnostic-only"
+    assert (
+        planner.diagnostics()["last_decision"]["candidate_count"]
+        == config.action_lattice.action_count
+    )


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a focused integration test proving the QR-DQN smoke trainer's own checkpoint can be loaded by the `DistributionalRLPlanner` runtime adapter, stepped as an absolute unicycle-command policy, and reported with diagnostic-only metadata.

Why now: PR 4157 added primitives and PR 4215 merged the trainer plus runtime adapter. This PR is the smallest consolidation slice for issue #4016 that closes the untested trainer-to-adapter handoff without duplicating the merged implementation.

Claim boundary: CPU smoke and adapter-load contract only. This is not benchmark evidence, not paper-grade evidence, and not a safety-improvement claim.

Required validation: focused CPU tests for QR-DQN trainer config/dry-run/smoke, runtime planner, map-runner registration, plus ruff on touched QR-DQN surfaces.

Remaining blocker: issue #4016 still needs matched mean-vs-CVaR diagnostic comparison before the issue-level evidence criteria are complete.

## Contract delta

New schema fields: none.

New fail-closed blockers: none. The existing adapter behavior remains unchanged: missing checkpoint fails closed unless fallback is explicitly enabled.

Compatibility impact: test-only contract coverage. No runtime code, configs, benchmark matrices, generated indexes, or public claim surfaces change.

New capability toward #4016: repository tests now prove that the CPU QR-DQN smoke trainer output is directly adapter-loadable by the map-runner runtime lane, not only that each side works against separate synthetic fixtures.

## Linked Issues

- Relates to #4016

## Summary

This PR adds `test_distributional_rl_smoke_checkpoint_loads_runtime_adapter`, which trains the tiny CPU smoke QR-DQN path, loads its produced checkpoint through `DistributionalRLPlanner`, calls `step(...)`, and verifies diagnostic-only metadata plus action-lattice candidate count.

## Domain-Aware Approval

- Required for PR: yes - evidence-validity-sensitive result classification
- Domains reviewed: evidence classification, benchmark interpretation, paper-facing claim boundary.
- Status: approved
- Approver/review source or waiver: test-only trainer-to-runtime contract coverage; no benchmark comparison, evidence classification change, experimental methodology change, figure eligibility change, benchmark interpretation, or paper-facing claim is introduced.
- Validity checklist:
  - Target claim/hypothesis: issue claim boundary stays diagnostic-only.
  - Comparator or split/evidence validity: single-slice CPU smoke proof of trainer-to-adapter compatibility; matched comparator evaluation remains tracked by issue #4016.
  - Fallback/degraded exclusions: fallback/degraded benchmark rows are not produced or interpreted.
  - Claim boundary: CPU smoke adapter-load contract only; no paper-facing benchmark claim.
  - Implementation integrity vs experimental validity: test proves checkpoint handoff compatibility, not result validity.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/training/test_train_distributional_rl_config.py tests/training/test_train_distributional_rl_dry_run.py tests/baselines/test_distributional_rl_planner.py tests/benchmark/test_map_runner_distributional_rl.py -q` PASS, 11 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check tests/training/test_train_distributional_rl_dry_run.py scripts/training/train_distributional_rl.py robot_sf/baselines/distributional_rl.py robot_sf/benchmark/map_runner_policies/distributional_rl.py` PASS.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/training/train_distributional_rl.py --config configs/training/distributional_rl/qr_dqn_issue_4016_smoke.yaml --dry-run --log-level WARNING` PASS; wrote diagnostic dry-run manifest with `train_steps: 0`.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/training/train_distributional_rl.py --config configs/training/distributional_rl/qr_dqn_issue_4016_smoke.yaml --log-level WARNING` PASS; wrote smoke checkpoint and manifest with `train_steps: 112`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream Propagation

Parent issue update: not performed because this run has `comment_issue_or_pr: false`. This PR body is the durable propagation surface for the delivered slice.

Claim map / benchmark report / leaderboard / artifact catalog: NA, no benchmark or claim update.

## Follow-Up Issues

- Deferred work: the issue-plan diagnostic comparison slice remains: train/evaluate matched mean-value and CVaR selection modes on paired seeds and report fallback/degraded rows as non-evidence.
- Issues opened follow-up: none; this is already tracked by #4016.

<details>
<summary>Governance appendix</summary>

Stack / dependency: built on current `origin/main`, after merged PR 4157 and PR 4215.

Fragmentation guard: two #4016 PRs merged in the last 24h (PR 4157, PR 4215), but both are nameable progression slices rather than guardrail/checker-only PRs. This PR is a consolidation/proof slice for the newly merged trainer-runtime handoff.

Research result guidance: diagnostic smoke contract only; result classification is diagnostic-only. No positive safety claim, benchmark conclusion, or paper-facing interpretation is introduced.

Artifacts: local `output/models/distributional_rl/issue_4016/` smoke outputs are ignored disposable validation artifacts and are not committed.

Risks: narrow test-only change. If the trainer checkpoint schema or adapter loader changes, this test should fail at the handoff boundary.

</details>
