### PR TITLE
Issue #4684: add live arm status watcher

### DIFF
--- a/scripts/dev/watch_live_arm_status.py
+++ b/scripts/dev/watch_live_arm_status.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Watch campaign live arm status and emit fail-closed cancellation decisions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_FAILURE_STATES = frozenset({"failed", "error", "contract_error"})
+DEFAULT_EVENT_LOG = "arm_status.jsonl"
+DEFAULT_LIVE_STATUS = "live_arm_status.json"
+CANCEL_EXIT_CODE = 20
+
+
+@dataclass(frozen=True, slots=True)
+class ArmStatusDecision:
+    """Single polling decision for a live campaign arm-status stream."""
+
+    action: str
+    reason: str
+    failing_arms: list[str]
+    failure_events: list[dict[str, Any]]
+    live_status_path: str
+    event_log_path: str
+    scancel_command: list[str] | None
+    executed: bool = False
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _load_events(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            event = json.loads(stripped)
+            if not isinstance(event, dict):
+                raise ValueError(f"{path}:{line_number} must contain a JSON object")
+            events.append(event)
+    return events
+
+
+def _scancel_command(job_id: str | None) -> list[str] | None:
+    if not job_id:
+        return None
+    return ["scancel", job_id]
+
+
+def decide_arm_status_action(
+    *,
+    live_status_path: Path,
+    event_log_path: Path,
+    job_id: str | None = None,
+    failure_states: set[str] | frozenset[str] = DEFAULT_FAILURE_STATES,
+) -> ArmStatusDecision:
+    """Return the private-ops action implied by status files without side effects."""
+
+    normalized_failure_states = {state.lower() for state in failure_states}
+    events = _load_events(event_log_path)
+    failure_events = [
+        event
+        for event in events
+        if str(event.get("state", "")).lower() in normalized_failure_states
+    ]
+    if failure_events:
+        failing_arms = sorted({str(event.get("arm", "unknown")) for event in failure_events})
+        return ArmStatusDecision(
+            action="cancel",
+            reason="fail_closed_arm_event",
+            failing_arms=failing_arms,
+            failure_events=failure_events,
+            live_status_path=str(live_status_path),
+            event_log_path=str(event_log_path),
+            scancel_command=_scancel_command(job_id),
+        )
+
+    live_status = _load_json(live_status_path)
+    if live_status is None:
+        return ArmStatusDecision(
+            action="wait",
+            reason="live_status_missing",
+            failing_arms=[],
+            failure_events=[],
+            live_status_path=str(live_status_path),
+            event_log_path=str(event_log_path),
+            scancel_command=None,
+        )
+
+    arms = live_status.get("arms")
+    if not isinstance(arms, dict):
+        raise ValueError(f"{live_status_path} must contain an object field named 'arms'")
+
+    failing_from_snapshot: list[dict[str, Any]] = []
+    for arm_key, arm_payload in arms.items():
+        if not isinstance(arm_payload, dict):
+            continue
+        status = str(arm_payload.get("status", "")).lower()
+        if status in normalized_failure_states:
+            failing_from_snapshot.append(
+                {
+                    "arm": str(arm_key),
+                    "state": status,
+                    "phase": live_status.get("phase"),
+                    "details": arm_payload,
+                }
+            )
+
+    if failing_from_snapshot:
+        return ArmStatusDecision(
+            action="cancel",
+            reason="fail_closed_live_status",
+            failing_arms=sorted({event["arm"] for event in failing_from_snapshot}),
+            failure_events=failing_from_snapshot,
+            live_status_path=str(live_status_path),
+            event_log_path=str(event_log_path),
+            scancel_command=_scancel_command(job_id),
+        )
+
+    statuses = {
+        str(arm_payload.get("status", "")).lower()
+        for arm_payload in arms.values()
+        if isinstance(arm_payload, dict)
+    }
+    action = "complete" if statuses == {"completed"} else "continue"
+    return ArmStatusDecision(
+        action=action,
+        reason=f"no_fail_closed_arm_status:{','.join(sorted(statuses)) or 'empty'}",
+        failing_arms=[],
+        failure_events=[],
+        live_status_path=str(live_status_path),
+        event_log_path=str(event_log_path),
+        scancel_command=None,
+    )
+
+
+def _paths_from_args(args: argparse.Namespace) -> tuple[Path, Path]:
+    if args.output_root is not None:
+        output_root = Path(args.output_root)
+        live_status_path = output_root / DEFAULT_LIVE_STATUS
+        event_log_path = output_root / DEFAULT_EVENT_LOG
+    else:
+        live_status_path = Path(args.live_status)
+        event_log_path = Path(args.event_log)
+    return live_status_path, event_log_path
+
+
+def _execute_scancel(command: list[str] | None) -> None:
+    if command is None:
+        raise RuntimeError("--execute-scancel requires --job-id when cancellation is needed")
+    subprocess.run(command, check=True)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse live arm-status watcher CLI arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Poll live_arm_status.json and arm_status.jsonl, then emit the scancel decision "
+            "needed by private ops. No cancellation is executed unless --execute-scancel is set."
+        )
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--output-root", help="Campaign output directory containing live status files."
+    )
+    source.add_argument("--live-status", help="Path to live_arm_status.json.")
+    parser.add_argument(
+        "--event-log",
+        help="Path to arm_status.jsonl. Required with --live-status; inferred with --output-root.",
+    )
+    parser.add_argument("--job-id", help="Slurm job id used to build a scancel command.")
+    parser.add_argument(
+        "--failure-state",
+        action="append",
+        default=[],
+        help="Additional arm state that should trigger cancellation.",
+    )
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=float,
+        default=0.0,
+        help="Seconds between polls when --max-polls is greater than 1.",
+    )
+    parser.add_argument(
+        "--max-polls",
+        type=int,
+        default=1,
+        help="Maximum polls before returning the latest non-cancel decision.",
+    )
+    parser.add_argument(
+        "--execute-scancel",
+        action="store_true",
+        help="Execute scancel when a fail-closed arm status is detected.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the decision as JSON.")
+    args = parser.parse_args(argv)
+    if args.live_status and not args.event_log:
+        parser.error("--event-log is required when --live-status is used")
+    if args.max_polls < 1:
+        parser.error("--max-polls must be at least 1")
+    if args.poll_interval_seconds < 0:
+        parser.error("--poll-interval-seconds must be non-negative")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run one bounded live arm-status polling cycle."""
+
+    args = parse_args(argv)
+    live_status_path, event_log_path = _paths_from_args(args)
+    failure_states = set(DEFAULT_FAILURE_STATES)
+    failure_states.update(args.failure_state)
+
+    decision: ArmStatusDecision | None = None
+    for attempt in range(args.max_polls):
+        decision = decide_arm_status_action(
+            live_status_path=live_status_path,
+            event_log_path=event_log_path,
+            job_id=args.job_id,
+            failure_states=failure_states,
+        )
+        if decision.action == "cancel" or attempt == args.max_polls - 1:
+            break
+        time.sleep(args.poll_interval_seconds)
+
+    assert decision is not None
+    if args.execute_scancel and decision.action == "cancel":
+        _execute_scancel(decision.scancel_command)
+        decision = ArmStatusDecision(**{**asdict(decision), "executed": True})
+
+    if args.json:
+        print(json.dumps(asdict(decision), indent=2, sort_keys=True))
+    elif decision.action == "cancel":
+        command = " ".join(decision.scancel_command or ["scancel", "<job-id-required>"])
+        print(f"cancel recommended: {command}; failing_arms={','.join(decision.failing_arms)}")
+    else:
+        print(f"{decision.action}: {decision.reason}")
+
+    return CANCEL_EXIT_CODE if decision.action == "cancel" else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/dev/test_watch_live_arm_status.py
+++ b/tests/dev/test_watch_live_arm_status.py
@@ -1,0 +1,120 @@
+"""Tests live arm-status private-ops cancellation decisions."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from scripts.dev.watch_live_arm_status import (
+    CANCEL_EXIT_CODE,
+    decide_arm_status_action,
+    main,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_jsonl(path: Path, records: list[dict[str, object]]) -> None:
+    path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def test_failed_event_recommends_scancel_without_executing(tmp_path: Path) -> None:
+    """Fail-closed arm events should produce a deterministic cancellation decision."""
+
+    output_root = tmp_path / "campaign"
+    output_root.mkdir()
+    _write_json(
+        output_root / "live_arm_status.json",
+        {
+            "schema_version": "robot_sf.issue_4205.static_constriction_codesign_campaign.v1.live_arm_status.v1",
+            "phase": "full",
+            "arms": {
+                "ppo_frozen_cbf_on": {"status": "running"},
+                "ppo_frozen_wrapper_on": {"status": "pending"},
+            },
+        },
+    )
+    _write_jsonl(
+        output_root / "arm_status.jsonl",
+        [
+            {"phase": "full", "arm": "ppo_frozen_cbf_on", "state": "running"},
+            {
+                "phase": "full",
+                "arm": "ppo_frozen_cbf_on",
+                "state": "failed",
+                "details": {"error": "ContractError: map runner failed closed"},
+            },
+        ],
+    )
+
+    decision = decide_arm_status_action(
+        live_status_path=output_root / "live_arm_status.json",
+        event_log_path=output_root / "arm_status.jsonl",
+        job_id="13320",
+    )
+
+    assert decision.action == "cancel"
+    assert decision.reason == "fail_closed_arm_event"
+    assert decision.failing_arms == ["ppo_frozen_cbf_on"]
+    assert decision.scancel_command == ["scancel", "13320"]
+    assert decision.executed is False
+
+
+def test_completed_live_status_is_noop(tmp_path: Path) -> None:
+    """Healthy completed arms should not request cancellation."""
+
+    output_root = tmp_path / "campaign"
+    output_root.mkdir()
+    _write_json(
+        output_root / "live_arm_status.json",
+        {
+            "schema_version": "robot_sf.issue_4205.static_constriction_codesign_campaign.v1.live_arm_status.v1",
+            "phase": "smoke",
+            "arms": {
+                "ppo_frozen_cbf_on": {"status": "completed"},
+                "ppo_frozen_wrapper_on": {"status": "completed"},
+                "ppo_frozen": {"status": "completed"},
+            },
+        },
+    )
+    _write_jsonl(output_root / "arm_status.jsonl", [])
+
+    decision = decide_arm_status_action(
+        live_status_path=output_root / "live_arm_status.json",
+        event_log_path=output_root / "arm_status.jsonl",
+        job_id="13320",
+    )
+
+    assert decision.action == "complete"
+    assert decision.scancel_command is None
+
+
+def test_cli_json_returns_cancel_exit_code(tmp_path: Path, capsys) -> None:
+    """Ops wrappers can poll once and branch on a stable nonzero cancel exit."""
+
+    output_root = tmp_path / "campaign"
+    output_root.mkdir()
+    _write_json(
+        output_root / "live_arm_status.json",
+        {
+            "schema_version": "robot_sf.issue_4205.static_constriction_codesign_campaign.v1.live_arm_status.v1",
+            "phase": "phase0",
+            "arms": {"ppo_frozen": {"status": "failed"}},
+        },
+    )
+
+    exit_code = main(["--output-root", str(output_root), "--job-id", "13300", "--json"])
+
+    assert exit_code == CANCEL_EXIT_CODE
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["action"] == "cancel"
+    assert payload["reason"] == "fail_closed_live_status"
+    assert payload["scancel_command"] == ["scancel", "13300"]


