### PR TITLE
Issue #4447: harden context-note freshness-decay checker

### DIFF
--- a/scripts/tools/check_context_note_freshness_decay.py
+++ b/scripts/tools/check_context_note_freshness_decay.py
@@ -69,14 +69,61 @@ def _load_yaml(path: Path) -> object:
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
+def _normalize_repo_path(
+    raw_path: object,
+    *,
+    repo_root: Path | None = None,
+    base_dir: Path | None = None,
+) -> Path | None:
+    """Return a normalized, safe repository-relative path if possible."""
+    if isinstance(raw_path, Path):
+        path = raw_path
+    elif isinstance(raw_path, str) and raw_path.strip():
+        path = Path(raw_path.strip())
+    else:
+        return None
+
+    if path.is_absolute():
+        if repo_root is None:
+            return None
+        try:
+            path = path.resolve().relative_to(repo_root.resolve())
+        except ValueError:
+            return None
+    elif base_dir is not None and not path.parts[:2] == ("docs", "context"):
+        path = base_dir / path
+
+    normalized = Path(os.path.normpath(path.as_posix()))
+    if normalized == Path(".") or ".." in normalized.parts:
+        return None
+    return normalized
+
+
 def _safe_repo_path(raw_path: object) -> Path | None:
     """Return a safe repository-relative Path if possible."""
-    if not isinstance(raw_path, str) or not raw_path.strip():
+    return _normalize_repo_path(raw_path)
+
+
+def _path_is_relative_to(path: Path, parent: Path) -> bool:
+    """Return whether path is parent or contained under parent."""
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_markdown_target(target: str, *, source_dir: Path, context_dir: Path) -> Path | None:
+    """Resolve a Markdown target to a normalized repository-relative path."""
+    direct_path = _normalize_repo_path(target)
+    if direct_path is None:
         return None
-    path = Path(raw_path.strip())
-    if path.is_absolute() or ".." in path.parts:
-        return None
-    return path
+    if _path_is_relative_to(direct_path, context_dir) or direct_path.parts[:2] == (
+        "docs",
+        "context",
+    ):
+        return direct_path
+    return _normalize_repo_path(target, base_dir=source_dir)
 
 
 def _catalog_entries(catalog_path: Path) -> list[dict[str, Any]]:
@@ -108,19 +155,22 @@ def _markdown_targets(text: str) -> set[str]:
 
 
 def _index_references(index_path: Path, *, context_dir: Path) -> set[Path]:
-    """Return note paths referenced by INDEX.md."""
+    """Return note paths referenced by INDEX.md.
+
+    Missing configured index files fail closed in ``check_freshness_decay`` so orphan
+    findings are not computed from an empty, misleading reference set.
+    """
     if not index_path.exists():
-        return set()
+        raise FileNotFoundError(index_path)
     targets = _markdown_targets(index_path.read_text(encoding="utf-8"))
     references: set[Path] = set()
     for target in targets:
-        path = Path(target)
+        path = _resolve_markdown_target(target, source_dir=context_dir, context_dir=context_dir)
+        if path is None:
+            continue
         if path.suffix != ".md":
             continue
-        if path.parts[:2] == ("docs", "context"):
-            references.add(path)
-        else:
-            references.add(context_dir / path)
+        references.add(path)
     return references
 
 
@@ -140,6 +190,31 @@ def _tracked_context_notes(repo_root: Path, context_dir: Path) -> set[Path]:
     return notes
 
 
+def _build_inbound_markdown_ref_map(repo_root: Path, context_dir: Path) -> dict[Path, set[Path]]:
+    """Map referenced context note paths to tracked Markdown files that reference them."""
+    output = _run(["git", "ls-files", "--", context_dir.as_posix()], cwd=repo_root)
+    inbound_refs: dict[Path, set[Path]] = {}
+    for line in output.splitlines():
+        source_path = _normalize_repo_path(line.strip())
+        if source_path is None or source_path.suffix != ".md":
+            continue
+        full_source_path = repo_root / source_path
+        if not full_source_path.is_file():
+            continue
+        try:
+            content = full_source_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for target in _markdown_targets(content):
+            target_path = _resolve_markdown_target(
+                target, source_dir=source_path.parent, context_dir=context_dir
+            )
+            if target_path is None or target_path.suffix != ".md" or target_path == source_path:
+                continue
+            inbound_refs.setdefault(target_path, set()).add(source_path)
+    return inbound_refs
+
+
 def _last_touch(repo_root: Path, path: Path) -> datetime | None:
     """Return the last commit touch date."""
     output = _run(["git", "log", "-1", "--format=%cI", "--", path.as_posix()], cwd=repo_root)
