### PR TITLE
Issue #4291: add traversible tree checksum closure audit

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -17,6 +17,10 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+  - path: docs/context/evidence/issue_4291_closure_audit_2026-07-04.md
+    status: evidence
+    freshness: evidence
+    area: data_staging
   - path: docs/context/evidence/issue_4164_closure_audit_2026-07-04.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_4291_closure_audit_2026-07-04.md
+++ b/docs/context/evidence/issue_4291_closure_audit_2026-07-04.md
@@ -1,0 +1,42 @@
+# Issue #4291 Closure Audit
+
+Date: 2026-07-04
+
+Issue: [#4291](https://github.com/ll7/robot_sf_ll7/issues/4291)
+
+Merged implementation PR: [#4296](https://github.com/ll7/robot_sf_ll7/pull/4296)
+
+Plain-language summary: issue #4291 asked for a reproducible way to generate the missing
+SocNavBench ETH traversible file from staged local mesh data. PR #4296 delivered the generator,
+tests, and runbook. The issue should not be treated as fully closed by repository code alone
+because the live maintainer comment keeps it open for the data-side publication step: run the
+real mesh build in the SocNavBench environment, re-seed the internal store, and update the
+external-data registry pin.
+
+SocNavBench means Social Navigation Benchmark. ETH is the ETH pedestrian map from that dataset
+family.
+
+## Acceptance Criteria Evidence
+
+| Criterion from #4291 | Evidence | Closure status |
+| --- | --- | --- |
+| Add `scripts/tools/generate_socnavbench_traversible.py` or extend the existing wrapper so staged ETH mesh data can produce `traversibles/<MAP>/data.pkl` in the data root, never in git. | PR #4296 added `scripts/tools/generate_socnavbench_traversible.py`. Its PR body states the wrapper builds `traversibles/<MAP>/data.pkl` from staged per-map mesh and writes into the data root. The durable context note records the same contract in `docs/context/issue_4291_socnavbench_traversible_generation.md`. | Met by PR #4296. |
+| Print a tree hash so the registry pin can be updated after the trusted generated artifact exists. | This PR adds `output_tree_sha256`, `output_tree_file_count`, and `output_tree_total_size_bytes` to generator reports for existing and newly generated `data.pkl` outputs, with tests in `tests/tools/test_generate_socnavbench_traversible.py`. The post-merge state surface `docs/context/issue_1498_state.yaml` records generated ETH `data.pkl` size and SHA-256, plus `manage_external_data.py check socnavbench-s3dis-eth` and `validate_socnav_map_batch.py --batch-id eth_first --preflight` ready status. | Code-report gap closed by this PR; trusted registry publication remains maintainer-owned. |
+| Provide skip-if-absent smoke behavior: fail clearly when the mesh is not staged, and support `--dry-run` without building. | PR #4296 added `tests/tools/test_generate_socnavbench_traversible.py`; its PR body records `uv run pytest tests/tools/test_generate_socnavbench_traversible.py -q` with 17 passing tests and a `--dry-run` smoke returning `blocked_missing_mesh`, exit 2, on a host without staged mesh. | Met by PR #4296. |
+| Document the generation command, expected output path, and derived-data policy. | PR #4296 updated `docs/socnav_assets_setup.md` section 7 and added `docs/context/issue_4291_socnavbench_traversible_generation.md`. The note says generated traversibles are derived data, stay in the data root, and must not be committed. | Met by PR #4296. |
+| Do not run generation in continuous integration and do not commit generated artifacts. | PR #4296 body states no generation was run and no artifact was committed. The tracked changes are the tool, tests, docs, and changelog only. | Met by PR #4296. |
+| Keep actual internal run, hub re-seed, and registry hash update as maintainer post-merge work. | The live issue comment dated 2026-07-03 says PR #4296 merged and keeps #4291 open for the real mesh-based build, internal store re-seed, and external-data registry pin update. `docs/context/issue_1498_state.yaml` records local generated-file evidence, but `configs/maps/socnavbench_import_batches.yaml` still marks source checksums as `pending_official_asset_staging`, and `scripts/tools/manage_external_data.py` still carries no pinned `expected_tree_sha256` for `socnavbench-s3dis-eth`. | Not fully closed by this PR-only lane. Remaining action is maintainer data publication, not another code guard. |
+
+## Current Closure Decision
+
+Do not create another broad generator or checker micro-slice for #4291. PR #4296 delivered the
+generator; this closure slice only adds the missing output-tree checksum report and evidence table.
+The only remaining blocker is the data-side publication state:
+
+1. Confirm the generated ETH traversible from the trusted SocNavBench environment.
+2. Re-seed the internal store.
+3. Pin or otherwise record the trusted external-data registry checksum.
+4. Re-run the ETH-first map conversion preflight and proceed with issue #1134 when ready.
+
+This audit did not run a full benchmark campaign, submit Slurm or GPU work, edit paper or
+dissertation claims, or commit generated SocNavBench data.

--- a/scripts/tools/generate_socnavbench_traversible.py
+++ b/scripts/tools/generate_socnavbench_traversible.py
@@ -37,8 +37,9 @@ Run the actual generation (maintainer step, SocNavBench environment with staged 
 
     uv run python scripts/tools/generate_socnavbench_traversible.py --map ETH
 
-The build prints the SHA-256 of the produced ``data.pkl`` so the external-data registry
-pin can be updated after the maintainer re-seeds the internal store.
+The build prints the SHA-256 of the produced ``data.pkl`` plus registry-style output
+tree checksum metadata so the external-data registry pin can be updated after the
+maintainer re-seeds the internal store.
 """
 
 from __future__ import annotations
@@ -132,6 +133,31 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def output_tree_checksum(paths: TraversiblePaths) -> dict[str, Any]:
+    """Return registry-style checksum metadata for the generated traversible output tree."""
+    if not paths.output_pkl.is_file():
+        return {
+            "output_tree_sha256": None,
+            "output_tree_file_count": 0,
+            "output_tree_total_size_bytes": 0,
+        }
+    file_sha = sha256_file(paths.output_pkl)
+    size = paths.output_pkl.stat().st_size
+    rel = paths.output_pkl.relative_to(paths.traversible_dir).as_posix()
+    digest = hashlib.sha256()
+    digest.update(rel.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(str(size).encode("ascii"))
+    digest.update(b"\0")
+    digest.update(file_sha.encode("ascii"))
+    digest.update(b"\0")
+    return {
+        "output_tree_sha256": digest.hexdigest(),
+        "output_tree_file_count": 1,
+        "output_tree_total_size_bytes": size,
+    }
+
+
 def preflight(map_name: str, *, root: Path | None = None) -> dict[str, Any]:
     """Inspect staged inputs and existing output for one map without building anything.
 
@@ -180,6 +206,7 @@ def preflight(map_name: str, *, root: Path | None = None) -> dict[str, Any]:
     if output_exists:
         # Surface the current pin so callers can compare before/after a --force rebuild.
         report["output_sha256"] = sha256_file(paths.output_pkl)
+        report.update(output_tree_checksum(paths))
     return report
 
 
@@ -248,11 +275,12 @@ def _build_socnav_traversible(paths: TraversiblePaths) -> None:  # pragma: no co
 def build_traversible(
     map_name: str, *, root: Path | None = None, force: bool = False
 ) -> dict[str, Any]:
-    """Build the traversible for one map, failing closed on missing inputs.
+    """Build traversible one map, failing closed on missing inputs.
 
-    Returns a report dict including the SHA-256 of the produced ``data.pkl`` so the
-    external-data registry pin can be updated. Raises :class:`TraversibleGenerationError`
-    if the mesh is not staged or if the build does not produce the expected output.
+    Returns report dict including SHA-256 produced ``data.pkl`` and registry-style output
+    tree checksum metadata so external-data registry pin can be updated. Raises
+    :class:`TraversibleGenerationError` if mesh is not staged or the build does not
+    produce expected output.
     """
     paths = resolve_paths(map_name, root=root)
     if not _mesh_is_staged(paths.mesh_dir):
@@ -269,6 +297,7 @@ def build_traversible(
             "status": STATUS_ALREADY_PRESENT,
             "built": False,
             "output_sha256": sha256_file(paths.output_pkl),
+            **output_tree_checksum(paths),
         }
 
     if force and paths.output_pkl.is_file():
@@ -288,6 +317,7 @@ def build_traversible(
         "status": "generated",
         "built": True,
         "output_sha256": sha256_file(paths.output_pkl),
+        **output_tree_checksum(paths),
     }
 
 

--- a/tests/tools/test_generate_socnavbench_traversible.py
+++ b/tests/tools/test_generate_socnavbench_traversible.py
@@ -8,6 +8,7 @@ imported by any of these paths.
 
 from __future__ import annotations
 
+import hashlib
 from typing import TYPE_CHECKING
 
 import pytest
@@ -23,6 +24,7 @@ from scripts.tools.generate_socnavbench_traversible import (
     TraversibleGenerationError,
     build_traversible,
     main,
+    output_tree_checksum,
     preflight,
     resolve_paths,
     sha256_file,
@@ -50,6 +52,19 @@ def _stage_mesh(root: Path, map_name: str = "ETH") -> Path:
 def _output_pkl(root: Path, map_name: str = "ETH") -> Path:
     """Return the traversible output path for a map under a synthetic external data root."""
     return root / SOCNAV_SUBPATH / DATASET_SUBPATH / "traversibles" / map_name / "data.pkl"
+
+
+def _expected_single_file_tree_hash(path: Path, *, root: Path) -> str:
+    """Return the registry-style tree hash for one file under root."""
+    file_sha = sha256_file(path)
+    digest = hashlib.sha256()
+    digest.update(path.relative_to(root).as_posix().encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(str(path.stat().st_size).encode("ascii"))
+    digest.update(b"\0")
+    digest.update(file_sha.encode("ascii"))
+    digest.update(b"\0")
+    return digest.hexdigest()
 
 
 def test_resolve_paths_uses_expected_layout(tmp_path: Path) -> None:
@@ -95,7 +110,7 @@ def test_preflight_ready_when_mesh_staged(tmp_path: Path) -> None:
 
 
 def test_preflight_already_present_reports_hash(tmp_path: Path) -> None:
-    """An existing output is reported as already-present with its content hash."""
+    """An existing output reports file and registry-style tree hashes."""
     _stage_mesh(tmp_path)
     out = _output_pkl(tmp_path)
     out.parent.mkdir(parents=True)
@@ -104,6 +119,19 @@ def test_preflight_already_present_reports_hash(tmp_path: Path) -> None:
     assert report["status"] == STATUS_ALREADY_PRESENT
     assert report["output_exists"] is True
     assert report["output_sha256"] == sha256_file(out)
+    assert report["output_tree_sha256"] == _expected_single_file_tree_hash(out, root=out.parent)
+    assert report["output_tree_file_count"] == 1
+    assert report["output_tree_total_size_bytes"] == len(b"fake-traversible")
+
+
+def test_output_tree_checksum_missing_output_reports_empty_tree(tmp_path: Path) -> None:
+    """Missing output yields explicit empty-tree metadata."""
+    paths = resolve_paths("ETH", root=tmp_path)
+    assert output_tree_checksum(paths) == {
+        "output_tree_sha256": None,
+        "output_tree_file_count": 0,
+        "output_tree_total_size_bytes": 0,
+    }
 
 
 def test_dry_run_absent_mesh_exits_blocked(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
@@ -160,3 +188,4 @@ def test_build_traversible_idempotent_when_output_present(tmp_path: Path) -> Non
     assert report["status"] == STATUS_ALREADY_PRESENT
     assert report["built"] is False
     assert report["output_sha256"] == sha256_file(out)
+    assert report["output_tree_sha256"] == _expected_single_file_tree_hash(out, root=out.parent)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds `output_tree_sha256`, `output_tree_file_count`, and `output_tree_total_size_bytes` to `generate_socnavbench_traversible.py` reports for existing and newly generated SocNavBench ETH `data.pkl` outputs, plus focused tests, a closure-audit evidence note, and catalog registration for that evidence file.
- **Why now:** Issue #4291 was mostly covered by merged PR #4296, but the issue acceptance text asked for a tree hash for registry pinning. PR #4296 reported only the produced file SHA-256, so this closes the smallest remaining code-report gap and maps all criteria to evidence.
- **Claim boundary:** Tooling/report metadata and closure audit only. No generated SocNavBench data is committed; no real mesh build or registry publication is claimed.
- **Required validation:** Focused generator tests, Ruff check/format, diff check, and CLI dry-run smoke listed below.
- **Remaining blocker:** Maintainer-only data publication remains: run the real mesh build in the trusted SocNavBench environment, re-seed the internal store, pin/update the external-data registry checksum, then proceed with #1134.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4291

## Contract delta

- **New report fields:** `output_tree_sha256`, `output_tree_file_count`, `output_tree_total_size_bytes`.
- **Checksum policy:** deterministic registry-style aggregate over the generated traversible output tree's relative path, byte size, and file SHA-256. Current output tree is the single `data.pkl` under `traversibles/<MAP>/`.
- **Fail-closed behavior:** unchanged. Missing mesh still exits blocked; build still refuses to claim success unless `data.pkl` exists.
- **Compatibility impact:** additive JSON fields only. Existing `output_sha256`, status values, exit codes, and paths are unchanged.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format scripts/tools/generate_socnavbench_traversible.py tests/tools/test_generate_socnavbench_traversible.py` -> 2 files left unchanged
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/generate_socnavbench_traversible.py tests/tools/test_generate_socnavbench_traversible.py` -> All checks passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_generate_socnavbench_traversible.py -q` -> 18 passed
- `git diff --check` -> pass
- `python scripts/dev/check_docs_evidence_integrity.py --base-ref origin/main` -> 4 changed file(s) passed
- CLI smoke with staged synthetic mesh/output and `--dry-run --report-json` -> `output_tree_sha256` present, `output_tree_file_count == 1`, `output_tree_total_size_bytes == 16`

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no real SocNavBench mesh build, no internal-store reseed, no registry pin publication, no paper/dissertation claim edits.

<details>
<summary>Closure audit and governance</summary>

- Acceptance evidence table: `docs/context/evidence/issue_4291_closure_audit_2026-07-04.md`, registered in `docs/context/catalog.yaml`.
- Late guidance check: re-read issue #4291 comments immediately before PR preparation; no comments newer than this run. Latest maintainer comment remains 2026-07-03T13:54:55Z and is incorporated.
- Dedupe check: no open PR found for #4291 / SocNavBench ETH traversible / `output_tree_sha256`; only merged #4296 covers the original generator slice.
- Fragmentation guard: only one #4291 PR (#4296) merged in the last 24h, so the two-PR guardrail does not block this small closure slice.
- State propagation: no issue comment posted because this lane has `comment_issue_or_pr: false`; this PR body plus the tracked closure-audit note are the durable state surface.
- No target-host, queue-routing, packet-lineage, or private ops state is encoded in tracked files.

</details>
