### PR TITLE
Issue #4784: Wire failure-record converter to real SVG maps (cheap-lane worker)

### DIFF
--- a/docs/context/issue_4760_failure_record_to_scenario.md
+++ b/docs/context/issue_4760_failure_record_to_scenario.md
@@ -128,7 +128,7 @@ Contextual factors become scenario metadata, not simulator behavior:
 
 1. **No LLM generation**: This prototype uses deterministic templates only.
 2. **Single pedestrians only**: Actor counts > 1 are noted but not expanded into groups.
-3. **Map assumptions**: Converter assumes canonical maps exist for each template.
+3. **Map templates are approximations**: Each template maps to an existing SVG under `maps/svg_maps/`. The map is a structural approximation of the failure environment, not a replica. Paths are computed relative to the generated YAML location so that `--output-yaml` produces file-relative paths and `--stdout` produces repo-relative paths.
 4. **No validation of executability**: Generated scenarios may reference POIs that do not exist in the target map.
 5. **No evidence claims**: Generated scenarios are hypotheses until executed and reviewed.
 

--- a/scripts/tools/convert_failure_record_to_scenario.py
+++ b/scripts/tools/convert_failure_record_to_scenario.py
@@ -15,12 +15,15 @@ from __future__ import annotations
 
 import argparse
 import copy
+import os
 import sys
 from pathlib import Path
 from typing import Any
 
 import yaml
 from loguru import logger
+
+_REPO_ROOT: Path = Path(__file__).resolve().parent.parent.parent
 
 FAILURE_RECORD_SCHEMA_VERSION = "failure-record.v1"
 SCENARIO_MATRIX_SCHEMA_VERSION = "robot_sf.scenario_matrix.v1"
@@ -35,12 +38,12 @@ ENVIRONMENT_TO_TEMPLATE = {
     "road_edge": "road_edge",
 }
 
