### PR TITLE
feat: add forecast lane status ledger (#2835)

### DIFF
--- a/robot_sf/benchmark/forecast_lane_inventory.py
+++ b/robot_sf/benchmark/forecast_lane_inventory.py
@@ -70,6 +70,31 @@ class ForecastCapabilitySpec:
     note: str = ""
 
 
+@dataclass(frozen=True)
+class ForecastLaneStatusSpec:
+    """One checked-progress row for the forecast research lane epic."""
+
+    requirement_id: str
+    requirement: str
+    current_artifacts: tuple[str, ...]
+    status: str
+    remaining_blocker: str
+    next_action: str
+    learned_predictor_gate: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return JSON-serializable status row."""
+        return {
+            "requirement_id": self.requirement_id,
+            "requirement": self.requirement,
+            "current_artifacts": list(self.current_artifacts),
+            "status": self.status,
+            "remaining_blocker": self.remaining_blocker,
+            "next_action": self.next_action,
+            "learned_predictor_gate": self.learned_predictor_gate,
+        }
+
+
 # Canonical forecast-lane registry. Each entry points at an existing owner module
 # under robot_sf/benchmark/; this inventory never reimplements those surfaces.
 _FORECAST_CAPABILITIES: tuple[ForecastCapabilitySpec, ...] = (
@@ -219,6 +244,95 @@ _FORECAST_CAPABILITIES: tuple[ForecastCapabilitySpec, ...] = (
 )
 
 
+_VALID_LANE_STATUSES = frozenset({"done", "partial", "unresolved", "blocked"})
+
+
+# Checked-progress ledger requested on issue #2835. This is deliberately durable
+# research-lane state, not transient queue routing state or campaign lineage.
+_FORECAST_LANE_STATUS_ROWS: tuple[ForecastLaneStatusSpec, ...] = (
+    ForecastLaneStatusSpec(
+        requirement_id="forecast_batch_v1",
+        requirement="ForecastBatch.v1 artifact contract",
+        current_artifacts=("#2836", "#2849", "robot_sf/benchmark/forecast_batch.py"),
+        status="done",
+        remaining_blocker="None for the schema/provenance contract.",
+        next_action="Keep downstream forecast artifacts on ForecastBatch.v1.",
+    ),
+    ForecastLaneStatusSpec(
+        requirement_id="observation_adapters",
+        requirement="Observation-level forecast adapters",
+        current_artifacts=("#2838", "#2860", "robot_sf/benchmark/forecast_observation_adapters.py"),
+        status="done",
+        remaining_blocker="None for oracle/full-state/tracked observation separation.",
+        next_action="Extend only when a new deployable observation tier lands.",
+    ),
+    ForecastLaneStatusSpec(
+        requirement_id="motion_rich_traces",
+        requirement="Motion-rich forecast-evaluable trace families",
+        current_artifacts=("#2774", "#2853", "#2884"),
+        status="partial",
+        remaining_blocker="Coverage is useful but not a final transfer-aware scenario matrix.",
+        next_action="Use fixture gaps from transferability rows to choose the next trace family.",
+    ),
+    ForecastLaneStatusSpec(
+        requirement_id="baseline_ladder",
+        requirement="CV, semantic-CV, and interaction-aware baseline ladder",
+        current_artifacts=("#2758", "#2781", "#2915"),
+        status="partial",
+        remaining_blocker="Baseline comparison is diagnostic until same-seed planner consumption is proven.",
+        next_action="Keep learned predictors gated until closed-loop rows compare these baselines.",
+        learned_predictor_gate=True,
+    ),
+    ForecastLaneStatusSpec(
+        requirement_id="calibration_and_risk",
+        requirement="Calibration, reliability, and forecast-risk readiness",
+        current_artifacts=("#2841", "#2865", "#2869"),
+        status="blocked",
+        remaining_blocker="Forecast-risk scoring rows are gated by eligible risk-filtered planner evidence.",
+        next_action="Populate risk-scoring-eligible rows through the closed-loop coupling path first.",
+        learned_predictor_gate=True,
+    ),
+    ForecastLaneStatusSpec(
+        requirement_id="transferability_matrix",
+        requirement="Transferability stress matrix",
+        current_artifacts=("#2847", "#2866", "#2887"),
+        status="partial",
+        remaining_blocker="Some matrix cells remain explicitly unavailable or diagnostic-only.",
+        next_action="Fill high-value blocked cells after observation, metric, and fixture owners are ready.",
+        learned_predictor_gate=True,
+    ),
+    ForecastLaneStatusSpec(
+        requirement_id="closed_loop_gate",
+        requirement="Same-seed closed-loop planner coupling gate",
+        current_artifacts=("#2843", "#2902", "#2916", "#2966"),
+        status="unresolved",
+        remaining_blocker=(
+            "Forecast improvement alone has not established non-regressive planner safety/progress."
+        ),
+        next_action="Run CPU/local gate slices only; no learned-heavy expansion until verdict is continue.",
+        learned_predictor_gate=True,
+    ),
+    ForecastLaneStatusSpec(
+        requirement_id="learned_predictor",
+        requirement="Learned probabilistic predictor expansion",
+        current_artifacts=("#2844", "#2845"),
+        status="blocked",
+        remaining_blocker="Requires closed-loop gate continue verdict plus calibration/transfer readiness.",
+        next_action="Keep to spec/scoping work; do not launch training from this epic.",
+        learned_predictor_gate=True,
+    ),
+    ForecastLaneStatusSpec(
+        requirement_id="final_synthesis",
+        requirement="Final forecast-lane synthesis",
+        current_artifacts=("#2864", "#2881", "#2929"),
+        status="partial",
+        remaining_blocker="Needs updated synthesis after gate and transfer rows settle.",
+        next_action="Consolidate blockers and next empirical action before any claim promotion.",
+        learned_predictor_gate=True,
+    ),
+)
+
+
 @dataclass
 class CapabilityProbeResult:
     """Outcome of probing a single forecast capability.
@@ -346,6 +460,73 @@ def build_forecast_lane_inventory(*, repo_root: Path | None = None) -> dict[str,
     }
 
 
+def build_forecast_lane_status() -> dict[str, Any]:
+    """Return the checked-progress ledger for forecast-lane issue #2835.
+
+    The status report answers a different question than the capability inventory:
+    not "does this module import?", but "which epic requirements are complete
+    enough to unblock learned-predictor work?". It remains read-only and does not
+    execute campaigns, training, predictors, or benchmark evaluation.
+    """
+    rows = list(_FORECAST_LANE_STATUS_ROWS)
+    invalid_rows = [row for row in rows if row.status not in _VALID_LANE_STATUSES]
+    learned_gate_blockers = [
+        row
+        for row in rows
+        if row.learned_predictor_gate and row.status in {"partial", "unresolved", "blocked"}
+    ]
+    status_counts = {
+        status: sum(row.status == status for row in rows) for status in _VALID_LANE_STATUSES
+    }
+    return {
+        "schema": "forecast_lane_status.v1",
+        "ok": not invalid_rows,
+        "learned_predictor_unblocked": not learned_gate_blockers,
+        "issue": 2835,
+        "claim_boundary": (
+            "Forecast-lane infrastructure is diagnostic until same-seed closed-loop "
+            "planner evidence establishes non-regressive safety/progress under explicit "
+            "fallback/degraded accounting."
+        ),
+        "requirements": [row.as_dict() for row in rows],
+        "summary": {
+            "total": len(rows),
+            "status_counts": status_counts,
+            "invalid_status_ids": [row.requirement_id for row in invalid_rows],
+            "learned_predictor_blocker_ids": [row.requirement_id for row in learned_gate_blockers],
+        },
+    }
+
+
+def format_status_markdown(report: dict[str, Any]) -> str:
+    """Render compact Markdown for the forecast-lane checked-progress ledger.
+
+    Returns:
+        Markdown status table plus learned-predictor blockers when present.
+    """
+    lines: list[str] = []
+    verdict = "UNBLOCKED" if report["learned_predictor_unblocked"] else "BLOCKED"
+    lines.append(f"# Forecast lane checked-progress ledger: learned predictor {verdict}")
+    lines.append("")
+    lines.append(report["claim_boundary"])
+    lines.append("")
+    lines.append("| Requirement | Status | Current artifact | Remaining blocker | Next action |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for row in report["requirements"]:
+        artifacts = ", ".join(row["current_artifacts"])
+        lines.append(
+            f"| {row['requirement']} | {row['status']} | {artifacts} | "
+            f"{row['remaining_blocker']} | {row['next_action']} |"
+        )
+    blocker_ids = report["summary"]["learned_predictor_blocker_ids"]
+    if blocker_ids:
+        lines.append("")
+        lines.append("## Learned-predictor blockers")
+        for blocker_id in blocker_ids:
+            lines.append(f"- `{blocker_id}`")
+    return "\n".join(lines)
+
+
 def format_inventory_markdown(report: dict[str, Any]) -> str:
     """Render a compact human-readable inventory report.
 
@@ -386,29 +567,39 @@ def format_inventory_markdown(report: dict[str, Any]) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entry point: print the inventory report and return an exit code.
+    """CLI entry point: print inventory or status report and return exit code.
 
     Returns:
-        ``0`` when every required capability is present, otherwise ``1``.
+        In default inventory mode, ``0`` if required capability is present,
+        otherwise ``1``. In status mode, ``0`` if the ledger itself is valid;
+        learned-predictor blockers are reported in the payload but do not make
+        the command fail because they are expected issue state.
     """
 
     parser = argparse.ArgumentParser(
         description=(
-            "Read-only forecast-lane capability inventory / preflight. "
-            "Reports missing forecast components as explicit blockers; does not "
-            "run predictors, training, or benchmarks."
+            "Read-only forecast-lane capability inventory / status preflight. "
+            "Reports missing forecast components and epic blockers explicitly; "
+            "does not run predictors, training, or benchmarks."
         )
     )
     parser.add_argument(
         "--json",
         action="store_true",
-        help="Emit the machine-readable inventory report as JSON.",
+        help="Emit the machine-readable report as JSON.",
+    )
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Emit checked-progress ledger for issue #2835 instead of import inventory.",
     )
     args = parser.parse_args(argv)
 
-    report = build_forecast_lane_inventory()
+    report = build_forecast_lane_status() if args.status else build_forecast_lane_inventory()
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))  # noqa: T201 - CLI output
+    elif args.status:
+        print(format_status_markdown(report))  # noqa: T201 - CLI output
     else:
         print(format_inventory_markdown(report))  # noqa: T201 - CLI output
 

--- a/scripts/benchmark/forecast_lane_preflight.py
+++ b/scripts/benchmark/forecast_lane_preflight.py
@@ -6,12 +6,14 @@ and importable on the current checkout::
 
     uv run python scripts/benchmark/forecast_lane_preflight.py
     uv run python scripts/benchmark/forecast_lane_preflight.py --json
+    uv run python scripts/benchmark/forecast_lane_preflight.py --status --json
 
 Exit code 0 means every required forecast capability is present; non-zero means a
 required capability is missing or broken (the report names the blocker and its
 owner). The check is read-only: it imports and inspects the canonical
-``robot_sf/benchmark`` forecast owners. It never runs predictors, training, or
-benchmark campaigns.
+``robot_sf/benchmark`` forecast owners. Status mode reports the issue #2835
+checked-progress ledger and learned-predictor blockers. It never runs
+predictors, training, or benchmark campaigns.
 """
 
 from __future__ import annotations

--- a/tests/benchmark/test_forecast_lane_inventory.py
+++ b/tests/benchmark/test_forecast_lane_inventory.py
@@ -173,5 +173,65 @@ def test_module_invocation_matches_script(monkeypatch):
     assert fli.main(["--json"]) == 0
 
 
+def test_status_report_preserves_learned_predictor_gate():
+    """Status ledger keeps learned predictors blocked while gate rows remain unresolved."""
+    report = fli.build_forecast_lane_status()
+
+    assert report["schema"] == "forecast_lane_status.v1"
+    assert report["ok"] is True
+    assert report["issue"] == 2835
+    assert report["learned_predictor_unblocked"] is False
+    assert "closed_loop_gate" in report["summary"]["learned_predictor_blocker_ids"]
+    assert "learned_predictor" in report["summary"]["learned_predictor_blocker_ids"]
+
+
+def test_status_rows_are_unique_and_valid():
+    """Ledger rows have stable ids, valid statuses, and actionable blockers."""
+    report = fli.build_forecast_lane_status()
+    rows = report["requirements"]
+    ids = [row["requirement_id"] for row in rows]
+
+    assert len(ids) == len(set(ids))
+    assert report["summary"]["invalid_status_ids"] == []
+    for row in rows:
+        assert row["status"] in fli._VALID_LANE_STATUSES
+        assert row["current_artifacts"]
+        assert row["remaining_blocker"]
+        assert row["next_action"]
+
+
+def test_status_markdown_lists_blockers():
+    """Markdown status view exposes learned-predictor blockers."""
+    report = fli.build_forecast_lane_status()
+    text = fli.format_status_markdown(report)
+
+    assert "learned predictor BLOCKED" in text
+    assert "Learned-predictor blockers" in text
+    assert "closed_loop_gate" in text
+
+
+def test_cli_status_json_reports_expected_blocker():
+    """The runnable script emits status JSON without running forecast workloads."""
+    proc = subprocess.run(
+        [sys.executable, "scripts/benchmark/forecast_lane_preflight.py", "--status", "--json"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["schema"] == "forecast_lane_status.v1"
+    assert payload["learned_predictor_unblocked"] is False
+    assert "closed_loop_gate" in payload["summary"]["learned_predictor_blocker_ids"]
+
+
+def test_module_status_invocation_succeeds():
+    """Status mode succeeds because blockers are issue state, not CLI failure."""
+    assert fli.main(["--status"]) == 0
+    assert fli.main(["--status", "--json"]) == 0
+
+
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a `forecast_lane_status.v1` checked-progress ledger to the existing forecast-lane preflight owner, plus `--status` CLI output and tests.

Why now: issue #2835 has evolved from a proposal epic into a durable progress ledger. The new capability records the current done/partial/unresolved/blocked state in one machine-readable surface instead of another transient issue comment stream.

Claim boundary: this is status/schema plumbing only. It does not claim forecast methods improve local-navigation safety, progress, transfer, or runtime; learned predictors remain blocked until same-seed closed-loop planner evidence, calibration/risk readiness, and transferability gaps are resolved.

Required validation: focused forecast-lane inventory/status tests, Ruff on changed files, and final `pr_ready_check` all passed.

Remaining blocker: the ledger intentionally reports learned-predictor expansion as blocked by `baseline_ladder`, `calibration_and_risk`, `transferability_matrix`, `closed_loop_gate`, `learned_predictor`, and `final_synthesis`.

## Contract delta

New schema/report surface:
- `forecast_lane_status.v1` from `build_forecast_lane_status()`.
- Status rows expose `requirement_id`, `requirement`, `current_artifacts`, `status`, `remaining_blocker`, `next_action`, and `learned_predictor_gate`.
- CLI: `uv run python scripts/benchmark/forecast_lane_preflight.py --status --json`.

New fail-closed blockers:
- `learned_predictor_unblocked` remains `false` while any learned-predictor gate row is `partial`, `unresolved`, or `blocked`.
- Invalid status vocabulary is reported through `summary.invalid_status_ids` and makes `ok=false`.

Compatibility impact:
- Default inventory mode and `--json` behavior remain intact.
- Status mode is additive and read-only; it imports existing forecast modules but runs no predictors, training, benchmark campaigns, Slurm, or GPU work.
- No transient target-host, queue-routing, or packet-lineage state is stored in tracked files.

## Issue

Relates to #2835.

## Scope summary

This PR delivers a named new capability: **forecast-lane checked-progress status contract**. It consolidates the epic’s durable requirement ledger beside the existing forecast-lane capability inventory, with tests covering blocker semantics and CLI JSON output.

## Validation

- `uv run ruff check robot_sf/benchmark/forecast_lane_inventory.py scripts/benchmark/forecast_lane_preflight.py tests/benchmark/test_forecast_lane_inventory.py` -> passed.
- `uv run pytest tests/benchmark/test_forecast_lane_inventory.py -q` -> 16 passed.
- `uv run python scripts/benchmark/forecast_lane_preflight.py --status --json` -> `forecast_lane_status.v1`, `learned_predictor_unblocked=false`, expected blocker ids emitted.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue_2835_pr_body.md scripts/dev/pr_ready_check.sh` -> passed; freshness stamp `output/validation/pr_ready/issue-2835-forecast-lane-status-contract.json`, head `1983d6bce6ee440a6ec143960ba0274ddd69c913`.

## Explicit out of scope

No full benchmark campaign run. No Slurm/GPU submission. No paper/dissertation claim edits. No learned predictor training or claim promotion.

<details>
<summary>Appendix: governance and propagation</summary>

State propagation: no issue comment is added from this PR because the durable state surface is now the tracked `forecast_lane_status.v1` contract and the PR body records remaining work. This avoids turning a high-churn epic into a comment stream.

Fragmentation guard: no open duplicate PR was found for issue #2835 or this status-ledger scope. No #2835 guardrail/checker/packet-refresh PRs were found merged in the last 24 hours, and this slice adds a named new capability rather than another micro-guard.

Late issue guidance: issue #2835 was re-read via REST immediately before PR opening because `gh issue view --comments` is blocked by GitHub's Projects classic GraphQL deprecation error in this repo. No comments updated after 2026-07-05T00:00:00Z were found.

</details>
