### PR TITLE
Issue #4777: publication figure style pack (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/figures/__init__.py
+++ b/robot_sf/benchmark/figures/__init__.py
@@ -2,14 +2,40 @@
 
 This package contains modules for generating various figures used in
 benchmark analysis and reporting.
+
+For publication-grade figures, use the :mod:`robot_sf.benchmark.figures.style`,
+:mod:`robot_sf.benchmark.figures.provenance`, and :mod:`robot_sf.benchmark.figures.export`
+modules.
 """
 
+from robot_sf.benchmark.figures.export import save_publication_figure
 from robot_sf.benchmark.figures.force_field import generate_force_field_figure
+from robot_sf.benchmark.figures.provenance import (
+    build_caption_fragment,
+    build_provenance,
+    write_caption_fragment,
+    write_provenance,
+)
+from robot_sf.benchmark.figures.style import (
+    figure_size,
+    planner_color,
+    planner_palette,
+    publication_style,
+)
 from robot_sf.benchmark.figures.thumbnails import ThumbMeta, save_montage, save_scenario_thumbnails
 
 __all__ = [
     "ThumbMeta",
+    "build_caption_fragment",
+    "build_provenance",
+    "figure_size",
     "generate_force_field_figure",
+    "planner_color",
+    "planner_palette",
+    "publication_style",
     "save_montage",
+    "save_publication_figure",
     "save_scenario_thumbnails",
+    "write_caption_fragment",
+    "write_provenance",
 ]

--- a/robot_sf/benchmark/figures/export.py
+++ b/robot_sf/benchmark/figures/export.py
@@ -1,0 +1,138 @@
+"""Vector and raster export helper for publication figures.
+
+This module provides utilities for saving matplotlib figures in multiple
+formats (PDF, PNG, SVG) with embedded metadata and provenance sidecars.
+
+Usage:
+    from robot_sf.benchmark.figures.export import save_publication_figure
+
+    paths = save_publication_figure(
+        fig,
+        output_base=Path("output/figure"),
+        formats=("pdf", "png"),
+        provenance={"source_artifacts": [...]},
+        caption_fragment="Campaign: example | Episodes: ep1, ep2",
+    )
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from robot_sf.benchmark.figures.provenance import (
+    build_provenance,
+    write_caption_fragment,
+    write_provenance,
+)
+
+
+def save_publication_figure(
+    fig,
+    output_base: Path,
+    *,
+    formats: tuple[str, ...] = ("pdf",),
+    provenance: dict[str, Any] | None = None,
+    caption_fragment: str | None = None,
+    timestamp=None,
+) -> list[Path]:
+    """Save a figure in multiple formats with provenance sidecar.
+
+    Args:
+        fig: Matplotlib figure object.
+        output_base: Base path for output (without extension).
+        formats: Tuple of output formats ("pdf", "png", "svg").
+        provenance: Optional provenance metadata dictionary.
+        caption_fragment: Optional LaTeX-ready caption fragment.
+        timestamp: Optional timestamp override for deterministic testing.
+
+    Returns:
+        List of paths to generated files (including sidecar).
+
+    Raises:
+        ValueError: If no valid formats specified.
+        RuntimeError: If matplotlib is not available.
+    """
+    if not formats:
+        raise ValueError("At least one format must be specified")
+
+    # Ensure matplotlib is available
+    try:
+        plt = importlib.import_module("matplotlib.pyplot")
+    except ImportError:
+        raise RuntimeError("matplotlib is required for figure export")
+
+    # Ensure output directory exists
+    output_base.parent.mkdir(parents=True, exist_ok=True)
+
+    # Build provenance if not provided
+    if provenance is None:
+        provenance = build_provenance(
+            generator_command="save_publication_figure",
+            figure_formats=list(formats),
+        )
+
+    # Save in each format
+    saved_files: list[Path] = []
+    for fmt in formats:
+        if fmt not in ("pdf", "png", "svg"):
+            raise ValueError(f"Unsupported format: {fmt!r}. Must be 'pdf', 'png', or 'svg'.")
+
+        output_path = output_base.parent / f"{output_base.name}.{fmt}"
+
+        # Save with appropriate settings
+        save_kwargs: dict[str, Any] = {
+            "format": fmt,
+            "bbox_inches": "tight",
+            "pad_inches": 0.05,
+        }
+
+        # Add metadata for PDF and PNG
+        if fmt == "pdf":
+            save_kwargs["metadata"] = {
+                "Title": output_base.name,
+                "Author": "Robot SF Benchmark",
+                "Subject": "Publication figure",
+                "Creator": "robot_sf benchmark visualization",
+            }
+        elif fmt == "png":
+            save_kwargs["dpi"] = 300
+
+        plt.savefig(output_path, **save_kwargs)
+        saved_files.append(output_path)
+
+        # Add to provenance output hashes
+        if "output_hashes" not in provenance:
+            provenance["output_hashes"] = {}
+        provenance["output_hashes"][output_path.name] = _file_sha256(output_path)
+
+    # Write provenance sidecar
+    provenance_path = write_provenance(output_base, provenance, timestamp=timestamp)
+    saved_files.append(provenance_path)
+
+    # Write caption fragment if provided
+    if caption_fragment is not None:
+        caption_path = write_caption_fragment(output_base, caption_fragment)
+        saved_files.append(caption_path)
+
+    return saved_files
+
+
+def _file_sha256(path: Path) -> str:
+    """Compute SHA-256 hash of a file.
+
+    Args:
+        path: Path to file.
+
+    Returns:
+        Hex digest of SHA-256 hash.
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/robot_sf/benchmark/figures/provenance.py
+++ b/robot_sf/benchmark/figures/provenance.py
@@ -1,0 +1,204 @@
+"""Provenance sidecar builder for publication figures.
+
+This module handles creation of provenance metadata files (.provenance.json)
+for generated figures, including source artifact hashes, seeds, config hashes,
+and generator commands.
+
+Usage:
+    from robot_sf.benchmark.figures.provenance import build_provenance, write_provenance
+
+    provenance = build_provenance(
+        source_artifacts=[{"path": "data.jsonl", "hash": "abc123"}],
+        generator_command="scripts/generate_figures.py --episodes data.jsonl",
+    )
+    write_provenance(Path("output/figure"), provenance)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+def _git_sha_short(length: int = 7) -> str:
+    """Get short git SHA for current HEAD.
+
+    Returns:
+        Short git SHA string or "unknown" if unavailable.
+    """
+    try:
+        sha = (
+            subprocess.check_output(
+                ["git", "rev-parse", f"--short={length}", "HEAD"],
+                stderr=subprocess.DEVNULL,
+            )
+            .decode("utf-8")
+            .strip()
+        )
+        return sha or "unknown"
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return "unknown"
+
+
+def _file_sha256(path: Path) -> str:
+    """Compute SHA-256 hash of a file.
+
+    Args:
+        path: Path to file.
+
+    Returns:
+        Hex digest of SHA-256 hash.
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+@dataclass
+class ProvenanceConfig:
+    """Configuration for building provenance metadata."""
+
+    source_artifacts: list[dict[str, Any]] = field(default_factory=list)
+    seeds: list[int] = field(default_factory=list)
+    episode_ids: list[str] = field(default_factory=list)
+    config_path: str | None = None
+    scenario_matrix_path: str | None = None
+    generator_command: str | None = None
+    figure_formats: list[str] = field(default_factory=list)
+    output_files: list[Path] = field(default_factory=list)
+    claim_boundary: str | None = None
+
+
+def build_provenance(config: ProvenanceConfig | None = None, **kwargs: Any) -> dict[str, Any]:
+    """Build provenance metadata dictionary.
+
+    Args:
+        config: Optional ProvenanceConfig object. If provided, kwargs are ignored.
+        **kwargs: Individual configuration values (for backward compatibility).
+
+    Returns:
+        Dictionary of provenance metadata.
+    """
+    if config is None:
+        config = ProvenanceConfig(**kwargs)
+
+    provenance: dict[str, Any] = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "repo_commit": _git_sha_short(),
+        "generator_command": config.generator_command or "unknown",
+        "source_artifacts": config.source_artifacts or [],
+        "seeds": config.seeds or [],
+        "episode_ids": config.episode_ids or [],
+        "figure_formats": config.figure_formats or [],
+        "output_hashes": {},
+    }
+
+    if config.config_path:
+        config_path = Path(config.config_path)
+        if config_path.exists():
+            provenance["config_path"] = str(config_path)
+            provenance["config_hash"] = _file_sha256(config_path)
+
+    if config.scenario_matrix_path:
+        matrix_path = Path(config.scenario_matrix_path)
+        if matrix_path.exists():
+            provenance["scenario_matrix_path"] = str(matrix_path)
+            provenance["scenario_matrix_hash"] = _file_sha256(matrix_path)
+
+    if config.output_files:
+        for output_file in config.output_files:
+            if output_file.exists():
+                provenance["output_hashes"][output_file.name] = _file_sha256(output_file)
+
+    if config.claim_boundary:
+        provenance["claim_boundary"] = config.claim_boundary
+
+    return provenance
+
+
+def write_provenance(
+    output_base: Path,
+    provenance: dict[str, Any],
+    *,
+    timestamp: datetime | None = None,
+) -> Path:
+    """Write provenance sidecar file.
+
+    Args:
+        output_base: Base path for the figure (without extension).
+        provenance: Provenance metadata dictionary.
+        timestamp: Optional timestamp override for deterministic testing.
+
+    Returns:
+        Path to written provenance file.
+    """
+    provenance_path = output_base.parent / f"{output_base.name}.provenance.json"
+
+    # Use provided timestamp or current time
+    provenance_copy = dict(provenance)
+    if timestamp is not None:
+        provenance_copy["generated_at"] = timestamp.isoformat()
+
+    provenance_path.write_text(
+        json.dumps(provenance_copy, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return provenance_path
+
+
+def build_caption_fragment(
+    *,
+    campaign_name: str | None = None,
+    episode_ids: list[str] | None = None,
+    scenario_id: str | None = None,
+) -> str:
+    """Build a LaTeX-ready caption fragment.
+
+    Args:
+        campaign_name: Name of the benchmark campaign.
+        episode_ids: List of episode identifiers.
+        scenario_id: Scenario identifier.
+
+    Returns:
+        LaTeX-ready one-liner caption.
+    """
+    parts = []
+    if campaign_name:
+        parts.append(f"Campaign: {campaign_name}")
+    if scenario_id:
+        parts.append(f"Scenario: {scenario_id}")
+    if episode_ids:
+        ep_str = ", ".join(episode_ids[:3])
+        if len(episode_ids) > 3:
+            ep_str += f", ... ({len(episode_ids)} total)"
+        parts.append(f"Episodes: {ep_str}")
+
+    if not parts:
+        return "\\textit{No provenance data}"
+
+    return " | ".join(parts)
+
+
+def write_caption_fragment(
+    output_base: Path,
+    caption: str,
+) -> Path:
+    """Write caption fragment file.
+
+    Args:
+        output_base: Base path for the figure (without extension).
+        caption: LaTeX-ready caption text.
+
+    Returns:
+        Path to written caption file.
+    """
+    caption_path = output_base.parent / f"{output_base.name}.caption.tex"
+    caption_path.write_text(caption, encoding="utf-8")
+    return caption_path

--- a/robot_sf/benchmark/figures/style.py
+++ b/robot_sf/benchmark/figures/style.py
@@ -1,0 +1,160 @@
+"""Publication-grade figure style context for benchmark visualization.
+
+This module provides an opt-in style context for generating publication-ready
+figures with consistent typography, colorblind-safe planner palette, and
+standardized sizing presets.
+
+Usage:
+    from robot_sf.benchmark.figures.style import publication_style, planner_color
+
+    with publication_style(size="single"):
+        fig, ax = plt.subplots()
+        # ... plot with publication styling ...
+"""
+
+from __future__ import annotations
+
+import importlib
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# Colorblind-safe palette for planners (Wong 2011 + custom extensions)
+# These colors are distinguishable under common color vision deficiencies
+_PLANNER_COLORS: dict[str, str] = {
+    "goal": "#E69F00",  # Orange
+    "orca": "#56B4E9",  # Sky blue
+    "social_force": "#009E73",  # Bluish green
+    "socnav_sampling": "#F0E442",  # Yellow
+    "ppo": "#0072B2",  # Blue
+    "sacadrl": "#D55E00",  # Vermillion
+    "prediction_planner": "#CC79A7",  # Reddish purple
+    "prediction_mpc": "#999999",  # Gray
+}
+
+# Fallback palette for unknown planners (cycles through these)
+_FALLBACK_PALETTE: list[str] = [
+    "#E69F00",
+    "#56B4E9",
+    "#009E73",
+    "#F0E442",
+    "#0072B2",
+    "#D55E00",
+    "#CC79A7",
+    "#999999",
+    "#66A61E",
+    "#E7298A",
+    "#7570B3",
+    "#A6761D",
+]
+
+
+def planner_palette() -> dict[str, str]:
+    """Return the canonical planner-to-color mapping.
+
+    Returns:
+        Dictionary mapping planner key names to hex color strings.
+    """
+    return dict(_PLANNER_COLORS)
+
+
+def planner_color(planner_key: str) -> str:
+    """Get the color for a specific planner.
+
+    For known planners, returns the fixed color. For unknown planners,
+    returns a deterministic fallback color based on a hash of the key.
+
+    Args:
+        planner_key: The planner identifier (e.g., "goal", "orca").
+
+    Returns:
+        Hex color string for the planner.
+    """
+    if planner_key in _PLANNER_COLORS:
+        return _PLANNER_COLORS[planner_key]
+
+    # Deterministic fallback: hash the key to select from fallback palette
+    idx = hash(planner_key) % len(_FALLBACK_PALETTE)
+    return _FALLBACK_PALETTE[idx]
+
+
+def figure_size(size: Literal["single", "double"]) -> tuple[float, float]:
+    """Get figure dimensions for publication layout.
+
+    Args:
+        size: Either "single" (~3.4 inches) or "double" (~7 inches).
+
+    Returns:
+        Tuple of (width, height) in inches.
+
+    Raises:
+        ValueError: If size is not "single" or "double".
+    """
+    if size == "single":
+        return (3.4, 2.5)
+    elif size == "double":
+        return (7.0, 4.0)
+    else:
+        raise ValueError(f"Invalid figure size: {size!r}. Must be 'single' or 'double'.")
+
+
+@contextmanager
+def publication_style(*, size: Literal["single", "double"] = "single") -> Iterator[None]:
+    """Context manager for publication-grade matplotlib styling.
+
+    Applies consistent typography, colorblind-safe colors, and sizing.
+    Restores original rcParams on exit.
+
+    Args:
+        size: Figure size preset ("single" or "double").
+
+    Yields:
+        None (context manager).
+
+    Example:
+        with publication_style(size="single"):
+            fig, ax = plt.subplots()
+            # ... plot ...
+    """
+    plt = importlib.import_module("matplotlib.pyplot")
+    original_params = dict(plt.rcParams)
+
+    try:
+        # Apply publication style
+        plt.rcParams.update(
+            {
+                # Typography: serif fonts compatible with LaTeX
+                "font.family": "serif",
+                "font.serif": ["Times New Roman", "DejaVu Serif", "serif"],
+                "font.size": 10,
+                "axes.labelsize": 11,
+                "axes.titlesize": 12,
+                "legend.fontsize": 9,
+                "xtick.labelsize": 9,
+                "ytick.labelsize": 9,
+                # Figure sizing
+                "figure.figsize": figure_size(size),
+                "figure.dpi": 150,
+                # Line and marker styles
+                "lines.linewidth": 1.5,
+                "lines.markersize": 4,
+                # Grid and spines
+                "axes.grid": False,
+                "axes.spines.top": False,
+                "axes.spines.right": False,
+                # Legend
+                "legend.frameon": False,
+                "legend.loc": "best",
+                # Save settings
+                "savefig.dpi": 300,
+                "savefig.bbox": "tight",
+                "savefig.pad_inches": 0.05,
+            }
+        )
+        yield
+    finally:
+        # Restore original rcParams
+        plt.rcParams.update(original_params)

--- a/robot_sf/benchmark/figures/style.py
+++ b/robot_sf/benchmark/figures/style.py
@@ -14,6 +14,7 @@ Usage:
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Literal
@@ -76,8 +77,12 @@ def planner_color(planner_key: str) -> str:
     if planner_key in _PLANNER_COLORS:
         return _PLANNER_COLORS[planner_key]
 
-    # Deterministic fallback: hash the key to select from fallback palette
-    idx = hash(planner_key) % len(_FALLBACK_PALETTE)
+    # Deterministic fallback: use a stable hash so an unknown planner keeps the
+    # same color across processes/figures. Python's builtin hash() is salted per
+    # process (PYTHONHASHSEED), so it must NOT be used here — it would give the
+    # same planner a different color in each figure-generation run.
+    digest = hashlib.sha256(planner_key.encode("utf-8")).digest()
+    idx = int.from_bytes(digest[:8], "big") % len(_FALLBACK_PALETTE)
     return _FALLBACK_PALETTE[idx]
 
 

--- a/tests/benchmark/test_publication_figure_style.py
+++ b/tests/benchmark/test_publication_figure_style.py
@@ -1,0 +1,323 @@
+"""Tests for publication figure style pack.
+
+This module tests the publication-style context, planner palette,
+vector export, and provenance sidecar functionality.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from robot_sf.benchmark.figures.export import save_publication_figure
+from robot_sf.benchmark.figures.provenance import (
+    build_caption_fragment,
+    build_provenance,
+    write_caption_fragment,
+    write_provenance,
+)
+from robot_sf.benchmark.figures.style import (
+    figure_size,
+    planner_color,
+    planner_palette,
+    publication_style,
+)
+
+
+class TestPlannerPalette:
+    """Tests for planner color palette."""
+
+    def test_planner_palette_returns_known_planners(self):
+        """Verify known planners are in the palette."""
+        palette = planner_palette()
+        assert "goal" in palette
+        assert "orca" in palette
+        assert "social_force" in palette
+        assert "ppo" in palette
+
+    def test_planner_color_known_planner(self):
+        """Verify known planners return fixed colors."""
+        assert planner_color("goal") == "#E69F00"
+        assert planner_color("orca") == "#56B4E9"
+
+    def test_planner_color_unknown_planner_deterministic(self):
+        """Verify unknown planners return deterministic fallback colors."""
+        color1 = planner_color("unknown_planner_xyz")
+        color2 = planner_color("unknown_planner_xyz")
+        assert color1 == color2
+
+    def test_planner_color_unknown_planner_hex_format(self):
+        """Verify unknown planner colors are valid hex."""
+        color = planner_color("unknown_planner")
+        assert color.startswith("#")
+        assert len(color) == 7
+
+
+class TestFigureSize:
+    """Tests for figure size presets."""
+
+    def test_single_column_size(self):
+        """Verify single-column size is approximately 3.4 inches."""
+        w, h = figure_size("single")
+        assert abs(w - 3.4) < 0.1
+        assert h > 0
+
+    def test_double_column_size(self):
+        """Verify double-column size is approximately 7 inches."""
+        w, h = figure_size("double")
+        assert abs(w - 7.0) < 0.1
+        assert h > 0
+
+    def test_invalid_size_raises(self):
+        """Verify invalid size raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid figure size"):
+            figure_size("invalid")
+
+
+class TestPublicationStyle:
+    """Tests for publication style context manager."""
+
+    def test_restores_rcparams_after_exit(self):
+        """Verify rcParams are restored after context exit."""
+        plt = pytest.importorskip("matplotlib.pyplot")
+        original_font = plt.rcParams["font.family"]
+
+        with publication_style():
+            # Inside context, font should be serif
+            assert "serif" in plt.rcParams["font.family"] or "serif" in str(
+                plt.rcParams["font.serif"]
+            )
+
+        # After exit, should be restored
+        assert plt.rcParams["font.family"] == original_font
+
+    def test_single_size_sets_figure_size(self):
+        """Verify single size sets correct figure dimensions."""
+        plt = pytest.importorskip("matplotlib.pyplot")
+
+        with publication_style(size="single"):
+            assert abs(plt.rcParams["figure.figsize"][0] - 3.4) < 0.1
+
+    def test_double_size_sets_figure_size(self):
+        """Verify double size sets correct figure dimensions."""
+        plt = pytest.importorskip("matplotlib.pyplot")
+
+        with publication_style(size="double"):
+            assert abs(plt.rcParams["figure.figsize"][0] - 7.0) < 0.1
+
+
+class TestProvenance:
+    """Tests for provenance sidecar builder."""
+
+    def test_build_provenance_minimal(self):
+        """Verify minimal provenance has required fields."""
+        provenance = build_provenance()
+        assert "generated_at" in provenance
+        assert "repo_commit" in provenance
+        assert "generator_command" in provenance
+
+    def test_build_provenance_with_source_artifacts(self):
+        """Verify provenance includes source artifacts."""
+        artifacts = [{"path": "data.jsonl", "hash": "abc123"}]
+        provenance = build_provenance(source_artifacts=artifacts)
+        assert provenance["source_artifacts"] == artifacts
+
+    def test_write_provenance_creates_file(self, tmp_path):
+        """Verify write_provenance creates a JSON file."""
+        output_base = tmp_path / "figure"
+        output_base.mkdir()
+        provenance = build_provenance()
+
+        path = write_provenance(output_base / "test", provenance)
+        assert path.exists()
+        assert path.suffix == ".json"
+
+    def test_write_provenance_is_deterministic(self, tmp_path):
+        """Verify same inputs produce identical provenance content."""
+        output_base = tmp_path / "figure"
+        output_base.mkdir()
+        provenance = build_provenance()
+
+        # Write twice with fixed timestamp
+        fixed_time = datetime(2026, 1, 1, tzinfo=UTC)
+        path1 = write_provenance(output_base / "test", provenance, timestamp=fixed_time)
+        path2 = write_provenance(output_base / "test2", provenance, timestamp=fixed_time)
+
+        content1 = json.loads(path1.read_text())
+        content2 = json.loads(path2.read_text())
+
+        # Compare ignoring output_hashes (different filenames)
+        content1.pop("output_hashes", None)
+        content2.pop("output_hashes", None)
+        assert content1 == content2
+
+    def test_build_caption_fragment(self):
+        """Verify caption fragment includes campaign and episodes."""
+        caption = build_caption_fragment(
+            campaign_name="test_campaign",
+            episode_ids=["ep1", "ep2", "ep3"],
+        )
+        assert "test_campaign" in caption
+        assert "ep1" in caption
+
+    def test_write_caption_fragment_creates_file(self, tmp_path):
+        """Verify write_caption_fragment creates a .caption.tex file."""
+        output_base = tmp_path / "figure"
+        output_base.mkdir()
+        caption = "Test caption"
+
+        path = write_caption_fragment(output_base / "test", caption)
+        assert path.exists()
+        assert path.suffix == ".tex"
+        assert path.read_text() == caption
+
+
+class TestExport:
+    """Tests for figure export helper."""
+
+    def test_save_publication_figure_pdf(self, tmp_path):
+        """Verify PDF export creates file and sidecar."""
+        plt = pytest.importorskip("matplotlib.pyplot")
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        paths = save_publication_figure(
+            fig,
+            tmp_path / "test_figure",
+            formats=("pdf",),
+            provenance=build_provenance(generator_command="test"),
+        )
+
+        plt.close(fig)
+
+        # Should have PDF and provenance
+        assert any(p.suffix == ".pdf" for p in paths)
+        assert any(".provenance.json" in p.name for p in paths)
+
+    def test_save_publication_figure_png(self, tmp_path):
+        """Verify PNG export creates file."""
+        plt = pytest.importorskip("matplotlib.pyplot")
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        paths = save_publication_figure(
+            fig,
+            tmp_path / "test_figure",
+            formats=("png",),
+            provenance=build_provenance(generator_command="test"),
+        )
+
+        plt.close(fig)
+
+        assert any(p.suffix == ".png" for p in paths)
+
+    def test_save_publication_figure_svg(self, tmp_path):
+        """Verify SVG export creates file."""
+        plt = pytest.importorskip("matplotlib.pyplot")
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        paths = save_publication_figure(
+            fig,
+            tmp_path / "test_figure",
+            formats=("svg",),
+            provenance=build_provenance(generator_command="test"),
+        )
+
+        plt.close(fig)
+
+        assert any(p.suffix == ".svg" for p in paths)
+
+    def test_save_publication_figure_with_caption(self, tmp_path):
+        """Verify caption fragment is written when provided."""
+        plt = pytest.importorskip("matplotlib.pyplot")
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        paths = save_publication_figure(
+            fig,
+            tmp_path / "test_figure",
+            formats=("pdf",),
+            caption_fragment="Test caption",
+        )
+
+        plt.close(fig)
+
+        assert any(".caption.tex" in p.name for p in paths)
+
+    def test_save_publication_figure_provenance_content(self, tmp_path):
+        """Verify provenance includes source hashes and command."""
+        plt = pytest.importorskip("matplotlib.pyplot")
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        provenance = build_provenance(
+            source_artifacts=[{"path": "data.jsonl", "hash": "abc123"}],
+            generator_command="test command",
+        )
+
+        paths = save_publication_figure(
+            fig,
+            tmp_path / "test_figure",
+            formats=("pdf",),
+            provenance=provenance,
+        )
+
+        plt.close(fig)
+
+        # Find provenance file
+        prov_path = next(p for p in paths if ".provenance.json" in p.name)
+        content = json.loads(prov_path.read_text())
+
+        assert content["generator_command"] == "test command"
+        assert content["source_artifacts"][0]["path"] == "data.jsonl"
+
+    def test_save_publication_figure_empty_formats_raises(self, tmp_path):
+        """Verify empty formats raises ValueError."""
+        plt = pytest.importorskip("matplotlib.pyplot")
+
+        fig, _ax = plt.subplots()
+
+        with pytest.raises(ValueError, match="At least one format"):
+            save_publication_figure(fig, tmp_path / "test", formats=())
+
+        plt.close(fig)
+
+
+class TestStyleDoesNotAlterData:
+    """Tests verifying style context does not alter plotted data."""
+
+    def test_plot_values_unchanged_by_style(self):
+        """Verify style context does not modify plot data."""
+        plt = pytest.importorskip("matplotlib.pyplot")
+
+        # Create a figure with known data
+        fig, ax = plt.subplots()
+        x_data = [1.0, 2.0, 3.0]
+        y_data = [4.0, 5.0, 6.0]
+        ax.plot(x_data, y_data)
+
+        # Get line data before style
+        line_before = ax.lines[0]
+        x_before = list(line_before.get_xdata())
+        y_before = list(line_before.get_ydata())
+
+        # Apply style
+        with publication_style():
+            # Get line data during style
+            line_during = ax.lines[0]
+            x_during = list(line_during.get_xdata())
+            y_during = list(line_during.get_ydata())
+
+        # Data should be unchanged
+        assert x_before == x_during
+        assert y_before == y_during
+
+        plt.close(fig)

--- a/tests/benchmark/test_publication_figure_style.py
+++ b/tests/benchmark/test_publication_figure_style.py
@@ -48,6 +48,18 @@ class TestPlannerPalette:
         color2 = planner_color("unknown_planner_xyz")
         assert color1 == color2
 
+    def test_planner_color_unknown_planner_stable_across_processes(self):
+        """Pin fallback colors so an unknown planner keeps its color everywhere.
+
+        The fallback must use a stable hash (not Python's per-process salted
+        ``hash()``); otherwise the same planner would get a different color in
+        each figure-generation run. These pinned values encode that contract:
+        if the fallback hashing changes, this test fails on purpose.
+        """
+        assert planner_color("planner_a") == "#66A61E"
+        assert planner_color("planner_b") == "#CC79A7"
+        assert planner_color("planner_c") == "#0072B2"
+
     def test_planner_color_unknown_planner_hex_format(self):
         """Verify unknown planner colors are valid hex."""
         color = planner_color("unknown_planner")


### PR DESCRIPTION
## What and Why

This PR implements the publication figure style pack requested in issue #4777:

1. **Style context** ()
   - Opt-in  context manager
   - Colorblind-safe planner palette (Wong 2011) with deterministic fallback
   - Single (~3.4in) and double (~7in) column size presets
   - Serif/TeX-compatible typography without requiring local TeX installation
   - Context manager restores original matplotlib rcParams on exit

2. **Provenance sidecar** ()
   -  creates metadata dict with source artifact SHA-256 hashes
   - Tracks seeds, episode IDs, config path/hash, scenario matrix, repo commit, generator command
   -  writes  sidecar files
   -  generates LaTeX-ready one-liner captions

3. **Vector export** ()
   -  saves figures in PDF, PNG, and/or SVG formats
   - Writes provenance sidecar and optional caption fragment automatically
   - Adds PDF metadata (Title, Author, Subject, Creator)
   - PNG export at 300 DPI for publication quality

4. **Tests** ()
   - 23 tests covering all new functionality
   - Verifies style context does not alter plotted data values
   - Tests rcParams restoration after context exit
   - Tests deterministic provenance generation
   - Tests PDF, PNG, SVG export with sidecars

## Validation

.......................                                                  [100%]
============================= slowest 10 durations =============================
0.10s call     tests/benchmark/test_publication_figure_style.py::TestExport::test_save_publication_figure_pdf
0.09s call     tests/benchmark/test_publication_figure_style.py::TestExport::test_save_publication_figure_png
0.05s call     tests/benchmark/test_publication_figure_style.py::TestExport::test_save_publication_figure_provenance_content
0.05s call     tests/benchmark/test_publication_figure_style.py::TestExport::test_save_publication_figure_svg
0.05s call     tests/benchmark/test_publication_figure_style.py::TestExport::test_save_publication_figure_with_caption
0.01s call     tests/benchmark/test_publication_figure_style.py::TestProvenance::test_write_provenance_is_deterministic
0.01s call     tests/benchmark/test_publication_figure_style.py::TestProvenance::test_write_provenance_creates_file

(3 durations < 0.005s hidden.  Use -vv to show these durations.)

Slow Test Report (soft<20s hard=60s, top 10)
1) tests/benchmark/test_publication_figure_style.py::TestExport::test_save_publication_figure_pdf  0.10s
2) tests/benchmark/test_publication_figure_style.py::TestExport::test_save_publication_figure_png  0.09s
3) tests/benchmark/test_publication_figure_style.py::TestExport::test_save_publication_figure_provenance_content  0.05s
4) tests/benchmark/test_publication_figure_style.py::TestExport::test_save_publication_figure_svg  0.05s
5) tests/benchmark/test_publication_figure_style.py::TestExport::test_save_publication_figure_with_caption  0.05s
6) tests/benchmark/test_publication_figure_style.py::TestProvenance::test_write_provenance_is_deterministic  0.01s
7) tests/benchmark/test_publication_figure_style.py::TestProvenance::test_write_provenance_creates_file  0.01s
8) tests/benchmark/test_publication_figure_style.py::TestProvenance::test_build_provenance_with_source_artifacts  0.00s
9) tests/benchmark/test_publication_figure_style.py::TestProvenance::test_build_provenance_minimal  0.00s
10) tests/benchmark/test_publication_figure_style.py::TestStyleDoesNotAlterData::test_plot_values_unchanged_by_style  0.00s

23 passed in 0.55s
All checks passed!
7 files left unchanged

## Successor Statement

This PR is the **first slice** of #4777: the standalone `robot_sf/benchmark/figures/{style,provenance,export}.py` module (opt-in style context, colorblind-safe planner palette, PDF/PNG/SVG export, provenance sidecars, caption fragments) with tests. It does **not** yet apply the pack to the existing generators (item 4), expose `--format` on existing figure CLIs (item 2), embed provenance in PDF/PNG metadata (item 3), or LaTeX-escape caption fragments. Those are tracked in **#4790**.

Refs #4777
Refs #4790

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added publication-ready figure export with support for multiple output formats and optional caption fragments.
  * Introduced provenance metadata generation for figures, including source tracking and output file hashes.
  * Added styling helpers for consistent figure sizing and color palettes, plus an easy-to-use publication styling mode.
* **Tests**
  * Added coverage for styling behavior, provenance output, caption fragment generation, and multi-format figure exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
