### PR TITLE
Issue #4437: add closure audit final summary output

### DIFF
--- a/scripts/dev/closure_mechanics.py
+++ b/scripts/dev/closure_mechanics.py
@@ -16,6 +16,7 @@ import json
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 # Comment templates from the issue plan.
@@ -45,6 +46,31 @@ Still open / not yet evidenced:
 {remaining_items}
 
 Keeping this parent issue open by design because it coordinates multiple slices."""
+
+FINAL_SUMMARY_TEMPLATE = """\
+## Closure audit summary
+
+Scope: open issues with at least one merged title-linked PR reviewed through the #4437 closure mechanics.
+
+Counts:
+- closed as fully covered: {closed_count}
+- residual annotated, kept open: {residual_count}
+- parent ledgers updated, kept open: {parent_count}
+- no action / skipped / failed: {skipped_count}
+
+Closed:
+{closed_items}
+
+Residual annotated:
+{residual_items}
+
+Parent ledgers updated:
+{parent_items}
+
+No action / skipped / failed:
+{skipped_items}
+
+Boundary: issue hygiene only. No code, queue edits, new issues, benchmark execution, Slurm/GPU submission, or paper/dissertation claim changes were performed by the issue-write pass."""
 
 
 @dataclass(frozen=True)
@@ -186,6 +212,91 @@ def build_close_command(*, issue_number: int, repo: str) -> list[str]:
     return ["gh", "issue", "close", str(issue_number), "--repo", repo, "--reason", "completed"]
 
 
+def _summary_issue_rows(
+    results: list[dict[str, object]],
+    *,
+    action_type: str,
+    completed_field: str,
+) -> list[str]:
+    """Return summary rows for successfully applied actions of one type."""
+    rows: list[str] = []
+    for entry in results:
+        if entry.get("action_type") != action_type:
+            continue
+        if entry.get(completed_field) is not True:
+            continue
+        issue_number = entry.get("issue_number")
+        if isinstance(issue_number, int):
+            rows.append(f"- #{issue_number}")
+    return rows
+
+
+def _skipped_summary_rows(results: list[dict[str, object]]) -> list[str]:
+    """Return rows for actions that did not complete their intended mutation."""
+    rows: list[str] = []
+    for entry in results:
+        issue_number = entry.get("issue_number")
+        if not isinstance(issue_number, int):
+            continue
+        action_type = str(entry.get("action_type", "unknown"))
+        expected_field = "closed" if action_type == "close_fully_covered" else "comment_posted"
+        if action_type == "no_action":
+            rows.append(f"- #{issue_number} no action")
+        elif entry.get(expected_field) is not True:
+            error = entry.get("error")
+            reason = f"{action_type} not completed"
+            if error:
+                reason = f"{reason}: {error}"
+            rows.append(f"- #{issue_number} {reason}")
+    return rows
+
+
+def _format_summary_items(rows: list[str]) -> str:
+    """Render summary rows with an explicit empty marker."""
+    return "\n".join(rows) if rows else "- (none)"
+
+
+def build_final_summary_comment(execution_result: dict[str, Any]) -> str:
+    """Build the final #4437 audit summary comment from execution results.
+
+    The summary only counts mutations that actually completed in the execution result.
+    Dry-run previews therefore produce zero applied counts and list planned actions as
+    skipped, preventing a preview from being presented as a completed write pass.
+    """
+    raw_results = execution_result.get("results", [])
+    if not isinstance(raw_results, list):
+        raw_results = []
+    results = [entry for entry in raw_results if isinstance(entry, dict)]
+
+    closed_rows = _summary_issue_rows(
+        results,
+        action_type="close_fully_covered",
+        completed_field="closed",
+    )
+    residual_rows = _summary_issue_rows(
+        results,
+        action_type="residual",
+        completed_field="comment_posted",
+    )
+    parent_rows = _summary_issue_rows(
+        results,
+        action_type="parent_ledger",
+        completed_field="comment_posted",
+    )
+    skipped_rows = _skipped_summary_rows(results)
+
+    return FINAL_SUMMARY_TEMPLATE.format(
+        closed_count=len(closed_rows),
+        residual_count=len(residual_rows),
+        parent_count=len(parent_rows),
+        skipped_count=len(skipped_rows),
+        closed_items=_format_summary_items(closed_rows),
+        residual_items=_format_summary_items(residual_rows),
+        parent_items=_format_summary_items(parent_rows),
+        skipped_items=_format_summary_items(skipped_rows),
+    )
+
+
 def execute_actions(
     actions: list[ClosureAction], *, repo: str, dry_run: bool = True
 ) -> dict[str, Any]:
@@ -266,6 +377,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Comma-separated list of issue numbers to classify as fully covered and close.",
     )
+    parser.add_argument(
+        "--summary-comment-file",
+        type=str,
+        default=None,
+        help="Write final #4437 summary comment Markdown from the execution result.",
+    )
     return parser
 
 
@@ -304,6 +421,10 @@ def main(argv: list[str] | None = None) -> int:
 
     actions = classify_and_build_actions(report, close_issues=close_issues_set)
     result = execute_actions(actions, repo=args.repo, dry_run=dry_run)
+    if args.summary_comment_file:
+        summary_comment = build_final_summary_comment(result)
+        Path(args.summary_comment_file).write_text(summary_comment + "\n", encoding="utf-8")
+        result["summary_comment_file"] = args.summary_comment_file
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0
 

--- a/tests/dev/test_closure_mechanics.py
+++ b/tests/dev/test_closure_mechanics.py
@@ -335,3 +335,75 @@ def test_main_parses_close_issues_cli_argument(
     # Wait, the main outputs results which have "should_close" and "action_type"
     assert payload["results"][0]["action_type"] == "close_fully_covered"
     assert payload["results"][0]["should_close"] is True
+
+
+def test_build_final_summary_comment_counts_completed_actions() -> None:
+    """Final #4437 summary counts only completed action results."""
+    result = {
+        "results": [
+            {
+                "issue_number": 12,
+                "action_type": "close_fully_covered",
+                "closed": True,
+                "comment_posted": True,
+                "error": None,
+            },
+            {
+                "issue_number": 13,
+                "action_type": "residual",
+                "closed": False,
+                "comment_posted": True,
+                "error": None,
+            },
+            {
+                "issue_number": 14,
+                "action_type": "parent_ledger",
+                "closed": False,
+                "comment_posted": True,
+                "error": None,
+            },
+            {
+                "issue_number": 15,
+                "action_type": "residual",
+                "closed": False,
+                "comment_posted": False,
+                "error": "permission denied",
+            },
+        ]
+    }
+
+    body = closure_mechanics.build_final_summary_comment(result)
+
+    assert "- closed as fully covered: 1" in body
+    assert "- residual annotated, kept open: 1" in body
+    assert "- parent ledgers updated, kept open: 1" in body
+    assert "- no action / skipped / failed: 1" in body
+    assert "- #12" in body
+    assert "- #13" in body
+    assert "- #14" in body
+    assert "- #15 residual not completed: permission denied" in body
+    assert "No code, queue edits, new issues" in body
+
+
+def test_main_writes_summary_comment_file(
+    tmp_path: object, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI writes final summary Markdown from dry-run result without posting it."""
+    import pathlib
+
+    report = _audit_report([_candidate(20, "file test", prs=[_pr_entry(77, "fix #20")])])
+    report_path = pathlib.Path(str(tmp_path)) / "report.json"
+    summary_path = pathlib.Path(str(tmp_path)) / "summary.md"
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+
+    exit_code = closure_mechanics.main(
+        ["--report-file", str(report_path), "--summary-comment-file", str(summary_path)]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    summary = summary_path.read_text(encoding="utf-8")
+    assert exit_code == 0
+    assert payload["summary_comment_file"] == str(summary_path)
+    assert "- closed as fully covered: 0" in summary
+    assert "- no action / skipped / failed: 1" in summary
+    assert "- #20 residual not completed" in summary


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** `scripts/dev/closure_mechanics.py` can now build the final #4437 closure-audit summary comment from the execution result and write it with `--summary-comment-file`. The summary counts only completed write mutations, so dry-run previews are listed as skipped instead of completed.
- **Why now:** #4437 has multiple merged enablement/consolidation PRs, but the remaining criteria still include the final #4437 summary comment. The fragmentation guard rules out another packet refresh; this PR adds a nameable integration capability for the authorized write pass.
- **Claim boundary:** Dev-tooling integration only. This does not execute issue comments/closures, does not close #4437, and does not claim the audit execution pass is complete.
- **Required validation:** focused closure-audit tests, Ruff, and final `pr_ready_check`.
- **Remaining blocker:** an authorized issue-write lane still must run the real audit write pass, close/comment live issues, and post the generated final #4437 summary comment.

## Contract delta

- New CLI flag: `scripts/dev/closure_mechanics.py --summary-comment-file <path>` writes the final #4437 summary Markdown generated from the execution result.
- New public helper: `build_final_summary_comment(execution_result)`.
- Fail-closed behavior: summary counts only entries whose `closed` or `comment_posted` field is true; dry-run or failed actions appear under `no action / skipped / failed`.
- Compatibility impact: additive only; existing dry-run/apply/comment/close behavior is unchanged.

## Issue

Refs #4437: https://github.com/ll7/robot_sf_ll7/issues/4437

## Scope summary

This PR implements the smallest remaining code/test slice toward #4437 after #4643: deterministic generation of the final summary comment body required by the closure audit. It is not another blocker restatement; it produces the concrete Markdown artifact the downstream authorized writer can post after the live write pass.

Fragmentation guard: #4622 and #4643 already merged for #4437 in the last 24h. This PR is a progression slice because it adds the new `--summary-comment-file` capability for the final-summary acceptance criterion.

Late-guidance check: issue #4437 and comments were re-read immediately before publication; no comments newer than 2026-07-06T14:53:26Z were present. Open PR dedupe found no active #4437 PR covering this scope.

## Validation

- `uv run ruff check --fix scripts/dev/closure_mechanics.py tests/dev/test_closure_mechanics.py` -> fixed 1 import-order issue, 0 remaining.
- `uv run ruff format scripts/dev/closure_mechanics.py tests/dev/test_closure_mechanics.py` -> 2 files left unchanged after fix.
- `uv run ruff check scripts/dev/closure_mechanics.py tests/dev/test_closure_mechanics.py` -> all checks passed.
- `uv run pytest tests/dev/test_closure_mechanics.py tests/dev/test_open_issue_closure_audit.py -q` -> 27 passed in 0.22s.
- `uv run python scripts/dev/closure_mechanics.py --report-file <run-dir>/summary_demo_report.json --summary-comment-file <run-dir>/summary_demo_comment.md` -> emitted `closure_mechanics.v1`, `dry_run=true`, `action_count=1`, and wrote the summary Markdown artifact.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=<run-dir>/PR_BODY.md scripts/dev/pr_ready_check.sh` -> passed; 1921 passed, broad exception ratchet passed, freshness stamp recorded clean tree for `365e105cf05eeb48e977fcbd335a768faddbf043`.

## Remaining #4437 checklist

- [ ] Run the real live closure audit candidate review/write pass with issue comment/close authority.
- [ ] Post closure/residual/parent-ledger comments on touched issues and close fully covered issues with `--reason completed`.
- [ ] Post the generated final #4437 summary comment with closed/residual/parent/skipped counts and issue numbers.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No GitHub issue comments or closures in this lane (`comment_issue_or_pr: false`).
- No transient queue-routing state added to tracked files.

<details>
<summary>Artifact and propagation notes</summary>

- Demo artifact path: `.git/codex-agent-runs/active/issue-4437/summary_demo_comment.md` (local run artifact, not tracked).
- State propagation: no issue comment was posted because this lane is explicitly not authorized for issue comments. The PR body records the remaining checklist and generated-summary capability; the existing issue comments remain the canonical public state until the authorized write lane posts the real summary.
- No durable benchmark/model artifacts were generated.

</details>
