### PR TITLE
Issue #4242: teach h600 #4195/#4206 builders to consume native mechanism/exposure fields + declared sidecars

### DIFF
--- a/scripts/analysis/build_issue_4195_h600_aggregation_artifact.py
+++ b/scripts/analysis/build_issue_4195_h600_aggregation_artifact.py
@@ -10,6 +10,7 @@ import json
 import math
 import random
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from statistics import mean
@@ -45,6 +46,17 @@ EXPOSURE_REQUIRED_COLUMNS = (
     "low_exposure_success",
 )
 EXPOSURE_PROVENANCE_COLUMN = "interaction_exposure_source"
+EXPOSURE_STATUS_COLUMN = "interaction_exposure_status"
+# Row-level exposure status markers that must never count as derivable evidence.
+# The native writer (robot_sf/benchmark/seed_variance.py) and the #4242 backfill
+# sidecar both emit ``not_derivable*`` / ``missing*`` markers when episode traces
+# cannot support the exposure denominators; these are visible but not imputed.
+EXPOSURE_NOT_DERIVABLE_PREFIXES = ("not_derivable", "missing", "not_applicable", "malformed")
+# source_manifest.json declares retained-run sidecars produced by the #4242
+# backfill helper; the exposure diagnostics builder may consume the declared
+# interaction-exposure sidecar when native episode-row fields are absent.
+SIDECAR_MANIFEST_KEY = "issue_4242_h600_sidecars"
+SIDECAR_EXPOSURE_FIELD = "interaction_exposure_sidecar"
 
 
 @dataclass(frozen=True)
@@ -678,65 +690,195 @@ def _build_horizon_sensitivity(
     }
 
 
-def _build_exposure_diagnostics(metadatas: list[dict[str, Any]]) -> dict[str, Any]:
-    """Return exposure diagnostics or a fail-closed missing-fields report."""
+def _row_is_not_derivable(status_value: str) -> bool:
+    """Return whether a row-level exposure status marks the row as not derivable."""
+
+    lowered = status_value.strip().lower()
+    return any(lowered.startswith(prefix) for prefix in EXPOSURE_NOT_DERIVABLE_PREFIXES)
+
+
+def _classify_exposure_rows(
+    rows: list[dict[str, str]],
+) -> tuple[int, int, dict[str, int], list[str]]:
+    """Classify exposure rows into derivable/not-derivable counts without imputation.
+
+    A row counts as derivable only when every required exposure value is present
+    *and* its native ``interaction_exposure_status`` (when emitted) is not a
+    ``not_derivable`` / ``missing`` marker. Absent values are never imputed.
+
+    Returns:
+        Derivable count, not-derivable count, status-marker histogram, and the
+        sorted set of provenance markers observed on the rows.
+    """
+
+    derivable_rows = 0
+    not_derivable_rows = 0
+    status_counts: dict[str, int] = defaultdict(int)
+    provenance: set[str] = set()
+    for row in rows:
+        status_value = str(row.get(EXPOSURE_STATUS_COLUMN, ""))
+        if status_value.strip():
+            status_counts[status_value.strip()] += 1
+        provenance_value = str(row.get(EXPOSURE_PROVENANCE_COLUMN, ""))
+        if provenance_value.strip():
+            provenance.add(provenance_value.strip())
+        has_required_values = all(str(row.get(column, "")) for column in EXPOSURE_REQUIRED_COLUMNS)
+        if has_required_values and not _row_is_not_derivable(status_value):
+            derivable_rows += 1
+        else:
+            not_derivable_rows += 1
+    return (
+        derivable_rows,
+        not_derivable_rows,
+        dict(sorted(status_counts.items())),
+        sorted(provenance),
+    )
+
+
+def _resolve_declared_exposure_sidecar(
+    output_dir: Path,
+    manifest: Mapping[str, Any] | None,
+) -> Path | None:
+    """Resolve the declared interaction-exposure sidecar from source_manifest.json.
+
+    The #4242 backfill helper records retained-run sidecars under the
+    ``issue_4242_h600_sidecars`` manifest block. When present, the exposure
+    diagnostics builder consumes the declared sidecar as an alternative to native
+    episode-row fields. Returns ``None`` when no sidecar is declared or the file
+    is missing.
+    """
+
+    if not isinstance(manifest, Mapping):
+        return None
+    sidecars = manifest.get(SIDECAR_MANIFEST_KEY)
+    if not isinstance(sidecars, Mapping):
+        return None
+    name = sidecars.get(SIDECAR_EXPOSURE_FIELD)
+    if not name:
+        return None
+    candidate = Path(name)
+    if not candidate.is_absolute():
+        candidate = output_dir / candidate
+    return candidate if candidate.exists() else None
+
+
+def _index_sidecar_rows_by_job(sidecar_path: Path) -> dict[str, list[dict[str, str]]]:
+    """Group declared exposure sidecar rows by their ``job_id`` column."""
+
+    by_job: dict[str, list[dict[str, str]]] = defaultdict(list)
+    for row in _read_csv_rows(sidecar_path):
+        by_job[str(row.get("job_id", ""))].append(row)
+    return dict(by_job)
+
+
+def _build_exposure_diagnostics(
+    metadatas: list[dict[str, Any]],
+    *,
+    declared_sidecar: Path | None = None,
+) -> dict[str, Any]:
+    """Return exposure diagnostics or a fail-closed missing-fields report.
+
+    Consumes, in order of preference: native ``seed_episode_rows.csv`` exposure
+    fields (including the ``interaction_exposure_status`` provenance column), then
+    a declared interaction-exposure sidecar when native fields are absent. Neither
+    path imputes absent values: rows carrying ``not_derivable`` / ``missing``
+    status markers stay visible but never count as derivable evidence.
+    """
+
+    sidecar_by_job: dict[str, list[dict[str, str]]] = {}
+    if declared_sidecar is not None and declared_sidecar.exists():
+        sidecar_by_job = _index_sidecar_rows_by_job(declared_sidecar)
 
     runs = []
     overall_missing: set[str] = set()
