### PR TITLE
Issue #1358: summarize ORCA-residual parent lane status

### DIFF
--- a/robot_sf/benchmark/orca_residual_lane_readiness.py
+++ b/robot_sf/benchmark/orca_residual_lane_readiness.py
@@ -382,6 +382,57 @@ def _build_issue_1475_decision_packet(
     }
 
 
+def _build_integration_report(
+    *,
+    overall_status: str,
+    prerequisites: list[PrerequisiteResult],
+    errors: list[str],
+) -> dict[str, Any]:
+    """Build a compact parent-level integration report for issue #1358.
+
+    The report is intentionally derived from the same readiness primitives as the
+    preflight checker. It gives reviewers and routing agents one coherent status
+    surface without turning this parent issue into a local training or benchmark
+    execution path.
+
+    Returns:
+        JSON-serializable parent integration status.
+    """
+    missing_or_invalid = [p.key for p in prerequisites if p.messages]
+    local_handoff_ready = overall_status == "blocked_on_followup"
+    return {
+        "issue": 1358,
+        "integration_status": (
+            "local_handoff_ready_parent_blocked"
+            if local_handoff_ready
+            else "local_contract_incomplete"
+        ),
+        "new_capability": "parent_integration_status_report",
+        "local_contract": {
+            "prerequisites_total": len(prerequisites),
+            "prerequisites_ready": sum(1 for p in prerequisites if p.present and not p.messages),
+            "missing_or_invalid_prerequisites": missing_or_invalid,
+        },
+        "remaining_blocker_keys": [b.key for b in LANE_BLOCKERS],
+        "next_empirical_action": (
+            "Use child #1475 to collect one bounded smoke training/evaluation artifact "
+            "set on an approved SLURM worker, then classify continue/revise/stop before "
+            "any nominal escalation."
+        ),
+        "non_claims": [
+            "no local training was run",
+            "no SLURM job was submitted",
+            "no benchmark campaign was run",
+            "no paper or dissertation claim is promoted",
+        ],
+        "claim_boundary": (
+            "Integration report only. A handoff-ready local contract is not learned-residual "
+            "evidence and does not unblock parent #1358 without child smoke/nominal artifacts."
+        ),
+        "errors": errors,
+    }
+
+
 def assess_lane_readiness(
     repo_root: Path,
     *,
@@ -465,6 +516,11 @@ def assess_lane_readiness(
         ],
         "issue_1475_decision_packet": _build_issue_1475_decision_packet(
             overall_status=overall_status,
+            errors=errors,
+        ),
+        "integration_report": _build_integration_report(
+            overall_status=overall_status,
+            prerequisites=prerequisites,
             errors=errors,
         ),
         "errors": errors,

--- a/tests/benchmark/test_orca_residual_lane_readiness.py
+++ b/tests/benchmark/test_orca_residual_lane_readiness.py
@@ -212,6 +212,36 @@ def test_real_repo_lane_is_blocked_on_followup() -> None:
     assert report["errors"] == []
 
 
+def test_integration_report_summarizes_parent_blocked_handoff() -> None:
+    """Real repo report gives one coherent parent status without claiming evidence."""
+    report = assess_lane_readiness(REPO_ROOT, validate_packet=True)
+
+    integration = report["integration_report"]
+    assert integration["issue"] == 1358
+    assert integration["new_capability"] == "parent_integration_status_report"
+    assert integration["integration_status"] == "local_handoff_ready_parent_blocked"
+    assert integration["local_contract"]["prerequisites_total"] == len(REQUIRED_PREREQUISITES)
+    assert integration["local_contract"]["missing_or_invalid_prerequisites"] == []
+    assert integration["remaining_blocker_keys"] == [b.key for b in LANE_BLOCKERS]
+    assert "child #1475" in integration["next_empirical_action"]
+    assert "no SLURM job was submitted" in integration["non_claims"]
+    assert "not learned-residual evidence" in integration["claim_boundary"]
+
+
+def test_integration_report_reflects_incomplete_local_contract(tmp_path: pathlib.Path) -> None:
+    """Incomplete local scaffolding is visible in parent integration status."""
+    _write_synthetic_lane(tmp_path)
+    (tmp_path / "configs/policy_search/candidates/orca_residual_guarded_ppo_v0.yaml").unlink()
+
+    report = assess_lane_readiness(tmp_path, validate_packet=False)
+
+    integration = report["integration_report"]
+    assert integration["integration_status"] == "local_contract_incomplete"
+    assert integration["local_contract"]["missing_or_invalid_prerequisites"] == ["candidate_v0"]
+    assert integration["errors"] == report["errors"]
+    assert integration["remaining_blocker_keys"] == [b.key for b in LANE_BLOCKERS]
+
+
 def test_cli_exit_codes(tmp_path: pathlib.Path) -> None:
     """CLI returns 0 when handoff-complete and 2 when a prerequisite is missing."""
     from scripts.tools.orca_residual_lane_readiness import main as cli_main


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds `integration_report` to the existing ORCA-residual lane readiness report, derived from the current prerequisite/blocker contract instead of adding a parallel checker.

Why now: issue #1358 is a blocked parent with prior local readiness slices already merged; this slice adds the nameable new capability `parent_integration_status_report` so reviewers and routing agents can see the parent status, remaining blockers, and next empirical action in one stable JSON surface.

Claim boundary: read-only status/reporting only. This does not run training, submit SLURM, run a benchmark campaign, alter planner behavior, or promote learned-residual evidence.

Required validation: focused CPU tests for the readiness contract, targeted Ruff, CLI JSON smoke, and final PR readiness wrapper.

Remaining blocker: parent #1358 remains gated on child #1475/#2445 durable smoke/nominal training evidence and continue/revise/stop classification.

## Contract delta

- New report field: `integration_report` from `assess_lane_readiness(...)`.
- New capability: `parent_integration_status_report`.
- New status values under `integration_report.integration_status`:
  - `local_handoff_ready_parent_blocked`
  - `local_contract_incomplete`
- New compatibility impact: additive JSON field only; existing readiness keys, CLI exit codes, and fail-closed behavior remain unchanged.
- New fail-closed behavior: none; the integration report reflects existing prerequisite errors and blocker keys without changing the top-level `overall_status` decision.

## Issue

Closes no parent issue. Supports https://github.com/ll7/robot_sf_ll7/issues/1358 while keeping it open/blocked for the required empirical child evidence.

## Scope summary

- Added parent-level integration/status summary to `robot_sf/benchmark/orca_residual_lane_readiness.py`.
- Added focused tests for the handoff-ready parent-blocked case and incomplete-local-contract case.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/benchmark/test_orca_residual_lane_readiness.py -q` -> pass, 14 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/orca_residual_lane_readiness.py --json` -> pass, reports `blocked_on_followup`, `local_handoff_ready_parent_blocked`, `parent_integration_status_report`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/orca_residual_lane_readiness.py tests/benchmark/test_orca_residual_lane_readiness.py` -> pass.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=... scripts/dev/pr_ready_check.sh` -> pass; final stamp `output/validation/pr_ready/issue-1358-backfill-admitted-research-coordinate-bounded-orca-residual-learned-loca.json`, full suite 1893 passed and optional-extra lane completed.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Governance appendix</summary>

- Freshness: re-read issue #1358 via REST immediately before commit/PR; latest issue update remains `2026-06-21T05:25:31Z`, latest comment update remains `2026-06-21T05:25:30Z`, so no late maintainer guidance was missed.
- Dedupe: no open PR matched issue #1358 or the new `parent_integration_status_report` capability before PR open.
- Fragmentation guard: prior #1358 slices were not two or more guard/checker packet-refresh PRs in the last 24h; this slice is also an integration/report capability rather than another micro-guard.
- State propagation: no issue comment is added because `comment_issue_or_pr=false`; the PR body is the durable state surface for this authorized run.

</details>
