### PR TITLE
Issue #4792: shared planner resolution for parallel sweep (cheap-lane worker)

### DIFF
--- a/scripts/benchmark/run_scenario_criticality_optimization.py
+++ b/scripts/benchmark/run_scenario_criticality_optimization.py
@@ -35,6 +35,9 @@ from robot_sf.benchmark.scenario_criticality_objective import (
     compute_criticality_score,
 )
 from robot_sf.training.scenario_loader import load_scenarios
+from scripts.validation.run_scenario_perturbation_criticality_pilot import (
+    resolve_planner_run_spec,
+)
 
 
 @dataclass
@@ -209,7 +212,7 @@ def _build_baseline_parameters(
     return params
 
 
-def _evaluate_candidate(  # noqa: C901
+def _evaluate_candidate(  # noqa: C901, PLR0913
     candidate_id: str,
     parameters: dict[str, float],
     scenario: dict[str, Any],
@@ -217,15 +220,21 @@ def _evaluate_candidate(  # noqa: C901
     objective_config: CriticalityObjectiveConfig,
     output_dir: Path,
     scenario_path: Path,
+    *,
+    resolved_algo: str | None = None,
+    resolved_algo_config_path: str | None = None,
 ) -> CandidateResult:
-    """Evaluate a single candidate by running the simulator."""
+    """Evaluate a single candidate by running the simulator.
+
+    Args:
+        resolved_algo: Pre-resolved planner algo name (avoids redundant resolution
+            per worker in parallel mode).
+        resolved_algo_config_path: Pre-resolved algo config path string.
+    """
     import time
     from types import SimpleNamespace
 
     from robot_sf.benchmark.map_runner import run_map_batch
-    from scripts.validation.run_scenario_perturbation_criticality_pilot import (
-        resolve_planner_run_spec,
-    )
 
     start_time = time.perf_counter()
     try:
@@ -240,11 +249,19 @@ def _evaluate_candidate(  # noqa: C901
         if temp_jsonl.exists():
             temp_jsonl.unlink()
 
-        # Resolve the planner
-        planner_name = config.planner_name
-        if planner_name == "safe_baseline":
-            planner_name = "goal"
-        spec = resolve_planner_run_spec(planner_name)
+        # Use pre-resolved planner spec if provided, otherwise resolve locally
+        if resolved_algo is not None:
+            algo = resolved_algo
+            algo_config_path = resolved_algo_config_path
+        else:
+            planner_name = config.planner_name
+            if planner_name == "safe_baseline":
+                planner_name = "goal"
+            spec = resolve_planner_run_spec(planner_name)
+            algo = spec.algo
+            algo_config_path = (
+                spec.algo_config_path.as_posix() if spec.algo_config_path is not None else None
+            )
 
         # Run the batch
         run_map_batch(
@@ -252,10 +269,8 @@ def _evaluate_candidate(  # noqa: C901
             out_path=temp_jsonl,
             schema_path=Path("robot_sf/benchmark/schemas/episode.schema.v1.json"),
             scenario_path=scenario_path,
-            algo=spec.algo,
-            algo_config_path=spec.algo_config_path.as_posix()
-            if spec.algo_config_path is not None
-            else None,
+            algo=algo,
+            algo_config_path=algo_config_path,
             horizon=config.horizon,
             dt=config.dt,
             resume=False,
@@ -414,6 +429,19 @@ def run_criticality_optimization(  # noqa: C901
     if effective_workers > 1:
         effective_workers = min(effective_workers, max(1, len(candidate_params)))
 
+    # Pre-resolve planner spec once in the main process so parallel workers
+    # avoid redundant YAML registry / candidate-config file I/O.
+    planner_name = config.planner_name
+    if planner_name == "safe_baseline":
+        planner_name = "goal"
+    _planner_spec = resolve_planner_run_spec(planner_name)
+    _resolved_algo = _planner_spec.algo
+    _resolved_algo_config_path = (
+        _planner_spec.algo_config_path.as_posix()
+        if _planner_spec.algo_config_path is not None
+        else None
+    )
+
     candidates: list[CandidateResult] = []
 
     if effective_workers <= 1:
@@ -427,6 +455,8 @@ def run_criticality_optimization(  # noqa: C901
                 objective_config=objective_config,
                 output_dir=output_dir,
                 scenario_path=scenario_path,
+                resolved_algo=_resolved_algo,
+                resolved_algo_config_path=_resolved_algo_config_path,
             )
             candidates.append(result)
     else:
@@ -442,6 +472,8 @@ def run_criticality_optimization(  # noqa: C901
                     objective_config=objective_config,
                     output_dir=output_dir,
                     scenario_path=scenario_path,
+                    resolved_algo=_resolved_algo,
+                    resolved_algo_config_path=_resolved_algo_config_path,
                 ): cand_id
                 for cand_id, params in candidate_params
             }
@@ -472,6 +504,9 @@ def run_criticality_optimization(  # noqa: C901
         "optimizer_seed": config.optimizer_seed,
         "sample_budget": config.sample_budget,
         "seeds_per_candidate": config.seeds,
+        "planner_name": config.planner_name,
+        "planner_algo": _resolved_algo,
+        "planner_algo_config_path": _resolved_algo_config_path,
         "parameter_space": {
             name: {
                 "type": p.param_type,

--- a/tests/benchmark/test_scenario_criticality_optimization.py
+++ b/tests/benchmark/test_scenario_criticality_optimization.py
@@ -27,6 +27,7 @@ ParameterDefinition = _MODULE.ParameterDefinition
 _build_baseline_parameters = _MODULE._build_baseline_parameters
 _parse_parameter_space = _MODULE._parse_parameter_space
 _sample_parameters = _MODULE._sample_parameters
+resolve_planner_run_spec = _MODULE.resolve_planner_run_spec
 run_criticality_optimization = _MODULE.run_criticality_optimization
 write_optimization_report = _MODULE.write_optimization_report
 
@@ -120,6 +121,9 @@ def test_manifest_contains_required_fields() -> None:
     assert "not_evaluable_count" in manifest
     assert "baseline_score" in manifest
     assert "generated_at" in manifest
+    assert "planner_name" in manifest
+    assert "planner_algo" in manifest
+    assert "planner_algo_config_path" in manifest
 
 
 def test_write_optimization_report(tmp_path: Path) -> None:
@@ -282,3 +286,38 @@ def test_effective_workers_capped_at_candidate_count() -> None:
     config.max_workers = 0
     _, manifest = run_criticality_optimization(config)
     assert manifest["max_workers"] <= manifest["total_candidates"]
+
+
+def test_manifest_includes_shared_planner_resolution() -> None:
+    """Manifest records the pre-resolved planner algo and config path."""
+    config = _make_test_config()
+    _, manifest = run_criticality_optimization(config)
+    assert "planner_algo" in manifest
+    assert manifest["planner_algo"] is not None
+    assert "planner_algo_config_path" in manifest
+    assert manifest["planner_name"] == config.planner_name
+
+
+def test_shared_planner_resolution_is_called_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-resolve planner spec once in the main process, not per worker.
+
+    Monkeypatch ``resolve_planner_run_spec`` to count calls.  Since
+    ProcessPoolExecutor forks the child, the patch does NOT propagate into
+    workers, so the main-process count must be exactly 1 regardless of
+    ``max_workers``.
+    """
+    call_count = {"n": 0}
+    original = _MODULE.resolve_planner_run_spec
+
+    def _counting_resolver(*args, **kwargs):  # type: ignore[no-untyped-def]
+        call_count["n"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(_MODULE, "resolve_planner_run_spec", _counting_resolver)
+
+    config = _make_test_config()
+    config.max_workers = 2
+    run_criticality_optimization(config)
+    assert call_count["n"] == 1


### PR DESCRIPTION
## What / Why

Implements the shared planner resolution optimization for the parallel sweep.

**Problem:** Each parallel worker independently resolved the planner spec by loading YAML registry and candidate-config files — redundant I/O that scales linearly with worker count.

**Solution:** Pre-resolve the planner spec once in the main process before dispatching to workers. The resolved `algo` and `algo_config_path` are passed to `_evaluate_candidate` via new keyword-only parameters.

### Changes

- Import `resolve_planner_run_spec` at module level for monkeypatchability
- Add `resolved_algo` / `resolved_algo_config_path` keyword params to `_evaluate_candidate`
- Record `planner_name`, `planner_algo`, `planner_algo_config_path` in manifest
- Add tests: `test_manifest_includes_shared_planner_resolution`, `test_shared_planner_resolution_is_called_once`

## Successor slice

This PR addresses the "parallel-sweep tuning (batching/shared planner resolution)" remaining item from PR #4812. Does not duplicate PR #4812.

## Validation

All tests pass:
```
uv run ruff check scripts/benchmark/run_scenario_criticality_optimization.py tests/benchmark/test_scenario_criticality_optimization.py
uv run pytest tests/benchmark/test_scenario_criticality_optimization.py -v -k "not cli_help"
```

18 tests passed (including 2 new tests).

## Remaining (issue stays open)

- Parallel sweep **batching** tuning once workload characteristics are profiled.
- Collision key schema finalization once the episode-metrics schema settles.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

Refs #4792