### PR TITLE
Issue #4525: honor dependency-gated guarded_ppo campaign skips (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from robot_sf.benchmark.aggregate import read_jsonl
+from robot_sf.benchmark.algorithm_readiness import get_algorithm_readiness
 from robot_sf.benchmark.camera_ready._artifacts import (
     _write_actuation_envelope_artifacts,
     _write_json,
@@ -292,6 +293,7 @@ def _prepare_campaign_planner_variant_run(
     planner: PlannerSpec,
     kinematics: str,
     active_observation_mode: str,
+    log_run: bool = True,
 ) -> _CampaignPlannerVariantRun:
     cfg = context.cfg
     planner_run_key = f"{_sanitize_name(planner.key)}__{_sanitize_name(kinematics)}"
@@ -305,14 +307,15 @@ def _prepare_campaign_planner_variant_run(
         planner.horizon_override if planner.horizon_override is not None else cfg.horizon
     )
     effective_dt = planner.dt_override if planner.dt_override is not None else cfg.dt
-    logger.info(
-        "Running campaign planner key={} algo={} kinematics={} profile={} workers={}",
-        planner.key,
-        planner.algo,
-        kinematics,
-        planner.benchmark_profile,
-        effective_workers,
-    )
+    if log_run:
+        logger.info(
+            "Running campaign planner key={} algo={} kinematics={} profile={} workers={}",
+            planner.key,
+            planner.algo,
+            kinematics,
+            planner.benchmark_profile,
+            effective_workers,
+        )
     scoped_scenarios = [
         _scenario_with_kinematics(
             sc,
@@ -333,6 +336,61 @@ def _prepare_campaign_planner_variant_run(
     )
 
 
+def _dependency_gated_planner_summary(
+    context: _CampaignPlannerMatrixContext,
+    *,
+    planner: PlannerSpec,
+    run: _CampaignPlannerVariantRun,
+) -> dict[str, Any]:
+    readiness = get_algorithm_readiness(planner.algo)
+    reason = str(planner.fail_closed_reason or "").strip() or (
+        f"{planner.key} blocked by availability_gate={planner.availability_gate!r}"
+    )
+    logger.info(
+        "Skipping dependency-gated planner key={} algo={} kinematics={} reason={}",
+        planner.key,
+        planner.algo,
+        run.kinematics,
+        reason,
+    )
+    return {
+        "status": "not_available",
+        "total_jobs": 0,
+        "written": 0,
+        "successful_jobs": 0,
+        "failed_jobs": 0,
+        "skipped_jobs": len(run.scoped_scenarios),
+        "failures": [],
+        "out_path": str(run.episodes_path),
+        "algorithm_readiness": {
+            "name": readiness.canonical_name if readiness is not None else planner.algo,
+            "tier": readiness.tier if readiness is not None else "unknown",
+            "profile": planner.benchmark_profile,
+        },
+        "algorithm_metadata_contract": {"planner_kinematics": {"execution_mode": "unknown"}},
+        "preflight": {
+            "status": "skipped",
+            "compatibility_status": "dependency_gated",
+            "compatibility_reason": reason,
+            "availability_gate": planner.availability_gate,
+            "learned_policy_contract": {"status": "not_applicable"},
+        },
+        "latency_stress_profile": (
+            _latency_stress_metadata(
+                context.cfg.latency_stress_profile,
+                dt=run.effective_dt,
+            )
+            if context.cfg.latency_stress_profile is not None
+            else None
+        ),
+        "latency_stress_metrics": (
+            not_available_latency_metrics()
+            if context.cfg.latency_stress_profile is not None
+            else None
+        ),
+    }
+
+
 def _run_campaign_planner_variant(
     context: _CampaignPlannerMatrixContext,
     *,
@@ -351,14 +409,19 @@ def _run_campaign_planner_variant(
         planner=planner,
         kinematics=kinematics,
         active_observation_mode=active_observation_mode,
+        log_run=planner.availability_gate != "dependency_gated",
     )
 
     planner_started_at_utc = _utc_now()
     planner_start = time.perf_counter()
-    batch_result = _execute_campaign_planner_batch(context, planner, run)
-    status = batch_result.status
-    summary = batch_result.summary
-    warnings.extend(batch_result.warnings)
+    if planner.availability_gate == "dependency_gated":
+        status = "not_available"
+        summary = _dependency_gated_planner_summary(context, planner=planner, run=run)
+    else:
+        batch_result = _execute_campaign_planner_batch(context, planner, run)
+        status = batch_result.status
+        summary = batch_result.summary
+        warnings.extend(batch_result.warnings)
     aggregates: dict[str, Any] | None = None
 
     planner_finished_at_utc = _utc_now()

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -3144,6 +3144,115 @@ def test_run_campaign_continues_after_not_available_when_stop_enabled(
     assert not any("Campaign halted early" in warning for warning in summary_payload["warnings"])
 
 
+def test_run_campaign_skips_dependency_gated_planner_before_execution(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Dependency-gated planners should become accepted-unavailable rows without calling run_batch."""
+    scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")
+    scenario_abs = (tmp_path / scenario_rel).resolve()
+    scenario_abs.parent.mkdir(parents=True, exist_ok=True)
+    scenario_abs.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+
+    guarded_config = get_repository_root() / "configs/algos/orca_prior_guarded_ppo_v1.yaml"
+    config_path = tmp_path / "campaign_dependency_gated.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: dependency_gated_campaign",
+                f"scenario_matrix: {scenario_rel.as_posix()}",
+                "seed_policy:",
+                "  mode: fixed-list",
+                "  seeds: [111]",
+                "stop_on_failure: true",
+                "planners:",
+                "  - key: goal",
+                "    algo: goal",
+                "    planner_group: core",
+                "    benchmark_profile: baseline-safe",
+                "  - key: guarded_ppo",
+                "    algo: guarded_ppo",
+                "    planner_group: experimental",
+                "    benchmark_profile: experimental",
+                f"    algo_config: {guarded_config.as_posix()}",
+                "    availability_gate: dependency_gated",
+                "    fail_closed_reason: guarded_ppo_checkpoint_observation_contract_missing",
+            ],
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    cfg = load_campaign_config(config_path)
+
+    call_order: list[str] = []
+
+    def _fake_run_batch(
+        scenarios_or_path,
+        out_path,
+        schema_path,
+        *,
+        algo,
+        benchmark_profile,
+        **kwargs,
+    ):
+        del scenarios_or_path, schema_path, benchmark_profile, kwargs
+        call_order.append(algo)
+        if algo != "goal":
+            raise AssertionError("run_batch should not be called for dependency-gated guarded_ppo")
+        Path(out_path).write_text(
+            json.dumps(
+                {
+                    "episode_id": "e-goal-0",
+                    "scenario_id": "mock",
+                    "seed": 111,
+                    "scenario_params": {
+                        "algo": "goal",
+                        "metadata": {"archetype": "crossing"},
+                    },
+                    "metrics": {"success": 1.0, "collisions": 0.0, "near_misses": 0.0},
+                    "algorithm_metadata": {"algorithm": "goal", "status": "ok"},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return {
+            "total_jobs": 1,
+            "written": 1,
+            "failed_jobs": 0,
+            "failures": [],
+            "algorithm_readiness": {
+                "name": "goal",
+                "tier": "baseline-ready",
+                "profile": "baseline-safe",
+            },
+        }
+
+    monkeypatch.setattr("robot_sf.benchmark.camera_ready_campaign.run_batch", _fake_run_batch)
+    result = run_campaign(cfg, output_root=tmp_path / "campaign_out", label="dependency_gated")
+    summary_payload = json.loads(Path(result["summary_json"]).read_text(encoding="utf-8"))
+    rows = {row["planner_key"]: row for row in summary_payload["planner_rows"]}
+
+    assert call_order == ["goal"]
+    assert rows["goal"]["status"] == "ok"
+    assert rows["guarded_ppo"]["status"] == "not_available"
+    assert rows["guarded_ppo"]["availability_status"] == "not_available"
+    assert rows["guarded_ppo"]["availability_reason"] == (
+        "guarded_ppo_checkpoint_observation_contract_missing"
+    )
+    assert rows["guarded_ppo"]["preflight_status"] == "skipped"
+    assert summary_payload["campaign"]["status"] == "accepted_unavailable_only"
+    assert summary_payload["campaign"]["unexpected_failed_runs"] == 0
+    assert result["status"] == "accepted_unavailable_only"
+    assert result["exit_code"] == 3
+    assert not any(
+        "Planner 'guarded_ppo' failed" in warning for warning in summary_payload["warnings"]
+    )
+
+
 def test_run_campaign_continues_after_failure_when_stop_disabled(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## What / why

- skip `dependency_gated` planners in `robot_sf/benchmark/camera_ready/campaign.py` before
  `run_batch` executes them
- synthesize a fail-closed `not_available` summary from the planner's configured
  `fail_closed_reason`
- add a campaign-level regression showing `guarded_ppo` becomes an accepted-unavailable row instead
  of an unexpected campaign failure

This fixes the trace-capable campaign path behind issue #4525: when `guarded_ppo` is marked
`availability_gate: dependency_gated` and checkpoint observation metadata is unavailable, the
campaign now records an accepted-unavailable row instead of raising the runtime metadata error that
produced exit 2. This slice preserves the repository's existing `accepted_unavailable_only` exit
semantics (exit 3) while removing the unexpected-failure path.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check --fix robot_sf/benchmark/camera_ready/campaign.py tests/benchmark/test_camera_ready_campaign.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/camera_ready/campaign.py tests/benchmark/test_camera_ready_campaign.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_camera_ready_campaign.py -q`
- CPU smoke: goal + `guarded_ppo` campaign returns `accepted_unavailable_only` / exit `3`, with
  `guarded_ppo` row status `not_available` and reason
  `guarded_ppo_checkpoint_observation_contract_missing`

## Successor statement

Not a successor slice; issue #4525 had no prior merged slice referenced in the issue thread.

This PR was produced by the GitHub-Copilot-CLI/gpt-5.4 cheap implementation lane; the review gate hardens and merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Campaign runs now correctly skip planners blocked by dependency availability, preventing unnecessary execution and logging.
  * Blocked planners are now reported as unavailable with clearer readiness and preflight status details.
  * Overall campaign results now reflect when only unavailable planners were present, with the appropriate exit status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #4525.
