### PR TITLE
Issue #4759: add event_disruption scenario family for public-event ODD stress (cheap-lane worker)

### DIFF
--- a/configs/scenarios/event_disruption.yaml
+++ b/configs/scenarios/event_disruption.yaml
@@ -1,0 +1,16 @@
+schema_version: robot_sf.scenario_matrix.v1
+includes:
+  - single/event_disruption_public_exit.yaml
+map_search_paths:
+  - ../../maps/svg_maps
+metadata:
+  scenario_family: event_disruption
+  purpose: >
+    Manifest for the event-disruption scenario family.  Contains ODD-stress
+    proxy scenarios for public-event disruption, using existing 2D simulation
+    primitives.  Experimental and opt-in; not a real-world event model.
+  not_real_world_event_model: true
+  odd_stress_proxy: public_event_disruption
+  authoring:
+    source_issue: https://github.com/ll7/robot_sf_ll7/issues/4759
+    benchmark_evidence: false

--- a/configs/scenarios/single/event_disruption_public_exit.yaml
+++ b/configs/scenarios/single/event_disruption_public_exit.yaml
@@ -1,0 +1,153 @@
+schema_version: robot_sf.scenario_matrix.v1
+scenarios:
+- name: event_disruption_public_exit_blocked_path_v1
+  map_id: classic_station_platform
+  scenario_family: event_disruption
+  simulation_config:
+    max_episode_steps: 500
+    ped_density: 0.2
+    archetype_composition:
+      exiting_crowd: 0.6
+      counter_flow: 0.25
+      non_cooperative: 0.15
+    archetype_speed_factors:
+      exiting_crowd: 1.2
+      counter_flow: 0.8
+      non_cooperative: 0.5
+    archetype_seed: 4759
+    route_spawn_distribution: "uniform"
+    route_spawn_jitter_frac: 0.1
+    route_spawn_seed: 4759
+  robot_config:
+    type: "differential_drive"
+    radius: 0.3
+    max_linear_speed: 1.0
+    max_angular_speed: 2.0
+  single_pedestrians:
+    - id: p1
+      goal: null
+      trajectory:
+        - [10.0, 18.0]
+        - [10.0, 12.0]
+        - [8.0, 6.0]
+        - [8.0, 2.0]
+      speed_m_s: 1.2
+      start_delay_s: 0.0
+      note: dense exit flow, outbound
+      metadata:
+        intent_label: crowd_exit_outbound
+    - id: p2
+      goal: null
+      trajectory:
+        - [14.0, 2.0]
+        - [14.0, 8.0]
+        - [12.0, 14.0]
+        - [12.0, 20.0]
+      speed_m_s: 0.8
+      start_delay_s: 2.0
+      note: counter-flow pedestrian
+      metadata:
+        intent_label: counter_flow_inbound
+    - id: p3
+      goal: null
+      trajectory:
+        - [6.0, 10.0]
+      start_delay_s: 0.0
+      wait_at:
+        - waypoint_index: 0
+          wait_s: 30.0
+          note: non-cooperative stopper in zone
+      hold_until_robot_within_m: 0.5
+      hold_ref_point: [6.0, 10.0]
+      hold_timeout_s: 60.0
+      note: non-cooperative pedestrian blocking path segment
+      metadata:
+        intent_label: non_cooperative_blocker
+  platform_semantics:
+    status: "metadata_only"
+    regions:
+      - id: temporary_blockage_01
+        kind: "hazard"
+        shape: "bbox"
+        bounds: [5.0, 6.0, 9.0, 14.0]
+        note: Temporary path blockage simulating event barricade
+        metadata:
+          blockage_type: event_barricade
+          removal_time_s: null
+          hazard_class: soft_blockage
+      - id: hazard_object_01
+        kind: "hazard"
+        shape: "polygon"
+        points:
+          - [7.5, 8.0]
+          - [7.5, 10.0]
+          - [8.5, 10.0]
+          - [8.5, 8.0]
+        note: Nonstandard obstacle (firework debris proxy)
+        metadata:
+          hazard_type: unexpected_debris
+          hazard_class: rigid_obstacle
+  observation_visibility:
+    enabled: false
+  metadata:
+    scenario_family: event_disruption
+    purpose: >
+      Experimental ODD-stress proxy for public-event disruption: dense crowd
+      exit flow with a temporary path blockage and nonstandard hazard object.
+      Models the class of failure triggered when a robot must transit shared
+      space during or after a mass public event that has produced blocked paths,
+      abnormal pedestrian behavior, and unexpected obstacles.
+    archetype: event_disruption_public_exit
+    flow: dense_bidirectional_with_blockage
+    behavior: crowd_exit_blockage
+    density: high
+    density_advisory: stress_proxy_only
+    not_real_world_event_model: true
+    odd_stress_proxy: public_event_disruption
+    expected_failure_modes:
+      - fallback_brake
+      - stuck
+      - near_miss
+      - excessive_pedestrian_disruption
+      - collision_with_hazard
+    disruption_dimensions:
+      dense_pedestrian_exit_flow: true
+      blocked_path_temporary_closure: true
+      non_cooperative_pedestrians: true
+      unexpected_hazard_object: true
+      communication_loss_flag: false
+      low_battery_limited_fallback: false
+      remote_assistance_unavailable: true
+      emergency_stop_trigger: true
+    communication_loss_flag: false
+    remote_assistance_available: false
+    limited_fallback_horizon_s: 3.0
+    authoring:
+      status: draft
+      source_issue: https://github.com/ll7/robot_sf_ll7/issues/4759
+      benchmark_evidence: false
+      claim_boundary: >
+        Experimental ODD-stress proxy, not a real-world event reconstruction.
+        Uses existing 2D simulation primitives to stress-test shared-space
+        autonomy under public-event conditions. Does not prove or claim
+        realistic crowd dynamics or robotaxi deployment equivalence.
+    plausibility:
+      status: unverified
+      verified_on: null
+      verified_by: null
+      method: null
+      notes: >
+        Prototype disruption scenario; synthetic pedestrian trajectories and
+        obstacle placement for architectural stress testing.  Requires runner
+        integration and benchmark evidence before use in planner ranking.
+      metrics_updated_on: null
+      metrics:
+        min_distance: null
+        mean_distance: null
+        robot_ped_within_5m_frac: null
+        ped_force_mean: null
+        force_q95: null
+  seeds:
+    - 4759
+    - 4760
+    - 4761

