### PR TITLE
Issue #4279: add SocNavBench ETH shape audit command

### DIFF
--- a/docs/datasets/socnavbench-s3dis-eth.md
+++ b/docs/datasets/socnavbench-s3dis-eth.md
@@ -55,3 +55,14 @@ uv run pytest tests/data/external/test_socnavbench_eth_shape.py
 With locally staged official assets, the same test loads `data.pkl` and checks the cheap structural
 contract. A successful pass is only local staging evidence; it is not a full benchmark campaign, a
 SocNavBench ETH map conversion, or a dissertation claim.
+
+To write a reviewable local audit artifact after staging official assets:
+
+```bash
+uv run python scripts/validation/check_socnavbench_eth_shape_contract.py \
+  --json-out output/validation/issue_4279/socnavbench_eth_shape_contract_audit.json
+```
+
+The command exits `0` only when the staged ETH mesh directory and traversible pickle satisfy the
+loader shape contract. Missing or malformed staged data exits `2` with a JSON report that names the
+missing path or malformed contract.

--- a/scripts/validation/check_socnavbench_eth_shape_contract.py
+++ b/scripts/validation/check_socnavbench_eth_shape_contract.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Emit a SocNavBench ETH staged-data shape-contract audit.
+
+This checker is intentionally local-data only: it never downloads, vendors, or
+redistributes SocNavBench/S3DIS assets. It composes the public
+``socnavbench_eth`` loader so the loader remains the shape-contract owner.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from robot_sf.data.external import socnavbench_eth
+
+REPORT_SCHEMA = "robot_sf_socnavbench_eth_shape_contract_audit.v1"
+ISSUE = 4279
+
+
+def _jsonable_path(path: Path) -> str:
+    """Return expanded absolute path for stable local audit output."""
+    return str(path.expanduser().resolve())
+
+
+def build_report(root: Path | str | None = None) -> tuple[dict[str, Any], int]:
+    """Build shape-contract report and matching process exit code.
+
+    Returns exit code ``0`` only when staged assets pass the real loader
+    contract. Missing or malformed local data exits ``2`` so automation can
+    distinguish "not ready" from a successful staged-data audit.
+    """
+    layout = socnavbench_eth.expected_layout(root)
+    report: dict[str, Any] = {
+        "schema": REPORT_SCHEMA,
+        "issue": ISSUE,
+        "asset_id": socnavbench_eth.ASSET_ID,
+        "ok": False,
+        "status": "missing",
+        "claim_boundary": (
+            "Local layout and cheap traversible shape only; not dataset-content "
+            "correctness, benchmark readiness, or paper/dissertation evidence."
+        ),
+        "no_download_performed": True,
+        "acquisition_doc": socnavbench_eth.ACQUISITION_DOC,
+        "root": _jsonable_path(layout.root),
+        "required_paths": {
+            "mesh_dir": {
+                "path": _jsonable_path(layout.mesh_dir),
+                "exists": layout.mesh_dir.is_dir(),
+                "kind": "directory",
+            },
+            "traversible_pickle": {
+                "path": _jsonable_path(layout.traversible_pickle),
+                "exists": layout.traversible_pickle.is_file(),
+                "kind": "file",
+            },
+        },
+    }
+
+    try:
+        contract = socnavbench_eth.load_shape_contract(root)
+    except socnavbench_eth.SocNavBenchEthDataError as exc:
+        report["error"] = str(exc)
+        if any(path["exists"] for path in report["required_paths"].values()):
+            report["status"] = "invalid"
+        return report, 2
+
+    report.update(
+        {
+            "ok": True,
+            "status": "passed",
+            "shape_contract": {
+                "resolution": contract.resolution,
+                "traversible_shape": list(contract.traversible_shape),
+                "traversible_dtype": contract.traversible_dtype,
+            },
+        }
+    )
+    return report, 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help=(
+            "Optional SocNavBench root. Defaults to the external-data registry "
+            "path for socnavbench-s3dis-eth."
+        ),
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=None,
+        help="Optional path to write the audit JSON. Stdout is always written.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the audit CLI."""
+    args = _parse_args(argv)
+    report, exit_code = build_report(args.root)
+    text = json.dumps(report, indent=2, sort_keys=True)
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/validation/test_check_socnavbench_eth_shape_contract.py
+++ b/tests/validation/test_check_socnavbench_eth_shape_contract.py
@@ -1,0 +1,79 @@
+"""Tests for the SocNavBench ETH shape-contract audit command."""
+
+from __future__ import annotations
+
+import json
+import pickle
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from robot_sf.data.external import socnavbench_eth
+from scripts.validation import check_socnavbench_eth_shape_contract as checker
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _stage_minimal_eth_fixture(root: Path) -> None:
+    """Create a tiny layout-compatible SocNavBench ETH fixture."""
+    layout = socnavbench_eth.expected_layout(root)
+    layout.mesh_dir.mkdir(parents=True)
+    (layout.mesh_dir / "mesh.obj").write_text("# synthetic mesh marker\n", encoding="utf-8")
+    layout.traversible_pickle.parent.mkdir(parents=True)
+    with layout.traversible_pickle.open("wb") as handle:
+        pickle.dump(
+            {
+                "resolution": 5.0,
+                "traversible": np.array([[True, False], [True, True]], dtype=bool),
+            },
+            handle,
+            protocol=2,
+        )
+
+
+def test_build_report_missing_data_fails_closed(tmp_path: Path) -> None:
+    """Missing staged data returns a fail-closed report."""
+    report, exit_code = checker.build_report(tmp_path / "socnavbench")
+
+    assert exit_code == 2
+    assert report["schema"] == checker.REPORT_SCHEMA
+    assert report["issue"] == 4279
+    assert report["asset_id"] == "socnavbench-s3dis-eth"
+    assert report["ok"] is False
+    assert report["status"] == "missing"
+    assert report["no_download_performed"] is True
+    assert report["required_paths"]["mesh_dir"]["exists"] is False
+    assert report["required_paths"]["traversible_pickle"]["exists"] is False
+
+
+def test_build_report_staged_data_passes_shape_contract(tmp_path: Path) -> None:
+    """Synthetic staged data exercises the passing shape-contract path."""
+    root = tmp_path / "socnavbench"
+    _stage_minimal_eth_fixture(root)
+
+    report, exit_code = checker.build_report(root)
+
+    assert exit_code == 0
+    assert report["ok"] is True
+    assert report["status"] == "passed"
+    assert report["shape_contract"] == {
+        "resolution": 5.0,
+        "traversible_dtype": "bool",
+        "traversible_shape": [2, 2],
+    }
+
+
+def test_main_writes_json_out_and_returns_missing(tmp_path: Path, capsys) -> None:
+    """CLI writes the same missing-data report to stdout and JSON output."""
+    report_path = tmp_path / "reports" / "audit.json"
+
+    exit_code = checker.main(
+        ["--root", str(tmp_path / "socnavbench"), "--json-out", str(report_path)]
+    )
+
+    assert exit_code == 2
+    stdout_report = json.loads(capsys.readouterr().out)
+    file_report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert stdout_report == file_report
+    assert file_report["status"] == "missing"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds `scripts/validation/check_socnavbench_eth_shape_contract.py`, a CPU-only SocNavBench ETH staged-data shape-contract audit command that emits JSON and returns `0` only when the official locally staged ETH mesh directory and traversible pickle satisfy the existing loader contract. It returns `2` for missing or malformed staged data. Tests cover missing-data fail-closed output, synthetic staged-data pass output, and `--json-out` artifact writing.

