### PR TITLE
Issue #4013 real-trajectory readiness gate

### DIFF
--- a/configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml
+++ b/configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml
@@ -1,0 +1,60 @@
+# Issue #4013 real-trajectory training manifest.
+#
+# This is a bring-your-own-data provenance contract for the ETH/BIWI walking
+# pedestrians annotations used by many ETH/UCY-style trajectory-prediction
+# baselines. It intentionally does not download, stage, or redistribute raw
+# external data. The #4013 readiness checker keeps Phase 3 blocked until a
+# local copy is checksum-validated.
+schema: robot_sf_real_trajectory_ingestion_manifest.v1
+dataset_id: issue_4013_eth_biwi
+title: ETH/BIWI walking pedestrians annotations for #4013 real-trajectory smoke
+source:
+  url: https://vision.ee.ethz.ch/datsets.html
+  version: BIWI Walking Pedestrians annotations
+  citation: "Pellegrini et al., You'll Never Walk Alone: Modeling Social Behavior for Multi-target Tracking, ICCV 2009."
+  access_date: "2026-07-06"
+license:
+  name: upstream research dataset terms; local supplier must verify rights
+  url: null
+  posture: bring-your-own
+  supplier_acknowledgment: true
+  redistribution: false
+retrieval:
+  instructions: >-
+    Obtain the ETH/BIWI walking pedestrians annotation archive from the official
+    ETH Computer Vision Lab datasets page under its current terms. Extract the
+    raw annotation files into staging_dir. Do not commit raw annotations or
+    converted trajectory files. After staging, compute the aggregate SHA-256 tree
+    checksum, set checksums.tree_sha256 and expected_tree_sha256, and change
+    availability to validated before using the data for #4013 real-trajectory
+    training or representative evaluation.
+  download_url: null
+  fail_closed: true
+checksums:
+  algorithm: SHA-256
+  tree_sha256: null
+  expected_tree_sha256: null
+conversion:
+  frame_rate_hz: 2.5
+  length_unit: meters
+  coordinate_frame: world_meters_xy
+  timestamp_field: frame
+  agent_id_field: pedestrian_id
+  position_fields: [x, y]
+  map_context_field: scene
+  missing_data_behavior: fail_closed
+splits:
+  naming: scene
+  members: [eth, hotel]
+staging:
+  staging_dir: ${ROBOT_SF_EXTERNAL_DATA_ROOT}/issue_4013_eth_biwi
+  local_only_raw: true
+  durable_storage_target: local-only-byo
+privacy:
+  pii_reviewed: false
+  notes: >-
+    Public overhead pedestrian trajectories; local supplier must review current
+    upstream terms and privacy posture before marking availability validated.
+availability: missing
+benchmark_eligibility: diagnostic_only
+related_issues: [4013, 3065, 3973]

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -194,6 +194,14 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_4445_ch8_statistics_reproducibility/source_manifest.json
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
+++ b/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
@@ -26,7 +26,7 @@
   "blockers": [
     {
       "code": "real_trajectory.availability_not_validated",
-      "message": "Phase 3 requires a checksum-validated real trajectory dataset; manifest availability is is 'missing'."
+      "message": "Phase 3 requires a checksum-validated real trajectory dataset; manifest availability is 'missing'."
     }
   ],
   "claim_boundary": "Real-trajectory readiness only. No raw data is staged by this checker; no benchmark, navigation-quality, paper, or dissertation claim is made.",

