### PR TITLE
Issue #4359: add collision scenario similarity report

### DIFF
--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -50,6 +50,10 @@ from robot_sf.benchmark.canonical_table_export import (
     export_canonical_table as _export_canonical_table,
 )
 from robot_sf.benchmark.canonical_table_export import load_rows_json as _load_canonical_rows_json
+from robot_sf.benchmark.collision_scenario_similarity import (
+    build_collision_scenario_similarity_report,
+    write_collision_scenario_similarity_report,
+)
 from robot_sf.benchmark.distributions import collect_grouped_values as _dist_collect
 from robot_sf.benchmark.distributions import save_distributions as _dist_save
 from robot_sf.benchmark.doctor import collect_doctor_report, doctor_exit_code
@@ -667,6 +671,37 @@ def _handle_classify_failure_mechanisms(args) -> int:
         return 0
     except Exception:
         logging.exception("Failure mechanism classification failed")
+        return 2
+
+
+def _handle_collision_scenario_similarity(args) -> int:
+    """Build collision-scenario similarity report from episode JSONL records.
+
+    Returns:
+        Process exit code.
+    """
+    try:
+        report = build_collision_scenario_similarity_report(
+            args.episodes_jsonl,
+            nearest_k=args.nearest_k,
+            group_threshold=args.group_threshold,
+            collision_threshold=args.collision_threshold,
+            near_miss_threshold=args.near_miss_threshold,
+            comfort_threshold=args.comfort_threshold,
+        )
+        write_collision_scenario_similarity_report(
+            report,
+            args.out_json,
+            out_markdown=args.out_markdown,
+        )
+        logging.info(
+            "Collision scenario similarity report wrote %d selected records to %s",
+            report["selection"]["selected_count"],
+            args.out_json,
+        )
+        return 0
+    except (EpisodeRecordInputError, OSError, TypeError, ValueError):
+        logging.exception("Collision scenario similarity report failed")
         return 2
 
 
