### PR TITLE
Issue #2844: expose learned prediction readiness blockers

### DIFF
--- a/scripts/validation/validate_learned_prediction_readiness.py
+++ b/scripts/validation/validate_learned_prediction_readiness.py
@@ -420,6 +420,25 @@ def _register_prerequisite(
     prerequisites[name] = {"status": status, "messages": messages}
 
 
+def _summarize_blocking_prerequisites(
+    prerequisites: dict[str, dict[str, list[str] | str]],
+) -> list[dict[str, object]]:
+    """Return blockers that still prevent learned-prediction training readiness."""
+    blockers: list[dict[str, object]] = []
+    for name, payload in prerequisites.items():
+        status = str(payload["status"])
+        if status == STATUS_PASSED:
+            continue
+        blockers.append(
+            {
+                "name": name,
+                "status": status,
+                "messages": payload["messages"],
+            }
+        )
+    return blockers
+
+
 def validate_readiness(
     doc_path: Path,
     registry_path: Path | None = None,
@@ -479,10 +498,12 @@ def validate_readiness(
         if status != STATUS_PASSED:
             errors.extend(messages)
 
+    blocking_prerequisites = _summarize_blocking_prerequisites(prerequisites)
     status = "ready" if not errors else "blocked"
     return {
         "status": status,
         "errors": errors,
+        "blocking_prerequisites": blocking_prerequisites,
         "checked": {
             "readiness_doc": str(doc_path),
             "trace_registry": str(registry_path) if registry_path else None,
@@ -587,6 +608,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f" - {key}: {status}")
     else:
         print("learned-prediction readiness: BLOCKED")
+        print(f"blocking prerequisites: {len(report['blocking_prerequisites'])}")
         for key, payload in report["prerequisites"].items():
             status = payload["status"]
             print(f" - {key}: {status}")

--- a/tests/validation/test_validate_learned_prediction_readiness.py
+++ b/tests/validation/test_validate_learned_prediction_readiness.py
@@ -235,6 +235,30 @@ def test_blocked_when_prerequisite_paths_not_provided(tmp_path: Path) -> None:
         "closed-loop gate path not provided",
     ):
         assert key in report["errors"]
+    assert [blocker["name"] for blocker in report["blocking_prerequisites"]] == [
+        "trace_registry",
+        "split_manifest",
+        "baseline_evidence",
+        "calibration_report",
+        "transferability_split",
+        "closed_loop_gate",
+    ]
+
+
+def test_ready_report_has_no_blocking_prerequisites(tmp_path: Path) -> None:
+    """Ready report exposes no remaining training blockers."""
+    bundle = _write_validation_bundle(tmp_path)
+    report = validate_readiness(
+        doc_path=bundle["doc"],
+        registry_path=bundle["registry"],
+        split_manifest_path=bundle["split"],
+        baseline_path=bundle["baseline"],
+        calibration_report_path=bundle["calibration"],
+        transferability_report_path=bundle["transferability"],
+        closed_loop_gate_path=bundle["closed_loop"],
+    )
+    assert report["status"] == "ready"
+    assert report["blocking_prerequisites"] == []
 
 
 def test_blocked_when_trace_registry_has_no_sources(tmp_path: Path) -> None:


### PR DESCRIPTION
Reviewer-critical summary

What changed: `validate_learned_prediction_readiness.py` now exposes a top-level `blocking_prerequisites` list in its structured report and prints the blocker count in blocked CLI output.

Why now: issue #2844 is live-blocked by maintainer comments until the learned-prediction readiness validator returns `ready`; downstream issue-state and handoff tooling need one canonical machine-readable blocker surface instead of re-deriving blocker state from mixed `errors` and `prerequisites` fields.

Claim boundary: this PR does not train, register, benchmark, or select a learned predictor. It only strengthens the existing fail-closed readiness-report contract for the blocked learned-prediction lane.

Required validation: focused validator tests, Ruff on touched files, and final PR readiness against `origin/main`.

Remaining blocker: #2844 remains blocked until calibration, transferability, closed-loop coupling, trace registry, split manifest, and baseline evidence inputs satisfy the readiness gate and the validator returns `ready`.

Contract delta

New schema/report fields: `validate_readiness()` reports `blocking_prerequisites`, a list of objects with `name`, `status`, and `messages` for every non-passed prerequisite.

New fail-closed blockers: none. The PR preserves existing prerequisite statuses and exit-code behavior; it only makes the remaining blockers explicit.

Compatibility impact: additive JSON/report field and one additional human-readable CLI line in blocked output. Existing `status`, `errors`, `checked`, and `prerequisites` keys remain unchanged.

Issue: closes no issue; supports #2844 by clarifying its blocked readiness state.

Scope summary

- Added a canonical `blocking_prerequisites` report list to the learned-prediction readiness validator.
- Added tests for blocked-path blocker names and ready-path empty blocker output.

Validation

- `uv run pytest tests/validation/test_validate_learned_prediction_readiness.py -q` -> 23 passed.
- `uv run ruff check scripts/validation/validate_learned_prediction_readiness.py tests/validation/test_validate_learned_prediction_readiness.py` -> All checks passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 1841 passed, 2 skipped on dirty interim tree before commit.
- `PR_READY_PR_BODY_FILE=<common-git-dir>/codex-agent-runs/active/issue-2844/PR_BODY.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; readiness stamp status=passed, tree_state=clean, 1841 passed, 2 skipped.

Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. No learned predictor implementation, training launch, model registry update, or benchmark-strength claim.

<details>
<summary>Governance appendix</summary>

- Fragmentation guard: no open PR or recent merged PR was found covering issue #2844 or this exact learned-prediction readiness-report scope; this is a nameable integration/reporting capability, not another standalone guardrail.
- State propagation: no issue comment was added because authorization forbids issue/PR comments. The PR body states the delivered slice and remaining blocker.
- Transient queue state: no host, packet-lineage, or ready-queue routing state was encoded in tracked files.

</details>
