### PR TITLE
Issue #4207: certification-transfer preflight + --validate-only mode (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/certification_transfer.py
+++ b/robot_sf/benchmark/certification_transfer.py
@@ -41,6 +41,24 @@ DEFAULT_PEDESTRIAN_MODELS = (SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1)
 # #4166-style gate spec.
 INTERACTION_NEAR_FIELD_M = 5.0
 INTERACTION_STATUSES = ("interacting", "non_interacting", "unknown")
+# Metric keys the runner can aggregate per gate cell (see ``_aggregate_metrics``). A release gate
+# whose ``metric`` is not in this set can never resolve to ``pass``/``fail``: every cell would be
+# ``not_evaluable``, the vacuously-inconclusive trap the issue #4207 preflight forbids.
+# ``preflight_gate_evaluability`` uses this set to fail closed with
+# ``blocked_no_evaluable_gate_family`` before any simulation runs.
+AGGREGATABLE_METRICS = frozenset(
+    {
+        "collision_rate",
+        "success_rate",
+        "near_miss_rate",
+        "min_clearance_m",
+        "proxemic_intrusion_rate",
+        "robot_ped_within_5m_frac",
+        "jerk_mean",
+    }
+)
+PREFLIGHT_OK = "ok"
+PREFLIGHT_BLOCKED_NO_EVALUABLE_GATE_FAMILY = "blocked_no_evaluable_gate_family"
 TRAINED_PLANNER_STRUCTURAL_CLASSES = frozenset({"learned_policy", "predictive"})
 TRAINED_PLANNER_ALGOS = frozenset({"ppo", "guarded_ppo", "prediction_planner"})
 TRAINED_PLANNER_ELIGIBLE = "eligible"
@@ -205,6 +223,56 @@ def validate_gate_spec(gate_spec: Mapping[str, Any], *, scenario_family: str) ->
         "schema_version": GATE_SPEC_SCHEMA_VERSION,
         "description": str(gate_spec.get("description", "")),
         "gates": normalized_gates,
