### PR TITLE
Issue #1126: add benchmark-ready next plan

### DIFF
--- a/scripts/tools/sdd_curation_preflight.py
+++ b/scripts/tools/sdd_curation_preflight.py
@@ -61,6 +61,48 @@ SMOKE_EXPLORATORY_ONLY = "exploratory_only"
 SMOKE_BLOCKED = "blocked"
 
 
+def build_benchmark_ready_next_plan(
+    *, classification: str, smoke_summary: dict[str, Any], generated_artifacts_load: bool
+) -> dict[str, Any]:
+    """Return a deterministic next empirical action for #1126 smoke decisions."""
+    blockers: list[str] = []
+    primary_action = "promote_benchmark_ready_candidate"
+    next_checks = [
+        "record benchmark-ready scenario/map/provenance pointer",
+        "open closure only after reviewer confirms benchmark-ready evidence boundary",
+    ]
+
+    if classification == SMOKE_BLOCKED:
+        primary_action = "fix_import_or_smoke_execution"
+        if not generated_artifacts_load:
+            blockers.append("generated artifacts did not load")
+        if not smoke_summary["executed"]:
+            blockers.append("representative smoke did not execute cleanly")
+        next_checks = [
+            "repair import/load/smoke execution failure",
+            "rerun one CPU representative smoke before classifying benchmark readiness",
+        ]
+    elif classification == SMOKE_EXPLORATORY_ONLY:
+        primary_action = "tune_current_candidate_or_select_alternate_scene"
+        if smoke_summary["timeouts"]:
+            blockers.append("timeout_before_goal")
+        if not smoke_summary["reached_goal"]:
+            blockers.append("goal_not_reached")
+        if smoke_summary["collisions"]:
+            blockers.append("collision_observed")
+        next_checks = [
+            "first try a CPU-only horizon/scale calibration on the current selected scene",
+            "if it still times out, select another SDD scene/video through the same preflight gate",
+            "record exploratory_only again unless smoke reaches the goal without timeout or collision",
+        ]
+
+    return {
+        "primary_action": primary_action,
+        "blockers": blockers,
+        "next_checks": next_checks,
+    }
+
+
 def probe_annotation_file(
     path: Path,
     *,
@@ -434,11 +476,18 @@ def classify_smoke_decision(
         if smoke_summary["collisions"]:
             reasons.append("recorded smoke run included collisions")
 
+    next_plan = build_benchmark_ready_next_plan(
+        classification=classification,
+        smoke_summary=smoke_summary,
+        generated_artifacts_load=generated_artifacts_load,
+    )
+
     return {
         "schema": "robot_sf_sdd_smoke_decision.v1",
         "issue": ISSUE,
         "classification": classification,
         "recommended_next_action": recommended_next_action,
+        "benchmark_ready_next_plan": next_plan,
         "benchmark_ready": classification == SMOKE_BENCHMARK_READY,
         "exploratory_only": classification == SMOKE_EXPLORATORY_ONLY,
         "generated_artifacts_load": generated_artifacts_load,

--- a/scripts/tools/sdd_curation_preflight.py
+++ b/scripts/tools/sdd_curation_preflight.py
@@ -62,7 +62,11 @@ SMOKE_BLOCKED = "blocked"
 
 
 def build_benchmark_ready_next_plan(
-    *, classification: str, smoke_summary: dict[str, Any], generated_artifacts_load: bool
+    *,
+    classification: str,
+    smoke_summary: dict[str, Any],
+    generated_artifacts_load: bool,
+    benchmark_promotion_allowed: bool = True,
 ) -> dict[str, Any]:
     """Return a deterministic next empirical action for #1126 smoke decisions."""
     blockers: list[str] = []
@@ -72,8 +76,24 @@ def build_benchmark_ready_next_plan(
         "open closure only after reviewer confirms benchmark-ready evidence boundary",
     ]
 
-    if classification == SMOKE_BLOCKED:
+    if (
+        classification == SMOKE_BLOCKED
+        and not benchmark_promotion_allowed
+        and (generated_artifacts_load and smoke_summary["executed"])
+    ):
+        # Smoke executed cleanly and artifacts loaded, but the preflight readiness gate
+        # withheld benchmark promotion (recommended_next_action=restore_dataset_backed_preflight).
+        # Reporting an import/execution repair here would contradict that decision.
+        primary_action = "restore_dataset_backed_preflight"
+        blockers.append("preflight did not allow benchmark promotion")
+        next_checks = [
+            "restore dataset-backed preflight before re-classifying",
+            "do not promote until preflight allows benchmark promotion",
+        ]
+    elif classification == SMOKE_BLOCKED:
         primary_action = "fix_import_or_smoke_execution"
+        if not benchmark_promotion_allowed:
+            blockers.append("preflight did not allow benchmark promotion")
         if not generated_artifacts_load:
             blockers.append("generated artifacts did not load")
         if not smoke_summary["executed"]:
@@ -480,6 +500,7 @@ def classify_smoke_decision(
         classification=classification,
         smoke_summary=smoke_summary,
         generated_artifacts_load=generated_artifacts_load,
+        benchmark_promotion_allowed=readiness.get("benchmark_promotion_allowed", False),
     )
 
     return {

--- a/tests/tools/test_sdd_curation_preflight.py
+++ b/tests/tools/test_sdd_curation_preflight.py
@@ -539,6 +539,11 @@ def test_smoke_decision_rejects_timeout_candidate_for_closure() -> None:
 
     assert decision["classification"] == sdd_curation_preflight.SMOKE_EXPLORATORY_ONLY
     assert decision["recommended_next_action"] == "tune_or_select_benchmark_ready_candidate"
+    assert decision["benchmark_ready_next_plan"]["primary_action"] == (
+        "tune_current_candidate_or_select_alternate_scene"
+    )
+    assert "timeout_before_goal" in decision["benchmark_ready_next_plan"]["blockers"]
+    assert "goal_not_reached" in decision["benchmark_ready_next_plan"]["blockers"]
     assert decision["exploratory_only"] is True
     assert decision["benchmark_ready"] is False
     assert any("timed out" in reason for reason in decision["reasons"])
@@ -563,6 +568,10 @@ def test_smoke_decision_promotes_clean_success_candidate() -> None:
 
     assert decision["classification"] == sdd_curation_preflight.SMOKE_BENCHMARK_READY
     assert decision["recommended_next_action"] == "promote_benchmark_ready_candidate"
+    assert decision["benchmark_ready_next_plan"]["primary_action"] == (
+        "promote_benchmark_ready_candidate"
+    )
+    assert decision["benchmark_ready_next_plan"]["blockers"] == []
     assert decision["benchmark_ready"] is True
 
 
@@ -585,4 +594,8 @@ def test_smoke_decision_fails_closed_when_artifacts_do_not_load() -> None:
 
     assert decision["classification"] == sdd_curation_preflight.SMOKE_BLOCKED
     assert decision["recommended_next_action"] == "fix_import_or_smoke_execution"
+    assert (
+        decision["benchmark_ready_next_plan"]["primary_action"] == "fix_import_or_smoke_execution"
+    )
+    assert "generated artifacts did not load" in decision["benchmark_ready_next_plan"]["blockers"]
     assert any("did not load" in reason for reason in decision["reasons"])

--- a/tests/tools/test_sdd_curation_preflight.py
+++ b/tests/tools/test_sdd_curation_preflight.py
@@ -575,6 +575,35 @@ def test_smoke_decision_promotes_clean_success_candidate() -> None:
     assert decision["benchmark_ready"] is True
 
 
+def test_smoke_decision_blocked_on_preflight_gate_reports_restore_plan() -> None:
+    """Clean smoke but withheld benchmark promotion yields a preflight-restore plan, not a repair plan."""
+    decision = sdd_curation_preflight.classify_smoke_decision(
+        {
+            "benchmark_promotion_allowed": False,
+            "output_classification": sdd_curation_preflight.OUTPUT_BENCHMARK_READY_CANDIDATE,
+        },
+        [
+            {
+                "horizon": 384,
+                "successful_jobs": 1,
+                "failed_jobs": 0,
+                "success": True,
+                "timeout": False,
+                "collisions": 0,
+            }
+        ],
+        generated_artifacts_load=True,
+    )
+
+    assert decision["classification"] == sdd_curation_preflight.SMOKE_BLOCKED
+    assert decision["recommended_next_action"] == "restore_dataset_backed_preflight"
+    plan = decision["benchmark_ready_next_plan"]
+    # Plan must agree with recommended_next_action, not misreport an import/execution failure.
+    assert plan["primary_action"] == "restore_dataset_backed_preflight"
+    assert "preflight did not allow benchmark promotion" in plan["blockers"]
+    assert plan["blockers"] != []
+
+
 def test_smoke_decision_fails_closed_when_artifacts_do_not_load() -> None:
     """Smoke classification must not hide generated artifact load failures."""
     decision = sdd_curation_preflight.classify_smoke_decision(


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `classify_smoke_decision()` now returns a machine-readable `benchmark_ready_next_plan` alongside the existing classification and `recommended_next_action` for issue #1126 Stanford Drone Dataset (SDD) smoke decisions.

Why now: the live closure audit and merged PRs #4616, #4638, #4647, #4668, and #4677 show the current real `bookstore/video0` candidate is only `exploratory_only` because both CPU smoke horizons timed out. With multiple same-day closure/checker PRs already merged, this is a consolidation slice: it turns the remaining benchmark-ready fork into one coherent contract instead of another status packet.

Claim boundary: this PR does not claim #1126 is complete. It makes the next CPU-only action explicit: tune/calibrate the current selected scene first, then select another SDD scene/video through the same preflight gate if timeout remains. It does not run a full benchmark campaign, submit Slurm/GPU work, commit raw SDD data, or edit paper/dissertation claims.

Required validation: focused SDD preflight tests plus Ruff on touched files. Final PR readiness was attempted after `uv sync --all-extras`; the wrapper required this PR body and should be re-run by the gate with the opened PR context.

Remaining blocker: #1126 still needs benchmark-ready SDD-derived scenario evidence, or a maintainer decision to accept the existing exploratory-only candidate. Current evidence remains `exploratory_only`, not `benchmark_ready`.

Refs #1126

## Contract delta

New schema fields:

- `robot_sf_sdd_smoke_decision.v1` now includes `benchmark_ready_next_plan`.
- The plan contains `primary_action`, `blockers`, and `next_checks`.

New fail-closed blockers:

- No new benchmark promotion path is added.
- Blocked decisions now surface artifact-load and smoke-execution blockers in the next plan.
- Exploratory timeout decisions surface `timeout_before_goal` and `goal_not_reached` blockers.

Compatibility impact:

- Existing `classification`, `recommended_next_action`, `benchmark_ready`, and `exploratory_only` fields are unchanged.
- The added field is additive for downstream consumers.

## Scope summary

- Added `build_benchmark_ready_next_plan()` in `scripts/tools/sdd_curation_preflight.py`.
- Threaded the plan into `classify_smoke_decision()` output.
- Extended focused tests for exploratory timeout, benchmark-ready success, and artifact-load failure branches.

## Validation

- `python -m py_compile scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/tools/test_sdd_curation_preflight.py -q` - passed, 23 tests
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` - passed, 1 file reformatted
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` - passed
- `git diff --check` - passed
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - first stopped on missing `duckdb`/`pyarrow`; after `uv sync --all-extras`, stopped on `missing_body` before this PR body existed

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No raw SDD annotation or generated scenario artifact commit.
- No paper/dissertation claim edits.
- No issue comment/state propagation: this issue is high-churn and `comment_issue_or_pr` was not authorized for this run; the PR body records the delivered slice and remaining work instead.

<details>
<summary>Closure audit evidence map</summary>

| Acceptance criterion | Evidence | Status |
| --- | --- | --- |
| #1497/BYO SDD source staged or blocked provenance recorded | PR #4638 pinned reviewed BYO SDD annotation tree checksum and size | Met for staging evidence |
| Scene/video selected with rationale | PR #4638 selected `bookstore/video0` and recorded selection probe | Met for exploratory slice |
| Import command, source identity, checksums, license/source URL, scale assumptions recorded | PR #4616 fixed runnable command; PR #4638 recorded URL/license/checksums/`--meters-per-pixel 0.0417` | Met for exploratory slice |
| Scenario/map artifacts load | PR #4638 recorded generated ignored output load assertions | Met for exploratory slice |
| Representative smoke succeeds or rejected explicitly | PR #4638 ran two CPU smoke horizons; PR #4647/#4668 classify timeout as `exploratory_only` | Met only as rejection, not closure-ready |
| Documentation states `benchmark_ready` vs `exploratory_only` | PR #4647/#4668/#4677 state current candidate is `exploratory_only` | Met |
| Small reviewable artifacts or durable pointers only | Prior PRs committed compact evidence/code/tests; raw SDD and generated artifacts remain untracked | Met |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured next-step plan to smoke decision results, making it easier to see the recommended action, blockers, and follow-up checks at a glance.

* **Bug Fixes**
  * Improved decision output for different smoke outcomes, including blocked runs, exploratory-only runs, and cases where generated artifacts fail to load.

* **Tests**
  * Expanded coverage to verify the new next-step plan details are included correctly in key smoke-decision scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->