### PR TITLE
Issue #4430: fix topology command-influence diagnostic limits

### DIFF
--- a/robot_sf/planner/topology_guided_local_policy.py
+++ b/robot_sf/planner/topology_guided_local_policy.py
@@ -616,6 +616,51 @@ def _near_parity_threshold_metadata(config: TopologyGuidedLocalPolicyConfig) -> 
     }
 
 
+def _topology_guided_config_metadata(config: TopologyGuidedLocalPolicyConfig) -> dict[str, Any]:
+    """Return shared topology-guided config metadata for diagnostics."""
+    return {
+        "schema_version": config.schema_version,
+        "enabled": bool(config.enabled),
+        "diagnostic_only": bool(config.diagnostic_only),
+        "claim_boundary": config.claim_boundary,
+        "candidate_required": bool(config.candidate_required),
+        "fallback_on_no_candidate": bool(config.fallback_on_no_candidate),
+        "arbitration_weight": float(config.arbitration_weight),
+        "min_route_progress_delta_m": float(config.min_route_progress_delta_m),
+        "stall_window_steps": int(config.stall_window_steps),
+        "near_parity_thresholds": _near_parity_threshold_metadata(config),
+    }
+
+
+def _dynamic_window_limit_metadata(
+    bounds: tuple[float, float, float, float],
+) -> dict[str, float]:
+    """Return command limit metadata for one dynamic-window step."""
+    v_min, v_max, w_min, w_max = bounds
+    return {
+        "min_linear": float(v_min),
+        "max_linear": float(v_max),
+        "min_angular": float(w_min),
+        "max_angular": float(w_max),
+    }
+
+
+def _project_command_to_dynamic_window(
+    command: tuple[float, float],
+    bounds: tuple[float, float, float, float],
+) -> tuple[float, float]:
+    """Project a command onto dynamic-window bounds used for the topology command.
+
+    Returns:
+        tuple[float, float]: Projected linear and angular command.
+    """
+    v_min, v_max, w_min, w_max = bounds
+    return (
+        float(np.clip(float(command[0]), float(v_min), float(v_max))),
+        float(np.clip(float(command[1]), float(w_min), float(w_max))),
+    )
+
+
 def _topology_guided_payload(raw: dict[str, Any]) -> dict[str, Any]:
     """Return flat topology config with optional nested ``topology_guided`` overrides applied."""
     payload = dict(raw)
@@ -1103,18 +1148,9 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
             ),
         }
         route_corridor["topology_status"] = "ok"
-        route_corridor["topology_guided_config"] = {
-            "schema_version": self.topology_config.schema_version,
-            "enabled": bool(self.topology_config.enabled),
-            "diagnostic_only": bool(self.topology_config.diagnostic_only),
-            "claim_boundary": self.topology_config.claim_boundary,
-            "candidate_required": bool(self.topology_config.candidate_required),
-            "fallback_on_no_candidate": bool(self.topology_config.fallback_on_no_candidate),
-            "arbitration_weight": float(self.topology_config.arbitration_weight),
-            "min_route_progress_delta_m": float(self.topology_config.min_route_progress_delta_m),
-            "stall_window_steps": int(self.topology_config.stall_window_steps),
-            "near_parity_thresholds": _near_parity_threshold_metadata(self.topology_config),
-        }
+        route_corridor["topology_guided_config"] = _topology_guided_config_metadata(
+            self.topology_config
+        )
         return route_corridor
 
     def _candidate_source_priority(self, source: str) -> int:
@@ -1220,16 +1256,17 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
             corridor_subgoal=corridor_subgoal,
             goal_posterior=goal_posterior,
         )
+        dynamic_window_bounds = self._dynamic_window(state["current_speed"], speed_cap)
         topology_candidate = self._topology_hypothesis_candidate(
             state=state,
             speed_cap=speed_cap,
             route_corridor=route_corridor,
-            bounds=self._dynamic_window(state["current_speed"], speed_cap),
+            bounds=dynamic_window_bounds,
         )
         if topology_candidate is not None:
             if candidates:
                 baseline = candidates[0]
