### PR TITLE
Issue #4165: accept map-runner proxemic ablation rows

### DIFF
--- a/docs/context/issue_4165_state.yaml
+++ b/docs/context/issue_4165_state.yaml
@@ -1,0 +1,32 @@
+issue: 4165
+title: "planner: proxemic costmap layer for classical baseline planners"
+state_surface: "high_churn_issue_state"
+entries:
+  - date_utc: "2026-07-04"
+    slice: "map-runner proxemic ablation report input contract"
+    branch: "issue-4165-closure-audit-verify-acceptance-criteria-of-4165-against-merged-prs-clos"
+    pr_url: "pending"
+    delivered:
+      - "Adds a fail-closed map-runner episode-record adapter for the paired proxemic ablation report."
+      - "Extends the issue-specific report CLI with --input-format map-runner while preserving legacy report-row input."
+      - "Adds focused tests for map-runner source provenance, layer-state mismatch blocking, and CLI report generation."
+    acceptance_audit:
+      - criterion: "Layer parameters configurable."
+        status: "met"
+        evidence: "Merged PR #4185 added configs/planners/proxemic_costmap_v1.yaml and planner config wiring."
+      - criterion: "At least one classical planner can run without the layer."
+        status: "met"
+        evidence: "Merged PR #4185 kept baseline hybrid-rule config and default proxemic layer disabled."
+      - criterion: "Paired report records intrusion, clearance, efficiency, success/collision caveats, and runtime overhead."
+        status: "partially_met"
+        evidence: "Merged PR #4250 added the report builder; PR #4277 added fixture evidence; this slice accepts real map-runner episode records."
+      - criterion: "Default behavior remains unchanged."
+        status: "met"
+        evidence: "Merged PR #4185 made the proxemic layer opt-in; this slice only changes report input handling."
+    remaining:
+      - "Run and attach real paired CPU smoke or campaign rows through the map-runner input contract."
+      - "Rebuild the paired report from those real rows before closing the issue."
+    out_of_scope:
+      - "full benchmark campaign"
+      - "Slurm or GPU submission"
+      - "paper-facing claim update"

--- a/docs/context/issue_4165_state.yaml
+++ b/docs/context/issue_4165_state.yaml
@@ -5,7 +5,7 @@ entries:
   - date_utc: "2026-07-04"
     slice: "map-runner proxemic ablation report input contract"
     branch: "issue-4165-closure-audit-verify-acceptance-criteria-of-4165-against-merged-prs-clos"
-    pr_url: "pending"
+    pr_url: "https://github.com/ll7/robot_sf_ll7/pull/4516"
     delivered:
       - "Adds a fail-closed map-runner episode-record adapter for the paired proxemic ablation report."
       - "Extends the issue-specific report CLI with --input-format map-runner while preserving legacy report-row input."

--- a/robot_sf/benchmark/proxemic_ablation_report.py
+++ b/robot_sf/benchmark/proxemic_ablation_report.py
@@ -22,6 +22,7 @@ REPORT_METRICS = (
     "runtime_seconds",
 )
 REPORT_CAVEATS = ("success", "collision")
