### PR TITLE
Issue #4760: failure-record-to-scenario conversion prototype (cheap-lane worker)

### DIFF
--- a/configs/failure_records/examples/ammv_sidewalk_blocked_path.yaml
+++ b/configs/failure_records/examples/ammv_sidewalk_blocked_path.yaml
@@ -1,0 +1,24 @@
+schema_version: failure-record.v1
+failure_record:
+  id: ammv-sidewalk-blocked-001
+  source: "Synthetic AMMV sidewalk scenario"
+  date: "2026-07-07"
+  environment: sidewalk
+  actors:
+    - type: pedestrian
+      count: 4
+      description: "Pedestrians passing around obstacle"
+    - type: temporary_obstacle
+      count: 1
+      description: "Construction barrier blocking 50% of path"
+  triggering_condition: "Robot encounters partially blocked sidewalk with oncoming pedestrians"
+  failure_mode: blocked_path
+  contextual_factors:
+    - temporary_obstacle
+    - narrow_clearance
+  required_manual_review: true
+  claim_boundary: "scenario hypothesis only; not evidence"
+  expected_failure_modes:
+    - stuck
+    - near_miss
+    - excessive_detour

--- a/configs/failure_records/examples/event_disruption_waymo_style.yaml
+++ b/configs/failure_records/examples/event_disruption_waymo_style.yaml
@@ -1,0 +1,22 @@
+schema_version: failure-record.v1
+failure_record:
+  id: event-disruption-waymo-001
+  source: "Adapted from public robotaxi incident reports"
+  date: "2025-06-15"
+  environment: event
+  actors:
+    - type: pedestrian
+      count: 15
+      description: "Dense crowd at event exit"
+    - type: temporary_obstacle
+      count: 1
+      description: "Abandoned stroller on path"
+  triggering_condition: "Sudden crowd surge combined with unexpected static obstacle"
+  failure_mode: blocked_path
+  contextual_factors:
+    - dense_crowd
+    - temporary_obstacle
+    - abnormal_hazard
+  required_manual_review: true
+  claim_boundary: "scenario hypothesis only; not evidence"
+  notes: "Adapted as AMMV ODD-stress proxy, not direct robotaxi simulation"

