### PR TITLE
Issue #1470: require oracle trace source manifests

### DIFF
--- a/configs/training/ppo_imitation/oracle_trace_uri_registry_issue_1470.yaml
+++ b/configs/training/ppo_imitation/oracle_trace_uri_registry_issue_1470.yaml
@@ -1,14 +1,14 @@
-# Oracle-imitation trace artifact-promotion readiness packet for issue #1470.
+# Oracle-imitation trace artifact-promotion readiness packet issue #1470.
 #
-# This packet records the merged, small tracked trace evidence from Slurm job 12911 while keeping
-# the downstream imitation-training gate fail-closed. Only the train split has a repository-tracked
-# local mirror; validation/evaluation still need durable raw-trace artifact URIs before training can
-# consume the dataset line.
+# This packet records merged, small tracked trace evidence from Slurm job 12911 while
+# keeping the downstream imitation-training gate fail-closed. Only the train split has
+# a repository-tracked local mirror; validation/evaluation still need durable raw-trace
+# artifact URIs before training can consume this dataset line.
 #
 # Validate base packet:
 #   uv run python scripts/validation/validate_oracle_trace_uri_registry.py \
 #     --config configs/training/ppo_imitation/oracle_trace_uri_registry_issue_1470.yaml --json
-# Validate strict downstream gate (expected to fail until all splits are resolvable):
+# Validate strict downstream gate (expected fail until all splits are resolvable):
 #   uv run python scripts/validation/validate_oracle_trace_uri_registry.py \
 #     --config configs/training/ppo_imitation/oracle_trace_uri_registry_issue_1470.yaml \
 #     --json --require-training-ready
@@ -17,9 +17,9 @@ dataset_id: issue_1397_oracle_imitation_v1
 source_issue: 1470
 related_issues: [2441, 2655]
 claim_boundary: >
-  Artifact-promotion readiness packet only. The train trace mirror is compact tracked evidence from
-  job 12911; this is not final NPZ dataset evidence, not imitation-training evidence, and not
-  benchmark or paper-facing planner evidence.
+  Artifact-promotion readiness packet only. The train trace mirror is compact tracked
+  evidence from job 12911; not final NPZ dataset evidence, not imitation-training
+  evidence, not benchmark or paper-facing planner evidence.
 traces:
   - split: train
     trace_id: train__issue1470_job12911_tracked_mirror
@@ -27,7 +27,9 @@ traces:
     sha256: 7a5246f69b2b939e72beb07d63102592ca3f8400f1ad4c7c2c1fac63c3a80270
     retrieval_status: resolvable
     local_mirror: docs/context/evidence/issue_1470_oracle_imitation_traces_12911_2026-06-17/oracle_imitation/issue1470_train_candidate_traces/train__hybrid_rule_v3_static_margin0_waypoint2__combined.jsonl
-    source_manifest: docs/context/evidence/issue_1470_oracle_imitation_traces_12911_2026-06-17/oracle_imitation/issue1470_train_candidate_traces/oracle_candidate_trace_manifest.json
+    source_manifest_uri: artifact://robot_sf_ll7/docs/context/evidence/issue_1470_oracle_imitation_traces_12911_2026-06-17/source_manifest:v1
+    source_manifest_sha256: b758394107ed72d2bcc24d52da016f00865291b7a1700bbd110c67b0f797e962
+    source_manifest_local_mirror: docs/context/evidence/issue_1470_oracle_imitation_traces_12911_2026-06-17/oracle_imitation/issue1470_train_candidate_traces/oracle_candidate_trace_manifest.json
   - split: validation
     trace_id: validation__issue1470_missing_durable_trace_uri
     uri: wandb-artifact://robot-sf/oracle-imitation/issue1470-validation:pending

