### PR TITLE
bench: pre-register issue #4400 current-roster release-gate campaign config

### DIFF
--- a/configs/benchmarks/release_gate_current_roster_social_proxemic_issue_4400.yaml
+++ b/configs/benchmarks/release_gate_current_roster_social_proxemic_issue_4400.yaml
@@ -1,0 +1,90 @@
+# Fresh current-roster release-gate campaign pre-registration for issue #4400.
+#
+# Plain-language summary: this config declares the next CPU campaign needed to
+# make current release-gate rows evaluable for clearance and personal-space
+# metrics. It does not submit the campaign or certify any release gate.
+name: release_gate_current_roster_social_proxemic_issue_4400
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+seed_policy:
+  mode: seed-set
+  seed_set: eval
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v1.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v1.json
+workers: 2
+horizon: 100
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+export_publication_bundle: true
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+release_gate_preregistration:
+  schema_version: release_gate_campaign_preregistration.v1
+  issue: 4400
+  purpose: >-
+    Re-run the issue #4313 current-roster release-gate evaluation on fresh rows
+    so min_clearance_m and proxemic_intrusion_rate gates can be evaluated.
+  claim_boundary: >-
+    Gate evaluability only. This config is not release certification, planner
+    ranking evidence, threshold approval, or paper-grade benchmark evidence.
+  retained_baseline_packet: docs/context/evidence/camera_ready_all_planners_2026-05-04/reports/campaign_summary.json
+  release_gate_spec: configs/benchmarks/release_gates/camera_ready_current_roster_gates.yaml
+  retained_summary_contract:
+    required_fields:
+      - min_clearance_m
+      - proxemic_intrusion_rate
+  metric_groups:
+    social_proxemic:
+      enabled: true
+      required_episode_metrics:
+        - min_clearance
+        - social_proxemic_intrusion_frac
+      retained_summary_fields:
+        - min_clearance_m
+        - proxemic_intrusion_rate
+  no_submit_boundary:
+    submit_in_this_pr: false
+    slurm_or_gpu_submission: false
+    campaign_execution: false
+    release_approval_claim: false
+planners:
+  - key: prediction_planner
+    algo: prediction_planner
+    algo_config: configs/algos/prediction_planner_camera_ready.yaml
+    benchmark_profile: experimental
+  - key: goal
+    algo: goal
+    benchmark_profile: baseline-safe
+  - key: social_force
+    algo: social_force
+    benchmark_profile: baseline-safe
+  - key: orca
+    algo: orca
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fallback
+  - key: ppo
+    algo: ppo
+    algo_config: configs/baselines/ppo_15m_grid_socnav.yaml
+    benchmark_profile: experimental
+    adapter_impact_eval: true
+  - key: socnav_sampling
+    algo: socnav_sampling
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fail-fast
+  - key: sacadrl
+    algo: sacadrl
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fallback
+  - key: socnav_bench
+    algo: socnav_bench
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fail-fast

--- a/docs/context/issue_4400_release_gate_current_roster_social_proxemic.md
+++ b/docs/context/issue_4400_release_gate_current_roster_social_proxemic.md
@@ -1,0 +1,36 @@
+# Issue #4400 Release-Gate Current-Roster Social-Proxemic Pre-Registration
+
+This note pre-registers the fresh current-roster release-gate campaign needed to
+make clearance and personal-space gates evaluable. It is a configuration
+contract only: no campaign has been submitted, no release gate has been
+recomputed, and no release approval claim is made.
+
+## Purpose
+
+Issue #4313 reported release-gate rows as `not_evaluable` for fields that were
+not present in the retained camera-ready packet. The issue #4331/#4334 reporting
+work preserves `min_clearance_m` and `proxemic_intrusion_rate` when fresh episode
+rows contain the source metrics. The issue #4400 config declares the fresh
+campaign that should produce those rows with the social-proxemic metric group
+explicitly enabled.
+
+## Registered Inputs
+
+- Campaign config:
+  `configs/benchmarks/release_gate_current_roster_social_proxemic_issue_4400.yaml`
+- Release-gate specification:
+  `configs/benchmarks/release_gates/camera_ready_current_roster_gates.yaml`
+- Retained baseline packet, intentionally unchanged:
+  `docs/context/evidence/camera_ready_all_planners_2026-05-04/reports/campaign_summary.json`
+- Scenario matrix:
+  `configs/scenarios/classic_interactions_francis2023.yaml`
+- Roster source:
+  the current 8-planner `camera_ready_all_planners` surface.
+
+## Claim Boundary
+
+The config supports gate evaluability only. It does not backfill the retained
+2026-05-04 packet, does not change release-gate thresholds, does not interpret a
+report, and does not certify a release. The next empirical action after merge is
+private-side campaign queueing followed by rerunning the issue #4313 evaluator
+on retrieved fresh rows.

