### PR TITLE
refactor: extract camera-ready config types (#3385)

### DIFF
--- a/robot_sf/benchmark/camera_ready/__init__.py
+++ b/robot_sf/benchmark/camera_ready/__init__.py
@@ -2,7 +2,8 @@
 
 Decomposes the historically monolithic ``camera_ready_campaign.py`` (~4967 LOC)
 into focused submodules (see #3385). Leaf helpers live in ``_util.py``;
-config dataclasses live in ``camera_ready_campaign_config.py``; the remaining
-orchestration/IO/computation stays in ``camera_ready_campaign.py`` until later
-slices extract it.
+config dataclasses live in ``_config_types.py`` while
+``camera_ready_campaign_config.py`` remains a compatibility facade. Most
+orchestration/IO/computation has moved into this package while
+``camera_ready_campaign.py`` preserves legacy import and monkeypatch surfaces.
 """

--- a/robot_sf/benchmark/camera_ready/_artifacts.py
+++ b/robot_sf/benchmark/camera_ready/_artifacts.py
@@ -6,8 +6,8 @@ import csv
 import json
 from typing import TYPE_CHECKING, Any
 
+from robot_sf.benchmark.camera_ready._config_types import _AMV_DIMENSIONS
 from robot_sf.benchmark.camera_ready._util import _sanitize_csv_cell
-from robot_sf.benchmark.camera_ready_campaign_config import _AMV_DIMENSIONS
 from robot_sf.benchmark.seed_variance import build_seed_variability_csv_rows
 from robot_sf.benchmark.snqi.compute import WEIGHT_NAMES
 

--- a/robot_sf/benchmark/camera_ready/_config.py
+++ b/robot_sf/benchmark/camera_ready/_config.py
@@ -16,8 +16,7 @@ from typing import Any
 
 import yaml
 
-from robot_sf.benchmark.camera_ready._util import _repo_relative
-from robot_sf.benchmark.camera_ready_campaign_config import (
+from robot_sf.benchmark.camera_ready._config_types import (
     _AMV_DIMENSIONS,
     DEFAULT_SEED_SETS_PATH,
     AmvProfileConfig,
@@ -27,6 +26,7 @@ from robot_sf.benchmark.camera_ready_campaign_config import (
     SeedPolicy,
     SnqiContractConfig,
 )
+from robot_sf.benchmark.camera_ready._util import _repo_relative
 from robot_sf.benchmark.latency_stress import (
     load_latency_stress_profile,
     validate_latency_stress_profile,

--- a/robot_sf/benchmark/camera_ready/_config_types.py
+++ b/robot_sf/benchmark/camera_ready/_config_types.py
@@ -1,0 +1,132 @@
+"""Config dataclasses for camera-ready benchmark campaign.
+
+These pure frozen configuration dataclasses and constants are the package-local
+owner for the #3385 camera-ready decomposition. Legacy modules re-export these
+objects to keep earlier import paths working without behavior changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from robot_sf.benchmark.latency_stress import LatencyStressProfile
+    from robot_sf.benchmark.synthetic_actuation import SyntheticActuationProfile
+
+DEFAULT_SEED_SETS_PATH = Path("configs/benchmarks/seed_sets_v1.yaml")
+_AMV_DIMENSIONS = ("use_case", "context", "speed_regime", "maneuver_type")
+
+
+@dataclass(frozen=True)
+class AmvProfileConfig:
+    """AMV paper-profile scope contract settings."""
+
+    name: str = "amv-paper-v1"
+    contract_version: str = "1"
+    coverage_enforcement: str = "warn"
+    required_dimensions: dict[str, tuple[str, ...]] = field(
+        default_factory=lambda: dict.fromkeys(_AMV_DIMENSIONS, ())
+    )
+
+
+@dataclass(frozen=True)
+class SeedPolicy:
+    """Seed selection policy for campaign scenarios."""
+
+    mode: str = "scenario-default"
+    seed_set: str | None = None
+    seeds: tuple[int, ...] = ()
+    seed_sets_path: Path = DEFAULT_SEED_SETS_PATH
+
+
+@dataclass(frozen=True)
+class ScenarioCandidateSelection:
+    """Optional named scenario subset for compact benchmark slices."""
+
+    names: tuple[str, ...] = ()
+    selection_name: str | None = None
+
+
+@dataclass(frozen=True)
+class PlannerSpec:
+    """One planner entry in a benchmark campaign matrix."""
+
+    key: str
+    algo: str
+    human_model_variant: str | None = None
+    human_model_source: str | None = None
+    benchmark_profile: str = "baseline-safe"
+    algo_config_path: Path | None = None
+    socnav_missing_prereq_policy: str = "fail-fast"
+    adapter_impact_eval: bool = False
+    observation_mode: str | None = None
+    workers_override: int | None = None
+    horizon_override: int | None = None
+    dt_override: float | None = None
+    enabled: bool = True
+    planner_group: str = "experimental"
+    planner_group_explicit: bool = False
+
+
+@dataclass(frozen=True)
+class SnqiContractConfig:
+    """SNQI paper-facing behavior contract configuration."""
+
+    enabled: bool = True
+    enforcement: str = "warn"
+    rank_alignment_warn_threshold: float = 0.5
+    rank_alignment_fail_threshold: float = 0.3
+    outcome_separation_warn_threshold: float = 0.05
+    outcome_separation_fail_threshold: float = 0.0
+    max_component_dominance_warn_threshold: float = 0.24
+    max_component_dominance_fail_threshold: float = 0.27
+    calibration_seed: int = 123
+    calibration_trials: int = 3000
+
+
+@dataclass(frozen=True)
+class CampaignConfig:
+    """Top-level camera-ready benchmark campaign config."""
+
+    name: str
+    scenario_matrix_path: Path
+    planners: tuple[PlannerSpec, ...]
+    scenario_candidates: ScenarioCandidateSelection = field(
+        default_factory=ScenarioCandidateSelection
+    )
+    scenario_amv_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
+    seed_policy: SeedPolicy = SeedPolicy()
+    scenario_horizons_path: Path | None = None
+    workers: int = 1
+    horizon: int | None = None
+    dt: float | None = None
+    record_forces: bool = True
+    resume: bool = True
+    bootstrap_samples: int = 400
+    bootstrap_confidence: float = 0.95
+    bootstrap_seed: int = 123
+    snqi_weights_path: Path | None = None
+    snqi_baseline_path: Path | None = None
+    stop_on_failure: bool = False
+    export_publication_bundle: bool = True
+    include_videos_in_publication: bool = False
+    overwrite_publication_bundle: bool = True
+    repository_url: str = "https://github.com/ll7/robot_sf_ll7"
+    release_tag: str = "{release_tag}"
+    doi: str = "10.5281/zenodo.<record-id>"
+    paper_interpretation_profile: str = "baseline-ready-core"
+    preview_scenario_limit: int = 100
+    kinematics_matrix: tuple[str, ...] = ("differential_drive",)
+    holonomic_command_mode: str = "vx_vy"
+    observation_mode: str | None = None
+    paper_facing: bool = False
+    paper_profile_version: str | None = None
+    amv_profile: AmvProfileConfig = field(default_factory=AmvProfileConfig)
+    synthetic_actuation_profile: SyntheticActuationProfile | None = None
+    latency_stress_profile: LatencyStressProfile | None = None
+    comparability_mapping_path: Path | None = None
+    snqi_contract: SnqiContractConfig = field(default_factory=SnqiContractConfig)
+    route_clearance_certifications_path: Path | None = None
+    observation_noise: dict[str, Any] | None = None

--- a/robot_sf/benchmark/camera_ready/_preflight.py
+++ b/robot_sf/benchmark/camera_ready/_preflight.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
-    from robot_sf.benchmark.camera_ready_campaign_config import CampaignConfig
+    from robot_sf.benchmark.camera_ready._config_types import CampaignConfig
 
 
 def _scenario_display_name(scenario: dict[str, Any]) -> str:

--- a/robot_sf/benchmark/camera_ready/_reporting.py
+++ b/robot_sf/benchmark/camera_ready/_reporting.py
@@ -13,8 +13,8 @@ from typing import TYPE_CHECKING, Any
 
 from robot_sf.benchmark.aggregate import read_jsonl
 from robot_sf.benchmark.camera_ready._artifacts import _escape_markdown_cell
+from robot_sf.benchmark.camera_ready._config_types import _AMV_DIMENSIONS, PlannerSpec
 from robot_sf.benchmark.camera_ready._summaries import _extract_amv_taxonomy
-from robot_sf.benchmark.camera_ready_campaign_config import _AMV_DIMENSIONS, PlannerSpec
 from robot_sf.benchmark.fallback_policy import (
     classify_planner_row_status,
     summarize_benchmark_availability,

--- a/robot_sf/benchmark/camera_ready/_run_state.py
+++ b/robot_sf/benchmark/camera_ready/_run_state.py
@@ -27,7 +27,7 @@ from robot_sf.common.artifact_paths import get_repository_root
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
-    from robot_sf.benchmark.camera_ready_campaign_config import CampaignConfig
+    from robot_sf.benchmark.camera_ready._config_types import CampaignConfig
 
 
 def _campaign_success_counters(

--- a/robot_sf/benchmark/camera_ready/_summaries.py
+++ b/robot_sf/benchmark/camera_ready/_summaries.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from robot_sf.benchmark.camera_ready._config_types import _AMV_DIMENSIONS, CampaignConfig
 from robot_sf.benchmark.camera_ready._util import (
     _hash_payload,
     _jsonable_repo_relative,
@@ -15,7 +16,6 @@ from robot_sf.benchmark.camera_ready._util import (
     _repo_relative,
     _synthetic_actuation_metadata,
 )
-from robot_sf.benchmark.camera_ready_campaign_config import _AMV_DIMENSIONS, CampaignConfig
 from robot_sf.benchmark.observation_noise import (
     normalize_observation_noise_spec,
     observation_noise_hash,

--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -90,7 +90,7 @@ from robot_sf.common.artifact_paths import get_artifact_category_path, get_repos
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from robot_sf.benchmark.camera_ready_campaign_config import CampaignConfig
+    from robot_sf.benchmark.camera_ready._config_types import CampaignConfig
 
 CAMPAIGN_SCHEMA_VERSION = "benchmark-camera-ready-campaign.v1"
 DEFAULT_EPISODE_SCHEMA_PATH = Path("robot_sf/benchmark/schemas/episode.schema.v1.json")

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -54,6 +54,16 @@ from robot_sf.benchmark.camera_ready._config import (  # noqa: F401 - re-exporte
     _validate_scenario_amv_override_keys,
     load_campaign_config,
 )
+from robot_sf.benchmark.camera_ready._config_types import (  # noqa: F401 - re-exported for back-compat
+    _AMV_DIMENSIONS,
+    DEFAULT_SEED_SETS_PATH,
+    AmvProfileConfig,
+    CampaignConfig,
+    PlannerSpec,
+    ScenarioCandidateSelection,
+    SeedPolicy,
+    SnqiContractConfig,
+)
 from robot_sf.benchmark.camera_ready._preflight import (  # noqa: F401 - re-exported back-compat
     _build_preflight_preview_payload,
     _build_preflight_validate_payload,
@@ -134,16 +144,6 @@ from robot_sf.benchmark.camera_ready._util import (  # noqa: F401 - re-exported 
     _utc_now,
 )
 from robot_sf.benchmark.camera_ready.campaign import run_campaign as _run_campaign_impl
-from robot_sf.benchmark.camera_ready_campaign_config import (  # noqa: F401 - re-exported for back-compat
-    _AMV_DIMENSIONS,
-    DEFAULT_SEED_SETS_PATH,
-    AmvProfileConfig,
-    CampaignConfig,
-    PlannerSpec,
-    ScenarioCandidateSelection,
-    SeedPolicy,
-    SnqiContractConfig,
-)
 from robot_sf.benchmark.runner import run_batch
 from robot_sf.benchmark.utils import (  # noqa: F401 - re-exported for back-compat / test patch surface
     load_optional_json,

--- a/robot_sf/benchmark/camera_ready_campaign_config.py
+++ b/robot_sf/benchmark/camera_ready_campaign_config.py
@@ -1,135 +1,28 @@
-"""Config dataclasses for the camera-ready benchmark campaign.
+"""Backward-compatible config dataclass import surface.
 
-Extracted verbatim from ``robot_sf.benchmark.camera_ready_campaign`` (#3405, first
-slice of the #3385 decomposition). These are pure frozen configuration dataclasses
-plus the two constants their field defaults reference; ``camera_ready_campaign``
-re-exports them so existing import paths keep working.
-
-No behavior change: definitions are a verbatim move.
+The definitions now live in ``robot_sf.benchmark.camera_ready._config_types`` as
+part of the #3385 camera-ready package decomposition. Keep this module as a
+compatibility facade for callers that imported the earlier extraction module
+directly.
 """
 
-from __future__ import annotations
+from robot_sf.benchmark.camera_ready._config_types import (  # noqa: F401
+    _AMV_DIMENSIONS,
+    DEFAULT_SEED_SETS_PATH,
+    AmvProfileConfig,
+    CampaignConfig,
+    PlannerSpec,
+    ScenarioCandidateSelection,
+    SeedPolicy,
+    SnqiContractConfig,
+)
 
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from robot_sf.benchmark.latency_stress import LatencyStressProfile
-    from robot_sf.benchmark.synthetic_actuation import SyntheticActuationProfile
-
-DEFAULT_SEED_SETS_PATH = Path("configs/benchmarks/seed_sets_v1.yaml")
-_AMV_DIMENSIONS = ("use_case", "context", "speed_regime", "maneuver_type")
-
-
-@dataclass(frozen=True)
-class AmvProfileConfig:
-    """AMV paper-profile scope contract settings."""
-
-    name: str = "amv-paper-v1"
-    contract_version: str = "1"
-    coverage_enforcement: str = "warn"
-    required_dimensions: dict[str, tuple[str, ...]] = field(
-        default_factory=lambda: dict.fromkeys(_AMV_DIMENSIONS, ())
-    )
-
-
-@dataclass(frozen=True)
-class SeedPolicy:
-    """Seed selection policy for campaign scenarios."""
-
-    mode: str = "scenario-default"
-    seed_set: str | None = None
-    seeds: tuple[int, ...] = ()
-    seed_sets_path: Path = DEFAULT_SEED_SETS_PATH
-
-
-@dataclass(frozen=True)
-class ScenarioCandidateSelection:
-    """Optional named scenario subset for compact benchmark slices."""
-
-    names: tuple[str, ...] = ()
-    selection_name: str | None = None
-
-
-@dataclass(frozen=True)
-class PlannerSpec:
-    """One planner entry in a benchmark campaign matrix."""
-
-    key: str
-    algo: str
-    human_model_variant: str | None = None
-    human_model_source: str | None = None
-    benchmark_profile: str = "baseline-safe"
-    algo_config_path: Path | None = None
-    socnav_missing_prereq_policy: str = "fail-fast"
-    adapter_impact_eval: bool = False
-    observation_mode: str | None = None
-    workers_override: int | None = None
-    horizon_override: int | None = None
-    dt_override: float | None = None
-    enabled: bool = True
-    planner_group: str = "experimental"
-    planner_group_explicit: bool = False
-
-
-@dataclass(frozen=True)
-class SnqiContractConfig:
-    """SNQI paper-facing behavior contract configuration."""
-
-    enabled: bool = True
-    enforcement: str = "warn"
-    rank_alignment_warn_threshold: float = 0.5
-    rank_alignment_fail_threshold: float = 0.3
-    outcome_separation_warn_threshold: float = 0.05
-    outcome_separation_fail_threshold: float = 0.0
-    max_component_dominance_warn_threshold: float = 0.24
-    max_component_dominance_fail_threshold: float = 0.27
-    calibration_seed: int = 123
-    calibration_trials: int = 3000
-
-
-@dataclass(frozen=True)
-class CampaignConfig:
-    """Top-level camera-ready benchmark campaign config."""
-
-    name: str
-    scenario_matrix_path: Path
-    planners: tuple[PlannerSpec, ...]
-    scenario_candidates: ScenarioCandidateSelection = field(
-        default_factory=ScenarioCandidateSelection
-    )
-    scenario_amv_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
-    seed_policy: SeedPolicy = SeedPolicy()
-    scenario_horizons_path: Path | None = None
-    workers: int = 1
-    horizon: int | None = None
-    dt: float | None = None
-    record_forces: bool = True
-    resume: bool = True
-    bootstrap_samples: int = 400
-    bootstrap_confidence: float = 0.95
-    bootstrap_seed: int = 123
-    snqi_weights_path: Path | None = None
-    snqi_baseline_path: Path | None = None
-    stop_on_failure: bool = False
-    export_publication_bundle: bool = True
-    include_videos_in_publication: bool = False
-    overwrite_publication_bundle: bool = True
-    repository_url: str = "https://github.com/ll7/robot_sf_ll7"
-    release_tag: str = "{release_tag}"
-    doi: str = "10.5281/zenodo.<record-id>"
-    paper_interpretation_profile: str = "baseline-ready-core"
-    preview_scenario_limit: int = 100
-    kinematics_matrix: tuple[str, ...] = ("differential_drive",)
-    holonomic_command_mode: str = "vx_vy"
-    observation_mode: str | None = None
-    paper_facing: bool = False
-    paper_profile_version: str | None = None
-    amv_profile: AmvProfileConfig = field(default_factory=AmvProfileConfig)
-    synthetic_actuation_profile: SyntheticActuationProfile | None = None
-    latency_stress_profile: LatencyStressProfile | None = None
-    comparability_mapping_path: Path | None = None
-    snqi_contract: SnqiContractConfig = field(default_factory=SnqiContractConfig)
-    route_clearance_certifications_path: Path | None = None
-    observation_noise: dict[str, Any] | None = None
+__all__ = [
+    "DEFAULT_SEED_SETS_PATH",
+    "AmvProfileConfig",
+    "CampaignConfig",
+    "PlannerSpec",
+    "ScenarioCandidateSelection",
+    "SeedPolicy",
+    "SnqiContractConfig",
+]

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -17,8 +17,10 @@ from loguru import logger
 
 import robot_sf.benchmark.camera_ready._artifacts as camera_ready_artifacts_module
 import robot_sf.benchmark.camera_ready._config as camera_ready_config_module
+import robot_sf.benchmark.camera_ready._config_types as camera_ready_config_types_module
 import robot_sf.benchmark.camera_ready._run_state as camera_ready_run_state_module
 import robot_sf.benchmark.camera_ready_campaign as camera_ready_campaign_module
+import robot_sf.benchmark.camera_ready_campaign_config as camera_ready_campaign_config_module
 from robot_sf.benchmark.artifact_publication import PublicationBundleResult
 from robot_sf.benchmark.camera_ready._artifacts import (
     _write_csv,
@@ -103,6 +105,27 @@ def test_camera_ready_campaign_reexports_package_config_loader() -> None:
     for helper_name in helper_names:
         assert getattr(camera_ready_campaign_module, helper_name) is getattr(
             camera_ready_config_module, helper_name
+        )
+
+
+def test_camera_ready_config_types_keep_legacy_import_identity() -> None:
+    """Config dataclass extraction keeps legacy import paths object-identical."""
+    public_names = (
+        "DEFAULT_SEED_SETS_PATH",
+        "AmvProfileConfig",
+        "CampaignConfig",
+        "PlannerSpec",
+        "ScenarioCandidateSelection",
+        "SeedPolicy",
+        "SnqiContractConfig",
+    )
+
+    for name in public_names:
+        assert getattr(camera_ready_campaign_config_module, name) is getattr(
+            camera_ready_config_types_module, name
+        )
+        assert getattr(camera_ready_campaign_module, name) is getattr(
+            camera_ready_config_types_module, name
         )
 
 


### PR DESCRIPTION
## Reviewer-critical summary

What changed: extracted the camera-ready campaign configuration dataclasses/constants into `robot_sf.benchmark.camera_ready._config_types`; `robot_sf.benchmark.camera_ready_campaign_config` is now a backward-compatible re-export facade, and package internals import the package-local owner.

Why now: #3385 has already landed orchestration, config-loader, artifact, report, run-state, and preflight progression slices. This is the next reversible package-ownership slice: config type definitions now live under `robot_sf/benchmark/camera_ready/` without changing behavior.

Claim boundary: behavior-preserving refactor only. No campaign execution, evidence interpretation, output schemas, row ordering, hash material, artifact contents, planner behavior, or paper/dissertation claims changed.

Required validation: focused camera-ready campaign regression tests plus scoped Ruff on touched camera-ready paths. Final PR readiness wrapper also run with this body source.

Remaining blocker: #3385 can remain open for any further compatibility thinning or final cleanup the maintainer wants; this PR does not run a sample campaign or claim byte-identical generated artifacts.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3385

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: existing imports from `robot_sf.benchmark.camera_ready_campaign_config` and `robot_sf.benchmark.camera_ready_campaign` continue to resolve to the same config dataclass/constant objects. Added a focused identity regression test.
- New capability delivered: config-type ownership extraction into the `camera_ready` package, with the old module preserved as a compatibility facade.

## Scope summary

Refs #3385.

This PR moves the already-extracted config dataclass concern into the target `robot_sf/benchmark/camera_ready/` package. It intentionally does not migrate downstream callers beyond package internals, does not change config parsing/validation behavior, and does not alter campaign outputs.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/camera_ready_campaign.py robot_sf/benchmark/camera_ready_campaign_config.py robot_sf/benchmark/camera_ready tests/benchmark/test_camera_ready_campaign.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_camera_ready_campaign.py -q` - passed, 132 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_camera_ready_campaign.py::test_camera_ready_config_types_keep_legacy_import_identity -q` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3385/pr_body.md scripts/dev/pr_ready_check.sh` - passed via compact validation summary `/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/compact-validation/validation-20260704T041908Z-809756.summary.json`.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream propagation

No issue comment/state-table update from this agent: `comment_issue_or_pr` is not authorized for this task. The PR body records the delivered slice and residual scope.

<details>
<summary>Process notes</summary>

- Read the live issue thread, including owner comments, before implementation.
- Open PR dedupe found no active PR covering #3385 or this exact config-type extraction scope.
- Recent #3385 merged PRs in the last 24h are progression slices (#4213, #4309, #4355), not guardrail/checker-only PRs. This PR also delivers a nameable progression slice.
- Late issue-thread check rerun immediately before PR creation on 2026-07-04; newest maintainer comment remained 2026-07-04T01:55:33Z (#4355 merged config loader/validator extraction), with no newer guidance to incorporate.

</details>
