### PR TITLE
fix: #4403 use spawn context for codesign runner multiprocessing

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -2288,6 +2288,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     safety_wrapper: dict[str, Any] | None = None,
     cbf_safety_filter: dict[str, Any] | None = None,
     record_simulation_step_trace: bool = False,
+    multiprocessing_context: Any | None = None,
     workers: int = 1,
     resume: bool = True,
 ) -> dict[str, Any]:
@@ -2706,6 +2707,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         scenario_id=_scenario_id,
         executor_cls=ProcessPoolExecutor,
         as_completed_fn=as_completed,
+        multiprocessing_context=multiprocessing_context,
     )
     wrote = batch_execution.wrote
     episode_records = batch_execution.episode_records

--- a/robot_sf/benchmark/map_runner_batch_runner.py
+++ b/robot_sf/benchmark/map_runner_batch_runner.py
@@ -156,6 +156,7 @@ def _parallel_execute_map_jobs(  # noqa: PLR0913
     workers: int,
     executor_cls,
     as_completed_fn,
+    multiprocessing_context: Any | None = None,
 ) -> tuple[int, list[dict[str, Any]], list[dict[str, Any]], bool, int, int, dict[str, Any] | None]:
     """Execute map-runner jobs in parallel and append records in job order.
 
@@ -170,7 +171,10 @@ def _parallel_execute_map_jobs(  # noqa: PLR0913
     adapter_samples_seen = False
     runtime_algorithm_contract: dict[str, Any] | None = None
     results_by_idx: dict[int, dict[str, Any]] = {}
-    with executor_cls(max_workers=int(workers)) as ex:
+    executor_kwargs: dict[str, Any] = {"max_workers": int(workers)}
+    if multiprocessing_context is not None:
+        executor_kwargs["mp_context"] = multiprocessing_context
+    with executor_cls(**executor_kwargs) as ex:
         future_to_job: dict[Any, tuple[int, dict[str, Any], int]] = {}
         for idx, (scenario, seed) in enumerate(jobs, start=1):
             fut = ex.submit(run_map_job, (scenario, seed, fixed_params))
@@ -256,6 +260,7 @@ def execute_map_jobs(  # noqa: PLR0913
     scenario_id,
     executor_cls,
     as_completed_fn,
+    multiprocessing_context: Any | None = None,
 ) -> BatchExecutionResult:
     """Execute map-runner jobs and append validated JSONL records.
 
