### PR TITLE
Issue #4017 constrained RL readiness gate

### DIFF
--- a/docs/context/evidence/issue_4017_constrained_rl/README.md
+++ b/docs/context/evidence/issue_4017_constrained_rl/README.md
@@ -1,14 +1,12 @@
-# Issue #4017 constrained-RL diagnostic comparison
+# Issue #4017 Constrained RL Diagnostic Comparison
 
-This directory documents the small issue #4017 diagnostic-reporting slice. The
-tracked artifact is the report contract and command path; generated smoke
-manifests, checkpoints, traces, and comparison reports stay under ignored
-`output/`.
+This directory documents the issue #4017 diagnostic-reporting slice. Generated smoke manifests,
+checkpoints, traces, comparison reports, and readiness reports stay under ignored `output/`.
 
-Claim boundary: the comparison is diagnostic-only. It records matched smoke
-manifest fields, constraint budgets, budget violations, multiplier trajectory,
-runtime when present in the manifest, and fallback or degraded status. It does
-not make a benchmark-strength, paper-grade, or dissertation safety claim.
+Claim boundary: comparison evidence is diagnostic-only. It records matched smoke manifest fields,
+constraint budgets, budget violations, multiplier trajectory, runtime when present in the manifest,
+and fallback/degraded status. It is not a benchmark-strength, paper-grade, or dissertation safety
+claim.
 
 Canonical commands:
 
@@ -30,6 +28,19 @@ Expected generated outputs:
 - `output/benchmarks/issue4017/comparison_report.json`
 - `output/benchmarks/issue4017/comparison_report.md`
 
-If smoke manifests are missing, stale, degraded, or lack required fields, the
-report builder fails closed or emits `diagnostic_blocked` with explicit blockers
-instead of treating the comparison as evidence.
+If smoke manifests are missing, stale, degraded, or lack required fields, the report builder fails
+closed and emits `diagnostic_blocked` with explicit blockers instead of treating the comparison as
+evidence.
+
+Consolidated readiness handoff:
+
+```bash
+uv run python scripts/analysis/check_constrained_rl_readiness_issue_4017.py \
+  --report output/benchmarks/issue4017/comparison_report.json \
+  --output output/benchmarks/issue4017/readiness_report.json
+```
+
+The readiness report is the integration surface for remaining issue #4017 work. It records whether
+the diagnostic comparison is ready for the next paired empirical campaign, which blockers remain,
+and the next empirical action. It keeps `ready_for_benchmark_claim` false until a separate
+benchmark-strength campaign is run and reviewed.

