### PR TITLE
Issue #3285: add target export previews

### DIFF
--- a/docs/context/issue_3285_scenario_interop_converter.md
+++ b/docs/context/issue_3285_scenario_interop_converter.md
@@ -1,111 +1,97 @@
-# Issue #3285 Dry-Run Scenario Interop Converter (2026-06-27)
+# Issue #3285 Dry-Run Scenario Interop Converter
 
-Status: implementation of the local, asset-free slice (`smoke evidence`). Not benchmark evidence and
-not a cross-benchmark validity claim.
+Status: local, asset-free implementation slice (`smoke evidence`). This is not benchmark
+evidence and does not claim cross-benchmark validity.
 
 Related:
 - GitHub issue: https://github.com/ll7/robot_sf_ll7/issues/3285
 - Conceptual mapping seed: [`issue_2928_socnavbench_hunavsim_metric_correspondence.md`](issue_2928_socnavbench_hunavsim_metric_correspondence.md)
-- Source-side contract: `robot_sf/benchmark/scenario_contract.py`, `robot_sf/benchmark/schema/scenarios.schema.json`
-- External-asset prerequisites (block the full external run): #1456, #1498, #2414, #1134
+- Source-side contract: `robot_sf/benchmark/scenario_contract.py`,
+  `robot_sf/benchmark/schema/scenarios.schema.json`
+- External-asset prerequisites that block an external run: #1456, #1498, #2414, #1134
 
-## What this slice delivers
+## Slice Delivers
 
-A deterministic, schema-validated **intermediate representation (IR)** for Robot SF scenario-matrix
-entries, plus an explicit unsupported-field report. This is the buildable-local part of #3285; it
-does **not** require external assets and does **not** emit any SocNavBench or HuNavSim file.
+The local converter emits deterministic, schema-validated intermediate representation (IR)
+for Robot SF scenario-matrix entries, plus explicit unsupported-field reports. It does not
+require external assets and does not emit runnable SocNavBench or HuNavSim files.
 
 - Module: `robot_sf/benchmark/scenario_interop.py` (`convert_scenario_to_ir`, `dump_ir`,
-  `validate_interop_ir`).
+  `validate_interop_ir`, `build_target_export_manifest`, `build_target_export_preview`).
 - IR schema: `robot_sf/benchmark/schemas/scenario_interop_ir.v1.json`
   (`robot_sf.scenario_interop_ir.v1`).
 - Dry-run CLI: `scripts/tools/convert_scenario_interop.py`.
 - Tests: `tests/benchmark/test_scenario_interop.py`,
   `tests/benchmark/test_scenario_interop_target_compatibility.py`.
 
-## Target Compatibility Report
+## Target Compatibility
 
-The converter also emits an asset-free target compatibility report
+The converter emits asset-free target compatibility reports
 (`robot_sf.scenario_interop_target_compatibility.v1`) for `socnavbench` and `hunavsim`.
-This is a fail-closed readiness projection, not a target artifact exporter.
+These are fail-closed readiness projections, not target artifact exports.
 
 - `ready`: false until target assets/adapters are staged and required IR fields are present.
-- `blockers`: explicit missing asset, adapter, map, agent, flow, or unsupported-field blockers.
-- `warnings`: non-blocking provenance or target-semantics gaps, such as missing seeds or HuNavSim
-  ROS/Gazebo launch semantics outside the target-neutral IR.
+- `blockers`: explicit missing asset, adapter, map, agent, flow, and unsupported-field blockers.
+- `warnings`: non-blocking provenance or target-semantics gaps, including missing seeds and
+  HuNavSim ROS/Gazebo launch semantics outside the target-neutral IR.
 
-Use `--target socnavbench` or `--target hunavsim` on the dry-run CLI to include a selected target
-report in the stderr summary. Omitting `--target` reports both targets.
+## Target Export Manifest And Preview
 