Why now: issue #4279 already has the loader, skip-if-absent tests, docs, and tracked closure-audit state from merged PRs #4286 and #4523. The remaining criterion is the license-gated staged-data pass; this PR adds the smallest reusable artifact-producing command for that pass without acquiring or storing raw data.

Claim boundary: local layout and cheap traversible shape only. This is not dataset-content correctness, benchmark readiness, SocNavBench ETH map conversion proof, or paper/dissertation evidence.

Required validation: run the command after staging official assets. On this host the official assets are absent, and the command intentionally reports `status: missing` with exit code `2`.

Remaining blocker: official SocNavBench/S3DIS ETH assets must still be acquired/staged under license terms before issue #4279 can close.

Refs #4279.

## Contract delta

- New schema: `robot_sf_socnavbench_eth_shape_contract_audit.v1` emitted by `scripts/validation/check_socnavbench_eth_shape_contract.py`.
- New fail-closed behavior: missing or malformed local SocNavBench ETH staged data exits `2` and writes a JSON report naming required paths and `docs/datasets/socnavbench-s3dis-eth.md`.
- Compatibility impact: no registry semantics change, no loader API change, no raw data path or download behavior added. Existing `scripts/tools/manage_external_data.py check socnavbench-s3dis-eth` behavior is unchanged.