@@ -150,42 +225,21 @@ def _last_touch(repo_root: Path, path: Path) -> datetime | None:
 
 def _has_inbound_markdown_ref(note_path: Path, repo_root: Path, context_dir: Path) -> bool:
     """Check if any other Markdown file under context_dir references note_path."""
-    output = _run(["git", "ls-files", "--", context_dir.as_posix()], cwd=repo_root)
-    for line in output.splitlines():
-        source_path = Path(line.strip())
-        if source_path.suffix != ".md" or source_path == note_path:
-            continue
-        full_source_path = repo_root / source_path
-        if not full_source_path.is_file():
-            continue
-        try:
-            content = full_source_path.read_text(encoding="utf-8")
-        except OSError:
-            continue
-        targets = _markdown_targets(content)
-        for target in targets:
-            target_path = Path(target)
-            if target_path.parts[:2] == ("docs", "context"):
-                resolved = target_path
-            else:
-                resolved = Path(os.path.normpath(source_path.parent / target_path))
-            if resolved == note_path:
-                return True
-    return False
+    return bool(_build_inbound_markdown_ref_map(repo_root, context_dir).get(note_path))
 
 
 def _is_referenced_in_catalog(
-    path: Path, current_entry: dict[str, Any], entries: list[dict[str, Any]]
+    path: Path, current_entry: dict[str, Any], entries: list[dict[str, Any]], repo_root: Path
 ) -> bool:
     """Check if the path is listed elsewhere in catalog.yaml."""
     for entry in entries:
         if entry is current_entry:
             continue
-        if _safe_repo_path(entry.get("path")) == path:
+        if _normalize_repo_path(entry.get("path"), repo_root=repo_root) == path:
             return True
-        if _safe_repo_path(entry.get("replacement")) == path:
+        if _normalize_repo_path(entry.get("replacement"), repo_root=repo_root) == path:
             return True
-    if _safe_repo_path(current_entry.get("replacement")) == path:
+    if _normalize_repo_path(current_entry.get("replacement"), repo_root=repo_root) == path:
         return True
     return False
 
