### PR TITLE
fix: #4205 runner crashes on dict-valued trace fields (keystone blocker #3, Slurm 13292)

### DIFF
--- a/scripts/benchmark/run_issue_4205_codesign_loop_campaign.py
+++ b/scripts/benchmark/run_issue_4205_codesign_loop_campaign.py
@@ -358,8 +358,8 @@ def _aggregate_per_arm(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
         trace_rows = sum(
             1
             for row in arm_rows
-            if row.get("low_progress_window") not in {"", None}
-            or row.get("local_minimum_indicator") not in {"", None}
+            if row.get("low_progress_window") not in ("", None)
+            or row.get("local_minimum_indicator") not in ("", None)
         )
         row_status_counts = Counter(str(row.get("row_status") or "completed") for row in arm_rows)
         output.append(

--- a/tests/benchmark/test_issue_4367_codesign_campaign_runner.py
+++ b/tests/benchmark/test_issue_4367_codesign_campaign_runner.py
@@ -238,3 +238,26 @@ def test_missing_hydration_manifest_fails_before_outputs(tmp_path: Path) -> None
     )
     assert exit_code == 2
     assert not output_root.exists()
+
+
+def test_aggregate_per_arm_tolerates_dict_valued_trace_fields() -> None:
+    """Slurm job 13292 regression: trace fields can be dict-valued; set-membership
+    against {"", None} raised TypeError (unhashable). Tuple membership must work."""
+    rows = [
+        {
+            "arm_key": "ppo_frozen",
+            "success": True,
+            "collision": False,
+            "near_miss": False,
+            "snqi": -0.1,
+            "deadlock_count": 0,
+            "low_progress_window": {"window_steps": 5, "threshold": 0.1},
+            "local_minimum_indicator": None,
+            "row_status": "completed",
+        }
+    ]
+    out = _MODULE._aggregate_per_arm(rows)
+    assert out[0]["arm_key"] == "ppo_frozen"
+    # the dict-valued field counts as a present trace field
+    trace_keys = [k for k in out[0] if "trace" in k]
+    assert trace_keys and any(out[0][k] in (1, True) for k in trace_keys)


### PR DESCRIPTION
One-line fix + regression test. `_aggregate_per_arm` used set-membership `x not in {"", None}` on `low_progress_window`/`local_minimum_indicator`, which raises `TypeError: unhashable type: 'dict'` when the episode row carries a dict-valued trace field — exactly what the #4301-instrumented episodes emit. Tuple membership (`not in ("", None)`) uses equality and handles unhashable values.

Verified: full test file green (4 passed) incl. the new regression test with a dict-valued field. Authored by the orchestrator to shortcut the fourth one-liner iteration on the keystone campaign (jobs 13286-13292 lineage; #4378 profile, #4394 map paths, #4403 CUDA-fork filed). Gate reviews + merges per standing contract — campaign resubmits (attempt 8) on merge.