### PR TITLE
Issue #2312: add learned-risk trace status packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Added a compact **learned-risk trace status packet** for issue #2312. The existing
+  `scripts/validation/validate_learned_risk_trace_manifest.py` validator now supports
+  `--status-json`, and `robot_sf/training/learned_risk_trace_manifest.py` exposes
+  `build_trace_manifest_status_packet()` so #1472 handoff/state propagation can reuse the same
+  fail-closed manifest decision without re-reading or reinterpreting the manifest. This is
+  data-preflight status only: no trace materialization, external-data copy, training run, SLURM
+  (Simple Linux Utility for Resource Management) submission, or research claim.
 * Added **typed collision-event export records** to new episode rows (issue #4454). The canonical
   `event_ledger` block is now `EpisodeEventLedger.v2` and can carry per-collision records with
   partner type/id, collision time, relative contact speed, clearance-series provenance, and exact

--- a/docs/context/issue_2312_learned_risk_trace_manifest.md
+++ b/docs/context/issue_2312_learned_risk_trace_manifest.md
@@ -7,35 +7,37 @@ Predecessor preflight: [`issue_2273_learned_risk_trace_preflight.md`](issue_2273
 
 ## Scope
 
-This change adds the **durable trace manifest + baseline-artifact-URI contract** and a
-**fail-closed validator** that #1472 learned-risk training can call before it runs. It does
-**not** materialize traces, copy external data, run training, or submit SLURM (Simple Linux Utility
-for Resource Management) jobs. The trace bytes are produced by the #1472 / #2441 SLURM runs; the
+This change adds a **durable trace manifest + baseline-artifact-URI contract** and a
+**fail-closed validator** that #1472 learned-risk training can call before runs. It does **not**
+materialize traces, copy external data, run training, or submit SLURM (Simple Linux Utility for
+Resource Management) jobs. The trace bytes are produced by the #1472 / #2441 SLURM runs; the
 manifest and validator are buildable now.
 
-This closes the `Training trace manifest -> missing` gap recorded in the #2273 preflight: there is
-now a tracked manifest and a mechanical readiness check, rather than only a launch packet plus a
+This closes the `Training trace manifest -> missing` gap recorded in #2273 preflight: the repository
+now has a tracked manifest and mechanical readiness check, rather than only a launch packet plus a
 contract fixture.
 
-## What landed
+## What Landed
 
 - `robot_sf/training/learned_risk_trace_manifest.py` — `validate_trace_manifest()` returns a
   `training_readiness_decision` of `ready_for_training_handoff` or, fail-closed,
   `artifact_retrieval_blocked`. Malformed manifests raise `LearnedRiskTraceManifestError`.
+  `build_trace_manifest_status_packet()` converts that same validation report into a compact
+  `learned-risk-trace-status.v1` handoff/status packet for #1472 state propagation.
 - `scripts/validation/validate_learned_risk_trace_manifest.py` — CLI with decision-coded exit
-  status: `0` ready, `2` structurally invalid, `3` blocked.
-- `configs/training/learned_risk_trace_manifest_issue_2312.yaml` — the tracked manifest, currently
-  in honest `blocked` state (pending baseline/trace aliases, `retrieval_status: blocked`).
+  status: `0` ready, `2` structurally invalid, `3` blocked. Use `--status-json` when a compact
+  state packet is needed instead of the full validation report.
+- `configs/training/learned_risk_trace_manifest_issue_2312.yaml` — tracked manifest, currently in
+  honest `blocked` state (pending baseline/trace aliases, `retrieval_status: blocked`).
 - `tests/training/test_learned_risk_trace_manifest.py` — synthetic-manifest tests for the decision
-  boundary plus the checked-in manifest.
-
-Shared checksum logic was promoted to `sha256_file()` in
-`robot_sf/training/learned_risk_launch_packet.py` and reused by both validators.
+  boundary plus checked-in manifest status-packet coverage. Shared checksum logic is promoted via
+  `sha256_file()` in `robot_sf/training/learned_risk_launch_packet.py` so training can verify
+  retrieved bytes.
 
 ## Contract
 
 A manifest (`schema_version: learned-risk-trace-manifest.v1`) is `ready_for_training_handoff` only
-when **all** hold; any failure yields `artifact_retrieval_blocked`:
+when **all** of these hold; any failure yields `artifact_retrieval_blocked`:
 
 - `baseline_artifact_uri` and every `trace_artifacts` entry use a durable URI scheme and carry no
   placeholder alias (`:pending`, `tbd`, `todo`, ...);
@@ -47,26 +49,30 @@ when **all** hold; any failure yields `artifact_retrieval_blocked`:
   `present`;
 - `retrieval_status` is `available`.
 
-Resolvability is the **local contract** (scheme, no placeholder, recorded digest, labels). A ready
-decision means "locally contract-complete", not "bytes fetched and verified"; the durable digest is
-what lets the training run verify the bytes it retrieves.
+Resolvability is the **local contract**: durable URI scheme, no placeholder, recorded digest, and
+present labels. A ready decision means "locally contract-complete", not "bytes fetched and
+verified"; the durable digest lets the training run verify the bytes it retrieves.
 
-## Current decision
+## Current Decision
 
 `artifact_retrieval_blocked`. The checked-in manifest still references `:pending` baseline and trace
-aliases and has `label_availability: pending`, so training stays blocked — the truthful state until
-the #1472 / #2441 SLURM run materializes and uploads versioned artifacts.
+aliases with `label_availability: pending`, so training stays blocked until the #1472 / #2441 SLURM
+run materializes and uploads versioned artifacts.
 
 ## Validation
 
 ```bash
 uv run python scripts/validation/validate_learned_risk_trace_manifest.py \
-  --config configs/training/learned_risk_trace_manifest_issue_2312.yaml --json   # exits 3 (blocked)
+  --config configs/training/learned_risk_trace_manifest_issue_2312.yaml --json
+# exits 3 (blocked)
+uv run python scripts/validation/validate_learned_risk_trace_manifest.py \
+  --config configs/training/learned_risk_trace_manifest_issue_2312.yaml --status-json
+# exits 3 (blocked) and emits learned-risk-trace-status.v1
 uv run python -m pytest tests/training/test_learned_risk_trace_manifest.py \
   tests/training/test_learned_risk_launch_packet.py -q
 ```
 
-## Claim boundary
+## Claim Boundary
 
 Data-preflight tooling only. It does not assert anything about the learned-risk model's quality; it
-makes the trace/baseline readiness of #1472 mechanically checkable and fail-closed.
+makes the trace/baseline readiness for #1472 mechanically checkable and fail-closed.

--- a/robot_sf/training/learned_risk_trace_manifest.py
+++ b/robot_sf/training/learned_risk_trace_manifest.py
@@ -154,6 +154,43 @@ def validate_trace_manifest(
     }
 
 
+def build_trace_manifest_status_packet(
+    report: dict[str, Any],
+    *,
+    manifest_path: Path | str,
+) -> dict[str, Any]:
+    """Build a compact handoff packet from a trace-manifest validation report.
+
+    The packet is intentionally derived from ``validate_trace_manifest`` output
+    rather than re-reading the manifest. That keeps downstream state propagation
+    tied to the same fail-closed decision #1472 training uses.
+
+    Returns:
+        Compact ``learned-risk-trace-status.v1`` packet suitable for handoff or
+        durable issue-state propagation.
+    """
+    decision = report.get("training_readiness_decision")
+    if decision == DECISION_READY:
+        next_action = "handoff_to_training_gate"
+    else:
+        next_action = "materialize_durable_trace_and_baseline_artifacts"
+
+    return {
+        "schema_version": "learned-risk-trace-status.v1",
+        "source_issue": report.get("source_issue"),
+        "parent_issue": report.get("parent_issue"),
+        "candidate_id": report.get("candidate_id"),
+        "manifest_path": str(manifest_path),
+        "training_readiness_decision": decision,
+        "training_ready": bool(report.get("training_ready")),
+        "baseline_artifact_uri": report.get("baseline_artifact_uri"),
+        "split_ids": list(report.get("split_ids", [])),
+        "label_availability": dict(report.get("label_availability", {})),
+        "blockers": list(report.get("blockers", [])),
+        "next_action": next_action,
+    }
+
+
 def _validate_structure(
     manifest: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -315,6 +352,7 @@ __all__ = [
     "DECISION_READY",
     "SCHEMA_VERSION",
     "LearnedRiskTraceManifestError",
+    "build_trace_manifest_status_packet",
     "load_trace_manifest",
     "validate_trace_manifest",
 ]

--- a/scripts/validation/validate_learned_risk_trace_manifest.py
+++ b/scripts/validation/validate_learned_risk_trace_manifest.py
@@ -1,6 +1,6 @@
-"""Validate a durable learned-risk trace manifest before #1472 training.
+"""Validate durable learned-risk trace manifest before #1472 training.
 
-Exit codes are distinct so callers (and #1472 readiness) can branch mechanically:
+Exit codes distinct so callers (and #1472 readiness) branch mechanically:
 
 - ``0`` -- manifest is contract-complete: ``ready_for_training_handoff``.
 - ``2`` -- manifest is structurally invalid and cannot be evaluated.
@@ -17,14 +17,15 @@ from pathlib import Path
 from robot_sf.training.learned_risk_trace_manifest import (
     DECISION_BLOCKED,
     LearnedRiskTraceManifestError,
+    build_trace_manifest_status_packet,
     validate_trace_manifest,
 )
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
-    """Build the command-line parser."""
+    """Build command-line parser."""
     parser = argparse.ArgumentParser(
-        description="Validate a durable learned-risk trace manifest (fail-closed)."
+        description="Validate durable learned-risk trace manifest (fail-closed)."
     )
     parser.add_argument("--config", required=True, type=Path, help="Trace-manifest YAML path.")
     parser.add_argument(
@@ -33,29 +34,39 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Repository root used to resolve relative paths.",
     )
-    parser.add_argument("--json", action="store_true", help="Emit a JSON validation report.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON validation report.")
+    parser.add_argument(
+        "--status-json",
+        action="store_true",
+        help="Emit compact #1472 handoff status JSON instead of the full validation report.",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Validate a trace manifest and return a decision-coded exit status."""
+    """Validate trace manifest and return decision-coded exit status."""
     args = build_arg_parser().parse_args(argv)
+
     try:
         report = validate_trace_manifest(args.config, repo_root=args.repo_root)
     except LearnedRiskTraceManifestError as exc:
-        if args.json:
+        if args.json or args.status_json:
             print(json.dumps({"status": "invalid", "error": str(exc)}, indent=2, sort_keys=True))
         else:
             print(str(exc))
         return 2
 
-    if args.json:
+    if args.status_json:
+        status_packet = build_trace_manifest_status_packet(report, manifest_path=args.config)
+        print(json.dumps(status_packet, indent=2, sort_keys=True))
+    elif args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
         decision = report["training_readiness_decision"]
         print(f"learned-risk trace manifest decision: {decision}")
         for blocker in report["blockers"]:
-            print(f"  - blocker: {blocker}")
+            print(f" - blocker: {blocker}")
+
     return 3 if report["training_readiness_decision"] == DECISION_BLOCKED else 0
 
 

--- a/tests/training/test_learned_risk_trace_manifest.py
+++ b/tests/training/test_learned_risk_trace_manifest.py
@@ -17,6 +17,7 @@ from robot_sf.training.learned_risk_trace_manifest import (
     DECISION_BLOCKED,
     DECISION_READY,
     LearnedRiskTraceManifestError,
+    build_trace_manifest_status_packet,
     validate_trace_manifest,
 )
 from scripts.validation.validate_learned_risk_trace_manifest import main as validate_cli_main
@@ -245,3 +246,29 @@ def test_cli_ready_manifest_returns_exit_zero(tmp_path: Path) -> None:
     exit_code = validate_cli_main(["--config", str(path), "--json"])
 
     assert exit_code == 0
+
+
+def test_status_packet_summarizes_blocked_manifest_for_handoff() -> None:
+    """Status packet preserves the fail-closed decision for #1472 handoff."""
+    report = validate_trace_manifest(_CHECKED_IN_MANIFEST, repo_root=_REPO_ROOT)
+
+    packet = build_trace_manifest_status_packet(
+        report, manifest_path="configs/training/learned_risk_trace_manifest_issue_2312.yaml"
+    )
+
+    assert packet["schema_version"] == "learned-risk-trace-status.v1"
+    assert packet["source_issue"] == 2312
+    assert packet["parent_issue"] == 1472
+    assert packet["training_ready"] is False
+    assert packet["training_readiness_decision"] == DECISION_BLOCKED
+    assert packet["next_action"] == "materialize_durable_trace_and_baseline_artifacts"
+    assert packet["blockers"] == report["blockers"]
+
+
+def test_cli_status_json_preserves_blocked_exit_code() -> None:
+    """The compact status output keeps the same fail-closed exit code."""
+    exit_code = validate_cli_main(
+        ["--config", str(_CHECKED_IN_MANIFEST), "--repo-root", str(_REPO_ROOT), "--status-json"]
+    )
+
+    assert exit_code == 3


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Adds a compact `learned-risk-trace-status.v1` status packet for the existing issue #2312 durable learned-risk trace manifest. `build_trace_manifest_status_packet()` derives the packet from the existing `validate_trace_manifest()` report, and `scripts/validation/validate_learned_risk_trace_manifest.py --status-json` exposes it for #1472 handoff/state propagation.

Why now: #2312 already has the manifest and fail-closed validator from PR #3762, plus the #1472 aggregate gate from PR #3772. This slice adds a new named capability rather than another checker refresh: a reusable status packet that carries the same fail-closed decision into durable handoff surfaces.

Claim boundary: Data-preflight status only. Current checked-in manifest still returns `artifact_retrieval_blocked`; this PR does not materialize trace artifacts, resolve W&B artifacts, run training, or promote any model/benchmark/paper claim.

Required validation: focused tests for the trace manifest owner and CLI, Ruff format/check for touched Python, whitespace diff check, and CPU-only validator smoke.

Remaining blocker: #1472/#2441 still need durable trace and baseline artifacts to replace `:pending` aliases, record checksums, set labels present, and set `retrieval_status: available`.

Issue: https://github.com/ll7/robot_sf_ll7/issues/2312

## Contract delta

New schema/output:
- `learned-risk-trace-status.v1` compact status packet, derived from `validate_trace_manifest()` output.
- Fields include `source_issue`, `parent_issue`, `candidate_id`, `manifest_path`, `training_readiness_decision`, `training_ready`, `baseline_artifact_uri`, `split_ids`, `label_availability`, `blockers`, and `next_action`.

New CLI behavior:
- `scripts/validation/validate_learned_risk_trace_manifest.py --status-json` emits the compact status packet.
- Exit-code contract is unchanged: `0` ready, `2` structurally invalid, `3` fail-closed blocked.

Fail-closed blockers:
- No new blockers are invented. The packet carries the existing manifest blockers from `validate_trace_manifest()`.

Compatibility impact:
- Existing `--json` and text output remain available.
- Existing Python validator report shape is preserved.
- New helper is exported from `robot_sf.training.learned_risk_trace_manifest`.

State propagation:
- No issue comment was posted because `comment_issue_or_pr` is false for this run. Durable propagation is via the updated context note plus the new status-packet command; current issue freshness was rechecked immediately before PR creation and no late maintainer guidance was present.

## Validation

- `uv run python -m pytest tests/training/test_learned_risk_trace_manifest.py -q` -> exit 0, `18 passed in 0.10s`
- `uv run ruff format --check robot_sf/training/learned_risk_trace_manifest.py scripts/validation/validate_learned_risk_trace_manifest.py tests/training/test_learned_risk_trace_manifest.py && uv run ruff check robot_sf/training/learned_risk_trace_manifest.py scripts/validation/validate_learned_risk_trace_manifest.py tests/training/test_learned_risk_trace_manifest.py` -> exit 0, `3 files already formatted`, `All checks passed!`
- `uv run python scripts/validation/validate_learned_risk_trace_manifest.py --config configs/training/learned_risk_trace_manifest_issue_2312.yaml --status-json` -> exit 3 as expected, `learned-risk-trace-status.v1 artifact_retrieval_blocked next=materialize_durable_trace_and_baseline_artifacts`
- `git diff --check origin/main...HEAD` -> exit 0

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Process notes</summary>

- Read `AGENTS.md`, `.agents/skills/README.md`, and the requested repo-local skills: `implementation-verification`, `pr-ready-check`, and `gh-pr-opener`.
- Fetched/pruned origin before starting.
- Read live issue #2312 and owner comment; latest issue update remained 2026-06-20, latest owner comment remained 2026-06-16.
- Verified no open PR covers #2312 / learned-risk trace status scope immediately before PR creation.
- Fragmentation guard: no #2312 PRs merged in the last 24h, so no consolidation-only stop triggered.
- Forbidden actions observed: no compute submission, no merge, no release, no delete.

</details>
