### PR TITLE
Issue #4013: add staging tree readiness evidence

### DIFF
--- a/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
+++ b/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
@@ -48,5 +48,10 @@
     "instructions": "Obtain the ETH/BIWI walking pedestrians annotation archive from the official ETH Computer Vision Lab datasets page under its current terms. Extract the raw annotation files into staging_dir. Do not commit raw annotations or converted trajectory files. After staging, compute the aggregate SHA-256 tree checksum, set checksums.tree_sha256 and expected_tree_sha256, and change availability to validated before using the data for #4013 real-trajectory training or representative evaluation."
   },
   "schema_version": "issue_4013.real_trajectory_readiness.v1",
+  "staging_tree": {
+    "available": false,
+    "reason": "environment variable unresolved",
+    "staging_dir": "${ROBOT_SF_EXTERNAL_DATA_ROOT}/issue_4013_eth_biwi"
+  },
   "status": "blocked_manifest_contract"
 }

--- a/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md
+++ b/docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.md
@@ -10,6 +10,10 @@ Claim boundary: real-trajectory readiness only. No raw data is staged, no full b
 - Dataset: `issue_4013_eth_biwi`
 - Availability: `validated`
 - Benchmark eligibility: `research_only`
+- Staging tree available: `False`
+- Staging tree path: `${ROBOT_SF_EXTERNAL_DATA_ROOT}/issue_4013_eth_biwi`
+- Staging tree files: `n/a`
+- Staging tree SHA-256: `n/a`
 - Acquisition URL: `https://ethz.ch/content/dam/ethz/special-interest/itet/cvl/vision-dam/documents/ewap_dataset_light.tgz`
 - Acquisition fail-closed: `True`
 

--- a/robot_sf/data_ingestion/real_trajectory_contract.py
+++ b/robot_sf/data_ingestion/real_trajectory_contract.py
@@ -86,6 +86,54 @@ def _staging_tree_sha256(source_root: Path) -> str:
     return digest.hexdigest()
 
 