--- a/docs/context/issue_4759_event_disruption_scenarios.md
+++ b/docs/context/issue_4759_event_disruption_scenarios.md
@@ -35,7 +35,7 @@ The `event_disruption` family covers the following disruption dimensions:
 |---|---|---|
 | Dense pedestrian exit flow | Yes | Bidirectional, high-density, multiple archetypes |
 | Blocked path / temporary closure | Yes | `platform_semantics` hazard regions |
-| Non-cooperative pedestrians | Yes | Zero-speed blockers, proxemic-hold semantics |
+| Non-cooperative pedestrians | Yes | Reduced-speed (0.5×) archetype + proxemic-hold semantics; literal zero-speed holding is realized only by the scripted `p3` pedestrian (`wait_at`/`hold_*`), since composition rejects speed factors ≤ 0 |
 | Unexpected hazard objects | Yes | Rigid obstacle proxies (firework debris) |
 | Communication-loss flag | Planned | Metadata-only for first slice |
 | Low-battery / limited-fallback horizon | Planned | Metadata-only for first slice |
@@ -56,7 +56,7 @@ A deterministic template with:
 - **Pedestrian archetypes:**
   - `exiting_crowd`: higher-speed outbound flow (60% of population)
   - `counter_flow`: lower-speed inbound flow (25%)
-  - `non_cooperative`: zero-speed path blockers (15%)
+  - `non_cooperative`: reduced-speed path blockers, `archetype_speed_factors.non_cooperative: 0.5` (15%); literal zero-speed holding is scripted separately via the `p3` pedestrian's `wait_at`/`hold_*` fields
 - **Hazard regions** (metadata-only):
   - `temporary_blockage_01`: bbox barricade simulating event closure
   - `hazard_object_01`: polygon debris proxy (rigid obstacle)
@@ -66,14 +66,15 @@ A deterministic template with:
 ## Running
 
 ```bash
-# Load and validate the scenario through the existing loader:
-uv run python -m robot_sf.benchmark.cli \
-  --scenario configs/scenarios/event_disruption.yaml \
-  --max-episodes 1
-
-# Run smoke tests:
+# Load and validate the scenario family (this is the actual validation path;
+# the smoke test loads each YAML and runs it through validate_scenario_list):
 uv run pytest tests/scenarios/test_event_disruption_scenarios.py -v
 ```
+
+Note: `robot_sf.benchmark.cli` runs benchmark matrices via subcommands
+(`--matrix`/`--out`), not single scenario-family files, so there is no
+`--scenario`/`--max-episodes` one-liner for this manifest — the pytest smoke
+test above is the supported load-and-validate entry point for this slice.
 
 ## Known Limitations
 

