### PR TITLE
Issue #4418: require locator hash and structural match

### DIFF
--- a/scripts/validation/verify_manuscript_asserted_numbers.py
+++ b/scripts/validation/verify_manuscript_asserted_numbers.py
@@ -165,6 +165,15 @@ def _verify_locator_table_hash(
     return recorded_sha256 == computed_sha256, actual_with_digest
 
 
+def _locator_status_reason(hash_matches: bool, values_match: bool) -> tuple[str, str | None]:
+    """Return locator row status after requiring artifact and structural matches."""
+    if not hash_matches:
+        return MISMATCH, "locator table_sha256 differs from table artifact"
+    if not values_match:
+        return MISMATCH, "expected locator fields differ from source-of-record value"
+    return MATCH, None
+
+
 def _source_locator_fields(entry: dict[str, Any], entry_id: str) -> dict[str, Any]:
     """Return optional source-locator review metadata for report rows."""
     source_locator_status = entry.get("source_locator_status")
@@ -230,9 +239,10 @@ def _verify_entry(
     expected = entry["expected"]
     locator_hash = _verify_locator_table_hash(actual, repo_root=repo_root, entry_id=entry_id)
     if locator_hash is not None:
+        structural_actual = actual
         hash_matches, actual = locator_hash
-        status = MATCH if hash_matches else MISMATCH
-        reason = None if status == MATCH else "locator table_sha256 differs from table artifact"
+        values_match = _values_equal(expected, structural_actual, tolerance=tolerance)
+        status, reason = _locator_status_reason(hash_matches, values_match)
         return VerificationResult(
             id=entry_id,
             status=status,

--- a/tests/validation/test_verify_manuscript_asserted_numbers.py
+++ b/tests/validation/test_verify_manuscript_asserted_numbers.py
@@ -24,22 +24,34 @@ SPEC.loader.exec_module(_MODULE)
 
 
 def _write_locator_declaration(
-    tmp_path: Path, *, recorded_sha256: str, expected_sha256: str
+    tmp_path: Path,
+    *,
+    recorded_sha256: str | None,
+    expected_sha256: str | None,
+    recorded_table_path: str | None = None,
+    expected_table_path: str | None = None,
+    expected_artifact_id: str = "fixture_table",
 ) -> Path:
     table = tmp_path / "table.md"
     table.write_text(
         "| planner_key | success_mean |\n| --- | --- |\n| ppo | 1.0 |\n", encoding="utf-8"
     )
+    actual_locator = {
+        "artifact_id": "fixture_table",
+        "table_path": recorded_table_path or str(table),
+    }
+    if recorded_sha256 is not None:
+        actual_locator["table_sha256"] = recorded_sha256
+    expected_locator = {
+        "artifact_id": expected_artifact_id,
+        "table_path": expected_table_path or str(table),
+    }
+    if expected_sha256 is not None:
+        expected_locator["table_sha256"] = expected_sha256
     locator = tmp_path / "locator.yaml"
     locator.write_text(
         yaml.safe_dump(
-            {
-                "heatmap_per_family_means_locator": {
-                    "artifact_id": "fixture_table",
-                    "table_path": str(table),
-                    "table_sha256": recorded_sha256,
-                }
-            },
+            {"heatmap_per_family_means_locator": actual_locator},
             sort_keys=False,
         ),
         encoding="utf-8",
@@ -56,11 +68,7 @@ def _write_locator_declaration(
                     {
                         "id": "heatmap_per_family_means_source",
                         "manuscript_locator": "fixture / heatmap per-family means",
-                        "expected": {
-                            "artifact_id": "fixture_table",
-                            "table_path": str(table),
-                            "table_sha256": expected_sha256,
-                        },
+                        "expected": expected_locator,
                         "source": {
                             "path": str(locator),
                             "pointer": "heatmap_per_family_means_locator",
@@ -141,14 +149,14 @@ def test_mismatch_returns_failure_without_silent_source_fix(tmp_path: Path) -> N
     assert report["results"][0]["actual"] == pytest.approx(0.19045845847432735)
 
 
-def test_locator_table_sha256_validates_against_recorded_artifact(tmp_path: Path) -> None:
-    """Locator table rows hash the recorded artifact instead of comparing expected copies."""
+def test_locator_table_sha256_and_structural_fields_match(tmp_path: Path) -> None:
+    """Locator table rows match when artifact hash and structural locator fields match."""
     table_content = "| planner_key | success_mean |\n| --- | --- |\n| ppo | 1.0 |\n"
     table_sha256 = hashlib.sha256(table_content.encode("utf-8")).hexdigest()
     declarations = _write_locator_declaration(
         tmp_path,
         recorded_sha256=table_sha256,
-        expected_sha256="0" * 64,
+        expected_sha256=table_sha256,
     )
 
     exit_code = _MODULE.main(
@@ -166,8 +174,38 @@ def test_locator_table_sha256_validates_against_recorded_artifact(tmp_path: Path
     report = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
     result = report["results"][0]
     assert result["status"] == "match"
-    assert result["expected"]["table_sha256"] == "0" * 64
+    assert result["expected"]["table_sha256"] == table_sha256
     assert result["actual"]["table_sha256"] == table_sha256
+    assert result["actual"]["computed_table_sha256"] == table_sha256
+
+
+def test_locator_table_sha256_match_with_structural_drift_fails(tmp_path: Path) -> None:
+    """Locator table rows fail when non-hash locator fields drift from expected."""
+    table_content = "| planner_key | success_mean |\n| --- | --- |\n| ppo | 1.0 |\n"
+    table_sha256 = hashlib.sha256(table_content.encode("utf-8")).hexdigest()
+    declarations = _write_locator_declaration(
+        tmp_path,
+        recorded_sha256=table_sha256,
+        expected_sha256=table_sha256,
+        expected_artifact_id="stale_fixture_table",
+    )
+    exit_code = _MODULE.main(
+        [
+            "--declarations",
+            str(declarations),
+            "--report",
+            str(tmp_path / "report.md"),
+            "--json-output",
+            str(tmp_path / "report.json"),
+        ]
+    )
+    assert exit_code == 1
+    report = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    result = report["results"][0]
+    assert result["status"] == "mismatch"
+    assert result["reason"] == "expected locator fields differ from source-of-record value"
+    assert result["expected"]["artifact_id"] == "stale_fixture_table"
+    assert result["actual"]["artifact_id"] == "fixture_table"
     assert result["actual"]["computed_table_sha256"] == table_sha256
 
 
@@ -197,6 +235,49 @@ def test_locator_table_sha256_mismatch_fails(tmp_path: Path) -> None:
     assert result["reason"] == "locator table_sha256 differs from table artifact"
     assert result["actual"]["table_sha256"] == "0" * 64
     assert result["actual"]["computed_table_sha256"] != "0" * 64
+
+
+def test_locator_table_missing_artifact_fails_closed(tmp_path: Path) -> None:
+    """Locator rows with missing table artifacts fail closed."""
+    missing_table = tmp_path / "missing-table.md"
+    declarations = _write_locator_declaration(
+        tmp_path,
+        recorded_sha256="0" * 64,
+        expected_sha256="0" * 64,
+        recorded_table_path=str(missing_table),
+        expected_table_path=str(missing_table),
+    )
+    exit_code = _MODULE.main(
+        [
+            "--declarations",
+            str(declarations),
+            "--report",
+            str(tmp_path / "report.md"),
+            "--json-output",
+            str(tmp_path / "report.json"),
+        ]
+    )
+    assert exit_code == 2
+
+
+def test_locator_table_missing_hash_metadata_fails_closed(tmp_path: Path) -> None:
+    """Locator rows with partial table metadata fail closed."""
+    declarations = _write_locator_declaration(
+        tmp_path,
+        recorded_sha256=None,
+        expected_sha256=None,
+    )
+    exit_code = _MODULE.main(
+        [
+            "--declarations",
+            str(declarations),
+            "--report",
+            str(tmp_path / "report.md"),
+            "--json-output",
+            str(tmp_path / "report.json"),
+        ]
+    )
+    assert exit_code == 2
 
 
 def test_missing_source_key_fails_closed(tmp_path: Path) -> None:


### PR DESCRIPTION
Reviewer-critical summary

What changed: `_verify_entry` now requires locator rows to satisfy both the recorded table artifact SHA-256 check and the structural expected-vs-actual locator dict comparison. The report still includes `computed_table_sha256`, but the structural comparison is made against the unaugmented source locator dict so the reporting-only digest field does not create false mismatches.

Why now: issue #4418 is a verifier follow-up to PR #4416/#4405. PR #4416 correctly added artifact-byte hash validation, but locator rows returned early before checking structural locator fields.

Claim boundary: validation tooling only. This PR changes no manuscript numbers, benchmark values, dissertation/paper claims, locator schema fields, campaign configs, or generated reports.

Required validation: focused CPU-only verifier tests plus Ruff on the touched files.

Remaining blocker: none for this scoped verifier slice. Claude Code on `imech156-u` owns the full PR gate, improvement cycle, and merge authority after this PR opens.

Contract delta

New schema fields: none.

New fail-closed blockers: a locator row with a matching `table_sha256` artifact but drifted structural locator fields now reports `mismatch` instead of `match`.

Compatibility impact: existing valid locator rows must keep the declaration `expected` copy structurally synchronized with the source locator row. Hash mismatch, missing artifact, and partial `table_path`/`table_sha256` metadata remain fail-closed.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4418

Scope summary

- Added `_locator_status_reason` and changed `_verify_entry` so locator rows require both hash and structural matches.
- Preserved `computed_table_sha256` as report metadata while excluding it from structural dict equality.
- Added focused tests for hash+structure match, hash match with structural drift, hash mismatch, missing artifact, and missing table metadata.

Validation command results

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_verify_manuscript_asserted_numbers.py -q` -> pass, 8 tests passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format scripts/validation/verify_manuscript_asserted_numbers.py tests/validation/test_verify_manuscript_asserted_numbers.py` -> pass, 2 files left unchanged after final run.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/verify_manuscript_asserted_numbers.py tests/validation/test_verify_manuscript_asserted_numbers.py` -> pass.
- `git diff --check` -> pass.

Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no manuscript-number changes, no benchmark-value changes, no locator schema expansion, no campaign runs.

State propagation

No issue comment was added because this task authorization set `comment_issue_or_pr: false`; this PR body records the delivered slice and remaining-work state instead.

<details>
<summary>Governance and freshness checks</summary>

- Required issue thread read: `gh issue view 4418 --repo ll7/robot_sf_ll7 --json number,title,state,updatedAt,body,comments,url`; issue had no comments and `updatedAt=2026-07-04T07:13:25Z`.
- Immediate pre-PR freshness check: `gh issue view 4418 --repo ll7/robot_sf_ll7 --json number,title,state,updatedAt,comments,url`; issue still had no comments and no newer maintainer guidance.
- Duplicate PR check: no open PR matched issue #4418 or this exact locator hash/structural-drift scope.
- Fragmentation guard: not blocked. There were not two or more guardrail/checker/packet-refresh PRs merged for issue #4418 in the last 24 hours; this is a nameable new verifier capability slice.
- Forbidden actions honored: no compute submission, merge, release, delete, issue/PR comment, benchmark campaign, or Slurm/GPU work.

</details>
