### PR TITLE
Issue #4546: settle SocNavBench ETH SVG artifact policy

### DIFF
--- a/docs/socnav_assets_setup.md
+++ b/docs/socnav_assets_setup.md
@@ -210,6 +210,19 @@ The wrapper composes the same license-safe asset registry, ETH traversible gener
 and Robot SF SVG parser smoke check. Missing licensed source assets fail closed with exit `2` and a
 JSON report; the command never downloads data or writes placeholder maps.
 
+Derived SVG artifact policy for issue #4546:
+
+- Commit `maps/svg_maps/socnavbench/socnavbench_eth.svg` only after the wrapper succeeds on the
+  official/user-supplied ETH source data and the report records both input `data.pkl` SHA-256 and
+  output SVG SHA-256.
+- Record the conversion report or a compact evidence note under `docs/context/evidence/` so reviewers
+  can verify the source hash, output hash, parser smoke result, and command used to regenerate the
+  SVG.
+- Do not commit placeholder, dry-run, or fixture-generated SVG output. Until official source data is
+  staged and smoke validation is green, the derived SVG remains absent and issue #4546 stays blocked.
+- Regenerate and review the committed SVG whenever the official traversible hash, converter settings,
+  or SVG parser contract changes.
+
 ## Licensing and Repository Hygiene
 
 - Do not commit downloaded dataset assets.


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Adds the missing issue #4546 runbook decision for `maps/svg_maps/socnavbench/socnavbench_eth.svg`: commit the derived SVG only after the official/user-supplied ETH data path succeeds, records input/output SHA-256, and passes parser smoke validation.

Why now: Closure audit found PR #4553 delivered the fail-closed stage/generate/convert/smoke wrapper, but the maintainer gate explicitly left the commit-vs-regenerate artifact-policy decision open.

Claim boundary: Docs-only policy slice. This does not stage real SocNavBench/S3DIS assets, generate the real SVG, or promote benchmark/paper evidence.

Required validation: Diff inspection plus lightweight docs proof/evidence checks.

Remaining blocker: Official/user-supplied ETH source data is still license-gated; real converter run, source/output SHA-256 evidence, and final generated SVG commit remain blocked by #1498 / #334.

## Contract delta

New schema fields: None.

New fail-closed blockers: None in code. The runbook now explicitly blocks committing placeholder, dry-run, or fixture-generated SVG output.

Compatibility impact: Documentation only. Existing wrapper/converter CLIs and absent-source fail-closed behavior are unchanged.

Issue: Refs #4546

## Scope summary

- Audited #4546 acceptance criteria against merged PR #4553 and maintainer gate comments.
- Implemented the smallest remaining unblocked criterion: explicit generated SVG artifact policy.
- Left license-gated real-data staging and SHA-256 evidence out of scope.

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Official/user-supplied ETH traversible staged outside git | Not met; issue comment `#issuecomment-4884404525` says real official-asset staging remains open and blocked on #1498 / #334. |
| Converter run succeeds with input/output hashes | Not met for real data; PR #4553 only provides fixture smoke tooling and missing-asset fail-closed behavior. |
| Generated SVG parser + map smoke validation green | Not met for real data; PR #4553 validates the wrapper on fixture data only. |
| Runbook states whether SVG is committed or regenerated on demand | Met by this PR: commit the derived SVG only after official source success, recorded input/output hashes, and smoke validation; never commit placeholder/dry-run/fixture output. |
| Public absent-source behavior remains fail-closed / skip-if-absent | Met by PR #4553 wrapper and tests; unchanged by this PR. |
| No raw licensed SocNavBench/S3DIS data committed | Met by PR #4553 and this docs-only PR; no raw or generated data files are added. |

## Validation

- `git diff --check` - passed.
- `scripts/dev/check_docs_proof_consistency_diff.sh` - passed, `OK docs/proof consistency check passed 1 changed file(s).`
- `uv run python scripts/dev/check_docs_evidence_integrity.py --files docs/socnav_assets_setup.md` - passed, `docs/evidence integrity: 1 changed file(s) passed.`

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no raw SocNavBench/S3DIS data download, no generated traversible pickle, and no generated real SVG.

## State propagation

No issue comment was added because this task authorization sets `comment_issue_or_pr: false`. This PR body is the durable handoff surface for the delivered policy slice and remaining checklist.

<details>
<summary>Governance appendix</summary>

- Fragmentation guard: only one #4546 PR (#4553) merged in the last 24 hours, so the two-PR micro-guard threshold is not met.
- New capability/contract: the runbook now has a concrete artifact policy for the generated SocNavBench ETH SVG.
- Late issue guidance: final `gh issue view 4546 --repo ll7/robot_sf_ll7 --comments` immediately before opening found no comments newer than this run's start time (`2026-07-05T04:05:39Z`).
- Full `pr_ready_check.sh` was not run because this is a low-risk docs-only policy clarification; the lightweight docs checks above match the AGENTS.md validation matrix.

</details>
