### PR TITLE
Issue #3300 pre-register stronger false-positive actor-injection matrix

### DIFF
--- a/configs/benchmarks/issue_3300_false_positive_stronger_nominal_smoke.yaml
+++ b/configs/benchmarks/issue_3300_false_positive_stronger_nominal_smoke.yaml
@@ -1,0 +1,17 @@
+name: issue_3300_false_positive_stronger_nominal_smoke
+scenario_matrix: configs/scenarios/sets/issue_3300_false_positive_stronger_structured_matrix.yaml
+workers: 1
+horizon: 20
+dt: 0.1
+record_forces: false
+record_planner_decision_trace: true
+resume: false
+export_publication_bundle: false
+seed_policy:
+  mode: fixed-list
+  seeds: [0, 3300]
+planners:
+  - key: goal
+    algo: goal
+    benchmark_profile: baseline-safe
+    observation_mode: socnav_state

--- a/configs/benchmarks/issue_3300_false_positive_stronger_perturbed_smoke.yaml
+++ b/configs/benchmarks/issue_3300_false_positive_stronger_perturbed_smoke.yaml
@@ -1,0 +1,18 @@
+name: issue_3300_false_positive_stronger_perturbed_smoke
+scenario_matrix: configs/scenarios/sets/issue_3300_false_positive_stronger_structured_matrix.yaml
+workers: 1
+horizon: 20
+dt: 0.1
+record_forces: false
+record_planner_decision_trace: true
+resume: false
+export_publication_bundle: false
+observation_noise: configs/benchmarks/observation_noise/issue_3300_false_positive_actor_injection_v1.yaml
+seed_policy:
+  mode: fixed-list
+  seeds: [0, 3300]
+planners:
+  - key: goal
+    algo: goal
+    benchmark_profile: baseline-safe
+    observation_mode: socnav_state

--- a/configs/scenarios/sets/issue_3300_false_positive_stronger_structured_matrix.yaml
+++ b/configs/scenarios/sets/issue_3300_false_positive_stronger_structured_matrix.yaml
@@ -1,0 +1,11 @@
+schema_version: robot_sf.scenario_matrix.v1
+includes:
+  - verified_simple_subset_v1.yaml
+  - ../single/issue_3233_near_field_observation_noise.yaml
+  - ../single/francis2023_intersection_wait.yaml
+select_scenarios:
+  - single_ped_crossing_orthogonal
+  - issue_3233_near_field_observation_noise
+  - francis2023_intersection_wait
+map_search_paths:
+  - ../../../maps/svg_maps

