### PR TITLE
Issue #4455 perception-degradation ladder enablement

### DIFF
--- a/configs/benchmarks/issue_4455_perception_degradation_ladder_preregistration.yaml
+++ b/configs/benchmarks/issue_4455_perception_degradation_ladder_preregistration.yaml
@@ -1,0 +1,5 @@
+# Issue #4455 canonical preregistration path requested by maintainer comment.
+# Keep this wrapper small so the detailed manifest has one canonical owner.
+include: perception_degradation/issue_4455_ladder_v1.yaml
+submit_in_this_pr: false
+claim_boundary: enablement_only_no_campaign_no_paper_claim

--- a/configs/benchmarks/perception_degradation/issue_4455_ladder_v1.yaml
+++ b/configs/benchmarks/perception_degradation/issue_4455_ladder_v1.yaml
@@ -1,0 +1,72 @@
+schema_version: perception-degradation-ladder.v1
+issue: 4455
+study_id: issue_4455_perception_degradation_ladder_v1
+status: preregistered_enablement_config
+claim_boundary: >
+  Enablement-only preregistration for a bounded planner-input perception-degradation
+  ladder. This config is not benchmark evidence, not a full campaign result, and
+  not a paper-facing claim until the generated configs are run and promoted with
+  provenance.
+scenario_matrix: configs/scenarios/planner_sanity_matrix_v1.yaml
+seed_policy:
+  mode: fixed-list
+  seeds: [111, 112]
+cpu_smoke_defaults:
+  workers: 1
+  horizon: 5
+  dt: 0.1
+  record_forces: false
+  resume: false
+  export_publication_bundle: false
+planners:
+  - key: hybrid_rule_v0_minimal
+    algo: hybrid_rule_local_planner
+    algo_config: configs/algos/hybrid_rule_v0_minimal.yaml
+    planner_group: experimental
+    benchmark_profile: experimental
+  - key: ppo_baseline
+    algo: ppo
+    algo_config: configs/baselines/ppo_15m_grid_socnav.yaml
+    planner_group: experimental
+    benchmark_profile: experimental
+    adapter_impact_eval: true
+  - key: orca_baseline
+    algo: orca
+    planner_group: core
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fail-fast
+profiles:
+  - key: nominal_oracle
+    profile_hash: 0a5609f0b2b1
+    description: Current oracle-grade planner input; baseline for ladder comparisons.
+    observation_noise:
+      enabled: false
+      profile: none
+  - key: gaussian_track_noise_low
+    profile_hash: fc9abd0c2c88
+    description: Low synthetic Gaussian pedestrian-track noise on planner input.
+    observation_noise:
+      profile: gaussian_track_noise_low
+      seed: 445501
+      pedestrian_position_noise_std_m: 0.05
+  - key: fixed_detection_delay_1
+    profile_hash: 55e7ff4d05c0
+    description: One-step fixed pedestrian detection delay on planner input.
+    observation_noise:
+      profile: fixed_detection_delay_1
+      seed: 445502
+      observation_delay_steps: 1
+  - key: false_negative_pedestrian_drop_10pct
+    profile_hash: c76cf85c757d
+    description: Ten percent pedestrian false-negative drops on planner input.
+    observation_noise:
+      profile: false_negative_pedestrian_drop_10pct
+      seed: 445503
+      pedestrian_false_negative_prob: 0.10
+  - key: occlusion_range_4m
+    profile_hash: 600086b5b447
+    description: Range-limited pedestrian visibility proxy on planner input.
+    observation_noise:
+      profile: occlusion_range_4m
+      seed: 445504
+      pedestrian_occlusion_max_range_m: 4.0

--- a/configs/benchmarks/perception_degradation_profiles_v1.yaml
+++ b/configs/benchmarks/perception_degradation_profiles_v1.yaml
@@ -1,0 +1,47 @@
+schema_version: perception-degradation-profiles.v1
+issue: 4455
+claim_boundary: >
+  Diagnostic, non-calibrated planner-input perception stressors only. Simulator
+  ground truth, collision detection, termination logic, and metric computation
+  remain unchanged.
+ordered_profile_keys:
+  - nominal_oracle
+  - gaussian_track_noise_low
+  - fixed_detection_delay_1
+  - false_negative_pedestrian_drop_10pct
+  - occlusion_range_4m
+profiles:
+  - key: nominal_oracle
+    profile_hash: 0a5609f0b2b1
+    claim_boundary: no-op oracle-grade planner input baseline
+    observation_noise:
+      enabled: false
+      profile: none
+  - key: gaussian_track_noise_low
+    profile_hash: fc9abd0c2c88
+    claim_boundary: non-calibrated Gaussian pedestrian-track noise on planner input
+    observation_noise:
+      profile: gaussian_track_noise_low
+      seed: 445501
+      pedestrian_position_noise_std_m: 0.05
+  - key: fixed_detection_delay_1
+    profile_hash: 55e7ff4d05c0
+    claim_boundary: deterministic one-step pedestrian detection delay on planner input
+    observation_noise:
+      profile: fixed_detection_delay_1
+      seed: 445502
+      observation_delay_steps: 1
+  - key: false_negative_pedestrian_drop_10pct
+    profile_hash: c76cf85c757d
+    claim_boundary: ten percent planner-facing pedestrian track dropout
+    observation_noise:
+      profile: false_negative_pedestrian_drop_10pct
+      seed: 445503
+      pedestrian_false_negative_prob: 0.10
+  - key: occlusion_range_4m
+    profile_hash: 600086b5b447
+    claim_boundary: planner-facing range-limited pedestrian visibility proxy
+    observation_noise:
+      profile: occlusion_range_4m
+      seed: 445504
+      pedestrian_occlusion_max_range_m: 4.0