--- a/docs/context/issue_4759_event_disruption_scenarios.md
+++ b/docs/context/issue_4759_event_disruption_scenarios.md
@@ -1,0 +1,106 @@
+# Issue #4759: Event-Disruption Scenario Family
+
+**Status:** prototype — schema draft, experimental ODD-stress proxy
+
+**Issue:** <https://github.com/ll7/robot_sf_ll7/issues/4759>
+
+## Motivation
+
+The July 4, 2025, Waymo fleet disruption in San Francisco exposed a class of
+deployment-context stressors that are not captured by ordinary navigation
+benchmark scenarios: dense crowd exits, blocked roads, abnormal pedestrian
+behavior, unexpected debris, and degraded fallback context (remote assistance
+unavailable, limited battery horizon). These are not edge cases in the
+traditional sense; they are Operating Design Domain (ODD) boundary crossings
+triggered by external events rather than routine interaction patterns.
+
+This scenario family serves as an ODD-stress proxy for testing automated mobile
+vehicle (AMMV) / mobile robot behavior under public-event conditions, using
+existing 2D simulation primitives.
+
+## Claim Boundary
+
+This is an **experimental ODD-stress proxy**, not a real-world event
+reconstruction or robotaxi deployment model. It does not claim or prove
+realistic crowd dynamics, traffic-signal realism, remote-assistance modeling,
+or planner-ranking changes. The scenarios are architecture-level stress fixtures
+for identifying how planners, simulators, and evaluation pipelines behave under
+unusual conditions.
+
+## Scenario Dimensions
+
+The `event_disruption` family covers the following disruption dimensions:
+
+| Dimension | Represented | Notes |
+|---|---|---|
+| Dense pedestrian exit flow | Yes | Bidirectional, high-density, multiple archetypes |
+| Blocked path / temporary closure | Yes | `platform_semantics` hazard regions |
+| Non-cooperative pedestrians | Yes | Zero-speed blockers, proxemic-hold semantics |
+| Unexpected hazard objects | Yes | Rigid obstacle proxies (firework debris) |
+| Communication-loss flag | Planned | Metadata-only for first slice |
+| Low-battery / limited-fallback horizon | Planned | Metadata-only for first slice |
+| Remote assistance unavailable | Yes | Metadata flag |
+| Emergency stop / fallback-brake trigger | Metadata | Expected failure-mode contract only |
+
+## Scenario Files
+
+- **Archetype:** `configs/scenarios/single/event_disruption_public_exit.yaml`
+- **Manifest:** `configs/scenarios/event_disruption.yaml`
+
+## Scenario Design: `event_disruption_public_exit_blocked_path_v1`
+
+A deterministic template with:
+
+- **Map:** `classic_station_platform` (plaza-like open space)
+- **Robot:** Differential-drive, must transit through the disruption zone
+- **Pedestrian archetypes:**
+  - `exiting_crowd`: higher-speed outbound flow (60% of population)
+  - `counter_flow`: lower-speed inbound flow (25%)
+  - `non_cooperative`: zero-speed path blockers (15%)
+- **Hazard regions** (metadata-only):
+  - `temporary_blockage_01`: bbox barricade simulating event closure
+  - `hazard_object_01`: polygon debris proxy (rigid obstacle)
+- **Expected failure modes:** `fallback_brake`, `stuck`, `near_miss`,
+  `excessive_pedestrian_disruption`, `collision_with_hazard`
+
+## Running
+
+```bash
+# Load and validate the scenario through the existing loader:
+uv run python -m robot_sf.benchmark.cli \
+  --scenario configs/scenarios/event_disruption.yaml \
+  --max-episodes 1
+
+# Run smoke tests:
+uv run pytest tests/scenarios/test_event_disruption_scenarios.py -v
+```
+
+## Known Limitations
+
+1. **No real crowd dynamics:** Pedestrian trajectories are authored, not
+   generated from a crowd-simulation model.
+2. **No remote-assistance model:** The `remote_assistance_available: false`
+   flag is metadata-only; there is no remote-assistance protocol in the
+   simulator.
+3. **Hazard regions are metadata:** The `platform_semantics` regions are
+   currently metadata-only and may not be enforced by all planner backends.
+   A follow-up issue should track planner-backend enforcement.
+4. **No battery or communication model:** Low-battery and communication-loss
+   dimensions are not yet represented.
+
+## Follow-Up Work
+
+- Planner-backend enforcement of `platform_semantics` hazard regions
+- Continuous-spawn crowd density variants (issue #3813 sustained-flow
+  infrastructure may be reusable)
+- Communication-loss and low-battery simulation layers
+- Benchmark campaign over seeds and planner configurations
+- Scenario variants: `crowd_navigation` map (Francis 2023), urban crossing,
+  emergency-vehicle interaction
+
+## Sources
+
+- Waymo fleet clogs Presidio after July 4 fireworks:
+  <https://abc7news.com/post/waymo-fleet-clogs-presidio-july-4-fireworks-leaving-vehicles-stranded-towed/19455862/>
+- Waymo looking into vehicles driving over fireworks in San Francisco:
+  <https://www.cbsnews.com/sanfrancisco/news/waymo-fireworks-san-francisco-july-4th/>

