### PR TITLE
Issue #3285: add target export manifests

### DIFF
--- a/docs/context/issue_3285_scenario_interop_converter.md
+++ b/docs/context/issue_3285_scenario_interop_converter.md
@@ -37,6 +37,17 @@ This is a fail-closed readiness projection, not a target artifact exporter.
 Use `--target socnavbench` or `--target hunavsim` on the dry-run CLI to include a selected target
 report in the stderr summary. Omitting `--target` reports both targets.
 
+## Target Export Manifest
+
+The converter can also write a deterministic, asset-free target export manifest
+(`robot_sf.scenario_interop_target_export_manifest.v1`) through `--target-out-dir`. This is a real
+JSON artifact contract for downstream adapters, but it is **not** a runnable SocNavBench or
+HuNavSim scenario file. When prerequisites are missing, the manifest remains fail-closed with
+`status: blocked`, `ready: false`, named blockers and warnings, and source scenario plus IR schema
+provenance.
+
+Generated files under `output/` remain worktree-local evidence unless promoted separately.
+
 ## IR contract
 
 The IR captures the scenario fields that are common across social-navigation testbeds:
@@ -70,23 +81,31 @@ uv run python scripts/tools/convert_scenario_interop.py --matrix configs/baselin
 
 # Write one <scenario_id>.ir.json per scenario
 uv run python scripts/tools/convert_scenario_interop.py \
-    --matrix configs/baselines/example_matrix.yaml --out-dir output/interop_ir
+  --matrix configs/baselines/example_matrix.yaml --out-dir output/interop_ir
+
+# Write fail-closed target export manifests
+uv run python scripts/tools/convert_scenario_interop.py \
+  --matrix configs/baselines/example_matrix.yaml \
+  --target socnavbench \
+  --target-out-dir output/issue_3285_target_export_manifest_smoke
 ```
 
-The CLI prints the IR to stdout and a `{"dry_run_summary": [...]}` block (scenario id, IR validity,
-unsupported-field count) to stderr. Exit code is non-zero if any scenario IR fails schema validation.
+The CLI prints the IR to stdout only when no output directory is requested and writes a
+`{"dry_run_summary": [...]}` block (scenario id, IR validity, unsupported-field count, target
+compatibility) to stderr. Exit code is non-zero if any scenario IR fails schema validation.
 
 ## Validation
 
 ```bash
 uv run python -m pytest tests/benchmark/test_scenario_interop.py -q          # 10 passed
 uv run python -m pytest tests/benchmark -k "scenario or convert or socnav" -q # 239 passed (issue cmd)
