### PR TITLE
Issue #3637: add reactivity rank finalizer

### DIFF
--- a/scripts/benchmark/finalize_reactivity_replay_rank_study_issue_3637.py
+++ b/scripts/benchmark/finalize_reactivity_replay_rank_study_issue_3637.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Finalize issue #3637 post-run analysis and compact evidence promotion.
+
+This command does not run the benchmark campaign. It is the post-run bridge for
+the predeclared campaign output: validate the completed campaign with the
+issue-specific analyzer, promote the compact reviewable artifacts, and emit one
+machine-readable handoff report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+_ANALYZER_PATH = (
+    _REPO_ROOT / "scripts" / "benchmark" / ("analyze_reactivity_replay_rank_study_issue_3637.py")
+)
+_PROMOTER_PATH = (
+    _REPO_ROOT / "scripts" / "benchmark" / ("promote_reactivity_replay_rank_study_issue_3637.py")
+)
+
+
+def _load_module(path: Path, name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_ANALYZER = _load_module(_ANALYZER_PATH, "_issue_3637_analyzer")
+_PROMOTER = _load_module(_PROMOTER_PATH, "_issue_3637_promoter")
+
+ISSUE = 3637
+SCHEMA_VERSION = "issue-3637-reactivity-replay-rank-finalization.v1"
+
+DEFAULT_PACKET = _ANALYZER.DEFAULT_PACKET
+DEFAULT_CAMPAIGN_DIR = _ANALYZER.DEFAULT_CAMPAIGN_DIR
+DEFAULT_CAMPAIGN_REPORT = _ANALYZER.DEFAULT_CAMPAIGN_REPORT
+DEFAULT_ANALYSIS_DIR = _ANALYZER.DEFAULT_OUTPUT_DIR
+DEFAULT_EVIDENCE_DIR = _PROMOTER.DEFAULT_EVIDENCE_DIR
+
+
+class FinalizationError(RuntimeError):
+    """Raised when issue #3637 post-run finalization cannot complete."""
+
+
+def finalize(
+    *,
+    packet_path: Path,
+    campaign_dir: Path,
+    campaign_report: Path,
+    analysis_dir: Path,
+    evidence_dir: Path,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Run analyzer and promoter as one post-campaign finalization step."""
+    try:
+        analysis = _ANALYZER.analyze(
+            packet_path=packet_path,
+            campaign_dir=campaign_dir,
+            campaign_report=campaign_report,
+            output_dir=analysis_dir,
+        )
+        promotion = _PROMOTER.promote(
+            analysis_dir,
+            evidence_dir,
+            overwrite=overwrite,
+        )
+    except (_ANALYZER.AnalysisInputError, _PROMOTER.PromotionError) as exc:
+        raise FinalizationError(str(exc)) from exc
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "finalized",
+        "issue": ISSUE,
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "packet": str(packet_path),
+        "campaign_dir": str(campaign_dir),
+        "campaign_report": str(campaign_report),
+        "analysis_dir": str(analysis_dir),
+        "evidence_dir": str(evidence_dir),
+        "analysis": {
+            "schema_version": analysis.get("schema_version"),
+            "episode_count": analysis.get("episode_count"),
+            "expected_episode_count": analysis.get("expected_episode_count"),
+            "claim_decision": analysis.get("claim_decision"),
+            "claim_boundary": analysis.get("claim_boundary"),
+            "seed_sufficiency_gate_decision": analysis.get("seed_sufficiency_gate_decision"),
+            "replay_limitation": analysis.get("replay_limitation"),
+        },
+        "promotion": promotion,
+        "closure_decision": "review_promoted_evidence_before_closure",
+        "remaining_acceptance_criteria": [
+            "Maintainer/reviewer must inspect promoted evidence and decide whether "
+            "the seed-sufficiency result supports closing issue #3637.",
+            "No paper-facing claim is established by this command alone.",
+        ],
+        "forbidden_actions_confirmed": {
+            "benchmark_campaign_execution": False,
+            "slurm_gpu_submission": False,
+            "paper_dissertation_claim_edit": False,
+        },
+    }
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
+    parser.add_argument("--campaign-dir", type=Path, default=DEFAULT_CAMPAIGN_DIR)
+    parser.add_argument("--campaign-report", type=Path, default=DEFAULT_CAMPAIGN_REPORT)
+    parser.add_argument("--analysis-dir", type=Path, default=DEFAULT_ANALYSIS_DIR)
+    parser.add_argument("--evidence-dir", type=Path, default=DEFAULT_EVIDENCE_DIR)
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="replace files in an existing evidence directory",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the issue #3637 post-run finalizer CLI."""
+    args = _parse_args(argv)
+    try:
+        result = finalize(
+            packet_path=args.packet,
+            campaign_dir=args.campaign_dir,
+            campaign_report=args.campaign_report,
+            analysis_dir=args.analysis_dir,
+            evidence_dir=args.evidence_dir,
+            overwrite=args.overwrite,
+        )
+    except FinalizationError as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "status": "blocked",
+                    "issue": ISSUE,
+                    "reason": str(exc),
+                    "next_empirical_action": (
+                        "Run the predeclared issue #3637 campaign, then rerun this finalizer."
+                    ),
+                },
+                sort_keys=True,
+            )
+        )
+        return 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py
+++ b/scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py
@@ -101,6 +101,7 @@ def _build_integration_report(
     campaign_dir: Path,
     report_json: Path,
     analyzer_command: str,
+    finalizer_command: str,
     preflight: dict[str, Any],
 ) -> dict[str, Any]:
     """Return machine-readable post-run handoff contract for issue #3637."""
