### PR TITLE
fix: resolve prediction_mpc_cbf map runner lookup for issue #4680

### DIFF
--- a/docs/context/evidence/issue_1126_live_closure_audit_2026-07-06.md
+++ b/docs/context/evidence/issue_1126_live_closure_audit_2026-07-06.md
@@ -61,15 +61,13 @@ Fresh isolated worktree:
 scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/manage_external_data.py list
 # sdd: status missing
 # expected path:
-# /home/luttkule/git/robot_sf_ll7.worktrees/issue-1126-closure-audit-verify-acceptance-criteria-v2/output/external_data/sdd
+# /home/luttkule/git/robot_sf_ll7.worktrees/issue-1126-closure-audit-verify-acceptance-criteria-v2/output/external_data/sdd # allow-abs-path: historical machine-local closure-audit evidence path
 ```
 
 Pinned-tree root probe against the primary checkout output root also failed closed in this session:
 
 ```bash
-ROBOT_SF_EXTERNAL_DATA_ROOT=/home/luttkule/git/robot_sf_ll7/output/external_data \
-  scripts/dev/run_worktree_shared_venv.sh -- \
-  python scripts/tools/sdd_curation_preflight.py --json
+ROBOT_SF_EXTERNAL_DATA_ROOT=/home/luttkule/git/robot_sf_ll7/output/external_data scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/sdd_curation_preflight.py --json # allow-abs-path: historical machine-local closure-audit probe root
 # staging_mode=proxy_schema_smoke
 # dataset_backed=false
 # benchmark_promotion_allowed=false

--- a/robot_sf/benchmark/policy_builders.py
+++ b/robot_sf/benchmark/policy_builders.py
@@ -100,6 +100,7 @@ _ADAPTER_POLICY_BUILDERS: dict[str, Callable[[dict[str, Any]], AdapterPolicySpec
     "cv_prediction_mpc": _build_prediction_mpc_policy_spec,
     "prediction_aware_mpc": _build_prediction_mpc_policy_spec,
     "prediction_mpc": _build_prediction_mpc_policy_spec,
+    "prediction_mpc_cbf": _build_prediction_mpc_policy_spec,
     "risk_dwa": _build_risk_dwa_policy_spec,
     "teb": _build_teb_policy_spec,
 }

--- a/tests/validation/test_issue_4206_trace_capable_h600_rerun_preregistration.py
+++ b/tests/validation/test_issue_4206_trace_capable_h600_rerun_preregistration.py
@@ -237,6 +237,30 @@ def test_runnable_h600_config_loads_trace_capture_flags() -> None:
     ]
 
 
