### PR TITLE
refactor: thin camera-ready config facade (#3385)

### DIFF
--- a/robot_sf/benchmark/camera_ready/__init__.py
+++ b/robot_sf/benchmark/camera_ready/__init__.py
@@ -1,9 +1,32 @@
 """Camera-ready campaign package.
 
-Decomposes the historically monolithic ``camera_ready_campaign.py`` (~4967 LOC)
-into focused submodules (see #3385). Leaf helpers live in ``_util.py``;
-config dataclasses live in ``_config_types.py`` while
-``camera_ready_campaign_config.py`` remains a compatibility facade. Most
-orchestration/IO/computation has moved into this package while
-``camera_ready_campaign.py`` preserves legacy import and monkeypatch surfaces.
+Decomposes historically monolithic ``camera_ready_campaign.py`` (~4967 LOC)
+into focused submodules (see #3385). Leaf helpers live in ``_util.py``; config
+dataclasses live in ``_config_types.py`` and are re-exported here as package
+surface while ``camera_ready_campaign_config.py`` remains compatibility facade.
+Most orchestration/IO/computation moved into package while
+``camera_ready_campaign.py`` preserves legacy import monkeypatch surfaces.
 """
+
+from robot_sf.benchmark.camera_ready._config import load_campaign_config
+from robot_sf.benchmark.camera_ready._config_types import _AMV_DIMENSIONS as _AMV_DIMENSIONS
+from robot_sf.benchmark.camera_ready._config_types import (
+    DEFAULT_SEED_SETS_PATH,
+    AmvProfileConfig,
+    CampaignConfig,
+    PlannerSpec,
+    ScenarioCandidateSelection,
+    SeedPolicy,
+    SnqiContractConfig,
+)
+
+__all__ = [
+    "DEFAULT_SEED_SETS_PATH",
+    "AmvProfileConfig",
+    "CampaignConfig",
+    "PlannerSpec",
+    "ScenarioCandidateSelection",
+    "SeedPolicy",
+    "SnqiContractConfig",
+    "load_campaign_config",
+]

--- a/robot_sf/benchmark/camera_ready_campaign_config.py
+++ b/robot_sf/benchmark/camera_ready_campaign_config.py
@@ -1,12 +1,11 @@
-"""Backward-compatible config dataclass import surface.
+"""Backward-compatible dataclass surface.
 
-The definitions now live in ``robot_sf.benchmark.camera_ready._config_types`` as
-part of the #3385 camera-ready package decomposition. Keep this module as a
-compatibility facade for callers that imported the earlier extraction module
-directly.
+The definitions now live under ``robot_sf.benchmark.camera_ready`` as part of
+the #3385 camera-ready package decomposition. Keep this module as a compatibility
+facade for callers that imported the earlier extraction module directly.
 """
 
-from robot_sf.benchmark.camera_ready._config_types import (  # noqa: F401
+from robot_sf.benchmark.camera_ready import (  # noqa: F401
     _AMV_DIMENSIONS,
     DEFAULT_SEED_SETS_PATH,
     AmvProfileConfig,

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -122,7 +122,9 @@ def test_camera_ready_config_types_keep_legacy_import_identity() -> None:
     )
 
     for name in public_names:
-        assert getattr(camera_ready_package, name) is getattr(camera_ready_config_types_module, name)
+        assert getattr(camera_ready_package, name) is getattr(
+            camera_ready_config_types_module, name
+        )
         assert getattr(camera_ready_campaign_config_module, name) is getattr(
             camera_ready_config_types_module, name
         )
@@ -134,7 +136,9 @@ def test_camera_ready_config_types_keep_legacy_import_identity() -> None:
         camera_ready_campaign_config_module._AMV_DIMENSIONS
         is camera_ready_config_types_module._AMV_DIMENSIONS
     )
-    assert camera_ready_package.load_campaign_config is camera_ready_config_module.load_campaign_config
+    assert (
+        camera_ready_package.load_campaign_config is camera_ready_config_module.load_campaign_config
+    )
 
 
 def test_camera_ready_campaign_reexports_package_run_state_helpers() -> None:

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -15,6 +15,7 @@ import pytest
 import yaml
 from loguru import logger
 
+import robot_sf.benchmark.camera_ready as camera_ready_package
 import robot_sf.benchmark.camera_ready._artifacts as camera_ready_artifacts_module
 import robot_sf.benchmark.camera_ready._config as camera_ready_config_module
 import robot_sf.benchmark.camera_ready._config_types as camera_ready_config_types_module
@@ -109,7 +110,7 @@ def test_camera_ready_campaign_reexports_package_config_loader() -> None:
 
 
 def test_camera_ready_config_types_keep_legacy_import_identity() -> None:
-    """Config dataclass extraction keeps legacy import paths object-identical."""
+    """Config dataclass extraction keeps package and legacy import paths object-identical."""
     public_names = (
         "DEFAULT_SEED_SETS_PATH",
         "AmvProfileConfig",
@@ -121,12 +122,19 @@ def test_camera_ready_config_types_keep_legacy_import_identity() -> None:
     )
 
     for name in public_names:
+        assert getattr(camera_ready_package, name) is getattr(camera_ready_config_types_module, name)
         assert getattr(camera_ready_campaign_config_module, name) is getattr(
             camera_ready_config_types_module, name
         )
         assert getattr(camera_ready_campaign_module, name) is getattr(
             camera_ready_config_types_module, name
         )
+    assert camera_ready_package._AMV_DIMENSIONS is camera_ready_config_types_module._AMV_DIMENSIONS
+    assert (
+        camera_ready_campaign_config_module._AMV_DIMENSIONS
+        is camera_ready_config_types_module._AMV_DIMENSIONS
+    )
+    assert camera_ready_package.load_campaign_config is camera_ready_config_module.load_campaign_config
 
 
 def test_camera_ready_campaign_reexports_package_run_state_helpers() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `robot_sf.benchmark.camera_ready` now exposes the extracted config dataclasses and `load_campaign_config` directly, and `camera_ready_campaign_config.py` is reduced to a compatibility re-export from that package surface.

Why now: #3385’s latest merged slice (#4384) moved config types into `_config_types.py` and explicitly left further compatibility thinning open. This is a small progression slice: the new capability is a package-level config import surface that lets future callers avoid the legacy config facade without breaking old imports.

Claim boundary: behavior-preserving import-surface refactor only. It preserves object identity across `camera_ready`, `camera_ready_campaign_config`, `camera_ready_campaign`, and `_config_types` for the covered config objects.

Required validation: focused camera-ready campaign tests plus Ruff on camera-ready modules.

Remaining blocker: `camera_ready_campaign.py` still keeps wrapper logic for legacy monkeypatch-on-old-import callers; this PR does not attempt final facade removal.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: legacy imports from `robot_sf.benchmark.camera_ready_campaign_config` and `robot_sf.benchmark.camera_ready_campaign` remain object-identical for covered config dataclasses/constants. The package import path `robot_sf.benchmark.camera_ready` now provides the same public config dataclasses and `load_campaign_config`.
- Fragmentation guard: progression slice, not a micro-guard/checker/status PR. Nameable capability is the package-level config import surface plus thinner legacy config facade.

## Summary

Relates to #3385.

## What Changed

- Added explicit config exports and `__all__` to `robot_sf/benchmark/camera_ready/__init__.py`.
- Pointed `robot_sf/benchmark/camera_ready_campaign_config.py` at the package surface instead of the private `_config_types` module.
- Extended the existing identity regression to cover package-level imports and the preserved private `_AMV_DIMENSIONS` compatibility attribute.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_camera_ready_campaign.py::test_camera_ready_config_types_keep_legacy_import_identity -q` PASS
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_camera_ready_campaign.py -q` PASS
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/camera_ready_campaign.py robot_sf/benchmark/camera_ready robot_sf/benchmark/camera_ready_campaign_config.py tests/benchmark/test_camera_ready_campaign.py` PASS

Not run: no full benchmark campaign, no Slurm/GPU submission, no paper/dissertation claim edits. Full PR-ready freshness stamp was not produced because this handoff is intentionally limited to the focused validation requested for the slice; Claude Code on `imech156-u` owns the full PR gate after open.

## Out Of Scope

- No campaign semantics changes.
- No report prose changes.
- No output schema changes.
- No artifact rewrites.
- No new benchmark evidence.
- No transient queue-routing state encoded in tracked files.

<details>
<summary>Governance Appendix</summary>

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - behavior-preserving refactor support slice.
- Comparator or baseline, applicable: `origin/main` import behavior.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution for compatibility thinning only.
- Decision stop rule, applicable: focused import identity regression and camera-ready test file pass.
- Parent issue, claim map, registry, context note, synthesis surface update: #3385 issue state is already high-churn; propagation is handled in this PR body to avoid adding another issue comment stream.
- New research/benchmark/metric/paper-facing analysis tool, any: NA.

## Domain-Aware Approval

Not required: no benchmark interpretation, metric semantics, evidence classification, figure eligibility, or paper-facing claim surface changed.

## Falsification / Non-Transfer Check

- Did mechanism activate? NA.
- Did intervention change command source, selected command, trajectory, route progress? No.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue #3385 compatibility thinning.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action

- Rerun needed: no for this slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with remaining facade/orchestration thinning only after reviewer gate.
- Proposed child issue existing follow-up: #3385.

## Risks / Rollout

- Compatibility risks: package import now loads `_config`; focused tests cover the expected camera-ready import path and object identity.
- Failure modes: external callers depending on only `camera_ready` package import being empty could observe extra attributes; this is intended package surface progression for #3385.
- Rollback fallback plan: revert this commit; legacy modules remain otherwise unchanged.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: #3385 issue thread, latest #4384 state update.
- Assumptions preserved: old config facade should remain importable; package-level config imports are the reversible next step.

## Downstream Propagation

- Parent issue updated: no, high-churn issue; state captured in PR body instead of another comment.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no.
- Not applicable because: this is a behavior-preserving import-surface refactor with no benchmark, registry, claim-map, or paper-facing changes.

## Reviewer Notes

- Closely verify that importing from `robot_sf.benchmark.camera_ready` is acceptable as the package-level config surface.
- Known limitation: `camera_ready_campaign.py` remains a compatibility wrapper for monkeypatch surfaces; final facade thinning remains future work.

</details>
