### PR TITLE
Issue #4013 fail closed validated trajectory staging

### DIFF
--- a/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
+++ b/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
@@ -23,18 +23,30 @@
   ],
   "availability": "validated",
   "benchmark_eligibility": "research_only",
-  "blockers": [],
+  "blockers": [
+    {
+      "code": "staging.env_unresolved_for_validated",
+      "message": "availability 'validated' requires staging.staging_dir to resolve to a local directory; set ROBOT_SF_EXTERNAL_DATA_ROOT or use an output/ path.",
+      "severity": "error"
+    }
+  ],
   "claim_boundary": "Real-trajectory readiness only. No raw data is staged by this checker; no benchmark, navigation-quality, paper, or dissertation claim is made.",
   "dataset_id": "issue_4013_eth_biwi",
   "issue": 4013,
   "manifest_path": "configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml",
   "next_action": "Stage ETH/BIWI or another approved real pedestrian trajectory dataset under $ROBOT_SF_EXTERNAL_DATA_ROOT, validate its checksum, update the manifest, then run real-trajectory training and representative evaluation.",
-  "preflight_issues": [],
+  "preflight_issues": [
+    {
+      "code": "staging.env_unresolved_for_validated",
+      "message": "availability 'validated' requires staging.staging_dir to resolve to a local directory; set ROBOT_SF_EXTERNAL_DATA_ROOT or use an output/ path.",
+      "severity": "error"
+    }
+  ],
   "retrieval": {
     "download_url": "https://ethz.ch/content/dam/ethz/special-interest/itet/cvl/vision-dam/documents/ewap_dataset_light.tgz",
     "fail_closed": true,
     "instructions": "Obtain the ETH/BIWI walking pedestrians annotation archive from the official ETH Computer Vision Lab datasets page under its current terms. Extract the raw annotation files into staging_dir. Do not commit raw annotations or converted trajectory files. After staging, compute the aggregate SHA-256 tree checksum, set checksums.tree_sha256 and expected_tree_sha256, and change availability to validated before using the data for #4013 real-trajectory training or representative evaluation."
   },
   "schema_version": "issue_4013.real_trajectory_readiness.v1",
-  "status": "ready_for_real_trajectory_training"
+  "status": "blocked_manifest_contract"
 }

--- a/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md
+++ b/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md
@@ -1,6 +1,6 @@
 # Issue #4013 Real-Trajectory Readiness
 
-Status: `ready_for_real_trajectory_training`
+Status: `blocked_manifest_contract`
 
 Claim boundary: real-trajectory readiness only. No raw data is staged, no full benchmark campaign is run, and no paper/dissertation claim is made.
 
@@ -15,7 +15,7 @@ Claim boundary: real-trajectory readiness only. No raw data is staged, no full b
 
 ## Blockers
 
-- None.
+- `staging.env_unresolved_for_validated`: availability 'validated' requires staging.staging_dir to resolve to a local directory; set ROBOT_SF_EXTERNAL_DATA_ROOT or use an output/ path.
 
 ## Acceptance Evidence
 

--- a/robot_sf/data_ingestion/real_trajectory_contract.py
+++ b/robot_sf/data_ingestion/real_trajectory_contract.py
@@ -27,6 +27,8 @@ from typing import Any
 import jsonschema
 import yaml
 
