### PR TITLE
Issue #4778: exemplar selection (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/exemplar_selection.py
+++ b/robot_sf/benchmark/exemplar_selection.py
@@ -1,0 +1,429 @@
+"""Exemplar episode auto-selection for campaign review.
+
+Selects representative episodes per (planner x mechanism/outcome) cell from
+campaign episodes.jsonl.  Emits a deterministic selection manifest that can be
+fed into the replay bridge (#4776) or used for direct figure generation.
+
+Part of issue #4778: exemplar selection + multi-planner trajectory overlays.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import subprocess
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+SELECTION_MANIFEST_SCHEMA_VERSION = "exemplar-selection.v1"
+
+SelectionMode = Literal["median", "best", "worst"]
+
+VALID_MODES: frozenset[str] = frozenset({"median", "best", "worst"})
+
+# Metric direction: "lower" means smaller is better (e.g. collisions),
+# "higher" means larger is better (e.g. path_efficiency).
+MetricDirection = Literal["lower", "higher"]
+
+METRIC_DIRECTIONS: dict[str, MetricDirection] = {
+    "collisions": "lower",
+    "near_misses": "lower",
+    "comfort_exposure": "lower",
+    "clearing_distance_min": "higher",
+    "clearing_distance_avg": "higher",
+    "path_efficiency": "higher",
+    "time_to_goal_norm": "lower",
+    "energy": "lower",
+    "jerk_mean": "lower",
+    "socnavbench_path_irregularity": "lower",
+    "success": "higher",
+}
+
+
+class ExemplarSelectionError(Exception):
+    """Raised when exemplar selection inputs are malformed."""
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedEpisode:
+    """One selected exemplar episode within a cell."""
+
+    episode_id: str
+    planner_key: str
+    scenario_id: str
+    seed: int
+    selection_mode: SelectionMode
+    selection_rank: int
+    metric_value: float
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class SkippedCell:
+    """A (planner x mechanism/outcome) cell that was not evaluable."""
+
+    cell_key: str
+    reason: str
+
+
+@dataclass
+class SelectionManifest:
+    """The full exemplar selection manifest."""
+
+    schema_version: str = SELECTION_MANIFEST_SCHEMA_VERSION
+    source_episodes: str = ""
+    source_sha256: str = ""
+    group_by: list[str] = field(default_factory=list)
+    metric: str = ""
+    metric_direction: MetricDirection = "lower"
+    selected: list[SelectedEpisode] = field(default_factory=list)
+    skipped_cells: list[SkippedCell] = field(default_factory=list)
+    git_hash: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serializable dict.
+
+        Returns:
+            JSON-serializable dict representation.
+        """
+        return asdict(self)
+
+
+def _git_sha_short(length: int = 7) -> str:
+    """Return short git SHA for the current HEAD.
+
+    Returns:
+        Short git SHA or "unknown" if unavailable.
+    """
+    try:
+        sha = (
+            subprocess.check_output(
+                ["git", "rev-parse", f"--short={length}", "HEAD"],
+                stderr=subprocess.DEVNULL,
+            )
+            .decode("utf-8")
+            .strip()
+        )
+        return sha or "unknown"
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return "unknown"
+
+
+def _compute_file_sha256(path: Path) -> str:
+    """Compute SHA-256 of a file for provenance.
+
+    Returns:
+        Hex-encoded SHA-256 digest.
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _get_nested(record: dict[str, Any], path: str, default: Any = None) -> Any:
+    """Resolve a dotted-path value from a dict.
+
+    Returns:
+        Value at the dotted path, or *default* when any segment is missing.
+    """
+    cur: Any = record
+    for part in path.split("."):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return default
+    return cur
+
+
+def _normalize_planner_key(record: dict[str, Any]) -> str:
+    """Extract planner key from an episode record.
+
+    Returns:
+        Planner identifier string.
+    """
+    for path in ("algo", "scenario_params.algo", "algorithm_metadata.algorithm"):
+        val = _get_nested(record, path)
+        if val is not None:
+            return str(val).strip()
+    return "unknown_planner"
+
+
+def _normalize_mechanism_key(record: dict[str, Any]) -> str:
+    """Extract mechanism label from an episode record.
+
+    Returns:
+        Mechanism label string.
+    """
+    val = _get_nested(record, "mechanism_label")
+    if val is not None:
+        return str(val).strip()
+    return "unknown_mechanism"
+
+
+def _normalize_outcome_key(record: dict[str, Any]) -> str:
+    """Extract outcome classification from an episode record.
+
+    Returns:
+        Outcome classification string.
+    """
+    outcome = record.get("outcome", {})
+    if isinstance(outcome, dict):
+        if outcome.get("collision_event"):
+            return "collision"
+        if outcome.get("route_complete"):
+            return "success"
+        if outcome.get("timeout_event"):
+            return "timeout"
+    status = record.get("status")
+    if status is not None:
+        return str(status)
+    return "unknown_outcome"
+
+
+def _normalize_grouping_key(record: dict[str, Any], key: str) -> str:
+    """Extract and normalize a grouping key from an episode record.
+
+    Returns:
+        Normalized grouping key string.
+    """
+    if key == "planner_key":
+        return _normalize_planner_key(record)
+
+    if key == "mechanism_label":
+        return _normalize_mechanism_key(record)
+
+    if key == "outcome":
+        return _normalize_outcome_key(record)
+
+    # Generic dotted path
+    val = _get_nested(record, key)
+    if val is not None:
+        return str(val)
+    return f"unknown_{key}"
+
+
+def _extract_metric(record: dict[str, Any], metric: str) -> float | None:
+    """Extract a metric value from an episode record.
+
+    Returns:
+        Metric value or ``None`` when missing or non-finite.
+    """
+    metrics = record.get("metrics", {})
+    if not isinstance(metrics, dict):
+        return None
+
+    val = metrics.get(metric)
+    if val is None:
+        return None
+
+    if isinstance(val, bool):
+        return 1.0 if val else 0.0
+
+    if isinstance(val, (int, float)):
+        fval = float(val)
+        if math.isfinite(fval):
+            return fval
+        return None
+
+    return None
+
+
+def _build_cell_key(group_values: dict[str, str]) -> str:
+    """Build a deterministic cell key from group values.
+
+    Returns:
+        Deterministic cell key string.
+    """
+    parts = [f"{k}={v}" for k, v in sorted(group_values.items())]
+    return "|".join(parts)
+
+
+def _select_in_cell(
+    cell_episodes: list[dict[str, Any]],
+    metric: str,
+    metric_direction: MetricDirection,
+    modes: Sequence[SelectionMode],
+    group_values: dict[str, str],
+) -> tuple[list[SelectedEpisode], SkippedCell | None]:
+    """Select exemplars within one cell.
+
+    Returns:
+        Tuple of (selected episodes, optional skipped cell).
+    """
+    cell_key = _build_cell_key(group_values)
+
+    # Extract metric values
+    scored: list[tuple[float, dict[str, Any]]] = []
+    for ep in cell_episodes:
+        val = _extract_metric(ep, metric)
+        if val is not None:
+            scored.append((val, ep))
+
+    if not scored:
+        return [], SkippedCell(
+            cell_key=cell_key,
+            reason=f"metric '{metric}' missing or non-finite for all {len(cell_episodes)} episodes",
+        )
+
+    # Sort: lower is better or higher is better
+    reverse = metric_direction == "higher"
+    scored.sort(key=lambda x: x[0], reverse=reverse)
+
+    planner_key = group_values.get("planner_key", "unknown_planner")
+    results: list[SelectedEpisode] = []
+
+    for mode in modes:
+        if mode == "best":
+            idx = 0
+        elif mode == "worst":
+            idx = len(scored) - 1
+        else:  # median
+            idx = len(scored) // 2
+
+        val, ep = scored[idx]
+        episode_id = ep.get("episode_id", "")
+        scenario_id = ep.get("scenario_id", "")
+        seed = ep.get("seed", 0)
+
+        results.append(
+            SelectedEpisode(
+                episode_id=str(episode_id),
+                planner_key=planner_key,
+                scenario_id=str(scenario_id),
+                seed=int(seed),
+                selection_mode=mode,
+                selection_rank=idx,
+                metric_value=val,
+                reason=f"{mode} within {cell_key}",
+            )
+        )
+
+    return results, None
+
+
+def select_exemplars(
+    episodes: list[dict[str, Any]],
+    *,
+    group_by: Sequence[str],
+    metric: str,
+    metric_direction: MetricDirection | None = None,
+    modes: Sequence[SelectionMode] = ("median", "best", "worst"),
+) -> tuple[list[SelectedEpisode], list[SkippedCell]]:
+    """Select exemplar episodes grouped by cell keys.
+
+    Args:
+        episodes: Parsed episode records from JSONL.
+        group_by: Grouping keys (e.g., ``["planner_key", "outcome"]``).
+        metric: Metric name to rank by.
+        metric_direction: ``"lower"`` or ``"higher"``.  Auto-detected from
+            ``METRIC_DIRECTIONS`` when ``None``.
+        modes: Selection modes to apply per cell.
+
+    Returns:
+        Tuple of (selected episodes, skipped cells).
+    """
+    if metric_direction is None:
+        metric_direction = METRIC_DIRECTIONS.get(metric, "lower")
+
+    # Validate modes
+    for m in modes:
+        if m not in VALID_MODES:
+            raise ExemplarSelectionError(f"Invalid selection mode: {m!r}")
+
+    # Group episodes by cell
+    cells: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    cell_group_values: dict[str, dict[str, str]] = {}
+
+    for ep in episodes:
+        group_values = {}
+        for key in group_by:
+            group_values[key] = _normalize_grouping_key(ep, key)
+        cell_key = _build_cell_key(group_values)
+        cells[cell_key].append(ep)
+        cell_group_values[cell_key] = group_values
+
+    # Select within each cell
+    all_selected: list[SelectedEpisode] = []
+    all_skipped: list[SkippedCell] = []
+
+    for cell_key in sorted(cells.keys()):
+        selected, skipped = _select_in_cell(
+            cells[cell_key],
+            metric,
+            metric_direction,
+            modes,
+            cell_group_values[cell_key],
+        )
+        all_selected.extend(selected)
+        if skipped is not None:
+            all_skipped.append(skipped)
+
+    return all_selected, all_skipped
+
+
+def build_manifest(
+    *,
+    source_episodes_path: Path | str,
+    group_by: Sequence[str],
+    metric: str,
+    metric_direction: MetricDirection | None = None,
+    selected: list[SelectedEpisode],
+    skipped_cells: list[SkippedCell],
+) -> SelectionManifest:
+    """Build a complete selection manifest from selection results.
+
+    Returns:
+        Populated ``SelectionManifest``.
+    """
+    source_path = Path(source_episodes_path)
+    source_sha256 = _compute_file_sha256(source_path) if source_path.exists() else "unknown"
+
+    if metric_direction is None:
+        metric_direction = METRIC_DIRECTIONS.get(metric, "lower")
+
+    return SelectionManifest(
+        source_episodes=str(source_path),
+        source_sha256=source_sha256,
+        group_by=list(group_by),
+        metric=metric,
+        metric_direction=metric_direction,
+        selected=selected,
+        skipped_cells=skipped_cells,
+        git_hash=_git_sha_short(),
+    )
+
+
+def save_manifest(manifest: SelectionManifest, output_path: Path | str) -> Path:
+    """Write the selection manifest to a JSON file.
+
+    Returns:
+        Path to the written manifest file.
+    """
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as f:
+        json.dump(manifest.to_dict(), f, indent=2, sort_keys=False)
+    return output
+
+
+__all__ = [
+    "METRIC_DIRECTIONS",
+    "SELECTION_MANIFEST_SCHEMA_VERSION",
+    "ExemplarSelectionError",
+    "MetricDirection",
+    "SelectedEpisode",
+    "SelectionManifest",
+    "SelectionMode",
+    "SkippedCell",
+    "build_manifest",
+    "save_manifest",
+    "select_exemplars",
+]

--- a/scripts/select_exemplar_episodes.py
+++ b/scripts/select_exemplar_episodes.py
@@ -1,0 +1,135 @@
+"""Select exemplar episodes from campaign JSONL.
+
+Reads a campaign episodes.jsonl, groups by planner/mechanism/outcome cells,
+selects median/best/worst by a configured metric, and writes a selection
+manifest.
+
+Usage:
+  uv run python scripts/select_exemplar_episodes.py \\
+    --episodes <episodes.jsonl> \\
+    --group-by planner_key,outcome \\
+    --metric path_efficiency \\
+    --modes median,best,worst \\
+    --output-manifest output/exemplars/selection_manifest.json
+
+Part of issue #4778.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.aggregate import read_jsonl
+from robot_sf.benchmark.errors import EpisodeRecordInputError
+from robot_sf.benchmark.exemplar_selection import (
+    METRIC_DIRECTIONS,
+    ExemplarSelectionError,
+    build_manifest,
+    save_manifest,
+    select_exemplars,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Select exemplar episodes from campaign JSONL.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--episodes",
+        required=True,
+        type=Path,
+        help="Path to episodes.jsonl file.",
+    )
+    parser.add_argument(
+        "--group-by",
+        default="planner_key,outcome",
+        help="Comma-separated grouping keys (default: planner_key,outcome).",
+    )
+    parser.add_argument(
+        "--metric",
+        default="path_efficiency",
+        help="Metric to rank by (default: path_efficiency).",
+    )
+    parser.add_argument(
+        "--metric-direction",
+        choices=["lower", "higher"],
+        default=None,
+        help="Metric direction. Auto-detected for known metrics.",
+    )
+    parser.add_argument(
+        "--modes",
+        default="median,best,worst",
+        help="Comma-separated selection modes (default: median,best,worst).",
+    )
+    parser.add_argument(
+        "--output-manifest",
+        required=True,
+        type=Path,
+        help="Output path for selection_manifest.json.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run exemplar selection CLI."""
+    args = parse_args(argv)
+
+    episodes_path: Path = args.episodes
+    if not episodes_path.exists():
+        print(f"Error: episodes file not found: {episodes_path}", file=sys.stderr)
+        return 1
+
+    group_by = [k.strip() for k in args.group_by.split(",") if k.strip()]
+    modes = [m.strip() for m in args.modes.split(",") if m.strip()]
+    metric = args.metric
+    metric_direction = args.metric_direction
+
+    # Show direction hint
+    if metric_direction is None:
+        auto = METRIC_DIRECTIONS.get(metric, "lower")
+        print(f"Auto-detected metric direction for '{metric}': {auto}")
+
+    try:
+        episodes = read_jsonl(episodes_path)
+    except (EpisodeRecordInputError, FileNotFoundError) as exc:
+        print(f"Error reading episodes: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Read {len(episodes)} episodes from {episodes_path}")
+
+    try:
+        selected, skipped = select_exemplars(
+            episodes,
+            group_by=group_by,
+            metric=metric,
+            metric_direction=metric_direction,
+            modes=modes,
+        )
+    except ExemplarSelectionError as exc:
+        print(f"Selection error: {exc}", file=sys.stderr)
+        return 1
+
+    manifest = build_manifest(
+        source_episodes_path=episodes_path,
+        group_by=group_by,
+        metric=metric,
+        metric_direction=metric_direction,
+        selected=selected,
+        skipped_cells=skipped,
+    )
+
+    output_path = save_manifest(manifest, args.output_manifest)
+    print(f"Selected {len(selected)} exemplars across {len(group_by)} grouping keys")
+    if skipped:
+        print(f"Skipped {len(skipped)} cells (metric missing or non-finite)")
+    print(f"Manifest written to {output_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmark/test_exemplar_selection.py
+++ b/tests/benchmark/test_exemplar_selection.py
@@ -1,0 +1,342 @@
+"""Tests for exemplar episode selection (issue #4778).
+
+Validates:
+- Deterministic median selection for odd and even cell sizes
+- Best/worst obey metric direction
+- Missing metric creates skipped cell
+- Tie-breaking is deterministic
+- Manifest includes source hash and claim boundary
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.exemplar_selection import (
+    ExemplarSelectionError,
+    SelectionManifest,
+    build_manifest,
+    save_manifest,
+    select_exemplars,
+)
+
+
+def _make_episode(
+    episode_id: str,
+    planner: str,
+    scenario_id: str,
+    seed: int,
+    metric_value: float | None,
+    metric_name: str = "path_efficiency",
+    *,
+    outcome: str | None = None,
+) -> dict[str, any]:
+    """Create a minimal episode record for testing."""
+    metrics = {}
+    if metric_value is not None:
+        metrics[metric_name] = metric_value
+
+    outcome_dict = {"collision_event": False, "route_complete": False, "timeout_event": True}
+    if outcome == "success":
+        outcome_dict = {"collision_event": False, "route_complete": True, "timeout_event": False}
+    elif outcome == "collision":
+        outcome_dict = {"collision_event": True, "route_complete": False, "timeout_event": False}
+
+    return {
+        "episode_id": episode_id,
+        "scenario_id": scenario_id,
+        "seed": seed,
+        "algo": planner,
+        "metrics": metrics,
+        "outcome": outcome_dict,
+        "status": outcome if outcome else "timeout",
+    }
+
+
+class TestMedianSelection:
+    """Test median selection determinism."""
+
+    def test_odd_cell_size(self) -> None:
+        """Median of 3 episodes selects the middle one (index 1)."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, 0.5),
+            _make_episode("ep2", "orca", "s1", 2, 0.8),
+            _make_episode("ep3", "orca", "s1", 3, 0.3),
+        ]
+        selected, skipped = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            metric_direction="higher",
+            modes=["median"],
+        )
+        assert len(selected) == 1
+        assert len(skipped) == 0
+        # Sorted descending: [0.8, 0.5, 0.3], median index=1 -> 0.5 (ep1)
+        assert selected[0].episode_id == "ep1"
+        assert selected[0].selection_mode == "median"
+        assert selected[0].metric_value == 0.5
+
+    def test_even_cell_size(self) -> None:
+        """Median of 4 episodes selects index 2 (floor(n/2))."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, 0.1),
+            _make_episode("ep2", "orca", "s1", 2, 0.5),
+            _make_episode("ep3", "orca", "s1", 3, 0.8),
+            _make_episode("ep4", "orca", "s1", 4, 0.9),
+        ]
+        selected, _skipped = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            metric_direction="higher",
+            modes=["median"],
+        )
+        assert len(selected) == 1
+        # Sorted descending: [0.9, 0.8, 0.5, 0.1], median index=2 -> 0.5
+        assert selected[0].episode_id == "ep2"
+        assert selected[0].metric_value == 0.5
+
+
+class TestBestWorstDirection:
+    """Test that best/worst obey metric direction."""
+
+    def test_higher_is_better(self) -> None:
+        """With higher-is-better, best has highest value."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, 0.3),
+            _make_episode("ep2", "orca", "s1", 2, 0.9),
+            _make_episode("ep3", "orca", "s1", 3, 0.6),
+        ]
+        selected, _ = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            metric_direction="higher",
+            modes=["best", "worst"],
+        )
+        best = next(s for s in selected if s.selection_mode == "best")
+        worst = next(s for s in selected if s.selection_mode == "worst")
+        assert best.episode_id == "ep2"
+        assert best.metric_value == 0.9
+        assert worst.episode_id == "ep1"
+        assert worst.metric_value == 0.3
+
+    def test_lower_is_better(self) -> None:
+        """With lower-is-better, best has lowest value."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, 3, metric_name="collisions"),
+            _make_episode("ep2", "orca", "s1", 2, 0, metric_name="collisions"),
+            _make_episode("ep3", "orca", "s1", 3, 1, metric_name="collisions"),
+        ]
+        selected, _ = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="collisions",
+            metric_direction="lower",
+            modes=["best", "worst"],
+        )
+        best = next(s for s in selected if s.selection_mode == "best")
+        worst = next(s for s in selected if s.selection_mode == "worst")
+        assert best.episode_id == "ep2"
+        assert best.metric_value == 0.0
+        assert worst.episode_id == "ep1"
+        assert worst.metric_value == 3.0
+
+
+class TestMissingMetric:
+    """Test handling of missing or non-finite metric values."""
+
+    def test_all_missing_creates_skipped_cell(self) -> None:
+        """When all episodes have missing metric, cell is skipped."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, None),
+            _make_episode("ep2", "orca", "s1", 2, None),
+        ]
+        selected, skipped = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            modes=["median"],
+        )
+        assert len(selected) == 0
+        assert len(skipped) == 1
+        assert "missing" in skipped[0].reason.lower() or "non-finite" in skipped[0].reason.lower()
+
+    def test_partial_missing_selects_valid(self) -> None:
+        """Episodes with valid metric are selected; missing ones are ignored."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, None),
+            _make_episode("ep2", "orca", "s1", 2, 0.7),
+            _make_episode("ep3", "orca", "s1", 3, 0.9),
+        ]
+        selected, _skipped = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            metric_direction="higher",
+            modes=["median"],
+        )
+        assert len(selected) == 1
+        # Only 2 valid episodes, median index=1 -> 0.7
+        assert selected[0].metric_value == 0.7
+
+
+class TestTieBreaking:
+    """Test deterministic tie-breaking."""
+
+    def test_same_metric_value_different_episode_id(self) -> None:
+        """When metric values tie, sort is stable (by input order)."""
+        episodes = [
+            _make_episode("ep_a", "orca", "s1", 1, 0.5),
+            _make_episode("ep_b", "orca", "s1", 2, 0.5),
+            _make_episode("ep_c", "orca", "s1", 3, 0.5),
+        ]
+        selected, _ = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            metric_direction="higher",
+            modes=["best", "median", "worst"],
+        )
+        # All have same value; best=first in sorted order, worst=last
+        best = next(s for s in selected if s.selection_mode == "best")
+        worst = next(s for s in selected if s.selection_mode == "worst")
+        assert best.episode_id == "ep_a"
+        assert worst.episode_id == "ep_c"
+
+
+class TestGrouping:
+    """Test multi-key grouping."""
+
+    def test_planner_x_outcome_grouping(self) -> None:
+        """Episodes are grouped by planner x outcome."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, 0.9, outcome="success"),
+            _make_episode("ep2", "orca", "s1", 2, 0.3, outcome="timeout"),
+            _make_episode("ep3", "sf", "s1", 3, 0.8, outcome="success"),
+            _make_episode("ep4", "sf", "s1", 4, 0.2, outcome="timeout"),
+        ]
+        selected, skipped = select_exemplars(
+            episodes,
+            group_by=["planner_key", "outcome"],
+            metric="path_efficiency",
+            metric_direction="higher",
+            modes=["best"],
+        )
+        # 4 groups x 1 mode = 4 selections
+        assert len(selected) == 4
+        assert len(skipped) == 0
+
+        orca_success = next(
+            s for s in selected if s.planner_key == "orca" and "success" in s.reason
+        )
+        assert orca_success.episode_id == "ep1"
+
+
+class TestManifest:
+    """Test manifest building and serialization."""
+
+    def test_manifest_schema_version(self) -> None:
+        """Manifest has correct schema version."""
+        manifest = SelectionManifest()
+        assert manifest.schema_version == "exemplar-selection.v1"
+
+    def test_manifest_to_dict_roundtrip(self) -> None:
+        """Manifest to_dict is JSON-serializable."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, 0.9),
+            _make_episode("ep2", "orca", "s1", 2, 0.5),
+        ]
+        selected, skipped = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            modes=["best"],
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", mode="w", delete=False) as f:
+            for ep in episodes:
+                f.write(json.dumps(ep) + "\n")
+            tmp_path = Path(f.name)
+
+        try:
+            manifest = build_manifest(
+                source_episodes_path=tmp_path,
+                group_by=["planner_key"],
+                metric="path_efficiency",
+                selected=selected,
+                skipped_cells=skipped,
+            )
+            d = manifest.to_dict()
+            json_str = json.dumps(d)
+            assert "exemplar-selection.v1" in json_str
+            assert len(d["selected"]) == 1
+            assert d["source_sha256"] != "unknown"
+        finally:
+            tmp_path.unlink()
+
+    def test_save_manifest_creates_file(self) -> None:
+        """save_manifest writes a valid JSON file."""
+        manifest = SelectionManifest(
+            metric="path_efficiency",
+            selected=[],
+            skipped_cells=[],
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = save_manifest(manifest, Path(tmpdir) / "sub" / "manifest.json")
+            assert out.exists()
+            data = json.loads(out.read_text())
+            assert data["schema_version"] == "exemplar-selection.v1"
+
+
+class TestInvalidMode:
+    """Test invalid selection mode rejection."""
+
+    def test_invalid_mode_raises(self) -> None:
+        """Invalid selection mode raises ExemplarSelectionError."""
+        episodes = [_make_episode("ep1", "orca", "s1", 1, 0.5)]
+        with pytest.raises(ExemplarSelectionError, match="Invalid selection mode"):
+            select_exemplars(
+                episodes,
+                group_by=["planner_key"],
+                metric="path_efficiency",
+                modes=["invalid_mode"],
+            )
+
+
+class TestMetricDirectionAutoDetection:
+    """Test automatic metric direction detection."""
+
+    def test_auto_detect_lower(self) -> None:
+        """Known lower-is-better metrics are auto-detected."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, 3, metric_name="collisions"),
+            _make_episode("ep2", "orca", "s1", 2, 0, metric_name="collisions"),
+        ]
+        selected, _ = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="collisions",
+            modes=["best"],
+        )
+        assert selected[0].episode_id == "ep2"
+        assert selected[0].metric_value == 0.0
+
+    def test_auto_detect_higher(self) -> None:
+        """Known higher-is-better metrics are auto-detected."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, 0.3),
+            _make_episode("ep2", "orca", "s1", 2, 0.9),
+        ]
+        selected, _ = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            modes=["best"],
+        )
+        assert selected[0].episode_id == "ep2"


### PR DESCRIPTION
## What / Why

Implements Part 1 of #4778: **exemplar episode auto-selection** for campaign review.

The selector groups episodes by `(planner x mechanism/outcome)` cells, selects
`median`/`best`/`worst` by a configurable metric, and writes a deterministic
`exemplar-selection.v1` manifest with provenance (source SHA-256, git hash).

**Dependencies #4776 (replay bridge) and #4777 (style pack) are still OPEN.**
Per the issue's dependency boundary, this PR implements only the pure selector
and manifest format.  Rendering integration (feeding the manifest into the
replay bridge, multi-planner overlay) is a follow-up once those land.

### Files added

| File | Purpose |
|------|---------|
| `robot_sf/benchmark/exemplar_selection.py` | Core selection logic, manifest dataclasses, provenance helpers |
| `scripts/select_exemplar_episodes.py` | CLI entry point |
| `tests/benchmark/test_exemplar_selection.py` | 14 focused tests |

### CLI usage

```bash
uv run python scripts/select_exemplar_episodes.py \
  --episodes <episodes.jsonl> \
  --group-by planner_key,outcome \
  --metric path_efficiency \
  --modes median,best,worst \
  --output-manifest output/exemplars/selection_manifest.json
```

## Validation

```
uv run pytest tests/benchmark/test_exemplar_selection.py -v
# 14 passed

uv run ruff check robot_sf/benchmark/exemplar_selection.py scripts/select_exemplar_episodes.py tests/benchmark/test_exemplar_selection.py
# All checks passed

uv run python scripts/select_exemplar_episodes.py --help
# prints usage
```

## Successor statement

This PR is a **partial slice** of #4778.  Remaining work:
- Part 2: Feed selection manifest into replay bridge (#4776)
- Part 3: Multi-planner trajectory overlay renderer
- Part 4: Overlay tests + integration with style pack (#4777)
- Part 5: Context documentation

Does not duplicate any prior merged PR.

Refs #4778

---

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation
lane; the review gate hardens and merges.