### PR TITLE
Issue #4366: close manuscript source-locator gaps

### DIFF
--- a/configs/validation/issue_4366_manuscript_asserted_numbers.yaml
+++ b/configs/validation/issue_4366_manuscript_asserted_numbers.yaml
@@ -2,13 +2,13 @@ schema_version: manuscript-asserted-number-declarations.v1
 issue: 4366
 claim_boundary: >-
   Verification aid for dissertation/manuscript asserted implementation numbers only. This file
-  does not edit manuscript claims, promote benchmark evidence, run campaigns, or silently fix source
-  values.
+  does not edit manuscript claims, promote benchmark evidence, run campaigns, or silently fix
+  source values.
 selection_assumption: >-
   The tracked issue thread names number families, but it does not include the dissertation-side
-  audit table. These ten declarations seed the most likely high-risk implementation-number
-  assertions from those named families. Ambiguous heatmap source records are explicitly marked
-  not_verifiable.
+  audit table. These ten declarations remain the reviewed top-10 seed from PR #4375 because each
+  row maps to one requested family and no live issue comment replaced the selection. Ambiguous
+  heatmap source records are explicitly marked not_verifiable.
 entries:
   - id: snqi_camera_ready_v3_w_success
     manuscript_locator: "audit finding F / SNQI weight vector / camera_ready_v3 / w_success"
@@ -54,6 +54,11 @@ entries:
     source:
       path: configs/scenarios/archetypes/classic_bottleneck.yaml
       pointer: scenarios[name=classic_bottleneck_high].simulation_config.ped_density
+    source_locator_status: resolved
+    source_locator_note: >-
+      The 0.0 value is the checked source field for the scenario row. It is a marker-placement
+      placeholder, not evidence that the high-density bottleneck scene has no pedestrians; see
+      configs/scenarios/archetypes/classic_density_tier_index.yaml#spawn_modes.markers.note.
 
   - id: ppo_br06_v3_total_timesteps
     manuscript_locator: "audit finding F / reinforcement learning training budget"
@@ -79,7 +84,17 @@ entries:
   - id: heatmap_per_family_means_source
     manuscript_locator: "audit finding F / heatmap per-family means"
     expected_status: not_verifiable
+    source_locator_status: not_verifiable
+    candidate_sources_reviewed:
+      - docs/benchmark_camera_ready.md#per-planner-per-family-archetype-metric-means
+      - docs/context/evidence/
+      - output/
     not_verifiable_reason: >-
-      The issue names heatmap per-family means but does not identify one canonical source-of-record
-      table or locator. This declaration records the gap instead of guessing among generated
-      evidence packets.
+      The issue names heatmap per-family means but does not identify one canonical
+      source-of-record table or locator. Repository search found documentation for
+      per-planner/per-family metric means and generated evidence/output locations, but no stable
+      reviewed declaration table for the manuscript heatmap values. This declaration records the
+      gap instead of guessing among generated evidence packets.
+    source_locator_note: >-
+      No manuscript value is treated as matched until a stable source table or explicit locator is
+      declared.

--- a/docs/context/evidence/issue_4366_manuscript_asserted_numbers_report.md
+++ b/docs/context/evidence/issue_4366_manuscript_asserted_numbers_report.md
@@ -7,7 +7,7 @@ Claim boundary: verification aid only. No manuscript edits, no claim changes, no
 
 Declarations: `configs/validation/issue_4366_manuscript_asserted_numbers.yaml`
 
-Selection assumption: The tracked issue thread names number families, but it does not include the dissertation-side audit table. These ten declarations seed the most likely high-risk implementation-number assertions from those named families. Ambiguous heatmap source records are explicitly marked not_verifiable.
+Selection assumption: The tracked issue thread names number families, but it does not include the dissertation-side audit table. These ten declarations remain the reviewed top-10 seed from PR #4375 because each row maps to one requested family and no live issue comment replaced the selection. Ambiguous heatmap source records are explicitly marked not_verifiable.
 
 ## Summary
 
@@ -19,17 +19,17 @@ Selection assumption: The tracked issue thread names number families, but it doe
 
 ## Results
 
