### PR TITLE
Issue #4761: add social preference label annotation pipeline (cheap-lane worker)

### DIFF
--- a/docs/context/issue_4761_social_preference_labels.md
+++ b/docs/context/issue_4761_social_preference_labels.md
@@ -1,0 +1,78 @@
+# Issue #4761: Diagnostic Social Preference Labels
+
+**Issue:** <https://github.com/ll7/robot_sf_ll7/issues/4761>
+
+**Status:** Implemented
+
+**Source:** SPLC paper (Social Preference Learning for Crowd Robot Navigation, arXiv:2607.01925).
+This config does not implement SPLC and does not claim learned or validated social preferences.
+
+## What This Is
+
+A diagnostic label schema and annotation pipeline for post-run analysis of crowd-navigation
+episode traces. The labels capture social-compliance dimensions (clearance, TTC, oscillation,
+etc.) that are distinct from hard safety predicates and benchmark gates.
+
+## What This Is Not
+
+- **Not an RL reward.** These labels must not be used as planner rewards or training signals.
+- **Not a benchmark gate.** These labels do not affect pass/fail verdicts in benchmark campaigns.
+- **Not human preference data.** The threshold bands are placeholder defaults aligned to existing
+  safety contracts, not calibrated human preference evidence.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `configs/diagnostics/social_preference_labels.yaml` | Label schema with 7 social preference labels, threshold bands, and claim boundary |
+| `robot_sf/benchmark/social_preference_labels.py` | Config validation and ``annotate_episode_social_preferences`` annotation pipeline |
+| `scripts/analysis/annotate_social_preference_labels.py` | CLI to annotate episode JSONL files with labels |
+| `tests/benchmark/test_social_preference_labels_config.py` | Config contract tests (loaded from the original issue) |
+| `tests/benchmark/test_social_preference_labels.py` | Annotation pipeline, CLI, and summary tests |
+
+## Label Schema
+
+The v1 schema defines seven labels:
+
+| Label | Metric Family | Preferred Direction | Automation |
+| --- | --- | --- | --- |
+| ``clearance`` | safety_proxemics | maximize | threshold_band |
+| ``ttc_margin`` | safety_ttc | maximize | threshold_band |
+| ``pedestrian_displacement`` | pedestrian_impact | minimize | manual/proxy |
+| ``path_blocking`` | path_corridor_interaction | avoid | not_available |
+| ``oscillation`` | motion_quality | minimize | threshold_band |
+| ``detour_burden`` | path_efficiency | minimize | manual/proxy |
+| ``recovery_smoothness`` | post_conflict_motion_quality | minimize | threshold_band |
+
+Each label can be annotated as:
+
+- ``satisfied`` (good band) / ``violated`` (poor band) / ``caution`` when a threshold band matches
+- ``not_available`` when required trace fields or candidate metrics are missing
+- ``uncertain`` when no band matches definitively
+
+## Usage
+
+Annotate a single episode or batch of episodes from JSONL::
+
+    uv run python scripts/analysis/annotate_social_preference_labels.py \
+      --episodes-jsonl output/episodes.jsonl \
+      --schema configs/diagnostics/social_preference_labels.yaml \
+      --output-jsonl output/social_preference_annotations.jsonl \
+      --summary-json output/social_preference_summary.json
+
+## Hard Safety vs Preference Labels
+
+Hard safety predicates (e.g. ``min_clearance_m < 0`` for collision) are fail-closed contract
+checks used in benchmark rows and planner verification. Social preference labels are diagnostic
+dimensions that live at a higher level: they describe the quality of the robot's social behavior
+without determining pass or fail for the benchmark contract.
+
+See ``robot_sf/benchmark/safety_predicates.py`` for the hard safety predicate definitions and
+``robot_sf/benchmark/thresholds.py`` for the collision/near-miss distance contracts.
+
+## Follow-Up
+
+The path_blocking label is currently ``not_available`` because no canonical path-corridor occupancy
+metric exists. Pedestrian displacement and detour burden are manual/proxy labels that require
+scenario baseline comparisons. These would benefit from a trace export contract for pedestrian
+route estimates and conflict-window attribution.

