### PR TITLE
fix: write learned-risk readiness JSON reports (#4586)

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -3083,6 +3083,10 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_4586_learned_risk_readiness_blocked_2026-07-06.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_2444_ammv_divergence_2026-06-23/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_4586_learned_risk_readiness_blocked_2026-07-06.json
+++ b/docs/context/evidence/issue_4586_learned_risk_readiness_blocked_2026-07-06.json
@@ -1,0 +1,43 @@
+{
+  "blockers": [
+    "trace_manifest: baseline_artifact_uri is an unresolved placeholder alias: wandb-artifact://robot-sf/policy-search/hybrid_rule_v3_static_margin0_waypoint2_baseline:pending",
+    "trace_manifest: trace_artifacts[0] is an unresolved placeholder alias: wandb-artifact://robot-sf/learned-risk/learned_risk_training_traces_stress_slice:pending",
+    "trace_manifest: trace_artifacts[1] is an unresolved placeholder alias: wandb-artifact://robot-sf/learned-risk/learned_risk_training_traces_full_matrix:pending",
+    "trace_manifest: label 'collision' is not 'present' (got 'pending')",
+    "trace_manifest: label 'near_miss' is not 'present' (got 'pending')",
+    "trace_manifest: label 'low_progress' is not 'present' (got 'pending')",
+    "trace_manifest: retrieval_status is not 'available'"
+  ],
+  "blocking_gates": [
+    "trace_manifest"
+  ],
+  "campaign_ready": false,
+  "campaign_state": "campaign_blocked",
+  "candidate_id": "learned_risk_model_v1",
+  "gates": [
+    {
+      "blockers": [],
+      "name": "launch_packet",
+      "status": "passed",
+      "summary": "launch packet valid for learned_risk_model_v1"
+    },
+    {
+      "blockers": [
+        "baseline_artifact_uri is an unresolved placeholder alias: wandb-artifact://robot-sf/policy-search/hybrid_rule_v3_static_margin0_waypoint2_baseline:pending",
+        "trace_artifacts[0] is an unresolved placeholder alias: wandb-artifact://robot-sf/learned-risk/learned_risk_training_traces_stress_slice:pending",
+        "trace_artifacts[1] is an unresolved placeholder alias: wandb-artifact://robot-sf/learned-risk/learned_risk_training_traces_full_matrix:pending",
+        "label 'collision' is not 'present' (got 'pending')",
+        "label 'near_miss' is not 'present' (got 'pending')",
+        "label 'low_progress' is not 'present' (got 'pending')",
+        "retrieval_status is not 'available'"
+      ],
+      "name": "trace_manifest",
+      "status": "blocked",
+      "summary": "trace manifest decision: artifact_retrieval_blocked"
+    }
+  ],
+  "issue": 1472,
+  "launch_packet": "configs/training/learned_risk_model_issue_1395_launch_packet.yaml",
+  "status": "ok",
+  "trace_manifest": "configs/training/learned_risk_trace_manifest_issue_2312.yaml"
+}

--- a/robot_sf/training/learned_risk_campaign_readiness.py
+++ b/robot_sf/training/learned_risk_campaign_readiness.py
@@ -107,8 +107,8 @@ def evaluate_campaign_readiness(
         "status": "ok",
         "candidate_id": "learned_risk_model_v1",
         "issue": 1472,
-        "launch_packet": str(launch_packet_path),
-        "trace_manifest": str(trace_manifest_path),
+        "launch_packet": _display_path(launch_packet_path, root),
+        "trace_manifest": _display_path(trace_manifest_path, root),
         "gates": gates,
         "campaign_ready": not blocking_gates,
         "campaign_state": campaign_state,
@@ -131,6 +131,14 @@ def _resolve_existing(path: Path | str, repo_root: Path, label: str) -> Path:
     if not resolved.is_file():
         raise LearnedRiskCampaignReadinessError(f"{label} is not a file: {path}")
     return resolved
+
+
+def _display_path(path: Path, repo_root: Path) -> str:
+    """Return repo-relative paths when possible for portable readiness JSON."""
+    try:
+        return path.relative_to(repo_root).as_posix()
+    except ValueError:
+        return str(path)
 
 
 def _evaluate_launch_packet_gate(launch_packet_path: Path, root: Path) -> dict[str, Any]:

--- a/scripts/validation/check_learned_risk_campaign_readiness.py
+++ b/scripts/validation/check_learned_risk_campaign_readiness.py
@@ -51,7 +51,13 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Repository root used to resolve relative paths.",
     )
-    parser.add_argument("--json", action="store_true", help="Emit a JSON readiness report.")
+    parser.add_argument(
+        "--json",
+        nargs="?",
+        const="-",
+        metavar="PATH",
+        help="Emit a JSON readiness report to stdout, or write it to PATH.",
+    )
     return parser
 
 
@@ -66,13 +72,13 @@ def main(argv: list[str] | None = None) -> int:
         )
     except LearnedRiskCampaignReadinessError as exc:
         if args.json:
