### PR TITLE
Issue #3275: emit proposal rerun stop-rule decision

### DIFF
--- a/scripts/adversarial/run_proposal_vs_random_issue_2921.py
+++ b/scripts/adversarial/run_proposal_vs_random_issue_2921.py
@@ -26,6 +26,49 @@ HELD_OUT_DIAGNOSTIC_BOUNDARY = (
 )
 
 
+def classify_issue_2921_stop_rule(
+    *,
+    held_out_evidence: bool,
+    held_out_status: str | None,
+    comparison: dict[str, float | int | str],
+) -> dict[str, Any]:
+    """Return the issue #2921 continue/revise/stop decision without promoting claims.
+
+    The issue #3275 rerun can only move into the #2921 stop-rule lane after the held-out
+    diagnostic gate is open. Until then the stop rule is explicitly blocked so plumbing-only
+    deltas cannot be mistaken for proposal-model evidence.
+    """
+    if not held_out_evidence:
+        return {
+            "status": "blocked",
+            "reason": held_out_status or "held_out_evidence_not_available",
+            "evidence_tier": "analysis_only",
+            "claim_boundary": "no #2921 stop-rule decision without held-out diagnostic evidence",
+        }
+
+    mean_delta = float(comparison["mean_objective_improvement"])
+    failure_delta = int(comparison["failure_count_improvement"])
+    if mean_delta > 0.0 or failure_delta > 0:
+        status = "continue"
+        reason = "diagnostic held-out deltas are positive; run the next predeclared proof step"
+    elif mean_delta < 0.0 or failure_delta < 0:
+        status = "stop"
+        reason = "diagnostic held-out deltas are negative; do not expand this proposal lane"
+    else:
+        status = "revise"
+        reason = "diagnostic held-out deltas are neutral; revise before another empirical batch"
+
+    return {
+        "status": status,
+        "reason": reason,
+        "evidence_tier": "diagnostic_only",
+        "claim_boundary": (
+            "issue #2921 stop-rule classification from held-out diagnostic evidence only; "
+            "not benchmark, paper, or planner-performance evidence"
+        ),
+    }
+
+
 def create_synthetic_search_space() -> Any:
     """Create a default synthetic search space config for diagnostics."""
     from robot_sf.adversarial.config import RangeConfig, SearchSpaceConfig
@@ -400,6 +443,24 @@ def main() -> int:
     else:
         comparison_interpretation = "plumbing_only_circular_archive_nearness_objective"
 
