### PR TITLE
Issue #3285: include traversible provenance prerequisite

### DIFF
--- a/robot_sf/benchmark/scenario_interop.py
+++ b/robot_sf/benchmark/scenario_interop.py
@@ -144,6 +144,13 @@ _TARGET_PREREQUISITES: dict[str, tuple[dict[str, Any], ...]] = {
             "reason": "Official SocNavBench ETH mesh directory is required for ETH map export.",
         },
         {
+            "code": "socnavbench_eth_traversible_provenance",
+            "issue": 1498,
+            "path": "docs/context/issue_1498_state.yaml",
+            "kind": "file",
+            "reason": "SocNavBench ETH traversible staging provenance is required before export.",
+        },
+        {
             "code": "socnavbench_eth_traversible_pickle",
             "issue": 1134,
             "path": (

--- a/tests/benchmark/test_scenario_interop_target_compatibility.py
+++ b/tests/benchmark/test_scenario_interop_target_compatibility.py
@@ -258,9 +258,10 @@ def test_target_prerequisite_report_fails_closed_for_missing_paths(tmp_path: Pat
     assert {item["code"] for item in report["remaining_blockers"]} == {
         "socnavbench_control_assets",
         "socnavbench_eth_mesh",
+        "socnavbench_eth_traversible_provenance",
         "socnavbench_eth_traversible_pickle",
     }
-    assert {item["issue"] for item in report["remaining_blockers"]} == {1456, 1134}
+    assert {item["issue"] for item in report["remaining_blockers"]} == {1456, 1498, 1134}
     assert "benchmark evidence" in report["claim_boundary"]
     assert validate_target_prerequisite_report(report) == []
 
@@ -271,6 +272,9 @@ def test_target_prerequisite_report_passes_when_expected_paths_exist(tmp_path: P
     (tmp_path / "third_party/socnavbench/sd3dis/stanford_building_parser_dataset/mesh/ETH").mkdir(
         parents=True
     )
+    provenance = tmp_path / "docs/context/issue_1498_state.yaml"
+    provenance.parent.mkdir(parents=True)
+    provenance.write_text("status: staged_verified_ready_for_eth_first\n", encoding="utf-8")
     traversible = (
         tmp_path
         / "third_party/socnavbench/sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl"


### PR DESCRIPTION
## Reviewer-critical summary
What changed: the SocNavBench target prerequisite report now includes the tracked #1498 ETH traversible provenance/state manifest as a first-class prerequisite, alongside #1456 control assets and #1134 ETH mesh/traversible files.

Why now: the latest #3285 owner note after PR #4730 says runnable export remains blocked on #1456/#1498/#2414/#1134, but the executable SocNavBench prerequisite report only surfaced #1456 and #1134.

Claim boundary: this is a local, read-only prerequisite-report contract update. It does not emit runnable SocNavBench or HuNavSim artifacts and is not benchmark evidence.

Required validation: focused prerequisite-report tests, touched-file lint/format, generated CLI prerequisite report, and PR-ready wrapper.

Remaining blocker: runnable external export still depends on external assets/adapters; this PR intentionally uses `Refs #3285`, not `Closes #3285`.

## Contract delta
- New schema fields: none.
- New fail-closed blockers: `socnavbench_eth_traversible_provenance` in `build_target_prerequisite_report(..., target="socnavbench")`.
- Compatibility impact: additive prerequisite item in the existing v1 report shape; consumers that iterate `prerequisites` or `remaining_blockers` continue to work. Consumers assuming exactly three SocNavBench prerequisites should update to treat the list as extensible.
- Fragmentation guard: this is a progression/integration slice, not a guard packet. It makes the existing executable report cover the full issue-listed SocNavBench prerequisite chain.

<details>
<summary>PR template details</summary>

## Summary
Adds #1498 provenance/state tracking to the executable SocNavBench prerequisite report for #3285.

## Linked Issues
- Refs #3285
- Relates #1498
- Relates #1456
- Relates #1134

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #1456, #1134
- Safe review independently: yes
- Review dependency reason, any: additive prerequisite-report contract only

## What Changed
- Added `socnavbench_eth_traversible_provenance` to `_TARGET_PREREQUISITES["socnavbench"]`.
- Updated focused tests so missing-path reports include #1498 and synthetic ready reports create the provenance manifest.

## Why Matters
- Added value: the executable report now matches the complete #3285 issue-linked prerequisite chain for SocNavBench export readiness.
- Expected impact: prevents closure audits and downstream tooling from losing #1498 when interpreting local prerequisite readiness.
- Why worth merging now: #3285 is high-churn after multiple merged slices; this consolidates one real contract mismatch rather than adding another prose-only audit.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3285 SocNavBench runnable-export prerequisite reporting.
- Comparator or baseline, applicable: previous report omitted #1498 from SocNavBench prerequisites.
- Evidence tier: NA - prerequisite-report support helper; validation uses focused tests and a generated report.
- Result classification: NA - no benchmark or research result claimed.
- Decision stop rule, applicable: report includes #1498 as present when tracked state exists and still blocks on #1456/#1134 when external paths are absent.
- Parent issue, claim map, registry, context note, synthesis surface update: #3285 PR body carries state propagation; no issue comment due task authorization.
- New research/benchmark/metric/paper-facing analysis tool, any: none; existing prerequisite report updated.

## Domain-Aware Approval
- approval concerns experimental validity waived / pending / blocked / not required: not required.
- Approver/review source waiver: no benchmark or paper-facing claim.
- Validity checklist: local prerequisite contract only.
- Target claim/hypothesis: executable prerequisite completeness for #3285.
- Comparator split/evidence validity: NA - no experimental comparator; implementation proof is focused tests plus generated report.
- Fallback/degraded exclusions: no fallback/degraded benchmark rows used.
- Claim boundary: not runnable target export, not benchmark evidence.
- Implementation integrity vs experimental validity: implementation integrity only.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes; generated report lists #1498 prerequisite as present from `docs/context/issue_1498_state.yaml`.
- Did intervention change command source, selected command, trajectory, route progress? no runtime benchmark path changed.
- Did scenario actually contain targeted failure mode? yes; prior report contract omitted #1498.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: none.

## Next Empirical Action
- Rerun needed: yes, after #1456/#1134 assets are staged.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: SocNavBench control assets and ETH mesh/traversible files remain missing on this checkout.
- Stop / revise / continue decision: continue only through external-asset staging issues.
- Proposed child issue existing follow-up: #1456 and #1134.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_scenario_interop_target_compatibility.py -q` - passed, 13 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/scenario_interop.py tests/benchmark/test_scenario_interop_target_compatibility.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/convert_scenario_interop.py --matrix configs/baselines/example_matrix.yaml --target socnavbench --target-prerequisite-out-dir <artifact-dir>` - passed; sample report status `blocked`, #1498 present, #1456/#1134 remaining blockers.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=<artifact> scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh` - passed; stamp `output/validation/pr_ready/issue-3285-closure-audit-20260707c.json` for head `59b4b166`.

## Performance / Runtime
- Baseline runtime: NA, no runtime benchmark path changed.
- Changed runtime: NA, no runtime benchmark path changed.
- Representative command: focused pytest command above.
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: prerequisite report omits an issue-linked SocNavBench export prerequisite or schema validation fails.

## Risks / Rollout
- Compatibility risks: consumers with hard-coded SocNavBench prerequisite count may need to accept an additive item.
- Failure modes: #1498 state manifest could move in a future state-surface cleanup; tests pin the path.
- Rollback fallback plan: revert the additive prerequisite item and test updates.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: `docs/context/issue_3285_scenario_interop_converter.md`, `docs/context/issue_1498_state.yaml`.
- Any assumptions need to preserved: #1498 is represented by the tracked state manifest; #1134 still owns the actual traversible pickle requirement.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: task authorization disallows issue comments; this PR body is the compact state surface. No benchmark, registry, claim-map, or paper-facing changes.

## Follow-Up Issues
- Deferred work: runnable SocNavBench/HuNavSim export remains blocked on external assets/adapters.
- Issues opened follow-up: none; existing #1456 and #1134 remain the next actions.

## Reviewer Notes
- Anything reviewer verify closely: generated report should list #1498 under `prerequisites`, not under `remaining_blockers` when run from repo root.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

</details>
