### PR TITLE
Issue #1126: add SDD scan next-action packets

### DIFF
--- a/scripts/tools/sdd_curation_preflight.py
+++ b/scripts/tools/sdd_curation_preflight.py
@@ -187,6 +187,7 @@ def scan_annotation_candidates(
     min_track_points: int,
     max_pedestrians: int,
     limit: int = 5,
+    next_action_packet_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Rank staged SDD annotation candidates without writing derived artifacts."""
     annotations = sorted(root.rglob("annotations.txt")) if root.is_dir() else []
@@ -209,6 +210,14 @@ def scan_annotation_candidates(
         ),
     )
     selected = ranked[:limit] if limit > 0 else ranked
+    if next_action_packet_config is not None:
+        for index, candidate in enumerate(selected, start=1):
+            candidate["next_action_packet"] = build_scan_candidate_next_action_packet(
+                candidate,
+                scan_root=root,
+                rank=index,
+                config=next_action_packet_config,
+            )
     satisfiable_count = sum(1 for probe in probes if probe["selection_satisfiable"])
     blockers = []
     if not root.is_dir():
@@ -333,6 +342,7 @@ def run_preflight(
     label: str,
     min_track_points: int,
     max_pedestrians: int,
+    next_action_packet_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Resolve the staging gate, optionally probe an annotation, and classify readiness."""
     staging_gate = manage_external_data.resolve_sdd_scenario_prior_mode(manifest_path=manifest_path)
@@ -352,6 +362,7 @@ def run_preflight(
             min_track_points=min_track_points,
             max_pedestrians=max_pedestrians,
             limit=scan_limit,
+            next_action_packet_config=next_action_packet_config,
         )
     return report
 
@@ -359,6 +370,47 @@ def run_preflight(
 def _shell_arg(value: str | Path) -> str:
     """Return a conservative single-token shell representation for packet commands."""
     return shlex.quote(str(value))
+
+
+def _safe_dataset_suffix(path: Path, *, scan_root: Path) -> str:
+    """Build a stable dataset-id suffix from a scanned annotation path."""
+    try:
+        relative = path.relative_to(scan_root)
+    except ValueError:
+        relative = path
+    parts = list(relative.parts)
+    if parts and parts[-1] == "annotations.txt":
+        parts = parts[:-1]
+    raw_suffix = "_".join(parts) or path.stem
+    safe = "".join(char.lower() if char.isalnum() else "_" for char in raw_suffix)
+    safe = "_".join(part for part in safe.split("_") if part)
+    return safe or "annotation"
+
+
+def build_scan_candidate_next_action_packet(
+    candidate: dict[str, Any],
+    *,
+    scan_root: Path,
+    rank: int,
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a runnable next-action packet for one ranked SDD scan candidate."""
+    annotation = Path(candidate["path"])
+    suffix = _safe_dataset_suffix(annotation, scan_root=scan_root)
+    output_dir = config.get("output_dir") or Path("output/sdd_curation/issue_1126_candidate_scan")
+    candidate_probe = {
+        key: value for key, value in candidate.items() if key != "next_action_packet"
+    }
+    return build_decision_packet(
+        {"candidate_scan_rank": rank, "candidate_probe": candidate_probe},
+        annotation=annotation,
+        label=config["label"],
+        min_track_points=config["min_track_points"],
+        max_pedestrians=config["max_pedestrians"],
+        dataset_id=f"{config['dataset_id_prefix']}_{suffix}",
+        output_dir=output_dir / f"{rank:02d}_{suffix}",
+        meters_per_pixel=config.get("meters_per_pixel"),
+    )
 
 
 def build_decision_packet(
@@ -795,6 +847,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=5,
         help="Maximum ranked scan candidates to include; use 0 to include all.",
     )
+    parser.add_argument(
+        "--scan-next-action-packets",
+        action="store_true",
+        help="Attach runnable preflight/import command packets to ranked scan candidates.",
+    )
     parser.add_argument("--label", default="Pedestrian", help="SDD label to probe for.")
     parser.add_argument("--min-track-points", type=int, default=8)
     parser.add_argument("--max-pedestrians", type=int, default=4)
@@ -852,6 +909,16 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("--min-track-points must be > 1")
     if args.max_pedestrians <= 0:
         raise SystemExit("--max-pedestrians must be > 0")
+    next_action_packet_config = None
+    if args.scan_next_action_packets:
+        next_action_packet_config = {
+            "label": args.label,
+            "min_track_points": args.min_track_points,
+            "max_pedestrians": args.max_pedestrians,
+            "dataset_id_prefix": args.decision_dataset_id,
+            "output_dir": args.decision_output_dir,
+            "meters_per_pixel": args.decision_meters_per_pixel,
+        }
     report = run_preflight(
         manifest_path=args.manifest,
         annotation=args.annotation,
@@ -860,6 +927,7 @@ def main(argv: list[str] | None = None) -> int:
         label=args.label,
         min_track_points=args.min_track_points,
         max_pedestrians=args.max_pedestrians,
+        next_action_packet_config=next_action_packet_config,
     )
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/tools/test_sdd_curation_preflight.py
+++ b/tests/tools/test_sdd_curation_preflight.py
@@ -665,6 +665,90 @@ def test_scan_annotation_candidates_ranks_satisfiable_candidates(tmp_path: Path)
     assert scan["candidates"][0]["usable_track_count"] == 2
 
 
+def test_scan_annotation_candidates_can_attach_next_action_packets(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Ranked scan output can carry runnable next empirical action commands."""
+    annotations = tmp_path / "annotations" / "bookstore" / "video0" / "annotations.txt"
+    annotations.parent.mkdir(parents=True)
+    _write_sdd_fixture(annotations)
+
+    scan = sdd_curation_preflight.scan_annotation_candidates(
+        tmp_path,
+        label="Pedestrian",
+        min_track_points=4,
+        max_pedestrians=4,
+        limit=1,
+        next_action_packet_config={
+            "label": "Pedestrian",
+            "min_track_points": 4,
+            "max_pedestrians": 4,
+            "dataset_id_prefix": "sdd_scan",
+            "output_dir": tmp_path / "derived",
+            "meters_per_pixel": 0.0417,
+        },
+    )
+
+    packet = scan["candidates"][0]["next_action_packet"]
+    assert packet["selected_annotation"] == str(annotations)
+    assert packet["curation_parameters"]["meters_per_pixel"] == 0.0417
+    assert packet["required_next_commands"]["preflight"].endswith(
+        "--require-benchmark-ready --json"
+    )
+
+    parsed = _parse_importer_command(packet["required_next_commands"]["import"], monkeypatch)
+    assert parsed.annotations == annotations
+    assert parsed.dataset_id == "sdd_scan_annotations_bookstore_video0"
+    assert parsed.out_dir == tmp_path / "derived" / "01_annotations_bookstore_video0"
+    assert parsed.meters_per_pixel == 0.0417
+
+
+def test_cli_scan_next_action_packets_are_opt_in(tmp_path: Path, monkeypatch, capsys) -> None:
+    """CLI scan can emit copyable next-action packets without benchmark promotion."""
+    annotations = tmp_path / "annotations" / "bookstore" / "video0" / "annotations.txt"
+    annotations.parent.mkdir(parents=True)
+    _write_sdd_fixture(annotations)
+    monkeypatch.setattr(
+        manage_external_data,
+        "resolve_sdd_scenario_prior_mode",
+        lambda *, manifest_path=None: {
+            "mode": manage_external_data.SDD_MODE_PROXY,
+            "dataset_backed": False,
+            "availability": {"state": "missing"},
+            "reason": "SDD not staged.",
+            "staging_dir": str(tmp_path),
+        },
+    )
+
+    exit_code = sdd_curation_preflight.main(
+        [
+            "--scan-root",
+            str(tmp_path),
+            "--scan-limit",
+            "1",
+            "--scan-next-action-packets",
+            "--min-track-points",
+            "4",
+            "--decision-dataset-id",
+            "sdd_scan",
+            "--decision-output-dir",
+            str(tmp_path / "derived"),
+            "--decision-meters-per-pixel",
+            "0.0417",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    report = json.loads(capsys.readouterr().out)
+    packet = report["candidate_scan"]["candidates"][0]["next_action_packet"]
+    assert report["benchmark_promotion_allowed"] is False
+    assert packet["selected_annotation"] == str(annotations)
+    assert packet["required_next_commands"]["preflight"].endswith(
+        "--require-benchmark-ready --json"
+    )
+
+
 def test_cli_scan_root_reports_candidates_without_benchmark_claim(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:


### PR DESCRIPTION
Reviewer-critical summary

What changed: `sdd_curation_preflight.py --scan-root` can now opt into `--scan-next-action-packets`, attaching a runnable decision packet to each ranked Stanford Drone Dataset (SDD) annotation candidate. The packet reuses the existing preflight/import command builder, carries the selected annotation, dataset id, output directory, scale argument, and remains metadata-only.

Why now: #1126 is not closure-ready. The live issue thread and merged PRs show staged BYO SDD provenance, one real `bookstore/video0` import, and CPU smoke evidence, but the candidate is still `exploratory_only` because smoke runs timed out. The smallest remaining CPU-only progression is to make the existing candidate scanner produce copyable next empirical actions once the staged SDD tree is restored.

Claim boundary: This PR adds a local command-generation capability and focused tests. It does not run a real SDD import/smoke, does not promote benchmark-ready evidence, and does not close #1126.

Required validation: focused preflight tests plus lint/format on the touched files; final PR readiness is expected to be run with this body file before opening.

Remaining blocker: restore or stage the licensed SDD annotation tree, run `sdd_curation_preflight.py --scan-root ... --scan-next-action-packets`, import the top ranked candidate, and run one CPU representative smoke that reaches the benchmark-ready boundary.

Contract delta

New schema fields / CLI output:
- Optional `candidate_scan.candidates[].next_action_packet` appears only when `--scan-next-action-packets` is passed.
- The packet uses the existing `robot_sf_sdd_curation_decision_packet.v1` shape.

New fail-closed blockers:
- None. The existing `benchmark_promotion_allowed` gate remains unchanged; proxy or missing SDD data still cannot become benchmark evidence.

Compatibility impact:
- Default scan output is unchanged unless the new opt-in flag is used.
- No raw SDD data or generated scenario/map artifacts are committed.

Issue

Refs #1126

Scope summary

This is a progression slice, not a guardrail/status refresh: it converts ranked SDD candidate scan output into runnable next-action packets so the next agent can proceed directly to import/smoke once real staged data is available.

Acceptance evidence

| Criterion | Evidence | Closure status |
| --- | --- | --- |
| #1497 staged official/BYO SDD source annotations or clear failure | Merged PR evidence records pinned BYO tree, but this local worktree currently has no SDD bytes under external-data roots. | Met historically, not locally runnable here |
| One scene/video selected with deterministic rationale | Prior evidence selected `bookstore/video0`; this PR enables ranked scan candidates to carry runnable packets for alternate selection. | Progression |
| Import command, source identity, checksums, license/source URL, scale assumptions recorded | Existing decision packet builder records command and scale; this PR reuses it from scan results. | Progression |
| Generated scenario/map artifacts load | Not run here because local SDD tree is absent. | Remaining |
| Representative CPU smoke succeeds or rejected reasons | Prior smoke rejected `bookstore/video0` as `exploratory_only`; no new smoke run here. | Remaining |
| Documentation states `benchmark_ready` vs `exploratory_only` | Existing merged evidence keeps this distinction; this PR does not alter classifier semantics. | Met |
| Only small reviewable artifacts or durable pointers committed | Only code and tests are changed. | Met |

Validation command results

- `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/tools/test_sdd_curation_preflight.py -q` — pass, 31 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` — pass.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` — pass.
- `python -m py_compile scripts/tools/sdd_curation_preflight.py tests/tools/test_sdd_curation_preflight.py` — pass.
- `git diff --check` — pass.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/sdd_curation_preflight.py --help` — pass; help includes `--scan-next-action-packets`.

Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

State propagation

No separate issue comment was added because this issue is high-churn (>3 PRs in 24h) and this run is not authorized for issue/PR comments. The PR body carries the state delta instead: `Refs #1126`, non-closure boundary, and remaining empirical checklist.

<details>
<summary>Appendix: live issue/fragmentation notes</summary>

- `gh issue view 1126 --comments` failed in this repo due GitHub classic Projects GraphQL deprecation; REST issue/comment API fallback was used to read the full issue body and all comments.
- No open PR matched `1126 in:title,body` before opening this branch.
- Fragmentation guard is active: multiple #1126 PRs merged in the last 24h. This PR is exempt as a progression slice that adds a nameable new capability: scan-ranked candidates can now emit runnable next-action packets.
- Late issue refresh before PR creation found no newer maintainer guidance changing the open/non-closure boundary.

</details>
