### PR TITLE
Issue #3557: add uncertainty-source generalization report

### DIFF
--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -9,6 +9,9 @@ Recent Package C prediction/observation closure audit:
 Recent uncertainty-representation generalization closure audit:
 [closure_audit.md](evidence/issue_3557_uncertainty_representation_generalization/closure_audit.md).
 
+Recent uncertainty-source generalization diagnostic evidence:
+[README.md](evidence/issue_3557_uncertainty_source_generalization/README.md).
+
 Recent reactivity-vs-replay rank-study closure audit:
 [issue_3637_closure_audit_2026-07-05.md](evidence/issue_3637_closure_audit_2026-07-05.md).
 

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -65,6 +65,10 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_3557_uncertainty_source_generalization
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_3463_topology_reselection_cross_slice_2026-07-05
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_3557_uncertainty_source_generalization/README.md
+++ b/docs/context/evidence/issue_3557_uncertainty_source_generalization/README.md
@@ -1,0 +1,31 @@
+# Issue #3557 Uncertainty-Source Generalization
+
+Plain-language summary: this artifact runs the controlled #3471 episode harness across registered ScenarioBelief uncertainty sources. It records per-source oracle/retained/dropped aggregate decisions without promoting the diagnostic result into benchmark evidence.
+
+- Issue: #3557
+- Schema: `uncertainty_source_generalization_report.v1`
+- Evidence tier: `diagnostic`
+- Generalization verdict: `generalizes`
+- Seeds: `[101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112]`
+- Command: `uv run python scripts/validation/run_uncertainty_source_generalization_issue_3557.py --config configs/benchmarks/scenario_belief_episode_safety_issue_3471.yaml`
+
+## Claim Boundary
+
+Controlled #3471 crossing scenario using real stream_gap planner and ScenarioBelief uncertainty gate. This is diagnostic-tier uncertainty-source generalization evidence only: no full benchmark campaign, no Slurm/GPU submission, no paper/dissertation claim.
+
+This is not a full benchmark campaign result. It does not use Slurm or GPU resources and does not edit paper or dissertation claims.
+
+## Per-Source Decisions
+
+| Source | Condition builder | Decision | Unsafe-rate delta | Min-separation delta (m) |
+| --- | --- | --- | ---: | ---: |
+| existence_degradation | _condition_existence_degraded | reproduces_unsafe_drop | 16.75 | -0.4518 |
+| visibility_occlusion | _condition_visibility_limited | inconclusive | 0.0 | 0.0 |
+| covariance_inflation | _condition_covariance_inflated | reproduces_unsafe_drop | 16.75 | -0.4518 |
+| class_probability | _condition_class_probability | reproduces_unsafe_drop | 16.75 | -0.4518 |
+| tracking_noise | _condition_tracking_noise | reproduces_unsafe_drop | 18.333333 | -0.0713 |
+
+Detailed machine-readable outputs:
+
+- `summary.json`
+- `per_source_decisions.csv`

--- a/docs/context/evidence/issue_3557_uncertainty_source_generalization/per_source_decisions.csv
+++ b/docs/context/evidence/issue_3557_uncertainty_source_generalization/per_source_decisions.csv
@@ -1,0 +1,6 @@
+source,condition_builder,harness_decision,source_decision,classifier_verdict,episodes,retained_unsafe_commit_rate,dropped_unsafe_commit_rate,unsafe_commit_rate_delta_dropped_minus_retained,retained_worst_min_separation_m,dropped_worst_min_separation_m,min_separation_delta_dropped_minus_retained_m,uncertainty_consumed_any,fail_closed_any
+existence_degradation,_condition_existence_degraded,revise,reproduces_unsafe_drop,reproduces_unsafe_dropping,12,3.75,20.5,16.75,-0.1694,-0.6212,-0.4518,True,False
+visibility_occlusion,_condition_visibility_limited,inconclusive,inconclusive,inconclusive,12,20.5,20.5,0.0,-0.6212,-0.6212,0.0,True,False
+covariance_inflation,_condition_covariance_inflated,revise,reproduces_unsafe_drop,reproduces_unsafe_dropping,12,3.75,20.5,16.75,-0.1694,-0.6212,-0.4518,True,False
+class_probability,_condition_class_probability,revise,reproduces_unsafe_drop,reproduces_unsafe_dropping,12,3.75,20.5,16.75,-0.1694,-0.6212,-0.4518,True,False
+tracking_noise,_condition_tracking_noise,revise,reproduces_unsafe_drop,reproduces_unsafe_dropping,12,2.166667,20.5,18.333333,-0.5499,-0.6212,-0.0713,True,False