@@ -200,10 +254,10 @@ def _check_superseded_rules(
     """Validate Rule A: superseded catalog rows must name their replacement."""
     findings: list[Finding] = []
     for index, entry in enumerate(entries):
-        path = _safe_repo_path(entry.get("path"))
+        path = _normalize_repo_path(entry.get("path"), repo_root=repo_root)
         status = entry.get("status")
         freshness = entry.get("freshness")
-        replacement = _safe_repo_path(entry.get("replacement"))
+        replacement = _normalize_repo_path(entry.get("replacement"), repo_root=repo_root)
 
         entry_path = (
             path.as_posix() if path is not None else f"{catalog_path.as_posix()}:entries[{index}]"
@@ -252,16 +306,16 @@ def _check_superseded_rules(
 def _check_stale_rules(
     entries: list[dict[str, Any]],
     repo_root: Path,
-    context_dir: Path,
     archive_dir: Path,
     max_age_days: int,
     now: datetime,
+    inbound_markdown_refs: dict[Path, set[Path]],
     proposed_moves: list[ProposedMove],
 ) -> list[Finding]:
     """Validate Rule B: current dated notes older than max age with no inbound references."""
     findings: list[Finding] = []
     for entry in entries:
-        path = _safe_repo_path(entry.get("path"))
+        path = _normalize_repo_path(entry.get("path"), repo_root=repo_root)
         status = entry.get("status")
         freshness = entry.get("freshness")
         if status != "current" or freshness != "dated" or path is None:
@@ -276,8 +330,8 @@ def _check_stale_rules(
         if age_days <= max_age_days:
             continue
 
-        has_md_ref = _has_inbound_markdown_ref(path, repo_root, context_dir)
-        has_catalog_ref = _is_referenced_in_catalog(path, entry, entries)
+        has_md_ref = bool(inbound_markdown_refs.get(path))
+        has_catalog_ref = _is_referenced_in_catalog(path, entry, entries, repo_root)
 
         if not (has_md_ref or has_catalog_ref):
             findings.append(
@@ -309,13 +363,14 @@ def _check_orphan_rules(
     tracked_notes: set[Path],
     entries: list[dict[str, Any]],
     indexed_paths: set[Path],
+    repo_root: Path,
 ) -> list[Finding]:
     """Validate Rule C: orphan notes absent from both INDEX.md and catalog.yaml."""
     catalog_paths_and_reps: set[Path] = set()
     for entry in entries:
-        if (p := _safe_repo_path(entry.get("path"))) is not None:
+        if (p := _normalize_repo_path(entry.get("path"), repo_root=repo_root)) is not None:
             catalog_paths_and_reps.add(p)
-        if (r := _safe_repo_path(entry.get("replacement"))) is not None:
+        if (r := _normalize_repo_path(entry.get("replacement"), repo_root=repo_root)) is not None:
             catalog_paths_and_reps.add(r)
 
     findings: list[Finding] = []
@@ -343,25 +398,63 @@ def check_freshness_decay(
     now: datetime | None = None,
 ) -> tuple[list[Finding], list[ProposedMove], list[str]]:
     """Scan docs/context notes for staleness, superseded replacement, and orphan signals."""
+    repo_root = repo_root.resolve()
+    normalized_catalog_path = _normalize_repo_path(catalog_path, repo_root=repo_root)
+    normalized_context_dir = _normalize_repo_path(context_dir, repo_root=repo_root)
+    normalized_index_path = _normalize_repo_path(index_path, repo_root=repo_root)
+    if normalized_catalog_path is None:
+        raise ValueError(f"catalog path must be repository-relative: {catalog_path}")
+    if normalized_context_dir is None:
+        raise ValueError(f"context dir must be repository-relative: {context_dir}")
+    if normalized_index_path is None:
+        raise ValueError(f"index path must be repository-relative: {index_path}")
+    catalog_path = normalized_catalog_path
+    context_dir = normalized_context_dir
+    index_path = normalized_index_path
+
     now = (now or datetime.now(UTC)).astimezone(UTC)
     archive_dir = context_dir / "archive"
     entries = _catalog_entries(repo_root / catalog_path)
-    indexed_paths = _index_references(repo_root / index_path, context_dir=context_dir)
-    tracked_notes = _tracked_context_notes(repo_root, context_dir)
 
     findings: list[Finding] = []
     proposed_moves: list[ProposedMove] = []
     conflicts: list[str] = []
+    try:
+        indexed_paths = _index_references(repo_root / index_path, context_dir=context_dir)
+        should_check_orphans = True
+    except FileNotFoundError:
+        indexed_paths = set()
+        should_check_orphans = False
+        findings.append(
+            Finding(
+                rule="missing_context_index",
+                severity="error",
+                path=index_path.as_posix(),
+                message=(
+                    "configured context index is missing; orphan checks fail closed because "
+                    "empty index references would be misleading"
+                ),
+            )
+        )
+    tracked_notes = _tracked_context_notes(repo_root, context_dir)
+    inbound_markdown_refs = _build_inbound_markdown_ref_map(repo_root, context_dir)
 
     findings.extend(
         _check_superseded_rules(entries, repo_root, catalog_path, archive_dir, proposed_moves)
     )
     findings.extend(
         _check_stale_rules(
-            entries, repo_root, context_dir, archive_dir, max_age_days, now, proposed_moves
+            entries,
+            repo_root,
+            archive_dir,
+            max_age_days,
+            now,
+            inbound_markdown_refs,
+            proposed_moves,
         )
     )
-    findings.extend(_check_orphan_rules(tracked_notes, entries, indexed_paths))
+    if should_check_orphans:
+        findings.extend(_check_orphan_rules(tracked_notes, entries, indexed_paths, repo_root))
 
     by_target: dict[str, list[str]] = {}
     for move in proposed_moves:

--- a/tests/tools/test_check_context_note_freshness_decay.py
+++ b/tests/tools/test_check_context_note_freshness_decay.py
@@ -13,6 +13,8 @@ from scripts.tools import check_context_note_freshness_decay as checker
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from pytest import MonkeyPatch
+
 
 def _run(repo: Path, *args: str, env: dict[str, str] | None = None) -> None:
     subprocess.run(
@@ -227,7 +229,7 @@ def test_rule_b_stale_current_dated_note(tmp_path: Path) -> None:
                 "path": "docs/context/dated.md",
                 "status": "current",
                 "freshness": "dated",
-            }
+            },
         ],
     )
     _commit(repo, "dated note", iso_date="2025-01-01T00:00:00+00:00")
@@ -259,7 +261,7 @@ def test_rule_b_stale_referenced_is_skipped(tmp_path: Path) -> None:
                 "path": "docs/context/dated.md",
                 "status": "current",
                 "freshness": "dated",
-            }
+            },
         ],
     )
     _commit(repo, "dated note with reference", iso_date="2025-01-01T00:00:00+00:00")
