### PR TITLE
Issue #4401: post-run rank-identifiability contract checker and standalone report (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/fidelity_rank_stability.py
+++ b/robot_sf/benchmark/fidelity_rank_stability.py
@@ -16,8 +16,10 @@ runs. The fidelity *sweep execution* lives with parent issue #3207.
 
 from __future__ import annotations
 
+import json
 import math
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from robot_sf.benchmark.rank_metrics import kendall_tau as _shared_kendall_tau
@@ -315,4 +317,94 @@ def analyze_fidelity_sensitivity(
         rank_identifiable=rank_identifiable,
         rank_identifiability_reason=rank_identifiability_reason,
         rank_stable=rank_stable,
+    )
+
+
+RANK_STABILITY_REPORT_SCHEMA = "fidelity_rank_stability_report.v1"
+
+
+def write_rank_identifiability_report(
+    report: Mapping[str, object],
+    output_dir: str | Path,
+) -> Path:
+    """Write the standalone rank-identifiability post-run contract report.
+
+    This is the artifact referenced by the ``post_run_contract_specs`` field
+    in the fixed-scope preflight.  It is a plain copy of the ``FidelitySensitivityReport``
+    dict with a leading ``schema_version`` wrapper so downstream contract
+    checkers can validate the file independently of the campaign report.
+
+    Returns:
+        Path to the written ``fidelity_rank_stability_report.json`` file.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / "fidelity_rank_stability_report.json"
+    payload: dict[str, object] = {
+        "schema_version": RANK_STABILITY_REPORT_SCHEMA,
+        **report,
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+@dataclass(frozen=True)
+class PostRunContractResult:
+    """Result of checking a ``post_run_contract_specs`` entry against a report."""
+
+    contract_id: str
+    satisfied: bool
+    reason: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return JSON-safe mapping."""
+        return {
+            "contract_id": self.contract_id,
+            "satisfied": self.satisfied,
+            "reason": self.reason,
+        }
+
+
+def check_rank_identifiability_contract(
+    report: Mapping[str, object],
+    contract_spec: Mapping[str, object],
+) -> PostRunContractResult:
+    """Check whether ``report`` satisfies a rank-identifiability post-run contract.
+
+    The ``contract_spec`` is one entry from the ``post_run_contract_specs``
+    list produced by the fixed-scope preflight.  Only the
+    ``non_zero_variance_and_rank_identifiable`` threshold is currently
+    supported; other thresholds raise :class:`ValueError`.
+
+    The check is fail-closed: any missing or unexpected field is treated as
+    a failure so that claim promotion stays blocked until the report is
+    well-formed.
+
+    Returns:
+        A :class:`PostRunContractResult` with the contract id, pass/fail,
+        and an optional human-readable reason on failure.
+    """
+    contract_id = str(contract_spec.get("id", "unknown"))
+    threshold = str(contract_spec.get("threshold", ""))
+    blocks_claims = bool(contract_spec.get("blocks_claims_when_failed", True))
+
+    if threshold != "non_zero_variance_and_rank_identifiable":
+        raise ValueError(
+            f"unsupported post-run contract threshold: {threshold!r}; "
+            "only 'non_zero_variance_and_rank_identifiable' is currently supported"
+        )
+
+    rank_identifiable = bool(report.get("rank_identifiable", False))
+    reason = str(report.get("rank_identifiability_reason") or "none")
+
+    if rank_identifiable:
+        return PostRunContractResult(contract_id=contract_id, satisfied=True, reason=None)
+
+    return PostRunContractResult(
+        contract_id=contract_id,
+        satisfied=False,
+        reason=(
+            f"rank not identifiable (reason={reason}); "
+            f"blocks_claims_when_failed={blocks_claims}"
+        ),
     )

