### PR TITLE
feat: offline behavior-token motion-prior diagnostics prototype (issue #4627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #4627 behavior-token motion-prior diagnostics (experimental, offline).** New
+  `experiments/behavior_tokens/` namespace with an offline, read-only prototype that turns saved
+  benchmark interaction traces into discrete "behavior tokens" for diagnostics. `extract_windows.py`
+  slides fixed-size windows over `algorithm_metadata.simulation_step_trace.steps` and converts each
+  into a documented, interpretable feature vector (clearance, time-to-contact proxy, robot-speed
+  statistics, stop/yield and oscillation proxies, near-conflict recovery); `quantize_trace_windows.py`
+  standardizes the finite feature columns and assigns each valid window a deterministic discrete
+  token id via k-means (scikit-learn with a NumPy-only fallback, token ids canonicalized by cluster
+  center so runs and libraries agree); `inspect_token_motifs.py` summarizes token distributions by
+  scenario/planner/outcome and exports heuristic *candidate* motif labels plus bounded example
+  windows. `schemas.py` holds the shared feature vocabulary and schema-version constants. Rows without
+  a usable trace are skipped with an explicit reason; non-derivable features are recorded as `null`
+  (never fabricated zeros). Covered by `tests/experiments/test_behavior_tokens.py`. Claim boundary:
+  very low priority, exploratory, diagnostic-only tooling — not validated metrics, benchmark evidence,
+  release-gate input, or paper/dissertation claim support, and no safety decision may depend on the
+  tokens. No new controller training, no transformer dependency, no benchmark pipeline integration,
+  no benchmark campaign run, and no SLURM/GPU submission.
 * **issue #4013 checkpoint-backed model-based action selection (diagnostic).** New
   `configs/algos/learned_prediction_mpc_issue_4013_checkpoint.yaml` wires the trained short-horizon
   predictor checkpoint into the `learned_prediction_mpc` adapter fail-closed (`allow_untrained_smoke`

--- a/experiments/behavior_tokens/README.md
+++ b/experiments/behavior_tokens/README.md
@@ -1,0 +1,116 @@
+# Behavior-token motion-prior diagnostics (experimental)
+
+> **Status: very low priority, experimental, diagnostic-only.** This tooling is an
+> offline prototype for inspecting saved interaction traces. It is **not** part of the
+> validated metric stack, the benchmark pipeline, any release gate, or any
+> paper/dissertation claim. **No safety decision may depend on these tokens.**
+
+Tracking issue: [#4627](https://github.com/ll7/robot_sf_ll7/issues/4627).
+
+## What this is
+
+A small, offline experiment that asks: *can pedestrian/robot interaction traces in
+`robot_sf_ll7` be represented as short discrete **behavior tokens**, and are those
+tokens useful for diagnostics such as scenario grouping, failure analysis, or
+regression-test stratification?*
+
+The idea is loosely inspired by work on reusable, pretrained motion/control priors
+(arXiv:2606.29148). **It is not a foundation-model claim.** There is no controller
+training, no transformer dependency, and no new simulation campaign — the scripts read
+existing saved traces and produce static diagnostic artifacts under `output/`.
+
+## What this is not
+
+- Not a new controller and not controller training.
+- Not a replacement for existing safety metrics.
+- Not a benchmark, leaderboard, or release input.
+- Not ground-truth interaction labels — token ids and motif labels are heuristic
+  *candidates* for manual inspection only.
+- Not evidence for any paper/dissertation claim.
+
+## Pipeline
+
+Three offline stages, each a standalone CLI (`--help` on each for full options):
+
+1. **`extract_windows.py`** — slide fixed-size windows over saved
+   `algorithm_metadata.simulation_step_trace.steps` and convert each window into a
+   compact, documented feature vector.
+2. **`quantize_trace_windows.py`** — standardize the finite feature columns and assign
+   each valid window a deterministic discrete **token id** (k-means; scikit-learn when
+   available, else a NumPy-only fallback).
+3. **`inspect_token_motifs.py`** — summarize token distributions by
+   scenario/planner/outcome and export representative example windows plus heuristic
+   *candidate* motif labels for manual inspection.
+
+`schemas.py` holds the shared feature vocabulary and schema-version constants embedded
+in every generated artifact for provenance.
+
+### Input contract
+
+The scripts read existing benchmark episode JSONL rows. A usable row carries:
+
+- `algorithm_metadata.simulation_step_trace.steps` (**required** — rows without it are
+  skipped with an explicit reason, never run through a new campaign);
+- `scenario_id`, `seed`, and a planner identifier
+  (`planner_key` / `scenario_params.algo` / `algorithm_metadata.algorithm`);
+- `status` / `outcome` / `termination_reason` (used for stratification when present).
+
+Each step is expected to look like the trace produced by the benchmark map runner:
+`{step, time_s, robot: {position, heading, velocity}, pedestrians: [{id, position,
+velocity?}], planner: {selected_action: {...}}}`.
+
+### Missing-value discipline
+
+If a feature cannot be derived for a window (for example, relative speed to the nearest
+pedestrian when pedestrian velocities are absent), it is recorded as JSON `null` and
+listed in the window's `missing_features`. **Genuine zero measurements** (for example,
+an all-straight command sequence giving an oscillation rate of `0.0`) are recorded as
+`0.0` and are *not* treated as missing. The quantizer clusters only on feature columns
+that are finite across enough windows and excludes windows that lack any selected
+feature (reported in its metadata), rather than back-filling fabricated values.
+
+## Usage
+
+```bash
+# 1. Extract windows from saved traces (offline; reads only).
+uv run python experiments/behavior_tokens/extract_windows.py \
+  --episode-jsonl 'output/**/episodes.jsonl' \
+  --window-steps 10 --stride-steps 5 \
+  --output-jsonl output/experiments/behavior_tokens/windows.jsonl \
+  --output-csv output/experiments/behavior_tokens/windows.csv
+
+# 2. Quantize windows into deterministic discrete tokens.
+uv run python experiments/behavior_tokens/quantize_trace_windows.py \
+  --windows-jsonl output/experiments/behavior_tokens/windows.jsonl \
+  --num-tokens 12 \
+  --output-json output/experiments/behavior_tokens/token_assignments.json \
+  --output-csv output/experiments/behavior_tokens/token_assignments.csv
+
+# 3. Inspect token motifs and export representative examples.
+uv run python experiments/behavior_tokens/inspect_token_motifs.py \
+  --windows-jsonl output/experiments/behavior_tokens/windows.jsonl \
+  --assignments-csv output/experiments/behavior_tokens/token_assignments.csv \
+  --output-dir output/experiments/behavior_tokens/inspection
+```
+
+All outputs default to `output/experiments/behavior_tokens/...`, which is git-ignored
+and worktree-local. Nothing here is promoted to durable evidence automatically.
+
+## Feature vocabulary
+
+The ordered feature list lives in `schemas.py` (`FEATURE_NAMES`) with one-line
+descriptions in `FEATURE_DESCRIPTIONS`. It covers clearance (min/mean/slope), relative
+speed to the nearest pedestrian, a time-to-contact proxy, robot speed statistics, an
+acceleration/command-change proxy, a nearest-pedestrian speed-change proxy, a
+stop/yield proxy, an oscillation/negotiation proxy, and a near-conflict recovery proxy.
+Route-progress delta is left `null` because it is not present in the step trace.
+
+## Tests
+
+```bash
+uv run pytest tests/experiments/test_behavior_tokens.py -q
+```
+
+The tests use synthetic in-memory traces (no saved campaign required) and cover window
+counting, missing-feature handling, no-trace skipping, quantizer determinism, one token
+per valid window, bounded example selection, and the experimental claim boundary.

--- a/experiments/behavior_tokens/extract_windows.py
+++ b/experiments/behavior_tokens/extract_windows.py
@@ -1,0 +1,631 @@
+"""Offline extraction of interaction-trace windows into feature vectors.
+
+Reads existing benchmark episode JSONL rows that contain a
+``algorithm_metadata.simulation_step_trace.steps`` list, slides fixed-size windows
+over each trace, and converts every window into a compact, interpretable feature
+vector (see :data:`experiments.behavior_tokens.schemas.FEATURE_NAMES`).
+
+This script is offline and non-invasive: it only reads saved traces and writes
+diagnostic artifacts under ``output/`` by default. It never launches a new
+simulation campaign. Rows without a usable step trace are skipped with an explicit
+reason (reported in the run summary), not silently dropped.
+
+Example::
+
+    uv run python experiments/behavior_tokens/extract_windows.py \\
+        --episode-jsonl 'output/**/episodes.jsonl' \\
+        --window-steps 10 --stride-steps 5 \\
+        --output-jsonl output/experiments/behavior_tokens/windows.jsonl \\
+        --output-csv output/experiments/behavior_tokens/windows.csv
+
+Claim boundary: exploratory diagnostic tooling only; not validated metric or
+benchmark evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import json
+import math
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+# Allow ``python experiments/behavior_tokens/extract_windows.py`` (script-style
+# execution puts the script directory on sys.path, not the repo root) as well as
+# namespace-package imports used by the test suite.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from experiments.behavior_tokens.schemas import (  # noqa: E402
+    CLAIM_BOUNDARY,
+    FEATURE_NAMES,
+    FEATURE_SCHEMA_VERSION,
+    NEAR_PEDESTRIAN_THRESHOLD_M,
+    STOP_SPEED_THRESHOLD_M_S,
+    WindowRecord,
+)
+
+
+def _finite(value: Any) -> float | None:
+    """Return ``value`` as a finite float, or ``None`` when not numeric/finite."""
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return numeric if math.isfinite(numeric) else None
+
+
+def _vec2(value: Any) -> np.ndarray | None:
+    """Return a length-2 float array from a ``[x, y]`` payload, or ``None``."""
+    if isinstance(value, (list, tuple, np.ndarray)) and len(value) >= 2:
+        x = _finite(value[0])
+        y = _finite(value[1])
+        if x is not None and y is not None:
+            return np.array([x, y], dtype=float)
+    return None
+
+
+def _slope(times: list[float], values: list[float]) -> float | None:
+    """Return the least-squares slope of ``values`` vs ``times`` (per second)."""
+    if len(times) < 2 or len(set(times)) < 2:
+        return None
+    slope = float(np.polyfit(np.asarray(times), np.asarray(values), 1)[0])
+    return slope if math.isfinite(slope) else None
+
+
+def _rms(values: list[float]) -> float | None:
+    """Return the root-mean-square of ``values``, or ``None`` when empty."""
+    if not values:
+        return None
+    return float(np.sqrt(np.mean(np.square(np.asarray(values)))))
+
+
+def _command_linear_angular(planner: Any) -> tuple[float | None, float | None]:
+    """Extract (linear_speed, angular_velocity) proxies from a step planner payload.
+
+    Supports both differential ``{linear_velocity, angular_velocity}`` and holonomic
+    ``{command_kind: holonomic_vxy_world, vx, vy}`` actions. Angular velocity is
+    ``None`` for holonomic commands (no scalar yaw command available).
+    """
+    if not isinstance(planner, dict):
+        return None, None
+    action = planner.get("selected_action")
+    if not isinstance(action, dict):
+        return None, None
+    if action.get("command_kind") == "holonomic_vxy_world":
+        vx = _finite(action.get("vx"))
+        vy = _finite(action.get("vy"))
+        if vx is None or vy is None:
+            return None, None
+        return float(math.hypot(vx, vy)), None
+    linear = _finite(action.get("linear_velocity"))
+    angular = _finite(action.get("angular_velocity"))
+    return linear, angular
+
+
+def _robot_speed(
+    robot: Any, prev_pos: np.ndarray | None, pos: np.ndarray | None, dt: float | None
+) -> float | None:
+    """Return robot speed from an explicit velocity, else a finite-difference proxy."""
+    if isinstance(robot, dict):
+        velocity = _vec2(robot.get("velocity"))
+        if velocity is not None:
+            return float(np.linalg.norm(velocity))
+    if prev_pos is not None and pos is not None and dt and dt > 0.0:
+        return float(np.linalg.norm(pos - prev_pos) / dt)
+    return None
+
+
+def _nearest_pedestrian(
+    robot_pos: np.ndarray | None, pedestrians: Any, robot_vel: np.ndarray | None
+) -> dict[str, Any] | None:
+    """Return nearest-pedestrian distance/speed info for one step, or ``None``.
+
+    ``rel_speed`` is only populated when the pedestrian carries a velocity; otherwise
+    it stays ``None`` so downstream features never fabricate a zero relative speed.
+    """
+    if robot_pos is None or not isinstance(pedestrians, list) or not pedestrians:
+        return None
+    best: dict[str, Any] | None = None
+    for ped in pedestrians:
+        if not isinstance(ped, dict):
+            continue
+        ped_pos = _vec2(ped.get("position"))
+        if ped_pos is None:
+            continue
+        distance = float(np.linalg.norm(ped_pos - robot_pos))
+        if best is None or distance < best["distance"]:
+            ped_vel = _vec2(ped.get("velocity"))
+            rel_speed = None
+            if ped_vel is not None and robot_vel is not None:
+                rel_speed = float(np.linalg.norm(ped_vel - robot_vel))
+            best = {
+                "distance": distance,
+                "ped_id": str(ped.get("id")) if ped.get("id") is not None else None,
+                "ped_speed": float(np.linalg.norm(ped_vel)) if ped_vel is not None else None,
+                "rel_speed": rel_speed,
+            }
+    return best
+
+
+def _step_time(step: dict[str, Any], index: int) -> float:
+    """Return a step time in seconds, falling back to the step index when absent."""
+    time_s = _finite(step.get("time_s"))
+    if time_s is not None:
+        return time_s
+    step_idx_val = _finite(step.get("step"))
+    return step_idx_val if step_idx_val is not None else float(index)
+
+
+class _ParsedWindow:
+    """Per-step series parsed from a window, aligned to make features easy to derive.
+
+    Keeping the parsing separate from feature math keeps each feature helper small and
+    individually testable, and ensures the missing-vs-zero distinction is applied once.
+    """
+
+    def __init__(self, steps: list[dict[str, Any]]) -> None:
+        self.times: list[float] = [_step_time(step, idx) for idx, step in enumerate(steps)]
+        # nearest_dists is aligned to steps (None when no pedestrian that step).
+        self.nearest_dists: list[float | None] = []
+        self.nearest_dist_times: list[float] = []
+        self.rel_speeds: list[float] = []
+        self.ped_speed_series: list[tuple[float, float]] = []  # (time, ped speed) while near
+        self.robot_speed_series: list[tuple[float, float]] = []  # (time, robot speed)
+        self.step_speed_dist: list[tuple[float | None, float | None]] = []  # per-step
+        self.linear_cmds: list[float] = []
+        self.angular_cmds: list[float] = []
+        self.headings: list[float] = []
+        self._parse(steps)
+
+    def _parse(self, steps: list[dict[str, Any]]) -> None:
+        prev_pos: np.ndarray | None = None
+        for idx, step in enumerate(steps):
+            robot = step.get("robot") if isinstance(step.get("robot"), dict) else {}
+            pos = _vec2(robot.get("position"))
+            robot_vel = _vec2(robot.get("velocity"))
+            dt = (self.times[idx] - self.times[idx - 1]) if idx > 0 else None
+            speed = _robot_speed(robot, prev_pos, pos, dt)
+            if speed is not None:
+                self.robot_speed_series.append((self.times[idx], speed))
+            heading = _finite(robot.get("heading"))
+            if heading is not None:
+                self.headings.append(heading)
+
+            nearest = _nearest_pedestrian(pos, step.get("pedestrians"), robot_vel)
+            distance = nearest["distance"] if nearest is not None else None
+            self.nearest_dists.append(distance)
+            self.step_speed_dist.append((speed, distance))
+            if nearest is not None:
+                self.nearest_dist_times.append(self.times[idx])
+                if nearest["rel_speed"] is not None:
+                    self.rel_speeds.append(nearest["rel_speed"])
+                if (
+                    nearest["ped_speed"] is not None
+                    and nearest["distance"] < NEAR_PEDESTRIAN_THRESHOLD_M
+                ):
+                    self.ped_speed_series.append((self.times[idx], nearest["ped_speed"]))
+
+            linear, angular = _command_linear_angular(step.get("planner"))
+            if linear is not None:
+                self.linear_cmds.append(linear)
+            if angular is not None:
+                self.angular_cmds.append(angular)
+            prev_pos = pos
+
+
+def _clearance_features(parsed: _ParsedWindow) -> dict[str, float | None]:
+    """Clearance min/mean/slope and near-conflict recovery from the distance series."""
+    valid = [d for d in parsed.nearest_dists if d is not None]
+    out: dict[str, float | None] = {}
+    if not valid:
+        return out
+    out["clearance_min_m"] = float(min(valid))
+    out["clearance_mean_m"] = float(np.mean(valid))
+    out["clearance_slope_m_per_s"] = _slope(parsed.nearest_dist_times, valid)
+    min_idx = min(range(len(valid)), key=lambda i: valid[i])
+    if min_idx < len(valid) - 1:
+        out["near_conflict_recovery_m"] = float(valid[-1] - valid[min_idx])
+    return out
+
+
+def _ttc_features(parsed: _ParsedWindow) -> dict[str, float | None]:
+    """Time-to-contact proxy min/slope from the closing-distance series."""
+    dists, times = parsed.nearest_dists, parsed.times
+    values: list[float] = []
+    value_times: list[float] = []
+    for i in range(1, len(dists)):
+        d_prev, d_cur = dists[i - 1], dists[i]
+        if d_prev is None or d_cur is None:
+            continue
+        dt = times[i] - times[i - 1]
+        if dt <= 0.0:
+            continue
+        closing = (d_prev - d_cur) / dt
+        if closing > 1e-9:
+            values.append(d_cur / closing)
+            value_times.append(times[i])
+    out: dict[str, float | None] = {}
+    if values:
+        out["ttc_proxy_min_s"] = float(min(values))
+        out["ttc_proxy_slope_s_per_s"] = _slope(value_times, values)
+    return out
+
+
+def _robot_speed_features(parsed: _ParsedWindow) -> dict[str, float | None]:
+    """Robot speed statistics plus an acceleration RMS proxy."""
+    series = parsed.robot_speed_series
+    out: dict[str, float | None] = {}
+    if not series:
+        return out
+    speeds = [s for _, s in series]
+    out["robot_speed_mean_m_s"] = float(np.mean(speeds))
+    out["robot_speed_min_m_s"] = float(min(speeds))
+    out["robot_speed_max_m_s"] = float(max(speeds))
+    accel = [
+        (series[i][1] - series[i - 1][1]) / (series[i][0] - series[i - 1][0])
+        for i in range(1, len(series))
+        if series[i][0] - series[i - 1][0] > 0.0
+    ]
+    out["robot_accel_rms_m_s2"] = _rms(accel)
+    return out
+
+
+def _command_features(parsed: _ParsedWindow) -> dict[str, float | None]:
+    """Command-change RMS and an oscillation (steering sign-change) rate proxy."""
+    out: dict[str, float | None] = {}
+    if len(parsed.linear_cmds) >= 2:
+        out["command_change_rms"] = _rms(
+            [
+                parsed.linear_cmds[i] - parsed.linear_cmds[i - 1]
+                for i in range(1, len(parsed.linear_cmds))
+            ]
+        )
+    # Prefer the angular command; fall back to heading deltas when commands are absent.
+    signal = parsed.angular_cmds if len(parsed.angular_cmds) >= 2 else None
+    if signal is None and len(parsed.headings) >= 3:
+        signal = [
+            parsed.headings[i] - parsed.headings[i - 1] for i in range(1, len(parsed.headings))
+        ]
+    if signal is not None and len(signal) >= 2:
+        signs = [1 if v > 1e-6 else (-1 if v < -1e-6 else 0) for v in signal]
+        nonzero = [s for s in signs if s != 0]
+        changes = sum(1 for i in range(1, len(nonzero)) if nonzero[i] != nonzero[i - 1])
+        out["oscillation_rate"] = float(changes / max(len(signal) - 1, 1))
+    return out
+
+
+def _interaction_features(parsed: _ParsedWindow) -> dict[str, float | None]:
+    """Relative-speed, pedestrian-speed-change, and stop/yield proxies."""
+    out: dict[str, float | None] = {}
+    if parsed.rel_speeds:
+        out["rel_speed_to_nearest_mean_m_s"] = float(np.mean(parsed.rel_speeds))
+    if len(parsed.ped_speed_series) >= 2:
+        changes = [
+            abs(parsed.ped_speed_series[i][1] - parsed.ped_speed_series[i - 1][1])
+            for i in range(1, len(parsed.ped_speed_series))
+        ]
+        out["ped_speed_change_near_robot_m_s"] = float(np.mean(changes))
+    # Stop/yield proxy: fraction of steps (with a known robot speed) that are slow
+    # while a pedestrian is near. Denominator is steps with a measured robot speed.
+    measured = [(speed, dist) for speed, dist in parsed.step_speed_dist if speed is not None]
+    if measured:
+        near = sum(
+            1
+            for speed, dist in measured
+            if speed < STOP_SPEED_THRESHOLD_M_S
+            and dist is not None
+            and dist < NEAR_PEDESTRIAN_THRESHOLD_M
+        )
+        out["stop_yield_fraction"] = float(near / len(measured))
+    return out
+
+
+def compute_window_features(
+    steps: list[dict[str, Any]],
+) -> tuple[dict[str, float | None], list[str]]:
+    """Compute the feature vector for one window of trace steps.
+
+    Returns a ``(features, missing_features)`` tuple where ``features`` maps every
+    name in :data:`FEATURE_NAMES` to a float or ``None``. Non-derivable features are
+    ``None`` and listed in ``missing_features``; genuine zero measurements stay
+    ``0.0`` and are not treated as missing. ``route_progress_delta_m`` is always
+    ``None`` because route progress is not present in the step trace.
+    """
+    parsed = _ParsedWindow(steps)
+    features: dict[str, float | None] = dict.fromkeys(FEATURE_NAMES)
+    for helper in (
+        _clearance_features,
+        _ttc_features,
+        _robot_speed_features,
+        _command_features,
+        _interaction_features,
+    ):
+        features.update(helper(parsed))
+    missing = [name for name in FEATURE_NAMES if features[name] is None]
+    return features, missing
+
+
+def _resolve_planner_key(row: dict[str, Any]) -> str:
+    """Resolve a planner identifier from the common episode-row fields."""
+    if row.get("planner_key"):
+        return str(row["planner_key"])
+    params = row.get("scenario_params")
+    if isinstance(params, dict) and params.get("algo"):
+        return str(params["algo"])
+    algo_meta = row.get("algorithm_metadata")
+    if isinstance(algo_meta, dict) and algo_meta.get("algorithm"):
+        return str(algo_meta["algorithm"])
+    return "unknown"
+
+
+def _trace_steps(row: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """Return the simulation step-trace list for a row, or ``None`` when absent."""
+    algo_meta = row.get("algorithm_metadata")
+    if not isinstance(algo_meta, dict):
+        return None
+    trace = algo_meta.get("simulation_step_trace")
+    if not isinstance(trace, dict):
+        return None
+    steps = trace.get("steps")
+    if not isinstance(steps, list) or not steps:
+        return None
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def iter_episode_rows(paths: list[str]) -> Any:
+    """Yield ``(source_path, row_index, row)`` for every JSONL row in ``paths``.
+
+    ``row`` is ``None`` for malformed (non-dict / unparseable) lines so the caller can
+    count them as skips.
+    """
+    for path in paths:
+        try:
+            handle = open(path, encoding="utf-8")
+        except OSError:
+            continue
+        with handle:
+            for row_index, raw_line in enumerate(handle):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    yield path, row_index, None
+                    continue
+                yield path, row_index, row if isinstance(row, dict) else None
+
+
+def extract_windows_from_row(
+    source_path: str,
+    row_index: int,
+    row: dict[str, Any],
+    *,
+    window_steps: int,
+    stride_steps: int,
+) -> tuple[list[WindowRecord], str | None]:
+    """Extract window records from one episode row.
+
+    Returns ``(records, skip_reason)``. ``skip_reason`` is a short string when no
+    windows could be produced (for example ``"no_simulation_step_trace"``), else
+    ``None``.
+    """
+    steps = _trace_steps(row)
+    if steps is None:
+        return [], "no_simulation_step_trace"
+    if len(steps) < window_steps:
+        return [], f"trace_too_short(<{window_steps}_steps)"
+
+    scenario_id = str(row.get("scenario_id") or "unknown")
+    planner_key = _resolve_planner_key(row)
+    seed = row.get("seed")
+    episode_id = str(row["episode_id"]) if row.get("episode_id") is not None else None
+    row_status = row.get("status") or row.get("row_status")
+    outcome = row.get("outcome") or row.get("termination_reason") or row_status
+    source_stem = Path(source_path).stem
+
+    records: list[WindowRecord] = []
+    stride = max(1, stride_steps)
+    for window_index, start in enumerate(range(0, len(steps) - window_steps + 1, stride)):
+        window = steps[start : start + window_steps]
+        features, missing = compute_window_features(window)
+        window_id = (
+            f"{source_stem}#r{row_index}#w{window_index}#s{int(window[0].get('step', start))}"
+        )
+        records.append(
+            WindowRecord(
+                window_id=window_id,
+                source_episode_path=source_path,
+                episode_id=episode_id,
+                scenario_id=scenario_id,
+                planner_key=planner_key,
+                seed=seed,
+                t_start_s=_finite(window[0].get("time_s")),
+                t_end_s=_finite(window[-1].get("time_s")),
+                step_start=int(window[0].get("step", start)),
+                step_end=int(window[-1].get("step", start + window_steps - 1)),
+                n_steps=len(window),
+                row_status=str(row_status) if row_status is not None else None,
+                outcome=str(outcome) if outcome is not None else None,
+                feature_schema_version=FEATURE_SCHEMA_VERSION,
+                features=features,
+                missing_features=missing,
+            )
+        )
+    if not records:
+        return [], "no_windows_after_striding"
+    return records, None
+
+
+def _expand_patterns(patterns: list[str]) -> list[str]:
+    """Expand glob patterns (recursive ``**`` supported) into a sorted file list."""
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for pattern in patterns:
+        matches = glob.glob(pattern, recursive=True)
+        if not matches and Path(pattern).is_file():
+            matches = [pattern]
+        for match in sorted(matches):
+            if match not in seen and Path(match).is_file():
+                seen.add(match)
+                resolved.append(match)
+    return resolved
+
+
+def _write_jsonl(path: Path, records: list[WindowRecord]) -> None:
+    """Write window records as one JSON object per line."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record.to_json_dict(), sort_keys=True))
+            handle.write("\n")
+
+
+def _write_csv(path: Path, records: list[WindowRecord]) -> None:
+    """Write a flattened CSV with one row per window (features as columns)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    meta_cols = [
+        "window_id",
+        "source_episode_path",
+        "episode_id",
+        "scenario_id",
+        "planner_key",
+        "seed",
+        "t_start_s",
+        "t_end_s",
+        "step_start",
+        "step_end",
+        "n_steps",
+        "row_status",
+        "outcome",
+        "feature_schema_version",
+    ]
+    columns = meta_cols + list(FEATURE_NAMES) + ["missing_features"]
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(columns)
+        for record in records:
+            payload = record.to_json_dict()
+            meta = [payload[col] for col in meta_cols]
+            feats = [payload["features"][name] for name in FEATURE_NAMES]
+            writer.writerow(meta + feats + [";".join(payload["missing_features"])])
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Return the CLI argument parser for window extraction."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract interaction-trace windows into diagnostic feature vectors from saved "
+            "episode JSONL rows. Offline and read-only; never runs a new campaign."
+        ),
+        epilog=CLAIM_BOUNDARY,
+    )
+    parser.add_argument(
+        "--episode-jsonl",
+        action="append",
+        default=None,
+        metavar="GLOB",
+        required=True,
+        help="Episode JSONL path or glob (recursive ** supported). Repeat to add sources.",
+    )
+    parser.add_argument(
+        "--window-steps",
+        type=int,
+        default=10,
+        help="Number of trace steps per window (default: 10).",
+    )
+    parser.add_argument(
+        "--stride-steps",
+        type=int,
+        default=5,
+        help="Step stride between consecutive windows (default: 5).",
+    )
+    parser.add_argument(
+        "--max-episodes",
+        type=int,
+        default=None,
+        help="Optional cap on the number of episode rows processed.",
+    )
+    parser.add_argument(
+        "--output-jsonl",
+        type=Path,
+        default=Path("output/experiments/behavior_tokens/windows.jsonl"),
+        help="Output JSONL path for window records.",
+    )
+    parser.add_argument(
+        "--output-csv", type=Path, default=None, help="Optional flattened CSV output path."
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns a process exit code."""
+    args = build_arg_parser().parse_args(argv)
+    if args.window_steps <= 0:
+        print("error: --window-steps must be positive", file=sys.stderr)
+        return 2
+
+    paths = _expand_patterns(args.episode_jsonl)
+    if not paths:
+        print(
+            "error: no episode JSONL files matched the given --episode-jsonl patterns "
+            "(offline mode never generates traces)",
+            file=sys.stderr,
+        )
+        return 1
+
+    records: list[WindowRecord] = []
+    skip_reasons: Counter[str] = Counter()
+    processed = 0
+    for source_path, row_index, row in iter_episode_rows(paths):
+        if args.max_episodes is not None and processed >= args.max_episodes:
+            break
+        processed += 1
+        if row is None:
+            skip_reasons["malformed_json_row"] += 1
+            continue
+        row_records, reason = extract_windows_from_row(
+            source_path,
+            row_index,
+            row,
+            window_steps=args.window_steps,
+            stride_steps=args.stride_steps,
+        )
+        if reason is not None:
+            skip_reasons[reason] += 1
+            continue
+        records.extend(row_records)
+
+    _write_jsonl(args.output_jsonl, records)
+    if args.output_csv is not None:
+        _write_csv(args.output_csv, records)
+
+    summary = {
+        "files_scanned": len(paths),
+        "rows_processed": processed,
+        "windows_written": len(records),
+        "skipped_rows": dict(sorted(skip_reasons.items())),
+        "output_jsonl": str(args.output_jsonl),
+        "output_csv": str(args.output_csv) if args.output_csv else None,
+        "feature_schema_version": FEATURE_SCHEMA_VERSION,
+    }
+    print(json.dumps(summary, indent=2))
+    if not records:
+        print(
+            "warning: no windows extracted; check that traces include "
+            "algorithm_metadata.simulation_step_trace.steps",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/behavior_tokens/inspect_token_motifs.py
+++ b/experiments/behavior_tokens/inspect_token_motifs.py
@@ -1,0 +1,389 @@
+"""Summarize behavior-token distributions and surface representative example windows.
+
+Joins the ``windows.jsonl`` (from ``extract_windows.py``) with token assignments
+(from ``quantize_trace_windows.py``) and writes diagnostic artifacts: a per-token
+summary broken down by scenario / planner / outcome / row status, a compact Markdown
+description of frequent tokens with heuristic *candidate* motif labels, and bounded
+example windows per frequent token.
+
+Example::
+
+    uv run python experiments/behavior_tokens/inspect_token_motifs.py \\
+        --windows-jsonl output/experiments/behavior_tokens/windows.jsonl \\
+        --assignments-csv output/experiments/behavior_tokens/token_assignments.csv \\
+        --output-dir output/experiments/behavior_tokens/inspection
+
+Claim boundary: motif labels are manual, heuristic *candidates* for inspection only.
+Token ids are not ground-truth labels and carry no benchmark or safety authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from experiments.behavior_tokens.schemas import (  # noqa: E402
+    CLAIM_BOUNDARY,
+    FEATURE_NAMES,
+    INSPECTION_SCHEMA_VERSION,
+    NEAR_PEDESTRIAN_THRESHOLD_M,
+    STOP_SPEED_THRESHOLD_M_S,
+)
+
+
+def load_windows(path: Path) -> dict[str, dict[str, Any]]:
+    """Load windows JSONL keyed by ``window_id``."""
+    windows: dict[str, dict[str, Any]] = {}
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            if isinstance(record, dict) and record.get("window_id"):
+                windows[str(record["window_id"])] = record
+    return windows
+
+
+def load_assignments(csv_path: Path | None, json_path: Path | None) -> dict[str, int]:
+    """Load ``window_id -> token_id`` from a CSV or JSON assignments file."""
+    if csv_path is not None:
+        assignments: dict[str, int] = {}
+        with open(csv_path, encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            for row in reader:
+                if row.get("window_id") and row.get("token_id") not in (None, ""):
+                    assignments[str(row["window_id"])] = int(float(row["token_id"]))
+        return assignments
+    if json_path is not None:
+        with open(json_path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+        items = payload.get("assignments", payload) if isinstance(payload, dict) else payload
+        return {
+            str(item["window_id"]): int(item["token_id"])
+            for item in items
+            if isinstance(item, dict) and "window_id" in item and "token_id" in item
+        }
+    raise ValueError("either --assignments-csv or --assignments-json must be provided")
+
+
+def _mean_features(windows: list[dict[str, Any]]) -> dict[str, float | None]:
+    """Return the mean of each feature over windows, ignoring null values."""
+    means: dict[str, float | None] = {}
+    for name in FEATURE_NAMES:
+        values = [
+            float(w["features"][name])
+            for w in windows
+            if isinstance(w.get("features"), dict) and _is_number(w["features"].get(name))
+        ]
+        means[name] = float(sum(values) / len(values)) if values else None
+    return means
+
+
+def _is_number(value: Any) -> bool:
+    """Return True when ``value`` is a real number (not bool/None)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def candidate_motif_label(mean_features: dict[str, float | None]) -> str:
+    """Return a heuristic *candidate* motif label from mean feature values.
+
+    Labels are deliberately suffixed ``_candidate`` because token ids are diagnostic,
+    not ground-truth interaction classes. The ordering encodes a rough priority:
+    the most safety-relevant motif that matches wins.
+    """
+
+    def val(name: str) -> float | None:
+        return mean_features.get(name)
+
+    clearance_min = val("clearance_min_m")
+    stop_yield = val("stop_yield_fraction")
+    oscillation = val("oscillation_rate")
+    speed_mean = val("robot_speed_mean_m_s")
+    speed_min = val("robot_speed_min_m_s")
+    recovery = val("near_conflict_recovery_m")
+    ttc_min = val("ttc_proxy_min_s")
+
+    # Deadlock/freeze: sustained near-zero speed while close to a pedestrian.
+    if (
+        speed_mean is not None
+        and speed_mean < STOP_SPEED_THRESHOLD_M_S
+        and clearance_min is not None
+        and clearance_min < NEAR_PEDESTRIAN_THRESHOLD_M
+    ):
+        return "deadlock_or_freeze_candidate"
+    # Yielding: frequently stopping/slowing while a pedestrian is near.
+    if stop_yield is not None and stop_yield >= 0.4:
+        return "yielding_candidate"
+    # Emergency-braking: very low clearance / TTC with a sharp slow-down.
+    if (clearance_min is not None and clearance_min < 0.5) or (
+        ttc_min is not None and ttc_min < 1.0
+    ):
+        return "emergency_braking_or_unsafe_cut_in_candidate"
+    # Oscillatory negotiation: frequent steering sign changes.
+    if oscillation is not None and oscillation >= 0.4:
+        return "oscillatory_negotiation_candidate"
+    # Assertive passing: maintaining speed with recovery after the closest point.
+    if speed_mean is not None and speed_mean >= 1.0 and recovery is not None and recovery > 0.5:
+        return "assertive_passing_candidate"
+    # Low-speed maneuvering near a pedestrian without a full stop.
+    if speed_min is not None and speed_min < STOP_SPEED_THRESHOLD_M_S:
+        return "slow_maneuver_candidate"
+    return "unlabeled_candidate"
+
+
+def build_summary(
+    windows: dict[str, dict[str, Any]], assignments: dict[str, int]
+) -> dict[str, Any]:
+    """Build the per-token summary structure joining windows and assignments."""
+    by_token: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    joined = 0
+    for window_id, token_id in assignments.items():
+        window = windows.get(window_id)
+        if window is None:
+            continue
+        by_token[token_id].append(window)
+        joined += 1
+
+    tokens: list[dict[str, Any]] = []
+    for token_id in sorted(by_token):
+        members = by_token[token_id]
+        mean_features = _mean_features(members)
+        tokens.append(
+            {
+                "token_id": token_id,
+                "count": len(members),
+                "candidate_motif_label": candidate_motif_label(mean_features),
+                "by_scenario": dict(Counter(str(w.get("scenario_id")) for w in members)),
+                "by_planner": dict(Counter(str(w.get("planner_key")) for w in members)),
+                "by_outcome": dict(Counter(str(w.get("outcome")) for w in members)),
+                "by_row_status": dict(Counter(str(w.get("row_status")) for w in members)),
+                "mean_features": mean_features,
+            }
+        )
+    return {
+        "inspection_schema_version": INSPECTION_SCHEMA_VERSION,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "windows_total": len(windows),
+        "assignments_total": len(assignments),
+        "windows_joined": joined,
+        "num_tokens": len(tokens),
+        "tokens": tokens,
+    }
+
+
+def select_examples(
+    windows: dict[str, dict[str, Any]],
+    assignments: dict[str, int],
+    token_id: int,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Return up to ``limit`` representative windows for a token (stable order)."""
+    members = [
+        windows[wid]
+        for wid, tid in sorted(assignments.items())
+        if tid == token_id and wid in windows
+    ]
+    return members[:limit]
+
+
+def _render_frequent_tokens_md(summary: dict[str, Any], min_count: int) -> str:
+    """Render a compact Markdown description of frequent tokens."""
+    lines = [
+        "# Frequent behavior-token motifs (diagnostic candidates)",
+        "",
+        f"> {CLAIM_BOUNDARY}",
+        "",
+        f"Tokens with count >= {min_count} are shown. Motif labels are heuristic "
+        "*candidates*, not validated interaction classes.",
+        "",
+    ]
+    frequent = [t for t in summary["tokens"] if t["count"] >= min_count]
+    if not frequent:
+        lines.append("_No token met the frequency threshold._")
+        return "\n".join(lines) + "\n"
+    for token in sorted(frequent, key=lambda t: t["count"], reverse=True):
+        lines.append(f"## Token {token['token_id']} — {token['candidate_motif_label']}")
+        lines.append("")
+        lines.append(f"- Count: {token['count']}")
+        top_scen = sorted(token["by_scenario"].items(), key=lambda kv: kv[1], reverse=True)[:3]
+        top_outcome = sorted(token["by_outcome"].items(), key=lambda kv: kv[1], reverse=True)[:3]
+        lines.append(f"- Top scenarios: {', '.join(f'{k} ({v})' for k, v in top_scen)}")
+        lines.append(f"- Top outcomes: {', '.join(f'{k} ({v})' for k, v in top_outcome)}")
+        key_feats = [
+            "clearance_min_m",
+            "robot_speed_mean_m_s",
+            "stop_yield_fraction",
+            "oscillation_rate",
+            "ttc_proxy_min_s",
+        ]
+        feat_bits = []
+        for name in key_feats:
+            value = token["mean_features"].get(name)
+            feat_bits.append(f"{name}={value:.3f}" if _is_number(value) else f"{name}=null")
+        lines.append(f"- Mean features: {', '.join(feat_bits)}")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def write_inspection_outputs(
+    output_dir: Path,
+    windows: dict[str, dict[str, Any]],
+    assignments: dict[str, int],
+    summary: dict[str, Any],
+    *,
+    min_token_count: int,
+    examples_per_token: int,
+) -> dict[str, Any]:
+    """Write summary, motif Markdown, and per-token example files. Returns a manifest."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    examples_dir = output_dir / "examples"
+    examples_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(output_dir / "token_summary.json", "w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+
+    with open(output_dir / "token_summary.csv", "w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [
+                "token_id",
+                "count",
+                "candidate_motif_label",
+                "n_scenarios",
+                "n_planners",
+                "n_outcomes",
+            ]
+        )
+        for token in summary["tokens"]:
+            writer.writerow(
+                [
+                    token["token_id"],
+                    token["count"],
+                    token["candidate_motif_label"],
+                    len(token["by_scenario"]),
+                    len(token["by_planner"]),
+                    len(token["by_outcome"]),
+                ]
+            )
+
+    with open(output_dir / "frequent_tokens.md", "w", encoding="utf-8") as handle:
+        handle.write(_render_frequent_tokens_md(summary, min_token_count))
+
+    example_files: list[str] = []
+    for token in summary["tokens"]:
+        if token["count"] < min_token_count:
+            continue
+        examples = select_examples(windows, assignments, token["token_id"], examples_per_token)
+        example_path = examples_dir / f"token_{token['token_id']}_examples.jsonl"
+        with open(example_path, "w", encoding="utf-8") as handle:
+            for window in examples:
+                handle.write(json.dumps(window, sort_keys=True))
+                handle.write("\n")
+        example_files.append(str(example_path))
+
+    return {
+        "token_summary_json": str(output_dir / "token_summary.json"),
+        "token_summary_csv": str(output_dir / "token_summary.csv"),
+        "frequent_tokens_md": str(output_dir / "frequent_tokens.md"),
+        "example_files": example_files,
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Return the CLI argument parser for motif inspection."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize behavior-token distributions and export representative example "
+            "windows for manual inspection. Offline and read-only."
+        ),
+        epilog=CLAIM_BOUNDARY,
+    )
+    parser.add_argument(
+        "--windows-jsonl",
+        type=Path,
+        required=True,
+        help="Input windows JSONL from extract_windows.py.",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--assignments-csv",
+        type=Path,
+        default=None,
+        help="Token assignments CSV (window_id, token_id).",
+    )
+    group.add_argument(
+        "--assignments-json",
+        type=Path,
+        default=None,
+        help="Token assignments JSON (metadata + assignments).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("output/experiments/behavior_tokens/inspection"),
+        help="Directory for inspection artifacts.",
+    )
+    parser.add_argument(
+        "--min-token-count",
+        type=int,
+        default=5,
+        help="Minimum count for a token to be 'frequent' (default: 5).",
+    )
+    parser.add_argument(
+        "--examples-per-token",
+        type=int,
+        default=10,
+        help="Representative example windows per frequent token (default: 10).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns a process exit code."""
+    args = build_arg_parser().parse_args(argv)
+    if not args.windows_jsonl.is_file():
+        print(f"error: windows JSONL not found: {args.windows_jsonl}", file=sys.stderr)
+        return 1
+    assignments_path = args.assignments_csv or args.assignments_json
+    if assignments_path is None or not Path(assignments_path).is_file():
+        print(f"error: assignments file not found: {assignments_path}", file=sys.stderr)
+        return 1
+
+    windows = load_windows(args.windows_jsonl)
+    assignments = load_assignments(args.assignments_csv, args.assignments_json)
+    summary = build_summary(windows, assignments)
+    manifest = write_inspection_outputs(
+        args.output_dir,
+        windows,
+        assignments,
+        summary,
+        min_token_count=args.min_token_count,
+        examples_per_token=args.examples_per_token,
+    )
+    print(
+        json.dumps(
+            {
+                "windows_total": summary["windows_total"],
+                "assignments_total": summary["assignments_total"],
+                "windows_joined": summary["windows_joined"],
+                "num_tokens": summary["num_tokens"],
+                **manifest,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/behavior_tokens/quantize_trace_windows.py
+++ b/experiments/behavior_tokens/quantize_trace_windows.py
@@ -1,0 +1,358 @@
+"""Deterministic quantization of trace-window features into discrete behavior tokens.
+
+Reads the ``windows.jsonl`` produced by ``extract_windows.py``, standardizes the
+subset of features that are finite across enough windows, and assigns each valid
+window a discrete token id via k-means (scikit-learn when available, otherwise a
+NumPy-only deterministic fallback). All randomness is seeded so repeated runs on the
+same input yield identical assignments.
+
+Example::
+
+    uv run python experiments/behavior_tokens/quantize_trace_windows.py \\
+        --windows-jsonl output/experiments/behavior_tokens/windows.jsonl \\
+        --num-tokens 12 \\
+        --output-json output/experiments/behavior_tokens/token_assignments.json \\
+        --output-csv output/experiments/behavior_tokens/token_assignments.csv
+
+Claim boundary: token ids are exploratory descriptors, not validated labels or
+benchmark evidence. A large transformer/model dependency is intentionally avoided.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from experiments.behavior_tokens.schemas import (  # noqa: E402
+    CLAIM_BOUNDARY,
+    FEATURE_NAMES,
+    QUANTIZER_SCHEMA_VERSION,
+)
+
+
+def load_windows(path: Path) -> list[dict[str, Any]]:
+    """Load window records from a JSONL file."""
+    windows: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            if isinstance(record, dict):
+                windows.append(record)
+    return windows
+
+
+def select_feature_columns(windows: list[dict[str, Any]], min_finite_fraction: float) -> list[str]:
+    """Return feature names whose finite-value fraction meets ``min_finite_fraction``.
+
+    Selecting columns by finite fraction (rather than imputing) keeps the token space
+    grounded in genuinely measured quantities. Windows that lack any selected feature
+    are later excluded as invalid rather than back-filled with fabricated values.
+    """
+    if not windows:
+        return []
+    selected: list[str] = []
+    for name in FEATURE_NAMES:
+        finite = sum(
+            1
+            for w in windows
+            if isinstance(w.get("features"), dict) and _is_finite(w["features"].get(name))
+        )
+        if finite / len(windows) >= min_finite_fraction:
+            selected.append(name)
+    return selected
+
+
+def _is_finite(value: Any) -> bool:
+    """Return True when ``value`` is a finite number."""
+    if isinstance(value, bool) or value is None:
+        return False
+    try:
+        return np.isfinite(float(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def build_feature_matrix(
+    windows: list[dict[str, Any]], columns: list[str]
+) -> tuple[np.ndarray, list[dict[str, Any]], int]:
+    """Return the feature matrix for valid windows plus the excluded count.
+
+    A window is *valid* when all selected ``columns`` are finite for it. Returns
+    ``(matrix, valid_windows, excluded_count)``.
+    """
+    rows: list[list[float]] = []
+    valid: list[dict[str, Any]] = []
+    excluded = 0
+    for window in windows:
+        feats = window.get("features")
+        if not isinstance(feats, dict) or not all(_is_finite(feats.get(c)) for c in columns):
+            excluded += 1
+            continue
+        rows.append([float(feats[c]) for c in columns])
+        valid.append(window)
+    matrix = np.asarray(rows, dtype=float) if rows else np.empty((0, len(columns)), dtype=float)
+    return matrix, valid, excluded
+
+
+def standardize(matrix: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Z-score standardize columns; return ``(standardized, mean, std)``.
+
+    Columns with zero variance use a std of 1.0 so they contribute no spurious scale.
+    """
+    mean = matrix.mean(axis=0)
+    std = matrix.std(axis=0)
+    safe_std = np.where(std < 1e-12, 1.0, std)
+    return (matrix - mean) / safe_std, mean, safe_std
+
+
+def _numpy_kmeans(
+    data: np.ndarray, num_tokens: int, seed: int, max_iter: int = 100
+) -> tuple[np.ndarray, np.ndarray]:
+    """Deterministic NumPy-only k-means (k-means++ style seeded init).
+
+    Returns ``(labels, centers)``. Used when scikit-learn is unavailable.
+    """
+    rng = np.random.default_rng(seed)
+    n = data.shape[0]
+    k = min(num_tokens, n)
+    # k-means++ initialization for stable, spread-out centers.
+    centers = [data[rng.integers(n)]]
+    for _ in range(1, k):
+        dist_sq = np.min([np.sum((data - c) ** 2, axis=1) for c in centers], axis=0)
+        total = dist_sq.sum()
+        if total <= 0:
+            centers.append(data[rng.integers(n)])
+            continue
+        probs = dist_sq / total
+        centers.append(data[rng.choice(n, p=probs)])
+    centers_arr = np.asarray(centers, dtype=float)
+    labels = np.zeros(n, dtype=int)
+    for _ in range(max_iter):
+        distances = np.linalg.norm(data[:, None, :] - centers_arr[None, :, :], axis=2)
+        new_labels = distances.argmin(axis=1)
+        if np.array_equal(new_labels, labels) and _ > 0:
+            labels = new_labels
+            break
+        labels = new_labels
+        for j in range(centers_arr.shape[0]):
+            members = data[labels == j]
+            if members.size:
+                centers_arr[j] = members.mean(axis=0)
+    return labels, centers_arr
+
+
+def _canonicalize_labels(labels: np.ndarray, centers: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Relabel clusters deterministically by ordering centers lexicographically.
+
+    scikit-learn's KMeans (via OpenMP) may permute cluster *label integers* between
+    otherwise-identical runs on degenerate data, even with a fixed ``random_state``.
+    Ordering clusters by their (rounded) center vectors makes token ids stable and
+    library-independent, so repeated runs and the NumPy fallback agree.
+    """
+    order = sorted(range(centers.shape[0]), key=lambda i: tuple(np.round(centers[i], 6).tolist()))
+    remap = {old: new for new, old in enumerate(order)}
+    new_labels = np.array([remap[int(label)] for label in labels], dtype=int)
+    return new_labels, centers[order]
+
+
+def quantize(data: np.ndarray, num_tokens: int, seed: int) -> tuple[np.ndarray, np.ndarray, str]:
+    """Cluster standardized ``data`` into ``num_tokens`` tokens.
+
+    Returns ``(labels, centers, algorithm)`` with deterministically canonicalized
+    token ids. Prefers scikit-learn KMeans; falls back to a deterministic NumPy
+    implementation when scikit-learn is not importable.
+    """
+    effective_k = min(num_tokens, data.shape[0])
+    try:
+        from sklearn.cluster import KMeans
+
+        model = KMeans(n_clusters=effective_k, random_state=seed, n_init=10)
+        labels = model.fit_predict(data)
+        canon_labels, canon_centers = _canonicalize_labels(
+            labels.astype(int), model.cluster_centers_
+        )
+        return canon_labels, canon_centers, "sklearn.KMeans"
+    except ImportError:
+        labels, centers = _numpy_kmeans(data, effective_k, seed)
+        canon_labels, canon_centers = _canonicalize_labels(labels, centers)
+        return canon_labels, canon_centers, "numpy_kmeans_fallback"
+
+
+def _write_outputs(
+    output_json: Path | None,
+    output_csv: Path | None,
+    assignments: list[dict[str, Any]],
+    metadata: dict[str, Any],
+) -> None:
+    """Write token assignments to JSON and/or CSV."""
+    if output_json is not None:
+        output_json.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_json, "w", encoding="utf-8") as handle:
+            json.dump(
+                {"metadata": metadata, "assignments": assignments},
+                handle,
+                indent=2,
+                sort_keys=True,
+            )
+    if output_csv is not None:
+        output_csv.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_csv, "w", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(["window_id", "token_id"])
+            for item in assignments:
+                writer.writerow([item["window_id"], item["token_id"]])
+
+
+def run_quantization(
+    windows: list[dict[str, Any]],
+    *,
+    num_tokens: int,
+    seed: int,
+    min_finite_fraction: float,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Quantize windows and return ``(assignments, metadata)``.
+
+    Fails closed by raising ``ValueError`` when no finite feature columns or no valid
+    windows remain, rather than emitting empty or fabricated token assignments.
+    """
+    columns = select_feature_columns(windows, min_finite_fraction)
+    if not columns:
+        raise ValueError(
+            "no feature columns meet the finite-fraction threshold; cannot quantize "
+            "(reduce --min-finite-fraction or extract richer traces)"
+        )
+    matrix, valid_windows, excluded = build_feature_matrix(windows, columns)
+    if matrix.shape[0] == 0:
+        raise ValueError("no windows have all selected features finite; cannot assign tokens")
+    standardized, mean, std = standardize(matrix)
+    labels, centers, algorithm = quantize(standardized, num_tokens, seed)
+
+    assignments = [
+        {"window_id": window["window_id"], "token_id": int(label)}
+        for window, label in zip(valid_windows, labels, strict=True)
+    ]
+    metadata = {
+        "quantizer_schema_version": QUANTIZER_SCHEMA_VERSION,
+        "algorithm": algorithm,
+        "seed": seed,
+        "num_tokens_requested": num_tokens,
+        "num_tokens_effective": int(centers.shape[0]),
+        "feature_columns": columns,
+        "min_finite_fraction": min_finite_fraction,
+        "normalization": {
+            "mean": {col: float(mean[i]) for i, col in enumerate(columns)},
+            "std": {col: float(std[i]) for i, col in enumerate(columns)},
+        },
+        "token_centers_standardized": {
+            str(token): {col: float(centers[token, i]) for i, col in enumerate(columns)}
+            for token in range(centers.shape[0])
+        },
+        "windows_total": len(windows),
+        "windows_valid": len(valid_windows),
+        "windows_excluded_missing_features": excluded,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    return assignments, metadata
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Return the CLI argument parser for token quantization."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Quantize trace-window feature vectors into deterministic discrete behavior "
+            "tokens. Offline and read-only; no transformer/model dependency."
+        ),
+        epilog=CLAIM_BOUNDARY,
+    )
+    parser.add_argument(
+        "--windows-jsonl",
+        type=Path,
+        required=True,
+        help="Input windows JSONL from extract_windows.py.",
+    )
+    parser.add_argument(
+        "--num-tokens", type=int, default=12, help="Target discrete vocabulary size (default: 12)."
+    )
+    parser.add_argument(
+        "--seed", type=int, default=0, help="Random seed for deterministic clustering (default: 0)."
+    )
+    parser.add_argument(
+        "--min-finite-fraction",
+        type=float,
+        default=0.9,
+        help="Minimum finite fraction for a feature column to be used (default: 0.9).",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("output/experiments/behavior_tokens/token_assignments.json"),
+        help="Output JSON path (assignments + metadata).",
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=Path,
+        default=None,
+        help="Optional CSV output path (window_id, token_id).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns a process exit code."""
+    args = build_arg_parser().parse_args(argv)
+    if args.num_tokens <= 0:
+        print("error: --num-tokens must be positive", file=sys.stderr)
+        return 2
+    if not args.windows_jsonl.is_file():
+        print(f"error: windows JSONL not found: {args.windows_jsonl}", file=sys.stderr)
+        return 1
+
+    windows = load_windows(args.windows_jsonl)
+    if not windows:
+        print("error: no window records in input JSONL", file=sys.stderr)
+        return 1
+    try:
+        assignments, metadata = run_quantization(
+            windows,
+            num_tokens=args.num_tokens,
+            seed=args.seed,
+            min_finite_fraction=args.min_finite_fraction,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    _write_outputs(args.output_json, args.output_csv, assignments, metadata)
+    print(
+        json.dumps(
+            {
+                "windows_total": metadata["windows_total"],
+                "windows_valid": metadata["windows_valid"],
+                "windows_excluded_missing_features": metadata["windows_excluded_missing_features"],
+                "num_tokens_effective": metadata["num_tokens_effective"],
+                "algorithm": metadata["algorithm"],
+                "feature_columns": metadata["feature_columns"],
+                "output_json": str(args.output_json) if args.output_json else None,
+                "output_csv": str(args.output_csv) if args.output_csv else None,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/behavior_tokens/schemas.py
+++ b/experiments/behavior_tokens/schemas.py
@@ -1,0 +1,139 @@
+"""Shared schema constants and dataclasses for behavior-token diagnostics.
+
+This module is intentionally dependency-light (standard library only) so it can be
+imported by the offline extraction, quantization, and inspection scripts as well as
+by tests. It defines the stable feature vocabulary and schema-version strings that
+downstream artifacts embed for provenance.
+
+Claim boundary: everything here supports *diagnostic* tooling only. Token ids and
+features are exploratory descriptors, not validated safety metrics or planner-ranking
+evidence. See ``README.md`` in this directory.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# Schema versions embedded in generated artifacts so consumers can detect drift.
+FEATURE_SCHEMA_VERSION = "behavior-token-features.v1"
+WINDOW_SCHEMA_VERSION = "behavior-token-window.v1"
+QUANTIZER_SCHEMA_VERSION = "behavior-token-quantizer.v1"
+INSPECTION_SCHEMA_VERSION = "behavior-token-inspection.v1"
+
+# One-line claim boundary reused across artifacts and CLI ``--help`` epilogues.
+CLAIM_BOUNDARY = (
+    "Experimental, low-priority diagnostic tooling. Behavior tokens are exploratory "
+    "descriptors of saved interaction traces; they are NOT validated safety metrics, "
+    "benchmark evidence, or paper/dissertation claim support. No safety decision may "
+    "depend on these tokens."
+)
+
+# Ordered, stable feature vocabulary. The order is part of the schema: quantizer
+# normalization statistics and token centers are recorded against this ordering.
+# ``None`` (JSON null) marks a feature that could not be derived for a window; such
+# features are also listed in the window's ``missing_features``. Genuinely
+# zero-valued measurements (for example, an all-straight command sequence giving an
+# oscillation rate of 0.0) are recorded as ``0.0`` and are NOT treated as missing.
+FEATURE_NAMES: tuple[str, ...] = (
+    "clearance_min_m",
+    "clearance_mean_m",
+    "clearance_slope_m_per_s",
+    "rel_speed_to_nearest_mean_m_s",
+    "ttc_proxy_min_s",
+    "ttc_proxy_slope_s_per_s",
+    "robot_speed_mean_m_s",
+    "robot_speed_min_m_s",
+    "robot_speed_max_m_s",
+    "robot_accel_rms_m_s2",
+    "command_change_rms",
+    "ped_speed_change_near_robot_m_s",
+    "route_progress_delta_m",
+    "stop_yield_fraction",
+    "oscillation_rate",
+    "near_conflict_recovery_m",
+)
+
+# Human-facing descriptions used in motif reports and the README feature table.
+FEATURE_DESCRIPTIONS: dict[str, str] = {
+    "clearance_min_m": "Minimum robot-to-nearest-pedestrian distance over the window (metres).",
+    "clearance_mean_m": "Mean robot-to-nearest-pedestrian distance over the window (metres).",
+    "clearance_slope_m_per_s": "Linear-fit slope of nearest-pedestrian distance vs time (m/s).",
+    "rel_speed_to_nearest_mean_m_s": "Mean relative speed to the nearest pedestrian (m/s); "
+    "requires pedestrian velocities.",
+    "ttc_proxy_min_s": "Minimum time-to-contact proxy from the closing distance series (s).",
+    "ttc_proxy_slope_s_per_s": "Linear-fit slope of the time-to-contact proxy vs time.",
+    "robot_speed_mean_m_s": "Mean robot speed over the window (m/s).",
+    "robot_speed_min_m_s": "Minimum robot speed over the window (m/s).",
+    "robot_speed_max_m_s": "Maximum robot speed over the window (m/s).",
+    "robot_accel_rms_m_s2": "RMS of robot speed change per second (acceleration proxy, m/s^2).",
+    "command_change_rms": "RMS step-to-step change in the commanded linear velocity.",
+    "ped_speed_change_near_robot_m_s": "Mean absolute nearest-pedestrian speed change while near "
+    "the robot (m/s); requires pedestrian velocities.",
+    "route_progress_delta_m": "Route progress change over the window; null when not present in "
+    "the trace.",
+    "stop_yield_fraction": "Fraction of steps with low robot speed while a pedestrian is near "
+    "(stop/yield proxy).",
+    "oscillation_rate": "Rate of angular-command (or heading) sign changes per step "
+    "(negotiation/oscillation proxy).",
+    "near_conflict_recovery_m": "Clearance recovered after the minimum-clearance step (m); null "
+    "when the minimum is at the window end.",
+}
+
+# Diagnostic thresholds (documented so token labels remain auditable).
+STOP_SPEED_THRESHOLD_M_S = 0.15
+NEAR_PEDESTRIAN_THRESHOLD_M = 2.0
+
+
+@dataclass
+class WindowRecord:
+    """One trajectory window with stable metadata plus its feature vector.
+
+    Attributes mirror the JSONL row layout written by ``extract_windows.py``.
+    ``features`` maps every name in :data:`FEATURE_NAMES` to a float or ``None``.
+    ``missing_features`` lists the names whose value is ``None`` (not derivable),
+    which is distinct from a genuine zero measurement.
+    """
+
+    window_id: str
+    source_episode_path: str
+    episode_id: str | None
+    scenario_id: str
+    planner_key: str
+    seed: Any
+    t_start_s: float | None
+    t_end_s: float | None
+    step_start: int
+    step_end: int
+    n_steps: int
+    row_status: str | None
+    outcome: str | None
+    feature_schema_version: str
+    features: dict[str, float | None]
+    missing_features: list[str] = field(default_factory=list)
+
+    def to_json_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dict for one ``windows.jsonl`` row."""
+        return {
+            "window_id": self.window_id,
+            "source_episode_path": self.source_episode_path,
+            "episode_id": self.episode_id,
+            "scenario_id": self.scenario_id,
+            "planner_key": self.planner_key,
+            "seed": self.seed,
+            "t_start_s": self.t_start_s,
+            "t_end_s": self.t_end_s,
+            "step_start": self.step_start,
+            "step_end": self.step_end,
+            "n_steps": self.n_steps,
+            "row_status": self.row_status,
+            "outcome": self.outcome,
+            "feature_schema_version": self.feature_schema_version,
+            "features": {name: self.features.get(name) for name in FEATURE_NAMES},
+            "missing_features": list(self.missing_features),
+        }
+
+
+def feature_names() -> list[str]:
+    """Return the ordered feature vocabulary as a fresh list."""
+    return list(FEATURE_NAMES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,6 +348,8 @@ max-statements = 60
 ]
 # One-off scripts / notebook exports: allow prints, local imports, optional deps.
 "scripts/**/*.py" = ["T201", "PLC0415", "TC001", "TC002", "D417", "DOC201"]
+# Experimental, offline CLI prototypes (issue #4627): same allowances as one-off scripts.
+"experiments/**/*.py" = ["T201", "PLC0415", "TC001", "TC002", "D417", "DOC201"]
 # Existing broad script exception handlers are ratcheted by
 # scripts/validation/check_broad_exceptions.py; keep BLE001 scoped current files.
 "scripts/analysis/amv_timeout_trace_analyzer.py" = ["BLE001"]

--- a/tests/experiments/test_behavior_tokens.py
+++ b/tests/experiments/test_behavior_tokens.py
@@ -1,0 +1,234 @@
+"""Tests for the offline behavior-token diagnostics prototype (issue #4627).
+
+These tests use synthetic in-memory traces only — they never run a simulation
+campaign. They exercise the documented contracts of the ``experiments.behavior_tokens``
+namespace: window extraction, missing-feature discipline, no-trace skipping, quantizer
+determinism, one-token-per-valid-window, bounded example selection, and the
+experimental claim boundary.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# The ``experiments`` namespace resolves to whichever checkout is first on sys.path.
+# From a linked worktree the editable install points at the main checkout, so pin the
+# worktree root ahead of it to load the code under test in this worktree.
+_WORKTREE_ROOT = Path(__file__).resolve().parents[2]
+if str(_WORKTREE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE_ROOT))
+
+from experiments.behavior_tokens import (  # noqa: E402
+    extract_windows,
+    inspect_token_motifs,
+    quantize_trace_windows,
+    schemas,
+)
+
+_BEHAVIOR_TOKENS_DIR = _WORKTREE_ROOT / "experiments" / "behavior_tokens"
+
+
+def _step(step_idx: int, robot_pos, ped_pos, *, ped_vel=None, linear=0.5, angular=0.0):
+    """Build one synthetic simulation-step-trace step dict."""
+    ped: dict = {"id": 1, "position": [float(ped_pos[0]), float(ped_pos[1])]}
+    if ped_vel is not None:
+        ped["velocity"] = [float(ped_vel[0]), float(ped_vel[1])]
+    return {
+        "step": step_idx,
+        "time_s": round((step_idx + 1) * 0.1, 3),
+        "robot": {
+            "position": [float(robot_pos[0]), float(robot_pos[1])],
+            "heading": 0.0,
+            "velocity": [float(linear), 0.0],
+        },
+        "pedestrians": [ped],
+        "planner": {"selected_action": {"linear_velocity": linear, "angular_velocity": angular}},
+    }
+
+
+def _episode_row(
+    n_steps=20,
+    *,
+    ped_vel=None,
+    scenario_id="s_synth",
+    planner="goal",
+    outcome="success",
+    seed=7,
+    angular_pattern=None,
+):
+    """Build a synthetic episode JSONL row carrying a simulation step trace."""
+    steps = []
+    for i in range(n_steps):
+        robot_pos = (float(i) * 0.2, 0.0)
+        ped_pos = (5.0 - i * 0.15, 0.3)  # pedestrian slowly approaching
+        angular = 0.0 if angular_pattern is None else angular_pattern[i % len(angular_pattern)]
+        steps.append(_step(i, robot_pos, ped_pos, ped_vel=ped_vel, angular=angular))
+    return {
+        "scenario_id": scenario_id,
+        "seed": seed,
+        "status": outcome,
+        "outcome": outcome,
+        "scenario_params": {"algo": planner},
+        "algorithm_metadata": {
+            "algorithm": planner,
+            "simulation_step_trace": {"schema_version": "simulation-step-trace.v1", "steps": steps},
+        },
+    }
+
+
+def test_extract_windows_expected_count():
+    """A 20-step trace with window=10 stride=5 yields exactly 3 windows."""
+    row = _episode_row(n_steps=20)
+    records, reason = extract_windows.extract_windows_from_row(
+        "output/run/episodes.jsonl", 0, row, window_steps=10, stride_steps=5
+    )
+    assert reason is None
+    assert len(records) == 3
+    # Metadata is carried through onto every window.
+    for record in records:
+        assert record.scenario_id == "s_synth"
+        assert record.planner_key == "goal"
+        assert record.seed == 7
+        assert record.n_steps == 10
+        assert record.feature_schema_version == schemas.FEATURE_SCHEMA_VERSION
+        assert set(record.features) == set(schemas.FEATURE_NAMES)
+
+
+def test_missing_optional_fields_are_null_not_zero():
+    """Pedestrian-velocity features must be null (not fabricated zeros) when absent."""
+    row = _episode_row(n_steps=12, ped_vel=None)
+    records, reason = extract_windows.extract_windows_from_row(
+        "output/run/episodes.jsonl", 0, row, window_steps=10, stride_steps=5
+    )
+    assert reason is None
+    record = records[0]
+    # Features that need pedestrian velocities cannot be derived -> null + missing.
+    assert record.features["rel_speed_to_nearest_mean_m_s"] is None
+    assert record.features["ped_speed_change_near_robot_m_s"] is None
+    assert "rel_speed_to_nearest_mean_m_s" in record.missing_features
+    # route progress is never present in the step trace -> always null.
+    assert record.features["route_progress_delta_m"] is None
+    # But robot-speed features ARE derivable and must not be null.
+    assert isinstance(record.features["robot_speed_mean_m_s"], float)
+    # A genuine zero (straight commands) is 0.0 and NOT treated as missing.
+    assert record.features["oscillation_rate"] == 0.0
+    assert "oscillation_rate" not in record.missing_features
+
+
+def test_no_trace_row_skipped_with_reason():
+    """Rows without a simulation step trace are skipped with an explicit reason."""
+    records, reason = extract_windows.extract_windows_from_row(
+        "output/run/episodes.jsonl", 0, {"scenario_id": "x"}, window_steps=10, stride_steps=5
+    )
+    assert records == []
+    assert reason == "no_simulation_step_trace"
+
+    # A trace shorter than the window is also skipped with a distinct reason.
+    short = _episode_row(n_steps=4)
+    records2, reason2 = extract_windows.extract_windows_from_row(
+        "output/run/episodes.jsonl", 0, short, window_steps=10, stride_steps=5
+    )
+    assert records2 == []
+    assert reason2.startswith("trace_too_short")
+
+
+def _synthetic_windows(count=15):
+    """Build a spread of window dicts (via the real extractor) for quantization tests."""
+    windows = []
+    for r in range(count):
+        # Vary pedestrian approach speed and command angle so features differ per row.
+        angular = [0.0, 0.1 * (r % 3)]
+        row = _episode_row(
+            n_steps=15,
+            ped_vel=(-0.1 - 0.02 * r, 0.0),
+            scenario_id=f"s{r % 3}",
+            planner=f"p{r % 2}",
+            outcome="collision" if r % 4 == 0 else "success",
+            angular_pattern=angular,
+        )
+        records, _ = extract_windows.extract_windows_from_row(
+            f"output/run/ep{r}.jsonl", r, row, window_steps=10, stride_steps=5
+        )
+        windows.extend(record.to_json_dict() for record in records)
+    return windows
+
+
+def test_quantizer_is_deterministic():
+    """Repeated quantization on identical input yields identical token assignments."""
+    windows = _synthetic_windows()
+    first, meta_first = quantize_trace_windows.run_quantization(
+        windows, num_tokens=4, seed=0, min_finite_fraction=0.9
+    )
+    second, meta_second = quantize_trace_windows.run_quantization(
+        windows, num_tokens=4, seed=0, min_finite_fraction=0.9
+    )
+    assert [a["token_id"] for a in first] == [a["token_id"] for a in second]
+    assert meta_first["feature_columns"] == meta_second["feature_columns"]
+    assert meta_first["quantizer_schema_version"] == schemas.QUANTIZER_SCHEMA_VERSION
+
+
+def test_one_token_per_valid_window():
+    """Every valid window receives exactly one integer token id."""
+    windows = _synthetic_windows()
+    assignments, metadata = quantize_trace_windows.run_quantization(
+        windows, num_tokens=4, seed=0, min_finite_fraction=0.9
+    )
+    assert len(assignments) == metadata["windows_valid"]
+    window_ids = {w["window_id"] for w in windows}
+    for item in assignments:
+        assert item["window_id"] in window_ids
+        assert isinstance(item["token_id"], int)
+    # Each assigned window id is unique.
+    assert len({a["window_id"] for a in assignments}) == len(assignments)
+
+
+def test_inspection_selects_bounded_examples(tmp_path):
+    """Motif inspection emits at most N representative examples per frequent token."""
+    windows_list = _synthetic_windows()
+    assignments, _ = quantize_trace_windows.run_quantization(
+        windows_list, num_tokens=3, seed=0, min_finite_fraction=0.9
+    )
+    windows_by_id = {w["window_id"]: w for w in windows_list}
+    assign_map = {a["window_id"]: a["token_id"] for a in assignments}
+    summary = inspect_token_motifs.build_summary(windows_by_id, assign_map)
+    assert summary["assignments_total"] == len(assignments)
+    assert summary["windows_joined"] == len(assignments)
+
+    manifest = inspect_token_motifs.write_inspection_outputs(
+        tmp_path / "inspection",
+        windows_by_id,
+        assign_map,
+        summary,
+        min_token_count=1,
+        examples_per_token=3,
+    )
+    assert Path(manifest["token_summary_json"]).is_file()
+    assert Path(manifest["frequent_tokens_md"]).is_file()
+    for example_file in manifest["example_files"]:
+        lines = [line for line in Path(example_file).read_text().splitlines() if line.strip()]
+        assert len(lines) <= 3
+    # Every token carries a heuristic candidate motif label.
+    for token in summary["tokens"]:
+        assert token["candidate_motif_label"].endswith("_candidate")
+
+
+def test_readme_and_metadata_carry_claim_boundary():
+    """README and generated metadata must record the experimental claim boundary."""
+    readme = (_BEHAVIOR_TOKENS_DIR / "README.md").read_text().lower()
+    assert "experimental" in readme
+    assert "not" in readme and "dissertation" in readme
+    assert "no safety decision may depend" in readme
+
+    windows = _synthetic_windows()
+    _, metadata = quantize_trace_windows.run_quantization(
+        windows, num_tokens=3, seed=0, min_finite_fraction=0.9
+    )
+    assert "claim_boundary" in metadata
+    assert "diagnostic" in metadata["claim_boundary"].lower()
+
+    summary = inspect_token_motifs.build_summary(
+        {w["window_id"]: w for w in windows},
+        {w["window_id"]: 0 for w in windows},
+    )
+    assert "claim_boundary" in summary


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** New offline, experimental `experiments/behavior_tokens/` namespace that turns saved benchmark interaction traces into discrete "behavior tokens" for diagnostics (3 standalone CLIs + shared schemas + tests), implementing the maintainer plan on #4627.
- **Why now:** #4627 is auto-admitted from the ready queue; the plan is fully specified and self-contained (offline, CPU-only), so the complete first exploratory slice is achievable in one session.
- **Claim boundary:** Very low priority, exploratory, **diagnostic-only** tooling. Behavior tokens are heuristic descriptors of saved traces — **not** validated metrics, benchmark evidence, a release gate, or paper/dissertation claim support. **No safety decision may depend on the tokens.** No new controller training, no transformer dependency, no benchmark-pipeline integration.
- **Required validation:** ruff check/format, `tests/experiments/test_behavior_tokens.py`, and a 3-stage end-to-end smoke on a synthetic trace file (results below).
- **Remaining blocker:** None for this first exploratory pass. Running the pipeline on *real* saved campaign traces (no local `episodes.jsonl` with `simulation_step_trace` exists in this checkout) and any downstream diagnostic use remain future, opt-in work.

Closes #4627

## Contract delta

- **New experimental namespace** `experiments/behavior_tokens/` (offline, read-only):
  - `extract_windows.py` — slides fixed windows over `algorithm_metadata.simulation_step_trace.steps` → documented feature vectors (clearance min/mean/slope, TTC proxy min/slope, robot-speed stats, accel/command-change proxy, stop/yield, oscillation, near-conflict recovery, relative/ped speed). Non-derivable features are JSON `null` + listed in `missing_features` (never fabricated zeros); rows without a trace are **skipped with an explicit reason**.
  - `quantize_trace_windows.py` — standardizes finite feature columns and assigns each valid window a **deterministic** discrete token id via k-means (scikit-learn, NumPy-only fallback). Token ids are **canonicalized by cluster center** so repeated runs and both backends agree. **Fails closed** (raises, non-zero exit) when no finite columns or no valid windows remain, rather than emitting empty/fabricated assignments.
  - `inspect_token_motifs.py` — token summary by scenario/planner/outcome/row-status, heuristic `*_candidate` motif labels, and **bounded** example windows per frequent token.
  - `schemas.py` — shared `FEATURE_NAMES` vocabulary + schema-version constants embedded in every artifact for provenance.
- **New schema-version strings** (artifact provenance): `behavior-token-features.v1`, `behavior-token-window.v1`, `behavior-token-quantizer.v1`, `behavior-token-inspection.v1`.
- **No new fail-closed benchmark blocker** and **no change to any existing metric/benchmark/schema surface.** All outputs default under git-ignored `output/experiments/behavior_tokens/...`.
- **Compatibility:** additive only. `pyproject.toml` gains an `experiments/**` ruff per-file-ignore mirroring the existing one-off-script allowances (`T201`, `PLC0415`, `TC001`, `TC002`, `D417`, `DOC201`).

## Validation results

| Command | Result |
| --- | --- |
| `ruff check experiments/behavior_tokens tests/experiments/test_behavior_tokens.py` | **All checks passed!** |
| `ruff format --check` (same paths) | reformatted then clean |
| `pytest tests/experiments/test_behavior_tokens.py -q` | **7 passed** |
| `python .../extract_windows.py --help` / `quantize_... --help` / `inspect_... --help` | exit 0 (all three) |
| 3-stage end-to-end smoke on a synthetic 25-row `episodes.jsonl` | 96 windows extracted, **1 no-trace row skipped** (`no_simulation_step_trace`), quantized → 8 tokens (`sklearn.KMeans`, 0 excluded), inspection wrote summary + `frequent_tokens.md` + bounded (≤5) example files |
| `scripts/tools/sync_ai_config.py --check` | AI config links validated: 7 symlinks (no drift) |

Tests cover: expected window count; missing-optional-field null discipline (no fabricated zeros) with a genuine-zero counter-check; no-trace / too-short skip reasons; quantizer determinism; one token id per valid window; bounded example selection; and the experimental claim boundary in README + generated metadata.

## Out of scope (explicit)

- **No full benchmark campaign run.** No Slurm/GPU submission. No paper/dissertation claim edits.
- No controller training, no transformer/model dependency, no benchmark/reporting-pipeline integration, no metric-stack change.
- No run on real saved campaign traces (none present locally with `simulation_step_trace`); the smoke used a synthetic trace file.

## State propagation

Low-churn issue (only the maintainer plan comment before this PR). Durable state surface updated via `CHANGELOG.md` (`[Unreleased] → Added`). This PR is schema/behavior only; no transient queue-routing state is encoded in tracked files.

<details>
<summary>Governance appendix</summary>

- **Research Result Guidance:** `NA — exploratory diagnostic tooling.` No claim/hypothesis is asserted; token ids and motif labels are heuristic candidates for manual inspection. Target synthesis surface if pursued: a future diagnostic context note under `docs/context/`.
- **Downstream Propagation:** parent issue #4627 (this PR); CHANGELOG updated. No claim map, leaderboard, registry, or benchmark report is affected (diagnostic-only). Disposable outputs live under git-ignored `output/experiments/behavior_tokens/`.
- **Follow-up:** first use on durable/real traces + any diagnostic application (scenario similarity, collision-cause grouping, regression stratification) is deferred, opt-in work; not required for this first exploratory slice.
- **Freshness:** re-checked issue #4627 comments immediately before opening — only the original maintainer plan comment (2026-07-06T14:00:34Z) exists; no newer guidance; no duplicate/overlapping PR.
</details>