-            print(json.dumps({"status": "invalid", "error": str(exc)}, indent=2, sort_keys=True))
+            _emit_json({"status": "invalid", "error": str(exc)}, args.json)
         else:
             print(str(exc))
         return 2
 
     if args.json:
-        print(json.dumps(report, indent=2, sort_keys=True))
+        _emit_json(report, args.json)
     else:
         print(f"learned-risk campaign decision: {report['campaign_state']}")
         for gate in report["gates"]:
@@ -80,6 +86,17 @@ def main(argv: list[str] | None = None) -> int:
         for blocker in report["blockers"]:
             print(f"    blocker: {blocker}")
     return 3 if report["campaign_state"] == CAMPAIGN_BLOCKED else 0
+
+
+def _emit_json(payload: dict[str, object], destination: str) -> None:
+    """Emit JSON to stdout or a requested path."""
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if destination == "-":
+        print(text)
+        return
+    path = Path(destination)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{text}\n", encoding="utf-8")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI guard

--- a/tests/training/test_learned_risk_campaign_readiness.py
+++ b/tests/training/test_learned_risk_campaign_readiness.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import json
 from pathlib import Path
 
 import pytest
@@ -154,6 +155,13 @@ def test_checked_in_campaign_reports_blocked() -> None:
     assert report["campaign_state"] == CAMPAIGN_BLOCKED
     assert report["campaign_ready"] is False
     assert report["issue"] == 1472
+    assert (
+        report["launch_packet"]
+        == "configs/training/learned_risk_model_issue_1395_launch_packet.yaml"
+    )
+    assert (
+        report["trace_manifest"] == "configs/training/learned_risk_trace_manifest_issue_2312.yaml"
+    )
     # The launch packet is internally valid; the campaign is blocked on the
     # unresolved durable trace/baseline artifacts only.
     assert _gate(report, "launch_packet")["status"] == "passed"
@@ -254,6 +262,49 @@ def test_cli_ready_exit_code(tmp_path: Path) -> None:
         ]
     )
     assert exit_code == 0
+
+
+def test_cli_writes_ready_json_path(tmp_path: Path) -> None:
+    """The CLI can write a ready report to a requested JSON path."""
+    report_path = tmp_path / "reports" / "ready.json"
+    exit_code = readiness_cli_main(
+        [
+            "--launch-packet",
+            str(_valid_launch_packet(tmp_path)),
+            "--trace-manifest",
+            str(_ready_trace_manifest(tmp_path)),
+            "--repo-root",
+            str(_REPO_ROOT),
+            "--json",
+            str(report_path),
+        ]
+    )
+
+    assert exit_code == 0
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["campaign_state"] == CAMPAIGN_READY
+    assert report["campaign_ready"] is True
+
+
+def test_cli_writes_blocked_json_path(tmp_path: Path) -> None:
+    """The CLI preserves blocked exit code when writing report JSON."""
+    report_path = tmp_path / "blocked.json"
+    exit_code = readiness_cli_main(
+        [
+            "--repo-root",
+            str(_REPO_ROOT),
+            "--json",
+            str(report_path),
+        ]
+    )
+
+    assert exit_code == 3
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["campaign_state"] == CAMPAIGN_BLOCKED
+    assert report["campaign_ready"] is False
+    assert report["blocking_gates"] == ["trace_manifest"]
+    assert any(":pending" in blocker for blocker in report["blockers"])
+    assert any("retrieval_status" in blocker for blocker in report["blockers"])
 
 
 def test_cli_missing_file_exit_code(tmp_path: Path) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `scripts/validation/check_learned_risk_campaign_readiness.py` now accepts the issue-plan command shape `--json <path>` while preserving the existing `--json` stdout behavior and exit-code contract. This PR also commits a durable blocked readiness report at `docs/context/evidence/issue_4586_learned_risk_readiness_blocked_2026-07-06.json`.

Why now: issue #4586 is blocked on private-side #1472 learned-risk trace/baseline artifact materialization. The repository can still make the blocker state precise and reproducible without pretending the artifacts exist.

Claim boundary: this is a checker/evidence slice only. It does not resolve private W&B artifact aliases, mark labels present, set `retrieval_status: available`, run training, submit Slurm/GPU jobs, or edit paper/dissertation claims.

Required validation: targeted CLI tests, targeted readiness command, JSON syntax validation, ruff, and full PR readiness gate.

Remaining blocker: private ops must materialize/freeze the baseline artifact and both learned-risk training trace artifacts, record 64-character SHA-256 digests, verify required labels, and only then update the trace manifest to `retrieval_status: available`.

## Contract delta

- New CLI compatibility: `--json` still emits the readiness report to stdout; `--json PATH` writes the same JSON report to `PATH`.
- Exit-code compatibility: ready remains `0`, invalid input remains `2`, blocked remains `3`, including when writing JSON to a file.
- New fail-closed evidence output: the committed readiness JSON records the current blockers: pending baseline alias, pending stress-slice trace alias, pending full-matrix trace alias, pending `collision` / `near_miss` / `low_progress` labels, and `retrieval_status` not available.
- Compatibility impact: existing callers using bare `--json` continue to work. Callers may now capture the report without shell redirection.

