### PR TITLE
test: checkpoint-backed model-based action selection smoke path (#4013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #4013 checkpoint-backed model-based action selection (diagnostic).** New
+  `configs/algos/learned_prediction_mpc_issue_4013_checkpoint.yaml` wires the trained short-horizon
+  predictor checkpoint into the `learned_prediction_mpc` adapter fail-closed (`allow_untrained_smoke`
+  and `fallback_to_constant_velocity` both false), and `tests/planner/test_learned_prediction_mpc_checkpoint.py`
+  proves the adapter's `plan()` emits a finite, bounded, goal-directed unicycle command from the
+  loaded checkpoint — in open space and with a pedestrian in the path — with the predictor reporting
+  `evidence_tier=checkpoint_loaded` (no fallback), plus a fail-closed check for a missing checkpoint.
+  This exercises the "model-based action selection runs on a smoke scenario" acceptance criterion of
+  #4013 end to end (previously only the predictor `predict()` path and metadata registration were
+  tested). Claim boundary: diagnostic-only path execution; not benchmark, navigation-quality, or
+  paper/dissertation evidence. The paired 3-arm smoke comparison (learned vs `cv_prediction_mpc` vs a
+  model-free baseline) and Phase 3 real-trajectory training remain open on #4013. No benchmark
+  campaign, no SLURM/GPU submission, no paper/dissertation claim edits.
 * **issue #4013 trained short-horizon pedestrian predictor (diagnostic).** New
   `robot_sf/planner/learned_short_horizon_trainer.py` plus
   `scripts/training/train_learned_short_horizon_predictor_issue_4013.py`

--- a/configs/algos/learned_prediction_mpc_issue_4013_checkpoint.yaml
+++ b/configs/algos/learned_prediction_mpc_issue_4013_checkpoint.yaml
@@ -1,0 +1,43 @@
+# Checkpoint-backed learned short-horizon prediction MPC config for issue #4013.
+#
+# Unlike learned_prediction_mpc_issue_4013_smoke.yaml (which loads the untrained
+# zero-initialized smoke model), this config loads the trained checkpoint produced
+# by the diagnostic Phase 2 trainer so the model-based arm runs on real learned
+# weights (evidence_tier=checkpoint_loaded) with NO fallback.
+#
+# Fail-closed: allow_untrained_smoke=false and fallback_to_constant_velocity=false,
+# so a missing/mismatched checkpoint raises instead of silently degrading. The
+# predictor dimensions below (max_pedestrians, horizon_steps, rollout_dt,
+# hidden_dim, model_type, history_steps) MUST match the trainer config
+# configs/training/learned_short_horizon_predictor_issue_4013_smoke.yaml or the
+# checkpoint load fails on a shape mismatch.
+#
+# Generate the checkpoint first (CPU, git-ignored output/):
+#   uv run python scripts/training/train_learned_short_horizon_predictor_issue_4013.py \
+#     --config configs/training/learned_short_horizon_predictor_issue_4013_smoke.yaml
+#
+# Claim boundary: diagnostic-only. The checkpoint is smoke evidence that the
+# predictor trains and loads without fallback; it is NOT benchmark, navigation-
+# quality, or paper-facing evidence. Running the paired 3-arm smoke comparison
+# (learned_prediction_mpc vs cv_prediction_mpc vs a model-free baseline) and
+# Phase 3 real-trajectory training remain open (see issue #4013).
+allow_testing_algorithms: true
+allow_untrained_smoke: false
+fallback_to_constant_velocity: false
+checkpoint_path: output/models/issue_4013/short_horizon_predictor/short_horizon_predictor.pt
+model_id: null
+normalizer_path: null
+device: cpu
+model_type: mlp
+max_pedestrians: 16
+history_steps: 4
+horizon_steps: 4
+rollout_dt: 0.2
+hidden_dim: 64
+max_linear_speed: 0.9
+max_angular_speed: 1.1
+goal_tolerance: 0.25
+pedestrian_safety_margin: 0.35
+solver_max_iterations: 16
+warm_start: true
+fallback_to_stop: true

--- a/docs/context/issue_4013_learned_model_based_planner_design.md
+++ b/docs/context/issue_4013_learned_model_based_planner_design.md
@@ -38,6 +38,13 @@ predictor and compare closed-loop navigation without reopening the retired large
   manifest records `feature_stats` as provenance metadata only, not an applied normalizer.
 - [x] Load the trained checkpoint without fallback. `LearnedShortHorizonPedestrianPredictor` loads the
   trained `.pt` and `predict()` returns `source="checkpoint_loaded"` on a smoke observation.
