### PR TITLE
Issue #4018 add density curriculum readiness packet

### DIFF
--- a/robot_sf/training/density_curriculum_readiness.py
+++ b/robot_sf/training/density_curriculum_readiness.py
@@ -1,0 +1,150 @@
+"""Readiness checks for issue #4018 density-curriculum comparison manifests."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+READINESS_SCHEMA_VERSION = "issue_4018.density_curriculum_readiness.v1"
+COMPARISON_SCHEMA_VERSION = "density_curriculum_comparison.v1"
+ISSUE_ID = "ll7/robot_sf_ll7#4018"
+CLAIM_BOUNDARY = "comparison readiness only; not benchmark evidence or a training-result claim"
+NEXT_EMPIRICAL_ACTION = (
+    "run the paired density-curriculum and fixed-density PPO smoke configs, then "
+    "replace the dry-run manifest with completed training artifact paths before any "
+    "performance or paper-facing claim"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DensityCurriculumReadiness:
+    """Fail-closed readiness verdict for a paired curriculum comparison manifest."""
+
+    status: str
+    blockers: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+    manifest_path: str | None = None
+    schema_version: str = READINESS_SCHEMA_VERSION
+    issue: str = ISSUE_ID
+    claim_boundary: str = CLAIM_BOUNDARY
+    next_empirical_action: str = NEXT_EMPIRICAL_ACTION
+    comparison: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-ready readiness packet."""
+        return {
+            "schema_version": self.schema_version,
+            "issue": self.issue,
+            "status": self.status,
+            "claim_boundary": self.claim_boundary,
+            "manifest_path": self.manifest_path,
+            "blockers": list(self.blockers),
+            "notes": list(self.notes),
+            "comparison": self.comparison,
+            "next_empirical_action": self.next_empirical_action,
+        }
+
+
+def evaluate_density_curriculum_readiness(
+    manifest_path: Path,
+) -> DensityCurriculumReadiness:
+    """Evaluate whether a density-curriculum comparison manifest can support a smoke run.
+
+    Returns:
+        Fail-closed readiness packet for the input manifest.
+    """
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    blockers: list[str] = []
+    notes: list[str] = []
+
+    if manifest.get("schema_version") != COMPARISON_SCHEMA_VERSION:
+        blockers.append("manifest schema_version must be density_curriculum_comparison.v1")
+    if manifest.get("issue") != ISSUE_ID:
+        blockers.append("manifest issue must be ll7/robot_sf_ll7#4018")
+    if "no benchmark" not in str(manifest.get("claim_boundary", "")).lower():
+        blockers.append("manifest claim_boundary must explicitly exclude benchmark claims")
+    if bool(manifest.get("dry_run", True)):
+        blockers.append("manifest is dry_run; paired training artifacts are not available")
+
+    curriculum = _arm(manifest, "curriculum", blockers)
+    baseline = _arm(manifest, "baseline", blockers)
+    _check_pair(curriculum, baseline, blockers)
+    _check_artifacts(manifest, blockers)
+
+    if not blockers:
+        notes.append("paired manifest is ready for diagnostic smoke comparison review")
+
+    status = "ready_diagnostic_smoke" if not blockers else "blocked"
+    return DensityCurriculumReadiness(
+        status=status,
+        blockers=tuple(blockers),
+        notes=tuple(notes),
+        manifest_path=str(manifest_path),
+        comparison={
+            "curriculum": _compact_arm(curriculum),
+            "baseline": _compact_arm(baseline),
+            "dry_run": bool(manifest.get("dry_run", True)),
+        },
+    )
+
+
+def _arm(
+    manifest: dict[str, Any],
+    name: str,
+    blockers: list[str],
+) -> dict[str, Any]:
+    raw = manifest.get(name)
+    if not isinstance(raw, dict):
+        blockers.append(f"{name} arm must be a mapping")
+        return {}
+    return raw
+
+
+def _check_pair(
+    curriculum: dict[str, Any],
+    baseline: dict[str, Any],
+    blockers: list[str],
+) -> None:
+    if curriculum.get("density_curriculum_enabled") is not True:
+        blockers.append("curriculum arm must enable density_curriculum")
+    if baseline.get("density_curriculum_enabled") is not False:
+        blockers.append("baseline arm must disable density_curriculum")
+
+    curriculum_steps = curriculum.get("total_timesteps")
+    baseline_steps = baseline.get("total_timesteps")
+    if curriculum_steps != baseline_steps:
+        blockers.append("curriculum and baseline total_timesteps must match")
+    if not isinstance(curriculum_steps, int) or curriculum_steps <= 0:
+        blockers.append("paired total_timesteps must be a positive integer")
+
+    curriculum_policy = curriculum.get("policy_id")
+    baseline_policy = baseline.get("policy_id")
+    if not curriculum_policy or not baseline_policy:
+        blockers.append("both arms must declare policy_id")
+    if curriculum_policy == baseline_policy:
+        blockers.append("curriculum and baseline policy_id values must be distinct")
+
+
+def _check_artifacts(manifest: dict[str, Any], blockers: list[str]) -> None:
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        blockers.append("manifest artifacts mapping is required for non-dry-run readiness")
+        return
+
+    for key in ("curriculum_checkpoint", "baseline_checkpoint"):
+        value = artifacts.get(key)
+        if not isinstance(value, str) or not value:
+            blockers.append(f"artifacts.{key} must name a completed checkpoint path")
+
+
+def _compact_arm(arm: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": arm.get("path"),
+        "policy_id": arm.get("policy_id"),
+        "total_timesteps": arm.get("total_timesteps"),
+        "density_curriculum_enabled": arm.get("density_curriculum_enabled"),
+    }

