### PR TITLE
refactor: consume canonical interaction-exposure fields in issue #3813 sustained-flow revival gate

### DIFF
--- a/robot_sf/benchmark/interaction_exposure.py
+++ b/robot_sf/benchmark/interaction_exposure.py
@@ -12,6 +12,30 @@ if TYPE_CHECKING:
 
 INTERACTION_EXPOSURE_SCHEMA_VERSION = "interaction_exposure.v1"
 
+# Canonical claim-bearing interaction-exposure fields. Downstream consumers (for example the
+# issue #3813 sustained-flow revival gate) must import this tuple instead of re-declaring the
+# field names, so the required-field contract has a single owner.
+INTERACTION_EXPOSURE_REQUIRED_FIELDS: tuple[str, ...] = (
+    "interaction_exposure_share",
+    "robot_motion_share_before_first_clearance",
+    "first_clearance_step",
+    "low_exposure_success",
+)
+
+# Status string emitted when the fields were successfully computed from retained trajectories.
+INTERACTION_EXPOSURE_COMPUTED_STATUS = "computed"
+
+# Prefix marking a status where the fields were retained/attempted but could not be derived from
+# the episode rows (for example a missing trace or no pedestrians present). Consumers use this to
+# distinguish "field never retained" from "field retained but not derivable".
+NOT_DERIVABLE_STATUS_PREFIX = "not_derivable_"
+
+
+def is_not_derivable_status(status: object) -> bool:
+    """Return whether ``status`` marks a retained-but-not-derivable exposure record."""
+
+    return isinstance(status, str) and status.strip().startswith(NOT_DERIVABLE_STATUS_PREFIX)
+
 
 class InteractionExposureError(ValueError):
     """Raised when interaction-exposure inputs are malformed."""

--- a/robot_sf/benchmark/sustained_flow_revival_gate.py
+++ b/robot_sf/benchmark/sustained_flow_revival_gate.py
@@ -12,6 +12,12 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from robot_sf.benchmark.interaction_exposure import (
+    INTERACTION_EXPOSURE_COMPUTED_STATUS,
+    INTERACTION_EXPOSURE_REQUIRED_FIELDS,
+    is_not_derivable_status,
+)
+
 SUSTAINED_FLOW_REVIVAL_GATE_SCHEMA_VERSION = "issue_3813.sustained_flow_revival_gate.v1"
 
 DECISION_REVIVE = "revive_sustained_flow"
@@ -28,14 +34,15 @@ DEFAULT_H600_CLAIM_IMPACT_EVIDENCE = Path(
     "sustained_flow_claim_impact_input.json"
 )
 
-REQUIRED_INTERACTION_EXPOSURE_FIELDS = (
-    "interaction_exposure_share",
-    "robot_motion_share_before_first_clearance",
-    "first_clearance_step",
-    "low_exposure_success",
-)
+# Consume the canonical interaction-exposure field contract (owned by
+# ``robot_sf.benchmark.interaction_exposure`` via issue #4242/#4278) instead of re-declaring the
+# field names here; the public alias is kept for backward compatibility with existing importers.
+REQUIRED_INTERACTION_EXPOSURE_FIELDS = INTERACTION_EXPOSURE_REQUIRED_FIELDS
 