+def test_prediction_mpc_cbf_trace_campaign_arm_builds_map_runner_policy() -> None:
+    """The trace-capable campaign path accepts the prediction_mpc_cbf roster arm."""
+    from robot_sf.benchmark.camera_ready._config import load_campaign_config
+    from robot_sf.benchmark.map_runner import _build_policy
+
+    cfg = load_campaign_config(RUN_CONFIG_PATH)
+    planner = next(planner for planner in cfg.planners if planner.key == "prediction_mpc_cbf")
+    assert planner.algo == "prediction_mpc_cbf"
+    assert planner.algo_config_path is not None
+
+    algo_config = yaml.safe_load(planner.algo_config_path.read_text(encoding="utf-8"))
+    policy, meta = _build_policy(
+        planner.algo,
+        algo_config,
+        robot_kinematics="differential_drive",
+        robot_command_mode="unicycle",
+    )
+
+    assert policy._planner_adapter.__class__.__name__ == "PredictionMPCPlannerAdapter"
+    assert meta["algorithm"] == "prediction_mpc"
+    assert meta["cbf_safety_filter"]["status"] == "enabled"
+    assert meta["planner_kinematics"]["planner_command_space"] == "unicycle_vw"
+
+
 def test_runnable_h600_preflight_reports_guarded_ppo_accepted_unavailable(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: registers `prediction_mpc_cbf` in the map-runner adapter policy registry and adds a campaign-path regression test for the trace-capable h600 roster arm.

Why now: job 13320 attempt 5 failed after #4594 with `Unknown map-based algorithm 'prediction_mpc_cbf'` in the campaign execution path, so unit-level command-contract coverage was not enough.

Claim boundary: this PR proves the trace-capable campaign config can resolve and build the `prediction_mpc_cbf` map-runner policy for differential-drive/unicycle execution. It does not claim benchmark performance or paper/dissertation results.

Required validation: targeted campaign-path validation plus full PR readiness gate.

Remaining blocker: no code blocker remains for the reported lookup failure. Ops still needs to run the authorized attempt 6 campaign outside this PR.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: `prediction_mpc_cbf` now resolves through the existing prediction MPC adapter builder when invoked by the map-based campaign runner. Existing `prediction_mpc` and `prediction_aware_mpc` keys keep their current behavior.
- State propagation: no issue comment was added because this run is not authorized to comment on issues or PRs; this PR body is the durable propagation surface for the delivered slice.

## Summary

Closes #4680.

This PR makes the trace-capable h600 campaign path recognize `prediction_mpc_cbf` as the CBF-enabled prediction MPC adapter variant instead of failing with an unknown map-based algorithm error. It also adds a regression test that loads the trace-rerun campaign config, selects the `prediction_mpc_cbf` arm, and builds it through `robot_sf.benchmark.map_runner._build_policy`.

## Linked Issues

- Closes #4680
- Follows up #4594

## Stack / Dependency

- Base dependency: `origin/main`
- Required prior PRs: #4594 merged
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: this is a direct campaign-path follow-up to #4594.

## What Changed

- Added `prediction_mpc_cbf` to `_ADAPTER_POLICY_BUILDERS` so map-runner policy resolution can reach the existing prediction MPC adapter builder.
- Added a campaign-path regression test covering the trace-capable h600 config and the exact `_build_policy` lookup path that produced the job 13320 failure.
- Added two `allow-abs-path` annotations to pre-existing issue #1126 closure-audit evidence lines so the repository absolute-path baseline check can run cleanly on current `origin/main` content.

## Why Matters

- Added value: prevents the campaign arm from killing trace-capable reruns at map-runner policy construction.
- Expected impact: `prediction_mpc_cbf` should build as a CBF-enabled `PredictionMPCPlannerAdapter` arm in the campaign path.
- Why worth merging now: attempt 6 was described as the last authorized campaign rerun attempt, so the campaign-path smoke needs to be in place before another compute attempt.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: blocker-resolution for `prediction_mpc_cbf` campaign policy lookup.
- Comparator or baseline, applicable: baseline `origin/main` lacks the map-runner adapter registry entry.
- Evidence tier: NA - runtime construction blocker fix; validation proof is listed below.
- Result classification: NA - no research or benchmark result claimed.
- Decision stop rule, applicable: campaign-path test must build the `prediction_mpc_cbf` arm and expose CBF-enabled metadata without fallback/degraded execution.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #4680 via this PR body; no claim-map or benchmark report update because no benchmark result is claimed.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support/runtime blocker fix, no new analysis tool.

## Domain-Aware Approval

- Approver/review source waiver: not required; no research, benchmark, metric, figure-eligibility, or paper-facing result is claimed.
- Validity checklist:
- Target claim/hypothesis: lookup blocker only.
- Comparator split/evidence validity: `origin/main` lacked `prediction_mpc_cbf` in the adapter registry; changed branch resolves it through the campaign path.
- Fallback/degraded exclusions: targeted test builds the real adapter and checks CBF metadata; no fallback/degraded benchmark row is treated as success.
- Claim boundary: no benchmark-performance or paper-facing claim.
- Implementation integrity vs experimental validity: implementation is a registry alias to the existing builder; empirical validity remains for the subsequent campaign rerun.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes, targeted test builds `PredictionMPCPlannerAdapter` for `prediction_mpc_cbf`.
- Did intervention change command source, selected command, trajectory, route progress? no trajectory or route progress claim.
- Did scenario actually contain targeted failure mode? yes, the test uses the trace-capable h600 campaign config and map-runner policy lookup.
- Result route: continue to external campaign rerun.
- Follow-up question issue weak, negative, non-transfer results: none.

## Next Empirical Action

- Rerun needed: yes, attempt 6 campaign outside this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: campaign output artifact is not produced by this PR.
- Stop / revise / continue decision: continue with ops rerun after merge.
- Proposed child issue existing follow-up: none.

## Validation / Proof

- `PYTEST_NUM_WORKERS=8 uv run pytest tests/validation/test_issue_4206_trace_capable_h600_rerun_preregistration.py -q` - passed.
- `uv run ruff check robot_sf/benchmark/policy_builders.py tests/validation/test_issue_4206_trace_capable_h600_rerun_preregistration.py` - passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-4680/pr_body.md scripts/dev/pr_ready_check.sh` - passed.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance

- Baseline runtime: NA - lookup blocker fix, no performance claim.
- Changed runtime: NA - lookup blocker fix, no performance claim.
- Representative command: `PYTEST_NUM_WORKERS=8 uv run pytest tests/validation/test_issue_4206_trace_capable_h600_rerun_preregistration.py -q`
- Hot-path call count profile anchor: NA - no performance or caching claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if campaign-path lookup for existing prediction MPC keys regresses or `prediction_mpc_cbf` no longer builds through `_build_policy`.

## Risks / Rollout

- Compatibility risks: low; the new key reuses the existing prediction MPC adapter builder and config metadata path. The issue #1126 evidence edit is annotation-only for pre-existing machine-local proof paths.
- Failure modes: the external campaign may still fail later during runtime dynamics or artifact handling; this PR only fixes the construction-time registry miss.
- Rollback fallback plan: remove the registry key and test if the alias proves semantically wrong.

## Docs / Provenance

- Updated docs: validation-hygiene annotations in `docs/context/evidence/issue_1126_live_closure_audit_2026-07-06.md`.
- Relevant design provenance notes: issue #4680 and PR #4594.
- Any assumptions need to preserved: `prediction_mpc_cbf` is the CBF-enabled variant represented by existing prediction MPC config metadata, not a separate adapter implementation.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no, issue/PR commenting was not authorized for this run.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark result claimed.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no benchmark artifact produced.
- Registry or config index updated (yes/no/NA): yes, adapter policy registry updated in code.
- Context index / memory note updated (yes/no/NA): NA - no reusable research result or workflow note.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR fixes a runtime campaign-path blocker and leaves the empirical campaign rerun to ops.

## Follow-Up Issues

- Deferred work: external attempt 6 campaign rerun, no Slurm/GPU submission in this PR.
- Issues opened follow-up: none.

## Reviewer Notes

- Please verify the alias is the intended contract: `prediction_mpc_cbf` maps to `PredictionMPCPlannerAdapter` and relies on CBF metadata from the existing config. The issue #1126 evidence annotations are included only because final readiness failed on that pre-existing baseline file.
- Known limitations: campaign-level smoke proves construction only; it does not exercise the full h600 campaign.

<details>
<summary>Process appendix</summary>

- Fragmentation guard: no open PR covers #4680 or the exact title/scope; no recent merged #4680 micro-guard PRs were found.
- Late guidance check: issue #4680 was re-read before PR creation; no comments existed and no maintainer guidance newer than the start time was present.
- Artifact classification: no durable benchmark artifacts created; local `output/` contents were not used as proof.

</details>
