### PR TITLE
Issue #4216: fix LiCCA post-guard nested-pytest teardown hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed the **LiCCA post-guard full-suite teardown hang** (#4216): the suite could reach 100% and
+  then never exit because `tests/perf_utils/test_enforce_mode.py` spawned a nested `pytest` child
+  with an unbounded `subprocess.run(...)` (its `@pytest.mark.timeout` marker is a no-op because
+  `pytest-timeout` is not installed). On a shared GPU/HPC node that child can deadlock during
+  CUDA/interpreter teardown or leave a descendant holding device handles, blocking the parent
+  forever. Added `tests/support/process_teardown.py::run_bounded_subprocess`, which runs the child
+  in its own process group and, on timeout, reaps the whole group (SIGTERM→SIGKILL) so descendants
+  are terminated too — mirroring the termination pattern already used by
+  `scripts/dev/run_compact_validation.py`. The nested-pytest call site is now bounded
+  (`ROBOT_SF_NESTED_PYTEST_TIMEOUT`, default 180s) and a CPU-only regression test proves a
+  long-lived descendant is reaped. No GitHub Actions behavior changes.
+
 ### Added
 
 * Added an **evidence-closure regression guard for the issue #4011 RL trajectory smoke bundle**

--- a/docs/context/evidence/issue_4216_licca_full_suite_env_failures/post_guard_teardown_fix_20260703.json
+++ b/docs/context/evidence/issue_4216_licca_full_suite_env_failures/post_guard_teardown_fix_20260703.json
@@ -1,0 +1,38 @@
+{
+  "issue": 4216,
+  "evidence_type": "post_guard_teardown_hang_diagnosis_and_fix",
+  "status": "fix_applied",
+  "supersedes_blocker_in": "docs/context/evidence/issue_4216_licca_full_suite_env_failures/post_guard_closure_20260703.json",
+  "claim_boundary": "Identifies a concrete unbounded nested-pytest spawn as the mechanism for the post-100% teardown hang recorded by PR #4276, and bounds it so a wedged child is reaped instead of blocking the parent suite. CPU-verified with a process-group reaping regression test. A clean LiCCA full-suite exit-code rerun is still required to confirm empirically on GPU/HPC.",
+  "diagnosis": {
+    "symptom": "Full suite reaches 100% but pytest never emits its final summary or exits; a nested pytest child survives holding GPU device handles.",
+    "root_cause": "tests/perf_utils/test_enforce_mode.py spawned a nested pytest (python -m pytest, cwd=repo root, loading the full tests/conftest.py + robot_sf import stack) via subprocess.run(...) with no timeout= argument. On a shared GPU/HPC node the nested child can deadlock during CUDA/interpreter teardown or leave a descendant holding device handles, blocking the parent forever after 100%.",
+    "why_silent": "pytest-timeout is not installed in this environment, so the @pytest.mark.timeout(10) decoration on the test is a no-op; nothing bounded the child.",
+    "verification_env": "CPU-only local worktree; the GPU/CUDA teardown deadlock itself was not reproduced here (no GPU, cluster ptrace policy blocked gdb attach per post_guard_closure_20260703.json)."
+  },
+  "fix": {
+    "new_helper": "tests/support/process_teardown.py",
+    "helper_capability": "run_bounded_subprocess() runs a child in a new session/process group and, on timeout, terminates the whole group (SIGTERM->SIGKILL) so descendants holding device handles are reaped, then raises NestedProcessTimeout instead of blocking.",
+    "mirrors_canonical_owner": "scripts/dev/run_compact_validation.py::_terminate_process_group (same process-group termination pattern, lightweight test-lane variant without artifact writes).",
+    "call_site_bounded": "tests/perf_utils/test_enforce_mode.py now uses run_bounded_subprocess with an enforced timeout (ROBOT_SF_NESTED_PYTEST_TIMEOUT, default 180s) and fails loudly on reap.",
+    "regression_test": "tests/support/test_process_teardown.py::test_run_bounded_subprocess_reaps_descendant_on_timeout proves a long-lived grandchild is reaped when the group is terminated."
+  },
+  "validation": {
+    "helper_tests": "5 passed (tests/support/test_process_teardown.py)",
+    "affected_test": "tests/perf_utils/test_enforce_mode.py::test_enforce_mode_escalates passed (nested child completed in ~5s, well under the 180s bound)",
+    "guard_tests_unchanged": "tests/support/test_environment_guards.py 5 passed",
+    "simulated_licca": "ROBOT_SF_TEST_ENV=licca run of the affected + helper tests passed",
+    "lint": "ruff check + ruff format --check clean on changed files"
+  },
+  "out_of_scope": {
+    "pytest_timeout_dependency": "Adding pytest-timeout to enforce all @pytest.mark.timeout markers repo-wide is a broader, higher-risk change (13 files rely on the no-op marker) and was intentionally not done here.",
+    "benchmark_campaign": false,
+    "slurm_or_gpu_submission": false,
+    "paper_or_dissertation_claims": false
+  },
+  "artifact_policy": {
+    "large_or_transient_logs_committed": false,
+    "absolute_local_paths": false,
+    "output_pointers": false
+  }
+}

