### PR TITLE
Issue #4756: add agent_run_manifest convention (cheap-lane worker)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,7 @@ thin: existing Markdown files remain the source of truth, and generated HTML und
 * **[ETH/UCY External Trajectory Data](./datasets/eth-ucy.md)** - Public acquisition, citation, and expected layout notes for locally staged ETH BIWI and UCY Crowds-by-Example trajectories
 * **[Context Retrieval Index](./context/INDEX.md)** - Retrieval-first catalog for current context-note entry points, status rules, optional context tools, and curated context-pack scopes
 * **[Agent Workflow Entrypoints And Large-File Navigation](./ai/agent_workflow_entrypoints.md)** - Correct `uv run` command patterns, validation entrypoints, model registry path, and targeted large-file reading guidance for agents
+* **[Agent Run Manifest](./agent_run_manifest.md)** - Lightweight `agent_run_manifest.yaml` convention for making substantial agent-assisted runs auditable: when it is required, where to store it, trace/log hygiene, and a copyable template
 * **[Issue #2013 Backend Adapter Contract](./context/issue_2013_backend_adapter_contract.md)** - Required adapter fields, fail-closed behavior, and claim boundaries for alternate simulator backend integration
 * **[Context Notes Workflow](./context/README.md)** - Canonical rules for linked Markdown handoff notes, note updates vs new notes, stale-note handling, and discoverability
 * **[Planner Contribution Guide](./contributing_planner.md)** - Minimum path for adding a planner with adapter/protocol metadata, config-first invocation, smoke proof, registry status, and benchmark boundaries

--- a/docs/agent_run_manifest.md
+++ b/docs/agent_run_manifest.md
@@ -1,0 +1,146 @@
+# Agent Run Manifest
+
+[Back to Documentation Index](./README.md)
+
+**Status**: Canonical convention for making substantial agent-assisted runs auditable.
+
+**Related issue**: [#4756](https://github.com/ll7/robot_sf_ll7/issues/4756)
+
+## What this manifest is for
+
+An `agent_run_manifest.yaml` is a lightweight, copyable record that captures what a substantial
+agent-assisted run did, under which tool/model/version and permission mode, which commands and tests
+it ran, what evidence it produced, and what trace/log hygiene and human validation were performed.
+It makes large Codex, Claude Code, Copilot, or other agent-assisted runs auditable without
+introducing a workflow system, telemetry collector, or runtime dependency.
+
+It is a documentation/template/checklist convention only. This first slice does not add mandatory CI
+enforcement, YAML schema validation libraries, or GitHub Actions. Follow-up issues may add a schema
+checker if validation is desired.
+
+## When the manifest is required
+
+Required for major agent-assisted work that creates or changes any of:
+
+- durable evidence (promoted into `docs/context/evidence/`),
+- benchmark or reporting gates,
+- generated artifacts that become durable dependencies,
+- CI or release policy,
+- substantial code paths.
+
+Recommended for multi-agent or multi-run tasks even when each individual task is small, so the
+combined run stays reviewable.
+
+## When the manifest is optional
+
+Optional for small comment-only edits, trivial docs tweaks, or single-line fixes that do not touch
+durable evidence, gates, generated artifacts, CI/release policy, or substantial code paths. When in
+doubt, attach one; a cheap manifest is better than an unrecorded run.
+
+## Where to store it
+
+- For a **PR evidence bundle**: attach or link the manifest in the PR body, or place it next to the
+  evidence under `docs/context/evidence/<issue-or-topic>/agent_run_manifest.yaml`. Do not store
+  manifests under worktree-local `output/`.
+- For an **issue evidence packet**: attach or link the manifest in an issue comment, or place it next
+  to the issue evidence under `docs/context/evidence/`.
+- Keep manifests repository-relative and tracked when they support durable evidence; keep them as
+  linked, redacted attachments when they only support an exploratory run.
+
+Start from [`docs/templates/agent_run_manifest.yaml`](./templates/agent_run_manifest.yaml). A scrubbed
+illustrative example is at
+[`docs/templates/agent_run_manifest.example.yaml`](./templates/agent_run_manifest.example.yaml).
+
+## What the manifest captures
+
+The template captures:
+
+- `schema_version` (`agent-run-manifest.v1`) so future validation can evolve cleanly;
+- tool, model, version, and permission mode;
+- worktree and optional workflow run id/name;
+- declared and actual agent counts;
+- commands run and tests run;
+- external pages accessed;
+- trace/log references (redacted or stored-privately);
+- trace redaction checked flag;
+- coarse cost or credit cap;
+- stop reason and retry count;
+- partial failures;
+- evidence produced (with durable locations);
+- human validity check note;
+- remaining risk.
+
+## Trace and log hygiene
+
+- Do not paste raw traces, private prompts, secrets, or precise token/credit details into a manifest.
+- Prefer a `trace_or_log_refs` entry that points to a stored-privately path or a redacted excerpt.
+- Set `trace_redaction_checked: true` only after reviewing the referenced traces/logs and confirming
+  they do not leak secrets, private prompts, or non-public user data.
+- Keep `cost_or_credit_cap` coarse (for example `~10 USD` or `<5% of weekly cap`); do not record
+  exact token counts or private billing details.
+
+See the [Artifact Evidence Vocabulary](./context/artifact_evidence_vocabulary.md) for the
+durable-vs-local distinction. Manifest `evidence_produced` entries should name durable locations,
+not worktree-local `output/` paths.
+
+## Human validation expectations
+
+- A human (reviewer or maintainer) should confirm the manifest fields match the actual run before
+  treating the run as established evidence.
+- `human_validity_check` should record what was checked (for example, "diff reviewed, validation
+  command rerun, template fields checked against issue acceptance criteria") or `pending`.
+- Fallback, degraded, failed, or not-available execution modes must be named in `partial_failures` or
+  `remaining_risk`; they are caveats, not success evidence, per the
+  [Issue #691 Benchmark Fallback Policy](./context/issue_691_benchmark_fallback_policy.md).
+
+## Examples
+
+### PR evidence bundle
+
+A PR that used a nontrivial agent run to add a durable evidence bundle should attach or link a
+manifest in the PR body, for example:
+
+```text
+Agent run manifest: docs/context/evidence/issue_4756_agent_run_manifest/agent_run_manifest.yaml
+- [x] If this PR used a nontrivial agent run, attach or link an agent_run_manifest.yaml and confirm
+      trace/log redaction was checked.
+```
+
+### Issue evidence packet
+
+An issue comment that posts agent-produced evidence should attach or link a manifest, for example:
+
+```text
+Agent run manifest: attached (scrubbed). Evidence produced: docs/context/evidence/issue_NNNN_*/.
+Trace redaction checked: true. Human validity check: pending maintainer review.
+```
+
+## Verification
+
+A minimal YAML-parse smoke for the template:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import yaml
+for path in [Path('docs/templates/agent_run_manifest.yaml'), Path('docs/templates/agent_run_manifest.example.yaml')]:
+    data = yaml.safe_load(path.read_text())
+    assert isinstance(data, dict)
+    assert data['agent_run']['schema_version'] == 'agent-run-manifest.v1'
+PY
+```
+
+If the repo has docs lint checks, run them as well. Otherwise use:
+
+```bash
+git diff --check
+```
+
+## Non-goals for this slice
+
+- No telemetry collectors, agent integrations, or mandatory CI enforcement.
+- No YAML validation libraries or GitHub Actions.
+- No change to existing evidence, benchmark, or release gates.
+
+Follow-up issues may add a schema checker or CI enforcement once the convention has been used enough
+to justify it.

--- a/docs/context/artifact_evidence_vocabulary.md
+++ b/docs/context/artifact_evidence_vocabulary.md
@@ -49,6 +49,10 @@ coverage, temporary exports, videos, and caches, but it is not a durable depende
   hydrated, the dependent benchmark or planner path should fail closed with an actionable message.
 - When evidence is expensive or too large to commit, track a manifest or pointer instead of copying
   raw episodes, videos, checkpoints, model caches, or logs into git.
+- Substantial agent-produced evidence should include an
+  [Agent Run Manifest](../agent_run_manifest.md) (`agent_run_manifest.yaml`) in the evidence bundle
+  so the run that produced the evidence is auditable. Start from
+  [`docs/templates/agent_run_manifest.yaml`](../templates/agent_run_manifest.yaml).
 
 ## Learned-Policy Artifact Manifests
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1936,6 +1936,19 @@ follow the higher-precedence source and make the smallest doc update needed to r
 7) Open PR with summary, risks, validation evidence, and links to docs/tests. Explicitly state
    which gates were skipped when using the cheap docs/instruction path.
 
+### Agent run manifest for PRs
+
+For nontrivial agent-assisted runs (Codex, Claude Code, Copilot, or other), attach or link an
+`agent_run_manifest.yaml` so the run is auditable. See
+[Agent Run Manifest](./agent_run_manifest.md) for when this is required versus optional, where to
+store it, and trace/log hygiene. Start from
+[`docs/templates/agent_run_manifest.yaml`](./templates/agent_run_manifest.yaml). Do not block all
+PRs on this yet; it is required for major agent-assisted work that creates or changes durable
+evidence, benchmark/reporting gates, generated artifacts, CI/release policy, or substantial code
+paths, and recommended for multi-agent or multi-run tasks.
+
+- [ ] If this PR used a nontrivial agent run, attach or link an agent_run_manifest.yaml and confirm trace/log redaction was checked.
+
 ### Final-readiness checklist for scripted tooling work
 - Run `uv run ruff check <touched_files>` and `uv run ruff format <touched_files>` before finalizing.
 - Run focused tests that cover modified paths (for example `uv run pytest tests/dev/test_snapshot_pr_queue.py`).

--- a/docs/templates/agent_run_manifest.example.yaml
+++ b/docs/templates/agent_run_manifest.example.yaml
@@ -1,0 +1,40 @@
+# Agent Run Manifest Example
+#
+# A small, scrubbed, illustrative example. Do not include real secrets, raw
+# traces, private prompts, or token/credit details beyond coarse caps. Copy
+# docs/templates/agent_run_manifest.yaml as the starting point for a real run.
+agent_run:
+  schema_version: agent-run-manifest.v1
+  objective: "Add docs-only agent run manifest convention with template and checklist."
+  tool: "codex"
+  model: "gpt-5-codex"
+  tool_version: "codex-cli 0.0.123"
+  permission_mode: "manual"
+  worktree: "../robot_sf_ll7.worktrees/cheap-issue-4756"
+  workflow_run_id: ""
+  workflow_name: ""
+  declared_agent_count: 1
+  actual_agent_count: 1
+  commands_run:
+    - "git fetch origin"
+    - "gh issue view 4756 --comments"
+    - "git worktree add -b cheap/issue-4756 ../robot_sf_ll7.worktrees/cheap-issue-4756 origin/main"
+    - "uv run python -c \"from pathlib import Path; import yaml; yaml.safe_load(Path('docs/templates/agent_run_manifest.yaml').read_text())\""
+    - "git diff --check"
+  tests_run:
+    - "yaml-parse smoke (pass)"
+  external_pages_accessed: []
+  trace_or_log_refs:
+    - "private agent-run artifact: common Git-dir codex-agent-runs/active/issue-4756.md (redacted)"
+  trace_redaction_checked: true
+  cost_or_credit_cap: "<2% of weekly cap"
+  stop_reason: "completed"
+  retries: 0
+  partial_failures: []
+  evidence_produced:
+    - "docs/templates/agent_run_manifest.yaml (template)"
+    - "docs/templates/agent_run_manifest.example.yaml (this example)"
+    - "docs/agent_run_manifest.md (usage documentation)"
+    - "docs/dev_guide.md (PR checklist item added)"
+  human_validity_check: "Maintainer reviewed the template fields against the issue acceptance criteria."
+  remaining_risk: "none known; no runtime dependency or CI enforcement introduced in this slice."

--- a/docs/templates/agent_run_manifest.yaml
+++ b/docs/templates/agent_run_manifest.yaml
@@ -1,0 +1,86 @@
+# Agent Run Manifest Template
+#
+# Copy this file and fill in the fields to make a substantial agent-assisted run
+# auditable. See docs/agent_run_manifest.md for when this manifest is required,
+# where to store it, and trace/log hygiene expectations.
+#
+# Keep values scrubbed: do not include secrets, raw private prompts, full traces,
+# or token/credit details beyond coarse caps. Point to redacted or stored-privately
+# trace/log refs instead of pasting raw content.
+#
+# schema_version lets future validation evolve cleanly. Do not change it here
+# unless the schema contract is intentionally being revised.
+agent_run:
+  schema_version: agent-run-manifest.v1
+
+  # One-sentence objective of the run.
+  objective: ""
+
+  # Tool that drove the run. Use one of: codex | claude-code | copilot | other.
+  tool: "codex|claude-code|copilot|other"
+
+  # Model identifier as reported by the tool, e.g. "gpt-5-codex" or "claude-sonnet-4".
+  model: ""
+
+  # Tool/runtime version string, e.g. CLI version or extension version.
+  tool_version: ""
+
+  # Permission mode the run operated under: manual | auto | other.
+  permission_mode: "manual|auto|other"
+
+  # Repository-relative or absolute worktree path the run edited in.
+  worktree: ""
+
+  # GitHub Actions run id, if the run was triggered from a workflow; else "".
+  workflow_run_id: ""
+
+  # GitHub Actions workflow name, if applicable; else "".
+  workflow_name: ""
+
+  # Number of agents the run declared it would use; null when not declared.
+  declared_agent_count: null
+
+  # Number of agents the run actually used; null when unknown or not applicable.
+  actual_agent_count: null
+
+  # Commands executed by the run. Keep each entry a short, copyable string.
+  # Prefer canonical repo commands (e.g. "uv run pytest tests/test_x.py -q").
+  commands_run: []
+
+  # Tests run, with outcome if known, e.g. "tests/test_x.py::test_a (pass)".
+  tests_run: []
+
+  # External pages accessed during the run, as URLs. Leave empty when none.
+  external_pages_accessed: []
+
+  # References to trace/log artifacts. Prefer a stored-privately path or a
+  # redacted excerpt; never paste raw traces that may contain secrets.
+  trace_or_log_refs: []
+
+  # Set true after confirming traces/logs were reviewed and redacted as needed.
+  trace_redaction_checked: false
+
+  # Coarse cost or credit cap for the run, e.g. "~10 USD" or "<5% of weekly cap".
+  # Do not record precise token counts or private billing details.
+  cost_or_credit_cap: ""
+
+  # Why the run stopped: completed | blocked | usage-guard | user-stop | error.
+  stop_reason: ""
+
+  # Number of retries the run performed after a recoverable failure.
+  retries: 0
+
+  # Partial failures during the run, each with a short label and status, e.g.
+  # "validation: ruff check failed, fixed and rerun (pass)".
+  partial_failures: []
+
+  # Evidence produced by the run. Each entry should name the artifact and its
+  # durable location (not a worktree-local output/ path), per the
+  # Artifact Evidence Vocabulary (docs/context/artifact_evidence_vocabulary.md).
+  evidence_produced: []
+
+  # Short note describing the human validity check performed, or "pending".
+  human_validity_check: ""
+
+  # Remaining risk or caveat after the run, or "none known".
+  remaining_risk: ""


### PR DESCRIPTION
## What and why

Adds a lightweight `agent_run_manifest.yaml` convention so substantial Codex / Claude Code / Copilot / other agent-assisted runs are auditable without introducing a workflow system, telemetry collector, or runtime dependency. This fully resolves issue #4756 (documentation/template/checklist slice only).

New/changed files:

- `docs/templates/agent_run_manifest.yaml` — copyable template with the issue-proposed schema plus a `schema_version: agent-run-manifest.v1` field for future validation evolution.
- `docs/templates/agent_run_manifest.example.yaml` — small scrubbed illustrative example (no secrets, raw traces, private prompts, or precise token/credit details).
- `docs/agent_run_manifest.md` — usage documentation: what the manifest is for, when it is required vs optional, where to store it, PR evidence bundle and issue evidence packet examples, trace/log hygiene, and human validation expectations.
- `docs/dev_guide.md` — new "Agent run manifest for PRs" subsection with the PR checklist item. The repo has no `.github/PULL_REQUEST_TEMPLATE.md`, so the checklist was added to the dev guide per the issue instruction. It does not block all PRs yet.
- `docs/context/artifact_evidence_vocabulary.md` — optional pointer that substantial agent-produced evidence should include an `agent_run_manifest.yaml` in the evidence bundle.
- `docs/README.md` — Documentation Index link to the new `Agent Run Manifest` page.

## Acceptance criteria met

- Template exists and is copyable.
- Documentation states when the manifest is required.
- Manifest captures tool/model/version, permission mode, commands/tests, trace hygiene, cost/credit cap, partial failures, and human validation.
- PR/checklist guidance exists.
- No runtime dependency or mandatory workflow system is introduced (no YAML validation libraries, no GitHub Actions, no telemetry collectors).

## Validation

Docs-only change; used the cheap official docs validation path (inspect diff, verify changed links/paths, run available lightweight docs checks). No campaigns, Slurm, training runs, or benchmark/paper claims.

```
# YAML parse smoke (extended to both YAML files), via shared-venv wrapper
scripts/dev/run_worktree_shared_venv.sh -- python - <<'PY'
from pathlib import Path
import yaml
paths = [Path('docs/templates/agent_run_manifest.yaml'), Path('docs/templates/agent_run_manifest.example.yaml')]
for path in paths:
    data = yaml.safe_load(path.read_text())
    assert isinstance(data, dict)
    assert data['agent_run']['schema_version'] == 'agent-run-manifest.v1'
    print(f"OK {path}")
PY
# Output:
# OK docs/templates/agent_run_manifest.yaml
# OK docs/templates/agent_run_manifest.example.yaml

git diff --check   # exit 0, no whitespace errors
BASE_REF=origin/main scripts/dev/run_worktree_shared_venv.sh -- bash scripts/dev/check_docs_proof_consistency_diff.sh
# Output: OK docs/proof consistency check passed for 6 changed file(s).
```

All referenced paths verified to resolve (`docs/agent_run_manifest.md`, both templates, `docs/context/issue_691_benchmark_fallback_policy.md`, `docs/context/evidence/README.md`).

## Artifact handling

No `output/` artifacts produced. No durable evidence promoted. Worktree-local output not used.

## Downstream propagation

NA — docs/template/checklist-only change with no research claim, no benchmark/metric/schema/model-provenance change, and no runtime behavior change.

Closes #4756

This PR was produced by the OpenCode-Go/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