+    }
+
+
+def preflight_gate_evaluability(
+    probe_config: Mapping[str, Any],
+    gate_spec: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Preflight-check that the declared scenario family has evaluable required gate metrics.
+
+    The certification-transfer probe declares a single, hard-coded scenario family (it is not
+    discovered dynamically at run time). A required release gate whose ``metric`` is not one the
+    runner can aggregate (:data:`AGGREGATABLE_METRICS`) can never produce a ``pass``/``fail``
+    decision: every cell would be ``not_evaluable``, the vacuously-inconclusive trap the issue
+    #4207 plan forbids. Such a family is not evaluable; preflight fails closed with
+    :data:`PREFLIGHT_BLOCKED_NO_EVALUABLE_GATE_FAMILY` instead of running a moot probe.
+
+    Optional gates (``required: false``) with non-aggregatable metrics do not block: they surface
+    as ``not_evaluable`` at evaluation time but do not drive the pass/fail decision.
+
+    Args:
+        probe_config: Normalized probe config (from :func:`validate_probe_config`).
+        gate_spec: Normalized gate spec (from :func:`validate_gate_spec`).
+
+    Returns:
+        Preflight payload with ``status`` (``ok`` or ``blocked_no_evaluable_gate_family``), the
+        declared ``scenario_family``, the runner's ``aggregatable_metrics``, the required gate
+        metrics, and the blocking ``not_evaluable_gate_ids`` / ``not_evaluable_gate_metrics``
+        (empty when the family is evaluable).
+    """
+
+    scenario_family = str(probe_config["scenario_family"])
+    gates = list(gate_spec.get("gates") or [])
+    required_gates = [gate for gate in gates if bool(gate.get("required", True))]
+    required_metrics = sorted({str(gate["metric"]) for gate in required_gates})
+    blocking = [
+        {"gate_id": str(gate["id"]), "metric": str(gate["metric"])}
+        for gate in required_gates
+        if str(gate["metric"]) not in AGGREGATABLE_METRICS
+    ]
+    not_evaluable_gate_ids = sorted({entry["gate_id"] for entry in blocking})
+    not_evaluable_gate_metrics = sorted({entry["metric"] for entry in blocking})
+    blocked = bool(blocking)
+    return {
+        "status": PREFLIGHT_BLOCKED_NO_EVALUABLE_GATE_FAMILY if blocked else PREFLIGHT_OK,
+        "scenario_family": scenario_family,
+        "aggregatable_metrics": sorted(AGGREGATABLE_METRICS),
+        "required_gate_metrics": required_metrics,
+        "not_evaluable_gate_ids": not_evaluable_gate_ids,
+        "not_evaluable_gate_metrics": not_evaluable_gate_metrics,
+        "blocking_gates": blocking,
     }
 
 

--- a/scripts/benchmark/run_certification_transfer_issue_4207.py
+++ b/scripts/benchmark/run_certification_transfer_issue_4207.py
@@ -10,8 +10,10 @@ from pathlib import Path
 from typing import Any
 
 from robot_sf.benchmark.certification_transfer import (
+    PREFLIGHT_OK,
     build_certification_transfer_report,
     load_yaml_mapping,
+    preflight_gate_evaluability,
     validate_gate_spec,
     validate_probe_config,
     write_certification_transfer_evidence,
@@ -24,14 +26,17 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SCHEMA_PATH = REPO_ROOT / "robot_sf/benchmark/schemas/episode.schema.v1.json"
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    """Parse CLI arguments."""
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config", type=Path, required=True, help="Probe YAML config.")
     parser.add_argument("--gate-spec", type=Path, required=True, help="Release-gate YAML spec.")
     parser.add_argument(
-        "--output-dir", type=Path, required=True, help="Compact evidence directory."
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Compact evidence directory (required unless --validate-only is set).",
     )
     parser.add_argument(
         "--generated-at",
@@ -43,20 +48,66 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         help="Existing episode JSONL input for report-only mode; skips CPU episode execution.",
     )
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help=(
+            "Preflight only: validate probe config, gate spec, arm resolution, and required-gate"
+            " metric evaluability without running simulation or writing evidence. Fails closed"
+            " with status 'blocked_no_evaluable_gate_family' when a required gate references a"
+            " metric the runner cannot aggregate."
+        ),
+    )
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    return build_parser().parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run or summarize the CPU certification-transfer probe."""
+    """Run, summarize, or preflight the CPU certification-transfer probe."""
 
     args = parse_args(argv)
+    parser = build_parser()
     config_path = _resolve(args.config)
     gate_spec_path = _resolve(args.gate_spec)
-    output_dir = _resolve(args.output_dir, must_exist=False)
     config = load_yaml_mapping(config_path)
     probe_config = validate_probe_config(config, base_dir=config_path.parent)
     gate_spec = load_yaml_mapping(gate_spec_path)
-    validate_gate_spec(gate_spec, scenario_family=probe_config["scenario_family"])
+    normalized_gate_spec = validate_gate_spec(
+        gate_spec, scenario_family=probe_config["scenario_family"]
+    )
+
+    # Preflight: the probe declares a single, hard-coded scenario family. A required gate whose
+    # metric the runner cannot aggregate would make every cell ``not_evaluable`` (a vacuously
+    # inconclusive run), so fail closed with ``blocked_no_evaluable_gate_family`` before any
+    # simulation or evidence write (issue #4207 preflight requirement).
+    preflight = preflight_gate_evaluability(probe_config, normalized_gate_spec)
+    if preflight["status"] != PREFLIGHT_OK:
+        print(
+            json.dumps(
+                {
+                    "status": preflight["status"],
+                    "scenario_family": preflight["scenario_family"],
+                    "not_evaluable_gate_ids": preflight["not_evaluable_gate_ids"],
+                    "not_evaluable_gate_metrics": preflight["not_evaluable_gate_metrics"],
+                    "aggregatable_metrics": preflight["aggregatable_metrics"],
+                },
+                sort_keys=True,
+            )
+        )
+        return 2
+
+    if args.validate_only:
+        print(json.dumps({"status": "ok", "preflight": preflight}, sort_keys=True))
+        return 0
+
+    if args.output_dir is None:
+        parser.error("--output-dir is required unless --validate-only is set")
+    output_dir = _resolve(args.output_dir, must_exist=False)
 
     generated_at = _generated_at(args.generated_at)
     if args.episodes_jsonl is None:

--- a/tests/benchmark/test_certification_transfer_issue_4207.py
+++ b/tests/benchmark/test_certification_transfer_issue_4207.py
@@ -3,17 +3,25 @@
 from __future__ import annotations
 
 import csv
+import importlib.util
 import json
+import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 from robot_sf.benchmark.certification_transfer import (
+    AGGREGATABLE_METRICS,
     CLAIM_BOUNDARY,
+    PREFLIGHT_BLOCKED_NO_EVALUABLE_GATE_FAMILY,
+    PREFLIGHT_OK,
     _repo_relative_path,
     build_certification_transfer_report,
     classify_interaction_status,
     load_yaml_mapping,
+    preflight_gate_evaluability,
+    validate_gate_spec,
     validate_probe_config,
     write_certification_transfer_evidence,
 )
@@ -37,6 +45,15 @@ INTERACTING_PHYSICS_CONFIG = (
 INTERACTING_PHYSICS_PACKET = (
     REPO_ROOT / "docs/context/evidence/issue_4207_interacting_physics_2026-07"
 )
+
+_RUNNER_MODULE_PATH = (
+    REPO_ROOT / "scripts" / "benchmark" / "run_certification_transfer_issue_4207.py"
+)
+_spec = importlib.util.spec_from_file_location("run_cert_transfer_4207", _RUNNER_MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+_run_cert_transfer = importlib.util.module_from_spec(_spec)
+sys.modules["run_cert_transfer_4207"] = _run_cert_transfer
+_spec.loader.exec_module(_run_cert_transfer)
 
 
 def test_transfer_matrix_detects_pass_fail_flips(tmp_path: Path) -> None:
@@ -549,6 +566,217 @@ def test_committed_physics_packet_records_real_near_field_contact() -> None:
         recorded = summary[key]["path"]
         assert not recorded.startswith(("/home/", "/Users/", "/root/")), recorded
         assert recorded.startswith("configs/"), recorded
+
+
+def test_preflight_passes_when_required_gate_metrics_are_aggregatable(tmp_path: Path) -> None:
+    """Preflight reports ok when every required gate metric is aggregatable."""
+
+    _config_path, _gate_path, config, gates = _write_config_pair(tmp_path)
+    normalized_config = validate_probe_config(config, base_dir=tmp_path)
+    normalized_gates = validate_gate_spec(
+        gates, scenario_family=normalized_config["scenario_family"]
+    )
+
+    result = preflight_gate_evaluability(normalized_config, normalized_gates)
+
+    assert result["status"] == PREFLIGHT_OK
+    assert result["not_evaluable_gate_ids"] == []
+    assert result["not_evaluable_gate_metrics"] == []
+    assert set(result["aggregatable_metrics"]) == set(AGGREGATABLE_METRICS)
+    assert set(result["required_gate_metrics"]) <= set(AGGREGATABLE_METRICS)
+
+
+def test_preflight_blocks_when_required_gate_metric_is_not_aggregatable(
+    tmp_path: Path,
+) -> None:
+    """A required gate on a non-aggregatable metric fails closed as blocked_no_evaluable_gate_family."""
+
+    _config_path, _gate_path, config, gates = _write_config_pair(tmp_path)
+    gates["gates"][0]["metric"] = "bogus_metric"
+    normalized_config = validate_probe_config(config, base_dir=tmp_path)
+    normalized_gates = validate_gate_spec(
+        gates, scenario_family=normalized_config["scenario_family"]
+    )
+
+    result = preflight_gate_evaluability(normalized_config, normalized_gates)
+
+    assert result["status"] == PREFLIGHT_BLOCKED_NO_EVALUABLE_GATE_FAMILY
+    assert result["not_evaluable_gate_ids"] == ["collision_rate_zero"]
+    assert result["not_evaluable_gate_metrics"] == ["bogus_metric"]
+    assert result["scenario_family"] == normalized_config["scenario_family"]
+
+
+def test_preflight_optional_gate_with_non_aggregatable_metric_does_not_block(
+    tmp_path: Path,
+) -> None:
+    """An optional gate on a non-aggregatable metric surfaces as not_evaluable but does not block."""
+
+    _config_path, _gate_path, config, gates = _write_config_pair(tmp_path)
+    gates["gates"].append(
+        {
+            "id": "optional_unknown_metric",
+            "metric": "bogus_metric",
+            "threshold": 0.0,
+            "direction": "max",
+            "category": "diagnostic",
+            "provenance": "fixture",
+            "required": False,
+            "scope": {"scenario_family": "fixture_family"},
+        }
+    )
+    normalized_config = validate_probe_config(config, base_dir=tmp_path)
+    normalized_gates = validate_gate_spec(
+        gates, scenario_family=normalized_config["scenario_family"]
+    )
+
+    result = preflight_gate_evaluability(normalized_config, normalized_gates)
+
+    assert result["status"] == PREFLIGHT_OK
+    assert result["not_evaluable_gate_ids"] == []
+
+
+def test_runner_validate_only_passes_preflight_on_committed_smoke_config(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--validate-only runs preflight on the committed smoke config without simulation."""
+
+    exit_code = _run_cert_transfer.main(
+        [
+            "--config",
+            str(INTERACTING_SMOKE_CONFIG),
+            "--gate-spec",
+            str(INTERACTING_SMOKE_GATES),
+            "--validate-only",
+        ]
+    )
+
+    assert exit_code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "ok"
+    assert out["preflight"]["status"] == PREFLIGHT_OK
+    assert out["preflight"]["scenario_family"] == "issue4207_interacting_smoke"
+    assert out["preflight"]["not_evaluable_gate_ids"] == []
+
+
+def test_runner_validate_only_fails_closed_on_non_evaluable_gate_family(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--validate-only exits 2 with blocked_no_evaluable_gate_family for a non-aggregatable required gate."""
+
+    config_path, gate_path = _write_runner_yaml_pair(tmp_path, gate_metric="bogus_metric")
+
+    exit_code = _run_cert_transfer.main(
+        [
+            "--config",
+            str(config_path),
+            "--gate-spec",
+            str(gate_path),
+            "--validate-only",
+        ]
+    )
+
+    assert exit_code == 2
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == PREFLIGHT_BLOCKED_NO_EVALUABLE_GATE_FAMILY
+    assert out["not_evaluable_gate_metrics"] == ["bogus_metric"]
+    assert "gate_one" in out["not_evaluable_gate_ids"]
+    assert "aggregatable_metrics" in out
+
+
+def test_runner_validate_only_does_not_require_output_dir(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--validate-only succeeds without --output-dir and writes no evidence artifacts."""
+
+    config_path, gate_path = _write_runner_yaml_pair(tmp_path)
+    evidence_dir = tmp_path / "evidence"
+
+    exit_code = _run_cert_transfer.main(
+        [
+            "--config",
+            str(config_path),
+            "--gate-spec",
+            str(gate_path),
+            "--validate-only",
+        ]
+    )
+
+    assert exit_code == 0
+    assert not evidence_dir.exists()
+
+
+def _write_runner_yaml_pair(
+    tmp_path: Path, *, gate_metric: str = "collision_rate", required: bool = True
+) -> tuple[Path, Path]:
+    """Write a minimal valid probe config and gate spec as real YAML for runner-level tests.
+
+    Unlike ``_write_config_pair`` (which writes placeholder file bodies and returns in-memory
+    mappings for ``build_certification_transfer_report`` tests), this helper writes YAML that the
+    runner's ``load_yaml_mapping`` can actually parse, so ``main`` can be exercised end-to-end up
+    to (but not including) simulation.
+    """
+
+    scenario_path = tmp_path / "scenario.yaml"
+    scenario_path.write_text("scenarios: []\n", encoding="utf-8")
+    algo_path = tmp_path / "algo.yaml"
+    algo_path.write_text("{}\n", encoding="utf-8")
+    config = {
+        "name": "issue_4207_certification_transfer_probe",
+        "schema_version": "certification-transfer-probe.v1",
+        "issue": 4207,
+        "paper_facing": False,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "pedestrian_models": [SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1],
+        "scenario_family": "fixture_family",
+        "scenario_matrix": str(scenario_path),
+        "seed_policy": {"mode": "fixed-list", "seeds": [111, 112, 113]},
+        "arms": [
+            {
+                "key": "goal_a",
+                "structural_class": "baseline_reactive",
+                "algo": "goal",
+                "algo_config": str(algo_path),
+                "development_pedestrian_model": "unknown",
+            },
+            {
+                "key": "goal_b",
+                "structural_class": "baseline_reactive",
+                "algo": "goal",
+                "development_pedestrian_model": "unknown",
+            },
+            {
+                "key": "goal_c",
+                "structural_class": "baseline_reactive",
+                "algo": "goal",
+                "development_pedestrian_model": "unknown",
+            },
+        ],
+        "horizon": 60,
+        "dt": 0.1,
+        "workers": 1,
+    }
+    gates = {
+        "schema_version": "benchmark_release_gate_spec.v1",
+        "gates": [
+            {
+                "id": "gate_one",
+                "metric": gate_metric,
+                "threshold": 0.0,
+                "direction": "max",
+                "category": "safety",
+                "provenance": "fixture",
+                "required": required,
+                "scope": {"scenario_family": "fixture_family"},
+            },
+        ],
+    }
+    config_path = tmp_path / "config.yaml"
+    gate_path = tmp_path / "gates.yaml"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    gate_path.write_text(yaml.safe_dump(gates), encoding="utf-8")
+    return config_path, gate_path
 
 
 def _write_config_pair(tmp_path: Path) -> tuple[Path, Path, dict[str, object], dict[str, object]]:


### PR DESCRIPTION
## What

Adds the **preflight capability named in the issue #4207 plan but not yet implemented**: a `preflight_gate_evaluability()` check that fails closed with `blocked_no_evaluable_gate_family` when a required release gate references a metric the runner cannot aggregate.

## Why

The issue #4207 plan states:

> During preflight, choose a family where #4166-style safety+comfort gate metrics are evaluable; if no family satisfies that, fail closed and report `blocked_no_evaluable_gate_family`.

The probe declares a single, hard-coded scenario family (it is not discovered dynamically). A required gate whose `metric` is not in the set the runner can aggregate (`collision_rate, success_rate, near_miss_rate, min_clearance_m, proxemic_intrusion_rate, robot_ped_within_5m_frac, jerk_mean`) can never resolve to `pass`/`fail` — every cell would be `not_evaluable`, the vacuously-inconclusive trap the plan forbids. This slice implements that fail-closed preflight so a moot probe is rejected before any simulation or evidence write.

## Changes (additive only)

- `robot_sf/benchmark/certification_transfer.py`: new `AGGREGATABLE_METRICS` frozenset, `PREFLIGHT_OK` / `PREFLIGHT_BLOCKED_NO_EVALUABLE_GATE_FAMILY` constants, and a public `preflight_gate_evaluability(probe_config, gate_spec)` function. Required gates with non-aggregatable metrics block; optional gates (`required: false`) with non-aggregatable metrics do **not** block (they surface as `not_evaluable` at evaluation time, but do not drive the pass/fail decision).
- `scripts/benchmark/run_certification_transfer_issue_4207.py`: new `--validate-only` mode (runs preflight without simulation or evidence writing; `--output-dir` not required in this mode), and a preflight fail-closed guard that runs in **all** modes (execute, report-only, validate-only) and exits `2` with a `blocked_no_evaluable_gate_family` JSON payload before any simulation. Also captures the previously-discarded normalized gate spec.
- `tests/benchmark/test_certification_transfer_issue_4207.py`: 6 focused tests — preflight ok / blocked / optional-gate-does-not-block at the unit level, plus runner `--validate-only` pass (committed smoke config, no simulation), runner `--validate-only` fail-closed (exit 2, `blocked_no_evaluable_gate_family`), and `--validate-only` not requiring `--output-dir`.

## Claim boundary

Diagnostic-only. No gate semantics, transfer-status, or trained-planner-readiness change; no simulation, campaign, Slurm, training, benchmark, or paper/dissertation claim is promoted. `not_evaluable` is never treated as `pass`. This slice does **not** attach trained-arm artifacts (the issue's remaining blocker) — that requires training runs outside this cheap-lane scope.

## Successor statement

Successor slice: **preflight + `--validate-only` mode**. Does not duplicate PR #4308 (interaction-validity guard), #4315 (interacting smoke family), #4324 (config/gate-spec path portability), #4337 (physics-verified probe), #4412 (interaction_metric_summary), #4433 (trained-planner claim policy), or #4480 (trained-planner readiness contract). Each of those is additive on a different surface; `blocked_no_evaluable_gate_family` and a `--validate-only` runner mode were absent from the tree prior to this PR.

## Validation (CPU-level only)

```
$ uv run pytest tests/benchmark/test_certification_transfer_issue_4207.py -q
........................                                                 [100%]
24 passed in 2.88s

$ uv run pytest tests/benchmark/test_ped_model_sensitivity.py tests/benchmark/test_release_gates.py -q
22 passed in 10.96s

$ uv run ruff check robot_sf/benchmark/certification_transfer.py scripts/benchmark/run_certification_transfer_issue_4207.py tests/benchmark/test_certification_transfer_issue_4207.py
All checks passed!

$ uv run ruff format --check robot_sf/benchmark/certification_transfer.py scripts/benchmark/run_certification_transfer_issue_4207.py tests/benchmark/test_certification_transfer_issue_4207.py
3 files already formatted
```

Base: `origin/main` (`d58da305e`). One commit, three files, +354/-7.

## Downstream propagation

NA — support/tooling-only change (additive preflight guard + CLI mode). No research, benchmark, metric, or paper-facing claim; no evidence packet regenerated and no shared artifact changed.

---

This PR was produced by the Command-Code/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
