### PR TITLE
Issue #4437: add open issue closure audit checker

### DIFF
--- a/scripts/dev/open_issue_closure_audit.py
+++ b/scripts/dev/open_issue_closure_audit.py
@@ -69,6 +69,15 @@ class ClosureAuditCandidate:
         }
 
 
+def _optional_str(value: object) -> str:
+    """Coerce an optional JSON field to text, mapping an explicit null to ``""``.
+
+    Prevents a null field (parsed to ``None``) from being coerced to the literal
+    string ``"None"``; valid strings pass through unchanged.
+    """
+    return str(value) if value is not None else ""
+
+
 def _is_issue_url(raw_url: object) -> bool:
     """Return true only for canonical GitHub issue URLs."""
     if not isinstance(raw_url, str):
@@ -95,7 +104,7 @@ def _issue_number(row: dict[str, object]) -> int | None:
     """Parse a GitHub search issue row number."""
     if not _is_issue_url(row.get("url")):
         return None
-    if str(row.get("state", "")).lower() != "open":
+    if _optional_str(row.get("state")).lower() != "open":
         return None
     try:
         return int(row["number"])
@@ -107,9 +116,9 @@ def _pull_request(row: dict[str, object], *, issue_number: int) -> LinkedPullReq
     """Parse a merged PR row and require a title link to the issue number."""
     if not _is_pull_request_url(row.get("url")):
         return None
-    if str(row.get("state", "")).lower() != "merged":
+    if _optional_str(row.get("state")).lower() != "merged":
         return None
-    title = str(row.get("title", ""))
+    title = _optional_str(row.get("title"))
     if not _title_mentions_issue(title, issue_number):
         return None
     try:
@@ -119,8 +128,8 @@ def _pull_request(row: dict[str, object], *, issue_number: int) -> LinkedPullReq
     return LinkedPullRequest(
         number=number,
         title=title,
-        url=str(row.get("url", "")),
-        merged_at=str(row.get("mergedAt") or row.get("closedAt") or ""),
+        url=_optional_str(row.get("url")),
+        merged_at=_optional_str(row.get("mergedAt") or row.get("closedAt")),
     )
 
 
@@ -165,14 +174,13 @@ def collect_candidates(
         )
         if not linked_prs:
             continue
