### PR TITLE
Issue #3463: make topology arbitration weight explicit

### DIFF
--- a/configs/policy_search/candidates/topology_guided_hybrid_rule_v0.yaml
+++ b/configs/policy_search/candidates/topology_guided_hybrid_rule_v0.yaml
@@ -5,6 +5,7 @@ params:
   allow_testing_algorithms: true
   diagnostic_only: true
   claim_boundary: diagnostic_only
+  arbitration_weight: 0.35
   min_hypotheses: 2
   max_hypotheses: 2
   block_radius_cells: 3

--- a/robot_sf/planner/topology_guided_local_policy.py
+++ b/robot_sf/planner/topology_guided_local_policy.py
@@ -1385,7 +1385,7 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
                 "stall_window_steps": int(self.topology_config.stall_window_steps),
             }
             if self._last_decision.get("selected_source") == "topology_hypothesis":
-                influence = dict(self._last_topology_command_influence or {})
+                influence = deepcopy(self._last_topology_command_influence or {})
                 influence.update(
                     {
                         "source": "topology_hypothesis",

--- a/robot_sf/planner/topology_guided_local_policy.py
+++ b/robot_sf/planner/topology_guided_local_policy.py
@@ -18,6 +18,7 @@ from robot_sf.planner.hybrid_rule_local_planner import (
 )
 
 _EPS = 1e-9
+_DEFAULT_TOPOLOGY_ARBITRATION_WEIGHT = 0.35
 _TOPOLOGY_KEYS = {
     "diagnostic_only",
     "claim_boundary",
@@ -77,7 +78,7 @@ class TopologyGuidedLocalPolicyConfig:
     enabled: bool = True
     candidate_required: bool = False
     fallback_on_no_candidate: bool = True
-    arbitration_weight: float = 1.0
+    arbitration_weight: float = _DEFAULT_TOPOLOGY_ARBITRATION_WEIGHT
     min_route_progress_delta_m: float = 0.05
     stall_window_steps: int = 20
     min_hypotheses: int = 2
@@ -699,7 +700,9 @@ def build_topology_guided_local_policy_config(
         enabled=bool(raw.get("enabled", True)),
         candidate_required=bool(raw.get("candidate_required", False)),
         fallback_on_no_candidate=bool(raw.get("fallback_on_no_candidate", True)),
-        arbitration_weight=_bounded_unit_float_field(raw, "arbitration_weight", 1.0),
+        arbitration_weight=_bounded_unit_float_field(
+            raw, "arbitration_weight", _DEFAULT_TOPOLOGY_ARBITRATION_WEIGHT
+        ),
         min_route_progress_delta_m=_non_negative_float_field(
             raw, "min_route_progress_delta_m", 0.05
         ),
@@ -772,6 +775,7 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
         self._topology_status_counts: Counter[str] = Counter()
         self._selected_hypothesis_counts: Counter[str] = Counter()
         self._last_topology_decision: dict[str, Any] | None = None
+        self._last_topology_command_influence: dict[str, Any] | None = None
         self._recent_primary_selections: deque[tuple[str, float | None]] = deque(
             maxlen=max(int(self.topology_config.primary_route_reuse_penalty_cooldown_steps), 1)
         )
@@ -784,6 +788,7 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
         self._topology_status_counts = Counter()
         self._selected_hypothesis_counts = Counter()
         self._last_topology_decision = None
+        self._last_topology_command_influence = None
         self._recent_primary_selections = deque(
             maxlen=max(int(self.topology_config.primary_route_reuse_penalty_cooldown_steps), 1)
         )
@@ -1207,6 +1212,7 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
         Returns:
             list[HybridRuleCandidate]: De-duplicated local command candidates.
         """
+        self._last_topology_command_influence = None
         candidates = super()._generate_candidates(
             state,
             speed_cap,
@@ -1223,15 +1229,51 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
         if topology_candidate is not None:
             if candidates:
                 baseline = candidates[0]
+                command_limits = {
+                    "max_linear": float(speed_cap),
+                    "max_angular": float(self.config.max_angular_speed),
+                }
+                arbitration_weight = float(self.topology_config.arbitration_weight)
+                raw_blended_linear = (1.0 - arbitration_weight) * float(
+                    baseline.linear
+                ) + arbitration_weight * float(topology_candidate.linear)
+                raw_blended_angular = (1.0 - arbitration_weight) * float(
+                    baseline.angular
+                ) + arbitration_weight * float(topology_candidate.angular)
                 blended_linear, blended_angular = blend_topology_command(
                     (baseline.linear, baseline.angular),
                     (topology_candidate.linear, topology_candidate.angular),
-                    weight=float(self.topology_config.arbitration_weight),
-                    command_limits={
-                        "max_linear": float(speed_cap),
-                        "max_angular": float(self.config.max_angular_speed),
-                    },
+                    weight=arbitration_weight,
+                    command_limits=command_limits,
                 )
+                selected_hypothesis_id = None
+                if isinstance(route_corridor, dict):
+                    hypothesis = route_corridor.get("topology_hypothesis")
+                    if isinstance(hypothesis, dict):
+                        selected_hypothesis_id = hypothesis.get("hypothesis_id")
+                self._last_topology_command_influence = {
+                    "schema_version": "topology-command-influence.v1",
+                    "source": "topology_hypothesis",
+                    "arbitration_weight": arbitration_weight,
+                    "selected_hypothesis_id": selected_hypothesis_id,
+                    "baseline_command": [float(baseline.linear), float(baseline.angular)],
+                    "topology_command": [
+                        float(topology_candidate.linear),
+                        float(topology_candidate.angular),
+                    ],
+                    "raw_blended_command": [
+                        float(raw_blended_linear),
+                        float(raw_blended_angular),
+                    ],
+                    "projected_command": [float(blended_linear), float(blended_angular)],
+                    "command_limits": command_limits,
+                    "projection_applied": not (
+                        np.isclose(raw_blended_linear, blended_linear)
+                        and np.isclose(raw_blended_angular, blended_angular)
+                    ),
+                    "linear_delta_from_baseline": float(blended_linear - baseline.linear),
+                    "angular_delta_from_baseline": float(blended_angular - baseline.angular),
+                }
                 topology_candidate = HybridRuleCandidate(
                     blended_linear,
                     blended_angular,
@@ -1330,21 +1372,30 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
                 self._last_decision["topology_lane_status"] = "fallback_only"
                 self._last_decision["topology_fallback_status"] = status
                 self._last_decision["topology_fallback_reason"] = topology.get("reason")
-                self._last_decision["topology_guided_config"] = {
-                    "schema_version": self.topology_config.schema_version,
-                    "diagnostic_only": bool(self.topology_config.diagnostic_only),
-                    "claim_boundary": self.topology_config.claim_boundary,
-                    "candidate_required": bool(self.topology_config.candidate_required),
-                    "fallback_on_no_candidate": bool(self.topology_config.fallback_on_no_candidate),
-                }
+            self._last_decision["topology_guided_config"] = {
+                "schema_version": self.topology_config.schema_version,
+                "diagnostic_only": bool(self.topology_config.diagnostic_only),
+                "claim_boundary": self.topology_config.claim_boundary,
+                "candidate_required": bool(self.topology_config.candidate_required),
+                "fallback_on_no_candidate": bool(self.topology_config.fallback_on_no_candidate),
+                "arbitration_weight": float(self.topology_config.arbitration_weight),
+                "min_route_progress_delta_m": float(
+                    self.topology_config.min_route_progress_delta_m
+                ),
+                "stall_window_steps": int(self.topology_config.stall_window_steps),
+            }
             if self._last_decision.get("selected_source") == "topology_hypothesis":
-                self._last_decision["topology_command_influence"] = {
-                    "source": "topology_hypothesis",
-                    "reason": "selected_hypothesis_route_command_won_safety_scoring",
-                    "selected_hypothesis_id": topology.get("selected_hypothesis_id"),
-                    "selected_score": self._last_decision.get("selected_score"),
-                    "selected_terms": self._last_decision.get("selected_terms", {}),
-                }
+                influence = dict(self._last_topology_command_influence or {})
+                influence.update(
+                    {
+                        "source": "topology_hypothesis",
+                        "reason": "selected_hypothesis_route_command_won_safety_scoring",
+                        "selected_hypothesis_id": topology.get("selected_hypothesis_id"),
+                        "selected_score": self._last_decision.get("selected_score"),
+                        "selected_terms": self._last_decision.get("selected_terms", {}),
+                    }
+                )
+                self._last_decision["topology_command_influence"] = influence
         return command
 
     def diagnostics(self) -> dict[str, Any]:

--- a/tests/planner/test_topology_guided_local_policy.py
+++ b/tests/planner/test_topology_guided_local_policy.py
@@ -123,6 +123,13 @@ def test_nested_topology_guided_config_does_not_mutate_caller_mapping() -> None:
     }
 
 
+def test_topology_arbitration_default_is_explicit_issue_3463_value() -> None:
+    """Missing legacy config uses the explicit topology arbitration default."""
+    config = build_topology_guided_local_policy_config({})
+
+    assert config.arbitration_weight == pytest.approx(0.35)
+
+
 def test_blend_topology_command_respects_weight_and_limits() -> None:
     """Explicit arbitration should be finite, monotone, and clipped to command limits."""
     limits = {"max_linear": 1.0, "max_angular": 0.5}
@@ -150,6 +157,13 @@ def test_blend_topology_command_rejects_invalid_weight() -> None:
             weight=1.5,
             command_limits={"max_linear": 1.0, "max_angular": 1.0},
         )
+
+
+@pytest.mark.parametrize("weight", [-0.1, 1.1, float("nan")])
+def test_topology_arbitration_config_rejects_invalid_weight(weight: float) -> None:
+    """The config parser validates topology arbitration strength fail-closed."""
+    with pytest.raises(ValueError, match="arbitration_weight"):
+        _config(arbitration_weight=weight)
 
 
 def test_topology_guided_selector_finds_two_distinct_route_hypotheses() -> None:
@@ -360,7 +374,7 @@ def test_topology_guided_policy_records_selected_hypothesis_diagnostics() -> Non
     assert route_corridor["topology_guided_config"]["schema_version"] == (
         "topology_guided_hybrid_rule.v1"
     )
-    assert route_corridor["topology_guided_config"]["arbitration_weight"] == pytest.approx(1.0)
+    assert route_corridor["topology_guided_config"]["arbitration_weight"] == pytest.approx(0.35)
     assert len(route_corridor["topology_hypotheses"]) == 2
     assert all("score_components" in item for item in route_corridor["topology_hypotheses"])
     assert any(
@@ -406,6 +420,14 @@ def test_topology_hypothesis_can_select_local_command_source() -> None:
         last_decision["topology_command_influence"]["selected_hypothesis_id"]
         == last_decision["route_corridor"]["topology_hypothesis"]["hypothesis_id"]
     )
+    influence = last_decision["topology_command_influence"]
+    assert influence["schema_version"] == "topology-command-influence.v1"
+    assert influence["arbitration_weight"] == pytest.approx(0.35)
+    assert influence["projected_command"] == last_decision["selected_command"]
+    assert isinstance(influence["projection_applied"], bool)
+    assert influence["command_limits"]["max_linear"] >= abs(influence["projected_command"][0])
+    assert influence["command_limits"]["max_angular"] >= abs(influence["projected_command"][1])
+    assert last_decision["topology_guided_config"]["arbitration_weight"] == pytest.approx(0.35)
 
 
 def test_topology_hypothesis_command_blends_headings_across_pi_boundary() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Makes topology-guided command arbitration strength explicit and validated at the planner/config boundary. The topology-guided hybrid rule now defaults `arbitration_weight` to `0.35`, the shipped candidate YAML declares that value, successful/fallback step metadata carries the weight, and selected topology commands preserve realized blend/projection diagnostics (`topology-command-influence.v1`).

Why now: PR 4388 added topology availability diagnostics and PR 4411 added route-progress/churn metadata; the live #3463 plan still left Phase 3 command-arbitration strength as the remaining root-cause family. This is a progression slice, not a micro-guard: the new capability is explicit, testable topology command arbitration plus realized influence metadata.

Claim boundary: Diagnostic-only planner instrumentation/config behavior. This PR does not claim benchmark improvement or promotion readiness; #3465 remains the benchmark-facing enabled-vs-disabled gate.

Required validation: Focused topology-guided planner/config tests, benchmark metadata wiring tests, Ruff on touched Python files, YAML parse for the candidate config, and final PR readiness if the local gate can run.

Remaining blocker: No full benchmark campaign has run, and no Slurm/GPU work was submitted. #3465 still owns any benchmark-facing promotion claim.

## Contract delta

- New/defaulted config contract: `arbitration_weight` is an explicit finite unit interval field for topology-guided local policy config, defaulting to `0.35`.
- Config compatibility: legacy configs without `arbitration_weight` now receive the explicit diagnostic default instead of the previous implicit full-strength topology blend.
- Diagnostics: selected topology commands include `topology-command-influence.v1` with baseline command, raw blend, projected command, limits, projection flag, selected hypothesis, and arbitration weight.
- Metadata preservation: per-step `topology_guided_config` now records `arbitration_weight`, `min_route_progress_delta_m`, and `stall_window_steps` for successful and fallback topology rows.
- Fail-closed blockers: invalid `arbitration_weight` values outside `[0, 1]` or non-finite values raise `ValueError`; fallback/degraded benchmark rows are not reclassified as success.

## Linked Issues

- Relates to `#3463`
- Refs #3463

## Scope summary

In scope:
- Explicit topology arbitration default/config value.
- Realized blend/projection command metadata for selected topology commands.
- Focused tests for invalid weights, default weight, weight 0/1/intermediate helper behavior, command-limit projection, and metadata preservation.

Out of scope:
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No #3465 promotion claim or benchmark-success interpretation.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #3463 Phase 3 command-arbitration strength is now explicit, validated, and observable in diagnostics.
- Comparator or baseline, applicable: Existing `topology_guided_hybrid_rule_v0` implicit default behavior on `origin/main`.
- Evidence tier: NA - implementation/config instrumentation; no research-result evidence claim.
- Result classification: NA - no benchmark or research-result classification claimed.
- Decision stop rule, applicable: Stop at config/helper/metadata/test slice; #3465 remains required for benchmark-facing enabled-vs-disabled comparison.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3463 remains open; no claim map or benchmark report updated.
- New research/benchmark/metric/paper-facing analysis tool, any: none.

## Domain-Aware Approval

- Required PR: yes
- Domains reviewed: planner config contract, diagnostic metadata, fallback/degraded exclusion boundary.
- Status: waived
- Approver/review source waiver: maintainer-scoped issue contract waiver; diagnostic-only implementation slice, benchmark-facing validity remains deferred to #3465.
- Validity checklist:
- Target claim/hypothesis: #3463 command-arbitration strength becomes explicit/testable; no performance claim.
- Comparator or split/evidence validity: origin/main implicit arbitration default versus this explicit config/default and focused tests; no benchmark comparator interpreted.
- Fallback/degraded exclusions: fallback/degraded rows remain non-success; no benchmark rows are produced or promoted.
- Claim boundary: diagnostic-only implementation/config metadata.
- Implementation integrity vs experimental validity: local tests prove config validation, blend/projection helper behavior, and metadata preservation; experimental validity remains deferred to #3465.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, focused planner test selects a topology command and preserves `topology-command-influence.v1` metadata.
- Did intervention change command source, selected command, trajectory, route progress? command source and metadata path exercised locally; no trajectory or route-progress benchmark claim.
- Did scenario actually contain targeted failure mode? targeted unit fixture exercises topology command selection and metadata, not a full failure-mode scenario.
- Result route: continue to #3465 for benchmark-facing comparison.
- Follow-up question issue weak, negative, non-transfer results: #3465 remains the promotion gate.

## Next Empirical Action

- Rerun needed: yes, #3465 enabled-vs-disabled benchmark gate before any benchmark-facing claim.
- Extractor analysis tool needed: no for this slice.
- Artifact missing unavailable: no durable benchmark artifact produced here.
- Stop / revise / continue decision: continue diagnostically; no promotion claim.
- Proposed child issue existing follow-up: #3465.

## Validation / Proof

- `python -m py_compile robot_sf/planner/topology_guided_local_policy.py tests/planner/test_topology_guided_local_policy.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/planner/test_topology_guided_local_policy.py -q` - passed, 50 tests
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/planner/topology_guided_local_policy.py tests/planner/test_topology_guided_local_policy.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_utils.py -k "topology_guided_episode or build_policy_topology_guided" -q` - passed, 3 tests, 135 deselected
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python - <<'PY' ... yaml.safe_load(...) ... PY` - passed, confirmed `params.arbitration_weight == 0.35`
- `PR_READY_PR_BODY_FILE=/tmp/issue-3463-pr-body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; core suite 1811 passed, optional-extra lane 4831 passed / 3 skipped, freshness stamp recorded for `d0b72142bb7c33dc16f9ae0026445fca359be65e`

## Downstream Propagation

- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no; #3465 already exists.
- Not applicable because: this run is not authorized to comment on issues or PRs (`comment_issue_or_pr: false`), and this slice makes no benchmark, registry, claim-map, or paper-facing update. This PR body is the canonical handoff surface for the delivered slice and remaining #3465 blocker.

## Follow-Up Issues

- Deferred work: #3465 benchmark-facing enabled-vs-disabled promotion gate.
- Issues opened follow-up: none.

<details>
<summary>Appendix: governance and freshness notes</summary>

- Live issue was read through the REST API because `gh issue view 3463 --comments` fails on GitHub's deprecated Projects Classic GraphQL field (`repository.issue.projectCards`). REST issue/comments showed latest update `2026-07-04T07:08:41Z`, already incorporated.
- Open PR dedupe found no open PR covering #3463/topology arbitration scope.
- Fragmentation guard: two #3463 PRs merged in the last 24h (PR 4388, PR 4411), but this proceeds under the progression-slice exemption because it adds the new Phase 3 capability: explicit, testable command-arbitration strength and realized influence metadata.
- Generated artifacts are limited to local validation output/venv caches; none are committed.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a default arbitration weight for topology-guided planning, with updated configuration support and validation for out-of-range or non-finite values.
  * Expanded planning diagnostics to show how topology and baseline commands are blended, including command limits, selection details, and projection behavior.

* **Bug Fixes**
  * Updated topology-guided diagnostics to use the new arbitration default consistently across planning outputs and test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->