-TEMPLATE_TO_MAP = {
-    "event_disruption": "../../maps/svg_maps/classic_crossing.svg",
-    "ammv_sidewalk": "../../maps/svg_maps/classic_doorway.svg",
-    "ammv_shared_space": "../../maps/svg_maps/classic_merging.svg",
-    "classic_crossing": "../../maps/svg_maps/classic_crossing.svg",
-    "road_edge": "../../maps/svg_maps/classic_t_intersection.svg",
+TEMPLATE_TO_MAP: dict[str, Path] = {
+    "event_disruption": Path("maps/svg_maps/classic_crossing.svg"),
+    "ammv_sidewalk": Path("maps/svg_maps/classic_doorway.svg"),
+    "ammv_shared_space": Path("maps/svg_maps/classic_merging.svg"),
+    "classic_crossing": Path("maps/svg_maps/classic_crossing.svg"),
+    "road_edge": Path("maps/svg_maps/classic_t_intersection.svg"),
 }
 
 FAILURE_MODE_TO_EXPECTED = {
@@ -59,6 +62,27 @@ CONTEXTUAL_FACTOR_WARNINGS = {
     "abnormal_hazard": "Hazard behavior is simplified",
     "narrow_clearance": "Clearance margins may need adjustment",
 }
+
+
+def _map_file_for_output(template: str, *, output_path: Path | None = None) -> str:
+    """Return the map file path relative to the generated scenario file.
+
+    When ``output_path`` is known the path is relative to the output directory.
+    Otherwise the repository-relative path is returned so that ``--stdout``
+    output documents the canonical location.
+    """
+    repo_rel = TEMPLATE_TO_MAP.get(template, TEMPLATE_TO_MAP["ammv_sidewalk"])
+    if output_path is None:
+        return repo_rel.as_posix()
+    return os.path.relpath(_REPO_ROOT / repo_rel, start=output_path.parent)
+
+
+def _resolve_generated_map_file(generated_yaml: Path, map_file: str) -> Path:
+    """Resolve a ``map_file`` value against the scenario YAML location."""
+    candidate = Path(map_file)
+    if not candidate.is_absolute():
+        candidate = generated_yaml.parent / candidate
+    return candidate.resolve()
 
 
 def _configure_logging(verbose: bool = False) -> None:
@@ -200,13 +224,15 @@ def _generate_pedestrians(
     return pedestrians
 
 
-def _build_scenario_payload(failure_record: dict[str, Any]) -> dict[str, Any]:
+def _build_scenario_payload(
+    failure_record: dict[str, Any], *, output_path: Path | None = None
+) -> dict[str, Any]:
     """Build the complete scenario YAML payload from a failure record."""
     fr = copy.deepcopy(failure_record)
 
     env = fr.get("environment", "sidewalk")
     template = ENVIRONMENT_TO_TEMPLATE.get(env, "ammv_sidewalk")
-    map_file = TEMPLATE_TO_MAP.get(template, TEMPLATE_TO_MAP["ammv_sidewalk"])
+    map_file = _map_file_for_output(template, output_path=output_path)
 
     failure_mode = fr.get("failure_mode", "blocked_path")
     expected_modes = FAILURE_MODE_TO_EXPECTED.get(failure_mode, ["stuck"])
@@ -304,7 +330,7 @@ def convert_failure_record(
 
     logger.info("Validation passed")
 
-    payload = _build_scenario_payload(record["failure_record"])
+    payload = _build_scenario_payload(record["failure_record"], output_path=output_path)
 
     if output_path is not None:
         output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/tools/convert_failure_record_to_scenario.py
+++ b/scripts/tools/convert_failure_record_to_scenario.py
@@ -36,11 +36,11 @@ ENVIRONMENT_TO_TEMPLATE = {
 }
 
 TEMPLATE_TO_MAP = {
-    "event_disruption": "../../../maps/svg_maps/event_disruption/event_disruption.svg",
-    "ammv_sidewalk": "../../../maps/svg_maps/ammv_sidewalk/ammv_sidewalk.svg",
-    "ammv_shared_space": "../../../maps/svg_maps/ammv_shared_space/ammv_shared_space.svg",
-    "classic_crossing": "../../../maps/svg_maps/classic_crossing/classic_crossing.svg",
-    "road_edge": "../../../maps/svg_maps/road_edge/road_edge.svg",
+    "event_disruption": "../../maps/svg_maps/classic_crossing.svg",
+    "ammv_sidewalk": "../../maps/svg_maps/classic_doorway.svg",
+    "ammv_shared_space": "../../maps/svg_maps/classic_merging.svg",
+    "classic_crossing": "../../maps/svg_maps/classic_crossing.svg",
+    "road_edge": "../../maps/svg_maps/classic_t_intersection.svg",
 }
 
 FAILURE_MODE_TO_EXPECTED = {

--- a/tests/tools/test_convert_failure_record_to_scenario.py
+++ b/tests/tools/test_convert_failure_record_to_scenario.py
@@ -12,10 +12,13 @@ import yaml
 
 from scripts.tools.convert_failure_record_to_scenario import (
     FAILURE_RECORD_SCHEMA_VERSION,
+    TEMPLATE_TO_MAP,
     _build_scenario_payload,
     _generate_assumptions,
     _generate_invalidity_warnings,
     _generate_pedestrians,
+    _map_file_for_output,
+    _resolve_generated_map_file,
     _validate_failure_record,
     convert_failure_record,
 )
@@ -284,18 +287,56 @@ class TestScenarioPayload:
 
     def test_map_file_paths_resolve_to_existing_files(self):
         """All emitted map_file paths must resolve to existing SVG maps."""
-        repo_root = Path(__file__).resolve().parent.parent.parent
         test_records = [
             VALID_EVENT_RECORD["failure_record"],
             VALID_SIDEWALK_RECORD["failure_record"],
         ]
         for record in test_records:
-            payload = _build_scenario_payload(record)
-            scenario = payload["scenarios"][0]
-            map_file = scenario["map_file"]
-            resolved = (repo_root / "output" / "failure_record_scenarios").resolve()
-            expected_map = (resolved / map_file).resolve()
-            assert expected_map.exists(), f"map_file {map_file!r} resolves to {expected_map} which does not exist"
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output_path = Path(tmpdir) / "scenario.yaml"
+                payload = _build_scenario_payload(record, output_path=output_path)
+                scenario = payload["scenarios"][0]
+                resolved = _resolve_generated_map_file(output_path, scenario["map_file"])
+                assert resolved.is_file(), (
+                    f"map_file {scenario['map_file']!r} resolves to {resolved} which does not exist"
+                )
+
+
+class TestMapFileResolution:
+    """Tests for TEMPLATE_TO_MAP and map path resolution."""
+
+    def test_all_template_to_map_entries_exist(self):
+        """Every TEMPLATE_TO_MAP entry must point to an existing SVG."""
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        for template, repo_rel in TEMPLATE_TO_MAP.items():
+            svg = (repo_root / repo_rel).resolve()
+            assert svg.is_file(), (
+                f"TEMPLATE_TO_MAP[{template!r}] -> {repo_rel} resolves to {svg}, which does not exist"
+            )
+
+    def test_stdout_uses_repo_relative_paths(self):
+        """When output_path is None the map path is repo-relative."""
+        payload = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"], output_path=None)
+        map_file = payload["scenarios"][0]["map_file"]
+        assert map_file.startswith("maps/svg_maps/"), (
+            f"stdout map_file should be repo-relative, got {map_file!r}"
+        )
+
+    def test_output_yaml_uses_output_relative_paths(self):
+        """When output_path is provided the map path is relative to its parent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "subdir" / "scenario.yaml"
+            payload = _build_scenario_payload(
+                VALID_SIDEWALK_RECORD["failure_record"], output_path=output_path
+            )
+            map_file = payload["scenarios"][0]["map_file"]
+            resolved = _resolve_generated_map_file(output_path, map_file)
+            assert resolved.is_file()
+
+    def test_map_file_for_output_returns_string(self):
+        """_map_file_for_output returns a plain string, not a Path."""
+        result = _map_file_for_output("ammv_sidewalk")
+        assert isinstance(result, str)
 
 
 class TestConvertFailureRecord:

--- a/tests/tools/test_convert_failure_record_to_scenario.py
+++ b/tests/tools/test_convert_failure_record_to_scenario.py
@@ -222,14 +222,14 @@ class TestScenarioPayload:
         payload = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
         assert "scenarios" in payload
         scenario = payload["scenarios"][0]
-        assert "event_disruption" in scenario["map_file"]
+        assert "classic_crossing" in scenario["map_file"]
         assert "failure_record_test-event-001" in scenario["name"]
 
     def test_sidewalk_scenario(self):
         """Sidewalk record generates sidewalk scenario."""
         payload = _build_scenario_payload(VALID_SIDEWALK_RECORD["failure_record"])
         scenario = payload["scenarios"][0]
-        assert "ammv_sidewalk" in scenario["map_file"]
+        assert "classic_doorway" in scenario["map_file"]
 
     def test_metadata_required_manual_review(self):
         """Output always has required_manual_review: true."""
@@ -281,6 +281,21 @@ class TestScenarioPayload:
         payload1 = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
         payload2 = _build_scenario_payload(VALID_EVENT_RECORD["failure_record"])
         assert payload1 == payload2
+
+    def test_map_file_paths_resolve_to_existing_files(self):
+        """All emitted map_file paths must resolve to existing SVG maps."""
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        test_records = [
+            VALID_EVENT_RECORD["failure_record"],
+            VALID_SIDEWALK_RECORD["failure_record"],
+        ]
+        for record in test_records:
+            payload = _build_scenario_payload(record)
+            scenario = payload["scenarios"][0]
+            map_file = scenario["map_file"]
+            resolved = (repo_root / "output" / "failure_record_scenarios").resolve()
+            expected_map = (resolved / map_file).resolve()
+            assert expected_map.exists(), f"map_file {map_file!r} resolves to {expected_map} which does not exist"
 
 
 class TestConvertFailureRecord:


### PR DESCRIPTION
## What / Why

`convert_failure_record_to_scenario.py` emitted `map_file` paths that pointed to nonexistent
subdirectories (`maps/svg_maps/event_disruption/event_disruption.svg`, etc.). This PR wires
each `TEMPLATE_TO_MAP` entry to an existing SVG under `maps/svg_maps/` and adds a
`_map_file_for_output` helper that computes the correct relative path based on the output
location:

- **`--output-yaml`**: paths are relative to the generated YAML file's parent directory
- **`--stdout`**: paths are repo-relative (`maps/svg_maps/*.svg`) for documentation clarity

## Changes

- `scripts/tools/convert_failure_record_to_scenario.py`:
  - `TEMPLATE_TO_MAP` now uses `Path` values with repo-relative paths to real SVG maps
  - Added `_REPO_ROOT`, `_map_file_for_output()`, `_resolve_generated_map_file()`
  - `_build_scenario_payload` accepts optional `output_path` for path computation
  - `convert_failure_record` passes `output_path` through to the payload builder

- `tests/tools/test_convert_failure_record_to_scenario.py`:
  - Added `TestMapFileResolution` class with 4 tests:
    - every `TEMPLATE_TO_MAP` entry points to an existing SVG
    - `--stdout` uses repo-relative paths
    - `--output-yaml` produces file-relative paths that resolve correctly
    - `_map_file_for_output` returns string type
  - Updated existing assertions to match new map names
  - All 40 tests pass

- `docs/context/issue_4760_failure_record_to_scenario.md`: updated limitations to remove
  "placeholder map" language and describe the path resolution strategy

## Validation

```
uv run ruff check scripts/tools/convert_failure_record_to_scenario.py tests/tools/test_convert_failure_record_to_scenario.py
# All checks passed!

uv run pytest tests/tools/test_convert_failure_record_to_scenario.py -v
# 40 passed in 0.12s
```

## Scope / Successor

This fully resolves #4784. All acceptance criteria met:
- Every `TEMPLATE_TO_MAP` entry maps to an existing SVG under `maps/svg_maps/`
- Emitted `map_file` resolves correctly from the generated YAML location
- Tests cover path resolution for generated outputs
- Draft/manual-review/non-evidence gating remains intact
- No new benchmark evidence or scenario certification is claimed

Closes #4784

---

This PR was produced by the Command-Code/MiMo-V2.5-Pro cheap implementation lane; the review gate hardens and merges.