### PR TITLE
fix(#1126): unblock CI baseline — annotate abs-path lines in closure-audit evidence

### DIFF
--- a/docs/context/evidence/issue_1126_live_closure_audit_2026-07-06.md
+++ b/docs/context/evidence/issue_1126_live_closure_audit_2026-07-06.md
@@ -61,13 +61,13 @@ Fresh isolated worktree:
 scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/manage_external_data.py list
 # sdd: status missing
 # expected path:
-# /home/luttkule/git/robot_sf_ll7.worktrees/issue-1126-closure-audit-verify-acceptance-criteria-v2/output/external_data/sdd
+# /home/luttkule/git/robot_sf_ll7.worktrees/issue-1126-closure-audit-verify-acceptance-criteria-v2/output/external_data/sdd  # allow-abs-path: verbatim recorded tool output (session worktree)
 ```
 
 Pinned-tree root probe against the primary checkout output root also failed closed in this session:
 
 ```bash
-ROBOT_SF_EXTERNAL_DATA_ROOT=/home/luttkule/git/robot_sf_ll7/output/external_data \
+ROBOT_SF_EXTERNAL_DATA_ROOT="$HOME"/git/robot_sf_ll7/output/external_data \
   scripts/dev/run_worktree_shared_venv.sh -- \
   python scripts/tools/sdd_curation_preflight.py --json
 # staging_mode=proxy_schema_smoke


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** annotate/portably-rewrite two absolute home-dir paths in `docs/context/evidence/issue_1126_live_closure_audit_2026-07-06.md`.

**Why now:** PR #4677 (`2546d6394`) merged this evidence file to `main` with two unannotated absolute home-dir paths (lines 64, 70). `tests/integration/test_check_config_abs_paths.py::TestCheckConfigAbsPaths::test_repo_baseline_is_clean` runs a **whole-repo** scan, so this breakage fails fast-feedback shard-2 on **every** open PR (#4685, #4679, #4552 all confirmed red on exactly these two lines), independent of what those PRs change.

**Fix:**
- Line 64 (verbatim tool output inside a bash block) — appended `# allow-abs-path: verbatim recorded tool output (session worktree)`; keeps the recorded path literal and honest per the checker's intended annotation mechanism.
- Line 70 (a runnable command with a trailing `\` continuation that cannot take a trailing marker) — rewritten to `"$HOME"/git/robot_sf_ll7/...`, which is more portable and still runnable.

**Claim boundary:** docs-only evidence hygiene fix. No code, config-semantics, benchmark, or paper claims. Unblocks the PR queue.

**Validation:**
- `uv run pytest tests/integration/test_check_config_abs_paths.py::TestCheckConfigAbsPaths::test_repo_baseline_is_clean -q` — **1 passed** (was failing on `main`).
- `python3 hooks/check_config_abs_paths.py` — exit 0.

Refs #1126
