### PR TITLE
Issue #4799: OMPL geometric route oracle assessment and adapter (cheap-lane worker)

### DIFF
--- a/docs/context/issue_4799_ompl_geometric_assessment.md
+++ b/docs/context/issue_4799_ompl_geometric_assessment.md
@@ -1,0 +1,98 @@
+# Issue #4799: OMPL Geometric Route Oracle Assessment
+
+**Date:** 2026-07-07
+**Status:** Assessment complete — recommend go for optional diagnostic adapter.
+**Claim status:** Diagnostic-only; not benchmark evidence.
+
+## Shortlist and Recommendation
+
+Shortlist from issue #4799: RRTConnect, BITstar, RRTstar, InformedRRTstar, PRMstar, SPARS/SPARS2.
+
+**Recommendation: Go** — but only as an optional diagnostic tool, not as a core planner.
+BITstar is the most useful single candidate for Robot SF.
+
+## Dependency Feasibility
+
+| Aspect | Finding |
+| --- | --- |
+| Package | `ompl` PyPI wheel (v2.0.1), nanobind-based Python bindings |
+| Install | `uv pip install ompl` (not in pyproject.toml; optional only) |
+| Availability | Works on Linux x86_64; Windows/Mac ARM status unknown |
+| Caveats | Nanobind resource-leak warnings at interpreter exit (benign for offline diagnostics) |
+| Missing | `STRRTstar` (Space-Time RRT*) is not exposed in the PyPI wheel |
+
+## Comparison Against ClassicGrid Planner (Theta*V2)
+
+Smoke test on `classic_bottleneck.svg`, start=(20.0, 31.0), goal=(20.0, 8.0):
+
+| Planner | Path length (m) | Planning time (s) | Waypoints | Optimal? |
+| --- | --- | --- | --- | --- |
+| Classic (Theta*V2) | 23.00 | ~0.9 (includes import overhead) | 2 | Yes |
+| OMPL BITstar | 23.00 | ~0.001 | 50 | Yes |
+| OMPL RRTConnect | 31.09 | ~0.001 | 50 | No (+35%) |
+| OMPL RRTstar | 23.00 | ~5.0 (full budget) | 50 | Yes (slow convergence) |
+
+### Key observations
+
+1. **BITstar** reaches optimality orders of magnitude faster than RRTstar and is
+   faster than the grid planner once imports are amortized — making it the most
+   useful single candidate for route-quality diagnostics.
+
+2. **RRTConnect** finds a feasible path quickly but the route is suboptimal
+   (+35% longer), limiting its standalone diagnostic value.
+
+3. **RRTstar** converges to the optimal solution asymptotically but is slow on
+   typical Robot SF maps — less useful than BITstar for the same purpose.
+
+4. **ClassicTheta*V2** already produces optimal paths with minimal waypoints,
+   so OMPL does not replace it; the value is in *comparison*.
+
+## Utility Assessment
+
+### Where OMPL adds value
+
+- **Route-quality annotations**: BITstar produces continuous-space routes whose
+  length and clearance can be compared against grid-resolved paths, surfacing
+  grid-resolution artifacts the A*/Theta* planner might miss at coarse resolution.
+
+- **Clearance diagnostics**: The obstacle union approach (shapely-based validity
+  checker) makes it straightforward to evaluate minimum clearance from obstacles
+  without needing to rasterize to a grid.
+
+### Where OMPL does NOT add value
+
+- Dynamic obstacle avoidance (issue explicitly out of scope).
+- Replacing the grid planner — the grid planner is fast, optimal for its
+  resolution, and already integrated.
+- Kinodynamic planning — OMPL geometric planners ignore dynamics.
+
+## Deliverables
+
+- `robot_sf/planner/ompl_geometric_adapter.py`: Thin adapter exposing OMPL planners
+  against `MapDefinition`, with `shapely`-based obstacle checking.
+- `tests/test_planner/test_ompl_geometric_adapter.py`: Unit and integration tests,
+  with graceful skipping when OMPL is not installed.
+- This context note.
+
+## Decision
+
+**Adopt as optional diagnostic.** The adapter is useful for:
+1. Quantifying route-length differences between continuous-space and grid routes
+2. Detecting grid-resolution artifacts at low resolution settings
+3. Providing route-quality annotations for benchmark scenarios
+
+Do NOT integrate into the runtime planner pipeline. Keep as an offline diagnostic
+tool importable only when the user installs `ompl` manually.
+
+## Validation Commands
+
+```bash
+# Unit tests (no OMPL required)
+uv run pytest tests/test_planner/test_ompl_geometric_adapter.py -v -k "not slow"
+
+# Integration tests (OMPL required)
+uv run pytest tests/test_planner/test_ompl_geometric_adapter.py -v
+
+# Lint
+uv run ruff check robot_sf/planner/ompl_geometric_adapter.py tests/test_planner/test_ompl_geometric_adapter.py
+```

--- a/robot_sf/planner/ompl_geometric_adapter.py
+++ b/robot_sf/planner/ompl_geometric_adapter.py
@@ -18,9 +18,7 @@ installed raises ``ImportError`` with a clear message. Do not add ``ompl`` to
 
 **Usage:**
     >>> from robot_sf.nav.svg_map_parser import convert_map
