### PR TITLE
Issue #3501: add paired safety-wrapper report builder

### DIFF
--- a/robot_sf/benchmark/safety_wrapper_factorial_report.py
+++ b/robot_sf/benchmark/safety_wrapper_factorial_report.py
@@ -1,0 +1,321 @@
+"""Paired effect-size report builder for issue #3501 safety-wrapper ablations.
+
+The report consumes completed ``wrapper_off``/``wrapper_on`` episode rows that
+already satisfy the issue #3501 ablation row checker. It does not execute
+episodes and does not promote benchmark or paper-facing claims by itself.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.safety_wrapper_ablation_manifest import (
+    PAIRING_KEY_FIELDS,
+    SAFETY_WRAPPER_MODE_FIELD,
+    WRAPPER_OFF_ARM,
+    WRAPPER_ON_ARM,
+    check_factorial_ablation_rows,
+)
+
+REPORT_SCHEMA_VERSION = "robot_sf.issue_3501_safety_wrapper_factorial_report.v1"
+
+SAFETY_WRAPPER_FACTORIAL_METRICS: tuple[str, ...] = (
+    "exact_collision_probability",
+    "near_miss_probability",
+    "min_predicted_separation_m",
+    "completion_probability",
+    "progress_at_timeout",
+    "false_positive_stop_rate",
+    "stop_yield_latency_s",
+    "wrapper_intervention_rate",
+)
+
+LOWER_IS_BETTER_METRICS = {
+    "exact_collision_probability",
+    "near_miss_probability",
+    "false_positive_stop_rate",
+    "stop_yield_latency_s",
+}
+
+HIGHER_IS_BETTER_METRICS = {
+    "min_predicted_separation_m",
+    "completion_probability",
+    "progress_at_timeout",
+}
+
+
+def build_safety_wrapper_factorial_report(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Build a paired issue #3501 effect-size report from completed rows.
+
+    Returns:
+        Structured report with paired and per-planner effect rows, or fail-closed blockers.
+    """
+
+    row_check = check_factorial_ablation_rows(rows)
+    if not row_check["complete"]:
+        return {
+            "schema_version": REPORT_SCHEMA_VERSION,
+            "issue": 3501,
+            "status": "blocked",
+            "reason": "ablation_rows_incomplete",
+            "benchmark_evidence": False,
+            "claim_boundary": _claim_boundary(),
+            "row_check": row_check,
+            "blocked_reasons": _row_check_blockers(row_check),
+            "paired_effects": [],
+            "per_planner_effects": [],
+        }
+
+    groups = _group_complete_pairs(rows)
+    pair_rows: list[dict[str, Any]] = []
+    missing_metrics: list[dict[str, Any]] = []
+    for key, by_arm in sorted(groups.items(), key=lambda item: item[0]):
+        off_row = by_arm[WRAPPER_OFF_ARM]
+        on_row = by_arm[WRAPPER_ON_ARM]
+        off_metrics = _extract_metrics(off_row)
+        on_metrics = _extract_metrics(on_row)
+        missing = [
+            metric
+            for metric in SAFETY_WRAPPER_FACTORIAL_METRICS
+            if metric not in off_metrics or metric not in on_metrics
+        ]
+        if missing:
+            missing_metrics.append(
+                {
+                    "pairing_key": dict(zip(PAIRING_KEY_FIELDS, key, strict=True)),
+                    "metrics": missing,
+                }
+            )
+            continue
+        pair_rows.append(
+            _paired_effect_row(
+                key=key,
+                off_metrics=off_metrics,
+                on_metrics=on_metrics,
+                off_row=off_row,
+                on_row=on_row,
+            )
+        )
+
+    if missing_metrics:
+        return {
+            "schema_version": REPORT_SCHEMA_VERSION,
+            "issue": 3501,
+            "status": "blocked",
+            "reason": "metric_values_incomplete",
+            "benchmark_evidence": False,
+            "claim_boundary": _claim_boundary(),
+            "row_check": row_check,
+            "blocked_reasons": [
+                "At least one complete off/on pair is missing primary outcome metrics."
+            ],
+            "missing_metrics": missing_metrics,
+            "paired_effects": pair_rows,
+            "per_planner_effects": [],
+        }
+
+    per_planner_effects = _per_planner_effects(pair_rows)
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "issue": 3501,
+        "status": "complete",
+        "benchmark_evidence": True,
+        "claim_boundary": _claim_boundary(),
+        "row_check": row_check,
+        "metric_directions": {
+            "lower_is_better": sorted(LOWER_IS_BETTER_METRICS),
+            "higher_is_better": sorted(HIGHER_IS_BETTER_METRICS),
+            "diagnostic_only": ["wrapper_intervention_rate"],
+        },
+        "pair_count": len(pair_rows),
+        "planner_count": len(per_planner_effects),
+        "paired_effects": pair_rows,
+        "per_planner_effects": per_planner_effects,
+    }
+
+
+def write_safety_wrapper_factorial_report(
+    report: Mapping[str, Any],
+    output_dir: str | Path,
+) -> dict[str, Path]:
+    """Write summary JSON, per-planner CSV, and Markdown evidence packet.
+
+    Returns:
+        Paths to written summary, CSV, and README artifacts.
+    """
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    summary_path = out / "summary.json"
+    summary_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    csv_path = out / "per_planner_effects.csv"
+    _write_per_planner_csv(report.get("per_planner_effects", []), csv_path)
+
+    readme_path = out / "README.md"
+    readme_path.write_text(_format_readme(report), encoding="utf-8")
+
+    return {
+        "summary": summary_path,
+        "per_planner_effects": csv_path,
+        "readme": readme_path,
+    }
+
+
+def _claim_boundary() -> str:
+    return (
+        "Diagnostic paired safety-wrapper factorial report. Rows must already be complete "
+        "native benchmark rows under the issue #3501 off/on contract. This report summarizes "
+        "observed paired effects only; it does not execute campaigns, tune thresholds, or make "
+        "paper/dissertation deployment-safety claims."
+    )
+
+
+def _row_check_blockers(row_check: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    for field in (
+        "missing_required_fields",
+        "invalid_provenance_fields",
+        "unexpected_wrapper_arms",
+        "duplicate_pair_rows",
+        "incomplete_pairs",
+        "pair_provenance_mismatches",
+    ):
+        if row_check.get(field):
+            blockers.append(f"{field}: {row_check[field]}")
+    return blockers or ["Ablation row checker did not mark the paired rows complete."]
+
+
+def _group_complete_pairs(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[tuple[Any, ...], dict[str, Mapping[str, Any]]]:
+    groups: dict[tuple[Any, ...], dict[str, Mapping[str, Any]]] = defaultdict(dict)
+    for row in rows:
+        key = tuple(row[field] for field in PAIRING_KEY_FIELDS)
+        groups[key][str(row["wrapper_arm"])] = row
+    return dict(groups)
+
+
+def _extract_metrics(row: Mapping[str, Any]) -> dict[str, float]:
+    metric_values = row.get("metric_values")
+    if not isinstance(metric_values, Mapping):
+        return {}
+    metrics: dict[str, float] = {}
+    for metric in SAFETY_WRAPPER_FACTORIAL_METRICS:
+        value = (
+            row.get(metric)
+            if metric == "wrapper_intervention_rate" and metric not in metric_values
+            else metric_values.get(metric)
+        )
+        if isinstance(value, bool):
+            continue
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(numeric):
+            metrics[metric] = numeric
+    return metrics
+
+
+def _paired_effect_row(
+    *,
+    key: tuple[Any, ...],
+    off_metrics: Mapping[str, float],
+    on_metrics: Mapping[str, float],
+    off_row: Mapping[str, Any],
+    on_row: Mapping[str, Any],
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "planner": str(key[0]),
+        "scenario_id": str(key[1]),
+        "seed": int(key[2]),
+        "wrapper_off_mode": off_row.get(SAFETY_WRAPPER_MODE_FIELD),
+        "wrapper_on_mode": on_row.get(SAFETY_WRAPPER_MODE_FIELD),
+        "software_commit": str(off_row["software_commit"]),
+    }
+    for metric in SAFETY_WRAPPER_FACTORIAL_METRICS:
+        off_value = float(off_metrics[metric])
+        on_value = float(on_metrics[metric])
+        row[f"{metric}_wrapper_off"] = off_value
+        row[f"{metric}_wrapper_on"] = on_value
+        row[f"{metric}_delta_on_minus_off"] = on_value - off_value
+    return row
+
+
+def _per_planner_effects(pair_rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    by_planner: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in pair_rows:
+        by_planner[str(row["planner"])].append(row)
+
+    results: list[dict[str, Any]] = []
+    for planner, rows in sorted(by_planner.items()):
+        result: dict[str, Any] = {"planner": planner, "pair_count": len(rows)}
+        for metric in SAFETY_WRAPPER_FACTORIAL_METRICS:
+            deltas = [float(row[f"{metric}_delta_on_minus_off"]) for row in rows]
+            result[f"{metric}_mean_delta_on_minus_off"] = sum(deltas) / len(deltas)
+        results.append(result)
+    return results
+
+
+def _write_per_planner_csv(rows: Any, path: Path) -> None:
+    fieldnames = [
+        "planner",
+        "pair_count",
+        *(f"{metric}_mean_delta_on_minus_off" for metric in SAFETY_WRAPPER_FACTORIAL_METRICS),
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        if isinstance(rows, Sequence) and not isinstance(rows, (str, bytes)):
+            for row in rows:
+                if isinstance(row, Mapping):
+                    writer.writerow({field: row.get(field, "") for field in fieldnames})
+
+
+def _format_readme(report: Mapping[str, Any]) -> str:
+    status = report.get("status", "unknown")
+    lines = [
+        "# Issue #3501 Safety Wrapper Factorial Report",
+        "",
+        str(report.get("claim_boundary", _claim_boundary())),
+        "",
+        f"- Status: `{status}`",
+        f"- Benchmark evidence: `{bool(report.get('benchmark_evidence', False))}`",
+        f"- Pair count: `{report.get('pair_count', 0)}`",
+        f"- Planner count: `{report.get('planner_count', 0)}`",
+        "",
+    ]
+    if status != "complete":
+        lines.extend(["## Blockers", ""])
+        for blocker in report.get("blocked_reasons", []):
+            lines.append(f"- {blocker}")
+        lines.append("")
+    else:
+        lines.extend(
+            [
+                "## Outputs",
+                "",
+                "- `summary.json`: complete paired effect report.",
+                "- `per_planner_effects.csv`: planner-level mean on-minus-off deltas.",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "REPORT_SCHEMA_VERSION",
+    "SAFETY_WRAPPER_FACTORIAL_METRICS",
+    "build_safety_wrapper_factorial_report",
+    "write_safety_wrapper_factorial_report",
+]

--- a/scripts/benchmark/build_issue3501_safety_wrapper_factorial_report.py
+++ b/scripts/benchmark/build_issue3501_safety_wrapper_factorial_report.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Build issue #3501 paired safety-wrapper factorial report artifacts."""
+
+from __future__ import annotations
+
+import argparse
+
+from robot_sf.benchmark.safety_wrapper_ablation_manifest import load_safety_wrapper_ablation_rows
+from robot_sf.benchmark.safety_wrapper_factorial_report import (
+    build_safety_wrapper_factorial_report,
+    write_safety_wrapper_factorial_report,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rows", required=True, help="Completed issue #3501 ablation rows JSON/JSONL."
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Output directory for summary.json, per_planner_effects.csv, and README.md.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Build report artifacts and fail closed when rows are incomplete."""
+
+    args = parse_args()
+    rows = load_safety_wrapper_ablation_rows(args.rows)
+    report = build_safety_wrapper_factorial_report(rows)
+    paths = write_safety_wrapper_factorial_report(report, args.out)
+    print(
+        "issue_3501_safety_wrapper_factorial_report "
+        f"status={report['status']} summary={paths['summary']}"
+    )
+    return 0 if report["status"] == "complete" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_safety_wrapper_factorial_report.py
+++ b/tests/benchmark/test_safety_wrapper_factorial_report.py
@@ -1,0 +1,224 @@
+"""Tests for issue #3501 paired safety-wrapper factorial reports."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.benchmark.safety_wrapper_ablation_manifest import (
+    SAFETY_WRAPPER_CONFIG_FIELD,
+    SAFETY_WRAPPER_MODE_DISABLED,
+    SAFETY_WRAPPER_MODE_ENABLED,
+    SAFETY_WRAPPER_MODE_FIELD,
+    WRAPPER_OFF_ARM,
+    WRAPPER_ON_ARM,
+)
+from robot_sf.benchmark.safety_wrapper_factorial_report import (
+    SAFETY_WRAPPER_FACTORIAL_METRICS,
+    build_safety_wrapper_factorial_report,
+    write_safety_wrapper_factorial_report,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _row(
+    wrapper_arm: str, *, seed: int, metrics: dict[str, float] | None = None
+) -> dict[str, object]:
+    enabled = wrapper_arm == WRAPPER_ON_ARM
+    base_metrics = {
+        "exact_collision_probability": 1.0,
+        "near_miss_probability": 1.0,
+        "min_predicted_separation_m": 0.2,
+        "completion_probability": 0.0,
+        "progress_at_timeout": 0.4,
+        "false_positive_stop_rate": 0.0,
+        "stop_yield_latency_s": 0.0,
+    }
+    if enabled:
+        base_metrics.update(
+            {
+                "exact_collision_probability": 0.0,
+                "near_miss_probability": 0.0,
+                "min_predicted_separation_m": 0.8,
+                "completion_probability": 1.0,
+                "progress_at_timeout": 1.0,
+                "false_positive_stop_rate": 0.1,
+                "stop_yield_latency_s": 0.2,
+            }
+        )
+    if metrics:
+        base_metrics.update(metrics)
+    return {
+        "study_id": "issue_3501_safety_wrapper_ablation_v1",
+        "planner": "orca",
+        "wrapper_arm": wrapper_arm,
+        SAFETY_WRAPPER_MODE_FIELD: (
+            SAFETY_WRAPPER_MODE_ENABLED if enabled else SAFETY_WRAPPER_MODE_DISABLED
+        ),
+        SAFETY_WRAPPER_CONFIG_FIELD: (
+            {
+                "pedestrian_caution_radius_m": 2.0,
+                "capped_speed_m_s": 0.5,
+                "ttc_veto_threshold_s": 1.0,
+                "clearance_veto_m": 0.3,
+            }
+            if enabled
+            else None
+        ),
+        "scenario_id": "francis2023_blind_corner",
+        "seed": seed,
+        "software_commit": "abc1234",
+        "event_ledger": {"schema_version": "EpisodeEventLedger.v1"},
+        "metric_values": base_metrics,
+        "wrapper_intervention_rate": 0.25 if enabled else 0.0,
+    }
+
+
+def _complete_rows() -> list[dict[str, object]]:
+    return [
+        _row(WRAPPER_OFF_ARM, seed=111),
+        _row(WRAPPER_ON_ARM, seed=111),
+        _row(WRAPPER_OFF_ARM, seed=112),
+        _row(WRAPPER_ON_ARM, seed=112),
+    ]
+
+
+def test_report_computes_paired_effects_and_per_planner_means() -> None:
+    """Complete off/on rows produce issue #3501 primary outcome deltas."""
+
+    report = build_safety_wrapper_factorial_report(_complete_rows())
+
+    assert report["status"] == "complete"
+    assert report["benchmark_evidence"] is True
+    assert report["pair_count"] == 2
+    assert report["planner_count"] == 1
+    assert report["row_check"]["complete"] is True
+    assert len(report["paired_effects"]) == 2
+    first = report["paired_effects"][0]
+    assert first["exact_collision_probability_delta_on_minus_off"] == -1.0
+    assert first["near_miss_probability_delta_on_minus_off"] == -1.0
+    assert first["min_predicted_separation_m_delta_on_minus_off"] == pytest.approx(0.6)
+    assert first["wrapper_intervention_rate_delta_on_minus_off"] == 0.25
+    per_planner = report["per_planner_effects"][0]
+    assert per_planner["planner"] == "orca"
+    assert per_planner["pair_count"] == 2
+    assert per_planner["completion_probability_mean_delta_on_minus_off"] == 1.0
+    for metric in SAFETY_WRAPPER_FACTORIAL_METRICS:
+        assert f"{metric}_mean_delta_on_minus_off" in per_planner
+
+
+def test_report_blocks_incomplete_pairs_before_effect_claims() -> None:
+    """The report builder reuses the fail-closed paired-row checker."""
+
+    report = build_safety_wrapper_factorial_report([_row(WRAPPER_OFF_ARM, seed=111)])
+
+    assert report["status"] == "blocked"
+    assert report["reason"] == "ablation_rows_incomplete"
+    assert report["benchmark_evidence"] is False
+    assert report["row_check"]["complete"] is False
+    assert report["per_planner_effects"] == []
+
+
+def test_report_blocks_missing_primary_outcome_metric() -> None:
+    """Complete row pairs still fail closed when issue #3501 outcomes are absent."""
+
+    rows = _complete_rows()
+    del rows[1]["metric_values"]["near_miss_probability"]  # type: ignore[index]
+    report = build_safety_wrapper_factorial_report(rows)
+
+    assert report["status"] == "blocked"
+    assert report["reason"] == "metric_values_incomplete"
+    assert report["benchmark_evidence"] is False
+    assert report["missing_metrics"] == [
+        {
+            "pairing_key": {
+                "planner": "orca",
+                "scenario_id": "francis2023_blind_corner",
+                "seed": 111,
+            },
+            "metrics": ["near_miss_probability"],
+        }
+    ]
+
+
+def test_write_report_outputs_expected_artifacts(tmp_path: Path) -> None:
+    """The writer emits the evidence packet files requested by issue #3501."""
+
+    report = build_safety_wrapper_factorial_report(_complete_rows())
+    paths = write_safety_wrapper_factorial_report(report, tmp_path)
+
+    assert paths["summary"].name == "summary.json"
+    assert paths["per_planner_effects"].name == "per_planner_effects.csv"
+    assert paths["readme"].name == "README.md"
+    summary = json.loads(paths["summary"].read_text(encoding="utf-8"))
+    assert summary["schema_version"] == "robot_sf.issue_3501_safety_wrapper_factorial_report.v1"
+    assert "exact_collision_probability_mean_delta_on_minus_off" in paths[
+        "per_planner_effects"
+    ].read_text(encoding="utf-8")
+    assert "Diagnostic paired safety-wrapper factorial report" in paths["readme"].read_text(
+        encoding="utf-8"
+    )
+
+
+def test_cli_fails_closed_for_incomplete_rows(tmp_path: Path) -> None:
+    """The CLI writes blockers and exits non-zero rather than overstating evidence."""
+
+    rows_path = tmp_path / "rows.json"
+    rows_path.write_text(json.dumps([_row(WRAPPER_OFF_ARM, seed=111)]) + "\n", encoding="utf-8")
+    out_dir = tmp_path / "report"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/benchmark/build_issue3501_safety_wrapper_factorial_report.py",
+            "--rows",
+            str(rows_path),
+            "--out",
+            str(out_dir),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert "status=blocked" in completed.stdout
+    summary = json.loads((out_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["status"] == "blocked"
+
+
+def test_cli_writes_complete_report(tmp_path: Path) -> None:
+    """The CLI builds the report artifacts for complete paired rows."""
+
+    rows_path = tmp_path / "rows.jsonl"
+    rows_path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in _complete_rows()) + "\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "report"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/benchmark/build_issue3501_safety_wrapper_factorial_report.py",
+            "--rows",
+            str(rows_path),
+            "--out",
+            str(out_dir),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "status=complete" in completed.stdout
+    assert (out_dir / "summary.json").is_file()
+    assert (out_dir / "per_planner_effects.csv").is_file()
+    assert (out_dir / "README.md").is_file()

--- a/tests/benchmark/test_safety_wrapper_factorial_report.py
+++ b/tests/benchmark/test_safety_wrapper_factorial_report.py
@@ -53,6 +53,12 @@ def _row(
             }
         )
     if metrics:
+        unknown = sorted(k for k in metrics if k not in base_metrics)
+        if unknown:
+            raise KeyError(
+                f"_row() metrics override contains unknown primary-outcome keys {unknown}; "
+                "check for typos against the base metric set."
+            )
         base_metrics.update(metrics)
     return {
         "study_id": "issue_3501_safety_wrapper_ablation_v1",


### PR DESCRIPTION
## Reviewer-critical summary
What changed: adds a CPU-only paired report builder for issue #3501 safety-wrapper factorial rows, plus a CLI that writes the requested `summary.json`, `per_planner_effects.csv`, and `README.md` evidence packet files once completed paired rows exist.

Why now: the closure audit found the wrapper core (#3591), runtime binding (#4137), manifest/checker support (#4104/#4108/#4112/#4116/#4124/#4128/#4136), preregistration (#4223), and false-stop diagnostic (#4298) are merged, but the issue still lacks the causal paired effect-size reporting contract for real `planner x {wrapper_off, wrapper_on}` rows. This is the smallest non-campaign slice that advances the remaining acceptance criteria without adding another blocker packet.

Claim boundary: reporting capability only. The new code consumes rows that already pass `check_factorial_ablation_rows`; it does not run episodes, submit Slurm/GPU work, tune thresholds, or promote paper/dissertation deployment-safety claims.

Required validation: focused report tests, adjacent safety-wrapper checker/preregistration tests, Ruff, and final PR readiness.

Remaining blocker: actual paired ablation execution over fixed scenario set and paired seeds, then running this report builder on durable row artifacts. Refs #3501.

## Contract delta
- New schema surface: `robot_sf.issue_3501_safety_wrapper_factorial_report.v1` for paired effect-size report output.
- New CLI: `scripts/benchmark/build_issue3501_safety_wrapper_factorial_report.py --rows <json-or-jsonl> --out <dir>`.
- New fail-closed blockers:
  - incomplete `wrapper_off`/`wrapper_on` pairs are rejected through the existing row checker before effect reporting;
  - missing primary outcome metrics block the report instead of emitting partial evidence.
- Compatibility impact: additive only. Existing manifest, preregistration, runtime, and checker APIs are unchanged.

## Linked Issues
- Refs #3501

## What Changed
- Added `robot_sf/benchmark/safety_wrapper_factorial_report.py` to aggregate complete paired rows into per-pair deltas and per-planner mean on-minus-off effects for the issue #3501 primary outcomes.
- Added `scripts/benchmark/build_issue3501_safety_wrapper_factorial_report.py` to write the evidence packet files named by the issue plan.
- Added focused tests for complete reports, incomplete-pair blockers, missing-metric blockers, writer outputs, and CLI exit behavior.

## Acceptance Evidence
| Criterion | Evidence | Status |
| --- | --- | --- |
| Composable `SafetyWrapper` around action interface, off by default opt-in | Merged PR #3591 added wrapper core; PR #4137 bound runtime config behind explicit opt-in. | Met before this PR |
| Fixed planner-agnostic thresholds, no post-hoc tuning | Merged checker/provenance slices #4104, #4108, #4112, #4116, #4124, #4128, #4136 and preregistration #4223 enforce fixed off/on row/config provenance. | Met before this PR |
| Factorial `planner x {wrapper_off, wrapper_on}` ablation over fixed scenario set paired seeds | PR #4223 preregistered CPU-smoke planned rows; actual paired campaign execution remains unrun. | Open |
| Ablation results emitted into safety-event ledger | Runtime/checker path requires `EpisodeEventLedger.v1`; durable executed campaign rows still pending. | Open |
| Primary outcomes reported including positive/negative/transfer-poor effects and progress/false-stop costs | This PR adds the paired effect-size report builder for exact collision, near miss, min separation, completion, progress, false-positive stop, stop/yield latency, and intervention rate. It blocks until complete rows provide those metrics. | Partially met by this PR; needs real rows |
| Result kept diagnostic-tier until durable evidence review | PR body and report claim boundary state diagnostic paired report only; no paper/dissertation claim edits. | Met |

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_safety_wrapper_factorial_report.py -q` -> 6 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_safety_wrapper_factorial_report.py tests/benchmark/test_safety_wrapper_factorial_preregistration.py tests/benchmark/test_safety_wrapper_ablation_manifest.py -q` -> 29 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/safety_wrapper_factorial_report.py scripts/benchmark/build_issue3501_safety_wrapper_factorial_report.py tests/benchmark/test_safety_wrapper_factorial_report.py` -> all checks passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/safety_wrapper_factorial_report.py scripts/benchmark/build_issue3501_safety_wrapper_factorial_report.py tests/benchmark/test_safety_wrapper_factorial_report.py` -> 3 files already formatted.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed in dirty-tree mode before commit; core lane reported 1897 passed, 2 skipped.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue3501_pr_body.md scripts/dev/pr_ready_check.sh` -> passed; clean-tree stamp for `fa54bbb5491ee0e9daaa7b704e2710905d62fba9`.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: unblock #3501 paired safety-wrapper factorial effect reporting once campaign rows exist.
- Comparator or baseline, applicable: `wrapper_on` minus `wrapper_off` paired rows sharing planner, scenario, seed, study, and software commit provenance.
- Evidence tier: NA - support/reporting helper with synthetic focused tests; not benchmark evidence.
- Result classification: NA - support/reporting helper; no research result claimed.
- Decision stop rule, applicable: do not interpret mitigation effect until real paired rows pass the row checker and this report completes on durable artifacts.
- Parent issue, claim map, registry, context note, synthesis surface update: PR body carries state propagation because issue/PR commenting was not authorized in this run.
- New research/benchmark/metric/paper-facing analysis tool, any: support helper only; representative use is covered by focused tests over complete and blocked row fixtures, and real durable input is the remaining paired campaign output for #3501.

## Domain-Aware Approval
- Required PR: required - reviewer approval is required for this benchmark effect-reporting contract
- Domains reviewed: evidence classification, comparator validity, fallback/degraded exclusions, claim boundary.
- Status: pending
- Approval or blocker note: pending reviewer gate; domain-aware approval is required before treating this analysis/reporting tool as merge-ready.
- Validity checklist: complete. The report fails closed on incomplete pairs and missing primary metrics.
- Target claim/hypothesis: no mitigation-effectiveness claim in this PR.
- Comparator or split/evidence validity: valid for tool contract only; real evidence validity remains blocked until rows pass the existing paired off/on checker on durable native benchmark artifacts.
- Fallback/degraded exclusions: complete. Fallback/degraded success is not claimed; row checker and durable row production remain responsible for native benchmark provenance.
- Claim boundary: complete. Diagnostic paired report builder only.
- Implementation integrity vs experimental validity: complete. Implementation prepares reporting contract; experimental validity still depends on future campaign rows.

## Falsification / Non-Transfer Check
- Did mechanism activate? unknown; no campaign run.
- Did intervention change command source, selected command, trajectory, route progress? unknown; no campaign run.
- Did scenario actually contain targeted failure mode? unknown; no campaign run.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: use this report on real paired rows and include positive, negative, and transfer-poor outcomes.

## Next Empirical Action
- Rerun needed: yes, execute paired `planner x {wrapper_off, wrapper_on}` ablation rows under the preregistered contract.
- Extractor analysis tool needed: no for the first paired report; this PR adds it.
- Artifact missing unavailable: durable executed row artifact for the paired campaign.
- Stop / revise / continue decision: continue.
- Proposed child issue existing follow-up: #3501 remains the parent until campaign execution/reporting lands.

## Risks / Rollout
- Compatibility risks: low; additive module and CLI.
- Failure modes: row producers may omit one of the required primary metrics; report will block with `metric_values_incomplete`.
- Rollback fallback plan: remove the additive CLI/module/tests if the report contract is superseded.

## Docs / Provenance
- Updated docs: none; this is executable reporting code with tests.
- Relevant design provenance notes: issue #3501 full thread; merged PRs #3591, #3712, #4104, #4108, #4112, #4116, #4124, #4128, #4136, #4137, #4223, #4298, #4517.
- Any assumptions need to be preserved: rows passed to this report are completed native benchmark rows and not fallback/degraded success evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; `comment_issue_or_pr` authorization is false for this run, so this PR body is the propagation surface.
- Claim map / benchmark report updated (yes/no/NA): no; no real campaign evidence was produced.
- Leaderboard / artifact catalog updated (yes/no/NA): no; no durable benchmark artifacts were produced.
- Registry or config index updated (yes/no/NA): NA; additive script/module only.
- Context index / memory note updated (yes/no/NA): no; no new durable evidence packet is committed.
- Follow-up issue opened deferred propagation (yes/no/NA): no; deferred work remains tracked by open parent issue #3501.
- Not applicable because: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Follow-Up Issues
- Deferred work: #3501 tracks execution of paired ablation rows and running `scripts/benchmark/build_issue3501_safety_wrapper_factorial_report.py` on durable rows.
- Issues opened follow-up: none; remaining work is tracked by open parent issue #3501.

## Reviewer Notes
- Verify closely that `benchmark_evidence: true` is only emitted after complete checked rows and all primary outcome metrics are present.
- Known limitation: tests use synthetic rows; no real paired campaign rows were available or authorized in this slice.

<details>
<summary>Closure audit context</summary>

The issue remains open after this PR because the causal paired campaign evidence is still missing. This PR is exempt from the fragmentation guard because it adds a nameable new capability toward the implementation plan: paired factorial effect-size report generation. It is not a guardrail/checker packet refresh.

Forbidden actions confirmed: no full benchmark campaign run, no Slurm/GPU submission, no merge, no release, no deletion.
</details>