--- a/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
+++ b/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
@@ -1,0 +1,40 @@
+{
+  "acceptance_evidence": [
+    {
+      "criterion": "short-horizon predictor trained",
+      "evidence": "Met at diagnostic tier by PR #4629 using seeded synthetic data; Phase 3 real-trajectory retraining remains blocked until this report reaches ready_for_real_trajectory_training."
+    },
+    {
+      "criterion": "model-based action selection runs on a smoke scenario",
+      "evidence": "Met at diagnostic tier by PR #4644 and PR #4655."
+    },
+    {
+      "criterion": "comparison against cv_prediction_mpc and one model-free baseline",
+      "evidence": "Met at diagnostic tier by PR #4655 with paired seed count 1; representative real-trajectory evaluation remains blocked by dataset readiness."
+    },
+    {
+      "criterion": "fallback/degraded rows are non-evidence",
+      "evidence": "Met by PR #4587 report contract and PR #4655 diagnostic report."
+    },
+    {
+      "criterion": "claim boundary excludes world-model and paper-grade claims",
+      "evidence": "Met in existing #4013 design/evidence docs; this report preserves that boundary."
+    }
+  ],
+  "availability": "missing",
+  "benchmark_eligibility": "diagnostic_only",
+  "blockers": [
+    {
+      "code": "real_trajectory.availability_not_validated",
+      "message": "Phase 3 requires a checksum-validated real trajectory dataset; manifest availability is is 'missing'."
+    }
+  ],
+  "claim_boundary": "Real-trajectory readiness only. No raw data is staged by this checker; no benchmark, navigation-quality, paper, or dissertation claim is made.",
+  "dataset_id": "issue_4013_eth_biwi",
+  "issue": 4013,
+  "manifest_path": "configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml",
+  "next_action": "Stage ETH/BIWI or another approved real pedestrian trajectory dataset under $ROBOT_SF_EXTERNAL_DATA_ROOT, validate its checksum, update the manifest, then run real-trajectory training and representative evaluation.",
+  "preflight_issues": [],
+  "schema_version": "issue_4013.real_trajectory_readiness.v1",
+  "status": "blocked_real_trajectory_data_unavailable"
+}

--- a/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md
+++ b/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md
@@ -1,0 +1,28 @@
+# Issue #4013 Real-Trajectory Readiness
+
+Status: `blocked_real_trajectory_data_unavailable`
+
+Claim boundary: real-trajectory readiness only. No raw data is staged, no full benchmark campaign is run, and no paper/dissertation claim is made.
+
+## Dataset Gate
+
+- Manifest: `configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml`
+- Dataset: `issue_4013_eth_biwi`
+- Availability: `missing`
+- Benchmark eligibility: `diagnostic_only`
+
+## Blockers
+
+- `real_trajectory.availability_not_validated`: Phase 3 requires a checksum-validated real trajectory dataset; manifest availability is is 'missing'.
+
+## Acceptance Evidence
+
+| Criterion | Evidence |
+| --- | --- |
+| short-horizon predictor trained | Met at diagnostic tier by PR #4629 using seeded synthetic data; Phase 3 real-trajectory retraining remains blocked until this report reaches ready_for_real_trajectory_training. |
+| model-based action selection runs on a smoke scenario | Met at diagnostic tier by PR #4644 and PR #4655. |
+| comparison against cv_prediction_mpc and one model-free baseline | Met at diagnostic tier by PR #4655 with paired seed count 1; representative real-trajectory evaluation remains blocked by dataset readiness. |
+| fallback/degraded rows are non-evidence | Met by PR #4587 report contract and PR #4655 diagnostic report. |
+| claim boundary excludes world-model and paper-grade claims | Met in existing #4013 design/evidence docs; this report preserves that boundary. |
+
+Next action: Stage ETH/BIWI or another approved real pedestrian trajectory dataset under $ROBOT_SF_EXTERNAL_DATA_ROOT, validate its checksum, update the manifest, then run real-trajectory training and representative evaluation.

--- a/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md
+++ b/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md
@@ -13,7 +13,7 @@ Claim boundary: real-trajectory readiness only. No raw data is staged, no full b
 
 ## Blockers
 
-- `real_trajectory.availability_not_validated`: Phase 3 requires a checksum-validated real trajectory dataset; manifest availability is is 'missing'.
+- `real_trajectory.availability_not_validated`: Phase 3 requires a checksum-validated real trajectory dataset; manifest availability is 'missing'.
 
 ## Acceptance Evidence
 