-        classification, recommended_action = _classification_for_issue(
-            str(issue_row.get("title", ""))
-        )
+        title = _optional_str(issue_row.get("title"))
+        classification, recommended_action = _classification_for_issue(title)
         candidates.append(
             ClosureAuditCandidate(
                 number=number,
-                title=str(issue_row.get("title", "")),
-                url=str(issue_row.get("url", "")),
+                title=title,
+                url=_optional_str(issue_row.get("url")),
                 title_linked_prs=tuple(sorted(linked_prs, key=lambda pr: pr.number)),
                 classification=classification,
                 recommended_action=recommended_action,

--- a/scripts/dev/open_issue_closure_audit.py
+++ b/scripts/dev/open_issue_closure_audit.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Audit open issues that may already be covered by merged title-linked PRs.
+
+The command is intentionally read-only. It finds open issues, searches merged PRs
+whose titles mention the issue number, and emits a machine-readable packet for a
+human closure/residual-status pass. It never closes issues, comments, edits
+labels, or mutates project queue state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+ISSUE_FIELDS = "number,title,url,state"
+PR_FIELDS = "number,title,url,state,closedAt"
+PARENT_MARKERS = re.compile(
+    r"\b(parent|roadmap|epic|tracking|multi[- ]slice|umbrella)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class LinkedPullRequest:
+    """Merged pull request whose title links it to an issue number."""
+
+    number: int
+    title: str
+    url: str
+    merged_at: str
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable PR summary."""
+        return {
+            "number": self.number,
+            "title": self.title,
+            "url": self.url,
+            "merged_at": self.merged_at,
+        }
+
+
+@dataclass(frozen=True)
+class ClosureAuditCandidate:
+    """Open issue with at least one merged title-linked pull request."""
+
+    number: int
+    title: str
+    url: str
+    title_linked_prs: tuple[LinkedPullRequest, ...]
+    classification: str
+    recommended_action: str
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable issue audit row."""
+        return {
+            "number": self.number,
+            "title": self.title,
+            "url": self.url,
+            "classification": self.classification,
+            "recommended_action": self.recommended_action,
+            "title_linked_prs": [pr.to_payload() for pr in self.title_linked_prs],
+        }
+
+
+def _is_issue_url(raw_url: object) -> bool:
+    """Return true only for canonical GitHub issue URLs."""
+    if not isinstance(raw_url, str):
+        return False
+    path_parts = [part for part in urlsplit(raw_url).path.split("/") if part]
+    if len(path_parts) != 4:
+        return False
+    _, _, resource, number = path_parts
+    return resource == "issues" and number.isdigit()
+
+
+def _is_pull_request_url(raw_url: object) -> bool:
+    """Return true only for canonical GitHub pull request URLs."""
+    if not isinstance(raw_url, str):
+        return False
+    path_parts = [part for part in urlsplit(raw_url).path.split("/") if part]
+    if len(path_parts) != 4:
+        return False
+    _, _, resource, number = path_parts
+    return resource == "pull" and number.isdigit()
+
+
+def _issue_number(row: dict[str, object]) -> int | None:
+    """Parse a GitHub search issue row number."""
+    if not _is_issue_url(row.get("url")):
+        return None
+    if str(row.get("state", "")).lower() != "open":
+        return None
+    try:
+        return int(row["number"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _pull_request(row: dict[str, object], *, issue_number: int) -> LinkedPullRequest | None:
+    """Parse a merged PR row and require a title link to the issue number."""
+    if not _is_pull_request_url(row.get("url")):
+        return None
+    if str(row.get("state", "")).lower() != "merged":
+        return None
+    title = str(row.get("title", ""))
+    if not _title_mentions_issue(title, issue_number):
+        return None
+    try:
+        number = int(row["number"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return LinkedPullRequest(
+        number=number,
+        title=title,
+        url=str(row.get("url", "")),
+        merged_at=str(row.get("mergedAt") or row.get("closedAt") or ""),
+    )
+
+
+def _title_mentions_issue(title: str, issue_number: int) -> bool:
+    """Return true when a PR title explicitly mentions an issue number."""
+    pattern = re.compile(rf"(?<!\d)(?:#)?{issue_number}(?!\d)")
+    return pattern.search(title) is not None
+
+
+def _classification_for_issue(title: str) -> tuple[str, str]:
+    """Classify issue handling path without deciding acceptance completion."""
+    if PARENT_MARKERS.search(title):
+        return (
+            "parent_or_roadmap",
+            "update_status_ledger_with_merged_slices_and_remaining_work",
+        )
+    return (
+        "closure_review_required",
+        "read_acceptance_criteria_then_close_if_fully_covered_else_comment_residual_checklist",
+    )
+
+
+def collect_candidates(
+    open_issue_rows: list[dict[str, object]],
+    merged_pr_rows_by_issue: dict[int, list[dict[str, object]]],
+) -> list[ClosureAuditCandidate]:
+    """Collect open issues with merged title-linked PRs from pre-fetched rows."""
+    candidates: list[ClosureAuditCandidate] = []
+    seen: set[int] = set()
+    for issue_row in open_issue_rows:
+        number = _issue_number(issue_row)
+        if number is None or number in seen:
+            continue
+        seen.add(number)
+        linked_prs = tuple(
+            pr
+            for pr in (
+                _pull_request(row, issue_number=number)
+                for row in merged_pr_rows_by_issue.get(number, [])
+            )
+            if pr is not None
+        )
+        if not linked_prs:
+            continue
+        classification, recommended_action = _classification_for_issue(
+            str(issue_row.get("title", ""))
+        )
+        candidates.append(
+            ClosureAuditCandidate(
+                number=number,
+                title=str(issue_row.get("title", "")),
+                url=str(issue_row.get("url", "")),
+                title_linked_prs=tuple(sorted(linked_prs, key=lambda pr: pr.number)),
+                classification=classification,
+                recommended_action=recommended_action,
+            )
+        )
+    return sorted(candidates, key=lambda candidate: candidate.number)
+
+
+def build_open_issues_command(*, repo: str, limit: int) -> list[str]:
+    """Build the read-only command that lists open issues."""
+    return [
+        "gh",
+        "search",
+        "issues",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        ISSUE_FIELDS,
+        "--limit",
+        str(limit),
+    ]
+
+
+def build_merged_prs_command(*, repo: str, issue_number: int, limit: int) -> list[str]:
+    """Build the read-only command that finds merged PR titles for one issue."""
+    return [
+        "gh",
+        "search",
+        "prs",
+        f"{issue_number} in:title",
+        "--repo",
+        repo,
+        "--merged",
+        "--json",
+        PR_FIELDS,
+        "--limit",
+        str(limit),
+    ]
+
+
+def _run_search_command(command: list[str]) -> list[dict[str, object]]:
+    """Run a GitHub CLI search command and parse JSON rows."""
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError("GitHub CLI 'gh' was not found") from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "").strip()
+        message = detail or f"exit code {exc.returncode}"
+        raise RuntimeError(f"GitHub CLI command failed ({' '.join(command)}): {message}") from exc
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON from GitHub CLI ({' '.join(command)}): {exc.msg}") from exc
+    if not isinstance(payload, list):
+        raise ValueError(f"Expected JSON list from GitHub CLI ({' '.join(command)})")
+    return [row for row in payload if isinstance(row, dict)]
+
+
+def fetch_open_issue_rows(*, repo: str, limit: int) -> list[dict[str, object]]:
+    """Fetch open issue rows with a read-only GitHub search."""
+    return _run_search_command(build_open_issues_command(repo=repo, limit=limit))
+
+
+def fetch_merged_pr_rows_by_issue(
+    *, repo: str, issue_numbers: list[int], limit_per_issue: int
+) -> dict[int, list[dict[str, object]]]:
+    """Fetch merged PR search rows for each issue number."""
+    rows_by_issue: dict[int, list[dict[str, object]]] = {}
+    for issue_number in issue_numbers:
+        rows_by_issue[issue_number] = _run_search_command(
+            build_merged_prs_command(
+                repo=repo,
+                issue_number=issue_number,
+                limit=limit_per_issue,
+            )
+        )
+    return rows_by_issue
+
+
+def build_report(*, repo: str, candidates: list[ClosureAuditCandidate]) -> dict[str, Any]:
+    """Build a machine-readable closure-audit report."""
+    parent_count = sum(candidate.classification == "parent_or_roadmap" for candidate in candidates)
+    review_count = len(candidates) - parent_count
+    return {
+        "schema": "open_issue_closure_audit.v1",
+        "ok": not candidates,
+        "read_only": True,
+        "issue_writes": False,
+        "project_writes": False,
+        "repo": repo,
+        "candidate_count": len(candidates),
+        "closure_review_count": review_count,
+        "parent_or_roadmap_count": parent_count,
+        "candidates": [candidate.to_payload() for candidate in candidates],
+        "failure_summary": {
+            "reason": "open_issues_with_merged_title_linked_prs",
+            "count": len(candidates),
+        }
+        if candidates
+        else None,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub repository OWNER/REPO.")
+    parser.add_argument("--issue-limit", type=int, default=100, help="Open issues to scan.")
+    parser.add_argument(
+        "--pr-limit-per-issue",
+        type=int,
+        default=20,
+        help="Merged PR rows to inspect per open issue.",
+    )
+    return parser
+
+
+def _dump_json(payload: dict[str, Any]) -> None:
+    """Print compact, deterministic JSON."""
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the read-only closure audit."""
+    args = _build_parser().parse_args(argv)
+    try:
+        open_issue_rows = fetch_open_issue_rows(repo=args.repo, limit=args.issue_limit)
+        issue_numbers = [
+            number
+            for number in (_issue_number(row) for row in open_issue_rows)
+            if number is not None
+        ]
+        merged_pr_rows_by_issue = fetch_merged_pr_rows_by_issue(
+            repo=args.repo,
+            issue_numbers=issue_numbers,
+            limit_per_issue=args.pr_limit_per_issue,
+        )
+        report = build_report(
+            repo=args.repo,
+            candidates=collect_candidates(open_issue_rows, merged_pr_rows_by_issue),
+        )
+    except (RuntimeError, ValueError) as exc:
+        _dump_json(
+            {
+                "schema": "open_issue_closure_audit.v1",
+                "ok": False,
+                "read_only": True,
+                "issue_writes": False,
+                "project_writes": False,
+                "repo": args.repo,
+                "candidate_count": None,
+                "candidates": [],
+                "error": str(exc),
+            }
+        )
+        return 2
+    _dump_json(report)
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/dev/test_open_issue_closure_audit.py
+++ b/tests/dev/test_open_issue_closure_audit.py
@@ -46,6 +46,30 @@ def test_collect_candidates_reports_open_issues_with_merged_title_linked_prs() -
     assert "acceptance_criteria" in candidates[0].recommended_action
 
 
+def test_collect_candidates_treats_null_fields_as_empty_not_none_string() -> None:
+    """Explicit JSON nulls must not coerce to the literal string ``"None"``."""
+    issue_row: dict[str, object] = {
+        "number": 20,
+        "title": None,
+        "url": "https://github.com/ll7/robot_sf_ll7/issues/20",
+        "state": "open",
+    }
+    pr_row: dict[str, object] = {
+        "number": 200,
+        "title": "fix #20 handler",
+        "url": "https://github.com/ll7/robot_sf_ll7/pull/200",
+        "state": "merged",
+        "closedAt": "2026-07-04T11:00:00Z",
+        "mergedAt": None,
+    }
+
+    candidates = open_issue_closure_audit.collect_candidates([issue_row], {20: [pr_row]})
+
+    assert len(candidates) == 1
+    assert candidates[0].title == ""
+    assert candidates[0].title_linked_prs[0].merged_at == "2026-07-04T11:00:00Z"
+
+
 def test_collect_candidates_classifies_parent_roadmap_without_closure() -> None:
     """Parent or roadmap issues get ledger-update guidance, not closure guidance."""
     candidates = open_issue_closure_audit.collect_candidates(

--- a/tests/dev/test_open_issue_closure_audit.py
+++ b/tests/dev/test_open_issue_closure_audit.py
@@ -1,0 +1,179 @@
+"""Tests read-only open-issue closure audit helpers."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from scripts.dev import open_issue_closure_audit
+
+
+def _issue(number: int, title: str, *, state: str = "open") -> dict[str, object]:
+    return {
+        "number": number,
+        "title": title,
+        "url": f"https://github.com/ll7/robot_sf_ll7/issues/{number}",
+        "state": state,
+    }
+
+
+def _pr(number: int, title: str, *, issue_number: int, state: str = "merged") -> dict[str, object]:
+    del issue_number
+    return {
+        "number": number,
+        "title": title,
+        "url": f"https://github.com/ll7/robot_sf_ll7/pull/{number}",
+        "state": state,
+        "closedAt": "2026-07-04T11:00:00Z",
+    }
+
+
+def test_collect_candidates_reports_open_issues_with_merged_title_linked_prs() -> None:
+    """Open issues with merged title-linked PRs become review candidates."""
+    candidates = open_issue_closure_audit.collect_candidates(
+        [_issue(12, "add checker"), _issue(13, "no coverage yet")],
+        {
+            12: [_pr(99, "fix #12 checker contract", issue_number=12)],
+            13: [_pr(100, "fix #130 unrelated", issue_number=13)],
+        },
+    )
+
+    assert [candidate.number for candidate in candidates] == [12]
+    assert candidates[0].classification == "closure_review_required"
+    assert candidates[0].title_linked_prs[0].number == 99
+    assert "acceptance_criteria" in candidates[0].recommended_action
+
+
+def test_collect_candidates_classifies_parent_roadmap_without_closure() -> None:
+    """Parent or roadmap issues get ledger-update guidance, not closure guidance."""
+    candidates = open_issue_closure_audit.collect_candidates(
+        [_issue(3481, "roadmap: multi-slice parent")],
+        {3481: [_pr(4000, "issue #3481 slice one", issue_number=3481)]},
+    )
+
+    assert candidates[0].classification == "parent_or_roadmap"
+    assert candidates[0].recommended_action == (
+        "update_status_ledger_with_merged_slices_and_remaining_work"
+    )
+
+
+def test_collect_candidates_ignores_closed_issues_pr_rows_and_unlinked_titles() -> None:
+    """The audit stays issue-specific and requires explicit title linkage."""
+    rows = [
+        _issue(12, "closed issue", state="closed"),
+        {
+            "number": 14,
+            "title": "pull request shaped row",
+            "url": "https://github.com/ll7/robot_sf_ll7/pull/14",
+            "state": "open",
+        },
+        _issue(15, "open issue"),
+    ]
+    pr_rows_by_issue = {
+        12: [_pr(91, "fix #12", issue_number=12)],
+        14: [_pr(92, "fix #14", issue_number=14)],
+        15: [_pr(93, "fix #150 not fifteen", issue_number=15)],
+    }
+
+    assert open_issue_closure_audit.collect_candidates(rows, pr_rows_by_issue) == []
+
+
+def test_build_report_emits_read_only_failure_summary() -> None:
+    """Candidate reports expose stable counts and no-write guarantees."""
+    candidates = open_issue_closure_audit.collect_candidates(
+        [_issue(12, "tracking parent issue"), _issue(13, "simple issue")],
+        {
+            12: [_pr(91, "fix #12", issue_number=12)],
+            13: [_pr(92, "fix #13", issue_number=13)],
+        },
+    )
+    report = open_issue_closure_audit.build_report(repo="ll7/robot_sf_ll7", candidates=candidates)
+
+    assert report["schema"] == "open_issue_closure_audit.v1"
+    assert report["ok"] is False
+    assert report["read_only"] is True
+    assert report["issue_writes"] is False
+    assert report["project_writes"] is False
+    assert report["candidate_count"] == 2
+    assert report["parent_or_roadmap_count"] == 1
+    assert report["closure_review_count"] == 1
+    assert report["failure_summary"]["reason"] == "open_issues_with_merged_title_linked_prs"
+
+
+def test_build_commands_are_read_only_github_searches() -> None:
+    """GitHub commands search only; they never comment, close, edit, or touch projects."""
+    open_command = open_issue_closure_audit.build_open_issues_command(
+        repo="ll7/robot_sf_ll7", limit=200
+    )
+    pr_command = open_issue_closure_audit.build_merged_prs_command(
+        repo="ll7/robot_sf_ll7", issue_number=4437, limit=20
+    )
+
+    assert open_command[:3] == ["gh", "search", "issues"]
+    assert "--state" in open_command
+    assert open_command[open_command.index("--state") + 1] == "open"
+    assert pr_command[:3] == ["gh", "search", "prs"]
+    assert "4437 in:title" in pr_command
+    assert "--merged" in pr_command
+    for command in (open_command, pr_command):
+        assert "comment" not in command
+        assert "close" not in command
+        assert "edit" not in command
+        assert "--project" not in command
+
+
+def test_main_outputs_candidates_and_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI returns 1 when closure-review candidates exist."""
+
+    def fake_open_rows(*, repo: str, limit: int) -> list[dict[str, object]]:
+        assert repo == "ll7/robot_sf_ll7"
+        assert limit == 10
+        return [_issue(12, "simple issue")]
+
+    def fake_pr_rows(
+        *, repo: str, issue_numbers: list[int], limit_per_issue: int
+    ) -> dict[int, list[dict[str, object]]]:
+        assert repo == "ll7/robot_sf_ll7"
+        assert issue_numbers == [12]
+        assert limit_per_issue == 5
+        return {12: [_pr(91, "issue #12 done", issue_number=12)]}
+
+    monkeypatch.setattr(open_issue_closure_audit, "fetch_open_issue_rows", fake_open_rows)
+    monkeypatch.setattr(open_issue_closure_audit, "fetch_merged_pr_rows_by_issue", fake_pr_rows)
+
+    exit_code = open_issue_closure_audit.main(
+        ["--repo", "ll7/robot_sf_ll7", "--issue-limit", "10", "--pr-limit-per-issue", "5"]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert payload["candidate_count"] == 1
+    assert payload["candidates"][0]["number"] == 12
+
+
+def test_run_search_command_reports_missing_gh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing GitHub CLI produces an actionable runtime error."""
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(open_issue_closure_audit.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="GitHub CLI 'gh' was not found"):
+        open_issue_closure_audit._run_search_command(["gh", "search", "issues"])
+
+
+def test_run_search_command_reports_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed GitHub CLI output is diagnosed before aggregation."""
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=("gh",), returncode=0, stdout="{not-json")
+
+    monkeypatch.setattr(open_issue_closure_audit.subprocess, "run", fake_run)
+
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        open_issue_closure_audit._run_search_command(["gh", "search", "issues"])


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds `scripts/dev/open_issue_closure_audit.py`, a read-only GitHub CLI checker that finds open issues with merged PRs whose titles mention the issue number, plus focused unit tests.

Why now: issue #4437 reports that the open issue count is inflated by issues likely already covered by merged PRs; this PR delivers a safe detector for that cleanup without performing unauthorized issue comments or closures.

Claim boundary: this is a workflow checker only. It does not decide acceptance criteria are met, close issues, comment on issues, edit labels, update projects, run benchmarks, submit Slurm/GPU work, or edit paper/dissertation claims.

Required validation: focused tests for aggregation/classification/no-write command construction, Ruff, and a live read-only checker smoke against `ll7/robot_sf_ll7`.

Remaining blocker: the actual closure/residual-comment pass remains outside this PR because this run has `comment_issue_or_pr: false`; a human or authorized follow-up must review acceptance criteria and apply comments/closures.

## Contract delta

- New schema: `open_issue_closure_audit.v1`.
- New report fields: `read_only`, `issue_writes`, `project_writes`, `candidate_count`, `closure_review_count`, `parent_or_roadmap_count`, `candidates`, and `failure_summary`.
- New fail-closed behavior: malformed GitHub CLI JSON, missing `gh`, or failed GitHub search returns a structured error and exit code `2`.
- Compatibility impact: additive dev tooling only; no existing workflow behavior changes.
- New capability: a bounded read-only closure-audit candidate detector for issue #4437.

<details>
<summary>PR Template Appendix</summary>

## Summary

Adds a read-only open-issue closure audit checker for issue #4437. The checker surfaces likely merged-covered open issues as a machine-readable candidate list while leaving closure/residual decisions to an authorized human pass.

## Linked Issues

- Relates to `#4437`

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed

- Added `scripts/dev/open_issue_closure_audit.py`.
- Added `tests/dev/test_open_issue_closure_audit.py`.
- Locked read-only command construction: `gh search issues` and `gh search prs --merged`; no comment/close/edit/project commands.
- Added candidate classification for ordinary closure review vs parent/roadmap ledger updates.

## Why Matters

- Added value: turns the issue #4437 cleanup into a repeatable audit packet rather than ad hoc manual search.
- Expected impact: identifies open issues that should be reviewed for closure or residual checklist comments.
- Why worth merging now: the live smoke found 17 candidates in the first 20 open issues, confirming the queue-inflation signal is actionable.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: `#4437` closure hygiene workflow blocker.
- Comparator or baseline, applicable: manual GitHub searching.
- Evidence tier: NA - support helper.
- Result classification: NA - workflow checker only.
- Decision stop rule, applicable: NA.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #4437.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper; it does not interpret research evidence.

## Domain-Aware Approval

- Required PR: no
- Approver/review source waiver: NA - no research, benchmark, metric, or paper-facing claim.
- Validity checklist:
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: NA.
- Claim boundary: checker only; no acceptance completion decisions.
- Implementation integrity vs experimental validity: unit tests and live read-only smoke validate command/report behavior only.

## Falsification / Non-Transfer Check

- Did mechanism activate? NA - support helper.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: authorization needed for the actual issue-comment/closure pass.

## Next Empirical Action

- Rerun needed: NA.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue to authorized closure/residual review.
- Proposed child issue existing follow-up: none.

## Validation / Proof

- `uv run pytest tests/dev/test_open_issue_closure_audit.py` - passed, 8 tests.
- `uv run ruff check scripts/dev/open_issue_closure_audit.py tests/dev/test_open_issue_closure_audit.py` - passed.
- `uv run ruff format --check scripts/dev/open_issue_closure_audit.py tests/dev/test_open_issue_closure_audit.py` - passed.
- `uv run python scripts/dev/open_issue_closure_audit.py --repo ll7/robot_sf_ll7 --issue-limit 20 --pr-limit-per-issue 10` - exited `1` as designed because candidates were found; live summary: `candidate_count=17`, `closure_review_count=17`, `parent_or_roadmap_count=0`.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-4437/PR_BODY.md scripts/dev/pr_ready_check.sh` - passed; freshness stamp recorded for head `8b742c206f627c0cd2c5148d00bc37571132a908`.

## Performance

- Baseline runtime: NA - no hot-path/runtime behavior changed.
- Changed runtime: NA.
- Representative command: `uv run python scripts/dev/open_issue_closure_audit.py --repo ll7/robot_sf_ll7 --issue-limit 20 --pr-limit-per-issue 10`
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: checker emits write commands, malformed JSON, or incorrect candidate aggregation.

## Risks / Rollout

- Compatibility risks: low; additive dev script only.
- Failure modes: GitHub CLI field changes or search syntax changes produce structured error exit `2`.
- Rollback fallback plan: remove the additive script and tests.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: issue #4437.
- Any assumptions need to preserved: actual acceptance completion cannot be inferred automatically from title-linked merged PRs.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this run explicitly has `comment_issue_or_pr: false`; the PR body records the delivered slice and remaining work instead of adding another issue comment.

## Follow-Up Issues

- Deferred work: authorized pass to review each candidate's acceptance criteria, close fully covered issues, annotate partial residual checklists, and update parent/roadmap ledgers.
- Issues opened follow-up: none - existing issue #4437 remains open for the authorized closure/residual pass.

## Reviewer Notes

- Anything reviewer verify closely: no-write guarantee and `gh search prs --merged` field contract (`closedAt` used as merged timestamp proxy).
- Any known limitations: title linkage is only a candidate detector; it intentionally does not read every issue/PR body or close anything.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new read-only audit report for open issues that may already be covered by merged pull requests.
  * Added a CLI entry point that returns machine-readable JSON with counts, candidate issues, linked PRs, and summary status.

* **Bug Fixes**
  * Improved issue and PR matching to avoid false positives from unrelated titles or non-canonical links.
  * Added clearer handling for missing fields and invalid command output.

* **Tests**
  * Added coverage for candidate selection, report structure, command generation, and CLI exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->