### PR TITLE
Issue #1358: keep parent audit artifact fresh

### DIFF
--- a/docs/context/evidence/issue_1358_acceptance_audit_2026-07-07.json
+++ b/docs/context/evidence/issue_1358_acceptance_audit_2026-07-07.json
@@ -85,9 +85,10 @@
       }
     ],
     "state_surface": {
-      "entry_status": "cpu_contract_delivered__external_slurm_rerun_pending",
+      "entry_status": "integration_report_delivered__external_slurm_rerun_pending",
       "errors": [],
-      "latest_recorded_at_utc": "2026-07-06T16:38:00Z",
+      "integration_report_status": "blocked",
+      "latest_recorded_at_utc": "2026-07-07T02:20:00Z",
       "path": "docs/context/issue_1475_state.yaml",
       "status": "valid"
     },

--- a/tests/validation/test_build_issue_1358_acceptance_audit.py
+++ b/tests/validation/test_build_issue_1358_acceptance_audit.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from scripts.validation.build_issue_1358_acceptance_audit import build_audit
+from scripts.validation.build_issue_1358_acceptance_audit import DEFAULT_OUTPUT, build_audit
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -69,3 +69,10 @@ def test_issue_1358_parent_audit_cli_writes_json_artifact(tmp_path: Path) -> Non
     assert payload["state_surface"]["path"] == "docs/context/issue_1358_state.yaml"
     assert payload["state_surface"]["errors"] == []
     assert "Slurm-capable lane" in payload["next_empirical_action"]
+
+
+def test_issue_1358_tracked_audit_artifact_matches_builder() -> None:
+    """Tracked parent evidence must match current merged child-state inputs."""
+    tracked_payload = json.loads((REPO_ROOT / DEFAULT_OUTPUT).read_text(encoding="utf-8"))
+
+    assert tracked_payload == build_audit(repo_root=REPO_ROOT)


### PR DESCRIPTION
## Reviewer-critical summary
What changed: refreshes the tracked Issue #1358 executable acceptance-audit JSON so it matches the current merged child #1475 state surface, and adds a regression test that the tracked artifact stays equal to the builder output.

Why now: PR #4715 merged the executable parent audit, then later merged state changed the child #1475 surface to `integration_report_delivered__external_slurm_rerun_pending`; rerunning the audit exposed tracked-artifact drift. This is the smallest evidence-integrity slice, not another blocker-status restatement.

Claim boundary: CPU-only evidence-generation consistency. The audit still reports `status=blocked` and `closure_call=keep_open`; it does not claim learned-residual success or benchmark-strengthening evidence.

Required validation: focused audit/readiness tests, targeted Ruff, final PR readiness wrapper.

Remaining blocker: child #1475 still needs a Slurm-capable ORCA-residual BC smoke rerun and, only if smoke passes, bounded nominal escalation before #1358 can receive a continue/revise/stop classification.

## Contract delta
New schema fields: none.

New fail-closed blockers: none. Existing fail-closed result remains: no closure while durable trained checkpoint pointer, non-fallback smoke/nominal evidence, scenario-stratified comparison report, and final lane classification are absent.

Compatibility impact: additive test coverage plus regenerated tracked JSON evidence. No runtime planner behavior, training config, benchmark runner, CLI schema, or state-surface format changes.

## Issue
Refs #1358

## Scope summary
- Regenerated `docs/context/evidence/issue_1358_acceptance_audit_2026-07-07.json` from `scripts/validation/build_issue_1358_acceptance_audit.py`.
- Added a regression test ensuring the tracked #1358 audit artifact matches current builder output.
- Fragmentation guard: this is a nameable evidence-integrity capability after #4706/#4715, not a new guardrail/checker packet or prose-only blocker refresh.
- State propagation: no issue comment posted because `comment_issue_or_pr=false`; the PR body and tracked JSON evidence are the durable propagation surface for this small update.

## Remaining criteria
- [ ] Trained checkpoint durable lineage explicit artifact pointer.
- [ ] Smoke nominal-sanity policy-search stages run without fallback/degraded success.
- [ ] Report compares ORCA, current PPO leader, failed guarded-PPO variants, and new residual policy.
- [ ] Result classified promote, revise, or reject using scenario-stratified evidence.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_build_issue_1358_acceptance_audit.py tests/benchmark/test_orca_residual_lane_readiness.py -q` — pass, 17 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/validation/test_build_issue_1358_acceptance_audit.py scripts/validation/build_issue_1358_acceptance_audit.py` — pass.
- `git diff --check` — pass.
- `PR_READY_PR_BODY_FILE=/tmp/issue_1358_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — pass; readiness stamp `output/validation/pr_ready/issue-1358-closure-audit-20260707T0340Z.json`, head `2c34b09d101b81272bf35c4ad85d2b8542a38834`.

## Out of scope
No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. No release, merge, delete, or issue comment action.

<details>
<summary>Freshness and late-guidance notes</summary>

Late issue check immediately before PR preparation used explicit JSON fields because `gh issue view 1358 --comments` can hit GitHub classic-project deprecation. Issue #1358 remained open, updated `2026-07-07T01:49:24Z`, with no comments newer than implementation start. Open-PR dedupe for #1358 returned none.

Merged #1358 PRs in the churn window include #4706 and #4715; this PR keeps the executable evidence artifact synchronized with the currently merged child-state inputs and adds a test to prevent recurrence.

</details>
