### PR TITLE
Issue #4785: populate min_ttc_s and fix max_deceleration_mps2 braking semantics (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/critical_intervals.py
+++ b/robot_sf/benchmark/critical_intervals.py
@@ -96,16 +96,9 @@ class IntervalMetrics:
     n_steps: int = 0
     min_clearance_m: float | None = None
     min_distance_m: float | None = None
-    # NOTE: min_ttc_s is not yet computed by _compute_interval_metrics_in_window
-    # (always None as shipped). Windowed TTC aggregation is tracked as a
-    # follow-up; kept in the schema so the field is stable when populated.
     min_ttc_s: float | None = None
     mean_speed_ms: float | None = None
     max_speed_ms: float | None = None
-    # NOTE: this is the max L2 magnitude of per-step velocity change (|Δv|/dt),
-    # i.e. total acceleration magnitude within the window — NOT a signed
-    # deceleration projected onto the braking direction. Rename/redefinition is
-    # tracked as a follow-up.
     max_deceleration_mps2: float | None = None
     heading_oscillation: float | None = None
     near_miss_count: int = 0
@@ -304,6 +297,102 @@ def _detect_ttc_threshold_crossing(  # noqa: C901
                 return t
 
     return None
+
+
+def _compute_window_min_ttc_s(  # noqa: C901
+    *,
+    robot_pos: np.ndarray,
+    robot_vel: np.ndarray | None,
+    peds_pos: np.ndarray,
+    ped_vel: np.ndarray | None,
+    dt: float,
+) -> float | None:
+    """Compute the minimum finite TTC over all steps and pedestrians.
+
+    Uses the same constant-velocity closing convention as
+    ``_detect_ttc_threshold_crossing``.
+
+    Returns
+    -------
+    float | None
+        Minimum finite TTC in seconds, or ``None`` when required data is
+        missing.  Never returns ``0``, ``NaN``, or ``inf`` for a missing-data
+        placeholder (``0.0`` is only returned for a true zero-distance overlap).
+    """
+
+    T = robot_pos.shape[0]
+    n_peds = peds_pos.shape[1] if peds_pos.ndim >= 3 else 0
+    if n_peds == 0 or T == 0 or robot_vel is None:
+        return None
+
+    if peds_pos.shape[0] < T:
+        return None
+
+    _MIN_SPEED = 1e-9
+    _MIN_DIST = 1e-9
+
+    min_ttc: float | None = None
+
+    for t in range(T):
+        for k in range(n_peds):
+            d_vec = peds_pos[t, k] - robot_pos[t]
+            dist = float(np.linalg.norm(d_vec))
+            if dist < _MIN_DIST:
+                min_ttc = 0.0 if min_ttc is None else min(min_ttc, 0.0)
+                continue
+
+            if ped_vel is None:
+                continue
+            v_rel = robot_vel[t] - ped_vel[t, k]
+            speed = float(np.linalg.norm(v_rel))
+            if speed < _MIN_SPEED:
+                continue
+
+            closing = float(np.dot(v_rel, d_vec))
+            if closing <= 0:
+                continue
+
+            ttc = dist / closing
+            if np.isfinite(ttc) and ttc > 0:
+                if min_ttc is None or ttc < min_ttc:
+                    min_ttc = ttc
+
+    return min_ttc
+
+
+def _compute_max_braking_deceleration_mps2(robot_vel: np.ndarray, *, dt: float) -> float | None:
+    """Compute maximum braking deceleration opposite the current velocity direction.
+
+    Braking deceleration is ``max(0, -dot(acc, vel_dir))`` at each step.
+    Pure turning at constant speed does **not** count as braking.
+
+    Returns
+    -------
+    float | None
+        Maximum braking deceleration in m/s², or ``None`` when fewer than two
+        velocity samples are available.
+    """
+
+    T = robot_vel.shape[0]
+    if T < 2:
+        return None
+
+    acc = np.zeros_like(robot_vel)
+    acc[0] = (robot_vel[1] - robot_vel[0]) / dt
+    acc[-1] = (robot_vel[-1] - robot_vel[-2]) / dt
+    if T > 2:
+        acc[1:-1] = (robot_vel[2:] - robot_vel[:-2]) / (2.0 * dt)
+
+    speed = np.linalg.norm(robot_vel, axis=1)
+    max_decel = 0.0
+    for t in range(T):
+        if speed[t] > 1e-9:
+            vel_dir = robot_vel[t] / speed[t]
+            tangential_a = float(np.dot(acc[t], vel_dir))
+            decel = max(0.0, -tangential_a)
+            max_decel = max(max_decel, decel)
+
+    return max_decel
 
 
 def _detect_first_braking_event(
@@ -526,7 +615,7 @@ def extract_critical_intervals(  # noqa: C901, PLR0912, PLR0915
     return intervals
 
 
-def _compute_interval_metrics_in_window(
+def _compute_interval_metrics_in_window(  # noqa: C901, PLR0912, PLR0915
     trace: dict[str, Any],
     *,
     start: int,
@@ -572,6 +661,36 @@ def _compute_interval_metrics_in_window(
         result["min_distance_m"] = None
         result["min_clearance_m"] = None
 
+    # TTC (time-to-collision)
+    if n_peds > 0 and sub_robot_pos.shape[0] > 0:
+        robot_vel_raw_ttc = trace.get("robot_vel")
+        robot_vel_arr: np.ndarray | None = None
+        if robot_vel_raw_ttc is not None:
+            full_vel_ttc = np.asarray(robot_vel_raw_ttc, dtype=float)
+            if full_vel_ttc.ndim == 1:
+                full_vel_ttc = full_vel_ttc.reshape(1, -1)
+            robot_vel_arr = full_vel_ttc[sl]
+
+        ped_vel_raw = trace.get("ped_vel")
+        ped_vel_arr: np.ndarray | None = None
+        if ped_vel_raw is not None:
+            full_ped_vel = np.asarray(ped_vel_raw, dtype=float)
+            if full_ped_vel.shape[0] >= end:
+                ped_vel_arr = full_ped_vel[sl]
+        elif sub_peds_pos.shape[0] >= 2:
+            ped_diffs = np.diff(sub_peds_pos, axis=0) / dt
+            ped_vel_arr = np.vstack([ped_diffs[:1], ped_diffs])
+
+        result["min_ttc_s"] = _compute_window_min_ttc_s(
+            robot_pos=sub_robot_pos,
+            robot_vel=robot_vel_arr,
+            peds_pos=sub_peds_pos,
+            ped_vel=ped_vel_arr,
+            dt=dt,
+        )
+    else:
+        result["min_ttc_s"] = None
+
     # Speed
     robot_vel_raw = trace.get("robot_vel")
     if robot_vel_raw is not None:
@@ -587,9 +706,7 @@ def _compute_interval_metrics_in_window(
         result["max_speed_ms"] = float(np.max(speeds))
 
         if sub_vel.shape[0] >= 2:
-            acc_diffs = np.diff(sub_vel, axis=0) / dt
-            acc_norms = np.linalg.norm(acc_diffs, axis=1)
-            result["max_deceleration_mps2"] = float(np.max(acc_norms))
+            result["max_deceleration_mps2"] = _compute_max_braking_deceleration_mps2(sub_vel, dt=dt)
     elif sub_robot_pos.shape[0] >= 2:
         vel_approx = np.diff(sub_robot_pos, axis=0) / dt
         speeds = np.linalg.norm(vel_approx, axis=1)
@@ -648,6 +765,7 @@ def summarize_interval_metrics(
                 n_steps=window_metrics.get("n_steps", 0),
                 min_clearance_m=window_metrics.get("min_clearance_m"),
                 min_distance_m=window_metrics.get("min_distance_m"),
+                min_ttc_s=window_metrics.get("min_ttc_s"),
                 mean_speed_ms=window_metrics.get("mean_speed_ms"),
                 max_speed_ms=window_metrics.get("max_speed_ms"),
                 max_deceleration_mps2=window_metrics.get("max_deceleration_mps2"),

--- a/tests/benchmark/test_critical_intervals.py
+++ b/tests/benchmark/test_critical_intervals.py
@@ -18,6 +18,7 @@ from robot_sf.benchmark.critical_intervals import (
     CriticalInterval,
     IntervalMetrics,
     _compute_interval_metrics_in_window,
+    _compute_max_braking_deceleration_mps2,
     extract_critical_intervals,
     load_config,
     report_to_dict,
@@ -509,20 +510,144 @@ class TestWindowedDeceleration:
     """max_deceleration_mps2 must reflect ONLY the window, not the whole run."""
 
     def test_deceleration_is_windowed_not_whole_run(self) -> None:
-        # A single large velocity change at steps 0->1 (Δv = 10 m/s over dt=0.1s
-        # => 100 m/s^2), then constant velocity for the rest of the trace.
+        # Robot moves east at 10 m/s for steps 1..5, then brakes to -5 m/s
+        # between steps 5 and 6, then stays at -5 m/s.  The deceleration spike
+        # lives between steps 5 and 6 only.
         n = 20
         dt = 0.1
         robot_vel = np.zeros((n, 2), dtype=float)
-        robot_vel[1:, 0] = 10.0  # spike between step 0 and step 1 only
+        robot_vel[1:6, 0] = 10.0
+        robot_vel[6:, 0] = -5.0
         robot_pos = np.cumsum(robot_vel * dt, axis=0)
         trace = _make_trace(robot_pos, robot_vel=robot_vel, dt=dt)
 
         whole = _compute_interval_metrics_in_window(trace, start=0, end=n)
-        # A late window that excludes the step-0->1 spike must see zero accel.
-        late = _compute_interval_metrics_in_window(trace, start=5, end=n)
+        # A late window that excludes the deceleration spike must see zero.
+        late = _compute_interval_metrics_in_window(trace, start=10, end=n)
 
-        assert whole["max_deceleration_mps2"] == pytest.approx(100.0)
+        # Central-difference at the 10→-5 transition: Δv=15, dt=0.2 → 75
+        assert whole["max_deceleration_mps2"] == pytest.approx(75.0)
         assert late["max_deceleration_mps2"] == pytest.approx(0.0)
         # The whole point of the feature: window value != whole-run value.
         assert late["max_deceleration_mps2"] < whole["max_deceleration_mps2"]
+
+
+# ---------------------------------------------------------------------------
+# min_ttc_s (issue #4785)
+# ---------------------------------------------------------------------------
+
+
+class TestWindowedMinTTC:
+    """min_ttc_s is populated when robot/pedestrian data are available."""
+
+    def test_closing_pair_produces_finite_ttc(self) -> None:
+        trace = _make_approaching_trace()
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        assert whole["min_ttc_s"] is not None
+        assert whole["min_ttc_s"] >= 0
+        assert np.isfinite(whole["min_ttc_s"])
+
+    def test_ttc_in_report_to_dict(self) -> None:
+        trace = _make_approaching_trace()
+        cfg = {
+            "critical_intervals": {
+                "closest_approach": {
+                    "enabled": True,
+                    "before_s": 0.5,
+                    "after_s": 0.5,
+                },
+            },
+        }
+        intervals = extract_critical_intervals(trace, cfg)
+        report = summarize_interval_metrics(trace, intervals)
+        d = report_to_dict(report)
+        assert len(d["interval_metrics"]) == 1
+        assert d["interval_metrics"][0]["min_ttc_s"] is not None
+        assert d["interval_metrics"][0]["min_ttc_s"] >= 0
+
+    def test_missing_robot_vel_gives_none(self) -> None:
+        trace = _make_approaching_trace()
+        del trace["robot_vel"]
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        assert whole["min_ttc_s"] is None
+
+    def test_no_peds_gives_none(self) -> None:
+        n = 5
+        robot_pos = np.zeros((n, 2))
+        robot_pos[:, 0] = np.arange(n) * 0.5
+        robot_vel = np.zeros((n, 2))
+        robot_vel[:, 0] = 1.0
+        trace = _make_trace(robot_pos, robot_vel=robot_vel)
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        assert whole["min_ttc_s"] is None
+
+    def test_non_closing_pair_gives_none(self) -> None:
+        n = 5
+        robot_pos = np.zeros((n, 2))
+        robot_vel = np.zeros((n, 2))
+        robot_vel[:, 0] = 1.0
+        peds_pos = np.zeros((n, 1, 2))
+        peds_pos[:, 0, 0] = 10.0
+        ped_vel = np.zeros((n, 1, 2))
+        ped_vel[:, 0, 0] = 2.0
+        trace = _make_trace(robot_pos, peds_pos, robot_vel=robot_vel, dt=0.1)
+        trace["ped_vel"] = ped_vel
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        assert whole["min_ttc_s"] is None
+
+
+# ---------------------------------------------------------------------------
+# max_deceleration_mps2 — braking semantics (issue #4785)
+# ---------------------------------------------------------------------------
+
+
+class TestBrakingDeceleration:
+    """max_deceleration_mps2 is braking deceleration, not acceleration magnitude."""
+
+    def test_deceleration_along_velocity_direction(self) -> None:
+        dt = 0.1
+        n = 10
+        robot_vel = np.zeros((n, 2))
+        robot_vel[:, 0] = np.linspace(5.0, 0.0, n)
+
+        result = _compute_max_braking_deceleration_mps2(robot_vel, dt=dt)
+        assert result is not None
+        assert result > 0
+        # Uniform deceleration: Δv/Δt = 5/(9*0.1) ≈ 5.556 m/s²
+        assert result == pytest.approx(50.0 / 9.0, abs=0.1)
+
+    def test_speed_increase_gives_zero_braking(self) -> None:
+        dt = 0.1
+        n = 5
+        robot_vel = np.zeros((n, 2))
+        robot_vel[:, 0] = np.linspace(1.0, 5.0, n)
+        result = _compute_max_braking_deceleration_mps2(robot_vel, dt=dt)
+        assert result is not None
+        assert result == pytest.approx(0.0)
+
+    def test_pure_turning_does_not_count_as_braking(self) -> None:
+        # Circular motion at constant speed: velocity direction changes but
+        # speed is constant, so tangential acceleration is zero.
+        speed = 5.0
+        omega = 1.0  # rad/s
+        n_steps = 200
+        t = np.arange(n_steps) * 0.01
+        robot_vel = np.column_stack([speed * np.cos(omega * t), speed * np.sin(omega * t)])
+        result = _compute_max_braking_deceleration_mps2(robot_vel, dt=0.01)
+        assert result is not None
+        # Central-difference introduces O(dt²·ω²·speed) numerical error;
+        # the key property is that it is orders of magnitude smaller than
+        # the centripetal acceleration (speed·ω = 5 m/s²).
+        assert result < 0.01 * speed * omega
+
+    def test_two_samples_only(self) -> None:
+        dt = 0.1
+        robot_vel = np.array([[10.0, 0.0], [0.0, 0.0]])
+        result = _compute_max_braking_deceleration_mps2(robot_vel, dt=dt)
+        assert result is not None
+        assert result == pytest.approx(100.0)
+
+    def test_single_sample_returns_none(self) -> None:
+        robot_vel = np.array([[5.0, 0.0]])
+        result = _compute_max_braking_deceleration_mps2(robot_vel, dt=0.1)
+        assert result is None


### PR DESCRIPTION
## What / Why

Follows up on gate review of PR #4782 (critical-interval metric windows, issue #4758). Two metric fields shipped as documented placeholders:

1. **`min_ttc_s`** — now populated via `_compute_window_min_ttc_s()` which computes windowed TTC using the same constant-velocity closing convention as `_detect_ttc_threshold_crossing()`. Returns `None` when robot velocity, pedestrian data, or non-closing pairs make computation unavailable. Never emits `0`, `NaN`, or `inf` as a missing-data placeholder.

2. **`max_deceleration_mps2`** — computation replaced from `max(|Δv|/dt)` (total acceleration magnitude) to true braking deceleration via `_compute_max_braking_deceleration_mps2()`. Projects acceleration onto current velocity direction: `max(0, -dot(acc, vel_dir))`. Pure turning at constant speed does not inflate braking deceleration.

Removed `NOTE:` comments that labeled these fields as placeholders/misnamed.

### Files changed

- `robot_sf/benchmark/critical_intervals.py` — added two helper functions, wired them into `_compute_interval_metrics_in_window()` and `summarize_interval_metrics()`, removed placeholder notes
- `tests/benchmark/test_critical_intervals.py` — added `TestWindowedMinTTC` (5 tests) and `TestBrakingDeceleration` (5 tests) covering TTC aggregation and braking semantics

### Validation

```
uv run ruff check robot_sf/benchmark/critical_intervals.py tests/benchmark/test_critical_intervals.py
  → All checks passed
uv run pytest tests/benchmark/test_critical_intervals.py -v
  → 33 passed in 2.21s
```

### Acceptance criteria met

- `min_ttc_s` populated for TTC-capable windows; `None` for missing data
- `max_deceleration_mps2` matches its name (true braking deceleration)
- Tests cover both TTC aggregation and braking semantics
- Feature remains experimental, opt-in, diagnostic-only

Closes #4785

This PR was produced by the SAIA/Qwen3.6-27B cheap implementation lane; the review gate hardens and merges.
