### PR TITLE
Issue #4762: footprint-orientation diagnostics for elongated AMMV bodies (cheap-lane worker)

### DIFF
--- a/configs/diagnostics/footprint_orientation_v1.yaml
+++ b/configs/diagnostics/footprint_orientation_v1.yaml
@@ -1,0 +1,126 @@
+schema_version: footprint-orientation.v1
+profile_id: footprint_orientation_diagnostic_v1
+claim_boundary: >
+  Diagnostic-only footprint-orientation proxy for elongated Autonomous
+  Micromobility Vehicle (AMMV) bodies. This is a diagnostic proxy, not a full
+  SE(2) planner implementation, not a collision-checking runtime, not a
+  benchmark or paper-facing result, and not calibrated against real-vehicle
+  swept-volume data. It samples a route centerline at fixed spacing, orients a
+  rigid footprint along the local tangent, and reports centerline clearance
+  separately from footprint-aware clearance. It does not simulate dynamic
+  obstacles, yaw control, recovery behavior, or the full swept volume of a
+  body turning through a corner.
+source_literature:
+  - id: se2_navigation_mesh_2026_arxiv_2607_01454
+    role: motivation_only
+    url: https://arxiv.org/abs/2607.01454
+    caveat: >
+      The SE(2) Navigation Mesh paper motivates orientation-aware traversability
+      for non-circular bodies. This repository config does not implement an
+      SE(2) navigation mesh and does not claim swept-volume correctness.
+  - id: cofls_2026_arxiv_2607_02222
+    role: motivation_only
+    url: https://arxiv.org/abs/2607.02222
+    caveat: >
+      The CoFL-S paper motivates language-conditioned sector flow fields for
+      local navigation. This repository config does not implement CoFL-S and
+      uses the reference only as orientation-aware-navigation motivation.
+availability_policy:
+  missing_required_trace_fields: not_available
+  missing_metric_key: not_available
+  fallback_or_degraded_row: diagnostic_only
+# Footprint models from issue #4762. `kind: circular` uses `radius_m`;
+# `kind: rectangular` uses `length_m` (along travel) and `width_m`
+# (perpendicular to travel). The rectangular footprint is oriented along the
+# local route tangent at each sample; this is a rigid-body proxy, not a yaw
+# planner.
+footprints:
+  - id: circular
+    display_name: Circular footprint
+    kind: circular
+    radius_m: 0.35
+    computation_status: diagnostic_available
+    notes: >
+      Baseline circular footprint matching the existing route-clearance
+      contract. Footprint-aware clearance equals centerline clearance minus
+      the radius.
+  - id: scooter_like
+    display_name: Scooter-like AMMV
+    kind: rectangular
+    length_m: 1.3
+    width_m: 0.55
+    computation_status: diagnostic_available
+    notes: >
+      Kick-scooter-class elongated body. Width drives corridor clearance;
+      length drives turn-overrun and forward-reach diagnostics.
+  - id: cargo_bike_like
+    display_name: Cargo-bike-like AMMV
+    kind: rectangular
+    length_m: 2.2
+    width_m: 0.8
+    computation_status: diagnostic_available
+    notes: >
+      Cargo-bike-class elongated body. Longer forward reach and wider stance
+      than the scooter-like body.
+  - id: shuttle_pod_like
+    display_name: Shuttle-pod-like AMMV
+    kind: rectangular
+    length_m: 3.0
+    width_m: 1.4
+    computation_status: diagnostic_available
+    notes: >
+      Shuttle-pod-class elongated body. Largest stance; used to surface
+      narrow-passage and turn infeasibility that circular clearance hides.
+# Synthetic scenario families from issue #4762. Each family is realized as a
+# self-contained route-plus-obstacle fixture so the diagnostic is reproducible
+# without external map assets. See docs/diagnostics/footprint_orientation.md.
+scenario_families:
+  - id: narrow_passage
+    display_name: Narrow passage
+    description: >
+      Straight corridor with a 0.9 m passage. Surfaces width-driven
+      infeasibility: a circular body clears while a shuttle-pod-class body
+      collides.
+    mechanism: width_driven
+  - id: pedestrian_crossing
+    display_name: Pedestrian crossing
+    description: >
+      Straight route passing a pedestrian-sized block offset from the
+      centerline. Surfaces width-driven clearance gradient across footprints.
+    mechanism: width_driven
+  - id: occluded_corner
+    display_name: Occluded corner
+    description: >
+      L-shaped route turning away from a wall just east of the corner. An
+      elongated body oriented along the incoming leg overruns the turn and
+      pokes the wall; a circular body clears.
+    mechanism: turn_overrun_length_driven
+  - id: recovery_after_avoidance
+    display_name: Recovery after avoidance
+    description: >
+      Straight route passing a recovery-zone block offset from the
+      centerline. Width-driven clearance proxy for post-avoidance geometry.
+    mechanism: width_driven
+  - id: blocked_path_turn_around
+    display_name: Blocked-path turn-around
+    description: >
+      Straight route terminating near a dead-end wall. An elongated body's
+      forward reach pokes the wall before the centerline reaches it; a
+      circular body clears.
+    mechanism: forward_reach_length_driven
+diagnostic_parameters:
+  # Spacing (meters) between oriented-footprint samples along the route.
+  sample_step_m: 0.1
+  # A scenario-footprint pair is reported as `collision` when the oriented
+  # footprint intersects any obstacle (boundary contact counts as collision,
+  # matching a conservative fail-closed diagnostic).
+  pass_threshold_m: 0.0
+  # Hard cap on sample count to keep the diagnostic cheap on long routes.
+  max_samples: 5000
+computation_status: diagnostic_available
+notes: >
+  The diagnostic report distinguishes centerline clearance (route LineString to
+  obstacle polygons, ignoring footprint) from footprint-aware clearance
+  (oriented rigid footprint sampled along the route). Both are reported per
+  scenario and per footprint so circular-vs-elongated pass/fail outcomes are
+  directly comparable. This is a diagnostic proxy only.

--- a/docs/diagnostics/footprint_orientation.md
+++ b/docs/diagnostics/footprint_orientation.md
@@ -1,0 +1,133 @@
+# Footprint-orientation diagnostics for elongated AMMV bodies
+
+> **Diagnostic proxy only.** This feature is a lightweight, CPU-only diagnostic.
+> It is **not a full SE(2) planner implementation**, not a collision-checking
+> runtime, not a benchmark or paper-facing result, and not calibrated against
+> real-vehicle swept-volume data. See the `claim_boundary` in
+> `configs/diagnostics/footprint_orientation_v1.yaml`.
+
+## Plain-language summary
+
+The robot in this repository is normally modeled as a **circle** (`radius_m`).
+Real Autonomous Micromobility Vehicles (AMMVs) — kick scooters, cargo bikes,
+delivery robots, shuttle pods — are **elongated**, so whether a route is
+traversable depends on the body's yaw (heading), not just its centerline
+clearance. This diagnostic compares route clearance under circular,
+rectangular, and elongated footprint assumptions on the same route, so that a
+route a circular body "clears" can be checked against what a scooter-, cargo-,
+or shuttle-pod-class body would actually do.
+
+Issue: #4762.
+
+## What it reports
+
+For each scenario and footprint model the diagnostic reports two **separate**
+quantities:
+
+- `centerline_clearance_m` — minimum distance from the route centerline (a
+  Shapely `LineString`) to the obstacle polygons, ignoring the footprint. This
+  is what the existing circular route-clearance contract reasons about.
+- `footprint_aware_clearance_m` — minimum distance from an oriented rigid
+  footprint, sampled along the route and oriented along the local tangent, to
+  the obstacle polygons (`0.0` when overlapping).
+
+It also reports a `status` of `clear` or `collision` (boundary contact counts
+as collision, conservative fail-closed). Reporting both numbers separately is
+the point: it makes circular-vs-elongated pass/fail outcomes directly
+comparable on the same route.
+
+## Footprint models
+
+Defined in `configs/diagnostics/footprint_orientation_v1.yaml`:
+
+| id | kind | radius / length × width |
+| --- | --- | --- |
+| `circular` | circular | r = 0.35 m |
+| `scooter_like` | rectangular | 1.3 × 0.55 m |
+| `cargo_bike_like` | rectangular | 2.2 × 0.8 m |
+| `shuttle_pod_like` | rectangular | 3.0 × 1.4 m |
+
+A circular footprint uses the analytic centerline-minus-radius margin (exact).
+A rectangular footprint is sampled along the route at `sample_step_m` (0.1 m)
+and a rigid rectangle is oriented along the local tangent at each sample.
+
+## Scenario families
+
+Five self-contained synthetic fixtures (no external map assets needed) that
+surface three distinct mechanisms:
+
+| family | mechanism | what it surfaces |
+| --- | --- | --- |
+| `narrow_passage` | width-driven | a 0.9 m corridor: circular clears, shuttle-pod collides |
+| `pedestrian_crossing` | width-driven | pedestrian block offset from centerline |
+| `occluded_corner` | turn-overrun length-driven | an elongated body oriented along the incoming leg overruns a turn and pokes a wall a circular body clears |
+| `recovery_after_avoidance` | width-driven | recovery-zone block offset from centerline |
+| `blocked_path_turn_around` | forward-reach length-driven | an elongated body's forward reach pokes a dead-end wall before the centerline reaches it |
+
+## Run it
+
+```bash
+# JSON to stdout
+python scripts/diagnostics/run_footprint_orientation_diagnostic.py
+
+# Markdown report to a file
+python scripts/diagnostics/run_footprint_orientation_diagnostic.py \
+  --format markdown --output footprint_diagnostic.md
+```
+
+## API
+
+```python
+from robot_sf.nav.footprint_diagnostic import (
+    load_footprint_orientation_config,
+    parse_footprints,
+    parse_diagnostic_parameters,
+    build_diagnostic_scenarios,
+    build_diagnostic_report,
+)
+
+payload = load_footprint_orientation_config(
+    "configs/diagnostics/footprint_orientation_v1.yaml"
+)
+footprints = parse_footprints(payload)
+params = parse_diagnostic_parameters(payload)
+scenarios = build_diagnostic_scenarios()
+report = build_diagnostic_report(
+    scenarios, footprints, params["sample_step_m"], params["max_samples"]
+)
+```
+
+## Relationship to existing route clearance
+
+The camera-ready route-clearance check
+(`robot_sf/benchmark/camera_ready/_route_clearance.py`) is a **fail-closed
+benchmark gate** for the circular footprint: it refuses to run a route whose
+centerline is closer to an obstacle than the robot radius. This diagnostic is
+**not** a gate and **not** a modification of that contract. It is a
+research/diagnostic tool that adds the missing orientation-aware
+(rectangular/elongated) view and compares it against the circular baseline on
+the same route. It does not change any benchmark, metric, or schema.
+
+## Limitations (honest caveats)
+
+- The rectangular footprint is oriented along the **local route tangent**. It
+  does not model yaw control or the body's actual heading during a turn.
+- It does **not** simulate the full swept volume of a body pivoting through a
+  corner; consecutive samples are independent oriented rectangles. A corner
+  sample therefore orients along an interpolated tangent, not the full
+  turn-sweep.
+- It samples at a fixed spacing (`sample_step_m`); sub-step features can be
+  missed.
+- Obstacles are static; there is no dynamic-obstacle or pedestrian modeling.
+- Boundary contact is reported as `collision` (conservative); this is a
+  diagnostic flag, not a penetration-depth measure.
+- `footprint_aware_clearance_m` is `0.0` (not a signed penetration depth) when
+  a rectangular footprint overlaps an obstacle.
+
+## Sources (motivation only)
+
+- SE(2) Navigation Mesh — https://arxiv.org/abs/2607.01454
+- CoFL-S: Spatially Queryable Sector Flow Fields — https://arxiv.org/abs/2607.02222
+
+Both are referenced as `motivation_only` in the config; this repository does
+not implement either method.