+    any_native_derivable = False
+    any_sidecar_derivable = False
     for metadata in metadatas:
         columns = set(metadata.get("seed_episode_columns") or [])
         missing = [column for column in EXPOSURE_REQUIRED_COLUMNS if column not in columns]
         overall_missing.update(missing)
         seed_rows_path = Path(metadata["seed_episode_rows"])
         seed_rows = _read_csv_rows(seed_rows_path) if seed_rows_path.exists() else []
-        derivable_rows = 0
-        not_derivable_rows = 0
-        for row in seed_rows:
-            has_required_values = all(
-                str(row.get(column, "")) for column in EXPOSURE_REQUIRED_COLUMNS
+        derivable_rows, not_derivable_rows, status_counts, provenance_values = (
+            _classify_exposure_rows(seed_rows)
+        )
+        native_present = not missing
+        if native_present and derivable_rows:
+            any_native_derivable = True
+        run = {
+            "job_id": metadata["job_id"],
+            "run_label": metadata["run_label"],
+            "seed_episode_rows": metadata["seed_episode_rows"],
+            "available_columns": sorted(columns),
+            "required_columns": list(EXPOSURE_REQUIRED_COLUMNS),
+            "missing_required_fields": missing,
+            "backfill_policy": "derive_from_retained_episode_rows_only_no_imputation",
+            "exposure_field_source": "native_episode_fields"
+            if native_present
+            else "blocked_missing_required_fields",
+            "derivable_episode_rows": derivable_rows,
+            "not_derivable_episode_rows": not_derivable_rows,
+            "native_exposure_status_counts": status_counts,
+            "exposure_provenance_values": provenance_values,
+            "status": "ready_for_episode_level_scan"
+            if native_present
+            else "blocked_missing_required_fields",
+        }
+        # Only fall back to the declared sidecar when native fields are absent, so
+        # native instrumentation always wins and the sidecar never masks it.
+        if not native_present and sidecar_by_job:
+            job_rows = sidecar_by_job.get(str(metadata["job_id"]), [])
+            s_derivable, s_not_derivable, s_status_counts, s_provenance = _classify_exposure_rows(
+                job_rows
             )
-            if has_required_values:
-                derivable_rows += 1
-            else:
-                not_derivable_rows += 1
-        provenance_values = sorted(
-            {
-                str(row.get(EXPOSURE_PROVENANCE_COLUMN, ""))
-                for row in seed_rows
-                if str(row.get(EXPOSURE_PROVENANCE_COLUMN, ""))
-            }
+            if s_derivable:
+                any_sidecar_derivable = True
+            run.update(
+                {
+                    "exposure_field_source": "sidecar_declared",
+                    "sidecar_path": _public_path(declared_sidecar),
+                    "sidecar_episode_rows": len(job_rows),
+                    "sidecar_derivable_episode_rows": s_derivable,
+                    "sidecar_not_derivable_episode_rows": s_not_derivable,
+                    "sidecar_exposure_status_counts": s_status_counts,
+                    "sidecar_provenance_values": s_provenance,
+                    "status": "sidecar_ready_for_episode_level_scan"
+                    if s_derivable
+                    else "sidecar_all_not_derivable",
+                }
+            )
+        runs.append(run)
+
+    if any_native_derivable or not overall_missing:
+        status = "ready_for_episode_level_scan"
+        exposure_field_source = "native_episode_fields"
+    elif sidecar_by_job:
+        status = (
+            "sidecar_ready_for_episode_level_scan"
+            if any_sidecar_derivable
+            else "sidecar_all_not_derivable"
         )
-        runs.append(
-            {
-                "job_id": metadata["job_id"],
-                "run_label": metadata["run_label"],
-                "seed_episode_rows": metadata["seed_episode_rows"],
-                "available_columns": sorted(columns),
-                "required_columns": list(EXPOSURE_REQUIRED_COLUMNS),
-                "missing_required_fields": missing,
-                "backfill_policy": "derive_from_retained_episode_rows_only_no_imputation",
-                "derivable_episode_rows": derivable_rows,
-                "not_derivable_episode_rows": not_derivable_rows,
-                "exposure_provenance_values": provenance_values,
-                "status": "blocked_missing_required_fields"
-                if missing
-                else "ready_for_episode_level_scan",
-            }
-        )
-    return {
+        exposure_field_source = "sidecar_declared"
+    else:
+        status = "blocked_missing_required_fields"
+        exposure_field_source = "blocked_missing_required_fields"
+
+    result = {
         "schema_version": f"{SCHEMA_VERSION}.interaction_exposure",
-        "status": "blocked_missing_required_fields"
-        if overall_missing
-        else "ready_for_episode_level_scan",
+        "status": status,
+        "exposure_field_source": exposure_field_source,
         "claim_boundary": (
             "interaction-exposure coverage is diagnostic-only and must be computed from episode-level "
-            "fields; absent fields are not imputed"
+            "fields or a trace-derived sidecar; absent fields are not imputed"
         ),
         "required_fields": list(EXPOSURE_REQUIRED_COLUMNS),
         "missing_required_fields": sorted(overall_missing),
         "backfill_policy": "derive_from_retained_episode_rows_only_no_imputation",
         "runs": runs,
     }
+    if sidecar_by_job:
+        result["declared_sidecar"] = _public_path(declared_sidecar)
+    return result
 
 
 def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
@@ -893,17 +1035,28 @@ def _write_exposure_markdown(path: Path, report: dict[str, Any]) -> None:
         "",
         "- Evidence status: `diagnostic-only`.",
         f"- Status: `{report['status']}`.",
-        "- Episode-level exposure fields are required; missing values are not imputed.",
+        f"- Exposure field source: `{report['exposure_field_source']}`.",
+        "- Episode-level exposure fields (native or declared sidecar) are required; "
+        "missing values are not imputed.",
         "",
-        "| job_id | run_label | status | missing_required_fields |",
-        "| --- | --- | --- | --- |",
+        "| job_id | run_label | exposure_field_source | status | derivable | not_derivable |"
+        " missing_required_fields |",
+        "| --- | --- | --- | --- | ---: | ---: | --- |",
     ]
     for row in report["runs"]:
+        derivable = row.get("sidecar_derivable_episode_rows", row.get("derivable_episode_rows", 0))
+        not_derivable = row.get(
+            "sidecar_not_derivable_episode_rows", row.get("not_derivable_episode_rows", 0)
+        )
         lines.append(
-            "| {job_id} | {run_label} | {status} | {missing} |".format(
+            "| {job_id} | {run_label} | {source} | {status} | {derivable} | {not_derivable} |"
+            " {missing} |".format(
                 job_id=row["job_id"],
                 run_label=row["run_label"],
+                source=row.get("exposure_field_source", ""),
                 status=row["status"],
+                derivable=derivable,
+                not_derivable=not_derivable,
                 missing=", ".join(row["missing_required_fields"]) or "none",
             )
         )
@@ -1006,9 +1159,10 @@ def extend_existing_artifact(
     manifest = _read_json(manifest_path)
     metadatas = _scrub_public_paths(manifest.get("runs") or [])
     manifest["runs"] = metadatas
+    declared_sidecar = _resolve_declared_exposure_sidecar(output_dir, manifest)
     snqi_recalibration = _build_h600_recalibration(rows, h500_reports=h500_s20_reports)
     horizon_sensitivity = _build_horizon_sensitivity(rows, h500_reports=h500_s20_reports)
-    exposure_diagnostics = _build_exposure_diagnostics(metadatas)
+    exposure_diagnostics = _build_exposure_diagnostics(metadatas, declared_sidecar=declared_sidecar)
     outputs = {
         "snqi_recalibration_bundle.json": output_dir / "snqi_recalibration_bundle.json",
         "snqi_recalibration_report.md": output_dir / "snqi_recalibration_report.md",
@@ -1069,6 +1223,7 @@ def build_artifact(
     output_dir: Path,
     bootstrap_samples: int,
     confidence: float,
+    interaction_exposure_sidecar: Path | None = None,
 ) -> dict[str, Any]:
     """Build all issue #4195 aggregation artifact files."""
 
@@ -1089,10 +1244,22 @@ def build_artifact(
         all_rows.extend(rows)
         metadatas.append(metadata)
 
+    # Prefer an explicit sidecar argument; otherwise reuse a declaration from an
+    # existing source_manifest.json before this run overwrites it.
+    declared_sidecar = interaction_exposure_sidecar
+    if declared_sidecar is None:
+        existing_manifest_path = output_dir / "source_manifest.json"
+        if existing_manifest_path.exists():
+            declared_sidecar = _resolve_declared_exposure_sidecar(
+                output_dir, _read_json(existing_manifest_path)
+            )
+    elif not declared_sidecar.exists():
+        declared_sidecar = None
+
     comparability = _comparability_report(metadatas)
     snqi_recalibration = _build_h600_recalibration(all_rows, h500_reports=h500_s20_reports)
     horizon_sensitivity = _build_horizon_sensitivity(all_rows, h500_reports=h500_s20_reports)
-    exposure_diagnostics = _build_exposure_diagnostics(metadatas)
+    exposure_diagnostics = _build_exposure_diagnostics(metadatas, declared_sidecar=declared_sidecar)
     outputs = {
         "planner_metric_summary.csv": output_dir / "planner_metric_summary.csv",
         "planner_metric_summary.md": output_dir / "planner_metric_summary.md",
@@ -1175,6 +1342,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="add items 3-5 outputs from an existing #4199 aggregation artifact",
     )
+    parser.add_argument(
+        "--interaction-exposure-sidecar",
+        type=Path,
+        default=None,
+        help=(
+            "optional declared interaction-exposure sidecar consumed when native "
+            "episode-row fields are absent; by default resolved from "
+            "source_manifest.json's issue_4242_h600_sidecars block"
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -1199,6 +1376,7 @@ def main(argv: list[str] | None = None) -> int:
             output_dir=args.output_dir,
             bootstrap_samples=args.bootstrap_samples,
             confidence=args.confidence,
+            interaction_exposure_sidecar=args.interaction_exposure_sidecar,
         )
     print(json.dumps(result, indent=2, sort_keys=True, default=_json_default))
     return 0 if result["status"] == "ok" else 1

--- a/tests/analysis/test_build_issue_4195_h600_aggregation_artifact.py
+++ b/tests/analysis/test_build_issue_4195_h600_aggregation_artifact.py
@@ -291,6 +291,177 @@ def test_build_artifact_accepts_native_exposure_fields_without_imputation(tmp_pa
     ]
 
 
+def _write_exposure_sidecar(
+    path: Path,
+    *,
+    statuses: dict[str, str],
+) -> None:
+    """Write a minimal #4242 interaction-exposure sidecar keyed by job_id.
+
+    ``statuses`` maps job_id -> row-level ``interaction_exposure_status``. A
+    ``computed`` status also carries populated required values; other statuses
+    leave the required values blank so no imputation is possible.
+    """
+
+    fieldnames = [
+        "job_id",
+        "run_label",
+        "episode_id",
+        "scenario_id",
+        "planner_key",
+        "seed",
+        "interaction_exposure_share",
+        "robot_motion_share_before_first_clearance",
+        "first_clearance_step",
+        "low_exposure_success",
+        "interaction_exposure_source",
+        "interaction_exposure_status",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for job_id, status in statuses.items():
+            computed = status == "computed"
+            writer.writerow(
+                {
+                    "job_id": job_id,
+                    "run_label": "confirm" if job_id == "13268" else "extended_roster",
+                    "episode_id": f"{job_id}-ep-0",
+                    "scenario_id": "a",
+                    "planner_key": "goal",
+                    "seed": "111",
+                    "interaction_exposure_share": "0.5" if computed else "",
+                    "robot_motion_share_before_first_clearance": "0.5" if computed else "",
+                    "first_clearance_step": "10" if computed else "",
+                    "low_exposure_success": "0.0" if computed else "",
+                    "interaction_exposure_source": "computed_from_retained_trace"
+                    if computed
+                    else "not_derivable_from_episode_record",
+                    "interaction_exposure_status": status,
+                }
+            )
+
+
+def _build_native_absent_artifact(tmp_path: Path) -> Path:
+    """Build a native-absent aggregation artifact and return its output dir."""
+
+    confirm_reports = tmp_path / "confirm" / "reports"
+    extended_reports = tmp_path / "extended" / "reports"
+    h500_reports = tmp_path / "h500" / "reports"
+    _write_fixture_reports(confirm_reports)
+    _write_fixture_reports(extended_reports, planners=("goal", "orca"))
+    _write_h500_fixture(h500_reports)
+    output_dir = tmp_path / "evidence"
+    result = build_artifact(
+        confirm_reports=confirm_reports,
+        extended_reports=extended_reports,
+        h500_s20_reports=h500_reports,
+        output_dir=output_dir,
+        bootstrap_samples=20,
+        confidence=0.95,
+    )
+    assert result["interaction_exposure_status"] == "blocked_missing_required_fields"
+    return output_dir
+
+
+def _declare_sidecar_in_manifest(output_dir: Path, sidecar_name: str) -> None:
+    """Add the #4242 sidecar declaration to the artifact's source manifest."""
+
+    manifest_path = output_dir / "source_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["issue_4242_h600_sidecars"] = {
+        "interaction_exposure_sidecar": sidecar_name,
+    }
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def test_extend_consumes_declared_sidecar_all_not_derivable_without_imputation(
+    tmp_path: Path,
+) -> None:
+    """A declared sidecar with only not-derivable rows stays fail-closed."""
+
+    output_dir = _build_native_absent_artifact(tmp_path)
+    _write_exposure_sidecar(
+        output_dir / "h600_interaction_exposure_sidecar.csv",
+        statuses={"13268": "not_derivable_missing_trace", "13273": "not_derivable_missing_trace"},
+    )
+    _declare_sidecar_in_manifest(output_dir, "h600_interaction_exposure_sidecar.csv")
+
+    result = extend_existing_artifact(
+        output_dir=output_dir,
+        h500_s20_reports=tmp_path / "h500" / "reports",
+    )
+
+    assert result["interaction_exposure_status"] == "sidecar_all_not_derivable"
+    exposure = json.loads((output_dir / "interaction_exposure_diagnostics.json").read_text())
+    assert exposure["exposure_field_source"] == "sidecar_declared"
+    assert exposure["declared_sidecar"] == (
+        "docs/context/evidence/issue_3810_h600_interpretation_2026-07/"
+        "h600_interaction_exposure_sidecar.csv"
+    ) or exposure["declared_sidecar"].endswith("h600_interaction_exposure_sidecar.csv")
+    confirm_run = next(row for row in exposure["runs"] if row["job_id"] == "13268")
+    assert confirm_run["exposure_field_source"] == "sidecar_declared"
+    assert confirm_run["sidecar_derivable_episode_rows"] == 0
+    assert confirm_run["sidecar_not_derivable_episode_rows"] == 1
+    assert confirm_run["sidecar_exposure_status_counts"] == {"not_derivable_missing_trace": 1}
+
+
+def test_extend_consumes_declared_sidecar_with_computed_rows(tmp_path: Path) -> None:
+    """A declared sidecar with a computed row unblocks the episode-level scan."""
+
+    output_dir = _build_native_absent_artifact(tmp_path)
+    _write_exposure_sidecar(
+        output_dir / "h600_interaction_exposure_sidecar.csv",
+        statuses={"13268": "computed", "13273": "not_derivable_missing_trace"},
+    )
+    _declare_sidecar_in_manifest(output_dir, "h600_interaction_exposure_sidecar.csv")
+
+    result = extend_existing_artifact(
+        output_dir=output_dir,
+        h500_s20_reports=tmp_path / "h500" / "reports",
+    )
+
+    assert result["interaction_exposure_status"] == "sidecar_ready_for_episode_level_scan"
+    exposure = json.loads((output_dir / "interaction_exposure_diagnostics.json").read_text())
+    confirm_run = next(row for row in exposure["runs"] if row["job_id"] == "13268")
+    assert confirm_run["status"] == "sidecar_ready_for_episode_level_scan"
+    assert confirm_run["sidecar_derivable_episode_rows"] == 1
+    extended_run = next(row for row in exposure["runs"] if row["job_id"] == "13273")
+    assert extended_run["status"] == "sidecar_all_not_derivable"
+
+
+def test_native_not_derivable_status_marker_is_not_counted_as_derivable(tmp_path: Path) -> None:
+    """Native rows with populated values but not-derivable status are not imputed."""
+
+    from scripts.analysis.build_issue_4195_h600_aggregation_artifact import (
+        _classify_exposure_rows,
+    )
+
+    rows = [
+        {
+            "interaction_exposure_share": "0.5",
+            "robot_motion_share_before_first_clearance": "0.5",
+            "first_clearance_step": "10",
+            "low_exposure_success": "0.0",
+            "interaction_exposure_status": "computed",
+            "interaction_exposure_source": "episode_metrics",
+        },
+        {
+            "interaction_exposure_share": "0.9",
+            "robot_motion_share_before_first_clearance": "0.9",
+            "first_clearance_step": "3",
+            "low_exposure_success": "0.0",
+            "interaction_exposure_status": "not_derivable_missing_trace",
+            "interaction_exposure_source": "not_derivable_from_episode_record",
+        },
+    ]
+    derivable, not_derivable, status_counts, provenance = _classify_exposure_rows(rows)
+    assert derivable == 1
+    assert not_derivable == 1
+    assert status_counts == {"computed": 1, "not_derivable_missing_trace": 1}
+    assert provenance == ["episode_metrics", "not_derivable_from_episode_record"]
+
+
 def test_build_artifact_fails_status_on_shared_hash_mismatch(tmp_path: Path) -> None:
     """Shared planners are not comparable when scenario matrix hashes differ."""
 

--- a/tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py
+++ b/tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py
@@ -416,6 +416,132 @@ def test_cli_json_summary(tmp_path: Path) -> None:
     assert payload["status"] == "blocked_missing_trace_verified_mechanism_labels"
 
 
+def _native_writer_episode(
+    planner_key: str,
+    *,
+    seed: int,
+    success: float,
+    trace_verified: bool,
+) -> dict[str, object]:
+    """Build one benchmark episode record for the native seed-row writer."""
+
+    taxonomy = {
+        "label": "static_deadlock_or_local_minimum",
+        "source": "trace_review_issue_2220",
+        "trace_status": "trace_verified" if trace_verified else "geometry_only",
+        "confidence": "observed_mechanism",
+    }
+    return {
+        "episode_id": f"ep-{planner_key}-{seed}",
+        "scenario_id": "classic_static_deadlock",
+        "seed": seed,
+        "algo": planner_key,
+        "planner_key": planner_key,
+        "kinematics": "differential_drive",
+        "failure_mechanism_taxonomy": taxonomy,
+        "metrics": {
+            "success": success,
+            "collisions": 0.0,
+            "near_misses": 1.0,
+            "time_to_goal_norm": 1.0,
+            "snqi": success,
+        },
+    }
+
+
+def _write_native_seed_rows(root: Path, rows: list[dict[str, object]]) -> None:
+    """Persist native writer rows to reports/seed_episode_rows.csv."""
+
+    reports = root / "reports"
+    reports.mkdir(parents=True)
+    fields = sorted({field for row in rows for field in row})
+    with (reports / "seed_episode_rows.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {field: ("" if row.get(field) is None else row[field]) for field in fields}
+            )
+    (reports / "campaign_summary.json").write_text('{"status": "fixture"}\n', encoding="utf-8")
+
+
+def test_native_writer_rows_are_consumed_by_builder(tmp_path: Path) -> None:
+    """End-to-end: the real seed-row writer output is consumed as native fields.
+
+    This closes the writer->builder contract for issue #4242: rows produced by
+    ``robot_sf.benchmark.seed_variance.build_seed_episode_rows`` (the #4301/#4255
+    native instrumentation) carry the canonical ``mechanism_*`` columns the #4206
+    builder requires, without any hand-authored taxonomy fields in the test.
+    """
+
+    from robot_sf.benchmark.seed_variance import build_seed_episode_rows
+
+    trace_records = [
+        _native_writer_episode("prediction_planner", seed=1, success=1.0, trace_verified=True),
+        _native_writer_episode(
+            "hybrid_rule_v3_fast_progress_static_escape",
+            seed=1,
+            success=0.4,
+            trace_verified=True,
+        ),
+        _native_writer_episode("ppo", seed=1, success=0.7, trace_verified=True),
+    ]
+    native_rows = build_seed_episode_rows(trace_records)
+    # The writer emitted the canonical consumption columns without a sidecar.
+    assert all(
+        row["mechanism_schema_version"] == "failure_mechanism_taxonomy.v1" for row in native_rows
+    )
+    assert all(row["mechanism_evidence_mode"] == "paired_trace" for row in native_rows)
+
+    confirm = tmp_path / "confirm"
+    extended = tmp_path / "extended"
+    _write_native_seed_rows(confirm, native_rows)
+    _write_native_seed_rows(extended, native_rows)
+    output = tmp_path / "evidence"
+
+    summary = _MODULE.build_packet(
+        config_path=CONFIG,
+        confirm_root=confirm,
+        extended_root=extended,
+        job13175_packet=tmp_path / "packet.json",
+        output_dir=output,
+        generated_at="2026-07-03T00:00:00Z",
+    )
+
+    assert summary["status"] == "analysis_ready_trace_verified"
+    assert summary["accepted_rows"] >= 3
+
+
+def test_native_writer_geometry_only_rows_are_rejected(tmp_path: Path) -> None:
+    """Non-trace-verified native rows fail closed to unknown, blocking F-C4(ii)."""
+
+    from robot_sf.benchmark.seed_variance import build_seed_episode_rows
+
+    native_rows = build_seed_episode_rows(
+        [_native_writer_episode("prediction_planner", seed=1, success=1.0, trace_verified=False)]
+    )
+    # The writer refuses geometry-only mechanism labels: label collapses to unknown.
+    assert native_rows[0]["mechanism_label"] == "unknown"
+    assert native_rows[0]["mechanism_evidence_mode"] == "unknown"
+
+    confirm = tmp_path / "confirm"
+    extended = tmp_path / "extended"
+    _write_native_seed_rows(confirm, native_rows)
+    _write_native_seed_rows(extended, native_rows)
+    output = tmp_path / "evidence"
+
+    summary = _MODULE.build_packet(
+        config_path=CONFIG,
+        confirm_root=confirm,
+        extended_root=extended,
+        job13175_packet=tmp_path / "packet.json",
+        output_dir=output,
+        generated_at="2026-07-03T00:00:00Z",
+    )
+
+    assert summary["status"] == "blocked_missing_trace_verified_mechanism_labels"
+
+
 def test_config_declares_forbidden_geometry_substitution() -> None:
     """The checked-in config owns classes and forbids geometry fallback."""
     payload = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** The #4195 h600 exposure-diagnostics builder now *consumes* native `seed_episode_rows.csv` exposure provenance (the `interaction_exposure_status` column emitted by the #4255/#4301 writer) and falls back to a **declared** interaction-exposure sidecar (`source_manifest.json` → `issue_4242_h600_sidecars.interaction_exposure_sidecar`) when native episode-row fields are absent. Adds a writer→builder contract test for the #4206 mechanism cross-cut.
- **Why now:** This is the remaining CPU closure slice named by the maintainer gate on 2026-07-03T14:37 (PR #4301): "teach `seed_episode_rows.csv` and the #4195/#4206 builders to *consume* the native blocks." It is a nameable progression slice (new capability: builder consumption of native provenance + declared sidecars), so it proceeds under the fragmentation-guard progression exemption.
- **Claim boundary:** `diagnostic-only`. No benchmark/ranking/paper/dissertation claim is promoted. No imputation: rows with `not_derivable` / `missing` status markers stay visible but never count as derivable evidence.
- **Required validation:** focused pytest for #4195 and #4206 (below) + a real-input run of the declared-sidecar path over the committed h600 sidecar.
- **Remaining blocker:** the retained h600 sidecar is uniformly `not_derivable_missing_trace` (no retained traces), so consumption is honest-but-empty — no derivable exposure evidence exists to unblock F-C4(ii). Regenerating the committed evidence directory is deferred (see out-of-scope).

## Contract delta

- **New consumption inputs (no schema *writes*):**
  - #4195 exposure diagnostics reads the native `interaction_exposure_status` provenance column and a declared sidecar path from `source_manifest.json`.
  - New CLI flag `--interaction-exposure-sidecar` (optional; otherwise auto-resolved from the manifest).
- **New report fields (`interaction_exposure_diagnostics.json`):** per-run `exposure_field_source` (`native_episode_fields` | `sidecar_declared` | `blocked_missing_required_fields`), `native_exposure_status_counts`, and sidecar counts; new top-level statuses `sidecar_ready_for_episode_level_scan` / `sidecar_all_not_derivable`.
- **Fail-closed preserved:** absent native fields *and* no declared sidecar → `blocked_missing_required_fields` (unchanged). Geometry-only mechanism labels remain rejected (#4206). Native instrumentation always wins over the sidecar.
- **Compatibility:** additive. Existing #4195/#4206 tests unchanged and green; no writer/schema changes.

## Issue

Refs #4242 — https://github.com/ll7/robot_sf_ll7/issues/4242 (issue stays OPEN)

## Scope

In scope: extend the existing #4195 and #4206 h600 builders to consume native `seed_episode_rows.csv` mechanism/exposure fields or declared sidecars, keep geometry-only labels rejected, preserve fail-closed behavior when fields are absent, and update focused tests.

The #4206 builder already consumed native `mechanism_*` fields + `reports/` sidecars and rejected geometry-only labels (added by #4255); this PR locks that in with an end-to-end writer→builder test that derives rows from the real `build_seed_episode_rows` writer instead of hand-authored fields. The substantive new consumption capability is on the #4195 exposure side.

## Validation

```
scripts/dev/run_worktree_shared_venv.sh -- uv run pytest \
  tests/analysis/test_build_issue_4195_h600_aggregation_artifact.py \
  tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py \
  tests/benchmark/test_seed_variance.py -q
# 32 passed in 2.23s
```

```
uv run ruff check <changed files>   # All checks passed!
uv run ruff format <changed files>  # applied
```

Real-input consumption of the committed declared sidecar (temp copy of the evidence dir; committed files NOT mutated):

```
uv run python scripts/analysis/build_issue_4195_h600_aggregation_artifact.py \
  --extend-existing --output-dir <tmp copy of docs/context/evidence/issue_3810_h600_interpretation_2026-07>
# interaction_exposure_status: sidecar_all_not_derivable
#   job 13268 | src sidecar_declared | 1008 rows | derivable 0 | not_derivable 1008
#   job 13273 | src sidecar_declared | 1296 rows | derivable 0 | not_derivable 1296
```

This matches the manifest's `interaction_exposure_status_counts: {not_derivable_missing_trace: 2304}` — the sidecar is consumed and correctly classified fail-closed, with zero imputation.

## Out of scope (explicit)

- **No full benchmark campaign run**, no Slurm/GPU submission, no new writer instrumentation, no imputed mechanism/exposure labels.
- **No paper/dissertation claim edits.**
- **Committed evidence-dir regeneration deferred:** re-running the builder over `docs/context/evidence/issue_3810_h600_interpretation_2026-07/` would rewrite sibling artifacts (SNQI/horizon/README/SHA256SUMS) also touched by #4239; since the retained sidecar yields no derivable exposure evidence, the rerun would only relabel `blocked_missing_required_fields` → `sidecar_all_not_derivable`. Left to a focused follow-up / maintainer to avoid a noisy, conflict-prone diff.

<details>
<summary>State propagation & governance</summary>

- **State propagation:** issue #4242 is high-churn (4 PRs in 24h). Per the launcher's state-propagation rule I am not adding another comment stream; the durable status change (builders now consume native provenance + declared sidecars; retained sidecar remains uniformly not-derivable) is captured here in the PR body. `comment_issue_or_pr` authorization is false for this lane, so the canonical issue-state update is deferred to the PR-gate owner.
- **Downstream propagation:** NA for claim maps / leaderboards — `diagnostic-only`, no metric/ranking movement.
- **Research result guidance:** target = AC #5 (builders consume native fields/sidecars); comparator = prior fail-closed `blocked_missing_required_fields`; evidence tier = `diagnostic-only`; result = capability landed, empirical exposure evidence still blocked by absent retained traces (no imputation); decision/stop rule = unchanged (F-C4(ii) stays blocked until trace-verified exposure exists).
- After this PR opens, Claude Code on `imech156-u` owns the full PR gate, improvement cycle, and merge authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
