### PR TITLE
docs: register ATC external-data acquisition/layout docs (#4289)

### DIFF
--- a/docs/datasets/atc.md
+++ b/docs/datasets/atc.md
@@ -1,0 +1,120 @@
+# ATC Pedestrian Tracking External Data
+
+Plain-language summary: Robot SF can record the expected local layout and provenance of the ATC
+(Osaka shopping-center) pedestrian tracking dataset, but it does **not** download, redistribute, or
+benchmark with the license-gated data unless you stage it yourself under the upstream research-use
+terms.
+
+This is the third dataset family in the #4224 external-data program (after the Stanford Drone
+Dataset and the ETH/UCY trajectory benchmarks). This page and its registry entry are
+**registry/docs only**: no dataset bytes, no automated acquisition, no loader, no shape-contract
+tests, no benchmark run, and no paper-facing claim are introduced here.
+
+Related issues: [#4289](https://github.com/ll7/robot_sf_ll7/issues/4289),
+[#4224](https://github.com/ll7/robot_sf_ll7/issues/4224),
+[#2918](https://github.com/ll7/robot_sf_ll7/issues/2918),
+[#3161](https://github.com/ll7/robot_sf_ll7/issues/3161),
+[#3971](https://github.com/ll7/robot_sf_ll7/issues/3971),
+[#3813](https://github.com/ll7/robot_sf_ll7/issues/3813),
+[#3950](https://github.com/ll7/robot_sf_ll7/issues/3950)
+
+## What it is
+
+The ATC dataset contains pedestrian position and body-direction trajectories collected with 3-D
+range sensors in part of the ATC (Asia and Pacific Trade Center) shopping-and-business center in
+Osaka, Japan. The full public release covers 92 collection days (24 Oct 2012 – 29 Nov 2013,
+typically Wednesday and Sunday, ~09:40–20:20) distributed as daily CSV files, packaged upstream as
+nine 7-Zip archives of 10–11 single-day files each, plus one standalone sample day.
+
+## Canonical registry identity
+
+The canonical Robot SF registry entry is **`atc-pedestrian`** in
+`scripts/tools/manage_external_data.py`.
+
+Issue #4289 originally proposed the bare id `atc`. The existing id `atc-pedestrian` is retained
+deliberately: it was registered as canonical in the merged #4224 slice (PR #4238) and matches the
+qualified-id convention of its sibling assets from that same slice (`eth-ucy-trajectories`,
+`ind-crossings`, `crowdbot`, `scand-demos`). Renaming a single member would break that convention
+and churn the registry, its tests, and the #4224 context note for no functional benefit. The
+maintainer implementation plan explicitly permits keeping the existing id with this rationale; a
+later cohort-wide rename remains possible if maintainers prefer bare ids across the whole program.
+
+Inspect the authoritative, always-up-to-date contract with:
+
+```bash
+uv run python scripts/tools/manage_external_data.py explain atc-pedestrian
+```
+
+## Official acquisition
+
+Acquire the dataset directly from the official ATR project page and keep it under the upstream terms:
+
+- Official source: <https://dil.atr.jp/crest2010_HRI/ATC_dataset/>
+
+The upstream terms state the data is *free to use for research purposes only* and that use must cite
+the reference paper (see [Citation](#citation)). The public Robot SF repository does not encode a
+scriptable download URL and does not commit dataset bytes: the registry keeps
+`auto_download_allowed=False` until a maintainer records stable terms and URL approval. Download the
+archives manually, extract the daily CSVs, and keep a local copy of the terms/README alongside the
+data.
+
+## Chosen subset policy
+
+The full ATC release is weeks of data. For local staging you do **not** need the entire release. The
+registry layout requires only a **small documented subset**: one or more daily trajectory CSV files
+(for example the upstream standalone sample day) plus a local terms/README note. Stage more days
+only if a later, explicitly scoped benchmark or loader task needs them.
+
+Each daily CSV file is named `atc-YYYYMMDD.csv` and has the columns (no header row upstream):
+
+```text
+time [ms, unixtime+ms/1000], person_id, x [mm], y [mm], z/height [mm],
+velocity [mm/s], motion_angle [rad], facing_angle [rad]
+```
+
+## Expected layout
+
+By default the registry expects the ATC root at `output/external_data/atc_pedestrian/`. To share one
+staged copy across worktrees, set `ROBOT_SF_EXTERNAL_DATA_ROOT` and place the tree under
+`$ROBOT_SF_EXTERNAL_DATA_ROOT/atc_pedestrian/` (the registry `shared_root_subpath`).
+
+```text
+$ROBOT_SF_EXTERNAL_DATA_ROOT/atc_pedestrian/
+  README.md   (or LICENSE.txt / TERMS.txt — a local copy of the upstream research-use terms)
+  atc-20121024.csv   (one or more daily trajectory CSVs; nested subdirectories are fine)
+```
+
+Required-path groups (at least one match per group; run `explain` for the exact patterns):
+
+- **trajectory**: `**/atc-*.csv` (preferred), or any `**/*.csv` if staged without the original name.
+- **license_or_readme**: `**/README*`, `**/LICENSE*`, or `**/TERMS*`.
+
+These are layout and presence checks only. They do not assert trajectory-content correctness,
+licensing status, benchmark readiness, or any paper-facing evidence.
+
+## Validation
+
+Without staged data, the registry check fails closed with `status: missing` / `ok: false`:
+
+```bash
+uv run python scripts/tools/manage_external_data.py explain atc-pedestrian
+uv run python scripts/tools/manage_external_data.py check atc-pedestrian
+uv run python scripts/tools/manage_external_data.py --json list
+```
+
+With locally staged official data, `check` (or `stage`) validates the required-path groups and can
+write a compact provenance manifest. A successful presence check is only local staging evidence; it
+is not a full benchmark campaign, a trajectory-loader validation, or a dissertation claim.
+
+## Citation
+
+> D. Brščić, T. Kanda, T. Ikeda, T. Miyashita, "Person position and body direction tracking in
+> large public spaces using 3-D range sensors," *IEEE Transactions on Human-Machine Systems*,
+> Vol. 43, No. 6, pp. 522–534, 2013.
+
+## Boundary and follow-up
+
+This slice adds registry metadata and acquisition/layout documentation only. Deferred follow-up
+(after local staging exists): an ATC trajectory loader plus skip-if-absent shape-contract tests,
+following the exemplar pattern established for #4279 (`socnavbench-s3dis-eth`). No download code,
+dataset bytes, benchmark consumer, or claim edit is part of #4289.

--- a/docs/external_data_setup.md
+++ b/docs/external_data_setup.md
@@ -21,6 +21,8 @@ The first supported asset groups are:
 - `eth-ucy`: ETH BIWI and UCY Crowds-by-Example pedestrian-trajectory
   acquisition/provenance metadata; see
   [ETH/UCY External Trajectory Data](./datasets/eth-ucy.md).
+- `atc-pedestrian`: ATC (Osaka shopping-center) pedestrian tracking trajectories (Brščić et al.
+  2013); see [ATC Pedestrian Tracking External Data](datasets/atc.md).
 
 `download` intentionally fails closed for these groups because the repository has not encoded a
 license-safe direct download path. Follow the official source instructions printed by `explain`,
@@ -58,6 +60,7 @@ summary.
 | `socnavbench-s3dis-eth` | <https://github.com/CMU-TBD/SocNavBench> install docs → the curated S3DIS/SBPD asset package | **S3DIS** meshes/traversibles have a separate access agreement; not redistributed by Robot SF | `third_party/socnavbench/` | `sd3dis/stanford_building_parser_dataset/mesh/ETH/` (dir) and `sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl` |
 | `socnavbench-control` | <https://github.com/CMU-TBD/SocNavBench> (`wayptnav_data`) | external SocNavBench assets, not redistributed | `third_party/socnavbench/` | `wayptnav_data/` (precomputed waypoint/control data) |
 | `eth-ucy` | <https://vision.ee.ethz.ch/datsets.html> plus UCY Crowds-by-Example source/paper provenance | research-use terms from upstream or maintainer-approved mirror; not redistributed by Robot SF | `output/external_data/eth-ucy/` or `$ROBOT_SF_EXTERNAL_DATA_ROOT/eth-ucy/` | ETH/Hotel `obsmat.txt`, UCY `.vsp` or trajectory `.txt`, plus local `README*`, `LICENSE*`, or `TERMS*`; see [ETH/UCY External Trajectory Data](./datasets/eth-ucy.md) |
+| `atc-pedestrian` | <https://dil.atr.jp/crest2010_HRI/ATC_dataset/> | ATR research-use-only terms; cite Brščić et al. 2013; not redistributed by Robot SF | `output/external_data/atc_pedestrian/` | one or more daily trajectory CSVs (`**/atc-*.csv`, columns `time person_id x y z velocity motion_angle facing_angle`) plus a local `README*`/`LICENSE*`/`TERMS*` terms copy |
 
 After placing the files, validate and write a provenance manifest:
 


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds the missing public acquisition/layout documentation for the ATC (Osaka
  shopping-center) pedestrian tracking dataset — new `docs/datasets/atc.md` plus asset-list/table
  entries and nav wiring in `docs/external_data_setup.md`. Docs-only.
- **Why now:** Third dataset family of the #4224 program (after SDD and ETH/UCY). The
  `atc-pedestrian` **registry entry, tests, and fixtures already landed** via #4238; only the
  public acquisition/layout docs and the canonical-id decision were still open for #4289.
- **Claim boundary:** Registry/docs metadata only. No dataset bytes, download code, loader, shape
  tests, benchmark run, or paper/dissertation claim. Every doc fact was verified against the live
  registry and the official ATR source page at implementation time.
- **Required validation:** registry `explain`/`check`, registry unit tests, Sphinx docs build — all
  green (below).
- **Remaining blocker:** none for this slice. Follow-up (deferred, needs local staging first): ATC
  trajectory loader + skip-if-absent shape-contract tests, mirroring the #4279 exemplar.

Closes part of #4224. Implements #4289 — https://github.com/ll7/robot_sf_ll7/issues/4289

## Contract delta

- **No schema/behavior change.** No new `AssetSpec`, `RequiredPath`, fail-closed blocker, or CLI
  behavior is introduced. The `atc-pedestrian` contract (source URL, license, required-path groups,
  `auto_download_allowed=False`, `expected_tree_sha256_status=pending_first_staging`) is unchanged
  from #4238; this PR documents it.
- **Canonical-id decision (recorded, reversible):** issue #4289 proposed bare id `atc`; the existing
  `atc-pedestrian` is **kept deliberately**. It was registered as canonical in merged #4238 and
  matches the qualified-id convention of its #4224 cohort (`eth-ucy-trajectories`, `ind-crossings`,
  `crowdbot`, `scand-demos`). Renaming one member would break that convention and churn the
  registry + ~10 test references + the #4224 context note for no functional gain. The maintainer
  implementation plan explicitly permits keeping the id with rationale; a later cohort-wide rename
  remains possible.

## Scope

- **In scope:** ATC registry acquisition/layout documentation + docs nav wiring; canonical-id
  decision recorded in the page and here.
- **Out of scope (unchanged):** loader/tests, download code, dataset bytes, campaign runs,
  Slurm/GPU work, real-world benchmark/paper claims.

## Validation

All run from the branch worktree (CPU only, no campaigns):

| Command | Result |
| --- | --- |
| `manage_external_data.py explain atc-pedestrian` | exit 0; source/license/required-paths match the docs |
| `manage_external_data.py --json check atc-pedestrian` | `status=missing`, `ok=false` (fail-closed, no staged data) |
| `pytest tests/tools/test_manage_external_data.py -q` | 29 passed |
| `sphinx -b html docs` | build succeeded; `datasets/atc` + `external_data_setup` read cleanly (only pre-existing unrelated `dev_guide.md` toctree warning) |

## Downstream Propagation

- Parent issue #4224 / context note `docs/context/issue_4224_external_dataset_registry.md`: already
  records the `atc-pedestrian` row; no registry contract changed, so no edit needed here.
- Issue-state propagation: `comment_issue_or_pr` is not authorized for this lane, so this PR body is
  the canonical state surface. No `docs/context/issue_4289_state.yaml` write (no transient
  queue-routing state to record).
- Research Result Guidance: `NA - docs/acquisition slice`, no research claim.

## Explicit out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Governance / process notes</summary>

- Fragmentation guard: first #4289 PR; progression slice adding a nameable capability (public ATC
  acquisition/layout docs + canonical-id decision), not a micro-guard.
- Freshness: re-checked issue #4289 comments immediately before opening; newest maintainer comment
  is the 2026-07-03T13:21:37Z implementation plan, already incorporated (including its
  keep-existing-id waiver path). No open PR duplicates #4289 or the ATC scope.
- Worktree: `robot_sf_ll7.worktrees/issue-4289-register-atc-external-data-acquisition-docs` off
  `origin/main`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
