### PR TITLE
#3207: wire fixed-scope preflight plan to per-cell episode execution (fail-closed, no campaign)

### DIFF
--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -38,7 +38,7 @@ from robot_sf.gym_env.environment_factory import make_robot_env
 from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 SCHEMA_VERSION = "issue_3207_fidelity_sensitivity_campaign_slice.v1"
@@ -271,6 +271,193 @@ def write_fixed_scope_run_plan(
         encoding="utf-8",
     )
     return plan_path
+
+
+# Catalog algorithm -> concrete runner planner. This is the only place a
+# fixed-scope planner group becomes an actual episode-executing planner. The
+# bounded slice runner has a native, dependency-free implementation only for the
+# social-force baseline, so that is the only binding here. ORCA (needs rvo2) and
+# the experimental hybrid-rule planner deliberately have NO binding: a cell that
+# resolves to them stays unbound and fails closed rather than silently running a
+# substitute planner (no silent fallback).
+RUNNER_ALGORITHM_PLANNERS: Mapping[str, str] = {
+    "social_force": "baseline_social_force",
+}
+
+
+@dataclass(frozen=True)
+class RunnerCellBinding:
+    """Concrete runner inputs bound to one fixed-scope run cell.
+
+    ``runner_bound`` is ``True`` only when the cell's resolved catalog algorithm
+    has a native runner planner *and* the preflight marked the planner available
+    and not pending an explicit opt-in *and* the variant has a supported runtime
+    binding. When it is ``False``, ``planner_name`` is ``None`` and
+    ``unbound_reason`` explains why; the runner must never substitute a supported
+    planner for an unbound cell.
+    """
+
+    cell: FixedScopeRunCell
+    variant: VariantSpec
+    planner_name: str | None
+    runner_bound: bool
+    unbound_reason: str | None
+
+
+def build_fixed_scope_variant_index(
+    config: Mapping[str, Any],
+) -> dict[tuple[str, str], VariantSpec]:
+    """Index one runtime-bound :class:`VariantSpec` per ``(axis, source key)``.
+
+    Unlike :func:`load_variant_specs` — which collapses to a single nominal
+    baseline for the bounded slice — this materializes *every* configured
+    variant, including each axis's own baseline, and keys them by
+    ``(axis_key, source_variant_key)``. That is exactly the grain a fixed-scope
+    run cell carries (``cell.axis`` / ``cell.variant``), so every plan cell maps
+    to exactly one variant runtime binding.
+
+    Args:
+        config: Raw fidelity-sensitivity study config mapping.
+
+    Returns:
+        Mapping of ``(axis_key, source_variant_key)`` to its runtime-bound spec.
+    """
+    index: dict[tuple[str, str], VariantSpec] = {}
+    for axis in config["axes"]:
+        axis_key = str(axis["key"])
+        for raw_variant in axis["variants"]:
+            source_key = str(raw_variant["key"])
+            baseline = bool(raw_variant.get("baseline", False))
+            patch = copy.deepcopy(raw_variant.get("patch") or {})
+            observation_noise = copy.deepcopy(raw_variant.get("observation_noise") or {})
+            runtime_binding = _runtime_binding(axis_key, patch, observation_noise)
+            index[(axis_key, source_key)] = VariantSpec(
+                axis=axis_key,
+                # Keep every variant key distinct (baselines included) so per-axis
+                # nominal cells stay traceable in output rows and stable seeds.
+                key=f"{axis_key}__{source_key}",
+                source_key=source_key,
+                baseline=baseline,
+                patch=patch,
+                observation_noise=observation_noise,
+                runtime_binding=runtime_binding,
+            )
+    return index
+
+
+def bind_fixed_scope_run_cell(
+    cell: FixedScopeRunCell,
+    variant_index: Mapping[tuple[str, str], VariantSpec],
+) -> RunnerCellBinding:
+    """Bind one fixed-scope run cell to concrete runner inputs, fail-closed.
+
+    The cell's ``(axis, variant)`` must resolve to a materialized variant spec;
+    a miss is an internal contract violation (the plan and the variant index
+    disagree), raised rather than silently dropped. The planner side is
+    fail-closed: a cell is only ``runner_bound`` when its resolved algorithm has
+    a native runner planner and the preflight found it available and not pending
+    an explicit opt-in. Unbound cells carry ``planner_name = None`` and never
+    inherit a substitute planner.
+
+    Args:
+        cell: One enumerated fixed-scope run cell.
+        variant_index: Output of :func:`build_fixed_scope_variant_index`.
+
+    Returns:
+        The resolved :class:`RunnerCellBinding`.
+
+    Raises:
+        KeyError: If the cell's ``(axis, variant)`` is absent from the index.
+    """
+    variant = variant_index.get((cell.axis, cell.variant))
+    if variant is None:
+        raise KeyError(
+            "fixed-scope run cell has no materialized variant: "
+            f"axis={cell.axis!r} variant={cell.variant!r}"
+        )
+
+    reasons: list[str] = []
+    planner_name = RUNNER_ALGORITHM_PLANNERS.get(cell.algorithm)
+    if planner_name is None:
+        reasons.append(f"no_native_runner_planner_for_algorithm:{cell.algorithm}")
+    if not cell.planner_available:
+        reasons.append(f"planner_unavailable:{cell.planner_group}")
+    if cell.requires_explicit_opt_in:
+        reasons.append(f"planner_requires_explicit_opt_in:{cell.planner_group}")
+    if variant.runtime_binding == "unsupported":
+        reasons.append(f"variant_runtime_binding_unsupported:{cell.axis}__{cell.variant}")
+
+    runner_bound = not reasons
+    return RunnerCellBinding(
+        cell=cell,
+        variant=variant,
+        planner_name=planner_name if runner_bound else None,
+        runner_bound=runner_bound,
+        unbound_reason=None if runner_bound else "; ".join(reasons),
+    )
+
+
+def _run_cells_from_plan(plan: Mapping[str, Any]) -> list[FixedScopeRunCell]:
+    """Reconstruct :class:`FixedScopeRunCell` objects from a serialized plan."""
+    return [FixedScopeRunCell(**cell) for cell in plan["run_cells"]]
+
+
+def bind_fixed_scope_run_plan(
+    plan: Mapping[str, Any],
+    config: Mapping[str, Any],
+) -> list[RunnerCellBinding]:
+    """Bind every cell of a fixed-scope run plan to concrete runner inputs.
+
+    Args:
+        plan: Packet from :func:`build_fixed_scope_run_plan`.
+        config: Raw fidelity-sensitivity study config the plan was built from.
+
+    Returns:
+        One :class:`RunnerCellBinding` per plan cell, in plan order.
+    """
+    variant_index = build_fixed_scope_variant_index(config)
+    return [bind_fixed_scope_run_cell(cell, variant_index) for cell in _run_cells_from_plan(plan)]
+
+
+def execute_fixed_scope_cells(
+    bindings: Sequence[RunnerCellBinding],
+    *,
+    cell_runner: Callable[[RunnerCellBinding], list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    """Run each runner-bound cell via ``cell_runner``; fail closed on unbound.
+
+    This is the per-cell execution seam: ``cell_runner`` receives one binding and
+    returns its episode rows. It is injected so the mapping from plan cell to
+    runner inputs (planner, variant, seed) is testable without the heavy real
+    simulator, and so the campaign runner never grows a second silent-fallback
+    path. If *any* binding is unbound this raises before running a single cell,
+    so a launch that slipped past the plan-level gate still cannot substitute a
+    supported planner for an ORCA/hybrid cell.
+
+    Args:
+        bindings: Bound cells from :func:`bind_fixed_scope_run_plan`.
+        cell_runner: Callable that executes one bound cell and returns its rows.
+
+    Returns:
+        Flattened episode rows across all bound cells.
+
+    Raises:
+        FixedScopeNotLaunchableError: If any binding is not ``runner_bound``.
+    """
+    unbound = [b for b in bindings if not b.runner_bound]
+    if unbound:
+        reasons = "; ".join(
+            f"{b.cell.planner_group}/{b.cell.axis}/{b.cell.variant}: {b.unbound_reason}"
+            for b in unbound[:5]
+        )
+        raise FixedScopeNotLaunchableError(
+            f"{len(unbound)} of {len(bindings)} fixed-scope cells are unbound; "
+            f"refusing to run with a substitute planner. Examples: {reasons}"
+        )
+    rows: list[dict[str, Any]] = []
+    for binding in bindings:
+        rows.extend(cell_runner(binding))
+    return rows
 
 
 @dataclass(frozen=True)
@@ -898,6 +1085,17 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "and the post-run rank-identifiability recheck unmet, so this fails closed."
         ),
     )