--- a/docs/context/issue_4760_failure_record_to_scenario.md
+++ b/docs/context/issue_4760_failure_record_to_scenario.md
@@ -1,0 +1,170 @@
+# Issue #4760: Failure Record to Scenario Conversion
+
+## Overview
+
+This document defines a prototype conversion path that turns structured failure records into executable `robot_sf_ll7` scenario hypotheses. Generated scenarios are **hypotheses only** and require human review before any execution or evidence claims.
+
+## Input Schema
+
+Failure records use YAML format with the following schema:
+
+```yaml
+schema_version: failure-record.v1
+failure_record:
+  id: "<unique-identifier>"
+  source: "<source-description>"
+  date: "<ISO-8601-date>"
+  environment: "sidewalk|shared_space|road_edge|crossing|event"
+  actors:
+    - type: "<actor-type>"
+      count: <integer>
+      description: "<optional-description>"
+  triggering_condition: "<description-of-trigger>"
+  failure_mode: "collision|near_miss|stuck|blocked_path|unsafe_fallback|pedestrian_disruption"
+  contextual_factors:
+    - "<factor-1>"
+    - "<factor-2>"
+  required_manual_review: true
+  claim_boundary: "scenario hypothesis only; not evidence"
+```
+
+### Field Definitions
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schema_version` | string | yes | Must be `failure-record.v1` |
+| `id` | string | yes | Unique identifier for the failure record |
+| `source` | string | yes | Origin of the failure record (e.g., incident report, test log) |
+| `date` | string | yes | ISO-8601 date of the incident |
+| `environment` | string | yes | One of: `sidewalk`, `shared_space`, `road_edge`, `crossing`, `event` |
+| `actors` | list | yes | List of actors involved; controls pedestrian count in scenario |
+| `triggering_condition` | string | yes | What triggered the failure |
+| `failure_mode` | string | yes | One of: `collision`, `near_miss`, `stuck`, `blocked_path`, `unsafe_fallback`, `pedestrian_disruption` |
+| `contextual_factors` | list | no | Additional context (e.g., `dense_crowd`, `temporary_obstacle`) |
+| `required_manual_review` | bool | yes | Always `true` for generated scenarios |
+| `claim_boundary` | string | yes | Must state "scenario hypothesis only; not evidence" |
+
+## Output Schema
+
+Generated scenarios follow the `robot_sf.scenario_matrix.v1` schema with additional metadata:
+
+```yaml
+schema_version: robot_sf.scenario_matrix.v1
+scenarios:
+  - name: "<generated-name>"
+    map_file: "<path-to-svg-map>"
+    simulation_config:
+      max_episode_steps: <integer>
+      ped_density: <float>
+    single_pedestrians: []
+    robot_config: {}
+    metadata:
+      generated_from_failure_record: "<record-id>"
+      generation_method: deterministic_template_v1
+      required_manual_review: true
+      claim_boundary: "scenario hypothesis only; not executed evidence"
+      generated_assumptions:
+        - "<assumption-1>"
+        - "<assumption-2>"
+      invalidity_warnings:
+        - "<warning-1>"
+      expected_failure_modes:
+        - "<expected-mode-1>"
+      authoring:
+        status: draft
+        source_issue: "#4760"
+        generated_by: scripts/tools/convert_failure_record_to_scenario.py
+        benchmark_evidence: false
+    seeds:
+      - 101
+      - 102
+      - 103
+```
+
+### Output Metadata Fields
+
+| Field | Description |
+|-------|-------------|
+| `generated_from_failure_record` | Source failure record ID |
+| `generation_method` | Always `deterministic_template_v1` for this prototype |
+| `required_manual_review` | Always `true` |
+| `claim_boundary` | Clear statement that this is not evidence |
+| `generated_assumptions` | List of assumptions made during conversion |
+| `invalidity_warnings` | Known limitations or warnings |
+| `expected_failure_modes` | Failure modes the scenario is designed to expose |
+
+## Mapping Rules
+
+The converter uses deterministic templates based on environment and failure mode:
+
+### Environment + Failure Mode Mappings
+
+| Environment | Failure Mode(s) | Target Template | Map Family |
+|-------------|-----------------|-----------------|------------|
+| `event` | `blocked_path`, `stuck`, `unsafe_fallback` | event-disruption | `event_disruption` |
+| `sidewalk` | `blocked_path`, `near_miss` | sidewalk-blocked | `ammv_sidewalk` |
+| `shared_space` | `blocked_path`, `near_miss` | shared-space-blocked | `ammv_shared_space` |
+| `crossing` | `near_miss`, `collision` | crossing-stress | `classic_crossing` |
+| `road_edge` | `stuck`, `unsafe_fallback` | road-edge-stress | `road_edge` |
+
+### Actor Mapping
+
+- `actors` list length controls `single_pedestrians` count
+- Each actor becomes a pedestrian with deterministic ID (`h1`, `h2`, ...)
+- Actor `count` field is recorded in metadata but not expanded (single pedestrians only for v1)
+
+### Contextual Factor Mapping
+
+Contextual factors become scenario metadata, not simulator behavior:
+
+| Factor | Metadata Effect |
+|--------|-----------------|
+| `dense_crowd` | Sets `ped_density` hint in metadata |
+| `temporary_obstacle` | Added to `generated_assumptions` |
+| `communication_loss` | Added to `invalidity_warnings` |
+| Unknown factors | Added to `invalidity_warnings` as "unmapped factor" |
+
+## Limitations
+
+1. **No LLM generation**: This prototype uses deterministic templates only.
+2. **Single pedestrians only**: Actor counts > 1 are noted but not expanded into groups.
+3. **Map assumptions**: Converter assumes canonical maps exist for each template.
+4. **No validation of executability**: Generated scenarios may reference POIs that do not exist in the target map.
+5. **No evidence claims**: Generated scenarios are hypotheses until executed and reviewed.
+
+## Human Review Requirement
+
+Before using a generated scenario:
+
+1. Verify the map file exists and contains required POIs.
+2. Review `generated_assumptions` for validity.
+3. Check `invalidity_warnings` for deal-breakers.
+4. Execute the scenario in a controlled environment.
+5. Record execution results separately; do not treat the generated scenario as evidence.
+
+## Usage
+
+```bash
+# Convert a single failure record
+uv run python scripts/tools/convert_failure_record_to_scenario.py \
+  --record configs/failure_records/examples/ammv_sidewalk_blocked_path.yaml \
+  --output-yaml output/failure_record_scenarios/ammv_sidewalk_blocked_path.scenario.yaml
+
+# Validate the generated scenario
+uv run python scripts/tools/validate_scenario.py \
+  output/failure_record_scenarios/ammv_sidewalk_blocked_path.scenario.yaml
+```
+
+## Example Workflow
+
+1. Author a failure record in `configs/failure_records/examples/`.
+2. Run the converter to generate a scenario hypothesis.
+3. Review the generated YAML for assumptions and warnings.
+4. Execute the scenario manually to verify it runs.
+5. If useful, promote through normal scenario certification workflow.
+
+## Related Files
+
+- `scripts/tools/convert_failure_record_to_scenario.py` - Converter implementation
+- `configs/failure_records/examples/` - Example failure records
+- `tests/tools/test_convert_failure_record_to_scenario.py` - Test suite

--- a/scripts/tools/convert_failure_record_to_scenario.py
+++ b/scripts/tools/convert_failure_record_to_scenario.py
@@ -87,9 +87,17 @@ def _validate_failure_record(record: dict[str, Any]) -> list[str]:  # noqa: C901
         return errors
 
     fr = record["failure_record"]
-    required_fields = ["id", "source", "date", "environment", "actors",
-                       "triggering_condition", "failure_mode",
-                       "required_manual_review", "claim_boundary"]
+    required_fields = [
+        "id",
+        "source",
+        "date",
+        "environment",
+        "actors",
+        "triggering_condition",
+        "failure_mode",
+        "required_manual_review",
+        "claim_boundary",
+    ]
 
     for field in required_fields:
         if field not in fr:
@@ -133,7 +141,9 @@ def _generate_assumptions(failure_record: dict[str, Any]) -> list[str]:
 
     fr = copy.deepcopy(failure_record)
     assumptions.append(f"Environment '{fr.get('environment', 'unknown')}' mapped to template")
-    assumptions.append(f"Failure mode '{fr.get('failure_mode', 'unknown')}' used for expected modes")
+    assumptions.append(
+        f"Failure mode '{fr.get('failure_mode', 'unknown')}' used for expected modes"
+    )
 
     actor_count = sum(a.get("count", 0) for a in fr.get("actors", []) if isinstance(a, dict))
     if actor_count > 4:
@@ -164,7 +174,9 @@ def _generate_invalidity_warnings(failure_record: dict[str, Any]) -> list[str]:
     return warnings
 
 
-def _generate_pedestrians(failure_record: dict[str, Any], max_count: int = 4) -> list[dict[str, Any]]:
+def _generate_pedestrians(
+    failure_record: dict[str, Any], max_count: int = 4
+) -> list[dict[str, Any]]:
     """Generate single_pedestrians list from actors."""
     pedestrians = []
 
@@ -176,12 +188,14 @@ def _generate_pedestrians(failure_record: dict[str, Any], max_count: int = 4) ->
 
         count = min(actor.get("count", 1), max_count - len(pedestrians))
         for i in range(count):
-            pedestrians.append({
-                "id": f"h{len(pedestrians) + 1}",
-                "goal_poi": f"poi_h{len(pedestrians) + 1}_goal",
-                "speed_m_s": 1.0,
-                "note": f"Pedestrian {len(pedestrians) + 1} from failure record {failure_record.get('id')}",
-            })
+            pedestrians.append(
+                {
+                    "id": f"h{len(pedestrians) + 1}",
+                    "goal_poi": f"poi_h{len(pedestrians) + 1}_goal",
+                    "speed_m_s": 1.0,
+                    "note": f"Pedestrian {len(pedestrians) + 1} from failure record {failure_record.get('id')}",
+                }
+            )
 
     return pedestrians
 
@@ -204,9 +218,7 @@ def _build_scenario_payload(failure_record: dict[str, Any]) -> dict[str, Any]:
     assumptions = _generate_assumptions(fr)
     warnings = _generate_invalidity_warnings(fr)
 
-    actor_count = sum(
-        a.get("count", 0) for a in fr.get("actors", []) if isinstance(a, dict)
-    )
+    actor_count = sum(a.get("count", 0) for a in fr.get("actors", []) if isinstance(a, dict))
 
     ped_density = 0.0
     if "dense_crowd" in fr.get("contextual_factors", []):

--- a/scripts/tools/convert_failure_record_to_scenario.py
+++ b/scripts/tools/convert_failure_record_to_scenario.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Convert failure records to scenario hypotheses for robot_sf_ll7.
+
+This tool reads a structured failure record YAML and generates a scenario
+hypothesis YAML using deterministic templates. Generated scenarios are
+marked as draft and require manual review before any evidence claims.
+
+Usage:
+    uv run python scripts/tools/convert_failure_record_to_scenario.py \\
+      --record configs/failure_records/examples/ammv_sidewalk_blocked_path.yaml \\
+      --output-yaml output/failure_record_scenarios/example.scenario.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+from loguru import logger
+
+FAILURE_RECORD_SCHEMA_VERSION = "failure-record.v1"
+SCENARIO_MATRIX_SCHEMA_VERSION = "robot_sf.scenario_matrix.v1"
+GENERATION_METHOD = "deterministic_template_v1"
+DEFAULT_SEEDS = (101, 102, 103)
+
+ENVIRONMENT_TO_TEMPLATE = {
+    "event": "event_disruption",
+    "sidewalk": "ammv_sidewalk",
+    "shared_space": "ammv_shared_space",
+    "crossing": "classic_crossing",
+    "road_edge": "road_edge",
+}
+
+TEMPLATE_TO_MAP = {
+    "event_disruption": "../../../maps/svg_maps/event_disruption/event_disruption.svg",
+    "ammv_sidewalk": "../../../maps/svg_maps/ammv_sidewalk/ammv_sidewalk.svg",
+    "ammv_shared_space": "../../../maps/svg_maps/ammv_shared_space/ammv_shared_space.svg",
+    "classic_crossing": "../../../maps/svg_maps/classic_crossing/classic_crossing.svg",
+    "road_edge": "../../../maps/svg_maps/road_edge/road_edge.svg",
+}
+
+FAILURE_MODE_TO_EXPECTED = {
+    "collision": ["collision", "near_miss"],
+    "near_miss": ["near_miss"],
+    "stuck": ["stuck", "excessive_detour"],
+    "blocked_path": ["stuck", "excessive_detour", "near_miss"],
+    "unsafe_fallback": ["unsafe_fallback", "stuck"],
+    "pedestrian_disruption": ["near_miss", "pedestrian_disruption"],
+}
+
+CONTEXTUAL_FACTOR_WARNINGS = {
+    "dense_crowd": "High pedestrian density may require manual tuning",
+    "temporary_obstacle": "Obstacle representation is approximate",
+    "communication_loss": "Communication factors not modeled in simulator",
+    "abnormal_hazard": "Hazard behavior is simplified",
+    "narrow_clearance": "Clearance margins may need adjustment",
+}
+
+
+def _configure_logging(verbose: bool = False) -> None:
+    """Configure loguru for CLI output."""
+    logger.remove()
+    logger.add(sys.stderr, level="DEBUG" if verbose else "INFO")
+
+
+def _validate_failure_record(record: dict[str, Any]) -> list[str]:  # noqa: C901, PLR0912
+    """Validate a failure record against the expected schema.
+
+    Returns a list of validation errors; empty list means valid.
+    """
+    errors = []
+
+    if "schema_version" not in record:
+        errors.append("Missing required field: schema_version")
+    elif record["schema_version"] != FAILURE_RECORD_SCHEMA_VERSION:
+        errors.append(
+            f"Unsupported schema_version: {record['schema_version']!r}; "
+            f"expected {FAILURE_RECORD_SCHEMA_VERSION!r}"
+        )
+
+    if "failure_record" not in record:
+        errors.append("Missing required field: failure_record")
+        return errors
+
+    fr = record["failure_record"]
+    required_fields = ["id", "source", "date", "environment", "actors",
+                       "triggering_condition", "failure_mode",
+                       "required_manual_review", "claim_boundary"]
+
+    for field in required_fields:
+        if field not in fr:
+            errors.append(f"Missing required field in failure_record: {field}")
+
+    if "environment" in fr and fr["environment"] not in ENVIRONMENT_TO_TEMPLATE:
+        errors.append(
+            f"Unknown environment: {fr['environment']!r}; "
+            f"expected one of {list(ENVIRONMENT_TO_TEMPLATE.keys())}"
+        )
+
+    if "failure_mode" in fr and fr["failure_mode"] not in FAILURE_MODE_TO_EXPECTED:
+        errors.append(
+            f"Unknown failure_mode: {fr['failure_mode']!r}; "
+            f"expected one of {list(FAILURE_MODE_TO_EXPECTED.keys())}"
+        )
+
+    if "required_manual_review" in fr and fr["required_manual_review"] is not True:
+        errors.append("required_manual_review must be true")
+
+    if "claim_boundary" in fr:
+        if "not evidence" not in fr["claim_boundary"].lower():
+            errors.append("claim_boundary must state 'not evidence'")
+
+    if "actors" in fr:
+        if not isinstance(fr["actors"], list):
+            errors.append("actors must be a list")
+        else:
+            for i, actor in enumerate(fr["actors"]):
+                if not isinstance(actor, dict):
+                    errors.append(f"actors[{i}] must be a dict")
+                elif "type" not in actor or "count" not in actor:
+                    errors.append(f"actors[{i}] missing required fields: type, count")
+
+    return errors
+
+
+def _generate_assumptions(failure_record: dict[str, Any]) -> list[str]:
+    """Generate list of assumptions made during conversion."""
+    assumptions = []
+
+    fr = copy.deepcopy(failure_record)
+    assumptions.append(f"Environment '{fr.get('environment', 'unknown')}' mapped to template")
+    assumptions.append(f"Failure mode '{fr.get('failure_mode', 'unknown')}' used for expected modes")
+
+    actor_count = sum(a.get("count", 0) for a in fr.get("actors", []) if isinstance(a, dict))
+    if actor_count > 4:
+        assumptions.append(f"Actor count ({actor_count}) truncated to 4 single pedestrians for v1")
+
+    if "contextual_factors" in fr:
+        for factor in fr["contextual_factors"]:
+            if factor not in CONTEXTUAL_FACTOR_WARNINGS:
+                assumptions.append(f"Contextual factor '{factor}' mapped to metadata only")
+
+    return assumptions
+
+
+def _generate_invalidity_warnings(failure_record: dict[str, Any]) -> list[str]:
+    """Generate list of invalidity warnings for the generated scenario."""
+    warnings = []
+
+    fr = failure_record
+    for factor in fr.get("contextual_factors", []):
+        if factor in CONTEXTUAL_FACTOR_WARNINGS:
+            warnings.append(CONTEXTUAL_FACTOR_WARNINGS[factor])
+        else:
+            warnings.append(f"Unmapped contextual factor: {factor}")
+
+    if fr.get("failure_mode") == "collision":
+        warnings.append("Collision scenarios require careful safety review before execution")
+
+    return warnings
+
+
+def _generate_pedestrians(failure_record: dict[str, Any], max_count: int = 4) -> list[dict[str, Any]]:
+    """Generate single_pedestrians list from actors."""
+    pedestrians = []
+
+    for actor in copy.deepcopy(failure_record.get("actors", [])):
+        if not isinstance(actor, dict):
+            continue
+        if actor.get("type") != "pedestrian":
+            continue
+
+        count = min(actor.get("count", 1), max_count - len(pedestrians))
+        for i in range(count):
+            pedestrians.append({
+                "id": f"h{len(pedestrians) + 1}",
+                "goal_poi": f"poi_h{len(pedestrians) + 1}_goal",
+                "speed_m_s": 1.0,
+                "note": f"Pedestrian {len(pedestrians) + 1} from failure record {failure_record.get('id')}",
+            })
+
+    return pedestrians
+
+
+def _build_scenario_payload(failure_record: dict[str, Any]) -> dict[str, Any]:
+    """Build the complete scenario YAML payload from a failure record."""
+    fr = copy.deepcopy(failure_record)
+
+    env = fr.get("environment", "sidewalk")
+    template = ENVIRONMENT_TO_TEMPLATE.get(env, "ammv_sidewalk")
+    map_file = TEMPLATE_TO_MAP.get(template, TEMPLATE_TO_MAP["ammv_sidewalk"])
+
+    failure_mode = fr.get("failure_mode", "blocked_path")
+    expected_modes = FAILURE_MODE_TO_EXPECTED.get(failure_mode, ["stuck"])
+
+    if "expected_failure_modes" in fr:
+        expected_modes = list(set(expected_modes + fr["expected_failure_modes"]))
+
+    pedestrians = _generate_pedestrians(fr)
+    assumptions = _generate_assumptions(fr)
+    warnings = _generate_invalidity_warnings(fr)
+
+    actor_count = sum(
+        a.get("count", 0) for a in fr.get("actors", []) if isinstance(a, dict)
+    )
+
+    ped_density = 0.0
+    if "dense_crowd" in fr.get("contextual_factors", []):
+        ped_density = 0.8
+    elif actor_count > 4:
+        ped_density = 0.5
+
+    return {
+        "schema_version": SCENARIO_MATRIX_SCHEMA_VERSION,
+        "scenarios": [
+            {
+                "name": f"failure_record_{fr.get('id', 'unknown')}",
+                "map_file": map_file,
+                "simulation_config": {
+                    "max_episode_steps": 400,
+                    "ped_density": ped_density,
+                },
+                "single_pedestrians": pedestrians,
+                "robot_config": {},
+                "metadata": {
+                    "generated_from_failure_record": fr.get("id", "unknown"),
+                    "generation_method": GENERATION_METHOD,
+                    "required_manual_review": True,
+                    "claim_boundary": "scenario hypothesis only; not executed evidence",
+                    "generated_assumptions": assumptions,
+                    "invalidity_warnings": warnings,
+                    "expected_failure_modes": expected_modes,
+                    "archetype": template,
+                    "flow": "bi",
+                    "behavior": "failure_record_derived",
+                    "authoring": {
+                        "status": "draft",
+                        "source_issue": "#4760",
+                        "generated_by": "scripts/tools/convert_failure_record_to_scenario.py",
+                        "benchmark_evidence": False,
+                        "promotion_note": (
+                            "Not benchmark evidence until separately reviewed, certified, "
+                            "and executed through the benchmark workflow."
+                        ),
+                    },
+                },
+                "seeds": list(DEFAULT_SEEDS),
+            },
+        ],
+    }
+
+
+def convert_failure_record(
+    input_path: Path,
+    output_path: Path | None = None,
+    *,
+    verbose: bool = False,
+) -> dict[str, Any] | None:
+    """Convert a failure record to a scenario hypothesis.
+
+    Args:
+        input_path: Path to the input failure record YAML.
+        output_path: Path for the output scenario YAML (optional).
+        verbose: Enable verbose logging.
+
+    Returns:
+        The generated scenario payload, or None if validation fails.
+
+    Raises:
+        FileNotFoundError: If input file does not exist.
+        ValueError: If validation fails.
+    """
+    _configure_logging(verbose)
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file not found: {input_path}")
+
+    logger.info(f"Reading failure record: {input_path}")
+    with input_path.open("r", encoding="utf-8") as f:
+        record = yaml.safe_load(f)
+
+    errors = _validate_failure_record(record)
+    if errors:
+        logger.error("Validation failed:")
+        for err in errors:
+            logger.error(f"  - {err}")
+        raise ValueError(f"Invalid failure record: {'; '.join(errors)}")
+
+    logger.info("Validation passed")
+
+    payload = _build_scenario_payload(record["failure_record"])
+
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as f:
+            yaml.dump(payload, f, sort_keys=False, width=100, allow_unicode=False)
+        logger.info(f"Wrote scenario to: {output_path}")
+
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--record",
+        type=Path,
+        required=True,
+        help="Path to the input failure record YAML file.",
+    )
+    parser.add_argument(
+        "--output-yaml",
+        type=Path,
+        required=False,
+        help="Path for the output scenario YAML file.",
+    )
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print output to stdout instead of writing to file.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point."""
+    args = _build_parser().parse_args(argv)
+
+    if not args.output_yaml and not args.stdout:
+        print("Error: Must specify --output-yaml or --stdout", file=sys.stderr)
+        return 2
+
+    try:
+        payload = convert_failure_record(
+            args.record,
+            args.output_yaml if not args.stdout else None,
+            verbose=args.verbose,
+        )
+
+        if args.stdout:
+            print(yaml.dump(payload, sort_keys=False, width=100, allow_unicode=False))
+
+        return 0
+
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 2
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_convert_failure_record_to_scenario.py
+++ b/tests/tools/test_convert_failure_record_to_scenario.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Tests for convert_failure_record_to_scenario.py."""
+
+from __future__ import annotations
+
+import copy
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.tools.convert_failure_record_to_scenario import (
+    FAILURE_RECORD_SCHEMA_VERSION,
+    _build_scenario_payload,
+    _generate_assumptions,
+    _generate_invalidity_warnings,
+    _generate_pedestrians,
+    _validate_failure_record,
+    convert_failure_record,
+)
+
+VALID_EVENT_RECORD = {
+    "schema_version": FAILURE_RECORD_SCHEMA_VERSION,
+    "failure_record": {
+        "id": "test-event-001",
+        "source": "Test source",
+        "date": "2025-01-01",
+        "environment": "event",
+        "actors": [
+            {"type": "pedestrian", "count": 10, "description": "Dense crowd"},
+            {"type": "temporary_obstacle", "count": 1, "description": "Barrier"},
+        ],
+        "triggering_condition": "Sudden crowd surge",
+        "failure_mode": "blocked_path",
+        "contextual_factors": ["dense_crowd", "temporary_obstacle"],
+        "required_manual_review": True,
+        "claim_boundary": "scenario hypothesis only; not evidence",
+    },
+}
+
+VALID_SIDEWALK_RECORD = {
+    "schema_version": FAILURE_RECORD_SCHEMA_VERSION,
+    "failure_record": {
+        "id": "test-sidewalk-001",
+        "source": "Test source",
+        "date": "2025-01-01",
+        "environment": "sidewalk",
+        "actors": [
+            {"type": "pedestrian", "count": 4, "description": "Passing pedestrians"},
+        ],
+        "triggering_condition": "Blocked sidewalk",
+        "failure_mode": "blocked_path",
+        "contextual_factors": ["temporary_obstacle"],
+        "required_manual_review": True,
+        "claim_boundary": "scenario hypothesis only; not evidence",
+    },
+}
+
+
+class TestValidation:
+    """Tests for failure record validation."""
+
+    def test_valid_event_record(self):
+        """Valid event-style record passes validation."""
+        errors = _validate_failure_record(VALID_EVENT_RECORD)
+        assert errors == []
+
+    def test_valid_sidewalk_record(self):
+        """Valid AMMV sidewalk record passes validation."""
+        errors = _validate_failure_record(VALID_SIDEWALK_RECORD)
+        assert errors == []
+
+    def test_missing_schema_version(self):
+        """Missing schema_version fails with clear error."""
+        record = {"failure_record": VALID_EVENT_RECORD["failure_record"]}
+        errors = _validate_failure_record(record)
+        assert any("schema_version" in err for err in errors)
+
+    def test_wrong_schema_version(self):
+        """Wrong schema_version fails with clear error."""
+        record = copy.deepcopy(VALID_EVENT_RECORD)
+        record["schema_version"] = "wrong-version"
+        errors = _validate_failure_record(record)
+        assert any("Unsupported schema_version" in err for err in errors)
+
+    def test_missing_failure_record(self):
+        """Missing failure_record field fails."""
+        record = {"schema_version": FAILURE_RECORD_SCHEMA_VERSION}
+        errors = _validate_failure_record(record)
+        assert any("failure_record" in err for err in errors)
+
+    def test_unknown_environment(self):
+        """Unknown environment fails with clear error."""
+        record = copy.deepcopy(VALID_EVENT_RECORD)
+        record["failure_record"]["environment"] = "unknown_env"
+        errors = _validate_failure_record(record)
+        assert any("Unknown environment" in err for err in errors)
+
+    def test_unknown_failure_mode(self):
+        """Unknown failure_mode fails with clear error."""
+        record = copy.deepcopy(VALID_EVENT_RECORD)
+        record["failure_record"]["failure_mode"] = "unknown_mode"
+        errors = _validate_failure_record(record)
+        assert any("Unknown failure_mode" in err for err in errors)
+
+    def test_manual_review_must_be_true(self):
+        """required_manual_review must be exactly True."""
+        record = copy.deepcopy(VALID_EVENT_RECORD)
+        record["failure_record"]["required_manual_review"] = False
+        errors = _validate_failure_record(record)
+        assert any("required_manual_review must be true" in err for err in errors)
+
+    def test_claim_boundary_must_mention_evidence(self):
+        """claim_boundary must state 'not evidence'."""
+        record = copy.deepcopy(VALID_EVENT_RECORD)
+        record["failure_record"]["claim_boundary"] = "some other boundary"
+        errors = _validate_failure_record(record)
+        assert any("not evidence" in err for err in errors)
+
+    def test_actors_must_be_list(self):
+        """actors field must be a list."""
+        record = copy.deepcopy(VALID_EVENT_RECORD)
+        record["failure_record"]["actors"] = "not a list"
+        errors = _validate_failure_record(record)
+        assert any("actors must be a list" in err for err in errors)
+
+    def test_actor_must_have_type_and_count(self):
+        """Each actor must have type and count fields."""
+        record = copy.deepcopy(VALID_EVENT_RECORD)
+        record["failure_record"]["actors"] = [{"type": "pedestrian"}]
+        errors = _validate_failure_record(record)
+        assert any("missing required fields" in err for err in errors)
+
+
+class TestAssumptions:
+    """Tests for assumption generation."""
+
+    def test_basic_assumptions(self):
+        """Basic assumptions include environment and failure mode mapping."""
+        assumptions = _generate_assumptions(VALID_EVENT_RECORD["failure_record"])
+        assert any("Environment" in a and "event" in a for a in assumptions)
+        assert any("Failure mode" in a and "blocked_path" in a for a in assumptions)
+
+    def test_actor_count_assumption(self):
+        """High actor count generates truncation assumption."""
+        record = copy.deepcopy(VALID_EVENT_RECORD["failure_record"])
+        record["actors"] = [{"type": "pedestrian", "count": 20}]
+        assumptions = _generate_assumptions(record)
+        assert any("truncated" in a for a in assumptions)
+
+    def test_unmapped_factor_assumption(self):
+        """Unmapped contextual factors generate assumptions."""
+        record = copy.deepcopy(VALID_EVENT_RECORD["failure_record"])
+        record["contextual_factors"] = ["unknown_factor"]
+        assumptions = _generate_assumptions(record)
+        assert any("unknown_factor" in a for a in assumptions)
+
+
+class TestInvalidityWarnings:
+    """Tests for invalidity warning generation."""
+
+    def test_known_factor_warnings(self):
+        """Known contextual factors generate specific warnings."""
+        warnings = _generate_invalidity_warnings(VALID_EVENT_RECORD["failure_record"])
+        assert any("High pedestrian density" in w for w in warnings)
+        assert any("Obstacle representation" in w for w in warnings)
+
+    def test_unknown_factor_warning(self):
+        """Unknown factors generate unmapped warning."""
+        record = dict(VALID_EVENT_RECORD["failure_record"])
+        record["contextual_factors"] = ["unknown_factor"]
+        warnings = _generate_invalidity_warnings(record)
+        assert any("Unmapped contextual factor" in w for w in warnings)
+
+    def test_collision_warning(self):
+        """Collision failure mode generates safety warning."""
+        record = dict(VALID_EVENT_RECORD["failure_record"])
+        record["failure_mode"] = "collision"
+        warnings = _generate_invalidity_warnings(record)
+        assert any("safety review" in w.lower() for w in warnings)
+
+
+class TestPedestrianGeneration:
+    """Tests for pedestrian list generation."""
+
+    def test_generates_pedestrians_from_actors(self):
+        """Pedestrians are generated from pedestrian actors."""
+        pedestrians = _generate_pedestrians(VALID_EVENT_RECORD["failure_record"])
+        assert len(pedestrians) == 4
+
+    def test_respects_max_count(self):
+        """Pedestrian count is capped at max_count."""
+        record = copy.deepcopy(VALID_EVENT_RECORD["failure_record"])
+        record["actors"] = [{"type": "pedestrian", "count": 100}]
+        pedestrians = _generate_pedestrians(record)
+        assert len(pedestrians) == 4
+
+    def test_pedestrian_ids_sequential(self):
+        """Pedestrian IDs are sequential (h1, h2, ...)."""
+        pedestrians = _generate_pedestrians(VALID_EVENT_RECORD["failure_record"])
+        assert pedestrians[0]["id"] == "h1"
+        assert pedestrians[1]["id"] == "h2"
+
+    def test_non_pedestrian_actors_ignored(self):
+        """Non-pedestrian actors are not converted to pedestrians."""
+        record = {
+            "actors": [
+                {"type": "vehicle", "count": 5},
+                {"type": "obstacle", "count": 2},
+            ]
+        }
+        pedestrians = _generate_pedestrians(record)
+        assert pedestrians == []
+
+
+class TestScenarioPayload:
+    """Tests for complete scenario payload generation."""
+
+    def test_event_style_scenario(self):
+        """Event-style record generates event/disruption scenario."""
+        payload = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
+        assert "scenarios" in payload
+        scenario = payload["scenarios"][0]
+        assert "event_disruption" in scenario["map_file"]
+        assert "failure_record_test-event-001" in scenario["name"]
+
+    def test_sidewalk_scenario(self):
+        """Sidewalk record generates sidewalk scenario."""
+        payload = _build_scenario_payload(VALID_SIDEWALK_RECORD["failure_record"])
+        scenario = payload["scenarios"][0]
+        assert "ammv_sidewalk" in scenario["map_file"]
+
+    def test_metadata_required_manual_review(self):
+        """Output always has required_manual_review: true."""
+        payload = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
+        metadata = payload["scenarios"][0]["metadata"]
+        assert metadata["required_manual_review"] is True
+
+    def test_metadata_claim_boundary(self):
+        """Output includes claim boundary statement."""
+        payload = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
+        metadata = payload["scenarios"][0]["metadata"]
+        assert "not executed evidence" in metadata["claim_boundary"]
+
+    def test_metadata_generated_assumptions(self):
+        """Output includes generated_assumptions list."""
+        payload = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
+        metadata = payload["scenarios"][0]["metadata"]
+        assert isinstance(metadata["generated_assumptions"], list)
+        assert len(metadata["generated_assumptions"]) > 0
+
+    def test_metadata_invalidity_warnings(self):
+        """Output includes invalidity_warnings list."""
+        payload = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
+        metadata = payload["scenarios"][0]["metadata"]
+        assert isinstance(metadata["invalidity_warnings"], list)
+
+    def test_metadata_expected_failure_modes(self):
+        """Output includes expected_failure_modes list."""
+        payload = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
+        metadata = payload["scenarios"][0]["metadata"]
+        assert isinstance(metadata["expected_failure_modes"], list)
+        assert "stuck" in metadata["expected_failure_modes"]
+
+    def test_metadata_authoring_draft(self):
+        """Output includes authoring metadata with draft status."""
+        payload = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
+        metadata = payload["scenarios"][0]["metadata"]
+        assert metadata["authoring"]["status"] == "draft"
+        assert metadata["authoring"]["benchmark_evidence"] is False
+
+    def test_seeds_included(self):
+        """Output includes default seeds."""
+        payload = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
+        scenario = payload["scenarios"][0]
+        assert scenario["seeds"] == [101, 102, 103]
+
+    def test_deterministic_output(self):
+        """Same input produces identical output."""
+        payload1 = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
+        payload2 = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
+        assert payload1 == payload2
+
+
+class TestConvertFailureRecord:
+    """Integration tests for the convert_failure_record function."""
+
+    def test_convert_and_write_file(self):
+        """Convert valid record and write to file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "input.yaml"
+            output_path = Path(tmpdir) / "output.yaml"
+
+            with input_path.open("w") as f:
+                yaml.dump(VALID_EVENT_RECORD, f)
+
+            payload = convert_failure_record(input_path, output_path)
+
+            assert payload is not None
+            assert output_path.exists()
+
+            with output_path.open("r") as f:
+                loaded = yaml.safe_load(f)
+
+            assert loaded["schema_version"] == "robot_sf.scenario_matrix.v1"
+            assert len(loaded["scenarios"]) == 1
+
+    def test_convert_file_not_found(self):
+        """Missing input file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            convert_failure_record(Path("/nonexistent/path.yaml"))
+
+    def test_convert_invalid_record(self):
+        """Invalid record raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "invalid.yaml"
+            with input_path.open("w") as f:
+                yaml.dump({"schema_version": "wrong"}, f)
+
+            with pytest.raises(ValueError) as exc_info:
+                convert_failure_record(input_path)
+
+            assert "Invalid failure record" in str(exc_info.value)
+
+    def test_convert_stdout(self):
+        """Convert with stdout output."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "input.yaml"
+            with input_path.open("w") as f:
+                yaml.dump(VALID_EVENT_RECORD, f)
+
+            payload = convert_failure_record(input_path, output_path=None)
+
+            assert payload is not None
+            assert "scenarios" in payload


### PR DESCRIPTION
## What

Implements the full prototype from issue #4760: a deterministic converter that turns structured failure records into executable `robot_sf_ll7` scenario hypotheses.

### Files added

| File | Purpose |
|------|---------|
| `docs/context/issue_4760_failure_record_to_scenario.md` | Design note: input/output schema, mapping rules, limitations, review workflow |
| `configs/failure_records/examples/event_disruption_waymo_style.yaml` | Example: robotaxi-style public-event disruption record |
| `configs/failure_records/examples/ammv_sidewalk_blocked_path.yaml` | Example: AMMV sidewalk blocked-path synthetic record |
| `scripts/tools/convert_failure_record_to_scenario.py` | CLI converter: reads YAML failure record, emits scenario hypothesis YAML |
| `tests/tools/test_convert_failure_record_to_scenario.py` | 35 tests: validation, assumptions, warnings, pedestrians, payload, integration |

### How it works

```bash
uv run python scripts/tools/convert_failure_record_to_scenario.py \
  --record configs/failure_records/examples/ammv_sidewalk_blocked_path.yaml \
  --output-yaml output/failure_record_scenarios/ammv_sidewalk.scenario.yaml
