### PR TITLE
fix: enforce staged checkpoint preflight for issue #4663

### DIFF
--- a/docs/context/issue_4365_h600_hybrid_vs_orca_s30_preregistration.md
+++ b/docs/context/issue_4365_h600_hybrid_vs_orca_s30_preregistration.md
@@ -64,6 +64,16 @@ The canonical focused validation command is:
 uv run pytest tests/benchmark/test_h600_hybrid_vs_orca_s30_config.py
 ```
 
+## Submit-Time Checkpoint Gate
+
+Before any S30 requeue or resume-append submission for this campaign, the submit path must run
+enforced staged checkpoint preflight (`checkpoint_preflight_mode="enforced_staged"`), which writes
+`preflight/checkpoint_staging.json` and uses `stage: true`. A `stageable_remote` checkpoint reference
+is not submit-safe by itself; the checkpoint must be staged and checksum-verified into the durable
+`output/model_cache` location (or an explicit submit cache) that the compute node will load. This
+note does not authorize a fresh output root, Slurm/GPU submission, benchmark interpretation, or
+paper/dissertation claim edit.
+
 ## Terminality Status
 
 PR #4368 landed the complete issue #4365 config and preflight-only slice on 2026-07-04:

--- a/robot_sf/benchmark/camera_ready/_legacy_campaign_facade.py
+++ b/robot_sf/benchmark/camera_ready/_legacy_campaign_facade.py
@@ -199,6 +199,8 @@ def prepare_campaign_preflight(
     label: str | None = None,
     campaign_id: str | None = None,
     invoked_command: str | None = None,
+    checkpoint_preflight_mode: str = "metadata_only",
+    checkpoint_cache_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Prepare campaign preflight artifacts via the extracted preflight module.
 
@@ -211,6 +213,8 @@ def prepare_campaign_preflight(
         label=label,
         campaign_id=campaign_id,
         invoked_command=invoked_command,
+        checkpoint_preflight_mode=checkpoint_preflight_mode,
+        checkpoint_cache_dir=checkpoint_cache_dir,
         validate_campaign_config=_validate_campaign_config,
         build_route_clearance_warnings=_build_route_clearance_warnings,
     )

--- a/robot_sf/benchmark/camera_ready/_preflight.py
+++ b/robot_sf/benchmark/camera_ready/_preflight.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
 
 import yaml
 
@@ -39,6 +40,7 @@ from robot_sf.benchmark.camera_ready._util import (
     _utc_now,
 )
 from robot_sf.benchmark.campaign_checkpoint_preflight import (
+    CampaignCheckpointPreflightError,
     check_campaign_arm_checkpoints_preflight,
 )
 from robot_sf.benchmark.latency_stress import not_available_latency_metrics
@@ -51,10 +53,40 @@ from robot_sf.benchmark.utils import _config_hash
 from robot_sf.common.artifact_paths import ensure_canonical_tree, get_artifact_category_path
 
 CAMPAIGN_SCHEMA_VERSION = "benchmark-camera-ready-campaign.v1"
+CheckpointPreflightMode = Literal["metadata_only", "enforced_staged"]
+
+
+def _checkpoint_staging_report_payload(
+    *,
+    mode: CheckpointPreflightMode,
+    cache_dir: Path | None,
+    summary: dict[str, Any] | None = None,
+    blocker: str | None = None,
+    arms: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Build persisted submit-safety report for campaign checkpoint preflight.
+
+    Returns:
+        JSON-serializable checkpoint staging report payload.
+    """
+    stage = mode == "enforced_staged"
+    return {
+        "schema_version": "campaign-checkpoint-staging-preflight.v1",
+        "mode": mode,
+        "stage": stage,
+        "submit_safe": bool(stage and blocker is None),
+        "cache_dir": str(cache_dir) if cache_dir is not None else None,
+        "status": "blocked" if blocker is not None else "ok",
+        "checked": int((summary or {}).get("checked", 0)),
+        "resolved": int((summary or {}).get("resolved", 0)),
+        "arms": list((summary or {}).get("arms", [])),
+        "blocked_arms": list(arms),
+        "blocker": blocker,
+    }
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
     from robot_sf.benchmark.camera_ready._config_types import CampaignConfig
 
@@ -228,13 +260,15 @@ def _build_preflight_preview_payload(
     return payload
 
 
-def prepare_campaign_preflight(
+def prepare_campaign_preflight(  # noqa: C901, PLR0913, PLR0915
     cfg: CampaignConfig,
     *,
     output_root: Path | None = None,
     label: str | None = None,
     campaign_id: str | None = None,
     invoked_command: str | None = None,
+    checkpoint_preflight_mode: CheckpointPreflightMode = "metadata_only",
+    checkpoint_cache_dir: Path | None = None,
     validate_campaign_config: Callable[[CampaignConfig], None] | None = None,
     build_route_clearance_warnings: Callable[..., list[dict[str, Any]]] | None = None,
 ) -> dict[str, Any]:
@@ -259,11 +293,12 @@ def prepare_campaign_preflight(
 
     validate_campaign_config(cfg)
     check_orca_rvo2_preflight(cfg)
-    # Fail fast when an enabled arm names a checkpoint that cannot be resolved (unknown/mistyped
-    # model_id, local_only-missing, or a missing model_path file) before any scenario loads. This
-    # is the cheap network-free guard; the enforced download+checksum staging step (stage=True) is
-    # run pre-sbatch by scripts/benchmark/preflight_campaign_checkpoints.py (issue #4613).
-    check_campaign_arm_checkpoints_preflight(cfg)
+    if checkpoint_preflight_mode not in ("metadata_only", "enforced_staged"):
+        raise ValueError(f"unknown checkpoint_preflight_mode: {checkpoint_preflight_mode!r}")
+    checkpoint_stage = checkpoint_preflight_mode == "enforced_staged"
+    resolved_checkpoint_cache_dir = (
+        checkpoint_cache_dir if checkpoint_cache_dir is not None else Path("output/model_cache")
+    )
     ensure_canonical_tree(categories=("benchmarks",))
     campaign_id = _resolve_campaign_id(cfg, label=label, campaign_id=campaign_id)
     base_dir = (
@@ -274,6 +309,38 @@ def prepare_campaign_preflight(
     campaign_root = (base_dir / campaign_id).resolve()
     reports_dir = campaign_root / "reports"
     preflight_dir = campaign_root / "preflight"
+    checkpoint_staging_path = preflight_dir / "checkpoint_staging.json"
+    # Fail fast when an enabled arm names a checkpoint that cannot be resolved (unknown/mistyped
+    # model_id, local_only-missing, or a missing model_path file) before any scenario loads. This
+    # is the cheap network-free guard; the enforced download+checksum staging step (stage=True) is
+    # run pre-sbatch by scripts/benchmark/preflight_campaign_checkpoints.py (issue #4613).
+    try:
+        checkpoint_summary = check_campaign_arm_checkpoints_preflight(
+            cfg,
+            stage=checkpoint_stage,
+            cache_dir=resolved_checkpoint_cache_dir if checkpoint_stage else None,
+        )
+    except CampaignCheckpointPreflightError as exc:
+        if checkpoint_stage:
+            _write_json(
+                checkpoint_staging_path,
+                _checkpoint_staging_report_payload(
+                    mode=checkpoint_preflight_mode,
+                    cache_dir=resolved_checkpoint_cache_dir,
+                    blocker=str(exc),
+                    arms=exc.arms,
+                ),
+            )
+        raise
+    if checkpoint_stage:
+        _write_json(
+            checkpoint_staging_path,
+            _checkpoint_staging_report_payload(
+                mode=checkpoint_preflight_mode,
+                cache_dir=resolved_checkpoint_cache_dir,
+                summary=checkpoint_summary,
+            ),
+        )
     reports_dir.mkdir(parents=True, exist_ok=True)
     preflight_dir.mkdir(parents=True, exist_ok=True)
 
@@ -483,6 +550,9 @@ def prepare_campaign_preflight(
         "artifacts": {
             "preflight_validate_config": _repo_relative(validate_config_path),
             "preflight_preview_scenarios": _repo_relative(preview_scenarios_path),
+            "preflight_checkpoint_staging": (
+                _repo_relative(checkpoint_staging_path) if checkpoint_stage else None
+            ),
             "matrix_summary_json": _repo_relative(matrix_summary_json_path),
             "matrix_summary_csv": _repo_relative(matrix_summary_csv_path),
             "amv_coverage_json": _repo_relative(amv_coverage_json_path),
@@ -504,6 +574,7 @@ def prepare_campaign_preflight(
         "campaign_root": campaign_root,
         "reports_dir": reports_dir,
         "preflight_dir": preflight_dir,
+        "checkpoint_staging_path": checkpoint_staging_path if checkpoint_stage else None,
         "validate_config_path": validate_config_path,
         "preview_scenarios_path": preview_scenarios_path,
         "matrix_summary_json_path": matrix_summary_json_path,

--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -648,6 +648,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
         label=label,
         campaign_id=campaign_id,
         invoked_command=invoked_command,
+        checkpoint_preflight_mode="enforced_staged",
     )
     campaign_id = str(prepared["campaign_id"])
     campaign_root = Path(prepared["campaign_root"])

--- a/robot_sf/benchmark/campaign_checkpoint_preflight.py
+++ b/robot_sf/benchmark/campaign_checkpoint_preflight.py
@@ -457,6 +457,12 @@ def check_campaign_arm_checkpoints_preflight(
                 "kind": resolution.reference.kind,
                 "value": resolution.reference.value,
                 "status": resolution.status,
+                "detail": resolution.detail,
+                "algo_config_path": (
+                    str(resolution.reference.algo_config_path)
+                    if resolution.reference.algo_config_path is not None
+                    else None
+                ),
                 "resolved_path": (
                     str(resolution.resolved_path) if resolution.resolved_path is not None else None
                 ),

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -4108,6 +4108,40 @@ def test_run_campaign_checks_orca_rvo2_before_loading_optional_artifacts(
         run_campaign(cfg, output_root=tmp_path / "out", label="orca")
 
 
+def test_run_campaign_requests_enforced_staged_checkpoint_preflight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Campaign runs use submit-safe checkpoint staging, not metadata-only preflight."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text("scenarios: []\n", encoding="utf-8")
+    cfg = CampaignConfig(
+        name="checkpoint_submit_mode",
+        scenario_matrix_path=scenario_path,
+        planners=(PlannerSpec(key="goal", algo="goal"),),
+        seed_policy=SeedPolicy(),
+    )
+    observed: dict[str, object] = {}
+
+    def fake_prepare_campaign_preflight(*_args: object, **kwargs: object) -> dict[str, object]:
+        observed.update(kwargs)
+        raise RuntimeError("stop after preflight mode assertion")
+
+    monkeypatch.setattr(
+        camera_ready_campaign_module,
+        "prepare_campaign_preflight",
+        fake_prepare_campaign_preflight,
+    )
+
+    with pytest.raises(RuntimeError, match="stop after preflight mode assertion"):
+        run_campaign(
+            cfg,
+            output_root=tmp_path / "out",
+            label="submit-mode",
+        )
+
+    assert observed["checkpoint_preflight_mode"] == "enforced_staged"
+
+
 def test_run_campaign_sanitizes_run_directory_keys(tmp_path: Path, monkeypatch) -> None:
     """Planner run directories should use sanitized planner/kinematics identifiers."""
     scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")

--- a/tests/benchmark/test_campaign_checkpoint_preflight.py
+++ b/tests/benchmark/test_campaign_checkpoint_preflight.py
@@ -8,6 +8,7 @@ a temporary registry fixture (present ``local_path`` => resolvable; absent/unkno
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 import pytest
@@ -278,3 +279,67 @@ def test_prepare_campaign_preflight_rejects_missing_checkpoint_before_scenarios(
 
     with pytest.raises(CampaignCheckpointPreflightError, match="unknown_model_id"):
         prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="ckpt")
+
+
+def test_prepare_campaign_preflight_enforced_stage_writes_submit_safe_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Submit-mode preflight stages and records a submit-safe checkpoint report."""
+    model_path = tmp_path / "model" / "policy.zip"
+    model_path.parent.mkdir(parents=True)
+    model_path.write_text("checkpoint", encoding="utf-8")
+    algo_config = _write_algo_config(
+        tmp_path, "ppo.yaml", {"algo": "ppo", "model_path": str(model_path)}
+    )
+    cfg = _campaign(
+        (PlannerSpec(key="ppo", algo="ppo", algo_config_path=algo_config),), tmp_path=tmp_path
+    )
+    monkeypatch.setattr(preflight_module, "_load_campaign_scenarios", lambda _cfg: [])
+
+    prepared = prepare_campaign_preflight(
+        cfg,
+        output_root=tmp_path / "out",
+        label="ckpt",
+        checkpoint_preflight_mode="enforced_staged",
+        checkpoint_cache_dir=tmp_path / "submit-cache",
+    )
+
+    report_path = prepared["checkpoint_staging_path"]
+    assert report_path is not None
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["mode"] == "enforced_staged"
+    assert report["stage"] is True
+    assert report["submit_safe"] is True
+    assert report["cache_dir"] == str(tmp_path / "submit-cache")
+    assert report["arms"][0]["planner_key"] == "ppo"
+    assert report["arms"][0]["status"] == "present_local"
+
+
+def test_prepare_campaign_preflight_enforced_stage_writes_blocked_report(
+    tmp_path: Path,
+) -> None:
+    """Submit-mode preflight records blocked checkpoint staging before raising."""
+    algo_config = _write_algo_config(
+        tmp_path, "ppo.yaml", {"algo": "ppo", "model_id": "definitely_missing_4663"}
+    )
+    cfg = _campaign(
+        (PlannerSpec(key="ppo", algo="ppo", algo_config_path=algo_config),), tmp_path=tmp_path
+    )
+    output_root = tmp_path / "out"
+
+    with pytest.raises(CampaignCheckpointPreflightError, match="stage_failed"):
+        prepare_campaign_preflight(
+            cfg,
+            output_root=output_root,
+            label="ckpt",
+            checkpoint_preflight_mode="enforced_staged",
+            checkpoint_cache_dir=tmp_path / "submit-cache",
+        )
+
+    report_path = next(output_root.glob("*/preflight/checkpoint_staging.json"))
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["mode"] == "enforced_staged"
+    assert report["submit_safe"] is False
+    assert report["status"] == "blocked"
+    assert report["blocked_arms"] == ["ppo"]
+    assert "definitely_missing_4663" in report["blocker"]


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `run_campaign()` now invokes camera-ready preflight with `checkpoint_preflight_mode="enforced_staged"`, so learned-arm `model_id` references call `check_campaign_arm_checkpoints_preflight(..., stage=True, cache_dir=...)` before campaign execution. Direct `prepare_campaign_preflight()` calls remain `metadata_only` by default for offline validation.

Why now: issue #4663 identified that #4620's checkpoint preflight was available but the actual camera-ready submit/run path still used the non-staging default, allowing `stageable_remote` to pass without a staged cache.

Claim boundary: this is CPU-only code/test evidence for the submit-path preflight contract. It does not run a full benchmark campaign, submit Slurm/GPU work, or edit paper/dissertation claims.

Required validation: focused tests and lint over the checkpoint preflight and camera-ready campaign surfaces.

Remaining blocker: none for the CPU-side enforcement contract. Empirical S30 campaign execution remains out of scope and requires separate submit authorization.

Closes #4663

## Contract delta

- New explicit preflight mode surface: `checkpoint_preflight_mode: metadata_only | enforced_staged` on `prepare_campaign_preflight(...)`.
- Submit/run path default: `run_campaign()` requests `enforced_staged`; direct/offline preflight retains `metadata_only`.
- New persisted pre-submit report: `preflight/checkpoint_staging.json` when enforced mode is used.
- New report fields: `schema_version`, `mode`, `stage`, `submit_safe`, `cache_dir`, `checked`, `resolved`, `arms`, `blocked_arms`, `blocker`.
- Per-arm checkpoint summaries now include `detail` and `algo_config_path` for actionable submit blockers.
- Compatibility impact: existing callers that do not pass `checkpoint_preflight_mode` keep metadata-only behavior; legacy facade forwards the new explicit parameters.

## Scope summary

- Wired enforced staged checkpoint validation into the actual camera-ready campaign run path.
- Persisted successful and blocked enforced-staging reports before scenario loading.
- Added focused CPU tests for submit-mode wiring, submit-safe report emission, and blocked report emission.
- Updated the S30 preregistration context note to record mandatory submit-time checkpoint staging without encoding transient queue or host state.

## Validation

- `uv run ruff check robot_sf/benchmark/campaign_checkpoint_preflight.py robot_sf/benchmark/camera_ready/_preflight.py robot_sf/benchmark/camera_ready/campaign.py robot_sf/benchmark/camera_ready/_legacy_campaign_facade.py scripts/benchmark/preflight_campaign_checkpoints.py tests/benchmark/test_campaign_checkpoint_preflight.py tests/benchmark/test_camera_ready_campaign.py`
  - Result: passed
- `uv run pytest tests/benchmark/test_campaign_checkpoint_preflight.py tests/benchmark/test_camera_ready_campaign.py -q`
  - Result: passed, `150 passed`
- `git diff --check`
  - Result: passed

## Explicit out-of-scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## State propagation

No issue comment was added because this run was authorized with `comment_issue_or_pr: false`. Durable propagation is included in the PR body and the tracked S30 context note update.

<details>
<summary>Appendix: freshness and guardrails</summary>

- Live issue #4663 comments were read before implementation and rechecked immediately before PR creation.
- No open PR duplicate was found for issue #4663 or the enforced staged checkpoint scope.
- Fragmentation guard: only predecessor #4620 was found as merged coverage for this scope; this PR adds the new named capability "enforced staged checkpoint validation in the submit/run path."
- Forbidden actions confirmed: no compute submission, no merge, no release, no deletion.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staged checkpoint preflight checks for campaign submissions, with clearer reporting when required checkpoints are present or missing.
  * Campaign preflight now saves a checkpoint staging report that summarizes readiness and any blocking issues.

* **Bug Fixes**
  * Prevents submission workflows from proceeding without verified checkpoint availability.
  * Improves error reporting for missing or unresolvable checkpoints during preflight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->