-                command_limits = {
+                behavior_command_limits = {
                     "max_linear": float(speed_cap),
                     "max_angular": float(self.config.max_angular_speed),
                 }
@@ -1244,7 +1281,11 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
                     (baseline.linear, baseline.angular),
                     (topology_candidate.linear, topology_candidate.angular),
                     weight=arbitration_weight,
-                    command_limits=command_limits,
+                    command_limits=behavior_command_limits,
+                )
+                projected_linear, projected_angular = _project_command_to_dynamic_window(
+                    (raw_blended_linear, raw_blended_angular),
+                    dynamic_window_bounds,
                 )
                 selected_hypothesis_id = None
                 if isinstance(route_corridor, dict):
@@ -1265,12 +1306,14 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
                         float(raw_blended_linear),
                         float(raw_blended_angular),
                     ],
-                    "projected_command": [float(blended_linear), float(blended_angular)],
-                    "command_limits": command_limits,
+                    "projected_command": [float(projected_linear), float(projected_angular)],
+                    "command_limits": _dynamic_window_limit_metadata(dynamic_window_bounds),
                     "projection_applied": not (
-                        np.isclose(raw_blended_linear, blended_linear)
-                        and np.isclose(raw_blended_angular, blended_angular)
+                        np.isclose(raw_blended_linear, projected_linear)
+                        and np.isclose(raw_blended_angular, projected_angular)
                     ),
+                    "behavior_command_limits": behavior_command_limits,
+                    "behavior_blended_command": [float(blended_linear), float(blended_angular)],
                     "linear_delta_from_baseline": float(blended_linear - baseline.linear),
                     "angular_delta_from_baseline": float(blended_angular - baseline.angular),
                 }
@@ -1368,22 +1411,13 @@ class TopologyGuidedHybridRulePlannerAdapter(HybridRuleLocalPlannerAdapter):
             return (0.0, 0.0)
         if self._last_decision:
             self._last_decision["topology_guided"] = topology
+            self._last_decision["topology_guided_config"] = _topology_guided_config_metadata(
+                self.topology_config
+            )
             if status != "ok":
                 self._last_decision["topology_lane_status"] = "fallback_only"
                 self._last_decision["topology_fallback_status"] = status
                 self._last_decision["topology_fallback_reason"] = topology.get("reason")
