### PR TITLE
feat(benchmark): #1489 hybrid-learning synthesis recommendation builder (fail-closed per-mechanism verdicts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* **issue #1489 hybrid-learning synthesis recommendation builder.**
+  `robot_sf/benchmark/hybrid_evidence_matrix.py` now exposes
+  `build_hybrid_synthesis_report()` / `build_hybrid_synthesis_report_file()`, the synthesis-
+  deliverable half of the #1489 contract. Given the existing prerequisite/status matrix, it emits an
+  explicit per-mechanism recommendation (`continue`/`revise`/`stop`/`gather_more_evidence`) while
+  staying fail-closed: a `continue`/`revise` verdict is *promoted* (marked authoritative via
+  `synthesis_verdict_promoted`) only when the synthesis gate is open (≥2 durable `complete` lanes and
+  no invalid rows), so no single pre-result lane, launch packet, smoke run, fallback/degraded row, or
+  invalid row can promote a synthesis verdict. Terminal `stop` decisions on an executed
+  stress/full-matrix slice are surfaced but never promoted. Focused tests cover the blocked, single-
+  complete, two-complete (gate opens), terminal-stop, invalid-row, and missing-lane paths
+  (`tests/benchmark/test_hybrid_synthesis_report.py`, 8 pass). This advances the #1489 acceptance
+  criterion *"synthesis recommends continue/revise/stop/gather-more-evidence for each mechanism"* by
+  providing the machinery that emits it; the issue stays open (`Refs #1489`), blocked on component
+  campaigns producing ≥2 durable comparable `complete` lanes (#1470/#1472/#1474/#1475/#1358). No
+  benchmark campaign run, no SLURM/GPU submission, no paper/dissertation claim edits.
+
 ### Fixed
 
 * **issue #1126 SDD curation decision packet — runnable import command.**

--- a/robot_sf/benchmark/hybrid_evidence_matrix.py
+++ b/robot_sf/benchmark/hybrid_evidence_matrix.py
@@ -47,6 +47,19 @@ ISSUE_1489_INTEGRATION_NEXT_ACTIONS = {
         "Run the conservative #1489 synthesis over the complete durable lanes."
     ),
 }
