### PR TITLE
Fix #4178: scope docs-proof wrapper catalog validation to catalog changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -768,6 +768,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed a **docs-proof readiness false-blocker for docs/context note PRs** (#4178, successor to
+  #4191). The `scripts/dev/check_docs_proof_consistency_diff.sh` wrapper unconditionally injected
+  `docs/context/catalog.yaml` into the `--path` selection for *any* docs/context-only diff, which
+  forced full catalog schema/provenance validation and surfaced pre-existing, unrelated catalog
+  debt (evidence rows that point at ignored `output/` artifacts). A PR that only edited a context
+  note (never touching `catalog.yaml`) was blocked by that baseline debt. The wrapper now keeps only
+  `README.md`/`INDEX.md` as always-selected link anchors; full catalog validation runs when
+  `catalog.yaml` is itself in the diff (selected naturally) or under the explicit
+  `--check-context-catalog` flag. #4191 already made the direct Python checker diff-scoped for
+  code-only diffs; this closes the same gap for docs/context note diffs. Strict catalog proof on
+  actual `catalog.yaml` changes and the explicit `--check-evidence-catalog` mode are unchanged, and
+  no catalog rows were repaired. Added a focused regression test.
+
 * Fixed **absolute machine paths leaking into the #4239 h600 SNQI evidence packet** (#4302). The
   builder `scripts/validation/build_issue_4239_h600_snqi_weight_set_ranking.py` hardened `_rel()` so a
   worktree `output/` symlink (which made `path.resolve()` escape the worktree root) no longer falls

--- a/scripts/dev/check_docs_proof_consistency_diff.sh
+++ b/scripts/dev/check_docs_proof_consistency_diff.sh
@@ -2,10 +2,16 @@
 set -euo pipefail
 
 # Diff-scoped PR handoff check:
-# - docs/context-only diffs include README, INDEX, and catalog paths explicitly,
-#   preserving strict docs proof and context-catalog diagnostics.
+# - docs/context-only diffs additionally select README and INDEX as link
+#   anchors, preserving strict added-note linkage proof.
 # - non-docs or mixed code diffs run changed-file proof only, so unrelated
 #   historical docs/context/catalog.yaml debt does not block code-only readiness.
+# - full docs/context/catalog.yaml schema/provenance validation runs only when
+#   catalog.yaml is itself part of the diff (it is then selected naturally) or
+#   via the explicit scripts/validation/check_docs_proof_consistency.py
+#   --check-context-catalog flag. This keeps unrelated baseline catalog debt
+#   from blocking docs/context note PRs that never touched catalog.yaml, while
+#   preserving strict catalog proof whenever catalog.yaml actually changes.
 # - full evidence catalog hygiene remains explicit via
 #   scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog.
 
@@ -14,10 +20,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common_setup.sh"
 
 BASE_REF="${BASE_REF:-origin/main}"
+# Link anchors always selected for docs/context-only diffs so added-note
+# README/INDEX linkage proof runs. Intentionally excludes catalog.yaml: forcing
+# it here would re-validate every catalog row and surface unrelated baseline
+# debt on note-only PRs. catalog.yaml is validated when it is itself in the diff
+# or under the explicit --check-context-catalog flag.
 DOCS_CONTEXT_PROOF_PATHS=(
   "docs/context/README.md"
   "docs/context/INDEX.md"
-  "docs/context/catalog.yaml"
 )
 
 path_selected() {

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -497,6 +497,29 @@ def test_code_only_diff_skips_context_catalog_debt(tmp_path: Path) -> None:
     )
 
 
+def test_docs_context_note_diff_with_anchors_skips_catalog_debt(tmp_path: Path) -> None:
+    """Docs/context note PRs must not surface unrelated baseline catalog debt.
+
+    Mirrors the ``check_docs_proof_consistency_diff.sh`` docs/context-only
+    selection after issue #4178: a changed note plus the README/INDEX link
+    anchors, but *not* ``catalog.yaml``.  Because the catalog is not selected,
+    pre-existing catalog debt (here an evidence row pointing at ignored
+    ``output/`` artifacts) must stay silent for the note-only PR.
+    """
+    repo_root = tmp_path
+    _write_catalog_with_output_pointer(repo_root)
+    (repo_root / "docs/context/example_note.md").write_text("Clean note body.\n", encoding="utf-8")
+
+    selected = [
+        ChangedFile(status="M", path=Path("docs/context/example_note.md")),
+        ChangedFile(status="M", path=Path("docs/context/README.md")),
+        ChangedFile(status="M", path=Path("docs/context/INDEX.md")),
+    ]
+
+    assert not _should_check_context_catalog(selected)
+    assert _collect_diagnostics(selected, repo_root=repo_root) == []
+
+
 def test_selected_context_catalog_keeps_strict_catalog_diagnostics(tmp_path: Path) -> None:
     """Selecting the context catalog keeps strict catalog provenance checks."""
     repo_root = tmp_path


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** `scripts/dev/check_docs_proof_consistency_diff.sh` no longer injects
  `docs/context/catalog.yaml` into the `--path` selection for docs/context-only diffs. Only
  `README.md`/`INDEX.md` remain as always-selected link anchors.
