### PR TITLE
Issue #3300 fail closed incompatible false-positive replay views

### DIFF
--- a/robot_sf/benchmark/false_positive_injection_readiness.py
+++ b/robot_sf/benchmark/false_positive_injection_readiness.py
@@ -27,9 +27,11 @@ Status vocabulary (aligned with ``robot_sf.benchmark.fallback_policy``):
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
+from robot_sf.benchmark.observation_levels import observation_level_spec
 from robot_sf.benchmark.observation_perturbation import (
     NOISE_PROFILE_FALSE_POSITIVE,
     ObservationPerturbationSpec,
@@ -68,6 +70,27 @@ INJECTION_INPUT_KEYS: tuple[str, ...] = (
     "false_positive_ids",
 )
 
+OBSERVATION_VIEW_KEYS: tuple[str, ...] = (
+    "planner_observation_view",
+    "observation_view",
+    "observation_contract",
+)
+OBSERVATION_LEVEL_KEYS: tuple[str, ...] = (
+    "observation_level",
+    "benchmark_observation_level",
+)
+OBSERVATION_MODE_KEYS: tuple[str, ...] = (
+    "active_observation_mode",
+    "observation_mode",
+    "planner_observation_mode",
+)
+REQUIRED_INPUT_KEYS: tuple[str, ...] = (
+    "required_inputs",
+    "planner_required_inputs",
+)
+PEDESTRIAN_INPUT_KEYS = frozenset({"pedestrians"})
+INCOMPATIBLE_OBSERVATION_MODES = frozenset({"goal_state"})
+
 
 @dataclass(frozen=True)
 class FalsePositiveInjectionReadiness:
@@ -90,6 +113,7 @@ class FalsePositiveInjectionReadiness:
     injected_actor_count: int = 0
     noise_profile: str | None = None
     provenance: dict[str, Any] = field(default_factory=dict)
+    observation_view: dict[str, Any] = field(default_factory=dict)
 
     @property
     def is_ready(self) -> bool:
@@ -107,6 +131,7 @@ class FalsePositiveInjectionReadiness:
             "noise_profile": self.noise_profile,
             "perturbation_family": FALSE_POSITIVE_PERTURBATION_FAMILY,
             "provenance": dict(self.provenance),
+            "observation_view": dict(self.observation_view),
         }
 
 
@@ -128,6 +153,89 @@ def _check_provenance(spec: dict[str, Any]) -> list[str]:
 def _provenance_echo(spec: dict[str, Any]) -> dict[str, Any]:
     """Return the provenance subset present in the spec for the report contract."""
     return {key: spec[key] for key in REQUIRED_PROVENANCE_FIELDS if key in spec}
