### PR TITLE
Add campaign credibility scorecard for issue #4653

### DIFF
--- a/docs/benchmark_spec.md
+++ b/docs/benchmark_spec.md
@@ -254,6 +254,25 @@ Episode records include `observation_noise`, `observation_noise_hash`, and
 also record the profile/hash. Absent or all-zero settings normalize to `profile: none` and leave
 planner observations unchanged.
 
+## Campaign Credibility Scorecard
+
+Campaign reports include `reports/campaign_credibility_scorecard.json` and a matching Markdown
+table in `reports/campaign_report.md`. The schema is
+`campaign_credibility_scorecard.v1`, a lightweight credibility summary inspired by
+NASA-STD-7009B for model and simulation reporting. It helps readers see which trust dimensions are
+supported by campaign artifacts and which remain unassessed.
+
+Every scorecard contains the same six factors: `verification`, `validation`, `input_pedigree`,
+`uncertainty_characterization`, `results_robustness`, and `use_history`. Each factor has
+`factor_id`, `factor`, `description`, `status`, `score`, `scale`, `justification`, and `evidence`.
+Status uses the coarse scale `not_assessed`, `weak`, `partial`, `strong`, or `not_applicable`.
+Scores use a companion `0` to `3` numeric value when mechanically assessed. Missing evidence fails closed: the factor remains
+`status: not_assessed` with `score: null`, and the Markdown table renders the score cell blank
+instead of omitting the factor. Mechanically derived factors may be pre-filled from pinned campaign
+inputs, seed-variability artifacts, structured report artifacts, and planner-row status summaries.
+The scorecard is reporting metadata only; it is not benchmark proof, paper evidence, or real-world
+validation.
+
 ## Metrics: Definitions + Caveats (Summary)
 
 Full details live in