@@ -121,17 +122,18 @@ def _build_integration_report(
             "campaign_report": str(report_json),
             "preflight_status": preflight["status"],
             "post_run_analyzer": analyzer_command,
+            "post_run_finalizer": finalizer_command,
         },
         "required_post_run_artifacts": [
             str(analysis_dir / filename) for filename in ANALYSIS_OUTPUT_FILES
         ],
         "remaining_acceptance_criteria": [
             "Run the predeclared >=3-planner, 20-seed reactive-vs-replay campaign.",
-            "Run the post-run analyzer against the completed campaign JSONL files.",
+            "Run the post-run finalizer against the completed campaign JSONL files.",
             "Record rank-stability and seed-sufficiency outputs in a durable evidence bundle.",
             "Classify the result conservatively before any paper-facing claim or issue closure.",
         ],
-        "next_empirical_action": analyzer_command,
+        "next_empirical_action": finalizer_command,
         "closure_decision": "keep_open_until_analysis_artifacts_exist",
         "forbidden_actions_confirmed": {
             "slurm_gpu_submission": False,
@@ -170,12 +172,20 @@ def main(argv: list[str] | None = None) -> int:
         f"--packet {args.packet} --campaign-dir {args.out_dir} "
         f"--campaign-report {args.report_json} --output-dir {args.out_dir / 'analysis'}"
     )
+    finalizer_command = (
+        "uv run python scripts/benchmark/"
+        "finalize_reactivity_replay_rank_study_issue_3637.py "
+        f"--packet {args.packet} --campaign-dir {args.out_dir} "
+        f"--campaign-report {args.report_json} --analysis-dir {args.out_dir / 'analysis'}"
+    )
     report["post_run_analyzer"] = analyzer_command
+    report["post_run_finalizer"] = finalizer_command
     report["integration_report"] = _build_integration_report(
         packet_path=args.packet,
         campaign_dir=args.out_dir,
         report_json=args.report_json,
         analyzer_command=analyzer_command,
+        finalizer_command=finalizer_command,
         preflight=preflight,
     )
 