--- a/robot_sf/nav/footprint_diagnostic.py
+++ b/robot_sf/nav/footprint_diagnostic.py
@@ -1,0 +1,724 @@
+"""Footprint-orientation diagnostics for elongated AMMV bodies (issue #4762).
+
+This module provides a lightweight, CPU-only diagnostic that compares route
+clearance under circular, rectangular, and elongated Autonomous Micromobility
+Vehicle (AMMV) footprint assumptions. It is a diagnostic proxy, not a full
+SE(2) planner implementation (see ``docs/diagnostics/footprint_orientation.md``
+and the ``claim_boundary`` in ``configs/diagnostics/footprint_orientation_v1.yaml``).
+
+The diagnostic reports two separate quantities per scenario and footprint:
+
+* ``centerline_clearance_m``: minimum distance from the route centerline
+  (a Shapely ``LineString``) to the obstacle polygons, ignoring the footprint.
+  This is what the existing circular route-clearance contract reasons about.
+* ``footprint_aware_clearance_m``: minimum distance from an oriented rigid
+  footprint, sampled along the route and oriented along the local tangent, to
+  the obstacle polygons. For circular footprints this is the analytic
+  centerline-minus-radius margin; for rectangular footprints it is the min
+  oriented-rectangle-to-obstacle distance (0 when overlapping).
+
+The two are reported separately so that a circular body that "clears" can be
+compared directly with an elongated body that "collides" on the same route.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from shapely.geometry import LineString, Point, Polygon
+from shapely.ops import unary_union
+
+if TYPE_CHECKING:
+    from robot_sf.common.types import Vec2D
+
+FOOTPRINT_ORIENTATION_SCHEMA_VERSION = "footprint-orientation.v1"
+FOOTPRINT_KIND_CIRCULAR = "circular"
+FOOTPRINT_KIND_RECTANGULAR = "rectangular"
+REQUIRED_SCENARIO_FAMILY_IDS = frozenset(
+    {
+        "narrow_passage",
+        "pedestrian_crossing",
+        "occluded_corner",
+        "recovery_after_avoidance",
+        "blocked_path_turn_around",
+    }
+)
+
+
+class FootprintOrientationConfigError(ValueError):
+    """Raised when a footprint-orientation diagnostic config violates the v1 contract."""
+
+
+@dataclass(frozen=True)
+class CircularFootprint:
+    """Circular robot footprint (baseline, matches the existing route-clearance contract).
+
+    Attributes:
+        id: Stable footprint identifier (lowercase snake_case).
+        radius_m: Footprint radius in meters.
+        kind: Discriminator constant, always ``"circular"``.
+    """
+
+    id: str
+    radius_m: float
+    kind: str = FOOTPRINT_KIND_CIRCULAR
+
+
+@dataclass(frozen=True)
+class RectangularFootprint:
+    """Rectangular AMMV footprint oriented along the local route tangent.
+
+    Attributes:
+        id: Stable footprint identifier (lowercase snake_case).
+        length_m: Body length in meters, aligned with the travel direction.
+        width_m: Body width in meters, perpendicular to the travel direction.
+        kind: Discriminator constant, always ``"rectangular"``.
+    """
+
+    id: str
+    length_m: float
+    width_m: float
+    kind: str = FOOTPRINT_KIND_RECTANGULAR
+
+
+FootprintModel = CircularFootprint | RectangularFootprint
+
+
+@dataclass
+class FootprintClearanceResult:
+    """One scenario's clearance outcome for a single footprint model.
+
+    Attributes:
+        footprint_id: Identifier of the footprint model.
+        kind: ``"circular"`` or ``"rectangular"``.
+        centerline_clearance_m: Min route-centerline-to-obstacle distance (``None`` if no obstacles).
+        footprint_aware_clearance_m: Min oriented-footprint-to-obstacle distance
+            (``None`` if no obstacles; ``0.0`` when overlapping).
+        collision: True when the oriented footprint intersects any obstacle
+            (boundary contact counts as collision, conservative fail-closed).
+        sample_count: Number of oriented-footprint samples evaluated (0/1 for the
+            analytic circular path).
+        method: ``"analytic_margin"`` for circular; ``"oriented_rectangle_sampling"`` for rectangular.
+    """
+
+    footprint_id: str
+    kind: str
+    centerline_clearance_m: float | None
+    footprint_aware_clearance_m: float | None
+    collision: bool
+    sample_count: int
+    method: str
+
+    @property
+    def status(self) -> str:
+        """Return ``"collision"`` when colliding, otherwise ``"clear"``."""
+
+        return "collision" if self.collision else "clear"
+
+
+@dataclass
+class FootprintDiagnosticScenario:
+    """A self-contained route-plus-obstacle diagnostic scenario fixture.
+
+    Attributes:
+        id: Scenario identifier (lowercase snake_case).
+        family: Scenario family identifier from the issue candidate list.
+        display_name: Human-readable scenario name.
+        description: Plain-language description of what the scenario surfaces.
+        mechanism: Diagnostic mechanism tag (e.g. ``"width_driven"``).
+        route: Ordered route waypoints.
+        obstacles: Obstacle polygons.
+    """
+
+    id: str
+    family: str
+    display_name: str
+    description: str
+    mechanism: str
+    route: list[Vec2D]
+    obstacles: list[Polygon]
+
+
+def load_footprint_orientation_config(path: Path | str) -> dict[str, Any]:
+    """Load and validate a footprint-orientation diagnostic YAML config.
+
+    Returns:
+        The validated YAML payload as a dictionary.
+    """
+
+    payload = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    return validate_footprint_orientation_config(payload)
+
+
+def validate_footprint_orientation_config(payload: Mapping[str, Any] | Any) -> dict[str, Any]:
+    """Validate the footprint-orientation diagnostic config contract.
+
+    Returns:
+        The validated payload as a dictionary.
+    """
+
+    if not isinstance(payload, Mapping):
+        raise FootprintOrientationConfigError("config payload must be a mapping")
+    _validate_top_level_contract(payload)
+    _validate_footprints(payload.get("footprints"))
+    _validate_scenario_families(payload.get("scenario_families"))
+    _validate_diagnostic_parameters(payload.get("diagnostic_parameters"))
+    return dict(payload)
+
+
+def parse_footprints(payload: Mapping[str, Any]) -> list[FootprintModel]:
+    """Parse validated footprint entries into dataclass models.
+
+    Returns:
+        Ordered list of ``CircularFootprint`` / ``RectangularFootprint``.
+    """
+
+    raw_footprints = payload.get("footprints")
+    if not isinstance(raw_footprints, list):
+        raise FootprintOrientationConfigError("footprints must be a non-empty list")
+    models: list[FootprintModel] = []
+    for entry in raw_footprints:
+        if not isinstance(entry, Mapping):
+            raise FootprintOrientationConfigError("footprint entries must be mappings")
+        models.append(_parse_footprint(entry))
+    return models
+
+
+def parse_diagnostic_parameters(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return validated diagnostic parameters with defaults applied."""
+
+    params = payload.get("diagnostic_parameters")
+    if not isinstance(params, Mapping):
+        raise FootprintOrientationConfigError("diagnostic_parameters must be a mapping")
+    sample_step = float(params.get("sample_step_m", 0.1))
+    max_samples = int(params.get("max_samples", 5000))
+    pass_threshold = float(params.get("pass_threshold_m", 0.0))
+    if not math.isfinite(sample_step) or sample_step <= 0.0:
+        raise FootprintOrientationConfigError("diagnostic_parameters.sample_step_m must be > 0")
+    if max_samples < 2:
+        raise FootprintOrientationConfigError("diagnostic_parameters.max_samples must be >= 2")
+    if not math.isfinite(pass_threshold) or pass_threshold < 0.0:
+        raise FootprintOrientationConfigError("diagnostic_parameters.pass_threshold_m must be >= 0")
+    return {
+        "sample_step_m": sample_step,
+        "max_samples": max_samples,
+        "pass_threshold_m": pass_threshold,
+    }
+
+
+def centerline_clearance_m(
+    route: Sequence[Vec2D],
+    obstacle_polygons: Sequence[Polygon],
+) -> float | None:
+    """Compute minimum distance from the route centerline to obstacle polygons.
+
+    Returns:
+        Minimum centerline-to-obstacle distance in meters, or ``None`` when the
+        route has fewer than two waypoints or there are no obstacles.
+    """
+
+    if len(route) < 2 or not obstacle_polygons:
+        return None
+    line = LineString(list(route))
+    if line.is_empty or line.length <= 0.0:
+        return None
+    obstacles = unary_union(list(obstacle_polygons))
+    if obstacles.is_empty:
+        return None
+    return float(line.distance(obstacles))
+
+
+def footprint_aware_clearance_m(
+    route: Sequence[Vec2D],
+    footprint: FootprintModel,
+    obstacle_polygons: Sequence[Polygon],
+    sample_step_m: float,
+    max_samples: int,
+) -> tuple[float | None, bool, int]:
+    """Compute min oriented-footprint-to-obstacle clearance along a route.
+
+    For circular footprints the clearance is the analytic centerline-minus-radius
+    margin (exact, no sampling). For rectangular footprints the route is sampled
+    at ``sample_step_m`` spacing and a rigid rectangle is oriented along the
+    local tangent at each sample.
+
+    Returns:
+        ``(clearance_m, collision, sample_count)`` where ``clearance_m`` is the
+        min footprint-to-obstacle distance (``0.0`` when overlapping, ``None``
+        when there are no obstacles or the route is degenerate), ``collision``
+        is True when the footprint intersects any obstacle, and ``sample_count``
+        is the number of evaluated samples.
+    """
+
+    if len(route) < 2 or not obstacle_polygons:
+        return None, False, 0
+    line = LineString(list(route))
+    length = float(line.length)
+    if length <= 0.0:
+        return None, False, 0
+    obstacles = unary_union(list(obstacle_polygons))
+    if obstacles.is_empty:
+        return None, False, 0
+
+    if isinstance(footprint, CircularFootprint):
+        center_distance = float(line.distance(obstacles))
+        clearance = max(0.0, center_distance - footprint.radius_m)
+        # Boundary contact (center_distance == radius) counts as collision.
+        collision = center_distance <= footprint.radius_m
+        return clearance, collision, 1
+
+    if not isinstance(footprint, RectangularFootprint):
+        raise FootprintOrientationConfigError(f"unsupported footprint type: {type(footprint)!r}")
+
+    sample_count = min(max_samples, max(2, math.ceil(length / sample_step_m) + 1))
+    eps = max(1e-3, length * 1e-6)
+    min_clearance: float | None = None
+    any_collision = False
+    for index in range(sample_count):
+        distance = length * index / (sample_count - 1) if sample_count > 1 else 0.0
+        point = line.interpolate(distance)
+        heading = _route_tangent(line, distance, length, eps)
+        rect = (
+            _oriented_rectangle(point.x, point.y, footprint.length_m, footprint.width_m, heading)
+            if heading is not None
+            else Point(point)
+        )
+        clearance = float(rect.distance(obstacles))
+        if min_clearance is None or clearance < min_clearance:
+            min_clearance = clearance
+        if rect.intersects(obstacles):
+            any_collision = True
+    if min_clearance is None:
+        return None, any_collision, sample_count
+    return float(min_clearance), any_collision, sample_count
+
+
+def run_footprint_diagnostic(
+    scenario: FootprintDiagnosticScenario,
+    footprints: Sequence[FootprintModel],
+    sample_step_m: float,
+    max_samples: int,
+) -> list[FootprintClearanceResult]:
+    """Run all footprint models against one scenario and return per-footprint results.
+
+    Returns:
+        One ``FootprintClearanceResult`` per footprint model, in config order.
+    """
+
+    centerline = centerline_clearance_m(scenario.route, scenario.obstacles)
+    results: list[FootprintClearanceResult] = []
+    for footprint in footprints:
+        clearance, collision, sample_count = footprint_aware_clearance_m(
+            scenario.route,
+            footprint,
+            scenario.obstacles,
+            sample_step_m,
+            max_samples,
+        )
+        method = (
+            "analytic_margin"
+            if isinstance(footprint, CircularFootprint)
+            else "oriented_rectangle_sampling"
+        )
+        results.append(
+            FootprintClearanceResult(
+                footprint_id=footprint.id,
+                kind=footprint.kind,
+                centerline_clearance_m=centerline,
+                footprint_aware_clearance_m=clearance,
+                collision=collision,
+                sample_count=sample_count,
+                method=method,
+            )
+        )
+    return results
+
+
+def build_diagnostic_report(
+    scenarios: Sequence[FootprintDiagnosticScenario],
+    footprints: Sequence[FootprintModel],
+    sample_step_m: float,
+    max_samples: int,
+    *,
+    profile_id: str = "footprint_orientation_diagnostic_v1",
+) -> dict[str, Any]:
+    """Build a JSON-serializable diagnostic report across scenarios and footprints.
+
+    The report distinguishes ``centerline_clearance_m`` from
+    ``footprint_aware_clearance_m`` per scenario and footprint, and lists which
+    footprints collide vs clear so circular-vs-elongated outcomes are comparable.
+
+    Returns:
+        A JSON-serializable report dict with ``profile_id``, ``schema_version``,
+        ``claim_boundary_note``, ``diagnostic_parameters``, and a ``scenarios``
+        list of per-scenario per-footprint result rows.
+    """
+
+    scenario_reports: list[dict[str, Any]] = []
+    for scenario in scenarios:
+        results = run_footprint_diagnostic(scenario, footprints, sample_step_m, max_samples)
+        rows = [_result_to_row(result) for result in results]
+        scenario_reports.append(
+            {
+                "scenario_id": scenario.id,
+                "family": scenario.family,
+                "display_name": scenario.display_name,
+                "description": scenario.description,
+                "mechanism": scenario.mechanism,
+                "obstacle_count": len(scenario.obstacles),
+                "route_waypoint_count": len(scenario.route),
+                "results": rows,
+                "collision_footprint_ids": [
+                    r["footprint_id"] for r in rows if r["status"] == "collision"
+                ],
+                "clear_footprint_ids": [r["footprint_id"] for r in rows if r["status"] == "clear"],
+            }
+        )
+    return {
+        "profile_id": profile_id,
+        "schema_version": FOOTPRINT_ORIENTATION_SCHEMA_VERSION,
+        "claim_boundary_note": (
+            "Diagnostic proxy only: not a full SE(2) planner implementation, not a "
+            "collision-checking runtime, not a benchmark or paper-facing result, and not "
+            "calibrated against real-vehicle swept-volume data."
+        ),
+        "diagnostic_parameters": {
+            "sample_step_m": float(sample_step_m),
+            "max_samples": int(max_samples),
+        },
+        "scenarios": scenario_reports,
+    }
+
+
+def build_diagnostic_scenarios() -> list[FootprintDiagnosticScenario]:
+    """Return the five self-contained scenario-family fixtures from issue #4762.
+
+    These synthetic fixtures make the diagnostic reproducible without external
+    map assets. Geometry is chosen so that circular and elongated footprints
+    produce contrasting pass/fail outcomes via three distinct mechanisms:
+    width-driven (narrow passage / pedestrian offset), turn-overrun
+    length-driven (occluded corner), and forward-reach length-driven
+    (blocked-path turn-around).
+    """
+
+    return [
+        FootprintDiagnosticScenario(
+            id="narrow_passage_v1",
+            family="narrow_passage",
+            display_name="Narrow passage",
+            description=(
+                "Straight 0.9 m corridor. A circular body clears while a "
+                "shuttle-pod-class body collides; surfaces width-driven infeasibility."
+            ),
+            mechanism="width_driven",
+            route=[(0.0, 5.0), (10.0, 5.0)],
+            obstacles=[
+                Polygon([(0.0, 5.45), (10.0, 5.45), (10.0, 10.0), (0.0, 10.0)]),
+                Polygon([(0.0, 0.0), (10.0, 0.0), (10.0, 4.55), (0.0, 4.55)]),
+            ],
+        ),
+        FootprintDiagnosticScenario(
+            id="pedestrian_crossing_v1",
+            family="pedestrian_crossing",
+            display_name="Pedestrian crossing",
+            description=(
+                "Straight route passing a pedestrian-sized block offset 0.45 m from "
+                "the centerline; surfaces width-driven clearance gradient."
+            ),
+            mechanism="width_driven",
+            route=[(0.0, 5.0), (10.0, 5.0)],
+            obstacles=[Polygon([(4.75, 5.45), (5.25, 5.45), (5.25, 5.95), (4.75, 5.95)])],
+        ),
+        FootprintDiagnosticScenario(
+            id="occluded_corner_v1",
+            family="occluded_corner",
+            display_name="Occluded corner",
+            description=(
+                "L-shaped route turning away from a wall just east of the corner. An "
+                "elongated body oriented along the incoming leg overruns the turn and "
+                "pokes the wall; a circular body clears."
+            ),
+            mechanism="turn_overrun_length_driven",
+            route=[(1.0, 1.0), (5.0, 1.0), (5.0, 6.0)],
+            obstacles=[Polygon([(5.7, -1.0), (9.0, -1.0), (9.0, 1.4), (5.7, 1.4)])],
+        ),
+        FootprintDiagnosticScenario(
+            id="recovery_after_avoidance_v1",
+            family="recovery_after_avoidance",
+            display_name="Recovery after avoidance",
+            description=(
+                "Straight route passing a recovery-zone block offset from the "
+                "centerline; width-driven clearance proxy for post-avoidance geometry."
+            ),
+            mechanism="width_driven",
+            route=[(0.0, 5.0), (10.0, 5.0)],
+            obstacles=[Polygon([(4.6, 5.6), (5.4, 5.6), (5.4, 6.4), (4.6, 6.4)])],
+        ),
+        FootprintDiagnosticScenario(
+            id="blocked_path_turn_around_v1",
+            family="blocked_path_turn_around",
+            display_name="Blocked-path turn-around",
+            description=(
+                "Straight route terminating 1.0 m before a dead-end wall. An "
+                "elongated body's forward reach pokes the wall before the centerline "
+                "reaches it; a circular body clears."
+            ),
+            mechanism="forward_reach_length_driven",
+            route=[(1.0, 5.0), (8.0, 5.0)],
+            obstacles=[Polygon([(9.0, 0.0), (12.0, 0.0), (12.0, 10.0), (9.0, 10.0)])],
+        ),
+    ]
+
+
+def _parse_footprint(entry: Mapping[str, Any]) -> FootprintModel:
+    kind = entry.get("kind")
+    footprint_id = entry.get("id")
+    if not isinstance(footprint_id, str) or not _is_lowercase_snake_case(footprint_id):
+        raise FootprintOrientationConfigError("footprint id must be a lowercase snake_case string")
+    if kind == FOOTPRINT_KIND_CIRCULAR:
+        radius = entry.get("radius_m")
+        if not _is_positive_finite(radius):
+            raise FootprintOrientationConfigError(
+                f"footprint {footprint_id!r} radius_m must be a positive finite number"
+            )
+        return CircularFootprint(id=footprint_id, radius_m=float(radius))
+    if kind == FOOTPRINT_KIND_RECTANGULAR:
+        length = entry.get("length_m")
+        width = entry.get("width_m")
+        if not _is_positive_finite(length) or not _is_positive_finite(width):
+            raise FootprintOrientationConfigError(
+                f"footprint {footprint_id!r} length_m and width_m must be positive finite numbers"
+            )
+        return RectangularFootprint(id=footprint_id, length_m=float(length), width_m=float(width))
+    raise FootprintOrientationConfigError(
+        f"footprint {footprint_id!r} kind must be 'circular' or 'rectangular'"
+    )
+
+
+def _validate_top_level_contract(payload: Mapping[str, Any]) -> None:
+    if payload.get("schema_version") != FOOTPRINT_ORIENTATION_SCHEMA_VERSION:
+        raise FootprintOrientationConfigError(
+            f"schema_version must be {FOOTPRINT_ORIENTATION_SCHEMA_VERSION}"
+        )
+    claim_boundary = payload.get("claim_boundary")
+    if not isinstance(claim_boundary, str) or not claim_boundary.strip():
+        raise FootprintOrientationConfigError("claim_boundary is required")
+    _require_boundary_language(claim_boundary)
+    _validate_source_literature(payload.get("source_literature"))
+
+
+def _validate_footprints(raw_footprints: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(raw_footprints, list) or not raw_footprints:
+        raise FootprintOrientationConfigError("footprints must be a non-empty list")
+    kinds: set[str] = set()
+    ids: list[str] = []
+    for index, entry in enumerate(raw_footprints):
+        if not isinstance(entry, Mapping):
+            raise FootprintOrientationConfigError(f"footprint {index} must be a mapping")
+        if not isinstance(entry.get("id"), str) or not _is_lowercase_snake_case(entry["id"]):
+            raise FootprintOrientationConfigError(
+                f"footprint {index} id must be lowercase snake_case"
+            )
+        ids.append(entry["id"])
+        kinds.add(entry.get("kind"))
+        _validate_footprint_entry(entry)
+    duplicate_ids = sorted({footprint_id for footprint_id in ids if ids.count(footprint_id) > 1})
+    if duplicate_ids:
+        raise FootprintOrientationConfigError(
+            f"duplicate footprint ids: {', '.join(duplicate_ids)}"
+        )
+    if FOOTPRINT_KIND_CIRCULAR not in kinds:
+        raise FootprintOrientationConfigError("at least one circular footprint is required")
+    if FOOTPRINT_KIND_RECTANGULAR not in kinds:
+        raise FootprintOrientationConfigError("at least one rectangular footprint is required")
+    return [entry for entry in raw_footprints if isinstance(entry, Mapping)]
+
+
+def _validate_footprint_entry(entry: Mapping[str, Any]) -> None:
+    footprint_id = str(entry["id"])
+    kind = entry.get("kind")
+    if kind not in (FOOTPRINT_KIND_CIRCULAR, FOOTPRINT_KIND_RECTANGULAR):
+        raise FootprintOrientationConfigError(
+            f"footprint {footprint_id!r} kind must be 'circular' or 'rectangular'"
+        )
+    for field_name in ("display_name", "computation_status", "notes"):
+        value = entry.get(field_name)
+        if not isinstance(value, str) or not value.strip():
+            raise FootprintOrientationConfigError(
+                f"footprint {footprint_id!r} {field_name} must be a non-empty string"
+            )
+    if kind == FOOTPRINT_KIND_CIRCULAR and not _is_positive_finite(entry.get("radius_m")):
+        raise FootprintOrientationConfigError(
+            f"footprint {footprint_id!r} radius_m must be a positive finite number"
+        )
+    if kind == FOOTPRINT_KIND_RECTANGULAR and (
+        not _is_positive_finite(entry.get("length_m"))
+        or not _is_positive_finite(entry.get("width_m"))
+    ):
+        raise FootprintOrientationConfigError(
+            f"footprint {footprint_id!r} length_m and width_m must be positive finite numbers"
+        )
+
+
+def _validate_scenario_families(raw_families: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(raw_families, list) or not raw_families:
+        raise FootprintOrientationConfigError("scenario_families must be a non-empty list")
+    ids: list[str] = []
+    for index, entry in enumerate(raw_families):
+        if not isinstance(entry, Mapping):
+            raise FootprintOrientationConfigError(f"scenario_family {index} must be a mapping")
+        family_id = entry.get("id")
+        if not isinstance(family_id, str) or not _is_lowercase_snake_case(family_id):
+            raise FootprintOrientationConfigError(
+                f"scenario_family {index} id must be lowercase snake_case"
+            )
+        ids.append(family_id)
+        for field_name in ("display_name", "description", "mechanism"):
+            value = entry.get(field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise FootprintOrientationConfigError(
+                    f"scenario_family {family_id!r} {field_name} must be a non-empty string"
+                )
+    duplicate_ids = sorted({family_id for family_id in ids if ids.count(family_id) > 1})
+    if duplicate_ids:
+        raise FootprintOrientationConfigError(
+            f"duplicate scenario_family ids: {', '.join(duplicate_ids)}"
+        )
+    missing_required = sorted(REQUIRED_SCENARIO_FAMILY_IDS.difference(ids))
+    if missing_required:
+        raise FootprintOrientationConfigError(
+            f"missing required scenario_family ids: {', '.join(missing_required)}"
+        )
+    return [entry for entry in raw_families if isinstance(entry, Mapping)]
+
+
+def _validate_diagnostic_parameters(raw_params: Any) -> None:
+    if not isinstance(raw_params, Mapping):
+        raise FootprintOrientationConfigError("diagnostic_parameters must be a mapping")
+    sample_step = raw_params.get("sample_step_m")
+    if not _is_positive_finite(sample_step):
+        raise FootprintOrientationConfigError("diagnostic_parameters.sample_step_m must be > 0")
+    max_samples = raw_params.get("max_samples")
+    if not isinstance(max_samples, int) or max_samples < 2:
+        raise FootprintOrientationConfigError(
+            "diagnostic_parameters.max_samples must be an int >= 2"
+        )
+    pass_threshold = raw_params.get("pass_threshold_m")
+    if not _is_nonnegative_finite(pass_threshold):
+        raise FootprintOrientationConfigError("diagnostic_parameters.pass_threshold_m must be >= 0")
+
+
+def _validate_source_literature(source_literature: Any) -> None:
+    if not isinstance(source_literature, list) or not source_literature:
+        raise FootprintOrientationConfigError("source_literature must be a non-empty list")
+    for entry in source_literature:
+        if not isinstance(entry, Mapping):
+            raise FootprintOrientationConfigError("source_literature entries must be mappings")
+        if entry.get("role") != "motivation_only":
+            raise FootprintOrientationConfigError(
+                "source_literature entries must use role motivation_only"
+            )
+        if not entry.get("url"):
+            raise FootprintOrientationConfigError("source_literature entries require url")
+
+
+def _require_boundary_language(claim_boundary: str) -> None:
+    normalized = claim_boundary.casefold()
+    required_phrases = ("diagnostic", "not a full se(2) planner", "not calibrated")
+    missing = [phrase for phrase in required_phrases if phrase not in normalized]
+    if missing:
+        raise FootprintOrientationConfigError(
+            "claim_boundary must explicitly state diagnostic, not-a-full-SE(2)-planner, "
+            "and not-calibrated status"
+        )
+
+
+def _result_to_row(result: FootprintClearanceResult) -> dict[str, Any]:
+    return {
+        "footprint_id": result.footprint_id,
+        "kind": result.kind,
+        "centerline_clearance_m": _round_or_none(result.centerline_clearance_m),
+        "footprint_aware_clearance_m": _round_or_none(result.footprint_aware_clearance_m),
+        "status": result.status,
+        "collision": result.collision,
+        "sample_count": result.sample_count,
+        "method": result.method,
+    }
+
+
+def _round_or_none(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(float(value), 6)
+
+
+def _oriented_rectangle(
+    cx: float,
+    cy: float,
+    length: float,
+    width: float,
+    heading_rad: float,
+) -> Polygon:
+    """Build an oriented rectangle centered at (cx, cy).
+
+    The rectangle's long axis (``length``) is aligned with ``heading_rad`` and
+    its short axis (``width``) is perpendicular.
+
+    Returns:
+        A Shapely ``Polygon`` for the oriented footprint centered at (cx, cy).
+    """
+
+    half_length = length / 2.0
+    half_width = width / 2.0
+    cos_h = math.cos(heading_rad)
+    sin_h = math.sin(heading_rad)
+    local_corners = [
+        (half_length, half_width),
+        (half_length, -half_width),
+        (-half_length, -half_width),
+        (-half_length, half_width),
+    ]
+    world_corners = [
+        (cx + x * cos_h - y * sin_h, cy + x * sin_h + y * cos_h) for x, y in local_corners
+    ]
+    return Polygon(world_corners)
+
+
+def _route_tangent(line: LineString, distance: float, length: float, eps: float) -> float | None:
+    """Return the local tangent heading (radians) at a route distance.
+
+    Returns ``None`` when the tangent is degenerate (e.g. a single-point route).
+    """
+
+    d_before = max(0.0, distance - eps)
+    d_after = min(length, distance + eps)
+    if d_after <= d_before:
+        return None
+    before = line.interpolate(d_before)
+    after = line.interpolate(d_after)
+    dx = after.x - before.x
+    dy = after.y - before.y
+    if dx == 0.0 and dy == 0.0:
+        return None
+    return float(math.atan2(dy, dx))
+
+
+def _is_positive_finite(value: Any) -> bool:
+    return isinstance(value, int | float) and math.isfinite(float(value)) and float(value) > 0.0
+
+
+def _is_nonnegative_finite(value: Any) -> bool:
+    return isinstance(value, int | float) and math.isfinite(float(value)) and float(value) >= 0.0
+
+
+def _is_lowercase_snake_case(value: str) -> bool:
+    if not value:
+        return False
+    return value[0].islower() and all(
+        char.islower() or char.isdigit() or char == "_" for char in value
+    )

--- a/robot_sf/nav/footprint_diagnostic.py
+++ b/robot_sf/nav/footprint_diagnostic.py
@@ -23,6 +23,7 @@ compared directly with an elongated body that "collides" on the same route.
 
 from __future__ import annotations
 
+import itertools
 import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -30,7 +31,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
-from shapely.geometry import LineString, Point, Polygon
+from shapely.geometry import LineString, Polygon
 from shapely.ops import unary_union
 
 if TYPE_CHECKING:
@@ -285,16 +286,21 @@ def footprint_aware_clearance_m(
 
     sample_count = min(max_samples, max(2, math.ceil(length / sample_step_m) + 1))
     eps = max(1e-3, length * 1e-6)
+    # Route-level fallback heading from the first non-degenerate segment. The
+    # route is guaranteed non-degenerate here (``length > 0``), so this is
+    # always available and lets a locally degenerate sample (e.g. duplicate
+    # consecutive waypoints) keep the full oriented footprint instead of
+    # collapsing to a zero-size point, which would understate collision risk
+    # and violate the fail-closed contract.
+    fallback_heading = _route_fallback_heading(line)
     min_clearance: float | None = None
     for index in range(sample_count):
         distance = length * index / (sample_count - 1) if sample_count > 1 else 0.0
         point = line.interpolate(distance)
         heading = _route_tangent(line, distance, length, eps)
-        rect = (
-            _oriented_rectangle(point.x, point.y, footprint.length_m, footprint.width_m, heading)
-            if heading is not None
-            else Point(point)
-        )
+        if heading is None:
+            heading = fallback_heading
+        rect = _oriented_rectangle(point.x, point.y, footprint.length_m, footprint.width_m, heading)
         clearance = float(rect.distance(obstacles))
         if min_clearance is None or clearance < min_clearance:
             min_clearance = clearance
@@ -698,6 +704,26 @@ def _oriented_rectangle(
         (cx + x * cos_h - y * sin_h, cy + x * sin_h + y * cos_h) for x, y in local_corners
     ]
     return Polygon(world_corners)
+
+
+def _route_fallback_heading(line: LineString) -> float:
+    """Return a heading (radians) from the first non-degenerate route segment.
+
+    Used as a conservative fallback when a local tangent is degenerate at a
+    sample point (e.g. duplicate consecutive waypoints) so the oriented
+    footprint never collapses to a zero-size point. The caller guarantees the
+    route has positive length, so at least one non-degenerate segment exists;
+    ``0.0`` is only returned in the theoretically-unreachable all-degenerate
+    case, keeping a full-size (axis-aligned) footprint rather than a point.
+    """
+
+    coords = list(line.coords)
+    for (x0, y0), (x1, y1) in itertools.pairwise(coords):
+        dx = x1 - x0
+        dy = y1 - y0
+        if dx != 0.0 or dy != 0.0:
+            return float(math.atan2(dy, dx))
+    return 0.0
 
 
 def _route_tangent(line: LineString, distance: float, length: float, eps: float) -> float | None:

--- a/robot_sf/nav/footprint_diagnostic.py
+++ b/robot_sf/nav/footprint_diagnostic.py
@@ -239,6 +239,7 @@ def footprint_aware_clearance_m(
     obstacle_polygons: Sequence[Polygon],
     sample_step_m: float,
     max_samples: int,
+    pass_threshold_m: float = 0.0,
 ) -> tuple[float | None, bool, int]:
     """Compute min oriented-footprint-to-obstacle clearance along a route.
 
@@ -247,12 +248,18 @@ def footprint_aware_clearance_m(
     at ``sample_step_m`` spacing and a rigid rectangle is oriented along the
     local tangent at each sample.
 
+    A scenario-footprint pair is reported as a collision when the min
+    footprint-to-obstacle clearance is ``<= pass_threshold_m``. The default
+    ``0.0`` treats boundary contact (touching or overlapping) as a collision,
+    matching a conservative fail-closed diagnostic; a positive threshold flags
+    near-misses within that margin.
+
     Returns:
         ``(clearance_m, collision, sample_count)`` where ``clearance_m`` is the
         min footprint-to-obstacle distance (``0.0`` when overlapping, ``None``
         when there are no obstacles or the route is degenerate), ``collision``
-        is True when the footprint intersects any obstacle, and ``sample_count``
-        is the number of evaluated samples.
+        is True when that clearance is ``<= pass_threshold_m``, and
+        ``sample_count`` is the number of evaluated samples.
     """
 
     if len(route) < 2 or not obstacle_polygons:
@@ -268,8 +275,9 @@ def footprint_aware_clearance_m(
     if isinstance(footprint, CircularFootprint):
         center_distance = float(line.distance(obstacles))
         clearance = max(0.0, center_distance - footprint.radius_m)
-        # Boundary contact (center_distance == radius) counts as collision.
-        collision = center_distance <= footprint.radius_m
+        # Boundary contact (clearance == 0) counts as collision at the default
+        # threshold; a positive threshold also flags near-misses.
+        collision = clearance <= pass_threshold_m
         return clearance, collision, 1
 
     if not isinstance(footprint, RectangularFootprint):
@@ -278,7 +286,6 @@ def footprint_aware_clearance_m(
     sample_count = min(max_samples, max(2, math.ceil(length / sample_step_m) + 1))
     eps = max(1e-3, length * 1e-6)
     min_clearance: float | None = None
-    any_collision = False
     for index in range(sample_count):
         distance = length * index / (sample_count - 1) if sample_count > 1 else 0.0
         point = line.interpolate(distance)
@@ -291,11 +298,9 @@ def footprint_aware_clearance_m(
         clearance = float(rect.distance(obstacles))
         if min_clearance is None or clearance < min_clearance:
             min_clearance = clearance
-        if rect.intersects(obstacles):
-            any_collision = True
     if min_clearance is None:
-        return None, any_collision, sample_count
-    return float(min_clearance), any_collision, sample_count
+        return None, False, sample_count
+    return float(min_clearance), min_clearance <= pass_threshold_m, sample_count
 
 
 def run_footprint_diagnostic(
@@ -303,6 +308,7 @@ def run_footprint_diagnostic(
     footprints: Sequence[FootprintModel],
     sample_step_m: float,
     max_samples: int,
+    pass_threshold_m: float = 0.0,
 ) -> list[FootprintClearanceResult]:
     """Run all footprint models against one scenario and return per-footprint results.
 
@@ -319,6 +325,7 @@ def run_footprint_diagnostic(
             scenario.obstacles,
             sample_step_m,
             max_samples,
+            pass_threshold_m,
         )
         method = (
             "analytic_margin"
@@ -345,6 +352,7 @@ def build_diagnostic_report(
     sample_step_m: float,
     max_samples: int,
     *,
+    pass_threshold_m: float = 0.0,
     profile_id: str = "footprint_orientation_diagnostic_v1",
 ) -> dict[str, Any]:
     """Build a JSON-serializable diagnostic report across scenarios and footprints.
@@ -361,7 +369,9 @@ def build_diagnostic_report(
 
     scenario_reports: list[dict[str, Any]] = []
     for scenario in scenarios:
-        results = run_footprint_diagnostic(scenario, footprints, sample_step_m, max_samples)
+        results = run_footprint_diagnostic(
+            scenario, footprints, sample_step_m, max_samples, pass_threshold_m
+        )
         rows = [_result_to_row(result) for result in results]
         scenario_reports.append(
             {
@@ -390,6 +400,7 @@ def build_diagnostic_report(
         "diagnostic_parameters": {
             "sample_step_m": float(sample_step_m),
             "max_samples": int(max_samples),
+            "pass_threshold_m": float(pass_threshold_m),
         },
         "scenarios": scenario_reports,
     }

--- a/scripts/diagnostics/run_footprint_orientation_diagnostic.py
+++ b/scripts/diagnostics/run_footprint_orientation_diagnostic.py
@@ -134,6 +134,7 @@ def main(argv: list[str] | None = None) -> int:
         footprints,
         params["sample_step_m"],
         params["max_samples"],
+        pass_threshold_m=params["pass_threshold_m"],
         profile_id=str(payload.get("profile_id", "footprint_orientation_diagnostic_v1")),
     )
     if args.format == "markdown":

--- a/scripts/diagnostics/run_footprint_orientation_diagnostic.py
+++ b/scripts/diagnostics/run_footprint_orientation_diagnostic.py
@@ -1,0 +1,152 @@
+"""Runner for the footprint-orientation diagnostic (issue #4762).
+
+Loads ``configs/diagnostics/footprint_orientation_v1.yaml``, runs the
+diagnostic on the five self-contained scenario-family fixtures, and writes a
+JSON or Markdown report. CPU-only; no campaigns, training, or benchmark
+claims.
+
+Examples:
+    python scripts/diagnostics/run_footprint_orientation_diagnostic.py
+    python scripts/diagnostics/run_footprint_orientation_diagnostic.py --format markdown
+    python scripts/diagnostics/run_footprint_orientation_diagnostic.py --format json --output report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.common.artifact_paths import get_repository_root
+from robot_sf.nav.footprint_diagnostic import (
+    build_diagnostic_report,
+    build_diagnostic_scenarios,
+    load_footprint_orientation_config,
+    parse_diagnostic_parameters,
+    parse_footprints,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs") / "diagnostics" / "footprint_orientation_v1.yaml"
+
+
+def _resolve_config_path(config_path: Path) -> Path:
+    """Resolve a config path against the repository root when relative."""
+
+    path = Path(config_path)
+    if path.is_absolute() and path.exists():
+        return path
+    repo_root = get_repository_root().resolve()
+    candidate = path if path.is_absolute() else (repo_root / path)
+    if not candidate.exists():
+        raise FileNotFoundError(f"footprint-orientation config not found: {path}")
+    return candidate
+
+
+def build_markdown_report(report: dict) -> str:
+    """Render a diagnostic report dict as a compact Markdown document."""
+
+    lines: list[str] = []
+    lines.append(f"# Footprint-orientation diagnostic ({report['profile_id']})")
+    lines.append("")
+    lines.append(f"> {report['claim_boundary_note']}")
+    lines.append("")
+    params = report["diagnostic_parameters"]
+    lines.append(
+        f"**Parameters:** sample_step={params['sample_step_m']} m, "
+        f"max_samples={params['max_samples']}"
+    )
+    lines.append("")
+    lines.append(
+        "| Scenario | Mechanism | Footprint | Kind | Centerline (m) | "
+        "Footprint-aware (m) | Status |"
+    )
+    lines.append("|---|---|---|---|---|---|---|")
+    for scenario in report["scenarios"]:
+        first = True
+        for row in scenario["results"]:
+            scenario_cell = scenario["display_name"] if first else ""
+            mechanism_cell = scenario["mechanism"] if first else ""
+            lines.append(
+                "| {scenario} | {mechanism} | {footprint} | {kind} | {cl} | {fa} | {status} |".format(
+                    scenario=scenario_cell,
+                    mechanism=mechanism_cell,
+                    footprint=row["footprint_id"],
+                    kind=row["kind"],
+                    cl=_fmt(row["centerline_clearance_m"]),
+                    fa=_fmt(row["footprint_aware_clearance_m"]),
+                    status=row["status"],
+                )
+            )
+            first = False
+    lines.append("")
+    lines.append(
+        "Centerline clearance ignores the footprint; footprint-aware clearance "
+        "orients a rigid footprint along the local route tangent. A `collision` "
+        "status means the oriented footprint intersects an obstacle. This is a "
+        "diagnostic proxy, not a full SE(2) planner."
+    )
+    return "\n".join(lines)
+
+
+def _fmt(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{float(value):.4f}"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the footprint-orientation diagnostic runner."""
+    parser = argparse.ArgumentParser(
+        description="Run the footprint-orientation diagnostic (issue #4762).",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_PATH,
+        help="Path to the footprint-orientation diagnostic YAML config.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="json",
+        help="Output format (default: json).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output file path (default: stdout).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the footprint-orientation diagnostic and emit a JSON or Markdown report."""
+    args = parse_args(argv)
+    config_path = _resolve_config_path(args.config)
+    payload = load_footprint_orientation_config(config_path)
+    footprints = parse_footprints(payload)
+    params = parse_diagnostic_parameters(payload)
+    scenarios = build_diagnostic_scenarios()
+    report = build_diagnostic_report(
+        scenarios,
+        footprints,
+        params["sample_step_m"],
+        params["max_samples"],
+        profile_id=str(payload.get("profile_id", "footprint_orientation_diagnostic_v1")),
+    )
+    if args.format == "markdown":
+        output_text = build_markdown_report(report)
+    else:
+        output_text = json.dumps(report, indent=2, sort_keys=True)
+    if args.output is not None:
+        Path(args.output).write_text(output_text + "\n", encoding="utf-8")
+        print(f"Wrote {args.output}", file=sys.stderr)
+    else:
+        print(output_text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/nav/test_footprint_diagnostic.py
+++ b/tests/nav/test_footprint_diagnostic.py
@@ -357,3 +357,51 @@ def test_runner_writes_markdown_and_json_reports(tmp_path: Path) -> None:
     assert "collision" in markdown
     # build_markdown_report must render a self-contained table from a report dict
     assert "shuttle_pod_like" in build_markdown_report(report)
+
+
+# --------------------------------------------------------------------------- #
+# pass_threshold_m (near-miss margin)
+# --------------------------------------------------------------------------- #
+
+
+def test_pass_threshold_flags_near_miss_as_collision(footprints: list, params: dict) -> None:
+    """A positive pass_threshold_m turns a near-miss clearance into a collision.
+
+    Locks the ``pass_threshold_m`` config field to actual behavior: at the default
+    ``0.0`` the scooter clears the narrow passage, but a threshold above its
+    clearance margin flips the same run to ``collision`` without moving geometry.
+    """
+
+    scenarios = {s.id: s for s in build_diagnostic_scenarios()}
+    narrow = scenarios["narrow_passage_v1"]
+    scooter = next(fp for fp in footprints if fp.id == "scooter_like")
+
+    clearance, collision_default, _ = footprint_aware_clearance_m(
+        narrow.route, scooter, narrow.obstacles, params["sample_step_m"], params["max_samples"]
+    )
+    assert clearance is not None and clearance > 0.0
+    assert collision_default is False
+
+    _, collision_strict, _ = footprint_aware_clearance_m(
+        narrow.route,
+        scooter,
+        narrow.obstacles,
+        params["sample_step_m"],
+        params["max_samples"],
+        pass_threshold_m=clearance + 0.05,
+    )
+    assert collision_strict is True
+
+    # The report threads the threshold and echoes it in diagnostic_parameters.
+    report = build_diagnostic_report(
+        [narrow],
+        footprints,
+        params["sample_step_m"],
+        params["max_samples"],
+        pass_threshold_m=clearance + 0.05,
+    )
+    assert report["diagnostic_parameters"]["pass_threshold_m"] == pytest.approx(clearance + 0.05)
+    scooter_row = next(
+        r for r in report["scenarios"][0]["results"] if r["footprint_id"] == "scooter_like"
+    )
+    assert scooter_row["status"] == "collision"

--- a/tests/nav/test_footprint_diagnostic.py
+++ b/tests/nav/test_footprint_diagnostic.py
@@ -1,0 +1,359 @@
+"""Tests for the footprint-orientation diagnostic (issue #4762)."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from robot_sf.nav.footprint_diagnostic import (
+    FOOTPRINT_ORIENTATION_SCHEMA_VERSION,
+    CircularFootprint,
+    FootprintOrientationConfigError,
+    RectangularFootprint,
+    build_diagnostic_report,
+    build_diagnostic_scenarios,
+    centerline_clearance_m,
+    footprint_aware_clearance_m,
+    load_footprint_orientation_config,
+    parse_diagnostic_parameters,
+    parse_footprints,
+    run_footprint_diagnostic,
+    validate_footprint_orientation_config,
+)
+
+CONFIG_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "diagnostics"
+    / "footprint_orientation_v1.yaml"
+)
+
+
+@pytest.fixture
+def valid_payload() -> dict:
+    """Return the repository footprint-orientation diagnostic config."""
+
+    return load_footprint_orientation_config(CONFIG_PATH)
+
+
+@pytest.fixture
+def footprints(valid_payload: dict) -> list:
+    """Return parsed footprint models from the checked-in config."""
+
+    return parse_footprints(valid_payload)
+
+
+@pytest.fixture
+def params(valid_payload: dict) -> dict:
+    """Return parsed diagnostic parameters from the checked-in config."""
+
+    return parse_diagnostic_parameters(valid_payload)
+
+
+def _result_by_footprint(results: list, footprint_id: str):
+    """Return the clearance result row for one footprint id."""
+
+    for result in results:
+        if result.footprint_id == footprint_id:
+            return result
+    raise AssertionError(f"missing result for footprint {footprint_id!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Config contract
+# --------------------------------------------------------------------------- #
+
+
+def test_config_loads_with_required_contract(valid_payload: dict) -> None:
+    """The checked-in config carries the v1 schema, boundary language, and footprints."""
+
+    assert valid_payload["schema_version"] == FOOTPRINT_ORIENTATION_SCHEMA_VERSION
+    claim = valid_payload["claim_boundary"].casefold()
+    assert "diagnostic" in claim
+    assert "not a full se(2) planner" in claim
+    assert "not calibrated" in claim
+    kinds = {footprint["kind"] for footprint in valid_payload["footprints"]}
+    assert "circular" in kinds
+    assert "rectangular" in kinds
+    family_ids = {family["id"] for family in valid_payload["scenario_families"]}
+    assert {
+        "narrow_passage",
+        "pedestrian_crossing",
+        "occluded_corner",
+        "recovery_after_avoidance",
+        "blocked_path_turn_around",
+    }.issubset(family_ids)
+    roles = {entry["role"] for entry in valid_payload["source_literature"]}
+    assert roles == {"motivation_only"}
+
+
+def test_parse_footprints_returns_circular_and_rectangular(footprints: list) -> None:
+    """Parsing yields the four issue #4762 footprint models with correct kinds."""
+
+    by_id = {footprint.id: footprint for footprint in footprints}
+    assert set(by_id) == {"circular", "scooter_like", "cargo_bike_like", "shuttle_pod_like"}
+    assert isinstance(by_id["circular"], CircularFootprint)
+    assert by_id["circular"].radius_m == pytest.approx(0.35)
+    assert isinstance(by_id["scooter_like"], RectangularFootprint)
+    assert by_id["scooter_like"].length_m == pytest.approx(1.3)
+    assert by_id["scooter_like"].width_m == pytest.approx(0.55)
+    assert isinstance(by_id["shuttle_pod_like"], RectangularFootprint)
+    assert by_id["shuttle_pod_like"].length_m == pytest.approx(3.0)
+
+
+def test_duplicate_footprint_ids_fail_closed(valid_payload: dict) -> None:
+    """Duplicate footprint IDs are rejected."""
+
+    payload = deepcopy(valid_payload)
+    payload["footprints"].append(deepcopy(payload["footprints"][0]))
+
+    with pytest.raises(FootprintOrientationConfigError, match="duplicate footprint ids"):
+        validate_footprint_orientation_config(payload)
+
+
+def test_missing_rectangular_footprint_fails_closed(valid_payload: dict) -> None:
+    """At least one rectangular footprint is required (AC1)."""
+
+    payload = deepcopy(valid_payload)
+    payload["footprints"] = [
+        footprint for footprint in payload["footprints"] if footprint["kind"] != "rectangular"
+    ]
+
+    with pytest.raises(FootprintOrientationConfigError, match="at least one rectangular"):
+        validate_footprint_orientation_config(payload)
+
+
+def test_invalid_footprint_kind_fails_closed(valid_payload: dict) -> None:
+    """Unknown footprint kinds are rejected."""
+
+    payload = deepcopy(valid_payload)
+    payload["footprints"][1]["kind"] = "elliptical"
+
+    with pytest.raises(
+        FootprintOrientationConfigError, match="kind must be 'circular' or 'rectangular'"
+    ):
+        validate_footprint_orientation_config(payload)
+
+
+def test_missing_claim_boundary_language_fails_closed(valid_payload: dict) -> None:
+    """The claim boundary must keep diagnostic, not-a-full-SE(2)-planner, and not-calibrated language."""
+
+    payload = deepcopy(valid_payload)
+    payload["claim_boundary"] = "a helpful clearance report"
+
+    with pytest.raises(FootprintOrientationConfigError, match="claim_boundary"):
+        validate_footprint_orientation_config(payload)
+
+
+def test_non_motivation_source_role_fails_closed(valid_payload: dict) -> None:
+    """Source literature cannot claim implemented-method status."""
+
+    payload = deepcopy(valid_payload)
+    payload["source_literature"][0]["role"] = "implemented_method"
+
+    with pytest.raises(FootprintOrientationConfigError, match="motivation_only"):
+        validate_footprint_orientation_config(payload)
+
+
+def test_missing_required_scenario_family_fails_closed(valid_payload: dict) -> None:
+    """All five candidate scenario families must be declared."""
+
+    payload = deepcopy(valid_payload)
+    payload["scenario_families"] = [
+        family for family in payload["scenario_families"] if family["id"] != "occluded_corner"
+    ]
+
+    with pytest.raises(FootprintOrientationConfigError, match="missing required scenario_family"):
+        validate_footprint_orientation_config(payload)
+
+
+def test_nonpositive_sample_step_fails_closed(valid_payload: dict) -> None:
+    """A non-positive sample step is rejected."""
+
+    payload = deepcopy(valid_payload)
+    payload["diagnostic_parameters"]["sample_step_m"] = 0.0
+
+    with pytest.raises(FootprintOrientationConfigError, match="sample_step_m"):
+        validate_footprint_orientation_config(payload)
+
+
+# --------------------------------------------------------------------------- #
+# Geometry: centerline vs footprint-aware clearance
+# --------------------------------------------------------------------------- #
+
+
+def test_centerline_clearance_matches_known_values() -> None:
+    """Centerline clearance is the bare route-to-obstacle distance, ignoring footprint."""
+
+    scenarios = {s.id: s for s in build_diagnostic_scenarios()}
+    assert centerline_clearance_m(
+        scenarios["narrow_passage_v1"].route, scenarios["narrow_passage_v1"].obstacles
+    ) == pytest.approx(0.45)
+    assert centerline_clearance_m(
+        scenarios["occluded_corner_v1"].route, scenarios["occluded_corner_v1"].obstacles
+    ) == pytest.approx(0.7)
+    assert centerline_clearance_m(
+        scenarios["blocked_path_turn_around_v1"].route,
+        scenarios["blocked_path_turn_around_v1"].obstacles,
+    ) == pytest.approx(1.0)
+
+
+def test_circular_footprint_aware_equals_centerline_minus_radius(
+    footprints: list, params: dict
+) -> None:
+    """For a circular footprint the analytic margin equals centerline minus radius (AC3)."""
+
+    scenarios = {s.id: s for s in build_diagnostic_scenarios()}
+    narrow = scenarios["narrow_passage_v1"]
+    circular = next(fp for fp in footprints if isinstance(fp, CircularFootprint))
+    clearance, collision, _ = footprint_aware_clearance_m(
+        narrow.route, circular, narrow.obstacles, params["sample_step_m"], params["max_samples"]
+    )
+    assert clearance == pytest.approx(0.45 - 0.35)
+    assert collision is False
+
+
+def test_shuttle_collides_in_narrow_passage_where_circular_clears(
+    footprints: list, params: dict
+) -> None:
+    """AC2: the same scenario produces contrasting pass/fail outcomes across footprints."""
+
+    scenarios = {s.id: s for s in build_diagnostic_scenarios()}
+    narrow = scenarios["narrow_passage_v1"]
+    results = {
+        r.footprint_id: r
+        for r in run_footprint_diagnostic(
+            narrow, footprints, params["sample_step_m"], params["max_samples"]
+        )
+    }
+    assert results["circular"].status == "clear"
+    assert results["scooter_like"].status == "clear"
+    assert results["cargo_bike_like"].status == "clear"
+    assert results["shuttle_pod_like"].status == "collision"
+    # Centerline clearance is identical across footprints (same route/obstacles),
+    # while footprint-aware clearance diverges: this is the AC3 distinction.
+    assert (
+        results["circular"].centerline_clearance_m
+        == results["shuttle_pod_like"].centerline_clearance_m
+    )
+    assert results["circular"].footprint_aware_clearance_m == pytest.approx(0.10)
+    assert results["shuttle_pod_like"].footprint_aware_clearance_m == pytest.approx(0.0)
+
+
+def test_occluded_corner_surfaces_turn_overrun_for_elongated_bodies(
+    footprints: list, params: dict
+) -> None:
+    """An elongated body oriented along the incoming leg overruns the turn and collides."""
+
+    scenarios = {s.id: s for s in build_diagnostic_scenarios()}
+    corner = scenarios["occluded_corner_v1"]
+    results = {
+        r.footprint_id: r
+        for r in run_footprint_diagnostic(
+            corner, footprints, params["sample_step_m"], params["max_samples"]
+        )
+    }
+    assert results["circular"].status == "clear"
+    assert results["scooter_like"].status == "clear"
+    assert results["cargo_bike_like"].status == "collision"
+    assert results["shuttle_pod_like"].status == "collision"
+    assert results["cargo_bike_like"].method == "oriented_rectangle_sampling"
+    assert results["circular"].method == "analytic_margin"
+
+
+def test_blocked_path_surfaces_forward_reach_for_elongated_bodies(
+    footprints: list, params: dict
+) -> None:
+    """An elongated body's forward reach pokes a dead-end wall a circular body clears."""
+
+    scenarios = {s.id: s for s in build_diagnostic_scenarios()}
+    blocked = scenarios["blocked_path_turn_around_v1"]
+    results = {
+        r.footprint_id: r
+        for r in run_footprint_diagnostic(
+            blocked, footprints, params["sample_step_m"], params["max_samples"]
+        )
+    }
+    assert results["circular"].status == "clear"
+    assert results["scooter_like"].status == "clear"
+    assert results["cargo_bike_like"].status == "collision"
+    assert results["shuttle_pod_like"].status == "collision"
+
+
+def test_footprint_aware_returns_none_without_obstacles(footprints: list, params: dict) -> None:
+    """Missing obstacles produce None, not a zero-like clearance."""
+
+    circular = next(fp for fp in footprints if isinstance(fp, CircularFootprint))
+    clearance, collision, samples = footprint_aware_clearance_m(
+        [(0.0, 0.0), (5.0, 0.0)], circular, [], params["sample_step_m"], params["max_samples"]
+    )
+    assert clearance is None
+    assert collision is False
+    assert samples == 0
+
+
+# --------------------------------------------------------------------------- #
+# Report shape
+# --------------------------------------------------------------------------- #
+
+
+def test_report_distinguishes_centerline_from_footprint_aware_clearance(
+    footprints: list, params: dict, valid_payload: dict
+) -> None:
+    """AC3: the report carries both clearance fields and a per-footprint status."""
+
+    scenarios = build_diagnostic_scenarios()
+    report = build_diagnostic_report(
+        scenarios,
+        footprints,
+        params["sample_step_m"],
+        params["max_samples"],
+        profile_id=valid_payload["profile_id"],
+    )
+    assert report["schema_version"] == FOOTPRINT_ORIENTATION_SCHEMA_VERSION
+    assert "not a full se(2) planner" in report["claim_boundary_note"].casefold()
+    assert len(report["scenarios"]) == 5
+    narrow = next(sc for sc in report["scenarios"] if sc["scenario_id"] == "narrow_passage_v1")
+    assert narrow["collision_footprint_ids"] == ["shuttle_pod_like"]
+    assert set(narrow["clear_footprint_ids"]) == {"circular", "scooter_like", "cargo_bike_like"}
+    for row in narrow["results"]:
+        assert "centerline_clearance_m" in row
+        assert "footprint_aware_clearance_m" in row
+        assert row["status"] in ("clear", "collision")
+
+
+# --------------------------------------------------------------------------- #
+# Runner
+# --------------------------------------------------------------------------- #
+
+
+def test_runner_writes_markdown_and_json_reports(tmp_path: Path) -> None:
+    """The runner produces both a JSON and a Markdown artifact from the checked-in config."""
+
+    from scripts.diagnostics.run_footprint_orientation_diagnostic import (
+        build_markdown_report,
+        main,
+    )
+
+    json_path = tmp_path / "report.json"
+    md_path = tmp_path / "report.md"
+
+    assert main(["--config", str(CONFIG_PATH), "--format", "json", "--output", str(json_path)]) == 0
+    assert (
+        main(["--config", str(CONFIG_PATH), "--format", "markdown", "--output", str(md_path)]) == 0
+    )
+
+    import json
+
+    report = json.loads(json_path.read_text(encoding="utf-8"))
+    assert report["profile_id"] == "footprint_orientation_diagnostic_v1"
+    assert len(report["scenarios"]) == 5
+
+    markdown = md_path.read_text(encoding="utf-8")
+    assert "Footprint-orientation diagnostic" in markdown
+    assert "Centerline (m)" in markdown
+    assert "collision" in markdown
+    # build_markdown_report must render a self-contained table from a report dict
+    assert "shuttle_pod_like" in build_markdown_report(report)

--- a/tests/nav/test_footprint_diagnostic.py
+++ b/tests/nav/test_footprint_diagnostic.py
@@ -294,6 +294,41 @@ def test_footprint_aware_returns_none_without_obstacles(footprints: list, params
     assert samples == 0
 
 
+def test_degenerate_local_tangent_keeps_full_footprint(params: dict) -> None:
+    """A duplicate mid-route waypoint must not collapse the footprint to a point.
+
+    A degenerate local tangent (repeated consecutive waypoint) previously fell
+    back to a zero-size point, which understates clearance and could miss a real
+    collision (fail-open). The route-level fallback heading must keep the full
+    oriented rectangle, so an elongated body flush against a wall still reports
+    the same near-zero clearance / collision it does without the duplicate.
+    """
+
+    from shapely.geometry import Polygon as _Polygon
+
+    footprint = RectangularFootprint(id="scooter_like", length_m=1.3, width_m=0.55)
+    # Wall directly beside a straight route; the elongated body clears it thinly.
+    obstacles = [_Polygon([(0.0, 0.30), (6.0, 0.30), (6.0, 2.0), (0.0, 2.0)])]
+    straight_route = [(0.0, 0.0), (2.0, 0.0), (4.0, 0.0), (6.0, 0.0)]
+    # Same route but with a duplicated mid-route waypoint -> degenerate tangent
+    # at that sample under the old code path.
+    duplicated_route = [(0.0, 0.0), (2.0, 0.0), (2.0, 0.0), (4.0, 0.0), (6.0, 0.0)]
+
+    baseline, _, _ = footprint_aware_clearance_m(
+        straight_route, footprint, obstacles, params["sample_step_m"], params["max_samples"]
+    )
+    with_dup, _, _ = footprint_aware_clearance_m(
+        duplicated_route, footprint, obstacles, params["sample_step_m"], params["max_samples"]
+    )
+    assert baseline is not None
+    assert with_dup is not None
+    # Full footprint retained: clearance stays the thin wall gap, not a larger
+    # point-to-wall distance that a collapsed footprint would report.
+    assert with_dup == pytest.approx(baseline, abs=1e-6)
+    # A degenerate sample must never yield MORE clearance than the true footprint.
+    assert with_dup <= baseline + 1e-9
+
+
 # --------------------------------------------------------------------------- #
 # Report shape
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Plain-language summary

The robot in this repository is normally modeled as a **circle** (`radius_m`).
Real Autonomous Micromobility Vehicles (AMMVs) — kick scooters, cargo bikes,
delivery robots, shuttle pods — are **elongated**, so route traversability
depends on the body's yaw, not just centerline clearance. This PR adds a
lightweight, CPU-only diagnostic that compares route clearance under circular,
rectangular, and elongated footprint assumptions on the same route, so that a
route a circular body "clears" can be checked against what a scooter-, cargo-,
or shuttle-pod-class body would actually do.

Issue: #4762 (fresh issue; no prior PRs. **Not a successor slice** — this PR
adds new capability and does not duplicate any merged PR.)

Closes #4762

## What / why

Adds a footprint-orientation diagnostic that, per scenario and footprint,
reports two **separately named** quantities:

- `centerline_clearance_m` — min route-centerline-to-obstacle distance, ignoring the footprint (what the existing circular route-clearance contract reasons about).
- `footprint_aware_clearance_m` — min oriented rigid-footprint-to-obstacle distance, sampled along the route and oriented along the local tangent (`0.0` when overlapping).

Plus a `status` of `clear` / `collision` (boundary contact counts as collision,
conservative fail-closed). Reporting both numbers separately is the point: it
makes circular-vs-elongated pass/fail outcomes directly comparable.

### Acceptance criteria

- **AC1 — config or utility represents circular + rectangular footprints.** `configs/diagnostics/footprint_orientation_v1.yaml` defines four footprints (`circular` r=0.35; `scooter_like` 1.3×0.55; `cargo_bike_like` 2.2×0.8; `shuttle_pod_like` 3.0×1.4) and `robot_sf/nav/footprint_diagnostic.py` provides `CircularFootprint` / `RectangularFootprint` dataclasses + a fail-closed config validator. ✔
- **AC2 — one diagnostic scenario compares pass/fail or clearance across footprint types.** Five self-contained scenario-family fixtures each compare all four footprints. E.g. `narrow_passage`: circular/scooter/cargo `clear`, shuttle `collision`; `occluded_corner`: circular/scooter `clear`, cargo/shuttle `collision` via turn-overrun. ✔
- **AC3 — report distinguishes centerline clearance from footprint-aware clearance.** Every result row carries both `centerline_clearance_m` and `footprint_aware_clearance_m`. ✔
- **AC4 — documented as a diagnostic proxy, not a full SE(2) planner.** `docs/diagnostics/footprint_orientation.md` + the `claim_boundary` in the YAML + the module docstring all state this explicitly. ✔

## New capability (does not duplicate existing work)

The repo's only existing footprint model is circular (`radius_m`); the
camera-ready route-clearance check (`robot_sf/benchmark/camera_ready/_route_clearance.py`)
is a fail-closed **benchmark gate** for the circular footprint only. This PR
adds the missing orientation-aware (rectangular/elongated) view as a
**research/diagnostic tool** and compares it against the circular baseline on
the same route. It does **not** modify any benchmark, metric, schema, or the
existing route-clearance gate.

## Files

- `configs/diagnostics/footprint_orientation_v1.yaml` — v1 config (footprint models, 5 scenario families, diagnostic parameters, claim boundary, motivation-only sources).
- `robot_sf/nav/footprint_diagnostic.py` — dataclasses, fail-closed config validator, centerline vs footprint-aware clearance geometry, report builder, 5 synthetic scenario fixtures.
- `scripts/diagnostics/run_footprint_orientation_diagnostic.py` — CLI producing JSON or Markdown report.
- `docs/diagnostics/footprint_orientation.md` — diagnostic-proxy documentation.
- `tests/nav/test_footprint_diagnostic.py` — 17 focused tests (config contract + fail-closed + geometry + report + runner).

## Validation output (CPU-only)

```
$ pytest tests/nav/test_footprint_diagnostic.py -q
17 passed in 1.57s

$ ruff check robot_sf/nav/footprint_diagnostic.py scripts/diagnostics/run_footprint_orientation_diagnostic.py tests/nav/test_footprint_diagnostic.py
All checks passed!

$ python scripts/diagnostics/run_footprint_orientation_diagnostic.py --format markdown
# Footprint-orientation diagnostic (footprint_orientation_diagnostic_v1)
| Scenario | Mechanism | Footprint | Kind | Centerline (m) | Footprint-aware (m) | Status |
| Narrow passage | width_driven | circular | circular | 0.4500 | 0.1000 | clear |
|  |  | shuttle_pod_like | rectangular | 0.4500 | 0.0000 | collision |
| Occluded corner | turn_overrun_length_driven | cargo_bike_like | rectangular | 0.7000 | 0.0000 | collision |
| Blocked-path turn-around | forward_reach_length_driven | cargo_bike_like | rectangular | 1.0000 | 0.0000 | collision |
... (5 scenarios × 4 footprints)
```

The three distinct mechanisms are demonstrated: width-driven (narrow passage /
pedestrian offset), turn-overrun length-driven (occluded corner), and
forward-reach length-driven (blocked-path turn-around).

Validation commands:

```
uv run pytest tests/nav/test_footprint_diagnostic.py -q
uv run ruff check robot_sf/nav/footprint_diagnostic.py scripts/diagnostics/run_footprint_orientation_diagnostic.py tests/nav/test_footprint_diagnostic.py
uv run python scripts/diagnostics/run_footprint_orientation_diagnostic.py --format markdown
```

## Evidence / claim propagation

This PR is a diagnostic tool, not a benchmark/metric/schema/paper-facing claim.
The `claim_boundary` in the YAML and the doc page explicitly state it is a
diagnostic proxy, not a full SE(2) planner, not calibrated against
real-vehicle swept-volume data, and not benchmark evidence.

- Target claim/hypothesis: N/A (diagnostic capability, not a claim).
- Comparator/baseline: circular footprint (existing repo contract).
- Evidence tier: diagnostic_only (not benchmark evidence).
- Result classification: diagnostic_available.
- Decision/stop rule: N/A.
- Synthesis/update target: none (no benchmark, metric, schema, or paper surface changed).
- Downstream propagation: NA — no benchmark, metric, schema, model-provenance, or paper-facing surface is modified; the diagnostic is additive and self-contained.
- Output/artifact handling: the runner writes to stdout or a user-specified `--output` path only; no `output/` artifacts are committed.

## Limitations (honest caveats, also in the doc page)

- The rectangular footprint is oriented along the **local route tangent**; it does not model yaw control or the body's actual heading during a turn, and does not simulate the full swept volume of a body pivoting through a corner.
- Fixed `sample_step_m` (0.1 m); sub-step features can be missed.
- Static obstacles only; no dynamic-obstacle or pedestrian modeling.
- Boundary contact is reported as `collision` (conservative); `footprint_aware_clearance_m` is `0.0` (not a signed penetration depth) when a rectangular footprint overlaps an obstacle.

This PR was produced by the OpenCode-Go/GLM-5.2 cheap implementation
lane; the review gate hardens and merges.