--- a/tests/benchmark/test_release_gate_current_roster_config_issue_4400.py
+++ b/tests/benchmark/test_release_gate_current_roster_config_issue_4400.py
@@ -1,0 +1,90 @@
+"""Tests for the issue #4400 release-gate campaign pre-registration config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.camera_ready_campaign import load_campaign_config
+
+CONFIG_PATH = Path("configs/benchmarks/release_gate_current_roster_social_proxemic_issue_4400.yaml")
+BASELINE_CONFIG_PATH = Path("configs/benchmarks/camera_ready_all_planners.yaml")
+EXPECTED_RELEASE_GATE_FIELDS = {"min_clearance_m", "proxemic_intrusion_rate"}
+FORBIDDEN_TRANSIENT_FIELDS = {
+    "target_host",
+    "submit_host",
+    "queue_host",
+    "packet_lineage",
+    "packet_lineage_pointer",
+    "private_ops_state",
+}
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_issue_4400_campaign_config_loads_and_matches_current_roster() -> None:
+    """Config loader accepts the pre-registration and keeps the #4313 roster."""
+    cfg = load_campaign_config(CONFIG_PATH)
+    baseline = load_campaign_config(BASELINE_CONFIG_PATH)
+
+    assert cfg.name == "release_gate_current_roster_social_proxemic_issue_4400"
+    assert cfg.scenario_matrix_path == baseline.scenario_matrix_path
+    assert cfg.seed_policy.mode == baseline.seed_policy.mode
+    assert cfg.seed_policy.seed_set == baseline.seed_policy.seed_set
+    assert [planner.key for planner in cfg.planners] == [
+        "prediction_planner",
+        "goal",
+        "social_force",
+        "orca",
+        "ppo",
+        "socnav_sampling",
+        "sacadrl",
+        "socnav_bench",
+    ]
+    assert [planner.key for planner in cfg.planners] == [
+        planner.key for planner in baseline.planners
+    ]
+
+
+def test_issue_4400_config_declares_social_proxemic_retained_summary_contract() -> None:
+    """The release-gate footgun stays explicit instead of relying on defaults."""
+    payload = _load_yaml(CONFIG_PATH)
+    prereg = payload["release_gate_preregistration"]
+    social_proxemic = prereg["metric_groups"]["social_proxemic"]
+
+    assert social_proxemic["enabled"] is True
+    assert set(prereg["retained_summary_contract"]["required_fields"]) == (
+        EXPECTED_RELEASE_GATE_FIELDS
+    )
+    assert set(social_proxemic["retained_summary_fields"]) == EXPECTED_RELEASE_GATE_FIELDS
+    assert set(social_proxemic["required_episode_metrics"]) == {
+        "min_clearance",
+        "social_proxemic_intrusion_frac",
+    }
+    assert prereg["release_gate_spec"] == (
+        "configs/benchmarks/release_gates/camera_ready_current_roster_gates.yaml"
+    )
+    assert "certification" in prereg["claim_boundary"]
+
+
+def test_issue_4400_config_preserves_no_submit_boundary_without_transient_state() -> None:
+    """The tracked config is a reusable contract, not a private queue packet."""
+    payload = _load_yaml(CONFIG_PATH)
+    prereg = payload["release_gate_preregistration"]
+    boundary = prereg["no_submit_boundary"]
+
+    assert boundary == {
+        "submit_in_this_pr": False,
+        "slurm_or_gpu_submission": False,
+        "campaign_execution": False,
+        "release_approval_claim": False,
+    }
+    serialized = yaml.safe_dump(payload)
+    for field in FORBIDDEN_TRANSIENT_FIELDS:
+        assert field not in serialized