+from robot_sf.common.artifact_paths import get_repository_root
+
 MANIFEST_SCHEMA_ID = "robot_sf_real_trajectory_ingestion_manifest.v1"
 
 _SCHEMA_PATH = (
@@ -46,10 +48,18 @@ _GITIGNORED_STAGING_PREFIXES = (
 def _resolved_staging_dir(staging_dir: str) -> Path:
     """Resolve a BYO staging directory after expanding environment variables.
 
+    Relative paths (for example the canonical ``output/`` artifact root) are
+    anchored to the repository root so validated-staging checks do not depend on
+    the current working directory. Paths that still contain an unresolved
+    environment variable are returned unexpanded so the caller can fail closed.
+
     Returns:
         Expanded local filesystem path.
     """
-    return Path(os.path.expandvars(staging_dir)).expanduser()
+    expanded = Path(os.path.expandvars(staging_dir)).expanduser()
+    if "$" in str(expanded) or expanded.is_absolute():
+        return expanded
+    return get_repository_root() / expanded
 
 
 def _validated_staging_issues(staging_dir: str) -> list[PreflightIssue]:

--- a/robot_sf/data_ingestion/real_trajectory_contract.py
+++ b/robot_sf/data_ingestion/real_trajectory_contract.py
@@ -19,6 +19,7 @@ This module performs no network access and stages no data; it only reads a manif
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -40,6 +41,56 @@ _GITIGNORED_STAGING_PREFIXES = (
     "${ROBOT_SF_EXTERNAL_DATA_ROOT}",
     "$ROBOT_SF_EXTERNAL_DATA_ROOT",
 )
+
+
+def _resolved_staging_dir(staging_dir: str) -> Path:
+    """Resolve a BYO staging directory after expanding environment variables.
+
+    Returns:
+        Expanded local filesystem path.
+    """
+    return Path(os.path.expandvars(staging_dir)).expanduser()
+
+
+def _validated_staging_issues(staging_dir: str) -> list[PreflightIssue]:
+    """Return fail-closed issues for a manifest claiming validated local staging.
+
+    Returns:
+        Blocking issues for unresolved, missing, or empty staging directories.
+    """
+    resolved_staging_dir = _resolved_staging_dir(staging_dir)
+    issues: list[PreflightIssue] = []
+    if "$" in str(resolved_staging_dir):
+        issues.append(
+            PreflightIssue(
+                code="staging.env_unresolved_for_validated",
+                message=(
+                    "availability 'validated' requires staging.staging_dir to resolve to a "
+                    "local directory; set ROBOT_SF_EXTERNAL_DATA_ROOT or use an output/ path."
+                ),
+            )
+        )
+    elif not resolved_staging_dir.is_dir():
+        issues.append(
+            PreflightIssue(
+                code="staging.dir_missing_for_validated",
+                message=(
+                    "availability 'validated' requires staging.staging_dir to exist locally: "
+                    f"{resolved_staging_dir}"
+                ),
+            )
+        )
+    elif not any(resolved_staging_dir.iterdir()):
+        issues.append(
+            PreflightIssue(
+                code="staging.dir_empty_for_validated",
+                message=(
+                    "availability 'validated' requires staging.staging_dir to contain "
+                    f"staged trajectory files: {resolved_staging_dir}"
+                ),
+            )
+        )
+    return issues
 
 
 class ContractError(RuntimeError):
@@ -226,6 +277,8 @@ def run_preflight(manifest: dict[str, Any], *, validate_structure: bool = True) 
                 ),
             )
         )
