### PR TITLE
Issue #4547: regenerate durable coupling report and Package C readiness rerun (cheap-lane worker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Extended the **Package C readiness helper** so issue #4547 can commit the real rerun artifact from
+  the retained #2916 coupling report. `scripts/tools/prediction_package_c_readiness.py` now accepts
+  `--output-markdown` alongside `--output-json`, which lets the cheap local lane write the durable
+  JSON + Markdown readiness bundle directly under `docs/context/evidence/` instead of relying on
+  shell redirection around stdout. No campaign, Slurm, or paper-facing claim was added; this is
+  coordination-proof only.
 * Added **metadata-only public-source discovery ledger checker** for real micromobility trace
   collection issue #3278. New schema `real_trace_source_discovery.v1`, module
   `robot_sf.analysis_workbench.real_trace_source_discovery`, CLI

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -2940,6 +2940,10 @@ entries:
     freshness: evidence
     area: predictive_planner
     legacy_dirty_evidence: true
+  - path: docs/context/evidence/issue_3080_package_c_readiness_2026-07-05
+    status: evidence
+    freshness: evidence
+    area: predictive_planner
   - path: docs/context/evidence/issue_2921_first_use/report.json
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/README.md
+++ b/docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/README.md
@@ -17,9 +17,9 @@ At least one forecast-risk row reduced safety events vs the control without a fa
 ## Reproducibility
 
 - Issue: #2916
-- Generated (UTC): 2026-06-23T07:34:20.813118+00:00
-- Command: `uv run python scripts/benchmark/run_forecast_risk_coupling_gate.py --config configs/research/forecast_risk_coupling_issue_2916.yaml --output-dir output/issue_2916_coupling_gate`
-- Repo HEAD: `566d820e`
+- Generated (UTC): 2026-07-05T01:04:08.184361+00:00
+- Command: `uv run python scripts/benchmark/run_forecast_risk_coupling_gate.py --config configs/research/forecast_risk_coupling_issue_2916.yaml --output-dir docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23`
+- Repo HEAD: `816976e44`
 - Config: `configs/research/forecast_risk_coupling_issue_2916.yaml`
 - Fixture: `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json`
 - Seed: 111
@@ -28,10 +28,10 @@ At least one forecast-risk row reduced safety events vs the control without a fa
 
 | row | class | collision | near_miss | safety_events | progress_m | stop_step | FP_stops | runtime_s | SNQI |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| no_forecast | ok | False | True | 1 | 0.82 | None | 0 | 0.000115 | 0.273333 |
-| cv_risk | ok | False | False | 0 | 0.45 | 5 | 0 | 0.000756 | 0.65 |
-| semantic_risk | ok | False | False | 0 | 0.45 | 5 | 0 | 0.000602 | 0.65 |
-| interaction_risk | ok | False | False | 0 | 0.45 | 5 | 0 | 0.000603 | 0.65 |
+| no_forecast | ok | False | True | 1 | 0.82 | None | 0 | 0.000303 | 0.273333 |
+| cv_risk | ok | False | False | 0 | 0.45 | 5 | 0 | 0.001496 | 0.65 |
+| semantic_risk | ok | False | False | 0 | 0.45 | 5 | 0 | 0.001337 | 0.65 |
+| interaction_risk | ok | False | False | 0 | 0.45 | 5 | 0 | 0.001342 | 0.65 |
 
 ## Safety-benefit vs false-positive-stopping trade-off
 

