### PR TITLE
test(benchmark): predeclare deferred S30 seed schedule (#4304)

### DIFF
--- a/configs/benchmarks/seed_sets_v1.yaml
+++ b/configs/benchmarks/seed_sets_v1.yaml
@@ -58,15 +58,8 @@ paper_eval_s20:
 
 # Issue #1554 paper-facing S30 extension. Extends the S20 set with ten more
 # contiguous seeds while preserving the frozen S3 `eval` seeds (111-113) and the
-# S10/S20 ordering (S10 prefix of S20 prefix of S30). Used by the S20/S30
-# seed-budget launch packet.
-#
-# PREDECLARED ONLY (issue #4304, maintainer ruling 2026-07-03): S30 is DEFERRED
-# for the dissertation draft. S20 (`paper_eval_s20`) is the draft evidence tier;
-# S30 is a reversible future escalation path, run only if a specific
-# paper/dissertation claim needs >=30 seeds or a reviewer requires it. This entry
-# predeclares the schedule so a future run is one Slurm job away with no protocol
-# debt; it does NOT imply any S30 campaign rows, benchmark result, or claim.
+# S10/S20 ordering. Used by the S20/S30 seed-budget launch packet; no S30 campaign
+# rows exist yet, so this set is a launch-only reference until the SLURM run lands.
 paper_eval_s30:
   - 111
   - 112

--- a/configs/benchmarks/seed_sets_v1.yaml
+++ b/configs/benchmarks/seed_sets_v1.yaml
@@ -58,8 +58,15 @@ paper_eval_s20:
 
 # Issue #1554 paper-facing S30 extension. Extends the S20 set with ten more
 # contiguous seeds while preserving the frozen S3 `eval` seeds (111-113) and the
-# S10/S20 ordering. Used by the S20/S30 seed-budget launch packet; no S30 campaign
-# rows exist yet, so this set is a launch-only reference until the SLURM run lands.
+# S10/S20 ordering (S10 prefix of S20 prefix of S30). Used by the S20/S30
+# seed-budget launch packet.
+#
+# PREDECLARED ONLY (issue #4304, maintainer ruling 2026-07-03): S30 is DEFERRED
+# for the dissertation draft. S20 (`paper_eval_s20`) is the draft evidence tier;
+# S30 is a reversible future escalation path, run only if a specific
+# paper/dissertation claim needs >=30 seeds or a reviewer requires it. This entry
+# predeclares the schedule so a future run is one Slurm job away with no protocol
+# debt; it does NOT imply any S30 campaign rows, benchmark result, or claim.
 paper_eval_s30:
   - 111
   - 112

--- a/docs/context/issue_1554_s20_s30_seed_budget.md
+++ b/docs/context/issue_1554_s20_s30_seed_budget.md
@@ -102,6 +102,23 @@ All inputs below are **to be confirmed by maintainer**; this note asserts no pap
   `diagnostic_only` rows are classified fail-closed with exact per-planner reasons and never
   counted as success. Missing/absent planner rows are classified fail-closed.
 
+## S30 deferral ruling (issue #4304, 2026-07-03)
+
+Maintainer ruling (2026-07-03, delegated decision): **S30 is deferred for the dissertation draft.**
+The dissertation-draft evidence tier is **S20** (`paper_eval_s20`). The S10→S20 comparison (job 13175
+closeout) shows the planner ranking is robust to seed budget at the draft's claim level, so a 30-seed
+budget is not required for the draft.
+
+`paper_eval_s30` (seeds 111–140) is kept **predeclared only**: a reversible future-escalation schedule
+so a later S30 run is one Slurm job away with no protocol debt. Run S30 only if a specific
+paper/dissertation claim needs ≥30 seeds or a reviewer requires it — post-draft by default. The
+predeclared entry implies **no** S30 campaign rows, benchmark result, ranking, or claim.
+
+Issue #4304 performs no Slurm submission and produces no new benchmark evidence; it predeclares the
+schedule, adds static seed-set contract tests (`tests/benchmark/test_seed_sets_v1.py`) that lock the
+S10 ⊂ S20 ⊂ S30 prefix-nesting property, and records this ruling. The status below is unchanged — a
+durable S20/S30 campaign result store is still the gate for any S20/S30 claim.
+
 ## Status
 
 `job_13198_constraints_first_analyzed` for the completed S20 H500 planner-family run. The

--- a/tests/benchmark/test_seed_sets_v1.py
+++ b/tests/benchmark/test_seed_sets_v1.py
@@ -1,0 +1,116 @@
+"""Static contract tests for the benchmark seed schedules in ``seed_sets_v1.yaml``.
+
+These tests are intentionally *static*: they load the YAML file and assert
+structural invariants only. They run no benchmark campaign, submit no Slurm job,
+and depend on no result store.
+
+They lock the prefix-nesting property that keeps earlier seed budgets comparable
+subsets of larger ones (S3 ``eval`` prefix of S5 prefix of S10 prefix of S20
+prefix of S30) and pin the predeclared, deferred S30 schedule from issue #4304
+(maintainer ruling 2026-07-03: S20 is the dissertation-draft tier; S30 is a
+reversible future-escalation path only).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SEED_SETS_PATH = ROOT / "configs/benchmarks/seed_sets_v1.yaml"
+
+# Expected named paper-facing seed schedules and their exact seed counts.
+EXPECTED_COUNTS = {
+    "paper_eval_s5": 5,
+    "paper_eval_s10": 10,
+    "paper_eval_s20": 20,
+    "paper_eval_s30": 30,
+}
+
+# The frozen contiguous schedule shared by every paper-facing tier.
+EXPECTED_S30 = list(range(111, 141))  # 111..140 inclusive
+
+
+@pytest.fixture(scope="module")
+def seed_sets() -> dict[str, Any]:
+    """Load the seed-set YAML once for the module."""
+    assert SEED_SETS_PATH.is_file(), f"missing seed-set config: {SEED_SETS_PATH}"
+    data = yaml.safe_load(SEED_SETS_PATH.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "seed_sets_v1.yaml must parse to a mapping"
+    return data
+
+
+def _seed_list(seed_sets: dict[str, Any], name: str) -> list[int]:
+    """Return a named seed set, asserting it is present and list-shaped."""
+    assert name in seed_sets, f"seed set {name!r} is missing"
+    value = seed_sets[name]
+    assert isinstance(value, list), f"seed set {name!r} must be a list"
+    return value
+
+
+def test_all_named_seed_sets_present(seed_sets: dict[str, Any]) -> None:
+    """The base ``dev``/``eval`` sets and every paper tier must exist."""
+    for name in ("dev", "eval", *EXPECTED_COUNTS):
+        assert name in seed_sets, f"expected seed set {name!r} to be defined"
+
+
+@pytest.mark.parametrize(("name", "count"), sorted(EXPECTED_COUNTS.items()))
+def test_seed_set_counts(seed_sets: dict[str, Any], name: str, count: int) -> None:
+    """Each paper tier has exactly the declared number of seeds."""
+    assert len(_seed_list(seed_sets, name)) == count
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_COUNTS))
+def test_seeds_are_unique_integers(seed_sets: dict[str, Any], name: str) -> None:
+    """Seeds are plain ``int`` values, unique, and never boolean."""
+    seeds = _seed_list(seed_sets, name)
+    for seed in seeds:
+        # ``bool`` is a subclass of ``int``; reject it explicitly so ``True``/
+        # ``False`` can never masquerade as a seed value.
+        assert type(seed) is int, f"{name} contains a non-int seed: {seed!r}"
+    assert len(seeds) == len(set(seeds)), f"{name} contains duplicate seeds"
+
+
+def test_prefix_nesting_holds_exactly(seed_sets: dict[str, Any]) -> None:
+    """S3/S5/S10/S20 are exact prefixes of the next-larger schedule.
+
+    Prefix nesting keeps earlier, smaller-budget campaigns valid subsets of
+    larger ones, so a later escalation never invalidates prior comparisons.
+    """
+    eval_seeds = _seed_list(seed_sets, "eval")
+    s5 = _seed_list(seed_sets, "paper_eval_s5")
+    s10 = _seed_list(seed_sets, "paper_eval_s10")
+    s20 = _seed_list(seed_sets, "paper_eval_s20")
+    s30 = _seed_list(seed_sets, "paper_eval_s30")
+
+    assert eval_seeds == s30[:3]
+    assert s5 == s30[:5]
+    assert s10 == s20[:10]
+    assert s10 == s30[:10]
+    assert s20 == s30[:20]
+
+
+def test_s30_matches_predeclared_schedule(seed_sets: dict[str, Any]) -> None:
+    """The deferred S30 schedule is the frozen contiguous block 111..140."""
+    assert _seed_list(seed_sets, "paper_eval_s30") == EXPECTED_S30
+
+
+def test_s30_does_not_reorder_earlier_tiers(seed_sets: dict[str, Any]) -> None:
+    """Predeclaring S30 must not mutate or reorder already-used S10/S20 seeds.
+
+    This is the reversibility guard: the escalation schedule only *appends*.
+    """
+    s10 = _seed_list(seed_sets, "paper_eval_s10")
+    s20 = _seed_list(seed_sets, "paper_eval_s20")
+    s30 = _seed_list(seed_sets, "paper_eval_s30")
+
+    # Order-preserving append property, not just set containment.
+    assert s30[:10] == s10
+    assert s30[:20] == s20
+    # The S30-only tail must be disjoint from the seeds S10/S20 already spent.
+    tail = s30[20:]
+    assert set(tail).isdisjoint(set(s20))
+    assert len(tail) == 10


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Verify + lock the predeclared `paper_eval_s30` seed schedule (seeds 111–140) in `configs/benchmarks/seed_sets_v1.yaml`; add static seed-set contract tests; record the 2026-07-03 S30 deferral ruling in the issue #1554 context note. The seeds already existed (added under #1554); this slice tightens the comment, adds test coverage, and documents the ruling.
- **Why now:** Maintainer ruling 2026-07-03 (issue #4304) defers S30 for the dissertation draft. Predeclaring the schedule now keeps a future S30 run one Slurm job away with no protocol debt, and the tests prevent later seed-schedule ambiguity.
- **Claim boundary:** **S20 (`paper_eval_s20`) is the dissertation-draft evidence tier; S30 is predeclared only** — a reversible future-escalation path. No S30 campaign rows, benchmark result, ranking, or claim are implied.
- **Required validation:** static seed-set tests + existing S20/S30 readiness tests pass; readiness checker still reports `blocked` (no S20/S30 result store) — unchanged.
- **Remaining blocker:** A durable S20/S30 campaign result store remains the gate for any S20/S30 claim (`blocked_until_run`); out of scope here.

Closes #4304.

## Contract delta

- **Config:** No seed values changed. `paper_eval_s30` comment now states predeclared-only / deferred / S20-is-draft-tier and that no S30 campaign rows are implied. `dev`, `eval`, and S5/S10/S20 unchanged.
- **New tests** (`tests/benchmark/test_seed_sets_v1.py`, static — no campaign/result-store dependency): counts 5/10/20/30, unique int-only seeds (boolean rejected), and exact `eval ⊂ S5 ⊂ S10 ⊂ S20 ⊂ S30` append-only prefix nesting (reversibility guard: escalation only appends, never reorders S10/S20).
- **No new fail-closed blockers**; no compatibility impact (append-only doc/test/comment slice).

## Validation

```
uv run ruff check tests/benchmark/test_seed_sets_v1.py configs   -> All checks passed! (exit 0)
uv run pytest tests/benchmark/test_seed_sets_v1.py \
              tests/validation/test_check_s20_s30_archive_readiness.py -q  -> 29 passed (exit 0)
uv run python scripts/validation/check_s20_s30_archive_readiness.py --json -> status "blocked" (exit 1, expected: no S20/S30 result store; s30_configured_as_escalation=true)
```

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no S5/S10/S20 seed changes, no archive/claim-card promotion, and no paper/dissertation claim edits.

<details>
<summary>Governance / provenance</summary>

- **Late-guidance re-check:** Re-read issue #4304 immediately before opening this PR; newest maintainer comment is the 2026-07-03 implementation plan, fully incorporated. No newer comments.
- **Fragmentation guard:** This is a progression slice adding a nameable new capability (static seed-set prefix-nesting contract tests + the recorded S30 deferral ruling), not a duplicate micro-guard.
- **Downstream propagation:** issue #1554 context note updated with the ruling. No campaign/leaderboard/registry updates needed (no new evidence produced).
- **Research Result Guidance:** `NA — no research claim`. This PR predeclares a reversible schedule and records a deferral ruling; it produces no benchmark evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new note documenting the S30 deferral decision and confirming the dissertation uses S20 evidence for now.
  * Clarified that no new benchmark evidence or job runs are included, and that future S20/S30 claims still depend on the durable result store.

* **Tests**
  * Added contract tests for benchmark seed sets to verify required tiers, exact counts, unique integer seeds, and strict prefix nesting.
  * Locked the deferred S30 seed schedule and ensured earlier tier ordering remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->