### PR TITLE
Issue #4448: guard guarded_ppo availability in trace-capable h600 config

### DIFF
--- a/configs/benchmarks/paper_experiment_matrix_v1_h600_trace_capable_rerun.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_h600_trace_capable_rerun.yaml
@@ -99,7 +99,7 @@ planners:
     algo_config: configs/algos/orca_prior_guarded_ppo_v1.yaml
     benchmark_profile: experimental
     availability_gate: dependency_gated
-    fail_closed_reason: checkpoint/config availability must be verified before campaign launch
+    fail_closed_reason: guarded_ppo_checkpoint_observation_contract_missing
   - key: prediction_planner
     algo: prediction_planner
     planner_group: experimental

--- a/robot_sf/benchmark/camera_ready/_config.py
+++ b/robot_sf/benchmark/camera_ready/_config.py
@@ -687,6 +687,16 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
                 socnav_missing_prereq_policy=str(
                     entry.get("socnav_missing_prereq_policy", "fail-fast"),
                 ),
+                availability_gate=(
+                    str(entry["availability_gate"]).strip()
+                    if entry.get("availability_gate") is not None
+                    else None
+                ),
+                fail_closed_reason=(
+                    str(entry["fail_closed_reason"]).strip()
+                    if entry.get("fail_closed_reason") is not None
+                    else None
+                ),
                 adapter_impact_eval=bool(entry.get("adapter_impact_eval", False)),
                 observation_mode=_normalize_observation_mode(
                     entry.get("observation_mode"),

--- a/robot_sf/benchmark/camera_ready/_config_types.py
+++ b/robot_sf/benchmark/camera_ready/_config_types.py
@@ -60,6 +60,8 @@ class PlannerSpec:
     benchmark_profile: str = "baseline-safe"
     algo_config_path: Path | None = None
     socnav_missing_prereq_policy: str = "fail-fast"
+    availability_gate: str | None = None
+    fail_closed_reason: str | None = None
     adapter_impact_eval: bool = False
     observation_mode: str | None = None
     workers_override: int | None = None

--- a/robot_sf/benchmark/camera_ready/_preflight.py
+++ b/robot_sf/benchmark/camera_ready/_preflight.py
@@ -456,6 +456,11 @@ def prepare_campaign_preflight(
                     if planner.algo_config_path is not None
                     else None
                 ),
+                "availability_gate": planner.availability_gate,
+                "fail_closed_reason": planner.fail_closed_reason,
+                "status": (
+                    "not_available" if planner.availability_gate == "dependency_gated" else "ok"
+                ),
                 "observation_mode": planner.observation_mode,
                 "enabled": planner.enabled,
             }

--- a/scripts/validation/check_issue_4206_trace_capable_h600_rerun_preregistration.py
+++ b/scripts/validation/check_issue_4206_trace_capable_h600_rerun_preregistration.py
@@ -135,6 +135,11 @@ def validate_runnable_config_pair(
         "guarded_ppo must declare availability_gate=dependency_gated",
     )
     _require(
+        guarded.get("fail_closed_reason") == "guarded_ppo_checkpoint_observation_contract_missing",
+        "guarded_ppo must declare fail_closed_reason="
+        "guarded_ppo_checkpoint_observation_contract_missing",
+    )
+    _require(
         bool(str(guarded.get("fail_closed_reason", "")).strip()),
         "guarded_ppo must declare fail_closed_reason",
     )