--- a/docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/forecast_risk_coupling_gate_report.json
+++ b/docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/forecast_risk_coupling_gate_report.json
@@ -7,9 +7,9 @@
   "claim_boundary_text": "Diagnostic-only forecast-risk closed-loop coupling gate on a single deterministic occluded-emergence fixture. Not paper-facing benchmark evidence. Tests whether forecast-derived risk changes navigation outcomes, not whether any predictor is accurate. No learned predictor is promoted.",
   "reproducibility": {
     "issue": 2916,
-    "generated_at_utc": "2026-06-23T07:34:20.813118+00:00",
-    "command": "uv run python scripts/benchmark/run_forecast_risk_coupling_gate.py --config configs/research/forecast_risk_coupling_issue_2916.yaml --output-dir output/issue_2916_coupling_gate",
-    "repo_head": "566d820e",
+    "generated_at_utc": "2026-07-05T01:04:08.184361+00:00",
+    "command": "uv run python scripts/benchmark/run_forecast_risk_coupling_gate.py --config configs/research/forecast_risk_coupling_issue_2916.yaml --output-dir docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23",
+    "repo_head": "816976e44",
     "config_path": "configs/research/forecast_risk_coupling_issue_2916.yaml"
   },
   "config": {
@@ -50,7 +50,7 @@
         "stop_yield_timing_steps": null,
         "false_positive_stops": 0,
         "true_positive_stops": 0,
-        "runtime_s": 0.000115,
+        "runtime_s": 0.000303,
         "snqi": 0.273333
       },
       "diagnostics": {
@@ -74,7 +74,9 @@
           "go",
           "go"
         ]
-      }
+      },
+      "seed": 111,
+      "scenario_id": "issue_2756_occluded_emergence"
     },
     {
       "row": "cv_risk",
@@ -93,7 +95,7 @@
         "stop_yield_timing_steps": 5,
         "false_positive_stops": 0,
         "true_positive_stops": 9,
-        "runtime_s": 0.000756,
+        "runtime_s": 0.001496,
         "snqi": 0.65
       },
       "diagnostics": {
@@ -117,7 +119,9 @@
           "yield",
           "yield"
         ]
-      }
+      },
+      "seed": 111,
+      "scenario_id": "issue_2756_occluded_emergence"
     },
     {
       "row": "semantic_risk",
@@ -136,7 +140,7 @@
         "stop_yield_timing_steps": 5,
         "false_positive_stops": 0,
         "true_positive_stops": 9,
-        "runtime_s": 0.000602,
+        "runtime_s": 0.001337,
         "snqi": 0.65
       },
       "diagnostics": {
@@ -160,7 +164,9 @@
           "yield",
           "yield"
         ]
-      }
+      },
+      "seed": 111,
+      "scenario_id": "issue_2756_occluded_emergence"
     },
     {
       "row": "interaction_risk",
@@ -179,7 +185,7 @@
         "stop_yield_timing_steps": 5,
         "false_positive_stops": 0,
         "true_positive_stops": 9,
-        "runtime_s": 0.000603,
+        "runtime_s": 0.001342,
         "snqi": 0.65
       },
       "diagnostics": {
@@ -203,7 +209,9 @@
           "yield",
           "yield"
         ]
