### PR TITLE
bench: resolve fixed-scope launch preflight prerequisites (#4401)

### DIFF
--- a/configs/research/fidelity_sensitivity_v1.yaml
+++ b/configs/research/fidelity_sensitivity_v1.yaml
@@ -45,6 +45,7 @@ fixed_scope:
   planner_opt_ins:
     hybrid_rule_v0_minimal:
       allow_testing_algorithms: true
+      rationale: issue_4401_fixed_scope_prelaunch_opt_in
 
 ranking:
   metric: snqi

--- a/robot_sf/benchmark/fidelity_fixed_scope_preflight.py
+++ b/robot_sf/benchmark/fidelity_fixed_scope_preflight.py
@@ -36,6 +36,10 @@ from robot_sf.benchmark.fidelity_rank_stability import PRIMARY_METRIC_ZERO_VARIA
 from robot_sf.benchmark.fidelity_sensitivity import validate_fidelity_sensitivity_config
 
 SCHEMA_VERSION = "fidelity-fixed-scope-preflight.v1"
+RVO2_REMEDIATION = (
+    "install orca extra `uv sync --all-extras`; if stale local CMake build remains, "
+    "remove `third_party/python-rvo2/build` first, retry."
+)
 
 DECISION_READY = "preflight_ready"
 DECISION_BLOCKED = "blocked"
@@ -95,6 +99,17 @@ def build_fixed_scope_preflight(
         "runtime_rank_identifiability_recheck_required: measured primary-metric variance is "
         "re-validated post-run via robot_sf/benchmark/fidelity_rank_stability.py"
     ]
+    post_run_contract_specs = [
+        {
+            "id": "runtime_rank_identifiability_recheck",
+            "report": "fidelity_rank_stability_report.json",
+            "builder": "robot_sf/benchmark/fidelity_rank_stability.py",
+            "metric": primary_metric["metric"],
+            "threshold": "non_zero_variance_and_rank_identifiable",
+            "output_path": ("output/fidelity_sensitivity/<campaign>/rank_identifiability.json"),
+            "blocks_claims_when_failed": True,
+        }
+    ]
 
     decision = DECISION_BLOCKED if blockers else DECISION_READY
 
@@ -115,6 +130,7 @@ def build_fixed_scope_preflight(
         "blockers": blockers,
         "launch_prerequisites": launch_prerequisites,
         "post_run_contracts": post_run_contracts,
+        "post_run_contract_specs": post_run_contract_specs,
         "next_command_template": (
             "uv run python scripts/benchmark/run_fidelity_sensitivity_campaign.py --config "
             f"{config_path} --out output/fidelity_sensitivity/"
@@ -248,7 +264,9 @@ def _resolve_planner_groups(
                 )
             if readiness.canonical_name == "orca":
                 if not _rvo2_importable():
-                    launch_prerequisites.append(f"planner_requires_rvo2:{group_name}")
+                    launch_prerequisites.append(
+                        f"planner_requires_rvo2:{group_name} — {RVO2_REMEDIATION}"
+                    )
         resolution.append(record)
     return resolution
 
@@ -346,6 +364,7 @@ __all__ = [
     "EVIDENCE_STATUS",
     "PREFLIGHT_CLAIM_BOUNDARY",
     "REQUIRED_CLAIM_BOUNDARY_PHRASES",
+    "RVO2_REMEDIATION",
     "SCHEMA_VERSION",
     "build_fixed_scope_preflight",
     "write_fixed_scope_preflight",

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -180,9 +180,10 @@ def build_fixed_scope_run_plan(
     the preflight owns the launch/readiness gate, while this function turns the
     materialized scope into the concrete run cells the campaign runner would
     iterate. It runs no episode. ``executable`` is only ``True`` when the
-    preflight is ready and *all* launch prerequisites and blockers are cleared,
-    so the shipped config (which still lists rvo2/opt-in/runner-not-wired
-    prerequisites) yields a fail-closed, non-executable plan.
+    preflight is ready and *all* launch prerequisites and blockers are cleared.
+    The shipped config carries the fixed-scope hybrid-rule opt-in and structured
+    post-run rank-identifiability contract, while ORCA/rvo2 remains
+    runtime-checked.
 
     Args:
         config: Raw fidelity-sensitivity study config mapping.
@@ -239,6 +240,7 @@ def build_fixed_scope_run_plan(
         "blockers": blockers,
         "launch_prerequisites": launch_prerequisites,
         "post_run_contracts": preflight["post_run_contracts"],
+        "post_run_contract_specs": preflight["post_run_contract_specs"],
         "gate_reasons": gate_reasons,
         "run_cells": [asdict(cell) for cell in cells],
     }
@@ -1170,9 +1172,9 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "--require-launchable",
         action="store_true",
         help=(
-            "With --fixed-scope-plan-only, exit non-zero (fail closed) unless every launch "
-            "prerequisite is cleared. The bounded slice runner leaves ORCA/rvo2, hybrid opt-in, "
-            "and the post-run rank-identifiability recheck unmet, so this fails closed."
+            "With --fixed-scope-plan-only, exit non-zero (fail closed) if any launch "
+            "prerequisite remains. The fixed-scope packet records residual gates such "
+            "as ORCA/rvo2 runtime availability."
         ),
     )
     parser.add_argument(

--- a/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
+++ b/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
@@ -103,7 +103,24 @@ def test_shipped_config_plan_is_launchable_when_prerequisites_are_bound() -> Non
     assert plan["executable"] is True
     assert plan["launched"] is False
     assert plan["gate_reasons"] == []
+    hybrid_resolution = next(
+        record
+        for record in plan["planner_resolution"]
+        if record["planner_group"] == "hybrid_rule_v0_minimal"
+    )
+    assert hybrid_resolution["explicit_opt_in_satisfied"] is True
+    assert hybrid_resolution["requires_explicit_opt_in"] is False
     assert "runtime_rank_identifiability_recheck_required" in " ".join(plan["post_run_contracts"])
+    rank_contract = plan["post_run_contract_specs"][0]
+    assert rank_contract == {
+        "id": "runtime_rank_identifiability_recheck",
+        "report": "fidelity_rank_stability_report.json",
+        "builder": "robot_sf/benchmark/fidelity_rank_stability.py",
+        "metric": "snqi",
+        "threshold": "non_zero_variance_and_rank_identifiable",
+        "output_path": "output/fidelity_sensitivity/<campaign>/rank_identifiability.json",
+        "blocks_claims_when_failed": True,
+    }
 
 
 def test_shipped_config_plan_fails_closed_without_rvo2(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -114,7 +131,11 @@ def test_shipped_config_plan_fails_closed_without_rvo2(monkeypatch: pytest.Monke
     )
     plan = _plan()
     assert plan["executable"] is False
-    assert "planner_requires_rvo2:orca" in plan["gate_reasons"]
+    assert plan["gate_reasons"] == [
+        "planner_requires_rvo2:orca — install orca extra `uv sync --all-extras`; "
+        "if stale local CMake build remains, remove `third_party/python-rvo2/build` "
+        "first, retry."
+    ]
 
 
 def test_ensure_launchable_raises_when_gated(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Reviewer-critical summary

What changed: resolves the fixed-scope launch prerequisite preflight slice for #4401 by keeping the hybrid-rule planner explicitly opted in, emitting a machine-readable post-run rank-identifiability recheck contract, propagating that contract into fixed-scope run plans, and replacing the terse ORCA/rvo2 gate with an actionable remediation string.

Why now: maintainer accepted this prerequisite-closure slice so #3207 fixed-scope campaign planning can reach launchable preflight/plan mode without campaign execution.

Claim boundary: this PR is preflight/plan wiring only. It is not benchmark evidence, simulator-realism evidence, sim-to-real evidence, paper-facing planner-ranking evidence, or a rank-identifiability result.

Required validation: focused fixed-scope tests, lint/format, final readiness wrapper, and fixed-scope plan-only `--require-launchable` dry run.

Remaining blocker: the post-run rank-identifiability report must still be produced and pass after an actual campaign before any rank claim is promoted.

Contract delta

- Config: `fixed_scope.planner_opt_ins.hybrid_rule_v0_minimal.rationale` now records `issue_4401_fixed_scope_prelaunch_opt_in` beside the existing `allow_testing_algorithms: true` opt-in.
- Preflight JSON: adds backward-compatible sibling field `post_run_contract_specs` while preserving existing string-only `post_run_contracts`.
- New post-run contract spec: `runtime_rank_identifiability_recheck` requires `robot_sf/benchmark/fidelity_rank_stability.py` to produce `fidelity_rank_stability_report.json` / `output/fidelity_sensitivity/<campaign>/rank_identifiability.json` for metric `snqi`, with threshold `non_zero_variance_and_rank_identifiable`, and blocks claim promotion when failed.
- ORCA launch gate: `planner_requires_rvo2:orca` now includes remediation: install the ORCA extra with `uv sync --all-extras`; remove stale `third_party/python-rvo2/build` first if a stale local CMake build remains.
- Compatibility impact: existing `post_run_contracts` consumers remain compatible; consumers that want machine-readable post-run requirements can read `post_run_contract_specs`.

Issue: closes prerequisite slice for https://github.com/ll7/robot_sf_ll7/issues/4401

Validation

- PASS `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/fidelity_fixed_scope_preflight.py scripts/benchmark/run_fidelity_sensitivity_campaign.py tests/benchmark/test_fidelity_fixed_scope_run_plan.py`
- PASS `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/fidelity_fixed_scope_preflight.py scripts/benchmark/run_fidelity_sensitivity_campaign.py tests/benchmark/test_fidelity_fixed_scope_run_plan.py`
- PASS `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_fidelity_fixed_scope_run_plan.py -q` (`18 passed`)
- PASS `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/run_fidelity_sensitivity_campaign.py --fixed-scope-plan-only --plan-out output/issue_3207_fixed_scope_plan_issue_4401 --require-launchable` (`preflight_decision=preflight_ready executable=True launched=False run_cells=108`)
- PASS `PR_READY_PR_BODY_FILE=/pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`status=passed`, `tree_state=clean`, head `f9e08252a7e80dc33d29a8ac68df07d93a779dfe`).

Out of scope

No full benchmark campaign run. No Slurm/GPU submission. No paper/dissertation claim edits. No new planner arms. No threshold changes. No rank claims. No target-host or packet-lineage queue-routing state encoded in tracked files.

State propagation

No issue comment/state-table write was performed because this run is not authorized to comment on issues or PRs (`comment_issue_or_pr: false`). This PR body is the single state propagation surface for the delivered slice.

<details>
<summary>Appendix: artifact classification and assumptions</summary>

Generated `output/issue_3207_fixed_scope_plan_issue_4401/` is ignored validation output only and is not committed as durable evidence.

Assumption: the reversible machine-readable contract surface is a sibling `post_run_contract_specs` field rather than replacing the existing `post_run_contracts` list, preserving compatibility for current consumers.
</details>
