### PR TITLE
Issue #3574: add generated population trace labels

### DIFF
--- a/robot_sf/benchmark/heterogeneous_population_ablation.py
+++ b/robot_sf/benchmark/heterogeneous_population_ablation.py
@@ -18,6 +18,10 @@ from robot_sf.benchmark.heterogeneous_population_metrics import (
     assess_control_trace_readiness,
     per_archetype_metrics_from_control_trace,
 )
+from robot_sf.benchmark.pedestrian_control_trace import (
+    PEDESTRIAN_CONTROL_TRACE_LABELS_KEY,
+    build_generated_population_control_trace_labels,
+)
 from robot_sf.ped_npc.ped_archetypes import allocate_archetype_counts, assign_archetype_labels
 
 HETEROGENEOUS_POPULATION_ABLATION_SCHEMA = "heterogeneous_population_ablation_harness.v1"
@@ -115,11 +119,19 @@ def build_mean_matched_population_pair(
                 "composition": dict(sorted(composition_values.items())),
                 "counts": dict(sorted(heterogeneous_counts.items())),
                 "records": heterogeneous_records,
+                PEDESTRIAN_CONTROL_TRACE_LABELS_KEY: build_generated_population_control_trace_labels(
+                    heterogeneous_records,
+                    source="mean_matched_harness.heterogeneous_population",
+                ),
             },
             "mean_matched_homogeneous": {
                 "composition": {homogeneous_archetype: 1.0},
                 "counts": {homogeneous_archetype: population_size},
                 "records": homogeneous_records,
+                PEDESTRIAN_CONTROL_TRACE_LABELS_KEY: build_generated_population_control_trace_labels(
+                    homogeneous_records,
+                    source="mean_matched_harness.mean_matched_homogeneous_population",
+                ),
             },
         },
     }
