### PR TITLE
Issue #1126: add SDD candidate scan preflight

### DIFF
--- a/docs/context/issue_1126_sdd_curation_preflight.md
+++ b/docs/context/issue_1126_sdd_curation_preflight.md
@@ -29,6 +29,12 @@ scenario into ignored `output/`, and runs two CPU `simple_policy` smoke jobs. Th
 benchmark-ready scenario-set criterion. The final integration audit is
 [`evidence/issue_1126_final_integration_2026-07-06.md`](evidence/issue_1126_final_integration_2026-07-06.md).
 
+PR #4685 added deterministic `benchmark_ready_next_plan` output to the smoke classifier. This
+candidate-scan slice adds `--scan-root` / `--scan-limit` to the preflight so the next CPU-only
+empirical action can rank staged `annotations.txt` files before import/smoke. The scan reuses the
+importer's parser, writes no derived artifacts, copies no raw SDD files, and still cannot promote a
+benchmark claim unless the external-data gate is dataset-backed.
+
 ## Owners
 
 - SDD staging gate: `scripts/tools/manage_external_data.py`
@@ -47,6 +53,9 @@ scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/manage_external_
 
 scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/sdd_curation_preflight.py --json
 # dataset_backed_prior, benchmark_promotion_allowed false until selected annotation probe passes