@@ -143,6 +148,19 @@ def validate_runnable_config_pair(
         "path": path.as_posix(),
         "planner_arm_count": len(actual_keys),
         "planner_keys": actual_keys,
+        "required_available_planner_count": len(
+            [
+                planner
+                for planner in planners
+                if isinstance(planner, dict)
+                and planner.get("availability_gate") != "dependency_gated"
+            ]
+        ),
+        "accepted_unavailable_planner_keys": [
+            planner["key"]
+            for planner in planners
+            if isinstance(planner, dict) and planner.get("availability_gate") == "dependency_gated"
+        ],
         "seeds": list(seed_policy["seeds"]),
         "horizon": payload["horizon"],
         "trace_capture": {

--- a/scripts/validation/check_issue_4206_trace_capable_h600_rerun_preregistration.py
+++ b/scripts/validation/check_issue_4206_trace_capable_h600_rerun_preregistration.py
@@ -157,7 +157,7 @@ def validate_runnable_config_pair(
             ]
         ),
         "accepted_unavailable_planner_keys": [
-            planner["key"]
+            planner.get("key")
             for planner in planners
             if isinstance(planner, dict) and planner.get("availability_gate") == "dependency_gated"
         ],

--- a/tests/validation/test_issue_4206_trace_capable_h600_rerun_preregistration.py
+++ b/tests/validation/test_issue_4206_trace_capable_h600_rerun_preregistration.py
@@ -197,6 +197,8 @@ def test_runnable_h600_config_matches_preregistration_contract() -> None:
     ]
     assert manifest["planner_keys"] == expected_keys
     assert manifest["planner_arm_count"] == len(expected_keys) == 12
+    assert manifest["required_available_planner_count"] == 11
+    assert manifest["accepted_unavailable_planner_keys"] == ["guarded_ppo"]
     assert manifest["seeds"] == [20, 21, 22, 23, 24]
     assert manifest["horizon"] == 600
     assert manifest["expected_scenario_matrix_hash"] == "c10df617a87c"
@@ -216,6 +218,9 @@ def test_runnable_h600_config_loads_trace_capture_flags() -> None:
     assert tuple(cfg.seed_policy.seeds) == (20, 21, 22, 23, 24)
     assert cfg.record_planner_decision_trace is True
     assert cfg.record_simulation_step_trace is True
+    guarded_ppo = next(planner for planner in cfg.planners if planner.key == "guarded_ppo")
+    assert guarded_ppo.availability_gate == "dependency_gated"
+    assert guarded_ppo.fail_closed_reason == "guarded_ppo_checkpoint_observation_contract_missing"
     assert [planner.key for planner in cfg.planners] == [
         "scenario_adaptive_hybrid_orca_v1",
         "hybrid_rule_v3_fast_progress_static_escape",
@@ -230,3 +235,28 @@ def test_runnable_h600_config_loads_trace_capture_flags() -> None:
         "socnav_sampling",
         "sacadrl",
     ]
+
+
+def test_runnable_h600_preflight_reports_guarded_ppo_accepted_unavailable(
+    tmp_path: Path,
+) -> None:
+    """Preflight exposes gated guarded_ppo as accepted unavailable, not unexpected failure."""
+    from robot_sf.benchmark.camera_ready._config import load_campaign_config
+    from robot_sf.benchmark.camera_ready._preflight import prepare_campaign_preflight
+
+    cfg = load_campaign_config(RUN_CONFIG_PATH)
+    preflight = prepare_campaign_preflight(
+        cfg,
+        output_root=tmp_path,
+        label="issue-4448",
+        validate_campaign_config=lambda _cfg: None,
+        build_route_clearance_warnings=lambda *_args, **_kwargs: [],
+    )
+
+    planner_rows = preflight["manifest_payload"]["planners"]
+    guarded_ppo = next(row for row in planner_rows if row["key"] == "guarded_ppo")
+    assert guarded_ppo["status"] == "not_available"
+    assert guarded_ppo["availability_gate"] == "dependency_gated"
+    assert (
+        guarded_ppo["fail_closed_reason"] == "guarded_ppo_checkpoint_observation_contract_missing"
+    )


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `guarded_ppo` now carries the explicit fail-closed reason `guarded_ppo_checkpoint_observation_contract_missing`, the camera-ready config loader preserves planner availability metadata, and preflight manifest rows mark dependency-gated planners as `not_available`.

Why now: issue #4448 blocks the trace-capable h600 rerun because one un-runnable `guarded_ppo` arm can fail the campaign instead of being counted as accepted unavailable.

Claim boundary: this is a config/preflight availability-gate slice only. It does not run the h600 benchmark campaign, submit Slurm/GPU work, change thresholds, interpret results, or edit paper/dissertation claims.