-## Target Export Manifest
+`--target-out-dir` writes deterministic, asset-free target export manifests
+(`robot_sf.scenario_interop_target_export_manifest.v1`). A manifest is a JSON handoff
+contract for downstream adapters; it is not a runnable SocNavBench or HuNavSim scenario file.
+When prerequisites are missing, it remains `status: blocked`, `ready: false`, with named
+blockers, warnings, source scenario, and source IR schema.
 
-The converter can also write a deterministic, asset-free target export manifest
-(`robot_sf.scenario_interop_target_export_manifest.v1`) through `--target-out-dir`. This is a real
-JSON artifact contract for downstream adapters, but it is **not** a runnable SocNavBench or
-HuNavSim scenario file. When prerequisites are missing, the manifest remains fail-closed with
-`status: blocked`, `ready: false`, named blockers and warnings, and source scenario plus IR schema
-provenance.
+`--target-preview-out-dir` writes deterministic, asset-free target-shaped preview payloads
+(`robot_sf.scenario_interop_target_export_preview.v1`). Preview payloads preserve the
+target-specific sections that a real writer must resolve: `scenario`/`pedestrians` for
+SocNavBench and `world`/`agents` for HuNavSim. They carry the same fail-closed blockers as
+the manifest and are adapter-development artifacts, not runnable external benchmark inputs.
 
-Generated files under `output/` remain worktree-local evidence unless promoted separately.
-
-## IR contract
-
-The IR captures the scenario fields that are common across social-navigation testbeds:
+## IR Contract
 
 | IR section | Source fields | Notes |
 |---|---|---|
-| `provenance` | `id`/`scenario_id`/`name`, `metadata`, all top-level keys, source file | Records source id (fixed precedence), `source_kind` (`axis`/`explicit_map`), full `source_fields`, and `source_metadata`. |
-| `geometry` | `obstacle`, `map_file` | `obstacle` is also mapped to a coarse `environment_type` (`open` → `open_space`, `bottleneck` → `constrained_passage`, `maze` → `cluttered`). |
+| `provenance` | `id`/`scenario_id`/`name`, `metadata`, all top-level keys, source file | Records source id, `source_kind` (`axis`/`explicit_map`), full `source_fields`, and `source_metadata`. |
+| `geometry` | `obstacle`, `map_file` | `obstacle` maps to coarse `environment_type` (`open` -> `open_space`, `bottleneck` -> `constrained_passage`, `maze` -> `cluttered`). |
 | `environment` | `density`, `flow`, `groups`, `speed_var`, `goal_topology`, `robot_context` | Target-neutral environment semantics. |
-| `agents` | `single_pedestrians[]` | start/goal POIs, preferred speed, role, role target, wait points; specs without an `id` get a deterministic positional id `agent_<index>`. |
-| `timing` | `repeats`, `seeds` | |
-| `unsupported_fields` | everything else | See below. |
+| `agents` | `single_pedestrians[]` | Start/goal points of interest, preferred speed, role, role target, wait points; specs without an `id` get deterministic id `agent_<index>`. |
+| `timing` | `repeats`, `seeds` | Preserves repeat count and explicit seed set when present. |
+| `unsupported_fields` | everything else | Every unmapped top-level source key is reported with a reason; nothing is silently dropped. |
 