+    parser.add_argument(
+        "--fixed-scope-execute",
+        action="store_true",
+        help=(
+            "Explicit opt-in to drive per-cell episode execution from the fixed-scope run "
+            "plan. Fails closed via ensure_fixed_scope_launchable unless every launch gate is "
+            "cleared, so on the shipped config it runs zero episodes. When launchable, each "
+            "plan cell is bound to concrete runner inputs (planner, variant, seed) with no "
+            "silent fallback for unbound (ORCA/hybrid) planners."
+        ),
+    )
     parser.add_argument("--date", default=dt.datetime.now(tz=dt.UTC).date().isoformat())
     return parser.parse_args(argv)
 
@@ -932,6 +1130,86 @@ def _run_fixed_scope_plan_only(args: argparse.Namespace, config: Mapping[str, An
     return 0
 
 
+def _default_fixed_scope_cell_runner(
+    *,
+    scenarios: Sequence[Mapping[str, Any]],
+    scenario_path: pathlib.Path,
+    horizon: int,
+) -> Callable[[RunnerCellBinding], list[dict[str, Any]]]:
+    """Build the real per-cell runner: one episode per scenario for a bound cell.
+
+    Only reached after :func:`ensure_fixed_scope_launchable` passes, so every
+    binding here is guaranteed ``runner_bound`` with a concrete ``planner_name``.
+    """
+
+    def _run(binding: RunnerCellBinding) -> list[dict[str, Any]]:
+        assert binding.planner_name is not None  # guaranteed by execute guard
+        return [
+            run_episode(
+                scenario,
+                scenario_path=scenario_path,
+                variant=binding.variant,
+                planner_name=binding.planner_name,
+                seed=int(binding.cell.seed),
+                horizon=horizon,
+            )
+            for scenario in scenarios
+        ]
+
+    return _run
+
+
+def _run_fixed_scope_execute(args: argparse.Namespace, config: Mapping[str, Any]) -> int:
+    """Drive per-cell episode execution from the fixed-scope plan, fail-closed.
+
+    Returns:
+        ``1`` (fail-closed, zero episodes) while any launch gate remains — the
+        state on the shipped config — or ``0`` after executing every bound cell
+        when the plan is fully launchable.
+    """
+    plan = build_fixed_scope_run_plan(
+        config,
+        config_path=args.config,
+        git_head=_git_head(),
+        date=str(args.date),
+    )
+    try:
+        ensure_fixed_scope_launchable(plan)
+    except FixedScopeNotLaunchableError as exc:
+        print(f"fail-closed: {exc}")
+        print(
+            "no episodes executed; fixed-scope per-cell execution stays gated behind "
+            "launch prerequisites (ORCA/rvo2, hybrid opt-in, runtime rank-identifiability recheck)"
+        )
+        return 1
+
+    # Reached only when every launch gate is cleared (not on the shipped config).
+    bindings = bind_fixed_scope_run_plan(plan, config)
+    scenario_set = str(plan["materialized_scope"]["scenario_set"])
+    scenario_path = REPO_ROOT / scenario_set
+    scenarios = list(load_scenarios(scenario_path))
+    if not scenarios:
+        raise ValueError(f"fixed-scope scenario set produced no scenarios: {scenario_path}")
+    rows = execute_fixed_scope_cells(
+        bindings,
+        cell_runner=_default_fixed_scope_cell_runner(
+            scenarios=scenarios,
+            scenario_path=scenario_path,
+            horizon=int(args.horizon),
+        ),
+    )
+    raw_root = REPO_ROOT / args.raw_root
+    raw_rows_path = raw_root / "episode_rows.jsonl"
+    raw_root.mkdir(parents=True, exist_ok=True)
+    raw_rows_path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    print(f"executed {len(rows)} fixed-scope episode rows across {len(bindings)} cells")
+    print(f"wrote raw rows: {_repo_rel(raw_rows_path)}")
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the bounded actual campaign."""
     args = _parse_args(argv)
@@ -943,6 +1221,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         # Plan-consumption mode: enumerate the full fixed-scope run plan and stop
         # before any episode. Execution stays fail-closed behind launch gates.
         return _run_fixed_scope_plan_only(args, config)
+    if args.fixed_scope_execute:
+        # Explicit opt-in: bind the plan to concrete per-cell runner inputs and
+        # execute, but only after ensure_fixed_scope_launchable passes. On the
+        # shipped config this fails closed and runs zero episodes.
+        return _run_fixed_scope_execute(args, config)
     scenario_path = REPO_ROOT / args.scenario_set
     scenarios = list(load_scenarios(scenario_path))
     if not scenarios:

--- a/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
+++ b/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
@@ -179,3 +179,145 @@ def test_plan_only_cli_require_launchable_fails_closed(tmp_path: Path) -> None:
         ]
     )
     assert exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-cell episode wiring: mapping fixed-scope plan cells to concrete runner
+# inputs, fail-closed, with no silent fallback (issue #3207 next launch gate).
+# ---------------------------------------------------------------------------
+
+
+def test_variant_index_covers_every_plan_cell() -> None:
+    """Every plan cell's (axis, variant) resolves to exactly one materialized variant."""
+    config = _config()
+    index = campaign_runner.build_fixed_scope_variant_index(config)
+    plan = _plan()
+
+    # Four axes x three variants each = twelve materialized variants.
+    assert len(index) == 12
+    for cell in plan["run_cells"]:
+        assert (cell["axis"], cell["variant"]) in index
+    # Every variant is runtime-bound (no "unsupported"), so no cell is stranded.
+    assert all(spec.runtime_binding != "unsupported" for spec in index.values())
+
+
+def test_bind_social_force_cell_maps_to_runner_planner() -> None:
+    """A default_social_force cell binds to the runner's baseline_social_force planner."""
+    config = _config()
+    index = campaign_runner.build_fixed_scope_variant_index(config)
+    cells = campaign_runner._run_cells_from_plan(_plan())
+    cell = next(c for c in cells if c.planner_group == "default_social_force")
+
+    binding = campaign_runner.bind_fixed_scope_run_cell(cell, index)
+    assert binding.runner_bound is True
+    assert binding.planner_name == "baseline_social_force"
+    assert binding.unbound_reason is None
+    # The bound variant carries the cell's own axis/variant runtime binding.
+    assert binding.variant.axis == cell.axis
+    assert binding.variant.source_key == cell.variant
+
+
+def test_bind_orca_cell_is_unbound_no_silent_fallback() -> None:
+    """An ORCA cell has no native runner planner and never inherits a substitute."""
+    config = _config()
+    index = campaign_runner.build_fixed_scope_variant_index(config)
+    cells = campaign_runner._run_cells_from_plan(_plan())
+    cell = next(c for c in cells if c.planner_group == "orca")
+
+    binding = campaign_runner.bind_fixed_scope_run_cell(cell, index)
+    assert binding.runner_bound is False
+    assert binding.planner_name is None
+    assert "no_native_runner_planner_for_algorithm:orca" in binding.unbound_reason
+
+
+def test_bind_hybrid_cell_requires_opt_in_unbound() -> None:
+    """The experimental hybrid-rule cell stays unbound pending explicit opt-in."""
+    config = _config()
+    index = campaign_runner.build_fixed_scope_variant_index(config)
+    cells = campaign_runner._run_cells_from_plan(_plan())
+    cell = next(c for c in cells if c.planner_group == "hybrid_rule_v0_minimal")
+
+    binding = campaign_runner.bind_fixed_scope_run_cell(cell, index)
+    assert binding.runner_bound is False
+    assert binding.planner_name is None
+    assert "planner_requires_explicit_opt_in:hybrid_rule_v0_minimal" in binding.unbound_reason
+
+
+def test_bind_plan_preserves_cell_count_and_order() -> None:
+    """bind_fixed_scope_run_plan yields one binding per plan cell, in plan order."""
+    config = _config()
+    plan = _plan()
+    bindings = campaign_runner.bind_fixed_scope_run_plan(plan, config)
+
+    assert len(bindings) == plan["run_cell_count"] == 108
+    for binding, cell in zip(bindings, plan["run_cells"], strict=True):
+        assert binding.cell.planner_group == cell["planner_group"]
+        assert binding.cell.axis == cell["axis"]
+        assert binding.cell.variant == cell["variant"]
+        assert binding.cell.seed == cell["seed"]
+    # Only the social-force group is runner-bound today; ORCA/hybrid stay unbound.
+    bound_groups = {b.cell.planner_group for b in bindings if b.runner_bound}
+    assert bound_groups == {"default_social_force"}
+
+
+def test_bind_missing_variant_raises_not_silently_dropped() -> None:
+    """A plan/variant-index disagreement is a hard error, not a silent skip."""
+    config = _config()
+    index = campaign_runner.build_fixed_scope_variant_index(config)
+    cells = campaign_runner._run_cells_from_plan(_plan())
+    ghost = cells[0].__class__(
+        **{**cells[0].__dict__, "axis": "no_such_axis", "variant": "no_such_variant"}
+    )
+    with pytest.raises(KeyError):
+        campaign_runner.bind_fixed_scope_run_cell(ghost, index)
+
+
+def test_execute_raises_on_unbound_cells_without_running_any() -> None:
+    """execute_fixed_scope_cells fails closed before running a single unbound cell."""
+    config = _config()
+    bindings = campaign_runner.bind_fixed_scope_run_plan(_plan(), config)
+    calls: list[object] = []
+
+    def _recording_runner(binding: object) -> list[dict]:
+        calls.append(binding)
+        return [{"marker": True}]
+
+    with pytest.raises(campaign_runner.FixedScopeNotLaunchableError):
+        campaign_runner.execute_fixed_scope_cells(bindings, cell_runner=_recording_runner)
+    # No silent fallback: the runner is never invoked when any cell is unbound.
+    assert calls == []
+
+
+def test_execute_runs_one_batch_per_bound_cell_with_correct_inputs() -> None:
+    """Each bound cell drives the injected runner with its planner, variant, and seed."""
+    config = _config()
+    bindings = campaign_runner.bind_fixed_scope_run_plan(_plan(), config)
+    bound = [b for b in bindings if b.runner_bound]
+    # Sanity: 12 variants x 3 seeds for the single runner-bound planner group.
+    assert len(bound) == 36
+
+    seen: list[tuple] = []
+
+    def _fake_runner(binding: object) -> list[dict]:
+        seen.append((binding.planner_name, binding.variant.source_key, binding.cell.seed))
+        return [{"planner": binding.planner_name}]
+
+    rows = campaign_runner.execute_fixed_scope_cells(bound, cell_runner=_fake_runner)
+    assert len(rows) == len(bound)
+    assert all(name == "baseline_social_force" for name, _variant, _seed in seen)
+    # Every (variant, seed) pairing in the bound scope is driven exactly once.
+    assert len(set(seen)) == len(bound)
+
+
+def test_fixed_scope_execute_cli_fails_closed_and_writes_no_rows(tmp_path: Path) -> None:
+    """--fixed-scope-execute exits non-zero and runs zero episodes on the shipped config."""
+    raw_root = tmp_path / "raw"
+    exit_code = campaign_runner.main(
+        [
+            "--fixed-scope-execute",
+            "--raw-root",
+            str(raw_root),
+        ]
+    )
+    assert exit_code == 1
+    assert not (raw_root / "episode_rows.jsonl").exists()


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** The `#3207` fidelity-sensitivity runner can now map the pre-registered fixed-scope run plan to **per-cell episode execution** behind an explicit `--fixed-scope-execute` opt-in. Every plan cell (`planner_group × axis-variant × seed`) resolves to concrete runner inputs (planner, runtime-bound variant, seed) with **no silent fallback**.
- **Why now:** This is the next CPU-local launch gate the issue thread enumerated after PR #4351 (fixed-scope preflight) and PR #4353 (plan-only consumption). PR #4353's closing note named "per-cell episode wiring in the runner" as remaining before launch. This is a **progression slice adding a nameable new capability** (per-cell episode wiring), not a micro-guard (fragmentation guard 6c exemption).
- **Claim boundary:** Launch-wiring only. On the shipped config the opt-in path **fails closed and runs zero episodes**. This is not benchmark, simulator-realism, sim-to-real, or paper-facing evidence. No campaign was run.
- **Required validation:** ruff check/format + focused pytest (below); manual CLI fail-closed check.
- **Remaining blocker:** The full fixed-scope campaign stays gated — ORCA needs rvo2, the hybrid-rule planner needs explicit opt-in, and the post-run rank-identifiability recheck is unmet. Those keep `ensure_fixed_scope_launchable` fail-closed regardless of this wiring.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3207

## Contract delta

New runner symbols (in `scripts/benchmark/run_fidelity_sensitivity_campaign.py`):

- `RUNNER_ALGORITHM_PLANNERS` — the single map from a resolved catalog algorithm to an episode-executing runner planner. Only `social_force → baseline_social_force` is bound today; ORCA and hybrid-rule are deliberately **absent** so their cells cannot inherit a substitute planner.
- `RunnerCellBinding` dataclass + `build_fixed_scope_variant_index`, `bind_fixed_scope_run_cell`, `bind_fixed_scope_run_plan` — map each plan cell to a concrete runtime-bound variant + planner, or mark it unbound with an explicit `unbound_reason`.
- `execute_fixed_scope_cells(bindings, *, cell_runner)` — per-cell execution seam (injectable runner for testability); **raises `FixedScopeNotLaunchableError` before running any cell** if any binding is unbound.
- `--fixed-scope-execute` CLI flag — explicit opt-in; builds the plan, calls the existing `ensure_fixed_scope_launchable`, and exits `1` (zero episodes) while launch gates remain.

New fail-closed behaviors: unbound (ORCA/hybrid) cells block execution; a plan/variant-index disagreement raises rather than silently dropping a cell.

Compatibility: additive only. The existing bounded-slice path, `--first-variant-per-axis-only`, and `--fixed-scope-plan-only` are unchanged. No config, schema, or preflight files touched.

Note: the preflight's `campaign_runner_not_wired_for_full_fixed_scope` launch prerequisite remains valid and untouched — the runner is now wired for per-cell execution of the **bound** (social-force) subset, but not for the full planner set (ORCA/hybrid stay unbound), so the plan stays non-launchable.

## Validation

```
$ ruff check scripts/benchmark/run_fidelity_sensitivity_campaign.py tests/benchmark/test_fidelity_fixed_scope_run_plan.py
All checks passed!
$ ruff format --check <same files>
2 files already formatted
$ pytest tests/benchmark/test_fidelity_fixed_scope_run_plan.py -q
17 passed in 2.22s      # 9 pre-existing + 8 new
$ pytest tests/benchmark/test_fidelity_fixed_scope_preflight.py tests/benchmark/test_fidelity_sensitivity.py tests/benchmark/test_fidelity_sensitivity_campaign.py -q
33 passed in 2.19s      # no regressions
$ python scripts/benchmark/run_fidelity_sensitivity_campaign.py --fixed-scope-execute --raw-root output/tmp
fail-closed: fixed-scope campaign is not launchable; unmet gates: planner_runtime_dependency:orca requires rvo2 ...
# exit 1; no episode_rows.jsonl written
```

## Out of scope (explicit)

- **No full benchmark campaign run**, no Slurm/GPU submission, no compute submit.
- **No paper/dissertation claim edits**; no simulator-validity / rank-stability claim promotion.
- Aggregation of per-cell rows into an evidence bundle and the post-run rank-identifiability recheck remain **future work** (the execute path produces raw rows only, and is unreachable on the shipped config because it fails closed).
- Removing the launch gates (rvo2 for ORCA, hybrid opt-in) is out of scope.

<details>
<summary>Downstream propagation & research-result guidance</summary>

- **Downstream Propagation:** Parent issue #3207 — **this PR is the canonical state surface for this slice**; no separate issue comment is posted because commenting is not authorized in this implementation lane (the downstream PR-gate owner may propagate). Claim map / leaderboard / registry: N/A (no evidence produced). Context index: N/A (no new evidence bundle).
- **Research Result Guidance:** N/A — support/wiring helper, no research claim. Target remains the full fixed-scope study; comparator = nominal fidelity; this PR moves no claim boundary. Decision/stop rule unchanged: launch stays fail-closed until rvo2/opt-in/recheck gates clear.
- **State propagation:** `#3207` is high-churn (>3 PRs/24h). Commenting is disabled in this lane, so this PR body is the single canonical surface for slice-delivered + remaining launch gates. No transient queue-routing state is encoded in tracked files.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
