### PR TITLE
Issue #4183: add paired diagnostic runner

### DIFF
--- a/scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py
+++ b/scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Run and rebuild the issue #4183 hybrid_global_rl diagnostic packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.hybrid_global_rl_diagnostic import (
+    BASELINE_ARM,
+    ROUTE_ARM,
+    build_diagnostic_report,
+    load_jsonl_records,
+    preflight_configs,
+)
+from robot_sf.benchmark.map_runner import run_map_batch
+
+DEFAULT_ROUTE_CONFIG = Path("configs/benchmarks/issue_4183_hybrid_global_rl_route_conditioned.yaml")
+DEFAULT_BASELINE_CONFIG = Path("configs/benchmarks/issue_4183_learned_local_unconditioned.yaml")
+DEFAULT_SCHEMA = Path("docs/dev/issues/social-navigation-benchmark/episode_schema.json")
+DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_4183_hybrid_global_rl_diagnostic")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--route-config", type=Path, default=DEFAULT_ROUTE_CONFIG)
+    parser.add_argument("--baseline-config", type=Path, default=DEFAULT_BASELINE_CONFIG)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--work-dir", type=Path, default=Path("output/issue_4183_hybrid_global_rl_run")
+    )
+    parser.add_argument("--horizon", type=int, help="Optional smoke horizon override.")
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    return parser.parse_args(argv)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a mapping.")
+    return payload
+
+
+def _fixed_list_seeds(config_payload: dict[str, Any], *, path: Path) -> list[int]:
+    seed_policy = config_payload.get("seed_policy") or {}
+    if not isinstance(seed_policy, dict) or seed_policy.get("mode") != "fixed-list":
+        raise ValueError(f"{path} must declare seed_policy.mode=fixed-list.")
+    seeds = seed_policy.get("seeds") or []
+    if not isinstance(seeds, list) or not seeds:
+        raise ValueError(f"{path} must declare a non-empty fixed seed list.")
+    return [int(seed) for seed in seeds]
+
+
+def _scenario_payload_with_config_seeds(
+    config_payload: dict[str, Any], *, path: Path
+) -> list[dict[str, Any]]:
+    scenario_matrix = Path(str(config_payload["scenario_matrix"]))
+    matrix_payload = _load_yaml(scenario_matrix)
+    scenarios = matrix_payload.get("scenarios")
+    if not isinstance(scenarios, list) or not scenarios:
+        raise ValueError(f"{scenario_matrix} must declare a non-empty scenarios list.")
+    seeds = _fixed_list_seeds(config_payload, path=path)
+    resolved: list[dict[str, Any]] = []
+    for scenario in scenarios:
+        if not isinstance(scenario, dict):
+            raise ValueError(f"{scenario_matrix} contains a non-mapping scenario entry.")
+        scenario_copy = dict(scenario)
+        scenario_copy["seeds"] = list(seeds)
+        resolved.append(scenario_copy)
+    return resolved
+
+
+def _planner_spec(config_payload: dict[str, Any], *, path: Path) -> dict[str, Any]:
+    planners = config_payload.get("planners")
+    if not isinstance(planners, list) or len(planners) != 1 or not isinstance(planners[0], dict):
+        raise ValueError(f"{path} must declare exactly one planner mapping.")
+    return planners[0]
+
+
+def _write_algo_config(planner: dict[str, Any], *, directory: Path, stem: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{stem}_algo.yaml"
+    path.write_text(yaml.safe_dump(planner.get("config") or {}, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _failure_rows(summary: dict[str, Any], *, arm: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for failure in summary.get("failures", []):
+        if not isinstance(failure, dict):
+            continue
+        rows.append(
+            {
+                "arm": arm,
+                "scenario_id": failure.get("scenario_id"),
+                "seed": failure.get("seed"),
+                "reason": failure.get("error"),
+                "row_classification": "fail_closed_no_episode_row",
+                "source": "issue_4183_paired_runner",
+            }
+        )
+    return rows
+
+
+def _run_arm(
+    *,
+    config_path: Path,
+    arm: str,
+    work_dir: Path,
+    schema_path: Path,
+    horizon_override: int | None,
+) -> tuple[Path, dict[str, Any], list[dict[str, Any]]]:
+    config_payload = _load_yaml(config_path)
+    planner = _planner_spec(config_payload, path=config_path)
+    scenarios = _scenario_payload_with_config_seeds(config_payload, path=config_path)
+    arm_work_dir = work_dir / arm
+    algo_config_path = _write_algo_config(planner, directory=arm_work_dir, stem=config_path.stem)
+    episodes_path = arm_work_dir / "episodes.jsonl"
+    episodes_path.unlink(missing_ok=True)
+    horizon = horizon_override if horizon_override is not None else int(config_payload["horizon"])
+    summary = run_map_batch(
+        scenarios,
+        episodes_path,
+        schema_path,
+        scenario_path=config_payload["scenario_matrix"],
+        horizon=horizon,
+        dt=float(config_payload["dt"]),
+        record_forces=bool(config_payload.get("record_forces", True)),
+        algo=str(planner["algo"]),
+        algo_config_path=str(algo_config_path),
+        benchmark_profile=str(planner.get("benchmark_profile", "diagnostic-only")),
+        workers=int(config_payload.get("workers", 1)),
+        resume=False,
+    )
+    return episodes_path, summary, _failure_rows(summary, arm=arm)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run both issue #4183 arms and rebuild the diagnostic packet."""
+    args = parse_args(argv)
+    preflight = preflight_configs(args.route_config, args.baseline_config, repo_root=args.repo_root)
+    if preflight["status"] != "valid":
+        print(json.dumps({"preflight": preflight}, indent=2, sort_keys=True))
+        return 2
+
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="issue_4183_", dir=args.work_dir) as tmp:
+        run_dir = Path(tmp)
+        route_episodes, route_summary, route_failures = _run_arm(
+            config_path=args.route_config,
+            arm=ROUTE_ARM,
+            work_dir=run_dir,
+            schema_path=args.schema,
+            horizon_override=args.horizon,
+        )
+        baseline_episodes, baseline_summary, baseline_failures = _run_arm(
+            config_path=args.baseline_config,
+            arm=BASELINE_ARM,
+            work_dir=run_dir,
+            schema_path=args.schema,
+            horizon_override=args.horizon,
+        )
+        summary = build_diagnostic_report(
+            route_records=load_jsonl_records(route_episodes),
+            baseline_records=load_jsonl_records(baseline_episodes),
+            route_config_path=args.route_config,
+            baseline_config_path=args.baseline_config,
+            output_dir=args.output_dir,
+            run_failures=[*route_failures, *baseline_failures],
+        )
+    print(
+        json.dumps(
+            {
+                "route_run": route_summary,
+                "baseline_run": baseline_summary,
+                "diagnostic_summary": summary,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if summary["included_diagnostic_rows"] > 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_issue_4183_paired_runner.py
+++ b/tests/benchmark/test_issue_4183_paired_runner.py
@@ -1,0 +1,103 @@
+"""Tests for the issue #4183 paired diagnostic runner."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.hybrid_global_rl_diagnostic import ROUTE_ARM
+
+
+def _load_issue_4183_runner():
+    script_path = Path("scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py")
+    spec = importlib.util.spec_from_file_location("issue_4183_runner", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_issue_4183_runner_honors_config_seed_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The paired runner overrides scenario-matrix seeds with benchmark-config seeds."""
+    scenario_matrix = tmp_path / "scenarios.yaml"
+    scenario_matrix.write_text(
+        yaml.safe_dump(
+            {
+                "scenarios": [
+                    {
+                        "name": "francis2023_intersection_wait",
+                        "seeds": [240],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "arm.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "scenario_matrix": str(scenario_matrix),
+                "seed_policy": {"mode": "fixed-list", "seeds": [4183, 4184]},
+                "horizon": 120,
+                "dt": 0.1,
+                "record_forces": True,
+                "workers": 1,
+                "planners": [
+                    {
+                        "algo": "hybrid_global_rl",
+                        "benchmark_profile": "diagnostic-only",
+                        "config": {"local_policy_algo": "ppo"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    captured: dict[str, object] = {}
+    issue_4183_runner = _load_issue_4183_runner()
+
+    def fake_run_map_batch(
+        scenarios_or_path: list[dict[str, object]],
+        out_path: Path,
+        *_args: object,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        captured["scenario_seeds"] = scenarios_or_path[0]["seeds"]
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text("", encoding="utf-8")
+        return {
+            "failures": [
+                {
+                    "error": "RuntimeError('hybrid_global_rl route waypoint unavailable')",
+                    "scenario_id": "francis2023_intersection_wait",
+                    "seed": 4183,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(issue_4183_runner, "run_map_batch", fake_run_map_batch)
+    _episodes_path, _summary, failures = issue_4183_runner._run_arm(
+        config_path=config_path,
+        arm=ROUTE_ARM,
+        work_dir=tmp_path / "run",
+        schema_path=tmp_path / "schema.json",
+        horizon_override=5,
+    )
+    assert captured["scenario_seeds"] == [4183, 4184]
+    assert failures == [
+        {
+            "arm": ROUTE_ARM,
+            "scenario_id": "francis2023_intersection_wait",
+            "seed": 4183,
+            "reason": "RuntimeError('hybrid_global_rl route waypoint unavailable')",
+            "row_classification": "fail_closed_no_episode_row",
+            "source": "issue_4183_paired_runner",
+        }
+    ]

--- a/tests/benchmark/test_issue_4183_paired_runner.py
+++ b/tests/benchmark/test_issue_4183_paired_runner.py
@@ -10,9 +10,11 @@ import yaml
 
 from robot_sf.benchmark.hybrid_global_rl_diagnostic import ROUTE_ARM
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
 
 def _load_issue_4183_runner():
-    script_path = Path("scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py")
+    script_path = _REPO_ROOT / "scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py"
     spec = importlib.util.spec_from_file_location("issue_4183_runner", script_path)
     assert spec is not None
     assert spec.loader is not None


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds `scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py`, a CPU paired-runner for the existing issue #4183 route/occupancy diagnostic configs. It loads both committed benchmark configs, enforces their fixed seed policy, writes per-arm algorithm configs under `output/`, runs both arms through `run_map_batch`, and rebuilds the existing diagnostic packet from emitted episode rows plus fail-closed runner failures.

Why now: the full issue audit found #4209 delivered the config/report contract and #4460 delivered the integration report, but the live issue remains open because the diagnostic still has zero valid paired episode rows. The missing smallest executable slice was a canonical runner that actually honors the issue benchmark configs instead of ad hoc reruns.

Claim boundary: diagnostic-tier runner capability. This PR does not claim route-conditioned improvement, benchmark success, paper/dissertation evidence, or completed empirical validation. The smoke run still exits nonzero by design because both arms fail closed and no native paired rows are produced.

Required validation: focused unit tests, Ruff, final PR readiness. The runner smoke was executed with `--horizon 10` to verify the real command path and confirmed config seeds `4183-4185` plus `run_status=blocked_no_valid_episode_rows`.

Remaining blocker: route-conditioned arm still fails closed with `RuntimeError('hybrid_global_rl route waypoint unavailable')`; unconditioned learned-local arm still fails closed with `RuntimeError('PPO model unavailable or prediction failed')`. Next empirical action is to resolve those runtime blockers so the same runner emits matched native episode rows.

## Contract delta

- New CLI: `scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py`.
- New behavior: scenario-matrix seeds are overridden by each benchmark config's `seed_policy.mode=fixed-list` seeds before calling `run_map_batch`.
- New fail-closed propagation: `run_map_batch` failures become diagnostic `run_failures` with `row_classification=fail_closed_no_episode_row` and source `issue_4183_paired_runner`.
- Compatibility impact: existing issue #4183 configs, packet schema, `paired_rows.csv`, and `summary.json` contracts are unchanged.


## Domain-Aware Approval

Required PR: yes.

Domains reviewed: hybrid_global_rl route/occupancy diagnostic runner; learned-policy checkpoint pairing; fallback/degraded exclusion policy.

Status: waived

Approver/review source waiver: PR-opening process waiver under task authorization; this is not domain approval for empirical claims. Claude Code on `imech156-u` owns full PR gate, improvement cycle, and merge authority after open.

Approval or blocker note: empirical domain approval remains blocked because the route-conditioned arm still fails closed with `RuntimeError('hybrid_global_rl route waypoint unavailable')` and the unconditioned learned-local arm still fails closed with `RuntimeError('PPO model unavailable or prediction failed')`.

Target claim/hypothesis: diagnostic-tier issue #4183 route/occupancy comparison runner.

Comparator or split/evidence validity: same scenario/config seed list and same learned checkpoint are enforced before execution.

Fallback/degraded exclusions: fail-closed runner failures are recorded as `fail_closed_no_episode_row`; fallback/degraded rows remain excluded from route-conditioned effect evidence.

Claim boundary: no benchmark-success claim; no paper/dissertation claim; no fallback row counted as success.

Implementation integrity vs experimental validity: runner implementation is validated; empirical comparison remains blocked by current runtime failures.

## Issue link

Closes none. Progresses #4183.

## Scope summary

This is the smallest remaining progression slice after auditing #4183, #4209, #4460, and the live issue comments. It makes the existing diagnostic comparison reproducible from one command and preserves the current empirical blocker without inventing new benchmark scope.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_4183_paired_runner.py tests/benchmark/test_hybrid_global_rl_diagnostic_issue_4183.py -q` -> passed, 8 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py tests/benchmark/test_issue_4183_paired_runner.py tests/benchmark/test_hybrid_global_rl_diagnostic_issue_4183.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py --horizon 10 --work-dir output/issue_4183_runner_smoke/work --output-dir output/issue_4183_runner_smoke/evidence` -> expected exit 1; verified runner uses seeds `4183`, `4184`, `4185` and reports `run_status=blocked_no_valid_episode_rows` with the two known fail-closed blockers.
- `PR_READY_PR_BODY_FILE=output/issue_4183_pr/pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; freshness stamp `output/validation/pr_ready/issue-4183-closure-audit-verify-acceptance-criteria-of-4183-against-merged-prs-clos.json`.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no fallback/degraded rows treated as successful evidence, and no tracked transient queue-routing state.

## Downstream propagation

No issue comment was posted because `comment_issue_or_pr=false` for this task. The PR body is the propagation surface for this low-churn issue; it lists the delivered runner slice and the remaining checklist:

- [x] Durable paired runner exists for the committed issue #4183 configs.
- [x] Runner enforces fixed-list seeds from the configs.
- [x] Runner propagates fail-closed failures into the diagnostic report builder.
- [ ] Route-conditioned arm emits native episode rows.
- [ ] Unconditioned learned-local arm emits native episode rows.
- [ ] Same-seed paired diagnostic rows are included in the packet.

<details>
<summary>Audit appendix</summary>

Acceptance evidence before this PR:

| Criterion | Evidence |
| --- | --- |
| Representative route/occupancy scenario config recorded durably | #4209 added `configs/benchmarks/issue_4183_hybrid_global_rl_route_conditioned.yaml` and `configs/benchmarks/issue_4183_learned_local_unconditioned.yaml`. |
| Both arms use same underlying learned policy/checkpoint where applicable | #4209 configs point both arms at `model/ppo_model_retrained_10m_2025-02-01.zip`. |
| Same-seed paired comparison emitted explicit inclusion/exclusion rules | #4209 added the report builder and packet schema; this PR adds the paired runner that enforces the config seed list before execution. |
| Adapter diagnostics record route conditioning/fail-closed/fallback state | #4209 report builder copies adapter diagnostics and excludes fallback/degraded rows. |
| Result linked back to #4161 and #4015 | #4209/#4460 packet README and summary link the parent work. |
| Empirical diagnostic completed with valid native paired rows | Not met. #4460 and the live issue comment at 2026-07-04T15:24:08Z state zero valid paired rows remain blocked. |

Late-guidance check: immediately before PR creation, the issue had no comments newer than the 2026-07-04T15:24:08Z gate-propagation comment.

Fragmentation guard: one #4183 PR (#4460) merged in the last 24h; this is a progression slice with the nameable new paired-runner capability, not another report-only micro-guard.

</details>
