### PR TITLE
Issue #4014 register PPO-Mamba smoke lane

### DIFF
--- a/configs/training/comparison_matrix/issue_4244_seven_arm_preregistration.yaml
+++ b/configs/training/comparison_matrix/issue_4244_seven_arm_preregistration.yaml
@@ -95,7 +95,8 @@ arms:
     display_name: PPO-Mamba
     algorithm_family: ppo_mamba
     lineage_issue: 4162
-    training_config: configs/training/comparison_matrix/placeholders/ppo_mamba_issue_4162.yaml
+    supporting_issue: 4014
+    training_config: configs/training/ppo/issue_4014_ppo_mamba_smoke.yaml
     smoke_contract_manifest: output/training/smoke_contracts/ppo_mamba_issue_4162.json
     budget_ref: shared_budget
     required_gates:

--- a/configs/training/ppo/issue_4014_ppo_mamba_smoke.yaml
+++ b/configs/training/ppo/issue_4014_ppo_mamba_smoke.yaml
@@ -1,0 +1,37 @@
+policy_id: ppo_mamba_issue_4014_smoke
+scenario_config: ../../scenarios/sets/classic_cross_trap_subset.yaml
+total_timesteps: 2048
+seeds: [4014]
+randomize_seeds: false
+feature_extractor: mamba
+feature_extractor_kwargs:
+  backend: torch_ssm_lite
+  d_model: 64
+  d_state: 16
+  d_conv: 4
+  expand: 2
+  num_layers: 1
+  dropout_rate: 0.0
+  sequence_source: rays
+  drive_hidden_dims: [32, 16]
+env_overrides:
+  observation_mode: default
+env_factory_kwargs:
+  reward_name: route_completion_v2
+convergence:
+  success_rate: 0.8
+  collision_rate: 0.1
+  plateau_window: 512
+evaluation:
+  frequency_episodes: 0
+  evaluation_episodes: 3
+  randomize_seeds: false
+  step_schedule:
+    - every_steps: 1024
+ppo_hyperparams:
+  learning_rate: 0.0001
+  n_steps: 128
+  batch_size: 64
+  n_epochs: 2
+  gamma: 0.99
+  gae_lambda: 0.95

--- a/docs/context/issue_4014_mamba_encoder_design.md
+++ b/docs/context/issue_4014_mamba_encoder_design.md
@@ -32,8 +32,19 @@ graphics processing unit (GPU) dependencies are introduced.
   - `rays`: current CPU-safe default, matching the LSTM extractor's within-observation ray sequence
   - `temporal_history`: fail-closed planned input key for the later bounded-history wrapper
 
+## 2026-07-04 PPO Training Registration Slice
+
+This successor slice registers `feature_extractor: mamba` in the standard Proximal Policy
+Optimization (PPO) training entry point and adds
+`configs/training/ppo/issue_4014_ppo_mamba_smoke.yaml`, a CPU-safe smoke config using the
+`torch_ssm_lite` backend. The issue #4244 comparison-matrix preregistration now points its
+`ppo_mamba` arm at this checked-in config instead of the placeholder.
+
+Claim boundary: this proves config parsing, policy selection, and dry-run trainability prep for the
+PPO-Mamba lane only. It does not run full PPO optimization, submit Slurm or GPU work, produce
+throughput metrics, or make benchmark, paper, or dissertation claims.
+
 ## Explicit Non-Claims
 
-This slice does not register `feature_extractor: mamba` in PPO training, does not run a benchmark
-campaign, does not submit Slurm Workload Manager or GPU jobs, and does not make paper- or
-dissertation-facing performance claims.
+This slice does not run a benchmark campaign, does not submit Slurm Workload Manager or GPU jobs,
+and does not make paper- or dissertation-facing performance claims.

--- a/scripts/training/train_ppo.py
+++ b/scripts/training/train_ppo.py
@@ -59,6 +59,7 @@ from robot_sf.feature_extractors.attention_extractor import AttentionFeatureExtr
 from robot_sf.feature_extractors.grid_socnav_extractor import GridSocNavExtractor
 from robot_sf.feature_extractors.lightweight_cnn_extractor import LightweightCNNExtractor
 from robot_sf.feature_extractors.lstm_extractor import LSTMFeatureExtractor
