### PR TITLE
feat(research): add issue #2845 revival decision packet

### DIFF
--- a/docs/context/forecast_heavy_model_study_2026-06-20.md
+++ b/docs/context/forecast_heavy_model_study_2026-06-20.md
@@ -103,8 +103,11 @@ uv run python scripts/research/check_forecast_heavy_model_inventory.py
 # Machine-readable report / static inventory
 uv run python scripts/research/check_forecast_heavy_model_inventory.py --json
 uv run python scripts/research/check_forecast_heavy_model_inventory.py --list
+# Fail-closed revival decision packet
+uv run python scripts/research/check_forecast_heavy_model_inventory.py --decision-packet
+uv run python scripts/research/check_forecast_heavy_model_inventory.py --decision-packet --json
 # Tests
-uv run python -m pytest tests/research/test_forecast_heavy_model_inventory.py -q
+uv run python -m pytest tests/research/test_forecast_heavy_model_inventory.py tests/prediction/test_forecast_heavy_model_decision_packet.py -q
 ```
 
 ## Related

--- a/robot_sf/research/forecast_heavy_model_inventory.py
+++ b/robot_sf/research/forecast_heavy_model_inventory.py
@@ -45,6 +45,7 @@ __all__ = [
     "MODEL_FAMILIES",
     "CostTier",
     "EntryPointSpec",
+    "HeavyModelRevivalDecisionPacket",
     "InventoryReport",
     "MinimumExperimentStatus",
     "ModelFamilySpec",
@@ -52,9 +53,11 @@ __all__ = [
     "PrerequisiteStatus",
     "SurfaceStatus",
     "build_inventory_report",
+    "build_revival_decision_packet",
     "probe_entry_point",
     "probe_prerequisite",
     "render_markdown",
+    "render_revival_decision_packet_markdown",
     "repo_root",
 ]
 
@@ -775,4 +778,154 @@ def render_markdown(report: InventoryReport) -> str:
         for blocked in p.spec.blocks:
             lines.append(f"  - blocks: {blocked}")
 
+    return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class HeavyModelRevivalDecisionPacket:
+    """Fail-closed decision packet for reviving issue #2845 beyond assessment.
+
+    The packet is deliberately derived from the inventory report so it cannot drift
+    into a separate issue-state ledger. It does not authorize training, Slurm/GPU
+    submission, dependency adoption, or planner integration.
+    """
+
+    issue: int
+    evidence_status: str
+    revival_status: str
+    recommendation: str
+    blockers: tuple[str, ...]
+    next_local_action: str
+    allowed_actions: tuple[str, ...]
+    forbidden_actions: tuple[str, ...]
+    required_before_offline_run: tuple[str, ...]
+    inventory: InventoryReport
+
+    def to_dict(self) -> dict[str, object]:
+        """Return JSON-safe decision packet representation."""
+        return {
+            "issue": self.issue,
+            "evidence_status": self.evidence_status,
+            "revival_status": self.revival_status,
+            "recommendation": self.recommendation,
+            "blockers": list(self.blockers),
+            "next_local_action": self.next_local_action,
+            "allowed_actions": list(self.allowed_actions),
+            "forbidden_actions": list(self.forbidden_actions),
+            "required_before_offline_run": list(self.required_before_offline_run),
+            "inventory": self.inventory.to_dict(),
+        }
+
+
+def _format_prerequisite_blocker(result: PrerequisiteProbeResult) -> str:
+    """Return one compact human-readable blocker from a prerequisite probe."""
+    scope = "external" if result.status is PrerequisiteStatus.EXTERNAL else "local"
+    return f"{result.spec.key} ({scope}): {result.spec.title}"
+
+
+def build_revival_decision_packet(
+    report: InventoryReport | None = None,
+) -> HeavyModelRevivalDecisionPacket:
+    """Build the #2845 fail-closed revival decision packet.
+
+    The packet answers whether the heavy predictor lane may move from
+    assessment-only inventory to an offline experiment. It is intentionally
+    conservative: broken required surfaces or missing local prerequisites keep the
+    status blocked, and external decisions/checkpoints are listed as required
+    before any actual offline run.
+
+    Returns:
+        Structured decision packet derived from the inventory report.
+    """
+    inventory = report if report is not None else build_inventory_report()
+    surface_blockers = tuple(
+        f"{surface.spec.key}: {surface.detail or surface.status.value}"
+        for surface in inventory.surface_blockers
+    )
+    prerequisite_blockers = tuple(
+        _format_prerequisite_blocker(prerequisite)
+        for prerequisite in inventory.pending_prerequisites
+    )
+    blockers = surface_blockers + prerequisite_blockers
+
+    local_ready = inventory.minimum_experiment_status is MinimumExperimentStatus.READY
+    external_pending = tuple(
+        prerequisite
+        for prerequisite in inventory.prerequisites
+        if prerequisite.status is PrerequisiteStatus.EXTERNAL
+    )
+
+    if not inventory.ok:
+        revival_status = "blocked_surface_contract"
+        recommendation = "repair offline-evaluation surfaces before any experiment planning"
+        next_local_action = "Restore the required forecast metric/calibration/dataset surfaces."
+    elif not local_ready:
+        revival_status = "deferred_blocked"
+        recommendation = "continue assessment only; do not implement or train a heavy model"
+        next_local_action = (
+            "Stage a bounded held-out forecast dataset manifest, then add the CPU budget config."
+        )
+    elif external_pending:
+        revival_status = "local_ready_external_blocked"
+        recommendation = "seek explicit dependency/checkpoint decision before offline run"
+        next_local_action = (
+            "Prepare the dependency/checkpoint decision record; do not submit compute."
+        )
+    else:
+        revival_status = "ready_for_cpu_offline_smoke"
+        recommendation = "run the CPU-only offline evaluator smoke, not a campaign"
+        next_local_action = "Run the config-first CPU smoke and record runtime/calibration/metrics."
+
+    return HeavyModelRevivalDecisionPacket(
+        issue=ISSUE,
+        evidence_status="analysis_only",
+        revival_status=revival_status,
+        recommendation=recommendation,
+        blockers=blockers,
+        next_local_action=next_local_action,
+        allowed_actions=(
+            "inventory/preflight maintenance",
+            "bounded held-out dataset manifest work",
+            "CPU-only evaluator smoke after prerequisites clear",
+        ),
+        forbidden_actions=(
+            "full benchmark campaign",
+            "Slurm/GPU submission",
+            "heavy model training",
+            "default planner integration",
+            "paper/dissertation claim promotion",
+        ),
+        required_before_offline_run=tuple(
+            _format_prerequisite_blocker(prerequisite)
+            for prerequisite in inventory.pending_prerequisites
+        ),
+        inventory=inventory,
+    )
+
+
+def render_revival_decision_packet_markdown(packet: HeavyModelRevivalDecisionPacket) -> str:
+    """Render a compact Markdown handoff packet for issue/PR review.
+
+    Returns:
+        Markdown text suitable for a review handoff or issue state note.
+    """
+    lines = [
+        f"# Issue #{packet.issue} heavy predictor revival decision packet",
+        "",
+        f"- Evidence status: `{packet.evidence_status}`",
+        f"- Revival status: `{packet.revival_status}`",
+        f"- Recommendation: {packet.recommendation}",
+        f"- Next local action: {packet.next_local_action}",
+        "",
+        "## Blockers",
+    ]
+    if packet.blockers:
+        lines.extend(f"- {blocker}" for blocker in packet.blockers)
+    else:
+        lines.append("- none")
+
+    lines.extend(["", "## Allowed actions"])
+    lines.extend(f"- {action}" for action in packet.allowed_actions)
+    lines.extend(["", "## Forbidden actions"])
+    lines.extend(f"- {action}" for action in packet.forbidden_actions)
     return "\n".join(lines)

--- a/scripts/research/check_forecast_heavy_model_inventory.py
+++ b/scripts/research/check_forecast_heavy_model_inventory.py
@@ -1,24 +1,10 @@
 #!/usr/bin/env python3
-"""Preflight the heavy forecast-model families / offline-experiment surface (#2845).
+"""Preflight heavy forecast-model families / offline-experiment surface (#2845).
 
-Read-only inventory CLI. It documents the candidate heavy predictor families
-(AgentFormer-like / transformer / CVAE / diffusion) with their planning-stage compute cost,
-inference latency, uncertainty quality, and repository integration burden; probes that the
-offline-evaluation entry-point surfaces such an experiment would touch are importable
-(fail-closed); and lists the still-missing minimum-offline-experiment prerequisites (a staged
-held-out dataset, a heavy-model -> ForecastBatch adapter, a CPU runtime budget, the study
-report, plus external dependency/checkpoint decisions) as explicit blockers.
-
-Modes:
-
-- default: render a compact Markdown report and exit non-zero only if a *required*
-  offline-evaluation surface is missing.
-- ``--json``: emit the machine-readable report instead of Markdown.
-- ``--list``: print the static inventory (families, surfaces, prerequisites) without probing.
-
-This tool trains nothing, runs no inference, adds no dependency, runs no benchmark, and makes no
-model-quality claim. The per-family tiers are literature-derived planning estimates, not
-repository measurements. See ``robot_sf/research/forecast_heavy_model_inventory.py``.
+This read-only CLI documents candidate heavy predictor families, probes the
+offline evaluation surfaces needed by a future experiment, and reports the
+minimum-experiment blockers. It trains nothing, runs no inference, adds no
+dependency, runs no benchmark, and makes no model-quality claim.
 """
 
 from __future__ import annotations
@@ -31,30 +17,36 @@ from robot_sf.research.forecast_heavy_model_inventory import (
     EXPERIMENT_PREREQUISITES,
     MODEL_FAMILIES,
     build_inventory_report,
+    build_revival_decision_packet,
     render_markdown,
+    render_revival_decision_packet_markdown,
 )
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
-    """Build the command-line parser."""
+    """Build command-line parser."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--json",
         action="store_true",
-        help="Emit the machine-readable inventory report as JSON.",
+        help="Emit machine-readable inventory report JSON.",
     )
     parser.add_argument(
         "--list",
         action="store_true",
-        help="Print the static inventory (no checkout probing) as JSON and exit 0.",
+        help="Print static inventory (no checkout probing) JSON and exit 0.",
+    )
+    parser.add_argument(
+        "--decision-packet",
+        action="store_true",
+        help="Emit the fail-closed issue #2845 revival decision packet.",
     )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the inventory preflight CLI and return a shell-friendly exit code."""
+    """Run inventory preflight CLI and return shell-friendly exit code."""
     args = build_arg_parser().parse_args(argv)
-
     if args.list:
         payload = {
             "issue": 2845,
@@ -66,6 +58,14 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     report = build_inventory_report()
+    if args.decision_packet:
+        packet = build_revival_decision_packet(report)
+        if args.json:
+            print(json.dumps(packet.to_dict(), indent=2, sort_keys=True))
+        else:
+            print(render_revival_decision_packet_markdown(packet))
+        return report.exit_code()
+
     if args.json:
         print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
     else:

--- a/tests/prediction/test_forecast_heavy_model_decision_packet.py
+++ b/tests/prediction/test_forecast_heavy_model_decision_packet.py
@@ -1,0 +1,98 @@
+"""Tests for the issue #2845 heavy-predictor revival decision packet."""
+
+from __future__ import annotations
+
+import json
+
+from robot_sf.research import forecast_heavy_model_inventory as inv
+from robot_sf.research.forecast_heavy_model_inventory import (
+    ENTRY_POINT_SURFACES,
+    EXPERIMENT_PREREQUISITES,
+    HeavyModelRevivalDecisionPacket,
+    MinimumExperimentStatus,
+    build_inventory_report,
+    build_revival_decision_packet,
+    render_revival_decision_packet_markdown,
+    repo_root,
+)
+from scripts.research.check_forecast_heavy_model_inventory import main as cli_main
+
+
+def _write(root, relpath: str) -> None:
+    path = root / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# test fixture\n", encoding="utf-8")
+
+
+def test_revival_decision_packet_is_fail_closed_on_real_checkout():
+    """The live checkout remains deferred; packet names blockers and allowed scope."""
+    packet = build_revival_decision_packet(build_inventory_report(root=repo_root()))
+
+    assert isinstance(packet, HeavyModelRevivalDecisionPacket)
+    assert packet.issue == inv.ISSUE
+    assert packet.evidence_status == "analysis_only"
+    assert packet.revival_status == "deferred_blocked"
+    assert "do not implement or train" in packet.recommendation
+    assert packet.blockers
+    assert any("staged_holdout_dataset" in blocker for blocker in packet.blockers)
+    assert "Slurm/GPU submission" in packet.forbidden_actions
+    assert "heavy model training" in packet.forbidden_actions
+    payload = packet.to_dict()
+    assert payload["inventory"]["minimum_experiment_status"] == "blocked"
+
+
+def test_revival_decision_packet_reports_surface_contract_blocker(tmp_path):
+    """Broken required surfaces outrank prerequisite planning blockers."""
+    report = build_inventory_report(root=tmp_path)
+    packet = build_revival_decision_packet(report)
+
+    assert packet.revival_status == "blocked_surface_contract"
+    assert "repair offline-evaluation surfaces" in packet.recommendation
+    assert any("forecast_metrics" in blocker for blocker in packet.blockers)
+
+
+def test_revival_decision_packet_marks_local_ready_external_blocked(tmp_path):
+    """When local prerequisites are present, external decisions still gate runs."""
+    for surface in ENTRY_POINT_SURFACES:
+        _write(tmp_path, surface.file_path)
+    for prereq in EXPERIMENT_PREREQUISITES:
+        if prereq.external or not prereq.probe_paths:
+            continue
+        concrete = prereq.probe_paths[0].replace("*", "match").replace("?", "x")
+        _write(tmp_path, concrete)
+
+    report = build_inventory_report(root=tmp_path)
+    assert report.minimum_experiment_status is MinimumExperimentStatus.READY
+    packet = build_revival_decision_packet(report)
+
+    assert packet.revival_status == "local_ready_external_blocked"
+    assert "dependency/checkpoint decision" in packet.recommendation
+    assert packet.required_before_offline_run
+
+
+def test_render_revival_decision_packet_markdown_contains_guardrails():
+    """Markdown packet exposes status, blockers, and forbidden actions."""
+    packet = build_revival_decision_packet(build_inventory_report(root=repo_root()))
+    text = render_revival_decision_packet_markdown(packet)
+
+    assert f"Issue #{inv.ISSUE}" in text
+    assert packet.revival_status in text
+    assert "## Blockers" in text
+    assert "## Forbidden actions" in text
+    assert "full benchmark campaign" in text
+
+
+def test_cli_decision_packet_modes_emit_guardrails(capsys):
+    """CLI packet modes emit Markdown and JSON guardrail views."""
+    code = cli_main(["--decision-packet"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "revival decision packet" in out
+    assert "Slurm/GPU submission" in out
+
+    code = cli_main(["--decision-packet", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["issue"] == inv.ISSUE
+    assert payload["revival_status"] == "deferred_blocked"
+    assert "full benchmark campaign" in payload["forbidden_actions"]


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a fail-closed revival decision packet for issue #2845 on top of the existing heavy forecast-model inventory/preflight. The new packet is available from `build_revival_decision_packet()` and `scripts/research/check_forecast_heavy_model_inventory.py --decision-packet` / `--decision-packet --json`.

Why now: live issue guidance keeps the heavy-predictor lane deferred behind coupling-gate evidence. This slice makes that deferred state mechanically checkable without implementing a model, running inference, or starting compute.

Claim boundary: analysis-only / preflight behavior. This PR does not provide model-quality evidence and does not move any benchmark, dissertation, or paper-facing claim.

Required validation: focused CPU tests for the inventory and decision-packet CLI, targeted Ruff lint, JSON packet smoke, and final PR-ready wrapper.

Remaining blocker: the lane remains `deferred_blocked` until a bounded held-out forecast dataset/manifest, heavy-model adapter, CPU budget config, dependency decision, and trained checkpoint decision exist.

Issue: https://github.com/ll7/robot_sf_ll7/issues/2845

## Contract delta

New behavior:
- `HeavyModelRevivalDecisionPacket` JSON-safe dataclass records `evidence_status`, `revival_status`, `recommendation`, blockers, next local action, allowed actions, forbidden actions, and the backing inventory report.
- `build_revival_decision_packet()` derives the packet from the canonical inventory/preflight report.
- `render_revival_decision_packet_markdown()` renders a compact review/issue handoff packet.
- CLI flag `--decision-packet` emits Markdown by default and JSON when combined with `--json`.

Fail-closed blockers:
- Broken required forecast surfaces produce `blocked_surface_contract`.
- Missing local minimum-experiment prerequisites produce `deferred_blocked`.
- Satisfied local prerequisites with unresolved external dependency/checkpoint decisions produce `local_ready_external_blocked`.

Compatibility impact:
- Default inventory CLI behavior is unchanged.
- `--json` remains the inventory report unless `--decision-packet` is also supplied.
- No new dependency, no model adapter, no benchmark campaign, no planner integration, no transient queue-routing state in tracked files.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/research/forecast_heavy_model_inventory.py scripts/research/check_forecast_heavy_model_inventory.py tests/prediction/test_forecast_heavy_model_decision_packet.py tests/research/test_forecast_heavy_model_inventory.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/research/test_forecast_heavy_model_inventory.py tests/prediction/test_forecast_heavy_model_decision_packet.py -q` -> passed, 30 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/research/check_forecast_heavy_model_inventory.py --decision-packet --json` -> passed; emitted `deferred_blocked | continue assessment only; do not implement or train a heavy model`.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue_2845_pr_body.md scripts/dev/pr_ready_check.sh` -> passed.