+def build_staging_tree_report(manifest: dict[str, Any]) -> dict[str, object]:
+    """Return local staging-tree availability and checksum evidence for a manifest.
+
+    The report is read-only and fail-closed: unresolved environment variables,
+    missing directories, and empty staging trees return ``available: false`` with
+    a reason instead of raising. Callers can include this payload in readiness
+    artifacts without touching or redistributing raw external data.
+    """
+    staging = manifest.get("staging", {})
+    staging_dir = staging.get("staging_dir") if isinstance(staging, dict) else None
+    if not isinstance(staging_dir, str):
+        report = {"available": False, "reason": "manifest.staging.staging_dir missing"}
+        return report
+
+    resolved = _resolved_staging_dir(staging_dir)
+    if "$" in str(resolved):
+        report = {
+            "available": False,
+            "staging_dir": str(resolved),
+            "reason": "environment variable unresolved",
+        }
+        return report
+    if not resolved.is_dir():
+        report = {
+            "available": False,
+            "staging_dir": str(resolved),
+            "reason": "staging directory missing",
+        }
+        return report
+
+    file_count = sum(1 for path in resolved.rglob("*") if path.is_file())
+    if file_count == 0:
+        report = {
+            "available": False,
+            "staging_dir": str(resolved),
+            "file_count": 0,
+            "reason": "staging directory empty",
+        }
+        return report
+
+    return {
+        "available": True,
+        "staging_dir": str(resolved),
+        "file_count": file_count,
+        "tree_sha256": _staging_tree_sha256(resolved),
+    }
+
+
 def _validated_staging_issues(staging_dir: str, checksums: dict[str, Any]) -> list[PreflightIssue]:
     """Return fail-closed issues for a manifest claiming validated local staging.
 

--- a/scripts/tools/check_real_trajectory_manifest.py
+++ b/scripts/tools/check_real_trajectory_manifest.py
@@ -28,8 +28,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from robot_sf.data_ingestion.real_trajectory_contract import (
     ContractError,
-    _resolved_staging_dir,
-    _staging_tree_sha256,
+    build_staging_tree_report,
     load_manifest,
     run_preflight,
 )
@@ -53,39 +52,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _staging_tree_report(manifest: dict) -> dict[str, object]:
-    staging = manifest.get("staging", {})
-    staging_dir = staging.get("staging_dir") if isinstance(staging, dict) else None
-    if not isinstance(staging_dir, str):
-        return {"available": False, "reason": "manifest.staging.staging_dir missing"}
-
-    resolved = _resolved_staging_dir(staging_dir)
-    if "$" in str(resolved):
-        return {
-            "available": False,
-            "staging_dir": str(resolved),
-            "reason": "environment variable unresolved",
-        }
-    if not resolved.is_dir():
-        return {
-            "available": False,
-            "staging_dir": str(resolved),
-            "reason": "staging directory missing",
-        }
-
-    file_count = sum(1 for path in resolved.rglob("*") if path.is_file())
-    if file_count == 0:
-        return {
-            "available": False,
-            "staging_dir": str(resolved),
-            "file_count": 0,
-            "reason": "staging directory empty",
-        }
-    return {
-        "available": True,
-        "staging_dir": str(resolved),
-        "file_count": file_count,
-        "tree_sha256": _staging_tree_sha256(resolved),
-    }
+    return build_staging_tree_report(manifest)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/training/check_issue_4013_real_trajectory_readiness.py
+++ b/scripts/training/check_issue_4013_real_trajectory_readiness.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from robot_sf.data_ingestion.real_trajectory_contract import (
     ContractError,
+    build_staging_tree_report,
     load_manifest,
     run_preflight,
 )
@@ -42,10 +43,12 @@ def build_report(manifest_path: Path) -> dict[str, Any]:
     try:
         manifest = load_manifest(manifest_path)
         preflight = run_preflight(manifest)
+        staging_tree = build_staging_tree_report(manifest)
         input_error: str | None = None
     except (ContractError, jsonschema.ValidationError) as exc:
         manifest = {}
         preflight = None
+        staging_tree = {"available": False, "reason": "manifest input error"}
         input_error = str(exc)
 
     if input_error:
@@ -133,6 +136,7 @@ def build_report(manifest_path: Path) -> dict[str, Any]:
         "dataset_id": dataset_id,
         "availability": availability,
         "benchmark_eligibility": benchmark_eligibility,
+        "staging_tree": staging_tree,
         "retrieval": {
             "download_url": retrieval.get("download_url"),
             "instructions": retrieval.get("instructions"),
@@ -169,6 +173,10 @@ def render_markdown(report: dict[str, Any]) -> str:
         f"- Dataset: `{report['dataset_id']}`",
         f"- Availability: `{report['availability']}`",
         f"- Benchmark eligibility: `{report['benchmark_eligibility']}`",
+        f"- Staging tree available: `{report['staging_tree'].get('available')}`",
+        f"- Staging tree path: `{report['staging_tree'].get('staging_dir', 'unresolved')}`",
+        f"- Staging tree files: `{report['staging_tree'].get('file_count', 'n/a')}`",
+        f"- Staging tree SHA-256: `{report['staging_tree'].get('tree_sha256', 'n/a')}`",
         f"- Acquisition URL: `{report['retrieval']['download_url'] or 'manual/license-gated'}`",
         f"- Acquisition fail-closed: `{report['retrieval']['fail_closed']}`",
         "",

--- a/tests/data/test_real_trajectory_contract.py
+++ b/tests/data/test_real_trajectory_contract.py
@@ -22,6 +22,9 @@ from robot_sf.data_ingestion import (
 )
 from robot_sf.data_ingestion import real_trajectory_contract as contract
 from scripts.tools.check_real_trajectory_manifest import main as check_manifest_main
+from scripts.training.check_issue_4013_real_trajectory_readiness import (
+    build_report as build_readiness_report,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLE_MANIFEST = REPO_ROOT / "configs" / "data" / "real_trajectory_manifest.example.yaml"
@@ -291,6 +294,84 @@ def test_manifest_cli_reports_staging_tree_checksum(
         "staging_dir": str(staging_dir),
         "file_count": 1,
         "tree_sha256": tree_sha256,
+    }
+
+
+def test_staging_tree_report_is_reusable_for_readiness_artifact(
+    valid_manifest: dict,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The #4013 readiness artifact records the same local staging checksum evidence."""
+    data_root = tmp_path / "external_data"
+    staging_dir = data_root / "synthetic_byo"
+    staging_dir.mkdir(parents=True)
+    (staging_dir / "trajectories.csv").write_text("frame,ped_id,x,y\n0,1,0,0\n", encoding="utf-8")
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(data_root))
+    valid_manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
+    valid_manifest["availability"] = "validated"
+    valid_manifest["benchmark_eligibility"] = "research_only"
+    tree_sha256 = contract._staging_tree_sha256(staging_dir)
+    valid_manifest["checksums"]["tree_sha256"] = tree_sha256
+    valid_manifest["checksums"]["expected_tree_sha256"] = tree_sha256
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(json.dumps(valid_manifest), encoding="utf-8")
+
+    report = build_readiness_report(manifest_path)
+
+    assert report["status"] == "ready_for_real_trajectory_training"
+    assert report["staging_tree"] == {
+        "available": True,
+        "staging_dir": str(staging_dir),
+        "file_count": 1,
+        "tree_sha256": tree_sha256,
+    }
+
+
+@pytest.mark.parametrize(
+    ("staging_dir", "expected_reason"),
+    [
+        (None, "manifest.staging.staging_dir missing"),
+        ("${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo", "environment variable unresolved"),
+        ("output/external_data/missing_synthetic_byo", "staging directory missing"),
+    ],
+)
+def test_staging_tree_report_fails_closed_before_checksum(
+    valid_manifest: dict,
+    staging_dir: str | None,
+    expected_reason: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Staging checksum evidence reports blockers instead of raising."""
+    monkeypatch.delenv("ROBOT_SF_EXTERNAL_DATA_ROOT", raising=False)
+    if staging_dir is None:
+        valid_manifest["staging"].pop("staging_dir")
+    else:
+        valid_manifest["staging"]["staging_dir"] = staging_dir
+
+    report = contract.build_staging_tree_report(valid_manifest)
+
+    assert report["available"] is False
+    assert report["reason"] == expected_reason
+
+
+def test_staging_tree_report_marks_empty_directory_unavailable(
+    valid_manifest: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty local staging root is visible but not usable evidence."""
+    data_root = tmp_path / "external_data"
+    staging_dir = data_root / "synthetic_byo"
+    staging_dir.mkdir(parents=True)
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(data_root))
+    valid_manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
+
+    report = contract.build_staging_tree_report(valid_manifest)
+
+    assert report == {
+        "available": False,
+        "staging_dir": str(staging_dir),
+        "file_count": 0,
+        "reason": "staging directory empty",
     }
 
 

