### PR TITLE
Issue #4014: emit PPO parameter metadata

### DIFF
--- a/scripts/training/train_ppo.py
+++ b/scripts/training/train_ppo.py
@@ -829,6 +829,42 @@ class TrainingOutputs:
     per_checkpoint_perf: list[dict[str, float | int]]
 
 
+def _count_parameters(module: object, *, trainable_only: bool) -> int | None:
+    """Count parameters exposed by a PyTorch-style module."""
+    parameters_fn = getattr(module, "parameters", None)
+    if not callable(parameters_fn):
+        return None
+    total = 0
+    for parameter in parameters_fn():
+        if trainable_only and not bool(getattr(parameter, "requires_grad", False)):
+            continue
+        numel_fn = getattr(parameter, "numel", None)
+        if not callable(numel_fn):
+            continue
+        total += int(numel_fn())
+    return total
+
+
+def _model_parameter_summary(model: object | None) -> dict[str, int | bool | None]:
+    """Return policy/model parameter counts for training comparison reports."""
+    if model is None:
+        return {
+            "available": False,
+            "policy_parameter_count": None,
+            "policy_trainable_parameter_count": None,
+            "model_parameter_count": None,
+            "model_trainable_parameter_count": None,
+        }
+    policy = getattr(model, "policy", None)
+    return {
+        "available": True,
+        "policy_parameter_count": _count_parameters(policy, trainable_only=False),
+        "policy_trainable_parameter_count": _count_parameters(policy, trainable_only=True),
+        "model_parameter_count": _count_parameters(model, trainable_only=False),
+        "model_trainable_parameter_count": _count_parameters(model, trainable_only=True),
+    }
+
+
 def _resolve_optional_path(path: Path, raw: object, *, field_name: str) -> Path | None:
     """Resolve an optional path field relative to the config file location."""
     if raw is None:
@@ -2029,6 +2065,7 @@ def _write_perf_summary(
     startup_sec: float,
     per_checkpoint_perf: Sequence[Mapping[str, float | int]],
     total_wall_clock_sec: float,
+    parameter_summary: Mapping[str, int | bool | None] | None = None,
 ) -> Path:
     """Write machine-readable performance summary for the training run."""
     perf_dir = get_imitation_report_dir() / "perf"
@@ -2042,6 +2079,9 @@ def _write_perf_summary(
         "total_wall_clock_sec": float(total_wall_clock_sec),
         "train_env_steps_per_sec_mean": float(np.mean(train_speeds)) if train_speeds else 0.0,
         "eval_sec_per_checkpoint": float(np.mean(eval_secs)) if eval_secs else 0.0,
+        "parameter_summary": dict(
+            parameter_summary if parameter_summary is not None else _model_parameter_summary(None)
+        ),
         "per_checkpoint_perf": list(per_checkpoint_perf),
     }
     json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -2891,6 +2931,10 @@ def _build_training_notes(
             )
         )
         notes.append(f"train_env_steps_per_sec_mean={mean_train_speed:.3f}")
+    parameter_summary = _model_parameter_summary(outputs.model)
+    policy_parameter_count = parameter_summary.get("policy_parameter_count")
+    if policy_parameter_count is not None:
+        notes.append(f"policy_parameter_count={policy_parameter_count}")
     if scenario_coverage:
         notes.append(f"scenario_coverage={scenario_coverage}")
     density_curriculum = build_density_curriculum_schedule(config.density_curriculum)
@@ -3067,6 +3111,7 @@ def run_expert_training(
         startup_sec=outputs.startup_sec,
         per_checkpoint_perf=outputs.per_checkpoint_perf,
         total_wall_clock_sec=wall_clock_seconds,
+        parameter_summary=_model_parameter_summary(outputs.model),
     )
     wall_clock_hours = wall_clock_seconds / 3600.0
     input_artifacts = [str(config.scenario_config)]

--- a/tests/training/test_train_expert_ppo_contract.py
+++ b/tests/training/test_train_expert_ppo_contract.py
@@ -457,6 +457,13 @@ def test_write_perf_summary_writes_expected_keys(tmp_path: Path, monkeypatch) ->
             }
         ],
         total_wall_clock_sec=12.0,
