### PR TITLE
fix: issue #4183 hybrid_global_rl diagnostic — executable baseline arm (schema + checkpoint hydration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **issue #4183 hybrid_global_rl diagnostic runner — executable baseline arm.**
+  The paired diagnostic runner `scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py` now
+  (a) validates episodes against the canonical `robot_sf/benchmark/schemas/episode.schema.v1.json`
+  instead of a stale strict schema that rejected native PPO episode records with
+  `additionalProperties` errors, and (b) hydrates the benchmark-promoted learned checkpoint from its
+  public GitHub release before preflight (`--no-hydrate` to skip). The #4183 preflight
+  (`robot_sf/benchmark/hybrid_global_rl_diagnostic.py`) also recognizes a hydrated release asset
+  whose cached file name (`<model_id>-model.zip`) differs from the registry `local_path`
+  (`model.zip`), so a present-and-loadable checkpoint no longer reports
+  `blocked_missing_learned_checkpoint`. With these fixes the unconditioned (baseline) arm produces
+  native episode rows (3/3 seeds) and the packet advances from `blocked_no_valid_episode_rows` to
+  `completed_with_fail_closed_exclusions`. Diagnostic-tier only; the route-conditioned arm remains
+  fail-closed because the benchmark observation carries no `occupancy_grid` channel for the
+  grid-route waypoint provider, so route-conditioned effect evidence stays blocked (see #4183).
+  New regression tests: `tests/benchmark/test_hybrid_global_rl_diagnostic_issue_4183.py` and
+  `tests/benchmark/test_issue_4183_paired_runner.py` (30 pass). No benchmark campaign, no SLURM/GPU
+  submission, no paper/dissertation claim edits.
 * **issue #1126 SDD curation decision packet — runnable import command.**
   `scripts/tools/sdd_curation_preflight.py::build_decision_packet` now emits an `import` handoff
   command that actually parses against the canonical importer

--- a/docs/context/evidence/issue_4183_hybrid_global_rl_diagnostic/README.md
+++ b/docs/context/evidence/issue_4183_hybrid_global_rl_diagnostic/README.md
@@ -3,15 +3,12 @@
 This packet records a diagnostic-only paired route/occupancy comparison for `hybrid_global_rl` against the same learned local policy without route conditioning.
 
 - Evidence status: `diagnostic-only`
-- Run status: `blocked_no_valid_episode_rows`
+- Run status: `completed_with_fail_closed_exclusions`
 - Claim boundary: diagnostic-only paired route/occupancy comparison; not benchmark-improvement or paper-facing evidence
 - Included diagnostic rows: 0
 - Fallback/degraded rows excluded: 0
-- Invalid pair rows: 0
+- Invalid pair rows: 3
 - Linked work: #4161 and #4015
-- Registry preflight: `preflight_registry_checkpoint_20260705.json` records the durable
-  `ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417` checkpoint
-  reference and the current `blocked_missing_learned_checkpoint` cache state.
 
 Rows marked fallback, degraded, unavailable, or missing-pair are not evidence for a route-conditioned effect. They remain diagnostic rows only.
 
@@ -24,9 +21,10 @@ This section classifies the diagnostic packet state so the next empirical action
 
 ### Blockers Remaining
 
-- no_valid_episode_rows: status=remaining, evidence=Fail-closed runner failures produced no paired episode rows.
+- no_included_route_conditioned_effect_rows: status=remaining, evidence=The packet has no native, paired route-conditioned effect rows.
 - fail_closed_route_conditioned_hybrid_global_rl: status=remaining, evidence=RuntimeError('hybrid_global_rl route waypoint unavailable'), row_classification=fail_closed_no_episode_row
-- fail_closed_learned_local_no_route_conditioning: status=remaining, evidence=RuntimeError('PPO model unavailable or prediction failed'), row_classification=fail_closed_no_episode_row
+- fail_closed_route_conditioned_hybrid_global_rl: status=remaining, evidence=RuntimeError('hybrid_global_rl route waypoint unavailable'), row_classification=fail_closed_no_episode_row
+- fail_closed_route_conditioned_hybrid_global_rl: status=remaining, evidence=RuntimeError('hybrid_global_rl route waypoint unavailable'), row_classification=fail_closed_no_episode_row
 
 ### New Blockers
 
@@ -35,9 +33,10 @@ This section classifies the diagnostic packet state so the next empirical action
 ### Intentional Exclusions
 
 - fallback_or_degraded_rows_excluded: status=intentional, evidence=0 rows excluded from route-conditioned effect evidence
-- pairing_errors_excluded: status=intentional, evidence=0 rows excluded because the scenario, seed, or checkpoint pairing contract was not satisfied
+- pairing_errors_excluded: status=intentional, evidence=3 rows excluded because the scenario, seed, or checkpoint pairing contract was not satisfied
 
 ## Fail-Closed Runner Failures
 
-- arm=route_conditioned_hybrid_global_rl, reason=RuntimeError('hybrid_global_rl route waypoint unavailable'), row_classification=fail_closed_no_episode_row, scenario_id=francis2023_intersection_wait, seed=4183, source=bounded CPU run_map_batch smoke on imech036
-- arm=learned_local_no_route_conditioning, reason=RuntimeError('PPO model unavailable or prediction failed'), row_classification=fail_closed_no_episode_row, scenario_id=francis2023_intersection_wait, seed=4183, source=bounded CPU run_map_batch smoke on imech036
+- arm=route_conditioned_hybrid_global_rl, scenario_id=francis2023_intersection_wait, seed=4183, reason=RuntimeError('hybrid_global_rl route waypoint unavailable'), row_classification=fail_closed_no_episode_row, source=issue_4183_paired_runner
+- arm=route_conditioned_hybrid_global_rl, scenario_id=francis2023_intersection_wait, seed=4184, reason=RuntimeError('hybrid_global_rl route waypoint unavailable'), row_classification=fail_closed_no_episode_row, source=issue_4183_paired_runner
+- arm=route_conditioned_hybrid_global_rl, scenario_id=francis2023_intersection_wait, seed=4185, reason=RuntimeError('hybrid_global_rl route waypoint unavailable'), row_classification=fail_closed_no_episode_row, source=issue_4183_paired_runner

--- a/docs/context/evidence/issue_4183_hybrid_global_rl_diagnostic/paired_rows.csv
+++ b/docs/context/evidence/issue_4183_hybrid_global_rl_diagnostic/paired_rows.csv
@@ -1,1 +1,4 @@
 scenario_id,seed,checkpoint,pair_status,row_inclusion,route_progress_route_conditioned,route_progress_unconditioned,success_route_conditioned,success_unconditioned,safety_event_route_conditioned,safety_event_unconditioned,route_conditioning_status,waypoint_status,waypoint_reason,fallback_status,exclusion_reason
+francis2023_intersection_wait,4183,ppo_model_retrained_10m_2025-02-01.zip,missing_pair,excluded_pairing_error,,,,,,,,,,,missing_route_conditioned_hybrid_global_rl
+francis2023_intersection_wait,4184,ppo_model_retrained_10m_2025-02-01.zip,missing_pair,excluded_pairing_error,,,,,,,,,,,missing_route_conditioned_hybrid_global_rl
+francis2023_intersection_wait,4185,ppo_model_retrained_10m_2025-02-01.zip,missing_pair,excluded_pairing_error,,,,,,,,,,,missing_route_conditioned_hybrid_global_rl

--- a/docs/context/evidence/issue_4183_hybrid_global_rl_diagnostic/summary.json
+++ b/docs/context/evidence/issue_4183_hybrid_global_rl_diagnostic/summary.json
@@ -6,14 +6,14 @@
   "claim_boundary": "diagnostic-only paired route/occupancy comparison; not benchmark-improvement or paper-facing evidence",
   "evidence_status": "diagnostic-only",
   "fallback_or_degraded_excluded_rows": 0,
-  "generated_at": "2026-07-04T14:51:23.030586+00:00",
+  "generated_at": "2026-07-06T11:36:33.040396+00:00",
   "included_diagnostic_rows": 0,
   "integration_report": {
     "blockers_new": [],
     "blockers_remaining": [
       {
-        "blocker": "no_valid_episode_rows",
-        "evidence": "Fail-closed runner failures produced no paired episode rows.",
+        "blocker": "no_included_route_conditioned_effect_rows",
+        "evidence": "The packet has no native, paired route-conditioned effect rows.",
         "status": "remaining"
       },
       {
@@ -23,8 +23,14 @@
         "status": "remaining"
       },
       {
-        "blocker": "fail_closed_learned_local_no_route_conditioning",
-        "evidence": "RuntimeError('PPO model unavailable or prediction failed')",
+        "blocker": "fail_closed_route_conditioned_hybrid_global_rl",
+        "evidence": "RuntimeError('hybrid_global_rl route waypoint unavailable')",
+        "row_classification": "fail_closed_no_episode_row",
+        "status": "remaining"
+      },
+      {
+        "blocker": "fail_closed_route_conditioned_hybrid_global_rl",
+        "evidence": "RuntimeError('hybrid_global_rl route waypoint unavailable')",
         "row_classification": "fail_closed_no_episode_row",
         "status": "remaining"
       }
@@ -37,13 +43,13 @@
       },
       {
         "blocker": "pairing_errors_excluded",
-        "evidence": "0 rows excluded because the scenario, seed, or checkpoint pairing contract was not satisfied",
+        "evidence": "3 rows excluded because the scenario, seed, or checkpoint pairing contract was not satisfied",
         "status": "intentional"
       }
     ],
     "next_empirical_action": "Resolve the fail-closed runner blockers, then rerun the same paired route/occupancy diagnostic builder so route-conditioned and unconditioned arms emit matched native episode rows for the predeclared seeds."
   },
