### PR TITLE
Issue #4539: reject non-repo release claim matrix paths

### DIFF
--- a/scripts/validation/check_release_claim_matrix_publication_gate.py
+++ b/scripts/validation/check_release_claim_matrix_publication_gate.py
@@ -75,7 +75,10 @@ def _repo_relative_file_exists(repo_root: Path, value: object) -> bool:
     if not isinstance(value, str) or not value:
         return False
     path = Path(value)
-    if path.is_absolute() or ".." in path.parts or path.parts[0] == "output":
+    # ``Path(".").parts`` is empty, so guard the index before the ``output`` check
+    # to keep pathological values (for example ``"."``) fail-closed instead of
+    # raising ``IndexError`` inside the publication gate.
+    if path.is_absolute() or ".." in path.parts or (path.parts and path.parts[0] == "output"):
         return False
     return (repo_root / path).is_file()
 

--- a/scripts/validation/check_release_claim_matrix_publication_gate.py
+++ b/scripts/validation/check_release_claim_matrix_publication_gate.py
@@ -69,12 +69,15 @@ def _row_id(row: dict[str, Any], index: int) -> str:
     return str(row.get("row_id") or f"row:{index:03d}")
 
 
-def _path_exists(repo_root: Path, value: object) -> bool:
-    """Return whether a repository-relative file path exists."""
+def _repo_relative_file_exists(repo_root: Path, value: object) -> bool:
+    """Return whether ``value`` is a repository-relative regular file."""
 
-    if not isinstance(value, str) or not value or value.startswith("output/"):
+    if not isinstance(value, str) or not value:
         return False
-    return (repo_root / value).is_file()
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts or path.parts[0] == "output":
+        return False
+    return (repo_root / path).is_file()
 
 
 def _check_benchmark_evidence_row(
@@ -106,13 +109,13 @@ def _check_benchmark_evidence_row(
                 next_action="Refresh the release evidence snapshot or exclude the row.",
             )
         )
-    if not _path_exists(repo_root, row.get("artifact_uri")):
+    if not _repo_relative_file_exists(repo_root, row.get("artifact_uri")):
         blockers.append(
             GateBlocker(
                 row_id=row_id,
                 check="artifact_uri",
                 severity="blocker",
-                reason="artifact_uri is missing, non-file, or points under output/",
+                reason="artifact_uri is missing, non-file, absolute, escaping, or under output/",
                 next_action="Promote a durable artifact pointer before publication.",
             )
         )
@@ -138,7 +141,7 @@ def _check_benchmark_evidence_row(
                 next_action="Record tracked provenance sources for the row.",
             )
         )
