### PR TITLE
Issue #4817: MAPF oracle CBS propagate time_edges_blocked + fix annotation + validate unique agent IDs (cheap-lane worker)

### DIFF
--- a/scripts/tools/mapf_oracle_diagnostic.py
+++ b/scripts/tools/mapf_oracle_diagnostic.py
@@ -404,9 +404,14 @@ def _load_agents(
     agents = data["agents"]
     if not isinstance(agents, list) or len(agents) == 0:
         raise ValueError("'agents' must be a non-empty list")
+    seen_ids: set[int] = set()
     for entry in agents:
         if "id" not in entry or "start" not in entry or "goal" not in entry:
             raise ValueError("Each agent needs 'id', 'start', and 'goal'")
+        agent_id = int(entry["id"])
+        if agent_id in seen_ids:
+            raise ValueError(f"Duplicate agent id: {agent_id}")
+        seen_ids.add(agent_id)
         for key in ("start", "goal"):
             pos = entry[key]
             if not isinstance(pos, list) or len(pos) != 2:
@@ -558,6 +563,7 @@ def cbs_search(  # noqa: C901
     time_blocked: dict[int, set[tuple[int, int]]] | None = None,
     max_time: int = 200,
     max_nodes: int = 500,
+    time_edges_blocked: dict[int, set[tuple[tuple[int, int], tuple[int, int]]]] | None = None,
 ) -> dict[str, Any] | None:
     """CBS (Conflict-Based Search) for multi-agent path finding.
 
@@ -579,7 +585,14 @@ def cbs_search(  # noqa: C901
         a = agent_map[aid]
         start = (int(a["start"][0]), int(a["start"][1]))
         goal = (int(a["goal"][0]), int(a["goal"][1]))
-        path = sipp_search(grid, start, goal, time_blocked, max_time)
+        path = sipp_search(
+            grid,
+            start,
+            goal,
+            time_blocked,
+            max_time,
+            time_edges_blocked=time_edges_blocked,
+        )
         if path is None:
             return None
         solution[aid] = path
@@ -648,6 +661,7 @@ def cbs_search(  # noqa: C901
                 goal,
                 time_blocked,
                 max_time,
+                time_edges_blocked=time_edges_blocked,
                 constraints=agent_constraints,
                 edge_constraints=agent_edge_constraints,
             )
@@ -678,9 +692,18 @@ def _run_cbs_search(
     time_blocked: dict[int, set[tuple[int, int]]],
     max_time: int,
     max_nodes: int,
+    dyn_obstacles: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Run CBS multi-agent search and fill diagnostic fields."""
-    result = cbs_search(grid, agents, time_blocked, max_time, max_nodes)
+    time_edges_blocked = _build_time_edges_blocked(dyn_obstacles) if dyn_obstacles else None
+    result = cbs_search(
+        grid,
+        agents,
+        time_blocked,
+        max_time,
+        max_nodes,
+        time_edges_blocked=time_edges_blocked,
+    )
 
     diagnostic["search_method"] = "cbs"
     diagnostic["agent_count"] = len(agents)
@@ -889,9 +912,18 @@ def _run_cbs_search(
     time_blocked: dict[int, set[tuple[int, int]]],
     max_time: int,
     max_nodes: int,
+    dyn_obstacles: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Run CBS multi-agent search and fill diagnostic fields."""
-    result = cbs_search(grid, agents, time_blocked, max_time, max_nodes)
+    time_edges_blocked = _build_time_edges_blocked(dyn_obstacles) if dyn_obstacles else None
+    result = cbs_search(
+        grid,
+        agents,
+        time_blocked,
+        max_time,
+        max_nodes,
+        time_edges_blocked=time_edges_blocked,
+    )
 
     diagnostic["search_method"] = "cbs"
     diagnostic["agent_count"] = len(agents)
@@ -1103,9 +1135,8 @@ def _load_inputs(
     list[dict[str, Any]] | None,
     list[dict[str, Any]] | None,
     dict[int, set[tuple[int, int]]],
-    int,
 ]:
-    """Load dynamic obstacles and agents from CLI args. Return (dyn_obstacles, agents, time_blocked, rc) or raise SystemExit."""
+    """Load dynamic obstacles and agents from CLI args. Return (dyn_obstacles, agents, time_blocked) or raise SystemExit."""
     dyn_obstacles: list[dict[str, Any]] | None = None
     time_blocked: dict[int, set[tuple[int, int]]] = {}
     if args.dynamic_obstacles is not None:
@@ -1196,6 +1227,7 @@ def main(argv: list[str] | None = None) -> int:
             time_blocked,
             args.max_time,
             args.cbs_max_nodes,
+            dyn_obstacles=dyn_obstacles,
         )
         if args.tpg and diagnostic.get("multi_agent_feasible") and diagnostic.get("agent_paths"):
             # Build solution from diagnostic output for TPG post-processing

--- a/tests/scripts/tools/test_mapf_oracle_diagnostic.py
+++ b/tests/scripts/tools/test_mapf_oracle_diagnostic.py
@@ -1525,3 +1525,172 @@ class TestTpgCli:
         finally:
             svg_path.unlink()
             agents_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# CBS dynamic-obstacle edge (swap) collision propagation
+# ---------------------------------------------------------------------------
+
+
+class TestCbsDynamicObstacleSwap:
+    """Regression tests for CBS propagating time_edges_blocked to SIPP.
+
+    Issue #4817: CBS ignored dynamic-obstacle edge (swap) collisions because
+    it never passed time_edges_blocked to its internal sipp_search calls.
+    """
+
+    def test_cbs_avoids_dynamic_obstacle_swap(self) -> None:
+        """CBS must avoid a swap collision with a single moving obstacle.
+
+        Agent 0 wants to move (0,0)->(1,0).  A dynamic obstacle moves
+        (1,0)->(0,0) at the same time step, forming a genuine swap.
+        Without time_edges_blocked propagation CBS would allow the swap;
+        with the fix the agent must detour or wait.
+        """
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        agents = [{"id": 0, "start": [0, 0], "goal": [1, 0]}]
+        dyn_obstacles = [{"id": 0, "trajectory": [[1, 0], [0, 0]]}]
+        time_blocked = _build_time_blocked(dyn_obstacles)
+        time_edges = _build_time_edges_blocked(dyn_obstacles)
+
+        result = cbs_search(
+            grid,
+            agents,
+            time_blocked,
+            max_time=50,
+            time_edges_blocked=time_edges,
+        )
+        assert result is not None
+        path = result["solution"][0]
+        # The direct swap move (0,0)@t0 -> (1,0)@t1 must be avoided.
+        if len(path) >= 2 and path[0] == (0, 0, 0) and path[1] == (1, 0, 1):
+            pytest.fail("CBS allowed a swap collision with a dynamic obstacle")
+
+    def test_cbs_multi_agent_with_dynamic_obstacle_swap(self) -> None:
+        """CBS with two agents avoids a dynamic-obstacle swap collision.
+
+        Agent 0 wants (0,0)->(2,0), agent 1 wants (2,0)->(0,0).
+        A dynamic obstacle moves (1,0)->(1,1) at t=0->t=1 (not a swap for
+        either agent, just a vertex block).  CBS must still produce valid
+        paths that avoid both agent-agent and agent-obstacle collisions.
+        """
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        agents = [
+            {"id": 0, "start": [0, 0], "goal": [2, 0]},
+            {"id": 1, "start": [2, 0], "goal": [0, 0]},
+        ]
+        dyn_obstacles = [{"id": 0, "trajectory": [[1, 0], [1, 1]]}]
+        time_blocked = _build_time_blocked(dyn_obstacles)
+        time_edges = _build_time_edges_blocked(dyn_obstacles)
+
+        result = cbs_search(
+            grid,
+            agents,
+            time_blocked,
+            max_time=50,
+            time_edges_blocked=time_edges,
+        )
+        assert result is not None
+        # Both agents reach their goals
+        assert result["solution"][0][-1][:2] == (2, 0)
+        assert result["solution"][1][-1][:2] == (0, 0)
+
+    def test_cbs_two_independent_obstacles_no_false_swap(self) -> None:
+        """Two independent obstacles must not cause a false swap block.
+
+        Obstacle A at (0,1)@t0 moving to (1,1)@t1, obstacle B at (1,0)@t0
+        moving to (0,0)@t1.  Agent 0 moves (0,0)->(0,1) at t0->t1.
+        Neither obstacle traverses the reverse edge (0,1)->(0,0), so the
+        move must be allowed (no over-blocking).
+        """
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        agents = [{"id": 0, "start": [0, 0], "goal": [0, 2]}]
+        dyn_obstacles = [
+            {"id": 0, "trajectory": [[0, 1], [1, 1]]},
+            {"id": 1, "trajectory": [[1, 0], [0, 0]]},
+        ]
+        time_blocked = _build_time_blocked(dyn_obstacles)
+        time_edges = _build_time_edges_blocked(dyn_obstacles)
+
+        result = cbs_search(
+            grid,
+            agents,
+            time_blocked,
+            max_time=50,
+            time_edges_blocked=time_edges,
+        )
+        assert result is not None
+        path = result["solution"][0]
+        # Optimal direct path should be allowed: (0,0)@0 -> (0,1)@1 -> (0,2)@2
+        assert path == [(0, 0, 0), (0, 1, 1), (0, 2, 2)]
+
+
+# ---------------------------------------------------------------------------
+# _load_agents duplicate ID validation
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAgentsDuplicateId:
+    """Tests for _load_agents rejecting duplicate agent IDs (issue #4817)."""
+
+    def test_duplicate_agent_id_rejected(self) -> None:
+        path = _make_agents_json(
+            [
+                {"id": 0, "start": [0, 0], "goal": [5, 5]},
+                {"id": 0, "start": [5, 0], "goal": [0, 5]},
+            ]
+        )
+        try:
+            with pytest.raises(ValueError, match="Duplicate agent id"):
+                _load_agents(path)
+        finally:
+            path.unlink()
+
+    def test_unique_agent_ids_accepted(self) -> None:
+        path = _make_agents_json(
+            [
+                {"id": 0, "start": [0, 0], "goal": [5, 5]},
+                {"id": 1, "start": [5, 0], "goal": [0, 5]},
+            ]
+        )
+        try:
+            result = _load_agents(path)
+            assert len(result) == 2
+        finally:
+            path.unlink()
+
+    def test_duplicate_non_zero_id(self) -> None:
+        path = _make_agents_json(
+            [
+                {"id": 3, "start": [0, 0], "goal": [5, 5]},
+                {"id": 3, "start": [5, 0], "goal": [0, 5]},
+            ]
+        )
+        try:
+            with pytest.raises(ValueError, match="Duplicate agent id: 3"):
+                _load_agents(path)
+        finally:
+            path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# _load_inputs return-type annotation
+# ---------------------------------------------------------------------------
+
+
+class TestLoadInputsAnnotation:
+    """Tests that _load_inputs returns a 3-tuple, not a 4-tuple (issue #4817)."""
+
+    def test_returns_three_tuple(self) -> None:
+        """_load_inputs must return (dyn_obstacles, agents, time_blocked)."""
+        import argparse
+
+        from scripts.tools.mapf_oracle_diagnostic import _load_inputs
+
+        args = argparse.Namespace(dynamic_obstacles=None, agents=None)
+        result = _load_inputs(args)
+        assert len(result) == 3
+        dyn_obstacles, agents, time_blocked = result
+        assert dyn_obstacles is None
+        assert agents is None
+        assert time_blocked == {}


### PR DESCRIPTION
## What

Fixes three pre-existing defects in the MAPF oracle diagnostic CBS code (`scripts/tools/mapf_oracle_diagnostic.py`), identified during PR #4816 gate review.

### 1. [HIGH] CBS ignores dynamic-obstacle edge (swap) collisions

`cbs_search()` did not accept or propagate `time_edges_blocked` to its internal `sipp_search()` calls (root solve + constraint-tree expansion). `sipp_search` supports `time_edges_blocked` (dynamic-obstacle swap avoidance, added for SIPP #4809), but CBS never passed it. Consequently, running CBS with dynamic obstacles could return paths that swap through a moving obstacle (fail-open feasibility).

**Fix**: Plumb `dyn_obstacles` → `_run_cbs_search` → build `time_edges_blocked` → `cbs_search` → both `sipp_search` calls. Added regression test: CBS with a dynamic obstacle whose swap would collide asserts the returned solution avoids the swap.

### 2. [HIGH] `_load_inputs` return-type annotation mismatch

The annotation declared a 4-tuple ending in `int` (leftover `rc` from an earlier design) but the function returns a 3-tuple `(dyn_obstacles, agents, time_blocked)` and raises `SystemExit` on error.

**Fix**: Annotation corrected to the actual 3-tuple.

### 3. [MEDIUM] `_load_agents` does not validate unique agent IDs

Duplicate IDs silently overwrite each other in `agent_map` but remain duplicated in `agent_ids`, giving incorrect search results.

**Fix**: Added a uniqueness check that raises `ValueError` with a clear error message.

## Why

These are diagnostic-only tooling defects in `scripts/tools/mapf_oracle_diagnostic.py`, not wired into the benchmark loop. Blast radius is manual diagnostic runs. All three were flagged by Gemini review threads on PR #4816.

## Validation

```
uv run ruff check scripts/tools/mapf_oracle_diagnostic.py tests/scripts/tools/test_mapf_oracle_diagnostic.py
uv run ruff format scripts/tools/mapf_oracle_diagnostic.py tests/scripts/tools/test_mapf_oracle_diagnostic.py
uv run pytest tests/scripts/tools/test_mapf_oracle_diagnostic.py -v
```

All 95 tests pass (including 7 new regression tests for these fixes).

## Tests added

- `TestCbsDynamicObstacleSwap::test_cbs_avoids_dynamic_obstacle_swap` — CBS avoids genuine swap with a single moving obstacle
- `TestCbsDynamicObstacleSwap::test_cbs_multi_agent_with_dynamic_obstacle_swap` — CBS with two agents avoids dynamic-obstacle swap
- `TestCbsDynamicObstacleSwap::test_cbs_two_independent_obstacles_no_false_swap` — Two independent obstacles must not cause a false swap block
- `TestLoadAgentsDuplicateId::test_duplicate_agent_id_rejected` — Duplicate agent ID raises ValueError
- `TestLoadAgentsDuplicateId::test_unique_agent_ids_accepted` — Unique agent IDs accepted
- `TestLoadAgentsDuplicateId::test_duplicate_non_zero_id` — Non-zero duplicate ID raises ValueError
- `TestLoadInputsAnnotation::test_returns_three_tuple` — _load_inputs returns a 3-tuple

Closes #4817

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.