### PR TITLE
Issue #3215: add scenario-family oracle readiness packet

### DIFF
--- a/scripts/tools/predictive_tournament_readiness.py
+++ b/scripts/tools/predictive_tournament_readiness.py
@@ -66,6 +66,21 @@ class ArmSpec:
     notes: str = ""
 
 
+@dataclass(frozen=True)
+class ProgressionSpec:
+    """Static definition for the next #3215 progression packet."""
+
+    packet_id: str
+    display_name: str
+    description: str
+    required_paths: tuple[Path, ...]
+    expected_output_path: Path
+    forecast_arms: tuple[str, ...]
+    outcomes: tuple[str, ...]
+    evidence_tier: str
+    notes: str = ""
+
+
 ARMS: tuple[ArmSpec, ...] = (
     ArmSpec(
         arm_id="selection",
@@ -117,6 +132,38 @@ ARMS: tuple[ArmSpec, ...] = (
             "Checks the frozen #3254 weighted crossing-conflict config for the #3214 "
             "model arm; retraining itself remains compute-gated."
         ),
+    ),
+)
+
+
+NEXT_PROGRESSION = ProgressionSpec(
+    packet_id="scenario_family_oracle_arm",
+    display_name="Scenario-family promotion packet with oracle forecast arm",
+    description=(
+        "Post-synthesis progression from the #3215 negative result: promote the "
+        "forecast-risk gate from a single fixture to a scenario-family packet and "
+        "include an oracle future-trajectory arm so later runs can separate planner "
+        "limits from prediction limits and scenario infeasibility."
+    ),
+    required_paths=(
+        Path("configs/scenarios/sets/predictive_hardcase_portfolio_v1.yaml"),
+        Path("scripts/benchmark/run_forecast_risk_coupling_gate.py"),
+        Path("robot_sf/benchmark/forecast_risk_adapter.py"),
+    ),
+    expected_output_path=Path("output/tmp/predictive_planner/campaigns/scenario_family_oracle_arm"),
+    forecast_arms=("none", "constant_velocity", "interaction_aware", "oracle_future"),
+    outcomes=(
+        "collision_rate",
+        "near_miss_rate",
+        "false_positive_stop_rate",
+        "progress_loss",
+        "stop_timing",
+        "forecast_risk_calibration",
+    ),
+    evidence_tier="diagnostic-only",
+    notes=(
+        "Presence-only packet readiness; does not generate the scenario family, "
+        "run paired seeds, or promote dissertation/paper claims."
     ),
 )
 
@@ -192,6 +239,30 @@ def evaluate_arm(repo_root: Path, arm: ArmSpec) -> ComponentReadiness:
     )
 
 
+def evaluate_next_progression(repo_root: Path) -> dict:
+    """Classify post-synthesis scenario-family/oracle-arm packet readiness."""
+    statuses, missing = _classify_paths(repo_root, NEXT_PROGRESSION.required_paths)
+    return {
+        "id": NEXT_PROGRESSION.packet_id,
+        "display_name": NEXT_PROGRESSION.display_name,
+        "status": "ready" if not missing else "blocked",
+        "paths": [{"path": p.path, "exists": p.exists} for p in statuses],
+        "expected_configs": [p.path for p in statuses if p.path.startswith("configs/")],
+        "blockers": [
+            {"path": path, "reason": "required scenario-family packet input is missing"}
+            for path in missing
+        ],
+        "missing_paths": missing,
+        "description": NEXT_PROGRESSION.description,
+        "expected_output_path": NEXT_PROGRESSION.expected_output_path.as_posix(),
+        "expected_output_paths": [NEXT_PROGRESSION.expected_output_path.as_posix()],
+        "forecast_arms": list(NEXT_PROGRESSION.forecast_arms),
+        "outcomes": list(NEXT_PROGRESSION.outcomes),
+        "evidence_tier": NEXT_PROGRESSION.evidence_tier,
+        "notes": NEXT_PROGRESSION.notes,
+    }
+
+
 def evaluate_readiness(repo_root: Path = REPO_ROOT) -> dict:
     """Build the full presence-only readiness report for the #3215 tournament.
 
@@ -201,6 +272,7 @@ def evaluate_readiness(repo_root: Path = REPO_ROOT) -> dict:
     """
     shared = evaluate_shared_protocol(repo_root)
     arms = [evaluate_arm(repo_root, arm) for arm in ARMS]
+    next_progression = evaluate_next_progression(repo_root)
 
     components_ready = shared.status == "ready" and all(a.status == "ready" for a in arms)
     prerequisites_status = "ready" if components_ready else "blocked"
