### PR TITLE
Issue #4546: add SocNavBench ETH stage SVG smoke wrapper

### DIFF
--- a/docs/socnav_assets_setup.md
+++ b/docs/socnav_assets_setup.md
@@ -197,6 +197,19 @@ official `traversibles/ETH/data.pkl` is absent or malformed, the converter exits
 placeholder map. This is conversion tooling only; it is not benchmark evidence until the generated
 SVG passes parser and smoke validation on staged source assets.
 
+For the full local issue #4546 stage/generate/convert/smoke path:
+
+```bash
+uv run python scripts/tools/stage_socnavbench_eth_traversible_svg.py \
+  --socnav-root /path/to/socnavbench \
+  --output-svg maps/svg_maps/socnavbench/socnavbench_eth.svg \
+  --report-json output/maps/issue_4546_socnavbench_eth_stage_svg_smoke.json
+```
+
+The wrapper composes the same license-safe asset registry, ETH traversible generator, SVG converter,
+and Robot SF SVG parser smoke check. Missing licensed source assets fail closed with exit `2` and a
+JSON report; the command never downloads data or writes placeholder maps.
+
 ## Licensing and Repository Hygiene
 
 - Do not commit downloaded dataset assets.

--- a/scripts/tools/stage_socnavbench_eth_traversible_svg.py
+++ b/scripts/tools/stage_socnavbench_eth_traversible_svg.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Stage SocNavBench ETH traversible data through SVG generation and smoke validation.
+
+This command is a thin issue #4546 orchestration layer around the canonical
+SocNavBench ETH owners:
+
+* ``manage_external_data.py`` for license-safe local asset layout checks.
+* ``generate_socnavbench_traversible.py`` for mesh-derived ``data.pkl`` creation.
+* ``convert_socnavbench_traversible_to_svg.py`` for Robot SF SVG conversion.
+
+It never downloads or commits SocNavBench/S3DIS bytes. Missing local assets fail closed with exit
+code 2 and a machine-readable report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from robot_sf.maps.verification.svg_inspection import inspect_svg
+from robot_sf.nav.svg_map_parser import convert_map
+from scripts.tools import convert_socnavbench_traversible_to_svg as converter
+from scripts.tools import generate_socnavbench_traversible as generator
+from scripts.tools.manage_external_data import EXTERNAL_DATA_ROOT_ENV, check_asset
+
+EXIT_BLOCKED = 2
+ASSET_ID = "socnavbench-s3dis-eth"
+DEFAULT_REPORT = Path("output/maps/issue_4546_socnavbench_eth_stage_svg_smoke.json")
+
+
+def _write_report(path: Path | None, report: dict[str, Any]) -> None:
+    """Write optional JSON report with stable formatting."""
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _smoke_svg(path: Path) -> dict[str, Any]:
+    """Run parser and capability smoke checks for the generated SVG."""
+    map_def = convert_map(str(path))
+    inspection = inspect_svg(path)
+    capability = inspection.capability_metadata
+    return {
+        "parser_obstacle_count": len(map_def.obstacles),
+        "parser_robot_spawn_zone_count": len(map_def.robot_spawn_zones),
+        "parser_robot_goal_zone_count": len(map_def.robot_goal_zones),
+        "parser_robot_route_count": len(map_def.robot_routes),
+        "parser_ped_spawn_zone_count": len(map_def.ped_spawn_zones),
+        "parser_ped_goal_zone_count": len(map_def.ped_goal_zones),
+        "parser_ped_route_count": len(map_def.ped_routes),
+        "has_robot_runtime_routes": capability.has_robot_runtime_routes,
+        "has_pedestrian_runtime_routes": capability.has_pedestrian_runtime_routes,
+        "has_explicit_robot_runtime_zones": capability.has_explicit_robot_runtime_zones,
+        "has_explicit_pedestrian_runtime_zones": capability.has_explicit_pedestrian_runtime_zones,
+    }
+
+
+def _smoke_ok(smoke: dict[str, Any]) -> bool:
+    """Return whether parser and capability metadata prove minimal runtime map wiring."""
+    count_keys = (
+        "parser_obstacle_count",
+        "parser_robot_spawn_zone_count",
+        "parser_robot_goal_zone_count",
+        "parser_robot_route_count",
+        "parser_ped_spawn_zone_count",
+        "parser_ped_goal_zone_count",
+        "parser_ped_route_count",
+    )
+    flag_keys = (
+        "has_robot_runtime_routes",
+        "has_pedestrian_runtime_routes",
+        "has_explicit_robot_runtime_zones",
+        "has_explicit_pedestrian_runtime_zones",
+    )
+    return all(smoke[key] > 0 for key in count_keys) and all(bool(smoke[key]) for key in flag_keys)
+
+
+def _generator_root_from_socnav_root(socnav_root: Path | None) -> Path | None:
+    """Adapt direct SocNavBench root input to the generator's external-data-root convention."""
+    if socnav_root is None:
+        return None
+    resolved = socnav_root.expanduser().resolve()
+    if resolved.name == "socnavbench":
+        return resolved.parent
+    return resolved
+
+
+def stage_generate_convert_smoke(
+    *,
+    socnav_root: Path | None,
+    output_svg: Path,
+    report_json: Path | None,
+    dry_run: bool,
+    force_generate: bool,
+) -> tuple[int, dict[str, Any]]:
+    """Run the SocNavBench ETH staging pipeline and return ``(exit_code, report)``."""
+    generator_root = _generator_root_from_socnav_root(socnav_root)
+    asset_report = check_asset(ASSET_ID, source_path=socnav_root)
+    preflight = generator.preflight("ETH", root=generator_root)
+    report: dict[str, Any] = {
+        "asset_id": ASSET_ID,
+        "status": "started",
+        "socnav_root": asset_report["source_path"],
+        "external_data_root_env": EXTERNAL_DATA_ROOT_ENV,
+        "asset_check": asset_report,
+        "generation_preflight": preflight,
+        "output_svg": str(output_svg),
+        "dry_run": dry_run,
+        "conversion_ready": False,
+        "smoke_ready": False,
+        "claim_boundary": (
+            "Smoke evidence only: validates local staged SocNavBench ETH traversible conversion "
+            "and SVG parser wiring. It is not benchmark evidence."
+        ),
+    }
+
+    if preflight["status"] == generator.STATUS_BLOCKED_MISSING_MESH:
+        report.update(
+            {
+                "status": "blocked_missing_mesh",
+                "next_action": preflight["next_action"],
+            }
+        )
+        _write_report(report_json, report)
+        return EXIT_BLOCKED, report
+
+    if preflight["status"] == generator.STATUS_READY:
+        if dry_run:
+            report.update(
+                {
+                    "status": "dry_run_generation_ready",
+                    "next_action": "Run without --dry-run to generate traversibles/ETH/data.pkl.",
+                }
+            )
+            _write_report(report_json, report)
+            return 0, report
+        try:
+            report["generation"] = generator.build_traversible(
+                "ETH",
+                root=generator_root,
+                force=force_generate,
+            )
+        except generator.TraversibleGenerationError as exc:
+            report.update({"status": "blocked_generation_failed", "next_action": str(exc)})
+            _write_report(report_json, report)
+            return EXIT_BLOCKED, report
+    else:
+        report["generation"] = {
+            "status": preflight["status"],
+            "output_pkl": preflight["output_pkl"],
+            "built": False,
+        }
+
+    converter_report = output_svg.with_suffix(output_svg.suffix + ".conversion.json")
+    converter_args = [
+        "--socnav-root",
+        str(Path(report["socnav_root"])),
+        "--output-svg",
+        str(output_svg),
+        "--report-json",
+        str(converter_report),
+    ]
+    if dry_run:
+        converter_args.append("--dry-run")
+    conversion_exit = converter.main(converter_args)
+    report["conversion_exit_code"] = conversion_exit
+    report["conversion_report_json"] = str(converter_report)
+    report["conversion_ready"] = conversion_exit == 0
+
+    if conversion_exit != 0:
+        report.update(
+            {
+                "status": "blocked_conversion_failed",
+                "next_action": "Inspect conversion report and re-stage official ETH traversible data.",
+            }
+        )
+        _write_report(report_json, report)
+        return conversion_exit, report
+
+    if dry_run:
+        report.update(
+            {
+                "status": "dry_run_conversion_ready",
+                "next_action": "Run without --dry-run to write SVG and execute parser smoke.",
+            }
+        )
+        _write_report(report_json, report)
+        return 0, report
+
+    smoke = _smoke_svg(output_svg)
+    report["smoke"] = smoke
+    report["smoke_ready"] = _smoke_ok(smoke)
+    report["status"] = "ready" if report["smoke_ready"] else "blocked_smoke_failed"
+    report["next_action"] = (
+        "Generated SVG passed parser smoke."
+        if report["smoke_ready"]
+        else "Generated SVG did not expose all required Robot SF runtime map primitives."
+    )
+    _write_report(report_json, report)
+    return 0 if report["smoke_ready"] else EXIT_BLOCKED, report
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--socnav-root", type=Path, default=None)
+    parser.add_argument("--output-svg", type=Path, default=converter.DEFAULT_OUTPUT)
+    parser.add_argument("--report-json", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--force-generate", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the CLI."""
+    args = build_arg_parser().parse_args(argv)
+    exit_code, report = stage_generate_convert_smoke(
+        socnav_root=args.socnav_root,
+        output_svg=args.output_svg,
+        report_json=args.report_json,
+        dry_run=args.dry_run,
+        force_generate=args.force_generate,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_stage_socnavbench_eth_traversible_svg.py
+++ b/tests/tools/test_stage_socnavbench_eth_traversible_svg.py
@@ -1,0 +1,82 @@
+"""Tests for the SocNavBench ETH stage/generate/convert/smoke wrapper."""
+
+from __future__ import annotations
+
+import pickle
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from scripts.tools import stage_socnavbench_eth_traversible_svg as stage_svg
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_socnav_eth_fixture(root: Path, traversible: np.ndarray) -> None:
+    """Write the minimal staged SocNavBench ETH layout used by the smoke wrapper."""
+    mesh_dir = root / "sd3dis" / "stanford_building_parser_dataset" / "mesh" / "ETH"
+    mesh_dir.mkdir(parents=True)
+    (mesh_dir / "mesh.obj").write_text("# fixture mesh marker\n", encoding="utf-8")
+    pkl_path = (
+        root / "sd3dis" / "stanford_building_parser_dataset" / "traversibles" / "ETH" / "data.pkl"
+    )
+    pkl_path.parent.mkdir(parents=True)
+    with pkl_path.open("wb") as handle:
+        pickle.dump({"resolution": 2.0, "traversible": traversible}, handle, protocol=2)
+
+
+def test_staged_eth_traversible_generates_parser_smoke_svg(tmp_path: Path) -> None:
+    """A locally staged ETH traversible is converted and smoke-validated."""
+    root = tmp_path / "socnavbench"
+    _write_socnav_eth_fixture(
+        root,
+        np.array(
+            [
+                [False, False, False, False, False, False],
+                [True, True, True, False, True, True],
+                [False, False, True, True, True, False],
+                [False, False, False, False, False, False],
+            ],
+            dtype=bool,
+        ),
+    )
+    output_svg = tmp_path / "socnavbench_eth.svg"
+    report_json = tmp_path / "report.json"
+
+    exit_code, report = stage_svg.stage_generate_convert_smoke(
+        socnav_root=root,
+        output_svg=output_svg,
+        report_json=report_json,
+        dry_run=False,
+        force_generate=False,
+    )
+
+    assert exit_code == 0
+    assert report["status"] == "ready"
+    assert report["generation"]["status"] == "already_present"
+    assert report["conversion_ready"] is True
+    assert report["smoke_ready"] is True
+    assert output_svg.is_file()
+    assert report_json.is_file()
+
+
+def test_missing_eth_mesh_fails_closed_without_svg(tmp_path: Path) -> None:
+    """Missing licensed SocNavBench inputs report a blocked state instead of a placeholder SVG."""
+    output_svg = tmp_path / "socnavbench_eth.svg"
+    report_json = tmp_path / "blocked.json"
+
+    exit_code, report = stage_svg.stage_generate_convert_smoke(
+        socnav_root=tmp_path / "missing_socnavbench",
+        output_svg=output_svg,
+        report_json=report_json,
+        dry_run=False,
+        force_generate=False,
+    )
+
+    assert exit_code == stage_svg.EXIT_BLOCKED
+    assert report["status"] == "blocked_missing_mesh"
+    assert report["conversion_ready"] is False
+    assert report["smoke_ready"] is False
+    assert not output_svg.exists()
+    assert report["generation_preflight"]["status"] == "blocked_missing_mesh"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Adds `scripts/tools/stage_socnavbench_eth_traversible_svg.py`, a thin issue #4546 orchestration wrapper that checks local SocNavBench ETH staging, generates `traversibles/ETH/data.pkl` when the curated mesh is staged, converts it to the planned Robot SF SVG, and runs SVG parser/capability smoke checks. The PR also adds focused tests for the staged-success and missing-asset fail-closed paths, plus the runbook command in `docs/socnav_assets_setup.md`.

Why now: Follow-up to #4535, which added the traversible-to-SVG converter. This slice adds the nameable progression capability around that converter: local stage/generate/convert/smoke orchestration.

Claim boundary: Smoke evidence only. This validates local staged SocNavBench ETH traversible conversion and SVG parser wiring on fixture data plus fail-closed behavior when licensed assets are missing. It is not benchmark evidence and does not claim official ETH asset checksums are available in this checkout.

Required validation: focused pytest for the new wrapper and converter, Ruff check/format, missing-asset CLI fail-closed check, and final `pr_ready_check.sh` freshness before handoff.

Remaining blocker: Real SocNavBench/S3DIS ETH mesh and generated traversible bytes remain external, license-gated local inputs. They are not downloaded, committed, or promoted by this PR.

## Contract delta

New schema fields: None.

New fail-closed blockers: The wrapper exits `2` with `status=blocked_missing_mesh`, `blocked_generation_failed`, `blocked_conversion_failed`, or `blocked_smoke_failed` instead of writing placeholder maps when required local inputs or smoke checks fail.

Compatibility impact: Existing generator/converter CLIs remain unchanged. The new wrapper composes existing owners and writes only requested output/report paths.

Issue: Refs #4546

## Scope summary

- Added a license-safe stage/generate/convert/smoke wrapper for SocNavBench ETH traversible SVG generation.
- Added fixture-backed smoke tests for successful local staging and missing-asset fail-closed behavior.
- Documented the wrapper command in the SocNavBench asset setup runbook.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_stage_socnavbench_eth_traversible_svg.py tests/tools/test_convert_socnavbench_traversible_to_svg.py` - passed, 6 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/stage_socnavbench_eth_traversible_svg.py tests/tools/test_stage_socnavbench_eth_traversible_svg.py && scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/tools/stage_socnavbench_eth_traversible_svg.py tests/tools/test_stage_socnavbench_eth_traversible_svg.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/stage_socnavbench_eth_traversible_svg.py --socnav-root /tmp/robot_sf_missing_socnavbench_4546 --output-svg output/tmp/issue4546_missing.svg --report-json output/tmp/issue4546_missing.json` - exited 2 as expected with `status=blocked_missing_mesh` and no SVG output.
- `PR_READY_PR_BODY_FILE=$(git rev-parse --git-common-dir)/codex-agent-runs/active/issue-4546/PR_BODY.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed at committed head `29b40f718133223b9953c46b564b6f464d8fe885`, 1891 passed / 2 skipped plus readiness checks.

## Follow-Up Issues

- #1498 tracks the license-gated SocNavBench/S3DIS external asset staging blocker.
- #334 tracks the SocNavBench ETH import batch that consumes the staged source assets once available.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no raw SocNavBench/S3DIS data download, no committed generated traversible pickle, and no committed generated SVG from absent licensed source data.

## State propagation

No separate issue comment was added because the task authorization sets `comment_issue_or_pr: false`. This PR body is the durable handoff surface for the delivered slice and remaining blocker.

<details>
<summary>Governance appendix</summary>

- Fragmentation guard: This is a progression slice, not another guardrail-only PR. The new capability is the `stage_socnavbench_eth_traversible_svg.py` orchestration command.
- Artifact policy: Raw external assets and generated traversibles stay local and ignored. The missing-asset smoke report under `output/tmp/` is validation scratch only, not committed evidence.
- Late issue guidance: Initial issue check before implementation had no comments. Final live issue check before PR open found maintainer comment https://github.com/ll7/robot_sf_ll7/issues/4546#issuecomment-4884344702 created 2026-07-05T01:01:42Z, after start; both `gh issue view` and REST returned only `<<ccr:d669e8fb733a,string,4.9KB>>`, so no additional actionable text was available to incorporate in this environment.

</details>