### PR TITLE
Issue #4767: restricted unpickler for production pickle.load sites (cheap-lane worker)

### DIFF
--- a/examples/recordings/README.md
+++ b/examples/recordings/README.md
@@ -1,0 +1,9 @@
+# Robot SF Recordings
+
+Pickle recordings shared in this directory are accepted only through a
+restricted unpickler that allowlists the exact RobotSF classes and NumPy
+reconstruction symbols present in known-good recordings. Arbitrary pickle
+files remain untrusted and will be rejected with an `UnsafePickleError` if
+they reference symbols outside the allowlist. Prefer JSONL or other safer
+formats for new recordings; format migration from pickle is post-submission
+work.

--- a/robot_sf/common/safe_pickle.py
+++ b/robot_sf/common/safe_pickle.py
@@ -1,0 +1,169 @@
+"""Restricted unpickler for RobotSF pickle loading.
+
+This module provides a restricted unpickler that only allows loading of specific
+known-safe classes and NumPy reconstruction symbols. Any other pickle globals
+are rejected with a clear error message.
+
+Security note: This is a mitigation, not a proof that pickle is safe. Restricted
+unpickling reduces RCE surface for known payloads; it is not a general-purpose
+safe pickle parser.
+"""
+
+from __future__ import annotations
+
+import io
+import pickle
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class UnsafePickleError(RuntimeError):
+    """Raised when a restricted unpickler rejects a pickle global."""
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    """Restricted unpickler that only allows specific known-safe globals."""
+
+    def __init__(
+        self,
+        file: io.BytesIO,
+        *,
+        allowed_globals: set[tuple[str, str]],
+        label: str,
+    ) -> None:
+        """Initialize the restricted unpickler.
+
+        Args:
+            file: BytesIO stream to unpickle from.
+            allowed_globals: Set of (module, name) tuples that are allowed.
+            label: Human-readable label for error messages (e.g., "playback recording").
+        """
+        super().__init__(file)
+        self._allowed_globals = frozenset(allowed_globals)
+        self._label = label
+
+    def find_class(self, module: str, name: str) -> Any:
+        """Override to restrict which globals can be loaded.
+
+        Args:
+            module: Module name of the class to load.
+            name: Class/function name to load.
+
+        Returns:
+            The class or function object if allowed.
+
+        Raises:
+            UnsafePickleError: If the (module, name) pair is not in the allowlist.
+        """
+        key = (module, name)
+        if key in self._allowed_globals:
+            return super().find_class(module, name)
+        raise UnsafePickleError(
+            f"Unsafe pickle global rejected for {self._label}: "
+            f"{module}.{name} is not in the allowlist. "
+            f"Allowed globals: {sorted(self._allowed_globals)}"
+        )
+
+
+# Allowlist for RobotSF playback recordings (states, map_def tuples).
+PLAYBACK_RECORDING_ALLOWED_GLOBALS: frozenset[tuple[str, str]] = frozenset(
+    {
+        # RobotSF simulation state classes
+        ("robot_sf.render.sim_state", "VisualizableSimState"),
+        ("robot_sf.render.sim_state", "VisualizableAction"),
+        ("robot_sf.render.sim_view", "VisualizableSimState"),
+        ("robot_sf.render.sim_view", "VisualizableAction"),
+        # RobotSF map and navigation classes
+        ("robot_sf.nav.map_config", "MapDefinition"),
+        ("robot_sf.nav.obstacle", "Obstacle"),
+        ("robot_sf.nav.global_route", "GlobalRoute"),
+        # NumPy array and scalar reconstruction (required for array data in recordings)
+        ("numpy", "ndarray"),
+        ("numpy", "dtype"),
+        ("numpy.core.multiarray", "scalar"),
+        ("numpy.core.multiarray", "_reconstruct"),
+        ("numpy.core.numeric", "scalar"),
+        ("numpy.core.numeric", "_reconstruct"),
+        # NumPy 2.x module paths
+        ("numpy._core.multiarray", "scalar"),
+        ("numpy._core.multiarray", "_reconstruct"),
+        # Required for protocol-2 pickles with bytes
+        ("_codecs", "encode"),
+    }
+)
+
+# Allowlist for SocNavBench ETH traversible payloads.
+SOCNAVBENCH_TRAVERSIBLE_ALLOWED_GLOBALS: frozenset[tuple[str, str]] = frozenset(
+    {
+        # NumPy array and scalar reconstruction only
+        ("numpy", "ndarray"),
+        ("numpy", "dtype"),
+        ("numpy.core.multiarray", "scalar"),
+        ("numpy.core.multiarray", "_reconstruct"),
+        ("numpy.core.numeric", "scalar"),
+        ("numpy.core.numeric", "_reconstruct"),
+        # NumPy 2.x module paths
+        ("numpy._core.multiarray", "scalar"),
+        ("numpy._core.multiarray", "_reconstruct"),
+        # Required for protocol-2 pickles with bytes
+        ("_codecs", "encode"),
+    }
+)
+
+
+def restricted_pickle_load(
+    file_obj: io.BytesIO,
+    *,
+    allowed_globals: frozenset[tuple[str, str]],
+    label: str,
+) -> Any:
+    """Load a pickle from a file object using a restricted unpickler.
+
+    Args:
+        file_obj: BytesIO stream to unpickle from.
+        allowed_globals: Set of (module, name) tuples that are allowed.
+        label: Human-readable label for error messages.
+
+    Returns:
+        The unpickled Python object.
+
+    Raises:
+        UnsafePickleError: If the pickle contains disallowed globals.
+    """
+    unpickler = RestrictedUnpickler(
+        file_obj,
+        allowed_globals=allowed_globals,
+        label=label,
+    )
+    return unpickler.load()
+
+
+def restricted_pickle_load_path(
+    path: Path,
+    *,
+    allowed_globals: frozenset[tuple[str, str]],
+    label: str,
+) -> Any:
+    """Load a pickle from a file path using a restricted unpickler.
+
+    Args:
+        path: Path to the pickle file.
+        allowed_globals: Set of (module, name) tuples that are allowed.
+        label: Human-readable label for error messages.
+
+    Returns:
+        The unpickled Python object.
+
+    Raises:
+        UnsafePickleError: If the pickle contains disallowed globals.
+        FileNotFoundError: If the file does not exist.
+        IsADirectoryError: If the path is a directory.
+    """
+    with path.open("rb") as f:
+        return restricted_pickle_load(
+            io.BytesIO(f.read()),
+            allowed_globals=allowed_globals,
+            label=label,
+        )

