### PR TITLE
Issue #4207 add trained arm readiness contract

### DIFF
--- a/robot_sf/benchmark/certification_transfer.py
+++ b/robot_sf/benchmark/certification_transfer.py
@@ -47,6 +47,7 @@ TRAINED_PLANNER_ELIGIBLE = "eligible"
 TRAINED_PLANNER_NOT_A_TRAINED_PLANNER = "not_a_trained_planner"
 TRAINED_PLANNER_EXCLUDED_MISSING_CHECKPOINT = "excluded_missing_checkpoint_or_config"
 TRAINED_PLANNER_EXCLUDED_FALLBACK = "excluded_fallback_execution"
+TRAINED_PLANNER_REQUIRED_FIELDS = ("algo_config", "checkpoint", "training_manifest")
 
 GATE_CELL_COLUMNS = (
     "planner_key",
@@ -157,6 +158,7 @@ def validate_probe_config(config: Mapping[str, Any], *, base_dir: Path) -> dict[
                 TRAINED_PLANNER_EXCLUDED_MISSING_CHECKPOINT,
                 TRAINED_PLANNER_EXCLUDED_FALLBACK,
             ],
+            "required_fields": list(TRAINED_PLANNER_REQUIRED_FIELDS),
         },
     }
 
@@ -299,6 +301,7 @@ def build_certification_transfer_report(
             for arm in normalized_config["arms"]
         ],
         "trained_planner_claim_policy": normalized_config["trained_planner_claim_policy"],
+        "trained_planner_readiness": _trained_planner_readiness(normalized_config["arms"]),
         "trained_planner_claim_status_counts": dict(
             Counter(row["trained_planner_claim_status"] for row in transfer_matrix)
         ),
@@ -660,30 +663,64 @@ def _validate_arms(raw_arms: object, *, base_dir: Path) -> list[dict[str, Any]]:
         algo = str(arm.get("algo", "")).strip()
         if not key or not structural_class or not algo:
             raise ValueError("each arm requires key, structural_class, and algo")
-        normalized = {
-            "key": key,
-            "structural_class": structural_class,
-            "algo": algo,
-            "benchmark_profile": str(arm.get("benchmark_profile", "experimental")),
-            "development_pedestrian_model": str(arm.get("development_pedestrian_model", "unknown")),
-        }
-        if arm.get("observation_mode") is not None:
-            normalized["observation_mode"] = str(arm["observation_mode"])
-        if arm.get("observation_level") is not None:
-            normalized["observation_level"] = str(arm["observation_level"])
-        if arm.get("fallback_execution") is not None:
-            normalized["fallback_execution"] = bool(arm["fallback_execution"])
-        if arm.get("fallback_to_goal") is not None:
-            normalized["fallback_to_goal"] = bool(arm["fallback_to_goal"])
-        if arm.get("algo_config") is not None:
-            normalized["algo_config"] = str(
-                _resolve_existing_path(arm.get("algo_config"), base_dir=base_dir)
-            )
+        normalized = _normalized_arm_base(
+            arm, key=key, structural_class=structural_class, algo=algo
+        )
+        _copy_optional_arm_fields(normalized, arm, base_dir=base_dir)
         status, exclusion = _trained_planner_claim_status(normalized)
         normalized["trained_planner_claim_status"] = status
         normalized["trained_planner_claim_exclusion"] = exclusion
         normalized_arms.append(normalized)
     return normalized_arms
+
+
+def _copy_optional_arm_fields(
+    normalized: dict[str, Any],
+    arm: Mapping[str, Any],
+    *,
+    base_dir: Path,
+) -> None:
+    for field in ("observation_mode", "observation_level"):
+        if arm.get(field) is not None:
+            normalized[field] = str(arm[field])
+    for field in ("fallback_execution", "fallback_to_goal"):
+        if arm.get(field) is not None:
+            normalized[field] = bool(arm[field])
+    _copy_optional_existing_path(normalized, arm, "algo_config", base_dir=base_dir)
+    for artifact_field in ("checkpoint", "training_manifest"):
+        _copy_optional_existing_path(
+            normalized,
+            arm,
+            artifact_field,
+            base_dir=base_dir,
+        )
+
+
+def _normalized_arm_base(
+    arm: Mapping[str, Any],
+    *,
+    key: str,
+    structural_class: str,
+    algo: str,
+) -> dict[str, Any]:
+    return {
+        "key": key,
+        "structural_class": structural_class,
+        "algo": algo,
+        "benchmark_profile": str(arm.get("benchmark_profile", "experimental")),
+        "development_pedestrian_model": str(arm.get("development_pedestrian_model", "unknown")),
+    }
+
+
+def _copy_optional_existing_path(
+    target: dict[str, Any],
+    source: Mapping[str, Any],
+    field: str,
+    *,
+    base_dir: Path,
+) -> None:
+    if source.get(field) is not None:
+        target[field] = str(_resolve_existing_path(source.get(field), base_dir=base_dir))
 
 
 def _trained_planner_claim_status(arm: Mapping[str, Any]) -> tuple[str, str]:
