### PR TITLE
fix: portable $HOME path in issue #1134 closure-audit evidence (broken-main baseline)

### DIFF
--- a/docs/context/evidence/issue_1134_closure_audit_2026-07-06.md
+++ b/docs/context/evidence/issue_1134_closure_audit_2026-07-06.md
@@ -36,7 +36,7 @@ empirical action.
 
 | Criterion | Status | Evidence |
 | --- | --- | --- |
-| `uv run python scripts/tools/validate_socnav_map_batch.py --batch-id eth_first` passes on staged source assets. | **Not met on this host** | Default worktree preflight exits 2 with `status=blocked_pending_source_assets`; explicit `/home/luttkule/external_data/socnavbench` preflight also exits 2 with both `eth_mesh_dir` and `eth_traversible_pickle` missing. PR #3771 added the fail-closed preflight; #1498/#4189 recorded a prior host-local staged-ready state, but the asset is not present on this host. |
+| `uv run python scripts/tools/validate_socnav_map_batch.py --batch-id eth_first` passes on staged source assets. | **Not met on this host** | Default worktree preflight exits 2 with `status=blocked_pending_source_assets`; explicit `$HOME/external_data/socnavbench` preflight also exits 2 with both `eth_mesh_dir` and `eth_traversible_pickle` missing. PR #3771 added the fail-closed preflight; #1498/#4189 recorded a prior host-local staged-ready state, but the asset is not present on this host. |
 | Source checksums/provenance recorded in context note successor note. | **Partially met, not sufficient for #1134 closure** | `docs/context/issue_1498_state.yaml` records a 2026-07-02 generated `data.pkl` path and SHA-256 from a prior host-local state. Current host validation cannot reproduce that state, so #1134 still needs fresh source checksum/provenance tied to the actual conversion run. |
 | `maps/svg_maps/socnavbench/socnavbench_eth.svg` generated from official source assets and small/reviewable enough for git. | **Not met** | PR #4535 added the converter, PR #4553 added the stage/generate/convert/smoke wrapper, and PR #4574 documented the artifact policy. No real `socnavbench_eth.svg` is committed because current host source assets are absent and placeholder/fixture output is forbidden. |
 | Converted SVG passes repository SVG/parser validation. | **Met for converter fixture only; not met for real ETH SVG** | PR #4535 added `test_fixture_traversible_converts_to_parser_valid_svg`. Real ETH SVG validation remains blocked until the real SVG exists. |
@@ -60,14 +60,14 @@ scripts/dev/run_worktree_shared_venv.sh -- \
     --report-json .git/codex-agent-runs/active/issue-1134/eth_first_preflight_default.json
 # exit 2; status=blocked_pending_source_assets; conversion_ready=false
 
-ROBOT_SF_EXTERNAL_DATA_ROOT=/home/luttkule/external_data \
+ROBOT_SF_EXTERNAL_DATA_ROOT=$HOME/external_data \
 scripts/dev/run_worktree_shared_venv.sh -- \
   uv run python scripts/tools/manage_external_data.py --json check socnavbench-s3dis-eth
 # exit 2; status=missing
 
 scripts/dev/run_worktree_shared_venv.sh -- \
   uv run python scripts/tools/validate_socnav_map_batch.py \
-    --socnav-root /home/luttkule/external_data/socnavbench \
+    --socnav-root $HOME/external_data/socnavbench \
     --batch-id eth_first \
     --preflight \
     --report-json .git/codex-agent-runs/active/issue-1134/eth_first_preflight_external_root.json


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Replaces three unannotated absolute home-dir paths (`/home/luttkule/external_data/...`) in `docs/context/evidence/issue_1134_closure_audit_2026-07-06.md` with the portable `$HOME/external_data/...` form. Docs-only.

**Why now (broken-main hotfix):** PR #4641 (issue #1134 closure audit) merged that evidence note with absolute home paths. The repo-baseline guard `hooks/check_config_abs_paths.py` scans **all** committed files under `docs/context/evidence/` via `git ls-files`, so `tests/integration/test_check_config_abs_paths.py::TestCheckConfigAbsPaths::test_repo_baseline_is_clean` now fails on every PR whose CI merges current main (observed on the `fast-feedback (2)` shard of PRs #4642 and #4643). This restores a clean baseline.

**Claim boundary:** Docs-only path portability fix; no runtime, config, benchmark, or semantic change. `$HOME` is not an absolute home-dir prefix (`/home/`|`/Users/`|`/root/`), so the guard passes.

**Validation:**
- `uv run python hooks/check_config_abs_paths.py` → exit 0.
- `uv run python -m pytest tests/integration/test_check_config_abs_paths.py -q` → 12 passed.

Refs #1134