+
+scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/sdd_curation_preflight.py --scan-root output/external_data/sdd --scan-limit 5 --json
+# candidate_scan ranks satisfiable annotations.txt files; still proxy-only unless dataset-backed gate passes
 ```
 
 Without the pinned tree present, the same commands still fail closed as `proxy_schema_smoke` and

--- a/scripts/tools/sdd_curation_preflight.py
+++ b/scripts/tools/sdd_curation_preflight.py
@@ -179,6 +179,59 @@ def probe_annotation_file(
     return report
 
 
+def scan_annotation_candidates(
+    root: Path,
+    *,
+    label: str,
+    min_track_points: int,
+    max_pedestrians: int,
+    limit: int = 5,
+) -> dict[str, Any]:
+    """Rank staged SDD annotation candidates without writing derived artifacts."""
+    annotations = sorted(root.rglob("annotations.txt")) if root.is_dir() else []
+    probes = [
+        probe_annotation_file(
+            path,
+            label=label,
+            min_track_points=min_track_points,
+            max_pedestrians=max_pedestrians,
+        )
+        for path in annotations
+    ]
+    ranked = sorted(
+        probes,
+        key=lambda probe: (
+            not probe["selection_satisfiable"],
+            -int(probe["usable_track_count"]),
+            -int(probe["usable_label_points"]),
+            probe["path"],
+        ),
+    )
+    selected = ranked[:limit] if limit > 0 else ranked
+    satisfiable_count = sum(1 for probe in probes if probe["selection_satisfiable"])
+    blockers = []
+    if not root.is_dir():
+        blockers.append(f"scan root is not a directory: {root}")
+    elif not annotations:
+        blockers.append(f"no annotations.txt files found below: {root}")
+    elif satisfiable_count == 0:
+        blockers.append(
+            f"no scanned annotation satisfies >= {min_track_points} usable "
+            f"'{import_sdd_scenarios.normalize_sdd_label(label)}' points"
+        )
+    return {
+        "root": str(root),
+        "label": import_sdd_scenarios.normalize_sdd_label(label),
+        "min_track_points": min_track_points,
+        "max_pedestrians": max_pedestrians,
+        "annotation_file_count": len(annotations),
+        "satisfiable_count": satisfiable_count,
+        "limit": limit,
+        "candidates": selected,
+        "blockers": blockers,
+    }
+
+
 def classify_curation_readiness(
     staging_gate: dict[str, Any],
     annotation_probe: dict[str, Any] | None = None,
@@ -274,6 +327,8 @@ def run_preflight(
     *,
     manifest_path: Path | None,
     annotation: Path | None,
+    scan_root: Path | None,
+    scan_limit: int,
     label: str,
     min_track_points: int,
     max_pedestrians: int,
@@ -288,7 +343,16 @@ def run_preflight(
             min_track_points=min_track_points,
             max_pedestrians=max_pedestrians,
         )
-    return classify_curation_readiness(staging_gate, probe)
+    report = classify_curation_readiness(staging_gate, probe)
+    if scan_root is not None:
+        report["candidate_scan"] = scan_annotation_candidates(
+            scan_root,
+            label=label,
+            min_track_points=min_track_points,
+            max_pedestrians=max_pedestrians,
+            limit=scan_limit,
+        )
+    return report
 
 
 def _shell_arg(value: str | Path) -> str:
@@ -557,6 +621,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Optional candidate SDD annotation file to probe against the curation selection rule.",
     )
+    parser.add_argument(
+        "--scan-root",
+        type=Path,
+        default=None,
+        help="Optional staged SDD root to scan for ranked annotations.txt curation candidates.",
+    )
+    parser.add_argument(
+        "--scan-limit",
+        type=int,
+        default=5,
+        help="Maximum ranked scan candidates to include; use 0 to include all.",
+    )
     parser.add_argument("--label", default="Pedestrian", help="SDD label to probe for.")
     parser.add_argument("--min-track-points", type=int, default=8)
     parser.add_argument("--max-pedestrians", type=int, default=4)
@@ -611,6 +687,8 @@ def main(argv: list[str] | None = None) -> int:
     report = run_preflight(
         manifest_path=args.manifest,
         annotation=args.annotation,
+        scan_root=args.scan_root,
+        scan_limit=args.scan_limit,
         label=args.label,
         min_track_points=args.min_track_points,
         max_pedestrians=args.max_pedestrians,

--- a/tests/tools/test_sdd_curation_preflight.py
+++ b/tests/tools/test_sdd_curation_preflight.py
@@ -628,3 +628,77 @@ def test_smoke_decision_fails_closed_when_artifacts_do_not_load() -> None:
     )
     assert "generated artifacts did not load" in decision["benchmark_ready_next_plan"]["blockers"]
     assert any("did not load" in reason for reason in decision["reasons"])
+
+
+def test_scan_annotation_candidates_ranks_satisfiable_candidates(tmp_path: Path) -> None:
+    """Candidate scanner ranks usable staged annotations without writing derived artifacts."""
+    weak = tmp_path / "annotations" / "bookstore" / "video0" / "annotations.txt"
+    strong = tmp_path / "annotations" / "deathCircle" / "video0" / "annotations.txt"
+    weak.parent.mkdir(parents=True)
+    strong.parent.mkdir(parents=True)
+    weak.write_text(
+        "\n".join(
+            [
+                "1 0 0 10 10 0 0 0 0 Pedestrian",
+                "1 5 0 15 10 5 0 0 0 Pedestrian",
+                "1 10 0 20 10 10 0 0 0 Pedestrian",
+                "1 15 0 25 10 15 0 0 0 Pedestrian",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    _write_sdd_fixture(strong)
+
+    scan = sdd_curation_preflight.scan_annotation_candidates(
+        tmp_path,
+        label="Pedestrian",
+        min_track_points=4,
+        max_pedestrians=4,
+        limit=1,
+    )
+
+    assert scan["annotation_file_count"] == 2
+    assert scan["satisfiable_count"] == 2
+    assert scan["blockers"] == []
+    assert len(scan["candidates"]) == 1
+    assert scan["candidates"][0]["path"] == str(strong)
+    assert scan["candidates"][0]["usable_track_count"] == 2
+
+
+def test_cli_scan_root_reports_candidates_without_benchmark_claim(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """CLI scan output remains proxy-only unless external-data staging gate is dataset-backed."""
+    annotations = tmp_path / "annotations" / "bookstore" / "video0" / "annotations.txt"
+    annotations.parent.mkdir(parents=True)
+    _write_sdd_fixture(annotations)
+    monkeypatch.setattr(
+        manage_external_data,
+        "resolve_sdd_scenario_prior_mode",
+        lambda manifest_path=None: {
+            "mode": manage_external_data.SDD_MODE_PROXY,
+            "dataset_backed": False,
+            "availability": {"state": "missing"},
+            "reason": "SDD not staged.",
+            "staging_dir": str(tmp_path),
+        },
+    )
+
+    exit_code = sdd_curation_preflight.main(
+        [
+            "--scan-root",
+            str(tmp_path),
+            "--scan-limit",
+            "1",
+            "--min-track-points",
+            "4",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["benchmark_promotion_allowed"] is False
+    assert report["output_classification"] == sdd_curation_preflight.OUTPUT_BLOCKED
+    assert report["candidate_scan"]["satisfiable_count"] == 1
+    assert report["candidate_scan"]["candidates"][0]["path"] == str(annotations)


### PR DESCRIPTION
Reviewer-critical summary

What changed: adds `scan_annotation_candidates()` plus `--scan-root` / `--scan-limit` to `scripts/tools/sdd_curation_preflight.py`, with fixture-backed tests and the #1126 context note updated as the high-churn state surface.

Why now: issue #1126 remains open after PR #4685 because the only real SDD candidate is still `exploratory_only`; the remaining empirical step is to choose/tune/select a benchmark-ready candidate. This slice adds the deterministic candidate ranking needed before the next CPU import/smoke attempt.

Claim boundary: metadata/preflight capability only. This PR does not import SDD, generate/commit scenario artifacts, run a benchmark campaign, submit Slurm/GPU work, or make paper/dissertation claims.

Required validation:

- `scripts/dev/run_worktree_shared_venv.sh -- python -m ruff format scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` -> pass, 2 files unchanged
- `scripts/dev/run_worktree_shared_venv.sh -- python -m ruff check scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` -> pass
- `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/tools/test_sdd_curation_preflight.py -q` -> pass, 26 tests
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/sdd_curation_preflight.py --scan-root output/external_data/sdd --scan-limit 5 --json` -> pass; fail-closed report with `benchmark_promotion_allowed=false`, `output_classification=blocked`, and `candidate_scan.blockers=["scan root is not a directory: output/external_data/sdd"]`