+MAP_RUNNER_INPUT_SOURCE = "map_runner_episode_records"
 
 _FIELD_ALIASES: dict[str, tuple[str, ...]] = {
     "intrusion_rate": (
@@ -119,6 +120,124 @@ def load_yaml_file(path: Path) -> dict[str, Any]:
     if not isinstance(loaded, Mapping):
         raise ValueError(f"config must be a YAML mapping: {path}")
     return dict(loaded)
+
+
+def map_runner_records_to_ablation_rows(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    arm: str,
+    expected_proxemic_enabled: bool,
+) -> list[dict[str, Any]]:
+    """Convert real map-runner episode records into paired ablation report rows.
+
+    Raises:
+        ValueError: If a record lacks required map-runner fields or layer-state metadata.
+
+    Returns:
+        Report-row dictionaries accepted by :func:`build_proxemic_ablation_report`.
+    """
+
+    rows: list[dict[str, Any]] = []
+    blockers: list[str] = []
+    for idx, record in enumerate(records):
+        metrics = record.get("metrics")
+        if not isinstance(metrics, Mapping):
+            blockers.append(f"{arm} record {idx} missing map-runner metrics mapping")
+            metrics = {}
+        proxemic_metadata = _proxemic_costmap_metadata(record)
+        if proxemic_metadata is None:
+            blockers.append(f"{arm} record {idx} missing algorithm_metadata proxemic_costmap")
+            proxemic_metadata = {}
+        enabled = proxemic_metadata.get("enabled")
+        if not isinstance(enabled, bool):
+            blockers.append(f"{arm} record {idx} proxemic_costmap.enabled must be boolean")
+        elif enabled is not expected_proxemic_enabled:
+            blockers.append(
+                f"{arm} record {idx} proxemic_costmap.enabled={enabled!r}; "
+                f"expected {expected_proxemic_enabled!r}"
+            )
+        fallback_or_degraded = proxemic_metadata.get("fallback_or_degraded")
+        if fallback_or_degraded is True:
+            blockers.append(f"{arm} record {idx} proxemic metadata marks fallback/degraded")
+
+        rows.append(
+            {
+                "scenario_id": record.get("scenario_id"),
+                "seed": record.get("seed"),
+                "row_status": record.get("status", record.get("row_status", "native")),
+                "metrics": {
+                    "intrusion_rate": _first_present(
+                        metrics,
+                        "intrusion_rate",
+                        "proxemic_intrusion_rate",
+                        "social_space_intrusion_rate",
+                    ),
+                    "minimum_clearance": _first_present(
+                        metrics,
+                        "minimum_clearance",
+                        "min_clearance",
+                        "min_distance",
+                        "clearing_distance_min",
+                    ),
+                    "path_efficiency": _first_present(metrics, "path_efficiency"),
+                    "runtime_seconds": _first_present(
+                        metrics,
+                        "runtime_seconds",
+                        "wall_time_seconds",
+                        "episode_runtime_seconds",
+                        "episode_sec",
+                    ),
+                    "success": _first_present(metrics, "success"),
+                    "collision": _first_present(metrics, "collision", "collisions"),
+                },
+                "source": MAP_RUNNER_INPUT_SOURCE,
+                "algo": record.get("algo"),
+                "proxemic_costmap": dict(proxemic_metadata),
+            }
+        )
+
+    if blockers:
+        raise ValueError("; ".join(blockers))
+    return rows
+
+
+def build_proxemic_ablation_report_from_map_runner_records(
+    *,
+    baseline_records: Sequence[Mapping[str, Any]],
+    proxemic_records: Sequence[Mapping[str, Any]],
+    smoke_config_path: Path,
+    proxemic_config_path: Path,
+    repo_root: Path = Path("."),
+) -> dict[str, Any]:
+    """Build a paired report from fail-closed map-runner episode records.
+
+    Returns:
+        Machine-readable report dictionary.
+    """
+
+    report = build_proxemic_ablation_report(
+        baseline_records=map_runner_records_to_ablation_rows(
+            baseline_records,
+            arm="baseline_classical",
+            expected_proxemic_enabled=False,
+        ),
+        proxemic_records=map_runner_records_to_ablation_rows(
+            proxemic_records,
+            arm="proxemic_costmap_on",
+            expected_proxemic_enabled=True,
+        ),
+        smoke_config_path=smoke_config_path,
+        proxemic_config_path=proxemic_config_path,
+        repo_root=repo_root,
+    )
+    report["claim_boundary"] = "paired_cpu_smoke_report_only"
+    report["input_source"] = {
+        "source": MAP_RUNNER_INPUT_SOURCE,
+        "fail_closed_layer_state": True,
+        "baseline_expected_proxemic_enabled": False,
+        "proxemic_expected_proxemic_enabled": True,
+    }
+    return report
 
 
 def build_proxemic_ablation_report(
@@ -393,6 +512,33 @@ def _mean(values: Iterable[float]) -> float:
     if not value_list:
         return 0.0
     return sum(value_list) / len(value_list)
+
+
+def _proxemic_costmap_metadata(record: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    algorithm_metadata = record.get("algorithm_metadata")
+    if not isinstance(algorithm_metadata, Mapping):
+        return None
+    direct = algorithm_metadata.get("proxemic_costmap")
+    if isinstance(direct, Mapping):
+        return direct
+    planner_runtime = algorithm_metadata.get("planner_runtime")
+    if isinstance(planner_runtime, Mapping):
+        proxemic_runtime = planner_runtime.get("proxemic_costmap")
+        if isinstance(proxemic_runtime, Mapping):
+            return proxemic_runtime
+    last_decision = algorithm_metadata.get("last_decision")
+    if isinstance(last_decision, Mapping):
+        proxemic_decision = last_decision.get("proxemic_costmap")
+        if isinstance(proxemic_decision, Mapping):
+            return proxemic_decision
+    return None
+
+
+def _first_present(record: Mapping[str, Any], *fields: str) -> Any | None:
+    for field in fields:
+        if field in record:
+            return record[field]
+    return None
 
 
 def _safe_ratio(numerator: float, denominator: float) -> float:

--- a/scripts/benchmark/build_proxemic_layer_ablation_report_issue_4165.py
+++ b/scripts/benchmark/build_proxemic_layer_ablation_report_issue_4165.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from robot_sf.benchmark.proxemic_ablation_report import (
     build_proxemic_ablation_report,
+    build_proxemic_ablation_report_from_map_runner_records,
     load_records,
     write_report_artifacts,
 )
@@ -23,6 +24,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--baseline-episodes", type=Path, required=True)
     parser.add_argument("--proxemic-episodes", type=Path, required=True)
+    parser.add_argument(
+        "--input-format",
+        choices=("report-rows", "map-runner"),
+        default="report-rows",
+        help=(
+            "Use 'map-runner' for real robot_sf.benchmark.map_runner episode records; "
+            "default keeps the legacy generic report-row input contract."
+        ),
+    )
     parser.add_argument("--smoke-config", type=Path, default=DEFAULT_SMOKE_CONFIG)
     parser.add_argument("--proxemic-config", type=Path, default=DEFAULT_PROXEMIC_CONFIG)
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
@@ -34,13 +44,24 @@ def main(argv: list[str] | None = None) -> int:
     """Run the report builder."""
 
     args = parse_args(argv)
-    report = build_proxemic_ablation_report(
-        baseline_records=load_records(args.baseline_episodes),
-        proxemic_records=load_records(args.proxemic_episodes),
-        smoke_config_path=args.smoke_config,
-        proxemic_config_path=args.proxemic_config,
-        repo_root=args.repo_root,
-    )
+    baseline_records = load_records(args.baseline_episodes)
+    proxemic_records = load_records(args.proxemic_episodes)
+    if args.input_format == "map-runner":
+        report = build_proxemic_ablation_report_from_map_runner_records(
+            baseline_records=baseline_records,
+            proxemic_records=proxemic_records,
+            smoke_config_path=args.smoke_config,
+            proxemic_config_path=args.proxemic_config,
+            repo_root=args.repo_root,
+        )
+    else:
+        report = build_proxemic_ablation_report(
+            baseline_records=baseline_records,
+            proxemic_records=proxemic_records,
+            smoke_config_path=args.smoke_config,
+            proxemic_config_path=args.proxemic_config,
+            repo_root=args.repo_root,
+        )
     write_report_artifacts(report, args.output_dir)
     print(args.output_dir / "summary.json")
     return 1 if report["report_status"] == "blocked" else 0

--- a/tests/benchmark/test_proxemic_ablation_report_issue_4165.py
+++ b/tests/benchmark/test_proxemic_ablation_report_issue_4165.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 
@@ -9,7 +10,9 @@ import pytest
 
 from robot_sf.benchmark.proxemic_ablation_report import (
     build_proxemic_ablation_report,
+    build_proxemic_ablation_report_from_map_runner_records,
     load_records,
+    map_runner_records_to_ablation_rows,
     write_report_artifacts,
 )
 
@@ -151,6 +154,155 @@ def test_checked_in_fixture_matches_report_contract() -> None:
     assert report["parameter_provenance"]["proxemic_config"]["sha256"]
 
 
+def test_builds_report_from_map_runner_episode_records(tmp_path: Path) -> None:
+    """Map-runner episode rows feed paired delta report with fail-closed provenance."""
+
+    smoke_config, proxemic_config = _write_configs(tmp_path)
+    baseline_records = [
+        _map_runner_record(
+            "crossing_easy",
+            1,
+            proxemic_enabled=False,
+            intrusion_rate=0.30,
+            clearance=0.55,
+            efficiency=0.80,
+            runtime=1.0,
+        )
+    ]
+    proxemic_records = [
+        _map_runner_record(
+            "crossing_easy",
+            1,
+            proxemic_enabled=True,
+            intrusion_rate=0.20,
+            clearance=0.70,
+            efficiency=0.78,
+            runtime=1.1,
+        )
+    ]
+
+    report = build_proxemic_ablation_report_from_map_runner_records(
+        baseline_records=baseline_records,
+        proxemic_records=proxemic_records,
+        smoke_config_path=smoke_config.relative_to(tmp_path),
+        proxemic_config_path=proxemic_config.relative_to(tmp_path),
+        repo_root=tmp_path,
+    )
+
+    assert report["report_status"] == "ready"
+    assert report["claim_boundary"] == "paired_cpu_smoke_report_only"
+    assert report["input_source"]["source"] == "map_runner_episode_records"
+    assert report["deltas"]["intrusion_rate_delta"] == pytest.approx(-0.1)
+
+
+def test_map_runner_rows_fail_closed_on_wrong_layer_state() -> None:
+    """Baseline/proxemic arm state mismatches are blocked before reporting."""
+
+    with pytest.raises(ValueError, match="expected False"):
+        map_runner_records_to_ablation_rows(
+            [_map_runner_record("crossing_easy", 1, proxemic_enabled=True)],
+            arm="baseline_classical",
+            expected_proxemic_enabled=False,
+        )
+
+
+def test_map_runner_rows_fail_closed_on_malformed_records() -> None:
+    """Malformed map-runner rows report all source-contract blockers."""
+
+    fallback = _map_runner_record("crossing_easy", 1, proxemic_enabled=True)
+    fallback["algorithm_metadata"]["last_decision"]["proxemic_costmap"]["fallback_or_degraded"] = (
+        True
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        map_runner_records_to_ablation_rows(
+            [
+                {"scenario_id": "missing-everything", "seed": 1},
+                {
+                    "scenario_id": "bad-enabled",
+                    "seed": 2,
+                    "metrics": {},
+                    "algorithm_metadata": {"proxemic_costmap": {"enabled": "yes"}},
+                },
+                fallback,
+            ],
+            arm="proxemic_costmap_on",
+            expected_proxemic_enabled=True,
+        )
+
+    message = str(excinfo.value)
+    assert "missing map-runner metrics mapping" in message
+    assert "missing algorithm_metadata proxemic_costmap" in message
+    assert "proxemic_costmap.enabled must be boolean" in message
+    assert "fallback/degraded" in message
+
+
+def test_map_runner_rows_accept_direct_and_runtime_proxemic_metadata() -> None:
+    """Map-runner adapter accepts known proxemic metadata locations."""
+
+    direct = _map_runner_record("crossing_easy", 1, proxemic_enabled=True)
+    direct["algorithm_metadata"]["proxemic_costmap"] = direct["algorithm_metadata"].pop(
+        "last_decision"
+    )["proxemic_costmap"]
+    runtime = _map_runner_record("crossing_hard", 2, proxemic_enabled=True)
+    runtime["algorithm_metadata"]["planner_runtime"] = runtime["algorithm_metadata"].pop(
+        "last_decision"
+    )
+
+    rows = map_runner_records_to_ablation_rows(
+        [direct, runtime],
+        arm="proxemic_costmap_on",
+        expected_proxemic_enabled=True,
+    )
+
+    assert [row["source"] for row in rows] == [
+        "map_runner_episode_records",
+        "map_runner_episode_records",
+    ]
+    assert rows[0]["proxemic_costmap"]["enabled"] is True
+    assert rows[1]["proxemic_costmap"]["enabled"] is True
+
+
+def test_cli_builds_map_runner_input_report(tmp_path: Path) -> None:
+    """Issue CLI supports real map-runner episode JSONL input."""
+
+    smoke_config, proxemic_config = _write_configs(tmp_path)
+    baseline_path = tmp_path / "baseline.jsonl"
+    proxemic_path = tmp_path / "proxemic.jsonl"
+    baseline_path.write_text(
+        json.dumps(_map_runner_record("crossing_easy", 1, proxemic_enabled=False)) + "\n",
+        encoding="utf-8",
+    )
+    proxemic_path.write_text(
+        json.dumps(_map_runner_record("crossing_easy", 1, proxemic_enabled=True)) + "\n",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "report"
+
+    exit_code = _report_main(
+        [
+            "--baseline-episodes",
+            str(baseline_path),
+            "--proxemic-episodes",
+            str(proxemic_path),
+            "--input-format",
+            "map-runner",
+            "--smoke-config",
+            str(smoke_config.relative_to(tmp_path)),
+            "--proxemic-config",
+            str(proxemic_config.relative_to(tmp_path)),
+            "--repo-root",
+            str(tmp_path),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    summary = json.loads((output_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["input_source"]["fail_closed_layer_state"] is True
+
+
 def _row(
     scenario_id: str,
     seed: int,
@@ -175,6 +327,55 @@ def _row(
             "collisions": 0,
         },
     }
+
+
+def _map_runner_record(
+    scenario_id: str,
+    seed: int,
+    *,
+    proxemic_enabled: bool,
+    intrusion_rate: float = 0.30,
+    clearance: float = 0.55,
+    efficiency: float = 0.80,
+    runtime: float = 1.0,
+) -> dict:
+    return {
+        "scenario_id": scenario_id,
+        "seed": seed,
+        "status": "completed",
+        "algo": "hybrid_rule_local_planner",
+        "metrics": {
+            "social_space_intrusion_rate": intrusion_rate,
+            "min_clearance": clearance,
+            "path_efficiency": efficiency,
+            "episode_sec": runtime,
+            "success": True,
+            "collision": False,
+        },
+        "algorithm_metadata": {
+            "last_decision": {
+                "proxemic_costmap": {
+                    "enabled": proxemic_enabled,
+                    "status": "ok" if proxemic_enabled else "disabled",
+                    "config_hash": "unit-test-hash",
+                    "fallback_or_degraded": False,
+                    "soft_cost_only": True,
+                }
+            }
+        },
+    }
+
+
+def _report_main(argv: list[str]) -> int:
+    script_path = (
+        _REPO_ROOT / "scripts/benchmark/build_proxemic_layer_ablation_report_issue_4165.py"
+    )
+    spec = importlib.util.spec_from_file_location("issue_4165_proxemic_report_cli", script_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.main(argv)
 
 
 def _write_configs(tmp_path: Path) -> tuple[Path, Path]:


### PR DESCRIPTION
Reviewer-critical summary

What changed: this PR adds a fail-closed map-runner episode-record input path for the issue #4165 paired proxemic ablation report, plus CLI/tests and a single high-churn issue-state surface.

Why now: the live #4165 thread shows PR #4185 delivered the opt-in proxemic layer and planner/config tests, PR #4250 delivered the paired report builder, and PR #4277 delivered fixture evidence, but real paired smoke/campaign rows remained open. This slice does not run a campaign; it creates the missing contract for real map-runner rows to become the report input.

Claim boundary: CPU smoke/report integration only. It does not close #4165 and does not promote benchmark, paper, or dissertation claims.

Required validation: focused #4165 report tests, Ruff check/format on touched Python files, YAML parse for the new state surface, and final PR readiness wrapper.

Remaining blocker: run real paired CPU smoke or campaign rows through `--input-format map-runner`, rebuild the paired report, and then close #4165 only if the report is ready.

Issue: Refs #4165

Contract delta

- New report helper: `build_proxemic_ablation_report_from_map_runner_records(...)` converts paired `robot_sf.benchmark.map_runner` episode records into the existing report-row contract.
- New fail-closed blockers: map-runner inputs must include `metrics`, proxemic layer metadata, boolean `proxemic_costmap.enabled`, expected baseline/proxemic enabled state, and no proxemic fallback/degraded marker.
- New CLI option: `scripts/benchmark/build_proxemic_layer_ablation_report_issue_4165.py --input-format map-runner` uses the new map-runner input contract; default `report-rows` preserves existing fixture/report-row compatibility.
- Compatibility impact: existing generic report-row inputs remain supported and unchanged.

Acceptance evidence

| Criterion | Evidence | Status |
| --- | --- | --- |
| Layer parameters configurable | PR #4185 added `configs/planners/proxemic_costmap_v1.yaml` and planner config wiring. | Met |
| At least one classical planner can run without the layer | PR #4185 kept the baseline hybrid-rule config and default proxemic layer disabled. | Met |
| Paired report records intrusion, clearance, efficiency, success/collision caveats, runtime overhead | PR #4250 added the report builder; PR #4277 added fixture evidence; this PR adds real map-runner row ingestion for that report. | Partially met |
| Default behavior remains unchanged | PR #4185 made the proxemic layer opt-in; this PR only changes report input handling. | Met |

Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_proxemic_ablation_report_issue_4165.py -q` -> passed, 8 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/proxemic_ablation_report.py scripts/benchmark/build_proxemic_layer_ablation_report_issue_4165.py tests/benchmark/test_proxemic_ablation_report_issue_4165.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/proxemic_ablation_report.py scripts/benchmark/build_proxemic_layer_ablation_report_issue_4165.py tests/benchmark/test_proxemic_ablation_report_issue_4165.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python - <<'PY' ... yaml.safe_load('docs/context/issue_4165_state.yaml') ... PY` -> passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr4165_body.md scripts/dev/pr_ready_check.sh` -> passed; stamp `output/validation/pr_ready/issue-4165-closure-audit-verify-acceptance-criteria-of-4165-against-merged-prs-clos.json` for code commit `4fc194f6737d85696d49b5161b77045055b98747`.
- `uv run python - <<'PY' ... yaml.safe_load('docs/context/issue_4165_state.yaml') ... PY` -> passed on final head `54a394a86` after recording the PR URL.

## Follow-Up Issues

Deferred work: Real paired CPU smoke or campaign rows plus rebuilt report evidence are still required before #4165 can close.

Issues opened follow-up: #4165 remains open for that empirical evidence step.

Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No issue close; #4165 still needs real paired rows and rebuilt report evidence.

<details>
<summary>Governance and freshness notes</summary>

- Full issue thread and comments were read via GitHub API after `gh issue view` failed on a deprecated classic Projects GraphQL field.
- Late-guidance check immediately before PR prep found no comments newer than start time (`2026-07-04T21:58:25Z`).
- Open PR dedupe found no open PR covering #4165 or this exact proxemic ablation integration scope.
- Fragmentation guard: three #4165 PRs are already merged, so this is an integration contract slice rather than another fixture/checker-only micro-guard.
- State propagation: high-churn issue state is recorded in `docs/context/issue_4165_state.yaml`; no issue comment was posted because issue/PR commenting is not authorized for this run.
- Forbidden actions: no compute submission, merge, release, or deletion.

</details>
