### PR TITLE
docs: record merged uncertainty-triggered fallback in CHANGELOG (#3974)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Documented the **runtime uncertainty-triggered fallback** for guarded PPO (#3974), which merged in
+  #4193 without a CHANGELOG entry. This is the successor slice the earlier #4138 entry below called
+  out as "not included"; that statement is now stale — the fallback ships in
+  `robot_sf/planner/guarded_ppo.py`. When `uncertainty_fallback_enabled` is set (default off), the
+  `GuardedPPOAdapter` guard can override a PPO command that is nominally clearance-safe but intrudes
+  into conformal uncertainty buffers (reusing #4138's `compute_intrusion_metrics`), crosses a
+  low-time-to-collision (TTC, the time until the robot and a pedestrian would collide at current
+  relative velocity) threshold, or crosses a diagnostic predicted-collision-probability proxy. The
+  override emits one of three decision labels — `uncertainty_fallback_stop`,
+  `uncertainty_fallback_slow_down`, or `uncertainty_fallback_configured` (delegates to the configured
+  fallback adapter, e.g. ORCA) —
+  and `robot_sf/benchmark/map_runner.py` counts each in `guard_stats`. The probability value is an
+  explicitly labeled **diagnostic proxy**, not a calibrated probability: shield metadata carries
+  `claim_boundary: diagnostic_proxy_not_safety_guarantee`. Diagnostic-only, default-off; no safety
+  guarantee, no benchmark claim, no paper-facing claim. Validation:
+  `uv run pytest tests/ -k "conformal or intrusion or fallback_trigger" -q`.
 * Added **diff-scoped context-note freshness gating** for issue #3190. The docs-proof consistency
   checker (`scripts/validation/check_docs_proof_consistency.py`) gains a `--freshness-scope
   {repo,diff}` option: `repo` (default) preserves the existing repo-wide `--check-context-note-freshness`


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** One `CHANGELOG.md` Unreleased/Added bullet documenting the runtime uncertainty-triggered fallback for guarded PPO (issue #3974). No code change.
- **Why now:** The fallback implementation, its constructed tests, and `map_runner` `guard_stats` counters were all delivered and **merged by PR #4193 on 2026-07-03**, but #4193 shipped **no CHANGELOG entry**. The log therefore still reads that the fallback "is not included" (in the earlier #4138 bullet) — now factually wrong. This PR closes that documentation gap so the CHANGELOG matches shipped behavior.
- **Claim boundary:** Docs-only, diagnostic. No safety guarantee, no benchmark claim, no paper/dissertation claim.
- **Required validation:** Merged implementation is green — `uv run pytest tests/planner/test_guarded_ppo_uncertainty_fallback.py tests/benchmark/test_uncertainty_safety.py -k "conformal or intrusion or fallback_trigger or uncertainty" -q` → **34 passed**.
- **Remaining blocker:** None for this slice. Issue #3974 itself is functionally complete on `main` (via #4138 + #4193) and can be closed by a maintainer once this doc trail lands.

## Contract delta

- **No schema/behavior change.** No new config fields, no new fail-closed blockers, no compatibility impact. The documented `uncertainty_fallback_enabled` flag defaults **off**; the diagnostic proxy carries `claim_boundary: diagnostic_proxy_not_safety_guarantee` (unchanged, already in `guarded_ppo.py`).

## Scope

- **In scope:** CHANGELOG correction for the already-merged fallback feature (#3974).
- **Out of scope (explicit):** No re-implementation of the fallback (already merged in #4193), no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Dedupe note

The maintainer implementation comment on #3974 requested implementing the fallback; that work was subsequently completed and merged by **#4193** (after the 2026-07-02 reopen). Re-implementing would duplicate merged code. The only genuine residual was the missing CHANGELOG record, delivered here.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3974

<details>
<summary>Governance / propagation</summary>

- **Validation tier:** docs-only (cheap path per `AGENTS.md`): diff inspected, referenced symbols/paths verified against `robot_sf/planner/guarded_ppo.py` and `robot_sf/benchmark/map_runner.py`, and the merged implementation re-run green (34 passed).
- **Downstream Propagation:** Parent issue #3974 — no comment posted (worker authorization `comment_issue_or_pr: false`); this PR body is the propagation surface. No claim map / leaderboard / registry update needed (diagnostic docs only).
- **Research Result Guidance:** `NA - support/docs closeout`. No research claim; documents an already-merged diagnostic instrumentation feature.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
