### PR TITLE
Issue #3161: consume dataset staging contract in prior comparison

### DIFF
--- a/scripts/analysis/compare_scenario_priors_issue_2919.py
+++ b/scripts/analysis/compare_scenario_priors_issue_2919.py
@@ -19,8 +19,19 @@ from typing import Any
 
 import yaml
 
+from robot_sf.research.scenario_prior_staging_contract import (
+    CONTRACT_STATUS_READY,
+    ScenarioPriorStagingContractError,
+    ScenarioPriorStagingContractReport,
+    check_scenario_prior_staging_contract,
+    load_scenario_prior_staging_contract,
+)
+
 DEFAULT_REGISTRY_PATH = Path("configs/research/scenario_prior_cards_issue_2917.yaml")
 DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21")
+DEFAULT_DATASET_STAGING_CONTRACT_PATH = Path(
+    "configs/research/scenario_prior_staging_contract_issue_3161.yaml"
+)
 REPORT_NAME = "scenario_prior_gap_report.md"
 SUMMARY_NAME = "summary.json"
 CSV_NAME = "parameter_comparisons.csv"
@@ -653,6 +664,87 @@ def analysis_base_commit(repo_root: Path) -> str:
     return result.stdout.strip()
 
 
+def load_dataset_staging_report(
+    contract_path: Path | None,
+    *,
+    repo_root: Path,
+) -> ScenarioPriorStagingContractReport | None:
+    """Load optional Issue #3161 dataset-backed staging readiness report."""
+
+    if contract_path is None:
+        return None
+    resolved_contract_path = (repo_root / contract_path).resolve()
+    contract = load_scenario_prior_staging_contract(resolved_contract_path)
+    return check_scenario_prior_staging_contract(
+        contract,
+        allowed_distribution_groups=set(PARAMETER_GROUPS),
+        source=resolved_contract_path,
+    )
+
+
+def _dataset_staging_summary(
+    staging_report: ScenarioPriorStagingContractReport | None,
+) -> dict[str, Any] | None:
+    """Return compact JSON-safe dataset-backed comparison readiness summary."""
+
+    if staging_report is None:
+        return None
+    return {
+        "schema_version": staging_report.schema_version,
+        "contract_id": staging_report.contract_id,
+        "issue": staging_report.issue,
+        "evidence_boundary": staging_report.evidence_boundary,
+        "contract_status": staging_report.contract_status,
+        "dataset_backed_comparison_allowed": staging_report.dataset_backed_comparison_allowed,
+        "comparison_ready_datasets": staging_report.comparison_ready_datasets,
+        "blockers": staging_report.blockers,
+        "datasets": [dataset.to_dict() for dataset in staging_report.datasets],
+    }
+
+
+def _dataset_staging_markdown_lines(
+    staging_report: ScenarioPriorStagingContractReport | None,
+) -> list[str]:
+    """Return report lines for Issue #3161 dataset-backed staging readiness."""
+
+    if staging_report is None:
+        return [
+            "- Dataset-backed staging contract was not checked in this run.",
+            "- Dataset-backed comparison remains out of scope for this report.",
+        ]
+    lines = [
+        f"- Contract status: `{staging_report.contract_status}`.",
+        f"- Dataset-backed comparison allowed: `{staging_report.dataset_backed_comparison_allowed}`.",
+        f"- Comparison-ready datasets: `{', '.join(staging_report.comparison_ready_datasets) or 'none'}`.",
+        f"- Evidence boundary: {staging_report.evidence_boundary}.",
+    ]
+    if staging_report.blockers:
+        lines.append("- Blockers:")
+        lines.extend(f"  - {blocker}" for blocker in staging_report.blockers)
+    lines.append("- Dataset statuses:")
+    lines.extend(
+        (
+            f"  - `{dataset.dataset_id}`: declared `{dataset.declared_staging_status}`, "
+            f"live `{dataset.live_staging_status or 'not-probed'}`, "
+            f"ready `{dataset.comparison_ready}`."
+        )
+        for dataset in staging_report.datasets
+    )
+    return lines
+
+
+def _dataset_not_ready_reasons(staging_report: ScenarioPriorStagingContractReport) -> list[str]:
+    """Return actionable reasons dataset-backed comparison is not ready."""
+
+    reasons = list(staging_report.blockers)
+    reasons.extend(
+        f"{dataset.dataset_id}: declared {dataset.declared_staging_status}"
+        for dataset in staging_report.datasets
+        if not dataset.comparison_ready and not dataset.blockers
+    )
+    return reasons
+
+
 def write_summary(
     *,
     rows: list[dict[str, Any]],
@@ -661,6 +753,7 @@ def write_summary(
     output_dir: Path,
     repo_root: Path,
     registry_path: Path,
+    dataset_staging_report: ScenarioPriorStagingContractReport | None = None,
 ) -> dict[str, Any]:
     """Write the machine-readable summary and return its payload."""
 
@@ -672,6 +765,7 @@ def write_summary(
         "evidence_tier": "analysis_only",
         "claim_boundary": CLAIM_BOUNDARY,
         "dataset_comparison_deferral": DATASET_DEFERRAL,
+        "dataset_backed_staging": _dataset_staging_summary(dataset_staging_report),
         "no_planner_ranking": NO_RANKING_NOTE,
         "sample_count": len(samples),
         "skipped_non_machine_readable_sources": skipped_sources,
@@ -700,6 +794,7 @@ def write_markdown_report(
     output_dir: Path,
     repo_root: Path,
     registry_path: Path,
+    dataset_staging_report: ScenarioPriorStagingContractReport | None = None,
 ) -> None:
     """Write the human-readable gap report."""
 
@@ -711,6 +806,10 @@ def write_markdown_report(
         f"- Registry input: `{registry_path.relative_to(repo_root).as_posix()}`.",
         f"- {DATASET_DEFERRAL}",
         f"- {NO_RANKING_NOTE}",
+        "",
+        "## Dataset-Backed Readiness",
+        "",
+        *_dataset_staging_markdown_lines(dataset_staging_report),
         "",
         "## Method",
         "",
@@ -776,27 +875,40 @@ def run_comparison(
     registry_path: Path = DEFAULT_REGISTRY_PATH,
     output_dir: Path = DEFAULT_OUTPUT_DIR,
     repo_root: Path | None = None,
+    dataset_staging_contract: Path | None = DEFAULT_DATASET_STAGING_CONTRACT_PATH,
+    require_dataset_backed_ready: bool = False,
 ) -> dict[str, Any]:
-    """Run the Issue #2919 comparison and write evidence files."""
+    """Run Issue #2919 comparison write evidence files."""
 
     repo_root = repo_root or repository_root()
     registry_path = (repo_root / registry_path).resolve()
     output_dir = (repo_root / output_dir).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
-
+    dataset_staging_report = load_dataset_staging_report(
+        dataset_staging_contract,
+        repo_root=repo_root,
+    )
+    if (
+        require_dataset_backed_ready
+        and dataset_staging_report is not None
+        and dataset_staging_report.contract_status != CONTRACT_STATUS_READY
+    ):
+        raise ScenarioPriorComparisonError(
+            "dataset-backed comparison requested but Issue #3161 staging contract is "
+            f"{dataset_staging_report.contract_status!r}; "
+            f"blockers: {'; '.join(_dataset_not_ready_reasons(dataset_staging_report)) or 'none'}"
+        )
     samples, skipped_sources = collect_samples(registry_path, repo_root)
     rows = build_comparison_rows(samples)
     if not rows:
-        raise ScenarioPriorComparisonError(
-            "no comparable authored and trace-derived parameters found"
-        )
-
+        raise ScenarioPriorComparisonError("no comparable authored trace-derived parameters found")
     write_csv(rows, output_dir / CSV_NAME)
     write_markdown_report(
         rows=rows,
         output_dir=output_dir,
         repo_root=repo_root,
         registry_path=registry_path,
+        dataset_staging_report=dataset_staging_report,
     )
     return write_summary(
         rows=rows,
@@ -805,6 +917,7 @@ def run_comparison(
         output_dir=output_dir,
         repo_root=repo_root,
         registry_path=registry_path,
+        dataset_staging_report=dataset_staging_report,
     )
 
 
@@ -829,6 +942,25 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_OUTPUT_DIR,
         help=f"Evidence output directory (default: {DEFAULT_OUTPUT_DIR})",
     )
+    parser.add_argument(
+        "--dataset-staging-contract",
+        type=Path,
+        default=DEFAULT_DATASET_STAGING_CONTRACT_PATH,
+        help=(
+            "Issue #3161 dataset-backed staging contract path "
+            f"(default: {DEFAULT_DATASET_STAGING_CONTRACT_PATH})"
+        ),
+    )
+    parser.add_argument(
+        "--skip-dataset-staging-contract",
+        action="store_true",
+        help="Do not load the Issue #3161 dataset-backed staging contract.",
+    )
+    parser.add_argument(
+        "--require-dataset-backed-ready",
+        action="store_true",
+        help="Fail unless the Issue #3161 staging contract permits dataset-backed comparison.",
+    )
     return parser.parse_args()
 
 
@@ -836,7 +968,18 @@ def main() -> None:
     """CLI entry point."""
 
     args = parse_args()
-    summary = run_comparison(registry_path=args.registry, output_dir=args.output_dir)
+    dataset_staging_contract = (
+        None if args.skip_dataset_staging_contract else args.dataset_staging_contract
+    )
+    try:
+        summary = run_comparison(
+            registry_path=args.registry,
+            output_dir=args.output_dir,
+            dataset_staging_contract=dataset_staging_contract,
+            require_dataset_backed_ready=args.require_dataset_backed_ready,
+        )
+    except (ScenarioPriorComparisonError, ScenarioPriorStagingContractError) as exc:
+        raise SystemExit(f"error: {exc}") from exc
     print(f"wrote {summary['files']['markdown_report']}")
     print(f"wrote {summary['files']['comparison_csv']}")
     print(f"wrote {summary['files']['summary_json']}")

--- a/scripts/analysis/compare_scenario_priors_issue_2919.py
+++ b/scripts/analysis/compare_scenario_priors_issue_2919.py
@@ -878,7 +878,7 @@ def run_comparison(
     dataset_staging_contract: Path | None = DEFAULT_DATASET_STAGING_CONTRACT_PATH,
     require_dataset_backed_ready: bool = False,
 ) -> dict[str, Any]:
-    """Run Issue #2919 comparison write evidence files."""
+    """Run the Issue #2919 comparison and write evidence files."""
 
     repo_root = repo_root or repository_root()
     registry_path = (repo_root / registry_path).resolve()
@@ -901,7 +901,9 @@ def run_comparison(
     samples, skipped_sources = collect_samples(registry_path, repo_root)
     rows = build_comparison_rows(samples)
     if not rows:
-        raise ScenarioPriorComparisonError("no comparable authored trace-derived parameters found")
+        raise ScenarioPriorComparisonError(
+            "no comparable authored and trace-derived parameters found"
+        )
     write_csv(rows, output_dir / CSV_NAME)
     write_markdown_report(
         rows=rows,

--- a/tests/analysis/test_compare_scenario_priors_issue_2919.py
+++ b/tests/analysis/test_compare_scenario_priors_issue_2919.py
@@ -82,6 +82,41 @@ def _mini_registry(tmp_path: Path) -> Path:
     )
 
 
+def _dataset_staging_contract(
+    tmp_path: Path, staging_status: str = "blocked-external-input"
+) -> Path:
+    """Write a minimal Issue #3161 dataset-backed staging contract."""
+
+    return _write_yaml(
+        tmp_path / "configs" / "research" / "scenario_prior_staging_contract_issue_3161.yaml",
+        {
+            "schema_version": "scenario_prior_staging_contract.v1",
+            "contract_id": "scenario_prior_staging_contract_issue_3161",
+            "issue": 3161,
+            "claim_boundary": "metadata-only staging readiness; no dataset-backed claim",
+            "authored_baseline": "configs/research/scenario_prior_cards_issue_2917.yaml",
+            "comparison_harness": "scripts/analysis/compare_scenario_priors_issue_2919.py",
+            "datasets": [
+                {
+                    "dataset_id": "sdd",
+                    "asset_id": "sdd",
+                    "title": "Stanford Drone Dataset annotations",
+                    "staging_status": staging_status,
+                    "redistribution": "none",
+                    "blocker_issues": [3065],
+                    "provenance": {
+                        "source_url": "https://cvgl.stanford.edu/projects/uav_data/",
+                        "license": "BYO local copy",
+                        "license_status": "license-gated",
+                        "citation": "Robicquet et al., ECCV 2016.",
+                    },
+                    "distribution_fields": ["pedestrian_speed", "pedestrian_density"],
+                }
+            ],
+        },
+    )
+
+
 def test_extract_parameter_samples_groups_ranges_and_scalars(tmp_path: Path) -> None:
     """Extractor should group supported scalar and range keys under canonical parameters."""
 
@@ -173,6 +208,7 @@ def test_run_comparison_writes_report_csv_and_summary(tmp_path: Path) -> None:
         registry_path=registry.relative_to(tmp_path),
         output_dir=output_dir.relative_to(tmp_path),
         repo_root=tmp_path,
+        dataset_staging_contract=None,
     )
 
     report_path = output_dir / comparator.REPORT_NAME
@@ -217,4 +253,46 @@ def test_run_comparison_fails_when_no_common_parameters(tmp_path: Path) -> None:
             registry_path=registry.relative_to(tmp_path),
             output_dir=Path("out"),
             repo_root=tmp_path,
+            dataset_staging_contract=None,
+        )
+
+
+def test_run_comparison_records_dataset_staging_blocker(tmp_path: Path) -> None:
+    """Runner should include Issue #3161 staging readiness without claiming dataset comparison."""
+
+    registry = _mini_registry(tmp_path)
+    contract = _dataset_staging_contract(tmp_path)
+    output_dir = tmp_path / "out"
+
+    summary = comparator.run_comparison(
+        registry_path=registry.relative_to(tmp_path),
+        output_dir=output_dir.relative_to(tmp_path),
+        repo_root=tmp_path,
+        dataset_staging_contract=contract.relative_to(tmp_path),
+    )
+
+    staging = summary["dataset_backed_staging"]
+    assert staging["contract_status"] == "blocked-external-input"
+    assert staging["dataset_backed_comparison_allowed"] is False
+    assert staging["comparison_ready_datasets"] == []
+
+    report = (output_dir / comparator.REPORT_NAME).read_text(encoding="utf-8")
+    assert "## Dataset-Backed Readiness" in report
+    assert "Contract status: `blocked-external-input`" in report
+    assert "Dataset-backed comparison allowed: `False`" in report
+
+
+def test_run_comparison_require_dataset_ready_fails_closed(tmp_path: Path) -> None:
+    """Require-ready mode should stop before producing dataset-backed comparison claims."""
+
+    registry = _mini_registry(tmp_path)
+    contract = _dataset_staging_contract(tmp_path)
+
+    with pytest.raises(comparator.ScenarioPriorComparisonError, match="staging contract"):
+        comparator.run_comparison(
+            registry_path=registry.relative_to(tmp_path),
+            output_dir=Path("out"),
+            repo_root=tmp_path,
+            dataset_staging_contract=contract.relative_to(tmp_path),
+            require_dataset_backed_ready=True,
         )


### PR DESCRIPTION
## Reviewer-critical summary

What changed: extends the existing `scripts/analysis/compare_scenario_priors_issue_2919.py` authored-vs-trace comparison with an Issue #3161 dataset-backed staging-readiness gate. The comparison now loads `configs/research/scenario_prior_staging_contract_issue_3161.yaml`, records readiness in `summary.json` and the Markdown report, and adds `--require-dataset-backed-ready` to fail closed until at least one staged dataset is contract-clean.

Why now: #3161 is still blocked on opt-in BYO/external staging, but the prior merged #3161 slice only checked the staging contract independently. This slice adds the new capability to consume that contract in the comparison path without importing raw external data.

Claim boundary: analysis-only readiness plumbing. This does not run a dataset-backed prior comparison, infer planner ranking, claim real-world representativeness, or edit paper/dissertation claims.

Required validation: focused comparison/staging tests, Ruff check/format, CPU CLI smoke, and a negative `--require-dataset-backed-ready` smoke proving current blocked datasets fail closed.

Remaining blocker: SDD, SocNavBench ETH, and AMV remain `blocked-external-input`; a user-supplied/staged dataset must flip the staging contract before dataset-backed comparison is allowed.

## Contract delta

- New comparison output field: `dataset_backed_staging` in `scenario_prior_gap_issue_2919.v1` summaries.
- New report section: `Dataset-Backed Readiness` in the Markdown gap report.
- New CLI flags: `--dataset-staging-contract`, `--skip-dataset-staging-contract`, and `--require-dataset-backed-ready`.
- New fail-closed blocker: require-ready mode exits before producing a dataset-backed comparison claim when the #3161 staging contract is not `ready`.
- Compatibility impact: default comparison still writes authored-vs-trace outputs, but now includes staging-readiness metadata from the tracked #3161 contract. Existing tests can opt out with `dataset_staging_contract=None` or the CLI skip flag.

## Linked issue

Refs #3161.

## Scope summary

Adds the nameable new capability: **dataset-backed staging-readiness consumption in the scenario-prior comparison path**. This is a progression slice after the merged staging-contract checker PR, not another standalone guardrail.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/analysis/test_compare_scenario_priors_issue_2919.py tests/research/test_scenario_prior_staging_contract.py -q` -> passed, 24 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/analysis/compare_scenario_priors_issue_2919.py tests/analysis/test_compare_scenario_priors_issue_2919.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/analysis/compare_scenario_priors_issue_2919.py tests/analysis/test_compare_scenario_priors_issue_2919.py` -> passed after formatting.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/analysis/compare_scenario_priors_issue_2919.py --output-dir output/issue_3161_compare_smoke` -> passed; wrote ignored local smoke outputs.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/analysis/compare_scenario_priors_issue_2919.py --output-dir output/issue_3161_compare_smoke_require --require-dataset-backed-ready` -> expected exit 1; failed closed with `blocked-external-input` for `sdd`, `socnavbench_eth`, and `amv`.

## Explicit out of scope

No full benchmark campaign run. No Slurm/GPU submission. No paper/dissertation claim edits. No raw external dataset import, storage, or redistribution.

## State propagation

No issue comment is posted from this run because authorization has `comment_issue_or_pr: false`. The PR body records the delivered slice and remaining blocker as the durable visible state surface for reviewer handoff.

<details>
<summary>Governance appendix</summary>

- Live issue was rechecked immediately before PR prep via REST API because `gh issue view --comments` hit GitHub classic Projects GraphQL deprecation. No maintainer comments newer than the run start were present; latest issue guidance remains 2026-06-29 blocked-on-data / external-data distribution.
- Open PR dedupe did not find an open #3161 PR covering this exact scope.
- Fragmentation guard: no two #3161 guardrail/checker/packet-refresh PRs were merged in the last 24 hours; this slice is also exempt as a progression capability that wires the existing contract into the comparison path.
- Artifact policy: smoke outputs remain ignored under `output/` and are not committed.

</details>