-| id | status | manuscript locator | expected | actual | source | reason |
-| --- | --- | --- | --- | --- | --- | --- |
-| snqi_camera_ready_v3_w_success | `match` | audit finding F / SNQI weight vector / camera_ready_v3 / w_success | `0.19045845847432735` | `0.19045845847432735` | `configs/benchmarks/snqi_weights_camera_ready_v3.json#w_success` |  |
-| snqi_camera_ready_v3_w_near | `match` | audit finding F / SNQI weight vector / camera_ready_v3 / w_near | `0.30825830332144416` | `0.30825830332144416` | `configs/benchmarks/snqi_weights_camera_ready_v3.json#w_near` |  |
-| snqi_canonical_weight_set_id | `match` | audit finding F / SNQI canonical set identifier | `camera_ready_v3` | `camera_ready_v3` | `configs/benchmarks/snqi_weight_sets_camera_ready.yaml#canonical_set` |  |
-| scenario_density_tier_labels | `match` | audit finding F / scenario-catalog density tiers | `["low", "medium", "high"]` | `["low", "medium", "high"]` | `configs/scenarios/archetypes/classic_density_tier_index.yaml#density_tiers` |  |
-| classic_crossing_high_ped_density | `match` | audit finding F / scenario-catalog density / classic_crossing_high | `0.08` | `0.08` | `configs/scenarios/archetypes/classic_crossing.yaml#scenarios[name=classic_crossing_high].simulation_config.ped_density` |  |
-| classic_bottleneck_high_ped_density | `match` | audit finding F / scenario-catalog density / classic_bottleneck_high | `0.0` | `0.0` | `configs/scenarios/archetypes/classic_bottleneck.yaml#scenarios[name=classic_bottleneck_high].simulation_config.ped_density` |  |
-| ppo_br06_v3_total_timesteps | `match` | audit finding F / reinforcement learning training budget | `15000000` | `15000000` | `configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml#total_timesteps` |  |
-| ppo_br06_v3_grid_resolution_m | `match` | audit finding F / reinforcement learning observation grid resolution | `0.2` | `0.2` | `configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml#env_overrides.grid_config.resolution` |  |
-| ppo_br06_v3_max_peds_per_group | `match` | audit finding F / pedestrian-module group-size cap | `3` | `3` | `configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml#env_overrides.sim_config.max_peds_per_group` |  |
-| heatmap_per_family_means_source | `not_verifiable` | audit finding F / heatmap per-family means | `not_verifiable` |  |  | The issue names heatmap per-family means but does not identify one canonical source-of-record table or locator. This declaration records the gap instead of guessing among generated evidence packets. |
+| id | status | manuscript locator | expected | actual | source | locator review | reason |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| snqi_camera_ready_v3_w_success | `match` | audit finding F / SNQI weight vector / camera_ready_v3 / w_success | `0.19045845847432735` | `0.19045845847432735` | `configs/benchmarks/snqi_weights_camera_ready_v3.json#w_success` | match |  |
+| snqi_camera_ready_v3_w_near | `match` | audit finding F / SNQI weight vector / camera_ready_v3 / w_near | `0.30825830332144416` | `0.30825830332144416` | `configs/benchmarks/snqi_weights_camera_ready_v3.json#w_near` | match |  |
+| snqi_canonical_weight_set_id | `match` | audit finding F / SNQI canonical set identifier | `camera_ready_v3` | `camera_ready_v3` | `configs/benchmarks/snqi_weight_sets_camera_ready.yaml#canonical_set` | match |  |
+| scenario_density_tier_labels | `match` | audit finding F / scenario-catalog density tiers | `["low", "medium", "high"]` | `["low", "medium", "high"]` | `configs/scenarios/archetypes/classic_density_tier_index.yaml#density_tiers` | match |  |
+| classic_crossing_high_ped_density | `match` | audit finding F / scenario-catalog density / classic_crossing_high | `0.08` | `0.08` | `configs/scenarios/archetypes/classic_crossing.yaml#scenarios[name=classic_crossing_high].simulation_config.ped_density` | match |  |
+| classic_bottleneck_high_ped_density | `match` | audit finding F / scenario-catalog density / classic_bottleneck_high | `0.0` | `0.0` | `configs/scenarios/archetypes/classic_bottleneck.yaml#scenarios[name=classic_bottleneck_high].simulation_config.ped_density` | resolved: The 0.0 value is the checked source field for the scenario row. It is a marker-placement placeholder, not evidence that the high-density bottleneck scene has no pedestrians; see configs/scenarios/archetypes/classic_density_tier_index.yaml#spawn_modes.markers.note. |  |
+| ppo_br06_v3_total_timesteps | `match` | audit finding F / reinforcement learning training budget | `15000000` | `15000000` | `configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml#total_timesteps` | match |  |
+| ppo_br06_v3_grid_resolution_m | `match` | audit finding F / reinforcement learning observation grid resolution | `0.2` | `0.2` | `configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml#env_overrides.grid_config.resolution` | match |  |
+| ppo_br06_v3_max_peds_per_group | `match` | audit finding F / pedestrian-module group-size cap | `3` | `3` | `configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml#env_overrides.sim_config.max_peds_per_group` | match |  |
+| heatmap_per_family_means_source | `not_verifiable` | audit finding F / heatmap per-family means | `not_verifiable` |  |  | not_verifiable: No manuscript value is treated as matched until a stable source table or explicit locator is declared. Reviewed: `docs/benchmark_camera_ready.md#per-planner-per-family-archetype-metric-means`; `docs/context/evidence/`; `output/` | The issue names heatmap per-family means but does not identify one canonical source-of-record table or locator. Repository search found documentation for per-planner/per-family metric means and generated evidence/output locations, but no stable reviewed declaration table for the manuscript heatmap values. This declaration records the gap instead of guessing among generated evidence packets. |
 
 <!-- /AI-GENERATED -->

