### PR TITLE
#3207: consume fixed-scope preflight plan in fidelity-sensitivity runner (fail-closed, no campaign)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Extended the **issue #3207 fidelity-sensitivity campaign runner to consume the fixed-scope preflight
+  plan** (`scripts/benchmark/run_fidelity_sensitivity_campaign.py`). A new `--fixed-scope-plan-only`
+  mode builds the preflight packet and enumerates the concrete full run plan — every
+  planner_group × axis-variant × seed run cell (the shipped config materializes 108 cells/scenario) —
+  with each cell carrying its resolved `algorithm_readiness` catalog algorithm and opt-in/tier state.
+  It runs **no** episode and promotes no claim; actual launch stays **fail-closed** behind the
+  preflight's unmet launch prerequisites (ORCA/rvo2 runtime dependency, hybrid-rule explicit opt-in,
+  runner-not-yet-wired for the full planner set, and the post-run rank-identifiability recheck). A
+  `--require-launchable` flag exits non-zero while any gate remains, and `ensure_fixed_scope_launchable`
+  raises `FixedScopeNotLaunchableError` so no full campaign can launch against unresolved prerequisites.
+  The enumerated plan JSON is written to gitignored `output/`; the bounded two-planner slice runner
+  behavior is unchanged. Not benchmark, simulator-realism, sim-to-real, or paper-facing evidence.
 * Added a **full fixed-scope fidelity-sensitivity preflight** for issue #3207 that pre-registers the
   simulator-fidelity sensitivity campaign before launch (`robot_sf/benchmark/fidelity_fixed_scope_preflight.py`,
   CLI `scripts/benchmark/preflight_fidelity_fixed_scope.py`). It materializes the explicit run plan

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -20,7 +20,7 @@ import math
 import pathlib
 import subprocess
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -28,8 +28,12 @@ import yaml
 
 from robot_sf.baselines.interface import Observation
 from robot_sf.baselines.social_force import SFPlannerConfig, SocialForcePlanner
+from robot_sf.benchmark.fidelity_fixed_scope_preflight import build_fixed_scope_preflight
 from robot_sf.benchmark.fidelity_rank_stability import analyze_fidelity_sensitivity
-from robot_sf.benchmark.fidelity_sensitivity import DIAGNOSTIC_SMOKE_CLAIM_BOUNDARY
+from robot_sf.benchmark.fidelity_sensitivity import (
+    DIAGNOSTIC_SMOKE_CLAIM_BOUNDARY,
+    validate_fidelity_sensitivity_config,
+)
 from robot_sf.gym_env.environment_factory import make_robot_env
 from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
 
@@ -61,6 +65,212 @@ CLAIM_BOUNDARY = (
     "paper-facing planner-ranking, or full #3207 acceptance evidence."
 )
 ARCHETYPE_SPEED_FACTORS = {"cautious": 0.8, "standard": 1.0, "hurried": 1.2}