+- [x] Model-based action selection runs on a smoke scenario. The `learned_prediction_mpc` adapter,
+  built on the trained checkpoint via `configs/algos/learned_prediction_mpc_issue_4013_checkpoint.yaml`
+  (fail-closed: `allow_untrained_smoke=false`, `fallback_to_constant_velocity=false`), emits a finite,
+  bounded, goal-directed unicycle command from `plan()` — including with a pedestrian in the path —
+  with the predictor reporting `evidence_tier=checkpoint_loaded` (no fallback). Proven by
+  `tests/planner/test_learned_prediction_mpc_checkpoint.py`. This exercises the end-to-end
+  model-based selection *path*; it is not the paired multi-arm benchmark comparison below.
 - [ ] Run the paired smoke *scenario* (benchmark runner) for all three arms and produce episode JSONL.
 - [ ] Compare against `cv_prediction_mpc` and a model-free baseline with paired seeds using the
   existing `scripts/analysis/compare_model_based_planning_issue_4013.py` report contract.

--- a/tests/planner/test_learned_prediction_mpc_checkpoint.py
+++ b/tests/planner/test_learned_prediction_mpc_checkpoint.py
@@ -1,0 +1,172 @@
+"""End-to-end checkpoint-backed model-based action selection for issue #4013.
+
+The existing tests prove the learned predictor *loads* a trained checkpoint
+(`tests/planner/test_learned_short_horizon_trainer.py`) and that the MPC adapter
+wires the predictor's ``predict`` into the prediction-MPC constraints
+(`tests/planner/test_learned_short_horizon_predictor.py`). Neither exercises the
+issue #4013 Definition-of-Done clause "model-based action selection runs on a
+smoke scenario": the adapter's ``plan`` was never called against a *trained*
+checkpoint to confirm a bounded unicycle command is actually emitted without
+fallback.
+
+These tests close that gap. They train a tiny CPU checkpoint, build the
+``learned_prediction_mpc`` adapter on that checkpoint (fail-closed, no untrained
+smoke, no constant-velocity fallback), and assert:
+
+* the predictor reports ``evidence_tier=checkpoint_loaded`` (real learned weights);
+* ``plan`` emits a finite, bounded, goal-directed command in open space;
+* ``plan`` still emits a bounded command when a pedestrian sits in the path
+  (model-based avoidance runs rather than crashing);
+* a configured-but-missing checkpoint fails closed instead of silently degrading.
+
+Claim boundary: diagnostic-only. This proves the checkpoint-backed model-based
+selection *path executes*; it is not benchmark, navigation-quality, or
+paper-facing evidence, and it is not the paired 3-arm smoke comparison that
+remains open on issue #4013.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robot_sf.planner.learned_prediction_mpc import build_learned_prediction_mpc_adapter
+from robot_sf.planner.learned_short_horizon_trainer import (
+    ShortHorizonTrainerConfig,
+    train_short_horizon_predictor,
+)
+
+# Small predictor geometry shared by the trainer and the inference adapter so the
+# checkpoint state dict loads without a shape mismatch. These must stay in sync.
+_MAX_PEDS = 3
+_HORIZON = 2
+_HIDDEN = 16
+
+
+def _obs(
+    *,
+    goal: tuple[float, float] = (3.0, 0.0),
+    ped_positions: list[tuple[float, float]] | None = None,
+    ped_velocities: list[tuple[float, float]] | None = None,
+) -> dict[str, object]:
+    """Build a compact SocNav observation payload for the adapter ``plan`` call."""
+
+    ped_positions = [] if ped_positions is None else ped_positions
+    ped_velocities = [] if ped_velocities is None else ped_velocities
+    return {
+        "robot": {
+            "position": np.asarray([0.0, 0.0], dtype=float),
+            "heading": np.asarray([0.0], dtype=float),
+            "speed": np.asarray([0.0], dtype=float),
+            "radius": np.asarray([0.25], dtype=float),
+        },
+        "goal": {
+            "current": np.asarray(goal, dtype=float),
+            "next": np.asarray(goal, dtype=float),
+        },
+        "pedestrians": {
+            "positions": np.asarray(ped_positions, dtype=float),
+            "velocities": np.asarray(ped_velocities, dtype=float),
+            "count": np.asarray([len(ped_positions)], dtype=float),
+            "radius": np.asarray([0.25], dtype=float),
+        },
+    }
+
+
+def _train_checkpoint(tmp_path) -> str:
+    """Train a fast tiny CPU checkpoint and return its path."""
+
+    config = ShortHorizonTrainerConfig(
+        max_pedestrians=_MAX_PEDS,
+        horizon_steps=_HORIZON,
+        hidden_dim=_HIDDEN,
+        num_samples=64,
+        epochs=60,
+        seed=4013,
+        output_dir=str(tmp_path / "short_horizon"),
+    )
+    result = train_short_horizon_predictor(config)
+    assert result.checkpoint_path.exists()
+    return str(result.checkpoint_path)
+
+
+def _checkpoint_algo_config(checkpoint_path: str) -> dict[str, object]:
+    """Build the fail-closed checkpoint-backed adapter config."""
+
+    return {
+        "allow_testing_algorithms": True,
+        "allow_untrained_smoke": False,
+        "fallback_to_constant_velocity": False,
+        "checkpoint_path": checkpoint_path,
+        "max_pedestrians": _MAX_PEDS,
+        "horizon_steps": _HORIZON,
+        "hidden_dim": _HIDDEN,
+        "rollout_dt": 0.2,
+        "solver_max_iterations": 16,
+    }
+
+
+def test_checkpoint_backed_adapter_loads_without_fallback(tmp_path) -> None:
+    """Adapter built on a trained checkpoint reports checkpoint-loaded, not fallback."""
+
+    pytest.importorskip("torch")
+    checkpoint_path = _train_checkpoint(tmp_path)
+    planner = build_learned_prediction_mpc_adapter(_checkpoint_algo_config(checkpoint_path))
+
+    diagnostics = planner.diagnostics()
+    assert diagnostics["predictor"]["backend"] == "learned_short_horizon"
+    assert diagnostics["predictor"]["evidence_tier"] == "checkpoint_loaded"
+    assert diagnostics["predictor"]["diagnostic_only"] is False
+
+    futures = planner._future_predictor.predict(_obs(), horizon_steps=_HORIZON, dt=0.2)
+    assert futures.source == "checkpoint_loaded"
+    assert np.all(np.isfinite(futures.positions_world))
+
+
+def test_checkpoint_backed_model_based_selection_runs_in_open_space(tmp_path) -> None:
+    """``plan`` emits a finite, bounded, goal-directed command from learned weights."""
+
+    pytest.importorskip("torch")
+    checkpoint_path = _train_checkpoint(tmp_path)
+    planner = build_learned_prediction_mpc_adapter(_checkpoint_algo_config(checkpoint_path))
+
+    linear, angular = planner.plan(_obs(goal=(3.0, 0.0)))
+
+    assert np.isfinite(linear)
+    assert np.isfinite(angular)
+    # Open-space command should advance toward the goal within control bounds.
+    assert linear > 0.0
+    assert linear <= planner.config.max_linear_speed
+    assert abs(angular) <= planner.config.max_angular_speed
+    # The plan came from the checkpoint-loaded predictor, not a fallback.
+    assert planner._future_predictor.diagnostics()["last_source"] == "checkpoint_loaded"
+
+
+def test_checkpoint_backed_model_based_selection_runs_with_pedestrian_in_path(tmp_path) -> None:
+    """Model-based avoidance runs and stays bounded when a pedestrian blocks the path."""
+
+    pytest.importorskip("torch")
+    checkpoint_path = _train_checkpoint(tmp_path)
+    planner = build_learned_prediction_mpc_adapter(_checkpoint_algo_config(checkpoint_path))
+
+    linear, angular = planner.plan(
+        _obs(
+            goal=(3.0, 0.0),
+            ped_positions=[(1.0, 0.0)],
+            ped_velocities=[(0.0, 0.0)],
+        )
+    )
+
+    assert np.isfinite(linear)
+    assert np.isfinite(angular)
+    assert 0.0 <= linear <= planner.config.max_linear_speed
+    assert abs(angular) <= planner.config.max_angular_speed
+
+
+def test_checkpoint_backed_adapter_fails_closed_on_missing_checkpoint(tmp_path) -> None:
+    """A configured-but-missing checkpoint fails closed instead of degrading silently."""
+
+    pytest.importorskip("torch")
+    missing = str(tmp_path / "does_not_exist.pt")
+    with pytest.raises(FileNotFoundError, match="checkpoint not found"):
+        build_learned_prediction_mpc_adapter(_checkpoint_algo_config(missing))


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds a checkpoint-backed `learned_prediction_mpc` algo config plus an end-to-end test that proves the adapter's `plan()` emits a real model-based command from a **trained** short-horizon predictor checkpoint (no fallback).
- **Why now (closure audit of #4013):** Four PRs have merged (#4160 backend, #4474 comparator preflight, #4587 report contract, #4629 Phase-2 trainer). The design doc's remaining-work checklist and the maintainer's 2026-07-06 state note keep #4013 **open**. Prior tests proved the predictor `predict()` loads a checkpoint and the adapter registers metadata, but **no test called `plan()` against a trained checkpoint** — so the DoD clause "model-based action selection runs on a smoke scenario" was unproven end to end. This slice closes that specific gap with an artifact (a passing integration test), not a readiness restatement.
- **Claim boundary:** diagnostic-only path-execution proof. Not benchmark, navigation-quality, or paper/dissertation evidence. The synthetic-checkpoint predictor is a learnability probe, not real ETH/UCY data.
- **Required validation:** `uv run pytest tests/planner/test_learned_prediction_mpc_checkpoint.py` (+ related planner/benchmark suites) — results below.
- **Remaining blocker (issue stays open):** the paired 3-arm smoke comparison (`learned_prediction_mpc` vs `cv_prediction_mpc` vs a model-free baseline, real episode JSONL → `compare_model_based_planning_issue_4013.py`) and Phase 3 real-trajectory training. Both are benchmark-RUN / real-data work outside this CPU-only, no-campaign slice.

Refs #4013 (partial — not Closes).

## Contract delta

- **New config:** `configs/algos/learned_prediction_mpc_issue_4013_checkpoint.yaml` — loads the trained checkpoint, **fail-closed** (`allow_untrained_smoke=false`, `fallback_to_constant_velocity=false`); a missing/mismatched checkpoint raises rather than silently degrading. Predictor dims mirror the trainer config for state-dict compatibility.
- **No runtime/behavior change** to shipped modules: this is a config + test + docs slice. No new schema fields on existing artifacts; no new fail-closed blockers in library code (the predictor's existing fail-closed paths are now asserted via the adapter).
- **Compatibility:** additive only. The config's `checkpoint_path` points at the git-ignored trainer output (`output/models/issue_4013/short_horizon_predictor/short_horizon_predictor.pt`); the header documents the one CPU command to generate it.

## Remaining-criteria checklist (issue #4013)

- [x] Short-horizon predictor trained; checkpoint/manifest/metrics published (#4629).
- [x] Trained checkpoint loads without fallback (`evidence_tier=checkpoint_loaded`) (#4629).
- [x] **Model-based action selection runs on a smoke scenario** — adapter `plan()` emits a bounded command from the trained checkpoint (this PR).
- [ ] Run the paired smoke *scenario* (benchmark runner) for all three arms and produce episode JSONL.
- [ ] Compare vs `cv_prediction_mpc` and a model-free baseline with paired seeds via `scripts/analysis/compare_model_based_planning_issue_4013.py`.
- [ ] Exclude/count fallback/degraded rows before any benchmark/paper claim.
- [ ] Phase 3: train on real trajectory data + representative evaluation.

## Validation

```
$ scripts/dev/run_worktree_shared_venv.sh -- uv run pytest \
    tests/planner/test_learned_prediction_mpc_checkpoint.py \
    tests/planner/test_learned_short_horizon_predictor.py \
    tests/planner/test_learned_short_horizon_trainer.py \
    tests/planner/test_prediction_mpc.py \
    tests/benchmark/test_map_runner_utils.py -q
=> 171 passed in 5.87s

$ uv run ruff check tests/planner/test_learned_prediction_mpc_checkpoint.py     => All checks passed!
$ uv run ruff format --check tests/planner/test_learned_prediction_mpc_checkpoint.py => 1 file already formatted
```

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Downstream propagation & research-result guidance</summary>

- **State propagation:** design doc `docs/context/issue_4013_learned_model_based_planner_design.md` remaining-work checklist updated (new `[x]` item + reproducible config reference); `CHANGELOG.md` updated. No new issue comment stream — the canonical durable surface (design doc checklist) is edited in place, per the high-churn one-surface rule.
- **Research result guidance:** target = DoD clause "model-based action selection runs on a smoke scenario"; comparator = existing untrained-smoke/predict-only coverage; evidence tier = `smoke evidence` / diagnostic-only; result = path execution proven by test; decision/stop rule = issue stays open until paired 3-arm comparison + Phase 3; synthesis surface = issue #4013 + the design doc.
- **Artifacts:** test trains a tiny checkpoint in `tmp_path` (no `output/` pollution); no durable artifact promoted by this PR.
</details>