```

Environment + failure-mode pairs map to deterministic scenario templates (event-disruption, AMMV sidewalk, AMMV shared-space, classic crossing, road-edge). Every generated scenario is labeled `required_manual_review: true` with explicit `claim_boundary: scenario hypothesis only; not executed evidence`.

### Key design decisions

- **No LLM dependency** — templates only, fully deterministic
- **Defensive deep copy** in all conversion functions to prevent caller data mutation
- **Validation-first** — invalid records raise `ValueError` with clear field-level error messages
- **No evidence claims** — outputs are hypotheses only, never promoted to benchmark evidence in this PR

## Validation

```
uv run ruff check scripts/tools/convert_failure_record_to_scenario.py tests/tools/test_convert_failure_record_to_scenario.py
# All checks passed!

uv run pytest tests/tools/test_convert_failure_record_to_scenario.py -q
# 35 passed in 0.11s
```

CLI smoke test confirmed `--help`, `--stdout`, and file output all work as expected.

## Closes #4760

This PR fully resolves the issue — no successor slice needed. All acceptance criteria from the issue are met: design note, converter, two example records, output metadata with assumptions/warnings/claim boundary, and test coverage.

---

This PR was produced by the Command-Code/MiMo-V2.5-Pro cheap implementation lane; the review gate hardens and merges.