--- a/robot_sf/training/oracle_trace_uri_registry.py
+++ b/robot_sf/training/oracle_trace_uri_registry.py
@@ -95,7 +95,9 @@ def validate_trace_uri_registry(
     _require_non_empty_string(registry, "dataset_id", errors)
 
     traces = _validate_traces(registry, root, errors)
-    splits_to_trace_ids, retrieval_status, resolvable_required = _summarize_traces(traces)
+    splits_to_trace_ids, retrieval_status, resolvable_required, source_manifests = (
+        _summarize_traces(traces)
+    )
     training_ready = _validate_training_ready_gate(
         splits_to_trace_ids,
         resolvable_required,
@@ -116,6 +118,7 @@ def validate_trace_uri_registry(
         "trace_count": len(traces),
         "splits": {split: splits_to_trace_ids.get(split, []) for split in _REQUIRED_SPLITS},
         "retrieval_status": retrieval_status,
+        "source_manifests": source_manifests,
         "training_ready": training_ready,
     }
 
@@ -175,6 +178,7 @@ def _validate_single_trace(
     uri = _validate_trace_uri(label, trace.get("uri"), errors)
     _validate_trace_checksum(label, trace.get("sha256"), status, errors)
     _validate_local_mirror(label, trace.get("local_mirror"), trace.get("sha256"), repo_root, errors)
+    _validate_source_manifest_metadata(label, trace, status, repo_root, errors)
     # Mark the concrete-durable check result so the gate logic can reuse it.
     trace["_uri_is_concrete_durable"] = uri is not None and _is_concrete_durable_uri(uri)
 
@@ -271,9 +275,43 @@ def _validate_local_mirror(
         )
 
 
+def _validate_source_manifest_metadata(
+    label: str,
+    trace: dict[str, Any],
+    status: Any,
+    repo_root: Path,
+    errors: list[str],
+) -> None:
+    """Validate provenance metadata for the source manifest behind a trace JSONL."""
+    raw_uri = trace.get("source_manifest_uri")
+    raw_sha = trace.get("source_manifest_sha256")
+    raw_mirror = trace.get("source_manifest_local_mirror")
+
+    if status == "resolvable":
+        if raw_uri is None:
+            errors.append(f"{label}.source_manifest_uri required retrieval_status 'resolvable'")
+        if raw_sha is None:
+            errors.append(f"{label}.source_manifest_sha256 required retrieval_status 'resolvable'")
+
+    uri = None
+    if raw_uri is not None:
+        uri = _validate_trace_uri(f"{label}.source_manifest", raw_uri, errors)
+    _validate_trace_checksum(f"{label}.source_manifest", raw_sha, status, errors)
+    _validate_local_mirror(
+        f"{label}.source_manifest",
+        raw_mirror,
+        raw_sha,
+        repo_root,
+        errors,
+    )
+    trace["_source_manifest_is_concrete_durable"] = uri is not None and _is_concrete_durable_uri(
+        uri
+    )
+
+
 def _summarize_traces(
     traces: list[dict[str, Any]],
-) -> tuple[dict[str, list[str]], dict[str, str], dict[str, bool]]:
+) -> tuple[dict[str, list[str]], dict[str, str], dict[str, bool], dict[str, str]]:
     """Build per-split trace-id lists, a trace-id->status map, and resolvable-required flags.
 
     Returns:
@@ -283,6 +321,7 @@ def _summarize_traces(
     splits_to_trace_ids: dict[str, list[str]] = {}
     retrieval_status: dict[str, str] = {}
     resolvable_required: dict[str, bool] = dict.fromkeys(_REQUIRED_SPLITS, False)
+    source_manifests: dict[str, str] = {}
     for trace in traces:
         split = trace.get("split")
         trace_id = trace.get("trace_id")
@@ -294,13 +333,17 @@ def _summarize_traces(
             splits_to_trace_ids.setdefault(split, []).append(trace_id)
         if isinstance(status, str):
             retrieval_status[trace_id] = status
+        source_manifest_uri = trace.get("source_manifest_uri")
+        if isinstance(source_manifest_uri, str) and source_manifest_uri.strip():
+            source_manifests[trace_id] = source_manifest_uri.strip()
         if (
             split in _REQUIRED_SPLITS
             and status == "resolvable"
             and trace.get("_uri_is_concrete_durable", False)
+            and trace.get("_source_manifest_is_concrete_durable", False)
         ):
             resolvable_required[split] = True
-    return splits_to_trace_ids, retrieval_status, resolvable_required
+    return splits_to_trace_ids, retrieval_status, resolvable_required, source_manifests
 
 
 def _validate_training_ready_gate(

--- a/tests/training/test_oracle_imitation_trace_uri_registry.py
+++ b/tests/training/test_oracle_imitation_trace_uri_registry.py
@@ -40,6 +40,8 @@ def _training_ready_registry() -> dict[str, object]:
                 "uri": "wandb-artifact://robot-sf/oracle-imitation/train:v1",
                 "sha256": "a" * 64,
                 "retrieval_status": "resolvable",
+                "source_manifest_uri": "wandb-artifact://robot-sf/oracle-imitation/train_manifest:v1",
+                "source_manifest_sha256": "1" * 64,
             },
             {
                 "split": "validation",
@@ -47,6 +49,8 @@ def _training_ready_registry() -> dict[str, object]:
                 "uri": "wandb-artifact://robot-sf/oracle-imitation/val:v1",
                 "sha256": "b" * 64,
                 "retrieval_status": "resolvable",
+                "source_manifest_uri": "wandb-artifact://robot-sf/oracle-imitation/val_manifest:v1",
+                "source_manifest_sha256": "2" * 64,
             },
             {
                 "split": "evaluation",
@@ -54,6 +58,8 @@ def _training_ready_registry() -> dict[str, object]:
                 "uri": "wandb-artifact://robot-sf/oracle-imitation/eval:v1",
                 "sha256": "c" * 64,
                 "retrieval_status": "resolvable",
+                "source_manifest_uri": "wandb-artifact://robot-sf/oracle-imitation/eval_manifest:v1",
+                "source_manifest_sha256": "3" * 64,
             },
         ],
     }
@@ -71,6 +77,7 @@ def test_complete_registry_is_training_ready(tmp_path: Path) -> None:
     assert report["training_ready"] is True
     assert report["trace_count"] == 3
     assert report["retrieval_status"]["train__demo_v1"] == "resolvable"
+    assert report["source_manifests"]["train__demo_v1"].endswith("/train_manifest:v1")
 
 
 def test_missing_uri_fails_closed(tmp_path: Path) -> None:
@@ -90,6 +97,18 @@ def test_missing_checksum_for_resolvable_fails_closed(tmp_path: Path) -> None:
     with pytest.raises(
         OracleTraceUriRegistryError,
         match="sha256 is required when retrieval_status is 'resolvable'",
+    ):
+        validate_trace_uri_registry(_write_registry(tmp_path, registry))
+
+
+def test_missing_source_manifest_for_resolvable_fails_closed(tmp_path: Path) -> None:
+    """A resolvable trace must bind JSONL bytes to source manifest provenance."""
+    registry = _training_ready_registry()
+    del registry["traces"][0]["source_manifest_uri"]
+
+    with pytest.raises(
+        OracleTraceUriRegistryError,
+        match="source_manifest_uri required retrieval_status 'resolvable'",
     ):
         validate_trace_uri_registry(_write_registry(tmp_path, registry))
 

--- a/tests/training/test_oracle_imitation_warm_start_readiness.py
+++ b/tests/training/test_oracle_imitation_warm_start_readiness.py
@@ -117,6 +117,8 @@ def _write_training_ready_trace_registry(tmp_path: Path) -> Path:
                 "uri": "wandb-artifact://robot-sf/oracle-imitation/train:v1",
                 "sha256": "a" * 64,
                 "retrieval_status": "resolvable",
+                "source_manifest_uri": "wandb-artifact://robot-sf/oracle-imitation/train_manifest:v1",
+                "source_manifest_sha256": "1" * 64,
             },
             {
                 "split": "validation",
@@ -124,6 +126,8 @@ def _write_training_ready_trace_registry(tmp_path: Path) -> Path:
                 "uri": "wandb-artifact://robot-sf/oracle-imitation/validation:v1",
                 "sha256": "b" * 64,
                 "retrieval_status": "resolvable",
+                "source_manifest_uri": "wandb-artifact://robot-sf/oracle-imitation/validation_manifest:v1",
+                "source_manifest_sha256": "2" * 64,
             },
             {
                 "split": "evaluation",
@@ -131,6 +135,8 @@ def _write_training_ready_trace_registry(tmp_path: Path) -> Path:
                 "uri": "wandb-artifact://robot-sf/oracle-imitation/evaluation:v1",
                 "sha256": "c" * 64,
                 "retrieval_status": "resolvable",
+                "source_manifest_uri": "wandb-artifact://robot-sf/oracle-imitation/evaluation_manifest:v1",
+                "source_manifest_sha256": "3" * 64,
             },
         ],
     }


### PR DESCRIPTION
## Reviewer-critical summary

What changed: #1470 oracle trace URI registry validation now requires resolvable trace entries to include source-manifest provenance metadata: durable source manifest URI, SHA-256 checksum, and optional local mirror checksum verification. The checked-in #1470 train trace entry now binds the tracked JSONL trace mirror to its tracked source manifest, and the validator report exposes `source_manifests` for downstream readiness automation.

Why now: the live issue thread says Slurm trace collection evidence is on `main`, but the lane remains blocked on durable raw-trace URI registry plus validator metadata before downstream imitation training. This slice adds that metadata contract without submitting compute or claiming training readiness.

Claim boundary: this is a schema/validator progression slice for trace provenance only. It does not make #1470 `dataset_ready`; validation and evaluation trace URIs remain blocked, and the registry still reports `training_ready=false`.

Required validation: focused registry/readiness tests, Ruff checks, base registry CLI smoke, strict fail-closed registry CLI smoke.

Remaining blocker: concrete durable validation/evaluation raw-trace artifact URIs are still missing; downstream #1496 warm-start training remains `artifact_retrieval_blocked`.

## Contract delta

- New per-resolvable-trace fields: `source_manifest_uri`, `source_manifest_sha256`, and optional `source_manifest_local_mirror`.
- New report field: `source_manifests`, mapping trace id to durable source manifest URI.
- New fail-closed blocker: a `retrieval_status: resolvable` trace without source manifest URI/checksum is invalid.
- Compatibility impact: pending/blocked trace entries may omit source-manifest metadata and remain valid but not training-ready. Existing training-ready registry fixtures must provide source-manifest metadata.

## Issue

Fixes part of #1470: https://github.com/ll7/robot_sf_ll7/issues/1470

## Scope summary

- Extended `robot_sf.training.oracle_trace_uri_registry` so a split only contributes to `training_ready` when both trace bytes and source manifest metadata are concrete durable references.
- Updated `configs/training/ppo_imitation/oracle_trace_uri_registry_issue_1470.yaml` with source-manifest metadata for the tracked train trace evidence from job 12911.
- Added regression tests for missing source manifest provenance and updated training-ready fixtures.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_oracle_imitation_trace_uri_registry.py tests/training/test_oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py -q` -> passed, 51 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/oracle_trace_uri_registry.py tests/training/test_oracle_imitation_trace_uri_registry.py tests/training/test_oracle_imitation_warm_start_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/training/oracle_trace_uri_registry.py tests/training/test_oracle_imitation_trace_uri_registry.py tests/training/test_oracle_imitation_warm_start_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/validate_oracle_trace_uri_registry.py --config configs/training/ppo_imitation/oracle_trace_uri_registry_issue_1470.yaml --json` -> passed; reports `training_ready=false` and exposes the train source manifest URI.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/validate_oracle_trace_uri_registry.py --config configs/training/ppo_imitation/oracle_trace_uri_registry_issue_1470.yaml --json --require-training-ready` -> expected fail-closed exit 2; validation/evaluation are not resolvable.

- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-1470/PR_BODY.md scripts/dev/pr_ready_check.sh` -> passed; stamp `output/validation/pr_ready/issue-1470-backfill-admitted-data-collect-oracle-imitation-dataset-from-launch-pack.json`, head `402d9c58b2cbe8c0c7a43ce890ee5328b127ade0`.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no training, no paper/dissertation claim edits, no merge, no release, no deletion.

## State propagation

No separate issue comment was posted because this run is not authorized to comment on issues/PRs. This PR body is the durable propagation surface for the delivered slice and remaining blocker.

<details>
<summary>Governance appendix</summary>

- Live issue freshness: issue/comments rechecked before PR publication via REST because `gh issue view --comments` currently fails on the repository classic Projects field. Latest comment observed: 2026-06-23T15:19:51Z, no maintainer guidance newer than this work start.
- Fragmentation guard: direct searches found prior merged #1470 readiness/trace PRs, but none in the last 24h and no open PR covering this exact source-manifest metadata contract. This is a progression slice, not another packet-only guard.
- Authorization boundaries honored: `compute_submit=false`, `merge=false`, `release=false`, `delete=false`.

</details>