Refs #4586

## Scope summary

In scope:
- Make the campaign-readiness checker support path-based JSON output requested by the issue implementation plan.
- Add regression tests for ready and blocked path-output behavior.
- Commit one durable blocked readiness report produced by the checker.

Out of scope:
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No private artifact fetching or raw dataset storage.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_learned_risk_campaign_readiness.py -q`
  - Exit code: 0
  - Result: 11 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_learned_risk_campaign_readiness.py tests/training/test_learned_risk_campaign_readiness.py`
  - Exit code: 0
  - Result: all checks passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/check_learned_risk_campaign_readiness.py tests/training/test_learned_risk_campaign_readiness.py`
  - Exit code: 0
  - Result: 2 files already formatted
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_learned_risk_campaign_readiness.py --json docs/context/evidence/issue_4586_learned_risk_readiness_blocked_2026-07-06.validation.json`
  - Exit code: 3
  - Result: expected `campaign_blocked`; temporary validation copy removed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m json.tool docs/context/evidence/issue_4586_learned_risk_readiness_blocked_2026-07-06.json >/tmp/issue4586_json_tool.out`
  - Exit code: 0
  - Result: committed JSON parses
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - Exit code: 0
  - Result: 1917 passed, 2 skipped

## Remaining work

- [ ] Replace `:pending` baseline and trace aliases with concrete durable artifact URIs after private-side materialization.
- [ ] Record SHA-256 digests for baseline, stress-slice traces, and full-matrix traces.
- [ ] Mark required labels `present` only after inspecting the materialized traces.
- [ ] Set `retrieval_status: available` only after the manifest contract is complete.
- [ ] Rerun readiness and launch/training gates; campaign execution remains outside this PR.

<details>
<summary>Governance appendix</summary>

## Linked Issues

- Refs `#4586`
- Related parent blocker: `#1472`
- Related trace manifest: `#2312`

## Stack / Dependency

- Base dependency: `origin/main`
- Required prior PRs: none
- Safe to review independently: yes

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #1472 learned-risk readiness blocker reporting.
- Comparator or baseline: current CLI required shell redirection for file capture and rejected `--json <path>`.
- Evidence tier: NA - support checker.
- Result classification: NA - support checker; blocked readiness evidence only.
- Decision stop rule: stop at checker/evidence capture because private artifact URIs and label verification are unavailable.
- Parent issue, claim map, registry, context note, synthesis surface update: committed durable readiness output; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool: NA, support checker only.

## Domain-Aware Approval

- Approver/review source waiver: waived, support checker/evidence slice only.
- Target claim/hypothesis: NA - no research claim.
- Comparator split/evidence validity: NA - no empirical comparison.
- Fallback/degraded exclusions: blocked readiness remains blocked; no fallback/degraded execution is presented as success.
- Claim boundary: local checker contract only.
- Implementation integrity vs experimental validity: implementation-only checker behavior; no experimental validity claim.

## Falsification / Non-Transfer Check

- Did mechanism activate? NA, no model mechanism.
- Did intervention change command source, selected command, trajectory, route progress? No.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue after private artifact materialization.
- Follow-up question issue weak, negative, non-transfer results: none opened.

## Next Empirical Action

- Rerun needed: yes, after private artifact materialization.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: baseline artifact, stress-slice training traces, full-matrix training traces, required label verification.
- Stop / revise / continue decision: continue once private artifacts exist.
- Proposed child issue existing follow-up: #1472 / private ops materialization.

## Risks / Rollout

- Compatibility risks: low; bare `--json` remains supported.
- Failure modes: path write can fail on filesystem permissions; argparse reports invalid usage for malformed invocations.
- Rollback fallback plan: revert CLI optional-path support; stdout JSON remains the pre-existing path.

## Docs / Provenance

- Updated docs: durable evidence JSON under `docs/context/evidence/`.
- Relevant design provenance notes: issue #4586 comments and #2312 trace manifest context.
- Assumptions preserved: private artifacts are unavailable; labels cannot be marked present.

## Downstream Propagation

- Parent issue updated: no, issue comments are not authorized in this task.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no.
- Not applicable because: this PR includes the canonical durable blocked evidence output and the PR body records the remaining private-ops blocker.

## Reviewer Notes

- Verify the CLI still prints JSON for bare `--json`.
- Verify `--json PATH` preserves blocked exit code `3` while writing report JSON.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The readiness check can now output JSON either to the console or directly to a file path.
  * Readiness reports now show more portable, repo-relative paths when possible.

* **Bug Fixes**
  * Added clearer blocked-state evidence for a campaign readiness issue.
  * Improved readiness output for blocked and ready scenarios to include more complete status details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->