@@ -705,6 +742,70 @@ def _trained_planner_claim_status(arm: Mapping[str, Any]) -> tuple[str, str]:
     if not str(arm.get("algo_config", "")).strip():
         return TRAINED_PLANNER_EXCLUDED_MISSING_CHECKPOINT, "missing_checkpoint_or_config"
     return TRAINED_PLANNER_ELIGIBLE, ""
+
+
+def _trained_planner_readiness(arms: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    for arm in arms:
+        status = str(arm["trained_planner_claim_status"])
+        missing_fields: list[str] = []
+        if _is_trained_planner_arm(arm):
+            if not str(arm.get("algo_config", "")).strip():
+                missing_fields.append("algo_config")
+            if not str(arm.get("checkpoint", "")).strip():
+                missing_fields.append("checkpoint")
+            if not str(arm.get("training_manifest", "")).strip():
+                missing_fields.append("training_manifest")
+        rows.append(
+            {
+                "planner_key": arm["key"],
+                "structural_class": arm["structural_class"],
+                "algo": arm["algo"],
+                "eligible_for_trained_planner_claim": status == TRAINED_PLANNER_ELIGIBLE
+                and not missing_fields,
+                "readiness_status": _readiness_status(status, missing_fields),
+                "missing_fields": missing_fields,
+                "trained_planner_claim_status": status,
+                "trained_planner_claim_exclusion": arm["trained_planner_claim_exclusion"],
+            }
+        )
+
+    blockers = [
+        row
+        for row in rows
+        if row["readiness_status"]
+        in {"blocked_missing_artifact_provenance", "blocked_fallback_execution"}
+    ]
+    eligible_rows = [row for row in rows if row["eligible_for_trained_planner_claim"]]
+    return {
+        "schema_version": "trained-planner-readiness.v1",
+        "claim_boundary": (
+            "eligible rows may support trained-planner comparison claims only after a fresh "
+            "certification-transfer run; excluded rows remain diagnostic-only"
+        ),
+        "required_fields": list(TRAINED_PLANNER_REQUIRED_FIELDS),
+        "all_trained_planner_arms_ready": not blockers,
+        "eligible_trained_planner_arm_count": len(eligible_rows),
+        "blocker_count": len(blockers),
+        "rows": rows,
+    }
+
+
+def _readiness_status(status: str, missing_fields: Sequence[str]) -> str:
+    if status == TRAINED_PLANNER_NOT_A_TRAINED_PLANNER:
+        return "not_required_baseline"
+    if status == TRAINED_PLANNER_EXCLUDED_FALLBACK:
+        return "blocked_fallback_execution"
+    if missing_fields:
+        return "blocked_missing_artifact_provenance"
+    return "ready_for_fresh_probe"
+
+
+def _is_trained_planner_arm(arm: Mapping[str, Any]) -> bool:
+    return (
+        str(arm.get("structural_class", "")) in TRAINED_PLANNER_STRUCTURAL_CLASSES
+        or str(arm.get("algo", "")) in TRAINED_PLANNER_ALGOS
+    )
 
 
 def _collision_value(record: Mapping[str, Any]) -> float | None:
@@ -804,6 +905,7 @@ def _metadata_payload(report: Mapping[str, Any]) -> dict[str, Any]:
         "seed_policy": report["seed_policy"],
         "arms": report["arms"],
         "trained_planner_claim_policy": report["trained_planner_claim_policy"],
+        "trained_planner_readiness": report["trained_planner_readiness"],
         "trained_planner_claim_status_counts": report["trained_planner_claim_status_counts"],
         "row_status_counts": report["row_status_counts"],
         "transfer_status_counts": report["transfer_status_counts"],
@@ -853,6 +955,9 @@ def _readme_markdown(report: Mapping[str, Any]) -> str:
         f"- Interaction status counts: `{dict(report['interaction_status_counts'])}`",
         f"- Trained-planner claim status counts: "
         f"`{dict(report['trained_planner_claim_status_counts'])}`",
+        f"- Trained-planner readiness: "
+        f"`{report['trained_planner_readiness']['eligible_trained_planner_arm_count']}` "
+        f"eligible, `{report['trained_planner_readiness']['blocker_count']}` blocked",
         f"- Physics near-field confirmed: `{interaction_metrics['physics_near_field_confirmed']}`",
         f"- Max robot-pedestrian within-5m fraction: "
         f"`{interaction_metrics['max_robot_ped_within_5m_frac']}`",

--- a/tests/benchmark/test_certification_transfer_issue_4207.py
+++ b/tests/benchmark/test_certification_transfer_issue_4207.py
@@ -157,6 +157,63 @@ def test_learned_predictive_missing_checkpoint_excluded_from_trained_planner_cla
     assert rows["fragile"]["trained_planner_claim_exclusion"] == "missing_checkpoint_or_config"
     assert rows["conservative"]["trained_planner_claim_exclusion"] == "missing_checkpoint_or_config"
     assert report["trained_planner_claim_status_counts"]["excluded_missing_checkpoint_or_config"]
+    readiness = report["trained_planner_readiness"]
+    assert readiness["all_trained_planner_arms_ready"] is False
+    assert readiness["blocker_count"] == 2
+    blocked = {
+        row["planner_key"]: row
+        for row in readiness["rows"]
+        if row["readiness_status"] == "blocked_missing_artifact_provenance"
+    }
+    assert blocked["fragile"]["missing_fields"] == [
+        "algo_config",
+        "checkpoint",
+        "training_manifest",
+    ]
+    assert blocked["conservative"]["missing_fields"] == [
+        "algo_config",
+        "checkpoint",
+        "training_manifest",
+    ]
+
+
+def test_trained_planner_readiness_turns_ready_with_artifact_provenance(
+    tmp_path: Path,
+) -> None:
+    """Checkpoint-backed trained arm records readiness for a fresh probe."""
+
+    config_path, gate_path, config, gates = _write_config_pair(tmp_path)
+    checkpoint_path = tmp_path / "policy.zip"
+    manifest_path = tmp_path / "training_manifest.json"
+    checkpoint_path.write_bytes(b"fixture checkpoint")
+    manifest_path.write_text('{"schema_version": "fixture"}\n', encoding="utf-8")
+    config["arms"][1].update(
+        {
+            "structural_class": "learned_policy",
+            "algo": "ppo",
+            "algo_config": str(tmp_path / "algo.yaml"),
+            "checkpoint": str(checkpoint_path),
+            "training_manifest": str(manifest_path),
+        }
+    )
+    records = [
+        _record("stable", SOCIAL_FORCE_DEFAULT, collision_rate=0.0),
+        _record("fragile", SOCIAL_FORCE_DEFAULT, collision_rate=0.0),
+    ]
+
+    report = build_certification_transfer_report(
+        records,
+        probe_config=config,
+        gate_spec=gates,
+        config_path=config_path,
+        gate_spec_path=gate_path,
+    )
+
+    readiness = report["trained_planner_readiness"]
+    row = next(row for row in readiness["rows"] if row["planner_key"] == "fragile")
+    assert row["eligible_for_trained_planner_claim"] is True
+    assert row["readiness_status"] == "ready_for_fresh_probe"
+    assert row["missing_fields"] == []
 
 
 def test_declared_fallback_execution_excluded_from_trained_planner_claims(tmp_path: Path) -> None:
@@ -217,6 +274,10 @@ def test_evidence_writer_emits_checksums_without_raw_artifacts(tmp_path: Path) -
     )
     loaded = json.loads(Path(paths["summary_json"]).read_text(encoding="utf-8"))
     assert loaded["issue"] == 4207
