### PR TITLE
Issue #4454: add closure audit evidence

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -17,6 +17,10 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+  - path: docs/context/evidence/issue_4454_closure_audit_2026-07-04.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_4163_closure_audit
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -120,6 +120,10 @@ Policy caveats:
 
 ## Current Bundles
 
+- `issue_4454_closure_audit_2026-07-04.md`: closure-audit integration report for
+  issue #4454. Maps merged PR #4456 typed collision-event export evidence to the live issue
+  acceptance criteria, with the issue left for authorized closure/comment propagation.
+
 - `issue_4224_closure_audit_2026-07-04.md`: closure-audit integration report for issue #4224.
   Maps merged public registry, acquisition-doc, and skip-if-absent loader PRs for ATC, ETH/UCY,
   inD, CrowdBot, and SCAND, while preserving the remaining private acquisition, seeding, and

--- a/docs/context/evidence/issue_4454_closure_audit_2026-07-04.md
+++ b/docs/context/evidence/issue_4454_closure_audit_2026-07-04.md
@@ -1,0 +1,55 @@
+# Issue #4454 Closure Audit
+
+Plain-language summary: merged PR #4456 delivered the typed collision-event export requested by
+issue #4454; this audit maps each acceptance criterion to merged evidence so the issue can be
+closed by an authorized issue-closing follow-up.
+
+## Source Thread
+
+- Issue: <https://github.com/ll7/robot_sf_ll7/issues/4454>
+- Merged implementation PR: <https://github.com/ll7/robot_sf_ll7/pull/4456>
+- Merge time: 2026-07-04 17:47 UTC
+- Audit date: 2026-07-04
+
+## Claim Boundary
+
+This is a closure-audit integration report only. It does not run a full benchmark campaign, submit
+Slurm or GPU compute, regenerate release rows, change metric semantics, or edit paper or dissertation
+claims. The delivered claim is additive instrumentation: episode rows can carry typed exact collision
+event records, while existing scalar collision metrics remain backward-compatible termination and
+aggregate indicators.
+
+## Acceptance Mapping
+
+| Acceptance criterion from #4454 | Delivered evidence | Status |
+| --- | --- | --- |
+| Episode rows contain additive typed collision-event records when event data is available. | PR #4456 bumps the canonical episode event ledger to `EpisodeEventLedger.v2`, adds `event_ledger.collision_events`, and emits the ledger from `run_map_episode` before validated JSONL writing. | Delivered by PR #4456. |
+| Event records include partner type/id, collision time, relative speed at contact, clearance/source metadata, and exact event source. | `robot_sf/benchmark/event_ledger.py` defines `CollisionEventRecord` with `collision_partner_type`, `collision_partner_id`, `collision_time`, `relative_speed_at_contact`, `clearance_series_source`, and `exact_event_source`; validation rejects malformed typed events. | Delivered by PR #4456. |
+| Pedestrian, static-geometry, boundary, and goal-artifact fixture tests cover classification behavior. | `tests/benchmark/test_event_ledger.py` parameterizes all four partner classes and checks normalized records preserve partner id, time, speed, clearance source, and exact source. `tests/benchmark/test_map_runner_utils.py` adds runtime helper coverage for pedestrian and obstacle/boundary classification paths. | Delivered by PR #4456. |
+| Camera-ready retention preserves event data documented compact sidecar or native export. | PR #4456 emits typed events natively through the normal episode JSONL export path. The issue thread's latest maintainer comment says retained durable-artifact consumers were gate-hardened for bounded `SUPPORTED_EVENT_LEDGER_SCHEMA_VERSIONS = {v1, v2}` compatibility with v3 fail-closed fixtures, so camera-ready retention can carry typed events without a separate metric reinterpretation layer. | Delivered by PR #4456, via native episode export and durable-consumer schema gate hardening. |
+| Existing scalar collision metrics and current claims are not reinterpreted. | PR #4456 keeps scalar fields backward-compatible and adds docs/changelog text that scalar `collision` / `outcome.collision_event` remains a termination indicator; safety claims should cite typed `event_ledger.collision_events`. | Delivered by PR #4456. |
+| Documentation clarifies typed events are required for future safety-validity citation. | PR #4456 updates `docs/benchmark_spec.md` and `CHANGELOG.md` to document the typed event ledger and the scalar collision-flag boundary. | Delivered by PR #4456. |
+
+## Closure Decision
+
+All repository-visible acceptance criteria in the live issue thread are satisfied by merged PR #4456.
+Issue #4454 is closable once an authorized actor can post the criterion-to-evidence closure comment
+and close the issue. This audit did not post an issue comment because the queue authorization for this
+run did not include `comment_issue_or_pr`.
+
+## Local Verification
+
+Audit-time validation for this docs-only slice:
+
+```bash
+scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/evidence/README.md --path docs/context/evidence/issue_4454_closure_audit_2026-07-04.md
+git diff --check
+scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_event_ledger.py tests/benchmark/test_map_runner_utils.py -q -k 'event_ledger or floors_exact_obstacle_collision_metrics'
+```
+
+The catalog edit was also parsed with PyYAML and checked for exactly one
+`docs/context/evidence/issue_4454_closure_audit_2026-07-04.md` entry with `status: evidence` and
+`freshness: evidence`.
+
+No full benchmark campaign run, no Slurm or GPU job submitted, and no paper or dissertation claim
+text changed.


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a compact closure-audit evidence note for issue #4454 and registers it in `docs/context/evidence/README.md` and `docs/context/catalog.yaml`.