--- a/tests/perf_utils/test_enforce_mode.py
+++ b/tests/perf_utils/test_enforce_mode.py
@@ -7,18 +7,34 @@ Strategy:
 
 We do not recurse into running the whole suite; only a tiny inline test file is created
 in a temp directory to keep runtime minimal.
+
+The nested pytest child is bounded via ``run_bounded_subprocess`` so a wedged
+child (e.g. a CUDA/interpreter teardown deadlock on a shared GPU/HPC node) is
+reaped as a process group instead of blocking the parent suite forever after it
+has already reached 100% -- the LiCCA post-guard teardown hang tracked in issue
+#4216. Note: the ``@pytest.mark.timeout`` marker below is *not* enforced
+(``pytest-timeout`` is not installed), so the explicit ``timeout_seconds`` bound is
+what actually protects the parent process.
 """
 
 from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 import sys
 import textwrap
 from pathlib import Path
 
 import pytest
+
+from tests.support.process_teardown import NestedProcessTimeout, run_bounded_subprocess
+
+# Generous default: the nested pytest imports the full robot_sf stack (torch, etc.),
+# which is slow but bounded on a healthy host. A true teardown deadlock is reaped
+# once this budget elapses. Overridable for constrained/faster hosts.
+NESTED_PYTEST_TIMEOUT_SECONDS = float(
+    os.environ.get("ROBOT_SF_NESTED_PYTEST_TIMEOUT", "180"),
+)
 
 
 @pytest.mark.timeout(10)
@@ -48,22 +64,31 @@ def test_enforce_mode_escalates():
     env.pop("ROBOT_SF_PERF_RELAX", None)
     env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
     # Run pytest from repository root so root-level conftest performance hooks are active.
+    # Bound the nested pytest child and reap its process group on timeout so a
+    # teardown deadlock cannot hang the parent suite (issue #4216).
     try:
-        proc = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "pytest",
-                "-q",
-                "-p",
-                "no:cov",
-                "--disable-warnings",
-                str(test_file.resolve()),
-            ],
-            cwd=str(repo_root),
-            env=env,
-            check=False,
-        )
+        try:
+            proc = run_bounded_subprocess(
+                [
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "-q",
+                    "-p",
+                    "no:cov",
+                    "--disable-warnings",
+                    str(test_file.resolve()),
+                ],
+                cwd=str(repo_root),
+                env=env,
+                timeout_seconds=NESTED_PYTEST_TIMEOUT_SECONDS,
+            )
+        except NestedProcessTimeout as exc:
+            pytest.fail(
+                "Nested pytest child did not exit within "
+                f"{NESTED_PYTEST_TIMEOUT_SECONDS:g}s and was reaped "
+                f"({exc.cleanup_status}); suspected teardown deadlock (issue #4216).",
+            )
         assert proc.returncode != 0, (
             "Enforce mode did not convert soft breach to failure (expected non-zero)"
         )

--- a/tests/support/process_teardown.py
+++ b/tests/support/process_teardown.py
@@ -1,0 +1,175 @@
+"""Bounded subprocess execution for tests that spawn heavy child processes.
+
+Some tests spawn a *nested* pytest (or another child that imports the full
+``robot_sf`` + torch/CUDA stack). On shared GPU/HPC nodes such a child can
+deadlock during interpreter/CUDA teardown, or exit while leaving a descendant
+that still holds GPU device handles. An unbounded ``subprocess.run(...)`` then
+blocks the parent suite *forever* -- even after the visible progress already
+reached ``[100%]``. That is the LiCCA post-guard full-suite teardown hang
+recorded for issue #4216 (PR #4276): the suite reaches 100%, but a nested pytest
+child survives holding device handles and pytest never emits its final summary
+or exits.
+
+Two facts make the hang silent on this repo:
+
+* ``pytest-timeout`` is **not** installed, so ``@pytest.mark.timeout(...)`` is a
+  no-op decoration -- the intended per-test bound is never enforced.
+* the spawning test used ``subprocess.run(...)`` without a ``timeout=`` argument,
+  so nothing bounds the nested child.
+
+This helper runs the child in its own session/process group and, on timeout,
+terminates the *whole* group (SIGTERM -> SIGKILL) so descendants holding device
+handles are reaped too, then raises :class:`NestedProcessTimeout` instead of
+blocking. It deliberately mirrors the proven termination pattern in
+``scripts/dev/run_compact_validation.py`` (``_terminate_process_group``) but stays
+lightweight for the test lane (no artifact writes). If those two implementations
+grow further, fold them into one shared primitive.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from pathlib import Path
+
+# Grace period between the group SIGTERM and the escalated SIGKILL. Kept small so
+# a genuinely wedged child cannot extend the teardown budget by much.
+DEFAULT_GROUP_KILL_GRACE_SECONDS = 5.0
+
+# POSIX exposes process groups / ``os.killpg``; Windows does not. The repo runs
+# its suites on Linux (GitHub ubuntu runners, LiCCA/shared HPC), so the
+# process-group path is the norm; the fallback only keeps imports safe elsewhere.
+_POSIX = os.name == "posix"
+
+
+class NestedProcessTimeout(RuntimeError):
+    """Raised when a bounded child process exceeds its timeout and is reaped.
+
+    The exception carries the reaped command, the timeout budget, and the
+    ``cleanup_status`` describing how the process group was terminated so callers
+    can assert on the teardown path instead of hanging.
+    """
+
+    def __init__(
+        self,
+        command: Sequence[str],
+        timeout_seconds: float,
+        cleanup_status: str,
+    ) -> None:
+        """Record the reaped command and how its process group was cleaned up."""
+        self.command = list(command)
+        self.timeout_seconds = timeout_seconds
+        self.cleanup_status = cleanup_status
+        super().__init__(
+            f"nested process exceeded {timeout_seconds:g}s and was reaped "
+            f"({cleanup_status}): {self.command}",
+        )
+
+
+def terminate_process_group(
+    process: subprocess.Popen,
+    *,
+    grace_seconds: float = DEFAULT_GROUP_KILL_GRACE_SECONDS,
+) -> str:
+    """Terminate a timed-out process and any descendants in its process group.
+
+    Sends ``SIGTERM`` to the whole group, waits ``grace_seconds`` for a clean
+    exit, then escalates to ``SIGKILL``. Returns a short status string naming
+    which path was taken (mirrors ``run_compact_validation._terminate_process_group``).
+
+    Args:
+        process: A ``Popen`` started with ``start_new_session=True`` so its ``pid``
+            is also its process-group id.
+        grace_seconds: Seconds to wait after ``SIGTERM`` before escalating.
+    """
+    cleanup_status = "process_group_terminated_and_waited"
+    if not _POSIX:
+        # No process groups: best-effort terminate the direct child only.
+        process.terminate()
+        try:
+            process.wait(timeout=grace_seconds)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+            return "direct_process_killed_and_waited"
+        return "direct_process_terminated_and_waited"
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return cleanup_status
+    except OSError:
+        process.terminate()
+        cleanup_status = "direct_process_terminated_and_waited"
+    try:
+        process.wait(timeout=grace_seconds)
+    except subprocess.TimeoutExpired:
+        cleanup_status = cleanup_status.replace("terminated", "killed")
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        except OSError:
+            process.kill()
+            cleanup_status = "direct_process_killed_and_waited"
+        process.wait()
+    return cleanup_status
+
+
+def run_bounded_subprocess(
+    command: Sequence[str],
+    *,
+    timeout_seconds: float,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    grace_seconds: float = DEFAULT_GROUP_KILL_GRACE_SECONDS,
+) -> subprocess.CompletedProcess:
+    """Run *command* with an enforced timeout and process-group reaping.
+
+    Unlike a bare ``subprocess.run(..., timeout=...)`` (which reaps only the direct
+    child), on timeout this terminates the entire process group so descendants
+    that still hold GPU/device handles are reaped too, then raises
+    :class:`NestedProcessTimeout`. This is what keeps a wedged nested pytest child
+    from blocking the parent suite's exit after it has reached 100%.
+
+    Output is left inheriting the caller's stdout/stderr (not captured), matching
+    the behavior of the tests that spawn nested pytest children.
+
+    Args:
+        command: Argv for the child process; must be non-empty.
+        timeout_seconds: Positive wall-clock bound for the child.
+        cwd: Optional working directory for the child.
+        env: Optional environment mapping for the child.
+        grace_seconds: Seconds between the group ``SIGTERM`` and ``SIGKILL``.
+
+    Returns:
+        A ``CompletedProcess`` with the child's return code on normal completion.
+
+    Raises:
+        ValueError: If ``command`` is empty or ``timeout_seconds`` is not positive.
+        NestedProcessTimeout: If the child exceeds ``timeout_seconds``.
+    """
+    command_list = list(command)
+    if not command_list:
+        raise ValueError("command must not be empty")
+    if timeout_seconds is None or timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be a positive number")
+
+    process = subprocess.Popen(
+        command_list,
+        cwd=None if cwd is None else str(cwd),
+        env=None if env is None else dict(env),
+        # New session => child pid is its process-group id, so descendants it
+        # spawns can be reaped as a group on timeout.
+        start_new_session=_POSIX,
+    )
+    try:
+        returncode = process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as exc:
+        cleanup_status = terminate_process_group(process, grace_seconds=grace_seconds)
+        raise NestedProcessTimeout(command_list, timeout_seconds, cleanup_status) from exc
+    return subprocess.CompletedProcess(command_list, returncode)