@@ -307,6 +312,7 @@ def execute_map_jobs(  # noqa: PLR0913
             workers=workers,
             executor_cls=executor_cls,
             as_completed_fn=as_completed_fn,
+            multiprocessing_context=multiprocessing_context,
         )
     return BatchExecutionResult(
         wrote=wrote,

--- a/scripts/benchmark/run_issue_4205_codesign_loop_campaign.py
+++ b/scripts/benchmark/run_issue_4205_codesign_loop_campaign.py
@@ -11,6 +11,7 @@ import argparse
 import csv
 import hashlib
 import json
+import multiprocessing
 import sys
 from collections import Counter, defaultdict
 from io import StringIO
@@ -453,6 +454,7 @@ def _run_arm(  # noqa: PLR0913
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Run one campaign arm and summarize its episode rows."""
     episode_jsonl_path = output_root / "episodes" / f"{arm_key}.jsonl"
+    multiprocessing_context = multiprocessing.get_context("spawn") if workers > 1 else None
     summary = run_map_batch(
         scenarios,
         episode_jsonl_path,
@@ -467,6 +469,7 @@ def _run_arm(  # noqa: PLR0913
         safety_wrapper=arm_runtime["safety_wrapper"],
         cbf_safety_filter=arm_runtime["cbf_safety_filter"],
         record_simulation_step_trace=True,
+        multiprocessing_context=multiprocessing_context,
         workers=workers,
         resume=resume,
     )

--- a/tests/benchmark/test_issue_4367_codesign_campaign_runner.py
+++ b/tests/benchmark/test_issue_4367_codesign_campaign_runner.py
@@ -222,6 +222,38 @@ def test_full_campaign_plan_uses_all_preregistered_scenarios_seeds_and_arms(
     assert calls[2]["cbf_safety_filter"]["enabled"] is True
 
 
+def test_parallel_campaign_uses_spawn_multiprocessing_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parallel co-design runs pass a spawn context into the map runner."""
+    contexts = []
+
+    def recording_runner(*args, **kwargs):
+        contexts.append(kwargs["multiprocessing_context"])
+        return _fake_run_map_batch(*args, **kwargs)
+
+    monkeypatch.setattr(_MODULE, "run_map_batch", recording_runner)
+    _MODULE.run_campaign(
+        _MODULE.parse_args(
+            [
+                "--config",
+                str(BENCHMARK_CONFIG),
+                "--hydration-manifest",
+                str(_hydration_manifest(tmp_path)),
+                "--output-root",
+                str(tmp_path / "campaign"),
+                "--smoke",
+                "--workers",
+                "2",
+            ]
+        )
+    )
+
+    assert len(contexts) == 3
+    assert {context.get_start_method() for context in contexts} == {"spawn"}
+
+
 def test_missing_hydration_manifest_fails_before_outputs(tmp_path: Path) -> None:
     """Campaign execution is fail-closed without the private hydration manifest."""
     output_root = tmp_path / "campaign"


### PR DESCRIPTION
Reviewer-critical summary
- What changed: the #4205 co-design campaign runner now passes a `multiprocessing.get_context("spawn")` context into the shared map-runner parallel executor when `--workers > 1`.
- Why now: issue #4403 records Slurm job 13291 failing on GPU nodes because the parallel path used forked subprocesses after CUDA initialization.
- Claim boundary: this PR fixes runner multiprocessing setup only; it does not change metrics, grids, planner behavior, or campaign interpretation.
- Required validation: focused regression test for spawn-context propagation and Ruff checks on touched runner/test files passed locally. Full PR gate is intentionally handed to Claude Code on `imech156-u` per the issue-queue handoff.
- Remaining blocker: a real `--smoke --workers 2` run needs the private #4205 hydration manifest/checkpoint on the execution host; no Slurm/GPU submission or full campaign was run in this PR.

Contract delta
- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: `run_map_batch` and `execute_map_jobs` accept an optional `multiprocessing_context` keyword. Existing callers keep default behavior. The #4205 campaign runner uses spawn only for parallel workers; serial runs still pass no context.

Issue
- Fixes #4403
- Scope: fix #4205 co-design runner fork/CUDA multiprocessing incompatibility and add a no-GPU regression test around parallel path setup.

Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_4367_codesign_campaign_runner.py` -> passed, 5 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/run_issue_4205_codesign_loop_campaign.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_batch_runner.py tests/benchmark/test_issue_4367_codesign_campaign_runner.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/benchmark/run_issue_4205_codesign_loop_campaign.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_batch_runner.py tests/benchmark/test_issue_4367_codesign_campaign_runner.py` -> passed, 4 files already formatted.
- `python -m py_compile scripts/benchmark/run_issue_4205_codesign_loop_campaign.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_batch_runner.py tests/benchmark/test_issue_4367_codesign_campaign_runner.py` -> passed.

Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No expansion of the co-design grid and no runner metric changes.

<details>
<summary>Governance and handoff notes</summary>

- Live issue check immediately before PR open: issue #4403 had no comments and no late maintainer guidance after start.
- PR dedupe check immediately before PR open: no open PR matched #4403 / fork+CUDA / multiprocessing / codesign runner scope.
- Fragmentation guard: one merged PR mentioning #4403 in the last 24h (#4406), below the two-PR stop threshold; this slice adds the nameable new capability of explicit spawn-context propagation for the #4205 runner parallel path.
- State propagation: no issue comment added because this run is not authorized to comment on issues/PRs. The PR body is the canonical handoff surface for this low-churn issue.
- Artifact policy: no durable benchmark artifacts produced; local validation output only.

</details>
