### PR TITLE
Issue #3574: add mean-matched heterogeneity harness manifest

### DIFF
--- a/configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml
+++ b/configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml
@@ -1,0 +1,32 @@
+schema_version: mean_matched_heterogeneity_harness.config.v1
+issue: 3574
+claim_boundary: harness_only_no_ablation_result
+trace_metric_keys:
+  - clearance_m
+planners:
+  - key: goal
+    algo: goal
+  - key: social_force
+    algo: social_force
+seeds:
+  - 101
+  - 102
+scenarios:
+  - id: issue_3574_classic_crossing_density_002
+    density: 0.02
+    population_size: 12
+    archetype_seed: 3574
+    composition:
+      cautious: 0.25
+      standard: 0.5
+      hurried: 0.25
+    archetypes:
+      cautious:
+        desired_speed_factor: 0.7
+        radius_m: 0.35
+      standard:
+        desired_speed_factor: 1.0
+        radius_m: 0.3
+      hurried:
+        desired_speed_factor: 1.4
+        radius_m: 0.25

--- a/docs/context/issue_3574_mean_matched_harness.md
+++ b/docs/context/issue_3574_mean_matched_harness.md
@@ -1,0 +1,26 @@
+# Issue #3574 Mean-Matched Harness
+
+This note records the dry-run harness added for issue #3574: it builds paired
+heterogeneous and homogeneous mean-matched rows before any benchmark campaign runs.
+
+## Claim Boundary
+
+- Evidence status: `diagnostic-only`.
+- The manifest is a pre-run contract, not a heterogeneous-population effect result.
+- It attributes future rows by scenario, seed, planner, density, and population arm.
+- It records the expected `pedestrian_control_trace` fields needed by the existing
+  per-archetype metric primitives.
+- It does not run a full ablation campaign, response-law mixture sweep, rank-order
+  sensitivity analysis, Slurm job, or paper/dissertation claim update.
+
+## Entrypoint
+
+```bash
+uv run python scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py \
+  --config configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml \
+  --output output/issue_3574_mean_matched_harness/manifest.json
+```
+
+The output uses schema `mean_matched_heterogeneity_harness.v1`. Missing episode
+trace inputs are fail-closed blockers until a future run supplies stable
+per-pedestrian archetype labels and per-step metric values.

