### PR TITLE
Issue #3463: add topology blocker triage report

### DIFF
--- a/docs/context/evidence/issue_3463_topology_reselection_cross_slice_2026-07-05/report.md
+++ b/docs/context/evidence/issue_3463_topology_reselection_cross_slice_2026-07-05/report.md
@@ -1,9 +1,9 @@
-# Issue #3463 — Topology Reselection Cross-Slice Diagnostic
+# Issue #3463 - Topology Reselection Cross-Slice Diagnostic
 
 Claim boundary: `diagnostic_only_not_benchmark_or_paper_evidence`.
 Classification: `blocked`.
 
-At least one progress-gated row did not produce diagnostic evidence.
+Progress-gated rows failed closed before producing diagnostic evidence: doorway_transfer:obstacle_collision.
 
 ## Decision Table
 
@@ -29,6 +29,12 @@ At least one progress-gated row did not produce diagnostic evidence.
 | simple_negative_control | negative_control | progress_gated | 0.05 | diagnostic_complete | success | 1.8000000268220901 | 0 | 0 | 0.0 |
 | simple_negative_control | negative_control | progress_gated | 0.1 | diagnostic_complete | success | 1.8000000268220901 | 0 | 0 | 0.0 |
 | simple_negative_control | negative_control | progress_gated | 0.2 | diagnostic_complete | success | 1.8000000268220901 | 0 | 0 | 0.0 |
+
+## Fail-Closed Blockers
+
+| Slice | Scenario | Outcome | Status counts | Candidate roles | Thresholds m | Rows | Route progress m | Next action |
+|---|---|---|---|---|---:|---:|---:|---|
+| doorway_transfer | classic_doorway_medium | obstacle_collision | not_available=5 | baseline, reuse_penalty, progress_gated | 0.05, 0.1, 0.2 | 5 | -12.02842730398372 | repair or replace this slice before benchmark-facing promotion |
 
 ## Caveats
 

--- a/docs/context/evidence/issue_3463_topology_reselection_cross_slice_2026-07-05/summary.json
+++ b/docs/context/evidence/issue_3463_topology_reselection_cross_slice_2026-07-05/summary.json
@@ -1,7 +1,34 @@
 {
+  "blockers": [
+    {
+      "candidate_roles": [
+        "baseline",
+        "reuse_penalty",
+        "progress_gated"
+      ],
+      "classification": "fail_closed_not_success_evidence",
+      "diagnostic_status_counts": {
+        "not_available": 5
+      },
+      "max_collision_rate": 1.0,
+      "max_route_progress_m": -12.02842730398372,
+      "min_route_progress_m": -12.02842730398372,
+      "next_empirical_action": "repair or replace this slice before benchmark-facing promotion",
+      "row_count": 5,
+      "scenario_name": "classic_doorway_medium",
+      "slice_id": "doorway_transfer",
+      "slice_role": "hard",
+      "terminal_outcome": "obstacle_collision",
+      "thresholds_m": [
+        0.05,
+        0.1,
+        0.2
+      ]
+    }
+  ],
   "claim_boundary": "diagnostic_only_not_benchmark_or_paper_evidence",
   "classification": "blocked",
-  "classification_rationale": "At least one progress-gated row did not produce diagnostic evidence.",
+  "classification_rationale": "Progress-gated rows failed closed before producing diagnostic evidence: doorway_transfer:obstacle_collision.",
   "commands": [
     {
       "candidate_role": "baseline",
@@ -13,7 +40,7 @@
         "--candidate-registry",
         "docs/context/policy_search/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/bottleneck_transfer/baseline/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/bottleneck_transfer/baseline/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -31,7 +58,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/bottleneck_transfer/baseline"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/bottleneck_transfer/baseline"
       ],
       "slice_id": "bottleneck_transfer",
       "threshold_m": null
@@ -46,7 +73,7 @@
         "--candidate-registry",
         "docs/context/policy_search/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/bottleneck_transfer/reuse_penalty/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/bottleneck_transfer/reuse_penalty/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -64,7 +91,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/bottleneck_transfer/reuse_penalty"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/bottleneck_transfer/reuse_penalty"
       ],
       "slice_id": "bottleneck_transfer",
       "threshold_m": null
@@ -77,9 +104,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p05",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.05/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.05/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.05/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.05/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -97,7 +124,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/bottleneck_transfer/progress_gated_threshold_0.05"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/bottleneck_transfer/progress_gated_threshold_0.05"
       ],
       "slice_id": "bottleneck_transfer",
       "threshold_m": 0.05