### PR DESCRIPTION
## Reviewer-critical summary
What changed: adds `scripts/dev/watch_live_arm_status.py`, a CPU-only L4 consumer for issue #4684 that reads `arm_status.jsonl` plus `live_arm_status.json`, detects fail-closed arm states, and emits a deterministic `scancel <job-id>` decision. It is dry-run by default; actual cancellation requires explicit `--execute-scancel`.

Why now: PR #4708 merged L0-L3 but left issue #4684 open because the owner gate comment at 2026-07-07T00:44:11Z required the L4 private-ops polling/scancel consumer before closure.

Claim boundary: this is a tracked public consumer/checker contract for private ops. It does not submit or cancel Slurm jobs during validation, does not run a campaign, and does not make any benchmark-result, paper, or dissertation claim.

Required validation: focused watcher tests, adjacent #4708 campaign-runner producer tests, touched-file lint/format, and final PR readiness wrapper.

Remaining blocker: none for the acceptance contract. Real private-ops deployment and any future campaign rerun remain operational follow-through outside this PR.

## Contract delta
New public utility: `scripts/dev/watch_live_arm_status.py`.

New behavior:
- reads `arm_status.jsonl` first so an append-only `failed` event triggers early cancellation even before final metadata is rewritten;
- falls back to `live_arm_status.json` and treats configured fail-closed statuses as cancel triggers;
- returns exit code `20` for cancel decisions and `0` for wait/continue/complete decisions;
- emits JSON when requested so private-ops wrappers can poll it directly;
- builds but does not execute `scancel` unless `--execute-scancel` is explicitly passed.

