### PR TITLE
Issue #4163: record rare-event reference blocker

### DIFF
--- a/configs/benchmarks/rare_event/issue_4163_crossing_smoke.yaml
+++ b/configs/benchmarks/rare_event/issue_4163_crossing_smoke.yaml
@@ -20,6 +20,17 @@ parameters:
 objective_event: collision_or_severe_intrusion
 samples: 32
 seed: 4163
+empirical_reference:
+  status: blocked
+  comparison: larger_bruteforce_reference
+  reason: >-
+    This crossing smoke config validates likelihood-ratio accounting only; no larger
+    brute-force reference has been run for calibrated rare-event estimates.
+  next_action: >-
+    Run the Phase 5 cheap-family naive baseline, accelerated sample, and larger
+    brute-force reference before claiming calibrated failure-rate evidence.
+  claim_boundary: >-
+    Diagnostic-only rare-event sampling smoke; not benchmark-strength failure-rate claim.
 scenario_matrix: configs/scenarios/planner_sanity_matrix_v1.yaml
 smoke_scenario_index: 0
 synthetic_toy_model:

--- a/configs/benchmarks/rare_event/issue_4163_static_constriction_smoke.yaml
+++ b/configs/benchmarks/rare_event/issue_4163_static_constriction_smoke.yaml
@@ -20,6 +20,18 @@ parameters:
 objective_event: collision_or_severe_intrusion
 samples: 32
 seed: 4163
+empirical_reference:
+  status: blocked
+  comparison: larger_bruteforce_reference
+  reason: >-
+    This static-constriction smoke config applies the rare-event accounting harness
+    to a cheap family only; no larger brute-force reference has been run.
+  next_action: >-
+    Run the Phase 5 cheap-family naive baseline, accelerated sample, and larger
+    brute-force reference before claiming calibrated failure-rate evidence.
+  claim_boundary: >-
+    Diagnostic-only static-constriction rare-event smoke; not benchmark-strength
+    failure-rate claim.
 scenario_matrix: configs/scenarios/sets/issue_2544_static_deadlock_smoke.yaml
 smoke_scenario_index: 0
 planner_arms:

--- a/scripts/benchmark/run_rare_event_estimation_issue_4163.py
+++ b/scripts/benchmark/run_rare_event_estimation_issue_4163.py
@@ -76,6 +76,7 @@ def main(argv: list[str] | None = None) -> int:
     static_family = _static_constriction_family(payload)
     if static_family:
         summary["static_constriction_family"] = static_family
+    summary["empirical_reference"] = _empirical_reference(payload)
     summary["out_of_scope"] = [
         "no full benchmark campaign run",
         "no Slurm/GPU submission",
@@ -138,6 +139,42 @@ def _static_constriction_family(payload: dict[str, Any]) -> dict[str, Any] | Non
             "diagnostic rare-event application only; not a failure-rate claim",
         ),
     }
+
+
+def _empirical_reference(payload: dict[str, Any]) -> dict[str, Any]:
+    reference = payload.get("empirical_reference")
+    if reference is None:
+        return {
+            "status": "blocked",
+            "comparison": "larger_bruteforce_reference",
+            "reason": "No brute-force reference evidence configured for this smoke run.",
+            "next_action": (
+                "Run the cheap-family naive baseline, accelerated sample, and larger brute-force "
+                "reference before treating the estimate as calibrated evidence."
+            ),
+            "claim_boundary": "diagnostic-only smoke; not benchmark-strength failure-rate claim",
+        }
+    if not isinstance(reference, dict):
+        raise ValueError("empirical_reference must be a mapping when provided")
+    status = str(reference.get("status", "")).strip()
+    if status not in {"blocked", "not_run", "planned", "available"}:
+        raise ValueError(
+            "empirical_reference.status must be one of: blocked, not_run, planned, available"
+        )
+    payload_reference = {
+        "status": status,
+        "comparison": reference.get("comparison", "larger_bruteforce_reference"),
+        "claim_boundary": reference.get(
+            "claim_boundary",
+            "diagnostic-only smoke; not benchmark-strength failure-rate claim",
+        ),
+    }
+    for key in ("reason", "next_action", "evidence_path", "reference_samples", "reference_seed"):
+        if key in reference:
+            payload_reference[key] = reference[key]
+    if status == "available" and "evidence_path" not in payload_reference:
+        raise ValueError("empirical_reference.evidence_path is required when status is available")
+    return payload_reference
 
 
 def _load_smoke_scenario(payload: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/benchmark/run_rare_event_estimation_issue_4163.py
+++ b/scripts/benchmark/run_rare_event_estimation_issue_4163.py
@@ -172,7 +172,7 @@ def _empirical_reference(payload: dict[str, Any]) -> dict[str, Any]:
     for key in ("reason", "next_action", "evidence_path", "reference_samples", "reference_seed"):
         if key in reference:
             payload_reference[key] = reference[key]
-    if status == "available" and "evidence_path" not in payload_reference:
+    if status == "available" and not str(payload_reference.get("evidence_path") or "").strip():
         raise ValueError("empirical_reference.evidence_path is required when status is available")
     return payload_reference
 

--- a/tests/benchmark/test_rare_event_sampling.py
+++ b/tests/benchmark/test_rare_event_sampling.py
@@ -171,6 +171,9 @@ def test_smoke_runner_writes_summary_with_provenance(tmp_path: Path) -> None:
     assert len(summary["sample_provenance"]["parameter_vector_hashes"]) == 8
     assert summary["planner_arms"] == ["synthetic_planner"]
     assert summary["episode_budget"] == 8
+    assert summary["empirical_reference"]["status"] == "blocked"
+    assert summary["empirical_reference"]["comparison"] == "larger_bruteforce_reference"
+    assert "larger brute-force reference" in summary["empirical_reference"]["next_action"]
     assert "synthetic_planner" in summary["arm_estimates"]
     assert "variance_ratio_vs_naive" in summary["arm_estimates"]["synthetic_planner"]
     assert (output_dir / "episodes.jsonl").exists()
@@ -205,6 +208,8 @@ def test_static_constriction_config_reports_two_arm_diagnostic_summary(tmp_path:
         "classic_head_on_corridor_low",
         "narrow_passage",
     ]
+    assert summary["empirical_reference"]["status"] == "blocked"
+    assert summary["empirical_reference"]["claim_boundary"].startswith("Diagnostic-only")
     for estimate in summary["arm_estimates"].values():
         assert estimate["objective_event"] == "collision_or_severe_intrusion"
         assert "confidence_interval" in estimate
@@ -239,6 +244,40 @@ planner_arms: []
     )
 
     with pytest.raises(ValueError, match="planner_arms must be a non-empty list"):
