### PR TITLE
feat(benchmark): add issue #3283 AMV latency decision packet

### DIFF
--- a/robot_sf/benchmark/actuation_latency_measurement_manifest.py
+++ b/robot_sf/benchmark/actuation_latency_measurement_manifest.py
@@ -129,6 +129,16 @@ CONTRACT_STATUS_READY = "ready"
 CONTRACT_STATUS_BLOCKED = "blocked"
 CONTRACT_STATUS_SYNTHETIC_ONLY = "synthetic-only"
 
+ISSUE_3283_BLOCKED_STATE = "blocked-external-input"
+ISSUE_3283_REVIVAL_CONDITION = (
+    "real AMV command-response collection method becomes available and staged data "
+    "passes provenance review"
+)
+ISSUE_3283_NEXT_EMPIRICAL_ACTION = (
+    "locate or collect real AMV command-response traces with synchronized command, "
+    "mechanical/yaw response, braking, acceleration, rider-load, and rider-response channels"
+)
+
 
 class AmvActuationLatencyManifestError(ValueError):
     """Raised when an AMV actuation-latency measurement manifest fails schema checks."""
@@ -174,6 +184,29 @@ class AmvActuationLatencyManifestReport:
             + self.separation_blockers
             + self.proposed_field_blockers
         )