+uv run python scripts/tools/convert_scenario_interop.py --matrix configs/baselines/example_matrix.yaml --target socnavbench --target-out-dir output/issue_3285_target_export_manifest_smoke # 3 blocked manifests written
 ```
 
 ## Claim boundary / blocked-until
 
-- This is a **dry-run + IR validation** slice only. It makes no claim of simulator equivalence,
-  planner transferability, or benchmark-score parity (see the boundary in
+- This is a **dry-run + IR validation + target export manifest** slice only. It makes no claim of
+  simulator equivalence, planner transferability, or benchmark-score parity (see the boundary in
   [`issue_2928_...`](issue_2928_socnavbench_hunavsim_metric_correspondence.md)).
-- Emitting real SocNavBench/HuNavSim assets and running them is **blocked** on staged external
-  assets (#1456 / #1498 / #2414 / #1134) and is intentionally out of scope here.
+- Emitting real runnable SocNavBench/HuNavSim scenario assets and running them is **blocked** on
+  staged external assets (#1456 / #1498 / #2414 / #1134) and is intentionally out of scope here.

--- a/robot_sf/benchmark/scenario_interop.py
+++ b/robot_sf/benchmark/scenario_interop.py
@@ -46,6 +46,7 @@ IR_SCHEMA_VERSION = "robot_sf.scenario_interop_ir.v1"
 CONVERTER_NAME = "robot_sf.scenario_interop"
 CONVERTER_VERSION = "1"
 TARGET_COMPATIBILITY_SCHEMA_VERSION = "robot_sf.scenario_interop_target_compatibility.v1"
+TARGET_EXPORT_MANIFEST_SCHEMA_VERSION = "robot_sf.scenario_interop_target_export_manifest.v1"
 SUPPORTED_TARGETS = ("socnavbench", "hunavsim")
 IR_SCHEMA_FILE = Path(__file__).with_name("schemas") / "scenario_interop_ir.v1.json"
 
@@ -406,6 +407,33 @@ def build_target_compatibility_report(
             }
         )
     return reports
+
+
+def build_target_export_manifest(ir: Mapping[str, Any], *, target: str) -> dict[str, Any]:
+    """Build a deterministic, fail-closed target export manifest.
+
+    The manifest is the asset-free artifact contract for downstream target exporters. It is not a
+    SocNavBench or HuNavSim scenario file; when target prerequisites are missing, it records the
+    named blockers that prevented real export.
+
+    Returns:
+        JSON-safe target export manifest with readiness status, blockers, and warnings.
+    """
+
+    report = build_target_compatibility_report(ir, targets=(target,))[0]
+    status = "ready" if report["ready"] else "blocked"
+    return {
+        "schema_version": TARGET_EXPORT_MANIFEST_SCHEMA_VERSION,
+        "artifact_kind": f"{target}_scenario_export_manifest",
+        "target": target,
+        "source_scenario_id": report["source_scenario_id"],
+        "source_ir_schema_version": ir.get("schema_version"),
+        "status": status,
+        "ready": report["ready"],
+        "blockers": report["blockers"],
+        "warnings": report["warnings"],
+        "compatibility_report_schema_version": report["schema_version"],
+    }
 
 
 def _target_blockers(ir: Mapping[str, Any], *, target: str) -> list[dict[str, str]]:

--- a/scripts/tools/convert_scenario_interop.py
+++ b/scripts/tools/convert_scenario_interop.py
@@ -33,6 +33,7 @@ import yaml
 from robot_sf.benchmark.scenario_interop import (
     SUPPORTED_TARGETS,
     build_target_compatibility_report,
+    build_target_export_manifest,
     convert_scenario_to_ir,
     dump_ir,
 )
@@ -84,6 +85,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Optional directory to write one <scenario_id>.ir.json file per scenario.",
     )
     parser.add_argument(
+        "--target-out-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Optional directory to write one <scenario_id>.<target>.export_manifest.json "
+            "fail-closed target export manifest per scenario and requested target."
+        ),
+    )
+    parser.add_argument(
         "--target",
         action="append",
         choices=SUPPORTED_TARGETS,
@@ -98,12 +108,19 @@ def main(argv: list[str] | None = None) -> int:
     scenarios = _load_scenarios(args.matrix)
     if args.out_dir is not None:
         args.out_dir.mkdir(parents=True, exist_ok=True)
+    if args.target_out_dir is not None:
+        args.target_out_dir.mkdir(parents=True, exist_ok=True)
 
     exit_code = 0
     summary: list[dict[str, Any]] = []
     for scenario in scenarios:
         result = convert_scenario_to_ir(scenario, source_file=str(args.matrix))
         scenario_id = result.ir["provenance"]["source_scenario_id"]
+        targets = args.target or SUPPORTED_TARGETS
+        target_compatibility = build_target_compatibility_report(
+            result.ir,
+            targets=targets,
+        )
         if not result.is_valid:
             exit_code = 1
         summary.append(
@@ -112,16 +129,20 @@ def main(argv: list[str] | None = None) -> int:
                 "ir_valid": result.is_valid,
                 "unsupported_field_count": len(result.unsupported_fields),
                 "schema_errors": result.schema_errors,
-                "target_compatibility": build_target_compatibility_report(
-                    result.ir,
-                    targets=args.target or SUPPORTED_TARGETS,
-                ),
+                "target_compatibility": target_compatibility,
             }
         )
         if args.out_dir is not None:
             out_path = args.out_dir / f"{scenario_id}.ir.json"
             out_path.write_text(dump_ir(result.ir), encoding="utf-8")
-        else:
+        if args.target_out_dir is not None:
+            for target in targets:
+                manifest = build_target_export_manifest(result.ir, target=target)
+                manifest_path = args.target_out_dir / (
+                    f"{scenario_id}.{target}.export_manifest.json"
+                )
+                manifest_path.write_text(dump_ir(manifest), encoding="utf-8")
+        if args.out_dir is None and args.target_out_dir is None:
             sys.stdout.write(dump_ir(result.ir))
 
     sys.stderr.write(json.dumps({"dry_run_summary": summary}, indent=2) + "\n")

--- a/tests/benchmark/test_scenario_interop_target_compatibility.py
+++ b/tests/benchmark/test_scenario_interop_target_compatibility.py
@@ -6,8 +6,11 @@ import pytest
 
 from robot_sf.benchmark.scenario_interop import (
     TARGET_COMPATIBILITY_SCHEMA_VERSION,
+    TARGET_EXPORT_MANIFEST_SCHEMA_VERSION,
     build_target_compatibility_report,
+    build_target_export_manifest,
     convert_scenario_to_ir,
+    dump_ir,
 )
 
 
@@ -72,6 +75,40 @@ def test_target_compatibility_report_names_axis_scenario_export_gaps() -> None:
     assert "map_file_missing" in blocker_codes
     assert "agents_missing" in blocker_codes
     assert report["warnings"] == []
+
+
+def test_target_export_manifest_records_blocked_artifact_contract() -> None:
+    """Export manifest preserves blockers without claiming target artifact readiness."""
+    result = convert_scenario_to_ir(_explicit_map_scenario())
+
+    manifest = build_target_export_manifest(result.ir, target="socnavbench")
+
+    assert manifest["schema_version"] == TARGET_EXPORT_MANIFEST_SCHEMA_VERSION
+    assert manifest["artifact_kind"] == "socnavbench_scenario_export_manifest"
+    assert manifest["target"] == "socnavbench"
+    assert manifest["source_scenario_id"] == "corridor-handoff"
+    assert manifest["source_ir_schema_version"] == result.ir["schema_version"]
+    assert manifest["status"] == "blocked"
+    assert manifest["ready"] is False
+    assert manifest["compatibility_report_schema_version"] == TARGET_COMPATIBILITY_SCHEMA_VERSION
+    assert {blocker["code"] for blocker in manifest["blockers"]} >= {
+        "socnavbench_assets_not_staged",
+        "unsupported_fields_present",
+    }
+
+
+def test_target_export_manifest_is_deterministic() -> None:
+    """Identical target manifest inputs serialize byte-identically."""
+    first = build_target_export_manifest(
+        convert_scenario_to_ir(_explicit_map_scenario()).ir,
+        target="hunavsim",
+    )
+    second = build_target_export_manifest(
+        convert_scenario_to_ir(_explicit_map_scenario()).ir,
+        target="hunavsim",
+    )
+
+    assert dump_ir(first) == dump_ir(second)
 
 
 def test_target_compatibility_report_rejects_unknown_target() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds an asset-free, deterministic target export manifest for Robot SF -> SocNavBench/HuNavSim scenario interop. The manifest is exposed through `build_target_export_manifest()` and `scripts/tools/convert_scenario_interop.py --target-out-dir`, and records fail-closed blockers instead of emitting runnable external benchmark assets.

Why now: issue #3285 already has the base intermediate representation (IR) converter from PR #3735 and target compatibility reports from PR #4562. The remaining issue state says real exports are blocked on staged assets/adapters; this PR delivers the smallest local progression slice: a concrete target export artifact contract that downstream adapters can consume once those prerequisites land.

Claim boundary: this is not benchmark evidence, not a SocNavBench/HuNavSim runnable scenario export, and not a cross-suite equivalence claim. All generated target manifests remain `status: blocked` while external assets/adapters are missing.

Required validation: focused interop tests, Ruff on changed code/tests, the issue benchmark selector, CLI manifest smoke, and PR readiness freshness.

Remaining blocker: runnable SocNavBench/HuNavSim scenario export still depends on staged assets/adapters tracked by #1456, #1498, #2414, and #1134.

Refs #3285

## Contract delta

- New manifest schema identifier: `robot_sf.scenario_interop_target_export_manifest.v1`.
- New API: `build_target_export_manifest(ir, target=...)`.
- New CLI option: `--target-out-dir`, writing one `<scenario_id>.<target>.export_manifest.json` per scenario and requested target.
- New manifest fields: `schema_version`, `artifact_kind`, `target`, `source_scenario_id`, `source_ir_schema_version`, `status`, `ready`, `blockers`, `warnings`, `compatibility_report_schema_version`.
- Fail-closed behavior: manifests preserve target compatibility blockers and use `status: blocked` / `ready: false` until target prerequisites are satisfied.
- Compatibility impact: additive API/CLI behavior only; existing IR schema, default stdout behavior, and `--out-dir` IR output remain compatible.

## Acceptance evidence

| Issue #3285 criterion | Evidence |
| --- | --- |
| Converter output schema-validates deterministic fixture scenario. | PR #3735 added `scenario_interop_ir.v1`, `convert_scenario_to_ir()`, deterministic `dump_ir()`, CLI, and tests. Current branch preserves that and `uv run python -m pytest tests/benchmark/test_scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py -q` passes. |
| Unsupported fields reported explicitly instead of silently dropped. | PR #3735 added `unsupported_fields`; PR #4562 added target compatibility blockers for unsupported source fields; this PR carries those blockers into the target export manifest. |
| Smoke dry-run command documented. | PR #3735 documented the IR dry-run CLI; this PR updates `docs/context/issue_3285_scenario_interop_converter.md` with `--target-out-dir` smoke usage and validates it locally. |
| Issue links external asset prerequisites required for full run. | Issue body and merged PR #4562 identify #1456, #1498, #2414, and #1134 as blockers; this PR keeps those blockers explicit in docs and generated manifests. |
| Real SocNavBench/HuNavSim artifact export. | Not complete. PR #4562's maintainer state says real export remains blocked on external assets/adapters. This PR adds the smallest local artifact contract toward export but does not claim runnable target assets. |

## Validation

- `uv run ruff check robot_sf/benchmark/scenario_interop.py scripts/tools/convert_scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py` - passed.
- `uv run python -m pytest tests/benchmark/test_scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py -q` - 15 passed.
- `uv run python -m pytest tests/benchmark -k "scenario or convert or socnav" -q` - passed after `uv sync --all-extras`; initial fresh-worktree attempt failed during collection on missing optional deps (`torch`, `duckdb`).
- `uv run python scripts/tools/convert_scenario_interop.py --matrix configs/baselines/example_matrix.yaml --target socnavbench --target-out-dir output/issue_3285_target_export_manifest_smoke` - exit 0; wrote 3 blocked SocNavBench export manifests; no IR stdout emitted in target-output-only mode.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue3285/pr_body.md scripts/dev/pr_ready_check.sh` - passed on the pushed branch head before PR open.

## Remaining checklist

- [ ] Stage or otherwise make available the required SocNavBench/HuNavSim assets/adapters (#1456, #1498, #2414, #1134).
- [ ] Implement real target-specific artifact writers that consume this manifest/IR contract.
- [ ] Run target-side preflight or smoke execution before treating any converted artifact as runnable external benchmark evidence.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No transient queue-routing state encoded in tracked files.
- No issue comment/state propagation was performed from this run because `comment_issue_or_pr` was not authorized; the PR body is the single durable propagation surface for this low-churn issue slice.

<details>
<summary>Audit notes</summary>

- Live issue comment from 2026-07-05 after PR #4562: base IR + target compatibility reporting exists; real export stays open/blocked on #1456, #1498, #2414, #1134.
- Direct issue implementation PRs reviewed: #3735 and #4562.
- Cross-referenced supporting PRs reviewed: #3596 (platform boundary note) and #3740 (presence-only cross-benchmark readiness checker).
- Fragmentation guard: only PR #4562 matched issue #3285 merged in the last 24h; this PR is a progression slice with a new export-manifest capability, not a guardrail/checker refresh.

</details>