--- a/scripts/training/check_density_curriculum_readiness.py
+++ b/scripts/training/check_density_curriculum_readiness.py
@@ -1,0 +1,35 @@
+"""Fail-closed readiness check for issue #4018 density-curriculum comparisons."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.training.density_curriculum_readiness import (
+    evaluate_density_curriculum_readiness,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the readiness check and return a fail-closed process status."""
+    args = _parse_args()
+    readiness = evaluate_density_curriculum_readiness(args.manifest)
+    payload = readiness.to_dict()
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return 0 if readiness.status == "ready_diagnostic_smoke" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/training/test_density_curriculum_readiness.py
+++ b/tests/training/test_density_curriculum_readiness.py
@@ -1,0 +1,129 @@
+"""Tests issue #4018 density-curriculum comparison readiness."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.training.density_curriculum_readiness import (
+    evaluate_density_curriculum_readiness,
+)
+from scripts.training.check_density_curriculum_readiness import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _manifest(*, dry_run: bool = False) -> dict[str, object]:
+    return {
+        "schema_version": "density_curriculum_comparison.v1",
+        "issue": "ll7/robot_sf_ll7#4018",
+        "claim_boundary": "diagnostic harness only; no benchmark training-result claim",
+        "dry_run": dry_run,
+        "curriculum": {
+            "path": "configs/training/ppo/ablations/issue_4018_density_curriculum_smoke.yaml",
+            "policy_id": "issue_4018_density_curriculum_smoke",
+            "total_timesteps": 4096,
+            "density_curriculum_enabled": True,
+        },
+        "baseline": {
+            "path": "configs/training/ppo/ablations/issue_4018_fixed_density_smoke.yaml",
+            "policy_id": "issue_4018_fixed_density_smoke",
+            "total_timesteps": 4096,
+            "density_curriculum_enabled": False,
+        },
+        "artifacts": {
+            "curriculum_checkpoint": "output/issue_4018/curriculum/best_model.zip",
+            "baseline_checkpoint": "output/issue_4018/baseline/best_model.zip",
+        },
+    }
+
+
+def _write_manifest(tmp_path: Path, payload: dict[str, object]) -> Path:
+    path = tmp_path / "comparison_manifest.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_readiness_accepts_completed_paired_manifest(tmp_path: Path) -> None:
+    """Completed paired manifests become diagnostic-smoke ready."""
+    path = _write_manifest(tmp_path, _manifest())
+
+    readiness = evaluate_density_curriculum_readiness(path).to_dict()
+
+    assert readiness["schema_version"] == "issue_4018.density_curriculum_readiness.v1"
+    assert readiness["status"] == "ready_diagnostic_smoke"
+    assert readiness["blockers"] == []
+    assert "not benchmark evidence" in readiness["claim_boundary"]
+    assert readiness["comparison"]["curriculum"]["density_curriculum_enabled"] is True
+    assert readiness["comparison"]["baseline"]["density_curriculum_enabled"] is False
+
+
+def test_readiness_blocks_dry_run_manifest_without_training_artifacts(tmp_path: Path) -> None:
+    """Dry-run comparison manifests are useful setup evidence but not run-ready evidence."""
+    payload = _manifest(dry_run=True)
+    payload.pop("artifacts")
+    path = _write_manifest(tmp_path, payload)
+
+    readiness = evaluate_density_curriculum_readiness(path).to_dict()
+
+    assert readiness["status"] == "blocked"
+    assert "manifest is dry_run" in " ".join(readiness["blockers"])
+    assert "artifacts mapping" in " ".join(readiness["blockers"])
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (
+            lambda payload: payload.__setitem__("schema_version", "wrong.v1"),
+            "schema_version",
+        ),
+        (
+            lambda payload: payload["baseline"].__setitem__("density_curriculum_enabled", True),
+            "baseline arm must disable",
+        ),
+        (
+            lambda payload: payload["baseline"].__setitem__("total_timesteps", 1024),
+            "total_timesteps",
+        ),
+    ],
+)
+def test_readiness_fails_closed_on_contract_drift(
+    tmp_path: Path,
+    mutate,
+    match: str,
+) -> None:
+    """Comparison contract drift is reported as a blocker."""
+    payload = _manifest()
+    mutate(payload)
+    path = _write_manifest(tmp_path, payload)
+
+    readiness = evaluate_density_curriculum_readiness(path)
+
+    assert readiness.status == "blocked"
+    assert match in " ".join(readiness.blockers)
+
+
+def test_cli_writes_packet_and_uses_fail_closed_exit_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI emits a JSON packet and returns non-zero while dry-run blockers remain."""
+    path = _write_manifest(tmp_path, _manifest(dry_run=True))
+    output = tmp_path / "readiness.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "check_density_curriculum_readiness.py",
+            str(path),
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert main() == 1
+    packet = json.loads(output.read_text(encoding="utf-8"))
+    assert packet["status"] == "blocked"