Compatibility impact: no behavior change for healthy arms or the campaign runner. Default operation is side-effect-free.

## Acceptance evidence
| Criterion | Evidence |
| --- | --- |
| L0 blocks submission on unknown algorithm and missing checkpoint. | Merged PR #4708 added full arm-resolution preflight plus fail-closed fixtures in `tests/benchmark/test_issue_4367_codesign_campaign_runner.py`; this PR reran that adjacent test module. |
| L1 + L2 phase-0 smoke and risky-first ordering in the campaign runner. | Merged PR #4708 added phase-0 smoke and risky-first ordering; this PR reran `tests/benchmark/test_issue_4367_codesign_campaign_runner.py`, including full-mode phase-0 assertions. |
| L3 status file written incrementally. | Merged PR #4708 added `live_arm_status.json` and `arm_status.jsonl`; this PR reran the producer tests and consumes those exact filenames. |
| L4 private-ops polling / scancel consumer. | This PR adds `scripts/dev/watch_live_arm_status.py` and `tests/dev/test_watch_live_arm_status.py`; tests prove failed events and failed live snapshots emit `scancel` decisions without executing them, while completed healthy arms are no-op. |
| No Slurm submissions or behavior change for healthy arms. | Validation was CPU-only; the watcher is dry-run by default and healthy completed status returns no cancel command. |