--- a/scripts/validation/verify_manuscript_asserted_numbers.py
+++ b/scripts/validation/verify_manuscript_asserted_numbers.py
@@ -41,6 +41,9 @@ class VerificationResult:
     source_path: str | None = None
     pointer: str | None = None
     reason: str | None = None
+    source_locator_status: str | None = None
+    source_locator_note: str | None = None
+    candidate_sources_reviewed: list[str] | None = None
 
 
 def _repo_root() -> Path:
@@ -123,6 +126,29 @@ def _values_equal(expected: Any, actual: Any, *, tolerance: float) -> bool:
     return expected == actual
 
 
+def _source_locator_fields(entry: dict[str, Any], entry_id: str) -> dict[str, Any]:
+    """Return optional source-locator review metadata for report rows."""
+    source_locator_status = entry.get("source_locator_status")
+    if source_locator_status is not None:
+        source_locator_status = str(source_locator_status)
+    source_locator_note = entry.get("source_locator_note")
+    if source_locator_note is not None:
+        source_locator_note = str(source_locator_note).strip() or None
+    candidate_sources_reviewed = entry.get("candidate_sources_reviewed")
+    if candidate_sources_reviewed is not None:
+        if not isinstance(candidate_sources_reviewed, list) or not all(
+            isinstance(candidate, str) for candidate in candidate_sources_reviewed
+        ):
+            raise VerificationError(
+                f"{entry_id}: candidate_sources_reviewed must be a list of strings"
+            )
+    return {
+        "source_locator_status": source_locator_status,
+        "source_locator_note": source_locator_note,
+        "candidate_sources_reviewed": candidate_sources_reviewed,
+    }
+
+
 def _verify_entry(
     entry: dict[str, Any], *, repo_root: Path, tolerance: float
 ) -> VerificationResult:
@@ -130,6 +156,8 @@ def _verify_entry(
     manuscript_locator = str(entry.get("manuscript_locator", ""))
     if not entry_id or not manuscript_locator:
         raise VerificationError("each entry requires id and manuscript_locator")
+
+    locator_fields = _source_locator_fields(entry, entry_id)
 
     expected_status = entry.get("expected_status", MATCH)
     if expected_status == NOT_VERIFIABLE:
@@ -142,6 +170,9 @@ def _verify_entry(
             manuscript_locator=manuscript_locator,
             expected=NOT_VERIFIABLE,
             reason=reason,
+            source_locator_status=locator_fields["source_locator_status"] or NOT_VERIFIABLE,
+            source_locator_note=locator_fields["source_locator_note"],
+            candidate_sources_reviewed=locator_fields["candidate_sources_reviewed"],
         )
     if expected_status != MATCH:
         raise VerificationError(f"{entry_id}: unsupported expected_status {expected_status!r}")
@@ -169,6 +200,9 @@ def _verify_entry(
         source_path=source_path,
         pointer=pointer,
         reason=reason,
+        source_locator_status=locator_fields["source_locator_status"] or MATCH,
+        source_locator_note=locator_fields["source_locator_note"],
+        candidate_sources_reviewed=locator_fields["candidate_sources_reviewed"],
     )
 
 
@@ -238,23 +272,32 @@ def write_markdown_report(report: dict[str, Any], path: Path) -> None:
         "",
         "## Results",
         "",
-        "| id | status | manuscript locator | expected | actual | source | reason |",
-        "| --- | --- | --- | --- | --- | --- | --- |",
+        "| id | status | manuscript locator | expected | actual | source | locator review | reason |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
     ]
     for result in report["results"]:
         source = ""
         if result.get("source_path"):
             source = f"`{result['source_path']}#{result['pointer']}`"
         reason = result.get("reason") or ""