-### Unsupported-field reporting (explicit, never silent)
-
-Every top-level source key is classified exactly once. Recognized simulator-specific keys
-(`simulation_config`, `robot_config`, `route_overrides_file`, `amv`, `multi_amv`, `supported`) and
-any unrecognized key are recorded in `unsupported_fields` with a reason. Nothing is silently dropped.
-
-### Determinism
-
-For a given scenario dict the IR is a pure function of the input: section/key order is fixed by
-construction, `provenance.source_fields` is sorted, and `unsupported_fields` is sorted by field name.
-`dump_ir` therefore yields byte-identical JSON across runs.
-
-## Dry-run command
+## Dry-Run Commands
 
 ```bash
-# Print IR + per-scenario validity summary
-uv run python scripts/tools/convert_scenario_interop.py --matrix configs/baselines/example_matrix.yaml
-
-# Write one <scenario_id>.ir.json per scenario
+# Print IR plus per-scenario validity summary.
 uv run python scripts/tools/convert_scenario_interop.py \
-  --matrix configs/baselines/example_matrix.yaml --out-dir output/interop_ir
+  --matrix configs/baselines/example_matrix.yaml
 
-# Write fail-closed target export manifests
+# Write one <scenario_id>.ir.json per scenario.
+uv run python scripts/tools/convert_scenario_interop.py \
+  --matrix configs/baselines/example_matrix.yaml \
+  --out-dir output/interop_ir
+
+# Write fail-closed target export manifests.
 uv run python scripts/tools/convert_scenario_interop.py \
   --matrix configs/baselines/example_matrix.yaml \
   --target socnavbench \
   --target-out-dir output/issue_3285_target_export_manifest_smoke
+
+# Write fail-closed target export previews.
+uv run python scripts/tools/convert_scenario_interop.py \
+  --matrix configs/baselines/example_matrix.yaml \
+  --target socnavbench \
+  --target-preview-out-dir output/issue_3285_target_export_preview_smoke
 ```
 
-The CLI prints the IR to stdout only when no output directory is requested and writes a
-`{"dry_run_summary": [...]}` block (scenario id, IR validity, unsupported-field count, target
-compatibility) to stderr. Exit code is non-zero if any scenario IR fails schema validation.
+The CLI prints IR to stdout only when no output directory is requested. It always writes a
+`{"dry_run_summary": [...]}` block to stderr and exits non-zero when a scenario IR fails schema
+validation.
 
-## Validation
+## Claim Boundary
 