+    metadata = json.loads(Path(paths["metadata_json"]).read_text(encoding="utf-8"))
+    assert metadata["trained_planner_readiness"]["schema_version"] == "trained-planner-readiness.v1"
+    readme = Path(paths["readme"]).read_text(encoding="utf-8")
+    assert "Trained-planner readiness" in readme
     with Path(paths["certification_transfer_matrix_csv"]).open("r", encoding="utf-8") as handle:
         rows = list(csv.DictReader(handle))
     assert rows


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds an additive `trained_planner_readiness` contract to the issue #4207 certification-transfer report, metadata, and generated README so the remaining trained-arm blocker is explicit per arm instead of inferred only from exclusion counts.

Why now: issue #4207 has multiple recent guard/checker/report PRs; this is the progression/consolidation slice for the remaining blocker from #4412/#4433: learned/predictive arms still need checkpoint-backed artifact provenance before a real trained-planner comparison can be claimed.

Claim boundary: diagnostic certification-transfer support only. This PR does not rerun the probe, does not promote any trained-planner comparison result, and does not change gate pass/fail or transfer-status semantics.

Required validation: focused certification-transfer/release-gate tests and Ruff over touched benchmark surfaces.

Remaining blocker: attach resolved `algo_config`, `checkpoint`, and `training_manifest` for learned/predictive arms, then run a fresh CPU certification-transfer probe before any trained-planner comparison claim.

## Contract delta