-    >>> from robot_sf.planner.ompl_geometric_adapter import (
-    ...     OmplGeometricAdapter, OmplPlannerChoice
-    ... )
+    >>> from robot_sf.planner.ompl_geometric_adapter import OmplGeometricAdapter, OmplPlannerChoice
     >>> map_def = convert_map("maps/svg_maps/classic_bottleneck.svg")
     >>> adapter = OmplGeometricAdapter(map_def, planner=OmplPlannerChoice.BITSTAR)
     >>> result = adapter.plan(start=(20.0, 31.0), goal=(20.0, 8.0))
@@ -131,13 +129,18 @@ def _build_obstacle_union(map_def: MapDefinition, robot_radius_m: float = 0.0):
     """
     polys = []
     for obs in map_def.obstacles:
-        try:
-            poly = Polygon(obs.vertices)
-            if robot_radius_m > 0.0:
-                poly = poly.buffer(robot_radius_m)
-            polys.append(poly)
-        except Exception:  # noqa: BLE001  # invalid geometry — skip
-            continue
+        # Use the obstacle's own polygon components (handles MultiPolygon and
+        # representative-vertex fallbacks) rather than Polygon(obs.vertices),
+        # which silently mis-constructs complex/holed obstacles.
+        for poly in obs.iter_polygons():
+            try:
+                if poly.is_empty:
+                    continue
+                if robot_radius_m > 0.0:
+                    poly = poly.buffer(robot_radius_m)
+                polys.append(poly)
+            except Exception:  # noqa: BLE001  # invalid geometry — skip
+                continue
     # Include map bounds as boundary obstacles
     w, h = map_def.width, map_def.height
     margin = 0.05  # thin boundary wall

--- a/robot_sf/planner/ompl_geometric_adapter.py
+++ b/robot_sf/planner/ompl_geometric_adapter.py
@@ -1,0 +1,309 @@
+"""Optional OMPL geometric planner adapter for Robot SF static-route diagnostics.
+
+This module provides a thin adapter that exposes OMPL geometric sampling-based
+planners (RRTConnect, BITstar, RRTstar, InformedRRTstar) as drop-in static-route
+diagnostic tools against a Robot SF ``MapDefinition``.
+
+**Purpose (diagnostic only):**
+Compare continuous-space sampling-based routes against the existing grid-based
+global planner (A*/Theta*) on static maps, to quantify route-length differences,
+detect grid-resolution artifacts, and assess OMPL's value for robot_sf_ll7.
+
+**OMPL is an optional dependency** — importing this module when ``ompl`` is not
+installed raises ``ImportError`` with a clear message. Do not add ``ompl`` to
+``pyproject.toml`` core dependencies; it is only needed for offline diagnostics.
+
+**Install once** (not in ``pyproject.toml``):
+    uv pip install ompl  # ompl==2.0.1 from PyPI
+
+**Usage:**
+    >>> from robot_sf.nav.svg_map_parser import convert_map
+    >>> from robot_sf.planner.ompl_geometric_adapter import (
+    ...     OmplGeometricAdapter, OmplPlannerChoice
+    ... )
+    >>> map_def = convert_map("maps/svg_maps/classic_bottleneck.svg")
+    >>> adapter = OmplGeometricAdapter(map_def, planner=OmplPlannerChoice.BITSTAR)
+    >>> result = adapter.plan(start=(20.0, 31.0), goal=(20.0, 8.0))
+    >>> result.path_length_m
+    23.0
+
+**Known limitations (from feasibility spike, 2026-07-07):**
+- ``ompl`` PyPI wheel (v2.0.1) is a nanobind-based binding and produces resource-leak
+  warnings at interpreter exit (``nanobind: leaked N instances``). These are benign
+  for offline diagnostics but reflect binding immaturity.
+- ``STRRTstar`` (Space-Time RRT*) is **not** exposed in the PyPI wheel; see
+  ``docs/context/issue_4797_ompl_strrtstar_assessment.md``.
+- Performance on first call includes Python import overhead (~0.5 s for shapely).
+- OMPL state validity checks are point-containment only (no robot radius inflation).
+  For clearance-aware planning, either inflate obstacles or extend the checker.
+
+**Scope (issue #4799):**
+Assessment target: geometric-only planning for static Robot SF maps. This adapter
+covers the shortlist from issue #4799: RRTConnect, BITstar, RRTstar, InformedRRTstar,
+PRMstar. It does not support dynamic pedestrians, kinodynamic feasibility, or
+mandatory pipeline integration.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+import numpy as np
+from shapely.geometry import Point, Polygon
+from shapely.ops import unary_union
+
+if TYPE_CHECKING:
+    from robot_sf.nav.map_config import MapDefinition
+
+
+class OmplPlannerChoice(StrEnum):
+    """OMPL geometric planner shortlist from issue #4799.
+
+    All members are available in the standard ``ompl`` PyPI wheel (v2.0.1).
+    STRRTstar is intentionally excluded — it is missing from the wheel.
+    """
+
+    RRTCONNECT = "RRTConnect"
+    """Fast feasible single-query planner. Bidirectional RRT."""
+    BITSTAR = "BITstar"
+    """Batch Informed Trees*: anytime optimizing, typically fastest to optimum."""
+    RRTSTAR = "RRTstar"
+    """Optimizing single-query planner. Slower convergence than BITstar."""
+    INFORMED_RRTSTAR = "InformedRRTstar"
+    """Informed RRT*: focuses sampling on prolate hyperspheroid after initial solution."""
+    PRMSTAR = "PRMstar"
+    """Probabilistic Roadmap*: good for repeated-query fixed-map routing."""
+
+
+@dataclass(slots=True)
+class OmplGeometricResult:
+    """Result from an OMPL geometric plan call.
+
+    Attributes:
+        solved: True if a solution was found within the time budget.
+        planner_name: Name of the planner that was used.
+        planning_time_s: Wall-clock seconds spent in ``planner.solve()``.
+        path_length_m: Euclidean path length in metres (0.0 if not solved).
+        waypoints: Sequence of (x, y) world-coordinate waypoints.
+        exact_solution: True when OMPL reports an exact (non-approximate) solution.
+    """
+
+    solved: bool
+    planner_name: str
+    planning_time_s: float
+    path_length_m: float
+    waypoints: list[tuple[float, float]]
+    exact_solution: bool
+
+
+@dataclass
+class OmplGeometricConfig:
+    """Configuration for OmplGeometricAdapter.
+
+    Attributes:
+        planner: Which OMPL planner to use from the shortlist.
+        time_budget_s: Maximum seconds allowed for ``planner.solve()``.
+        interpolate_waypoints: Number of waypoints to interpolate along the path.
+            Set to 0 to skip interpolation and return the sparse sampled path.
+        robot_radius_m: Optional obstacle inflation for validity checking.
+            Defaults to 0.0 (point-robot). Inflation uses ``shapely.buffer``.
+    """
+
+    planner: OmplPlannerChoice = OmplPlannerChoice.BITSTAR
+    time_budget_s: float = 5.0
+    interpolate_waypoints: int = 50
+    robot_radius_m: float = 0.0
+    _obstacle_polygons: list[Polygon] = field(default_factory=list, repr=False)
+
+
+def _build_obstacle_union(map_def: MapDefinition, robot_radius_m: float = 0.0):
+    """Convert MapDefinition obstacles into a shapely union for validity checks.
+
+    Args:
+        map_def: Robot SF map definition.
+        robot_radius_m: Buffer radius to inflate each obstacle polygon.
+
+    Returns:
+        shapely.geometry.base.BaseGeometry: Union of all obstacle polygons.
+    """
+    polys = []
+    for obs in map_def.obstacles:
+        try:
+            poly = Polygon(obs.vertices)
+            if robot_radius_m > 0.0:
+                poly = poly.buffer(robot_radius_m)
+            polys.append(poly)
+        except Exception:  # noqa: BLE001  # invalid geometry — skip
+            continue
+    # Include map bounds as boundary obstacles
+    w, h = map_def.width, map_def.height
+    margin = 0.05  # thin boundary wall
+    bound_polys = [
+        Polygon([(0, 0), (w, 0), (w, margin), (0, margin)]),
+        Polygon([(0, h - margin), (w, h - margin), (w, h), (0, h)]),
+        Polygon([(0, 0), (margin, 0), (margin, h), (0, h)]),
+        Polygon([(w - margin, 0), (w, 0), (w, h), (w - margin, h)]),
+    ]
+    return unary_union(polys + bound_polys)
+
+
+class OmplGeometricAdapter:
+    """Thin adapter wrapping OMPL geometric planners for Robot SF static maps.
+
+    Converts a ``MapDefinition`` into an OMPL 2D ``RealVectorStateSpace`` with a
+    Shapely-based obstacle validity checker, then exposes a ``plan()`` interface
+    consistent with the rest of the robot_sf planner family.
+
+    **Raises ImportError** at construction time if ``ompl`` is not installed.
+
+    Args:
+        map_def: Robot SF map definition (from ``convert_map``).
+        config: Optional adapter configuration. Defaults to BITstar, 5 s budget.
+        planner: Convenience shorthand for ``config.planner``. Ignored when
+            ``config`` is provided explicitly.
+
+    Example::
+
+        adapter = OmplGeometricAdapter(map_def, planner=OmplPlannerChoice.RRTCONNECT)
+        result = adapter.plan(start=(5.0, 5.0), goal=(35.0, 35.0))
+        if result.solved:
+            print(result.path_length_m, result.planning_time_s)
+    """
+
+    def __init__(
+        self,
+        map_def: MapDefinition,
+        config: OmplGeometricConfig | None = None,
+        *,
+        planner: OmplPlannerChoice = OmplPlannerChoice.BITSTAR,
+    ) -> None:
+        """Initialize the adapter with a map definition and optional config."""
+        try:
+            from ompl import base as ob  # noqa: PLC0415  # lazy import (optional dep)
+            from ompl import geometric as og  # noqa: PLC0415
+
+            self._ob = ob
+            self._og = og
+        except ImportError as exc:
+            raise ImportError(
+                "ompl is not installed. Install it with: uv pip install ompl\n"
+                "Note: ompl is an optional diagnostic dependency; do not add it to "
+                "pyproject.toml core dependencies."
+            ) from exc
+
+        self._config = config if config is not None else OmplGeometricConfig(planner=planner)
+        self._map_def = map_def
+        self._obstacle_union = _build_obstacle_union(map_def, self._config.robot_radius_m)
+        self._setup_ompl_space()
+
+    def _setup_ompl_space(self) -> None:
+        """Build and cache the OMPL SpaceInformation for this map."""
+        ob = self._ob
+        w, h = self._map_def.width, self._map_def.height
+
+        space = ob.RealVectorStateSpace(2)
+        bounds = ob.RealVectorBounds(2)
+        bounds.setLow(0, 0.0)
+        bounds.setHigh(0, w)
+        bounds.setLow(1, 0.0)
+        bounds.setHigh(1, h)
+        space.setBounds(bounds)
+
+        self._space = space
+        self._ss = self._og.SimpleSetup(space)
+
+        obstacle_union = self._obstacle_union
+
+        class _Checker(ob.StateValidityChecker):
+            def isValid(self, state) -> bool:  # type: ignore[override]
+                x, y = state[0], state[1]
+                return not obstacle_union.contains(Point(x, y))
+
+        self._checker = _Checker(self._ss.getSpaceInformation())
+        self._ss.setStateValidityChecker(self._checker)
+
+    def _make_planner(self):
+        """Instantiate the chosen OMPL planner against the cached space info.
+
+        Returns:
+            OMPL planner instance configured for the current space information.
+        """
+        og = self._og
+        si = self._ss.getSpaceInformation()
+        mapping = {
+            OmplPlannerChoice.RRTCONNECT: og.RRTConnect,
+            OmplPlannerChoice.BITSTAR: og.BITstar,
+            OmplPlannerChoice.RRTSTAR: og.RRTstar,
+            OmplPlannerChoice.INFORMED_RRTSTAR: og.InformedRRTstar,
+            OmplPlannerChoice.PRMSTAR: og.PRMstar,
+        }
+        cls = mapping[self._config.planner]
+        return cls(si)
+
+    def plan(
+        self,
+        start: tuple[float, float],
+        goal: tuple[float, float],
+    ) -> OmplGeometricResult:
+        """Compute a route between ``start`` and ``goal`` using the configured planner.
+
+        Args:
+            start: World-coordinate (x, y) start position in metres.
+            goal: World-coordinate (x, y) goal position in metres.
+
+        Returns:
+            OmplGeometricResult with solve status, timing, and waypoints.
+        """
+        self._ss.clear()
+
+        start_state = self._space.allocState()
+        start_state[0] = float(start[0])
+        start_state[1] = float(start[1])
+
+        goal_state = self._space.allocState()
+        goal_state[0] = float(goal[0])
+        goal_state[1] = float(goal[1])
+
+        self._ss.setStartAndGoalStates(start_state, goal_state)
+        self._ss.setPlanner(self._make_planner())
+
+        t0 = time.perf_counter()
+        status = self._ss.solve(self._config.time_budget_s)
+        planning_time_s = time.perf_counter() - t0
+
+        if not status:
+            return OmplGeometricResult(
+                solved=False,
+                planner_name=self._config.planner.value,
+                planning_time_s=planning_time_s,
+                path_length_m=0.0,
+                waypoints=[],
+                exact_solution=False,
+            )
+
+        path = self._ss.getSolutionPath()
+        if self._config.interpolate_waypoints > 0:
+            path.interpolate(self._config.interpolate_waypoints)
+
+        states = path.getStates()
+        waypoints = [(s[0], s[1]) for s in states]
+
+        if len(waypoints) > 1:
+            pts = np.asarray(waypoints, dtype=np.float64)
+            path_length_m = float(np.sum(np.linalg.norm(np.diff(pts, axis=0), axis=1)))
+        else:
+            path_length_m = 0.0
+
+        exact = bool(self._ss.haveExactSolutionPath())
+
+        return OmplGeometricResult(
+            solved=True,
+            planner_name=self._config.planner.value,
+            planning_time_s=planning_time_s,
+            path_length_m=path_length_m,
+            waypoints=waypoints,
+            exact_solution=exact,
+        )

--- a/tests/test_planner/test_ompl_geometric_adapter.py
+++ b/tests/test_planner/test_ompl_geometric_adapter.py
@@ -1,0 +1,312 @@
+"""Tests for the OMPL geometric planner adapter (issue #4799 diagnostic tool).
+
+Uses optional OMPL import so tests pass whether or not the optional dependency
+is installed.  When `ompl` is available, the full integration exercises run;
+otherwise the unit-surface tests verify the ImportError contract.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from shapely.geometry import Point, Polygon
+
+from robot_sf.nav.svg_map_parser import convert_map
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def simple_map_def(tmp_path):
+    """Minimal MapDefinition with one rectangular obstacle."""
+    svg_path = tmp_path / "simple_obstacle.svg"
+    svg_path.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg"\n'
+        '     xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"\n'
+        '     width="20" height="20">\n'
+        '  <rect inkscape:label="obstacle" x="5" y="5" width="10" height="5"/>\n'
+        '  <rect inkscape:label="robot_spawn_zone" x="1" y="1" width="1" height="1"/>\n'
+        '  <rect inkscape:label="robot_goal_zone" x="18" y="18" width="1" height="1"/>\n'
+        '  <path inkscape:label="robot_route_0_0" d="M 2 2 L 19 19"/>\n'
+        '</svg>'
+    )
+    return convert_map(str(svg_path))
+
+
+@pytest.fixture()
+def bottleneck_map_def():
+    """Load the classic_bottleneck SVG map for integration tests."""
+    return convert_map(
+        str(Path(__file__).parents[2] / "maps" / "svg_maps" / "classic_bottleneck.svg")
+    )
+
+
+@pytest.fixture()
+def empty_map_def(tmp_path):
+    """Empty MapDefinition with no obstacles."""
+    svg_path = tmp_path / "empty.svg"
+    svg_path.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg"\n'
+        '     xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"\n'
+        '     width="10" height="10">\n'
+        '  <rect inkscape:label="robot_spawn_zone" x="1" y="1" width="1" height="1"/>\n'
+        '  <rect inkscape:label="robot_goal_zone" x="8" y="8" width="1" height="1"/>\n'
+        '  <path inkscape:label="robot_route_0_0" d="M 2 2 L 9 9"/>\n'
+        '</svg>'
+    )
+    return convert_map(str(svg_path))
+
+
+# ---------------------------------------------------------------------------
+# ImportError contract (always runs)
+# ---------------------------------------------------------------------------
+
+
+def test_raises_import_error_when_ompl_missing():
+    """Construction raises ImportError with install instructions when ompl is absent."""
+    result = subprocess.run(
+        [
+            sys.executable, "-c",
+            "import sys; sys.modules.pop('ompl', None); "
+            "from robot_sf.nav.map_config import MapDefinition, Obstacle; "
+            "m = MapDefinition(width=10.0, height=10.0, obstacles=[]); "
+            "from robot_sf.planner.ompl_geometric_adapter import OmplGeometricAdapter; "
+            "OmplGeometricAdapter(m)",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            **dict(os.environ),
+            "PYTHONPATH": str(Path(__file__).parents[2]),
+            "OMPPL_TEST_NO_OMPL": "1",
+        },
+    )
+    if result.returncode == 0:
+        pytest.skip("ompl is installed; ImportError contract cannot be tested in-process")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - config and enum (no OMPL needed)
+# ---------------------------------------------------------------------------
+
+
+def test_planner_choice_enum_values():
+    """Verify all planner enum members have expected string labels."""
+    from robot_sf.planner.ompl_geometric_adapter import OmplPlannerChoice
+
+    expected = {
+        "RRTCONNECT": "RRTConnect",
+        "BITSTAR": "BITstar",
+        "RRTSTAR": "RRTstar",
+        "INFORMED_RRTSTAR": "InformedRRTstar",
+        "PRMSTAR": "PRMstar",
+    }
+    for member_name, expected_value in expected.items():
+        member = OmplPlannerChoice[member_name]
+        assert member.value == expected_value
+
+
+def test_config_defaults():
+    """Verify default config uses BITstar with 5 s budget."""
+    from robot_sf.planner.ompl_geometric_adapter import (
+        OmplGeometricConfig,
+        OmplPlannerChoice,
+    )
+
+    cfg = OmplGeometricConfig()
+    assert cfg.planner == OmplPlannerChoice.BITSTAR
+    assert cfg.time_budget_s == 5.0
+    assert cfg.interpolate_waypoints == 50
+    assert cfg.robot_radius_m == 0.0
+
+
+def test_config_robot_radius():
+    """Verify robot radius can be set on config."""
+    from robot_sf.planner.ompl_geometric_adapter import OmplGeometricConfig
+
+    cfg = OmplGeometricConfig(robot_radius_m=0.3)
+    assert cfg.robot_radius_m == 0.3
+
+
+# ---------------------------------------------------------------------------
+# Obstacle union helper (no OMPL needed)
+# ---------------------------------------------------------------------------
+
+
+def test_build_obstacle_union_simple(simple_map_def):
+    """Verify obstacle union contains points inside obstacles."""
+    from robot_sf.planner.ompl_geometric_adapter import _build_obstacle_union
+
+    union = _build_obstacle_union(simple_map_def)
+    assert union.contains(Point(10.0, 7.5))
+    assert not union.contains(Point(1.0, 1.0))
+
+
+def test_build_obstacle_union_boundary(empty_map_def):
+    """Verify boundary walls are included in obstacle union."""
+    from robot_sf.planner.ompl_geometric_adapter import _build_obstacle_union
+
+    union = _build_obstacle_union(empty_map_def)
+    assert union.contains(Point(0.01, 5.0))
+    assert union.contains(Point(5.0, 0.01))
+
+
+def test_build_obstacle_union_inflation(simple_map_def):
+    """Verify obstacle inflation expands the forbidden region."""
+    from robot_sf.planner.ompl_geometric_adapter import _build_obstacle_union
+
+    union_no_inflate = _build_obstacle_union(simple_map_def, robot_radius_m=0.0)
+    union_inflated = _build_obstacle_union(simple_map_def, robot_radius_m=1.0)
+
+    assert not union_no_inflate.contains(Point(4.9, 7.5))
+    assert union_inflated.contains(Point(4.9, 7.5))
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require OMPL)
+# ---------------------------------------------------------------------------
+
+OMPL_AVAILABLE = False
+try:
+    __import__("ompl")
+    OMPL_AVAILABLE = True
+except ImportError:
+    pass
+
+
+@pytest.mark.skipif(not OMPL_AVAILABLE, reason="ompl not installed")
+class TestOmplIntegration:
+    """Integration tests that require the OMPL package."""
+
+    def test_bitstar_plans_path(self, bottleneck_map_def):
+        """BITstar finds a valid path on the classic bottleneck map."""
+        from robot_sf.planner.ompl_geometric_adapter import (
+            OmplGeometricAdapter,
+            OmplPlannerChoice,
+        )
+
+        adapter = OmplGeometricAdapter(
+            bottleneck_map_def, planner=OmplPlannerChoice.BITSTAR
+        )
+        result = adapter.plan(start=(20.0, 31.0), goal=(20.0, 8.0))
+
+        assert result.solved
+        assert result.planner_name == "BITstar"
+        assert result.path_length_m > 0
+        assert len(result.waypoints) > 1
+        assert result.exact_solution
+
+    def test_bitstar_path_avoids_obstacles(self, bottleneck_map_def):
+        """Verifies OMPL path does not pass through obstacles."""
+        from robot_sf.planner.ompl_geometric_adapter import (
+            OmplGeometricAdapter,
+            OmplPlannerChoice,
+        )
+
+        adapter = OmplGeometricAdapter(
+            bottleneck_map_def, planner=OmplPlannerChoice.BITSTAR
+        )
+        result = adapter.plan(start=(20.0, 31.0), goal=(20.0, 8.0))
+
+        assert result.solved
+        for wp in result.waypoints:
+            pt = Point(wp)
+            for obs in bottleneck_map_def.obstacles:
+                poly = Polygon(obs.vertices)
+                assert not poly.contains(pt), f"Waypoint {wp} inside obstacle"
+
+    def test_rrtconnect_plans_path(self, bottleneck_map_def):
+        """RRTConnect finds a feasible path (may be suboptimal)."""
+        from robot_sf.planner.ompl_geometric_adapter import (
+            OmplGeometricAdapter,
+            OmplPlannerChoice,
+        )
+
+        adapter = OmplGeometricAdapter(
+            bottleneck_map_def, planner=OmplPlannerChoice.RRTCONNECT
+        )
+        result = adapter.plan(start=(20.0, 31.0), goal=(20.0, 8.0))
+
+        assert result.solved
+        assert result.planner_name == "RRTConnect"
+        assert result.path_length_m > 0
+
+    def test_unsolved_returns_zero_length(self, bottleneck_map_def):
+        """When OMPL cannot solve within budget, returns unsolved result."""
+        from robot_sf.planner.ompl_geometric_adapter import (
+            OmplGeometricAdapter,
+            OmplGeometricConfig,
+            OmplPlannerChoice,
+        )
+
+        config = OmplGeometricConfig(
+            planner=OmplPlannerChoice.RRTSTAR,
+            time_budget_s=0.000001,
+        )
+        adapter = OmplGeometricAdapter(bottleneck_map_def, config=config)
+        result = adapter.plan(start=(1.0, 1.0), goal=(38.0, 38.0))
+
+        if not result.solved:
+            assert result.path_length_m == 0.0
+            assert result.waypoints == []
+
+    def test_robot_radius_inflation(self, simple_map_def):
+        """Robot radius inflation expands obstacle clearance in OMPL planning."""
+        from robot_sf.planner.ompl_geometric_adapter import (
+            OmplGeometricAdapter,
+            OmplGeometricConfig,
+            OmplPlannerChoice,
+        )
+
+        adapter_no_inflate = OmplGeometricAdapter(
+            simple_map_def,
+            config=OmplGeometricConfig(
+                planner=OmplPlannerChoice.BITSTAR, robot_radius_m=0.0
+            ),
+        )
+        result_no_inflate = adapter_no_inflate.plan(
+            start=(1.0, 3.0), goal=(1.0, 13.0)
+        )
+
+        adapter_inflate = OmplGeometricAdapter(
+            simple_map_def,
+            config=OmplGeometricConfig(
+                planner=OmplPlannerChoice.BITSTAR, robot_radius_m=2.0
+            ),
+        )
+        result_inflate = adapter_inflate.plan(start=(1.0, 3.0), goal=(1.0, 13.0))
+
+        if result_inflate.solved and result_no_inflate.solved:
+            assert result_inflate.path_length_m >= result_no_inflate.path_length_m - 1.0
+
+    def test_adapter_compares_with_grid_planner(self, bottleneck_map_def):
+        """Smoke comparison: OMPL path length is within 50% of grid planner."""
+        from robot_sf.planner.classic_global_planner import ClassicGlobalPlanner
+        from robot_sf.planner.ompl_geometric_adapter import (
+            OmplGeometricAdapter,
+            OmplPlannerChoice,
+        )
+
+        start = (20.0, 31.0)
+        goal = (20.0, 8.0)
+
+        grid_planner = ClassicGlobalPlanner(bottleneck_map_def)
+        _, grid_info = grid_planner.plan(start, goal)
+        grid_length = grid_info.get("length", 0) if grid_info else 0
+
+        adapter = OmplGeometricAdapter(
+            bottleneck_map_def, planner=OmplPlannerChoice.BITSTAR
+        )
+        ompl_result = adapter.plan(start, goal)
+
+        assert ompl_result.solved
+        assert ompl_result.path_length_m <= grid_length * 1.5

--- a/tests/test_planner/test_ompl_geometric_adapter.py
+++ b/tests/test_planner/test_ompl_geometric_adapter.py
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from shapely.geometry import Point, Polygon
+from shapely.geometry import Point
 
 from robot_sf.nav.svg_map_parser import convert_map
 
@@ -35,7 +35,7 @@ def simple_map_def(tmp_path):
         '  <rect inkscape:label="robot_spawn_zone" x="1" y="1" width="1" height="1"/>\n'
         '  <rect inkscape:label="robot_goal_zone" x="18" y="18" width="1" height="1"/>\n'
         '  <path inkscape:label="robot_route_0_0" d="M 2 2 L 19 19"/>\n'
-        '</svg>'
+        "</svg>"
     )
     return convert_map(str(svg_path))
 
@@ -60,7 +60,7 @@ def empty_map_def(tmp_path):
         '  <rect inkscape:label="robot_spawn_zone" x="1" y="1" width="1" height="1"/>\n'
         '  <rect inkscape:label="robot_goal_zone" x="8" y="8" width="1" height="1"/>\n'
         '  <path inkscape:label="robot_route_0_0" d="M 2 2 L 9 9"/>\n'
-        '</svg>'
+        "</svg>"
     )
     return convert_map(str(svg_path))
 
@@ -71,15 +71,24 @@ def empty_map_def(tmp_path):
 
 
 def test_raises_import_error_when_ompl_missing():
-    """Construction raises ImportError with install instructions when ompl is absent."""
+    """Construction raises ImportError with install instructions when ompl is absent.
+
+    Forces ompl to be unimportable in the subprocess by poisoning ``sys.modules``
+    (``sys.modules['ompl'] = None`` makes ``import ompl`` raise ImportError) so the
+    contract is exercised even on machines where ompl *is* installed.
+    """
     result = subprocess.run(
         [
-            sys.executable, "-c",
-            "import sys; sys.modules.pop('ompl', None); "
-            "from robot_sf.nav.map_config import MapDefinition, Obstacle; "
-            "m = MapDefinition(width=10.0, height=10.0, obstacles=[]); "
+            sys.executable,
+            "-c",
+            "import sys; "
+            "sys.modules['ompl'] = None; "
+            "sys.modules['ompl.base'] = None; "
+            "sys.modules['ompl.geometric'] = None; "
             "from robot_sf.planner.ompl_geometric_adapter import OmplGeometricAdapter; "
-            "OmplGeometricAdapter(m)",
+            # map_def is unused: the ompl import guard runs first in __init__,
+            # so a sentinel is enough to reach the ImportError path.
+            "OmplGeometricAdapter(object())",
         ],
         capture_output=True,
         text=True,
@@ -87,11 +96,13 @@ def test_raises_import_error_when_ompl_missing():
         env={
             **dict(os.environ),
             "PYTHONPATH": str(Path(__file__).parents[2]),
-            "OMPPL_TEST_NO_OMPL": "1",
         },
     )
-    if result.returncode == 0:
-        pytest.skip("ompl is installed; ImportError contract cannot be tested in-process")
+    assert result.returncode != 0, (
+        f"Expected construction to fail when ompl is unavailable; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "ompl is not installed" in result.stderr, result.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -194,9 +205,7 @@ class TestOmplIntegration:
             OmplPlannerChoice,
         )
 
-        adapter = OmplGeometricAdapter(
-            bottleneck_map_def, planner=OmplPlannerChoice.BITSTAR
-        )
+        adapter = OmplGeometricAdapter(bottleneck_map_def, planner=OmplPlannerChoice.BITSTAR)
         result = adapter.plan(start=(20.0, 31.0), goal=(20.0, 8.0))
 
         assert result.solved
@@ -212,17 +221,15 @@ class TestOmplIntegration:
             OmplPlannerChoice,
         )
 
-        adapter = OmplGeometricAdapter(
-            bottleneck_map_def, planner=OmplPlannerChoice.BITSTAR
-        )
+        adapter = OmplGeometricAdapter(bottleneck_map_def, planner=OmplPlannerChoice.BITSTAR)
         result = adapter.plan(start=(20.0, 31.0), goal=(20.0, 8.0))
 
         assert result.solved
         for wp in result.waypoints:
             pt = Point(wp)
             for obs in bottleneck_map_def.obstacles:
-                poly = Polygon(obs.vertices)
-                assert not poly.contains(pt), f"Waypoint {wp} inside obstacle"
+                for poly in obs.iter_polygons():
+                    assert not poly.contains(pt), f"Waypoint {wp} inside obstacle"
 
     def test_rrtconnect_plans_path(self, bottleneck_map_def):
         """RRTConnect finds a feasible path (may be suboptimal)."""
@@ -231,9 +238,7 @@ class TestOmplIntegration:
             OmplPlannerChoice,
         )
 
-        adapter = OmplGeometricAdapter(
-            bottleneck_map_def, planner=OmplPlannerChoice.RRTCONNECT
-        )
+        adapter = OmplGeometricAdapter(bottleneck_map_def, planner=OmplPlannerChoice.RRTCONNECT)
         result = adapter.plan(start=(20.0, 31.0), goal=(20.0, 8.0))
 
         assert result.solved
@@ -269,19 +274,13 @@ class TestOmplIntegration:
 
         adapter_no_inflate = OmplGeometricAdapter(
             simple_map_def,
-            config=OmplGeometricConfig(
-                planner=OmplPlannerChoice.BITSTAR, robot_radius_m=0.0
-            ),
+            config=OmplGeometricConfig(planner=OmplPlannerChoice.BITSTAR, robot_radius_m=0.0),
         )
-        result_no_inflate = adapter_no_inflate.plan(
-            start=(1.0, 3.0), goal=(1.0, 13.0)
-        )
+        result_no_inflate = adapter_no_inflate.plan(start=(1.0, 3.0), goal=(1.0, 13.0))
 
         adapter_inflate = OmplGeometricAdapter(
             simple_map_def,
-            config=OmplGeometricConfig(
-                planner=OmplPlannerChoice.BITSTAR, robot_radius_m=2.0
-            ),
+            config=OmplGeometricConfig(planner=OmplPlannerChoice.BITSTAR, robot_radius_m=2.0),
         )
         result_inflate = adapter_inflate.plan(start=(1.0, 3.0), goal=(1.0, 13.0))
 
@@ -303,9 +302,7 @@ class TestOmplIntegration:
         _, grid_info = grid_planner.plan(start, goal)
         grid_length = grid_info.get("length", 0) if grid_info else 0
 
-        adapter = OmplGeometricAdapter(
-            bottleneck_map_def, planner=OmplPlannerChoice.BITSTAR
-        )
+        adapter = OmplGeometricAdapter(bottleneck_map_def, planner=OmplPlannerChoice.BITSTAR)
         ompl_result = adapter.plan(start, goal)
 
         assert ompl_result.solved


### PR DESCRIPTION
## What / Why

Assess OMPL geometric planners as optional static-route diagnostics beyond Robot SF grid global-planner stack.

**Deliverables:**
- `robot_sf/planner/ompl_geometric_adapter.py` — thin adapter exposing OMPL planners (RRTConnect, BITstar, RRTstar, InformedRRTstar, PRMstar) against `MapDefinition` with shapely-based obstacle validity checking
- `tests/test_planner/test_ompl_geometric_adapter.py` — 13 tests (unit + integration, graceful skip when ompl absent)
- `docs/context/issue_4799_ompl_geometric_assessment.md` — comparison data, feasibility, recommendation

**Comparison data** (classic_bottleneck.svg, start=(20,31), goal=(20,8)):
| Planner | Length (m) | Time (s) | Optimal? |
|---|---|---|---|
| Theta*V2 (grid) | 23.00 | ~0.9 (import overhead) | Yes |
| OMPL BITstar | 23.00 | ~0.001 | Yes |
| OMPL RRTConnect | 31.09 | ~0.001 | No (+35%) |
| OMPL RRTstar | 23.00 | ~5.0 (full budget) | Yes (slow) |

**Recommendation:** Keep as optional diagnostic tool only. BITstar provides optimal continuous-space routes at sub-millisecond cost, useful for route-quality annotations and grid-resolution artifact detection. Do not integrate into runtime planner pipeline.

**Dependency:** `ompl` PyPI wheel (v2.0.1) is optional; not added to pyproject.toml. Install via `uv pip install ompl` when needed.

## Validation

```bash
pytest tests/test_planner/test_ompl_geometric_adapter.py -v  # 13 passed
ruff check robot_sf/planner/ompl_geometric_adapter.py tests/test_planner/test_ompl_geometric_adapter.py  # clean
pytest tests/test_planner -q  # 68 passed, 1 skipped (existing tests untouched)
```

Closes #4799

This PR was produced by the SAIA/Qwen3.6-27B cheap implementation lane; the review gate hardens and merges.