## Validation
- `uv run pytest tests/dev/test_watch_live_arm_status.py -q` -> passed, 3 tests.
- `uv run pytest tests/dev/test_watch_live_arm_status.py tests/benchmark/test_issue_4367_codesign_campaign_runner.py -q` -> passed, 11 tests.
- `uv run ruff check scripts/dev/watch_live_arm_status.py tests/dev/test_watch_live_arm_status.py` -> passed.
- `uv run ruff format scripts/dev/watch_live_arm_status.py tests/dev/test_watch_live_arm_status.py --check` -> passed after formatting.
- `PR_READY_PR_BODY_FILE=<common-git-dir>/codex-agent-runs/active/issue-4684/pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; clean-head stamp recorded at `output/validation/pr_ready/issue-4684-closure-audit-verify-acceptance-criteria-of-4684-against-merged-prs-clos.json`.

## Issue / scope
Refs #4684.

> **Gate demotion (2026-07-07):** demoted the auto-close keyword to a plain `Refs` reference for #4684 (was previously an auto-close directive). The issue's written acceptance scopes the poll/scancel consumer OUT of this repo ("the poll/scancel itself is private-ops work, out of scope here — emit the stream only"), and the maintainer's 2026-07-07 comment keeps #4684 open "until L4 lands" as private-ops wiring. This PR lands the L4 *decision helper* in `scripts/dev/`, but the private-ops 15-min polling cycle wiring + a real scancel-on-failure verification are not demonstrable from this repo, so the merge must not auto-close. The gate will post a state comment on #4684 and leave closure to the maintainer.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

State propagation: the gate (not this worker) will post the #4684 state update after merge.

Late guidance check: immediately before opening, I re-read issue #4684 and found only the 2026-07-07T00:44:11Z owner comment requiring L4; this PR implements that requirement.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: only one merged #4684 PR (#4708) appeared in the last 24h search, so the two-or-more micro-guardrail stop condition did not apply. This PR is also a progression slice: it adds the nameable L4 live-status consumer capability.

Artifact handling: no new benchmark artifacts were produced or promoted. `output/` remains ignored/local.

Closure call: #4708 covers L0-L3, and this PR adds the L4 decision helper. The merge gate demoted `Closes` → `Refs` (see the demotion note above); #4684 stays open pending private-ops wiring + verification.

</details>