--- a/robot_sf/benchmark/fidelity_rank_stability.py
+++ b/robot_sf/benchmark/fidelity_rank_stability.py
@@ -341,8 +341,8 @@ def write_rank_identifiability_report(
     out.mkdir(parents=True, exist_ok=True)
     path = out / "fidelity_rank_stability_report.json"
     payload: dict[str, object] = {
-        "schema_version": RANK_STABILITY_REPORT_SCHEMA,
         **report,
+        "schema_version": RANK_STABILITY_REPORT_SCHEMA,
     }
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path
@@ -404,7 +404,6 @@ def check_rank_identifiability_contract(
         contract_id=contract_id,
         satisfied=False,
         reason=(
-            f"rank not identifiable (reason={reason}); "
-            f"blocks_claims_when_failed={blocks_claims}"
+            f"rank not identifiable (reason={reason}); blocks_claims_when_failed={blocks_claims}"
         ),
     )

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -29,7 +29,12 @@ import yaml
 from robot_sf.baselines.interface import Observation
 from robot_sf.baselines.social_force import SFPlannerConfig, SocialForcePlanner
 from robot_sf.benchmark.fidelity_fixed_scope_preflight import build_fixed_scope_preflight
-from robot_sf.benchmark.fidelity_rank_stability import analyze_fidelity_sensitivity
+from robot_sf.benchmark.fidelity_rank_stability import (
+    PostRunContractResult,
+    analyze_fidelity_sensitivity,
+    check_rank_identifiability_contract,
+    write_rank_identifiability_report,
+)
 from robot_sf.benchmark.fidelity_sensitivity import (
     DIAGNOSTIC_SMOKE_CLAIM_BOUNDARY,
     validate_fidelity_sensitivity_config,
@@ -1140,6 +1145,10 @@ def write_outputs(
         for variant, by_planner in sorted(report["aggregates"].items()):
             for planner, metrics in sorted(by_planner.items()):
                 writer.writerow({"variant": variant, "planner": planner, **metrics})
+    # Standalone post-run contract artifact: rank-identifiability report.
+    rank_report = report.get("rank_stability")
+    if isinstance(rank_report, Mapping):
+        write_rank_identifiability_report(rank_report, evidence_dir)
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -1313,7 +1322,21 @@ def _run_fixed_scope_execute(args: argparse.Namespace, config: Mapping[str, Any]
         raw_root=raw_root,
         evidence_dir=REPO_ROOT / args.evidence_dir,
     )
-    if not bool(report["rank_stability"].get("rank_identifiable")):
+    # Post-run contract gate: validate rank-identifiability against plan spec.
+    contract_specs = plan.get("post_run_contract_specs") or []
+    rank_contract_spec = next(
+        (spec for spec in contract_specs if spec.get("id") == "runtime_rank_identifiability_recheck"),
+        None,
+    )
+    if rank_contract_spec is not None:
+        contract_result = check_rank_identifiability_contract(
+            report["rank_stability"], rank_contract_spec
+        )
+        if not contract_result.satisfied:
+            print(f"fail-closed: post-run contract '{contract_result.contract_id}' failed: "
+                  f"{contract_result.reason}")
+            return 1
+    elif not bool(report["rank_stability"].get("rank_identifiable")):
         reason = report["rank_stability"].get("rank_identifiability_reason", "unknown")
         print(f"fail-closed: post-run rank identifiability recheck failed: {reason}")
         return 1

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -30,7 +30,6 @@ from robot_sf.baselines.interface import Observation
 from robot_sf.baselines.social_force import SFPlannerConfig, SocialForcePlanner
 from robot_sf.benchmark.fidelity_fixed_scope_preflight import build_fixed_scope_preflight
 from robot_sf.benchmark.fidelity_rank_stability import (
-    PostRunContractResult,
     analyze_fidelity_sensitivity,
     check_rank_identifiability_contract,
     write_rank_identifiability_report,
@@ -1325,7 +1324,11 @@ def _run_fixed_scope_execute(args: argparse.Namespace, config: Mapping[str, Any]
     # Post-run contract gate: validate rank-identifiability against plan spec.
     contract_specs = plan.get("post_run_contract_specs") or []
     rank_contract_spec = next(
-        (spec for spec in contract_specs if spec.get("id") == "runtime_rank_identifiability_recheck"),
+        (
+            spec
+            for spec in contract_specs
+            if spec.get("id") == "runtime_rank_identifiability_recheck"
+        ),
         None,
     )
     if rank_contract_spec is not None:
@@ -1333,8 +1336,10 @@ def _run_fixed_scope_execute(args: argparse.Namespace, config: Mapping[str, Any]
             report["rank_stability"], rank_contract_spec
         )
         if not contract_result.satisfied:
-            print(f"fail-closed: post-run contract '{contract_result.contract_id}' failed: "
-                  f"{contract_result.reason}")
+            print(
+                f"fail-closed: post-run contract '{contract_result.contract_id}' failed: "
+                f"{contract_result.reason}"
+            )
             return 1
     elif not bool(report["rank_stability"].get("rank_identifiable")):
         reason = report["rank_stability"].get("rank_identifiability_reason", "unknown")

--- a/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
+++ b/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
@@ -369,3 +369,49 @@ def test_fixed_scope_execute_cli_fails_closed_and_writes_no_rows(
     )
     assert exit_code == 1
     assert not (raw_root / "episode_rows.jsonl").exists()
+
+
+# ---------------------------------------------------------------------------
+# Post-run contract: rank-identifiability report and checker wiring
+# ---------------------------------------------------------------------------
+
+
+def test_plan_carries_rank_identifiability_contract_spec() -> None:
+    """The plan's post_run_contract_specs includes the rank-identifiability recheck."""
+    from robot_sf.benchmark.fidelity_rank_stability import (
+        PostRunContractResult,
+        check_rank_identifiability_contract,
+    )
+
+    plan = _plan()
+    specs = plan.get("post_run_contract_specs") or []
+    rank_spec = next(
+        (s for s in specs if s.get("id") == "runtime_rank_identifiability_recheck"),
+        None,
+    )
+    assert rank_spec is not None, "rank-identifiability contract spec missing from plan"
+    assert rank_spec["threshold"] == "non_zero_variance_and_rank_identifiable"
+    assert rank_spec["blocks_claims_when_failed"] is True
+    assert rank_spec["builder"] == "robot_sf/benchmark/fidelity_rank_stability.py"
+
+    # The contract checker is importable and callable on a well-formed report.
+    identifiable_report = {"rank_identifiable": True, "rank_identifiability_reason": None}
+    result = check_rank_identifiability_contract(identifiable_report, rank_spec)
+    assert isinstance(result, PostRunContractResult)
+    assert result.satisfied is True
+
+    non_identifiable_report = {
+        "rank_identifiable": False,
+        "rank_identifiability_reason": "primary_metric_zero_variance",
+    }
+    result_fail = check_rank_identifiability_contract(non_identifiable_report, rank_spec)
+    assert result_fail.satisfied is False
+    assert "rank not identifiable" in (result_fail.reason or "")
+
+
+def test_campaign_runner_imports_contract_checker() -> None:
+    """The campaign runner module exposes the post-run contract checker."""
+    assert hasattr(campaign_runner, "check_rank_identifiability_contract")
+    assert hasattr(campaign_runner, "write_rank_identifiability_report")
+    assert callable(campaign_runner.check_rank_identifiability_contract)
+    assert callable(campaign_runner.write_rank_identifiability_report)

--- a/tests/benchmark/test_fidelity_rank_stability.py
+++ b/tests/benchmark/test_fidelity_rank_stability.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -11,11 +12,15 @@ from robot_sf.benchmark.fidelity_rank_stability import (
     AXIS_PRIMARY_METRIC_NON_IDENTIFIABLE_REASON,
     FIDELITY_RANK_STABILITY_SCHEMA,
     PRIMARY_METRIC_ZERO_VARIANCE_REASON,
+    RANK_STABILITY_REPORT_SCHEMA,
+    PostRunContractResult,
     analyze_fidelity_sensitivity,
+    check_rank_identifiability_contract,
     count_rank_flips,
     kendall_tau,
     metric_drift,
     rank_planners,
+    write_rank_identifiability_report,
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -249,3 +254,78 @@ def test_config_declares_three_axes_and_primary_metric() -> None:
     assert data["primary_metric"]
     assert len(data["fidelity_axes"]) >= 3
     assert {"timestep", "sfm_params", "observation_noise"} <= set(data["fidelity_axes"])
+
+
+# --- post-run contract: standalone report write -----------------------------
+
+
+def test_write_rank_identifiability_report_roundtrips(tmp_path: Path) -> None:
+    """The standalone report file carries the wrapper schema and report content."""
+    report = analyze_fidelity_sensitivity(
+        _NOMINAL, {}, primary_metric="success_rate", drift_metrics=["success_rate"]
+    ).to_dict()
+    path = write_rank_identifiability_report(report, tmp_path)
+    assert path.name == "fidelity_rank_stability_report.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == RANK_STABILITY_REPORT_SCHEMA
+    assert payload["rank_identifiable"] is True
+    assert payload["primary_metric"] == "success_rate"
+
+
+# --- post-run contract: check_rank_identifiability_contract -----------------
+
+
+_CONTRACT_SPEC = {
+    "id": "runtime_rank_identifiability_recheck",
+    "report": "fidelity_rank_stability_report.json",
+    "builder": "robot_sf/benchmark/fidelity_rank_stability.py",
+    "metric": "success_rate",
+    "threshold": "non_zero_variance_and_rank_identifiable",
+    "output_path": "output/fidelity_sensitivity/<campaign>/rank_identifiability.json",
+    "blocks_claims_when_failed": True,
+}
+
+
+def test_check_contract_passes_when_identifiable() -> None:
+    """An identifiable report satisfies the contract."""
+    report = analyze_fidelity_sensitivity(
+        _NOMINAL, {}, primary_metric="success_rate", drift_metrics=["success_rate"]
+    ).to_dict()
+    result = check_rank_identifiability_contract(report, _CONTRACT_SPEC)
+    assert result.satisfied is True
+    assert result.reason is None
+    assert result.contract_id == "runtime_rank_identifiability_recheck"
+
+
+def test_check_contract_fails_when_not_identifiable() -> None:
+    """All-tied metrics fail the identifiability contract."""
+    tied = {
+        "p_a": {"success_rate": 0.0},
+        "p_b": {"success_rate": 0.0},
+    }
+    report = analyze_fidelity_sensitivity(
+        tied, {}, primary_metric="success_rate", drift_metrics=["success_rate"]
+    ).to_dict()
+    result = check_rank_identifiability_contract(report, _CONTRACT_SPEC)
+    assert result.satisfied is False
+    assert result.reason is not None
+    assert "rank not identifiable" in result.reason
+    assert "blocks_claims_when_failed=True" in result.reason
+
+
+def test_check_contract_rejects_unsupported_threshold() -> None:
+    """An unknown threshold raises ValueError."""
+    bad_spec = {**_CONTRACT_SPEC, "threshold": "bogus"}
+    report = analyze_fidelity_sensitivity(
+        _NOMINAL, {}, primary_metric="success_rate", drift_metrics=["success_rate"]
+    ).to_dict()
+    with pytest.raises(ValueError, match="unsupported post-run contract threshold"):
+        check_rank_identifiability_contract(report, bad_spec)
+
+
+def test_check_contract_result_to_dict_roundtrips() -> None:
+    """PostRunContractResult.to_dict is JSON-safe."""
+    result = PostRunContractResult(contract_id="test", satisfied=True, reason=None)
+    payload = result.to_dict()
+    assert json.dumps(payload)
+    assert payload == {"contract_id": "test", "satisfied": True, "reason": None}


### PR DESCRIPTION
## What / Why

**Successor slice to PR #4420.** PR #4420 wired the preflight/plan `post_run_contract_specs` so the campaign plan declares the rank-identifiability recheck contract, but the campaign runner did not produce the standalone report artifact or validate it against the contract spec.

This PR closes the remaining gap:

- **`write_rank_identifiability_report()`** — writes the standalone `fidelity_rank_stability_report.json` artifact referenced by the `post_run_contract_specs` `output_path` field.
- **`check_rank_identifiability_contract()`** — fail-closed validation of a rank-stability report against the `non_zero_variance_and_rank_identifiable` threshold, returning a `PostRunContractResult`.
- **Campaign runner wiring** — `write_outputs` now emits the standalone report alongside summary.json; the post-run gate uses `check_rank_identifiability_contract` when a `runtime_rank_identifiability_recheck` contract spec is present.
- **Focused tests** — 5 new tests covering report roundtrip, contract pass/fail, unsupported threshold rejection, result serialization, and campaign runner wiring.

Does not duplicate PR #4420 (preflight/plan wiring) or PR #4420's existing tests.

## Validation

- `uv run ruff check` — PASS
- `uv run ruff format --check` — PASS
- `uv run pytest tests/benchmark/test_fidelity_rank_stability.py -q` — 15 passed
- `uv run pytest tests/benchmark/test_fidelity_fixed_scope_run_plan.py -q` — 18 passed

## Claim boundary

Post-run contract validation wiring only. Not benchmark evidence, not simulator-realism evidence, not sim-to-real evidence, and not paper-facing evidence.

## Successor statement

Successor slice to PR #4420. If a further slice is needed to run the actual full fixed-scope campaign and produce the rank-identifiability report from real episode data, that is out of scope for this PR.

## Out of scope

No campaign execution, no Slurm/GPU submission, no paper/dissertation claim edits, no new planner arms, no threshold changes.

---

This PR was produced by the Command-Code/MiMo-V2.5-Pro cheap implementation lane; the review gate hardens and merges.