### PR TITLE
Issue #4013: expose real-trajectory staging checksum

### DIFF
--- a/scripts/tools/check_real_trajectory_manifest.py
+++ b/scripts/tools/check_real_trajectory_manifest.py
@@ -28,6 +28,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from robot_sf.data_ingestion.real_trajectory_contract import (
     ContractError,
+    _resolved_staging_dir,
+    _staging_tree_sha256,
     load_manifest,
     run_preflight,
 )
@@ -39,7 +41,51 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--json", action="store_true", help="Emit a machine-readable JSON report instead of text."
     )
+    parser.add_argument(
+        "--staging-checksum",
+        action="store_true",
+        help=(
+            "Include the resolved staging directory and aggregate SHA-256 tree checksum when "
+            "staging files are locally available."
+        ),
+    )
     return parser
+
+
+def _staging_tree_report(manifest: dict) -> dict[str, object]:
+    staging = manifest.get("staging", {})
+    staging_dir = staging.get("staging_dir") if isinstance(staging, dict) else None
+    if not isinstance(staging_dir, str):
+        return {"available": False, "reason": "manifest.staging.staging_dir missing"}
+
+    resolved = _resolved_staging_dir(staging_dir)
+    if "$" in str(resolved):
+        return {
+            "available": False,
+            "staging_dir": str(resolved),
+            "reason": "environment variable unresolved",
+        }
+    if not resolved.is_dir():
+        return {
+            "available": False,
+            "staging_dir": str(resolved),
+            "reason": "staging directory missing",
+        }
+
+    file_count = sum(1 for path in resolved.rglob("*") if path.is_file())
+    if file_count == 0:
+        return {
+            "available": False,
+            "staging_dir": str(resolved),
+            "file_count": 0,
+            "reason": "staging directory empty",
+        }
+    return {
+        "available": True,
+        "staging_dir": str(resolved),
+        "file_count": file_count,
+        "tree_sha256": _staging_tree_sha256(resolved),
+    }
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -68,6 +114,8 @@ def main(argv: list[str] | None = None) -> int:
                 for i in result.issues
             ],
         }
+        if args.staging_checksum:
+            payload["staging_tree"] = _staging_tree_report(manifest)
         print(json.dumps(payload, indent=2))
     else:
         status = "OK" if result.ok else "FAIL"
@@ -76,6 +124,8 @@ def main(argv: list[str] | None = None) -> int:
             f"  availability={result.availability} "
             f"benchmark_eligibility={result.benchmark_eligibility}"
         )
+        if args.staging_checksum:
+            print(f" staging_tree={_staging_tree_report(manifest)}")
         for issue in result.issues:
             print(f"  [{issue.severity}] {issue.code}: {issue.message}")
 

--- a/tests/data/test_real_trajectory_contract.py
+++ b/tests/data/test_real_trajectory_contract.py
@@ -6,6 +6,7 @@ never download, stage, or read real external data.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import jsonschema
@@ -20,6 +21,7 @@ from robot_sf.data_ingestion import (
     validate_manifest_structure,
 )
 from robot_sf.data_ingestion import real_trajectory_contract as contract
