### PR TITLE
Issue #4792: add CMA-ES optimizer for criticality search (cheap-lane worker)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ socnav = [
     # SocNavBench planner prerequisites used by the vendored subset.
     "scikit-fmm>=2024.5",
 ]
+criticality = [
+    "cma>=3.3.0",
+]
 
 [build-system]
 requires = ["hatchling", "Cython>=3.0.0"]

--- a/scripts/benchmark/run_scenario_criticality_optimization.py
+++ b/scripts/benchmark/run_scenario_criticality_optimization.py
@@ -193,9 +193,7 @@ def _parse_optimization_config(payload: dict[str, Any]) -> OptimizationConfig:
         cma_es_maxiter=int(payload.get("cma_es_maxiter", 30)),
         cma_es_sigma0=float(payload.get("cma_es_sigma0", 0.5)),
         cma_es_seed=(
-            int(payload["cma_es_seed"])
-            if payload.get("cma_es_seed") is not None
-            else None
+            int(payload["cma_es_seed"]) if payload.get("cma_es_seed") is not None else None
         ),
     )
 
@@ -477,7 +475,6 @@ def _run_differential_evolution(
     return de_candidates
 
 
-
 def _run_cma_es(
     config: OptimizationConfig,
     scenario: dict[str, Any],
@@ -507,7 +504,6 @@ def _run_cma_es(
     ]
     if not continuous_names:
         raise ValueError("cma_es requires at least one continuous parameter")
-
 
     # Compute the search range midpoint and initial sigma
     midpoints = [
@@ -588,7 +584,6 @@ def _run_cma_es(
     cma_candidates.append(cma_best)
 
     return cma_candidates
-
 
 
 def run_criticality_optimization(  # noqa: C901, PLR0912, PLR0915

--- a/scripts/benchmark/run_scenario_criticality_optimization.py
+++ b/scripts/benchmark/run_scenario_criticality_optimization.py
@@ -63,7 +63,7 @@ class OptimizationConfig:
 
     Attributes:
         parameter_space: Dict of parameter name to ParameterDefinition
-        optimizer_type: "random_search" or "differential_evolution"
+        optimizer_type: "random_search", "differential_evolution", or "cma_es"
         sample_budget: Number of candidates to evaluate
         optimizer_seed: Random seed for reproducibility
         scenario_family: Path to scenario YAML or list of scenario dicts
@@ -94,6 +94,10 @@ class OptimizationConfig:
     de_maxiter: int = 50
     de_popsize: int = 15
     de_seed: int | None = None
+    # CMA-ES-specific settings (ignored for other optimizer types)
+    cma_es_maxiter: int = 30
+    cma_es_sigma0: float = 0.5
+    cma_es_seed: int | None = None
 
 
 @dataclass
@@ -186,6 +190,13 @@ def _parse_optimization_config(payload: dict[str, Any]) -> OptimizationConfig:
         de_maxiter=int(payload.get("de_maxiter", 50)),
         de_popsize=int(payload.get("de_popsize", 15)),
         de_seed=(int(payload["de_seed"]) if payload.get("de_seed") is not None else None),
+        cma_es_maxiter=int(payload.get("cma_es_maxiter", 30)),
+        cma_es_sigma0=float(payload.get("cma_es_sigma0", 0.5)),
+        cma_es_seed=(
+            int(payload["cma_es_seed"])
+            if payload.get("cma_es_seed") is not None
+            else None
+        ),
     )
 
 
@@ -466,6 +477,120 @@ def _run_differential_evolution(
     return de_candidates
 
 
+
+def _run_cma_es(
+    config: OptimizationConfig,
+    scenario: dict[str, Any],
+    scenario_path: Path,
+    objective_config: CriticalityObjectiveConfig,
+    output_dir: Path,
+    resolved_algo: str,
+    resolved_algo_config_path: str | None,
+) -> list[CandidateResult]:
+    """Run CMA-ES optimization.
+
+    CMA-ES minimizes, so we negate the criticality score (which should be maximized).
+    Only continuous parameters are supported; discrete params default to baseline.
+    Requires the ``cma`` package (install via ``uv pip install -e ".[criticality]"``).
+    """
+    try:
+        import cma
+    except ImportError as exc:
+        raise ImportError(
+            "cma_es optimizer requires the 'cma' package. "
+            'Install with: uv pip install -e ".[criticality]"'
+        ) from exc
+
+    # CMA-ES requires all-continuous params; extract bounds and dimensionality
+    continuous_names = [
+        name for name, p in config.parameter_space.items() if p.param_type == "continuous"
+    ]
+    if not continuous_names:
+        raise ValueError("cma_es requires at least one continuous parameter")
+
+
+    # Compute the search range midpoint and initial sigma
+    midpoints = [
+        (config.parameter_space[name].min + config.parameter_space[name].max) / 2.0
+        for name in continuous_names
+    ]
+    half_ranges = [
+        (config.parameter_space[name].max - config.parameter_space[name].min) / 2.0
+        for name in continuous_names
+    ]
+    sigma0 = config.cma_es_sigma0 * max(half_ranges)
+
+    # Container for evaluated candidates
+    cma_candidates: list[CandidateResult] = []
+    trial_counter: int = 0
+
+    def _cma_objective(x: list[float]) -> float:
+        """CMA-ES minimizes; return negative criticality score."""
+        nonlocal trial_counter
+        params = dict(zip(continuous_names, x, strict=True))
+        # Fill discrete params with baseline (first value)
+        for name, pdef in config.parameter_space.items():
+            if pdef.param_type == "discrete" and name not in params:
+                params[name] = pdef.values[0] if pdef.values else 0.0
+
+        trial_counter += 1
+        result = _evaluate_candidate(
+            candidate_id=f"cma_trial_{trial_counter:04d}",
+            parameters=params,
+            scenario=scenario,
+            config=config,
+            objective_config=objective_config,
+            output_dir=output_dir,
+            scenario_path=scenario_path,
+            resolved_algo=resolved_algo,
+            resolved_algo_config_path=resolved_algo_config_path,
+        )
+        cma_candidates.append(result)
+        if result.status == "evaluated":
+            return -result.criticality_score
+        return 1e12
+
+    seed = config.cma_es_seed if config.cma_es_seed is not None else config.optimizer_seed
+
+    lower_bounds = [config.parameter_space[name].min for name in continuous_names]
+    upper_bounds = [config.parameter_space[name].max for name in continuous_names]
+
+    options = {
+        "maxiter": config.cma_es_maxiter,
+        "seed": seed,
+        "bounds": [lower_bounds, upper_bounds],
+        "verbose": -9,
+    }
+
+    result = cma.fmin2(
+        _cma_objective,
+        x0=midpoints,
+        sigma0=sigma0,
+        options=options,
+    )
+
+    optimum_params = dict(zip(continuous_names, result[0], strict=True))
+    for name, pdef in config.parameter_space.items():
+        if pdef.param_type == "discrete" and name not in optimum_params:
+            optimum_params[name] = pdef.values[0] if pdef.values else 0.0
+
+    cma_best = _evaluate_candidate(
+        candidate_id="cma_optimum",
+        parameters=optimum_params,
+        scenario=scenario,
+        config=config,
+        objective_config=objective_config,
+        output_dir=output_dir,
+        scenario_path=scenario_path,
+        resolved_algo=resolved_algo,
+        resolved_algo_config_path=resolved_algo_config_path,
+    )
+    cma_candidates.append(cma_best)
+
+    return cma_candidates
+
+
+
 def run_criticality_optimization(  # noqa: C901, PLR0912, PLR0915
     config: OptimizationConfig,
     output_dir: Path | None = None,
@@ -613,10 +738,34 @@ def run_criticality_optimization(  # noqa: C901, PLR0912, PLR0915
             resolved_algo_config_path=_resolved_algo_config_path,
         )
         candidates = [baseline_result] + de_results
+    elif config.optimizer_type == "cma_es":
+        cma_results = _run_cma_es(
+            config=config,
+            scenario=scenario,
+            scenario_path=scenario_path,
+            objective_config=objective_config,
+            output_dir=output_dir,
+            resolved_algo=_resolved_algo,
+            resolved_algo_config_path=_resolved_algo_config_path,
+        )
+        # CMA-ES results include the optimum; prepend baseline
+        baseline_params = _build_baseline_parameters(config.parameter_space)
+        baseline_result = _evaluate_candidate(
+            candidate_id="baseline_unperturbed",
+            parameters=baseline_params,
+            scenario=scenario,
+            config=config,
+            objective_config=objective_config,
+            output_dir=output_dir,
+            scenario_path=scenario_path,
+            resolved_algo=_resolved_algo,
+            resolved_algo_config_path=_resolved_algo_config_path,
+        )
+        candidates = [baseline_result] + cma_results
     else:
         raise ValueError(
             f"unsupported optimizer_type {config.optimizer_type!r}; "
-            "supported: random_search, differential_evolution"
+            "supported: random_search, differential_evolution, cma_es"
         )
 
     evaluated = [c for c in candidates if c.status == "evaluated"]
@@ -641,7 +790,16 @@ def run_criticality_optimization(  # noqa: C901, PLR0912, PLR0915
             # reflects a reproducible seed instead of null.
             "de_seed": config.de_seed if config.de_seed is not None else config.optimizer_seed,
         }
-
+    # CMA-ES-specific manifest fields
+    cma_manifest = {}
+    if config.optimizer_type == "cma_es":
+        cma_manifest = {
+            "cma_es_maxiter": config.cma_es_maxiter,
+            "cma_es_sigma0": config.cma_es_sigma0,
+            "cma_es_seed": config.cma_es_seed
+            if config.cma_es_seed is not None
+            else config.optimizer_seed,
+        }
     manifest = {
         "issue": 4362,
         "claim_boundary": "exploratory/diagnostic-only; not a validated benchmark method",
@@ -675,6 +833,7 @@ def run_criticality_optimization(  # noqa: C901, PLR0912, PLR0915
         "generated_at": datetime.now(UTC).isoformat(),
     }
     manifest.update(de_manifest)
+    manifest.update(cma_manifest)
 
     return candidates, manifest
 

--- a/tests/benchmark/test_scenario_criticality_optimization.py
+++ b/tests/benchmark/test_scenario_criticality_optimization.py
@@ -623,3 +623,179 @@ def test_de_optimum_score_comparable_to_baseline() -> None:
     assert optimum.status == "evaluated"
     assert math.isfinite(baseline.criticality_score)
     assert math.isfinite(optimum.criticality_score)
+
+
+# ── CMA-ES optimizer tests ──────────────────────────────────────────────
+
+_CMA_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "benchmark"
+    / "run_scenario_criticality_optimization.py"
+)
+
+
+def _load_cma_opt_module(mod_name: str):
+    """Load the optimization script as a fresh module for CMA-ES tests."""
+    import importlib.util as _u
+
+    spec = _u.spec_from_file_location(mod_name, _CMA_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = _u.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_cma_es_optimizer_accepted() -> None:
+    """CMA-ES optimizer_type is accepted by the runner."""
+    mod = _load_cma_opt_module("_cma_test_opt")
+
+    config = mod.OptimizationConfig(
+        parameter_space={
+            "pedestrian_speed_scale": mod.ParameterDefinition(
+                param_type="continuous", min=0.7, max=1.4
+            ),
+            "pedestrian_start_delay_s": mod.ParameterDefinition(
+                param_type="continuous", min=0.0, max=2.0
+            ),
+        },
+        optimizer_type="cma_es",
+        sample_budget=5,
+        optimizer_seed=42,
+        seeds=[0],
+        cma_es_maxiter=5,
+        cma_es_sigma0=0.5,
+    )
+    candidates, manifest = mod.run_criticality_optimization(config)
+    assert manifest["optimizer_type"] == "cma_es"
+    assert len(candidates) >= 2  # baseline + at least cma_optimum
+
+
+def test_cma_es_requires_continuous_params() -> None:
+    """CMA-ES rejects all-discrete parameter spaces."""
+    mod = _load_cma_opt_module("_cma_test_opt2")
+
+    config = mod.OptimizationConfig(
+        parameter_space={
+            "mode": mod.ParameterDefinition(
+                param_type="discrete", values=[1.0, 2.0]
+            ),
+        },
+        optimizer_type="cma_es",
+        cma_es_maxiter=2,
+    )
+    with pytest.raises(ValueError, match="cma_es requires at least one continuous"):
+        mod.run_criticality_optimization(config)
+
+
+def test_cma_es_manifest_fields() -> None:
+    """CMA-ES run records optimizer-specific manifest fields."""
+    mod = _load_cma_opt_module("_cma_test_opt3")
+
+    config = mod.OptimizationConfig(
+        parameter_space={
+            "pedestrian_speed_scale": mod.ParameterDefinition(
+                param_type="continuous", min=0.7, max=1.4
+            ),
+        },
+        optimizer_type="cma_es",
+        sample_budget=2,
+        optimizer_seed=77,
+        seeds=[0],
+        cma_es_maxiter=3,
+        cma_es_sigma0=0.3,
+        cma_es_seed=99,
+    )
+    _, manifest = mod.run_criticality_optimization(config)
+    assert manifest["cma_es_maxiter"] == 3
+    assert manifest["cma_es_sigma0"] == 0.3
+    assert manifest["cma_es_seed"] == 99
+
+
+def test_cma_es_seed_fallback() -> None:
+    """CMA-ES falls back to optimizer_seed when cma_es_seed is None."""
+    mod = _load_cma_opt_module("_cma_test_opt4")
+
+    config = mod.OptimizationConfig(
+        parameter_space={
+            "pedestrian_speed_scale": mod.ParameterDefinition(
+                param_type="continuous", min=0.7, max=1.4
+            ),
+        },
+        optimizer_type="cma_es",
+        sample_budget=2,
+        optimizer_seed=123,
+        seeds=[0],
+        cma_es_maxiter=2,
+        cma_es_seed=None,
+    )
+    _, manifest = mod.run_criticality_optimization(config)
+    assert manifest["cma_es_seed"] == 123
+
+
+def test_cma_es_optimum_score_finite() -> None:
+    """CMA-ES optimum and baseline both produce finite scores."""
+    import math
+
+    mod = _load_cma_opt_module("_cma_test_opt5")
+
+    config = mod.OptimizationConfig(
+        parameter_space={
+            "pedestrian_speed_scale": mod.ParameterDefinition(
+                param_type="continuous", min=0.7, max=1.4
+            ),
+            "pedestrian_start_delay_s": mod.ParameterDefinition(
+                param_type="continuous", min=0.0, max=2.0
+            ),
+        },
+        optimizer_type="cma_es",
+        sample_budget=3,
+        optimizer_seed=42,
+        seeds=[0],
+        cma_es_maxiter=5,
+        cma_es_sigma0=0.5,
+    )
+    candidates, _ = mod.run_criticality_optimization(config)
+
+    baseline = next(c for c in candidates
+                    if c.candidate_id == "baseline_unperturbed")
+    optimum = next(
+        (c for c in candidates if c.candidate_id == "cma_optimum"),
+        None,
+    )
+
+    assert baseline.status == "evaluated"
+    assert math.isfinite(baseline.criticality_score)
+    assert optimum is not None, "cma_optimum candidate not found"
+    assert optimum.status == "evaluated"
+    assert math.isfinite(optimum.criticality_score)
+
+
+def test_cma_es_import_error_message() -> None:
+    """Missing cma package raises ImportError with install hint."""
+    from unittest import mock
+
+    mod = _load_cma_opt_module("_cma_test_opt6")
+
+    config = mod.OptimizationConfig(
+        parameter_space={
+            "x": mod.ParameterDefinition(
+                param_type="continuous", min=0.0, max=1.0
+            ),
+        },
+        optimizer_type="cma_es",
+        cma_es_maxiter=1,
+    )
+
+    # Patch _run_cma_es to simulate the import failure
+    with mock.patch.object(
+        mod,
+        "_run_cma_es",
+        side_effect=ImportError(
+            "cma_es optimizer requires the 'cma' package. "
+            'Install with: uv pip install -e ".[criticality]"'
+        ),
+    ):
+        with pytest.raises(ImportError, match="cma_es optimizer requires"):
+            mod.run_criticality_optimization(config)

--- a/tests/benchmark/test_scenario_criticality_optimization.py
+++ b/tests/benchmark/test_scenario_criticality_optimization.py
@@ -678,9 +678,7 @@ def test_cma_es_requires_continuous_params() -> None:
 
     config = mod.OptimizationConfig(
         parameter_space={
-            "mode": mod.ParameterDefinition(
-                param_type="discrete", values=[1.0, 2.0]
-            ),
+            "mode": mod.ParameterDefinition(param_type="discrete", values=[1.0, 2.0]),
         },
         optimizer_type="cma_es",
         cma_es_maxiter=2,
@@ -758,8 +756,7 @@ def test_cma_es_optimum_score_finite() -> None:
     )
     candidates, _ = mod.run_criticality_optimization(config)
 
-    baseline = next(c for c in candidates
-                    if c.candidate_id == "baseline_unperturbed")
+    baseline = next(c for c in candidates if c.candidate_id == "baseline_unperturbed")
     optimum = next(
         (c for c in candidates if c.candidate_id == "cma_optimum"),
         None,
@@ -780,9 +777,7 @@ def test_cma_es_import_error_message() -> None:
 
     config = mod.OptimizationConfig(
         parameter_space={
-            "x": mod.ParameterDefinition(
-                param_type="continuous", min=0.0, max=1.0
-            ),
+            "x": mod.ParameterDefinition(param_type="continuous", min=0.0, max=1.0),
         },
         optimizer_type="cma_es",
         cma_es_maxiter=1,

--- a/uv.lock
+++ b/uv.lock
@@ -558,6 +558,18 @@ wheels = [
 ]
 
 [[package]]
+name = "cma"
+version = "4.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/ac/8c27720838e293898671f01b5c452236a0c74f4799a3f2d5fcccbbf50d71/cma-4.4.4.tar.gz", hash = "sha256:632bd654b5dce04c0eaa3166679d3e4773ce7a79eab7934e7f363c341b9a8170", size = 316645, upload-time = "2026-02-25T22:18:16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/d4/ec46cedab6a6145e21768baa8110db3e2e836a320d8499e4ef18bc894e61/cma-4.4.4-py3-none-any.whl", hash = "sha256:edb6d02eb2aac2d54650f16a8f0c70711ff17445957de7c9de92ff7fd4b7ef38", size = 328311, upload-time = "2026-02-25T22:18:09.602Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -4927,6 +4939,9 @@ analytics = [
 browser = [
     { name = "playwright" },
 ]
+criticality = [
+    { name = "cma" },
+]
 gpu = [
     { name = "torch" },
 ]
@@ -4991,6 +5006,7 @@ imitation = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cma", marker = "extra == 'criticality'", specifier = ">=3.3.0" },
     { name = "duckdb", marker = "extra == 'analytics'", specifier = ">=1.4.0" },
     { name = "geopandas", specifier = ">=1.1.4" },
     { name = "gymnasium", specifier = ">=0.29,<1.2" },
@@ -5039,7 +5055,7 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'progress'", specifier = ">=4.68.3" },
     { name = "wandb", marker = "extra == 'training'", specifier = ">=0.28.0" },
 ]
-provides-extras = ["gpu", "training", "recurrent", "rllib", "progress", "analysis", "analytics", "viz", "browser", "sacadrl", "orca", "socnav"]
+provides-extras = ["gpu", "training", "recurrent", "rllib", "progress", "analysis", "analytics", "viz", "browser", "sacadrl", "orca", "socnav", "criticality"]
 
 [package.metadata.requires-dev]
 carla = [{ name = "carla", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==0.9.16" }]


### PR DESCRIPTION
## What and why

Adds CMA-ES (Covariance Matrix Adaptation Evolution Strategy) as a third optimizer type (`cma_es`) for the scenario criticality search, alongside the existing `random_search` and `differential_evolution` options.

This addresses the "(Stretch) Add a second optimizer (CMA-ES / Bayesian) behind the same interface" remaining item from issue #4792.

**Successor slice:** This is the CMA-ES optimizer addition. Prior slices landed in PRs #4804, #4812, #4819, #4821, and #4822 (real runner, collision key, parallel sweep, DE optimizer, and CPU validation).

## Changes

- **`scripts/benchmark/run_scenario_criticality_optimization.py`**:
  - `_run_cma_es()`: CMA-ES optimizer using the `cma` package (lazy import, bounds-aware via `cma.fmin2`)
  - Wired into `run_criticality_optimization()` dispatcher
  - Config: `cma_es_maxiter` (default 30), `cma_es_sigma0` (default 0.5), `cma_es_seed`
  - CMA-ES-specific manifest fields recorded
  - ImportError with install hint when `cma` package missing

- **`pyproject.toml`**: Added `criticality` optional extra with `cma>=3.3.0`

- **`tests/benchmark/test_scenario_criticality_optimization.py`**: 6 new tests:
  - `test_cma_es_optimizer_accepted`: CMA-ES runs end-to-end
  - `test_cma_es_requires_continuous_params`: Rejects all-discrete parameter spaces
  - `test_cma_es_manifest_fields`: Manifest records CMA-ES-specific config
  - `test_cma_es_seed_fallback`: Falls back to `optimizer_seed` when `cma_es_seed` is None
  - `test_cma_es_optimum_score_finite`: Optimum and baseline produce finite scores
  - `test_cma_es_import_error_message`: Clear error when `cma` package missing

## Validation

```
pytest tests/benchmark/test_scenario_criticality_optimization.py -v -k "cma"
# 6 passed in ~50s (all CMA-ES integration tests run full simulator)

pytest tests/benchmark/test_scenario_criticality_optimization.py -v -k "not cma"
# 32 passed — no regression in existing DE/random_search/objective tests
```

## Remaining for issue #4792

- Parallel-batch tuning (batching/shared planner resolution optimization once profiled)
- Collision-key schema finalization (depends on episode-metrics schema settling)
- Bayesian optimizer option (not implemented in this slice)

This PR was produced by the codex-harness/SAIA-Qwen3.6-27B cheap implementation
lane; the review gate hardens and merges.

Refs #4792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `criticality` optional install extra for users who want the criticality optimization tools.
  * Added support for an additional optimization method, with configurable iteration count, initial spread, and seed options.

* **Bug Fixes**
  * Improved handling of mixed parameter spaces by requiring a continuous parameter for the new optimizer.
  * Ensured optimization results and manifests include the new optimizer’s settings and evaluated candidates consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->