### PR TITLE
Issue #1472: add learned-risk Slurm execution contract

### DIFF
--- a/configs/training/learned_risk_model_issue_1395_launch_packet.yaml
+++ b/configs/training/learned_risk_model_issue_1395_launch_packet.yaml
@@ -10,8 +10,7 @@ slurm_execution:
     - run
     - python
     - scripts/training/train_learned_risk_model.py
-    - --config
-    - configs/training/learned_risk_model_v1.yaml
+    - --config=configs/training/learned_risk_model_v1.yaml
   expected_output_root: wandb-artifact://robot-sf/learned-risk/learned_risk_model_v1:pending
   expected_log_path: slurm://learned-risk-model-v1/logs/%j.out
   status_artifact_path: wandb-artifact://robot-sf/learned-risk/learned_risk_model_v1_status:pending

--- a/configs/training/learned_risk_model_issue_1395_launch_packet.yaml
+++ b/configs/training/learned_risk_model_issue_1395_launch_packet.yaml
@@ -2,6 +2,19 @@ schema_version: learned-risk-launch-packet.v1
 candidate_id: learned_risk_model_v1
 generating_commit: e14e2f8bc2058d9f0e071219629915dd5b5dd5a8
 slurm_handoff: docs/context/policy_search/SLURM/001_learned_risk_model_v1.md
+slurm_execution:
+  entrypoint: scripts/training/train_learned_risk_model.py
+  config: configs/training/learned_risk_model_v1.yaml
+  command:
+    - uv
+    - run
+    - python
+    - scripts/training/train_learned_risk_model.py
+    - --config
+    - configs/training/learned_risk_model_v1.yaml
+  expected_output_root: wandb-artifact://robot-sf/learned-risk/learned_risk_model_v1:pending
+  expected_log_path: slurm://learned-risk-model-v1/logs/%j.out
+  status_artifact_path: wandb-artifact://robot-sf/learned-risk/learned_risk_model_v1_status:pending
 trace_input_contract:
   required_episode_fields:
     - scenario_id

--- a/docs/context/issue_1395_learned_risk_launch_packet.md
+++ b/docs/context/issue_1395_learned_risk_launch_packet.md
@@ -16,6 +16,17 @@ model, run stress/full-matrix evaluation, submit SLURM jobs, or promote a learne
 - Evidence fixture:
   `docs/context/evidence/issue_1395_learned_risk_launch_packet_2026-05-24/`
 
+## Slurm Execution Contract
+
+The launch packet records the planned Slurm execution surface for issue #1472:
+`slurm_execution.entrypoint`, `slurm_execution.config`, `slurm_execution.command`,
+`slurm_execution.expected_output_root`, `slurm_execution.expected_log_path`, and
+`slurm_execution.status_artifact_path`.
+
+The validator requires those fields and rejects worktree-local `output/` paths for execution
+artifacts. These fields are pre-submit contract metadata only; they do not launch training,
+resolve private trace assets, or turn pending artifact aliases into evidence.
+
 ## Frozen Baseline
 
 The launch packet freezes `hybrid_rule_v3_static_margin0_waypoint2` as the non-learning baseline