+        run_smoke(
+            [
+                "--config",
+                str(config_path),
+                "--output-dir",
+                str(tmp_path / "output"),
+                "--evidence-dir",
+                str(tmp_path / "evidence"),
+            ]
+        )
+
+
+def test_smoke_runner_rejects_available_reference_without_evidence(tmp_path: Path) -> None:
+    """Available empirical references must point at the reference evidence."""
+
+    config_path = tmp_path / "rare_event_bad_reference.yaml"
+    payload = _toy_spec_payload(samples=2)
+    payload["parameters"] = {
+        "ped_density": {
+            "base": "uniform",
+            "low": 0.01,
+            "high": 0.08,
+            "proposal_low": 0.04,
+            "proposal_high": 0.08,
+        }
+    }
+    payload["objective_event"] = "collision_or_severe_intrusion"
+    payload["empirical_reference"] = {
+        "status": "available",
+        "comparison": "larger_bruteforce_reference",
+    }
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="empirical_reference.evidence_path"):
         run_smoke(
             [
                 "--config",

--- a/tests/benchmark/test_rare_event_sampling.py
+++ b/tests/benchmark/test_rare_event_sampling.py
@@ -288,3 +288,41 @@ def test_smoke_runner_rejects_available_reference_without_evidence(tmp_path: Pat
                 str(tmp_path / "evidence"),
             ]
         )
+
+
+@pytest.mark.parametrize("empty_path", [None, "", "   "])
+def test_smoke_runner_rejects_available_reference_with_empty_evidence_path(
+    tmp_path: Path, empty_path: object
+) -> None:
+    """A present-but-empty evidence_path must not bypass the available-reference gate."""
+
+    config_path = tmp_path / "rare_event_empty_reference.yaml"
+    payload = _toy_spec_payload(samples=2)
+    payload["parameters"] = {
+        "ped_density": {
+            "base": "uniform",
+            "low": 0.01,
+            "high": 0.08,
+            "proposal_low": 0.04,
+            "proposal_high": 0.08,
+        }
+    }
+    payload["objective_event"] = "collision_or_severe_intrusion"
+    payload["empirical_reference"] = {
+        "status": "available",
+        "comparison": "larger_bruteforce_reference",
+        "evidence_path": empty_path,
+    }
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="empirical_reference.evidence_path"):
+        run_smoke(
+            [
+                "--config",
+                str(config_path),
+                "--output-dir",
+                str(tmp_path / "output"),
+                "--evidence-dir",
+                str(tmp_path / "evidence"),
+            ]
+        )


### PR DESCRIPTION
## Reviewer-critical summary

What changed: the issue #4163 rare-event smoke runner now emits an explicit `empirical_reference` contract in every summary, and both existing smoke configs declare the larger brute-force reference comparison as blocked.

Why now: merged issue #4163 slices already provide the sampling harness and static-constriction smoke application; the next coherent successor slice is to prevent Phase 5 validation from being silently implied before a cheap-family brute-force reference exists.

