### PR TITLE
fix: runnable SDD curation decision-packet import command + issue #1126 closure audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* **issue #1126 SDD curation decision packet — runnable import command.**
+  `scripts/tools/sdd_curation_preflight.py::build_decision_packet` now emits an `import` handoff
+  command that actually parses against the canonical importer
+  `scripts/tools/import_sdd_scenarios.py`: it uses the importer's real flags `--annotations` and
+  `--out-dir` (previously `--annotation`/`--output-dir`, which the importer rejects with exit `2`)
+  and includes the *required* `--meters-per-pixel` scale assumption (previously omitted). A new
+  `--decision-meters-per-pixel` CLI flag records the scene scale in `curation_parameters`
+  (`meters_per_pixel`); when unset the command carries an explicit `<meters-per-pixel>` placeholder
+  the curator must fill from the selected scene's calibration. Regression tests parse the generated
+  command with the importer's own parser so the handoff cannot silently drift again
+  (`tests/tools/test_sdd_curation_preflight.py`, 15 pass; 75 pass across the SDD suite). This closes
+  a gap in an acceptance criterion of #1126 (record import command + scale assumptions); the issue
+  itself stays open, blocked on BYO real SDD annotation staging (raw-data + checksum/license
+  provenance). No real SDD data touched, no benchmark campaign, no SLURM/GPU submission, no
+  paper/dissertation claim edits.
+
 ### Changed