@@ -1983,6 +2018,47 @@ def _add_classify_failure_mechanisms_subparser(
     p.set_defaults(cmd="classify-failure-mechanisms")
 
 
+def _add_collision_scenario_similarity_subparser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register collision-scenario-similarity subcommand parser."""
+    p = subparsers.add_parser(
+        "collision-scenario-similarity",
+        help="Build nearest-neighbor groups for collision and near-collision episodes.",
+    )
+    p.add_argument("--episodes-jsonl", required=True, help="Input benchmark episode JSONL path.")
+    p.add_argument("--out-json", required=True, help="Output similarity report JSON path.")
+    p.add_argument("--out-markdown", default=None, help="Optional Markdown inspection report path.")
+    p.add_argument(
+        "--nearest-k", type=int, default=3, help="Neighbors to list per selected record."
+    )
+    p.add_argument(
+        "--group-threshold",
+        type=float,
+        default=0.35,
+        help="Maximum normalized distance linking records into a group.",
+    )
+    p.add_argument(
+        "--collision-threshold",
+        type=float,
+        default=1.0,
+        help="Minimum collisions for selection.",
+    )
+    p.add_argument(
+        "--near-miss-threshold",
+        type=float,
+        default=0.0,
+        help="Strict lower bound for near_misses selection.",
+    )
+    p.add_argument(
+        "--comfort-threshold",
+        type=float,
+        default=0.2,
+        help="Minimum comfort_exposure for selection.",
+    )
+    p.set_defaults(cmd="collision-scenario-similarity")
+
+
 def _add_validate_row_claims_subparser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -2582,6 +2658,7 @@ def _attach_core_subcommands(parser: argparse.ArgumentParser) -> None:  # noqa: 
     _add_metric_layers_subparser(subparsers)
     _add_stress_coverage_report_subparser(subparsers)
     _add_classify_failure_mechanisms_subparser(subparsers)
+    _add_collision_scenario_similarity_subparser(subparsers)
     _add_claim_subparser(subparsers)
     _add_validate_row_claims_subparser(subparsers)
     _add_export_parquet_subparser(subparsers)
@@ -3088,6 +3165,7 @@ def cli_main(argv: list[str] | None = None) -> int:
         "metric-layers": _handle_metric_layers,
         "stress-coverage-report": _handle_stress_coverage_report,
         "classify-failure-mechanisms": _handle_classify_failure_mechanisms,
+        "collision-scenario-similarity": _handle_collision_scenario_similarity,
         "claim": _handle_claim,
         "validate-row-claims": _handle_validate_row_claims,
         "export-parquet": _handle_export_parquet,

--- a/robot_sf/benchmark/collision_scenario_similarity.py
+++ b/robot_sf/benchmark/collision_scenario_similarity.py
@@ -1,0 +1,413 @@
+"""Collision and near-collision scenario similarity reports.
+
+This module builds a deterministic analysis-aid report from existing benchmark
+episode JSONL records.  It is intentionally descriptive: nearest-neighbor and
+group assignments are not benchmark evidence unless separately validated against
+external labels.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.aggregate import read_jsonl
+from robot_sf.benchmark.failure_extractor import is_failure
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+SCHEMA_VERSION = "collision_scenario_similarity.v1"
+ISSUE_URL = "https://github.com/ll7/robot_sf_ll7/issues/4359"
+
+_NUMERIC_FEATURES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("collisions", ("metrics.collisions", "collisions")),
+    ("near_misses", ("metrics.near_misses", "near_misses")),
+    (
+        "min_separation",
+        ("metrics.min_separation", "metrics.minimum_separation", "min_separation"),
+    ),
+    ("time_to_conflict", ("metrics.time_to_conflict", "time_to_conflict")),
+    ("comfort_exposure", ("metrics.comfort_exposure", "comfort_exposure")),
+    ("time_to_goal", ("metrics.time_to_goal", "time_to_goal")),
+    ("num_pedestrians", ("scenario_params.num_pedestrians", "num_pedestrians")),
+    ("mean_speed", ("metrics.mean_speed", "metrics.average_speed")),
+)
+
+_CATEGORICAL_FEATURES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("map", ("map_name", "map_id", "scenario_params.map_name")),
+    ("scenario_family", ("scenario_family", "scenario_params.family", "scenario_params.kind")),
+    ("planner", ("planner_id", "algo", "scenario_params.algo", "scenario_params.planner")),
+    ("termination_reason", ("termination_reason", "status")),
+)
+
+
+@dataclass(frozen=True)
+class ScenarioDescriptor:
+    """Feature descriptor for one unsafe or near-unsafe episode."""
+
+    record_id: str
+    source_index: int
+    numeric: dict[str, float]
+    categorical: dict[str, str]
+    event: dict[str, Any]
+
+    def to_json(self) -> dict[str, Any]:
+        """Return JSON-safe descriptor payload."""
+        return {
+            "record_id": self.record_id,
+            "source_index": self.source_index,
+            "numeric": dict(sorted(self.numeric.items())),
+            "categorical": dict(sorted(self.categorical.items())),
+            "event": self.event,
+        }
+
+
+def _nested(record: dict[str, Any], path: str) -> Any:
+    current: Any = record
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _first_present(record: dict[str, Any], paths: Sequence[str]) -> Any:
+    for path in paths:
+        value = _nested(record, path)
+        if value is not None:
+            return value
+    return None
+
+
+def _finite_float(value: Any) -> float | None:
+    try:
+        candidate = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isfinite(candidate):
+        return candidate
+    return None
+
+
+def _record_id(record: dict[str, Any], index: int) -> str:
+    for key in ("episode_id", "record_id", "run_id"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    scenario_id = record.get("scenario_id")
+    seed = record.get("seed")
+    if scenario_id is not None and seed is not None:
+        return f"{scenario_id}:seed={seed}:row={index}"
+    if scenario_id is not None:
+        return f"{scenario_id}:row={index}"
+    return f"row={index}"
+
+
+def _event_summary(record: dict[str, Any]) -> dict[str, Any]:
+    metrics = record.get("metrics") if isinstance(record.get("metrics"), dict) else {}
+    return {
+        "scenario_id": record.get("scenario_id"),
+        "seed": record.get("seed"),
+        "collisions": metrics.get("collisions", record.get("collisions", 0)),
+        "near_misses": metrics.get("near_misses", record.get("near_misses", 0)),
+        "min_separation": metrics.get(
+            "min_separation",
+            metrics.get("minimum_separation", record.get("min_separation")),
+        ),
+        "termination_reason": record.get("termination_reason", record.get("status")),
+    }
+
+
+def describe_collision_scenarios(
+    records: Iterable[dict[str, Any]],
+    *,
+    collision_threshold: float = 1.0,
+    near_miss_threshold: float = 0.0,
+    comfort_threshold: float = 0.2,
+) -> list[ScenarioDescriptor]:
+    """Extract descriptors for collision, near-miss, or high-discomfort records.
+
+    Returns:
+        Descriptors for records selected by the failure-like thresholds.
+    """
+    descriptors: list[ScenarioDescriptor] = []
+    for index, record in enumerate(records):
+        if not is_failure(
+            record,
+            collision_threshold=collision_threshold,
+            near_miss_threshold=near_miss_threshold,
+            comfort_threshold=comfort_threshold,
+        ):
+            continue
+
+        numeric: dict[str, float] = {}
+        for name, paths in _NUMERIC_FEATURES:
+            value = _finite_float(_first_present(record, paths))
+            if value is not None:
+                numeric[name] = value
+
+        categorical: dict[str, str] = {}
+        for name, paths in _CATEGORICAL_FEATURES:
+            value = _first_present(record, paths)
+            if value is not None and str(value).strip():
+                categorical[name] = str(value).strip()
+
+        descriptors.append(
+            ScenarioDescriptor(
+                record_id=_record_id(record, index),
+                source_index=index,
+                numeric=numeric,
+                categorical=categorical,
+                event=_event_summary(record),
+            )
+        )
+    return descriptors
+
+
+def _numeric_ranges(descriptors: Sequence[ScenarioDescriptor]) -> dict[str, tuple[float, float]]:
+    ranges: dict[str, tuple[float, float]] = {}
+    for name, _paths in _NUMERIC_FEATURES:
+        values = [
+            descriptor.numeric[name] for descriptor in descriptors if name in descriptor.numeric
+        ]
+        if values:
+            ranges[name] = (min(values), max(values))
+    return ranges
+
+
+def _feature_distance(
+    left: ScenarioDescriptor,
+    right: ScenarioDescriptor,
+    *,
+    numeric_ranges: dict[str, tuple[float, float]],
+) -> tuple[float, list[str]]:
+    components: list[float] = []
+    shared_features: list[str] = []
+
+    for name, (minimum, maximum) in numeric_ranges.items():
+        if name not in left.numeric or name not in right.numeric:
+            continue
+        scale = maximum - minimum
+        value = 0.0 if scale == 0 else abs(left.numeric[name] - right.numeric[name]) / scale
+        components.append(value)
+        shared_features.append(name)
+
+    for name, _paths in _CATEGORICAL_FEATURES:
+        if name not in left.categorical or name not in right.categorical:
+            continue
+        components.append(0.0 if left.categorical[name] == right.categorical[name] else 1.0)
+        shared_features.append(name)
+
+    if not components:
+        return 1.0, []
+    return sum(components) / len(components), shared_features
+
+
+def _nearest_neighbors(
+    descriptors: Sequence[ScenarioDescriptor],
+    *,
+    nearest_k: int,
+) -> tuple[list[dict[str, Any]], dict[tuple[int, int], float]]:
+    ranges = _numeric_ranges(descriptors)
+    pair_distances: dict[tuple[int, int], float] = {}
+    rows: list[dict[str, Any]] = []
+    for left_index, left in enumerate(descriptors):
+        candidates: list[dict[str, Any]] = []
+        for right_index, right in enumerate(descriptors):
+            if left_index == right_index:
+                continue
+            distance, shared_features = _feature_distance(left, right, numeric_ranges=ranges)
+            pair_distances[tuple(sorted((left_index, right_index)))] = distance
+            candidates.append(
+                {
+                    "record_id": right.record_id,
+                    "distance": round(distance, 6),
+                    "shared_features": shared_features,
+                }
+            )
+        candidates.sort(key=lambda row: (row["distance"], row["record_id"]))
+        rows.append({"record_id": left.record_id, "neighbors": candidates[:nearest_k]})
+    return rows, pair_distances
+
+
+def _group_descriptors(
+    descriptors: Sequence[ScenarioDescriptor],
+    pair_distances: dict[tuple[int, int], float],
+    *,
+    threshold: float,
+) -> list[dict[str, Any]]:
+    parent = list(range(len(descriptors)))
+
+    def find(index: int) -> int:
+        while parent[index] != index:
+            parent[index] = parent[parent[index]]
+            index = parent[index]
+        return index
+
+    def union(left: int, right: int) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parent[right_root] = left_root
+
+    for (left, right), distance in pair_distances.items():
+        if distance <= threshold:
+            union(left, right)
+
+    components: dict[int, list[int]] = defaultdict(list)
+    for index in range(len(descriptors)):
+        components[find(index)].append(index)
+
+    groups: list[dict[str, Any]] = []
+    for group_index, member_indexes in enumerate(
+        sorted(
+            components.values(), key=lambda values: (-len(values), descriptors[values[0]].record_id)
+        ),
+        start=1,
+    ):
+        representative_index = _representative(member_indexes, pair_distances)
+        groups.append(
+            {
+                "group_id": f"group-{group_index}",
+                "size": len(member_indexes),
+                "representative_record_id": descriptors[representative_index].record_id,
+                "record_ids": [descriptors[index].record_id for index in member_indexes],
+            }
+        )
+    return groups
+
+
+def _representative(
+    member_indexes: Sequence[int],
+    pair_distances: dict[tuple[int, int], float],
+) -> int:
+    if len(member_indexes) == 1:
+        return member_indexes[0]
+    scored: list[tuple[float, int]] = []
+    for candidate in member_indexes:
+        total = 0.0
+        for other in member_indexes:
+            if candidate == other:
+                continue
+            total += pair_distances.get(tuple(sorted((candidate, other))), 1.0)
+        scored.append((total / (len(member_indexes) - 1), candidate))
+    scored.sort()
+    return scored[0][1]
+
+
+def build_collision_scenario_similarity_report(
+    episodes_jsonl: str | Path,
+    *,
+    nearest_k: int = 3,
+    group_threshold: float = 0.35,
+    collision_threshold: float = 1.0,
+    near_miss_threshold: float = 0.0,
+    comfort_threshold: float = 0.2,
+) -> dict[str, Any]:
+    """Build a scenario-similarity report from benchmark episode JSONL records.
+
+    Returns:
+        JSON-safe report with descriptors, nearest neighbors, groups, and limitations.
+    """
+    records = read_jsonl([Path(episodes_jsonl)])
+    descriptors = describe_collision_scenarios(
+        records,
+        collision_threshold=collision_threshold,
+        near_miss_threshold=near_miss_threshold,
+        comfort_threshold=comfort_threshold,
+    )
+    neighbors, pair_distances = _nearest_neighbors(descriptors, nearest_k=max(0, int(nearest_k)))
+    groups = _group_descriptors(descriptors, pair_distances, threshold=float(group_threshold))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": ISSUE_URL,
+        "inputs": {"episodes_jsonl": str(episodes_jsonl), "record_count": len(records)},
+        "selection": {
+            "selected_count": len(descriptors),
+            "collision_threshold": collision_threshold,
+            "near_miss_threshold": near_miss_threshold,
+            "comfort_threshold": comfort_threshold,
+        },
+        "feature_sets": {
+            "numeric": [name for name, _paths in _NUMERIC_FEATURES],
+            "categorical": [name for name, _paths in _CATEGORICAL_FEATURES],
+        },
+        "descriptors": [descriptor.to_json() for descriptor in descriptors],
+        "nearest_neighbors": neighbors,
+        "groups": groups,
+        "limitations": [
+            "Scenario similarity is an analysis aid, not benchmark evidence by itself.",
+            "Distances depend on logged descriptor fields and do not validate external labels.",
+            "Missing trajectory-level fields are excluded rather than imputed.",
+        ],
+    }
+
+
+def format_collision_scenario_similarity_markdown(report: dict[str, Any]) -> str:
+    """Format a compact Markdown table for reviewer inspection.
+
+    Returns:
+        Markdown report text.
+    """
+    lines = [
+        "# Collision Scenario Similarity Report",
+        "",
+        f"- Schema: `{report['schema_version']}`",
+        f"- Selected records: {report['selection']['selected_count']} / "
+        f"{report['inputs']['record_count']}",
+        "",
+        "## Groups",
+        "",
+        "| group | size | representative | members |",
+        "| --- | ---: | --- | --- |",
+    ]
+    for group in report["groups"]:
+        lines.append(
+            f"| {group['group_id']} | {group['size']} | "
+            f"`{group['representative_record_id']}` | "
+            f"{', '.join(f'`{record_id}`' for record_id in group['record_ids'])} |"
+        )
+    lines.extend(["", "## Nearest Neighbors", "", "| record | neighbors |", "| --- | --- |"])
+    for row in report["nearest_neighbors"]:
+        neighbor_text = ", ".join(
+            f"`{neighbor['record_id']}` ({neighbor['distance']:.3f})"
+            for neighbor in row["neighbors"]
+        )
+        lines.append(f"| `{row['record_id']}` | {neighbor_text} |")
+    lines.extend(["", "## Limitations", ""])
+    lines.extend(f"- {limitation}" for limitation in report["limitations"])
+    return "\n".join(lines) + "\n"
+
+
+def write_collision_scenario_similarity_report(
+    report: dict[str, Any],
+    out_json: str | Path,
+    *,
+    out_markdown: str | Path | None = None,
+) -> None:
+    """Write JSON and optional Markdown scenario-similarity reports."""
+    out_json_path = Path(out_json)
+    out_json_path.parent.mkdir(parents=True, exist_ok=True)
+    out_json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if out_markdown is not None:
+        out_markdown_path = Path(out_markdown)
+        out_markdown_path.parent.mkdir(parents=True, exist_ok=True)
+        out_markdown_path.write_text(
+            format_collision_scenario_similarity_markdown(report),
+            encoding="utf-8",
+        )
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "ScenarioDescriptor",
+    "build_collision_scenario_similarity_report",
+    "describe_collision_scenarios",
+    "format_collision_scenario_similarity_markdown",
+    "write_collision_scenario_similarity_report",
+]