-  "invalid_pair_rows": 0,
+  "invalid_pair_rows": 3,
   "issue": 4183,
   "linked_work": {
     "adapter_pr": 4161,
@@ -52,13 +58,22 @@
   "paired_rows_csv": "paired_rows.csv",
   "preflight": {
     "baseline_config": "configs/benchmarks/issue_4183_learned_local_unconditioned.yaml",
-    "checkpoint_sha256": "02a31a95720453871aa16af7712dd8ed56a7b4aa11ccb1f405e7837f052d296d",
+    "checkpoint_reference": {
+      "claim_boundary": "benchmark_promoted",
+      "local_path": "output/model_cache/ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417/model.zip",
+      "model_id": "ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417",
+      "observation_mode": "dict",
+      "resolved_path": "output/model_cache/ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417/ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417-model.zip",
+      "type": "model_id"
+    },
+    "checkpoint_sha256": "2b30df812bfcc737924b126b0763d69c567fe20716dc1c1eba8f56f926b49c1d",
     "claim_boundary": "diagnostic-only paired route/occupancy comparison; not benchmark-improvement or paper-facing evidence",
     "dt": 0.1,
     "errors": [],
     "horizon": 120,
     "issue": 4183,
-    "learned_policy_checkpoint": "model/ppo_model_retrained_10m_2025-02-01.zip",
+    "learned_policy_checkpoint": "output/model_cache/ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417/model.zip",
+    "learned_policy_model_id": "ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417",
     "route_config": "configs/benchmarks/issue_4183_hybrid_global_rl_route_conditioned.yaml",
     "scenario_matrix": "configs/scenarios/single/francis2023_intersection_wait.yaml",
     "schema_version": "issue-4183-hybrid-global-rl-diagnostic.v1",
@@ -70,7 +85,7 @@
     "status": "valid"
   },
   "route_conditioned_effect_claim_rows": 0,
-  "row_count": 0,
+  "row_count": 3,
   "row_inclusion_rule": "exclude fallback/degraded/unavailable/missing-pair rows from route-conditioned effect evidence",
   "run_failures": [
     {
@@ -79,17 +94,25 @@
       "row_classification": "fail_closed_no_episode_row",
       "scenario_id": "francis2023_intersection_wait",
       "seed": 4183,
-      "source": "bounded CPU run_map_batch smoke on imech036"
+      "source": "issue_4183_paired_runner"
     },
     {
-      "arm": "learned_local_no_route_conditioning",
-      "reason": "RuntimeError('PPO model unavailable or prediction failed')",
+      "arm": "route_conditioned_hybrid_global_rl",
+      "reason": "RuntimeError('hybrid_global_rl route waypoint unavailable')",
       "row_classification": "fail_closed_no_episode_row",
       "scenario_id": "francis2023_intersection_wait",
-      "seed": 4183,
-      "source": "bounded CPU run_map_batch smoke on imech036"
+      "seed": 4184,
+      "source": "issue_4183_paired_runner"
+    },
+    {
+      "arm": "route_conditioned_hybrid_global_rl",
+      "reason": "RuntimeError('hybrid_global_rl route waypoint unavailable')",
+      "row_classification": "fail_closed_no_episode_row",
+      "scenario_id": "francis2023_intersection_wait",
+      "seed": 4185,
+      "source": "issue_4183_paired_runner"
     }
   ],
-  "run_status": "blocked_no_valid_episode_rows",
+  "run_status": "completed_with_fail_closed_exclusions",
   "schema_version": "issue-4183-hybrid-global-rl-diagnostic.v1"
 }

