### PR TITLE
Issue #3285: validate target handoff artifacts

### DIFF
--- a/docs/context/issue_3285_scenario_interop_converter.md
+++ b/docs/context/issue_3285_scenario_interop_converter.md
@@ -17,9 +17,15 @@ for Robot SF scenario-matrix entries, plus explicit unsupported-field reports. I
 require external assets and does not emit runnable SocNavBench or HuNavSim files.
 
 - Module: `robot_sf/benchmark/scenario_interop.py` (`convert_scenario_to_ir`, `dump_ir`,
-  `validate_interop_ir`, `build_target_export_manifest`, `build_target_export_preview`).
+  `validate_interop_ir`, `validate_target_compatibility_report`,
+  `validate_target_export_manifest`, `validate_target_export_preview`,
+  `build_target_export_manifest`, `build_target_export_preview`).
 - IR schema: `robot_sf/benchmark/schemas/scenario_interop_ir.v1.json`
   (`robot_sf.scenario_interop_ir.v1`).
+- Target handoff schemas:
+  `robot_sf/benchmark/schemas/scenario_interop_target_compatibility.v1.json`,
+  `robot_sf/benchmark/schemas/scenario_interop_target_export_manifest.v1.json`, and
+  `robot_sf/benchmark/schemas/scenario_interop_target_export_preview.v1.json`.
 - Dry-run CLI: `scripts/tools/convert_scenario_interop.py`.
 - Tests: `tests/benchmark/test_scenario_interop.py`,
   `tests/benchmark/test_scenario_interop_target_compatibility.py`.
