### PR TITLE
Issue #1126: add SDD curation integration report

### DIFF
--- a/scripts/tools/sdd_curation_preflight.py
+++ b/scripts/tools/sdd_curation_preflight.py
@@ -43,6 +43,7 @@ from scripts.tools import import_sdd_scenarios, manage_external_data
 
 PREFLIGHT_SCHEMA = "sdd_curation_preflight.v1"
 DECISION_PACKET_SCHEMA = "robot_sf_sdd_curation_decision_packet.v1"
+INTEGRATION_REPORT_SCHEMA = "robot_sf_sdd_curation_integration_report.v1"
 ISSUE = 1126
 
 # Curation evidence states (kept strictly distinct so a proxy run can never read as benchmark).
@@ -581,6 +582,167 @@ def classify_smoke_decision(
     }
 
 
+def _criterion(
+    criterion: str,
+    status: str,
+    evidence: str,
+    remaining: str | None = None,
+) -> dict[str, str]:
+    """Build one stable issue #1126 acceptance row."""
+    row = {
+        "criterion": criterion,
+        "status": status,
+        "evidence": evidence,
+    }
+    if remaining:
+        row["remaining"] = remaining
+    return row
+
+
+def build_integration_report(
+    readiness: dict[str, Any],
+    *,
+    smoke_decision: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Summarize #1126 closure state from readiness and optional smoke evidence.
+
+    This is a report-only contract. It consolidates the staged-data, candidate-selection,
+    and smoke-decision gates without importing data, writing derived scenario artifacts, or
+    promoting an exploratory candidate as benchmark-ready.
+    """
+    dataset_backed = bool(readiness.get("dataset_backed", False))
+    benchmark_promotion_allowed = bool(readiness.get("benchmark_promotion_allowed", False))
+    annotation_probe = readiness.get("annotation_probe") or {}
+    candidate_scan = readiness.get("candidate_scan") or {}
+    scan_candidates = candidate_scan.get("candidates") or []
+
+    classification = smoke_decision.get("classification") if smoke_decision is not None else None
+    benchmark_ready = classification == SMOKE_BENCHMARK_READY
+    exploratory_only = classification == SMOKE_EXPLORATORY_ONLY
+
+    if benchmark_ready:
+        closure_status = "ready_to_close"
+        next_action = "close_issue_after_reviewer_confirms_benchmark_ready_boundary"
+    elif exploratory_only:
+        closure_status = "open_exploratory_only"
+        next_action = "tune_current_candidate_or_select_alternate_scene"
+    elif dataset_backed and scan_candidates:
+        closure_status = "open_empirical_action_ready"
+        next_action = "import_top_ranked_candidate_and_run_one_cpu_smoke"
+    elif dataset_backed:
+        closure_status = "open_needs_candidate_selection"
+        next_action = "scan_or_probe_staged_annotations_for_satisfiable_candidate"
+    else:
+        closure_status = "blocked_external_input"
+        next_action = "stage_or_restore_licensed_sdd_annotations_then_rerun_preflight"
+
+    criteria = [
+        _criterion(
+            "#1497 staged official/BYO SDD source annotations locally or recorded failure keeps issue blocked.",
+            "met" if dataset_backed else "blocked",
+            (
+                f"staging_mode={readiness.get('staging_mode')}; "
+                f"dataset_backed={dataset_backed}; "
+                f"staging_reason={readiness.get('staging_reason')}"
+            ),
+            None
+            if dataset_backed
+            else "Restore or stage the licensed SDD tree with checksum/license provenance.",
+        ),
+        _criterion(
+            "One scene/video selected with deterministic selection rationale.",
+            "met"
+            if annotation_probe.get("selection_satisfiable")
+            else "actionable"
+            if scan_candidates
+            else "pending",
+            (
+                f"annotation_probe={annotation_probe or None}; "
+                f"candidate_scan_satisfiable_count={candidate_scan.get('satisfiable_count')}"
+            ),
+            None
+            if annotation_probe.get("selection_satisfiable")
+            else "Probe/import the top ranked satisfiable candidate from candidate_scan.",
+        ),
+        _criterion(
+            "Import command, source identity, checksums, license/source URL, and scale assumptions recorded.",
+            "met" if benchmark_promotion_allowed else "pending",
+            (
+                "readiness permits benchmark promotion"
+                if benchmark_promotion_allowed
+                else "benchmark promotion is still fail-closed"
+            ),
+            None
+            if benchmark_promotion_allowed
+            else "Record selected annotation, checksum/license provenance, and meters-per-pixel before promotion.",
+        ),
+        _criterion(
+            "Generated scenario/map artifacts pass repository loading/parser validation.",
+            "met"
+            if smoke_decision and smoke_decision.get("generated_artifacts_load")
+            else "pending",
+            (
+                f"generated_artifacts_load={smoke_decision.get('generated_artifacts_load')}"
+                if smoke_decision
+                else "no smoke decision supplied"
+            ),
+            None
+            if smoke_decision and smoke_decision.get("generated_artifacts_load")
+            else "Run importer and load generated scenario/map/provenance artifacts.",
+        ),
+        _criterion(
+            "At least one representative smoke run succeeds or output explicitly rejected with reasons.",
+            "met" if smoke_decision else "pending",
+            (
+                f"classification={classification}; reasons={smoke_decision.get('reasons')}"
+                if smoke_decision
+                else "no representative smoke decision supplied"
+            ),
+            None if smoke_decision else "Run one CPU representative smoke and classify the result.",
+        ),
+        _criterion(
+            "Documentation states benchmark_ready vs exploratory_only status.",
+            "met" if smoke_decision else "pending",
+            (
+                f"benchmark_ready={benchmark_ready}; exploratory_only={exploratory_only}"
+                if smoke_decision
+                else f"output_classification={readiness.get('output_classification')}"
+            ),
+            None if smoke_decision else "Attach smoke decision before closure.",
+        ),
+        _criterion(
+            "Only small reviewable artifacts or durable pointers committed.",
+            "met",
+            "integration report is metadata-only; raw SDD and generated scenario outputs remain untracked",
+        ),
+    ]
+
+    blockers = [
+        row["remaining"] for row in criteria if row["status"] != "met" and row.get("remaining")
+    ]
+
+    return {
+        "schema": INTEGRATION_REPORT_SCHEMA,
+        "issue": ISSUE,
+        "closure_status": closure_status,
+        "next_empirical_action": next_action,
+        "claim_boundary": (
+            "integration report only; no raw SDD commit, generated scenario promotion, "
+            "full benchmark campaign, Slurm/GPU submission, or paper-facing claim"
+        ),
+        "readiness_summary": {
+            "staging_mode": readiness.get("staging_mode"),
+            "dataset_backed": dataset_backed,
+            "benchmark_promotion_allowed": benchmark_promotion_allowed,
+            "output_classification": readiness.get("output_classification"),
+            "candidate_scan_satisfiable_count": candidate_scan.get("satisfiable_count"),
+        },
+        "smoke_summary": smoke_decision,
+        "acceptance_criteria": criteria,
+        "remaining_blockers": blockers,
+    }
+
+
 def _format_human(report: dict[str, Any]) -> str:
     """Render a compact human-readable summary of the readiness report."""
     lines = [
@@ -642,6 +804,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         default=None,
         help="Write a JSON handoff packet for the first real SDD curation run.",
+    )
+    parser.add_argument(
+        "--write-integration-report",
+        type=Path,
+        default=None,
+        help="Write JSON issue #1126 acceptance/closure integration report.",
     )
     parser.add_argument(
         "--decision-dataset-id",
@@ -711,6 +879,13 @@ def main(argv: list[str] | None = None) -> int:
         args.write_decision_packet.parent.mkdir(parents=True, exist_ok=True)
         args.write_decision_packet.write_text(
             json.dumps(packet, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.write_integration_report is not None:
+        integration_report = build_integration_report(report)
+        args.write_integration_report.parent.mkdir(parents=True, exist_ok=True)
+        args.write_integration_report.write_text(
+            json.dumps(integration_report, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
     if args.require_benchmark_ready and not report["benchmark_promotion_allowed"]:

--- a/tests/tools/test_sdd_curation_preflight.py
+++ b/tests/tools/test_sdd_curation_preflight.py
@@ -702,3 +702,106 @@ def test_cli_scan_root_reports_candidates_without_benchmark_claim(
     assert report["output_classification"] == sdd_curation_preflight.OUTPUT_BLOCKED
     assert report["candidate_scan"]["satisfiable_count"] == 1
     assert report["candidate_scan"]["candidates"][0]["path"] == str(annotations)
+
+
+def test_integration_report_keeps_unstaged_sdd_blocked(tmp_path: Path) -> None:
+    """Integration report maps #1126 criteria without promoting missing SDD data."""
+    readiness = sdd_curation_preflight.classify_curation_readiness(
+        {
+            "mode": manage_external_data.SDD_MODE_PROXY,
+            "dataset_backed": False,
+            "availability": {"state": "missing"},
+            "reason": "SDD not staged.",
+            "staging_dir": str(tmp_path),
+        },
+        None,
+    )
+
+    report = sdd_curation_preflight.build_integration_report(readiness)
+
+    assert report["schema"] == sdd_curation_preflight.INTEGRATION_REPORT_SCHEMA
+    assert report["closure_status"] == "blocked_external_input"
+    assert report["next_empirical_action"] == (
+        "stage_or_restore_licensed_sdd_annotations_then_rerun_preflight"
+    )
+    assert report["readiness_summary"]["benchmark_promotion_allowed"] is False
+    criteria = {row["criterion"]: row for row in report["acceptance_criteria"]}
+    assert (
+        criteria[
+            "#1497 staged official/BYO SDD source annotations locally or recorded failure keeps issue blocked."
+        ]["status"]
+        == "blocked"
+    )
+    assert (
+        criteria["Only small reviewable artifacts or durable pointers committed."]["status"]
+        == "met"
+    )
+    assert report["remaining_blockers"]
+
+
+def test_integration_report_closes_only_with_benchmark_ready_smoke(tmp_path: Path) -> None:
+    """Only a loaded benchmark-ready smoke decision makes #1126 ready to close."""
+    annotations = tmp_path / "annotations.txt"
+    _write_sdd_fixture(annotations)
+    readiness = sdd_curation_preflight.classify_curation_readiness(
+        {
+            "mode": manage_external_data.SDD_MODE_DATASET_BACKED,
+            "dataset_backed": True,
+            "availability": {"state": "dataset_backed"},
+            "reason": "SDD staged validated.",
+            "staging_dir": str(tmp_path),
+        },
+        sdd_curation_preflight.probe_annotation_file(
+            annotations, label="Pedestrian", min_track_points=4, max_pedestrians=4
+        ),
+    )
+    smoke_decision = sdd_curation_preflight.classify_smoke_decision(
+        readiness,
+        [
+            {
+                "horizon": 384,
+                "successful_jobs": 1,
+                "failed_jobs": 0,
+                "success": True,
+                "timeout": False,
+                "collisions": 0,
+            }
+        ],
+        generated_artifacts_load=True,
+    )
+
+    report = sdd_curation_preflight.build_integration_report(
+        readiness, smoke_decision=smoke_decision
+    )
+
+    assert report["closure_status"] == "ready_to_close"
+    assert report["smoke_summary"]["classification"] == sdd_curation_preflight.SMOKE_BENCHMARK_READY
+    assert report["remaining_blockers"] == []
+    assert all(row["status"] == "met" for row in report["acceptance_criteria"])
+
+
+def test_cli_writes_integration_report_without_raw_outputs(tmp_path: Path, monkeypatch) -> None:
+    """CLI integration report is metadata-only and follows current preflight blockers."""
+    report_path = tmp_path / "issue_1126_integration.json"
+    monkeypatch.setattr(
+        manage_external_data,
+        "resolve_sdd_scenario_prior_mode",
+        lambda manifest_path=None: {
+            "mode": manage_external_data.SDD_MODE_PROXY,
+            "dataset_backed": False,
+            "availability": {"state": "missing"},
+            "reason": "SDD not staged.",
+            "staging_dir": str(tmp_path / "sdd"),
+        },
+    )
+
+    exit_code = sdd_curation_preflight.main(
+        ["--write-integration-report", str(report_path), "--json"]
+    )
+
+    assert exit_code == 0
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["schema"] == sdd_curation_preflight.INTEGRATION_REPORT_SCHEMA
+    assert report["closure_status"] == "blocked_external_input"
+    assert report["claim_boundary"].startswith("integration report only")
+    assert not (tmp_path / "sdd_curation").exists()


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds `build_integration_report()` plus `--write-integration-report` to `scripts/tools/sdd_curation_preflight.py`, with focused tests. The report maps #1126 acceptance criteria to the current preflight/scan/smoke evidence boundary and emits the next empirical action without importing SDD data or writing generated scenario artifacts.

Why now: PR #4695 merged candidate scanning, but #1126 remains open and high-churn. The fragmentation guard calls for a consolidation/integration slice rather than another blocker packet. This PR adds a nameable progression capability: a machine-readable #1126 integration report that downstream gates can use to distinguish `blocked_external_input`, `open_empirical_action_ready`, `open_exploratory_only`, and `ready_to_close`.

Claim boundary: metadata/report generation only. It does not stage or download Stanford Drone Dataset (SDD) data, generate or commit SDD scenario/map/provenance outputs, run a benchmark campaign, submit Slurm/GPU work, or make paper/dissertation claims.

Required validation:

- `scripts/dev/run_worktree_shared_venv.sh -- python -m py_compile scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` -> pass
- `scripts/dev/run_worktree_shared_venv.sh -- python -m ruff format scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` -> pass, 2 files reformatted before commit
- `scripts/dev/run_worktree_shared_venv.sh -- python -m ruff check scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` -> pass
- `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/tools/test_sdd_curation_preflight.py -q` -> pass, 29 tests
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/sdd_curation_preflight.py --scan-root output/external_data/sdd --scan-limit 5 --write-integration-report .git/codex-agent-runs/active/issue-1126/integration_report.json --json` -> pass; generated report classifies this worktree as `blocked_external_input` because `output/external_data/sdd` is absent and `benchmark_promotion_allowed=false`
- `git diff --check` -> pass

Remaining blocker: #1126 is not closed by this PR. The current fresh-worktree report still requires restoring/staging the licensed SDD tree, probing/importing a selected candidate, loading generated artifacts, and running/classifying one CPU representative smoke before `benchmark_ready` closure.

Refs #1126

## Contract delta

New schema field/surface:

- `robot_sf_sdd_curation_integration_report.v1`
- CLI flag: `--write-integration-report <path>`
- report fields include `closure_status`, `next_empirical_action`, `readiness_summary`, optional `smoke_summary`, `acceptance_criteria`, and `remaining_blockers`

New fail-closed blockers:

- Report stays `blocked_external_input` when SDD is not dataset-backed.
- Report stays open unless a supplied smoke decision is `benchmark_ready` with loaded artifacts.
- Exploratory-only smoke maps to `open_exploratory_only`, not closure.

Compatibility impact:

- Existing preflight JSON, decision packet, smoke decision fields, and candidate scan behavior are unchanged.
- The new report writer is additive and metadata-only.

## Scope summary

Issue: https://github.com/ll7/robot_sf_ll7/issues/1126

Changed files:

- `scripts/tools/sdd_curation_preflight.py`: adds integration report schema/builder and CLI writer.
- `tests/tools/test_sdd_curation_preflight.py`: adds blocked, benchmark-ready, and CLI writer coverage.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. No SDD raw files, generated SDD scenario/map/provenance outputs, or transient queue-routing state are committed.

## State propagation

No issue comment was posted because this lane does not authorize `comment_issue_or_pr`. Because #1126 is high-churn (>3 PRs/24h), this PR uses the PR body plus the generated integration report artifact as the canonical handoff surface instead of adding another issue comment stream entry.

<details>
<summary>Acceptance evidence and freshness</summary>

| Criterion | Current evidence | PR effect |
| --- | --- | --- |
| #1497 staged official/BYO SDD source annotations locally or recorded failure keeps issue blocked | Fresh worktree report: `dataset_backed=false`, `staging_mode=proxy_schema_smoke`, `benchmark_promotion_allowed=false` | Integration report records `blocked_external_input` and keeps closure blocked. |
| One scene/video selected by deterministic rule | PR #4695 added candidate scan; current fresh worktree scan root missing, `satisfiable_count=0` | Report records pending/actionable state based on probe/scan inputs. |
| Import command, source identity, checksums, license/source URL, scale assumptions recorded | Prior PRs recorded exploratory `bookstore/video0`; current worktree has no staged data | Report does not mark this met unless benchmark promotion is allowed. |
| Generated scenario/map artifacts pass loading/parser validation | Prior exploratory slice loaded artifacts; no current smoke decision supplied | Report keeps this pending without smoke/load evidence. |
| Representative smoke succeeds or rejected explicitly | Prior smoke classified `exploratory_only`; no new smoke run here | Report closes only when supplied smoke decision is `benchmark_ready`. |
| Documentation states `benchmark_ready` vs `exploratory_only` | Prior PRs document exploratory-only; new report encodes closure status | Report distinguishes `ready_to_close`, `open_exploratory_only`, `open_empirical_action_ready`, and `blocked_external_input`. |
| Only small reviewable artifacts/durable pointers committed | This PR changes only code/tests and writes scratch report under `.git/codex-agent-runs` | Met. |

Late guidance check: immediately before PR preparation, live issue/comments had no maintainer comments newer than the PR #4695 gate update at 2026-07-06T20:13:28Z. Open PR dedupe search returned `[]`.

Fragmentation guard: active. More than two #1126 PRs merged in the last 24 hours; this PR is a consolidation/integration capability, not another micro-guard or packet refresh.

</details>