--- a/tests/scenarios/test_event_disruption_scenarios.py
+++ b/tests/scenarios/test_event_disruption_scenarios.py
@@ -1,0 +1,206 @@
+"""Scenario-loader coverage for issue #4759 event-disruption scenarios."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_sf.benchmark.scenario_schema import validate_scenario_list
+from robot_sf.training.scenario_loader import (
+    build_robot_config_from_scenario,
+    load_scenarios,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCENARIO_ARCHETYPE = REPO_ROOT / "configs/scenarios/single/event_disruption_public_exit.yaml"
+SCENARIO_MANIFEST = REPO_ROOT / "configs/scenarios/event_disruption.yaml"
+
+
+class TestEventDisruptionArchetypeLoads:
+    """The archetype YAML is parseable and has the expected fields."""
+
+    def test_archetype_manifest_loads(self) -> None:
+        """Archetype file loads through existing scenario loader."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        assert len(scenarios) >= 1
+
+    def test_scenario_family_is_event_disruption(self) -> None:
+        """Scenario carries event_disruption family metadata."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        scenario = next(
+            (
+                s
+                for s in scenarios
+                if s.get("name") == "event_disruption_public_exit_blocked_path_v1"
+            ),
+            None,
+        )
+        assert scenario is not None
+        assert scenario.get("scenario_family") == "event_disruption"
+        assert (scenario.get("metadata") or {}).get("scenario_family") == "event_disruption"
+
+    def test_expected_failure_modes_present(self) -> None:
+        """Expected failure-mode metadata lists event-relevant modes."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        scenario = next(
+            (
+                s
+                for s in scenarios
+                if s.get("name") == "event_disruption_public_exit_blocked_path_v1"
+            ),
+            None,
+        )
+        assert scenario is not None
+        failure_modes = scenario["metadata"]["expected_failure_modes"]
+        assert isinstance(failure_modes, list)
+        assert len(failure_modes) >= 2
+        expected_sub_modes = {"fallback_brake", "stuck", "near_miss"}
+        assert expected_sub_modes.issubset(set(failure_modes))
+
+    def test_map_resolves(self) -> None:
+        """The scenario references a valid map."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        scenario = next(
+            (
+                s
+                for s in scenarios
+                if s.get("name") == "event_disruption_public_exit_blocked_path_v1"
+            ),
+            None,
+        )
+        assert scenario is not None
+        assert "map_file" in scenario or "map_id" in scenario
+
+    def test_has_blockage_and_hazard(self) -> None:
+        """Scenario defines at least one blockage/hazard region."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        scenario = next(
+            (
+                s
+                for s in scenarios
+                if s.get("name") == "event_disruption_public_exit_blocked_path_v1"
+            ),
+            None,
+        )
+        assert scenario is not None
+        ps = scenario.get("platform_semantics", {})
+        assert ps.get("status") == "metadata_only"
+        regions = ps.get("regions", [])
+        assert len(regions) >= 1
+        kinds = {r.get("kind") for r in regions}
+        assert "hazard" in kinds
+
+    def test_has_multiple_pedestrian_routes(self) -> None:
+        """Scenario defines at least two pedestrians with routes."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        scenario = next(
+            (
+                s
+                for s in scenarios
+                if s.get("name") == "event_disruption_public_exit_blocked_path_v1"
+            ),
+            None,
+        )
+        assert scenario is not None
+        peds = scenario.get("single_pedestrians", [])
+        assert len(peds) >= 3
+        ped_ids = {p["id"] for p in peds}
+        assert ped_ids == {"p1", "p2", "p3"}
+
+    def test_non_cooperative_pedestrian_present(self) -> None:
+        """At least one non-cooperative (zero-speed, proxemic-hold) pedestrian."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        scenario = next(
+            (
+                s
+                for s in scenarios
+                if s.get("name") == "event_disruption_public_exit_blocked_path_v1"
+            ),
+            None,
+        )
+        assert scenario is not None
+        peds = scenario.get("single_pedestrians", [])
+        blocker = [
+            p
+            for p in peds
+            if (p.get("metadata") or {}).get("intent_label") == "non_cooperative_blocker"
+        ]
+        assert len(blocker) == 1
+        assert "wait_at" in blocker[0]
+
+    def test_density_above_baseline(self) -> None:
+        """Pedestrian density is set for stress testing."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        scenario = next(
+            (
+                s
+                for s in scenarios
+                if s.get("name") == "event_disruption_public_exit_blocked_path_v1"
+            ),
+            None,
+        )
+        assert scenario is not None
+        ped_density = scenario.get("simulation_config", {}).get("ped_density", 0.0)
+        assert ped_density > 0.05
+
+    def test_proxy_boundary_in_metadata(self) -> None:
+        """Metadata explicitly states this is an ODD-stress proxy, not a real event model."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        scenario = next(
+            (
+                s
+                for s in scenarios
+                if s.get("name") == "event_disruption_public_exit_blocked_path_v1"
+            ),
+            None,
+        )
+        assert scenario is not None
+        meta = scenario["metadata"]
+        assert meta.get("not_real_world_event_model") is True
+        assert meta.get("odd_stress_proxy") == "public_event_disruption"
+
+    def test_schema_validation_passes(self) -> None:
+        """Scenario entry passes JSON-schema validation."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        errors = validate_scenario_list([dict(s) for s in scenarios])
+        assert errors == [], f"Schema validation errors: {errors}"
+
+    def test_build_robot_config_succeeds(self) -> None:
+        """build_robot_config_from_scenario runs without error."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        scenario = next(
+            (
+                s
+                for s in scenarios
+                if s.get("name") == "event_disruption_public_exit_blocked_path_v1"
+            ),
+            None,
+        )
+        assert scenario is not None
+        build_robot_config_from_scenario(scenario, scenario_path=SCENARIO_ARCHETYPE)
+
+
+class TestEventDisruptionManifest:
+    """The manifest wrapper loads and expands correctly."""
+
+    def test_manifest_loads_included_scenario(self) -> None:
+        """Manifest include expands to the archetype scenario."""
+        scenarios = load_scenarios(SCENARIO_MANIFEST)
+        assert len(scenarios) >= 1
+        names = {s.get("name") for s in scenarios}
+        assert "event_disruption_public_exit_blocked_path_v1" in names
+
+    def test_seeds_present(self) -> None:
+        """Scenario has multiple seeds for reproducible evaluation."""
+        scenarios = load_scenarios(SCENARIO_ARCHETYPE)
+        scenario = next(
+            (
+                s
+                for s in scenarios
+                if s.get("name") == "event_disruption_public_exit_blocked_path_v1"
+            ),
+            None,
+        )
+        assert scenario is not None
+        seeds = scenario.get("seeds")
+        assert isinstance(seeds, list)
+        assert len(seeds) >= 2


