### PR TITLE
Issue #2918: add pedestrian prior fixture extraction

### DIFF
--- a/robot_sf/benchmark/pedestrian_prior_extraction.py
+++ b/robot_sf/benchmark/pedestrian_prior_extraction.py
@@ -1,0 +1,372 @@
+"""Fixture/local pedestrian-prior extraction helpers for issue #2918.
+
+This module extracts compact bounded prior summaries from already-available
+trajectory records. It intentionally does not download, stage, or store raw
+external datasets. Dataset-backed claim admission remains owned by
+``pedestrian_prior_extraction_manifest``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.pedestrian_prior_extraction_manifest import (
+    PRIOR_EXTRACTION_EVIDENCE_BOUNDARY,
+    REQUIRED_PRIOR_PARAMETERS,
+)
+
+PEDESTRIAN_PRIOR_EXTRACTION_REPORT_SCHEMA_VERSION = "pedestrian_prior_extraction_report.v1"
+
+
+class PedestrianPriorExtractionError(ValueError):
+    """Raised when trajectory input cannot support prior extraction."""
+
+
+@dataclass(frozen=True)
+class PriorParameterSummary:
+    """Compact bounded summary for one extracted prior parameter."""
+
+    name: str
+    units: str
+    count: int
+    minimum: float
+    maximum: float
+    mean: float
+    value_status: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-safe dictionary representation."""
+
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PedestrianPriorExtractionReport:
+    """Compact prior extraction report without raw trajectory samples."""
+
+    schema_version: str
+    source_id: str
+    value_status: str
+    evidence_boundary: str
+    parameter_summaries: list[PriorParameterSummary]
+    provenance: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-safe dictionary representation."""
+
+        payload = asdict(self)
+        payload["parameter_summaries"] = [summary.to_dict() for summary in self.parameter_summaries]
+        return payload
+
+
+def load_pedestrian_prior_trajectory_fixture(path: str | Path) -> dict[str, Any]:
+    """Load a fixture/local trajectory file in YAML or JSON format.
+
+    Returns:
+        Parsed fixture payload.
+    """
+
+    fixture_path = Path(path)
+    if not fixture_path.is_file():
+        raise PedestrianPriorExtractionError(f"trajectory fixture not found: {fixture_path}")
+    try:
+        payload = yaml.safe_load(fixture_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive
+        raise PedestrianPriorExtractionError(f"invalid YAML/JSON: {exc}") from exc
+    if not isinstance(payload, Mapping):
+        raise PedestrianPriorExtractionError("trajectory fixture must be a mapping")
+    return dict(payload)
+
+
+def extract_pedestrian_prior_report(
+    payload: Mapping[str, Any],
+    *,
+    value_status: str = "proxy-placeholder",
+) -> PedestrianPriorExtractionReport:
+    """Extract compact pedestrian-prior summaries from trajectory records.
+
+    Args:
+        payload: Mapping with ``observations`` records containing
+            ``pedestrian_id``, ``time``, ``x``, and ``y``.
+        value_status: Status stamped on extracted values. Use
+            ``proxy-placeholder`` for fixtures; reserve ``dataset-backed`` for
+            separately staged and manifest-admitted external data.
+
+    Returns:
+        Compact extraction report containing summaries, not raw trajectories.
+    """
+
+    if value_status not in {"proxy-placeholder", "dataset-backed"}:
+        raise PedestrianPriorExtractionError(
+            "value_status must be 'proxy-placeholder' or 'dataset-backed'"
+        )
+    observations = _parse_observations(payload.get("observations"))
+    bounds = _parse_bounds(payload.get("bounds"))
+    source_id = str(payload.get("source_id") or "pedestrian_prior_fixture")
+    provenance = _provenance(payload, value_status=value_status)
+
+    speeds = _segment_speeds(observations)
+    headings = _pedestrian_headings(observations)
+    densities = _frame_densities(observations, bounds)
+    distances = _interaction_distances(observations)
+    stop_durations = _stop_yield_durations(observations)
+
+    values_by_parameter = {
+        "walking_speed": ("m/s", speeds),
+        "crossing_angle": ("deg", headings),
+        "density": ("ped/m^2", densities),
+        "interaction_distance": ("m", distances),
+        "stop_yield_timing": ("s", stop_durations),
+    }
+    summaries = [
+        _summarize(name, units, values, value_status=value_status)
+        for name, (units, values) in values_by_parameter.items()
+    ]
+    return PedestrianPriorExtractionReport(
+        schema_version=PEDESTRIAN_PRIOR_EXTRACTION_REPORT_SCHEMA_VERSION,
+        source_id=source_id,
+        value_status=value_status,
+        evidence_boundary=PRIOR_EXTRACTION_EVIDENCE_BOUNDARY,
+        parameter_summaries=summaries,
+        provenance=provenance,
+    )
+
+
+def extract_pedestrian_prior_report_from_file(
+    path: str | Path,
+    *,
+    value_status: str = "proxy-placeholder",
+) -> PedestrianPriorExtractionReport:
+    """Load a trajectory fixture/local file and extract compact prior summaries.
+
+    Returns:
+        Compact extraction report containing summaries, not raw trajectories.
+    """
+
+    return extract_pedestrian_prior_report(
+        load_pedestrian_prior_trajectory_fixture(path),
+        value_status=value_status,
+    )
+
+
+def write_pedestrian_prior_extraction_report(
+    report: PedestrianPriorExtractionReport,
+    path: str | Path,
+) -> None:
+    """Write compact extraction report as deterministic JSON."""
+
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _parse_observations(raw_observations: Any) -> list[dict[str, float | str]]:
+    if not isinstance(raw_observations, list) or not raw_observations:
+        raise PedestrianPriorExtractionError("observations must be a non-empty list")
+    observations: list[dict[str, float | str]] = []
+    for index, raw in enumerate(raw_observations):
+        if not isinstance(raw, Mapping):
+            raise PedestrianPriorExtractionError(f"observations[{index}] must be a mapping")
+        try:
+            pedestrian_id = str(raw["pedestrian_id"])
+            time = float(raw["time"])
+            x = float(raw["x"])
+            y = float(raw["y"])
+        except KeyError as exc:
+            raise PedestrianPriorExtractionError(
+                f"observations[{index}] missing required field {exc.args[0]!r}"
+            ) from exc
+        except (TypeError, ValueError) as exc:
+            raise PedestrianPriorExtractionError(
+                f"observations[{index}] has non-numeric time/x/y"
+            ) from exc
+        observations.append(
+            {
+                "pedestrian_id": pedestrian_id,
+                "time": time,
+                "x": x,
+                "y": y,
+            }
+        )
+    return sorted(observations, key=lambda item: (str(item["pedestrian_id"]), float(item["time"])))
+
+
+def _parse_bounds(raw_bounds: Any) -> tuple[float, float, float, float]:
+    if raw_bounds is None:
+        raise PedestrianPriorExtractionError("bounds are required for density extraction")
+    if not isinstance(raw_bounds, Mapping):
+        raise PedestrianPriorExtractionError("bounds must be a mapping")
+    try:
+        min_x = float(raw_bounds["min_x"])
+        max_x = float(raw_bounds["max_x"])
+        min_y = float(raw_bounds["min_y"])
+        max_y = float(raw_bounds["max_y"])
+    except KeyError as exc:
+        raise PedestrianPriorExtractionError(
+            f"bounds missing required field {exc.args[0]!r}"
+        ) from exc
+    except (TypeError, ValueError) as exc:
+        raise PedestrianPriorExtractionError("bounds values must be numeric") from exc
+    if max_x <= min_x or max_y <= min_y:
+        raise PedestrianPriorExtractionError("bounds must have positive width and height")
+    return (min_x, max_x, min_y, max_y)
+
+
+def _group_by_pedestrian(
+    observations: Iterable[Mapping[str, float | str]],
+) -> dict[str, list[Mapping[str, float | str]]]:
+    grouped: dict[str, list[Mapping[str, float | str]]] = {}
+    for observation in observations:
+        grouped.setdefault(str(observation["pedestrian_id"]), []).append(observation)
+    return grouped
+
+
+def _segment_speeds(observations: list[Mapping[str, float | str]]) -> list[float]:
+    speeds: list[float] = []
+    for track in _group_by_pedestrian(observations).values():
+        ordered = sorted(track, key=lambda item: float(item["time"]))
+        for start, end in pairwise(ordered):
+            dt = float(end["time"]) - float(start["time"])
+            if dt <= 0.0:
+                raise PedestrianPriorExtractionError("pedestrian tracks must have increasing time")
+            speeds.append(
+                math.hypot(float(end["x"]) - float(start["x"]), float(end["y"]) - float(start["y"]))
+                / dt
+            )
+    if not speeds:
+        raise PedestrianPriorExtractionError("at least one two-point pedestrian track is required")
+    return speeds
+
+
+def _pedestrian_headings(observations: list[Mapping[str, float | str]]) -> list[float]:
+    headings: list[float] = []
+    for track in _group_by_pedestrian(observations).values():
+        ordered = sorted(track, key=lambda item: float(item["time"]))
+        if len(ordered) < 2:
+            continue
+        dx = float(ordered[-1]["x"]) - float(ordered[0]["x"])
+        dy = float(ordered[-1]["y"]) - float(ordered[0]["y"])
+        if dx == 0.0 and dy == 0.0:
+            headings.append(0.0)
+        else:
+            headings.append(abs(math.degrees(math.atan2(dy, dx))))
+    if not headings:
+        raise PedestrianPriorExtractionError("at least one moving pedestrian heading is required")
+    return headings
+
+
+def _frame_densities(
+    observations: list[Mapping[str, float | str]],
+    bounds: tuple[float, float, float, float],
+) -> list[float]:
+    min_x, max_x, min_y, max_y = bounds
+    area = (max_x - min_x) * (max_y - min_y)
+    frame_counts: dict[float, int] = {}
+    for observation in observations:
+        x = float(observation["x"])
+        y = float(observation["y"])
+        if min_x <= x <= max_x and min_y <= y <= max_y:
+            time = float(observation["time"])
+            frame_counts[time] = frame_counts.get(time, 0) + 1
+    if not frame_counts:
+        raise PedestrianPriorExtractionError("no observations fall inside density bounds")
+    return [count / area for count in frame_counts.values()]
+
+
+def _interaction_distances(observations: list[Mapping[str, float | str]]) -> list[float]:
+    by_time: dict[float, list[Mapping[str, float | str]]] = {}
+    for observation in observations:
+        by_time.setdefault(float(observation["time"]), []).append(observation)
+    distances: list[float] = []
+    for frame in by_time.values():
+        if len(frame) < 2:
+            continue
+        for index, observation in enumerate(frame):
+            nearest = min(
+                math.hypot(
+                    float(observation["x"]) - float(other["x"]),
+                    float(observation["y"]) - float(other["y"]),
+                )
+                for other_index, other in enumerate(frame)
+                if other_index != index
+            )
+            distances.append(nearest)
+    if not distances:
+        raise PedestrianPriorExtractionError(
+            "at least one timestamp with two pedestrians is required for interaction distance"
+        )
+    return distances
+
+
+def _stop_yield_durations(
+    observations: list[Mapping[str, float | str]],
+    *,
+    speed_threshold_mps: float = 0.05,
+) -> list[float]:
+    durations: list[float] = []
+    for track in _group_by_pedestrian(observations).values():
+        ordered = sorted(track, key=lambda item: float(item["time"]))
+        current_duration = 0.0
+        for start, end in pairwise(ordered):
+            dt = float(end["time"]) - float(start["time"])
+            if dt <= 0.0:
+                raise PedestrianPriorExtractionError("pedestrian tracks must have increasing time")
+            speed = (
+                math.hypot(
+                    float(end["x"]) - float(start["x"]),
+                    float(end["y"]) - float(start["y"]),
+                )
+                / dt
+            )
+            if speed <= speed_threshold_mps:
+                current_duration += dt
+            elif current_duration > 0.0:
+                durations.append(current_duration)
+                current_duration = 0.0
+        if current_duration > 0.0:
+            durations.append(current_duration)
+    return durations or [0.0]
+
+
+def _summarize(
+    name: str,
+    units: str,
+    values: list[float],
+    *,
+    value_status: str,
+) -> PriorParameterSummary:
+    if name not in REQUIRED_PRIOR_PARAMETERS:
+        raise PedestrianPriorExtractionError(f"unexpected prior parameter: {name}")
+    if not values:
+        raise PedestrianPriorExtractionError(f"no values extracted for {name}")
+    return PriorParameterSummary(
+        name=name,
+        units=units,
+        count=len(values),
+        minimum=round(min(values), 6),
+        maximum=round(max(values), 6),
+        mean=round(sum(values) / len(values), 6),
+        value_status=value_status,
+    )
+
+
+def _provenance(payload: Mapping[str, Any], *, value_status: str) -> dict[str, Any]:
+    raw_provenance = payload.get("provenance", {})
+    provenance = dict(raw_provenance) if isinstance(raw_provenance, Mapping) else {}
+    provenance.setdefault(
+        "source_kind", "fixture" if value_status == "proxy-placeholder" else "staged"
+    )
+    provenance.setdefault("raw_trajectory_storage", "not_stored_in_git")
+    provenance.setdefault("claim_boundary", PRIOR_EXTRACTION_EVIDENCE_BOUNDARY)
+    return provenance

--- a/scripts/tools/extract_pedestrian_prior.py
+++ b/scripts/tools/extract_pedestrian_prior.py
@@ -1,0 +1,65 @@
+"""Extract compact pedestrian-prior summaries from a local trajectory fixture.
+
+This issue #2918 helper is CPU/local only. It reads an already-available
+fixture or staged local file, writes bounded summaries, and never stores raw
+trajectory samples in the output report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.pedestrian_prior_extraction import (
+    PedestrianPriorExtractionError,
+    extract_pedestrian_prior_report_from_file,
+    write_pedestrian_prior_extraction_report,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input", required=True, type=Path, help="Local trajectory YAML/JSON input."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path for deterministic compact JSON report.",
+    )
+    parser.add_argument(
+        "--value-status",
+        choices=("proxy-placeholder", "dataset-backed"),
+        default="proxy-placeholder",
+        help=(
+            "Status stamped on extracted values. Use dataset-backed only after separate "
+            "license-compatible staging and manifest admission."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run extraction CLI and return a process exit code."""
+
+    args = _parse_args(argv)
+    try:
+        report = extract_pedestrian_prior_report_from_file(
+            args.input,
+            value_status=args.value_status,
+        )
+    except PedestrianPriorExtractionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    payload = report.to_dict()
+    if args.output:
+        write_pedestrian_prior_extraction_report(report, args.output)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/benchmark/fixtures/issue_2918_pedestrian_prior_fixture.yaml
+++ b/tests/benchmark/fixtures/issue_2918_pedestrian_prior_fixture.yaml
@@ -1,0 +1,35 @@
+schema_version: pedestrian_prior_fixture.v1
+source_id: issue_2918_proxy_fixture
+bounds:
+  min_x: 0.0
+  max_x: 10.0
+  min_y: 0.0
+  max_y: 10.0
+provenance:
+  source_kind: fixture
+  license: repository-test-fixture
+observations:
+  - pedestrian_id: p1
+    time: 0.0
+    x: 0.0
+    y: 0.0
+  - pedestrian_id: p1
+    time: 1.0
+    x: 1.0
+    y: 0.0
+  - pedestrian_id: p1
+    time: 2.0
+    x: 1.0
+    y: 0.0
+  - pedestrian_id: p2
+    time: 0.0
+    x: 0.0
+    y: 2.0
+  - pedestrian_id: p2
+    time: 1.0
+    x: 0.0
+    y: 3.0
+  - pedestrian_id: p2
+    time: 2.0
+    x: 0.0
+    y: 4.0

--- a/tests/benchmark/test_issue_2918_pedestrian_prior_extraction.py
+++ b/tests/benchmark/test_issue_2918_pedestrian_prior_extraction.py
@@ -1,0 +1,120 @@
+"""Tests fixture/local pedestrian-prior extraction pipeline for issue #2918."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.pedestrian_prior_extraction import (
+    PEDESTRIAN_PRIOR_EXTRACTION_REPORT_SCHEMA_VERSION,
+    PedestrianPriorExtractionError,
+    extract_pedestrian_prior_report,
+    extract_pedestrian_prior_report_from_file,
+    write_pedestrian_prior_extraction_report,
+)
+from robot_sf.benchmark.pedestrian_prior_extraction_manifest import (
+    PRIOR_EXTRACTION_EVIDENCE_BOUNDARY,
+    REQUIRED_PRIOR_PARAMETERS,
+)
+from scripts.tools.extract_pedestrian_prior import main as extract_cli_main
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent / "fixtures" / "issue_2918_pedestrian_prior_fixture.yaml"
+)
+
+
+def _summary_by_name(report) -> dict:
+    return {summary.name: summary for summary in report.parameter_summaries}
+
+
+def test_fixture_extraction_emits_all_required_prior_parameters() -> None:
+    """A local fixture produces bounded summaries for every issue #2918 parameter."""
+
+    report = extract_pedestrian_prior_report_from_file(FIXTURE_PATH)
+    summaries = _summary_by_name(report)
+
+    assert report.schema_version == PEDESTRIAN_PRIOR_EXTRACTION_REPORT_SCHEMA_VERSION
+    assert report.source_id == "issue_2918_proxy_fixture"
+    assert report.value_status == "proxy-placeholder"
+    assert report.evidence_boundary == PRIOR_EXTRACTION_EVIDENCE_BOUNDARY
+    assert tuple(summaries) == REQUIRED_PRIOR_PARAMETERS
+    assert summaries["walking_speed"].minimum == 0.0
+    assert summaries["walking_speed"].maximum == 1.0
+    assert summaries["walking_speed"].mean == 0.75
+    assert summaries["density"].minimum == 0.02
+    assert summaries["density"].maximum == 0.02
+    assert summaries["interaction_distance"].minimum == 2.0
+    assert summaries["stop_yield_timing"].maximum == 1.0
+    assert all(summary.value_status == "proxy-placeholder" for summary in summaries.values())
+
+
+def test_report_serialization_excludes_raw_observations(tmp_path: Path) -> None:
+    """Output report stores compact summaries and provenance, not raw trajectories."""
+
+    report = extract_pedestrian_prior_report_from_file(FIXTURE_PATH)
+    output_path = tmp_path / "prior_report.json"
+
+    write_pedestrian_prior_extraction_report(report, output_path)
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert "observations" not in payload
+    assert "parameter_summaries" in payload
+    assert payload["provenance"]["raw_trajectory_storage"] == "not_stored_in_git"
+
+
+def test_cli_writes_report_and_prints_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI supports fixture smoke extraction without campaigns or external data downloads."""
+
+    output_path = tmp_path / "report.json"
+
+    exit_code = extract_cli_main(["--input", str(FIXTURE_PATH), "--output", str(output_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert output_path.is_file()
+    assert json.loads(captured.out)["source_id"] == "issue_2918_proxy_fixture"
+
+
+def test_dataset_backed_status_is_only_a_stamp_not_manifest_admission() -> None:
+    """Extraction can stamp staged values but does not bypass the manifest gate."""
+
+    report = extract_pedestrian_prior_report_from_file(FIXTURE_PATH, value_status="dataset-backed")
+
+    assert report.value_status == "dataset-backed"
+    assert report.evidence_boundary == PRIOR_EXTRACTION_EVIDENCE_BOUNDARY
+    assert report.provenance["claim_boundary"] == PRIOR_EXTRACTION_EVIDENCE_BOUNDARY
+
+
+def test_missing_density_bounds_fail_closed() -> None:
+    """Density is a required issue #2918 parameter, so missing bounds fail closed."""
+
+    with pytest.raises(PedestrianPriorExtractionError, match="bounds are required"):
+        extract_pedestrian_prior_report(
+            {
+                "source_id": "missing_bounds",
+                "observations": [
+                    {"pedestrian_id": "p1", "time": 0.0, "x": 0.0, "y": 0.0},
+                    {"pedestrian_id": "p1", "time": 1.0, "x": 1.0, "y": 0.0},
+                ],
+            }
+        )
+
+
+def test_single_pedestrian_fixture_fails_interaction_distance_closed() -> None:
+    """Interaction-distance extraction requires at least one two-pedestrian frame."""
+
+    with pytest.raises(PedestrianPriorExtractionError, match="two pedestrians"):
+        extract_pedestrian_prior_report(
+            {
+                "source_id": "single_pedestrian",
+                "bounds": {"min_x": 0, "max_x": 10, "min_y": 0, "max_y": 10},
+                "observations": [
+                    {"pedestrian_id": "p1", "time": 0.0, "x": 0.0, "y": 0.0},
+                    {"pedestrian_id": "p1", "time": 1.0, "x": 1.0, "y": 0.0},
+                ],
+            }
+        )


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a new #2918 **fixture/local pedestrian-prior extraction pipeline** that reads already-available trajectory records and emits compact bounded summaries for walking speed, crossing angle, density, interaction distance, and stop/yield timing. It also adds a CPU-only CLI smoke path and focused tests.