--- a/docs/context/issue_4455_perception_degradation_ladder.md
+++ b/docs/context/issue_4455_perception_degradation_ladder.md
@@ -1,0 +1,52 @@
+# Issue #4455 Perception-Degradation Ladder
+
+Issue: [#4455](https://github.com/ll7/robot_sf_ll7/issues/4455)
+
+This note records the enablement contract for a bounded perception-degradation
+ladder requested after external dissertation review. The current benchmark
+campaigns use oracle-grade planner input; this slice pre-registers diagnostic,
+non-calibrated stress profiles so a later campaign can measure whether planner
+ranking and failure modes survive degraded planner input.
+
+## Claim Boundary
+
+This is an enablement and pre-registration surface only. It is not benchmark
+evidence, not a full campaign result, and not a paper or dissertation claim.
+
+All degradation profiles apply to planner input only. Simulator ground truth,
+collision detection, termination logic, trajectory recording, and metric
+computation remain unchanged. Episode rows retain the normalized
+`observation_noise` block, `observation_noise_hash`, and
+`observation_noise_stats` counters for provenance.
+
+## Profile Table
+
+The canonical profile catalog is
+`configs/benchmarks/perception_degradation_profiles_v1.yaml`.
+
+| Profile | Hash | Planner-input perturbation |
+| --- | --- | --- |
+| `nominal_oracle` | `0a5609f0b2b1` | No-op oracle-grade baseline |
+| `gaussian_track_noise_low` | `fc9abd0c2c88` | Gaussian pedestrian-track coordinate noise |
+| `fixed_detection_delay_1` | `55e7ff4d05c0` | One-step pedestrian-observation delay |
+| `false_negative_pedestrian_drop_10pct` | `c76cf85c757d` | 10% pedestrian track dropout |
+| `occlusion_range_4m` | `600086b5b447` | Hide pedestrian tracks outside 4m range |
+
+The preregistered ladder manifest is
+`configs/benchmarks/perception_degradation/issue_4455_ladder_v1.yaml`; the
+maintainer-requested wrapper path is
+`configs/benchmarks/issue_4455_perception_degradation_ladder_preregistration.yaml`.
+
+## Handoff
+
+Use
+`scripts/benchmark/build_perception_degradation_ladder_issue_4455.py --validate-only`
+for a cheap profile/config check. Use the same script with `--out-dir` to
+generate one camera-ready CPU smoke config per profile under local `output/`.
+Those generated configs are disposable local validation artifacts unless a later
+campaign promotes them with provenance.
+
+Private-queue or Slurm submission is intentionally out of scope for this PR.
+The next empirical action remains under issue #4455: run the generated configs
+or a capacity-appropriate campaign, then synthesize whether rank stability and
+failure-mode stability survive the degradation ladder.

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -103,6 +103,7 @@ from robot_sf.benchmark.metrics import EpisodeData, compute_all_metrics, post_pr
 from robot_sf.benchmark.observation_noise import (
     apply_observation_noise,
     make_observation_noise_rng,
+    make_observation_noise_state,
     merge_observation_noise_stats,
     new_observation_noise_stats,
     normalize_observation_noise_spec,
@@ -829,6 +830,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     )
     noise_spec = normalize_observation_noise_spec(observation_noise)
     noise_rng = make_observation_noise_rng(noise_spec, seed=seed, scenario_id=scenario_id)
+    noise_state = make_observation_noise_state(noise_spec)
     noise_stats = new_observation_noise_stats()
     tracking_precision_spec = normalize_tracking_precision_spec(tracking_precision)
     tracking_precision_rng = make_tracking_precision_rng(
@@ -996,7 +998,12 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         ammv_command_actions: list[dict[str, Any]] = []
         view_integrity: dict[str, Any] | None = None
         for step_idx in range(horizon_val):
-            policy_obs, step_noise_stats = apply_observation_noise(obs, noise_spec, noise_rng)
+            policy_obs, step_noise_stats = apply_observation_noise(
+                obs,
+                noise_spec,
+                noise_rng,
+                noise_state,
+            )
             merge_observation_noise_stats(noise_stats, step_noise_stats)
             policy_obs, corrupted_ped_positions = _apply_tracking_precision_to_observation(
                 policy_obs,

--- a/robot_sf/benchmark/observation_noise.py
+++ b/robot_sf/benchmark/observation_noise.py
@@ -572,11 +572,19 @@ def _apply_observation_delay(
     delay_steps = int(spec.get("observation_delay_steps", 0) or 0)
     if delay_steps <= 0:
         return
+    if state is None:
+        # Fail closed: observation delay needs persistent per-episode state to
+        # carry pedestrian snapshots across steps. A transient state created
+        # here would be discarded every call, silently yielding a no-op delay
+        # (under-reported perception degradation). Callers must thread the
+        # state from ``make_observation_noise_state``.
+        raise ValueError(
+            "observation_delay_steps > 0 requires a persistent ObservationNoiseState; "
+            "pass the state from make_observation_noise_state()"
+        )
     snapshot = _pedestrian_snapshot(obs)
     if snapshot is None:
         return
-    if state is None:
-        state = ObservationNoiseState(delay_steps=delay_steps)
     state.pedestrian_delay_buffer.append(snapshot)
     if len(state.pedestrian_delay_buffer) <= delay_steps:
         return

--- a/robot_sf/benchmark/observation_noise.py
+++ b/robot_sf/benchmark/observation_noise.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import deque
 from copy import deepcopy
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -24,7 +26,10 @@ _DEFAULT_SPEC: dict[str, Any] = {
     "heading_noise_std_rad": 0.0,
     "lidar_dropout_prob": 0.0,
     "lidar_dropout_value": 0.0,
+    "pedestrian_position_noise_std_m": 0.0,
     "pedestrian_false_negative_prob": 0.0,
+    "pedestrian_occlusion_max_range_m": None,
+    "observation_delay_steps": 0,
     "pedestrian_false_positive_prob": 0.0,
     "pedestrian_false_positive_radius_m": 4.0,
     "pedestrian_false_positive_radius": 0.35,
@@ -34,77 +39,128 @@ _DEFAULT_SPEC: dict[str, Any] = {
 _LIDAR_KEYS = {"lidar", "lidar_rays", "laser", "laser_scan", "range", "ranges", "rays"}
 
 
+@dataclass
+class ObservationNoiseState:
+    """Mutable per-episode state for temporal planner-input perturbations."""
+
+    delay_steps: int = 0
+    pedestrian_delay_buffer: deque[dict[str, Any]] = field(default_factory=deque)
+
+    def __post_init__(self) -> None:
+        """Normalize delay-buffer capacity."""
+
+        if self.delay_steps < 0:
+            raise ValueError("delay_steps must be >= 0")
+        capacity = max(1, self.delay_steps + 1)
+        if self.pedestrian_delay_buffer.maxlen != capacity:
+            self.pedestrian_delay_buffer = deque(
+                self.pedestrian_delay_buffer,
+                maxlen=capacity,
+            )
+
+
 def observation_noise_hash(spec: dict[str, Any]) -> str:
-    """Return a stable short hash for a normalized observation-noise spec."""
+    """Return a stable short hash for a normalized observation-noise spec.
+
+    Returns:
+        Twelve-character SHA-1 prefix for provenance fields.
+    """
+
     encoded = json.dumps(spec, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha1(encoded).hexdigest()[:12]
 
 
 def normalize_observation_noise_spec(spec: dict[str, Any] | None) -> dict[str, Any]:
-    """Validate and normalize an optional observation-noise configuration.
+    """Validate and normalize optional observation-noise configuration.
 
     Returns:
-        Canonical JSON-serializable noise specification. Omitted or zero-valued specs become a
-        disabled ``profile: none`` no-op profile.
+        Canonical JSON-serializable observation-noise specification.
     """
+
     if spec is None:
         return dict(_DEFAULT_SPEC)
     if not isinstance(spec, dict):
         raise TypeError("observation_noise must be a mapping")
 
-    enabled_explicit = "enabled" in spec
     normalized = dict(_DEFAULT_SPEC)
-    normalized.update(deepcopy(spec))
+    normalized.update(spec)
+
+    enabled_explicit = "enabled" in spec
+    _normalize_float_fields(normalized)
+
+    delay_steps = int(normalized.get("observation_delay_steps", 0) or 0)
+    if delay_steps < 0:
+        raise ValueError("observation_delay_steps must be >= 0")
+    normalized["observation_delay_steps"] = delay_steps
+
+    normalized["pedestrian_occlusion_max_range_m"] = _normalize_optional_positive_float(
+        normalized.get("pedestrian_occlusion_max_range_m"),
+        "pedestrian_occlusion_max_range_m",
+    )
+
     normalized["profile"] = str(normalized.get("profile") or NO_OBSERVATION_NOISE_PROFILE)
-    normalized["interpretation"] = OBSERVATION_NOISE_INTERPRETATION
+    normalized["interpretation"] = str(
+        normalized.get("interpretation") or OBSERVATION_NOISE_INTERPRETATION
+    )
+    seed = normalized.get("seed")
+    normalized["seed"] = int(seed) if seed is not None else None
+
+    active = (
+        any(
+            float(normalized[key]) > 0.0
+            for key in (
+                "pose_noise_std_m",
+                "heading_noise_std_rad",
+                "lidar_dropout_prob",
+                "pedestrian_position_noise_std_m",
+                "pedestrian_false_negative_prob",
+                "pedestrian_false_positive_prob",
+                "observation_delay_steps",
+            )
+        )
+        or normalized["pedestrian_occlusion_max_range_m"] is not None
+    )
+    normalized["enabled"] = bool(normalized.get("enabled", False)) if enabled_explicit else active
+    if not normalized["enabled"]:
+        normalized["profile"] = NO_OBSERVATION_NOISE_PROFILE
+    return normalized
+
+
+def _normalize_float_fields(normalized: dict[str, Any]) -> None:
+    """Normalize scalar float fields in place."""
 
     for key in (
         "pose_noise_std_m",
         "heading_noise_std_rad",
         "lidar_dropout_prob",
         "lidar_dropout_value",
+        "pedestrian_position_noise_std_m",
         "pedestrian_false_negative_prob",
         "pedestrian_false_positive_prob",
         "pedestrian_false_positive_radius_m",
         "pedestrian_false_positive_radius",
     ):
-        normalized[key] = float(normalized.get(key, 0.0))
+        normalized[key] = float(normalized.get(key, 0.0) or 0.0)
+        if key.endswith("_prob") and not 0.0 <= normalized[key] <= 1.0:
+            raise ValueError(f"{key} must be in [0, 1]")
+        if (
+            key.endswith("_std_m") or key.endswith("_std_rad") or key.endswith("_radius_m")
+        ) and normalized[key] < 0.0:
+            raise ValueError(f"{key} must be >= 0")
 
-    for key in (
-        "lidar_dropout_prob",
-        "pedestrian_false_negative_prob",
-        "pedestrian_false_positive_prob",
-    ):
-        value = float(normalized[key])
-        if not 0.0 <= value <= 1.0:
-            raise ValueError(f"observation_noise.{key} must be between 0 and 1")
 
-    for key in (
-        "pose_noise_std_m",
-        "heading_noise_std_rad",
-        "pedestrian_false_positive_radius_m",
-        "pedestrian_false_positive_radius",
-    ):
-        if float(normalized[key]) < 0.0:
-            raise ValueError(f"observation_noise.{key} must be non-negative")
+def _normalize_optional_positive_float(value: Any, key: str) -> float | None:
+    """Normalize an optional positive float.
 
-    seed = normalized.get("seed")
-    normalized["seed"] = int(seed) if seed is not None else None
-    active = any(
-        float(normalized[key]) > 0.0
-        for key in (
-            "pose_noise_std_m",
-            "heading_noise_std_rad",
-            "lidar_dropout_prob",
-            "pedestrian_false_negative_prob",
-            "pedestrian_false_positive_prob",
-        )
-    )
-    normalized["enabled"] = (
-        bool(normalized.get("enabled", False)) if enabled_explicit else active
-    ) and active
-    if not normalized["enabled"]:
-        normalized["profile"] = NO_OBSERVATION_NOISE_PROFILE
+    Returns:
+        Positive float when provided; otherwise ``None``.
+    """
+
+    if value is None:
+        return None
+    normalized = float(value)
+    if normalized <= 0.0:
+        raise ValueError(f"{key} must be positive when set")
     return normalized
 
 
@@ -112,8 +168,9 @@ def load_observation_noise_spec(path: str | Path) -> dict[str, Any]:
     """Load and normalize an observation-noise YAML file.
 
     Returns:
-        Canonical observation-noise spec.
+        Canonical observation-noise specification.
     """
+
     noise_path = Path(path)
     data = yaml.safe_load(noise_path.read_text(encoding="utf-8")) or {}
     if isinstance(data, dict) and isinstance(data.get("observation_noise"), dict):
@@ -122,13 +179,17 @@ def load_observation_noise_spec(path: str | Path) -> dict[str, Any]:
 
 
 def make_observation_noise_rng(
-    spec: dict[str, Any], *, seed: int, scenario_id: str
+    spec: dict[str, Any],
+    *,
+    seed: int,
+    scenario_id: str,
 ) -> np.random.Generator:
     """Create a deterministic per-episode RNG for observation corruption.
 
     Returns:
-        NumPy generator scoped to the scenario seed and normalized spec.
+        NumPy generator scoped to the scenario, episode seed, and profile.
     """
+
     spec_seed = spec.get("seed")
     material = {
         "episode_seed": int(seed),
@@ -143,46 +204,87 @@ def make_observation_noise_rng(
     return np.random.default_rng(int.from_bytes(digest[:8], "big", signed=False))
 
 
+def make_observation_noise_state(spec: dict[str, Any]) -> ObservationNoiseState:
+    """Create per-episode mutable state for observation-noise application.
+
+    Returns:
+        Mutable state object used across steps in one episode.
+    """
+
+    return ObservationNoiseState(delay_steps=int(spec.get("observation_delay_steps", 0) or 0))
+
+
 def new_observation_noise_stats() -> dict[str, int]:
-    """Return zeroed per-episode observation-noise counters."""
+    """Return zeroed per-episode observation-noise counters.
+
+    Returns:
+        Counter mapping for per-step or per-episode observation-noise stats.
+    """
+
     return {
         "steps_with_noise": 0,
         "pose_noise_applied": 0,
         "heading_noise_applied": 0,
         "lidar_values_dropped": 0,
+        "pedestrian_position_noise_applied": 0,
         "pedestrians_removed": 0,
+        "pedestrians_occluded": 0,
+        "observation_delay_applied": 0,
         "pedestrians_added": 0,
     }
+
+
+def merge_observation_noise_stats(total: dict[str, int], step: dict[str, int]) -> None:
+    """Accumulate step-level observation-noise counters into an episode total."""
+
+    for key, value in step.items():
+        total[key] = int(total.get(key, 0)) + int(value)
 
 
 def apply_observation_noise(
     obs: dict[str, Any],
     spec: dict[str, Any],
     rng: np.random.Generator,
+    state: ObservationNoiseState | None = None,
 ) -> tuple[dict[str, Any], dict[str, int]]:
     """Apply benchmark observation noise to one planner input observation.
 
     Returns:
-        Pair of noisy observation and step-level noise counters.
+        Pair of noisy observation copy and step-level observation-noise counters.
     """
+
     stats = new_observation_noise_stats()
     if not bool(spec.get("enabled", False)):
         return obs, stats
-
     noisy = deepcopy(obs)
     _apply_pose_noise(noisy, spec, rng, stats)
     _apply_lidar_dropout(noisy, spec, rng, stats)
     _apply_pedestrian_noise(noisy, spec, rng, stats)
+    _apply_observation_delay(noisy, spec, state, stats)
     if any(value > 0 for key, value in stats.items() if key != "steps_with_noise"):
         stats["steps_with_noise"] = 1
     return noisy, stats
 
 
 def _as_xy_array(value: Any) -> np.ndarray | None:
-    arr = np.asarray(value, dtype=float)
+    try:
+        arr = np.asarray(value, dtype=float)
+    except (TypeError, ValueError):
+        return None
     if arr.size < 2:
         return None
     return arr.reshape(-1)[:2].astype(float, copy=True)
+
+
+def _robot_position(obs: dict[str, Any]) -> np.ndarray:
+    robot_pos = _as_xy_array(obs.get("robot_position"))
+    if robot_pos is not None:
+        return robot_pos
+    robot = obs.get("robot") if isinstance(obs.get("robot"), dict) else {}
+    robot_pos = _as_xy_array(robot.get("position"))
+    if robot_pos is not None:
+        return robot_pos
+    return np.zeros(2, dtype=float)
 
 
 def _apply_pose_noise(
@@ -215,7 +317,7 @@ def _apply_pose_noise(
     if robot is not None and "heading" in robot:
         robot["heading"] = _with_heading_delta(robot["heading"], delta_heading)
         stats["heading_noise_applied"] += 1
-    elif "robot_heading" in obs:
+    if "robot_heading" in obs:
         obs["robot_heading"] = _with_heading_delta(obs["robot_heading"], delta_heading)
         stats["heading_noise_applied"] += 1
 
@@ -248,7 +350,6 @@ def _apply_lidar_dropout(
                     node[key] = _drop_numeric_values(value, dropout_prob, dropout_value, rng, stats)
                 elif isinstance(value, dict):
                     _visit(value)
-            return node
         return node
 
     _visit(obs)
@@ -284,6 +385,7 @@ def _apply_pedestrian_noise(
     if not isinstance(pedestrians, dict):
         _apply_flat_pedestrian_noise(obs, spec, rng, stats)
         return
+
     positions = np.asarray(pedestrians.get("positions", []), dtype=float).reshape(-1, 2)
     velocities = np.asarray(pedestrians.get("velocities", []), dtype=float).reshape(-1, 2)
     radii = np.asarray(pedestrians.get("radius", []), dtype=float).reshape(-1)
@@ -301,19 +403,29 @@ def _apply_pedestrian_noise(
         radii = radii[keep]
         stats["pedestrians_removed"] += removed
 
+    positions, velocities, radii = _apply_range_occlusion(
+        obs,
+        positions,
+        velocities,
+        radii,
+        spec,
+        stats,
+    )
+    positions = _apply_pedestrian_position_noise(positions, spec, rng, stats)
+
     fp_prob = float(spec.get("pedestrian_false_positive_prob", 0.0))
     if fp_prob > 0.0 and float(rng.random()) < fp_prob:
-        robot = obs.get("robot") if isinstance(obs.get("robot"), dict) else {}
-        robot_pos = _as_xy_array(robot.get("position", [0.0, 0.0]))
-        if robot_pos is None:
-            robot_pos = np.zeros(2, dtype=float)
+        robot_pos = _robot_position(obs)
         angle = float(rng.uniform(0.0, 2.0 * np.pi))
         radius_m = float(rng.uniform(0.0, spec.get("pedestrian_false_positive_radius_m", 4.0)))
         fp_pos = robot_pos + np.array([np.cos(angle), np.sin(angle)], dtype=float) * radius_m
         positions = np.vstack([positions, fp_pos.reshape(1, 2)])
         velocities = np.vstack([velocities, np.zeros((1, 2), dtype=float)])
         radii = np.concatenate(
-            [radii, np.array([float(spec.get("pedestrian_false_positive_radius", 0.35))])]
+            [
+                radii,
+                np.asarray([float(spec.get("pedestrian_false_positive_radius", 0.35))]),
+            ]
         )
         stats["pedestrians_added"] += 1
 
@@ -329,7 +441,6 @@ def _apply_flat_pedestrian_noise(
     rng: np.random.Generator,
     stats: dict[str, int],
 ) -> None:
-    """Apply pedestrian noise to flattened SocNav structured observations."""
     if "pedestrians_positions" not in obs:
         return
     positions_buf = np.asarray(obs.get("pedestrians_positions", []), dtype=float).reshape(-1, 2)
@@ -354,18 +465,23 @@ def _apply_flat_pedestrian_noise(
         velocities = velocities[keep]
         stats["pedestrians_removed"] += removed
 
+    positions, velocities, _ = _apply_range_occlusion(
+        obs,
+        positions,
+        velocities,
+        np.full((positions.shape[0],), 0.35, dtype=float),
+        spec,
+        stats,
+    )
+    positions = _apply_pedestrian_position_noise(positions, spec, rng, stats)
+
     fp_prob = float(spec.get("pedestrian_false_positive_prob", 0.0))
     if (
         fp_prob > 0.0
         and positions.shape[0] < positions_buf.shape[0]
         and float(rng.random()) < fp_prob
     ):
-        robot_pos = _as_xy_array(obs.get("robot_position"))
-        if robot_pos is None:
-            robot = obs.get("robot") if isinstance(obs.get("robot"), dict) else {}
-            robot_pos = _as_xy_array(robot.get("position", [0.0, 0.0]))
-        if robot_pos is None:
-            robot_pos = np.zeros(2, dtype=float)
+        robot_pos = _robot_position(obs)
         angle = float(rng.uniform(0.0, 2.0 * np.pi))
         radius_m = float(rng.uniform(0.0, spec.get("pedestrian_false_positive_radius_m", 4.0)))
         fp_pos = robot_pos + np.array([np.cos(angle), np.sin(angle)], dtype=float) * radius_m
@@ -373,28 +489,97 @@ def _apply_flat_pedestrian_noise(
         velocities = np.vstack([velocities, np.zeros((1, 2), dtype=float)])
         stats["pedestrians_added"] += 1
 
-    out_positions = np.array(positions_buf, copy=True)
-    out_velocities = np.array(velocities_buf, copy=True)
+    out_positions = np.array(positions_buf, dtype=float, copy=True)
+    out_velocities = np.array(velocities_buf, dtype=float, copy=True)
     out_positions[:] = 0.0
     out_velocities[:] = 0.0
-    out_count = min(positions.shape[0], out_positions.shape[0])
-    if out_count:
-        out_positions[:out_count] = positions[:out_count]
-        out_velocities[:out_count] = velocities[:out_count]
+    out_positions[: positions.shape[0]] = positions
+    out_velocities[: velocities.shape[0]] = velocities
     obs["pedestrians_positions"] = out_positions.tolist()
     obs["pedestrians_velocities"] = out_velocities.tolist()
-    obs["pedestrians_count"] = np.array([float(out_count)], dtype=float).tolist()
+    obs["pedestrians_count"] = [float(positions.shape[0])]
 
 
-def merge_observation_noise_stats(
-    total: dict[str, int],
-    step_stats: dict[str, int],
-) -> dict[str, int]:
-    """Accumulate step-level noise counters into an episode total.
+def _apply_range_occlusion(
+    obs: dict[str, Any],
+    positions: np.ndarray,
+    velocities: np.ndarray,
+    radii: np.ndarray,
+    spec: dict[str, Any],
+    stats: dict[str, int],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    range_limit = spec.get("pedestrian_occlusion_max_range_m")
+    if range_limit is None or positions.shape[0] == 0:
+        return positions, velocities, radii
+    robot_pos = _robot_position(obs)
+    distances = np.linalg.norm(positions - robot_pos.reshape(1, 2), axis=1)
+    keep = distances <= float(range_limit)
+    occluded = int(positions.shape[0] - np.count_nonzero(keep))
+    if occluded <= 0:
+        return positions, velocities, radii
+    stats["pedestrians_occluded"] += occluded
+    return positions[keep], velocities[keep], radii[keep]
+
+
+def _apply_pedestrian_position_noise(
+    positions: np.ndarray,
+    spec: dict[str, Any],
+    rng: np.random.Generator,
+    stats: dict[str, int],
+) -> np.ndarray:
+    """Apply Gaussian noise to planner-facing pedestrian coordinates.
 
     Returns:
-        The updated total counter mapping.
+        Pedestrian positions with deterministic Gaussian offsets applied.
     """
-    for key, value in step_stats.items():
-        total[key] = int(total.get(key, 0)) + int(value)
-    return total
+
+    noise_std = float(spec.get("pedestrian_position_noise_std_m", 0.0))
+    if noise_std <= 0.0 or positions.shape[0] == 0:
+        return positions
+    stats["pedestrian_position_noise_applied"] += int(positions.shape[0])
+    return positions + rng.normal(0.0, noise_std, size=positions.shape)
+
+
+def _pedestrian_snapshot(obs: dict[str, Any]) -> dict[str, Any] | None:
+    pedestrians = obs.get("pedestrians")
+    if isinstance(pedestrians, dict):
+        return {"kind": "structured", "pedestrians": deepcopy(pedestrians)}
+    if "pedestrians_positions" in obs:
+        return {
+            "kind": "flat",
+            "pedestrians_positions": deepcopy(obs.get("pedestrians_positions")),
+            "pedestrians_velocities": deepcopy(obs.get("pedestrians_velocities")),
+            "pedestrians_count": deepcopy(obs.get("pedestrians_count")),
+        }
+    return None
+
+
+def _restore_pedestrian_snapshot(obs: dict[str, Any], snapshot: dict[str, Any]) -> None:
+    if snapshot.get("kind") == "structured":
+        obs["pedestrians"] = deepcopy(snapshot["pedestrians"])
+        return
+    obs["pedestrians_positions"] = deepcopy(snapshot.get("pedestrians_positions"))
+    obs["pedestrians_velocities"] = deepcopy(snapshot.get("pedestrians_velocities"))
+    obs["pedestrians_count"] = deepcopy(snapshot.get("pedestrians_count"))
+
+
+def _apply_observation_delay(
+    obs: dict[str, Any],
+    spec: dict[str, Any],
+    state: ObservationNoiseState | None,
+    stats: dict[str, int],
+) -> None:
+    delay_steps = int(spec.get("observation_delay_steps", 0) or 0)
+    if delay_steps <= 0:
+        return
+    snapshot = _pedestrian_snapshot(obs)
+    if snapshot is None:
+        return
+    if state is None:
+        state = ObservationNoiseState(delay_steps=delay_steps)
+    state.pedestrian_delay_buffer.append(snapshot)
+    if len(state.pedestrian_delay_buffer) <= delay_steps:
+        return
+    delayed_snapshot = state.pedestrian_delay_buffer[0]
+    _restore_pedestrian_snapshot(obs, delayed_snapshot)
+    stats["observation_delay_applied"] += 1

--- a/scripts/benchmark/build_perception_degradation_ladder_issue_4455.py
+++ b/scripts/benchmark/build_perception_degradation_ladder_issue_4455.py
@@ -1,0 +1,125 @@
+"""Build issue #4455 perception-degradation ladder smoke configs.
+
+The script expands a preregistered ladder manifest into one camera-ready campaign
+config per degradation profile. It does not run or submit a benchmark campaign.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.camera_ready._config import load_campaign_config
+from robot_sf.benchmark.observation_noise import (
+    normalize_observation_noise_spec,
+    observation_noise_hash,
+)
+
+DEFAULT_MANIFEST = Path("configs/benchmarks/perception_degradation/issue_4455_ladder_v1.yaml")
+DEFAULT_OUT_DIR = Path("output/benchmarks/issue_4455_perception_degradation_ladder")
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise TypeError(f"{path} must contain a YAML mapping")
+    return data
+
+
+def _require_list(payload: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    values = payload.get(key)
+    if not isinstance(values, list) or not values:
+        raise ValueError(f"{key} must be a non-empty list")
+    if any(not isinstance(value, dict) for value in values):
+        raise TypeError(f"{key} entries must be mappings")
+    return values
+
+
+def _campaign_payload(manifest: dict[str, Any], profile: dict[str, Any]) -> dict[str, Any]:
+    profile_key = str(profile.get("key") or "").strip()
+    if not profile_key:
+        raise ValueError("profile key is required")
+    observation_noise = normalize_observation_noise_spec(profile.get("observation_noise"))
+    declared_hash = str(profile.get("profile_hash") or "").strip()
+    computed_hash = observation_noise_hash(observation_noise)
+    if declared_hash and declared_hash != computed_hash:
+        raise ValueError(
+            f"profile {profile_key!r} declared hash {declared_hash!r} "
+            f"does not match normalized hash {computed_hash!r}"
+        )
+    defaults = dict(manifest.get("cpu_smoke_defaults") or {})
+    return {
+        "name": f"issue_4455_perception_degradation_{profile_key}",
+        "scenario_matrix": manifest["scenario_matrix"],
+        "seed_policy": manifest["seed_policy"],
+        "workers": int(defaults.get("workers", 1)),
+        "horizon": int(defaults.get("horizon", 5)),
+        "dt": float(defaults.get("dt", 0.1)),
+        "record_forces": bool(defaults.get("record_forces", False)),
+        "resume": bool(defaults.get("resume", False)),
+        "export_publication_bundle": bool(defaults.get("export_publication_bundle", False)),
+        "observation_noise": observation_noise,
+        "planners": manifest["planners"],
+        "claim_boundary": manifest["claim_boundary"],
+    }
+
+
+def build_ladder_configs(
+    manifest_path: Path = DEFAULT_MANIFEST,
+    out_dir: Path = DEFAULT_OUT_DIR,
+    *,
+    validate_only: bool = False,
+) -> list[Path]:
+    """Validate the preregistered ladder and optionally write campaign configs."""
+
+    manifest = _load_yaml(manifest_path)
+    if manifest.get("schema_version") != "perception-degradation-ladder.v1":
+        raise ValueError("schema_version must be perception-degradation-ladder.v1")
+    if int(manifest.get("issue", 0)) != 4455:
+        raise ValueError("issue must be 4455")
+    if not manifest.get("scenario_matrix"):
+        raise ValueError("scenario_matrix is required")
+    if not isinstance(manifest.get("seed_policy"), dict):
+        raise TypeError("seed_policy must be a mapping")
+    _require_list(manifest, "planners")
+    profiles = _require_list(manifest, "profiles")
+
+    generated: list[Path] = []
+    if not validate_only:
+        out_dir.mkdir(parents=True, exist_ok=True)
+    for profile in profiles:
+        payload = _campaign_payload(manifest, profile)
+        if validate_only:
+            continue
+        path = out_dir / f"{payload['name']}.yaml"
+        path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+        load_campaign_config(path)
+        generated.append(path)
+    return generated
+
+
+def main() -> int:
+    """Run the issue #4455 ladder config builder CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--validate-only", action="store_true")
+    args = parser.parse_args()
+    generated = build_ladder_configs(
+        args.manifest,
+        args.out_dir,
+        validate_only=args.validate_only,
+    )
+    if args.validate_only:
+        print(f"validated {args.manifest}")
+    else:
+        print(f"wrote {len(generated)} configs to {args.out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_observation_noise.py
+++ b/tests/benchmark/test_observation_noise.py
@@ -8,6 +8,7 @@ import pytest
 from robot_sf.benchmark.observation_noise import (
     apply_observation_noise,
     make_observation_noise_rng,
+    make_observation_noise_state,
     normalize_observation_noise_spec,
     observation_noise_hash,
 )
@@ -73,6 +74,84 @@ def test_observation_noise_applies_lidar_pedestrian_and_pose_noise() -> None:
     assert stats["pedestrians_removed"] == 2
     assert stats["pedestrians_added"] == 1
     assert stats["steps_with_noise"] == 1
+
+
+def test_observation_noise_range_occlusion_filters_planner_pedestrians() -> None:
+    """Range occlusion removes only planner-facing pedestrian detections."""
+
+    spec = normalize_observation_noise_spec(
+        {
+            "profile": "range_occlusion",
+            "pedestrian_occlusion_max_range_m": 1.5,
+        }
+    )
+    obs = _sample_obs()
+    rng = make_observation_noise_rng(spec, seed=1, scenario_id="s1")
+
+    noisy, stats = apply_observation_noise(obs, spec, rng)
+
+    assert spec["enabled"] is True
+    assert obs["pedestrians"]["count"] == 2
+    assert noisy["pedestrians"]["count"] == 1
+    assert noisy["pedestrians"]["positions"] == [[2.0, 2.0]]
+    assert stats["pedestrians_occluded"] == 1
+    assert stats["steps_with_noise"] == 1
+
+
+def test_observation_noise_adds_deterministic_pedestrian_track_noise_only() -> None:
+    """Gaussian track noise perturbs planner-facing pedestrians, not simulator truth."""
+
+    spec = normalize_observation_noise_spec(
+        {
+            "profile": "pedestrian_track_noise",
+            "seed": 4455,
+            "pedestrian_position_noise_std_m": 0.1,
+        }
+    )
+    obs = _sample_obs()
+    rng_a = make_observation_noise_rng(spec, seed=1, scenario_id="s1")
+    rng_b = make_observation_noise_rng(spec, seed=1, scenario_id="s1")
+
+    noisy_a, stats_a = apply_observation_noise(obs, spec, rng_a)
+    noisy_b, stats_b = apply_observation_noise(obs, spec, rng_b)
+
+    assert obs["pedestrians"]["positions"] == [[2.0, 2.0], [3.0, 2.0]]
+    assert noisy_a["robot"]["position"] == [1.0, 2.0]
+    assert noisy_a["pedestrians"]["positions"] != [[2.0, 2.0], [3.0, 2.0]]
+    assert noisy_a["pedestrians"]["positions"] == noisy_b["pedestrians"]["positions"]
+    assert stats_a["pedestrian_position_noise_applied"] == 2
+    assert stats_a == stats_b
+    assert stats_a["steps_with_noise"] == 1
+
+
+def test_observation_noise_delay_uses_previous_pedestrian_snapshot() -> None:
+    """Observation delay lags pedestrian detections while leaving robot pose current."""
+
+    spec = normalize_observation_noise_spec(
+        {
+            "profile": "one_step_delay",
+            "observation_delay_steps": 1,
+        }
+    )
+    state = make_observation_noise_state(spec)
+    rng = make_observation_noise_rng(spec, seed=1, scenario_id="s1")
+    first = _sample_obs()
+    second = _sample_obs()
+    second["robot"]["position"] = [10.0, 20.0]
+    second["pedestrians"]["positions"] = [[8.0, 8.0]]
+    second["pedestrians"]["velocities"] = [[0.0, 0.0]]
+    second["pedestrians"]["radius"] = [0.35]
+    second["pedestrians"]["count"] = 1
+
+    first_noisy, first_stats = apply_observation_noise(first, spec, rng, state)
+    second_noisy, second_stats = apply_observation_noise(second, spec, rng, state)
+
+    assert first_noisy["pedestrians"]["positions"] == [[2.0, 2.0], [3.0, 2.0]]
+    assert first_stats["observation_delay_applied"] == 0
+    assert second_noisy["robot"]["position"] == [10.0, 20.0]
+    assert second_noisy["pedestrians"]["positions"] == [[2.0, 2.0], [3.0, 2.0]]
+    assert second_stats["observation_delay_applied"] == 1
+    assert second_stats["steps_with_noise"] == 1
 
 
 def test_observation_noise_applies_map_runner_top_level_pose_keys() -> None:

--- a/tests/benchmark/test_observation_noise.py
+++ b/tests/benchmark/test_observation_noise.py
@@ -154,6 +154,20 @@ def test_observation_noise_delay_uses_previous_pedestrian_snapshot() -> None:
     assert second_stats["steps_with_noise"] == 1
 
 
+def test_observation_noise_delay_requires_persistent_state() -> None:
+    """Enabling observation delay without persistent state fails closed."""
+
+    spec = normalize_observation_noise_spec(
+        {
+            "profile": "one_step_delay",
+            "observation_delay_steps": 1,
+        }
+    )
+    rng = make_observation_noise_rng(spec, seed=1, scenario_id="s1")
+    with pytest.raises(ValueError, match="persistent ObservationNoiseState"):
+        apply_observation_noise(_sample_obs(), spec, rng)
+
+
 def test_observation_noise_applies_map_runner_top_level_pose_keys() -> None:
     """Map-runner SOCNAV observations expose top-level robot pose fields."""
     spec = normalize_observation_noise_spec(

--- a/tests/benchmark/test_perception_degradation_ladder_issue_4455.py
+++ b/tests/benchmark/test_perception_degradation_ladder_issue_4455.py
@@ -1,0 +1,80 @@
+"""Tests for issue #4455 perception-degradation ladder preregistration."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+from robot_sf.benchmark.camera_ready._config import load_campaign_config
+from robot_sf.benchmark.observation_noise import (
+    normalize_observation_noise_spec,
+    observation_noise_hash,
+)
+
+_SCRIPT_PATH = Path("scripts/benchmark/build_perception_degradation_ladder_issue_4455.py")
+_SPEC = importlib.util.spec_from_file_location("issue_4455_ladder_builder", _SCRIPT_PATH)
+assert _SPEC is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MODULE)
+
+DEFAULT_MANIFEST = _MODULE.DEFAULT_MANIFEST
+build_ladder_configs = _MODULE.build_ladder_configs
+
+PROFILE_CATALOG = Path("configs/benchmarks/perception_degradation_profiles_v1.yaml")
+PREREGISTRATION_WRAPPER = Path(
+    "configs/benchmarks/issue_4455_perception_degradation_ladder_preregistration.yaml"
+)
+
+
+def test_issue_4455_ladder_generates_loadable_profile_configs(tmp_path: Path) -> None:
+    """The preregistered ladder expands into camera-ready smoke configs."""
+
+    out_dir = tmp_path / "ladder"
+
+    generated = build_ladder_configs(DEFAULT_MANIFEST, out_dir)
+
+    assert len(generated) == 5
+    loaded = [load_campaign_config(path) for path in generated]
+    profiles = {cfg.observation_noise["profile"]: cfg for cfg in loaded if cfg.observation_noise}
+    assert "none" in profiles
+    assert profiles["fixed_detection_delay_1"].observation_noise["observation_delay_steps"] == 1
+    assert (
+        profiles["occlusion_range_4m"].observation_noise["pedestrian_occlusion_max_range_m"] == 4.0
+    )
+    assert all(cfg.seed_policy.seeds == (111, 112) for cfg in loaded)
+    assert all(len(cfg.planners) == 3 for cfg in loaded)
+
+
+def test_issue_4455_ladder_validate_only_does_not_write_configs(tmp_path: Path) -> None:
+    """Validate-only mode checks the manifest without producing local campaign artifacts."""
+
+    generated = build_ladder_configs(DEFAULT_MANIFEST, tmp_path / "ladder", validate_only=True)
+
+    assert generated == []
+    assert not (tmp_path / "ladder").exists()
+
+
+def test_issue_4455_profile_catalog_pins_unique_ordered_hashes() -> None:
+    """The canonical profile catalog pins ordered unique normalized hashes."""
+
+    catalog = yaml.safe_load(PROFILE_CATALOG.read_text(encoding="utf-8"))
+    profiles = catalog["profiles"]
+    keys = [profile["key"] for profile in profiles]
+
+    assert keys == catalog["ordered_profile_keys"]
+    assert len(keys) == len(set(keys))
+    for profile in profiles:
+        normalized = normalize_observation_noise_spec(profile["observation_noise"])
+        assert profile["profile_hash"] == observation_noise_hash(normalized)
+
+
+def test_issue_4455_preregistration_wrapper_points_to_detailed_manifest() -> None:
+    """The maintainer-requested preregistration path remains discoverable."""
+
+    wrapper = yaml.safe_load(PREREGISTRATION_WRAPPER.read_text(encoding="utf-8"))
+
+    assert wrapper["include"] == "perception_degradation/issue_4455_ladder_v1.yaml"
+    assert wrapper["submit_in_this_pr"] is False


### PR DESCRIPTION
Reviewer-critical summary

What changed: Adds issue #4455 perception-degradation ladder enablement: planner-input noise now supports Gaussian pedestrian-track noise, fixed pedestrian-observation delay, range-limited pedestrian occlusion, and existing false-negative drops. Adds canonical profile/preregistration configs, a context note, and a generator/checker that expands the ladder into per-profile camera-ready CPU smoke configs.

Why now: Issue #4455 identifies oracle-grade perception as an external-review gap; this PR provides the smallest runnable contract needed before any private queue campaign.

Claim boundary: Enablement only. This is not benchmark evidence, not a full campaign result, and not a paper/dissertation claim.

Required validation: targeted observation-noise/generator/config tests, ladder validate/generate commands, and final PR readiness.

Remaining blocker: no full benchmark campaign has run; ranking/failure-mode survival remains unmeasured.

Contract delta

New schema/config fields: `observation_noise.pedestrian_position_noise_std_m`, `observation_noise.observation_delay_steps`, and `observation_noise.pedestrian_occlusion_max_range_m`.

New fail-closed blockers: invalid negative delay, negative noise, invalid probabilities, or non-positive occlusion range fail during observation-noise normalization.

Compatibility impact: existing profiles remain compatible; omitted fields default to no pedestrian-track noise, no delay, and no range occlusion. `seed` normalization remains `int | None`.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4455

## Summary
Implements the issue #4455 perception-degradation ladder enablement slice: runtime planner-input Gaussian pedestrian-track noise, delay/range occlusion support, canonical profile/preregistration configs, context note, and generator/checker tests. No campaign is submitted or claimed.

## Linked Issues
- Relates to `#4455`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Extended `robot_sf.benchmark.observation_noise` with Gaussian pedestrian-track noise, per-episode delay state, and range-limited pedestrian occlusion.
- Wired observation-noise delay state into `run_map_episode` so delay persists across steps.
- Added `configs/benchmarks/perception_degradation_profiles_v1.yaml`, `configs/benchmarks/perception_degradation/issue_4455_ladder_v1.yaml`, and `configs/benchmarks/issue_4455_perception_degradation_ladder_preregistration.yaml`.
- Added `scripts/benchmark/build_perception_degradation_ladder_issue_4455.py` to validate/generate per-profile camera-ready CPU smoke configs.
- Added `docs/context/issue_4455_perception_degradation_ladder.md` with motivation, profile table, planner-input-only invariant, and private-queue handoff.
- Added focused tests for runtime knobs, stable profile hashes, canonical config paths, and manifest expansion.

## Why Matters
- Added value: Turns issue #4455 from a scoped review gap into a runnable enablement contract.
- Expected impact: Allows the next owner to run a bounded CPU/private-queue smoke or campaign without inventing config semantics.
- Why worth merging now: It is a nameable progression slice, not another micro-guardrail.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: whether planner ranking/failure modes survive bounded perception degradation.
- Comparator or baseline, applicable: nominal oracle profile in `issue_4455_ladder_v1.yaml`.
- Evidence tier: NA - enablement/support helper; targeted tests validate plumbing only.
- Result classification: NA - no research result classified.
- Decision stop rule, applicable: stop before claim promotion until generated configs run with provenance and fallback/degraded exclusions.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #4455 and `docs/context/issue_4455_perception_degradation_ladder.md`.
- New research/benchmark/metric/paper-facing analysis tool, any: support helper only; it generates configs and does not interpret benchmark evidence.

## Domain-Aware Approval
- Required PR: no
- Domains reviewed: NA - enablement/support helper only
- Status: not required
- Approver/review source waiver: not required; no empirical result or paper-facing claim is classified.
- Validity checklist:
- Target claim/hypothesis: enable perception-degradation measurement, not claim outcome.
- Comparator split/evidence validity: preregistered nominal/degraded profile split only; not measured here.
- Fallback/degraded exclusions: no fallback/degraded campaign row is counted by this PR.
- Claim boundary: enablement only.
- Implementation integrity vs experimental validity: focused tests cover implementation; experimental validity remains future campaign work under #4455.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes for unit-tested Gaussian pedestrian-track noise, delay, dropout, and range occlusion paths.
- Did intervention change command source, selected command, trajectory, route progress? unmeasured; no campaign run.
- Did scenario actually contain targeted failure mode? unmeasured; smoke config uses existing planner sanity scenario subset.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: issue #4455 remains the parent for empirical action.

## Next Empirical Action
- Rerun needed: yes, generated configs need campaign execution.
- Extractor analysis tool needed: no for this slice.
- Artifact missing unavailable: full benchmark campaign artifacts.
- Stop / revise / continue decision: continue to private queue or CPU smoke execution after review.
- Proposed child issue existing follow-up: #4455 tracks the campaign execution and synthesis follow-up unless maintainer wants a separate campaign-run child.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_observation_noise.py tests/benchmark/test_perception_degradation_ladder_issue_4455.py` - passed, 15 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_perception_degradation_ladder_issue_4455.py --validate-only` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_perception_degradation_ladder_issue_4455.py --out-dir output/benchmarks/issue_4455_perception_degradation_ladder` - passed, wrote 5 disposable local configs.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/validation/issue_4455_pr_body.md scripts/dev/pr_ready_check.sh` - passed; clean-tree stamp for `0a6763a28` at `2026-07-04T14:36:46Z`.

Explicit out-of-scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: observation-noise normalizer now accepts three new optional fields; existing omitted-field configs remain no-op compatible.
- Failure modes: generated configs are smoke launch packets only; campaign results may still be unavailable or inconclusive.
- Rollback fallback plan: revert this PR to remove the new fields/generator; existing observation-noise profiles are preserved.

## Docs / Provenance
- Updated docs: `docs/context/issue_4455_perception_degradation_ladder.md`.
- Relevant design provenance notes: issue #4455 body and maintainer comment `4882370862` from `2026-07-04T14:15:52Z`.
- Any assumptions need to preserved: the ladder applies degradation to planner input only, not simulator ground truth or scoring.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; authorization says `comment_issue_or_pr: false`.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark result claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA, direct paths are named in PR and context note.
- Context index / memory note updated (yes/no/NA): yes, context note added.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no evidence result is promoted; state propagation is handled in this PR body due comment authorization being false.

## Follow-Up Issues
- Deferred work: #4455 remains open to run generated configs/campaign and synthesize whether ranking/failure modes survive degradation.
- Issues opened follow-up: none; #4455 is the existing parent/follow-up issue.

<details>
<summary>Appendix: governance notes</summary>

Late maintainer guidance: comment `4882370862` from `2026-07-04T14:15:52Z` was read before PR open and incorporated by adding the requested canonical profile catalog path, preregistration wrapper path, pedestrian-track Gaussian noise, stable hashes, focused tests, and context note.

Fragmentation guard: no open or merged PRs were found for `4455` or the exact perception-degradation scope at start or immediately before PR open, so this is a progression slice adding a nameable new capability.

Artifact classification: files under `output/benchmarks/issue_4455_perception_degradation_ladder`, `output/coverage`, and `output/validation` are disposable local validation artifacts and are not committed.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new preregistered benchmark ladder for perception degradation with multiple profile variants and a validation-only build mode.
  * Expanded observation-noise handling to support delayed observations, range-based occlusion, and configurable pedestrian noise profiles.

* **Bug Fixes**
  * Improved consistency of planner-facing noisy observations across episodes and profiles.

* **Documentation**
  * Added guidance describing the benchmark contract, profile catalog, and validation workflow.

* **Tests**
  * Added coverage for noise profiles, ladder generation, profile hashing, and preregistration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->