-            self._last_decision["topology_guided_config"] = {
-                "schema_version": self.topology_config.schema_version,
-                "diagnostic_only": bool(self.topology_config.diagnostic_only),
-                "claim_boundary": self.topology_config.claim_boundary,
-                "candidate_required": bool(self.topology_config.candidate_required),
-                "fallback_on_no_candidate": bool(self.topology_config.fallback_on_no_candidate),
-                "arbitration_weight": float(self.topology_config.arbitration_weight),
-                "min_route_progress_delta_m": float(
-                    self.topology_config.min_route_progress_delta_m
-                ),
-                "stall_window_steps": int(self.topology_config.stall_window_steps),
-            }
             if self._last_decision.get("selected_source") == "topology_hypothesis":
                 influence = deepcopy(self._last_topology_command_influence or {})
                 influence.update(

--- a/tests/planner/test_topology_guided_local_policy.py
+++ b/tests/planner/test_topology_guided_local_policy.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from robot_sf.planner.hybrid_rule_local_planner import (
+    HybridRuleCandidate,
+    HybridRuleLocalPlannerAdapter,
+)
 from robot_sf.planner.topology_guided_local_policy import (
     TopologyGuidedHybridRulePlannerAdapter,
     _apply_primary_route_reuse_penalty,
@@ -374,7 +378,11 @@ def test_topology_guided_policy_records_selected_hypothesis_diagnostics() -> Non
     assert route_corridor["topology_guided_config"]["schema_version"] == (
         "topology_guided_hybrid_rule.v1"
     )
+    assert route_corridor["topology_guided_config"]["enabled"] is True
     assert route_corridor["topology_guided_config"]["arbitration_weight"] == pytest.approx(0.35)
+    assert route_corridor["topology_guided_config"]["near_parity_thresholds"]["schema_version"] == (
+        "topology_near_parity_thresholds.v1"
+    )
     assert len(route_corridor["topology_hypotheses"]) == 2
     assert all("score_components" in item for item in route_corridor["topology_hypotheses"])
     assert any(
@@ -423,11 +431,76 @@ def test_topology_hypothesis_can_select_local_command_source() -> None:
     influence = last_decision["topology_command_influence"]
     assert influence["schema_version"] == "topology-command-influence.v1"
     assert influence["arbitration_weight"] == pytest.approx(0.35)
-    assert influence["projected_command"] == last_decision["selected_command"]
+    assert influence["behavior_blended_command"] == last_decision["selected_command"]
     assert isinstance(influence["projection_applied"], bool)
     assert influence["command_limits"]["max_linear"] >= abs(influence["projected_command"][0])
     assert influence["command_limits"]["max_angular"] >= abs(influence["projected_command"][1])
     assert last_decision["topology_guided_config"]["arbitration_weight"] == pytest.approx(0.35)
+    assert last_decision["topology_guided_config"]["enabled"] is True
+    assert last_decision["topology_guided_config"]["near_parity_thresholds"]["schema_version"] == (
+        "topology_near_parity_thresholds.v1"
+    )
+
+
+def test_topology_command_influence_uses_dynamic_window_limits(monkeypatch) -> None:
+    """Diagnostic projection uses per-step bounds without changing the blended command."""
+    planner = TopologyGuidedHybridRulePlannerAdapter(
+        _config(
+            arbitration_weight=1.0,
+            max_linear_accel=0.0,
+            max_angular_accel=0.0,
+            max_angular_speed=1.0,
+        )
+    )
+
+    def base_candidates(self, state, speed_cap, **kwargs):
+        return [
+            HybridRuleCandidate(
+                1.0,
+                0.5,
+                "corridor_subgoal",
+                ((float(self.config.rollout_horizon), 1.0, 0.5),),
+            )
+        ]
+
+    def topology_candidate(**kwargs):
+        return HybridRuleCandidate(
+            1.0,
+            0.5,
+            "topology_hypothesis",
+            ((float(planner.config.rollout_horizon), 1.0, 0.5),),
+        )
+
+    monkeypatch.setattr(HybridRuleLocalPlannerAdapter, "_generate_candidates", base_candidates)
+    monkeypatch.setattr(planner, "_topology_hypothesis_candidate", topology_candidate)
+
+    candidates = planner._generate_candidates(
+        {"current_speed": 0.0},
+        1.0,
+        route_corridor={"topology_hypothesis": {"hypothesis_id": "primary_route"}},
+    )
+
+    topology = next(
+        candidate for candidate in candidates if candidate.source == "topology_hypothesis"
+    )
+    influence = planner._last_topology_command_influence
+    assert topology.linear == pytest.approx(1.0)
+    assert topology.angular == pytest.approx(0.5)
+    assert influence is not None
+    assert influence["raw_blended_command"] == pytest.approx([1.0, 0.5])
+    assert influence["behavior_blended_command"] == pytest.approx([1.0, 0.5])
+    assert influence["projected_command"] == pytest.approx([0.0, 0.0])
+    assert influence["projection_applied"] is True
+    assert influence["command_limits"] == {
+        "min_linear": 0.0,
+        "max_linear": 0.0,
+        "min_angular": 0.0,
+        "max_angular": 0.0,
+    }
+    assert influence["behavior_command_limits"] == {
+        "max_linear": 1.0,
+        "max_angular": 1.0,
+    }
 
 
 def test_topology_hypothesis_command_blends_headings_across_pi_boundary() -> None:

--- a/tests/planner/test_topology_guided_local_policy.py
+++ b/tests/planner/test_topology_guided_local_policy.py
@@ -433,8 +433,22 @@ def test_topology_hypothesis_can_select_local_command_source() -> None:
     assert influence["arbitration_weight"] == pytest.approx(0.35)
     assert influence["behavior_blended_command"] == last_decision["selected_command"]
     assert isinstance(influence["projection_applied"], bool)
-    assert influence["command_limits"]["max_linear"] >= abs(influence["projected_command"][0])
-    assert influence["command_limits"]["max_angular"] >= abs(influence["projected_command"][1])
+    assert (
+        influence["command_limits"]["min_linear"]
+        <= influence["projected_command"][0]
+        <= influence["command_limits"]["max_linear"]
+    ), (
+        f"Linear command {influence['projected_command'][0]} out of dynamic-window bounds "
+        f"[{influence['command_limits']['min_linear']}, {influence['command_limits']['max_linear']}]"
+    )
+    assert (
+        influence["command_limits"]["min_angular"]
+        <= influence["projected_command"][1]
+        <= influence["command_limits"]["max_angular"]
+    ), (
+        f"Angular command {influence['projected_command'][1]} out of dynamic-window bounds "
+        f"[{influence['command_limits']['min_angular']}, {influence['command_limits']['max_angular']}]"
+    )
     assert last_decision["topology_guided_config"]["arbitration_weight"] == pytest.approx(0.35)
     assert last_decision["topology_guided_config"]["enabled"] is True
     assert last_decision["topology_guided_config"]["near_parity_thresholds"]["schema_version"] == (


### PR DESCRIPTION
## Reviewer-critical summary

What changed: fixes #4430 by making `topology-command-influence.v1` report `command_limits`, `projected_command`, and `projection_applied` from the actual per-step `_dynamic_window(...)` bounds used to construct the topology command, while preserving the existing final blended command behavior. It also centralizes the duplicated `topology_guided_config` metadata block so route-corridor and plan-level diagnostics carry the same fields.

Why now: #4430 is a fresh CodeRabbit follow-up from #4426. PR #4426 merged while this run was underway, so this branch was rebased onto current `origin/main` before opening.

Claim boundary: diagnostic fidelity and schema uniformity only. No planner behavior change, no benchmark evidence, no topology arbitration tuning, no paper/dissertation claim edits.

Required validation: focused topology-guided local-policy unit tests plus Ruff on touched planner/tests. Final readiness was run against `origin/main`.

Remaining blocker: #3465 remains the benchmark-facing enabled-vs-disabled gate; it should not consume `projection_applied` as ground truth until this diagnostic correction lands.

## Contract delta

- `topology-command-influence.v1` `command_limits` now describes dynamic-window bounds with `min_linear`, `max_linear`, `min_angular`, and `max_angular`.
- `topology-command-influence.v1` `projected_command` and `projection_applied` now reflect projection against those per-step dynamic-window bounds.
- The actual emitted topology candidate remains based on the existing behavior blend limits; `behavior_command_limits` and `behavior_blended_command` make that boundary explicit for diagnostics.
- `topology_guided_config` is now built by one helper and includes `enabled` plus `near_parity_thresholds` consistently on route-corridor and plan-level diagnostics.
- No new fail-closed blockers, no compatibility requirement for benchmark reports, and no schema migration beyond additive diagnostic fields.

## Issue

Refs #4430.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/planner/test_topology_guided_local_policy.py -q` - passed, 51 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/planner/topology_guided_local_policy.py tests/planner/test_topology_guided_local_policy.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/planner/topology_guided_local_policy.py tests/planner/test_topology_guided_local_policy.py` - passed.
- `git diff --check` - passed.
- `PR_READY_PR_BODY_FILE=<common-git-dir>/codex-agent-runs/active/issue-4430/pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed.

Out of scope and not run: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream propagation

No issue comment/state update was made because this run is not authorized to comment on issues or PRs (`comment_issue_or_pr: false`). This PR body is the durable propagation surface for the delivered slice.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: immediate pre-open checks found no open or closed same-scope PR for #4430. PR #4426 merged during this run and is now part of `origin/main`. This is a progression slice with a nameable new capability: dynamic-window-faithful topology command-influence diagnostics.

Late guidance check: issue #4430 was re-read immediately before push/open; there were no comments and no newer maintainer guidance after start timestamp `2026-07-04T10:22:27Z`.

Base assumption update: the issue originally pointed at code on PR #4426. After #4426 merged, this branch was rebased onto `origin/main` to avoid a stacked PR and keep the final diff to the #4430 slice.

Artifact classification: no benchmark artifacts, model artifacts, or generated outputs are committed. Local validation stamps/logs remain under ignored/local output or `.git/codex-agent-runs`.

</details>
