### PR TITLE
Issue #3481: consume per-pair pedestrian-pedestrian FoV forces at the simulator seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   submission. Pre-registration only: runs no episodes, submits no campaign, and derives no mechanism
   label. Validated with `tests/validation/test_issue_4206_trace_capable_h600_rerun_preregistration.py`
   (16 fixture cases).
+* Wired **per-pair pedestrian-pedestrian forces into the opt-in `hsfm_anisotropic_fov_v1` simulator
+  runtime** (#3481). The field-of-view (FoV) pedestrian model now consumes per-pair social-force
+  contributions instead of the coarse aggregate `np.min` attenuation. Two pure helpers were added to
+  `robot_sf/sim/pedestrian_model_variants.py`: `pairwise_social_force_contributions(...)` builds the
+  `(N, N, 2)` per-pair social-force matrix by reusing PySocialForce's own `social_force_ped_ped`
+  kernel (so summing over neighbors reproduces the aggregate `SocialForce()` the engine already
+  computes), and `fov_attenuated_total_force(...)` isolates the ped-ped social term from the total
+  force and replaces it with its per-pair FoV-attenuated form. `Simulator._step_pedestrians`
+  (inherited by `PedSimulator`) now reads the live `SocialForce` component parameters (fail-closed if
+  absent), builds the per-pair matrix from the current PySocialForce state, and attenuates each
+  neighbor's push by its own FoV weight before HSFM stepping. Only the `hsfm_anisotropic_fov_v1` path
+  changed: a rear neighbor is now down-weighted without disturbing an in-cone neighbor or the actor's
+  goal/obstacle drive, whereas the previous path scaled the *entire* per-actor force by a single
+  weight. `social_force_default`, `hsfm_total_force_v1`, and `hsfm_ttc_predictive_v1` are unchanged;
+  the aggregate helper `anisotropic_fov_total_force` is retained as the reference contrast. Evidence
+  tier stays diagnostic/prototype — **no** calibrated-realism, benchmark-strength, or
+  paper/dissertation claim. Vectorizing the `O(N^2)` per-pair matrix and narrow-passage / bottleneck
+  benchmark evidence remain follow-ups. Context note:
+  `docs/context/issue_3481_hsfm_ttc_predictive_forces.md`.
+
 * Extended the **AMMV feasibility batch-summary artifact block** with the claim-boundary markers it
   was missing, so a consumer reading only the summary sees the same non-hardware boundary as the
   per-episode payload (#3466). `robot_sf/benchmark/map_runner_batch_summary.py` now emits

--- a/docs/context/issue_3481_hsfm_ttc_predictive_forces.md
+++ b/docs/context/issue_3481_hsfm_ttc_predictive_forces.md
@@ -109,3 +109,70 @@ isolation instead of the aggregate `np.min` path) remains follow-up work, as doe
 lateral-sliding / bottleneck freeze benchmark evidence and any evidence-tier upgrade. No full
 benchmark campaign, Slurm/GPU submission, external calibration, or paper/dissertation claim edit was
 performed in this slice.
+
+## Runtime wiring of per-pair pedestrian-pedestrian forces (2026-07-04)
+
+This slice closes the "wire per-pair pp-force contributions from the simulator seam" follow-up named
+above and in the maintainer's PR #4297 gate comment. The `hsfm_anisotropic_fov_v1` runtime path now
+consumes per-pair pedestrian-pedestrian forces instead of the aggregate `np.min` attenuation.
+
+New capability: **runtime consumption of per-pair pedestrian-pedestrian forces at the simulator
+seam.**
+
+### What changed
+
+- New pure helper `pairwise_social_force_contributions(positions, velocities, *, activation_threshold,
+  n, n_prime, lambda_importance, gamma, factor)` returns the `(N, N, 2)` per-pair social-force matrix
+  where `[i, j]` is the repulsion neighbor `j` exerts on actor `i`. It reuses PySocialForce's own
+  pairwise kernel (`social_force_ped_ped`) with the same activation threshold and `factor`, so
+  `contributions.sum(axis=1)` reproduces the aggregate `SocialForce()` the physics engine already
+  sums into the total force (verified in a unit test against `pysocialforce.forces.social_force`).
+- New pure helper `fov_attenuated_total_force(total_forces, pairwise_social_forces, positions,
+  headings, *, cone_half_angle_rad, rear_weight)` isolates the aggregate ped-ped social term from the
+  full total force and replaces it with the per-pair FoV-attenuated form:
+
+  ```text
+  result = total_forces - pairwise_social.sum(axis=1) + pairwise_fov_attenuated_forces(...)
+  ```
+
+- The simulator seam (`Simulator._step_pedestrians`, inherited by `PedSimulator`) for
+  `hsfm_anisotropic_fov_v1` now: reads the live `SocialForce` component's parameters
+  (`_social_force_component`, fail-closed if absent), builds the per-pair matrix from the current
+  PySocialForce state (`_pairwise_social_force_contributions`), and calls
+  `fov_attenuated_total_force` before `step_hsfm_total_force`.
+
+### Behavior boundary
+
+- Only the `hsfm_anisotropic_fov_v1` runtime path changed. `social_force_default`,
+  `hsfm_total_force_v1`, and `hsfm_ttc_predictive_v1` are untouched.
+- The previous aggregate path scaled the *entire* per-actor force (goal + social + obstacle + robot
+  coupling) by a single `np.min` FoV weight. The new path attenuates *only* the pedestrian-pedestrian
+  social contributions, per pair, so a rear neighbor is down-weighted without disturbing an in-cone
+  neighbor or the actor's goal/obstacle drive. This is a behavior change for the opt-in FoV model
+  only; the runtime FoV smoke test was updated to pin the new per-pair composition.
+- The aggregate helper `anisotropic_fov_total_force` is retained (still unit-tested) as the reference
+  contrast for the isolation tests.
+- Total-force reconstruction subtracts and re-adds the social term, so non-social forces are
+  preserved to floating-point tolerance. Evidence tier stays diagnostic/prototype.
+
+### Known limitations / follow-up
+
+- `pairwise_social_force_contributions` is an `O(N^2)` Python loop over the njit kernel. It matches
+  the aggregate exactly but should be vectorized before benchmark-scale pedestrian counts, mirroring
+  the earlier TTC weight-path vectorization.
+- Narrow-passage lateral-sliding and bottleneck freeze/deadlock benchmark evidence, seed-controlled
+  campaigns, and any evidence-tier upgrade remain out of scope. No full benchmark campaign, Slurm/GPU
+  submission, external calibration, or paper/dissertation claim edit was performed in this slice.
+
+### Validation
+
+```bash
+uv run pytest tests/sim/test_hsfm_fov_pairwise_isolation.py \
+  tests/sim/test_hsfm_total_force_model.py \
+  tests/sim/test_ttc_predictive_pedestrian_model.py -q
+uv run ruff check robot_sf/sim/pedestrian_model_variants.py robot_sf/sim/simulator.py tests/sim
+```
+
+Plus an end-to-end smoke: a real `make_robot_env` run with `pedestrian_model=hsfm_anisotropic_fov_v1`
+stepped 15 times with finite pedestrian positions, confirming the real force list exposes a
+`SocialForce` component for the seam.

--- a/robot_sf/sim/pedestrian_model_variants.py
+++ b/robot_sf/sim/pedestrian_model_variants.py
@@ -341,6 +341,178 @@ def pairwise_fov_attenuated_forces(
     return attenuated.sum(axis=1)
 
 
+def _validate_social_force_inputs(
+    positions: np.ndarray,
+    velocities: np.ndarray,
+    *,
+    activation_threshold: float,
+    factor: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return finite social-force input arrays or raise a clear validation error."""
+    position_array = np.asarray(positions, dtype=float)
+    velocity_array = np.asarray(velocities, dtype=float)
+    if position_array.ndim != 2 or position_array.shape[1] != 2:
+        raise ValueError("positions must have shape (N, 2)")
+    if velocity_array.shape != position_array.shape:
+        raise ValueError("velocities must have shape (N, 2) matching positions")
+    if not (np.all(np.isfinite(position_array)) and np.all(np.isfinite(velocity_array))):
+        raise ValueError("positions and velocities must be finite")
+    if not np.isfinite(activation_threshold) or activation_threshold < 0:
+        raise ValueError("activation_threshold must be finite and >= 0")
+    if not np.isfinite(factor):
+        raise ValueError("factor must be finite")
+    return position_array, velocity_array
+
+
+def pairwise_social_force_contributions(
+    positions: np.ndarray,
+    velocities: np.ndarray,
+    *,
+    activation_threshold: float,
+    n: int,
+    n_prime: int,
+    lambda_importance: float,
+    gamma: float,
+    factor: float,
+) -> np.ndarray:
+    """Return per-pair pedestrian-pedestrian social-force contributions ``(N, N, 2)``.
+
+    Entry ``[i, j]`` is the social repulsion neighbor ``j`` exerts on actor ``i``. The
+    contribution reuses PySocialForce's own pairwise force law (``social_force_ped_ped``)
+    with the same activation threshold and ``factor`` scaling, so summing over neighbors
+    reproduces the aggregate ``SocialForce`` output PySocialForce already computes:
+
+        ``contributions.sum(axis=1) == SocialForce()`` (to floating-point tolerance).
+
+    This is the seam that the runtime needs to consume *per-pair* pedestrian-pedestrian
+    forces (issue #3481). Once the pairwise decomposition is available, a downstream
+    anisotropic field-of-view attenuation can down-weight a single rear neighbor without
+    disturbing an in-cone neighbor, instead of collapsing to the coarse ``np.min``
+    aggregate mode in :func:`anisotropic_fov_total_force`.
+
+    The layer stays independent of simulator objects so it is unit-testable without a full
+    environment; it only depends on the pure pairwise force kernel. The current
+    implementation is an ``O(N^2)`` Python loop over the njit kernel and is
+    diagnostic/prototype: vectorizing this matrix is a named follow-up before
+    benchmark-scale use, mirroring the earlier TTC weight-path vectorization.
+
+    Args:
+        positions: Pedestrian positions with shape ``(N, 2)``.
+        velocities: Pedestrian velocities with shape ``(N, 2)``.
+        activation_threshold: Max interaction distance in metres; pairs beyond it
+            contribute zero, matching PySocialForce's ``SocialForce`` masking.
+        n: Angular decay-shape parameter for the lateral (angle) interaction component.
+        n_prime: Angular decay-shape parameter for the velocity-aligned component.
+        lambda_importance: Weight of relative velocity in the interaction direction.
+        gamma: Scale factor for the interaction range parameter.
+        factor: Global scaling factor applied to every pairwise contribution.
+
+    Returns:
+        Per-pair force array with shape ``(N, N, 2)``; the diagonal is zero.
+    """
+    # Deferred import keeps this module numpy-pure at import time so importing the
+    # broadly-used ``SimulationSettings`` config never pays numba's import cost; the
+    # numba kernel only loads when this opt-in seam is actually exercised.
+    from pysocialforce.forces import social_force_ped_ped  # noqa: PLC0415
+
+    position_array, velocity_array = _validate_social_force_inputs(
+        positions,
+        velocities,
+        activation_threshold=activation_threshold,
+        factor=factor,
+    )
+    pedestrian_count = position_array.shape[0]
+    contributions = np.zeros((pedestrian_count, pedestrian_count, 2), dtype=float)
+    if pedestrian_count <= 1:
+        return contributions
+
+    threshold_sq = float(activation_threshold) ** 2
+    for i in range(pedestrian_count):
+        for j in range(pedestrian_count):
+            if i == j:
+                continue
+            # PySocialForce convention: position diff is p_i - p_j, velocity diff is
+            # v_j - v_i (see ``social_force`` in pysocialforce.forces).
+            pos_diff = position_array[i] - position_array[j]
+            if float(pos_diff[0] ** 2 + pos_diff[1] ** 2) > threshold_sq:
+                continue
+            vel_diff = velocity_array[j] - velocity_array[i]
+            force_x, force_y = social_force_ped_ped(
+                (float(pos_diff[0]), float(pos_diff[1])),
+                (float(vel_diff[0]), float(vel_diff[1])),
+                n,
+                n_prime,
+                lambda_importance,
+                gamma,
+            )
+            contributions[i, j, 0] = float(factor) * float(force_x)
+            contributions[i, j, 1] = float(factor) * float(force_y)
+    return contributions
+
+
+def fov_attenuated_total_force(
+    total_forces: np.ndarray,
+    pairwise_social_forces: np.ndarray,
+    positions: np.ndarray,
+    headings: np.ndarray,
+    *,
+    cone_half_angle_rad: float,
+    rear_weight: float,
+    epsilon: float = 1e-9,
+) -> np.ndarray:
+    """Replace the aggregate ped-ped social term with its per-pair FoV-attenuated form.
+
+    Given a fully aggregated total force per actor (desired + social + obstacle + robot
+    coupling, as PySocialForce sums it) and the per-pair pedestrian-pedestrian social
+    contributions that produced its social component, this isolates only that social term
+    and re-attenuates it *per pair* through the field-of-view weights:
+
+        ``result = total_forces - pairwise_social.sum(axis=1) + attenuated_social``
+
+    where ``attenuated_social`` comes from :func:`pairwise_fov_attenuated_forces`. Unlike
+    :func:`anisotropic_fov_total_force`, this neither scales the non-social forces nor
+    collapses the pairwise weights to a single ``np.min`` factor per actor, so a rear
+    neighbor is down-weighted without disturbing an in-cone neighbor's push or the actor's
+    goal/obstacle drive. Evidence tier stays diagnostic/prototype.
+
+    Args:
+        total_forces: Aggregated per-actor force with shape ``(N, 2)``.
+        pairwise_social_forces: Per-pair ped-ped contributions with shape ``(N, N, 2)``;
+            ``[i, j]`` is neighbor ``j``'s social force on actor ``i``.
+        positions: Pedestrian positions with shape ``(N, 2)``.
+        headings: Per-pedestrian heading angles with shape ``(N,)``.
+        cone_half_angle_rad: Half-angle of the forward field-of-view cone in radians.
+        rear_weight: Attenuation factor in ``[0, 1]`` applied outside the cone.
+        epsilon: Small positive tolerance for degenerate zero-distance pairs.
+
+    Returns:
+        Per-actor attenuated total force with shape ``(N, 2)``.
+    """
+    total_array = np.asarray(total_forces, dtype=float)
+    social_array = np.asarray(pairwise_social_forces, dtype=float)
+    position_array = np.asarray(positions, dtype=float)
+    pedestrian_count = position_array.shape[0]
+    if total_array.shape != (pedestrian_count, 2):
+        raise ValueError("total_forces must have shape (N, 2) matching positions")
+    if social_array.shape != (pedestrian_count, pedestrian_count, 2):
+        raise ValueError("pairwise_social_forces must have shape (N, N, 2) matching positions")
+    if not np.all(np.isfinite(total_array)):
+        raise ValueError("total_forces must be finite")
+    if pedestrian_count == 0:
+        return total_array.copy()
+
+    social_aggregate = social_array.sum(axis=1)
+    attenuated_social = pairwise_fov_attenuated_forces(
+        social_array,
+        position_array,
+        headings,
+        cone_half_angle_rad=cone_half_angle_rad,
+        rear_weight=rear_weight,
+        epsilon=epsilon,
+    )
+    return total_array - social_aggregate + attenuated_social
+
+
 def ttc_predictive_repulsion(
     positions: np.ndarray,
     velocities: np.ndarray,

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -31,7 +31,7 @@ from loguru import logger
 from pysocialforce import Simulator as PySFSimulator
 from pysocialforce.config import SimulatorConfig as PySFSimConfig
 from pysocialforce.forces import Force as PySFForce
-from pysocialforce.forces import ObstacleForce
+from pysocialforce.forces import ObstacleForce, SocialForce
 from pysocialforce.simulator import make_forces as pysf_make_forces
 
 from robot_sf.common.types import Line2D, PedPose, RobotAction, RobotPose, Vec2D
@@ -55,8 +55,9 @@ from robot_sf.sim.pedestrian_model_variants import (
     HSFM_ANISOTROPIC_FOV_V1,
     HSFM_TOTAL_FORCE_V1,
     HSFM_TTC_PREDICTIVE_V1,
-    anisotropic_fov_total_force,
+    fov_attenuated_total_force,
     normalize_pedestrian_model,
+    pairwise_social_force_contributions,
     step_hsfm_total_force,
     ttc_predictive_repulsion,
 )
@@ -284,10 +285,16 @@ class Simulator:
                 )
         elif self.pedestrian_model == HSFM_ANISOTROPIC_FOV_V1:
             fov_config = self.config.anisotropic_fov
-            ped_forces = anisotropic_fov_total_force(
+            # Consume per-pair pedestrian-pedestrian contributions instead of the coarse
+            # ``np.min`` aggregate (issue #3481): isolate the social term, attenuate each
+            # neighbor's push by its own field-of-view weight, and leave the actor's
+            # goal/obstacle drive untouched.
+            pairwise_social = self._pairwise_social_force_contributions(current_state)
+            ped_forces = fov_attenuated_total_force(
+                np.asarray(ped_forces, dtype=float),
+                pairwise_social,
                 current_state[:, PYSF_POSITION_SLICE],
                 self.ped_headings,
-                ped_forces,
                 cone_half_angle_rad=fov_config.cone_half_angle_rad,
                 rear_weight=fov_config.rear_weight,
             )
@@ -300,6 +307,49 @@ class Simulator:
         )
         current_state[...] = next_state
         self.pysf_sim.peds.update(current_state, groups)
+
+    def _social_force_component(self) -> SocialForce:
+        """Return the active PySocialForce ped-ped ``SocialForce`` component.
+
+        The pairwise field-of-view model needs the social force's parameters
+        (activation threshold, factor, and interaction exponents) so its per-pair
+        reconstruction exactly matches the aggregate PySocialForce already sums into the
+        total force. Fail closed if the component is missing, mirroring the ``max_speeds``
+        guard, so the opt-in model never silently degrades to a different force law.
+
+        Returns:
+            The ``SocialForce`` instance from the physics engine's force list.
+        """
+        for force in self.pysf_sim.forces:
+            if isinstance(force, SocialForce):
+                return force
+        raise RuntimeError(
+            "PySocialForce SocialForce component is unavailable for the pairwise "
+            "field-of-view pedestrian model"
+        )
+
+    def _pairwise_social_force_contributions(self, state: np.ndarray) -> np.ndarray:
+        """Build the per-pair ped-ped social-force matrix for the current state.
+
+        Args:
+            state: PySocialForce state buffer whose columns expose positions and
+                velocities via ``PYSF_POSITION_SLICE`` / ``PYSF_VELOCITY_SLICE``.
+
+        Returns:
+            Per-pair contributions with shape ``(N, N, 2)`` matching the aggregate
+            ``SocialForce`` output when summed over neighbors.
+        """
+        social_config = self._social_force_component().config
+        return pairwise_social_force_contributions(
+            state[:, PYSF_POSITION_SLICE],
+            state[:, PYSF_VELOCITY_SLICE],
+            activation_threshold=social_config.activation_threshold,
+            n=social_config.n,
+            n_prime=social_config.n_prime,
+            lambda_importance=social_config.lambda_importance,
+            gamma=social_config.gamma,
+            factor=social_config.factor,
+        )
 
     def _reset_social_force_state(self) -> None:
         """Restore pedestrian physics state for a fresh deterministic episode reset."""

--- a/tests/sim/test_hsfm_fov_pairwise_isolation.py
+++ b/tests/sim/test_hsfm_fov_pairwise_isolation.py
@@ -17,13 +17,29 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from pysocialforce.config import SocialForceConfig
+from pysocialforce.forces import social_force
 
 from robot_sf.sim.pedestrian_model_variants import (
     anisotropic_fov_total_force,
     anisotropic_fov_weights,
+    fov_attenuated_total_force,
     pairwise_fov_attenuated_forces,
+    pairwise_social_force_contributions,
     pairwise_time_to_collision,
 )
+
+
+def _social_kwargs(config: SocialForceConfig) -> dict:
+    """Mirror a ``SocialForceConfig`` as pairwise-contribution keyword arguments."""
+    return {
+        "activation_threshold": config.activation_threshold,
+        "n": config.n,
+        "n_prime": config.n_prime,
+        "lambda_importance": config.lambda_importance,
+        "gamma": config.gamma,
+        "factor": config.factor,
+    }
 
 
 def _reference_scalar_ttc(
@@ -235,3 +251,163 @@ def test_vectorized_ttc_bottleneck_fixture_is_finite_and_bounded() -> None:
     finite = ttc[np.isfinite(ttc)]
     assert np.all(finite >= 0.0)
     assert np.all(finite <= 5.0)
+
+
+def test_pairwise_social_contributions_sum_matches_pysf_aggregate() -> None:
+    """Summing per-pair contributions reproduces PySocialForce's aggregate social force.
+
+    This is the correctness contract that lets the runtime substitute the per-pair
+    decomposition for the aggregate the physics engine already sums into the total force.
+    """
+    rng = np.random.default_rng(3481)
+    positions = rng.uniform(-3.0, 3.0, size=(6, 2))
+    velocities = rng.uniform(-1.0, 1.0, size=(6, 2))
+    config = SocialForceConfig()
+
+    contributions = pairwise_social_force_contributions(
+        positions, velocities, **_social_kwargs(config)
+    )
+    assert contributions.shape == (6, 6, 2)
+
+    expected_aggregate = (
+        social_force(
+            positions,
+            velocities,
+            config.activation_threshold,
+            config.n,
+            config.n_prime,
+            config.lambda_importance,
+            config.gamma,
+        )
+        * config.factor
+    )
+    np.testing.assert_allclose(contributions.sum(axis=1), expected_aggregate, rtol=1e-9, atol=1e-9)
+
+
+def test_pairwise_social_contributions_respect_activation_threshold() -> None:
+    """Pairs beyond the activation threshold contribute exactly zero, like PySocialForce."""
+    positions = np.array([[0.0, 0.0], [0.5, 0.0], [50.0, 0.0]], dtype=float)
+    velocities = np.zeros((3, 2), dtype=float)
+    config = SocialForceConfig()
+
+    contributions = pairwise_social_force_contributions(
+        positions, velocities, **_social_kwargs(config)
+    )
+    # Distant actor 2 is outside the 20 m activation radius in either direction.
+    assert contributions[0, 2].tolist() == [0.0, 0.0]
+    assert contributions[2, 0].tolist() == [0.0, 0.0]
+    # The diagonal is always zero (no self-interaction).
+    assert np.allclose(np.einsum("iik->ik", contributions), 0.0)
+
+
+def test_pairwise_social_contributions_fail_closed() -> None:
+    """Fail closed on bad shapes and non-finite inputs."""
+    good = np.zeros((3, 2), dtype=float)
+    config = SocialForceConfig()
+    with pytest.raises(ValueError, match="positions"):
+        pairwise_social_force_contributions(
+            np.zeros((3, 3), dtype=float), good, **_social_kwargs(config)
+        )
+    with pytest.raises(ValueError, match="finite"):
+        bad = good.copy()
+        bad[0, 0] = np.nan
+        pairwise_social_force_contributions(bad, good, **_social_kwargs(config))
+    with pytest.raises(ValueError, match="activation_threshold"):
+        pairwise_social_force_contributions(
+            good, good, **{**_social_kwargs(config), "activation_threshold": -1.0}
+        )
+
+
+def test_fov_attenuated_total_force_full_cone_recovers_total() -> None:
+    """A full-plane cone leaves the total force unchanged (attenuation is identity)."""
+    rng = np.random.default_rng(11)
+    positions = rng.normal(size=(4, 2))
+    velocities = rng.normal(size=(4, 2))
+    headings = rng.uniform(-np.pi, np.pi, size=4)
+    total = rng.normal(size=(4, 2))
+    config = SocialForceConfig()
+    pairwise = pairwise_social_force_contributions(positions, velocities, **_social_kwargs(config))
+
+    result = fov_attenuated_total_force(
+        total,
+        pairwise,
+        positions,
+        headings,
+        cone_half_angle_rad=np.pi,  # every neighbor in cone -> no attenuation
+        rear_weight=0.0,
+    )
+    np.testing.assert_allclose(result, total, rtol=1e-9, atol=1e-9)
+
+
+def test_fov_attenuated_total_force_only_rescales_social_component() -> None:
+    """Only the ped-ped social term is re-weighted; the rest of the total is preserved.
+
+    The result must equal ``total - social_aggregate + per_pair_attenuated_social`` and,
+    equivalently, differ from the input total by exactly the change in the social term.
+    """
+    positions = np.array([[0.0, 0.0], [1.0, 0.0], [-1.0, 0.0]], dtype=float)
+    headings = np.array([0.0, np.pi, 0.0], dtype=float)
+    total = np.array([[3.0, 1.0], [-2.0, 0.5], [0.0, -1.0]], dtype=float)
+    rear_weight = 0.25
+    cone_half_angle_rad = np.pi / 2
+
+    pairwise = np.zeros((3, 3, 2), dtype=float)
+    pairwise[0, 1] = np.array([-2.0, 0.0])  # in-cone neighbor ahead of actor 0
+    pairwise[0, 2] = np.array([2.0, 0.0])  # rear neighbor behind actor 0
+
+    weights = anisotropic_fov_weights(
+        positions, headings, cone_half_angle_rad=cone_half_angle_rad, rear_weight=rear_weight
+    )
+    expected_attenuated = np.einsum("ij,ijk->ik", weights, pairwise)
+    expected = total - pairwise.sum(axis=1) + expected_attenuated
+
+    result = fov_attenuated_total_force(
+        total,
+        pairwise,
+        positions,
+        headings,
+        cone_half_angle_rad=cone_half_angle_rad,
+        rear_weight=rear_weight,
+    )
+    np.testing.assert_allclose(result, expected, rtol=1e-12, atol=1e-12)
+
+    # Non-interacting actors (rows 1 and 2 have no pairwise contributions here) keep their
+    # full total force untouched by the FoV re-weighting.
+    np.testing.assert_allclose(result[1], total[1], rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(result[2], total[2], rtol=1e-12, atol=1e-12)
+
+
+def test_fov_attenuated_total_force_rejects_bad_shapes() -> None:
+    """Fail closed on mismatched total/pairwise shapes and non-finite totals."""
+    positions = np.zeros((3, 2), dtype=float)
+    headings = np.zeros(3, dtype=float)
+    pairwise = np.zeros((3, 3, 2), dtype=float)
+    with pytest.raises(ValueError, match="total_forces must have shape"):
+        fov_attenuated_total_force(
+            np.zeros((2, 2), dtype=float),
+            pairwise,
+            positions,
+            headings,
+            cone_half_angle_rad=np.pi / 2,
+            rear_weight=0.5,
+        )
+    with pytest.raises(ValueError, match="pairwise_social_forces must have shape"):
+        fov_attenuated_total_force(
+            np.zeros((3, 2), dtype=float),
+            np.zeros((3, 2), dtype=float),
+            positions,
+            headings,
+            cone_half_angle_rad=np.pi / 2,
+            rear_weight=0.5,
+        )
+    with pytest.raises(ValueError, match="total_forces must be finite"):
+        bad_total = np.zeros((3, 2), dtype=float)
+        bad_total[0, 0] = np.inf
+        fov_attenuated_total_force(
+            bad_total,
+            pairwise,
+            positions,
+            headings,
+            cone_half_angle_rad=np.pi / 2,
+            rear_weight=0.5,
+        )

--- a/tests/sim/test_hsfm_total_force_model.py
+++ b/tests/sim/test_hsfm_total_force_model.py
@@ -6,6 +6,8 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+from pysocialforce.config import SocialForceConfig
+from pysocialforce.forces import SocialForce
 
 from robot_sf.sim.pedestrian_model_variants import (
     HSFM_ANISOTROPIC_FOV_V1,
@@ -14,13 +16,30 @@ from robot_sf.sim.pedestrian_model_variants import (
     SOCIAL_FORCE_DEFAULT,
     anisotropic_fov_total_force,
     anisotropic_fov_weights,
+    fov_attenuated_total_force,
     heading_from_total_force,
     normalize_pedestrian_model,
+    pairwise_social_force_contributions,
     step_hsfm_total_force,
 )
 from robot_sf.sim.sim_config import SimulationSettings
 from robot_sf.sim.simulator import Simulator
 from robot_sf.training.scenario_loader import build_robot_config_from_scenario
+
+PYSF_POSITION_SLICE = slice(0, 2)
+PYSF_VELOCITY_SLICE = slice(2, 4)
+
+
+def _social_force_kwargs(config: SocialForceConfig) -> dict:
+    """Return the pairwise-contribution kwargs mirroring a ``SocialForceConfig``."""
+    return {
+        "activation_threshold": config.activation_threshold,
+        "n": config.n,
+        "n_prime": config.n_prime,
+        "lambda_importance": config.lambda_importance,
+        "gamma": config.gamma,
+        "factor": config.factor,
+    }
 
 
 class _FakePedState:
@@ -170,36 +189,138 @@ def test_scenario_anisotropic_fov_selector_marks_config_enabled(tmp_path) -> Non
     assert config.sim_config.anisotropic_fov.rear_weight == pytest.approx(0.25)
 
 
-def test_simulator_hsfm_anisotropic_fov_one_step_smoke_is_finite_and_deterministic() -> None:
-    """The FoV selector applies deterministic rear attenuation before HSFM stepping."""
+def _make_fov_simulator(
+    state: np.ndarray,
+    headings: np.ndarray,
+    social_config: SocialForceConfig,
+    *,
+    cone_half_angle_rad: float,
+    rear_weight: float,
+) -> tuple[Simulator, _FakePedState]:
+    """Build a bare FoV-model ``Simulator`` around a fake ped state and social force.
+
+    The seam only reads the ``SocialForce`` component for its config, so a stored-only
+    ``SocialForce`` instance is sufficient to exercise the runtime path.
+    """
+    peds = _FakePedState(state)
+    sim = object.__new__(Simulator)
+    sim.pedestrian_model = HSFM_ANISOTROPIC_FOV_V1
+    sim.pysf_sim = SimpleNamespace(peds=peds, forces=[SocialForce(social_config, None)])
+    sim.config = SimulationSettings(
+        pedestrian_model=HSFM_ANISOTROPIC_FOV_V1,
+        anisotropic_fov={
+            "cone_half_angle_rad": cone_half_angle_rad,
+            "rear_weight": rear_weight,
+        },
+        time_per_step_in_secs=0.1,
+    )
+    sim.ped_headings = headings.copy()
+    return sim, peds
+
+
+def test_simulator_hsfm_anisotropic_fov_one_step_matches_per_pair_composition() -> None:
+    """The FoV selector consumes per-pair ped-ped forces, not the ``np.min`` aggregate.
+
+    The runtime seam must isolate the pedestrian-pedestrian social component, attenuate it
+    per pair, and add it back to the untouched goal/obstacle drive. This pins the seam to
+    the pure :func:`fov_attenuated_total_force` composition (issue #3481).
+    """
     state = np.array(
         [
             [0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.5],
             [-1.0, 0.0, 0.0, 0.0, -10.0, 0.0, 0.5],
+            [1.2, 0.0, 0.0, 0.0, 10.0, 0.0, 0.5],
         ],
         dtype=float,
     )
+    headings = np.array([0.0, 0.0, np.pi], dtype=float)
+    social_config = SocialForceConfig()
+    total_forces = np.array([[2.0, 0.5], [2.0, 0.0], [-1.0, 0.3]], dtype=float)
+    cone_half_angle_rad = np.pi / 2
+    rear_weight = 0.25
+
+    # Independent reference: build the per-pair matrix and pure composition from a snapshot
+    # of the pre-step positions/velocities and the same social-force parameters.
+    positions = state[:, PYSF_POSITION_SLICE].copy()
+    velocities = state[:, PYSF_VELOCITY_SLICE].copy()
+    pairwise_social = pairwise_social_force_contributions(
+        positions, velocities, **_social_force_kwargs(social_config)
+    )
+    expected_forces = fov_attenuated_total_force(
+        total_forces,
+        pairwise_social,
+        positions,
+        headings,
+        cone_half_angle_rad=cone_half_angle_rad,
+        rear_weight=rear_weight,
+    )
+    expected_state, expected_headings = step_hsfm_total_force(
+        state.copy(),
+        expected_forces,
+        headings,
+        dt=0.1,
+        max_speeds=np.full(state.shape[0], 10.0, dtype=float),
+    )
+
+    sim, peds = _make_fov_simulator(
+        state,
+        headings,
+        social_config,
+        cone_half_angle_rad=cone_half_angle_rad,
+        rear_weight=rear_weight,
+    )
+    sim._step_pedestrians(total_forces.copy(), [[0], [1], [2]])
+
+    assert peds.updated_state is state
+    assert np.all(np.isfinite(state))
+    assert np.all(np.isfinite(sim.ped_headings))
+    np.testing.assert_allclose(state, expected_state, rtol=1e-9, atol=1e-9)
+    np.testing.assert_allclose(sim.ped_headings, expected_headings, rtol=1e-9, atol=1e-9)
+
+
+def test_simulator_hsfm_anisotropic_fov_step_is_deterministic() -> None:
+    """Repeated identical steps yield byte-identical state (deterministic opt-in path)."""
+    base_state = np.array(
+        [
+            [0.0, 0.0, 0.1, 0.0, 10.0, 0.0, 0.5],
+            [-0.8, 0.2, 0.0, 0.0, -10.0, 0.0, 0.5],
+        ],
+        dtype=float,
+    )
+    headings = np.array([0.0, np.pi], dtype=float)
+    forces = np.array([[1.5, 0.2], [1.0, -0.1]], dtype=float)
+
+    results = []
+    for _ in range(2):
+        sim, _ = _make_fov_simulator(
+            base_state.copy(),
+            headings,
+            SocialForceConfig(),
+            cone_half_angle_rad=np.pi / 2,
+            rear_weight=0.3,
+        )
+        sim._step_pedestrians(forces.copy(), [[0], [1]])
+        results.append(sim.pysf_sim.peds.state.copy())
+
+    np.testing.assert_array_equal(results[0], results[1])
+
+
+def test_simulator_hsfm_anisotropic_fov_fails_closed_without_social_force() -> None:
+    """A missing ``SocialForce`` component fails closed instead of silently degrading."""
+    state = np.array([[0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.5]], dtype=float)
     peds = _FakePedState(state)
     sim = object.__new__(Simulator)
     sim.pedestrian_model = HSFM_ANISOTROPIC_FOV_V1
-    sim.pysf_sim = SimpleNamespace(peds=peds)
+    sim.pysf_sim = SimpleNamespace(peds=peds, forces=[])
     sim.config = SimulationSettings(
         pedestrian_model=HSFM_ANISOTROPIC_FOV_V1,
         anisotropic_fov={"cone_half_angle_rad": np.pi / 2, "rear_weight": 0.25},
         time_per_step_in_secs=0.1,
     )
-    sim.ped_headings = np.array([0.0, 0.0], dtype=float)
+    sim.ped_headings = np.array([0.0], dtype=float)
 
-    sim._step_pedestrians(np.array([[2.0, 0.0], [2.0, 0.0]], dtype=float), [[0], [1]])
-
-    assert peds.updated_groups == [[0], [1]]
-    assert peds.updated_state is state
-    assert np.all(np.isfinite(state))
-    assert np.all(np.isfinite(sim.ped_headings))
-    assert state[0, 2] == pytest.approx(0.05)
-    assert state[0, 0] == pytest.approx(0.005)
-    assert state[1, 2] == pytest.approx(0.2)
-    assert state[1, 0] == pytest.approx(-0.98)
+    with pytest.raises(RuntimeError, match="SocialForce component is unavailable"):
+        sim._step_pedestrians(np.array([[2.0, 0.0]], dtype=float), [[0]])
 
 
 def test_anisotropic_fov_weights_match_nested_loop_oracle() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** The opt-in `hsfm_anisotropic_fov_v1` pedestrian model now consumes **per-pair pedestrian-pedestrian forces** at the simulator seam instead of the aggregate `np.min` field-of-view (FoV) attenuation applied to the whole force. New capability: **runtime consumption of per-pair pp-force contributions** — the exact next step named in the PR #4297 gate comment on #3481.
- **Why now:** PR #4297 landed the pairwise-isolated FoV helper + vectorized TTC at the pure-math layer but left the runtime still using the coarse aggregate. The maintainer named this as the remaining CPU slice: *"wire per-pair pp-force contributions from the simulator seam so runtime consumes isolation instead of the np.min aggregate."*
- **Claim boundary:** diagnostic/prototype only. **No** calibrated-realism, benchmark-strength, planner-ranking, or paper/dissertation claim. Only the opt-in `hsfm_anisotropic_fov_v1` runtime path changed.
- **Required validation:** focused unit + simulator tests below (38 passed) + a real-env end-to-end smoke; CPU only.
- **Remaining blocker:** `pairwise_social_force_contributions` is an `O(N^2)` Python loop over the njit kernel (matches the aggregate exactly; vectorize before benchmark scale). Narrow-passage lateral-sliding and bottleneck freeze/deadlock benchmark evidence and any evidence-tier upgrade remain out of scope.

Closes part of #3481 (issue stays open for benchmark evidence / vectorization).

## Contract delta

- **New pure helpers** in `robot_sf/sim/pedestrian_model_variants.py`:
  - `pairwise_social_force_contributions(positions, velocities, *, activation_threshold, n, n_prime, lambda_importance, gamma, factor) -> (N, N, 2)` — reuses PySocialForce's `social_force_ped_ped` kernel so `contributions.sum(axis=1)` reproduces the aggregate `SocialForce()` the engine already sums into the total force (pinned by a unit test against `pysocialforce.forces.social_force`).
  - `fov_attenuated_total_force(total_forces, pairwise_social_forces, positions, headings, *, cone_half_angle_rad, rear_weight) -> (N, 2)` — `total - social_aggregate + pairwise_fov_attenuated_forces(...)`.
- **New fail-closed blocker:** `Simulator._social_force_component` raises `RuntimeError` if no `SocialForce` component is present (mirrors the existing `max_speeds` guard) so the opt-in model never silently degrades to a different force law.
- **Behavior change (opt-in only):** the previous FoV path scaled the *entire* per-actor force (goal + social + obstacle + robot) by a single `np.min` weight; the new path attenuates *only* the ped-ped social contributions, per pair. `social_force_default`, `hsfm_total_force_v1`, `hsfm_ttc_predictive_v1` are byte/behavior-unchanged. The aggregate helper `anisotropic_fov_total_force` is **retained** as the reference contrast for the isolation tests.
- **Compatibility:** no config schema change, no PySocialForce state-schema change. The runtime FoV smoke test was updated to pin the new per-pair composition.

## Validation

```
uv run pytest tests/sim/test_hsfm_fov_pairwise_isolation.py \
  tests/sim/test_hsfm_total_force_model.py \
  tests/sim/test_ttc_predictive_pedestrian_model.py -q
# 38 passed

uv run ruff check robot_sf/sim tests/sim   # All checks passed!
uv run ruff format --check <changed files>  # already formatted
```

End-to-end smoke (not committed): a real `make_robot_env` run with `pedestrian_model=hsfm_anisotropic_fov_v1` stepped 15 times with finite pedestrian positions, confirming the real force list exposes a `SocialForce` component for the seam.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no default pedestrian-model change, no calibrated-realism or lateral-sliding/bottleneck-freeze evidence promotion.

<details>
<summary>Governance / propagation</summary>

- **Late-guidance check (step 6b):** re-read issue #3481 immediately before opening; newest maintainer comment (PR #4297 gate) names exactly this task. No newer comments; no open PR duplicates the scope.
- **Fragmentation guard (6c):** three progression PRs merged for #3481 in the last 24h (#4202/#4258/#4297). This slice is **exempt** as a progression slice adding a nameable new capability (runtime per-pair force consumption), not a micro-guard.
- **State propagation (6e):** canonical durable surface is the context note `docs/context/issue_3481_hsfm_ttc_predictive_forces.md` (updated with a runtime-wiring section). Issue comment omitted (comment authorization off for this worker); no transient routing state added to tracked files (6d).
- **Downstream Propagation:** parent issue #3481 stays open; context note updated; no claim map / leaderboard / registry impact (diagnostic/prototype). `CHANGELOG.md` updated.
- **Research Result Guidance:** target = wire per-pair pp-forces into runtime; comparator = prior aggregate `np.min` path; evidence tier = diagnostic/prototype; result = capability landed, no empirical claim; synthesis surface = context note.
</details>
