### PR TITLE
Issue #4522: make activation diagnostics measured-only (cheap-lane worker)

### DIFF
--- a/scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py
+++ b/scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py
@@ -214,28 +214,24 @@ def _activation_diagnostics(
     alpha = float(arm["pedestrian_uncertainty_alpha_mps"])
     if alpha == 0.0:
         return {}
+    diagnostics = {
+        "envelope_activation_count": None,
+        "effective_radius_used_by_planner": None,
+    }
     planner_runtime = record.get("planner_runtime")
-    envelope = {}
-    if isinstance(planner_runtime, Mapping):
-        raw_envelope = planner_runtime.get("pedestrian_uncertainty_envelope")
-        if isinstance(raw_envelope, Mapping):
-            envelope = dict(raw_envelope)
+    if not isinstance(planner_runtime, Mapping):
+        return diagnostics
+    raw_envelope = planner_runtime.get("pedestrian_uncertainty_envelope")
+    if not isinstance(raw_envelope, Mapping):
+        return diagnostics
+    envelope = dict(raw_envelope)
     used = envelope.get("effective_radius_used_by_planner")
     if isinstance(used, bool):
-        effective_used = used
-    else:
-        effective_used = bool(
-            envelope.get("enabled", arm["pedestrian_uncertainty_envelope_enabled"])
-        )
+        diagnostics["effective_radius_used_by_planner"] = used
     count = envelope.get("envelope_activation_count")
-    if isinstance(count, bool) or not isinstance(count, int) or count < 0:
-        count = (
-            1 if effective_used and row_status not in {"failed", "blocked", "not_available"} else 0
-        )
-    return {
-        "envelope_activation_count": count,
-        "effective_radius_used_by_planner": effective_used,
-    }
+    if isinstance(count, int) and not isinstance(count, bool) and count >= 0:
+        diagnostics["envelope_activation_count"] = count
+    return diagnostics
 
 
 def _record_identity(

--- a/scripts/validation/build_issue_4232_uncertainty_envelope_evidence.py
+++ b/scripts/validation/build_issue_4232_uncertainty_envelope_evidence.py
@@ -257,9 +257,11 @@ def _activation_status(row: Mapping[str, Any]) -> tuple[str, int | None, bool | 
         raise EvidenceBuildError(f"{_row_id(row)}: diagnostics must be a mapping")
     if float(row["alpha_mps"]) == 0.0:
         return "not_applicable_alpha_zero", None, None
+    count_present = "envelope_activation_count" in diagnostics
+    used_present = "effective_radius_used_by_planner" in diagnostics
     count = diagnostics.get("envelope_activation_count")
     used = diagnostics.get("effective_radius_used_by_planner")
-    if count is None and used is None:
+    if not count_present and not used_present:
         raise EvidenceBuildError(f"{_row_id(row)}: missing envelope activation diagnostics")
     if count is not None:
         if isinstance(count, bool) or not isinstance(count, int) or count < 0:
@@ -268,6 +270,8 @@ def _activation_status(row: Mapping[str, Any]) -> tuple[str, int | None, bool | 
         raise EvidenceBuildError(
             f"{_row_id(row)}: effective_radius_used_by_planner must be boolean"
         )
+    if count is None and used is None:
+        return "unknown_mechanism_activation", None, None
     activated = (count or 0) > 0 or bool(used)
     return ("activated" if activated else "no_mechanism_activation", count, used)
 

--- a/tests/benchmark/test_run_issue_4232_uncertainty_envelope_alpha_sweep.py
+++ b/tests/benchmark/test_run_issue_4232_uncertainty_envelope_alpha_sweep.py
@@ -297,7 +297,9 @@ def test_issue_4232_diagnostic_runner_keeps_missing_activation_telemetry_unknown
         ).read_text(encoding="utf-8")
     )
     assert activation["status_counts"]["unknown_mechanism_activation"] == 1
-    activation_by_arm = {row["alpha_arm_key"]: row["activation_status"] for row in activation["rows"]}
+    activation_by_arm = {
+        row["alpha_arm_key"]: row["activation_status"] for row in activation["rows"]
+    }
     assert activation_by_arm["envelope_on_alpha_0p10"] == "unknown_mechanism_activation"
 
 

--- a/tests/benchmark/test_run_issue_4232_uncertainty_envelope_alpha_sweep.py
+++ b/tests/benchmark/test_run_issue_4232_uncertainty_envelope_alpha_sweep.py
@@ -122,6 +122,185 @@ def test_issue_4232_diagnostic_runner_writes_compact_diagnostic_evidence(
     assert "not ready for benchmark-strength" in claim_readiness
 
 
+@pytest.mark.parametrize("row_status", ["diagnostic_only", "failed", "blocked", "not_available"])
+def test_activation_diagnostics_keep_missing_telemetry_unknown(row_status: str) -> None:
+    """Nonzero-alpha rows without telemetry stay unknown instead of synthesizing activation."""
+    diagnostics = _MODULE._activation_diagnostics(
+        {},
+        arm={
+            "pedestrian_uncertainty_alpha_mps": 0.1,
+            "pedestrian_uncertainty_envelope_enabled": True,
+        },
+        row_status=row_status,
+    )
+
+    assert diagnostics == {
+        "envelope_activation_count": None,
+        "effective_radius_used_by_planner": None,
+    }
+
+
+def test_activation_diagnostics_keep_empty_envelope_mapping_unknown() -> None:
+    """An empty envelope telemetry mapping must not synthesize activation from arm intent."""
+    diagnostics = _MODULE._activation_diagnostics(
+        {"planner_runtime": {"pedestrian_uncertainty_envelope": {}}},
+        arm={
+            "pedestrian_uncertainty_alpha_mps": 0.1,
+            "pedestrian_uncertainty_envelope_enabled": True,
+        },
+        row_status="diagnostic_only",
+    )
+
+    assert diagnostics == {
+        "envelope_activation_count": None,
+        "effective_radius_used_by_planner": None,
+    }
+
+
+def test_activation_diagnostics_preserve_valid_runtime_telemetry() -> None:
+    """Well-formed runtime telemetry is preserved without coercion."""
+    diagnostics = _MODULE._activation_diagnostics(
+        {
+            "planner_runtime": {
+                "pedestrian_uncertainty_envelope": {
+                    "effective_radius_used_by_planner": True,
+                    "envelope_activation_count": 3,
+                }
+            }
+        },
+        arm={
+            "pedestrian_uncertainty_alpha_mps": 0.1,
+            "pedestrian_uncertainty_envelope_enabled": True,
+        },
+        row_status="successful_evidence",
+    )
+
+    assert diagnostics == {
+        "envelope_activation_count": 3,
+        "effective_radius_used_by_planner": True,
+    }
+
+
+def test_activation_diagnostics_keep_malformed_fields_unknown() -> None:
+    """Malformed telemetry fields remain unknown while valid telemetry stays preserved."""
+    diagnostics = _MODULE._activation_diagnostics(
+        {
+            "planner_runtime": {
+                "pedestrian_uncertainty_envelope": {
+                    "effective_radius_used_by_planner": "yes",
+                    "envelope_activation_count": 3,
+                }
+            }
+        },
+        arm={
+            "pedestrian_uncertainty_alpha_mps": 0.1,
+            "pedestrian_uncertainty_envelope_enabled": True,
+        },
+        row_status="successful_evidence",
+    )
+
+    assert diagnostics == {
+        "envelope_activation_count": 3,
+        "effective_radius_used_by_planner": None,
+    }
+
+
+def test_activation_diagnostics_keep_alpha_zero_behavior_stable() -> None:
+    """Alpha-zero arms still omit activation diagnostics entirely."""
+    diagnostics = _MODULE._activation_diagnostics(
+        {},
+        arm={
+            "pedestrian_uncertainty_alpha_mps": 0.0,
+            "pedestrian_uncertainty_envelope_enabled": True,
+        },
+        row_status="diagnostic_only",
+    )
+
+    assert diagnostics == {}
+
+
+def test_issue_4232_diagnostic_runner_keeps_missing_activation_telemetry_unknown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing runtime telemetry for enabled nonzero alpha stays unknown end-to-end."""
+
+    def _missing_nonzero_telemetry_run_map_batch(
+        scenarios: list[dict[str, object]],
+        out_path: str | Path,
+        *_args: object,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        scenario = scenarios[0]
+        alpha = float(scenario["simulation_config"]["pedestrian_uncertainty_alpha_mps"])  # type: ignore[index]
+        enabled = bool(scenario["simulation_config"]["pedestrian_uncertainty_envelope_enabled"])  # type: ignore[index]
+        record = {
+            "scenario_id": scenario["id"],
+            "seed": 111,
+            "success": True,
+            "collision": False,
+            "metrics": {
+                "near_misses": 0,
+                "mean_clearance": 0.8 + alpha,
+                "path_efficiency": 0.7,
+                "runtime_seconds": 0.05 + alpha,
+            },
+        }
+        if not (enabled and alpha > 0.0):
+            record["planner_runtime"] = {
+                "pedestrian_uncertainty_envelope": {
+                    "enabled": enabled,
+                    "alpha_mps": alpha,
+                    "effective_radius_used_by_planner": enabled and alpha > 0.0,
+                    "envelope_activation_count": 2 if enabled and alpha > 0.0 else 0,
+                }
+            }
+        path = Path(out_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+        return {"written": 1}
+
+    monkeypatch.setattr(_MODULE, "load_scenario_matrix", _fake_scenarios)
+    monkeypatch.setattr(
+        _MODULE.map_runner,
+        "run_map_batch",
+        _missing_nonzero_telemetry_run_map_batch,
+    )
+
+    report = _MODULE.run_diagnostic(
+        _MODULE.parse_args(
+            [
+                "--packet",
+                str(PACKET),
+                "--output-dir",
+                str(tmp_path / "issue_4232"),
+                "--max-scenarios",
+                "1",
+                "--max-seeds",
+                "1",
+            ]
+        )
+    )
+
+    assert report["ok"] is True
+
+    rows_path = tmp_path / "issue_4232" / "compact_alpha_sweep_rows.json"
+    rows = json.loads(rows_path.read_text(encoding="utf-8"))["rows"]
+    nonzero = next(row for row in rows if row["alpha_arm_key"] == "envelope_on_alpha_0p10")
+    assert nonzero["diagnostics"] == {
+        "envelope_activation_count": None,
+        "effective_radius_used_by_planner": None,
+    }
+
+    activation = json.loads(
+        (
+            tmp_path / "issue_4232" / "compact_evidence" / "envelope_activation_diagnostics.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert activation["status_counts"]["unknown_mechanism_activation"] == 1
+    activation_by_arm = {row["alpha_arm_key"]: row["activation_status"] for row in activation["rows"]}
+    assert activation_by_arm["envelope_on_alpha_0p10"] == "unknown_mechanism_activation"
+
+
 def test_issue_4232_diagnostic_runner_fails_unknown_alpha_arm(tmp_path: Path) -> None:
     """Runner rejects alpha arms not pre-registered in the packet."""
     args = _MODULE.parse_args(


### PR DESCRIPTION
## Summary
- make the issue #4232 alpha-sweep runner keep envelope activation diagnostics measured-only instead of synthesizing activation from arm intent
- preserve valid runtime telemetry, keep absent or malformed telemetry unknown, and allow the compact evidence builder to summarize explicit unknown activation safely
- add focused regression coverage for missing telemetry, empty envelope telemetry, valid telemetry preservation, malformed telemetry, failed/blocked/not_available rows, and alpha-zero stability

## Why
PR #4521 added the diagnostic alpha-sweep runner. This successor slice hardens the activation-diagnostics contract so `compact_alpha_sweep_rows.json` does not imply measured activation when the planner never reported envelope telemetry.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_run_issue_4232_uncertainty_envelope_alpha_sweep.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/run_issue_4232_uncertainty_envelope_alpha_sweep.py scripts/validation/build_issue_4232_uncertainty_envelope_evidence.py tests/benchmark/test_run_issue_4232_uncertainty_envelope_alpha_sweep.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_build_issue_4232_uncertainty_envelope_evidence.py -q`

## Successor slice
successor slice: measured-only envelope activation diagnostics; does not duplicate PR #4521.

## Notes
- Domain-Aware Approval: not applicable; this is diagnostic-only tooling hardening and does not change benchmark or paper-facing claims.
- Artifact handling: NA; no durable output artifacts were produced for this cheap-lane implementation slice.

Closes #4522.

This PR was produced by the GitHub-Copilot-CLI/gpt-5.4 cheap implementation lane; the review gate hardens and merges.