-    elif any(not _path_exists(repo_root, source_ref) for source_ref in source_refs):
+    elif any(not _repo_relative_file_exists(repo_root, source_ref) for source_ref in source_refs):
         blockers.append(
             GateBlocker(
                 row_id=row_id,

--- a/tests/validation/test_check_release_claim_matrix_publication_gate.py
+++ b/tests/validation/test_check_release_claim_matrix_publication_gate.py
@@ -140,6 +140,33 @@ def test_gate_rejects_source_refs_with_parent_directory_components(tmp_path) -> 
     assert [blocker["check"] for blocker in report["blockers"]] == ["source_refs"]
 
 
+def test_gate_fails_closed_for_dot_artifact_uri_without_crashing(tmp_path) -> None:
+    """A ``"."`` path must block rather than raise ``IndexError`` on empty parts."""
+
+    source = tmp_path / "source.json"
+    source.write_text("{}", encoding="utf-8")
+
+    report = build_gate_report(
+        _matrix(
+            [
+                {
+                    "row_id": "release_artifact:dot-path",
+                    "classification": "benchmark evidence",
+                    "availability_status": "available",
+                    "artifact_match": True,
+                    "artifact_uri": ".",
+                    "scenario_certification": "accepted",
+                    "source_refs": ["source.json"],
+                }
+            ]
+        ),
+        repo_root=tmp_path,
+    )
+
+    assert report["status"] == "blocked"
+    assert [blocker["check"] for blocker in report["blockers"]] == ["artifact_uri"]
+
+
 def test_gate_rejects_non_benchmark_success_promotion(tmp_path) -> None:
     """Diagnostic and non-claim rows must not set benchmark_success true."""
 

--- a/tests/validation/test_check_release_claim_matrix_publication_gate.py
+++ b/tests/validation/test_check_release_claim_matrix_publication_gate.py
@@ -80,6 +80,66 @@ def test_gate_fails_closed_for_missing_certification_and_output_artifact(tmp_pat
     assert checks == {"artifact_uri", "scenario_certification"}
 
 
+def test_gate_rejects_absolute_artifact_uri_even_when_file_exists(tmp_path) -> None:
+    """Benchmark artifacts must be repo-relative durable files."""
+
+    artifact = tmp_path / "absolute-artifact.json"
+    source = tmp_path / "docs" / "context" / "source.json"
+    artifact.write_text("{}", encoding="utf-8")
+    source.parent.mkdir(parents=True)
+    source.write_text("{}", encoding="utf-8")
+
+    report = build_gate_report(
+        _matrix(
+            [
+                {
+                    "row_id": "release_artifact:absolute",
+                    "classification": "benchmark evidence",
+                    "availability_status": "available",
+                    "artifact_match": True,
+                    "artifact_uri": str(artifact),
+                    "scenario_certification": "accepted",
+                    "source_refs": ["docs/context/source.json"],
+                }
+            ]
+        ),
+        repo_root=tmp_path,
+    )
+
+    assert report["status"] == "blocked"
+    assert [blocker["check"] for blocker in report["blockers"]] == ["artifact_uri"]
+
+
+def test_gate_rejects_source_refs_with_parent_directory_components(tmp_path) -> None:
+    """Source refs must not escape or normalize around the repository contract."""
+
+    artifact = tmp_path / "docs" / "context" / "evidence" / "artifact.json"
+    source = tmp_path / "source.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("{}", encoding="utf-8")
+    source.write_text("{}", encoding="utf-8")
+
+    report = build_gate_report(
+        _matrix(
+            [
+                {
+                    "row_id": "release_artifact:traversal-source",
+                    "classification": "benchmark evidence",
+                    "availability_status": "available",
+                    "artifact_match": True,
+                    "artifact_uri": "docs/context/evidence/artifact.json",
+                    "scenario_certification": "accepted",
+                    "source_refs": ["docs/../source.json"],
+                }
+            ]
+        ),
+        repo_root=tmp_path,
+    )
+
+    assert report["status"] == "blocked"
+    assert [blocker["check"] for blocker in report["blockers"]] == ["source_refs"]
+
+
 def test_gate_rejects_non_benchmark_success_promotion(tmp_path) -> None:
     """Diagnostic and non-claim rows must not set benchmark_success true."""
 


### PR DESCRIPTION
Reviewer-critical summary

What changed: hardens `scripts/validation/check_release_claim_matrix_publication_gate.py` so `artifact_uri` and `source_refs` must be existing repository-relative regular files. Absolute paths, `..` traversal components, missing paths, and `output/...` paths now fail closed.

Why now: closure audit for #4539 found that merged PR #4544 already covered the unknown-classification criterion, while the path-hardening criterion from the maintainer implementation plan remained open. This PR is a progression slice, not another packet refresh: it adds the named path-contract capability for release claim matrix publication checks.

Claim boundary: CPU-only validation hardening over the existing tracked release claim matrix only. No benchmark campaign, Slurm/GPU submission, release action, certification ratification, or paper/dissertation claim edit.

Required validation: focused Ruff, focused validation tests, committed-matrix gate check, and repository PR readiness wrapper.

Remaining blocker: the positive `scenario_cert.v1` accepted vocabulary is still deferred because the issue thread explicitly says not to guess it silently before maintainer confirmation.

Contract delta

- New fail-closed path contract: release claim matrix `artifact_uri` and `source_refs` must be repository-relative regular files under the supplied `repo_root`.
- New rejected path classes: absolute paths, paths containing `..`, paths under `output/`, empty/non-string values, and non-files.
- Existing JSON report schema remains stable; new failures still use existing blocker checks `artifact_uri` and `source_refs`.
- Compatibility impact: existing durable repo-relative file paths continue to pass; local output paths and path escapes are blocked intentionally.

Issue: closes part of https://github.com/ll7/robot_sf_ll7/issues/4539

Scope summary

- Renamed `_path_exists` to `_repo_relative_file_exists` to match the stricter contract.
- Added regression coverage for an absolute `artifact_uri` that points to an existing file.
- Added regression coverage for a `source_refs` path with a parent-directory component that resolves to an existing file.

Acceptance evidence

| #4539 criterion | Evidence |
| --- | --- |
| Unrecognized `classification` values fail closed | Already merged in #4544 (`Issue #4539: fail closed on unknown classification labels`). Current tests include `test_gate_fails_closed_for_unknown_classification`. |
| Scenario certification requires positive accepted value | Not implemented here. The issue comment says to defer if the exact `scenario_cert.v1` accepted vocabulary is not ratified and to avoid guessing silently. |
| Absolute non-repo-relative artifact/source paths rejected | Implemented here via `_repo_relative_file_exists`; covered by `test_gate_rejects_absolute_artifact_uri_even_when_file_exists` and `test_gate_rejects_source_refs_with_parent_directory_components`. |
| Tests cover latent fail-open paths | Focused tests cover unknown classification via #4544 and path hardening in this PR. Certification remains explicitly deferred pending vocabulary confirmation. |
| Current committed release claim matrix remains blocked; no publication or claim state changes | `uv run python scripts/validation/check_release_claim_matrix_publication_gate.py --json` returns `status=blocked`, `blockers=3`, `gate_exit=1` as expected. |

Validation

- `uv run ruff check scripts/validation/check_release_claim_matrix_publication_gate.py tests/validation/test_check_release_claim_matrix_publication_gate.py` -> passed.
- `uv run pytest tests/validation/test_check_release_claim_matrix_publication_gate.py -q` -> passed, 8 tests.
- `uv run python scripts/validation/check_release_claim_matrix_publication_gate.py --json` -> expected blocked gate: `status=blocked`, `blockers=3`, `gate_exit=1`.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue4539_pr_body.md scripts/dev/pr_ready_check.sh` -> passed; stamp `output/validation/pr_ready/issue-4539-closure-audit-verify-acceptance-criteria-of-4539-against-merged-prs-clos.json` recorded `status=passed`, clean tree.

Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no release action, and no scenario-certification vocabulary ratification.

Downstream propagation

No separate issue comment/state update is included because this lane has `comment_issue_or_pr=false`; this PR body is the durable state surface for the delivered slice and residual checklist.

<details>
<summary>Closure audit notes</summary>

Live issue thread read via REST API because `gh issue view --comments` failed on GitHub classic Projects GraphQL deprecation. Timeline references PR #4536, issue #2910, commit `fedf6cf8a0df`, and the maintainer implementation-plan comment from 2026-07-05T01:01:15Z.

Merged PRs considered:

- #4536 `validation: gate release claim matrix publication (#2910)` established the publication gate and tests.
- #4544 `Issue #4539: fail closed on unknown classification labels (cheap-lane worker)` implemented the unknown-classification fail-closed criterion.

Fragmentation guard: two related PRs merged in the last 24h, but this PR is exempt as a progression slice adding the named path-contract capability from the implementation plan.

</details>
