### PR TITLE
Issue #4207: interaction-validity guard for the certification-transfer evidence packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added an **interaction-validity guard** to the issue #4207 certification-transfer probe (#4207):
+  `robot_sf/benchmark/certification_transfer.py` gains `classify_interaction_status(...)` and now
+  tags every gate cell with `interaction_status` (`interacting` / `non_interacting` / `unknown`) and
+  every transfer-matrix row with `interaction_status` plus an `interaction_exercised` flag. Because
+  `social_force_default` and `hsfm_total_force_v1` only diverge when the robot enters the 5 m
+  pedestrian near field, a `stable_pass`/`stable_fail` built from cells that never do is *vacuous* —
+  it does not demonstrate certification robustness. The report/metadata now carry
+  `interaction_status_counts` and a `model_sensitivity_exercised` boolean, and the README/claim
+  boundary spell out the vacuity caveat. New
+  `scripts/benchmark/annotate_certification_transfer_interaction_issue_4207.py` applies the guard
+  post-hoc to a recorded `summary.json` (no new simulation) and emits `interaction_validity.{md,csv}`.
+  Running it on the committed 2026-07 packet shows all 8 cells are `non_interacting`
+  (`robot_ped_within_5m_frac == 0`, `min_clearance_m ≈ 20 m`), so its "0 flips" result is not yet
+  evidence of model-robust certification; the residual empirical action is an interacting scenario
+  family. Diagnostic-only; no deployment, benchmark-strength, or paper/dissertation claim.
 * Added a **safety-wrapper false-stop diagnostic** for `wrapper_on` benchmark rows (#3501):
   `robot_sf/benchmark/safety_wrapper_runtime.py` gains `analyze_false_stop_diagnostic(...)`, and the
   episode summary now embeds a schema-tagged `false_stop_diagnostic` block plus a

--- a/docs/context/evidence/issue_4207_certification_transfer_probe_2026-07/interaction_validity.csv
+++ b/docs/context/evidence/issue_4207_certification_transfer_probe_2026-07/interaction_validity.csv
@@ -1,0 +1,9 @@
+planner_key,structural_class,evaluation_model,gate_status,interaction_status,min_clearance_m,robot_ped_within_5m_frac,episodes
+goal,baseline_reactive,social_force_default,pass,non_interacting,24.1214633051,0,3
+goal,baseline_reactive,hsfm_total_force_v1,pass,non_interacting,24.1214633051,0,3
+ppo,learned_policy,social_force_default,pass,non_interacting,19.8766165182,0,3
+ppo,learned_policy,hsfm_total_force_v1,pass,non_interacting,19.8766165182,0,3
+prediction_planner,predictive,social_force_default,fail,non_interacting,24.1765022681,0,3
+prediction_planner,predictive,hsfm_total_force_v1,fail,non_interacting,24.1765022681,0,3
+guarded_ppo,constraint_first,social_force_default,pass,non_interacting,19.8853869032,0,3
+guarded_ppo,constraint_first,hsfm_total_force_v1,pass,non_interacting,19.8853869032,0,3

--- a/docs/context/evidence/issue_4207_certification_transfer_probe_2026-07/interaction_validity.md
+++ b/docs/context/evidence/issue_4207_certification_transfer_probe_2026-07/interaction_validity.md
@@ -1,0 +1,28 @@
+# Issue #4207 Certification-Transfer Interaction-Validity Annotation
+
+Post-hoc, diagnostic-only annotation. This does NOT run a new simulation; it classifies the interaction status of each cell from the aggregate metrics already recorded in `summary.json`.
+
+- Near-field band: `5` m (`social_force_default` and `hsfm_total_force_v1` only diverge inside it).
+- Interaction status counts: `{'non_interacting': 8}`
+- Model sensitivity exercised: `False`
+
+**Verdict:** Model sensitivity was NOT exercised: every recorded cell stayed outside the 5 m pedestrian near field, so the certification-transfer statuses are vacuous and do NOT demonstrate certification robustness.
+
+## Per-cell interaction status
+
+| planner_key | evaluation_model | gate_status | interaction_status | min_clearance_m | robot_ped_within_5m_frac | episodes |
+| --- | --- | --- | --- | --- | --- | --- |
+| goal | social_force_default | pass | non_interacting | 24.1214633051 | 0 | 3 |
+| goal | hsfm_total_force_v1 | pass | non_interacting | 24.1214633051 | 0 | 3 |
+| ppo | social_force_default | pass | non_interacting | 19.8766165182 | 0 | 3 |
+| ppo | hsfm_total_force_v1 | pass | non_interacting | 19.8766165182 | 0 | 3 |
+| prediction_planner | social_force_default | fail | non_interacting | 24.1765022681 | 0 | 3 |
+| prediction_planner | hsfm_total_force_v1 | fail | non_interacting | 24.1765022681 | 0 | 3 |
+| guarded_ppo | social_force_default | pass | non_interacting | 19.8853869032 | 0 | 3 |
+| guarded_ppo | hsfm_total_force_v1 | pass | non_interacting | 19.8853869032 | 0 | 3 |
+
+## Provenance
+
+- Source summary: `summary.json` (sha256 `2ed383ee44f2746730c38dc1f32093e9d094c03292c4d634484a182c0b640295`)
+- Companion CSV: `interaction_validity.csv`
+- Claim boundary: diagnostic certification-transfer interaction validity; no deployment, safety, benchmark-strength, or paper/dissertation claim.

--- a/robot_sf/benchmark/certification_transfer.py
+++ b/robot_sf/benchmark/certification_transfer.py
@@ -26,12 +26,23 @@ ISSUE = 4207
 CLAIM_BOUNDARY = "diagnostic_certification_transfer_probe_no_deployment_claim"
 DEFAULT_PEDESTRIAN_MODELS = (SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1)
 
+# Near-field proxemic band (metres). ``social_force_default`` and ``hsfm_total_force_v1``
+# differ only in pedestrian force dynamics, so their pass/fail decision can only diverge
+# when the robot actually enters the pedestrian near field. A cell whose episodes never
+# bring the robot within this band exercises no model-sensitive dynamics; a stable transfer
+# status over such a cell is therefore vacuous, not evidence of certification robustness.
+# The 5 m band mirrors the ``robot_ped_within_5m_frac`` comfort metric already used by the
+# #4166-style gate spec.
+INTERACTION_NEAR_FIELD_M = 5.0
+INTERACTION_STATUSES = ("interacting", "non_interacting", "unknown")
+
 GATE_CELL_COLUMNS = (
     "planner_key",
     "structural_class",
     "scenario_family",
     "evaluation_model",
     "gate_status",
+    "interaction_status",
     "failed_gate_ids",
     "not_evaluable_gate_ids",
     "episodes",
@@ -45,6 +56,8 @@ TRANSFER_MATRIX_COLUMNS = (
     "certification_gate_status",
     "evaluation_gate_status",
     "transfer_status",
+    "interaction_status",
+    "interaction_exercised",
     "flip_type",
     "failed_gate_ids",
     "not_evaluable_gate_ids",
@@ -260,11 +273,18 @@ def build_certification_transfer_report(
         "flip_cases": flip_cases,
         "row_status_counts": dict(Counter(row["gate_status"] for row in gate_cells)),
         "transfer_status_counts": dict(Counter(row["transfer_status"] for row in transfer_matrix)),
+        "interaction_status_counts": dict(
+            Counter(row["interaction_status"] for row in transfer_matrix)
+        ),
+        "model_sensitivity_exercised": any(row["interaction_exercised"] for row in transfer_matrix),
         "claim_boundary_notes": [
             "Diagnostic transfer probe only.",
             "Provisional gate thresholds are not certification approval.",
             "not_evaluable is never treated as pass.",
             "Model-transfer flips indicate model-assumption fragility in the gate decision.",
+            "A stable transfer status over non_interacting cells is vacuous: the robot never "
+            "entered the pedestrian near field, so the SFM/HSFM swap was not exercised and no "
+            "certification-robustness conclusion follows.",
             "No deployment, real-world safety, or general planner-superiority claim follows.",
         ],
     }
@@ -354,6 +374,7 @@ def _build_gate_cells(
                     "scenario_family": scenario_family,
                     "evaluation_model": evaluation_model,
                     "gate_status": gate_status,
+                    "interaction_status": classify_interaction_status(metrics),
                     "failed_gate_ids": ";".join(failed),
                     "not_evaluable_gate_ids": ";".join(not_evaluable),
                     "episodes": len(matching),
@@ -386,6 +407,10 @@ def _build_transfer_matrix(
                     str(certification_cell["gate_status"]),
                     str(evaluation_cell["gate_status"]),
                 )
+                interaction_status, interaction_exercised = _transfer_interaction(
+                    str(certification_cell["interaction_status"]),
+                    str(evaluation_cell["interaction_status"]),
+                )
                 rows.append(
                     {
                         "planner_key": arm["key"],
@@ -396,6 +421,8 @@ def _build_transfer_matrix(
                         "certification_gate_status": certification_cell["gate_status"],
                         "evaluation_gate_status": evaluation_cell["gate_status"],
                         "transfer_status": transfer_status,
+                        "interaction_status": interaction_status,
+                        "interaction_exercised": interaction_exercised,
                         "flip_type": flip_type,
                         "failed_gate_ids": evaluation_cell["failed_gate_ids"],
                         "not_evaluable_gate_ids": evaluation_cell["not_evaluable_gate_ids"],
@@ -476,6 +503,47 @@ def _evaluate_gate(metrics: Mapping[str, float | None], gate: Mapping[str, Any])
         "threshold": threshold,
         "direction": direction,
     }
+
+
+def classify_interaction_status(metrics: Mapping[str, float | None]) -> str:
+    """Classify whether a cell's episodes exercised the robot-pedestrian near field.
+
+    ``social_force_default`` and ``hsfm_total_force_v1`` only diverge when the robot enters
+    the pedestrian near field, so a cell that never does cannot demonstrate certification
+    fragility (its stable transfer status is vacuous).
+
+    Returns:
+        ``"interacting"`` when a proximity metric shows near-field contact,
+        ``"non_interacting"`` when proximity metrics are present but show no contact, and
+        ``"unknown"`` when no proximity metric is available (e.g. an empty/not_evaluable cell).
+    """
+
+    within_frac = metrics.get("robot_ped_within_5m_frac")
+    min_clearance = metrics.get("min_clearance_m")
+    if within_frac is None and min_clearance is None:
+        return "unknown"
+    entered_near_field = (within_frac is not None and within_frac > 0.0) or (
+        min_clearance is not None and min_clearance < INTERACTION_NEAR_FIELD_M
+    )
+    return "interacting" if entered_near_field else "non_interacting"
+
+
+def _transfer_interaction(certification_status: str, evaluation_status: str) -> tuple[str, bool]:
+    """Combine two cells' interaction statuses into a transfer-row interaction verdict.
+
+    Returns:
+        The combined interaction status (``unknown`` dominates, then ``non_interacting``) and
+        an ``interaction_exercised`` flag that is true only when both cells are interacting.
+    """
+
+    statuses = {certification_status, evaluation_status}
+    if "unknown" in statuses:
+        combined = "unknown"
+    elif statuses == {"interacting"}:
+        combined = "interacting"
+    else:
+        combined = "non_interacting"
+    return combined, combined == "interacting"
 
 
 def _transfer_status(certification_status: str, evaluation_status: str) -> tuple[str, str]:
@@ -624,6 +692,8 @@ def _metadata_payload(report: Mapping[str, Any]) -> dict[str, Any]:
         "arms": report["arms"],
         "row_status_counts": report["row_status_counts"],
         "transfer_status_counts": report["transfer_status_counts"],
+        "interaction_status_counts": report["interaction_status_counts"],
+        "model_sensitivity_exercised": report["model_sensitivity_exercised"],
     }
 
 
@@ -634,6 +704,9 @@ def _claim_boundary_markdown(report: Mapping[str, Any]) -> str:
         "- Diagnostic certification-transfer probe only.",
         "- Provisional gates are reporting thresholds, not certification approval.",
         "- `not_evaluable` cells are fail-closed and never count as `pass`.",
+        "- `non_interacting` cells (robot never inside the 5 m pedestrian near field) cannot "
+        "demonstrate certification robustness; a stable status over them is vacuous, because the "
+        "SFM/HSFM swap was never exercised.",
         "- Pass/fail flips are a result: model-assumption fragility in the certification decision.",
         "- No full benchmark campaign, Slurm or GPU submission, retraining, deployment claim, "
         "real-world safety claim, or paper/dissertation claim promotion is included.",
@@ -658,7 +731,13 @@ def _readme_markdown(report: Mapping[str, Any]) -> str:
         "",
         f"- Gate status counts: `{dict(report['row_status_counts'])}`",
         f"- Transfer status counts: `{dict(report['transfer_status_counts'])}`",
+        f"- Interaction status counts: `{dict(report['interaction_status_counts'])}`",
+        f"- Model sensitivity exercised: `{report['model_sensitivity_exercised']}`",
         f"- Flip cases: `{len(report['flip_cases'])}`",
+        "",
+        "If `Model sensitivity exercised` is `false`, every transfer cell is `non_interacting` "
+        "or `unknown`: the robot never entered the pedestrian near field, so the stable statuses "
+        "above are vacuous and do not demonstrate certification robustness.",
         "",
         "## Files",
         "",

--- a/scripts/benchmark/annotate_certification_transfer_interaction_issue_4207.py
+++ b/scripts/benchmark/annotate_certification_transfer_interaction_issue_4207.py
@@ -1,0 +1,198 @@
+"""Post-hoc interaction-validity annotation for an issue #4207 evidence packet.
+
+This tool re-reads the per-cell aggregate metrics already recorded in a certification-transfer
+``summary.json`` and classifies whether each cell exercised the robot-pedestrian near field
+(see :func:`robot_sf.benchmark.certification_transfer.classify_interaction_status`). It does NOT
+run a new simulation; it only annotates an existing recorded run so a reviewer can tell a genuine
+``stable_pass``/``stable_fail`` (model swap exercised, no flip) apart from a vacuous one (the robot
+never entered the pedestrian near field, so the SFM/HSFM swap was never exercised).
+
+Outputs ``interaction_validity.csv`` and ``interaction_validity.md`` next to the summary. The
+verdict is diagnostic-only and adds no deployment, safety, or paper/dissertation claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.certification_transfer import (
+    INTERACTION_NEAR_FIELD_M,
+    classify_interaction_status,
+)
+
+CELL_COLUMNS = (
+    "planner_key",
+    "structural_class",
+    "evaluation_model",
+    "gate_status",
+    "interaction_status",
+    "min_clearance_m",
+    "robot_ped_within_5m_frac",
+    "episodes",
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        required=True,
+        help="Path to a recorded certification-transfer summary.json.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for annotation artifacts (defaults to the summary directory).",
+    )
+    return parser.parse_args(argv)
+
+
+def annotate(summary_path: Path, output_dir: Path) -> dict[str, Any]:
+    """Classify interaction status for each recorded gate cell.
+
+    Returns:
+        Mapping with the per-cell rows and aggregate interaction-status counts.
+    """
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    rows: list[dict[str, Any]] = []
+    for cell in summary.get("gate_cells", []):
+        metrics = cell.get("metrics") or {}
+        rows.append(
+            {
+                "planner_key": cell.get("planner_key"),
+                "structural_class": cell.get("structural_class"),
+                "evaluation_model": cell.get("evaluation_model"),
+                "gate_status": cell.get("gate_status"),
+                "interaction_status": classify_interaction_status(metrics),
+                "min_clearance_m": metrics.get("min_clearance_m"),
+                "robot_ped_within_5m_frac": metrics.get("robot_ped_within_5m_frac"),
+                "episodes": cell.get("episodes"),
+            }
+        )
+    counts = dict(Counter(row["interaction_status"] for row in rows))
+    model_sensitivity_exercised = counts.get("interacting", 0) > 0
+    output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = output_dir / "interaction_validity.csv"
+    md_path = output_dir / "interaction_validity.md"
+    _write_csv(csv_path, rows)
+    md_path.write_text(
+        _markdown(summary_path, rows, counts, model_sensitivity_exercised, csv_path),
+        encoding="utf-8",
+    )
+    return {
+        "rows": rows,
+        "interaction_status_counts": counts,
+        "model_sensitivity_exercised": model_sensitivity_exercised,
+        "csv": str(csv_path),
+        "md": str(md_path),
+    }
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle, fieldnames=CELL_COLUMNS, extrasaction="ignore", lineterminator="\n"
+        )
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({column: _csv_value(row.get(column)) for column in CELL_COLUMNS})
+
+
+def _csv_value(value: Any) -> Any:
+    if value is None:
+        return "NA"
+    if isinstance(value, float):
+        return f"{value:.12g}"
+    return value
+
+
+def _markdown(
+    summary_path: Path,
+    rows: list[dict[str, Any]],
+    counts: dict[str, int],
+    model_sensitivity_exercised: bool,
+    csv_path: Path,
+) -> str:
+    verdict = (
+        "Model sensitivity WAS exercised: at least one cell entered the pedestrian near field."
+        if model_sensitivity_exercised
+        else "Model sensitivity was NOT exercised: every recorded cell stayed outside the "
+        f"{INTERACTION_NEAR_FIELD_M:g} m pedestrian near field, so the certification-transfer "
+        "statuses are vacuous and do NOT demonstrate certification robustness."
+    )
+    lines = [
+        "# Issue #4207 Certification-Transfer Interaction-Validity Annotation",
+        "",
+        "Post-hoc, diagnostic-only annotation. This does NOT run a new simulation; it classifies "
+        "the interaction status of each cell from the aggregate metrics already recorded in "
+        f"`{summary_path.name}`.",
+        "",
+        f"- Near-field band: `{INTERACTION_NEAR_FIELD_M:g}` m "
+        "(`social_force_default` and `hsfm_total_force_v1` only diverge inside it).",
+        f"- Interaction status counts: `{counts}`",
+        f"- Model sensitivity exercised: `{model_sensitivity_exercised}`",
+        "",
+        f"**Verdict:** {verdict}",
+        "",
+        "## Per-cell interaction status",
+        "",
+        "| planner_key | evaluation_model | gate_status | interaction_status | "
+        "min_clearance_m | robot_ped_within_5m_frac | episodes |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            "| {planner_key} | {evaluation_model} | {gate_status} | {interaction_status} | "
+            "{min_clearance_m} | {within} | {episodes} |".format(
+                planner_key=row["planner_key"],
+                evaluation_model=row["evaluation_model"],
+                gate_status=row["gate_status"],
+                interaction_status=row["interaction_status"],
+                min_clearance_m=_csv_value(row["min_clearance_m"]),
+                within=_csv_value(row["robot_ped_within_5m_frac"]),
+                episodes=row["episodes"],
+            )
+        )
+    lines += [
+        "",
+        "## Provenance",
+        "",
+        f"- Source summary: `{summary_path.name}` (sha256 `{_sha256_file(summary_path)}`)",
+        f"- Companion CSV: `{csv_path.name}`",
+        "- Claim boundary: diagnostic certification-transfer interaction validity; no deployment, "
+        "safety, benchmark-strength, or paper/dissertation claim.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Annotate a recorded certification-transfer packet with interaction validity."""
+
+    args = parse_args(argv)
+    summary_path = args.summary.resolve()
+    output_dir = (args.output_dir or summary_path.parent).resolve()
+    result = annotate(summary_path, output_dir)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_certification_transfer_issue_4207.py
+++ b/tests/benchmark/test_certification_transfer_issue_4207.py
@@ -11,6 +11,7 @@ import pytest
 from robot_sf.benchmark.certification_transfer import (
     CLAIM_BOUNDARY,
     build_certification_transfer_report,
+    classify_interaction_status,
     validate_probe_config,
     write_certification_transfer_evidence,
 )
@@ -144,6 +145,109 @@ def test_evidence_writer_emits_checksums_without_raw_artifacts(tmp_path: Path) -
     assert rows
 
 
+def test_interaction_status_classifier_distinguishes_near_field_contact() -> None:
+    """Proximity metrics decide interacting vs non_interacting vs unknown."""
+
+    assert classify_interaction_status({"robot_ped_within_5m_frac": 0.4}) == "interacting"
+    assert classify_interaction_status({"min_clearance_m": 1.2}) == "interacting"
+    # No near-field contact: robot never within 5 m and min clearance far outside the band.
+    assert (
+        classify_interaction_status({"robot_ped_within_5m_frac": 0.0, "min_clearance_m": 20.0})
+        == "non_interacting"
+    )
+    # No proximity metric at all (e.g. an empty / not_evaluable cell).
+    assert classify_interaction_status({"collision_rate": 0.0}) == "unknown"
+    assert classify_interaction_status({}) == "unknown"
+
+
+def test_non_interacting_stable_transfer_is_flagged_not_model_robust(tmp_path: Path) -> None:
+    """A stable_pass built from non_interacting cells must not read as model robustness."""
+
+    config_path, gate_path, config, gates = _write_config_pair(tmp_path)
+    # The "stable" arm passes the gates but never enters the 5 m pedestrian band (mirroring the
+    # committed 2026-07 packet: robot_ped_within_5m_frac=0, min_clearance ~20 m); the "fragile"
+    # arm here does enter the near field. Both use the 4-arm fixture config keys.
+    records = [
+        _record(
+            "stable",
+            SOCIAL_FORCE_DEFAULT,
+            collision_rate=0.0,
+            within_5m_frac=0.0,
+            min_clearance_m=20.0,
+        ),
+        _record(
+            "stable",
+            HSFM_TOTAL_FORCE_V1,
+            collision_rate=0.0,
+            within_5m_frac=0.0,
+            min_clearance_m=20.0,
+        ),
+        _record(
+            "fragile",
+            SOCIAL_FORCE_DEFAULT,
+            collision_rate=0.0,
+            within_5m_frac=0.3,
+            min_clearance_m=1.5,
+        ),
+        _record(
+            "fragile",
+            HSFM_TOTAL_FORCE_V1,
+            collision_rate=0.0,
+            within_5m_frac=0.3,
+            min_clearance_m=1.5,
+        ),
+    ]
+
+    report = build_certification_transfer_report(
+        records,
+        probe_config=config,
+        gate_spec=gates,
+        config_path=config_path,
+        gate_spec_path=gate_path,
+    )
+
+    stable_rows = [
+        r for r in report["certification_transfer_matrix"] if r["planner_key"] == "stable"
+    ]
+    assert stable_rows
+    assert all(r["transfer_status"] == "stable_pass" for r in stable_rows)
+    # The stable status is vacuous: no cell entered the near field, so it is not exercised.
+    assert all(r["interaction_status"] == "non_interacting" for r in stable_rows)
+    assert all(r["interaction_exercised"] is False for r in stable_rows)
+
+    contact_rows = [
+        r for r in report["certification_transfer_matrix"] if r["planner_key"] == "fragile"
+    ]
+    assert all(r["interaction_status"] == "interacting" for r in contact_rows)
+    assert all(r["interaction_exercised"] is True for r in contact_rows)
+
+    # Model sensitivity is exercised overall because the fragile arm entered the near field.
+    assert report["model_sensitivity_exercised"] is True
+    assert report["interaction_status_counts"].get("non_interacting", 0) >= 1
+
+
+def test_all_non_interacting_report_marks_sensitivity_unexercised(tmp_path: Path) -> None:
+    """When every cell stays outside the near field, model sensitivity is not exercised."""
+
+    config_path, gate_path, config, gates = _write_config_pair(tmp_path)
+    records = [
+        _record(arm, model, collision_rate=0.0, within_5m_frac=0.0, min_clearance_m=18.0)
+        for arm in ("stable", "fragile", "conservative", "blocked")
+        for model in (SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1)
+    ]
+
+    report = build_certification_transfer_report(
+        records,
+        probe_config=config,
+        gate_spec=gates,
+        config_path=config_path,
+        gate_spec_path=gate_path,
+    )
+
+    assert report["model_sensitivity_exercised"] is False
+    assert set(report["interaction_status_counts"]) <= {"non_interacting"}
+
+
 def _write_config_pair(tmp_path: Path) -> tuple[Path, Path, dict[str, object], dict[str, object]]:
     scenario_path = tmp_path / "scenario.yaml"
     scenario_path.write_text("scenarios: []\n", encoding="utf-8")
@@ -210,10 +314,16 @@ def _record(
     *,
     collision_rate: float = 0.0,
     include_required: bool = True,
+    within_5m_frac: float | None = None,
+    min_clearance_m: float | None = None,
 ) -> dict[str, object]:
-    metrics = {"collision_rate": collision_rate}
+    metrics: dict[str, float] = {"collision_rate": collision_rate}
     if include_required:
         metrics["near_miss_rate"] = 0.0
+    if within_5m_frac is not None:
+        metrics["robot_ped_within_5m_frac"] = within_5m_frac
+    if min_clearance_m is not None:
+        metrics["min_clearance_m"] = min_clearance_m
     return {
         "planner_key": planner_key,
         "scenario_family": "fixture_family",


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Adds an *interaction-validity guard* to the issue #4207 certification-transfer probe (`robot_sf/benchmark/certification_transfer.py`), plus a post-hoc annotator, tests, and the guard's verdict on the committed 2026-07 evidence packet.

**Why now:** The probe (merged in #4221) compares release-gate pass/fail under `social_force_default` vs `hsfm_total_force_v1`. Those pedestrian models diverge **only when the robot enters the pedestrian near field**. The committed 2026-07 packet reports "0 flips, all stable" — but every cell has `robot_ped_within_5m_frac == 0` and `min_clearance_m ≈ 20 m`, and every SFM↔HSFM metric delta is exactly `0`. The robot never interacts with pedestrians, so that stable result is **vacuous**: it cannot demonstrate certification robustness, yet without a guard it reads as if it does. This is a validity-boundary concern — exactly the issue's RQ2 framing.

**Claim boundary:** Diagnostic-only. No deployment, real-world-safety, benchmark-strength, or paper/dissertation claim. `not_evaluable` and `non_interacting` are never treated as `pass`.

**Required validation (run, shared venv):**
- `pytest tests/benchmark/test_certification_transfer_issue_4207.py tests/benchmark/test_release_gates.py tests/benchmark/test_ped_model_sensitivity.py -q` → **26 passed**
- `ruff check robot_sf/benchmark scripts/benchmark tests/benchmark` → **All checks passed**
- `scripts/tools/sync_ai_config.py --check` → **7 symlinks validated** (no drift)
- Annotator on committed packet → all **8 cells `non_interacting`**, `model_sensitivity_exercised = false`.

**Remaining blocker:** The empirical certification-transfer question is still open — the current run never exercised the pedestrian model. The residual action (out of scope here) is an *interacting* scenario family (or geometry/spawn fix) where the robot enters the 5 m band, then re-run the CPU probe so `model_sensitivity_exercised = true`.

## Contract delta

- **New schema fields (additive, `certification-transfer-report.v1`):**
  - Gate cells + `certification_gate_cells.csv`: `interaction_status` ∈ {`interacting`, `non_interacting`, `unknown`}.
  - Transfer matrix + `certification_transfer_matrix.csv`/`flip_cases.csv`: `interaction_status`, `interaction_exercised` (bool).
  - Report + `metadata.json`: `interaction_status_counts`, `model_sensitivity_exercised`.
- **New public API:** `classify_interaction_status(metrics)`, `INTERACTION_NEAR_FIELD_M = 5.0` (mirrors the `robot_ped_within_5m_frac` gate metric).
- **No new fail-closed blocker on execution.** The guard annotates, it does not gate runs. `non_interacting`/`unknown` are reported, not raised.
- **Compatibility:** CSV column additions are additive; the historical committed packet's original writer artifacts and `SHA256SUMS` are unchanged. The new `interaction_validity.{md,csv}` are supplementary (self-describing, carry the source `summary.json` sha256).

## Scope

- **In scope:** interaction-validity capability in the probe module + a re-usable post-hoc annotator, used once on the committed packet.
- **Out of scope (explicit):** no full benchmark campaign run, no Slurm/GPU submission, no retraining, no new simulation, no deployment/safety certification claim, no paper/dissertation claim edit.

## Issue

Refs #4207 (progression slice; the empirical interacting re-run remains — issue stays open). Issue: https://github.com/ll7/robot_sf_ll7/issues/4207

<details>
<summary>Governance / propagation</summary>

- **Fragmentation guard:** only #4221 merged for #4207 in the last 24h (< 2), and this is a *progression slice* adding a nameable new capability (interaction-validity guard), so it proceeds at full throttle.
- **State propagation (6e):** issue commenting is not authorized for this lane (`comment_issue_or_pr: false`), so no status comment is posted; this PR body is the single canonical surface. No transient queue-routing state is written to tracked files (6d).
- **Latest-comment check (6b):** re-checked #4207 immediately before opening — newest comment is the 2026-07-03T04:22:37Z implementation plan; no newer maintainer guidance to incorporate.
- **Downstream Propagation:** parent issue #4207 (this PR); evidence packet `docs/context/evidence/issue_4207_certification_transfer_probe_2026-07/` updated with the guard verdict; no claim map / leaderboard / registry change (diagnostic-only).
- **Research Result Guidance:** target = validity boundary of the certification-transfer decision; comparator = SFM vs HSFM gate decision; evidence tier = diagnostic-only; result classification = **negative/validity** (current run does not exercise model sensitivity); decision rule = require `model_sensitivity_exercised = true` before reading transfer stability as robustness; synthesis surface = issue #4207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>