### PR TITLE
Add SocNavBench ETH shape-contract loader (#4279)

### DIFF
--- a/docs/datasets/socnavbench-s3dis-eth.md
+++ b/docs/datasets/socnavbench-s3dis-eth.md
@@ -1,0 +1,57 @@
+# SocNavBench S3DIS ETH External Data
+
+Plain-language summary: Robot SF can check the local shape of SocNavBench ETH map assets, but it
+does not download, redistribute, or benchmark with the license-gated dataset unless you stage it
+yourself.
+
+Related issues: [#4279](https://github.com/ll7/robot_sf_ll7/issues/4279),
+[#1498](https://github.com/ll7/robot_sf_ll7/issues/1498),
+[#334](https://github.com/ll7/robot_sf_ll7/issues/334)
+
+## Acquisition
+
+Use the official SocNavBench installation instructions and the Stanford 3D Indoor Spaces
+(S3DIS) or Stanford Building Parser Dataset (SBPD) access path referenced there. The upstream code
+repository is <https://github.com/CMU-TBD/SocNavBench>. The public Robot SF repository does not
+encode a download URL or commit dataset bytes because the S3DIS/SBPD meshes and traversible files
+have separate access terms.
+
+The canonical Robot SF registry entry is `socnavbench-s3dis-eth` in
+`scripts/tools/manage_external_data.py`. Use it to inspect the expected local layout:
+
+```bash
+uv run python scripts/tools/manage_external_data.py explain socnavbench-s3dis-eth
+```
+
+## Expected Layout
+
+By default, the registry expects the SocNavBench root at `third_party/socnavbench/`. To share one
+staged copy across worktrees, set `ROBOT_SF_EXTERNAL_DATA_ROOT` and place the SocNavBench tree under
+`$ROBOT_SF_EXTERNAL_DATA_ROOT/socnavbench/`.
+
+Required files under the SocNavBench root:
+
+```text
+sd3dis/stanford_building_parser_dataset/mesh/ETH/
+sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl
+```
+
+The traversible pickle must load as a mapping with:
+
+- `resolution`: finite positive numeric map resolution.
+- `traversible`: non-empty two-dimensional boolean or numeric array.
+
+These checks are shape and layout checks only. They do not assert map content correctness, licensing
+status, benchmark readiness, or paper-facing evidence.
+
+## Validation
+
+Without staged data, the structural test skips:
+
+```bash
+uv run pytest tests/data/external/test_socnavbench_eth_shape.py
+```
+
+With locally staged official assets, the same test loads `data.pkl` and checks the cheap structural
+contract. A successful pass is only local staging evidence; it is not a full benchmark campaign, a
+SocNavBench ETH map conversion, or a dissertation claim.

--- a/docs/external_data_setup.md
+++ b/docs/external_data_setup.md
@@ -14,7 +14,8 @@ uv run python scripts/tools/manage_external_data.py stage sdd --source /path/to/
 The first supported asset groups are:
 
 - `sdd`: Stanford Drone Dataset annotation text files for the SDD scenario importer.
-- `socnavbench-s3dis-eth`: SocNavBench/S3DIS ETH mesh and traversible inputs.
+- `socnavbench-s3dis-eth`: SocNavBench/S3DIS ETH mesh and traversible inputs; see
+  [SocNavBench S3DIS ETH External Data](datasets/socnavbench-s3dis-eth.md).
 - `socnavbench-control`: SocNavBench `wayptnav_data` control-pipeline assets.
 - `amv-calibration`: local-only AMV actuation calibration source provenance for #1585/#1559.
 

--- a/robot_sf/data/__init__.py
+++ b/robot_sf/data/__init__.py
@@ -1,0 +1,1 @@
+"""Dataset access helpers for local Robot SF data contracts."""

--- a/robot_sf/data/external/__init__.py
+++ b/robot_sf/data/external/__init__.py
@@ -1,0 +1,1 @@
+"""License-safe accessors for bring-your-own external datasets."""

--- a/robot_sf/data/external/socnavbench_eth.py
+++ b/robot_sf/data/external/socnavbench_eth.py
@@ -1,0 +1,153 @@
+"""SocNavBench ETH external-data shape contract.
+
+The loader only inspects locally staged files. It never downloads or vendors the
+license-gated SocNavBench/S3DIS ETH dataset bytes.
+"""
+
+from __future__ import annotations
+
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from scripts.tools.manage_external_data import (
+    EXTERNAL_DATA_ROOT_ENV,
+    check_asset,
+    resolve_asset_local_path_by_id,
+)
+
+ASSET_ID = "socnavbench-s3dis-eth"
+_S3DIS_BASE = Path("sd3dis") / "stanford_building_parser_dataset"
+ETH_MESH_RELATIVE_PATH = _S3DIS_BASE / "mesh" / "ETH"
+ETH_TRAVERSIBLE_RELATIVE_PATH = _S3DIS_BASE / "traversibles" / "ETH" / "data.pkl"
+ACQUISITION_DOC = "docs/datasets/socnavbench-s3dis-eth.md"
+
+
+class SocNavBenchEthDataError(RuntimeError):
+    """Raised when staged SocNavBench ETH data is absent or structurally invalid."""
+
+
+@dataclass(frozen=True)
+class SocNavBenchEthLayout:
+    """Resolved filesystem layout for the locally staged SocNavBench ETH asset."""
+
+    root: Path
+    mesh_dir: Path
+    traversible_pickle: Path
+
+
+@dataclass(frozen=True)
+class SocNavBenchEthShapeContract:
+    """Cheap structural summary of the ETH traversible pickle."""
+
+    resolution: float
+    traversible_shape: tuple[int, int]
+    traversible_dtype: str
+
+
+def resolve_root(root: Path | str | None = None) -> Path:
+    """Return the SocNavBench root, honoring the shared external-data registry."""
+
+    if root is not None:
+        return Path(root).expanduser().resolve()
+    return resolve_asset_local_path_by_id(ASSET_ID).expanduser().resolve()
+
+
+def expected_layout(root: Path | str | None = None) -> SocNavBenchEthLayout:
+    """Return expected ETH paths without asserting that data is staged."""
+
+    resolved = resolve_root(root)
+    return SocNavBenchEthLayout(
+        root=resolved,
+        mesh_dir=resolved / ETH_MESH_RELATIVE_PATH,
+        traversible_pickle=resolved / ETH_TRAVERSIBLE_RELATIVE_PATH,
+    )
+
+
+def availability_report(root: Path | str | None = None) -> dict[str, Any]:
+    """Return the canonical external-data registry availability report."""
+
+    return check_asset(ASSET_ID, source_path=resolve_root(root))
+
+
+def is_available(root: Path | str | None = None) -> bool:
+    """Return whether all required SocNavBench ETH source assets are staged."""
+
+    return bool(availability_report(root).get("ok", False))
+
+
+def require_available(root: Path | str | None = None) -> SocNavBenchEthLayout:
+    """Return staged layout or raise an actionable acquisition error."""
+
+    report = availability_report(root)
+    if report.get("ok", False):
+        return expected_layout(root)
+
+    missing_paths = report.get("missing_required_paths") or [
+        str(ETH_MESH_RELATIVE_PATH),
+        str(ETH_TRAVERSIBLE_RELATIVE_PATH),
+    ]
+    missing = ", ".join(str(path) for path in missing_paths)
+    action = str(report.get("action") or "stage the official SocNavBench ETH assets")
+    raise SocNavBenchEthDataError(
+        f"{ASSET_ID} is not staged or is incomplete at {report['source_path']}. "
+        f"Missing required paths: {missing or 'unknown'}. {action} "
+        f"See {ACQUISITION_DOC}. You may set {EXTERNAL_DATA_ROOT_ENV} to a shared "
+        "external-data root."
+    )
+
+
+def load_shape_contract(root: Path | str | None = None) -> SocNavBenchEthShapeContract:
+    """Load and validate the cheap traversible-map shape contract.
+
+    Returns:
+        A structural summary of the staged ETH traversible pickle.
+    """
+
+    layout = require_available(root)
+    try:
+        with layout.traversible_pickle.open("rb") as handle:
+            payload = pickle.load(handle)
+    except Exception as exc:  # pragma: no cover - depends on malformed external bytes.
+        raise SocNavBenchEthDataError(
+            f"Could not load {layout.traversible_pickle}. Re-stage official "
+            f"{ASSET_ID} assets and re-run the shape test."
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise SocNavBenchEthDataError(
+            f"{layout.traversible_pickle} must contain a mapping with 'resolution' "
+            "and 'traversible' keys."
+        )
+    if "resolution" not in payload or "traversible" not in payload:
+        raise SocNavBenchEthDataError(
+            f"{layout.traversible_pickle} missing required keys: resolution, traversible."
+        )
+
+    resolution = payload["resolution"]
+    if not isinstance(resolution, (int, float, np.integer, np.floating)):
+        raise SocNavBenchEthDataError("SocNavBench ETH resolution must be numeric.")
+    resolution_float = float(resolution)
+    if not np.isfinite(resolution_float) or resolution_float <= 0:
+        raise SocNavBenchEthDataError("SocNavBench ETH resolution must be finite and positive.")
+
+    traversible = np.asarray(payload["traversible"])
+    if traversible.ndim != 2 or 0 in traversible.shape:
+        raise SocNavBenchEthDataError("SocNavBench ETH traversible must be a non-empty 2D array.")
+    if not (
+        np.issubdtype(traversible.dtype, np.bool_) or np.issubdtype(traversible.dtype, np.number)
+    ):
+        raise SocNavBenchEthDataError("SocNavBench ETH traversible dtype must be bool or numeric.")
+    if np.issubdtype(traversible.dtype, np.number) and not np.isfinite(traversible).all():
+        raise SocNavBenchEthDataError(
+            "SocNavBench ETH traversible array contains non-finite values."
+        )
+
+    return SocNavBenchEthShapeContract(
+        resolution=resolution_float,
+        traversible_shape=tuple(int(axis) for axis in traversible.shape),
+        traversible_dtype=str(traversible.dtype),
+    )

--- a/tests/data/external/test_socnavbench_eth_shape.py
+++ b/tests/data/external/test_socnavbench_eth_shape.py
@@ -1,0 +1,71 @@
+"""Skip-if-absent shape-contract tests for SocNavBench ETH external data."""
+
+from __future__ import annotations
+
+import pickle
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from robot_sf.data.external import socnavbench_eth
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _stage_minimal_eth_fixture(root: Path) -> None:
+    """Create a tiny layout-compatible SocNavBench ETH fixture."""
+
+    layout = socnavbench_eth.expected_layout(root)
+    layout.mesh_dir.mkdir(parents=True)
+    (layout.mesh_dir / "mesh.obj").write_text("# synthetic mesh marker\n", encoding="utf-8")
+    layout.traversible_pickle.parent.mkdir(parents=True)
+    with layout.traversible_pickle.open("wb") as handle:
+        pickle.dump(
+            {
+                "resolution": 5.0,
+                "traversible": np.array([[True, False], [True, True]], dtype=bool),
+            },
+            handle,
+            protocol=2,
+        )
+
+
+def test_socnavbench_eth_absent_data_skips(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """External clones without SocNavBench ETH bytes should skip, not fail."""
+
+    monkeypatch.setenv(socnavbench_eth.EXTERNAL_DATA_ROOT_ENV, str(tmp_path))
+    if not socnavbench_eth.is_available():
+        pytest.skip("external dataset not staged")
+    pytest.fail("temporary empty external-data root unexpectedly satisfied ETH contract")
+
+
+def test_socnavbench_eth_shape_contract_with_synthetic_layout(tmp_path: Path) -> None:
+    """Available data path checks layout and traversible pickle structure."""
+
+    root = tmp_path / "socnavbench"
+    _stage_minimal_eth_fixture(root)
+
+    assert socnavbench_eth.is_available(root)
+    layout = socnavbench_eth.require_available(root)
+    assert layout.mesh_dir.is_dir()
+    assert layout.traversible_pickle.is_file()
+
+    shape = socnavbench_eth.load_shape_contract(root)
+    assert shape.resolution == 5.0
+    assert shape.traversible_shape == (2, 2)
+    assert shape.traversible_dtype == "bool"
+
+
+def test_socnavbench_eth_shape_contract_rejects_malformed_pickle(tmp_path: Path) -> None:
+    """Malformed staged traversible files fail closed with an actionable error."""
+
+    root = tmp_path / "socnavbench"
+    _stage_minimal_eth_fixture(root)
+    layout = socnavbench_eth.expected_layout(root)
+    with layout.traversible_pickle.open("wb") as handle:
+        pickle.dump({"resolution": 5.0}, handle, protocol=2)
+
+    with pytest.raises(socnavbench_eth.SocNavBenchEthDataError, match="missing required keys"):
+        socnavbench_eth.load_shape_contract(root)


### PR DESCRIPTION
Reviewer-critical summary

What changed: adds a license-safe `socnavbench-s3dis-eth` loader/accessor under `robot_sf.data.external`, skip-if-absent structural tests, and a short acquisition/layout doc for local SocNavBench ETH staging.

Why now: issue #4279 asks for the SocNavBench ETH exemplar pattern from #4224 so later external-data families can copy a small, CI-safe shape-contract slice.

Claim boundary: this PR proves only local layout and cheap traversible-pickle structure. It does not prove dataset content correctness, map conversion readiness, benchmark readiness, or any paper/dissertation claim.

Required validation: focused CPU-only loader tests and the existing SocNavBench map-batch validator regression path. The local registry check confirms ETH assets are absent on this host and fail closed as expected.

Remaining blocker: official SocNavBench/S3DIS ETH bytes still must be acquired and staged under license before reviewers can run a staged-data pass.

Contract delta

New schema fields: none.

New fail-closed blockers: `SocNavBenchEthDataError` now names missing ETH mesh/traversible paths and points to `docs/datasets/socnavbench-s3dis-eth.md` when the local asset is absent, incomplete, or malformed.

Compatibility impact: no changes to `scripts/tools/manage_external_data.py` semantics, no download path, no dataset bytes, no CI/private data staging requirement. The loader reuses the existing `socnavbench-s3dis-eth` registry entry and `ROBOT_SF_EXTERNAL_DATA_ROOT` resolution.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4279

Scope summary

- Added `robot_sf.data.external.socnavbench_eth` with `is_available()`, `require_available()`, and `load_shape_contract()` accessors.
- Added skip-if-absent tests plus synthetic present/malformed layout coverage.
- Added SocNavBench ETH acquisition/layout docs and linked them from the external-data setup page.

Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/data tests/data/external/test_socnavbench_eth_shape.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/data/external/test_socnavbench_eth_shape.py tests/tools/test_validate_socnav_map_batch.py -q` -> passed, `10 passed, 1 skipped`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/manage_external_data.py --json check socnavbench-s3dis-eth` -> expected exit `2`; reports missing `sd3dis/stanford_building_parser_dataset/mesh/ETH` and `sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl`, confirming absent-data fail-closed behavior on this host.
- Docs/path check: verified `docs/datasets/socnavbench-s3dis-eth.md`, `docs/external_data_setup.md`, the `manage_external_data.py explain socnavbench-s3dis-eth` command text, and `ROBOT_SF_EXTERNAL_DATA_ROOT` references are present.

Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. No dataset bytes, download code, `manage_external_data.py` semantic changes, or CI/private data staging.

<details>
<summary>Governance and freshness appendix</summary>

- Live issue refresh immediately before PR open: #4279 was still open, updated at `2026-07-03T12:15:20Z`, with no comments.
- Duplicate PR check immediately before PR open: no open PR matched `4279`, `socnavbench-s3dis-eth`, or `SocNavBench ETH shape-contract`.
- Fragmentation guard: no recent merged guardrail/checker/packet-refresh PRs for #4279 found; this is a nameable progression slice adding the SocNavBench ETH loader/accessor capability.
- State propagation: no issue comment was added because this run has `comment_issue_or_pr: false`; this PR body records the delivered slice and remaining staged-data blocker as the single propagated surface.

</details>