Why now: merged PR #3754 already supplied the manifest/preflight checker, but the issue body still names an executable fixture extraction slice. The live issue comments keep real dataset-backed SDD extraction blocked on user-supplied/license-compatible staging (#3065/#2657), so this PR advances only the local extraction capability without ingesting external data.

Claim boundary: extraction logic and fixture smoke only. Output reports carry `prior_extraction_plan_only_no_calibrated_prior_claim`, store no raw trajectories, and do not admit dataset-backed claims; admission remains controlled by the existing manifest/preflight contract.

Required validation: focused unit tests, CLI CPU smoke, lint/format, final `pr_ready_check`.

Remaining blocker: one real dataset-backed prior smoke still requires staged license-compatible external data. No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Contract delta

- New report schema string: `pedestrian_prior_extraction_report.v1`.
- New extraction API: `robot_sf.benchmark.pedestrian_prior_extraction.extract_pedestrian_prior_report*`.
- New CLI: `scripts/tools/extract_pedestrian_prior.py --input <fixture-or-staged-local-yaml> [--output report.json]`.
- New fail-closed blockers: missing/non-positive density bounds, invalid observations, non-increasing track time, missing two-point tracks, and missing two-pedestrian frames for interaction distance.
- Compatibility impact: additive only; existing manifest checker and dataset-backed admission behavior are unchanged.