--- a/docs/context/evidence/issue_3557_uncertainty_source_generalization/summary.json
+++ b/docs/context/evidence/issue_3557_uncertainty_source_generalization/summary.json
@@ -1,0 +1,175 @@
+{
+  "claim_boundary": "Controlled #3471 crossing scenario using real stream_gap planner and ScenarioBelief uncertainty gate. This is diagnostic-tier uncertainty-source generalization evidence only: no full benchmark campaign, no Slurm/GPU submission, no paper/dissertation claim.",
+  "decision_layer": {
+    "evidence_kind": "diagnostic_proxy",
+    "generalization": "generalizes",
+    "inconclusive_sources": [
+      "visibility_occlusion"
+    ],
+    "n_sources": 5,
+    "per_source": [
+      {
+        "min_separation_delta_m": -0.4518,
+        "n_episodes": 12,
+        "source": "existence_degradation",
+        "unsafe_commit_delta": 16.75,
+        "verdict": "reproduces_unsafe_dropping"
+      },
+      {
+        "min_separation_delta_m": 0.0,
+        "n_episodes": 12,
+        "source": "visibility_occlusion",
+        "unsafe_commit_delta": 0.0,
+        "verdict": "inconclusive"
+      },
+      {
+        "min_separation_delta_m": -0.4518,
+        "n_episodes": 12,
+        "source": "covariance_inflation",
+        "unsafe_commit_delta": 16.75,
+        "verdict": "reproduces_unsafe_dropping"
+      },
+      {
+        "min_separation_delta_m": -0.4518,
+        "n_episodes": 12,
+        "source": "class_probability",
+        "unsafe_commit_delta": 16.75,
+        "verdict": "reproduces_unsafe_dropping"
+      },
+      {
+        "min_separation_delta_m": -0.0713,
+        "n_episodes": 12,
+        "source": "tracking_noise",
+        "unsafe_commit_delta": 18.333333333333332,
+        "verdict": "reproduces_unsafe_dropping"
+      }
+    ],
+    "reproducing_sources": [
+      "class_probability",
+      "covariance_inflation",
+      "existence_degradation",
+      "tracking_noise"
+    ],
+    "schema_version": "uncertainty_source_generalization.v1"
+  },
+  "evidence_tier": "diagnostic",
+  "generalization": "generalizes",
+  "issue": 3557,
+  "params": {
+    "corridor_x": 5.0,
+    "dt": 0.1,
+    "goal_x": 9.0,
+    "max_steps": 120,
+    "near_miss_margin": 0.6,
+    "path_y": 5.0,
+    "ped_cross_speed": 0.7,
+    "ped_radius": 0.3,
+    "robot_radius": 0.4,
+    "start_x": 2.0
+  },
+  "per_source": [
+    {
+      "classifier_verdict": "reproduces_unsafe_dropping",
+      "condition_builder": "_condition_existence_degraded",
+      "dropped_unsafe_commit_rate": 20.5,
+      "dropped_worst_min_separation_m": -0.6212,
+      "episodes": 12,
+      "fail_closed_any": false,
+      "harness_decision": "revise",
+      "min_separation_delta_dropped_minus_retained_m": -0.4518,
+      "retained_unsafe_commit_rate": 3.75,
+      "retained_worst_min_separation_m": -0.1694,
+      "source": "existence_degradation",
+      "source_decision": "reproduces_unsafe_drop",
+      "uncertainty_consumed_any": true,
+      "unsafe_commit_rate_delta_dropped_minus_retained": 16.75
+    },
+    {
+      "classifier_verdict": "inconclusive",
+      "condition_builder": "_condition_visibility_limited",
+      "dropped_unsafe_commit_rate": 20.5,
+      "dropped_worst_min_separation_m": -0.6212,
+      "episodes": 12,
+      "fail_closed_any": false,
+      "harness_decision": "inconclusive",
+      "min_separation_delta_dropped_minus_retained_m": 0.0,
+      "retained_unsafe_commit_rate": 20.5,
+      "retained_worst_min_separation_m": -0.6212,
+      "source": "visibility_occlusion",
+      "source_decision": "inconclusive",
+      "uncertainty_consumed_any": true,
+      "unsafe_commit_rate_delta_dropped_minus_retained": 0.0
+    },
+    {
+      "classifier_verdict": "reproduces_unsafe_dropping",
+      "condition_builder": "_condition_covariance_inflated",
+      "dropped_unsafe_commit_rate": 20.5,
+      "dropped_worst_min_separation_m": -0.6212,
+      "episodes": 12,
+      "fail_closed_any": false,
+      "harness_decision": "revise",
+      "min_separation_delta_dropped_minus_retained_m": -0.4518,
+      "retained_unsafe_commit_rate": 3.75,
+      "retained_worst_min_separation_m": -0.1694,
+      "source": "covariance_inflation",
+      "source_decision": "reproduces_unsafe_drop",
+      "uncertainty_consumed_any": true,
+      "unsafe_commit_rate_delta_dropped_minus_retained": 16.75
+    },
+    {
+      "classifier_verdict": "reproduces_unsafe_dropping",
+      "condition_builder": "_condition_class_probability",
+      "dropped_unsafe_commit_rate": 20.5,
+      "dropped_worst_min_separation_m": -0.6212,
+      "episodes": 12,
+      "fail_closed_any": false,
+      "harness_decision": "revise",
+      "min_separation_delta_dropped_minus_retained_m": -0.4518,
+      "retained_unsafe_commit_rate": 3.75,
+      "retained_worst_min_separation_m": -0.1694,
+      "source": "class_probability",
+      "source_decision": "reproduces_unsafe_drop",
+      "uncertainty_consumed_any": true,
+      "unsafe_commit_rate_delta_dropped_minus_retained": 16.75
+    },
+    {
+      "classifier_verdict": "reproduces_unsafe_dropping",
+      "condition_builder": "_condition_tracking_noise",
+      "dropped_unsafe_commit_rate": 20.5,
+      "dropped_worst_min_separation_m": -0.6212,
+      "episodes": 12,
+      "fail_closed_any": false,
+      "harness_decision": "revise",
+      "min_separation_delta_dropped_minus_retained_m": -0.0713,
+      "retained_unsafe_commit_rate": 2.166667,
+      "retained_worst_min_separation_m": -0.5499,
+      "source": "tracking_noise",
+      "source_decision": "reproduces_unsafe_drop",
+      "uncertainty_consumed_any": true,
+      "unsafe_commit_rate_delta_dropped_minus_retained": 18.333333
+    }
+  ],
+  "schema_version": "uncertainty_source_generalization_report.v1",
+  "seed_count": 12,
+  "seeds": [
+    101,
+    102,
+    103,
+    104,
+    105,
+    106,
+    107,
+    108,
+    109,
+    110,
+    111,
+    112
+  ],
+  "sources": [
+    "existence_degradation",
+    "visibility_occlusion",
+    "covariance_inflation",
+    "class_probability",
+    "tracking_noise"
+  ]
+}

--- a/scripts/validation/run_scenario_belief_episode_safety_issue_3471.py
+++ b/scripts/validation/run_scenario_belief_episode_safety_issue_3471.py
@@ -38,7 +38,11 @@ import numpy as np
 from robot_sf.gym_env.unified_config import RobotSimulationConfig
 from robot_sf.planner.scenario_belief_adapter import project_scenario_belief_for_planner
 from robot_sf.planner.stream_gap import StreamGapPlannerAdapter, StreamGapPlannerConfig