--- a/robot_sf/training/learned_risk_launch_packet.py
+++ b/robot_sf/training/learned_risk_launch_packet.py
@@ -96,6 +96,7 @@ def validate_launch_packet(
     trace_report = _validate_trace_contract(packet, root, errors)
     baseline_report = _validate_baseline_packet(packet, root, errors)
     safety_report = _validate_safety_policy(packet, errors)
+    slurm_execution_report = _validate_slurm_execution(packet, errors)
     _validate_execution_boundary(packet, errors)
 
     if errors:
@@ -111,6 +112,7 @@ def validate_launch_packet(
         "trace_contract": trace_report,
         "baseline_comparison": baseline_report,
         "safety_policy": safety_report,
+        "slurm_execution": slurm_execution_report,
     }
 
 
@@ -224,6 +226,43 @@ def _validate_execution_boundary(packet: dict[str, Any], errors: list[str]) -> N
         errors.append("execution_boundary.full_training_in_this_issue must be false")
     _require_non_empty_string(execution, "slurm_command_shape", errors)
     _require_non_empty_string(execution, "local_preflight_command", errors)
+
+
+def _validate_slurm_execution(packet: dict[str, Any], errors: list[str]) -> dict[str, Any]:
+    slurm_execution = packet.get("slurm_execution")
+    if not isinstance(slurm_execution, dict):
+        errors.append("slurm_execution must be mapping")
+        return {}
+
+    required_keys = (
+        "entrypoint",
+        "config",
+        "expected_output_root",
+        "expected_log_path",
+        "status_artifact_path",
+    )
+    for key in required_keys:
+        _require_non_empty_string(slurm_execution, key, errors)
+
+    command = slurm_execution.get("command")
+    if not isinstance(command, list) or not command:
+        errors.append("slurm_execution.command must be non-empty list")
+    elif not all(isinstance(part, str) and part.strip() for part in command):
+        errors.append("slurm_execution.command entries must be non-empty strings")
+
+    for key in ("expected_output_root", "expected_log_path", "status_artifact_path"):
+        value = slurm_execution.get(key)
+        if isinstance(value, str) and "output" in Path(value).parts:
+            errors.append(f"slurm_execution.{key} must not depend on worktree-local output")
+
+    return {
+        "entrypoint": slurm_execution.get("entrypoint"),
+        "config": slurm_execution.get("config"),
+        "expected_output_root": slurm_execution.get("expected_output_root"),
+        "expected_log_path": slurm_execution.get("expected_log_path"),
+        "status_artifact_path": slurm_execution.get("status_artifact_path"),
+        "command": list(command) if isinstance(command, list) else [],
+    }
 
 
 def _validate_required_list(

--- a/tests/training/test_learned_risk_campaign_readiness.py
+++ b/tests/training/test_learned_risk_campaign_readiness.py
@@ -57,6 +57,25 @@ def _valid_launch_packet(tmp_path: Path) -> Path:
         "candidate_id": "learned_risk_model_v1",
         "generating_commit": "e14e2f8bc2058d9f0e071219629915dd5b5dd5a8",
         "slurm_handoff": "docs/context/policy_search/SLURM/001_learned_risk_model_v1.md",
+        "slurm_execution": {
+            "entrypoint": "scripts/training/train_learned_risk_model.py",
+            "config": "configs/training/learned_risk_model_v1.yaml",
+            "command": [
+                "uv",
+                "run",
+                "python",
+                "scripts/training/train_learned_risk_model.py",
+                "--config",
+                "configs/training/learned_risk_model_v1.yaml",
+            ],
+            "expected_output_root": (
+                "wandb-artifact://robot-sf/learned-risk/learned_risk_model_v1:pending"
+            ),
+            "expected_log_path": "slurm://learned-risk-model-v1/logs/%j.out",
+            "status_artifact_path": (
+                "wandb-artifact://robot-sf/learned-risk/learned_risk_model_v1_status:pending"
+            ),
+        },
         "trace_input_contract": {
             "required_episode_fields": [
                 "scenario_id",

--- a/tests/training/test_learned_risk_launch_packet.py
+++ b/tests/training/test_learned_risk_launch_packet.py
@@ -40,6 +40,25 @@ def _valid_packet(tmp_path: Path) -> dict[str, object]:
         "candidate_id": "learned_risk_model_v1",
         "generating_commit": "e14e2f8bc2058d9f0e071219629915dd5b5dd5a8",
         "slurm_handoff": "docs/context/policy_search/SLURM/001_learned_risk_model_v1.md",
+        "slurm_execution": {
+            "entrypoint": "scripts/training/train_learned_risk_model.py",
+            "config": "configs/training/learned_risk_model_v1.yaml",
+            "command": [
+                "uv",
+                "run",
+                "python",
+                "scripts/training/train_learned_risk_model.py",
+                "--config",
+                "configs/training/learned_risk_model_v1.yaml",
+            ],
+            "expected_output_root": (
+                "wandb-artifact://robot-sf/learned-risk/learned_risk_model_v1:pending"
+            ),
+            "expected_log_path": "slurm://learned-risk-model-v1/logs/%j.out",
+            "status_artifact_path": (
+                "wandb-artifact://robot-sf/learned-risk/learned_risk_model_v1_status:pending"
+            ),
+        },
         "trace_input_contract": {
             "required_episode_fields": [
                 "scenario_id",
@@ -99,6 +118,30 @@ def test_issue_1395_launch_packet_validates() -> None:
     assert report["baseline_comparison"]["candidate_id"] == (
         "hybrid_rule_v3_static_margin0_waypoint2"
     )
+    assert report["slurm_execution"]["entrypoint"] == (
+        "scripts/training/train_learned_risk_model.py"
+    )
+    assert report["slurm_execution"]["expected_log_path"].startswith("slurm://")
+
+
+def test_validate_launch_packet_rejects_missing_slurm_execution(tmp_path: Path) -> None:
+    """Launch packets must name the Slurm execution/log artifact contract."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken.pop("slurm_execution")
+
+    with pytest.raises(LearnedRiskLaunchPacketError, match="slurm_execution"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
+
+
+def test_validate_launch_packet_rejects_local_slurm_execution_output(tmp_path: Path) -> None:
+    """Slurm execution outputs must point to durable or scheduler-managed locations."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    broken["slurm_execution"]["expected_output_root"] = "output/learned-risk/local"
+
+    with pytest.raises(LearnedRiskLaunchPacketError, match="worktree-local output"):
+        validate_launch_packet(_write_packet(tmp_path, broken))
 
 
 def test_validate_launch_packet_rejects_missing_trace_fields(tmp_path: Path) -> None:

--- a/tests/training/test_learned_risk_launch_packet.py
+++ b/tests/training/test_learned_risk_launch_packet.py
@@ -48,8 +48,7 @@ def _valid_packet(tmp_path: Path) -> dict[str, object]:
                 "run",
                 "python",
                 "scripts/training/train_learned_risk_model.py",
-                "--config",
-                "configs/training/learned_risk_model_v1.yaml",
+                "--config=configs/training/learned_risk_model_v1.yaml",
             ],
             "expected_output_root": (
                 "wandb-artifact://robot-sf/learned-risk/learned_risk_model_v1:pending"


### PR DESCRIPTION
## Reviewer-critical summary

Issue link: https://github.com/ll7/robot_sf_ll7/issues/1472

What changed: adds a machine-checked `slurm_execution` block to the learned-risk launch packet and exposes it in `validate_launch_packet()` JSON reports. The validator now requires the planned entrypoint, config, command, expected output root, expected Slurm log path, and status artifact path, and rejects worktree-local `output/` execution artifact paths.

Why now: issue #1472 had prior merged packet, trace-manifest, and campaign-readiness gates, but the issue checklist still named "Slurm command/wrapper expected output/log paths recorded" as an unmechanized pre-submit contract.

Claim boundary: this is a local pre-submit contract slice only. It does not submit Slurm, train a model, resolve private/licensed trace data, publish artifacts, or promote benchmark/paper claims. The current campaign gate remains fail-closed on the trace manifest.

Required validation: focused launch-packet/campaign tests, Ruff on touched Python, docs proof consistency, and launch-packet/campaign readiness CLI smoke.

Remaining blocker: `check_learned_risk_campaign_readiness.py --json` still exits `3` with `trace_manifest` blockers for pending baseline/trace artifact aliases, pending labels, and `retrieval_status` not `available`.

## Contract delta

New schema fields in `configs/training/learned_risk_model_issue_1395_launch_packet.yaml`:

- `slurm_execution.entrypoint`
- `slurm_execution.config`
- `slurm_execution.command`
- `slurm_execution.expected_output_root`
- `slurm_execution.expected_log_path`
- `slurm_execution.status_artifact_path`

New fail-closed blockers:

- Missing or non-mapping `slurm_execution`.
- Empty required `slurm_execution` strings.
- Empty or non-string command entries.
- Worktree-local `output/` paths for execution output/log/status artifacts.

Compatibility impact: additive launch-packet validation/report field. Existing packets that omit `slurm_execution` now fail validation intentionally for issue #1472 readiness; campaign readiness remains blocked until trace-manifest data is available.

New capability: learned-risk Slurm execution path contract validation.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/learned_risk_launch_packet.py tests/training/test_learned_risk_launch_packet.py tests/training/test_learned_risk_campaign_readiness.py scripts/validation/validate_learned_risk_launch_packet.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/training/test_learned_risk_launch_packet.py tests/training/test_learned_risk_campaign_readiness.py -q` - passed, 17 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/validate_learned_risk_launch_packet.py --config configs/training/learned_risk_model_issue_1395_launch_packet.yaml --json` - passed, reports `status: valid` and includes `slurm_execution`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_learned_risk_campaign_readiness.py --json` - expected exit `3`; launch-packet gate passed, campaign remains blocked on trace-manifest artifact retrieval.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` - passed.
- `git diff --check origin/main...HEAD` - passed.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No training run.
- No paper/dissertation claim edits.
- No issue comment/state mutation: task authorization had `comment_issue_or_pr: false`; this PR body is the durable propagation surface for this slice.

<details>
<summary>Governance notes</summary>

Late-guidance check: rechecked issue #1472 via REST issue/comments endpoint before PR open. No comments newer than this run start were present; latest issue update remained 2026-06-29.

Fragmentation guard: prior #1472 PRs covering launch packet, trace manifest, and campaign readiness were older than 24h. This is a progression slice with the nameable new capability above, not another micro-guard.

Artifact policy: no generated output, checkpoint, Slurm log, raw trace data, or private/licensed asset is committed.

</details>
