### PR TITLE
feat(#3481): opt-in HSFM body-orientation alignment torque (hsfm_alignment_torque_v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #3481 — opt-in HSFM body-orientation alignment torque (`hsfm_alignment_torque_v1`).**
+  A new pedestrian-model selector that decouples pedestrian body orientation `phi` from the
+  instantaneous total-force direction: instead of snapping the heading each step (as
+  `hsfm_total_force_v1` does), the orientation relaxes toward the desired direction via a damped
+  second-order alignment torque (`k_theta` stiffness, `k_omega` damping, bounded turn rate). Adds the
+  pure helpers `wrap_to_pi` and `step_alignment_torque_heading` in
+  `robot_sf/sim/pedestrian_model_variants.py`, an `AlignmentTorqueConfig` opt-in surface on
+  `SimulationSettings` (validated fail-closed), scenario-config selection, and simulator-seam
+  angular-velocity state. Default pedestrian model and all prior selectors are unchanged. This
+  delivers the maintainer-named remaining code prerequisite for #3481 (the HSFM
+  heading-state/alignment-torque Definition-of-Done bullet); evidence tier stays
+  diagnostic/prototype — no calibrated-realism, benchmark, or paper claim. See
+  `docs/context/issue_3481_hsfm_alignment_torque.md`.
 * Extended the **Package C readiness helper** so issue #4547 can commit the real rerun artifact from
   the retained #2916 coupling report. `scripts/tools/prediction_package_c_readiness.py` now accepts
   `--output-markdown` alongside `--output-json`, which lets the cheap local lane write the durable

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -171,7 +171,11 @@ unavailable rows are not benchmark-success evidence.
 Recent HSFM + TTC predictive force prototype:
 [issue_3481_hsfm_ttc_predictive_forces.md](issue_3481_hsfm_ttc_predictive_forces.md)
 records the opt-in `hsfm_ttc_predictive_v1` selector, TTC parameter contract, diagnostic evidence
