### PR TITLE
Issue #4682 emit campaign credibility scorecard

### DIFF
--- a/scripts/tools/analyze_camera_ready_campaign.py
+++ b/scripts/tools/analyze_camera_ready_campaign.py
@@ -371,6 +371,192 @@ def _load_scenario_difficulty_analysis(
     )
 
 
+def _credibility_check(
+    *,
+    check_id: str,
+    label: str,
+    status: str,
+    score: float,
+    evidence: str,
+    blocker: str | None = None,
+) -> dict[str, Any]:
+    """Build one deterministic NASA-7009-style credibility check row."""
+    return {
+        "check_id": check_id,
+        "label": label,
+        "status": status,
+        "score": max(0.0, min(1.0, float(score))),
+        "evidence": evidence,
+        "blocker": blocker,
+    }
+
+
+def _status_from_score(score: float) -> str:
+    """Map a numeric credibility score to a conservative status."""
+    if score >= 0.8:
+        return "pass"
+    if score >= 0.5:
+        return "warning"
+    return "fail"
+
+
+def _build_credibility_scorecard(
+    *,
+    diagnostics: list[dict[str, Any]],
+    findings: list[str],
+    scenario_difficulty: dict[str, Any],
+    summary_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a per-campaign credibility scorecard from emitted analysis artifacts."""
+    planner_count = len(diagnostics)
+    episode_count = sum(int(item.get("episodes_file", 0) or 0) for item in diagnostics)
+    run_findings = sum(len(item.get("findings", []) or []) for item in diagnostics)
+    fallback_count = sum(
+        1
+        for item in diagnostics
+        if str(item.get("preflight_status", "")).lower() in {"fallback", "degraded"}
+    )
+    absolute_path_count = sum(
+        int(item.get("absolute_map_path_count", 0) or 0) for item in diagnostics
+    )
+    scenario_rows = scenario_difficulty.get("scenario_rows")
+    scenario_count = len(scenario_rows) if isinstance(scenario_rows, list) else 0
+    artifacts = summary_payload.get("artifacts")
+    seed_rows = artifacts.get("seed_variability_json") if isinstance(artifacts, dict) else None
+
+    checks: list[dict[str, Any]] = [
+        _credibility_check(
+            check_id="traceable_campaign_artifacts",
+            label="Traceable campaign artifacts",
+            status="pass" if planner_count and episode_count else "fail",
+            score=1.0 if planner_count and episode_count else 0.0,
+            evidence=f"{planner_count} planner runs with {episode_count} episode records",
+            blocker=None if planner_count and episode_count else "No episode evidence found.",
+        )
+    ]
+
+    verification_score = 1.0
+    blockers: list[str] = []
+    if run_findings:
+        verification_score -= 0.4
+        blockers.append(f"{run_findings} planner consistency finding(s)")
+    if absolute_path_count:
+        verification_score -= 0.2
+        blockers.append(f"{absolute_path_count} absolute map path reference(s)")
+    verification_score = max(0.0, verification_score)
+    checks.append(
+        _credibility_check(
+            check_id="verification_consistency",
+            label="Verification consistency",
+            status=_status_from_score(verification_score),
+            score=verification_score,
+            evidence="; ".join(blockers) if blockers else "No analyzer consistency findings.",
+            blocker="; ".join(blockers) if verification_score < 0.5 else None,
+        )
+    )
+    checks.append(
+        _credibility_check(
+            check_id="validation_coverage",
+            label="Validation coverage",
+            status="pass" if scenario_count else "warning",
+            score=1.0 if scenario_count else 0.5,
+            evidence=(
+                f"{scenario_count} scenario difficulty row(s)"
+                if scenario_count
+                else "Scenario difficulty artifact unavailable."
+            ),
+        )
+    )
+    checks.append(
+        _credibility_check(
+            check_id="uncertainty_characterization",
+            label="Uncertainty characterization",
+            status="pass" if seed_rows else "warning",
+            score=1.0 if seed_rows else 0.5,
+            evidence=(
+                f"Seed variability artifact declared: {seed_rows}"
+                if seed_rows
+                else "No seed variability artifact declared."
+            ),
+        )
+    )
+    limitation_score = 1.0 if not fallback_count and not findings else 0.5
+    checks.append(
+        _credibility_check(
+            check_id="limitations_explicit",
+            label="Limitations explicit",
+            status=_status_from_score(limitation_score),
+            score=limitation_score,
+            evidence=(
+                "No fallback/degraded planner rows and no campaign findings."
+                if limitation_score == 1.0
+                else f"{fallback_count} fallback/degraded run(s); {len(findings)} campaign finding(s)"
+            ),
+        )
+    )
+
+    score = round(sum(float(item["score"]) for item in checks) / len(checks), 4)
+    fail_closed_blockers = [
+        str(item["blocker"])
+        for item in checks
+        if item.get("status") == "fail" and item.get("blocker")
+    ]
+    if fallback_count:
+        fail_closed_blockers.append(
+            f"{fallback_count} planner run(s) used fallback or degraded execution."
+        )
+    status = "credible_diagnostic"
+    if fail_closed_blockers:
+        status = "fail_closed"
+    elif score < 0.8:
+        status = "limited_diagnostic"
+    return {
+        "schema_version": "nasa-7009-style-credibility-scorecard.v1",
+        "status": status,
+        "score": score,
+        "claim_boundary": (
+            "Diagnostic campaign-report credibility only; not paper-facing evidence and "
+            "not a benchmark-success promotion."
+        ),
+        "checks": checks,
+        "fail_closed_blockers": fail_closed_blockers,
+    }
+
+
+def _credibility_scorecard_markdown_lines(scorecard: Any) -> list[str]:
+    """Render credibility scorecard lines for the campaign analysis report."""
+    if not isinstance(scorecard, dict) or not scorecard:
+        return []
+    lines = [
+        "## Credibility Scorecard",
+        "",
+        f"- Status: `{scorecard.get('status', 'unknown')}`",
+        f"- Score: `{_format_float(scorecard.get('score'))}`",
+        f"- Claim boundary: {scorecard.get('claim_boundary', 'diagnostic only')}",
+        "",
+        "| check | status | score | evidence | blocker |",
+        "|---|---|---:|---|---|",
+    ]
+    checks = scorecard.get("checks", [])
+    if isinstance(checks, list):
+        for check in checks:
+            if not isinstance(check, dict):
+                continue
+            lines.append(
+                "| "
+                f"{check.get('label', check.get('check_id', 'unknown'))} | "
+                f"{check.get('status', 'unknown')} | "
+                f"{_format_float(check.get('score'))} | "
+                f"{check.get('evidence', '')} | "
+                f"{check.get('blocker') or '-'} |"
+            )
+    blockers = scorecard.get("fail_closed_blockers", [])
+    if isinstance(blockers, list) and blockers:
+        lines.extend(["", "Fail-closed blockers:"])
+        lines.extend(f"- {blocker}" for blocker in blockers)
+    return lines
+
+
 def _analyze_planner(  # noqa: C901, PLR0915
     run_entry: dict[str, Any],
     row_entry: dict[str, Any] | None,
@@ -677,6 +863,7 @@ def _build_markdown_report(payload: dict[str, Any]) -> str:
     planners = payload.get("planners", [])
     runtime_hotspots = payload.get("runtime_hotspots", {})
     scenario_difficulty = payload.get("scenario_difficulty", {})
+    credibility_scorecard = payload.get("credibility_scorecard", {})
     findings = payload.get("findings", [])
     lines = [
         "# Camera-Ready Campaign Analysis",
@@ -741,6 +928,8 @@ def _build_markdown_report(payload: dict[str, Any]) -> str:
         lines.extend(
             [""] + _scenario_difficulty_markdown_lines(scenario_difficulty, heading_prefix="##")
         )
+
+    lines.extend([""] + _credibility_scorecard_markdown_lines(credibility_scorecard))
 
     lines.extend(["", "## Findings", ""])
     if findings:
@@ -813,6 +1002,12 @@ def analyze_campaign(
     for finding in scenario_difficulty.get("findings", []):
         findings.append(f"scenario_difficulty: {finding}")
     findings = sorted(set(findings))
+    credibility_scorecard = _build_credibility_scorecard(
+        diagnostics=diagnostics_payload,
+        findings=findings,
+        scenario_difficulty=scenario_difficulty,
+        summary_payload=summary_payload,
+    )
 
     return {
         "campaign": {
@@ -827,6 +1022,7 @@ def analyze_campaign(
             "slowest_planners": slowest_planners,
         },
         "scenario_difficulty": scenario_difficulty,
+        "credibility_scorecard": credibility_scorecard,
         "findings": findings,
     }
 

--- a/tests/tools/test_analyze_camera_ready_campaign.py
+++ b/tests/tools/test_analyze_camera_ready_campaign.py
@@ -11,6 +11,7 @@ import pytest
 
 from robot_sf.benchmark.scenario_difficulty import build_scenario_difficulty_analysis
 from scripts.tools.analyze_camera_ready_campaign import (
+    _build_markdown_report,
     _build_scenario_difficulty_markdown,
     analyze_campaign,
     main,
@@ -1136,3 +1137,33 @@ def test_analyze_campaign_cli_respects_output_overrides_for_difficulty_sidecars(
     }
     assert difficulty_json.exists()
     assert difficulty_md.exists()
+
+
+def test_analyze_campaign_emits_credibility_scorecard(tmp_path: Path) -> None:
+    """Campaign analysis emits a diagnostic credibility scorecard per campaign."""
+    campaign_root = tmp_path / "campaign"
+    _write_scenario_difficulty_campaign(campaign_root)
+
+    analysis = analyze_campaign(campaign_root)
+    scorecard = analysis["credibility_scorecard"]
+
+    assert scorecard["schema_version"] == "nasa-7009-style-credibility-scorecard.v1"
+    assert scorecard["status"] == "credible_diagnostic"
+    assert scorecard["score"] == pytest.approx(0.82)
+    assert "not paper-facing evidence" in scorecard["claim_boundary"]
+    assert {check["check_id"] for check in scorecard["checks"]} == {
+        "traceable_campaign_artifacts",
+        "verification_consistency",
+        "validation_coverage",
+        "uncertainty_characterization",
+        "limitations_explicit",
+    }
+    assert scorecard["fail_closed_blockers"] == []
+    checks_by_id = {check["check_id"]: check for check in scorecard["checks"]}
+    assert checks_by_id["verification_consistency"]["status"] == "warning"
+    assert checks_by_id["limitations_explicit"]["status"] == "warning"
+
+    markdown = _build_markdown_report(analysis)
+    assert "## Credibility Scorecard" in markdown
+    assert "| Traceable campaign artifacts | pass | 1.0000 |" in markdown
+    assert "not a benchmark-success promotion" in markdown


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `scripts/tools/analyze_camera_ready_campaign.py` now emits a per-campaign NASA-7009-style credibility scorecard in `campaign_analysis.json` and renders it in `campaign_analysis.md`. The scorecard is built from already-emitted campaign analysis surfaces: planner diagnostics, scenario-difficulty analysis, seed-variability artifact presence, fallback/degraded execution, and campaign findings.

Why now: issue #4682 asks for the scorecard to be emitted per campaign; this adds it to the canonical camera-ready campaign report builder rather than creating a parallel reporting script.

Claim scope: campaign-report credibility review only. This PR does not promote any benchmark result, paper/dissertation claim, or campaign outcome.

Required validation: focused analyzer tests plus final repository PR readiness.

Remaining blocker: none for the reporting contract. Campaign execution is not required by issue #4682 and remains outside this PR.

Refs #4682

## Contract delta

New schema fields:

- `campaign_analysis.json.credibility_scorecard.schema_version`: `nasa-7009-style-credibility-scorecard.v1`
- `campaign_analysis.json.credibility_scorecard.status`: `credible_diagnostic`, `limited_diagnostic`, or `fail_closed`
- `campaign_analysis.json.credibility_scorecard.score`: average score across emitted checks, rounded to four decimals
- `campaign_analysis.json.credibility_scorecard.claim_boundary`: fixed diagnostic report boundary text
- `campaign_analysis.json.credibility_scorecard.checks[]`: deterministic rows with `check_id`, `label`, `status`, `score`, `evidence`, and `blocker`
- `campaign_analysis.json.credibility_scorecard.fail_closed_blockers[]`: fail-closed blockers derived from failed checks plus fallback/degraded execution

New fail-closed blockers:

- No planner/episode evidence found produces `status=fail_closed`.
- Fallback or degraded planner execution adds an explicit fail-closed blocker.

Compatibility impact:

- Additive JSON and Markdown report fields only.
- No campaign runner, benchmark metric, schema migration, or result-store behavior changed.

## Scope summary

- Extended the canonical camera-ready campaign analyzer to emit the credibility scorecard per analyzed campaign.
- Added focused coverage in `tests/tools/test_analyze_camera_ready_campaign.py` for JSON schema, diagnostic status, warning checks, fail-closed blocker absence in the rich fixture, and Markdown rendering.

## Validation

- `uv run ruff format scripts/tools/analyze_camera_ready_campaign.py tests/tools/test_analyze_camera_ready_campaign.py` -> passed, 2 files left unchanged after final run.
- `uv run ruff check scripts/tools/analyze_camera_ready_campaign.py tests/tools/test_analyze_camera_ready_campaign.py` -> passed.
- `uv run pytest tests/tools/test_analyze_camera_ready_campaign.py -q` -> passed, 16 passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed on dirty tree before commit, 1919 passed, 2 skipped.
- `PR_READY_PR_BODY_FILE=$COMMON_GIT_DIR/codex-agent-runs/active/issue-4682/PR_BODY.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed before PR open.

## Follow-Up Issues

- Deferred work: none. This PR completes the requested reporting contract for issue #4682; no residual implementation scope is deferred.
- Issues opened follow-up: none.

## Domain-Aware Approval

Required PR: credibility scorecard review for campaign reporting wording.
Domains reviewed: benchmark reporting semantics, fallback/degraded exclusions, paper-facing result claim boundary.
Status: approved waiver for support/reporting change.
Approver/review source waiver: approved by implementer self-review; maintainer ratification occurs through PR review.
Approval or blocker note: approved credibility-reporting surface; no blocker remains for PR review.
Target claim/hypothesis: support/reporting contract for issue #4682, emit per-campaign credibility diagnostics without promoting benchmark claims.
Comparator or split/evidence validity: no comparator, split, seed schedule, or empirical evidence set is changed; the scorecard reads existing campaign-analysis artifacts only.
Fallback/degraded exclusions: fallback or degraded execution is recorded as a scorecard fail-closed blocker, not success evidence.
Claim scope: diagnostic campaign-report credibility only; not evidence for paper-facing result claims and not promotion to benchmark success.
Implementation integrity vs experimental validity: implementation integrity covered by focused tests and PR readiness; experimental validity remains outside scope because no campaign result is interpreted.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No transient target-host or packet-lineage state encoded in tracked files.

## State propagation

No separate issue comment is needed: this non-draft PR uses `Refs #4682`, includes the delivered slice and claim boundary, and issue #4682 has no existing comment thread or high-churn state surface to consolidate.

<details>
<summary>Process appendix</summary>

- Live issue refreshed before opening: issue body is a CCR pointer, zero comments, last updated 2026-07-06T18:14:26Z.
- Open PR dedupe search for `4682 OR NASA-7009 OR credibility scorecard` returned no open PRs.
- Fragmentation guard: no merged guardrail/checker/packet-refresh PRs found for this issue in the prior 24h; this PR is a progression slice adding the nameable scorecard-emission capability.
- Artifact classification: readiness artifacts under ignored `output/coverage/` and `output/validation/`; no generated output committed.

</details>