### PR DESCRIPTION
## Reviewer-critical summary
What changed: adds the issue #4400 current-roster release-gate campaign pre-registration config, a short context note, and a focused regression test pinning roster identity, social-proxemic opt-in, retained-summary fields, and the no-submit boundary.

Why now: issue #4313 release-gate rows remain `not_evaluable` for `min_clearance_m` and `proxemic_intrusion_rate` unless a fresh campaign is run with the social-proxemic metric group explicitly enabled.

Claim boundary: gate evaluability prerequisite only. This PR does not run a benchmark campaign, submit to Slurm/GPU, regenerate release-gate results, change thresholds, certify a release, rank planners, or edit paper/dissertation claims.

Required validation: config schema/identity checks and release-gate config validation against the existing evaluator contract; CPU only.

Remaining blocker: after merge, private-side orchestration still needs to queue the campaign and rerun the issue #4313 release-gate evaluator on retrieved fresh rows.

## Contract delta
New config: `configs/benchmarks/release_gate_current_roster_social_proxemic_issue_4400.yaml`.

New schema-like metadata block: `release_gate_preregistration` with `schema_version`, `issue`, `purpose`, `claim_boundary`, `retained_baseline_packet`, `release_gate_spec`, `retained_summary_contract.required_fields`, `metric_groups.social_proxemic`, and `no_submit_boundary`.

Required retained-summary fields: `min_clearance_m`, `proxemic_intrusion_rate`.

New fail-closed blockers pinned by tests: social-proxemic group must be explicitly enabled, source episode metrics must be declared, the 8-planner current roster must match `camera_ready_all_planners`, and transient host/queue/packet lineage fields must not appear in the tracked config.

Compatibility impact: no runtime code or evaluator threshold changes. Existing campaign loading still accepts the config; the extra preregistration block is metadata for reviewers/orchestrators and tests.

## Linked Issues
- Relates to #4400
- Relates to #4313
- Relates to #4331
- Relates to #4334
- Relates to #4166

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #4400 remains open for private-side campaign retrieval and evaluator rerun tracking
- Safe to review independently: yes
- Review dependency reason, any: this is a preregistration/config slice only

## What Changed
- Added `release_gate_current_roster_social_proxemic_issue_4400.yaml`, mirroring the current 8-planner `camera_ready_all_planners` roster and retained scenario/seed surface.
- Added `docs/context/issue_4400_release_gate_current_roster_social_proxemic.md` documenting purpose, inputs, retained baseline packet, gate spec, and no-certification boundary.
- Added `tests/benchmark/test_release_gate_current_roster_config_issue_4400.py` to pin roster identity, explicit social-proxemic metric group opt-in, retained summary field contract, no-submit boundary, and absence of transient queue state.

## Why Matters
- Added value: makes the release-gate evaluator prerequisite reviewable before private-side campaign dispatch.
- Expected impact: later fresh rows can populate `min_clearance_m` and `proxemic_intrusion_rate` for the existing release-gate evaluator instead of repeating `not_evaluable` due to missing fields.
- Why worth merging now: it closes the #4166/#4313 follow-through config gap without spending compute or changing thresholds.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for release-gate evaluability of current-roster rows.
- Comparator or baseline, applicable: retained 2026-05-04 `camera_ready_all_planners` packet is referenced but intentionally unchanged.
- Evidence tier: NA - config preregistration only; targeted validation listed below.
- Result classification: NA - no benchmark result produced.
- Decision stop rule, applicable: if fresh rows still omit `min_clearance_m` or `proxemic_intrusion_rate`, issue #4313 gates remain `not_evaluable` and the campaign/evaluator contract needs repair before interpretation.
- Parent issue, claim map, registry, context note, synthesis surface update: context note added for #4400.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no new analysis tool.

