### PR TITLE
#3207: pre-register full fixed-scope fidelity-sensitivity preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a **full fixed-scope fidelity-sensitivity preflight** for issue #3207 that pre-registers the
+  simulator-fidelity sensitivity campaign before launch (`robot_sf/benchmark/fidelity_fixed_scope_preflight.py`,
+  CLI `scripts/benchmark/preflight_fidelity_fixed_scope.py`). It materializes the explicit run plan
+  (planner groups × axis variants × seeds over the fixed scenario set), resolves every planner group
+  against the canonical `algorithm_readiness` catalog and **fails closed** on unavailable/placeholder
+  planners, and validates the primary (ranking) metric is identifiable by contract (failing closed on
+  metrics pre-declared non-identifiable/zero-variance per #3299). It emits a launch/readiness packet
+  only — `preflight_ready` is a pre-registration gate, not execution-ready, and not benchmark,
+  simulator-realism, sim-to-real, or paper-facing evidence. The shipped
+  `configs/research/fidelity_sensitivity_v1.yaml` now carries an explicit
+  `fixed_scope.planner_algorithms` binding so its planner labels resolve. No benchmark campaign was
+  run.
 * Added license-safe **CrowdBot and SCAND shape-contract loaders** plus skip-if-absent tests for the
   #4224 external-data program (public slice b). `robot_sf/data/external/crowdbot.py` and
   `robot_sf/data/external/scand.py` only inspect locally staged files — they never download, vendor,

--- a/configs/research/fidelity_sensitivity_v1.yaml
+++ b/configs/research/fidelity_sensitivity_v1.yaml
@@ -32,6 +32,14 @@ fixed_scope:
     - orca
     - default_social_force
     - hybrid_rule_v0_minimal
+  # Explicit binding of each planner-group label to a canonical algorithm in the
+  # robot_sf.benchmark.algorithm_readiness catalog. Making the full-fixed-scope
+  # planner set resolvable is what the #3207 preflight checks before launch; the
+  # `default_social_force` label is a configured `social_force` baseline.
+  planner_algorithms:
+    orca: orca
+    default_social_force: social_force
+    hybrid_rule_v0_minimal: hybrid_rule_v0_minimal
 
 ranking:
   metric: snqi

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -3027,3 +3027,11 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_3207_fidelity_fixed_scope_preflight_2026-07-04/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3207_fidelity_fixed_scope_preflight_2026-07-04/fidelity_fixed_scope_preflight.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence

--- a/docs/context/evidence/issue_3207_fidelity_fixed_scope_preflight_2026-07-04/README.md
+++ b/docs/context/evidence/issue_3207_fidelity_fixed_scope_preflight_2026-07-04/README.md
@@ -1,0 +1,35 @@
+# Issue #3207 — Full fixed-scope fidelity-sensitivity preflight (2026-07-04)
+
+First-use evidence for the full fixed-scope **preflight** added by the #3207
+pre-registration slice. This is a **launch/readiness artifact only** — it is not
+benchmark evidence, not simulator-realism evidence, not sim-to-real evidence, and
+not paper-facing evidence. No benchmark episodes were run to produce it.
+
+## What this records
+
+`fidelity_fixed_scope_preflight.json` is the deterministic preflight packet built
+from the shipped study config `configs/research/fidelity_sensitivity_v1.yaml` at
+`origin/main` base commit `b619d1be4`.
+
+- `decision`: `preflight_ready` — the contract-level launch checks pass.
+- `materialized_scope.run_cells_per_scenario`: `108` (3 planner groups × 12 axis
+  variants × 3 seeds), enumerated per scenario in the fixed scenario set.
+- `planner_resolution`: every planner group resolves to a non-placeholder
+  algorithm-readiness catalog entry (`orca` → `orca`, `default_social_force` →
+  `social_force`, `hybrid_rule_v0_minimal` → `hybrid_rule_local_planner`).
+- `primary_metric`: `snqi` is identifiable by contract.
+- `launch_prerequisites`: `preflight_ready` is **not** execution-ready. The
+  campaign runner is still a bounded two-planner slice, ORCA needs rvo2, the
+  hybrid planner needs explicit opt-in, and runtime rank-identifiability must be
+  re-checked on measured results.
+
+## Regenerate
+
+```bash
+uv run python scripts/benchmark/preflight_fidelity_fixed_scope.py \
+  --config configs/research/fidelity_sensitivity_v1.yaml \
+  --out output/fidelity_sensitivity/preflight --require-ready
+```
+
+The `git_head` field differs by checkout; all other fields are deterministic for
+a given config.

--- a/docs/context/evidence/issue_3207_fidelity_fixed_scope_preflight_2026-07-04/fidelity_fixed_scope_preflight.json
+++ b/docs/context/evidence/issue_3207_fidelity_fixed_scope_preflight_2026-07-04/fidelity_fixed_scope_preflight.json
@@ -1,0 +1,80 @@
+{
+  "blockers": [],
+  "claim_boundary": "Launch/readiness preflight only: pre-registers the full fixed-scope fidelity-sensitivity campaign scope, planner availability, and primary-metric identifiability. preflight_ready is a pre-registration gate, not an execution-ready signal; it is not benchmark evidence, not simulator-realism evidence, not sim-to-real evidence, and not paper-facing evidence.",
+  "config_path": "configs/research/fidelity_sensitivity_v1.yaml",
+  "date": "2026-07-04",
+  "decision": "preflight_ready",
+  "evidence_status": "launch_readiness_preflight_not_benchmark_evidence",
+  "git_head": "b619d1be465f08c6edbea0f259e3d6cab07abaf4",
+  "issue": 3207,
+  "launch_prerequisites": [
+    "planner_runtime_dependency:orca requires rvo2 or an explicit fallback policy",
+    "planner_requires_explicit_opt_in:hybrid_rule_v0_minimal (set allow_testing_algorithms in the algo config before launch)",
+    "campaign_runner_not_wired_for_full_fixed_scope: scripts/benchmark/run_fidelity_sensitivity_campaign.py currently runs a bounded two-planner slice; extend it to the resolved planner set before launch",
+    "runtime_rank_identifiability_recheck_required: measured primary-metric variance must be re-validated post-run via robot_sf/benchmark/fidelity_rank_stability.py"
+  ],
+  "materialized_scope": {
+    "axis_count": 4,
+    "planner_group_count": 3,
+    "planner_groups": [
+      "orca",
+      "default_social_force",
+      "hybrid_rule_v0_minimal"
+    ],
+    "run_cells_note": "run_cells_per_scenario counts planner_group x axis-variant x seed cells for each scenario in scenario_set; scenario multiplicity is resolved by the campaign runner and is not expanded here.",
+    "run_cells_per_scenario": 108,
+    "scenario_set": "configs/benchmarks/paper_experiment_matrix_v1.yaml",
+    "seed_count": 3,
+    "seeds": [
+      111,
+      112,
+      113
+    ],
+    "variant_count": 12
+  },
+  "next_command_template": "uv run python scripts/benchmark/run_fidelity_sensitivity_campaign.py --config configs/research/fidelity_sensitivity_v1.yaml --out output/fidelity_sensitivity/",
+  "planner_resolution": [
+    {
+      "algorithm": "orca",
+      "available": true,
+      "canonical_name": "orca",
+      "explicit_algorithm_binding": true,
+      "note": "ORCA baseline (requires rvo2 or explicit fallback policy).",
+      "planner_group": "orca",
+      "requires_explicit_opt_in": false,
+      "tier": "baseline-ready"
+    },
+    {
+      "algorithm": "social_force",
+      "available": true,
+      "canonical_name": "social_force",
+      "explicit_algorithm_binding": true,
+      "note": "Social-force adapter baseline.",
+      "planner_group": "default_social_force",
+      "requires_explicit_opt_in": false,
+      "tier": "baseline-ready"
+    },
+    {
+      "algorithm": "hybrid_rule_v0_minimal",
+      "available": true,
+      "canonical_name": "hybrid_rule_local_planner",
+      "explicit_algorithm_binding": true,
+      "note": "Deterministic hybrid-rule local planner family; v0 is minimal DWA-style. Actuation-aware aliases are synthetic diagnostic-only candidates.",
+      "planner_group": "hybrid_rule_v0_minimal",
+      "requires_explicit_opt_in": true,
+      "tier": "experimental"
+    }
+  ],
+  "preflight_ready": true,
+  "primary_metric": {
+    "direction": "higher_is_better",
+    "higher_is_better": true,
+    "identifiable_by_contract": true,
+    "metric": "snqi",
+    "non_identifiable_reason": null,
+    "present_in_metrics": true,
+    "runtime_identifiability_deferred": "measured zero-variance / degenerate rankings are detected post-run; see robot_sf/benchmark/fidelity_rank_stability.py"
+  },
+  "schema_version": "fidelity-fixed-scope-preflight.v1",
+  "study_id": "issue_3207_fidelity_sensitivity_v1"
+}

--- a/robot_sf/benchmark/fidelity_fixed_scope_preflight.py
+++ b/robot_sf/benchmark/fidelity_fixed_scope_preflight.py
@@ -1,0 +1,331 @@
+"""Full fixed-scope fidelity-sensitivity preflight (issue #3207).
+
+This module pre-registers the *full fixed-scope* simulator-fidelity sensitivity
+campaign before it is launched. It does three things and nothing more:
+
+1. **Materializes** the explicit run plan from the study config — every planner
+   group crossed with every axis variant and every fixed seed over the fixed
+   scenario set — so the intended full scope is enumerated rather than implied.
+2. **Resolves planner availability** against the canonical
+   :mod:`robot_sf.benchmark.algorithm_readiness` catalog and **fails closed** on
+   any planner group that cannot be resolved to a non-placeholder algorithm.
+3. **Validates the primary (ranking) metric** is identifiable *by contract*
+   (declared, present in the metric list, with a direction, and not flagged
+   non-identifiable/zero-variance per issue #3299) and **fails closed** otherwise.
+
+It runs no benchmark episodes and promotes no claim. ``preflight_ready`` is a
+pre-registration gate only: it means the contract-level launch checks pass, not
+that the campaign runner is wired to execute the full planner set, that the
+runtime dependencies (e.g. rvo2 for ORCA) are present, or that the measured
+ranking will be identifiable at runtime. Those remain explicit
+``launch_prerequisites``. The emitted packet is a launch/readiness artifact and
+is not benchmark evidence, not simulator-realism evidence, not sim-to-real
+evidence, and not paper-facing evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.algorithm_readiness import get_algorithm_readiness
+from robot_sf.benchmark.fidelity_rank_stability import PRIMARY_METRIC_ZERO_VARIANCE_REASON
+from robot_sf.benchmark.fidelity_sensitivity import validate_fidelity_sensitivity_config
+
+SCHEMA_VERSION = "fidelity-fixed-scope-preflight.v1"
+
+DECISION_READY = "preflight_ready"
+DECISION_BLOCKED = "blocked"
+
+EVIDENCE_STATUS = "launch_readiness_preflight_not_benchmark_evidence"
+
+# Phrases the decision-checker family (simulator_dependence_validity_boundary)
+# already requires in every no-claim boundary; the preflight packet reuses them
+# so downstream consumers see a consistent claim boundary.
+REQUIRED_CLAIM_BOUNDARY_PHRASES = (
+    "not benchmark evidence",
+    "not simulator-realism evidence",
+    "not sim-to-real evidence",
+    "not paper-facing evidence",
+)
+
+PREFLIGHT_CLAIM_BOUNDARY = (
+    "Launch/readiness preflight only: pre-registers the full fixed-scope fidelity-sensitivity "
+    "campaign scope, planner availability, and primary-metric identifiability. "
+    "preflight_ready is a pre-registration gate, not an execution-ready signal; it is "
+    "not benchmark evidence, not simulator-realism evidence, not sim-to-real evidence, "
+    "and not paper-facing evidence."
+)
+
+
+def build_fixed_scope_preflight(
+    config: Mapping[str, Any],
+    *,
+    config_path: str,
+    git_head: str,
+    date: str | None = None,
+) -> dict[str, Any]:
+    """Build a fail-closed full fixed-scope preflight/readiness packet.
+
+    Args:
+        config: Raw fidelity-sensitivity study config mapping.
+        config_path: Repo-relative path of the config, recorded for provenance.
+        git_head: Git head recorded for provenance.
+        date: Optional ISO date string recorded for provenance.
+
+    Returns:
+        JSON-serializable readiness packet. ``decision`` is ``preflight_ready``
+        only when no blockers are present; otherwise it is ``blocked``.
+    """
+    validated = validate_fidelity_sensitivity_config(config)
+
+    blockers: list[str] = []
+    launch_prerequisites: list[str] = []
+
+    materialized = _materialize_full_fixed_scope(validated)
+    planner_resolution = _resolve_planner_groups(
+        validated, blockers=blockers, launch_prerequisites=launch_prerequisites
+    )
+    primary_metric = _check_primary_metric(validated, blockers=blockers)
+
+    # The bounded slice runner is intentionally not wired for the full planner
+    # set yet; surface that as a launch prerequisite so preflight_ready is never
+    # read as "the campaign will run".
+    launch_prerequisites.append(
+        "campaign_runner_not_wired_for_full_fixed_scope: "
+        "scripts/benchmark/run_fidelity_sensitivity_campaign.py currently runs a bounded "
+        "two-planner slice; extend it to the resolved planner set before launch"
+    )
+    launch_prerequisites.append(
+        "runtime_rank_identifiability_recheck_required: measured primary-metric variance must be "
+        "re-validated post-run via robot_sf/benchmark/fidelity_rank_stability.py"
+    )
+
+    decision = DECISION_BLOCKED if blockers else DECISION_READY
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": int(validated.get("issue", 3207)),
+        "study_id": str(validated["study_id"]),
+        "decision": decision,
+        "preflight_ready": decision == DECISION_READY,
+        "evidence_status": EVIDENCE_STATUS,
+        "claim_boundary": PREFLIGHT_CLAIM_BOUNDARY,
+        "config_path": config_path,
+        "git_head": git_head,
+        "date": date,
+        "materialized_scope": materialized,
+        "planner_resolution": planner_resolution,
+        "primary_metric": primary_metric,
+        "blockers": blockers,
+        "launch_prerequisites": launch_prerequisites,
+        "next_command_template": (
+            "uv run python scripts/benchmark/run_fidelity_sensitivity_campaign.py --config "
+            f"{config_path} --out output/fidelity_sensitivity/"
+        ),
+    }
+
+
+def write_fixed_scope_preflight(packet: Mapping[str, Any], output_dir: str | Path) -> Path:
+    """Write a deterministic JSON preflight packet.
+
+    Returns:
+        Path to the written ``fidelity_fixed_scope_preflight.json`` file.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    packet_path = out / "fidelity_fixed_scope_preflight.json"
+    packet_path.write_text(
+        json.dumps(packet, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return packet_path
+
+
+def _materialize_full_fixed_scope(validated: Mapping[str, Any]) -> dict[str, Any]:
+    """Enumerate the explicit full fixed-scope run plan.
+
+    Returns:
+        Counts and identifiers for the planner × axis-variant × seed cells that
+        the full campaign must cover per scenario in the fixed scenario set.
+    """
+    fixed_scope = validated["fixed_scope"]
+    seeds = list(fixed_scope["seeds"])
+    planner_groups = list(fixed_scope["planner_groups"])
+    axes = validated["axes"]
+    variant_count = sum(len(axis["variants"]) for axis in axes)
+    run_cells = len(planner_groups) * variant_count * len(seeds)
+    return {
+        "scenario_set": str(fixed_scope["scenario_set"]),
+        "seed_count": len(seeds),
+        "seeds": seeds,
+        "planner_group_count": len(planner_groups),
+        "planner_groups": planner_groups,
+        "axis_count": len(axes),
+        "variant_count": variant_count,
+        "run_cells_per_scenario": run_cells,
+        "run_cells_note": (
+            "run_cells_per_scenario counts planner_group x axis-variant x seed cells for each "
+            "scenario in scenario_set; scenario multiplicity is resolved by the campaign runner "
+            "and is not expanded here."
+        ),
+    }
+
+
+def _resolve_planner_groups(
+    validated: Mapping[str, Any],
+    *,
+    blockers: list[str],
+    launch_prerequisites: list[str],
+) -> list[dict[str, Any]]:
+    """Resolve each planner group to a catalog algorithm, failing closed.
+
+    A planner group resolves through an explicit ``fixed_scope.planner_algorithms``
+    mapping when present, otherwise via the group label directly. Unresolved or
+    placeholder-tier planners are recorded as blockers; experimental planners that
+    require explicit opt-in are recorded as launch prerequisites.
+
+    Returns:
+        Per-planner resolution records in config order.
+    """
+    fixed_scope = validated["fixed_scope"]
+    planner_groups = list(fixed_scope["planner_groups"])
+    algorithm_map = fixed_scope.get("planner_algorithms")
+    if algorithm_map is not None and not isinstance(algorithm_map, Mapping):
+        raise ValueError("fixed_scope.planner_algorithms must be a mapping when set")
+
+    resolution: list[dict[str, Any]] = []
+    for group in planner_groups:
+        group_name = str(group)
+        algorithm = (
+            str(algorithm_map[group_name]) if _in_map(algorithm_map, group_name) else group_name
+        )
+        readiness = get_algorithm_readiness(algorithm)
+        record: dict[str, Any] = {
+            "planner_group": group_name,
+            "algorithm": algorithm,
+            "explicit_algorithm_binding": _in_map(algorithm_map, group_name),
+        }
+        if readiness is None:
+            record.update(
+                available=False,
+                canonical_name=None,
+                tier=None,
+                requires_explicit_opt_in=None,
+                note="unresolved: no algorithm-readiness catalog entry",
+            )
+            blockers.append(f"planner_unavailable:{group_name}")
+        elif readiness.tier == "placeholder":
+            record.update(
+                available=False,
+                canonical_name=readiness.canonical_name,
+                tier=readiness.tier,
+                requires_explicit_opt_in=readiness.requires_explicit_opt_in,
+                note=readiness.note,
+            )
+            blockers.append(f"planner_placeholder:{group_name}")
+        else:
+            record.update(
+                available=True,
+                canonical_name=readiness.canonical_name,
+                tier=readiness.tier,
+                requires_explicit_opt_in=readiness.requires_explicit_opt_in,
+                note=readiness.note,
+            )
+            if readiness.requires_explicit_opt_in:
+                launch_prerequisites.append(
+                    f"planner_requires_explicit_opt_in:{group_name} "
+                    "(set allow_testing_algorithms in the algo config before launch)"
+                )
+            if readiness.canonical_name == "orca":
+                launch_prerequisites.append(
+                    "planner_runtime_dependency:orca requires rvo2 or an explicit fallback policy"
+                )
+        resolution.append(record)
+    return resolution
+
+
+def _check_primary_metric(
+    validated: Mapping[str, Any],
+    *,
+    blockers: list[str],
+) -> dict[str, Any]:
+    """Validate the primary (ranking) metric is identifiable by contract.
+
+    Fails closed when the ranking metric is absent from the declared metric list
+    or is explicitly flagged non-identifiable / zero-variance (issue #3299).
+
+    Returns:
+        Primary-metric identifiability record.
+    """
+    ranking = validated["ranking"]
+    primary = str(ranking["metric"])
+    metric_entries = {
+        str(entry.get("name")): entry
+        for entry in validated["metrics"]
+        if isinstance(entry, Mapping)
+    }
+    entry = metric_entries.get(primary)
+    present = entry is not None
+
+    non_identifiable_reason: str | None = None
+    if not present:
+        # validate_fidelity_sensitivity_config already requires membership, but
+        # keep the fail-closed branch explicit for defense in depth.
+        non_identifiable_reason = "primary_metric_not_in_metrics"
+        blockers.append(f"primary_metric_missing:{primary}")
+    elif _entry_declares_non_identifiable(entry):
+        non_identifiable_reason = _declared_non_identifiable_reason(entry)
+        blockers.append(f"primary_metric_non_identifiable:{non_identifiable_reason}")
+
+    direction = None
+    if present:
+        direction = entry.get("direction")
+
+    return {
+        "metric": primary,
+        "direction": direction,
+        "higher_is_better": bool(ranking.get("higher_is_better", False)),
+        "present_in_metrics": present,
+        "identifiable_by_contract": non_identifiable_reason is None,
+        "non_identifiable_reason": non_identifiable_reason,
+        "runtime_identifiability_deferred": (
+            "measured zero-variance / degenerate rankings are detected post-run; "
+            "see robot_sf/benchmark/fidelity_rank_stability.py"
+        ),
+    }
+
+
+def _entry_declares_non_identifiable(entry: Mapping[str, Any]) -> bool:
+    """Return whether a metric entry pre-declares itself non-identifiable."""
+    if entry.get("identifiable") is False:
+        return True
+    if entry.get("non_identifiable") is True:
+        return True
+    return entry.get("expected_variance") == "zero"
+
+
+def _declared_non_identifiable_reason(entry: Mapping[str, Any]) -> str:
+    """Return the declared non-identifiability reason for a metric entry."""
+    reason = entry.get("non_identifiable_reason")
+    if reason:
+        return str(reason)
+    return PRIMARY_METRIC_ZERO_VARIANCE_REASON
+
+
+def _in_map(mapping: Mapping[str, Any] | None, key: str) -> bool:
+    return isinstance(mapping, Mapping) and key in mapping
+
+
+__all__ = [
+    "DECISION_BLOCKED",
+    "DECISION_READY",
+    "EVIDENCE_STATUS",
+    "PREFLIGHT_CLAIM_BOUNDARY",
+    "REQUIRED_CLAIM_BOUNDARY_PHRASES",
+    "SCHEMA_VERSION",
+    "build_fixed_scope_preflight",
+    "write_fixed_scope_preflight",
+]

--- a/scripts/benchmark/preflight_fidelity_fixed_scope.py
+++ b/scripts/benchmark/preflight_fidelity_fixed_scope.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Preflight the full fixed-scope #3207 fidelity-sensitivity campaign (no execution).
+
+Materializes the full fixed-scope run plan from the study config, resolves planner
+availability against the algorithm-readiness catalog, and validates that the
+primary (ranking) metric is identifiable by contract. Emits a launch/readiness
+packet only; it fails closed and runs no benchmark episodes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from robot_sf.benchmark.fidelity_fixed_scope_preflight import (
+    DECISION_READY,
+    build_fixed_scope_preflight,
+    write_fixed_scope_preflight,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = "configs/research/fidelity_sensitivity_v1.yaml"
+
+
+def _git_head() -> str:
+    """Return the current git head, or ``unknown`` when unavailable."""
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, stderr=subprocess.DEVNULL
+            )
+            .decode("utf-8")
+            .strip()
+        )
+    except (subprocess.SubprocessError, OSError):
+        return "unknown"
+
+
+def _repo_rel(path: Path) -> str:
+    """Return a repo-relative path string when possible."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG,
+        help="Fidelity-sensitivity study config (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Optional output directory for the preflight packet JSON.",
+    )
+    parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Exit non-zero when the preflight is not ready.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """CLI entry point."""
+    args = parse_args()
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        config_path = REPO_ROOT / config_path
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+
+    packet = build_fixed_scope_preflight(
+        config,
+        config_path=_repo_rel(config_path),
+        git_head=_git_head(),
+    )
+
+    if args.out:
+        out_dir = Path(args.out)
+        if not out_dir.is_absolute():
+            out_dir = REPO_ROOT / out_dir
+        packet_path = write_fixed_scope_preflight(packet, out_dir)
+        print(f"wrote fidelity fixed-scope preflight packet: {_repo_rel(packet_path)}")
+
+    print(f"decision: {packet['decision']}")
+    if packet["blockers"]:
+        print("blockers:")
+        for blocker in packet["blockers"]:
+            print(f"  - {blocker}")
+
+    if args.require_ready and packet["decision"] != DECISION_READY:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_fidelity_fixed_scope_preflight.py
+++ b/tests/benchmark/test_fidelity_fixed_scope_preflight.py
@@ -1,0 +1,197 @@
+"""Tests for the full fixed-scope fidelity-sensitivity preflight (issue #3207)."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from robot_sf.benchmark.fidelity_fixed_scope_preflight import (
+    DECISION_BLOCKED,
+    DECISION_READY,
+    REQUIRED_CLAIM_BOUNDARY_PHRASES,
+    SCHEMA_VERSION,
+    build_fixed_scope_preflight,
+    write_fixed_scope_preflight,
+)
+from robot_sf.benchmark.fidelity_sensitivity import load_fidelity_sensitivity_config
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REAL_CONFIG = REPO_ROOT / "configs/research/fidelity_sensitivity_v1.yaml"
+
+
+def _base_config() -> dict[str, Any]:
+    """Return a minimal valid fidelity-sensitivity config with resolvable planners."""
+    return {
+        "schema_version": "fidelity-sensitivity.v1",
+        "issue": 3207,
+        "study_id": "unit_test_fixed_scope",
+        "fixed_scope": {
+            "scenario_set": "configs/benchmarks/paper_experiment_matrix_v1.yaml",
+            "seeds": [111, 112, 113],
+            "planner_groups": ["orca", "default_social_force"],
+            "planner_algorithms": {
+                "orca": "orca",
+                "default_social_force": "social_force",
+            },
+        },
+        "ranking": {"metric": "snqi", "higher_is_better": True},
+        "metrics": [
+            {"name": "snqi", "direction": "higher_is_better"},
+            {"name": "success", "direction": "higher_is_better"},
+        ],
+        "axes": [
+            {
+                "key": f"axis_{index}",
+                "variants": [
+                    {"key": f"axis_{index}_nominal", "baseline": True},
+                    {"key": f"axis_{index}_alt"},
+                ],
+            }
+            for index in range(3)
+        ],
+    }
+
+
+def _build(config: dict[str, Any]) -> dict[str, Any]:
+    return build_fixed_scope_preflight(config, config_path="configs/x.yaml", git_head="deadbeef")
+
+
+def test_ready_path_materializes_full_scope() -> None:
+    """A resolvable config is preflight_ready with an explicit materialized scope."""
+    packet = _build(_base_config())
+
+    assert packet["schema_version"] == SCHEMA_VERSION
+    assert packet["decision"] == DECISION_READY
+    assert packet["preflight_ready"] is True
+    assert packet["blockers"] == []
+
+    scope = packet["materialized_scope"]
+    # 2 planner groups x (3 axes x 2 variants = 6 variants) x 3 seeds = 36 cells.
+    assert scope["planner_group_count"] == 2
+    assert scope["axis_count"] == 3
+    assert scope["variant_count"] == 6
+    assert scope["seed_count"] == 3
+    assert scope["run_cells_per_scenario"] == 36
+
+
+def test_ready_path_records_claim_boundary_phrases() -> None:
+    """The preflight packet carries the no-claim boundary phrases."""
+    packet = _build(_base_config())
+    for phrase in REQUIRED_CLAIM_BOUNDARY_PHRASES:
+        assert phrase in packet["claim_boundary"]
+    assert packet["evidence_status"].endswith("not_benchmark_evidence")
+
+
+def test_primary_metric_identifiable_by_contract() -> None:
+    """The declared ranking metric is reported identifiable by contract."""
+    packet = _build(_base_config())
+    primary = packet["primary_metric"]
+    assert primary["metric"] == "snqi"
+    assert primary["present_in_metrics"] is True
+    assert primary["identifiable_by_contract"] is True
+    assert primary["non_identifiable_reason"] is None
+
+
+def test_unresolved_planner_fails_closed() -> None:
+    """An unknown planner group with no explicit binding blocks the preflight."""
+    config = _base_config()
+    config["fixed_scope"]["planner_groups"].append("nonexistent_planner")
+    packet = _build(config)
+
+    assert packet["decision"] == DECISION_BLOCKED
+    assert packet["preflight_ready"] is False
+    assert "planner_unavailable:nonexistent_planner" in packet["blockers"]
+
+
+def test_unbound_default_social_force_fails_closed() -> None:
+    """Without the explicit algorithm binding, the label does not resolve."""
+    config = _base_config()
+    # Drop the explicit binding so the label is resolved directly (and fails).
+    config["fixed_scope"].pop("planner_algorithms")
+    packet = _build(config)
+
+    assert packet["decision"] == DECISION_BLOCKED
+    assert "planner_unavailable:default_social_force" in packet["blockers"]
+
+
+def test_placeholder_planner_fails_closed() -> None:
+    """A placeholder-tier catalog planner is treated as unavailable."""
+    config = _base_config()
+    config["fixed_scope"]["planner_groups"] = ["orca", "rvo"]
+    config["fixed_scope"]["planner_algorithms"] = {"orca": "orca", "rvo": "rvo"}
+    packet = _build(config)
+
+    assert packet["decision"] == DECISION_BLOCKED
+    assert "planner_placeholder:rvo" in packet["blockers"]
+
+
+def test_non_identifiable_primary_metric_fails_closed() -> None:
+    """A primary metric flagged non-identifiable blocks the preflight (issue #3299)."""
+    config = _base_config()
+    config["metrics"][0]["identifiable"] = False
+    config["metrics"][0]["non_identifiable_reason"] = "primary_metric_zero_variance"
+    packet = _build(config)
+
+    assert packet["decision"] == DECISION_BLOCKED
+    assert "primary_metric_non_identifiable:primary_metric_zero_variance" in packet["blockers"]
+    assert packet["primary_metric"]["identifiable_by_contract"] is False
+
+
+def test_experimental_planner_recorded_as_launch_prerequisite() -> None:
+    """Opt-in planners resolve but surface an explicit launch prerequisite."""
+    config = _base_config()
+    config["fixed_scope"]["planner_groups"].append("hybrid_rule_v0_minimal")
+    config["fixed_scope"]["planner_algorithms"]["hybrid_rule_v0_minimal"] = "hybrid_rule_v0_minimal"
+    packet = _build(config)
+
+    assert packet["decision"] == DECISION_READY
+    prereqs = "\n".join(packet["launch_prerequisites"])
+    assert "planner_requires_explicit_opt_in:hybrid_rule_v0_minimal" in prereqs
+    # The runner-not-wired prerequisite always guards against false-ready reads.
+    assert "campaign_runner_not_wired_for_full_fixed_scope" in prereqs
+
+
+def test_bad_planner_algorithms_type_raises() -> None:
+    """A non-mapping planner_algorithms surface is a hard config error."""
+    config = _base_config()
+    config["fixed_scope"]["planner_algorithms"] = ["orca"]
+    with pytest.raises(ValueError, match="planner_algorithms"):
+        _build(config)
+
+
+def test_write_packet_round_trips(tmp_path: Path) -> None:
+    """Writing then reading the packet preserves the decision."""
+    packet = _build(_base_config())
+    out = write_fixed_scope_preflight(packet, tmp_path)
+    assert out.name == "fidelity_fixed_scope_preflight.json"
+    loaded = json.loads(out.read_text(encoding="utf-8"))
+    assert loaded["decision"] == packet["decision"]
+    assert loaded["schema_version"] == SCHEMA_VERSION
+
+
+def test_real_config_is_preflight_ready() -> None:
+    """The shipped #3207 config resolves to a ready preflight with the full scope."""
+    config = load_fidelity_sensitivity_config(REAL_CONFIG)
+    packet = build_fixed_scope_preflight(
+        config, config_path="configs/research/fidelity_sensitivity_v1.yaml", git_head="deadbeef"
+    )
+    assert packet["decision"] == DECISION_READY
+    scope = packet["materialized_scope"]
+    # 3 planner groups x 12 variants (4 axes x 3) x 3 seeds = 108 cells.
+    assert scope["planner_group_count"] == 3
+    assert scope["variant_count"] == 12
+    assert scope["run_cells_per_scenario"] == 108
+    # Every resolved planner maps to a canonical catalog name.
+    assert all(record["canonical_name"] for record in packet["planner_resolution"])
+
+
+def test_real_config_unchanged_by_preflight() -> None:
+    """Building the packet does not mutate the input config."""
+    config = load_fidelity_sensitivity_config(REAL_CONFIG)
+    before = copy.deepcopy(config)
+    build_fixed_scope_preflight(config, config_path="x", git_head="x")
+    assert config == before


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds a **full fixed-scope fidelity-sensitivity preflight** for issue #3207 — a launch/readiness gate that pre-registers the simulator-fidelity sensitivity campaign before it runs. New module `robot_sf/benchmark/fidelity_fixed_scope_preflight.py` + CLI `scripts/benchmark/preflight_fidelity_fixed_scope.py`.
- **Why now:** The July 2, 2026 maintainer plan on #3207 states earlier slices produced only diagnostic tooling/evidence and that the missing piece is the **full fixed-scope preflight** before claimable validity-boundary evidence. This is a progression slice adding a nameable new capability (full-fixed-scope materialization + fail-closed launch gate), not another micro-guard.
- **Claim boundary:** Emits a launch/readiness packet **only**. `preflight_ready` is a pre-registration gate — **not execution-ready**, and **not benchmark evidence, not simulator-realism evidence, not sim-to-real evidence, and not paper-facing evidence**. No benchmark episodes were run.
- **Required validation:** focused new tests + existing #3207 fidelity/simulator-dependence suite + preflight-only CLI (CPU only). See results below.
- **Remaining blocker:** `preflight_ready` explicitly lists `launch_prerequisites` (runner still a bounded two-planner slice; ORCA needs rvo2; hybrid planner needs opt-in; runtime rank-identifiability re-check). Actual campaign execution and claim promotion remain out of scope.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3207

## Scope

In scope (delivered):
- **Materialization**: enumerates the explicit full run plan — planner groups × axis variants × seeds over the fixed scenario set (shipped config → 3 × 12 × 3 = **108 run cells/scenario**).
- **Fail-closed planner availability**: each planner group resolves against the canonical `robot_sf/benchmark/algorithm_readiness.py` catalog; unresolved or placeholder-tier planners block.
- **Fail-closed primary-metric identifiability**: the ranking metric must be declared, present in `metrics`, and not pre-declared non-identifiable/zero-variance (per #3299).
- **Launch/readiness packet only** (JSON), plus a small durable first-use evidence copy.

Out of scope (explicit): **no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits**, no new analysis path, no claim promotion.

## Contract delta

- New module/CLI/schema: `SCHEMA_VERSION = "fidelity-fixed-scope-preflight.v1"`; packet fields `decision` (`preflight_ready`|`blocked`), `preflight_ready`, `materialized_scope`, `planner_resolution`, `primary_metric`, `blockers`, `launch_prerequisites`.
- New fail-closed blockers: `planner_unavailable:<group>`, `planner_placeholder:<group>`, `primary_metric_missing:<metric>`, `primary_metric_non_identifiable:<reason>`.
- Config: `configs/research/fidelity_sensitivity_v1.yaml` gains an explicit `fixed_scope.planner_algorithms` binding (`default_social_force → social_force`, etc.) so labels resolve to catalog algorithms. Backward compatible — the field is optional; without it, unresolved labels fail closed (covered by a test).
- Compatibility: no change to existing `fidelity_sensitivity`, `fidelity_sweep_manifest`, or `simulator_dependence_validity_boundary` behavior (existing suite green).

## Validation

```
# new preflight unit tests
uv run python -m pytest tests/benchmark/test_fidelity_fixed_scope_preflight.py -q
  -> 12 passed

# existing #3207 fidelity / simulator-dependence suite (regression guard)
uv run python -m pytest tests -k "fidelity or simulator_dependence or fidelity_sweep" -q
  -> 70 passed, 11174 deselected

# preflight-only CLI on shipped config (CPU only, no execution)
uv run python scripts/benchmark/preflight_fidelity_fixed_scope.py \
  --config configs/research/fidelity_sensitivity_v1.yaml \
  --out output/fidelity_sensitivity/preflight --require-ready
  -> decision: preflight_ready ; exit 0

ruff check + ruff format: clean on all changed files
```

## Assumptions (reversible)

- The **primary metric** = `ranking.metric` (`snqi`), matching the launch-packet contract; the analysis-surface `primary_metric` is left untouched.
- `default_social_force` is a configured `social_force` baseline (widely used label across the repo), so it is resolved via the new explicit binding rather than treated as a permanent blocker. Removing the binding is a tested fail-closed path.
- Pre-run non-identifiability is a **contract-level** check (declared flags); measured/zero-variance detection stays with the post-run `fidelity_rank_stability.py` and is listed as a launch prerequisite.

<details>
<summary>Governance / propagation</summary>

- **Fragmentation guard (2026-07-02):** no #3207 guardrail PRs merged in the last 24h; regardless, this is a progression slice adding a nameable new capability (full-fixed-scope preflight), so it proceeds under the exemption.
- **Late-guidance re-check:** re-read #3207 immediately before opening; latest comment is the July 2 plan (`2026-07-02T01:59:37Z`) — no newer maintainer guidance.
- **Downstream Propagation:** durable first-use evidence promoted to `docs/context/evidence/issue_3207_fidelity_fixed_scope_preflight_2026-07-04/`. State propagation: this PR body is the slice-delivered surface; no transient queue-routing state is encoded in tracked files.
- **Research Result Guidance:** `NA - launch/readiness gate` — no research claim is made; the packet is explicitly not benchmark evidence.
- **Artifacts:** the runtime packet goes to gitignored `output/`; only the deterministic promoted copy + config/tooling are tracked.

</details>

## Out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits were made in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new preflight check for fixed-scope fidelity-sensitivity campaigns, with a clear ready/blocked decision and a launch packet you can inspect before running anything.
  * The preflight now verifies planner availability, scope coverage, and primary metric readiness before launch.

* **Bug Fixes**
  * Tightened configuration handling so planner labels resolve consistently and invalid or incomplete setups fail closed instead of proceeding.

* **Documentation**
  * Added updated evidence and guidance for regenerating the preflight output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->