### PR TITLE
Issue #4771: Release 0.0.2 reproduction note (cheap-lane worker)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -231,7 +231,9 @@ thin: existing Markdown files remain the source of truth, and generated HTML und
 * **[Issue #750 Paper Results Handoff](./context/issue_750_paper_results_handoff.md)** - Deterministic paper-facing JSON/CSV handoff contract for frozen benchmark bundles with CI metadata and provenance fields
 * **[Benchmark Release 0.0.2 Execution Log](./context/benchmark_release_0_0_2_2026-04-13.md)** - All-planners release manifest/config decisions, tmux execution path, assumptions, and follow-up publish steps
 * **[Benchmark Release 0.0.2 Publication Snapshot](./experiments/publication/20260414_benchmark_release_0_0_2/summary.md)** - Durable scoped seven-planner release pointer with DOI, archive checksum, embedded manifest/checksum/SNQI paths, and fresh-checkout recovery command
+* **[Benchmark Release 0.0.2 Reproduction Note](./benchmark_release_0_0_2_reproduction.md)** - Dedicated copy-paste procedure for reproducing release 0.0.2 results from a fresh clone of main using the downloaded release archive and running the regeneration parity test
 * **[Issue #1062 Paper Evidence Archive Pointer](./context/issue_1062_paper_evidence_archive.md)** - Paper evidence archive recovery note for the scoped `0.0.2` bundle without committing raw benchmark outputs
+
 * **[Issue #435 Map Coverage Flow](./context/issue_435_map_coverage_flow.md)** - Parent flow state for map coverage, SocNavBench import, and map-quality child issues
 * **[Issue #328 Real-World Map Parent Tracker](./context/issue_328_real_world_map_parent.md)** - Parent/child map-coverage split, child issue status, and shared validation contract for real-world benchmark maps
 * **[Issue #692 Scenario Difficulty Analysis](./context/issue_692_scenario_difficulty_analysis.md)** - Artifact-driven camera-ready workflow for consensus ranking, planner residuals, and verified-simple subset assessment

--- a/docs/benchmark_release_0_0_2_reproduction.md
+++ b/docs/benchmark_release_0_0_2_reproduction.md
@@ -1,0 +1,48 @@
+# Reproducing Release 0.0.2
+
+This document provides step-by-step instructions to reproduce the canonical paper handoff results for benchmark release `0.0.2`.
+
+## Overview and Key Differences
+
+- **Release Tag (`0.0.2`)**: Points to commit `cbeaca617` (three commits earlier than the campaign completion). This commit has the core simulation logic and code representation.
+- **Campaign Commit (`f7ebdcae2375d085e925213197a75a386e26a79c`)**: Contains the final generated publication manifest, checksums, and the scoped release manifest that exists outside the tag `0.0.2` tree.
+- **Parity Test**: The regeneration parity test (`tests/benchmark/test_paper_results_handoff.py::test_canonical_handoff_matches_durable_release_campaign_table`) lives on `main` (not in the tag tree). Therefore, reproduction must be run from a fresh clone of `main` using the downloaded release `0.0.2` bundle.
+
+> [!NOTE]
+> This reproduction procedure does not modify the immutable release artifact on GitHub or Zenodo.
+
+## Scoped Manifest Path
+
+The exact scoped release manifest is located at:
+`configs/benchmarks/releases/paper_experiment_matrix_7planners_v1_release_v0_0_2_scoped.yaml`
+
+## Release Archive & Pinned SHA-256
+
+- **Archive Name**: `paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz`
+- **Expected SHA-256**: `64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90`
+
+## Fresh Clone Reproduction Commands
+
+Run the following commands from a fresh checkout of the `main` branch to download the bundle, verify its checksum, and run the regeneration parity test:
+
+```bash
+# Clone the repository and navigate to the root
+git clone https://github.com/ll7/robot_sf_ll7.git
+cd robot_sf_ll7
+
+# Setup the virtual environment and sync dependencies
+uv sync --all-extras
+
+# Download the release bundle
+mkdir -p output/benchmark_release_0_0_2
+gh release download 0.0.2 \
+  --pattern 'paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz' \
+  --dir output/benchmark_release_0_0_2
+
+# Verify the SHA-256 checksum of the downloaded bundle
+sha256sum output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz
+
+# Run the regeneration parity test
+ROBOT_SF_PAPER_HANDOFF_BUNDLE=output/benchmark_release_0_0_2/paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz \
+  uv run pytest tests/benchmark/test_paper_results_handoff.py::test_canonical_handoff_matches_durable_release_campaign_table -q
+```

--- a/docs/benchmark_release_0_0_2_reproduction.md
+++ b/docs/benchmark_release_0_0_2_reproduction.md
@@ -4,7 +4,7 @@ This document provides step-by-step instructions to reproduce the canonical pape
 
 ## Overview and Key Differences
 
-- **Release Tag (`0.0.2`)**: Points to commit `cbeaca617` (three commits earlier than the campaign completion). This commit has the core simulation logic and code representation.
+- **Release Tag (`0.0.2`)**: Points to commit `cbeaca610` (three commits earlier than the campaign completion). This commit has the core simulation logic and code representation.
 - **Campaign Commit (`f7ebdcae2375d085e925213197a75a386e26a79c`)**: Contains the final generated publication manifest, checksums, and the scoped release manifest that exists outside the tag `0.0.2` tree.
 - **Parity Test**: The regeneration parity test (`tests/benchmark/test_paper_results_handoff.py::test_canonical_handoff_matches_durable_release_campaign_table`) lives on `main` (not in the tag tree). Therefore, reproduction must be run from a fresh clone of `main` using the downloaded release `0.0.2` bundle.
 

--- a/docs/benchmark_release_reproducibility.md
+++ b/docs/benchmark_release_reproducibility.md
@@ -139,6 +139,11 @@ For the current scoped seven-planner paper release, use the tracked publication 
 
 - `docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md`
 - `docs/experiments/publication/20260414_benchmark_release_0_0_2/release_metadata.json`
+- `docs/benchmark_release_0_0_2_reproduction.md` - Dedicated copy-paste procedure for reproducing release 0.0.2 results
+
+> [!NOTE]
+> **Release 0.0.2 Note**: The annotated tag `0.0.2` tree references the generic `paper_experiment_matrix_v1_release_v0_1.yaml` manifest. The actual scoped manifest (`configs/benchmarks/releases/paper_experiment_matrix_7planners_v1_release_v0_0_2_scoped.yaml`) and the parity test logic live on the `main` branch, not in the tag tree. To reproduce release 0.0.2, follow the dedicated [Release 0.0.2 Reproduction Note](benchmark_release_0_0_2_reproduction.md).
+
 
 Durable endpoints:
 

--- a/docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md
+++ b/docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md
@@ -12,6 +12,10 @@ the licensed SocNavBench dataset assets were not staged for the release run. The
 documented in
 [`docs/context/benchmark_release_0_0_2_scoped_rationale.md`](../../../context/benchmark_release_0_0_2_scoped_rationale.md).
 
+> [!TIP]
+> For instructions on reproducing and verifying release 0.0.2, see the dedicated [Release 0.0.2 Reproduction Note](../../../benchmark_release_0_0_2_reproduction.md).
+
+
 ## Public Endpoints
 
 - Release: `https://github.com/ll7/robot_sf_ll7/releases/tag/0.0.2`

--- a/tests/docs/test_release_0_0_2_reproduction_doc.py
+++ b/tests/docs/test_release_0_0_2_reproduction_doc.py
@@ -1,0 +1,59 @@
+"""Tests for the Release 0.0.2 Reproduction Note."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REPRO_NOTE = ROOT / "docs" / "benchmark_release_0_0_2_reproduction.md"
+DOCS_README = ROOT / "docs" / "README.md"
+REPRODUCIBILITY_GUIDE = ROOT / "docs" / "benchmark_release_reproducibility.md"
+SUMMARY_NOTE = (
+    ROOT
+    / "docs"
+    / "experiments"
+    / "publication"
+    / "20260414_benchmark_release_0_0_2"
+    / "summary.md"
+)
+
+
+def test_release_0_0_2_reproduction_doc_content() -> None:
+    """Verify that the reproduction doc contains all necessary instructions and variables."""
+    assert REPRO_NOTE.exists()
+    text = REPRO_NOTE.read_text(encoding="utf-8")
+
+    # Verify scoped manifest path is present
+    assert (
+        "configs/benchmarks/releases/paper_experiment_matrix_7planners_v1_release_v0_0_2_scoped.yaml"
+        in text
+    )
+
+    # Verify ROBOT_SF_PAPER_HANDOFF_BUNDLE environment variable is present
+    assert "ROBOT_SF_PAPER_HANDOFF_BUNDLE" in text
+
+    # Verify canonical handoff parity test command is present
+    assert (
+        "tests/benchmark/test_paper_results_handoff.py::test_canonical_handoff_matches_durable_release_campaign_table"
+        in text
+    )
+
+    # Verify 0.0.2 release archive name is present
+    assert (
+        "paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle.tar.gz"
+        in text
+    )
+
+    # Verify expected SHA-256 checksum is present
+    assert "64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90" in text
+
+    # Verify explanation of annotated tag and campaign commit difference is present
+    assert "cbeaca617" in text
+    assert "f7ebdcae2375d085e925213197a75a386e26a79c" in text
+
+
+def test_release_0_0_2_reproduction_doc_is_linked() -> None:
+    """Verify that the reproduction doc is correctly referenced in READMEs and snapshot summaries."""
+    note_name = "benchmark_release_0_0_2_reproduction.md"
+
+    assert note_name in DOCS_README.read_text(encoding="utf-8")
+    assert note_name in REPRODUCIBILITY_GUIDE.read_text(encoding="utf-8")
+    assert note_name in SUMMARY_NOTE.read_text(encoding="utf-8")

--- a/tests/docs/test_release_0_0_2_reproduction_doc.py
+++ b/tests/docs/test_release_0_0_2_reproduction_doc.py
@@ -46,7 +46,8 @@ def test_release_0_0_2_reproduction_doc_content() -> None:
     assert "64e8510ab7ba934103c709907f66a783c7b3dd2dd58aa4bd725e762da2734d90" in text
 
     # Verify explanation of annotated tag and campaign commit difference is present
-    assert "cbeaca617" in text
+    # (short SHA of the 0.0.2 tag commit cbeaca6109654b4053c19542a0a17ed656a387a6)
+    assert "cbeaca610" in text
     assert "f7ebdcae2375d085e925213197a75a386e26a79c" in text
 
 


### PR DESCRIPTION
## What / Why

Bridges the immutable `0.0.2` tag-tree reproducibility gap with a docs-only note on `main` branch.

- Adds `docs/benchmark_release_0_0_2_reproduction.md` detailing why the campaign commit differs from the annotated tag tree, the exact scoped manifest path, expected archive SHA-256, and reproduction/parity-test commands.
- Updates `docs/benchmark_release_reproducibility.md` to reference the new note and clarify the tag tree manifest indirection.
- Links the reproduction note from `docs/experiments/publication/20260414_benchmark_release_0_0_2/summary.md`.
- Indexes the reproduction note in `docs/README.md`.
- Adds regression tests in `tests/docs/test_release_0_0_2_reproduction_doc.py` to assert content and linkage requirements.

The annotated tag `0.0.2` points to a commit three commits earlier than the campaign completion, which references the generic v0.1 manifest. The scoped manifest and the parity-test logic exist on `main` and not in the tag tree. This note provides a copy-paste procedure from a fresh clone of `main` to run the regeneration parity test against the downloaded release archive.

## Validation

All 178 tests in `tests/docs/` passed successfully, including the new assertions verifying that the note contains all required variables (manifest path, archive name, expected SHA, `ROBOT_SF_PAPER_HANDOFF_BUNDLE`, and test name) and is indexed/linked correctly.

```
tests/docs/test_release_0_0_2_reproduction_doc.py ..                     [100%]
============================= 178 passed in 2.72s ==============================
```

`ruff` format and lint checks passed cleanly.

Closes #4771

This PR was produced by the agy/Gemini-3.5-Flash cheap implementation lane; the review gate hardens and merges.