<details>
<summary>PR details</summary>

## Linked issue

- Addresses a new fixture-extraction capability slice of https://github.com/ll7/robot_sf_ll7/issues/2918
- Prior merged slice: #3754 added the staging/preflight manifest checker.

## Scope summary

- Added compact extractor for the five issue-scoped prior parameters.
- Added deterministic JSON report writer that excludes raw `observations`.
- Added fixture and tests covering successful extraction, CLI smoke, serialization boundary, dataset-backed status boundary, and fail-closed missing inputs.

## Validation

- `uv run pytest tests/benchmark/test_issue_2918_pedestrian_prior_extraction.py tests/benchmark/test_issue_2918_pedestrian_prior_extraction_manifest.py -q` -> passed, 23 passed.
- `uv run ruff check robot_sf/benchmark/pedestrian_prior_extraction.py scripts/tools/extract_pedestrian_prior.py tests/benchmark/test_issue_2918_pedestrian_prior_extraction.py` -> passed.
- `uv run ruff format --check robot_sf/benchmark/pedestrian_prior_extraction.py scripts/tools/extract_pedestrian_prior.py tests/benchmark/test_issue_2918_pedestrian_prior_extraction.py` -> passed.
- `uv run python scripts/tools/extract_pedestrian_prior.py --input tests/benchmark/fixtures/issue_2918_pedestrian_prior_fixture.yaml --output output/issue_2918_prior_fixture_report.json` -> passed; output is ignored/disposable local smoke artifact.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue_2918/pr_body.md scripts/dev/pr_ready_check.sh` -> passed; clean-head stamp `output/validation/pr_ready/issue-2918-backfill-admitted-data-pilot-external-pedestrian-prior-extraction-after.json`.

## Out of scope

- No external data downloaded, ingested, staged, or committed.
- No raw trajectories stored in git.
- No calibrated/representative/dataset-backed pedestrian-prior claim.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream propagation

No issue comment added because the run authorization has `comment_issue_or_pr: false`. This PR body is the durable propagation surface for the delivered slice and remaining external-data blocker.

## Artifact handling

`output/issue_2918_prior_fixture_report.json` was generated only as an ignored local CLI-smoke artifact and is not durable evidence.

</details>
