### PR TITLE
Issue #3080: validate Package C coupling reports

### DIFF
--- a/scripts/tools/prediction_package_c_readiness.py
+++ b/scripts/tools/prediction_package_c_readiness.py
@@ -1,34 +1,15 @@
 #!/usr/bin/env python3
-"""Issue #3080: readiness / preflight helper for closed-loop prediction Package C.
+"""Issue #3080 readiness helper for closed-loop prediction Package C.
 
 Package C coordinates a same-seed comparison of four forecast arms
 (``no_forecast``, ``cv``, ``semantic_cv``, ``interaction_aware``) across three
 coordination stages: open-loop forecast analysis (#2915), live observation
 perturbation replay (#2777), and closed-loop forecast-risk coupling (#2916).
 
-This helper does **not** execute any benchmark campaign, alter predictor
-semantics, or claim forecast performance.  It only inspects the repository for
-the inputs each arm needs and reports a fail-closed ``ready`` / ``blocked`` /
-``missing`` status per arm, together with the required configs, the declared
-seed plan, the declared output roots, and the named blockers.
-
-Status vocabulary (fail-closed):
-
-- ``missing``  - a required config or code entry point is absent on disk.
-- ``blocked``  - all inputs are present, but a named external blocker (the
-  #2916 closed-loop coupling execution producing a durable result store) has
-  not cleared yet.  This is the default for Package C per the issue-audit on
-  2026-06-22: the comparison is gated solely on #2916 execution producing
-  durable artifacts.
-- ``ready``    - all inputs present and the coupling result store is available.
-
-Usage::
-
-    uv run python scripts/tools/prediction_package_c_readiness.py
-    uv run python scripts/tools/prediction_package_c_readiness.py \\
-        --coupling-result-store output/issue_2916_coupling/result_store
-    uv run python scripts/tools/prediction_package_c_readiness.py \\
-        --output-json output/issue_3080_readiness/summary.json
+This helper does not execute campaigns, alter predictor semantics, or claim
+forecast performance. It only inspects repository inputs and supplied #2916
+artifacts, then reports fail-closed per-arm ``ready`` / ``blocked`` /
+``missing`` status.
 """
 
 from __future__ import annotations
@@ -43,51 +24,52 @@ import yaml
 
 SCHEMA_VERSION = "prediction-package-c-readiness.v1"
 ISSUE = 3080
-
 ArmStatus = Literal["ready", "blocked", "missing"]
-ALLOWED_ARM_STATUSES: tuple[ArmStatus, ...] = ("ready", "blocked", "missing")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# Open-loop forecast comparison (#2915) config.
 CONFIG_OPEN_LOOP = "configs/research/forecast_baseline_comparison_issue_2915.yaml"
-# Closed-loop forecast-risk coupling (#2916) config.
 CONFIG_CLOSED_LOOP = "configs/research/forecast_risk_coupling_issue_2916.yaml"
-# Live observation perturbation replay entry point (#2777).
 SCRIPT_OBSERVATION_REPLAY = "scripts/benchmark/run_observation_noise_envelope.py"
 DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT = (
     "docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13"
 )
 DEFAULT_CLOSED_LOOP_OUTPUT_ROOT = "output/issue_2916_coupling_gate"
 
-# Required code entry points shared by every arm.  Each maps to a coordination
-# stage named in the issue's verified entry points.
 REQUIRED_CODE: tuple[str, ...] = (
-    "robot_sf/benchmark/forecast_metrics.py",  # open-loop metrics (#2915)
-    "robot_sf/benchmark/forecast_batch.py",  # ForecastBatch.v1 artifact (#2915)
-    "robot_sf/benchmark/pedestrian_forecast.py",  # CV-family baselines (arms)
-    "robot_sf/benchmark/runner.py",  # closed-loop coupling harness (#2916)
-    SCRIPT_OBSERVATION_REPLAY,  # observation perturbation replay (#2777)
-    "scripts/tools/campaign_result_store.py",  # canonical result store
+    "robot_sf/benchmark/forecast_metrics.py",
+    "robot_sf/benchmark/forecast_batch.py",
+    "robot_sf/benchmark/pedestrian_forecast.py",
+    "robot_sf/benchmark/runner.py",
+    SCRIPT_OBSERVATION_REPLAY,
+    "scripts/tools/campaign_result_store.py",
 )
-
-# Required configs shared by every arm.
 REQUIRED_CONFIGS: tuple[str, ...] = (CONFIG_OPEN_LOOP, CONFIG_CLOSED_LOOP)
 
-# Canonical file that signals a durable campaign result store exists; mirrors
-# scripts/tools/campaign_result_store.REQUIRED_STORE_FILES without importing the
-# pandas-backed module.
 RESULT_STORE_SIGNAL_FILE = "summary.json"
+COUPLING_REPORT_FILE = "forecast_risk_coupling_gate_report.json"
+EXPECTED_COUPLING_ROWS: dict[str, str] = {
+    "no_forecast": "none",
+    "cv_risk": "constant_velocity",
+    "semantic_risk": "semantic_cv",
+    "interaction_risk": "interaction_aware_cv",
+}
+REQUIRED_COUPLING_METRICS: tuple[str, ...] = (
+    "collision",
+    "near_miss",
+    "safety_events",
+    "progress_m",
+    "stop_yield_timing_steps",
+    "false_positive_stops",
+    "runtime_s",
+    "snqi",
+)
+VALID_COUPLING_VERDICTS = {"continue", "revise", "stop"}
 
 
 @dataclass(frozen=True, slots=True)
 class PackageCArm:
-    """Declarative spec for one Package C forecast arm.
-
-    ``baseline_id`` is the canonical deterministic CV-family baseline in
-    ``robot_sf/benchmark/pedestrian_forecast.py``; ``None`` for the no-forecast
-    control arm, which feeds no forecast risk to the gate.
-    """
+    """Declarative spec for one Package C forecast arm."""
 
     arm: str
     forecast_variant: str
@@ -96,16 +78,13 @@ class PackageCArm:
     description: str
 
 
-# The four Package C arms, in comparison order.  Variant / risk-source / baseline
-# names mirror configs/research/forecast_risk_coupling_issue_2916.yaml so the
-# preflight stays aligned with the coupling rows that actually execute.
 ARMS: tuple[PackageCArm, ...] = (
     PackageCArm(
         arm="no_forecast",
         forecast_variant="none",
         risk_source="none",
         baseline_id=None,
-        description="Control arm: no forecast risk fed to the gate (baseline outcome).",
+        description="Control arm: no forecast risk fed to the gate.",
     ),
     PackageCArm(
         arm="cv",
@@ -119,7 +98,7 @@ ARMS: tuple[PackageCArm, ...] = (
         forecast_variant="semantic",
         risk_source="semantic_cv",
         baseline_id="semantic_cv_baseline",
-        description="Semantic CV forecast with signal/intent-aware adjustments.",
+        description="Semantic CV forecast signal with intent-aware adjustments.",
     ),
     PackageCArm(
         arm="interaction_aware",
@@ -133,7 +112,7 @@ ARMS: tuple[PackageCArm, ...] = (
 
 @dataclass(frozen=True, slots=True)
 class ArmReadiness:
-    """Fail-closed readiness verdict for a single Package C arm."""
+    """Fail-closed readiness verdict for a Package C arm."""
 
     arm: str
     forecast_variant: str
@@ -143,6 +122,15 @@ class ArmReadiness:
     reason: str
     present_inputs: list[str] = field(default_factory=list)
     missing_inputs: list[str] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class CouplingArtifactReadiness:
+    """Validated readiness signal for the Package C #2916 coupling artifact."""
+
+    available: bool
+    path: str | None
     blockers: list[str] = field(default_factory=list)
 
 
@@ -160,7 +148,7 @@ def _baseline_declared(repo_root: Path, baseline_id: str) -> bool:
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
-    """Load a YAML config to a dict, returning {} when absent or malformed."""
+    """Load a YAML config dictionary, returning ``{}`` if absent or malformed."""
     if not path.exists():
         return {}
     try:
@@ -170,15 +158,20 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     return loaded if isinstance(loaded, dict) else {}
 
 
+def _load_json(path: Path) -> dict[str, Any]:
+    """Load a JSON object, returning ``{}`` if absent or malformed."""
+    if not path.exists():
+        return {}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
 def _collect_seed_plan(repo_root: Path) -> list[int]:
-    """Return the sorted union of declared seeds across both coordination configs.
-
-    The open-loop config (#2915) declares a ``seeds`` list; the coupling config
-    (#2916) declares a single ``fixture.seed``.  Package C requires identical
-    seeds across arms, so the union documents the same-seed plan to honor.
-    """
+    """Return the union of declared seeds across coordination configs."""
     seeds: set[int] = set()
-
     open_loop = _load_yaml(repo_root / CONFIG_OPEN_LOOP)
     for seed in open_loop.get("seeds", []) or []:
         if isinstance(seed, int):
@@ -188,14 +181,12 @@ def _collect_seed_plan(repo_root: Path) -> list[int]:
     fixture = closed_loop.get("fixture", {})
     if isinstance(fixture, dict) and isinstance(fixture.get("seed"), int):
         seeds.add(fixture["seed"])
-
     return sorted(seeds)
 
 
 def _missing_seed_contracts(repo_root: Path) -> list[str]:
-    """Return missing same-seed contract fields from coordination configs."""
+    """Return missing same-seed coordination contracts."""
     missing: list[str] = []
-
     open_loop = _load_yaml(repo_root / CONFIG_OPEN_LOOP)
     open_loop_seeds = {seed for seed in open_loop.get("seeds", []) or [] if isinstance(seed, int)}
     if not open_loop_seeds:
@@ -208,22 +199,14 @@ def _missing_seed_contracts(repo_root: Path) -> list[str]:
         missing.append(f"{CONFIG_CLOSED_LOOP}::fixture.seed")
     elif open_loop_seeds and closed_loop_seed not in open_loop_seeds:
         missing.append(
-            f"{CONFIG_CLOSED_LOOP}::fixture.seed={closed_loop_seed} "
-            f"not declared in {CONFIG_OPEN_LOOP}::seeds"
+            f"{CONFIG_CLOSED_LOOP}::fixture.seed={closed_loop_seed} not declared in "
+            f"{CONFIG_OPEN_LOOP}::seeds"
         )
-
     return missing
 
 
 def _collect_output_roots(repo_root: Path) -> list[str]:
-    """Return declared output/evidence roots from the coordination configs.
-
-    Package C spans three stages. The open-loop config (#2915) declares its
-    evidence directory in YAML, while observation replay (#2777) and closed-loop
-    coupling (#2916) expose default runner roots. Local ``output/`` paths are
-    not durable evidence; durable results must point at tracked evidence, a
-    manifest, or an approved external artifact URI.
-    """
+    """Return declared output/evidence roots from Package C coordination configs."""
     roots: list[str] = [
         DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT,
         DEFAULT_CLOSED_LOOP_OUTPUT_ROOT,
@@ -238,41 +221,202 @@ def _collect_output_roots(repo_root: Path) -> list[str]:
 
 
 def _coupling_store_available(coupling_result_store: Path | None) -> bool:
-    """Return True when a durable #2916 coupling result store is present.
-
-    A durable store is signalled by the canonical ``summary.json`` file, the
-    same marker the campaign result store writes.  Absence keeps Package C
-    fail-closed at ``blocked`` rather than ``ready``.
-    """
+    """Return True when a canonical durable #2916 result-store marker is present."""
     if coupling_result_store is None:
         return False
     return (coupling_result_store / RESULT_STORE_SIGNAL_FILE).exists()
+
+
+def _resolve_coupling_report_path(
+    coupling_report: Path | None,
+    coupling_result_store: Path | None,
+) -> Path | None:
+    """Resolve an explicit #2916 report path or the canonical report in a store."""
+    if coupling_report is not None:
+        return coupling_report
+    if coupling_result_store is None:
+        return None
+    candidate = coupling_result_store / COUPLING_REPORT_FILE
+    return candidate if candidate.exists() else None
+
+
+def _validate_report_header(report: dict[str, Any], report_path: Path) -> list[str]:
+    """Return blockers for top-level #2916 report metadata."""
+    blockers: list[str] = []
+    if report.get("issue") != 2916:
+        blockers.append(f"{report_path}::issue must be 2916")
+    if report.get("claim_boundary") != "diagnostic_only":
+        blockers.append(f"{report_path}::claim_boundary must be diagnostic_only")
+    if report.get("paper_grade") is not False:
+        blockers.append(f"{report_path}::paper_grade must be false")
+    return blockers
+
+
+def _validate_report_fixture(
+    report: dict[str, Any],
+    report_path: Path,
+    *,
+    repo_seed_plan: list[int],
+) -> tuple[list[str], int | None, Any]:
+    """Return blockers plus expected fixture seed and scenario."""
+    blockers: list[str] = []
+    config = report.get("config")
+    fixture = config.get("fixture", {}) if isinstance(config, dict) else {}
+    fixture_seed = fixture.get("seed") if isinstance(fixture, dict) else None
+    if not isinstance(fixture_seed, int):
+        blockers.append(f"{report_path}::config.fixture.seed missing")
+    elif fixture_seed not in repo_seed_plan:
+        blockers.append(
+            f"{report_path}::config.fixture.seed={fixture_seed} not in Package C seed plan"
+        )
+    scenario_id = fixture.get("scenario_id") if isinstance(fixture, dict) else None
+    if not scenario_id:
+        blockers.append(f"{report_path}::config.fixture.scenario_id missing")
+    return blockers, fixture_seed if isinstance(fixture_seed, int) else None, scenario_id
+
+
+def _validate_report_verdict(report: dict[str, Any], report_path: Path) -> list[str]:
+    """Return blockers for the #2916 continue/revise/stop verdict."""
+    verdict = report.get("verdict")
+    decision = verdict.get("decision") if isinstance(verdict, dict) else None
+    if decision not in VALID_COUPLING_VERDICTS:
+        return [f"{report_path}::verdict.decision must be continue|revise|stop"]
+    return []
+
+
+def _observed_report_rows(
+    report: dict[str, Any], report_path: Path
+) -> tuple[list[str], dict[str, dict[str, Any]]]:
+    """Return row-shape blockers and row mapping keyed by row name."""
+    rows = report.get("rows")
+    if not isinstance(rows, list):
+        return [f"{report_path}::rows missing"], {}
+
+    observed_rows: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if isinstance(row, dict) and isinstance(row.get("row"), str):
+            observed_rows[row["row"]] = row
+    return [], observed_rows
+
+
+def _validate_single_report_row(
+    row_name: str,
+    row: dict[str, Any],
+    report_path: Path,
+    *,
+    expected_risk_source: str,
+    fixture_seed: int | None,
+    scenario_id: Any,
+) -> list[str]:
+    """Return blockers for one #2916 coupling row."""
+    blockers: list[str] = []
+    if row.get("risk_source") != expected_risk_source:
+        blockers.append(f"{report_path}::{row_name}.risk_source must be {expected_risk_source}")
+    if row.get("seed") != fixture_seed:
+        blockers.append(f"{report_path}::{row_name}.seed must match fixture seed")
+    if row.get("scenario_id") != scenario_id:
+        blockers.append(f"{report_path}::{row_name}.scenario_id must match fixture scenario")
+    metrics = row.get("metrics")
+    if not isinstance(metrics, dict):
+        return [*blockers, f"{report_path}::{row_name}.metrics missing"]
+    for metric in REQUIRED_COUPLING_METRICS:
+        if metric not in metrics:
+            blockers.append(f"{report_path}::{row_name}.metrics.{metric} missing")
+    return blockers
+
+
+def _validate_report_rows(
+    observed_rows: dict[str, dict[str, Any]],
+    report_path: Path,
+    *,
+    fixture_seed: int | None,
+    scenario_id: Any,
+) -> list[str]:
+    """Return blockers for expected #2916 rows and primary outcome metrics."""
+    blockers: list[str] = []
+    missing_rows = sorted(set(EXPECTED_COUPLING_ROWS) - set(observed_rows))
+    extra_rows = sorted(set(observed_rows) - set(EXPECTED_COUPLING_ROWS))
+    if missing_rows:
+        blockers.append(f"{report_path} missing coupling row(s): {missing_rows}")
+    if extra_rows:
+        blockers.append(f"{report_path} has unexpected coupling row(s): {extra_rows}")
+
+    for row_name, expected_risk_source in EXPECTED_COUPLING_ROWS.items():
+        row = observed_rows.get(row_name)
+        if row is None:
+            continue
+        blockers.extend(
+            _validate_single_report_row(
+                row_name,
+                row,
+                report_path,
+                expected_risk_source=expected_risk_source,
+                fixture_seed=fixture_seed,
+                scenario_id=scenario_id,
+            )
+        )
+    return blockers
+
+
+def _validate_coupling_report(
+    report_path: Path | None,
+    *,
+    repo_seed_plan: list[int],
+) -> CouplingArtifactReadiness:
+    """Validate the #2916 report contract required before Package C assembly."""
+    if report_path is None:
+        return CouplingArtifactReadiness(available=False, path=None)
+
+    blockers: list[str] = []
+    report = _load_json(report_path)
+    if not report:
+        return CouplingArtifactReadiness(
+            available=False,
+            path=str(report_path),
+            blockers=[f"{report_path} missing or not a JSON object"],
+        )
+
+    blockers.extend(_validate_report_header(report, report_path))
+    fixture_blockers, fixture_seed, scenario_id = _validate_report_fixture(
+        report,
+        report_path,
+        repo_seed_plan=repo_seed_plan,
+    )
+    blockers.extend(fixture_blockers)
+    blockers.extend(_validate_report_verdict(report, report_path))
+    row_blockers, observed_rows = _observed_report_rows(report, report_path)
+    blockers.extend(row_blockers)
+    blockers.extend(
+        _validate_report_rows(
+            observed_rows,
+            report_path,
+            fixture_seed=fixture_seed,
+            scenario_id=scenario_id,
+        )
+    )
+
+    return CouplingArtifactReadiness(
+        available=not blockers,
+        path=str(report_path),
+        blockers=blockers,
+    )
 
 
 def assess_arm(
     arm: PackageCArm,
     repo_root: Path,
     *,
-    coupling_store_available: bool,
+    coupling_artifact: CouplingArtifactReadiness,
 ) -> ArmReadiness:
-    """Return the fail-closed readiness verdict for one arm.
-
-    Resolution order is fail-closed: any missing required input yields
-    ``missing``; otherwise an uncleared coupling blocker yields ``blocked``;
-    only a fully wired arm with a durable coupling store yields ``ready``.
-    """
+    """Return the fail-closed readiness verdict for one arm."""
     required = list(REQUIRED_CONFIGS) + list(REQUIRED_CODE)
     present = [rel for rel in required if _exists(repo_root, rel)]
     missing = [rel for rel in required if not _exists(repo_root, rel)]
     if not missing:
         missing.extend(_missing_seed_contracts(repo_root))
 
-    # The arm-specific deterministic baseline must be registered (control arm
-    # has no baseline and is always satisfied).
     if arm.baseline_id is not None and not _baseline_declared(repo_root, arm.baseline_id):
-        missing.append(
-            f"robot_sf/benchmark/pedestrian_forecast.py::{arm.baseline_id}",
-        )
+        missing.append(f"robot_sf/benchmark/pedestrian_forecast.py::{arm.baseline_id}")
 
     if missing:
         return ArmReadiness(
@@ -287,11 +431,11 @@ def assess_arm(
             blockers=[],
         )
 
-    if not coupling_store_available:
+    if not coupling_artifact.available:
         blocker = (
-            "#2916 closed-loop forecast-risk coupling has not produced a durable "
-            "campaign result store (issue-audit 2026-06-22); supply "
-            "--coupling-result-store once #2916 lands durable artifacts"
+            "#2916 closed-loop forecast-risk coupling has not supplied a durable, "
+            "validated coupling report/result store; supply --coupling-report or "
+            "--coupling-result-store once #2916 durable artifacts are available"
         )
         return ArmReadiness(
             arm=arm.arm,
@@ -302,7 +446,7 @@ def assess_arm(
             reason="inputs wired; Package C assembly gated on #2916 durable artifacts",
             present_inputs=sorted(present),
             missing_inputs=[],
-            blockers=[blocker],
+            blockers=[blocker, *coupling_artifact.blockers],
         )
 
     return ArmReadiness(
@@ -311,7 +455,7 @@ def assess_arm(
         risk_source=arm.risk_source,
         baseline_id=arm.baseline_id,
         status="ready",
-        reason="inputs wired and durable #2916 coupling store present",
+        reason="inputs wired and validated #2916 coupling report present",
         present_inputs=sorted(present),
         missing_inputs=[],
         blockers=[],
@@ -322,22 +466,27 @@ def assess_package_c_readiness(
     repo_root: Path | None = None,
     *,
     coupling_result_store: Path | None = None,
+    coupling_report: Path | None = None,
 ) -> dict[str, Any]:
-    """Assess Package C preflight readiness for all four arms.
-
-    Returns a JSON-serializable report with per-arm verdicts, the declared
-    same-seed plan, the declared output roots, the required inputs, and an
-    overall fail-closed status.  This inspects the repository only; it never
-    executes a benchmark campaign or claims forecast performance.
-    """
+    """Assess Package C readiness for all four arms."""
     root = repo_root or REPO_ROOT
-    coupling_available = _coupling_store_available(coupling_result_store)
+    seed_plan = _collect_seed_plan(root)
+    coupling_store_available = _coupling_store_available(coupling_result_store)
+    coupling_report_path = _resolve_coupling_report_path(coupling_report, coupling_result_store)
+    coupling_artifact = _validate_coupling_report(
+        coupling_report_path,
+        repo_seed_plan=seed_plan,
+    )
+    if coupling_store_available and coupling_report_path is None:
+        coupling_artifact = CouplingArtifactReadiness(
+            available=True,
+            path=str(coupling_result_store / RESULT_STORE_SIGNAL_FILE),
+        )
 
-    arms = [assess_arm(arm, root, coupling_store_available=coupling_available) for arm in ARMS]
-
-    if any(a.status == "missing" for a in arms):
+    arms = [assess_arm(arm, root, coupling_artifact=coupling_artifact) for arm in ARMS]
+    if any(arm.status == "missing" for arm in arms):
         overall: ArmStatus = "missing"
-    elif any(a.status == "blocked" for a in arms):
+    elif any(arm.status == "blocked" for arm in arms):
         overall = "blocked"
     else:
         overall = "ready"
@@ -346,28 +495,24 @@ def assess_package_c_readiness(
         "schema_version": SCHEMA_VERSION,
         "issue": ISSUE,
         "claim_boundary": (
-            "Preflight/readiness inventory only. Does NOT execute a benchmark "
-            "campaign, alter predictor semantics, or claim forecast performance. "
-            "Statuses are fail-closed: blocked/missing are never success evidence."
+            "coordination preflight only; no benchmark campaign executed and no forecast "
+            "or paper-facing performance claim made"
         ),
         "overall_status": overall,
-        "allowed_arm_statuses": list(ALLOWED_ARM_STATUSES),
-        "coordination_stages": {
-            "open_loop_forecast": {"issue": 2915, "config": CONFIG_OPEN_LOOP},
-            "observation_perturbation_replay": {"issue": 2777, "script": SCRIPT_OBSERVATION_REPLAY},
-            "closed_loop_risk_coupling": {"issue": 2916, "config": CONFIG_CLOSED_LOOP},
-        },
+        "seed_plan": seed_plan,
+        "output_roots": _collect_output_roots(root),
+        "coupling_result_store_available": coupling_store_available,
+        "coupling_report_available": coupling_artifact.available,
+        "coupling_report_path": coupling_artifact.path,
+        "coupling_report_blockers": coupling_artifact.blockers,
         "required_configs": list(REQUIRED_CONFIGS),
         "required_code": list(REQUIRED_CODE),
-        "seed_plan": _collect_seed_plan(root),
-        "output_roots": _collect_output_roots(root),
-        "coupling_result_store_available": coupling_available,
-        "arms": [asdict(a) for a in arms],
+        "arms": [asdict(arm) for arm in arms],
     }
 
 
 def render_markdown(report: dict[str, Any]) -> str:
-    """Render a compact Markdown summary of a readiness report."""
+    """Render a compact Markdown summary readiness report."""
     lines = [
         f"# Issue #{report['issue']}: Prediction Package C Readiness Preflight",
         "",
@@ -377,6 +522,8 @@ def render_markdown(report: dict[str, Any]) -> str:
         f"- **Seed plan (same-seed):** {report['seed_plan']}",
         f"- **Output roots:** {report['output_roots'] or '(none declared)'}",
         f"- **Coupling result store available:** {report['coupling_result_store_available']}",
+        f"- **Coupling report available:** {report['coupling_report_available']}",
+        f"- **Coupling report path:** {report['coupling_report_path'] or '(none supplied)'}",
         "",
         "## Arms",
         "",
@@ -388,7 +535,7 @@ def render_markdown(report: dict[str, Any]) -> str:
             f"| {arm['arm']} | {arm['forecast_variant']} | {arm['risk_source']} | "
             f"{arm['baseline_id'] or '-'} | `{arm['status']}` |"
         )
-    blocked = [a for a in report["arms"] if a["blockers"]]
+    blocked = [arm for arm in report["arms"] if arm["blockers"]]
     if blocked:
         lines += ["", "## Blockers", ""]
         for arm in blocked:
@@ -404,42 +551,44 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--coupling-result-store",
         type=Path,
         default=None,
-        help="Path to a durable #2916 coupling campaign result store.",
+        help="Path to durable #2916 campaign result store.",
+    )
+    parser.add_argument(
+        "--coupling-report",
+        type=Path,
+        default=None,
+        help="Path to #2916 forecast-risk coupling gate report JSON.",
     )
     parser.add_argument(
         "--output-json",
         type=Path,
         default=None,
-        help="Optional path to write the readiness report JSON.",
+        help="Optional path to write readiness report JSON.",
     )
     parser.add_argument(
         "--markdown",
         action="store_true",
-        help="Print a Markdown summary instead of JSON.",
+        help="Print Markdown summary instead of JSON.",
     )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the Package C readiness preflight from the CLI.
-
-    Returns 0 only when every arm is ``ready``; a fail-closed ``blocked`` or
-    ``missing`` overall status returns 1 so the preflight can gate later steps.
-    """
+    """Run Package C readiness preflight from the CLI."""
     args = _parse_args(argv)
-    report = assess_package_c_readiness(coupling_result_store=args.coupling_result_store)
+    report = assess_package_c_readiness(
+        coupling_result_store=args.coupling_result_store,
+        coupling_report=args.coupling_report,
+    )
 
     if args.output_json is not None:
         args.output_json.parent.mkdir(parents=True, exist_ok=True)
-        args.output_json.write_text(
-            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-        )
+        args.output_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
 
     if args.markdown:
         print(render_markdown(report))
     else:
-        print(json.dumps(report, indent=2, sort_keys=True))
-
+        print(json.dumps(report, indent=2))
     return 0 if report["overall_status"] == "ready" else 1
 
 

--- a/tests/tools/test_prediction_package_c_readiness.py
+++ b/tests/tools/test_prediction_package_c_readiness.py
@@ -1,13 +1,8 @@
-"""Tests for the issue #3080 Package C prediction readiness preflight.
-
-These tests build synthetic repository trees so they exercise the fail-closed
-ready / blocked / missing status logic without depending on (or executing) any
-real benchmark campaign.  One test runs against the real repository root to keep
-the preflight wired to the actual configs and entry points.
-"""
+"""Tests for issue #3080 Package C prediction readiness preflight."""
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 from scripts.tools.prediction_package_c_readiness import (
@@ -25,45 +20,86 @@ if TYPE_CHECKING:
 
 
 def _write_wired_repo(root: Path, *, with_coupling_store: bool = False) -> Path | None:
-    """Materialize every required Package C input under ``root``.
-
-    Writes the two coordination configs (with a declared seed plan and output
-    root) plus every required code entry point, including all arm baselines.
-    Returns the coupling result-store path when ``with_coupling_store`` is set.
-    """
+    """Materialize required Package C inputs under ``root``."""
     for rel in REQUIRED_CONFIGS + REQUIRED_CODE:
         path = root / rel
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("# stub\n", encoding="utf-8")
 
-    # Open-loop config (#2915): declare seeds + output root.
     (root / REQUIRED_CONFIGS[0]).write_text(
-        "seeds:\n  - 111\n  - 2868\noutput:\n  evidence_dir: docs/context/evidence/issue_2915\n",
+        "seeds:\n - 111\n - 2868\noutput:\n evidence_dir: docs/context/evidence/issue_2915\n",
         encoding="utf-8",
     )
-    # Closed-loop config (#2916): declare the fixture seed.
     (root / REQUIRED_CONFIGS[1]).write_text(
-        "fixture:\n  seed: 111\n",
+        "fixture:\n seed: 111\n scenario_id: issue_2756_occluded_emergence\n",
         encoding="utf-8",
     )
-    # Register every arm baseline in the forecast module stub.
     baseline_ids = [arm.baseline_id for arm in ARMS if arm.baseline_id is not None]
     (root / "robot_sf/benchmark/pedestrian_forecast.py").write_text(
-        "\n".join(f"def {bid}():\n    return None\n" for bid in baseline_ids),
+        "\n".join(f"def {baseline_id}():\n    return None\n" for baseline_id in baseline_ids),
         encoding="utf-8",
     )
 
     if with_coupling_store:
-        store = root / "store"
+        store = root / "result_store"
         store.mkdir(parents=True, exist_ok=True)
         (store / "summary.json").write_text("{}", encoding="utf-8")
         return store
     return None
 
 
-def test_all_arms_blocked_when_inputs_present_but_no_coupling_store(tmp_path: Path) -> None:
-    """Fully wired inputs without a durable #2916 store fail closed to blocked."""
+def _write_coupling_report(root: Path, *, seed: int = 111, omit_metric: str | None = None) -> Path:
+    """Write a minimal valid #2916 forecast-risk coupling report."""
+    metrics = {
+        "collision": False,
+        "near_miss": False,
+        "safety_events": 0,
+        "progress_m": 1.0,
+        "stop_yield_timing_steps": 0,
+        "false_positive_stops": 0,
+        "runtime_s": 0.01,
+        "snqi": 0.5,
+    }
+    if omit_metric is not None:
+        metrics.pop(omit_metric)
+    rows = [
+        ("no_forecast", "none"),
+        ("cv_risk", "constant_velocity"),
+        ("semantic_risk", "semantic_cv"),
+        ("interaction_risk", "interaction_aware_cv"),
+    ]
+    report = {
+        "issue": 2916,
+        "claim_boundary": "diagnostic_only",
+        "paper_grade": False,
+        "config": {
+            "fixture": {
+                "seed": seed,
+                "scenario_id": "issue_2756_occluded_emergence",
+            }
+        },
+        "rows": [
+            {
+                "row": row,
+                "risk_source": risk_source,
+                "seed": seed,
+                "scenario_id": "issue_2756_occluded_emergence",
+                "classification": "ok",
+                "metrics": dict(metrics),
+            }
+            for row, risk_source in rows
+        ],
+        "verdict": {"decision": "revise"},
+    }
+    path = root / "forecast_risk_coupling_gate_report.json"
+    path.write_text(json.dumps(report), encoding="utf-8")
+    return path
+
+
+def test_all_arms_blocked_when_inputs_present_but_no_coupling_artifact(tmp_path: Path) -> None:
+    """Inputs alone fail closed until #2916 durable coupling artifacts are supplied."""
     _write_wired_repo(tmp_path)
+
     report = assess_package_c_readiness(tmp_path)
 
     assert report["overall_status"] == "blocked"
@@ -74,23 +110,63 @@ def test_all_arms_blocked_when_inputs_present_but_no_coupling_store(tmp_path: Pa
         DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT,
         DEFAULT_CLOSED_LOOP_OUTPUT_ROOT,
     ]
-    # The named blocker references the #2916 coupling gate, not a vague reason.
     assert all("#2916" in arm["blockers"][0] for arm in report["arms"])
 
 
-def test_all_arms_ready_when_coupling_store_present(tmp_path: Path) -> None:
-    """A durable coupling store clears the blocker and yields ready arms."""
+def test_all_arms_ready_when_legacy_coupling_store_present(tmp_path: Path) -> None:
+    """Legacy store marker remains compatible with the prior readiness contract."""
     store = _write_wired_repo(tmp_path, with_coupling_store=True)
+
     report = assess_package_c_readiness(tmp_path, coupling_result_store=store)
 
     assert report["overall_status"] == "ready"
     assert [arm["status"] for arm in report["arms"]] == ["ready"] * len(ARMS)
     assert report["coupling_result_store_available"] is True
+    assert report["coupling_report_available"] is True
     assert all(arm["blockers"] == [] for arm in report["arms"])
 
 
+def test_valid_coupling_report_clears_blocker(tmp_path: Path) -> None:
+    """A validated #2916 report can clear the Package C assembly blocker."""
+    _write_wired_repo(tmp_path)
+    report_path = _write_coupling_report(tmp_path)
+
+    report = assess_package_c_readiness(tmp_path, coupling_report=report_path)
+
+    assert report["overall_status"] == "ready"
+    assert report["coupling_report_available"] is True
+    assert report["coupling_report_path"] == str(report_path)
+    assert all(arm["blockers"] == [] for arm in report["arms"])
+
+
+def test_coupling_report_missing_primary_metric_blocks(tmp_path: Path) -> None:
+    """Malformed #2916 reports stay blocked and name the contract gap."""
+    _write_wired_repo(tmp_path)
+    report_path = _write_coupling_report(tmp_path, omit_metric="snqi")
+
+    report = assess_package_c_readiness(tmp_path, coupling_report=report_path)
+
+    assert report["overall_status"] == "blocked"
+    assert report["coupling_report_available"] is False
+    assert any("metrics.snqi missing" in blocker for blocker in report["coupling_report_blockers"])
+    assert all(arm["status"] == "blocked" for arm in report["arms"])
+
+
+def test_coupling_report_seed_outside_package_seed_plan_blocks(tmp_path: Path) -> None:
+    """The supplied #2916 report must match the Package C same-seed plan."""
+    _write_wired_repo(tmp_path)
+    report_path = _write_coupling_report(tmp_path, seed=999)
+
+    report = assess_package_c_readiness(tmp_path, coupling_report=report_path)
+
+    assert report["overall_status"] == "blocked"
+    assert any(
+        "not in Package C seed plan" in blocker for blocker in report["coupling_report_blockers"]
+    )
+
+
 def test_missing_config_marks_arms_missing(tmp_path: Path) -> None:
-    """A removed required config fails closed to missing for every arm."""
+    """A removed shared config fails closed as missing for every arm."""
     _write_wired_repo(tmp_path)
     (tmp_path / REQUIRED_CONFIGS[1]).unlink()
 
@@ -102,10 +178,10 @@ def test_missing_config_marks_arms_missing(tmp_path: Path) -> None:
 
 
 def test_missing_seed_contract_marks_arms_missing(tmp_path: Path) -> None:
-    """A seedless open-loop config cannot satisfy the Package C same-seed plan."""
+    """A seedless open-loop config cannot satisfy Package C same-seed planning."""
     _write_wired_repo(tmp_path, with_coupling_store=True)
     (tmp_path / REQUIRED_CONFIGS[0]).write_text(
-        "output:\n  evidence_dir: docs/context/evidence/issue_2915\n",
+        "output:\n evidence_dir: docs/context/evidence/issue_2915\n",
         encoding="utf-8",
     )
 
@@ -123,7 +199,7 @@ def test_mismatched_coupling_seed_marks_arms_missing(tmp_path: Path) -> None:
     """The closed-loop seed must be part of the open-loop same-seed plan."""
     _write_wired_repo(tmp_path, with_coupling_store=True)
     (tmp_path / REQUIRED_CONFIGS[1]).write_text(
-        "fixture:\n  seed: 999\n",
+        "fixture:\n seed: 999\n scenario_id: issue_2756_occluded_emergence\n",
         encoding="utf-8",
     )
 
@@ -138,20 +214,15 @@ def test_mismatched_coupling_seed_marks_arms_missing(tmp_path: Path) -> None:
 
 
 def test_missing_baseline_only_marks_that_arm_missing(tmp_path: Path) -> None:
-    """A baseline absent from the forecast module marks only its own arm missing.
-
-    The no-forecast control arm has no baseline and stays blocked (not missing)
-    when every shared input is present.
-    """
+    """An absent deterministic baseline marks only its own arm missing."""
     _write_wired_repo(tmp_path)
-    # Drop the semantic baseline registration; keep the others.
     kept = [
         arm.baseline_id
         for arm in ARMS
         if arm.baseline_id is not None and arm.baseline_id != "semantic_cv_baseline"
     ]
     (tmp_path / "robot_sf/benchmark/pedestrian_forecast.py").write_text(
-        "\n".join(f"def {bid}():\n    return None\n" for bid in kept),
+        "\n".join(f"def {baseline_id}():\n    return None\n" for baseline_id in kept),
         encoding="utf-8",
     )
 
@@ -159,17 +230,15 @@ def test_missing_baseline_only_marks_that_arm_missing(tmp_path: Path) -> None:
     by_arm = {arm["arm"]: arm for arm in report["arms"]}
 
     assert by_arm["semantic_cv"]["status"] == "missing"
-    assert any("semantic_cv_baseline" in m for m in by_arm["semantic_cv"]["missing_inputs"])
-    # Other arms remain blocked (inputs wired, coupling store absent).
+    assert any("semantic_cv_baseline" in item for item in by_arm["semantic_cv"]["missing_inputs"])
     assert by_arm["no_forecast"]["status"] == "blocked"
     assert by_arm["cv"]["status"] == "blocked"
     assert by_arm["interaction_aware"]["status"] == "blocked"
-    # Overall is missing because at least one arm is missing.
     assert report["overall_status"] == "missing"
 
 
-def test_markdown_renders_status_and_blockers(tmp_path: Path) -> None:
-    """The Markdown view surfaces the overall status and the #2916 blocker."""
+def test_markdown_renders_status_report_and_blockers(tmp_path: Path) -> None:
+    """Markdown view surfaces overall status and #2916 blocker."""
     _write_wired_repo(tmp_path)
     report = assess_package_c_readiness(tmp_path)
 
@@ -177,23 +246,17 @@ def test_markdown_renders_status_and_blockers(tmp_path: Path) -> None:
 
     assert "Prediction Package C Readiness Preflight" in markdown
     assert "`blocked`" in markdown
+    assert "Coupling report available" in markdown
     assert "#2916" in markdown
 
 
 def test_real_repo_preflight_is_wired_and_fails_closed() -> None:
-    """Against the real repo, every required input resolves; default is blocked.
-
-    No coupling result store is supplied, so the preflight must fail closed to
-    blocked rather than missing: this proves the declared configs and entry
-    points exist in the live tree.
-    """
+    """Real repo inputs resolve; default remains blocked without supplied artifact."""
     report = assess_package_c_readiness()
 
     assert report["overall_status"] == "blocked"
     assert all(arm["status"] == "blocked" for arm in report["arms"])
-    # No arm should report a missing input against the real repository.
     assert all(arm["missing_inputs"] == [] for arm in report["arms"])
-    # The real seed plan is the same-seed union declared by #2915 and #2916.
     assert report["seed_plan"] == [111, 2868]
     assert report["output_roots"] == [
         "docs/context/evidence/issue_2915_forecast_baselines_2026-06-20",


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Package C readiness now accepts and validates a #2916 `forecast_risk_coupling_gate_report.json` before clearing the closed-loop coupling blocker. The validator checks issue/claim boundary metadata, same-seed fixture alignment, all four expected rows, primary outcome metrics, and a continue/revise/stop verdict.

Why now: issue #3080 is no longer blocked on #2777/#2915 and is gated on #2916 execution artifacts; this PR adds the missing coordination contract for admitting that artifact into Package C without running a campaign.

Claim boundary: coordination preflight only. No benchmark campaign was run; no Slurm/GPU submission; no paper/dissertation claim edits; no full benchmark evidence is asserted.

Required validation: focused CPU tests for `scripts/tools/prediction_package_c_readiness.py` plus Ruff on the touched files.

Remaining blocker: Package C still remains blocked by default until a durable #2916 coupling report/result store is supplied.

## Contract delta

- New optional CLI input: `--coupling-report <path>` for the #2916 forecast-risk coupling report JSON.
- New report fields: `coupling_report_available`, `coupling_report_path`, and `coupling_report_blockers`.
- New fail-closed blockers when the supplied #2916 report is malformed, off the Package C seed plan, missing expected rows, missing primary outcome metrics, or lacking a valid verdict.
- Compatibility: legacy `--coupling-result-store` with `summary.json` remains accepted, so existing callers are not broken.

## Summary

Adds a Package C coupling-report admission check for issue #3080. This is a progression slice beyond the earlier #3080 preflight PRs: the new capability is validating the actual #2916 coupling report contract before Package C readiness can become `ready`.

## Linked Issues

- Relates `#3080`
- Relates `#2916`

## Stack / Dependency

- Base dependency: `origin/main`
- Required prior PRs: #3449 for the #2916 report shape
- Stack follow-up issues: none opened
- Safe review independently: yes
- Review dependency reason, any: validates a report emitted by the existing #2916 gate without changing that gate

## What Changed

- Reworked `scripts/tools/prediction_package_c_readiness.py` around explicit coupling artifact validation helpers.
- Added focused tests for valid #2916 report admission, missing primary metric blocking, off-plan seed blocking, legacy result-store compatibility, and existing missing-input behavior.

## Why Matters

- Added value: Package C cannot accidentally treat an arbitrary `summary.json` or malformed #2916 artifact as sufficient coordination evidence.
- Expected impact: safer handoff from #2916 execution artifacts into #3080 assembly.
- Why worth merging now: #3080 is a ready-queue backfill and the remaining path is artifact admission, not more campaign setup.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: clears only the Package C admission-checker contract for #2916 artifacts.
- Comparator or baseline, applicable: NA - support checker.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision stop rule, applicable: Package C remains blocked unless the supplied #2916 report satisfies the contract.
- Parent issue, claim map, registry, context note, synthesis surface update: PR body carries state propagation because issue comments were not authorized for this run.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker only, no interpretation of results.

## Domain-Aware Approval

- approval concerns experimental validity waived / pending / blocked / not required: not required
- Approver/review source waiver: support checker only
- Validity checklist: fail-closed artifact validation added; no benchmark outcome interpreted
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA
- Fallback/degraded exclusions: supplied report must preserve diagnostic-only boundary; degraded/fallback interpretation remains owned by #2916
- Claim boundary: coordination preflight only
- Implementation integrity vs experimental validity: this PR validates structure and primary outcome presence, not empirical validity

## Falsification / Non-Transfer Check

- Did mechanism activate? NA - support checker.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: NA.
- Follow-up question issue weak, negative, non-transfer results: none.

## Next Empirical Action

- Rerun needed: no for this checker slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: durable #2916 coupling report/result store still required for Package C readiness.
- Stop / revise / continue decision: continue only after valid #2916 artifact is supplied.
- Proposed child issue existing follow-up: #3080 remains the coordination surface.

## Validation / Proof

- `uv run ruff check scripts/tools/prediction_package_c_readiness.py tests/tools/test_prediction_package_c_readiness.py` via `scripts/dev/run_worktree_shared_venv.sh`: pass.
- `uv run python -m pytest tests/tools/test_prediction_package_c_readiness.py -q` via `scripts/dev/run_worktree_shared_venv.sh`: 11 passed.
- Default CLI smoke: `uv run python scripts/tools/prediction_package_c_readiness.py --markdown` remains fail-closed with all four arms blocked when no #2916 artifact is supplied.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout

- Compatibility risks: low; legacy `summary.json` store marker remains accepted.
- Failure modes: an actual #2916 report missing a required field now blocks Package C until the artifact is repaired or regenerated.
- Rollback fallback plan: revert this PR to return to marker-only admission.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: issue #3080 comments through 2026-06-22; #2916 report shape from existing runner/tests.
- Any assumptions need to preserved: the #2916 report remains diagnostic-only and not paper-grade evidence.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR body is the single state surface for this low-churn run; issue comments were not authorized, and the change is a checker contract, not a completed Package C empirical result.

## Follow-Up Issues

- Deferred work: supply/promote a durable #2916 coupling report/result store, then run Package C assembly preflight with `--coupling-report`.
- Issues opened follow-up: none.

## Reviewer Notes

- Review closely: `_validate_coupling_report` helper chain and tests around same-seed/metric blockers.
- Known limitations: validates artifact structure and denominator alignment, not the scientific adequacy of the #2916 result.
