### PR TITLE
Issue #4016: add acceptance audit artifact

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -222,6 +222,14 @@ entries:
     status: evidence
     freshness: evidence
     area: training
+  - path: docs/context/evidence/issue_4016_distributional_rl_smoke/acceptance_audit.json
+    status: evidence
+    freshness: evidence
+    area: training
+  - path: docs/context/evidence/issue_4016_distributional_rl_smoke/acceptance_audit.md
+    status: evidence
+    freshness: evidence
+    area: training
   - path: docs/context/evidence/issue_4016_distributional_rl_smoke/qr_dqn_cvar_manifest.json
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_4016_distributional_rl_smoke/acceptance_audit.json
+++ b/docs/context/evidence/issue_4016_distributional_rl_smoke/acceptance_audit.json
@@ -1,0 +1,112 @@
+{
+  "blockers": [
+    "Run or ingest a benchmark-runner measured comparison for mean and cvar_lower modes on safety-relevant scenarios; keep fallback/degraded rows excluded or marked non-evidence."
+  ],
+  "claim_boundary": "closure audit of merged implementation evidence; diagnostic-only smoke evidence is not benchmark-strength safety evidence",
+  "closure_status": "partial",
+  "criteria": [
+    {
+      "criterion": "QR-DQN-style distributional critic trains on a smoke scenario.",
+      "evidence": [
+        "PR #4215 added the QR-DQN smoke trainer path.",
+        "PR #4672 records output/models/distributional_rl/issue_4016/training_manifest.json as the source for checked-in smoke manifests.",
+        "summary.json records fallback_or_degraded=False."
+      ],
+      "status": "met"
+    },
+    {
+      "criterion": "Risk-sensitive selection runs in map_runner/runtime adapter.",
+      "evidence": [
+        "PR #4215 added robot_sf/baselines/distributional_rl.py and robot_sf/benchmark/map_runner_policies/distributional_rl.py.",
+        "PR #4672 materialized cvar_lower runtime diagnostics from the merged adapter."
+      ],
+      "status": "met"
+    },
+    {
+      "criterion": "Same checkpoint can be evaluated in mean and cvar_lower selection modes.",
+      "evidence": [
+        "mean checkpoint: output/models/distributional_rl/issue_4016/qr_dqn_issue_4016_smoke.pt",
+        "cvar checkpoint: output/models/distributional_rl/issue_4016/qr_dqn_issue_4016_smoke.pt",
+        "matched seed=True, matched total_timesteps=True."
+      ],
+      "remaining_work": null,
+      "status": "met"
+    },
+    {
+      "criterion": "Mean-value comparator on the same discrete action lattice is available.",
+      "evidence": [
+        "PR #4672 added configs/baselines/distributional_rl_issue_4016_mean.yaml.",
+        "qr_dqn_mean_manifest.json risk_objective='mean'."
+      ],
+      "remaining_work": null,
+      "status": "met"
+    },
+    {
+      "criterion": "Matched-seed diagnostic comparison is recorded.",
+      "evidence": [
+        "PR #4476 added scripts/analysis/compare_distributional_rl_issue_4016.py.",
+        "PR #4672 checked in distributional_rl_risk_comparison.json and .md.",
+        "comparison_status='valid_diagnostic'."
+      ],
+      "remaining_work": null,
+      "status": "met"
+    },
+    {
+      "criterion": "Reports include collision, near-miss, min-clearance, success/progress, and path-efficiency tradeoffs.",
+      "evidence": [
+        "Required metric keys present in smoke manifests: True.",
+        "PR #4672 gate review states these are synthetic-observation placeholders, not measured benchmark safety outcomes."
+      ],
+      "remaining_work": "Run or ingest a benchmark-runner measured comparison for mean and cvar_lower modes on safety-relevant scenarios; keep fallback/degraded rows excluded or marked non-evidence.",
+      "status": "partial"
+    },
+    {
+      "criterion": "Fallback/degraded rows are explicitly excluded or marked non-evidence.",
+      "evidence": [
+        "summary fallback_or_degraded=False.",
+        "comparison fallback_degraded_rows={'excluded': 0, 'included_as_non_evidence': 0}."
+      ],
+      "remaining_work": null,
+      "status": "met"
+    },
+    {
+      "criterion": "Claim boundary is explicit and does not promote paper-facing safety claims.",
+      "evidence": [
+        "summary evidence_tier='diagnostic-only'.",
+        "comparison benchmark_safety_claim=False."
+      ],
+      "remaining_work": null,
+      "status": "met"
+    }
+  ],
+  "forbidden_actions_confirmed": {
+    "full_benchmark_campaign_run": false,
+    "paper_or_dissertation_claim_edit": false,
+    "slurm_or_gpu_submission": false
+  },
+  "generated_at": "2026-07-06T21:10:02.252690+00:00",
+  "issue": 4016,
+  "merged_prs_reviewed": [
+    {
+      "evidence": "distributional RL primitives: lattice, quantile critic, risk objectives",
+      "pr": 4157
+    },
+    {
+      "evidence": "QR-DQN smoke trainer and runtime adapter",
+      "pr": 4215
+    },
+    {
+      "evidence": "trainer/adapter handoff proof",
+      "pr": 4283
+    },
+    {
+      "evidence": "diagnostic mean-vs-risk comparison report contract",
+      "pr": 4476
+    },
+    {
+      "evidence": "real smoke checkpoint materialized through mean and CVaR manifests",
+      "pr": 4672
+    }
+  ],
+  "schema_version": "issue_4016.acceptance_audit.v1"
+}

