### PR TITLE
Issue #4683: export release assurance cases

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -3516,6 +3516,10 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_4683_release_assurance_case_example.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_1126_closure_audit_2026-07-06.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_1126_live_closure_audit_2026-07-06.md
+++ b/docs/context/evidence/issue_1126_live_closure_audit_2026-07-06.md
@@ -61,13 +61,13 @@ Fresh isolated worktree:
 scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/manage_external_data.py list
 # sdd: status missing
 # expected path:
-# /home/luttkule/git/robot_sf_ll7.worktrees/issue-1126-closure-audit-verify-acceptance-criteria-v2/output/external_data/sdd
+# output/external_data/sdd
 ```
 
 Pinned-tree root probe against the primary checkout output root also failed closed in this session:
 
 ```bash
-ROBOT_SF_EXTERNAL_DATA_ROOT=/home/luttkule/git/robot_sf_ll7/output/external_data \
+ROBOT_SF_EXTERNAL_DATA_ROOT=output/external_data \
   scripts/dev/run_worktree_shared_venv.sh -- \
   python scripts/tools/sdd_curation_preflight.py --json
 # staging_mode=proxy_schema_smoke

--- a/docs/context/evidence/issue_4683_release_assurance_case_example.json
+++ b/docs/context/evidence/issue_4683_release_assurance_case_example.json
@@ -1,0 +1,311 @@
+{
+  "arguments": [
+    {
+      "claim_id": "C_release_bundle_manifest",
+      "evidence_ids": [
+        "E_release_manifest",
+        "E_campaign_config",
+        "E_scenario_matrix",
+        "E_release_checklist",
+        "E_citation",
+        "E_snqi_weights",
+        "E_snqi_baseline"
+      ],
+      "id": "A_release_manifest_integrity",
+      "strategy": "manifest_integrity",
+      "text": "The release bundle is argued from a versioned manifest whose core files are present and, where the manifest pins a digest, checksum-matched."
+    },
+    {
+      "claim_id": "C_roster_seed_scope_context",
+      "evidence_ids": [
+        "E_release_manifest",
+        "E_campaign_config",
+        "E_scenario_matrix"
+      ],
+      "id": "A_roster_seed_scope",
+      "strategy": "manifest_context",
+      "text": "Planner roster, seed policy, scenario scope, and kinematic scope are taken from the release manifest rather than reconstructed from code."
+    },
+    {
+      "claim_id": "C_gate_collision_rate_zero",
+      "evidence_ids": [
+        "E_release_gate_spec"
+      ],
+      "gate": {
+        "category": "safety",
+        "direction": "max",
+        "gate_id": "collision_rate_zero",
+        "metric": "collision_rate",
+        "required": true,
+        "scope": {},
+        "threshold": 0.0
+      },
+      "id": "A_gate_collision_rate_zero",
+      "strategy": "threshold_gate_specification",
+      "text": "Gate claim is derived directly from the gate spec threshold, metric, category, requirement flag, and scope."
+    },
+    {
+      "claim_id": "C_gate_near_miss_rate_limit",
+      "evidence_ids": [
+        "E_release_gate_spec"
+      ],
+      "gate": {
+        "category": "safety",
+        "direction": "max",
+        "gate_id": "near_miss_rate_limit",
+        "metric": "near_miss_rate",
+        "required": true,
+        "scope": {},
+        "threshold": 0.05
+      },
+      "id": "A_gate_near_miss_rate_limit",
+      "strategy": "threshold_gate_specification",
+      "text": "Gate claim is derived directly from the gate spec threshold, metric, category, requirement flag, and scope."
+    },
+    {
+      "claim_id": "C_gate_min_clearance_floor",
+      "evidence_ids": [
+        "E_release_gate_spec"
+      ],
+      "gate": {
+        "category": "safety",
+        "direction": "min",
+        "gate_id": "min_clearance_floor",
+        "metric": "min_clearance_m",
+        "required": true,
+        "scope": {},
+        "threshold": 0.25
+      },
+      "id": "A_gate_min_clearance_floor",
+      "strategy": "threshold_gate_specification",
+      "text": "Gate claim is derived directly from the gate spec threshold, metric, category, requirement flag, and scope."
+    },
+    {
+      "claim_id": "C_gate_proxemic_intrusion_rate_limit",
+      "evidence_ids": [
+        "E_release_gate_spec"
+      ],
+      "gate": {
+        "category": "comfort",
+        "direction": "max",
+        "gate_id": "proxemic_intrusion_rate_limit",
+        "metric": "proxemic_intrusion_rate",
+        "required": true,
+        "scope": {},
+        "threshold": 0.1
+      },
+      "id": "A_gate_proxemic_intrusion_rate_limit",
+      "strategy": "threshold_gate_specification",
+      "text": "Gate claim is derived directly from the gate spec threshold, metric, category, requirement flag, and scope."
+    },
+    {
+      "claim_id": "C_gate_jerk_mean_limit",
+      "evidence_ids": [
+        "E_release_gate_spec"
+      ],
+      "gate": {
+        "category": "comfort",
+        "direction": "max",
+        "gate_id": "jerk_mean_limit",
+        "metric": "jerk_mean",
+        "required": true,
+        "scope": {},
+        "threshold": 2.0
+      },
+      "id": "A_gate_jerk_mean_limit",
+      "strategy": "threshold_gate_specification",
+      "text": "Gate claim is derived directly from the gate spec threshold, metric, category, requirement flag, and scope."
+    }
+  ],
+  "claim_boundary": "Machine-readable assurance export only. This document records release manifest, gate-spec, and evidence-reference integrity; it does not run a benchmark campaign or promote paper/dissertation claims.",
+  "claims": [
+    {
+      "argument_ids": [
+        "A_release_manifest_integrity"
+      ],
+      "id": "C_release_bundle_manifest",
+      "text": "Release `paper_experiment_matrix_v1_smoke_v0_1_0` is defined by a versioned release manifest with checksum-backed core inputs."
+    },
+    {
+      "argument_ids": [
+        "A_roster_seed_scope"
+      ],
+      "id": "C_roster_seed_scope_context",
+      "text": "Planner roster, seed policy, scenario matrix, and kinematic scope are explicit release context claims."
+    },
+    {
+      "argument_ids": [
+        "A_gate_collision_rate_zero"
+      ],
+      "id": "C_gate_collision_rate_zero",
+      "text": "safety gate `collision_rate_zero` requires `collision_rate` <= 0 (required)."
+    },
+    {
+      "argument_ids": [
+        "A_gate_near_miss_rate_limit"
+      ],
+      "id": "C_gate_near_miss_rate_limit",
+      "text": "safety gate `near_miss_rate_limit` requires `near_miss_rate` <= 0.05 (required)."
+    },
+    {
+      "argument_ids": [
+        "A_gate_min_clearance_floor"
+      ],
+      "id": "C_gate_min_clearance_floor",
+      "text": "safety gate `min_clearance_floor` requires `min_clearance_m` >= 0.25 (required)."
+    },
+    {
+      "argument_ids": [
+        "A_gate_proxemic_intrusion_rate_limit"
+      ],
+      "id": "C_gate_proxemic_intrusion_rate_limit",
+      "text": "comfort gate `proxemic_intrusion_rate_limit` requires `proxemic_intrusion_rate` <= 0.1 (required)."
+    },
+    {
+      "argument_ids": [
+        "A_gate_jerk_mean_limit"
+      ],
+      "id": "C_gate_jerk_mean_limit",
+      "text": "comfort gate `jerk_mean_limit` requires `jerk_mean` <= 2 (required)."
+    }
+  ],
+  "evidence": [
+    {
+      "description": "Release manifest that pins release identity, roster, scope, and artifacts.",
+      "id": "E_release_manifest",
+      "kind": "file",
+      "manifest_field": "release_manifest",
+      "path": "configs/benchmarks/releases/paper_experiment_matrix_v1_release_smoke_v0_1.yaml",
+      "sha256": "ea0896e209828efd0edf3e8e50c8a7295594b393cb498f6e96cb23bb82a71701"
+    },
+    {
+      "description": "Canonical campaign config referenced by the release manifest.",
+      "expected_sha256": "60620b8f28ceb65b6468b343ab1988f87b1187c86ad534bdf2513d48d008ba5e",
+      "id": "E_campaign_config",
+      "kind": "file",
+      "manifest_field": "canonical_campaign_config",
+      "path": "configs/benchmarks/paper_experiment_matrix_v1_release_smoke.yaml",
+      "sha256": "60620b8f28ceb65b6468b343ab1988f87b1187c86ad534bdf2513d48d008ba5e"
+    },
+    {
+      "description": "Scenario matrix referenced by the release manifest.",
+      "expected_sha256": "5c5426d31859cdf69692b85fdade92c58e4379bd9d93963743d932d044c6f6fb",
+      "id": "E_scenario_matrix",
+      "kind": "file",
+      "manifest_field": "scenario.matrix_path",
+      "path": "configs/scenarios/single/francis2023_blind_corner.yaml",
+      "sha256": "5c5426d31859cdf69692b85fdade92c58e4379bd9d93963743d932d044c6f6fb"
+    },
+    {
+      "description": "Release checklist/preflight owner referenced by the release manifest.",
+      "id": "E_release_checklist",
+      "kind": "file",
+      "manifest_field": "release_checklist_path",
+      "path": "docs/RELEASE.md",
+      "sha256": "b38fbb18f5cab43bd23c4bbe44ecb46ad9a89f8dcac6e31eba63989d67b13a34"
+    },
+    {
+      "description": "Citation metadata referenced by the release manifest.",
+      "id": "E_citation",
+      "kind": "file",
+      "manifest_field": "citation_path",
+      "path": "CITATION.cff",
+      "sha256": "39725ab6c3cb7c21f294bc7a562056ef3293a647bbe770d905747662615249a8"
+    },
+    {
+      "description": "Social Navigation Quality Index weights referenced by the manifest.",
+      "expected_sha256": "71a67c3c02faff166f8c96bef8bcf898533981ca2b2c4493829988520fb1aeb2",
+      "id": "E_snqi_weights",
+      "kind": "file",
+      "manifest_field": "metrics.snqi_weights_path",
+      "path": "configs/benchmarks/snqi_weights_camera_ready_v3.json",
+      "sha256": "71a67c3c02faff166f8c96bef8bcf898533981ca2b2c4493829988520fb1aeb2"
+    },
+    {
+      "description": "Social Navigation Quality Index baseline referenced by the manifest.",
+      "expected_sha256": "329ca5766491e1587979d0a435c7ba676e148ccdff97040a36546bbb9414035a",
+      "id": "E_snqi_baseline",
+      "kind": "file",
+      "manifest_field": "metrics.snqi_baseline_path",
+      "path": "configs/benchmarks/snqi_baseline_camera_ready_v3.json",
+      "sha256": "329ca5766491e1587979d0a435c7ba676e148ccdff97040a36546bbb9414035a"
+    },
+    {
+      "description": "Release gate specification used as the claim layer.",
+      "id": "E_release_gate_spec",
+      "kind": "file",
+      "manifest_field": "release_gate_spec",
+      "path": "configs/benchmarks/release_gates/default_safety_comfort_gates.yaml",
+      "sha256": "5abed9ba523bc5cd1a1fd556089c1e7a8cfe1657fcdde9b6b6b55c3b1edc53a0"
+    }
+  ],
+  "generated_at_utc": "2026-07-06T00:00:00Z",
+  "release": {
+    "benchmark_protocol_version": "0.1.0",
+    "maturity": "pre-1.0",
+    "release_id": "paper_experiment_matrix_v1_smoke_v0_1_0",
+    "release_tag": "paper-benchmark-smoke-v0.1.0"
+  },
+  "release_context": {
+    "holonomic_command_mode": null,
+    "kinematics_matrix": [
+      "differential_drive"
+    ],
+    "planner_groups": {
+      "goal": "core",
+      "orca": "core",
+      "ppo": "experimental",
+      "prediction_planner": "experimental",
+      "sacadrl": "experimental",
+      "social_force": "core",
+      "socnav_sampling": "experimental"
+    },
+    "planner_keys": [
+      "prediction_planner",
+      "goal",
+      "social_force",
+      "orca",
+      "ppo",
+      "socnav_sampling",
+      "sacadrl"
+    ],
+    "required_artifact_paths": [
+      "campaign_manifest.json",
+      "manifest.json",
+      "run_meta.json",
+      "preflight/validate_config.json",
+      "preflight/preview_scenarios.json",
+      "reports/campaign_summary.json",
+      "reports/campaign_report.md",
+      "reports/matrix_summary.json",
+      "reports/campaign_table.md",
+      "reports/snqi_diagnostics.json"
+    ],
+    "seed_policy": {
+      "mode": "fixed-list",
+      "seed_sets_path": "../../benchmarks/seed_sets_v1.yaml",
+      "seeds": [
+        111
+      ]
+    }
+  },
+  "root_argument_ids": [
+    "A_release_manifest_integrity",
+    "A_roster_seed_scope",
+    "A_gate_collision_rate_zero",
+    "A_gate_near_miss_rate_limit",
+    "A_gate_min_clearance_floor",
+    "A_gate_proxemic_intrusion_rate_limit",
+    "A_gate_jerk_mean_limit"
+  ],
+  "root_claim_ids": [
+    "C_release_bundle_manifest",
+    "C_roster_seed_scope_context",
+    "C_gate_collision_rate_zero",
+    "C_gate_near_miss_rate_limit",
+    "C_gate_min_clearance_floor",
+    "C_gate_proxemic_intrusion_rate_limit",
+    "C_gate_jerk_mean_limit"
+  ],
+  "schema_version": "benchmark_release_assurance_case.v1"
+}

