### PR TITLE
Issue #4792: pin collision metric key + parallel sweep (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/scenario_criticality_objective.py
+++ b/robot_sf/benchmark/scenario_criticality_objective.py
@@ -16,11 +16,27 @@ Claim boundary: exploratory/diagnostic-only; not a validated benchmark method.
 from __future__ import annotations
 
 import copy
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from robot_sf.benchmark.map_runner_episode import EpisodeData
+
+_LOGGER = logging.getLogger(__name__)
+
+#: Canonical collision metric key expected from the episode-metrics schema.
+#: All new episode outputs should use this key.  The fallback chain below
+#: exists only for backward compatibility with older simulator outputs.
+CANONICAL_COLLISION_KEY: str = "collision_count"
+
+#: Ordered fallback keys tried when the canonical key is absent.
+#: The order is: agent-scoped count, then total-scoped, then legacy name.
+COLLISION_KEY_FALLBACKS: tuple[str, ...] = (
+    "agent_collision_count",
+    "total_collision_count",
+    "collisions",
+)
 
 
 @dataclass
@@ -60,6 +76,7 @@ class CriticalityResult:
         status: "evaluated", "not_evaluable", or "invalid_candidate"
         reason: Optional explanation for non-evaluated status
         raw_metrics: Dict of raw metric values used
+        collision_key_used: The actual metric key resolved for collision count
     """
 
     criticality_score: float
@@ -71,6 +88,7 @@ class CriticalityResult:
     status: str
     reason: str | None = None
     raw_metrics: dict[str, float] | None = None
+    collision_key_used: str | None = None
 
 
 def _safe_get_metric(
@@ -107,6 +125,26 @@ def _safe_get_metric(
     return default if default is not None else float("nan")
 
 
+def _resolve_collision_key(metrics: dict[str, Any]) -> tuple[str, bool]:
+    """Resolve the collision metric key with explicit fallback chain.
+
+    Returns:
+        Tuple of (resolved_key, used_fallback). ``used_fallback`` is True
+        when the canonical key was absent and a fallback key was selected.
+    """
+    if CANONICAL_COLLISION_KEY in metrics:
+        return CANONICAL_COLLISION_KEY, False
+    for fallback in COLLISION_KEY_FALLBACKS:
+        if fallback in metrics:
+            _LOGGER.info(
+                "Collision metric: canonical key %r missing, using fallback %r",
+                CANONICAL_COLLISION_KEY,
+                fallback,
+            )
+            return fallback, True
+    return CANONICAL_COLLISION_KEY, False
+
+
 def compute_criticality_score(
     episode_data: EpisodeData,
     config: CriticalityObjectiveConfig | None = None,
@@ -134,13 +172,8 @@ def compute_criticality_score(
 
     fail_closed = config.fail_closed
 
-    # Map collision metric from alternative simulator keys if main key is absent
-    col_key = "collision_count"
-    if col_key not in metrics:
-        for alt in ["collisions", "agent_collision_count", "total_collision_count"]:
-            if alt in metrics:
-                col_key = alt
-                break
+    # Resolve collision metric key with explicit fallback chain
+    col_key, _used_fallback = _resolve_collision_key(metrics)
     collision_count = _safe_get_metric(metrics, col_key, 0.0, fail_closed)
     near_misses = _safe_get_metric(metrics, "near_misses", 0.0, fail_closed)
     min_clearance = _safe_get_metric(metrics, "min_clearance", float("nan"), fail_closed)
@@ -165,6 +198,7 @@ def compute_criticality_score(
             status="not_evaluable",
             reason="Missing required metrics with fail_closed=True",
             raw_metrics=metrics,
+            collision_key_used=col_key,
         )
 
     collision_count = collision_count if collision_count is not None else 0.0
@@ -206,6 +240,7 @@ def compute_criticality_score(
             "failure_to_progress": failure_to_progress,
             "stalled_time": stalled_time,
         },
+        collision_key_used=col_key,
     )
 
 
@@ -329,6 +364,8 @@ def apply_criticality_parameters(
 
 
 __all__ = [
+    "CANONICAL_COLLISION_KEY",
+    "COLLISION_KEY_FALLBACKS",
     "CriticalityObjectiveConfig",
     "CriticalityResult",
     "apply_criticality_parameters",

--- a/robot_sf/benchmark/scenario_criticality_objective.py
+++ b/robot_sf/benchmark/scenario_criticality_objective.py
@@ -125,12 +125,15 @@ def _safe_get_metric(
     return default if default is not None else float("nan")
 
 
-def _resolve_collision_key(metrics: dict[str, Any]) -> tuple[str, bool]:
+def _resolve_collision_key(metrics: dict[str, Any]) -> tuple[str | None, bool]:
     """Resolve the collision metric key with explicit fallback chain.
 
     Returns:
-        Tuple of (resolved_key, used_fallback). ``used_fallback`` is True
+        Tuple of ``(resolved_key, used_fallback)``. ``used_fallback`` is True
         when the canonical key was absent and a fallback key was selected.
+        ``resolved_key`` is ``None`` when *neither* the canonical key nor any
+        fallback is present, so callers can report that no collision key was
+        actually found rather than mislabelling it as the canonical key.
     """
     if CANONICAL_COLLISION_KEY in metrics:
         return CANONICAL_COLLISION_KEY, False
@@ -142,7 +145,7 @@ def _resolve_collision_key(metrics: dict[str, Any]) -> tuple[str, bool]:
                 fallback,
             )
             return fallback, True
-    return CANONICAL_COLLISION_KEY, False
+    return None, False
 
 
 def compute_criticality_score(
@@ -172,9 +175,13 @@ def compute_criticality_score(
 
     fail_closed = config.fail_closed
 
-    # Resolve collision metric key with explicit fallback chain
+    # Resolve collision metric key with explicit fallback chain. ``col_key`` is
+    # None when no collision key is present; read via the canonical key (yields
+    # the default) but report ``collision_key_used=None`` for transparency.
     col_key, _used_fallback = _resolve_collision_key(metrics)
-    collision_count = _safe_get_metric(metrics, col_key, 0.0, fail_closed)
+    collision_count = _safe_get_metric(
+        metrics, col_key or CANONICAL_COLLISION_KEY, 0.0, fail_closed
+    )
     near_misses = _safe_get_metric(metrics, "near_misses", 0.0, fail_closed)
     min_clearance = _safe_get_metric(metrics, "min_clearance", float("nan"), fail_closed)
     failure_to_progress = _safe_get_metric(metrics, "failure_to_progress", 0.0, fail_closed)

--- a/scripts/benchmark/run_scenario_criticality_optimization.py
+++ b/scripts/benchmark/run_scenario_criticality_optimization.py
@@ -21,6 +21,7 @@ import argparse
 import hashlib
 import json
 import random
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -68,6 +69,9 @@ class OptimizationConfig:
         objective_weights: Weights for criticality objective
         invalid_run_policy: "fail_closed" or "log_continue"
         diagnostic_only: Must be True to acknowledge exploratory status
+        horizon: Simulation horizon in steps
+        dt: Simulation timestep in seconds
+        max_workers: Max parallel candidates (1 = sequential, 0 = auto)
     """
 
     parameter_space: dict[str, ParameterDefinition]
@@ -82,6 +86,7 @@ class OptimizationConfig:
     diagnostic_only: bool = True
     horizon: int = 80
     dt: float = 0.1
+    max_workers: int = 1
 
 
 @dataclass
@@ -170,6 +175,7 @@ def _parse_optimization_config(payload: dict[str, Any]) -> OptimizationConfig:
         diagnostic_only=bool(payload.get("diagnostic_only_not_benchmark_gate", True)),
         horizon=int(payload.get("horizon", 80)),
         dt=float(payload.get("dt", 0.1)),
+        max_workers=int(payload.get("max_workers", 1)),
     )
 
 
@@ -341,7 +347,7 @@ def _evaluate_candidate(  # noqa: C901
         )
 
 
