### PR TITLE
Issue #4206: align h600 mechanism packet builder schema

### DIFF
--- a/scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py
+++ b/scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py
@@ -16,11 +16,17 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from robot_sf.benchmark.failure_mechanism_taxonomy import (
+    GEOMETRY_ONLY_FIELDS,
+    MECHANISM_SCHEMA_VERSION,
+    REQUIRED_MECHANISM_FIELDS,
+    TRACE_VERIFIED_EVIDENCE_MODES,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
 
 CONFIG_SCHEMA_VERSION = "issue_4206_policy_structure_mechanism_crosscut_config.v1"
-MECHANISM_SCHEMA_VERSION = "failure_mechanism_taxonomy.v1"
 READY_STATUS = "analysis_ready_trace_verified"
 BLOCKED_STATUS = "blocked_missing_trace_verified_mechanism_labels"
 # The h600 run artifacts were never retrieved to this host, so no episode rows exist to inspect.
@@ -41,13 +47,6 @@ BLOCKER_KIND_LABEL = "missing_mechanism_labels"
 BLOCKER_KIND_NOT_DERIVABLE = "mechanism_labels_not_derivable_predates_trace_capture"
 REPORT_SCHEMA_VERSION = "issue_4206_policy_structure_mechanism_crosscut_report.v1"
 
-REQUIRED_MECHANISM_FIELDS = (
-    "mechanism_schema_version",
-    "mechanism_label",
-    "mechanism_confidence",
-    "mechanism_evidence_mode",
-    "mechanism_evidence_uri",
-)
 LEGACY_MECHANISM_FIELD_ALIASES = (
     ("failure_mechanism_taxonomy_schema", "mechanism_schema_version"),
     ("failure_mechanism_label", "mechanism_label"),
@@ -65,12 +64,6 @@ MECHANISM_MARKER_FIELDS = ("mechanism_backfill_status", "mechanism_caveat")
 # (`not_derivable_non_trace_verified_mechanism`) is a different gap (a label was asserted without a
 # trace) and stays a plain missing-trace-verified-label block, so match the marker exactly.
 NOT_DERIVABLE_MISSING_TRACE_MARKER = "not_derivable_missing_trace"
-GEOMETRY_ONLY_FIELDS = (
-    "geometry_bucket",
-    "scenario_geometry_bucket",
-    "geometry_label",
-    "scenario_family",
-)
 SIDECAR_NAMES = (
     "mechanism_labels.csv",
     "failure_mechanism_labels.csv",
@@ -241,7 +234,7 @@ def _merge_mechanism_fields(
     row: Mapping[str, Any], sidecar_index: Mapping[tuple[str, ...], Mapping[str, Any]]
 ) -> dict[str, Any]:
     merged = _normalize_mechanism_fields(row)
-    if all(str(merged.get(field, "")) for field in REQUIRED_MECHANISM_FIELDS):
+    if all(field in merged for field in REQUIRED_MECHANISM_FIELDS):
         return merged
     for key in _sidecar_keys(row):
         sidecar = sidecar_index.get(key)
@@ -249,7 +242,7 @@ def _merge_mechanism_fields(
             continue
         sidecar = _normalize_mechanism_fields(sidecar)
         for field in REQUIRED_MECHANISM_FIELDS:
-            if not merged.get(field) and sidecar.get(field):
+            if (field not in merged or not merged.get(field)) and field in sidecar:
                 merged[field] = sidecar[field]
         for field in MECHANISM_MARKER_FIELDS:
             if not merged.get(field) and sidecar.get(field):
@@ -361,15 +354,8 @@ def _load_run_rows(
         row = _merge_mechanism_fields(raw, sidecar_index)
         row["source_run"] = run_name
         row["source_root"] = str(root)
-        missing_fields = [
-            field for field in REQUIRED_MECHANISM_FIELDS if not str(row.get(field, ""))
-        ]
-        if row.get("mechanism_evidence_mode") not in {
-            "paired_trace",
-            "deterministic_replay",
-            "direct_probe",
-            "root_cause",
-        }:
+        missing_fields = [field for field in REQUIRED_MECHANISM_FIELDS if field not in row]
+        if row.get("mechanism_evidence_mode") not in TRACE_VERIFIED_EVIDENCE_MODES:
             missing_fields.append("mechanism_evidence_mode=trace_verified_source")
         if missing_fields:
             not_derivable = _is_not_derivable_row(row)

--- a/tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py
+++ b/tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py
@@ -12,6 +12,13 @@ from pathlib import Path
 
 import yaml
 
+from robot_sf.benchmark.failure_mechanism_taxonomy import (
+    GEOMETRY_ONLY_FIELDS,
+    MECHANISM_SCHEMA_VERSION,
+    REQUIRED_MECHANISM_FIELDS,
+    TRACE_VERIFIED_EVIDENCE_MODES,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py"
 CONFIG = REPO_ROOT / "configs/analysis/issue_4206_policy_structure_mechanism_crosscut.yaml"
@@ -21,6 +28,14 @@ assert _SPEC is not None
 assert _SPEC.loader is not None
 _MODULE = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MODULE)
+
+
+def test_builder_uses_canonical_failure_mechanism_taxonomy_contract() -> None:
+    """Builder and trace-capable pre-registration validator share one schema owner."""
+    assert _MODULE.MECHANISM_SCHEMA_VERSION == MECHANISM_SCHEMA_VERSION
+    assert _MODULE.REQUIRED_MECHANISM_FIELDS == REQUIRED_MECHANISM_FIELDS
+    assert _MODULE.TRACE_VERIFIED_EVIDENCE_MODES == TRACE_VERIFIED_EVIDENCE_MODES
+    assert set(_MODULE.GEOMETRY_ONLY_FIELDS) == GEOMETRY_ONLY_FIELDS
 
 
 def _write_rows(root: Path, rows: list[dict[str, object]]) -> None:
@@ -53,6 +68,8 @@ def _base_row(planner_key: str, success: float, collision: float = 0.0) -> dict[
         "mechanism_confidence": "observed_mechanism",
         "mechanism_evidence_mode": "paired_trace",
         "mechanism_evidence_uri": "docs/context/issue_2220_failure_mechanism_taxonomy.md",
+        "mechanism_case_id": f"fixture-{planner_key}",
+        "mechanism_caveat": "",
     }
 
 
@@ -120,7 +137,7 @@ def test_missing_mechanism_label_blocks_f_c4ii_tables(tmp_path: Path) -> None:
     extended = tmp_path / "extended"
     row = _base_row("prediction_planner", 1.0)
     for field in _MODULE.REQUIRED_MECHANISM_FIELDS:
-        row.pop(field)
+        row.pop(field, None)
     _write_rows(confirm, [row])
     _write_rows(extended, [row])
     output = tmp_path / "evidence"
@@ -150,7 +167,7 @@ def test_geometry_bucket_labels_are_rejected_as_substitutes(tmp_path: Path) -> N
     extended = tmp_path / "extended"
     row = _base_row("prediction_planner", 1.0)
     for field in _MODULE.REQUIRED_MECHANISM_FIELDS:
-        row.pop(field)
+        row.pop(field, None)
     row["geometry_label"] = "static_deadlock_or_local_minimum"
     _write_rows(confirm, [row])
     _write_rows(extended, [row])
@@ -322,7 +339,7 @@ def test_sidecar_episode_id_only_does_not_attach_to_other_keys(tmp_path: Path) -
     row = _base_row("prediction_planner", 1.0)
     row["episode_id"] = "shared-episode"
     for field in _MODULE.REQUIRED_MECHANISM_FIELDS:
-        row.pop(field)
+        row.pop(field, None)
     _write_rows(confirm, [row])
     _write_rows(extended, [row])
     sidecar = _base_row("other_planner", 0.0)
@@ -448,7 +465,7 @@ def test_present_rows_missing_labels_stay_a_label_block(tmp_path: Path) -> None:
     extended = tmp_path / "extended"
     row = _base_row("prediction_planner", 1.0)
     for field in _MODULE.REQUIRED_MECHANISM_FIELDS:
-        row.pop(field)
+        row.pop(field, None)
     _write_rows(confirm, [row])
     _write_rows(extended, [row])
     output = tmp_path / "evidence"
@@ -482,6 +499,8 @@ def _native_writer_episode(
         "source": "trace_review_issue_2220",
         "trace_status": "trace_verified" if trace_verified else "geometry_only",
         "confidence": "observed_mechanism",
+        "case_id": f"fixture-{planner_key}-{seed}",
+        "caveat": "",
     }
     return {
         "episode_id": f"ep-{planner_key}-{seed}",
@@ -623,7 +642,7 @@ def _unlabeled_seed_rows(root: Path, planners: list[str]) -> list[dict[str, obje
     for planner in planners:
         row = _base_row(planner, 1.0)
         for field in _MODULE.REQUIRED_MECHANISM_FIELDS:
-            row.pop(field)
+            row.pop(field, None)
         rows.append(row)
     _write_rows(root, rows)
     return rows
@@ -695,6 +714,7 @@ def test_declared_sidecar_all_not_derivable_reports_predates_trace_capture_block
         "mechanism_confidence": "unknown",
         "mechanism_evidence_mode": "unknown",
         "mechanism_evidence_uri": "",
+        "mechanism_case_id": "",
         "mechanism_backfill_status": "not_derivable_missing_trace",
         "mechanism_caveat": "not_derivable_missing_trace",
     }
@@ -743,6 +763,8 @@ def test_declared_sidecar_supplies_trace_labels_unblocks_tables(tmp_path: Path) 
         "mechanism_confidence": "observed_mechanism",
         "mechanism_evidence_mode": "paired_trace",
         "mechanism_evidence_uri": "docs/context/issue_2220_failure_mechanism_taxonomy.md",
+        "mechanism_case_id": "fixture-trace-case",
+        "mechanism_caveat": "",
     }
     sidecar = tmp_path / "sidecar.csv"
     _write_sidecar_csv(sidecar, confirm_rows, trace_mechanism)


### PR DESCRIPTION
## Reviewer-critical summary

What changed: aligns the issue #4206 mechanism cross-cut packet builder with the canonical `failure_mechanism_taxonomy.v1` schema owner used by the merged trace-capable h600 pre-registration validator. The builder now imports the canonical schema version, required fields, trace-verified evidence modes, and geometry-only field list instead of carrying a five-field local copy.

Why now: issue #4206 has had several guardrail and packet-refresh PRs in the last 24h. This is a progression slice: the nameable new capability is one shared taxonomy contract between the retained-artifact packet builder and the trace-capable re-run validator, so future h600 packet refreshes cannot silently omit `mechanism_case_id` or `mechanism_caveat`.

Claim boundary: this PR changes schema consumption and tests only. It does not produce mechanism-rank F-C4(ii) conclusions. A host-local builder check on imech039 found the full `output/.../13268` and `output/.../13273` episode-row trees were not hydrated in this worktree, so the durable checked-in packet was not overwritten with a transient missing-input state.

Required validation: focused #4206 builder tests, #4206 pre-registration validator, Ruff format/check on touched files, and final PR readiness.

Remaining blocker: the issue remains blocked on trace-capable h600 evidence rows or hydrated retained run artifacts with trace-verified labels. No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits were performed.

## Contract delta

New schema fields consumed by the builder via canonical owner:

- `mechanism_case_id`
- `mechanism_caveat`

New fail-closed behavior:

- Required mechanism-field checks now use field presence against the canonical schema instead of a local five-field non-empty text list.
- Blank-but-present canonical text fields such as `mechanism_caveat` can be carried through sidecar merge instead of being treated as absent.
- Trace-verified source eligibility now uses canonical `TRACE_VERIFIED_EVIDENCE_MODES`.

Compatibility impact:

- Happy-path fixture rows and sidecars now include the seven-field canonical taxonomy record.
- Rows without mechanism fields, geometry-only substitutes, non-trace labels, fallback/degraded rows, and all-`not_derivable` retained sidecars remain fail-closed under existing statuses.

## Issue

Refs #4206.

## Scope summary

- Updated `scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py` to import canonical taxonomy constants from `robot_sf/benchmark/failure_mechanism_taxonomy.py`.
- Added regression coverage in `tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py` proving the builder stays aligned with the canonical schema owner.
- Updated fixtures to carry `mechanism_case_id` and `mechanism_caveat` where trace-positive rows are expected to unblock tables.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py -q` -> passed, 23 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_4206_trace_capable_h600_rerun_preregistration.py --config configs/benchmarks/issue_4206_trace_capable_h600_rerun_preregistration.yaml` -> passed, pre-registration valid.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py` -> passed, unchanged.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py --config configs/analysis/issue_4206_policy_structure_mechanism_crosscut.yaml --confirm-root output/issue3810-h600-longhorizon-confirm-run/13268 --extended-root output/issue3810-h600-extroster-run/13273 --job13175-packet docs/context/evidence/issue_3653_snqi_decision_disagreement_job_13175/packet.json --output-dir /tmp/issue_4206_host_local_builder_check --generated-at 2026-07-04T06:25:00Z` -> exited 0, emitted `status: blocked_missing_input_artifacts` because retained `output/` trees were not hydrated in this worktree; output kept outside git and not committed as durable issue state.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No geometry-bucket fallback conclusions.
- No issue/PR comment propagation: this run was authorized with `comment_issue_or_pr: false`; state propagation is contained in this PR body.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: more than two #4206 PRs merged in the last 24h, so this PR is not a micro-guard. It is a consolidation/progression slice that unifies the retained-artifact builder with the merged pre-registration validator's canonical schema contract.

Late guidance check: live issue comments were re-read immediately before PR open; no comments newer than the run start time were present.

Forbidden actions confirmation: no compute submission, merge, release, or deletion performed.

</details>