### PR DESCRIPTION
Add experimental event_disruption scenario family for stress-testing shared-space autonomy under public-event conditions (inspired by Waymo July 4 SF disruption).

## What/Why

Creates an ODD-stress proxy scenario family for public-event disruption testing:
- dense bidirectional pedestrian flow
- temporary path blockage
- nonstandard hazard object
- non-cooperative pedestrian behavior
- explicit expected failure modes in metadata

## Files

- configs/scenarios/single/event_disruption_public_exit.yaml
- configs/scenarios/event_disruption.yaml
- tests/scenarios/test_event_disruption_scenarios.py
- docs/context/issue_4759_event_disruption_scenarios.md

## Validation

```bash
uv run pytest tests/scenarios/test_event_disruption_scenarios.py -q
# 13 passed

uv run ruff check tests/scenarios/test_event_disruption_scenarios.py
# All checks passed
```

## Acceptance Criteria

- [x] event_disruption scenario metadata exists and can be selected from the scenario runner
- [x] Scenario records expected failure modes (fallback_brake, stuck, near_miss, excessive_pedestrian_disruption, collision_with_hazard)
- [x] Reuses existing 2D simulation primitives (no robotaxi infrastructure required)
- [x] Documentation explicitly states this is an ODD-stress proxy, not a real-world event model

## Claim Boundary

This PR was produced by the SAIA/Qwen3.5-397B-A17B cheap implementation lane; the review gate hardens and merges.

Closes #4759