--- a/tests/training/test_issue_4013_real_trajectory_readiness.py
+++ b/tests/training/test_issue_4013_real_trajectory_readiness.py
@@ -1,132 +1,111 @@
-"""Tests for the issue #4013 real-trajectory readiness checker."""
+"""Tests for issue #4013 real-trajectory readiness reporting."""
 
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import pytest
 import yaml
 
-from robot_sf.data_ingestion import real_trajectory_contract as contract
-from scripts.training.check_issue_4013_real_trajectory_readiness import (
-    build_report,
-    render_markdown,
+from robot_sf.data_ingestion.real_trajectory_contract import (
+    _staging_tree_sha256,
+    build_staging_tree_report,
 )
+from scripts.training.check_issue_4013_real_trajectory_readiness import build_report
+from tests.data.test_real_trajectory_contract import valid_manifest as _valid_manifest_fixture
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
 def _manifest() -> dict:
-    return {
-        "schema": "robot_sf_real_trajectory_ingestion_manifest.v1",
-        "dataset_id": "issue_4013_test",
-        "title": "Issue 4013 test trajectories",
-        "source": {
-            "url": "https://example.org",
-            "version": "test",
-            "citation": "Test citation",
-            "access_date": "2026-07-06",
-        },
-        "license": {
-            "name": "test",
-            "url": None,
-            "posture": "bring-your-own",
-            "supplier_acknowledgment": True,
-            "redistribution": False,
-        },
-        "retrieval": {
-            "instructions": "Stage locally.",
-            "download_url": "https://example.org/trajectories.tgz",
-            "fail_closed": True,
-        },
-        "checksums": {
-            "algorithm": "SHA-256",
-            "tree_sha256": None,
-            "expected_tree_sha256": None,
-        },
-        "conversion": {
-            "frame_rate_hz": 2.5,
-            "length_unit": "meters",
-            "coordinate_frame": "world_meters_xy",
-            "timestamp_field": "frame",
-            "agent_id_field": "pedestrian_id",
-            "position_fields": ["x", "y"],
-            "map_context_field": "scene",
-            "missing_data_behavior": "fail_closed",
-        },
-        "splits": {"naming": "scene", "members": ["eth"]},
-        "staging": {
-            "staging_dir": "${ROBOT_SF_EXTERNAL_DATA_ROOT}/issue_4013_test",
-            "local_only_raw": True,
-            "durable_storage_target": "local-only-byo",
-        },
-        "privacy": {"pii_reviewed": True, "notes": "Test manifest only."},
-        "availability": "missing",
-        "benchmark_eligibility": "diagnostic_only",
-        "related_issues": [4013],
-    }
+    manifest = _valid_manifest_fixture.__wrapped__()
+    manifest["availability"] = "validated"
+    manifest["benchmark_eligibility"] = "research_only"
+    return manifest
 
 
 def _write_manifest(tmp_path: Path, manifest: dict) -> Path:
-    path = tmp_path / "manifest.yaml"
-    path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
-    return path
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    return manifest_path
 
 
-def test_missing_real_dataset_blocks_phase3_without_contract_error(tmp_path: Path) -> None:
-    """Missing validated real data blocks Phase 3 without failing manifest structure."""
-    report = build_report(_write_manifest(tmp_path, _manifest()))
+@pytest.mark.parametrize(
+    ("staging_dir", "reason"),
+    [
+        ("${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo", "environment variable unresolved"),
+        ("output/external_data/missing_synthetic_byo", "staging directory missing"),
+    ],
+)
+def test_readiness_report_records_unavailable_staging_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    staging_dir: str | None,
+    reason: str,
+) -> None:
+    """The issue #4013 readiness report exposes staging-tree blockers."""
+    monkeypatch.delenv("ROBOT_SF_EXTERNAL_DATA_ROOT", raising=False)
+    manifest = _manifest()
+    manifest["staging"]["staging_dir"] = staging_dir
 