+from scripts.tools.check_real_trajectory_manifest import main as check_manifest_main
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLE_MANIFEST = REPO_ROOT / "configs" / "data" / "real_trajectory_manifest.example.yaml"
@@ -255,6 +257,41 @@ def test_validated_staging_tree_must_match_recorded_checksum(
 
     assert not result.ok
     assert any(i.code == "checksums.staging_tree_mismatch" for i in result.errors)
+
+
+def test_manifest_cli_reports_staging_tree_checksum(
+    valid_manifest: dict,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The manifest CLI exposes local staging checksum evidence for #4013 Phase 3."""
+
+    data_root = tmp_path / "external_data"
+    staging_dir = data_root / "synthetic_byo"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "trajectories.csv").write_text("frame,ped_id,x,y\n0,1,0,0\n", encoding="utf-8")
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(data_root))
+    valid_manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
+    valid_manifest["availability"] = "validated"
+    valid_manifest["benchmark_eligibility"] = "benchmark_candidate"
+    tree_sha256 = contract._staging_tree_sha256(staging_dir)
+    valid_manifest["checksums"]["tree_sha256"] = tree_sha256
+    valid_manifest["checksums"]["expected_tree_sha256"] = tree_sha256
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(valid_manifest), encoding="utf-8")
+
+    exit_code = check_manifest_main([str(manifest_path), "--json", "--staging-checksum"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["staging_tree"] == {
+        "available": True,
+        "staging_dir": str(staging_dir),
+        "file_count": 1,
+        "tree_sha256": tree_sha256,
+    }
 
 
 def test_validated_checksums_must_be_pinned_consistently(


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds `--staging-checksum` to `scripts/tools/check_real_trajectory_manifest.py` so local BYO ETH/BIWI staging can produce the exact checksum evidence required by the #4013 Phase 3 gate using the same resolver and aggregate tree SHA-256 helper as fail-closed preflight.

Why now: the live #4013 audit after PR #4719 shows diagnostic criteria are met, but closure remains blocked on a reachable checksum-pinned ETH/BIWI staging root, real-trajectory training, and representative evaluation. This is a progression slice toward the first remaining blocker, not another audit refresh.

Claim boundary: local manifest/staging checksum tooling only. This PR does not stage or redistribute raw external data, run real-trajectory training, run a benchmark campaign, or make benchmark, navigation-quality, paper, or dissertation claims.

Required validation: focused real-trajectory contract tests, Ruff on touched Python, `git diff --check`, and the manifest CLI against the tracked #4013 manifest.

Remaining blocker: `ROBOT_SF_EXTERNAL_DATA_ROOT` is still unset here, so the tracked #4013 manifest reports `staging_tree.available=false` with reason `environment variable unresolved`; real ETH/BIWI data staging, real-trajectory training, and representative evaluation remain open.

Refs #4013

## Contract delta

- New CLI option: `scripts/tools/check_real_trajectory_manifest.py --staging-checksum` adds a `staging_tree` JSON/text block with resolved staging directory, file count, and `tree_sha256` when local files are available.
- New fail-closed output states: unresolved environment variable, missing staging directory, empty staging directory, or missing manifest staging path are reported without downloading or modifying data.
- Compatibility impact: additive CLI output only; existing exit-code behavior and manifest preflight semantics are unchanged.

## Scope summary

- Kept #4013 open because PR #4719's acceptance audit remains partial.
- Added the smallest CPU-only capability needed to move the reachable checksum-pinned staging criterion forward.
- Added focused synthetic tests; no external data is downloaded, staged, committed, or required.

## Acceptance evidence

| Criterion | Evidence | Status |
| --- | --- | --- |
| Short-horizon predictor contract and learned backend exist. | PRs #4474/#4629 and `training_manifest.v1.json`. | Met |
| Short-horizon predictor trains or fails closed with dataset blocker. | PR #4629 diagnostic training; readiness/audit artifacts keep real-data blocker explicit. | Met at diagnostic tier |
| Model-based action selection runs on a smoke scenario. | PR #4644/#4655 diagnostic smoke comparison. | Met at diagnostic tier |
| Comparator smoke includes `cv_prediction_mpc` and one model-free baseline. | `comparison_report.v1.json` roles include all three arms. | Met at diagnostic tier |
| Fallback/degraded rows are excluded or marked non-evidence. | `comparison_report.v1.json` fallback/degraded summary remains clean. | Met |
| Claim boundary excludes large world-model and paper-grade claims. | Existing design/evidence docs and PR body keep diagnostic tier boundary. | Met |
| Real pedestrian trajectory dataset is reachable and checksum-pinned. | This PR adds the local checksum reporting capability; current command reports unresolved `${ROBOT_SF_EXTERNAL_DATA_ROOT}`. | Partial |
| Real-trajectory predictor training has run on validated data. | No validated data root here; not run. | Blocked |
| Representative evaluation compares learned predictor against `cv_prediction_mpc` and a model-free baseline. | Requires validated real-data training first; not run. | Blocked |

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/data/test_real_trajectory_contract.py -q` passed, 25 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/data_ingestion/real_trajectory_contract.py scripts/tools/check_real_trajectory_manifest.py tests/data/test_real_trajectory_contract.py` passed.
- `git diff --check` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/check_real_trajectory_manifest.py configs/data/issue_4013_eth_biwi_real_trajectory_manifest.yaml --json --staging-checksum` exited 1 as expected for the current machine state; decisive line: `staging_tree.available=false`, `reason=environment variable unresolved`.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no raw external dataset staging or redistribution, no real-trajectory training run, no representative evaluation run, no paper/dissertation claim edits.

## Domain-Aware Approval

Required PR: yes
Required: yes
- Required PR: yes
- Reason: domain-aware approval required because evidence-validity terms appear while #4013 remains diagnostic tier.
- Domains reviewed: evidence classification, manuscript claims.
- Status: waived
- Approval or blocker note: self-review waiver; this PR does not promote a benchmark, navigation-quality, safety, paper, or dissertation claim and only exposes existing fail-closed staging checksum procedure through CLI output.
- Validity checklist:
  - Target claim/hypothesis: local staged-data checksum reporting uses the same resolver and tree hash as real-trajectory manifest preflight.
  - Comparator or split/evidence validity: NA, no empirical comparison or data split added.
  - Fallback/degraded exclusions: unchanged; no benchmark rows produced.
  - Claim boundary: no real-data availability, training, representative evaluation, benchmark, or manuscript claim is made.
  - Implementation integrity vs experimental validity: tests prove checksum output shape and consistency, not planner quality.

## State propagation

No issue comment was posted because this run's authorization has `comment_issue_or_pr=false`. High-churn #4013 state remains canonical in the existing acceptance audit artifact from PR #4719 plus this PR body; no transient queue-routing state is encoded in tracked files.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: more than two #4013 guard/checker/audit PRs merged in the last 24 hours. This PR is a progression slice because it adds a nameable capability: CLI local staged-data checksum reporting with the same hash procedure as fail-closed preflight.

Late guidance check: immediately before commit/PR publication, `gh issue view 4013 --repo ll7/robot_sf_ll7 --comments` showed no maintainer comments newer than this run's start; latest state update remains PR #4719 at 2026-07-07T02:51:07Z.

Open PR dedupe: open PR search for #4013 / issue-4013 / real trajectory staging checksum returned `[]`.

Artifact policy: no raw external data, benchmark outputs, checkpoints, videos, or large logs are committed.

</details>
