### PR TITLE
feat(#3466): batch-summary AMMV feasibility claim-boundary parity + doc-drift fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Extended the **AMMV feasibility batch-summary artifact block** with the claim-boundary markers it
+  was missing, so a consumer reading only the summary sees the same non-hardware boundary as the
+  per-episode payload (#3466). `robot_sf/benchmark/map_runner_batch_summary.py` now emits
+  `algorithm_metadata_contract.ammv_feasibility` via the new pure helper
+  `build_ammv_feasibility_summary`, which adds `evidence_kind: "diagnostic_proxy"` and a
+  `status` field (`"available"` / `"no_ammv_episodes"`) alongside the existing
+  `proxy_kind: "internal_non_hardware"` and the four folded fields (`min_stability_margin`,
+  `tip_over_violation`, `n_curvature_violations`, `feasible`). Folds stay worst-case (minimum
+  margin, OR tip-over, all-episodes-feasible), so a single tip-over-prone episode is never averaged
+  away. Additive and backward-compatible; internal proxy only — **no** hardware-calibrated AMMV
+  safety claim. Refreshed `docs/context/issue_3466_ammv_command_feasibility.md` (the note previously
+  described the artifact wiring as deferred; it landed in #3845).
+
 * Added license-safe **CrowdBot and SCAND shape-contract loaders** plus skip-if-absent tests for the
   #4224 external-data program (public slice b). `robot_sf/data/external/crowdbot.py` and
   `robot_sf/data/external/scand.py` only inspect locally staged files — they never download, vendor,

--- a/docs/context/issue_3466_ammv_command_feasibility.md
+++ b/docs/context/issue_3466_ammv_command_feasibility.md
@@ -1,7 +1,13 @@
-# Issue #3466 — AMMV command-feasibility / tip-over evaluator (increment)
+# Issue #3466 — AMMV command-feasibility / tip-over evaluator + artifact wiring
 
 **Status:** diagnostic / internal-proxy. Thresholds are explicit non-hardware assumptions; no
-paper-facing AMMV safety claim before benchmark evidence exists.
+paper-facing AMMV safety claim before benchmark evidence exists. Artifact-pipeline wiring has
+**landed** (evaluator #3600, per-episode + batch wiring #3845, batch claim-boundary parity #3466
+follow-up).
+
+> **AMMV** = Autonomous Micromobility Vehicle (three-wheeled tadpole layout). See
+> [`glossary.md`](../glossary.md) if unfamiliar. Everything here is an *internal proxy*: it flags
+> commands a three-wheeled platform likely could not execute, **not** a hardware-calibrated claim.
 
 ## What this is
 
@@ -22,19 +28,53 @@ consistent (a test cross-checks this).
 at near-zero speed), and an overall `feasible` verdict. `AmmvFeasibilityParams` defaults align with
 the benchmark-surface stability geometry.
 
-## Scope boundary
+`evaluate_artifact_command_feasibility(commands)` adapts the pure evaluator to the map-runner
+artifact surface (per-step mappings with `linear_velocity` / `angular_velocity`) and fails closed
+(`status: missing_inputs`, `feasible: false`, `tip_over_violation: true`) when commands are missing,
+malformed, or holonomic-only — the three-wheeled proxy cannot infer yaw feasibility from `vx/vy`.
 
-Pure and side-effect free — no planner-behavior change. Surfacing these fields in benchmark
-artifacts / evidence summaries (the artifact-pipeline wiring, Tier-2) is the deliberate deferred
-follow-up.
+## Artifact wiring (where the fields appear)
+
+- **Per-episode** (`robot_sf/benchmark/map_runner_episode.py`): `run_map_episode` records the
+  evaluator output under `algorithm_metadata.ammv_feasibility` for every episode
+  (`algo_meta["ammv_feasibility"] = evaluate_artifact_command_feasibility(ammv_command_actions)`).
+  Additive under `algorithm_metadata`, so existing episode rows stay backward-compatible.
+- **Batch summary** (`robot_sf/benchmark/map_runner_batch_summary.py`):
+  `accumulate_batch_metadata` folds per-episode payloads into `feasibility_totals`;
+  `build_ammv_feasibility_summary(feasibility_totals)` emits the aggregate
+  `algorithm_metadata_contract.ammv_feasibility` block.
+
+### Claim boundary carried on both surfaces
+
+Both the per-episode payload and the batch-summary block carry the same claim-boundary markers so a
+consumer reading **only** the summary cannot mistake the aggregate for calibrated hardware evidence:
+
+- `evidence_kind: "diagnostic_proxy"`
+- `proxy_kind: "internal_non_hardware"`
+- `status: "available"` (or `"no_ammv_episodes"` at batch level when nothing contributed, so a
+  `None` margin with `feasible: false` is interpretable rather than silently ambiguous).
+
+Batch folds are **worst-case**, never means: `min_stability_margin` is the minimum across episodes,
+`tip_over_violation` is OR, and `feasible` requires every contributing episode to be feasible.
 
 ## Tests
 
-`tests/benchmark/test_ammv_feasibility.py` (7 tests): feasible sequence passes, over-yaw trips
-tip-over, excess curvature flagged, in-place yaw limit, agreement with
-`metrics.evaluate_stability_margin`, and length/empty/param validation.
+`tests/benchmark/test_ammv_feasibility.py`:
+
+- Evaluator: feasible sequence passes, over-yaw trips tip-over, excess curvature flagged, in-place
+  yaw limit, agreement with `metrics.evaluate_stability_margin`, length/empty/param validation,
+  non-finite fail-closed.
+- Artifact adapter: versioned-field extraction, fail-closed for missing yaw-rate / invalid inputs.
+- Batch fold: `test_batch_metadata_folds_ammv_feasibility_fields` (totals), plus
+  `test_batch_summary_block_carries_claim_boundary_and_worst_case_fields` and
+  `test_batch_summary_block_fails_closed_without_ammv_episodes` (summary block: claim boundary +
+  worst-case reduction + no-episode fail-closed).
+
+`tests/benchmark/test_map_runner_utils.py` asserts the per-episode record exposes the versioned
+`ammv_feasibility` block with the four acceptance fields.
 
 ## Related
 
 - Tip-over computation source of truth + #3479/#3587 reconciliation: `robot_sf/benchmark/metrics.py`,
   `robot_sf/robot/rollover_proxy.py`.
+- Runtime rollover proxy (in-sim, complementary surface): #3479.

--- a/docs/context/issue_3466_state.yaml
+++ b/docs/context/issue_3466_state.yaml
@@ -1,0 +1,33 @@
+# Append-only execution-state ledger for issue #3466
+# (AMMV feasibility fields wired into benchmark artifacts).
+# Newest entry last. Schema/behavior changes live in the PR diff; this file only
+# records slice lineage and remaining-work state so the canonical surface is one file.
+schema_version: issue-state.v1
+issue: 3466
+
+entries:
+  - date: "2026-07-04"
+    slice: "Batch-summary AMMV claim-boundary parity + doc-drift correction"
+    pr_branch: "issue-3466-ammv-batch-claim-boundary-parity"
+    delivered:
+      - "Extracted build_ammv_feasibility_summary() as a pure, unit-testable helper in
+         map_runner_batch_summary.py."
+      - "Added evidence_kind='diagnostic_proxy' and status ('available'/'no_ammv_episodes') to the
+         batch-summary ammv_feasibility block for claim-boundary parity with the per-episode payload."
+      - "Focused tests: batch-summary claim boundary + worst-case fold + no-episode fail-closed."
+      - "Refreshed docs/context/issue_3466_ammv_command_feasibility.md (previously said the artifact
+         wiring was deferred; it landed in #3845)."
+    acceptance_status: "met"
+    acceptance_notes: >
+      Core acceptance criteria (per-episode + batch fields min_stability_margin, tip_over_violation,
+      n_curvature_violations, feasible; internal_non_hardware; backward-compatible) were already
+      satisfied by evaluator #3600 and wiring #3845. This slice closes the batch-surface claim-
+      boundary gap and the stale context note.
+    out_of_scope:
+      - "No new proxy math, no runtime rollover behavior (that is #3479)."
+      - "No hardware AMMV claim, no external actuation data, no benchmark campaign run."
+      - "No Slurm/GPU submission, no paper/dissertation claim edits."
+    remaining_work:
+      - "None required for the artifact-wiring scope. Any future calibration of the internal proxy
+         envelope remains blocked on real AMMV actuation data (#1585/#2000 provenance), and stays a
+         separate research lane, not artifact wiring."

--- a/robot_sf/benchmark/map_runner_batch_summary.py
+++ b/robot_sf/benchmark/map_runner_batch_summary.py
@@ -15,6 +15,7 @@ from robot_sf.benchmark.map_runner_provenance import map_result_provenance
 from robot_sf.benchmark.utils import attach_track_metadata
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
 
@@ -203,6 +204,48 @@ def merge_runtime_algorithm_contract(  # noqa: C901
     return base_contract
 
 
+def build_ammv_feasibility_summary(feasibility_totals: Mapping[str, float]) -> dict[str, Any]:
+    """Fold per-episode AMMV feasibility totals into the batch-summary artifact block (issue #3466).
+
+    The per-episode ``ammv_feasibility.v1`` payload carries the claim-boundary markers
+    (``evidence_kind`` / ``proxy_kind`` / ``status``) that keep this internal proxy from being read
+    as calibrated hardware AMMV safety evidence. This helper re-attaches the same markers to the
+    batch aggregate so a consumer that reads only the summary sees the identical boundary, then folds
+    the four acceptance fields conservatively:
+
+    - ``min_stability_margin`` is the worst-case (minimum) margin across contributing episodes, not a
+      mean, so a single tip-over-prone episode is never averaged away.
+    - ``tip_over_violation`` / ``feasible`` are worst-case AND/OR reductions: any tip-over marks the
+      batch, and ``feasible`` requires every contributing episode to be feasible.
+    - ``status`` distinguishes a real aggregate from the fail-closed "no eligible episodes" case, so
+      a ``None`` margin with ``feasible: false`` is interpretable rather than silently ambiguous.
+
+    Returns:
+        The versioned ``ammv_feasibility.v1`` batch-summary block marked ``internal_non_hardware``.
+    """
+    ammv_episode_count = int(feasibility_totals.get("ammv_episode_count", 0))
+    ammv_margin = float(feasibility_totals.get("ammv_min_stability_margin", float("inf")))
+    return {
+        "schema_version": "ammv_feasibility.v1",
+        "evidence_kind": "diagnostic_proxy",
+        "proxy_kind": "internal_non_hardware",
+        "status": "available" if ammv_episode_count > 0 else "no_ammv_episodes",
+        "episode_count": ammv_episode_count,
+        "commands_evaluated": int(feasibility_totals.get("ammv_commands_evaluated", 0)),
+        "min_stability_margin": (
+            ammv_margin if ammv_episode_count > 0 and ammv_margin != float("inf") else None
+        ),
+        "tip_over_violation": bool(
+            int(feasibility_totals.get("ammv_tip_over_episode_count", 0)) > 0
+        ),
+        "n_curvature_violations": int(feasibility_totals.get("ammv_curvature_violation_count", 0)),
+        "feasible": bool(
+            ammv_episode_count > 0
+            and int(feasibility_totals.get("ammv_feasible_episode_count", 0)) == ammv_episode_count
+        ),
+    }
+
+
 def build_completed_batch_summary(  # noqa: PLR0913
     *,
     algo_contract: dict[str, Any],
@@ -321,25 +364,7 @@ def build_completed_batch_summary(  # noqa: PLR0913
         "max_abs_delta_linear": float(feasibility_totals["max_abs_delta_linear"]),
         "max_abs_delta_angular": float(feasibility_totals["max_abs_delta_angular"]),
     }
-    ammv_episode_count = int(feasibility_totals.get("ammv_episode_count", 0))
-    ammv_margin = float(feasibility_totals.get("ammv_min_stability_margin", float("inf")))
-    algo_contract["ammv_feasibility"] = {
-        "schema_version": "ammv_feasibility.v1",
-        "proxy_kind": "internal_non_hardware",
-        "episode_count": ammv_episode_count,
-        "commands_evaluated": int(feasibility_totals.get("ammv_commands_evaluated", 0)),
-        "min_stability_margin": (
-            ammv_margin if ammv_episode_count > 0 and ammv_margin != float("inf") else None
-        ),
-        "tip_over_violation": bool(
-            int(feasibility_totals.get("ammv_tip_over_episode_count", 0)) > 0
-        ),
-        "n_curvature_violations": int(feasibility_totals.get("ammv_curvature_violation_count", 0)),
-        "feasible": bool(
-            ammv_episode_count > 0
-            and int(feasibility_totals.get("ammv_feasible_episode_count", 0)) == ammv_episode_count
-        ),
-    }
+    algo_contract["ammv_feasibility"] = build_ammv_feasibility_summary(feasibility_totals)
 
     summary = {
         "total_jobs": total_jobs,

--- a/tests/benchmark/test_ammv_feasibility.py
+++ b/tests/benchmark/test_ammv_feasibility.py
@@ -12,7 +12,10 @@ from robot_sf.benchmark.ammv_feasibility import (
     evaluate_command_feasibility,
 )
 from robot_sf.benchmark.map_runner_batch_runner import _initial_feasibility_totals
-from robot_sf.benchmark.map_runner_batch_summary import accumulate_batch_metadata
+from robot_sf.benchmark.map_runner_batch_summary import (
+    accumulate_batch_metadata,
+    build_ammv_feasibility_summary,
+)
 
 
 def test_feasible_command_sequence_is_classified_feasible() -> None:
@@ -178,6 +181,58 @@ def test_batch_metadata_folds_ammv_feasibility_fields() -> None:
     assert totals["ammv_tip_over_episode_count"] == 0
     assert totals["ammv_curvature_violation_count"] == 1
     assert totals["ammv_feasible_episode_count"] == 0
+
+
+def test_batch_summary_block_carries_claim_boundary_and_worst_case_fields() -> None:
+    """Batch summary AMMV block mirrors the per-episode claim boundary and folds worst-case."""
+    totals = _initial_feasibility_totals()
+    # Two contributing episodes: one feasible with a larger margin, one tip-over with a smaller
+    # margin. The worst case (tip-over, min margin) must dominate the aggregate.
+    for margin, tip_over, feasible, curvature in ((0.30, False, True, 0), (0.05, True, False, 2)):
+        accumulate_batch_metadata(
+            {
+                "algorithm_metadata": {
+                    "ammv_feasibility": {
+                        "schema_version": AMMV_FEASIBILITY_SCHEMA,
+                        "proxy_kind": "internal_non_hardware",
+                        "n_commands": 4,
+                        "min_stability_margin": margin,
+                        "tip_over_violation": tip_over,
+                        "n_curvature_violations": curvature,
+                        "feasible": feasible,
+                    }
+                }
+            },
+            feasibility_totals=totals,
+        )
+
+    block = build_ammv_feasibility_summary(totals)
+
+    # Claim-boundary parity with the per-episode payload: a consumer reading only the batch
+    # summary must still see the diagnostic-proxy / non-hardware markers.
+    assert block["schema_version"] == AMMV_FEASIBILITY_SCHEMA
+    assert block["evidence_kind"] == "diagnostic_proxy"
+    assert block["proxy_kind"] == "internal_non_hardware"
+    assert block["status"] == "available"
+    # Worst-case reductions across the two episodes.
+    assert block["episode_count"] == 2
+    assert block["commands_evaluated"] == 8
+    assert block["min_stability_margin"] == pytest.approx(0.05)
+    assert block["tip_over_violation"] is True
+    assert block["n_curvature_violations"] == 2
+    assert block["feasible"] is False
+
+
+def test_batch_summary_block_fails_closed_without_ammv_episodes() -> None:
+    """With no contributing episodes the batch block fails closed and stays interpretable."""
+    block = build_ammv_feasibility_summary(_initial_feasibility_totals())
+
+    assert block["evidence_kind"] == "diagnostic_proxy"
+    assert block["proxy_kind"] == "internal_non_hardware"
+    assert block["status"] == "no_ammv_episodes"
+    assert block["episode_count"] == 0
+    assert block["min_stability_margin"] is None
+    assert block["feasible"] is False
 
 
 def test_invalid_params_rejected() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** The batch-summary `algorithm_metadata_contract.ammv_feasibility` block now carries the same claim-boundary markers as the per-episode payload. Extracted the block into a pure, unit-testable helper `build_ammv_feasibility_summary()`.
- **Why now:** Issue [#3466](https://github.com/ll7/robot_sf_ll7/issues/3466) narrowed to artifact/evidence wiring. The evaluator (#3600) and per-episode + batch wiring (#3845) already landed, so the four AMMV fields (`min_stability_margin`, `tip_over_violation`, `n_curvature_violations`, `feasible`) are present at both surfaces and marked `internal_non_hardware`. The remaining gap: a consumer reading **only** the batch summary could not see the `evidence_kind: diagnostic_proxy` marker that guards against reading this internal proxy as calibrated hardware AMMV safety evidence — exactly the maintainer's "prevent paper-facing AMMV safety claims" acceptance criterion.
- **Claim boundary:** Internal proxy only (`evidence_kind: diagnostic_proxy`, `proxy_kind: internal_non_hardware`). **No** hardware-calibrated AMMV claim; thresholds are explicit non-hardware assumptions. Envelope calibration remains blocked on real AMMV actuation data (#1585/#2000).
- **Required validation:** focused artifact-schema/fixture tests (below), CPU only.
- **Remaining blocker:** none for the artifact-wiring scope; the core acceptance criteria were already met by #3600/#3845 and this slice closes the batch-surface claim-boundary gap + a stale context note.

## Contract delta

New fields on the batch-summary `ammv_feasibility` block (additive, backward-compatible):

| field | value | purpose |
| --- | --- | --- |
| `evidence_kind` | `"diagnostic_proxy"` | claim-boundary parity with the per-episode payload |
| `status` | `"available"` / `"no_ammv_episodes"` | makes a `None` margin + `feasible: false` interpretable (fail-closed when no episodes contribute) |

Existing keys (`schema_version`, `proxy_kind`, `episode_count`, `commands_evaluated`, `min_stability_margin`, `tip_over_violation`, `n_curvature_violations`, `feasible`) are unchanged. No new fail-closed blockers on the benchmark run path; folds stay worst-case (minimum margin, OR tip-over, all-episodes-feasible) so a single tip-over-prone episode is never averaged away.

## Scope

- **In scope:** batch-summary claim-boundary parity for the already-wired `ammv_feasibility.v1` fields; refresh of the stale context note (it described the artifact wiring as deferred — it landed in #3845); append-only `docs/context/issue_3466_state.yaml`.
- **Out of scope (explicit):** no new proxy math; no runtime rollover behavior (that is #3479); no hardware AMMV claim; no external actuation data; **no full benchmark campaign run**; **no Slurm/GPU submission**; **no paper/dissertation claim edits**.

## Validation

```
scripts/dev/run_worktree_shared_venv.sh -- uv run pytest \
  tests/benchmark/test_ammv_feasibility.py tests/benchmark/test_map_runner_utils.py -q
# -> 149 passed

scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check \
  robot_sf/benchmark/map_runner_batch_summary.py tests/benchmark/test_ammv_feasibility.py
# -> All checks passed!
```

New tests: `test_batch_summary_block_carries_claim_boundary_and_worst_case_fields` (claim boundary + worst-case fold across two episodes) and `test_batch_summary_block_fails_closed_without_ammv_episodes` (no-episode fail-closed).

<details>
<summary>Governance / propagation appendix</summary>

- **Fragmentation guard:** #3600 and #3845 merged 2026-06-25 / 2026-06-29 (both > 24h ago), so this is not a same-day micro-guard burst. This is a nameable progression slice (batch-surface claim-boundary parity) toward the issue's "prevent paper-facing AMMV safety claims" criterion, not another checker.
- **State propagation:** issue commenting was not authorized for this run, so state is recorded in the append-only `docs/context/issue_3466_state.yaml` and the refreshed context note rather than an issue comment.
- **Downstream propagation:** parent issue #3466 (this PR), context note refreshed, CHANGELOG updated. No leaderboard/registry/model-provenance surface affected (internal diagnostic proxy, no benchmark evidence claim).
- **Research result guidance:** `NA` — this is artifact claim-boundary wiring, not a research claim; the diagnostic proxy asserts no benchmark/paper result.

Closes #3466.
</details>
