### PR TITLE
Issue #3285: add target prerequisite report

### DIFF
--- a/docs/context/issue_3285_scenario_interop_converter.md
+++ b/docs/context/issue_3285_scenario_interop_converter.md
@@ -1,5 +1,9 @@
 # Issue #3285 Dry-Run Scenario Interop Converter
 
+Plain-language summary: Robot SF can emit deterministic local handoff artifacts for
+SocNavBench and HuNavSim scenario conversion, but it still cannot claim runnable external
+benchmark export until the external assets and adapters are staged.
+
 Status: local, asset-free implementation slice (`smoke evidence`). This is not benchmark
 evidence and does not claim cross-benchmark validity.
 
@@ -8,63 +12,36 @@ Related:
 - Conceptual mapping seed: [`issue_2928_socnavbench_hunavsim_metric_correspondence.md`](issue_2928_socnavbench_hunavsim_metric_correspondence.md)
 - Source-side contract: `robot_sf/benchmark/scenario_contract.py`,
   `robot_sf/benchmark/schema/scenarios.schema.json`
-- External-asset prerequisites that block an external run: #1456, #1498, #2414, #1134
+- External-asset prerequisites block external run: #1456, #1498, #2414, #1134
 
 ## Slice Delivers
 
 The local converter emits deterministic, schema-validated intermediate representation (IR)
-for Robot SF scenario-matrix entries, plus explicit unsupported-field reports. It does not
-require external assets and does not emit runnable SocNavBench or HuNavSim files.
+Robot SF scenario-matrix entries, explicit unsupported-field reports, fail-closed target
+compatibility reports, export manifests, target-shaped previews, and local-only prerequisite
+reports. It does not download assets and does not emit runnable SocNavBench or HuNavSim files.
 
-- Module: `robot_sf/benchmark/scenario_interop.py` (`convert_scenario_to_ir`, `dump_ir`,
-  `validate_interop_ir`, `validate_target_compatibility_report`,
-  `validate_target_export_manifest`, `validate_target_export_preview`,
-  `build_target_export_manifest`, `build_target_export_preview`).
+- Module: `robot_sf/benchmark/scenario_interop.py`
+- CLI: `scripts/tools/convert_scenario_interop.py`
+- Tests: `tests/benchmark/test_scenario_interop.py`,
+  `tests/benchmark/test_scenario_interop_target_compatibility.py`
 - IR schema: `robot_sf/benchmark/schemas/scenario_interop_ir.v1.json`
-  (`robot_sf.scenario_interop_ir.v1`).
 - Target handoff schemas:
   `robot_sf/benchmark/schemas/scenario_interop_target_compatibility.v1.json`,
-  `robot_sf/benchmark/schemas/scenario_interop_target_export_manifest.v1.json`, and
-  `robot_sf/benchmark/schemas/scenario_interop_target_export_preview.v1.json`.
-- Dry-run CLI: `scripts/tools/convert_scenario_interop.py`.
-- Tests: `tests/benchmark/test_scenario_interop.py`,
-  `tests/benchmark/test_scenario_interop_target_compatibility.py`.
+  `robot_sf/benchmark/schemas/scenario_interop_target_export_manifest.v1.json`,
+  `robot_sf/benchmark/schemas/scenario_interop_target_export_preview.v1.json`,
+  `robot_sf/benchmark/schemas/scenario_interop_target_prerequisite_report.v1.json`
 
-## Target Compatibility
-
-The converter emits asset-free target compatibility reports
-(`robot_sf.scenario_interop_target_compatibility.v1`) for `socnavbench` and `hunavsim`.
-These are fail-closed readiness projections, not target artifact exports.
-
-- `ready`: false until target assets/adapters are staged and required IR fields are present.
-- `blockers`: explicit missing asset, adapter, map, agent, flow, and unsupported-field blockers.
-- `warnings`: non-blocking provenance or target-semantics gaps, including missing seeds and
-  HuNavSim ROS/Gazebo launch semantics outside the target-neutral IR.
-
-## Target Export Manifest And Preview
-
-`--target-out-dir` writes deterministic, asset-free target export manifests
-(`robot_sf.scenario_interop_target_export_manifest.v1`). A manifest is a JSON handoff
-contract for downstream adapters; it is not a runnable SocNavBench or HuNavSim scenario file.
-When prerequisites are missing, it remains `status: blocked`, `ready: false`, with named
-blockers, warnings, source scenario, and source IR schema.
-
-`--target-preview-out-dir` writes deterministic, asset-free target-shaped preview payloads
-(`robot_sf.scenario_interop_target_export_preview.v1`). Preview payloads preserve the
-target-specific sections that a real writer must resolve: `scenario`/`pedestrians` for
-SocNavBench and `world`/`agents` for HuNavSim. They carry the same fail-closed blockers as
-the manifest and are adapter-development artifacts, not runnable external benchmark inputs.
-
-## IR Contract
+## Mapping Contract
 
 | IR section | Source fields | Notes |
