### PR TITLE
feat(data): add AMV calibration admission status (#2415)

### DIFF
--- a/scripts/tools/manage_external_data.py
+++ b/scripts/tools/manage_external_data.py
@@ -25,6 +25,9 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST_DIR = REPO_ROOT / "output" / "external_data" / "manifests"
 EXTERNAL_DATA_ROOT_ENV = "ROBOT_SF_EXTERNAL_DATA_ROOT"
+DEFAULT_AMV_COMMAND_RESPONSE_MANIFEST = (
+    REPO_ROOT / "configs" / "research" / "amv_command_response_trace_manifest_issue_2415.yaml"
+)
 
 # Canonical SDD staging manifest. This is the single editable provenance contract for the SDD
 # asset (issues #2657, #3473): maintainers pin `expected_tree_sha256` and tune the disk-check size
@@ -1837,6 +1840,12 @@ def parse_args() -> argparse.Namespace:
     )
     sdd_mode.add_argument("--manifest", type=Path, default=None)
 
+    amv_status = subparsers.add_parser(
+        "amv-calibration-status",
+        help="Report AMV command-response calibration admission status; fails closed.",
+    )
+    amv_status.add_argument("--manifest", type=Path, default=None)
+
     sdd_download = subparsers.add_parser(
         "sdd-download", help="Guarded SDD staging: requires explicit confirmation; fails closed."
     )
@@ -1982,6 +1991,92 @@ def _handle_sdd_mode(args: argparse.Namespace) -> int:
     return 0 if gate["dataset_backed"] else 2
 
 
+def build_amv_calibration_status(manifest_path: Path | None = None) -> dict[str, Any]:
+    """Return AMV calibration admission status from asset presence plus trace manifest.
+
+    The report is intentionally fail-closed: it never admits AMV command-response calibration
+    unless the issue #2415 manifest is structurally clean and a declared staged trace reconciles
+    with the live ``amv-calibration`` external-data asset status.
+    """
+    from robot_sf.benchmark.synthetic_actuation import actuation_variability_fields
+    from robot_sf.research.amv_command_response_trace_manifest import (
+        AmvTraceManifestError,
+        check_amv_trace_manifest,
+        load_amv_trace_manifest,
+    )
+
+    asset_report = check_asset("amv-calibration")
+    manifest_source = manifest_path or DEFAULT_AMV_COMMAND_RESPONSE_MANIFEST
+    try:
+        manifest = load_amv_trace_manifest(manifest_source)
+        asset_ids = {
+            str(trace["asset_id"])
+            for trace in manifest["traces"]
+            if trace.get("asset_id") is not None
+        }
+        live_status = {
+            asset_id: (
+                str(asset_report["status"])
+                if asset_id == "amv-calibration"
+                else str(check_asset(asset_id)["status"])
+            )
+            for asset_id in sorted(asset_ids)
+        }
+        trace_report = check_amv_trace_manifest(
+            manifest,
+            allowed_calibration_targets=set(actuation_variability_fields()),
+            live_staging_status=live_status,
+            source=manifest_source,
+        )
+        trace_payload = trace_report.to_dict()
+        blocker_details = trace_report.blockers
+    except (AmvTraceManifestError, ValueError) as exc:
+        trace_payload = {
+            "manifest_status": "invalid",
+            "calibration_ingest_allowed": False,
+            "error": str(exc),
+        }
+        live_status = {"amv-calibration": str(asset_report["status"])}
+        blocker_details = [str(exc)]
+
+    ready = asset_report["status"] == "available" and trace_payload["calibration_ingest_allowed"]
+    blocker_keys: list[str] = []
+    if asset_report["status"] != "available":
+        blocker_keys.append("amv_calibration_asset_missing")
+    if not trace_payload["calibration_ingest_allowed"]:
+        blocker_keys.append("command_response_trace_manifest_not_ready")
+
+    return {
+        "schema": "amv_calibration_status.v1",
+        "issue": 2415,
+        "asset_id": "amv-calibration",
+        "ready": ready,
+        "blocked_external_input": not ready,
+        "blockers": blocker_keys,
+        "blocker_details": blocker_details,
+        "asset_status": asset_report,
+        "manifest_path": str(manifest_source),
+        "live_staging_status": live_status,
+        "trace_manifest_report": trace_payload,
+        "evidence_boundary": (
+            "asset_presence_plus_manifest_contract_only_no_trace_ingest_no_calibration_run"
+        ),
+        "next_step": (
+            "Stage a maintainer-accepted real AMV command-response trace bundle through "
+            "`manage_external_data.py stage amv-calibration`, then rerun this status check."
+            if not ready
+            else "AMV command-response trace bundle is staged and manifest-clean for calibration ingest."
+        ),
+    }
+
+
+def _handle_amv_calibration_status(args: argparse.Namespace) -> int:
+    """Handle amv-calibration-status subcommand."""
+    payload = build_amv_calibration_status(args.manifest)
+    _print_json(payload)
+    return 0 if payload["ready"] else 2
+
+
 def _handle_sdd_download(args: argparse.Namespace) -> int:
     """Handle the sdd-download subcommand."""
     spec = load_sdd_staging_spec(args.manifest)