+        parameter_summary={
+            "available": True,
+            "policy_parameter_count": 1234,
+            "policy_trainable_parameter_count": 1200,
+            "model_parameter_count": None,
+            "model_trainable_parameter_count": None,
+        },
     )
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload["run_id"] == "demo_run"
@@ -464,6 +471,43 @@ def test_write_perf_summary_writes_expected_keys(tmp_path: Path, monkeypatch) ->
     assert payload["total_wall_clock_sec"] == 12.0
     assert payload["train_env_steps_per_sec_mean"] == 100.0
     assert payload["eval_sec_per_checkpoint"] == 3.0
+    assert payload["parameter_summary"] == {
+        "available": True,
+        "policy_parameter_count": 1234,
+        "policy_trainable_parameter_count": 1200,
+        "model_parameter_count": None,
+        "model_trainable_parameter_count": None,
+    }
+
+
+def test_model_parameter_summary_counts_policy_parameters() -> None:
+    """Parameter summary should count total and trainable policy parameters."""
+
+    class _Parameter:
+        def __init__(self, count: int, *, requires_grad: bool) -> None:
+            self._count = count
+            self.requires_grad = requires_grad
+
+        def numel(self) -> int:
+            return self._count
+
+    class _Policy:
+        def parameters(self) -> list[_Parameter]:
+            return [
+                _Parameter(3, requires_grad=True),
+                _Parameter(5, requires_grad=False),
+            ]
+
+    class _Model:
+        policy = _Policy()
+
+    assert train_ppo._model_parameter_summary(_Model()) == {
+        "available": True,
+        "policy_parameter_count": 8,
+        "policy_trainable_parameter_count": 3,
+        "model_parameter_count": None,
+        "model_trainable_parameter_count": None,
+    }
 
 
 def _capture_evaluate_policy_info_logs(monkeypatch, tmp_path: Path, *, episodes: int) -> list[str]:

--- a/tests/training/test_train_ppo_mamba_config_issue_4014.py
+++ b/tests/training/test_train_ppo_mamba_config_issue_4014.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 from robot_sf.feature_extractors.mamba_extractor import MambaFeatureExtractor
@@ -42,3 +46,39 @@ def test_ppo_policy_selection_routes_mamba_extractor() -> None:
     assert policy_kwargs["features_extractor_class"] is MambaFeatureExtractor
     assert policy_kwargs["features_extractor_kwargs"] == config.feature_extractor_kwargs
     assert critic_profile == "standard"
