### PR TITLE
Issue #4539: fail closed on unknown classification labels (cheap-lane worker)

### DIFF
--- a/scripts/validation/check_release_claim_matrix_publication_gate.py
+++ b/scripts/validation/check_release_claim_matrix_publication_gate.py
@@ -24,6 +24,8 @@ DEFAULT_MATRIX_PATH = Path(
 )
 SCHEMA_VERSION = "release-claim-matrix-publication-gate.v1"
 EXPECTED_MATRIX_SCHEMA = "release_claim_matrix_issue_3294.v1"
+BENCHMARK_EVIDENCE_CLASSIFICATION = "benchmark evidence"
+KNOWN_NON_BENCHMARK_CLASSIFICATIONS = frozenset({"diagnostic evidence", "non-claim"})
 NOT_CERTIFIED_VALUES = {
     "",
     "missing",
@@ -169,10 +171,10 @@ def build_gate_report(matrix: dict[str, Any], *, repo_root: Path) -> dict[str, A
             raise ValueError(f"Matrix row {index} must be an object")
         row_id = _row_id(row, index)
         classification = str(row.get("classification", "")).strip().lower()
-        if classification == "benchmark evidence":
+        if classification == BENCHMARK_EVIDENCE_CLASSIFICATION:
             benchmark_rows += 1
             blockers.extend(_check_benchmark_evidence_row(row, row_id=row_id, repo_root=repo_root))
-        else:
+        elif classification in KNOWN_NON_BENCHMARK_CLASSIFICATIONS:
             diagnostic_or_non_claim_rows += 1
             if row.get("benchmark_success") is True:
                 blockers.append(
@@ -184,6 +186,19 @@ def build_gate_report(matrix: dict[str, Any], *, repo_root: Path) -> dict[str, A
                         next_action="Downgrade benchmark_success or reclassify with full evidence.",
                     )
                 )
+        else:
+            blockers.append(
+                GateBlocker(
+                    row_id=row_id,
+                    check="classification",
+                    severity="blocker",
+                    reason=f"unrecognized classification {classification or 'missing'}",
+                    next_action=(
+                        "Use benchmark evidence or a known non-benchmark classification before "
+                        "publication."
+                    ),
+                )
+            )
 
     return {
         "schema_version": SCHEMA_VERSION,

--- a/tests/validation/test_check_release_claim_matrix_publication_gate.py
+++ b/tests/validation/test_check_release_claim_matrix_publication_gate.py
@@ -100,6 +100,36 @@ def test_gate_rejects_non_benchmark_success_promotion(tmp_path) -> None:
     assert report["blockers"][0]["check"] == "non_benchmark_promotion"
 
 
+def test_gate_fails_closed_for_unknown_classification(tmp_path) -> None:
+    """Unknown classification labels must not silently bypass strict checks."""
+
+    report = build_gate_report(
+        _matrix(
+            [
+                {
+                    "row_id": "release_artifact:unknown-classification",
+                    "classification": "nominal benchmark evidence",
+                    "benchmark_success": False,
+                }
+            ]
+        ),
+        repo_root=tmp_path,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == [
+        {
+            "row_id": "release_artifact:unknown-classification",
+            "check": "classification",
+            "severity": "blocker",
+            "reason": "unrecognized classification nominal benchmark evidence",
+            "next_action": (
+                "Use benchmark evidence or a known non-benchmark classification before publication."
+            ),
+        }
+    ]
+
+
 def test_committed_matrix_remains_blocked_until_certification_is_attached() -> None:
     """Current tracked matrix is an integration surface, not a publication-ready claim."""
 


### PR DESCRIPTION
## Summary
Fail closed when the release-claim-matrix publication gate sees an unrecognized classification label, so future taxonomy drift cannot silently take the lenient non-benchmark branch.

## Linked Issues
- Relates to `#4539`
- Relates to `#2910`

## Stack / Dependency
- Base dependency: `PR #4536`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `PR #4536` introduced the gate; this slice hardens one latent fail-open path without duplicating that baseline implementation.

## What Changed
- Added explicit classification constants for benchmark and known non-benchmark rows.
- Changed `build_gate_report` to emit a blocker when a row uses an unknown classification instead of silently routing it through the non-benchmark branch.
- Added a focused regression test covering an unknown `nominal benchmark evidence` label.

## Why It Matters
- Added value: unknown or renamed classification labels now fail closed.
- Expected impact: future release-claim-matrix taxonomy changes cannot bypass stricter publication checks by typo or drift.
- Why this is worth merging now: it closes the concrete latent hazard named in `#4539` with a small local change and leaves the maintainer-owned scenario-certification vocabulary decision untouched.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: release-claim-matrix publication gate fail-closed behavior
- Comparator or baseline, if applicable: current `origin/main` gate behavior
- Evidence tier: NA - support validation-gate hardening
- Result classification: NA - support validation-gate hardening
- Decision or stop rule, if applicable: gate must block unknown classifications instead of treating them as ordinary non-benchmark rows
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#4539`
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper

## Domain-Aware Approval
- Required for this PR: no - this changes implementation integrity for a validation gate, not evidence interpretation
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: NA
- Validity checklist:
  - Target claim/hypothesis: NA
  - Comparator or split/evidence validity: NA
  - Fallback/degraded exclusions: NA
  - Claim boundary: CPU-only gate logic only
  - Implementation integrity vs experimental validity: implementation integrity only

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: maintainer-owned `scenario_cert.v1` allowlist follow-up remains in `#4539`

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none for this slice
- Stop / revise / continue decision: continue with the separate scenario-certification vocabulary hardening once the accepted-state contract is confirmed
- Proposed child issue or existing follow-up: existing follow-up remains `#4539`

## Validation / Proof
- Commands run:
  - `uv run ruff check scripts/validation/check_release_claim_matrix_publication_gate.py tests/validation/test_check_release_claim_matrix_publication_gate.py`
  - `uv run pytest tests/validation/test_check_release_claim_matrix_publication_gate.py -q`
- Evidence that the change works here:
  - Ruff passed on the changed files.
  - Focused pytest passed with `6 passed`.
- Benchmarks or smoke tests, if applicable:
  - NA - CPU-only validation gate logic

## Risks / Rollout
- Compatibility risks: low; only unknown classification labels change behavior, and they now fail closed.
- Failure modes: any newly introduced classification string will block until the gate is taught about it explicitly.
- Rollback or fallback plan: revert this branch if reviewers want a different unknown-classification policy.

## Docs / Provenance
- Updated docs: none
- Relevant design or provenance notes: issue `#4539`, predecessor `PR #4536`
- Any assumptions that need to be preserved: only `benchmark evidence`, `diagnostic evidence`, and `non-claim` are currently recognized by this slice

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is a narrow validation-script hardening change with no new durable evidence artifact

## Follow-Up Issues
- Deferred work: scenario-certification allowlist hardening remains deferred pending the maintainer-owned accepted vocabulary decision already noted in `#4539`
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: the new blocker path only applies to unknown classification labels and does not alter current known matrix rows.
- Any known limitations: this slice intentionally does not change `scenario_certification` handling.

Related predecessor slice: this change hardens unknown classification handling and does not duplicate PR #4536, which introduced the publication gate itself.

This PR was produced by the GitHub-Copilot-CLI/gpt-5.4 cheap implementation lane; the review gate hardens and merges.