+
+* Recorded the **issue #1126 SDD-curation closure audit** at
+  `docs/context/evidence/issue_1126_closure_audit_2026-07-06.md` (linked from the #1126 context
+  note). It maps each acceptance criterion to merged-PR evidence (#1091 importer, #3765 fail-closed
+  preflight, #4564 decision packet, plus this PR's import-command fix) and to freshly reproduced
+  fail-closed validation, then records the closure decision: **keep open**, blocked on BYO licensed
+  SDD annotation staging (the only remaining criteria require real staged data, which does not exist
+  locally). Docs + support-tooling only.
 
 * Recorded the **issue #2312 closure audit** at
   `docs/context/evidence/issue_2312_closure_audit.md` (linked from the #2312 context note). It maps

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -3339,3 +3339,7 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_1126_closure_audit_2026-07-06.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence

--- a/docs/context/evidence/issue_1126_closure_audit_2026-07-06.md
+++ b/docs/context/evidence/issue_1126_closure_audit_2026-07-06.md
@@ -1,0 +1,125 @@
+# Issue #1126 Closure Audit
+
+Date: 2026-07-06
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/1126>
+Parent: <https://github.com/ll7/robot_sf_ll7/issues/1091>
+Context note: [`issue_1126_sdd_curation_preflight.md`](../issue_1126_sdd_curation_preflight.md)
+
+## Purpose
+
+Closure audit for #1126 (`bench: curate first real SDD-derived benchmark scenario set`). This note
+maps each acceptance criterion to evidence, records freshly reproduced fail-closed validation, and
+states the closure decision. It asserts only data-preflight / support-tooling readiness: it does
+**not** stage real Stanford Drone Dataset (SDD) annotations, run the importer against real data, run
+a benchmark campaign, or promote any model/benchmark/paper claim.
+
+## Closure decision: KEEP OPEN (blocked on external data)
+
+#1126 stays open with label `state:blocked-external-input`. The **agent-executable, fixture-backed
+slice** — the curation-step readiness gate, the fail-closed evidence contract, and the metadata-only
+decision packet — is complete and covered by tests. The **remaining acceptance criteria require a
+real licensed SDD annotation file staged locally** (bring-your-own, per the 2026-06-22 issue-audit
+reframe and the 2026-07-05 gate update). No such file exists at any approved local source root in
+this checkout, so real scene selection, real import, and the real smoke run cannot be performed and
+must not be faked with fixtures.
+
+Per the repository COMPLETE-FIRST rule an issue whose only remainder is a *compute* run counts as
+complete; #1126's remainder is instead an **external raw-data staging** gate (licensed SDD +
+checksum/license provenance), which is explicitly excluded from agent scope. It therefore stays open,
+not closed.
+
+## Authoritative scope
+
+The issue body's `agent-exec-spec:v1` block (appended 2026-06-20) is the authoritative agent scoping
+and overrides older body wording. It defines the agent-executable slice as: build/verify the
+curation logic on importer fixtures; ensure missing SDD fails closed (never an implied
+dataset-backed result); keep `proxy_schema_smoke` strictly distinct from `dataset_backed_prior`. It
+marks real SDD annotation staging as `Blocked-until` #1497 (validated by #2413). The 2026-07-05
+maintainer comment confirms the identical residual: "Remains open: BYO real SDD annotation staging
+(raw-data gate + checksum/license provenance) before benchmark-ready promotion."
+
+## Acceptance criteria → evidence
+
+| Acceptance criterion (issue body) | Status | Evidence |
+| --- | --- | --- |
+| #1497 has staged official SDD annotations locally, or recorded a clear access/provenance failure that keeps this issue blocked | Blocked (honest fail-closed) | No SDD source at `output/StanfordDroneDataset`, `output/stanford_drone_dataset`, `third_party/sdd`, `third_party/stanford_drone_dataset`, `output/external_data/sdd`. `manage_external_data.py list` reports SDD `Missing local source path` with the license-gated manual acquisition instructions (reproduced below). |
+| One scene/video selected with a recorded deterministic selection rule | Deferred (needs real data) | Deterministic selection rule implemented + fixture-tested: `probe_annotation_file` requires ≥1 track with ≥`min_track_points` usable `label` points after `lost`/label filtering (`sdd_curation_preflight.py`; PR #3765). Concrete scene identity cannot be recorded until BYO data is staged. |
+| Import command, source identity, source checksums, license/source URL, and scale assumptions recorded | Met for the *handoff contract* (this PR); real values deferred | The decision packet (PR #4564) records the import command, dataset id, and label; **this PR fixes the generated import command so it is runnable and now records the `meters_per_pixel` scale assumption** (see "Contract fix" below). Real checksums/URL/scale values are filled at BYO staging time via `manage_external_data.py` + the packet's `--decision-meters-per-pixel`. |
+| Generated scenario/map artifacts pass repository loading/parser validation | Deferred (needs real data) | Importer `import_sdd_scenarios.py` (#1091) and its loader are unit-tested on fixtures; a real generated artifact requires staged data. |
+| At least one representative smoke run succeeds or output is explicitly rejected with reasons | Deferred (needs real data) | The decision packet's `required_next_commands.smoke_validation` names the exact post-import smoke step; it cannot execute without a real generated scenario. |
+| Documentation states `benchmark_ready` vs `exploratory_only` | Met for the gate | The preflight fails closed to `proxy_schema_smoke` / `output_classification: blocked` while unstaged and only reaches `benchmark_candidate` when `dataset_backed` (PR #3765); the final `benchmark_ready` vs `exploratory_only` call is a documented post-smoke decision. |
+| Only small reviewable artifacts or durable pointers committed | Met | No raw SDD or bulky output committed; decision packet is written to git-ignored `output/sdd_curation/issue_1126/`. `raw_data_policy.raw_sdd_committed = False`. |
+
+### Contract fix delivered by this PR
+
+Auditing the #4564 decision packet surfaced a real defect: its generated `import` handoff command
+was **not runnable**. It used `--annotation`/`--output-dir` and omitted the *required*
+`--meters-per-pixel`, while the canonical importer requires `--annotations`, `--out-dir`, and
+`--meters-per-pixel`. A curator copy-pasting it would hit argparse exit `2` before touching data,
+and the packet recorded no scale assumption at all (an explicit acceptance-criterion item).
+
+This PR fixes `build_decision_packet` to emit `--annotations`/`--out-dir`/`--meters-per-pixel`, adds
+a `--decision-meters-per-pixel` CLI flag, records `meters_per_pixel` in `curation_parameters`, and
+emits a `<meters-per-pixel>` placeholder when the scale is unset (scene-specific until BYO staging).
+New regression tests parse the generated command with the importer's own parser so it cannot drift
+again.
+
+### Contributing merged PRs
+
+| PR | Commit | Merged | Contribution |
+| --- | --- | --- | --- |
+| #1091 (#1127) | `9aefd352b` | — | SDD trajectory scenario importer `scripts/tools/import_sdd_scenarios.py` |
+| #3765 | `95b913a13` | 2026-06-27 | Fail-closed SDD curation readiness preflight (`sdd_curation_preflight.py` + tests) |
+| #4564 | `87afce809` | 2026-07-05 | `build_decision_packet()` + `--write-decision-packet`/`--decision-*` flags (metadata-only handoff) |
+| this PR | — | — | Fix the packet's import command to be importer-runnable; record `meters_per_pixel` scale |
+
+Related staging owners (separate issues): #1497 BYO staging preflight (`87afce809`... see
+`manage_external_data.py`), #2413 manifest validation, #3473 staging consolidation, #2657 staging
+recipe.
+
+## Reproduced validation (2026-07-06, worktree from `origin/main` @ `405eb5b5a`)
+
+```bash
+scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/import_sdd_scenarios.py --help
+# exit 0
+
+scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/manage_external_data.py list
+# exit 0; sdd -> "Missing local source path" + license-gated manual acquisition instructions
+
+scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/sdd_curation_preflight.py
+# staging mode: proxy_schema_smoke; dataset_backed: False; benchmark promotion: False; output class: blocked
+
+scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/sdd_curation_preflight.py --require-benchmark-ready
+# exit 3 (fail closed) — refuses to treat the blocked state as benchmark-ready
+
+scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/sdd_curation_preflight.py \
+  --write-decision-packet output/sdd_curation/issue_1126/decision_packet.json \
+  --decision-meters-per-pixel 0.0417
+# exit 0; packet import command:
+#   uv run python scripts/tools/import_sdd_scenarios.py --annotations '<staged-sdd>/.../annotations.txt' \
+#   --out-dir output/sdd_curation/issue_1126 --dataset-id sdd_first_real_candidate --label Pedestrian \
+#   --meters-per-pixel 0.0417 --min-track-points 8 --max-pedestrians 4   (parses against the importer)
+
+scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/tools/test_sdd_curation_preflight.py -q
+# 15 passed
+
+scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/ -k "sdd or import_scenarios" -q
+# 75 passed
+```
+
+## Remaining criteria checklist (unblock gate)
+
+Real curation starts only after a contributor stages a licensed SDD copy. Remaining items, all
+requiring the external raw-data gate:
+
+- [ ] Stage a licensed SDD annotation directory via `manage_external_data.py stage sdd --source <path>`
+      with checksum + license provenance so `resolve_sdd_scenario_prior_mode` reports `dataset_backed_prior`.
+- [ ] Select one scene/video (deterministic rule already implemented) and record its identity, source
+      URL/license, checksums, and calibrated `--decision-meters-per-pixel`.
+- [ ] Run the packet's (now-runnable) importer command and load the generated scenario/map.
+- [ ] Run one CPU smoke path; mark `benchmark_ready` or `exploratory_only`, or reject with reasons.
+
+## Out of scope here
+
+No SDD download/ingestion, no real curation run, no benchmark campaign, no SLURM/GPU submission, no
+paper/dissertation claim edits.

--- a/docs/context/issue_1126_sdd_curation_preflight.md
+++ b/docs/context/issue_1126_sdd_curation_preflight.md
@@ -4,6 +4,11 @@ Status: Current. Scope: the *curation-step* readiness gate only. This note does 
 real-data curation run; issue #1126 stays `state:blocked-external-input` until licensed SDD
 annotations are staged (issue #1497, validated by #2413).
 
+**Closure audit (2026-07-06):** [`evidence/issue_1126_closure_audit_2026-07-06.md`](evidence/issue_1126_closure_audit_2026-07-06.md)
+maps every acceptance criterion to evidence and records the decision to keep #1126 open, blocked on
+BYO licensed SDD staging. That audit also fixed the #4564 decision packet's generated importer
+command (now `--annotations`/`--out-dir` + a recorded `--meters-per-pixel` scale assumption).
+
 ## Why this exists
 
 Issue #1126 curates the first real SDD-derived benchmark scenario set *after* a licensed annotation
@@ -42,8 +47,8 @@ closed otherwise. This preflight is the curation-step gate; it is distinct from:
 ```bash
 uv run python scripts/tools/import_sdd_scenarios.py --help
 uv run python scripts/tools/sdd_curation_preflight.py            # -> proxy_schema_smoke, promotion False
-uv run python -m pytest tests/tools/test_sdd_curation_preflight.py -q   # 8 passed
-uv run python -m pytest tests/ -k "sdd or import_scenarios" -q          # 53 passed
+uv run python -m pytest tests/tools/test_sdd_curation_preflight.py -q   # 15 passed (2026-07-06)
+uv run python -m pytest tests/ -k "sdd or import_scenarios" -q          # 75 passed (2026-07-06)
 ```
 
 The CLI on this checkout reports `staging mode: proxy_schema_smoke`, `dataset_backed: False`,

--- a/scripts/tools/sdd_curation_preflight.py
+++ b/scripts/tools/sdd_curation_preflight.py
@@ -234,23 +234,44 @@ def build_decision_packet(
     max_pedestrians: int,
     dataset_id: str,
     output_dir: Path,
+    meters_per_pixel: float | None = None,
 ) -> dict[str, Any]:
-    """Build a metadata-only handoff packet for the first real SDD curation run."""
+    """Build a metadata-only handoff packet for the first real SDD curation run.
+
+    The generated ``import`` command must be *runnable* against the canonical importer
+    ``scripts/tools/import_sdd_scenarios.py`` so a future curator can copy it verbatim once real
+    SDD annotations are staged. That importer requires ``--annotations`` (not ``--annotation``),
+    ``--out-dir`` (not ``--output-dir``), and a ``--meters-per-pixel`` scale assumption; emitting
+    the wrong flags or omitting the required scale makes the handoff command fail closed at argparse
+    before any data is touched.
+
+    ``meters_per_pixel`` records the scene scale assumption required by the issue acceptance
+    criteria. It is scene-dependent and unknown until real BYO annotations are staged, so when it is
+    ``None`` the command carries an explicit ``<meters-per-pixel>`` placeholder the curator must fill
+    from the selected scene's calibration, and the packet records ``meters_per_pixel: null``.
+    """
     annotation_placeholder = "<staged-sdd>/<scene>/<video>/annotations.txt"
     annotation_command_arg: str | Path = (
         annotation if annotation is not None else annotation_placeholder
     )
+    # meters-per-pixel is a *required* importer argument but is scene-specific, so keep a fill-in
+    # placeholder token until the curator records the selected scene's calibrated scale.
+    meters_per_pixel_arg = (
+        repr(meters_per_pixel) if meters_per_pixel is not None else "<meters-per-pixel>"
+    )
     import_command = " ".join(
         [
             "uv run python scripts/tools/import_sdd_scenarios.py",
-            "--annotation",
+            "--annotations",
             _shell_arg(annotation_command_arg),
+            "--out-dir",
+            _shell_arg(output_dir),
             "--dataset-id",
             _shell_arg(dataset_id),
-            "--output-dir",
-            _shell_arg(output_dir),
             "--label",
             _shell_arg(label),
+            "--meters-per-pixel",
+            meters_per_pixel_arg,
             "--min-track-points",
             str(min_track_points),
             "--max-pedestrians",
@@ -284,6 +305,7 @@ def build_decision_packet(
         "curation_parameters": {
             "dataset_id": dataset_id,
             "label": import_sdd_scenarios.normalize_sdd_label(label),
+            "meters_per_pixel": meters_per_pixel,
             "min_track_points": min_track_points,
             "max_pedestrians": max_pedestrians,
             "output_dir": str(output_dir),
@@ -366,6 +388,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Output directory to place in the decision packet import command.",
     )
     parser.add_argument(
+        "--decision-meters-per-pixel",
+        type=float,
+        default=None,
+        help=(
+            "Scene meters-per-pixel scale assumption to record in the decision packet import "
+            "command. Scene-specific; when omitted the command carries a <meters-per-pixel> "
+            "placeholder the curator must fill from the selected scene's calibration."
+        ),
+    )
+    parser.add_argument(
         "--require-benchmark-ready",
         action="store_true",
         help="Exit non-zero unless curation output may be promoted as benchmark evidence.",
@@ -405,6 +437,7 @@ def main(argv: list[str] | None = None) -> int:
             max_pedestrians=args.max_pedestrians,
             dataset_id=args.decision_dataset_id,
             output_dir=args.decision_output_dir,
+            meters_per_pixel=args.decision_meters_per_pixel,
         )
         args.write_decision_packet.parent.mkdir(parents=True, exist_ok=True)
         args.write_decision_packet.write_text(

--- a/scripts/tools/sdd_curation_preflight.py
+++ b/scripts/tools/sdd_curation_preflight.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import shlex
 import sys
 from pathlib import Path
@@ -250,6 +251,15 @@ def build_decision_packet(
     ``None`` the command carries an explicit ``<meters-per-pixel>`` placeholder the curator must fill
     from the selected scene's calibration, and the packet records ``meters_per_pixel: null``.
     """
+    # Fail closed on an invalid scale rather than emitting a command the importer rejects (or, for
+    # NaN/inf, silently accepts and turns into garbage geometry). The importer requires
+    # ``--meters-per-pixel > 0``; mirror that here and additionally reject non-finite values so the
+    # generated handoff command stays runnable. ``None`` is the intended "unknown scale" case and
+    # is preserved as a fill-in placeholder below.
+    if meters_per_pixel is not None and (
+        not math.isfinite(meters_per_pixel) or meters_per_pixel <= 0
+    ):
+        raise ValueError(f"meters_per_pixel must be a finite value > 0, got {meters_per_pixel!r}")
     annotation_placeholder = "<staged-sdd>/<scene>/<video>/annotations.txt"
     annotation_command_arg: str | Path = (
         annotation if annotation is not None else annotation_placeholder

--- a/tests/tools/test_sdd_curation_preflight.py
+++ b/tests/tools/test_sdd_curation_preflight.py
@@ -8,9 +8,10 @@ benchmark evidence regardless of whether the importer could parse a candidate fi
 from __future__ import annotations
 
 import json
+import shlex
 from typing import TYPE_CHECKING
 
-from scripts.tools import manage_external_data, sdd_curation_preflight
+from scripts.tools import import_sdd_scenarios, manage_external_data, sdd_curation_preflight
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -334,3 +335,125 @@ def test_cli_writes_decision_packet_without_benchmark_claim(tmp_path: Path, monk
     assert packet["readiness"]["evidence_status"] == sdd_curation_preflight.EVIDENCE_PROXY
     assert packet["readiness"]["benchmark_promotion_allowed"] is False
     assert not (tmp_path / "derived").exists()
+
+
+def _parse_importer_command(import_command: str, monkeypatch) -> object:
+    """Parse the generated import command with the importer's own argparse parser.
+
+    ``import_sdd_scenarios.parse_args`` reads ``sys.argv`` directly, so we strip the
+    ``uv run python <script>`` prefix and stage the remaining tokens as argv.
+    """
+    tokens = shlex.split(import_command)
+    assert tokens[:3] == ["uv", "run", "python"]
+    assert tokens[3].endswith("import_sdd_scenarios.py")
+    monkeypatch.setattr("sys.argv", ["import_sdd_scenarios.py", *tokens[4:]])
+    return import_sdd_scenarios.parse_args()
+
+
+def test_decision_packet_import_command_is_runnable_by_importer(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The generated import command must parse against the real importer CLI (issue #1126).
+
+    Regression guard: the importer requires ``--annotations``/``--out-dir``/``--meters-per-pixel``.
+    An earlier packet emitted ``--annotation``/``--output-dir`` and omitted the scale, so the
+    handoff command failed closed at argparse. We parse the generated command with the importer's
+    own parser to prove a curator can run it verbatim.
+    """
+    annotations = tmp_path / "annotations.txt"
+    _write_sdd_fixture(annotations)
+    report = sdd_curation_preflight.classify_curation_readiness(
+        {"mode": manage_external_data.SDD_MODE_PROXY, "dataset_backed": False}, None
+    )
+
+    packet = sdd_curation_preflight.build_decision_packet(
+        report,
+        annotation=annotations,
+        label="Pedestrian",
+        min_track_points=8,
+        max_pedestrians=4,
+        dataset_id="sdd_test_scene",
+        output_dir=tmp_path / "derived",
+        meters_per_pixel=0.0417,
+    )
+
+    import_command = packet["required_next_commands"]["import"]
+    # Uses the importer's real flag names, not the earlier broken --annotation/--output-dir.
+    assert "--annotations" in import_command
+    assert "--out-dir" in import_command
+    assert "--annotation " not in import_command
+    assert "--output-dir" not in import_command
+
+    parsed = _parse_importer_command(import_command, monkeypatch)
+    assert str(parsed.annotations) == str(annotations)
+    assert str(parsed.out_dir) == str(tmp_path / "derived")
+    assert parsed.meters_per_pixel == 0.0417
+    assert parsed.dataset_id == "sdd_test_scene"
+    assert packet["curation_parameters"]["meters_per_pixel"] == 0.0417
+
+
+def test_decision_packet_records_scale_placeholder_when_unset(tmp_path: Path, monkeypatch) -> None:
+    """Without a scene scale the packet keeps a fill-in placeholder and records meters_per_pixel=None.
+
+    The scale is scene-specific and unknown until BYO annotations are staged, so the command must
+    surface an explicit ``<meters-per-pixel>`` token rather than silently dropping the required flag.
+    """
+    report = sdd_curation_preflight.classify_curation_readiness(
+        {"mode": manage_external_data.SDD_MODE_PROXY, "dataset_backed": False}, None
+    )
+
+    packet = sdd_curation_preflight.build_decision_packet(
+        report,
+        annotation=None,
+        label="Pedestrian",
+        min_track_points=8,
+        max_pedestrians=4,
+        dataset_id="sdd_first_real_candidate",
+        output_dir=tmp_path / "derived",
+    )
+
+    import_command = packet["required_next_commands"]["import"]
+    assert "--meters-per-pixel <meters-per-pixel>" in import_command
+    assert packet["curation_parameters"]["meters_per_pixel"] is None
+    # Once the curator fills the placeholder scale, the command parses as a valid float.
+    filled = import_command.replace("<meters-per-pixel>", "0.05").replace(
+        "<staged-sdd>/<scene>/<video>/annotations.txt", str(tmp_path / "a.txt")
+    )
+    parsed = _parse_importer_command(filled, monkeypatch)
+    assert parsed.meters_per_pixel == 0.05
+
+
+def test_cli_decision_meters_per_pixel_is_recorded(tmp_path: Path, monkeypatch) -> None:
+    """The --decision-meters-per-pixel flag threads the scene scale into the packet."""
+    annotations = tmp_path / "annotations.txt"
+    packet_path = tmp_path / "packet.json"
+    _write_sdd_fixture(annotations)
+    monkeypatch.setattr(
+        manage_external_data,
+        "resolve_sdd_scenario_prior_mode",
+        lambda *, manifest_path=None: {
+            "mode": manage_external_data.SDD_MODE_PROXY,
+            "dataset_backed": False,
+            "availability": {"state": "missing"},
+            "reason": "SDD not staged.",
+            "staging_dir": str(tmp_path),
+        },
+    )
+
+    exit_code = sdd_curation_preflight.main(
+        [
+            "--annotation",
+            str(annotations),
+            "--min-track-points",
+            "4",
+            "--write-decision-packet",
+            str(packet_path),
+            "--decision-meters-per-pixel",
+            "0.0417",
+        ]
+    )
+
+    assert exit_code == 0
+    packet = json.loads(packet_path.read_text(encoding="utf-8"))
+    assert packet["curation_parameters"]["meters_per_pixel"] == 0.0417
+    assert "--meters-per-pixel 0.0417" in packet["required_next_commands"]["import"]

--- a/tests/tools/test_sdd_curation_preflight.py
+++ b/tests/tools/test_sdd_curation_preflight.py
@@ -8,8 +8,11 @@ benchmark evidence regardless of whether the importer could parse a candidate fi
 from __future__ import annotations
 
 import json
+import math
 import shlex
 from typing import TYPE_CHECKING
+
+import pytest
 
 from scripts.tools import import_sdd_scenarios, manage_external_data, sdd_curation_preflight
 
@@ -457,3 +460,28 @@ def test_cli_decision_meters_per_pixel_is_recorded(tmp_path: Path, monkeypatch) 
     packet = json.loads(packet_path.read_text(encoding="utf-8"))
     assert packet["curation_parameters"]["meters_per_pixel"] == 0.0417
     assert "--meters-per-pixel 0.0417" in packet["required_next_commands"]["import"]
+
+
+@pytest.mark.parametrize("bad_scale", [0.0, -0.05, float("nan"), float("inf")])
+def test_decision_packet_rejects_invalid_meters_per_pixel(tmp_path: Path, bad_scale: float) -> None:
+    """A non-positive or non-finite scale must fail closed at packet build (issue #1126).
+
+    The importer requires ``--meters-per-pixel > 0``; a NaN/inf slips past that ``<= 0`` guard and
+    would produce garbage geometry. Reject it here so the generated handoff command is never emitted
+    with an unrunnable/garbage scale.
+    """
+    report = sdd_curation_preflight.classify_curation_readiness(
+        {"mode": manage_external_data.SDD_MODE_PROXY, "dataset_backed": False}, None
+    )
+    with pytest.raises(ValueError, match="finite value > 0"):
+        sdd_curation_preflight.build_decision_packet(
+            report,
+            annotation=None,
+            label="Pedestrian",
+            min_track_points=8,
+            max_pedestrians=4,
+            dataset_id="sdd_first_real_candidate",
+            output_dir=tmp_path / "derived",
+            meters_per_pixel=bad_scale,
+        )
+    assert not math.isfinite(bad_scale) or bad_scale <= 0  # guards the parametrization intent


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Closure audit for issue #1126 (`bench: curate first real SDD-derived benchmark
  scenario set`). The audit surfaced a real defect in the #4564 decision packet: its generated
  `import` handoff command was **not runnable**. This PR fixes it and records the full
  criterion→evidence map.
- **Why now:** Ready-queue closure audit. #1126 is a blocked-external-input (BYO SDD) issue whose
  agent-executable slice landed across #1091/#3765/#4564, but the packet's handoff command would
  fail closed at argparse for a future curator, and the required `meters_per_pixel` scale assumption
  (an explicit acceptance-criterion item) was not recorded anywhere.
- **Claim boundary:** Support-tooling + data-preflight / docs. No real SDD data staged, no importer
  run against real data, no benchmark campaign, no model/benchmark/paper claim.
- **Required validation:** `pytest tests/tools/test_sdd_curation_preflight.py` (15 pass) and
  `pytest tests/ -k "sdd or import_scenarios"` (75 pass); fail-closed preflight reproduced (exit 3).
- **Remaining blocker:** #1126 stays **open**, blocked on BYO licensed SDD annotation staging
  (raw-data gate + checksum/license provenance). The only remaining acceptance criteria require real
  staged data that does not exist locally.

Issue: https://github.com/ll7/robot_sf_ll7/issues/1126

## Contract delta

`scripts/tools/sdd_curation_preflight.py::build_decision_packet`:

- Generated `import` command now uses the importer's real flags **`--annotations`** and
  **`--out-dir`** (were `--annotation`/`--output-dir`, which `import_sdd_scenarios.py` rejects with
  exit `2`) and includes the **required `--meters-per-pixel`** scale (was omitted entirely).
- New optional `meters_per_pixel` packet field in `curation_parameters`; new CLI flag
  **`--decision-meters-per-pixel`**. When unset, the command carries an explicit
  `<meters-per-pixel>` placeholder the curator must fill from the selected scene's calibration
  (scene-specific until BYO staging), and the packet records `meters_per_pixel: null`.
- Backwards compatible: `build_decision_packet` gains a keyword-only arg with a default; the
  packet schema (`robot_sf_sdd_curation_decision_packet.v1`) gains a field but drops none. No
  fail-closed behavior of the preflight gate changes.

Regression guard: two new tests parse the generated command with the importer's own argparse parser,
so the handoff cannot silently drift back to broken flags.

## Scope summary

- Fix the decision-packet import command + record scale assumption (code + tests).
- Add closure-audit criterion→evidence map at
  `docs/context/evidence/issue_1126_closure_audit_2026-07-06.md`, linked from the #1126 context note.
- CHANGELOG entries under Fixed + Changed.

Decision: **keep #1126 open**. The fixture-backed curation-step slice (readiness gate, fail-closed
evidence contract, runnable handoff packet) is complete; real scene selection / import / smoke run
require a licensed SDD copy staged locally, which is out of agent scope (external raw-data gate).

## Validation command results

Reproduced in a worktree from `origin/main` @ `405eb5b5a` via `scripts/dev/run_worktree_shared_venv.sh`:

```text
import_sdd_scenarios.py --help                                  -> exit 0
manage_external_data.py list                                    -> sdd "Missing local source path" (license-gated)
sdd_curation_preflight.py                                       -> proxy_schema_smoke; dataset_backed False; promotion False; class blocked
sdd_curation_preflight.py --require-benchmark-ready             -> exit 3 (fail closed)
sdd_curation_preflight.py --write-decision-packet ... \
  --decision-meters-per-pixel 0.0417                            -> exit 0; import cmd uses --annotations/--out-dir/--meters-per-pixel and parses
pytest tests/tools/test_sdd_curation_preflight.py -q            -> 15 passed
pytest tests/ -k "sdd or import_scenarios" -q                   -> 75 passed
ruff check / ruff format (changed files)                        -> clean
```

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no real
SDD data staging or redistribution.

Refs #1126

<details>
<summary>Governance / state propagation</summary>

- **State propagation:** `comment_issue_or_pr` is not authorized for this lane, so no issue comment
  was posted; this PR body + the tracked closure-audit note under `docs/context/evidence/` are the
  durable state surface. No transient queue-routing state is encoded in tracked files.
- **Fragmentation guard:** only one packet PR (#4564) merged in the last 24h (not ≥2), and this is a
  progression slice — it delivers a nameable new capability (a *runnable* curation handoff command +
  recorded scale assumption) plus the closure-audit integration report, not a blocker-state refresh.
- **Freshness:** re-checked #1126 immediately before opening; no maintainer comment newer than the
  2026-07-05 gate update (which this PR's remaining-blocker note reflects).
- **Downstream Propagation:** parent #1091 unaffected; no benchmark report / leaderboard / registry
  changes (no benchmark evidence produced). Context index unchanged (note linked from existing
  #1126 context note).
- **Research Result Guidance:** NA — support/tooling + closure-audit docs; no research claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
