### PR TITLE
Issue #3300 run structured-pedestrian false-positive replay

### DIFF
--- a/configs/benchmarks/issue_3300_false_positive_nominal_smoke.yaml
+++ b/configs/benchmarks/issue_3300_false_positive_nominal_smoke.yaml
@@ -13,3 +13,4 @@ planners:
   - key: goal
     algo: goal
     benchmark_profile: baseline-safe
+    observation_mode: socnav_state

--- a/configs/benchmarks/issue_3300_false_positive_perturbed_smoke.yaml
+++ b/configs/benchmarks/issue_3300_false_positive_perturbed_smoke.yaml
@@ -14,3 +14,4 @@ planners:
   - key: goal
     algo: goal
     benchmark_profile: baseline-safe
+    observation_mode: socnav_state

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -3095,3 +3095,19 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/false_positive_replay_report.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/robustness_delta.csv
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence

--- a/docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/README.md
+++ b/docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/README.md
@@ -1,0 +1,76 @@
+# Issue #3300 Structured False-Positive Actor-Injection Replay Evidence
+
+This bundle records a bounded CPU-local executable replay for issue #3300 using a
+planner observation view that exposes structured pedestrian slots.
+
+## Claim Boundary
+
+- Evidence status: smoke/diagnostic evidence only.
+- Replay mode: executable camera-ready benchmark smoke, not trace-derived diagnostics.
+- Scope: one local CPU scenario, one planner, one seed.
+- Out of scope: full benchmark campaign, Slurm/GPU submission, hardware sensor realism, and
+  paper-facing robustness claims.
+
+## Inputs
+
+- Issue: <https://github.com/ll7/robot_sf_ll7/issues/3300>
+- Replay source: this PR branch head, based on
+  `25495f55b`.
+- Scenario matrix: `configs/scenarios/sets/issue_3300_false_positive_single_ped_smoke.yaml`
+- Scenario: `single_ped_crossing_orthogonal`
+- Planner: `goal`
+- Observation mode: `socnav_state`
+- Observation level: `tracked_agents_no_noise`
+- Seed: `0`
+- Nominal config: `configs/benchmarks/issue_3300_false_positive_nominal_smoke.yaml`
+- Perturbed config: `configs/benchmarks/issue_3300_false_positive_perturbed_smoke.yaml`
+- Perturbation profile:
+  `configs/benchmarks/observation_noise/issue_3300_false_positive_actor_injection_v1.yaml`
+
+## Commands
+
+```bash
+scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/run_camera_ready_benchmark.py \
+  --config configs/benchmarks/issue_3300_false_positive_nominal_smoke.yaml \
+  --mode run \
+  --output-root output/benchmarks/issue_3300_structured \
+  --campaign-id issue_3300_nominal_structured_ped_smoke_v5 \
+  --skip-publication-bundle
+
+scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/run_camera_ready_benchmark.py \
+  --config configs/benchmarks/issue_3300_false_positive_perturbed_smoke.yaml \
+  --mode run \
+  --output-root output/benchmarks/issue_3300_structured \
+  --campaign-id issue_3300_false_positive_structured_ped_smoke_v5 \
+  --skip-publication-bundle
+
+scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_false_positive_replay_report_issue_3300.py \
+  --nominal-jsonl output/benchmarks/issue_3300_structured/issue_3300_nominal_structured_ped_smoke_v5/runs/goal__differential_drive/episodes.jsonl \
+  --perturbed-jsonl output/benchmarks/issue_3300_structured/issue_3300_false_positive_structured_ped_smoke_v5/runs/goal__differential_drive/episodes.jsonl \
+  --output-json docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/summary.json \
+  --output-csv docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/robustness_delta.csv \
+  --output-md docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/false_positive_replay_report.md \
+  --replay-mode executable
+```
+
+## Result
+
+- Classification: `scenario_too_weak`.
+- Injection occurred: `pedestrians_added: 5`, `steps_with_noise: 5`.
+- Pairing: one nominal row matched one perturbed row; no unmatched rows.
+- Outcome delta: no selected-action or route-completion change under this one pinned smoke.
+- Fallback/degraded status: both campaign rows completed natively; no fallback/degraded rows were
+  counted as success evidence.
+
+## Artifacts
+
+- `summary.json`: structured issue #3300 replay report.
+- `robustness_delta.csv`: one-row nominal-vs-perturbed delta.
+- `false_positive_replay_report.md`: generated compact Markdown report.
+- Raw benchmark outputs remain under ignored `output/benchmarks/issue_3300_structured/`.
+
+## Residual Risk
+
+This closes the compatible structured-pedestrian replay gap, but it does not show a behavioral
+effect. A broader or stronger scenario/seed matrix is required before any robustness or perception
+claim can move beyond this smoke/diagnostic boundary.