-|---|---|---|
-| `provenance` | `id`/`scenario_id`/`name`, `metadata`, all top-level keys, source file | Records source id, `source_kind` (`axis`/`explicit_map`), full `source_fields`, and `source_metadata`. |
-| `geometry` | `obstacle`, `map_file` | `obstacle` maps to coarse `environment_type` (`open` -> `open_space`, `bottleneck` -> `constrained_passage`, `maze` -> `cluttered`). |
+| --- | --- | --- |
+| `provenance` | `id`, `scenario_id`, `name`, source file, source fields | Stable source trace. |
+| `geometry` | `obstacle`, `map_file` | Coarse target-neutral environment type. |
 | `environment` | `density`, `flow`, `groups`, `speed_var`, `goal_topology`, `robot_context` | Target-neutral environment semantics. |
-| `agents` | `single_pedestrians[]` | Start/goal points of interest, preferred speed, role, role target, wait points; specs without an `id` get deterministic id `agent_<index>`. |
+| `agents` | `single_pedestrians[]` | Start/goal points, preferred speed, role, role target, wait points. |
 | `timing` | `repeats`, `seeds` | Preserves repeat count and explicit seed set when present. |
-| `unsupported_fields` | everything else | Every unmapped top-level source key is reported with a reason; nothing is silently dropped. |
+| `unsupported_fields` | everything else | Every unmapped top-level source key is reported with a reason. |
 
 ## Dry-Run Commands
 
@@ -89,32 +66,39 @@ uv run python scripts/tools/convert_scenario_interop.py \
   --matrix configs/baselines/example_matrix.yaml \
   --target socnavbench \
   --target-preview-out-dir output/issue_3285_target_export_preview_smoke
