### PR TITLE
Issue #4692: resolve phantom dash matches on split-list config commands (cheap-lane worker)

### DIFF
--- a/scripts/dev/check_docs_evidence_integrity.py
+++ b/scripts/dev/check_docs_evidence_integrity.py
@@ -492,7 +492,9 @@ def _extract_cited_paths(text: str) -> set[str]:
     for match in _CITED_REPO_PATH.finditer(text):
         paths.add(_clean_cited_path(match.group("path")))
     paths -= output_paths
-    return {path for path in paths if path and not _looks_dynamic(path)}
+    return {
+        path for path in paths if path and not _looks_dynamic(path) and not path.startswith("-")
+    }
 
 
 def _is_artifact_registry(path: Path) -> bool:

--- a/tests/dev/test_check_docs_evidence_integrity.py
+++ b/tests/dev/test_check_docs_evidence_integrity.py
@@ -388,3 +388,34 @@ def test_blocking_mode_fails_on_problems(tmp_path: Path, monkeypatch: MonkeyPatc
     (tmp_path / "broken.json").write_text("{not valid}", encoding="utf-8")
 
     assert main(["--files", "broken.json"]) == 1
+
+
+def test_split_list_config_does_not_yield_phantom_dash(tmp_path: Path) -> None:
+    """A YAML or markdown document splitting --config and its value doesn't yield '-'."""
+    config_file = tmp_path / "configs/training/learned_risk_model_v1.yaml"
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text("model: learned_risk\n", encoding="utf-8")
+
+    note = tmp_path / "docs/context/issue_4692.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        "command:\n  - --config\n  - configs/training/learned_risk_model_v1.yaml\n",
+        encoding="utf-8",
+    )
+
+    problems = check_files([note.relative_to(tmp_path).as_posix()], root=tmp_path)
+    assert problems == []
+
+
+def test_split_list_config_still_detects_genuine_missing_path(tmp_path: Path) -> None:
+    """A split-list config command still reports the config if it does not exist."""
+    note = tmp_path / "docs/context/issue_4692.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        "command:\n  - --config\n  - configs/training/missing_config_file.yaml\n",
+        encoding="utf-8",
+    )
+
+    problems = check_files([note.relative_to(tmp_path).as_posix()], root=tmp_path)
+    assert len(problems) == 1
+    assert "configs/training/missing_config_file.yaml" in problems[0]


### PR DESCRIPTION
## Summary of Changes

### What & Why
In `scripts/dev/check_docs_evidence_integrity.py`, the `_CONFIG_FLAG` regex matched a split list-form config command (where `--config` is on one item and the yaml file path on the next) by consuming the newline, indentation, and list-dash `-` as the config path. This resulted in a phantom cited path `-` which failed the integrity checks.
We resolved this by filtering out extracted cited paths starting with a dash `-` in `_extract_cited_paths` (no valid repository path starts with a dash).

### Acceptance Criteria Covered
- List-form `--config` / value commands no longer yield a phantom `-` cited path.
- Added regression tests covering the split-list command form and checking that genuine missing paths are still correctly detected.

## Validation Output

- Ran `uv run pytest tests/dev/test_check_docs_evidence_integrity.py` -> passed (24 tests).
- Ran `uv run pytest tests/dev` -> passed (625 tests).
- Ran `uv run ruff check . --fix && uv run ruff format .` -> passed.

Closes #4692

This PR was produced by the agy/Gemini-3.5-Flash cheap implementation lane; the review gate hardens and merges.
