### PR TITLE
Issue #4778: replay-bridge integration for overlay (cheap-lane worker)

### DIFF
--- a/docs/context/issue_4778_exemplar_overlay_figures.md
+++ b/docs/context/issue_4778_exemplar_overlay_figures.md
@@ -1,0 +1,78 @@
+# Issue #4778 — Exemplar Selection + Multi-Planner Overlay Integration
+
+## Purpose
+
+This note documents the integration between the three figure-generation
+capabilities for campaign episode review:
+
+1. **Exemplar episode auto-selection** (`robot_sf/benchmark/exemplar_selection.py`,
+   `scripts/select_exemplar_episodes.py`): Picks representative episodes per
+   (planner × mechanism/outcome) cell — median, best, worst by a chosen metric —
+   and emits a deterministic selection manifest.
+
+2. **Replay bridge** (`robot_sf/benchmark/episode_replay_figure.py`,
+   `scripts/replay_episode_figure.py`): Takes a persisted campaign episode row
+   and replays it to produce provenance-stamped stills, filmstrip, and trajectory
+   figures.
+
+3. **Multi-planner trajectory overlay** (`robot_sf/benchmark/multi_planner_overlay.py`,
+   `scripts/render_multi_planner_trajectory_overlay.py`): Overlays robot
+   trajectories from multiple planners on the same scenario+seed into a single
+   provenance-stamped comparison figure.
+
+## Data Flow
+
+```
+campaign/episodes.jsonl
+        │
+        ├──► select_exemplar_episodes.py ──► selection_manifest.json
+        │                                        │
+        ▼                                        ▼
+ replay_episode_figure.py              render_multi_planner_trajectory_overlay.py
+   (single episode replay)               --selection-manifest <manifest.json>
+        │                                        │
+        ▼                                        ▼
+ stills / filmstrip / trajectory         multi-planner overlay figure
+```
+
+## Integration Points
+
+### replay_steps → overlay extraction
+
+Episode records carrying `replay_steps` data (from the replay bridge) are now
+supported by `extract_trajectory_from_episode()`. The function first tries
+inline trajectory fields (`trajectory.robot_positions`, etc.), then falls back
+to extracting `(x, y)` from `replay_steps` entries.
+
+### ReplayEpisode → TrajectoryRow bridge
+
+`trajectory_row_from_replay_episode()` converts a `ReplayEpisode` object into a
+`TrajectoryRow` for use with the overlay renderer. This enables programmatic
+pipelines where replay data is loaded in-process rather than through JSONL.
+
+### Selection manifest → overlay CLI
+
+`scripts/render_multi_planner_trajectory_overlay.py` accepts
+`--selection-manifest <path>` to drive overlay generation from an exemplar
+selection manifest. The CLI resolves `(scenario_id, seed, planner_keys)` from
+manifest entries and renders overlays for all cells in the manifest.
+
+## Claim Boundary
+
+All three tools produce **descriptive visualizations only** — they are not
+benchmark evidence or metric claims. Provenance sidecars record the claim
+boundary explicitly.
+
+## Dependencies
+
+- **#4777 (style pack)**: merged — provides shared planner palette and
+  publication style.
+- **#4776 (replay bridge)**: merged — provides `ReplayEpisode`/`ReplayStep`
+  data structures and figure generation.
+
+## Merged PRs
+
+- PR #4788: Exemplar selection (Part 1)
+- PR #4808: Multi-planner overlay (Part 2)
+- PR #4796: Replay bridge (#4776)
+- PR #4786: Style pack (#4777)

--- a/robot_sf/benchmark/multi_planner_overlay.py
+++ b/robot_sf/benchmark/multi_planner_overlay.py
@@ -108,6 +108,36 @@ _TRAJECTORY_PATHS: list[tuple[str, str]] = [
 ]
 
 