--- a/robot_sf/data/external/socnavbench_eth.py
+++ b/robot_sf/data/external/socnavbench_eth.py
@@ -2,17 +2,26 @@
 
 The loader only inspects locally staged files. It never downloads or vendors the
 license-gated SocNavBench/S3DIS ETH dataset bytes.
+
+Security:
+    The traversible pickle is loaded through a restricted unpickler that only allows
+    NumPy reconstruction symbols. Arbitrary pickle files remain untrusted.
 """
 
 from __future__ import annotations
 
-import pickle
+import io
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 
+from robot_sf.common.safe_pickle import (
+    SOCNAVBENCH_TRAVERSIBLE_ALLOWED_GLOBALS,
+    UnsafePickleError,
+    restricted_pickle_load,
+)
 from scripts.tools.manage_external_data import (
     EXTERNAL_DATA_ROOT_ENV,
     check_asset,
@@ -110,7 +119,16 @@ def load_shape_contract(root: Path | str | None = None) -> SocNavBenchEthShapeCo
     layout = require_available(root)
     try:
         with layout.traversible_pickle.open("rb") as handle:
-            payload = pickle.load(handle)
+            payload = restricted_pickle_load(
+                io.BytesIO(handle.read()),
+                allowed_globals=SOCNAVBENCH_TRAVERSIBLE_ALLOWED_GLOBALS,
+                label="SocNavBench ETH traversible",
+            )
+    except UnsafePickleError as exc:
+        raise SocNavBenchEthDataError(
+            f"Unsafe pickle rejected for {layout.traversible_pickle}: {exc}. "
+            f"Re-stage official {ASSET_ID} assets if this is a legitimate file."
+        ) from exc
     except Exception as exc:  # pragma: no cover - depends on malformed external bytes.
         raise SocNavBenchEthDataError(
             f"Could not load {layout.traversible_pickle}. Re-stage official "

--- a/robot_sf/render/jsonl_playback.py
+++ b/robot_sf/render/jsonl_playback.py
@@ -19,6 +19,7 @@ Schema Support:
     - Legacy multi-episode pickle file segmentation
 """
 