- **Why now:** Issue #4178 (successor to merged #4191) reports a docs-proof readiness
  **false-blocker**. #4191 made the direct Python checker diff-scoped for *code-only* diffs, but the
  shell wrapper still force-validated the whole catalog for *any* docs/context diff, surfacing
  pre-existing, unrelated catalog debt on note-only PRs.
- **Claim boundary:** This separates unrelated baseline catalog debt from docs/context note-PR
  readiness. It does **not** repair any catalog rows and does **not** weaken strict catalog/evidence
  checks when catalog proof is genuinely selected.
- **Required validation:** focused checker tests + the diff wrapper on representative diffs
  (results below).
- **Remaining blocker:** none for this slice. The 8 baseline `catalog.yaml` evidence rows that point
  at ignored `output/` artifacts are still real debt; repairing them is explicitly out of scope
  (tracked separately from this readiness fix).

Closes #4178.

## Contract delta

- **Behavior change (wrapper only):** full `docs/context/catalog.yaml` schema/provenance validation
  now runs **only** when `catalog.yaml` is itself part of the branch diff (selected naturally) or
  under the explicit `--check-context-catalog` flag. Previously it ran for every docs/context-only
  diff.
- **No new schema fields, no new fail-closed blockers.** The Python checker's public interface is
  unchanged; `_should_check_context_catalog` / `--check-context-catalog` / `--check-evidence-catalog`
  all keep their #4191 semantics.
- **Compatibility:** code-only PRs unchanged; docs/context PRs that *do* touch `catalog.yaml` still
  get strict full validation; `--check-evidence-catalog` hygiene pass unchanged.

## Root cause (reproduced)

Pre-fix, on current `main`, a committed docs/context note-only diff (e.g. editing
`docs/context/INDEX.md`, catalog untouched):

```
$ BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
ERROR docs/context/catalog.yaml: entries[1].path is evidence and points to ignored output/ artifacts
... (8 unrelated baseline rows) ...
EXIT=1
```

The same diff through the direct Python checker (`--base origin/main`) already passed with `EXIT=0`,
confirming the residual gap was the wrapper's unconditional `catalog.yaml` injection, not the
checker.

## Validation

All commands run on `imech156-u` (CPU only; no campaigns, no Slurm/GPU).

| Command | Result |
| --- | --- |
| `ruff check` (checker + test) | All checks passed |
| `ruff format --check` (checker + test) | formatted |
| `bash -n check_docs_proof_consistency_diff.sh` | syntax OK |
| `uv run python scripts/tools/sync_ai_config.py --check` | AI config links validated |
| `pytest tests/validation/test_check_docs_proof_consistency.py` | **42 passed** (incl. new regression) |

Post-fix wrapper behavior across scenarios:

| Scenario | Expected | Result |
| --- | --- | --- |
| A. docs/context note-only PR (catalog untouched) | pass | `EXIT=0` (2 files: note + README anchor) |
| B. PR that changes `catalog.yaml` | strict fail on real debt | `EXIT=1` (baseline rows reported) |
| C. code-only PR | pass | `EXIT=0` |
| D. explicit `--check-context-catalog` on code diff | strict fail | `EXIT=1` |

New regression test: `test_docs_context_note_diff_with_anchors_skips_catalog_debt` — asserts a
wrapper-style docs/context selection (changed note + README/INDEX anchors, no `catalog.yaml`) does
not surface baseline catalog debt, while the existing
`test_selected_context_catalog_keeps_strict_catalog_diagnostics` proves strict validation still
fires when `catalog.yaml` is selected.

## Decision record

- **Chosen mechanism:** wrapper-level scoping (drop `catalog.yaml` from the always-injected anchors),
  not catalog-row repair. The direct checker was already correctly diff-scoped by #4191, so the
  remaining fix belongs in the wrapper.
- **Why strict proof is not weakened:** changed-`catalog.yaml` PRs and `--check-context-catalog`
  still run full validation; `--check-evidence-catalog` is untouched. Non-goal "do not suppress
  diagnostics for changed `catalog.yaml`" is preserved.
- **Deviation from the (pre-#4191) issue-body plan:** the original Step-2 design listed
  "wrapper selected the required docs proof paths for a docs/context-only PR" as a trigger for full
  catalog validation. Per the ready-queue framing (fix the residual false-blocker) and the issue
  title ("make docs-proof diff scoping ignore unrelated catalog debt"), that trigger is exactly the
  false-blocker and is intentionally removed here. README/INDEX link-anchor selection is retained.

## Downstream Propagation

State surface: this PR body is the canonical status surface for the slice (issue commenting was not
authorized for this run). Low-churn issue (#4191 the only prior merged PR); no issue-state table or
tracked routing-state file is needed — this is a schema/behavior change, not queue-routing state.
No claim map / leaderboard / registry impact.

## Research Result Guidance

`NA - support/tooling`. This is a validation-tooling bugfix with no benchmark, metric, model, or
paper-facing claim.

## Out of scope (explicit)

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No repair of the 8 pre-existing `catalog.yaml` evidence rows (unrelated baseline debt).
- No weakening of docs/context checks when docs surfaces genuinely change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