+        locator_review = result.get("source_locator_status") or ""
+        if result.get("source_locator_note"):
+            locator_review = f"{locator_review}: {result['source_locator_note']}"
+        if result.get("candidate_sources_reviewed"):
+            candidates = "; ".join(
+                f"`{candidate}`" for candidate in result["candidate_sources_reviewed"]
+            )
+            locator_review = f"{locator_review} Reviewed: {candidates}".strip()
         actual = "" if result.get("actual") is None else _format_value(result["actual"])
         lines.append(
-            "| {id} | `{status}` | {locator} | {expected} | {actual} | {source} | {reason} |".format(
+            "| {id} | `{status}` | {locator} | {expected} | {actual} | {source} | {locator_review} | {reason} |".format(
                 id=result["id"],
                 status=result["status"],
                 locator=_escape_table_cell(str(result["manuscript_locator"])),
                 expected=_escape_table_cell(_format_value(result["expected"])),
                 actual=_escape_table_cell(actual),
                 source=_escape_table_cell(source),
+                locator_review=_escape_table_cell(str(locator_review)),
                 reason=_escape_table_cell(str(reason)),
             )
         )

--- a/tests/validation/test_verify_manuscript_asserted_numbers.py
+++ b/tests/validation/test_verify_manuscript_asserted_numbers.py
@@ -51,9 +51,16 @@ def test_checked_in_declarations_verify_and_report(tmp_path: Path) -> None:
     assert "AI-GENERATED" in text
     assert "heatmap_per_family_means_source" in text
     assert "`not_verifiable`" in text
+    assert "marker-placement placeholder" in text
+    assert "No manuscript value is treated as matched" in text
+    heatmap = next(
+        result for result in report["results"] if result["id"] == "heatmap_per_family_means_source"
+    )
+    assert heatmap["source_locator_status"] == "not_verifiable"
+    assert "docs/context/evidence/" in heatmap["candidate_sources_reviewed"]
     result_rows = [line for line in text.splitlines() if line.startswith("| ")][2:]
     assert len(result_rows) == 10
-    assert all(line.count("|") == 8 for line in result_rows)
+    assert all(line.count("|") == 9 for line in result_rows)
 
 
 def test_mismatch_returns_failure_without_silent_source_fix(tmp_path: Path) -> None:


### PR DESCRIPTION
## Reviewer-critical summary
What changed: this PR keeps the ten PR #4375 manuscript-number declarations, adds explicit source-locator review metadata to the verifier schema/report, resolves the `classic_bottleneck_high` `ped_density: 0.0` locator caveat as a marker-placement placeholder, and documents the heatmap per-family-means source-locator gap as still `not_verifiable`.

Why now: issue #4366 remained open after PR #4375 because reviewer-visible declaration-selection and source-locator gaps needed closure.

Claim boundary: verification aid only. This PR edits no manuscript/dissertation claims, changes no benchmark values, runs no campaigns, and does not treat the heatmap row as matched.

Required validation: focused verifier tests plus the manuscript-number verification command; no Slurm/GPU/full benchmark campaign.

Remaining blocker: heatmap per-family means still lack a stable source-of-record table or explicit locator, so the row stays fail-closed as `not_verifiable`.

## Contract delta
New declaration/report fields: optional `source_locator_status`, `source_locator_note`, and `candidate_sources_reviewed` are accepted by `scripts/validation/verify_manuscript_asserted_numbers.py` and surfaced in the generated Markdown report.

New fail-closed blockers: none. The existing heatmap row remains `not_verifiable` until a stable source table or explicit locator is declared.

Compatibility impact: existing declarations without the new optional fields continue to verify; report output adds a `locator review` column.

## Linked Issues
- Relates `#4366`

## Scope Summary
- Reviewed the top-10 declaration selection from PR #4375 against the live issue thread; no newer maintainer comment replaced the selection.
- Added locator-review metadata for `classic_bottleneck_high_ped_density` explaining that source `0.0` is a marker-placement placeholder, not an empty-scene claim.
- Added reviewed candidate locations for `heatmap_per_family_means_source` and regenerated the committed AI-GENERATED report with 9 matches, 0 mismatches, 1 not-verifiable.

## Validation / Proof
- `uv run ruff check scripts/validation/verify_manuscript_asserted_numbers.py tests/validation/test_verify_manuscript_asserted_numbers.py` -> pass.
- `uv run ruff format --check scripts/validation/verify_manuscript_asserted_numbers.py tests/validation/test_verify_manuscript_asserted_numbers.py` -> pass.
- `uv run python scripts/validation/verify_manuscript_asserted_numbers.py --declarations configs/validation/issue_4366_manuscript_asserted_numbers.yaml --report docs/context/evidence/issue_4366_manuscript_asserted_numbers_report.md --json-output output/validation/issue_4366_report.json` -> `verified 10 declarations: 9 match, 0 mismatch, 1 not_verifiable`.
- `uv run pytest tests/validation/test_verify_manuscript_asserted_numbers.py -q` -> 3 passed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` was attempted after `uv sync --all-extras`; first blocked on missing extras, then blocked on missing PR body before this body artifact existed. The focused validation above is the intended issue validation floor.

## Explicit Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No benchmark value changes or new manuscript assertions.
- No unverifiable value is treated as a match.

<details>
<summary>Governance appendix</summary>

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: close issue #4366 reviewer-visible verifier/report source-locator gaps.
- Comparator or baseline, applicable: PR #4375 verifier/report state.
- Evidence tier: targeted verifier proof.
- Result classification: blocker-resolution for source-locator reporting, with heatmap intentionally still not-verifiable.
- Decision stop rule, applicable: report preserves 9 match / 0 mismatch / 1 not-verifiable and surfaces locator status for reviewer audit.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #4366 via this PR body/report.
- New research/benchmark/metric/paper-facing analysis tool, any: no new analysis tool; small verifier metadata/report extension only.

## Domain-Aware Approval
- Required for this PR: yes, waiver requested for verifier-report metadata closure.
- Domains reviewed: verifier declarations, source-locator provenance, fail-closed not-verifiable reporting.
- Status: waived.
- Approval concerns experimental validity: not required.
- Approver/review source or waiver: issue #4366 scope is verifier/report closure only; no benchmark values, manuscript claims, or paper-facing interpretation change.
- Validity checklist: targeted verifier command and focused tests only.
- Target claim/hypothesis: source-locator reporting for issue #4366 verifier declarations.
- Comparator or split/evidence validity: baseline is PR #4375 checked-in declarations and report; no empirical benchmark comparison is made.
- Fallback/degraded exclusions: heatmap source gap remains not_verifiable, not a fallback success.
- Claim boundary: no manuscript edits, no claim changes, no full benchmark campaign, no Slurm/GPU submission.
- Implementation integrity vs experimental validity: implementation only surfaces locator metadata and preserves fail-closed verifier behavior; experimental validity is intentionally not claimed.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - verifier/report metadata closure only.
- Result route: continue - issue can now review the remaining heatmap locator blocker explicitly.

## Next Empirical Action
- Rerun needed: no campaign rerun for this PR.
- Artifact missing unavailable: stable heatmap per-family-means source table or explicit manuscript locator.
- Stop / revise / continue decision: continue only after that source table/locator exists.

## Risks / Rollout
- Compatibility risks: low; new declaration fields are optional.
- Failure modes: candidate source list could be incomplete; fail-closed status avoids false match.
- Rollback fallback plan: revert this PR to restore PR #4375 verifier behavior.

## Docs / Provenance
- Updated docs: regenerated `docs/context/evidence/issue_4366_manuscript_asserted_numbers_report.md`.
- Relevant design provenance notes: issue #4366 and PR #4375.
- Assumptions preserved: the PR #4375 ten-row selection is retained because live issue comments did not replace it.

## Downstream Propagation
- Parent issue updated: no, because this run is not authorized to comment on issues/PRs; PR body carries compact status.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no.
- Not applicable because: this is a verifier/report closure slice, not a benchmark or claim-map update.

## Follow-Up Issues
- Deferred work: tracked by #4366; declare or produce a stable source-of-record locator for manuscript heatmap per-family means if those values must be verified.
- Issues opened follow-up: none; #4366 remains open and already tracks the remaining heatmap locator gap.

## Reviewer Notes
- Verify closely: the `classic_bottleneck_high` row remains a match to `ped_density: 0.0`, with the locator note clarifying marker-placement semantics.
- Known limitations: heatmap per-family means remain not-verifiable.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer verification details for manuscript-number checks, including source locator review information in the report.
  * Expanded the report table with an additional column for locator review notes.

* **Bug Fixes**
  * Clarified how ambiguous heatmap-related records are labeled when they can’t be verified.
  * Improved explanation text for specific declaration outcomes, including placeholder values and review status.

* **Tests**
  * Strengthened validation of the generated report to confirm the new column and updated verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->