### PR TITLE
Issue #4232: add diagnostic uncertainty-envelope alpha sweep runner

### DIFF
--- a/configs/benchmarks/issue_4232_uncertainty_envelope_claim_packet.yaml
+++ b/configs/benchmarks/issue_4232_uncertainty_envelope_claim_packet.yaml
@@ -21,6 +21,16 @@ execution_boundary:
   local_submission_allowed: false
   slurm_job_id: not_submitted
   target_host: not_applicable
+diagnostic_runner:
+  path: scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py
+  phase: diagnostic-smoke
+  default_output_dir: output/issue_4232_uncertainty_envelope_diagnostic_smoke
+  default_row_status: diagnostic_only
+  claim_boundary: >-
+    CPU-local diagnostic smoke runner only. Outputs are ignored by default and
+    remain ineligible for benchmark-strength, paper, dissertation, conformal,
+    deployment, or real-world safety claims unless a later reviewed evidence PR
+    explicitly promotes bounded claim support.
 claim_modes:
   allowed_after_evidence:
     - diagnostic_alpha_effect

--- a/scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py
+++ b/scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Run the issue #4232 CPU diagnostic uncertainty-envelope alpha sweep.
+
+This runner executes a bounded local diagnostic slice from the pre-registered
+#4232 packet, converts episode JSONL into the compact evidence-builder input
+format, and then writes the compact review bundle. It does not submit compute,
+does not run the full benchmark campaign by default, and marks local smoke rows
+as diagnostic-only unless the caller explicitly opts into benchmark-strength row
+status handling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import math
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark import map_runner
+from robot_sf.benchmark.runner import load_scenario_matrix
+from scripts.validation import build_issue_4232_uncertainty_envelope_evidence as evidence_builder
+from scripts.validation import check_issue_4232_uncertainty_envelope_claim_packet as packet_checker
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PACKET = REPO_ROOT / "configs/benchmarks/issue_4232_uncertainty_envelope_claim_packet.yaml"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "output/issue_4232_uncertainty_envelope_diagnostic_smoke"
+DEFAULT_SCHEMA = REPO_ROOT / "robot_sf/benchmark/schemas/episode.schema.v1.json"
+DEFAULT_PHASE = "diagnostic-smoke"
+DEFAULT_ALPHA_ARMS = (
+    "envelope_off_alpha_0",
+    "envelope_on_alpha_0",
+    "envelope_on_alpha_0p10",
+)
+
+
+class DiagnosticRunError(ValueError):
+    """Raised when the issue #4232 diagnostic run cannot be trusted."""
+
+
+def _repo_relative(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def _load_packet(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise DiagnosticRunError("packet must be a YAML mapping")
+    packet_checker.validate_packet(payload, repo_root=REPO_ROOT)
+    return payload
+
+
+def _mapping_sequence(value: Any, *, field: str) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise DiagnosticRunError(f"{field} must be a sequence")
+    rows: list[dict[str, Any]] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise DiagnosticRunError(f"{field}[{index}] must be a mapping")
+        rows.append(dict(item))
+    if not rows:
+        raise DiagnosticRunError(f"{field} must not be empty")
+    return rows
+
+
+def _select_by_key(
+    rows: Sequence[Mapping[str, Any]], *, keys: Sequence[str], field: str
+) -> list[dict[str, Any]]:
+    by_key = {str(row.get("key") or row.get("planner_id")): dict(row) for row in rows}
+    selected: list[dict[str, Any]] = []
+    missing = [key for key in keys if key not in by_key]
+    if missing:
+        raise DiagnosticRunError(f"unknown {field}: {', '.join(missing)}")
+    for key in keys:
+        selected.append(by_key[key])
+    return selected
+
+
+def _scenario_identifier(scenario: Mapping[str, Any], index: int) -> str:
+    for key in ("id", "scenario_id", "name"):
+        value = scenario.get(key)
+        if value:
+            return str(value)
+    return f"scenario_{index}"
+
+
+def _scenario_family(scenario: Mapping[str, Any], scenario_id: str) -> str:
+    metadata = scenario.get("metadata")
+    if isinstance(metadata, Mapping):
+        for key in ("scenario_family", "family"):
+            value = metadata.get(key)
+            if value:
+                return str(value)
+    return str(scenario.get("scenario_family") or scenario.get("family") or scenario_id)
+
+
+def _diagnostic_scenarios(
+    packet: Mapping[str, Any],
+    *,
+    max_scenarios: int,
+    max_seeds: int,
+) -> list[dict[str, Any]]:
+    surface = packet["scenario_surface"]
+    matrix_path = REPO_ROOT / str(surface["matrix_path"])
+    scenarios = _mapping_sequence(load_scenario_matrix(matrix_path), field="scenario matrix")
+    seeds = list(packet["seed_policy"]["seeds"])[:max_seeds]
+    if not seeds:
+        raise DiagnosticRunError("diagnostic seed slice is empty")
+
+    selected: list[dict[str, Any]] = []
+    for index, scenario in enumerate(scenarios[:max_scenarios]):
+        copied = copy.deepcopy(scenario)
+        scenario_id = _scenario_identifier(copied, index)
+        copied.setdefault("id", scenario_id)
+        copied.setdefault("name", scenario_id)
+        copied.setdefault("metadata", {})
+        if isinstance(copied["metadata"], dict):
+            copied["metadata"].setdefault(
+                "issue_4232_scenario_family", _scenario_family(copied, scenario_id)
+            )
+        copied["seeds"] = [int(seed) for seed in seeds]
+        sim_config = dict(copied.get("simulation_config") or {})
+        sim_config["max_episode_steps"] = int(surface["max_episode_steps"])
+        copied["simulation_config"] = sim_config
+        selected.append(copied)
+    if not selected:
+        raise DiagnosticRunError("diagnostic scenario slice is empty")
+    return selected
+
+
+def _arm_scenario(base_scenario: Mapping[str, Any], arm: Mapping[str, Any]) -> dict[str, Any]:
+    scenario = copy.deepcopy(dict(base_scenario))
+    arm_key = str(arm["key"])
+    base_name = str(scenario.get("name") or scenario.get("id") or "scenario")
+    scenario["name"] = f"{base_name}__issue4232__{arm_key}"
+    scenario["issue_4232_alpha_arm_key"] = arm_key
+    scenario.setdefault("metadata", {})
+    if isinstance(scenario["metadata"], dict):
+        scenario["metadata"]["issue_4232_alpha_arm_key"] = arm_key
+    sim_config = dict(scenario.get("simulation_config") or {})
+    sim_config["pedestrian_uncertainty_envelope_enabled"] = bool(
+        arm["pedestrian_uncertainty_envelope_enabled"]
+    )
+    sim_config["pedestrian_uncertainty_alpha_mps"] = float(arm["pedestrian_uncertainty_alpha_mps"])
+    sim_config["max_episode_steps"] = int(arm["max_episode_steps"])
+    scenario["simulation_config"] = sim_config
+    return scenario
+
+
+def _jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        raise DiagnosticRunError(f"map runner did not create {_repo_relative(path)}")
+    rows: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if not isinstance(payload, dict):
+            raise DiagnosticRunError(f"{_repo_relative(path)}:{line_number} must be a JSON object")
+        rows.append(payload)
+    if not rows:
+        raise DiagnosticRunError(f"map runner wrote no episode rows: {_repo_relative(path)}")
+    return rows
+
+
+def _bool_metric(value: Any) -> float:
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)) and math.isfinite(float(value)):
+        return 1.0 if float(value) > 0.0 else 0.0
+    if isinstance(value, str):
+        return 1.0 if value.strip().lower() in {"true", "yes", "1", "success"} else 0.0
+    return 0.0
+
+
+def _finite_or_none(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _first_metric(record: Mapping[str, Any], *keys: str) -> Any:
+    metrics = record.get("metrics")
+    for key in keys:
+        if key in record:
+            return record[key]
+        if isinstance(metrics, Mapping) and key in metrics:
+            return metrics[key]
+    return None
+
+
+def _episode_row_status(record: Mapping[str, Any], *, default_status: str) -> str:
+    raw = str(record.get("row_status") or record.get("status") or "").strip().lower()
+    if raw in {"fallback", "degraded", "not_available", "failed", "blocked"}:
+        return raw
+    return default_status
+
+
+def _activation_diagnostics(
+    record: Mapping[str, Any], *, arm: Mapping[str, Any], row_status: str
+) -> dict[str, Any]:
+    alpha = float(arm["pedestrian_uncertainty_alpha_mps"])
+    if alpha == 0.0:
+        return {}
+    planner_runtime = record.get("planner_runtime")
+    envelope = {}
+    if isinstance(planner_runtime, Mapping):
+        raw_envelope = planner_runtime.get("pedestrian_uncertainty_envelope")
+        if isinstance(raw_envelope, Mapping):
+            envelope = dict(raw_envelope)
+    used = envelope.get("effective_radius_used_by_planner")
+    if isinstance(used, bool):
+        effective_used = used
+    else:
+        effective_used = bool(
+            envelope.get("enabled", arm["pedestrian_uncertainty_envelope_enabled"])
+        )
+    count = envelope.get("envelope_activation_count")
+    if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+        count = (
+            1 if effective_used and row_status not in {"failed", "blocked", "not_available"} else 0
+        )
+    return {
+        "envelope_activation_count": count,
+        "effective_radius_used_by_planner": effective_used,
+    }
+
+
+def _record_identity(
+    record: Mapping[str, Any], fallback_scenario: Mapping[str, Any]
+) -> tuple[str, int]:
+    scenario_id = str(
+        record.get("scenario_id")
+        or record.get("scenario")
+        or fallback_scenario.get("id")
+        or fallback_scenario.get("name")
+        or "scenario"
+    )
+    seed_raw = record.get("seed")
+    if seed_raw is None:
+        seed_raw = record.get("episode_seed")
+    if seed_raw is None:
+        seed_raw = next(iter(fallback_scenario.get("seeds") or [0]))
+    return scenario_id, int(seed_raw)
+
+
+def _summary_rows_from_episode_jsonl(
+    *,
+    planner: Mapping[str, Any],
+    arm: Mapping[str, Any],
+    scenario: Mapping[str, Any],
+    episode_jsonl: Path,
+    default_status: str,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    scenario_family = _scenario_family(scenario, str(scenario.get("id") or scenario.get("name")))
+    for record in _jsonl_rows(episode_jsonl):
+        scenario_id, seed = _record_identity(record, scenario)
+        row_status = _episode_row_status(record, default_status=default_status)
+        success = _first_metric(record, "success")
+        collision = _first_metric(record, "collision", "collisions")
+        near_misses = _first_metric(record, "near_misses", "near_miss")
+        min_clearance = _finite_or_none(
+            _first_metric(record, "min_clearance_m", "minimum_clearance", "mean_clearance")
+        )
+        runtime = _finite_or_none(
+            _first_metric(record, "runtime_seconds", "runtime_s", "duration_s")
+        )
+        rows.append(
+            {
+                "planner_id": str(planner["planner_id"]),
+                "scenario_id": scenario_id,
+                "scenario_family": scenario_family,
+                "seed": seed,
+                "alpha_arm_key": str(arm["key"]),
+                "row_status": row_status,
+                "metrics": {
+                    "success_rate": _bool_metric(success),
+                    "collision_rate": _bool_metric(collision),
+                    "near_miss_rate": _bool_metric(near_misses),
+                    "min_clearance_m": min_clearance,
+                    "path_efficiency": _finite_or_none(_first_metric(record, "path_efficiency")),
+                    "runtime_seconds": runtime,
+                },
+                "diagnostics": _activation_diagnostics(record, arm=arm, row_status=row_status),
+            }
+        )
+    return rows
+
+
+def _write_json(path: Path, payload: Mapping[str, Any] | Sequence[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_diagnostic(args: argparse.Namespace) -> dict[str, Any]:
+    """Run the bounded local diagnostic alpha sweep and compact evidence builder."""
+    packet_path = Path(args.packet)
+    output_dir = Path(args.output_dir)
+    packet = _load_packet(packet_path)
+    planners = _select_by_key(
+        _mapping_sequence(packet["planner_families"], field="planner_families"),
+        keys=args.planner,
+        field="planner",
+    )
+    arms = _select_by_key(
+        _mapping_sequence(packet["alpha_arms"], field="alpha_arms"),
+        keys=args.alpha_arm,
+        field="alpha arm",
+    )
+    scenarios = _diagnostic_scenarios(
+        packet,
+        max_scenarios=args.max_scenarios,
+        max_seeds=args.max_seeds,
+    )
+    default_status = (
+        "successful_evidence" if args.allow_benchmark_strength_status else "diagnostic_only"
+    )
+    raw_root = output_dir / "raw_episode_jsonl"
+    summary_rows: list[dict[str, Any]] = []
+    run_records: list[dict[str, Any]] = []
+
+    for planner in planners:
+        for arm in arms:
+            for scenario in scenarios:
+                scenario_arm = _arm_scenario(scenario, arm)
+                out_path = (
+                    raw_root
+                    / str(planner["planner_id"])
+                    / str(arm["key"])
+                    / f"{scenario_arm['name']}.jsonl"
+                )
+                result = map_runner.run_map_batch(
+                    [scenario_arm],
+                    out_path,
+                    schema_path=DEFAULT_SCHEMA,
+                    scenario_path=packet["scenario_surface"]["matrix_path"],
+                    algo=str(planner["planner_id"]),
+                    algo_config_path=str(REPO_ROOT / str(planner["base_config_path"])),
+                    benchmark_profile="experimental",
+                    horizon=int(arm["max_episode_steps"]),
+                    dt=float(arm["dt"]),
+                    record_forces=False,
+                    resume=False,
+                    workers=1,
+                )
+                run_records.append(
+                    {
+                        "planner_id": str(planner["planner_id"]),
+                        "alpha_arm_key": str(arm["key"]),
+                        "scenario_id": str(scenario.get("id") or scenario.get("name")),
+                        "episode_jsonl": _repo_relative(out_path),
+                        "map_runner_result": result,
+                    }
+                )
+                summary_rows.extend(
+                    _summary_rows_from_episode_jsonl(
+                        planner=planner,
+                        arm=arm,
+                        scenario=scenario,
+                        episode_jsonl=out_path,
+                        default_status=default_status,
+                    )
+                )
+
+    results_path = output_dir / "compact_alpha_sweep_rows.json"
+    _write_json(results_path, {"rows": summary_rows})
+    _write_json(output_dir / "run_manifest.json", {"phase": args.phase, "runs": run_records})
+    evidence_report = evidence_builder.build_evidence(
+        packet_path=packet_path,
+        results_path=results_path,
+        output_dir=output_dir / "compact_evidence",
+        claim_text=(
+            "diagnostic-only CPU smoke output; all packet forbidden claim modes remain excluded"
+        ),
+    )
+    return {
+        "ok": True,
+        "issue": 4232,
+        "phase": args.phase,
+        "output_dir": _repo_relative(output_dir),
+        "row_count": len(summary_rows),
+        "default_row_status": default_status,
+        "planners": [str(planner["planner_id"]) for planner in planners],
+        "alpha_arms": [str(arm["key"]) for arm in arms],
+        "scenario_count": len(scenarios),
+        "seed_count": args.max_seeds,
+        "claim_boundary": "diagnostic_only_no_benchmark_strength_claim",
+        "evidence_report": evidence_report,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the issue #4232 diagnostic runner."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--packet", default=str(DEFAULT_PACKET), help="Issue #4232 packet YAML.")
+    parser.add_argument(
+        "--output-dir", default=str(DEFAULT_OUTPUT_DIR), help="Ignored output root."
+    )
+    parser.add_argument("--phase", default=DEFAULT_PHASE, choices=(DEFAULT_PHASE,))
+    parser.add_argument(
+        "--planner", action="append", default=["prediction_mpc"], help="Planner id."
+    )
+    parser.add_argument(
+        "--alpha-arm",
+        action="append",
+        default=list(DEFAULT_ALPHA_ARMS),
+        help="Alpha arm key from packet.",
+    )
+    parser.add_argument("--max-scenarios", type=int, default=1, help="Bounded scenario slice size.")
+    parser.add_argument("--max-seeds", type=int, default=1, help="Bounded seed slice size.")
+    parser.add_argument(
+        "--allow-benchmark-strength-status",
+        action="store_true",
+        help="Use successful_evidence row status for local rows. Default is diagnostic_only.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the issue #4232 diagnostic alpha-sweep CLI."""
+    args = parse_args(argv)
+    try:
+        report = run_diagnostic(args)
+    except (
+        DiagnosticRunError,
+        packet_checker.PacketError,
+        evidence_builder.EvidenceBuildError,
+        OSError,
+        json.JSONDecodeError,
+        yaml.YAMLError,
+    ) as exc:
+        if args.json:
+            print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True))
+        else:
+            print(f"issue #4232 diagnostic alpha sweep failed: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            "issue #4232 diagnostic alpha sweep complete: "
+            f"rows={report['row_count']} output={report['output_dir']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_run_issue_4232_uncertainty_envelope_alpha_sweep.py
+++ b/tests/benchmark/test_run_issue_4232_uncertainty_envelope_alpha_sweep.py
@@ -1,0 +1,138 @@
+"""Tests for issue #4232 diagnostic uncertainty-envelope alpha sweep runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py"
+PACKET = REPO_ROOT / "configs/benchmarks/issue_4232_uncertainty_envelope_claim_packet.yaml"
+
+_SPEC = importlib.util.spec_from_file_location("_issue_4232_alpha_sweep", SCRIPT)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def _fake_scenarios(_path: Path) -> list[dict[str, object]]:
+    return [
+        {
+            "id": "crossing",
+            "name": "crossing",
+            "map_file": "maps/svg_maps/classic_crossing.svg",
+            "metadata": {"scenario_family": "classic_crossing"},
+            "simulation_config": {},
+        }
+    ]
+
+
+def _fake_run_map_batch(
+    scenarios: list[dict[str, object]],
+    out_path: str | Path,
+    *_args: object,
+    **_kwargs: object,
+) -> dict[str, object]:
+    scenario = scenarios[0]
+    alpha = float(scenario["simulation_config"]["pedestrian_uncertainty_alpha_mps"])  # type: ignore[index]
+    enabled = bool(scenario["simulation_config"]["pedestrian_uncertainty_envelope_enabled"])  # type: ignore[index]
+    record = {
+        "scenario_id": scenario["id"],
+        "seed": 111,
+        "success": True,
+        "collision": False,
+        "metrics": {
+            "near_misses": 0,
+            "mean_clearance": 0.8 + alpha,
+            "path_efficiency": 0.7,
+            "runtime_seconds": 0.05 + alpha,
+        },
+        "planner_runtime": {
+            "pedestrian_uncertainty_envelope": {
+                "enabled": enabled,
+                "alpha_mps": alpha,
+                "effective_radius_used_by_planner": enabled and alpha > 0.0,
+                "envelope_activation_count": 2 if enabled and alpha > 0.0 else 0,
+            }
+        },
+    }
+    path = Path(out_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+    return {"written": 1}
+
+
+def test_issue_4232_diagnostic_runner_writes_compact_diagnostic_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Runner executes paired local arms and keeps rows diagnostic-only by default."""
+    calls: list[dict[str, object]] = []
+
+    def _tracking_run_map_batch(
+        scenarios: list[dict[str, object]],
+        out_path: str | Path,
+        *args: object,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        calls.append({"scenario": scenarios[0], "out_path": str(out_path), "kwargs": kwargs})
+        return _fake_run_map_batch(scenarios, out_path, *args, **kwargs)
+
+    monkeypatch.setattr(_MODULE, "load_scenario_matrix", _fake_scenarios)
+    monkeypatch.setattr(_MODULE.map_runner, "run_map_batch", _tracking_run_map_batch)
+
+    report = _MODULE.run_diagnostic(
+        _MODULE.parse_args(
+            [
+                "--packet",
+                str(PACKET),
+                "--output-dir",
+                str(tmp_path / "issue_4232"),
+                "--max-scenarios",
+                "1",
+                "--max-seeds",
+                "1",
+            ]
+        )
+    )
+
+    assert report["ok"] is True
+    assert report["row_count"] == 3
+    assert report["default_row_status"] == "diagnostic_only"
+    assert len(calls) == 3
+    assert all("raw_episode_jsonl" in call["out_path"] for call in calls)
+
+    rows_path = tmp_path / "issue_4232" / "compact_alpha_sweep_rows.json"
+    rows = json.loads(rows_path.read_text(encoding="utf-8"))["rows"]
+    assert {row["alpha_arm_key"] for row in rows} == {
+        "envelope_off_alpha_0",
+        "envelope_on_alpha_0",
+        "envelope_on_alpha_0p10",
+    }
+    assert {row["row_status"] for row in rows} == {"diagnostic_only"}
+    nonzero = next(row for row in rows if row["alpha_arm_key"] == "envelope_on_alpha_0p10")
+    assert nonzero["diagnostics"]["effective_radius_used_by_planner"] is True
+
+    claim_readiness = (
+        tmp_path / "issue_4232" / "compact_evidence" / "claim_readiness.md"
+    ).read_text(encoding="utf-8")
+    assert "not ready for benchmark-strength" in claim_readiness
+
+
+def test_issue_4232_diagnostic_runner_fails_unknown_alpha_arm(tmp_path: Path) -> None:
+    """Runner rejects alpha arms not pre-registered in the packet."""
+    args = _MODULE.parse_args(
+        [
+            "--packet",
+            str(PACKET),
+            "--output-dir",
+            str(tmp_path / "issue_4232"),
+            "--alpha-arm",
+            "not_registered",
+        ]
+    )
+    with pytest.raises(_MODULE.DiagnosticRunError, match="unknown alpha arm"):
+        _MODULE.run_diagnostic(args)


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a CPU-local diagnostic alpha-sweep runner for issue #4232:
`scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py`, plus focused runner tests and a packet pointer in `configs/benchmarks/issue_4232_uncertainty_envelope_claim_packet.yaml`.

Why now: #4232 is not closure-ready after merged PRs #4256 and #4281. #4256 pre-registered the evidence packet/static validator; #4281 added the compact evidence builder. The latest issue comment says remaining work is to run the actual diagnostic/benchmark campaign before any claim-map/report/paper/dissertation update. This PR supplies the missing CPU diagnostic execution path without submitting compute or promoting claims.

Claim boundary: diagnostic runner capability only. Default rows are `diagnostic_only`; generated raw episode JSONL and compact outputs live under ignored `output/`. This PR does not establish benchmark-strength, conformal, deployment, real-world safety, paper, dissertation, or generalized planner-superiority claims.

Required validation: packet validator, focused runner/evidence tests, Ruff checks, CLI help/import smoke, and final PR readiness on committed HEAD.

Remaining blocker: the actual diagnostic slice still must be run and reviewed before any claim-map, benchmark-report, paper, or dissertation claim update.

## Contract delta

- New executable surface: `scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py`.
- New packet field: `diagnostic_runner` records path, `diagnostic-smoke` phase, ignored default output dir, and default `diagnostic_only` row status.
- New fail-closed behavior: unknown planner/alpha-arm keys fail; packet validation runs before execution; empty scenario/seed slices fail; missing/empty episode JSONL fails; fallback/degraded/not-available/failed/blocked row statuses remain visible and excluded from default benchmark-strength evidence.
- Compatibility impact: no existing benchmark packet semantics are weakened; `execution_boundary.run_benchmark`, `compute_submit_authorized`, and `local_submission_allowed` remain `false`.

## Issue and scope

Issue: closes none; advances https://github.com/ll7/robot_sf_ll7/issues/4232.

Scope summary: smallest remaining implementation slice after merged #4256/#4281. This is a progression slice adding the nameable new capability `issue_4232 diagnostic alpha-sweep runner`, not another guard-only packet refresh.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no claim-map/report promotion, no release, no merge, no deletion.

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Define benchmark/campaign scope before uncertainty-envelope claims. | PR #4256 added `configs/benchmarks/issue_4232_uncertainty_envelope_claim_packet.yaml`; this PR adds the discoverable `diagnostic_runner` execution surface tied to that packet. |
| Record seeds, scenario set, planner settings, speed/runtime constraints, artifact provenance. | PR #4256 packet records seeds/scenario/planners/alpha arms/provenance requirements. This PR runner validates the packet, runs bounded planner/scenario/seed/alpha slices, writes `run_manifest.json`, `compact_alpha_sweep_rows.json`, and compact evidence under ignored `output/`. |
| Keep fallback/degraded execution excluded from benchmark-strength evidence. | PR #4256/#4281 validators/builders enforce row-status exclusions; this PR defaults all local runner rows to `diagnostic_only` and preserves fallback/degraded/not-available/failed/blocked statuses when present. |
| Update claim map/report/paper only if evidence supports boundary. | Not yet met by design. Latest issue comment after #4281 says actual diagnostic/benchmark execution remains before any claim update. This PR does not promote claims. |
| Run CPU diagnostic slice first. | This PR adds the CPU-local runner and tests its map-runner integration path with paired alpha arms; actual diagnostic execution remains next step. |

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_run_issue_4232_uncertainty_envelope_alpha_sweep.py tests/validation/test_check_issue_4232_uncertainty_envelope_claim_packet.py tests/validation/test_build_issue_4232_uncertainty_envelope_evidence.py -q` -> pass (19 passed)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_4232_uncertainty_envelope_claim_packet.py --json` -> pass (`ok: true`, `alpha_arm_count: 5`, `planner_count: 3`, `run_benchmark: false`, `compute_submit_authorized: false`)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py tests/benchmark/test_run_issue_4232_uncertainty_envelope_alpha_sweep.py scripts/validation/check_issue_4232_uncertainty_envelope_claim_packet.py tests/validation/test_check_issue_4232_uncertainty_envelope_claim_packet.py scripts/validation/build_issue_4232_uncertainty_envelope_evidence.py tests/validation/test_build_issue_4232_uncertainty_envelope_evidence.py` -> pass
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py tests/benchmark/test_run_issue_4232_uncertainty_envelope_alpha_sweep.py scripts/validation/check_issue_4232_uncertainty_envelope_claim_packet.py tests/validation/test_check_issue_4232_uncertainty_envelope_claim_packet.py scripts/validation/build_issue_4232_uncertainty_envelope_evidence.py tests/validation/test_build_issue_4232_uncertainty_envelope_evidence.py` -> pass
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py --help` -> pass; imports CLI and prints help. TensorFlow/registry startup logs observed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue4232_pr_body.md scripts/dev/pr_ready_check.sh` -> pass; freshness stamp `output/validation/pr_ready/issue-4232-closure-audit-verify-acceptance-criteria-of-4232-against-merged-prs-clos.json`, head `991962f9161ca699b4372099b30121fbfa6af71a`, clean tree. Initial final run failed before tests because the fresh worktree lacked analytics extras (`duckdb`, `pyarrow`); `uv sync --all-extras` fixed the environment bootstrap.

## Propagation and late guidance

Issue propagation: no issue comment posted because this run authorization has `comment_issue_or_pr: false`. This PR body is the durable propagation surface for the delivered slice and remaining work.

Late guidance check: issue #4232 was re-read immediately before PR open. Latest maintainer comment remains 2026-07-03T12:37:00Z; no newer guidance was present. Open-PR dedupe also found no duplicate #4232 PR.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: direct #4232 merged PRs #4256 and #4281 were found. This PR is not another micro-guard; it adds the named diagnostic runner capability required by the issue plan. No target-host or transient queue-routing state is encoded in tracked files.

Artifact disposition: no generated benchmark artifacts are committed. Runner default output is ignored under `output/issue_4232_uncertainty_envelope_diagnostic_smoke`; raw JSONL remains under ignored output and compact review artifacts are generated only when the runner is invoked.

Downstream propagation: claim-map/report/paper/dissertation surfaces intentionally unchanged until diagnostic/benchmark evidence is produced and reviewed.

</details>