--- a/robot_sf/benchmark/release_assurance_case.py
+++ b/robot_sf/benchmark/release_assurance_case.py
@@ -1,0 +1,486 @@
+"""Release-bundle assurance case export.
+
+This module turns the release manifest and optional release gate specs/reports
+into a machine-readable claim -> argument -> evidence document.  It is
+deliberately a packaging/provenance contract: it checks referenced files and
+hashes, but it does not run a benchmark campaign or promote paper-facing claims.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from robot_sf.benchmark.release_gates import GateSpec, load_release_gate_spec
+from robot_sf.benchmark.release_protocol import BenchmarkReleaseManifest, load_release_manifest
+from robot_sf.common.artifact_paths import get_repository_root
+
+RELEASE_ASSURANCE_CASE_SCHEMA_VERSION = "benchmark_release_assurance_case.v1"
+
+
+@dataclass(frozen=True)
+class ReleaseAssuranceEvidenceProblem:
+    """One fail-closed stale-reference problem in a release assurance case."""
+
+    evidence_id: str
+    path: str
+    reason: str
+
+
+def _sha256_file(path: Path) -> str:
+    """Return SHA-256 digest for ``path``."""
+
+    digest = __import__("hashlib").sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _repo_relative(path: Path, repo_root: Path) -> str:
+    """Return a stable repository-relative path when possible."""
+
+    resolved = path.resolve()
+    root = repo_root.resolve()
+    try:
+        return resolved.relative_to(root).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def _evidence_leaf(
+    *,
+    evidence_id: str,
+    description: str,
+    path: Path,
+    repo_root: Path,
+    manifest_field: str,
+    expected_sha256: str | None = None,
+    kind: str = "file",
+) -> dict[str, Any]:
+    """Build one present evidence leaf with current and expected checksums.
+
+    Returns:
+        Evidence leaf payload.
+    """
+
+    sha256 = _sha256_file(path)
+    leaf: dict[str, Any] = {
+        "id": evidence_id,
+        "kind": kind,
+        "description": description,
+        "path": _repo_relative(path, repo_root),
+        "sha256": sha256,
+        "manifest_field": manifest_field,
+    }
+    if expected_sha256:
+        leaf["expected_sha256"] = expected_sha256
+    return leaf
+
+
+def _gate_claim_text(gate: GateSpec) -> str:
+    """Return concise claim text for a release gate specification."""
+
+    comparator = "<=" if gate.direction == "max" else ">="
+    required = "required" if gate.required else "advisory"
+    return (
+        f"{gate.category} gate `{gate.gate_id}` requires `{gate.metric}` "
+        f"{comparator} {gate.threshold:g} ({required})."
+    )
+
+
+def build_release_assurance_case(
+    manifest: BenchmarkReleaseManifest,
+    *,
+    gate_spec_path: Path | None = None,
+    release_gate_report_path: Path | None = None,
+    generated_at_utc: str | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Build a release-bundle claim -> argument -> evidence payload.
+
+    Args:
+        manifest: Parsed release manifest.
+        gate_spec_path: Optional release-gate spec to expose as claim layer.
+        release_gate_report_path: Optional report proving gate evaluations.
+        generated_at_utc: Stable timestamp override for reproducible examples.
+        repo_root: Repository root used to format evidence paths.
+
+    Returns:
+        JSON-serializable release assurance case.
+    """
+
+    root = (repo_root or get_repository_root()).resolve()
+    evidence: list[dict[str, Any]] = [
+        _evidence_leaf(
+            evidence_id="E_release_manifest",
+            description="Release manifest that pins release identity, roster, scope, and artifacts.",
+            path=manifest.path,
+            repo_root=root,
+            manifest_field="release_manifest",
+        ),
+        _evidence_leaf(
+            evidence_id="E_campaign_config",
+            description="Canonical campaign config referenced by the release manifest.",
+            path=manifest.canonical_campaign_config_path,
+            repo_root=root,
+            manifest_field="canonical_campaign_config",
+            expected_sha256=manifest.campaign_config_sha256,
+        ),
+        _evidence_leaf(
+            evidence_id="E_scenario_matrix",
+            description="Scenario matrix referenced by the release manifest.",
+            path=manifest.scenario_matrix_path,
+            repo_root=root,
+            manifest_field="scenario.matrix_path",
+            expected_sha256=manifest.scenario_matrix_sha256,
+        ),
+        _evidence_leaf(
+            evidence_id="E_release_checklist",
+            description="Release checklist/preflight owner referenced by the release manifest.",
+            path=manifest.release_checklist_path,
+            repo_root=root,
+            manifest_field="release_checklist_path",
+        ),
+        _evidence_leaf(
+            evidence_id="E_citation",
+            description="Citation metadata referenced by the release manifest.",
+            path=manifest.citation_path,
+            repo_root=root,
+            manifest_field="citation_path",
+        ),
+    ]
+    if manifest.snqi_weights_path is not None:
+        evidence.append(
+            _evidence_leaf(
+                evidence_id="E_snqi_weights",
+                description="Social Navigation Quality Index weights referenced by the manifest.",
+                path=manifest.snqi_weights_path,
+                repo_root=root,
+                manifest_field="metrics.snqi_weights_path",
+                expected_sha256=manifest.snqi_weights_sha256,
+            )
+        )
+    if manifest.snqi_baseline_path is not None:
+        evidence.append(
+            _evidence_leaf(
+                evidence_id="E_snqi_baseline",
+                description="Social Navigation Quality Index baseline referenced by the manifest.",
+                path=manifest.snqi_baseline_path,
+                repo_root=root,
+                manifest_field="metrics.snqi_baseline_path",
+                expected_sha256=manifest.snqi_baseline_sha256,
+            )
+        )
+
+    gate_claim_ids: list[str] = []
+    gate_argument_ids: list[str] = []
+    gate_specs: list[GateSpec] = []
+    if gate_spec_path is not None:
+        gate_specs = load_release_gate_spec(gate_spec_path)
+        evidence.append(
+            _evidence_leaf(
+                evidence_id="E_release_gate_spec",
+                description="Release gate specification used as the claim layer.",
+                path=gate_spec_path,
+                repo_root=root,
+                manifest_field="release_gate_spec",
+            )
+        )
+    if release_gate_report_path is not None:
+        evidence.append(
+            _evidence_leaf(
+                evidence_id="E_release_gate_report",
+                description="Release gate evaluation report over benchmark rows.",
+                path=release_gate_report_path,
+                repo_root=root,
+                manifest_field="release_gate_report",
+            )
+        )
+
+    arguments: list[dict[str, Any]] = [
+        {
+            "id": "A_release_manifest_integrity",
+            "claim_id": "C_release_bundle_manifest",
+            "strategy": "manifest_integrity",
+            "text": (
+                "The release bundle is argued from a versioned manifest whose core files "
+                "are present and, where the manifest pins a digest, checksum-matched."
+            ),
+            "evidence_ids": [
+                "E_release_manifest",
+                "E_campaign_config",
+                "E_scenario_matrix",
+                "E_release_checklist",
+                "E_citation",
+            ]
+            + (["E_snqi_weights"] if manifest.snqi_weights_path is not None else [])
+            + (["E_snqi_baseline"] if manifest.snqi_baseline_path is not None else []),
+        },
+        {
+            "id": "A_roster_seed_scope",
+            "claim_id": "C_roster_seed_scope_context",
+            "strategy": "manifest_context",
+            "text": (
+                "Planner roster, seed policy, scenario scope, and kinematic scope are "
+                "taken from the release manifest rather than reconstructed from code."
+            ),
+            "evidence_ids": ["E_release_manifest", "E_campaign_config", "E_scenario_matrix"],
+        },
+    ]
+
+    if gate_specs:
+        for gate in gate_specs:
+            claim_id = f"C_gate_{gate.gate_id}"
+            argument_id = f"A_gate_{gate.gate_id}"
+            gate_claim_ids.append(claim_id)
+            gate_argument_ids.append(argument_id)
+            evidence_ids = ["E_release_gate_spec"]
+            if release_gate_report_path is not None:
+                evidence_ids.append("E_release_gate_report")
+            arguments.append(
+                {
+                    "id": argument_id,
+                    "claim_id": claim_id,
+                    "strategy": "threshold_gate_specification",
+                    "text": (
+                        "Gate claim is derived directly from the gate spec threshold, "
+                        "metric, category, requirement flag, and scope."
+                    ),
+                    "evidence_ids": evidence_ids,
+                    "gate": {
+                        "gate_id": gate.gate_id,
+                        "metric": gate.metric,
+                        "threshold": gate.threshold,
+                        "direction": gate.direction,
+                        "category": gate.category,
+                        "required": gate.required,
+                        "scope": dict(gate.scope or {}),
+                    },
+                }
+            )
+
+    claims = [
+        {
+            "id": "C_release_bundle_manifest",
+            "text": (
+                f"Release `{manifest.release_id}` is defined by a versioned release "
+                "manifest with checksum-backed core inputs."
+            ),
+            "argument_ids": ["A_release_manifest_integrity"],
+        },
+        {
+            "id": "C_roster_seed_scope_context",
+            "text": (
+                "Planner roster, seed policy, scenario matrix, and kinematic scope are "
+                "explicit release context claims."
+            ),
+            "argument_ids": ["A_roster_seed_scope"],
+        },
+    ]
+    claims.extend(
+        {
+            "id": f"C_gate_{gate.gate_id}",
+            "text": _gate_claim_text(gate),
+            "argument_ids": [f"A_gate_{gate.gate_id}"],
+        }
+        for gate in gate_specs
+    )
+
+    return {
+        "schema_version": RELEASE_ASSURANCE_CASE_SCHEMA_VERSION,
+        "generated_at_utc": generated_at_utc
+        or datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "release": {
+            "release_id": manifest.release_id,
+            "release_tag": manifest.release_tag,
+            "benchmark_protocol_version": manifest.benchmark_protocol_version,
+            "maturity": manifest.maturity,
+        },
+        "claim_boundary": (
+            "Machine-readable assurance export only. This document records release "
+            "manifest, gate-spec, and evidence-reference integrity; it does not run "
+            "a benchmark campaign or promote paper/dissertation claims."
+        ),
+        "release_context": {
+            "planner_keys": list(manifest.planner_keys),
+            "planner_groups": manifest.planner_groups,
+            "seed_policy": manifest.seed_policy,
+            "kinematics_matrix": list(manifest.expected_kinematics_matrix),
+            "holonomic_command_mode": manifest.expected_holonomic_command_mode,
+            "required_artifact_paths": list(manifest.required_artifact_paths),
+        },
+        "claims": claims,
+        "arguments": arguments,
+        "evidence": evidence,
+        "root_claim_ids": [
+            "C_release_bundle_manifest",
+            "C_roster_seed_scope_context",
+            *gate_claim_ids,
+        ],
+        "root_argument_ids": [
+            "A_release_manifest_integrity",
+            "A_roster_seed_scope",
+            *gate_argument_ids,
+        ],
+    }
+
+
+def validate_release_assurance_case_schema(payload: dict[str, Any]) -> None:
+    """Validate a release assurance case payload against its JSON Schema."""
+
+    schema_path = (
+        get_repository_root() / "robot_sf/benchmark/schemas/release_assurance_case.schema.v1.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    Draft202012Validator(schema).validate(payload)
+    _validate_release_assurance_case_links(payload)
+
+
+def _ids_by_section(payload: dict[str, Any], section: str) -> set[str]:
+    """Return unique IDs for one list section, raising on duplicates."""
+
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for item in payload.get(section, []):
+        item_id = str(item.get("id", ""))
+        if item_id in seen:
+            duplicates.add(item_id)
+        seen.add(item_id)
+    if duplicates:
+        raise ValueError(f"{section} contains duplicate ids: {sorted(duplicates)}")
+    return seen
+
+
+def _validate_release_assurance_case_links(payload: dict[str, Any]) -> None:  # noqa: C901
+    """Validate claim -> argument -> evidence ID references."""
+
+    claim_ids = _ids_by_section(payload, "claims")
+    argument_ids = _ids_by_section(payload, "arguments")
+    evidence_ids = _ids_by_section(payload, "evidence")
+    for claim in payload.get("claims", []):
+        for argument_id in claim.get("argument_ids", []):
+            if argument_id not in argument_ids:
+                raise ValueError(f"claim {claim['id']} references missing argument {argument_id}")
+    for argument in payload.get("arguments", []):
+        if argument["claim_id"] not in claim_ids:
+            raise ValueError(
+                f"argument {argument['id']} references missing claim {argument['claim_id']}"
+            )
+        for evidence_id in argument.get("evidence_ids", []):
+            if evidence_id not in evidence_ids:
+                raise ValueError(
+                    f"argument {argument['id']} references missing evidence {evidence_id}"
+                )
+    for claim_id in payload.get("root_claim_ids", []):
+        if claim_id not in claim_ids:
+            raise ValueError(f"root_claim_ids references missing claim {claim_id}")
+    for argument_id in payload.get("root_argument_ids", []):
+        if argument_id not in argument_ids:
+            raise ValueError(f"root_argument_ids references missing argument {argument_id}")
+
+
+def validate_release_assurance_case_references(
+    payload: dict[str, Any],
+    *,
+    repo_root: Path | None = None,
+) -> list[ReleaseAssuranceEvidenceProblem]:
+    """Return stale or missing evidence-reference problems for ``payload``."""
+
+    root = (repo_root or get_repository_root()).resolve()
+    problems: list[ReleaseAssuranceEvidenceProblem] = []
+    for leaf in payload.get("evidence", []):
+        if not isinstance(leaf, dict):
+            continue
+        evidence_id = str(leaf.get("id", ""))
+        rel_path = str(leaf.get("path", ""))
+        expected_sha = str(leaf.get("sha256", ""))
+        if not rel_path:
+            problems.append(
+                ReleaseAssuranceEvidenceProblem(evidence_id, rel_path, "missing evidence path")
+            )
+            continue
+        path = Path(rel_path)
+        if not path.is_absolute():
+            path = root / path
+        if not path.is_file():
+            problems.append(
+                ReleaseAssuranceEvidenceProblem(evidence_id, rel_path, "evidence file not found")
+            )
+            continue
+        actual_sha = _sha256_file(path)
+        if actual_sha != expected_sha:
+            problems.append(
+                ReleaseAssuranceEvidenceProblem(
+                    evidence_id,
+                    rel_path,
+                    f"sha256 mismatch: recorded {expected_sha}, actual {actual_sha}",
+                )
+            )
+        expected_manifest_sha = leaf.get("expected_sha256")
+        if expected_manifest_sha and expected_manifest_sha != expected_sha:
+            problems.append(
+                ReleaseAssuranceEvidenceProblem(
+                    evidence_id,
+                    rel_path,
+                    (
+                        "manifest expected_sha256 does not match evidence sha256: "
+                        f"{expected_manifest_sha} != {expected_sha}"
+                    ),
+                )
+            )
+    return problems
+
+
+def write_release_assurance_case(payload: dict[str, Any], path: Path) -> Path:
+    """Write ``payload`` as stable, pretty JSON.
+
+    Returns:
+        Path that was written.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def load_release_assurance_case(path: str | Path) -> dict[str, Any]:
+    """Load a release assurance case JSON document.
+
+    Returns:
+        Parsed release assurance case object.
+    """
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Release assurance case must be a JSON object: {path}")
+    return payload
+
+
+def build_release_assurance_case_from_paths(
+    *,
+    manifest_path: Path,
+    gate_spec_path: Path | None = None,
+    release_gate_report_path: Path | None = None,
+    generated_at_utc: str | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Load path inputs and build a release assurance case payload.
+
+    Returns:
+        Release assurance case payload.
+    """
+
+    manifest = load_release_manifest(manifest_path)
+    return build_release_assurance_case(
+        manifest,
+        gate_spec_path=gate_spec_path,
+        release_gate_report_path=release_gate_report_path,
+        generated_at_utc=generated_at_utc,
+        repo_root=repo_root,
+    )

--- a/robot_sf/benchmark/schemas/release_assurance_case.schema.v1.json
+++ b/robot_sf/benchmark/schemas/release_assurance_case.schema.v1.json
@@ -1,0 +1,245 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/release_assurance_case.schema.v1.json",
+  "title": "Robot SF release assurance case (v1)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at_utc",
+    "release",
+    "claim_boundary",
+    "release_context",
+    "claims",
+    "arguments",
+    "evidence",
+    "root_claim_ids",
+    "root_argument_ids"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "benchmark_release_assurance_case.v1"
+    },
+    "generated_at_utc": {
+      "type": "string",
+      "minLength": 1
+    },
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "release_id",
+        "release_tag",
+        "benchmark_protocol_version",
+        "maturity"
+      ],
+      "properties": {
+        "release_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "release_tag": {
+          "type": "string",
+          "minLength": 1
+        },
+        "benchmark_protocol_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "maturity": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "claim_boundary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "release_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "planner_keys",
+        "planner_groups",
+        "seed_policy",
+        "kinematics_matrix",
+        "holonomic_command_mode",
+        "required_artifact_paths"
+      ],
+      "properties": {
+        "planner_keys": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "planner_groups": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "seed_policy": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "kinematics_matrix": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "holonomic_command_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "required_artifact_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "text",
+          "argument_ids"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1
+          },
+          "argument_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "arguments": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "claim_id",
+          "strategy",
+          "text",
+          "evidence_ids"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "claim_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "strategy": {
+            "type": "string",
+            "minLength": 1
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "gate": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "kind",
+          "description",
+          "path",
+          "sha256",
+          "manifest_field"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "kind": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "expected_sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "manifest_field": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "root_claim_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "root_argument_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/scripts/validation/check_release_assurance_case.py
+++ b/scripts/validation/check_release_assurance_case.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Generate or check release assurance case JSON.
+
+The default mode checks a checked-in worked example and fails closed if any
+evidence leaf is missing or its recorded SHA-256 no longer matches the file on
+disk.  Generation is explicit so CI does not silently refresh stale evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.release_assurance_case import (
+    build_release_assurance_case_from_paths,
+    load_release_assurance_case,
+    validate_release_assurance_case_references,
+    validate_release_assurance_case_schema,
+    write_release_assurance_case,
+)
+
+DEFAULT_CASE = Path("docs/context/evidence/issue_4683_release_assurance_case_example.json")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--case", type=Path, default=DEFAULT_CASE, help="Assurance case JSON path.")
+    parser.add_argument("--manifest", type=Path, help="Release manifest used when generating.")
+    parser.add_argument("--gate-spec", type=Path, help="Release gate spec used when generating.")
+    parser.add_argument(
+        "--gate-report", type=Path, help="Optional gate report used when generating."
+    )
+    parser.add_argument(
+        "--generated-at-utc",
+        help="Stable timestamp override for reproducible generated examples.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Generate --case from --manifest/--gate-spec instead of checking an existing case.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the release assurance case checker."""
+
+    args = _parse_args(argv)
+    if args.write:
+        if args.manifest is None:
+            raise SystemExit("--manifest is required with --write")
+        payload = build_release_assurance_case_from_paths(
+            manifest_path=args.manifest,
+            gate_spec_path=args.gate_spec,
+            release_gate_report_path=args.gate_report,
+            generated_at_utc=args.generated_at_utc,
+        )
+        validate_release_assurance_case_schema(payload)
+        problems = validate_release_assurance_case_references(payload)
+        if problems:
+            for problem in problems:
+                print(
+                    f"{problem.evidence_id}: {problem.path}: {problem.reason}",
+                    file=sys.stderr,
+                )
+            return 1
+        write_release_assurance_case(payload, args.case)
+        print(f"wrote {args.case}")
+        return 0
+
+    payload = load_release_assurance_case(args.case)
+    validate_release_assurance_case_schema(payload)
+    problems = validate_release_assurance_case_references(payload)
+    if problems:
+        for problem in problems:
+            print(f"{problem.evidence_id}: {problem.path}: {problem.reason}", file=sys.stderr)
+        return 1
+    print(
+        json.dumps(
+            {
+                "status": "valid",
+                "case": str(args.case),
+                "evidence_count": len(payload["evidence"]),
+                "claim_count": len(payload["claims"]),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_release_assurance_case.py
+++ b/tests/benchmark/test_release_assurance_case.py
@@ -1,0 +1,69 @@
+"""Tests for release assurance case export and stale-reference checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.release_assurance_case import (
+    build_release_assurance_case_from_paths,
+    validate_release_assurance_case_references,
+    validate_release_assurance_case_schema,
+)
+
+SMOKE_MANIFEST = Path(
+    "configs/benchmarks/releases/paper_experiment_matrix_v1_release_smoke_v0_1.yaml"
+)
+GATE_SPEC = Path("configs/benchmarks/release_gates/default_safety_comfort_gates.yaml")
+
+
+def test_release_assurance_case_exports_gate_claims_and_manifest_evidence() -> None:
+    """Exporter maps gate specs and release manifest inputs to claim evidence."""
+
+    payload = build_release_assurance_case_from_paths(
+        manifest_path=SMOKE_MANIFEST,
+        gate_spec_path=GATE_SPEC,
+        generated_at_utc="2026-07-06T00:00:00Z",
+    )
+
+    validate_release_assurance_case_schema(payload)
+    assert validate_release_assurance_case_references(payload) == []
+    assert payload["schema_version"] == "benchmark_release_assurance_case.v1"
+    assert payload["release"]["release_id"] == "paper_experiment_matrix_v1_smoke_v0_1_0"
+    assert "C_gate_collision_rate_zero" in {claim["id"] for claim in payload["claims"]}
+    assert "E_release_gate_spec" in {leaf["id"] for leaf in payload["evidence"]}
+    campaign_config = next(
+        leaf for leaf in payload["evidence"] if leaf["id"] == "E_campaign_config"
+    )
+    assert campaign_config["sha256"] == campaign_config["expected_sha256"]
+
+
+def test_release_assurance_case_reference_check_fails_on_stale_sha(tmp_path: Path) -> None:
+    """Checker fails closed when a referenced evidence checksum goes stale."""
+
+    payload = build_release_assurance_case_from_paths(
+        manifest_path=SMOKE_MANIFEST,
+        gate_spec_path=GATE_SPEC,
+        generated_at_utc="2026-07-06T00:00:00Z",
+    )
+    stale_payload = json.loads(json.dumps(payload))
+    stale_payload["evidence"][0]["sha256"] = "0" * 64
+
+    problems = validate_release_assurance_case_references(stale_payload)
+
+    assert problems
+    assert problems[0].evidence_id == "E_release_manifest"
+    assert "sha256 mismatch" in problems[0].reason
+
+
+def test_checked_in_release_assurance_case_example_stays_fresh() -> None:
+    """Worked example remains schema-valid and evidence-reference fresh."""
+
+    payload = json.loads(
+        Path("docs/context/evidence/issue_4683_release_assurance_case_example.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    validate_release_assurance_case_schema(payload)
+    assert validate_release_assurance_case_references(payload) == []


### PR DESCRIPTION
## Reviewer-critical summary

What changed: Adds a release assurance-case exporter for issue #4683: a JSON schema, builder, CLI checker, checked-in worked example, and tests that map release-manifest context plus gate specs into explicit claim -> argument -> evidence records with SHA-256 evidence leaves.

Why now: #4683 asks for the gate-spec direction from #4166 to become a machine-readable assurance layer for release bundles, with stale-reference checking so the case cannot drift from evidence artifacts.

Claim boundary: This is a release packaging/provenance contract only. It checks manifest/gate-spec/evidence-reference integrity and does not run a benchmark campaign or promote paper/dissertation claims.

Required validation: The PR includes a checked example at `docs/context/evidence/issue_4683_release_assurance_case_example.json`; `scripts/validation/check_release_assurance_case.py` validates schema links and fails closed if any evidence leaf SHA-256 is stale. `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed with clean-tree stamp `output/validation/pr_ready/issue-4683-assurance-export.json`.

Remaining blocker: None for #4683's code/test/CPU-validation acceptance. Future release runs still need actual release-bundle generation and campaign artifacts before any benchmark or paper claim can be strengthened.

Closes #4683

## Contract delta

New schema fields: `benchmark_release_assurance_case.v1` adds top-level `release`, `release_context`, `claims`, `arguments`, `evidence`, `root_claim_ids`, and `root_argument_ids`. Evidence leaves carry `path`, `sha256`, `manifest_field`, and optional `expected_sha256`.

New fail-closed blockers: the checker fails when JSON schema validation fails, claim/argument/evidence IDs do not resolve, evidence files are missing, evidence SHA-256 values drift, or manifest-pinned `expected_sha256` does not match the evidence leaf.

Compatibility impact: additive only. Existing release manifests, gate specs, and assurance-fragment exports remain unchanged. The PR also removes two machine-local absolute paths from an existing issue #1126 evidence note because the full readiness gate now checks the docs/context/evidence baseline.

State propagation: no separate issue comment/state update was made because this run lacks `comment_issue_or_pr` authorization; the PR body is the durable propagation surface for this slice.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Validation</summary>

- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_release_assurance_case.py` -> passed; `{"case":"docs/context/evidence/issue_4683_release_assurance_case_example.json","claim_count":7,"evidence_count":8,"status":"valid"}`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_release_assurance_case.py -q` -> passed; `3 passed`
- `source .venv/bin/activate && pytest tests/integration/test_check_config_abs_paths.py::TestCheckConfigAbsPaths::test_repo_baseline_is_clean -q` -> passed; `1 passed`
- `source .venv/bin/activate && python scripts/dev/check_docs_evidence_integrity.py --base-ref origin/main` -> passed; `docs/evidence integrity: 7 changed file(s) passed.`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; clean-tree stamp `output/validation/pr_ready/issue-4683-assurance-export.json`, head `71dece3afe5d832815c1200404b1e4f723ca1879`.

</details>