--- a/docs/context/evidence/issue_4016_distributional_rl_smoke/acceptance_audit.md
+++ b/docs/context/evidence/issue_4016_distributional_rl_smoke/acceptance_audit.md
@@ -1,0 +1,32 @@
+# Issue #4016 Acceptance Audit
+
+This audit maps issue #4016 closure criteria to merged implementation evidence. It is conservative: diagnostic smoke evidence is not treated as benchmark-strength safety evidence.
+
+- Closure status: `partial`.
+- Claim boundary: closure audit of merged implementation evidence; diagnostic-only smoke evidence is not benchmark-strength safety evidence.
+- No full benchmark campaign, Slurm/GPU submission, or paper/dissertation claim edit was performed.
+
+## Merged PR Evidence
+
+- PR #4157: distributional RL primitives: lattice, quantile critic, risk objectives.
+- PR #4215: QR-DQN smoke trainer and runtime adapter.
+- PR #4283: trainer/adapter handoff proof.
+- PR #4476: diagnostic mean-vs-risk comparison report contract.
+- PR #4672: real smoke checkpoint materialized through mean and CVaR manifests.
+
+## Criteria
+
+| Criterion | Status | Evidence | Remaining work |
+| --- | --- | --- | --- |
+| QR-DQN-style distributional critic trains on a smoke scenario. | `met` | PR #4215 added the QR-DQN smoke trainer path.<br>PR #4672 records output/models/distributional_rl/issue_4016/training_manifest.json as the source for checked-in smoke manifests.<br>summary.json records fallback_or_degraded=False. | None |
+| Risk-sensitive selection runs in map_runner/runtime adapter. | `met` | PR #4215 added robot_sf/baselines/distributional_rl.py and robot_sf/benchmark/map_runner_policies/distributional_rl.py.<br>PR #4672 materialized cvar_lower runtime diagnostics from the merged adapter. | None |
+| Same checkpoint can be evaluated in mean and cvar_lower selection modes. | `met` | mean checkpoint: output/models/distributional_rl/issue_4016/qr_dqn_issue_4016_smoke.pt<br>cvar checkpoint: output/models/distributional_rl/issue_4016/qr_dqn_issue_4016_smoke.pt<br>matched seed=True, matched total_timesteps=True. | None |
+| Mean-value comparator on the same discrete action lattice is available. | `met` | PR #4672 added configs/baselines/distributional_rl_issue_4016_mean.yaml.<br>qr_dqn_mean_manifest.json risk_objective='mean'. | None |
+| Matched-seed diagnostic comparison is recorded. | `met` | PR #4476 added scripts/analysis/compare_distributional_rl_issue_4016.py.<br>PR #4672 checked in distributional_rl_risk_comparison.json and .md.<br>comparison_status='valid_diagnostic'. | None |
+| Reports include collision, near-miss, min-clearance, success/progress, and path-efficiency tradeoffs. | `partial` | Required metric keys present in smoke manifests: True.<br>PR #4672 gate review states these are synthetic-observation placeholders, not measured benchmark safety outcomes. | Run or ingest a benchmark-runner measured comparison for mean and cvar_lower modes on safety-relevant scenarios; keep fallback/degraded rows excluded or marked non-evidence. |
+| Fallback/degraded rows are explicitly excluded or marked non-evidence. | `met` | summary fallback_or_degraded=False.<br>comparison fallback_degraded_rows={'excluded': 0, 'included_as_non_evidence': 0}. | None |
+| Claim boundary is explicit and does not promote paper-facing safety claims. | `met` | summary evidence_tier='diagnostic-only'.<br>comparison benchmark_safety_claim=False. | None |
+
+## Closure Decision
+
+#4016 should stay open. The remaining blocker is measured benchmark-runner evidence for the mean-vs-CVaR safety-relevant comparison; the current checked-in smoke metrics are diagnostic placeholders.