Why now: PR #4456 merged the typed collision-event ledger implementation, but issue #4454 remains open; this PR provides the criterion-to-evidence closure map without inventing new benchmark scope.

Claim boundary: closure-audit integration report only. It does not run a full benchmark campaign, submit Slurm/GPU compute, regenerate release rows, change metric semantics, or edit paper/dissertation claims.

Required validation: docs proof consistency for the touched evidence docs, YAML parse/assertion for the new catalog entry, `git diff --check`, and focused typed event-ledger tests.

Remaining blocker: no repository-visible implementation criterion remains. Issue #4454 still needs an authorized issue closure/comment because this run is not authorized to comment on issues or PRs.

## Contract delta

New schema fields: none in this PR. The audit records that merged PR #4456 introduced `EpisodeEventLedger.v2` typed `event_ledger.collision_events` records.

New fail-closed blockers: none in this PR. The audit records the existing `SUPPORTED_EVENT_LEDGER_SCHEMA_VERSIONS = {v1, v2}` compatibility/fail-closed boundary from PR #4456.

Compatibility impact: docs-only evidence registration. No runtime behavior, benchmark metric semantics, episode JSONL writer behavior, or durable artifact schema behavior changes in this PR.

## Issue

Closes readiness gap for <https://github.com/ll7/robot_sf_ll7/issues/4454> by documenting why the issue is closable after merged PR #4456. This PR does not close the issue directly because queue authorization did not include `comment_issue_or_pr`.

## Scope summary

- Adds `docs/context/evidence/issue_4454_closure_audit_2026-07-04.md` with an acceptance criterion to evidence table.
- Adds the evidence note to `docs/context/evidence/README.md`.
- Adds the evidence note to `docs/context/catalog.yaml`.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/evidence/README.md --path docs/context/evidence/issue_4454_closure_audit_2026-07-04.md` -> pass
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python - <<'PY' ... parse docs/context/catalog.yaml and assert one #4454 evidence entry ... PY` -> pass
- `git diff --check` -> pass
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_event_ledger.py tests/benchmark/test_map_runner_utils.py -q -k 'event_ledger or floors_exact_obstacle_collision_metrics'` -> pass, 18 selected tests

Note: `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` initially stopped before checks when analytics extras were missing; after `uv sync --all-extras`, it stopped at the expected `missing_body` gate. This PR body is the configured body source for the final rerun.

## Out of scope

No full benchmark campaign run. No Slurm/GPU submission. No paper/dissertation claim edits. No issue comment or issue closure performed by this run.

## Late guidance and duplicate check

Immediately before PR open, `gh issue view 4454 --repo ll7/robot_sf_ll7 --comments` showed latest issue update at 2026-07-04T17:47:25Z and no maintainer comments newer than this run's start. `gh pr list` found no open PR covering issue #4454 or the typed collision-event closure-audit scope. Fragmentation guard: only one issue #4454 PR, #4456, merged in the last 24 hours, so the two-PR micro-guard threshold was not met.

## Downstream propagation

The durable propagation surface is this PR body plus the tracked closure-audit evidence note. No issue comment was posted because `comment_issue_or_pr` is not authorized for this run.

<details>
<summary>Appendix: acceptance evidence</summary>

| Criterion | Evidence |
| --- | --- |
| Episode rows contain additive typed collision-event records when event data is available. | PR #4456 adds `EpisodeEventLedger.v2`, `event_ledger.collision_events`, and native `run_map_episode` emission before validated JSONL writing. |
| Event records include partner type/id, collision time, relative speed, clearance/source metadata, exact event source. | PR #4456 defines and validates `CollisionEventRecord` fields in `robot_sf/benchmark/event_ledger.py`. |
| Pedestrian/static geometry/boundary/goal-artifact fixture tests cover classification behavior. | PR #4456 adds parameterized typed collision-event tests and map-runner helper coverage. |
| Camera-ready retention preserves event data documented compact sidecar or native export. | PR #4456 emits typed events through normal episode JSONL export and gate-hardened durable consumers for supported event-ledger schema versions. |
| Existing scalar collision metrics current claims not reinterpreted. | PR #4456 keeps scalar compatibility and documents scalar `collision` as a termination indicator. |
| Documentation clarifies typed events required future safety-validity citation. | PR #4456 updates `docs/benchmark_spec.md` and `CHANGELOG.md`; this PR adds closure-audit evidence mapping. |

</details>