-      }
+      },
+      "seed": 111,
+      "scenario_id": "issue_2756_occluded_emergence"
     }
   ],
   "verdict": {
@@ -220,7 +228,7 @@
         "safety_event_reduction_vs_control": 1,
         "false_positive_stops": 0,
         "false_positive_stop_ratio_vs_control": 1.0,
-        "runtime_s": 0.000756,
+        "runtime_s": 0.001496,
         "is_safety_benefit": true,
         "fp_regression": false,
         "runtime_regression": false,
@@ -233,7 +241,7 @@
         "safety_event_reduction_vs_control": 1,
         "false_positive_stops": 0,
         "false_positive_stop_ratio_vs_control": 1.0,
-        "runtime_s": 0.000602,
+        "runtime_s": 0.001337,
         "is_safety_benefit": true,
         "fp_regression": false,
         "runtime_regression": false,
@@ -246,7 +254,7 @@
         "safety_event_reduction_vs_control": 1,
         "false_positive_stops": 0,
         "false_positive_stop_ratio_vs_control": 1.0,
-        "runtime_s": 0.000603,
+        "runtime_s": 0.001342,
         "is_safety_benefit": true,
         "fp_regression": false,
         "runtime_regression": false,

--- a/docs/context/evidence/issue_3080_package_c_readiness_2026-07-05/README.md
+++ b/docs/context/evidence/issue_3080_package_c_readiness_2026-07-05/README.md
@@ -1,0 +1,19 @@
+# Issue #3080: Prediction Package C Readiness Preflight
+
+**Claim boundary:** coordination preflight only; no benchmark campaign executed and no forecast or paper-facing performance claim made
+
+- **Overall status:** `ready`
+- **Seed plan (same-seed):** [111, 2868]
+- **Output roots:** ['docs/context/evidence/issue_2915_forecast_baselines_2026-06-20', 'docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13', 'docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23']
+- **Coupling result store available:** False
+- **Coupling report available:** True
+- **Coupling report path:** docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/forecast_risk_coupling_gate_report.json
+
+## Arms
+
+| arm | variant | risk_source | baseline | status |
+| --- | --- | --- | --- | --- |
+| no_forecast | none | none | - | `ready` |
+| cv | cv | constant_velocity | constant_velocity_gaussian_baseline | `ready` |
+| semantic_cv | semantic | semantic_cv | semantic_cv_baseline | `ready` |
+| interaction_aware | interaction_aware | interaction_aware_cv | interaction_aware_cv_baseline | `ready` |

--- a/docs/context/evidence/issue_3080_package_c_readiness_2026-07-05/package_c_readiness_report.json
+++ b/docs/context/evidence/issue_3080_package_c_readiness_2026-07-05/package_c_readiness_report.json
@@ -1,0 +1,113 @@
+{
+  "schema_version": "prediction-package-c-readiness.v1",
+  "issue": 3080,
+  "claim_boundary": "coordination preflight only; no benchmark campaign executed and no forecast or paper-facing performance claim made",
+  "overall_status": "ready",
+  "seed_plan": [
+    111,
+    2868
+  ],
+  "output_roots": [
+    "docs/context/evidence/issue_2915_forecast_baselines_2026-06-20",
+    "docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13",
+    "docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23"
+  ],
+  "coupling_result_store_available": false,
+  "coupling_report_available": true,
+  "coupling_report_path": "docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/forecast_risk_coupling_gate_report.json",
+  "coupling_report_blockers": [],
+  "required_configs": [
+    "configs/research/forecast_baseline_comparison_issue_2915.yaml",
+    "configs/research/forecast_risk_coupling_issue_2916.yaml"
+  ],
+  "required_code": [
+    "robot_sf/benchmark/forecast_metrics.py",
+    "robot_sf/benchmark/forecast_batch.py",
+    "robot_sf/benchmark/pedestrian_forecast.py",
+    "robot_sf/benchmark/runner.py",
+    "scripts/benchmark/run_observation_noise_envelope.py",
+    "scripts/tools/campaign_result_store.py"
+  ],
+  "arms": [
+    {
+      "arm": "no_forecast",
+      "forecast_variant": "none",
+      "risk_source": "none",
+      "baseline_id": null,
+      "status": "ready",
+      "reason": "inputs wired and validated #2916 coupling report present",
+      "present_inputs": [
+        "configs/research/forecast_baseline_comparison_issue_2915.yaml",
+        "configs/research/forecast_risk_coupling_issue_2916.yaml",
+        "robot_sf/benchmark/forecast_batch.py",
+        "robot_sf/benchmark/forecast_metrics.py",
+        "robot_sf/benchmark/pedestrian_forecast.py",
+        "robot_sf/benchmark/runner.py",
+        "scripts/benchmark/run_observation_noise_envelope.py",
+        "scripts/tools/campaign_result_store.py"
+      ],
+      "missing_inputs": [],
+      "blockers": []
+    },
+    {
+      "arm": "cv",
+      "forecast_variant": "cv",
+      "risk_source": "constant_velocity",
+      "baseline_id": "constant_velocity_gaussian_baseline",
+      "status": "ready",
+      "reason": "inputs wired and validated #2916 coupling report present",
+      "present_inputs": [
+        "configs/research/forecast_baseline_comparison_issue_2915.yaml",
+        "configs/research/forecast_risk_coupling_issue_2916.yaml",
+        "robot_sf/benchmark/forecast_batch.py",
+        "robot_sf/benchmark/forecast_metrics.py",
+        "robot_sf/benchmark/pedestrian_forecast.py",
+        "robot_sf/benchmark/runner.py",
+        "scripts/benchmark/run_observation_noise_envelope.py",
+        "scripts/tools/campaign_result_store.py"
+      ],
+      "missing_inputs": [],
+      "blockers": []
+    },
+    {
+      "arm": "semantic_cv",
+      "forecast_variant": "semantic",
+      "risk_source": "semantic_cv",
+      "baseline_id": "semantic_cv_baseline",
+      "status": "ready",
+      "reason": "inputs wired and validated #2916 coupling report present",
+      "present_inputs": [
+        "configs/research/forecast_baseline_comparison_issue_2915.yaml",
+        "configs/research/forecast_risk_coupling_issue_2916.yaml",
+        "robot_sf/benchmark/forecast_batch.py",
+        "robot_sf/benchmark/forecast_metrics.py",
+        "robot_sf/benchmark/pedestrian_forecast.py",
+        "robot_sf/benchmark/runner.py",
+        "scripts/benchmark/run_observation_noise_envelope.py",
+        "scripts/tools/campaign_result_store.py"
+      ],
+      "missing_inputs": [],
+      "blockers": []
+    },
+    {
+      "arm": "interaction_aware",
+      "forecast_variant": "interaction_aware",
+      "risk_source": "interaction_aware_cv",
+      "baseline_id": "interaction_aware_cv_baseline",
+      "status": "ready",
+      "reason": "inputs wired and validated #2916 coupling report present",
+      "present_inputs": [
+        "configs/research/forecast_baseline_comparison_issue_2915.yaml",
+        "configs/research/forecast_risk_coupling_issue_2916.yaml",
+        "robot_sf/benchmark/forecast_batch.py",
+        "robot_sf/benchmark/forecast_metrics.py",
+        "robot_sf/benchmark/pedestrian_forecast.py",
+        "robot_sf/benchmark/runner.py",
+        "scripts/benchmark/run_observation_noise_envelope.py",
+        "scripts/tools/campaign_result_store.py"
+      ],
+      "missing_inputs": [],
+      "blockers": []
+    }
+  ]
+}

--- a/scripts/benchmark/run_forecast_risk_coupling_gate.py
+++ b/scripts/benchmark/run_forecast_risk_coupling_gate.py
@@ -594,6 +594,15 @@ def build_report(
     Returns:
         The complete report mapping.
     """
+    fixture = cfg["fixture"]
+    rows = [
+        {
+            **row,
+            "seed": int(fixture["seed"]),
+            "scenario_id": fixture["scenario_id"],
+        }
+        for row in results
+    ]
     return {
         "schema_version": "forecast_risk_coupling_gate.v1",
         "issue": 2916,
@@ -610,11 +619,11 @@ def build_report(
         "reproducibility": repro,
         "config": {
             "config_path": repro["config_path"],
-            "fixture": cfg["fixture"],
+            "fixture": fixture,
             "risk_gate": cfg["risk_gate"],
             "verdict_thresholds": cfg["verdict"],
         },
-        "rows": results,
+        "rows": rows,
         "verdict": verdict,
         "caveats": [
             "Single deterministic fixture (seed=111), single occluded-emergence scenario.",

--- a/scripts/tools/prediction_package_c_readiness.py
+++ b/scripts/tools/prediction_package_c_readiness.py
@@ -34,7 +34,9 @@ SCRIPT_OBSERVATION_REPLAY = "scripts/benchmark/run_observation_noise_envelope.py
 DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT = (
     "docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13"
 )
-DEFAULT_CLOSED_LOOP_OUTPUT_ROOT = "docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23"
+DEFAULT_CLOSED_LOOP_OUTPUT_ROOT = (
+    "docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23"
+)
 
 REQUIRED_CODE: tuple[str, ...] = (
     "robot_sf/benchmark/forecast_metrics.py",

--- a/scripts/tools/prediction_package_c_readiness.py
+++ b/scripts/tools/prediction_package_c_readiness.py
@@ -34,7 +34,7 @@ SCRIPT_OBSERVATION_REPLAY = "scripts/benchmark/run_observation_noise_envelope.py
 DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT = (
     "docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13"
 )
-DEFAULT_CLOSED_LOOP_OUTPUT_ROOT = "output/issue_2916_coupling_gate"
+DEFAULT_CLOSED_LOOP_OUTPUT_ROOT = "docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23"
 
 REQUIRED_CODE: tuple[str, ...] = (
     "robot_sf/benchmark/forecast_metrics.py",
@@ -544,6 +544,21 @@ def render_markdown(report: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def write_report_outputs(
+    report: dict[str, Any],
+    *,
+    output_json: Path | None = None,
+    output_markdown: Path | None = None,
+) -> None:
+    """Persist the readiness report to the requested durable output paths."""
+    if output_json is not None:
+        output_json.parent.mkdir(parents=True, exist_ok=True)
+        output_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if output_markdown is not None:
+        output_markdown.parent.mkdir(parents=True, exist_ok=True)
+        output_markdown.write_text(render_markdown(report) + "\n", encoding="utf-8")
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -566,6 +581,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Optional path to write readiness report JSON.",
     )
     parser.add_argument(
+        "--output-markdown",
+        type=Path,
+        default=None,
+        help="Optional path to write readiness report Markdown.",
+    )
+    parser.add_argument(
         "--markdown",
         action="store_true",
         help="Print Markdown summary instead of JSON.",
@@ -581,9 +602,11 @@ def main(argv: list[str] | None = None) -> int:
         coupling_report=args.coupling_report,
     )
 
-    if args.output_json is not None:
-        args.output_json.parent.mkdir(parents=True, exist_ok=True)
-        args.output_json.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    write_report_outputs(
+        report,
+        output_json=args.output_json,
+        output_markdown=args.output_markdown,
+    )
 
     if args.markdown:
         print(render_markdown(report))

--- a/tests/benchmark/test_forecast_risk_coupling_gate_issue_2916.py
+++ b/tests/benchmark/test_forecast_risk_coupling_gate_issue_2916.py
@@ -409,5 +409,7 @@ def test_runner_rows_share_seed_and_scenario(tmp_path):
     assert fixture["scenario_id"] == "issue_2756_occluded_emergence"
     row_names = {row["row"] for row in report["rows"]}
     assert row_names == {"no_forecast", "cv_risk", "semantic_risk", "interaction_risk"}
+    assert {row["seed"] for row in report["rows"]} == {fixture["seed"]}
+    assert {row["scenario_id"] for row in report["rows"]} == {fixture["scenario_id"]}
     # The verdict is one of the three allowed branches.
     assert report["verdict"]["decision"] in {"continue", "revise", "stop"}

--- a/tests/tools/test_prediction_package_c_readiness.py
+++ b/tests/tools/test_prediction_package_c_readiness.py
@@ -9,10 +9,12 @@ from scripts.tools.prediction_package_c_readiness import (
     ARMS,
     DEFAULT_CLOSED_LOOP_OUTPUT_ROOT,
     DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT,
+    REPO_ROOT,
     REQUIRED_CODE,
     REQUIRED_CONFIGS,
     assess_package_c_readiness,
     render_markdown,
+    write_report_outputs,
 )
 
 if TYPE_CHECKING:
@@ -250,6 +252,29 @@ def test_markdown_renders_status_report_and_blockers(tmp_path: Path) -> None:
     assert "#2916" in markdown
 
 
+def test_write_report_outputs_persists_json_and_markdown(tmp_path: Path) -> None:
+    """Durable rerun outputs can be written directly from a validated readiness report."""
+    _write_wired_repo(tmp_path)
+    report_path = _write_coupling_report(tmp_path)
+    report = assess_package_c_readiness(tmp_path, coupling_report=report_path)
+    output_dir = tmp_path / "docs/context/evidence/issue_3080_package_c_readiness"
+    output_json = output_dir / "package_c_readiness_report.json"
+    output_markdown = output_dir / "README.md"
+
+    write_report_outputs(
+        report,
+        output_json=output_json,
+        output_markdown=output_markdown,
+    )
+
+    assert json.loads(output_json.read_text(encoding="utf-8")) == report
+    markdown = output_markdown.read_text(encoding="utf-8")
+    assert markdown.endswith("\n")
+    assert "Prediction Package C Readiness Preflight" in markdown
+    assert "`ready`" in markdown
+    assert str(report_path) in markdown
+
+
 def test_real_repo_preflight_is_wired_and_fails_closed() -> None:
     """Real repo inputs resolve; default remains blocked without supplied artifact."""
     report = assess_package_c_readiness()
@@ -263,3 +288,18 @@ def test_real_repo_preflight_is_wired_and_fails_closed() -> None:
         DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT,
         DEFAULT_CLOSED_LOOP_OUTPUT_ROOT,
     ]
+
+
+def test_real_repo_coupling_report_clears_package_c_blocker() -> None:
+    """The committed #2916 report should satisfy the current Package C contract."""
+    report = assess_package_c_readiness(
+        coupling_report=(
+            REPO_ROOT
+            / "docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23"
+            / "forecast_risk_coupling_gate_report.json"
+        )
+    )
+
+    assert report["overall_status"] == "ready"
+    assert report["coupling_report_available"] is True
+    assert all(arm["status"] == "ready" for arm in report["arms"])


### PR DESCRIPTION
## Summary

This PR turns issue #4547 into the real artifact-producing follow-up to PR #4542.

- `scripts/benchmark/run_forecast_risk_coupling_gate.py` now stamps every #2916 row with the shared fixture `seed` and `scenario_id`, so the durable coupling report satisfies the fail-closed Package C admission contract added in PR #4542.
- `scripts/tools/prediction_package_c_readiness.py` now writes a durable Markdown summary via `--output-markdown` and reports the durable #2916 evidence root instead of the old worktree-local output path.
- Regenerated `docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/{forecast_risk_coupling_gate_report.json,README.md}` and committed `docs/context/evidence/issue_3080_package_c_readiness_2026-07-05/{package_c_readiness_report.json,README.md}` from the retained local fixture artifacts. The rerun now reports `overall_status: ready`.

## Why

PR #4542 intentionally stopped at validation. The retained #2916 report still missed the per-row denominator fields that the new validator requires, so Package C stayed blocked even though the underlying local inputs already existed. This slice fixes the report contract at the producer, regenerates the durable report, and checks in the actual Package C rerun bundle.

## Successor slice

successor slice: regenerate the durable #2916 coupling report so it passes the #4542 contract and commit the Package C readiness rerun bundle; does not duplicate PR #4542.

## Validation output

- `source .venv/bin/activate && uv run pytest tests/benchmark/test_forecast_risk_coupling_gate_issue_2916.py tests/tools/test_prediction_package_c_readiness.py -q` -> `34 passed in 2.83s`
- `source .venv/bin/activate && uv run ruff check scripts/benchmark/run_forecast_risk_coupling_gate.py scripts/tools/prediction_package_c_readiness.py tests/benchmark/test_forecast_risk_coupling_gate_issue_2916.py tests/tools/test_prediction_package_c_readiness.py` -> `All checks passed!`
- `source .venv/bin/activate && uv run python scripts/benchmark/run_forecast_risk_coupling_gate.py --config configs/research/forecast_risk_coupling_issue_2916.yaml --output-dir docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23` -> rewrote the durable report and emitted `Verdict: continue`
- `source .venv/bin/activate && uv run python scripts/tools/prediction_package_c_readiness.py --coupling-report docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/forecast_risk_coupling_gate_report.json --output-json docs/context/evidence/issue_3080_package_c_readiness_2026-07-05/package_c_readiness_report.json --output-markdown docs/context/evidence/issue_3080_package_c_readiness_2026-07-05/README.md` -> `overall_status: ready`, `coupling_report_available: true`, `coupling_report_blockers: []`

## Claim boundary

- `docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/` remains diagnostic-only #2916 evidence over the retained deterministic fixture.
- `docs/context/evidence/issue_3080_package_c_readiness_2026-07-05/` is Package C coordination proof only; it is not a benchmark, training, or paper-facing claim.

This PR was produced by the GitHub-Copilot-CLI/gpt-5.4 cheap implementation lane; the review gate hardens and merges.

Closes #4547.
