### PR TITLE
feat: CrowdBot and SCAND skip-if-absent shape-contract loaders (issue #4224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Added license-safe **CrowdBot and SCAND shape-contract loaders** plus skip-if-absent tests for the
+  #4224 external-data program (public slice b). `robot_sf/data/external/crowdbot.py` and
+  `robot_sf/data/external/scand.py` only inspect locally staged files — they never download, vendor,
+  or redistribute dataset bytes — and validate a cheap structural contract (documented
+  recording + license/readme layout present; every staged CSV export non-empty and rectangular;
+  every JSON export parseable; no empty ROS bag). Both share the reusable engine
+  `robot_sf/data/external/recording_shape_contract.py`, which reuses the canonical registry
+  availability contract in `scripts/tools/manage_external_data.py`. Acquisition/layout docs added at
+  `docs/datasets/crowdbot.md` and `docs/datasets/scand.md`. Registry/contract only: no dataset
+  bytes, no automated acquisition, no benchmark or paper/dissertation claim.
+
 ### Fixed
 
 * Removed absolute, username-bearing local paths from the committed issue #4207

--- a/docs/context/issue_4224_external_dataset_registry.md
+++ b/docs/context/issue_4224_external_dataset_registry.md
@@ -41,3 +41,22 @@ uv run python scripts/tools/manage_external_data.py --json provenance-check <ass
 
 Only pin `expected_tree_sha256` after reviewing that the staged tree corresponds to the official
 asset and no raw data is tracked by git.
+
+### Shape-contract loaders (public slice b)
+
+Per the 2026-07-03 maintainer ruling, each asset gets a license-safe shape-contract loader plus
+skip-if-absent tests that validate the expected structure and skip when data is absent (no bytes,
+ever). Current status:
+
+| Asset | Loader module | Tests |
+| --- | --- | --- |
+| `atc-pedestrian` | `robot_sf/data/external/atc.py` | `tests/data/external/test_atc_shape.py` |
+| `eth-ucy-trajectories` | `robot_sf/data/external/eth_ucy.py` | `tests/data/external/test_eth_ucy_shape.py` |
+| `ind-crossings` | `robot_sf/data/external/ind.py` | `tests/data/external/test_ind_shape.py` |
+| `crowdbot` | `robot_sf/data/external/crowdbot.py` | `tests/data/external/test_crowdbot_shape.py` |
+| `scand-demos` | `robot_sf/data/external/scand.py` | `tests/data/external/test_scand_shape.py` |
+
+`crowdbot` and `scand-demos` are recording-style datasets (ROS bags plus exported CSV/JSON tables and
+a license/readme copy) and share the reusable engine in
+`robot_sf/data/external/recording_shape_contract.py`. A passing shape contract is local structural
+evidence only; it is not a benchmark, ingestion, or paper-facing claim.

--- a/docs/datasets/crowdbot.md
+++ b/docs/datasets/crowdbot.md
@@ -1,0 +1,103 @@
+# CrowdBot Robot-in-Crowd External Data
+
+Plain-language summary: Robot SF can record the expected local layout and provenance of the CrowdBot
+(EPFL LASA Qolo robot-in-crowd) dataset and validate a cheap **shape contract** against a locally
+staged copy, but it does **not** download, redistribute, or benchmark with the research-access-gated
+data unless you stage it yourself under the upstream terms.
+
+This is a CrowdBot slice of the #4224 external-data program. It adds a license-safe loader plus
+skip-if-absent shape-contract tests on top of the previously merged registry entry (PR #4238). No
+dataset bytes, no automated acquisition, no benchmark run, and no paper-facing claim are introduced
+here.
+
+Related issues: [#4224](https://github.com/ll7/robot_sf_ll7/issues/4224),
+[#3977](https://github.com/ll7/robot_sf_ll7/issues/3977)
+
+## What it is
+
+CrowdBot (Paez-Granados et al. 2021) captures a Qolo mobile robot navigating pedestrian crowds in
+Lausanne, distributed as ROS bag recordings with exported track/annotation tables. It targets
+robot-reaction realism validation for the public-requirement scenario families (#3977).
+
+## Canonical registry identity
+
+The canonical Robot SF registry entry is **`crowdbot`** in `scripts/tools/manage_external_data.py`.
+Inspect the authoritative, always-up-to-date contract with:
+
+```bash
+uv run python scripts/tools/manage_external_data.py explain crowdbot
+```
+
+## Official acquisition
+
+Acquire the dataset directly from the official source and keep it under the upstream terms:
+
+- Official source: <https://www.epfl.ch/labs/lasa/crowdbot-dataset/>
+
+CrowdBot is a research-request / bring-your-own asset; the published dataset points to IEEE DataPort.
+The public Robot SF repository does not encode a scriptable download URL and does not commit dataset
+bytes: the registry keeps `auto_download_allowed=False`. Obtain the data manually under the official
+terms and keep a local copy of the terms/README alongside the data.
+
+## Expected layout
+
+By default the registry expects the CrowdBot root at `output/external_data/crowdbot/`. To share one
+staged copy across worktrees, set `ROBOT_SF_EXTERNAL_DATA_ROOT` and place the tree under
+`$ROBOT_SF_EXTERNAL_DATA_ROOT/crowdbot/` (the registry `shared_root_subpath`).
+
+```text
+$ROBOT_SF_EXTERNAL_DATA_ROOT/crowdbot/
+  README.md          (or LICENSE* / TERMS* — a local copy of the upstream terms)
+  <run>.bag          (one or more ROS bag recordings; nested subdirectories are fine)
+  <export>.csv       (optional exported track/annotation tables)
+  <metadata>.json    (optional metadata/annotation JSON)
+```
+
+Required-path groups (at least one match per group; run `explain` for the exact patterns):
+
+- **recording**: `**/*.bag`, `**/*.csv`, or `**/*.json`.
+- **license_or_readme**: `**/README*`, `**/LICENSE*`, or `**/TERMS*`.
+
+These are layout and presence checks only. They do not assert recording-content correctness,
+licensing status, benchmark readiness, or any paper-facing evidence.
+
+## Shape contract loader
+
+`robot_sf/data/external/crowdbot.py` is a license-safe loader that only inspects locally staged
+files. It never downloads, vendors, or redistributes dataset bytes, and it makes no
+robot-reaction-realism claim. It validates a cheap, structural shape contract: the documented
+recording + license/readme layout exists, every staged CSV export is a non-empty rectangular table,
+every staged JSON export parses, and no ROS bag is empty. It intentionally asserts no content values.
+
+```python
+from robot_sf.data.external import crowdbot
+
+if crowdbot.is_available():
+    contract = crowdbot.load_shape_contract()
+```
+
+- `is_available(root=None)` returns `False` for an absent or incomplete layout.
+- `require_available(root=None)` raises `CrowdBotDataError` with an actionable docs pointer when the
+  layout is absent/incomplete.
+- `load_shape_contract(root=None)` returns recording counts plus per-file shape metadata (CSV
+  row/column counts, JSON top-level type, bag byte sizes) and the resolved license/readme files.
+
+```bash
+uv run pytest tests/data/external/test_crowdbot_shape.py -q
+```
+
+The shape-contract tests never require the gated bytes: the only real-data path skips when the
+dataset is absent, and every other test builds a synthetic layout under a temp directory.
+
+## Claim boundary
+
+External-data registry and shape contract only. A passing `crowdbot` shape contract means only that a
+local copy matched the documented recording/license layout and parsed structurally. It does not mean
+the data has been downloaded, license-approved for redistribution, ingested, or used to support a
+benchmark or paper-facing claim. This asset is an alternative/complement to the blocked SDD route
+(#4079), not a resolution of it.
+
+## Citation
+
+> D. Paez-Granados, Y. He, D. Gonon, et al., "Pedestrian-Robot Interactions on Autonomous Crowd
+> Navigation: Reactive Control Methods and Evaluation Metrics," 2021.

--- a/docs/datasets/scand.md
+++ b/docs/datasets/scand.md
@@ -1,0 +1,106 @@
+# SCAND Socially-Compliant Navigation Demonstrations External Data
+
+Plain-language summary: Robot SF can record the expected local layout and provenance of the SCAND
+(Socially CompliAnt Navigation Dataset) demonstrations and validate a cheap **shape contract**
+against a locally staged copy, but it does **not** download, redistribute, or benchmark with the
+terms-gated data unless you stage it yourself under the upstream terms.
+
+This is a SCAND slice of the #4224 external-data program. It adds a license-safe loader plus
+skip-if-absent shape-contract tests on top of the previously merged registry entry (PR #4238). No
+dataset bytes, no automated acquisition, no benchmark run, and no paper-facing claim are introduced
+here.
+
+Related issues: [#4224](https://github.com/ll7/robot_sf_ll7/issues/4224),
+[#1470](https://github.com/ll7/robot_sf_ll7/issues/1470),
+[#1496](https://github.com/ll7/robot_sf_ll7/issues/1496)
+
+## What it is
+
+SCAND (Karnan et al. 2022) is 8.7 hours of socially-compliant human-teleoperated navigation
+demonstrations, distributed as ROS bag recordings. It targets a real-demonstration alternative for
+the oracle-imitation lane (#1470 / #1496).
+
+## Canonical registry identity
+
+The canonical Robot SF registry entry is **`scand-demos`** in
+`scripts/tools/manage_external_data.py`. Inspect the authoritative, always-up-to-date contract with:
+
+```bash
+uv run python scripts/tools/manage_external_data.py explain scand-demos
+```
+
+## Official acquisition
+
+Acquire the dataset directly from the official Texas Data Repository release and keep it under the
+upstream terms:
+
+- Official source:
+  <https://dataverse.tdl.org/dataset.xhtml?persistentId=doi:10.18738/T8/0PRYRH>
+
+The dataset is large; select files manually through the official DataVerse interface. The public
+Robot SF repository does not encode a scriptable download URL and does not commit dataset bytes: the
+registry keeps `auto_download_allowed=False`. Keep a local copy of the terms/README alongside the
+data.
+
+## Expected layout
+
+By default the registry expects the SCAND root at `output/external_data/scand_demos/`. To share one
+staged copy across worktrees, set `ROBOT_SF_EXTERNAL_DATA_ROOT` and place the tree under
+`$ROBOT_SF_EXTERNAL_DATA_ROOT/scand_demos/` (the registry `shared_root_subpath`).
+
+```text
+$ROBOT_SF_EXTERNAL_DATA_ROOT/scand_demos/
+  LICENSE.txt        (or README* / TERMS* — a local copy of the upstream terms)
+  <demo>.bag         (one or more ROS bag demonstrations; nested subdirectories are fine)
+  <export>.csv       (optional exported trajectory/command tables)
+  <metadata>.json    (optional metadata/annotation JSON)
+```
+
+Required-path groups (at least one match per group; run `explain` for the exact patterns):
+
+- **recording**: `**/*.bag`, `**/*.csv`, or `**/*.json`.
+- **license_or_readme**: `**/README*`, `**/LICENSE*`, or `**/TERMS*`.
+
+These are layout and presence checks only. They do not assert recording-content correctness,
+licensing status, benchmark readiness, or any paper-facing evidence.
+
+## Shape contract loader
+
+`robot_sf/data/external/scand.py` is a license-safe loader that only inspects locally staged files.
+It never downloads, vendors, or redistributes dataset bytes, and it makes no oracle-imitation claim.
+It validates a cheap, structural shape contract: the documented recording + license/readme layout
+exists, every staged CSV export is a non-empty rectangular table, every staged JSON export parses,
+and no ROS bag is empty. It intentionally asserts no content values.
+
+```python
+from robot_sf.data.external import scand
+
+if scand.is_available():
+    contract = scand.load_shape_contract()
+```
+
+- `is_available(root=None)` returns `False` for an absent or incomplete layout.
+- `require_available(root=None)` raises `ScandDataError` with an actionable docs pointer when the
+  layout is absent/incomplete.
+- `load_shape_contract(root=None)` returns recording counts plus per-file shape metadata (CSV
+  row/column counts, JSON top-level type, bag byte sizes) and the resolved license/readme files.
+
+```bash
+uv run pytest tests/data/external/test_scand_shape.py -q
+```
+
+The shape-contract tests never require the gated bytes: the only real-data path skips when the
+dataset is absent, and every other test builds a synthetic layout under a temp directory.
+
+## Claim boundary
+
+External-data registry and shape contract only. A passing `scand-demos` shape contract means only
+that a local copy matched the documented recording/license layout and parsed structurally. It does
+not mean the data has been downloaded, license-approved for redistribution, ingested, or used to
+support a benchmark or paper-facing claim. This asset is an alternative/complement to the blocked SDD
+route (#4079), not a resolution of it.
+
+## Citation
+
+> H. Karnan, A. Nair, X. Xiao, et al., "Socially CompliAnt Navigation Dataset (SCAND): A Large-Scale
+> Dataset of Demonstrations for Social Navigation," *IEEE Robotics and Automation Letters*, 2022.

--- a/robot_sf/data/external/crowdbot.py
+++ b/robot_sf/data/external/crowdbot.py
@@ -1,0 +1,84 @@
+"""CrowdBot robot-in-crowd external-data shape contract.
+
+Plain-language summary: this loader only inspects locally staged CrowdBot files
+(ROS bags plus exported CSV/JSON tables and a license/README copy). It never
+downloads, vendors, or redistributes the research-access-gated EPFL LASA CrowdBot
+dataset bytes. The contract is cheap and structural: it confirms the documented
+recording + license/readme layout exists and that each staged CSV/JSON export
+parses and each ROS bag is non-empty. It asserts no dataset content and makes no
+robot-reaction-realism claim.
+
+The expected layout, source, and staging workflow are documented in
+``docs/datasets/crowdbot.md``; the availability contract is the ``crowdbot``
+registry entry in ``scripts/tools/manage_external_data.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.data.external import recording_shape_contract as _engine
+from robot_sf.data.external.recording_shape_contract import (
+    EXTERNAL_DATA_ROOT_ENV,
+    RecordingDatasetError,
+    RecordingDatasetPaths,
+    RecordingDatasetSpec,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+CROWDBOT_ASSET_ID = "crowdbot"
+ACQUISITION_DOC = "docs/datasets/crowdbot.md"
+
+__all__ = [
+    "ACQUISITION_DOC",
+    "CROWDBOT_ASSET_ID",
+    "EXTERNAL_DATA_ROOT_ENV",
+    "CrowdBotDataError",
+    "dataset_root",
+    "is_available",
+    "load_shape_contract",
+    "require_available",
+]
+
+
+class CrowdBotDataError(RecordingDatasetError):
+    """Raised when staged CrowdBot data is present but structurally invalid."""
+
+
+_SPEC = RecordingDatasetSpec(
+    asset_id=CROWDBOT_ASSET_ID,
+    title="CrowdBot robot-in-crowd dataset",
+    docs_path=ACQUISITION_DOC,
+    error_cls=CrowdBotDataError,
+)
+
+
+def dataset_root(root: Path | str | None = None) -> Path:
+    """Return the CrowdBot dataset root, honoring the shared external-data root."""
+
+    return _engine.resolve_root(_SPEC, root)
+
+
+def is_available(root: Path | str | None = None) -> bool:
+    """Return whether the documented CrowdBot recording layout is staged."""
+
+    return _engine.is_available(_SPEC, root)
+
+
+def require_available(root: Path | str | None = None) -> RecordingDatasetPaths:
+    """Return resolved CrowdBot files or raise an actionable acquisition error."""
+
+    return _engine.require_available(_SPEC, root)
+
+
+def load_shape_contract(root: Path | str | None = None) -> dict[str, Any]:
+    """Load and validate the cheap CrowdBot recording-style shape contract.
+
+    Returns:
+        A structural contract mapping with recording counts and per-file shape
+        metadata; see :func:`recording_shape_contract.load_shape_contract`.
+    """
+
+    return _engine.load_shape_contract(_SPEC, root)

--- a/robot_sf/data/external/recording_shape_contract.py
+++ b/robot_sf/data/external/recording_shape_contract.py
@@ -1,0 +1,314 @@
+"""Reusable skip-if-absent shape contract for recording-style external datasets.
+
+Plain-language summary: several license-gated robot-in-crowd datasets (CrowdBot,
+SCAND) ship as ROS bag recordings plus exported CSV/JSON tables and a license or
+README file, rather than as flat numeric trajectory matrices like ETH/UCY. This
+module provides one cheap, structural shape contract shared by those datasets. It
+confirms that the registry-declared recording + license/readme layout is present
+and that every staged CSV/JSON export parses as a well-formed, non-empty
+table/object and that no ROS bag is empty. It never downloads, vendors, or
+redistributes dataset bytes, and it asserts no dataset content (no exact frame
+counts, sensor values, trajectories, or scene identities).
+
+Availability resolution reuses the canonical registry contract in
+``scripts/tools/manage_external_data.py`` (the ``recording`` and
+``license_or_readme`` required-path groups) so the loader and the registry never
+drift. Per-dataset wrappers (``crowdbot.py``, ``scand.py``) bind a
+:class:`RecordingDatasetSpec` and expose the thin module-level API used by the
+skip-if-absent shape-contract tests.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+from scripts.tools.manage_external_data import (
+    EXTERNAL_DATA_ROOT_ENV,
+    check_asset,
+    resolve_asset_local_path_by_id,
+)
+
+# Recording/export file extensions recognized by the structural contract. These
+# mirror the registry ``recording`` required-path group for the recording-style
+# assets (ROS bags plus exported CSV/JSON tables).
+_BAG_SUFFIX = ".bag"
+_CSV_SUFFIX = ".csv"
+_JSON_SUFFIX = ".json"
+
+# Filename prefixes accepted for the license/terms/readme required-path group.
+_LICENSE_README_PREFIXES = ("readme", "license", "terms")
+
+__all__ = [
+    "EXTERNAL_DATA_ROOT_ENV",
+    "RecordingDatasetError",
+    "RecordingDatasetPaths",
+    "RecordingDatasetSpec",
+    "availability_report",
+    "is_available",
+    "load_shape_contract",
+    "require_available",
+    "resolve_root",
+]
+
+
+class RecordingDatasetError(RuntimeError):
+    """Raised when a staged recording-style dataset is present but invalid.
+
+    Per-dataset modules subclass this so their tests and callers can match a
+    dataset-specific error type while sharing this module's validation logic.
+    """
+
+
+@dataclass(frozen=True)
+class RecordingDatasetSpec:
+    """Binding descriptor for one recording-style external dataset.
+
+    Attributes:
+        asset_id: Canonical registry id in ``manage_external_data.py``.
+        title: Human-facing dataset title used in error messages.
+        docs_path: Repository-relative acquisition/layout doc page.
+        error_cls: Concrete :class:`RecordingDatasetError` subclass to raise.
+    """
+
+    asset_id: str
+    title: str
+    docs_path: str
+    error_cls: type[RecordingDatasetError]
+
+
+@dataclass(frozen=True)
+class RecordingDatasetPaths:
+    """Resolved recording and license/readme files for a staged dataset."""
+
+    root: Path
+    bag_files: tuple[Path, ...]
+    csv_files: tuple[Path, ...]
+    json_files: tuple[Path, ...]
+    license_or_readme: tuple[Path, ...]
+    docs_path: str
+
+
+def resolve_root(spec: RecordingDatasetSpec, root: Path | str | None = None) -> Path:
+    """Return the dataset root, honoring the shared external-data registry.
+
+    Args:
+        spec: Dataset binding descriptor.
+        root: Explicit dataset root. When ``None`` the shared external-data
+            registry resolves the path from ``ROBOT_SF_EXTERNAL_DATA_ROOT`` (or
+            the repo-local default). The path is not required to exist.
+    """
+
+    if root is not None:
+        return Path(root).expanduser().resolve()
+    return resolve_asset_local_path_by_id(spec.asset_id).expanduser().resolve()
+
+
+def availability_report(
+    spec: RecordingDatasetSpec, root: Path | str | None = None
+) -> dict[str, Any]:
+    """Return the canonical registry availability report for the dataset."""
+
+    return check_asset(spec.asset_id, source_path=resolve_root(spec, root))
+
+
+def is_available(spec: RecordingDatasetSpec, root: Path | str | None = None) -> bool:
+    """Return whether the required recording + license/readme layout is staged.
+
+    Returns ``False`` for an absent or incomplete layout so skip-if-absent tests
+    can skip cleanly. A present-but-malformed recording/export file does not fail
+    this check; it is reported by :func:`load_shape_contract`.
+    """
+
+    return bool(availability_report(spec, root).get("ok", False))
+
+
+def require_available(
+    spec: RecordingDatasetSpec, root: Path | str | None = None
+) -> RecordingDatasetPaths:
+    """Return resolved recording files or raise an actionable acquisition error."""
+
+    report = availability_report(spec, root)
+    resolved_root = Path(report["source_path"])
+    if not report.get("ok", False):
+        missing = ", ".join(str(path) for path in report.get("missing_required_paths") or [])
+        action = str(report.get("action") or f"stage the official {spec.asset_id} assets")
+        raise spec.error_cls(
+            f"{spec.asset_id} is not staged or is incomplete at {resolved_root}. "
+            f"Missing required group(s): {missing or 'unknown'}. {action} "
+            f"See {spec.docs_path}. You may set {EXTERNAL_DATA_ROOT_ENV} to a shared "
+            "external-data root."
+        )
+    return _resolve_paths(spec, resolved_root)
+
+
+def _resolve_paths(spec: RecordingDatasetSpec, root: Path) -> RecordingDatasetPaths:
+    """Enumerate recording and license/readme files under a staged root.
+
+    Returns:
+        The resolved :class:`RecordingDatasetPaths` with bag/csv/json and
+        license-or-readme files sorted by path.
+    """
+
+    bag_files: list[Path] = []
+    csv_files: list[Path] = []
+    json_files: list[Path] = []
+    license_or_readme: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        suffix = path.suffix.lower()
+        if suffix == _BAG_SUFFIX:
+            bag_files.append(path)
+        elif suffix == _CSV_SUFFIX:
+            csv_files.append(path)
+        elif suffix == _JSON_SUFFIX:
+            json_files.append(path)
+        if path.name.lower().startswith(_LICENSE_README_PREFIXES):
+            license_or_readme.append(path)
+    return RecordingDatasetPaths(
+        root=root,
+        bag_files=tuple(bag_files),
+        csv_files=tuple(csv_files),
+        json_files=tuple(json_files),
+        license_or_readme=tuple(license_or_readme),
+        docs_path=spec.docs_path,
+    )
+
+
+def _read_text(spec: RecordingDatasetSpec, path: Path) -> str:
+    """Read a staged export file as UTF-8 text or fail closed.
+
+    Returns:
+        The decoded file text.
+    """
+
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise spec.error_cls(
+            f"{spec.asset_id} file {path} could not be read as UTF-8 text. "
+            f"Re-stage per {spec.docs_path}."
+        ) from exc
+
+
+def _validate_csv(spec: RecordingDatasetSpec, path: Path) -> dict[str, Any]:
+    """Validate one staged CSV export as a non-empty rectangular table.
+
+    This is a structural check only: it confirms the export parses as CSV, holds
+    at least one non-empty row, and every non-empty row shares one column count.
+    It asserts no column names or cell values.
+
+    Returns:
+        A mapping with the ``row_count`` and ``column_count`` of the table.
+
+    Raises:
+        RecordingDatasetError subclass: If the file is empty or non-rectangular.
+    """
+
+    text = _read_text(spec, path)
+    rows = [row for row in csv.reader(StringIO(text)) if any(cell.strip() for cell in row)]
+    if not rows:
+        raise spec.error_cls(
+            f"{spec.asset_id} CSV export {path} has no non-empty data rows. See {spec.docs_path}."
+        )
+    column_count = len(rows[0])
+    if any(len(row) != column_count for row in rows):
+        raise spec.error_cls(
+            f"{spec.asset_id} CSV export {path} is not rectangular; rows have "
+            f"varying column counts. See {spec.docs_path}."
+        )
+    return {"row_count": len(rows), "column_count": column_count}
+
+
+def _validate_json(spec: RecordingDatasetSpec, path: Path) -> dict[str, Any]:
+    """Validate one staged JSON export as parseable and summarize its top type.
+
+    Returns:
+        A mapping with the ``top_level_type`` name of the parsed JSON payload.
+
+    Raises:
+        RecordingDatasetError subclass: If the file does not parse as JSON.
+    """
+
+    text = _read_text(spec, path)
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise spec.error_cls(
+            f"{spec.asset_id} JSON export {path} is not valid JSON: {exc}. See {spec.docs_path}."
+        ) from exc
+    return {"top_level_type": type(payload).__name__}
+
+
+def _validate_bag(spec: RecordingDatasetSpec, path: Path) -> dict[str, Any]:
+    """Validate one staged ROS bag structurally (present and non-empty).
+
+    Full ROS bag decoding needs optional heavy dependencies, so the shape
+    contract only requires a non-empty file. Raises when the bag is zero bytes.
+
+    Returns:
+        A mapping with the ``size_bytes`` of the staged bag.
+    """
+
+    size_bytes = path.stat().st_size
+    if size_bytes <= 0:
+        raise spec.error_cls(
+            f"{spec.asset_id} ROS bag {path} is empty (0 bytes). Re-stage per {spec.docs_path}."
+        )
+    return {"size_bytes": size_bytes}
+
+
+def load_shape_contract(
+    spec: RecordingDatasetSpec, root: Path | str | None = None
+) -> dict[str, Any]:
+    """Load and validate the cheap recording-style shape contract.
+
+    Args:
+        spec: Dataset binding descriptor.
+        root: Explicit dataset root, or ``None`` to resolve via the shared
+            external-data registry.
+
+    Returns:
+        A structural contract mapping with recording counts and per-file shape
+        metadata (CSV row/column counts, JSON top-level type, bag byte sizes) and
+        the resolved license/readme files. No dataset content is asserted.
+
+    Raises:
+        RecordingDatasetError subclass: If the dataset is absent/incomplete or any
+            staged recording/export file is malformed.
+    """
+
+    paths = require_available(spec, root)
+    csv_shapes = {
+        path.relative_to(paths.root).as_posix(): _validate_csv(spec, path)
+        for path in paths.csv_files
+    }
+    json_shapes = {
+        path.relative_to(paths.root).as_posix(): _validate_json(spec, path)
+        for path in paths.json_files
+    }
+    bag_shapes = {
+        path.relative_to(paths.root).as_posix(): _validate_bag(spec, path)
+        for path in paths.bag_files
+    }
+    return {
+        "asset_id": spec.asset_id,
+        "root": str(paths.root),
+        "docs_path": paths.docs_path,
+        "recording_counts": {
+            "bag": len(paths.bag_files),
+            "csv": len(paths.csv_files),
+            "json": len(paths.json_files),
+        },
+        "csv_files": csv_shapes,
+        "json_files": json_shapes,
+        "bag_files": bag_shapes,
+        "license_or_readme": [
+            path.relative_to(paths.root).as_posix() for path in paths.license_or_readme
+        ],
+    }

--- a/robot_sf/data/external/scand.py
+++ b/robot_sf/data/external/scand.py
@@ -1,0 +1,84 @@
+"""SCAND socially-compliant navigation demonstrations shape contract.
+
+Plain-language summary: this loader only inspects locally staged SCAND files
+(ROS bags plus exported CSV/JSON tables and a license/README copy). It never
+downloads, vendors, or redistributes the terms-gated SCAND (Socially CompliAnt
+Navigation Dataset, Karnan et al. 2022) bytes. The contract is cheap and
+structural: it confirms the documented recording + license/readme layout exists
+and that each staged CSV/JSON export parses and each ROS bag is non-empty. It
+asserts no dataset content and makes no oracle-imitation claim.
+
+The expected layout, source, and staging workflow are documented in
+``docs/datasets/scand.md``; the availability contract is the ``scand-demos``
+registry entry in ``scripts/tools/manage_external_data.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.data.external import recording_shape_contract as _engine
+from robot_sf.data.external.recording_shape_contract import (
+    EXTERNAL_DATA_ROOT_ENV,
+    RecordingDatasetError,
+    RecordingDatasetPaths,
+    RecordingDatasetSpec,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SCAND_ASSET_ID = "scand-demos"
+ACQUISITION_DOC = "docs/datasets/scand.md"
+
+__all__ = [
+    "ACQUISITION_DOC",
+    "EXTERNAL_DATA_ROOT_ENV",
+    "SCAND_ASSET_ID",
+    "ScandDataError",
+    "dataset_root",
+    "is_available",
+    "load_shape_contract",
+    "require_available",
+]
+
+
+class ScandDataError(RecordingDatasetError):
+    """Raised when staged SCAND data is present but structurally invalid."""
+
+
+_SPEC = RecordingDatasetSpec(
+    asset_id=SCAND_ASSET_ID,
+    title="SCAND socially compliant navigation demonstrations",
+    docs_path=ACQUISITION_DOC,
+    error_cls=ScandDataError,
+)
+
+
+def dataset_root(root: Path | str | None = None) -> Path:
+    """Return the SCAND dataset root, honoring the shared external-data root."""
+
+    return _engine.resolve_root(_SPEC, root)
+
+
+def is_available(root: Path | str | None = None) -> bool:
+    """Return whether the documented SCAND recording layout is staged."""
+
+    return _engine.is_available(_SPEC, root)
+
+
+def require_available(root: Path | str | None = None) -> RecordingDatasetPaths:
+    """Return resolved SCAND files or raise an actionable acquisition error."""
+
+    return _engine.require_available(_SPEC, root)
+
+
+def load_shape_contract(root: Path | str | None = None) -> dict[str, Any]:
+    """Load and validate the cheap SCAND recording-style shape contract.
+
+    Returns:
+        A structural contract mapping with recording counts and per-file shape
+        metadata; see :func:`recording_shape_contract.load_shape_contract`.
+    """
+
+    return _engine.load_shape_contract(_SPEC, root)

--- a/tests/data/external/test_crowdbot_shape.py
+++ b/tests/data/external/test_crowdbot_shape.py
@@ -1,0 +1,142 @@
+"""Skip-if-absent shape-contract tests for CrowdBot external data.
+
+These tests never require the research-access-gated CrowdBot bytes. Exactly one
+test path depends on locally staged real data and skips when it is absent; every
+other test builds a synthetic recording-style layout under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.data.external import crowdbot
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _stage_minimal_dataset(root: Path) -> None:
+    """Create a tiny documented CrowdBot layout satisfying the registry groups.
+
+    Writes one non-empty ROS bag, one rectangular CSV export, one valid JSON
+    metadata file, and a local terms/README copy.
+    """
+
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "qolo_run.bag").write_bytes(b"#ROSBAG V2.0\n\x00\x01")
+    (root / "tracks.csv").write_text("t,id,x,y\n0.0,1,2.0,3.0\n0.1,1,2.1,3.1\n", encoding="utf-8")
+    (root / "meta.json").write_text('{"robot": "qolo", "site": "lausanne"}', encoding="utf-8")
+    (root / "README.md").write_text(
+        "Local copy of CrowdBot research-use terms.\n", encoding="utf-8"
+    )
+
+
+def test_crowdbot_absent_data_skips(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """External clones without staged CrowdBot bytes skip instead of failing."""
+
+    monkeypatch.setenv(crowdbot.EXTERNAL_DATA_ROOT_ENV, str(tmp_path))
+    if not crowdbot.is_available():
+        pytest.skip("external dataset not staged")
+    pytest.fail("temporary empty external-data root unexpectedly satisfied CrowdBot contract")
+
+
+def test_crowdbot_shape_contract_with_synthetic_layout(tmp_path: Path) -> None:
+    """A complete synthetic layout resolves and produces recording shape metadata."""
+
+    root = tmp_path / "crowdbot"
+    _stage_minimal_dataset(root)
+
+    assert crowdbot.is_available(root)
+    paths = crowdbot.require_available(root)
+    assert len(paths.bag_files) == 1
+    assert len(paths.csv_files) == 1
+    assert len(paths.json_files) == 1
+    assert len(paths.license_or_readme) == 1
+
+    contract = crowdbot.load_shape_contract(root)
+    assert contract["asset_id"] == "crowdbot"
+    assert contract["docs_path"] == "docs/datasets/crowdbot.md"
+    assert contract["recording_counts"] == {"bag": 1, "csv": 1, "json": 1}
+    assert contract["csv_files"]["tracks.csv"] == {"row_count": 3, "column_count": 4}
+    assert contract["json_files"]["meta.json"]["top_level_type"] == "dict"
+    assert contract["bag_files"]["qolo_run.bag"]["size_bytes"] > 0
+    assert contract["license_or_readme"] == ["README.md"]
+
+
+def test_crowdbot_missing_license_is_unavailable(tmp_path: Path) -> None:
+    """A layout without a license/readme copy is unavailable and raises with docs pointer."""
+
+    root = tmp_path / "crowdbot"
+    _stage_minimal_dataset(root)
+    (root / "README.md").unlink()
+
+    assert not crowdbot.is_available(root)
+    with pytest.raises(crowdbot.CrowdBotDataError, match="docs/datasets/crowdbot.md"):
+        crowdbot.require_available(root)
+
+
+def test_crowdbot_missing_recording_is_unavailable(tmp_path: Path) -> None:
+    """A layout without any recording/export file is unavailable."""
+
+    root = tmp_path / "crowdbot"
+    root.mkdir(parents=True)
+    (root / "README.md").write_text("terms only\n", encoding="utf-8")
+
+    assert not crowdbot.is_available(root)
+    with pytest.raises(crowdbot.CrowdBotDataError):
+        crowdbot.require_available(root)
+
+
+def test_crowdbot_absent_root_error_names_docs(tmp_path: Path) -> None:
+    """An absent dataset root fails closed with an actionable docs pointer."""
+
+    root = tmp_path / "crowdbot"
+    assert not crowdbot.is_available(root)
+    with pytest.raises(crowdbot.CrowdBotDataError, match="docs/datasets/crowdbot.md"):
+        crowdbot.require_available(root)
+
+
+def test_crowdbot_empty_csv_fails_closed(tmp_path: Path) -> None:
+    """An empty staged CSV export fails closed with an actionable error."""
+
+    root = tmp_path / "crowdbot"
+    _stage_minimal_dataset(root)
+    (root / "tracks.csv").write_text("", encoding="utf-8")
+
+    with pytest.raises(crowdbot.CrowdBotDataError, match="no non-empty data rows"):
+        crowdbot.load_shape_contract(root)
+
+
+def test_crowdbot_ragged_csv_fails_closed(tmp_path: Path) -> None:
+    """A non-rectangular CSV export fails closed with an actionable error."""
+
+    root = tmp_path / "crowdbot"
+    _stage_minimal_dataset(root)
+    (root / "tracks.csv").write_text("t,id,x,y\n0.0,1,2.0\n", encoding="utf-8")
+
+    with pytest.raises(crowdbot.CrowdBotDataError, match="not rectangular"):
+        crowdbot.load_shape_contract(root)
+
+
+def test_crowdbot_malformed_json_fails_closed(tmp_path: Path) -> None:
+    """A malformed JSON export fails closed with an actionable error."""
+
+    root = tmp_path / "crowdbot"
+    _stage_minimal_dataset(root)
+    (root / "meta.json").write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(crowdbot.CrowdBotDataError, match="not valid JSON"):
+        crowdbot.load_shape_contract(root)
+
+
+def test_crowdbot_empty_bag_fails_closed(tmp_path: Path) -> None:
+    """A zero-byte ROS bag fails closed with an actionable error."""
+
+    root = tmp_path / "crowdbot"
+    _stage_minimal_dataset(root)
+    (root / "qolo_run.bag").write_bytes(b"")
+
+    with pytest.raises(crowdbot.CrowdBotDataError, match="empty"):
+        crowdbot.load_shape_contract(root)

--- a/tests/data/external/test_scand_shape.py
+++ b/tests/data/external/test_scand_shape.py
@@ -1,0 +1,142 @@
+"""Skip-if-absent shape-contract tests for SCAND external data.
+
+These tests never require the terms-gated SCAND bytes. Exactly one test path
+depends on locally staged real data and skips when it is absent; every other test
+builds a synthetic recording-style layout under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.data.external import scand
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _stage_minimal_dataset(root: Path) -> None:
+    """Create a tiny documented SCAND layout satisfying the registry groups.
+
+    Writes one non-empty ROS bag demonstration, one rectangular CSV export, one
+    valid JSON metadata file, and a local terms/README copy. A nested demo
+    subdirectory exercises recursive discovery.
+    """
+
+    demo_dir = root / "demonstrations"
+    demo_dir.mkdir(parents=True, exist_ok=True)
+    (demo_dir / "spot_demo.bag").write_bytes(b"#ROSBAG V2.0\n\x00\x01")
+    (root / "commands.csv").write_text("t,v,omega\n0.0,0.5,0.0\n0.1,0.5,0.1\n", encoding="utf-8")
+    (root / "meta.json").write_text('{"platform": "spot", "hours": 8.7}', encoding="utf-8")
+    (root / "LICENSE.txt").write_text("Local copy of SCAND dataset terms.\n", encoding="utf-8")
+
+
+def test_scand_absent_data_skips(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """External clones without staged SCAND bytes skip instead of failing."""
+
+    monkeypatch.setenv(scand.EXTERNAL_DATA_ROOT_ENV, str(tmp_path))
+    if not scand.is_available():
+        pytest.skip("external dataset not staged")
+    pytest.fail("temporary empty external-data root unexpectedly satisfied SCAND contract")
+
+
+def test_scand_shape_contract_with_synthetic_layout(tmp_path: Path) -> None:
+    """A complete synthetic layout resolves and produces recording shape metadata."""
+
+    root = tmp_path / "scand_demos"
+    _stage_minimal_dataset(root)
+
+    assert scand.is_available(root)
+    paths = scand.require_available(root)
+    assert len(paths.bag_files) == 1
+    assert len(paths.csv_files) == 1
+    assert len(paths.json_files) == 1
+    assert len(paths.license_or_readme) == 1
+
+    contract = scand.load_shape_contract(root)
+    assert contract["asset_id"] == "scand-demos"
+    assert contract["docs_path"] == "docs/datasets/scand.md"
+    assert contract["recording_counts"] == {"bag": 1, "csv": 1, "json": 1}
+    assert contract["csv_files"]["commands.csv"] == {"row_count": 3, "column_count": 3}
+    assert contract["json_files"]["meta.json"]["top_level_type"] == "dict"
+    assert contract["bag_files"]["demonstrations/spot_demo.bag"]["size_bytes"] > 0
+    assert contract["license_or_readme"] == ["LICENSE.txt"]
+
+
+def test_scand_missing_license_is_unavailable(tmp_path: Path) -> None:
+    """A layout without a license/readme copy is unavailable and raises with docs pointer."""
+
+    root = tmp_path / "scand_demos"
+    _stage_minimal_dataset(root)
+    (root / "LICENSE.txt").unlink()
+
+    assert not scand.is_available(root)
+    with pytest.raises(scand.ScandDataError, match="docs/datasets/scand.md"):
+        scand.require_available(root)
+
+
+def test_scand_missing_recording_is_unavailable(tmp_path: Path) -> None:
+    """A layout without any recording/export file is unavailable."""
+
+    root = tmp_path / "scand_demos"
+    root.mkdir(parents=True)
+    (root / "LICENSE.txt").write_text("terms only\n", encoding="utf-8")
+
+    assert not scand.is_available(root)
+    with pytest.raises(scand.ScandDataError):
+        scand.require_available(root)
+
+
+def test_scand_absent_root_error_names_docs(tmp_path: Path) -> None:
+    """An absent dataset root fails closed with an actionable docs pointer."""
+
+    root = tmp_path / "scand_demos"
+    assert not scand.is_available(root)
+    with pytest.raises(scand.ScandDataError, match="docs/datasets/scand.md"):
+        scand.require_available(root)
+
+
+def test_scand_empty_csv_fails_closed(tmp_path: Path) -> None:
+    """An empty staged CSV export fails closed with an actionable error."""
+
+    root = tmp_path / "scand_demos"
+    _stage_minimal_dataset(root)
+    (root / "commands.csv").write_text("", encoding="utf-8")
+
+    with pytest.raises(scand.ScandDataError, match="no non-empty data rows"):
+        scand.load_shape_contract(root)
+
+
+def test_scand_ragged_csv_fails_closed(tmp_path: Path) -> None:
+    """A non-rectangular CSV export fails closed with an actionable error."""
+
+    root = tmp_path / "scand_demos"
+    _stage_minimal_dataset(root)
+    (root / "commands.csv").write_text("t,v,omega\n0.0,0.5\n", encoding="utf-8")
+
+    with pytest.raises(scand.ScandDataError, match="not rectangular"):
+        scand.load_shape_contract(root)
+
+
+def test_scand_malformed_json_fails_closed(tmp_path: Path) -> None:
+    """A malformed JSON export fails closed with an actionable error."""
+
+    root = tmp_path / "scand_demos"
+    _stage_minimal_dataset(root)
+    (root / "meta.json").write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(scand.ScandDataError, match="not valid JSON"):
+        scand.load_shape_contract(root)
+
+
+def test_scand_empty_bag_fails_closed(tmp_path: Path) -> None:
+    """A zero-byte ROS bag fails closed with an actionable error."""
+
+    root = tmp_path / "scand_demos"
+    _stage_minimal_dataset(root)
+    (root / "demonstrations" / "spot_demo.bag").write_bytes(b"")
+
+    with pytest.raises(scand.ScandDataError, match="empty"):
+        scand.load_shape_contract(root)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds license-safe **CrowdBot** and **SCAND** shape-contract loaders plus
  skip-if-absent / malformed-layout tests — public slice (b) of the #4224 external-data program.
- **Why now:** The 2026-07-03 maintainer ruling on issue #4224 splits each dataset family into
  (a) registry + acquisition doc and (b) shape-contract loader + skip-if-absent tests. Registry
  entries for all five assets merged in PR #4238; ATC / ETH-UCY / inD loaders are already merged.
  CrowdBot and SCAND are the remaining (b) slices for this family. This is a **progression slice**
  adding a nameable new capability (two new loaders), so it proceeds under the issue plan rather
  than being a micro-guard (fragmentation guard 6c exemption).
- **Claim boundary:** Registry/contract only. Loaders only inspect **locally staged** files and
  never download, vendor, or redistribute dataset bytes. A passing shape contract is local
  structural evidence only — not ingestion, benchmark, or paper/dissertation evidence.
- **Required validation:** `uv run pytest tests/data/external/ -q` and
  `uv run ruff check robot_sf/data/external tests/data/external` (results below).
- **Remaining blocker:** Private-side acquisition/seeding (slice c) and `expected_tree_sha256`
  pinning stay with maintainers/private-ops after local staging under each dataset's terms.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4224

## Contract delta

- **New modules (no schema change to the registry):**
  - `robot_sf/data/external/recording_shape_contract.py` — reusable engine for recording-style
    datasets; resolves availability via the canonical `check_asset` registry contract.
  - `robot_sf/data/external/crowdbot.py`, `robot_sf/data/external/scand.py` — thin per-dataset
    wrappers exposing `is_available` / `require_available` / `load_shape_contract` and a
    dataset-specific `*DataError`.
- **New fail-closed behavior:** `load_shape_contract` raises for an absent/incomplete layout,
  an empty or non-rectangular CSV export, an unparseable JSON export, or a zero-byte ROS bag —
  each error names the acquisition doc. `is_available` returns `False` (skip, not fail) when data
  is absent or the registry-required groups are unmatched.
- **Compatibility impact:** None. No existing loader, registry entry, or `AssetSpec` field is
  modified; `manage_external_data.py` is unchanged. CrowdBot/SCAND registry entries (from #4238)
  keep `auto_download_allowed=False` and `expected_tree_sha256_status=pending_first_staging`.

## Scope

In scope: CrowdBot + SCAND shape-contract loaders, skip-if-absent/malformed-layout tests,
acquisition/layout docs (`docs/datasets/crowdbot.md`, `docs/datasets/scand.md`), and a loader-status
note in `docs/context/issue_4224_external_dataset_registry.md`.

Out of scope (explicitly not done): downloading or staging raw data, automated acquisition,
`expected_tree_sha256` provenance pinning, benchmark consumers, private-ops/Slurm runs, **no full
benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.**

## Validation

```text
$ uv run pytest tests/data/external/ -q
48 passed, 6 skipped
  (the 6 skips are the skip-if-absent real-data paths: no external data staged in CI)

$ uv run ruff check robot_sf/data/external tests/data/external
All checks passed!
```

New tests: `tests/data/external/test_crowdbot_shape.py`,
`tests/data/external/test_scand_shape.py` (9 tests each; 1 skip-if-absent real-data path per file,
8 synthetic-layout cases covering resolve, missing-license, missing-recording, absent-root,
empty/ragged CSV, malformed JSON, and empty ROS bag).

## Freshness / late-guidance check

Re-checked issue #4224 comments immediately before opening: newest maintainer comment is the
2026-07-03T12:14Z program ruling (incorporated). No newer guidance; no open PR covers CrowdBot/SCAND
loaders or issue #4224.

<details>
<summary>Downstream propagation & governance</summary>

- **State propagation:** Added a "Shape-contract loaders (public slice b)" status table to
  `docs/context/issue_4224_external_dataset_registry.md` (single durable surface; this lane's
  authorization disables issue/PR comments).
- **Canonical-owner:** CrowdBot and SCAND are the only two structurally identical recording-style
  members, so they share one new engine rather than forking; ATC/ETH-UCY/inD loaders remain distinct
  because their formats differ. No duplicate of an existing capability is introduced.
- **Research Result Guidance:** NA — support/contract slice, no research claim. A passing contract is
  local structural evidence only.
- **CHANGELOG:** Updated under Unreleased → Added.
- **Follow-up (not in this PR):** private-side acquire → seed on hub → fetch on spoke (slice c), then
  pin `expected_tree_sha256` after staging review.

</details>