@@ -214,6 +286,7 @@ def evaluate_readiness(repo_root: Path = REPO_ROOT) -> dict:
         "run_gates": list(RUN_GATES),
         "shared_protocol": _component_to_dict(shared),
         "arms": [_component_to_dict(a) for a in arms],
+        "next_progression": next_progression,
     }
 
 
@@ -268,6 +341,23 @@ def render_text(report: dict) -> str:
         if arm["missing_paths"]:
             lines.append(f"    blockers: {', '.join(arm['missing_paths'])}")
         lines.append("")
+
+    progression = report["next_progression"]
+    lines.append(
+        f"[next progression] {progression['display_name']}: {progression['status'].upper()}"
+    )
+    lines.append(f"  evidence tier: {progression['evidence_tier']}")
+    lines.append(f"  forecast arms: {', '.join(progression['forecast_arms'])}")
+    lines.append(f"  outcomes: {', '.join(progression['outcomes'])}")
+    for path in progression["paths"]:
+        mark = "ok " if path["exists"] else "MISS"
+        lines.append(f"  [{mark}] {path['path']}")
+    lines.append(f"  expected output: {progression['expected_output_path']}")
+    if progression["missing_paths"]:
+        lines.append(f"  blockers: {', '.join(progression['missing_paths'])}")
+    if progression.get("notes"):
+        lines.append(f"  note: {progression['notes']}")
+    lines.append("")
 
     lines.append("Run gates (must clear before launching; out of scope for this helper):")
     for gate in report["run_gates"]:

--- a/tests/test_predictive_tournament_readiness.py
+++ b/tests/test_predictive_tournament_readiness.py
@@ -13,9 +13,11 @@ import pytest
 
 from scripts.tools.predictive_tournament_readiness import (
     ARMS,
+    NEXT_PROGRESSION,
     RUN_GATES,
     SHARED_PROTOCOL_PATHS,
     evaluate_arm,
+    evaluate_next_progression,
     evaluate_readiness,
     main,
     render_text,
@@ -43,6 +45,8 @@ def _stage_all_prerequisites(repo_root: Path) -> None:
                 _touch(repo_root, rel)
             else:
                 (repo_root / rel).mkdir(parents=True, exist_ok=True)
+    for rel in NEXT_PROGRESSION.required_paths:
+        _touch(repo_root, rel)
 
 
 def test_all_present_reports_ready(tmp_path: Path) -> None:
@@ -100,6 +104,42 @@ def test_report_surfaces_expected_configs_and_output_paths(tmp_path: Path) -> No
         in model["expected_configs"]
     )
     assert selection["expected_output_paths"] == [selection["expected_output_path"]]
+
+
+def test_next_progression_reports_scenario_family_oracle_packet(tmp_path: Path) -> None:
+    """Report names the post-synthesis scenario-family/oracle-arm progression."""
+    _stage_all_prerequisites(tmp_path)
+
+    progression = evaluate_readiness(tmp_path)["next_progression"]
+
+    assert progression["id"] == "scenario_family_oracle_arm"
+    assert progression["status"] == "ready"
+    assert progression["evidence_tier"] == "diagnostic-only"
+    assert "oracle_future" in progression["forecast_arms"]
+    assert "collision_rate" in progression["outcomes"]
+    assert (
+        "configs/scenarios/sets/predictive_hardcase_portfolio_v1.yaml"
+        in progression["expected_configs"]
+    )
+    assert progression["expected_output_paths"] == [progression["expected_output_path"]]
+
+
+def test_next_progression_blocks_on_missing_packet_input(tmp_path: Path) -> None:
+    """Scenario-family packet readiness fails closed when an input is absent."""
+    _stage_all_prerequisites(tmp_path)
+    missing = NEXT_PROGRESSION.required_paths[0]
+    (tmp_path / missing).unlink()
+
+    progression = evaluate_next_progression(tmp_path)
+
+    assert progression["status"] == "blocked"
+    assert progression["missing_paths"] == [missing.as_posix()]
+    assert progression["blockers"] == [
+        {
+            "path": missing.as_posix(),
+            "reason": "required scenario-family packet input is missing",
+        }
+    ]
 
 
 def test_missing_shared_protocol_blocks_overall(tmp_path: Path) -> None:
@@ -171,6 +211,8 @@ def test_render_text_runs_and_mentions_status(tmp_path: Path) -> None:
 
     assert "tournament readiness" in text.lower()
     assert "READY" in text