+import io
 import json
 import pickle
 from dataclasses import dataclass
@@ -28,6 +29,10 @@ from typing import Any, Union
 import loguru
 import numpy as np
 
+from robot_sf.common.safe_pickle import (
+    PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+    restricted_pickle_load,
+)
 from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition
 from robot_sf.nav.obstacle import Obstacle
@@ -457,18 +462,26 @@ class JSONLPlaybackLoader:
     def _load_pickle_file(self, file_path: Path) -> tuple[PlaybackEpisode, MapDefinition]:
         """Load legacy pickle file and convert to episode format.
         Only for backward compatibility.
-        Use with caution and only with trusted inputs.
+        Uses a restricted unpickler to reject unsafe pickle globals.
 
         Args:
             file_path: Path to pickle file
 
         Returns:
             Tuple of (PlaybackEpisode, MapDefinition)
+
+        Raises:
+            UnsafePickleError: If the pickle contains disallowed globals.
         """
         logger.info(f"Loading legacy pickle file: {file_path}")
 
-        with open(file_path, "rb") as f:
-            states, map_def = pickle.load(f)
+        with file_path.open("rb") as f:
+            data = restricted_pickle_load(
+                io.BytesIO(f.read()),
+                allowed_globals=PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+                label="playback recording",
+            )
+        states, map_def = data
 
         # Detect episode boundaries in multi-episode pickle files
         reset_points = self._detect_reset_points(states)

--- a/robot_sf/render/playback_recording.py
+++ b/robot_sf/render/playback_recording.py
@@ -14,13 +14,23 @@ Notes:
     The pickle files should contain a tuple of (states, map_def) where:
     - states: List[VisualizableSimState] - Sequence of simulation states
     - map_def: MapDefinition - Configuration of the simulation environment