Claim boundary: diagnostic-only smoke/schema behavior. This PR does not claim calibrated rare-event failure-rate estimates or benchmark-strength evidence.

Required validation: focused rare-event tests, Ruff on touched Python, smoke runner on the static-constriction config, and repository PR readiness were run locally.

Remaining blocker: Phase 5 still needs the empirical run: cheap-family naive baseline, accelerated sample, and larger brute-force reference on the same family.

## Contract delta

New summary/config field: `empirical_reference`.

Supported statuses: `blocked`, `not_run`, `planned`, `available`.

New fail-closed blocker: `status: available` now requires `empirical_reference.evidence_path`; the runner raises `ValueError` when available reference evidence is declared without a path.

Compatibility impact: existing configs without `empirical_reference` continue to run and receive a default blocked reference contract in the emitted summary. The two issue #4163 smoke configs now declare the blocked reference explicitly.

## Issue

Closes no issue; advances #4163.

Issue link: https://github.com/ll7/robot_sf_ll7/issues/4163

Late guidance check: immediately before PR prep, issue #4163 was re-read via GitHub API including comments. Latest issue/comment timestamp remained 2026-07-02T15:24:28Z, so there were no maintainer comments newer than this work start to incorporate.

Fragmentation guard: existing merged #4163 PRs found were #4188 and #4233; no open PR covers this exact scope. This is a progression slice adding a nameable new capability: an empirical-reference blocker/summary contract for the rare-event runner.

State propagation: no issue comment or issue-state edit is made from this run because `comment_issue_or_pr` authorization is false. This PR body is the handoff surface and records delivered slice plus remaining empirical blocker.

## Scope summary

- Add `empirical_reference` summary emission to `scripts/benchmark/run_rare_event_estimation_issue_4163.py`.
- Record blocked empirical-reference comparison in both issue #4163 smoke configs.
- Extend rare-event tests for blocked summary propagation and fail-closed available-reference validation.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: issue #4163 Phase 5 empirical-reference blocker for rare-event failure-rate estimates.
- Comparator or baseline, applicable: larger brute-force reference remains missing; no empirical comparison is claimed here.
- Evidence tier: NA - diagnostic blocker contract only.
- Result classification: NA - no research result promoted.
- Decision stop rule, applicable: keep calibrated rare-event failure-rate claims blocked until cheap-family naive baseline, accelerated sample, and larger brute-force reference exist.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #4163.
- New research/benchmark/metric/paper-facing analysis tool, any: no new estimator tool; existing runner now records the empirical-reference state explicitly.

## Domain-Aware Approval

- Required PR: approval required
- Domains reviewed: evidence classification, benchmark interpretation
- Status: waived
- Approval or blocker note: implementation self-review waiver; issue #4163 requires explicit Phase 5 brute-force blocker and this PR records that blocker without promoting empirical validation.
- Validity checklist:
  - Target claim/hypothesis: rare-event failure-rate estimates remain blocked pending Phase 5 reference evidence
  - Comparator or split/evidence validity: no comparator evidence added; larger brute-force reference remains missing
  - Fallback/degraded exclusions: no fallback or degraded execution is counted as success evidence
  - Claim boundary: diagnostic-only smoke/schema behavior; not benchmark-strength evidence
  - Implementation integrity vs experimental validity: tests prove summary contract and fail-closed validation, not empirical estimator validity

## Validation

- `uv run pytest tests/benchmark/test_rare_event_sampling.py -q` -> passed, 8 tests.
- `uv run ruff check robot_sf/benchmark/rare_event_sampling.py scripts/benchmark/run_rare_event_estimation_issue_4163.py tests/benchmark/test_rare_event_sampling.py` -> passed.
- `uv run python scripts/benchmark/run_rare_event_estimation_issue_4163.py --config configs/benchmarks/rare_event/issue_4163_static_constriction_smoke.yaml --output-dir output/validation/issue_4163_static --evidence-dir output/validation/issue_4163_static_evidence` -> passed; summary emitted `empirical_reference.status = blocked`.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; core lane 1824 tests, optional lane completed, readiness stamp `output/validation/pr_ready/issue-4163-bulk-admitted-successor-slice-for-issue-4163.json`.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Appendix: governance notes</summary>

Generated artifacts are ignored local validation outputs only: `output/validation/...`, `output/coverage/...`, and the PR readiness stamp. No generated benchmark artifact is committed as durable evidence.

This PR does not encode transient queue-routing state, target hosts, or packet lineage in tracked files.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark smoke runs now include clearer empirical-reference status in generated summaries.
  * Added diagnostic guidance for rare-event smoke configurations, including next steps and claim boundaries.

* **Bug Fixes**
  * Improved validation so “available” empirical references must include evidence details, preventing incomplete benchmark claims.
  * Smoke-test outputs now consistently report the reference comparison used for rare-event checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->