### PR TITLE
fix(#4358): rebase PR #4331 onto main and retain release-gate evaluability guard

### DIFF
--- a/tests/benchmark/test_release_gates.py
+++ b/tests/benchmark/test_release_gates.py
@@ -507,6 +507,56 @@ def test_shipped_current_roster_spec_loads_with_coverage_gates() -> None:
     assert {gate.category for gate in gates} == {"safety", "comfort"}
 
 
+def test_instrumented_gate_metrics_make_coverage_gaps_evaluable() -> None:
+    """Recording min_clearance_m/proxemic_intrusion_rate flips coverage gaps evaluable (#4166).
+
+    Once a campaign summary row carries the release-gate-aligned metric fields
+    (`min_clearance_m`, `proxemic_intrusion_rate`) — which `_planner_report_row`
+    now emits on `origin/main` after #4326/#4334 — the shipped current-roster
+    coverage-gap gates must evaluate to pass/fail instead of ``not_evaluable``. A
+    row that omits those fields must still fail closed as ``not_evaluable``.
+
+    This is an end-to-end evaluability guard for issue #4166: it exercises
+    ``evaluate_release_gates`` with explicit row values, so it is independent of
+    how the emitter computes ``min_clearance_m`` (mean vs. worst-case) and stays
+    valid against the worst-case implementation retained on main.
+    """
+
+    gates = load_release_gate_spec(_CURRENT_ROSTER_SPEC)
+    rows = [
+        # Instrumented row: both gate-aligned metrics recorded -> gates evaluable.
+        {
+            "planner_key": "instrumented",
+            "scenario_family": "all",
+            "collisions_mean": "0.02",
+            "near_misses_mean": "1.0",
+            "jerk_mean": "0.5",
+            "comfort_exposure_mean": "0.02",
+            "min_clearance_m": "0.40",  # >= 0.25 floor -> pass
+            "proxemic_intrusion_rate": "0.20",  # > 0.10 limit -> fail
+        },
+        # Uninstrumented row: gate metrics absent -> coverage gaps stay not_evaluable.
+        {
+            "planner_key": "legacy",
+            "scenario_family": "all",
+            "collisions_mean": "0.02",
+            "near_misses_mean": "1.0",
+            "jerk_mean": "0.5",
+            "comfort_exposure_mean": "0.02",
+        },
+    ]
+    report = evaluate_release_gates(rows, gates)
+    detail = {row["planner_key"]: row for row in report["results"]}
+
+    instrumented_gates = {gate["gate_id"]: gate for gate in detail["instrumented"]["gate_results"]}
+    assert instrumented_gates["min_clearance_floor_coverage_gap"]["status"] == "pass"
+    assert instrumented_gates["proxemic_intrusion_rate_coverage_gap"]["status"] == "fail"
+
+    legacy_gates = {gate["gate_id"]: gate for gate in detail["legacy"]["gate_results"]}
+    assert legacy_gates["min_clearance_floor_coverage_gap"]["status"] == "not_evaluable"
+    assert legacy_gates["proxemic_intrusion_rate_coverage_gap"]["status"] == "not_evaluable"
+
+
 def test_current_roster_evidence_matches_retained_campaign() -> None:
     """Rebuilding from the retained campaign reproduces the committed evidence packet."""
 


### PR DESCRIPTION
## Reviewer-critical summary

What changed: rebased open PR #4331 onto current `origin/main` for issue #4358 and retained only the main-compatible release-gate evaluability guard in `tests/benchmark/test_release_gates.py`.

Why now: the original emitter implementation was superseded by merged PR #4334, which already owns the correct worst-case `min_clearance_m` reporting semantics on `main`; PR #4331 needed to stop conflicting while preserving the useful coverage-gap evaluability regression test.

Claim boundary: this PR proves that rows containing release-gate-aligned `min_clearance_m` and `proxemic_intrusion_rate` values make the shipped current-roster coverage-gap gates evaluable, while rows missing those fields still fail closed as `not_evaluable`. It does not claim a fresh campaign has populated those fields.

Required validation: focused release-gate tests plus full local PR readiness passed on imech156-u after rebasing.

Remaining blocker: GitHub CI for the force-pushed PR head still needs to complete. Claude Code on imech156-u owns the full PR gate, improvement cycle, and merge authority after this handoff.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: removes the stale conflicting emitter change from this PR’s diff; keeps only an additive test that verifies existing release-gate evaluation behavior against explicit row values.
- State propagation: no separate issue comment was added because this run was not authorized to comment on issues or PRs; this PR body is the durable handoff surface for issue #4358.

## Scope

Issue: https://github.com/ll7/robot_sf_ll7/issues/4358

This is a fix-worker PR-branch slice for open PR #4331:

- rebase the PR branch onto current `origin/main`;
- preserve a narrow regression guard for release-gate coverage-gap evaluability;
- avoid reintroducing the superseded `min_clearance_m` emitter semantics from the pre-#4334 branch.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Validation

- `uv run pytest tests/benchmark/test_release_gates.py -q` -> passed, 13 tests.
- `uv run ruff check tests/benchmark/test_release_gates.py` -> passed.
- `uv run ruff format --check tests/benchmark/test_release_gates.py` -> passed.
- `uv run python scripts/dev/run_compact_validation.py -- bash -lc 'BASE_REF=origin/main scripts/dev/pr_ready_check.sh'` -> passed, exit code 0, 262.229 seconds.

Validation artifacts:

- Summary JSON: `/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/compact-validation/validation-20260704T020513Z-562533.summary.json`
- Full log: `/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/compact-validation/validation-20260704T020513Z-562533.log`

<details>
<summary>Appendix: governance and artifact notes</summary>

- Late issue freshness check: `gh issue view 4358 --repo ll7/robot_sf_ll7 --comments --json number,title,updatedAt,comments,body,url` returned no comments and `updatedAt=2026-07-04T01:54:51Z`; no maintainer guidance newer than this run was present.
- Fragmentation guard: no merged PRs for issue #4358 were found in the last 24 hours with `gh pr list --repo ll7/robot_sf_ll7 --state merged --search "4358 merged:>=2026-07-03"`.
- Durable artifact policy: no generated benchmark outputs, model artifacts, raw datasets, or `output/` contents were added.
- Transient queue-routing state: none encoded in tracked files.

</details>
