### PR TITLE
Issue #4454: add typed collision event ledger (cheap-lane worker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Added **typed collision-event export records** to new episode rows (issue #4454). The canonical
+  `event_ledger` block is now `EpisodeEventLedger.v2` and can carry per-collision records with
+  partner type/id, collision time, relative contact speed, clearance-series provenance, and exact
+  event provenance. `run_map_episode` now emits the ledger natively before JSONL validation, so the
+  camera-ready retention path keeps the typed events automatically. Behavioral note: the scalar
+  `collision` / `outcome.collision_event` flag remains a termination indicator; safety claims should
+  cite the typed `event_ledger.collision_events` records instead of inferring collisions from the
+  scalar flag alone.
 * **Vectorized the O(N²) pairwise pedestrian-pedestrian social-force contribution path** used by the
   opt-in `hsfm_anisotropic_fov_v1` runtime seam (issue #3481). `pairwise_social_force_contributions`
   (`robot_sf/sim/pedestrian_model_variants.py`) previously built its `(N, N, 2)` per-pair matrix with

--- a/docs/benchmark_spec.md
+++ b/docs/benchmark_spec.md
@@ -266,6 +266,8 @@ Full details live in
 * `time_to_goal_ideal_ratio`: success-only ratio of achieved time to ideal time
   (`shortest_path_len / robot_max_speed`).
 * `outcome.collision_event`: canonical per-episode collision event flag for new episode outputs.
+* `event_ledger.collision_events`: typed exact collision-event records (`EpisodeEventLedger.v2`)
+  carrying partner type/id, collision time, relative contact speed, and source provenance.
 * `metrics.collisions`: collision count metric based on distance thresholds. For schema v1 episode
   outputs it must agree with `outcome.collision_event`: positive when the canonical event is true
   and zero when the canonical event is false.
@@ -313,6 +315,9 @@ Full details live in
 * `time_to_goal_norm` includes failures via clamp-to-`1.0`; for success-only reporting, use
   `time_to_goal_norm_success_only` together with the numeric validity flag
   `time_to_goal_success_only_valid == 1.0`.
+* The scalar `collision` / `outcome.collision_event` flag is a termination indicator, not a typed
+  safety interpretation. Safety claims should cite `event_ledger.collision_events` (for example, do
+  not reinterpret a non-collision doorway trace with ~1.37 m clearance as collision evidence).
 * Experimental `ped_impact_*` metrics are exploratory and should be reported
   with the associated validity/sample counters from `metrics.pedestrian_impact.sample_counts`.
   Deltas can be undefined when a pedestrian has only near or only far samples.

--- a/robot_sf/benchmark/event_ledger.py
+++ b/robot_sf/benchmark/event_ledger.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
-EPISODE_EVENT_LEDGER_SCHEMA_VERSION = "EpisodeEventLedger.v1"
+EPISODE_EVENT_LEDGER_SCHEMA_VERSION = "EpisodeEventLedger.v2"
+COLLISION_PARTNER_TYPES = (
+    "pedestrian",
+    "static_geometry",
+    "boundary",
+    "goal_artifact",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,6 +39,18 @@ class SurrogateEvents:
 
 
 @dataclass(frozen=True, slots=True)
+class CollisionEventRecord:
+    """Typed exact-collision record for one collision event."""
+
+    collision_partner_type: str
+    collision_partner_id: str | None
+    collision_time: float
+    relative_speed_at_contact: float | None
+    clearance_series_source: str
+    exact_event_source: str
+
+
+@dataclass(frozen=True, slots=True)
 class EpisodeEventLedger:
     """Versioned source-of-truth event block for benchmark episode records."""
 
@@ -42,6 +60,7 @@ class EpisodeEventLedger:
     planner: str
     software_commit: str | None
     exact_events: ExactEvents
+    collision_events: list[CollisionEventRecord] = field(default_factory=list)
     surrogate_events: SurrogateEvents = field(default_factory=SurrogateEvents)
     metric_definitions: dict[str, dict[str, str]] = field(default_factory=dict)
     reconciliation: dict[str, Any] = field(default_factory=dict)
@@ -154,8 +173,69 @@ def _predicate_event(
     return _bool_at(payload, event_key), f"safety_predicates.{predicate_key}.{event_key}"
 
 
-def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
-    """Build an ``EpisodeEventLedger.v1`` payload from an episode record.
+def _normalize_collision_partner_type(value: Any) -> str:
+    """Return a validated collision partner type."""
+    partner_type = str(value).strip()
+    if partner_type not in COLLISION_PARTNER_TYPES:
+        allowed = ", ".join(COLLISION_PARTNER_TYPES)
+        raise ValueError(
+            f"collision_partner_type must be one of {allowed}; got {partner_type!r}"
+        )
+    return partner_type
+
+
+def _normalize_collision_event_record(event: Mapping[str, Any]) -> CollisionEventRecord:
+    """Validate and normalize one typed collision-event payload.
+
+    Returns:
+        Normalized collision-event record ready for JSON serialization.
+    """
+    collision_time = _finite_float(event.get("collision_time"))
+    if collision_time is None or collision_time < 0.0:
+        raise ValueError("collision_time must be a finite value >= 0.")
+    clearance_series_source = str(event.get("clearance_series_source") or "").strip()
+    if not clearance_series_source:
+        raise ValueError("clearance_series_source must be a non-empty string.")
+    exact_event_source = str(event.get("exact_event_source") or "").strip()
+    if not exact_event_source:
+        raise ValueError("exact_event_source must be a non-empty string.")
+    collision_partner_id = event.get("collision_partner_id")
+    normalized_partner_id = (
+        str(collision_partner_id).strip() if collision_partner_id is not None else None
+    )
+    if normalized_partner_id == "":
+        normalized_partner_id = None
+    return CollisionEventRecord(
+        collision_partner_type=_normalize_collision_partner_type(event.get("collision_partner_type")),
+        collision_partner_id=normalized_partner_id,
+        collision_time=collision_time,
+        relative_speed_at_contact=_finite_float(event.get("relative_speed_at_contact")),
+        clearance_series_source=clearance_series_source,
+        exact_event_source=exact_event_source,
+    )
+
+
+def _normalize_collision_events(
+    collision_events: Sequence[Mapping[str, Any]] | None,
+) -> list[CollisionEventRecord]:
+    """Return validated typed collision events."""
+    if collision_events is None:
+        return []
+    normalized: list[CollisionEventRecord] = []
+    for event in collision_events:
+        if not isinstance(event, Mapping):
+            raise ValueError("collision event records must be mappings.")
+        normalized.append(_normalize_collision_event_record(event))
+    normalized.sort(key=lambda event: (event.collision_time, event.collision_partner_type))
+    return normalized
+
+
+def build_event_ledger(
+    record: Mapping[str, Any],
+    *,
+    collision_events: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build an ``EpisodeEventLedger.v2`` payload from an episode record.
 
     Returns:
         JSON-serializable ledger payload.
@@ -201,6 +281,7 @@ def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
     )
     if predicate_oscillation_source is not None:
         oscillation_source = predicate_oscillation_source
+    normalized_collision_events = _normalize_collision_events(collision_events)
 
     metric_definitions = {
         "collision_count": {
@@ -263,6 +344,7 @@ def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
             str(record.get("git_hash")) if record.get("git_hash") is not None else None
         ),
         exact_events=exact,
+        collision_events=normalized_collision_events,
         surrogate_events=surrogate,
         metric_definitions=metric_definitions,
         reconciliation=reconciliation,
@@ -305,6 +387,8 @@ def reconcile_event_ledger(ledger: Mapping[str, Any]) -> list[str]:
     reconciliation = reconciliation if isinstance(reconciliation, Mapping) else {}
     metric_definitions = ledger.get("metric_definitions")
     metric_definitions = metric_definitions if isinstance(metric_definitions, Mapping) else {}
+    collision_events = ledger.get("collision_events")
+    collision_events = collision_events if isinstance(collision_events, list) else []
 
     collision_metric = _finite_float(reconciliation.get("collision_metric_value"))
     if bool(exact.get("collision")) and (collision_metric is None or collision_metric <= 0.0):
@@ -327,6 +411,24 @@ def reconcile_event_ledger(ledger: Mapping[str, Any]) -> list[str]:
     ]
     if missing_definitions:
         violations.append("missing metric definitions: " + ", ".join(missing_definitions))
+    for index, event in enumerate(collision_events):
+        if not isinstance(event, Mapping):
+            violations.append(f"collision_events[{index}] must be a mapping")
+            continue
+        partner_type = str(event.get("collision_partner_type") or "")
+        if partner_type not in COLLISION_PARTNER_TYPES:
+            violations.append(
+                f"collision_events[{index}].collision_partner_type invalid: {partner_type!r}"
+            )
+        collision_time = _finite_float(event.get("collision_time"))
+        if collision_time is None or collision_time < 0.0:
+            violations.append(f"collision_events[{index}].collision_time must be finite and >= 0")
+        if not str(event.get("clearance_series_source") or "").strip():
+            violations.append(
+                f"collision_events[{index}].clearance_series_source must be non-empty"
+            )
+        if not str(event.get("exact_event_source") or "").strip():
+            violations.append(f"collision_events[{index}].exact_event_source must be non-empty")
     return violations
 
 
@@ -340,7 +442,9 @@ def validate_record_event_ledger(record: dict[str, Any]) -> list[str]:
 
 
 __all__ = [
+    "COLLISION_PARTNER_TYPES",
     "EPISODE_EVENT_LEDGER_SCHEMA_VERSION",
+    "CollisionEventRecord",
     "EpisodeEventLedger",
     "ExactEvents",
     "SurrogateEvents",

--- a/robot_sf/benchmark/event_ledger.py
+++ b/robot_sf/benchmark/event_ledger.py
@@ -178,9 +178,7 @@ def _normalize_collision_partner_type(value: Any) -> str:
     partner_type = str(value).strip()
     if partner_type not in COLLISION_PARTNER_TYPES:
         allowed = ", ".join(COLLISION_PARTNER_TYPES)
-        raise ValueError(
-            f"collision_partner_type must be one of {allowed}; got {partner_type!r}"
-        )
+        raise ValueError(f"collision_partner_type must be one of {allowed}; got {partner_type!r}")
     return partner_type
 
 
@@ -206,7 +204,9 @@ def _normalize_collision_event_record(event: Mapping[str, Any]) -> CollisionEven
     if normalized_partner_id == "":
         normalized_partner_id = None
     return CollisionEventRecord(
-        collision_partner_type=_normalize_collision_partner_type(event.get("collision_partner_type")),
+        collision_partner_type=_normalize_collision_partner_type(
+            event.get("collision_partner_type")
+        ),
         collision_partner_id=normalized_partner_id,
         collision_time=collision_time,
         relative_speed_at_contact=_finite_float(event.get("relative_speed_at_contact")),

--- a/robot_sf/benchmark/event_ledger.py
+++ b/robot_sf/benchmark/event_ledger.py
@@ -8,6 +8,12 @@ from dataclasses import asdict, dataclass, field
 from typing import Any
 
 EPISODE_EVENT_LEDGER_SCHEMA_VERSION = "EpisodeEventLedger.v2"
+SUPPORTED_EVENT_LEDGER_SCHEMA_VERSIONS = frozenset(
+    {
+        "EpisodeEventLedger.v1",
+        EPISODE_EVENT_LEDGER_SCHEMA_VERSION,
+    }
+)
 COLLISION_PARTNER_TYPES = (
     "pedestrian",
     "static_geometry",
@@ -444,6 +450,7 @@ def validate_record_event_ledger(record: dict[str, Any]) -> list[str]:
 __all__ = [
     "COLLISION_PARTNER_TYPES",
     "EPISODE_EVENT_LEDGER_SCHEMA_VERSION",
+    "SUPPORTED_EVENT_LEDGER_SCHEMA_VERSIONS",
     "CollisionEventRecord",
     "EpisodeEventLedger",
     "ExactEvents",

--- a/robot_sf/benchmark/frozen_trace_reconciliation.py
+++ b/robot_sf/benchmark/frozen_trace_reconciliation.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any
 
-from robot_sf.benchmark.event_ledger import EPISODE_EVENT_LEDGER_SCHEMA_VERSION
+from robot_sf.benchmark.event_ledger import SUPPORTED_EVENT_LEDGER_SCHEMA_VERSIONS
 
 FROZEN_TRACE_RECONCILIATION_SCHEMA = "frozen_trace_event_reconciliation.v1"
 FROZEN_TRACE_MISSING_EXPORT_SCHEMA = "frozen_trace_event_export_blocker.v1"
@@ -47,19 +47,21 @@ def _ledger_from_row(row: Mapping[str, Any]) -> Mapping[str, Any]:
 
     ledger = (
         row
-        if row.get("schema_version") == EPISODE_EVENT_LEDGER_SCHEMA_VERSION
+        if row.get("schema_version") in SUPPORTED_EVENT_LEDGER_SCHEMA_VERSIONS
         else row.get("event_ledger")
     )
     if not isinstance(ledger, Mapping):
-        if row.get("event_ledger_schema_version") == EPISODE_EVENT_LEDGER_SCHEMA_VERSION:
+        if row.get("event_ledger_schema_version") in SUPPORTED_EVENT_LEDGER_SCHEMA_VERSIONS:
             raise ValueError(
                 "frozen reconciliation rows must carry event_ledger exact/surrogate event "
-                "values; metric-semantics exports only name EpisodeEventLedger.v1 and cannot "
+                "values; metric-semantics exports only name the event ledger schema and cannot "
                 "be compared without the durable ledger payload"
             )
         raise ValueError("frozen reconciliation rows must contain event_ledger")
-    if ledger.get("schema_version") != EPISODE_EVENT_LEDGER_SCHEMA_VERSION:
-        raise ValueError("frozen reconciliation rows must contain EpisodeEventLedger.v1 payloads")
+    if ledger.get("schema_version") not in SUPPORTED_EVENT_LEDGER_SCHEMA_VERSIONS:
+        raise ValueError(
+            "frozen reconciliation rows must contain a supported EpisodeEventLedger payload"
+        )
     return ledger
 
 

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -28,6 +28,7 @@ from robot_sf.benchmark.cbf_safety_filter_runtime import (
 from robot_sf.benchmark.cbf_safety_filter_runtime import (
     runtime_config_from_mapping as cbf_runtime_config_from_mapping,
 )
+from robot_sf.benchmark.event_ledger import build_event_ledger
 from robot_sf.benchmark.failure_mechanism_taxonomy import unknown_failure_mechanism_record
 from robot_sf.benchmark.group_space_metrics import group_specs_from_map
 from robot_sf.benchmark.interaction_exposure import (
@@ -177,6 +178,169 @@ class VisibilityEvidenceTrace:
     track_confidence: np.ndarray | None = None
     status: str = "unavailable"
     reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _CollisionEventContext:
+    """Immutable context for per-step collision-event typing."""
+
+    dt_seconds: float
+    map_def: Any
+    robot_radius: float
+    ped_radius: float
+
+
+def _point_to_segment_distance(point: np.ndarray, segment: Any) -> float:
+    """Return Euclidean distance from ``point`` to one line segment."""
+    try:
+        segment_arr = np.asarray(segment, dtype=float)
+    except (TypeError, ValueError):
+        return float("inf")
+    if segment_arr.shape != (2, 2):
+        return float("inf")
+    start = segment_arr[0]
+    end = segment_arr[1]
+    line_vec = end - start
+    denom = float(np.dot(line_vec, line_vec))
+    if denom <= 0.0:
+        return float(np.linalg.norm(point - start))
+    t_val = float(np.dot(point - start, line_vec) / denom)
+    closest = start + np.clip(t_val, 0.0, 1.0) * line_vec
+    return float(np.linalg.norm(point - closest))
+
+
+def _closest_segment_partner_id(
+    point: np.ndarray,
+    segments: list[Any],
+    *,
+    prefix: str,
+) -> str | None:
+    """Return a stable partner id for the nearest segment, when available."""
+    if not segments:
+        return None
+    indexed_distances = [
+        (_point_to_segment_distance(point, segment), index) for index, segment in enumerate(segments)
+    ]
+    finite = [(distance, index) for distance, index in indexed_distances if math.isfinite(distance)]
+    if not finite:
+        return None
+    _, best_index = min(finite)
+    return f"{prefix}:{best_index}"
+
+
+def _map_obstacle_segments(map_def: Any) -> list[Any]:
+    """Return flattened obstacle segments from the live map definition."""
+    obstacles = getattr(map_def, "obstacles", None)
+    if not isinstance(obstacles, list):
+        return []
+    segments: list[Any] = []
+    for obstacle in obstacles:
+        lines = getattr(obstacle, "lines", None)
+        if isinstance(lines, list):
+            segments.extend(lines)
+    return segments
+
+
+def _point_inside_map_bounds(point: np.ndarray, map_def: Any) -> bool:
+    """Return whether ``point`` lies inside the declared rectangular map bounds."""
+    width = getattr(map_def, "width", None)
+    height = getattr(map_def, "height", None)
+    if not isinstance(width, int | float) or not isinstance(height, int | float):
+        return True
+    if not math.isfinite(float(width)) or not math.isfinite(float(height)):
+        return True
+    return 0.0 <= float(point[0]) <= float(width) and 0.0 <= float(point[1]) <= float(height)
+
+
+def _step_collision_events(
+    *,
+    step_idx: int,
+    robot_pos: np.ndarray,
+    previous_robot_pos: np.ndarray | None,
+    ped_positions: np.ndarray,
+    previous_ped_positions: np.ndarray | None,
+    meta: Mapping[str, Any],
+    context: _CollisionEventContext,
+) -> list[dict[str, Any]]:
+    """Return typed collision-event records for one simulator step."""
+    events: list[dict[str, Any]] = []
+    collision_time = float((step_idx + 1) * context.dt_seconds)
+    if previous_robot_pos is not None and context.dt_seconds > 0.0:
+        robot_velocity = (robot_pos - previous_robot_pos) / context.dt_seconds
+    else:
+        robot_velocity = np.zeros(2, dtype=float)
+
+    if bool(meta.get("is_pedestrian_collision", False)):
+        ped_array = np.asarray(ped_positions, dtype=float).reshape(-1, 2)
+        partner_id: str | None = None
+        relative_speed = float(np.linalg.norm(robot_velocity))
+        if ped_array.size:
+            ped_distances = np.linalg.norm(ped_array - robot_pos[np.newaxis, :], axis=1)
+            contact_threshold = max(0.0, context.robot_radius + context.ped_radius) + 1.0e-6
+            contact_candidates = np.where(ped_distances <= contact_threshold)[0]
+            if contact_candidates.size:
+                ped_index = int(contact_candidates[np.argmin(ped_distances[contact_candidates])])
+            else:
+                ped_index = int(np.argmin(ped_distances))
+            partner_id = str(ped_index)
+            ped_velocity = np.zeros(2, dtype=float)
+            if (
+                previous_ped_positions is not None
+                and previous_ped_positions.shape == ped_array.shape
+                and context.dt_seconds > 0.0
+            ):
+                ped_velocity = (
+                    ped_array[ped_index] - previous_ped_positions[ped_index]
+                ) / context.dt_seconds
+            relative_speed = float(np.linalg.norm(robot_velocity - ped_velocity))
+        events.append(
+            {
+                "collision_partner_type": "pedestrian",
+                "collision_partner_id": partner_id,
+                "collision_time": collision_time,
+                "relative_speed_at_contact": relative_speed,
+                "clearance_series_source": "runtime.step.pedestrian_positions",
+                "exact_event_source": "runtime.step.meta.is_pedestrian_collision",
+            }
+        )
+
+    if bool(meta.get("is_obstacle_collision", False)):
+        bounds = list(getattr(context.map_def, "bounds", [])) if context.map_def is not None else []
+        obstacle_segments = _map_obstacle_segments(context.map_def)
+        in_bounds = (
+            _point_inside_map_bounds(robot_pos, context.map_def)
+            if context.map_def is not None
+            else True
+        )
+        partner_type = "static_geometry" if in_bounds else "boundary"
+        partner_type_override = str(meta.get("collision_partner_type") or "").strip()
+        if partner_type_override in {"static_geometry", "boundary", "goal_artifact"}:
+            partner_type = partner_type_override
+        partner_id = (
+            str(meta.get("collision_partner_id"))
+            if meta.get("collision_partner_id") is not None
+            else _closest_segment_partner_id(
+                robot_pos,
+                obstacle_segments if partner_type == "static_geometry" else bounds,
+                prefix="obstacle" if partner_type == "static_geometry" else "boundary",
+            )
+        )
+        events.append(
+            {
+                "collision_partner_type": partner_type,
+                "collision_partner_id": partner_id,
+                "collision_time": collision_time,
+                "relative_speed_at_contact": float(np.linalg.norm(robot_velocity)),
+                "clearance_series_source": (
+                    "runtime.step.map.obstacles"
+                    if partner_type in {"static_geometry", "goal_artifact"}
+                    else "runtime.step.map.bounds"
+                ),
+                "exact_event_source": "runtime.step.meta.is_obstacle_collision",
+            }
+        )
+
+    return events
 
 
 def _nearest_hazard_distances(
@@ -984,14 +1148,25 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         obstacle_collision_seen = False
         robot_collision_seen = False
         timeout_seen = False
+        collision_events: list[dict[str, Any]] = []
 
-        map_def = None
+        map_def = getattr(env.simulator, "map_def", None)
         goal_vec = np.asarray(env.simulator.goal_pos[0], dtype=float)
         initial_robot_pos = np.asarray(env.simulator.robot_pos[0], dtype=float)
         initial_goal_distance = float(np.linalg.norm(initial_robot_pos - goal_vec))
+        robot_radius = float(getattr(getattr(config, "robot_config", None), "radius", 1.0))
+        ped_radius = float(getattr(config.sim_config, "ped_radius", 0.4))
+        collision_event_context = _CollisionEventContext(
+            dt_seconds=float(config.sim_config.time_per_step_in_secs),
+            map_def=map_def,
+            robot_radius=robot_radius,
+            ped_radius=ped_radius,
+        )
         previous_trace_robot_pos = np.array(initial_robot_pos, dtype=float, copy=True)
         previous_trace_ped_pos: np.ndarray | None = None
         previous_trace_heading = _observation_heading(obs)
+        previous_collision_robot_pos = np.array(initial_robot_pos, dtype=float, copy=True)
+        previous_collision_ped_pos: np.ndarray | None = None
         robot_headings: list[float] = []
         ammv_command_actions: list[dict[str, Any]] = []
         view_integrity: dict[str, Any] | None = None
@@ -1375,6 +1550,19 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 meta.get("is_robot_collision", False)
             )
             timeout_seen = timeout_seen or step_timeout
+            collision_events.extend(
+                _step_collision_events(
+                    step_idx=step_idx,
+                    robot_pos=robot_pos,
+                    previous_robot_pos=previous_collision_robot_pos,
+                    ped_positions=peds,
+                    previous_ped_positions=previous_collision_ped_pos,
+                    meta=meta,
+                    context=collision_event_context,
+                )
+            )
+            previous_collision_robot_pos = np.array(robot_pos, dtype=float, copy=True)
+            previous_collision_ped_pos = np.array(peds, dtype=float, copy=True)
             if reached_goal_step is None and step_success:
                 reached_goal_step = step_idx
             if step_success:
@@ -1793,6 +1981,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
             success=route_complete and not collision_seen,
         )
     )
+    record["event_ledger"] = build_event_ledger(record, collision_events=collision_events)
     if benchmark_track is not None:
         record["benchmark_track"] = benchmark_track
     if track_schema_version is not None:

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -219,7 +219,8 @@ def _closest_segment_partner_id(
     if not segments:
         return None
     indexed_distances = [
-        (_point_to_segment_distance(point, segment), index) for index, segment in enumerate(segments)
+        (_point_to_segment_distance(point, segment), index)
+        for index, segment in enumerate(segments)
     ]
     finite = [(distance, index) for distance, index in indexed_distances if math.isfinite(distance)]
     if not finite:
@@ -274,20 +275,32 @@ def _step_collision_events(
         ped_array = np.asarray(ped_positions, dtype=float).reshape(-1, 2)
         partner_id: str | None = None
         relative_speed = float(np.linalg.norm(robot_velocity))
-        if ped_array.size:
-            ped_distances = np.linalg.norm(ped_array - robot_pos[np.newaxis, :], axis=1)
+        # Filter non-finite pedestrian slots (padded/absent pedestrians) before
+        # selecting the contact partner: np.argmin over a NaN-containing array
+        # returns a NaN index, which would propagate NaN into
+        # relative_speed_at_contact and violate the non-finite safety rule.
+        finite_indices = (
+            np.where(np.all(np.isfinite(ped_array), axis=1))[0]
+            if ped_array.size
+            else np.empty(0, dtype=int)
+        )
+        if finite_indices.size:
+            finite_positions = ped_array[finite_indices]
+            ped_distances = np.linalg.norm(finite_positions - robot_pos[np.newaxis, :], axis=1)
             contact_threshold = max(0.0, context.robot_radius + context.ped_radius) + 1.0e-6
             contact_candidates = np.where(ped_distances <= contact_threshold)[0]
             if contact_candidates.size:
-                ped_index = int(contact_candidates[np.argmin(ped_distances[contact_candidates])])
+                nearest = int(contact_candidates[np.argmin(ped_distances[contact_candidates])])
             else:
-                ped_index = int(np.argmin(ped_distances))
+                nearest = int(np.argmin(ped_distances))
+            ped_index = int(finite_indices[nearest])
             partner_id = str(ped_index)
             ped_velocity = np.zeros(2, dtype=float)
             if (
                 previous_ped_positions is not None
                 and previous_ped_positions.shape == ped_array.shape
                 and context.dt_seconds > 0.0
+                and np.all(np.isfinite(previous_ped_positions[ped_index]))
             ):
                 ped_velocity = (
                     ped_array[ped_index] - previous_ped_positions[ped_index]
@@ -1154,8 +1167,13 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         goal_vec = np.asarray(env.simulator.goal_pos[0], dtype=float)
         initial_robot_pos = np.asarray(env.simulator.robot_pos[0], dtype=float)
         initial_goal_distance = float(np.linalg.norm(initial_robot_pos - goal_vec))
-        robot_radius = float(getattr(getattr(config, "robot_config", None), "radius", 1.0))
-        ped_radius = float(getattr(config.sim_config, "ped_radius", 0.4))
+        # Normalize optional radii before float(): getattr returns the default
+        # only when the attribute is absent, so an explicit None in config would
+        # otherwise raise TypeError in float(None).
+        robot_radius_val = getattr(getattr(config, "robot_config", None), "radius", 1.0)
+        robot_radius = float(robot_radius_val if robot_radius_val is not None else 1.0)
+        ped_radius_val = getattr(config.sim_config, "ped_radius", 0.4)
+        ped_radius = float(ped_radius_val if ped_radius_val is not None else 0.4)
         collision_event_context = _CollisionEventContext(
             dt_seconds=float(config.sim_config.time_per_step_in_secs),
             map_def=map_def,

--- a/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
+++ b/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import yaml
 
+from robot_sf.benchmark.event_ledger import SUPPORTED_EVENT_LEDGER_SCHEMA_VERSIONS
 from robot_sf.robot.safety_wrapper import SAFETY_WRAPPER_SCHEMA, SafetyWrapperConfig
 
 SAFETY_WRAPPER_ABLATION_SCHEMA = "safety-wrapper-ablation-manifest.v1"
@@ -57,7 +58,6 @@ REQUIRED_ROW_FIELDS = (
     "wrapper_intervention_rate",
 )
 
-REQUIRED_EVENT_LEDGER_SCHEMA = "EpisodeEventLedger.v1"
 PLANNER_SOURCE_SUFFIX = "::planners[].key"
 DRY_RUN_CLAIM_BOUNDARY = (
     "dry-run factorial-ablation manifest only: enumerates the fixed issue #3501 "
@@ -556,7 +556,7 @@ def _row_provenance_errors(row: Mapping[str, Any]) -> list[str]:
     event_ledger = row.get("event_ledger")
     if (
         not isinstance(event_ledger, Mapping)
-        or event_ledger.get("schema_version") != REQUIRED_EVENT_LEDGER_SCHEMA
+        or event_ledger.get("schema_version") not in SUPPORTED_EVENT_LEDGER_SCHEMA_VERSIONS
     ):
         invalid.append("event_ledger")
 

--- a/tests/benchmark/test_event_ledger.py
+++ b/tests/benchmark/test_event_ledger.py
@@ -60,6 +60,18 @@ def _schema(path: Path) -> Path:
     return schema_path
 
 
+def _typed_collision_event(partner_type: str) -> dict[str, object]:
+    """Return one typed collision-event fixture for the supplied partner type."""
+    return {
+        "collision_partner_type": partner_type,
+        "collision_partner_id": f"{partner_type}:0",
+        "collision_time": 0.3,
+        "relative_speed_at_contact": 0.7,
+        "clearance_series_source": f"fixture.{partner_type}.clearance",
+        "exact_event_source": f"fixture.{partner_type}.exact",
+    }
+
+
 def test_build_event_ledger_records_exact_and_surrogate_events() -> None:
     """Ledger payloads should expose exact outcomes and derived event definitions."""
     ledger = build_event_ledger(_record(collision_event=True, collisions=1.0))
@@ -73,6 +85,38 @@ def test_build_event_ledger_records_exact_and_surrogate_events() -> None:
     assert ledger["exact_events"]["goal_reached"] is False
     assert ledger["surrogate_events"]["near_miss"] is True
     assert ledger["metric_definitions"]["collision_count"]["source"] == "metrics.collisions"
+    assert ledger["reconciliation"]["audit_result"] == "pass"
+
+
+@pytest.mark.parametrize(
+    ("partner_type", "partner_id"),
+    [
+        ("pedestrian", "pedestrian:0"),
+        ("static_geometry", "static_geometry:0"),
+        ("boundary", "boundary:0"),
+        ("goal_artifact", "goal_artifact:0"),
+    ],
+)
+def test_build_event_ledger_preserves_typed_collision_events(
+    partner_type: str,
+    partner_id: str,
+) -> None:
+    """Typed collision-event fixtures should survive normalization for every partner class."""
+    ledger = build_event_ledger(
+        _record(collision_event=True, collisions=1.0),
+        collision_events=[_typed_collision_event(partner_type)],
+    )
+
+    assert ledger["collision_events"] == [
+        {
+            "collision_partner_type": partner_type,
+            "collision_partner_id": partner_id,
+            "collision_time": pytest.approx(0.3),
+            "relative_speed_at_contact": pytest.approx(0.7),
+            "clearance_series_source": f"fixture.{partner_type}.clearance",
+            "exact_event_source": f"fixture.{partner_type}.exact",
+        }
+    ]
     assert ledger["reconciliation"]["audit_result"] == "pass"
 
 
@@ -176,6 +220,19 @@ def test_reconcile_event_ledger_requires_metric_definitions() -> None:
     del ledger["metric_definitions"]["ttc_breach"]
 
     assert reconcile_event_ledger(ledger) == ["missing metric definitions: ttc_breach"]
+
+
+def test_reconcile_event_ledger_rejects_malformed_collision_event() -> None:
+    """Manually supplied typed collision events must keep their source metadata populated."""
+    ledger = build_event_ledger(
+        _record(collision_event=True, collisions=1.0),
+        collision_events=[_typed_collision_event("boundary")],
+    )
+    ledger["collision_events"][0]["exact_event_source"] = ""
+
+    assert reconcile_event_ledger(ledger) == [
+        "collision_events[0].exact_event_source must be non-empty"
+    ]
 
 
 def test_validate_record_event_ledger_attaches_canonical_payload() -> None:

--- a/tests/benchmark/test_event_ledger_reconciliation_export.py
+++ b/tests/benchmark/test_event_ledger_reconciliation_export.py
@@ -56,7 +56,7 @@ def test_build_export_row_wraps_episode_identity_and_audit_table() -> None:
     assert row["seed"] == 7
     assert row["planner"] == "goal"
     assert row["software_commit"] == "abc123"
-    assert row["event_ledger_schema_version"] == "EpisodeEventLedger.v1"
+    assert row["event_ledger_schema_version"] == "EpisodeEventLedger.v2"
     assert row["reconciliation_table"]["reconciles"] is True
     assert {entry["field"] for entry in row["reconciliation_table"]["rows"]} >= {
         "collision_count",

--- a/tests/benchmark/test_frozen_trace_reconciliation.py
+++ b/tests/benchmark/test_frozen_trace_reconciliation.py
@@ -382,6 +382,20 @@ def test_episode_keys_preserve_valid_falsy_identifiers() -> None:
     assert report["unchanged_rows"] == [{"episode_key": "0|0|0|0"}]
 
 
+def test_v1_durable_rows_pass_and_unsupported_schema_fails_closed() -> None:
+    """Frozen durable v1 ledgers remain supported, unknown schema versions do not."""
+
+    v1_row = _ledger_row("episode-1")
+    report = build_frozen_trace_reconciliation_report([v1_row], [v1_row])
+
+    assert report["unchanged_rows"] == [{"episode_key": "scenario-a|episode-1|7|demo"}]
+
+    unsupported_row = _ledger_row("episode-1")
+    unsupported_row["event_ledger"]["schema_version"] = "EpisodeEventLedger.v3"
+    with pytest.raises(ValueError, match="supported EpisodeEventLedger payload"):
+        build_frozen_trace_reconciliation_report([unsupported_row], [v1_row])
+
+
 def test_cli_jsonl_parse_error_names_path_and_line(tmp_path: Path) -> None:
     """Malformed JSONL input errors should identify the path and line."""
 

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -3818,6 +3818,17 @@ def test_run_map_episode_floors_exact_obstacle_collision_metrics(
     assert record["metrics"]["total_collision_count"] == pytest.approx(1.0)
     assert record["metrics"]["collisions"] == pytest.approx(1.0)
     assert record["metrics"]["wall_collisions"] == pytest.approx(1.0)
+    assert record["event_ledger"]["schema_version"] == "EpisodeEventLedger.v2"
+    assert record["event_ledger"]["collision_events"] == [
+        {
+            "collision_partner_type": "static_geometry",
+            "collision_partner_id": None,
+            "collision_time": pytest.approx(0.1),
+            "relative_speed_at_contact": pytest.approx(0.0),
+            "clearance_series_source": "runtime.step.map.obstacles",
+            "exact_event_source": "runtime.step.meta.is_obstacle_collision",
+        }
+    ]
 
 
 def test_collision_metric_floor_preserves_untyped_collision_event() -> None:

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -57,7 +57,11 @@ from robot_sf.benchmark.map_runner_batch_plan import (
     build_worker_fixed_params,
     resolve_batch_kinematics_tag,
 )
-from robot_sf.benchmark.map_runner_episode import _topology_guided_episode_diagnostics
+from robot_sf.benchmark.map_runner_episode import (
+    _CollisionEventContext,
+    _step_collision_events,
+    _topology_guided_episode_diagnostics,
+)
 from robot_sf.benchmark.map_runner_metrics import (
     _episode_collision_value,
     summarize_collision_metrics,
@@ -5742,3 +5746,53 @@ def test_map_episode_visibility_trace_feeds_occlusion_near_miss_predicate(monkey
     predicate = record["safety_predicates"]["occlusion_near_miss_predicate"]
     assert predicate["status"] == "true"
     assert predicate["occlusion_near_miss"] is True
+
+
+def test_step_collision_events_ignores_nonfinite_pedestrians() -> None:
+    """Padded NaN pedestrian slots must not propagate NaN into contact speed."""
+    context = _CollisionEventContext(
+        dt_seconds=0.1,
+        map_def=None,
+        robot_radius=0.5,
+        ped_radius=0.4,
+    )
+    ped_positions = np.array([[np.nan, np.nan], [1.2, 0.0]], dtype=float)
+    previous_ped_positions = np.array([[np.nan, np.nan], [1.5, 0.0]], dtype=float)
+    events = _step_collision_events(
+        step_idx=0,
+        robot_pos=np.array([1.0, 0.0], dtype=float),
+        previous_robot_pos=np.array([0.8, 0.0], dtype=float),
+        ped_positions=ped_positions,
+        previous_ped_positions=previous_ped_positions,
+        meta={"is_pedestrian_collision": True},
+        context=context,
+    )
+    assert len(events) == 1
+    event = events[0]
+    # The finite pedestrian (index 1) is selected, not the NaN-padded slot.
+    assert event["collision_partner_id"] == "1"
+    assert math.isfinite(event["relative_speed_at_contact"])
+
+
+def test_step_collision_events_all_nonfinite_pedestrians_stays_finite() -> None:
+    """When every pedestrian slot is non-finite, contact speed falls back to robot speed."""
+    context = _CollisionEventContext(
+        dt_seconds=0.1,
+        map_def=None,
+        robot_radius=0.5,
+        ped_radius=0.4,
+    )
+    ped_positions = np.array([[np.nan, np.nan]], dtype=float)
+    events = _step_collision_events(
+        step_idx=0,
+        robot_pos=np.array([1.0, 0.0], dtype=float),
+        previous_robot_pos=np.array([0.8, 0.0], dtype=float),
+        ped_positions=ped_positions,
+        previous_ped_positions=None,
+        meta={"is_pedestrian_collision": True},
+        context=context,
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert event["collision_partner_id"] is None
+    assert math.isfinite(event["relative_speed_at_contact"])

--- a/tests/benchmark/test_safety_wrapper_ablation_manifest.py
+++ b/tests/benchmark/test_safety_wrapper_ablation_manifest.py
@@ -271,6 +271,31 @@ def test_check_factorial_ablation_rows_accepts_exact_paired_rows() -> None:
     assert report["pair_provenance_mismatches"] == []
 
 
+def test_check_factorial_ablation_rows_accepts_supported_v2_event_ledger() -> None:
+    """Live v2 ledger rows remain valid for the additive collision-events schema bump."""
+
+    rows = [_ablation_row(WRAPPER_OFF_ARM), _ablation_row(WRAPPER_ON_ARM)]
+    for row in rows:
+        row["event_ledger"]["schema_version"] = "EpisodeEventLedger.v2"
+
+    report = check_factorial_ablation_rows(rows)
+
+    assert report["complete"] is True
+    assert report["invalid_provenance_fields"] == []
+
+
+def test_check_factorial_ablation_rows_rejects_unsupported_event_ledger_schema() -> None:
+    """Unsupported event-ledger versions fail closed before ablation comparison."""
+
+    rows = [_ablation_row(WRAPPER_OFF_ARM), _ablation_row(WRAPPER_ON_ARM)]
+    rows[0]["event_ledger"]["schema_version"] = "EpisodeEventLedger.v3"
+
+    report = check_factorial_ablation_rows(rows)
+
+    assert report["complete"] is False
+    assert report["invalid_provenance_fields"] == [{"row_index": 0, "fields": ["event_ledger"]}]
+
+
 def test_check_factorial_ablation_rows_rejects_arm_mode_mismatch() -> None:
     """Wrapper arm and opt-in mode provenance must agree before comparison."""
     off_row = _ablation_row(WRAPPER_OFF_ARM)


### PR DESCRIPTION
## What
- bump the canonical episode event ledger to `EpisodeEventLedger.v2` and add typed `collision_events` records with partner type/id, collision time, relative contact speed, and provenance fields
- emit that ledger natively from `run_map_episode`, so exported JSONL rows already carry typed collision events before writer validation
- add focused tests for all requested partner classes and document that the scalar collision flag is only a termination indicator

## Why
- issue #4454 needs typed collision-event evidence, not only scalar collision termination flags or aggregate ped/geometry counts
- camera-ready retention already flows through the normal episode export path, so native `run_map_episode` emission makes retained campaign rows carry the typed events automatically

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_event_ledger.py tests/benchmark/test_map_runner_utils.py -q -k 'event_ledger or floors_exact_obstacle_collision_metrics'`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/benchmark/event_ledger.py robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_event_ledger.py tests/benchmark/test_map_runner_utils.py`

This PR was produced by the GitHub-Copilot-CLI/gpt-5.4 cheap implementation lane; the review gate hardens and merges.
