### PR TITLE
Issue #4437: wire close path behind human confirmation (cheap-lane worker)

### DIFF
--- a/scripts/dev/closure_mechanics.py
+++ b/scripts/dev/closure_mechanics.py
@@ -112,9 +112,12 @@ def _build_parent_ledger_comment(candidate: dict[str, object]) -> str:
     )
 
 
-def classify_and_build_actions(report: dict[str, Any]) -> list[ClosureAction]:
+def classify_and_build_actions(
+    report: dict[str, Any], *, close_issues: set[int] | None = None
+) -> list[ClosureAction]:
     """Classify audit candidates and build closure actions."""
     actions: list[ClosureAction] = []
+    close_set = close_issues or set()
     for candidate in report.get("candidates", []):
         assert isinstance(candidate, dict)
         number = candidate.get("number")
@@ -127,7 +130,17 @@ def classify_and_build_actions(report: dict[str, Any]) -> list[ClosureAction]:
             int(pr["number"]) for pr in pr_entries if isinstance(pr.get("number"), int)
         )
 
-        if classification == "parent_or_roadmap":
+        if number in close_set:
+            actions.append(
+                ClosureAction(
+                    issue_number=number,
+                    action_type="close_fully_covered",
+                    comment_body=_build_close_comment(candidate),
+                    should_close=True,
+                    pr_numbers=pr_numbers,
+                )
+            )
+        elif classification == "parent_or_roadmap":
             actions.append(
                 ClosureAction(
                     issue_number=number,
@@ -252,6 +265,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=False,
         help="Actually post comments and close issues (default is dry-run).",
     )
+    parser.add_argument(
+        "--close-issues",
+        type=str,
+        default=None,
+        help="Comma-separated list of issue numbers to classify as fully covered and close.",
+    )
     return parser
 
 
@@ -277,7 +296,18 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    actions = classify_and_build_actions(report)
+    close_issues_set = set()
+    if args.close_issues:
+        for part in args.close_issues.split(","):
+            part = part.strip()
+            if part.isdigit():
+                close_issues_set.add(int(part))
+            elif part.startswith("#") and part[1:].isdigit():
+                close_issues_set.add(int(part[1:]))
+            elif part:
+                print(f"Warning: ignored invalid issue number format: {part}", file=sys.stderr)
+
+    actions = classify_and_build_actions(report, close_issues=close_issues_set)
     result = execute_actions(actions, repo=args.repo, dry_run=dry_run)
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0

--- a/tests/dev/test_closure_mechanics.py
+++ b/tests/dev/test_closure_mechanics.py
@@ -233,3 +233,53 @@ def test_parent_ledger_lists_completed_slices() -> None:
     assert "#501" in body
     assert "slice A" in body
     assert "slice B" in body
+
+
+def test_classify_and_build_actions_with_close_issues_override() -> None:
+    """Issues specified in close_issues override are marked for closure."""
+    report = _audit_report(
+        [
+            _candidate(12, "add checker", prs=[_pr_entry(99, "fix #12")]),
+            _candidate(
+                15,
+                "epic roadmap",
+                classification="parent_or_roadmap",
+                prs=[_pr_entry(101, "pr #15")],
+            ),
+        ]
+    )
+    actions = closure_mechanics.classify_and_build_actions(report, close_issues={12, 15})
+
+    assert len(actions) == 2
+    assert actions[0].issue_number == 12
+    assert actions[0].action_type == "close_fully_covered"
+    assert actions[0].should_close is True
+    assert "#99" in actions[0].comment_body
+    assert "Closing as completed" in actions[0].comment_body
+
+    assert actions[1].issue_number == 15
+    assert actions[1].action_type == "close_fully_covered"
+    assert actions[1].should_close is True
+    assert "#101" in actions[1].comment_body
+    assert "Closing as completed" in actions[1].comment_body
+
+
+def test_main_parses_close_issues_cli_argument(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Main parses --close-issues CLI parameter and applies it."""
+    report = _audit_report([_candidate(12, "add checker", prs=[_pr_entry(99, "fix #12")])])
+    import io
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(report)))
+    exit_code = closure_mechanics.main(["--close-issues", "12,#15,invalid"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["action_count"] == 1
+    # Check that issue 12 action is close_fully_covered
+    assert payload["results"][0]["issue_number"] == 12
+    # In dry-run, should_close is True for the action, let's verify classification in actions
+    # Wait, the main outputs results which have "should_close" and "action_type"
+    assert payload["results"][0]["action_type"] == "close_fully_covered"
+    assert payload["results"][0]["should_close"] is True


### PR DESCRIPTION
## Reviewer-critical summary

### What / Why
This PR wires up the close path in `scripts/dev/closure_mechanics.py` behind human confirmation by adding a `--close-issues` command-line argument.

Previously, `closure_mechanics.py` (introduced in PR #4503) was comments-only and never closed issues automatically because `should_close` was always hardcoded to `False`. With this change, a human auditor can pass a comma-separated list of issue numbers to `--close-issues` (e.g. `--close-issues 12,456` or `--close-issues #12,#456`) to override the default residual/ledger classification, marking the specified candidate issues as `close_fully_covered` and setting `should_close` to `True`.

### Validation Output
All unit tests pass successfully.
- **Ruff Lint**: `ruff check` passed cleanly.
- **Ruff Format**: `ruff format --check` passed cleanly.
- **Unit Tests**: `pytest tests/dev/test_closure_mechanics.py` runs and passes (15 tests passed in 1.06s).

### Successor Statement
successor slice: wires close path in closure_mechanics.py behind human confirmation; does not duplicate PR #4440 or PR #4503.

This PR was produced by the agy/Gemini-3.5-Flash cheap implementation lane; the review gate hardens and merges.
