### PR TITLE
Issue #4409: harden h600 mechanism-label validation delegation

### DIFF
--- a/scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py
+++ b/scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py
@@ -21,6 +21,8 @@ from robot_sf.benchmark.failure_mechanism_taxonomy import (
     MECHANISM_SCHEMA_VERSION,
     REQUIRED_MECHANISM_FIELDS,
     TRACE_VERIFIED_EVIDENCE_MODES,
+    FailureMechanismTaxonomyError,
+    validate_failure_mechanism_record,
 )
 
 if TYPE_CHECKING:
@@ -220,6 +222,17 @@ def _mechanism_payload(row: Mapping[str, Any]) -> dict[str, Any]:
     return {field: row.get(field, "") for field in REQUIRED_MECHANISM_FIELDS}
 
 
+def _mechanism_validation_errors(row: Mapping[str, Any]) -> list[str]:
+    missing_fields = [field for field in REQUIRED_MECHANISM_FIELDS if field not in row]
+    if missing_fields:
+        return missing_fields
+    try:
+        validate_failure_mechanism_record(_mechanism_payload(row))
+    except FailureMechanismTaxonomyError as exc:
+        return [f"failure_mechanism_taxonomy: {exc}"]
+    return []
+
+
 def _normalize_mechanism_fields(row: Mapping[str, Any]) -> dict[str, Any]:
     """Normalize v1 episode-row taxonomy fields to the report's stable names."""
 
@@ -234,7 +247,7 @@ def _merge_mechanism_fields(
     row: Mapping[str, Any], sidecar_index: Mapping[tuple[str, ...], Mapping[str, Any]]
 ) -> dict[str, Any]:
     merged = _normalize_mechanism_fields(row)
-    if all(field in merged for field in REQUIRED_MECHANISM_FIELDS):
+    if not _mechanism_validation_errors(merged):
         return merged
     for key in _sidecar_keys(row):
         sidecar = sidecar_index.get(key)
@@ -354,7 +367,7 @@ def _load_run_rows(
         row = _merge_mechanism_fields(raw, sidecar_index)
         row["source_run"] = run_name
         row["source_root"] = str(root)
-        missing_fields = [field for field in REQUIRED_MECHANISM_FIELDS if field not in row]
+        missing_fields = _mechanism_validation_errors(row)
         if row.get("mechanism_evidence_mode") not in TRACE_VERIFIED_EVIDENCE_MODES:
             missing_fields.append("mechanism_evidence_mode=trace_verified_source")
         if missing_fields:

--- a/tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py
+++ b/tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py
@@ -161,6 +161,34 @@ def test_missing_mechanism_label_blocks_f_c4ii_tables(tmp_path: Path) -> None:
     assert _read_csv(output / "f_c4ii_probe_predictive_dominance.csv") == []
 
 
+def test_empty_present_mechanism_label_blocks_f_c4ii_tables(tmp_path: Path) -> None:
+    """Present-but-empty taxonomy fields fail through the canonical validator."""
+    confirm = tmp_path / "confirm"
+    extended = tmp_path / "extended"
+    row = _base_row("prediction_planner", 1.0)
+    row["mechanism_label"] = ""
+    _write_rows(confirm, [row])
+    _write_rows(extended, [row])
+    output = tmp_path / "evidence"
+
+    summary = _MODULE.build_packet(
+        config_path=CONFIG,
+        confirm_root=confirm,
+        extended_root=extended,
+        job13175_packet=tmp_path / "packet.json",
+        output_dir=output,
+        generated_at="2026-07-03T00:00:00Z",
+    )
+
+    assert summary["status"] == "blocked_missing_trace_verified_mechanism_labels"
+    missing = json.loads((output / "missing_instrumentation.json").read_text(encoding="utf-8"))
+    assert missing["missing_row_count"] == 2
+    assert missing["missing_rows_sample"][0]["missing_fields"] == [
+        "failure_mechanism_taxonomy: unsupported mechanism_label: ''"
+    ]
+    assert _read_csv(output / "f_c4ii_probe_predictive_dominance.csv") == []
+
+
 def test_geometry_bucket_labels_are_rejected_as_substitutes(tmp_path: Path) -> None:
     """Geometry-only labels cannot satisfy the mechanism taxonomy contract."""
     confirm = tmp_path / "confirm"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: the issue #4206 h600 mechanism cross-cut builder now delegates per-row taxonomy-field validation to `validate_failure_mechanism_record` before accepting a row as mechanism-labeled.

Why now: issue #4409 identified that the post-#4402 presence-only gate could accept present-but-empty semantic fields such as an empty `mechanism_label`.

Claim boundary: validation-tooling only. This hardens fail-closed row acceptance and does not change benchmark values, rankings, taxonomy labels, manuscript claims, or campaign outputs.

Required validation: focused #4206 builder tests, canonical failure-mechanism validator tests, Ruff on touched validation/taxonomy paths.

Remaining blocker: no full benchmark campaign was run; Claude Code on `imech156-u` owns the full PR gate and merge authority after this PR opens.

## Contract delta

New schema fields: none.

New fail-closed blockers: rows with all required mechanism keys present but values rejected by `validate_failure_mechanism_record` are now blocked with a `failure_mechanism_taxonomy: ...` missing-field detail.

Compatibility impact: existing missing-field behavior remains; `mechanism_caveat` may still be empty for `observed_mechanism` because the canonical validator already encodes that schema rule. The builder still separately requires `mechanism_evidence_mode` to be trace-verified for this packet.

## Scope

Issue: #4409.

In scope:
- Delegate the #4206 cross-cut builder's per-row mechanism-field validation to `validate_failure_mechanism_record`.
- Preserve existing fail-closed behavior and add a regression test for present-but-empty labels.

Out of scope:
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No benchmark value, ranking, taxonomy-label, or manuscript-claim changes.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py` -> passed, 24 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_failure_mechanism_taxonomy.py` -> passed, 3 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py robot_sf/benchmark/failure_mechanism_taxonomy.py tests/benchmark/test_failure_mechanism_taxonomy.py` -> passed.

## State propagation

No separate issue comment or state-table update was performed because this task authorization sets `comment_issue_or_pr: false`; this PR body records the delivered slice and remaining blocker.

<details>
<summary>Governance appendix</summary>

- Live issue comments were checked before implementation and again before PR preparation; issue #4409 had no comments and no maintainer update after `2026-07-04T06:30:12Z`.
- Open PR dedupe found no open PR covering issue #4409 or this exact title/scope.
- Fragmentation guard did not block this progression slice: one related merged PR was found in the last 24h, below the two-PR guardrail threshold.
- No transient queue-routing state, target-host state, or packet lineage was encoded in tracked files.

</details>