--- a/robot_sf/benchmark/heterogeneous_population_ablation.py
+++ b/robot_sf/benchmark/heterogeneous_population_ablation.py
@@ -7,10 +7,10 @@ per-archetype metric breakdowns when per-pedestrian control traces are present.
 It does not run benchmark campaigns or promote heterogeneous-population claims.
 """
 
-from __future__ import annotations
-
+import hashlib
+import json
 import math
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -21,6 +21,7 @@ from robot_sf.benchmark.heterogeneous_population_metrics import (
 from robot_sf.ped_npc.ped_archetypes import allocate_archetype_counts, assign_archetype_labels
 
 HETEROGENEOUS_POPULATION_ABLATION_SCHEMA = "heterogeneous_population_ablation_harness.v1"
+MEAN_MATCHED_HETEROGENEITY_HARNESS_SCHEMA = "mean_matched_heterogeneity_harness.v1"
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,6 +185,67 @@ def build_per_archetype_ablation_report(
     }
 
 
+def build_mean_matched_harness_manifest(
+    config: Mapping[str, Any],
+    *,
+    config_path: str | None = None,
+) -> dict[str, Any]:
+    """Build a dry-run manifest for paired heterogeneous mean-matched runs.
+
+    The manifest is a pre-run contract. It proves that future rows are attributable by
+    scenario, seed, planner, density, and population arm, while keeping missing episode
+    control traces explicit until a benchmark run supplies them.
+
+    Returns:
+        Versioned manifest payload with paired rows and trace-readiness diagnostics.
+    """
+
+    scenarios = _required_sequence(config, "scenarios")
+    planner_rows = _planner_rows(_required_sequence(config, "planners"))
+    seed_rows = _seed_rows(_required_sequence(config, "seeds"))
+    metric_keys = _metric_keys(config.get("trace_metric_keys", ("clearance_m",)))
+
+    scenario_rows: list[dict[str, Any]] = []
+    manifest_rows: list[dict[str, Any]] = []
+    blockers: list[str] = []
+
+    for scenario_index, scenario in enumerate(scenarios):
+        if not isinstance(scenario, Mapping):
+            raise ValueError(f"scenarios[{scenario_index}] must be mapping")
+        scenario_row, scenario_manifest_rows, scenario_blockers = _manifest_scenario_rows(
+            scenario,
+            scenario_index=scenario_index,
+            planner_rows=planner_rows,
+            seed_rows=seed_rows,
+            metric_keys=metric_keys,
+        )
+        scenario_rows.append(scenario_row)
+        manifest_rows.extend(scenario_manifest_rows)
+        blockers.extend(scenario_blockers)
+
+    status = "ready" if not blockers else "blocked_pending_control_trace"
+    return {
+        "schema_version": MEAN_MATCHED_HETEROGENEITY_HARNESS_SCHEMA,
+        "issue": 3574,
+        "status": status,
+        "claim_boundary": "harness_only_no_ablation_result",
+        "config_path": config_path,
+        "paired_arms": ["heterogeneous", "mean_matched_homogeneous"],
+        "scenario_rows": scenario_rows,
+        "planner_rows": planner_rows,
+        "seed_rows": seed_rows,
+        "trace_metric_keys": metric_keys,
+        "expected_episode_output_keys": [
+            "metadata.pedestrian_control_trace",
+            "metadata.pedestrian_control_trace.pedestrians[].archetype",
+            "metadata.pedestrian_control_trace.pedestrians[].steps[]",
+        ],
+        "manifest_rows": manifest_rows,
+        "row_count": len(manifest_rows),
+        "blockers": blockers,
+    }
+
+
 def audit_smoke_mean_match(
     smoke_report: Mapping[str, Any],
     *,
@@ -299,6 +361,238 @@ def _smoke_conditions(smoke_report: Mapping[str, Any]) -> Mapping[str, Any]:
     return condition_payloads
 
 
+def _manifest_scenario_rows(
+    scenario: Mapping[str, Any],
+    *,
+    scenario_index: int,
+    planner_rows: Sequence[Mapping[str, Any]],
+    seed_rows: Sequence[Mapping[str, Any]],
+    metric_keys: Sequence[str],
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    scenario_id = _required_str(scenario, "id", context=f"scenarios[{scenario_index}]")
+    density = _required_float(scenario, "density", context=f"scenarios[{scenario_index}]")
+    if density < 0.0:
+        raise ValueError(f"scenarios[{scenario_index}].density must be >= 0")
+    population_size = _required_int(
+        scenario, "population_size", context=f"scenarios[{scenario_index}]"
+    )
+    composition = _normalize_composition(_required_mapping(scenario, "composition"))
+    archetypes = _required_mapping(scenario, "archetypes")
+    pair = build_mean_matched_population_pair(
+        population_size=population_size,
+        composition=composition,
+        archetypes=archetypes,
+        seed=scenario.get("archetype_seed"),
+    )
+    composition_hash = _stable_hash(
+        {
+            "population_size": population_size,
+            "composition": pair["arms"]["heterogeneous"]["composition"],
+            "mean_matched_parameters": pair["mean_matched_parameters"],
+        }
+    )
+    trace_readiness_by_arm, blockers = _trace_readiness_by_arm(
+        scenario,
+        scenario_id=scenario_id,
+        metric_keys=metric_keys,
+    )
+
+    scenario_row = {
+        "scenario_id": scenario_id,
+        "density": density,
+        "population_size": population_size,
+        "population_composition_hash": composition_hash,
+        "heterogeneous_counts": pair["arms"]["heterogeneous"]["counts"],
+        "mean_matched_parameters": pair["mean_matched_parameters"],
+        "trace_readiness_by_arm": trace_readiness_by_arm,
+    }
+
+    manifest_rows: list[dict[str, Any]] = []
+    for planner in planner_rows:
+        for seed in seed_rows:
+            for arm in ("heterogeneous", "mean_matched_homogeneous"):
+                manifest_rows.append(
+                    {
+                        "scenario_id": scenario_id,
+                        "planner": planner["key"],
+                        "seed": seed["seed"],
+                        "density": density,
+                        "population_arm": arm,
+                        "paired_arm": (
+                            "mean_matched_homogeneous"
+                            if arm == "heterogeneous"
+                            else "heterogeneous"
+                        ),
+                        "population_composition_hash": composition_hash,
+                        "expected_episode_output_keys": [
+                            "metadata.pedestrian_control_trace",
+                            "metadata.pedestrian_control_trace.pedestrians[].archetype",
+                            *[
+                                "metadata.pedestrian_control_trace.pedestrians[]."
+                                f"steps[].{metric_key}"
+                                for metric_key in metric_keys
+                            ],
+                        ],
+                        "trace_readiness": trace_readiness_by_arm[arm],
+                        "arm_population": pair["arms"][arm],
+                    }
+                )
+
+    return scenario_row, manifest_rows, blockers
+
+
+def _trace_readiness_by_arm(
+    scenario: Mapping[str, Any],
+    *,
+    scenario_id: str,
+    metric_keys: Sequence[str],
+) -> tuple[dict[str, Any], list[str]]:
+    traces = scenario.get("control_traces")
+    if traces is not None and not isinstance(traces, Mapping):
+        raise ValueError("scenario.control_traces must be mapping when provided")
+
+    readiness_by_arm: dict[str, Any] = {}
+    blockers: list[str] = []
+    for arm in ("heterogeneous", "mean_matched_homogeneous"):
+        trace = traces.get(arm) if isinstance(traces, Mapping) else None
+        if trace is None:
+            readiness = {
+                "schema_version": HETEROGENEOUS_POPULATION_ABLATION_SCHEMA,
+                "source": "pedestrian_control_trace",
+                "status": "blocked",
+                "ready": False,
+                "metric_keys": list(metric_keys),
+                "blockers": [
+                    "metadata.pedestrian_control_trace missing",
+                    *[
+                        "metadata.pedestrian_control_trace.pedestrians[]."
+                        f"steps[].{metric_key} missing"
+                        for metric_key in metric_keys
+                    ],
+                ],
+            }
+        else:
+            readiness = {
+                "schema_version": HETEROGENEOUS_POPULATION_ABLATION_SCHEMA,
+                "source": "pedestrian_control_trace",
+                "status": "ready",
+                "ready": True,
+                "metric_keys": list(metric_keys),
+                "metrics": {
+                    metric_key: assess_control_trace_readiness(trace, metric_key).to_dict()
+                    for metric_key in metric_keys
+                },
+            }
+            metric_blockers = [
+                blocker
+                for metric_readiness in readiness["metrics"].values()
+                for blocker in metric_readiness["blockers"]
+            ]
+            if metric_blockers:
+                readiness["status"] = "blocked"
+                readiness["ready"] = False
+                readiness["blockers"] = metric_blockers
+
+        readiness_by_arm[arm] = readiness
+        if not readiness["ready"]:
+            blockers.extend(f"{scenario_id}/{arm}: {blocker}" for blocker in readiness["blockers"])
+
+    return readiness_by_arm, blockers
+
+
+def _planner_rows(planners: Sequence[Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for index, planner in enumerate(planners):
+        if isinstance(planner, str):
+            key = planner.strip()
+            payload: dict[str, Any] = {"key": key}
+        elif isinstance(planner, Mapping):
+            key = _required_str(planner, "key", context=f"planners[{index}]")
+            payload = {"key": key}
+            if planner.get("algo") is not None:
+                payload["algo"] = str(planner["algo"])
+        else:
+            raise ValueError(f"planners[{index}] must be string or mapping")
+        if not key:
+            raise ValueError(f"planners[{index}].key must be non-empty")
+        rows.append(payload)
+    return rows
+
+
+def _seed_rows(seeds: Sequence[Any]) -> list[dict[str, int]]:
+    rows: list[dict[str, int]] = []
+    for index, seed in enumerate(seeds):
+        if isinstance(seed, bool):
+            raise ValueError(f"seeds[{index}] must be integer")
+        try:
+            rows.append({"seed": int(seed)})
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"seeds[{index}] must be integer") from exc
+    return rows
+
+
+def _metric_keys(raw_metric_keys: Any) -> list[str]:
+    if not isinstance(raw_metric_keys, Sequence) or isinstance(raw_metric_keys, str):
+        raise ValueError("trace_metric_keys must be sequence")
+    metric_keys = [str(metric_key).strip() for metric_key in raw_metric_keys]
+    if not metric_keys or any(not metric_key for metric_key in metric_keys):
+        raise ValueError("trace_metric_keys must contain non-empty metric keys")
+    return metric_keys
+
+
+def _required_sequence(config: Mapping[str, Any], key: str) -> Sequence[Any]:
+    value = config.get(key)
+    if not isinstance(value, Sequence) or isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be non-empty sequence")
+    return value
+
+
+def _required_mapping(config: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    value = config.get(key)
+    if not isinstance(value, Mapping) or not value:
+        raise ValueError(f"{key} must be non-empty mapping")
+    return value
+
+
+def _required_str(config: Mapping[str, Any], key: str, *, context: str) -> str:
+    value = config.get(key)
+    text = "" if value is None else str(value).strip()
+    if not text:
+        raise ValueError(f"{context}.{key} must be non-empty")
+    return text
+
+
+def _required_float(config: Mapping[str, Any], key: str, *, context: str) -> float:
+    try:
+        value = float(config[key])
+    except KeyError as exc:
+        raise ValueError(f"{context}.{key} missing") from exc
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{context}.{key} must be numeric") from exc
+    if not math.isfinite(value):
+        raise ValueError(f"{context}.{key} must be finite")
+    return value
+
+
+def _required_int(config: Mapping[str, Any], key: str, *, context: str) -> int:
+    if isinstance(config.get(key), bool):
+        raise ValueError(f"{context}.{key} must be integer")
+    try:
+        value = int(config[key])
+    except KeyError as exc:
+        raise ValueError(f"{context}.{key} missing") from exc
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{context}.{key} must be integer") from exc
+    if value <= 0:
+        raise ValueError(f"{context}.{key} must be positive")
+    return value
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
 def _normalize_composition(composition: Mapping[str, float]) -> dict[str, float]:
     if not composition:
         raise ValueError("composition must be non-empty")
@@ -380,8 +674,10 @@ def _population_record(
 
 __all__ = [
     "HETEROGENEOUS_POPULATION_ABLATION_SCHEMA",
+    "MEAN_MATCHED_HETEROGENEITY_HARNESS_SCHEMA",
     "ArchetypePopulationSpec",
     "audit_smoke_mean_match",
+    "build_mean_matched_harness_manifest",
     "build_mean_matched_population_pair",
     "build_per_archetype_ablation_report",
 ]

--- a/scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py
+++ b/scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Build the issue #3574 mean-matched heterogeneity dry-run manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.heterogeneous_population_ablation import (
+    build_mean_matched_harness_manifest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default="configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml",
+        help="Tracked issue #3574 dry-run harness config.",
+    )
+    parser.add_argument(
+        "--output",
+        default="output/issue_3574_mean_matched_harness/manifest.json",
+        help="Manifest JSON output path.",
+    )
+    return parser.parse_args()
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return payload
+
+
+def _display_path(path: Path) -> Path:
+    try:
+        return path.relative_to(REPO_ROOT)
+    except ValueError:
+        return path
+
+
+def main() -> int:
+    """Build and write the manifest."""
+
+    args = parse_args()
+    config_path = REPO_ROOT / args.config
+    output_path = REPO_ROOT / args.output
+    manifest = build_mean_matched_harness_manifest(
+        _load_yaml(config_path),
+        config_path=args.config,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    print(f"wrote issue #3574 mean-matched heterogeneity manifest: {_display_path(output_path)}")
+    print(f"status: {manifest['status']}; rows: {manifest['row_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_heterogeneous_population_ablation.py
+++ b/tests/benchmark/test_heterogeneous_population_ablation.py
@@ -9,8 +9,10 @@ import pytest
 
 from robot_sf.benchmark.heterogeneous_population_ablation import (
     HETEROGENEOUS_POPULATION_ABLATION_SCHEMA,
+    MEAN_MATCHED_HETEROGENEITY_HARNESS_SCHEMA,
     ArchetypePopulationSpec,
     audit_smoke_mean_match,
+    build_mean_matched_harness_manifest,
     build_mean_matched_population_pair,
     build_per_archetype_ablation_report,
 )
@@ -186,4 +188,140 @@ def test_issue_3206_three_seed_smoke_audits_as_mean_matched_but_not_per_archetyp
     assert (
         detailed_report["per_archetype_distributional_status"]
         == "not_computable_from_current_smoke"
+    )
+
+
+def _manifest_config() -> dict[str, object]:
+    return {
+        "trace_metric_keys": ["clearance_m"],
+        "planners": [{"key": "goal", "algo": "goal"}, {"key": "social_force"}],
+        "seeds": [101, 102],
+        "scenarios": [
+            {
+                "id": "classic_density_002",
+                "density": 0.02,
+                "population_size": 4,
+                "archetype_seed": 3574,
+                "composition": {"cautious": 0.25, "standard": 0.5, "hurried": 0.25},
+                "archetypes": {
+                    "cautious": {"desired_speed_factor": 0.7, "radius_m": 0.35},
+                    "standard": {"desired_speed_factor": 1.0, "radius_m": 0.3},
+                    "hurried": {"desired_speed_factor": 1.4, "radius_m": 0.25},
+                },
+            }
+        ],
+    }
+
+
+def test_mean_matched_harness_manifest_attributes_rows_by_pairing_keys() -> None:
+    """Dry-run rows are attributable by scenario, seed, planner, density, and arm."""
+
+    manifest = build_mean_matched_harness_manifest(_manifest_config(), config_path="smoke.yaml")
+
+    assert manifest["schema_version"] == MEAN_MATCHED_HETEROGENEITY_HARNESS_SCHEMA
+    assert manifest["issue"] == 3574
+    assert manifest["claim_boundary"] == "harness_only_no_ablation_result"
+    assert manifest["paired_arms"] == ["heterogeneous", "mean_matched_homogeneous"]
+    assert manifest["row_count"] == 8
+    rows = manifest["manifest_rows"]
+    row_keys = {
+        (row["scenario_id"], row["planner"], row["seed"], row["density"], row["population_arm"])
+        for row in rows
+    }
+    assert ("classic_density_002", "goal", 101, 0.02, "heterogeneous") in row_keys
+    assert ("classic_density_002", "goal", 101, 0.02, "mean_matched_homogeneous") in row_keys
+    assert {row["population_composition_hash"] for row in rows} == {
+        manifest["scenario_rows"][0]["population_composition_hash"]
+    }
+    assert {
+        row["arm_population"]["counts"]["mean_matched_homogeneous"]
+        for row in rows
+        if row["population_arm"] == "mean_matched_homogeneous"
+    } == {4}
+    assert manifest["scenario_rows"][0]["mean_matched_parameters"][
+        "desired_speed_factor"
+    ] == pytest.approx(1.025)
+
+
+def test_mean_matched_harness_manifest_fails_closed_on_missing_control_trace_inputs() -> None:
+    """Pre-run manifests name the exact trace fields future metrics require."""
+
+    manifest = build_mean_matched_harness_manifest(_manifest_config())
+
+    assert manifest["status"] == "blocked_pending_control_trace"
+    assert any(
+        "metadata.pedestrian_control_trace missing" in blocker for blocker in manifest["blockers"]
+    )
+    assert any("steps[].clearance_m missing" in blocker for blocker in manifest["blockers"])
+    first_row = manifest["manifest_rows"][0]
+    assert first_row["trace_readiness"]["ready"] is False
+    assert (
+        "metadata.pedestrian_control_trace.pedestrians[].steps[].clearance_m"
+        in first_row["expected_episode_output_keys"]
+    )
+
+
+def test_mean_matched_harness_manifest_accepts_fixture_control_traces() -> None:
+    """Fixture-only dry-run proves bridge to existing trace-readiness primitive."""
+
+    config = _manifest_config()
+    scenario = config["scenarios"][0]
+    assert isinstance(scenario, dict)
+    scenario["control_traces"] = {
+        "heterogeneous": _control_trace(),
+        "mean_matched_homogeneous": _control_trace(),
+    }
+
+    manifest = build_mean_matched_harness_manifest(config)
+
+    assert manifest["status"] == "ready"
+    assert manifest["blockers"] == []
+    readiness = manifest["scenario_rows"][0]["trace_readiness_by_arm"]["heterogeneous"]
+    assert readiness["metrics"]["clearance_m"]["status"] == "ready"
+    assert readiness["metrics"]["clearance_m"]["archetype_counts"] == {
+        "cautious": 1,
+        "hurried": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    ("patch", "match"),
+    [
+        ({"trace_metric_keys": "clearance_m"}, "trace_metric_keys must be sequence"),
+        ({"seeds": [True]}, "seeds"),
+        ({"planners": [object()]}, "planners\\[0\\] must be string or mapping"),
+    ],
+)
+def test_mean_matched_harness_manifest_rejects_malformed_config(
+    patch: dict[str, object],
+    match: str,
+) -> None:
+    """Malformed dry-run configs fail before producing ambiguous row contracts."""
+
+    config = _manifest_config()
+    config.update(patch)
+
+    with pytest.raises(ValueError, match=match):
+        build_mean_matched_harness_manifest(config)
+
+
+def test_mean_matched_harness_manifest_reports_bad_fixture_trace_metric() -> None:
+    """Trace fixtures with missing metric fields stay blocked with field-level detail."""
+
+    config = _manifest_config()
+    scenario = config["scenarios"][0]
+    assert isinstance(scenario, dict)
+    scenario["control_traces"] = {
+        "heterogeneous": {
+            "pedestrians": [{"id": "ped_cautious", "archetype": "cautious", "steps": [{}]}]
+        },
+        "mean_matched_homogeneous": _control_trace(),
+    }
+
+    manifest = build_mean_matched_harness_manifest(config)
+
+    assert manifest["status"] == "blocked_pending_control_trace"
+    assert any(
+        "control_trace.pedestrians[0].steps[0] missing 'clearance_m'" in blocker
+        for blocker in manifest["blockers"]
     )


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Adds a versioned `mean_matched_heterogeneity_harness.v1` dry-run manifest path for issue #3574 on top of the existing `heterogeneous_population_ablation.py` owner. The new CLI emits paired heterogeneous / mean-matched-homogeneous rows attributable by scenario, seed, planner, density, population arm, and population-composition hash.

Why now: The issue thread's latest maintainer plan narrowed this slice to harness/config/reporting only: construct future paired rows, reuse existing per-archetype metric primitives, and fail closed when per-pedestrian control traces are not yet present.

Claim boundary: `harness_only_no_ablation_result` / diagnostic-only. This PR does not report a heterogeneous-population effect, planner rank order, realism claim, or paper/dissertation claim.

Required validation: focused harness/metric/control-trace tests, dry-run manifest CLI, lint/format, and full `pr_ready_check` with optional predictive lane after `uv sync --all-extras`.

Remaining blocker: real benchmark episodes still need to supply stable `metadata.pedestrian_control_trace` rows with per-pedestrian archetype labels and requested per-step metrics before per-archetype effect analysis can be claimed.

## Contract delta

- New schema: `mean_matched_heterogeneity_harness.v1`.
- New tracked smoke config: `configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml`.
- New CLI: `scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py`.
- Manifest rows now carry `scenario_id`, `planner`, `seed`, `density`, `population_arm`, `paired_arm`, `population_composition_hash`, expected episode output keys, trace-readiness diagnostics, and arm population records.
- New fail-closed blockers: missing `metadata.pedestrian_control_trace` and missing `metadata.pedestrian_control_trace.pedestrians[].steps[].<metric>` are explicit row blockers.
- Compatibility impact: additive only; no existing schema field or benchmark result interpretation changes.

Addresses #3574 for this harness-manifest slice; broader ablation evidence remains out of scope.

## Validation / proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_heterogeneous_population_ablation.py tests/benchmark/test_heterogeneous_population_metrics.py tests/benchmark/test_pedestrian_control_trace.py -q`
  - Result: passed, `49 passed`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py --config configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml --output output/issue_3574_mean_matched_harness/manifest.json`
  - Result: passed, wrote 8 dry-run rows with status `blocked_pending_control_trace`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/heterogeneous_population_ablation.py scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py tests/benchmark/test_heterogeneous_population_ablation.py && git diff --check`
  - Result: passed.
- `uv sync --all-extras`
  - Result: passed; installed optional predictive-lane dependencies including `torch`.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - Result: passed; core lane `1807 passed, 2 skipped`; optional lane completed; freshness stamp passed at `6e9b2cbeed752f1278a5aad456252fa19d847bb0`.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree`
  - Result: passed, `fresh: true`, clean tree.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no response-law mixture sweep, no rank-order claim, and no paper/dissertation claim edits.

## Downstream propagation

Parent issue propagation is intentionally not posted as an issue comment because this run's authorization sets `comment_issue_or_pr: false`. This PR body records the slice delivered, remaining blocker, and claim boundary as the canonical visible state for the handoff to Claude Code.

<details>
<summary>Template appendix</summary>

## Summary

Adds the smallest harness-manifest path needed to wire issue #3574's mean-matched heterogeneous population follow-up without claiming ablation results.

## Linked Issues

- Relates `#3574`

## Stack / Dependency

- Base dependency: none
- Required prior PRs: existing merged #3574 metric/control-trace/harness primitives on `origin/main`
- Stack follow-up issues: none opened here
- Safe review independently: yes
- Review dependency reason: additive manifest/reporting slice

## What Changed

- Extended `robot_sf/benchmark/heterogeneous_population_ablation.py` with manifest construction and trace-readiness diagnostics.
- Added a CLI and tracked smoke config for dry-run manifest emission.
- Added focused tests for row attribution, fail-closed trace blockers, fixture trace readiness, and malformed config handling.
- Added a context note documenting the harness claim boundary.

## Why Matters

- Added value: future ablation rows can be generated with stable attribution and exact missing-input blockers.
- Expected impact: unblocks per-archetype analysis preparation without overclaiming.
- Why worth merging now: matches the latest issue thread plan and keeps future campaign setup reproducible.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: blocker-resolution for missing mean-matched harness manifest inputs.
- Comparator or baseline, applicable: heterogeneous vs homogeneous mean-matched arm construction only.
- Evidence tier: NA - harness-only support contract; validation proves manifest wiring, not research evidence.
- Result classification: NA - support helper, no benchmark result.
- Decision stop rule, applicable: manifest rows are attributable and missing control-trace inputs are explicit blockers.
- Parent issue, claim map, registry, context note, synthesis surface update: `docs/context/issue_3574_mean_matched_harness.md`.
- New research/benchmark/metric/paper-facing analysis tool, any: dry-run manifest builder only; no analysis result.

## Domain-Aware Approval

- Required PR: no - harness-only support contract; no experimental-validity claim is promoted.
- Domains reviewed: NA - no benchmark result.
- Status: not required.
- Approver/review source waiver: NA - no evidence-validity approval required because this PR only emits pre-run manifests.
- Fallback/degraded exclusions: no benchmark execution; missing traces are blocked, not success evidence.
- Claim boundary: `harness_only_no_ablation_result`.
- Target claim/hypothesis: no heterogeneity-effect claim.
- Comparator split/evidence validity: future split only; no comparator result.
- Implementation integrity vs experimental validity: tests cover manifest wiring; experimental validity remains out of scope.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, CLI emitted the manifest.
- Did intervention change command source, selected command, trajectory, route progress? no runtime campaign executed.
- Did scenario actually contain targeted failure mode? diagnostic-only pre-run contract.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: future run must supply stable per-pedestrian traces before any effect claim.

## Next Empirical Action

- Rerun needed: yes, future benchmark episodes.
- Extractor analysis tool needed: existing `heterogeneous_population_metrics.py` primitives are wired by fixture readiness.
- Artifact missing unavailable: real episode control traces.
- Stop / revise / continue decision: continue to trace-backed ablation run when campaign scope is authorized.
- Proposed child issue existing follow-up: none opened here.

## Risks / Rollout

- Compatibility risks: low; additive schema/CLI/tests.
- Failure modes: malformed configs or missing traces fail closed with explicit blockers.
- Rollback fallback plan: remove additive CLI/config/schema surface.

## Docs / Provenance

- Updated docs: `docs/context/issue_3574_mean_matched_harness.md`.
- Relevant design provenance notes: issue #3574 latest harness-only plan.
- Any assumptions need to preserved: manifests are pre-run contracts, not effect evidence.

## Follow-Up Issues

- Deferred work: full ablation campaign, response-law mixture sweep, rank-order sensitivity, paper/dissertation claims remain tracked by parent #3574.
- Issues opened follow-up: none - parent #3574 remains open to track deferred broader work.

## Reviewer Notes

- Verify the row contract and claim boundary closely.
- Known limitations: generated manifest output under `output/` is ignored/disposable; no durable result artifact is promoted because no campaign ran.

</details>