--- a/docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/false_positive_replay_report.md
+++ b/docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/false_positive_replay_report.md
@@ -1,0 +1,31 @@
+# Issue #3300 False-Positive Actor-Injection Replay
+
+## Claim Boundary
+CPU-local observation-quality replay smoke for false-positive actor injection. Diagnostic only; not a full benchmark campaign, hardware sensor model, or paper-facing claim.
+
+## Classification
+- Label: `scenario_too_weak`
+- Reason: false-positive injection occurred but pinned smoke outcomes did not change
+- Replay mode: `executable`
+
+## Pairing
+- Paired rows: `1`
+- Unmatched nominal rows: `0`
+- Unmatched perturbed rows: `0`
+
+## Injection Summary
+- Pedestrians added: `5`
+- Steps with noise: `5`
+- Perturbation profiles: `issue_3300_false_positive_actor_injection_v1`
+- Perturbation hashes: `f3149ea5da06`
+
+## Episode Deltas
+
+| planner | scenario | seed | pedestrians added | changed fields |
+|---|---|---:|---:|---|
+| goal | single_ped_crossing_orthogonal | 0 | 5 | none |
+
+## Caveats
+- CPU replay smoke only.
+- False-positive effects are reported separately from other observation noise.
+- No full benchmark campaign, Slurm/GPU submission, or paper-facing claim.

--- a/docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/robustness_delta.csv
+++ b/docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/robustness_delta.csv
@@ -1,0 +1,2 @@
+planner_key,scenario_id,seed,pedestrians_added,steps_with_noise,nominal_actor_count,perturbed_actor_count,changed_fields,metric_delta,selected_action_nominal,selected_action_perturbed
+goal,single_ped_crossing_orthogonal,0,5,5,,,,"{""route_complete"": 0.0}",,

--- a/docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/summary.json
+++ b/docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/summary.json
@@ -1,0 +1,88 @@
+{
+  "claim_boundary": "CPU-local observation-quality replay smoke for false-positive actor injection. Diagnostic only; not a full benchmark campaign, hardware sensor model, or paper-facing claim.",
+  "classification": {
+    "label": "scenario_too_weak",
+    "reason": "false-positive injection occurred but pinned smoke outcomes did not change"
+  },
+  "injection_summary": {
+    "hashes": [
+      "f3149ea5da06"
+    ],
+    "pedestrians_added": 5,
+    "profiles": [
+      "issue_3300_false_positive_actor_injection_v1"
+    ],
+    "steps_with_noise": 5
+  },
+  "inputs": {
+    "nominal_jsonl": "output/benchmarks/issue_3300_structured/issue_3300_nominal_structured_ped_smoke_v5/runs/goal__differential_drive/episodes.jsonl",
+    "perturbed_jsonl": "output/benchmarks/issue_3300_structured/issue_3300_false_positive_structured_ped_smoke_v5/runs/goal__differential_drive/episodes.jsonl"
+  },
+  "issue": 3300,
+  "pairing": {
+    "pair_keys": [
+      "planner_identity",
+      "algo",
+      "scenario_id",
+      "seed",
+      "observation_mode",
+      "observation_level"
+    ],
+    "paired_rows": 1,
+    "unmatched_nominal_keys": [],
+    "unmatched_nominal_rows": 0,
+    "unmatched_perturbed_keys": [],
+    "unmatched_perturbed_rows": 0
+  },
+  "per_episode_deltas": [
+    {
+      "changed_fields": [],
+      "metric_delta": {
+        "route_complete": 0.0
+      },
+      "observed_actor_counts": {
+        "nominal": null,
+        "perturbed": null
+      },
+      "pedestrians_added": 5,
+      "planner_key": "goal",
+      "scenario_id": "single_ped_crossing_orthogonal",
+      "seed": 0,
+      "selected_action": {
+        "changed": false,
+        "nominal": null,
+        "perturbed": null
+      },
+      "steps_with_noise": 5
+    }
+  ],
+  "planner_rows": [
+    {
+      "algo": "goal",
+      "collision_delta": 0.0,
+      "noise_stats_sum": {
+        "heading_noise_applied": 0,
+        "lidar_values_dropped": 0,
+        "pedestrians_added": 5,
+        "pedestrians_removed": 0,
+        "pose_noise_applied": 0,
+        "steps_with_noise": 5
+      },
+      "nominal_collision_incidence": 0.0,
+      "nominal_success_incidence": 0.0,
+      "paired_episodes": 1,
+      "perturbation_hashes": [
+        "f3149ea5da06"
+      ],
+      "perturbation_profiles": [
+        "issue_3300_false_positive_actor_injection_v1"
+      ],
+      "perturbed_collision_incidence": 0.0,
+      "perturbed_success_incidence": 0.0,
+      "planner_key": "goal",
+      "success_delta": 0.0
+    }
+  ],
+  "replay_mode": "executable",
+  "schema_version": "false_positive_actor_injection_replay.v1"
+}