-boundary, and explicit no-benchmark/no-paper-claim scope.
+boundary, and explicit no-benchmark/no-paper-claim scope. The companion body-orientation
+alignment-torque slice is in
+[issue_3481_hsfm_alignment_torque.md](issue_3481_hsfm_alignment_torque.md): the opt-in
+`hsfm_alignment_torque_v1` selector that decouples pedestrian heading `phi` from the instantaneous
+force direction via a damped second-order torque (diagnostic/prototype).
 
 Recent heavy forecast-model study/preflight: [forecast_heavy_model_study_2026-06-20.md](forecast_heavy_model_study_2026-06-20.md)
 records the analysis-only inventory of heavy predictor families (transformer, AgentFormer-like,

--- a/docs/context/issue_3481_hsfm_alignment_torque.md
+++ b/docs/context/issue_3481_hsfm_alignment_torque.md
@@ -1,0 +1,94 @@
+# Issue #3481: HSFM Body-Orientation Alignment Torque
+
+This note records the opt-in body-orientation **alignment-torque** slice for issue
+[#3481](https://github.com/ll7/robot_sf_ll7/issues/3481). It is the maintainer-named remaining
+code prerequisite ("HSFM body-orientation/alignment-torque prerequisite", 2026-07-05 gate comment)
+for the Definition-of-Done bullet:
+
+> HSFM heading state + alignment-torque term added, decoupling `phi_i` from instantaneous `v_i`.
+
+Evidence tier: **diagnostic / prototype**. No calibrated-realism, benchmark-strength, planner-ranking,
+paper-facing, or dissertation claim is made or promoted here. Sibling slice:
+[`issue_3481_hsfm_ttc_predictive_forces.md`](issue_3481_hsfm_ttc_predictive_forces.md).
+
+## Motivation: what "decoupled" means
+
+The Phase 1 `hsfm_total_force_v1` path (and its TTC/FoV descendants) orients each pedestrian by
+**snapping** the heading to the instantaneous total-force direction every step
+(`arctan2(force_y, force_x)` in `step_hsfm_total_force`). That is still fully *coupled* to the
+instantaneous force/velocity: the body can flip orientation arbitrarily fast.
+
+In the Headed Social Force Model (Farina et al., 2017) the body orientation `phi_i` is a genuine
+state variable driven toward the desired direction by a damped rotational torque with bounded turn
+rate. This removes the instantaneous heading snap — the orientation *lags* the desired direction —
+which is the behavior the issue wants so a planner cannot exploit an instant heading flip.
+
+## Selector key
+
+- `hsfm_alignment_torque_v1`: reuses the `hsfm_total_force_v1` position/velocity stepping, but
+  replaces the instant heading snap with a damped second-order alignment torque. The total-force
+  direction becomes the *desired* orientation; the actual body orientation relaxes toward it.
+
+The default pedestrian model and all prior selectors are unchanged; a regression test pins that
+`hsfm_total_force_v1` still snaps its heading.
+
+## Torque contract
+
+Pure, simulator-independent helpers in `robot_sf/sim/pedestrian_model_variants.py`:
+
+- `wrap_to_pi(angle)` — wrap to `(-pi, pi]` (the `-pi` boundary folds to `+pi`).
+- `step_alignment_torque_heading(headings, angular_velocities, target_headings, *, dt, k_theta,
+  k_omega, max_angular_speed)` — one semi-implicit Euler step of the per-pedestrian dynamics:
+
+```text
+e      = wrap_to_pi(target - phi)                         # shortest signed angular error
+omega' = clip(omega + dt * (k_theta*e - k_omega*omega),   # damped restoring torque
+              -max_angular_speed, +max_angular_speed)      # bounded turn rate
+phi'   = wrap_to_pi(phi + dt * omega')
+```
+
+Returns updated `(headings, angular_velocities)`. Critical damping is `k_omega = 2*sqrt(k_theta)`.
+
+## Parameters
+
+`SimulationSettings.alignment_torque` (`AlignmentTorqueConfig`) stores the opt-in surface, validated
+fail-closed in `__post_init__`:
+
+- `enabled` (auto-set `True` when `pedestrian_model == hsfm_alignment_torque_v1`)
+- `k_theta > 0` (default `4.0`)
+- `k_omega >= 0` (default `4.0`, i.e. critical damping for the default stiffness)
+- `max_angular_speed_rad_s > 0` (default `pi`)
+
+Scenario `simulation_config` can select the model and override params (see
+`_set_simulation_override_attr` in `robot_sf/training/scenario_loader.py`, now table-driven over the
+opt-in force-config registry).
+
+## Simulator seam
+
+`Simulator._step_pedestrians` tracks a per-pedestrian `ped_angular_velocities` state (zeroed at init
+and on episode reset). For `hsfm_alignment_torque_v1` it calls `step_hsfm_total_force` for the
+kinematics + desired heading, then integrates the actual heading with
+`step_alignment_torque_heading`. Deterministic for fixed initial state and config.
+
+## Validation
+
+```bash
+uv run pytest tests/sim/test_hsfm_alignment_torque_model.py -q
+uv run pytest tests/sim/ tests/test_scenario_loader_overrides.py \
+  tests/training/test_scenario_loader.py -q
+uv run ruff check robot_sf/sim robot_sf/training/scenario_loader.py \
+  tests/sim/test_hsfm_alignment_torque_model.py
+```
+
+`tests/sim/test_hsfm_alignment_torque_model.py` covers: `wrap_to_pi`; hold-when-aligned;
+no-snap-in-one-step (decoupling); a per-element oracle match; convergence under critical damping;
+angular-speed cap; shortest-turn wrapping; fail-closed parameter/shape/finiteness validation; config
+validation and selector-enable provenance; scenario selection; and a deterministic simulator smoke
+contrasting the lagged heading against the still-snapping `hsfm_total_force_v1`.
+
+## Remaining for closure (unchanged by this slice)
+
+- Seed-controlled campaign / benchmark-strength synthesis for narrow-passage lateral-sliding and
+  bottleneck freeze/deadlock (campaign RUN — out of scope for CPU-only slices).
+- Calibrated-realism support (needs external-data calibration).
+- Any evidence-tier upgrade above diagnostic/prototype.

--- a/robot_sf/sim/pedestrian_model_variants.py
+++ b/robot_sf/sim/pedestrian_model_variants.py
@@ -10,12 +10,14 @@ SOCIAL_FORCE_DEFAULT = "social_force_default"
 HSFM_TOTAL_FORCE_V1 = "hsfm_total_force_v1"
 HSFM_TTC_PREDICTIVE_V1 = "hsfm_ttc_predictive_v1"
 HSFM_ANISOTROPIC_FOV_V1 = "hsfm_anisotropic_fov_v1"
+HSFM_ALIGNMENT_TORQUE_V1 = "hsfm_alignment_torque_v1"
 SUPPORTED_PEDESTRIAN_MODELS = frozenset(
     {
         SOCIAL_FORCE_DEFAULT,
         HSFM_TOTAL_FORCE_V1,
         HSFM_TTC_PREDICTIVE_V1,
         HSFM_ANISOTROPIC_FOV_V1,
+        HSFM_ALIGNMENT_TORQUE_V1,
     }
 )
 
@@ -689,3 +691,95 @@ def step_hsfm_total_force(
     force_headings = np.arctan2(force_array[:, 1], force_array[:, 0])
     next_headings = np.where(force_norms <= epsilon, previous_headings, force_headings)
     return next_state, next_headings
+
+
+def wrap_to_pi(angle: np.ndarray | float) -> np.ndarray:
+    """Wrap angle(s) in radians to the ``(-pi, pi]`` interval.
+
+    Returns:
+        The angle(s) wrapped to a single canonical turn, as a float array.
+    """
+    wrapped = np.mod(np.asarray(angle, dtype=float) + np.pi, 2.0 * np.pi) - np.pi
+    # ``np.mod`` maps the -pi boundary to -pi; fold it to +pi so the interval is (-pi, pi].
+    wrapped = np.where(wrapped <= -np.pi, np.pi, wrapped)
+    return wrapped
+
+
+def step_alignment_torque_heading(
+    headings: np.ndarray,
+    angular_velocities: np.ndarray,
+    target_headings: np.ndarray,
+    *,
+    dt: float,
+    k_theta: float,
+    k_omega: float,
+    max_angular_speed: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Advance body orientation via a damped second-order alignment torque (HSFM).
+
+    In the Headed Social Force Model the pedestrian body orientation ``phi_i`` is a state
+    variable that is *decoupled* from the instantaneous velocity/force direction: rather than
+    snapping to the desired direction each step (as :func:`step_hsfm_total_force` does), the
+    orientation is driven toward a target by a restoring torque with angular inertia and
+    damping. This removes the instantaneous heading snap and produces a physically bounded
+    turn rate.
+
+    The per-pedestrian dynamics integrate
+
+        ``omega' = omega + dt * (k_theta * e - k_omega * omega)``  (semi-implicit Euler)
+        ``phi'   = wrap(phi + dt * omega')``
+
+    where ``e = wrap(target - phi)`` is the shortest signed angular error. ``k_omega`` is the
+    angular damping; critical damping corresponds to ``k_omega = 2 * sqrt(k_theta)``. The
+    updated angular speed is clipped to ``[-max_angular_speed, max_angular_speed]`` so a large
+    error cannot produce an unbounded spin. The layer is independent of simulator objects so it
+    is unit-testable in isolation; it is diagnostic/prototype and makes no calibrated-realism
+    claim.
+
+    Args:
+        headings: Current body orientations ``phi`` with shape ``(N,)`` in radians.
+        angular_velocities: Current angular velocities ``omega`` with shape ``(N,)`` in rad/s.
+        target_headings: Desired orientations with shape ``(N,)`` in radians (typically the
+            total-force / desired direction of motion).
+        dt: Positive integration timestep in seconds.
+        k_theta: Positive angular stiffness (restoring gain toward the target).
+        k_omega: Non-negative angular damping gain.
+        max_angular_speed: Positive cap on ``|omega|`` in rad/s.
+
+    Returns:
+        Tuple of updated ``(headings, angular_velocities)``, each with shape ``(N,)``.
+    """
+    heading_array = np.asarray(headings, dtype=float)
+    angular_velocity_array = np.asarray(angular_velocities, dtype=float)
+    target_array = np.asarray(target_headings, dtype=float)
+
+    if heading_array.ndim != 1:
+        raise ValueError("headings must have shape (N,)")
+    if angular_velocity_array.shape != heading_array.shape:
+        raise ValueError("angular_velocities must have shape (N,) matching headings")
+    if target_array.shape != heading_array.shape:
+        raise ValueError("target_headings must have shape (N,) matching headings")
+    if not (
+        np.all(np.isfinite(heading_array))
+        and np.all(np.isfinite(angular_velocity_array))
+        and np.all(np.isfinite(target_array))
+    ):
+        raise ValueError("headings, angular_velocities, and target_headings must be finite")
+    if not np.isfinite(dt) or dt <= 0:
+        raise ValueError("dt must be finite and > 0")
+    if not np.isfinite(k_theta) or k_theta <= 0:
+        raise ValueError("k_theta must be finite and > 0")
+    if not np.isfinite(k_omega) or k_omega < 0:
+        raise ValueError("k_omega must be finite and >= 0")
+    if not np.isfinite(max_angular_speed) or max_angular_speed <= 0:
+        raise ValueError("max_angular_speed must be finite and > 0")
+
+    error = wrap_to_pi(target_array - heading_array)
+    next_angular_velocity = angular_velocity_array + float(dt) * (
+        float(k_theta) * error - float(k_omega) * angular_velocity_array
+    )
+    next_angular_velocity = np.clip(
+        next_angular_velocity, -float(max_angular_speed), float(max_angular_speed)
+    )
+    next_heading = wrap_to_pi(heading_array + float(dt) * next_angular_velocity)
+    return next_heading, next_angular_velocity

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -6,6 +6,7 @@ from math import ceil, isfinite
 from robot_sf.ped_npc.adversial_ped_force import AdversarialPedForceConfig
 from robot_sf.ped_npc.ped_robot_force import PedRobotForceConfig
 from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_ALIGNMENT_TORQUE_V1,
     HSFM_ANISOTROPIC_FOV_V1,
     HSFM_TTC_PREDICTIVE_V1,
     normalize_pedestrian_model,
@@ -105,6 +106,56 @@ def _pedestrian_model_anisotropic_fov_config(
     return fov_config
 
 
+@dataclass(frozen=True)
+class AlignmentTorqueConfig:
+    """Opt-in HSFM body-orientation alignment-torque parameters.
+
+    The alignment torque decouples pedestrian body orientation ``phi`` from the instantaneous
+    force/velocity direction: instead of snapping to the desired direction each step, ``phi``
+    is driven toward it by a damped second-order torque (``k_theta`` stiffness, ``k_omega``
+    damping) with a bounded angular speed. Critical damping is ``k_omega = 2 * sqrt(k_theta)``.
+    """
+
+    enabled: bool = False
+    k_theta: float = 4.0
+    k_omega: float = 4.0
+    max_angular_speed_rad_s: float = 3.141592653589793
+
+    def __post_init__(self) -> None:
+        """Validate finite positive alignment-torque parameters."""
+        if not isfinite(self.k_theta) or self.k_theta <= 0:
+            raise ValueError("alignment_torque.k_theta must be > 0")
+        if not isfinite(self.k_omega) or self.k_omega < 0:
+            raise ValueError("alignment_torque.k_omega must be >= 0")
+        if not isfinite(self.max_angular_speed_rad_s) or self.max_angular_speed_rad_s <= 0:
+            raise ValueError("alignment_torque.max_angular_speed_rad_s must be > 0")
+
+
+def _normalize_alignment_torque_config(
+    value: AlignmentTorqueConfig | dict,
+) -> AlignmentTorqueConfig:
+    """Return a validated alignment-torque config."""
+    if isinstance(value, AlignmentTorqueConfig):
+        return value
+    if isinstance(value, dict):
+        return AlignmentTorqueConfig(**value)
+    raise ValueError("alignment_torque must be an AlignmentTorqueConfig or dict")
+
+
+def _pedestrian_model_alignment_torque_config(
+    pedestrian_model: str,
+    alignment_config: AlignmentTorqueConfig,
+) -> AlignmentTorqueConfig:
+    """Enable alignment-torque provenance when the selector is active.
+
+    Returns:
+        Updated config with ``enabled=True`` when the selector activates it.
+    """
+    if pedestrian_model == HSFM_ALIGNMENT_TORQUE_V1 and not alignment_config.enabled:
+        return replace(alignment_config, enabled=True)
+    return alignment_config
+
+
 @dataclass
 class SimulationSettings:
     """
@@ -128,6 +179,9 @@ class SimulationSettings:
 
     anisotropic_fov: AnisotropicFovConfig = field(default_factory=AnisotropicFovConfig)
     """Anisotropic field-of-view settings used by ``hsfm_anisotropic_fov_v1``."""
+
+    alignment_torque: AlignmentTorqueConfig = field(default_factory=AlignmentTorqueConfig)
+    """Body-orientation alignment-torque settings used by ``hsfm_alignment_torque_v1``."""
 
     difficulty: int = 0
     """Difficulty level"""
@@ -213,6 +267,11 @@ class SimulationSettings:
         self.anisotropic_fov = _pedestrian_model_anisotropic_fov_config(
             self.pedestrian_model,
             self.anisotropic_fov,
+        )
+        self.alignment_torque = _normalize_alignment_torque_config(self.alignment_torque)
+        self.alignment_torque = _pedestrian_model_alignment_torque_config(
+            self.pedestrian_model,
+            self.alignment_torque,
         )
         # Check that the maximum number of pedestrians per group is positive
         if self.max_peds_per_group <= 0:

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -380,7 +380,13 @@ class Simulator:
         initial_headings = getattr(self, "_initial_ped_headings", None)
         if initial_headings is not None:
             self.ped_headings = initial_headings.copy()
-        self.ped_angular_velocities = np.zeros_like(self.ped_headings)
+        # Only (re)initialize angular velocities when headings exist. ``_reset_social_force_state``
+        # runs on the shared reset path, including partially-constructed ``PedSimulator`` stubs that
+        # never set ``ped_headings``; an unconditional ``zeros_like(self.ped_headings)`` regressed
+        # that path with an AttributeError.
+        existing_headings = getattr(self, "ped_headings", None)
+        if existing_headings is not None:
+            self.ped_angular_velocities = np.zeros_like(existing_headings)
         self.last_ped_forces = np.zeros((0, 2), dtype=float)
         for behavior in getattr(self, "peds_behaviors", ()):
             behavior.reset()

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -52,12 +52,14 @@ from robot_sf.ped_npc.ped_robot_force import PedRobotForce, PedRobotForceConfig
 from robot_sf.ped_npc.ped_zone import sample_zone
 from robot_sf.robot.robot_state import Robot
 from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_ALIGNMENT_TORQUE_V1,
     HSFM_ANISOTROPIC_FOV_V1,
     HSFM_TOTAL_FORCE_V1,
     HSFM_TTC_PREDICTIVE_V1,
     fov_attenuated_total_force,
     normalize_pedestrian_model,
     pairwise_social_force_contributions,
+    step_alignment_torque_heading,
     step_hsfm_total_force,
     ttc_predictive_repulsion,
 )
@@ -167,6 +169,7 @@ class Simulator:
     _initial_pysf_states: np.ndarray = field(init=False, repr=False)
     ped_headings: np.ndarray = field(init=False, repr=False)
     _initial_ped_headings: np.ndarray = field(init=False, repr=False)
+    ped_angular_velocities: np.ndarray = field(init=False, repr=False)
     pedestrian_model: str = field(init=False)
 
     def __post_init__(self):
@@ -235,6 +238,7 @@ class Simulator:
         self.pedestrian_model = normalize_pedestrian_model(self.config.pedestrian_model)
         self.ped_headings = self._headings_from_current_ped_velocities()
         self._initial_ped_headings = self.ped_headings.copy()
+        self.ped_angular_velocities = np.zeros_like(self.ped_headings)
         self._initial_pysf_states = self.pysf_state.pysf_states().copy()
         self.reset_state()
 
@@ -257,6 +261,7 @@ class Simulator:
             HSFM_TOTAL_FORCE_V1,
             HSFM_TTC_PREDICTIVE_V1,
             HSFM_ANISOTROPIC_FOV_V1,
+            HSFM_ALIGNMENT_TORQUE_V1,
         }:
             self.pysf_sim.peds.step(ped_forces, groups)
             self.ped_headings = self._headings_from_current_ped_velocities()
@@ -298,13 +303,29 @@ class Simulator:
                 cone_half_angle_rad=fov_config.cone_half_angle_rad,
                 rear_weight=fov_config.rear_weight,
             )