-_COMPLETE_EXPOSURE_STATUSES = {"computed", "ok", "complete"}
+# Statuses that positively assert the required exposure fields were computed. The canonical
+# ``computed`` status is sourced from the interaction-exposure module; ``ok``/``complete`` remain
+# accepted synonyms for upstream diagnostic reports that predate the canonical convention.
+_COMPLETE_EXPOSURE_STATUSES = {INTERACTION_EXPOSURE_COMPUTED_STATUS, "ok", "complete"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,7 +108,17 @@ def build_sustained_flow_revival_gate_report(
 
     blocking_reasons: list[str] = []
     if not _interaction_exposure_complete(interaction_exposure):
-        blocking_reasons.append("interaction-exposure diagnostics missing computed required fields")
+        if _interaction_exposure_retained_but_not_derivable(interaction_exposure):
+            # The required fields are retained as columns but their values could not be derived
+            # from the episode rows (canonical ``not_derivable_*`` status). This is a distinct
+            # blocker from fields that were never retained; both still fail the gate closed.
+            blocking_reasons.append(
+                "interaction-exposure fields retained but not derivable from episode rows"
+            )
+        else:
+            blocking_reasons.append(
+                "interaction-exposure diagnostics missing computed required fields"
+            )
 
     affected_rows = _affected_rows(interaction_exposure, claim_impact)
     if not affected_rows:
@@ -180,6 +197,55 @@ def _interaction_exposure_complete(report: Mapping[str, Any]) -> bool:
         return False
 
     return True
+
+
+def _interaction_exposure_retained_but_not_derivable(report: Mapping[str, Any]) -> bool:
+    """Return whether required exposure fields are retained but cannot be derived.
+
+    Distinguishes the "retained-but-not-derivable" state (columns present, but the canonical
+    ``not_derivable_*`` status or a zero-derivable/positive-not-derivable episode-row count means
+    no value could be computed) from the "fields never retained" state. Both fail the gate closed,
+    but naming the difference keeps the deferred-evidence blocker precise.
+    """
+
+    runs = _run_mappings(report)
+    entities = runs if runs else (report,)
+    saw_retained_not_derivable = False
+    for entity in entities:
+        if not _fields_retained(entity):
+            continue
+        if _entity_not_derivable(entity):
+            saw_retained_not_derivable = True
+        else:
+            # A retained-and-derivable entity means the incompleteness is not (only) a
+            # not-derivable state, so do not label the whole report that way.
+            return False
+    return saw_retained_not_derivable
+
+
+def _fields_retained(entity: Mapping[str, Any]) -> bool:
+    """Return whether all required exposure fields are present as columns on ``entity``."""
+
+    if set(_string_sequence(entity.get("missing_required_fields"))):
+        return False
+    retained = set(_string_sequence(entity.get("available_columns")))
+    retained.update(_string_sequence(entity.get("computed_fields")))
+    return set(REQUIRED_INTERACTION_EXPOSURE_FIELDS) <= retained
+
+
+def _entity_not_derivable(entity: Mapping[str, Any]) -> bool:
+    """Return whether ``entity`` marks its retained exposure fields as not derivable."""
+
+    if is_not_derivable_status(entity.get("status")):
+        return True
+    if is_not_derivable_status(entity.get("interaction_exposure_status")):
+        return True
+    not_derivable_rows = entity.get("not_derivable_episode_rows")
+    derivable_rows = entity.get("derivable_episode_rows")
+    if isinstance(not_derivable_rows, int) and not_derivable_rows > 0:
+        if not isinstance(derivable_rows, int) or derivable_rows == 0:
+            return True
+    return False
 
 
 def _run_mappings(report: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...] | None:

--- a/tests/benchmark/test_issue_3813_sustained_flow_revival_gate.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_revival_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from robot_sf.benchmark.interaction_exposure import INTERACTION_EXPOSURE_REQUIRED_FIELDS
 from robot_sf.benchmark.sustained_flow_revival_gate import (
     DECISION_DEFER,
     DECISION_REVIVE,
@@ -17,6 +18,12 @@ from robot_sf.benchmark.sustained_flow_revival_gate import (
 from scripts.validation.report_issue_3813_sustained_flow_revival_gate import main as gate_main
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_required_fields_consume_canonical_interaction_exposure_contract() -> None:
+    """The gate must reuse the canonical interaction-exposure field tuple, not a private copy."""
+
+    assert REQUIRED_INTERACTION_EXPOSURE_FIELDS == INTERACTION_EXPOSURE_REQUIRED_FIELDS
 
 
 def _complete_exposure() -> dict:
@@ -138,6 +145,70 @@ def test_complete_non_load_bearing_evidence_stops_sustained_flow() -> None:
     assert report.decision == DECISION_STOP
     assert report.ready_for_revived_implementation is False
     assert report.blocking_reasons == ()
+
+
+def test_retained_but_not_derivable_fields_defer_with_distinct_reason() -> None:
+    """Retained columns with a canonical not-derivable status DEFER via a distinct blocker."""
+
+    exposure = {
+        "runs": [
+            {
+                "job_id": "13268",
+                "run_label": "confirm",
+                "status": "not_derivable_missing_trace",
+                "available_columns": list(REQUIRED_INTERACTION_EXPOSURE_FIELDS),
+                "not_derivable_episode_rows": 12,
+                "derivable_episode_rows": 0,
+            }
+        ],
+    }
+    report = build_sustained_flow_revival_gate_report(
+        exposure,
+        claim_impact=_claim_impact(changed=True),
+        claim_impact_evidence_path="docs/context/evidence/claim_impact.json",
+    )
+    payload = report.to_payload()
+    assert payload["decision"] == DECISION_DEFER
+    assert payload["ready_for_revived_implementation"] is False
+    assert (
+        "interaction-exposure fields retained but not derivable from episode rows"
+        in payload["blocking_reasons"]
+    )
+    # The retained-but-not-derivable state must not be conflated with fields never retained.
+    assert (
+        "interaction-exposure diagnostics missing computed required fields"
+        not in payload["blocking_reasons"]
+    )
+
+
+def test_missing_fields_are_not_labelled_retained_but_not_derivable() -> None:
+    """When required columns are absent, the gate keeps the 'missing fields' blocker wording."""
+
+    exposure = {
+        "runs": [
+            {
+                "job_id": "13268",
+                "status": "blocked_missing_required_fields",
+                "available_columns": ["planner_key", "scenario_id", "success"],
+                "missing_required_fields": list(REQUIRED_INTERACTION_EXPOSURE_FIELDS),
+            }
+        ],
+    }
+    report = build_sustained_flow_revival_gate_report(
+        exposure,
+        claim_impact=_claim_impact(changed=True),
+        claim_impact_evidence_path="docs/context/evidence/claim_impact.json",
+    )
+    payload = report.to_payload()
+    assert payload["decision"] == DECISION_DEFER
+    assert (
+        "interaction-exposure diagnostics missing computed required fields"
+        in payload["blocking_reasons"]
+    )
+    assert (
+        "interaction-exposure fields retained but not derivable from episode rows"
+        not in payload["blocking_reasons"]
+    )
 
 
 def test_cli_reports_default_tracked_gate_decision(capsys) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** The issue #3813 sustained-flow revival gate now *consumes* the canonical interaction-exposure field contract from `robot_sf/benchmark/interaction_exposure.py` (owned by issue #4242/#4278) instead of re-declaring the four required field names and the `"computed"` status string itself. It also gains a distinct **retained-but-not-derivable** blocker so deferred-evidence reasons stay precise.
- **Why now:** This is the useful residual of superseded PR #4292. That PR was closed because it re-added `interaction_exposure.py` from scratch (add/add conflict with the canonical module). The genuinely-new part — the revival gate consuming main's module + the retained-but-not-derivable blocker — was never landed. This PR delivers exactly that as a **de-duplication / consolidation slice** (per the repo "Canonical Owner Check" rule), not a new scenario family.
- **Claim boundary:** Revival gate only. No sustained-flow runtime implementation, no benchmark campaign, no default benchmark conclusion, and no paper/dissertation claim is changed. The gate stays `defer_needs_more_evidence` against current tracked h600 evidence (behavior-preserving).
- **Required validation:** focused revival-gate + interaction-exposure fixture tests (below), ruff check/format on changed files. CPU only; no campaigns.
- **Remaining blocker (unchanged):** the gate cannot revive/stop until the retained h600 rows carry computed interaction-exposure fields **and** a computable claim-decision impact. Issue stays in `defer` state.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3813

### Maintainer-direction note (transparency)

The latest issue comment (2026-07-03 18:07, PR #4292 closure) says "all intended artifacts already on main via #4278/#4264/#4282" and "no further implementation slices ... unless the revival condition fires." Inspection of `main` shows the revival gate did **not** yet consume the canonical module (it duplicated the field/status contract), which the earlier gate notes (16:05 / 17:55) flagged as the residual to rebuild on main's #4278 module. This PR closes that specific duplication only; it does not fire revival and does not add a new capability. If the maintainer prefers to hold the residual, the change is safely revertible.

## Contract delta

- **New canonical exports** in `interaction_exposure.py` (additive, no behavior change): `INTERACTION_EXPOSURE_REQUIRED_FIELDS`, `INTERACTION_EXPOSURE_COMPUTED_STATUS`, `NOT_DERIVABLE_STATUS_PREFIX`, `is_not_derivable_status()`.
- **New fail-closed blocker** in the revival gate: `"interaction-exposure fields retained but not derivable from episode rows"` — emitted (still `defer`) when required columns are retained but the canonical `not_derivable_*` status or a zero-derivable / positive-not-derivable episode-row count means no value could be computed. This is distinct from the pre-existing `"... missing computed required fields"` blocker (fields never retained).
- **Compatibility:** `REQUIRED_INTERACTION_EXPOSURE_FIELDS` is preserved as a public alias, so existing importers and the CLI/report path are unaffected. Current tracked-evidence gate output is byte-for-byte the same decision + blocking reasons as before.

## Validation

```
scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/interaction_exposure.py robot_sf/benchmark/sustained_flow_revival_gate.py tests/benchmark/test_issue_3813_sustained_flow_revival_gate.py
# -> All checks passed!

scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check <same files>
# -> 3 files already formatted

scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_revival_gate.py tests/benchmark/test_interaction_exposure.py tests/benchmark/test_map_runner_episode_schema.py -q
# -> 23 passed

scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark -k "sustained_flow or interaction_exposure" -q
# -> 38 passed, 3035 deselected

scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/report_issue_3813_sustained_flow_revival_gate.py --json
# -> decision=defer_needs_more_evidence, ready_for_revived_implementation=false (unchanged)
```

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. `interaction_exposure.py` is not reimplemented (only additive exports). No new scenario family is added; the gate does not revive one.

<details>
<summary>Downstream propagation & research-result guidance</summary>

- **Downstream Propagation:** Parent issue #3813 stays open in `defer` state; no claim map / leaderboard / registry update needed (diagnostic-gate wiring only, no conclusion change). State propagation: this PR body is the single status surface; no tracked queue-routing state is added.
- **Research Result Guidance:** `NA - support/consolidation slice`. Target: reduce field-contract drift between the revival gate and the canonical interaction-exposure owner; comparator/baseline: N/A (no metric); result classification: diagnostic-only, behavior-preserving; decision/stop rule: gate remains `defer` until h600 exposure fields + claim-impact are computable.

After this PR is open, Claude Code on `imech156-u` owns the full PR gate, improvement cycle, and merge authority.
</details>