-from robot_sf.representation import Estimate2D, scenario_belief_from_simulator_oracle
+from robot_sf.representation import (
+    Estimate2D,
+    VisibilityState,
+    scenario_belief_from_simulator_oracle,
+)
 
 SCHEMA_VERSION = "scenario-belief-episode-safety.v1"
 ISSUE = 3471
@@ -76,6 +80,35 @@ UNCERTAINTY_REPRESENTATIONS: dict[str, dict[str, str]] = {
     "envelope_inflation": {
         "gate_field": "uncertainty_max_position_variance",
         "description": "inflate corridor-agent position variance above the stream_gap envelope gate",
+    },
+}
+
+#: Issue #3557 uncertainty-source registry mapped to the existing #2546 condition owners.
+UNCERTAINTY_SOURCES: dict[str, dict[str, str]] = {
+    "existence_degradation": {
+        "condition_builder": "_condition_existence_degraded",
+        "gate_field": "uncertainty_min_existence_probability",
+        "description": "degrade corridor-agent existence confidence below stream_gap gate",
+    },
+    "visibility_occlusion": {
+        "condition_builder": "_condition_visibility_limited",
+        "gate_field": "visibility_filter",
+        "description": "mark corridor agent occluded with policy position and velocity missing",
+    },
+    "covariance_inflation": {
+        "condition_builder": "_condition_covariance_inflated",
+        "gate_field": "uncertainty_max_position_variance",
+        "description": "inflate corridor-agent position covariance above stream_gap gate",
+    },
+    "class_probability": {
+        "condition_builder": "_condition_class_probability",
+        "gate_field": "uncertainty_min_class_probability",
+        "description": "spread corridor-agent class probabilities below stream_gap gate",
+    },
+    "tracking_noise": {
+        "condition_builder": "_condition_tracking_noise",
+        "gate_field": "tracking_noise_proxy",
+        "description": "shift corridor-agent tracked position with stale observation metadata",
     },
 }
 