--- a/robot_sf/benchmark/observation_noise.py
+++ b/robot_sf/benchmark/observation_noise.py
@@ -282,6 +282,7 @@ def _apply_pedestrian_noise(
 ) -> None:
     pedestrians = obs.get("pedestrians")
     if not isinstance(pedestrians, dict):
+        _apply_flat_pedestrian_noise(obs, spec, rng, stats)
         return
     positions = np.asarray(pedestrians.get("positions", []), dtype=float).reshape(-1, 2)
     velocities = np.asarray(pedestrians.get("velocities", []), dtype=float).reshape(-1, 2)
@@ -320,6 +321,69 @@ def _apply_pedestrian_noise(
     pedestrians["velocities"] = velocities.tolist()
     pedestrians["radius"] = radii.tolist()
     pedestrians["count"] = int(positions.shape[0])
+
+
+def _apply_flat_pedestrian_noise(
+    obs: dict[str, Any],
+    spec: dict[str, Any],
+    rng: np.random.Generator,
+    stats: dict[str, int],
+) -> None:
+    """Apply pedestrian noise to flattened SocNav structured observations."""
+    if "pedestrians_positions" not in obs:
+        return
+    positions_buf = np.asarray(obs.get("pedestrians_positions", []), dtype=float).reshape(-1, 2)
+    if positions_buf.size == 0:
+        return
+    velocities_buf = np.asarray(obs.get("pedestrians_velocities", []), dtype=float).reshape(-1, 2)
+    if velocities_buf.shape[0] != positions_buf.shape[0]:
+        velocities_buf = np.zeros_like(positions_buf)
+    count_arr = np.asarray(
+        obs.get("pedestrians_count", [positions_buf.shape[0]]), dtype=float
+    ).reshape(-1)
+    active_count = int(count_arr[0]) if count_arr.size else int(positions_buf.shape[0])
+    active_count = max(0, min(active_count, positions_buf.shape[0]))
+    positions = positions_buf[:active_count].copy()
+    velocities = velocities_buf[:active_count].copy()
+
+    fn_prob = float(spec.get("pedestrian_false_negative_prob", 0.0))
+    if fn_prob > 0.0 and positions.shape[0] > 0:
+        keep = rng.random(positions.shape[0]) >= fn_prob
+        removed = int(positions.shape[0] - np.count_nonzero(keep))
+        positions = positions[keep]
+        velocities = velocities[keep]
+        stats["pedestrians_removed"] += removed
+
+    fp_prob = float(spec.get("pedestrian_false_positive_prob", 0.0))
+    if (
+        fp_prob > 0.0
+        and positions.shape[0] < positions_buf.shape[0]
+        and float(rng.random()) < fp_prob
+    ):
+        robot_pos = _as_xy_array(obs.get("robot_position"))
+        if robot_pos is None:
+            robot = obs.get("robot") if isinstance(obs.get("robot"), dict) else {}
+            robot_pos = _as_xy_array(robot.get("position", [0.0, 0.0]))
+        if robot_pos is None:
+            robot_pos = np.zeros(2, dtype=float)
+        angle = float(rng.uniform(0.0, 2.0 * np.pi))
+        radius_m = float(rng.uniform(0.0, spec.get("pedestrian_false_positive_radius_m", 4.0)))
+        fp_pos = robot_pos + np.array([np.cos(angle), np.sin(angle)], dtype=float) * radius_m
+        positions = np.vstack([positions, fp_pos.reshape(1, 2)])
+        velocities = np.vstack([velocities, np.zeros((1, 2), dtype=float)])
+        stats["pedestrians_added"] += 1
+
+    out_positions = np.array(positions_buf, copy=True)
+    out_velocities = np.array(velocities_buf, copy=True)
+    out_positions[:] = 0.0
+    out_velocities[:] = 0.0
+    out_count = min(positions.shape[0], out_positions.shape[0])
+    if out_count:
+        out_positions[:out_count] = positions[:out_count]
+        out_velocities[:out_count] = velocities[:out_count]
+    obs["pedestrians_positions"] = out_positions.tolist()
+    obs["pedestrians_velocities"] = out_velocities.tolist()
+    obs["pedestrians_count"] = np.array([float(out_count)], dtype=float).tolist()
 
 
 def merge_observation_noise_stats(

--- a/tests/benchmark/test_observation_noise.py
+++ b/tests/benchmark/test_observation_noise.py
@@ -101,6 +101,87 @@ def test_observation_noise_applies_map_runner_top_level_pose_keys() -> None:
     assert stats["steps_with_noise"] == 1
 
 
+def test_observation_noise_adds_false_positive_to_flat_socnav_pedestrians() -> None:
+    """Flattened SocNav observations still expose structured pedestrian slots."""
+    spec = normalize_observation_noise_spec(
+        {
+            "profile": "flat_false_positive",
+            "seed": 3300,
+            "pedestrian_false_positive_prob": 1.0,
+            "pedestrian_false_positive_radius_m": 3.0,
+            "pedestrian_false_positive_radius": 0.35,
+        }
+    )
+    obs = {
+        "robot_position": np.array([1.0, 2.0], dtype=np.float32),
+        "pedestrians_positions": np.array([[2.0, 2.0], [0.0, 0.0], [0.0, 0.0]], dtype=np.float32),
+        "pedestrians_velocities": np.zeros((3, 2), dtype=np.float32),
+        "pedestrians_radius": np.array([0.35], dtype=np.float32),
+        "pedestrians_count": np.array([1.0], dtype=np.float32),
+    }
+    rng_a = make_observation_noise_rng(spec, seed=0, scenario_id="s1")
+    rng_b = make_observation_noise_rng(spec, seed=0, scenario_id="s1")
+
+    noisy_a, stats_a = apply_observation_noise(obs, spec, rng_a)
+    noisy_b, stats_b = apply_observation_noise(obs, spec, rng_b)
+
+    assert stats_a["pedestrians_added"] == 1
+    assert stats_a["steps_with_noise"] == 1
+    assert noisy_a["pedestrians_count"] == [2.0]
+    assert noisy_a["pedestrians_positions"][0] == [2.0, 2.0]
+    assert noisy_a["pedestrians_positions"][1] != [0.0, 0.0]
+    assert noisy_a["pedestrians_positions"] == noisy_b["pedestrians_positions"]
+    assert stats_a == stats_b
+
+
+def test_flat_socnav_pedestrian_noise_ignores_missing_or_empty_slots() -> None:
+    """Flat pedestrian noise remains a no-op when no structured slots exist."""
+    spec = normalize_observation_noise_spec(
+        {"profile": "flat_empty", "pedestrian_false_positive_prob": 1.0}
+    )
+    rng = make_observation_noise_rng(spec, seed=0, scenario_id="s1")
+
+    noisy_missing, stats_missing = apply_observation_noise(
+        {"robot_position": [1.0, 2.0]}, spec, rng
+    )
+    noisy_empty, stats_empty = apply_observation_noise(
+        {"pedestrians_positions": np.empty((0, 2), dtype=np.float32)}, spec, rng
+    )
+
+    assert noisy_missing == {"robot_position": [1.0, 2.0]}
+    assert all(value == 0 for value in stats_missing.values())
+    assert np.asarray(noisy_empty["pedestrians_positions"]).size == 0
+    assert all(value == 0 for value in stats_empty.values())
+
+
+def test_flat_socnav_pedestrian_noise_removes_and_uses_robot_fallback() -> None:
+    """Flat pedestrian false-negative and false-positive branches update active slots."""
+    spec = normalize_observation_noise_spec(
+        {
+            "profile": "flat_remove_add",
+            "pedestrian_false_negative_prob": 1.0,
+            "pedestrian_false_positive_prob": 1.0,
+            "pedestrian_false_positive_radius_m": 0.0,
+        }
+    )
+    obs = {
+        "robot": {"position": [3.0, 4.0]},
+        "pedestrians_positions": np.array([[2.0, 2.0], [0.0, 0.0]], dtype=np.float32),
+        "pedestrians_velocities": np.array([[0.1, 0.0]], dtype=np.float32),
+        "pedestrians_count": np.array([1.0], dtype=np.float32),
+    }
+    rng = make_observation_noise_rng(spec, seed=0, scenario_id="s1")
+
+    noisy, stats = apply_observation_noise(obs, spec, rng)
+
+    assert stats["pedestrians_removed"] == 1
+    assert stats["pedestrians_added"] == 1
+    assert stats["steps_with_noise"] == 1
+    assert noisy["pedestrians_count"] == [1.0]
+    assert noisy["pedestrians_positions"][0] == [3.0, 4.0]
+    assert noisy["pedestrians_velocities"][0] == [0.0, 0.0]
+
+
 def test_observation_noise_validates_probability_ranges() -> None:
     """Probability-like noise fields should reject invalid values."""
     with pytest.raises(ValueError, match="lidar_dropout_prob"):


### PR DESCRIPTION
## Reviewer-critical summary

What changed: This PR makes the existing issue #3300 false-positive actor-injection smoke actually run against a structured pedestrian observation view. It sets the paired #3300 smoke configs to `socnav_state`, lets observation noise mutate flattened SocNav pedestrian slots (`pedestrians_positions`, `pedestrians_velocities`, `pedestrians_count`), and forwards `record_planner_decision_trace` through the camera-ready batch wrappers that blocked current main.

Why now: Issue #3300 remained open after PR #4390 and PR #4413 because the remaining gap was the compatible CPU replay, not another guardrail/checker slice.

Claim boundary: The replay is bounded smoke/diagnostic evidence only. It is not a full benchmark campaign, not a Slurm/GPU run, not a hardware sensor model, and not a paper/dissertation robustness claim.

Required validation: Focused observation-noise/report tests, bounded CPU nominal and false-positive replay, generated compact evidence, and PR readiness. The replay completed natively with no fallback/degraded rows; the result is `scenario_too_weak` because injection occurred but this one pinned smoke did not change predeclared outcomes.

Remaining blocker: No behavior effect was observed in the one-scenario/one-seed smoke. A stronger scenario/seed matrix is needed before any robustness claim can move beyond this smoke/diagnostic boundary.

## Contract delta

- New compatible replay config behavior: `configs/benchmarks/issue_3300_false_positive_{nominal,perturbed}_smoke.yaml` now request `observation_mode: socnav_state` for the `goal` planner smoke.
- Observation-noise compatibility: false-positive pedestrian injection now supports flattened SocNav structured observations with `pedestrians_positions`, `pedestrians_velocities`, and `pedestrians_count`, in addition to the existing nested `pedestrians` dict.
- Batch plumbing compatibility: `record_planner_decision_trace` now forwards from camera-ready campaign execution through `run_batch()`, `run_map_batch()`, map-worker fixed params, and worker execution to the existing map episode runner.
- New fail-closed blockers: none. The existing #3300 report still classifies no-injection runs as `blocked_unavailable`; this PR changes the compatible path so injection can occur.
- Compatibility impact: default behavior is unchanged because the new trace flag defaults to `False`, and flat pedestrian injection only activates for observations already carrying flattened structured pedestrian slots.

## Linked Issues

- Relates to #3300

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_utils.py::test_map_batch_plan_builds_worker_fixed_params tests/benchmark/test_camera_ready_campaign.py::test_run_campaign_writes_core_artifacts tests/benchmark/test_observation_noise.py tests/benchmark/test_observation_noise_envelope.py tests/benchmark/test_false_positive_actor_injection_replay.py -q` -> passed, 36 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/runner.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_batch_plan.py robot_sf/benchmark/map_runner_worker.py robot_sf/benchmark/observation_noise.py tests/benchmark/test_camera_ready_campaign.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_observation_noise.py tests/benchmark/test_false_positive_actor_injection_replay.py` -> passed.
- Config load/assertion check for both #3300 smoke configs -> passed; both resolve `goal goal socnav_state`.
- Nominal CPU smoke: `issue_3300_nominal_structured_ped_smoke_v5` -> exit 0, `benchmark_success`, 1 successful row, 0 fallback/degraded rows.
- Perturbed CPU smoke: `issue_3300_false_positive_structured_ped_smoke_v5` -> exit 0, `benchmark_success`, 1 successful row, 0 fallback/degraded rows.
- Report build: `scripts/benchmark/build_false_positive_replay_report_issue_3300.py ... --replay-mode executable` -> passed.
- Evidence assertion: `summary.json` has `classification.label == "scenario_too_weak"`, `pedestrians_added == 5`, `steps_with_noise == 5`.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue_3300_pr_body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed on clean head `419de2bab3cf99b23fa0775b3d6953b7b88d311d`.

Evidence bundle: `docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/`.

## Explicit Out Of Scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no hardware sensor-realism claim, and no fallback/degraded rows counted as success.

<details>
<summary>Appendix: template fields</summary>

## Stack / Dependency

- Base dependency: `origin/main`
- Required prior PRs: PR #4390 and PR #4413 are already merged context for this slice.
- Safe review independently: yes

## What Changed

- Added flattened SocNav pedestrian-slot support to the existing observation-noise false-positive injection path.
- Forwarded `record_planner_decision_trace` through the existing camera-ready/map batch execution layers.
- Updated #3300 paired smoke configs to request `socnav_state`.
- Added compact evidence showing executable replay injection occurred and classified as `scenario_too_weak`.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: issue #3300 compatible structured-pedestrian false-positive replay blocker.
- Comparator or baseline: nominal executable smoke vs perturbed false-positive actor-injection executable smoke.
- Evidence scope: targeted smoke / diagnostic probe.
- Replay result: diagnostic-only; `scenario_too_weak`.
- Decision stop rule: stop after bounded CPU replay and compact report; do not promote to benchmark or paper-facing claim.
- Parent issue / context surface update: evidence bundle in `docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/`.

## Domain-Aware Approval

Required PR: yes, because the PR carries smoke/diagnostic evidence.
Domains reviewed: false-positive actor-injection replay validity and fallback/degraded exclusion.
Status: waived for claim promotion; reviewer approval still required for merge.
Approval or blocker note: PR explicitly does not promote a benchmark, paper-facing, or robustness claim; it records smoke/diagnostic evidence only.
Target claim/hypothesis: issue #3300 compatible structured-pedestrian false-positive replay can execute and report injection.
Comparator or split/evidence validity: paired nominal vs perturbed one-scenario/one-seed CPU smoke, same planner/config except observation noise.
Fallback/degraded exclusions: both replay rows completed natively; no fallback/degraded rows counted.
Claim boundary: smoke/diagnostic evidence only.
Implementation integrity vs experimental validity: implementation enables compatible replay mechanics; evidence remains scenario-too-weak and not a behavior-effect claim.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, `pedestrians_added: 5`, `steps_with_noise: 5`.
- Did intervention change command source, selected command, trajectory, route progress? no selected-action or route-completion delta recorded in this one pinned smoke.
- Did scenario actually contain targeted failure mode? weak/inconclusive; injection occurred, but the scenario did not produce measurable behavioral change.
- Result route: continue only with a stronger follow-up scenario/seed matrix if issue #3300 needs observed behavior effect.

## Next Empirical Action

- Rerun needed: yes, only if the issue needs observed behavior effect beyond compatible replay execution.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: no; compact evidence is tracked, raw output remains ignored under `output/`.
- Stop / revise / continue decision: this PR stops at compatible replay closure and records residual risk.

## Risks / Rollout

- Compatibility risks: low; new flat observation support is additive and trace forwarding defaults off.
- Failure modes: flat observation arrays without spare padded pedestrian slots cannot add a false positive; stats stay zero and report remains fail-closed/blocked.
- Rollback fallback plan: revert this PR; prior fail-closed behavior remains documented in PR #4413.

## Docs / Provenance

- Updated docs: evidence bundle README, generated summary JSON, CSV, and Markdown report.
- Assumptions preserved: `socnav_state` is the effective compatible observation view for this bounded smoke; flattened runtime observation keys are the map-runner SocNav representation.

## Downstream Propagation

- Parent issue updated: no, task authorization has `comment_issue_or_pr: false`.
- Claim map / benchmark report updated: no, this is smoke/diagnostic evidence only.
- Leaderboard / artifact catalog updated: no.
- Registry or config index updated: no.
- Context index / memory note updated: no; evidence path is issue-specific and linked here.
- Follow-up issue opened deferred propagation: no, comment/issue mutation is not authorized.
- Not applicable because: this PR carries the durable compact evidence and PR body propagation surface; no issue comment was posted.

## Follow-Up Issues

Deferred work: none
Issues opened follow-up: none; no follow-up issue needed for this bounded smoke/diagnostic slice.

## Reviewer Notes

- Please verify that the claim boundary remains smoke/diagnostic only.
- Please verify that `record_planner_decision_trace` forwarding is purely additive and default-off.

</details>