--- a/scripts/analysis/audit_issue_4016_acceptance.py
+++ b/scripts/analysis/audit_issue_4016_acceptance.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Generate the issue #4016 acceptance-criteria audit artifact.
+
+The audit is intentionally conservative: smoke diagnostics can satisfy smoke
+criteria, but they do not close benchmark-strength measured comparison criteria.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_ISSUE = 4016
+_REQUIRED_METRICS = (
+    "success_rate",
+    "collision_rate",
+    "near_miss_rate",
+    "mean_min_clearance",
+    "mean_path_efficiency",
+)
+
+
+def build_acceptance_audit(
+    *,
+    evidence_dir: str | Path = "docs/context/evidence/issue_4016_distributional_rl_smoke",
+) -> dict[str, Any]:
+    """Build the conservative issue #4016 closure audit from checked-in evidence."""
+    evidence_dir = Path(evidence_dir)
+    summary = _read_json_object(evidence_dir / "summary.json")
+    comparison = _read_json_object(evidence_dir / "distributional_rl_risk_comparison.json")
+    mean_manifest = _read_json_object(evidence_dir / "qr_dqn_mean_manifest.json")
+    cvar_manifest = _read_json_object(evidence_dir / "qr_dqn_cvar_manifest.json")
+
+    criteria = _criteria(summary, comparison, mean_manifest, cvar_manifest)
+    closure_status = "complete" if all(item["status"] == "met" for item in criteria) else "partial"
+    blockers = [
+        item["remaining_work"]
+        for item in criteria
+        if item["status"] != "met" and item.get("remaining_work")
+    ]
+    return {
+        "schema_version": "issue_4016.acceptance_audit.v1",
+        "issue": _ISSUE,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "closure_status": closure_status,
+        "claim_boundary": (
+            "closure audit of merged implementation evidence; diagnostic-only smoke evidence is "
+            "not benchmark-strength safety evidence"
+        ),
+        "merged_prs_reviewed": [
+            {
+                "pr": 4157,
+                "evidence": "distributional RL primitives: lattice, quantile critic, risk objectives",
+            },
+            {
+                "pr": 4215,
+                "evidence": "QR-DQN smoke trainer and runtime adapter",
+            },
+            {
+                "pr": 4283,
+                "evidence": "trainer/adapter handoff proof",
+            },
+            {
+                "pr": 4476,
+                "evidence": "diagnostic mean-vs-risk comparison report contract",
+            },
+            {
+                "pr": 4672,
+                "evidence": "real smoke checkpoint materialized through mean and CVaR manifests",
+            },
+        ],
+        "criteria": criteria,
+        "blockers": blockers,
+        "forbidden_actions_confirmed": {
+            "full_benchmark_campaign_run": False,
+            "slurm_or_gpu_submission": False,
+            "paper_or_dissertation_claim_edit": False,
+        },
+    }
+
+
+def write_acceptance_audit(
+    *,
+    evidence_dir: str | Path = "docs/context/evidence/issue_4016_distributional_rl_smoke",
+    output_json: str | Path | None = None,
+    output_markdown: str | Path | None = None,
+) -> dict[str, Any]:
+    """Build and write the JSON and Markdown audit artifacts."""
+    evidence_dir = Path(evidence_dir)
+    audit = build_acceptance_audit(evidence_dir=evidence_dir)
+    output_json = (
+        Path(output_json) if output_json is not None else evidence_dir / "acceptance_audit.json"
+    )
+    output_markdown = (
+        Path(output_markdown)
+        if output_markdown is not None
+        else evidence_dir / "acceptance_audit.md"
+    )
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    output_markdown.write_text(_render_markdown(audit), encoding="utf-8")
+    return audit
+
+
+def _criteria(
+    summary: Mapping[str, Any],
+    comparison: Mapping[str, Any],
+    mean_manifest: Mapping[str, Any],
+    cvar_manifest: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    same_checkpoint = mean_manifest.get("checkpoint_path") == cvar_manifest.get("checkpoint_path")
+    same_seed = mean_manifest.get("seed") == cvar_manifest.get("seed")
+    same_steps = mean_manifest.get("total_timesteps") == cvar_manifest.get("total_timesteps")
+    fallback_clean = (
+        summary.get("fallback_or_degraded") is False
+        and comparison.get("fallback_degraded_rows", {}).get("excluded") == 0
+        and comparison.get("fallback_degraded_rows", {}).get("included_as_non_evidence") == 0
+        and mean_manifest.get("fallback_or_degraded") is False
+        and cvar_manifest.get("fallback_or_degraded") is False
+    )
+    metric_keys_present = _has_metrics(mean_manifest) and _has_metrics(cvar_manifest)
+    diagnostic_only = (
+        summary.get("evidence_tier") == "diagnostic-only"
+        and comparison.get("evidence_tier") == "diagnostic-only"
+        and comparison.get("effect", {}).get("benchmark_safety_claim") is False
+    )
+
+    return [
+        {
+            "criterion": "QR-DQN-style distributional critic trains on a smoke scenario.",
+            "status": "met",
+            "evidence": [
+                "PR #4215 added the QR-DQN smoke trainer path.",
+                "PR #4672 records output/models/distributional_rl/issue_4016/training_manifest.json "
+                "as the source for checked-in smoke manifests.",
+                f"summary.json records fallback_or_degraded={summary.get('fallback_or_degraded')!r}.",
+            ],
+        },
+        {
+            "criterion": "Risk-sensitive selection runs in map_runner/runtime adapter.",
+            "status": "met",
+            "evidence": [
+                "PR #4215 added robot_sf/baselines/distributional_rl.py and "
+                "robot_sf/benchmark/map_runner_policies/distributional_rl.py.",
+                "PR #4672 materialized cvar_lower runtime diagnostics from the merged adapter.",
+            ],
+        },
+        {
+            "criterion": "Same checkpoint can be evaluated in mean and cvar_lower selection modes.",
+            "status": "met" if same_checkpoint and same_seed and same_steps else "blocked",
+            "evidence": [
+                f"mean checkpoint: {mean_manifest.get('checkpoint_path')}",
+                f"cvar checkpoint: {cvar_manifest.get('checkpoint_path')}",
+                f"matched seed={same_seed}, matched total_timesteps={same_steps}.",
+            ],
+            "remaining_work": None
+            if same_checkpoint and same_seed and same_steps
+            else "Regenerate paired manifests from one checkpoint with matched seed and timesteps.",
+        },
+        {
+            "criterion": "Mean-value comparator on the same discrete action lattice is available.",
+            "status": "met" if mean_manifest.get("risk_objective") == "mean" else "blocked",
+            "evidence": [
+                "PR #4672 added configs/baselines/distributional_rl_issue_4016_mean.yaml.",
+                f"qr_dqn_mean_manifest.json risk_objective={mean_manifest.get('risk_objective')!r}.",
+            ],
+            "remaining_work": None
+            if mean_manifest.get("risk_objective") == "mean"
+            else "Materialize a mean-selection manifest on the same action lattice.",
+        },
+        {
+            "criterion": "Matched-seed diagnostic comparison is recorded.",
+            "status": "met"
+            if comparison.get("effect", {}).get("comparison_status") == "valid_diagnostic"
+            else "blocked",
+            "evidence": [
+                "PR #4476 added scripts/analysis/compare_distributional_rl_issue_4016.py.",
+                "PR #4672 checked in distributional_rl_risk_comparison.json and .md.",
+                f"comparison_status={comparison.get('effect', {}).get('comparison_status')!r}.",
+            ],
+            "remaining_work": None
+            if comparison.get("effect", {}).get("comparison_status") == "valid_diagnostic"
+            else "Run the diagnostic comparison generator on matched mean and cvar manifests.",
+        },
+        {
+            "criterion": (
+                "Reports include collision, near-miss, min-clearance, success/progress, and "
+                "path-efficiency tradeoffs."
+            ),
+            "status": "partial",
+            "evidence": [
+                f"Required metric keys present in smoke manifests: {metric_keys_present}.",
+                "PR #4672 gate review states these are synthetic-observation placeholders, not "
+                "measured benchmark safety outcomes.",
+            ],
+            "remaining_work": (
+                "Run or ingest a benchmark-runner measured comparison for mean and cvar_lower modes "
+                "on safety-relevant scenarios; keep fallback/degraded rows excluded or marked "
+                "non-evidence."
+            ),
+        },
+        {
+            "criterion": "Fallback/degraded rows are explicitly excluded or marked non-evidence.",
+            "status": "met" if fallback_clean else "blocked",
+            "evidence": [
+                f"summary fallback_or_degraded={summary.get('fallback_or_degraded')!r}.",
+                f"comparison fallback_degraded_rows={comparison.get('fallback_degraded_rows')!r}.",
+            ],
+            "remaining_work": None
+            if fallback_clean
+            else "Regenerate comparison with degraded/fallback rows excluded or marked non-evidence.",
+        },
+        {
+            "criterion": "Claim boundary is explicit and does not promote paper-facing safety claims.",
+            "status": "met" if diagnostic_only else "blocked",
+            "evidence": [
+                f"summary evidence_tier={summary.get('evidence_tier')!r}.",
+                f"comparison benchmark_safety_claim="
+                f"{comparison.get('effect', {}).get('benchmark_safety_claim')!r}.",
+            ],
+            "remaining_work": None
+            if diagnostic_only
+            else "Restore diagnostic-only claim boundary before using this evidence.",
+        },
+    ]
+
+
+def _has_metrics(manifest: Mapping[str, Any]) -> bool:
+    metrics = manifest.get("metrics")
+    return isinstance(metrics, Mapping) and all(key in metrics for key in _REQUIRED_METRICS)
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise OSError(f"could not read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"could not parse {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _render_markdown(audit: Mapping[str, Any]) -> str:
+    lines = [
+        "# Issue #4016 Acceptance Audit",
+        "",
+        "This audit maps issue #4016 closure criteria to merged implementation evidence. "
+        "It is conservative: diagnostic smoke evidence is not treated as benchmark-strength "
+        "safety evidence.",
+        "",
+        f"- Closure status: `{audit['closure_status']}`.",
+        f"- Claim boundary: {audit['claim_boundary']}.",
+        "- No full benchmark campaign, Slurm/GPU submission, or paper/dissertation claim edit "
+        "was performed.",
+        "",
+        "## Merged PR Evidence",
+        "",
+    ]
+    for item in audit["merged_prs_reviewed"]:
+        lines.append(f"- PR #{item['pr']}: {item['evidence']}.")
+    lines.extend(["", "## Criteria", ""])
+    lines.append("| Criterion | Status | Evidence | Remaining work |")
+    lines.append("| --- | --- | --- | --- |")
+    for item in audit["criteria"]:
+        evidence = "<br>".join(str(value) for value in item["evidence"])
+        remaining = item.get("remaining_work") or "None"
+        lines.append(f"| {item['criterion']} | `{item['status']}` | {evidence} | {remaining} |")
+    lines.extend(["", "## Closure Decision", ""])
+    if audit["closure_status"] == "complete":
+        lines.append("All listed criteria are met; #4016 can close when this audit is accepted.")
+    else:
+        lines.append(
+            "#4016 should stay open. The remaining blocker is measured benchmark-runner evidence "
+            "for the mean-vs-CVaR safety-relevant comparison; the current checked-in smoke metrics "
+            "are diagnostic placeholders."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the command-line audit generator."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--evidence-dir",
+        default="docs/context/evidence/issue_4016_distributional_rl_smoke",
+        help="Issue #4016 evidence directory.",
+    )
+    parser.add_argument("--output-json", help="Acceptance audit JSON output path.")
+    parser.add_argument("--output-markdown", help="Acceptance audit Markdown output path.")
+    args = parser.parse_args(argv)
+    audit = write_acceptance_audit(
+        evidence_dir=args.evidence_dir,
+        output_json=args.output_json,
+        output_markdown=args.output_markdown,
+    )
+    print(json.dumps({"closure_status": audit["closure_status"], "issue": _ISSUE}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/analysis/test_audit_issue_4016_acceptance.py
+++ b/tests/analysis/test_audit_issue_4016_acceptance.py
@@ -1,0 +1,131 @@
+"""Tests issue #4016 acceptance audit generation."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.analysis.audit_issue_4016_acceptance import (
+    build_acceptance_audit,
+    write_acceptance_audit,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _evidence_dir(tmp_path: Path) -> Path:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    _write_json(
+        evidence_dir / "summary.json",
+        {
+            "schema_version": "issue_4016.smoke_manifest_materialization.v1",
+            "issue": 4016,
+            "evidence_tier": "diagnostic-only",
+            "claim_boundary": "risk-selection diagnostic only; not benchmark evidence",
+            "fallback_or_degraded": False,
+        },
+    )
+    base_manifest = {
+        "policy_id": "qr_dqn_issue_4016_mean",
+        "algorithm": "qr_dqn",
+        "evidence_tier": "diagnostic-only",
+        "claim_boundary": "risk-selection diagnostic only; not benchmark evidence",
+        "risk_alpha": 0.2,
+        "seed": 4016,
+        "total_timesteps": 128,
+        "checkpoint_path": "output/models/distributional_rl/issue_4016/qr_dqn_issue_4016_smoke.pt",
+        "fallback_or_degraded": False,
+        "metrics": {
+            "success_rate": 0.0,
+            "collision_rate": 0.0,
+            "near_miss_rate": 0.0,
+            "mean_min_clearance": 1.0,
+            "mean_path_efficiency": 0.5,
+        },
+    }
+    mean = dict(base_manifest, risk_objective="mean")
+    cvar = dict(base_manifest, policy_id="qr_dqn_issue_4016_cvar", risk_objective="cvar_lower")
+    _write_json(evidence_dir / "qr_dqn_mean_manifest.json", mean)
+    _write_json(evidence_dir / "qr_dqn_cvar_manifest.json", cvar)
+    _write_json(
+        evidence_dir / "distributional_rl_risk_comparison.json",
+        {
+            "evidence_tier": "diagnostic-only",
+            "effect": {
+                "benchmark_safety_claim": False,
+                "comparison_status": "valid_diagnostic",
+            },
+            "fallback_degraded_rows": {
+                "excluded": 0,
+                "included_as_non_evidence": 0,
+            },
+        },
+    )
+    return evidence_dir
+
+
+def test_acceptance_audit_keeps_measured_metrics_partial(tmp_path: Path) -> None:
+    """Smoke metrics keep the closure audit partial until measured evidence exists."""
+    audit = build_acceptance_audit(evidence_dir=_evidence_dir(tmp_path))
+
+    assert audit["closure_status"] == "partial"
+    statuses = {item["criterion"]: item["status"] for item in audit["criteria"]}
+    measured_metric_statuses = [
+        status for criterion, status in statuses.items() if criterion.startswith("Reports include")
+    ]
+    assert measured_metric_statuses == ["partial"]
+    assert any("benchmark-runner measured comparison" in blocker for blocker in audit["blockers"])
+
+
+def test_acceptance_audit_fails_closed_on_degraded_comparison(tmp_path: Path) -> None:
+    """Fallback/degraded comparison rows block closure evidence."""
+    evidence_dir = _evidence_dir(tmp_path)
+    comparison_path = evidence_dir / "distributional_rl_risk_comparison.json"
+    comparison = json.loads(comparison_path.read_text(encoding="utf-8"))
+    comparison["fallback_degraded_rows"]["included_as_non_evidence"] = 1
+    comparison_path.write_text(json.dumps(comparison), encoding="utf-8")
+
+    audit = build_acceptance_audit(evidence_dir=evidence_dir)
+
+    degraded_statuses = [
+        item["status"]
+        for item in audit["criteria"]
+        if item["criterion"].startswith("Fallback/degraded rows")
+    ]
+    assert degraded_statuses == ["blocked"]
+
+
+def test_write_acceptance_audit_outputs_json_and_markdown(tmp_path: Path) -> None:
+    """The writer emits both machine and human-readable audit artifacts."""
+    evidence_dir = _evidence_dir(tmp_path)
+    output_json = tmp_path / "acceptance_audit.json"
+    output_markdown = tmp_path / "acceptance_audit.md"
+
+    audit = write_acceptance_audit(
+        evidence_dir=evidence_dir,
+        output_json=output_json,
+        output_markdown=output_markdown,
+    )
+
+    assert json.loads(output_json.read_text(encoding="utf-8"))["schema_version"] == (
+        "issue_4016.acceptance_audit.v1"
+    )
+    assert "# Issue #4016 Acceptance Audit" in output_markdown.read_text(encoding="utf-8")
+    assert audit["closure_status"] == "partial"
+
+
+def test_acceptance_audit_requires_json_objects(tmp_path: Path) -> None:
+    """Malformed evidence files fail closed instead of producing an audit."""
+    evidence_dir = _evidence_dir(tmp_path)
+    (evidence_dir / "summary.json").write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        build_acceptance_audit(evidence_dir=evidence_dir)


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a checked, reproducible acceptance-audit generator for issue #4016 plus checked-in JSON/Markdown audit artifacts under `docs/context/evidence/issue_4016_distributional_rl_smoke/`.

Why now: PR #4672 merged the real smoke-manifest slice, but #4016 stayed open. This audit maps each closure criterion to merged PR evidence and prevents the synthetic-observation smoke report from being mistaken for benchmark-strength measured safety evidence.

Claim boundary: partial closure audit only. The audit marks 7/8 criteria met and keeps the issue open because the metric-tradeoff criterion still needs benchmark-runner measured mean-vs-CVaR evidence on safety-relevant scenarios. This is diagnostic/evidence tracking, not a paper-facing claim.

Required validation:
- `uv run pytest tests/analysis/test_audit_issue_4016_acceptance.py -q` -> passed, 4 tests.
- `uv run ruff check scripts/analysis/audit_issue_4016_acceptance.py tests/analysis/test_audit_issue_4016_acceptance.py` -> passed.
- `uv run python scripts/dev/check_docs_evidence_integrity.py --base-ref origin/main` -> passed, 5 changed files.

Remaining blocker: run or ingest benchmark-runner measured comparison for mean and `cvar_lower` modes on safety-relevant scenarios, with fallback/degraded rows excluded or marked non-evidence.

Refs #4016

## Contract delta

New evidence schema:
- `issue_4016.acceptance_audit.v1` in `acceptance_audit.json`.
- Criteria entries carry `criterion`, `status`, `evidence`, and optional `remaining_work`.
- `closure_status` is `partial` unless every criterion is `met`.

New fail-closed behavior:
- Audit generation requires JSON-object evidence inputs.
- Fallback/degraded comparison rows block the fallback/degraded criterion.
- Smoke metrics remain `partial` for measured safety tradeoffs even when metric keys exist, because PR #4672 identified those metrics as synthetic-observation placeholders.

Compatibility impact: additive only. Existing comparison scripts, manifests, configs, and benchmark paths are unchanged. `docs/context/catalog.yaml` registers the two new audit artifacts.

## Scope summary

In scope:
- Acceptance evidence mapping for merged PRs #4157, #4215, #4283, #4476, and #4672.
- A small CPU-only generator: `scripts/analysis/audit_issue_4016_acceptance.py`.
- Tests for partial closure, degraded-row fail-closed handling, artifact writing, and malformed JSON input.

Out of scope:
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No issue comment propagation; this PR body is the durable propagation surface because this task authorization disallows issue/PR comments.

<details>
<summary>Acceptance evidence table</summary>

| Criterion | Status | Evidence |
| --- | --- | --- |
| QR-DQN-style distributional critic trains on a smoke scenario | met | PR #4215 trainer path; PR #4672 smoke training manifest source; `summary.json` fallback/degraded false |
| Risk-sensitive selection runs in map_runner/runtime adapter | met | PR #4215 runtime adapter and map-runner policy; PR #4672 `cvar_lower` runtime diagnostics |
| Same checkpoint can be evaluated in mean and `cvar_lower` modes | met | `qr_dqn_mean_manifest.json` and `qr_dqn_cvar_manifest.json` share checkpoint, seed, and timesteps |
| Mean-value comparator on same discrete action lattice | met | PR #4672 mean baseline config and mean manifest |
| Matched-seed diagnostic comparison recorded | met | PR #4476 report contract; PR #4672 checked-in comparison JSON/Markdown |
| Collision, near-miss, min-clearance, success/progress, path-efficiency tradeoffs | partial | Metric keys exist in smoke manifests, but PR #4672 gate review classified them as synthetic-observation placeholders, not measured benchmark safety outcomes |
| Fallback/degraded rows excluded or marked non-evidence | met | `summary.json` and comparison fallback/degraded rows are clean |
| Explicit claim boundary, no paper-facing safety claim | met | `diagnostic-only`; `benchmark_safety_claim=false` |

</details>