--- a/scripts/training/check_issue_4013_real_trajectory_readiness.py
+++ b/scripts/training/check_issue_4013_real_trajectory_readiness.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Fail-closed real-trajectory readiness report for issue #4013.
+
+The checker reads only a real-trajectory ingestion manifest. It never downloads,
+copies, or converts external data. The intended use is to keep #4013 Phase 3
+honest: diagnostic synthetic evidence remains useful, but real-trajectory
+training and representative evaluation stay blocked until a local dataset copy is
+checksum-validated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from robot_sf.data_ingestion.real_trajectory_contract import (
+    ContractError,
+    load_manifest,
+    run_preflight,
+)
+
+SCHEMA_VERSION = "issue_4013.real_trajectory_readiness.v1"
+DEFAULT_MANIFEST = Path("configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml")
+DEFAULT_OUTPUT_JSON = Path(
+    "docs/context/evidence/issue_4013_learned_model_based_planning/"
+    "real_trajectory_readiness.v1.json"
+)
+DEFAULT_OUTPUT_MARKDOWN = Path(
+    "docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md"
+)
+
+
+def build_report(manifest_path: Path) -> dict[str, Any]:
+    """Build #4013 Phase 3 readiness report from one manifest."""
+    try:
+        manifest = load_manifest(manifest_path)
+        preflight = run_preflight(manifest)
+        input_error: str | None = None
+    except (ContractError, jsonschema.ValidationError) as exc:
+        manifest = {}
+        preflight = None
+        input_error = str(exc)
+
+    if input_error:
+        status = "blocked_manifest_contract"
+        blockers = [{"code": "manifest.input_error", "message": input_error}]
+        dataset_id = None
+        availability = "unknown"
+        benchmark_eligibility = "unknown"
+        issues: list[dict[str, str]] = []
+    else:
+        assert preflight is not None
+        issues = [
+            {"code": issue.code, "severity": issue.severity, "message": issue.message}
+            for issue in preflight.issues
+        ]
+        dataset_id = preflight.dataset_id
+        availability = preflight.availability
+        benchmark_eligibility = preflight.benchmark_eligibility
+        blockers = [issue for issue in issues if issue["severity"] == "error"]
+        if blockers:
+            status = "blocked_manifest_contract"
+        elif availability != "validated":
+            status = "blocked_real_trajectory_data_unavailable"
+            blockers = [
+                {
+                    "code": "real_trajectory.availability_not_validated",
+                    "message": (
+                        "Phase 3 requires a checksum-validated real trajectory dataset; "
+                        f"manifest availability is is {availability!r}."
+                    ),
+                }
+            ]
+        elif benchmark_eligibility not in {"research_only", "benchmark_candidate"}:
+            status = "blocked_real_trajectory_not_evaluation_ready"
+            blockers = [
+                {
+                    "code": "real_trajectory.eligibility_too_low",
+                    "message": (
+                        "Representative evaluation requires research_only or "
+                        "benchmark_candidate eligibility; manifest currently records "
+                        f"{benchmark_eligibility!r}."
+                    ),
+                }
+            ]
+        else:
+            status = "ready_for_real_trajectory_training"
+
+    acceptance_evidence = [
+        {
+            "criterion": "short-horizon predictor trained",
+            "evidence": (
+                "Met at diagnostic tier by PR #4629 using seeded synthetic data; "
+                "Phase 3 real-trajectory retraining remains blocked until this report "
+                "reaches ready_for_real_trajectory_training."
+            ),
+        },
+        {
+            "criterion": "model-based action selection runs on a smoke scenario",
+            "evidence": "Met at diagnostic tier by PR #4644 and PR #4655.",
+        },
+        {
+            "criterion": "comparison against cv_prediction_mpc and one model-free baseline",
+            "evidence": (
+                "Met at diagnostic tier by PR #4655 with paired seed count 1; "
+                "representative real-trajectory evaluation remains blocked by dataset readiness."
+            ),
+        },
+        {
+            "criterion": "fallback/degraded rows are non-evidence",
+            "evidence": "Met by PR #4587 report contract and PR #4655 diagnostic report.",
+        },
+        {
+            "criterion": "claim boundary excludes world-model and paper-grade claims",
+            "evidence": "Met in existing #4013 design/evidence docs; this report preserves that boundary.",
+        },
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 4013,
+        "status": status,
+        "manifest_path": str(manifest_path),
+        "dataset_id": dataset_id,
+        "availability": availability,
+        "benchmark_eligibility": benchmark_eligibility,
+        "preflight_issues": issues,
+        "blockers": blockers,
+        "acceptance_evidence": acceptance_evidence,
+        "claim_boundary": (
+            "Real-trajectory readiness only. No raw data is staged by this checker; "
+            "no benchmark, navigation-quality, paper, or dissertation claim is made."
+        ),
+        "next_action": (
+            "Stage ETH/BIWI or another approved real pedestrian trajectory dataset under "
+            "$ROBOT_SF_EXTERNAL_DATA_ROOT, validate its checksum, update the manifest, "
+            "then run real-trajectory training and representative evaluation."
+        ),
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    """Render a compact human-readable report."""
+    lines = [
+        "# Issue #4013 Real-Trajectory Readiness",
+        "",
+        f"Status: `{report['status']}`",
+        "",
+        "Claim boundary: real-trajectory readiness only. No raw data is staged, no full "
+        "benchmark campaign is run, and no paper/dissertation claim is made.",
+        "",
+        "## Dataset Gate",
+        "",
+        f"- Manifest: `{report['manifest_path']}`",
+        f"- Dataset: `{report['dataset_id']}`",
+        f"- Availability: `{report['availability']}`",
+        f"- Benchmark eligibility: `{report['benchmark_eligibility']}`",
+        "",
+        "## Blockers",
+        "",
+    ]
+    blockers = report["blockers"]
+    if blockers:
+        lines.extend(f"- `{item['code']}`: {item['message']}" for item in blockers)
+    else:
+        lines.append("- None.")
+    lines.extend(["", "## Acceptance Evidence", "", "| Criterion | Evidence |", "| --- | --- |"])
+    for item in report["acceptance_evidence"]:
+        lines.append(f"| {item['criterion']} | {item['evidence']} |")
+    lines.extend(["", f"Next action: {report['next_action']}", ""])
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output-json", type=Path, default=DEFAULT_OUTPUT_JSON)
+    parser.add_argument("--output-markdown", type=Path, default=DEFAULT_OUTPUT_MARKDOWN)
+    parser.add_argument("--check", action="store_true", help="Do not write outputs; print JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the readiness checker and optionally write report artifacts."""
+    args = _build_parser().parse_args(argv)
+    report = build_report(args.manifest)
+    if args.check:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    args.output_markdown.parent.mkdir(parents=True, exist_ok=True)
+    args.output_markdown.write_text(render_markdown(report), encoding="utf-8")
+    print(json.dumps({"status": report["status"], "output_json": str(args.output_json)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/training/check_issue_4013_real_trajectory_readiness.py
+++ b/scripts/training/check_issue_4013_real_trajectory_readiness.py
@@ -74,7 +74,7 @@ def build_report(manifest_path: Path) -> dict[str, Any]:
                     "code": "real_trajectory.availability_not_validated",
                     "message": (
                         "Phase 3 requires a checksum-validated real trajectory dataset; "
-                        f"manifest availability is is {availability!r}."
+                        f"manifest availability is {availability!r}."
                     ),
                 }
             ]

--- a/tests/training/test_issue_4013_real_trajectory_readiness.py
+++ b/tests/training/test_issue_4013_real_trajectory_readiness.py
@@ -1,0 +1,117 @@
+"""Tests for the issue #4013 real-trajectory readiness checker."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+import yaml
+
+from scripts.training.check_issue_4013_real_trajectory_readiness import (
+    build_report,
+    render_markdown,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _manifest() -> dict:
+    return {
+        "schema": "robot_sf_real_trajectory_ingestion_manifest.v1",
+        "dataset_id": "issue_4013_test",
+        "title": "Issue 4013 test trajectories",
+        "source": {
+            "url": "https://example.org",
+            "version": "test",
+            "citation": "Test citation",
+            "access_date": "2026-07-06",
+        },
+        "license": {
+            "name": "test",
+            "url": None,
+            "posture": "bring-your-own",
+            "supplier_acknowledgment": True,
+            "redistribution": False,
+        },
+        "retrieval": {
+            "instructions": "Stage locally.",
+            "download_url": None,
+            "fail_closed": True,
+        },
+        "checksums": {
+            "algorithm": "SHA-256",
+            "tree_sha256": None,
+            "expected_tree_sha256": None,
+        },
+        "conversion": {
+            "frame_rate_hz": 2.5,
+            "length_unit": "meters",
+            "coordinate_frame": "world_meters_xy",
+            "timestamp_field": "frame",
+            "agent_id_field": "pedestrian_id",
+            "position_fields": ["x", "y"],
+            "map_context_field": "scene",
+            "missing_data_behavior": "fail_closed",
+        },
+        "splits": {"naming": "scene", "members": ["eth"]},
+        "staging": {
+            "staging_dir": "${ROBOT_SF_EXTERNAL_DATA_ROOT}/issue_4013_test",
+            "local_only_raw": True,
+            "durable_storage_target": "local-only-byo",
+        },
+        "privacy": {"pii_reviewed": True, "notes": "Test manifest only."},
+        "availability": "missing",
+        "benchmark_eligibility": "diagnostic_only",
+        "related_issues": [4013],
+    }
+
+
+def _write_manifest(tmp_path: Path, manifest: dict) -> Path:
+    path = tmp_path / "manifest.yaml"
+    path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def test_missing_real_dataset_blocks_phase3_without_contract_error(tmp_path: Path) -> None:
+    """Missing validated real data blocks Phase 3 without failing manifest structure."""
+    report = build_report(_write_manifest(tmp_path, _manifest()))
+
+    assert report["status"] == "blocked_real_trajectory_data_unavailable"
+    assert report["blockers"][0]["code"] == "real_trajectory.availability_not_validated"
+    assert report["preflight_issues"] == []
+
+
+def test_validated_research_manifest_is_ready_for_real_trajectory_training(tmp_path: Path) -> None:
+    """Checksum-validated research-eligible manifests unlock real-trajectory training."""
+    manifest = deepcopy(_manifest())
+    manifest["availability"] = "validated"
+    manifest["benchmark_eligibility"] = "research_only"
+    manifest["checksums"]["tree_sha256"] = "a" * 64
+    manifest["checksums"]["expected_tree_sha256"] = "a" * 64
+
+    report = build_report(_write_manifest(tmp_path, manifest))
+
+    assert report["status"] == "ready_for_real_trajectory_training"
+    assert report["blockers"] == []
+
+
+def test_manifest_contract_error_blocks_before_training(tmp_path: Path) -> None:
+    """Manifest contract violations block before any training/evaluation can run."""
+    manifest = _manifest()
+    manifest["license"]["supplier_acknowledgment"] = False
+
+    report = build_report(_write_manifest(tmp_path, manifest))
+
+    assert report["status"] == "blocked_manifest_contract"
+    assert report["blockers"][0]["code"] == "license.acknowledgment_missing"
+
+
+def test_markdown_contains_acceptance_evidence_and_claim_boundary(tmp_path: Path) -> None:
+    """Markdown report includes the closure-audit evidence and claim boundary."""
+    report = build_report(_write_manifest(tmp_path, _manifest()))
+    markdown = render_markdown(report)
+
+    assert "Issue #4013 Real-Trajectory Readiness" in markdown
+    assert "No raw data is staged" in markdown
+    assert "comparison against cv_prediction_mpc" in markdown


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds the #4013 Phase 3 real-trajectory readiness slice: an ETH/BIWI bring-your-own-data manifest, a fail-closed readiness checker, focused tests, and generated JSON/Markdown evidence under the existing #4013 evidence bundle.

Why now: merged PRs #4629, #4644, and #4655 satisfy the diagnostic synthetic/trained-checkpoint/paired-smoke criteria, but the live issue thread keeps #4013 open for real trajectory data plus representative evaluation. This PR turns that remaining blocker into a reproducible artifact instead of another readiness packet.

Claim boundary: readiness/provenance only. The current status is `blocked_real_trajectory_data_unavailable`; no raw data is downloaded, staged, committed, or treated as benchmark evidence.

Required validation: focused checker tests, manifest preflight, Ruff on touched Python, JSON artifact parse, and diff-scoped docs proof check.

Remaining blocker: stage ETH/BIWI or another approved real pedestrian trajectory dataset under `$ROBOT_SF_EXTERNAL_DATA_ROOT`, checksum-validate it, update the manifest to `availability: validated`, then run real-trajectory training plus representative evaluation.

Refs #4013

## Contract delta

New tracked manifest: `configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml` records official-source retrieval instructions, BYO license posture, conversion expectations, git-ignored staging root, checksum placeholders, and `availability: missing`.

New fail-closed checker: `scripts/training/check_issue_4013_real_trajectory_readiness.py` emits `issue_4013.real_trajectory_readiness.v1` with statuses:

- `blocked_manifest_contract`
- `blocked_real_trajectory_data_unavailable`
- `blocked_real_trajectory_not_evaluation_ready`
- `ready_for_real_trajectory_training`

Compatibility impact: additive only; no planner, benchmark runner, trainer semantics, or schema consumed by existing runtime paths changes. The checker reads metadata only and performs no network or filesystem staging of raw data.

## Acceptance criteria -> evidence

| Criterion | Evidence | Status |
| --- | --- | --- |
| Short-horizon predictor trained | PR #4629 trained a diagnostic synthetic checkpoint; this PR records real-trajectory retraining as blocked until dataset validation. | Diagnostic met; Phase 3 blocked |
| Model-based action selection runs on smoke scenario | PR #4644 and PR #4655 prove diagnostic checkpoint-backed action selection. | Met at diagnostic tier |
| Comparison against `cv_prediction_mpc` and one model-free baseline | PR #4655 produced paired 3-arm diagnostic report, `status=diagnostic_ready`, `paired_seed_count=1`. | Met at diagnostic tier |
| Fallback/degraded rows are non-evidence | PR #4587 report contract and PR #4655 diagnostic report exclude fallback/degraded evidence. | Met |
| No world-model or paper-grade overclaim | Existing #4013 evidence plus this readiness report keep diagnostic/readiness boundary explicit. | Met |
| Real trajectory data plus representative evaluation | `real_trajectory_readiness.v1.json` reports `blocked_real_trajectory_data_unavailable`. | Remaining blocker |

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/training/test_issue_4013_real_trajectory_readiness.py -q` -> passed, 4 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/training/check_issue_4013_real_trajectory_readiness.py tests/training/test_issue_4013_real_trajectory_readiness.py --output-format=concise` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/check_real_trajectory_manifest.py configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml --json` -> passed, `ok: true`, `availability: missing`, `benchmark_eligibility: diagnostic_only`.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/training/check_issue_4013_real_trajectory_readiness.py` -> passed, generated status `blocked_real_trajectory_data_unavailable`.
- `python -m json.tool docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json` -> passed.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` -> passed for 5 changed files.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no raw external dataset staging, no paper/dissertation claim edits, no issue comment due `comment_issue_or_pr=false` authorization.

## State propagation

High-churn issue state is propagated through the durable readiness artifact `docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.{json,md}` and this PR body. No transient queue-routing state was encoded in tracked files.

<details>
<summary>Operational notes</summary>

Fragmentation guard: more than two #4013 PRs merged in the last 24h, so this is a consolidation/progression slice, not another micro-guard. The nameable new capability is the real-trajectory readiness gate for Phase 3.

Late issue refresh: re-read #4013 before PR creation; no maintainer comments newer than the 2026-07-06 16:06 UTC state update were present. Open-PR dedupe search found no existing #4013 real-trajectory readiness PR.

Generated ignored local artifacts: `.venv/`, `.pytest_cache/`, `.ruff_cache/`, and `__pycache__/` are local validation byproducts and are not committed.

</details>