--- a/robot_sf/benchmark/hybrid_global_rl_diagnostic.py
+++ b/robot_sf/benchmark/hybrid_global_rl_diagnostic.py
@@ -203,12 +203,23 @@ def _resolve_checkpoint_reference(
         local_path = Path(str(entry.get("local_path", "")))
         promotion = entry.get("benchmark_promotion")
         checkpoint_path = local_path if local_path.is_absolute() else repo_root / local_path
+        # A benchmark-promoted checkpoint is hydrated from its public GitHub release into
+        # ``output/model_cache/<model_id>/<asset_name>``. That cached file name does not match
+        # the registry ``local_path`` (``model.zip``), so a bare ``local_path`` existence check
+        # would wrongly report ``blocked_missing_learned_checkpoint`` even when the checkpoint is
+        # present and loadable via ``resolve_model_path``. Recognize the hydrated release asset so
+        # preflight stays download-free but consistent with how the policy actually loads.
+        if not checkpoint_path.exists():
+            hydrated_path = _github_release_cache_path(entry, repo_root=repo_root)
+            if hydrated_path is not None and hydrated_path.exists():
+                checkpoint_path = hydrated_path
         return (
             checkpoint_path,
             {
                 "type": "model_id",
                 "model_id": config.learned_policy_model_id,
                 "local_path": str(local_path),
+                "resolved_path": str(checkpoint_path),
                 "claim_boundary": (
                     promotion.get("claim_boundary") if isinstance(promotion, dict) else None
                 ),
@@ -224,6 +235,26 @@ def _resolve_checkpoint_reference(
         {"type": "local_path", "path": config.learned_policy_checkpoint},
         [],
     )
+
+
+def _github_release_cache_path(entry: dict[str, Any], *, repo_root: Path) -> Path | None:
+    """Return the canonical model-cache path for a github-release artifact, if declared.
+
+    This mirrors ``robot_sf.models.registry._download_from_github_release`` which caches the
+    asset under ``output/model_cache/<model_id>/<asset_name>``.
+
+    Returns:
+        Path | None: Expected hydrated artifact path, or ``None`` when no github release is set.
+    """
+
+    release = entry.get("github_release")
+    if not isinstance(release, dict):
+        return None
+    asset_name = str(release.get("asset_name") or "").strip()
+    model_id = str(entry.get("model_id") or "").strip()
+    if not asset_name or not model_id:
+        return None
+    return repo_root / "output" / "model_cache" / model_id / asset_name
 
 
 def load_jsonl_records(path: str | Path) -> list[dict[str, Any]]:

--- a/scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py
+++ b/scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py
@@ -54,11 +54,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _hydrate_checkpoints(*config_paths: Path) -> list[str]:
+def _hydrate_checkpoints(*config_paths: Path, repo_root: Path = Path(".")) -> list[str]:
     """Hydrate promoted learned checkpoints referenced by the paired configs.
 
     Downloads the public benchmark-promoted checkpoint into the canonical model cache when a
-    ``learned_policy_model_id`` is declared, so the download-free preflight can find it.
+    ``learned_policy_model_id`` is declared, so the download-free preflight can find it. The
+    registry and cache are resolved under ``repo_root`` so hydration lands where
+    ``preflight_configs`` (and ``_github_release_cache_path``) look for the asset when
+    ``--repo-root`` differs from the current working directory.
 
     Returns:
         list[str]: Human-readable notes describing each hydration attempt.
@@ -71,7 +74,12 @@ def _hydrate_checkpoints(*config_paths: Path) -> list[str]:
         if not model_id or model_id in seen:
             continue
         seen.add(model_id)
-        resolved = resolve_model_path(model_id, allow_download=True)
+        resolved = resolve_model_path(
+            model_id,
+            allow_download=True,
+            registry_path=repo_root / "model" / "registry.yaml",
+            cache_dir=repo_root / "output" / "model_cache",
+        )
         notes.append(f"hydrated {model_id} -> {resolved}")
     return notes
 
@@ -183,7 +191,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     hydration_notes: list[str] = []
     if not args.no_hydrate:
-        hydration_notes = _hydrate_checkpoints(args.route_config, args.baseline_config)
+        hydration_notes = _hydrate_checkpoints(
+            args.route_config, args.baseline_config, repo_root=args.repo_root
+        )
     preflight = preflight_configs(args.route_config, args.baseline_config, repo_root=args.repo_root)
     if preflight["status"] != "valid":
         print(

--- a/scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py
+++ b/scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py
@@ -15,14 +15,19 @@ from robot_sf.benchmark.hybrid_global_rl_diagnostic import (
     BASELINE_ARM,
     ROUTE_ARM,
     build_diagnostic_report,
+    load_diagnostic_config,
     load_jsonl_records,
     preflight_configs,
 )
 from robot_sf.benchmark.map_runner import run_map_batch
+from robot_sf.models.registry import resolve_model_path
 
 DEFAULT_ROUTE_CONFIG = Path("configs/benchmarks/issue_4183_hybrid_global_rl_route_conditioned.yaml")
 DEFAULT_BASELINE_CONFIG = Path("configs/benchmarks/issue_4183_learned_local_unconditioned.yaml")
-DEFAULT_SCHEMA = Path("docs/dev/issues/social-navigation-benchmark/episode_schema.json")
+# Use the canonical benchmark episode schema (as every other map-runner entry point does). The
+# previous per-issue pointer to the stale strict schema rejected native PPO episode records with
+# additionalProperties errors and left the baseline arm without valid rows.
+DEFAULT_SCHEMA = Path("robot_sf/benchmark/schemas/episode.schema.v1.json")
 DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_4183_hybrid_global_rl_diagnostic")
 
 
@@ -38,7 +43,37 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--horizon", type=int, help="Optional smoke horizon override.")
     parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument(
+        "--no-hydrate",
+        action="store_true",
+        help=(
+            "Skip public-release hydration of the promoted learned checkpoint. Use in offline/CI "
+            "contexts where the model cache is already populated."
+        ),
+    )
     return parser.parse_args(argv)
+
+
+def _hydrate_checkpoints(*config_paths: Path) -> list[str]:
+    """Hydrate promoted learned checkpoints referenced by the paired configs.
+
+    Downloads the public benchmark-promoted checkpoint into the canonical model cache when a
+    ``learned_policy_model_id`` is declared, so the download-free preflight can find it.
+
+    Returns:
+        list[str]: Human-readable notes describing each hydration attempt.
+    """
+
+    notes: list[str] = []
+    seen: set[str] = set()
+    for config_path in config_paths:
+        model_id = load_diagnostic_config(config_path).learned_policy_model_id
+        if not model_id or model_id in seen:
+            continue
+        seen.add(model_id)
+        resolved = resolve_model_path(model_id, allow_download=True)
+        notes.append(f"hydrated {model_id} -> {resolved}")
+    return notes
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -146,9 +181,16 @@ def _run_arm(
 def main(argv: list[str] | None = None) -> int:
     """Run both issue #4183 arms and rebuild the diagnostic packet."""
     args = parse_args(argv)
+    hydration_notes: list[str] = []
+    if not args.no_hydrate:
+        hydration_notes = _hydrate_checkpoints(args.route_config, args.baseline_config)
     preflight = preflight_configs(args.route_config, args.baseline_config, repo_root=args.repo_root)
     if preflight["status"] != "valid":
-        print(json.dumps({"preflight": preflight}, indent=2, sort_keys=True))
+        print(
+            json.dumps(
+                {"preflight": preflight, "hydration": hydration_notes}, indent=2, sort_keys=True
+            )
+        )
         return 2
 
     args.work_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/benchmark/test_hybrid_global_rl_diagnostic_issue_4183.py
+++ b/tests/benchmark/test_hybrid_global_rl_diagnostic_issue_4183.py
@@ -110,6 +110,32 @@ def test_preflight_blocks_missing_checkpoint(tmp_path: Path) -> None:
     assert any("blocked_missing_learned_checkpoint" in error for error in report["errors"])
 
 
+def test_preflight_recognizes_hydrated_github_release_asset(tmp_path: Path) -> None:
+    """A hydrated public-release checkpoint passes preflight even when its cached file name
+    differs from the registry ``local_path``.
+
+    ``resolve_model_path`` caches a GitHub-release artifact under
+    ``output/model_cache/<model_id>/<asset_name>``. That name does not match the registry
+    ``local_path`` (``model.zip``), so a bare ``local_path`` existence check would wrongly report
+    ``blocked_missing_learned_checkpoint``. Preflight must recognize the hydrated asset instead.
+    """
+    from robot_sf.models import get_registry_entry
+
+    repo_root = _repo_root_with_issue_inputs(tmp_path, include_checkpoint=False)
+    asset_name = str(get_registry_entry(REGISTRY_MODEL_ID)["github_release"]["asset_name"])
+    asset_path = repo_root / "output/model_cache" / REGISTRY_MODEL_ID / asset_name
+    asset_path.parent.mkdir(parents=True, exist_ok=True)
+    asset_path.write_text("hydrated release asset\n", encoding="utf-8")
+    # The registry local_path (``model.zip``) intentionally does not exist for this test.
+    assert not (repo_root / REGISTRY_CHECKPOINT).exists()
+
+    report = preflight_configs(ROUTE_CONFIG, BASELINE_CONFIG, repo_root=repo_root)
+
+    assert report["status"] == "valid"
+    assert str(report["checkpoint_reference"]["resolved_path"]).endswith(asset_name)
+    assert report["checkpoint_sha256"]
+
+
 def test_preflight_blocks_missing_registry_entry(tmp_path: Path) -> None:
     """A stale model_id fails closed with a registry-specific error."""
 

--- a/tests/benchmark/test_issue_4183_paired_runner.py
+++ b/tests/benchmark/test_issue_4183_paired_runner.py
@@ -103,3 +103,56 @@ def test_issue_4183_runner_honors_config_seed_policy(
             "source": "issue_4183_paired_runner",
         }
     ]
+
+
+def test_runner_uses_canonical_episode_schema() -> None:
+    """The paired runner validates episodes against the canonical benchmark schema.
+
+    The prior per-issue pointer to the stale strict schema rejected native PPO episode records
+    with ``additionalProperties`` errors and left the baseline arm without valid rows.
+    """
+    module = _load_issue_4183_runner()
+    assert module.DEFAULT_SCHEMA == Path("robot_sf/benchmark/schemas/episode.schema.v1.json")
+    assert (_REPO_ROOT / module.DEFAULT_SCHEMA).exists()
+
+
+def test_runner_hydrates_declared_model_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_hydrate_checkpoints`` resolves each declared learned-policy model id exactly once."""
+    module = _load_issue_4183_runner()
+
+    def _arm_config(arm: str, *, route: bool) -> Path:
+        path = tmp_path / f"{arm}.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "scenario_matrix": "configs/scenarios/single/francis2023_intersection_wait.yaml",
+                    "seed_policy": {"mode": "fixed-list", "seeds": [4183]},
+                    "horizon": 120,
+                    "dt": 0.1,
+                    "issue_4183_diagnostic": {
+                        "arm": arm,
+                        "route_conditioning_enabled": route,
+                        "learned_policy_checkpoint": "output/model_cache/m/model.zip",
+                        "learned_policy_model_id": "shared_model_id",
+                        "row_inclusion_rule": "exclude fallback rows",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    resolved: list[str] = []
+    monkeypatch.setattr(
+        module,
+        "resolve_model_path",
+        lambda model_id, **_kwargs: resolved.append(model_id) or Path(f"/cache/{model_id}"),
+    )
+    route_config = _arm_config("route_conditioned_hybrid_global_rl", route=True)
+    baseline_config = _arm_config("learned_local_no_route_conditioning", route=False)
+
+    notes = module._hydrate_checkpoints(route_config, baseline_config)
+
+    # Both arms share one promoted checkpoint: hydrate it once, not per arm.
+    assert resolved == ["shared_model_id"]
+    assert notes == ["hydrated shared_model_id -> /cache/shared_model_id"]

--- a/tests/benchmark/test_issue_4183_paired_runner.py
+++ b/tests/benchmark/test_issue_4183_paired_runner.py
@@ -143,16 +143,22 @@ def test_runner_hydrates_declared_model_id(tmp_path: Path, monkeypatch: pytest.M
         return path
 
     resolved: list[str] = []
-    monkeypatch.setattr(
-        module,
-        "resolve_model_path",
-        lambda model_id, **_kwargs: resolved.append(model_id) or Path(f"/cache/{model_id}"),
-    )
+    kwargs_seen: list[dict] = []
+
+    def _fake_resolve(model_id, **kwargs):
+        resolved.append(model_id)
+        kwargs_seen.append(kwargs)
+        return Path(f"/cache/{model_id}")
+
+    monkeypatch.setattr(module, "resolve_model_path", _fake_resolve)
     route_config = _arm_config("route_conditioned_hybrid_global_rl", route=True)
     baseline_config = _arm_config("learned_local_no_route_conditioning", route=False)
 
-    notes = module._hydrate_checkpoints(route_config, baseline_config)
+    notes = module._hydrate_checkpoints(route_config, baseline_config, repo_root=tmp_path)
 
     # Both arms share one promoted checkpoint: hydrate it once, not per arm.
     assert resolved == ["shared_model_id"]
     assert notes == ["hydrated shared_model_id -> /cache/shared_model_id"]
+    # Hydration must honor ``repo_root`` so the asset lands where preflight looks for it.
+    assert kwargs_seen[0]["registry_path"] == tmp_path / "model" / "registry.yaml"
+    assert kwargs_seen[0]["cache_dir"] == tmp_path / "output" / "model_cache"


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Closure audit for #4183 turned into the smallest empirical progression slice: the paired `hybrid_global_rl` diagnostic runner is now executable for the baseline arm. Fixes the episode-schema pointer, adds public-release checkpoint hydration, and makes preflight recognize the hydrated checkpoint.
- **Why now:** The issue was re-admitted (PR #4579 merged, issue still open with no live row). A real run — enabled by hydrating the promoted checkpoint from its **public GitHub release** (no credentials) — showed the runner could never emit native rows for two separate, previously-conflated reasons, both fixed here.
- **Claim boundary:** `diagnostic-only`. Not benchmark-improvement or paper-facing. The route-conditioned *effect* comparison is still blocked (see remaining work), so this does **not** close #4183.
- **Required validation:** focused pytest (30 pass) + a real CPU paired run that regenerated the committed evidence packet.
- **Remaining blocker:** route-conditioned arm fail-closes — the benchmark observation has no `occupancy_grid` channel for the grid-route waypoint provider.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4183 — **Refs #4183** (partial; does not close).

## Contract delta

- **Behavior:** `scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py`
  - `DEFAULT_SCHEMA` → `robot_sf/benchmark/schemas/episode.schema.v1.json` (the canonical schema every other map-runner entry point uses). The prior per-issue pointer to the stale strict `docs/dev/issues/social-navigation-benchmark/episode_schema.json` (`additionalProperties:false`) rejected native PPO episode records.
  - New `_hydrate_checkpoints()` step hydrates the promoted checkpoint from its public GitHub release before preflight; new `--no-hydrate` flag skips it for offline/CI.
- **Preflight recognition:** `robot_sf/benchmark/hybrid_global_rl_diagnostic.py::_resolve_checkpoint_reference` now recognizes a hydrated release asset at `output/model_cache/<model_id>/<asset_name>` (via new `_github_release_cache_path`) when it differs from the registry `local_path` (`model.zip`), and reports a `resolved_path` in `checkpoint_reference`. Preflight stays download-free.
- **No new fail-closed blockers.** Compatibility: additive only (new optional flag, new metadata field); existing fail-closed semantics for genuinely-missing checkpoints preserved (`test_preflight_blocks_missing_checkpoint` still passes).

## Evidence

Empirical CPU paired run on this host (host-agnostic packet; `source=issue_4183_paired_runner`):

| Signal | Before | After |
| --- | --- | --- |
| preflight status | `blocked_missing_learned_checkpoint` | `valid` (sha256 `2b30df81…b49c1d`) |
| baseline (unconditioned) arm | `RuntimeError('PPO model unavailable…')` | **3/3 native episode rows** |
| packet `run_status` | `blocked_no_valid_episode_rows` | `completed_with_fail_closed_exclusions` |
| route-conditioned arm | `route waypoint unavailable` | `route waypoint unavailable` (unchanged — see below) |

Regenerated committed packet: `docs/context/evidence/issue_4183_hybrid_global_rl_diagnostic/{README.md,summary.json,paired_rows.csv}`.

## Acceptance-criteria checklist (Refs #4183)

- [x] Representative scenario/config + checkpoint recorded durably (registry model_id, sha256 pinned; public-release hydration).
- [x] Both arms use the same underlying learned checkpoint where applicable.
- [x] Same-seed paired comparison *emitted* with explicit inclusion/exclusion rules (baseline native rows land as `missing_pair` because the route arm has no rows).
- [x] Adapter fail-closed/conditioning diagnostics recorded per row.
- [x] Result linked back to #4161 / #4015; diagnostic-tier.
- [ ] **Route-conditioned vs unconditioned effect rows** — still blocked. Root cause isolated: `GridRouteWaypointProvider` → `_extract_grid_payload(observation)` returns `None` because the benchmark observation (`obs_mode: dict`) carries no `occupancy_grid` channel, so the route arm fail-closes with `route waypoint unavailable`. **Next empirical action:** enable an occupancy-grid observation channel for the #4183 scenario (env/observation-contract change) and confirm PPO-policy obs compatibility, then rerun for matched native route rows. This is an env/observation-contract change with policy-compatibility risk — deliberately out of scope for this slice.

## Validation

```
# focused tests (shared venv)
python -m pytest tests/benchmark/test_hybrid_global_rl_diagnostic_issue_4183.py \
                 tests/benchmark/test_issue_4183_paired_runner.py \
                 tests/planner/test_hybrid_global_rl.py -q
# -> 30 passed

ruff check <changed files>            # All checks passed
ruff format --check <changed files>  # formatted

# real CPU paired run (regenerates committed packet)
python scripts/benchmark/run_hybrid_global_rl_diagnostic_issue_4183.py
# -> baseline 3/3 successful, route 0/3 (fail-closed), run_status=completed_with_fail_closed_exclusions
```

## Out of scope (explicit)

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no route-conditioned effect claim. The issue stays open.

<details>
<summary>Downstream propagation &amp; governance</summary>

- **Parent issue #4183:** stays open; this slice unblocks the baseline arm and precisely isolates the one remaining blocker (documented above and in the regenerated packet integration report).
- **Claim map / leaderboard / registry:** NA — diagnostic-tier, no promoted claim; checkpoint already registered in `model/registry.yaml`.
- **Context/evidence:** regenerated `docs/context/evidence/issue_4183_hybrid_global_rl_diagnostic/` in place.
- **State propagation:** carried in this PR body + the packet's integration report (`comment_issue_or_pr` not authorized for this lane; no separate state comment posted).
- **Research Result Guidance:** target = complete the deferred route/occupancy diagnostic for #4161/#4015; comparator = unconditioned learned-local arm; evidence tier = diagnostic-only; result = baseline arm now native, route arm still blocked (negative/blocked result recorded); decision/stop rule = no route-conditioned effect claim until matched native route rows exist.
</details>