@@ -188,11 +221,58 @@ def _degrade_agent_for_representation(agent: Any, uncertainty_representation: st
     raise ValueError(f"unknown uncertainty representation: {uncertainty_representation}")
 
 
+def _degrade_agent_for_source(agent: Any, uncertainty_source: str) -> Any:
+    """Apply one issue #3557 uncertainty-source condition to the corridor agent."""
+    if uncertainty_source == "existence_degradation":
+        return replace(agent, existence_probability=_DEGRADED_EXISTENCE)
+    if uncertainty_source == "visibility_occlusion":
+        return replace(
+            agent,
+            visibility_state=VisibilityState.OCCLUDED,
+            last_observed_age_s=1.0,
+            missing_fields=("policy_position", "policy_velocity"),
+        )
+    if uncertainty_source == "covariance_inflation":
+        return replace(
+            agent,
+            position=Estimate2D.point(
+                agent.position.mean_xy,
+                confidence=agent.position.confidence,
+                variance=_INFLATED_POSITION_VARIANCE,
+                frame_id=agent.position.frame_id,
+                units=agent.position.units,
+                covariance_units=agent.position.covariance_units,
+            ),
+        )
+    if uncertainty_source == "class_probability":
+        return replace(
+            agent,
+            class_probabilities=(("pedestrian", 0.3), ("cyclist", 0.4), ("unknown", 0.3)),
+        )
+    if uncertainty_source == "tracking_noise":
+        shifted = np.asarray(agent.position.mean_xy, dtype=float) + np.array([0.35, -0.2])
+        return replace(
+            agent,
+            position=Estimate2D.point(
+                (float(shifted[0]), float(shifted[1])),
+                confidence=0.35,
+                variance=1.2,
+                frame_id=agent.position.frame_id,
+                units=agent.position.units,
+                covariance_units=agent.position.covariance_units,
+            ),
+            last_observed_age_s=1.0,
+            missing_fields=("fresh_track",),
+        )
+    raise ValueError(f"unknown uncertainty source: {uncertainty_source}")
+
+
 def build_belief_for_mode(
     state: ScenarioState,
     mode: str,
     params: EpisodeParams,
     uncertainty_representation: str = "belief_drop",
+    uncertainty_source: str = "existence_degradation",
 ) -> Any:
     """Build the ScenarioBelief for ``mode`` from the current ground-truth state.
 
@@ -201,6 +281,8 @@ def build_belief_for_mode(
     """
     if uncertainty_representation not in UNCERTAINTY_REPRESENTATIONS:
         raise ValueError(f"unknown uncertainty representation: {uncertainty_representation}")
+    if uncertainty_source not in UNCERTAINTY_SOURCES:
+        raise ValueError(f"unknown uncertainty source: {uncertainty_source}")
     simulator = _make_simulator(state, params)
     belief = scenario_belief_from_simulator_oracle(
         simulator, env_config=RobotSimulationConfig(), max_pedestrians=4
@@ -218,7 +300,19 @@ def build_belief_for_mode(
             np.linalg.norm(np.asarray(agents[i].position.mean_xy, dtype=float) - corridor_true)
         ),
     )
-    agents[idx] = _degrade_agent_for_representation(agents[idx], uncertainty_representation)
+    if (
+        uncertainty_representation != "belief_drop"
+        and uncertainty_source != "existence_degradation"
+    ):
+        raise ValueError(
+            "non-default uncertainty_source is only supported with belief_drop "
+            "uncertainty_representation"
+        )
+    agents[idx] = (
+        _degrade_agent_for_source(agents[idx], uncertainty_source)
+        if uncertainty_source != "existence_degradation"
+        else _degrade_agent_for_representation(agents[idx], uncertainty_representation)
+    )
     return replace(belief, agents=tuple(agents))
 
 
@@ -275,6 +369,7 @@ def run_episode(
     params: EpisodeParams,
     gate_thresholds: dict[str, float] | None = None,
     uncertainty_representation: str = "belief_drop",
+    uncertainty_source: str = "existence_degradation",
 ) -> dict[str, Any]:
     """Roll one controlled episode under ``mode`` and return episode-level safety metrics.
 
@@ -299,7 +394,13 @@ def run_episode(
     fail_closed = False
 
     for step in range(params.max_steps):
-        belief = build_belief_for_mode(state, mode, params, uncertainty_representation)
+        belief = build_belief_for_mode(
+            state,
+            mode,
+            params,
+            uncertainty_representation=uncertainty_representation,
+            uncertainty_source=uncertainty_source,
+        )
         projection = project_scenario_belief_for_planner(belief, planner_key=PLANNER_KEY)
         status = projection.compatibility.get("status")
         if status == "fail_closed":
@@ -338,6 +439,7 @@ def run_episode(
     return {
         "mode": mode,
         "uncertainty_representation": uncertainty_representation,
+        "uncertainty_source": uncertainty_source,
         "seed": seed,
         "collision": collision,
         "min_separation": round(min_sep, 4),
@@ -408,10 +510,21 @@ def run_matrix(
     seeds: list[int],
     params: EpisodeParams,
     uncertainty_representation: str = "belief_drop",
+    uncertainty_source: str = "existence_degradation",
 ) -> dict[str, Any]:
     """Run all modes across the seed matrix and assemble the classified report."""
     if uncertainty_representation not in UNCERTAINTY_REPRESENTATIONS:
         raise ValueError(f"unknown uncertainty representation: {uncertainty_representation}")
+    if uncertainty_source not in UNCERTAINTY_SOURCES:
+        raise ValueError(f"unknown uncertainty source: {uncertainty_source}")
+    if (
+        uncertainty_representation != "belief_drop"
+        and uncertainty_source != "existence_degradation"
+    ):
+        raise ValueError(
+            "non-default uncertainty_source is only supported with belief_drop "
+            "uncertainty_representation"
+        )
     episodes: dict[str, list[dict[str, Any]]] = {}
     by_mode: dict[str, dict[str, Any]] = {}
     for mode in MODES:
@@ -421,6 +534,7 @@ def run_matrix(
                 seed,
                 params,
                 uncertainty_representation=uncertainty_representation,
+                uncertainty_source=uncertainty_source,
             )
             for seed in seeds
         ]
@@ -432,6 +546,7 @@ def run_matrix(
         "followup_issue": 3557,
         "evidence_tier": "diagnostic",
         "uncertainty_representation": uncertainty_representation,
+        "uncertainty_source": uncertainty_source,
         "uncertainty_representation_contract": {
             "available_representations": sorted(UNCERTAINTY_REPRESENTATIONS),
             "selected": UNCERTAINTY_REPRESENTATIONS[uncertainty_representation],
@@ -439,6 +554,14 @@ def run_matrix(
                 "Harness-level representation parameterization only; each run remains a "
                 "controlled #3471 episode contrast and is not a cross-representation "
                 "generalization claim."
+            ),
+        },
+        "uncertainty_source_contract": {
+            "available_sources": sorted(UNCERTAINTY_SOURCES),
+            "selected": UNCERTAINTY_SOURCES[uncertainty_source],
+            "claim_boundary": (
+                "Harness-level source parameterization only; each run remains "
+                "controlled #3471 episode contrast and must be reported per source."
             ),
         },
         "claim_boundary": (
@@ -483,6 +606,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "representation applied to the corridor agent."
         ),
     )
+    parser.add_argument(
+        "--uncertainty-source",
+        choices=sorted(UNCERTAINTY_SOURCES),
+        default="existence_degradation",
+        help=(
+            "Issue #3557 harness parameter. Selects ScenarioBelief uncertainty "
+            "source condition for the corridor agent."
+        ),
+    )
     parser.add_argument("--output-json", type=Path, default=None)
     return parser.parse_args(argv)
 
@@ -502,6 +634,7 @@ def main(argv: list[str] | None = None) -> int:
         seeds,
         params,
         uncertainty_representation=args.uncertainty_representation,
+        uncertainty_source=args.uncertainty_source,
     )
     report["generated_at_utc"] = datetime.now(UTC).isoformat()
 

--- a/scripts/validation/run_uncertainty_source_generalization_issue_3557.py
+++ b/scripts/validation/run_uncertainty_source_generalization_issue_3557.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Run issue #3557 uncertainty-source generalization report.
+
+This composes the controlled #3471 ScenarioBelief episode harness across the
+registered uncertainty sources. The output is diagnostic-tier evidence only:
+it is not a full benchmark campaign and does not promote paper-facing claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from robot_sf.representation.uncertainty_source_generalization import (
+    INCONCLUSIVE,
+    NO_EFFECT,
+    REPRODUCES,
+    SourceContrast,
+    assess_source_generalization,
+)
+from scripts.validation.run_scenario_belief_episode_safety_issue_3471 import (
+    UNCERTAINTY_SOURCES,
+    EpisodeParams,
+    load_config,
+    run_matrix,
+)
+
+ISSUE = 3557
+SCHEMA_VERSION = "uncertainty_source_generalization_report.v1"
+DEFAULT_CONFIG = Path("configs/benchmarks/scenario_belief_episode_safety_issue_3471.yaml")
+DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_3557_uncertainty_source_generalization")
+DEFAULT_SOURCES = tuple(UNCERTAINTY_SOURCES)
+CLAIM_BOUNDARY = (
+    "Controlled #3471 crossing scenario using real stream_gap planner and ScenarioBelief "
+    "uncertainty gate. This is diagnostic-tier uncertainty-source generalization evidence "
+    "only: no full benchmark campaign, no Slurm/GPU submission, no paper/dissertation claim."
+)
+
+_ISSUE_DECISIONS = {
+    REPRODUCES: "reproduces_unsafe_drop",
+    NO_EFFECT: "no_measurable_difference",
+    INCONCLUSIVE: "inconclusive",
+}
+
+
+def _unsafe_commit_rate(report: dict[str, Any], mode: str) -> float:
+    """Return unsafe-commit rate for one mode aggregate."""
+    aggregate = report["by_mode"][mode]
+    episodes = int(aggregate["episodes"])
+    if episodes <= 0:
+        raise ValueError(f"mode {mode!r} has no episodes")
+    return float(aggregate["total_unsafe_commit_steps"]) / episodes
+
+
+def contrast_from_source_report(report: dict[str, Any]) -> SourceContrast:
+    """Convert one source harness report into the merged issue #3557 classifier input."""
+    retained = report["by_mode"]["uncertain_retained"]
+    dropped = report["by_mode"]["uncertain_dropped"]
+    return SourceContrast(
+        source=str(report["uncertainty_source"]),
+        retained_unsafe_commit_rate=_unsafe_commit_rate(report, "uncertain_retained"),
+        dropped_unsafe_commit_rate=_unsafe_commit_rate(report, "uncertain_dropped"),
+        min_separation_delta_m=round(
+            float(dropped["worst_min_separation"]) - float(retained["worst_min_separation"]),
+            6,
+        ),
+        n_episodes=int(dropped["episodes"]),
+    )
+
+
+def _row_from_source_report(
+    report: dict[str, Any],
+    verdict_by_source: dict[str, str],
+) -> dict[str, Any]:
+    """Return one CSV/Markdown row for a source report."""
+    retained = report["by_mode"]["uncertain_retained"]
+    dropped = report["by_mode"]["uncertain_dropped"]
+    source = str(report["uncertainty_source"])
+    retained_rate = _unsafe_commit_rate(report, "uncertain_retained")
+    dropped_rate = _unsafe_commit_rate(report, "uncertain_dropped")
+    verdict = verdict_by_source[source]
+    return {
+        "source": source,
+        "condition_builder": report["uncertainty_source_contract"]["selected"]["condition_builder"],
+        "harness_decision": report["decision"]["decision"],
+        "source_decision": _ISSUE_DECISIONS.get(verdict, "blocked"),
+        "classifier_verdict": verdict,
+        "episodes": dropped["episodes"],
+        "retained_unsafe_commit_rate": round(retained_rate, 6),
+        "dropped_unsafe_commit_rate": round(dropped_rate, 6),
+        "unsafe_commit_rate_delta_dropped_minus_retained": round(dropped_rate - retained_rate, 6),
+        "retained_worst_min_separation_m": retained["worst_min_separation"],
+        "dropped_worst_min_separation_m": dropped["worst_min_separation"],
+        "min_separation_delta_dropped_minus_retained_m": round(
+            float(dropped["worst_min_separation"]) - float(retained["worst_min_separation"]),
+            6,
+        ),
+        "uncertainty_consumed_any": dropped["uncertainty_consumed_any"],
+        "fail_closed_any": dropped["fail_closed_any"],
+    }
+
+
+def build_report(
+    *,
+    seeds: list[int],
+    params: EpisodeParams,
+    sources: list[str],
+) -> dict[str, Any]:
+    """Run all requested sources and assemble issue #3557 diagnostic report."""
+    unknown = sorted(set(sources) - set(UNCERTAINTY_SOURCES))
+    if unknown:
+        raise ValueError(f"unknown uncertainty source(s): {unknown}")
+
+    source_reports = [run_matrix(seeds, params, uncertainty_source=source) for source in sources]
+    decision_layer = assess_source_generalization(
+        [contrast_from_source_report(report) for report in source_reports]
+    )
+    verdict_by_source = {
+        str(row["source"]): str(row["verdict"]) for row in decision_layer["per_source"]
+    }
+    rows = [_row_from_source_report(report, verdict_by_source) for report in source_reports]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": ISSUE,
+        "evidence_tier": "diagnostic",
+        "claim_boundary": CLAIM_BOUNDARY,
+        "sources": list(sources),
+        "seed_count": len(seeds),
+        "seeds": seeds,
+        "params": vars(params),
+        "generalization": decision_layer["generalization"],
+        "decision_layer": decision_layer,
+        "per_source": rows,
+        "source_reports": source_reports,
+    }
+
+
+def write_report_artifacts(report: dict[str, Any], output_dir: Path, command: str) -> None:
+    """Write compact tracked source-generalization artifacts."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = output_dir / "summary.json"
+    csv_path = output_dir / "per_source_decisions.csv"
+    readme_path = output_dir / "README.md"
+
+    compact = dict(report)
+    compact.pop("source_reports", None)
+    summary_path.write_text(json.dumps(compact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    fieldnames = list(report["per_source"][0].keys()) if report["per_source"] else []
+    with csv_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(report["per_source"])
+
+    rows = "\n".join(
+        "| {source} | {condition_builder} | {source_decision} | "
+        "{unsafe_commit_rate_delta_dropped_minus_retained} | "
+        "{min_separation_delta_dropped_minus_retained_m} |".format(**row)
+        for row in report["per_source"]
+    )
+    readme_path.write_text(
+        "\n".join(
+            [
+                "# Issue #3557 Uncertainty-Source Generalization",
+                "",
+                "Plain-language summary: this artifact runs the controlled #3471 "
+                "episode harness across registered ScenarioBelief uncertainty sources. "
+                "It records per-source oracle/retained/dropped aggregate decisions "
+                "without promoting the diagnostic result into benchmark evidence.",
+                "",
+                f"- Issue: #{ISSUE}",
+                f"- Schema: `{SCHEMA_VERSION}`",
+                f"- Evidence tier: `{report['evidence_tier']}`",
+                f"- Generalization verdict: `{report['generalization']}`",
+                f"- Seeds: `{report['seeds']}`",
+                f"- Command: `{command}`",
+                "",
+                "## Claim Boundary",
+                "",
+                CLAIM_BOUNDARY,
+                "",
+                "This is not a full benchmark campaign result. It does not use Slurm "
+                "or GPU resources and does not edit paper or dissertation claims.",
+                "",
+                "## Per-Source Decisions",
+                "",
+                "| Source | Condition builder | Decision | Unsafe-rate delta | "
+                "Min-separation delta (m) |",
+                "| --- | --- | --- | ---: | ---: |",
+                rows,
+                "",
+                "Detailed machine-readable outputs:",
+                "",
+                "- `summary.json`",
+                "- `per_source_decisions.csv`",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--seeds", type=int, nargs="+", default=None)
+    parser.add_argument("--max-steps", type=int, default=None)
+    parser.add_argument("--sources", choices=sorted(UNCERTAINTY_SOURCES), nargs="+", default=None)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = parse_args(argv)
+    seeds, params = (
+        load_config(args.config)
+        if args.config is not None
+        else (list(range(101, 113)), EpisodeParams())
+    )
+    if args.seeds is not None:
+        seeds = args.seeds
+    if args.max_steps is not None:
+        params = replace(params, max_steps=args.max_steps)
+    sources = list(args.sources or DEFAULT_SOURCES)
+    report = build_report(seeds=seeds, params=params, sources=sources)
+    try:
+        script = Path(__file__).resolve().relative_to(Path.cwd().resolve())
+    except ValueError:
+        script = Path(__file__).name
+    command_args = sys.argv[1:] if argv is None else argv
+    command = " ".join(["uv run python", str(script), *command_args])
+    write_report_artifacts(report, args.output_dir, command)
+    compact = {
+        "schema_version": report["schema_version"],
+        "issue": report["issue"],
+        "evidence_tier": report["evidence_tier"],
+        "generalization": report["generalization"],
+        "seed_count": report["seed_count"],
+        "source_count": len(report["sources"]),
+        "output_dir": str(args.output_dir),
+    }
+    print(json.dumps(compact, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/validation/test_run_scenario_belief_episode_safety_issue_3471.py
+++ b/tests/validation/test_run_scenario_belief_episode_safety_issue_3471.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from robot_sf.planner.scenario_belief_adapter import project_scenario_belief_for_planner
+from robot_sf.representation import VisibilityState
 from scripts.validation.run_scenario_belief_episode_safety_issue_3471 import (
     MODES,
     UNCERTAINTY_REPRESENTATIONS,
+    UNCERTAINTY_SOURCES,
     EpisodeParams,
     _is_commit,
     build_belief_for_mode,
@@ -88,6 +91,45 @@ def test_unknown_uncertainty_representation_fails_closed():
         raise AssertionError("unknown uncertainty representation was accepted")
 
 
+def test_each_uncertainty_source_runs_and_is_reported():
+    """Issue #3557 harness parameterizes source and reports the selected contract."""
+    for source in UNCERTAINTY_SOURCES:
+        row = run_episode(
+            "uncertain_dropped",
+            seed=101,
+            params=_FAST,
+            uncertainty_source=source,
+        )
+        assert row["uncertainty_source"] == source
+
+        report = run_matrix([101], _FAST, uncertainty_source=source)
+        assert report["followup_issue"] == 3557
+        assert report["uncertainty_source"] == source
+        assert report["uncertainty_source_contract"]["selected"]["condition_builder"]
+        assert (
+            "controlled #3471 episode contrast"
+            in (report["uncertainty_source_contract"]["claim_boundary"])
+        )
+        assert set(report["by_mode"]) == set(MODES)
+
+
+def test_unknown_uncertainty_source_fails_closed():
+    """Unknown uncertainty-source names fail closed instead silently using default."""
+    with pytest.raises(ValueError, match="unknown uncertainty source"):
+        run_matrix([101], _FAST, uncertainty_source="unknown")
+
+
+def test_mixed_non_default_representation_and_source_fails_closed():
+    """The harness does not produce ambiguous mixed representation/source evidence."""
+    with pytest.raises(ValueError, match="non-default uncertainty_source"):
+        run_matrix(
+            [101],
+            _FAST,
+            uncertainty_representation="conformal_radius",
+            uncertainty_source="visibility_occlusion",
+        )
+
+
 def test_retained_matches_oracle():
     """Retaining uncertain agents (gate off) is behaviorally identical to oracle.
 
@@ -131,6 +173,43 @@ def test_degraded_mode_lowers_corridor_existence():
     min_dropped = min(a.existence_probability for a in dropped.agents)
     assert min_dropped < min_oracle
     assert min_dropped < 0.5
+
+
+def test_uncertainty_source_conditions_mutate_corridor_belief():
+    """Registered source conditions reuse #2546-style belief perturbations."""
+    state = build_initial_state(101, _FAST)
+
+    occluded = build_belief_for_mode(
+        state,
+        "uncertain_dropped",
+        _FAST,
+        uncertainty_source="visibility_occlusion",
+    )
+    assert any(agent.visibility_state == VisibilityState.OCCLUDED for agent in occluded.agents)
+
+    covariance = build_belief_for_mode(
+        state,
+        "uncertain_dropped",
+        _FAST,
+        uncertainty_source="covariance_inflation",
+    )
+    assert max(float(np.max(agent.position.covariance_xy)) for agent in covariance.agents) > 1.0
+
+    class_probability = build_belief_for_mode(
+        state,
+        "uncertain_dropped",
+        _FAST,
+        uncertainty_source="class_probability",
+    )
+    assert any(len(agent.class_probabilities) > 1 for agent in class_probability.agents)
+
+    tracking = build_belief_for_mode(
+        state,
+        "uncertain_dropped",
+        _FAST,
+        uncertainty_source="tracking_noise",
+    )
+    assert any("fresh_track" in agent.missing_fields for agent in tracking.agents)
 
 
 def test_is_commit_detects_commit_speed():