--- a/robot_sf/benchmark/social_preference_labels.py
+++ b/robot_sf/benchmark/social_preference_labels.py
@@ -1,8 +1,16 @@
-"""Validation helpers for diagnostic social preference label configs."""
+"""Diagnostic social preference label config and annotation utilities.
+
+This module provides config validation via ``load_social_preference_label_config`` and an
+annotation entry point ``annotate_episode_social_preferences`` that applies threshold bands
+from the config to episode metric traces. The labels are diagnostic-only and must not be used
+as RL rewards or planner control signals.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import math
+import re
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +43,7 @@ REQUIRED_LABEL_FIELDS = frozenset(
         "notes",
     }
 )
+ANNOTATION_METHODS = frozenset({"threshold_band", "manual", "not_available"})
 
 
 class SocialPreferenceLabelConfigError(ValueError):
@@ -251,3 +260,523 @@ def _is_lowercase_snake_case(value: str) -> bool:
     return value[0].islower() and all(
         char.islower() or char.isdigit() or char == "_" for char in value
     )
+
+
+# ---------------------------------------------------------------------------
+# Threshold-band parsing helpers (private)
+# ---------------------------------------------------------------------------
+
+_THRESHOLDS_RE = re.compile(r"^(<|<=|>=|>|=)\s*([0-9eE.+\-]+)\s*[\-,]*(\s*[0-9eE.+\-]+)?")
+_BAND_RE = re.compile(r"(\[|\()?\s*([0-9eE.+\-]+)\s*,\s*([0-9eE.+\-]+)\s*([)\]])?")
+
+
+def _parse_threshold_band(value: Any) -> str | None:
+    """Return the band name whose range contains ``value``.
+
+    Supports simple band syntax used in the YAML config:
+    ``"< 0.0"``, ``"[0.0, 0.5)"``, ``">= 0.5"``.
+
+    Returns:
+        The band name (e.g. ``"poor"``, ``"caution"``, ``"acceptable"``) or
+        ``None`` when no band matches.
+    """
+    not_match: list[str] = []
+
+    for band_name, band_spec in value.items():
+        band_str = str(band_spec).strip()
+        matched = _match_band_spec(float(band_str))
+        if matched is not None:
+            return band_name
+        not_match.append(band_name + "=" + band_str)
+
+    return None
+
+
+def _match_band_spec(spec: str) -> float | None:
+    """Return the numeric value covered by a single band spec, or None."""
+    spec = spec.strip()
+
+    m = _THRESHOLDS_RE.match(spec)
+    if m:
+        op = m.group(1) or "<"
+        lo = float(m.group(2))
+        hi = float(m.group(3)) if m.group(3) else lo
+        return lo, op, hi  # type: ignore[return-value]
+    return None
+
+
+def _get_metric_value(episode: Mapping[str, Any], keys: Sequence[str]) -> float | None:
+    """Search ``episode["metrics"]`` for the first key whose dot-path resolves to a number.
+
+    Returns:
+        The numeric metric value or ``None`` if no key is found or the value is non-finite.
+    """
+
+    metrics = episode.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return None
+
+    for key in keys:
+        value = _resolve_dot_path(metrics, key)
+        if value is not None:
+            try:
+                numeric = float(value)
+                return numeric if _is_finite(numeric) else None
+            except (TypeError, ValueError):
+                continue
+
+    return None
+
+
+def _resolve_dot_path(root: Mapping[str, Any], dot_path: str) -> Any:
+    """Resolve a dotted metric key into a value.
+
+    Candidate keys in the YAML config may include a ``metrics.`` prefix even though
+    ``root`` is already the episode's ``metrics`` mapping. A leading ``metrics.`` segment
+    is stripped before resolution.
+
+    Returns:
+        The resolved Python object, or ``None`` if the path does not resolve.
+    """
+
+    parts = [p for p in dot_path.split(".") if p]
+    if parts and parts[0] == "metrics":
+        parts = parts[1:]
+    cur: Any = root
+    for part in parts:
+        if isinstance(cur, Mapping):
+            cur = cur.get(part)
+        else:
+            return None
+    return cur
+
+
+def _is_finite(value: float) -> bool:
+    return math.isfinite(value)
+
+
+def _has_metric_key_path(
+    episode: Mapping[str, Any],
+    key: str,
+) -> bool:
+    """Return True if the dot-path resolves to *any* present leaf (not None)."""
+
+    metrics = episode.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return False
+
+    found = _resolve_dot_path(metrics, key)
+    return found is not None
+
+
+# ---------------------------------------------------------------------------
+# Public annotation API
+# ---------------------------------------------------------------------------
+
+
+def get_episode_metric_names(episode: Mapping[str, Any]) -> set[str]:
+    """Return a set of all leaf key-paths available under the episode's ``metrics``.
+
+    Flattens nested dicts using dot-notation (e.g. ``social_acceptability.x``).
+    """
+
+    metrics = episode.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return set()
+
+    result: set[str] = set()
+    _flatten_dict(metrics, "", result)
+    return result
+
+
+def _flatten_dict(d: Mapping[str, Any], prefix: str, out: set[str]) -> None:
+    """Recursively add dot-notation leaf keys to ``out``."""
+
+    for key, value in d.items():
+        full = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, Mapping):
+            _flatten_dict(value, full, out)
+        elif value is not None:
+            out.add(full)
+
+
+def annotate_episode_social_preferences(
+    episode: Mapping[str, Any],
+    *,
+    schema: dict[str, Any] | None = None,
+    config_path: str | Path | None = None,
+    trace_fields: set[str] | None = None,
+) -> dict[str, Any]:
+    """Annotate a single episode record with diagnostic social preference labels.
+
+    Applies the threshold-band rules from the schema to the metrics embedded in
+    ``episode``. Labels whose required trace fields or candidate metric keys are
+    missing are marked ``"not_available"`` rather than silently defaulting.
+
+    The return value is safe to serialise as JSON and append to a ``.jsonl`` file.
+
+    Args:
+        episode: An episode record containing at least a ``"metrics"`` mapping.
+        schema: Pre-loaded, validated label schema (``dict``). Mutually exclusive
+            with ``config_path``; ``schema`` takes precedence.
+        config_path: Path to the YAML config when schema is not provided.
+        trace_fields: Optional set of trace-field names available in the episode.
+            If not provided, availability checks use the presence of candidate
+            metric keys in the episode's ``"metrics"`` mapping.
+
+    Returns:
+        A dictionary with ``schema_version``, ``claim_boundary``, ``episode_id``,
+        and a ``labels`` list describing each label's diagnostic annotation.
+    """
+
+    if schema is None:
+        if config_path is None:
+            raise ValueError("annotate_episode_social_preferences requires schema or config_path")
+        schema = load_social_preference_label_config(Path(config_path))
+
+    labels_cfg = schema["labels"]
+    schema_version = schema.get("schema_version", SOCIAL_PREFERENCE_LABEL_SCHEMA_VERSION)
+    claim_boundary = schema.get("claim_boundary", "")
+    source_metrics_present = get_episode_metric_names(episode)
+    trace_fields = set(trace_fields) if trace_fields else None
+
+    annotations: list[dict[str, Any]] = []
+
+    for label in labels_cfg:
+        annotation = _annotate_one_label(
+            label,
+            episode,
+            trace_fields=trace_fields,
+            source_metrics=source_metrics_present,
+        )
+        annotations.append(annotation)
+
+    episode_id = (
+        episode.get("episode_id")
+        or episode.get("seed")
+        or episode.get("scenario_seed")
+        or "unknown"
+    )
+    return {
+        "schema_version": schema_version,
+        "claim_boundary": claim_boundary,
+        "episode_id": episode_id,
+        "labels": annotations,
+    }
+
+
+def _annotate_one_label(
+    label: Mapping[str, Any],
+    episode: Mapping[str, Any],
+    *,
+    trace_fields: set[str] | None,
+    source_metrics: set[str],
+) -> dict[str, Any]:
+    """Annotate a single label for a single episode.
+
+    Returns:
+        A dictionary with label_id, display_name, metric_family, value, annotation,
+        method, reason, evidence, and unit.
+    """
+
+    label_id = str(label["id"])
+    display_name = str(label.get("display_name", label_id))
+    metric_family = str(label.get("metric_family", "unknown"))
+    unit = str(label.get("unit", ""))
+    computation_status = str(label.get("computation_status", ""))
+
+    # Check structural availability first
+    if trace_fields is not None:
+        avail = label_availability(label, trace_fields)
+        if avail == "not_available":
+            return {
+                "label_id": label_id,
+                "display_name": display_name,
+                "metric_family": metric_family,
+                "value": None,
+                "annotation": "not_available",
+                "method": "not_available",
+                "reason": "required trace fields missing",
+                "evidence": {},
+                "unit": unit,
+            }
+
+    candidate_keys = label.get("candidate_metric_keys")
+    if not isinstance(candidate_keys, list) or not candidate_keys:
+        return {
+            "label_id": label_id,
+            "display_name": display_name,
+            "metric_family": metric_family,
+            "value": None,
+            "annotation": "not_available",
+            "method": "not_available",
+            "reason": "no candidate metric keys",
+            "evidence": {},
+            "unit": unit,
+        }
+
+    # Try to find a metric value
+    metric_value = _get_metric_value(episode, candidate_keys)
+    matched_key: str | None = None
+    if metric_value is not None:
+        for k in candidate_keys:
+            if _has_metric_key_path(episode, k):
+                matched_key = k
+                break
+
+    if metric_value is None:
+        return {
+            "label_id": label_id,
+            "display_name": display_name,
+            "metric_family": metric_family,
+            "value": None,
+            "annotation": "not_available",
+            "method": "not_available",
+            "reason": f"none of candidate keys present: {candidate_keys}",
+            "evidence": {
+                "candidate_keys_checked": candidate_keys,
+            },
+            "unit": unit,
+        }
+
+    # Apply threshold bands
+    thresholds = label.get("diagnostic_thresholds", {})
+    bands: dict[str, str] = thresholds.get("bands", {})
+    band_result = _classify_value_to_band(metric_value, bands)
+
+    return {
+        "label_id": label_id,
+        "display_name": display_name,
+        "metric_family": metric_family,
+        "value": metric_value,
+        "annotation": band_result,
+        "method": "threshold_band",
+        "reason": f"threshold band {band_result}",
+        "evidence": {
+            "metric_key": matched_key,
+            "metric_value": metric_value,
+            "threshold_bands": bands,
+            "computation_status": computation_status,
+        },
+        "unit": unit,
+    }
+
+
+def _classify_value_to_band(raw_value: float, bands: dict[str, str]) -> str:
+    """Classify a metric value into a band name using the YAML threshold bands.
+
+    Falls back to ``"uncertain"`` when no band matches or the bands dictionary is empty.
+
+    Returns:
+        The band name string (e.g. ``"acceptable"``, ``"poor"``, ``"caution"``, ``"uncertain"``).
+    """
+
+    if not bands:
+        return "uncertain"
+
+    matched_band = _match_value_to_band_spec(raw_value, bands)
+    if matched_band is not None:
+        return matched_band
+
+    # Fallback: try numeric sorting to find nearest band
+    return _fallback_band_classification(raw_value, bands)
+
+
+def _match_value_to_band_spec(value: float, bands: dict[str, str]) -> str | None:
+    """Try each band spec; return the first band name that contains ``value``.
+
+    Returns:
+        The band name or ``None`` if no band matches.
+    """
+
+    for band_name, spec in bands.items():
+        spec_str = str(spec).strip()
+        if _value_in_band_spec(value, spec_str):
+            return band_name
+    return None
+
+
+def _value_in_band_spec(value: float, spec: str) -> bool:
+    """Return True if ``value`` falls in the range described by ``spec``."""
+
+    spec = spec.strip()
+
+    # Simple comparisons: "< 0.0", "<= 0.0", ">= 0.5", "> 1.0"
+    m = _THRESHOLDS_RE.match(spec)
+    if m:
+        op = m.group(1) or "<"
+        threshold = float(m.group(2))
+        return _apply_op(value, op, threshold)
+
+    # Interval: "[0.0, 0.5)", "(0.0, 1.0]", "(0.0, 1.0)", "[0.0, 0.5]"
+    im = _BAND_RE.match(spec)
+    if im:
+        lo_bracket = im.group(1) or "["
+        lo = float(im.group(2))
+        hi = float(im.group(3))
+        hi_bracket = im.group(4) or "]"
+
+        lo_ok = value > lo if lo_bracket == "(" else value >= lo
+        hi_ok = value < hi if hi_bracket == ")" else value <= hi
+        return lo_ok and hi_ok
+
+    return False
+
+
+def _apply_op(value: float, op: str, threshold: float) -> bool:
+    """Evaluate a comparison operator.
+
+    Returns:
+        ``True`` if the operator holds for ``value`` and ``threshold``.
+    """
+
+    if op == "<":
+        return value < threshold
+    if op == "<=":
+        return value <= threshold
+    if op == ">=":
+        return value >= threshold
+    if op == ">":
+        return value > threshold
+    if op == "=":
+        return value == threshold
+    return False
+
+
+def _fallback_band_classification(value: float, bands: dict[str, str]) -> str:
+    """Heuristic fallback when the YAML bands use prose instead of numeric ranges.
+
+    Returns:
+        The best-guess band name string.
+    """
+
+    # Extract numeric thresholds and their band names to sort them
+    numeric_bands: list[tuple[float, str]] = []
+    for band_name, spec in bands.items():
+        spec_str = str(spec).strip()
+        extracted = _extract_threshold_number(spec_str)
+        if extracted is not None:
+            numeric_bands.append((extracted, band_name))
+
+    if not numeric_bands:
+        return "uncertain"
+
+    numeric_bands.sort()
+    threshold, band_name = numeric_bands[-1]
+    if value >= threshold:
+        return band_name
+
+    # Otherwise, find the highest band where value >= threshold
+    for threshold, band_name in numeric_bands:
+        if value >= threshold:
+            return band_name
+
+    # Below all thresholds — use the lowest band
+    return numeric_bands[0][1]
+
+
+def _extract_threshold_number(spec: str) -> float | None:
+    """Extract a leading numeric threshold from a band spec string.
+
+    Returns:
+        The extracted float or ``None`` if not parseable.
+    """
+
+    spec = spec.replace("[", "").replace("(", "").replace("]", "").replace(")", "").strip()
+    parts = spec.split(",")
+    for part in parts:
+        part = part.strip()
+        part = part.lstrip("<>=").strip()
+        try:
+            return float(part)
+        except (ValueError, TypeError):
+            continue
+    return None
+
+
+def annotate_episodes_social_preferences(
+    episodes: Sequence[Mapping[str, Any]],
+    *,
+    schema: dict[str, Any] | None = None,
+    config_path: str | Path | None = None,
+    trace_fields: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Annotate a sequence of episode records with social preference labels.
+
+    Returns:
+        A list of annotation dicts, one per episode.
+    """
+
+    return [
+        annotate_episode_social_preferences(
+            ep, schema=schema, config_path=config_path, trace_fields=trace_fields
+        )
+        for ep in episodes
+    ]
+
+
+def build_label_summary(annotations: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Build a summary of social preference label results across a batch of annotations.
+
+    Counts label annotation values and ``not_available`` reasons per label.
+
+    Returns:
+        A dictionary with schema_version, claim_boundary, total_episodes, per-label
+        annotation counts, and not_available_reasons.
+    """
+
+    schema_version = ""
+    claim_boundary = ""
+    label_counts: dict[str, dict[str, int]] = {}
+    not_available_reasons: dict[str, dict[str, int]] = {}
+
+    for annotation in annotations:
+        schema_version = annotation.get("schema_version", schema_version) or schema_version
+        claim_boundary = annotation.get("claim_boundary", claim_boundary) or claim_boundary
+
+        for label_result in annotation.get("labels", []):
+            label_id = label_result.get("label_id", "unknown")
+            annotation_value = label_result.get("annotation", "unknown")
+
+            if label_id not in label_counts:
+                label_counts[label_id] = {}
+
+            label_counts[label_id][annotation_value] = (
+                label_counts[label_id].get(annotation_value, 0) + 1
+            )
+
+            if annotation_value == "not_available":
+                if label_id not in not_available_reasons:
+                    not_available_reasons[label_id] = {}
+                reason = label_result.get("reason", "unknown")
+                not_available_reasons[label_id][reason] = (
+                    not_available_reasons[label_id].get(reason, 0) + 1
+                )
+
+    total_episodes = len(annotations)
+    summary = {
+        "schema_version": schema_version,
+        "claim_boundary": claim_boundary,
+        "total_episodes": total_episodes,
+        "labels": {},
+        "not_available_reasons": not_available_reasons,
+    }
+
+    for label_id, counts in sorted(label_counts.items()):
+        label_summary = {
+            "count": sums(counts) if counts else 0,
+            "annotation_counts": dict(sorted(counts.items())),
+        }
+        summary["labels"][label_id] = label_summary
+
+    return summary
+
+
+def sums(d: dict[str, int]) -> int:
+    """Sums the values in a dictionary of counts.
+
+    Returns:
+        The total count across all keys.
+    """
+
+    return sum(d.values())

--- a/robot_sf/benchmark/social_preference_labels.py
+++ b/robot_sf/benchmark/social_preference_labels.py
@@ -270,27 +270,34 @@ _THRESHOLDS_RE = re.compile(r"^(<|<=|>=|>|=)\s*([0-9eE.+\-]+)\s*[\-,]*(\s*[0-9eE
 _BAND_RE = re.compile(r"(\[|\()?\s*([0-9eE.+\-]+)\s*,\s*([0-9eE.+\-]+)\s*([)\]])?")
 
 
-def _get_metric_value(episode: Mapping[str, Any], keys: Sequence[str]) -> float | None:
+def _get_metric_value(
+    episode: Mapping[str, Any], keys: Sequence[str]
+) -> tuple[str | None, float | None]:
     """Search ``episode["metrics"]`` for the first key whose dot-path resolves to a number.
 
+    Non-finite values (NaN, Inf) and non-numeric leaves are skipped so that a
+    later candidate key can still supply a usable value.
+
     Returns:
-        The numeric metric value or ``None`` if no key is found or the value is non-finite.
+        A ``(matched_key, numeric_value)`` tuple, or ``(None, None)`` if no
+        candidate key resolves to a finite number.
     """
 
     metrics = episode.get("metrics")
     if not isinstance(metrics, Mapping):
-        return None
+        return None, None
 
     for key in keys:
         value = _resolve_dot_path(metrics, key)
         if value is not None:
             try:
                 numeric = float(value)
-                return numeric if _is_finite(numeric) else None
             except (TypeError, ValueError):
                 continue
+            if _is_finite(numeric):
+                return key, numeric
 
-    return None
+    return None, None
 
 
 def _resolve_dot_path(root: Mapping[str, Any], dot_path: str) -> Any:
@@ -318,20 +325,6 @@ def _resolve_dot_path(root: Mapping[str, Any], dot_path: str) -> Any:
 
 def _is_finite(value: float) -> bool:
     return math.isfinite(value)
-
-
-def _has_metric_key_path(
-    episode: Mapping[str, Any],
-    key: str,
-) -> bool:
-    """Return True if the dot-path resolves to *any* present leaf (not None)."""
-
-    metrics = episode.get("metrics")
-    if not isinstance(metrics, Mapping):
-        return False
-
-    found = _resolve_dot_path(metrics, key)
-    return found is not None
 
 
 # ---------------------------------------------------------------------------
@@ -480,14 +473,8 @@ def _annotate_one_label(
             "unit": unit,
         }
 
-    # Try to find a metric value
-    metric_value = _get_metric_value(episode, candidate_keys)
-    matched_key: str | None = None
-    if metric_value is not None:
-        for k in candidate_keys:
-            if _has_metric_key_path(episode, k):
-                matched_key = k
-                break
+    # Try to find a metric value; matched_key is the key that produced it.
+    matched_key, metric_value = _get_metric_value(episode, candidate_keys)
 
     if metric_value is None:
         return {
@@ -627,12 +614,9 @@ def _fallback_band_classification(value: float, bands: dict[str, str]) -> str:
         return "uncertain"
 
     numeric_bands.sort()
-    threshold, band_name = numeric_bands[-1]
-    if value >= threshold:
-        return band_name
 
-    # Otherwise, find the highest band where value >= threshold
-    for threshold, band_name in numeric_bands:
+    # Find the highest band whose threshold the value still meets.
+    for threshold, band_name in reversed(numeric_bands):
         if value >= threshold:
             return band_name
 

--- a/robot_sf/benchmark/social_preference_labels.py
+++ b/robot_sf/benchmark/social_preference_labels.py
@@ -270,41 +270,6 @@ _THRESHOLDS_RE = re.compile(r"^(<|<=|>=|>|=)\s*([0-9eE.+\-]+)\s*[\-,]*(\s*[0-9eE
 _BAND_RE = re.compile(r"(\[|\()?\s*([0-9eE.+\-]+)\s*,\s*([0-9eE.+\-]+)\s*([)\]])?")
 
 
-def _parse_threshold_band(value: Any) -> str | None:
-    """Return the band name whose range contains ``value``.
-
-    Supports simple band syntax used in the YAML config:
-    ``"< 0.0"``, ``"[0.0, 0.5)"``, ``">= 0.5"``.
-
-    Returns:
-        The band name (e.g. ``"poor"``, ``"caution"``, ``"acceptable"``) or
-        ``None`` when no band matches.
-    """
-    not_match: list[str] = []
-
-    for band_name, band_spec in value.items():
-        band_str = str(band_spec).strip()
-        matched = _match_band_spec(float(band_str))
-        if matched is not None:
-            return band_name
-        not_match.append(band_name + "=" + band_str)
-
-    return None
-
-
-def _match_band_spec(spec: str) -> float | None:
-    """Return the numeric value covered by a single band spec, or None."""
-    spec = spec.strip()
-
-    m = _THRESHOLDS_RE.match(spec)
-    if m:
-        op = m.group(1) or "<"
-        lo = float(m.group(2))
-        hi = float(m.group(3)) if m.group(3) else lo
-        return lo, op, hi  # type: ignore[return-value]
-    return None
-
-
 def _get_metric_value(episode: Mapping[str, Any], keys: Sequence[str]) -> float | None:
     """Search ``episode["metrics"]`` for the first key whose dot-path resolves to a number.
 
@@ -764,7 +729,7 @@ def build_label_summary(annotations: Sequence[dict[str, Any]]) -> dict[str, Any]
 
     for label_id, counts in sorted(label_counts.items()):
         label_summary = {
-            "count": sums(counts) if counts else 0,
+            "count": _sum_counts(counts) if counts else 0,
             "annotation_counts": dict(sorted(counts.items())),
         }
         summary["labels"][label_id] = label_summary
@@ -772,8 +737,8 @@ def build_label_summary(annotations: Sequence[dict[str, Any]]) -> dict[str, Any]
     return summary
 
 
-def sums(d: dict[str, int]) -> int:
-    """Sums the values in a dictionary of counts.
+def _sum_counts(d: dict[str, int]) -> int:
+    """Sum the values in a dictionary of counts.
 
     Returns:
         The total count across all keys.

--- a/scripts/analysis/annotate_social_preference_labels.py
+++ b/scripts/analysis/annotate_social_preference_labels.py
@@ -1,0 +1,136 @@
+"""CLI: annotate episode JSONL files with diagnostic social preference labels.
+
+Reads episode records from a JSONL file (or stdin), applies threshold-band rules
+from the social preference label config, and writes annotated results to an output
+JSONL file plus a compact summary JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.social_preference_labels import (
+    annotate_episodes_social_preferences,
+    build_label_summary,
+    load_social_preference_label_config,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Annotate episode JSONL with diagnostic social preference labels."
+    )
+    parser.add_argument(
+        "--episodes-jsonl",
+        type=str,
+        default="-",
+        help="Path to episode JSONL file (default: stdin).",
+    )
+    parser.add_argument(
+        "--schema",
+        type=str,
+        default=None,
+        help="Path to social preference label YAML config.",
+    )
+    parser.add_argument(
+        "--trace-fields",
+        type=str,
+        nargs="*",
+        default=None,
+        help="Explicit trace-field names for availability checks.",
+    )
+    parser.add_argument(
+        "--output-jsonl",
+        type=str,
+        default=None,
+        help="Path to write annotation JSONL (default: stdout).",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=str,
+        default=None,
+        help="Path to write annotation JSONL (default: stdout).",
+    )
+    parser.add_argument(
+        "--summary-json",
+        type=str,
+        default=None,
+        help="Path to write summary JSON with label counts and reasons.",
+    )
+    return parser.parse_args(argv)
+
+
+def _read_episodes(path: str) -> list[dict[str, Any]]:
+    """Read episode records from a JSONL file or stdin."""
+
+    episodes: list[dict[str, Any]] = []
+    source = sys.stdin if path == "-" else open(path, encoding="utf-8")
+    with source as fh:
+        for line_num, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                episodes.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                print(
+                    f"Warning: skipping malformed JSONL line {line_num}: {exc}",
+                    file=sys.stderr,
+                )
+    return episodes
+
+
+def main() -> None:
+    """Entry point for the social preference label annotation CLI."""
+    args = _parse_args()
+
+    if args.schema is None:
+        print("Error: --schema is required.", file=sys.stderr)
+        sys.exit(1)
+
+    schema = load_social_preference_label_config(Path(args.schema))
+
+    episodes = _read_episodes(args.episodes_jsonl)
+    if not episodes:
+        print("Warning: no episodes to annotate.", file=sys.stderr)
+
+    trace_fields = set(args.trace_fields) if args.trace_fields else None
+
+    annotations = annotate_episodes_social_preferences(
+        episodes,
+        schema=schema,
+        trace_fields=trace_fields,
+    )
+
+    output_jsonl = args.output_jsonl
+    output_json = args.output_json
+    summary_json = args.summary_json
+    summary = build_label_summary(annotations)
+
+    # Write annotation JSONL
+    if output_jsonl and output_jsonl != "-":
+        with open(output_jsonl, "w", encoding="utf-8") as fh:
+            for ann in annotations:
+                fh.write(json.dumps(ann, sort_keys=True) + "\n")
+    elif output_json and output_json != "-":
+        with open(output_json, "w", encoding="utf-8") as fh:
+            for ann in annotations:
+                fh.write(json.dumps(ann, sort_keys=True) + "\n")
+    else:
+        for ann in annotations:
+            print(json.dumps(ann, sort_keys=True))
+
+    # Write summary JSON
+    if summary_json:
+        with open(summary_json, "w", encoding="utf-8") as fh:
+            json.dump(summary, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        print(f"Summary written to {summary_json}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark/test_social_preference_labels.py
+++ b/tests/benchmark/test_social_preference_labels.py
@@ -342,3 +342,36 @@ class TestNestedMetricLookup:
 
         assert clearance_annotation["annotation"] == "acceptable"
         assert clearance_annotation["value"] == 0.7
+
+
+class TestCandidateKeyResolution:
+    """Regression tests for metric-key selection (PR #4774 gate hardening)."""
+
+    def test_non_finite_first_candidate_falls_through(self, schema: dict) -> None:
+        """A NaN in the first candidate key must not shadow a later finite candidate.
+
+        ``min_clearance`` (first candidate) is non-finite, so annotation should
+        fall through to ``mean_clearance`` rather than reporting not_available.
+        """
+
+        episode = _make_episode({"min_clearance": float("nan"), "mean_clearance": 1.1})
+        result = annotate_episode_social_preferences(episode, schema=schema)
+        clearance = next(a for a in result["labels"] if a["label_id"] == "clearance")
+
+        assert clearance["annotation"] != "not_available"
+        assert clearance["value"] == 1.1
+        assert clearance["evidence"]["metric_key"] == "mean_clearance"
+
+    def test_matched_key_is_the_value_producing_key(self, schema: dict) -> None:
+        """evidence.metric_key must be the key that produced the numeric value.
+
+        A present-but-non-numeric first candidate must not be reported as the
+        matched key when a later candidate supplies the value.
+        """
+
+        episode = _make_episode({"min_clearance": "not-a-number", "mean_clearance": 0.9})
+        result = annotate_episode_social_preferences(episode, schema=schema)
+        clearance = next(a for a in result["labels"] if a["label_id"] == "clearance")
+
+        assert clearance["value"] == 0.9
+        assert clearance["evidence"]["metric_key"] == "mean_clearance"

--- a/tests/benchmark/test_social_preference_labels.py
+++ b/tests/benchmark/test_social_preference_labels.py
@@ -1,0 +1,344 @@
+"""Tests for the social preference label annotation pipeline.
+
+Covers the ``annotate_episode_social_preferences`` function, threshold-band
+classification, CLI smoke paths, and summary building.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.social_preference_labels import (
+    annotate_episode_social_preferences,
+    annotate_episodes_social_preferences,
+    build_label_summary,
+    get_episode_metric_names,
+    load_social_preference_label_config,
+)
+
+CONFIG_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "diagnostics"
+    / "social_preference_labels.yaml"
+)
+
+
+@pytest.fixture
+def schema() -> dict:
+    """Load the checked-in social preference label schema."""
+
+    return load_social_preference_label_config(CONFIG_PATH)
+
+
+def _make_episode(metrics: dict) -> dict:
+    """Build a minimal episode record with the given metrics dict."""
+
+    return {"episode_id": "test-ep", "metrics": metrics}
+
+
+class TestAnnotateEpisodeClearanceMargin:
+    """The clearance label is the first fully automated label."""
+
+    def test_clearance_satisfied_when_high(self, schema: dict) -> None:
+        """A clearance value well above the acceptable band is satisfied."""
+
+        episode = _make_episode({"min_clearance": 1.2})
+        result = annotate_episode_social_preferences(episode, schema=schema)
+        clearance_annotation = next(a for a in result["labels"] if a["label_id"] == "clearance")
+
+        assert clearance_annotation["annotation"] == "acceptable"
+        assert clearance_annotation["method"] == "threshold_band"
+        assert clearance_annotation["value"] == 1.2
+
+    def test_clearance_violated_when_negative(self, schema: dict) -> None:
+        """A negative clearance (collision) is violated."""
+
+        episode = _make_episode({"min_clearance": -0.05})
+        result = annotate_episode_social_preferences(episode, schema=schema)
+        clearance_annotation = next(a for a in result["labels"] if a["label_id"] == "clearance")
+
+        assert clearance_annotation["annotation"] == "poor"
+        assert clearance_annotation["method"] == "threshold_band"
+
+    def test_clearance_not_available_when_metric_missing(self, schema: dict) -> None:
+        """Missing clearance metrics produce not_available."""
+
+        episode = _make_episode({"other_metric": 0.5})
+        result = annotate_episode_social_preferences(episode, schema=schema)
+        clearance_annotation = next(a for a in result["labels"] if a["label_id"] == "clearance")
+
+        assert clearance_annotation["annotation"] == "not_available"
+        assert clearance_annotation["method"] == "not_available"
+
+
+class TestAnnotateEpisodeTtcMargin:
+    """TTC margin is automated when the metric is present."""
+
+    def test_ttc_margin_violated_when_low(self, schema: dict) -> None:
+        """A low TTC value is classified as poor."""
+
+        episode = _make_episode({"near_misses_ttc": 0.3})
+        result = annotate_episode_social_preferences(episode, schema=schema)
+        ttc_annotation = next(a for a in result["labels"] if a["label_id"] == "ttc_margin")
+
+        assert ttc_annotation["annotation"] == "poor"
+
+    def test_ttc_margin_not_available_when_metric_missing(self, schema: dict) -> None:
+        """Missing TTC metrics produce not_available."""
+
+        episode = _make_episode({"min_clearance": 0.8})
+        result = annotate_episode_social_preferences(episode, schema=schema)
+        ttc_annotation = next(a for a in result["labels"] if a["label_id"] == "ttc_margin")
+
+        assert ttc_annotation["annotation"] == "not_available"
+
+
+class TestAnnotateEpisodePathBlocking:
+    """Path blocking is not_available by design (no candidate metric keys)."""
+
+    def test_path_blocking_always_not_available(self, schema: dict) -> None:
+        """The path_blocking label has empty candidate_metric_keys, so it is always unavailable."""
+
+        episode = _make_episode({"min_clearance": 0.8, "jerk_mean": 0.1})
+        result = annotate_episode_social_preferences(episode, schema=schema)
+        pb_annotation = next(a for a in result["labels"] if a["label_id"] == "path_blocking")
+
+        assert pb_annotation["annotation"] == "not_available"
+        assert pb_annotation["method"] == "not_available"
+
+
+class TestAnnotationOutputStructure:
+    """Ensure the annotation dict has the correct shape."""
+
+    def test_output_includes_schema_version_and_claim_boundary(self, schema: dict) -> None:
+        """The annotation output echoes schema version and claim boundary."""
+
+        episode = _make_episode({"min_clearance": 0.8})
+        result = annotate_episode_social_preferences(episode, schema=schema)
+
+        assert result["schema_version"] == "social-preference-labels.v1"
+        assert "diagnostic" in result["claim_boundary"].lower()
+        assert "not a reward" in result["claim_boundary"].lower()
+        assert "label" in result["episode_id"] or isinstance(result["episode_id"], str)
+
+    def test_output_includes_all_labels(self, schema: dict) -> None:
+        """Every label from the schema appears in the annotation."""
+
+        episode = _make_episode({"min_clearance": 0.8})
+        result = annotate_episode_social_preferences(episode, schema=schema)
+        annotation_ids = {a["label_id"] for a in result["labels"]}
+
+        config_label_ids = {label_entry["id"] for label_entry in schema["labels"]}
+        assert annotation_ids == config_label_ids
+
+    def test_each_annotation_has_required_fields(self, schema: dict) -> None:
+        """Each annotation object carries the expected keys."""
+
+        episode = _make_episode({"min_clearance": 0.8})
+        result = annotate_episode_social_preferences(episode, schema=schema)
+
+        required_keys = {
+            "label_id",
+            "display_name",
+            "metric_family",
+            "value",
+            "annotation",
+            "method",
+            "reason",
+            "evidence",
+            "unit",
+        }
+        for annotation in result["labels"]:
+            assert required_keys.issubset(annotation.keys()), (
+                f"annotation {annotation.get('label_id', '?')} missing keys: "
+                f"{required_keys - annotation.keys()}"
+            )
+
+
+class TestAnnotateMultipleEpisodes:
+    """Batch annotation and summary generation."""
+
+    def test_batch_annotations(self, schema: dict) -> None:
+        """annotate_episodes_social_preferences returns one result per episode."""
+
+        episodes = [
+            _make_episode({"min_clearance": 1.2}),
+            _make_episode({"min_clearance": -0.05}),
+            _make_episode({"jerk_mean": 0.1}),
+        ]
+        results = annotate_episodes_social_preferences(episodes, schema=schema)
+
+        assert len(results) == 3
+        assert results[0]["labels"] is not None
+
+    def test_build_label_summary_counts(self, schema: dict) -> None:
+        """build_label_summary rolls up annotation counts per label."""
+
+        episodes = [
+            _make_episode({"min_clearance": 1.2, "jerk_mean": 0.05}),
+            _make_episode({"min_clearance": -0.05, "jerk_mean": 0.3}),
+            _make_episode({"min_clearance": 0.3}),
+        ]
+        results = annotate_episodes_social_preferences(episodes, schema=schema)
+        summary = build_label_summary(results)
+
+        assert summary["total_episodes"] == 3
+        assert "clearance" in summary["labels"]
+        assert "not_available_reasons" in summary
+
+
+class TestTraceFieldAvailability:
+    """Trace-field-based availability filters override metric presence."""
+
+    def test_trace_fields_filter_clearance(self, schema: dict) -> None:
+        """When required trace fields are missing, label is unavailable even with metrics."""
+
+        episode = _make_episode({"min_clearance": 0.8})
+        result = annotate_episode_social_preferences(
+            episode,
+            schema=schema,
+            trace_fields={"robot_trajectory"},
+        )
+        clearance_annotation = next(a for a in result["labels"] if a["label_id"] == "clearance")
+
+        assert clearance_annotation["annotation"] == "not_available"
+
+    def test_trace_fields_allow_clearance(self, schema: dict) -> None:
+        """When all required trace fields are present, label uses metric value."""
+
+        episode = _make_episode({"min_clearance": 0.8})
+        result = annotate_episode_social_preferences(
+            episode,
+            schema=schema,
+            trace_fields={
+                "robot_trajectory",
+                "pedestrian_trajectories",
+                "metric_parameters.threshold_profile",
+            },
+        )
+        clearance_annotation = next(a for a in result["labels"] if a["label_id"] == "clearance")
+
+        assert clearance_annotation["annotation"] == "acceptable"
+
+
+class TestGetEpisodeMetricNames:
+    """Metric name flattening for diagnostic tracing."""
+
+    def test_flattens_nested_metrics(self) -> None:
+        """Nested dicts produce dot-notation keys."""
+
+        episode = {
+            "metrics": {
+                "min_clearance": 0.5,
+                "social_acceptability": {
+                    "social_proxemic_min_clearance_m": 0.6,
+                },
+            }
+        }
+        names = get_episode_metric_names(episode)
+
+        assert "min_clearance" in names
+        assert "social_acceptability.social_proxemic_min_clearance_m" in names
+
+    def test_empty_metrics(self) -> None:
+        """Missing metrics returns empty set."""
+
+        episode = {"episode_id": "x"}
+        names = get_episode_metric_names(episode)
+        assert names == set()
+
+
+class TestCliSmoke:
+    """Smoke tests for the CLI script."""
+
+    def test_annotate_cli_help(self) -> None:
+        """The CLI --help flag succeeds."""
+
+        import subprocess
+
+        result = subprocess.run(
+            ["python", "-m", "scripts.analysis.annotate_social_preference_labels", "--help"],
+            capture_output=True,
+            check=False,
+            text=True,
+            cwd=str(Path(__file__).resolve().parents[2]),
+        )
+        assert result.returncode == 0
+        assert "social preference" in result.stdout.lower() or "social" in result.stdout.lower()
+
+    def test_annotate_cli_writes_output(self, schema: dict) -> None:
+        """The CLI reads JSONL stdin, writes annotated JSONL and summary."""
+
+        episode = _make_episode({"min_clearance": 0.8})
+
+        with (
+            tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as ep_file,
+            tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as out_file,
+            tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as summary_file,
+        ):
+            ep_file.write(json.dumps(episode) + "\n")
+            ep_file.flush()
+
+            import subprocess
+
+            result = subprocess.run(
+                [
+                    "python",
+                    str(
+                        Path(__file__).resolve().parents[2]
+                        / "scripts"
+                        / "analysis"
+                        / "annotate_social_preference_labels.py"
+                    ),
+                    "--episodes-jsonl",
+                    ep_file.name,
+                    "--schema",
+                    str(CONFIG_PATH),
+                    "--output-jsonl",
+                    out_file.name,
+                    "--summary-json",
+                    summary_file.name,
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            assert result.returncode == 0, f"CLI failed: {result.stderr}"
+
+            with open(out_file.name) as f:
+                output_lines = f.read().strip().split("\n")
+                assert len(output_lines) == 1
+                output = json.loads(output_lines[0])
+                assert output["schema_version"] == "social-preference-labels.v1"
+                clearance_label = next(a for a in output["labels"] if a["label_id"] == "clearance")
+                assert clearance_label["annotation"] == "acceptable"
+
+            with open(summary_file.name) as f:
+                summary = json.load(f)
+                assert summary["total_episodes"] == 1
+                assert "clearance" in summary["labels"]
+
+
+class TestNestedMetricLookup:
+    """The candidate metric key ``metrics.social_acceptability.x`` is resolved correctly."""
+
+    def test_nested_dot_path_cleared(self, schema: dict) -> None:
+        """A nested social_proxemic_min_clearance_m metric is found by the annotation."""
+
+        episode = _make_episode(
+            {
+                "social_acceptability": {
+                    "social_proxemic_min_clearance_m": 0.7,
+                }
+            }
+        )
+        result = annotate_episode_social_preferences(episode, schema=schema)
+        clearance_annotation = next(a for a in result["labels"] if a["label_id"] == "clearance")
+
+        assert clearance_annotation["annotation"] == "acceptable"
+        assert clearance_annotation["value"] == 0.7


### PR DESCRIPTION
## What / Why

Implements the diagnostic social preference label annotation pipeline for post-run
episode analysis (issue #4761).

This extends the existing label schema and config validation with:

- **Annotation function**: `annotate_episode_social_preferences()` applies
  threshold-band rules from the schema to episode metrics, producing per-label
  diagnostic annotations (acceptable/poor/caution/not_available).
- **Batch CLI**: `scripts/analysis/annotate_social_preference_labels.py` reads
  episode JSONL and writes annotation JSONL plus a summary JSON with label counts
  and `not_available` reasons.
- **Summary builder**: `build_label_summary()` for roll-up of annotation results.
- **Context note**: `docs/context/issue_4761_social_preference_labels.md`
  documents the diagnostic-only nature and distinction from hard safety predicates.

## Validation

```
28 passed in 2.34s  # 10 config tests + 18 new annotation/CLI/syntax tests
ruff check — clean
ruff format — clean
```

Tested annotations cover:
- Clearance margin: satisfied (high values), violated (negative), not_available (missing metric)
- TTC margin: violated (low), not_available (missing)
- Path blocking: always not_available (no candidate metrics)
- Nested metric path resolution (metrics.social_acceptability.x)
- Trace-field availability filtering
- Batch annotation and summary construction
- CLI `--help` and JSONL round-trip

## Closes #4761

This PR was produced by the SAIA/Qwen3.6-27B cheap implementation lane; the review gate hardens and merges.