+
+FIXED_SCOPE_PLAN_SCHEMA_VERSION = "issue_3207_fidelity_fixed_scope_run_plan.v1"
+FIXED_SCOPE_PLAN_CLAIM_BOUNDARY = (
+    "fixed_scope_run_plan_enumeration_only: consumes the issue #3207 fixed-scope preflight "
+    "packet and enumerates the concrete planner_group x axis-variant x seed run cells that the "
+    "full fixed-scope campaign would execute. It launches no episode and promotes no claim; "
+    "execution stays fail-closed behind unmet launch prerequisites (ORCA/rvo2 runtime "
+    "dependency, hybrid-rule explicit opt-in, and the post-run rank-identifiability recheck). "
+    "It is not benchmark evidence, not simulator-realism evidence, not sim-to-real evidence, "
+    "and not paper-facing evidence."
+)
+
+
+class FixedScopeNotLaunchableError(RuntimeError):
+    """Raised when a fixed-scope run plan still has unmet launch gates.
+
+    The bounded slice runner intentionally leaves the ORCA/rvo2 runtime
+    dependency, the hybrid-rule explicit opt-in, and the post-run
+    rank-identifiability recheck unsatisfied, so an actual full campaign launch
+    must fail closed rather than silently run against unresolved prerequisites.
+    """
+
+
+@dataclass(frozen=True)
+class FixedScopeRunCell:
+    """One planner_group x axis-variant x seed cell of the full fixed scope.
+
+    A cell describes a unit of work the full campaign would execute for each
+    scenario in the fixed scenario set. It carries the resolved catalog
+    algorithm and its availability/opt-in state so downstream launch logic can
+    reason about the cell without re-resolving the planner group.
+    """
+
+    planner_group: str
+    algorithm: str
+    planner_available: bool
+    planner_tier: str | None
+    requires_explicit_opt_in: bool
+    axis: str
+    variant: str
+    baseline_variant: bool
+    seed: int
+    scenario_set: str
+
+
+def enumerate_fixed_scope_run_cells(
+    validated: Mapping[str, Any],
+    resolution_by_group: Mapping[str, Mapping[str, Any]],
+) -> list[FixedScopeRunCell]:
+    """Enumerate the full fixed-scope run cells from a validated study config.
+
+    The enumeration mirrors the preflight materialization order
+    (planner_group x every axis variant x seed, including baseline variants) so
+    the cell count matches ``materialized_scope.run_cells_per_scenario``.
+
+    Args:
+        validated: Config returned by ``validate_fidelity_sensitivity_config``.
+        resolution_by_group: Planner-group name to preflight resolution record.
+
+    Returns:
+        Run cells in deterministic planner/axis/variant/seed order.
+    """
+    fixed_scope = validated["fixed_scope"]
+    seeds = [int(seed) for seed in fixed_scope["seeds"]]
+    scenario_set = str(fixed_scope["scenario_set"])
+    planner_groups = [str(group) for group in fixed_scope["planner_groups"]]
+    cells: list[FixedScopeRunCell] = []
+    for group in planner_groups:
+        record = resolution_by_group.get(group, {})
+        for axis in validated["axes"]:
+            axis_key = str(axis["key"])
+            for variant in axis["variants"]:
+                variant_key = str(variant["key"])
+                baseline = bool(variant.get("baseline", False))
+                for seed in seeds:
+                    cells.append(
+                        FixedScopeRunCell(
+                            planner_group=group,
+                            algorithm=str(record.get("algorithm", group)),
+                            planner_available=bool(record.get("available", False)),
+                            planner_tier=record.get("tier"),
+                            requires_explicit_opt_in=bool(
+                                record.get("requires_explicit_opt_in", False)
+                            ),
+                            axis=axis_key,
+                            variant=variant_key,
+                            baseline_variant=baseline,
+                            seed=seed,
+                            scenario_set=scenario_set,
+                        )
+                    )
+    return cells
+
+
+def build_fixed_scope_run_plan(
+    config: Mapping[str, Any],
+    *,
+    config_path: str,
+    git_head: str,
+    date: str | None = None,
+) -> dict[str, Any]:
+    """Consume the #3207 fixed-scope preflight and build an executable run plan.
+
+    This is the runner-side counterpart to
+    :func:`robot_sf.benchmark.fidelity_fixed_scope_preflight.build_fixed_scope_preflight`:
+    the preflight owns the launch/readiness gate, while this function turns the
+    materialized scope into the concrete run cells the campaign runner would
+    iterate. It runs no episode. ``executable`` is only ``True`` when the
+    preflight is ready and *all* launch prerequisites and blockers are cleared,
+    so the shipped config (which still lists rvo2/opt-in/runner-not-wired
+    prerequisites) yields a fail-closed, non-executable plan.
+
+    Args:
+        config: Raw fidelity-sensitivity study config mapping.
+        config_path: Repo-relative config path, recorded for provenance.
+        git_head: Git head recorded for provenance.
+        date: Optional ISO date string recorded for provenance.
+
+    Returns:
+        JSON-serializable run-plan packet embedding the preflight decision, the
+        enumerated run cells, and the residual launch gates.
+    """
+    validated = validate_fidelity_sensitivity_config(config)
+    preflight = build_fixed_scope_preflight(
+        config, config_path=config_path, git_head=git_head, date=date
+    )
+    resolution_by_group = {
+        str(record["planner_group"]): record for record in preflight["planner_resolution"]
+    }
+    cells = enumerate_fixed_scope_run_cells(validated, resolution_by_group)
+
+    materialized = preflight["materialized_scope"]
+    expected_cells = int(materialized["run_cells_per_scenario"])
+    if len(cells) != expected_cells:
+        # Internal contract: the runner plan and the preflight materialization
+        # must agree on scope, otherwise one of them is stale.
+        raise ValueError(
+            "fixed-scope run-plan enumeration disagrees with preflight materialization: "
+            f"{len(cells)} cells vs run_cells_per_scenario={expected_cells}"
+        )
+
+    blockers = list(preflight["blockers"])
+    launch_prerequisites = list(preflight["launch_prerequisites"])
+    gate_reasons = blockers + launch_prerequisites
+    executable = bool(preflight["preflight_ready"]) and not gate_reasons
+
+    return {
+        "schema_version": FIXED_SCOPE_PLAN_SCHEMA_VERSION,
+        "issue": int(preflight.get("issue", 3207)),
+        "study_id": str(validated["study_id"]),
+        "claim_boundary": FIXED_SCOPE_PLAN_CLAIM_BOUNDARY,
+        "config_path": config_path,
+        "git_head": git_head,
+        "date": date,
+        "preflight_decision": preflight["decision"],
+        "preflight_ready": bool(preflight["preflight_ready"]),
+        "preflight_claim_boundary": preflight["claim_boundary"],
+        "executable": executable,
+        "launched": False,
+        "run_cell_count": len(cells),
+        "run_cells_per_scenario_expected": expected_cells,
+        "materialized_scope": materialized,
+        "planner_resolution": preflight["planner_resolution"],
+        "primary_metric": preflight["primary_metric"],
+        "blockers": blockers,
+        "launch_prerequisites": launch_prerequisites,
+        "gate_reasons": gate_reasons,
+        "run_cells": [asdict(cell) for cell in cells],
+    }
+
+
+def ensure_fixed_scope_launchable(plan: Mapping[str, Any]) -> None:
+    """Fail closed unless a fixed-scope run plan has cleared every launch gate.
+
+    Args:
+        plan: Packet from :func:`build_fixed_scope_run_plan`.
+
+    Raises:
+        FixedScopeNotLaunchableError: If the plan is not executable or any
+            blocker/launch-prerequisite remains.
+    """
+    gate_reasons = list(plan.get("gate_reasons") or [])
+    if plan.get("executable") and not gate_reasons:
+        return
+    reasons = gate_reasons or ["preflight_not_ready"]
+    raise FixedScopeNotLaunchableError(
+        "fixed-scope campaign is not launchable; unmet gates: " + "; ".join(reasons)
+    )
+
+
+def write_fixed_scope_run_plan(
+    plan: Mapping[str, Any], output_dir: str | pathlib.Path
+) -> pathlib.Path:
+    """Write a deterministic fixed-scope run-plan JSON to gitignored output.
+
+    Returns:
+        Path to the written ``fidelity_fixed_scope_run_plan.json`` file.
+    """
+    out = pathlib.Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    plan_path = out / "fidelity_fixed_scope_run_plan.json"
+    plan_path.write_text(
+        json.dumps(plan, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return plan_path
 
 
 @dataclass(frozen=True)
@@ -666,8 +876,60 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Run only the baseline plus the first runtime-bound perturbation per fidelity axis.",
     )
+    parser.add_argument(
+        "--fixed-scope-plan-only",
+        action="store_true",
+        help=(
+            "Consume the #3207 fixed-scope preflight and enumerate the full run plan "
+            "(planner_group x axis-variant x seed) without running any episode."
+        ),
+    )
+    parser.add_argument(
+        "--plan-out",
+        default="output/fidelity_sensitivity/issue_3207_fixed_scope_run_plan",
+        help="Directory for the emitted fixed-scope run-plan JSON (gitignored output).",
+    )
+    parser.add_argument(
+        "--require-launchable",
+        action="store_true",
+        help=(
+            "With --fixed-scope-plan-only, exit non-zero (fail closed) unless every launch "
+            "prerequisite is cleared. The bounded slice runner leaves ORCA/rvo2, hybrid opt-in, "
+            "and the post-run rank-identifiability recheck unmet, so this fails closed."
+        ),
+    )
     parser.add_argument("--date", default=dt.datetime.now(tz=dt.UTC).date().isoformat())
     return parser.parse_args(argv)
+
+
+def _run_fixed_scope_plan_only(args: argparse.Namespace, config: Mapping[str, Any]) -> int:
+    """Emit the fixed-scope run plan without running any episode.
+
+    Returns:
+        ``0`` on success, or ``1`` when ``--require-launchable`` is set and the
+        plan still has unmet launch gates (fail-closed).
+    """
+    plan = build_fixed_scope_run_plan(
+        config,
+        config_path=args.config,
+        git_head=_git_head(),
+        date=str(args.date),
+    )
+    plan_path = write_fixed_scope_run_plan(plan, REPO_ROOT / args.plan_out)
+    print(f"wrote fixed-scope run plan: {_repo_rel(plan_path)}")
+    print(
+        f"preflight_decision={plan['preflight_decision']} executable={plan['executable']} "
+        f"launched={plan['launched']} run_cells={plan['run_cell_count']}"
+    )
+    for reason in plan["gate_reasons"]:
+        print(f"  launch gate: {reason}")
+    if args.require_launchable:
+        try:
+            ensure_fixed_scope_launchable(plan)
+        except FixedScopeNotLaunchableError as exc:
+            print(f"fail-closed: {exc}")
+            return 1
+    return 0
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -677,6 +939,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     if not isinstance(config, Mapping):
         raise ValueError(f"config must be a mapping: {config_path}")
+    if args.fixed_scope_plan_only:
+        # Plan-consumption mode: enumerate the full fixed-scope run plan and stop
+        # before any episode. Execution stays fail-closed behind launch gates.
+        return _run_fixed_scope_plan_only(args, config)
     scenario_path = REPO_ROOT / args.scenario_set
     scenarios = list(load_scenarios(scenario_path))
     if not scenarios:

--- a/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
+++ b/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
@@ -1,0 +1,181 @@
+"""Tests for the issue #3207 fixed-scope run-plan consumption path.
+
+These cover the runner-side counterpart to the fixed-scope preflight: the
+campaign runner consumes the pre-registered plan and enumerates the concrete
+planner_group x axis-variant x seed run cells, while keeping actual launch
+fail-closed behind unmet launch prerequisites (ORCA/rvo2, hybrid opt-in, and the
+post-run rank-identifiability recheck). No benchmark episodes are run.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.fidelity_fixed_scope_preflight import build_fixed_scope_preflight
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs" / "research" / "fidelity_sensitivity_v1.yaml"
+
+
+def _load_campaign_runner() -> ModuleType:
+    module_path = REPO_ROOT / "scripts" / "benchmark" / "run_fidelity_sensitivity_campaign.py"
+    spec = importlib.util.spec_from_file_location(
+        "fidelity_sensitivity_campaign_runner", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load campaign runner module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["fidelity_sensitivity_campaign_runner"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+campaign_runner = _load_campaign_runner()
+
+
+def _config() -> dict:
+    return yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def _plan() -> dict:
+    return campaign_runner.build_fixed_scope_run_plan(
+        _config(),
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="test-head",
+    )
+
+
+def test_run_plan_cell_count_matches_preflight_materialization() -> None:
+    """Enumerated run cells must equal preflight run_cells_per_scenario (3x12x3=108)."""
+    config = _config()
+    preflight = build_fixed_scope_preflight(
+        config, config_path="configs/research/fidelity_sensitivity_v1.yaml", git_head="test-head"
+    )
+    plan = _plan()
+
+    expected = preflight["materialized_scope"]["run_cells_per_scenario"]
+    assert plan["run_cell_count"] == expected
+    assert len(plan["run_cells"]) == expected
+    assert plan["run_cells_per_scenario_expected"] == expected
+
+
+def test_run_cells_carry_resolved_algorithm_and_scope_axes() -> None:
+    """Each cell exposes the resolved catalog algorithm, axis, variant, and seed."""
+    plan = _plan()
+    groups = {cell["planner_group"] for cell in plan["run_cells"]}
+    axes = {cell["axis"] for cell in plan["run_cells"]}
+    seeds = {cell["seed"] for cell in plan["run_cells"]}
+    algorithms = {cell["planner_group"]: cell["algorithm"] for cell in plan["run_cells"]}
+
+    assert groups == {"orca", "default_social_force", "hybrid_rule_v0_minimal"}
+    assert {
+        "integration_timestep",
+        "social_force_speed_archetypes",
+        "observation_noise",
+        "clearance_radius",
+    } <= axes
+    assert seeds == {111, 112, 113}
+    # default_social_force resolves to the canonical social_force algorithm.
+    assert algorithms["default_social_force"] == "social_force"
+    # Baseline variants are included in the full fixed scope: one baseline per
+    # axis (4 axes) x every planner group (3) x every seed (3) => 36 cells.
+    assert sum(1 for cell in plan["run_cells"] if cell["baseline_variant"]) == 4 * len(
+        groups
+    ) * len(seeds)
+
+
+def test_shipped_config_plan_is_not_launchable_and_records_gates() -> None:
+    """The shipped config is preflight_ready but fails closed on launch prerequisites."""
+    plan = _plan()
+
+    assert plan["preflight_decision"] == "preflight_ready"
+    assert plan["preflight_ready"] is True
+    # Fail-closed: unmet launch prerequisites keep the plan non-executable / unlaunched.
+    assert plan["executable"] is False
+    assert plan["launched"] is False
+    assert plan["gate_reasons"], "expected residual launch gates"
+
+    joined = " ".join(plan["gate_reasons"])
+    assert "rvo2" in joined  # ORCA runtime dependency
+    assert "explicit_opt_in:hybrid_rule_v0_minimal" in joined  # hybrid opt-in
+    assert "runtime_rank_identifiability_recheck_required" in joined  # post-run recheck
+    assert "campaign_runner_not_wired_for_full_fixed_scope" in joined
+
+
+def test_ensure_launchable_raises_when_gated() -> None:
+    """ensure_fixed_scope_launchable must fail closed while gates remain."""
+    plan = _plan()
+    with pytest.raises(campaign_runner.FixedScopeNotLaunchableError):
+        campaign_runner.ensure_fixed_scope_launchable(plan)
+
+
+def test_ensure_launchable_passes_only_when_all_gates_cleared() -> None:
+    """A fully cleared plan is the only launchable state."""
+    plan = _plan()
+    plan["executable"] = True
+    plan["gate_reasons"] = []
+    # Should not raise.
+    campaign_runner.ensure_fixed_scope_launchable(plan)
+
+
+def test_unresolved_planner_group_blocks_plan_fail_closed() -> None:
+    """Removing the planner_algorithms binding must surface a fail-closed blocker."""
+    config = copy.deepcopy(_config())
+    # Without the explicit binding, the ``default_social_force`` label no longer
+    # resolves to a catalog algorithm and must fail closed as a blocker.
+    del config["fixed_scope"]["planner_algorithms"]
+    plan = campaign_runner.build_fixed_scope_run_plan(
+        config,
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="test-head",
+    )
+
+    assert plan["preflight_decision"] == "blocked"
+    assert plan["executable"] is False
+    assert any(reason.startswith("planner_unavailable:") for reason in plan["blockers"])
+    with pytest.raises(campaign_runner.FixedScopeNotLaunchableError):
+        campaign_runner.ensure_fixed_scope_launchable(plan)
+
+
+def test_plan_only_cli_writes_plan_without_running_episodes(tmp_path: Path) -> None:
+    """--fixed-scope-plan-only emits the plan JSON and never runs an episode."""
+    plan_dir = tmp_path / "plan"
+    exit_code = campaign_runner.main(
+        [
+            "--fixed-scope-plan-only",
+            "--plan-out",
+            str(plan_dir),
+        ]
+    )
+    assert exit_code == 0
+    plan_path = plan_dir / "fidelity_fixed_scope_run_plan.json"
+    assert plan_path.exists()
+    import json
+
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    assert plan["schema_version"] == campaign_runner.FIXED_SCOPE_PLAN_SCHEMA_VERSION
+    assert plan["launched"] is False
+    assert plan["run_cell_count"] == 108
+
+
+def test_plan_only_cli_require_launchable_fails_closed(tmp_path: Path) -> None:
+    """--require-launchable exits non-zero because launch gates remain unmet."""
+    exit_code = campaign_runner.main(
+        [
+            "--fixed-scope-plan-only",
+            "--plan-out",
+            str(tmp_path / "plan"),
+            "--require-launchable",
+        ]
+    )
+    assert exit_code == 1


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Extends the issue #3207 fidelity-sensitivity **campaign runner** (`scripts/benchmark/run_fidelity_sensitivity_campaign.py`) to **consume the fixed-scope preflight plan** (from merged PR #4351) and enumerate the concrete full run plan — without launching a campaign. New `--fixed-scope-plan-only` mode + `build_fixed_scope_run_plan` / `ensure_fixed_scope_launchable` helpers.
- **Why now (progression slice):** PR #4351's preflight explicitly enumerates as its top remaining launch prerequisite that the *campaign runner is still a bounded two-planner slice* and must be "extend[ed] to the resolved planner set before launch." This PR delivers that plan-consumption capability (the runner can now materialize the full 108-cell plan from the preflight), a **nameable new capability** — not a duplicate micro-guard.
- **Claim boundary:** Enumeration/launch-plan only. It runs **no** episode and promotes no claim. `executable` is `False` for the shipped config; execution stays **fail-closed** behind the preflight's unmet prerequisites. Not benchmark evidence, not simulator-realism evidence, not sim-to-real evidence, not paper-facing evidence.
- **Required validation:** new focused tests + the existing #3207 fidelity/simulator-dependence suite + the plan-only CLI (CPU only). Results below.
- **Remaining blocker:** actual full-fixed-scope execution still needs rvo2 for ORCA, explicit opt-in for the hybrid-rule planner, per-cell episode wiring, and the post-run rank-identifiability recheck. All are surfaced as fail-closed launch gates; none are resolved here.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3207

## Scope

In scope (delivered):
- **Plan consumption:** `build_fixed_scope_run_plan(config, ...)` builds the preflight packet (reusing `robot_sf/benchmark/fidelity_fixed_scope_preflight.py`) and enumerates every `planner_group × axis-variant × seed` run cell. The shipped config materializes **108 cells/scenario** (3 planner groups × 12 variants × 3 seeds); the enumerated cell count is asserted equal to the preflight `materialized_scope.run_cells_per_scenario`.
- **Resolved cells:** each `FixedScopeRunCell` carries its resolved `algorithm_readiness` catalog algorithm plus availability / tier / opt-in state, so launch logic need not re-resolve.
- **Fail-closed launch gate:** `executable` is `True` only when `preflight_ready` **and** no blockers/launch-prerequisites remain. `ensure_fixed_scope_launchable(plan)` raises `FixedScopeNotLaunchableError` while any gate remains.
- **CLI:** `--fixed-scope-plan-only` writes the enumerated plan JSON to gitignored `output/` and runs no episode; `--require-launchable` exits non-zero (fail-closed) while gated.

Out of scope (explicit): **no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.** The bounded two-planner slice runner behavior is unchanged; no episode is executed.

## Contract delta

- **New runner API:** `build_fixed_scope_run_plan`, `enumerate_fixed_scope_run_cells`, `ensure_fixed_scope_launchable`, `write_fixed_scope_run_plan`, `FixedScopeRunCell`, `FixedScopeNotLaunchableError`; `FIXED_SCOPE_PLAN_SCHEMA_VERSION = "issue_3207_fidelity_fixed_scope_run_plan.v1"`.
- **New plan packet fields:** `preflight_decision`, `executable`, `launched` (always `False` here), `run_cell_count`, `run_cells_per_scenario_expected`, `run_cells[]`, `blockers`, `launch_prerequisites`, `gate_reasons`.
- **New fail-closed behavior:** `--require-launchable` returns exit 1 while gates remain; unresolved planner groups propagate the preflight's `planner_unavailable:*` blockers into a non-executable plan.
- **Compatibility:** purely additive. No change to the bounded-slice execution path, the preflight, or the config; the new mode is opt-in via flag.

## Validation

```
# new plan-consumption tests
uv run python -m pytest tests/benchmark/test_fidelity_fixed_scope_run_plan.py -q
  -> 8 passed

# existing #3207 fidelity / simulator-dependence suite (regression guard)
uv run python -m pytest tests -k "fidelity or simulator_dependence or fidelity_sweep" -q
  -> 78 passed, 11198 deselected

# plan-only CLI on shipped config (CPU only, no episode); fails closed under --require-launchable
uv run python scripts/benchmark/run_fidelity_sensitivity_campaign.py --fixed-scope-plan-only --require-launchable
  -> preflight_decision=preflight_ready executable=False launched=False run_cells=108 ; exit 1 (fail-closed)

ruff check + ruff format: clean on all changed files
```

## Out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits were made in this PR. Execution of the 108-cell campaign remains gated (fail-closed) behind unmet launch prerequisites.

<details>
<summary>Governance / propagation</summary>

- **Fragmentation guard (2026-07-02, calibrated):** only one #3207 PR merged in the last 24h (#4351, the preflight). This PR is a **progression slice adding a nameable new capability** (runner-side fixed-scope plan consumption), so it proceeds under the exemption rather than as another micro-guard.
- **Late-guidance re-check:** re-read #3207 immediately before opening. Latest comment (`2026-07-03T23:58:38Z`) is the PR #4351 gate-propagation note, which names "campaign runner still a bounded two-planner slice" as the remaining prerequisite this PR addresses. No newer/conflicting maintainer guidance.
- **State propagation:** this PR body is the slice-delivered surface. No transient queue-routing state (target hosts, packet lineage) is encoded in tracked files.
- **Downstream Propagation:** no tracked evidence bundle added — the enumerated plan JSON is a launch/readiness artifact written to gitignored `output/`, consistent with the preflight packet's treatment. `Research Result Guidance: NA - launch/readiness plan-consumption; no research claim.`
- **Artifacts:** plan JSON goes to gitignored `output/fidelity_sensitivity/issue_3207_fixed_scope_run_plan/`; only runner code + tests + CHANGELOG are tracked.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