@@ -110,9 +137,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p1",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.1/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.1/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.1/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.1/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -130,7 +157,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/bottleneck_transfer/progress_gated_threshold_0.1"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/bottleneck_transfer/progress_gated_threshold_0.1"
       ],
       "slice_id": "bottleneck_transfer",
       "threshold_m": 0.1
@@ -143,9 +170,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p2",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.2/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.2/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.2/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/bottleneck_transfer/progress_gated_threshold_0.2/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -163,7 +190,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/bottleneck_transfer/progress_gated_threshold_0.2"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/bottleneck_transfer/progress_gated_threshold_0.2"
       ],
       "slice_id": "bottleneck_transfer",
       "threshold_m": 0.2
@@ -178,7 +205,7 @@
         "--candidate-registry",
         "docs/context/policy_search/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/doorway_transfer/baseline/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/doorway_transfer/baseline/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -196,7 +223,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/doorway_transfer/baseline"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/doorway_transfer/baseline"
       ],
       "slice_id": "doorway_transfer",
       "threshold_m": null
@@ -211,7 +238,7 @@
         "--candidate-registry",
         "docs/context/policy_search/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/doorway_transfer/reuse_penalty/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/doorway_transfer/reuse_penalty/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -229,7 +256,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/doorway_transfer/reuse_penalty"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/doorway_transfer/reuse_penalty"
       ],
       "slice_id": "doorway_transfer",
       "threshold_m": null
@@ -242,9 +269,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p05",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/doorway_transfer/progress_gated_threshold_0.05/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/doorway_transfer/progress_gated_threshold_0.05/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/doorway_transfer/progress_gated_threshold_0.05/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/doorway_transfer/progress_gated_threshold_0.05/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -262,7 +289,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/doorway_transfer/progress_gated_threshold_0.05"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/doorway_transfer/progress_gated_threshold_0.05"
       ],
       "slice_id": "doorway_transfer",
       "threshold_m": 0.05
@@ -275,9 +302,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p1",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/doorway_transfer/progress_gated_threshold_0.1/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/doorway_transfer/progress_gated_threshold_0.1/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/doorway_transfer/progress_gated_threshold_0.1/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/doorway_transfer/progress_gated_threshold_0.1/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -295,7 +322,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/doorway_transfer/progress_gated_threshold_0.1"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/doorway_transfer/progress_gated_threshold_0.1"
       ],
       "slice_id": "doorway_transfer",
       "threshold_m": 0.1
@@ -308,9 +335,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p2",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/doorway_transfer/progress_gated_threshold_0.2/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/doorway_transfer/progress_gated_threshold_0.2/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/doorway_transfer/progress_gated_threshold_0.2/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/doorway_transfer/progress_gated_threshold_0.2/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -328,7 +355,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/doorway_transfer/progress_gated_threshold_0.2"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/doorway_transfer/progress_gated_threshold_0.2"
       ],
       "slice_id": "doorway_transfer",
       "threshold_m": 0.2
@@ -343,7 +370,7 @@
         "--candidate-registry",
         "docs/context/policy_search/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/t_intersection_transfer/baseline/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/t_intersection_transfer/baseline/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -361,7 +388,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/t_intersection_transfer/baseline"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/t_intersection_transfer/baseline"
       ],
       "slice_id": "t_intersection_transfer",
       "threshold_m": null
