### PR TITLE
Issue #3637: add campaign runner study-issue and evidence-tier CLI metadata overrides (cheap-lane worker)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,6 +361,7 @@ max-statements = 60
 "scripts/benchmark/run_forecast_risk_coupling_gate.py" = ["BLE001"]
 "scripts/benchmark/run_observation_noise_envelope.py" = ["BLE001"]
 "scripts/benchmark/run_observation_noise_live_replay_issue_2777.py" = ["BLE001"]
+"scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py" = ["PLR0913"]
 "scripts/benchmark_ped_policy_collisions.py" = ["BLE001"]
 "scripts/benchmark_repro_check.py" = ["BLE001"]
 "scripts/classic_benchmark_full.py" = ["BLE001"]

--- a/scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py
+++ b/scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py
@@ -188,6 +188,8 @@ def run_campaign(
     horizon: int,
     dt: float,
     workers: int,
+    study_issue: int = ISSUE,
+    evidence_tier: str = "diagnostic",
 ) -> dict[str, Any]:
     """Run the paired reactive-vs-replay ablation across planners and assemble the report.
 
@@ -214,11 +216,12 @@ def run_campaign(
         contrasts.append(build_contrast(planner, reactive, replay))
 
     assessment = assess_reactivity_ablation(contrasts) if contrasts else None
-    return {
+    report: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "quantifier_schema": REACTIVITY_ABLATION_SCHEMA,
-        "issue": ISSUE,
-        "evidence_tier": "diagnostic",
+        "issue": study_issue,
+        "source_mechanism_issue": ISSUE,
+        "evidence_tier": evidence_tier,
         "claim_boundary": (
             "Real-runner reactive-vs-replay result on a bounded family at small N. 'Replay' = "
             "robot->ped force disabled in a live social-force sim (not pre-recorded playback); the "
@@ -235,6 +238,7 @@ def run_campaign(
         "per_planner": per_planner,
         "assessment": assessment,
     }
+    return report
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -250,6 +254,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--dt", type=float, default=0.1)
     parser.add_argument("--workers", type=int, default=4)
     parser.add_argument("--report-json", type=Path, default=None)
+    parser.add_argument(
+        "--study-issue",
+        type=int,
+        default=ISSUE,
+        help="issue number for report (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--evidence-tier",
+        type=str,
+        default="diagnostic",
+        help="evidence tier label for report (default: %(default)s)",
+    )
     return parser.parse_args(argv)
 
 
@@ -264,6 +280,8 @@ def main(argv: list[str] | None = None) -> int:
         horizon=args.horizon,
         dt=args.dt,
         workers=args.workers,
+        study_issue=args.study_issue,
+        evidence_tier=args.evidence_tier,
     )
     report["generated_at_utc"] = datetime.now(UTC).isoformat()
     print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/benchmark/test_run_reactivity_ablation_campaign_issue_3573.py
+++ b/tests/benchmark/test_run_reactivity_ablation_campaign_issue_3573.py
@@ -83,6 +83,7 @@ def test_campaign_runs_real_runner_and_feeds_quantifier(tmp_path: Path) -> None:
     )
 
     assert report["issue"] == 3573
+    assert report["source_mechanism_issue"] == 3573
     assert report["evidence_tier"] == "diagnostic"
     assert "goal" in report["per_planner"]
     for condition in ("reactive", "replay"):
@@ -90,3 +91,22 @@ def test_campaign_runs_real_runner_and_feeds_quantifier(tmp_path: Path) -> None:
         assert {"collision_rate", "near_miss_rate", "min_separation_m"} <= set(block)
     assert report["assessment"]["schema_version"] == REACTIVITY_ABLATION_SCHEMA
     assert report["assessment"]["n_planners"] == 1
+
+
+def test_campaign_study_issue_and_evidence_tier_override(tmp_path: Path) -> None:
+    """CLI metadata flags override the default issue number and evidence tier."""
+    report = run_campaign(
+        Path("configs/scenarios/sets/classic_crossing_subset.yaml"),
+        seeds=[101],
+        planners=("goal",),
+        out_dir=tmp_path,
+        horizon=60,
+        dt=0.1,
+        workers=1,
+        study_issue=3637,
+        evidence_tier="seed_sufficient_candidate",
+    )
+
+    assert report["issue"] == 3637
+    assert report["source_mechanism_issue"] == 3573
+    assert report["evidence_tier"] == "seed_sufficient_candidate"


### PR DESCRIPTION
## What

Adds optional `--study-issue` and `--evidence-tier` CLI flags to the `#3573` campaign runner
(`scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py`) so `#3637` campaign reports
can carry the correct study issue number and evidence tier without breaking the `#3573` diagnostic
default.

## Why

Issue #3637 Phase 3 calls for optional CLI metadata to reduce report ambiguity in the existing
campaign runner. Currently `ISSUE=3573` and `evidence_tier="diagnostic"` are hard-coded. When the
`#3637` paper-grade campaign is run, the report should identify itself as `#3637` with tier
`seed_sufficient_candidate` while preserving the `#3573` source mechanism lineage.

## Changes

- `run_campaign` accepts `study_issue` (default `ISSUE=3573`) and `evidence_tier` (default
  `"diagnostic"`) keyword arguments
- Report now includes `source_mechanism_issue=3573` for lineage tracking
- CLI adds `--study-issue` and `--evidence-tier` flags
- `pyproject.toml` per-file ruff override for PLR0913 on the runner (9 vs 8 max-args)
- New test verifies the override path: `study_issue=3637`, `evidence_tier="seed_sufficient_candidate"`,
  `source_mechanism_issue` stays 3573

## Validation

```
uv run pytest tests/benchmark/test_run_reactivity_ablation_campaign_issue_3573.py -q
uv run pytest tests/benchmark/test_reactivity_replay_preflight_issue_3637.py tests/benchmark/test_analyze_reactivity_replay_rank_study_issue_3637.py tests/tools/test_seed_sufficiency_gate.py -q
uv run ruff check scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py tests/benchmark/test_run_reactivity_ablation_campaign_issue_3573.py
uv run ruff format --check scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py tests/benchmark/test_run_reactivity_ablation_campaign_issue_3573.py
```

All 56 related tests pass. Ruff check and format pass.

## Successor slice

This is a successor slice to PR #4462 (post-run analyzer). This PR does not duplicate that work.
PR #4462 added the analysis script; this PR adds the CLI metadata overrides so the campaign runner
can tag reports for `#3637`.

## Claim boundary

This PR makes no benchmark, paper, dissertation, or rank-effect claim. It only adds optional
metadata flags to the existing campaign runner.

## Remaining blocker

The actual >=3-planner, 20-seed reactivity-vs-replay campaign still needs to be run before any
evidence note or paper-grade claim decision can be made. This PR does not run the campaign.

This PR was produced by the Command-Code/MiMo-V2.5-Pro cheap implementation lane; the review gate hardens and merges.