### PR TITLE
Issue #2655: wire trace registry into launch packet readiness

### DIFF
--- a/robot_sf/training/oracle_imitation_launch_packet.py
+++ b/robot_sf/training/oracle_imitation_launch_packet.py
@@ -9,6 +9,11 @@ from typing import Any
 
 import yaml
 
+from robot_sf.training.oracle_trace_uri_registry import (
+    OracleTraceUriRegistryError,
+    validate_trace_uri_registry,
+)
+
 _SCHEMA_VERSION = "oracle-imitation-launch-packet.v1"
 _SPLITS = ("train", "validation", "evaluation")
 _GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -87,8 +92,15 @@ def validate_launch_packet(
     _validate_generating_commit(packet, errors)
     artifact_paths = _validate_artifacts(packet, root, errors)
     collection_roots = _validate_collection_roots(packet, errors)
+    trace_uri_registry = _validate_trace_uri_registry_pointer(
+        packet,
+        root,
+        require_training_ready=require_training_ready,
+        errors=errors,
+    )
     training_ready = _validate_training_artifact_gate(
         artifact_paths,
+        trace_uri_registry=trace_uri_registry,
         require_training_ready=require_training_ready,
         errors=errors,
     )
@@ -107,6 +119,7 @@ def validate_launch_packet(
         "seeds_by_split": {split: list(packet["seeds_by_split"][split]) for split in _SPLITS},
         "artifact_paths": artifact_paths,
         "collection_roots": collection_roots,
+        "trace_uri_registry": trace_uri_registry,
         "training_ready": training_ready,
     }
 
@@ -378,9 +391,16 @@ def _validate_artifacts(
 def _validate_training_artifact_gate(
     artifact_paths: dict[str, str],
     *,
+    trace_uri_registry: dict[str, Any] | None,
     require_training_ready: bool,
     errors: list[str],
 ) -> bool:
+    if trace_uri_registry is not None:
+        training_ready = bool(trace_uri_registry.get("training_ready", False))
+        if require_training_ready and not training_ready:
+            errors.append("trace_uri_registry must be training_ready when --require-training-ready")
+        return training_ready
+
     required_trace_artifacts = {
         "train_trace_jsonl_uri",
         "validation_trace_jsonl_uri",
@@ -418,6 +438,53 @@ def _validate_training_artifact_gate(
             f"{', '.join(non_durable_required)}"
         )
     return training_ready
+
+
+def _validate_trace_uri_registry_pointer(
+    packet: dict[str, Any],
+    repo_root: Path,
+    *,
+    require_training_ready: bool,
+    errors: list[str],
+) -> dict[str, Any] | None:
+    registry_path = packet.get("trace_uri_registry")
+    if registry_path is None:
+        return None
+    if not isinstance(registry_path, str) or not registry_path.strip():
+        errors.append("trace_uri_registry must be non-empty path string when provided")
+        return None
+
+    try:
+        report = validate_trace_uri_registry(
+            _resolve_path(registry_path, repo_root),
+            repo_root=repo_root,
+            require_training_ready=require_training_ready,
+        )
+    except OracleTraceUriRegistryError as exc:
+        errors.append(f"trace_uri_registry failed validation: {_first_error_line(exc)}")
+        return {
+            "path": registry_path,
+            "status": "invalid",
+            "training_ready": False,
+        }
+
+    return {
+        "path": registry_path,
+        "status": report["status"],
+        "dataset_id": report["dataset_id"],
+        "splits": report["splits"],
+        "retrieval_status": report["retrieval_status"],
+        "training_ready": report["training_ready"],
+    }
+
+
+def _first_error_line(exc: Exception) -> str:
+    for line in str(exc).splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.endswith("failed validation:"):
+            continue
+        return stripped.removeprefix("- ").strip()
+    return str(exc)
 
 
 def _validate_collection_roots(packet: dict[str, Any], errors: list[str]) -> dict[str, str]:

--- a/tests/training/test_oracle_imitation_launch_packet.py
+++ b/tests/training/test_oracle_imitation_launch_packet.py
@@ -23,6 +23,39 @@ def _write_packet(tmp_path: Path, packet: dict[str, object]) -> Path:
     return path
 
 
+def _write_trace_uri_registry(
+    tmp_path: Path,
+    *,
+    retrieval_status: str = "resolvable",
+    sha256: str | None = None,
+) -> Path:
+    digest = sha256 or ("a" * 64)
+    traces = []
+    for split in ("train", "validation", "evaluation"):
+        traces.append(
+            {
+                "split": split,
+                "trace_id": f"{split}__demo_oracle_imitation",
+                "uri": f"wandb-artifact://robot-sf/oracle-imitation/{split}:v1",
+                "sha256": digest if retrieval_status == "resolvable" else "pending",
+                "retrieval_status": retrieval_status,
+            }
+        )
+    path = tmp_path / "trace_registry.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "oracle-trace-uri-registry.v1",
+                "dataset_id": "demo_oracle_imitation",
+                "traces": traces,
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
 def _valid_packet(tmp_path: Path) -> dict[str, object]:
     fixture = tmp_path / "fixture.json"
     fixture.write_text('{"status": "dry-run"}\n', encoding="utf-8")
@@ -203,6 +236,50 @@ def test_validate_launch_packet_accepts_training_ready_trace_artifacts(tmp_path:
     )
 
     assert report["training_ready"] is True
+
+
+def test_validate_launch_packet_accepts_training_ready_trace_uri_registry(tmp_path: Path) -> None:
+    """A valid trace URI registry can satisfy the downstream training gate."""
+    packet = _valid_packet(tmp_path)
+    packet["trace_uri_registry"] = str(_write_trace_uri_registry(tmp_path))
+
+    report = validate_launch_packet(
+        _write_packet(tmp_path, packet),
+        require_training_ready=True,
+    )
+
+    assert report["training_ready"] is True
+    assert report["trace_uri_registry"]["training_ready"] is True
+    assert report["trace_uri_registry"]["splits"] == {
+        "train": ["train__demo_oracle_imitation"],
+        "validation": ["validation__demo_oracle_imitation"],
+        "evaluation": ["evaluation__demo_oracle_imitation"],
+    }
+
+
+def test_validate_launch_packet_rejects_pending_trace_uri_registry(tmp_path: Path) -> None:
+    """Strict launch-packet readiness fails closed on pending registry traces."""
+    packet = _valid_packet(tmp_path)
+    packet["trace_uri_registry"] = str(
+        _write_trace_uri_registry(tmp_path, retrieval_status="pending")
+    )
+
+    with pytest.raises(LaunchPacketError, match="trace_uri_registry failed validation"):
+        validate_launch_packet(
+            _write_packet(tmp_path, packet),
+            require_training_ready=True,
+        )
+
+
+def test_validate_launch_packet_rejects_invalid_trace_uri_registry_path(
+    tmp_path: Path,
+) -> None:
+    """Registry pointers must resolve to a valid registry file when present."""
+    packet = _valid_packet(tmp_path)
+    packet["trace_uri_registry"] = "missing/trace_registry.yaml"
+
+    with pytest.raises(LaunchPacketError, match="trace_uri_registry failed validation"):
+        validate_launch_packet(_write_packet(tmp_path, packet), require_training_ready=True)
 
 
 def test_validate_launch_packet_rejects_pending_training_artifacts(tmp_path: Path) -> None:

--- a/tests/training/test_oracle_imitation_launch_packet.py
+++ b/tests/training/test_oracle_imitation_launch_packet.py
@@ -32,15 +32,21 @@ def _write_trace_uri_registry(
     digest = sha256 or ("a" * 64)
     traces = []
     for split in ("train", "validation", "evaluation"):
-        traces.append(
-            {
-                "split": split,
-                "trace_id": f"{split}__demo_oracle_imitation",
-                "uri": f"wandb-artifact://robot-sf/oracle-imitation/{split}:v1",
-                "sha256": digest if retrieval_status == "resolvable" else "pending",
-                "retrieval_status": retrieval_status,
-            }
-        )
+        trace = {
+            "split": split,
+            "trace_id": f"{split}__demo_oracle_imitation",
+            "uri": f"wandb-artifact://robot-sf/oracle-imitation/{split}:v1",
+            "sha256": digest if retrieval_status == "resolvable" else "pending",
+            "retrieval_status": retrieval_status,
+        }
+        if retrieval_status == "resolvable":
+            # Resolvable traces must bind JSONL bytes to source-manifest
+            # provenance (oracle-trace-uri-registry.v1 contract, issue #1470).
+            trace["source_manifest_uri"] = (
+                f"wandb-artifact://robot-sf/oracle-imitation/{split}_manifest:v1"
+            )
+            trace["source_manifest_sha256"] = digest
+        traces.append(trace)
     path = tmp_path / "trace_registry.yaml"
     path.write_text(
         yaml.safe_dump(


### PR DESCRIPTION
Reviewer-critical summary

What changed: wires optional `trace_uri_registry` support into `validate_oracle_imitation_launch_packet.py` through the canonical `robot_sf.training.oracle_trace_uri_registry` validator. A launch packet can now satisfy `--require-training-ready` with a valid durable trace-URI registry instead of duplicating raw trace URIs under legacy `artifact_paths`.

Why now: issue #2655 already has the standalone registry slice from PR #3745; this PR adds the missing launch-packet integration named in the issue body without staging licensed/private data.

Claim boundary: this is a local schema/validator integration only. It proves the launch-packet validator consumes and fails closed on the registry contract; it does not prove any oracle traces are collected, published, licensed for redistribution, or suitable for training.

Required validation: focused tests plus lint/format/help smoke listed below.

Remaining blocker: real training-ready state still requires private/durable oracle trace artifacts with concrete URIs and SHA-256 checksums; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

Contract delta

- New optional launch-packet field: `trace_uri_registry`, a path to an `oracle-trace-uri-registry.v1` YAML file.
- New report field: `trace_uri_registry`, containing the registry path, status, dataset id, splits, retrieval status, and `training_ready` result when configured.
- New fail-closed blocker: invalid, missing, pending, or non-training-ready registry pointers fail `--require-training-ready` through the launch-packet validator.
- Compatibility impact: packets without `trace_uri_registry` keep the existing artifact-path training-ready gate unchanged.

Issue: https://github.com/ll7/robot_sf_ll7/issues/2655

Scope summary

- Extended `robot_sf/training/oracle_imitation_launch_packet.py` to call the canonical durable trace URI registry validator.
- Added launch-packet tests for a complete registry, pending registry, and missing registry path.

Validation

- `uv run python -m pytest tests/training/test_oracle_imitation_launch_packet.py tests/training/test_oracle_imitation_trace_uri_registry.py -q` passed.
- `uv run ruff check robot_sf/training/oracle_imitation_launch_packet.py tests/training/test_oracle_imitation_launch_packet.py` passed.
- `uv run ruff format --check robot_sf/training/oracle_imitation_launch_packet.py tests/training/test_oracle_imitation_launch_packet.py` passed.
- `uv run python scripts/validation/validate_oracle_imitation_launch_packet.py --help` passed.
- `git diff --check` passed.

State propagation

No separate issue comment was posted because this run was explicitly authorized with `comment_issue_or_pr: false`. This PR body records the delivered slice and remaining blocker as the remote-visible propagation surface.

<details>
<summary>Governance appendix</summary>

- Prior coverage checked: PR #3745 already added the standalone durable trace-URI registry and validator. This PR adds a new capability: launch-packet training-ready validation consumes that registry.
- Freshness checked immediately before opening: issue #2655 had no maintainer comments newer than the run start timestamp; latest issue comment remained 2026-07-05 00:53 UTC.
- Open PR dedupe checked: no open PR directly covers #2655 launch-packet registry integration; PR #4556 is for #1470 trace-source manifests.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no licensed/private data staging.

</details>
