### PR TITLE
Issue #4013 surface real-trajectory acquisition readiness

### DIFF
--- a/configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml
+++ b/configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml
@@ -28,7 +28,7 @@ retrieval:
     checksum, set checksums.tree_sha256 and expected_tree_sha256, and change
     availability to validated before using the data for #4013 real-trajectory
     training or representative evaluation.
-  download_url: null
+  download_url: https://ethz.ch/content/dam/ethz/special-interest/itet/cvl/vision-dam/documents/ewap_dataset_light.tgz
   fail_closed: true
 checksums:
   algorithm: SHA-256

--- a/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
+++ b/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
@@ -35,6 +35,11 @@
   "manifest_path": "configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml",
   "next_action": "Stage ETH/BIWI or another approved real pedestrian trajectory dataset under $ROBOT_SF_EXTERNAL_DATA_ROOT, validate its checksum, update the manifest, then run real-trajectory training and representative evaluation.",
   "preflight_issues": [],
+  "retrieval": {
+    "download_url": "https://ethz.ch/content/dam/ethz/special-interest/itet/cvl/vision-dam/documents/ewap_dataset_light.tgz",
+    "fail_closed": true,
+    "instructions": "Obtain the ETH/BIWI walking pedestrians annotation archive from the official ETH Computer Vision Lab datasets page under its current terms. Extract the raw annotation files into staging_dir. Do not commit raw annotations or converted trajectory files. After staging, compute the aggregate SHA-256 tree checksum, set checksums.tree_sha256 and expected_tree_sha256, and change availability to validated before using the data for #4013 real-trajectory training or representative evaluation."
+  },
   "schema_version": "issue_4013.real_trajectory_readiness.v1",
   "status": "blocked_real_trajectory_data_unavailable"
 }

--- a/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md
+++ b/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md
@@ -10,6 +10,8 @@ Claim boundary: real-trajectory readiness only. No raw data is staged, no full b
 - Dataset: `issue_4013_eth_biwi`
 - Availability: `missing`
 - Benchmark eligibility: `diagnostic_only`
+- Acquisition URL: `https://ethz.ch/content/dam/ethz/special-interest/itet/cvl/vision-dam/documents/ewap_dataset_light.tgz`
+- Acquisition fail-closed: `True`
 
 ## Blockers
 
@@ -26,3 +28,6 @@ Claim boundary: real-trajectory readiness only. No raw data is staged, no full b
 | claim boundary excludes world-model and paper-grade claims | Met in existing #4013 design/evidence docs; this report preserves that boundary. |
 
 Next action: Stage ETH/BIWI or another approved real pedestrian trajectory dataset under $ROBOT_SF_EXTERNAL_DATA_ROOT, validate its checksum, update the manifest, then run real-trajectory training and representative evaluation.
+
+Acquisition instructions:
+Obtain the ETH/BIWI walking pedestrians annotation archive from the official ETH Computer Vision Lab datasets page under its current terms. Extract the raw annotation files into staging_dir. Do not commit raw annotations or converted trajectory files. After staging, compute the aggregate SHA-256 tree checksum, set checksums.tree_sha256 and expected_tree_sha256, and change availability to validated before using the data for #4013 real-trajectory training or representative evaluation.

--- a/scripts/training/check_issue_4013_real_trajectory_readiness.py
+++ b/scripts/training/check_issue_4013_real_trajectory_readiness.py
@@ -54,9 +54,11 @@ def build_report(manifest_path: Path) -> dict[str, Any]:
         dataset_id = None
         availability = "unknown"
         benchmark_eligibility = "unknown"
+        retrieval = {"download_url": None, "instructions": None, "fail_closed": True}
         issues: list[dict[str, str]] = []
     else:
         assert preflight is not None