@@ -2014,6 +2109,7 @@ def main() -> int:
         "sdd-status": _handle_sdd_status,
         "sdd-validate": _handle_sdd_validate,
         "sdd-mode": _handle_sdd_mode,
+        "amv-calibration-status": _handle_amv_calibration_status,
         "sdd-download": _handle_sdd_download,
     }
     try:

--- a/tests/tools/test_manage_external_data_amv_calibration_status.py
+++ b/tests/tools/test_manage_external_data_amv_calibration_status.py
@@ -1,0 +1,78 @@
+"""Tests for AMV calibration admission status in manage_external_data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from scripts.tools.manage_external_data import build_amv_calibration_status
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ISSUE_2415_MANIFEST = (
+    REPO_ROOT / "configs" / "research" / "amv_command_response_trace_manifest_issue_2415.yaml"
+)
+
+
+def _write_manifest_with_status(tmp_path: Path, staging_status: str) -> Path:
+    payload = yaml.safe_load(ISSUE_2415_MANIFEST.read_text(encoding="utf-8"))
+    payload["traces"][0]["staging_status"] = staging_status
+    if staging_status == "staged":
+        payload["traces"][0]["blocker_issues"] = []
+    manifest_path = tmp_path / "amv_trace_manifest.yaml"
+    manifest_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return manifest_path
+
+
+def test_amv_calibration_status_defaults_to_blocked_external_input() -> None:
+    """Issue #2415 currently has no real AMV trace bundle and must fail closed."""
+    report = build_amv_calibration_status()
+
+    assert report["schema"] == "amv_calibration_status.v1"
+    assert report["issue"] == 2415
+    assert report["ready"] is False
+    assert report["blocked_external_input"] is True
+    assert "amv_calibration_asset_missing" in report["blockers"]
+    assert "command_response_trace_manifest_not_ready" in report["blockers"]
+    assert report["asset_status"]["status"] == "missing"
+    assert report["trace_manifest_report"]["manifest_status"] == "blocked-external-input"
+    assert report["trace_manifest_report"]["calibration_ingest_allowed"] is False
+
+
+def test_amv_calibration_status_does_not_admit_asset_without_staged_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A present asset is insufficient while the issue #2415 trace manifest remains blocked."""
+    external_root = tmp_path / "external"
+    amv_bundle = external_root / "amv_calibration"
+    amv_bundle.mkdir(parents=True)
+    (amv_bundle / "source.yaml").write_text("source: maintainer-accepted\n", encoding="utf-8")
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(external_root))
+
+    report = build_amv_calibration_status()
+
+    assert report["asset_status"]["status"] == "available"
+    assert report["ready"] is False
+    assert report["blockers"] == ["command_response_trace_manifest_not_ready"]
+    assert report["trace_manifest_report"]["manifest_status"] == "blocked-external-input"
+
+
+def test_amv_calibration_status_admits_staged_manifest_and_asset(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A staged bundle plus staged manifest is the future calibration-admission condition."""
+    external_root = tmp_path / "external"
+    amv_bundle = external_root / "amv_calibration"
+    amv_bundle.mkdir(parents=True)
+    (amv_bundle / "source.yaml").write_text("source: maintainer-accepted\n", encoding="utf-8")
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(external_root))
+    staged_manifest = _write_manifest_with_status(tmp_path, "staged")
+
+    report = build_amv_calibration_status(staged_manifest)
+
+    assert report["asset_status"]["status"] == "available"
+    assert report["ready"] is True
+    assert report["blocked_external_input"] is False
+    assert report["blockers"] == []
+    assert report["trace_manifest_report"]["manifest_status"] == "ready"
+    assert report["trace_manifest_report"]["calibration_ingest_allowed"] is True


### PR DESCRIPTION
Reviewer-critical summary

What changed: Adds `manage_external_data.py --json amv-calibration-status`, an integrated AMV calibration-path admission report for issue #2415. It combines the live `amv-calibration` external-data asset presence check with the existing command-response trace manifest validator.

Why now: PR #3756 added the issue #2415 manifest preflight; this slice connects that contract to the actual `amv-calibration` external-data path so downstream tooling has one fail-closed status endpoint instead of separate issue-specific checks.

Claim boundary: support/tooling contract only. No real AMV command-response trace was staged, ingested, transformed, or calibrated; no benchmark, paper, dissertation, or hardware-calibrated AMV claim is made.

Required validation: focused CPU tests for the new status builder plus existing issue #2415 manifest tests; Ruff on touched files; CLI smoke for current blocked status.

Remaining blocker: issue #2415 remains `blocked-external-input` until a maintainer-accepted real AMV command-response trace bundle/source exists and is staged locally through `amv-calibration`.

Contract delta

- New CLI: `uv run python scripts/tools/manage_external_data.py --json amv-calibration-status`.
- New JSON schema tag: `amv_calibration_status.v1`.
- New report fields include `ready`, `blocked_external_input`, `blockers`, `asset_status`, `live_staging_status`, `trace_manifest_report`, and an explicit evidence boundary.
- New fail-closed blockers: `amv_calibration_asset_missing` and `command_response_trace_manifest_not_ready`.
- Compatibility impact: additive only; existing `list`, `check`, `stage`, SDD, and provenance commands are unchanged. AMV-specific manifest imports are lazy so generic external-data commands remain lightweight.

<details>
<summary>PR details</summary>

## Summary
Adds an integrated AMV calibration admission-status command to the external-data assistant and tests the blocked/current, asset-only, and fully staged future paths.

## Linked Issues
- Relates to #2415
- Related blockers: #2000, #1585, #1559

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none; builds on already-merged #3756 behavior now present on `origin/main`
- Safe to review independently: yes

## What Changed
- `scripts/tools/manage_external_data.py`: adds `build_amv_calibration_status()` and the `amv-calibration-status` subcommand.
- `tests/tools/test_manage_external_data_amv_calibration_status.py`: verifies fail-closed current state, rejects asset-only admission, and admits only staged asset plus staged manifest.

## Why Matters
- Added value: one canonical external-data path check for whether AMV command-response calibration may ingest staged traces.
- Expected impact: prevents proxy or merely present files from being treated as hardware-calibrated AMV trace evidence.
- Why worth merging now: issue #2415 is hard-blocked on real data, but this makes the eventual admission gate executable and reviewable.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker #2415, real AMV command-response trace admission path.
- Comparator or baseline, applicable: existing issue-specific manifest preflight from #3756.
- Support-tooling proof level: focused CPU tests and CLI smoke only.
- Status classification: support-tooling admission guard; issue remains blocked-external-input.
- Decision stop rule, applicable: status remains non-ready until both asset presence and manifest readiness are true.
- Parent issue, claim map, registry, context note, synthesis surface update: PR body documents state; no new claim-map or benchmark update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper, no interpretation of research evidence.

## Domain-Aware Approval
- Required PR: yes - sensitive wording appears in the issue blocker summary.
- Domains reviewed: external-data staging provenance, AMV calibration admission guard.
- Status: waived for support-tooling only.
- Approver/review source waiver: support-tooling waiver; this PR adds an admission-status guard only and does not change evidence classification, experimental comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claim surfaces.
- Validity checklist: support-tooling only; no benchmark validity claim.
- Target claim/hypothesis: no research claim; blocks/admission state for #2415 only.
- Comparator or split/evidence validity: no comparator or benchmark split; readiness is a local asset-plus-manifest contract.
- Fallback/degraded exclusions: no fallback/degraded benchmark execution is counted as evidence.
- Claim boundary: support-tooling contract only; no trace ingest or calibration run.
- Implementation integrity vs experimental validity: implementation integrity covered by focused tests; experimental validity remains blocked on real AMV trace data.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - support helper.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue only after real external data source exists.
- Follow-up question issue weak, negative, non-transfer results: none.

## Next Empirical Action
- Rerun needed: no campaign rerun from this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: real AMV command-response trace bundle/source remains unavailable.
- Stop / revise / continue decision: continue only if real source collection method becomes available.
- Proposed child issue existing follow-up: keep #2415 blocked under #2000/#1585.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_manage_external_data_amv_calibration_status.py tests/research/test_amv_command_response_trace_manifest.py -q` -> passed, 24 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/manage_external_data.py tests/tools/test_manage_external_data_amv_calibration_status.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/manage_external_data.py --json list` -> passed, clean JSON with 9 assets.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/manage_external_data.py --json amv-calibration-status` -> exit 2 expected for current blocked state; decisive fields: `ready=false`, `blocked_external_input=true`, blockers `amv_calibration_asset_missing,command_response_trace_manifest_not_ready`, manifest status `blocked-external-input`.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance
- Baseline runtime: NA, no hot path or campaign runtime claimed.
- Changed runtime: NA.
- Representative command: `uv run python scripts/tools/manage_external_data.py --json amv-calibration-status`.
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: external-data generic commands emit non-JSON noise, or AMV status admits calibration without both staged asset and ready manifest.

## Risks / Rollout
- Compatibility risks: low, additive CLI subcommand and helper.
- Failure modes: AMV status imports the existing synthetic-actuation vocabulary and may emit existing dependency logs on stderr before JSON on stdout in some environments; generic commands keep lazy behavior.
- Rollback fallback plan: remove subcommand/helper and tests; existing issue-specific manifest checker remains.

## Docs / Provenance
- Updated docs: none; command is discoverable via CLI help and PR body. A direct docs patch was intentionally deferred to keep this slice minimal.
- Relevant design provenance notes: issue #2415, prior #3756 manifest preflight.
- Assumptions preserved: real AMV trace availability is <5% per maintainer decision on 2026-06-22; proxy/synthetic data is not calibrated AMV evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, `comment_issue_or_pr=false` in task authorization; state is propagated in this PR body only.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark, registry, claim-map, or paper-facing evidence changed.

## Follow-Up Issues
- Deferred work: #2415 remains the linked deferred issue for staging real AMV command-response traces if a viable source/collection method appears.
- Issues opened follow-up: none.

## Reviewer Notes
- New capability: integrated `amv-calibration-status` admission endpoint on the external-data path.
- Known limitation: issue #2415 remains blocked; this PR deliberately makes that state executable rather than bypassing it.

</details>