--- a/tests/validation/test_run_uncertainty_source_generalization_issue_3557.py
+++ b/tests/validation/test_run_uncertainty_source_generalization_issue_3557.py
@@ -1,0 +1,79 @@
+"""Tests issue #3557 uncertainty-source generalization report runner."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.validation.run_scenario_belief_episode_safety_issue_3471 import (
+    UNCERTAINTY_SOURCES,
+    EpisodeParams,
+    run_matrix,
+)
+from scripts.validation.run_uncertainty_source_generalization_issue_3557 import (
+    CLAIM_BOUNDARY,
+    SCHEMA_VERSION,
+    build_report,
+    contrast_from_source_report,
+    write_report_artifacts,
+)
+
+_FAST = EpisodeParams(max_steps=40)
+
+
+def test_contrast_from_source_report_uses_source_and_dropped_minus_retained_deltas() -> None:
+    """Source report converts into the merged issue #3557 contrast primitive."""
+    report = run_matrix([101, 102], _FAST, uncertainty_source="existence_degradation")
+    contrast = contrast_from_source_report(report)
+    assert contrast.source == "existence_degradation"
+    assert contrast.n_episodes == 2
+    assert contrast.dropped_unsafe_commit_rate >= 0.0
+    assert isinstance(contrast.min_separation_delta_m, float)
+
+
+def test_build_report_runs_all_requested_sources() -> None:
+    """Report includes one visible decision row per requested uncertainty source."""
+    sources = ["existence_degradation", "visibility_occlusion", "covariance_inflation"]
+    report = build_report(seeds=[101, 102], params=_FAST, sources=sources)
+
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["issue"] == 3557
+    assert "no full benchmark campaign" in report["claim_boundary"]
+    assert [row["source"] for row in report["per_source"]] == sources
+    assert {entry["source"] for entry in report["decision_layer"]["per_source"]} == set(sources)
+    assert {row["condition_builder"] for row in report["per_source"]}
+
+
+def test_unknown_source_fails_closed() -> None:
+    """Unknown source names fail closed before producing a report."""
+    with pytest.raises(ValueError, match="unknown uncertainty source"):
+        build_report(seeds=[101], params=_FAST, sources=["unknown"])
+
+
+def test_write_report_artifacts(tmp_path) -> None:
+    """Writer emits README, summary, and per-source CSV with claim boundary."""
+    report = build_report(
+        seeds=[101],
+        params=_FAST,
+        sources=["existence_degradation", "class_probability"],
+    )
+    write_report_artifacts(report, tmp_path, "uv run python source-script")
+
+    summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+    assert summary["schema_version"] == SCHEMA_VERSION
+    assert "source_reports" not in summary
+    assert (
+        (tmp_path / "per_source_decisions.csv")
+        .read_text(encoding="utf-8")
+        .startswith("source,condition_builder")
+    )
+    readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert CLAIM_BOUNDARY in readme
+    assert "not a full benchmark campaign" in readme
+
+
+def test_default_source_registry_matches_harness_sources() -> None:
+    """Report runner and harness share the same source registry."""
+    report = build_report(seeds=[101], params=_FAST, sources=list(UNCERTAINTY_SOURCES))
+    assert report["sources"] == list(UNCERTAINTY_SOURCES)


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds the missing issue #3557 uncertainty-source execution slice. The #3471 controlled episode harness now accepts `--uncertainty-source existence_degradation|visibility_occlusion|covariance_inflation|class_probability|tracking_noise`, records source metadata in episode/matrix output, and fails closed for unsupported or ambiguous mixed source/representation settings. A new source report runner writes tracked diagnostic evidence under `docs/context/evidence/issue_3557_uncertainty_source_generalization/`.

