### PR TITLE
Issue #4468: guard fast-feedback benchmark reconciliation tests

### DIFF
--- a/scripts/dev/ci_driver.sh
+++ b/scripts/dev/ci_driver.sh
@@ -213,6 +213,21 @@ run_examples_smoke_phase() {
   uv run python scripts/validation/run_examples_smoke.py --skip-perf-tests
 }
 
+run_fast_feedback_benchmark_reconciliation_guard() {
+  local shard_count="${PYTEST_SHARD_COUNT:-1}"
+  local shard_index="${PYTEST_SHARD_INDEX:-1}"
+
+  if [[ "$shard_count" =~ ^[0-9]+$ ]] && [[ "$shard_count" -gt 1 ]] && [[ "$shard_index" != "1" ]]; then
+    echo "Skipping benchmark reconciliation guard on pytest shard $shard_index/$shard_count"
+    return 0
+  fi
+
+  echo "Running fast-feedback benchmark reconciliation guard..."
+  uv run pytest -q \
+    tests/benchmark/test_frozen_trace_reconciliation.py \
+    tests/benchmark/test_safety_wrapper_ablation_manifest.py
+}
+
 run_phase() {
   local phase="$1"
   local event_name="$2"
@@ -232,6 +247,7 @@ run_phase() {
       ;;
     test)
       "$SCRIPT_DIR/check_event_ledger_reconciliation_guard.sh"
+      run_fast_feedback_benchmark_reconciliation_guard
       "$SCRIPT_DIR/run_tests_parallel.sh" --ignore=tests/examples
       ;;
     examples-smoke)

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -221,6 +221,21 @@ def test_ci_driver_typecheck_phase_is_explicitly_advisory() -> None:
     assert "uvx ty check . --exit-zero" in script_text
 
 
+def test_ci_driver_test_phase_runs_benchmark_reconciliation_guard() -> None:
+    """Fast-feedback must not silently skip frozen-trace reconciliation tests."""
+
+    script_text = CI_DRIVER.read_text(encoding="utf-8")
+
+    assert "run_fast_feedback_benchmark_reconciliation_guard()" in script_text
+    assert "Running fast-feedback benchmark reconciliation guard" in script_text
+    assert "tests/benchmark/test_frozen_trace_reconciliation.py" in script_text
+    assert "tests/benchmark/test_safety_wrapper_ablation_manifest.py" in script_text
+    assert '[[ "$shard_index" != "1" ]]' in script_text
+    assert "$SCRIPT_DIR/check_event_ledger_reconciliation_guard.sh" in script_text
+    assert "run_fast_feedback_benchmark_reconciliation_guard" in script_text
+    assert '"$SCRIPT_DIR/run_tests_parallel.sh" --ignore=tests/examples' in script_text
+
+
 def test_run_ci_local_loads_default_phases_from_ci_driver() -> None:
     """Avoid duplicating the canonical CI phase list in the local wrapper."""
 


### PR DESCRIPTION
Reviewer-critical summary

What changed: `scripts/dev/ci_driver.sh test` now runs an explicit fast-feedback benchmark reconciliation guard for `tests/benchmark/test_frozen_trace_reconciliation.py` and `tests/benchmark/test_safety_wrapper_ablation_manifest.py` before the sharded wrapper.

Why now: issue #4468 reported that these benchmark reconciliation regressions may not surface in pull-request fast-feedback shards.

Claim boundary: CI/process guard only. This PR does not change benchmark semantics, event-ledger semantics, frozen-trace reconciliation logic, or safety-wrapper ablation behavior.

Required validation: focused guard tests plus full local PR readiness on this branch.

Remaining blocker: no full benchmark campaign was run; this slice only ensures the named regression tests execute in fast-feedback.

Contract delta

New schema fields: none.

New fail-closed blockers: pull-request fast-feedback shard 1 now fails if either named benchmark reconciliation test file fails. Other shards skip only this explicit duplicate guard and continue through `run_tests_parallel.sh`.

Compatibility impact: CI test phase gains one direct pytest invocation for two benchmark reconciliation files. No runtime API or benchmark output contract changes.

Issue: closes #4468

Scope summary

- Added `run_fast_feedback_benchmark_reconciliation_guard` to `scripts/dev/ci_driver.sh`.
- Wired the guard into the `test` phase after the existing event-ledger reconciliation guard and before the split pytest suite.
- Added a static CI script contract test so future wrapper edits keep the guard and both required files visible.

Validation command results

- `bash -n scripts/dev/ci_driver.sh` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_ci_script_contract.py::test_ci_driver_test_phase_runs_benchmark_reconciliation_guard -q` -> passed, 1 test.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest -q tests/benchmark/test_frozen_trace_reconciliation.py tests/benchmark/test_safety_wrapper_ablation_manifest.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/test_ci_script_contract.py && scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check tests/test_ci_script_contract.py` -> passed.
- `uv run python scripts/dev/run_compact_validation.py --timeout-seconds 1800 -- env BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed, exit 0; summary `/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/compact-validation/validation-20260704T161905Z-6456.summary.json`; full log `/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/compact-validation/validation-20260704T161905Z-6456.log`.

Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No issue comment/state-table update was made because this run authorized `comment_issue_or_pr: false`; state propagation is captured in this PR body.

<details>
<summary>Process notes</summary>

Late guidance check: immediately before PR open, `gh issue view 4468 --repo ll7/robot_sf_ll7 --json number,title,state,body,comments,updatedAt,url` showed no comments on issue #4468.

Duplicate check: open PR search for `4468`, `fast-feedback`, `frozen_trace`, and `safety_wrapper_ablation_manifest` found no overlapping open PR.

Fragmentation guard: no issue #4468 PRs were found merged in the recent search window; this is a progression slice adding a nameable CI guard capability.

</details>