+
+
+def test_ppo_mamba_dry_run_emits_parameter_summary_placeholder(tmp_path: Path) -> None:
+    """Dry-run PPO-Mamba perf summary records the parameter-count contract."""
+    env = {
+        **os.environ,
+        "ROBOT_SF_ARTIFACT_ROOT": str(tmp_path),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/training/train_ppo.py",
+            "--config",
+            str(CONFIG_PATH),
+            "--dry-run",
+            "--log-level",
+            "WARNING",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    perf_paths = sorted((tmp_path / "benchmarks" / "ppo_imitation" / "perf").glob("*.json"))
+    assert len(perf_paths) == 1
+    payload = json.loads(perf_paths[0].read_text(encoding="utf-8"))
+    assert payload["parameter_summary"] == {
+        "available": False,
+        "policy_parameter_count": None,
+        "policy_trainable_parameter_count": None,
+        "model_parameter_count": None,
+        "model_trainable_parameter_count": None,
+    }


### PR DESCRIPTION
Reviewer-critical summary

What changed: `scripts/training/train_ppo.py` now writes a `parameter_summary` block into the existing PPO performance summary JSON and records `policy_parameter_count=...` in training notes when a constructed model is available. This directly advances issue #4014's remaining requirement that PPO / RecurrentPPO-LSTM / PPO-Mamba comparison artifacts include parameter-count metadata alongside throughput.

Why now: closure audit found #4014 is not complete. Merged PR #4475 registered the PPO-Mamba smoke lane, and the latest issue comment says remaining work is matched smoke/full training runs emitting throughput plus parameter-count metadata and diagnostic comparison artifacts. This PR is the smallest nameable progression slice toward that remaining plan.

Claim boundary: this PR proves the PPO training artifact schema can carry parameter-count metadata and that the #4014 PPO-Mamba dry-run emits the field. It does not run the matched training campaign, does not produce the final three-way diagnostic report, and does not establish benchmark or paper-grade evidence.

Required validation: focused tests for parameter-summary serialization/counting and PPO-Mamba dry-run artifact emission, direct PPO-Mamba dry-run command, Ruff check, and final PR readiness.

Remaining blocker: #4014 still needs matched PPO, RecurrentPPO-LSTM, and PPO-Mamba smoke/full training runs with throughput and populated parameter counts, followed by diagnostic comparison artifacts with explicit claim boundary.

Contract delta

New schema fields: existing PPO perf summary JSON now includes `parameter_summary` with `available`, `policy_parameter_count`, `policy_trainable_parameter_count`, `model_parameter_count`, and `model_trainable_parameter_count`.

New fail-closed blockers: none. Dry-runs that intentionally skip model construction record `available: false` with null counts instead of pretending a parameter count exists.

Compatibility impact: existing perf-summary consumers keep all prior keys; this is an additive JSON field. Training behavior and PPO config defaults are unchanged.

Issue: closes no issue; advances https://github.com/ll7/robot_sf_ll7/issues/4014.

Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Read full issue thread and linked/merged PRs | Read live #4014 issue body/comments and merged PR #4475. Latest maintainer state: #4475 registered PPO-Mamba smoke lane; remaining work is matched training throughput, parameter counts, and diagnostic artifacts. |
| Do not close if acceptance criteria are unmet | #4014 remains open because matched three-way training/report criteria are not met by #4475 or this slice. |
| Smallest remaining slice | Adds parameter-count metadata to the canonical PPO perf summary writer and tests it through the #4014 PPO-Mamba dry-run path. |
| Fragmentation guard | Only one #4014 PR (#4475) found merged in the prior 24h; this PR adds a nameable new capability, not another guardrail/checker packet. |
| Late guidance check | Re-ran `gh issue view 4014 --repo ll7/robot_sf_ll7 --comments --json ...` before PR open; latest comment remains 2026-07-04T18:35:45Z, older than this run. |

Validation

- `uv run ruff check scripts/training/train_ppo.py tests/training/test_train_expert_ppo_contract.py tests/training/test_train_ppo_mamba_config_issue_4014.py` passed.
- `uv run pytest tests/training/test_train_expert_ppo_contract.py::test_write_perf_summary_writes_expected_keys tests/training/test_train_expert_ppo_contract.py::test_model_parameter_summary_counts_policy_parameters tests/training/test_train_ppo_mamba_config_issue_4014.py -q` passed: 5 tests.
- `ROBOT_SF_ARTIFACT_ROOT=$(mktemp -d) uv run python scripts/training/train_ppo.py --config configs/training/ppo/issue_4014_ppo_mamba_smoke.yaml --dry-run --log-level WARNING` passed; perf JSON included `parameter_summary.available=false` for dry-run.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed on dirty tree before commit; log: `/tmp/issue4014_pr_ready.log`.
- `PR_READY_PR_BODY_FILE=/tmp/issue4014_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed before PR open.

Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Governance and artifact notes</summary>

State propagation: issue comments were not posted because `comment_issue_or_pr` is false. No tracked issue-state file was added because this PR is a schema/behavior slice and the request forbids encoding transient queue-routing state in tracked files; remaining work is captured in this PR body.

Generated artifacts: local readiness/coverage outputs under `output/` and direct dry-run artifacts under `/tmp/issue4014-dryrun.*` are disposable validation artifacts and are not committed.

Reviewer handoff: Claude Code on `imech156-u` owns full PR gate, improvement cycle, and merge authority after this PR opens.

</details>
