### PR TITLE
feat: add SDD curation decision packet (#1126)

### DIFF
--- a/docs/context/issue_1126_sdd_curation_preflight.md
+++ b/docs/context/issue_1126_sdd_curation_preflight.md
@@ -65,3 +65,16 @@ benchmark-ready. `--require-benchmark-ready` exits non-zero (3) so callers fail 
 
 No SDD download/ingestion, no real curation run, no benchmark campaign, no Slurm/GPU submission, and
 no paper/dissertation claim edits.
+
+## Decision Packet Slice (2026-07-05)
+
+The preflight CLI can now write a metadata-only decision packet:
+
+```bash
+uv run python scripts/tools/sdd_curation_preflight.py \
+  --annotation <staged>/annotations.txt \
+  --write-decision-packet output/sdd_curation/issue_1126/decision_packet.json \
+  --json
+```
+
+The packet records the readiness report, selected annotation path, curation parameters, next preflight/import commands, and raw-data policy. It deliberately does not write scenario/map outputs, does not commit raw SDD files, and does not promote proxy or fixture runs as benchmark evidence.

--- a/scripts/tools/sdd_curation_preflight.py
+++ b/scripts/tools/sdd_curation_preflight.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import sys
 from pathlib import Path
 from typing import Any
@@ -40,6 +41,7 @@ from typing import Any
 from scripts.tools import import_sdd_scenarios, manage_external_data
 
 PREFLIGHT_SCHEMA = "sdd_curation_preflight.v1"
+DECISION_PACKET_SCHEMA = "robot_sf_sdd_curation_decision_packet.v1"
 ISSUE = 1126
 
 # Curation evidence states (kept strictly distinct so a proxy run can never read as benchmark).
@@ -218,6 +220,90 @@ def run_preflight(
     return classify_curation_readiness(staging_gate, probe)
 
 
+def _shell_arg(value: str | Path) -> str:
+    """Return a conservative single-token shell representation for packet commands."""
+    return shlex.quote(str(value))
+
+
+def build_decision_packet(
+    report: dict[str, Any],
+    *,
+    annotation: Path | None,
+    label: str,
+    min_track_points: int,
+    max_pedestrians: int,
+    dataset_id: str,
+    output_dir: Path,
+) -> dict[str, Any]:
+    """Build a metadata-only handoff packet for the first real SDD curation run."""
+    annotation_placeholder = "<staged-sdd>/<scene>/<video>/annotations.txt"
+    annotation_command_arg: str | Path = (
+        annotation if annotation is not None else annotation_placeholder
+    )
+    import_command = " ".join(
+        [
+            "uv run python scripts/tools/import_sdd_scenarios.py",
+            "--annotation",
+            _shell_arg(annotation_command_arg),
+            "--dataset-id",
+            _shell_arg(dataset_id),
+            "--output-dir",
+            _shell_arg(output_dir),
+            "--label",
+            _shell_arg(label),
+            "--min-track-points",
+            str(min_track_points),
+            "--max-pedestrians",
+            str(max_pedestrians),
+        ]
+    )
+    preflight_command = " ".join(
+        [
+            "uv run python scripts/tools/sdd_curation_preflight.py",
+            "--annotation",
+            _shell_arg(annotation_command_arg),
+            "--label",
+            _shell_arg(label),
+            "--min-track-points",
+            str(min_track_points),
+            "--max-pedestrians",
+            str(max_pedestrians),
+            "--require-benchmark-ready",
+            "--json",
+        ]
+    )
+    return {
+        "schema": DECISION_PACKET_SCHEMA,
+        "issue": ISSUE,
+        "claim_boundary": (
+            "decision packet only; no real SDD curation run, benchmark campaign, "
+            "or paper-facing claim"
+        ),
+        "readiness": report,
+        "selected_annotation": str(annotation) if annotation is not None else None,
+        "curation_parameters": {
+            "dataset_id": dataset_id,
+            "label": import_sdd_scenarios.normalize_sdd_label(label),
+            "min_track_points": min_track_points,
+            "max_pedestrians": max_pedestrians,
+            "output_dir": str(output_dir),
+        },
+        "required_next_commands": {
+            "preflight": preflight_command,
+            "import": import_command,
+            "smoke_validation": (
+                "load generated scenario/map and run one CPU smoke path before marking "
+                "benchmark_ready; otherwise record exploratory_only or blocked reason"
+            ),
+        },
+        "raw_data_policy": {
+            "raw_sdd_committed": False,
+            "requires_dataset_backed_gate": True,
+            "requires_source_checksum_and_license_provenance": True,
+        },
+    }
+
+
 def _format_human(report: dict[str, Any]) -> str:
     """Render a compact human-readable summary of the readiness report."""
     lines = [
@@ -263,6 +349,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--max-pedestrians", type=int, default=4)
     parser.add_argument("--json", action="store_true", help="Emit the report as JSON.")
     parser.add_argument(
+        "--write-decision-packet",
+        type=Path,
+        default=None,
+        help="Write a JSON handoff packet for the first real SDD curation run.",
+    )
+    parser.add_argument(
+        "--decision-dataset-id",
+        default="sdd_first_real_candidate",
+        help="Dataset ID to place in the decision packet import command.",
+    )
+    parser.add_argument(
+        "--decision-output-dir",
+        type=Path,
+        default=Path("output/sdd_curation/issue_1126"),
+        help="Output directory to place in the decision packet import command.",
+    )
+    parser.add_argument(
         "--require-benchmark-ready",
         action="store_true",
         help="Exit non-zero unless curation output may be promoted as benchmark evidence.",
@@ -293,6 +396,21 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
         print(_format_human(report))
+    if args.write_decision_packet is not None:
+        packet = build_decision_packet(
+            report,
+            annotation=args.annotation,
+            label=args.label,
+            min_track_points=args.min_track_points,
+            max_pedestrians=args.max_pedestrians,
+            dataset_id=args.decision_dataset_id,
+            output_dir=args.decision_output_dir,
+        )
+        args.write_decision_packet.parent.mkdir(parents=True, exist_ok=True)
+        args.write_decision_packet.write_text(
+            json.dumps(packet, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
     if args.require_benchmark_ready and not report["benchmark_promotion_allowed"]:
         return 3
     return 0

--- a/tests/tools/test_sdd_curation_preflight.py
+++ b/tests/tools/test_sdd_curation_preflight.py
@@ -7,6 +7,7 @@ benchmark evidence regardless of whether the importer could parse a candidate fi
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 from scripts.tools import manage_external_data, sdd_curation_preflight
@@ -261,3 +262,75 @@ def test_cli_require_benchmark_ready_fails_closed_when_unstaged(
     assert exit_code == 3
     out = capsys.readouterr().out
     assert '"benchmark_promotion_allowed": false' in out
+
+
+def test_decision_packet_preserves_proxy_blocker(tmp_path: Path) -> None:
+    """Decision packet records proxy-only ceiling, not benchmark readiness."""
+    annotations = tmp_path / "annotations.txt"
+    _write_sdd_fixture(annotations)
+    proxy_gate = {
+        "mode": manage_external_data.SDD_MODE_PROXY,
+        "dataset_backed": False,
+        "availability": {"state": "missing"},
+        "reason": "SDD not staged.",
+        "staging_dir": str(tmp_path),
+    }
+    probe = sdd_curation_preflight.probe_annotation_file(
+        annotations, label="Pedestrian", min_track_points=4, max_pedestrians=4
+    )
+    report = sdd_curation_preflight.classify_curation_readiness(proxy_gate, probe)
+
+    packet = sdd_curation_preflight.build_decision_packet(
+        report,
+        annotation=annotations,
+        label="Pedestrian",
+        min_track_points=4,
+        max_pedestrians=4,
+        dataset_id="sdd_test_scene",
+        output_dir=tmp_path / "derived",
+    )
+
+    assert packet["schema"] == sdd_curation_preflight.DECISION_PACKET_SCHEMA
+    assert packet["readiness"]["benchmark_promotion_allowed"] is False
+    assert packet["readiness"]["output_classification"] == sdd_curation_preflight.OUTPUT_PROXY_ONLY
+    assert packet["raw_data_policy"]["raw_sdd_committed"] is False
+    assert "--dataset-id sdd_test_scene" in packet["required_next_commands"]["import"]
+
+
+def test_cli_writes_decision_packet_without_benchmark_claim(tmp_path: Path, monkeypatch) -> None:
+    """CLI packet output is metadata-only and keeps missing SDD fail-closed."""
+    annotations = tmp_path / "annotations.txt"
+    packet_path = tmp_path / "packet.json"
+    _write_sdd_fixture(annotations)
+    monkeypatch.setattr(
+        manage_external_data,
+        "resolve_sdd_scenario_prior_mode",
+        lambda *, manifest_path=None: {
+            "mode": manage_external_data.SDD_MODE_PROXY,
+            "dataset_backed": False,
+            "availability": {"state": "missing"},
+            "reason": "SDD not staged.",
+            "staging_dir": str(tmp_path),
+        },
+    )
+
+    exit_code = sdd_curation_preflight.main(
+        [
+            "--annotation",
+            str(annotations),
+            "--min-track-points",
+            "4",
+            "--decision-dataset-id",
+            "sdd_test_scene",
+            "--write-decision-packet",
+            str(packet_path),
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    packet = json.loads(packet_path.read_text(encoding="utf-8"))
+    assert packet["claim_boundary"].startswith("decision packet only")
+    assert packet["readiness"]["evidence_status"] == sdd_curation_preflight.EVIDENCE_PROXY
+    assert packet["readiness"]["benchmark_promotion_allowed"] is False
+    assert not (tmp_path / "derived").exists()


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a metadata-only SDD curation decision packet writer to `scripts/tools/sdd_curation_preflight.py`, with tests and context-note documentation.

Why now: issue #1126 is still blocked on bring-your-own Stanford Drone Dataset (SDD) annotations, but the ready-queue slice can safely add a handoff packet that records the exact fail-closed readiness state and next commands for the first real curation run.

Claim boundary: this PR does not curate real SDD scenarios, does not run the importer on real data, and does not claim benchmark readiness. It only writes a JSON decision packet from the existing preflight report.

Required validation: focused CPU tests for the curation preflight/importer path plus lint/format checks. Full PR-ready freshness stamp was not generated; the broader `tests/ -k "sdd or import_scenarios"` selector currently fails during unrelated collection because optional training/analytics dependencies are absent in this fresh worktree.

Remaining blocker: real SDD annotations still need local BYO staging, checksum/license provenance, selected scene/video, scale assumptions, generated artifact review, and CPU smoke validation before benchmark-ready evidence exists.

## Contract delta

New schema field/surface: `robot_sf_sdd_curation_decision_packet.v1` JSON packets, written only when `--write-decision-packet <path>` is supplied.

New CLI options:

- `--write-decision-packet <path>` writes the metadata-only packet.
- `--decision-dataset-id <id>` controls the dataset ID embedded in the suggested import command.
- `--decision-output-dir <path>` controls the suggested derived-output directory embedded in the suggested import command.

New fail-closed blockers: none beyond the existing preflight gate. The packet preserves `benchmark_promotion_allowed: false` and proxy/blocker state when SDD is not dataset-backed.

Compatibility impact: default preflight behavior and exit codes are unchanged unless the new packet option is used.

## Issue

Closes no issue. Advances #1126 with the new named capability: SDD curation decision packet writer.

## Scope summary

- Compose the existing SDD staging/preflight result into a small JSON handoff packet.
- Include next preflight/import command strings and raw-data policy in the packet.
- Add fixture-backed tests proving proxy/fixture input remains non-promotable benchmark evidence.
- Document the packet slice in `docs/context/issue_1126_sdd_curation_preflight.md`.

## Validation

- `python -m py_compile scripts/tools/sdd_curation_preflight.py` PASS
- `uv run ruff format scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` PASS (`1 file reformatted, 1 file left unchanged`)
- `uv run ruff check scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` PASS
- `uv run pytest tests/tools/test_sdd_curation_preflight.py -q` PASS (`12 passed`)
- `uv run pytest tests/tools/test_import_sdd_scenarios.py -q` PASS (`6 passed`)
- `uv run python scripts/tools/sdd_curation_preflight.py --write-decision-packet output/sdd_curation/issue_1126/decision_packet_smoke.json --json >/tmp/issue1126_preflight.json && python -m json.tool output/sdd_curation/issue_1126/decision_packet_smoke.json >/tmp/issue1126_packet.json` PASS; ignored smoke output deleted before commit
- `uv run python -m pytest tests/ -k "sdd or import_scenarios" -q` FAILS during unrelated collection because optional packages are missing in this fresh worktree (`torch`, `stable_baselines3`, `duckdb`, `optuna`, `pyarrow`, `sqlalchemy`). Focused SDD tests above pass.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` FAILS with `reason: missing` because no full PR-ready stamp was generated; tree was clean.

## Explicit out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. No SDD download, no raw SDD commit, no generated scenario/map artifacts committed.

## State propagation

No issue comment was posted because this run was not authorized to comment on issues or PRs. This PR body is the propagation surface for the delivered slice and remaining blocker.

<details>
<summary>Process appendix</summary>

- Read the live issue body and all comments via `gh issue view 1126 --repo ll7/robot_sf_ll7 --json body,comments,...` because plain `--comments` hit GitHub classic Projects deprecation.
- Rechecked the live issue before PR open; no comments newer than start time were present.
- Dedupe check found no open PR for #1126 / SDD curation decision packet. One prior merged #1126 PR (#3765) added the fail-closed readiness preflight, so this PR adds a distinct progression capability.
- This PR does not encode transient host, queue, or packet lineage state in tracked files.
</details>