- New report/metadata field: `trained_planner_readiness` with schema `trained-planner-readiness.v1`.
- New readiness rows per arm: `eligible_for_trained_planner_claim`, `readiness_status`, `missing_fields`, `trained_planner_claim_status`, and `trained_planner_claim_exclusion`.
- New required artifact fields for trained-planner claim readiness: `algo_config`, `checkpoint`, `training_manifest`.
- New fail-closed blockers: `blocked_missing_artifact_provenance` and `blocked_fallback_execution`.
- Compatibility impact: additive JSON/README fields only; existing gate cells, transfer matrix columns, transfer statuses, and retained packet interpretation are unchanged.

## Linked Issues

- Relates to #4207

## Scope summary

Implemented in-place in `robot_sf/benchmark/certification_transfer.py` and covered by `tests/benchmark/test_certification_transfer_issue_4207.py`.

This is a new capability toward the issue plan: a reusable trained-arm readiness contract for deciding whether the next issue #4207 CPU rerun can support trained-planner comparison claims.

## Validation / Proof

- `uv run ruff check robot_sf/benchmark/certification_transfer.py tests/benchmark/test_certification_transfer_issue_4207.py` -> passed.
- `uv run pytest tests/benchmark/test_ped_model_sensitivity.py tests/benchmark/test_release_gates.py tests/benchmark/test_certification_transfer_issue_4207.py -q` -> 40 passed.
- `python -m py_compile robot_sf/benchmark/certification_transfer.py tests/benchmark/test_certification_transfer_issue_4207.py` -> passed.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream propagation

No issue comment was added from this PR-opening lane because `comment_issue_or_pr=false`. High-churn issue #4207 state is instead summarized in this PR body; Claude Code on `imech156-u` owns the full PR gate and any canonical state-table propagation after review.

<details>
<summary>Governance appendix</summary>

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason: additive report contract only

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: blocker-resolution for trained learned/predictive arm readiness under issue #4207
- Comparator or baseline, applicable: current report only exposes exclusion counts; changed report exposes per-arm readiness blockers
- Evidence tier: targeted smoke / diagnostic support contract
- Result classification: blocker-resolution
- Decision stop rule, applicable: readiness rows must fail closed until artifact provenance fields are present
- Parent issue, claim map, registry, context note, synthesis surface update: #4207 PR body only, no issue comment authorized
- New research/benchmark/metric/paper-facing analysis tool, any: NA - additive support contract, no result interpretation

## Domain-Aware Approval

- Required PR: yes - benchmark-support contract affects evidence-validity gating for #4207
- Required for PR: yes - benchmark-support contract affects evidence-validity gating for #4207
- Status: waived
- Domains reviewed: benchmark certification-transfer report contract, trained-planner claim exclusion policy
- Approval or blocker note: waived because additive support contract only, no empirical claim promoted in this PR
- Approver/review source waiver: pending reviewer; domain-aware approval concerns experimental validity and is pending
- Validity checklist: additive readiness metadata, no gate semantic change
- Target claim/hypothesis: no trained-planner comparison claim
- Comparator or split/evidence validity: current baseline is missing only exclusion counts; changed contract adds per-arm readiness blockers. No empirical rerun here.
- Fallback/degraded exclusions: fallback and missing artifact states remain excluded
- Claim boundary: diagnostic-only, no deployment/paper claim
- Implementation integrity vs experimental validity: implementation contract only

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, tests exercise blocked and ready readiness rows
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? NA, no rerun
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: attach real trained-arm artifacts and rerun CPU probe

## Next Empirical Action

- Rerun needed: yes, after checkpoint/config/manifest provenance exists
- Extractor analysis tool needed: no
- Artifact missing unavailable: trained learned/predictive checkpoints and training manifests for issue #4207 arms
- Stop / revise / continue decision: continue after artifacts are available
- Proposed child issue existing follow-up: #4207 remaining blocker

## Risks / Rollout

- Compatibility risks: consumers assuming a fixed summary/metadata field set should tolerate additive fields
- Failure modes: future configs may provide algo config without checkpoint/manifest; readiness stays blocked
- Rollback fallback plan: remove additive readiness field and tests if downstream tooling cannot accept additive JSON keys

## Docs / Provenance

- Updated docs: generated README writer now includes readiness counts for future packets
- Relevant design provenance notes: issue #4207 comments after #4412/#4433
- Any assumptions need to preserved: `algo_config`, `checkpoint`, and `training_manifest` are the minimum artifact provenance for trained-planner comparison readiness

## Follow-Up Issues

- Deferred work: real checkpoint-backed CPU certification-transfer rerun tracked by #4207
- Issues opened follow-up: none; existing follow-up is #4207

## Reviewer Notes

- Verify closely that this does not reinterpret retained issue #4207 evidence packets as trained-planner evidence.
- Known limitation: this PR does not locate or attach trained checkpoints.

</details>