+    if availability == "validated":
+        issues.extend(_validated_staging_issues(staging["staging_dir"]))
 
     return PreflightResult(
         dataset_id=manifest["dataset_id"],

--- a/tests/data/test_real_trajectory_contract.py
+++ b/tests/data/test_real_trajectory_contract.py
@@ -234,6 +234,30 @@ def test_validated_staging_dir_must_be_non_empty(
     assert any(i.code == "staging.dir_empty_for_validated" for i in result.errors)
 
 
+def test_validated_output_relative_staging_is_cwd_independent(
+    valid_manifest: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An ``output/``-relative validated manifest resolves against the repo root, not cwd."""
+    from robot_sf.data_ingestion import real_trajectory_contract as contract
+
+    repo_root = tmp_path / "repo"
+    staging_dir = repo_root / "output" / "external_data" / "synthetic_byo"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "trajectories.csv").write_text("frame,ped_id,x,y\n0,1,0,0\n", encoding="utf-8")
+    monkeypatch.setattr(contract, "get_repository_root", lambda: repo_root)
+    valid_manifest["staging"]["staging_dir"] = "output/external_data/synthetic_byo"
+    valid_manifest["availability"] = "validated"
+    valid_manifest["checksums"]["tree_sha256"] = "a" * 64
+    valid_manifest["checksums"]["expected_tree_sha256"] = "a" * 64
+
+    # Run from an unrelated cwd; resolution must still find the repo-root staging dir.
+    other_cwd = tmp_path / "elsewhere"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+    result = run_preflight(valid_manifest)
+    assert result.ok, [f"{i.code}: {i.message}" for i in result.errors]
+
+
 def test_project_hosted_posture_warns(valid_manifest: dict) -> None:
     """The project-hosted posture produces an advisory warning, not a hard error."""
     valid_manifest["license"]["posture"] = "project-hosted"

--- a/tests/data/test_real_trajectory_contract.py
+++ b/tests/data/test_real_trajectory_contract.py
@@ -172,14 +172,66 @@ def test_validated_availability_requires_checksum(valid_manifest: dict) -> None:
     assert any(i.code == "checksums.missing_for_validated" for i in result.errors)
 
 
-def test_fully_validated_benchmark_candidate_passes(valid_manifest: dict) -> None:
+def test_fully_validated_benchmark_candidate_passes(
+    valid_manifest: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A staged, checksum-validated benchmark candidate passes preflight."""
+    data_root = tmp_path / "external_data"
+    staging_dir = data_root / "synthetic_byo"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "trajectories.csv").write_text("frame,ped_id,x,y\n0,1,0,0\n", encoding="utf-8")
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(data_root))
+    valid_manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
     valid_manifest["availability"] = "validated"
     valid_manifest["benchmark_eligibility"] = "benchmark_candidate"
     valid_manifest["checksums"]["tree_sha256"] = "a" * 64
     valid_manifest["checksums"]["expected_tree_sha256"] = "a" * 64
     result = run_preflight(valid_manifest)
     assert result.ok, [f"{i.code}: {i.message}" for i in result.errors]
+
+
+def test_validated_external_data_root_must_resolve(
+    valid_manifest: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Validated manifests fail closed when the external-data env var is unset."""
+    monkeypatch.delenv("ROBOT_SF_EXTERNAL_DATA_ROOT", raising=False)
+    valid_manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
+    valid_manifest["availability"] = "validated"
+    valid_manifest["checksums"]["tree_sha256"] = "a" * 64
+    valid_manifest["checksums"]["expected_tree_sha256"] = "a" * 64
+    result = run_preflight(valid_manifest)
+    assert not result.ok
+    assert any(i.code == "staging.env_unresolved_for_validated" for i in result.errors)
+
+
+def test_validated_staging_dir_must_exist(
+    valid_manifest: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Validated manifests fail closed when the resolved staging directory is absent."""
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(tmp_path / "external_data"))
+    valid_manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
+    valid_manifest["availability"] = "validated"
+    valid_manifest["checksums"]["tree_sha256"] = "a" * 64
+    valid_manifest["checksums"]["expected_tree_sha256"] = "a" * 64
+    result = run_preflight(valid_manifest)
+    assert not result.ok
+    assert any(i.code == "staging.dir_missing_for_validated" for i in result.errors)
+
+
+def test_validated_staging_dir_must_be_non_empty(
+    valid_manifest: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Validated manifests fail closed when the local staging directory has no files."""
+    data_root = tmp_path / "external_data"
+    (data_root / "synthetic_byo").mkdir(parents=True)
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(data_root))
+    valid_manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
+    valid_manifest["availability"] = "validated"
+    valid_manifest["checksums"]["tree_sha256"] = "a" * 64
+    valid_manifest["checksums"]["expected_tree_sha256"] = "a" * 64
+    result = run_preflight(valid_manifest)
+    assert not result.ok
+    assert any(i.code == "staging.dir_empty_for_validated" for i in result.errors)
 
 
 def test_project_hosted_posture_warns(valid_manifest: dict) -> None:

--- a/tests/training/test_issue_4013_real_trajectory_readiness.py
+++ b/tests/training/test_issue_4013_real_trajectory_readiness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
+import pytest
 import yaml
 
 from scripts.training.check_issue_4013_real_trajectory_readiness import (
@@ -83,8 +84,17 @@ def test_missing_real_dataset_blocks_phase3_without_contract_error(tmp_path: Pat
     assert report["preflight_issues"] == []
 
 
-def test_validated_research_manifest_is_ready_for_real_trajectory_training(tmp_path: Path) -> None:
-    """Checksum-validated research-eligible manifests unlock real-trajectory training."""
+def test_validated_research_manifest_is_ready_for_real_trajectory_training(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Checksum-validated staged research manifests unlock real-trajectory training."""
+    data_root = tmp_path / "external_data"
+    staging_dir = data_root / "issue_4013_test"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "trajectories.csv").write_text(
+        "scene,frame,pedestrian_id,x,y\neth,0,1,0,0\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(data_root))
     manifest = deepcopy(_manifest())
     manifest["availability"] = "validated"
     manifest["benchmark_eligibility"] = "research_only"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: #4013 closure audit found the current real-trajectory readiness report could say `ready_for_real_trajectory_training` when the manifest had `availability: validated` but the local staging root was unresolved on this host. This PR makes validated real-trajectory manifests fail closed unless `staging.staging_dir` resolves to a local, existing, non-empty directory, updates focused tests, and regenerates the #4013 readiness evidence to the actual current state: `blocked_manifest_contract`.

Why now: the live issue thread latest note (2026-07-06 21:35:42Z, PR #4700) keeps #4013 open for real ETH/BIWI staging, real-trajectory training, and representative evaluation. Merged PR #4697 changed metadata to `availability: validated`, but the artifact was not locally reachable here (`ROBOT_SF_EXTERNAL_DATA_ROOT` unset), so closure would overstate readiness.

Claim boundary: integration/contract correctness only. This PR does not train on ETH/BIWI, run representative evaluation, run a full benchmark campaign, submit Slurm/GPU work, or make paper/dissertation/navigation-quality claims.

Required validation: focused data-ingestion and #4013 readiness tests, Ruff on touched Python, regenerated readiness evidence, and real-trajectory trainer fail-closed probe.

Remaining blocker: set `ROBOT_SF_EXTERNAL_DATA_ROOT` to the checksum-pinned ETH/BIWI staging root or restage the dataset under an approved local root, then run real-trajectory training and representative evaluation vs `cv_prediction_mpc` plus a model-free baseline.

Refs #4013

## Contract delta

- `run_preflight()` now treats `availability: validated` as a local proof claim, not metadata only.
- New fail-closed blockers:
  - `staging.env_unresolved_for_validated`
  - `staging.dir_missing_for_validated`
  - `staging.dir_empty_for_validated`
- Compatibility impact: stricter only for manifests claiming `availability: validated`; `missing` and other non-validated BYO manifests keep the existing metadata-only behavior.
- #4013 durable state surface: regenerated `docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.{json,md}`. No issue comment was posted because this run was not authorized to comment, and the tracked evidence report is the canonical low-churn state surface for this slice.

## Acceptance evidence

| Criterion | Evidence | Status |
| --- | --- | --- |
| Read full issue thread and linked merged PR state | `gh issue view 4013 --repo ll7/robot_sf_ll7 --comments`; merged PR scan found #4629, #4644, #4655, #4665, #4679, #4697, #4700 relevant. Latest issue comment remains 2026-07-06 21:35:42Z. | Done |
| Short-horizon predictor trains | PR #4629 met diagnostic synthetic training; PR #4700 added real-trajectory trainer path. This PR proves current host cannot yet run the real path because staging root is unresolved. | Partial for Phase 3 |
| `learned_prediction_mpc` loads checkpoint and action selection runs | PR #4644 and #4655 met diagnostic-tier smoke/comparison. | Met at diagnostic tier |
| Comparison against `cv_prediction_mpc` and model-free baseline | PR #4655 produced paired diagnostic comparison. | Met at diagnostic tier |
| Real-trajectory training and representative evaluation | This PR prevents false-ready closure and records `blocked_manifest_contract` until local validated staging is reachable. | Remaining |

## Validation

- `uv sync --all-extras` completed in the fresh worktree.
- `uv run pytest tests/data/test_real_trajectory_contract.py tests/training/test_issue_4013_real_trajectory_readiness.py -q` -> 24 passed.
- `uv run ruff check robot_sf/data_ingestion/real_trajectory_contract.py tests/data/test_real_trajectory_contract.py tests/training/test_issue_4013_real_trajectory_readiness.py` -> all checks passed.
- `uv run ruff format robot_sf/data_ingestion/real_trajectory_contract.py tests/data/test_real_trajectory_contract.py tests/training/test_issue_4013_real_trajectory_readiness.py` -> 3 files left unchanged.
- `uv run python scripts/training/check_issue_4013_real_trajectory_readiness.py` -> `status=blocked_manifest_contract`, blocker `staging.env_unresolved_for_validated`.
- `uv run python scripts/training/train_learned_short_horizon_predictor_issue_4013.py --config configs/training/learned_short_horizon_predictor_issue_4013_real_trajectory.yaml` -> expected exit 1, `ValueError: real-trajectory manifest failed preflight: availability 'validated' requires staging.staging_dir to resolve to a local directory...`.

## Follow-Up Issues

- #4013 remains open for the next empirical slice: reachable checksum-pinned ETH/BIWI staging root, real-trajectory training run, and representative evaluation versus `cv_prediction_mpc` plus a model-free baseline.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Governance and freshness notes</summary>

- Fragmentation guard: recent #4013 merged slices include readiness/checker work, so this PR is scoped as an integration contract correction plus regenerated evidence, not a status-only packet. The nameable capability is local-staging proof for validated BYO real-trajectory manifests.
- Live dedupe before PR: no open PR matched #4013 title/body search.
- Late guidance check immediately before PR: no maintainer comment newer than the start-time issue state was present; latest remains PR #4700 state update at 2026-07-06T21:35:42Z.
- Closure call: partial. Use `Refs #4013`; issue #4013 remains open for the empirical follow-up.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Readiness checks now block validated manifests unless the staging location resolves to a local, existing, non-empty directory.
  * Improved error reporting so blocked setups clearly indicate what needs to be fixed before training can proceed.

* **Documentation**
  * Updated the readiness report to reflect the new blocked status and the related staging requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->