Why now: the live #3557 thread still showed the source-parameterized harness/report as the remaining in-scope CPU work after merged PRs #3593, #3603, #4235, #4481, and #4595. The latest issue comment before PR prep was from 2026-07-05 and said the issue remained open; no newer guidance appeared during the required refresh.

Claim boundary: diagnostic controlled-scenario evidence only. The generated report uses the #3471 crossing harness with 12 seeds across 5 uncertainty sources; it does not run a full benchmark campaign and does not edit paper/dissertation claims. Source outcomes are visible: four sources reproduce the unsafe-drop effect and `visibility_occlusion` is inconclusive; the existing classifier reports `generalizes` across measurable sources while listing the inconclusive source separately.

Required validation: focused source/harness tests, Ruff lint/format, generated tracked evidence, and final PR readiness attempted after worktree bootstrap.

Remaining blocker: no code/test/evidence-generation blocker remains for the issue contract. Full benchmark campaign/Slurm promotion remains explicitly out of scope for this PR and the current task.

## Contract delta

- New CLI/API contract: `scripts/validation/run_scenario_belief_episode_safety_issue_3471.py --uncertainty-source <source>`.
- New source registry: `UNCERTAINTY_SOURCES` maps issue #3557 source keys to existing condition-builder owners.
- New report writer: `scripts/validation/run_uncertainty_source_generalization_issue_3557.py`.
- New tracked evidence: `docs/context/evidence/issue_3557_uncertainty_source_generalization/{README.md,summary.json,per_source_decisions.csv}`.
- New fail-closed blockers: unknown source names and mixed non-default representation/source settings raise `ValueError`; argparse choices reject unsupported CLI source names.
- Compatibility impact: default behavior remains `belief_drop` + `existence_degradation`, preserving #3471 behavior and existing representation report calls.
- State propagation: updated `docs/context/INDEX.md` and `docs/context/catalog.yaml`; no issue comment was posted because this run was not authorized to comment on issues/PRs.