+    comparison = {
+        "interpretation": comparison_interpretation,
+        "mean_objective_improvement": round(
+            proposal_metrics["mean_objective"] - random_metrics["mean_objective"], 4
+        ),
+        "max_objective_improvement": round(
+            proposal_metrics["max_objective"] - random_metrics["max_objective"], 4
+        ),
+        "failure_count_improvement": (
+            proposal_metrics["failure_count"] - random_metrics["failure_count"]
+        ),
+    }
+    issue_2921_stop_rule = classify_issue_2921_stop_rule(
+        held_out_evidence=held_out_evidence,
+        held_out_status=held_out_status,
+        comparison=comparison,
+    )
+
     report = {
         "schema_version": "adversarial_proposal_comparison.v1",
         "state": state,
@@ -418,18 +479,8 @@ def main() -> int:
         "seed": args.seed,
         "random_metrics": random_metrics,
         "proposal_metrics": proposal_metrics,
-        "comparison": {
-            "interpretation": comparison_interpretation,
-            "mean_objective_improvement": round(
-                proposal_metrics["mean_objective"] - random_metrics["mean_objective"], 4
-            ),
-            "max_objective_improvement": round(
-                proposal_metrics["max_objective"] - random_metrics["max_objective"], 4
-            ),
-            "failure_count_improvement": (
-                proposal_metrics["failure_count"] - random_metrics["failure_count"]
-            ),
-        },
+        "comparison": comparison,
+        "issue_2921_stop_rule": issue_2921_stop_rule,
         "archive_evaluation_provenance": provenance,
         "independent_outcome_evaluation": independent_evaluation,
         "null_tests": independent_evaluation.get(

--- a/tests/adversarial/test_adversarial_proposal_model_issue_2921.py
+++ b/tests/adversarial/test_adversarial_proposal_model_issue_2921.py
@@ -448,6 +448,15 @@ def test_real_archive_with_independent_outcomes_becomes_diagnostic_only(
     assert report["planner_performance_claim"] is False
     assert report["result_classification"] == "held_out_diagnostic_only"
     assert report["comparison"]["interpretation"] == "independent_planner_execution_outcomes"
+    assert report["issue_2921_stop_rule"] == {
+        "status": "continue",
+        "reason": "diagnostic held-out deltas are positive; run the next predeclared proof step",
+        "evidence_tier": "diagnostic_only",
+        "claim_boundary": (
+            "issue #2921 stop-rule classification from held-out diagnostic evidence only; "
+            "not benchmark, paper, or planner-performance evidence"
+        ),
+    }
     assert report["archive_evaluation_provenance"]["held_out_evidence_status"] == (
         "eligible_held_out_diagnostic"
     )
@@ -518,6 +527,8 @@ def test_real_archive_seed_overlap_cannot_be_held_out_evidence(tmp_path: Path, m
     assert report["comparison"]["interpretation"] == (
         "independent_outcomes_rejected_by_held_out_gate"
     )
+    assert report["issue_2921_stop_rule"]["status"] == "blocked"
+    assert report["issue_2921_stop_rule"]["reason"] == "not_available_no_disjoint_split"
     assert provenance["held_out_evidence_status"] == "not_available_no_disjoint_split"
     assert provenance["disjointness_checks_passed"] is False
     assert provenance["seed_overlap"] == [100, 101, 102]
@@ -580,4 +591,8 @@ def test_real_archive_with_circular_outcomes_stays_fail_closed(tmp_path: Path, m
     )
     assert report["independent_outcome_evaluation"]["status"] == (
         "blocked_invalid_independent_outcomes"
+    )
+    assert report["issue_2921_stop_rule"]["status"] == "blocked"
+    assert report["issue_2921_stop_rule"]["reason"] == (
+        "not_available_requires_independent_planner_outcomes"
     )

--- a/tests/adversarial/test_adversarial_proposal_model_issue_2921.py
+++ b/tests/adversarial/test_adversarial_proposal_model_issue_2921.py
@@ -11,9 +11,54 @@ from robot_sf.adversarial.config import CandidateSpec, Pose2D
 from robot_sf.adversarial.proposal_model import FailureArchiveProposalModel
 from robot_sf.adversarial.scenario_manifest import AdversarialScenarioManifest
 from scripts.adversarial.run_proposal_vs_random_issue_2921 import (
+    classify_issue_2921_stop_rule,
     create_synthetic_archive,
     create_synthetic_search_space,
 )
+
+
+def _held_out_comparison(*, mean_delta: float, failure_delta: int) -> dict[str, float | int | str]:
+    """Build a comparison payload for the #2921 stop-rule classifier."""
+    return {
+        "interpretation": "independent_planner_execution_outcomes",
+        "mean_objective_improvement": mean_delta,
+        "max_objective_improvement": mean_delta,
+        "failure_count_improvement": failure_delta,
+    }
+
+
+def test_classify_issue_2921_stop_rule_blocks_without_held_out_evidence() -> None:
+    """The stop rule must fail closed to blocked when held-out evidence is unavailable."""
+    decision = classify_issue_2921_stop_rule(
+        held_out_evidence=False,
+        held_out_status="not_available_no_disjoint_split",
+        comparison=_held_out_comparison(mean_delta=5.0, failure_delta=5),
+    )
+    assert decision["status"] == "blocked"
+    assert decision["reason"] == "not_available_no_disjoint_split"
+    assert decision["evidence_tier"] == "analysis_only"
+
+
+def test_classify_issue_2921_stop_rule_stop_on_negative_deltas() -> None:
+    """Negative held-out deltas classify as stop (do not expand the proposal lane)."""
+    decision = classify_issue_2921_stop_rule(
+        held_out_evidence=True,
+        held_out_status="eligible_held_out_diagnostic",
+        comparison=_held_out_comparison(mean_delta=-0.5, failure_delta=-2),
+    )
+    assert decision["status"] == "stop"
+    assert decision["evidence_tier"] == "diagnostic_only"
+
+
+def test_classify_issue_2921_stop_rule_revise_on_neutral_deltas() -> None:
+    """Neutral (zero) held-out deltas classify as revise before another empirical batch."""
+    decision = classify_issue_2921_stop_rule(
+        held_out_evidence=True,
+        held_out_status="eligible_held_out_diagnostic",
+        comparison=_held_out_comparison(mean_delta=0.0, failure_delta=0),
+    )
+    assert decision["status"] == "revise"
+    assert decision["evidence_tier"] == "diagnostic_only"
 
 
 def _candidate(x: float, y: float, speed: float = 1.0) -> CandidateSpec:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `scripts/adversarial/run_proposal_vs_random_issue_2921.py` now emits an explicit `issue_2921_stop_rule` object in the proposal-vs-random report, and the adversarial tests assert it on eligible held-out diagnostic and blocked paths.

Why now: issue #3275 is still open after merged readiness/closure-packet PRs because the latest live issue state says the real rerun evidence remains blocked. The closure audit found one small remaining report-contract criterion not explicitly surfaced by the runner: the #2921 continue/revise/stop classification.

Claim boundary: this is a CPU-only report-contract slice. It does not run a full benchmark campaign, does not submit SLURM/GPU work, does not promote a paper/dissertation claim, and does not claim proposal-model improvement.

Required validation: focused adversarial proposal-model and closure-packet tests, Ruff on touched files, and PR readiness wrapper.

Remaining blocker: real disjoint certified failure archive rerun evidence is still needed to clear the fail-closed disposition recorded by PR #4323.

## Contract delta

- New report field: `issue_2921_stop_rule`.
- Field values:
  - `status: blocked` until `held_out_evidence` is true.
  - `status: continue`, `revise`, or `stop` only after the held-out diagnostic gate opens.
- `evidence_tier` remains `analysis_only` or `diagnostic_only`; benchmark and paper flags stay false.
- Compatibility impact: additive JSON report field only; existing report fields are unchanged.
- New fail-closed behavior: plumbing-only or rejected independent-outcome paths now explicitly report that the #2921 stop-rule decision is blocked rather than leaving the criterion implicit.

## Domain-Aware Approval

- Required PR: yes - evidence-validity-sensitive result classification
- Domains reviewed: evidence classification, adversarial rerun report contract, fallback/degraded exclusions.
- Status: approved
- Approver/review source waiver: implementation review of report-contract metadata; no experimental-validity claim is promoted.
- Approval or blocker note: approved for report-contract plumbing; reviewer should not treat this as evidence that real rerun blockers are cleared.
- Validity checklist:
  - Target claim/hypothesis: no new target claim; report-contract support for #3275/#2921.
  - Comparator or split/evidence validity: unchanged; existing held-out diagnostic gate still controls eligibility.
  - Fallback/degraded exclusions: unchanged; fallback/degraded independent outcome rows remain rejected before held-out diagnostics open.
  - Claim boundary: analysis-scoped report metadata; no benchmark, paper, or planner-performance claim.
  - Implementation integrity vs experimental validity: focused tests verify report shape and fail-closed/eligible paths; real rerun evidence remains out of scope.

## Linked issue

Relates to #3275.

## Scope summary

This PR is the smallest remaining closure-audit slice found after reading the full issue body, issue comments, and merged PR state. It does not try to replace the already-merged closure packet. It adds a nameable capability toward the implementation plan: explicit stop-rule classification in the real proposal-vs-random report contract.

## Acceptance evidence

| #3275 criterion | Evidence / status |
| --- | --- |
| Fit/evaluation data disjoint scenario family and overlap checks recorded | Existing merged implementation in `robot_sf/adversarial/disjoint_evaluation.py` and proposal-runner provenance; exercised by `test_active_real_archive_computes_disjoint_provenance_but_fails_closed`. |
| `held_out_evidence` false unless scenario-family, seed, archive-ID disjointness checks pass | Existing merged held-out gate; exercised by seed-overlap rejection test and independent-outcome eligible test. |
| Evaluation metric independent of proposal ranking objective based on actual planner executions with certified failure outcomes | Existing independent-outcome packet path accepts `outcome_source: planner_execution` and rejects archive-nearness/fallback/degraded rows; real durable rerun evidence remains absent. |
| Every emitted candidate explicit manifest lineage certification status | Covered by merged readiness/closure packet checks; latest issue comment after PR #4323 still records blocker state for real inputs. |
| Missing/malformed real search-space input fails closed rather than synthetic fallback | Existing proposal-runner and closure-packet tests cover blocked/fail-closed behavior. |
| Shuffled-outcome and proposal-ranking permutation null tests implemented/reported | Existing independent-outcome and null-test prerequisite paths; exercised by focused proposal-model and closure-packet tests. |
| Result classified continue/revise/stop under issue #2921 stop rule | Added in this PR via `issue_2921_stop_rule`; tests cover `continue` for eligible held-out diagnostics and `blocked` when evidence is not eligible. |
| No benchmark or paper-facing claim unless evidence tier supports it | Preserved: report keeps `benchmark_evidence: false`, `planner_performance_claim: false`, and scoped claim boundaries. |

## Validation / proof

- `uv run pytest tests/adversarial/test_adversarial_proposal_model_issue_2921.py -q` — passed.
- `uv run pytest tests/adversarial/test_adversarial_proposal_model_issue_2921.py tests/adversarial/test_rerun_closure_packet.py -q` — passed after merging `origin/main`.
- `uv run ruff format scripts/adversarial/run_proposal_vs_random_issue_2921.py tests/adversarial/test_adversarial_proposal_model_issue_2921.py` — no changes.
- `uv run ruff check scripts/adversarial/run_proposal_vs_random_issue_2921.py tests/adversarial/test_adversarial_proposal_model_issue_2921.py` — passed.
- `git diff --check` — passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr3275_body.md scripts/dev/pr_ready_check.sh` — passed; stamp recorded at `output/validation/pr_ready/issue-3275-closure-audit-verify-acceptance-criteria-of-3275-against-merged-prs-clos.json`.

## Out of scope

- No full benchmark campaign run.
- No SLURM/GPU submission.
- No paper/dissertation claim edits.
- No issue comment or issue close action; `comment_issue_or_pr` was not authorized for this run. State propagation is therefore carried by this PR body.

<details>
<summary>Audit and freshness notes</summary>

- Live issue was read via GitHub REST API because `gh issue view --comments` failed on GitHub's deprecated classic-project GraphQL field.
- Latest live issue update before this PR was the PR #4323 propagation comment: issue stays open; closure packet documents blockers; real rerun evidence remains.
- No open PR covered #3275 or this exact stop-rule scope at pre-PR dedupe.
- Fragmentation guard did not block this slice: only PR #4323 matched #3275 merged since 2026-07-03T00:00:00Z in the checked window, and this PR adds a nameable new report-contract capability rather than another micro-guard.
- No maintainer comments newer than the start of this run were found in the pre-PR live issue refresh.

</details>