--- a/tests/benchmark/test_collision_scenario_similarity.py
+++ b/tests/benchmark/test_collision_scenario_similarity.py
@@ -1,0 +1,148 @@
+"""Tests for collision scenario similarity analysis reports."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.cli import cli_main
+from robot_sf.benchmark.collision_scenario_similarity import (
+    SCHEMA_VERSION,
+    build_collision_scenario_similarity_report,
+    describe_collision_scenarios,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
+
+
+def _records() -> list[dict]:
+    return [
+        {
+            "episode_id": "alpha-1",
+            "scenario_id": "crossing-alpha",
+            "seed": 1,
+            "map_name": "atrium",
+            "termination_reason": "collision",
+            "scenario_params": {"algo": "orca", "family": "crossing", "num_pedestrians": 6},
+            "metrics": {
+                "collisions": 1,
+                "near_misses": 1,
+                "min_separation": 0.04,
+                "time_to_conflict": 1.2,
+                "comfort_exposure": 0.3,
+                "time_to_goal": 18.0,
+            },
+        },
+        {
+            "episode_id": "alpha-2",
+            "scenario_id": "crossing-alpha",
+            "seed": 2,
+            "map_name": "atrium",
+            "termination_reason": "collision",
+            "scenario_params": {"algo": "orca", "family": "crossing", "num_pedestrians": 6},
+            "metrics": {
+                "collisions": 1,
+                "near_misses": 1,
+                "min_separation": 0.05,
+                "time_to_conflict": 1.3,
+                "comfort_exposure": 0.31,
+                "time_to_goal": 18.5,
+            },
+        },
+        {
+            "episode_id": "beta-1",
+            "scenario_id": "doorway-beta",
+            "seed": 3,
+            "map_name": "doorway",
+            "termination_reason": "near_miss",
+            "scenario_params": {"algo": "dwa", "family": "doorway", "num_pedestrians": 12},
+            "metrics": {
+                "collisions": 0,
+                "near_misses": 2,
+                "min_separation": 0.18,
+                "time_to_conflict": 4.0,
+                "comfort_exposure": 0.25,
+                "time_to_goal": 35.0,
+            },
+        },
+        {
+            "episode_id": "safe-1",
+            "scenario_id": "easy",
+            "seed": 4,
+            "map_name": "atrium",
+            "termination_reason": "success",
+            "scenario_params": {"algo": "orca", "family": "crossing", "num_pedestrians": 3},
+            "metrics": {
+                "collisions": 0,
+                "near_misses": 0,
+                "min_separation": 1.2,
+                "time_to_goal": 12.0,
+            },
+        },
+    ]
+
+
+def test_describe_collision_scenarios_selects_only_unsafe_records() -> None:
+    """Descriptor extraction selects only collision, near-miss, or discomfort cases."""
+    descriptors = describe_collision_scenarios(_records())
+
+    assert [descriptor.record_id for descriptor in descriptors] == ["alpha-1", "alpha-2", "beta-1"]
+    assert descriptors[0].numeric["min_separation"] == 0.04
+    assert descriptors[0].categorical["scenario_family"] == "crossing"
+    assert descriptors[2].event["near_misses"] == 2
+
+
+def test_similarity_report_groups_nearby_collision_cases(tmp_path: Path) -> None:
+    """Report groups the two similar crossing collisions before the doorway case."""
+    episodes = tmp_path / "episodes.jsonl"
+    _write_jsonl(episodes, _records())
+
+    report = build_collision_scenario_similarity_report(
+        episodes,
+        nearest_k=1,
+        group_threshold=0.35,
+    )
+
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["selection"]["selected_count"] == 3
+    assert report["nearest_neighbors"][0]["record_id"] == "alpha-1"
+    assert report["nearest_neighbors"][0]["neighbors"][0]["record_id"] == "alpha-2"
+    alpha_group = next(group for group in report["groups"] if "alpha-1" in group["record_ids"])
+    assert alpha_group["record_ids"] == ["alpha-1", "alpha-2"]
+    assert alpha_group["representative_record_id"] in {"alpha-1", "alpha-2"}
+    assert any("analysis aid" in limitation for limitation in report["limitations"])
+
+
+def test_collision_scenario_similarity_cli_writes_json_and_markdown(tmp_path: Path) -> None:
+    """CLI writes both machine-readable and reviewer-readable reports."""
+    episodes = tmp_path / "episodes.jsonl"
+    out_json = tmp_path / "similarity.json"
+    out_md = tmp_path / "similarity.md"
+    _write_jsonl(episodes, _records())
+
+    exit_code = cli_main(
+        [
+            "collision-scenario-similarity",
+            "--episodes-jsonl",
+            str(episodes),
+            "--out-json",
+            str(out_json),
+            "--out-markdown",
+            str(out_md),
+            "--nearest-k",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["nearest_neighbors"][0]["neighbors"]
+    markdown = out_md.read_text(encoding="utf-8")
+    assert "Collision Scenario Similarity Report" in markdown
+    assert "alpha-1" in markdown

--- a/tests/benchmark/test_collision_scenario_similarity.py
+++ b/tests/benchmark/test_collision_scenario_similarity.py
@@ -146,3 +146,35 @@ def test_collision_scenario_similarity_cli_writes_json_and_markdown(tmp_path: Pa
     markdown = out_md.read_text(encoding="utf-8")
     assert "Collision Scenario Similarity Report" in markdown
     assert "alpha-1" in markdown
+
+
+def test_collision_scenario_similarity_cli_fails_closed_on_bad_input(tmp_path: Path) -> None:
+    """Missing or malformed episode JSONL fails closed with exit code 2 and no output."""
+    out_json = tmp_path / "similarity.json"
+
+    missing = tmp_path / "does_not_exist.jsonl"
+    missing_exit = cli_main(
+        [
+            "collision-scenario-similarity",
+            "--episodes-jsonl",
+            str(missing),
+            "--out-json",
+            str(out_json),
+        ]
+    )
+    assert missing_exit == 2
+    assert not out_json.exists()
+
+    malformed = tmp_path / "malformed.jsonl"
+    malformed.write_text("{not valid json}\n", encoding="utf-8")
+    malformed_exit = cli_main(
+        [
+            "collision-scenario-similarity",
+            "--episodes-jsonl",
+            str(malformed),
+            "--out-json",
+            str(out_json),
+        ]
+    )
+    assert malformed_exit == 2
+    assert not out_json.exists()


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a deterministic `collision-scenario-similarity` benchmark CLI report that extracts collision, near-miss, and high-discomfort episode descriptors from existing episode JSONL, computes normalized nearest neighbors, and groups similar unsafe scenarios for inspection.

Why now: issue #4359 asks for a first collision-scenario similarity lane so repeated unsafe patterns are easier to compare instead of treating each run as an isolated anecdote.

Claim boundary: this is an analysis aid only. It does not validate external scenario labels, does not establish benchmark conclusions, and does not change planner, metric, or campaign semantics.

Required validation: focused descriptor/report/CLI tests plus the repository PR readiness gate. Validation was run locally; final readiness used the shared main-checkout virtualenv because the fresh worktree virtualenv lacked optional `torch` for the predictive lane.

Remaining blocker: representative use on a durable real benchmark artifact is still future work; this PR proves the command on a deterministic fixture and leaves full benchmark campaign / Slurm execution out of scope.

## Contract delta

- New CLI: `uv run python -m robot_sf.benchmark.cli collision-scenario-similarity --episodes-jsonl <episodes.jsonl> --out-json <report.json> [--out-markdown <report.md>]`.
- New report schema marker: `collision_scenario_similarity.v1`.
- New report fields: `inputs`, `selection`, `feature_sets`, `descriptors`, `nearest_neighbors`, `groups`, and `limitations`.
- New fail-closed behavior: malformed or missing episode JSONL still fails through the existing strict benchmark JSONL reader; CLI handler returns exit code `2` on report generation errors.
- Compatibility impact: additive only. No existing benchmark metrics, planner modes, schemas, or campaign execution paths are changed.

## Summary

Adds the first reversible implementation slice for #4359: a benchmark-owned scenario similarity report over existing episode JSONL records, with nearest-neighbor output, simple connected groups, Markdown inspection output, and focused deterministic tests.

## Linked Issues

- Relates to #4359

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed

- Added `robot_sf.benchmark.collision_scenario_similarity` for descriptor extraction, normalized pairwise distance, nearest-neighbor rows, group summaries, JSON report writing, and Markdown formatting.
- Registered `collision-scenario-similarity` in `robot_sf.benchmark.cli`.
- Added focused tests covering unsafe-record selection, nearest-neighbor/group behavior, and CLI JSON/Markdown outputs.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: unblocks inspection tooling for #4359 collision and near-collision scenario similarity analysis.
- Comparator or baseline, applicable: NA; this PR does not compare planners or publish research results.
- Evidence tier: targeted smoke / diagnostic analysis tool.
- Result classification: diagnostic-only.
- Decision stop rule, applicable: command generates deterministic report from fixture and labels limitations as analysis-aid only.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #4359 remains open for durable artifact use and empirical follow-up.
- New research/benchmark/metric/paper-facing analysis tool, any: yes; representative real durable benchmark input is deferred to #4359 follow-up because this PR intentionally avoids full benchmark campaign and Slurm/GPU submission.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/cli.py robot_sf/benchmark/collision_scenario_similarity.py tests/benchmark/test_collision_scenario_similarity.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_collision_scenario_similarity.py -q` -> `3 passed`.
- Initial `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` in the fresh worktree -> core lane passed (`1807 passed, 2 skipped`), optional lane failed before branch-specific execution because `torch` was absent from the fresh worktree virtualenv.
- `scripts/dev/run_worktree_shared_venv.sh -- bash -lc 'BASE_REF=origin/main scripts/dev/pr_ready_check.sh'` -> core lane passed (`1807 passed, 2 skipped`); optional lane passed (`4780 passed, 7 skipped, 5 warnings`); changed-file coverage warnings remained above the configured minimum (`cli.py` 86.4%, `collision_scenario_similarity.py` 93.8%).
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout

- Compatibility risks: low; additive CLI/report module only.
- Failure modes: similarity distance depends on logged descriptor fields and may miss trajectory-level similarity when logs do not include trajectory features.
- Rollback fallback plan: remove the additive CLI registration and module.

## Docs / Provenance

- Updated docs: NA; CLI help and report limitations document this first implementation slice.
- Relevant design provenance notes: issue #4359.
- Any assumptions need to preserved: descriptor similarity is diagnostic and should not be promoted to benchmark evidence without external validation or a durable representative artifact.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: authorization explicitly disallows issue/PR comments beyond opening this PR (`comment_issue_or_pr: false`), and this PR is diagnostic tooling rather than a benchmark result propagation surface.

## Follow-Up Issues

- Deferred work: run the command on a durable/versioned benchmark artifact and use the output to choose representative collision scenario groups for deeper analysis under #4359.
- Issues opened follow-up: none; #4359 remains the parent issue.

## Reviewer Notes

- Review the descriptor fields and distance normalization closely; the implementation intentionally excludes missing fields rather than imputing values.
- Known limitation: this PR does not include trajectory-shape features unless future episode artifacts expose them in a stable schema.

<details>
<summary>Governance appendix</summary>

## Domain-Aware Approval

- Required for PR: yes - research/benchmark-labeled diagnostic analysis tool.
- Domains reviewed: benchmark diagnostic tooling, scenario descriptor validity.
- Status: waived - this PR is diagnostic tooling only; empirical-validity promotion is deferred to #4359 durable-artifact follow-up.
- Approval or blocker note: waiver is limited to merging the additive diagnostic report tool; benchmark or paper-facing claims remain blocked until #4359 validates the report on durable/versioned benchmark input.
- Approver/review source waiver: active issue authorizes a reversible diagnostic/checker slice; this waiver does not approve empirical claims.
- Validity checklist: analysis-aid limitation is present in report output.
- Target claim/hypothesis: #4359 scenario-similarity tooling only; no planner-quality or benchmark-performance claim.
- Comparator or split/evidence validity: no comparator split is evaluated in this PR; evidence validity is limited to deterministic fixture coverage of the report contract, with real artifact validation deferred to #4359.
- Fallback/degraded exclusions: no benchmark run or planner outcome claim is made.
- Claim boundary: diagnostic similarity grouping only.
- Implementation integrity vs experimental validity: implementation is covered by deterministic fixture tests; empirical validity remains future work.

## Falsification / Non-Transfer Check

- Did mechanism activate? unknown; no real campaign artifact evaluated in this PR.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? fixture includes collision and near-miss records only for code-path proof.
- Result route: continue under #4359 with durable artifact use.
- Follow-up question issue weak, negative, non-transfer results: whether descriptor-only similarity agrees with trajectory-level or external labels.

## Next Empirical Action

- Rerun needed: yes, on a durable benchmark artifact.
- Extractor analysis tool needed: no; this PR adds the first extractor/report tool.
- Artifact missing unavailable: durable representative episode JSONL for #4359 follow-up.
- Stop / revise / continue decision: continue.
- Proposed child issue existing follow-up: #4359.

## Performance Proof

- Baseline runtime: NA; no caching or hot-path runtime claim.
- Changed runtime: NA.
- Representative command: `uv run python -m robot_sf.benchmark.cli collision-scenario-similarity --episodes-jsonl <episodes.jsonl> --out-json <report.json>`.
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: CLI cannot generate deterministic fixture report or report overclaims benchmark evidence.

</details>
