### PR TITLE
validation: gate release claim matrix publication (#2910)

### DIFF
--- a/scripts/validation/check_release_claim_matrix_publication_gate.py
+++ b/scripts/validation/check_release_claim_matrix_publication_gate.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Fail-closed publication gate for the v0.1 release claim matrix.
+
+The gate is intentionally narrow: it checks the existing Issue #3294 release
+claim matrix against Issue #2910 publication prerequisites. It does not run a
+benchmark campaign, create certification records, or promote any claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+DEFAULT_MATRIX_PATH = Path(
+    "docs/context/evidence/issue_3294_release_claim_matrix/release_claim_matrix.json"
+)
+SCHEMA_VERSION = "release-claim-matrix-publication-gate.v1"
+EXPECTED_MATRIX_SCHEMA = "release_claim_matrix_issue_3294.v1"
+NOT_CERTIFIED_VALUES = {
+    "",
+    "missing",
+    "not_available",
+    "not_available_in_manifest",
+    "not_recorded",
+    "unknown",
+}
+
+
+@dataclass(frozen=True)
+class GateBlocker:
+    """One fail-closed blocker found in a release claim matrix row."""
+
+    row_id: str
+    check: str
+    severity: str
+    reason: str
+    next_action: str
+
+
+def get_repository_root() -> Path:
+    """Return repository root for default matrix and artifact path resolution."""
+
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    """Load a JSON object from ``path``."""
+
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _row_id(row: dict[str, Any], index: int) -> str:
+    """Return stable row identifier for reports."""
+
+    return str(row.get("row_id") or f"row:{index:03d}")
+
+
+def _path_exists(repo_root: Path, value: object) -> bool:
+    """Return whether a repository-relative file path exists."""
+
+    if not isinstance(value, str) or not value or value.startswith("output/"):
+        return False
+    return (repo_root / value).is_file()
+
+
+def _check_benchmark_evidence_row(
+    row: dict[str, Any],
+    *,
+    row_id: str,
+    repo_root: Path,
+) -> list[GateBlocker]:
+    """Check publication prerequisites for one benchmark-evidence row."""
+
+    blockers: list[GateBlocker] = []
+    if row.get("availability_status") != "available":
+        blockers.append(
+            GateBlocker(
+                row_id=row_id,
+                check="availability",
+                severity="blocker",
+                reason="benchmark-evidence row is not marked available",
+                next_action="Provide a durable available artifact or downgrade the row.",
+            )
+        )
+    if row.get("artifact_match") is not True:
+        blockers.append(
+            GateBlocker(
+                row_id=row_id,
+                check="artifact_match",
+                severity="blocker",
+                reason="benchmark-evidence row does not verify an artifact match",
+                next_action="Refresh the release evidence snapshot or exclude the row.",
+            )
+        )
+    if not _path_exists(repo_root, row.get("artifact_uri")):
+        blockers.append(
+            GateBlocker(
+                row_id=row_id,
+                check="artifact_uri",
+                severity="blocker",
+                reason="artifact_uri is missing, non-file, or points under output/",
+                next_action="Promote a durable artifact pointer before publication.",
+            )
+        )
+    certification = str(row.get("scenario_certification", "")).strip().lower()
+    if certification in NOT_CERTIFIED_VALUES:
+        blockers.append(
+            GateBlocker(
+                row_id=row_id,
+                check="scenario_certification",
+                severity="blocker",
+                reason=f"scenario certification is {certification or 'missing'}",
+                next_action="Attach scenario_cert.v1 status or keep the row out of the v0.1 publication set.",
+            )
+        )
+    source_refs = row.get("source_refs")
+    if not isinstance(source_refs, list) or not source_refs:
+        blockers.append(
+            GateBlocker(
+                row_id=row_id,
+                check="source_refs",
+                severity="blocker",
+                reason="benchmark-evidence row has no source_refs provenance",
+                next_action="Record tracked provenance sources for the row.",
+            )
+        )
+    elif any(not _path_exists(repo_root, source_ref) for source_ref in source_refs):
+        blockers.append(
+            GateBlocker(
+                row_id=row_id,
+                check="source_refs",
+                severity="blocker",
+                reason="one or more source_refs are missing or not tracked files",
+                next_action="Fix source_refs to repository files or remove the row.",
+            )
+        )
+    return blockers
+
+
+def build_gate_report(matrix: dict[str, Any], *, repo_root: Path) -> dict[str, Any]:
+    """Build deterministic publication-gate report for a release claim matrix."""
+
+    matrix_schema = matrix.get("schema_version")
+    if matrix_schema != EXPECTED_MATRIX_SCHEMA:
+        raise ValueError(
+            f"Matrix schema_version {matrix_schema!r}, expected {EXPECTED_MATRIX_SCHEMA!r}"
+        )
+    rows = matrix.get("rows")
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("Matrix must contain a non-empty rows list")
+
+    blockers: list[GateBlocker] = []
+    benchmark_rows = 0
+    diagnostic_or_non_claim_rows = 0
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"Matrix row {index} must be an object")
+        row_id = _row_id(row, index)
+        classification = str(row.get("classification", "")).strip().lower()
+        if classification == "benchmark evidence":
+            benchmark_rows += 1
+            blockers.extend(_check_benchmark_evidence_row(row, row_id=row_id, repo_root=repo_root))
+        else:
+            diagnostic_or_non_claim_rows += 1
+            if row.get("benchmark_success") is True:
+                blockers.append(
+                    GateBlocker(
+                        row_id=row_id,
+                        check="non_benchmark_promotion",
+                        severity="blocker",
+                        reason="non-benchmark row sets benchmark_success=true",
+                        next_action="Downgrade benchmark_success or reclassify with full evidence.",
+                    )
+                )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 2910,
+        "input_matrix_schema": matrix_schema,
+        "input_matrix_issue": matrix.get("issue"),
+        "status": "blocked" if blockers else "pass",
+        "claim_boundary": (
+            "CPU-only gate over existing tracked release claim matrix; no campaign, Slurm, "
+            "training, release, or paper claim promotion performed."
+        ),
+        "summary": {
+            "row_count": len(rows),
+            "benchmark_evidence_rows": benchmark_rows,
+            "diagnostic_or_non_claim_rows": diagnostic_or_non_claim_rows,
+            "blocker_count": len(blockers),
+        },
+        "blockers": [asdict(blocker) for blocker in blockers],
+    }
+
+
+def _render_text(report: dict[str, Any]) -> str:
+    """Render concise human-readable gate status."""
+
+    summary = report["summary"]
+    lines = [
+        f"status: {report['status']}",
+        f"rows: {summary['row_count']}",
+        f"benchmark_evidence_rows: {summary['benchmark_evidence_rows']}",
+        f"blockers: {summary['blocker_count']}",
+    ]
+    for blocker in report["blockers"]:
+        lines.append(
+            f"- {blocker['row_id']} [{blocker['check']}]: {blocker['reason']} "
+            f"next={blocker['next_action']}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--matrix",
+        type=Path,
+        default=None,
+        help="Release claim matrix JSON path.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root used to resolve matrix artifact paths.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON report.")
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve() if args.repo_root else get_repository_root()
+    matrix_path = args.matrix if args.matrix else repo_root / DEFAULT_MATRIX_PATH
+    try:
+        report = build_gate_report(_load_json(matrix_path), repo_root=repo_root)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(_render_text(report))
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/validation/test_check_release_claim_matrix_publication_gate.py
+++ b/tests/validation/test_check_release_claim_matrix_publication_gate.py
@@ -1,0 +1,141 @@
+"""Tests for the Issue #2910 release claim matrix publication gate."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.validation.check_release_claim_matrix_publication_gate import (
+    EXPECTED_MATRIX_SCHEMA,
+    build_gate_report,
+    main,
+)
+
+
+def _matrix(rows: list[dict]) -> dict:
+    """Build minimal release claim matrix fixture."""
+
+    return {
+        "schema_version": EXPECTED_MATRIX_SCHEMA,
+        "issue": 3294,
+        "rows": rows,
+    }
+
+
+def test_gate_passes_complete_benchmark_evidence_row(tmp_path) -> None:
+    """A benchmark-evidence row passes when publication prerequisites are present."""
+
+    artifact = tmp_path / "docs" / "context" / "evidence" / "artifact.json"
+    source = tmp_path / "docs" / "context" / "source.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("{}", encoding="utf-8")
+    source.write_text("{}", encoding="utf-8")
+
+    report = build_gate_report(
+        _matrix(
+            [
+                {
+                    "row_id": "release_artifact:complete",
+                    "classification": "benchmark evidence",
+                    "availability_status": "available",
+                    "artifact_match": True,
+                    "artifact_uri": "docs/context/evidence/artifact.json",
+                    "scenario_certification": "scenario_cert.v1:accepted",
+                    "source_refs": ["docs/context/source.json"],
+                }
+            ]
+        ),
+        repo_root=tmp_path,
+    )
+
+    assert report["status"] == "pass"
+    assert report["summary"]["blocker_count"] == 0
+
+
+def test_gate_fails_closed_for_missing_certification_and_output_artifact(tmp_path) -> None:
+    """Benchmark-evidence rows fail closed on missing certification and local outputs."""
+
+    source = tmp_path / "docs" / "context" / "source.json"
+    source.parent.mkdir(parents=True)
+    source.write_text("{}", encoding="utf-8")
+
+    report = build_gate_report(
+        _matrix(
+            [
+                {
+                    "row_id": "release_artifact:blocked",
+                    "classification": "benchmark evidence",
+                    "availability_status": "available",
+                    "artifact_match": True,
+                    "artifact_uri": "output/local.json",
+                    "scenario_certification": "not_available_in_manifest",
+                    "source_refs": ["docs/context/source.json"],
+                }
+            ]
+        ),
+        repo_root=tmp_path,
+    )
+
+    assert report["status"] == "blocked"
+    checks = {blocker["check"] for blocker in report["blockers"]}
+    assert checks == {"artifact_uri", "scenario_certification"}
+
+
+def test_gate_rejects_non_benchmark_success_promotion(tmp_path) -> None:
+    """Diagnostic and non-claim rows must not set benchmark_success true."""
+
+    report = build_gate_report(
+        _matrix(
+            [
+                {
+                    "row_id": "leaderboard:diagnostic",
+                    "classification": "diagnostic evidence",
+                    "benchmark_success": True,
+                }
+            ]
+        ),
+        repo_root=tmp_path,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"][0]["check"] == "non_benchmark_promotion"
+
+
+def test_committed_matrix_remains_blocked_until_certification_is_attached() -> None:
+    """Current tracked matrix is an integration surface, not a publication-ready claim."""
+
+    report_json = main(["--json"])
+
+    assert report_json == 1
+
+
+def test_cli_emits_json_report_for_synthetic_matrix(tmp_path, capsys) -> None:
+    """CLI JSON output is deterministic enough for downstream wrappers."""
+
+    artifact = tmp_path / "artifact.json"
+    source = tmp_path / "source.json"
+    artifact.write_text("{}", encoding="utf-8")
+    source.write_text("{}", encoding="utf-8")
+    matrix_path = tmp_path / "matrix.json"
+    matrix_path.write_text(
+        json.dumps(
+            _matrix(
+                [
+                    {
+                        "row_id": "release_artifact:complete",
+                        "classification": "benchmark evidence",
+                        "availability_status": "available",
+                        "artifact_match": True,
+                        "artifact_uri": "artifact.json",
+                        "scenario_certification": "accepted",
+                        "source_refs": ["source.json"],
+                    }
+                ]
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    assert main(["--matrix", str(matrix_path), "--repo-root", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "release-claim-matrix-publication-gate.v1"
+    assert payload["status"] == "pass"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a CPU-only fail-closed publication gate over the existing Issue #3294 release claim matrix for Issue #2910.

Why now: the #2910 epic already has prerequisite, readiness-dashboard, and release-claim-matrix slices; this PR adds the missing machine-checkable integration gate that says whether the current matrix is publication-ready.

Claim boundary: this does not run a benchmark campaign, create scenario certification, submit Slurm/GPU work, publish a release, or edit paper/dissertation claims. The current tracked matrix remains blocked because the three benchmark-evidence release-artifact rows have `scenario_certification=not_available_in_manifest`.

Required validation: focused validation script tests, Ruff lint/format, and final PR readiness wrapper.

Remaining blocker: attach accepted scenario certification status to publication candidate rows or keep those rows out of the v0.1 publication set.

Issue: https://github.com/ll7/robot_sf_ll7/issues/2910

## Contract delta

New capability: `scripts/validation/check_release_claim_matrix_publication_gate.py` reads `docs/context/evidence/issue_3294_release_claim_matrix/release_claim_matrix.json` and emits `release-claim-matrix-publication-gate.v1`.

New fail-closed blockers:
- benchmark-evidence rows must be available, artifact-matched, backed by a durable non-`output/` artifact file, carry non-missing scenario certification, and list existing source provenance files.
- diagnostic and non-claim rows must not set `benchmark_success=true`.

Compatibility impact: additive CLI and tests only. No existing schema is migrated, and no benchmark evidence is reclassified.

## Scope summary

- Added the #2910 release claim matrix publication gate.
- Added focused tests for passing rows, missing certification/local-output blockers, diagnostic promotion blockers, JSON CLI output, and the current committed matrix’s blocked status.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_release_claim_matrix_publication_gate.py tests/validation/test_check_release_claim_matrix_publication_gate.py` -> pass.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/check_release_claim_matrix_publication_gate.py tests/validation/test_check_release_claim_matrix_publication_gate.py` -> pass.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_release_claim_matrix_publication_gate.py -q` -> pass, 5 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_release_claim_matrix_publication_gate.py --json` -> expected exit 1; status `blocked`, blocker_count `3`, checks `scenario_certification`.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue2910-pr/body.md scripts/dev/pr_ready_check.sh` -> pass; freshness stamp recorded for `dccda06d667655cc2113ea9c46cafce77c9194c5`.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no training, no release/tag/upload, and no paper/dissertation claim edits.

## State propagation

No new issue comment is needed for this low-churn slice because the PR body is the durable propagation surface: it states the delivered new capability, current blocker, and remaining next action.

<details>
<summary>Governance appendix</summary>

Late issue refresh: checked Issue #2910 body/comments immediately before opening; latest maintainer comment remains 2026-06-21, with no newer guidance to incorporate.

Duplicate/fragmentation guard: no open PR covers #2910 or this exact gate scope; no #2910 PRs merged in the last 24 hours. This is a progression slice, not another micro-guard, because it adds a named new capability: the release claim matrix publication gate.

Forbidden actions confirmed: no compute submission, no merge, no release, no deletion.

</details>