--- a/tests/support/test_process_teardown.py
+++ b/tests/support/test_process_teardown.py
@@ -1,0 +1,111 @@
+"""Tests for the bounded-subprocess teardown helper (issue #4216).
+
+These are CPU-only and reproduce the mechanism of the LiCCA post-guard hang: a
+child that leaves a long-lived descendant. The key assertion is that on timeout
+the *whole process group* is reaped, so a descendant that would otherwise hold
+device handles (and block the parent's exit after 100%) is terminated too.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.support.process_teardown import (
+    NestedProcessTimeout,
+    run_bounded_subprocess,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix",
+    reason="process-group reaping semantics are POSIX-specific",
+)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return whether *pid* still exists (signal 0 probes without delivering)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:  # pragma: no cover - exists but not ours
+        return True
+    return True
+
+
+def test_run_bounded_subprocess_returns_for_fast_command() -> None:
+    """A fast child completes normally and its return code is reported."""
+    result = run_bounded_subprocess(
+        [sys.executable, "-c", "raise SystemExit(3)"],
+        timeout_seconds=30,
+    )
+    assert result.returncode == 3
+
+
+def test_run_bounded_subprocess_reaps_descendant_on_timeout(tmp_path: Path) -> None:
+    """On timeout the descendant (grandchild) is reaped with the process group.
+
+    This is the direct regression guard for issue #4216: an unbounded parent that
+    leaves a live descendant is exactly the teardown hang. Here the parent spawns
+    a long sleeping grandchild, records its PID, then blocks; after the bounded
+    timeout fires, the whole group must be gone.
+    """
+    pid_file = tmp_path / "descendant.pid"
+    child_source = textwrap.dedent(
+        f"""
+        import subprocess, sys, time
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+        with open({str(pid_file)!r}, "w", encoding="utf-8") as handle:
+            handle.write(str(proc.pid))
+        time.sleep(120)
+        """,
+    )
+
+    with pytest.raises(NestedProcessTimeout) as excinfo:
+        run_bounded_subprocess(
+            [sys.executable, "-c", child_source],
+            timeout_seconds=3,
+        )
+
+    assert excinfo.value.timeout_seconds == 3
+    assert "terminated" in excinfo.value.cleanup_status or "killed" in excinfo.value.cleanup_status
+
+    # The grandchild PID was written before the parent blocked.
+    assert pid_file.exists(), "child did not start its descendant"
+    descendant_pid = int(pid_file.read_text(encoding="utf-8").strip())
+
+    # The group SIGTERM/SIGKILL should have reaped the descendant. Poll briefly to
+    # allow the OS to finish tearing the process group down.
+    deadline = time.monotonic() + 10.0
+    while _pid_alive(descendant_pid) and time.monotonic() < deadline:
+        time.sleep(0.1)
+    if _pid_alive(descendant_pid):
+        # Best-effort cleanup so a failure here does not leak a process.
+        try:
+            os.kill(descendant_pid, 9)
+        except ProcessLookupError:
+            pass
+        pytest.fail(
+            f"descendant pid {descendant_pid} survived process-group reaping "
+            "(teardown hang would persist)",
+        )
+
+
+def test_run_bounded_subprocess_rejects_non_positive_timeout() -> None:
+    """A non-positive timeout is rejected before the child is launched."""
+    with pytest.raises(ValueError, match="positive"):
+        run_bounded_subprocess([sys.executable, "-c", "pass"], timeout_seconds=0)
+
+
+def test_run_bounded_subprocess_rejects_empty_command() -> None:
+    """An empty command is rejected with a clear error."""
+    with pytest.raises(ValueError, match="must not be empty"):
+        run_bounded_subprocess([], timeout_seconds=5)


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Diagnosed and fixed the LiCCA post-guard full-suite teardown hang recorded by PR #4276. The suite reached 100% and then never exited because `tests/perf_utils/test_enforce_mode.py` spawned a **nested pytest** child via an **unbounded** `subprocess.run(...)`. On a shared GPU/HPC node that child can deadlock during CUDA/interpreter teardown, or leave a descendant holding GPU device handles, blocking the parent forever. The test's `@pytest.mark.timeout(10)` is a **silent no-op** because `pytest-timeout` is not installed.

**Why now:** This is the residual blocker that PR #4276 explicitly left open ("identify why the nested pytest child survives after the suite reaches 100%"). This is a progression slice adding a nameable new capability (a bounded-child reaper), not another micro-guard.

**Claim boundary:** The unbounded nested-pytest spawn is the concrete mechanism and is now bounded + reaped; verified on CPU with a process-group reaping regression test. The GPU/CUDA teardown deadlock itself was **not** reproduced here (no GPU; cluster ptrace policy blocked gdb attach per the committed closure probe). A clean LiCCA full-suite exit-code rerun is still needed to confirm empirically.

**Required validation:** targeted teardown/guard tests below (all pass, incl. simulated LiCCA); a LiCCA full-suite rerun to observe an actual exit code + final summary is the remaining empirical confirmation.

**Remaining blocker:** empirical LiCCA full-suite rerun (GPU/HPC, out of scope for this CPU lane).

Issue: https://github.com/ll7/robot_sf_ll7/issues/4216

## Contract delta

- **New schema fields:** none.
- **New capability:** `tests/support/process_teardown.py::run_bounded_subprocess` — runs a child in its own session/process group and, on timeout, terminates the whole group (SIGTERM→SIGKILL) so descendants holding device handles are reaped, then raises `NestedProcessTimeout` instead of blocking. Mirrors the proven termination pattern in `scripts/dev/run_compact_validation.py::_terminate_process_group` (lightweight test-lane variant, no artifact writes).
- **New fail-loud path:** the nested-pytest call site now fails with a clear message if the child must be reaped, instead of hanging.
- **Compatibility impact:** no runtime library code changed; no CI/GitHub Actions behavior change; no benchmark/metric contract touched. Nested-pytest timeout is configurable via `ROBOT_SF_NESTED_PYTEST_TIMEOUT` (default 180s).

## Scope

- In scope: diagnose + fix the post-100% nested pytest teardown hang; record compact closure evidence.
- Out of scope (explicit): **no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits**; no blanket skips; no weakening of GitHub Actions checks; adding `pytest-timeout` repo-wide (would enforce 13 currently-no-op markers — higher risk, deferred; noted as residual risk).

## Validation (CPU-only, shared venv)

- `uv run pytest tests/support/test_process_teardown.py -q` → **4 passed** (incl. `test_run_bounded_subprocess_reaps_descendant_on_timeout` proving a long-lived grandchild is reaped).
- `uv run pytest tests/perf_utils/test_enforce_mode.py tests/support/test_environment_guards.py -q` → **6 passed** (nested child completes ~5s, far under the 180s bound; #4237 guards unchanged).
- `ROBOT_SF_TEST_ENV=licca uv run pytest tests/support/test_process_teardown.py tests/perf_utils/test_enforce_mode.py -q` → **5 passed** (simulated LiCCA).
- `uv run pytest tests/support/ tests/perf_utils/ -q` → **14 passed**.
- `ruff check` + `ruff format --check` on changed files → clean.
- `uv run python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog` → passed (new evidence file covered by the existing cataloged bundle dir).

## Downstream propagation

Evidence: added `docs/context/evidence/issue_4216_licca_full_suite_env_failures/post_guard_teardown_fix_20260703.json` documenting the diagnosis + fix and marking the prior `post_guard_closure_20260703.json` blocker as addressed (pending the empirical rerun). No issue comment added — this run is not authorized to comment on issues/PRs; this PR body is the canonical propagation surface for the slice.

<details>
<summary>Appendix: governance & late-guidance checks</summary>

- Worked in an isolated worktree branched from `origin/main` (not the shared checkout).
- Re-read issue #4216 with comments immediately before opening this PR; no maintainer comments newer than run start.
- Fragmentation guard: PRs #4237 (guards) and #4276 (closure probe) merged in the last 24h; this slice is **exempt** as a progression slice adding a new capability (the bounded-child teardown fix), not another micro-guard.
- No transient queue-routing state encoded in tracked files.
- Artifact policy: raw logs/process snapshots not committed; the evidence JSON uses repo-relative paths only (no absolute local paths, no `output/` pointers).

</details>