## Linked Issues

Closes #3557

## Scope summary

- Parameterized the controlled #3471 harness by the five uncertainty-source keys named in #3557.
- Added per-source diagnostic report generation using the merged `uncertainty_source_generalization.v1` classifier.
- Added focused tests for source registry execution, unsupported-source failure, mixed-source/representation failure, source belief mutations, report structure, and artifact writing.

## Validation / Proof

```bash
scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_run_scenario_belief_episode_safety_issue_3471.py tests/validation/test_run_uncertainty_source_generalization_issue_3557.py tests/representation/test_uncertainty_source_generalization.py -q
# 18 passed
```

```bash
scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/run_scenario_belief_episode_safety_issue_3471.py scripts/validation/run_uncertainty_source_generalization_issue_3557.py tests/validation/test_run_scenario_belief_episode_safety_issue_3471.py tests/validation/test_run_uncertainty_source_generalization_issue_3557.py
# All checks passed
```

```bash
scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/run_scenario_belief_episode_safety_issue_3471.py scripts/validation/run_uncertainty_source_generalization_issue_3557.py tests/validation/test_run_scenario_belief_episode_safety_issue_3471.py tests/validation/test_run_uncertainty_source_generalization_issue_3557.py
# 4 files already formatted
```

```bash
scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/run_uncertainty_source_generalization_issue_3557.py --config configs/benchmarks/scenario_belief_episode_safety_issue_3471.yaml
# wrote docs/context/evidence/issue_3557_uncertainty_source_generalization; summary: schema uncertainty_source_generalization_report.v1, generalization generalizes, 12 seeds, 5 sources
```