+    assert "oracle_future" in text
+    assert "diagnostic-only" in text
 
 
 def test_main_exit_code_reflects_prerequisite_status(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a `scenario_family_oracle_arm` next-progression packet to the existing #3215 predictive tournament readiness helper. The report now names the post-synthesis scenario-family/oracle-arm contract proposed in the latest issue guidance: forecast arms, outcome surfaces, required local inputs, expected output path, diagnostic-only evidence tier, and fail-closed blockers.

Why now: #3215 already has multiple merged readiness/guard slices and the tournament synthesis is recorded. The newest maintainer guidance on 2026-06-23 points to promoting the forecast-risk gate from a single fixture to a scenario family with an oracle future-trajectory arm, so this PR adds that nameable progression capability instead of another micro-guard.

Claim boundary: presence-only local readiness metadata. This PR does not generate the scenario family, run paired seeds, rank planners, promote benchmark evidence, or edit paper/dissertation claims.

Required validation: focused helper tests, lint/format, helper JSON smoke, and final PR readiness where available.

Remaining blocker: actual scenario-family generation and any paired-seed campaign remain out of scope and still require explicit future implementation plus authorized compute.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3215

## Contract delta

New report field:
- `next_progression`: readiness packet for `scenario_family_oracle_arm`.

New packet metadata:
- `forecast_arms`: `none`, `constant_velocity`, `interaction_aware`, `oracle_future`.
- `outcomes`: collision rate, near-miss rate, false-positive stop rate, progress loss, stop timing, forecast-risk calibration.
- `evidence_tier`: `diagnostic-only`.
- `expected_output_paths`: `output/tmp/predictive_planner/campaigns/scenario_family_oracle_arm`.

New fail-closed blockers:
- Missing scenario-family packet inputs produce `blockers` entries with reason `required scenario-family packet input is missing`.

Compatibility impact:
- Existing `shared_protocol`, `arms`, `run_authorized`, and `run_gates` fields are unchanged.
- `run_authorized` remains `false`; this helper still cannot authorize or submit compute.

## Scope summary

In scope:
- Extend `scripts/tools/predictive_tournament_readiness.py` with the scenario-family/oracle-arm next-progression packet.
- Add focused tests for ready/blocked packet status, oracle-arm metadata, diagnostic-only tier, and text rendering.

Out of scope:
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No tracked transient queue-routing state, target-host state, or packet lineage pointers.

## Validation

- `uv run ruff format scripts/tools/predictive_tournament_readiness.py tests/test_predictive_tournament_readiness.py` - passed, 2 files left unchanged.
- `uv run ruff check scripts/tools/predictive_tournament_readiness.py tests/test_predictive_tournament_readiness.py` - passed.
- `uv run pytest tests/test_predictive_tournament_readiness.py -q` - passed, 16 tests.
- `uv run python scripts/tools/predictive_tournament_readiness.py --json` - passed, exit 0; `next_progression.id=scenario_family_oracle_arm`, `status=ready`, `evidence_tier=diagnostic-only`, `run_authorized=false`.
- `git diff --check` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=/tmp/issue3215_pr_body.md scripts/dev/pr_ready_check.sh` - passed; freshness stamp `output/validation/pr_ready/issue-3215-breakthrough-portfolio-scenario-family.json` recorded `status=passed` for head `13d9098bfc96c326370603dc534b6ae7fe4ca70d`.

## State propagation

No issue comment or state-table update was performed because this run explicitly has `comment_issue_or_pr: false`. The PR body is the propagation surface for the delivered slice.

<details>
<summary>Governance appendix</summary>

Research-result guidance: support/tooling helper only. No benchmark result, metric interpretation, artifact promotion, or paper-facing claim is produced.

Latest issue guidance checked before opening: live #3215 comments through 2026-06-23T11:10:25Z; no newer maintainer comment appeared during this run.

Fragmentation guard: prior #3215 readiness/guard PRs exist, so this PR intentionally delivers a progression capability named `scenario_family_oracle_arm` rather than another guardrail-only slice.

</details>


## Domain-Aware Approval

- Required for PR: yes - body uses evidence-validity-sensitive terms to state the claim boundary; this PR itself is a support/tooling helper.
- Required PR: yes - body uses evidence-validity-sensitive terms to state the claim boundary; this PR itself is a support/tooling helper.
- Domains reviewed: evidence classification
- Status: waived
- Approver/review source waiver: explicit waiver for support helper; no evidence interpretation, benchmark result, or paper-facing claim is changed.
- Approval or blocker note: explicit waiver for support helper; no evidence interpretation, benchmark result, or paper-facing claim is changed.
- Validity checklist:
- Target claim/hypothesis: NA - readiness metadata only.
- Comparator split/evidence validity: NA - no campaign, metric comparison, or split interpretation run.
- Comparator or split/evidence validity: NA - no campaign, metric comparison, or split interpretation run.
- Fallback/degraded exclusions: helper reports prerequisites only and does not evaluate benchmark rows.
- Claim boundary: packet metadata only; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: tests cover report schema and fail-closed missing-input behavior; experimental validity remains for a future scenario-family campaign.