+        retrieval = manifest["retrieval"]
         issues = [
             {"code": issue.code, "severity": issue.severity, "message": issue.message}
             for issue in preflight.issues
@@ -131,6 +133,11 @@ def build_report(manifest_path: Path) -> dict[str, Any]:
         "dataset_id": dataset_id,
         "availability": availability,
         "benchmark_eligibility": benchmark_eligibility,
+        "retrieval": {
+            "download_url": retrieval.get("download_url"),
+            "instructions": retrieval.get("instructions"),
+            "fail_closed": retrieval.get("fail_closed"),
+        },
         "preflight_issues": issues,
         "blockers": blockers,
         "acceptance_evidence": acceptance_evidence,
@@ -162,6 +169,8 @@ def render_markdown(report: dict[str, Any]) -> str:
         f"- Dataset: `{report['dataset_id']}`",
         f"- Availability: `{report['availability']}`",
         f"- Benchmark eligibility: `{report['benchmark_eligibility']}`",
+        f"- Acquisition URL: `{report['retrieval']['download_url'] or 'manual/license-gated'}`",
+        f"- Acquisition fail-closed: `{report['retrieval']['fail_closed']}`",
         "",
         "## Blockers",
         "",
@@ -175,6 +184,9 @@ def render_markdown(report: dict[str, Any]) -> str:
     for item in report["acceptance_evidence"]:
         lines.append(f"| {item['criterion']} | {item['evidence']} |")
     lines.extend(["", f"Next action: {report['next_action']}", ""])
+    instructions = report["retrieval"].get("instructions")
+    if instructions:
+        lines.extend(["Acquisition instructions:", instructions, ""])
     return "\n".join(lines)
 
 

--- a/tests/training/test_issue_4013_real_trajectory_readiness.py
+++ b/tests/training/test_issue_4013_real_trajectory_readiness.py
@@ -36,7 +36,7 @@ def _manifest() -> dict:
         },
         "retrieval": {
             "instructions": "Stage locally.",
-            "download_url": None,
+            "download_url": "https://example.org/trajectories.tgz",
             "fail_closed": True,
         },
         "checksums": {
@@ -78,6 +78,7 @@ def test_missing_real_dataset_blocks_phase3_without_contract_error(tmp_path: Pat
     report = build_report(_write_manifest(tmp_path, _manifest()))
 
     assert report["status"] == "blocked_real_trajectory_data_unavailable"
+    assert report["retrieval"]["download_url"] == "https://example.org/trajectories.tgz"
     assert report["blockers"][0]["code"] == "real_trajectory.availability_not_validated"
     assert report["preflight_issues"] == []
 
@@ -114,4 +115,6 @@ def test_markdown_contains_acceptance_evidence_and_claim_boundary(tmp_path: Path
 
     assert "Issue #4013 Real-Trajectory Readiness" in markdown
     assert "No raw data is staged" in markdown
+    assert "Acquisition URL: `https://example.org/trajectories.tgz`" in markdown
+    assert "Acquisition instructions:" in markdown
     assert "comparison against cv_prediction_mpc" in markdown


### PR DESCRIPTION
## Reviewer-critical summary

What changed: #4013 real-trajectory readiness now carries the official ETH/BIWI annotations acquisition URL in the manifest, JSON report, and Markdown evidence bundle.

Why now: the closure audit found the original Definition Done diagnostic criteria are covered by merged PRs, but the live maintainer thread keeps #4013 open for Phase 3 real-trajectory training/evaluation. PR #4665 added the fail-closed checker while leaving the public acquisition pointer unset; this slice makes that blocker actionable without staging raw data.

Claim boundary: this is acquisition/readiness metadata only. It does not download, stage, convert, train on, or evaluate real trajectory data, and it makes no benchmark, navigation-quality, paper, or dissertation claim.

Required validation: focused checker tests, Ruff check/format, real-trajectory manifest preflight, generated readiness report, public URL HEAD check, and final PR readiness.

Remaining blocker: `status=blocked_real_trajectory_data_unavailable` remains correct until ETH/BIWI or another approved real pedestrian trajectory dataset is staged under `$ROBOT_SF_EXTERNAL_DATA_ROOT`, checksum-validated, and used for real-trajectory training plus representative evaluation.

## Contract delta

New report fields: `retrieval.download_url`, `retrieval.instructions`, and `retrieval.fail_closed` are now emitted by `issue_4013.real_trajectory_readiness.v1`.

New manifest value: `configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml` records the official ETH/BIWI annotations-only TGZ URL.

Fail-closed behavior: unchanged. The readiness checker still blocks unless `availability: validated` and representative eligibility is sufficient; the refreshed tracked evidence remains `blocked_real_trajectory_data_unavailable`.

Compatibility impact: additive JSON fields and Markdown rows only. Existing status names and blockers are unchanged.

## Issue

Refs #4013.

| Criterion | Evidence | Status |
| --- | --- | --- |
| Short-horizon predictor trained | PR #4629 trained the diagnostic seeded synthetic predictor and recorded diagnostic Phase 2 evidence. | Met at diagnostic tier; real-trajectory retraining remains open. |
| Model-based action selection runs on smoke scenario | PR #4644 proved checkpoint-backed `learned_prediction_mpc` adapter `plan()` execution with no fallback; PR #4655 ran the learned arm in the paired diagnostic smoke. | Met at diagnostic tier. |
| Comparison vs model-free baseline | PR #4655 produced the paired 3-arm diagnostic report: `learned_prediction_mpc`, `cv_prediction_mpc`, and model-free `goal` baseline on matched scenario/seed. | Met at diagnostic tier. |
| Fallback/degraded rows excluded as evidence | PR #4587 report contract and PR #4655 evidence enforce zero fallback/degraded rows for diagnostic evidence. | Met. |
| Claim boundary excludes large world-model and paper-grade claims | Existing #4013 design/evidence docs plus the readiness report preserve diagnostic/readiness-only language. | Met. |
| Phase 3 real-trajectory training/evaluation | PR #4665 added the fail-closed readiness gate; this PR adds the official public acquisition URL and surfaces it in reports. | Still blocked on local checksum-validated data and real-trajectory training/evaluation. |

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/training/test_issue_4013_real_trajectory_readiness.py -q` passed: `4 passed in 1.44s`.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/training/check_issue_4013_real_trajectory_readiness.py tests/training/test_issue_4013_real_trajectory_readiness.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/training/check_issue_4013_real_trajectory_readiness.py tests/training/test_issue_4013_real_trajectory_readiness.py` passed: `2 files already formatted`.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/check_real_trajectory_manifest.py configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml --json` passed: `ok=true`, `availability=missing`, `issues=[]`.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/training/check_issue_4013_real_trajectory_readiness.py --check` passed: `status=blocked_real_trajectory_data_unavailable` with the ETH/BIWI acquisition URL surfaced.
- `curl -I -L --max-time 20 https://ethz.ch/content/dam/ethz/special-interest/itet/cvl/vision-dam/documents/ewap_dataset_light.tgz` passed: HTTP 200, `content-length: 406603`.
- `git diff --check` passed.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` pending rerun with this PR body file.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no raw external dataset staging or commit, no real-trajectory training run, no merge, no release, no deletion, and no paper/dissertation claim edits.

## Follow-Up Issues

- #4013 remains open for the Phase 3 work: stage a checksum-validated real trajectory dataset, rerun readiness to `ready_for_real_trajectory_training`, train on real trajectories, and run the representative evaluation.

## State propagation

This is a high-churn issue and `comment_issue_or_pr=false` for this task, so no additional issue comment is posted. The PR body is the canonical state surface for this slice; the tracked readiness evidence remains the durable report.

<details>
<summary>Appendix: closure audit notes</summary>

The live issue remains open because the latest maintainer state after PR #4665 says Phase 3 is blocked by unavailable real trajectory data. This PR is therefore intentionally partial and uses `Refs #4013`.

No late maintainer comments were present after the start of this work when checked before PR opening.

</details>
