### PR TITLE
Issue #3637: add packet-backed reactivity replay rank launcher

### DIFF
--- a/scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py
+++ b/scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Run the packet-backed issue #3637 reactivity-vs-replay rank study.
+
+This is the execution bridge between the frozen launch packet and the existing
+#3573 paired campaign runner. It does not choose planners, seeds, scenario set,
+or evidence labels on the command line; those come from the predeclared packet
+after the same fail-closed preflight used by the planning checker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Keep this script runnable directly from the repository root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from robot_sf.benchmark.reactivity_replay_preflight import (  # noqa: E402
+    build_preflight_manifest,
+    run_plan_from_packet,
+)
+
+_RUNNER_PATH = (
+    _REPO_ROOT / "scripts" / "benchmark" / "run_reactivity_ablation_campaign_issue_3573.py"
+)
+_RUNNER_SPEC = importlib.util.spec_from_file_location("_issue_3573_reactivity_runner", _RUNNER_PATH)
+if _RUNNER_SPEC is None or _RUNNER_SPEC.loader is None:
+    raise ImportError(f"cannot load campaign runner from {_RUNNER_PATH}")
+_RUNNER = importlib.util.module_from_spec(_RUNNER_SPEC)
+_RUNNER_SPEC.loader.exec_module(_RUNNER)
+run_campaign = _RUNNER.run_campaign
+
+DEFAULT_PACKET = Path(
+    "configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml"
+)
+DEFAULT_OUTPUT_DIR = Path("output/issue_3637_reactivity_rank_study")
+DEFAULT_REPORT_JSON = DEFAULT_OUTPUT_DIR / "report.json"
+ISSUE = 3637
+EVIDENCE_TIER = "seed_sufficient_candidate"
+
+
+def _load_packet(path: Path) -> dict[str, Any]:
+    """Load the issue #3637 YAML launch packet."""
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected YAML mapping top level")
+    return payload
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the packet-backed campaign launcher."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--packet",
+        type=Path,
+        default=DEFAULT_PACKET,
+        help="Frozen issue #3637 launch-packet YAML.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory for campaign JSONL files and report.",
+    )
+    parser.add_argument(
+        "--report-json",
+        type=Path,
+        default=DEFAULT_REPORT_JSON,
+        help="Path for campaign report JSON.",
+    )
+    parser.add_argument("--dt", type=float, default=0.1)
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable campaign report on stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the preflighted #3637 packet through the existing paired runner."""
+    args = _parse_args(argv)
+    packet = _load_packet(args.packet)
+    plan = run_plan_from_packet(packet)
+    preflight = build_preflight_manifest(plan)
+    if preflight["status"] != "ready":
+        print(json.dumps(preflight, indent=2, sort_keys=True), file=sys.stderr)
+        return 1
+
+    report = run_campaign(
+        Path(plan.scenario_set),
+        list(plan.arm_seeds["reactive"]),
+        tuple(plan.planners),
+        args.out_dir,
+        horizon=plan.horizon,
+        dt=args.dt,
+        workers=args.workers,
+        study_issue=ISSUE,
+        evidence_tier=EVIDENCE_TIER,
+    )
+    report["generated_at_utc"] = datetime.now(UTC).isoformat()
+    report["launch_packet"] = str(args.packet)
+    report["preflight_status"] = preflight["status"]
+    report["post_run_analyzer"] = (
+        "uv run python scripts/benchmark/"
+        "analyze_reactivity_replay_rank_study_issue_3637.py "
+        f"--packet {args.packet} --campaign-dir {args.out_dir} "
+        f"--campaign-report {args.report_json} --output-dir {args.out_dir / 'analysis'}"
+    )
+
+    args.report_json.parent.mkdir(parents=True, exist_ok=True)
+    args.report_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"wrote {args.report_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py
+++ b/tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py
@@ -1,0 +1,102 @@
+"""Tests for the packet-backed issue #3637 campaign launcher.
+
+The tests mock benchmark execution. They verify the frozen launch packet is the
+single source of truth for campaign arguments without running the campaign.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "benchmark" / "run_reactivity_replay_rank_study_issue_3637.py"
+PACKET = REPO_ROOT / "configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml"
+
+SPEC = importlib.util.spec_from_file_location("_issue_3637_runner", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+runner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(runner)
+
+
+def test_runner_uses_packet_plan_and_writes_report(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """The launcher should pass frozen packet values to the existing campaign runner."""
+    calls = []
+
+    def fake_run_campaign(*args: object, **kwargs: object) -> dict[str, object]:
+        set_path, seeds, planners, out_dir = args
+        calls.append(
+            {
+                "set_path": set_path,
+                "seeds": seeds,
+                "planners": planners,
+                "out_dir": out_dir,
+                "horizon": kwargs["horizon"],
+                "dt": kwargs["dt"],
+                "workers": kwargs["workers"],
+                "study_issue": kwargs["study_issue"],
+                "evidence_tier": kwargs["evidence_tier"],
+            }
+        )
+        return {"schema_version": "reactivity-ablation-campaign.v1", "issue": kwargs["study_issue"]}
+
+    monkeypatch.setattr(runner, "run_campaign", fake_run_campaign)
+    out_dir = tmp_path / "campaign"
+    report_json = tmp_path / "report.json"
+
+    exit_code = runner.main(
+        [
+            "--packet",
+            str(PACKET),
+            "--out-dir",
+            str(out_dir),
+            "--report-json",
+            str(report_json),
+            "--dt",
+            "0.2",
+            "--workers",
+            "2",
+        ]
+    )
+
+    assert exit_code == 0
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["set_path"] == Path("configs/scenarios/sets/classic_crossing_subset.yaml")
+    assert call["seeds"] == list(range(101, 121))
+    assert call["planners"] == ("goal", "orca", "social_force")
+    assert call["out_dir"] == out_dir
+    assert call["horizon"] == 300
+    assert call["dt"] == 0.2
+    assert call["workers"] == 2
+    assert call["study_issue"] == 3637
+    assert call["evidence_tier"] == "seed_sufficient_candidate"
+
+    report = json.loads(report_json.read_text(encoding="utf-8"))
+    assert report["preflight_status"] == "ready"
+    assert report["launch_packet"] == str(PACKET)
+    assert "analyze_reactivity_replay_rank_study_issue_3637.py" in report["post_run_analyzer"]
+
+
+def test_runner_fails_before_campaign_when_packet_preflight_blocks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A weakened launch packet should fail closed without starting the campaign."""
+    packet = yaml.safe_load(PACKET.read_text(encoding="utf-8"))
+    packet["planners"] = ["goal", "orca"]
+    blocked_packet = tmp_path / "blocked.yaml"
+    blocked_packet.write_text(yaml.safe_dump(packet), encoding="utf-8")
+
+    def fail_run_campaign(*args: object, **kwargs: object) -> dict[str, object]:
+        raise AssertionError("campaign must not run for blocked packet")
+
+    monkeypatch.setattr(runner, "run_campaign", fail_run_campaign)
+
+    exit_code = runner.main(["--packet", str(blocked_packet), "--out-dir", str(tmp_path)])
+
+    assert exit_code == 1


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds `scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py`, a packet-backed launcher that converts the frozen issue #3637 launch packet into the existing #3573 paired reactive-vs-replay campaign runner without retyping planners, seeds, scenario set, horizon, issue metadata, or evidence tier.