-```bash
-uv run python -m pytest tests/benchmark/test_scenario_interop.py -q          # 10 passed
-uv run python -m pytest tests/benchmark -k "scenario or convert or socnav" -q # 239 passed (issue cmd)
-uv run python scripts/tools/convert_scenario_interop.py --matrix configs/baselines/example_matrix.yaml --target socnavbench --target-out-dir output/issue_3285_target_export_manifest_smoke # 3 blocked manifests written
-```
-
-## Claim boundary / blocked-until
-
-- This is a **dry-run + IR validation + target export manifest** slice only. It makes no claim of
-  simulator equivalence, planner transferability, or benchmark-score parity (see the boundary in
-  [`issue_2928_...`](issue_2928_socnavbench_hunavsim_metric_correspondence.md)).
-- Emitting real runnable SocNavBench/HuNavSim scenario assets and running them is **blocked** on
-  staged external assets (#1456 / #1498 / #2414 / #1134) and is intentionally out of scope here.
+- This dry-run, IR validation, target export manifest, and target export preview slice makes no
+  claim about simulator equivalence, planner transferability, or benchmark-score parity.
+- Emitting real runnable SocNavBench/HuNavSim scenario assets and running them remains blocked on
+  staged external assets/adapters (#1456, #1498, #2414, #1134).

--- a/robot_sf/benchmark/scenario_interop.py
+++ b/robot_sf/benchmark/scenario_interop.py
@@ -47,6 +47,7 @@ CONVERTER_NAME = "robot_sf.scenario_interop"
 CONVERTER_VERSION = "1"
 TARGET_COMPATIBILITY_SCHEMA_VERSION = "robot_sf.scenario_interop_target_compatibility.v1"
 TARGET_EXPORT_MANIFEST_SCHEMA_VERSION = "robot_sf.scenario_interop_target_export_manifest.v1"
+TARGET_EXPORT_PREVIEW_SCHEMA_VERSION = "robot_sf.scenario_interop_target_export_preview.v1"
 SUPPORTED_TARGETS = ("socnavbench", "hunavsim")
 IR_SCHEMA_FILE = Path(__file__).with_name("schemas") / "scenario_interop_ir.v1.json"
 
@@ -436,6 +437,95 @@ def build_target_export_manifest(ir: Mapping[str, Any], *, target: str) -> dict[
     }
 
 
+def build_target_export_preview(ir: Mapping[str, Any], *, target: str) -> dict[str, Any]:
+    """Build deterministic, target-shaped preview payload without external assets.
+
+    The preview is an asset-free handoff artifact: it preserves the target-specific
+    sections a real exporter must resolve while still failing closed through the
+    same compatibility blockers as the export manifest.
+
+    Returns:
+        JSON-safe target export preview with target-shaped payload and fail-closed status.
+    """
+
+    report = build_target_compatibility_report(ir, targets=(target,))[0]
+    payload = (
+        _build_socnavbench_preview_payload(ir)
+        if target == "socnavbench"
+        else _build_hunavsim_preview_payload(ir)
+    )
+    return {
+        "schema_version": TARGET_EXPORT_PREVIEW_SCHEMA_VERSION,
+        "artifact_kind": f"{target}_scenario_export_preview",
+        "target": target,
+        "source_scenario_id": report["source_scenario_id"],
+        "source_ir_schema_version": ir.get("schema_version"),
+        "status": "ready" if report["ready"] else "blocked",
+        "ready": report["ready"],
+        "blockers": report["blockers"],
+        "warnings": report["warnings"],
+        "payload": payload,
+        "compatibility_report_schema_version": report["schema_version"],
+    }
+
+
+def _build_socnavbench_preview_payload(ir: Mapping[str, Any]) -> dict[str, Any]:
+    geometry = ir.get("geometry") if isinstance(ir.get("geometry"), Mapping) else {}
+    environment = ir.get("environment") if isinstance(ir.get("environment"), Mapping) else {}
+    timing = ir.get("timing") if isinstance(ir.get("timing"), Mapping) else {}
+    return {
+        "scenario": {
+            "name": _ir_source_id(ir),
+            "map": geometry.get("map_file"),
+            "environment_type": geometry.get("environment_type"),
+            "flow": environment.get("flow"),
+            "density": environment.get("density"),
+            "seed_set": timing.get("seeds"),
+        },
+        "pedestrians": [
+            {
+                "id": agent.get("id"),
+                "start": agent.get("start"),
+                "goal": agent.get("goal"),
+                "preferred_speed_mps": agent.get("preferred_speed_mps"),
+            }
+            for agent in _ir_agents(ir)
+        ],
+    }
+
+
+def _build_hunavsim_preview_payload(ir: Mapping[str, Any]) -> dict[str, Any]:
+    geometry = ir.get("geometry") if isinstance(ir.get("geometry"), Mapping) else {}
+    environment = ir.get("environment") if isinstance(ir.get("environment"), Mapping) else {}
+    return {
+        "world": {
+            "map_file": geometry.get("map_file"),
+            "obstacle_topology": geometry.get("obstacle_topology"),
+            "flow": environment.get("flow"),
+        },
+        "agents": [
+            {
+                "name": agent.get("id"),
+                "start_poi": agent.get("start"),
+                "goal_poi": agent.get("goal"),
+                "behavior": {
+                    "preferred_speed_mps": agent.get("preferred_speed_mps"),
+                    "role": agent.get("role"),
+                    "role_target_id": agent.get("role_target_id"),
+                },
+            }
+            for agent in _ir_agents(ir)
+        ],
+    }
+
+
+def _ir_agents(ir: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    agents = ir.get("agents")
+    if not isinstance(agents, Sequence) or isinstance(agents, (str, bytes)):
+        return []
+    return [agent for agent in agents if isinstance(agent, Mapping)]
+
+
 def _target_blockers(ir: Mapping[str, Any], *, target: str) -> list[dict[str, str]]:
     blockers: list[dict[str, str]] = [dict(item) for item in _TARGET_ASSET_BLOCKERS[target]]
     geometry = ir.get("geometry") if isinstance(ir.get("geometry"), Mapping) else {}
@@ -526,8 +616,12 @@ __all__ = [
     "IR_SCHEMA_VERSION",
     "SUPPORTED_TARGETS",
     "TARGET_COMPATIBILITY_SCHEMA_VERSION",
+    "TARGET_EXPORT_MANIFEST_SCHEMA_VERSION",
+    "TARGET_EXPORT_PREVIEW_SCHEMA_VERSION",
     "ScenarioInteropResult",
     "build_target_compatibility_report",
+    "build_target_export_manifest",
+    "build_target_export_preview",
     "convert_scenario_to_ir",
     "dump_ir",
     "load_interop_ir_schema",

--- a/scripts/tools/convert_scenario_interop.py
+++ b/scripts/tools/convert_scenario_interop.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
 """Dry-run Robot SF -> external-benchmark scenario converter CLI (issue #3285).
 
-Reads a Robot SF scenario-matrix file (YAML or JSON; a single scenario dict or a
-list of scenario dicts) and emits the deterministic, schema-validated interop
-**intermediate representation (IR)** for each scenario, plus an explicit
-unsupported-field report.
-
-This is a *dry run*: it requires no external assets and produces no SocNavBench or
-HuNavSim file. It makes no cross-benchmark validity claim. See
-``robot_sf/benchmark/scenario_interop.py`` for the contract and claim boundary.
-
-Examples:
-    # Print IR + unsupported report for every scenario in a matrix
-    uv run python scripts/tools/convert_scenario_interop.py \
-        --matrix configs/baselines/example_matrix.yaml
-
-    # Write one IR JSON file per scenario into a directory
-    uv run python scripts/tools/convert_scenario_interop.py \
-        --matrix configs/baselines/example_matrix.yaml --out-dir output/interop_ir
+Reads Robot SF scenario-matrix files and emits deterministic, schema-validated
+intermediate representation (IR) scenarios, explicit unsupported-field reports,
+fail-closed target export manifests, and asset-free target-shaped preview files.
+No command here produces runnable SocNavBench or HuNavSim assets.
 """
 
 from __future__ import annotations
@@ -34,49 +21,60 @@ from robot_sf.benchmark.scenario_interop import (
     SUPPORTED_TARGETS,
     build_target_compatibility_report,
     build_target_export_manifest,
+    build_target_export_preview,
     convert_scenario_to_ir,
     dump_ir,
 )
 
 
 def _load_scenarios(path: Path) -> list[dict[str, Any]]:
-    """Load scenario dicts from a YAML/JSON matrix file.
-
-    Accepts a single scenario mapping, a top-level list, or a ``{"scenarios": [...]}``
-    wrapper.
-
-    Returns:
-        Scenario dicts in file order.
-
-    Raises:
-        ValueError: When the file does not contain a usable scenario shape.
-    """
+    """Load scenario dicts from a YAML/JSON matrix file."""
 
     raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     if isinstance(raw, dict) and "scenarios" in raw:
         raw = raw["scenarios"]
     if isinstance(raw, dict):
-        return [raw]
-    if isinstance(raw, list) and all(isinstance(item, dict) for item in raw):
-        return raw
-    raise ValueError(
-        f"{path}: expected a scenario mapping, a list of mappings, or a top-level 'scenarios' list"
-    )
+        raw = [raw]
+    if not isinstance(raw, list) or not all(isinstance(item, dict) for item in raw):
+        raise ValueError(f"{path} must contain a scenario dict or list of scenario dicts")
+    return raw
+
+
+def _write_outputs(
+    *,
+    ir: dict[str, Any],
+    scenario_id: str,
+    targets: tuple[str, ...] | list[str],
+    out_dir: Path | None,
+    target_out_dir: Path | None,
+    target_preview_out_dir: Path | None,
+) -> None:
+    """Write requested IR, manifest, and preview outputs for one scenario."""
+
+    if out_dir is not None:
+        out_path = out_dir / f"{scenario_id}.ir.json"
+        out_path.write_text(dump_ir(ir), encoding="utf-8")
+    if target_out_dir is not None:
+        for target in targets:
+            manifest = build_target_export_manifest(ir, target=target)
+            manifest_path = target_out_dir / f"{scenario_id}.{target}.export_manifest.json"
+            manifest_path.write_text(dump_ir(manifest), encoding="utf-8")
+    if target_preview_out_dir is not None:
+        for target in targets:
+            preview = build_target_export_preview(ir, target=target)
+            preview_path = target_preview_out_dir / f"{scenario_id}.{target}.export_preview.json"
+            preview_path.write_text(dump_ir(preview), encoding="utf-8")
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the dry-run converter CLI.
-
-    Returns:
-        Process exit code: ``0`` when every scenario IR validated, ``1`` otherwise.
-    """
+    """Run CLI and return ``0`` when every scenario IR validates."""
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--matrix",
         required=True,
         type=Path,
-        help="Path to a Robot SF scenario-matrix YAML/JSON file.",
+        help="Path to Robot SF scenario-matrix YAML/JSON file.",
     )
     parser.add_argument(
         "--out-dir",
@@ -89,8 +87,18 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=None,
         help=(
-            "Optional directory to write one <scenario_id>.<target>.export_manifest.json "
-            "fail-closed target export manifest per scenario and requested target."
+            "Optional directory to write one "
+            "<scenario_id>.<target>.export_manifest.json fail-closed target export "
+            "manifest per scenario and requested target."
+        ),
+    )
+    parser.add_argument(
+        "--target-preview-out-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Optional directory to write one <scenario_id>.<target>.export_preview.json "
+            "asset-free target-shaped preview per scenario and requested target."
         ),
     )
     parser.add_argument(
@@ -99,17 +107,16 @@ def main(argv: list[str] | None = None) -> int:
         choices=SUPPORTED_TARGETS,
         default=[],
         help=(
-            "Include fail-closed compatibility report for target exporter. "
+            "Include fail-closed compatibility report for a target exporter. "
             "May be passed more than once."
         ),
     )
     args = parser.parse_args(argv)
 
     scenarios = _load_scenarios(args.matrix)
-    if args.out_dir is not None:
-        args.out_dir.mkdir(parents=True, exist_ok=True)
-    if args.target_out_dir is not None:
-        args.target_out_dir.mkdir(parents=True, exist_ok=True)
+    for directory in (args.out_dir, args.target_out_dir, args.target_preview_out_dir):
+        if directory is not None:
+            directory.mkdir(parents=True, exist_ok=True)
 
     exit_code = 0
     summary: list[dict[str, Any]] = []
@@ -121,6 +128,7 @@ def main(argv: list[str] | None = None) -> int:
             result.ir,
             targets=targets,
         )
+
         if not result.is_valid:
             exit_code = 1
         summary.append(
@@ -132,17 +140,21 @@ def main(argv: list[str] | None = None) -> int:
                 "target_compatibility": target_compatibility,
             }
         )
-        if args.out_dir is not None:
-            out_path = args.out_dir / f"{scenario_id}.ir.json"
-            out_path.write_text(dump_ir(result.ir), encoding="utf-8")
-        if args.target_out_dir is not None:
-            for target in targets:
-                manifest = build_target_export_manifest(result.ir, target=target)
-                manifest_path = args.target_out_dir / (
-                    f"{scenario_id}.{target}.export_manifest.json"
-                )
-                manifest_path.write_text(dump_ir(manifest), encoding="utf-8")
-        if args.out_dir is None and args.target_out_dir is None:
+
+        _write_outputs(
+            ir=result.ir,
+            scenario_id=scenario_id,
+            targets=targets,
+            out_dir=args.out_dir,
+            target_out_dir=args.target_out_dir,
+            target_preview_out_dir=args.target_preview_out_dir,
+        )
+
+        if (
+            args.out_dir is None
+            and args.target_out_dir is None
+            and args.target_preview_out_dir is None
+        ):
             sys.stdout.write(dump_ir(result.ir))
 
     sys.stderr.write(json.dumps({"dry_run_summary": summary}, indent=2) + "\n")

--- a/tests/benchmark/test_scenario_interop_target_compatibility.py
+++ b/tests/benchmark/test_scenario_interop_target_compatibility.py
@@ -7,8 +7,10 @@ import pytest
 from robot_sf.benchmark.scenario_interop import (
     TARGET_COMPATIBILITY_SCHEMA_VERSION,
     TARGET_EXPORT_MANIFEST_SCHEMA_VERSION,
+    TARGET_EXPORT_PREVIEW_SCHEMA_VERSION,
     build_target_compatibility_report,
     build_target_export_manifest,
+    build_target_export_preview,
     convert_scenario_to_ir,
     dump_ir,
 )
@@ -106,6 +108,81 @@ def test_target_export_manifest_is_deterministic() -> None:
     second = build_target_export_manifest(
         convert_scenario_to_ir(_explicit_map_scenario()).ir,
         target="hunavsim",
+    )
+
+    assert dump_ir(first) == dump_ir(second)
+
+
+def test_socnavbench_export_preview_contains_target_shaped_payload() -> None:
+    """SocNavBench preview preserves mapped sections while still blocked."""
+
+    result = convert_scenario_to_ir(_explicit_map_scenario())
+    preview = build_target_export_preview(result.ir, target="socnavbench")
+
+    assert preview["schema_version"] == TARGET_EXPORT_PREVIEW_SCHEMA_VERSION
+    assert preview["artifact_kind"] == "socnavbench_scenario_export_preview"
+    assert preview["status"] == "blocked"
+    assert preview["payload"]["scenario"] == {
+        "name": "corridor-handoff",
+        "map": "maps/svg_maps/corridor.svg",
+        "environment_type": None,
+        "flow": "bi",
+        "density": None,
+        "seed_set": None,
+    }
+    assert preview["payload"]["pedestrians"] == [
+        {
+            "id": "ped-1",
+            "start": "north",
+            "goal": "south",
+            "preferred_speed_mps": 1.2,
+        }
+    ]
+    assert {blocker["code"] for blocker in preview["blockers"]} >= {
+        "socnavbench_assets_not_staged",
+        "unsupported_fields_present",
+    }
+
+
+def test_hunavsim_export_preview_contains_target_shaped_payload() -> None:
+    """HuNavSim preview records ROS-adapter-shaped inputs without claiming readiness."""
+
+    result = convert_scenario_to_ir(_explicit_map_scenario())
+    preview = build_target_export_preview(result.ir, target="hunavsim")
+
+    assert preview["schema_version"] == TARGET_EXPORT_PREVIEW_SCHEMA_VERSION
+    assert preview["artifact_kind"] == "hunavsim_scenario_export_preview"
+    assert preview["status"] == "blocked"
+    assert preview["payload"]["world"] == {
+        "map_file": "maps/svg_maps/corridor.svg",
+        "obstacle_topology": None,
+        "flow": "bi",
+    }
+    assert preview["payload"]["agents"] == [
+        {
+            "name": "ped-1",
+            "start_poi": "north",
+            "goal_poi": "south",
+            "behavior": {
+                "preferred_speed_mps": 1.2,
+                "role": None,
+                "role_target_id": None,
+            },
+        }
+    ]
+    assert any(warning["code"] == "ros_semantics_unmapped" for warning in preview["warnings"])
+
+
+def test_target_export_preview_is_deterministic() -> None:
+    """Identical target preview inputs serialize byte-identically."""
+
+    first = build_target_export_preview(
+        convert_scenario_to_ir(_explicit_map_scenario()).ir,
+        target="socnavbench",
+    )
+    second = build_target_export_preview(
+        convert_scenario_to_ir(_explicit_map_scenario()).ir,
+        target="socnavbench",
     )
 
     assert dump_ir(first) == dump_ir(second)


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds deterministic, asset-free target export previews for issue #3285. `build_target_export_preview()` now emits target-shaped handoff payloads for SocNavBench (`scenario`/`pedestrians`) and HuNavSim (`world`/`agents`), and `convert_scenario_interop.py --target-preview-out-dir` writes one blocked preview JSON per scenario/target.

Why now: after merged PRs #3735, #4562, and #4673, the live issue still has one local progression gap before real external export: target-specific writer inputs were only represented as blockers/manifests. This slice adds a nameable new capability without requiring external assets or adapters.

Claim boundary: smoke evidence only. These previews are not runnable SocNavBench/HuNavSim scenario files, not benchmark evidence, and not a cross-benchmark equivalence or score-parity claim.

Required validation: focused interop tests, Ruff on changed Python files, issue-hinted benchmark selector, and CLI smoke for preview generation.

Remaining blocker: real runnable SocNavBench/HuNavSim artifact export still depends on staged external assets/adapters tracked by #1456, #1498, #2414, and #1134.

Refs #3285

## Contract delta

- New schema identifier: `robot_sf.scenario_interop_target_export_preview.v1`.
- New API: `build_target_export_preview(ir, target=...)`.
- New CLI option: `--target-preview-out-dir`, writing `<scenario_id>.<target>.export_preview.json`.
- New preview payloads:
  - SocNavBench: `payload.scenario` plus `payload.pedestrians`.
  - HuNavSim: `payload.world` plus `payload.agents`.
- Compatibility impact: additive only. Existing IR output, target compatibility reports, and target export manifests are unchanged.
- Fail-closed behavior: previews carry the same `ready`, `status`, `blockers`, and `warnings` fields as the manifest and remain blocked while target prerequisites are missing.

## Issue

https://github.com/ll7/robot_sf_ll7/issues/3285

## Scope summary

- Added target export preview API and deterministic target-shaped preview payload builders in `robot_sf/benchmark/scenario_interop.py`.
- Added `--target-preview-out-dir` to `scripts/tools/convert_scenario_interop.py`.
- Extended `tests/benchmark/test_scenario_interop_target_compatibility.py` for SocNavBench preview, HuNavSim preview, and preview determinism.
- Refreshed `docs/context/issue_3285_scenario_interop_converter.md` to document the manifest/preview boundary.

## Acceptance evidence

| Criterion | Evidence |
|---|---|
| Converter output schema-validated deterministic fixture scenario. | PR #3735 added IR schema validation and deterministic fixture tests; this PR preserves those tests and adds deterministic preview serialization coverage. |
| Unsupported fields reported explicitly instead silently dropped. | PR #3735 added unsupported-field reporting/tests; this PR reuses that report and keeps unresolved unsupported fields as preview blockers. |
| Smoke dry-run command documented. | PR #3735 documented the IR dry-run; PR #4673 documented manifest output; this PR documents `--target-preview-out-dir`. |
| Issue links external asset prerequisites required full run. | Issue and docs continue to name #1456, #1498, #2414, and #1134 as full-run blockers. |
| Real SocNavBench/HuNavSim artifact export. | Still not complete; this PR adds target-shaped preview handoff artifacts only. Runnable export remains blocked on external assets/adapters. |

## Validation

- `uv run ruff check robot_sf/benchmark/scenario_interop.py scripts/tools/convert_scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py` - passed.
- `uv run python -m pytest tests/benchmark/test_scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py -q` - 18 passed.
- `uv run python -m pytest tests/benchmark -k "scenario or convert or socnav" -q` - passed after `uv sync --all-extras`; initial fresh-worktree attempt failed during collection on missing optional deps (`torch`, `duckdb`).
- `uv run python scripts/tools/convert_scenario_interop.py --matrix configs/baselines/example_matrix.yaml --target socnavbench --target-preview-out-dir output/issue_3285_target_export_preview_smoke_after_merge` - exit 0; wrote 3 blocked SocNavBench preview files under ignored `output/`.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No runnable SocNavBench/HuNavSim export claim.

## Propagation

No issue comment was posted because this run is not authorized to comment on issues/PRs. This PR body is the durable propagation surface for the delivered slice and remaining blocker.

<details>
<summary>Readiness notes</summary>

- Live issue thread was read with comments before work and rechecked immediately before PR preparation; no maintainer comments newer than the start time were present.
- Open PR dedupe found no open PR for #3285 or this exact target-preview scope.
- Fragmentation guard: only one #3285 PR (#4673) was merged in the last 24 hours. This PR is a progression slice adding a target export preview capability, not a checker/packet refresh.
- Generated output classification: preview smoke files under `output/issue_3285_target_export_preview_smoke*` are ignored, worktree-local smoke artifacts and are not committed.
</details>