@@ -95,3 +101,20 @@ validation.
   claim about simulator equivalence, planner transferability, or benchmark-score parity.
 - Emitting real runnable SocNavBench/HuNavSim scenario assets and running them remains blocked on
   staged external assets/adapters (#1456, #1498, #2414, #1134).
+
+## Closure Audit Integration 2026-07-07
+
+Merged evidence through PR #4711 satisfies the original asset-free acceptance criteria:
+
+| Acceptance criterion | Evidence |
+| --- | --- |
+| Converter output schema-validated deterministic fixture scenario. | PR #3735 added the IR converter, `scenario_interop_ir.v1.json`, deterministic serialization tests, and schema validation. |
+| Unsupported fields reported explicitly instead silently dropped. | PR #3735 records unmapped top-level source fields in `unsupported_fields`; PR #4562 and PR #4711 propagate those blockers into target compatibility and preview artifacts. |
+| Smoke dry-run command documented. | PR #3735 documented the IR CLI; PR #4673 and PR #4711 extended this note with manifest and preview dry-run commands. |
+| Issue links external asset prerequisites required full run. | The issue thread and this note keep #1456, #1498, #2414, and #1134 as full-run blockers. |
+
+This integration slice adds JSON-Schema validation for the target compatibility, target export
+manifest, and target export preview artifacts introduced after the base IR converter. It does not
+change the closure boundary: runnable SocNavBench/HuNavSim export remains intentionally blocked
+until external assets and adapters are staged. The next empirical action is an asset-backed adapter
+smoke after the relevant prerequisite issue provides staged target inputs.

--- a/docs/context/issue_3285_state.yaml
+++ b/docs/context/issue_3285_state.yaml
@@ -1,0 +1,21 @@
+# Append-only durable state for issue #3285. Do not store host routing, queue packet lineage,
+# credentials, or private asset locations here.
+entries:
+  - date: "2026-07-07"
+    source: "closure_audit_integration_slice"
+    status: "open_blocked_on_external_assets"
+    delivered:
+      - "Target compatibility, export manifest, and export preview artifacts now have JSON schemas."
+      - "Existing target handoff builders have validation helpers and focused tamper tests."
+    acceptance_evidence:
+      - criterion: "Converter output schema-validated deterministic fixture scenario."
+        evidence: "PR #3735 added IR schema validation and deterministic fixture tests; this slice adds schema validation for later target handoff artifacts."
+      - criterion: "Unsupported fields reported explicitly instead silently dropped."
+        evidence: "PR #3735 emits unsupported_fields; PR #4562 and PR #4711 preserve those blockers in target compatibility and preview payloads."
+      - criterion: "Smoke dry-run command documented."
+        evidence: "docs/context/issue_3285_scenario_interop_converter.md documents IR, manifest, and preview dry-run commands."
+      - criterion: "Issue links external asset prerequisites required full run."
+        evidence: "Issue #3285 and docs/context/issue_3285_scenario_interop_converter.md name #1456, #1498, #2414, and #1134 as full-run blockers."
+    remaining:
+      - "Runnable SocNavBench/HuNavSim export remains blocked on staged external assets/adapters tracked by #1456, #1498, #2414, and #1134."
+    next_empirical_action: "Run an asset-backed target adapter smoke after prerequisite staged inputs exist."

--- a/robot_sf/benchmark/scenario_interop.py
+++ b/robot_sf/benchmark/scenario_interop.py
@@ -50,6 +50,15 @@ TARGET_EXPORT_MANIFEST_SCHEMA_VERSION = "robot_sf.scenario_interop_target_export
 TARGET_EXPORT_PREVIEW_SCHEMA_VERSION = "robot_sf.scenario_interop_target_export_preview.v1"
 SUPPORTED_TARGETS = ("socnavbench", "hunavsim")
 IR_SCHEMA_FILE = Path(__file__).with_name("schemas") / "scenario_interop_ir.v1.json"
+TARGET_COMPATIBILITY_SCHEMA_FILE = (
+    Path(__file__).with_name("schemas") / "scenario_interop_target_compatibility.v1.json"
+)
+TARGET_EXPORT_MANIFEST_SCHEMA_FILE = (
+    Path(__file__).with_name("schemas") / "scenario_interop_target_export_manifest.v1.json"
+)
+TARGET_EXPORT_PREVIEW_SCHEMA_FILE = (
+    Path(__file__).with_name("schemas") / "scenario_interop_target_export_preview.v1.json"
+)
 
 # Source keys that map directly into IR sections. Anything not in this set is
 # reported in ``unsupported_fields`` rather than silently dropped.
@@ -147,6 +156,39 @@ def load_interop_ir_schema() -> dict[str, Any]:
     return json.loads(IR_SCHEMA_FILE.read_text(encoding="utf-8"))
 
 
+@lru_cache(maxsize=1)
+def load_target_compatibility_schema() -> dict[str, Any]:
+    """Load the target compatibility report JSON Schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+
+    return json.loads(TARGET_COMPATIBILITY_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+@lru_cache(maxsize=1)
+def load_target_export_manifest_schema() -> dict[str, Any]:
+    """Load the target export manifest JSON Schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+
+    return json.loads(TARGET_EXPORT_MANIFEST_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+@lru_cache(maxsize=1)
+def load_target_export_preview_schema() -> dict[str, Any]:
+    """Load the target export preview JSON Schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+
+    return json.loads(TARGET_EXPORT_PREVIEW_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
 def validate_interop_ir(ir: Mapping[str, Any]) -> list[str]:
     """Validate an IR payload against the interop IR schema.
 
@@ -157,10 +199,63 @@ def validate_interop_ir(ir: Mapping[str, Any]) -> list[str]:
         Sorted JSON-pointer-prefixed validation error strings; empty when valid.
     """
 
-    validator = Draft202012Validator(load_interop_ir_schema())
+    return _validate_json_schema(ir, schema=load_interop_ir_schema())
+
+
+def validate_target_compatibility_report(report: Mapping[str, Any]) -> list[str]:
+    """Validate a target compatibility report against its JSON Schema.
+
+    Args:
+        report: Candidate compatibility report.
+
+    Returns:
+        Sorted JSON-pointer-prefixed validation error strings; empty when valid.
+    """
+
+    return _validate_json_schema(report, schema=load_target_compatibility_schema())
+
+
+def validate_target_export_manifest(manifest: Mapping[str, Any]) -> list[str]:
+    """Validate a target export manifest against its JSON Schema.
+
+    Args:
+        manifest: Candidate target export manifest.
+
+    Returns:
+        Sorted JSON-pointer-prefixed validation error strings; empty when valid.
+    """
+
+    return _validate_json_schema(manifest, schema=load_target_export_manifest_schema())
+
+
+def validate_target_export_preview(preview: Mapping[str, Any]) -> list[str]:
+    """Validate a target export preview against its JSON Schema.
+
+    Args:
+        preview: Candidate target export preview.
+
+    Returns:
+        Sorted JSON-pointer-prefixed validation error strings; empty when valid.
+    """
+
+    return _validate_json_schema(preview, schema=load_target_export_preview_schema())
+
+
+def _validate_json_schema(payload: Mapping[str, Any], *, schema: Mapping[str, Any]) -> list[str]:
+    """Return deterministic JSON-Schema validation errors for a payload.
+
+    Args:
+        payload: Candidate JSON-compatible mapping.
+        schema: JSON Schema mapping.
+
+    Returns:
+        Sorted JSON-pointer-prefixed validation error strings; empty when valid.
+    """
+
+    validator = Draft202012Validator(schema)
     return [
         f"{json_pointer(error.absolute_path)}: {error.message}"
-        for error in sorted(validator.iter_errors(ir), key=lambda err: list(err.absolute_path))
+        for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
     ]
 
 

--- a/robot_sf/benchmark/schemas/scenario_interop_target_compatibility.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_interop_target_compatibility.v1.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ll7.github.io/robot_sf/scenario_interop_target_compatibility.v1.json",
+  "title": "Robot SF Cross-Benchmark Scenario Target Compatibility Report (v1)",
+  "description": "Asset-free readiness report for projecting Robot SF scenario interop IR toward SocNavBench or HuNavSim. A blocked report is expected until target assets and adapters are staged.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "target",
+    "source_scenario_id",
+    "ready",
+    "blockers",
+    "warnings"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "robot_sf.scenario_interop_target_compatibility.v1"
+    },
+    "target": {
+      "$ref": "#/$defs/target"
+    },
+    "source_scenario_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ready": {
+      "type": "boolean"
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    }
+  },
+  "$defs": {
+    "target": {
+      "enum": [
+        "socnavbench",
+        "hunavsim"
+      ]
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "field",
+        "reason"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/robot_sf/benchmark/schemas/scenario_interop_target_export_manifest.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_interop_target_export_manifest.v1.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ll7.github.io/robot_sf/scenario_interop_target_export_manifest.v1.json",
+  "title": "Robot SF Cross-Benchmark Scenario Target Export Manifest (v1)",
+  "description": "Fail-closed manifest for target scenario export attempts. It records readiness, blockers, and source provenance without claiming runnable SocNavBench or HuNavSim artifacts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "target",
+    "source_scenario_id",
+    "source_ir_schema_version",
+    "status",
+    "ready",
+    "blockers",
+    "warnings",
+    "compatibility_report_schema_version"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "robot_sf.scenario_interop_target_export_manifest.v1"
+    },
+    "artifact_kind": {
+      "enum": [
+        "socnavbench_scenario_export_manifest",
+        "hunavsim_scenario_export_manifest"
+      ]
+    },
+    "target": {
+      "$ref": "#/$defs/target"
+    },
+    "source_scenario_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_ir_schema_version": {
+      "const": "robot_sf.scenario_interop_ir.v1"
+    },
+    "status": {
+      "enum": [
+        "ready",
+        "blocked"
+      ]
+    },
+    "ready": {
+      "type": "boolean"
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    },
+    "compatibility_report_schema_version": {
+      "const": "robot_sf.scenario_interop_target_compatibility.v1"
+    }
+  },
+  "$defs": {
+    "target": {
+      "enum": [
+        "socnavbench",
+        "hunavsim"
+      ]
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "field",
+        "reason"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/robot_sf/benchmark/schemas/scenario_interop_target_export_preview.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_interop_target_export_preview.v1.json
@@ -1,0 +1,271 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ll7.github.io/robot_sf/scenario_interop_target_export_preview.v1.json",
+  "title": "Robot SF Cross-Benchmark Scenario Target Export Preview (v1)",
+  "description": "Asset-free target-shaped preview payload for SocNavBench or HuNavSim scenario export handoff. The payload is not a runnable external benchmark artifact.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "target",
+    "source_scenario_id",
+    "source_ir_schema_version",
+    "status",
+    "ready",
+    "blockers",
+    "warnings",
+    "payload",
+    "compatibility_report_schema_version"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "robot_sf.scenario_interop_target_export_preview.v1"
+    },
+    "artifact_kind": {
+      "enum": [
+        "socnavbench_scenario_export_preview",
+        "hunavsim_scenario_export_preview"
+      ]
+    },
+    "target": {
+      "$ref": "#/$defs/target"
+    },
+    "source_scenario_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_ir_schema_version": {
+      "const": "robot_sf.scenario_interop_ir.v1"
+    },
+    "status": {
+      "enum": [
+        "ready",
+        "blocked"
+      ]
+    },
+    "ready": {
+      "type": "boolean"
+    },
+    "blockers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    },
+    "payload": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/socnavbench_payload"
+        },
+        {
+          "$ref": "#/$defs/hunavsim_payload"
+        }
+      ]
+    },
+    "compatibility_report_schema_version": {
+      "const": "robot_sf.scenario_interop_target_compatibility.v1"
+    }
+  },
+  "$defs": {
+    "target": {
+      "enum": [
+        "socnavbench",
+        "hunavsim"
+      ]
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "field",
+        "reason"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "nullable_string": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "nullable_number": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "socnavbench_payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scenario",
+        "pedestrians"
+      ],
+      "properties": {
+        "scenario": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "map",
+            "environment_type",
+            "flow",
+            "density",
+            "seed_set"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "map": {
+              "$ref": "#/$defs/nullable_string"
+            },
+            "environment_type": {
+              "$ref": "#/$defs/nullable_string"
+            },
+            "flow": {
+              "$ref": "#/$defs/nullable_string"
+            },
+            "density": {
+              "$ref": "#/$defs/nullable_string"
+            },
+            "seed_set": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        "pedestrians": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "start",
+              "goal",
+              "preferred_speed_mps"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "start": {
+                "$ref": "#/$defs/nullable_string"
+              },
+              "goal": {
+                "$ref": "#/$defs/nullable_string"
+              },
+              "preferred_speed_mps": {
+                "$ref": "#/$defs/nullable_number"
+              }
+            }
+          }
+        }
+      }
+    },
+    "hunavsim_payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "world",
+        "agents"
+      ],
+      "properties": {
+        "world": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "map_file",
+            "obstacle_topology",
+            "flow"
+          ],
+          "properties": {
+            "map_file": {
+              "$ref": "#/$defs/nullable_string"
+            },
+            "obstacle_topology": {
+              "$ref": "#/$defs/nullable_string"
+            },
+            "flow": {
+              "$ref": "#/$defs/nullable_string"
+            }
+          }
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "start_poi",
+              "goal_poi",
+              "behavior"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "start_poi": {
+                "$ref": "#/$defs/nullable_string"
+              },
+              "goal_poi": {
+                "$ref": "#/$defs/nullable_string"
+              },
+              "behavior": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "preferred_speed_mps",
+                  "role",
+                  "role_target_id"
+                ],
+                "properties": {
+                  "preferred_speed_mps": {
+                    "$ref": "#/$defs/nullable_number"
+                  },
+                  "role": {
+                    "$ref": "#/$defs/nullable_string"
+                  },
+                  "role_target_id": {
+                    "$ref": "#/$defs/nullable_string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/benchmark/test_scenario_interop_target_compatibility.py
+++ b/tests/benchmark/test_scenario_interop_target_compatibility.py
@@ -13,6 +13,12 @@ from robot_sf.benchmark.scenario_interop import (
     build_target_export_preview,
     convert_scenario_to_ir,
     dump_ir,
+    load_target_compatibility_schema,
+    load_target_export_manifest_schema,
+    load_target_export_preview_schema,
+    validate_target_compatibility_report,
+    validate_target_export_manifest,
+    validate_target_export_preview,
 )
 
 
@@ -65,6 +71,7 @@ def test_target_compatibility_report_fails_closed_for_missing_external_assets() 
     assert "socnavbench_assets_not_staged" in blockers_by_target["socnavbench"]
     assert "hunavsim_adapter_not_staged" in blockers_by_target["hunavsim"]
     assert "unsupported_fields_present" in blockers_by_target["socnavbench"]
+    assert all(validate_target_compatibility_report(report) == [] for report in reports)
 
 
 def test_target_compatibility_report_names_axis_scenario_export_gaps() -> None:
@@ -97,6 +104,7 @@ def test_target_export_manifest_records_blocked_artifact_contract() -> None:
         "socnavbench_assets_not_staged",
         "unsupported_fields_present",
     }
+    assert validate_target_export_manifest(manifest) == []
 
 
 def test_target_export_manifest_is_deterministic() -> None:
@@ -142,6 +150,7 @@ def test_socnavbench_export_preview_contains_target_shaped_payload() -> None:
         "socnavbench_assets_not_staged",
         "unsupported_fields_present",
     }
+    assert validate_target_export_preview(preview) == []
 
 
 def test_hunavsim_export_preview_contains_target_shaped_payload() -> None:
@@ -171,6 +180,32 @@ def test_hunavsim_export_preview_contains_target_shaped_payload() -> None:
         }
     ]
     assert any(warning["code"] == "ros_semantics_unmapped" for warning in preview["warnings"])
+    assert validate_target_export_preview(preview) == []
+
+
+def test_target_artifact_schema_loaders_and_tamper_checks() -> None:
+    """Target artifact schema helpers load schemas and reject malformed payloads."""
+
+    assert load_target_compatibility_schema()["title"]
+    assert load_target_export_manifest_schema()["title"]
+    assert load_target_export_preview_schema()["title"]
+
+    result = convert_scenario_to_ir(_explicit_map_scenario())
+
+    compatibility = build_target_compatibility_report(result.ir, targets=("socnavbench",))[0]
+    broken_compatibility = dict(compatibility)
+    broken_compatibility["target"] = "unknownsim"
+    assert validate_target_compatibility_report(broken_compatibility) != []
+
+    manifest = build_target_export_manifest(result.ir, target="socnavbench")
+    broken_manifest = dict(manifest)
+    broken_manifest["status"] = "exported"
+    assert validate_target_export_manifest(broken_manifest) != []
+
+    preview = build_target_export_preview(result.ir, target="socnavbench")
+    broken_preview = dict(preview)
+    broken_preview["payload"] = {"unexpected": True}
+    assert validate_target_export_preview(broken_preview) != []
 
 
 def test_target_export_preview_is_deterministic() -> None:


### PR DESCRIPTION
Reviewer-critical summary

What changed: adds JSON-Schema files and validation helpers for the target compatibility report, target export manifest, and target export preview artifacts used by the Robot SF to SocNavBench/HuNavSim interop dry-run path.

Why now: #3285 has multiple merged asset-free slices in the last 24 hours (#4562, #4673, #4711). This is the consolidation/integration slice required by the fragmentation guard: it turns the newer target handoff artifacts into one coherent machine-validated contract instead of adding another packet refresh.

Claim boundary: this validates asset-free handoff artifacts only. It does not produce runnable SocNavBench or HuNavSim scenario assets, does not run an external benchmark, and does not claim simulator equivalence, planner transferability, benchmark-score parity, or paper/dissertation evidence.

Required validation: targeted interop tests, the issue's benchmark-filter validation command, CLI smoke generation with schema validation of emitted IR/manifests/previews, and final `pr_ready_check`.

Remaining blocker: runnable SocNavBench/HuNavSim export remains blocked on staged external assets/adapters tracked by #1456, #1498, #2414, and #1134.

Contract delta

- New schema files:
  - `robot_sf/benchmark/schemas/scenario_interop_target_compatibility.v1.json`
  - `robot_sf/benchmark/schemas/scenario_interop_target_export_manifest.v1.json`
  - `robot_sf/benchmark/schemas/scenario_interop_target_export_preview.v1.json`
- New validation helpers:
  - `validate_target_compatibility_report()`
  - `validate_target_export_manifest()`
  - `validate_target_export_preview()`
- New fail-closed blockers: none. Existing blockers remain represented as structured `blockers[]` diagnostics.
- Compatibility impact: additive API/schema contract only. Existing artifact payload keys are preserved; schema validation now rejects malformed targets/status/payload shapes.

Refs #3285

Scope summary

- Maps #3285's original asset-free acceptance criteria to merged PR evidence in `docs/context/issue_3285_scenario_interop_converter.md`.
- Adds the durable high-churn state surface `docs/context/issue_3285_state.yaml` instead of adding an issue comment stream.
- Adds focused tests for generated valid target artifacts and tampered invalid artifacts.

Validation command results

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py -q` -> passed: 19 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py && scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py` -> passed.
- `python3 -m json.tool ...scenario_interop_target_*.json` -> passed for all three new schema files.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/benchmark -k "scenario or convert or socnav" -q` -> passed.
- CLI smoke: `scripts/tools/convert_scenario_interop.py --matrix configs/baselines/example_matrix.yaml --out-dir output/issue_3285_schema_smoke/ir --target socnavbench --target hunavsim --target-out-dir output/issue_3285_schema_smoke/manifests --target-preview-out-dir output/issue_3285_schema_smoke/previews` plus validator helper check -> passed: 3 IR files, 6 manifests, 6 previews.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3285/pr_body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed: clean-tree stamp for 8c383f18242e567d21f4af4b3e9bf3db2ceb4879.

Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No compute submission.
- No paper/dissertation claim edits.
- No release action.
- No merge action.

<details>
<summary>Acceptance evidence and residual checklist</summary>

| Criterion | Evidence |
| --- | --- |
| Converter output schema-validated deterministic fixture scenario. | PR #3735 added the IR converter, `scenario_interop_ir.v1.json`, deterministic serialization tests, and schema validation. This PR adds schema validation for the later target handoff artifacts. |
| Unsupported fields reported explicitly instead silently dropped. | PR #3735 emits `unsupported_fields`; PR #4562 and PR #4711 preserve those blockers in target compatibility and preview payloads. |
| Smoke dry-run command documented. | `docs/context/issue_3285_scenario_interop_converter.md` documents IR, manifest, and preview dry-run commands. |
| Issue links external asset prerequisites required full run. | Issue #3285 and `docs/context/issue_3285_scenario_interop_converter.md` name #1456, #1498, #2414, and #1134 as full-run blockers. |

Remaining:

- [ ] Runnable SocNavBench/HuNavSim export after staged external assets/adapters exist (#1456, #1498, #2414, #1134).
- [ ] Asset-backed target adapter smoke after prerequisite staged inputs exist.

</details>
