### PR TITLE
Issue #4794: fix exemplar median selection direction-invariance (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/exemplar_selection.py
+++ b/robot_sf/benchmark/exemplar_selection.py
@@ -106,12 +106,18 @@ def _git_sha_short(length: int = 7) -> str:
             subprocess.check_output(
                 ["git", "rev-parse", f"--short={length}", "HEAD"],
                 stderr=subprocess.DEVNULL,
+                timeout=5,
             )
             .decode("utf-8")
             .strip()
         )
         return sha or "unknown"
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        OSError,
+    ):
         return "unknown"
 
 
@@ -273,18 +279,18 @@ def _select_in_cell(
             reason=f"metric '{metric}' missing or non-finite for all {len(cell_episodes)} episodes",
         )
 
-    # Sort: lower is better or higher is better
-    reverse = metric_direction == "higher"
-    scored.sort(key=lambda x: x[0], reverse=reverse)
+    # Canonical ascending sort by metric value so median index is
+    # invariant to metric_direction.  Direction only affects best/worst.
+    scored.sort(key=lambda x: x[0])
 
     planner_key = group_values.get("planner_key", "unknown_planner")
     results: list[SelectedEpisode] = []
 
     for mode in modes:
         if mode == "best":
-            idx = 0
+            idx = len(scored) - 1 if metric_direction == "higher" else 0
         elif mode == "worst":
-            idx = len(scored) - 1
+            idx = 0 if metric_direction == "higher" else len(scored) - 1
         else:  # median
             idx = len(scored) // 2
 
@@ -384,7 +390,7 @@ def build_manifest(
         Populated ``SelectionManifest``.
     """
     source_path = Path(source_episodes_path)
-    source_sha256 = _compute_file_sha256(source_path) if source_path.exists() else "unknown"
+    source_sha256 = _compute_file_sha256(source_path) if source_path.is_file() else "unknown"
 
     if metric_direction is None:
         metric_direction = METRIC_DIRECTIONS.get(metric, "lower")

--- a/tests/benchmark/test_exemplar_selection.py
+++ b/tests/benchmark/test_exemplar_selection.py
@@ -82,7 +82,7 @@ class TestMedianSelection:
         assert selected[0].metric_value == 0.5
 
     def test_even_cell_size(self) -> None:
-        """Median of 4 episodes selects index 2 (floor(n/2))."""
+        """Median of 4 episodes selects index 2 (floor(n/2)) in canonical ascending order."""
         episodes = [
             _make_episode("ep1", "orca", "s1", 1, 0.1),
             _make_episode("ep2", "orca", "s1", 2, 0.5),
@@ -97,9 +97,9 @@ class TestMedianSelection:
             modes=["median"],
         )
         assert len(selected) == 1
-        # Sorted descending: [0.9, 0.8, 0.5, 0.1], median index=2 -> 0.5
-        assert selected[0].episode_id == "ep2"
-        assert selected[0].metric_value == 0.5
+        # Canonical ascending sort: [0.1, 0.5, 0.8, 0.9], median index=2 -> 0.8
+        assert selected[0].episode_id == "ep3"
+        assert selected[0].metric_value == 0.8
 
 
 class TestBestWorstDirection:
@@ -182,8 +182,8 @@ class TestMissingMetric:
             modes=["median"],
         )
         assert len(selected) == 1
-        # Only 2 valid episodes, median index=1 -> 0.7
-        assert selected[0].metric_value == 0.7
+        # Only 2 valid episodes, canonical ascending: [0.7, 0.9], median index=1 -> 0.9
+        assert selected[0].metric_value == 0.9
 
 
 class TestTieBreaking:
@@ -203,11 +203,12 @@ class TestTieBreaking:
             metric_direction="higher",
             modes=["best", "median", "worst"],
         )
-        # All have same value; best=first in sorted order, worst=last
+        # All have same value; with canonical ascending sort and higher direction,
+        # best = last (ep_c), worst = first (ep_a).
         best = next(s for s in selected if s.selection_mode == "best")
         worst = next(s for s in selected if s.selection_mode == "worst")
-        assert best.episode_id == "ep_a"
-        assert worst.episode_id == "ep_c"
+        assert best.episode_id == "ep_c"
+        assert worst.episode_id == "ep_a"
 
 
 class TestGrouping:
@@ -340,3 +341,59 @@ class TestMetricDirectionAutoDetection:
             modes=["best"],
         )
         assert selected[0].episode_id == "ep2"
+
+
+class TestDirectionInvariantMedian:
+    """Regression test for issue #4794: median selection must be invariant to metric_direction."""
+
+    def test_same_median_under_both_directions(self) -> None:
+        """Median episode is the same regardless of metric_direction flip."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, 0.1),
+            _make_episode("ep2", "orca", "s1", 2, 0.5),
+            _make_episode("ep3", "orca", "s1", 3, 0.8),
+            _make_episode("ep4", "orca", "s1", 4, 0.9),
+        ]
+        selected_higher, _ = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            metric_direction="higher",
+            modes=["median"],
+        )
+        selected_lower, _ = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            metric_direction="lower",
+            modes=["median"],
+        )
+        assert len(selected_higher) == 1
+        assert len(selected_lower) == 1
+        assert selected_higher[0].episode_id == selected_lower[0].episode_id
+        assert selected_higher[0].metric_value == selected_lower[0].metric_value
+
+    def test_odd_size_same_median_both_directions(self) -> None:
+        """Median of odd-sized group is also direction-invariant."""
+        episodes = [
+            _make_episode("ep1", "orca", "s1", 1, 0.2),
+            _make_episode("ep2", "orca", "s1", 2, 0.6),
+            _make_episode("ep3", "orca", "s1", 3, 0.8),
+            _make_episode("ep4", "orca", "s1", 4, 0.9),
+            _make_episode("ep5", "orca", "s1", 5, 1.0),
+        ]
+        selected_higher, _ = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            metric_direction="higher",
+            modes=["median"],
+        )
+        selected_lower, _ = select_exemplars(
+            episodes,
+            group_by=["planner_key"],
+            metric="path_efficiency",
+            metric_direction="lower",
+            modes=["median"],
+        )
+        assert selected_higher[0].episode_id == selected_lower[0].episode_id


### PR DESCRIPTION
## What/Why

Fixes non-deterministic median episode selection in .

**Defect**: For even-sized groups, flipping  (higher vs lower) selected a DIFFERENT episode as median because the sort order varied with direction. This broke reproducibility of figure selection for the dissertation pipeline (#4778 chain).

## Changes

### 
- **Median invariance**:  now always sorts by canonical ascending metric value. Median index is direction-invariant. Direction only affects best/worst selection.
- ** guard**:  uses  instead of  for source SHA computation (avoids hashing directories).
- **Git SHA timeout**:  adds a 5-second timeout to the subprocess call, and catches .

### 
- Updated  and  for new canonical ascending sort behavior.
- Updated  tie-breaking expectations.
- Added  regression class:
  -  (even cell, 4 episodes)
  -  (odd cell, 5 episodes)

## Validation



Closes #4794

---

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.