### PR TITLE
Issue #3425: add finalizer claim decision contract

### DIFF
--- a/scripts/tools/slurm_job_finalize.py
+++ b/scripts/tools/slurm_job_finalize.py
@@ -47,6 +47,7 @@ DURABLE_URI_SCHEMES = (
     "gs://",
     "dvc://",
 )
+ALLOWED_CLAIM_DECISIONS = {"promote", "keep_diagnostic", "block", "stop"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -178,6 +179,19 @@ def validate_durable_uri(value: str | None) -> str | None:
     return candidate
 
 
+def normalize_claim_decision(value: str | None) -> str | None:
+    """Normalize bounded #3425 claim-decision labels."""
+    if value is None:
+        return None
+    normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+    if not normalized:
+        return None
+    if normalized not in ALLOWED_CLAIM_DECISIONS:
+        allowed = ", ".join(sorted(ALLOWED_CLAIM_DECISIONS))
+        raise ValueError(f"claim decision {value!r} must be one of: {allowed}")
+    return normalized
+
+
 def classify_durable_status(classification: str, durable_uri: str | None) -> str:
     """Classify durable-store readiness, fail-closed.
 
@@ -238,11 +252,17 @@ def issue_update_markdown(report: dict[str, Any]) -> str:
         f"- artifact status: `{report['artifact_status']}`",
         f"- durable status: `{report.get('durable_status', 'not_applicable')}`"
         + (f" -> `{report['durable_uri']}`" if report.get("durable_uri") else ""),
-        f"- claim boundary: {report['claim_boundary']}",
-        "",
-        "| Artifact | Required | Status | SHA256 |",
-        "| --- | --- | --- | --- |",
     ]
+    if report.get("claim_decision"):
+        lines.append(f"- claim decision: `{report['claim_decision']}`")
+    lines.extend(
+        [
+            f"- claim boundary: {report['claim_boundary']}",
+            "",
+            "| Artifact | Required | Status | SHA256 |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
     for artifact in report["artifacts"]:
         status = "present" if artifact["exists"] else "missing"
         digest = artifact["sha256"] or "n/a"
@@ -255,10 +275,11 @@ def issue_update_markdown(report: dict[str, Any]) -> str:
 
 def ledger_update_markdown(report: dict[str, Any]) -> str:
     """Return one compact ledger row for context notes or issue comments."""
+    claim_decision = report.get("claim_decision") or "n/a"
     return (
         f"| #{report['issue_number']} | `{report['job_id']}` | "
         f"`{report['classification']}` | `{report['artifact_status']}` | "
-        f"{report['next_action']} |"
+        f"`{claim_decision}` | {report['next_action']} |"
     )
 
 
@@ -292,9 +313,11 @@ def build_finalization_report(  # noqa: PLR0913
     manual_decision: bool = False,
     notes: str = "",
     durable_uri: str | None = None,
+    claim_decision: str | None = None,
 ) -> dict[str, Any]:
     """Build a compact SLURM finalization report."""
     validated_uri = validate_durable_uri(durable_uri)
+    normalized_claim_decision = normalize_claim_decision(claim_decision)
     artifacts = [
         artifact_record(path, repo_root=repo_root, role="expected", required=True)
         for path in expected_artifacts
@@ -326,6 +349,8 @@ def build_finalization_report(  # noqa: PLR0913
         "next_action": _next_action(classification),
         "notes": notes,
     }
+    if normalized_claim_decision is not None:
+        report["claim_decision"] = normalized_claim_decision
     report["issue_update_markdown"] = issue_update_markdown(report)
     report["ledger_update_markdown"] = ledger_update_markdown(report)
     return report
@@ -342,6 +367,7 @@ def build_control_plane_finalization_report(  # noqa: PLR0913
     manual_decision: bool = False,
     notes: str = "",
     durable_uri: str | None = None,
+    claim_decision: str | None = None,
 ) -> dict[str, Any]:
     """Build a report using the July 2026 research-control-plane run contract."""
     root = Path(run_root)
@@ -356,6 +382,7 @@ def build_control_plane_finalization_report(  # noqa: PLR0913
         manual_decision=manual_decision,
         notes=notes,
         durable_uri=durable_uri,
+        claim_decision=claim_decision,
     )
 
 
@@ -379,6 +406,17 @@ def _durable_uri_cli(value: str) -> str:
     if validated is None:
         raise argparse.ArgumentTypeError("durable URI must be non-empty")
     return validated
+
+
+def _claim_decision_cli(value: str) -> str:
+    """argparse type for bounded claim-decision labels."""
+    try:
+        normalized = normalize_claim_decision(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    if normalized is None:
+        raise argparse.ArgumentTypeError("claim decision must be non-empty")
+    return normalized
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -418,6 +456,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--notes", default="", help="Optional short note copied into the report.")
     parser.add_argument(
+        "--claim-decision",
+        type=_claim_decision_cli,
+        metavar="{promote,keep-diagnostic,keep_diagnostic,block,stop}",
+        help=(
+            "Bounded final disposition for the SLURM-to-claim slice. "
+            "Accepted labels normalize to promote, keep_diagnostic, block, or stop."
+        ),
+    )
+    parser.add_argument(
         "--durable-uri",
         type=_durable_uri_cli,
         help=(
@@ -444,6 +491,7 @@ def main(argv: list[str] | None = None) -> int:
             manual_decision=args.manual_decision,
             notes=args.notes,
             durable_uri=args.durable_uri,
+            claim_decision=args.claim_decision,
         )
     else:
         report = build_finalization_report(
@@ -456,6 +504,7 @@ def main(argv: list[str] | None = None) -> int:
             manual_decision=args.manual_decision,
             notes=args.notes,
             durable_uri=args.durable_uri,
+            claim_decision=args.claim_decision,
         )
     write_report(report, args.output, markdown_output=args.markdown_output)
     print(report["issue_update_markdown"])

--- a/scripts/validation/preflight_slurm_finalizer.py
+++ b/scripts/validation/preflight_slurm_finalizer.py
@@ -84,6 +84,7 @@ SCHEMA_VERSION = "slurm-finalizer-preflight.v1"
 _SUCCESS_CLASSIFICATIONS = {"success"}
 _DURABLE_POINTER_PREFIXES = (
     "wandb://",
+    "wandb-artifact://",
     "https://",
     "http://",
     "s3://",

--- a/tests/tools/test_slurm_job_finalize.py
+++ b/tests/tools/test_slurm_job_finalize.py
@@ -158,6 +158,8 @@ def test_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
             str(output),
             "--markdown-output",
             str(markdown),
+            "--claim-decision",
+            "keep-diagnostic",
         ]
     )
 
@@ -165,8 +167,12 @@ def test_cli_writes_json_and_markdown(tmp_path: Path, capsys) -> None:
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["schema_version"] == "robot-sf-slurm-job-finalization.v1"
     assert payload["classification"] == "success"
+    assert payload["claim_decision"] == "keep_diagnostic"
+    assert "| `keep_diagnostic` |" in payload["ledger_update_markdown"]
     assert markdown.read_text(encoding="utf-8").startswith("SLURM finalization")
-    assert "classification: `success`" in capsys.readouterr().out
+    rendered = capsys.readouterr().out
+    assert "classification: `success`" in rendered
+    assert "claim decision: `keep_diagnostic`" in rendered
 
 
 def test_cli_returns_nonzero_for_missing_artifacts(tmp_path: Path) -> None:

--- a/tests/validation/test_preflight_slurm_finalizer.py
+++ b/tests/validation/test_preflight_slurm_finalizer.py
@@ -114,6 +114,21 @@ def test_ready_when_all_inputs_present(tmp_path: Path) -> None:
     assert statuses["claim_decision_present"] == "ready"
 
 
+def test_ready_accepts_wandb_artifact_durable_pointer(tmp_path: Path) -> None:
+    """Weights & Biases artifact URIs are durable pointers for finalizer evidence."""
+    inputs = _ready_inputs(tmp_path)
+    _write_finalizer(
+        tmp_path / "finalizer.json",
+        durable_uri="wandb-artifact://robot-sf/finalizer/job-12345:latest",
+    )
+
+    report = gate.preflight(**inputs)
+
+    assert report["ready"] is True
+    statuses = {check["name"]: check["status"] for check in report["checks"]}
+    assert statuses["durable_pointer_present"] == "ready"
+
+
 def test_blocks_when_durable_pointer_missing(tmp_path: Path) -> None:
     """A successful finalizer without a durable pointer fails closed."""
     inputs = _ready_inputs(tmp_path)


### PR DESCRIPTION
## Reviewer-critical summary
What changed: `slurm_job_finalize.py` now accepts and emits a bounded `claim_decision` (`promote`, `keep_diagnostic`, `block`, `stop`) in JSON, generated issue Markdown, and ledger Markdown; `preflight_slurm_finalizer.py` now accepts `wandb-artifact://` as a durable pointer scheme.

Why now: issue #3425's maintainer plan requires the SLURM finalizer chain to produce an explicit claim decision and to fail closed on durable pointer/linkage gaps before any evidence is interpreted.

Claim boundary: support/tooling contract only. This PR does not run the SLURM campaign, does not reconcile a terminal job, and does not promote benchmark, planner-ranking, paper, or dissertation claims.

Required validation: focused finalizer/preflight tests plus the repository PR-ready gate against `origin/main`.

Remaining blocker: the actual `submission -> finalizer -> durable evidence -> summary -> claim decision` empirical run still requires an authorized SLURM-capable handoff and durable artifacts.

## Contract delta
New schema field: finalizer manifests may now include `claim_decision` when `--claim-decision` or the builder argument is supplied. The field is omitted when not supplied for backward compatibility.

New accepted values: `promote`, `keep_diagnostic`, `block`, `stop`; CLI spellings normalize `keep-diagnostic` and `keep diagnostic` to `keep_diagnostic`.

Fail-closed blockers: no blocker is relaxed. Preflight still requires successful finalizers to carry durable pointers and claim decisions; it now recognizes `wandb-artifact://` consistently with the finalizer and reconciler durable-pointer policy.

Compatibility impact: existing callers without `claim_decision` keep the old JSON shape. #3425 finalizer runs can now generate the required decision field without manually reconstructing issue comments.

Fragmentation guard: this is a progression slice adding a nameable new capability toward the issue plan: first-class finalizer claim-decision output plus aligned W&B Artifact durable-pointer acceptance.

## Linked Issues
- Relates to #3425
- Issue link: https://github.com/ll7/robot_sf_ll7/issues/3425

## What Changed
- Added `normalize_claim_decision()` and `--claim-decision` to `scripts/tools/slurm_job_finalize.py`.
- Rendered `claim_decision` in generated issue-update Markdown and ledger Markdown when present.
- Added `wandb-artifact://` to the preflight durable-pointer prefixes.
- Extended focused tests for finalizer CLI output and preflight durable-pointer readiness.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3425 workflow blocker: finalizer output must carry an explicit bounded claim decision before downstream interpretation.
- Comparator or baseline, applicable: NA - support/tooling contract.
- Evidence tier: NA - support helper; validation uses targeted CLI/preflight tests but makes no benchmark or research evidence claim.
- Result classification: NA - support helper; resolves a tooling contract gap but does not classify research evidence.
- Decision stop rule, applicable: NA.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3425 remains open for the empirical run.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper only.

## Domain-Aware Approval
- Approval concerns: not required for support/tooling contract; no evidence classification or paper-facing claim is changed.
- Fallback/degraded exclusions: no fallback/degraded execution is counted as evidence.
- Claim boundary: tooling contract only.

## Next Empirical Action
- Rerun needed: yes, for #3425 completion on an authorized SLURM-capable route.
- Extractor analysis tool needed: no new extractor from this PR.
- Artifact missing unavailable: terminal SLURM/finalizer durable evidence remains unavailable in this PR.
- Stop / revise / continue decision: continue with the empirical handoff after this contract gap is merged.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m py_compile scripts/tools/slurm_job_finalize.py scripts/validation/preflight_slurm_finalizer.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_slurm_job_finalize.py tests/validation/test_preflight_slurm_finalizer.py` - passed, 40 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format scripts/tools/slurm_job_finalize.py scripts/validation/preflight_slurm_finalizer.py tests/tools/test_slurm_job_finalize.py tests/validation/test_preflight_slurm_finalizer.py` - passed, 4 files left unchanged.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/slurm_job_finalize.py scripts/validation/preflight_slurm_finalizer.py tests/tools/test_slurm_job_finalize.py tests/validation/test_preflight_slurm_finalizer.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- env BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed before commit; core lane `1843 passed` with dirty-tree stamp.
- `scripts/dev/run_worktree_shared_venv.sh -- env PR_READY_MODE=final PR_READY_PR_BODY_FILE=<body> BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed on clean committed HEAD `919634f`; core lane `1843 passed`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: low; `claim_decision` is optional unless callers opt in.
- Failure modes: invalid decision labels now fail fast through builder/CLI validation.
- Rollback fallback plan: revert this PR; existing manifests without the field remain readable.

## Downstream Propagation
- Parent issue updated: no. This run is not authorized to comment on issues/PRs (`comment_issue_or_pr: false`). The PR body is the canonical public propagation surface for this slice.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no, issue #3425 already tracks the remaining empirical handoff.

<details>
<summary>Reviewer Notes</summary>

- No private host/account/scratch details are encoded in tracked files.
- No transient queue-routing state or packet lineage pointers are committed.
- The actual #3425 campaign evidence should still be produced as compact durable artifacts under the issue's existing evidence plan once SLURM execution is authorized.

</details>
