### PR TITLE
Issue #3501: safety-wrapper deadlock-recovery stage + closure-audit reconciliation

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -176,9 +176,10 @@ is included.
   the issue blocked on missing durable comparable component campaign outputs.
 
 - `issue_3501_closure_audit_2026-07-04.md`: closure-audit integration report for
-  issue #3501. Maps merged PRs #3591, #4137, #4136, #4223, and #4298 planner-agnostic
-  safety wrapper and ablation/preregistration evidence to acceptance criteria
-  without promoting benchmark, Slurm, or paper-facing claims.
+  issue #3501 (reconciled 2026-07-06), mapping the merged safety-wrapper PRs and the
+  new deadlock-recovery stage to acceptance criteria. Records honestly that the two
+  remaining criteria are compute-gated (the paired ablation RUN and its report on
+  executed rows). No benchmark, Slurm, or paper-facing claims are promoted.
 
 - `issue_4245_closure_audit_2026-07-04.md`: closure-audit integration report for
   issue #4245. Maps merged PR #4257 standalone offline-pretraining checkpoint

--- a/docs/context/evidence/issue_3501_closure_audit_2026-07-04.md
+++ b/docs/context/evidence/issue_3501_closure_audit_2026-07-04.md
@@ -1,45 +1,80 @@
 # Issue #3501 Closure Audit
 
-Plain-language summary: merged PRs #3591, #4137, #4136, #4223, and #4298 delivered the planner-agnostic safety wrapper and factorial-ablation execution/preregistration harness requested by issue #3501. This audit maps each acceptance criterion to the merged evidence so the issue can be closed by an authorized follow-up.
+Plain-language summary: the merged PRs below delivered the planner-agnostic safety wrapper and its
+factorial-ablation harness, preregistration, false-stop diagnostic, and paired effect-size report
+builder. This audit maps each acceptance criterion to the evidence and states honestly what remains.
+**Reconciled 2026-07-06:** the deadlock-recovery stage (a named criterion, previously deferred) is
+now implemented, and the two remaining criteria are compute-gated — an actual paired campaign RUN
+and its ledger/report emission on executed rows. The earlier "all criteria satisfied / closable"
+wording is superseded by this reconciliation.
 
 ## Source Thread
 
 - Issue: <https://github.com/ll7/robot_sf_ll7/issues/3501>
 - Merged Implementation PRs:
-  - Wrapper Core: <https://github.com/ll7/robot_sf_ll7/pull/3591>
+  - Wrapper Core (3 stateless stages): <https://github.com/ll7/robot_sf_ll7/pull/3591>
   - Runtime Integration: <https://github.com/ll7/robot_sf_ll7/pull/4137>
   - Manifest Builder: <https://github.com/ll7/robot_sf_ll7/pull/4136>
   - Preregistration Config: <https://github.com/ll7/robot_sf_ll7/pull/4223>
   - False-Stop Diagnostic: <https://github.com/ll7/robot_sf_ll7/pull/4298>
-- Audit date: 2026-07-04
+  - Paired Effect-Size Report Builder: <https://github.com/ll7/robot_sf_ll7/pull/4598>
+  - Deadlock-Recovery Stage: this PR
+- Audit dates: 2026-07-04 (initial), 2026-07-06 (reconciliation)
 
 ## Claim Boundary
 
-This is a closure-audit integration report only. It does not run a full benchmark campaign, submit Slurm or GPU compute, or edit paper or dissertation claims. The delivered capability is an opt-in runtime safety wrapper and its dry-run manifest/preregistration checking harness.
+This is a closure-audit integration report only. It does not run a full benchmark campaign, submit
+Slurm or GPU compute, or edit paper or dissertation claims. The delivered capability is an opt-in
+runtime safety wrapper (four predeclared stages), its dry-run manifest/preregistration checking
+harness, and a paired effect-size report builder that consumes completed ablation rows. No paired
+ablation has been executed, so no mitigation-effect size exists yet.
 
 ## Acceptance Mapping
 
 | Acceptance criterion from #3501 | Delivered evidence | Status |
 | --- | --- | --- |
