### PR TITLE
Issue #1585: gate AMV calibration on source provenance

### DIFF
--- a/scripts/tools/manage_external_data.py
+++ b/scripts/tools/manage_external_data.py
@@ -28,6 +28,9 @@ EXTERNAL_DATA_ROOT_ENV = "ROBOT_SF_EXTERNAL_DATA_ROOT"
 DEFAULT_AMV_COMMAND_RESPONSE_MANIFEST = (
     REPO_ROOT / "configs" / "research" / "amv_command_response_trace_manifest_issue_2415.yaml"
 )
+DEFAULT_AMV_CALIBRATION_SOURCE_MANIFEST = (
+    REPO_ROOT / "configs" / "benchmarks" / "issue_1585_amv_calibration_source_manifest.yaml"
+)
 
 # Canonical SDD staging manifest. This is the single editable provenance contract for the SDD
 # asset (issues #2657, #3473): maintainers pin `expected_tree_sha256` and tune the disk-check size
@@ -1856,6 +1859,12 @@ def parse_args() -> argparse.Namespace:
         help="Report AMV command-response calibration admission status; fails closed.",
     )
     amv_status.add_argument("--manifest", type=Path, default=None)
+    amv_status.add_argument(
+        "--source-manifest",
+        type=Path,
+        default=None,
+        help="Path to amv_calibration_source_manifest.v1 provenance manifest.",
+    )
 
     sdd_download = subparsers.add_parser(
         "sdd-download", help="Guarded SDD staging: requires explicit confirmation; fails closed."
@@ -2002,13 +2011,22 @@ def _handle_sdd_mode(args: argparse.Namespace) -> int:
     return 0 if gate["dataset_backed"] else 2
 
 
-def build_amv_calibration_status(manifest_path: Path | None = None) -> dict[str, Any]:
-    """Return AMV calibration admission status from asset presence plus trace manifest.
+def build_amv_calibration_status(
+    manifest_path: Path | None = None,
+    source_manifest_path: Path | None = None,
+) -> dict[str, Any]:
+    """Return AMV calibration admission status from asset, trace, and source provenance.
 
     The report is intentionally fail-closed: it never admits AMV command-response calibration
-    unless the issue #2415 manifest is structurally clean and a declared staged trace reconciles
-    with the live ``amv-calibration`` external-data asset status.
+    unless the issue #2415 trace manifest is structurally clean, a declared staged trace reconciles
+    with live ``amv-calibration`` external-data asset status, and issue #1585 source provenance
+    is accepted for hardware-calibrated AMV claims.
     """
+    from robot_sf.benchmark.amv_calibration_source_manifest import (
+        AmvCalibrationSourceManifestError,
+        check_amv_calibration_source_manifest,
+        load_amv_calibration_source_manifest,
+    )
     from robot_sf.benchmark.synthetic_actuation import actuation_variability_fields
     from robot_sf.research.amv_command_response_trace_manifest import (
         AmvTraceManifestError,
@@ -2050,12 +2068,43 @@ def build_amv_calibration_status(manifest_path: Path | None = None) -> dict[str,
         live_status = {"amv-calibration": str(asset_report["status"])}
         blocker_details = [str(exc)]
 
-    ready = asset_report["status"] == "available" and trace_payload["calibration_ingest_allowed"]
+    source_manifest_source = source_manifest_path or DEFAULT_AMV_CALIBRATION_SOURCE_MANIFEST
+    try:
+        source_manifest = load_amv_calibration_source_manifest(source_manifest_source)
+        source_report = check_amv_calibration_source_manifest(
+            source_manifest,
+            allowed_calibration_fields=set(actuation_variability_fields()),
+        )
+        source_payload = source_report.to_dict()
+        source_ready = source_report.is_ready
+        hardware_source_ready = source_report.hardware_calibration_claim_allowed
+        if not source_ready:
+            blocker_details.extend(source_report.blockers)
+        if source_ready and not hardware_source_ready:
+            blocker_details.append(
+                "AMV calibration source must allow hardware-calibrated claims; "
+                "platform-class proxy sources are insufficient"
+            )
+    except (AmvCalibrationSourceManifestError, ValueError) as exc:
+        source_payload = {
+            "source_status": "invalid",
+            "hardware_calibration_claim_allowed": False,
+            "error": str(exc),
+        }
+        source_ready = False
+        hardware_source_ready = False
+        blocker_details.append(str(exc))
+
     blocker_keys: list[str] = []
     if asset_report["status"] != "available":
         blocker_keys.append("amv_calibration_asset_missing")
     if not trace_payload["calibration_ingest_allowed"]:
         blocker_keys.append("command_response_trace_manifest_not_ready")
+    if not source_ready:
+        blocker_keys.append("amv_calibration_source_manifest_not_ready")
+    if source_ready and not hardware_source_ready:
+        blocker_keys.append("amv_calibration_source_not_hardware_calibrated")
+    ready = not blocker_keys
 
     return {
         "schema": "amv_calibration_status.v1",
@@ -2067,23 +2116,26 @@ def build_amv_calibration_status(manifest_path: Path | None = None) -> dict[str,
         "blocker_details": blocker_details,
         "asset_status": asset_report,
         "manifest_path": str(manifest_source),
+        "source_manifest_path": str(source_manifest_source),
         "live_staging_status": live_status,
         "trace_manifest_report": trace_payload,
+        "source_manifest_report": source_payload,
         "evidence_boundary": (
-            "asset_presence_plus_manifest_contract_only_no_trace_ingest_no_calibration_run"
+            "asset_presence_plus_trace_and_source_manifest_contracts_only_"
+            "no_trace_ingest_no_calibration_run"
         ),
         "next_step": (
-            "Stage a maintainer-accepted real AMV command-response trace bundle through "
-            "`manage_external_data.py stage amv-calibration`, then rerun this status check."
+            "Stage maintainer-accepted real AMV command-response trace bundle and accepted "
+            "hardware-calibrated source provenance, then rerun this status check."
             if not ready
-            else "AMV command-response trace bundle is staged and manifest-clean for calibration ingest."
+            else "AMV command-response trace bundle is staged and manifest-clean; calibration ingest allowed."
         ),
     }
 
 
 def _handle_amv_calibration_status(args: argparse.Namespace) -> int:
     """Handle amv-calibration-status subcommand."""
-    payload = build_amv_calibration_status(args.manifest)
+    payload = build_amv_calibration_status(args.manifest, args.source_manifest)
     _print_json(payload)
     return 0 if payload["ready"] else 2
 

--- a/tests/tools/test_manage_external_data_amv_calibration_status.py
+++ b/tests/tools/test_manage_external_data_amv_calibration_status.py
@@ -1,4 +1,4 @@
-"""Tests for AMV calibration admission status in manage_external_data."""
+"""Tests AMV calibration admission status in manage_external_data."""
 
 from __future__ import annotations
 
@@ -24,8 +24,36 @@ def _write_manifest_with_status(tmp_path: Path, staging_status: str) -> Path:
     return manifest_path
 
 
+def _write_source_manifest(tmp_path: Path, *, source_type: str = "hardware_trace") -> Path:
+    payload = {
+        "schema_version": "amv_calibration_source_manifest.v1",
+        "manifest_id": f"test_{source_type}_source",
+        "issue": 1585,
+        "source_status": "ready",
+        "source_type": source_type,
+        "source_uri": "https://example.com/amv/source-bundle",
+        "license": "test-fixture-redistribution-approved",
+        "license_status": "accepted",
+        "claim_boundary": (
+            "platform_class_proxy"
+            if source_type == "platform_class_proxy"
+            else "hardware-calibrated"
+        ),
+        "calibration_fields": [
+            {
+                "name": "max_linear_accel_m_s2",
+                "support_status": "supported",
+                "units": "m/s^2",
+            }
+        ],
+    }
+    manifest_path = tmp_path / f"amv_{source_type}_source_manifest.yaml"
+    manifest_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return manifest_path
+
+
 def test_amv_calibration_status_defaults_to_blocked_external_input() -> None:
-    """Issue #2415 currently has no real AMV trace bundle and must fail closed."""
+    """Issue #2415 currently has no real AMV trace bundle and fails closed."""
     report = build_amv_calibration_status()
 
     assert report["schema"] == "amv_calibration_status.v1"
@@ -34,15 +62,18 @@ def test_amv_calibration_status_defaults_to_blocked_external_input() -> None:
     assert report["blocked_external_input"] is True
     assert "amv_calibration_asset_missing" in report["blockers"]
     assert "command_response_trace_manifest_not_ready" in report["blockers"]
+    assert "amv_calibration_source_manifest_not_ready" in report["blockers"]
     assert report["asset_status"]["status"] == "missing"
     assert report["trace_manifest_report"]["manifest_status"] == "blocked-external-input"
     assert report["trace_manifest_report"]["calibration_ingest_allowed"] is False
+    assert report["source_manifest_report"]["source_status"] == "blocked-external-input"
+    assert report["source_manifest_report"]["hardware_calibration_claim_allowed"] is False
 
 
 def test_amv_calibration_status_does_not_admit_asset_without_staged_manifest(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """A present asset is insufficient while the issue #2415 trace manifest remains blocked."""
+    """A present asset is insufficient while issue #2415 trace manifest remains blocked."""
     external_root = tmp_path / "external"
     amv_bundle = external_root / "amv_calibration"
     amv_bundle.mkdir(parents=True)
@@ -53,22 +84,66 @@ def test_amv_calibration_status_does_not_admit_asset_without_staged_manifest(
 
     assert report["asset_status"]["status"] == "available"
     assert report["ready"] is False
-    assert report["blockers"] == ["command_response_trace_manifest_not_ready"]
+    assert report["blockers"] == [
+        "command_response_trace_manifest_not_ready",
+        "amv_calibration_source_manifest_not_ready",
+    ]
     assert report["trace_manifest_report"]["manifest_status"] == "blocked-external-input"
 
 
-def test_amv_calibration_status_admits_staged_manifest_and_asset(
+def test_amv_calibration_status_rejects_staged_manifest_without_source_provenance(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """A staged bundle plus staged manifest is the future calibration-admission condition."""
+    """A staged bundle and trace manifest still need issue #1585 source provenance."""
     external_root = tmp_path / "external"
     amv_bundle = external_root / "amv_calibration"
     amv_bundle.mkdir(parents=True)
     (amv_bundle / "source.yaml").write_text("source: maintainer-accepted\n", encoding="utf-8")
     monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(external_root))
-    staged_manifest = _write_manifest_with_status(tmp_path, "staged")
 
+    staged_manifest = _write_manifest_with_status(tmp_path, "staged")
     report = build_amv_calibration_status(staged_manifest)
+
+    assert report["asset_status"]["status"] == "available"
+    assert report["ready"] is False
+    assert report["blockers"] == ["amv_calibration_source_manifest_not_ready"]
+    assert report["trace_manifest_report"]["manifest_status"] == "ready"
+    assert report["trace_manifest_report"]["calibration_ingest_allowed"] is True
+
+
+def test_amv_calibration_status_rejects_platform_class_proxy_source(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A proxy source can be ready for proxy wording but not hardware-calibrated admission."""
+    external_root = tmp_path / "external"
+    amv_bundle = external_root / "amv_calibration"
+    amv_bundle.mkdir(parents=True)
+    (amv_bundle / "source.yaml").write_text("source: maintainer-accepted\n", encoding="utf-8")
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(external_root))
+
+    staged_manifest = _write_manifest_with_status(tmp_path, "staged")
+    source_manifest = _write_source_manifest(tmp_path, source_type="platform_class_proxy")
+    report = build_amv_calibration_status(staged_manifest, source_manifest)
+
+    assert report["ready"] is False
+    assert report["blockers"] == ["amv_calibration_source_not_hardware_calibrated"]
+    assert report["source_manifest_report"]["source_status"] == "ready"
+    assert report["source_manifest_report"]["hardware_calibration_claim_allowed"] is False
+
+
+def test_amv_calibration_status_admits_staged_manifest_asset_and_hardware_source(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Future admission requires staged trace, asset presence, and hardware source provenance."""
+    external_root = tmp_path / "external"
+    amv_bundle = external_root / "amv_calibration"
+    amv_bundle.mkdir(parents=True)
+    (amv_bundle / "source.yaml").write_text("source: maintainer-accepted\n", encoding="utf-8")
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(external_root))
+
+    staged_manifest = _write_manifest_with_status(tmp_path, "staged")
+    source_manifest = _write_source_manifest(tmp_path)
+    report = build_amv_calibration_status(staged_manifest, source_manifest)
 
     assert report["asset_status"]["status"] == "available"
     assert report["ready"] is True
@@ -76,3 +151,5 @@ def test_amv_calibration_status_admits_staged_manifest_and_asset(
     assert report["blockers"] == []
     assert report["trace_manifest_report"]["manifest_status"] == "ready"
     assert report["trace_manifest_report"]["calibration_ingest_allowed"] is True
+    assert report["source_manifest_report"]["source_status"] == "ready"
+    assert report["source_manifest_report"]["hardware_calibration_claim_allowed"] is True


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `amv-calibration-status` now gates admission on the #1585 AMV calibration source-provenance manifest in addition to the existing external-data asset and #2415 command-response trace manifest checks.

Why now: issue #1585 remains hard-blocked on real hardware-calibrated source provenance, and prior slices already added standalone manifest/checker pieces. This slice consolidates those contracts at the live admission endpoint so staged files plus a clean trace manifest cannot bypass source-provenance readiness.

Claim boundary: support-tooling contract only. No external data was collected, staged, copied, ingested, calibrated, or promoted; no paper/dissertation claim surface changed.

Required validation: focused CPU tests for AMV calibration status, command-response trace manifest, and #1585 source manifest; Ruff check/format on touched files; CLI smoke for current blocked state.

Remaining blocker: #1585/#2000 still need a maintainer-accepted hardware trace, official specification, or other hardware-calibrated source provenance. Platform-class proxy sources remain insufficient for hardware-calibrated AMV admission.

## Contract delta

- New CLI option: `uv run python scripts/tools/manage_external_data.py --json amv-calibration-status --source-manifest <path>`.
- New status fields: `source_manifest_path`, `source_manifest_report`.
- New fail-closed blockers: `amv_calibration_source_manifest_not_ready`, `amv_calibration_source_not_hardware_calibrated`.
- Readiness now requires all three conditions: `amv-calibration` asset available, #2415 trace manifest allows calibration ingest, and #1585 source manifest is ready for hardware-calibrated AMV claims.
- Compatibility impact: additive JSON fields and CLI option; stricter readiness for the AMV calibration admission endpoint only.

<details>
<summary>Governance appendix</summary>

## Linked Issues

- Relates #1585
- Related blockers: #2000, #2415

## Scope Summary

In scope: integrate the existing #1585 source-provenance manifest checker into the existing `amv-calibration-status` admission path and update focused tests.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no raw external dataset storage, no calibration run, no benchmark or metric semantics change.

## Fragmentation / Prior Coverage

Prior merged slices included the standalone #1585 source manifest checker (#3794) and the `amv-calibration-status` endpoint for #2415 (#4512). This PR adds a new named capability: source-provenance admission integration at `amv-calibration-status`, including explicit platform-class proxy rejection for hardware-calibrated admission.

Late issue check: re-read #1585 after implementation on 2026-07-05; latest maintainer comment remains 2026-07-04 23:04:30Z and confirms the issue is blocked on unavailable/licensed external data. No newer guidance was missed.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_manage_external_data_amv_calibration_status.py tests/research/test_amv_command_response_trace_manifest.py tests/benchmark/test_issue_1585_amv_calibration_source_manifest.py -q` - exit 0, 33 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/manage_external_data.py tests/tools/test_manage_external_data_amv_calibration_status.py` - exit 0, all checks passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/tools/manage_external_data.py tests/tools/test_manage_external_data_amv_calibration_status.py` - exit 0, 2 files already formatted.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/manage_external_data.py --json amv-calibration-status` - exit 2 expected current blocked state; decisive fields: `ready=false`, blockers include `amv_calibration_asset_missing`, `command_response_trace_manifest_not_ready`, `amv_calibration_source_manifest_not_ready`, source status `blocked-external-input`, hardware allowed `false`.

## Research Result Guidance

- Target claim / hypothesis / blocker: #1585/#2000 AMV calibration source-provenance blocker, support tooling only.
- Comparator or baseline: previous `amv-calibration-status` admitted on asset plus trace manifest only.
- Evidence tier: NA - support helper.
- Result classification: NA - no research result.
- Decision stop rule: calibration admission remains blocked until both real staged trace data and hardware-calibrated source provenance exist.
- Fallback/degraded exclusions: no benchmark execution path touched.

## Downstream Propagation

- Parent issue updated: no; `comment_issue_or_pr=false` in authorization. PR body is the canonical propagation surface for this low-churn slice.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no; #2000/#2415 already track remaining source/trace blockers.
- Not applicable because: no benchmark, registry, claim-map, leaderboard, paper-facing, or durable artifact result changed.

## Risks / Rollout

- Compatibility risks: clients that treated `amv-calibration-status.ready` as asset+trace-only will now see stricter fail-closed behavior until #1585 source provenance is ready.
- Failure modes: future source manifests marked platform-class proxy remain non-admissible for hardware-calibrated AMV calibration, by design.
- Rollback fallback plan: revert the source-manifest gate and tests to restore prior asset+trace-only readiness.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AMV calibration status checks now consider both command-response traces and source-provenance records.
  * Added support for supplying a separate source manifest when checking calibration readiness.

* **Bug Fixes**
  * Calibration readiness is now stricter and only reports ready when the asset, trace evidence, and approved source provenance all align.
  * Status output now includes clearer blockers and report details for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->