@@ -236,6 +248,7 @@ def build_mean_matched_harness_manifest(
         "seed_rows": seed_rows,
         "trace_metric_keys": metric_keys,
         "expected_episode_output_keys": [
+            f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY}",
             "metadata.pedestrian_control_trace",
             "metadata.pedestrian_control_trace.pedestrians[].archetype",
             "metadata.pedestrian_control_trace.pedestrians[].steps[]",
@@ -425,6 +438,7 @@ def _manifest_scenario_rows(
                         ),
                         "population_composition_hash": composition_hash,
                         "expected_episode_output_keys": [
+                            f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY}",
                             "metadata.pedestrian_control_trace",
                             "metadata.pedestrian_control_trace.pedestrians[].archetype",
                             *[

--- a/robot_sf/benchmark/pedestrian_control_trace.py
+++ b/robot_sf/benchmark/pedestrian_control_trace.py
@@ -157,7 +157,7 @@ def build_pedestrian_control_trace(
 
     archetype_source = (
         f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY}"
-        if _trace_label_records(scenario)
+        if PEDESTRIAN_CONTROL_TRACE_LABELS_KEY in scenario
         else "scenario.single_pedestrians.metadata"
     )
     return {

--- a/robot_sf/benchmark/pedestrian_control_trace.py
+++ b/robot_sf/benchmark/pedestrian_control_trace.py
@@ -11,6 +11,8 @@ import numpy as np
 from robot_sf.benchmark.finite_checks import require_finite_array, require_finite_scalar
 
 PEDESTRIAN_CONTROL_TRACE_SCHEMA = "pedestrian-control-trace.v1"
+PEDESTRIAN_CONTROL_TRACE_LABELS_SCHEMA = "pedestrian-control-trace-labels.v1"
+PEDESTRIAN_CONTROL_TRACE_LABELS_KEY = "pedestrian_control_trace_labels"
 
 _ARCHETYPE_KEYS = (
     "archetype",
@@ -18,11 +20,15 @@ _ARCHETYPE_KEYS = (
     "behavior_archetype",
     "speed_archetype",
 )
+_OPTIONAL_LABEL_KEYS = ("desired_speed_factor", "response_law", "source")
 
 
 def has_pedestrian_control_trace_metadata(scenario: Mapping[str, Any]) -> bool:
     """Return true when a scenario carries explicit per-pedestrian archetype labels."""
 
+    if PEDESTRIAN_CONTROL_TRACE_LABELS_KEY in scenario:
+        trace_labels = _trace_label_records(scenario)
+        return any(_pedestrian_archetype(pedestrian) is not None for pedestrian in trace_labels)
     single_pedestrians = _single_pedestrians(scenario)
     return any(_pedestrian_archetype(pedestrian) is not None for pedestrian in single_pedestrians)
 
@@ -40,6 +46,8 @@ def attach_pedestrian_control_trace(
     Args:
         metadata: Mutable algorithm metadata payload receiving `pedestrian_control_trace`.
         scenario: Scenario dictionary containing optional `single_pedestrians` metadata.
+            Generated-population scenarios may instead provide
+            `pedestrian_control_trace_labels`.
         ped_positions: Simulator pedestrian positions shaped `(steps, pedestrians, 2)`.
         ped_forces: Optional simulator pedestrian force vectors with the same shape.
         dt: Episode time step in seconds.
@@ -138,24 +146,84 @@ def build_pedestrian_control_trace(
             pedestrian_steps.append(payload)
             previous_position = np.array(position, dtype=float, copy=True)
 
-        pedestrians.append(
-            {
-                "id": str(pedestrian_metadata.get("id") or f"pedestrian_{simulator_index}"),
-                "simulator_index": simulator_index,
-                "archetype": archetype,
-                "steps": pedestrian_steps,
-            }
-        )
+        pedestrian_payload: dict[str, Any] = {
+            "id": str(pedestrian_metadata.get("id") or f"pedestrian_{simulator_index}"),
+            "simulator_index": simulator_index,
+            "archetype": archetype,
+            "steps": pedestrian_steps,
+        }
+        _copy_optional_label_fields(pedestrian_payload, pedestrian_metadata)
+        pedestrians.append(pedestrian_payload)
 
+    archetype_source = (
+        f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY}"
+        if _trace_label_records(scenario)
+        else "scenario.single_pedestrians.metadata"
+    )
     return {
         "schema_version": PEDESTRIAN_CONTROL_TRACE_SCHEMA,
         "dt": dt_value,
         "source": "map_runner_episode",
-        "archetype_source": "scenario.single_pedestrians.metadata",
+        "archetype_source": archetype_source,
         "pedestrian_count": pedestrian_count,
         "step_count": step_count,
         "pedestrians": pedestrians,
     }
+
+
+def build_generated_population_control_trace_labels(
+    population_records: Sequence[Mapping[str, Any]],
+    *,
+    source: str,
+) -> list[dict[str, Any]]:
+    """Build stable simulator-index labels for generated heterogeneous populations.
+
+    Attach returned records to a benchmark scenario as
+    ``pedestrian_control_trace_labels`` before map-runner execution. The records
+    carry no metric values; they only label generated pedestrians so the
+    mean-matched harness can distinguish ready traces from exact missing fields.
+
+    Returns:
+        Stable label records sorted by simulator pedestrian index.
+    """
+
+    source_value = str(source).strip()
+    if not source_value:
+        raise ValueError("pedestrian_control_trace_labels source must be non-empty")
+    labels: list[dict[str, Any]] = []
+    seen_indices: set[int] = set()
+    for record_index, record in enumerate(population_records):
+        if not isinstance(record, Mapping):
+            raise ValueError(f"population_records[{record_index}] must be mapping")
+        try:
+            simulator_index = int(record["simulator_index"])
+        except KeyError as exc:
+            raise ValueError(f"population_records[{record_index}].simulator_index missing") from exc
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"population_records[{record_index}].simulator_index must be integer"
+            ) from exc
+        if simulator_index < 0:
+            raise ValueError(f"population_records[{record_index}].simulator_index must be >= 0")
+        if simulator_index in seen_indices:
+            raise ValueError(
+                f"pedestrian_control_trace_labels duplicate simulator_index {simulator_index}"
+            )
+        seen_indices.add(simulator_index)
+        archetype = _pedestrian_archetype(record)
+        if archetype is None:
+            raise ValueError(f"population_records[{record_index}] missing archetype")
+        label: dict[str, Any] = {
+            "schema_version": PEDESTRIAN_CONTROL_TRACE_LABELS_SCHEMA,
+            "id": str(record.get("id") or f"pedestrian_{simulator_index}"),
+            "simulator_index": simulator_index,
+            "archetype": archetype,
+            "source": source_value,
+        }
+        _copy_optional_label_fields(label, record)
+        labels.append(label)
+    labels.sort(key=lambda item: int(item["simulator_index"]))
+    return labels
 
 
 def _single_pedestrians(scenario: Mapping[str, Any]) -> list[Mapping[str, Any]]:
@@ -165,10 +233,30 @@ def _single_pedestrians(scenario: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     return [ped for ped in single_pedestrians if isinstance(ped, Mapping)]
 
 
+def _trace_label_records(scenario: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    if PEDESTRIAN_CONTROL_TRACE_LABELS_KEY not in scenario:
+        return []
+    labels = scenario.get(PEDESTRIAN_CONTROL_TRACE_LABELS_KEY)
+    if not isinstance(labels, Sequence) or isinstance(labels, str):
+        raise ValueError(f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY} must be sequence")
+    trace_labels: list[Mapping[str, Any]] = []
+    for label_index, label in enumerate(labels):
+        if not isinstance(label, Mapping):
+            raise ValueError(
+                f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY}[{label_index}] must be mapping"
+            )
+        trace_labels.append(label)
+    return trace_labels
+
+
 def _aligned_pedestrian_metadata(
     scenario: Mapping[str, Any],
     pedestrian_count: int,
 ) -> list[Mapping[str, Any]]:
+    if PEDESTRIAN_CONTROL_TRACE_LABELS_KEY in scenario:
+        trace_labels = _trace_label_records(scenario)
+        return _aligned_trace_label_metadata(trace_labels, pedestrian_count)
+
     single_pedestrians = _single_pedestrians(scenario)
     if pedestrian_count == 0:
         return []
@@ -182,6 +270,41 @@ def _aligned_pedestrian_metadata(
     metadata: list[Mapping[str, Any]] = [{} for _ in range(offset)]
     metadata.extend(single_pedestrians)
     return metadata
+
+
+def _aligned_trace_label_metadata(
+    trace_labels: Sequence[Mapping[str, Any]],
+    pedestrian_count: int,
+) -> list[Mapping[str, Any]]:
+    if pedestrian_count == 0:
+        return []
+    if len(trace_labels) != pedestrian_count:
+        raise ValueError(
+            "pedestrian_control_trace_labels length must equal simulator pedestrian count "
+            f"(got {len(trace_labels)}, expected {pedestrian_count})"
+        )
+    by_index: dict[int, Mapping[str, Any]] = {}
+    for label_index, label in enumerate(trace_labels):
+        try:
+            simulator_index = int(label["simulator_index"])
+        except KeyError as exc:
+            raise ValueError(
+                f"pedestrian_control_trace_labels[{label_index}].simulator_index missing"
+            ) from exc
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"pedestrian_control_trace_labels[{label_index}].simulator_index must be integer"
+            ) from exc
+        if not 0 <= simulator_index < pedestrian_count:
+            raise ValueError(
+                f"pedestrian_control_trace_labels[{label_index}].simulator_index out of range"
+            )
+        if simulator_index in by_index:
+            raise ValueError(
+                f"pedestrian_control_trace_labels duplicate simulator_index {simulator_index}"
+            )
+        by_index[simulator_index] = label
+    return [by_index[index] for index in range(pedestrian_count)]
 
 
 def _pedestrian_archetype(pedestrian: Mapping[str, Any]) -> str | None:
@@ -202,9 +325,18 @@ def _pedestrian_archetype(pedestrian: Mapping[str, Any]) -> str | None:
     return None
 
 
+def _copy_optional_label_fields(destination: dict[str, Any], source: Mapping[str, Any]) -> None:
+    for key in _OPTIONAL_LABEL_KEYS:
+        if key in source and source[key] is not None:
+            destination[key] = source[key]
+
+
 __all__ = [
+    "PEDESTRIAN_CONTROL_TRACE_LABELS_KEY",
+    "PEDESTRIAN_CONTROL_TRACE_LABELS_SCHEMA",
     "PEDESTRIAN_CONTROL_TRACE_SCHEMA",
     "attach_pedestrian_control_trace",
+    "build_generated_population_control_trace_labels",
     "build_pedestrian_control_trace",
     "has_pedestrian_control_trace_metadata",
 ]

--- a/tests/benchmark/test_heterogeneous_population_ablation.py
+++ b/tests/benchmark/test_heterogeneous_population_ablation.py
@@ -16,6 +16,7 @@ from robot_sf.benchmark.heterogeneous_population_ablation import (
     build_mean_matched_population_pair,
     build_per_archetype_ablation_report,
 )
+from robot_sf.benchmark.pedestrian_control_trace import PEDESTRIAN_CONTROL_TRACE_LABELS_KEY
 
 
 def _archetypes() -> dict[str, ArchetypePopulationSpec]:
@@ -73,6 +74,16 @@ def test_mean_matched_population_pair_preserves_weighted_speed_and_radius() -> N
     assert {record["archetype"] for record in homogeneous_records} == {"mean_matched_homogeneous"}
     assert {record["desired_speed_factor"] for record in homogeneous_records} == {1.025}
     assert {record["radius_m"] for record in homogeneous_records} == {0.3}
+    heterogeneous_labels = report["arms"]["heterogeneous"][PEDESTRIAN_CONTROL_TRACE_LABELS_KEY]
+    assert len(heterogeneous_labels) == 12
+    assert heterogeneous_labels[0]["simulator_index"] == 0
+    assert heterogeneous_labels[0]["source"] == "mean_matched_harness.heterogeneous_population"
+    assert {label["desired_speed_factor"] for label in heterogeneous_labels} == {0.7, 1.0, 1.4}
+    homogeneous_labels = report["arms"]["mean_matched_homogeneous"][
+        PEDESTRIAN_CONTROL_TRACE_LABELS_KEY
+    ]
+    assert {label["archetype"] for label in homogeneous_labels} == {"mean_matched_homogeneous"}
+    assert {label["desired_speed_factor"] for label in homogeneous_labels} == {1.025}
 
 
 def test_mean_matched_population_pair_rejects_unknown_archetype() -> None:
@@ -256,9 +267,15 @@ def test_mean_matched_harness_manifest_fails_closed_on_missing_control_trace_inp
     first_row = manifest["manifest_rows"][0]
     assert first_row["trace_readiness"]["ready"] is False
     assert (
+        f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY}"
+        in first_row["expected_episode_output_keys"]
+    )
+    assert (
         "metadata.pedestrian_control_trace.pedestrians[].steps[].clearance_m"
         in first_row["expected_episode_output_keys"]
     )
+    assert PEDESTRIAN_CONTROL_TRACE_LABELS_KEY in first_row["arm_population"]
+    assert len(first_row["arm_population"][PEDESTRIAN_CONTROL_TRACE_LABELS_KEY]) == 4
 
 
 def test_mean_matched_harness_manifest_accepts_fixture_control_traces() -> None:

--- a/tests/benchmark/test_pedestrian_control_trace.py
+++ b/tests/benchmark/test_pedestrian_control_trace.py
@@ -179,6 +179,9 @@ def test_generated_population_trace_labels_accept_zero_pedestrian_trace() -> Non
 
     assert trace["pedestrian_count"] == 0
     assert trace["pedestrians"] == []
+    # An explicit (empty) label feed must be attributed to the labels key, not to
+    # single_pedestrians metadata, even when it yields zero pedestrians.
+    assert trace["archetype_source"] == f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY}"
 
 
 @pytest.mark.parametrize(

--- a/tests/benchmark/test_pedestrian_control_trace.py
+++ b/tests/benchmark/test_pedestrian_control_trace.py
@@ -8,8 +8,10 @@ import numpy as np
 import pytest
 
 from robot_sf.benchmark.pedestrian_control_trace import (
+    PEDESTRIAN_CONTROL_TRACE_LABELS_KEY,
     PEDESTRIAN_CONTROL_TRACE_SCHEMA,
     attach_pedestrian_control_trace,
+    build_generated_population_control_trace_labels,
     build_pedestrian_control_trace,
     has_pedestrian_control_trace_metadata,
 )
@@ -68,6 +70,12 @@ def test_has_pedestrian_control_trace_metadata_detects_archetypes() -> None:
     """Episode integration should only attach the trace for explicitly labeled pedestrians."""
 
     assert has_pedestrian_control_trace_metadata(_scenario()) is True
+    assert (
+        has_pedestrian_control_trace_metadata(
+            {PEDESTRIAN_CONTROL_TRACE_LABELS_KEY: [{"simulator_index": 0, "archetype": "cautious"}]}
+        )
+        is True
+    )
     assert has_pedestrian_control_trace_metadata({"single_pedestrians": [{"id": "ped"}]}) is False
 
 
@@ -102,6 +110,187 @@ def test_attach_pedestrian_control_trace_skips_unlabeled_scenarios() -> None:
     )
 
     assert metadata == {"existing": True}
+
+
+def test_generated_population_trace_labels_feed_control_trace() -> None:
+    """Generated population records can label simulator-indexed trace rows."""
+
+    labels = build_generated_population_control_trace_labels(
+        [
+            {"simulator_index": 1, "archetype": "hurried", "desired_speed_factor": 1.4},
+            {"simulator_index": 0, "archetype": "cautious", "desired_speed_factor": 0.7},
+        ],
+        source="unit.generated_population",
+    )
+
+    trace = build_pedestrian_control_trace(
+        scenario={PEDESTRIAN_CONTROL_TRACE_LABELS_KEY: labels},
+        ped_positions=np.zeros((1, 2, 2), dtype=float),
+        ped_forces=None,
+        dt=0.1,
+    )
+
+    assert trace["archetype_source"] == f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY}"
+    assert trace["pedestrians"][0]["archetype"] == "cautious"
+    assert trace["pedestrians"][0]["desired_speed_factor"] == pytest.approx(0.7)
+    assert trace["pedestrians"][0]["source"] == "unit.generated_population"
+    assert trace["pedestrians"][1]["archetype"] == "hurried"
+    assert trace["pedestrians"][1]["desired_speed_factor"] == pytest.approx(1.4)
+
+
+def test_generated_population_trace_labels_fail_closed_on_count_mismatch() -> None:
+    """Incomplete generated-label feeds report the exact label contract mismatch."""
+
+    labels = build_generated_population_control_trace_labels(
+        [{"simulator_index": 0, "archetype": "cautious"}],
+        source="unit.generated_population",
+    )
+
+    with pytest.raises(ValueError, match="pedestrian_control_trace_labels length"):
+        build_pedestrian_control_trace(
+            scenario={PEDESTRIAN_CONTROL_TRACE_LABELS_KEY: labels},
+            ped_positions=np.zeros((1, 2, 2), dtype=float),
+            ped_forces=None,
+            dt=0.1,
+        )
+
+
+def test_explicit_empty_generated_population_trace_labels_fail_closed() -> None:
+    """An explicit generated-label field is a contract, not an unlabeled scenario."""
+
+    with pytest.raises(ValueError, match="pedestrian_control_trace_labels length"):
+        build_pedestrian_control_trace(
+            scenario={PEDESTRIAN_CONTROL_TRACE_LABELS_KEY: []},
+            ped_positions=np.zeros((1, 1, 2), dtype=float),
+            ped_forces=None,
+            dt=0.1,
+        )
+
+
+def test_generated_population_trace_labels_accept_zero_pedestrian_trace() -> None:
+    """Empty generated-label feeds are valid only when simulator has no pedestrians."""
+
+    trace = build_pedestrian_control_trace(
+        scenario={PEDESTRIAN_CONTROL_TRACE_LABELS_KEY: []},
+        ped_positions=np.zeros((1, 0, 2), dtype=float),
+        ped_forces=None,
+        dt=0.1,
+    )
+
+    assert trace["pedestrian_count"] == 0
+    assert trace["pedestrians"] == []
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"dt": 0.0}, "dt must be positive"),
+        ({"ped_positions": np.zeros((1, 2), dtype=float)}, "ped_positions must have shape"),
+        (
+            {
+                "ped_forces": np.zeros((2, 1, 2), dtype=float),
+            },
+            "ped_forces must match",
+        ),
+    ],
+)
+def test_build_pedestrian_control_trace_rejects_invalid_trace_shape(
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    """Trace shape and timing contracts fail before emitting partial labels."""
+
+    params = {
+        "scenario": {"single_pedestrians": [{"metadata": {"archetype": "cautious"}}]},
+        "ped_positions": np.zeros((1, 1, 2), dtype=float),
+        "ped_forces": None,
+        "dt": 0.1,
+    }
+    params.update(kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        build_pedestrian_control_trace(**params)
+
+
+def test_build_pedestrian_control_trace_rejects_excess_single_metadata() -> None:
+    """Single-pedestrian metadata cannot exceed simulator pedestrian count."""
+
+    with pytest.raises(ValueError, match="metadata exceeds simulator pedestrian count"):
+        build_pedestrian_control_trace(
+            scenario={
+                "single_pedestrians": [
+                    {"metadata": {"archetype": "cautious"}},
+                    {"metadata": {"archetype": "hurried"}},
+                ]
+            },
+            ped_positions=np.zeros((1, 1, 2), dtype=float),
+            ped_forces=None,
+            dt=0.1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("records", "source", "message"),
+    [
+        ([{"simulator_index": 0, "archetype": "cautious"}], "", "source must be non-empty"),
+        ([object()], "unit", "population_records\\[0\\] must be mapping"),
+        ([{"archetype": "cautious"}], "unit", "simulator_index missing"),
+        ([{"simulator_index": "bad", "archetype": "cautious"}], "unit", "must be integer"),
+        ([{"simulator_index": -1, "archetype": "cautious"}], "unit", "must be >= 0"),
+        (
+            [
+                {"simulator_index": 0, "archetype": "cautious"},
+                {"simulator_index": 0, "archetype": "hurried"},
+            ],
+            "unit",
+            "duplicate simulator_index 0",
+        ),
+        ([{"simulator_index": 0}], "unit", "missing archetype"),
+    ],
+)
+def test_build_generated_population_control_trace_labels_rejects_bad_records(
+    records: list[object],
+    source: str,
+    message: str,
+) -> None:
+    """Generated label construction fails closed on malformed population records."""
+
+    with pytest.raises(ValueError, match=message):
+        build_generated_population_control_trace_labels(records, source=source)
+
+
+@pytest.mark.parametrize(
+    ("labels", "pedestrian_count", "message"),
+    [
+        ("bad", 1, "must be sequence"),
+        ([object()], 1, "pedestrian_control_trace_labels\\[0\\] must be mapping"),
+        ([{"archetype": "cautious"}], 1, "simulator_index missing"),
+        ([{"simulator_index": "bad", "archetype": "cautious"}], 1, "must be integer"),
+        ([{"simulator_index": 2, "archetype": "cautious"}], 1, "out of range"),
+        (
+            [
+                {"simulator_index": 0, "archetype": "cautious"},
+                {"simulator_index": 0, "archetype": "hurried"},
+            ],
+            2,
+            "duplicate simulator_index 0",
+        ),
+    ],
+)
+def test_explicit_generated_population_trace_labels_reject_malformed_labels(
+    labels: object,
+    pedestrian_count: int,
+    message: str,
+) -> None:
+    """Scenario-provided generated labels report exact malformed label fields."""
+
+    with pytest.raises(ValueError, match=message):
+        build_pedestrian_control_trace(
+            scenario={PEDESTRIAN_CONTROL_TRACE_LABELS_KEY: labels},
+            ped_positions=np.zeros((1, pedestrian_count, 2), dtype=float),
+            ped_forces=None,
+            dt=0.1,
+        )
 
 
 @pytest.mark.parametrize("bad_value", [math.nan, math.inf])


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Adds a generated-population `pedestrian_control_trace_labels` feed for issue #3574. Mean-matched harness arms now carry stable simulator-indexed labels, and the episode control-trace logger can use those labels to emit per-pedestrian archetype, desired-speed-factor, response-law/source fields without relying on `single_pedestrians` metadata.

Why now: PR #4399 landed the dry-run mean-matched manifest harness, but the live issue thread still identifies per-pedestrian control-trace labels for generated heterogeneous populations as the next blocker before ablation runs can produce trace-backed inputs.

Claim boundary: trace-readiness unblock only. This PR does not run the ablation campaign, does not claim a heterogeneity effect, and does not change metric semantics beyond exact label-feed readiness/fail-closed diagnostics.

Required validation: focused control-trace and harness tests, manifest dry-run smoke, Ruff on touched modules, and final PR readiness from the committed head.

Remaining blocker: future benchmark episodes still need actual per-step metric fields such as `clearance_m` in `metadata.pedestrian_control_trace.pedestrians[].steps[]` before per-archetype effect analysis is ready.

## Contract delta

- New scenario input key: `pedestrian_control_trace_labels`, carrying stable per-pedestrian records sorted by `simulator_index`.
- New schema marker: `pedestrian-control-trace-labels.v1` on generated label records.
- Extended trace output: generated-label traces preserve `archetype`, `desired_speed_factor`, `response_law`, and `source` when present.
- Extended mean-matched manifest rows: each `arm_population` now carries `pedestrian_control_trace_labels`, and expected episode keys now include `scenario.pedestrian_control_trace_labels`.
- New fail-closed blockers: malformed/empty/generated label feeds fail with exact `pedestrian_control_trace_labels` count/index errors instead of silently downgrading to unlabeled traces.
- Compatibility impact: additive for existing `single_pedestrians` trace metadata; existing unlabeled scenarios still skip trace attachment.

## Linked issue

- Relates to #3574

## Scope summary

- Added generated-population label construction in `robot_sf/benchmark/pedestrian_control_trace.py`.
- Wired label records into `robot_sf/benchmark/heterogeneous_population_ablation.py` arm payloads and manifest expected keys.
- Added focused regression tests for generated-label trace attachment, fail-closed mismatch handling, and manifest row labels.

## Validation

- `uv run pytest tests/benchmark/test_pedestrian_control_trace.py tests/benchmark/test_heterogeneous_population_ablation.py -q` - passed, 43 tests.
- `uv run ruff check robot_sf/benchmark/pedestrian_control_trace.py robot_sf/benchmark/heterogeneous_population_ablation.py tests/benchmark/test_pedestrian_control_trace.py tests/benchmark/test_heterogeneous_population_ablation.py` - passed.
- `uv run ruff format --check robot_sf/benchmark/pedestrian_control_trace.py robot_sf/benchmark/heterogeneous_population_ablation.py tests/benchmark/test_pedestrian_control_trace.py tests/benchmark/test_heterogeneous_population_ablation.py` - passed.
- `uv run python scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py --config configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml --output output/issue_3574_manifest_smoke.json` - passed; manifest status remains `blocked_pending_control_trace`, rows `8`, first heterogeneous row carries `12` generated labels and declares `scenario.pedestrian_control_trace_labels`.
- `git diff --check` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3574/PR_BODY.md scripts/dev/pr_ready_check.sh` - passed; freshness stamp `output/validation/pr_ready/issue-3574-instrument-heterogeneous-population-traces-for-mean-matched-ablation.json`, head `cc4a6f66`, changed-line coverage 100% for touched executable files.

## Explicit out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No response-law mixture sweep.
- No three-planner rank sensitivity or benchmark-strength realism claim.

## State propagation

No separate issue comment was added because this run is not authorized to comment on issues or PRs. This PR body is the durable state surface for the delivered progression slice: generated-population trace labels are now wired; actual per-step metric-bearing benchmark traces and ablation runs remain deferred to #3574.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: PR #4399 was the only issue #3574 PR observed merged in the last 24 hours during preflight, so this progression slice is allowed. The nameable new capability is generated-population per-pedestrian trace label feed for the existing mean-matched harness.

Artifact policy: generated `output/issue_3574_manifest_smoke.json` is ignored validation output and is not committed as durable evidence.

Late guidance check: refreshed immediately before PR open; latest issue thread guidance remained the PR #4399 gate note, with no newer maintainer comments to incorporate.

</details>