```bash
scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml
# exit 1: unrelated pre-existing catalog entries point at ignored output/ artifacts
```

```bash
PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh
# first exit 2: missing analytics deps in fresh worktree; after `uv sync --all-extras`, exit 2: PR body source missing
# rerun with PR_READY_PR_BODY_FILE after this body was prepared before PR open
```

## Explicit out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No fallback/degraded benchmark execution counted as success.

<details>
<summary>Appendix: template fields</summary>

## Stack / Dependency

- Base dependency: origin/main.
- Required prior PRs: #3593, #3603, #4235, #4481, #4595 already merged.
- Stack follow-up issues: none opened.
- Safe review independently: yes.
- Review dependency reason, any: source slice composes already-merged decision layer and #3471 harness.

## What Changed

- Added uncertainty-source registry and source-aware belief perturbations to the #3471 harness.
- Added source report runner and tracked evidence artifacts.
- Added tests and context catalog/index entries.

## Why Matters

- Added value: closes the source-specific gap left after prior representation-only evidence.
- Expected impact: reviewers can inspect per-source oracle/retained/dropped diagnostic outcomes without a campaign run.
- Why worth merging now: this is the smallest CPU-only slice that produces the real missing #3557 outputs.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: whether the unsafe-dropping effect generalizes across existing ScenarioBelief uncertainty sources in the controlled #3471 episode harness.
- Comparator or baseline, applicable: oracle / uncertain_retained / uncertain_dropped arms over common seeds.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only, with `visibility_occlusion` inconclusive.
- Decision stop rule, applicable: record per-source decisions and do not promote to benchmark/paper claim.
- Parent issue, claim map, registry, context note, synthesis surface update: #3557; `docs/context/evidence/issue_3557_uncertainty_source_generalization/`; context index/catalog.
- New research/benchmark/metric/paper-facing analysis tool, any: report writer used on tracked config `configs/benchmarks/scenario_belief_episode_safety_issue_3471.yaml`.

## Domain-Aware Approval

Required PR: yes
Required: yes
Required for this PR: yes
Required for PR: yes
Domains reviewed: diagnostic source-generalization evidence, claim boundary, fallback/degraded exclusions
Status: waived
Approver/review source waiver: self-reviewed diagnostic-only CPU harness/report slice; reviewer should verify claim boundary
Approver/review source or waiver: self-reviewed diagnostic-only CPU harness/report slice; reviewer should verify claim boundary
Validity checklist: per-source rows visible; inconclusive source not hidden; fallback/degraded benchmark execution not counted
Target claim/hypothesis: diagnostic #3471 source generalization only
Comparator or split/evidence validity: common seed contract across source arms
Fallback/degraded exclusions: full benchmark fallback/degraded modes not used
Claim boundary: no full benchmark campaign, no Slurm/GPU, no paper/dissertation claim
Implementation integrity vs experimental validity: implementation adds harness/report mechanics; diagnostic outcome remains limited

## Falsification / Non-Transfer Check

- Did mechanism activate? yes for four measurable sources; `visibility_occlusion` remained inconclusive.
- Did intervention change command source, selected command, trajectory, route progress? diagnostic report records unsafe-rate/min-separation deltas.
- Did scenario actually contain targeted failure mode? yes for existence/covariance/class/tracking rows; no measurable visibility row effect.
- Result route: continue only if a separate benchmark-promotion task is intentionally scoped.
- Follow-up question issue weak, negative, non-transfer results: none opened.

## Next Empirical Action

- Rerun needed: no for #3557 CPU diagnostic contract.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: no.
- Stop / revise / continue decision: stop for #3557 CPU source-generalization contract; any benchmark campaign promotion belongs to a separate campaign lane.
- Proposed child issue existing follow-up: none opened.

## Risks / Rollout

- Compatibility risks: low; defaults preserve existing behavior.
- Failure modes: source perturbations are controlled-scenario proxies and should not be interpreted as sensor-model fidelity.
- Rollback fallback plan: revert this commit; existing representation evidence remains intact.

## Docs / Provenance

- Updated docs: context index/catalog and tracked evidence README/summary/CSV.
- Relevant design provenance notes: #3557 issue plan comments through 2026-07-05.
- Any assumptions need preserved: current task treats campaign/Slurm execution as out of scope.

## Downstream Propagation

- Parent issue updated: no, issue commenting not authorized.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: artifact catalog yes.
- Registry or config index updated: NA.
- Context index / memory note updated: yes.
- Follow-up issue opened deferred propagation: no.
- Not applicable because: diagnostic-only source evidence, no benchmark/paper claim.

## Follow-Up Issues

- Deferred work: none for #3557 CPU diagnostic contract.
- Issues opened follow-up: none.

## Reviewer Notes

- Verify `visibility_occlusion` remains explicitly inconclusive and is not hidden by the overall `generalizes` classifier verdict.
- Verify this PR does not encode transient queue-routing state.

</details>