+
+
+def _first_present(mapping: Mapping[str, Any], keys: tuple[str, ...]) -> Any:
+    """Return first non-empty mapping value for keys."""
+    for key in keys:
+        value = mapping.get(key)
+        if value is not None and not (isinstance(value, str) and not value.strip()):
+            return value
+    return None
+
+
+def _list_strings(value: Any) -> list[str]:
+    """Normalize scalar/list view metadata into strings.
+
+    Returns:
+        Non-empty string values extracted from ``value``.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _observation_view(spec: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract declared planner observation-view metadata from a readiness spec.
+
+    Returns:
+        Normalized observation-level, active-mode, and required-input metadata.
+    """
+    view: Mapping[str, Any] = {}
+    for key in OBSERVATION_VIEW_KEYS:
+        value = spec.get(key)
+        if isinstance(value, Mapping):
+            view = value
+            break
+
+    observation_level = _first_present(view, OBSERVATION_LEVEL_KEYS)
+    if observation_level is None:
+        observation_level = _first_present(spec, OBSERVATION_LEVEL_KEYS)
+
+    observation_mode = _first_present(view, OBSERVATION_MODE_KEYS)
+    if observation_mode is None:
+        observation_mode = _first_present(spec, OBSERVATION_MODE_KEYS)
+
+    required_inputs = _list_strings(_first_present(view, REQUIRED_INPUT_KEYS))
+    if not required_inputs:
+        required_inputs = _list_strings(_first_present(spec, REQUIRED_INPUT_KEYS))
+
+    if not required_inputs and observation_level is not None:
+        try:
+            required_inputs = list(observation_level_spec(str(observation_level)).required_inputs)
+        except ValueError:
+            required_inputs = []
+
+    return {
+        "observation_level": str(observation_level).strip() if observation_level else None,
+        "active_observation_mode": str(observation_mode).strip() if observation_mode else None,
+        "required_inputs": required_inputs,
+    }
+
+
+def _check_observation_view_compatibility(view: Mapping[str, Any]) -> list[str]:
+    """Return blockers when injected actors cannot reach planner observations."""
+    required_inputs = set(_list_strings(view.get("required_inputs")))
+    observation_mode = str(view.get("active_observation_mode") or "").strip()
+
+    blockers: list[str] = []
+    if not any(required in required_inputs for required in PEDESTRIAN_INPUT_KEYS):
+        blockers.append(
+            "planner observation view must expose structured pedestrians for "
+            "false-positive actor injection; add planner_observation_view.required_inputs "
+            "including 'pedestrians' or use a compatible planner/config"
+        )
+    if observation_mode in INCOMPATIBLE_OBSERVATION_MODES:
+        blockers.append(
+            f"planner observation mode {observation_mode!r} cannot carry structured "
+            "injected pedestrians; use a pedestrian-observation mode such as "
+            "'socnav_state', 'headed_socnav_state', or 'gst_human_state'"
+        )
+    return blockers
 
 
 def check_false_positive_injection_readiness(
@@ -157,6 +265,7 @@ def check_false_positive_injection_readiness(
 
     blockers: list[str] = []
     provenance = _provenance_echo(spec)
+    observation_view = _observation_view(spec)
     blockers.extend(_check_provenance(spec))
 
     # Reuse the canonical perturbation spec for input validation rather than
@@ -174,6 +283,7 @@ def check_false_positive_injection_readiness(
             status=STATUS_BLOCKED,
             blockers=blockers,
             provenance=provenance,
+            observation_view=observation_view,
         )
 
     assert perturbation_spec is not None  # guaranteed when no blockers recorded
@@ -186,6 +296,18 @@ def check_false_positive_injection_readiness(
             injected_actor_count=0,
             noise_profile=perturbation_spec.noise_profile,
             provenance=provenance,
+            observation_view=observation_view,
+        )
+
+    blockers.extend(_check_observation_view_compatibility(observation_view))
+    if blockers:
+        return FalsePositiveInjectionReadiness(
+            status=STATUS_BLOCKED,
+            blockers=blockers,
+            injected_actor_count=injected_actor_count,
+            noise_profile=perturbation_spec.noise_profile,
+            provenance=provenance,
+            observation_view=observation_view,
         )
 
     return FalsePositiveInjectionReadiness(
@@ -193,4 +315,5 @@ def check_false_positive_injection_readiness(
         injected_actor_count=injected_actor_count,
         noise_profile=perturbation_spec.noise_profile,
         provenance=provenance,
+        observation_view=observation_view,
     )

--- a/tests/benchmark/test_false_positive_injection_readiness.py
+++ b/tests/benchmark/test_false_positive_injection_readiness.py
@@ -48,6 +48,11 @@ def _ready_spec() -> dict[str, object]:
     """Return a fully valid false-positive injection replay-condition spec."""
     return {
         **_valid_provenance(),
+        "planner_observation_view": {
+            "observation_level": "oracle_full_state",
+            "active_observation_mode": "socnav_state",
+            "required_inputs": ["robot_state", "goal", "pedestrians"],
+        },
         "false_positive_positions": [[2.0, 3.0]],
         "false_positive_velocities": [[0.0, 0.0]],
         "false_positive_ids": ["fp_close"],
@@ -78,7 +83,12 @@ class TestReadyCondition:
 
     def test_multiple_injected_actors_counted(self) -> None:
         """Injected-actor count reflects all requested false positives."""
-        spec = {**_valid_provenance(), "false_positive_positions": [[2.0, 3.0], [4.0, 5.0]]}
+        spec = {
+            **_ready_spec(),
+            "false_positive_positions": [[2.0, 3.0], [4.0, 5.0]],
+            "false_positive_velocities": [[0.0, 0.0], [0.0, 0.0]],
+            "false_positive_ids": ["fp_close", "fp_far"],
+        }
         readiness = check_false_positive_injection_readiness(spec)
         assert readiness.status == STATUS_READY
         assert readiness.injected_actor_count == 2
@@ -127,6 +137,29 @@ class TestFailClosed:
         readiness = check_false_positive_injection_readiness(spec)
         assert readiness.status == STATUS_BLOCKED
         assert any("perturbation_family" in blocker for blocker in readiness.blockers)
+
+    def test_missing_observation_view_blocks_when_injecting_actor(self) -> None:
+        """Injected actors require a declared structured-pedestrian planner view."""
+        spec = _ready_spec()
+        del spec["planner_observation_view"]
+        readiness = check_false_positive_injection_readiness(spec)
+        assert readiness.status == STATUS_BLOCKED
+        assert any("structured pedestrians" in blocker for blocker in readiness.blockers)
+        assert readiness.injected_actor_count == 1
+
+    def test_goal_state_observation_view_blocks_false_positive_injection(self) -> None:
+        """A goal-only observation view fails closed before replay execution."""
+        spec = {
+            **_ready_spec(),
+            "planner_observation_view": {
+                "observation_level": "oracle_full_state",
+                "active_observation_mode": "goal_state",
+                "required_inputs": ["robot_state", "goal", "pedestrians"],
+            },
+        }
+        readiness = check_false_positive_injection_readiness(spec)
+        assert readiness.status == STATUS_BLOCKED
+        assert any("goal_state" in blocker for blocker in readiness.blockers)
 
     def test_malformed_positions_block(self) -> None:
         """A bad injection-input shape must fail closed, not raise out."""

--- a/tests/fixtures/benchmark/false_positive_actor_injection/replay_condition_ready.yaml
+++ b/tests/fixtures/benchmark/false_positive_actor_injection/replay_condition_ready.yaml
@@ -1,8 +1,8 @@
 # Minimal valid false-positive actor-injection replay condition (issue #3300).
 #
-# Readiness fixture only: it carries the injected-actor inputs and the provenance
-# fields required before a false-positive actor-injection replay can run. It does
-# not itself run a replay or assert any benchmark/safety outcome.
+# Readiness fixture only: carries injected-actor inputs, provenance, and a
+# planner observation view capable of carrying structured pedestrians. It does
+# not itself run replay or assert any benchmark/safety outcome.
 false_positive_injection:
   # Provenance contract (REQUIRED_PROVENANCE_FIELDS).
   scenario_id: occluded_emergence_episode_0000
@@ -10,6 +10,14 @@ false_positive_injection:
   planner_mode: trace_derived
   perturbation_family: false_positive_actor_injection
   execution_mode: readiness_check_only
+  planner_observation_view:
+    observation_level: oracle_full_state
+    active_observation_mode: socnav_state
+    required_inputs:
+      - robot_state
+      - goal
+      - pedestrians
+
   # Injected observed-only false-positive actor inputs.
   false_positive_positions:
     - [2.0, 3.0]


### PR DESCRIPTION
## Reviewer-critical summary

What changed: issue #3300 false-positive actor-injection readiness now fail-closes when injected actors are requested but the declared planner observation view cannot carry structured pedestrians. The readiness JSON also echoes the normalized `observation_view` it checked.

Why now: PR #4390 produced native CPU replay evidence but classified `blocked_unavailable` because the `goal_state` planner view injected zero actors. This PR adds the remaining CPU-implementable preflight guard so incompatible configs fail before replay execution.

Claim boundary: preflight/config-guard behavior only. No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

Required validation: focused readiness tests plus touched-file Ruff; final PR gate run with this body file.

Remaining blocker: #3300 still needs an empirical replay using a planner/config whose effective observation view exposes structured pedestrian observations.

## Contract delta

New schema field:
- `observation_view` is included in `FalsePositiveInjectionReadiness.to_dict()` with normalized `observation_level`, `active_observation_mode`, and `required_inputs`.

New fail-closed blockers:
- Requested false-positive actors now require a declared planner observation view whose required inputs include `pedestrians`.
- `active_observation_mode: goal_state` is rejected for false-positive actor injection because PR #4390 showed it cannot carry injected structured pedestrians to the planner.

Compatibility impact:
- Specs with no requested false-positive actors still return `not_available`.
- Compatible specs declaring structured-pedestrian views such as `socnav_state` remain `ready`.
- Incompatible or underspecified injected-actor specs now return `blocked` with an actionable message instead of passing as false-positive replay-ready.

## Summary

Adds the issue #3300 fail-closed observation-view compatibility guard to the existing false-positive injection readiness checker.

## Linked Issues

- Relates `#3300`

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed

- Added observation-view extraction and compatibility checks to `robot_sf/benchmark/false_positive_injection_readiness.py`.
- Updated the ready fixture to declare a structured-pedestrian-capable planner observation view.
- Added focused tests for missing observation-view metadata and `goal_state` incompatibility.

## Why Matters

- Added value: rejects false-positive replay configs that would otherwise produce zero injected actors and a false sense of readiness.
- Expected impact: incompatible issue #3300 replay specs fail closed before execution with actionable blockers.
- Why worth merging now: it directly addresses the remaining handoff from PR #4390.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - support preflight guard for incompatible false-positive actor-injection replay configs.
- Comparator or baseline, applicable: previous readiness accepted injected-actor specs without checking planner observation-view compatibility.
- Evidence tier: NA - support preflight guard; no replay evidence claim.
- Result classification: NA - support preflight guard.
- Decision stop rule, applicable: readiness returns `blocked` for missing/incompatible observation views while compatible structured-pedestrian specs remain `ready`.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3300 remains open; PR body records remaining blocker.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support preflight helper.

## Domain-Aware Approval

- Approval concerns experimental validity waived / pending / blocked / not required: not required.
- Approver/review source waiver: this PR makes no observed false-positive effect claim.
- Validity checklist: fail-closed preflight only; no replay outcome interpretation.
- Target claim/hypothesis: incompatible configs are rejected before execution.
- Comparator split/evidence validity: targeted readiness tests cover ready, missing-view blocked, and `goal_state` blocked paths.
- Fallback/degraded exclusions: no fallback/degraded run is treated as evidence.
- Claim boundary: no full benchmark campaign, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: implementation changes readiness classification only.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, targeted tests exercise the new blockers.
- Did intervention change command source, selected command, trajectory, route progress? no, preflight-only.
- Did scenario actually contain targeted failure mode? PR #4390 evidence recorded `goal_state` zero injected actors; this PR encodes that incompatible-view guard.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: run a planner/config exposing structured pedestrian observations for empirical #3300 replay.

## Next Empirical Action

- Rerun needed: yes, outside this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: observed false-positive replay evidence remains unavailable until a compatible planner/config is used.
- Stop / revise / continue decision: continue with compatible structured-pedestrian observation replay.
- Proposed child issue existing follow-up: #3300 remains the parent issue.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_false_positive_injection_readiness.py -q` -> pass, 21 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/check_false_positive_injection_readiness.py tests/fixtures/benchmark/false_positive_actor_injection/replay_condition_ready.yaml` -> pass, status `ready`, `injected_actor_count: 1`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/check_false_positive_injection_readiness.py --help` -> pass.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/false_positive_injection_readiness.py tests/benchmark/test_false_positive_injection_readiness.py` -> pass.
- `PYTEST_NUM_WORKERS=8 scripts/dev/run_worktree_shared_venv.sh -- env PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3300/pr_body.md scripts/dev/pr_ready_check.sh` -> pass; freshness stamp `output/validation/pr_ready/issue-3300-fail-closed-on-incompatible-false-positive-replay-configs.json`, head `424710c0aa7ba9b37e94b4225f6959a387a86452`.

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Impact

- Baseline runtime: NA, no runtime hot-path change claimed.
- Changed runtime: NA, readiness helper only.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_false_positive_injection_readiness.py -q`.
- Hot-path call count profile anchor: NA, no benchmark runtime path changed.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: revert if compatible structured-pedestrian readiness specs no longer return `ready` or incompatible injected-actor specs no longer return `blocked`.

## Risks / Rollout

- Compatibility risks: injected-actor readiness specs must now declare planner observation-view metadata; underspecified specs will block.
- Failure modes: overly conservative view metadata could block a compatible future adapter until it declares `required_inputs: [pedestrians]`.
- Rollback fallback plan: revert this readiness guard and fixture/test update.

## Docs / Provenance

- Updated docs: none; fixture comments updated.
- Relevant design provenance notes: PR #4390 evidence bundle and issue #3300 comment at 2026-07-04T05:29:20Z.
- Any assumptions need to preserved: `goal_state` is treated as incompatible for structured false-positive pedestrian injection based on PR #4390 CPU replay evidence.

## Downstream Propagation

- Parent issue updated (yes/no/NA): NA; PR body records remaining blocker and user instruction assigns later full PR gate/merge authority to Claude Code.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark evidence claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: this PR is a preflight guard, not an evidence-producing replay result.

## Follow-Up Issues

- Deferred work: run #3300 replay with a planner/config whose observation view carries structured pedestrians.
- Issues opened follow-up: none.

## Reviewer Notes

- Review the compatibility boundary in `_check_observation_view_compatibility`; it intentionally rejects `goal_state` and missing `pedestrians` inputs only when actors are requested.
- Known limitation: this does not add new observation-noise capability or produce observed false-positive effects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing planner observation-view details in false-positive injection readiness checks.
  * Ready responses now include observation-view information, including observation level, active mode, and required inputs.

* **Bug Fixes**
  * Readiness now blocks when observation-view data is missing or incompatible with injected pedestrian inputs.
  * Added clearer blocker messages when required view fields or supported modes are not present.

* **Tests**
  * Expanded readiness coverage for missing and incompatible observation-view scenarios.
  * Updated ready-case fixture data to reflect the new observation-view requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->