### PR TITLE
Issue #4317: resolve bare docs-evidence checksum entries against the packet dir

### DIFF
--- a/scripts/dev/check_docs_evidence_integrity.py
+++ b/scripts/dev/check_docs_evidence_integrity.py
@@ -286,6 +286,22 @@ def _checksum_manifest_paths(path: Path, *, root: Path) -> list[Path]:
     return [parent / name for name in sorted(_CHECKSUM_FILENAMES) if (parent / name).is_file()]
 
 
+def _resolve_checksum_target(candidate: Path, *, manifest: Path, root: Path) -> Path:
+    """Resolve a manifest checksum entry to the file it should verify.
+
+    Prefer the file adjacent to the manifest (standard ``sha256sum -c`` semantics
+    run from the packet directory), so a bare entry such as ``README.md`` verifies
+    the packet's own file rather than a repo-root file with the same name (issue
+    #4317). Fall back to the repo-root-relative resolution only when no
+    manifest-local file exists, which preserves manifests written with
+    repo-root-relative paths (for example ``docs/context/evidence/.../summary.json``).
+    """
+    manifest_candidate = manifest.parent / candidate
+    if manifest_candidate.exists():
+        return manifest_candidate
+    return root / candidate
+
+
 def _parse_checksum_line(line: str, *, manifest: Path, root: Path) -> tuple[str, Path] | None:
     """Parse a sha256sum-style manifest line."""
     stripped = line.strip()