@@ -376,7 +403,7 @@
         "--candidate-registry",
         "docs/context/policy_search/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/t_intersection_transfer/reuse_penalty/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/t_intersection_transfer/reuse_penalty/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -394,7 +421,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/t_intersection_transfer/reuse_penalty"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/t_intersection_transfer/reuse_penalty"
       ],
       "slice_id": "t_intersection_transfer",
       "threshold_m": null
@@ -407,9 +434,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p05",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.05/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.05/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.05/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.05/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -427,7 +454,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/t_intersection_transfer/progress_gated_threshold_0.05"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/t_intersection_transfer/progress_gated_threshold_0.05"
       ],
       "slice_id": "t_intersection_transfer",
       "threshold_m": 0.05
@@ -440,9 +467,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p1",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.1/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.1/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.1/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.1/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -460,7 +487,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/t_intersection_transfer/progress_gated_threshold_0.1"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/t_intersection_transfer/progress_gated_threshold_0.1"
       ],
       "slice_id": "t_intersection_transfer",
       "threshold_m": 0.1
@@ -473,9 +500,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p2",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.2/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.2/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.2/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/t_intersection_transfer/progress_gated_threshold_0.2/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -493,7 +520,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/t_intersection_transfer/progress_gated_threshold_0.2"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/t_intersection_transfer/progress_gated_threshold_0.2"
       ],
       "slice_id": "t_intersection_transfer",
       "threshold_m": 0.2
@@ -508,7 +535,7 @@
         "--candidate-registry",
         "docs/context/policy_search/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/simple_negative_control/baseline/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/simple_negative_control/baseline/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -526,7 +553,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/simple_negative_control/baseline"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/simple_negative_control/baseline"
       ],
       "slice_id": "simple_negative_control",
       "threshold_m": null
@@ -541,7 +568,7 @@
         "--candidate-registry",
         "docs/context/policy_search/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/simple_negative_control/reuse_penalty/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/simple_negative_control/reuse_penalty/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -559,7 +586,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/simple_negative_control/reuse_penalty"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/simple_negative_control/reuse_penalty"
       ],
       "slice_id": "simple_negative_control",
       "threshold_m": null
@@ -572,9 +599,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p05",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/simple_negative_control/progress_gated_threshold_0.05/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/simple_negative_control/progress_gated_threshold_0.05/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/simple_negative_control/progress_gated_threshold_0.05/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/simple_negative_control/progress_gated_threshold_0.05/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -592,7 +619,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/simple_negative_control/progress_gated_threshold_0.05"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/simple_negative_control/progress_gated_threshold_0.05"
       ],
       "slice_id": "simple_negative_control",
       "threshold_m": 0.05
@@ -605,9 +632,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p1",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/simple_negative_control/progress_gated_threshold_0.1/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/simple_negative_control/progress_gated_threshold_0.1/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/simple_negative_control/progress_gated_threshold_0.1/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/simple_negative_control/progress_gated_threshold_0.1/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -625,7 +652,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/simple_negative_control/progress_gated_threshold_0.1"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/simple_negative_control/progress_gated_threshold_0.1"
       ],
       "slice_id": "simple_negative_control",
       "threshold_m": 0.1
@@ -638,9 +665,9 @@
         "--candidate",
         "topology_guided_hybrid_rule_v0_progress_gated_reselection_monotone_threshold_0p2",
         "--candidate-registry",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/simple_negative_control/progress_gated_threshold_0.2/candidate_registry.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/simple_negative_control/progress_gated_threshold_0.2/candidate_registry.yaml",
         "--funnel-config",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/_generated_inputs/simple_negative_control/progress_gated_threshold_0.2/funnel.yaml",
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/_generated_inputs/simple_negative_control/progress_gated_threshold_0.2/funnel.yaml",
         "--stage",
         "issue_3463_slice",
         "--scenario-name",
@@ -658,7 +685,7 @@
         "--block-stride-cells",
         "8",
         "--output-dir",
