### PR TITLE
feat(release): add release preflight runner (#3081)

### DIFF
--- a/scripts/tools/run_release_preflight.py
+++ b/scripts/tools/run_release_preflight.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Run a fail-closed release preflight checklist.
+
+This is a thin CLI wrapper around ``robot_sf.benchmark.release_preflight``.
+It does not publish, tag, upload, regenerate evidence, or declare release
+readiness. It only writes the evaluator's JSON and Markdown reports and
+returns a shell-friendly status code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.release_preflight import (
+    ReleasePreflightError,
+    evaluate_release_preflight,
+    load_release_preflight_checklist,
+    render_markdown,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse release-preflight CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checklist",
+        required=True,
+        type=Path,
+        help="Path to a release_preflight_checklist.v1 YAML/JSON file.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=Path("."),
+        type=Path,
+        help="Repository root used to resolve checklist artifact paths.",
+    )
+    parser.add_argument(
+        "--out-json",
+        required=True,
+        type=Path,
+        help="Where to write the structured preflight report JSON.",
+    )
+    parser.add_argument(
+        "--out-md",
+        required=True,
+        type=Path,
+        help="Where to write the rendered Markdown preflight report.",
+    )
+    return parser.parse_args(argv)
+
+
+def _write_text(path: Path, text: str) -> None:
+    """Write UTF-8 text, creating parent directories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run release preflight and return POSIX-style exit code.
+
+    Exit codes:
+    - 0: checklist evaluated with status ``passed``.
+    - 2: checklist evaluated with status ``blocked``.
+    - 1: malformed checklist, unexpected evaluator status, or report write error.
+    """
+    args = _parse_args(argv)
+
+    try:
+        checklist = load_release_preflight_checklist(args.checklist)
+        result = evaluate_release_preflight(checklist, args.repo_root)
+        report_json = json.dumps(result, indent=2, sort_keys=True) + "\n"
+        report_markdown = render_markdown(result) + "\n"
+        _write_text(args.out_json, report_json)
+        _write_text(args.out_md, report_markdown)
+    except (OSError, ReleasePreflightError, ValueError, json.JSONDecodeError) as exc:
+        print(f"release preflight failed: {exc}", file=sys.stderr)
+        return 1
+
+    if result["status"] == "passed":
+        return 0
+    if result["status"] == "blocked":
+        return 2
+
+    print(f"release preflight returned unexpected status {result['status']!r}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_run_release_preflight.py
+++ b/tests/tools/test_run_release_preflight.py
@@ -1,0 +1,133 @@
+"""Tests for the release preflight CLI runner."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import yaml
+
+from robot_sf.benchmark.release_preflight import SCHEMA_VERSION
+from scripts.tools import run_release_preflight
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_yaml(path: Path, payload: object) -> None:
+    """Write a YAML fixture, creating parent directories."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+
+def _checklist(path: str) -> dict[str, object]:
+    """Build a minimal release-preflight checklist fixture."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "release_id": "synthetic_release",
+        "items": [
+            {
+                "item_id": "reproduction_record",
+                "criterion": "reproduction",
+                "check": "artifact_present",
+                "path": path,
+            }
+        ],
+    }
+
+
+def test_run_release_preflight_passes_and_writes_reports(tmp_path: Path) -> None:
+    """A satisfied checklist exits 0 and writes JSON plus Markdown reports."""
+    repo_root = tmp_path / "repo"
+    checklist_path = tmp_path / "checklist.yaml"
+    out_json = tmp_path / "reports" / "release_preflight_report.json"
+    out_md = tmp_path / "reports" / "release_preflight_report.md"
+    (repo_root / "docs/context/evidence/release_july_2026").mkdir(parents=True)
+    (repo_root / "docs/context/evidence/release_july_2026/reproduction_record.md").write_text(
+        "synthetic reproduction record\n",
+        encoding="utf-8",
+    )
+    _write_yaml(
+        checklist_path,
+        _checklist("docs/context/evidence/release_july_2026/reproduction_record.md"),
+    )
+
+    exit_code = run_release_preflight.main(
+        [
+            "--checklist",
+            str(checklist_path),
+            "--repo-root",
+            str(repo_root),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["status"] == "passed"
+    assert payload["summary"] == {"blocked": 0, "complete": 1, "total": 1}
+    assert "Status: **passed**" in out_md.read_text(encoding="utf-8")
+
+
+def test_run_release_preflight_blocked_exits_2_and_writes_reports(tmp_path: Path) -> None:
+    """A blocked checklist exits 2 while preserving evaluator reports."""
+    checklist_path = tmp_path / "checklist.yaml"
+    out_json = tmp_path / "release_preflight_report.json"
+    out_md = tmp_path / "release_preflight_report.md"
+    _write_yaml(checklist_path, _checklist("docs/context/evidence/missing.md"))
+
+    exit_code = run_release_preflight.main(
+        [
+            "--checklist",
+            str(checklist_path),
+            "--repo-root",
+            str(tmp_path),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+
+    assert exit_code == 2
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert payload["status"] == "blocked"
+    assert payload["items"][0]["status"] == "blocked"
+    assert "missing" in payload["items"][0]["gaps"][0]
+    assert "Status: **blocked**" in out_md.read_text(encoding="utf-8")
+
+
+def test_run_release_preflight_malformed_checklist_exits_1(tmp_path: Path, capsys) -> None:
+    """A malformed checklist exits 1 and cannot produce a false pass."""
+    checklist_path = tmp_path / "bad.yaml"
+    out_json = tmp_path / "release_preflight_report.json"
+    out_md = tmp_path / "release_preflight_report.md"
+    _write_yaml(
+        checklist_path,
+        {
+            "schema_version": "wrong",
+            "release_id": "synthetic_release",
+            "items": [],
+        },
+    )
+
+    exit_code = run_release_preflight.main(
+        [
+            "--checklist",
+            str(checklist_path),
+            "--repo-root",
+            str(tmp_path),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+
+    assert exit_code == 1
+    assert not out_json.exists()
+    assert not out_md.exists()
+    assert "release preflight failed:" in capsys.readouterr().err


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds `scripts/tools/run_release_preflight.py`, a standalone CLI runner for the existing fail-closed release preflight evaluator, plus focused tests for passed, blocked, and malformed-checklist outcomes.

Why now: issue #3081's latest implementation plan calls out this runner as the next executable slice before the full July 2026 release evidence package is available.

Claim boundary: this PR only operationalizes the existing checklist evaluator. It does not reproduce a principal result, regenerate release tables or figures, publish artifacts, close #3081, or assert release readiness.

Required validation: the runner must write JSON and Markdown reports, return `0` only for `passed`, return `2` for `blocked`, return `1` for malformed inputs, and preserve the current shipped checklist's fail-closed blocked behavior until durable evidence exists.

Remaining blocker: #3081 still needs the durable July 2026 release evidence package: reproduction record, canonical table/figure manifest, claim cards, sprint issue ledger, checksums, and a passing preflight report.

## Contract delta

New schema fields: none.

New fail-closed blockers: none in the evaluator contract. The CLI exposes existing fail-closed evaluator states as shell exit codes:

- `0`: checklist evaluated as `passed`
- `2`: checklist evaluated as `blocked`
- `1`: malformed checklist, write failure, or unexpected evaluator status

Compatibility impact: additive tool entry point only. Existing `robot_sf.benchmark.release_preflight` behavior and checklist YAML remain unchanged.

## Scope

Issue: #3081

Progression slice/new capability: standalone release preflight CLI runner for the existing July 2026 release-readiness checklist.

Changed files:

- `scripts/tools/run_release_preflight.py`: adds the CLI wrapper.
- `tests/tools/test_run_release_preflight.py`: covers pass/block/error exit-code and report-writing behavior.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/tools/test_run_release_preflight.py -q` -> passed, 3 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/run_release_preflight.py --checklist configs/benchmarks/releases/release_july_2026_preflight_issue_3081.yaml --repo-root . --out-json /tmp/issue3081_release_preflight_report.json --out-md /tmp/issue3081_release_preflight_report.md` -> exit code 2 as expected; report status `blocked`, summary `{blocked: 4, complete: 0, total: 4}`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/run_release_preflight.py tests/tools/test_run_release_preflight.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/tools/run_release_preflight.py tests/tools/test_run_release_preflight.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/tools/test_run_release_preflight.py tests/benchmark/test_release_preflight.py -q` -> passed, 29 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/ -k "release or claim or canonical" -q` -> passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; 1809 passed, 2 skipped; freshness stamp `output/validation/pr_ready/issue-3081-bulk-admitted-issue-3081-see-issue-thread-for-scope.json`.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> fresh, clean tree, head `6c7f0cde399246a60ba0a74323c9f7af49215dcc`.

## Remaining work

- Locate/validate the durable Package B or other selected principal result store.
- Build `docs/context/evidence/release_july_2026/` package artifacts.
- Run the new CLI against the populated evidence package until the report is either passed or honestly blocked with precise gaps.

<details>
<summary>Process checks</summary>

- Late issue freshness: rechecked issue #3081 and comments immediately before opening; no comments newer than `2026-07-04T12:13:13Z`.
- Dedupe: no open PR found for #3081 / release-preflight / July 2026 research package scope.
- Fragmentation guard: no #3081 PRs merged in the last 24 hours.
- State propagation: no separate issue comment was added because this run is not authorized to comment on issues/PRs; this PR body records the delivered slice and remaining work as the durable handoff surface.
- Forbidden actions: no compute submission, merge, release, deletion, or full benchmark campaign.

</details>
