### PR TITLE
Issue #1475: verify closure state surface

### DIFF
--- a/docs/context/evidence/issue_1475_acceptance_audit_2026-07-06.json
+++ b/docs/context/evidence/issue_1475_acceptance_audit_2026-07-06.json
@@ -34,7 +34,8 @@
   "checked_paths": [
     "docs/context/evidence/issue_1475_orca_residual_bc_smoke_12913_2026-06-17/summary.json",
     "docs/context/evidence/issue_1475_orca_residual_bc_smoke_12913_2026-06-17/source_slurm_checksum_manifest.sha256",
-    "docs/context/evidence/issue_1475_closure_audit_2026-07-06.md"
+    "docs/context/evidence/issue_1475_closure_audit_2026-07-06.md",
+    "docs/context/issue_1475_state.yaml"
   ],
   "claim_boundary": "CPU-only acceptance audit over tracked evidence; no Slurm/GPU submission, benchmark campaign, training run, or paper-facing claim.",
   "closure_audit_contains_issue_1475": true,
@@ -69,5 +70,12 @@
     "status": "invalid"
   },
   "source_thread_summary": "Issue #1475 live thread reviewed via gh api on 2026-07-06; latest maintainer comment remains the 2026-07-05 post-PR #4561 gate update.",
+  "state_surface": {
+    "entry_status": "cpu_contract_delivered__external_slurm_rerun_pending",
+    "errors": [],
+    "latest_recorded_at_utc": "2026-07-06T16:38:00Z",
+    "path": "docs/context/issue_1475_state.yaml",
+    "status": "valid"
+  },
   "status": "blocked"
 }

--- a/docs/context/issue_1475_state.yaml
+++ b/docs/context/issue_1475_state.yaml
@@ -30,7 +30,7 @@ entries:
       hours. This entry is the single durable state propagation surface for the
       high-churn issue, not another guardrail/checker slice.
     closure_boundary:
-      closure_call_for_this_pr: "refs_not_closes"
+      closure_call_for_this_pr: "keep_open"
       reason: >-
         The executable acceptance audit remains fail-closed over tracked evidence:
         smoke evidence is recorded, fallback/degraded success is excluded, but
@@ -56,7 +56,7 @@ entries:
           checksum, but the tracked smoke summary has no durable
           artifact_pointer_status, so checkpoint pointer completion is not
           proven.
-      - criterion: "Diagnostics report includes required residual and fallback fields."
+      - criterion: "Diagnostics report includes ORCA command, raw residual, bounded residual, final guarded command, residual clipping rate, guard veto rate, fallback/degraded status."
         status: not_met
         evidence: >-
           The executable audit reports missing residual_clipping_rate,
@@ -73,7 +73,7 @@ entries:
         evidence: >-
           The job-12913 smoke result is durably tracked as failed_closed with
           nominal_escalation_allowed=false.
-      - criterion: "Nominal result classified ready for #1358 continuation, revise, or stop."
+      - criterion: "Nominal result classified ready #1358 continuation, revise, stop."
         status: not_met
         evidence: >-
           No nominal result exists in tracked evidence. The smoke gate remains