-def run_criticality_optimization(
+def run_criticality_optimization(  # noqa: C901
     config: OptimizationConfig,
     output_dir: Path | None = None,
 ) -> tuple[list[CandidateResult], dict[str, Any]]:
@@ -367,7 +373,6 @@ def run_criticality_optimization(
         scenarios = list(config.scenario_family)
 
     if not scenarios:
-        # Fallback default scenario
         default_path = Path("configs/scenarios/single/francis2023_blind_corner.yaml")
         if default_path.exists():
             scenarios = load_scenarios(default_path)
@@ -379,7 +384,6 @@ def run_criticality_optimization(
 
     rng = random.Random(config.optimizer_seed)
     baseline_params = _build_baseline_parameters(config.parameter_space)
-    candidates = []
 
     objective_config = CriticalityObjectiveConfig(
         collision_weight=config.objective_weights.get("collision", 10.0),
@@ -390,34 +394,62 @@ def run_criticality_optimization(
         stalled_time_weight=config.objective_weights.get("stalled_time", 0.5),
     )
 
-    baseline_result = _evaluate_candidate(
-        candidate_id="baseline_unperturbed",
-        parameters=baseline_params,
-        scenario=scenario,
-        config=config,
-        objective_config=objective_config,
-        output_dir=output_dir,
-        scenario_path=scenario_path,
-    )
-    candidates.append(baseline_result)
-
+    # Pre-sample all candidate parameters for deterministic parallel execution
+    candidate_params: list[tuple[str, dict[str, float]]] = [
+        ("baseline_unperturbed", baseline_params),
+    ]
     for i in range(config.sample_budget):
         params = _sample_parameters(config.parameter_space, rng)
-        candidate_id = f"candidate_{i:04d}"
+        candidate_params.append((f"candidate_{i:04d}", params))
 
-        result = _evaluate_candidate(
-            candidate_id=candidate_id,
-            parameters=params,
-            scenario=scenario,
-            config=config,
-            objective_config=objective_config,
-            output_dir=output_dir,
-            scenario_path=scenario_path,
-        )
-        candidates.append(result)
+    # Resolve effective worker count: 0 means auto (cpu_count), 1 means sequential
+    effective_workers = config.max_workers
+    if effective_workers == 0:
+        import os
+
+        effective_workers = os.cpu_count() or 1
+
+    candidates: list[CandidateResult] = []
+
+    if effective_workers <= 1:
+        # Sequential evaluation (original behavior)
+        for cand_id, params in candidate_params:
+            result = _evaluate_candidate(
+                candidate_id=cand_id,
+                parameters=params,
+                scenario=scenario,
+                config=config,
+                objective_config=objective_config,
+                output_dir=output_dir,
+                scenario_path=scenario_path,
+            )
+            candidates.append(result)
+    else:
+        # Parallel evaluation with ProcessPoolExecutor
+        with ProcessPoolExecutor(max_workers=effective_workers) as executor:
+            futures = {
+                executor.submit(
+                    _evaluate_candidate,
+                    candidate_id=cand_id,
+                    parameters=params,
+                    scenario=scenario,
+                    config=config,
+                    objective_config=objective_config,
+                    output_dir=output_dir,
+                    scenario_path=scenario_path,
+                ): cand_id
+                for cand_id, params in candidate_params
+            }
+            for future in as_completed(futures):
+                candidates.append(future.result())
 
     evaluated = [c for c in candidates if c.status == "evaluated"]
     best_candidates = sorted(evaluated, key=lambda c: c.criticality_score, reverse=True)[:5]
+
+    baseline_candidate = next(
+        (c for c in candidates if c.candidate_id == "baseline_unperturbed"), None
+    )
+    baseline_score = baseline_candidate.criticality_score if baseline_candidate else float("nan")
 
     manifest = {
         "issue": 4362,
@@ -438,13 +470,14 @@ def run_criticality_optimization(
         },
         "objective_weights": config.objective_weights,
         "invalid_run_policy": config.invalid_run_policy,
+        "max_workers": effective_workers,
         "total_candidates": len(candidates),
         "evaluated_count": len(evaluated),
         "invalid_count": len([c for c in candidates if c.status == "invalid_candidate"]),
         "not_evaluable_count": len([c for c in candidates if c.status == "not_evaluable"]),
         "best_candidate_id": best_candidates[0].candidate_id if best_candidates else None,
         "best_criticality_score": best_candidates[0].criticality_score if best_candidates else None,
-        "baseline_score": baseline_result.criticality_score,
+        "baseline_score": baseline_score,
         "generated_at": datetime.now(UTC).isoformat(),
     }
 

--- a/scripts/benchmark/run_scenario_criticality_optimization.py
+++ b/scripts/benchmark/run_scenario_criticality_optimization.py
@@ -444,7 +444,12 @@ def run_criticality_optimization(  # noqa: C901
                 candidates.append(future.result())
 
     evaluated = [c for c in candidates if c.status == "evaluated"]
-    best_candidates = sorted(evaluated, key=lambda c: c.criticality_score, reverse=True)[:5]
+    # Secondary key on candidate_id makes "best" selection reproducible: parallel
+    # workers complete in nondeterministic order, so ties on criticality_score must
+    # break deterministically rather than on completion order.
+    best_candidates = sorted(
+        evaluated, key=lambda c: (-c.criticality_score, c.candidate_id)
+    )[:5]
 
     baseline_candidate = next(
         (c for c in candidates if c.candidate_id == "baseline_unperturbed"), None

--- a/scripts/benchmark/run_scenario_criticality_optimization.py
+++ b/scripts/benchmark/run_scenario_criticality_optimization.py
@@ -408,6 +408,11 @@ def run_criticality_optimization(  # noqa: C901
         import os
 
         effective_workers = os.cpu_count() or 1
+    # Never spawn more workers than there are candidates to evaluate: on a
+    # high-core host, max_workers=0 (auto) would otherwise start dozens of idle
+    # processes for a handful of candidates.
+    if effective_workers > 1:
+        effective_workers = min(effective_workers, max(1, len(candidate_params)))
 
     candidates: list[CandidateResult] = []
 
@@ -442,14 +447,17 @@ def run_criticality_optimization(  # noqa: C901
             }
             for future in as_completed(futures):
                 candidates.append(future.result())
+        # ProcessPoolExecutor completes futures in nondeterministic order.
+        # Restore a stable, reproducible ordering by candidate_id so the whole
+        # downstream (report listing, tie-breaking, manifest) matches the
+        # sequential path regardless of which worker finished first.
+        candidates.sort(key=lambda c: c.candidate_id)
 
     evaluated = [c for c in candidates if c.status == "evaluated"]
     # Secondary key on candidate_id makes "best" selection reproducible: parallel
     # workers complete in nondeterministic order, so ties on criticality_score must
     # break deterministically rather than on completion order.
-    best_candidates = sorted(
-        evaluated, key=lambda c: (-c.criticality_score, c.candidate_id)
-    )[:5]
+    best_candidates = sorted(evaluated, key=lambda c: (-c.criticality_score, c.candidate_id))[:5]
 
     baseline_candidate = next(
         (c for c in candidates if c.candidate_id == "baseline_unperturbed"), None
@@ -556,7 +564,9 @@ def write_optimization_report(
 
     best_candidates_json = output_dir / "best_candidates.json"
     evaluated = [c for c in candidates if c.status == "evaluated"]
-    best = sorted(evaluated, key=lambda c: c.criticality_score, reverse=True)[:5]
+    # Tie-break on candidate_id so the written "best" list is reproducible when
+    # multiple candidates share a criticality_score (matches run_* selection).
+    best = sorted(evaluated, key=lambda c: (-c.criticality_score, c.candidate_id))[:5]
     with best_candidates_json.open("w", encoding="utf-8") as f:
         json.dump(
             [

--- a/tests/benchmark/test_scenario_criticality_objective.py
+++ b/tests/benchmark/test_scenario_criticality_objective.py
@@ -339,6 +339,29 @@ def test_collision_key_canonical_takes_precedence_over_fallbacks() -> None:
     assert result.collision_term == 10.0
 
 
+def test_collision_key_used_none_when_no_key_present() -> None:
+    """When neither canonical nor any fallback key exists, collision_key_used is None.
+
+    Regression: previously the absent case reported the canonical key as
+    ``collision_key_used``, falsely implying it was found in the metrics.
+    """
+    episode = _MockEpisodeData(
+        metrics={
+            "near_misses": 0,
+            "min_clearance": 0.6,
+            "failure_to_progress": 0,
+            "stalled_time": 0,
+        }
+    )
+    # fail_closed=False so the absent collision metric defaults to 0.0 and the
+    # episode still evaluates; the point is that collision_key_used is None
+    # (not falsely reported as the canonical key) when no key was found.
+    result = compute_criticality_score(episode, CriticalityObjectiveConfig(fail_closed=False))
+    assert result.status == "evaluated"
+    assert result.collision_key_used is None
+    assert result.collision_term == 0.0
+
+
 def test_canonical_collision_key_constant_value() -> None:
     """CANONICAL_COLLISION_KEY is 'collision_count'."""
     assert CANONICAL_COLLISION_KEY == "collision_count"

--- a/tests/benchmark/test_scenario_criticality_objective.py
+++ b/tests/benchmark/test_scenario_criticality_objective.py
@@ -7,6 +7,8 @@ import math
 import pytest
 
 from robot_sf.benchmark.scenario_criticality_objective import (
+    CANONICAL_COLLISION_KEY,
+    COLLISION_KEY_FALLBACKS,
     CriticalityObjectiveConfig,
     apply_criticality_parameters,
     compute_criticality_score,
@@ -250,3 +252,102 @@ def test_criticality_score_stalled_time() -> None:
 
     assert result_stall.stalled_time_term == 5.0
     assert result_stall.criticality_score > result_no.criticality_score
+
+
+def test_collision_key_canonical_used_when_present() -> None:
+    """Canonical collision_count key is preferred when present."""
+    episode = _MockEpisodeData(
+        metrics={
+            "collision_count": 3,
+            "near_misses": 0,
+            "min_clearance": 0.6,
+            "failure_to_progress": 0,
+            "stalled_time": 0,
+        }
+    )
+    result = compute_criticality_score(episode)
+    assert result.status == "evaluated"
+    assert result.collision_key_used == CANONICAL_COLLISION_KEY
+    assert result.collision_term == 30.0
+
+
+def test_collision_key_fallback_agent_collision_count() -> None:
+    """Falls back to agent_collision_count when canonical key is absent."""
+    episode = _MockEpisodeData(
+        metrics={
+            "agent_collision_count": 2,
+            "near_misses": 0,
+            "min_clearance": 0.6,
+            "failure_to_progress": 0,
+            "stalled_time": 0,
+        }
+    )
+    result = compute_criticality_score(episode)
+    assert result.status == "evaluated"
+    assert result.collision_key_used == "agent_collision_count"
+    assert result.collision_term == 20.0
+
+
+def test_collision_key_fallback_total_collision_count() -> None:
+    """Falls back to total_collision_count when earlier keys are absent."""
+    episode = _MockEpisodeData(
+        metrics={
+            "total_collision_count": 4,
+            "near_misses": 0,
+            "min_clearance": 0.6,
+            "failure_to_progress": 0,
+            "stalled_time": 0,
+        }
+    )
+    result = compute_criticality_score(episode)
+    assert result.status == "evaluated"
+    assert result.collision_key_used == "total_collision_count"
+    assert result.collision_term == 40.0
+
+
+def test_collision_key_fallback_collisions() -> None:
+    """Falls back to legacy 'collisions' key when others are absent."""
+    episode = _MockEpisodeData(
+        metrics={
+            "collisions": 1,
+            "near_misses": 0,
+            "min_clearance": 0.6,
+            "failure_to_progress": 0,
+            "stalled_time": 0,
+        }
+    )
+    result = compute_criticality_score(episode)
+    assert result.status == "evaluated"
+    assert result.collision_key_used == "collisions"
+    assert result.collision_term == 10.0
+
+
+def test_collision_key_canonical_takes_precedence_over_fallbacks() -> None:
+    """Canonical key is used even when fallback keys also exist."""
+    episode = _MockEpisodeData(
+        metrics={
+            "collision_count": 1,
+            "agent_collision_count": 99,
+            "near_misses": 0,
+            "min_clearance": 0.6,
+            "failure_to_progress": 0,
+            "stalled_time": 0,
+        }
+    )
+    result = compute_criticality_score(episode)
+    assert result.collision_key_used == CANONICAL_COLLISION_KEY
+    assert result.collision_term == 10.0
+
+
+def test_canonical_collision_key_constant_value() -> None:
+    """CANONICAL_COLLISION_KEY is 'collision_count'."""
+    assert CANONICAL_COLLISION_KEY == "collision_count"
+
+
+def test_collision_key_fallbacks_ordered() -> None:
+    """Fallback chain has the expected order and length."""
+    assert COLLISION_KEY_FALLBACKS == (
+        "agent_collision_count",
+        "total_collision_count",
+        "collisions",
+    )

--- a/tests/benchmark/test_scenario_criticality_optimization.py
+++ b/tests/benchmark/test_scenario_criticality_optimization.py
@@ -249,3 +249,36 @@ def test_manifest_includes_max_workers() -> None:
     config.max_workers = 1
     _, manifest = run_criticality_optimization(config)
     assert manifest["max_workers"] == 1
+
+
+def test_parallel_matches_sequential_and_is_deterministic() -> None:
+    """max_workers=2 exercises the ProcessPoolExecutor path and yields the same,
+    deterministically-ordered results as the sequential path.
+
+    Guards against the nondeterministic ``as_completed`` ordering: candidates
+    must come back sorted by candidate_id regardless of worker completion order.
+    """
+    seq_config = _make_test_config(optimizer_seed=7)
+    seq_config.max_workers = 1
+    seq_candidates, _ = run_criticality_optimization(seq_config)
+
+    par_config = _make_test_config(optimizer_seed=7)
+    par_config.max_workers = 2
+    par_candidates, par_manifest = run_criticality_optimization(par_config)
+
+    # Effective workers is capped at the candidate count (baseline + budget).
+    assert 1 < par_manifest["max_workers"] <= len(par_candidates)
+
+    assert [c.candidate_id for c in par_candidates] == [c.candidate_id for c in seq_candidates]
+    for cp, cs in zip(par_candidates, seq_candidates, strict=True):
+        assert cp.status == cs.status
+        if cp.status == "evaluated":
+            assert cp.criticality_score == pytest.approx(cs.criticality_score)
+
+
+def test_effective_workers_capped_at_candidate_count() -> None:
+    """max_workers=0 (auto) must not spawn more workers than there are candidates."""
+    config = _make_test_config(sample_budget=2)
+    config.max_workers = 0
+    _, manifest = run_criticality_optimization(config)
+    assert manifest["max_workers"] <= manifest["total_candidates"]

--- a/tests/benchmark/test_scenario_criticality_optimization.py
+++ b/tests/benchmark/test_scenario_criticality_optimization.py
@@ -228,3 +228,24 @@ def test_cli_help() -> None:
     assert (
         "scenario criticality" in result.stdout.lower() or "optimization" in result.stdout.lower()
     )
+
+
+def test_max_workers_default_is_sequential() -> None:
+    """Default max_workers=1 means sequential execution."""
+    config = _make_test_config()
+    assert config.max_workers == 1
+
+
+def test_max_workers_stored_in_config() -> None:
+    """max_workers can be set on OptimizationConfig."""
+    config = _make_test_config()
+    config.max_workers = 2
+    assert config.max_workers == 2
+
+
+def test_manifest_includes_max_workers() -> None:
+    """Manifest records the effective max_workers used."""
+    config = _make_test_config()
+    config.max_workers = 1
+    _, manifest = run_criticality_optimization(config)
+    assert manifest["max_workers"] == 1


### PR DESCRIPTION
## What / Why

Implements the two remaining items from PR #4804 gate review:

1. **Pin collision metric to canonical `collision_count` key**: Define `CANONICAL_COLLISION_KEY` and `COLLISION_KEY_FALLBACKS` as explicit constants. Collision key resolution now uses `_resolve_collision_key()` with logging when a fallback is selected. `CriticalityResult` exposes `collision_key_used` for transparency.

2. **Parallel multi-candidate sweep**: Add `max_workers` parameter to `OptimizationConfig`. When `max_workers > 1`, candidates are evaluated in parallel via `ProcessPoolExecutor`. When `max_workers == 0`, uses `os.cpu_count()`. Default remains `1` (sequential).

## Successor slice

This PR addresses the remaining work identified after PR #4804 merged. Does not duplicate PR #4804.

## Validation

All tests pass:
```
uv run ruff check robot_sf/benchmark/scenario_criticality_objective.py scripts/benchmark/run_scenario_criticality_optimization.py
uv run pytest tests/benchmark/test_scenario_criticality_objective.py tests/benchmark/test_scenario_criticality_optimization.py -v
```

32 tests passed (17 objective + 15 optimization).

## Remaining (issue stays open)

- Parallel multi-candidate sweep **tuning** (e.g., batching, shared planner resolution) once workload characteristics are profiled.
- Collision key schema finalization once the episode-metrics schema settles.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

Refs #4792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable parallel execution in scenario criticality optimization, improving evaluation speed for larger runs.
  * Optimization run outputs now record the effective worker count used.

* **Bug Fixes**
  * Criticality scoring now reliably recognizes collision metrics across multiple available metric names, reducing failed or inconsistent evaluations.
  * Top candidate selection is now deterministic even when evaluations run in parallel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->