### PR TITLE
feat(research): add vertical flow preflight stages (#3057)

### DIFF
--- a/configs/research/research_package_registry_issue_3057.yaml
+++ b/configs/research/research_package_registry_issue_3057.yaml
@@ -96,8 +96,23 @@ packages:
     # until #3081 publishes it (rather than reusing an upstream package's artifact and
     # reporting the release as ready before it is produced).
     required_artifacts:
-      - docs/context/issue_3081_july_2026_release_manifest.md
+    - docs/context/issue_3081_july_2026_release_manifest.md
+    flow_stages:
+    - id: campaign_manifest
+      artifact: docs/benchmark_campaign_manifest.md
+    - id: scenario_seed_expansion
+      artifact: configs/benchmarks/issue_3059_research_engine_suite_v0.yaml
+    - id: local_or_slurm_execution_packet
+      artifact: configs/benchmarks/issue_3078_package_a_readiness.yaml
+    - id: episode_rows_result_store
+      artifact: docs/context/issue_3076_campaign_result_store_contract.md
+    - id: social_compliance_metrics
+      artifact: configs/benchmarks/social_compliance_metric_contract_v1.yaml
+    - id: comparison_report
+      artifact: scripts/tools/build_campaign_comparison_report.py
+    - id: claim_card_durable_manifest
+      artifact: docs/context/issue_3081_july_2026_release_manifest.md
     prerequisites:
-      - package_a_rank_stability
-      - package_b_adversarial
-      - package_c_prediction
+    - package_a_rank_stability
+    - package_b_adversarial
+    - package_c_prediction

--- a/robot_sf/research/package_registry.py
+++ b/robot_sf/research/package_registry.py
@@ -45,6 +45,14 @@ STATUS_BLOCKED = "blocked"
 
 
 @dataclass(frozen=True, slots=True)
+class ResearchFlowStage:
+    """One named vertical-flow stage required by a package."""
+
+    stage_id: str
+    artifact: str
+
+
+@dataclass(frozen=True, slots=True)
 class ResearchPackage:
     """One declared research-engine package and its preflight inputs.
 
@@ -63,6 +71,7 @@ class ResearchPackage:
     resource: str | None
     required_artifacts: tuple[str, ...]
     prerequisites: tuple[str, ...]
+    flow_stages: tuple[ResearchFlowStage, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -254,6 +263,7 @@ def _evaluate_package(
             present_artifacts.append(artifact)
         else:
             missing_artifacts.append(artifact)
+    flow_stage_results = _evaluate_flow_stages(package.flow_stages, repo_root=repo_root)
 
     # A prerequisite counts as satisfied only when it resolved to ``ready``; anything
     # else (blocked) is a blocking gap. Unknown ids are rejected at load time.
@@ -272,6 +282,18 @@ def _evaluate_package(
                 "detail": f"required artifact not found: {artifact}",
             }
         )
+    for stage in flow_stage_results:
+        if not stage["present"]:
+            gaps.append(
+                {
+                    "package_id": package.package_id,
+                    "gap_type": "missing_flow_stage",
+                    "detail": (
+                        f"vertical flow stage {stage['stage_id']} missing artifact: "
+                        f"{stage['artifact']}"
+                    ),
+                }
+            )
     for prerequisite in blocked_prerequisites:
         gaps.append(
             {
@@ -296,6 +318,7 @@ def _evaluate_package(
         },
         "prerequisites": list(package.prerequisites),
         "blocked_prerequisites": blocked_prerequisites,
+        "flow_stages": flow_stage_results,
         "gaps": gaps,
     }
 
@@ -335,6 +358,7 @@ def _parse_package(item: Any, *, index: int) -> ResearchPackage:
     prerequisites = _parse_str_list(
         item.get("prerequisites", []), field="prerequisites", package_id=package_id
     )
+    flow_stages = _parse_flow_stages(item.get("flow_stages", []), package_id=package_id)
     return ResearchPackage(
         package_id=package_id,
         title=title,
@@ -342,7 +366,54 @@ def _parse_package(item: Any, *, index: int) -> ResearchPackage:
         resource=resource,
         required_artifacts=required_artifacts,
         prerequisites=prerequisites,
+        flow_stages=flow_stages,
     )
+
+
+def _evaluate_flow_stages(
+    stages: tuple[ResearchFlowStage, ...], *, repo_root: Path
+) -> list[dict[str, Any]]:
+    """Return presence report for declared vertical-flow stages."""
+    return [
+        {
+            "stage_id": stage.stage_id,
+            "artifact": stage.artifact,
+            "present": (repo_root / stage.artifact).exists(),
+        }
+        for stage in stages
+    ]
+
+
+def _parse_flow_stages(raw: Any, *, package_id: str) -> tuple[ResearchFlowStage, ...]:
+    """Parse optional package vertical-flow stage declarations.
+
+    Returns:
+        Parsed flow-stage declarations.
+    """
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(f"package {package_id!r} field 'flow_stages' must be a list")
+    stages: list[ResearchFlowStage] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"package {package_id!r} flow_stages[{index}] must be mapping")
+        stage_id = str(item.get("id", "")).strip()
+        if not stage_id:
+            raise ValueError(
+                f"package {package_id!r} flow_stages[{index}] must define non-empty 'id'"
+            )
+        if stage_id in seen:
+            raise ValueError(f"package {package_id!r} duplicate flow stage id {stage_id!r}")
+        seen.add(stage_id)
+        artifact = str(item.get("artifact", "")).strip()
+        if not artifact:
+            raise ValueError(
+                f"package {package_id!r} flow_stages[{index}] must define non-empty 'artifact'"
+            )
+        stages.append(ResearchFlowStage(stage_id=stage_id, artifact=artifact))
+    return tuple(stages)
 
 
 def _parse_str_list(value: Any, *, field: str, package_id: str) -> tuple[str, ...]:

--- a/tests/research/test_package_registry.py
+++ b/tests/research/test_package_registry.py
@@ -115,6 +115,59 @@ def test_blocked_prerequisite_propagates(tmp_path: Path) -> None:
     assert any(g["gap_type"] == "blocked_prerequisite" for g in downstream["gaps"])
 
 
+def test_missing_flow_stage_blocks_package(tmp_path: Path) -> None:
+    """A missing declared vertical-flow stage fails closed."""
+    (tmp_path / "manifest.md").write_text("ok", encoding="utf-8")
+    registry_path = _write_registry(
+        tmp_path,
+        [
+            {
+                "id": "release",
+                "title": "Release",
+                "required_artifacts": ["manifest.md"],
+                "prerequisites": [],
+                "flow_stages": [
+                    {"id": "campaign_manifest", "artifact": "manifest.md"},
+                    {"id": "claim_card", "artifact": "missing_claim_card.yaml"},
+                ],
+            }
+        ],
+    )
+
+    report = evaluate_registry_preflight(load_registry(registry_path), repo_root=tmp_path)
+
+    package = report["packages"][0]
+    assert package["status"] == "blocked"
+    assert package["flow_stages"] == [
+        {"stage_id": "campaign_manifest", "artifact": "manifest.md", "present": True},
+        {"stage_id": "claim_card", "artifact": "missing_claim_card.yaml", "present": False},
+    ]
+    assert {
+        "package_id": "release",
+        "gap_type": "missing_flow_stage",
+        "detail": ("vertical flow stage claim_card missing artifact: missing_claim_card.yaml"),
+    } in report["gaps"]
+
+
+def test_malformed_flow_stage_rejected(tmp_path: Path) -> None:
+    """Flow stages require stable ids and artifact paths."""
+    registry_path = _write_registry(
+        tmp_path,
+        [
+            {
+                "id": "release",
+                "title": "Release",
+                "required_artifacts": [],
+                "prerequisites": [],
+                "flow_stages": [{"id": "campaign_manifest"}],
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="flow_stages\\[0\\].*artifact"):
+        load_registry(registry_path)
+
+
 def test_dependency_order_independent_of_declaration_order(tmp_path: Path) -> None:
     """Prerequisites resolve transitively regardless of declared order."""
     for name in ("a.yaml", "b.yaml"):
@@ -269,3 +322,18 @@ def test_real_registry_preflight_against_checkout() -> None:
     # The release gate points at a release-owned artifact that #3081 has not yet
     # published, so it must fail closed to blocked rather than reporting ready.
     assert statuses["release_july_2026"] == "blocked"
+    release = next(p for p in report["packages"] if p["package_id"] == "release_july_2026")
+    stage_ids = {stage["stage_id"] for stage in release["flow_stages"]}
+    assert stage_ids == {
+        "campaign_manifest",
+        "scenario_seed_expansion",
+        "local_or_slurm_execution_packet",
+        "episode_rows_result_store",
+        "social_compliance_metrics",
+        "comparison_report",
+        "claim_card_durable_manifest",
+    }
+    assert any(
+        gap["gap_type"] == "missing_flow_stage" and "claim_card_durable_manifest" in gap["detail"]
+        for gap in release["gaps"]
+    )


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds an optional `flow_stages` contract to the existing #3057 research-package registry/preflight so the epic vertical path is reported as named stage artifacts, not just coarse package artifacts.

Why now: issue #3057’s live audit addendum says the research engine is not operational until a vertical path is visible from campaign manifest through result store, metrics, report, and durable claim-card manifest. This PR adds the smallest read-only checker support for that path without campaigns or scheduler work.

Claim boundary: metadata/preflight only. It reports tracked artifact presence and missing stage blockers; it makes no benchmark, metric, planner, paper, or dissertation claim.

Required validation: focused registry tests plus CPU preflight CLI smoke and Ruff checks passed locally.

Remaining blocker: the shipped release package still fails closed until `docs/context/issue_3081_july_2026_release_manifest.md` exists; the preflight now names that as both the release artifact and the `claim_card_durable_manifest` vertical-flow stage blocker.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3057

## Contract delta

- New schema-compatible optional package field: `flow_stages`, a list of `{id, artifact}` entries.
- New preflight output field per package: `flow_stages`, rendered as `{stage_id, artifact, present}` objects.
- New fail-closed blocker type: `missing_flow_stage` when a declared stage artifact is absent.
- Compatibility impact: existing registry entries without `flow_stages` continue to parse as an empty stage list; existing required-artifact and prerequisite semantics are unchanged.

## Scope summary

- Extended `robot_sf/research/package_registry.py` in place, the canonical owner for #3057 package preflight.
- Updated `configs/research/research_package_registry_issue_3057.yaml` so `release_july_2026` declares the vertical path stages: campaign manifest, scenario/seed expansion, local execution packet, result-store contract, social-compliance metrics, comparison report, and durable claim-card manifest.
- Added focused synthetic and shipped-registry tests for stage parsing, stage blockers, and real-checkout reporting.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/research/test_package_registry.py -q` -> 15 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/research_package_preflight.py --format json` -> exit 0; summary `ready_count=7`, `blocked_count=1`, release blocker `missing_flow_stage: claim_card_durable_manifest`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/research/package_registry.py tests/research/test_package_registry.py` -> all checks passed
- `git diff --check` -> exit 0

Full `pr_ready_check.sh` not run: this is a narrow registry/preflight contract change with focused tests and lint/format proof; no shared runtime execution path, campaign runner, metric computation, or benchmark semantics changed.

## Explicit out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No scheduler, training, release publication, or empirical claim promotion.

## Downstream propagation

No issue comment was added: issue #3057 is a high-churn epic and this PR body is the canonical state propagation for this slice. It names the delivered capability and the remaining release-manifest blocker without adding another comment stream.

<details>
<summary>Freshness and dedupe notes</summary>

- `gh issue view 3057 --comments` is blocked in this repo by the GitHub Projects classic deprecation GraphQL error, so freshness was checked via `gh api repos/ll7/robot_sf_ll7/issues/3057` plus paginated issue comments.
- Latest maintainer comment remains 2026-06-21T05:26:40Z; no late guidance newer than this work start was found.
- Open PR search for #3057 / continuous social-navigation research engine / vertical flow / research package registry returned no existing open coverage.
- Fragmentation guard: no #3057 guardrail/checker/packet-refresh PRs merged in the last 24h were found; this slice is also a progression slice with a nameable new capability, “vertical flow preflight stages.”

</details>