-    assert report["status"] == "blocked_real_trajectory_data_unavailable"
-    assert report["retrieval"]["download_url"] == "https://example.org/trajectories.tgz"
-    assert report["blockers"][0]["code"] == "real_trajectory.availability_not_validated"
-    assert report["preflight_issues"] == []
+    report = build_report(_write_manifest(tmp_path, manifest))
+
+    assert report["staging_tree"]["available"] is False
+    assert report["staging_tree"]["reason"] == reason
 
 
-def test_validated_research_manifest_is_ready_for_real_trajectory_training(
+def test_readiness_report_records_available_staging_tree(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Checksum-validated staged research manifests unlock real-trajectory training."""
+    """A checksum-pinned local tree is surfaced in the readiness report."""
     data_root = tmp_path / "external_data"
-    staging_dir = data_root / "issue_4013_test"
+    staging_dir = data_root / "synthetic_byo"
     staging_dir.mkdir(parents=True)
-    (staging_dir / "trajectories.csv").write_text(
-        "scene,frame,pedestrian_id,x,y\neth,0,1,0,0\n", encoding="utf-8"
-    )
+    (staging_dir / "trajectories.csv").write_text("frame,ped_id,x,y\n0,1,0,0\n", encoding="utf-8")
     monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(data_root))
-    manifest = deepcopy(_manifest())
-    manifest["availability"] = "validated"
-    manifest["benchmark_eligibility"] = "research_only"
-    tree_sha256 = contract._staging_tree_sha256(staging_dir)
+    manifest = _manifest()
+    manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
+    tree_sha256 = _staging_tree_sha256(staging_dir)
     manifest["checksums"]["tree_sha256"] = tree_sha256
     manifest["checksums"]["expected_tree_sha256"] = tree_sha256
 
     report = build_report(_write_manifest(tmp_path, manifest))
 
     assert report["status"] == "ready_for_real_trajectory_training"
-    assert report["blockers"] == []
+    assert report["staging_tree"] == {
+        "available": True,
+        "staging_dir": str(staging_dir),
+        "file_count": 1,
+        "tree_sha256": tree_sha256,
+    }
 
 
-def test_manifest_contract_error_blocks_before_training(tmp_path: Path) -> None:
-    """Manifest contract violations block before any training/evaluation can run."""
+def test_staging_tree_helper_reports_schema_invalid_missing_staging_dir() -> None:
+    """The shared helper can still describe a schema-invalid missing staging field."""
     manifest = _manifest()
-    manifest["license"]["supplier_acknowledgment"] = False
+    manifest["staging"].pop("staging_dir")
 
-    report = build_report(_write_manifest(tmp_path, manifest))
+    assert build_staging_tree_report(manifest) == {
+        "available": False,
+        "reason": "manifest.staging.staging_dir missing",
+    }
 
-    assert report["status"] == "blocked_manifest_contract"
-    assert report["blockers"][0]["code"] == "license.acknowledgment_missing"
 
+def test_staging_tree_helper_reports_empty_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The shared helper reports an empty local staging tree as unavailable."""
+    data_root = tmp_path / "external_data"
+    staging_dir = data_root / "synthetic_byo"
+    staging_dir.mkdir(parents=True)
+    monkeypatch.setenv("ROBOT_SF_EXTERNAL_DATA_ROOT", str(data_root))
+    manifest = _manifest()
+    manifest["staging"]["staging_dir"] = "${ROBOT_SF_EXTERNAL_DATA_ROOT}/synthetic_byo"
 
-def test_markdown_contains_acceptance_evidence_and_claim_boundary(tmp_path: Path) -> None:
-    """Markdown report includes the closure-audit evidence and claim boundary."""
-    report = build_report(_write_manifest(tmp_path, _manifest()))
-    markdown = render_markdown(report)
-
-    assert "Issue #4013 Real-Trajectory Readiness" in markdown
-    assert "No raw data is staged" in markdown
-    assert "Acquisition URL: `https://example.org/trajectories.tgz`" in markdown
-    assert "Acquisition instructions:" in markdown
-    assert "comparison against cv_prediction_mpc" in markdown
+    assert build_staging_tree_report(manifest) == {
+        "available": False,
+        "staging_dir": str(staging_dir),
+        "file_count": 0,
+        "reason": "staging directory empty",
+    }


### PR DESCRIPTION
## Reviewer-critical summary

What changed: promotes the real-trajectory staging-tree checksum probe into the canonical real-trajectory ingestion contract, reuses it from the existing manifest CLI, and records the same `staging_tree` payload in the issue #4013 readiness artifact.

Why now: the live closure audit for #4013 remains partial after PR #4736 because the next blocker is the unresolved checksum-pinned ETH/BIWI staging root. This slice adds a reusable evidence surface for exactly what local staging tree was observed, without downloading, staging, or redistributing raw external data.

Claim boundary: readiness/evidence-surface integration only. This is not benchmark evidence, navigation-quality evidence, paper/dissertation evidence, or evidence that real ETH/BIWI data is available on this host.

Required validation: focused real-trajectory contract tests, audit tests, Ruff, and final `pr_ready_check.sh`.

Remaining blocker: #4013 still needs a reachable checksum-pinned ETH/BIWI staging root under `ROBOT_SF_EXTERNAL_DATA_ROOT`, then real-trajectory predictor training and representative evaluation against `cv_prediction_mpc` plus one model-free baseline.

Refs #4013.

## Contract delta

- Adds `build_staging_tree_report(manifest)` to the real-trajectory ingestion contract.
- `scripts/tools/check_real_trajectory_manifest.py --staging-checksum` now uses the shared contract helper instead of duplicate private logic.
- `issue_4013.real_trajectory_readiness.v1` now includes `staging_tree` with availability, resolved staging path, optional file count, optional tree SHA-256, and fail-closed reason.
- Compatibility impact: additive JSON/Markdown fields only; no raw external data is read unless a caller already points the manifest at a local staging directory.
- New fail-closed blocker: none. Existing unresolved `ROBOT_SF_EXTERNAL_DATA_ROOT` blocker is now represented in the readiness artifact as `staging_tree.available=false`.

## Validation

- `uv run python scripts/training/check_issue_4013_real_trajectory_readiness.py` passed; regenerated readiness evidence with `status=blocked_manifest_contract` and `staging_tree.available=false`.
- `uv run python scripts/analysis/audit_issue_4013_acceptance.py --write` passed; closure remains `partial`.
- `uv run pytest tests/data/test_real_trajectory_contract.py tests/analysis/test_audit_issue_4013_acceptance.py -q` passed: 28 passed.
- `uv run ruff check robot_sf/data_ingestion/real_trajectory_contract.py scripts/tools/check_real_trajectory_manifest.py scripts/training/check_issue_4013_real_trajectory_readiness.py tests/data/test_real_trajectory_contract.py scripts/analysis/audit_issue_4013_acceptance.py tests/analysis/test_audit_issue_4013_acceptance.py` passed.
- `uv run ruff format --check robot_sf/data_ingestion/real_trajectory_contract.py scripts/tools/check_real_trajectory_manifest.py scripts/training/check_issue_4013_real_trajectory_readiness.py tests/data/test_real_trajectory_contract.py scripts/analysis/audit_issue_4013_acceptance.py tests/analysis/test_audit_issue_4013_acceptance.py` passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed on dirty-tree interim run: 1924 passed, 2 skipped.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=.git/codex-agent-runs/active/issue-4013/pr_body.md scripts/dev/pr_ready_check.sh` passed on clean head `715e308e62a2c95284319b8311ebd07e30bd0a5f`: core lane 1926 passed; optional-extra lane 5153 passed, 5 skipped; changed-file coverage satisfied; freshness stamp passed.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no raw external dataset staging or redistribution, no paper/dissertation claim edits.

## Research Result Guidance
- Evidence tier: NA - readiness plumbing only, no new research result
- Result classification: NA - no benchmark or paper claim

## Domain-Aware Approval
- Required PR: yes - evidence-validity-sensitive result classification
- Domains reviewed: evidence classification, figure eligibility
- Status: waived
- Approver/review source waiver: maintainer waiver; diagnostic-only docs update
- Validity checklist:
 - Target claim/hypothesis: issue claim boundary stays diagnostic-only
 - Comparator or split/evidence validity: existing targeted smoke proof only
 - Fallback/degraded exclusions: fallback/degraded evidence remains excluded
 - Claim boundary: no paper-facing benchmark claim
 - Implementation integrity vs experimental validity: tests prove gate behavior, not result validity

## State Propagation

No issue comment is posted because #4013 is high churn and comments are not authorized for this run. The changed durable evidence surface is `docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.{json,md}`; it is the canonical state update for this slice.

<details>
<summary>Acceptance evidence</summary>

| Criterion | Evidence | Status |
| --- | --- | --- |
| Short-horizon predictor contract and learned backend exist. | Merged PRs #4474/#4629 plus checked-in training manifest. | Met at diagnostic tier |
| Short-horizon predictor trains or fails closed with dataset blocker. | Diagnostic training evidence exists; real-data readiness remains fail-closed. | Met at diagnostic tier |
| Model-based action selection runs on a smoke scenario. | PR #4644 and PR #4655 evidence. | Met at diagnostic tier |
| Comparator smoke includes `cv_prediction_mpc` and model-free baseline. | `comparison_report.v1.json` roles include all three arms. | Met at diagnostic tier |
| Fallback/degraded rows excluded or marked non-evidence. | Comparator report excludes fallback/degraded evidence rows. | Met |
| Claim boundary excludes large world-model and paper-grade claims. | Existing #4013 evidence remains diagnostic-only. | Met |
| Real pedestrian trajectory dataset is reachable and checksum-pinned. | Current readiness now records `staging_tree.available=false` because `ROBOT_SF_EXTERNAL_DATA_ROOT` is unresolved. | Blocked |
| Real-trajectory predictor training has run on validated data. | No checked-in real-data training evidence. | Blocked |
| Representative evaluation compares learned predictor against `cv_prediction_mpc` and one model-free baseline. | Existing comparison is diagnostic synthetic/checkpoint smoke only. | Blocked |

Fragmentation guard: multiple #4013 guard/checker/audit PRs merged in the last 24 hours. This PR is a progression/integration slice with a nameable new capability: reusable staging-tree evidence in the canonical real-trajectory readiness contract.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Readiness reports now include staging tree status, location, file count, and checksum details.
  * Markdown documentation for the dataset gate now shows the new staging tree information.

* **Bug Fixes**
  * Staging tree checks now fail closed when the data root is missing, unresolved, empty, or unavailable.

* **Tests**
  * Added coverage for staging tree availability, checksum matching, and failure reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->