-| Composable `SafetyWrapper` implemented around the action interface (clearance/TTC prediction, speed cap near pedestrians, hard stop/yield veto), off by default and opt-in per run. | PR #3591 added `robot_sf/robot/safety_wrapper.py` implementing `apply_safety_wrapper` with hard-stop, speed cap, and pass-through stages. Tested in `tests/test_safety_wrapper.py`. | Delivered by PR #3591. |
+| Composable `SafetyWrapper` implemented around the action interface (clearance/TTC prediction, speed cap near pedestrians, hard stop/yield veto, **deadlock recovery**), off by default and opt-in per run. | PR #3591 added `robot_sf/robot/safety_wrapper.py` with the three stateless stages (`apply_safety_wrapper`). The stateful **deadlock-recovery** stage (`DeadlockRecoveryMonitor`) is added by this PR — opt-in, disabled by default, rotates in place to break a freeze and never adds forward speed (veto preserved). Tested in `tests/test_safety_wrapper.py` and `tests/test_safety_wrapper_deadlock.py`. | Stages implemented (this PR completes deadlock recovery); runtime wiring of the monitor pending. |
 | Wrapper thresholds predeclared (planner-agnostic, fixed; no post-hoc per-planner tuning). | Enforced via `SafetyWrapperConfig` in `robot_sf/robot/safety_wrapper.py` (defensive caution radius = 2.0m, capped speed = 0.5 m/s, TTC veto = 1.0s, clearance veto = 0.3m). Checked by manifest validation. | Delivered by PR #3591. |
 | Safety-context construction from simulator state and command immediately before step. | PR #4137 added `compute_safety_context_from_env` in `robot_sf/benchmark/safety_wrapper_runtime.py` to retrieve pre-step robot/pedestrian position, heading, and velocity. | Delivered by PR #4137. |
 | Opt-in runtime config wrapper binding in benchmark runner. | PR #4137 wired `apply_runtime_safety_wrapper` and `ineligible_safety_wrapper_step_record` into `run_map_episode` under `robot_sf/benchmark/map_runner_episode.py`. | Delivered by PR #4137. |
-| Factorial `planner × {wrapper off, wrapper on}` ablation manifest and validation. | PR #4136 added `robot_sf/benchmark/safety_wrapper_ablation_manifest.py` verifying off/on contrast, paired seeds, and planner IDs. Configured in `configs/research/safety_wrapper_ablation_v1.yaml`. | Delivered by PR #4136. |
-| Ablation results emitted into the safety-event ledger (#3482) and episode metadata. | PR #4137 updated `run_map_episode` to construct and attach `safety_wrapper` summary metadata, which is validated and serialized into the ledger via `build_event_ledger(record)`. | Delivered by PR #4137. |
-| Primary outcomes reported (probabilities, min separation, false stop, latency, etc.). | PR #4137 and PR #4298 added `analyze_false_stop_diagnostic` to categorize hard-stops using a forward-window clearance persistence check, and summarized clearances, TTCs, and intervention rates. | Delivered by PRs #4137, #4298. |
+| Factorial `planner × {wrapper off, wrapper on}` ablation **run** over a fixed scenario set with paired seeds. | Harness exists: PR #4136 `safety_wrapper_ablation_manifest.py` (off/on contrast, paired seeds, planner IDs); `configs/research/safety_wrapper_ablation_v1.yaml`; PR #4223 preregistered the CPU-smoke plan. **No paired ablation has been executed** — the preregistration harness builds *planned* rows only. | **Open — compute-gated** (needs a campaign RUN, out of the audit's scope). |
+| Ablation results emitted into the safety-event ledger (#3482) and episode metadata. | Emission path exists: PR #4137 `run_map_episode` attaches validated `safety_wrapper` summary metadata for serialization. Requires *executed* episode rows to emit. | **Open — compute-gated** (depends on the ablation run above). |
+| Primary outcomes reported (collision/near-miss probability, min separation, completion, progress-at-timeout, false-stop rate, latency, intervention rate), positive AND negative effects. | Reporting contract exists: PR #4598 `safety_wrapper_factorial_report.py` builds per-pair and per-planner mean on-minus-off effect sizes and fails closed on incomplete pairs / missing metrics; PR #4298 added the false-stop diagnostic. **No real rows to report yet.** | **Open — compute-gated** (report builder ready; awaits executed rows). |
 | Preregistration CPU-smoke execution verification. | PR #4223 added `configs/benchmarks/issue_3501_safety_wrapper_factorial_preregistration_cpu_smoke.yaml` and `robot_sf/benchmark/safety_wrapper_factorial_preregistration.py` to build and verify a CPU-smoke preregistration plan. | Delivered by PR #4223. |
-| Result kept diagnostic-tier until durable; no paper-facing deployment-safety claim. | The manifest builder explicitly tags dry-run outputs as `not_benchmark_evidence` and defines the `claim_boundary` to prevent premature paper or dissertation claims. | Enforced by design. |
+| Result kept diagnostic-tier until durable; no paper-facing deployment-safety claim. | The manifest builder tags dry-run outputs as `not_benchmark_evidence`; the report builder tags `benchmark_evidence: False` and a `claim_boundary`. | Enforced by design. |
 
 ## Closure Decision
 
-All acceptance criteria in the live issue thread are satisfied by merged PRs. Issue #3501 is closable once an authorized actor can post this criterion-to-evidence closure comment and close the issue.
+**Not fully closable yet.** After this PR's deadlock-recovery stage, every *implementable* (CPU-only,
+no-compute) criterion is delivered: all four wrapper stages, runtime binding, ablation manifest +
+checker, preregistration, false-stop diagnostic, and the paired effect-size report builder. Two
+criteria remain and both are **compute-gated**, not implementable in this lane:
+
+1. run the paired `planner × {wrapper_off, wrapper_on}` ablation over the fixed scenario set + paired
+   seeds (the excluded campaign RUN), emitting executed rows into the #3482-style ledger;
+2. build the paired effect-size report on those executed rows (the report builder is ready) and keep
+   it diagnostic-tier.
+
+One additional implementable follow-up remains for the ablation to actually exercise the new stage:
+**wire `DeadlockRecoveryMonitor` into the benchmark runtime step loop** (the runtime path is
+currently stateless). This is a small, CPU-only slice but is scoped out of this closure-audit PR to
+keep the blast radius zero for default runs.
+
+Per the maintainer COMPLETE-FIRST rule, an issue whose only remainder is a campaign RUN counts as
+complete for the implementation lane; the honest research status, however, is that **no
+mitigation-effect size has been measured yet**, so this PR uses `Refs #3501` (not `Closes`) with the
+remaining checklist above. An authorized actor may close #3501 once the paired campaign has run and
+the diagnostic report is emitted, or may split the campaign RUN into a dedicated gated-run issue.
 
 ## Local Verification
 
 Audit-time validation for this docs-only slice:
 
 ```bash
-./.venv/bin/pytest tests/test_safety_wrapper.py tests/benchmark/test_safety_wrapper_runtime.py tests/benchmark/test_safety_wrapper_ablation_manifest.py tests/benchmark/test_safety_wrapper_factorial_preregistration.py
+./.venv/bin/pytest tests/test_safety_wrapper.py tests/test_safety_wrapper_deadlock.py \
+  tests/benchmark/test_safety_wrapper_runtime.py \
+  tests/benchmark/test_safety_wrapper_ablation_manifest.py \
+  tests/benchmark/test_safety_wrapper_factorial_preregistration.py \
+  tests/benchmark/test_safety_wrapper_factorial_report.py
 git diff --check
 ```

--- a/docs/context/issue_3501_safety_wrapper.md
+++ b/docs/context/issue_3501_safety_wrapper.md
@@ -37,18 +37,47 @@ reporting), and the original action + context.
 | `ttc_veto_threshold_s` | 1.0 | hard-stop TTC gate |
 | `clearance_veto_m` | 0.3 | hard-stop clearance gate |
 
