### PR TITLE
Issue #4757: experimental trajectory verifier prototype (cheap-lane worker)

### DIFF
--- a/configs/benchmarks/trajectory_verifier_default.yaml
+++ b/configs/benchmarks/trajectory_verifier_default.yaml
@@ -1,0 +1,25 @@
+name: trajectory_verifier_default
+description: >
+  Optional default thresholds manifest for the experimental AMMV trajectory
+  verifier (issue #4757). The verifier does not load this config automatically;
+  it is a discoverability and reproducibility pointer for offline analysis.
+  Values mirror TrajectoryVerifierConfig defaults in
+  robot_sf/benchmark/trajectory_verifier.py. Experimental diagnostic only: not a
+  formal safety case, not conformalized, not learned, and does not change
+  default planner behavior.
+schema: trajectory_verifier.v1
+claim_boundary: >
+  experimental test-time verification prototype; not a formal safety case;
+  not conformalized; not learned; missing data fails closed to warn;
+  default planner behavior unchanged
+thresholds:
+  min_clearance_m: 0.25
+  warn_clearance_m: 0.5
+  min_ttc_s: 1.0
+  warn_ttc_s: 1.5
+  max_brake_deceleration_mps2: 2.5
+  max_heading_oscillation_count: 3
+  stale_prediction_max_age_s: 0.5
+footprint_defaults:
+  robot_radius_m: 0.3
+  pedestrian_radius_m: 0.3

--- a/docs/context/issue_4757_trajectory_verifier.md
+++ b/docs/context/issue_4757_trajectory_verifier.md
@@ -1,0 +1,85 @@
+# Issue #4757 Experimental AMMV Trajectory Verifier
+
+Date: 2026-07-07
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/4757>
+
+Status: Proposal / experimental prototype (not benchmark evidence).
+
+## Goal
+
+Prototype an experimental, opt-in trajectory verifier for AMMV (Autonomous
+Micromobility Vehicle) planner outputs. The verifier evaluates candidate or
+executed robot trajectories against structured safety/comfort predicates and
+returns `accept`, `warn`, or `fallback_brake` without changing existing planner
+behavior unless explicitly enabled in a future slice.
+
+This is an **experimental test-time verification prototype**. It is:
+
+- **not a formal safety case**;
+- **not conformalized** (no calibrated prediction intervals);
+- **not learned** (deterministic predicates only, no trained score model);
+- **missing data fails closed to `warn`** rather than fabricating metrics such as
+  time-to-collision from missing velocities;
+- **default planner behavior unchanged** (no wiring into planner control loops,
+  release gates, benchmark scoring, or paper/dissertation claims in the first
+  slice).
+
+## Files
+
+- `robot_sf/benchmark/trajectory_verifier.py` - pure evaluator with
+  `TrajectoryVerifierConfig`, `VerifierResult`, `verify_trajectory(...)`, and the
+  opt-in `verify_episode_trace_window(...)` trace adapter.
+- `tests/benchmark/test_trajectory_verifier.py` - deterministic fixtures covering
+  `accept`, `warn`, `fallback_brake`, missing-velocity fail-closed, oscillation
+  warn, shape validation, decision precedence, and trace-window slicing.
+- `configs/benchmarks/trajectory_verifier_default.yaml` - optional default
+  thresholds manifest mirroring `TrajectoryVerifierConfig` defaults. The verifier
+  does not load this config automatically; it is a discoverability and
+  reproducibility pointer for offline analysis.
+
+## Predicate Summary
+
+1. **Minimum footprint clearance** - center distance minus robot and pedestrian
+   radii. Below the hard minimum fires `fallback_brake`; below the warning
+   threshold (but above the hard minimum) fires `warn`.
+2. **Time-to-collision (TTC) proxy** - simple constant-velocity closure model for
+   the robot vs the nearest pedestrian. Missing velocities surface as
+   `stale_or_missing_state` warning rather than a fabricated TTC. Below the hard
+   threshold fires `fallback_brake`.
+3. **Braking feasibility** - stopping distance `v^2 / (2 * a)` compared with
+   projected clearance along the robot heading for pedestrians within the lateral
+   footprint envelope. Infeasible braking near a pedestrian fires `fallback_brake`.
+4. **Stale prediction / missing state** - `prediction_age_s` above the configured
+   threshold, or missing robot/pedestrian velocities, fires `warn`.
+5. **Recovery smoothness / oscillation proxy** - counts large heading changes
+   between consecutive moving timesteps. Excessive oscillation fires `warn`.
+
+## Decision Aggregation
+
+Precedence: `fallback_brake > warn > accept`. The `risk_score` is a deterministic
+decomposition in `[0, 1]`: `1.0` when any hard predicate fired; otherwise the
+maximum soft-predicate contribution (each soft predicate contributes a value in
+`[0, 0.5]`); `0.0` for a clean accept. The decomposition is documented in
+`_aggregate_risk_score` and covered by the unit tests. No score model is trained.
+
+## Verification Commands
+
+```bash
+uv run ruff check robot_sf/benchmark/trajectory_verifier.py tests/benchmark/test_trajectory_verifier.py
+uv run pytest tests/benchmark/test_trajectory_verifier.py -q
+```
+
+## Out of Scope (First Slice)
+
+- Wiring the verifier into any planner control loop, runner, release gate, or
+  benchmark scoring surface.
+- Conformal calibration of thresholds.
+- Learned risk scoring.
+- Any benchmark, paper, or dissertation claim that depends on verifier output.
+
+## Future Hooks
+
+The `verify_episode_trace_window(...)` adapter is the intended entry point for
+offline episode-trace diagnostics. It can later support critical-interval or
+trajectory-report diagnostics, but does not alter planner commands in this slice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -502,6 +502,8 @@ max-statements = 60
 "robot_sf/benchmark/visualization.py" = ["BLE001"]
 "robot_sf/adversarial/**/*.py" = ["D417", "DOC201", "TC001", "TC003"]
 "robot_sf/adversarial/config.py" = ["C901", "PLR0913"]
+# trajectory_verifier: verify_trajectory has 9 keyword-only args as specified by issue #4757 API contract
+"robot_sf/benchmark/trajectory_verifier.py" = ["PLR0913"]
 "robot_sf/adversarial/search.py" = ["BLE001"]
 "robot_sf/adversarial/certification.py" = ["BLE001", "PLC0415"]
 "tests/adversarial/**/*.py" = ["D100", "D103", "TC003"]

--- a/robot_sf/benchmark/trajectory_verifier.py
+++ b/robot_sf/benchmark/trajectory_verifier.py
@@ -1,0 +1,713 @@
+"""Experimental trajectory verifier for AMMV planner outputs (issue #4757).
+
+Opt-in, test-time / offline-analysis verifier for candidate or executed robot
+trajectories. Evaluates deterministic safety/comfort predicates against a robot
+trajectory and pedestrian state and returns ``accept``, ``warn``, or
+``fallback_brake`` without changing default planner behavior.
+
+Conservative by design: missing or stale inputs fail closed to ``warn``; only
+hard safety violations (clearance / TTC / braking feasibility) escalate to
+``fallback_brake``. TTC is never fabricated from missing velocities.
+
+Scope boundary: experimental diagnostic only, not a formal safety case, not
+conformalized, not learned. Wiring into a planner control loop, release gate, or
+benchmark scoring is explicitly out of scope for the first slice and must remain
+opt-in. The implementation is pure and side-effect free so it can be unit-tested
+and called from offline analysis utilities (see :func:`verify_episode_trace_window`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+TRAJECTORY_VERIFIER_SCHEMA = "trajectory_verifier.v1"
+TRAJECTORY_VERIFIER_CLAIM_BOUNDARY = (
+    "experimental test-time verification prototype; not a formal safety case; "
+    "not conformalized; not learned; missing data fails closed to warn; "
+    "default planner behavior unchanged"
+)
+
+DECISION_ACCEPT = "accept"
+DECISION_WARN = "warn"
+DECISION_FALLBACK_BRAKE = "fallback_brake"
+_DECISION_RANK = {DECISION_ACCEPT: 0, DECISION_WARN: 1, DECISION_FALLBACK_BRAKE: 2}
+
+PRED_CLEARANCE_HARD = "min_clearance_hard"
+PRED_CLEARANCE_WARN = "min_clearance_warn"
+PRED_TTC_HARD = "ttc_hard"
+PRED_TTC_WARN = "ttc_warn"
+PRED_BRAKING_INFEASIBLE = "braking_infeasible"
+PRED_STALE_OR_MISSING_STATE = "stale_or_missing_state"
+PRED_RECOVERY_SMOOTHNESS = "recovery_smoothness"
+
+_HEADING_OSCILLATION_MIN_SPEED_MPS = 0.05
+_HEADING_OSCILLATION_ANGLE_RAD = float(np.pi / 6.0)
+
+
+@dataclass(frozen=True, slots=True)
+class TrajectoryVerifierConfig:
+    """Thresholds for the experimental trajectory verifier.
+
+    Attributes:
+        min_clearance_m: Hard minimum footprint clearance (center distance minus
+            robot and pedestrian radii). Below this fires ``fallback_brake``.
+        warn_clearance_m: Soft clearance threshold. Below this (but above the hard
+            minimum) fires ``warn``.
+        min_ttc_s: Hard minimum time-to-collision. Below this fires ``fallback_brake``.
+        warn_ttc_s: Soft TTC threshold. Below this (but above the hard minimum) fires
+            ``warn``.
+        max_brake_deceleration_mps2: Proxy maximum braking deceleration for the
+            braking-feasibility predicate. Stopping distance is ``v^2 / (2 * a)``.
+        max_heading_oscillation_count: Maximum allowed heading sign / large-angle
+            changes along the planned path before firing ``warn``.
+        stale_prediction_max_age_s: Maximum tolerable prediction age. Above this
+            fires ``warn`` via the stale-prediction predicate.
+    """
+
+    min_clearance_m: float = 0.25
+    warn_clearance_m: float = 0.5
+    min_ttc_s: float = 1.0
+    warn_ttc_s: float = 1.5
+    max_brake_deceleration_mps2: float = 2.5
+    max_heading_oscillation_count: int = 3
+    stale_prediction_max_age_s: float = 0.5
+
+    def __post_init__(self) -> None:
+        """Validate thresholds so the verifier cannot be silently misconfigured."""
+        if self.min_clearance_m < 0.0:
+            raise ValueError("TrajectoryVerifierConfig.min_clearance_m must be >= 0")
+        if self.warn_clearance_m < self.min_clearance_m:
+            raise ValueError("TrajectoryVerifierConfig.warn_clearance_m must be >= min_clearance_m")
+        if self.min_ttc_s <= 0.0:
+            raise ValueError("TrajectoryVerifierConfig.min_ttc_s must be > 0")
+        if self.warn_ttc_s < self.min_ttc_s:
+            raise ValueError("TrajectoryVerifierConfig.warn_ttc_s must be >= min_ttc_s")
+        if self.max_brake_deceleration_mps2 <= 0.0:
+            raise ValueError("TrajectoryVerifierConfig.max_brake_deceleration_mps2 must be > 0")
+        if self.max_heading_oscillation_count < 0:
+            raise ValueError("TrajectoryVerifierConfig.max_heading_oscillation_count must be >= 0")
+        if self.stale_prediction_max_age_s <= 0.0:
+            raise ValueError("TrajectoryVerifierConfig.stale_prediction_max_age_s must be > 0")
+
+
+@dataclass(frozen=True, slots=True)
+class VerifierResult:
+    """Outcome of :func:`verify_trajectory`.
+
+    Attributes:
+        decision: Aggregate decision, one of ``accept``, ``warn``, ``fallback_brake``.
+        risk_score: Interpretable deterministic score in ``[0, 1]``. ``1.0`` when any
+            hard predicate fired; otherwise the maximum soft-predicate contribution
+            (each soft predicate contributes a value in ``[0, 0.5]``); ``0.0`` for a
+            clean accept. See :func:`_aggregate_risk_score` for the decomposition.
+        violated_predicates: Tuple of predicate identifiers that fired, in evaluation
+            order. Empty for a clean accept.
+        min_distance_m: Minimum center-to-center distance between the robot and any
+            pedestrian over the trajectory, or ``None`` when there are no pedestrians.
+        min_clearance_m: Minimum footprint clearance (``min_distance_m`` minus the sum
+            of robot and pedestrian radii), or ``None`` when there are no pedestrians.
+        min_ttc_s: Minimum time-to-collision proxy over the trajectory, or ``None`` when
+            velocities are missing or no converging pair exists.
+        braking_feasible: ``True`` when braking is feasible everywhere along the
+            trajectory, ``False`` when the braking-infeasible predicate fired, ``None``
+            when robot velocities are missing so braking feasibility is not evaluated.
+        claim_boundary: Explicit experimental claim boundary string; always equal to
+            :data:`TRAJECTORY_VERIFIER_CLAIM_BOUNDARY`.
+    """
+
+    decision: Literal["accept", "warn", "fallback_brake"]
+    risk_score: float
+    violated_predicates: tuple[str, ...]
+    min_distance_m: float | None
+    min_clearance_m: float | None
+    min_ttc_s: float | None
+    braking_feasible: bool | None
+    claim_boundary: str = field(default=TRAJECTORY_VERIFIER_CLAIM_BOUNDARY)
+
+
+def _as_float2d(name: str, array: np.ndarray | None) -> np.ndarray | None:
+    """Validate a (T, 2) trajectory array or return None for missing input.
+
+    Returns:
+        The validated float array of shape ``(T, 2)``, or ``None`` if ``array`` is
+        ``None``.
+
+    Raises:
+        ValueError: If the array is not shape ``(T, 2)`` or has zero timesteps.
+    """
+    if array is None:
+        return None
+    arr = np.asarray(array, dtype=float)
+    if arr.ndim != 2 or arr.shape[1] != 2:
+        raise ValueError(f"{name} must have shape (T, 2); got {arr.shape}")
+    if arr.shape[0] == 0:
+        raise ValueError(f"{name} must contain at least one timestep; got {arr.shape}")
+    return arr
+
+
+def _as_ped_positions(name: str, array: np.ndarray, expected_t: int) -> np.ndarray:
+    """Validate pedestrian positions and broadcast static (N, 2) to (T, N, 2).
+
+    Returns:
+        Pedestrian positions of shape ``(expected_t, N, 2)``.
+
+    Raises:
+        ValueError: If the shape is not ``(T, N, 2)`` or ``(N, 2)``, the time dim does
+            not match ``expected_t``, or there are no pedestrians.
+    """
+    arr = np.asarray(array, dtype=float)
+    if arr.ndim == 2:
+        if arr.shape[1] != 2:
+            raise ValueError(f"{name} with shape (N, 2) must have last dim 2; got {arr.shape}")
+        if arr.shape[0] == 0:
+            raise ValueError(f"{name} must contain at least one pedestrian; got {arr.shape}")
+        return np.broadcast_to(arr[None, :, :], (expected_t, arr.shape[0], 2)).copy()
+    if arr.ndim == 3:
+        if arr.shape[2] != 2:
+            raise ValueError(f"{name} with shape (T, N, 2) must have last dim 2; got {arr.shape}")
+        if arr.shape[0] != expected_t:
+            raise ValueError(
+                f"{name} time dim {arr.shape[0]} does not match robot_positions time dim "
+                f"{expected_t}"
+            )
+        if arr.shape[1] == 0:
+            raise ValueError(f"{name} must contain at least one pedestrian; got {arr.shape}")
+        return arr
+    raise ValueError(
+        f"{name} must have shape (T, N, 2) or (N, 2); got {arr.shape} (ndim={arr.ndim})"
+    )
+
+
+def _as_ped_velocities(
+    name: str, array: np.ndarray | None, target_shape: tuple[int, int, int]
+) -> np.ndarray | None:
+    """Validate pedestrian velocities against the broadcast pedestrian-position shape.
+
+    Accepts ``(T, N, 2)`` (time-varying, must match ``target_shape`` exactly) or
+    ``(N, 2)`` (static velocities broadcast across the robot time dim ``T``).
+
+    Returns:
+        The validated pedestrian velocities of shape ``target_shape``, or ``None`` if
+        ``array`` is ``None``.
+
+    Raises:
+        ValueError: If the shape does not match ``target_shape`` and is not a valid
+            static ``(N, 2)`` array.
+    """
+    if array is None:
+        return None
+    arr = np.asarray(array, dtype=float)
+    if arr.ndim == 2:
+        if arr.shape != (target_shape[1], 2):
+            raise ValueError(
+                f"{name} with shape (N, 2) must be {target_shape[1], 2}; got {arr.shape}"
+            )
+        return np.broadcast_to(arr[None, :, :], target_shape).copy()
+    if arr.shape != target_shape:
+        raise ValueError(
+            f"{name} must have shape {target_shape} or (N, 2) matching pedestrian_positions; "
+            f"got {arr.shape}"
+        )
+    return arr
+
+
+def _pairwise_distances(robot_positions: np.ndarray, ped_positions: np.ndarray) -> np.ndarray:
+    """Return per-timestep per-pedestrian center distances, shape (T, N)."""
+    diff = ped_positions - robot_positions[:, None, :]
+    return np.linalg.norm(diff, axis=-1)
+
+
+def _ttc_proxy(
+    robot_positions: np.ndarray,
+    robot_velocities: np.ndarray,
+    ped_positions: np.ndarray,
+    ped_velocities: np.ndarray,
+    sum_radii: float,
+) -> np.ndarray:
+    """Return per-timestep per-pedestrian TTC proxy in seconds, shape (T, N).
+
+    Uses a simple constant-velocity closure model:
+    ``ttc = -dot(d, v_rel) / |v_rel|^2`` when the pair is converging (``dot(d, v_rel) < 0``)
+    and the relative speed is non-negligible. Already-touching pairs (center distance
+    below ``sum_radii``) yield ``ttc = 0``. Separating or parallel pairs yield ``inf``.
+    """
+    diff = ped_positions - robot_positions[:, None, :]
+    rel_vel = ped_velocities - robot_velocities[:, None, :]
+    rel_speed_sq = np.sum(rel_vel * rel_vel, axis=-1)
+    closing = np.sum(diff * rel_vel, axis=-1)
+    dist = np.linalg.norm(diff, axis=-1)
+    ttc = np.full_like(dist, np.inf)
+    converging = (closing < 0.0) & (rel_speed_sq > 1.0e-12)
+    ttc = np.where(converging, -closing / np.where(converging, rel_speed_sq, 1.0), ttc)
+    ttc = np.where(dist <= sum_radii, 0.0, ttc)
+    return ttc
+
+
+def _braking_feasible(
+    robot_positions: np.ndarray,
+    robot_velocities: np.ndarray,
+    ped_positions: np.ndarray,
+    ped_velocities: np.ndarray | None,
+    sum_radii: float,
+    max_decel: float,
+) -> bool:
+    """Return True iff the robot can stop before colliding with any pedestrian ahead.
+
+    For each timestep with non-negligible robot speed, compute the stopping distance
+    ``d_stop = v^2 / (2 * a)`` and the clearance to each pedestrian projected onto the
+    robot heading. If a pedestrian is ahead of the robot within the lateral footprint
+    envelope (``|perpendicular offset| <= sum_radii``) and the projected clearance is
+    less than ``d_stop``, braking is infeasible.
+    """
+    robot_speed = np.linalg.norm(robot_velocities, axis=-1)
+    diff = ped_positions - robot_positions[:, None, :]
+    speed_safe = np.where(robot_speed > 1.0e-9, robot_speed, 1.0)
+    heading = robot_velocities / speed_safe[:, None]
+    along = np.sum(diff * heading[:, None, :], axis=-1)
+    lateral = np.sqrt(np.maximum(np.sum(diff * diff, axis=-1) - along * along, 0.0))
+    d_stop = (robot_speed**2) / (2.0 * max_decel)
+    ahead = along > 0.0
+    moving = robot_speed > 1.0e-9
+    in_envelope = lateral <= sum_radii
+    cannot_stop = along < d_stop[:, None]
+    infeasible = moving[:, None] & ahead & in_envelope & cannot_stop
+    return not bool(np.any(infeasible))
+
+
+def _count_heading_oscillations(
+    robot_velocities: np.ndarray,
+    min_speed_mps: float = _HEADING_OSCILLATION_MIN_SPEED_MPS,
+    angle_rad: float = _HEADING_OSCILLATION_ANGLE_RAD,
+) -> int:
+    """Count large heading changes between consecutive moving timesteps.
+
+    A heading change counts when both timesteps have speed above ``min_speed_mps`` and
+    the absolute angular difference exceeds ``angle_rad``. This is a deterministic
+    oscillation proxy; it does not infer intent.
+
+    Returns:
+        The number of large heading changes between consecutive moving timesteps.
+    """
+    speed = np.linalg.norm(robot_velocities, axis=-1)
+    moving = speed > min_speed_mps
+    if int(np.sum(moving)) < 2:
+        return 0
+    angles = np.arctan2(robot_velocities[:, 1], robot_velocities[:, 0])
+    d_angle = np.abs(np.diff(angles))
+    d_angle = np.minimum(d_angle, 2.0 * np.pi - d_angle)
+    moving_pairs = moving[1:] & moving[:-1]
+    return int(np.sum((d_angle > angle_rad) & moving_pairs))
+
+
+def _aggregate_risk_score(
+    hard_fired: bool,
+    soft_risks: Mapping[str, float],
+) -> float:
+    """Combine predicate-level risks into one interpretable score in ``[0, 1]``.
+
+    Decomposition (deterministic, not learned):
+
+    - Any hard predicate firing => ``1.0`` (fallback_brake territory).
+    - Otherwise the score is the maximum soft-predicate contribution, each in
+      ``[0, 0.5]``:
+        * clearance soft risk: linear ramp from 0 at ``warn_clearance`` to 0.5 at the
+          hard ``min_clearance`` threshold.
+        * ttc soft risk: linear ramp from 0 at ``warn_ttc`` to 0.5 at the hard
+          ``min_ttc`` threshold.
+        * stale / missing-state risk: fixed 0.3 (input-state uncertainty, not a
+          measured motion violation).
+        * recovery-smoothness / oscillation risk: ``min(count / (2 * max_count), 0.5)``.
+    - Clean accept => ``0.0``.
+
+    Returns:
+        The aggregated risk score in ``[0, 1]``.
+    """
+    if hard_fired:
+        return 1.0
+    if not soft_risks:
+        return 0.0
+    return max(soft_risks.values())
+
+
+def _ramp(value: float, warn: float, hard: float, at_warn: float, at_hard: float) -> float:
+    """Linear ramp of ``value`` between ``warn`` and ``hard`` thresholds.
+
+    Returns ``at_warn`` when ``value >= warn`` and ``at_hard`` when ``value <= hard``;
+    interpolated linearly in between. ``hard`` must be the more-severe threshold
+    (smaller for clearance/ttc).
+
+    Returns:
+        Interpolated value between ``at_warn`` and ``at_hard``.
+    """
+    if warn == hard:
+        return at_hard if value <= hard else at_warn
+    span = warn - hard
+    t = (warn - value) / span
+    t = max(0.0, min(1.0, t))
+    return at_warn + t * (at_hard - at_warn)
+
+
+# ---------------------------------------------------------------------------
+# Predicate evaluation helpers — each returns (violated_list, hard_fired, soft_risks)
+# ---------------------------------------------------------------------------
+
+
+def _eval_clearance(
+    min_clearance_m: float,
+    cfg: TrajectoryVerifierConfig,
+) -> tuple[list[str], bool, dict[str, float]]:
+    """Evaluate minimum footprint clearance predicate.
+
+    Returns:
+        Tuple of (violated_predicates, hard_fired, soft_risks).
+    """
+    violated: list[str] = []
+    hard_fired = False
+    soft_risks: dict[str, float] = {}
+    if min_clearance_m < cfg.min_clearance_m:
+        violated.append(PRED_CLEARANCE_HARD)
+        hard_fired = True
+    elif min_clearance_m < cfg.warn_clearance_m:
+        violated.append(PRED_CLEARANCE_WARN)
+        soft_risks[PRED_CLEARANCE_WARN] = _ramp(
+            min_clearance_m, cfg.warn_clearance_m, cfg.min_clearance_m, 0.0, 0.5
+        )
+    return violated, hard_fired, soft_risks
+
+
+def _eval_ttc_and_braking(
+    robot_pos: np.ndarray,
+    robot_vel: np.ndarray,
+    ped_pos: np.ndarray,
+    ped_vel: np.ndarray,
+    sum_radii: float,
+    cfg: TrajectoryVerifierConfig,
+) -> tuple[list[str], bool, dict[str, float], float | None, bool]:
+    """Evaluate TTC and braking-feasibility predicates (requires velocity inputs).
+
+    Returns:
+        Tuple of (violated_predicates, hard_fired, soft_risks, min_ttc_s, braking_feasible).
+    """
+    violated: list[str] = []
+    hard_fired = False
+    soft_risks: dict[str, float] = {}
+
+    ttc = _ttc_proxy(robot_pos, robot_vel, ped_pos, ped_vel, sum_radii)
+    finite = ttc[np.isfinite(ttc)]
+    min_ttc_s: float | None = float(np.min(finite)) if finite.size else None
+    if min_ttc_s is not None:
+        if min_ttc_s < cfg.min_ttc_s:
+            violated.append(PRED_TTC_HARD)
+            hard_fired = True
+        elif min_ttc_s < cfg.warn_ttc_s:
+            violated.append(PRED_TTC_WARN)
+            soft_risks[PRED_TTC_WARN] = _ramp(min_ttc_s, cfg.warn_ttc_s, cfg.min_ttc_s, 0.0, 0.5)
+
+    braking_ok = _braking_feasible(
+        robot_pos, robot_vel, ped_pos, ped_vel, sum_radii, cfg.max_brake_deceleration_mps2
+    )
+    if not braking_ok:
+        violated.append(PRED_BRAKING_INFEASIBLE)
+        hard_fired = True
+
+    return violated, hard_fired, soft_risks, min_ttc_s, braking_ok
+
+
+def _eval_stale_prediction(
+    missing_state: bool,
+    prediction_age_s: float | None,
+    cfg: TrajectoryVerifierConfig,
+) -> tuple[list[str], dict[str, float]]:
+    """Evaluate stale / missing-state predicate.
+
+    Returns:
+        Tuple of (violated_predicates, soft_risks).
+    """
+    violated: list[str] = []
+    soft_risks: dict[str, float] = {}
+    if missing_state:
+        violated.append(PRED_STALE_OR_MISSING_STATE)
+        soft_risks[PRED_STALE_OR_MISSING_STATE] = 0.3
+    if prediction_age_s is not None and prediction_age_s > cfg.stale_prediction_max_age_s:
+        if PRED_STALE_OR_MISSING_STATE not in violated:
+            violated.append(PRED_STALE_OR_MISSING_STATE)
+        soft_risks[PRED_STALE_OR_MISSING_STATE] = max(
+            soft_risks.get(PRED_STALE_OR_MISSING_STATE, 0.0), 0.3
+        )
+    return violated, soft_risks
+
+
+def _eval_oscillation(
+    robot_vel: np.ndarray | None,
+    cfg: TrajectoryVerifierConfig,
+) -> tuple[list[str], dict[str, float]]:
+    """Evaluate recovery-smoothness / oscillation-proxy predicate.
+
+    Returns:
+        Tuple of (violated_predicates, soft_risks).
+    """
+    violated: list[str] = []
+    soft_risks: dict[str, float] = {}
+    if robot_vel is None:
+        return violated, soft_risks
+    osc_count = _count_heading_oscillations(robot_vel)
+    if osc_count > cfg.max_heading_oscillation_count:
+        violated.append(PRED_RECOVERY_SMOOTHNESS)
+        soft_risks[PRED_RECOVERY_SMOOTHNESS] = min(
+            osc_count / (2.0 * max(cfg.max_heading_oscillation_count, 1)), 0.5
+        )
+    return violated, soft_risks
+
+
+def _validate_inputs(
+    robot_positions: np.ndarray,
+    robot_velocities: np.ndarray | None,
+    pedestrian_positions: np.ndarray,
+    pedestrian_velocities: np.ndarray | None,
+    dt_s: float,
+    robot_radius_m: float,
+    pedestrian_radius_m: float,
+) -> tuple[np.ndarray, np.ndarray | None, np.ndarray, np.ndarray | None]:
+    """Validate and coerce all input arrays, returning coerced forms.
+
+    Returns:
+        Tuple of (robot_pos, robot_vel, ped_pos, ped_vel) after shape validation.
+
+    Raises:
+        ValueError: If any argument is invalid.
+    """
+    if dt_s <= 0.0:
+        raise ValueError(f"dt_s must be > 0; got {dt_s}")
+    if robot_radius_m < 0.0:
+        raise ValueError(f"robot_radius_m must be >= 0; got {robot_radius_m}")
+    if pedestrian_radius_m < 0.0:
+        raise ValueError(f"pedestrian_radius_m must be >= 0; got {pedestrian_radius_m}")
+
+    robot_pos = _as_float2d("robot_positions", robot_positions)
+    if robot_pos is None:
+        raise ValueError("robot_positions is required and must have shape (T, 2)")
+    robot_vel = _as_float2d("robot_velocities", robot_velocities)
+    if robot_vel is not None and robot_vel.shape != robot_pos.shape:
+        raise ValueError(
+            f"robot_velocities shape {robot_vel.shape} must match robot_positions "
+            f"shape {robot_pos.shape}"
+        )
+    ped_pos = _as_ped_positions("pedestrian_positions", pedestrian_positions, robot_pos.shape[0])
+    ped_vel = _as_ped_velocities("pedestrian_velocities", pedestrian_velocities, ped_pos.shape)
+    return robot_pos, robot_vel, ped_pos, ped_vel
+
+
+def verify_trajectory(
+    *,
+    robot_positions: np.ndarray,
+    robot_velocities: np.ndarray | None,
+    pedestrian_positions: np.ndarray,
+    pedestrian_velocities: np.ndarray | None,
+    dt_s: float,
+    robot_radius_m: float,
+    pedestrian_radius_m: float,
+    config: TrajectoryVerifierConfig | None = None,
+    prediction_age_s: float | None = None,
+) -> VerifierResult:
+    """Verify a robot trajectory against deterministic safety/comfort predicates.
+
+    Args:
+        robot_positions: Robot positions over time, shape ``(T, 2)``.
+        robot_velocities: Robot velocities over time, shape ``(T, 2)``, or ``None`` if
+            missing (the verifier fails closed to warn for missing state).
+        pedestrian_positions: Pedestrian positions, shape ``(T, N, 2)`` (time-varying)
+            or ``(N, 2)`` (static; broadcast to the robot time dim).
+        pedestrian_velocities: Pedestrian velocities, shape matching the broadcast
+            pedestrian positions, or ``None`` if missing.
+        dt_s: Timestep duration in seconds. Must be positive.
+        robot_radius_m: Robot footprint radius in meters. Must be non-negative.
+        pedestrian_radius_m: Pedestrian footprint radius in meters. Must be non-negative.
+        config: Verifier thresholds. Defaults to :class:`TrajectoryVerifierConfig`.
+        prediction_age_s: Age of the pedestrian prediction at the start of the window.
+            If greater than ``config.stale_prediction_max_age_s`` the verifier fires the
+            stale-prediction warning. ``None`` means no age signal is available, which
+            is treated as not-stale (the missing-velocity predicate handles missing
+            motion state separately).
+
+    Returns:
+        A :class:`VerifierResult` with the aggregate decision, risk score, violated
+        predicates, and core metrics.
+
+    Raises:
+        ValueError: If any array shape is invalid, ``dt_s`` is non-positive, or radii
+            are negative.
+    """
+    robot_pos, robot_vel, ped_pos, ped_vel = _validate_inputs(
+        robot_positions,
+        robot_velocities,
+        pedestrian_positions,
+        pedestrian_velocities,
+        dt_s,
+        robot_radius_m,
+        pedestrian_radius_m,
+    )
+    cfg = config if config is not None else TrajectoryVerifierConfig()
+    sum_radii = robot_radius_m + pedestrian_radius_m
+    distances = _pairwise_distances(robot_pos, ped_pos)
+    min_distance_m = float(np.min(distances))
+    min_clearance_m = min_distance_m - sum_radii
+
+    violated: list[str] = []
+    hard_fired = False
+    soft_risks: dict[str, float] = {}
+
+    # Predicate 1: minimum footprint clearance.
+    v, h, s = _eval_clearance(min_clearance_m, cfg)
+    violated.extend(v)
+    hard_fired = hard_fired or h
+    soft_risks.update(s)
+
+    # Predicates 2 & 3: TTC and braking feasibility (requires velocity).
+    min_ttc_s: float | None = None
+    braking_feasible: bool | None = None
+    missing_state = robot_vel is None or ped_vel is None
+    if robot_vel is not None and ped_vel is not None:
+        v, h, s, min_ttc_s, bf = _eval_ttc_and_braking(
+            robot_pos, robot_vel, ped_pos, ped_vel, sum_radii, cfg
+        )
+        braking_feasible = bf
+        violated.extend(v)
+        hard_fired = hard_fired or h
+        soft_risks.update(s)
+
+    # Predicate 4: stale / missing state.
+    v, s = _eval_stale_prediction(missing_state, prediction_age_s, cfg)
+    violated.extend(v)
+    soft_risks.update(s)
+
+    # Predicate 5: recovery smoothness / oscillation proxy.
+    v, s = _eval_oscillation(robot_vel, cfg)
+    violated.extend(v)
+    soft_risks.update(s)
+
+    if hard_fired:
+        decision: Literal["accept", "warn", "fallback_brake"] = DECISION_FALLBACK_BRAKE
+    elif violated:
+        decision = DECISION_WARN
+    else:
+        decision = DECISION_ACCEPT
+
+    risk_score = _aggregate_risk_score(hard_fired, soft_risks)
+
+    return VerifierResult(
+        decision=decision,
+        risk_score=risk_score,
+        violated_predicates=tuple(violated),
+        min_distance_m=min_distance_m,
+        min_clearance_m=min_clearance_m,
+        min_ttc_s=min_ttc_s,
+        braking_feasible=braking_feasible,
+    )
+
+
+def verify_episode_trace_window(
+    trace: Mapping[str, Any],
+    *,
+    start: int = 0,
+    end: int | None = None,
+    config: TrajectoryVerifierConfig | None = None,
+    robot_radius_m: float = 0.3,
+    pedestrian_radius_m: float = 0.3,
+    dt_s: float | None = None,
+) -> VerifierResult:
+    """Opt-in helper to verify a window of an episode trace mapping.
+
+    This is a thin adapter intended for offline analysis and tests. It does **not**
+    alter planner commands and is not wired into any runner by default. The trace must
+    expose the keys ``robot_positions``, ``pedestrian_positions``, and ``dt_s`` (or
+    ``dt``). Optional keys: ``robot_velocities``, ``pedestrian_velocities``,
+    ``prediction_age_s``.
+
+    Args:
+        trace: Mapping with the keys described above. ``robot_positions`` must have
+            shape ``(T, 2)``; ``pedestrian_positions`` may be ``(T, N, 2)`` or
+            ``(N, 2)``.
+        start: Inclusive start index of the window.
+        end: Exclusive end index of the window; defaults to the trajectory end.
+        config: Verifier thresholds. Defaults to :class:`TrajectoryVerifierConfig`.
+        robot_radius_m: Robot footprint radius in meters.
+        pedestrian_radius_m: Pedestrian footprint radius in meters.
+        dt_s: Timestep duration override; if ``None`` the trace ``dt_s`` (or ``dt``)
+            key is used.
+
+    Returns:
+        The :class:`VerifierResult` for the requested window.
+
+    Raises:
+        ValueError: If required keys are missing, shapes are invalid, or the window is
+            empty.
+    """
+    for key in ("robot_positions", "pedestrian_positions"):
+        if key not in trace:
+            raise ValueError(f"verify_episode_trace_window requires trace key {key!r}")
+    resolved_dt = dt_s if dt_s is not None else trace.get("dt_s", trace.get("dt"))
+    if resolved_dt is None:
+        raise ValueError("verify_episode_trace_window requires dt_s (or trace key 'dt_s' / 'dt')")
+
+    robot_positions = np.asarray(trace["robot_positions"], dtype=float)
+    pedestrian_positions = np.asarray(trace["pedestrian_positions"], dtype=float)
+    end_idx = end if end is not None else robot_positions.shape[0]
+    if start < 0 or end_idx <= start:
+        raise ValueError(
+            f"trace window must satisfy 0 <= start < end; got start={start}, end={end_idx}"
+        )
+    robot_positions = robot_positions[start:end_idx]
+    pedestrian_positions = (
+        pedestrian_positions[start:end_idx]
+        if pedestrian_positions.ndim == 3
+        else pedestrian_positions
+    )
+    robot_velocities = trace.get("robot_velocities")
+    if robot_velocities is not None:
+        robot_velocities = np.asarray(robot_velocities, dtype=float)[start:end_idx]
+    pedestrian_velocities = trace.get("pedestrian_velocities")
+    if pedestrian_velocities is not None:
+        pedestrian_velocities_arr = np.asarray(pedestrian_velocities, dtype=float)
+        if pedestrian_velocities_arr.ndim == 3:
+            pedestrian_velocities = pedestrian_velocities_arr[start:end_idx]
+        else:
+            pedestrian_velocities = pedestrian_velocities_arr
+    prediction_age_s = trace.get("prediction_age_s")
+
+    return verify_trajectory(
+        robot_positions=robot_positions,
+        robot_velocities=robot_velocities,
+        pedestrian_positions=pedestrian_positions,
+        pedestrian_velocities=pedestrian_velocities,
+        dt_s=float(resolved_dt),
+        robot_radius_m=robot_radius_m,
+        pedestrian_radius_m=pedestrian_radius_m,
+        config=config,
+        prediction_age_s=(float(prediction_age_s) if prediction_age_s is not None else None),
+    )
+
+
+__all__ = [
+    "DECISION_ACCEPT",
+    "DECISION_FALLBACK_BRAKE",
+    "DECISION_WARN",
+    "PRED_BRAKING_INFEASIBLE",
+    "PRED_CLEARANCE_HARD",
+    "PRED_CLEARANCE_WARN",
+    "PRED_RECOVERY_SMOOTHNESS",
+    "PRED_STALE_OR_MISSING_STATE",
+    "PRED_TTC_HARD",
+    "PRED_TTC_WARN",
+    "TRAJECTORY_VERIFIER_CLAIM_BOUNDARY",
+    "TRAJECTORY_VERIFIER_SCHEMA",
+    "TrajectoryVerifierConfig",
+    "VerifierResult",
+    "verify_episode_trace_window",
+    "verify_trajectory",
+]

--- a/robot_sf/benchmark/trajectory_verifier.py
+++ b/robot_sf/benchmark/trajectory_verifier.py
@@ -131,6 +131,17 @@ class VerifierResult:
     claim_boundary: str = field(default=TRAJECTORY_VERIFIER_CLAIM_BOUNDARY)
 
 
+def _require_finite(name: str, arr: np.ndarray) -> None:
+    """Raise ``ValueError`` if ``arr`` holds any non-finite (NaN/inf) value.
+
+    Non-finite inputs would silently defeat every threshold comparison — e.g.
+    ``nan < min_clearance`` evaluates to ``False`` — and could cause an unsafe
+    trajectory to be accepted. Reject them at the input boundary (fail closed).
+    """
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} must contain only finite values (no NaN or inf)")
+
+
 def _as_float2d(name: str, array: np.ndarray | None) -> np.ndarray | None:
     """Validate a (T, 2) trajectory array or return None for missing input.
 
@@ -148,6 +159,7 @@ def _as_float2d(name: str, array: np.ndarray | None) -> np.ndarray | None:
         raise ValueError(f"{name} must have shape (T, 2); got {arr.shape}")
     if arr.shape[0] == 0:
         raise ValueError(f"{name} must contain at least one timestep; got {arr.shape}")
+    _require_finite(name, arr)
     return arr
 
 
@@ -162,6 +174,7 @@ def _as_ped_positions(name: str, array: np.ndarray, expected_t: int) -> np.ndarr
             not match ``expected_t``, or there are no pedestrians.
     """
     arr = np.asarray(array, dtype=float)
+    _require_finite(name, arr)
     if arr.ndim == 2:
         if arr.shape[1] != 2:
             raise ValueError(f"{name} with shape (N, 2) must have last dim 2; got {arr.shape}")
@@ -203,6 +216,7 @@ def _as_ped_velocities(
     if array is None:
         return None
     arr = np.asarray(array, dtype=float)
+    _require_finite(name, arr)
     if arr.ndim == 2:
         if arr.shape != (target_shape[1], 2):
             raise ValueError(
@@ -260,10 +274,13 @@ def _braking_feasible(
     """Return True iff the robot can stop before colliding with any pedestrian ahead.
 
     For each timestep with non-negligible robot speed, compute the stopping distance
-    ``d_stop = v^2 / (2 * a)`` and the clearance to each pedestrian projected onto the
-    robot heading. If a pedestrian is ahead of the robot within the lateral footprint
-    envelope (``|perpendicular offset| <= sum_radii``) and the projected clearance is
-    less than ``d_stop``, braking is infeasible.
+    ``d_stop = v^2 / (2 * a)`` and the longitudinal clearance to each pedestrian
+    projected onto the robot heading. Because both bodies have physical size, a
+    collision occurs when the center-to-center along-heading distance reaches
+    ``sum_radii``; the available braking distance is therefore ``along - sum_radii``.
+    If a pedestrian is ahead of the robot within the lateral footprint envelope
+    (``|perpendicular offset| <= sum_radii``) and that available distance is less than
+    ``d_stop``, braking is infeasible.
     """
     robot_speed = np.linalg.norm(robot_velocities, axis=-1)
     diff = ped_positions - robot_positions[:, None, :]
@@ -275,7 +292,11 @@ def _braking_feasible(
     ahead = along > 0.0
     moving = robot_speed > 1.0e-9
     in_envelope = lateral <= sum_radii
-    cannot_stop = along < d_stop[:, None]
+    # Subtract the summed radii: the robot must stop before the footprints touch,
+    # not before the centers coincide. Ignoring sum_radii would call braking
+    # feasible even when the robot halts inside the pedestrian (fail-open).
+    available = along - sum_radii
+    cannot_stop = available < d_stop[:, None]
     infeasible = moving[:, None] & ahead & in_envelope & cannot_stop
     return not bool(np.any(infeasible))
 
@@ -298,11 +319,14 @@ def _count_heading_oscillations(
     moving = speed > min_speed_mps
     if int(np.sum(moving)) < 2:
         return 0
-    angles = np.arctan2(robot_velocities[:, 1], robot_velocities[:, 0])
+    # Compare consecutive *moving* timesteps. Filtering to the moving subsequence
+    # first (rather than masking adjacent-pair differences) means a heading change
+    # spanning a stopped/slow timestep is still counted, matching the docstring.
+    moving_velocities = robot_velocities[moving]
+    angles = np.arctan2(moving_velocities[:, 1], moving_velocities[:, 0])
     d_angle = np.abs(np.diff(angles))
     d_angle = np.minimum(d_angle, 2.0 * np.pi - d_angle)
-    moving_pairs = moving[1:] & moving[:-1]
-    return int(np.sum((d_angle > angle_rad) & moving_pairs))
+    return int(np.sum(d_angle > angle_rad))
 
 
 def _aggregate_risk_score(

--- a/tests/benchmark/test_trajectory_verifier.py
+++ b/tests/benchmark/test_trajectory_verifier.py
@@ -448,3 +448,105 @@ def test_schema_and_claim_boundary_constants() -> None:
     assert "not a formal safety case" in TRAJECTORY_VERIFIER_CLAIM_BOUNDARY
     assert "not learned" in TRAJECTORY_VERIFIER_CLAIM_BOUNDARY
     assert "default planner behavior unchanged" in TRAJECTORY_VERIFIER_CLAIM_BOUNDARY
+
+
+def test_braking_accounts_for_footprint_radii() -> None:
+    """Braking is infeasible when the robot would stop inside the pedestrian footprint.
+
+    Regression for the sum_radii gap: at 2 m/s ``d_stop = 0.8 m``. With the
+    nearest along-heading center distance at 0.9 m and ``sum_radii = 0.2 m`` the
+    available braking distance is ``0.9 - 0.2 = 0.7 m < 0.8 m`` -> infeasible.
+    Ignoring the radii (comparing 0.9 m directly to 0.8 m) would wrongly call
+    braking feasible even though the robot halts inside the pedestrian.
+    """
+    n = 5
+    robot_pos = np.stack([np.linspace(0.0, 0.4, n), np.zeros(n)], axis=1)
+    robot_vel = np.tile([2.0, 0.0], (n, 1))  # d_stop = 4 / (2 * 2.5) = 0.8 m
+    ped_pos = np.array([[1.3, 0.0]])  # min along-distance = 1.3 - 0.4 = 0.9 m
+    ped_vel = np.array([[0.0, 0.0]])
+    # Loose clearance/TTC thresholds so only the braking predicate can fire here.
+    cfg = TrajectoryVerifierConfig(
+        min_clearance_m=0.05, warn_clearance_m=0.1, min_ttc_s=0.1, warn_ttc_s=0.2
+    )
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.1,
+        pedestrian_radius_m=0.1,  # sum_radii = 0.2 m
+        config=cfg,
+    )
+    assert result.braking_feasible is False
+    assert PRED_BRAKING_INFEASIBLE in result.violated_predicates
+
+
+def test_heading_oscillation_counted_across_a_pause() -> None:
+    """Heading reversals separated by a stopped timestep still count as oscillations.
+
+    Regression for the adjacent-pair mask: previously a turn straddling a
+    non-moving timestep was dropped because both bordering pairs contained a
+    stopped step. Filtering to the moving subsequence first counts the reversal
+    between consecutive *moving* timesteps regardless of intervening pauses.
+    """
+    velocities: list[list[float]] = []
+    move_idx = 0
+    for i in range(20):
+        if i % 2 == 1:
+            velocities.append([0.0, 0.0])  # pause between every moving step
+        else:
+            heading = 0.0 if move_idx % 2 == 0 else np.pi  # alternate east/west
+            velocities.append([0.5 * float(np.cos(heading)), 0.5 * float(np.sin(heading))])
+            move_idx += 1
+    robot_vel = np.array(velocities)
+    robot_pos = np.cumsum(robot_vel * 0.1, axis=0)
+    ped_pos = np.array([[10.0, 10.0]])
+    ped_vel = np.array([[0.0, 0.0]])
+    cfg = TrajectoryVerifierConfig(max_heading_oscillation_count=3)
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.2,
+        pedestrian_radius_m=0.2,
+        config=cfg,
+    )
+    assert PRED_RECOVERY_SMOOTHNESS in result.violated_predicates
+
+
+def test_non_finite_inputs_raise() -> None:
+    """NaN/inf inputs are rejected at the boundary, never silently accepted.
+
+    A ``nan`` in a position would defeat threshold comparisons (``nan < x`` is
+    ``False``), so the verifier must fail closed with a clear ValueError.
+    """
+    robot_pos, robot_vel, ped_pos, ped_vel = _straight_trajectory(ped_offset=(5.0, 0.0))
+
+    bad_robot = robot_pos.copy()
+    bad_robot[0, 0] = np.nan
+    with pytest.raises(ValueError, match="finite"):
+        verify_trajectory(
+            robot_positions=bad_robot,
+            robot_velocities=robot_vel,
+            pedestrian_positions=ped_pos,
+            pedestrian_velocities=ped_vel,
+            dt_s=0.1,
+            robot_radius_m=0.3,
+            pedestrian_radius_m=0.3,
+        )
+
+    bad_ped = ped_pos.copy()
+    bad_ped[0, 0, 0] = np.inf
+    with pytest.raises(ValueError, match="finite"):
+        verify_trajectory(
+            robot_positions=robot_pos,
+            robot_velocities=robot_vel,
+            pedestrian_positions=bad_ped,
+            pedestrian_velocities=ped_vel,
+            dt_s=0.1,
+            robot_radius_m=0.3,
+            pedestrian_radius_m=0.3,
+        )

--- a/tests/benchmark/test_trajectory_verifier.py
+++ b/tests/benchmark/test_trajectory_verifier.py
@@ -1,0 +1,450 @@
+"""Tests for the experimental AMMV trajectory verifier (issue #4757)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.trajectory_verifier import (
+    DECISION_ACCEPT,
+    DECISION_FALLBACK_BRAKE,
+    DECISION_WARN,
+    PRED_BRAKING_INFEASIBLE,
+    PRED_CLEARANCE_HARD,
+    PRED_CLEARANCE_WARN,
+    PRED_RECOVERY_SMOOTHNESS,
+    PRED_STALE_OR_MISSING_STATE,
+    PRED_TTC_HARD,
+    PRED_TTC_WARN,
+    TRAJECTORY_VERIFIER_CLAIM_BOUNDARY,
+    TRAJECTORY_VERIFIER_SCHEMA,
+    TrajectoryVerifierConfig,
+    VerifierResult,
+    verify_episode_trace_window,
+    verify_trajectory,
+)
+
+
+def _straight_trajectory(
+    *,
+    n_steps: int = 10,
+    robot_speed: float = 0.5,
+    ped_offset: tuple[float, float] = (5.0, 0.0),
+    ped_velocity: tuple[float, float] = (0.0, 0.0),
+    dt_s: float = 0.1,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return (robot_pos, robot_vel, ped_pos, ped_vel) for a straight robot path.
+
+    Pedestrian arrays have shape ``(n_steps, 1, 2)`` (one pedestrian over time).
+    """
+    t = np.arange(n_steps, dtype=float) * dt_s
+    robot_pos = np.stack([t * robot_speed, np.zeros(n_steps)], axis=1)
+    robot_vel = np.tile([robot_speed, 0.0], (n_steps, 1))
+    ped_pos = np.tile(np.array([ped_offset], dtype=float), (n_steps, 1, 1))
+    ped_vel = np.tile(np.array([ped_velocity], dtype=float), (n_steps, 1, 1))
+    return robot_pos, robot_vel, ped_pos, ped_vel
+
+
+def test_accept_straight_path_pedestrian_far() -> None:
+    """A straight path with a far-away pedestrian and finite clearance/TTC is accepted."""
+    robot_pos, robot_vel, ped_pos, ped_vel = _straight_trajectory(
+        ped_offset=(5.0, 2.0), robot_speed=0.5
+    )
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.3,
+        pedestrian_radius_m=0.3,
+    )
+    assert result.decision == DECISION_ACCEPT
+    assert result.violated_predicates == ()
+    assert result.risk_score == 0.0
+    assert result.min_distance_m is not None and result.min_distance_m > 1.0
+    assert result.min_clearance_m is not None and result.min_clearance_m > 0.5
+    assert result.min_ttc_s is None or result.min_ttc_s > 1.5
+    assert result.braking_feasible is True
+    assert result.claim_boundary == TRAJECTORY_VERIFIER_CLAIM_BOUNDARY
+
+
+def test_warn_pedestrian_near_warning_clearance() -> None:
+    """A pedestrian within the warning clearance band (but above hard) triggers warn."""
+    n = 10
+    robot_pos = np.tile([0.0, 0.0], (n, 1))
+    robot_vel = np.tile([0.0, 0.0], (n, 1))
+    cfg = TrajectoryVerifierConfig(min_clearance_m=0.1, warn_clearance_m=0.5)
+    # clearance = 0.7 - 0.2 = 0.5 -> exactly at warn threshold boundary; accept or warn.
+    ped_pos = np.array([[0.7, 0.0]])
+    ped_vel = np.array([[0.0, 0.0]])
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.1,
+        pedestrian_radius_m=0.1,
+        config=cfg,
+    )
+    assert result.decision in {DECISION_WARN, DECISION_ACCEPT}
+    # Now place clearance strictly inside the warn band (0.1, 0.5).
+    ped_pos = np.array([[0.55, 0.0]])
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.1,
+        pedestrian_radius_m=0.1,
+        config=cfg,
+    )
+    assert result.decision == DECISION_WARN
+    assert PRED_CLEARANCE_WARN in result.violated_predicates
+    assert PRED_CLEARANCE_HARD not in result.violated_predicates
+    assert 0.0 < result.risk_score <= 0.5
+
+
+def test_warn_stale_prediction_age() -> None:
+    """A prediction age above the stale threshold triggers a warn predicate."""
+    robot_pos, robot_vel, ped_pos, ped_vel = _straight_trajectory(ped_offset=(5.0, 5.0))
+    cfg = TrajectoryVerifierConfig(stale_prediction_max_age_s=0.2)
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.3,
+        pedestrian_radius_m=0.3,
+        config=cfg,
+        prediction_age_s=0.5,
+    )
+    assert result.decision == DECISION_WARN
+    assert PRED_STALE_OR_MISSING_STATE in result.violated_predicates
+    assert result.risk_score >= 0.3
+
+
+def test_fallback_clearance_below_hard_minimum() -> None:
+    """A pedestrian within the hard clearance minimum triggers fallback_brake."""
+    n = 5
+    robot_pos = np.tile([0.0, 0.0], (n, 1))
+    robot_vel = np.tile([0.0, 0.0], (n, 1))
+    ped_pos = np.array([[0.4, 0.0]])  # clearance = 0.4 - 0.6 = -0.2 < min_clearance
+    ped_vel = np.array([[0.0, 0.0]])
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.3,
+        pedestrian_radius_m=0.3,
+    )
+    assert result.decision == DECISION_FALLBACK_BRAKE
+    assert PRED_CLEARANCE_HARD in result.violated_predicates
+    assert result.risk_score == 1.0
+    assert result.min_clearance_m is not None and result.min_clearance_m < 0.25
+
+
+def test_fallback_ttc_below_hard_minimum() -> None:
+    """A pedestrian on a head-on collision course triggers the hard TTC predicate."""
+    n = 20
+    dt = 0.1
+    t = np.arange(n, dtype=float) * dt
+    # Robot at x=t*1.0 moving +x; ped at x=5.0-t*1.0 moving -x; closing at 2.0 m/s.
+    robot_pos = np.stack([t * 1.0, np.zeros(n)], axis=1)
+    robot_vel = np.tile([1.0, 0.0], (n, 1))
+    ped_pos = np.stack([5.0 - t * 1.0, np.zeros(n)], axis=1)
+    ped_vel = np.tile([-1.0, 0.0], (n, 1))
+    cfg = TrajectoryVerifierConfig(min_ttc_s=1.0, warn_ttc_s=1.5, min_clearance_m=0.05)
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=dt,
+        robot_radius_m=0.05,
+        pedestrian_radius_m=0.05,
+        config=cfg,
+    )
+    assert result.decision == DECISION_FALLBACK_BRAKE
+    assert PRED_TTC_HARD in result.violated_predicates
+    assert result.min_ttc_s is not None and result.min_ttc_s < 1.0
+
+
+def test_fallback_braking_infeasible() -> None:
+    """A pedestrian ahead within the stopping distance triggers braking-infeasible."""
+    n = 5
+    robot_pos = np.stack([np.linspace(0.0, 0.4, n), np.zeros(n)], axis=1)
+    robot_vel = np.tile([2.0, 0.0], (n, 1))  # 2 m/s; d_stop = 4/(2*2.5) = 0.8 m
+    ped_pos = np.array([[0.6, 0.0]])  # 0.2..0.6 m ahead, < 0.8 m stopping distance
+    ped_vel = np.array([[0.0, 0.0]])
+    cfg = TrajectoryVerifierConfig(
+        min_clearance_m=0.05, warn_clearance_m=0.1, min_ttc_s=0.1, warn_ttc_s=0.2
+    )
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.1,
+        pedestrian_radius_m=0.1,
+        config=cfg,
+    )
+    assert result.decision == DECISION_FALLBACK_BRAKE
+    assert PRED_BRAKING_INFEASIBLE in result.violated_predicates
+    assert result.braking_feasible is False
+
+
+def test_missing_pedestrian_velocity_warns_not_fabricated() -> None:
+    """Missing pedestrian velocities surface as a warn predicate, never a fabricated TTC."""
+    robot_pos, robot_vel, ped_pos, _ = _straight_trajectory(ped_offset=(2.0, 0.0))
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=None,
+        dt_s=0.1,
+        robot_radius_m=0.3,
+        pedestrian_radius_m=0.3,
+    )
+    assert result.decision == DECISION_WARN
+    assert PRED_STALE_OR_MISSING_STATE in result.violated_predicates
+    assert PRED_TTC_HARD not in result.violated_predicates
+    assert PRED_TTC_WARN not in result.violated_predicates
+    assert result.min_ttc_s is None
+    assert result.braking_feasible is None
+
+
+def test_missing_robot_velocity_warns_and_skips_braking() -> None:
+    """Missing robot velocity surfaces as warn and skips braking-feasibility evaluation."""
+    _, _, ped_pos, ped_vel = _straight_trajectory(ped_offset=(3.0, 0.0))
+    robot_pos = np.zeros((10, 2))
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=None,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.3,
+        pedestrian_radius_m=0.3,
+    )
+    assert result.decision == DECISION_WARN
+    assert PRED_STALE_OR_MISSING_STATE in result.violated_predicates
+    assert result.braking_feasible is None
+    assert result.min_ttc_s is None
+
+
+def test_oscillatory_trajectory_triggers_smoothness_warn() -> None:
+    """A trajectory with many large heading changes triggers the recovery-smoothness warn."""
+    n = 16
+    # Alternate heading by ~pi/2 each step above min speed; expect > 3 oscillations.
+    angles = np.array([(0.0 if i % 2 == 0 else np.pi / 2) for i in range(n)])
+    robot_vel = np.stack([np.cos(angles), np.sin(angles)], axis=1) * 0.5
+    robot_pos = np.cumsum(robot_vel * 0.1, axis=0)
+    ped_pos = np.array([[10.0, 10.0]])
+    ped_vel = np.array([[0.0, 0.0]])
+    cfg = TrajectoryVerifierConfig(max_heading_oscillation_count=3)
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.2,
+        pedestrian_radius_m=0.2,
+        config=cfg,
+    )
+    assert result.decision == DECISION_WARN
+    assert PRED_RECOVERY_SMOOTHNESS in result.violated_predicates
+    assert result.risk_score > 0.0
+
+
+def test_invalid_robot_positions_shape_raises() -> None:
+    """A robot_positions array that is not (T, 2) raises a clear ValueError."""
+    with pytest.raises(ValueError, match="robot_positions"):
+        verify_trajectory(
+            robot_positions=np.zeros((5, 3)),
+            robot_velocities=None,
+            pedestrian_positions=np.zeros((1, 2)),
+            pedestrian_velocities=None,
+            dt_s=0.1,
+            robot_radius_m=0.3,
+            pedestrian_radius_m=0.3,
+        )
+
+
+def test_invalid_pedestrian_positions_time_dim_raises() -> None:
+    """A pedestrian_positions time dim mismatch raises a clear ValueError."""
+    with pytest.raises(ValueError, match="pedestrian_positions"):
+        verify_trajectory(
+            robot_positions=np.zeros((5, 2)),
+            robot_velocities=None,
+            pedestrian_positions=np.zeros((3, 1, 2)),
+            pedestrian_velocities=None,
+            dt_s=0.1,
+            robot_radius_m=0.3,
+            pedestrian_radius_m=0.3,
+        )
+
+
+def test_invalid_robot_velocity_shape_raises() -> None:
+    """A robot_velocities shape mismatch raises a clear ValueError."""
+    with pytest.raises(ValueError, match="robot_velocities"):
+        verify_trajectory(
+            robot_positions=np.zeros((5, 2)),
+            robot_velocities=np.zeros((4, 2)),
+            pedestrian_positions=np.zeros((1, 2)),
+            pedestrian_velocities=None,
+            dt_s=0.1,
+            robot_radius_m=0.3,
+            pedestrian_radius_m=0.3,
+        )
+
+
+def test_invalid_pedestrian_velocity_shape_raises() -> None:
+    """A pedestrian_velocities shape mismatch raises a clear ValueError."""
+    with pytest.raises(ValueError, match="pedestrian_velocities"):
+        verify_trajectory(
+            robot_positions=np.zeros((5, 2)),
+            robot_velocities=np.zeros((5, 2)),
+            pedestrian_positions=np.zeros((5, 2)),
+            pedestrian_velocities=np.zeros((4, 2)),
+            dt_s=0.1,
+            robot_radius_m=0.3,
+            pedestrian_radius_m=0.3,
+        )
+
+
+def test_non_positive_dt_raises() -> None:
+    """A non-positive dt_s raises ValueError."""
+    robot_pos = np.zeros((3, 2))
+    ped_pos = np.tile([2.0, 0.0], (3, 1))
+    with pytest.raises(ValueError, match="dt_s"):
+        verify_trajectory(
+            robot_positions=robot_pos,
+            robot_velocities=None,
+            pedestrian_positions=ped_pos,
+            pedestrian_velocities=None,
+            dt_s=0.0,
+            robot_radius_m=0.3,
+            pedestrian_radius_m=0.3,
+        )
+
+
+def test_negative_radius_raises() -> None:
+    """A negative radius raises ValueError."""
+    robot_pos = np.zeros((3, 2))
+    ped_pos = np.tile([2.0, 0.0], (3, 1))
+    with pytest.raises(ValueError, match="robot_radius_m"):
+        verify_trajectory(
+            robot_positions=robot_pos,
+            robot_velocities=None,
+            pedestrian_positions=ped_pos,
+            pedestrian_velocities=None,
+            dt_s=0.1,
+            robot_radius_m=-0.1,
+            pedestrian_radius_m=0.3,
+        )
+
+
+def test_invalid_config_thresholds_raise() -> None:
+    """Invalid TrajectoryVerifierConfig thresholds raise ValueError."""
+    with pytest.raises(ValueError, match="warn_clearance_m"):
+        TrajectoryVerifierConfig(min_clearance_m=0.5, warn_clearance_m=0.3)
+    with pytest.raises(ValueError, match="warn_ttc_s"):
+        TrajectoryVerifierConfig(min_ttc_s=2.0, warn_ttc_s=1.0)
+    with pytest.raises(ValueError, match="max_brake_deceleration_mps2"):
+        TrajectoryVerifierConfig(max_brake_deceleration_mps2=0.0)
+
+
+def test_decision_precedence_fallback_over_warn() -> None:
+    """A trajectory that fires both hard and soft predicates reports fallback_brake."""
+    n = 5
+    robot_pos = np.tile([0.0, 0.0], (n, 1))
+    robot_vel = np.tile([0.0, 0.0], (n, 1))
+    ped_pos = np.array([[0.3, 0.0]])  # clearance -0.3 < hard minimum
+    ped_vel = np.array([[0.0, 0.0]])
+    # Also stale to ensure warn would fire if hard did not.
+    cfg = TrajectoryVerifierConfig(stale_prediction_max_age_s=0.1)
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.3,
+        pedestrian_radius_m=0.3,
+        config=cfg,
+        prediction_age_s=0.5,
+    )
+    assert result.decision == DECISION_FALLBACK_BRAKE
+    assert PRED_CLEARANCE_HARD in result.violated_predicates
+    assert PRED_STALE_OR_MISSING_STATE in result.violated_predicates
+    assert result.risk_score == 1.0
+
+
+def test_static_pedestrian_positions_broadcast() -> None:
+    """A static (N, 2) pedestrian array is broadcast across the robot time dim."""
+    n = 10
+    robot_pos = np.stack([np.linspace(0.0, 1.0, n), np.zeros(n)], axis=1)
+    robot_vel = np.tile([0.1, 0.0], (n, 1))
+    ped_pos_static = np.array([[5.0, 5.0]])  # shape (1, 2); broadcast to (n, 1, 2)
+    ped_vel = np.zeros((n, 1, 2))
+    result = verify_trajectory(
+        robot_positions=robot_pos,
+        robot_velocities=robot_vel,
+        pedestrian_positions=ped_pos_static,
+        pedestrian_velocities=ped_vel,
+        dt_s=0.1,
+        robot_radius_m=0.3,
+        pedestrian_radius_m=0.3,
+    )
+    assert result.decision == DECISION_ACCEPT
+    assert result.min_distance_m is not None and result.min_distance_m > 4.0
+
+
+def test_verify_episode_trace_window_accepts_and_windows() -> None:
+    """The opt-in trace-window helper slices and returns the same verifier contract."""
+    robot_pos, robot_vel, ped_pos, ped_vel = _straight_trajectory(
+        n_steps=20, ped_offset=(10.0, 0.0)
+    )
+    trace = {
+        "robot_positions": robot_pos,
+        "robot_velocities": robot_vel,
+        "pedestrian_positions": ped_pos,
+        "pedestrian_velocities": ped_vel,
+        "dt_s": 0.1,
+    }
+    result = verify_episode_trace_window(trace, start=0, end=10)
+    assert isinstance(result, VerifierResult)
+    assert result.decision == DECISION_ACCEPT
+
+
+def test_verify_episode_trace_window_missing_keys_raises() -> None:
+    """The trace helper raises ValueError when required keys are missing."""
+    with pytest.raises(ValueError, match="robot_positions"):
+        verify_episode_trace_window({"pedestrian_positions": np.zeros((1, 2))})
+
+
+def test_verify_episode_trace_window_empty_window_raises() -> None:
+    """The trace helper raises ValueError for an empty window."""
+    trace = {
+        "robot_positions": np.zeros((5, 2)),
+        "pedestrian_positions": np.zeros((5, 1, 2)),
+        "dt_s": 0.1,
+    }
+    with pytest.raises(ValueError, match="window"):
+        verify_episode_trace_window(trace, start=3, end=3)
+
+
+def test_schema_and_claim_boundary_constants() -> None:
+    """Schema and claim-boundary constants are stable and explicit."""
+    assert TRAJECTORY_VERIFIER_SCHEMA == "trajectory_verifier.v1"
+    assert "not a formal safety case" in TRAJECTORY_VERIFIER_CLAIM_BOUNDARY
+    assert "not learned" in TRAJECTORY_VERIFIER_CLAIM_BOUNDARY
+    assert "default planner behavior unchanged" in TRAJECTORY_VERIFIER_CLAIM_BOUNDARY


### PR DESCRIPTION
## What / Why

Implements issue #4757: a new opt-in, experimental trajectory verifier for AMMV planner outputs.

### New files

| File | Purpose |
|------|---------|
| `robot_sf/benchmark/trajectory_verifier.py` | Core verifier: 5 deterministic predicates, decision aggregation, risk score, `verify_episode_trace_window` opt-in helper |
| `tests/benchmark/test_trajectory_verifier.py` | 22 deterministic unit tests covering all required fixtures |
| `docs/context/issue_4757_trajectory_verifier.md` | Experimental-status context note with explicit claim boundary |
| `configs/benchmarks/trajectory_verifier_default.yaml` | Default threshold config |

### Predicates implemented

1. **Minimum footprint clearance** — fallback below hard threshold; warn below soft threshold
2. **TTC threshold** — constant-velocity closure proxy; missing velocities → warn (never fabricated TTC)
3. **Braking feasibility** — stopping-distance vs pedestrian clearance along heading
4. **Stale / missing state** — flags stale prediction age or absent velocity inputs
5. **Recovery smoothness / oscillation proxy** — counts large heading-angle changes

### Decision aggregation

`fallback_brake > warn > accept` — hard violations always escalate; soft violations produce warn; missing inputs fail closed to warn.

### Scope boundary

Experimental and opt-in only. Not wired into any planner control loop, runner, release gate, or benchmark scoring. Default planner behavior is unchanged.

### pyproject.toml change

Added `PLR0913` per-file-ignore for `robot_sf/benchmark/trajectory_verifier.py` — the `verify_trajectory` function requires 9 keyword-only arguments as specified by the issue API contract; reducing them would break the contract.

## Validation output

```
$ uv run ruff check robot_sf/benchmark/trajectory_verifier.py tests/benchmark/test_trajectory_verifier.py
All checks passed!

$ uv run pytest tests/benchmark/test_trajectory_verifier.py -q
......................                                         [100%]
22 passed in 0.97s
```

## Successor statement

This PR fully implements all acceptance criteria from issue #4757 in one slice. No further slices required.

Closes #4757

---

This PR was produced by the agy/Claude-Sonnet-4.6-Thinking cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental trajectory verification tool for AMMV planner outputs, with configurable safety and comfort thresholds.
  * Introduced offline trace-window verification for analyzing recorded episodes.
  * Published a new guide explaining the verifier’s behavior, checks, and usage.

* **Bug Fixes**
  * Added safeguards for missing or stale motion data.
  * Improved decision handling across clearance, collision-risk, braking, and oscillation checks.

* **Tests**
  * Added coverage for verifier decisions, threshold validation, input-shape errors, and trace-window slicing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->