--- a/robot_sf/benchmark/false_positive_matrix_readiness.py
+++ b/robot_sf/benchmark/false_positive_matrix_readiness.py
@@ -117,7 +117,7 @@ def check_false_positive_matrix_readiness(
     )
     pedestrian_scenario_ids = [
         scenario_id
-        for scenario_id, scenario in zip(scenario_ids, nominal_scenarios, strict=False)
+        for scenario_id, scenario in zip(scenario_ids, nominal_scenarios, strict=True)
         if _scenario_has_pedestrians(scenario)
     ]
     injection_probe = _structured_injection_probe(
@@ -220,7 +220,11 @@ def _observation_noise_blockers(
 def _scenario_ids(scenarios: Sequence[Mapping[str, Any]]) -> list[str]:
     ids: list[str] = []
     for scenario in scenarios:
-        value = scenario.get("name") or scenario.get("scenario_id") or scenario.get("id")
+        value = scenario.get("name")
+        if value is None:
+            value = scenario.get("scenario_id")
+        if value is None:
+            value = scenario.get("id")
         ids.append(str(value) if value is not None else "unknown")
     return ids
 
@@ -255,6 +259,7 @@ def _scenario_has_pedestrians(scenario: Mapping[str, Any]) -> bool:
 def _structured_injection_probe(noise_spec: Mapping[str, Any] | None) -> dict[str, Any]:
     if noise_spec is None:
         return {"pedestrians_added": 0, "steps_with_noise": 0}
+    noise_dict = dict(noise_spec)
     observation = {
         "robot": {"position": [1.0, 2.0]},
         "pedestrians_positions": [[2.0, 2.0], [0.0, 0.0], [0.0, 0.0]],
@@ -262,11 +267,11 @@ def _structured_injection_probe(noise_spec: Mapping[str, Any] | None) -> dict[st
         "pedestrians_count": [1.0],
     }
     rng = make_observation_noise_rng(
-        noise_spec,
+        noise_dict,
         seed=0,
         scenario_id="issue_3300_matrix_readiness_probe",
     )
-    noisy, stats = apply_observation_noise(observation, noise_spec, rng)
+    noisy, stats = apply_observation_noise(observation, noise_dict, rng)
     return {
         "pedestrians_added": int(stats.get("pedestrians_added", 0)),
         "steps_with_noise": int(stats.get("steps_with_noise", 0)),

--- a/robot_sf/benchmark/false_positive_matrix_readiness.py
+++ b/robot_sf/benchmark/false_positive_matrix_readiness.py
@@ -1,0 +1,280 @@
+"""Readiness checks for issue #3300 stronger false-positive replay matrices.
+
+This module validates the predeclared matrix/config contract only. It does not run a
+benchmark campaign or promote robustness claims.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.camera_ready import load_campaign_config
+from robot_sf.benchmark.camera_ready._config import _load_campaign_scenarios
+from robot_sf.benchmark.observation_noise import (
+    apply_observation_noise,
+    make_observation_noise_rng,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from robot_sf.benchmark.camera_ready._config_types import CampaignConfig
+
+ISSUE = 3300
+SCHEMA_VERSION = "false_positive_actor_injection_matrix_readiness.v1"
+STATUS_READY = "ready"
+STATUS_BLOCKED = "blocked"
+REQUIRED_OBSERVATION_MODE = "socnav_state"
+REQUIRED_OBSERVATION_NOISE_PROFILE = "issue_3300_false_positive_actor_injection_v1"
+DEFAULT_MIN_SCENARIOS = 2
+DEFAULT_MIN_SEEDS = 2
+
+
+@dataclass(frozen=True)
+class FalsePositiveMatrixReadiness:
+    """Structured verdict for a paired #3300 false-positive replay matrix."""
+
+    status: str
+    blockers: list[str] = field(default_factory=list)
+    scenario_ids: list[str] = field(default_factory=list)
+    seeds: list[int] = field(default_factory=list)
+    planner_observation_modes: list[str] = field(default_factory=list)
+    pedestrian_scenario_ids: list[str] = field(default_factory=list)
+    injection_probe: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_ready(self) -> bool:
+        """Return True only when the paired matrix satisfies the #3300 contract."""
+
+        return self.status == STATUS_READY
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the readiness verdict for CLI and PR evidence.
+
+        Returns:
+            JSON-serializable readiness payload.
+        """
+
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "issue": ISSUE,
+            "status": self.status,
+            "blockers": list(self.blockers),
+            "scenario_ids": list(self.scenario_ids),
+            "seeds": list(self.seeds),
+            "planner_observation_modes": list(self.planner_observation_modes),
+            "pedestrian_scenario_ids": list(self.pedestrian_scenario_ids),
+            "injection_probe": dict(self.injection_probe),
+        }
+
+
+@dataclass(frozen=True)
+class _ReadinessInputs:
+    nominal_cfg: CampaignConfig
+    perturbed_cfg: CampaignConfig
+    nominal_ids: Sequence[str]
+    perturbed_ids: Sequence[str]
+    scenario_ids: Sequence[str]
+    seeds: Sequence[int]
+    planner_modes: Sequence[str]
+    pedestrian_scenario_ids: Sequence[str]
+    injection_probe: Mapping[str, Any]
+
+
+def check_false_positive_matrix_readiness(
+    nominal_config_path: Path,
+    perturbed_config_path: Path,
+    *,
+    min_scenarios: int = DEFAULT_MIN_SCENARIOS,
+    min_seeds: int = DEFAULT_MIN_SEEDS,
+) -> FalsePositiveMatrixReadiness:
+    """Validate paired #3300 stronger-matrix configs fail closed before replay.
+
+    Args:
+        nominal_config_path: Camera-ready nominal replay config.
+        perturbed_config_path: Camera-ready false-positive replay config.
+        min_scenarios: Minimum predeclared scenario count.
+        min_seeds: Minimum fixed seed count.
+
+    Returns:
+        Readiness verdict with actionable blockers when the matrix is too weak.
+    """
+
+    nominal_cfg = load_campaign_config(nominal_config_path)
+    perturbed_cfg = load_campaign_config(perturbed_config_path)
+
+    nominal_scenarios = _load_campaign_scenarios(nominal_cfg)
+    perturbed_scenarios = _load_campaign_scenarios(perturbed_cfg)
+    nominal_ids = _scenario_ids(nominal_scenarios)
+    perturbed_ids = _scenario_ids(perturbed_scenarios)
+    scenario_ids = nominal_ids
+
+    seeds = _fixed_seeds(perturbed_cfg)
+    planner_modes = sorted(
+        {mode for cfg in (nominal_cfg, perturbed_cfg) for mode in _planner_observation_modes(cfg)}
+    )
+    pedestrian_scenario_ids = [
+        scenario_id
+        for scenario_id, scenario in zip(scenario_ids, nominal_scenarios, strict=False)
+        if _scenario_has_pedestrians(scenario)
+    ]
+    injection_probe = _structured_injection_probe(
+        perturbed_cfg.observation_noise
+        if isinstance(perturbed_cfg.observation_noise, Mapping)
+        else None
+    )
+    blockers = _readiness_blockers(
+        _ReadinessInputs(
+            nominal_cfg=nominal_cfg,
+            perturbed_cfg=perturbed_cfg,
+            nominal_ids=nominal_ids,
+            perturbed_ids=perturbed_ids,
+            scenario_ids=scenario_ids,
+            seeds=seeds,
+            planner_modes=planner_modes,
+            pedestrian_scenario_ids=pedestrian_scenario_ids,
+            injection_probe=injection_probe,
+        ),
+        min_scenarios=min_scenarios,
+        min_seeds=min_seeds,
+    )
+
+    return FalsePositiveMatrixReadiness(
+        status=STATUS_BLOCKED if blockers else STATUS_READY,
+        blockers=blockers,
+        scenario_ids=scenario_ids,
+        seeds=seeds,
+        planner_observation_modes=planner_modes,
+        pedestrian_scenario_ids=pedestrian_scenario_ids,
+        injection_probe=injection_probe,
+    )
+
+
+def _readiness_blockers(
+    inputs: _ReadinessInputs,
+    *,
+    min_scenarios: int,
+    min_seeds: int,
+) -> list[str]:
+    """Return fail-closed blockers for the paired #3300 matrix."""
+
+    blockers: list[str] = []
+    if inputs.nominal_ids != inputs.perturbed_ids:
+        blockers.append(
+            "nominal and perturbed configs must resolve the same ordered scenario matrix"
+        )
+    if len(set(inputs.scenario_ids)) < min_scenarios:
+        blockers.append(
+            f"stronger matrix requires at least {min_scenarios} distinct scenarios; "
+            f"found {len(set(inputs.scenario_ids))}"
+        )
+    if _fixed_seeds(inputs.nominal_cfg) != list(inputs.seeds):
+        blockers.append("nominal and perturbed configs must use the same fixed seed list")
+    if len(set(inputs.seeds)) < min_seeds:
+        blockers.append(
+            f"stronger matrix requires at least {min_seeds} distinct fixed seeds; "
+            f"found {len(set(inputs.seeds))}"
+        )
+    blockers.extend(_planner_mode_blockers(inputs.planner_modes))
+    blockers.extend(_observation_noise_blockers(inputs.nominal_cfg, inputs.perturbed_cfg))
+    if not inputs.pedestrian_scenario_ids:
+        blockers.append("matrix must include at least one pedestrian-bearing scenario")
+    if int(inputs.injection_probe.get("pedestrians_added", 0)) <= 0:
+        blockers.append(
+            "false-positive profile must add at least one actor to a structured "
+            "pedestrian observation probe"
+        )
+    return blockers
+
+
+def _planner_mode_blockers(planner_modes: Sequence[str]) -> list[str]:
+    non_structured = [mode for mode in planner_modes if mode != REQUIRED_OBSERVATION_MODE]
+    if not non_structured:
+        return []
+    return [
+        "all #3300 false-positive matrix planners must use "
+        f"{REQUIRED_OBSERVATION_MODE}; found {non_structured}"
+    ]
+
+
+def _observation_noise_blockers(
+    nominal_cfg: CampaignConfig,
+    perturbed_cfg: CampaignConfig,
+) -> list[str]:
+    blockers: list[str] = []
+    profile = None
+    if isinstance(perturbed_cfg.observation_noise, Mapping):
+        profile = perturbed_cfg.observation_noise.get("profile")
+    if profile != REQUIRED_OBSERVATION_NOISE_PROFILE:
+        blockers.append(
+            "perturbed config must reference the issue #3300 false-positive "
+            f"profile {REQUIRED_OBSERVATION_NOISE_PROFILE}"
+        )
+    if nominal_cfg.observation_noise is not None:
+        blockers.append("nominal config must leave observation_noise disabled")
+    return blockers
+
+
+def _scenario_ids(scenarios: Sequence[Mapping[str, Any]]) -> list[str]:
+    ids: list[str] = []
+    for scenario in scenarios:
+        value = scenario.get("name") or scenario.get("scenario_id") or scenario.get("id")
+        ids.append(str(value) if value is not None else "unknown")
+    return ids
+
+
+def _fixed_seeds(cfg: CampaignConfig) -> list[int]:
+    if cfg.seed_policy.mode != "fixed-list":
+        return []
+    return [int(seed) for seed in cfg.seed_policy.seeds]
+
+
+def _planner_observation_modes(cfg: CampaignConfig) -> list[str]:
+    modes: list[str] = []
+    for planner in cfg.planners:
+        mode = planner.observation_mode or cfg.observation_mode
+        if mode:
+            modes.append(str(mode))
+    return modes
+
+
+def _scenario_has_pedestrians(scenario: Mapping[str, Any]) -> bool:
+    if scenario.get("single_pedestrians"):
+        return True
+    sim_config = scenario.get("simulation_config")
+    if isinstance(sim_config, Mapping):
+        try:
+            return float(sim_config.get("ped_density", 0.0)) > 0.0
+        except (TypeError, ValueError):
+            return False
+    return False
+
+
+def _structured_injection_probe(noise_spec: Mapping[str, Any] | None) -> dict[str, Any]:
+    if noise_spec is None:
+        return {"pedestrians_added": 0, "steps_with_noise": 0}
+    observation = {
+        "robot": {"position": [1.0, 2.0]},
+        "pedestrians_positions": [[2.0, 2.0], [0.0, 0.0], [0.0, 0.0]],
+        "pedestrians_velocities": [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+        "pedestrians_count": [1.0],
+    }
+    rng = make_observation_noise_rng(
+        noise_spec,
+        seed=0,
+        scenario_id="issue_3300_matrix_readiness_probe",
+    )
+    noisy, stats = apply_observation_noise(observation, noise_spec, rng)
+    return {
+        "pedestrians_added": int(stats.get("pedestrians_added", 0)),
+        "steps_with_noise": int(stats.get("steps_with_noise", 0)),
+        "pedestrians_count": _first_int(noisy.get("pedestrians_count")),
+    }
+
+
+def _first_int(value: Any) -> int:
+    if isinstance(value, list | tuple) and value:
+        return int(value[0])
+    return int(value or 0)

--- a/scripts/benchmark/check_false_positive_matrix_readiness_issue_3300.py
+++ b/scripts/benchmark/check_false_positive_matrix_readiness_issue_3300.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Fail-closed readiness check for issue #3300 stronger replay matrices."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.false_positive_matrix_readiness import (
+    STATUS_BLOCKED,
+    check_false_positive_matrix_readiness,
+)
+
+BLOCKED_EXIT_CODE = 3
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--nominal-config", type=Path, required=True)
+    parser.add_argument("--perturbed-config", type=Path, required=True)
+    parser.add_argument("--min-scenarios", type=int, default=2)
+    parser.add_argument("--min-seeds", type=int, default=2)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the issue #3300 matrix readiness CLI."""
+
+    args = _build_parser().parse_args(argv)
+    readiness = check_false_positive_matrix_readiness(
+        args.nominal_config,
+        args.perturbed_config,
+        min_scenarios=args.min_scenarios,
+        min_seeds=args.min_seeds,
+    )
+    print(json.dumps(readiness.to_dict(), indent=2, sort_keys=True))
+    if readiness.status == STATUS_BLOCKED:
+        return BLOCKED_EXIT_CODE
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmark/test_false_positive_matrix_readiness.py
+++ b/tests/benchmark/test_false_positive_matrix_readiness.py
@@ -1,0 +1,130 @@
+"""Tests for issue #3300 stronger false-positive matrix readiness."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.false_positive_matrix_readiness import (
+    REQUIRED_OBSERVATION_MODE,
+    STATUS_BLOCKED,
+    STATUS_READY,
+    check_false_positive_matrix_readiness,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NOMINAL_CONFIG = (
+    REPO_ROOT / "configs/benchmarks/issue_3300_false_positive_stronger_nominal_smoke.yaml"
+)
+PERTURBED_CONFIG = (
+    REPO_ROOT / "configs/benchmarks/issue_3300_false_positive_stronger_perturbed_smoke.yaml"
+)
+SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/check_false_positive_matrix_readiness_issue_3300.py"
+
+
+def test_stronger_matrix_configs_are_ready() -> None:
+    """The preregistered stronger matrix has multiple scenarios, seeds, and injection."""
+
+    readiness = check_false_positive_matrix_readiness(NOMINAL_CONFIG, PERTURBED_CONFIG)
+
+    assert readiness.status == STATUS_READY
+    assert len(set(readiness.scenario_ids)) == 3
+    assert len(set(readiness.seeds)) == 2
+    assert readiness.planner_observation_modes == [REQUIRED_OBSERVATION_MODE]
+    assert len(readiness.pedestrian_scenario_ids) == 3
+    assert readiness.injection_probe["pedestrians_added"] == 1
+    assert readiness.injection_probe["pedestrians_count"] == 2
+
+
+def test_one_scenario_or_one_seed_matrix_blocks() -> None:
+    """The checker rejects another one-scenario or one-seed smoke as too weak."""
+
+    readiness = check_false_positive_matrix_readiness(
+        REPO_ROOT / "configs/benchmarks/issue_3300_false_positive_nominal_smoke.yaml",
+        REPO_ROOT / "configs/benchmarks/issue_3300_false_positive_perturbed_smoke.yaml",
+    )
+
+    assert readiness.status == STATUS_BLOCKED
+    assert any("at least 2 distinct scenarios" in blocker for blocker in readiness.blockers)
+    assert any("at least 2 distinct fixed seeds" in blocker for blocker in readiness.blockers)
+
+
+def test_non_structured_planner_observation_blocks(tmp_path: Path) -> None:
+    """The matrix must keep planner observations structured-pedestrian compatible."""
+
+    nominal = tmp_path / "nominal.yaml"
+    perturbed = tmp_path / "perturbed.yaml"
+    nominal.write_text(
+        NOMINAL_CONFIG.read_text(encoding="utf-8").replace(
+            "observation_mode: socnav_state",
+            "observation_mode: goal_state",
+        ),
+        encoding="utf-8",
+    )
+    perturbed.write_text(PERTURBED_CONFIG.read_text(encoding="utf-8"), encoding="utf-8")
+
+    readiness = check_false_positive_matrix_readiness(nominal, perturbed)
+
+    assert readiness.status == STATUS_BLOCKED
+    assert any(REQUIRED_OBSERVATION_MODE in blocker for blocker in readiness.blockers)
+
+
+@pytest.mark.parametrize("min_scenarios,min_seeds", [(3, 2), (2, 2)])
+def test_cli_ready_contract(min_scenarios: int, min_seeds: int) -> None:
+    """CLI emits JSON readiness evidence and exits zero for the stronger matrix."""
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--nominal-config",
+            str(NOMINAL_CONFIG),
+            "--perturbed-config",
+            str(PERTURBED_CONFIG),
+            "--min-scenarios",
+            str(min_scenarios),
+            "--min-seeds",
+            str(min_seeds),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == STATUS_READY
+    assert payload["injection_probe"]["pedestrians_added"] == 1
+
+
+def test_cli_blocks_too_weak_threshold() -> None:
+    """CLI fails closed when the requested matrix threshold is not met."""
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--nominal-config",
+            str(NOMINAL_CONFIG),
+            "--perturbed-config",
+            str(PERTURBED_CONFIG),
+            "--min-scenarios",
+            "4",
+            "--min-seeds",
+            "2",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    assert result.returncode == 3, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == STATUS_BLOCKED
+    assert payload["blockers"]

--- a/tests/benchmark/test_false_positive_matrix_readiness.py
+++ b/tests/benchmark/test_false_positive_matrix_readiness.py
@@ -13,6 +13,7 @@ from robot_sf.benchmark.false_positive_matrix_readiness import (
     REQUIRED_OBSERVATION_MODE,
     STATUS_BLOCKED,
     STATUS_READY,
+    _scenario_ids,
     check_false_positive_matrix_readiness,
 )
 
@@ -38,6 +39,21 @@ def test_stronger_matrix_configs_are_ready() -> None:
     assert len(readiness.pedestrian_scenario_ids) == 3
     assert readiness.injection_probe["pedestrians_added"] == 1
     assert readiness.injection_probe["pedestrians_count"] == 2
+
+
+def test_scenario_ids_treat_null_name_as_missing_not_none_string() -> None:
+    """A null ``name`` falls through to scenario_id/id instead of coercing to "None"."""
+
+    ids = _scenario_ids(
+        [
+            {"name": "corridor_a"},
+            {"name": None, "scenario_id": "trap_b"},
+            {"name": None, "scenario_id": None, "id": "cross_c"},
+            {"name": None, "scenario_id": None, "id": None},
+        ]
+    )
+
+    assert ids == ["corridor_a", "trap_b", "cross_c", "unknown"]
 
 
 def test_one_scenario_or_one_seed_matrix_blocks() -> None:


### PR DESCRIPTION
## Reviewer-critical summary
What changed: Adds a stronger predeclared #3300 false-positive actor-injection matrix with 3 pedestrian-bearing scenarios x 2 fixed seeds, paired nominal/perturbed camera-ready smoke configs, and a fail-closed readiness CLI/test contract for matrix strength and structured-pedestrian compatibility.

Why now: PR #4431 made structured-pedestrian false-positive injection run, but its one-scenario/one-seed smoke was classified `scenario_too_weak`. This PR is a progression slice with the new capability of pre-registering and checking a stronger structured-pedestrian scenario/seed matrix, not another guard-only PR.

Claim boundary: This is smoke/diagnostic readiness plus one compact CPU perturbed smoke proving the stronger matrix exercises `socnav_state` structured pedestrian observations. It is not a robustness claim, full benchmark campaign, Slurm/GPU run, hardware sensor-realism model, or paper/dissertation claim.

Required validation: Focused matrix-readiness tests, focused observation-noise/report tests, #3300 matrix readiness CLI, compact CPU perturbed smoke, and full PR readiness.

Remaining blocker: The PR pre-registers the stronger paired matrix and proves perturbed injection on CPU, but it does not run the paired nominal-vs-perturbed report over the full stronger matrix or claim observed behavior-effect robustness.

## Contract delta
- New scenario matrix: `configs/scenarios/sets/issue_3300_false_positive_stronger_structured_matrix.yaml` selects `single_ped_crossing_orthogonal`, `issue_3233_near_field_observation_noise`, and `francis2023_intersection_wait`.
- New benchmark configs: `configs/benchmarks/issue_3300_false_positive_stronger_{nominal,perturbed}_smoke.yaml` use `socnav_state`, seeds `[0, 3300]`, horizon `20`, and matching planner/config surfaces except perturbed observation noise.
- New fail-closed checker: `scripts/benchmark/check_false_positive_matrix_readiness_issue_3300.py` exits `3` when the matrix is too weak, the paired configs diverge, planners do not use `socnav_state`, the perturbed profile is missing, or the structured injection probe adds no pedestrian.
- Compatibility impact: additive config/checker/test surface only; no default benchmark behavior changes.

## Issue
Fixes part of https://github.com/ll7/robot_sf_ll7/issues/3300.

## Scope summary
In scope: stronger predeclared false-positive actor-injection scenario/seed matrix, paired smoke configs, fail-closed readiness checks, and compact CPU smoke evidence that the matrix exercises structured pedestrian observations.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no hardware sensor-realism claim, no new observation-noise semantics, and no robustness promotion.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/false_positive_matrix_readiness.py scripts/benchmark/check_false_positive_matrix_readiness_issue_3300.py tests/benchmark/test_false_positive_matrix_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/false_positive_matrix_readiness.py scripts/benchmark/check_false_positive_matrix_readiness_issue_3300.py tests/benchmark/test_false_positive_matrix_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_false_positive_matrix_readiness.py -q` -> passed, 6 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_observation_noise.py tests/benchmark/test_false_positive_actor_injection_replay.py tests/benchmark/test_false_positive_matrix_readiness.py -q` -> passed, 22 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/check_false_positive_matrix_readiness_issue_3300.py --nominal-config configs/benchmarks/issue_3300_false_positive_stronger_nominal_smoke.yaml --perturbed-config configs/benchmarks/issue_3300_false_positive_stronger_perturbed_smoke.yaml --min-scenarios 3 --min-seeds 2` -> passed; `status=ready`, 3 scenarios, seeds `[0, 3300]`, `planner_observation_modes=[socnav_state]`, injection probe `pedestrians_added=1`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/issue_3300_false_positive_stronger_perturbed_smoke.yaml --mode run --output-root output/benchmarks/issue_3300_stronger_matrix --campaign-id issue_3300_stronger_perturbed_cpu_smoke --skip-publication-bundle` -> passed; 6 episodes, scenarios `francis2023_intersection_wait`, `issue_3233_near_field_observation_noise`, `single_ped_crossing_orthogonal`, seeds `[0, 3300]`, observation mode `socnav_state`, `pedestrians_added=102`, `steps_with_noise=102`, no fallback/degraded rows reported in command summary.
- `scripts/dev/run_worktree_shared_venv.sh -- bash -lc 'BASE_REF=origin/main scripts/dev/pr_ready_check.sh'` -> passed on dirty pre-commit tree.
- `scripts/dev/run_worktree_shared_venv.sh -- bash -lc 'PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue_3300_pr_body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh'` -> passed on clean head `8ab3451168a3d27fcddd7cfa29274328d15c7664`; freshness check reported `fresh: true`, `tree_state: clean`.

## Downstream propagation
No issue comment was posted because this task explicitly set `comment_issue_or_pr: false`. No tracked `docs/context/issue_3300_state.yaml` existed to update, and this PR body is the authorized durable state surface for the slice. Late guidance check reran the live issue comments immediately before PR publication; no #3300 comments were newer than the 2026-07-04 13:52:11+02:00 start time.

<details>
<summary>Appendix: governance and artifact notes</summary>

Fragmentation guard: two issue #3300 PRs merged in the previous 24 hours (#4390 and #4431). This PR proceeds under the progression-slice exemption because it adds the nameable new capability of a predeclared stronger scenario/seed matrix with fail-closed readiness checks.

Artifact classification: compact readiness and smoke summaries are stored under the common Git dir agent-run scratch area; raw benchmark output remains ignored under `output/`. No generated benchmark output is committed.

Late duplicate check: no open PR covered issue #3300 or this stronger false-positive actor-injection matrix scope before opening.
</details>
