### PR TITLE
Issue #1134: add SocNavBench ETH traversible SVG converter

### DIFF
--- a/docs/socnav_assets_setup.md
+++ b/docs/socnav_assets_setup.md
@@ -180,6 +180,23 @@ step produces the exact `eth_traversible_pickle` input that
 `scripts/tools/validate_socnav_map_batch.py --batch-id eth_first --preflight` reports as missing,
 so generating it unblocks the ETH map conversion (issue #1134).
 
+## 8. Convert ETH Traversible to Robot SF SVG
+
+After `eth_first` source assets pass preflight, convert the staged ETH traversible into the planned
+Robot SF SVG map with:
+
+```bash
+uv run python scripts/tools/convert_socnavbench_traversible_to_svg.py \
+  --socnav-root /path/to/socnavbench \
+  --output-svg maps/svg_maps/socnavbench/socnavbench_eth.svg \
+  --report-json output/maps/issue_1134_socnavbench_eth_conversion.json
+```
+
+Use `--dry-run` to validate the source pickle and conversion shape without writing the SVG. If the
+official `traversibles/ETH/data.pkl` is absent or malformed, the converter exits `2` and writes no
+placeholder map. This is conversion tooling only; it is not benchmark evidence until the generated
+SVG passes parser and smoke validation on staged source assets.
+
 ## Licensing and Repository Hygiene
 
 - Do not commit downloaded dataset assets.

--- a/scripts/tools/convert_socnavbench_traversible_to_svg.py
+++ b/scripts/tools/convert_socnavbench_traversible_to_svg.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Convert a staged SocNavBench traversible pickle into a Robot SF SVG map.
+
+This is the narrow issue #1134 conversion path: it consumes the official
+``traversibles/ETH/data.pkl`` staging contract and produces a reviewable SVG
+map artifact. It never downloads data and it refuses to write a placeholder map
+when the staged source pickle is absent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pickle
+from collections import deque
+from dataclasses import dataclass
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+from xml.sax.saxutils import escape
+
+import numpy as np
+
+from scripts.tools.manage_external_data import resolve_asset_local_path_by_id
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT = REPO_ROOT / "maps" / "svg_maps" / "socnavbench" / "socnavbench_eth.svg"
+EXIT_BLOCKED = 2
+SOCNAV_ASSET_ID = "socnavbench-s3dis-eth"
+ETH_TRAVERSIBLE_RELATIVE_PATH = (
+    Path("sd3dis") / "stanford_building_parser_dataset" / "traversibles" / "ETH" / "data.pkl"
+)
+
+
+@dataclass(frozen=True)
+class GridPoint:
+    """A traversible grid point in row/column coordinates."""
+
+    row: int
+    col: int
+
+
+@dataclass(frozen=True)
+class RectRun:
+    """Axis-aligned run of obstacle cells in half-open grid coordinates."""
+
+    row_start: int
+    row_end: int
+    col_start: int
+    col_end: int
+
+
+@dataclass(frozen=True)
+class TraversibleMap:
+    """Validated SocNavBench traversible payload ready for SVG conversion."""
+
+    resolution: float
+    traversible: np.ndarray
+    source_path: Path
+
+    @property
+    def cell_size(self) -> float:
+        """Return cell edge length in map units."""
+
+        return 1.0 / self.resolution
+
+    @property
+    def width(self) -> float:
+        """Return map width in Robot SF SVG units."""
+
+        return float(self.traversible.shape[1]) * self.cell_size
+
+    @property
+    def height(self) -> float:
+        """Return map height in Robot SF SVG units."""
+
+        return float(self.traversible.shape[0]) * self.cell_size
+
+
+class SocNavBenchConversionError(RuntimeError):
+    """Raised when staged SocNavBench data cannot be converted safely."""
+
+
+def sha256_file(path: Path) -> str:
+    """Return SHA-256 hex digest for ``path``."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_traversible(path: Path) -> TraversibleMap:
+    """Load and validate a SocNavBench traversible ``data.pkl`` file."""
+
+    try:
+        with path.open("rb") as handle:
+            payload = pickle.load(handle)
+    except Exception as exc:  # pragma: no cover - exact pickle failure varies.
+        raise SocNavBenchConversionError(f"Could not load traversible pickle: {path}") from exc
+
+    if not isinstance(payload, dict):
+        raise SocNavBenchConversionError("Traversible pickle must contain a mapping payload.")
+    if "resolution" not in payload or "traversible" not in payload:
+        raise SocNavBenchConversionError(
+            "Traversible pickle missing required keys: resolution, traversible."
+        )
+
+    resolution = float(payload["resolution"])
+    if not np.isfinite(resolution) or resolution <= 0:
+        raise SocNavBenchConversionError("Traversible resolution must be finite and positive.")
+
+    traversible = np.asarray(payload["traversible"])
+    if traversible.ndim != 2 or 0 in traversible.shape:
+        raise SocNavBenchConversionError("Traversible array must be non-empty and two-dimensional.")
+    if np.issubdtype(traversible.dtype, np.number) and not np.isfinite(traversible).all():
+        raise SocNavBenchConversionError("Traversible array contains non-finite values.")
+
+    free_mask = traversible.astype(bool)
+    if not free_mask.any():
+        raise SocNavBenchConversionError("Traversible array contains no free cells.")
+    return TraversibleMap(resolution=resolution, traversible=free_mask, source_path=path)
+
+
+def _neighbors(point: GridPoint, shape: tuple[int, int]) -> list[GridPoint]:
+    """Return four-connected in-bounds neighbors."""
+
+    rows, cols = shape
+    candidates = (
+        GridPoint(point.row - 1, point.col),
+        GridPoint(point.row + 1, point.col),
+        GridPoint(point.row, point.col - 1),
+        GridPoint(point.row, point.col + 1),
+    )
+    return [
+        candidate
+        for candidate in candidates
+        if 0 <= candidate.row < rows and 0 <= candidate.col < cols
+    ]
+
+
+def largest_component(mask: np.ndarray) -> set[GridPoint]:
+    """Return the largest four-connected free-space component."""
+
+    seen: set[GridPoint] = set()
+    best: set[GridPoint] = set()
+    rows, cols = mask.shape
+    for row in range(rows):
+        for col in range(cols):
+            start = GridPoint(row, col)
+            if not mask[row, col] or start in seen:
+                continue
+            component: set[GridPoint] = set()
+            queue: deque[GridPoint] = deque([start])
+            seen.add(start)
+            while queue:
+                point = queue.popleft()
+                component.add(point)
+                for neighbor in _neighbors(point, mask.shape):
+                    if mask[neighbor.row, neighbor.col] and neighbor not in seen:
+                        seen.add(neighbor)
+                        queue.append(neighbor)
+            if len(component) > len(best):
+                best = component
+    if not best:
+        raise SocNavBenchConversionError("No connected traversible component found.")
+    return best
+
+
+def select_route_endpoints(component: set[GridPoint]) -> tuple[GridPoint, GridPoint]:
+    """Select deterministic left-to-right endpoints inside a free-space component."""
+
+    ordered = sorted(component, key=lambda point: (point.col, point.row))
+    start_col = ordered[0].col
+    goal_col = ordered[-1].col
+    start_candidates = [point for point in ordered if point.col == start_col]
+    goal_candidates = [point for point in ordered if point.col == goal_col]
+    median_row = sorted(point.row for point in component)[len(component) // 2]
+    start = min(start_candidates, key=lambda point: (abs(point.row - median_row), point.row))
+    goal = min(goal_candidates, key=lambda point: (abs(point.row - median_row), point.row))
+    if start == goal:
+        raise SocNavBenchConversionError("Largest traversible component is too small for a route.")
+    return start, goal
+
+
+def shortest_path(mask: np.ndarray, start: GridPoint, goal: GridPoint) -> list[GridPoint]:
+    """Return a deterministic four-connected shortest path between two free cells."""
+
+    queue: deque[GridPoint] = deque([start])
+    previous: dict[GridPoint, GridPoint | None] = {start: None}
+    while queue:
+        point = queue.popleft()
+        if point == goal:
+            break
+        for neighbor in _neighbors(point, mask.shape):
+            if mask[neighbor.row, neighbor.col] and neighbor not in previous:
+                previous[neighbor] = point
+                queue.append(neighbor)
+    if goal not in previous:
+        raise SocNavBenchConversionError("No traversible path connects selected route endpoints.")
+
+    path: list[GridPoint] = []
+    cursor: GridPoint | None = goal
+    while cursor is not None:
+        path.append(cursor)
+        cursor = previous[cursor]
+    return list(reversed(path))
+
+
+def simplify_path(path: list[GridPoint]) -> list[GridPoint]:
+    """Drop intermediate collinear grid points from a route path."""
+
+    if len(path) <= 2:
+        return path
+    simplified = [path[0]]
+    prev_direction: tuple[int, int] | None = None
+    for left, right in pairwise(path):
+        direction = (right.row - left.row, right.col - left.col)
+        if prev_direction is not None and direction != prev_direction:
+            simplified.append(left)
+        prev_direction = direction
+    simplified.append(path[-1])
+    return simplified
+
+
+def obstacle_runs(mask: np.ndarray) -> list[RectRun]:
+    """Merge non-traversible cells into row-aligned rectangular obstacle runs."""
+
+    active: dict[tuple[int, int], RectRun] = {}
+    finished: list[RectRun] = []
+    for row in range(mask.shape[0]):
+        row_runs: list[tuple[int, int]] = []
+        col = 0
+        while col < mask.shape[1]:
+            if mask[row, col]:
+                col += 1
+                continue
+            start_col = col
+            while col < mask.shape[1] and not mask[row, col]:
+                col += 1
+            row_runs.append((start_col, col))
+
+        next_active: dict[tuple[int, int], RectRun] = {}
+        for run in row_runs:
+            previous = active.pop(run, None)
+            if previous is None:
+                next_active[run] = RectRun(row, row + 1, run[0], run[1])
+            else:
+                next_active[run] = RectRun(
+                    previous.row_start, row + 1, previous.col_start, previous.col_end
+                )
+        finished.extend(active.values())
+        active = next_active
+    finished.extend(active.values())
+    return finished
+
+
+def grid_center(point: GridPoint, cell_size: float) -> tuple[float, float]:
+    """Return SVG-space center coordinate for a grid cell."""
+
+    return ((point.col + 0.5) * cell_size, (point.row + 0.5) * cell_size)
+
+
+def _format_float(value: float) -> str:
+    """Format floats compactly while keeping SVG stable."""
+
+    return f"{value:.6f}".rstrip("0").rstrip(".")
+
+
+def _path_d(points: list[GridPoint], cell_size: float) -> str:
+    """Return SVG path data from grid points."""
+
+    coords = [grid_center(point, cell_size) for point in points]
+    head = coords[0]
+    tail = coords[1:]
+    parts = [f"M {_format_float(head[0])},{_format_float(head[1])}"]
+    parts.extend(f"L {_format_float(x)},{_format_float(y)}" for x, y in tail)
+    return " ".join(parts)
+
+
+def _zone_rect(point: GridPoint, cell_size: float) -> tuple[float, float, float, float]:
+    """Return a one-cell SVG rect centered on ``point``."""
+
+    center_x, center_y = grid_center(point, cell_size)
+    return center_x - cell_size / 2.0, center_y - cell_size / 2.0, cell_size, cell_size
+
+
+def render_svg(
+    map_data: TraversibleMap, *, map_id: str = "socnavbench_eth"
+) -> tuple[str, dict[str, Any]]:
+    """Render traversible data to SVG text and conversion metadata."""
+
+    component = largest_component(map_data.traversible)
+    start, goal = select_route_endpoints(component)
+    route = simplify_path(shortest_path(map_data.traversible, start, goal))
+    runs = obstacle_runs(map_data.traversible)
+    cell = map_data.cell_size
+
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8" standalone="no"?>',
+        (
+            f'<svg width="{_format_float(map_data.width)}" height="{_format_float(map_data.height)}" '
+            f'viewBox="0 0 {_format_float(map_data.width)} {_format_float(map_data.height)}" '
+            f'version="1.1" id="svg_{escape(map_id)}" '
+            'xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape">'
+        ),
+        f'  <g id="{escape(map_id)}" inkscape:label="SocNavBench ETH converted map">',
+        (
+            "    <!-- Generated from SocNavBench traversible data.pkl; "
+            "raw staged data remains outside git. -->"
+        ),
+    ]
+
+    for idx, run in enumerate(runs):
+        x = run.col_start * cell
+        y = run.row_start * cell
+        width = (run.col_end - run.col_start) * cell
+        height = (run.row_end - run.row_start) * cell
+        lines.append(
+            "    "
+            f'<rect id="obstacle_{idx}" x="{_format_float(x)}" y="{_format_float(y)}" '
+            f'width="{_format_float(width)}" height="{_format_float(height)}" '
+            'style="fill:#000000" inkscape:label="obstacle" />'
+        )
+
+    zone_specs = (
+        ("robot_spawn_zone_0", start, "#ffdf00"),
+        ("robot_goal_zone_0", goal, "#ff6c00"),
+        ("ped_spawn_zone_0", goal, "#29a35a"),
+        ("ped_goal_zone_0", start, "#246fe0"),
+    )
+    for label, point, fill in zone_specs:
+        x, y, width, height = _zone_rect(point, cell)
+        lines.append(
+            "    "
+            f'<rect id="{label}" x="{_format_float(x)}" y="{_format_float(y)}" '
+            f'width="{_format_float(width)}" height="{_format_float(height)}" '
+            f'style="fill:{fill}" inkscape:label="{label}" />'
+        )
+
+    robot_path = _path_d(route, cell)
+    ped_path = _path_d(list(reversed(route)), cell)
+    lines.extend(
+        [
+            (
+                f'    <path id="robot_route_0_0" d="{escape(robot_path)}" '
+                'style="fill:none;stroke:#0310b4;stroke-width:0.08" '
+                'inkscape:label="robot_route_0_0" />'
+            ),
+            (
+                f'    <path id="ped_route_0_0" d="{escape(ped_path)}" '
+                'style="fill:none;stroke:#00a05a;stroke-width:0.08" '
+                'inkscape:label="ped_route_0_0" />'
+            ),
+            "  </g>",
+            "</svg>",
+            "",
+        ]
+    )
+    metadata = {
+        "map_id": map_id,
+        "source_path": str(map_data.source_path),
+        "resolution": map_data.resolution,
+        "traversible_shape": list(map_data.traversible.shape),
+        "map_width": map_data.width,
+        "map_height": map_data.height,
+        "free_cell_count": int(map_data.traversible.sum()),
+        "obstacle_rect_count": len(runs),
+        "route_point_count": len(route),
+        "route_start_cell": [start.row, start.col],
+        "route_goal_cell": [goal.row, goal.col],
+    }
+    return "\n".join(lines), metadata
+
+
+def resolve_source(args: argparse.Namespace) -> Path:
+    """Resolve the input traversible pickle path from CLI arguments."""
+
+    if args.input_pkl is not None:
+        return args.input_pkl.expanduser().resolve()
+    socnav_root = (
+        args.socnav_root.expanduser().resolve()
+        if args.socnav_root is not None
+        else resolve_asset_local_path_by_id(SOCNAV_ASSET_ID).expanduser().resolve()
+    )
+    return socnav_root / ETH_TRAVERSIBLE_RELATIVE_PATH
+
+
+def write_report(path: Path | None, report: dict[str, Any]) -> None:
+    """Write optional JSON report."""
+
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build command-line parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--socnav-root", type=Path, default=None)
+    parser.add_argument("--input-pkl", type=Path, default=None)
+    parser.add_argument("--output-svg", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--report-json", type=Path, default=None)
+    parser.add_argument("--map-id", default="socnavbench_eth")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--max-obstacle-rects",
+        type=int,
+        default=50000,
+        help="Fail closed if conversion would emit more obstacle rectangles.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the SocNavBench traversible-to-SVG converter."""
+
+    args = build_arg_parser().parse_args(argv)
+    source = resolve_source(args)
+    output_svg = args.output_svg.expanduser().resolve()
+    if not source.is_file():
+        report = {
+            "status": "blocked_missing_traversible",
+            "conversion_ready": False,
+            "source_path": str(source),
+            "output_svg": str(output_svg),
+            "next_action": (
+                "Stage official SocNavBench ETH traversible data.pkl via the external-data "
+                "contract, then re-run this converter. No placeholder SVG was written."
+            ),
+        }
+        print(json.dumps(report, indent=2, sort_keys=True))
+        write_report(args.report_json, report)
+        return EXIT_BLOCKED
+
+    try:
+        map_data = load_traversible(source)
+        svg_text, metadata = render_svg(map_data, map_id=args.map_id)
+    except SocNavBenchConversionError as exc:
+        report = {
+            "status": "blocked_invalid_traversible",
+            "conversion_ready": False,
+            "source_path": str(source),
+            "output_svg": str(output_svg),
+            "error": str(exc),
+        }
+        print(json.dumps(report, indent=2, sort_keys=True))
+        write_report(args.report_json, report)
+        return EXIT_BLOCKED
+
+    if metadata["obstacle_rect_count"] > args.max_obstacle_rects:
+        report = {
+            **metadata,
+            "status": "blocked_too_many_obstacle_rects",
+            "conversion_ready": False,
+            "source_sha256": sha256_file(source),
+            "output_svg": str(output_svg),
+            "max_obstacle_rects": args.max_obstacle_rects,
+        }
+        print(json.dumps(report, indent=2, sort_keys=True))
+        write_report(args.report_json, report)
+        return EXIT_BLOCKED
+
+    report = {
+        **metadata,
+        "status": "dry_run_ready" if args.dry_run else "converted",
+        "conversion_ready": True,
+        "source_sha256": sha256_file(source),
+        "output_svg": str(output_svg),
+        "wrote_svg": not args.dry_run,
+    }
+    if not args.dry_run:
+        output_svg.parent.mkdir(parents=True, exist_ok=True)
+        output_svg.write_text(svg_text, encoding="utf-8")
+        report["output_sha256"] = sha256_file(output_svg)
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    write_report(args.report_json, report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/broad_exception_baseline.json
+++ b/scripts/validation/broad_exception_baseline.json
@@ -78,6 +78,7 @@
       "scripts/tools/classify_observation_noise_mechanisms.py": 1,
       "scripts/tools/compare_holonomic_vs_differential_rollout.py": 1,
       "scripts/tools/compile_benchmark_artifacts.py": 1,
+      "scripts/tools/convert_socnavbench_traversible_to_svg.py": 1,
       "scripts/tools/generate_next_issue_shortlist.py": 1,
       "scripts/tools/generate_odd_hazard_coverage_matrix.py": 1,
       "scripts/tools/generate_scenario_atlas.py": 1,
@@ -126,7 +127,7 @@
       "scripts/validation/verify_maps.py": 1,
       "scripts/validation/verify_sf_implementation.py": 4
     },
-    "total": 285
+    "total": 286
   },
   "description": "Broad exception handler baseline for benchmark/script surfaces. Run scripts/validation/check_broad_exceptions.py --write-baseline to refresh after intentionally removing or approving entries.",
   "entries": [
@@ -1965,6 +1966,15 @@
       "lineno": 455,
       "path": "scripts/tools/compile_benchmark_artifacts.py",
       "source": "except Exception as exc:"
+    },
+    {
+      "col_offset": 4,
+      "context": "load_traversible",
+      "fingerprint": "49bd66ffcc64c649",
+      "handler": "Exception",
+      "lineno": 101,
+      "path": "scripts/tools/convert_socnavbench_traversible_to_svg.py",
+      "source": "except Exception as exc:  # pragma: no cover - exact pickle failure varies."
     },
     {
       "col_offset": 4,

--- a/tests/tools/test_convert_socnavbench_traversible_to_svg.py
+++ b/tests/tools/test_convert_socnavbench_traversible_to_svg.py
@@ -1,0 +1,141 @@
+"""Tests for SocNavBench traversible-to-SVG conversion."""
+
+from __future__ import annotations
+
+import pickle
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from robot_sf.maps.verification.svg_inspection import inspect_svg
+from robot_sf.nav.svg_map_parser import convert_map
+from scripts.tools import convert_socnavbench_traversible_to_svg as converter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_traversible(path: Path, traversible: np.ndarray, *, resolution: float = 2.0) -> None:
+    """Write a minimal SocNavBench-compatible traversible pickle."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as handle:
+        pickle.dump(
+            {"resolution": resolution, "traversible": traversible},
+            handle,
+            protocol=2,
+        )
+
+
+def test_fixture_traversible_converts_to_parser_valid_svg(tmp_path: Path) -> None:
+    """A staged traversible fixture should produce Robot SF parser-facing map primitives."""
+
+    pkl_path = tmp_path / "data.pkl"
+    output_svg = tmp_path / "socnavbench_eth.svg"
+    _write_traversible(
+        pkl_path,
+        np.array(
+            [
+                [False, False, False, False, False, False],
+                [True, True, True, False, True, True],
+                [False, False, True, True, True, False],
+                [False, False, False, False, False, False],
+            ],
+            dtype=bool,
+        ),
+    )
+
+    exit_code = converter.main(
+        [
+            "--input-pkl",
+            str(pkl_path),
+            "--output-svg",
+            str(output_svg),
+        ]
+    )
+
+    assert exit_code == 0
+    map_def = convert_map(str(output_svg))
+    assert map_def.obstacles
+    assert map_def.robot_spawn_zones
+    assert map_def.robot_goal_zones
+    assert map_def.robot_routes
+    assert map_def.ped_spawn_zones
+    assert map_def.ped_goal_zones
+    assert map_def.ped_routes
+
+    inspection = inspect_svg(output_svg)
+    assert inspection.capability_metadata.has_robot_runtime_routes is True
+    assert inspection.capability_metadata.has_pedestrian_runtime_routes is True
+    assert inspection.capability_metadata.has_explicit_robot_runtime_zones is True
+    assert inspection.capability_metadata.has_explicit_pedestrian_runtime_zones is True
+
+
+def test_dry_run_reports_ready_without_writing_svg(tmp_path: Path) -> None:
+    """Dry-run mode validates conversion shape but leaves output untouched."""
+
+    pkl_path = tmp_path / "data.pkl"
+    output_svg = tmp_path / "socnavbench_eth.svg"
+    report_json = tmp_path / "report.json"
+    _write_traversible(pkl_path, np.ones((3, 4), dtype=bool))
+
+    exit_code = converter.main(
+        [
+            "--input-pkl",
+            str(pkl_path),
+            "--output-svg",
+            str(output_svg),
+            "--report-json",
+            str(report_json),
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    assert not output_svg.exists()
+    assert '"status": "dry_run_ready"' in report_json.read_text(encoding="utf-8")
+
+
+def test_missing_official_source_fails_closed_without_placeholder(tmp_path: Path) -> None:
+    """Absent staged traversible should exit blocked and not write a placeholder SVG."""
+
+    output_svg = tmp_path / "socnavbench_eth.svg"
+    report_json = tmp_path / "blocked.json"
+
+    exit_code = converter.main(
+        [
+            "--input-pkl",
+            str(tmp_path / "missing" / "data.pkl"),
+            "--output-svg",
+            str(output_svg),
+            "--report-json",
+            str(report_json),
+        ]
+    )
+
+    assert exit_code == converter.EXIT_BLOCKED
+    assert not output_svg.exists()
+    report_text = report_json.read_text(encoding="utf-8")
+    assert '"status": "blocked_missing_traversible"' in report_text
+    assert '"conversion_ready": false' in report_text
+
+
+def test_invalid_traversible_payload_fails_closed(tmp_path: Path) -> None:
+    """Malformed source pickles should fail closed instead of emitting a map."""
+
+    pkl_path = tmp_path / "data.pkl"
+    output_svg = tmp_path / "socnavbench_eth.svg"
+    with pkl_path.open("wb") as handle:
+        pickle.dump({"resolution": 2.0}, handle, protocol=2)
+
+    exit_code = converter.main(
+        [
+            "--input-pkl",
+            str(pkl_path),
+            "--output-svg",
+            str(output_svg),
+        ]
+    )
+
+    assert exit_code == converter.EXIT_BLOCKED
+    assert not output_svg.exists()


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds `scripts/tools/convert_socnavbench_traversible_to_svg.py`, a deterministic CPU-only converter from staged SocNavBench ETH `traversibles/ETH/data.pkl` to the planned Robot SF SVG map, plus fixture tests and runbook docs.
- **Why now:** Previous #1134/#1498 slices defined readiness/staging/generation gates; this progression slice adds the missing nameable conversion capability without fabricating a placeholder map.
- **Claim boundary:** Tooling and fixture/parser proof only. On `auxme-imech039`, the official ETH traversible is still absent, so no real `maps/svg_maps/socnavbench/socnavbench_eth.svg` is generated or committed.
- **Required validation:** Focused converter and existing batch-validator tests, Ruff, docs/diff checks, and absent-source fail-closed smoke below.
- **Remaining blocker:** Stage official/user-supplied ETH mesh/traversible under the SocNavBench external-data root, then run the converter for the real SVG and follow with parser/smoke validation.

Issue: https://github.com/ll7/robot_sf_ll7/issues/1134

## Contract delta

- **New tool:** `scripts/tools/convert_socnavbench_traversible_to_svg.py`.
- **Input contract:** SocNavBench traversible pickle mapping with `resolution` and 2D `traversible`; default path resolves through `socnavbench-s3dis-eth` external-data root to `sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl`.
- **Output contract:** Robot SF SVG at caller-selected `--output-svg` with generated obstacle rectangles, explicit robot/pedestrian spawn and goal zones, and BFS-backed robot/pedestrian route paths.
- **New fail-closed blockers:** missing source pickle, malformed traversible payload, empty/no-route traversible, or excessive obstacle-rectangle output all exit `2` and write no placeholder SVG.
- **Compatibility impact:** additive CLI/docs/tests only; no existing validator semantics changed and no raw/generated SocNavBench data is tracked.

## Validation

| Command | Exit | Result |
| --- | ---: | --- |
| `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format scripts/tools/convert_socnavbench_traversible_to_svg.py tests/tools/test_convert_socnavbench_traversible_to_svg.py` | 0 | 2 files left unchanged |
| `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/convert_socnavbench_traversible_to_svg.py tests/tools/test_convert_socnavbench_traversible_to_svg.py` | 0 | All checks passed |
| `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_validate_socnav_map_batch.py tests/tools/test_convert_socnavbench_traversible_to_svg.py -q` | 0 | 12 passed |
| `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/convert_socnavbench_traversible_to_svg.py --socnav-root /home/luttkule/external_data/socnavbench --dry-run --report-json /tmp/issue1134_convert_absent.json` | 2 | Expected fail-closed: `status=blocked_missing_traversible`; no SVG written |
| `git diff --check` / `git diff --cached --check` | 0 | no whitespace errors |
| `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_docs_evidence_integrity.py --base-ref origin/main` | 0 | no changed docs/evidence files to check |

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no dataset byte commit, no placeholder ETH-like SVG.

## Late-guidance check

Re-read issue #1134 immediately before opening this PR. Latest maintainer comment remains `2026-07-04T23:08:33Z`: conversion is blocked because `third_party/socnavbench/sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl` is not staged. This PR incorporates that guidance by adding converter capability while keeping absent real data fail-closed. No open PR covers #1134. Fragmentation guard: one related guard/checker PR (`#4519`) merged in the last 24h, below the two-PR threshold; this is a progression slice with new conversion capability, not another micro-guard.

<details>
<summary>Downstream propagation and governance</summary>

- **State propagation:** No issue comment posted because `comment_issue_or_pr=false` in this run authorization. No tracked queue-routing or host state added. PR body is the durable propagation surface for this low-churn slice; issue #1134 should remain open/blocked until real staged assets produce the SVG and parser/smoke proof.
- **Artifact policy:** `/tmp/issue1134_convert_absent.json` is local validation output only. No files under `output/` or raw SocNavBench assets were committed.
- **Research Result Guidance:** `NA - support/tooling slice`; no benchmark, metric, leaderboard, paper, or dissertation claim.

</details>
