### PR TITLE
Issue #4013 verify real-trajectory staging checksums

### DIFF
--- a/robot_sf/data_ingestion/real_trajectory_contract.py
+++ b/robot_sf/data_ingestion/real_trajectory_contract.py
@@ -18,6 +18,7 @@ This module performs no network access and stages no data; it only reads a manif
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from dataclasses import dataclass, field
@@ -62,7 +63,30 @@ def _resolved_staging_dir(staging_dir: str) -> Path:
     return get_repository_root() / expanded
 
 
-def _validated_staging_issues(staging_dir: str) -> list[PreflightIssue]:
+def _staging_tree_sha256(source_root: Path) -> str:
+    """Return aggregate SHA-256 over every file below ``source_root``.
+
+    Relative path, byte size, and per-file SHA-256 all contribute to the
+    aggregate so renamed, truncated, or modified local raw files fail closed.
+    """
+
+    digest = hashlib.sha256()
+    for file_path in sorted(path for path in source_root.rglob("*") if path.is_file()):
+        file_digest = hashlib.sha256()
+        with file_path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                file_digest.update(chunk)
+        relative_path = file_path.relative_to(source_root).as_posix()
+        digest.update(relative_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(file_path.stat().st_size).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(file_digest.hexdigest().encode("ascii"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _validated_staging_issues(staging_dir: str, checksums: dict[str, Any]) -> list[PreflightIssue]:
     """Return fail-closed issues for a manifest claiming validated local staging.
 
     Returns:
@@ -100,6 +124,45 @@ def _validated_staging_issues(staging_dir: str) -> list[PreflightIssue]:
                 ),
             )
         )
+    expected_tree_sha256 = checksums["expected_tree_sha256"]
+    recorded_tree_sha256 = checksums["tree_sha256"]
+    if not expected_tree_sha256:
+        issues.append(
+            PreflightIssue(
+                code="checksums.expected_missing_for_validated",
+                message=(
+                    "availability 'validated' requires checksums.expected_tree_sha256 "
+                    "to pin the staged-file tree."
+                ),
+            )
+        )
+    elif recorded_tree_sha256 and recorded_tree_sha256 != expected_tree_sha256:
+        issues.append(
+            PreflightIssue(
+                code="checksums.recorded_expected_mismatch",
+                message=(
+                    "checksums.tree_sha256 must match checksums.expected_tree_sha256 "
+                    "for validated real-trajectory staging."
+                ),
+            )
+        )
+
+    if issues:
+        return issues
+
+    computed_tree_sha256 = _staging_tree_sha256(resolved_staging_dir)
+    if computed_tree_sha256 != recorded_tree_sha256:
+        issues.append(
+            PreflightIssue(
+                code="checksums.staging_tree_mismatch",
+                message=(
+                    "availability 'validated' requires the local staging tree checksum "
+                    "to match checksums.tree_sha256; computed "
+                    f"{computed_tree_sha256}, expected {recorded_tree_sha256}."
+                ),
+            )
+        )
+
     return issues
 
 
@@ -288,7 +351,7 @@ def run_preflight(manifest: dict[str, Any], *, validate_structure: bool = True) 
             )
         )
     if availability == "validated":
-        issues.extend(_validated_staging_issues(staging["staging_dir"]))
+        issues.extend(_validated_staging_issues(staging["staging_dir"], checksums))
 
     return PreflightResult(
         dataset_id=manifest["dataset_id"],

--- a/tests/data/test_real_trajectory_contract.py
+++ b/tests/data/test_real_trajectory_contract.py
@@ -19,6 +19,7 @@ from robot_sf.data_ingestion import (
     run_preflight,
     validate_manifest_structure,
 )
+from robot_sf.data_ingestion import real_trajectory_contract as contract
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLE_MANIFEST = REPO_ROOT / "configs" / "data" / "real_trajectory_manifest.example.yaml"
@@ -184,8 +185,9 @@ def test_fully_validated_benchmark_candidate_passes(
     valid_manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
     valid_manifest["availability"] = "validated"
     valid_manifest["benchmark_eligibility"] = "benchmark_candidate"
-    valid_manifest["checksums"]["tree_sha256"] = "a" * 64
-    valid_manifest["checksums"]["expected_tree_sha256"] = "a" * 64
+    tree_sha256 = contract._staging_tree_sha256(staging_dir)
+    valid_manifest["checksums"]["tree_sha256"] = tree_sha256
+    valid_manifest["checksums"]["expected_tree_sha256"] = tree_sha256
     result = run_preflight(valid_manifest)
     assert result.ok, [f"{i.code}: {i.message}" for i in result.errors]
 
@@ -234,6 +236,48 @@ def test_validated_staging_dir_must_be_non_empty(
     assert any(i.code == "staging.dir_empty_for_validated" for i in result.errors)
 
 
+def test_validated_staging_tree_must_match_recorded_checksum(
+    valid_manifest: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Validated manifests fail closed when local files do not match pinned checksum."""
+
+    data_root = tmp_path / "external_data"
+    staging_dir = data_root / "synthetic_byo"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "trajectories.csv").write_text("frame,ped_id,x,y\n0,1,0,0\n", encoding="utf-8")
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(data_root))
+    valid_manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
+    valid_manifest["availability"] = "validated"
+    valid_manifest["checksums"]["tree_sha256"] = "b" * 64
+    valid_manifest["checksums"]["expected_tree_sha256"] = "b" * 64
+
+    result = run_preflight(valid_manifest)
+
+    assert not result.ok
+    assert any(i.code == "checksums.staging_tree_mismatch" for i in result.errors)
+
+
+def test_validated_checksums_must_be_pinned_consistently(
+    valid_manifest: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Validated manifests fail closed when recorded and expected hashes diverge."""
+
+    data_root = tmp_path / "external_data"
+    staging_dir = data_root / "synthetic_byo"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "trajectories.csv").write_text("frame,ped_id,x,y\n0,1,0,0\n", encoding="utf-8")
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(data_root))
+    valid_manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
+    valid_manifest["availability"] = "validated"
+    valid_manifest["checksums"]["tree_sha256"] = contract._staging_tree_sha256(staging_dir)
+    valid_manifest["checksums"]["expected_tree_sha256"] = "c" * 64
+
+    result = run_preflight(valid_manifest)
+
+    assert not result.ok
+    assert any(i.code == "checksums.recorded_expected_mismatch" for i in result.errors)
+
+
 def test_validated_output_relative_staging_is_cwd_independent(
     valid_manifest: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -247,8 +291,9 @@ def test_validated_output_relative_staging_is_cwd_independent(
     monkeypatch.setattr(contract, "get_repository_root", lambda: repo_root)
     valid_manifest["staging"]["staging_dir"] = "output/external_data/synthetic_byo"
     valid_manifest["availability"] = "validated"
-    valid_manifest["checksums"]["tree_sha256"] = "a" * 64
-    valid_manifest["checksums"]["expected_tree_sha256"] = "a" * 64
+    tree_sha256 = contract._staging_tree_sha256(staging_dir)
+    valid_manifest["checksums"]["tree_sha256"] = tree_sha256
+    valid_manifest["checksums"]["expected_tree_sha256"] = tree_sha256
 
     # Run from an unrelated cwd; resolution must still find the repo-root staging dir.
     other_cwd = tmp_path / "elsewhere"

--- a/tests/planner/test_learned_short_horizon_trainer.py
+++ b/tests/planner/test_learned_short_horizon_trainer.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 import torch
 
+from robot_sf.data_ingestion import real_trajectory_contract as contract
 from robot_sf.planner.learned_short_horizon_predictor import (
     LearnedShortHorizonPedestrianPredictor,
     predictor_io_dims,
@@ -135,6 +136,7 @@ def test_real_trajectory_manifest_batch_requires_validated_data(tmp_path, monkey
         + "\n",
         encoding="utf-8",
     )
+    tree_sha256 = contract._staging_tree_sha256(staging_dir)
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(
         json.dumps(
@@ -162,8 +164,8 @@ def test_real_trajectory_manifest_batch_requires_validated_data(tmp_path, monkey
                 },
                 "checksums": {
                     "algorithm": "SHA-256",
-                    "tree_sha256": "0" * 64,
-                    "expected_tree_sha256": "0" * 64,
+                    "tree_sha256": tree_sha256,
+                    "expected_tree_sha256": tree_sha256,
                 },
                 "conversion": {
                     "frame_rate_hz": 2.5,

--- a/tests/training/test_issue_4013_real_trajectory_readiness.py
+++ b/tests/training/test_issue_4013_real_trajectory_readiness.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 import yaml
 
+from robot_sf.data_ingestion import real_trajectory_contract as contract
 from scripts.training.check_issue_4013_real_trajectory_readiness import (
     build_report,
     render_markdown,
@@ -98,8 +99,9 @@ def test_validated_research_manifest_is_ready_for_real_trajectory_training(
     manifest = deepcopy(_manifest())
     manifest["availability"] = "validated"
     manifest["benchmark_eligibility"] = "research_only"
-    manifest["checksums"]["tree_sha256"] = "a" * 64
-    manifest["checksums"]["expected_tree_sha256"] = "a" * 64
+    tree_sha256 = contract._staging_tree_sha256(staging_dir)
+    manifest["checksums"]["tree_sha256"] = tree_sha256
+    manifest["checksums"]["expected_tree_sha256"] = tree_sha256
 
     report = build_report(_write_manifest(tmp_path, manifest))
 


### PR DESCRIPTION
Reviewer-critical summary

What changed: `availability: validated` real-trajectory manifests now fail closed unless the resolved local staging tree hashes to the recorded `checksums.tree_sha256`, and the recorded hash matches `checksums.expected_tree_sha256`.

Why now: #4013 is still open after PR #4704 because Phase 3 remains blocked on reachable checksum-pinned ETH/BIWI staging, then real-trajectory training and representative evaluation. The current checker proved the staging directory exists/non-empty, but did not verify that the local bytes match the pinned aggregate hash.

Claim boundary: this is a contract/integration slice only. It does not stage ETH/BIWI data, does not run real-trajectory training, does not run a full benchmark campaign, and makes no benchmark, navigation-quality, paper, or dissertation claim.

Required validation: focused real-trajectory contract/readiness tests plus Ruff on touched files. The tracked #4013 readiness report was regenerated and remains cleanly unchanged at `blocked_manifest_contract` because this worktree has no local ETH/BIWI staging root.

Remaining blocker: reachable checksum-pinned ETH/BIWI staging root, then real-trajectory training and representative evaluation versus `cv_prediction_mpc` plus the model-free baseline.

Contract delta

- New fail-closed blocker: `checksums.expected_missing_for_validated` when a validated manifest lacks a pinned expected tree hash.
- New fail-closed blocker: `checksums.recorded_expected_mismatch` when `tree_sha256` and `expected_tree_sha256` diverge.
- New fail-closed blocker: `checksums.staging_tree_mismatch` when local staged files do not hash to the manifest's recorded tree hash.
- Compatibility impact: stricter only for manifests claiming `availability: validated`; missing/staged manifests and unresolved/missing/empty staging roots continue to fail at their existing earlier blockers.

## Summary

Refs #4013. Adds checksum verification to the real-trajectory ingestion preflight so #4013 Phase 3 cannot proceed from a merely non-empty staging directory.

## Linked Issues

- Refs #4013

## What Changed

- Added deterministic staged-file tree hashing in `robot_sf/data_ingestion/real_trajectory_contract.py`.
- Required validated manifests to have consistent recorded and expected aggregate SHA-256 hashes.
- Added regression tests for valid hash, local tree mismatch, recorded/expected mismatch, the #4013 readiness report's validated path, and the real-trajectory trainer fixture.

## Acceptance Evidence

| Criterion | Evidence |
| --- | --- |
| Read full issue thread including comments | `gh issue view 4013 --repo ll7/robot_sf_ll7 --json ...` captured the live thread; latest comment remains PR #4704 state update at 2026-07-07 00:28:39Z. |
| Verify no open PR already covers #4013 | `gh pr list --repo ll7/robot_sf_ll7 --state open --search "4013 OR real trajectory staging checksum OR real-trajectory staging"` returned `[]`. |
| Fragmentation guard | More than two #4013 PRs merged in the last 24h, so this PR is a progression/integration capability, not another readiness packet: validated staging must match a pinned checksum. |
| Existing acceptance criteria mapped | Diagnostic predictor training, smoke action selection, 3-arm diagnostic comparison, fallback exclusion, and claim boundary are evidenced by merged PRs/comments #4629, #4644, #4655, #4587, #4665, #4679, #4700, #4704. |
| Remaining criterion addressed by smallest slice | Adds the missing checksum-pinned staging verification needed before real-trajectory training/evaluation can proceed. |

## Validation / Proof

- `python3 -m py_compile robot_sf/data_ingestion/real_trajectory_contract.py tests/data/test_real_trajectory_contract.py tests/training/test_issue_4013_real_trajectory_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/data_ingestion/real_trajectory_contract.py tests/data/test_real_trajectory_contract.py tests/training/test_issue_4013_real_trajectory_readiness.py tests/planner/test_learned_short_horizon_trainer.py` -> passed; one file reformatted.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/data_ingestion/real_trajectory_contract.py tests/data/test_real_trajectory_contract.py tests/training/test_issue_4013_real_trajectory_readiness.py tests/planner/test_learned_short_horizon_trainer.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/data/test_real_trajectory_contract.py tests/training/test_issue_4013_real_trajectory_readiness.py tests/planner/test_learned_short_horizon_trainer.py::test_real_trajectory_manifest_batch_requires_validated_data -q` -> passed, 28 tests.
- `PR_READY_PR_BODY_FILE=/tmp/issue4013_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; core lane 1923 tests, optional lane 5138 tests, freshness stamp `output/validation/pr_ready/issue-4013-closure-audit-20260707.json` at head `564903fe`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/training/check_issue_4013_real_trajectory_readiness.py --output-json docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json --output-markdown docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md && git diff --exit-code -- docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md` -> passed; report remains `blocked_manifest_contract` and tracked evidence unchanged.

## Out of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No raw ETH/BIWI or ETH/UCY dataset staging or redistribution.

## Remaining Checklist

- [ ] Stage ETH/BIWI or approved real pedestrian trajectory data under a reachable local `ROBOT_SF_EXTERNAL_DATA_ROOT` path.
- [ ] Validate the staged tree checksum against the pinned manifest hash.
- [ ] Run real-trajectory predictor training.
- [ ] Run representative evaluation against `cv_prediction_mpc` plus the model-free baseline.

<details>
<summary>Governance and propagation</summary>

Research Result Guidance: support/runtime contract hardening for a blocked research issue. Evidence tier is targeted contract tests plus readiness checker execution; no research result or benchmark claim.

Domain-Aware Approval: not required for a claim promotion; this PR tightens fail-closed eligibility before any real-data claim can proceed.

Downstream Propagation: no issue comment was added because this task authorization set `comment_issue_or_pr: false`. High-churn state is carried in this PR body for the gate/Claude follow-up rather than adding a comment stream. The tracked readiness evidence files were regenerated and stayed unchanged.

Late guidance check: immediately before body preparation, `gh issue view 4013 --repo ll7/robot_sf_ll7 --json number,title,state,updatedAt,comments,url` showed no comments newer than the PR #4704 state update at 2026-07-07 00:28:39Z.

</details>