+## Deadlock recovery (`safety_wrapper_deadlock_recovery.v1`)
+
+The stateful fourth stage lives in `DeadlockRecoveryMonitor` (same module), an **opt-in,
+disabled-by-default** monitor composed *around* `apply_safety_wrapper`. Call `monitor.step(...)`
+once per simulation step with the executed (post-transform) command and the same `SafetyContext`.
+It breaks the *frozen robot* failure mode (planner keeps commanding near-zero forward speed while a
+nearby pedestrian/obstacle blocks progress, so the episode stalls without a collision):
+
+1. a step counts **frozen** when `|executed forward speed| ≤ frozen_speed_eps_m_s` **and** the step
+   is hazard-blocked (nearest pedestrian within `hazard_proximity_m`, or finite predicted clearance
+   ≤ `hazard_clearance_m`) — a legitimate goal-reached stop with clear surroundings is *not* a
+   deadlock;
+2. once the frozen run reaches `patience_steps`, a bounded in-place rotation
+   (`recovery_turn_sign · recovery_angular_velocity_rad_s`) is applied for up to `recovery_steps`
+   steps; a completed maneuver re-arms the patience window so a still-stuck robot pauses one cycle
+   (letting the planner react) before rotating again.
+
+**Safety property:** recovery only ever overrides *angular* velocity — forward speed is passed
+through unchanged — so it never overrides the hard stop/yield veto and can never inject forward
+motion into a hazard. Predeclared defaults: `patience_steps=20`, `recovery_steps=10`,
+`recovery_angular_velocity_rad_s=0.5`, `recovery_turn_sign=+1`, `frozen_speed_eps_m_s=0.05`,
+`hazard_proximity_m=2.0`, `hazard_clearance_m=0.5`.
+
 ## Scope boundary
 
