### PR TITLE
fix: resolve prediction_mpc_cbf command contract for issue #4592

### DIFF
--- a/robot_sf/benchmark/algorithm_readiness.py
+++ b/robot_sf/benchmark/algorithm_readiness.py
@@ -449,7 +449,12 @@ _ALGORITHMS: tuple[AlgorithmReadiness, ...] = (
     AlgorithmReadiness(
         canonical_name="prediction_mpc",
         tier="experimental",
-        aliases=("prediction_mpc", "prediction_aware_mpc", "cv_prediction_mpc"),
+        aliases=(
+            "prediction_mpc",
+            "prediction_mpc_cbf",
+            "prediction_aware_mpc",
+            "cv_prediction_mpc",
+        ),
         note=(
             "Prediction-aware MPC local planner with constant-velocity pedestrian futures "
             "as hard time-varying collision constraints."

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -19,6 +19,7 @@ def test_canonical_algorithm_name_resolves_aliases() -> None:
     """Alias names should resolve to canonical benchmark algorithm names."""
     assert canonical_algorithm_name("simple_policy") == "goal"
     assert canonical_algorithm_name("sf") == "social_force"
+    assert canonical_algorithm_name("prediction_mpc_cbf") == "prediction_mpc"
     assert canonical_algorithm_name("unknown_algo") == "unknown_algo"
 
 
@@ -637,6 +638,25 @@ def test_prediction_mpc_metadata_exposes_constraint_mpc_contract() -> None:
         "pedestrians",
         "predicted_pedestrian_futures",
     ]
+
+
+def test_prediction_mpc_cbf_alias_reuses_supported_mpc_command_contract() -> None:
+    """Trace rosters may name the CBF arm without losing MPC command metadata."""
+    meta = enrich_algorithm_metadata(
+        algo="prediction_mpc_cbf",
+        metadata={"status": "ok"},
+        execution_mode="adapter",
+        robot_kinematics="differential_drive",
+    )
+
+    planner = meta["planner_kinematics"]
+    action = meta["planner_contract"]["action_contract"]
+    assert meta["algorithm"] == "prediction_mpc_cbf"
+    assert meta["canonical_algorithm"] == "prediction_mpc"
+    assert planner["planner_command_space"] == "unicycle_vw"
+    assert planner["adapter_name"] == "PredictionMPCPlannerAdapter"
+    assert action["command_space"] == "unicycle_vw"
+    assert action["output_keys"] == ["v", "omega"]
 
 
 def test_infer_execution_mode_from_counts() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- What changed: registered `prediction_mpc_cbf` as a readiness alias of canonical `prediction_mpc`, and added metadata regression coverage for the h600 trace roster name.
- Why now: issue #4592 reports the trace-capable h600 campaign dying when `prediction_mpc_cbf` reaches metadata enrichment with `planner_command_space: unknown`.
- Claim boundary: this fixes the metadata/action-contract blocker only; it does not claim campaign success, planner quality, or safety performance.
- Required validation: targeted metadata/h600 tests plus full `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`.
- Remaining blocker: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits were performed.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: `prediction_mpc_cbf` now resolves to canonical `prediction_mpc` for readiness, observation, kinematics, and planner-contract metadata. Existing `prediction_mpc` aliases are unchanged.

## Linked Issues

- Closes #4592

## Scope Summary

- Added `prediction_mpc_cbf` to the `prediction_mpc` readiness alias set.
- Added tests proving the alias keeps the requested algorithm label while resolving the canonical planner contract to `unicycle_vw` with the `PredictionMPCPlannerAdapter`.

## Validation / Proof

- `source .venv/bin/activate && pytest tests/benchmark/test_algorithm_metadata_contract.py::test_canonical_algorithm_name_resolves_aliases tests/benchmark/test_algorithm_metadata_contract.py::test_prediction_mpc_metadata_exposes_constraint_mpc_contract tests/benchmark/test_algorithm_metadata_contract.py::test_prediction_mpc_cbf_alias_reuses_supported_mpc_command_contract -q` - passed, 3 passed.
- `source .venv/bin/activate && pytest tests/benchmark/test_h600_extended_roster_config.py -q` - passed, 3 passed.
- `source .venv/bin/activate && python - <<'PY' ... enrich_algorithm_metadata(algo='prediction_mpc_cbf') ... PY` - passed, printed `prediction_mpc`, `unicycle_vw`, `unicycle_vw`.
- `source .venv/bin/activate && pytest tests/benchmark/test_algorithm_metadata_contract.py -q` - passed, 40 passed.
- `source .venv/bin/activate && ruff check robot_sf/benchmark/algorithm_readiness.py tests/benchmark/test_algorithm_metadata_contract.py` - passed.
- `source .venv/bin/activate && ruff format --check robot_sf/benchmark/algorithm_readiness.py tests/benchmark/test_algorithm_metadata_contract.py` - passed.
- `source .venv/bin/activate && BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; interim dirty-tree stamp recorded at `output/validation/pr_ready/issue-4592-auto-admitted-fix-prediction-mpc-cbf-unsupported-command-space-unknown-k.json`.
- `source .venv/bin/activate && PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE="$(git rev-parse --git-path codex-agent-runs/active/issue-4592/PR_BODY.md)" scripts/dev/pr_ready_check.sh` - passed; clean committed-head stamp for `8512b2c76a6e74c4e2942daa77b537e3e10bd75a` recorded at `output/validation/pr_ready/issue-4592-auto-admitted-fix-prediction-mpc-cbf-unsupported-command-space-unknown-k.json`.

## Out of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No benchmark-result, leaderboard, or artifact-catalog claim promotion.

## Downstream Propagation

- Parent issue updated: no, comment_issue_or_pr authorization is false for this run.
- Claim map / benchmark report updated: NA; this is a metadata unblocker, not campaign evidence.
- Leaderboard / artifact catalog updated: NA; no benchmark artifact was produced or promoted.
- Registry or config index updated: NA; readiness alias map is the canonical behavior surface touched here.
- Context index / memory note updated: NA; no durable research result or new workflow contract.
- Follow-up issue opened deferred propagation: no.
- Not applicable because: the PR body is the single state surface for this low-churn issue handoff under the provided no-comment authorization.

<details>
<summary>Governance appendix</summary>

## Stack / Dependency

- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason: NA

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: unblocks `prediction_mpc_cbf` metadata enrichment for trace-capable h600 campaign execution.
- Comparator or baseline: pre-fix direct reproducer raised `ValueError: Unsupported planner command space: 'unknown'`; post-fix direct reproducer resolves `prediction_mpc / unicycle_vw / unicycle_vw`.
- Evidence tier: NA - runtime metadata contract fix, not research evidence.
- Result classification: NA - no research result.
- Decision stop rule: stop at metadata contract fix; campaign execution remains outside this authorized run.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #4592 via this PR.
- New research/benchmark/metric/paper-facing analysis tool: NA.

## Domain-Aware Approval

- Required PR: yes.
- Domains reviewed: metadata alias contract.
- Status: waived.
- Approver/review source or waiver: self-review waiver because this PR fixes metadata alias resolution only and makes no benchmark, planner-quality, or paper-facing claim.
- Target claim/hypothesis: metadata unblocker only.
- Comparator or split/evidence validity: direct pre/post metadata reproducer plus focused regression tests; no experimental comparison claim.
- Fallback/degraded exclusions: no fallback/degraded benchmark execution counted as success.
- Claim boundary: no campaign or planner-performance claim.
- Implementation integrity vs experimental validity: implementation integrity covered by tests/readiness; experimental validity out of scope.

## Falsification / Non-Transfer Check

- Did mechanism activate: yes, alias changes canonical metadata resolution for `prediction_mpc_cbf`.
- Did intervention change command source, selected command, trajectory, route progress: unknown; no campaign run.
- Did scenario actually contain targeted failure mode: metadata reproducer contained targeted failure path.
- Result route: continue to campaign run outside this PR.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action

- Rerun needed: yes, a trace-capable h600 campaign/run should be relaunched by the authorized compute owner.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: full campaign output.
- Stop / revise / continue decision: continue after merge with campaign execution.
- Proposed child issue existing follow-up: #4592 campaign rerun remains the follow-up action until merge closes the blocker.

## Risks / Rollout

- Compatibility risks: low; the alias reuses the already tested `prediction_mpc` contract.
- Failure modes: if `prediction_mpc_cbf` later needs a materially distinct runtime contract, this alias would need to become an explicit profile instead.
- Rollback fallback plan: revert the alias and regression test.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: `prediction_mpc_cbf` h600 roster entry uses the existing prediction MPC adapter/config surface with CBF enabled.
- Assumptions preserved: CBF is a configuration variant of the prediction MPC adapter, not a separate command-space family.

## Follow-Up Issues

- Deferred work: full campaign rerun and any resulting empirical interpretation.
- Issues opened follow-up: none.

## Reviewer Notes

- Verify the alias is sufficient for readiness and planner-contract metadata without weakening unknown-command-space fail-closed behavior for truly unknown algorithms.
- Known limitations: no full h600 benchmark campaign was run.

</details>