-        "output/diagnostics/issue_3463_topology_reselection_cross_slice_2026-07-05/runs/simple_negative_control/progress_gated_threshold_0.2"
+        "output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07/runs/simple_negative_control/progress_gated_threshold_0.2"
       ],
       "slice_id": "simple_negative_control",
       "threshold_m": 0.2

--- a/scripts/validation/run_topology_reselection_cross_slice.py
+++ b/scripts/validation/run_topology_reselection_cross_slice.py
@@ -7,7 +7,6 @@ import argparse
 import copy
 import json
 import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -246,7 +245,7 @@ def command_for_row(
             issue_number=_manifest_issue_number(manifest),
         )
     return [
-        sys.executable,
+        ".venv/bin/python3",
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         candidate,
@@ -376,6 +375,69 @@ def row_metrics(row: SweepRow, result: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def summarize_blockers(metrics: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group fail-closed rows into compact blocker records."""
+    grouped: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    for row in metrics:
+        status = str(row.get("diagnostic_status") or "unknown")
+        if status == "diagnostic_complete":
+            continue
+        key = (
+            str(row.get("slice_id") or "unknown_slice"),
+            str(row.get("slice_role") or "unknown_role"),
+            str(row.get("scenario_name") or "unknown_scenario"),
+            str(row.get("terminal_outcome") or "unknown_outcome"),
+        )
+        entry = grouped.setdefault(
+            key,
+            {
+                "slice_id": key[0],
+                "slice_role": key[1],
+                "scenario_name": key[2],
+                "terminal_outcome": key[3],
+                "diagnostic_status_counts": {},
+                "candidate_roles": [],
+                "thresholds_m": [],
+                "row_count": 0,
+                "max_collision_rate": 0.0,
+                "min_route_progress_m": None,
+                "max_route_progress_m": None,
+                "classification": "fail_closed_not_success_evidence",
+                "next_empirical_action": (
+                    "repair or replace this slice before benchmark-facing promotion"
+                ),
+            },
+        )
+        entry["row_count"] += 1
+        status_counts = entry["diagnostic_status_counts"]
+        status_counts[status] = int(status_counts.get(status, 0)) + 1
+        candidate_role = str(row.get("candidate_role") or "unknown_candidate_role")
+        if candidate_role not in entry["candidate_roles"]:
+            entry["candidate_roles"].append(candidate_role)
+        threshold = row.get("threshold_m")
+        if threshold is not None and threshold not in entry["thresholds_m"]:
+            entry["thresholds_m"].append(threshold)
+        entry["max_collision_rate"] = max(
+            float(entry["max_collision_rate"]),
+            float(row.get("collision_rate") or 0.0),
+        )
+        progress = row.get("route_progress_m")
+        if isinstance(progress, int | float):
+            min_progress = entry["min_route_progress_m"]
+            max_progress = entry["max_route_progress_m"]
+            entry["min_route_progress_m"] = (
+                float(progress)
+                if min_progress is None
+                else min(float(min_progress), float(progress))
+            )
+            entry["max_route_progress_m"] = (
+                float(progress)
+                if max_progress is None
+                else max(float(max_progress), float(progress))
+            )
+    return sorted(grouped.values(), key=lambda item: (item["slice_id"], item["terminal_outcome"]))
+
+
 def classify_report(metrics: list[dict[str, Any]]) -> tuple[str, str]:
     """Classify progress-gated reselection from aggregate hard/control metrics.
 
@@ -390,6 +452,16 @@ def classify_report(metrics: list[dict[str, Any]]) -> tuple[str, str]:
     if not progress_rows or not reuse_rows:
         return "blocked", "Missing progress-gated or reuse-penalty rows."
     if any(row["diagnostic_status"] != "diagnostic_complete" for row in progress_rows):
+        blockers = summarize_blockers(progress_rows)
+        if blockers:
+            blocker_names = ", ".join(
+                f"{item['slice_id']}:{item['terminal_outcome']}" for item in blockers
+            )
+            return (
+                "blocked",
+                "Progress-gated rows failed closed before producing diagnostic evidence: "
+                f"{blocker_names}.",
+            )
         return "blocked", "At least one progress-gated row did not produce diagnostic evidence."
     if any(row["topology_command_steps"] == 0 for row in hard_progress):
         return "stop", "A hard slice lost topology-command influence under progress gating."
@@ -423,7 +495,7 @@ def report_markdown(report: dict[str, Any]) -> str:
     """
 
     lines = [
-        f"# Issue {report['issue']} Topology Reselection Cross-Slice Diagnostic",
+        f"# Issue #{report['issue']} - Topology Reselection Cross-Slice Diagnostic",
         "",
         f"Claim boundary: `{report['claim_boundary']}`.",
         f"Classification: `{report['classification']}`.",
@@ -445,6 +517,38 @@ def report_markdown(report: dict[str, Any]) -> str:
             f"{row['topology_switch_count']} | {row['deadlock_duration_steps']} | "
             f"{row['collision_rate']} |"
         )
+    blockers = report.get("blockers", [])
+    if blockers:
+        lines.extend(
+            [
+                "",
+                "## Fail-Closed Blockers",
+                "",
+                "| Slice | Scenario | Outcome | Status counts | Candidate roles | Thresholds m | Rows | Route progress m | Next action |",
+                "|---|---|---|---|---|---:|---:|---:|---|",
+            ]
+        )
+        for item in blockers:
+            status_counts = ", ".join(
+                f"{key}={value}" for key, value in sorted(item["diagnostic_status_counts"].items())
+            )
+            thresholds = ", ".join(str(value) for value in item["thresholds_m"]) or "NA"
+            progress_min = item.get("min_route_progress_m")
+            progress_max = item.get("max_route_progress_m")
+            if progress_min is None or progress_max is None:
+                progress_range = "NA"
+            elif progress_min == progress_max:
+                progress_range = str(progress_min)
+            else:
+                progress_range = f"{progress_min} to {progress_max}"
+            lines.append(
+                "| "
+                f"{item['slice_id']} | {item['scenario_name']} | "
+                f"{item['terminal_outcome']} | {status_counts} | "
+                f"{', '.join(item['candidate_roles'])} | {thresholds} | "
+                f"{item['row_count']} | {progress_range} | "
+                f"{item['next_empirical_action']} |"
+            )
     lines.extend(
         [
             "",
@@ -494,6 +598,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.dry_run
         else classify_report(metrics)
     )
+    blockers = [] if args.dry_run else summarize_blockers(metrics)
     report = {
         "schema": "topology_reselection_cross_slice_report.v1",
         "issue": _manifest_issue_number(manifest),
@@ -511,6 +616,7 @@ def main(argv: list[str] | None = None) -> int:
             }
             for item in row_results
         ],
+        "blockers": blockers,
         "rows": metrics,
     }
     json_path = output_dir / "topology_reselection_cross_slice_report.json"

--- a/scripts/validation/run_topology_reselection_cross_slice.py
+++ b/scripts/validation/run_topology_reselection_cross_slice.py
@@ -7,6 +7,7 @@ import argparse
 import copy
 import json
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -15,6 +16,12 @@ import yaml
 
 _DEFAULT_MANIFEST = Path("configs/policy_search/topology_reselection_cross_slice_issue_2716.yaml")
 _DEFAULT_REGISTRY = Path("docs/context/policy_search/candidate_registry.yaml")
+
+# Recorded (repo-relative) interpreter used in tracked evidence commands so the
+# provenance stays reproducible and free of absolute worktree paths. Execution
+# substitutes the real ``sys.executable`` (see ``run_row``) so the script does
+# not depend on the process cwd or a ``.venv`` at a fixed location.
+_RECORDED_INTERPRETER = ".venv/bin/python3"
 
 
 def _manifest_issue_number(manifest: dict[str, Any]) -> int:
@@ -245,7 +252,7 @@ def command_for_row(
             issue_number=_manifest_issue_number(manifest),
         )
     return [
-        ".venv/bin/python3",
+        _RECORDED_INTERPRETER,
         "scripts/validation/run_topology_hypothesis_diagnostics.py",
         "--candidate",
         candidate,
@@ -281,7 +288,12 @@ def run_row(command: list[str]) -> dict[str, Any]:
         Row result payload.
     """
 
-    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    exec_command = command
+    if command and command[0] == _RECORDED_INTERPRETER:
+        # Execute with the live interpreter; the recorded/relative form is kept
+        # only for reproducible evidence provenance, not for process launch.
+        exec_command = [sys.executable, *command[1:]]
+    completed = subprocess.run(exec_command, check=False, capture_output=True, text=True)
     stdout_payload: dict[str, Any] = {}
     if completed.stdout.strip():
         stdout_payload = json.loads(completed.stdout)

--- a/tests/validation/test_run_topology_reselection_cross_slice.py
+++ b/tests/validation/test_run_topology_reselection_cross_slice.py
@@ -629,3 +629,106 @@ def test_issue_2742_classifier_revises_when_hard_all_exhaust() -> None:
 
     assert classification == "revise"
     assert "horizon_exhausted" in rationale
+
+
+def test_blocker_summary_groups_unavailable_progress_gated_rows() -> None:
+    """Issue-3463 blocked rows should name the failing slice and outcome."""
+    rows = [
+        {
+            "candidate_role": "progress_gated",
+            "slice_id": "doorway_transfer",
+            "slice_role": "hard",
+            "scenario_name": "classic_doorway_medium",
+            "diagnostic_status": "not_available",
+            "terminal_outcome": "obstacle_collision",
+            "threshold_m": 0.05,
+            "collision_rate": 1.0,
+            "route_progress_m": -12.0,
+        },
+        {
+            "candidate_role": "progress_gated",
+            "slice_id": "doorway_transfer",
+            "slice_role": "hard",
+            "scenario_name": "classic_doorway_medium",
+            "diagnostic_status": "not_available",
+            "terminal_outcome": "obstacle_collision",
+            "threshold_m": 0.1,
+            "collision_rate": 1.0,
+            "route_progress_m": -12.0,
+        },
+        {
+            "candidate_role": "reuse_penalty",
+            "slice_id": "doorway_transfer",
+            "slice_role": "hard",
+            "scenario_name": "classic_doorway_medium",
+            "diagnostic_status": "not_available",
+            "terminal_outcome": "obstacle_collision",
+            "threshold_m": None,
+            "collision_rate": 1.0,
+            "route_progress_m": -12.0,
+        },
+    ]
+
+    blockers = runner.summarize_blockers(rows)
+    classification, rationale = runner.classify_report(rows)
+
+    assert classification == "blocked"
+    assert "doorway_transfer:obstacle_collision" in rationale
+    assert len(blockers) == 1
+    blocker = blockers[0]
+    assert blocker["slice_id"] == "doorway_transfer"
+    assert blocker["diagnostic_status_counts"] == {"not_available": 3}
+    assert blocker["candidate_roles"] == ["progress_gated", "reuse_penalty"]
+    assert blocker["thresholds_m"] == [0.05, 0.1]
+    assert blocker["classification"] == "fail_closed_not_success_evidence"
+
+
+def test_report_markdown_renders_fail_closed_blockers() -> None:
+    """Markdown report should expose blocker triage before caveats."""
+    report = {
+        "issue": 3463,
+        "claim_boundary": "diagnostic_only_not_benchmark_or_paper_evidence",
+        "classification": "blocked",
+        "classification_rationale": (
+            "Progress-gated rows failed closed before producing diagnostic evidence: "
+            "doorway_transfer:obstacle_collision."
+        ),
+        "rows": [
+            {
+                "slice_id": "doorway_transfer",
+                "slice_role": "hard",
+                "candidate_role": "progress_gated",
+                "threshold_m": 0.05,
+                "diagnostic_status": "not_available",
+                "terminal_outcome": "obstacle_collision",
+                "route_progress_m": -12.0,
+                "topology_switch_count": 0,
+                "deadlock_duration_steps": 0,
+                "collision_rate": 1.0,
+            }
+        ],
+        "blockers": [
+            {
+                "slice_id": "doorway_transfer",
+                "slice_role": "hard",
+                "scenario_name": "classic_doorway_medium",
+                "terminal_outcome": "obstacle_collision",
+                "diagnostic_status_counts": {"not_available": 1},
+                "candidate_roles": ["progress_gated"],
+                "thresholds_m": [0.05],
+                "row_count": 1,
+                "min_route_progress_m": -12.0,
+                "max_route_progress_m": -12.0,
+                "next_empirical_action": (
+                    "repair or replace this slice before benchmark-facing promotion"
+                ),
+            }
+        ],
+    }
+
+    markdown = runner.report_markdown(report)
+
+    assert "## Fail-Closed Blockers" in markdown
+    assert "doorway_transfer" in markdown
+    assert "classic_doorway_medium" in markdown
+    assert "repair or replace this slice" in markdown

--- a/tests/validation/test_run_topology_reselection_cross_slice.py
+++ b/tests/validation/test_run_topology_reselection_cross_slice.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import yaml
@@ -250,6 +251,28 @@ def test_run_row_handles_child_command_without_json_stdout(monkeypatch) -> None:
     assert result["diagnostic_status"] == "command_failed"
     assert result["trace"] is None
     assert "boom" in result["stderr_excerpt"]
+
+
+def test_run_row_executes_with_live_interpreter_not_recorded_path(monkeypatch) -> None:
+    """Execution must use sys.executable; the recorded relative interpreter is provenance only."""
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(*args, **kwargs):
+        captured["argv"] = args[0]
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    recorded = [runner._RECORDED_INTERPRETER, "scripts/validation/some_child.py", "--flag"]
+    runner.run_row(recorded)
+
+    # argv[0] is swapped to the live interpreter so launch never depends on cwd
+    # or a .venv at a fixed location; the remaining args are preserved verbatim.
+    assert captured["argv"][0] == sys.executable
+    assert captured["argv"][1:] == recorded[1:]
+    # The caller's recorded command is left untouched for evidence provenance.
+    assert recorded[0] == runner._RECORDED_INTERPRETER
 
 
 # --- Issue #2742 successor manifest tests ---


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds a fail-closed blocker triage section to the topology reselection cross-slice diagnostic report and regenerates the compact issue #3463 evidence bundle from a real CPU run. New capability: `topology_reselection_fail_closed_blocker_triage.v1`, which groups unavailable rows by slice, scenario, terminal outcome, status counts, candidates, thresholds, and next empirical action.

Why now: prior merged slices delivered diagnostics/arbitration/route-progress/reselection/integration evidence, but the real packet still only reported a generic blocked classification. This names the remaining blocker: all five `doorway_transfer` rows are `not_available` with `obstacle_collision`.

Claim boundary: diagnostic-only. This PR does not claim planner improvement, benchmark promotion, paper/dissertation evidence, or completion of #3465.

Required validation: focused reporter tests, lint, abs-path check, full CPU manifest run, and clean PR readiness.

Remaining blocker: repair or replace `classic_doorway_medium` / `doorway_transfer` before any benchmark-facing enabled-vs-disabled promotion. #3465 remains the promotion gate.

Refs #3463

## Contract delta

New report fields:

- `blockers[]` in `topology_reselection_cross_slice_report.v1`.
- Per blocker: `slice_id`, `slice_role`, `scenario_name`, `terminal_outcome`, `diagnostic_status_counts`, `candidate_roles`, `thresholds_m`, `row_count`, `max_collision_rate`, `min_route_progress_m`, `max_route_progress_m`, `classification`, `next_empirical_action`.

Fail-closed behavior:

- Blocked progress-gated reports now name grouped fail-closed blockers in `classification_rationale` instead of only saying a row lacked diagnostic evidence.
- Fallback/unavailable/degraded rows remain non-success evidence.

Compatibility impact:

- Additive JSON field only. Existing `rows`, `classification`, and `classification_rationale` remain present.
- Recorded commands use repo-relative `.venv/bin/python3`, avoiding absolute worktree paths in tracked evidence.

## Scope summary

- Updated `scripts/validation/run_topology_reselection_cross_slice.py` to summarize blocker rows and render them in Markdown.
- Added focused tests for blocker grouping and Markdown rendering.
- Regenerated `docs/context/evidence/issue_3463_topology_reselection_cross_slice_2026-07-05/{summary.json,report.md}` from the issue #3463 CPU manifest.

## Validation

- `uv run ruff format scripts/validation/run_topology_reselection_cross_slice.py tests/validation/test_run_topology_reselection_cross_slice.py` -> pass.
- `uv run ruff check scripts/validation/run_topology_reselection_cross_slice.py tests/validation/test_run_topology_reselection_cross_slice.py` -> pass.
- `uv run pytest tests/validation/test_run_topology_reselection_cross_slice.py -q` -> 21 passed.
- `python hooks/check_config_abs_paths.py --all` -> pass.
- `LOGURU_LEVEL=WARNING TF_CPP_MIN_LOG_LEVEL=2 PYGAME_HIDE_SUPPORT_PROMPT=1 DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run python scripts/validation/run_topology_reselection_cross_slice.py --manifest configs/policy_search/topology_reselection_cross_slice_issue_3463.yaml --output-dir output/diagnostics/issue_3463_topology_reselection_cross_slice_blocker_triage_2026-07-07` -> exit 0, classification `blocked`, blocker `doorway_transfer:obstacle_collision`.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> pass, 1924 passed / 2 skipped, dirty-tree interim stamp before commit.
- `PR_READY_PR_BODY_FILE=/tmp/issue3463_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> final clean-head pass before PR open.

## Domain-Aware Approval

- Required for PR: yes - diagnostic evidence classification is updated.
- Domains reviewed: evidence classification, benchmark interpretation.
- Status: waived
- Approval or blocker note: self-review waiver for diagnostic-only blocker classification; no benchmark, planner, paper, or dissertation claim is promoted.
- Validity checklist:
  - Target claim/hypothesis: issue #3463 remains diagnostic-only; the new claim is only that the report names fail-closed blockers.
  - Comparator or split/evidence validity: existing issue #3463 CPU manifest rows are summarized; no benchmark comparator or enabled-vs-disabled promotion is asserted.
  - Fallback/degraded exclusions: unavailable, fallback, degraded, and blocked rows remain excluded from success evidence.
  - Claim boundary: no paper-facing benchmark claim; #3465 remains the benchmark-facing promotion gate.
  - Implementation integrity vs experimental validity: tests and PR readiness prove report behavior; they do not validate planner improvement.

## Explicit out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No merge, release, deletion, or compute submission.

## Downstream propagation

No issue comment was posted because this run was not authorized for issue/PR comments. The PR body is the propagation surface for this slice; Claude Code on `imech156-u` owns the post-open gate and may update the canonical issue state if needed.

<details>
<summary>Governance appendix</summary>

Fragmentation guard: the only issue #3463 merge found in the last 24 hours was PR #4604, an evidence path hygiene fix. This PR is a progression slice with a named diagnostic capability, not another guardrail-only refresh.

Late guidance check: immediately before PR preparation, issue #3463 had no maintainer comments newer than the initial read; latest visible issue update remained 2026-07-04.

Artifact classification: per-row trace outputs remain under ignored `output/diagnostics/...`; only compact JSON/Markdown evidence is tracked.

Closure call: partial. Use `Refs #3463`; do not close because the issue remains diagnostic-only and #3465 is still the benchmark-facing promotion gate.

</details>