## Acceptance evidence

| Criterion | Evidence | Status |
| --- | --- | --- |
| Add SocNavBench ETH loader/accessor module. | Merged PR #4286 added `robot_sf/data/external/socnavbench_eth.py` with `is_available`, `require_available`, `expected_layout`, and `load_shape_contract`. | Met |
| Skip-if-absent tests keep CI green without external data. | Merged PR #4286 added `tests/data/external/test_socnavbench_eth_shape.py`; this branch reran it with `2 passed, 1 skipped`. | Met |
| Acquisition/layout docs exist and name claim boundary. | Merged PR #4286 added `docs/datasets/socnavbench-s3dis-eth.md`; this PR adds the artifact-producing audit command to the validation section. | Met |
| Staged-data path deterministic through registry/root override. | Merged PR #4286 uses the existing `socnavbench-s3dis-eth` registry path. `manage_external_data.py --json check socnavbench-s3dis-eth` reports the expected missing paths on this host. | Met for path contract; not closed for real-data staging |
| Staged official assets execute and pass shape contract. | This PR adds `scripts/validation/check_socnavbench_eth_shape_contract.py` to produce the pass/fail JSON artifact once official assets are staged. Current host result is `status: missing`, exit code `2`. | Remaining external-input blocker |
| No raw SocNavBench/S3DIS data, download path, benchmark claim, or paper/dissertation claim. | Diff only adds validation command, tests, and docs pointer; no data bytes or download code. | Met |

## Validation

- `uv run ruff check scripts/validation/check_socnavbench_eth_shape_contract.py tests/validation/test_check_socnavbench_eth_shape_contract.py robot_sf/data tests/data/external/test_socnavbench_eth_shape.py` -> passed.
- `uv run pytest tests/validation/test_check_socnavbench_eth_shape_contract.py tests/data/external/test_socnavbench_eth_shape.py -q` -> `5 passed, 1 skipped`.
- `uv run pytest tests/tools/test_manage_external_data.py -q` -> `35 passed`.
- `uv run python scripts/validation/check_socnavbench_eth_shape_contract.py --json-out output/validation/issue_4279/socnavbench_eth_shape_contract_audit.json` -> expected exit code `2`, JSON `status: missing` because official ETH assets are not staged on this host.
- `uv run python scripts/tools/manage_external_data.py --json check socnavbench-s3dis-eth` -> expected exit code `2`, JSON `status: incomplete`, missing ETH mesh directory and traversible pickle.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no raw external-data acquisition or staging, no dataset download path, no paper/dissertation claim edits.

## Propagation

No separate issue comment or state-file update is included in this PR. Existing merged PR #4523 already created the durable `docs/context/issue_4279_state.yaml` not-ready state surface, run authorization disallows issue comments, and this PR body records the new behavior plus the remaining external-input blocker without adding transient queue-routing state to tracked files.

<details>
<summary>Freshness and dedupe</summary>

- `gh issue view 4279 --repo ll7/robot_sf_ll7 --comments` was retried immediately before PR publication but still fails on GitHub's deprecated classic Projects field: `repository.issue.projectCards`.
- REST fallback checked issue #4279 and all comments: issue still open, two comments, latest comment `2026-07-03T13:24:48Z`, no maintainer comments newer than this run.
- Open PR dedupe: `gh search prs 4279 --repo ll7/robot_sf_ll7 --state open` returned no open PRs.
- Fragmentation guard: only one prior #4279 closure-audit/state PR was found (#4523). This PR adds a nameable new capability: a reusable staged-data shape-contract audit command.

</details>