Required validation: issue #4206 preregistration tests and checker prove the runnable h600 config keeps 12 rostered arms, counts 11 required available arms, and reports `guarded_ppo` as the accepted-unavailable gated arm. Full repository PR readiness passed on the committed head.

Remaining blocker: the `guarded_ppo` arm remains unavailable until the guarded-PPO checkpoint observation contract is promoted; the roster entry is intentionally preserved so it can re-enable when that dependency lands.

## Contract delta

- New preserved planner metadata in camera-ready configs: `availability_gate` and `fail_closed_reason` on `PlannerSpec`.
- New preflight manifest row behavior: planners with `availability_gate: dependency_gated` emit `status: not_available` instead of looking like unexpected failures.
- H600 config compatibility impact: `guarded_ppo` remains in the roster with explicit reason `guarded_ppo_checkpoint_observation_contract_missing`; available-arm evidence should be computed over the non-gated arms.
- No transient queue-routing state, target-host state, packet lineage pointer, raw dataset, or generated benchmark output is tracked in this PR.

## Linked Issue

Addresses #4448.

## Scope summary

This PR implements a progression slice toward the issue plan: an executable config/preflight availability gate for the trace-capable h600 campaign blocker. It does not remove `guarded_ppo` from the roster.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_issue_4206_trace_capable_h600_rerun_preregistration.py -q` -> passed, 19 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_4206_trace_capable_h600_rerun_preregistration.py --config configs/benchmarks/issue_4206_trace_capable_h600_rerun_preregistration.yaml --run-config configs/benchmarks/paper_experiment_matrix_v1_h600_trace_capable_rerun.yaml --manifest-out /tmp/issue_4448_manifest.json` -> passed; manifest reports `accepted_unavailable_planner_keys: ["guarded_ppo"]`, `required_available_planner_count: 11`, `planner_arm_count: 12`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/camera_ready/_config.py robot_sf/benchmark/camera_ready/_config_types.py robot_sf/benchmark/camera_ready/_preflight.py scripts/validation/check_issue_4206_trace_capable_h600_rerun_preregistration.py tests/validation/test_issue_4206_trace_capable_h600_rerun_preregistration.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- env BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed on dirty pre-commit tree; follow-up final clean-head check also run with this PR body.
- `scripts/dev/run_worktree_shared_venv.sh -- env PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue_4448_pr_body.md scripts/dev/pr_ready_check.sh` -> passed on clean committed head; stamp `output/validation/pr_ready/issue-4448-fix-guarded-ppo-availability-gate-trace-capable-campaign-blocker.json` has `status: passed`, `tree_state: clean`, `head_sha: 079ecd8651d71487f18e304c77bcaed9b24917b6`.

## Follow-Up Issues

- Existing follow-up: guarded-PPO checkpoint promotion lane #1554 must produce/promote the checkpoint observation contract before `guarded_ppo` becomes available.
- Existing job context: Slurm 13285 remains the upstream promotion lane referenced by issue #4448; this PR does not inspect or mutate it.
- Deferred empirical action: review owner may rerun/resume the trace-capable h600 campaign after this availability gate merges.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream propagation

No separate issue comment was added because this task explicitly sets `comment_issue_or_pr: false`. This PR body is the durable state surface for this low-churn issue slice: delivered availability-gate preflight behavior; remaining work is empirical resubmission/reuse of the resumable h600 campaign after review ownership transfers.

<details>
<summary>Governance appendix</summary>

Research result guidance: blocker-resolution support slice; evidence tier is targeted smoke plus full PR readiness. No benchmark result or paper-facing claim is promoted.

Domain-aware approval: not required for validity claims because this PR changes config/preflight availability behavior only; it does not reinterpret benchmark evidence.

Next empirical action: after review/merge, Claude Code on `imech156-u` owns the full PR gate, improvement cycle, and any authorized campaign resubmission decision. This PR itself does not submit compute.

Risks: downstream tools that expected preflight manifest planner rows without `status` now receive additional compatible fields. The intended behavior is fail-closed: gated rows are visible as `not_available` and excluded from success evidence rather than silently dropped.

Artifacts: local `output/coverage/` and `output/validation/` from readiness are ignored disposable validation outputs, not committed durable evidence.

</details>