## Out of scope

No full benchmark campaign run. No Slurm/GPU submission. No training. No planner integration. No paper/dissertation claim edits.

## Downstream propagation

No issue comment is posted from this run because comment authorization is false. The durable state propagation for this slice is the PR body plus the updated issue-specific study note documenting the new packet command.

## Domain-Aware Approval

- Required for PR: yes - waived because this is an analysis-only preflight packet with no evidence classification or benchmark interpretation change.
- Domains reviewed: NA - no benchmark, metric, figure, or paper-facing claim surface changed.
- Status: waived
- Approval or blocker note: Waived by proportional-validation policy for analysis-only preflight; packet explicitly blocks claim promotion and compute.
- Validity checklist:
  - Target claim/hypothesis: NA - no model-quality or benchmark claim; packet keeps issue #2845 deferred.
  - Comparator or split/evidence validity: No data split, comparator result, or experimental measurement is introduced by this PR.
  - Fallback/degraded exclusions: Explicitly no benchmark campaign or degraded/fallback success evidence.
  - Claim boundary: analysis-only preflight and revival-state contract; no paper-facing claim.
  - Implementation integrity vs experimental validity: implementation verified by focused unit tests/CLI smoke; experimental validity remains blocked by missing prerequisites.

<details>
<summary>Freshness and prior-slice checks</summary>

- Live issue was read with comments before work and refreshed immediately before PR open. Latest maintainer comment remains 2026-07-02: heavy-predictor assessment stays deferred behind coupling gate #2916; no newer maintainer guidance was present.
- Existing merged slice #3746 covered inventory/preflight. This PR adds the new named capability: fail-closed revival decision packet.
- Fragmentation guard: no two guardrail/checker/packet-refresh PRs for #2845 merged in the last 24h.

</details>
