### PR TITLE
docs: issue #1475 audit follow-up — add PR #2998 to reviewed list, define ORCA

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -148,7 +148,7 @@ is included.
 
 - `issue_1475_closure_audit_2026-07-06.md`: closure-audit / integration report for
   Issue #1475 (ORCA-residual BC smoke/nominal lineage job). Maps launch-packet,
-  adapter, telemetry-emission, and gate PRs #1875, #2989, #3502, #3844, and
+  adapter, telemetry-emission, and gate PRs #1875, #2989, #2998, #3502, #3844, and
   PR #4561 plus the durably recorded failed-closed job-12913 smoke to the
   acceptance criteria. Recommends keeping the issue open: CPU-side criteria are
   delivered and the #2445 missing-telemetry stop trigger is resolved, but the

--- a/docs/context/evidence/issue_1475_closure_audit_2026-07-06.md
+++ b/docs/context/evidence/issue_1475_closure_audit_2026-07-06.md
@@ -1,7 +1,8 @@
 # Issue #1475 Closure Audit
 
 Plain-language summary: issue #1475 asked a Slurm-capable owner to run a bounded
-ORCA-residual behavior-cloning (BC) smoke job and, if it passed, escalate to a
+ORCA (Optimal Reciprocal Collision Avoidance)-residual behavior-cloning (BC)
+smoke job and, if it passed, escalate to a
 nominal job producing a durable learned-residual dataset and checkpoint. **This
 audit recommends keeping #1475 open.** All CPU-implementable enabling criteria
 (launch packet, runtime observation-contract adapter, residual telemetry
@@ -47,6 +48,9 @@ names the exact next empirical action rather than closing the issue.
   - PR #2989, `5b94970458f72f4bfb9104931370a3ef7e0caf0f`,
     <https://github.com/ll7/robot_sf_ll7/pull/2989> — promoted Slurm closeout
     evidence for #1470 and #1475 (job-12913 smoke bundle).
+  - PR #2998, `48c01ed40d178de53986ca80ed2fb26587432b9e`,
+    <https://github.com/ll7/robot_sf_ll7/pull/2998> — emit ORCA residual smoke
+    evidence fields (the missing-telemetry population fix paired with #3502).
   - PR #3502, `332ffe4e6cbe5cf4bd6ee06944831e84db4e2a45`,
     <https://github.com/ll7/robot_sf_ll7/pull/3502> — emit `residual_clipped`
     on no-residual GuardedPPO decisions (resolves the #2445 missing-telemetry


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** docs-only follow-up to merged PR #4608 (`Refs #1475`). Applies
  the three still-valid review findings that PR #4608 was merged before they could
  land (it merged at head `b4b4c44b`, prior to the review-fix commit).
- **Findings addressed:**
  1. Gemini (medium): PR #2998 (`48c01ed40`, "emit ORCA residual smoke evidence
     fields") was cited in the audit prose/table but missing from the "Merged PRs
     reviewed" list and the `evidence/README.md` summary. Added to both.
  2. CodeRabbit (minor): ORCA now spelled out on first use ("ORCA (Optimal
     Reciprocal Collision Avoidance)").
- **Not addressed:** CodeRabbit's "fix the README link target" was a false positive
  (the README entries are backtick code-spans, not markdown links; no
  `](evidence/issue_1475...)` link exists). No change.
- **Claim boundary:** docs-only. No compute, no benchmark, no code/schema change,
  no issue closure. #1475 remains open per PR #4608's audit.
- **Validation:** `check_docs_evidence_integrity.py` → 2 files passed;
  `git diff --check` clean.

## Contract delta

None. Additive edits to one evidence note and its README summary line.

## Issue

`Refs #1475` — follow-up completeness fix for the closure audit; does not change
the audit's keep-open recommendation.