+def _extract_positions_from_replay_steps(
+    record: dict[str, Any],
+) -> list[tuple[float, float]]:
+    """Extract robot positions from ``replay_steps`` in an episode record.
+
+    The replay bridge (#4776) stores per-step ``(t, x, y, heading)`` data in
+    the ``replay_steps`` field.  This function converts it to the flat
+    ``(x, y)`` position list the overlay renderer expects.
+
+    Returns:
+        List of ``(x, y)`` tuples with finite coordinates, or an empty
+        list when ``replay_steps`` is absent or contains no valid entries.
+    """
+    replay_steps = record.get("replay_steps")
+    if not isinstance(replay_steps, list) or not replay_steps:
+        return []
+
+    positions: list[tuple[float, float]] = []
+    for step in replay_steps:
+        if isinstance(step, dict):
+            pair = _coerce_finite_pair(step.get("x"), step.get("y"))
+        elif isinstance(step, (list, tuple)) and len(step) >= 3:
+            pair = _coerce_finite_pair(step[1], step[2])
+        else:
+            continue
+        if pair is not None:
+            positions.append(pair)
+    return positions
+
+
 def _get_nested(record: dict[str, Any], path: str, default: Any = None) -> Any:
     """Resolve a dotted-path value from a dict.
 
@@ -227,6 +257,9 @@ def extract_trajectory_from_episode(
             positions = _parse_positions(raw)
             if positions:
                 break
+
+    if not positions:
+        positions = _extract_positions_from_replay_steps(record)
 
     if not positions:
         return None
@@ -545,6 +578,58 @@ def _git_sha_short(length: int = 7) -> str:
         return "unknown"
 
 
+def trajectory_row_from_replay_episode(
+    replay_episode: Any,
+    *,
+    planner_key: str = "",
+    source_path: str = "",
+) -> TrajectoryRow:
+    """Convert a ``ReplayEpisode`` (replay bridge) to a ``TrajectoryRow``.
+
+    This bridges the replay bridge (#4776) into the overlay renderer
+    (#4778).  The replay episode's step-by-step ``(x, y)`` positions are
+    extracted; pedestrian snapshot positions from the last step are
+    included when available.
+
+    Args:
+        replay_episode: A ``ReplayEpisode`` instance from
+            ``robot_sf.benchmark.full_classic.replay``.
+        planner_key: Planner identifier; falls back to ``"unknown_planner"``.
+        source_path: Optional source provenance path.
+
+    Returns:
+        ``TrajectoryRow`` with positions from the replay episode.
+
+    Raises:
+        MultiPlannerOverlayError: If the replay episode has no steps.
+    """
+    if not replay_episode.steps:
+        raise MultiPlannerOverlayError(f"ReplayEpisode {replay_episode.episode_id!r} has no steps")
+
+    positions = [(s.x, s.y) for s in replay_episode.steps]
+
+    pedestrians: list[tuple[float, float]] | None = None
+    last_step = replay_episode.steps[-1]
+    if last_step.ped_positions:
+        pedestrians = [
+            (float(p[0]), float(p[1]))
+            for p in last_step.ped_positions
+            if len(p) >= 2 and math.isfinite(float(p[0])) and math.isfinite(float(p[1]))
+        ]
+        if not pedestrians:
+            pedestrians = None
+
+    return TrajectoryRow(
+        episode_id=replay_episode.episode_id,
+        planner_key=planner_key or "unknown_planner",
+        scenario_id=replay_episode.scenario_id,
+        seed=0,
+        positions=positions,
+        pedestrians=pedestrians,
+        source_path=source_path,
+    )
+
+
 def load_episodes(path: Path | str) -> list[dict[str, Any]]:
     """Load episodes from a JSONL file.
 
@@ -578,4 +663,5 @@ __all__ = [
     "extract_trajectory_from_episode",
     "load_episodes",
     "select_episodes_for_overlay",
+    "trajectory_row_from_replay_episode",
 ]

--- a/robot_sf/benchmark/multi_planner_overlay.py
+++ b/robot_sf/benchmark/multi_planner_overlay.py
@@ -606,7 +606,15 @@ def trajectory_row_from_replay_episode(
     if not replay_episode.steps:
         raise MultiPlannerOverlayError(f"ReplayEpisode {replay_episode.episode_id!r} has no steps")
 
-    positions = [(s.x, s.y) for s in replay_episode.steps]
+    positions = [
+        (float(s.x), float(s.y))
+        for s in replay_episode.steps
+        if math.isfinite(float(s.x)) and math.isfinite(float(s.y))
+    ]
+    if not positions:
+        raise MultiPlannerOverlayError(
+            f"ReplayEpisode {replay_episode.episode_id!r} has no finite positions"
+        )
 
     pedestrians: list[tuple[float, float]] | None = None
     last_step = replay_episode.steps[-1]

--- a/scripts/render_multi_planner_trajectory_overlay.py
+++ b/scripts/render_multi_planner_trajectory_overlay.py
@@ -161,7 +161,10 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         cells: dict[tuple[str, int], list[str]] = {}
         for entry in selected:
             scenario = entry.get("scenario_id", "")
-            seed_val = entry.get("seed", 0)
+            # Coerce a null/absent seed to 0 so grouping keys stay int-typed
+            # (entry.get(..., 0) still yields None when the key is present-but-null).
+            seed_raw = entry.get("seed", 0)
+            seed_val = 0 if seed_raw is None else seed_raw
             planner = entry.get("planner_key", "")
             key = (scenario, seed_val)
             cells.setdefault(key, []).append(planner)

--- a/scripts/render_multi_planner_trajectory_overlay.py
+++ b/scripts/render_multi_planner_trajectory_overlay.py
@@ -15,6 +15,12 @@ Usage:
       --planners orca,ppo \\
       --out-dir output/overlays
 
+Or with a selection manifest from the exemplar selector (#4778):
+    uv run python scripts/render_multi_planner_trajectory_overlay.py \\
+      --episodes campaign/episodes.jsonl \\
+      --selection-manifest output/exemplars/selection_manifest.json \\
+      --out-dir output/overlays
+
 Exit codes:
     0  Success
     1  Missing or invalid inputs
@@ -24,6 +30,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -49,19 +56,25 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--scenario-id",
-        required=True,
-        help="Scenario identifier to filter on.",
+        default=None,
+        help="Scenario identifier to filter on (required unless --selection-manifest).",
     )
     parser.add_argument(
         "--seed",
         type=int,
-        required=True,
-        help="Seed to filter on.",
+        default=None,
+        help="Seed to filter on (required unless --selection-manifest).",
     )
     parser.add_argument(
         "--planners",
-        required=True,
-        help="Comma-separated planner keys to overlay.",
+        default=None,
+        help="Comma-separated planner keys to overlay (required unless --selection-manifest).",
+    )
+    parser.add_argument(
+        "--selection-manifest",
+        default=None,
+        help="Path to exemplar selection_manifest.json (from select_exemplar_episodes.py). "
+        "When provided, --scenario-id, --seed, and --planners are derived from the manifest.",
     )
     parser.add_argument(
         "--out-dir",
@@ -87,7 +100,35 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: list[str] | None = None) -> int:
+def _load_selection_manifest(path: str) -> dict:
+    """Load and validate a selection manifest file.
+
+    Returns:
+        Parsed manifest dict.
+
+    Raises:
+        SystemExit: On missing file or invalid schema.
+    """
+    manifest_path = Path(path)
+    if not manifest_path.exists():
+        print(f"Error: selection manifest not found: {manifest_path}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        with manifest_path.open("r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Error reading selection manifest: {exc}", file=sys.stderr)
+        sys.exit(1)
+    if manifest.get("schema_version") != "exemplar-selection.v1":
+        print(
+            f"Error: unsupported manifest schema: {manifest.get('schema_version')}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:  # noqa: C901
     """Run the multi-planner trajectory overlay CLI.
 
     Returns:
@@ -95,13 +136,7 @@ def main(argv: list[str] | None = None) -> int:
     """
     args = _parse_args(argv)
 
-    planner_keys = [p.strip() for p in args.planners.split(",") if p.strip()]
     formats = [f.strip() for f in args.formats.split(",") if f.strip()]
-
-    if not planner_keys:
-        print("Error: --planners must not be empty", file=sys.stderr)
-        return 1
-
     if not formats:
         print("Error: --formats must not be empty", file=sys.stderr)
         return 1
@@ -113,40 +148,125 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error loading episodes: {exc}", file=sys.stderr)
         return 1
 
-    # Select episodes for overlay
+    # Resolve overlay parameters: from manifest or CLI args
+    manifest = None
+    if args.selection_manifest:
+        manifest = _load_selection_manifest(args.selection_manifest)
+        selected = manifest.get("selected", [])
+        if not selected:
+            print("Error: selection manifest contains no selected episodes", file=sys.stderr)
+            return 1
+
+        # Group by (scenario_id, seed) and collect planners
+        cells: dict[tuple[str, int], list[str]] = {}
+        for entry in selected:
+            scenario = entry.get("scenario_id", "")
+            seed_val = entry.get("seed", 0)
+            planner = entry.get("planner_key", "")
+            key = (scenario, seed_val)
+            cells.setdefault(key, []).append(planner)
+
+        if args.scenario_id is not None and args.seed is not None:
+            override_key = (args.scenario_id, args.seed)
+            if override_key in cells:
+                cells = {override_key: cells[override_key]}
+            else:
+                print(
+                    f"Warning: scenario={args.scenario_id} seed={args.seed} not in manifest; "
+                    "using all manifest cells",
+                    file=sys.stderr,
+                )
+        # If neither --scenario-id nor --seed is provided, render all cells
+    elif args.scenario_id is None or args.seed is None or args.planners is None:
+        print(
+            "Error: --scenario-id, --seed, and --planners are required "
+            "unless --selection-manifest is provided",
+            file=sys.stderr,
+        )
+        return 1
+    else:
+        planner_keys = [p.strip() for p in args.planners.split(",") if p.strip()]
+        if not planner_keys:
+            print("Error: --planners must not be empty", file=sys.stderr)
+            return 1
+        cells = {(args.scenario_id, args.seed): planner_keys}
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    exit_code = 0
+    for (scenario_id, seed), planner_keys in cells.items():
+        exit_code = max(
+            exit_code,
+            _render_one_cell(
+                episodes=episodes,
+                scenario_id=scenario_id,
+                seed=seed,
+                planner_keys=planner_keys,
+                out_dir=out_dir,
+                formats=formats,
+                dpi=args.dpi,
+                allow_missing=args.allow_missing,
+                manifest_path=args.selection_manifest,
+            ),
+        )
+
+    return exit_code
+
+
+def _render_one_cell(  # noqa: PLR0913
+    *,
+    episodes: list[dict],
+    scenario_id: str,
+    seed: int,
+    planner_keys: list[str],
+    out_dir: Path,
+    formats: list[str],
+    dpi: int,
+    allow_missing: bool,
+    manifest_path: str | None,
+) -> int:
+    """Render overlay for one (scenario, seed) cell.
+
+    Returns:
+        Exit code.
+    """
     try:
         trajectory_rows = select_episodes_for_overlay(
             episodes,
-            scenario_id=args.scenario_id,
-            seed=args.seed,
+            scenario_id=scenario_id,
+            seed=seed,
             planner_keys=planner_keys,
         )
     except MultiPlannerOverlayError as exc:
-        if args.allow_missing:
-            return _handle_missing_planners(episodes, args, formats)
+        if allow_missing:
+            return _handle_missing_planners(
+                episodes=episodes,
+                scenario_id=scenario_id,
+                seed=seed,
+                planner_keys=planner_keys,
+                out_dir=out_dir,
+                formats=formats,
+                dpi=dpi,
+            )
         print(f"Error: {exc}", file=sys.stderr)
         print("Use --allow-missing to continue with available planners.", file=sys.stderr)
         return 2
 
-    # Build output path
-    out_dir = Path(args.out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    output_base = out_dir / f"{args.scenario_id}_seed{args.seed}"
+    output_base = out_dir / f"{scenario_id}_seed{seed}"
 
-    # Render
     try:
         saved = build_overlay_figure(
             trajectory_rows,
             output_base=output_base,
             formats=formats,
-            dpi=args.dpi,
+            dpi=dpi,
         )
     except (MultiPlannerOverlayError, ValueError) as exc:
         print(f"Error rendering overlay: {exc}", file=sys.stderr)
         return 1
 
-    # Print results
-    print(f"Overlay rendered: {len(saved)} file(s)")
+    print(f"Overlay rendered ({scenario_id}, seed {seed}): {len(saved)} file(s)")
     for path in saved:
         print(f"  {path}")
 
@@ -154,9 +274,14 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _handle_missing_planners(
+    *,
     episodes: list[dict],
-    args: argparse.Namespace,
+    scenario_id: str,
+    seed: int,
+    planner_keys: list[str],
+    out_dir: Path,
     formats: list[str],
+    dpi: int,
 ) -> int:
     """Handle missing planners when --allow-missing is set.
 
@@ -166,48 +291,39 @@ def _handle_missing_planners(
     from robot_sf.benchmark.multi_planner_overlay import _find_trajectory_row
 
     available: list[str] = []
-    for pk in args.planners.split(","):
-        pk = pk.strip()
-        if not pk:
-            continue
-        # Reuse the canonical matcher so a planner counts as available only
-        # when it actually resolves to valid trajectory data (shared seed
-        # coercion + fail-closed extraction).
-        if _find_trajectory_row(episodes, args.scenario_id, args.seed, pk) is not None:
+    for pk in planner_keys:
+        if _find_trajectory_row(episodes, scenario_id, seed, pk) is not None:
             available.append(pk)
 
     if not available:
         print("Error: no trajectory data available", file=sys.stderr)
         return 2
 
-    # Select with available planners
     try:
         trajectory_rows = select_episodes_for_overlay(
             episodes,
-            scenario_id=args.scenario_id,
-            seed=args.seed,
+            scenario_id=scenario_id,
+            seed=seed,
             planner_keys=available,
         )
     except MultiPlannerOverlayError:
         print("Error: no trajectories available after filtering", file=sys.stderr)
         return 2
 
-    out_dir = Path(args.out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    output_base = out_dir / f"{args.scenario_id}_seed{args.seed}"
+    output_base = out_dir / f"{scenario_id}_seed{seed}"
 
     try:
         saved = build_overlay_figure(
             trajectory_rows,
             output_base=output_base,
             formats=formats,
-            dpi=args.dpi,
+            dpi=dpi,
         )
     except (MultiPlannerOverlayError, ValueError) as exc:
         print(f"Error rendering overlay: {exc}", file=sys.stderr)
         return 1
 
-    print(f"Overlay rendered: {len(saved)} file(s)")
+    print(f"Overlay rendered ({scenario_id}, seed {seed}): {len(saved)} file(s)")
     for path in saved:
         print(f"  {path}")
 

--- a/tests/benchmark/test_replay_overlay_integration.py
+++ b/tests/benchmark/test_replay_overlay_integration.py
@@ -1,0 +1,558 @@
+"""Tests for replay-bridge ↔ overlay integration (issue #4778).
+
+Validates that replay_steps data feeds correctly into the overlay renderer
+and that the ReplayEpisode → TrajectoryRow bridge works.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from robot_sf.benchmark.full_classic.replay import ReplayEpisode, ReplayStep
+from robot_sf.benchmark.multi_planner_overlay import (
+    MultiPlannerOverlayError,
+    extract_trajectory_from_episode,
+    trajectory_row_from_replay_episode,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# replay_steps extraction from episode records
+# ---------------------------------------------------------------------------
+
+
+class TestReplayStepsExtraction:
+    """Test extracting trajectories from replay_steps in episode records."""
+
+    def test_replay_steps_dict_format(self) -> None:
+        """Extract from replay_steps with dict entries."""
+        ep: dict[str, Any] = {
+            "episode_id": "ep_rs1",
+            "scenario_id": "corridor",
+            "seed": 42,
+            "algo": "orca",
+            "replay_steps": [
+                {"t": 0.0, "x": 0.0, "y": 0.0, "heading": 0.0},
+                {"t": 0.1, "x": 0.5, "y": 0.1, "heading": 0.2},
+                {"t": 0.2, "x": 1.0, "y": 0.2, "heading": 0.3},
+            ],
+        }
+        row = extract_trajectory_from_episode(ep)
+        assert row is not None
+        assert row.positions == [(0.0, 0.0), (0.5, 0.1), (1.0, 0.2)]
+        assert row.planner_key == "orca"
+        assert row.episode_id == "ep_rs1"
+
+    def test_replay_steps_list_format(self) -> None:
+        """Extract from replay_steps with list/tuple entries (t, x, y, heading)."""
+        ep: dict[str, Any] = {
+            "episode_id": "ep_rs2",
+            "scenario_id": "hallway",
+            "seed": 7,
+            "algo": "ppo",
+            "replay_steps": [
+                [0.0, 1.0, 2.0, 0.5],
+                [0.1, 1.5, 2.1, 0.6],
+            ],
+        }
+        row = extract_trajectory_from_episode(ep)
+        assert row is not None
+        assert row.positions == [(1.0, 2.0), (1.5, 2.1)]
+
+    def test_replay_steps_nonfinite_skipped(self) -> None:
+        """Non-finite replay step coordinates are skipped."""
+        ep: dict[str, Any] = {
+            "episode_id": "ep_rs_nan",
+            "scenario_id": "corridor",
+            "seed": 1,
+            "algo": "orca",
+            "replay_steps": [
+                {"t": 0.0, "x": 0.0, "y": 0.0, "heading": 0.0},
+                {"t": 0.1, "x": float("nan"), "y": 0.1, "heading": 0.0},
+                {"t": 0.2, "x": 1.0, "y": 0.2, "heading": 0.0},
+            ],
+        }
+        row = extract_trajectory_from_episode(ep)
+        assert row is not None
+        assert len(row.positions) == 2
+
+    def test_replay_steps_empty_returns_none(self) -> None:
+        """Empty replay_steps list yields no trajectory."""
+        ep: dict[str, Any] = {
+            "episode_id": "ep_empty_rs",
+            "scenario_id": "corridor",
+            "seed": 1,
+            "algo": "orca",
+            "replay_steps": [],
+        }
+        assert extract_trajectory_from_episode(ep) is None
+
+    def test_inline_trajectory_takes_precedence(self) -> None:
+        """Inline trajectory fields take precedence over replay_steps."""
+        ep: dict[str, Any] = {
+            "episode_id": "ep_both",
+            "scenario_id": "corridor",
+            "seed": 1,
+            "algo": "orca",
+            "trajectory": {"robot_positions": [[0.0, 0.0], [1.0, 1.0]]},
+            "replay_steps": [
+                {"t": 0.0, "x": 5.0, "y": 5.0, "heading": 0.0},
+                {"t": 0.1, "x": 6.0, "y": 6.0, "heading": 0.0},
+            ],
+        }
+        row = extract_trajectory_from_episode(ep)
+        assert row is not None
+        assert row.positions == [(0.0, 0.0), (1.0, 1.0)]
+
+    def test_replay_steps_malformed_entries_skipped(self) -> None:
+        """Malformed replay step entries are skipped gracefully."""
+        ep: dict[str, Any] = {
+            "episode_id": "ep_malformed",
+            "scenario_id": "corridor",
+            "seed": 1,
+            "algo": "orca",
+            "replay_steps": [
+                {"t": 0.0, "x": 0.0, "y": 0.0, "heading": 0.0},
+                "invalid_step",
+                {"t": 0.2, "x": 1.0, "y": 0.2, "heading": 0.0},
+            ],
+        }
+        row = extract_trajectory_from_episode(ep)
+        assert row is not None
+        assert len(row.positions) == 2
+
+    def test_replay_steps_with_pedestrians_in_episode(self) -> None:
+        """Pedestrians from the episode record are included with replay_steps."""
+        ep: dict[str, Any] = {
+            "episode_id": "ep_peds_rs",
+            "scenario_id": "corridor",
+            "seed": 1,
+            "algo": "orca",
+            "replay_steps": [
+                {"t": 0.0, "x": 0.0, "y": 0.0, "heading": 0.0},
+                {"t": 0.1, "x": 1.0, "y": 0.0, "heading": 0.0},
+            ],
+            "pedestrians": [{"position": [0.5, 0.5]}, {"position": [0.3, 0.7]}],
+        }
+        row = extract_trajectory_from_episode(ep)
+        assert row is not None
+        assert row.pedestrians == [(0.5, 0.5), (0.3, 0.7)]
+
+
+# ---------------------------------------------------------------------------
+# ReplayEpisode → TrajectoryRow bridge
+# ---------------------------------------------------------------------------
+
+
+class TestTrajectoryRowFromReplayEpisode:
+    """Test converting ReplayEpisode to TrajectoryRow."""
+
+    def test_basic_conversion(self) -> None:
+        """Basic ReplayEpisode conversion produces correct TrajectoryRow."""
+        replay = ReplayEpisode(
+            episode_id="ep_bridge_1",
+            scenario_id="corridor",
+            steps=[
+                ReplayStep(t=0.0, x=0.0, y=0.0, heading=0.0),
+                ReplayStep(t=0.1, x=0.5, y=0.1, heading=0.2),
+                ReplayStep(t=0.2, x=1.0, y=0.3, heading=0.4),
+            ],
+        )
+        row = trajectory_row_from_replay_episode(replay, planner_key="orca")
+        assert row.episode_id == "ep_bridge_1"
+        assert row.scenario_id == "corridor"
+        assert row.planner_key == "orca"
+        assert row.positions == [(0.0, 0.0), (0.5, 0.1), (1.0, 0.3)]
+        assert row.pedestrians is None
+
+    def test_with_pedestrian_snapshot(self) -> None:
+        """Last-step pedestrian positions are captured."""
+        replay = ReplayEpisode(
+            episode_id="ep_bridge_peds",
+            scenario_id="hallway",
+            steps=[
+                ReplayStep(t=0.0, x=0.0, y=0.0, heading=0.0),
+                ReplayStep(
+                    t=0.1,
+                    x=1.0,
+                    y=0.0,
+                    heading=0.0,
+                    ped_positions=[(0.5, 0.5), (0.3, 0.7)],
+                ),
+            ],
+        )
+        row = trajectory_row_from_replay_episode(replay, planner_key="ppo")
+        assert row.pedestrians == [(0.5, 0.5), (0.3, 0.7)]
+
+    def test_empty_steps_raises(self) -> None:
+        """ReplayEpisode with no steps raises MultiPlannerOverlayError."""
+        replay = ReplayEpisode(
+            episode_id="ep_empty",
+            scenario_id="corridor",
+            steps=[],
+        )
+        with pytest.raises(MultiPlannerOverlayError, match="no steps"):
+            trajectory_row_from_replay_episode(replay)
+
+    def test_nonfinite_ped_positions_excluded(self) -> None:
+        """Non-finite pedestrian positions are excluded."""
+        replay = ReplayEpisode(
+            episode_id="ep_bad_peds",
+            scenario_id="corridor",
+            steps=[
+                ReplayStep(
+                    t=0.0,
+                    x=0.0,
+                    y=0.0,
+                    heading=0.0,
+                    ped_positions=[(0.5, 0.5), (float("nan"), 1.0), (float("inf"), 2.0)],
+                ),
+            ],
+        )
+        row = trajectory_row_from_replay_episode(replay)
+        assert row.pedestrians == [(0.5, 0.5)]
+
+    def test_unknown_planner_fallback(self) -> None:
+        """Empty planner_key falls back to 'unknown_planner'."""
+        replay = ReplayEpisode(
+            episode_id="ep_unknown",
+            scenario_id="corridor",
+            steps=[ReplayStep(t=0.0, x=0.0, y=0.0, heading=0.0)],
+        )
+        row = trajectory_row_from_replay_episode(replay)
+        assert row.planner_key == "unknown_planner"
+
+    def test_source_path_preserved(self) -> None:
+        """Source path is preserved in the TrajectoryRow."""
+        replay = ReplayEpisode(
+            episode_id="ep_src",
+            scenario_id="corridor",
+            steps=[ReplayStep(t=0.0, x=0.0, y=0.0, heading=0.0)],
+        )
+        row = trajectory_row_from_replay_episode(
+            replay, planner_key="orca", source_path="/some/path.jsonl"
+        )
+        assert row.source_path == "/some/path.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Selection manifest → overlay integration (CLI)
+# ---------------------------------------------------------------------------
+
+
+class TestSelectionManifestCLI:
+    """Test CLI --selection-manifest integration."""
+
+    def test_cli_with_manifest(self, tmp_path: Path) -> None:
+        """CLI renders overlay from selection manifest."""
+        from scripts.render_multi_planner_trajectory_overlay import main as cli_main
+
+        # Create episodes JSONL
+        ep_file = tmp_path / "episodes.jsonl"
+        episodes = [
+            {
+                "episode_id": "ep_orca",
+                "algo": "orca",
+                "scenario_id": "corridor",
+                "seed": 42,
+                "trajectory": {"robot_positions": [[0, 0], [1, 1], [2, 0]]},
+            },
+            {
+                "episode_id": "ep_ppo",
+                "algo": "ppo",
+                "scenario_id": "corridor",
+                "seed": 42,
+                "trajectory": {"robot_positions": [[0, 0], [0.5, 2], [2, 0]]},
+            },
+        ]
+        ep_file.write_text(
+            "\n".join(json.dumps(e) for e in episodes) + "\n",
+            encoding="utf-8",
+        )
+
+        # Create selection manifest
+        manifest = {
+            "schema_version": "exemplar-selection.v1",
+            "source_episodes": str(ep_file),
+            "group_by": ["planner_key"],
+            "metric": "path_efficiency",
+            "selected": [
+                {
+                    "episode_id": "ep_orca",
+                    "planner_key": "orca",
+                    "scenario_id": "corridor",
+                    "seed": 42,
+                    "selection_mode": "median",
+                    "selection_rank": 0,
+                    "metric_value": 0.8,
+                    "reason": "median within cell",
+                },
+                {
+                    "episode_id": "ep_ppo",
+                    "planner_key": "ppo",
+                    "scenario_id": "corridor",
+                    "seed": 42,
+                    "selection_mode": "median",
+                    "selection_rank": 0,
+                    "metric_value": 0.7,
+                    "reason": "median within cell",
+                },
+            ],
+            "skipped_cells": [],
+        }
+        manifest_file = tmp_path / "selection_manifest.json"
+        manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+
+        out_dir = tmp_path / "overlay_out"
+        exit_code = cli_main(
+            [
+                "--episodes",
+                str(ep_file),
+                "--selection-manifest",
+                str(manifest_file),
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+        assert exit_code == 0
+        png_path = out_dir / "corridor_seed42.png"
+        assert png_path.exists()
+
+    def test_cli_manifest_missing_episodes(self, tmp_path: Path) -> None:
+        """CLI returns error when manifest references episodes not in JSONL."""
+        from scripts.render_multi_planner_trajectory_overlay import main as cli_main
+
+        ep_file = tmp_path / "episodes.jsonl"
+        ep_file.write_text(
+            json.dumps(
+                {
+                    "episode_id": "ep_orca",
+                    "algo": "orca",
+                    "scenario_id": "corridor",
+                    "seed": 42,
+                    "trajectory": {"robot_positions": [[0, 0], [1, 1]]},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        manifest = {
+            "schema_version": "exemplar-selection.v1",
+            "selected": [
+                {
+                    "episode_id": "ep_orca",
+                    "planner_key": "orca",
+                    "scenario_id": "corridor",
+                    "seed": 42,
+                },
+                {
+                    "episode_id": "ep_missing",
+                    "planner_key": "ppo",
+                    "scenario_id": "corridor",
+                    "seed": 42,
+                },
+            ],
+        }
+        manifest_file = tmp_path / "manifest.json"
+        manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+
+        out_dir = tmp_path / "out"
+        exit_code = cli_main(
+            [
+                "--episodes",
+                str(ep_file),
+                "--selection-manifest",
+                str(manifest_file),
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+        assert exit_code == 2
+
+    def test_cli_manifest_with_allow_missing(self, tmp_path: Path) -> None:
+        """CLI with --allow-missing renders available planners from manifest."""
+        from scripts.render_multi_planner_trajectory_overlay import main as cli_main
+
+        ep_file = tmp_path / "episodes.jsonl"
+        ep_file.write_text(
+            json.dumps(
+                {
+                    "episode_id": "ep_orca",
+                    "algo": "orca",
+                    "scenario_id": "corridor",
+                    "seed": 42,
+                    "trajectory": {"robot_positions": [[0, 0], [1, 1]]},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        manifest = {
+            "schema_version": "exemplar-selection.v1",
+            "selected": [
+                {
+                    "episode_id": "ep_orca",
+                    "planner_key": "orca",
+                    "scenario_id": "corridor",
+                    "seed": 42,
+                },
+                {
+                    "episode_id": "ep_missing",
+                    "planner_key": "ppo",
+                    "scenario_id": "corridor",
+                    "seed": 42,
+                },
+            ],
+        }
+        manifest_file = tmp_path / "manifest.json"
+        manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+
+        out_dir = tmp_path / "out"
+        exit_code = cli_main(
+            [
+                "--episodes",
+                str(ep_file),
+                "--selection-manifest",
+                str(manifest_file),
+                "--out-dir",
+                str(out_dir),
+                "--allow-missing",
+            ]
+        )
+        assert exit_code == 0
+        png_path = out_dir / "corridor_seed42.png"
+        assert png_path.exists()
+
+    def test_cli_manifest_empty_selected(self, tmp_path: Path) -> None:
+        """CLI returns error when manifest has no selected episodes."""
+        from scripts.render_multi_planner_trajectory_overlay import main as cli_main
+
+        ep_file = tmp_path / "episodes.jsonl"
+        ep_file.write_text(
+            json.dumps({"episode_id": "ep1", "algo": "orca", "scenario_id": "s", "seed": 1}) + "\n",
+            encoding="utf-8",
+        )
+
+        manifest = {
+            "schema_version": "exemplar-selection.v1",
+            "selected": [],
+        }
+        manifest_file = tmp_path / "manifest.json"
+        manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+
+        exit_code = cli_main(
+            [
+                "--episodes",
+                str(ep_file),
+                "--selection-manifest",
+                str(manifest_file),
+                "--out-dir",
+                str(tmp_path / "out"),
+            ]
+        )
+        assert exit_code == 1
+
+    def test_cli_manifest_bad_schema(self, tmp_path: Path) -> None:
+        """CLI returns error on unsupported manifest schema."""
+        from scripts.render_multi_planner_trajectory_overlay import main as cli_main
+
+        ep_file = tmp_path / "episodes.jsonl"
+        ep_file.write_text(
+            json.dumps({"episode_id": "ep1", "algo": "orca", "scenario_id": "s", "seed": 1}) + "\n",
+            encoding="utf-8",
+        )
+
+        manifest = {"schema_version": "wrong.v0", "selected": []}
+        manifest_file = tmp_path / "manifest.json"
+        manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with pytest.raises(SystemExit, match="1"):
+            cli_main(
+                [
+                    "--episodes",
+                    str(ep_file),
+                    "--selection-manifest",
+                    str(manifest_file),
+                    "--out-dir",
+                    str(tmp_path / "out"),
+                ]
+            )
+
+    def test_cli_requires_args_without_manifest(self, tmp_path: Path) -> None:
+        """CLI returns error when neither manifest nor required args provided."""
+        from scripts.render_multi_planner_trajectory_overlay import main as cli_main
+
+        ep_file = tmp_path / "episodes.jsonl"
+        ep_file.write_text(
+            json.dumps({"episode_id": "ep1", "algo": "orca", "scenario_id": "s", "seed": 1}) + "\n",
+            encoding="utf-8",
+        )
+
+        exit_code = cli_main(["--episodes", str(ep_file), "--out-dir", str(tmp_path / "out")])
+        assert exit_code == 1
+
+    def test_cli_manifest_multiple_cells(self, tmp_path: Path) -> None:
+        """CLI renders overlays for multiple cells in a manifest."""
+        from scripts.render_multi_planner_trajectory_overlay import main as cli_main
+
+        ep_file = tmp_path / "episodes.jsonl"
+        records = [
+            {
+                "episode_id": "ep1",
+                "algo": "orca",
+                "scenario_id": "corridor",
+                "seed": 1,
+                "trajectory": {"robot_positions": [[0, 0], [1, 1]]},
+            },
+            {
+                "episode_id": "ep2",
+                "algo": "orca",
+                "scenario_id": "hallway",
+                "seed": 2,
+                "trajectory": {"robot_positions": [[0, 0], [2, 2]]},
+            },
+        ]
+        ep_file.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+
+        manifest = {
+            "schema_version": "exemplar-selection.v1",
+            "selected": [
+                {
+                    "episode_id": "ep1",
+                    "planner_key": "orca",
+                    "scenario_id": "corridor",
+                    "seed": 1,
+                },
+                {
+                    "episode_id": "ep2",
+                    "planner_key": "orca",
+                    "scenario_id": "hallway",
+                    "seed": 2,
+                },
+            ],
+        }
+        manifest_file = tmp_path / "manifest.json"
+        manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+
+        out_dir = tmp_path / "out"
+        exit_code = cli_main(
+            [
+                "--episodes",
+                str(ep_file),
+                "--selection-manifest",
+                str(manifest_file),
+                "--out-dir",
+                str(out_dir),
+            ]
+        )
+        assert exit_code == 0
+        assert (out_dir / "corridor_seed1.png").exists()
+        assert (out_dir / "hallway_seed2.png").exists()


### PR DESCRIPTION
## What / Why

Adds **replay-bridge integration** to the multi-planner trajectory overlay renderer — the remaining work item from #4778.

Episode records carrying `replay_steps` data (from the replay bridge, #4776) can now be visualized through the multi-planner overlay without requiring inline trajectory fields. This closes the loop between the exemplar selector, replay bridge, and overlay renderer.

### Changes

| File | Change |
|------|--------|
| `robot_sf/benchmark/multi_planner_overlay.py` | `extract_trajectory_from_episode()` falls back to `replay_steps` when inline fields absent; new `trajectory_row_from_replay_episode()` bridge function |
| `scripts/render_multi_planner_trajectory_overlay.py` | `--selection-manifest` CLI flag to drive overlays from exemplar selection manifests; multi-cell rendering support |
| `tests/benchmark/test_replay_overlay_integration.py` | 20 focused tests: replay_steps extraction (7), ReplayEpisode bridge (6), manifest-driven CLI (7) |
| `docs/context/issue_4778_exemplar_overlay_figures.md` | Integration context documentation |

### Key behaviors

- **replay_steps extraction**: dict `{t, x, y, heading}` and list `[t, x, y, heading]` formats; non-finite entries skipped; inline trajectory fields still take precedence
- **ReplayEpisode → TrajectoryRow**: converts step-by-step positions; captures last-step pedestrian snapshots; fails closed on empty steps
- **Selection manifest CLI**: reads `exemplar-selection.v1` manifest, resolves `(scenario, seed, planners)` per cell, renders all cells or overrides with `--scenario-id`/`--seed`

## Validation

```
$ uv run ruff check robot_sf/benchmark/multi_planner_overlay.py \
    scripts/render_multi_planner_trajectory_overlay.py \
    tests/benchmark/test_replay_overlay_integration.py
All checks passed!

$ uv run pytest tests/benchmark/test_replay_overlay_integration.py -v
20 passed in 1.39s

$ uv run pytest tests/benchmark/test_multi_planner_overlay.py -v
23 passed in 1.09s (no regressions)
```

## Successor statement

This is a **successor slice** to PR #4788 (exemplar selection) and PR #4808 (overlay renderer). Adds the replay-bridge integration explicitly listed as remaining work in the #4778 thread. Does not duplicate those PRs.

## Claim boundary

Visual comparison integration only. No metric or benchmark claims.

Refs #4778

---

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.