## Domain-Aware Approval
- Required PR: yes
- Domains reviewed: benchmark config contract, release-gate evaluator input contract.
- Status: approved waiver
- Approver/review source waiver: waiver per issue #4400 config/test/pre-registration scope; future campaign execution owns empirical validity.
- Validity checklist: no campaign run, no release-gate result interpretation, no threshold change, no fallback/degraded success claim.
- Target claim/hypothesis: gate evaluability prerequisite only.
- Comparator or split/evidence validity: valid only as a config identity check against `camera_ready_all_planners`; no empirical comparator result is produced.
- Fallback/degraded exclusions: no execution rows are classified in this PR.
- Claim boundary: config prerequisite, not certification.
- Implementation integrity vs experimental validity: tests cover config contract; empirical validity remains blocked on a future fresh campaign.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no campaign execution.
- Did intervention change command source, selected command, trajectory, route progress? NA - config preregistration only.
- Did scenario actually contain targeted failure mode? NA - no rows produced.
- Result route: continue after merge with private-side campaign queue.
- Follow-up question issue weak, negative, non-transfer results: #4313 remains the evaluator retrieval/interpretation lane.

## Next Empirical Action
- Rerun needed: yes, after merge, private-side campaign queue only.
- Extractor analysis tool needed: no new tool in this PR.
- Artifact missing unavailable: fresh current-roster rows with the two retained-summary fields.
- Stop / revise / continue decision: continue to campaign dispatch after review/merge.
- Proposed child issue existing follow-up: #4400 remains open for campaign dispatch and evaluator rerun tracking.

## Validation / Proof
- `uv run ruff check tests/benchmark/test_release_gate_current_roster_config_issue_4400.py` - pass.
- `uv run pytest tests/benchmark/test_release_gate_current_roster_config_issue_4400.py -q` - pass, 3 tests.
- `uv run pytest tests/benchmark/test_release_gates.py -q` - pass, 13 tests.
- `uv run python - <<'PY' ... load_campaign_config(...) + load_release_gate_spec(...)` - pass; printed `planner_count=8`, current roster keys, `social_proxemic_enabled=True`, `retained_summary_fields=min_clearance_m,proxemic_intrusion_rate`, and `release_gate_count=6`.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - run for clean-head freshness before PR open; see PR readiness artifact for final status.

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits were performed.

## Risks / Rollout
- Compatibility risks: extra preregistration metadata is ignored by the campaign loader; tests pin the intended consumer contract.
- Failure modes: future campaign rows may still omit source episode metrics if runtime metric emission changes; evaluator would remain `not_evaluable` rather than silently passing.
- Rollback fallback plan: remove the preregistration config/note/test if a different current-roster dispatch contract supersedes this slice.

## Docs / Provenance
- Updated docs: `docs/context/issue_4400_release_gate_current_roster_social_proxemic.md`.
- Relevant design provenance notes: issue #4400 body/comment; retained packet path recorded in config and note.
- Any assumptions need to preserved: the current 8-planner roster and scenario surface should match `camera_ready_all_planners` until a later explicit release-gate roster change.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; this run is not authorized to comment on issues/PRs.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark result claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no artifact/result produced.
- Registry or config index updated (yes/no/NA): NA - no index currently owns this preregistration config.
- Context index / memory note updated (yes/no/NA): context note added; index update deferred because #4400 is a narrow per-issue preregistration note, not a reusable entry point.
- Follow-up issue opened deferred propagation (yes/no/NA): no; #4400 remains open and covers the next action.
- Not applicable because: the PR body is the propagation surface for this run due `comment_issue_or_pr: false`; no additional issue comment is authorized.

## Follow-Up Issues
- Deferred work: private-side campaign dispatch and evaluator rerun on retrieved fresh rows; tracked by open issue #4400.
- Issues opened follow-up: none.

<details>
<summary>Review Notes</summary>

- Verify the new config does not encode transient host, queue, packet lineage, private ops, or submission state.
- Verify the PR does not claim release approval or benchmark evidence.
- Verify `min_clearance_m` and `proxemic_intrusion_rate` are only declared as required retained-summary fields for a future fresh campaign.

</details>