--- a/scripts/validation/build_issue_1475_acceptance_audit.py
+++ b/scripts/validation/build_issue_1475_acceptance_audit.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from robot_sf.training.orca_residual_lineage_packet import (
     OrcaResidualLineagePacketError,
     validate_smoke_nominal_gate,
@@ -25,6 +27,7 @@ DEFAULT_SOURCE_CHECKSUMS = Path(
 )
 DEFAULT_CLOSURE_AUDIT = Path("docs/context/evidence/issue_1475_closure_audit_2026-07-06.md")
 DEFAULT_OUTPUT = Path("docs/context/evidence/issue_1475_acceptance_audit_2026-07-06.json")
+DEFAULT_STATE_SURFACE = Path("docs/context/issue_1475_state.yaml")
 
 
 @dataclass(frozen=True)
@@ -57,6 +60,18 @@ def _load_json(path: Path) -> dict[str, Any]:
         raise SystemExit(f"failed to parse {path}: {exc}") from exc
     if not isinstance(data, dict):
         raise SystemExit(f"{path} must contain a JSON object")
+    return data
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise SystemExit(f"failed read {path}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise SystemExit(f"failed parse {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SystemExit(f"{path} must contain a YAML mapping")
     return data
 
 
@@ -101,12 +116,60 @@ def _smoke_gate_input(summary: dict[str, Any]) -> dict[str, Any]:
     return gate_summary
 
 
+def _state_surface_check(
+    *,
+    repo_root: Path,
+    state_surface_path: Path,
+    acceptance_evidence: list[CriterionAudit],
+    closure_call: str,
+) -> dict[str, Any]:
+    """Check the append-only high-churn state row matches this audit."""
+
+    state_surface = _load_yaml(repo_root / state_surface_path)
+    entries = state_surface.get("entries")
+    if not isinstance(entries, list) or not entries:
+        return {
+            "path": str(state_surface_path),
+            "status": "invalid",
+            "errors": ["state surface has no entries"],
+        }
+    latest = entries[-1]
+    errors: list[str] = []
+    if state_surface.get("issue") != 1475:
+        errors.append(f"issue must be 1475, got {state_surface.get('issue')!r}")
+    closure_boundary = latest.get("closure_boundary", {})
+    if closure_boundary.get("closure_call_for_this_pr") != closure_call:
+        errors.append(
+            "latest entry closure_call_for_this_pr "
+            f"{closure_boundary.get('closure_call_for_this_pr')!r} != {closure_call!r}"
+        )
+    state_by_criterion = {
+        item.get("criterion"): item.get("status")
+        for item in latest.get("acceptance_evidence", [])
+        if isinstance(item, dict)
+    }
+    for item in acceptance_evidence:
+        if state_by_criterion.get(item.criterion) != item.status:
+            errors.append(
+                f"{item.criterion!r} status "
+                f"{state_by_criterion.get(item.criterion)!r} != {item.status!r}"
+            )
+    return {
+        "path": str(state_surface_path),
+        "status": "valid" if not errors else "invalid",
+        "latest_recorded_at_utc": latest.get("recorded_at_utc"),
+        "entry_status": latest.get("status"),
+        "errors": errors,
+    }
+
+
 def build_audit(
     *,
     repo_root: Path,
     smoke_summary_path: Path = DEFAULT_SMOKE_SUMMARY,
     source_checksums_path: Path = DEFAULT_SOURCE_CHECKSUMS,
     closure_audit_path: Path = DEFAULT_CLOSURE_AUDIT,
+    state_surface_path: Path = DEFAULT_STATE_SURFACE,
 ) -> dict[str, Any]:
     """Build a fail-closed issue #1475 acceptance audit."""
 
@@ -203,12 +266,19 @@ def build_audit(
 
     unmet_statuses = {"not_met", "partially_met"}
     status = "complete" if all(item.status == "met" for item in criteria) else "blocked"
+    closure_call = "close" if status == "complete" else "keep_open"
+    state_surface = _state_surface_check(
+        repo_root=repo_root,
+        state_surface_path=state_surface_path,
+        acceptance_evidence=criteria,
+        closure_call=closure_call,
+    )
 
     return {
         "schema_version": SCHEMA_VERSION,
         "issue": 1475,
         "status": status,
-        "closure_call": "close" if status == "complete" else "keep_open",
+        "closure_call": closure_call,
         "claim_boundary": (
             "CPU-only acceptance audit over tracked evidence; no Slurm/GPU submission, "
             "benchmark campaign, training run, or paper-facing claim."
@@ -217,6 +287,7 @@ def build_audit(
             str(smoke_summary_path),
             str(source_checksums_path),
             str(closure_audit_path),
+            str(state_surface_path),
         ],
         "smoke_gate": {
             "status": smoke_gate_status,
@@ -226,6 +297,7 @@ def build_audit(
         "remaining_criteria": [
             item.to_dict() for item in criteria if item.status in unmet_statuses
         ],
+        "state_surface": state_surface,
         "next_empirical_action": (
             "Run one bounded ORCA-residual BC smoke rerun on a Slurm-capable host; only if "
             "validate_smoke_nominal_gate passes, escalate nominal and classify #1358 "
@@ -249,6 +321,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--smoke-summary", type=Path, default=DEFAULT_SMOKE_SUMMARY)
     parser.add_argument("--source-checksums", type=Path, default=DEFAULT_SOURCE_CHECKSUMS)
     parser.add_argument("--closure-audit", type=Path, default=DEFAULT_CLOSURE_AUDIT)
+    parser.add_argument("--state-surface", type=Path, default=DEFAULT_STATE_SURFACE)
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
     parser.add_argument("--write", action="store_true", help="Write the JSON artifact to --output.")
     return parser
@@ -264,6 +337,7 @@ def main() -> int:
         smoke_summary_path=args.smoke_summary,
         source_checksums_path=args.source_checksums,
         closure_audit_path=args.closure_audit,
+        state_surface_path=args.state_surface,
     )
 
     payload = json.dumps(report, indent=2, sort_keys=True) + "\n"

--- a/tests/validation/test_build_issue_1475_acceptance_audit.py
+++ b/tests/validation/test_build_issue_1475_acceptance_audit.py
@@ -22,6 +22,10 @@ def test_issue_1475_acceptance_audit_stays_fail_closed_on_tracked_smoke() -> Non
     assert report["closure_call"] == "keep_open"
     assert report["smoke_gate"]["status"] == "invalid"
     assert "smoke summary missing required entries" in report["smoke_gate"]["error"]
+    assert report["state_surface"]["status"] == "valid"
+    assert report["state_surface"]["entry_status"] == (
+        "cpu_contract_delivered__external_slurm_rerun_pending"
+    )
 
     statuses = {item["criterion"]: item["status"] for item in report["acceptance_evidence"]}
     assert (
@@ -60,4 +64,6 @@ def test_issue_1475_acceptance_audit_cli_writes_json_artifact(tmp_path: Path) ->
     assert payload["issue"] == 1475
     assert payload["status"] == "blocked"
     assert payload["acceptance_evidence"]
+    assert payload["state_surface"]["path"] == "docs/context/issue_1475_state.yaml"
+    assert payload["state_surface"]["errors"] == []
     assert "Slurm-capable host" in payload["next_empirical_action"]


### PR DESCRIPTION
**Reviewer-critical summary**
What changed: extends the executable issue #1475 acceptance audit so it validates the canonical high-churn state surface (`docs/context/issue_1475_state.yaml`) against the generated criterion evidence, then regenerates the JSON audit artifact with `state_surface.status=valid`.

Why now: #1475 has had four related audit/checker/state PRs merged in the last 24 hours (#4608, #4609, #4661, #4667). This is a consolidation/integration slice, not another blocker refresh: the state row is now mechanically checked against the criterion audit.

Claim boundary: CPU-only audit/state consistency over tracked evidence. This PR does not run Slurm/GPU jobs, train policies, run a benchmark campaign, or promote any paper/dissertation claim.

Required validation: focused audit tests, Ruff check/format on the changed script/test, regenerated audit JSON, docs proof consistency for the changed state/audit artifacts, and final PR readiness wrapper.

Remaining blocker: Refs #1475. The issue should stay open because the tracked smoke summary still fails closed; a Slurm-capable owner must run one bounded ORCA-residual behavior-cloning smoke rerun, pass `validate_smoke_nominal_gate()`, then run bounded nominal and classify the #1358 continuation/revise/stop result.

Late issue check before PR open: `gh issue view 1475 --repo ll7/robot_sf_ll7 --comments` still shows 35 comments; latest maintainer comment is 2026-07-05T02:58:46Z with the same Slurm smoke-rerun gate guidance. No newer maintainer guidance was found.

**Contract delta**
- New audit output field: `state_surface`, with `path`, `status`, `errors`, `latest_recorded_at_utc`, and `entry_status`.
- New fail-closed blocker: if the latest high-churn state row disagrees with the generated closure call or criterion statuses, the audit emits `state_surface.status=invalid` with explicit errors.
- Compatibility impact: additive JSON field and optional `--state-surface` CLI argument; existing acceptance evidence schema remains unchanged.
- State propagation: updated the single high-churn durable state surface, `docs/context/issue_1475_state.yaml`, instead of adding an issue comment stream.

**Validation**
- `uv run pytest tests/validation/test_build_issue_1475_acceptance_audit.py -q` -> 2 passed.
- `uv run ruff check scripts/validation/build_issue_1475_acceptance_audit.py tests/validation/test_build_issue_1475_acceptance_audit.py` -> passed.
- `uv run ruff format --check scripts/validation/build_issue_1475_acceptance_audit.py tests/validation/test_build_issue_1475_acceptance_audit.py` -> 2 files already formatted.
- `uv run python scripts/validation/build_issue_1475_acceptance_audit.py --repo-root .` -> emitted `status=blocked`, `closure_call=keep_open`, `state_surface.status=valid`.
- `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/issue_1475_state.yaml --path docs/context/evidence/issue_1475_acceptance_audit_2026-07-06.json` -> passed.
- `git diff --check` -> passed.
- `PR_READY_PR_BODY_FILE=/tmp/issue1475_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed with this body file.

**Out of scope**
No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no issue comment, no merge, no release, no deletion.

<details>
<summary>Acceptance Evidence</summary>

| Criterion | Evidence | Status |
| --- | --- | --- |
| Residual dataset manifest NPZ recorded durable artifacts. | Source checksum manifest records smoke NPZ checksum, but tracked smoke summary has no durable `artifact_pointer_status`. | Partially met |
| Learned residual checkpoint pointer durable included in completion update. | Source checksum manifest records smoke checkpoint checksum, but tracked smoke summary has no durable `artifact_pointer_status`. | Partially met |
| Diagnostics report includes ORCA command, raw residual, bounded residual, final guarded command, residual clipping rate, guard veto rate, fallback/degraded status. | Tracked smoke summary still lacks required smoke evidence fields. | Not met |
| Fallback/degraded rows are not counted learned-residual success evidence. | `validate_smoke_nominal_gate()` fails closed when fallback/degraded or artifact-pointer status is invalid. | Met |
| Smoke result recorded before nominal escalation. | Job 12913 smoke summary is durably tracked as failed-closed with `nominal_escalation_allowed=false`. | Met |
| Nominal result classified ready #1358 continuation, revise, stop. | No nominal result exists in tracked evidence. | Not met |

</details>
