### PR TITLE
Issue #4803: guard benchmark plot helpers against empty/non-finite metric inputs (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/visualization.py
+++ b/robot_sf/benchmark/visualization.py
@@ -625,6 +625,28 @@ def _filter_finite(values: list) -> list[float]:
     return result
 
 
+def _pair_finite(xs: list, ys: list) -> tuple[list[float], list[float]]:
+    """Return finite (x, y) pairs, dropping a pair when either side is non-finite.
+
+    Used for the success-vs-SNQI scatter so points stay episode-aligned: filtering
+    each series independently would mis-pair points when the two series drop
+    different indices.
+    """
+    xs_out: list[float] = []
+    ys_out: list[float] = []
+    for x, y in zip(xs, ys, strict=False):
+        if x is None or y is None:
+            continue
+        try:
+            fx, fy = float(x), float(y)
+        except (TypeError, ValueError):
+            continue
+        if np.isfinite(fx) and np.isfinite(fy):
+            xs_out.append(fx)
+            ys_out.append(fy)
+    return xs_out, ys_out
+
+
 def _ax_no_data(ax, title: str, xlabel: str = "", ylabel: str = "") -> None:
     """Render a 'No valid data' placeholder on *ax* when a series is empty."""
     ax.set_title(title)
@@ -679,11 +701,10 @@ def _populate_metrics_axes(ax1, ax2, ax3, ax4, collisions, success_rates, snqi_s
     else:
         _ax_no_data(ax3, "SNQI Score Distribution", "SNQI Score", "Frequency")
 
-    # Plot 4: Success vs SNQI scatter
-    if finite_success and finite_snqi:
-        # Align lengths in case counts differ after independent filtering
-        min_len = min(len(finite_success), len(finite_snqi))
-        ax4.scatter(finite_success[:min_len], finite_snqi[:min_len], alpha=0.6, color="purple")
+    # Plot 4: Success vs SNQI scatter (pair-filtered so points stay episode-aligned)
+    paired_success, paired_snqi = _pair_finite(success_rates, snqi_scores)
+    if paired_success:
+        ax4.scatter(paired_success, paired_snqi, alpha=0.6, color="purple")
         ax4.set_title("Success Rate vs SNQI")
         ax4.set_xlabel("Success Rate")
         ax4.set_ylabel("SNQI Score")

--- a/robot_sf/benchmark/visualization.py
+++ b/robot_sf/benchmark/visualization.py
@@ -610,31 +610,85 @@ def _filter_episodes(
     return filtered_episodes
 
 
+def _filter_finite(values: list) -> list[float]:
+    """Return only finite (non-None, non-NaN, non-Inf) numeric values."""
+    result = []
+    for v in values:
+        if v is None:
+            continue
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            continue
+        if np.isfinite(f):
+            result.append(f)
+    return result
+
+
+def _ax_no_data(ax, title: str, xlabel: str = "", ylabel: str = "") -> None:
+    """Render a 'No valid data' placeholder on *ax* when a series is empty."""
+    ax.set_title(title)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.text(
+        0.5,
+        0.5,
+        "No valid data",
+        transform=ax.transAxes,
+        ha="center",
+        va="center",
+        fontsize=12,
+        color="gray",
+    )
+
+
 def _populate_metrics_axes(ax1, ax2, ax3, ax4, collisions, success_rates, snqi_scores) -> None:
-    """Draw the four metrics subplots (factored for both render paths)."""
+    """Draw the four metrics subplots (factored for both render paths).
+
+    Filters ``None`` / non-finite values per series before plotting.
+    Renders a 'No valid data' placeholder when a filtered series is empty.
+    """
+    finite_collisions = _filter_finite(collisions)
+    finite_success = _filter_finite(success_rates)
+    finite_snqi = _filter_finite(snqi_scores)
+
     # Plot 1: Collision distribution
-    ax1.hist(collisions, bins=20, alpha=0.7, color="red")
-    ax1.set_title("Collision Rate Distribution")
-    ax1.set_xlabel("Collision Rate")
-    ax1.set_ylabel("Frequency")
+    if finite_collisions:
+        ax1.hist(finite_collisions, bins=20, alpha=0.7, color="red")
+        ax1.set_title("Collision Rate Distribution")
+        ax1.set_xlabel("Collision Rate")
+        ax1.set_ylabel("Frequency")
+    else:
+        _ax_no_data(ax1, "Collision Rate Distribution", "Collision Rate", "Frequency")
 
     # Plot 2: Success rate distribution
-    ax2.hist(success_rates, bins=20, alpha=0.7, color="green")
-    ax2.set_title("Success Rate Distribution")
-    ax2.set_xlabel("Success Rate")
-    ax2.set_ylabel("Frequency")
+    if finite_success:
+        ax2.hist(finite_success, bins=20, alpha=0.7, color="green")
+        ax2.set_title("Success Rate Distribution")
+        ax2.set_xlabel("Success Rate")
+        ax2.set_ylabel("Frequency")
+    else:
+        _ax_no_data(ax2, "Success Rate Distribution", "Success Rate", "Frequency")
 
     # Plot 3: SNQI distribution
-    ax3.hist(snqi_scores, bins=20, alpha=0.7, color="blue")
-    ax3.set_title("SNQI Score Distribution")
-    ax3.set_xlabel("SNQI Score")
-    ax3.set_ylabel("Frequency")
+    if finite_snqi:
+        ax3.hist(finite_snqi, bins=20, alpha=0.7, color="blue")
+        ax3.set_title("SNQI Score Distribution")
+        ax3.set_xlabel("SNQI Score")
+        ax3.set_ylabel("Frequency")
+    else:
+        _ax_no_data(ax3, "SNQI Score Distribution", "SNQI Score", "Frequency")
 
     # Plot 4: Success vs SNQI scatter
-    ax4.scatter(success_rates, snqi_scores, alpha=0.6, color="purple")
-    ax4.set_title("Success Rate vs SNQI")
-    ax4.set_xlabel("Success Rate")
-    ax4.set_ylabel("SNQI Score")
+    if finite_success and finite_snqi:
+        # Align lengths in case counts differ after independent filtering
+        min_len = min(len(finite_success), len(finite_snqi))
+        ax4.scatter(finite_success[:min_len], finite_snqi[:min_len], alpha=0.6, color="purple")
+        ax4.set_title("Success Rate vs SNQI")
+        ax4.set_xlabel("Success Rate")
+        ax4.set_ylabel("SNQI Score")
+    else:
+        _ax_no_data(ax4, "Success Rate vs SNQI", "Success Rate", "SNQI Score")
 
 
 def _generate_metrics_plot(
@@ -733,24 +787,39 @@ def _generate_metrics_plot(
 def _populate_scenario_comparison_axes(
     ax1, ax2, ax3, scenarios, avg_snqi, avg_collisions, success_rates
 ) -> None:
-    """Draw the three scenario comparison subplots (factored for both paths)."""
+    """Draw the three scenario comparison subplots (factored for both paths).
+
+    ``avg_snqi``, ``avg_collisions``, and ``success_rates`` must already be
+    finite-filtered lists aligned with ``scenarios``.  When a series is empty
+    (no scenarios remain after filtering), a 'No valid data' placeholder is
+    rendered instead of calling bar() with an empty sequence.
+    """
     # Plot 1: Average SNQI by scenario
-    ax1.bar(scenarios, avg_snqi, color="blue", alpha=0.7)
-    ax1.set_title("Average SNQI by Scenario")
-    ax1.set_ylabel("SNQI Score")
-    ax1.tick_params(axis="x", rotation=45)
+    if scenarios:
+        ax1.bar(scenarios, avg_snqi, color="blue", alpha=0.7)
+        ax1.set_title("Average SNQI by Scenario")
+        ax1.set_ylabel("SNQI Score")
+        ax1.tick_params(axis="x", rotation=45)
+    else:
+        _ax_no_data(ax1, "Average SNQI by Scenario", ylabel="SNQI Score")
 
     # Plot 2: Average collision rate by scenario
-    ax2.bar(scenarios, avg_collisions, color="red", alpha=0.7)
-    ax2.set_title("Average Collision Rate by Scenario")
-    ax2.set_ylabel("Collision Rate")
-    ax2.tick_params(axis="x", rotation=45)
+    if scenarios:
+        ax2.bar(scenarios, avg_collisions, color="red", alpha=0.7)
+        ax2.set_title("Average Collision Rate by Scenario")
+        ax2.set_ylabel("Collision Rate")
+        ax2.tick_params(axis="x", rotation=45)
+    else:
+        _ax_no_data(ax2, "Average Collision Rate by Scenario", ylabel="Collision Rate")
 
     # Plot 3: Success rate by scenario
-    ax3.bar(scenarios, success_rates, color="green", alpha=0.7)
-    ax3.set_title("Success Rate by Scenario")
-    ax3.set_ylabel("Success Rate")
-    ax3.tick_params(axis="x", rotation=45)
+    if scenarios:
+        ax3.bar(scenarios, success_rates, color="green", alpha=0.7)
+        ax3.set_title("Success Rate by Scenario")
+        ax3.set_ylabel("Success Rate")
+        ax3.tick_params(axis="x", rotation=45)
+    else:
+        _ax_no_data(ax3, "Success Rate by Scenario", ylabel="Success Rate")
 
 
 def _generate_scenario_comparison_plot(
@@ -786,13 +855,17 @@ def _generate_scenario_comparison_plot(
 
         for scenario in scenarios:
             eps = scenario_groups[scenario]
-            snqi_scores = [ep.get("metrics", {}).get("snqi", 0) for ep in eps]
-            collision_rates = [ep.get("metrics", {}).get("collision_rate", 0) for ep in eps]
-            successes = [ep.get("metrics", {}).get("success_rate", 1) for ep in eps]
+            snqi_scores = _filter_finite([ep.get("metrics", {}).get("snqi") for ep in eps])
+            collision_rates = _filter_finite(
+                [ep.get("metrics", {}).get("collision_rate") for ep in eps]
+            )
+            successes = _filter_finite([ep.get("metrics", {}).get("success_rate") for ep in eps])
 
-            avg_snqi.append(sum(snqi_scores) / len(snqi_scores))
-            avg_collisions.append(sum(collision_rates) / len(collision_rates))
-            success_rates.append(sum(successes) / len(successes))
+            avg_snqi.append(sum(snqi_scores) / len(snqi_scores) if snqi_scores else 0.0)
+            avg_collisions.append(
+                sum(collision_rates) / len(collision_rates) if collision_rates else 0.0
+            )
+            success_rates.append(sum(successes) / len(successes) if successes else 0.0)
 
         plot_filename = "scenario_comparison.pdf"
         if publication:

--- a/robot_sf/benchmark/visualization.py
+++ b/robot_sf/benchmark/visualization.py
@@ -730,9 +730,9 @@ def _generate_metrics_plot(
 
     try:
         # Extract metrics
-        collisions = [ep.get("metrics", {}).get("collision_rate", 0) for ep in episodes]
-        success_rates = [ep.get("metrics", {}).get("success_rate", 0) for ep in episodes]
-        snqi_scores = [ep.get("metrics", {}).get("snqi", 0) for ep in episodes]
+        collisions = [(ep.get("metrics") or {}).get("collision_rate", 0) for ep in episodes]
+        success_rates = [(ep.get("metrics") or {}).get("success_rate", 0) for ep in episodes]
+        snqi_scores = [(ep.get("metrics") or {}).get("snqi", 0) for ep in episodes]
 
         plot_filename = "metrics_distribution.pdf"
         if publication:
@@ -876,11 +876,13 @@ def _generate_scenario_comparison_plot(
 
         for scenario in scenarios:
             eps = scenario_groups[scenario]
-            snqi_scores = _filter_finite([ep.get("metrics", {}).get("snqi") for ep in eps])
+            snqi_scores = _filter_finite([(ep.get("metrics") or {}).get("snqi") for ep in eps])
             collision_rates = _filter_finite(
-                [ep.get("metrics", {}).get("collision_rate") for ep in eps]
+                [(ep.get("metrics") or {}).get("collision_rate") for ep in eps]
             )
-            successes = _filter_finite([ep.get("metrics", {}).get("success_rate") for ep in eps])
+            successes = _filter_finite(
+                [(ep.get("metrics") or {}).get("success_rate") for ep in eps]
+            )
 
             avg_snqi.append(sum(snqi_scores) / len(snqi_scores) if snqi_scores else 0.0)
             avg_collisions.append(

--- a/tests/test_benchmark_plot_helpers_robustness.py
+++ b/tests/test_benchmark_plot_helpers_robustness.py
@@ -215,3 +215,32 @@ def test_populate_scenario_comparison_axes_valid_uses_bar():
     ax1.bar.assert_called_once()
     ax2.bar.assert_called_once()
     ax3.bar.assert_called_once()
+
+
+def test_generate_metrics_plot_null_metrics_no_raise(tmp_path):
+    """An episode with an explicit ``metrics: None`` must not raise AttributeError.
+
+    ``ep.get("metrics", {})`` returns ``None`` for a null-valued key, so the
+    downstream ``.get(...)`` would crash; the generator must coerce to ``{}``.
+    """
+    from robot_sf.benchmark.visualization import _generate_metrics_plot
+
+    episodes = [
+        {"scenario_id": "s", "metrics": None},
+        {"scenario_id": "s", "metrics": {"snqi": 0.5, "collision_rate": 0.1, "success_rate": 0.9}},
+    ]
+    artifact = _generate_metrics_plot(episodes, str(tmp_path))
+    assert artifact.status == "generated"
+
+
+def test_generate_scenario_comparison_plot_null_metrics_no_raise(tmp_path):
+    """Explicit ``metrics: None`` must not crash scenario comparison aggregation."""
+    from robot_sf.benchmark.visualization import _generate_scenario_comparison_plot
+
+    episodes = [
+        {"scenario_id": "a", "metrics": None},
+        {"scenario_id": "a", "metrics": {"snqi": 0.4, "collision_rate": 0.2, "success_rate": 0.8}},
+        {"scenario_id": "b", "metrics": None},
+    ]
+    artifact = _generate_scenario_comparison_plot(episodes, str(tmp_path))
+    assert artifact.status == "generated"

--- a/tests/test_benchmark_plot_helpers_robustness.py
+++ b/tests/test_benchmark_plot_helpers_robustness.py
@@ -51,6 +51,26 @@ def test_filter_finite_empty_input():
     assert _filter_finite([]) == []
 
 
+def test_pair_finite_keeps_episode_alignment():
+    """_pair_finite drops a pair when either side is non-finite, keeping x/y aligned."""
+    from robot_sf.benchmark.visualization import _pair_finite
+
+    # episode 0: success finite, snqi NaN -> drop; episode 1: both finite -> keep;
+    # episode 2: success None -> drop.
+    xs, ys = _pair_finite([0.2, 0.5, None], [float("nan"), 0.9, 0.3])
+    assert xs == pytest.approx([0.5])
+    assert ys == pytest.approx([0.9])
+
+
+def test_pair_finite_empty_when_no_overlap():
+    """No pair survives when finite values never coincide on the same index."""
+    from robot_sf.benchmark.visualization import _pair_finite
+
+    xs, ys = _pair_finite([0.1, float("nan")], [float("nan"), 0.2])
+    assert xs == []
+    assert ys == []
+
+
 def test_ax_no_data_does_not_raise():
     """_ax_no_data renders placeholder text and sets axis labels."""
     from robot_sf.benchmark.visualization import _ax_no_data

--- a/tests/test_benchmark_plot_helpers_robustness.py
+++ b/tests/test_benchmark_plot_helpers_robustness.py
@@ -1,0 +1,197 @@
+"""Tests for issue #4803: benchmark plot helpers guard against empty / non-finite inputs.
+
+Acceptance criteria from the issue:
+- Both helpers filter None/non-finite values and handle empty input without raising.
+- Each helper called with empty and NaN-laden inputs renders without error.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers: _filter_finite, _ax_no_data
+# ---------------------------------------------------------------------------
+
+
+def test_filter_finite_removes_none():
+    """None values are stripped from the output list."""
+    from robot_sf.benchmark.visualization import _filter_finite
+
+    assert _filter_finite([None, 1.0, None]) == [1.0]
+
+
+def test_filter_finite_removes_nan():
+    """NaN values are stripped from the output list."""
+    from robot_sf.benchmark.visualization import _filter_finite
+
+    assert _filter_finite([float("nan"), 0.5]) == [0.5]
+
+
+def test_filter_finite_removes_inf():
+    """±Inf values are stripped from the output list."""
+    from robot_sf.benchmark.visualization import _filter_finite
+
+    assert _filter_finite([float("inf"), float("-inf"), 0.1]) == pytest.approx([0.1])
+
+
+def test_filter_finite_all_non_finite():
+    """All-invalid inputs produce an empty list."""
+    from robot_sf.benchmark.visualization import _filter_finite
+
+    assert _filter_finite([None, float("nan"), float("inf")]) == []
+
+
+def test_filter_finite_empty_input():
+    """Empty input returns empty list without error."""
+    from robot_sf.benchmark.visualization import _filter_finite
+
+    assert _filter_finite([]) == []
+
+
+def test_ax_no_data_does_not_raise():
+    """_ax_no_data renders placeholder text and sets axis labels."""
+    from robot_sf.benchmark.visualization import _ax_no_data
+
+    ax = MagicMock()
+    _ax_no_data(ax, "My Title", xlabel="X", ylabel="Y")
+    ax.set_title.assert_called_once_with("My Title")
+    ax.set_xlabel.assert_called_once_with("X")
+    ax.set_ylabel.assert_called_once_with("Y")
+    ax.text.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _populate_metrics_axes: normal and degenerate inputs
+# ---------------------------------------------------------------------------
+
+
+def _make_axes():
+    """Return four MagicMock axes."""
+    return MagicMock(), MagicMock(), MagicMock(), MagicMock()
+
+
+@pytest.mark.parametrize(
+    "collisions, success_rates, snqi_scores",
+    [
+        # All empty
+        ([], [], []),
+        # All None
+        ([None, None], [None], [None]),
+        # Mixed NaN / Inf / None
+        ([float("nan"), None, float("inf")], [None], [float("nan")]),
+        # Some valid, some invalid
+        ([None, 0.1, float("nan")], [0.5, None], [float("inf"), 0.7]),
+    ],
+)
+def test_populate_metrics_axes_degenerate_no_raise(collisions, success_rates, snqi_scores):
+    """_populate_metrics_axes must not raise for degenerate inputs."""
+    from robot_sf.benchmark.visualization import _populate_metrics_axes
+
+    ax1, ax2, ax3, ax4 = _make_axes()
+    # Should complete without raising
+    _populate_metrics_axes(ax1, ax2, ax3, ax4, collisions, success_rates, snqi_scores)
+
+
+def test_populate_metrics_axes_empty_uses_no_data_placeholder():
+    """When all series are empty, _ax_no_data is called for each subplot."""
+    from robot_sf.benchmark.visualization import _populate_metrics_axes
+
+    ax1, ax2, ax3, ax4 = _make_axes()
+    _populate_metrics_axes(ax1, ax2, ax3, ax4, [], [], [])
+
+    # No hist/scatter calls when data is absent
+    ax1.hist.assert_not_called()
+    ax2.hist.assert_not_called()
+    ax3.hist.assert_not_called()
+    ax4.scatter.assert_not_called()
+
+    # Placeholder text rendered on each axis
+    for ax in (ax1, ax2, ax3, ax4):
+        ax.text.assert_called_once()
+
+
+def test_populate_metrics_axes_valid_data_uses_plots():
+    """With valid data, hist and scatter are called (not placeholders)."""
+    from robot_sf.benchmark.visualization import _populate_metrics_axes
+
+    ax1, ax2, ax3, ax4 = _make_axes()
+    _populate_metrics_axes(
+        ax1,
+        ax2,
+        ax3,
+        ax4,
+        [0.1, 0.2],
+        [0.8, 0.9],
+        [0.6, 0.7],
+    )
+
+    ax1.hist.assert_called_once()
+    ax2.hist.assert_called_once()
+    ax3.hist.assert_called_once()
+    ax4.scatter.assert_called_once()
+
+
+def test_populate_metrics_axes_nan_filtered_valid_data_uses_plots():
+    """Valid values survive NaN filtering and still reach hist/scatter."""
+    from robot_sf.benchmark.visualization import _populate_metrics_axes
+
+    ax1, ax2, ax3, ax4 = _make_axes()
+    _populate_metrics_axes(
+        ax1,
+        ax2,
+        ax3,
+        ax4,
+        [0.1, float("nan"), None],  # one finite value
+        [float("inf"), 0.5],  # one finite value
+        [None, 0.9],  # one finite value
+    )
+
+    ax1.hist.assert_called_once()
+    ax2.hist.assert_called_once()
+    ax3.hist.assert_called_once()
+    ax4.scatter.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _populate_scenario_comparison_axes: normal and degenerate inputs
+# ---------------------------------------------------------------------------
+
+
+def test_populate_scenario_comparison_axes_empty_no_raise():
+    """_populate_scenario_comparison_axes with empty scenarios must not raise."""
+    from robot_sf.benchmark.visualization import _populate_scenario_comparison_axes
+
+    ax1, ax2, ax3 = MagicMock(), MagicMock(), MagicMock()
+    _populate_scenario_comparison_axes(ax1, ax2, ax3, [], [], [], [])
+
+    # bar must not be called with empty sequences
+    ax1.bar.assert_not_called()
+    ax2.bar.assert_not_called()
+    ax3.bar.assert_not_called()
+
+    # Placeholder text rendered on each axis
+    for ax in (ax1, ax2, ax3):
+        ax.text.assert_called_once()
+
+
+def test_populate_scenario_comparison_axes_valid_uses_bar():
+    """With valid scenarios, bar is called for each subplot."""
+    from robot_sf.benchmark.visualization import _populate_scenario_comparison_axes
+
+    ax1, ax2, ax3 = MagicMock(), MagicMock(), MagicMock()
+    _populate_scenario_comparison_axes(
+        ax1,
+        ax2,
+        ax3,
+        ["scen_a", "scen_b"],
+        [0.8, 0.7],
+        [0.1, 0.2],
+        [0.9, 0.85],
+    )
+
+    ax1.bar.assert_called_once()
+    ax2.bar.assert_called_once()
+    ax3.bar.assert_called_once()


### PR DESCRIPTION
## What / Why

`_populate_metrics_axes` and `_populate_scenario_comparison_axes` in
`robot_sf/benchmark/visualization.py` passed metric lists straight to
matplotlib `hist` / `scatter` / `bar` without filtering `None` / `NaN` / `Inf`
or handling the fully-empty case. With degenerate inputs matplotlib could
produce empty axes or fail to compute limits (surfaced by gemini-code-assist on
PR #4800, lines ~638 and ~748).

## Changes

- **`_filter_finite(values)`** — new private helper; strips `None`, `NaN`, and
  `±Inf` from any metric series before plotting.
- **`_ax_no_data(ax, title, xlabel, ylabel)`** — new private helper; renders a
  grey "No valid data" text placeholder when a filtered series is empty.
- **`_populate_metrics_axes`** — filters each of the three series through
  `_filter_finite`; falls back to `_ax_no_data` per-subplot when the filtered
  series is empty; aligns scatter lengths when success_rates and snqi_scores
  filter to different lengths.
- **`_populate_scenario_comparison_axes`** — renders `_ax_no_data` placeholders
  when the scenarios list is empty after upstream filtering.
- **`_generate_scenario_comparison_plot`** — applies `_filter_finite` on each
  per-scenario metric list before averaging; uses 0.0 fallback to prevent
  `ZeroDivisionError` when the full list is non-finite.

## Validation

```
DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/test_benchmark_plot_helpers_robustness.py -v
```

```
15 passed in 1.56s
```

```
uv run ruff check robot_sf/benchmark/visualization.py tests/test_benchmark_plot_helpers_robustness.py
# All checks passed!
uv run ruff format --check robot_sf/benchmark/visualization.py tests/test_benchmark_plot_helpers_robustness.py
# 2 files already formatted
```

Test cases cover: `_filter_finite` with None / NaN / Inf / all-invalid / empty inputs;
`_ax_no_data` placeholder rendering; `_populate_metrics_axes` with all-empty, all-None,
mixed-invalid, and valid data; `_populate_scenario_comparison_axes` with empty and valid data.

## Successor statement

Fully resolves the issue; no successor slice required.

Closes #4803

---

This PR was produced by the agy/Claude-Sonnet-4.6-Thinking cheap implementation
lane; the review gate hardens and merges.
