### PR TITLE
fix: de-absolutize venv path in issue_3463 evidence (unblocks PR queue fast-feedback)

### DIFF
--- a/docs/context/evidence/issue_3463_topology_reselection_cross_slice_2026-07-05/summary.json
+++ b/docs/context/evidence/issue_3463_topology_reselection_cross_slice_2026-07-05/summary.json
@@ -6,7 +6,7 @@
     {
       "candidate_role": "baseline",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0",
@@ -39,7 +39,7 @@
     {
       "candidate_role": "reuse_penalty",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_reuse_penalty",
@@ -72,7 +72,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p05",
@@ -105,7 +105,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p1",
@@ -138,7 +138,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p2",
@@ -171,7 +171,7 @@
     {
       "candidate_role": "baseline",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0",
@@ -204,7 +204,7 @@
     {
       "candidate_role": "reuse_penalty",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_reuse_penalty",
@@ -237,7 +237,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p05",
@@ -270,7 +270,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p1",
@@ -303,7 +303,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p2",
@@ -336,7 +336,7 @@
     {
       "candidate_role": "baseline",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0",
@@ -369,7 +369,7 @@
     {
       "candidate_role": "reuse_penalty",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_reuse_penalty",
@@ -402,7 +402,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p05",
@@ -435,7 +435,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p1",
@@ -468,7 +468,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p2",
@@ -501,7 +501,7 @@
     {
       "candidate_role": "baseline",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0",
@@ -534,7 +534,7 @@
     {
       "candidate_role": "reuse_penalty",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_reuse_penalty",
@@ -567,7 +567,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p05",
@@ -600,7 +600,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p1",
@@ -633,7 +633,7 @@
     {
       "candidate_role": "progress_gated",
       "command": [
-        "/home/luttkule/git/robot_sf_ll7/.venv/bin/python3",
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p2",


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** rewrites the absolute worktree venv path
(`/home/luttkule/git/robot_sf_ll7/.venv/bin/python3`, 20 occurrences) in
`docs/context/evidence/issue_3463_topology_reselection_cross_slice_2026-07-05/summary.json`
to the repo-relative `.venv/bin/python3`.

**Why now — main is red, blocking the whole PR queue:** PR #4600 merged the
issue_3463 topology cross-slice evidence bundle. Its `summary.json` command
captures baked in an absolute home-dir venv path. That packet is NEW (not in
the `LEGACY_EVIDENCE_ALLOWLIST`), so the repo-wide abs-path guard
(`tests/integration/test_check_config_abs_paths.py`, which runs the checker
with `--all`) now fails on `origin/main`. #4600 was docs-only, so its own CI
path-filtered the unit lane and the breakage merged undetected. Every
subsequent PR that runs `fast-feedback` (unit tests) fails at `fast-feedback (2)`
through no fault of its own (observed on #4601, #4591).

**Claim boundary:** portability/reproducibility hygiene only. No runtime,
schema, benchmark, config, or claim surface changes; the JSON still parses and
no metric/provenance value changes. The path is faithful — the same venv,
expressed repo-relative, which is exactly the remediation the guard's error
message prescribes ("Use a repo-relative path").

**Validation:**
- `python hooks/check_config_abs_paths.py --all` → exit 0 (was exit 1 on main).
- `uv run pytest tests/integration/test_check_config_abs_paths.py -q` → 12 passed.
- `python -c "import json; json.load(open(...summary.json))"` → parses.

Refs #4600, #3463.