--- a/tests/benchmark/test_finalize_reactivity_replay_rank_study_issue_3637.py
+++ b/tests/benchmark/test_finalize_reactivity_replay_rank_study_issue_3637.py
@@ -1,0 +1,200 @@
+"""Tests issue #3637 post-run finalizer."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = (
+    REPO_ROOT / "scripts" / "benchmark" / "finalize_reactivity_replay_rank_study_issue_3637.py"
+)
+
+SPEC = importlib.util.spec_from_file_location("_issue_3637_finalizer", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+FINALIZER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(FINALIZER)
+
+PLANNERS = ("goal", "orca", "social_force")
+CONDITIONS = ("reactive", "replay")
+SCENARIOS = ("classic_crossing_low", "classic_crossing_high")
+
+
+def _write_packet(tmp_path: Path, *, seeds: list[int]) -> Path:
+    scenario_set = tmp_path / "scenario_set.yaml"
+    scenario_set.write_text(
+        yaml.safe_dump({"select_scenarios": list(SCENARIOS)}),
+        encoding="utf-8",
+    )
+    packet = {
+        "schema_version": "reactivity_replay_rank_study_preflight.v1",
+        "issue": 3637,
+        "planners": list(PLANNERS),
+        "scenario_set": str(scenario_set),
+        "horizon": 300,
+        "seeds": seeds,
+        "replay": {
+            "is_trajectory_playback": False,
+            "limitation": (
+                "'replay' = robot->pedestrian social-force term disabled in live "
+                "social-force sim (peds_have_robot_repulsion=false); NOT "
+                "pre-recorded trajectory playback."
+            ),
+        },
+        "min_planners": 3,
+        "min_seeds": 20,
+        "rank_stability_analysis": {
+            "paired_seed_resampling": True,
+            "required_metrics": ["collision_rate", "near_miss_rate", "min_separation_m"],
+            "rank_metric": "collision_rate",
+            "bootstrap_resamples": 5000,
+            "schedule": "s20",
+            "target_ci_half_width": 0.10,
+            "rank_effect_stability_threshold": 0.95,
+            "seed_sufficiency_gate_command": (
+                "uv run python scripts/tools/seed_sufficiency_gate.py "
+                "--input-json <frozen_gate_input.json>"
+            ),
+            "replay_limitation_required": True,
+            "claim_boundary": (
+                "No paper-facing claim until post-run seed-sufficiency gate and "
+                "claim-card review confirm rank-stability evidence with the replay "
+                "force-off limitation."
+            ),
+        },
+        "out_of_scope": [
+            "no_full_benchmark_campaign",
+            "no_slurm_gpu_submission",
+            "no_paper_dissertation_claim_edits",
+        ],
+    }
+    packet_path = tmp_path / "packet.yaml"
+    packet_path.write_text(yaml.safe_dump(packet), encoding="utf-8")
+    return packet_path
+
+
+def _record(scenario: str, seed: int, *, collision: int) -> dict[str, object]:
+    return {
+        "scenario_id": scenario,
+        "seed": seed,
+        "metrics": {
+            "total_collision_count": collision,
+            "near_misses": collision,
+            "min_clearance": 1.0,
+        },
+    }
+
+
+def _write_campaign(tmp_path: Path, *, seeds: list[int]) -> tuple[Path, Path]:
+    campaign_dir = tmp_path / "campaign"
+    campaign_dir.mkdir()
+    collision_plan = {
+        "goal": {"reactive": 0, "replay": 1},
+        "orca": {"reactive": 1, "replay": 0},
+        "social_force": {"reactive": 0, "replay": 0},
+    }
+    for planner in PLANNERS:
+        for condition in CONDITIONS:
+            rows = [
+                _record(
+                    scenario,
+                    seed,
+                    collision=collision_plan[planner][condition],
+                )
+                for seed in seeds
+                for scenario in SCENARIOS
+            ]
+            (campaign_dir / f"episodes_{planner}_{condition}.jsonl").write_text(
+                "".join(json.dumps(row) + "\n" for row in rows),
+                encoding="utf-8",
+            )
+    report_path = campaign_dir / "report.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "reactivity-ablation-campaign.v1",
+                "replay_limitation": {"is_trajectory_playback": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return campaign_dir, report_path
+
+
+def test_finalize_runs_analyzer_and_promotes_evidence(tmp_path: Path) -> None:
+    """A complete campaign bundle becomes compact durable evidence in one command."""
+    seeds = list(range(101, 121))
+    packet = _write_packet(tmp_path, seeds=seeds)
+    campaign_dir, campaign_report = _write_campaign(tmp_path, seeds=seeds)
+    analysis_dir = tmp_path / "analysis"
+    evidence_dir = tmp_path / "evidence"
+
+    result = FINALIZER.finalize(
+        packet_path=packet,
+        campaign_dir=campaign_dir,
+        campaign_report=campaign_report,
+        analysis_dir=analysis_dir,
+        evidence_dir=evidence_dir,
+    )
+
+    assert result["status"] == "finalized"
+    assert result["issue"] == 3637
+    assert result["analysis"]["episode_count"] == 240
+    assert result["analysis"]["expected_episode_count"] == 240
+    assert result["promotion"]["status"] == "promoted"
+    assert (analysis_dir / "seed_gate_decision.json").exists()
+    assert (evidence_dir / "seed_gate_decision.json").exists()
+    assert (evidence_dir / "manifest.sha256").exists()
+    assert result["forbidden_actions_confirmed"] == {
+        "benchmark_campaign_execution": False,
+        "slurm_gpu_submission": False,
+        "paper_dissertation_claim_edit": False,
+    }
+
+
+def test_finalize_fails_closed_when_campaign_outputs_missing(tmp_path: Path) -> None:
+    """The finalizer reports ordinary missing inputs as blocked, not partial evidence."""
+    seeds = list(range(101, 121))
+    packet = _write_packet(tmp_path, seeds=seeds)
+    with pytest.raises(FINALIZER.FinalizationError, match="missing campaign report"):
+        FINALIZER.finalize(
+            packet_path=packet,
+            campaign_dir=tmp_path / "missing-campaign",
+            campaign_report=tmp_path / "missing-campaign" / "report.json",
+            analysis_dir=tmp_path / "analysis",
+            evidence_dir=tmp_path / "evidence",
+        )
+
+
+def test_cli_reports_blocked_for_missing_campaign(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The CLI emits a compact blocked JSON object for absent campaign outputs."""
+    seeds = list(range(101, 121))
+    packet = _write_packet(tmp_path, seeds=seeds)
+
+    exit_code = FINALIZER.main(
+        [
+            "--packet",
+            str(packet),
+            "--campaign-dir",
+            str(tmp_path / "missing-campaign"),
+            "--campaign-report",
+            str(tmp_path / "missing-campaign" / "report.json"),
+            "--analysis-dir",
+            str(tmp_path / "analysis"),
+            "--evidence-dir",
+            str(tmp_path / "evidence"),
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "blocked"
+    assert payload["issue"] == 3637
+    assert "missing campaign report" in payload["reason"]

--- a/tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py
+++ b/tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py
@@ -81,6 +81,7 @@ def test_runner_uses_packet_plan_and_writes_report(monkeypatch: pytest.MonkeyPat
     assert report["preflight_status"] == "ready"
     assert report["launch_packet"] == str(PACKET)
     assert "analyze_reactivity_replay_rank_study_issue_3637.py" in report["post_run_analyzer"]
+    assert "finalize_reactivity_replay_rank_study_issue_3637.py" in report["post_run_finalizer"]
     integration = report["integration_report"]
     assert (
         integration["schema_version"] == "issue-3637-reactivity-replay-rank-integration-report.v1"
@@ -93,6 +94,7 @@ def test_runner_uses_packet_plan_and_writes_report(monkeypatch: pytest.MonkeyPat
         "campaign_report": str(report_json),
         "preflight_status": "ready",
         "post_run_analyzer": report["post_run_analyzer"],
+        "post_run_finalizer": report["post_run_finalizer"],
     }
     assert integration["required_post_run_artifacts"] == [
         str(out_dir / "analysis" / "README.md"),
@@ -102,7 +104,7 @@ def test_runner_uses_packet_plan_and_writes_report(monkeypatch: pytest.MonkeyPat
         str(out_dir / "analysis" / "rank_bootstrap_summary.json"),
         str(out_dir / "analysis" / "per_planner_condition_metrics.csv"),
     ]
-    assert integration["next_empirical_action"] == report["post_run_analyzer"]
+    assert integration["next_empirical_action"] == report["post_run_finalizer"]
     assert integration["forbidden_actions_confirmed"] == {
         "slurm_gpu_submission": False,
         "paper_dissertation_claim_edit": False,


### PR DESCRIPTION
## Reviewer-critical summary

What changed: adds `scripts/benchmark/finalize_reactivity_replay_rank_study_issue_3637.py`, a CPU-only post-run finalizer that runs the existing #3637 analyzer and evidence promoter as one fail-closed command after the predeclared campaign output exists. The packet-backed launcher now records this finalizer as `post_run_finalizer` and as the `next_empirical_action` in its integration report.

Why now: the closure audit found #3637 is still open after PR #4739 because the empirical campaign has not run. This is the smallest non-duplicative integration slice under the high-churn fragmentation guard: it adds the nameable missing post-run artifact-first command, rather than another blocker note or packet refresh.

Claim boundary: Refs #3637. This PR does not run the benchmark campaign, does not promote real #3637 evidence, does not claim rank stability, and does not close the issue. The finalizer only works after completed campaign JSONL files and the campaign report exist; otherwise it returns `status=blocked`.

Required validation: focused finalizer/launcher/analyzer/promoter tests, Ruff check/format, default finalizer blocked check on the current missing campaign output, and final PR readiness wrapper on the clean branch.

Remaining blocker: #3637 still needs the predeclared `goal`, `orca`, `social_force` × seeds `101..120` reactivity-vs-replay campaign run, then this finalizer must be run and the promoted compact evidence must be reviewed before any closure or paper-facing claim.

## Contract delta

New schema fields: `post_run_finalizer` in the issue #3637 launcher report and integration report.
New fail-closed blockers: the finalizer returns blocked JSON if campaign report/JSONL inputs are missing, analyzer validation fails, or promotion refuses incomplete artifacts.
Compatibility impact: additive issue-specific script and report field. Existing analyzer, promoter, runner defaults, planner behavior, metric semantics, schemas, and benchmark execution behavior are unchanged.
State propagation: no issue comment posted because `comment_issue_or_pr=false`; this PR body is the durable handoff surface for delivered slice and remaining checklist.

## Scope summary

Issue link: https://github.com/ll7/robot_sf_ll7/issues/3637

This PR adds one post-run command:

```bash
uv run python scripts/benchmark/finalize_reactivity_replay_rank_study_issue_3637.py \
  --packet configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml \
  --campaign-dir output/issue_3637_reactivity_rank_study \
  --campaign-report output/issue_3637_reactivity_rank_study/report.json \
  --analysis-dir output/issue_3637_reactivity_rank_study/analysis
```

The command runs the existing analyzer, writes `analysis.json`, `frozen_gate_input.json`, `seed_gate_decision.json`, `rank_bootstrap_summary.json`, and `per_planner_condition_metrics.csv`, then promotes the compact evidence bundle through the existing promoter.

Refs #3637

## Acceptance evidence

| Criterion | Evidence | Status |
| --- | --- | --- |
| Reactivity-vs-replay run across >=3 planners seed budget sufficient rank stability | Merged PRs #3696/#4150/#4707/#4716/#4739 provide packet, launcher, integration handoff, and gate-decision contract. This PR adds finalizer handoff after campaign output exists. | Not complete until campaign runs. |
| Rank stability / confidence reported reactivity effect | Analyzer/promoter contract exists; this PR runs them together and fails closed if inputs are missing. | Contract ready; empirical output pending. |
| Replay force-off limitation stated | Existing analyzer/promoter checks still require `is_trajectory_playback=false`. | Mechanism surfaces met; final empirical bundle pending. |
| Conservative docs/context interpretation | No interpretation changed here. Finalizer emits promoted evidence for later review. | Pending empirical bundle review. |
| Run reproduces same command and seed set | Launcher now points from packet-backed campaign report to the finalizer as next empirical action. | Launch/finalization handoff met; empirical output pending. |

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_finalize_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_analyze_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_promote_reactivity_replay_rank_study_issue_3637.py -q` -> passed, 19 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/finalize_reactivity_replay_rank_study_issue_3637.py scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_finalize_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/benchmark/finalize_reactivity_replay_rank_study_issue_3637.py scripts/benchmark/run_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_finalize_reactivity_replay_rank_study_issue_3637.py tests/benchmark/test_run_reactivity_replay_rank_study_issue_3637.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/finalize_reactivity_replay_rank_study_issue_3637.py --packet configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml --campaign-dir output/issue_3637_reactivity_rank_study --campaign-report output/issue_3637_reactivity_rank_study/report.json --analysis-dir output/issue_3637_reactivity_rank_study/analysis --evidence-dir /tmp/issue_3637_no_write_evidence` -> expected blocked, exit 1, `reason="missing campaign report: output/issue_3637_reactivity_rank_study/report.json"`.

Final readiness wrapper result will be added before opening.

## Remaining checklist

- [ ] Execute the predeclared issue #3637 campaign for `goal`, `orca`, `social_force`, seeds `101..120`.
- [ ] Run the new finalizer against completed outputs.
- [ ] Review promoted compact evidence and `seed_gate_decision.json`.
- [ ] Record conservative interpretation and closure decision; close only if acceptance criteria are met.

## Explicit out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Appendix: PR template fields</summary>

## Linked Issues

- Refs `#3637`

## Stack / Dependency

- Base dependency: merged #4739
- Safe review independently: yes
- Review dependency reason, any: additive issue-specific post-run finalization bridge

## Research Result Guidance

- Target claim / blocker this affects: post-run artifact-first finalization for #3637 after campaign output exists.
- Evidence tier: targeted smoke / support tooling.
- Result classification: blocker-resolution for workflow integration, not benchmark evidence.
- Parent issue: #3637 remains open for empirical campaign execution and interpretation.

## Risks / Rollout

- Compatibility risks: new report field is additive; downstream readers that ignore unknown fields are unaffected.
- Failure modes: finalizer returns blocked until campaign outputs exist, by design.
- Rollback fallback plan: use existing analyzer and promoter separately.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: issue #3637 thread and merged PRs #4462/#4707/#4716/#4728/#4739.

</details>

## Domain-Aware Approval

- Required for PR: approval required for benchmark/evidence-contract wording.
- Domains reviewed: issue #3637 benchmark evidence finalization contract, seed-sufficiency artifact promotion boundary.
- Status: waived.
- Approver/review source waiver: self-review waiver for non-empirical, issue-specific post-run workflow integration; no benchmark result or paper-facing claim is promoted.
- Approval or blocker note: empirical validity remains blocked on the actual #3637 campaign run and promoted evidence review.
- Validity checklist:
  - Target claim/hypothesis: no reactivity-rank claim promoted.
  - Comparator or split/evidence validity: no comparator result interpreted; tests use synthetic complete/missing campaign fixtures only.
  - Fallback/degraded exclusions: unchanged; fallback/degraded execution remains non-success evidence.
  - Claim boundary: finalizer does not close #3637 or establish paper-facing evidence by itself.
  - Implementation integrity vs experimental validity: focused tests prove finalization wiring and fail-closed behavior only.

## Final Readiness

- `PR_READY_PR_BODY_FILE=/tmp/issue_3637_pr/body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed on clean head `bec0467ef37483c37a0f752de4227fdaa63174dd`; stamp `output/validation/pr_ready/issue-3637-closure-audit-20260707d.json`.