+from robot_sf.feature_extractors.mamba_extractor import MambaFeatureExtractor
 from robot_sf.feature_extractors.mlp_extractor import MLPFeatureExtractor
 from robot_sf.gym_env.environment_factory import make_robot_env
 from robot_sf.gym_env.observation_mode import ObservationMode
@@ -1225,6 +1226,7 @@ _FEATURE_EXTRACTOR_REGISTRY: dict[str, type] = {
     "attention": AttentionFeatureExtractor,
     "lightweight_cnn": LightweightCNNExtractor,
     "lstm": LSTMFeatureExtractor,
+    "mamba": MambaFeatureExtractor,
 }
 
 

--- a/tests/training/test_comparison_matrix_preregistration_issue_4244.py
+++ b/tests/training/test_comparison_matrix_preregistration_issue_4244.py
@@ -48,14 +48,17 @@ def test_issue_4244_matrix_uses_identical_budget_refs_for_every_arm() -> None:
     assert matrix.shared_budget["total_timesteps"] == 15000000
 
 
-def test_issue_4244_matrix_bounds_placeholder_training_config() -> None:
-    """Only PPO-Mamba lacks a checked-in training config on origin/main."""
+def test_issue_4244_matrix_has_no_placeholder_training_configs() -> None:
+    """All matrix arms point at executable training configs after the PPO-Mamba slice."""
     matrix = load_matrix(CONFIG_PATH)
 
     placeholder_arms = {
         arm.arm_id for arm in matrix.arms if "/placeholders/" in arm.training_config
     }
-    assert placeholder_arms == {"ppo_mamba"}
+    assert placeholder_arms == set()
+
+    ppo_mamba = next(arm for arm in matrix.arms if arm.arm_id == "ppo_mamba")
+    assert ppo_mamba.training_config == "configs/training/ppo/issue_4014_ppo_mamba_smoke.yaml"
 
 
 def test_issue_4244_matrix_requires_sac_after_issue_4245_gate() -> None:

--- a/tests/training/test_train_ppo_mamba_config_issue_4014.py
+++ b/tests/training/test_train_ppo_mamba_config_issue_4014.py
@@ -1,0 +1,43 @@
+"""Training config tests for the issue #4014 PPO-Mamba smoke lane."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_sf.feature_extractors.mamba_extractor import MambaFeatureExtractor
+from scripts.training import train_ppo
+
+CONFIG_PATH = Path("configs/training/ppo/issue_4014_ppo_mamba_smoke.yaml")
+
+
+def test_ppo_mamba_smoke_config_loads_cpu_safe_extractor_contract() -> None:
+    """The PPO-Mamba smoke config registers the CPU-safe Mamba extractor."""
+    config = train_ppo.load_expert_training_config(CONFIG_PATH)
+
+    assert config.policy_id == "ppo_mamba_issue_4014_smoke"
+    assert config.feature_extractor == "mamba"
+    assert config.feature_extractor_kwargs == {
+        "backend": "torch_ssm_lite",
+        "d_model": 64,
+        "d_state": 16,
+        "d_conv": 4,
+        "expand": 2,
+        "num_layers": 1,
+        "dropout_rate": 0.0,
+        "sequence_source": "rays",
+        "drive_hidden_dims": [32, 16],
+    }
+    assert config.total_timesteps == 2048
+    assert config.seeds == (4014,)
+
+
+def test_ppo_policy_selection_routes_mamba_extractor() -> None:
+    """PPO policy kwargs should instantiate the Mamba extractor instead of SB3 default features."""
+    config = train_ppo.load_expert_training_config(CONFIG_PATH)
+
+    policy, policy_kwargs, critic_profile = train_ppo._resolve_policy_selection(config)
+
+    assert policy == "MultiInputPolicy"
+    assert policy_kwargs["features_extractor_class"] is MambaFeatureExtractor
+    assert policy_kwargs["features_extractor_kwargs"] == config.feature_extractor_kwargs
+    assert critic_profile == "standard"

--- a/tests/training/test_train_ppo_mamba_config_issue_4014.py
+++ b/tests/training/test_train_ppo_mamba_config_issue_4014.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from robot_sf.feature_extractors.mamba_extractor import MambaFeatureExtractor
 from scripts.training import train_ppo
 
-CONFIG_PATH = Path("configs/training/ppo/issue_4014_ppo_mamba_smoke.yaml")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs" / "training" / "ppo" / "issue_4014_ppo_mamba_smoke.yaml"
 
 
 def test_ppo_mamba_smoke_config_loads_cpu_safe_extractor_contract() -> None:


### PR DESCRIPTION
Reviewer-critical summary

What changed: Registers `feature_extractor: mamba` in the standard PPO training entry point, adds a CPU-safe PPO-Mamba smoke config for issue #4014, and points the issue #4244 comparison-matrix PPO-Mamba arm at the checked-in config instead of the placeholder.

Why now: Prior merged #4014 slices added the Mamba extractor primitive and true RecurrentPPO LSTM lane; this is the next nameable progression slice that makes PPO-Mamba selectable by training config and usable by the preregistered comparison matrix.

Claim boundary: This proves config parsing, PPO policy selection, comparison-matrix wiring, and dry-run trainability prep only. It is not full PPO optimization, not a throughput report, not benchmark evidence, and not a paper/dissertation claim.

Required validation: focused pytest coverage for the PPO-Mamba config, Mamba extractor, RecurrentPPO config, and comparison matrix; `train_ppo.py --dry-run` on the new config; final `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`.

Remaining blocker: issue #4014 still needs actual matched smoke/full training runs that emit throughput, parameter/count metadata, and diagnostic comparison artifacts for PPO, RecurrentPPO-LSTM, and PPO-Mamba.

Contract delta

New schema fields: none.

New config/behavior surface: `feature_extractor: mamba` now resolves to `MambaFeatureExtractor` in `scripts/training/train_ppo.py`; `configs/training/ppo/issue_4014_ppo_mamba_smoke.yaml` provides the CPU-safe PPO-Mamba smoke lane using `backend: torch_ssm_lite`.

New fail-closed blockers: none added in this slice. Existing Mamba extractor backend validation remains the fail-closed surface for invalid backend/source settings and exact-backend dependency requirements.

Compatibility impact: existing PPO configs keep current behavior. The issue #4244 comparison matrix no longer references the PPO-Mamba placeholder config; it now references the executable #4014 smoke config, while its smoke-contract manifest gate still remains required before campaign submission.

Issue: Closes none; advances #4014.

Scope summary

- Added PPO-Mamba training registry support.
- Added matched CPU-safe PPO-Mamba smoke config.
- Updated the comparison-matrix preregistration to consume the real PPO-Mamba config.
- Updated the #4014 context note with the claim boundary and residual work.

Validation

- `uv run ruff check --fix tests/training/test_train_ppo_mamba_config_issue_4014.py` -> passed, fixed import order.
- `uv run ruff format scripts/training/train_ppo.py tests/training/test_train_ppo_mamba_config_issue_4014.py tests/training/test_comparison_matrix_preregistration_issue_4244.py` -> passed, unchanged after fix.
- `uv run ruff check scripts/training/train_ppo.py tests/training/test_train_ppo_mamba_config_issue_4014.py tests/training/test_comparison_matrix_preregistration_issue_4244.py` -> passed.
- `uv run pytest tests/training/test_train_ppo_mamba_config_issue_4014.py tests/test_mamba_feature_extractor.py tests/training/test_train_recurrent_ppo_config.py tests/training/test_comparison_matrix_preregistration_issue_4244.py -q` -> passed, 32 tests.
- `uv run python scripts/training/train_ppo.py --config configs/training/ppo/issue_4014_ppo_mamba_smoke.yaml --dry-run --log-level WARNING` -> passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed before commit; final clean-tree run is recorded separately before PR open.

Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Governance and artifact notes</summary>

Fragmentation guard: only one #4014 PR was found merged in the prior 24 hours before this slice, so the guard did not block another progression slice. This PR adds a nameable new capability: the PPO-Mamba training-config lane.

Generated artifacts: local dry-run/readiness outputs under `output/` are disposable ignored validation artifacts and are not committed or treated as durable evidence.

State propagation: high-churn issue-state propagation is not performed by this PR because authorization forbids issue/PR comments and tracked transient queue-routing state is forbidden for this PR. The durable state surface updated here is the existing #4014 context note, limited to schema/behavior status and claim boundary.
</details>