+
+Security:
+    Legacy .pkl recordings are loaded through a restricted unpickler that only allows
+    known-safe RobotSF classes and NumPy reconstruction symbols. Arbitrary pickle files
+    remain untrusted and may be rejected. Prefer JSONL or other safer formats for new
+    recordings.
 """
 
+import io
 import os
-import pickle
 
 import loguru
 
+from robot_sf.common.safe_pickle import (
+    PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+    restricted_pickle_load,
+)
 from robot_sf.nav.map_config import MapDefinition
 from robot_sf.render.sim_state import VisualizableSimState
 from robot_sf.render.sim_view import SimulationView
@@ -60,8 +70,13 @@ def load_states(filename: str) -> tuple[list[VisualizableSimState], MapDefinitio
         raise ValueError(f"File {filename} is empty; expected pickle with (states, map_def) tuple")
 
     logger.info(f"Loading states from {filename}")
-    with open(filename, "rb") as f:  # rb = read binary
-        states, map_def = pickle.load(f)
+    with open(filename, "rb") as f:
+        data = restricted_pickle_load(
+            io.BytesIO(f.read()),
+            allowed_globals=PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+            label="playback recording",
+        )
+    states, map_def = data
     logger.info(f"Loaded {len(states)} states")
 
     # Verify `states` is a list of VisualizableSimState

--- a/tests/common/test_safe_pickle.py
+++ b/tests/common/test_safe_pickle.py
@@ -1,0 +1,252 @@
+"""Tests for restricted unpickler security and functionality."""
+
+import io
+import os
+import pickle
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from robot_sf.common.safe_pickle import (
+    PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+    SOCNAVBENCH_TRAVERSIBLE_ALLOWED_GLOBALS,
+    UnsafePickleError,
+    restricted_pickle_load,
+    restricted_pickle_load_path,
+)
+
+
+class TestRestrictedUnpickler:
+    """Tests for the RestrictedUnpickler class."""
+
+    def test_allowed_global_is_accepted(self) -> None:
+        """Verify that an allowed global is accepted."""
+        data = {"key": "value"}
+        buffer = io.BytesIO()
+        pickle.dump(data, buffer)
+        buffer.seek(0)
+
+        result = restricted_pickle_load(
+            buffer,
+            allowed_globals=frozenset({("builtins", "dict")}),
+            label="test",
+        )
+        assert result == data
+
+    def test_disallowed_global_is_rejected(self) -> None:
+        """Verify that a disallowed global raises UnsafePickleError."""
+        data = {"key": np.array([1, 2, 3])}
+        buffer = io.BytesIO()
+        pickle.dump(data, buffer)
+        buffer.seek(0)
+
+        # Use an empty allowlist to force rejection of numpy globals
+        with pytest.raises(UnsafePickleError, match="Unsafe pickle global rejected"):
+            restricted_pickle_load(
+                buffer,
+                allowed_globals=frozenset(),
+                label="test",
+            )
+
+    def test_malicious_pickle_os_system_rejected(self) -> None:
+        """Verify that malicious pickle with os.system is rejected."""
+
+        class Evil:
+            def __reduce__(self):
+                return (os.system, ("echo should-not-run",))
+
+        buffer = io.BytesIO()
+        pickle.dump(Evil(), buffer)
+        buffer.seek(0)
+
+        with pytest.raises(UnsafePickleError) as exc_info:
+            restricted_pickle_load(
+                buffer,
+                allowed_globals=PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+                label="malicious test payload",
+            )
+
+        # Verify the error message contains the rejected symbol
+        assert "posix.system" in str(exc_info.value) or "os.system" in str(exc_info.value)
+        assert "malicious test payload" in str(exc_info.value)
+
+    def test_malicious_pickle_subprocess_rejected(self) -> None:
+        """Verify that malicious pickle with subprocess is rejected."""
+
+        class Evil:
+            def __reduce__(self):
+                return (subprocess.call, (["echo", "should-not-run"],))
+
+        import subprocess
+
+        buffer = io.BytesIO()
+        pickle.dump(Evil(), buffer)
+        buffer.seek(0)
+
+        with pytest.raises(UnsafePickleError):
+            restricted_pickle_load(
+                buffer,
+                allowed_globals=PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+                label="malicious subprocess payload",
+            )
+
+    def test_malicious_pickle_exec_rejected(self) -> None:
+        """Verify that malicious pickle with exec is rejected."""
+
+        class Evil:
+            def __reduce__(self):
+                return (eval, ("__import__('os').system('echo should-not-run')",))  # noqa: S307
+
+        buffer = io.BytesIO()
+        pickle.dump(Evil(), buffer)
+        buffer.seek(0)
+
+        with pytest.raises(UnsafePickleError):
+            restricted_pickle_load(
+                buffer,
+                allowed_globals=PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+                label="malicious eval payload",
+            )
+
+    def test_error_message_includes_rejected_symbol(self) -> None:
+        """Verify error message includes the rejected module.name and label."""
+        data = {"key": np.array([1, 2, 3])}
+        buffer = io.BytesIO()
+        pickle.dump(data, buffer)
+        buffer.seek(0)
+
+        with pytest.raises(UnsafePickleError) as exc_info:
+            restricted_pickle_load(
+                buffer,
+                allowed_globals=frozenset(),
+                label="test_label",
+            )
+
+        assert "test_label" in str(exc_info.value)
+        assert "numpy" in str(exc_info.value)
+
+
+class TestPlaybackRecordingAllowlist:
+    """Tests for the PLAYBACK_RECORDING_ALLOWED_GLOBALS allowlist."""
+
+    def test_numpy_array_reconstruction(self) -> None:
+        """Verify NumPy arrays can be reconstructed."""
+        data = {"array": np.array([1, 2, 3]), "scalar": np.float64(3.14)}
+        buffer = io.BytesIO()
+        pickle.dump(data, buffer)
+        buffer.seek(0)
+
+        result = restricted_pickle_load(
+            buffer,
+            allowed_globals=PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+            label="numpy test",
+        )
+        assert np.array_equal(result["array"], data["array"])
+        assert result["scalar"] == data["scalar"]
+
+    def test_nested_dict_with_arrays(self) -> None:
+        """Verify nested dicts with arrays work."""
+        data = {
+            "outer": {
+                "inner": np.array([[1, 2], [3, 4]]),
+                "value": 42,
+            }
+        }
+        buffer = io.BytesIO()
+        pickle.dump(data, buffer)
+        buffer.seek(0)
+
+        result = restricted_pickle_load(
+            buffer,
+            allowed_globals=PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+            label="nested test",
+        )
+        assert np.array_equal(result["outer"]["inner"], data["outer"]["inner"])
+
+
+class TestSocNavBenchAllowlist:
+    """Tests for the SOCNAVBENCH_TRAVERSIBLE_ALLOWED_GLOBALS allowlist."""
+
+    def test_dict_with_numpy_array(self) -> None:
+        """Verify dict with NumPy array (typical traversible payload) loads."""
+        data = {
+            "resolution": 0.05,
+            "traversible": np.zeros((100, 100), dtype=np.float32),
+        }
+        buffer = io.BytesIO()
+        pickle.dump(data, buffer)
+        buffer.seek(0)
+
+        result = restricted_pickle_load(
+            buffer,
+            allowed_globals=SOCNAVBENCH_TRAVERSIBLE_ALLOWED_GLOBALS,
+            label="SocNavBench traversible test",
+        )
+        assert result["resolution"] == 0.05
+        assert result["traversible"].shape == (100, 100)
+
+    def test_nested_structure(self) -> None:
+        """Verify nested dict/list/tuple with arrays works."""
+        data = {
+            "resolution": 0.1,
+            "metadata": {"name": "test", "values": [1, 2, 3]},
+            "traversible": np.ones((50, 50), dtype=np.float64),
+        }
+        buffer = io.BytesIO()
+        pickle.dump(data, buffer)
+        buffer.seek(0)
+
+        result = restricted_pickle_load(
+            buffer,
+            allowed_globals=SOCNAVBENCH_TRAVERSIBLE_ALLOWED_GLOBALS,
+            label="SocNavBench nested test",
+        )
+        assert result["resolution"] == 0.1
+        assert result["metadata"]["name"] == "test"
+        assert result["traversible"].shape == (50, 50)
+
+
+class TestRestrictedPickleLoadPath:
+    """Tests for the restricted_pickle_load_path function."""
+
+    def test_load_from_path(self) -> None:
+        """Verify loading from a file path works."""
+        data = {"test": "value", "array": np.array([1, 2, 3])}
+
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            temp_path = Path(f.name)
+            pickle.dump(data, f)
+
+        try:
+            result = restricted_pickle_load_path(
+                temp_path,
+                allowed_globals=PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+                label="path test",
+            )
+            assert result["test"] == data["test"]
+            assert np.array_equal(result["array"], data["array"])
+        finally:
+            temp_path.unlink()
+
+    def test_load_from_path_rejects_malicious(self) -> None:
+        """Verify that malicious file is rejected when loading from path."""
+
+        class Evil:
+            def __reduce__(self):
+                return (os.system, ("echo should-not-run",))
+
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            temp_path = Path(f.name)
+            pickle.dump(Evil(), f)
+
+        try:
+            with pytest.raises(UnsafePickleError):
+                restricted_pickle_load_path(
+                    temp_path,
+                    allowed_globals=PLAYBACK_RECORDING_ALLOWED_GLOBALS,
+                    label="malicious path test",
+                )
+        finally:
+            temp_path.unlink()

--- a/tests/data/test_socnavbench_eth_safe_pickle.py
+++ b/tests/data/test_socnavbench_eth_safe_pickle.py
@@ -1,0 +1,103 @@
+"""Tests for safe pickle integration in socnavbench_eth module."""
+
+from __future__ import annotations
+
+import os
+import pickle
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from robot_sf.data.external import socnavbench_eth
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _stage_minimal_eth_fixture(root: Path) -> None:
+    """Create a tiny layout-compatible SocNavBench ETH fixture."""
+    layout = socnavbench_eth.expected_layout(root)
+    layout.mesh_dir.mkdir(parents=True)
+    (layout.mesh_dir / "mesh.obj").write_text("# synthetic mesh marker\n", encoding="utf-8")
+    layout.traversible_pickle.parent.mkdir(parents=True)
+    with layout.traversible_pickle.open("wb") as handle:
+        pickle.dump(
+            {
+                "resolution": 5.0,
+                "traversible": np.array([[True, False], [True, True]], dtype=bool),
+            },
+            handle,
+            protocol=2,
+        )
+
+
+class TestSocNavBenchEthSafePickle:
+    """Tests for safe pickle in socnavbench_eth.load_shape_contract."""
+
+    def test_legitimate_traversible_loads(self, tmp_path: Path) -> None:
+        """Verify that a legitimate traversible pickle loads successfully."""
+        root = tmp_path / "socnavbench"
+        _stage_minimal_eth_fixture(root)
+
+        shape = socnavbench_eth.load_shape_contract(root)
+        assert shape.resolution == 5.0
+        assert shape.traversible_shape == (2, 2)
+        assert shape.traversible_dtype == "bool"
+
+    def test_malicious_pickle_rejected(self, tmp_path: Path) -> None:
+        """Verify that malicious pickle is rejected before execution."""
+
+        class Evil:
+            def __reduce__(self):
+                return (os.system, ("echo should-not-run",))
+
+        root = tmp_path / "socnavbench"
+        _stage_minimal_eth_fixture(root)
+        layout = socnavbench_eth.expected_layout(root)
+
+        with layout.traversible_pickle.open("wb") as handle:
+            pickle.dump(Evil(), handle, protocol=2)
+
+        with pytest.raises(socnavbench_eth.SocNavBenchEthDataError, match="Unsafe pickle rejected"):
+            socnavbench_eth.load_shape_contract(root)
+
+    def test_malicious_subprocess_rejected(self, tmp_path: Path) -> None:
+        """Verify that malicious subprocess pickle is rejected."""
+        import subprocess
+
+        class Evil:
+            def __reduce__(self):
+                return (subprocess.call, (["echo", "should-not-run"],))
+
+        root = tmp_path / "socnavbench"
+        _stage_minimal_eth_fixture(root)
+        layout = socnavbench_eth.expected_layout(root)
+
+        with layout.traversible_pickle.open("wb") as handle:
+            pickle.dump(Evil(), handle, protocol=2)
+
+        with pytest.raises(socnavbench_eth.SocNavBenchEthDataError):
+            socnavbench_eth.load_shape_contract(root)
+
+    def test_numpy_array_traversible_loads(self, tmp_path: Path) -> None:
+        """Verify that a traversible with float array loads successfully."""
+        root = tmp_path / "socnavbench"
+        layout = socnavbench_eth.expected_layout(root)
+        layout.mesh_dir.mkdir(parents=True)
+        (layout.mesh_dir / "mesh.obj").write_text("# synthetic mesh marker\n", encoding="utf-8")
+        layout.traversible_pickle.parent.mkdir(parents=True)
+        with layout.traversible_pickle.open("wb") as handle:
+            pickle.dump(
+                {
+                    "resolution": 0.05,
+                    "traversible": np.zeros((10, 10), dtype=np.float32),
+                },
+                handle,
+                protocol=2,
+            )
+
+        shape = socnavbench_eth.load_shape_contract(root)
+        assert shape.resolution == 0.05
+        assert shape.traversible_shape == (10, 10)
+        assert shape.traversible_dtype == "float32"

--- a/tests/pygame/test_frame_export.py
+++ b/tests/pygame/test_frame_export.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from PIL import Image
 
+from robot_sf.common.safe_pickle import UnsafePickleError
 from robot_sf.render import frame_export
 from robot_sf.render.playback_recording import load_states
 from robot_sf.render.sim_state import VisualizableSimState
@@ -51,12 +52,18 @@ def test_load_states_accepts_base_visualizable_sim_state(tmp_path: Path) -> None
 
 
 def test_load_states_rejects_arbitrary_objects(tmp_path: Path) -> None:
-    """The broader base-type acceptance does not accept arbitrary objects."""
+    """Arbitrary objects are rejected by the restricted unpickler.
+
+    Since #4767, ``load_states`` loads through a restricted unpickler that
+    allowlists known-safe globals, so an arbitrary ``object()`` is rejected at
+    unpickle time (``UnsafePickleError``) — before the post-load type check that
+    previously raised ``TypeError('Invalid states')``.
+    """
     pickle_path = tmp_path / "states.pkl"
     with pickle_path.open("wb") as handle:
         pickle.dump(([object()], _empty_map_definition()), handle)
 
-    with pytest.raises(TypeError, match="Invalid states"):
+    with pytest.raises(UnsafePickleError, match="builtins.object"):
         load_states(str(pickle_path))
 
 

--- a/tests/render/test_playback_recording_safe_pickle.py
+++ b/tests/render/test_playback_recording_safe_pickle.py
@@ -10,13 +10,16 @@ import pytest
 from robot_sf.common.safe_pickle import UnsafePickleError
 from robot_sf.render.playback_recording import load_states
 
+# Resolve repo-relative fixtures from this file, not the process cwd.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
 
 class TestPlaybackRecordingSafePickle:
     """Tests for safe pickle in playback_recording.load_states."""
 
     def test_real_example_recording_loads(self) -> None:
         """Verify that a real example recording loads unchanged."""
-        example_dir = Path("examples/recordings")
+        example_dir = _REPO_ROOT / "examples" / "recordings"
         pkl_files = list(example_dir.glob("*.pkl"))
 
         if not pkl_files:

--- a/tests/render/test_playback_recording_safe_pickle.py
+++ b/tests/render/test_playback_recording_safe_pickle.py
@@ -1,0 +1,70 @@
+"""Tests for safe pickle integration in playback_recording module."""
+
+import os
+import pickle
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from robot_sf.common.safe_pickle import UnsafePickleError
+from robot_sf.render.playback_recording import load_states
+
+
+class TestPlaybackRecordingSafePickle:
+    """Tests for safe pickle in playback_recording.load_states."""
+
+    def test_real_example_recording_loads(self) -> None:
+        """Verify that a real example recording loads unchanged."""
+        example_dir = Path("examples/recordings")
+        pkl_files = list(example_dir.glob("*.pkl"))
+
+        if not pkl_files:
+            pytest.skip("No example recordings available")
+
+        smallest = min(pkl_files, key=lambda p: p.stat().st_size)
+        loaded_states, _loaded_map_def = load_states(str(smallest))
+        assert len(loaded_states) > 0
+
+    def test_malicious_pickle_rejected(self) -> None:
+        """Verify that malicious pickle is rejected before execution."""
+
+        class Evil:
+            def __reduce__(self):
+                return (os.system, ("echo should-not-run",))
+
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            temp_path = Path(f.name)
+            pickle.dump(Evil(), f)
+
+        try:
+            with pytest.raises(UnsafePickleError) as exc_info:
+                load_states(str(temp_path))
+
+            assert "posix.system" in str(exc_info.value) or "os.system" in str(exc_info.value)
+            assert "playback recording" in str(exc_info.value)
+        finally:
+            temp_path.unlink()
+
+    def test_empty_file_error(self) -> None:
+        """Verify that empty file raises appropriate error."""
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            temp_path = Path(f.name)
+
+        try:
+            with pytest.raises(ValueError, match="empty"):
+                load_states(str(temp_path))
+        finally:
+            temp_path.unlink()
+
+    def test_wrong_type_error(self) -> None:
+        """Verify that wrong tuple type raises TypeError."""
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            temp_path = Path(f.name)
+            pickle.dump({"wrong": "structure"}, f)
+
+        try:
+            with pytest.raises((TypeError, ValueError)):
+                load_states(str(temp_path))
+        finally:
+            temp_path.unlink()


### PR DESCRIPTION
## What

Replace the three production `pickle.load(...)` calls with a restricted unpickler that allowlists only the symbols required by existing trusted RobotSF recordings and SocNavBench ETH traversible payloads, rejecting malicious or unexpected pickle globals with a clear error.

## Why

External code review identified `pickle.load` in 3 production files as an RCE surface:
- `robot_sf/render/jsonl_playback.py`
- `robot_sf/render/playback_recording.py`
- `robot_sf/data/external/socnavbench_eth.py`

Recordings (`.pkl`) are shared in `examples/recordings/`, so the trust boundary is real.

## Changes

### New files
- `robot_sf/common/safe_pickle.py` — `RestrictedUnpickler`, `restricted_pickle_load`, `restricted_pickle_load_path`, and named allowlists (`PLAYBACK_RECORDING_ALLOWED_GLOBALS`, `SOCNAVBENCH_TRAVERSIBLE_ALLOWED_GLOBALS`)
- `tests/common/test_safe_pickle.py` — 12 tests for restricted unpickler security and functionality
- `tests/render/test_playback_recording_safe_pickle.py` — 4 tests for playback recording safe pickle integration
- `tests/data/test_socnavbench_eth_safe_pickle.py` — 4 tests for SocNavBench ETH safe pickle integration
- `examples/recordings/README.md` — trust boundary documentation

### Modified files
- `robot_sf/render/jsonl_playback.py` — use `restricted_pickle_load` in `_load_pickle_file`
- `robot_sf/render/playback_recording.py` — use `restricted_pickle_load` in `load_states`
- `robot_sf/data/external/socnavbench_eth.py` — use `restricted_pickle_load` in `load_shape_contract`

## Validation

```bash
uv run ruff check robot_sf/common/safe_pickle.py robot_sf/render/jsonl_playback.py robot_sf/render/playback_recording.py robot_sf/data/external/socnavbench_eth.py tests/common/test_safe_pickle.py tests/render/test_playback_recording_safe_pickle.py tests/data/test_socnavbench_eth_safe_pickle.py

uv run pytest tests/common/test_safe_pickle.py tests/render/test_playback_recording_safe_pickle.py tests/data/test_socnavbench_eth_safe_pickle.py tests/data/external/test_socnavbench_eth_shape.py -v
```

All 24 tests pass (20 new + 4 existing), ruff clean.

## Notes

- Allowlists include both NumPy 1.x (`numpy.core.multiarray`) and NumPy 2.x (`numpy._core.multiarray`) paths for compatibility
- `_codecs.encode` added to both allowlists for protocol-2 pickle support
- Malicious pickle tests cover `os.system`, `subprocess.call`, and `eval` attack vectors
- Real example recording (`examples/recordings/2024-11-19_20-39-32.pkl`) loads unchanged through the restricted unpickler
- This is a mitigation, not a proof that pickle is safe — docs are precise about this boundary

Closes #4767

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.