+# Per-mechanism recommendations the #1489 synthesis report can emit. ``continue``
+# and ``revise`` are promoted only from durable ``complete`` lanes when the gate
+# is open; ``stop`` is a terminal negative decision from a full-slice lane; every
+# other lane state maps to ``gather_more_evidence`` (fail-closed default).
+SYNTHESIS_RECOMMENDATIONS = frozenset({"continue", "revise", "stop", "gather_more_evidence"})
+# Human-readable basis for each per-mechanism recommendation, keyed by the
+# campaign-lifecycle state from :func:`classify_component_campaign_state`.
+_SYNTHESIS_BASIS_BY_STATE = {
+    "complete": "durable_complete_lane",
+    "ready": "executed_non_synthesis",
+    "blocked": "pre_runtime_or_invalid",
+    "missing": "no_campaign_row",
+}
 ROW_REQUIRED_FIELDS = frozenset(
     {
         "component",
@@ -399,6 +412,120 @@ def build_hybrid_prerequisite_matrix_file(
     report["input_path"] = _repo_relative_or_absolute(
         path.resolve(), root=(repo_root or get_repository_root())
     )
+    return report
+
+
+def build_hybrid_synthesis_report(matrix_report: dict[str, Any]) -> dict[str, Any]:
+    """Assemble the #1489 per-mechanism synthesis recommendation from a matrix.
+
+    This is the synthesis-deliverable half of the #1489 contract. It turns the
+    campaign-lifecycle matrix produced by :func:`build_hybrid_prerequisite_matrix`
+    into an explicit per-mechanism recommendation
+    (``continue``/``revise``/``stop``/``gather_more_evidence``) while staying
+    fail-closed:
+
+    - A ``continue``/``revise`` verdict is *promoted* (marked authoritative) only
+      when the prerequisite gate is open — at least ``prerequisite_count`` durable
+      ``complete`` lanes and no invalid rows. No single pre-result lane, launch
+      packet, smoke run, or fallback/degraded row can open the gate, so none can
+      promote a synthesis verdict.
+    - A ``stop`` recommendation is surfaced only for a lane that actually executed
+      a synthesis-tier slice (``stress``/``full_matrix``) and concluded ``stop``.
+      It is a terminal negative decision, never a promoted synthesis verdict.
+    - Every other lane (missing, blocked, executed-but-not-synthesis-grade) maps to
+      ``gather_more_evidence``.
+
+    Args:
+        matrix_report: The report returned by
+            :func:`build_hybrid_prerequisite_matrix` or
+            :func:`build_hybrid_prerequisite_matrix_file`.
+
+    Returns:
+        Compact synthesis report with the overall eligibility decision and a
+        per-mechanism recommendation list. When the gate is blocked the report
+        echoes the integration-status blockers and next empirical action so no
+        weak lane is silently promoted.
+    """
+    integration = matrix_report.get("integration_status", {})
+    prerequisite_met = bool(matrix_report.get("prerequisite_met"))
+    rows_valid = bool(matrix_report.get("rows_valid", True))
+    gate_open = prerequisite_met and rows_valid
+
+    mechanisms: list[dict[str, Any]] = []
+    promoted_verdict_count = 0
+    for lane in matrix_report.get("lanes", []):
+        state = lane.get("state")
+        verdict = lane.get("verdict")
+        if state == "complete" and verdict in SYNTHESIS_VERDICTS:
+            recommendation = verdict
+        elif verdict == "stop" and lane.get("evidence_tier") in SYNTHESIS_TIERS:
+            recommendation = "stop"
+        else:
+            recommendation = "gather_more_evidence"
+        promoted = gate_open and state == "complete" and recommendation in SYNTHESIS_VERDICTS
+        if promoted:
+            promoted_verdict_count += 1
+        mechanisms.append(
+            {
+                "component": lane.get("component"),
+                "source_issue": lane.get("source_issue"),
+                "state": state,
+                "recommendation": recommendation,
+                "recommendation_basis": _SYNTHESIS_BASIS_BY_STATE.get(state, "unknown"),
+                "synthesis_verdict_promoted": promoted,
+            }
+        )
+
+    return {
+        "issue": "#1489",
+        "status": "ready_for_synthesis" if gate_open else "blocked",
+        "eligible": gate_open,
+        "claim_boundary": (
+            "conservative per-mechanism synthesis recommendation; a verdict is "
+            "authoritative only when synthesis_verdict_promoted is true (gate open). "
+            "Not benchmark evidence on its own."
+        ),
+        "prerequisite_count": matrix_report.get("prerequisite_count"),
+        "complete_count": matrix_report.get("complete_count"),
+        "promoted_verdict_count": promoted_verdict_count,
+        "blockers": list(integration.get("blockers", [])),
+        "next_empirical_action": integration.get("next_empirical_action"),
+        "mechanisms": mechanisms,
+    }
+
+
+def build_hybrid_synthesis_report_file(
+    path: Path,
+    *,
+    expected_components: list[str] | None = None,
+    repo_root: Path | None = None,
+    check_git_history: bool = False,
+    prerequisite_count: int = DEFAULT_SYNTHESIS_PREREQUISITE_COUNT,
+) -> dict[str, Any]:
+    """Load a matrix file and build its #1489 synthesis recommendation report.
+
+    Args:
+        path: YAML/JSON evidence-matrix file accepted by
+            :func:`load_hybrid_evidence_input`.
+        expected_components: Optional expected component names (see
+            :func:`build_hybrid_prerequisite_matrix`).
+        repo_root: Repository root for provenance-path resolution.
+        check_git_history: Forwarded to the row validator to verify git SHAs.
+        prerequisite_count: Minimum ``complete`` lanes that open the gate.
+
+    Returns:
+        The synthesis report with the input format and path attached.
+    """
+    matrix_report = build_hybrid_prerequisite_matrix_file(
+        path,
+        expected_components=expected_components,
+        repo_root=repo_root,
+        check_git_history=check_git_history,
+        prerequisite_count=prerequisite_count,
+    )
+    report = build_hybrid_synthesis_report(matrix_report)
+    report["input_format"] = matrix_report.get("input_format")
+    report["input_path"] = matrix_report.get("input_path")
     return report
 
 
@@ -1074,9 +1201,12 @@ __all__ = [
     "COMPONENT_CAMPAIGN_STATES",
     "DEFAULT_SYNTHESIS_PREREQUISITE_COUNT",
     "PRE_RUNTIME_TIERS",
+    "SYNTHESIS_RECOMMENDATIONS",
     "HybridEvidenceMatrixValidationError",
     "build_hybrid_prerequisite_matrix",
     "build_hybrid_prerequisite_matrix_file",
+    "build_hybrid_synthesis_report",
+    "build_hybrid_synthesis_report_file",
     "classify_component_campaign_state",
     "load_hybrid_evidence_input",
     "validate_hybrid_evidence_file",

--- a/robot_sf/benchmark/hybrid_evidence_matrix.py
+++ b/robot_sf/benchmark/hybrid_evidence_matrix.py
@@ -448,7 +448,9 @@ def build_hybrid_synthesis_report(matrix_report: dict[str, Any]) -> dict[str, An
     """
     integration = matrix_report.get("integration_status", {})
     prerequisite_met = bool(matrix_report.get("prerequisite_met"))
-    rows_valid = bool(matrix_report.get("rows_valid", True))
+    # Fail-closed: a missing or None ``rows_valid`` must NOT open the gate. Only an
+    # explicit truthy value from a validated matrix report counts as valid rows.
+    rows_valid = bool(matrix_report.get("rows_valid", False))
     gate_open = prerequisite_met and rows_valid
 
     mechanisms: list[dict[str, Any]] = []

--- a/tests/benchmark/test_hybrid_synthesis_report.py
+++ b/tests/benchmark/test_hybrid_synthesis_report.py
@@ -145,6 +145,22 @@ def test_all_recommendations_use_the_shared_vocabulary() -> None:
         assert lane["recommendation"] in SYNTHESIS_RECOMMENDATIONS
 
 
+def test_missing_or_none_rows_valid_keeps_gate_closed() -> None:
+    """A matrix report lacking (or None) ``rows_valid`` must not open the gate."""
+    matrix = build_hybrid_prerequisite_matrix([_complete_row(), _second_complete_row()])
+    assert matrix["prerequisite_met"] is True  # two complete lanes clears prereq
+
+    dropped = {k: v for k, v in matrix.items() if k != "rows_valid"}
+    none_valued = {**matrix, "rows_valid": None}
+
+    for degraded in (dropped, none_valued):
+        report = build_hybrid_synthesis_report(degraded)
+        assert report["eligible"] is False
+        assert report["status"] == "blocked"
+        assert report["promoted_verdict_count"] == 0
+        assert all(m["synthesis_verdict_promoted"] is False for m in report["mechanisms"])
+
+
 def test_file_helper_attaches_input_metadata() -> None:
     """The file helper classifies fixture rows and records the input path."""
     report = build_hybrid_synthesis_report_file(FIXTURE_ROOT / "valid_rows.yaml")

--- a/tests/benchmark/test_hybrid_synthesis_report.py
+++ b/tests/benchmark/test_hybrid_synthesis_report.py
@@ -1,0 +1,157 @@
+"""Tests for the #1489 hybrid-learning synthesis recommendation report.
+
+These tests exercise :func:`build_hybrid_synthesis_report`, the synthesis-
+deliverable half of the #1489 contract. They confirm the fail-closed promotion
+rule (a ``continue``/``revise`` verdict is authoritative only when the
+prerequisite gate is open), the terminal ``stop`` surfacing rule, and that no
+pre-result, single-complete, or invalid-row matrix can promote a verdict. Rows
+are built from the shared evidence-matrix fixtures and mutated synthetically so
+each case is focused and deterministic.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+from robot_sf.benchmark.hybrid_evidence_matrix import (
+    SYNTHESIS_RECOMMENDATIONS,
+    build_hybrid_prerequisite_matrix,
+    build_hybrid_synthesis_report,
+    build_hybrid_synthesis_report_file,
+    load_hybrid_evidence_input,
+)
+
+FIXTURE_ROOT = Path("tests/fixtures/hybrid_evidence_matrix/v1")
+
+
+def _complete_row() -> dict:
+    """Return a deep copy of the synthesis-eligible stress-slice fixture row."""
+    _input_format, rows = load_hybrid_evidence_input(FIXTURE_ROOT / "valid_rows.yaml")
+    return copy.deepcopy(rows[0])
+
+
+def _blocked_launch_packet_row() -> dict:
+    """Return a deep copy of the not-run launch-packet fixture row."""
+    _input_format, rows = load_hybrid_evidence_input(FIXTURE_ROOT / "valid_rows.yaml")
+    return copy.deepcopy(rows[1])
+
+
+def _second_complete_row() -> dict:
+    """Return a distinct second synthesis-eligible lane."""
+    row = _complete_row()
+    row["component"] = "orca_residual_learned_v1"
+    row["source_issue"] = "#1358"
+    return row
+
+
+def _stop_full_slice_row() -> dict:
+    """Return an executed stress-slice lane that concluded ``stop``."""
+    row = _complete_row()
+    row["component"] = "shielded_ppo_repair_v1"
+    row["source_issue"] = "#1474"
+    row["verdict"] = "stop"
+    return row
+
+
+def _synthesis_from_rows(rows: list[dict], **kwargs) -> dict:
+    """Build the prerequisite matrix then the synthesis report."""
+    matrix = build_hybrid_prerequisite_matrix(rows, **kwargs)
+    return build_hybrid_synthesis_report(matrix)
+
+
+def test_no_complete_lanes_stays_blocked_and_unpromoted() -> None:
+    """A launch-packet-only matrix must fail closed with no promoted verdicts."""
+    report = _synthesis_from_rows([_blocked_launch_packet_row()])
+
+    assert report["status"] == "blocked"
+    assert report["eligible"] is False
+    assert report["promoted_verdict_count"] == 0
+    assert report["blockers"]
+    assert report["mechanisms"][0]["recommendation"] == "gather_more_evidence"
+    assert report["mechanisms"][0]["synthesis_verdict_promoted"] is False
+
+
+def test_single_complete_lane_does_not_open_the_gate() -> None:
+    """One complete lane recommends its verdict but is not yet promoted."""
+    report = _synthesis_from_rows([_complete_row()])
+
+    assert report["status"] == "blocked"
+    assert report["eligible"] is False
+    assert report["promoted_verdict_count"] == 0
+    lane = report["mechanisms"][0]
+    assert lane["recommendation"] == "continue"
+    assert lane["recommendation_basis"] == "durable_complete_lane"
+    assert lane["synthesis_verdict_promoted"] is False
+
+
+def test_two_complete_lanes_open_the_gate_and_promote() -> None:
+    """At two durable complete lanes the gate opens and both verdicts promote."""
+    report = _synthesis_from_rows([_complete_row(), _second_complete_row()])
+
+    assert report["status"] == "ready_for_synthesis"
+    assert report["eligible"] is True
+    assert report["promoted_verdict_count"] == 2
+    assert report["blockers"] == []
+    for lane in report["mechanisms"]:
+        assert lane["recommendation"] in {"continue", "revise"}
+        assert lane["synthesis_verdict_promoted"] is True
+
+
+def test_terminal_stop_is_surfaced_but_never_promoted() -> None:
+    """A stress-slice lane concluding ``stop`` surfaces as stop, unpromoted."""
+    report = _synthesis_from_rows([_stop_full_slice_row(), _complete_row()])
+
+    stop_lane = next(m for m in report["mechanisms"] if m["component"] == "shielded_ppo_repair_v1")
+    assert stop_lane["recommendation"] == "stop"
+    assert stop_lane["synthesis_verdict_promoted"] is False
+    # One complete + one stop lane => only one complete lane => gate stays closed.
+    assert report["eligible"] is False
+    assert report["promoted_verdict_count"] == 0
+
+
+def test_invalid_row_keeps_gate_closed_even_with_two_complete() -> None:
+    """An invalid row makes the matrix not rows_valid, so nothing promotes."""
+    invalid = _complete_row()
+    invalid.pop("outcomes")  # drop a required field -> invalid row
+    report = _synthesis_from_rows([_complete_row(), _second_complete_row(), invalid])
+
+    assert report["eligible"] is False
+    assert report["status"] == "blocked"
+    assert report["promoted_verdict_count"] == 0
+    assert any("invalid" in blocker for blocker in report["blockers"])
+
+
+def test_missing_expected_component_maps_to_gather_more_evidence() -> None:
+    """An expected-but-absent lane is reported as gather_more_evidence."""
+    report = _synthesis_from_rows(
+        [_complete_row()], expected_components=["learned_risk_model_v1", "absent_component"]
+    )
+
+    missing = next(m for m in report["mechanisms"] if m["component"] == "absent_component")
+    assert missing["state"] == "missing"
+    assert missing["recommendation"] == "gather_more_evidence"
+    assert missing["recommendation_basis"] == "no_campaign_row"
+    assert missing["synthesis_verdict_promoted"] is False
+
+
+def test_all_recommendations_use_the_shared_vocabulary() -> None:
+    """Every emitted recommendation must be in the declared vocabulary."""
+    report = _synthesis_from_rows(
+        [_complete_row(), _stop_full_slice_row(), _blocked_launch_packet_row()]
+    )
+
+    for lane in report["mechanisms"]:
+        assert lane["recommendation"] in SYNTHESIS_RECOMMENDATIONS
+
+
+def test_file_helper_attaches_input_metadata() -> None:
+    """The file helper classifies fixture rows and records the input path."""
+    report = build_hybrid_synthesis_report_file(FIXTURE_ROOT / "valid_rows.yaml")
+
+    assert report["issue"] == "#1489"
+    # The fixture holds one complete lane and one launch packet => blocked.
+    assert report["status"] == "blocked"
+    assert report["eligible"] is False
+    assert isinstance(report["input_format"], str) and report["input_format"]
+    assert report["input_path"].endswith("valid_rows.yaml")


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Added `build_hybrid_synthesis_report()` / `build_hybrid_synthesis_report_file()` to `robot_sf/benchmark/hybrid_evidence_matrix.py` — the synthesis-deliverable half of the #1489 contract. It turns the existing prerequisite/status matrix into an explicit per-mechanism recommendation (`continue`/`revise`/`stop`/`gather_more_evidence`).
- **Why now:** The #1489 machinery already had the schema, validator, lifecycle classifier, prerequisite gate, and integration-status report, but **no builder emitted the per-mechanism synthesis recommendation** the issue asks for. This is a nameable new capability toward the implementation plan, not a blocker refresh.
- **Claim boundary:** Enabling/contract code only. Fail-closed: a verdict is authoritative (`synthesis_verdict_promoted: true`) **only** when the synthesis gate is open (≥2 durable `complete` lanes, no invalid rows). No benchmark claim is promoted; this is not benchmark evidence on its own.
- **Required validation:** `uv run pytest tests/benchmark/test_hybrid_synthesis_report.py tests/benchmark/test_hybrid_prerequisite_matrix.py tests/benchmark/test_hybrid_evidence_matrix.py -q` (37 pass) + `ruff check`/`format` clean.
- **Remaining blocker:** #1489 stays **open** — comparative synthesis still requires ≥2 component campaigns (#1470/#1472/#1474/#1475/#1358) to produce durable comparable `complete` lanes (SLURM-bound, out of scope here).

## Contract delta

- **New public API:** `build_hybrid_synthesis_report(matrix_report)`, `build_hybrid_synthesis_report_file(path, ...)`, constant `SYNTHESIS_RECOMMENDATIONS` (added to `__all__`).
- **New fail-closed behavior:** per-mechanism promotion is gated on the whole-matrix synthesis gate. A single `complete` lane, a launch packet, a smoke/nominal run, a fallback/degraded row, or any invalid row **cannot** promote a `continue`/`revise` verdict. Terminal `stop` on an executed stress/full-matrix slice is surfaced but never promoted.
- **Compatibility impact:** additive only. No existing function signature, schema field, validator rule, or gate threshold changed; existing hybrid-matrix tests pass unchanged.

## Scope

- Issue: https://github.com/ll7/robot_sf_ll7/issues/1489
- Refs #1489 (partial — does **not** close). Advances the acceptance criterion *"synthesis recommends continue/revise/stop/gather-more-evidence for each mechanism"* by delivering the machinery that emits it, with fail-closed promotion so no weak lane is silently synthesized.

### Remaining #1489 criteria checklist

- [x] Shared synthesis table + diagnostics contract (schema/validator — prior PRs #1516/#1535/#1547).
- [x] Prerequisite/status matrix + integration-status report (prior PRs #3736/#4452).
- [x] Per-mechanism recommendation builder (`continue`/`revise`/`stop`/`gather_more_evidence`), fail-closed **(this PR)**.
- [ ] ≥2 component campaigns produce durable comparable `complete` lanes (#1470/#1472/#1474/#1475/#1358) — **blocked, SLURM-bound**.
- [ ] Reader can tell whether learned components improved downstream metrics — blocked on the above.
- [ ] Final conservative synthesis note over real complete lanes — blocked on the above.

## Validation results

```
$ uv run pytest tests/benchmark/test_hybrid_synthesis_report.py \
    tests/benchmark/test_hybrid_prerequisite_matrix.py \
    tests/benchmark/test_hybrid_evidence_matrix.py -q
8 passed  (new synthesis-report tests)
37 passed total across the three hybrid-matrix test modules

$ scripts/dev/ruff_fix_format.sh
All checks passed! ; 2543 files left unchanged
```

## Out of scope

- No full benchmark campaign run.
- No SLURM/GPU submission.
- No paper/dissertation claim edits.

## State propagation

Low-churn issue (no #1489 PR merged in the last 24h). No transient queue-routing state is written to tracked files. Durable state lives in this PR's contract change + CHANGELOG; the remaining-criteria checklist above records the blocker. `comment_issue_or_pr` is disabled for this lane, so no issue comment is posted — the merge of this PR (with the checklist) is the state surface.

<details>
<summary>Governance / process notes</summary>

- Isolated worktree from `origin/main`; branch `issue-1489-hybrid-synthesis-report-builder`.
- Fragmentation guard: not triggered (no ≥2 guard/checker/packet-refresh PRs merged for #1489 in the last 24h); regardless, this is an exempt progression slice adding a nameable new capability.
- Prior closure audit (`docs/context/evidence/issue_1489_closure_audit_2026-07-05.md`, PR #4563) concluded "keep open, blocked"; this PR does not restate that — it implements the smallest remaining CPU-only capability toward an open acceptance criterion.
- Extends the canonical owner `robot_sf/benchmark/hybrid_evidence_matrix.py` rather than creating a new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hybrid synthesis recommendations for benchmark reports, including clearer status outcomes and next-step guidance.
  * New file-based reporting now includes input metadata alongside the generated synthesis summary.

* **Bug Fixes**
  * Improved fail-closed behavior so recommendations stay blocked when prerequisites aren’t met or rows are invalid.
  * Terminal stop outcomes are now surfaced appropriately without being promoted.

* **Tests**
  * Added coverage for gate behavior, promotion rules, invalid-row handling, and report metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->