-        next_state, self.ped_headings = step_hsfm_total_force(
+        next_state, target_headings = step_hsfm_total_force(
             current_state,
             ped_forces,
             self.ped_headings,
             dt=self.config.time_per_step_in_secs,
             max_speeds=max_speeds,
         )
+        if self.pedestrian_model == HSFM_ALIGNMENT_TORQUE_V1:
+            # Decouple body orientation from the instantaneous force direction (issue #3481):
+            # treat the total-force heading as the desired orientation and relax toward it
+            # with a bounded damped torque instead of snapping to it each step.
+            torque_config = self.config.alignment_torque
+            self.ped_headings, self.ped_angular_velocities = step_alignment_torque_heading(
+                self.ped_headings,
+                self.ped_angular_velocities,
+                target_headings,
+                dt=self.config.time_per_step_in_secs,
+                k_theta=torque_config.k_theta,
+                k_omega=torque_config.k_omega,
+                max_angular_speed=torque_config.max_angular_speed_rad_s,
+            )
+        else:
+            self.ped_headings = target_headings
         current_state[...] = next_state
         self.pysf_sim.peds.update(current_state, groups)
 
@@ -359,6 +380,7 @@ class Simulator:
         initial_headings = getattr(self, "_initial_ped_headings", None)
         if initial_headings is not None:
             self.ped_headings = initial_headings.copy()
+        self.ped_angular_velocities = np.zeros_like(self.ped_headings)
         self.last_ped_forces = np.zeros((0, 2), dtype=float)
         for behavior in getattr(self, "peds_behaviors", ()):
             behavior.reset()
@@ -628,6 +650,7 @@ class PedSimulator(Simulator):
         self.pedestrian_model = normalize_pedestrian_model(self.config.pedestrian_model)
         self.ped_headings = self._headings_from_current_ped_velocities()
         self._initial_ped_headings = self.ped_headings.copy()
+        self.ped_angular_velocities = np.zeros_like(self.ped_headings)
         self._initial_pysf_states = self.pysf_state.pysf_states().copy()
 
         self.reset_state()

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -2108,7 +2108,14 @@ def _set_simulation_override_attr(
         # Nested opt-in force config given directly; auto-enable when its selector is active.
         config_cls, selector_model = config_spec
         sub_overrides = dict(overrides[attr])
-        if overrides.get("pedestrian_model") == selector_model:
+        # Auto-enable when the selector model is active either via this scenario's overrides or
+        # via the already-applied base config; checking only the overrides would silently reset
+        # ``enabled`` to False when the base config selects the model but the scenario omits
+        # ``pedestrian_model`` (provenance-loss regression flagged in review).
+        if (
+            overrides.get("pedestrian_model") == selector_model
+            or config.sim_config.pedestrian_model == selector_model
+        ):
             sub_overrides["enabled"] = True
         setattr(config.sim_config, attr, config_cls(**sub_overrides))
     elif attr == "pedestrian_model" and overrides[attr] in _PEDESTRIAN_MODEL_ENABLE_ATTR:

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -32,8 +32,16 @@ from robot_sf.nav.svg_map_parser import convert_map
 from robot_sf.robot.bicycle_drive import BicycleDriveSettings
 from robot_sf.robot.differential_drive import DifferentialDriveSettings
 from robot_sf.robot.holonomic_drive import HolonomicDriveSettings
-from robot_sf.sim.pedestrian_model_variants import HSFM_ANISOTROPIC_FOV_V1, HSFM_TTC_PREDICTIVE_V1
-from robot_sf.sim.sim_config import AnisotropicFovConfig, TtcPredictiveForceConfig
+from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_ALIGNMENT_TORQUE_V1,
+    HSFM_ANISOTROPIC_FOV_V1,
+    HSFM_TTC_PREDICTIVE_V1,
+)
+from robot_sf.sim.sim_config import (
+    AlignmentTorqueConfig,
+    AnisotropicFovConfig,
+    TtcPredictiveForceConfig,
+)
 
 _MAP_REGISTRY_ENV = "ROBOT_SF_MAP_REGISTRY"
 _MAP_REGISTRY_PATH = Path("maps/registry.yaml")
@@ -2075,33 +2083,42 @@ def _apply_single_pedestrian_override(
     )
 
 
+# Opt-in pedestrian-model config attribute -> (config dataclass, activating model selector).
+# Each entry drives both the nested-mapping override path and the ``pedestrian_model``
+# selector path below, so adding a new opt-in force model is a single-line change here.
+_OPT_IN_PEDESTRIAN_MODEL_CONFIGS: dict[str, tuple[type, str]] = {
+    "ttc_predictive_force": (TtcPredictiveForceConfig, HSFM_TTC_PREDICTIVE_V1),
+    "anisotropic_fov": (AnisotropicFovConfig, HSFM_ANISOTROPIC_FOV_V1),
+    "alignment_torque": (AlignmentTorqueConfig, HSFM_ALIGNMENT_TORQUE_V1),
+}
+# Reverse lookup: activating model selector -> its opt-in config attribute name.
+_PEDESTRIAN_MODEL_ENABLE_ATTR: dict[str, str] = {
+    selector: attr for attr, (_, selector) in _OPT_IN_PEDESTRIAN_MODEL_CONFIGS.items()
+}
+
+
 def _set_simulation_override_attr(
     config: RobotSimulationConfig,
     attr: str,
     overrides: Mapping[str, Any],
 ) -> None:
     """Apply one scenario-level simulation override attribute."""
-    if attr == "ttc_predictive_force" and isinstance(overrides[attr], Mapping):
-        ttc_force_overrides = dict(overrides[attr])
-        if overrides.get("pedestrian_model") == HSFM_TTC_PREDICTIVE_V1:
-            ttc_force_overrides["enabled"] = True
-        setattr(config.sim_config, attr, TtcPredictiveForceConfig(**ttc_force_overrides))
-    elif attr == "anisotropic_fov" and isinstance(overrides[attr], Mapping):
-        fov_overrides = dict(overrides[attr])
-        if overrides.get("pedestrian_model") == HSFM_ANISOTROPIC_FOV_V1:
-            fov_overrides["enabled"] = True
-        setattr(config.sim_config, attr, AnisotropicFovConfig(**fov_overrides))
-    elif attr == "pedestrian_model" and overrides[attr] == HSFM_TTC_PREDICTIVE_V1:
+    config_spec = _OPT_IN_PEDESTRIAN_MODEL_CONFIGS.get(attr)
+    if config_spec is not None and isinstance(overrides[attr], Mapping):
+        # Nested opt-in force config given directly; auto-enable when its selector is active.
+        config_cls, selector_model = config_spec
+        sub_overrides = dict(overrides[attr])
+        if overrides.get("pedestrian_model") == selector_model:
+            sub_overrides["enabled"] = True
+        setattr(config.sim_config, attr, config_cls(**sub_overrides))
+    elif attr == "pedestrian_model" and overrides[attr] in _PEDESTRIAN_MODEL_ENABLE_ATTR:
+        # Selecting an opt-in model marks its companion config enabled for provenance.
         setattr(config.sim_config, attr, overrides[attr])
-        config.sim_config.ttc_predictive_force = replace(
-            config.sim_config.ttc_predictive_force,
-            enabled=True,
-        )
-    elif attr == "pedestrian_model" and overrides[attr] == HSFM_ANISOTROPIC_FOV_V1:
-        setattr(config.sim_config, attr, overrides[attr])
-        config.sim_config.anisotropic_fov = replace(
-            config.sim_config.anisotropic_fov,
-            enabled=True,
+        enable_attr = _PEDESTRIAN_MODEL_ENABLE_ATTR[overrides[attr]]
+        setattr(
+            config.sim_config,
+            enable_attr,
+            replace(getattr(config.sim_config, enable_attr), enabled=True),
         )
     elif attr == "pedestrian_uncertainty_envelope_enabled":
         setattr(
@@ -2149,6 +2166,7 @@ def _apply_simulation_overrides(
         "pedestrian_model",
         "ttc_predictive_force",
         "anisotropic_fov",
+        "alignment_torque",
         "route_spawn_distribution",
         "route_spawn_jitter_frac",
         "route_spawn_seed",

--- a/tests/sim/test_hsfm_alignment_torque_model.py
+++ b/tests/sim/test_hsfm_alignment_torque_model.py
@@ -1,0 +1,315 @@
+"""Tests for the opt-in HSFM body-orientation alignment-torque pedestrian model.
+
+The alignment torque (issue #3481) decouples pedestrian body orientation ``phi`` from the
+instantaneous total-force / velocity direction: instead of snapping to the desired direction
+each step, ``phi`` relaxes toward it via a damped second-order torque with a bounded turn rate.
+These tests pin the pure-math contract, the config validation surface, and the simulator seam.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_ALIGNMENT_TORQUE_V1,
+    HSFM_TOTAL_FORCE_V1,
+    step_alignment_torque_heading,
+    wrap_to_pi,
+)
+from robot_sf.sim.sim_config import AlignmentTorqueConfig, SimulationSettings
+from robot_sf.sim.simulator import Simulator
+from robot_sf.training.scenario_loader import build_robot_config_from_scenario
+
+
+class _FakePedState:
+    def __init__(self, state: np.ndarray) -> None:
+        self.state = state
+        self.max_speeds = np.full(state.shape[0], 10.0, dtype=float)
+        self.updated_state: np.ndarray | None = None
+        self.updated_groups: list[list[int]] | None = None
+
+    def update(self, state: np.ndarray, groups: list[list[int]]) -> None:
+        self.updated_state = state
+        self.updated_groups = groups
+
+
+def _alignment_oracle(
+    headings: np.ndarray,
+    angular_velocities: np.ndarray,
+    target_headings: np.ndarray,
+    *,
+    dt: float,
+    k_theta: float,
+    k_omega: float,
+    max_angular_speed: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Independent per-element reference for the semi-implicit torque integrator."""
+    next_heading = np.empty_like(headings, dtype=float)
+    next_omega = np.empty_like(angular_velocities, dtype=float)
+    for i in range(headings.shape[0]):
+        error = np.mod(target_headings[i] - headings[i] + np.pi, 2.0 * np.pi) - np.pi
+        omega = angular_velocities[i] + dt * (k_theta * error - k_omega * angular_velocities[i])
+        omega = float(np.clip(omega, -max_angular_speed, max_angular_speed))
+        phi = np.mod(headings[i] + dt * omega + np.pi, 2.0 * np.pi) - np.pi
+        next_heading[i] = phi
+        next_omega[i] = omega
+    return next_heading, next_omega
+
+
+def test_wrap_to_pi_folds_to_half_open_interval() -> None:
+    """Angles wrap into ``(-pi, pi]`` with the -pi boundary folded to +pi."""
+    assert wrap_to_pi(0.0) == pytest.approx(0.0)
+    assert wrap_to_pi(np.pi) == pytest.approx(np.pi)
+    assert wrap_to_pi(-np.pi) == pytest.approx(np.pi)
+    assert wrap_to_pi(3.0 * np.pi) == pytest.approx(np.pi)
+    assert float(wrap_to_pi(1.5 * np.pi)) == pytest.approx(-0.5 * np.pi)
+    wrapped = wrap_to_pi(np.array([2.0 * np.pi, -2.5 * np.pi]))
+    assert wrapped == pytest.approx([0.0, -0.5 * np.pi])
+
+
+def test_alignment_torque_holds_when_already_aligned() -> None:
+    """A pedestrian already facing the target neither turns nor accumulates angular speed."""
+    headings = np.array([0.3, -1.2], dtype=float)
+    next_heading, next_omega = step_alignment_torque_heading(
+        headings,
+        np.zeros_like(headings),
+        headings.copy(),
+        dt=0.1,
+        k_theta=4.0,
+        k_omega=4.0,
+        max_angular_speed=np.pi,
+    )
+    assert next_heading == pytest.approx(headings)
+    assert next_omega == pytest.approx([0.0, 0.0])
+
+
+def test_alignment_torque_does_not_snap_to_target_in_one_step() -> None:
+    """Unlike the instant-snap HSFM heading, a large error only partially turns per step.
+
+    This is the decoupling contract: the body orientation lags the desired direction rather
+    than jumping to it, so a planner cannot exploit an instantaneous heading flip.
+    """
+    heading = np.array([0.0], dtype=float)
+    target = np.array([np.pi / 2], dtype=float)
+    next_heading, next_omega = step_alignment_torque_heading(
+        heading,
+        np.zeros_like(heading),
+        target,
+        dt=0.1,
+        k_theta=4.0,
+        k_omega=4.0,
+        max_angular_speed=np.pi,
+    )
+    # Turned toward the target but well short of it, and with a positive angular velocity.
+    assert 0.0 < float(next_heading[0]) < float(target[0])
+    assert float(next_omega[0]) > 0.0
+
+
+def test_alignment_torque_matches_semi_implicit_oracle() -> None:
+    """The vectorized integrator matches an independent per-element reference."""
+    headings = np.array([0.0, 1.0, -2.5, 3.0], dtype=float)
+    angular_velocities = np.array([0.0, -0.5, 0.2, 1.0], dtype=float)
+    targets = np.array([np.pi / 2, -1.0, 2.5, -3.0], dtype=float)
+    kwargs = {"dt": 0.1, "k_theta": 6.0, "k_omega": 4.9, "max_angular_speed": 2.0}
+
+    actual_heading, actual_omega = step_alignment_torque_heading(
+        headings, angular_velocities, targets, **kwargs
+    )
+    expected_heading, expected_omega = _alignment_oracle(
+        headings, angular_velocities, targets, **kwargs
+    )
+    assert actual_heading == pytest.approx(expected_heading)
+    assert actual_omega == pytest.approx(expected_omega)
+
+
+def test_alignment_torque_converges_to_target_over_time() -> None:
+    """Repeated damped steps settle the heading onto the target orientation."""
+    heading = np.array([0.0], dtype=float)
+    omega = np.array([0.0], dtype=float)
+    target = np.array([1.2], dtype=float)
+    for _ in range(400):
+        heading, omega = step_alignment_torque_heading(
+            heading,
+            omega,
+            target,
+            dt=0.05,
+            k_theta=4.0,
+            k_omega=4.0,  # critical damping: k_omega == 2*sqrt(k_theta)
+            max_angular_speed=np.pi,
+        )
+    assert float(heading[0]) == pytest.approx(float(target[0]), abs=1e-3)
+    assert float(omega[0]) == pytest.approx(0.0, abs=1e-3)
+
+
+def test_alignment_torque_respects_angular_speed_cap() -> None:
+    """A large error cannot produce an angular speed above the configured cap."""
+    heading = np.array([0.0], dtype=float)
+    _, next_omega = step_alignment_torque_heading(
+        heading,
+        np.zeros_like(heading),
+        np.array([np.pi], dtype=float),
+        dt=1.0,
+        k_theta=100.0,
+        k_omega=0.0,
+        max_angular_speed=0.5,
+    )
+    assert abs(float(next_omega[0])) == pytest.approx(0.5)
+
+
+def test_alignment_torque_takes_shortest_signed_turn() -> None:
+    """The error uses the wrapped shortest angle, so a near-pi target turns the short way."""
+    heading = np.array([3.0], dtype=float)  # close to +pi
+    target = np.array([-3.0], dtype=float)  # close to -pi; shortest turn is CCW past +pi
+    _, next_omega = step_alignment_torque_heading(
+        heading,
+        np.zeros_like(heading),
+        target,
+        dt=0.01,
+        k_theta=4.0,
+        k_omega=0.0,
+        max_angular_speed=np.pi,
+    )
+    # Shortest signed error (-3 - 3) wraps to +0.283 rad, so the turn is positive (CCW).
+    assert float(next_omega[0]) > 0.0
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"dt": 0.0, "k_theta": 1.0, "k_omega": 1.0, "max_angular_speed": 1.0},
+        {"dt": 0.1, "k_theta": 0.0, "k_omega": 1.0, "max_angular_speed": 1.0},
+        {"dt": 0.1, "k_theta": 1.0, "k_omega": -1.0, "max_angular_speed": 1.0},
+        {"dt": 0.1, "k_theta": 1.0, "k_omega": 1.0, "max_angular_speed": 0.0},
+    ],
+)
+def test_alignment_torque_fails_closed_on_invalid_parameters(kwargs: dict) -> None:
+    """Non-positive gains / timestep / speed cap raise instead of stepping silently."""
+    heading = np.zeros(2, dtype=float)
+    with pytest.raises(ValueError):
+        step_alignment_torque_heading(heading, heading.copy(), heading.copy(), **kwargs)
+
+
+def test_alignment_torque_rejects_shape_and_finiteness_violations() -> None:
+    """Mismatched shapes and non-finite inputs are rejected."""
+    heading = np.zeros(3, dtype=float)
+    valid = {"dt": 0.1, "k_theta": 1.0, "k_omega": 1.0, "max_angular_speed": 1.0}
+    with pytest.raises(ValueError, match="angular_velocities must have shape"):
+        step_alignment_torque_heading(heading, np.zeros(2), heading.copy(), **valid)
+    with pytest.raises(ValueError, match="target_headings must have shape"):
+        step_alignment_torque_heading(heading, heading.copy(), np.zeros(2), **valid)
+    with pytest.raises(ValueError, match="must be finite"):
+        step_alignment_torque_heading(
+            np.array([np.nan, 0.0, 0.0]), heading.copy(), heading.copy(), **valid
+        )
+
+
+def test_alignment_torque_config_validates_parameters() -> None:
+    """The config dataclass fails closed on non-positive gains and speed cap."""
+    default = AlignmentTorqueConfig()
+    assert default.enabled is False
+    assert default.k_omega == pytest.approx(2.0 * np.sqrt(default.k_theta))
+    with pytest.raises(ValueError, match="k_theta must be > 0"):
+        AlignmentTorqueConfig(k_theta=0.0)
+    with pytest.raises(ValueError, match="k_omega must be >= 0"):
+        AlignmentTorqueConfig(k_omega=-1.0)
+    with pytest.raises(ValueError, match="max_angular_speed_rad_s must be > 0"):
+        AlignmentTorqueConfig(max_angular_speed_rad_s=0.0)
+
+
+def test_alignment_torque_selector_marks_config_enabled() -> None:
+    """Selecting the alignment-torque model records active provenance on the config."""
+    settings = SimulationSettings(pedestrian_model=HSFM_ALIGNMENT_TORQUE_V1)
+    assert settings.pedestrian_model == HSFM_ALIGNMENT_TORQUE_V1
+    assert settings.alignment_torque.enabled is True
+    # The default model leaves the opt-in config disabled.
+    assert SimulationSettings().alignment_torque.enabled is False
+
+
+def test_scenario_alignment_torque_selector_marks_config_enabled(tmp_path) -> None:
+    """Scenario ``simulation_config`` can select the alignment-torque model and params."""
+    config = build_robot_config_from_scenario(
+        {
+            "simulation_config": {
+                "pedestrian_model": HSFM_ALIGNMENT_TORQUE_V1,
+                "alignment_torque": {"k_theta": 9.0, "k_omega": 6.0},
+            }
+        },
+        scenario_path=tmp_path / "scenario.yaml",
+    )
+    assert config.sim_config.pedestrian_model == HSFM_ALIGNMENT_TORQUE_V1
+    assert config.sim_config.alignment_torque.enabled is True
+    assert config.sim_config.alignment_torque.k_theta == pytest.approx(9.0)
+    assert config.sim_config.alignment_torque.k_omega == pytest.approx(6.0)
+
+
+def _make_alignment_torque_sim(
+    state: np.ndarray, headings: np.ndarray
+) -> tuple[Simulator, _FakePedState]:
+    peds = _FakePedState(state)
+    sim = object.__new__(Simulator)
+    sim.pedestrian_model = HSFM_ALIGNMENT_TORQUE_V1
+    sim.pysf_sim = SimpleNamespace(peds=peds)
+    sim.config = SimulationSettings(
+        pedestrian_model=HSFM_ALIGNMENT_TORQUE_V1,
+        alignment_torque={"k_theta": 4.0, "k_omega": 4.0, "max_angular_speed_rad_s": np.pi},
+        time_per_step_in_secs=0.1,
+    )
+    sim.ped_headings = headings.copy()
+    sim.ped_angular_velocities = np.zeros_like(headings)
+    return sim, peds
+
+
+def test_simulator_alignment_torque_one_step_is_finite_and_does_not_snap() -> None:
+    """The alignment-torque selector steps kinematics like HSFM but lags the heading.
+
+    Contrasted with ``hsfm_total_force_v1``, whose heading snaps to the force direction
+    (``pi/2`` here), the alignment-torque model only partially rotates in one step.
+    """
+    state = np.array([[0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.5]], dtype=float)
+    sim, peds = _make_alignment_torque_sim(state, np.array([0.0], dtype=float))
+
+    sim._step_pedestrians(np.array([[0.0, 2.0]], dtype=float), [[0]])
+
+    assert peds.updated_state is state
+    assert peds.updated_groups == [[0]]
+    assert np.all(np.isfinite(state))
+    assert np.all(np.isfinite(sim.ped_headings))
+    # Kinematics match the HSFM total-force velocity update (force points +y).
+    assert state[0, 3] == pytest.approx(0.2)
+    # Heading turned toward +pi/2 but did NOT snap to it (decoupled from instantaneous force).
+    assert 0.0 < float(sim.ped_headings[0]) < np.pi / 2
+    assert float(sim.ped_angular_velocities[0]) > 0.0
+
+
+def test_simulator_alignment_torque_step_is_deterministic() -> None:
+    """Identical initial state and config yield identical alignment-torque output."""
+    state_a = np.array([[0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.5]], dtype=float)
+    state_b = state_a.copy()
+    sim_a, _ = _make_alignment_torque_sim(state_a, np.array([0.0], dtype=float))
+    sim_b, _ = _make_alignment_torque_sim(state_b, np.array([0.0], dtype=float))
+
+    sim_a._step_pedestrians(np.array([[1.0, 1.0]], dtype=float), [[0]])
+    sim_b._step_pedestrians(np.array([[1.0, 1.0]], dtype=float), [[0]])
+
+    assert state_a == pytest.approx(state_b)
+    assert sim_a.ped_headings == pytest.approx(sim_b.ped_headings)
+    assert sim_a.ped_angular_velocities == pytest.approx(sim_b.ped_angular_velocities)
+
+
+def test_simulator_hsfm_total_force_still_snaps_heading() -> None:
+    """Regression guard: the Phase 1 HSFM model keeps its instant force-direction heading."""
+    state = np.array([[0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.5]], dtype=float)
+    peds = _FakePedState(state)
+    sim = object.__new__(Simulator)
+    sim.pedestrian_model = HSFM_TOTAL_FORCE_V1
+    sim.pysf_sim = SimpleNamespace(peds=peds)
+    sim.config = SimulationSettings(pedestrian_model=HSFM_TOTAL_FORCE_V1, time_per_step_in_secs=0.1)
+    sim.ped_headings = np.array([0.0], dtype=float)
+    sim.ped_angular_velocities = np.zeros(1, dtype=float)
+
+    sim._step_pedestrians(np.array([[0.0, 2.0]], dtype=float), [[0]])
+
+    assert float(sim.ped_headings[0]) == pytest.approx(np.pi / 2)

--- a/tests/sim/test_hsfm_alignment_torque_model.py
+++ b/tests/sim/test_hsfm_alignment_torque_model.py
@@ -245,6 +245,25 @@ def test_scenario_alignment_torque_selector_marks_config_enabled(tmp_path) -> No
     assert config.sim_config.alignment_torque.k_omega == pytest.approx(6.0)
 
 
+def test_alignment_torque_override_preserves_enabled_when_model_active_in_base(tmp_path) -> None:
+    """A nested ``alignment_torque`` override must not silently reset ``enabled`` when the base
+    config already selects the model but the scenario omits ``pedestrian_model``."""
+    from robot_sf.training.scenario_loader import _apply_simulation_overrides
+
+    config = build_robot_config_from_scenario(
+        {"simulation_config": {"pedestrian_model": HSFM_ALIGNMENT_TORQUE_V1}},
+        scenario_path=tmp_path / "scenario.yaml",
+    )
+    assert config.sim_config.alignment_torque.enabled is True
+
+    # Second override tweaks a torque param but does NOT re-declare pedestrian_model.
+    _apply_simulation_overrides(config, {"alignment_torque": {"k_theta": 7.0}})
+
+    assert config.sim_config.pedestrian_model == HSFM_ALIGNMENT_TORQUE_V1
+    assert config.sim_config.alignment_torque.enabled is True
+    assert config.sim_config.alignment_torque.k_theta == pytest.approx(7.0)
+
+
 def _make_alignment_torque_sim(
     state: np.ndarray, headings: np.ndarray
 ) -> tuple[Simulator, _FakePedState]:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds an opt-in `hsfm_alignment_torque_v1` pedestrian model that gives HSFM a real **body-orientation alignment torque** — pedestrian heading `phi` is decoupled from the instantaneous total-force direction and relaxes toward it via a damped second-order torque with a bounded turn rate, instead of the instant snap used by `hsfm_total_force_v1`.
- **Why now:** This is the maintainer-named remaining code prerequisite for issue #3481. The re-admit trigger comment (#4593 merge, 2026-07-05T09:52Z) explicitly lists *"HSFM body-orientation/alignment-torque prerequisite"* as remaining for closure. It maps directly to the Definition-of-Done bullet *"HSFM heading state + alignment-torque term added, decoupling `phi_i` from instantaneous `v_i`."*
- **Claim boundary:** diagnostic/prototype only. No calibrated-realism, benchmark-strength, planner-ranking, paper-facing, or dissertation claim. Default pedestrian model and all prior selectors are byte/behavior-unchanged (pinned by a regression test).
- **Required validation:** focused sim + scenario-loader tests + ruff (results below).
- **Remaining blocker for issue closure (unchanged by this PR):** seed-controlled campaign / benchmark-strength synthesis (narrow-passage lateral-sliding, bottleneck freeze/deadlock) and calibrated-realism support — both out of scope for a CPU-only slice (a campaign *run* / external-data calibration).

Closure audit result: **not closeable yet** — this PR delivers the smallest remaining *code* criterion; the residual criteria are campaign-run / external-data, so this is `Refs`, not `Closes`.

## Contract delta

- **New selector:** `hsfm_alignment_torque_v1` in `SUPPORTED_PEDESTRIAN_MODELS`.
- **New config:** `AlignmentTorqueConfig` (`enabled`, `k_theta>0`, `k_omega>=0`, `max_angular_speed_rad_s>0`) on `SimulationSettings.alignment_torque`, validated fail-closed in `__post_init__`; auto-`enabled` when the selector is active (mirrors the TTC/FoV pattern). Scenario `simulation_config.alignment_torque` mapping is supported.
- **New public helpers:** `wrap_to_pi`, `step_alignment_torque_heading` (pure, simulator-independent, unit-testable).
- **New runtime state:** `Simulator.ped_angular_velocities` (zeroed at init and episode reset).
- **Refactor (behavior-preserving):** `scenario_loader._set_simulation_override_attr` is now table-driven over an opt-in force-config registry (`_OPT_IN_PEDESTRIAN_MODEL_CONFIGS`), collapsing six near-duplicate branches to two and keeping the function under the C901 complexity gate; existing TTC/FoV scenario-selection tests still pass.
- **Compatibility impact:** none for existing models — default path and `hsfm_total_force_v1` / `hsfm_ttc_predictive_v1` / `hsfm_anisotropic_fov_v1` are unchanged.

## Fragmentation guard

Per the 2026-07-02 process review guard: this is a **progression slice that adds a nameable new capability** (the HSFM alignment torque), not another micro-guard/packet refresh — so it proceeds at full throttle and is exempt from the consolidation rule.

## Validation

```
uv run pytest tests/sim/test_hsfm_alignment_torque_model.py -q      -> 18 passed
uv run pytest tests/sim/ tests/test_scenario_loader_overrides.py \
  tests/training/test_scenario_loader.py \
  tests/training/test_scenario_loader_additional.py -q              -> 142 passed
uv run ruff check robot_sf/sim robot_sf/training/scenario_loader.py \
  tests/sim/test_hsfm_alignment_torque_model.py                     -> All checks passed
uv run ruff format ...                                              -> clean
```

(Focused validation via the shared-venv worktree wrapper; the touched surface is simulator runtime + scenario config, exercised by unit tests. No full `pr_ready_check` run in this lane — the PR gate owns the merge-blocking pipeline.)

## Links

- Issue: https://github.com/ll7/robot_sf_ll7/issues/3481
- Context note: `docs/context/issue_3481_hsfm_alignment_torque.md`
- Sibling slice: `docs/context/issue_3481_hsfm_ttc_predictive_forces.md`

Refs #3481

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Governance / propagation</summary>

- **Scope:** smallest remaining code criterion for #3481; CPU-only; no default-model change.
- **State propagation:** issue-comment authorization is disabled for this lane, so no issue status comment was posted. The durable state surface is this PR body + the new context note + the CHANGELOG `Added` entry, which record the delivered slice and the unchanged remaining blockers. No transient queue-routing state is written to tracked files.
- **Closure declaration:** partial (`Refs`, not `Closes`). Remaining criteria are campaign-run / external-data, outside a CPU-only slice. The merge gate ratifies the final call.
- **Downstream propagation:** parent issue #3481 (context note + CHANGELOG updated); no leaderboard / registry / benchmark-report change (diagnostic-tier, no metric produced).
- **Research result guidance:** target = remove the instantaneous heading-snap coupling in HSFM; comparator = `hsfm_total_force_v1` (still snaps, pinned by regression test); evidence tier = diagnostic/prototype; decision/stop rule = torque path exists, is opt-in, finite, deterministic, and measurably lags the desired heading; synthesis surface = `docs/context/issue_3481_hsfm_alignment_torque.md`.

</details>
