### PR TITLE
feat: add source discovery ledger for issue #3278

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added **metadata-only public-source discovery ledger checker** for real micromobility trace
+  collection issue #3278. New schema `real_trace_source_discovery.v1`, module
+  `robot_sf.analysis_workbench.real_trace_source_discovery`, CLI
+  `scripts/tools/check_real_trace_source_discovery.py`, and example ledger
+  `configs/benchmarks/issue_3278_real_trace_source_discovery_example.yaml` record candidate public
+  sources searched for `late_evasive_reaction` and `oscillatory_local_control` validation traces.
+  The checker fails closed until every required target has an available, accepted/permissive,
+  directly covering source. It stores no raw external data, downloads nothing, and makes no
+  real-world validation, calibration, benchmark, or paper-facing claim.
+
 * **Wired the CrowdBot and SCAND external datasets into the external-data setup nav and completed
   their registry traceability** (issue #4357, #4224 program). `docs/external_data_setup.md` now lists
   and tabulates `crowdbot` and `scand-demos` alongside their program siblings (SDD, ETH/UCY, ATC,

--- a/configs/benchmarks/issue_3278_real_trace_source_discovery_example.yaml
+++ b/configs/benchmarks/issue_3278_real_trace_source_discovery_example.yaml
@@ -1,0 +1,31 @@
+# Example public-source discovery ledger for issue #3278.
+#
+# This file records metadata about candidate public sources only. It contains no
+# raw trace data, downloads nothing, and makes no real-world validation claim.
+# The maintainer decision on issue #3278 keeps implementation blocked until a
+# viable data-gathering method appears.
+schema_version: real_trace_source_discovery.v1
+issue: 3278
+discovery_status: complete
+required_targets:
+  - late_evasive_reaction
+  - oscillatory_local_control
+candidate_sources:
+  - source_id: placeholder_public_micromobility_survey
+    title: Placeholder public micromobility trajectory source
+    source_type: public_dataset
+    url_or_reference: "TBD - replace only after accepted source discovery"
+    license_status: unknown
+    access_status: blocked
+    coverage_status: proxy_only
+    covered_targets:
+      - late_evasive_reaction
+      - oscillatory_local_control
+    notes: >
+      Demonstrates the blocked-external-input state. Public trajectory
+      datasets may provide proxy kinematics, but no accepted source is known
+      to provide directly usable late-evasive and oscillatory validation traces.
+notes: >
+  Fail-closed discovery ledger example. A future source may move one target to
+  ready only when access is available, license status is accepted or permissive,
+  and coverage is direct.

--- a/robot_sf/analysis_workbench/__init__.py
+++ b/robot_sf/analysis_workbench/__init__.py
@@ -1,5 +1,16 @@
 """Analysis-workbench contracts and helpers."""
 
+from robot_sf.analysis_workbench.real_trace_source_discovery import (
+    REAL_TRACE_SOURCE_DISCOVERY_SCHEMA_VERSION,
+    SOURCE_DISCOVERY_EVIDENCE_BOUNDARY,
+    SOURCE_DISCOVERY_STATUS_BLOCKED,
+    SOURCE_DISCOVERY_STATUS_READY,
+    RealTraceSourceDiscoveryError,
+    RealTraceSourceDiscoveryReport,
+    SourceCandidateReport,
+    check_real_trace_source_discovery,
+    load_real_trace_source_discovery,
+)
 from robot_sf.analysis_workbench.real_trace_validation_contract import (
     CONTRACT_EVIDENCE_BOUNDARY,
     REAL_TRACE_VALIDATION_CONTRACT_SCHEMA_VERSION,
@@ -44,18 +55,25 @@ from robot_sf.analysis_workbench.trace_failure_predicates import (
 
 __all__ = [
     "CONTRACT_EVIDENCE_BOUNDARY",
+    "REAL_TRACE_SOURCE_DISCOVERY_SCHEMA_VERSION",
     "REAL_TRACE_VALIDATION_CONTRACT_SCHEMA_VERSION",
     "SIMULATION_TIMELINE_SCHEMA_FILE",
     "SIMULATION_TIMELINE_SCHEMA_VERSION",
     "SIMULATION_TRACE_EXPORT_SCHEMA_VERSION",
+    "SOURCE_DISCOVERY_EVIDENCE_BOUNDARY",
+    "SOURCE_DISCOVERY_STATUS_BLOCKED",
+    "SOURCE_DISCOVERY_STATUS_READY",
     "TRACE_ANNOTATION_SET_SCHEMA_VERSION",
     "TRACE_FAILURE_PREDICATE_SCHEMA_VERSION",
     "PredicateCompatibility",
+    "RealTraceSourceDiscoveryError",
+    "RealTraceSourceDiscoveryReport",
     "RealTraceValidationContractError",
     "RealTraceValidationContractReport",
     "SimulationTimelineValidationError",
     "SimulationTraceExport",
     "SimulationTraceExportValidationError",
+    "SourceCandidateReport",
     "TraceAnnotationSet",
     "TraceAnnotationSetValidationError",
     "TraceFailurePredicate",
@@ -63,8 +81,10 @@ __all__ = [
     "aggregate_trace_failure_predicate_tables",
     "build_simulation_timeline",
     "build_trace_failure_predicate_definitions",
+    "check_real_trace_source_discovery",
     "check_real_trace_validation_contract",
     "extract_trace_failure_predicates",
+    "load_real_trace_source_discovery",
     "load_real_trace_validation_contract",
     "load_simulation_timeline_schema",
     "load_simulation_trace_export",

--- a/robot_sf/analysis_workbench/real_trace_source_discovery.py
+++ b/robot_sf/analysis_workbench/real_trace_source_discovery.py
@@ -1,0 +1,263 @@
+"""Public-source discovery ledger for issue #3278 real micromobility traces.
+
+The checker records which public sources were reviewed for late-evasive and
+oscillatory validation data. It does not download, copy, or inspect raw
+external traces. Its only claim is whether the metadata ledger names at least
+one usable source for each required validation target.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator
+
+from robot_sf.common.json_pointer import json_pointer
+
+REAL_TRACE_SOURCE_DISCOVERY_SCHEMA_VERSION = "real_trace_source_discovery.v1"
+SOURCE_DISCOVERY_EVIDENCE_BOUNDARY = "public_source_discovery_only_no_real_world_validation"
+SOURCE_DISCOVERY_STATUS_READY = "ready"
+SOURCE_DISCOVERY_STATUS_BLOCKED = "blocked"
+
+DEFAULT_REQUIRED_TARGETS = (
+    "late_evasive_reaction",
+    "oscillatory_local_control",
+)
+
+USABLE_ACCESS_STATUSES = {"available"}
+USABLE_LICENSE_STATUSES = {"accepted", "permissive"}
+USABLE_COVERAGE_STATUSES = {"direct"}
+
+SCHEMA_FILE = Path(__file__).resolve().parent / "schemas" / "real_trace_source_discovery.v1.json"
+
+
+class RealTraceSourceDiscoveryError(ValueError):
+    """Raised when a real-trace source discovery ledger is malformed."""
+
+    def __init__(self, errors: list[str], *, source: str | Path | None = None):
+        """Build an actionable validation error."""
+        self.errors = tuple(errors)
+        self.source = str(source) if source is not None else None
+        prefix = f"{self.source}: " if self.source else ""
+        super().__init__(prefix + "; ".join(errors))
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCandidateReport:
+    """Compatibility status for one public-source candidate."""
+
+    source_id: str
+    title: str
+    status: str
+    matched_targets: tuple[str, ...]
+    blockers: tuple[str, ...] = field(default_factory=tuple)
+    notes: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RealTraceSourceDiscoveryReport:
+    """Fail-closed report for issue #3278 public-source discovery."""
+
+    schema_version: str
+    discovery_status: str
+    evidence_boundary: str
+    required_targets: tuple[str, ...]
+    ready_targets: tuple[str, ...]
+    blocked_targets: tuple[str, ...]
+    blockers: tuple[str, ...]
+    source_reports: tuple[SourceCandidateReport, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable report."""
+        return asdict(self)
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Serialize report as stable JSON.
+
+        Returns:
+            JSON string suitable for CLI output.
+        """
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+
+@lru_cache(maxsize=1)
+def load_real_trace_source_discovery_schema() -> dict[str, Any]:
+    """Load the JSON schema for ``real_trace_source_discovery.v1`` ledgers.
+
+    Returns:
+        Parsed JSON schema mapping.
+    """
+    return json.loads(SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def load_real_trace_source_discovery(path: str | Path) -> dict[str, Any]:
+    """Load and schema-check a YAML or JSON source-discovery ledger.
+
+    Returns:
+        Parsed ledger mapping.
+    """
+    ledger_path = Path(path)
+    if not ledger_path.is_file():
+        raise RealTraceSourceDiscoveryError(["ledger file not found"], source=ledger_path)
+
+    try:
+        payload = yaml.safe_load(ledger_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive
+        raise RealTraceSourceDiscoveryError(
+            [f"invalid YAML/JSON: {exc}"], source=ledger_path
+        ) from exc
+
+    if not isinstance(payload, Mapping):
+        raise RealTraceSourceDiscoveryError(["expected a mapping payload"], source=ledger_path)
+
+    _raise_on_schema_errors(payload, source=ledger_path)
+    return dict(payload)
+
+
+def check_real_trace_source_discovery(
+    ledger: Mapping[str, Any],
+    *,
+    source: str | Path | None = None,
+) -> RealTraceSourceDiscoveryReport:
+    """Check whether public-source discovery has usable issue #3278 inputs.
+
+    A target is ready only when at least one candidate source has accepted or
+    permissive licensing, available access, and direct coverage for that target.
+    All other states remain blocked external-input evidence.
+
+    Returns:
+        Structured fail-closed source discovery report.
+    """
+    _raise_on_schema_errors(ledger, source=source)
+
+    required_targets = tuple(ledger.get("required_targets", DEFAULT_REQUIRED_TARGETS))
+    source_reports = tuple(
+        _candidate_report(candidate, required_targets)
+        for candidate in ledger.get("candidate_sources", [])
+    )
+    ready_targets = tuple(
+        target
+        for target in required_targets
+        if any(
+            report.status == SOURCE_DISCOVERY_STATUS_READY and target in report.matched_targets
+            for report in source_reports
+        )
+    )
+    blocked_targets = tuple(
+        target for target in required_targets if target not in set(ready_targets)
+    )
+
+    blockers = list(_ledger_blockers(ledger))
+    blockers.extend(
+        f"required target {target!r} has no usable public source" for target in blocked_targets
+    )
+
+    discovery_status = (
+        SOURCE_DISCOVERY_STATUS_READY
+        if not blockers and not blocked_targets
+        else SOURCE_DISCOVERY_STATUS_BLOCKED
+    )
+
+    return RealTraceSourceDiscoveryReport(
+        schema_version=REAL_TRACE_SOURCE_DISCOVERY_SCHEMA_VERSION,
+        discovery_status=discovery_status,
+        evidence_boundary=SOURCE_DISCOVERY_EVIDENCE_BOUNDARY,
+        required_targets=required_targets,
+        ready_targets=ready_targets,
+        blocked_targets=blocked_targets,
+        blockers=tuple(blockers),
+        source_reports=source_reports,
+    )
+
+
+def _raise_on_schema_errors(payload: Mapping[str, Any], *, source: str | Path | None) -> None:
+    """Raise when a ledger violates the JSON schema."""
+    validator = Draft202012Validator(load_real_trace_source_discovery_schema())
+    errors = [
+        f"{json_pointer(error.absolute_path)}: {error.message}"
+        for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
+    ]
+    if errors:
+        raise RealTraceSourceDiscoveryError(errors, source=source)
+
+
+def _candidate_report(
+    candidate: Mapping[str, Any],
+    required_targets: Sequence[str],
+) -> SourceCandidateReport:
+    """Classify one candidate source against required targets.
+
+    Returns:
+        Candidate-level status and blockers.
+    """
+    matched_targets = tuple(
+        target for target in candidate.get("covered_targets", []) if target in required_targets
+    )
+    blockers = list(_candidate_blockers(candidate))
+    missing_targets = [
+        target for target in candidate.get("covered_targets", []) if target not in required_targets
+    ]
+    if missing_targets:
+        blockers.append(
+            "covered_targets includes unsupported target(s): " + ", ".join(sorted(missing_targets))
+        )
+
+    status = (
+        SOURCE_DISCOVERY_STATUS_READY
+        if matched_targets and not blockers
+        else SOURCE_DISCOVERY_STATUS_BLOCKED
+    )
+
+    return SourceCandidateReport(
+        source_id=str(candidate["source_id"]),
+        title=str(candidate["title"]),
+        status=status,
+        matched_targets=matched_targets,
+        blockers=tuple(blockers),
+        notes=candidate.get("notes"),
+    )
+
+
+def _ledger_blockers(ledger: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return ledger-level blockers independent of individual sources.
+
+    Returns:
+        Human-readable blocker strings.
+    """
+    blockers: list[str] = []
+    discovery_status = ledger.get("discovery_status")
+    if discovery_status != "complete":
+        blockers.append(f"discovery_status is {discovery_status!r}, expected 'complete'")
+    if not ledger.get("candidate_sources"):
+        blockers.append("candidate_sources is empty")
+    return tuple(blockers)
+
+
+def _candidate_blockers(candidate: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return candidate-level blockers for source usability.
+
+    Returns:
+        Human-readable blocker strings.
+    """
+    blockers: list[str] = []
+    access_status = candidate.get("access_status")
+    if access_status not in USABLE_ACCESS_STATUSES:
+        blockers.append(f"access_status is {access_status!r}, expected 'available'")
+
+    license_status = candidate.get("license_status")
+    if license_status not in USABLE_LICENSE_STATUSES:
+        blockers.append(f"license_status is {license_status!r}, expected accepted/permissive")
+
+    coverage_status = candidate.get("coverage_status")
+    if coverage_status not in USABLE_COVERAGE_STATUSES:
+        blockers.append(f"coverage_status is {coverage_status!r}, expected 'direct'")
+
+    if not candidate.get("covered_targets"):
+        blockers.append("covered_targets is empty")
+    return tuple(blockers)

--- a/robot_sf/analysis_workbench/schemas/real_trace_source_discovery.v1.json
+++ b/robot_sf/analysis_workbench/schemas/real_trace_source_discovery.v1.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://robot-sf.local/schemas/real_trace_source_discovery.v1.json",
+  "title": "Robot SF Real Micromobility Trace Source Discovery Ledger v1",
+  "description": "Metadata-only ledger of public sources reviewed for issue #3278 real micromobility validation traces. It stores no raw trace data and makes no real-world validation claim.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "issue",
+    "discovery_status",
+    "required_targets",
+    "candidate_sources"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "real_trace_source_discovery.v1"
+    },
+    "issue": {
+      "const": 3278
+    },
+    "discovery_status": {
+      "enum": ["not_started", "in_progress", "complete"]
+    },
+    "required_targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "candidate_sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "source_id",
+          "title",
+          "source_type",
+          "url_or_reference",
+          "license_status",
+          "access_status",
+          "coverage_status",
+          "covered_targets"
+        ],
+        "properties": {
+          "source_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9_.-]+$"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_type": {
+            "enum": [
+              "public_dataset",
+              "paper_supplement",
+              "repository",
+              "field_measurement",
+              "collaborator",
+              "other"
+            ]
+          },
+          "url_or_reference": {
+            "type": "string",
+            "minLength": 1
+          },
+          "license_status": {
+            "enum": ["accepted", "permissive", "restricted", "unknown", "blocked"]
+          },
+          "access_status": {
+            "enum": ["available", "pending", "blocked", "unknown"]
+          },
+          "coverage_status": {
+            "enum": ["direct", "proxy_only", "insufficient", "unknown"]
+          },
+          "covered_targets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "notes": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/scripts/tools/check_real_trace_source_discovery.py
+++ b/scripts/tools/check_real_trace_source_discovery.py
@@ -1,0 +1,74 @@
+"""CLI checker for issue #3278 public-source discovery ledgers.
+
+The checker validates metadata only. It does not download, copy, or inspect raw
+external traces, and it makes no real-world validation claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.analysis_workbench.real_trace_source_discovery import (
+    SOURCE_DISCOVERY_STATUS_READY,
+    RealTraceSourceDiscoveryError,
+    check_real_trace_source_discovery,
+    load_real_trace_source_discovery,
+)
+
+DEFAULT_LEDGER = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "benchmarks"
+    / "issue_3278_real_trace_source_discovery_example.yaml"
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ledger",
+        type=Path,
+        default=DEFAULT_LEDGER,
+        help="Path to real_trace_source_discovery.v1 ledger (JSON or YAML).",
+    )
+    parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Exit non-zero unless discovery_status is 'ready'.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the ledger check and print a JSON report."""
+    args = _parse_args(argv)
+    try:
+        ledger = load_real_trace_source_discovery(args.ledger)
+        report = check_real_trace_source_discovery(ledger, source=args.ledger)
+    except RealTraceSourceDiscoveryError as exc:
+        print(
+            json.dumps(
+                {
+                    "status": "schema_error",
+                    "source": exc.source,
+                    "errors": list(exc.errors),
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+    print(report.to_json())
+    if args.require_ready and report.discovery_status != SOURCE_DISCOVERY_STATUS_READY:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/analysis_workbench/test_real_trace_source_discovery.py
+++ b/tests/analysis_workbench/test_real_trace_source_discovery.py
@@ -1,0 +1,126 @@
+"""Tests for issue #3278 public-source discovery ledger checker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robot_sf.analysis_workbench.real_trace_source_discovery import (
+    REAL_TRACE_SOURCE_DISCOVERY_SCHEMA_VERSION,
+    SOURCE_DISCOVERY_EVIDENCE_BOUNDARY,
+    SOURCE_DISCOVERY_STATUS_BLOCKED,
+    SOURCE_DISCOVERY_STATUS_READY,
+    RealTraceSourceDiscoveryError,
+    check_real_trace_source_discovery,
+    load_real_trace_source_discovery,
+)
+
+EXAMPLE_LEDGER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "benchmarks"
+    / "issue_3278_real_trace_source_discovery_example.yaml"
+)
+
+
+def _ready_ledger() -> dict:
+    """Return a complete discovery ledger with usable sources for both targets."""
+    return {
+        "schema_version": REAL_TRACE_SOURCE_DISCOVERY_SCHEMA_VERSION,
+        "issue": 3278,
+        "discovery_status": "complete",
+        "required_targets": ["late_evasive_reaction", "oscillatory_local_control"],
+        "candidate_sources": [
+            {
+                "source_id": "usable_late",
+                "title": "Usable late-evasive source",
+                "source_type": "public_dataset",
+                "url_or_reference": "https://example.invalid/late",
+                "license_status": "accepted",
+                "access_status": "available",
+                "coverage_status": "direct",
+                "covered_targets": ["late_evasive_reaction"],
+            },
+            {
+                "source_id": "usable_oscillatory",
+                "title": "Usable oscillatory source",
+                "source_type": "paper_supplement",
+                "url_or_reference": "https://example.invalid/oscillatory",
+                "license_status": "permissive",
+                "access_status": "available",
+                "coverage_status": "direct",
+                "covered_targets": ["oscillatory_local_control"],
+            },
+        ],
+    }
+
+
+def test_ready_ledger_requires_usable_source_for_each_target() -> None:
+    """Accepted, available, direct sources make every required target ready."""
+    report = check_real_trace_source_discovery(_ready_ledger())
+
+    assert report.discovery_status == SOURCE_DISCOVERY_STATUS_READY
+    assert report.ready_targets == ("late_evasive_reaction", "oscillatory_local_control")
+    assert report.blocked_targets == ()
+    assert report.blockers == ()
+    assert all(source.status == SOURCE_DISCOVERY_STATUS_READY for source in report.source_reports)
+    assert report.evidence_boundary == SOURCE_DISCOVERY_EVIDENCE_BOUNDARY
+
+
+def test_proxy_or_blocked_sources_fail_closed() -> None:
+    """Proxy-only or inaccessible candidates keep the issue externally blocked."""
+    ledger = _ready_ledger()
+    ledger["candidate_sources"][0]["access_status"] = "blocked"
+    ledger["candidate_sources"][0]["coverage_status"] = "proxy_only"
+
+    report = check_real_trace_source_discovery(ledger)
+
+    assert report.discovery_status == SOURCE_DISCOVERY_STATUS_BLOCKED
+    assert report.ready_targets == ("oscillatory_local_control",)
+    assert report.blocked_targets == ("late_evasive_reaction",)
+    assert any("late_evasive_reaction" in blocker for blocker in report.blockers)
+    blocked_source = report.source_reports[0]
+    assert blocked_source.status == SOURCE_DISCOVERY_STATUS_BLOCKED
+    assert any("access_status" in blocker for blocker in blocked_source.blockers)
+    assert any("coverage_status" in blocker for blocker in blocked_source.blockers)
+
+
+def test_incomplete_discovery_status_blocks_even_with_usable_source() -> None:
+    """Ledger-level discovery status must be complete before readiness is allowed."""
+    ledger = _ready_ledger()
+    ledger["discovery_status"] = "in_progress"
+
+    report = check_real_trace_source_discovery(ledger)
+
+    assert report.discovery_status == SOURCE_DISCOVERY_STATUS_BLOCKED
+    assert any("discovery_status" in blocker for blocker in report.blockers)
+
+
+def test_schema_rejects_wrong_issue() -> None:
+    """Discovery ledgers are issue-specific and cannot be reused silently."""
+    ledger = _ready_ledger()
+    ledger["issue"] = 3277
+
+    with pytest.raises(RealTraceSourceDiscoveryError, match="/issue"):
+        check_real_trace_source_discovery(ledger)
+
+
+def test_example_ledger_loads_and_reports_external_block() -> None:
+    """The committed example remains a metadata-only blocked ledger."""
+    ledger = load_real_trace_source_discovery(EXAMPLE_LEDGER_PATH)
+
+    report = check_real_trace_source_discovery(ledger, source=EXAMPLE_LEDGER_PATH)
+
+    assert report.discovery_status == SOURCE_DISCOVERY_STATUS_BLOCKED
+    assert set(report.blocked_targets) == {
+        "late_evasive_reaction",
+        "oscillatory_local_control",
+    }
+    assert report.source_reports[0].status == SOURCE_DISCOVERY_STATUS_BLOCKED
+
+
+def test_load_missing_file_raises() -> None:
+    """Loading a missing ledger path raises a clear error."""
+    with pytest.raises(RealTraceSourceDiscoveryError, match="not found"):
+        load_real_trace_source_discovery(EXAMPLE_LEDGER_PATH.with_suffix(".missing.yaml"))


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a metadata-only `real_trace_source_discovery.v1` ledger checker for issue #3278. It records candidate public sources searched for late-evasive and oscillatory real micromobility validation traces and reports whether each required target has a usable source.

Why now: the live issue thread has a maintainer hard-block noting no realistic real-data source is currently available (<5% estimated feasibility). Prior PR #3739 added a candidate trace validation-contract checker; this PR adds the missing source-discovery readiness surface so future public-source discovery can be recorded fail-closed before any data ingestion.

Claim boundary: no raw external data, no downloads, no real-world validation, no calibrated AMV actuation claim, no benchmark or paper/dissertation claim. The example ledger intentionally remains `blocked`.

Required validation: focused unit tests for ready/blocked/schema states, existing real-trace validation-contract tests, Ruff on changed Python surfaces, CLI smoke showing the example ledger is blocked, and `--require-ready` returning exit 2 for the blocked placeholder.

Remaining blocker: issue #3278 still needs an accepted, available source with direct coverage for `late_evasive_reaction` and `oscillatory_local_control` before real validation can proceed.

## Contract delta

- New schema: `real_trace_source_discovery.v1`.
- New public API: `check_real_trace_source_discovery`, `load_real_trace_source_discovery`, `RealTraceSourceDiscoveryReport`, `SourceCandidateReport`.
- New CLI: `scripts/tools/check_real_trace_source_discovery.py`.
- New fail-closed blockers: incomplete discovery status, empty candidate source list, unavailable access, unknown/restricted license, proxy-only/insufficient coverage, unsupported covered targets, and missing usable source per required target.
- Compatibility impact: additive only; no existing schema, benchmark runner, predicate contract, or data loader semantics changed.

## Linked Issues

- Relates to `#3278`

## Stack / Dependency

- Base dependency: `origin/main`
- Required prior PRs: #3739 is merged and provides the candidate trace validation-contract checker this complements.
- Stack follow-up issues: none opened.
- Safe review independently: yes.
- Review dependency reason, any: additive source-discovery checker only.

## What Changed

- Added `robot_sf.analysis_workbench.real_trace_source_discovery`.
- Added JSON schema and example blocked ledger for issue #3278.
- Added CLI checker for discovery ledgers.
- Exported the new API through `robot_sf.analysis_workbench`.
- Added unit tests and changelog entry.

## Why Matters

- Added value: future source searches can be recorded in a structured, fail-closed format instead of silently implying data availability.
- Expected impact: keeps #3278 tracked as blocked-external-input until a source genuinely satisfies access, license, and direct-coverage requirements.
- Why worth merging now: it adds a nameable new capability toward the issue plan without running campaigns or storing external data.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: issue #3278 external-input blocker for real micromobility validation traces.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - support checker; validation commands are implementation proof only.
- Result classification: NA - support checker; the underlying data blocker remains.
- Decision stop rule, applicable: ready only when every required target has an available, accepted/permissive, directly covering source.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3278.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker; it does not interpret research evidence.

## Domain-Aware Approval

- Approver/review source waiver: not required; no benchmark, metric, paper-facing, or evidence-classification claim promoted.
- Validity checklist: fail-closed source readiness only.
- Target claim/hypothesis: no real-world validation claim.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: proxy-only candidates remain blocked.
- Claim boundary: public-source discovery only, no data ingestion.
- Implementation integrity vs experimental validity: implementation validates metadata contract only.

## Falsification / Non-Transfer Check

- Did mechanism activate? NA.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue only after real source is available.
- Follow-up question issue weak, negative, non-transfer results: none opened.

## Next Empirical Action

- Rerun needed: no.
- Extractor analysis tool needed: no for this PR; future source-specific extractor may be needed after data source acceptance.
- Artifact missing unavailable: accepted real micromobility trace source remains unavailable.
- Stop / revise / continue decision: continue tracking as blocked-external-input.
- Proposed child issue existing follow-up: issue #3278 remains open.

## Validation / Proof

- `uv run ruff check robot_sf/analysis_workbench/real_trace_source_discovery.py scripts/tools/check_real_trace_source_discovery.py tests/analysis_workbench/test_real_trace_source_discovery.py robot_sf/analysis_workbench/__init__.py` -> passed.
- `uv run pytest tests/analysis_workbench/test_real_trace_source_discovery.py tests/analysis_workbench/test_real_trace_validation_contract.py` -> 21 passed.
- `uv run python scripts/tools/check_real_trace_source_discovery.py --ledger configs/benchmarks/issue_3278_real_trace_source_discovery_example.yaml` -> exit 0, reports both required targets blocked.
- `uv run python scripts/tools/check_real_trace_source_discovery.py --ledger configs/benchmarks/issue_3278_real_trace_source_discovery_example.yaml --require-ready` -> exit 2 as expected for fail-closed blocked placeholder.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3278/PR_BODY.md scripts/dev/pr_ready_check.sh` -> see readiness result before merge.

## Performance Baseline

- Baseline runtime: NA, no runtime path changed.
- Changed runtime: NA, no runtime path changed.
- Representative command: `uv run python scripts/tools/check_real_trace_source_discovery.py --ledger configs/benchmarks/issue_3278_real_trace_source_discovery_example.yaml`.
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: checker allows proxy-only or inaccessible source to mark a required target ready.

## Risks / Rollout

- Compatibility risks: low; additive schema/API/CLI only.
- Failure modes: future ledgers may overstate direct coverage; reviewer should check source-specific evidence before changing example placeholders.
- Rollback fallback plan: remove additive checker/schema/CLI and continue using issue comments plus #3739 descriptor checker.

## Docs / Provenance

- Updated docs: `CHANGELOG.md`.
- Relevant design provenance notes: issue #3278 maintainer blocked-external-input comment; PR #3739 prior contract checker.
- Any assumptions need to preserved: proxy-only public trajectory sources are not sufficient for real validation readiness.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: `comment_issue_or_pr=false` for this run and the PR body records slice delivered, remaining blocker, and no claim-map/benchmark/paper-facing change. No additional issue-state propagation is needed for this additive checker.

## Follow-Up Issues

- Deferred work: tracked by existing parent issue #3278; locate or obtain a real source with accepted access/license and direct coverage for both required validation targets.
- Issues opened follow-up: none; existing issue #3278 remains the tracking surface.

## Reviewer Notes

- Review the fail-closed semantics closely: `--require-ready` should return 2 for the committed placeholder ledger.
- Known limitation: this does not collect data; it only records whether a candidate source is usable enough to unblock later source-specific staging.

<details>
<summary>Governance appendix</summary>

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No raw external dataset committed.
- No issue/PR comments posted by this run.

</details>