@@ -341,3 +343,140 @@ def test_conflict_target_exists(tmp_path: Path) -> None:
     _findings, _proposed_moves, conflicts = checker.check_freshness_decay(repo_root=repo)
     assert len(conflicts) == 1
     assert "target_exists" in conflicts[0]
+
+
+def test_absolute_paths_normalize_and_preserve_custom_context_dir(tmp_path: Path) -> None:
+    """Absolute inputs compare against normalized repo-relative paths."""
+    repo = _repo(tmp_path)
+    context_dir = repo / "custom/ctx"
+    _write(repo, "custom/ctx/old.md", "# Old\n")
+    _write(repo, "custom/ctx/new.md", "# New\n")
+    _write(repo, "custom/ctx/INDEX.md", "[old](./old.md)\n")
+    _write(
+        repo,
+        "custom/ctx/catalog.yaml",
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "entries": [
+                    {
+                        "path": str(repo / "custom/ctx/old.md"),
+                        "status": "superseded",
+                        "freshness": "dated",
+                        "replacement": str(repo / "custom/ctx/new.md"),
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+    )
+    _commit(repo, "custom context normalized paths", iso_date="2026-01-02T00:00:00+00:00")
+
+    findings, proposed_moves, _conflicts = checker.check_freshness_decay(
+        repo_root=repo,
+        catalog_path=repo / "custom/ctx/catalog.yaml",
+        context_dir=context_dir,
+        index_path=repo / "custom/ctx/INDEX.md",
+    )
+
+    assert findings == []
+    assert proposed_moves[0].source == "custom/ctx/old.md"
+    assert proposed_moves[0].target == "custom/ctx/archive/old.md"
+
+
+def test_missing_index_fails_closed_without_orphan_noise(tmp_path: Path) -> None:
+    """Missing configured INDEX.md is an error and skips misleading orphan checks."""
+    repo = _repo(tmp_path)
+    (repo / "docs/context/INDEX.md").unlink()
+    _write(repo, "docs/context/orphan.md", "# Orphan\n")
+    _commit(repo, "remove context index", iso_date="2026-01-02T00:00:00+00:00")
+
+    findings, _proposed_moves, _conflicts = checker.check_freshness_decay(repo_root=repo)
+
+    assert [finding.rule for finding in findings] == ["missing_context_index"]
+    assert findings[0].severity == "error"
+    assert findings[0].path == "docs/context/INDEX.md"
+    assert "fail closed" in findings[0].message
+
+
+def test_rule_b_stale_referenced_by_markdown_file_is_skipped(tmp_path: Path) -> None:
+    """A non-index Markdown inbound reference suppresses stale-current findings."""
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/dated.md", "# Dated\n")
+    _write(repo, "docs/context/topic.md", "[dated](dated.md)\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/dated.md",
+                "status": "current",
+                "freshness": "dated",
+            },
+            {
+                "path": "docs/context/topic.md",
+                "status": "current",
+                "freshness": "maintained",
+            },
+        ],
+    )
+    _commit(repo, "dated note markdown reference", iso_date="2025-01-01T00:00:00+00:00")
+
+    findings, proposed_moves, _conflicts = checker.check_freshness_decay(
+        repo_root=repo,
+        max_age_days=180,
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    assert findings == []
+    assert proposed_moves == []
+
+
+def test_inbound_markdown_refs_are_built_once_per_check(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Multiple stale notes reuse one inbound Markdown map instead of rescanning per note."""
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/dated_a.md", "# Dated A\n")
+    _write(repo, "docs/context/dated_b.md", "# Dated B\n")
+    _write(repo, "docs/context/topic.md", "[dated a](dated_a.md)\n[dated b](dated_b.md)\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/dated_a.md",
+                "status": "current",
+                "freshness": "dated",
+            },
+            {
+                "path": "docs/context/dated_b.md",
+                "status": "current",
+                "freshness": "dated",
+            },
+            {
+                "path": "docs/context/topic.md",
+                "status": "current",
+                "freshness": "maintained",
+            },
+        ],
+    )
+    _commit(repo, "two dated notes markdown references", iso_date="2025-01-01T00:00:00+00:00")
+    original_run = checker._run
+    ls_files_calls = 0
+
+    def counted_run(cmd: list[str], *, cwd: Path) -> str:
+        nonlocal ls_files_calls
+        if cmd[:2] == ["git", "ls-files"] and cmd[-1] == "docs/context":
+            ls_files_calls += 1
+        return original_run(cmd, cwd=cwd)
+
+    monkeypatch.setattr(checker, "_run", counted_run)
+
+    findings, proposed_moves, _conflicts = checker.check_freshness_decay(
+        repo_root=repo,
+        max_age_days=180,
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    assert findings == []
+    assert proposed_moves == []
+    assert ls_files_calls == 2


### PR DESCRIPTION
## Reviewer-critical summary
What changed: hardens `scripts/tools/check_context_note_freshness_decay.py` with centralized repo-relative path normalization, a one-pass inbound Markdown reference map, and explicit fail-closed handling for missing configured context indexes.

Why now: issue #4447 is the follow-up slice to #3190 / PR #4442 review notes; this implements the nameable new capability requested in the live issue plan.

Claim boundary: dev tooling only. This PR changes context-note checker behavior and tests; it makes no benchmark, runtime, queue-routing, evidence-claim, paper, or dissertation claim.

Required validation: focused checker tests, Ruff on changed files, two real checker JSON smoke invocations, and final repository PR readiness.

Remaining blocker: none known for this slice. Broader context-note decay policy tuning remains outside this PR.

## Contract delta
New schema fields: none. Existing JSON `findings` can now include `rule="missing_context_index"` with `severity="error"` when the configured index path is absent.

New fail-closed blockers: missing configured index no longer silently behaves as an empty reference set; orphan checks are skipped in that condition so the report does not produce misleading orphan findings.

Compatibility impact: callers using the default in-repo `docs/context/INDEX.md` keep the same successful exit behavior. Callers pointing `--index` at a missing file now receive a JSON error finding and nonzero CLI exit even without `--strict`.

## Summary
Hardens the context-note freshness-decay checker for issue #4447 by normalizing checker paths, reusing an inbound-reference map, and making missing-index behavior explicit and tested.

## Linked Issues
- Closes #4447
- Relates #3190

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `_normalize_repo_path` / Markdown target resolution for CLI paths, catalog `path` / `replacement` values, index links, and inbound Markdown links.
- Replaced stale-rule per-note inbound Markdown scans with one `_build_inbound_markdown_ref_map(...)` pass reused across entries.
- Converted missing configured index from implicit empty references to `missing_context_index` error finding and skipped orphan checks for that misleading state.
- Added tests for absolute/custom path normalization, missing-index fail-closed behavior, Markdown inbound-reference suppression, and one-pass inbound scanning.

## Why Matters
- Added value: the checker is faster on large context-note sets and fails closed when its configured index input is absent.
- Expected impact: more reliable context-note maintenance reports with clearer failure modes.
- Why worth merging now: completes the ready-queue follow-up scope from the live #4447 implementation plan.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support tooling only.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - support tooling.
- Result classification: NA - no research claim.
- Decision stop rule, applicable: NA.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #4447 only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no research interpretation added.

## Domain-Aware Approval
- Required PR: yes - waiver recorded because template terms are present while this PR is support tooling only.
- Domains reviewed: context-note checker behavior, support-tooling validation boundary
- Status: waived
- Approver/review source waiver: self-review waiver; no benchmark, metric, model-provenance, paper-facing, or evidence-classification semantics changed.
- Validity checklist:
  - Target claim/hypothesis: no research claim; checker behavior only.
  - Comparator split/evidence validity: NA - no experimental comparator or split.
  - Fallback/degraded exclusions: no benchmark fallback or degraded evidence is used.
  - Claim boundary: support tooling contract only.
  - Implementation integrity vs experimental validity: tests and smoke commands prove checker behavior, not experimental validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: NA.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for this support-tooling slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: stop this slice after review.
- Proposed child issue existing follow-up: none.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/check_context_note_freshness_decay.py tests/tools/test_check_context_note_freshness_decay.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_check_context_note_freshness_decay.py -q` - passed, 13 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/check_context_note_freshness_decay.py --json-output output/context_freshness_decay_issue_4447.json` - passed, exit_code 0, findings 464, proposed_moves 0, conflicts 0.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/check_context_note_freshness_decay.py --catalog docs/context/catalog.yaml --context-dir docs/context --index docs/context/INDEX.md --json-output output/context_freshness_decay_issue_4447_default.json` - passed, exit_code 0, findings 464, proposed_moves 0, conflicts 0.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=\(git rev-parse --git-common-dir\)/codex-agent-runs/active/issue-4447/pr_body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed, clean-tree final readiness stamp for `a6463f3d6028571b27ac48e79f10a16e2b972f53`.

## Performance Evidence
- Baseline runtime: not measured; no numeric speed claim is made.
- Changed runtime: not measured; no numeric speed claim is made.
- Representative command: `uv run pytest tests/tools/test_check_context_note_freshness_decay.py -q` plus real checker JSON smoke commands above.
- Hot-path call count profile anchor: `test_inbound_markdown_refs_are_built_once_per_check` verifies two `git ls-files` calls total for tracked-note and inbound-map construction across multiple stale notes, rather than per stale note.
- Cache-hit reuse counter: NA - no cache claimed.
- Rollback failure criterion: missing-index reports silently as empty references again, inbound Markdown references no longer suppress stale-current findings, or custom context-dir archive targets regress.

## Risks / Rollout
- Compatibility risks: callers that intentionally relied on a missing `--index` path being lenient will now see an error finding and nonzero CLI exit.
- Failure modes: path normalization could reject paths outside the repository; that is intentional for checker safety.
- Rollback fallback plan: revert this PR to restore prior lenient missing-index behavior and per-note inbound scanning.

## Docs / Provenance
- Updated docs: none; behavior is documented in function docstrings and tests.
- Relevant design provenance notes: issue #4447 implementation plan comment from 2026-07-04 14:13:37 UTC.
- Any assumptions need to be preserved: missing configured index should fail closed, as recommended in the live issue plan.

## Downstream Propagation
- Parent issue updated: no.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no.
- Not applicable because: this is a support-tooling PR. Issue/comment propagation is not performed because `comment_issue_or_pr=false`; this PR body is the durable state surface for the delivered slice.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none

## Reviewer Notes
- Verify the missing-index contract carefully: it now emits an error finding and skips orphan checks to avoid misleading results.
- Verify custom context-dir behavior: archive moves remain under the configured context directory.

<details>
<summary>Governance Appendix</summary>

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

Late guidance check: `gh api repos/ll7/robot_sf_ll7/issues/4447` and comments were refreshed before PR open. No maintainer comments newer than this run start were present; the latest issue comment was the implementation plan at 2026-07-04 14:13:37 UTC.

Fragmentation guard: no open PR covers #4447 or this exact scope; recent merged search did not find two or more issue-#4447 guardrail/checker/packet-refresh PRs in the last 24h. This PR is a progression slice with a nameable new capability: one-pass inbound Markdown reference map plus fail-closed missing-index handling.

Generated artifacts: local JSON smoke outputs and coverage output remain under ignored `output/` and are not durable dependencies.

</details>
