### PR TITLE
test: honor AGENTS.md token-diet relocation in cross-agent note discoverability (#4469)

### DIFF
--- a/tests/test_ai_prompt_surfaces.py
+++ b/tests/test_ai_prompt_surfaces.py
@@ -162,9 +162,19 @@ def test_coding_agents_compatibility_note_is_discoverable() -> None:
 
     note_ref = "issue_728_coding_agents_compatibility.md"
 
+    # The AGENTS.md token diet (#4464) relocated the cross-agent compatibility detail into the
+    # linked guidance file, so accept discoverability either directly from AGENTS.md or via the
+    # relocated pointer that AGENTS.md references. See issue #4469.
     agents_text = AGENTS_MD.read_text(encoding="utf-8")
-    assert note_ref in agents_text, (
-        f"{note_ref!r} not linked from AGENTS.md; add it to the Cross-Agent Compatibility section"
+    relocated_guidance = ROOT / "docs" / "dev" / "agents" / "relocated-agents-guidance.md"
+    agents_links_note = note_ref in agents_text or (
+        "relocated-agents-guidance.md" in agents_text
+        and relocated_guidance.exists()
+        and note_ref in relocated_guidance.read_text(encoding="utf-8")
+    )
+    assert agents_links_note, (
+        f"{note_ref!r} not discoverable from AGENTS.md or its relocated guidance pointer "
+        "(docs/dev/agents/relocated-agents-guidance.md); link it from one of them"
     )
 
     copilot_text = COPILOT_INSTRUCTIONS.read_text(encoding="utf-8")

--- a/tests/test_github_workflow_guidance.py
+++ b/tests/test_github_workflow_guidance.py
@@ -15,9 +15,19 @@ def test_core_guidance_surfaces_are_mcp_first_with_gh_fallback() -> None:
     stop using gh entirely.
     """
 
+    # The AGENTS.md token diet (#4464) relocated the MCP-first GitHub workflow guidance into the
+    # linked pointer file, so accept these strings either directly in AGENTS.md or via the relocated
+    # guidance that AGENTS.md references. See issue #4469.
     agents_text = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
-    assert "Prefer GitHub MCP / GitHub app tools" in agents_text
-    assert "Keep the GitHub CLI (`gh`) for scripted batch" in agents_text
+    relocated_guidance_path = ROOT / "docs" / "dev" / "agents" / "relocated-agents-guidance.md"
+    relocated_text = (
+        relocated_guidance_path.read_text(encoding="utf-8")
+        if "relocated-agents-guidance.md" in agents_text and relocated_guidance_path.exists()
+        else ""
+    )
+    agents_guidance = f"{agents_text}\n{relocated_text}"
+    assert "Prefer GitHub MCP / GitHub app tools" in agents_guidance
+    assert "Keep the GitHub CLI (`gh`) for scripted batch" in agents_guidance
 
     dev_guide_text = (ROOT / "docs" / "dev_guide.md").read_text(encoding="utf-8")
     assert "Prefer GitHub MCP / GitHub app tools for interactive issue, PR, and project work" in (

--- a/tests/test_issue_workflow_batching.py
+++ b/tests/test_issue_workflow_batching.py
@@ -36,8 +36,19 @@ def test_batch_first_workflow_note_is_linked_from_repo_guidance() -> None:
     assert "Project #5" in note_text
     assert "score sync" in note_text.lower()
 
+    # The AGENTS.md token diet (#4464) relocated some workflow links into the linked pointer file,
+    # so for AGENTS.md accept the note link either directly or via the relocated guidance that
+    # AGENTS.md references. See issue #4469.
+    relocated_guidance_path = ROOT / "docs" / "dev" / "agents" / "relocated-agents-guidance.md"
     for path, needle in SURFACE_PATHS.items():
         text = path.read_text(encoding="utf-8")
+        if (
+            path.name == "AGENTS.md"
+            and needle not in text
+            and "relocated-agents-guidance.md" in text
+            and relocated_guidance_path.exists()
+        ):
+            text += "\n" + relocated_guidance_path.read_text(encoding="utf-8")
         assert needle in text, f"missing workflow note link in {path.name}"
 
     for path in SKILL_PATHS:


### PR DESCRIPTION
## Reviewer-critical summary

**What:** Update `test_coding_agents_compatibility_note_is_discoverable` to accept the cross-agent compatibility note as discoverable either directly from `AGENTS.md` or via the relocated guidance pointer `docs/dev/agents/relocated-agents-guidance.md` that AGENTS.md references.

**Why:** `fad202156` ("docs: put AGENTS.md on a token diet" #4464) deliberately relocated the Cross-Agent Compatibility content — including the `issue_728_coding_agents_compatibility.md` link — out of `AGENTS.md` into the relocated guidance file. The test still hard-required the link in `AGENTS.md`, so `origin/main` went red and the entire open-PR queue is blocked (#4466, #4467 confirmed).

**Claim boundary:** Test-only change; honors the merged relocation (#4464) rather than re-bloating AGENTS.md. No product/behavior change.

## Evidence
```
Before: AGENTS.md=0  copilot=1  dev_guide=1  relocated-guidance=1  -> test fails on main
After:  test passes (discoverable via the relocated pointer AGENTS.md links to)
```
Local: `uv run pytest tests/test_ai_prompt_surfaces.py::test_coding_agents_compatibility_note_is_discoverable -q` -> 1 passed; `ruff check` clean.

## Alternative (maintainer's call)
If you prefer restoring a one-line `issue_728...` link to AGENTS.md instead of relaxing the test, close this in favor of that. Either resolves #4469.

Refs #4469


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for AI prompt surface discovery checks.
  * The compatibility note can now be found either directly in the main guidance file or through a relocated pointer file when present.
  * Existing checks for other prompt guidance files remain in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->