+
+
+@dataclass(frozen=True, slots=True)
+class AmvActuationLatencyDecisionPacket:
+    """Machine-readable issue #3283 decision state derived from an intake report."""
+
+    issue: int
+    manifest_id: str
+    contract_status: str
+    measurement_status: str
+    blocked_state: str | None
+    evidence_boundary: str
+    measured_value_claim_allowed: bool
+    claim_boundary: str
+    remaining_blockers: list[str]
+    required_input: str | None
+    next_empirical_action: str | None
+    unrelated_calibration_work_blocked: bool
+    revival_condition: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-safe dictionary representation."""
+        return asdict(self)
 
 
 @lru_cache(maxsize=1)
@@ -307,6 +340,55 @@ def check_amv_actuation_latency_measurement_manifest(
             "contract_status": contract_status,
             "measured_value_claim_allowed": claim_allowed,
         }
+    )
+
+
+def build_amv_actuation_latency_decision_packet(
+    manifest: Mapping[str, Any],
+    *,
+    source: str | Path | None = None,
+) -> AmvActuationLatencyDecisionPacket:
+    """Build a reviewer-facing decision packet for issue #3283.
+
+    The packet intentionally consumes only metadata already accepted by the
+    manifest checker. It does not read, stage, or infer real command-response
+    data, and it never upgrades synthetic or blocked manifests into measured
+    autonomous-micromobility-vehicle (AMV) evidence.
+
+    Returns:
+        Decision packet with claim boundary, blockers, and next empirical action.
+    """
+    report = check_amv_actuation_latency_measurement_manifest(manifest, source=source)
+    blocked_on_external_input = (
+        report.contract_status == CONTRACT_STATUS_BLOCKED
+        and report.measurement_status == ISSUE_3283_BLOCKED_STATE
+    )
+    remaining_blockers = report.blockers
+    if blocked_on_external_input and not remaining_blockers:
+        remaining_blockers = ["real AMV command-response data not staged or provenance-reviewed"]
+
+    return AmvActuationLatencyDecisionPacket(
+        issue=3283,
+        manifest_id=report.manifest_id,
+        contract_status=report.contract_status,
+        measurement_status=report.measurement_status,
+        blocked_state=ISSUE_3283_BLOCKED_STATE if blocked_on_external_input else None,
+        evidence_boundary=report.evidence_boundary,
+        measured_value_claim_allowed=report.measured_value_claim_allowed,
+        claim_boundary=(
+            "no measured AMV latency or rider-coupling claim"
+            if not report.measured_value_claim_allowed
+            else "measured manifest ready for downstream claim review"
+        ),
+        remaining_blockers=remaining_blockers,
+        required_input=(
+            "accepted real AMV command-response data" if blocked_on_external_input else None
+        ),
+        next_empirical_action=(
+            ISSUE_3283_NEXT_EMPIRICAL_ACTION if blocked_on_external_input else None
+        ),
+        unrelated_calibration_work_blocked=False,
+        revival_condition=ISSUE_3283_REVIVAL_CONDITION if blocked_on_external_input else None,
     )
 
 

--- a/tests/benchmark/test_issue_3283_amv_actuation_latency_measurement_manifest.py
+++ b/tests/benchmark/test_issue_3283_amv_actuation_latency_measurement_manifest.py
@@ -18,6 +18,7 @@ from robot_sf.benchmark.actuation_latency_measurement_manifest import (
     PROPOSED_RIDER_COUPLING_PROFILE_FIELDS,
     REQUIRED_MEASUREMENT_QUANTITIES,
     AmvActuationLatencyManifestError,
+    build_amv_actuation_latency_decision_packet,
     check_amv_actuation_latency_measurement_manifest,
     load_amv_actuation_latency_measurement_manifest,
 )
@@ -250,6 +251,51 @@ def test_example_manifest_loads_and_is_blocked_external_input() -> None:
     assert report.measured_value_claim_allowed is False
     # Example ships a complete plan: only the external data is missing.
     assert report.blockers == []
+
+
+def test_blocked_plan_decision_packet_names_required_external_input() -> None:
+    """Decision packet converts a complete blocked plan into next empirical action."""
+    manifest = load_amv_actuation_latency_measurement_manifest(EXAMPLE_MANIFEST_PATH)
+    packet = build_amv_actuation_latency_decision_packet(manifest)
+
+    assert packet.issue == 3283
+    assert packet.contract_status == CONTRACT_STATUS_BLOCKED
+    assert packet.blocked_state == "blocked-external-input"
+    assert packet.measured_value_claim_allowed is False
+    assert packet.required_input == "accepted real AMV command-response data"
+    assert packet.remaining_blockers == [
+        "real AMV command-response data not staged or provenance-reviewed"
+    ]
+    assert "locate or collect real AMV command-response traces" in packet.next_empirical_action
+    assert packet.unrelated_calibration_work_blocked is False
+    assert packet.to_dict()["claim_boundary"] == "no measured AMV latency or rider-coupling claim"
+
+
+def test_decision_packet_preserves_manifest_blockers() -> None:
+    """Malformed blocked plan keeps concrete blockers instead of generic data blocker."""
+    manifest = _manifest("blocked-external-input", "pending")
+    manifest["sensor_channels"] = [
+        channel for channel in manifest["sensor_channels"] if channel["quantity"] != "yaw_response"
+    ]
+
+    packet = build_amv_actuation_latency_decision_packet(manifest)
+
+    assert packet.blocked_state == "blocked-external-input"
+    assert any("yaw_response" in blocker for blocker in packet.remaining_blockers)
+    assert packet.required_input == "accepted real AMV command-response data"
+
+
+def test_ready_measured_decision_packet_not_marked_external_blocked() -> None:
+    """Ready measured manifests remain ready and do not inherit issue hard-block state."""
+    packet = build_amv_actuation_latency_decision_packet(_measured_manifest())
+
+    assert packet.contract_status == CONTRACT_STATUS_READY
+    assert packet.blocked_state is None
+    assert packet.measured_value_claim_allowed is True
+    assert packet.remaining_blockers == []
+    assert packet.required_input is None
+    assert packet.next_empirical_action is None
+    assert packet.revival_condition is None
 
 
 def test_example_manifest_yaml_is_well_formed() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Adds an issue #3283 AMV actuation-latency decision-packet capability on top of the existing intake manifest checker from PR #3747. The packet converts a manifest report into a machine-readable integration state: claim boundary, remaining blockers, required external input, revival condition, and next empirical action.

**Why now:** Issue #3283 is hard-blocked by maintainer guidance on 2026-06-22: realistic real-data source probability is <5%, keep tracked, no measured calibration claims. This slice consolidates that state in code so future automation can consume the blocked decision without inventing another transient queue surface.

**Claim boundary:** No measured AMV latency, rider-coupling, or calibrated-actuation value is asserted. A complete `blocked-external-input` plan reports `contract_status: blocked`, `measured_value_claim_allowed: false`, and the generic remaining blocker: real AMV command-response data is not staged or provenance-reviewed.

**Required validation:** Focused unit tests plus Ruff on the changed module/test file.

**Remaining blocker:** A real AMV command-response collection method and accepted staged data remain required before any measured profile promotion.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3283

## Contract delta

- New dataclass: `AmvActuationLatencyDecisionPacket`.
- New helper: `build_amv_actuation_latency_decision_packet(manifest, source=None)`.
- New stable blocked fields:
  - `blocked_state: blocked-external-input` for complete blocked plans.
  - `required_input: accepted real AMV command-response data`.
  - `next_empirical_action`: locate or collect real AMV command-response traces with synchronized command, mechanical/yaw response, braking, acceleration, rider-load, and rider-response channels.
  - `revival_condition`: real AMV command-response collection method becomes available and staged data passes provenance review.
- Compatibility impact: additive Python API only; no schema change, no manifest format change, no CLI behavior change.
- New capability beyond PR #3747: decision-packet integration output, not another manifest guard/checker.

## Validation

```bash
scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/actuation_latency_measurement_manifest.py tests/benchmark/test_issue_3283_amv_actuation_latency_measurement_manifest.py
# 1 file reformatted, 1 file left unchanged

scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/actuation_latency_measurement_manifest.py tests/benchmark/test_issue_3283_amv_actuation_latency_measurement_manifest.py
# All checks passed!

scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3283_amv_actuation_latency_measurement_manifest.py -q
# 17 passed
```

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No external data collected, staged, inferred, or promoted.

## Downstream propagation

No issue comment was posted because this run was authorized with `comment_issue_or_pr: false`. No tracked issue-state file was added because issue #3283 does not already have `docs/context/issue_3283_state.yaml`, and this PR intentionally avoids encoding transient queue-routing state in tracked files. The PR body is the propagation surface for this low-churn additive code slice.

<details>
<summary>Freshness and guardrails</summary>

- Live issue read immediately before PR open: no maintainer comments newer than run start; latest owner comment remains 2026-06-22 hard-block guidance.
- Open PR duplicate check immediately before PR open: no open PR covering #3283 or exact AMV latency/rider-coupling scope.
- Fragmentation guard: prior merged PR #3747 added the intake manifest checker; this PR adds a nameable new progression capability, the decision-packet integration output.
- Forbidden actions not performed: no compute submission, no merge, no release, no delete.

</details>
