### PR TITLE
Issue #3574: add per-step clearance_m metric to pedestrian control traces (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -1772,6 +1772,9 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
             ped_positions=ped_pos_arr,
             ped_forces=ped_forces_arr if record_forces else None,
             dt=float(config.sim_config.time_per_step_in_secs),
+            robot_positions=robot_pos_arr,
+            robot_radius=float(getattr(robot_config, "radius", 1.0)),
+            ped_radius=float(getattr(config.sim_config, "ped_radius", 0.4)),
         )
     tracking_precision_summary: dict[str, Any] = {
         "spec": tracking_precision_spec,

--- a/robot_sf/benchmark/pedestrian_control_trace.py
+++ b/robot_sf/benchmark/pedestrian_control_trace.py
@@ -40,6 +40,9 @@ def attach_pedestrian_control_trace(
     ped_positions: np.ndarray,
     ped_forces: np.ndarray | None,
     dt: float,
+    robot_positions: np.ndarray | None = None,
+    robot_radius: float = 0.0,
+    ped_radius: float = 0.0,
 ) -> None:
     """Attach a control trace to episode metadata when archetype labels are available.
 
@@ -51,6 +54,9 @@ def attach_pedestrian_control_trace(
         ped_positions: Simulator pedestrian positions shaped `(steps, pedestrians, 2)`.
         ped_forces: Optional simulator pedestrian force vectors with the same shape.
         dt: Episode time step in seconds.
+        robot_positions: Optional simulator robot positions shaped `(steps, 2)`.
+        robot_radius: Optional simulator robot footprint radius.
+        ped_radius: Optional simulator pedestrian footprint radius.
     """
 
     if not has_pedestrian_control_trace_metadata(scenario):
@@ -60,7 +66,108 @@ def attach_pedestrian_control_trace(
         ped_positions=ped_positions,
         ped_forces=ped_forces,
         dt=dt,
+        robot_positions=robot_positions,
+        robot_radius=robot_radius,
+        ped_radius=ped_radius,
     )
+
+
+def _validate_robot_parameters(
+    robot_positions: np.ndarray | None,
+    robot_radius: float,
+    ped_radius: float,
+    positions: np.ndarray,
+) -> tuple[np.ndarray | None, float, float]:
+    """Validate robot parameters.
+
+    Returns:
+        tuple[np.ndarray | None, float, float]: Resolved position, robot_radius, and ped_radius.
+    """
+    if robot_positions is None:
+        return None, 0.0, 0.0
+    robot_pos = require_finite_array("pedestrian_control_trace.robot_positions", robot_positions)
+    if robot_pos.ndim != 2 or robot_pos.shape[1] != 2:
+        raise ValueError(
+            "pedestrian_control_trace.robot_positions must have shape (steps, 2)"
+        )
+    if robot_pos.shape[0] != positions.shape[0]:
+        raise ValueError(
+            "pedestrian_control_trace.robot_positions step count must match ped_positions"
+        )
+    robot_rad = require_finite_scalar("pedestrian_control_trace.robot_radius", robot_radius)
+    if robot_rad < 0.0:
+        raise ValueError("robot_radius must be non-negative")
+    ped_rad = require_finite_scalar("pedestrian_control_trace.ped_radius", ped_radius)
+    if ped_rad < 0.0:
+        raise ValueError("ped_radius must be non-negative")
+    return robot_pos, robot_rad, ped_rad
+
+
+def _build_pedestrian_steps(
+    *,
+    positions: np.ndarray,
+    forces: np.ndarray | None,
+    robot_pos: np.ndarray | None,
+    robot_rad: float,
+    ped_rad: float,
+    dt_value: float,
+    simulator_index: int,
+) -> list[dict[str, Any]]:
+    """Build per-step payloads for a single pedestrian.
+
+    Returns:
+        list[dict[str, Any]]: Per-step payloads for the pedestrian.
+    """
+    step_count = int(positions.shape[0])
+    pedestrian_steps: list[dict[str, Any]] = []
+    previous_position: np.ndarray | None = None
+    for step in range(step_count):
+        position = positions[step]
+        velocity = (
+            (position - previous_position) / dt_value
+            if previous_position is not None
+            else np.zeros(2, dtype=float)
+        )
+        speed = float(np.linalg.norm(velocity))
+        require_finite_scalar(
+            f"pedestrian_control_trace.pedestrians[{simulator_index}].steps[{step}].speed_m_s",
+            speed,
+        )
+        payload: dict[str, Any] = {
+            "step": step,
+            "x_m": float(position[0]),
+            "y_m": float(position[1]),
+            "vx_m_s": float(velocity[0]),
+            "vy_m_s": float(velocity[1]),
+            "speed_m_s": speed,
+        }
+        if robot_pos is not None:
+            r_pos = robot_pos[step]
+            dist = float(np.linalg.norm(position - r_pos))
+            clearance = dist - (robot_rad + ped_rad)
+            require_finite_scalar(
+                f"pedestrian_control_trace.pedestrians[{simulator_index}].steps[{step}].clearance_m",
+                clearance,
+            )
+            payload["clearance_m"] = clearance
+        if forces is not None:
+            force = forces[step]
+            force_norm = float(np.linalg.norm(force))
+            require_finite_scalar(
+                "pedestrian_control_trace."
+                f"pedestrians[{simulator_index}].steps[{step}].force_norm",
+                force_norm,
+            )
+            payload.update(
+                {
+                    "force_x": float(force[0]),
+                    "force_y": float(force[1]),
+                    "force_norm": force_norm,
+                }
+            )
+        pedestrian_steps.append(payload)
+        previous_position = np.array(position, dtype=float, copy=True)
+    return pedestrian_steps
 
 
 def build_pedestrian_control_trace(
@@ -69,6 +176,9 @@ def build_pedestrian_control_trace(
     ped_positions: np.ndarray,
     ped_forces: np.ndarray | None,
     dt: float,
+    robot_positions: np.ndarray | None = None,
+    robot_radius: float = 0.0,
+    ped_radius: float = 0.0,
 ) -> dict[str, Any]:
     """Build a finite, per-pedestrian control trace grouped by simulator pedestrian index.
 
@@ -95,6 +205,10 @@ def build_pedestrian_control_trace(
         if forces.shape != positions.shape:
             raise ValueError("pedestrian_control_trace.ped_forces must match ped_positions shape")
 
+    robot_pos, robot_rad, ped_rad = _validate_robot_parameters(
+        robot_positions, robot_radius, ped_radius, positions
+    )
+
     step_count = int(positions.shape[0])
     pedestrian_count = int(positions.shape[1])
     metadata = _aligned_pedestrian_metadata(scenario, pedestrian_count)
@@ -106,45 +220,15 @@ def build_pedestrian_control_trace(
                 "pedestrian_control_trace requires archetype metadata for "
                 f"simulator pedestrian {simulator_index}"
             )
-        pedestrian_steps: list[dict[str, Any]] = []
-        previous_position: np.ndarray | None = None
-        for step in range(step_count):
-            position = positions[step, simulator_index]
-            velocity = (
-                (position - previous_position) / dt_value
-                if previous_position is not None
-                else np.zeros(2, dtype=float)
-            )
-            speed = float(np.linalg.norm(velocity))
-            require_finite_scalar(
-                f"pedestrian_control_trace.pedestrians[{simulator_index}].steps[{step}].speed_m_s",
-                speed,
-            )
-            payload: dict[str, Any] = {
-                "step": step,
-                "x_m": float(position[0]),
-                "y_m": float(position[1]),
-                "vx_m_s": float(velocity[0]),
-                "vy_m_s": float(velocity[1]),
-                "speed_m_s": speed,
-            }
-            if forces is not None:
-                force = forces[step, simulator_index]
-                force_norm = float(np.linalg.norm(force))
-                require_finite_scalar(
-                    "pedestrian_control_trace."
-                    f"pedestrians[{simulator_index}].steps[{step}].force_norm",
-                    force_norm,
-                )
-                payload.update(
-                    {
-                        "force_x": float(force[0]),
-                        "force_y": float(force[1]),
-                        "force_norm": force_norm,
-                    }
-                )
-            pedestrian_steps.append(payload)
-            previous_position = np.array(position, dtype=float, copy=True)
+        pedestrian_steps = _build_pedestrian_steps(
+            positions=positions[:, simulator_index],
+            forces=forces[:, simulator_index] if forces is not None else None,
+            robot_pos=robot_pos,
+            robot_rad=robot_rad,
+            ped_rad=ped_rad,
+            dt_value=dt_value,
+            simulator_index=simulator_index,
+        )
 
         pedestrian_payload: dict[str, Any] = {
             "id": str(pedestrian_metadata.get("id") or f"pedestrian_{simulator_index}"),

--- a/robot_sf/benchmark/pedestrian_control_trace.py
+++ b/robot_sf/benchmark/pedestrian_control_trace.py
@@ -87,9 +87,7 @@ def _validate_robot_parameters(
         return None, 0.0, 0.0
     robot_pos = require_finite_array("pedestrian_control_trace.robot_positions", robot_positions)
     if robot_pos.ndim != 2 or robot_pos.shape[1] != 2:
-        raise ValueError(
-            "pedestrian_control_trace.robot_positions must have shape (steps, 2)"
-        )
+        raise ValueError("pedestrian_control_trace.robot_positions must have shape (steps, 2)")
     if robot_pos.shape[0] != positions.shape[0]:
         raise ValueError(
             "pedestrian_control_trace.robot_positions step count must match ped_positions"
@@ -154,8 +152,7 @@ def _build_pedestrian_steps(
             force = forces[step]
             force_norm = float(np.linalg.norm(force))
             require_finite_scalar(
-                "pedestrian_control_trace."
-                f"pedestrians[{simulator_index}].steps[{step}].force_norm",
+                f"pedestrian_control_trace.pedestrians[{simulator_index}].steps[{step}].force_norm",
                 force_norm,
             )
             payload.update(

--- a/tests/benchmark/test_pedestrian_control_trace.py
+++ b/tests/benchmark/test_pedestrian_control_trace.py
@@ -106,8 +106,14 @@ def test_build_pedestrian_control_trace_computes_clearance() -> None:
     [
         ({"robot_positions": np.zeros((1, 2), dtype=float)}, "step count must match"),
         ({"robot_positions": np.zeros((2, 3), dtype=float)}, "must have shape"),
-        ({"robot_positions": np.zeros((2, 2), dtype=float), "robot_radius": -0.1}, "must be non-negative"),
-        ({"robot_positions": np.zeros((2, 2), dtype=float), "ped_radius": -0.1}, "must be non-negative"),
+        (
+            {"robot_positions": np.zeros((2, 2), dtype=float), "robot_radius": -0.1},
+            "must be non-negative",
+        ),
+        (
+            {"robot_positions": np.zeros((2, 2), dtype=float), "ped_radius": -0.1},
+            "must be non-negative",
+        ),
     ],
 )
 def test_build_pedestrian_control_trace_rejects_invalid_robot_params(

--- a/tests/benchmark/test_pedestrian_control_trace.py
+++ b/tests/benchmark/test_pedestrian_control_trace.py
@@ -66,6 +66,69 @@ def test_build_pedestrian_control_trace_records_archetype_controls() -> None:
     assert hurried["steps"][1]["speed_m_s"] == pytest.approx(2.0)
 
 
+def test_build_pedestrian_control_trace_computes_clearance() -> None:
+    """Recorder computes per-step clearance_m when robot positions are supplied."""
+
+    positions = np.array(
+        [
+            [[0.0, 0.0], [2.0, 0.0]],
+            [[0.0, 1.0], [2.0, 3.0]],
+        ],
+        dtype=float,
+    )
+    robot_positions = np.array(
+        [
+            [1.0, 0.0],
+            [1.0, 1.0],
+        ],
+        dtype=float,
+    )
+
+    trace = build_pedestrian_control_trace(
+        scenario=_scenario(),
+        ped_positions=positions,
+        ped_forces=None,
+        dt=0.1,
+        robot_positions=robot_positions,
+        robot_radius=0.3,
+        ped_radius=0.2,
+    )
+
+    cautious, hurried = trace["pedestrians"]
+    assert cautious["steps"][0]["clearance_m"] == pytest.approx(0.5)
+    assert cautious["steps"][1]["clearance_m"] == pytest.approx(0.5)
+    assert hurried["steps"][0]["clearance_m"] == pytest.approx(0.5)
+    assert hurried["steps"][1]["clearance_m"] == pytest.approx(math.sqrt(5) - 0.5)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"robot_positions": np.zeros((1, 2), dtype=float)}, "step count must match"),
+        ({"robot_positions": np.zeros((2, 3), dtype=float)}, "must have shape"),
+        ({"robot_positions": np.zeros((2, 2), dtype=float), "robot_radius": -0.1}, "must be non-negative"),
+        ({"robot_positions": np.zeros((2, 2), dtype=float), "ped_radius": -0.1}, "must be non-negative"),
+    ],
+)
+def test_build_pedestrian_control_trace_rejects_invalid_robot_params(
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    """Invalid robot positions or radii raise ValueError."""
+
+    positions = np.zeros((2, 2, 2), dtype=float)
+    params = {
+        "scenario": _scenario(),
+        "ped_positions": positions,
+        "ped_forces": None,
+        "dt": 0.1,
+    }
+    params.update(kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        build_pedestrian_control_trace(**params)
+
+
 def test_has_pedestrian_control_trace_metadata_detects_archetypes() -> None:
     """Episode integration should only attach the trace for explicitly labeled pedestrians."""
 


### PR DESCRIPTION
### What/Why
This PR implements the next slice of issue #3574 by adding actual per-step `clearance_m` metric fields to the `pedestrian_control_trace` step metadata.
Previously, the manifest remained `blocked_pending_control_trace` due to the lack of this field. We added `robot_positions`, `robot_radius`, and `ped_radius` to the trace logging interface, passed them in from the map runner context, and updated the trace builder to compute and log the Euclidean distance between each pedestrian and the robot at each step (minus their footprints' radii).

### Successor Statement
successor slice: per-step clearance_m metric logging in pedestrian control traces; does not duplicate PR #4399 or PR #4438

### Validation Output
`pytest` results (75 targeted tests passed):
```
============================= test session starts ==============================
platform linux -- Python 3.13.14, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-3574-20260704T190238Z
configfile: pyproject.toml
plugins: xdist-3.8.0, cov-7.0.0, split-0.11.0, anyio-4.12.1
collecting ... collecting 33 items                                                            collected 75 items                                                             

tests/benchmark/test_pedestrian_control_trace.py ....................... [ 30%]
..........                                                               [ 44%]
tests/benchmark/test_heterogeneous_population_metrics.py ............... [ 64%]
............                                                             [ 80%]
tests/benchmark/test_heterogeneous_population_ablation.py .............. [ 98%]
.                                                                        [100%]

============================== 75 passed in 2.71s ==============================
```

`ruff check` results:
```
All checks passed!
```

This PR was produced by the agy/Gemini-3.5-Flash cheap implementation lane; the review gate hardens and merges.
