### PR TITLE
Issue #4520: Release GPU memory between serial arms (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/map_runner_batch_runner.py
+++ b/robot_sf/benchmark/map_runner_batch_runner.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import gc
+import os
+import sys
 import time
 from pathlib import Path
 from typing import Any, NamedTuple
 
 from loguru import logger
+
+# Set PyTorch allocator configuration early before torch is loaded.
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
 
 FeasibilityTotals = dict[str, float | int]
 
@@ -131,6 +137,14 @@ def _serial_execute_map_jobs(  # noqa: PLR0913
                         "error": repr(exc),
                     }
                 )
+            finally:
+                # Force garbage collection to clean up model/env refs between consecutive arms
+                gc.collect()
+                if "torch" in sys.modules:
+                    import torch  # noqa: PLC0415
+
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
     return (
         wrote,
         episode_records,

--- a/tests/benchmark/test_issue_4520_gpu_memory.py
+++ b/tests/benchmark/test_issue_4520_gpu_memory.py
@@ -1,0 +1,76 @@
+"""Tests for memory teardown behavior between consecutive serial arms (issue #4520)."""
+
+from __future__ import annotations
+
+import gc
+from pathlib import Path  # noqa: TC003
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from robot_sf.benchmark.map_runner_batch_runner import _serial_execute_map_jobs
+
+
+def test_serial_execute_map_jobs_gpu_teardown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure serial multi-arm execution runs gc.collect and torch.cuda.empty_cache."""
+    import torch
+
+    empty_cache_called = 0
+
+    def mock_empty_cache() -> None:
+        nonlocal empty_cache_called
+        empty_cache_called += 1
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "empty_cache", mock_empty_cache)
+
+    gc_collect_called = 0
+    original_gc_collect = gc.collect
+
+    def mock_gc_collect(*args: Any, **kwargs: Any) -> int:
+        nonlocal gc_collect_called
+        gc_collect_called += 1
+        return original_gc_collect(*args, **kwargs)
+
+    monkeypatch.setattr(gc, "collect", mock_gc_collect)
+
+    # Setup mock arguments
+    jobs = [({"name": "scenario_1"}, 42), ({"name": "scenario_2"}, 43)]
+    fixed_params: dict[str, Any] = {}
+    out_path = tmp_path / "episodes.jsonl"
+    schema: dict[str, Any] = {}
+
+    run_map_job = Mock(return_value={"scenario_id": "dummy"})
+    write_validated_to_handle = Mock()
+
+    class DummyBridgeUpdate:
+        adapter_requested_seen = False
+        adapter_native_steps = 0
+        adapter_adapted_steps = 0
+        runtime_algorithm_contract = None
+
+    apply_worker_metadata_bridge = Mock(return_value=DummyBridgeUpdate())
+    scenario_id = Mock(return_value="scenario-id")
+    feasibility_totals: dict[str, Any] = {}
+
+    # Execute
+    wrote, _, failures, _, _, _, _ = _serial_execute_map_jobs(
+        jobs=jobs,
+        fixed_params=fixed_params,
+        out_path=out_path,
+        schema=schema,
+        run_map_job=run_map_job,
+        write_validated_to_handle=write_validated_to_handle,
+        apply_worker_metadata_bridge=apply_worker_metadata_bridge,
+        scenario_id=scenario_id,
+        feasibility_totals=feasibility_totals,
+    )
+
+    # Asserts
+    assert wrote == 2
+    assert len(failures) == 0
+    assert empty_cache_called == 2
+    assert gc_collect_called >= 2


### PR DESCRIPTION
## What/Why
This PR addresses issue #4520 by adding explicit teardown logic in `_serial_execute_map_jobs` inside `robot_sf/benchmark/map_runner_batch_runner.py`. Specifically:
- Sets `os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")` early at module-load to optimize segment allocations.
- Calls `gc.collect()` and `torch.cuda.empty_cache()` inside the `finally` block of the serial job runner loop to ensure model and environment resources are reclaimed between consecutive arms/episodes.

## Validation Output
All tests pass, including a new targeted unit test `tests/benchmark/test_issue_4520_gpu_memory.py` which mocks a GPU environment and verifies the teardown hooks are triggered exactly the expected number of times:
```
============================= test session starts ==============================
platform linux -- Python 3.13.14, pytest-9.1.1, pluggy-1.6.0
collected 141 items

tests/benchmark/test_issue_4520_gpu_memory.py .                          [  0%]
tests/benchmark/test_map_runner_utils.py ............................... [ 22%]
........................................................................ [ 73%]
.....................................                                    [100%]
============================== 141 passed in 7.48s ==============================
```

This PR was produced by the agy/Gemini-3.5-Flash cheap implementation lane; the review gate hardens and merges.