--- a/robot_sf/benchmark/camera_ready/_legacy_campaign_facade.py
+++ b/robot_sf/benchmark/camera_ready/_legacy_campaign_facade.py
@@ -86,6 +86,7 @@ from robot_sf.benchmark.camera_ready._reporting import (  # noqa: F401 - re-expo
     _safe_float,
     _scenario_family,
     _strict_vs_fallback_comparisons,
+    build_campaign_credibility_scorecard,
     write_campaign_report,
 )
 from robot_sf.benchmark.camera_ready._route_clearance import (  # noqa: F401 - re-exported for back-compat
@@ -263,6 +264,7 @@ __all__ = [
     "RouteClearanceError",
     "SeedPolicy",
     "SnqiContractConfig",
+    "build_campaign_credibility_scorecard",
     "load_campaign_config",
     "prepare_campaign_preflight",
     "run_campaign",

--- a/robot_sf/benchmark/camera_ready/_reporting.py
+++ b/robot_sf/benchmark/camera_ready/_reporting.py
@@ -43,6 +43,180 @@ _REPORT_METRICS: tuple[str, ...] = (
     "snqi",
 )
 
+_CREDIBILITY_SCORECARD_SCHEMA = "campaign_credibility_scorecard.v1"
+_CREDIBILITY_SCORECARD_FACTORS: tuple[dict[str, str], ...] = (
+    {
+        "factor_id": "verification",
+        "factor": "Verification",
+        "description": "Repository and campaign checks supporting correct implementation.",
+    },
+    {
+        "factor_id": "validation",
+        "factor": "Validation",
+        "description": "Comparison against trusted real-world or independent reference data.",
+    },
+    {
+        "factor_id": "input_pedigree",
+        "factor": "Input pedigree",
+        "description": "Pinned inputs, hashes, manifests, and source provenance.",
+    },
+    {
+        "factor_id": "uncertainty_characterization",
+        "factor": "Uncertainty characterization",
+        "description": "Seed repetition, confidence intervals, or variance analysis.",
+    },
+    {
+        "factor_id": "results_robustness",
+        "factor": "Results robustness",
+        "description": "Coverage across planners, scenarios, and non-success classifications.",
+    },
+    {
+        "factor_id": "use_history",
+        "factor": "Use history",
+        "description": "Prior accepted use of this campaign configuration or equivalent evidence.",
+    },
+)
+_CREDIBILITY_STATUS_BY_SCORE = {
+    0: "weak",
+    1: "weak",
+    2: "partial",
+    3: "strong",
+}
+
+
+def _not_assessed_factor(spec: dict[str, str]) -> dict[str, Any]:
+    """Build one fail-closed credibility factor row.
+
+    Returns:
+        Factor row with ``not_assessed`` status and a null score.
+    """
+    return {
+        **spec,
+        "status": "not_assessed",
+        "score": None,
+        "scale": "not_assessed | weak | partial | strong | not_applicable",
+        "justification": "No campaign artifact supplied enough evidence for this factor.",
+        "evidence": [],
+    }
+
+
+def build_campaign_credibility_scorecard(payload: dict[str, Any]) -> dict[str, Any]:
+    """Build NASA-STD-7009-style per-campaign credibility scorecard.
+
+    The scorecard is deliberately conservative: every expected factor is present, and factors
+    without direct campaign evidence remain ``not_assessed`` instead of being silently omitted.
+
+    Returns:
+        Scorecard payload for JSON and Markdown campaign reports.
+    """
+    campaign = payload.get("campaign", {}) if isinstance(payload.get("campaign"), dict) else {}
+    artifacts = payload.get("artifacts", {}) if isinstance(payload.get("artifacts"), dict) else {}
+    rows = payload.get("planner_rows", []) if isinstance(payload.get("planner_rows"), list) else []
+    factors = {
+        spec["factor_id"]: _not_assessed_factor(spec) for spec in _CREDIBILITY_SCORECARD_FACTORS
+    }
+
+    if campaign.get("git_hash") and campaign.get("scenario_matrix_hash"):
+        factors["input_pedigree"].update(
+            {
+                "status": "partial",
+                "score": 2,
+                "justification": (
+                    "Campaign records git commit and scenario matrix hash; external input "
+                    "lineage remains limited to recorded artifacts."
+                ),
+                "evidence": [
+                    f"git_hash={campaign.get('git_hash')}",
+                    f"scenario_matrix_hash={campaign.get('scenario_matrix_hash')}",
+                    f"campaign_manifest={artifacts.get('campaign_manifest')}",
+                ],
+            }
+        )
+
+    seed_count = campaign.get("seed_count")
+    try:
+        seed_count_int = int(seed_count)
+    except (TypeError, ValueError):
+        seed_count_int = 0
+    if seed_count_int > 1 or artifacts.get("seed_variability_json"):
+        score = 2 if seed_count_int > 1 else 1
+        factors["uncertainty_characterization"].update(
+            {
+                "status": _CREDIBILITY_STATUS_BY_SCORE[score],
+                "score": score,
+                "justification": (
+                    f"Campaign records {seed_count_int} seed(s) and seed-variability artifacts "
+                    "when available; no claim beyond campaign-level uncertainty."
+                ),
+                "evidence": [
+                    f"seed_count={seed_count_int}",
+                    f"seed_variability_json={artifacts.get('seed_variability_json')}",
+                    f"statistical_sufficiency_json={artifacts.get('statistical_sufficiency_json')}",
+                ],
+            }
+        )
+
+    if artifacts.get("campaign_summary_json") and artifacts.get("campaign_table_csv"):
+        factors["verification"].update(
+            {
+                "status": "weak",
+                "score": 1,
+                "justification": (
+                    "Report was generated from structured campaign summary/table artifacts; "
+                    "test-suite evidence is not embedded in the campaign artifact."
+                ),
+                "evidence": [
+                    f"campaign_summary_json={artifacts.get('campaign_summary_json')}",
+                    f"campaign_table_csv={artifacts.get('campaign_table_csv')}",
+                ],
+            }
+        )
+
+    total_runs = len(rows)
+    successful_runs = sum(1 for row in rows if str(row.get("status")) == "ok")
+    if total_runs:
+        factors["results_robustness"].update(
+            {
+                "status": _CREDIBILITY_STATUS_BY_SCORE[1 if successful_runs else 0],
+                "score": 1 if successful_runs else 0,
+                "justification": (
+                    f"Campaign reports {successful_runs}/{total_runs} successful planner row(s); "
+                    "fallback/degraded rows remain caveats, not success evidence."
+                ),
+                "evidence": [
+                    f"total_runs={total_runs}",
+                    f"successful_runs={successful_runs}",
+                    f"row_status_summary={campaign.get('row_status_summary', {})}",
+                ],
+            }
+        )
+
+    assessed_scores = [
+        int(factor["score"])
+        for factor in factors.values()
+        if factor.get("status") not in {"not_assessed", "not_applicable"}
+        and factor.get("score") is not None
+    ]
+    overall_score = (
+        round(sum(assessed_scores) / len(assessed_scores), 2) if assessed_scores else None
+    )
+    return {
+        "schema_version": _CREDIBILITY_SCORECARD_SCHEMA,
+        "standard_reference": "NASA-STD-7009B-inspired credibility assessment",
+        "campaign_id": campaign.get("campaign_id", "unknown"),
+        "overall_score": overall_score,
+        "overall_status": (
+            _CREDIBILITY_STATUS_BY_SCORE[round(overall_score)]
+            if overall_score is not None
+            else "not_assessed"
+        ),
+        "claim_boundary": (
+            "Scorecard is reporting metadata for campaign credibility dimensions; it is not "
+            "benchmark proof, paper evidence, or real-world validation."
+        ),
+        "factors": [factors[spec["factor_id"]] for spec in _CREDIBILITY_SCORECARD_FACTORS],
+    }
+
 
 def _metric_mean(block: dict[str, Any], metric: str) -> float:
     """Extract aggregate mean value for one metric.
@@ -615,6 +789,7 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
     campaign = payload.get("campaign", {})
     rows = payload.get("planner_rows", [])
     warnings = payload.get("warnings", [])
+    scorecard = payload.get("credibility_scorecard")
     accepted_unavailable_rows = [
         row
         for row in rows
@@ -680,6 +855,37 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
             )
     else:
         lines.append("No planner rows were produced.")
+    if not isinstance(scorecard, dict):
+        scorecard = build_campaign_credibility_scorecard(payload)
+    factors = scorecard.get("factors", []) if isinstance(scorecard.get("factors"), list) else []
+    lines.extend(
+        [
+            "",
+            "## Credibility Scorecard",
+            "",
+            (
+                "NASA-STD-7009B-inspired campaign credibility metadata. "
+                "Unscored factors are shown as `not_assessed`."
+            ),
+            "",
+            f"- Schema: `{scorecard.get('schema_version', 'unknown')}`",
+            f"- Overall status: `{scorecard.get('overall_status', 'not_assessed')}`",
+            f"- Overall score: `{scorecard.get('overall_score')}`",
+            f"- Claim boundary: `{scorecard.get('claim_boundary', 'unknown')}`",
+            "",
+            "| factor | status | score | justification |",
+            "|---|---|---:|---|",
+        ]
+    )
+    for factor in factors:
+        lines.append(
+            "| "
+            f"{_escape_markdown_cell(factor.get('factor'))} | "
+            f"{_escape_markdown_cell(factor.get('status'))} | "
+            f"{_escape_markdown_cell(factor.get('score'))} | "
+            f"{_escape_markdown_cell(factor.get('justification'))} |"
+        )
+
     fallback_rows = [
         row for row in rows if str(row.get("readiness_status", "")) in {"fallback", "degraded"}
     ]

--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -39,6 +39,7 @@ from robot_sf.benchmark.camera_ready._reporting import (
     _build_breakdown_rows,
     _build_scenario_amv_lookup,
     _planner_report_row,
+    build_campaign_credibility_scorecard,
     write_campaign_report,
 )
 from robot_sf.benchmark.camera_ready._run_state import _campaign_success_counters
@@ -691,6 +692,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0915
 
     summary_json_path = reports_dir / "campaign_summary.json"
     report_md_path = reports_dir / "campaign_report.md"
+    credibility_scorecard_json_path = reports_dir / "campaign_credibility_scorecard.json"
 
     csv_path, md_table_path = _write_table_artifacts(
         reports_dir,
@@ -1268,6 +1270,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0915
         "artifacts": {
             "campaign_manifest": _repo_relative(campaign_root / "campaign_manifest.json"),
             "campaign_summary_json": _repo_relative(summary_json_path),
+            "campaign_credibility_scorecard_json": _repo_relative(credibility_scorecard_json_path),
             "campaign_table_csv": _repo_relative(csv_path),
             "campaign_table_md": _repo_relative(md_table_path),
             "campaign_table_core_csv": _repo_relative(core_csv_path),
@@ -1495,6 +1498,10 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0915
     ):
         warnings.append("Publication bundle export skipped because benchmark_success=false.")
 
+    campaign_summary["credibility_scorecard"] = build_campaign_credibility_scorecard(
+        campaign_summary
+    )
+    _write_json(credibility_scorecard_json_path, campaign_summary["credibility_scorecard"])
     _write_json(summary_json_path, campaign_summary)
     write_campaign_report(report_md_path, campaign_summary)
 

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -57,6 +57,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
     _sanitize_name,
     _scenario_with_kinematics,
     _sha256_file,
+    build_campaign_credibility_scorecard,
     load_campaign_config,
     prepare_campaign_preflight,
     run_campaign,
@@ -2497,6 +2498,7 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
     assert (campaign_root / "reports" / "kinematics_skipped_combinations.csv").exists()
     assert (campaign_root / "reports" / "kinematics_skipped_combinations.md").exists()
     assert (campaign_root / "reports" / "campaign_report.md").exists()
+    assert (campaign_root / "reports" / "campaign_credibility_scorecard.json").exists()
     assert (campaign_root / "preflight" / "validate_config.json").exists()
     assert (campaign_root / "preflight" / "preview_scenarios.json").exists()
     preview_payload = json.loads(
@@ -2576,6 +2578,12 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
     assert ppo_row["availability_status"] == "not_available"
     assert ppo_row["benchmark_success"] == "false"
     assert summary_payload["campaign"]["paper_interpretation_profile"] == "baseline-ready-core"
+    assert summary_payload["artifacts"]["campaign_credibility_scorecard_json"].endswith(
+        "reports/campaign_credibility_scorecard.json"
+    )
+    assert summary_payload["credibility_scorecard"]["schema_version"] == (
+        "campaign_credibility_scorecard.v1"
+    )
     assert summary_payload["artifacts"]["matrix_summary_json"].endswith(
         "reports/matrix_summary.json"
     )
@@ -3469,6 +3477,55 @@ def test_write_campaign_report_escapes_markdown_cells(tmp_path: Path) -> None:
     assert "## Unexpected Failed/Partial Planners" in report_text
     assert "No accepted unavailable/excluded planners." in report_text
     assert "No unexpected failed/partial planners." in report_text
+
+
+def test_campaign_credibility_scorecard_fail_closed_defaults() -> None:
+    """Credibility scorecard includes every factor and fails closed when evidence is absent."""
+    scorecard = build_campaign_credibility_scorecard(
+        {"campaign": {"campaign_id": "c1"}, "planner_rows": [], "artifacts": {}}
+    )
+
+    assert scorecard["schema_version"] == "campaign_credibility_scorecard.v1"
+    assert scorecard["overall_status"] == "not_assessed"
+    assert scorecard["overall_score"] is None
+    assert [factor["factor_id"] for factor in scorecard["factors"]] == [
+        "verification",
+        "validation",
+        "input_pedigree",
+        "uncertainty_characterization",
+        "results_robustness",
+        "use_history",
+    ]
+    assert all(factor["status"] == "not_assessed" for factor in scorecard["factors"])
+    assert all(factor["score"] is None for factor in scorecard["factors"])
+
+
+def test_write_campaign_report_renders_credibility_scorecard(tmp_path: Path) -> None:
+    """Markdown report renders assessed and not-assessed credibility factors."""
+    report_path = tmp_path / "campaign_report.md"
+    payload = {
+        "campaign": {
+            "campaign_id": "c1",
+            "git_hash": "abc123",
+            "scenario_matrix_hash": "sha256:matrix",
+            "seed_count": 3,
+        },
+        "planner_rows": [{"planner_key": "p1", "status": "ok"}],
+        "artifacts": {
+            "campaign_manifest": "campaign_manifest.json",
+            "campaign_summary_json": "reports/campaign_summary.json",
+            "campaign_table_csv": "reports/campaign_table.csv",
+            "seed_variability_json": "reports/seed_variability_by_scenario.json",
+        },
+    }
+
+    write_campaign_report(report_path, payload)
+    report_text = report_path.read_text(encoding="utf-8")
+
+    assert "## Credibility Scorecard" in report_text
+    assert "`campaign_credibility_scorecard.v1`" in report_text
+    assert "| Input pedigree | partial | 2 |" in report_text
+    assert "| Validation | not_assessed |  |" in report_text
 
 
 @pytest.mark.parametrize("unexpected_status", ["failed", "partial-failure"])


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a NASA-STD-7009B-inspired per-campaign credibility scorecard to camera-ready campaign reporting. Campaign generation now writes `reports/campaign_credibility_scorecard.json`, embeds the same payload in `campaign_summary.json`, and renders a Markdown scorecard section in `campaign_report.md`.

Why now: issue #4653 asks campaign reports to state trust dimensions alongside metric values.

Claim boundary: this is reporting metadata only. It does not upgrade benchmark results, simulator validation, release-gate outcomes, or paper/dissertation claims.

Required validation: targeted scorecard/report tests plus the repository PR readiness gate.

Remaining blocker: none for the requested reporting contract.

Closes #4653

## Contract delta

New schema/artifacts:
- `campaign_credibility_scorecard.v1`
- `reports/campaign_credibility_scorecard.json`
- `campaign_summary.json` now includes `credibility_scorecard`
- `campaign_summary.json["artifacts"]` now includes `campaign_credibility_scorecard_json`
- `campaign_report.md` now includes `## Credibility Scorecard`

Scorecard factors:
- `verification`
- `validation`
- `input_pedigree`
- `uncertainty_characterization`
- `results_robustness`
- `use_history`

Fail-closed blockers:
- Every schema factor is always emitted.
- Missing evidence renders `status: not_assessed` and `score: null` in JSON.
- Markdown renders null scores as a blank cell and keeps the factor visible.
- Fallback/degraded planner rows remain caveats and are not treated as success evidence.

Compatibility impact: additive reporting fields and one new report JSON artifact. Existing campaign summary/report consumers should continue to work if they ignore unknown fields/artifacts.

Late guidance: incorporated the 2026-07-06T14:36:28Z issue comment by aligning the scorecard to the requested credibility dimensions, using the requested coarse status scale (`not_assessed`, `weak`, `partial`, `strong`, `not_applicable`), documenting the schema, and adding tests for fail-closed factor emission plus campaign orchestration output.

State propagation: no issue comment was added because this run is not authorized to `comment_issue_or_pr`; this PR body is the durable propagation surface for the delivered slice.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Domain-Aware Approval

- Required for PR: not applicable
- Domains reviewed: reporting metadata, fail-closed campaign artifact schema
- Status: not applicable
- Approver/review source waiver: not required because this PR only adds reporting metadata and does not change metrics, rankings, planner behavior, or result interpretation.
- Target claim/hypothesis: NA - no research claim or hypothesis is introduced.
- Comparator split/evidence validity: NA - no comparator or empirical split is changed.
- Fallback/degraded exclusions: fallback/degraded planner rows remain caveats and are not treated as success evidence.
- Claim boundary: reporting metadata only; no benchmark, paper, simulator-validation, or release claim is upgraded.
- Implementation integrity vs experimental validity: implementation is validated by focused tests and PR readiness; experimental validity is unchanged.

## Validation

- `uv run ruff check robot_sf/benchmark/camera_ready/_reporting.py robot_sf/benchmark/camera_ready/campaign.py robot_sf/benchmark/camera_ready/_legacy_campaign_facade.py tests/benchmark/test_camera_ready_campaign.py` -> passed
- `uv run pytest tests/benchmark/test_camera_ready_campaign.py -k "credibility_scorecard or write_campaign_report"` -> 5 passed
- `uv run pytest tests/benchmark/test_camera_ready_campaign.py::test_run_campaign_writes_core_artifacts` -> 1 passed
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed before commit; 1916 passed, 2 skipped; dirty-tree stamp only because changes were uncommitted at the time
- `PR_READY_PR_BODY_FILE=<common-git-dir>/codex-agent-runs/active/issue-4653/PR_BODY.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; core lane 1918 passed; optional lane passed; clean-tree stamp `output/validation/pr_ready/issue-4653-credibility-scorecard.json`

<details>
<summary>Governance appendix</summary>

Issue link: https://github.com/ll7/robot_sf_ll7/issues/4653

Scope summary: reporting/schema/docs/tests for per-campaign credibility scorecards. This PR does not change planner behavior, benchmark metrics, or interpretation rules.

Fragmentation guard: duplicate PR search found no open or merged PRs covering issue #4653 or the NASA-7009 credibility scorecard scope.

Artifact policy: generated validation artifacts remain under ignored `output/`; no bulky generated benchmark outputs are committed.

</details>