Why now: the merged closure audit PR #4590 shows all preflight/analyzer scaffolding is present, but the actual S20 campaign remains the blocker. This is a progression slice, not another guardrail: it adds the nameable missing execution bridge from frozen packet to campaign run while still failing closed when preflight blocks.

Claim boundary: Refs #3637. This PR does not run the benchmark campaign, does not produce rank-stability evidence, and does not make a paper/dissertation claim. It only makes the next campaign execution reproducible from the predeclared packet.

Required validation:
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py -q` -> pass, 2 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_reactivity_replay_preflight_issue_3637.py tests/benchmark/test_analyze_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_run_reactivity_ablation_campaign_issue_3573.py tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py -q` -> pass, 57 tests, 1 existing numba warning.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py` -> pass.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py` -> pass.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/preflight_reactivity_replay_rank_study_issue_3637.py --packet configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml --json` -> pass, status `ready`, 9 checks.

Remaining blocker: run the packet-backed campaign command, then run `scripts/benchmark/analyze_reactivity_replay_rank_study_issue_3637.py` on the completed outputs and promote the compact seed-sufficiency evidence bundle plus conservative interpretation.

State propagation: no separate issue comment or state-table mutation was made because `comment_issue_or_pr=false`; this PR body is the durable handoff surface for the delivered slice and remaining checklist.

## Contract delta

New schema fields: none.
New fail-closed blockers: the launcher exits before campaign execution if the frozen packet preflight status is not `ready`.
Compatibility impact: additive script and tests only; existing #3573 runner defaults and existing #3637 preflight/analyzer behavior are unchanged.

## Scope summary

Issue link: https://github.com/ll7/robot_sf_ll7/issues/3637

Added a CPU-side execution bridge for the already-declared #3637 campaign. The launcher:
- loads `configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml`;
- rebuilds the canonical preflight plan and requires status `ready`;
- invokes `run_campaign` with packet planners `goal`, `orca`, `social_force`, paired seeds `101..120`, scenario set `classic_crossing_subset`, horizon `300`, `study_issue=3637`, and `evidence_tier=seed_sufficient_candidate`;
- writes the campaign report and embeds the expected post-run analyzer command.

## Remaining criteria checklist

- [ ] Execute the full #3637 S20 campaign from the frozen packet using the new launcher.
- [ ] Run the post-run analyzer on completed outputs to produce `analysis.json`, `frozen_gate_input.json`, `rank_bootstrap_summary.json`, and compact review artifacts.
- [ ] Record conservative docs/context interpretation with the replay force-off limitation and seed-sufficiency decision.

## Explicit out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Appendix: closure-audit evidence mapping</summary>

| Acceptance criterion | Current evidence | Status |
| --- | --- | --- |
| Reactivity-vs-replay run across at least three planners with seed budget sufficient for rank stability | PR #3696/#3853/#3860/#3876/#4150 define and harden the packet/preflight; PR #4462 adds post-run analyzer; this PR adds packet-backed execution bridge. | Not complete until campaign is run and analyzed. |
| Rank stability / confidence reported for reactivity effect | PR #4462 adds analyzer and seed-gate input generation. | Not complete until durable campaign output exists. |
| Replay force-off limitation stated | PR #3594, #3696, #4150, #4462 carry and enforce `replay` = robot-to-pedestrian force disabled, not trajectory playback. | Mechanism surfaces met; final evidence bundle still pending run. |
| Conservative docs/context interpretation | PR #4590 records closure audit and blocker; final interpretation requires campaign output. | Partial. |
| Run reproduces same command and seed set | Packet pins seed set and command family; this PR makes packet the launcher source of truth. | Ready for execution; evidence pending run. |

</details>
