### PR TITLE
Issue #3637: add reactivity rank study integration handoff

### DIFF
--- a/scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py
+++ b/scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py
@@ -46,6 +46,13 @@ DEFAULT_OUTPUT_DIR = Path("output/issue_3637_reactivity_rank_study")
 DEFAULT_REPORT_JSON = DEFAULT_OUTPUT_DIR / "report.json"
 ISSUE = 3637
 EVIDENCE_TIER = "seed_sufficient_candidate"
+ANALYSIS_OUTPUT_FILES = (
+    "README.md",
+    "analysis.json",
+    "frozen_gate_input.json",
+    "rank_bootstrap_summary.json",
+    "per_planner_condition_metrics.csv",
+)
 
 
 def _load_packet(path: Path) -> dict[str, Any]:
@@ -87,6 +94,51 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _build_integration_report(
+    *,
+    packet_path: Path,
+    campaign_dir: Path,
+    report_json: Path,
+    analyzer_command: str,
+    preflight: dict[str, Any],
+) -> dict[str, Any]:
+    """Return machine-readable post-run handoff contract for issue #3637."""
+    analysis_dir = campaign_dir / "analysis"
+    return {
+        "schema_version": "issue-3637-reactivity-replay-rank-integration-report.v1",
+        "issue": ISSUE,
+        "status": "campaign_ran_analysis_required",
+        "evidence_tier": EVIDENCE_TIER,
+        "claim_boundary": (
+            "No issue #3637 paper-facing or closure claim until the post-run analyzer "
+            "validates the complete paired planner/arm/seed/scenario matrix and emits "
+            "seed-sufficiency artifacts."
+        ),
+        "delivered_contract": {
+            "launch_packet": str(packet_path),
+            "campaign_dir": str(campaign_dir),
+            "campaign_report": str(report_json),
+            "preflight_status": preflight["status"],
+            "post_run_analyzer": analyzer_command,
+        },
+        "required_post_run_artifacts": [
+            str(analysis_dir / filename) for filename in ANALYSIS_OUTPUT_FILES
+        ],
+        "remaining_acceptance_criteria": [
+            "Run the predeclared >=3-planner, 20-seed reactive-vs-replay campaign.",
+            "Run the post-run analyzer against the completed campaign JSONL files.",
+            "Record rank-stability and seed-sufficiency outputs in a durable evidence bundle.",
+            "Classify the result conservatively before any paper-facing claim or issue closure.",
+        ],
+        "next_empirical_action": analyzer_command,
+        "closure_decision": "keep_open_until_analysis_artifacts_exist",
+        "forbidden_actions_confirmed": {
+            "slurm_gpu_submission": False,
+            "paper_dissertation_claim_edit": False,
+        },
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the preflighted #3637 packet through the existing paired runner."""
     args = _parse_args(argv)
@@ -111,11 +163,19 @@ def main(argv: list[str] | None = None) -> int:
     report["generated_at_utc"] = datetime.now(UTC).isoformat()
     report["launch_packet"] = str(args.packet)
     report["preflight_status"] = preflight["status"]
-    report["post_run_analyzer"] = (
+    analyzer_command = (
         "uv run python scripts/benchmark/"
         "analyze_reactivity_replay_rank_study_issue_3637.py "
         f"--packet {args.packet} --campaign-dir {args.out_dir} "
         f"--campaign-report {args.report_json} --output-dir {args.out_dir / 'analysis'}"
+    )
+    report["post_run_analyzer"] = analyzer_command
+    report["integration_report"] = _build_integration_report(
+        packet_path=args.packet,
+        campaign_dir=args.out_dir,
+        report_json=args.report_json,
+        analyzer_command=analyzer_command,
+        preflight=preflight,
     )
 
     args.report_json.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py
+++ b/tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py
@@ -81,6 +81,31 @@ def test_runner_uses_packet_plan_and_writes_report(monkeypatch: pytest.MonkeyPat
     assert report["preflight_status"] == "ready"
     assert report["launch_packet"] == str(PACKET)
     assert "analyze_reactivity_replay_rank_study_issue_3637.py" in report["post_run_analyzer"]
+    integration = report["integration_report"]
+    assert (
+        integration["schema_version"] == "issue-3637-reactivity-replay-rank-integration-report.v1"
+    )
+    assert integration["status"] == "campaign_ran_analysis_required"
+    assert integration["closure_decision"] == "keep_open_until_analysis_artifacts_exist"
+    assert integration["delivered_contract"] == {
+        "launch_packet": str(PACKET),
+        "campaign_dir": str(out_dir),
+        "campaign_report": str(report_json),
+        "preflight_status": "ready",
+        "post_run_analyzer": report["post_run_analyzer"],
+    }
+    assert integration["required_post_run_artifacts"] == [
+        str(out_dir / "analysis" / "README.md"),
+        str(out_dir / "analysis" / "analysis.json"),
+        str(out_dir / "analysis" / "frozen_gate_input.json"),
+        str(out_dir / "analysis" / "rank_bootstrap_summary.json"),
+        str(out_dir / "analysis" / "per_planner_condition_metrics.csv"),
+    ]
+    assert integration["next_empirical_action"] == report["post_run_analyzer"]
+    assert integration["forbidden_actions_confirmed"] == {
+        "slurm_gpu_submission": False,
+        "paper_dissertation_claim_edit": False,
+    }
 
 
 def test_runner_fails_before_campaign_when_packet_preflight_blocks(


### PR DESCRIPTION
## Reviewer-critical summary

What changed: the packet-backed issue #3637 launcher now writes a structured `integration_report` into the campaign report JSON. It records the delivered launch contract, required post-run analysis artifacts, remaining acceptance criteria, closure decision boundary, and the next empirical analyzer command.

Why now: issue #3637 already has multiple merged guard/preflight/analyzer/launcher slices, and the July 7 closure audit found the original acceptance criteria are still blocked on the actual >=3-planner, 20-seed campaign plus durable analysis bundle. This PR is a consolidation/integration slice, not another static blocker note.

Claim boundary: this does not run the campaign and does not make a benchmark, rank-stability, paper-facing, or closure claim. It only makes the runner's post-campaign handoff machine-readable so the eventual empirical run cannot be mistaken for complete before analyzer artifacts exist.

Required validation: focused launcher tests plus lint/format and the full repository PR readiness wrapper passed on clean commit `5f99f889c42068228f5c7793e8bfa735ade70bcd`.

Remaining blocker: #3637 still needs the predeclared campaign run, post-run analyzer outputs, seed-sufficiency/rank-stability decision, and conservative evidence bundle before closure.

Refs #3637

## Contract delta

- New report field: `integration_report`.
- New schema label: `issue-3637-reactivity-replay-rank-integration-report.v1`.
- New machine-readable closure boundary: `closure_decision=keep_open_until_analysis_artifacts_exist`.
- New required artifact list for the post-run analyzer: `README.md`, `analysis.json`, `frozen_gate_input.json`, `rank_bootstrap_summary.json`, and `per_planner_condition_metrics.csv` under the launcher output analysis directory.
- Compatibility impact: additive JSON report fields only; existing `post_run_analyzer`, launch packet, preflight, and campaign runner behavior are unchanged.

## Scope summary

This PR updates:

- `scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py` to include the structured integration handoff in the generated campaign report.
- `tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py` to assert the handoff contract under mocked campaign execution.

Fragmentation guard: more than two #3637 guard/checker/packet-refresh slices merged recently, so this PR adds a nameable integration capability instead of another micro-guard.

State propagation: no issue comment was posted because this task authorization explicitly disallowed `comment_issue_or_pr`. No separate tracked state table update is needed because this PR changes the runner's durable report contract directly and its body records the current remaining checklist.

## Acceptance evidence

| Issue #3637 criterion | Evidence in merged/current work | Status |
| --- | --- | --- |
| Reactivity-vs-replay run across >=3 planners at sufficient seed budget. | Launch packet and launcher exist; this PR records the campaign handoff contract. No durable campaign outputs exist yet. | Not met; still blocked on campaign execution. |
| Rank stability / confidence reported. | Analyzer exists and this PR records its required output paths. No completed analyzer output exists yet. | Not met; requires campaign outputs. |
| Replay caveat present in artifacts. | Merged packet/analyzer surfaces enforce force-off-not-trajectory-playback caveat; final evidence bundle still must carry it. | Partially met until final bundle exists. |
| Conservative interpretation recorded in `docs/context`. | Prior closure audit/preflight notes record no-claim boundary; this PR adds the runner-level machine-readable no-closure boundary. | Partially met; final interpretation requires empirical analysis. |
| Reproducible same command + seed set. | Launch packet pins planners, seeds `101..120`, scenario set, horizon, and analyzer command; this PR records the exact next analyzer command in the campaign report. | Launch contract met; empirical reproduction bundle still missing. |
| Reactivity-rank claim supported by rank-stability evidence. | No rank-stability evidence exists yet. | Not met. |

## Validation

- `uv run pytest tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py -q` -> passed, `2 passed in 0.44s`.
- `uv run ruff check scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py` -> passed.
- `uv run ruff format --check scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py` -> passed.
- `git diff --check` -> passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; clean-tree freshness stamp written to `output/validation/pr_ready/issue-3637-closure-audit-integration-20260707.json`.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> passed, `fresh=true`.

Note: the first readiness wrapper attempt failed in the optional lane because the fresh worktree venv lacked `torch`; after `uv sync --all-extras`, the same wrapper passed.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No issue closure keyword because #3637 acceptance criteria are not complete.

<details>
<summary>Appendix: artifact and live-state checks</summary>

- Live issue refresh immediately before PR: #3637 open; latest issue comment remains 2026-07-04T19:39:37Z.
- Open PR dedupe immediately before PR: no open PR matched issue #3637 or this exact reactivity replay rank-study scope.
- Generated `output/` artifacts are local validation cache/coverage/model-cache files and are intentionally untracked.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured integration report to campaign outputs, capturing run details, required artifacts, and completion criteria.
  * Included the analyzer command and related run metadata in the final report.

* **Tests**
  * Expanded coverage to verify the new report structure, expected values, required artifacts list, and closure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->