+
+# Write local-only prerequisite reports for runnable export readiness.
+uv run python scripts/tools/convert_scenario_interop.py \
+  --matrix configs/baselines/example_matrix.yaml \
+  --target socnavbench \
+  --target-prerequisite-out-dir output/issue_3285_target_prerequisite_smoke
 ```
 
 The CLI prints IR to stdout only when no output directory is requested. It always writes a
-`{"dry_run_summary": [...]}` block to stderr and exits non-zero when a scenario IR fails schema
+`{"dry_run_summary": [...]}` block to stderr and exits non-zero when scenario IR fails schema
 validation.
 
 ## Claim Boundary
 
-- This dry-run, IR validation, target export manifest, and target export preview slice makes no
-  claim about simulator equivalence, planner transferability, or benchmark-score parity.
-- Emitting real runnable SocNavBench/HuNavSim scenario assets and running them remains blocked on
-  staged external assets/adapters (#1456, #1498, #2414, #1134).
+- Dry-run IR validation, target compatibility, export manifest, export preview, and target
+  prerequisite reports make no claim about simulator equivalence, planner transferability,
+  benchmark-score parity, runnable external export, or paper/dissertation evidence.
+- Real runnable SocNavBench/HuNavSim scenario asset export remains blocked on staged external
+  assets/adapters (#1456, #1498, #2414, #1134).
 
 ## Closure Audit Integration 2026-07-07
 
-Merged evidence through PR #4711 satisfies the original asset-free acceptance criteria:
+Merged evidence through PR #4718 satisfies the original asset-free acceptance criteria:
 
 | Acceptance criterion | Evidence |
 | --- | --- |
-| Converter output schema-validated deterministic fixture scenario. | PR #3735 added the IR converter, `scenario_interop_ir.v1.json`, deterministic serialization tests, and schema validation. |
-| Unsupported fields reported explicitly instead silently dropped. | PR #3735 records unmapped top-level source fields in `unsupported_fields`; PR #4562 and PR #4711 propagate those blockers into target compatibility and preview artifacts. |
-| Smoke dry-run command documented. | PR #3735 documented the IR CLI; PR #4673 and PR #4711 extended this note with manifest and preview dry-run commands. |
-| Issue links external asset prerequisites required full run. | The issue thread and this note keep #1456, #1498, #2414, and #1134 as full-run blockers. |
+| Converter output is schema-validated for deterministic fixture scenarios. | PR #3735 added the IR converter, `scenario_interop_ir.v1.json`, deterministic serialization tests, and schema validation. |
+| Unsupported fields are reported explicitly instead of silently dropped. | PR #3735 records unmapped top-level source fields in `unsupported_fields`; PR #4562 and PR #4711 propagate blockers into target compatibility and preview artifacts. |
+| Smoke dry-run command is documented. | PR #3735 documented the IR CLI; PR #4673 and PR #4711 extended the note with manifest and preview dry-run commands. |
+| External asset prerequisites required for full run are linked. | The issue thread and this note keep #1456, #1498, #2414, and #1134 as full-run blockers. |
 
-This integration slice adds JSON-Schema validation for the target compatibility, target export
-manifest, and target export preview artifacts introduced after the base IR converter. It does not
-change the closure boundary: runnable SocNavBench/HuNavSim export remains intentionally blocked
-until external assets and adapters are staged. The next empirical action is an asset-backed adapter
-smoke after the relevant prerequisite issue provides staged target inputs.
+The current integration slice adds a schema-validated target prerequisite report so the remaining
+external blockers become one machine-readable local preflight artifact. It does not change the
+closure boundary: runnable SocNavBench/HuNavSim export remains intentionally blocked until external
+assets and adapters are staged. The next empirical action is an asset-backed adapter smoke after a
+prerequisite issue provides staged target inputs.

--- a/robot_sf/benchmark/scenario_interop.py
+++ b/robot_sf/benchmark/scenario_interop.py
@@ -48,6 +48,9 @@ CONVERTER_VERSION = "1"
 TARGET_COMPATIBILITY_SCHEMA_VERSION = "robot_sf.scenario_interop_target_compatibility.v1"
 TARGET_EXPORT_MANIFEST_SCHEMA_VERSION = "robot_sf.scenario_interop_target_export_manifest.v1"
 TARGET_EXPORT_PREVIEW_SCHEMA_VERSION = "robot_sf.scenario_interop_target_export_preview.v1"
+TARGET_PREREQUISITE_REPORT_SCHEMA_VERSION = (
+    "robot_sf.scenario_interop_target_prerequisite_report.v1"
+)
 SUPPORTED_TARGETS = ("socnavbench", "hunavsim")
 IR_SCHEMA_FILE = Path(__file__).with_name("schemas") / "scenario_interop_ir.v1.json"
 TARGET_COMPATIBILITY_SCHEMA_FILE = (
@@ -58,6 +61,9 @@ TARGET_EXPORT_MANIFEST_SCHEMA_FILE = (
 )
 TARGET_EXPORT_PREVIEW_SCHEMA_FILE = (
     Path(__file__).with_name("schemas") / "scenario_interop_target_export_preview.v1.json"
+)
+TARGET_PREREQUISITE_REPORT_SCHEMA_FILE = (
+    Path(__file__).with_name("schemas") / "scenario_interop_target_prerequisite_report.v1.json"
 )
 
 # Source keys that map directly into IR sections. Anything not in this set is
@@ -117,6 +123,44 @@ _TARGET_ASSET_BLOCKERS: dict[str, tuple[dict[str, str], ...]] = {
             "code": "hunavsim_adapter_not_staged",
             "field": "target_adapter",
             "reason": "HuNavSim export requires a staged adapter/schema fixture (#2414).",
+        },
+    ),
+}
+
+_TARGET_PREREQUISITES: dict[str, tuple[dict[str, Any], ...]] = {
+    "socnavbench": (
+        {
+            "code": "socnavbench_control_assets",
+            "issue": 1456,
+            "path": "third_party/socnavbench/wayptnav_data",
+            "kind": "directory",
+            "reason": "SocNavBench control-pipeline data must be staged before runnable export.",
+        },
+        {
+            "code": "socnavbench_eth_mesh",
+            "issue": 1134,
+            "path": ("third_party/socnavbench/sd3dis/stanford_building_parser_dataset/mesh/ETH"),
+            "kind": "directory",
+            "reason": "Official SocNavBench ETH mesh directory is required for ETH map export.",
+        },
+        {
+            "code": "socnavbench_eth_traversible_pickle",
+            "issue": 1134,
+            "path": (
+                "third_party/socnavbench/sd3dis/"
+                "stanford_building_parser_dataset/traversibles/ETH/data.pkl"
+            ),
+            "kind": "file",
+            "reason": "Official SocNavBench ETH traversible pickle is required for ETH map export.",
+        },
+    ),
+    "hunavsim": (
+        {
+            "code": "hunavsim_adapter_checkout",
+            "issue": 2414,
+            "path": "third_party/hunav_sim",
+            "kind": "directory",
+            "reason": "HuNavSim adapter/schema checkout must be staged before runnable export.",
         },
     ),
 }
@@ -189,6 +233,17 @@ def load_target_export_preview_schema() -> dict[str, Any]:
     return json.loads(TARGET_EXPORT_PREVIEW_SCHEMA_FILE.read_text(encoding="utf-8"))
 
 
+@lru_cache(maxsize=1)
+def load_target_prerequisite_report_schema() -> dict[str, Any]:
+    """Load target prerequisite report JSON Schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+
+    return json.loads(TARGET_PREREQUISITE_REPORT_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
 def validate_interop_ir(ir: Mapping[str, Any]) -> list[str]:
     """Validate an IR payload against the interop IR schema.
 
@@ -239,6 +294,19 @@ def validate_target_export_preview(preview: Mapping[str, Any]) -> list[str]:
     """
 
     return _validate_json_schema(preview, schema=load_target_export_preview_schema())
+
+
+def validate_target_prerequisite_report(report: Mapping[str, Any]) -> list[str]:
+    """Validate target prerequisite report against JSON Schema.
+
+    Args:
+        report: Candidate prerequisite report.
+
+    Returns:
+        Sorted JSON-pointer-prefixed validation error strings; empty valid.
+    """
+
+    return _validate_json_schema(report, schema=load_target_prerequisite_report_schema())
 
 
 def _validate_json_schema(payload: Mapping[str, Any], *, schema: Mapping[str, Any]) -> list[str]:
@@ -564,6 +632,87 @@ def build_target_export_preview(ir: Mapping[str, Any], *, target: str) -> dict[s
     }
 
 
+def build_target_prerequisite_report(
+    ir: Mapping[str, Any],
+    *,
+    target: str,
+    root: Path | str | None = None,
+) -> dict[str, Any]:
+    """Build local prerequisite status for a runnable target export.
+
+    The report checks only local filesystem presence for known external
+    prerequisites. It does not download, vendor, or validate licensed external
+    data and therefore remains a preflight handoff artifact, not benchmark
+    evidence.
+
+    Args:
+        ir: Source interop IR.
+        target: Target benchmark name.
+        root: Optional repository root for tests or alternate checkouts.
+
+    Returns:
+        JSON-safe target prerequisite report.
+    """
+
+    if target not in SUPPORTED_TARGETS:
+        raise ValueError(
+            f"unsupported target {target!r}; expected one {', '.join(SUPPORTED_TARGETS)}"
+        )
+    repo_root = Path(root) if root is not None else Path.cwd()
+    prerequisites = [
+        _target_prerequisite_status(item, root=repo_root) for item in _TARGET_PREREQUISITES[target]
+    ]
+    missing = [item for item in prerequisites if item["status"] != "present"]
+    return {
+        "schema_version": TARGET_PREREQUISITE_REPORT_SCHEMA_VERSION,
+        "artifact_kind": f"{target}_scenario_export_prerequisite_report",
+        "target": target,
+        "source_scenario_id": _ir_source_id(ir),
+        "status": "ready" if not missing else "blocked",
+        "ready": not missing,
+        "no_download_performed": True,
+        "prerequisites": prerequisites,
+        "remaining_blockers": [
+            {
+                "code": item["code"],
+                "issue": item["issue"],
+                "path": item["path"],
+                "reason": item["reason"],
+            }
+            for item in missing
+        ],
+        "next_empirical_action": (
+            "Stage the missing external prerequisite paths through their owning "
+            "issues, then rerun this report before enabling runnable export."
+            if missing
+            else "Run the target exporter smoke path with the staged prerequisites."
+        ),
+        "claim_boundary": (
+            "Local prerequisite presence check only; not runnable target export, "
+            "benchmark evidence, or paper/dissertation claim."
+        ),
+    }
+
+
+def _target_prerequisite_status(
+    prerequisite: Mapping[str, Any],
+    *,
+    root: Path,
+) -> dict[str, Any]:
+    path = str(prerequisite["path"])
+    absolute_path = root / path
+    kind = str(prerequisite["kind"])
+    exists = absolute_path.is_dir() if kind == "directory" else absolute_path.is_file()
+    return {
+        "code": str(prerequisite["code"]),
+        "issue": int(prerequisite["issue"]),
+        "path": path,
+        "kind": kind,
+        "status": "present" if exists else "missing",
+        "reason": str(prerequisite["reason"]),
+    }
+
+
 def _build_socnavbench_preview_payload(ir: Mapping[str, Any]) -> dict[str, Any]:
     geometry = ir.get("geometry") if isinstance(ir.get("geometry"), Mapping) else {}
     environment = ir.get("environment") if isinstance(ir.get("environment"), Mapping) else {}
@@ -713,12 +862,16 @@ __all__ = [
     "TARGET_COMPATIBILITY_SCHEMA_VERSION",
     "TARGET_EXPORT_MANIFEST_SCHEMA_VERSION",
     "TARGET_EXPORT_PREVIEW_SCHEMA_VERSION",
+    "TARGET_PREREQUISITE_REPORT_SCHEMA_VERSION",
     "ScenarioInteropResult",
     "build_target_compatibility_report",
     "build_target_export_manifest",
     "build_target_export_preview",
+    "build_target_prerequisite_report",
     "convert_scenario_to_ir",
     "dump_ir",
     "load_interop_ir_schema",
+    "load_target_prerequisite_report_schema",
     "validate_interop_ir",
+    "validate_target_prerequisite_report",
 ]

--- a/robot_sf/benchmark/schemas/scenario_interop_target_prerequisite_report.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_interop_target_prerequisite_report.v1.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ll7.github.io/robot_sf/scenario_interop_target_prerequisite_report.v1.json",
+  "title": "Robot SF Cross-Benchmark Scenario Target Prerequisite Report (v1)",
+  "description": "Local-only prerequisite status for runnable SocNavBench or HuNavSim scenario export. It checks known paths without downloading, vendoring, or validating external data content.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "target",
+    "source_scenario_id",
+    "status",
+    "ready",
+    "no_download_performed",
+    "prerequisites",
+    "remaining_blockers",
+    "next_empirical_action",
+    "claim_boundary"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "robot_sf.scenario_interop_target_prerequisite_report.v1"
+    },
+    "artifact_kind": {
+      "enum": [
+        "socnavbench_scenario_export_prerequisite_report",
+        "hunavsim_scenario_export_prerequisite_report"
+      ]
+    },
+    "target": {
+      "$ref": "#/$defs/target"
+    },
+    "source_scenario_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "enum": [
+        "ready",
+        "blocked"
+      ]
+    },
+    "ready": {
+      "type": "boolean"
+    },
+    "no_download_performed": {
+      "const": true
+    },
+    "prerequisites": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/prerequisite"
+      }
+    },
+    "remaining_blockers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/blocker"
+      }
+    },
+    "next_empirical_action": {
+      "type": "string",
+      "minLength": 1
+    },
+    "claim_boundary": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "$defs": {
+    "target": {
+      "enum": [
+        "socnavbench",
+        "hunavsim"
+      ]
+    },
+    "prerequisite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "issue",
+        "path",
+        "kind",
+        "status",
+        "reason"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "issue": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "enum": [
+            "directory",
+            "file"
+          ]
+        },
+        "status": {
+          "enum": [
+            "present",
+            "missing"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "blocker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "issue",
+        "path",
+        "reason"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "issue": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/scripts/tools/convert_scenario_interop.py
+++ b/scripts/tools/convert_scenario_interop.py
@@ -22,6 +22,7 @@ from robot_sf.benchmark.scenario_interop import (
     build_target_compatibility_report,
     build_target_export_manifest,
     build_target_export_preview,
+    build_target_prerequisite_report,
     convert_scenario_to_ir,
     dump_ir,
 )
@@ -48,6 +49,7 @@ def _write_outputs(
     out_dir: Path | None,
     target_out_dir: Path | None,
     target_preview_out_dir: Path | None,
+    target_prerequisite_out_dir: Path | None,
 ) -> None:
     """Write requested IR, manifest, and preview outputs for one scenario."""
 
@@ -64,6 +66,13 @@ def _write_outputs(
             preview = build_target_export_preview(ir, target=target)
             preview_path = target_preview_out_dir / f"{scenario_id}.{target}.export_preview.json"
             preview_path.write_text(dump_ir(preview), encoding="utf-8")
+    if target_prerequisite_out_dir is not None:
+        for target in targets:
+            report = build_target_prerequisite_report(ir, target=target)
+            report_path = (
+                target_prerequisite_out_dir / f"{scenario_id}.{target}.prerequisite_report.json"
+            )
+            report_path.write_text(dump_ir(report), encoding="utf-8")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -102,6 +111,15 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--target-prerequisite-out-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Optional write one <scenario_id>.<target>.prerequisite_report.json "
+            "local-only prerequisite report per scenario requested target."
+        ),
+    )
+    parser.add_argument(
         "--target",
         action="append",
         choices=SUPPORTED_TARGETS,
@@ -114,7 +132,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     scenarios = _load_scenarios(args.matrix)
-    for directory in (args.out_dir, args.target_out_dir, args.target_preview_out_dir):
+    for directory in (
+        args.out_dir,
+        args.target_out_dir,
+        args.target_preview_out_dir,
+        args.target_prerequisite_out_dir,
+    ):
         if directory is not None:
             directory.mkdir(parents=True, exist_ok=True)
 
@@ -148,12 +171,14 @@ def main(argv: list[str] | None = None) -> int:
             out_dir=args.out_dir,
             target_out_dir=args.target_out_dir,
             target_preview_out_dir=args.target_preview_out_dir,
+            target_prerequisite_out_dir=args.target_prerequisite_out_dir,
         )
 
         if (
             args.out_dir is None
             and args.target_out_dir is None
             and args.target_preview_out_dir is None
+            and args.target_prerequisite_out_dir is None
         ):
             sys.stdout.write(dump_ir(result.ir))
 

--- a/tests/benchmark/test_scenario_interop_target_compatibility.py
+++ b/tests/benchmark/test_scenario_interop_target_compatibility.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 from robot_sf.benchmark.scenario_interop import (
     TARGET_COMPATIBILITY_SCHEMA_VERSION,
@@ -32,6 +29,8 @@ from robot_sf.benchmark.scenario_interop import (
     validate_target_export_preview,
     validate_target_prerequisite_report,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _axis_scenario() -> dict:
@@ -316,6 +315,7 @@ def test_cli_writes_target_prerequisite_reports(tmp_path: Path) -> None:
             "--target-prerequisite-out-dir",
             str(out_dir),
         ],
+        cwd=REPO_ROOT,
         check=True,
         capture_output=True,
         text=True,

--- a/tests/benchmark/test_scenario_interop_target_compatibility.py
+++ b/tests/benchmark/test_scenario_interop_target_compatibility.py
@@ -2,23 +2,35 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
 import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from robot_sf.benchmark.scenario_interop import (
     TARGET_COMPATIBILITY_SCHEMA_VERSION,
     TARGET_EXPORT_MANIFEST_SCHEMA_VERSION,
     TARGET_EXPORT_PREVIEW_SCHEMA_VERSION,
+    TARGET_PREREQUISITE_REPORT_SCHEMA_VERSION,
     build_target_compatibility_report,
     build_target_export_manifest,
     build_target_export_preview,
+    build_target_prerequisite_report,
     convert_scenario_to_ir,
     dump_ir,
     load_target_compatibility_schema,
     load_target_export_manifest_schema,
     load_target_export_preview_schema,
+    load_target_prerequisite_report_schema,
     validate_target_compatibility_report,
     validate_target_export_manifest,
     validate_target_export_preview,
+    validate_target_prerequisite_report,
 )
 
 
@@ -229,3 +241,91 @@ def test_target_compatibility_report_rejects_unknown_target() -> None:
 
     with pytest.raises(ValueError, match="unsupported target"):
         build_target_compatibility_report(result.ir, targets=("unknownsim",))
+
+
+def test_target_prerequisite_report_fails_closed_for_missing_paths(tmp_path: Path) -> None:
+    """Runnable-export prerequisites are reported explicitly when absent."""
+    result = convert_scenario_to_ir(_explicit_map_scenario())
+
+    report = build_target_prerequisite_report(result.ir, target="socnavbench", root=tmp_path)
+
+    assert report["schema_version"] == TARGET_PREREQUISITE_REPORT_SCHEMA_VERSION
+    assert report["artifact_kind"] == "socnavbench_scenario_export_prerequisite_report"
+    assert report["target"] == "socnavbench"
+    assert report["source_scenario_id"] == "corridor-handoff"
+    assert report["status"] == "blocked"
+    assert report["ready"] is False
+    assert report["no_download_performed"] is True
+    assert {item["code"] for item in report["remaining_blockers"]} == {
+        "socnavbench_control_assets",
+        "socnavbench_eth_mesh",
+        "socnavbench_eth_traversible_pickle",
+    }
+    assert {item["issue"] for item in report["remaining_blockers"]} == {1456, 1134}
+    assert "benchmark evidence" in report["claim_boundary"]
+    assert validate_target_prerequisite_report(report) == []
+
+
+def test_target_prerequisite_report_passes_when_expected_paths_exist(tmp_path: Path) -> None:
+    """Synthetic local paths exercise the ready prerequisite-report path."""
+    (tmp_path / "third_party/socnavbench/wayptnav_data").mkdir(parents=True)
+    (tmp_path / "third_party/socnavbench/sd3dis/stanford_building_parser_dataset/mesh/ETH").mkdir(
+        parents=True
+    )
+    traversible = (
+        tmp_path
+        / "third_party/socnavbench/sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl"
+    )
+    traversible.parent.mkdir(parents=True)
+    traversible.write_bytes(b"synthetic-placeholder")
+    result = convert_scenario_to_ir(_explicit_map_scenario())
+
+    report = build_target_prerequisite_report(result.ir, target="socnavbench", root=tmp_path)
+
+    assert report["status"] == "ready"
+    assert report["ready"] is True
+    assert report["remaining_blockers"] == []
+    assert {item["status"] for item in report["prerequisites"]} == {"present"}
+    assert "target exporter smoke path" in report["next_empirical_action"]
+    assert validate_target_prerequisite_report(report) == []
+
+
+def test_target_prerequisite_schema_loader_and_tamper_check(tmp_path: Path) -> None:
+    """Prerequisite schema helper loads and rejects malformed reports."""
+    assert load_target_prerequisite_report_schema()["title"]
+    result = convert_scenario_to_ir(_explicit_map_scenario())
+    report = build_target_prerequisite_report(result.ir, target="hunavsim", root=tmp_path)
+    broken = dict(report)
+    broken["no_download_performed"] = False
+
+    assert validate_target_prerequisite_report(report) == []
+    assert validate_target_prerequisite_report(broken) != []
+
+
+def test_cli_writes_target_prerequisite_reports(tmp_path: Path) -> None:
+    """CLI emits local-only prerequisite reports for requested targets."""
+    out_dir = tmp_path / "prerequisites"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tools/convert_scenario_interop.py",
+            "--matrix",
+            "configs/baselines/example_matrix.yaml",
+            "--target",
+            "socnavbench",
+            "--target-prerequisite-out-dir",
+            str(out_dir),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout == ""
+    report_paths = sorted(out_dir.glob("*.socnavbench.prerequisite_report.json"))
+    assert report_paths
+    report = json.loads(report_paths[0].read_text(encoding="utf-8"))
+    assert report["schema_version"] == TARGET_PREREQUISITE_REPORT_SCHEMA_VERSION
+    assert report["target"] == "socnavbench"
+    assert report["no_download_performed"] is True
+    assert validate_target_prerequisite_report(report) == []


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a schema-validated `scenario_interop_target_prerequisite_report.v1` artifact plus Python API and CLI output via `--target-prerequisite-out-dir`.

Why now: #3285 has multiple recent guardrail/audit PRs; this is the consolidation/progression slice that turns the remaining runnable-export blockers into one machine-readable local preflight artifact instead of another status-only packet.

Claim boundary: this is a local-only prerequisite presence check. It performs no downloads, emits no runnable SocNavBench/HuNavSim assets, runs no benchmark campaign, and makes no paper/dissertation claim.

Required validation:
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/scenario_interop.py scripts/tools/convert_scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_scenario_interop_target_compatibility.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/convert_scenario_interop.py --matrix configs/baselines/example_matrix.yaml --target socnavbench --target-prerequisite-out-dir output/issue_3285_target_prerequisite_smoke`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/benchmark -k "scenario or convert or socnav" -q`
- `scripts/dev/run_worktree_shared_venv.sh -- bash -lc 'BASE_REF=origin/main scripts/dev/pr_ready_check.sh'`

Remaining blocker: runnable SocNavBench/HuNavSim export remains blocked on external assets/adapters tracked by #1456/#1134 and the existing HuNavSim prerequisite issue lineage. This PR references #3285 but does not use a closure keyword.

## Contract delta

- New schema: `robot_sf/benchmark/schemas/scenario_interop_target_prerequisite_report.v1.json`.
- New API: `build_target_prerequisite_report()`, `validate_target_prerequisite_report()`, and `load_target_prerequisite_report_schema()`.
- New CLI output: `scripts/tools/convert_scenario_interop.py --target-prerequisite-out-dir <dir>` writes one `<scenario_id>.<target>.prerequisite_report.json` file per requested target.
- New fail-closed blockers: SocNavBench control assets, SocNavBench ETH mesh, SocNavBench ETH traversible pickle, and HuNavSim adapter checkout are reported as missing until their local paths exist.
- Compatibility impact: additive only. Existing IR, compatibility report, manifest, preview schemas, and CLI flags are unchanged.

## Scope

Refs #3285.

In scope:
- Add one concrete local prerequisite report artifact for the remaining runnable-export blockers.
- Update focused tests and the #3285 context note.

Out of scope:
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No external data download, vendoring, or license-gated asset staging.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/scenario_interop.py scripts/tools/convert_scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py` — passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_scenario_interop_target_compatibility.py -q` — passed, 13 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/convert_scenario_interop.py --matrix configs/baselines/example_matrix.yaml --target socnavbench --target-prerequisite-out-dir output/issue_3285_target_prerequisite_smoke` — passed; wrote 3 prerequisite reports; sample report was `blocked`, `ready=false`, `no_download_performed=true`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/benchmark -k "scenario or convert or socnav" -q` — passed.
- `scripts/dev/run_worktree_shared_venv.sh -- bash -lc 'BASE_REF=origin/main scripts/dev/pr_ready_check.sh'` — passed; core lane reported `1926 passed`.

## Acceptance evidence

| Criterion | Evidence |
| --- | --- |
| Converter output schema-validated deterministic fixture scenario. | Already met by PR #3735; preserved by the focused and broader benchmark-filter tests. |
| Unsupported fields reported explicitly instead silently dropped. | Already met by PR #3735 and propagated by #4562/#4711; preserved by existing tests. |
| Smoke dry-run command documented. | Existing IR/manifest/preview commands preserved; this PR documents the new prerequisite-report smoke command in `docs/context/issue_3285_scenario_interop_converter.md`. |
| Issue links external asset prerequisites required full run. | Existing blockers #1456/#1134/#1498/#2414 remain documented; this PR adds a local prerequisite report naming the concrete missing paths and owner issues for runnable export readiness. |
| Real runnable SocNavBench/HuNavSim artifact export. | Not met. This PR intentionally stops at local prerequisite preflight because external assets/adapters are not staged. |

## Follow-Up Issues

- #1456: stage SocNavBench control-pipeline assets required before runnable SocNavBench export.
- #1134: stage official SocNavBench ETH mesh/traversible inputs and validate generated map assets.

The live #3285 thread still names #2414 in the HuNavSim prerequisite lineage, but #2414 is closed;
this PR does not create or assume a new HuNavSim follow-up issue.

## Propagation

Durable state surface updated in `docs/context/issue_3285_scenario_interop_converter.md`. No separate issue comment is posted from this run because the issue is high-churn and this authorization has `comment_issue_or_pr: false`.

<details>
<summary>Artifact handling</summary>

The CLI smoke wrote temporary files under `output/issue_3285_target_prerequisite_smoke/`; they were inspected and removed. Full readiness produced ignored coverage/readiness artifacts under `output/`, which remain untracked and are not durable evidence for this PR.

</details>