-Pure per-step transform, **off by default** — changes no runtime/benchmark behavior. Deferred
-follow-ups: the factorial `planner × {off, on}` **ablation campaign** (SLURM runs over a fixed
-scenario set + paired seeds, emitting into the #3482 ledger), live wiring into
-`robot_sf/robot/action_adapters.py`, and a stateful deadlock-recovery stage.
+`apply_safety_wrapper` is a pure per-step transform and `DeadlockRecoveryMonitor` is off by default,
+so the wrapper **changes no runtime/benchmark behavior** unless explicitly opted in. Deferred
+follow-ups: **wiring `DeadlockRecoveryMonitor` into the benchmark runtime step loop**
+(`robot_sf/benchmark/safety_wrapper_runtime.py` + `map_runner_episode.py`, currently stateless), the
+factorial `planner × {off, on}` **ablation campaign** (runs over a fixed scenario set + paired
+seeds, emitting into the #3482 ledger), and live wiring into `robot_sf/robot/action_adapters.py`.
 
 ## Tests
 
 `tests/test_safety_wrapper.py` (12 tests): disabled pass-through, safe pass-through, speed cap
 near pedestrians (and no-cap when already slow), hard stop on low TTC and on low clearance, veto
 precedence over the speed cap, schema/record contract, and config validation.
+`tests/test_safety_wrapper_deadlock.py` (11 tests): disabled pass-through, no-recovery-before-patience,
+recovery engages at patience and rotates in place, cyclic maneuver/patience re-arm, turn sign,
+movement resets the frozen run, clear-surroundings-is-not-a-deadlock, forward speed never added under
+a persistent hard stop, obstacle-only freeze, counter reset, and config validation.
 
 ## Related
 

--- a/robot_sf/robot/safety_wrapper.py
+++ b/robot_sf/robot/safety_wrapper.py
@@ -12,8 +12,14 @@ stages:
 
 The wrapper is **off by default** and opt-in per run, with **fixed, predeclared thresholds** (no
 per-planner tuning), so a factorial ``planner × {wrapper off, wrapper on}`` ablation can quantify
-its effect. This module is the pure per-step transform; the ablation campaign, live wiring into the
-action adapters, and a stateful deadlock-recovery stage are deliberate follow-ups.
+its effect. :func:`apply_safety_wrapper` is the pure per-step transform.
+
+The fourth predeclared stage, **deadlock recovery**, is stateful (it needs a run of frozen steps
+to detect a stall), so it lives in :class:`DeadlockRecoveryMonitor` — an opt-in, disabled-by-default
+monitor that composes *around* the per-step transform. It only ever overrides angular velocity to
+rotate free of a freeze; it never adds forward speed, so it cannot override the hard stop/yield veto
+or worsen a collision. Wiring the monitor into the benchmark runtime step loop and running the
+paired ablation campaign remain deliberate follow-ups.
 
 Thresholds are predeclared modeling choices, diagnostic until durable evidence.
 """
@@ -25,6 +31,7 @@ from dataclasses import dataclass
 from typing import Any
 
 SAFETY_WRAPPER_SCHEMA = "safety_wrapper.v1"
+DEADLOCK_RECOVERY_SCHEMA = "safety_wrapper_deadlock_recovery.v1"
 
 # Intervention labels (stable vocabulary).
 INTERVENTION_DISABLED = "disabled"
@@ -152,12 +159,203 @@ def _record(
     }
 
 
+@dataclass(frozen=True, slots=True)
+class DeadlockRecoveryConfig:
+    """Fixed, predeclared deadlock-recovery thresholds (planner-agnostic).
+
+    Deadlock recovery is the stateful fourth safety stage: it breaks the *frozen robot* failure
+    mode (the planner keeps commanding near-zero forward speed while a nearby pedestrian or
+    obstacle blocks progress, so the episode stalls without a collision) by permitting a bounded
+    in-place rotation to search for a new heading. It is a modeling choice, predeclared and fixed
+    (no per-planner tuning), and diagnostic until durable evidence.
+
+    Attributes:
+        enabled: Whether the monitor is active. **Off by default** (opt-in per run).
+        patience_steps: Consecutive frozen steps required before recovery engages.
+        recovery_steps: Maximum steps a single recovery maneuver persists before re-evaluating.
+        recovery_angular_velocity_rad_s: In-place rotation magnitude applied during recovery.
+        recovery_turn_sign: Fixed rotation direction (+1 or -1); predeclared, not tuned per run.
+        frozen_speed_eps_m_s: Executed forward-speed magnitude at/below which a step counts frozen.
+        hazard_proximity_m: A frozen step counts as a deadlock only when the nearest pedestrian is
+            within this distance (so a legitimate goal-reached stop is not treated as a deadlock).
+        hazard_clearance_m: Alternatively, a finite predicted clearance at/below this also marks the
+            step as hazard-blocked (obstacle-driven freeze without a nearby pedestrian).
+    """
+
+    enabled: bool = False
+    patience_steps: int = 20
+    recovery_steps: int = 10
+    recovery_angular_velocity_rad_s: float = 0.5
+    recovery_turn_sign: int = 1
+    frozen_speed_eps_m_s: float = 0.05
+    hazard_proximity_m: float = 2.0
+    hazard_clearance_m: float = 0.5
+
+    def __post_init__(self) -> None:
+        """Validate that the recovery thresholds are physically usable."""
+        if self.patience_steps < 1:
+            raise ValueError(
+                f"DeadlockRecoveryConfig.patience_steps must be >= 1, got {self.patience_steps!r}"
+            )
+        if self.recovery_steps < 1:
+            raise ValueError(
+                f"DeadlockRecoveryConfig.recovery_steps must be >= 1, got {self.recovery_steps!r}"
+            )
+        if self.recovery_turn_sign not in (-1, 1):
+            raise ValueError(
+                "DeadlockRecoveryConfig.recovery_turn_sign must be -1 or 1, "
+                f"got {self.recovery_turn_sign!r}"
+            )
+        if not (self.recovery_angular_velocity_rad_s > 0.0):
+            raise ValueError(
+                "DeadlockRecoveryConfig.recovery_angular_velocity_rad_s must be > 0, "
+                f"got {self.recovery_angular_velocity_rad_s!r}"
+            )
+        for name in ("frozen_speed_eps_m_s", "hazard_proximity_m", "hazard_clearance_m"):
+            value = getattr(self, name)
+            if not (value >= 0.0):
+                raise ValueError(f"DeadlockRecoveryConfig.{name} must be >= 0, got {value!r}")
+
+
+def _is_hazard_blocked(context: SafetyContext, config: DeadlockRecoveryConfig) -> bool:
+    """Return whether the step is blocked by a nearby pedestrian or obstacle.
+
+    Used to distinguish a genuine deadlock (frozen while blocked) from a legitimate stop with
+    clear surroundings (e.g. goal reached), which must not trigger recovery.
+    """
+    near_pedestrian = context.min_pedestrian_distance_m <= config.hazard_proximity_m
+    near_obstacle = (
+        math.isfinite(context.min_clearance_m)
+        and context.min_clearance_m <= config.hazard_clearance_m
+    )
+    return bool(near_pedestrian or near_obstacle)
+
+
+class DeadlockRecoveryMonitor:
+    """Stateful, opt-in deadlock-recovery stage composed around the per-step transform.
+
+    Call :meth:`step` once per simulation step with the *executed* (post-:func:`apply_safety_wrapper`)
+    command and the same :class:`SafetyContext`. The monitor tracks a run of frozen steps and, once
+    ``patience_steps`` is reached, overrides the angular velocity with a bounded in-place rotation
+    for up to ``recovery_steps`` steps to break the stall. **Forward speed is passed through
+    unchanged**, so any upstream hard stop/yield veto (which zeroes forward speed) is preserved and
+    recovery can never inject forward motion into a hazard.
+
+    The monitor is deterministic and holds only integer counters, so a fresh instance per episode
+    yields reproducible behavior.
+    """
+
+    def __init__(self, config: DeadlockRecoveryConfig | None = None) -> None:
+        """Initialize a monitor with predeclared thresholds and a cleared counter state."""
+        self._config = config or DeadlockRecoveryConfig()
+        self.reset()
+
+    @property
+    def config(self) -> DeadlockRecoveryConfig:
+        """Return the predeclared recovery configuration."""
+        return self._config
+
+    def reset(self) -> None:
+        """Clear the frozen-run and recovery counters (call once per episode)."""
+        self._frozen_run = 0
+        self._recovery_remaining = 0
+
+    def step(
+        self,
+        corrected_linear_velocity: float,
+        corrected_angular_velocity: float,
+        context: SafetyContext,
+    ) -> dict[str, Any]:
+        """Advance the monitor one step and return the (possibly recovery-adjusted) command record.
+
+        Args:
+            corrected_linear_velocity: Forward speed already produced by the per-step transform.
+            corrected_angular_velocity: Angular velocity already produced by the transform.
+            context: The per-step safety signals (same context passed to the transform).
+
+        Returns:
+            dict[str, Any]: Versioned record with the deadlock state and the final command. Forward
+            speed always equals ``corrected_linear_velocity``; angular velocity is overridden only
+            while a recovery maneuver is active.
+        """
+        config = self._config
+        original = (float(corrected_linear_velocity), float(corrected_angular_velocity))
+
+        if not config.enabled:
+            return self._record(config, original, original, frozen=False, recovery_applied=False)
+
+        frozen = abs(
+            float(corrected_linear_velocity)
+        ) <= config.frozen_speed_eps_m_s and _is_hazard_blocked(context, config)
+        if frozen:
+            self._frozen_run += 1
+        else:
+            # Progress resumed (or surroundings cleared): the stall is over.
+            self._frozen_run = 0
+            self._recovery_remaining = 0
+
+        # Engage a new maneuver once the frozen run crosses patience and none is in flight.
+        if self._recovery_remaining <= 0 and self._frozen_run >= config.patience_steps:
+            self._recovery_remaining = config.recovery_steps
+
+        recovery_applied = frozen and self._recovery_remaining > 0
+        if recovery_applied:
+            self._recovery_remaining -= 1
+            final = (
+                float(corrected_linear_velocity),  # forward speed preserved; never increased
+                config.recovery_turn_sign * config.recovery_angular_velocity_rad_s,
+            )
+        else:
+            final = original
+        record = self._record(
+            config, original, final, frozen=frozen, recovery_applied=recovery_applied
+        )
+        # A maneuver that just used its last step re-arms the patience window: reset the frozen run
+        # so a still-stuck robot pauses for one patience cycle (giving the planner a fresh chance)
+        # before rotating again, rather than overriding angular velocity on every frozen step.
+        if recovery_applied and self._recovery_remaining == 0:
+            self._frozen_run = 0
+        return record
+
+    def _record(
+        self,
+        config: DeadlockRecoveryConfig,
+        original: tuple[float, float],
+        final: tuple[float, float],
+        *,
+        frozen: bool,
+        recovery_applied: bool,
+    ) -> dict[str, Any]:
+        """Build the versioned deadlock-recovery record.
+
+        Returns:
+            dict[str, Any]: The schema-tagged deadlock-recovery output record.
+        """
+        return {
+            "schema_version": DEADLOCK_RECOVERY_SCHEMA,
+            "evidence_kind": "diagnostic_proxy",
+            "enabled": config.enabled,
+            "frozen": bool(frozen),
+            "frozen_run": int(self._frozen_run),
+            "deadlock_detected": bool(config.enabled and self._frozen_run >= config.patience_steps),
+            "recovery_active": bool(recovery_applied),
+            "recovery_steps_remaining": int(self._recovery_remaining),
+            "input_linear_velocity": original[0],
+            "input_angular_velocity": original[1],
+            "final_linear_velocity": final[0],
+            "final_angular_velocity": final[1],
+        }
+
+
 __all__ = [
+    "DEADLOCK_RECOVERY_SCHEMA",
     "INTERVENTION_DISABLED",
     "INTERVENTION_HARD_STOP",
     "INTERVENTION_NONE",
     "INTERVENTION_SPEED_CAP",
     "SAFETY_WRAPPER_SCHEMA",
+    "DeadlockRecoveryConfig",
+    "DeadlockRecoveryMonitor",
     "SafetyContext",
     "SafetyWrapperConfig",
     "apply_safety_wrapper",

--- a/tests/test_safety_wrapper_deadlock.py
+++ b/tests/test_safety_wrapper_deadlock.py
@@ -1,0 +1,165 @@
+"""Tests for the stateful deadlock-recovery stage of the issue #3501 safety wrapper.
+
+These exercise the fourth predeclared safety stage: it must break the *frozen robot* failure mode
+by permitting a bounded in-place rotation, while never adding forward speed (so the hard stop/yield
+veto is preserved and recovery cannot inject forward motion into a hazard).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.robot.safety_wrapper import (
+    DEADLOCK_RECOVERY_SCHEMA,
+    DeadlockRecoveryConfig,
+    DeadlockRecoveryMonitor,
+    SafetyContext,
+)
+
+# A context where the robot is boxed in by a nearby pedestrian (hazard-blocked).
+BLOCKED = SafetyContext(min_pedestrian_distance_m=0.8, min_clearance_m=0.2, min_ttc_s=0.5)
+# A context with clear surroundings (e.g. goal reached): a stop here is not a deadlock.
+CLEAR = SafetyContext(min_pedestrian_distance_m=25.0, min_clearance_m=24.0, min_ttc_s=None)
+
+
+def _run_frozen(monitor: DeadlockRecoveryMonitor, n: int, context: SafetyContext = BLOCKED):
+    """Feed ``n`` frozen (zero forward speed) steps and return the per-step records."""
+    return [monitor.step(0.0, 0.0, context) for _ in range(n)]
+
+
+def test_disabled_monitor_is_passthrough():
+    """A disabled monitor never recovers and passes the command through unchanged."""
+    monitor = DeadlockRecoveryMonitor()  # disabled by default
+    record = monitor.step(0.0, 0.0, BLOCKED)
+    assert record["enabled"] is False
+    assert record["recovery_active"] is False
+    assert record["final_linear_velocity"] == 0.0
+    assert record["final_angular_velocity"] == 0.0
+    assert record["schema_version"] == DEADLOCK_RECOVERY_SCHEMA
+
+
+def test_no_recovery_before_patience():
+    """Recovery must not engage while the frozen run is below ``patience_steps``."""
+    config = DeadlockRecoveryConfig(enabled=True, patience_steps=5, recovery_steps=3)
+    monitor = DeadlockRecoveryMonitor(config)
+    records = _run_frozen(monitor, 4)
+    assert all(not r["recovery_active"] for r in records)
+    assert [r["frozen_run"] for r in records] == [1, 2, 3, 4]
+    assert all(not r["deadlock_detected"] for r in records)
+
+
+def test_recovery_engages_at_patience_and_rotates_in_place():
+    """At ``patience_steps`` a deadlock is detected and an in-place rotation is applied."""
+    config = DeadlockRecoveryConfig(
+        enabled=True,
+        patience_steps=3,
+        recovery_steps=2,
+        recovery_angular_velocity_rad_s=0.7,
+        recovery_turn_sign=1,
+    )
+    monitor = DeadlockRecoveryMonitor(config)
+    records = _run_frozen(monitor, 5)
+    # Steps 1-2: below patience, no recovery. Step 3 hits patience -> recovery engages.
+    assert not records[0]["recovery_active"]
+    assert not records[1]["recovery_active"]
+    assert records[2]["deadlock_detected"] is True
+    assert records[2]["recovery_active"] is True
+    # Recovery overrides angular velocity but preserves forward speed (0.0 here).
+    assert records[2]["final_angular_velocity"] == pytest.approx(0.7)
+    assert records[2]["final_linear_velocity"] == 0.0
+
+
+def test_recovery_cycles_maneuver_then_re_arms_patience():
+    """A completed maneuver re-arms patience, so a still-stuck robot pauses then retries."""
+    config = DeadlockRecoveryConfig(enabled=True, patience_steps=2, recovery_steps=2)
+    monitor = DeadlockRecoveryMonitor(config)
+    records = _run_frozen(monitor, 6)
+    active = [r["recovery_active"] for r in records]
+    # Patience reached at index 1 -> a 2-step maneuver (indices 1,2). The completed maneuver
+    # re-arms the patience window, so the still-frozen robot pauses one step (index 3) to let the
+    # planner react, then a fresh maneuver runs (indices 4,5).
+    assert active == [False, True, True, False, True, True]
+
+
+def test_negative_turn_sign_rotates_the_other_way():
+    """``recovery_turn_sign=-1`` rotates in the opposite direction during recovery."""
+    config = DeadlockRecoveryConfig(
+        enabled=True, patience_steps=1, recovery_steps=1, recovery_turn_sign=-1
+    )
+    monitor = DeadlockRecoveryMonitor(config)
+    record = monitor.step(0.0, 0.0, BLOCKED)
+    assert record["final_angular_velocity"] == pytest.approx(-0.5)
+
+
+def test_movement_resets_frozen_run_and_ends_recovery():
+    """Resumed forward motion clears the frozen run and cancels any active maneuver."""
+    config = DeadlockRecoveryConfig(enabled=True, patience_steps=2, recovery_steps=5)
+    monitor = DeadlockRecoveryMonitor(config)
+    _run_frozen(monitor, 3)  # engage recovery
+    moving = monitor.step(0.9, 0.1, BLOCKED)  # robot moves again
+    assert moving["frozen_run"] == 0
+    assert moving["recovery_active"] is False
+    assert moving["recovery_steps_remaining"] == 0
+    assert moving["final_linear_velocity"] == pytest.approx(0.9)
+    assert moving["final_angular_velocity"] == pytest.approx(0.1)
+
+
+def test_clear_surroundings_is_not_a_deadlock():
+    """A frozen robot with clear surroundings (goal reached) is never treated as deadlocked."""
+    config = DeadlockRecoveryConfig(enabled=True, patience_steps=2, recovery_steps=3)
+    monitor = DeadlockRecoveryMonitor(config)
+    records = _run_frozen(monitor, 10, context=CLEAR)
+    # Frozen but not hazard-blocked (goal reached): never counts as a deadlock.
+    assert all(r["frozen_run"] == 0 for r in records)
+    assert all(not r["recovery_active"] for r in records)
+    assert all(not r["deadlock_detected"] for r in records)
+
+
+def test_recovery_never_adds_forward_speed_during_hard_stop():
+    """Recovery only rotates; it never re-introduces forward speed under a persistent hard stop."""
+    # Simulate a persistent hard stop: the wrapper zeroes forward speed each step. Recovery must
+    # only add rotation and must never re-introduce forward motion into the hazard.
+    config = DeadlockRecoveryConfig(enabled=True, patience_steps=2, recovery_steps=4)
+    monitor = DeadlockRecoveryMonitor(config)
+    records = _run_frozen(monitor, 6)
+    for record in records:
+        assert record["final_linear_velocity"] == 0.0
+
+
+def test_obstacle_only_freeze_counts_as_hazard_blocked():
+    """A tight predicted clearance marks a freeze as hazard-blocked without a nearby pedestrian."""
+    context = SafetyContext(min_pedestrian_distance_m=50.0, min_clearance_m=0.1, min_ttc_s=None)
+    config = DeadlockRecoveryConfig(enabled=True, patience_steps=1, recovery_steps=1)
+    monitor = DeadlockRecoveryMonitor(config)
+    record = monitor.step(0.0, 0.0, context)
+    assert record["deadlock_detected"] is True
+    assert record["recovery_active"] is True
+
+
+def test_reset_clears_counters():
+    """``reset`` clears the frozen-run and recovery counters for a fresh episode."""
+    config = DeadlockRecoveryConfig(enabled=True, patience_steps=2, recovery_steps=3)
+    monitor = DeadlockRecoveryMonitor(config)
+    _run_frozen(monitor, 3)
+    monitor.reset()
+    first = monitor.step(0.0, 0.0, BLOCKED)
+    assert first["frozen_run"] == 1
+    assert first["recovery_active"] is False
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"patience_steps": 0},
+        {"recovery_steps": 0},
+        {"recovery_turn_sign": 0},
+        {"recovery_angular_velocity_rad_s": 0.0},
+        {"frozen_speed_eps_m_s": -0.1},
+        {"hazard_proximity_m": -1.0},
+        {"hazard_clearance_m": -0.5},
+    ],
+)
+def test_config_rejects_invalid_thresholds(kwargs):
+    """Out-of-range recovery thresholds are rejected at construction time."""
+    with pytest.raises(ValueError):
+        DeadlockRecoveryConfig(enabled=True, **kwargs)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** implements the deferred fourth stage of the issue #3501 planner-agnostic safety wrapper — a stateful **deadlock-recovery** monitor (`DeadlockRecoveryConfig` + `DeadlockRecoveryMonitor`, schema `safety_wrapper_deadlock_recovery.v1`) in `robot_sf/robot/safety_wrapper.py`. Plus a closure-audit reconciliation of #3501.
- **Why now:** this is the maintainer implementation plan's Phase 2 stage 4 ("deadlock recovery after a fixed stagnant window"), the only wrapper stage never implemented across #3591/#4137/#4136/#4223/#4298/#4598. The closure audit found every other CPU-only criterion already merged; this is the smallest remaining *implementable* slice (the paired ablation is the excluded compute RUN).
- **Claim boundary:** diagnostic-tier component; opt-in and **disabled by default**. It changes no default or existing runtime/benchmark behavior. No mitigation-effect size is measured here.
- **Required validation:** focused deadlock tests + the full safety-wrapper bundle + Ruff + docs proof-consistency (results below).
- **Remaining blocker:** the paired `planner × {wrapper_off, wrapper_on}` ablation RUN over the fixed scenario set + paired seeds (compute-gated), then the report builder (#4598) on executed rows. One additional CPU-only follow-up: wire `DeadlockRecoveryMonitor` into the (currently stateless) benchmark runtime step loop so the ablation exercises the stage.

## Contract delta

- **New public API** (additive): `DeadlockRecoveryConfig`, `DeadlockRecoveryMonitor`, `DEADLOCK_RECOVERY_SCHEMA` in `robot_sf/robot/safety_wrapper.py`.
- **Safety property (fail-safe):** recovery only overrides *angular* velocity; forward speed is passed through unchanged, so the hard stop/yield veto (which zeroes forward speed) is preserved and recovery can never add forward motion into a hazard.
- **Deadlock definition (predeclared, fixed, no per-planner tuning):** a step is frozen when `|executed forward speed| ≤ frozen_speed_eps_m_s` AND hazard-blocked (nearest pedestrian ≤ `hazard_proximity_m`, or finite predicted clearance ≤ `hazard_clearance_m`); a goal-reached stop with clear surroundings is not a deadlock. After `patience_steps` frozen steps, a bounded in-place rotation runs for up to `recovery_steps`, then re-arms patience.
- **Compatibility impact:** none for existing behavior. `apply_safety_wrapper` and the benchmark runtime are byte-for-byte unchanged; the monitor is inert unless explicitly instantiated and enabled.

### Assumption recorded (reversible)

The maintainer plan named `recovery_mode: conservative_yield`. This first increment implements a concrete conservative rotate-in-place escape as the initial recovery behavior (fixed predeclared thresholds); the config is a clean seam for a future `recovery_mode` enum. Field names follow the already-landed `safety_wrapper.py` style rather than the plan's earlier YAML sketch (which the merged code had already superseded).

## Scope summary

Issue: https://github.com/ll7/robot_sf_ll7/issues/3501

Closure audit of #3501 (see `docs/context/evidence/issue_3501_closure_audit_2026-07-04.md`, reconciled 2026-07-06): all CPU-only criteria are delivered after this PR (four wrapper stages, runtime binding, ablation manifest + checker, preregistration, false-stop diagnostic, paired effect-size report builder). Two criteria remain and are **compute-gated** (the paired ablation RUN and its report on executed rows), so this PR uses `Refs #3501`, consistent with the unanimous gate disposition that the issue stays open pending the campaign.

## Validation

```
uv run pytest tests/test_safety_wrapper.py tests/test_safety_wrapper_deadlock.py \
  tests/benchmark/test_safety_wrapper_runtime.py \
  tests/benchmark/test_safety_wrapper_ablation_manifest.py \
  tests/benchmark/test_safety_wrapper_factorial_preregistration.py \
  tests/benchmark/test_safety_wrapper_factorial_report.py
# -> 103 passed in 32.63s

uv run ruff check robot_sf/robot/safety_wrapper.py tests/test_safety_wrapper_deadlock.py
# -> All checks passed!

BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
# -> OK docs/proof consistency check passed for 5 changed file(s).
```

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. The deadlock monitor is not wired into the benchmark runtime here (deferred, CPU-only follow-up); the paired ablation RUN + effect-size report on executed rows remain the compute-gated remainder.

## Downstream Propagation

- Parent issue #3501: closure-audit evidence doc reconciled in this PR (`docs/context/evidence/issue_3501_closure_audit_2026-07-04.md`); context note `docs/context/issue_3501_safety_wrapper.md` updated; evidence catalog entry (`docs/context/evidence/README.md`) refreshed. No separate issue comment (this PR is the single durable state surface for the slice).
- Registry/leaderboard/claim map: N/A — diagnostic component, no benchmark evidence promoted.

<details>
<summary>Research Result Guidance</summary>

- **Target claim/blocker:** advances #3501 wrapper-completeness criterion (four stages); the causal mitigation-effect claim remains blocked on the compute-gated paired ablation RUN.
- **Comparator/baseline:** paired `wrapper_off` vs `wrapper_on` (future run).
- **Evidence tier:** diagnostic-only (opt-in, disabled by default; unit-tested contract).
- **Result classification:** capability slice (new stage), not a benchmark result.
- **Decision/stop rule:** N/A — no measurement performed.
- **Synthesis surface:** `docs/context/evidence/issue_3501_closure_audit_2026-07-04.md`.
</details>

Refs #3501


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional deadlock-recovery mode that can help a frozen robot rotate out of stuck situations while keeping forward motion unchanged.
  * Introduced new diagnostic details for deadlock detection and recovery status.

* **Bug Fixes**
  * Improved handling of persistent stops so recovery can retry after a pause and reset when motion resumes.
  * Added safeguards to avoid triggering recovery in clear, non-blocked surroundings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->