### PR TITLE
training: align predictive retraining summary contract (#3214)

### DIFF
--- a/robot_sf/training/predictive_retraining_readiness.py
+++ b/robot_sf/training/predictive_retraining_readiness.py
@@ -144,7 +144,7 @@ def _validate_static_contract(
     _require_existing_repo_path(inputs, "weighting_spec", packet_path, repo_root, blockers)
     _require_existing_repo_path(inputs, "pipeline_config", packet_path, repo_root, blockers)
     _validate_launch_packet_sections(payload, blockers)
-    _validate_pipeline_config(inputs, packet_path, repo_root, blockers)
+    _validate_pipeline_config(payload, inputs, packet_path, repo_root, blockers)
 
     prior_result = _mapping(payload.get("prior_result"))
     _require_non_empty_string(prior_result, "status", blockers, prefix="prior_result")
@@ -211,6 +211,7 @@ def _validate_launch_packet_sections(payload: dict[str, Any], blockers: list[str
 
 
 def _validate_pipeline_config(
+    packet: dict[str, Any],
     inputs: dict[str, Any],
     packet_path: Path,
     repo_root: Path,
@@ -230,6 +231,7 @@ def _validate_pipeline_config(
         return
 
     _validate_pipeline_output_contract(pipeline, blockers)
+    _validate_packet_pipeline_summary_contract(packet, pipeline, blockers)
     _validate_pipeline_scenario_paths(pipeline, pipeline_path, repo_root, blockers)
 
     for key in _REQUIRED_PIPELINE_COLLECTIONS:
@@ -270,6 +272,28 @@ def _validate_pipeline_output_contract(
     if provenance.get("status") != "expected_missing_until_training":
         blockers.append(
             "pipeline_config.output.provenance.status must be expected_missing_until_training"
+        )
+
+
+def _validate_packet_pipeline_summary_contract(
+    packet: dict[str, Any],
+    pipeline: dict[str, Any],
+    blockers: list[str],
+) -> None:
+    """Require packet and pipeline to point at the same hard-seed summary artifact."""
+
+    evaluation_config = _mapping(packet.get("evaluation_config"))
+    packet_summary = evaluation_config.get("summary_path")
+    provenance = _mapping(
+        _mapping(pipeline.get("output")).get("provenance") or pipeline.get("provenance")
+    )
+    pipeline_summary = provenance.get("hard_seed_evaluation_summary")
+    if not isinstance(packet_summary, str) or not isinstance(pipeline_summary, str):
+        return
+    if packet_summary != pipeline_summary:
+        blockers.append(
+            "evaluation_config.summary_path must match "
+            "pipeline_config.output.provenance.hard_seed_evaluation_summary"
         )
 
 

--- a/tests/training/test_predictive_retraining_readiness.py
+++ b/tests/training/test_predictive_retraining_readiness.py
@@ -221,6 +221,27 @@ def test_missing_pipeline_retraining_prerequisites_fail_closed(tmp_path: Path) -
     )
 
 
+def test_packet_pipeline_summary_mismatch_fails_closed(tmp_path: Path) -> None:
+    """Divergent packet and pipeline hard-seed summary targets block launch readiness."""
+
+    payload = _complete_payload(tmp_path)
+    payload["evaluation_config"] = {
+        **payload["evaluation_config"],
+        "summary_path": "output/tmp/predictive_planner/pipeline/evaluation/stale/summary.json",
+    }
+    packet = _write_packet(tmp_path, payload)
+
+    report = evaluate_retraining_readiness(packet, repo_root=tmp_path)
+
+    assert report["packet_complete"] is False
+    assert report["launch_ready"] is False
+    assert any(
+        "evaluation_config.summary_path must match "
+        "pipeline_config.output.provenance.hard_seed_evaluation_summary" in blocker
+        for blocker in report["blockers"]
+    )
+
+
 def test_missing_retraining_prerequisites_fail_closed(tmp_path: Path) -> None:
     """Missing control-law/provenance prerequisites keep packet incomplete."""
 


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Tightened the #3214 predictive retraining readiness checker so the packet `evaluation_config.summary_path` must match the referenced pipeline config's `output.provenance.hard_seed_evaluation_summary`.

Why now: Prior #3214 slices created the hard-case weighting spec, launch preflight, and readiness packet. This progression slice closes a remaining static consistency gap before any future compute lane can rely on the packet/pipeline pair.

Claim boundary: This is a public static readiness/checker contract only. It does not publish a retrained checkpoint, authorize compute submission, run a benchmark campaign, or change paper/dissertation claims.

Required validation: Targeted unit coverage for the new mismatch blocker, the checked-in readiness packet CLI, Ruff format/check on touched files, and final PR readiness.

Remaining blocker: The checked-in #3214 packet remains `retraining_blocked` until a public control-law-side change and checkpoint/evaluation provenance plan exist; the 2026-06-30 issue note still sequences #3214 after #3216.

## Contract delta

New schema fields: none.

New fail-closed blockers: If `evaluation_config.summary_path` in the readiness packet diverges from `pipeline_config.output.provenance.hard_seed_evaluation_summary`, the packet is incomplete and launch readiness remains false.

Compatibility impact: Existing valid packets continue to pass when both existing fields agree. Stale packets now fail closed instead of silently pointing reviewers at a different hard-seed summary artifact than the pipeline will produce.

## Issue

Refs https://github.com/ll7/robot_sf_ll7/issues/3214 (does not close it; #3214 remains `retraining_blocked` per the Remaining blocker section).

## Scope summary

- Added packet/pipeline hard-seed summary consistency validation in `robot_sf/training/predictive_retraining_readiness.py`.
- Added a regression test proving a stale packet summary path fails closed.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_predictive_retraining_readiness.py` - passed, 9 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/training/check_predictive_retraining_readiness.py --packet configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml` - passed; packet complete, launch_ready false, decision retraining_blocked, blockers [].
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/training/predictive_retraining_readiness.py tests/training/test_predictive_retraining_readiness.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/predictive_retraining_readiness.py tests/training/test_predictive_retraining_readiness.py` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue3214_pr_body.md scripts/dev/pr_ready_check.sh` - passed; freshness stamp recorded for f6d5fbd13551dbe31354675cffc6a2ca07881adc.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream propagation

No separate issue comment was added: this low-churn static contract progression is summarized here, and Claude Code on `imech156-u` owns the full PR gate/improvement cycle after open.

<details>
<summary>Governance appendix</summary>

Late guidance check: Immediately before PR open, `gh issue view 3214 --repo ll7/robot_sf_ll7 --comments --json ...` showed the latest comment at 2026-06-30T14:52:25Z, before this run; no new maintainer guidance was missed.

Fragmentation guard: No open PR covered #3214, and no two guardrail/checker/packet-refresh PRs merged for #3214 in the last 24 hours. This PR adds the nameable new capability of packet/pipeline hard-seed summary consistency validation.

Artifact policy: No generated output artifacts are committed. Worktree-local `output/` remains temporary.

Forbidden actions: No compute submission, merge, release, or delete action performed.

</details>