### PR DESCRIPTION
Reviewer-critical summary

What changed: adds a fail-closed issue #4018 density-curriculum readiness packet over the existing `density_curriculum_comparison.v1` manifest. The new checker classifies whether a paired curriculum-vs-fixed PPO smoke comparison has moved beyond dry-run setup into diagnostic-smoke-ready evidence.

Why now: PR #4169 wired the density curriculum mechanism, smoke configs, and dry-run comparison manifest. This successor slice adds a nameable integration capability: a canonical readiness verdict and next empirical action before any full training or performance claim.

Claim boundary: readiness/contract behavior only. This PR does not run paired training, benchmark performance, promote curriculum quality, or make paper/dissertation claims.

Required validation: focused readiness tests, focused comparison/readiness CLI execution, Ruff on touched files, core repository readiness wrapper, and final clean-tree PR readiness wrapper.

Remaining blocker: issue #4018 still needs the actual paired curriculum and fixed-density PPO smoke training run with completed checkpoint artifact paths before any empirical comparison can be reviewed.

## Contract delta

- New schema: `issue_4018.density_curriculum_readiness.v1`.
- New CLI: `scripts/training/check_density_curriculum_readiness.py <comparison_manifest.json> --output <readiness.json>`.
- New fail-closed blockers: wrong comparison schema, wrong issue, missing benchmark-claim exclusion, dry-run manifest, missing or malformed curriculum/baseline arms, mismatched timesteps, missing/duplicate policy IDs, incorrect curriculum enablement, and missing checkpoint artifact paths.
- Compatibility impact: additive only. Existing density curriculum configs, training entry points, and `density_curriculum_comparison.v1` dry-run manifest behavior are unchanged.

## Issue

Advances https://github.com/ll7/robot_sf_ll7/issues/4018. Does not close the parent research issue.

## Scope summary

- Adds reusable readiness evaluator in `robot_sf/training/density_curriculum_readiness.py`.
- Adds thin CLI wrapper in `scripts/training/check_density_curriculum_readiness.py`.
- Adds focused tests for ready, dry-run-blocked, contract-drift, and CLI exit-code behavior.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/training/density_curriculum_readiness.py scripts/training/check_density_curriculum_readiness.py tests/training/test_density_curriculum_readiness.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/density_curriculum_readiness.py scripts/training/check_density_curriculum_readiness.py tests/training/test_density_curriculum_readiness.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_density_curriculum_readiness.py tests/training/test_density_curriculum_comparison.py -q` passed, 7 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/training/run_density_curriculum_comparison.py --curriculum-config configs/training/ppo/ablations/issue_4018_density_curriculum_smoke.yaml --baseline-config configs/training/ppo/ablations/issue_4018_fixed_density_smoke.yaml --output-dir output/validation/issue_4018_density_curriculum --dry-run` passed and wrote `comparison_manifest.json`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/training/check_density_curriculum_readiness.py output/validation/issue_4018_density_curriculum/comparison_manifest.json --output output/validation/issue_4018_density_curriculum/readiness.json` returned the expected fail-closed readiness status `blocked` for dry-run/no-artifact inputs.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed on dirty interim tree; core lane reported `1841 passed, 2 skipped`.
- `PR_READY_PR_BODY_FILE=/tmp/issue4018_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed on clean committed tree.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: the visible issue #4018 PR history includes prior merged PR #4169 in the last 24h window at task start, not two or more guardrail/checker/packet-refresh PRs. This PR is a progression slice with a new named capability: density-curriculum comparison readiness packets.

Late guidance check: issue #4018 was re-read before opening via GitHub REST API because `gh issue view --comments` fails on a deprecated Projects Classic GraphQL field. No comments newer than task start were present; latest issue update remained 2026-07-02T15:24:45Z.

State propagation: no issue comment is posted because this run has `comment_issue_or_pr: false`; the PR body records delivered slice and remaining blocker.

Artifacts: generated `output/validation/issue_4018_density_curriculum/` and readiness wrapper artifacts are ignored local validation outputs only. No transient host, queue-routing, or packet-lineage state is encoded in tracked files.

Forbidden actions: no compute submission, merge, release, deletion, or full benchmark campaign.

</details>