@@ -300,10 +316,8 @@ def _parse_checksum_line(line: str, *, manifest: Path, root: Path) -> tuple[str,
     if candidate.is_absolute() or ".." in candidate.parts:
         return None
 
-    root_candidate = root / candidate
-    if root_candidate.exists():
-        return match.group("hash").lower(), root_candidate
-    return match.group("hash").lower(), manifest.parent / candidate
+    target = _resolve_checksum_target(candidate, manifest=manifest, root=root)
+    return match.group("hash").lower(), target
 
 
 def _sha256(path: Path) -> str:

--- a/tests/dev/test_check_docs_evidence_integrity.py
+++ b/tests/dev/test_check_docs_evidence_integrity.py
@@ -164,6 +164,85 @@ def test_changed_checksum_manifest_validates_targets(tmp_path: Path) -> None:
     assert problems == []
 
 
+def test_bare_name_manifest_verifies_packet_local_file(tmp_path: Path) -> None:
+    """A bare SHA256SUMS entry must verify the packet's own file, not a repo-root twin.
+
+    Regression for issue #4317: packets generated with ``sha256sum *`` list bare
+    filenames (for example ``README.md``). A repo-root file with the same name must
+    not shadow the packet-local file during verification.
+    """
+    (tmp_path / "README.md").write_text("# repo root readme\n", encoding="utf-8")
+
+    bundle = tmp_path / "docs/context/evidence/issue_999_collision"
+    bundle.mkdir(parents=True)
+    readme = bundle / "README.md"
+    readme.write_text("# packet readme\n", encoding="utf-8")
+    manifest = bundle / "SHA256SUMS"
+    manifest.write_text(f"{_sha256(readme)}  README.md\n", encoding="utf-8")
+    _write_catalog(
+        tmp_path,
+        [
+            readme.relative_to(tmp_path).as_posix(),
+            manifest.relative_to(tmp_path).as_posix(),
+        ],
+    )
+
+    problems = check_files([manifest.relative_to(tmp_path).as_posix()], root=tmp_path)
+
+    assert problems == []
+
+
+def test_bare_name_mismatch_names_packet_local_target(tmp_path: Path) -> None:
+    """A wrong bare-name hash must fail against the packet-local file, not repo root."""
+    (tmp_path / "README.md").write_text("# repo root readme\n", encoding="utf-8")
+
+    bundle = tmp_path / "docs/context/evidence/issue_999_collision_bad"
+    bundle.mkdir(parents=True)
+    readme = bundle / "README.md"
+    readme.write_text("# packet readme\n", encoding="utf-8")
+    manifest = bundle / "SHA256SUMS"
+    manifest.write_text(f"{'0' * 64}  README.md\n", encoding="utf-8")
+    _write_catalog(
+        tmp_path,
+        [
+            readme.relative_to(tmp_path).as_posix(),
+            manifest.relative_to(tmp_path).as_posix(),
+        ],
+    )
+
+    problems = check_files([manifest.relative_to(tmp_path).as_posix()], root=tmp_path)
+
+    assert any("checksum mismatch" in problem for problem in problems)
+    # The mismatch must name the packet-local README, not the repo-root twin.
+    assert any(str(readme) in problem for problem in problems)
+    assert not any(
+        problem.endswith(f"checksum mismatch for {tmp_path / 'README.md'}") for problem in problems
+    )
+
+
+def test_changed_bare_name_packet_file_is_validated(tmp_path: Path) -> None:
+    """Changing a packet-local file finds its adjacent bare-name manifest entry (issue #4317)."""
+    (tmp_path / "README.md").write_text("# repo root readme\n", encoding="utf-8")
+
+    bundle = tmp_path / "docs/context/evidence/issue_999_changed_bare"
+    bundle.mkdir(parents=True)
+    readme = bundle / "README.md"
+    readme.write_text("# packet readme\n", encoding="utf-8")
+    manifest = bundle / "SHA256SUMS"
+    manifest.write_text(f"{_sha256(readme)}  README.md\n", encoding="utf-8")
+    _write_catalog(
+        tmp_path,
+        [
+            readme.relative_to(tmp_path).as_posix(),
+            manifest.relative_to(tmp_path).as_posix(),
+        ],
+    )
+
+    problems = check_files([readme.relative_to(tmp_path).as_posix()], root=tmp_path)
+
+    assert problems == []
+
+
 def test_catalog_change_validates_registered_paths(tmp_path: Path) -> None:
     """Changing catalog.yaml validates that registered paths exist."""
     _write_catalog(tmp_path, ["docs/context/evidence/issue_999_missing/summary.json"])


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** `scripts/dev/check_docs_evidence_integrity.py` now resolves a `SHA256SUMS` entry against the manifest's own directory first (`manifest.parent / candidate`), falling back to repo-root (`root / candidate`) only when no manifest-local file exists.
- **Why now:** Fresh gate bug from PR #4315. Evidence packets generated with `sha256sum *` list bare filenames; a bare `README.md` was verified against the **repo-root** `README.md` instead of the packet's own file, silently failing `docs-evidence-integrity`. PR #4315 worked around it by rewriting its manifest; this removes the footgun.
- **Claim boundary:** Diagnostic-only infra hardening. No benchmark result, evidence interpretation, or paper/dissertation claim changes.
- **Required validation:** `uv run pytest tests/dev/test_check_docs_evidence_integrity.py -q` → 22 passed. Ruff check + format clean.
- **Remaining blocker:** None. Historical grandfathered packets are unchanged (checker only runs on changed files); if such a packet is later touched, it now validates correctly against its own file.

Closes #4317.

## Contract delta

- **New helper:** `_resolve_checksum_target(candidate, *, manifest, root)` — manifest-local-first resolution (standard `sha256sum -c` locality).
- **Behavior change:** bare-name manifest entries now resolve to the packet-local file rather than a repo-root twin. This is strictly the intended verification semantics; it does not weaken any check.
- **Preserved:** repo-root-relative manifests (e.g. `docs/context/evidence/.../summary.json`) still resolve from root because their manifest-local path does not exist; absolute paths and `..` remain rejected.
- **Compatibility:** no schema/CLI change; return shape of `_parse_checksum_line` unchanged (`tuple[str, Path] | None`).

## Validation

| Command | Result |
| --- | --- |
| `uv run ruff check scripts/dev/check_docs_evidence_integrity.py tests/dev/test_check_docs_evidence_integrity.py` | All checks passed |
| `uv run ruff format --check` (both files) | formatted |
| `uv run pytest tests/dev/test_check_docs_evidence_integrity.py -q` | 22 passed |
| `uv run python scripts/dev/check_docs_evidence_integrity.py --files <changed files>` | 2 changed file(s) passed |

**Test-first proof:** temporarily reverting the resolver to the old root-first logic makes the two collision regression tests (`test_bare_name_manifest_verifies_packet_local_file`, `test_bare_name_mismatch_names_packet_local_target`) fail; the fix makes them pass.

## Tests added

- `test_bare_name_manifest_verifies_packet_local_file` — repo-root `README.md` + packet-local `README.md`; bare `README.md` entry validates against the packet file.
- `test_bare_name_mismatch_names_packet_local_target` — wrong hash reports a mismatch naming the packet-local target, not the repo-root twin.
- `test_changed_bare_name_packet_file_is_validated` — a changed packet-local file finds its adjacent bare-name manifest entry.
- Repo-root-relative compatibility remains covered by the existing `test_changed_checksum_manifest_validates_targets`.

## Out of scope

- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Historical packets are not rewritten (per issue scope).

<details>
<summary>Governance / process notes</summary>

- Followed maintainer implementation plan (option 1) from the issue comment dated 2026-07-03; no newer comments at PR-open time.
- Downstream Propagation: NA — self-contained checker/test hardening; no claim map, leaderboard, registry, or context index depends on this behavior change.
- Research Result Guidance: NA — support/tooling hardening with no research claim.
- After this PR is open, the PR gate / improvement cycle / merge authority is owned downstream.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
