### PR TITLE
data-infra: tighten SocNavBench control asset contract (#1456)

### DIFF
--- a/scripts/tools/manage_external_data.py
+++ b/scripts/tools/manage_external_data.py
@@ -199,7 +199,8 @@ ASSETS: tuple[AssetSpec, ...] = (
         shared_root_subpath=Path("socnavbench"),
         source_url="https://github.com/CMU-TBD/SocNavBench",
         source_note=(
-            "SocNavBench wayptnav_data assets used by the control/waypoint navigation pipeline."
+            "SocNavBench wayptnav_data and S3DIS/SBPD assets used by the control/waypoint "
+            "navigation pipeline."
         ),
         license_note=(
             "External SocNavBench data assets are not redistributed by Robot SF; verify local "
@@ -207,13 +208,23 @@ ASSETS: tuple[AssetSpec, ...] = (
         ),
         access_note=(
             "License-gated/manual acquisition. Follow docs/socnav_assets_setup.md, then stage "
-            "wayptnav_data under third_party/socnavbench."
+            "wayptnav_data and S3DIS/SBPD data under third_party/socnavbench."
         ),
         required_paths=(
             RequiredPath(
                 pattern="wayptnav_data",
                 kind="directory",
                 description="Precomputed SocNavBench waypoint/control-pipeline data.",
+            ),
+            RequiredPath(
+                pattern="sd3dis/stanford_building_parser_dataset",
+                kind="directory",
+                description="S3DIS/SBPD dataset root used by the SocNav map loader.",
+            ),
+            RequiredPath(
+                pattern="sd3dis/stanford_building_parser_dataset/traversibles",
+                kind="directory",
+                description="Precomputed SocNavBench traversible grids.",
             ),
         ),
         related_issues=(1456, 562),

--- a/tests/tools/test_manage_external_data.py
+++ b/tests/tools/test_manage_external_data.py
@@ -41,6 +41,16 @@ def _write_socnavbench_eth_fixture(path: Path) -> None:
     (traversible_dir / "data.pkl").write_bytes(b"synthetic fixture, not official data")
 
 
+def _write_socnavbench_control_fixture(path: Path) -> None:
+    """Create minimal SocNavBench control-pipeline fixture; not official data."""
+    wayptnav_dir = path / "wayptnav_data"
+    traversibles_dir = path / "sd3dis" / "stanford_building_parser_dataset" / "traversibles"
+    wayptnav_dir.mkdir(parents=True, exist_ok=True)
+    traversibles_dir.mkdir(parents=True, exist_ok=True)
+    (wayptnav_dir / "README.txt").write_text("Synthetic waypoint fixture.\n", encoding="utf-8")
+    (traversibles_dir / "data.pkl").write_bytes(b"synthetic traversible fixture")
+
+
 def _write_atc_fixture(path: Path) -> None:
     """Create minimal ATC-shaped fixture; not official data."""
     path.mkdir(parents=True, exist_ok=True)
@@ -127,6 +137,50 @@ def test_missing_license_gated_asset_fails_closed(tmp_path: Path) -> None:
     }
     assert report["auto_download_allowed"] is False
     assert "official acquisition" in report["action"]
+
+
+def test_socnavbench_control_requires_all_schematic_asset_groups(tmp_path: Path) -> None:
+    """#1456: wayptnav alone is not enough for SocNavBench control re-entry."""
+    source_root = tmp_path / "socnavbench"
+    wayptnav_dir = source_root / "wayptnav_data"
+    wayptnav_dir.mkdir(parents=True)
+    (wayptnav_dir / "README.txt").write_text("Synthetic waypoint fixture.\n", encoding="utf-8")
+
+    report = manage_external_data.check_asset("socnavbench-control", source_path=source_root)
+
+    assert report["ok"] is False
+    assert report["status"] == "incomplete"
+    assert "wayptnav_data" in report["matched_required_paths"]
+    assert "sd3dis/stanford_building_parser_dataset" in report["missing_required_paths"]
+    assert (
+        "sd3dis/stanford_building_parser_dataset/traversibles" in report["missing_required_paths"]
+    )
+
+
+def test_socnavbench_control_provenance_check_accepts_complete_manifest(tmp_path: Path) -> None:
+    """#1456: BYO control assets can be staged with complete path provenance."""
+    _init_git_repo(tmp_path, gitignore="external/socnavbench/\n")
+    source_root = tmp_path / "external" / "socnavbench"
+    _write_socnavbench_control_fixture(source_root)
+    manifest_path = tmp_path / "manifests" / "socnavbench-control.provenance.json"
+
+    manage_external_data.stage_asset(
+        "socnavbench-control",
+        source_path=source_root,
+        manifest_out=manifest_path,
+        repo_root=tmp_path,
+    )
+    report = manage_external_data.check_provenance_manifest("socnavbench-control", manifest_path)
+
+    assert report["ok"] is True
+    assert report["status"] == "ready"
+    assert report["missing_metadata"] == []
+    assert report["asset_id"] == "socnavbench-control"
+    assert report["matched_required_paths"] == [
+        "sd3dis/stanford_building_parser_dataset",
+        "sd3dis/stanford_building_parser_dataset/traversibles",
+        "wayptnav_data",
+    ]
 
 
 def test_unset_external_data_root_preserves_repo_default(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -620,15 +674,20 @@ def test_cli_provenance_check_reports_missing_socnavbench_eth_metadata(tmp_path:
     assert "tree_sha256" in payload["missing_metadata"]
 
 
-def test_socnavbench_control_check_accepts_wayptnav_layout(tmp_path: Path) -> None:
-    """Control-pipeline assets should validate from the expected wayptnav directory."""
+def test_socnavbench_control_check_rejects_wayptnav_only_layout(tmp_path: Path) -> None:
+    """Control-pipeline assets require wayptnav plus S3DIS/SBPD groups."""
     (tmp_path / "wayptnav_data").mkdir()
     (tmp_path / "wayptnav_data" / "README.md").write_text("local fixture\n", encoding="utf-8")
 
     report = manage_external_data.check_asset("socnavbench-control", source_path=tmp_path)
 
-    assert report["ok"] is True
+    assert report["ok"] is False
+    assert report["status"] == "incomplete"
     assert report["matched_required_paths"] == ["wayptnav_data"]
+    assert "sd3dis/stanford_building_parser_dataset" in report["missing_required_paths"]
+    assert (
+        "sd3dis/stanford_building_parser_dataset/traversibles" in report["missing_required_paths"]
+    )
 
 
 def test_socnavbench_s3dis_rejects_empty_required_mesh_directory(tmp_path: Path) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Tightens the public `socnavbench-control` external-data contract so `manage_external_data.py check/stage/provenance-check` requires all schematic control-pipeline groups named by #1456: `wayptnav_data`, `sd3dis/stanford_building_parser_dataset`, and `sd3dis/stanford_building_parser_dataset/traversibles`.

Why now: #1456 remains blocked on licensed SocNavBench bytes that cannot be committed publicly, but the public BYO-data checker still accepted a `wayptnav_data`-only layout. Prior PR #3755 made `prepare_socnav_assets.py` fail closed on placeholder/missing paths; this progression slice aligns the canonical external-data assistant with that same asset boundary.

Claim boundary: This PR adds checker/provenance contract behavior only. It does not stage licensed SocNavBench assets, does not prove `socnav_bench` re-entry, and does not produce benchmark evidence.

Required validation: focused unit tests for `manage_external_data.py`, SocNav map/asset filter tests, lint/format on touched files, and fail-closed CPU smoke checks for missing local assets.

Remaining blocker: #1456 still needs licensed SocNavBench control-pipeline assets distributed/staged through the private mechanism before the re-entry probe can count as restored.

## Contract delta

- New required paths for `socnavbench-control` in `scripts/tools/manage_external_data.py`:
  - `wayptnav_data`
  - `sd3dis/stanford_building_parser_dataset`
  - `sd3dis/stanford_building_parser_dataset/traversibles`
- New fail-closed blocker: a `wayptnav_data`-only source now reports `status=incomplete` and lists the missing S3DIS/SBPD groups.
- Compatibility impact: existing complete BYO staging remains valid; incomplete local sources that previously passed must add the S3DIS/SBPD dataset root and traversibles before staging/provenance readiness is `ready`.

## Summary

Relates #1456.

This is a public data-infrastructure checker slice for SocNavBench control-pipeline asset restoration. It adds the missing S3DIS/SBPD requirements to the canonical external-data assistant and covers both incomplete and complete synthetic fixtures.

## Validation / Proof

- `uv run pytest tests/tools/test_manage_external_data.py -q` - passed, 35 tests.
- `uv run ruff format scripts/tools/manage_external_data.py tests/tools/test_manage_external_data.py` - passed; 1 file reformatted.
- `uv run ruff check scripts/tools/manage_external_data.py tests/tools/test_manage_external_data.py` - passed.
- `uv run python scripts/tools/validate_socnav_map_batch.py --help` - passed.
- `uv run python scripts/tools/manage_external_data.py list` - passed; `socnavbench-control` reports `status: incomplete` in this checkout without local licensed assets.
- `uv run pytest tests/ -k "socnav and (map or asset)" -q` - passed, 43 tests, 1 pre-existing PytestRemovedIn10Warning.
- `uv run python scripts/tools/manage_external_data.py --json check socnavbench-control` - expected exit 2 fail-closed; JSON lists missing `wayptnav_data`, `sd3dis/stanford_building_parser_dataset`, and `sd3dis/stanford_building_parser_dataset/traversibles`.
- `uv run python scripts/tools/prepare_socnav_assets.py --report-json output/tmp/issue1456_socnav_asset_report.json` - expected exit 2 fail-closed; report lists the same three missing schematic-required assets.
- `git diff --check` - passed.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream propagation

No issue comment or state-table update from this worker: `comment_issue_or_pr=false` in the authorization. The PR body is the canonical propagation surface for this slice; Claude Code on `imech156-u` owns the full PR gate/improvement cycle after open.

<details>
<summary>Governance appendix</summary>

## Linked Issues

- Relates `#1456`

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason: none

## What Changed

- `scripts/tools/manage_external_data.py`: `socnavbench-control` now declares S3DIS/SBPD dataset root and traversibles as required paths alongside `wayptnav_data`.
- `tests/tools/test_manage_external_data.py`: adds synthetic complete control-pipeline fixture coverage, rejects `wayptnav_data`-only staging, and checks provenance readiness for the complete path set.

## Why Matters

- Added value: prevents a public BYO-staging manifest from marking SocNavBench control-pipeline assets ready when only waypoint data is present.
- Expected impact: future staging/provenance checks match the #1456 re-entry asset boundary before any empirical probe runs.
- Why worth merging now: closes a checker inconsistency while the actual licensed asset distribution remains blocked.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #1456 asset-restoration blocker, checker contract only.
- Comparator or baseline, applicable: previous `socnavbench-control` check accepted `wayptnav_data` only.
- Evidence tier: NA
- Result classification: NA
- Decision stop rule, applicable: complete BYO fixture passes provenance readiness; `wayptnav_data`-only fixture fails closed.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #1456; no claim map/leaderboard update.
- New research/benchmark/metric/paper-facing analysis tool, any: none.

## Domain-Aware Approval

- Approval concerns experimental validity and waived / pending / blocked / not required: not required; support/tooling contract only.
- Approver/review source waiver: NA.
- Validity checklist: no benchmark or paper-facing claim.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: no fallback/degraded execution counted as success.
- Claim boundary: checker/provenance contract only.
- Implementation integrity vs experimental validity: implementation integrity covered by targeted tests.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, `wayptnav_data`-only fixture now fails closed.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? yes, synthetic incomplete staging lacks S3DIS/SBPD groups.
- Result route: continue after licensed assets become available.
- Follow-up question issue weak, negative, non-transfer results: none opened.

## Next Empirical Action

- Rerun needed: yes, after licensed assets are staged.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: SocNavBench control-pipeline bytes remain unavailable in public repo.
- Stop / revise / continue decision: continue only when private data distribution stages assets.
- Proposed child issue existing follow-up: #1456 remains the tracker.

## Risks / Rollout

- Compatibility risks: local partial SocNavBench copies that used to pass `check socnavbench-control` now fail until S3DIS/SBPD paths are present.
- Failure modes: downstream scripts relying on the weaker checker may need to stage the full schematic layout.
- Rollback fallback plan: revert this PR to restore the prior `wayptnav_data`-only contract.

## Docs / Provenance

- Updated docs: none; `docs/socnav_assets_setup.md` already names these required schematic paths.
- Relevant design provenance notes: #1456 issue thread, #3755 placeholder fail-closed readiness slice.
- Any assumptions need preserved: public repo cannot commit licensed SocNavBench assets; this PR only changes schema/behavior.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no, comments not authorized for this worker.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): yes, external-data registry behavior changed in code.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark evidence or paper-facing claim changed.

## Follow-Up Issues

- Deferred work: stage licensed assets through private distribution, then rerun the open #1456 re-entry probe without fallback/degraded/not-available status.
- Issues opened follow-up: none.

## Reviewer Notes

- Anything reviewer verify closely: the required path set now intentionally matches `prepare_socnav_assets.py` schematic mode.
- Any known limitations: no actual SocNavBench assets are present in this public worktree, so the local smoke checks fail closed by design.

</details>