Remaining blocker: #1126 still needs a staged dataset-backed SDD tree and a benchmark-ready CPU import/smoke result. Current real evidence remains `exploratory_only` because `bookstore/video0` timed out.

Contract delta

- New report field: `candidate_scan`, emitted only when `--scan-root` is provided.
- New CLI flags: `--scan-root <path>` and `--scan-limit <n>`.
- New fail-closed blocker: missing/non-directory scan root or no satisfiable `annotations.txt` files is reported inside `candidate_scan.blockers`.
- Compatibility impact: default preflight behavior is unchanged when `--scan-root` is omitted; scanner writes no derived artifacts and does not affect `benchmark_promotion_allowed`.
- State propagation: high-churn #1126 state is updated in `docs/context/issue_1126_sdd_curation_preflight.md` instead of adding another issue comment.

Refs #1126

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Acceptance evidence and late-guidance check</summary>

Issue #1126 acceptance map after reading the live issue and comments:

| Criterion | Current evidence | Status after this PR |
| --- | --- | --- |
| Official/BYO SDD source staged with provenance/checksum or fail-closed blocker | PR #4638 pinned expected SDD tree checksum; this worktree lacks local SDD bytes and the scanner reports missing root fail-closed. | Still requires staged local data for next empirical run. |
| One scene/video selected by deterministic rationale | PR #4638 selected `bookstore/video0`; smoke timed out. This PR adds ranking over staged annotations so alternate selection is deterministic. | Progression capability added; benchmark-ready selection still requires real data scan + smoke. |
| Import command, source identity, checksums, license/source URL, scale assumptions recorded | PR #4616/#4638 recorded fixed importer command and scale assumption. | Unchanged. |
| Generated scenario/map artifacts pass loading/parser validation | PR #4638 recorded exploratory generated outputs loaded. | Unchanged; no new artifacts generated. |
| Representative smoke succeeds or rejects explicitly | PR #4638/#4647/#4668 rejected closure because smoke timed out; PR #4685 added next-plan classification. | Unchanged; this PR enables deterministic next candidate selection. |
| `benchmark_ready` vs `exploratory_only` documented | PR #4647/#4668 and current context note document `exploratory_only`. | Preserved. |
| Only small reviewable artifacts/durable pointers committed | This PR changes only preflight code, tests, and context note. | Met. |

Late guidance guard: immediately before PR creation, `gh issue view 1126 --repo ll7/robot_sf_ll7 --comments` showed no maintainer comments newer than the PR #4685 gate note already incorporated. Open PR dedupe search returned `[]`.
</details>