--- a/scripts/analysis/check_constrained_rl_readiness_issue_4017.py
+++ b/scripts/analysis/check_constrained_rl_readiness_issue_4017.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Fail-closed readiness gate for issue #4017 constrained-RL evidence.
+
+This checker consolidates the existing CPU-smoke diagnostic comparison into a
+single machine-readable handoff. It does not train policies, run benchmark
+campaigns, submit Slurm jobs, or promote a paper-facing safety claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+SCHEMA_VERSION = "issue_4017.constrained_rl_readiness.v1"
+EXPECTED_REPORT_SCHEMA = "issue_4017.constrained_rl_diagnostic.v1"
+READY_STATUS = "diagnostic_ready_for_empirical_campaign"
+BLOCKED_STATUS = "diagnostic_blocked"
+BLOCKED_EXIT_CODE = 3
+
+
+def assess_readiness(report_path: str | Path) -> dict[str, object]:
+    """Return fail-closed readiness assessment for a diagnostic comparison report."""
+    path = Path(report_path).resolve()
+    report = _read_json_object(path)
+    blockers = _collect_blockers(report)
+    status = BLOCKED_STATUS if blockers else READY_STATUS
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 4017,
+        "source_report": str(path),
+        "status": status,
+        "claim_boundary": (
+            "diagnostic constrained-RL smoke readiness only; not benchmark-strength, "
+            "paper-grade, or dissertation safety evidence"
+        ),
+        "ready_for_benchmark_claim": False,
+        "ready_for_empirical_campaign": not blockers,
+        "blockers_remaining": blockers,
+        "intentional_limits": [
+            "no full benchmark campaign run",
+            "no Slurm/GPU submission",
+            "no metric semantics redefinition",
+            "no safety-wrapper or uncertainty-buffer claim",
+            "no paper/dissertation claim edit",
+        ],
+        "next_empirical_action": _next_empirical_action(blockers),
+        "contract": {
+            "requires_report_schema": EXPECTED_REPORT_SCHEMA,
+            "requires_report_status": "diagnostic_ready",
+            "requires_diagnostic_only_tier": True,
+            "requires_non_degraded_evidence": True,
+            "requires_matched_seed_and_timesteps": True,
+            "requires_budget_violation_and_multiplier_update": True,
+            "requires_runtime_recorded": True,
+        },
+    }
+
+
+def _collect_blockers(report: Mapping[str, object]) -> list[str]:
+    """Collect readiness blockers without treating diagnostic evidence as a claim."""
+    blockers: list[str] = []
+    blockers.extend(_report_contract_blockers(report))
+    blockers.extend(_run_summary_blockers("baseline", _mapping(report.get("baseline"))))
+    blockers.extend(_run_summary_blockers("constrained", _mapping(report.get("constrained"))))
+    blockers.extend(_constraint_effect_blockers(_mapping(report.get("constraint_effect"))))
+
+    trace = _mapping(report.get("constraint_trace"))
+    if int(trace.get("record_count") or 0) <= 0:
+        blockers.append("constraint trace has no completed episode records")
+    return _dedupe(blockers)
+
+
+def _report_contract_blockers(report: Mapping[str, object]) -> list[str]:
+    """Return blockers from top-level report contract fields."""
+    blockers: list[str] = []
+    if report.get("schema_version") != EXPECTED_REPORT_SCHEMA:
+        blockers.append("comparison report schema is missing or unsupported")
+    if report.get("issue") != 4017:
+        blockers.append("comparison report does not target issue 4017")
+    if report.get("evidence_tier") != "diagnostic-only":
+        blockers.append("comparison report must stay diagnostic-only")
+    if report.get("status") != "diagnostic_ready":
+        blockers.append("comparison report status is not diagnostic_ready")
+    blockers.extend(_string_list(report.get("blockers")))
+    if bool(report.get("fallback_or_degraded", True)):
+        blockers.append("comparison report is fallback/degraded or omits non-degraded proof")
+    return blockers
+
+
+def _run_summary_blockers(role: str, summary: Mapping[str, object]) -> list[str]:
+    """Return blockers for one training manifest summary."""
+    blockers: list[str] = []
+    if bool(summary.get("dry_run", True)):
+        blockers.append(f"{role} manifest is dry-run only")
+    if summary.get("runtime_status") != "recorded":
+        blockers.append(f"{role} manifest does not record runtime_seconds")
+    if bool(summary.get("fallback_or_degraded", True)):
+        blockers.append(f"{role} manifest is fallback/degraded")
+    if _string_list(summary.get("missing_fields")):
+        blockers.append(f"{role} manifest is missing required fields")
+    return blockers
+
+
+def _constraint_effect_blockers(effect: Mapping[str, object]) -> list[str]:
+    """Return blockers from the constrained-vs-unconstrained effect summary."""
+    blockers: list[str] = []
+    if effect.get("interpretation") != "diagnostic_only":
+        blockers.append("constraint effect interpretation must remain diagnostic_only")
+    if effect.get("matched_seed") is not True:
+        blockers.append("baseline and constrained manifests do not use the same seed")
+    if effect.get("matched_total_timesteps") is not True:
+        blockers.append("baseline and constrained manifests do not use matched timesteps")
+    if bool(effect.get("benchmark_safety_claim", True)):
+        blockers.append("comparison report attempts a benchmark safety claim")
+    if not _string_list(effect.get("budget_violation_constraints")):
+        blockers.append("no positive budget violation was observed")
+    if not _string_list(effect.get("multiplier_changed_constraints")):
+        blockers.append("no Lagrange multiplier update was observed")
+    return blockers
+
+
+def _next_empirical_action(blockers: Sequence[str]) -> str:
+    if blockers:
+        return (
+            "Regenerate the matched CPU-smoke manifests and comparison report until this "
+            "readiness gate reports diagnostic_ready_for_empirical_campaign."
+        )
+    return (
+        "Run the paired constrained/unconstrained empirical campaign on the configured "
+        "diagnostic scenario set, then archive the generated manifests, trace, comparison "
+        "report, and this readiness report before making any stronger safety claim."
+    )
+
+
+def _read_json_object(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        raise FileNotFoundError(f"comparison report does not exist: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"comparison report must be a JSON object: {path}")
+    return data
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        return []
+    return [str(item) for item in value]
+
+
+def _dedupe(items: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=Path("output/benchmarks/issue4017/comparison_report.json"),
+        help="Issue #4017 diagnostic comparison report JSON.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path for the readiness report JSON.",
+    )
+    parser.add_argument(
+        "--allow-blocked",
+        action="store_true",
+        help="Exit 0 even when the report remains blocked.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the readiness CLI."""
+    args = _build_parser().parse_args(argv)
+    readiness = assess_readiness(args.report)
+    text = json.dumps(readiness, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    print(text, end="")
+    if readiness["status"] == BLOCKED_STATUS and not args.allow_blocked:
+        return BLOCKED_EXIT_CODE
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/analysis/test_check_constrained_rl_readiness_issue_4017.py
+++ b/tests/analysis/test_check_constrained_rl_readiness_issue_4017.py
@@ -1,0 +1,98 @@
+"""Tests for issue #4017 constrained-RL readiness consolidation."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.analysis.check_constrained_rl_readiness_issue_4017 import (
+    BLOCKED_EXIT_CODE,
+    assess_readiness,
+    main,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_ready_report_maps_to_next_empirical_action(tmp_path: Path) -> None:
+    """A complete diagnostic report is ready for the next empirical campaign."""
+    report_path = tmp_path / "comparison_report.json"
+    report_path.write_text(json.dumps(_report()), encoding="utf-8")
+
+    readiness = assess_readiness(report_path)
+
+    assert readiness["status"] == "diagnostic_ready_for_empirical_campaign"
+    assert readiness["ready_for_empirical_campaign"] is True
+    assert readiness["ready_for_benchmark_claim"] is False
+    assert readiness["blockers_remaining"] == []
+    assert "paired constrained/unconstrained empirical campaign" in str(
+        readiness["next_empirical_action"]
+    )
+
+
+def test_blocked_report_preserves_remaining_blockers(tmp_path: Path) -> None:
+    """Missing runtime and absent multiplier updates block stronger handoff."""
+    report = _report()
+    report["status"] = "diagnostic_blocked"
+    report["blockers"] = ["constrained trace has no completed episode multiplier records"]
+    report["baseline"]["runtime_status"] = "missing_from_manifest"
+    report["constraint_effect"]["multiplier_changed_constraints"] = []
+    report_path = tmp_path / "comparison_report.json"
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+
+    readiness = assess_readiness(report_path)
+
+    assert readiness["status"] == "diagnostic_blocked"
+    assert readiness["ready_for_empirical_campaign"] is False
+    assert "comparison report status is not diagnostic_ready" in readiness["blockers_remaining"]
+    assert "baseline manifest does not record runtime_seconds" in readiness["blockers_remaining"]
+    assert "no Lagrange multiplier update was observed" in readiness["blockers_remaining"]
+    assert "Regenerate the matched CPU-smoke manifests" in readiness["next_empirical_action"]
+
+
+def test_cli_exit_code_allows_explicit_blocked_diagnostic(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI exits non-zero for blocked evidence unless explicitly allowed."""
+    report = _report()
+    report["fallback_or_degraded"] = True
+    report_path = tmp_path / "comparison_report.json"
+    output_path = tmp_path / "readiness.json"
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+
+    assert main(["--report", str(report_path), "--output", str(output_path)]) == BLOCKED_EXIT_CODE
+    assert main(["--report", str(report_path), "--allow-blocked"]) == 0
+    captured = capsys.readouterr()
+    assert "diagnostic_blocked" in captured.out
+    assert json.loads(output_path.read_text(encoding="utf-8"))["status"] == "diagnostic_blocked"
+
+
+def _report() -> dict[str, object]:
+    run_summary = {
+        "dry_run": False,
+        "runtime_status": "recorded",
+        "fallback_or_degraded": False,
+        "missing_fields": [],
+    }
+    return {
+        "schema_version": "issue_4017.constrained_rl_diagnostic.v1",
+        "issue": 4017,
+        "evidence_tier": "diagnostic-only",
+        "status": "diagnostic_ready",
+        "blockers": [],
+        "fallback_or_degraded": False,
+        "baseline": dict(run_summary),
+        "constrained": dict(run_summary),
+        "constraint_effect": {
+            "interpretation": "diagnostic_only",
+            "matched_seed": True,
+            "matched_total_timesteps": True,
+            "benchmark_safety_claim": False,
+            "budget_violation_constraints": ["collision_any"],
+            "multiplier_changed_constraints": ["collision_any"],
+        },
+        "constraint_trace": {"record_count": 1},
+    }


### PR DESCRIPTION
Reviewer-critical summary

What changed: Adds `scripts/analysis/check_constrained_rl_readiness_issue_4017.py`, a fail-closed readiness gate over the existing issue #4017 constrained-vs-unconstrained diagnostic comparison report, plus tests and the documented handoff command.

Why now: Two issue #4017 implementation/report PRs merged in the last 24 hours (#4214, #4259). Per the fragmentation guard, this is a consolidation slice rather than another micro-guard: it produces one coherent integration contract for the remaining empirical-campaign path.

Claim boundary: This PR only classifies diagnostic readiness. It does not train policies, run a benchmark campaign, submit Slurm/GPU work, redefine metrics, or make paper/dissertation safety claims.

Required validation: targeted analysis tests and Ruff for the new checker; final readiness wrapper run with this PR body.

Remaining blocker: issue #4017 still needs the broader paired empirical campaign / benchmark-strength safety claim path before any stronger constrained-RL claim.

Contract delta

New schema: `issue_4017.constrained_rl_readiness.v1` readiness JSON emitted by the checker.

New fail-closed blockers: unsupported comparison schema, wrong issue, non-diagnostic evidence tier, non-ready comparison status, fallback/degraded evidence, dry-run manifests, missing `runtime_seconds`, missing required manifest fields, unmatched seed/timesteps, attempted benchmark safety claim, no positive budget violation, no Lagrange multiplier update, or empty constraint trace.

Compatibility impact: additive script/test/docs only. Existing training configs, comparison report schema, benchmark metrics, and generated output locations remain unchanged. The checker reads the existing `output/benchmarks/issue4017/comparison_report.json` and can write an optional ignored readiness report.

Issue: Refs #4017

Scope summary

- Add a constrained-RL diagnostic readiness CLI for issue #4017.
- Add synthetic tests for ready, blocked, and CLI exit-code behavior.
- Update `docs/context/evidence/issue_4017_constrained_rl/README.md` with the readiness handoff command and claim boundary.

Validation command results

- `uv run pytest tests/analysis/test_check_constrained_rl_readiness_issue_4017.py tests/analysis/test_compare_constrained_rl_issue_4017.py -q` -> passed, 7 tests.
- `uv run ruff check scripts/analysis/check_constrained_rl_readiness_issue_4017.py tests/analysis/test_check_constrained_rl_readiness_issue_4017.py` -> passed.
- `uv run python scripts/analysis/check_constrained_rl_readiness_issue_4017.py --help` -> passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/pr_bodies/issue_4017_pr.md scripts/dev/pr_ready_check.sh` -> passed; stamp `output/validation/pr_ready/issue-4017-bulk-admitted-successor-slice-for-issue-4017.json`, head `2d4ea09d4311faff1d703e2b191600a5cdba8ac3`.

Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Process notes</summary>

- Fragmentation guard observed: PR #4214 and PR #4259 merged for issue #4017 within the last 24 hours, so this PR is a consolidation/integration slice.
- Late-guidance check before commit found issue #4017 had no comments newer than the start of this run; this will be rechecked immediately before opening.
- No transient queue-routing state, target-host state, or packet lineage pointer is encoded in tracked files.
- State propagation: no issue comment added because `comment_issue_or_pr` is not authorized in this task. The PR body records the delivered slice and remaining blocker.
</details>
