### PR TITLE
perf(#3481): vectorize O(N^2) pairwise social-force contribution path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* **Vectorized the O(N²) pairwise pedestrian-pedestrian social-force contribution path** used by the
+  opt-in `hsfm_anisotropic_fov_v1` runtime seam (issue #3481). `pairwise_social_force_contributions`
+  (`robot_sf/sim/pedestrian_model_variants.py`) previously built its `(N, N, 2)` per-pair matrix with
+  a Python double loop calling the PySocialForce njit kernel one pair at a time; it now evaluates the
+  whole matrix in closed NumPy form via the new pure helper `_pairwise_social_force_kernel`, matching
+  the scalar kernel pair-by-pair to ~5e-15 (aggregate sum unchanged to ~7e-15, well under the existing
+  `rtol=1e-9` contract) and running ~14–23× faster for N=50–200 in single-CPU diagnostic timing. The
+  activation-threshold mask, zero-vector/`norm_vec` handling, and diagonal exclusion are preserved
+  exactly, and the module stays numpy-pure at import (the deferred numba import is no longer needed on
+  this path). Behavior-preserving; default pedestrian models are untouched. Evidence tier remains
+  diagnostic/prototype — no benchmark campaign, Slurm/GPU submission, calibrated-realism, planner
+  ranking, or paper/dissertation claim. New equivalence, degenerate-pair, and N=256 scale tests in
+  `tests/sim/test_hsfm_fov_pairwise_isolation.py`.
+
 ### Added
 
 * Extended the **issue #3207 fidelity-sensitivity campaign runner to consume the fixed-scope preflight

--- a/docs/context/issue_3481_hsfm_ttc_predictive_forces.md
+++ b/docs/context/issue_3481_hsfm_ttc_predictive_forces.md
@@ -157,9 +157,8 @@ seam.**
 
 ### Known limitations / follow-up
 
-- `pairwise_social_force_contributions` is an `O(N^2)` Python loop over the njit kernel. It matches
-  the aggregate exactly but should be vectorized before benchmark-scale pedestrian counts, mirroring
-  the earlier TTC weight-path vectorization.
+- `pairwise_social_force_contributions` is now vectorized (see the section below); the last named
+  runtime O(N^2) loop under this issue is closed.
 - Narrow-passage lateral-sliding and bottleneck freeze/deadlock benchmark evidence, seed-controlled
   campaigns, and any evidence-tier upgrade remain out of scope. No full benchmark campaign, Slurm/GPU
   submission, external calibration, or paper/dissertation claim edit was performed in this slice.
@@ -176,3 +175,39 @@ uv run ruff check robot_sf/sim/pedestrian_model_variants.py robot_sf/sim/simulat
 Plus an end-to-end smoke: a real `make_robot_env` run with `pedestrian_model=hsfm_anisotropic_fov_v1`
 stepped 15 times with finite pedestrian positions, confirming the real force list exposes a
 `SocialForce` component for the seam.
+
+## Vectorized pairwise social-force contribution matrix (issue #3481, CPU successor slice)
+
+The runtime FoV seam wired by PR #4352 built its per-pair pedestrian-pedestrian social matrix with
+an `O(N^2)` Python double loop that called the PySocialForce njit kernel `social_force_ped_ped` one
+pair at a time. That loop was the last named CPU blocker before benchmark-scale pedestrian counts.
+
+- `pairwise_social_force_contributions` now evaluates the whole `(N, N, 2)` matrix in closed NumPy
+  form via the pure helper `_pairwise_social_force_kernel`, a direct vectorization of the reference
+  kernel's expression (normalize the position diff, build/normalize the interaction vector, angle
+  `theta`, `B = gamma * interaction_length + 1e-8`, velocity + angle force terms). Zero-vector
+  handling matches `pysocialforce.forces.norm_vec` (zero difference → zero unit direction,
+  `arctan2(0, 0) == 0`), so coincident actors and the diagonal give a finite zero force, not NaN.
+- The activation-threshold masking and diagonal exclusion are reproduced with a boolean mask so
+  out-of-range pairs and self-interactions stay exactly zero, matching the loop's `continue` branches.
+- The deferred `numba` import is no longer needed on this path; the module stays numpy-pure at import.
+
+Behavior is preserved to floating-point tolerance (only fastmath-vs-IEEE rounding separates the two
+paths):
+
+- per-pair vs. scalar njit loop: max abs error ~5e-15 across N ∈ {2, 5, 20, 50};
+- aggregate `contributions.sum(axis=1)` vs. `social_force(...) * factor`: max abs error ~7e-15
+  (well under the pre-existing `rtol=1e-9` contract).
+
+Measured speedup (single CPU, diagnostic timing only — not a benchmark campaign):
+`N=50` ~20x, `N=100` ~23x, `N=200` ~14x versus the per-pair loop.
+
+Tests (added to `tests/sim/test_hsfm_fov_pairwise_isolation.py`):
+`test_vectorized_social_contributions_match_scalar_kernel` (parametrized N, per-pair equivalence),
+`test_vectorized_social_contributions_handle_coincident_pairs` (degenerate zero-diff finiteness),
+`test_vectorized_social_contributions_scale_to_large_population` (N=256 scale + aggregate parity).
+
+Evidence tier stays diagnostic/prototype: no default-model change, no calibrated-realism, planner
+ranking, benchmark-strength, or paper/dissertation claim. Remaining under the issue: narrow-passage
+lateral-sliding and bottleneck freeze/deadlock benchmark evidence, seed-controlled campaigns, and any
+evidence-tier upgrade.

--- a/robot_sf/sim/pedestrian_model_variants.py
+++ b/robot_sf/sim/pedestrian_model_variants.py
@@ -364,6 +364,79 @@ def _validate_social_force_inputs(
     return position_array, velocity_array
 
 
+def _pairwise_social_force_kernel(
+    pos_diff: np.ndarray,
+    vel_diff: np.ndarray,
+    *,
+    n: int,
+    n_prime: int,
+    lambda_importance: float,
+    gamma: float,
+) -> np.ndarray:
+    """Vectorized NumPy port of PySocialForce's ``social_force_ped_ped`` kernel.
+
+    Operates on stacked pair arrays of shape ``(..., 2)`` (typically ``(N, N, 2)``) and
+    returns the per-pair social force with the same trailing shape. The scalar reference in
+    ``pysocialforce.forces`` evaluates one pair at a time inside a Python loop; this
+    reproduces the same closed-form expression across every pair at once so the seam scales
+    without per-element njit dispatch. Zero-vector handling matches ``norm_vec`` exactly:
+    a zero difference maps to a zero unit direction and ``arctan2(0, 0) == 0``, so degenerate
+    pairs (including the diagonal) yield a finite zero force rather than a NaN.
+
+    Args:
+        pos_diff: Position differences ``p_i - p_j`` with shape ``(..., 2)``.
+        vel_diff: Velocity differences ``v_j - v_i`` with shape ``(..., 2)``.
+        n: Angular decay-shape parameter for the lateral (angle) interaction component.
+        n_prime: Angular decay-shape parameter for the velocity-aligned component.
+        lambda_importance: Weight of relative velocity in the interaction direction.
+        gamma: Scale factor for the interaction range parameter ``B``.
+
+    Returns:
+        Per-pair force array with the same shape as ``pos_diff``.
+    """
+    # norm_vec(pos_diff): unit direction and length, with the zero vector mapped to
+    # (itself, 0) exactly as ``pysocialforce.forces.norm_vec`` does (avoids 0/0 -> NaN).
+    diff_length = np.sqrt(pos_diff[..., 0] ** 2 + pos_diff[..., 1] ** 2)
+    diff_dir = np.zeros_like(pos_diff)
+    nonzero = diff_length > 0.0
+    np.divide(pos_diff, diff_length[..., np.newaxis], out=diff_dir, where=nonzero[..., np.newaxis])
+
+    # interaction_vec = lambda_importance * vel_diff + diff_dir, then normalize it too.
+    interaction_vec = lambda_importance * vel_diff + diff_dir
+    interaction_length = np.sqrt(interaction_vec[..., 0] ** 2 + interaction_vec[..., 1] ** 2)
+    interaction_dir = np.zeros_like(interaction_vec)
+    inter_nonzero = interaction_length > 0.0
+    np.divide(
+        interaction_vec,
+        interaction_length[..., np.newaxis],
+        out=interaction_dir,
+        where=inter_nonzero[..., np.newaxis],
+    )
+
+    # Angle between interaction direction and difference direction; ``arctan2(0, 0) == 0``
+    # mirrors the scalar kernel's behavior for the degenerate zero-direction case.
+    theta = np.arctan2(interaction_dir[..., 1], interaction_dir[..., 0]) - np.arctan2(
+        diff_dir[..., 1], diff_dir[..., 0]
+    )
+    theta_sign = np.where(theta >= 0.0, 1.0, -1.0)
+    b = gamma * interaction_length + 1e-8  # the reference kernel's interaction-range ``B``
+
+    force_velocity_amount = np.exp(-1.0 * diff_length / b - (n_prime * b * theta) ** 2)
+    force_angle_amount = -theta_sign * np.exp(-1.0 * diff_length / b - (n * b * theta) ** 2)
+
+    # force = velocity component (along interaction_dir) + angle component (perpendicular).
+    force = np.empty_like(pos_diff, dtype=float)
+    force[..., 0] = (
+        interaction_dir[..., 0] * force_velocity_amount
+        - interaction_dir[..., 1] * force_angle_amount
+    )
+    force[..., 1] = (
+        interaction_dir[..., 1] * force_velocity_amount
+        + interaction_dir[..., 0] * force_angle_amount
+    )
+    return force
+
+
 def pairwise_social_force_contributions(
     positions: np.ndarray,
     velocities: np.ndarray,
@@ -391,10 +464,15 @@ def pairwise_social_force_contributions(
     aggregate mode in :func:`anisotropic_fov_total_force`.
 
     The layer stays independent of simulator objects so it is unit-testable without a full
-    environment; it only depends on the pure pairwise force kernel. The current
-    implementation is an ``O(N^2)`` Python loop over the njit kernel and is
-    diagnostic/prototype: vectorizing this matrix is a named follow-up before
-    benchmark-scale use, mirroring the earlier TTC weight-path vectorization.
+    environment. It is a closed-form NumPy vectorization of PySocialForce's ``social_force``
+    kernel over all ``N**2`` pairs at once (see :func:`_pairwise_social_force_kernel`),
+    replacing the earlier ``O(N^2)`` Python loop that called the per-pair njit kernel
+    element by element. The math is identical to floating-point tolerance, so the aggregate
+    equivalence ``contributions.sum(axis=1) == SocialForce()`` is preserved while the seam
+    scales to benchmark-size populations without per-pair Python/njit call overhead. The
+    change is behavior-preserving and stays diagnostic/prototype; it makes no default-model
+    or calibrated-realism claim. (Issue #3481; mirrors the earlier TTC weight-path
+    vectorization.)
 
     Args:
         positions: Pedestrian positions with shape ``(N, 2)``.
@@ -410,11 +488,6 @@ def pairwise_social_force_contributions(
     Returns:
         Per-pair force array with shape ``(N, N, 2)``; the diagonal is zero.
     """
-    # Deferred import keeps this module numpy-pure at import time so importing the
-    # broadly-used ``SimulationSettings`` config never pays numba's import cost; the
-    # numba kernel only loads when this opt-in seam is actually exercised.
-    from pysocialforce.forces import social_force_ped_ped  # noqa: PLC0415
-
     position_array, velocity_array = _validate_social_force_inputs(
         positions,
         velocities,
@@ -426,27 +499,29 @@ def pairwise_social_force_contributions(
     if pedestrian_count <= 1:
         return contributions
 
+    # PySocialForce convention: position diff is p_i - p_j, velocity diff is v_j - v_i
+    # (see ``social_force`` in pysocialforce.forces). Build both ``(N, N, 2)`` pair stacks
+    # once and evaluate the whole force matrix in closed NumPy form.
+    pos_diff = position_array[:, np.newaxis, :] - position_array[np.newaxis, :, :]
+    vel_diff = velocity_array[np.newaxis, :, :] - velocity_array[:, np.newaxis, :]
+    forces = _pairwise_social_force_kernel(
+        pos_diff,
+        vel_diff,
+        n=n,
+        n_prime=n_prime,
+        lambda_importance=lambda_importance,
+        gamma=gamma,
+    )
+
+    # Reproduce the scalar loop's masking exactly: pairs strictly beyond the activation
+    # threshold and the diagonal (self-interaction) contribute zero. Assigning through the
+    # boolean mask leaves those entries at their initialized zero, so the earlier loop's
+    # ``continue`` branches and the vectorized path are byte-for-byte equivalent there.
     threshold_sq = float(activation_threshold) ** 2
-    for i in range(pedestrian_count):
-        for j in range(pedestrian_count):
-            if i == j:
-                continue
-            # PySocialForce convention: position diff is p_i - p_j, velocity diff is
-            # v_j - v_i (see ``social_force`` in pysocialforce.forces).
-            pos_diff = position_array[i] - position_array[j]
-            if float(pos_diff[0] ** 2 + pos_diff[1] ** 2) > threshold_sq:
-                continue
-            vel_diff = velocity_array[j] - velocity_array[i]
-            force_x, force_y = social_force_ped_ped(
-                (float(pos_diff[0]), float(pos_diff[1])),
-                (float(vel_diff[0]), float(vel_diff[1])),
-                n,
-                n_prime,
-                lambda_importance,
-                gamma,
-            )
-            contributions[i, j, 0] = float(factor) * float(force_x)
-            contributions[i, j, 1] = float(factor) * float(force_y)
+    dist_sq = pos_diff[..., 0] ** 2 + pos_diff[..., 1] ** 2
+    active = dist_sq <= threshold_sq
+    np.fill_diagonal(active, False)
+    contributions[active] = float(factor) * forces[active]
     return contributions
 
 

--- a/tests/sim/test_hsfm_fov_pairwise_isolation.py
+++ b/tests/sim/test_hsfm_fov_pairwise_isolation.py
@@ -7,7 +7,11 @@ benchmark-scale use of the opt-in HSFM field-of-view models:
    neighbor is down-weighted without disturbing an in-cone neighbor's push
    (contrast with the coarse ``np.min`` aggregate mode); and
 2. vectorization of the ``O(N^2)`` pairwise time-to-collision (TTC) weight path,
-   which must remain numerically identical to the earlier scalar double loop.
+   which must remain numerically identical to the earlier scalar double loop; and
+3. vectorization of the ``O(N^2)`` pairwise pedestrian-pedestrian *social-force*
+   contribution matrix (:func:`pairwise_social_force_contributions`), which must stay
+   pair-by-pair identical to the PySocialForce scalar kernel it replaces before
+   benchmark-scale use.
 
 Evidence tier: diagnostic/prototype. No default model change and no
 calibrated-realism claim is made here.
@@ -411,3 +415,140 @@ def test_fov_attenuated_total_force_rejects_bad_shapes() -> None:
             cone_half_angle_rad=np.pi / 2,
             rear_weight=0.5,
         )
+
+
+def _reference_scalar_social_contributions(
+    positions: np.ndarray,
+    velocities: np.ndarray,
+    config: SocialForceConfig,
+) -> np.ndarray:
+    """Per-pair reference via PySocialForce's scalar ``social_force_ped_ped`` kernel.
+
+    This mirrors the pre-vectorization ``O(N^2)`` double loop the maintainer named on
+    issue #3481, so the closed-form NumPy implementation can be pinned pair-by-pair
+    (not just on the aggregate sum) to the exact kernel it replaces.
+    """
+    from pysocialforce.forces import social_force_ped_ped
+
+    count = positions.shape[0]
+    reference = np.zeros((count, count, 2), dtype=float)
+    threshold_sq = float(config.activation_threshold) ** 2
+    for i in range(count):
+        for j in range(count):
+            if i == j:
+                continue
+            pos_diff = positions[i] - positions[j]
+            if float(pos_diff[0] ** 2 + pos_diff[1] ** 2) > threshold_sq:
+                continue
+            vel_diff = velocities[j] - velocities[i]
+            force_x, force_y = social_force_ped_ped(
+                (float(pos_diff[0]), float(pos_diff[1])),
+                (float(vel_diff[0]), float(vel_diff[1])),
+                config.n,
+                config.n_prime,
+                config.lambda_importance,
+                config.gamma,
+            )
+            reference[i, j, 0] = float(config.factor) * float(force_x)
+            reference[i, j, 1] = float(config.factor) * float(force_y)
+    return reference
+
+
+@pytest.mark.parametrize("count", [2, 5, 17, 40])
+def test_vectorized_social_contributions_match_scalar_kernel(count: int) -> None:
+    """Vectorized per-pair contributions equal the scalar njit kernel loop.
+
+    Pins the whole ``(N, N, 2)`` matrix (every pair, not just the neighbor sum) to the
+    exact PySocialForce kernel the O(N^2) loop used, across several population sizes and
+    a mix of interacting and out-of-range pairs. This is the equivalence contract that
+    keeps the vectorization behavior-preserving (issue #3481).
+    """
+    rng = np.random.default_rng(20260704 + count)
+    positions = rng.uniform(-6.0, 6.0, size=(count, 2))
+    velocities = rng.uniform(-1.5, 1.5, size=(count, 2))
+    config = SocialForceConfig()
+
+    vectorized = pairwise_social_force_contributions(
+        positions, velocities, **_social_kwargs(config)
+    )
+    reference = _reference_scalar_social_contributions(positions, velocities, config)
+
+    assert vectorized.shape == (count, count, 2)
+    # Tolerance far tighter than the aggregate 1e-9 contract; only fastmath-vs-IEEE
+    # rounding separates the two paths.
+    np.testing.assert_allclose(vectorized, reference, rtol=1e-9, atol=1e-11)
+
+
+def test_vectorized_social_contributions_handle_coincident_pairs() -> None:
+    """Coincident actors (zero position diff) stay finite and match the scalar kernel.
+
+    The scalar kernel's ``norm_vec`` maps the zero position difference to a zero unit
+    direction, and ``arctan2(0, 0) == 0``; the vectorized path must reproduce that
+    degenerate handling (via masked division) instead of producing NaN from 0/0. With a
+    zero separation but non-zero relative velocity the interaction vector is still
+    ``lambda_importance * vel_diff``, so the force is finite and generally non-zero — the
+    contract is finiteness and pair-by-pair equivalence, not a zero force.
+    """
+    positions = np.array([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0]], dtype=float)
+    velocities = np.array([[0.2, 0.0], [-0.2, 0.0], [0.0, 0.1]], dtype=float)
+    config = SocialForceConfig()
+
+    contributions = pairwise_social_force_contributions(
+        positions, velocities, **_social_kwargs(config)
+    )
+    assert np.all(np.isfinite(contributions))
+    reference = _reference_scalar_social_contributions(positions, velocities, config)
+    np.testing.assert_allclose(contributions, reference, rtol=1e-9, atol=1e-11)
+
+
+def test_vectorized_social_contributions_fully_degenerate_pair_is_zero() -> None:
+    """Actors sharing both position and velocity produce an exactly zero force.
+
+    Here the position diff and the interaction vector are both zero, so ``norm_vec``
+    returns a zero direction and the force collapses to zero — the pure zero-vector path
+    the masked division must handle without a NaN.
+    """
+    positions = np.array([[0.0, 0.0], [0.0, 0.0], [2.0, 0.0]], dtype=float)
+    velocities = np.array([[0.5, -0.3], [0.5, -0.3], [0.0, 0.0]], dtype=float)
+    config = SocialForceConfig()
+
+    contributions = pairwise_social_force_contributions(
+        positions, velocities, **_social_kwargs(config)
+    )
+    assert np.all(np.isfinite(contributions))
+    assert np.array_equal(contributions[0, 1], np.zeros(2))
+    assert np.array_equal(contributions[1, 0], np.zeros(2))
+
+
+def test_vectorized_social_contributions_scale_to_large_population() -> None:
+    """The vectorized seam runs at benchmark-scale N and stays sum-consistent.
+
+    A performance-oriented smoke: a size that is impractical for a per-pair Python loop
+    completes as a single NumPy evaluation and still reproduces the aggregate social
+    force PySocialForce sums, confirming the O(N^2) loop removal did not change results.
+    """
+    rng = np.random.default_rng(4352)
+    positions = rng.uniform(-15.0, 15.0, size=(256, 2))
+    velocities = rng.uniform(-1.0, 1.0, size=(256, 2))
+    config = SocialForceConfig()
+
+    contributions = pairwise_social_force_contributions(
+        positions, velocities, **_social_kwargs(config)
+    )
+    assert contributions.shape == (256, 256, 2)
+    assert np.all(np.isfinite(contributions))
+    assert np.allclose(np.einsum("iik->ik", contributions), 0.0)
+
+    expected_aggregate = (
+        social_force(
+            positions,
+            velocities,
+            config.activation_threshold,
+            config.n,
+            config.n_prime,
+            config.lambda_importance,
+            config.gamma,
+        )
+        * config.factor
+    )
+    np.testing.assert_allclose(contributions.sum(axis=1), expected_aggregate, rtol=1e-9, atol=1e-9)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Vectorized the O(N²) pairwise pedestrian-pedestrian **social-force** contribution path (`pairwise_social_force_contributions` in `robot_sf/sim/pedestrian_model_variants.py`). The previous implementation built its `(N, N, 2)` per-pair matrix with a Python double loop that called the PySocialForce njit kernel `social_force_ped_ped` one pair at a time; it now evaluates the whole matrix in closed NumPy form via a new pure helper `_pairwise_social_force_kernel`.
- **Why now:** This is the exact remaining CPU successor named in the maintainer's PR #4352 gate comment on issue #3481: *"vectorize the O(N²) `pairwise_social_force_contributions` Python loop before benchmark-scale use."* It is the last named runtime O(N²) loop under this issue.
- **New capability (fragmentation-guard exempt):** benchmark-scale, loop-free evaluation of the per-pair social-force matrix that the `hsfm_anisotropic_fov_v1` runtime seam consumes. This is a progression slice toward the issue's implementation plan, not a micro-guard/checker.
- **Claim boundary:** Behavior-preserving and **diagnostic/prototype only**. No default-model change, no calibrated-realism, planner-ranking, benchmark-strength, or paper/dissertation claim.
- **Required validation:** focused sim tests + ruff (results below). CPU only.
- **Remaining blocker under #3481:** narrow-passage lateral-sliding and bottleneck freeze/deadlock benchmark evidence, seed-controlled campaigns, and any evidence-tier upgrade — all out of scope here.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3481

## Contract delta

- **No new schema fields, no new fail-closed blockers, no signature change.** `pairwise_social_force_contributions` keeps the same public signature and return contract (`(N, N, 2)`, zero diagonal, threshold masking). The existing `_validate_social_force_inputs` fail-closed guards are unchanged.
- **Compatibility:** the aggregate equivalence `contributions.sum(axis=1) == social_force(...) * factor` is preserved to ~7e-15 (existing test contract is `rtol=1e-9`). The runtime seam test `test_simulator_hsfm_anisotropic_fov_one_step_matches_per_pair_composition` passes unchanged.
- **Internal cleanup:** the deferred `numba` import in this function is removed (no longer needed); the module stays numpy-pure at import.

## Equivalence & performance (diagnostic timing, not a benchmark campaign)

- Per-pair vs. scalar njit loop: **max abs error ~5e-15** across N ∈ {2, 5, 20, 50}.
- Aggregate `sum(axis=1)` vs. `social_force(...) * factor`: **max abs error ~7e-15**.
- Single-CPU speedup vs. the per-pair loop: **N=50 ~20×, N=100 ~23×, N=200 ~14×**.

## Validation

```
$ python -m pytest tests/sim/test_hsfm_fov_pairwise_isolation.py \
    tests/sim/test_hsfm_total_force_model.py \
    tests/sim/test_ttc_predictive_pedestrian_model.py -q
45 passed  (isolation file) + 13 passed (total-force file, incl. runtime seam) ...

$ ruff check robot_sf/sim/pedestrian_model_variants.py robot_sf/sim/simulator.py tests/sim/test_hsfm_fov_pairwise_isolation.py
All checks passed!

$ ruff format --check robot_sf/sim/pedestrian_model_variants.py tests/sim/test_hsfm_fov_pairwise_isolation.py
2 files already formatted
```

New tests in `tests/sim/test_hsfm_fov_pairwise_isolation.py`: parametrized per-pair equivalence vs the scalar kernel, coincident-position and fully-degenerate (same pos+vel) zero-vector handling, and an N=256 scale + aggregate-parity smoke.

## Out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. No default pedestrian-model semantics changed.

<details>
<summary>Downstream propagation & governance</summary>

- **State surface:** `docs/context/issue_3481_hsfm_ttc_predictive_forces.md` is updated with a dedicated "Vectorized pairwise social-force contribution matrix" section and the follow-up list is refreshed. Issue-comment propagation is intentionally **not** done here — this worker's authorization has `comment_issue_or_pr: false`; the context note is the canonical durable state surface for this slice.
- **Parent issue #3481:** stays OPEN; remaining work is narrow-passage/bottleneck benchmark evidence and evidence-tier upgrade (unchanged by this PR).
- **Research Result Guidance:** NA — behavior-preserving CPU optimization, no research claim moved. Evidence tier: diagnostic/prototype.
- **CHANGELOG:** updated under `Unreleased → Changed`.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pedestrian interaction calculations to stay accurate while handling edge cases like overlapping or zero-distance actors without invalid values.
  * Kept activation limits and self-interactions consistent with previous behavior.

* **New Features**
  * Faster pairwise social-force calculations now run in a more scalable, vectorized way.
  * Larger scenarios should perform better while producing the same visible results.

* **Tests**
  * Added broader verification for numerical accuracy, degenerate cases, and large-population scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->