### PR TITLE
Issue #3078: Package A pipeline orchestrator (cheap-lane worker)

### DIFF
--- a/scripts/tools/run_package_a_pipeline.py
+++ b/scripts/tools/run_package_a_pipeline.py
@@ -1,0 +1,757 @@
+#!/usr/bin/env python3
+"""End-to-end Package A pipeline orchestrator (issue #3078).
+
+Runs the seed-sufficiency analysis, held-out-family transfer validation,
+and preliminary claim-card generation on supplied campaign data or synthetic
+fixtures. Classifies the result under the issue #3078 fail-closed vocabulary.
+
+This is the canonical entry point that assembles the Package A deliverables:
+
+  - seed-sufficiency analysis (interval widths, rank stability, figure)
+  - held-out-family partition validity + leakage audit structure
+  - baseline table (benchmark-set summary)
+  - transfer-delta table (benchmark-set vs held-out-family per planner)
+  - transfer-delta figure (PNG)
+  - preliminary claim card with issue result classification
+
+When real campaign data is absent the pipeline falls back to synthetic fixture
+campaigns and classifies the result as ``diagnostic`` rather than ``benchmark``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+from matplotlib import pyplot as plt
+
+SCHEMA_VERSION = "package_a_pipeline_output.v1"
+PACKAGE_A_CLASSIFICATION = (
+    "benchmark",
+    "diagnostic",
+    "negative",
+    "null",
+    "invalid",
+    "blocked",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture campaign generation
+# ---------------------------------------------------------------------------
+
+
+def _create_campaign_fixture(
+    root: Path,
+    *,
+    seed_count: int,
+    planners: dict[str, dict[str, float]],
+    scenario_families: list[str],
+    ci_half_width: float = 0.1,
+) -> Path:
+    """Create a minimal campaign fixture under ``root`` with ``reports/``.
+
+    Args:
+        root: Campaign root directory to create.
+        seed_count: Number of seeds in this campaign.
+        planners: Mapping of planner key to metric summaries.
+        scenario_families: Scenario families to emit rows for.
+        ci_half_width: Confidence interval half-width for metrics.
+    """
+    reports = root / "reports"
+    root.mkdir(parents=True, exist_ok=True)
+    reports.mkdir(parents=True, exist_ok=True)
+
+    seed_rows = []
+    variability_rows = []
+    for family in scenario_families:
+        scenario_id = f"{family}_s1"
+        for planner_key, metrics in planners.items():
+            summary = {
+                metric: {
+                    "mean": value,
+                    "ci_half_width": ci_half_width,
+                    "ci_low": value - ci_half_width,
+                    "ci_high": value + ci_half_width,
+                }
+                for metric, value in metrics.items()
+            }
+            variability_rows.append(
+                {
+                    "scenario_id": scenario_id,
+                    "scenario_family": family,
+                    "planner_key": planner_key,
+                    "kinematics": "differential_drive",
+                    "seed_count": seed_count,
+                    "summary": summary,
+                }
+            )
+            successes = int(metrics.get("success", 0.0) * seed_count)
+            collisions = int(metrics.get("collisions", 0.0) * seed_count)
+            snqi = metrics.get("snqi", 0.0)
+            for seed_index in range(seed_count):
+                seed_rows.append(
+                    {
+                        "episode_id": f"{planner_key}-{family}-{seed_index}",
+                        "scenario_id": scenario_id,
+                        "scenario_family": family,
+                        "planner_key": planner_key,
+                        "seed": 111 + seed_index,
+                        "success": "1" if seed_index < successes else "0",
+                        "collision": "1" if seed_index < collisions else "0",
+                        "snqi": f"{snqi:.4f}",
+                    }
+                )
+
+    (reports / "seed_variability_by_scenario.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "benchmark-seed-variability-by-scenario.v1",
+                "metrics": ["success", "collisions", "snqi"],
+                "rows": variability_rows,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _write_seed_episode_rows(reports / "seed_episode_rows.csv", seed_rows)
+    (reports / "statistical_sufficiency.json").write_text(
+        json.dumps({"bootstrap": {"seed": 123}}) + "\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _write_seed_episode_rows(path: Path, rows: list[dict[str, str]]) -> None:
+    """Write seed episode rows CSV."""
+    fieldnames = [
+        "episode_id",
+        "scenario_id",
+        "scenario_family",
+        "planner_key",
+        "seed",
+        "success",
+        "collision",
+        "snqi",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+# ---------------------------------------------------------------------------
+# Baseline table
+# ---------------------------------------------------------------------------
+
+
+def _build_baseline_table(
+    campaign_roots: list[Path],
+    *,
+    metrics: tuple[str, ...] = ("success", "collisions", "snqi"),
+) -> list[dict[str, Any]]:
+    """Build a compact baseline table from campaign roots.
+
+    Returns one row per campaign-seed-count-planner with the requested metric
+    means.  The table is deterministic and sorted.
+    """
+    rows: list[dict[str, Any]] = []
+    for campaign_root in campaign_roots:
+        payload = json.loads(
+            (campaign_root / "reports" / "seed_variability_by_scenario.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        for row in payload.get("rows", []):
+            planner_key = str(row.get("planner_key", "unknown"))
+            summary = row.get("summary") or {}
+            baseline_row: dict[str, Any] = {
+                "campaign": campaign_root.name,
+                "scenario_id": str(row.get("scenario_id", "")),
+                "scenario_family": str(row.get("scenario_family", "")),
+                "planner_key": planner_key,
+                "seed_count": row.get("seed_count", 0),
+            }
+            for metric in metrics:
+                metric_summary = summary.get(metric) or {}
+                mean = metric_summary.get("mean")
+                ci_low = metric_summary.get("ci_low")
+                ci_high = metric_summary.get("ci_high")
+                baseline_row[f"{metric}_mean"] = _safe_float(mean)
+                baseline_row[f"{metric}_ci_low"] = _safe_float(ci_low)
+                baseline_row[f"{metric}_ci_high"] = _safe_float(ci_high)
+            rows.append(baseline_row)
+    rows.sort(
+        key=lambda r: (
+            r["campaign"],
+            r["scenario_family"],
+            r["planner_key"],
+        )
+    )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Transfer-delta computation
+# ---------------------------------------------------------------------------
+
+
+def _safe_float(value: Any) -> float | None:
+    """Parse a finite float or return None."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _build_transfer_delta(
+    benchmark_rows: list[dict[str, Any]],
+    heldout_rows: list[dict[str, Any]],
+    *,
+    metric: str = "snqi",
+) -> list[dict[str, Any]]:
+    """Compute per-planner transfer deltas between benchmark-set and held-out-family.
+
+    A transfer delta is the difference between the mean metric on benchmark-set
+    and the mean metric on the held-out-family.  Positive values mean the
+    planner performed better on the benchmark set than on held-out data (expected
+    transfer loss when delta > 0 for SNQI-style metrics).
+    """
+    benchmark_map: dict[str, float | None] = {}
+    for row in benchmark_rows:
+        key = row["planner_key"]
+        value = _safe_float(row.get(f"{metric}_mean"))
+        if value is not None:
+            benchmark_map[key] = value
+
+    heldout_map: dict[str, float | None] = {}
+    for row in heldout_rows:
+        key = row["planner_key"]
+        value = _safe_float(row.get(f"{metric}_mean"))
+        if value is not None:
+            heldout_map[key] = value
+
+    planners = sorted(set(benchmark_map) | set(heldout_map))
+    deltas: list[dict[str, Any]] = []
+    for planner in planners:
+        benchmark_val = benchmark_map.get(planner)
+        heldout_val = heldout_map.get(planner)
+        delta = None
+        if benchmark_val is not None and heldout_val is not None:
+            delta = benchmark_val - heldout_val
+        deltas.append(
+            {
+                "planner_key": planner,
+                f"benchmark_{metric}": benchmark_val,
+                f"heldout_{metric}": heldout_val,
+                f"transfer_delta_{metric}": delta,
+                "transfer_direction": (
+                    "positive_transfer"
+                    if delta is not None and delta > 0
+                    else "negative_transfer"
+                    if delta is not None and delta < 0
+                    else "identical"
+                    if delta == 0
+                    else "incomplete"
+                ),
+            }
+        )
+    return deltas
+
+
+# ---------------------------------------------------------------------------
+# Transfer-delta figure
+# ---------------------------------------------------------------------------
+
+
+def _write_transfer_delta_figure(
+    path: Path,
+    deltas: list[dict[str, Any]],
+    *,
+    metric: str = "snqi",
+) -> None:
+    """Write a bar-chart PNG of transfer deltas by planner."""
+    fig, ax = plt.subplots(figsize=(6, 3.5))
+    keys = [row["planner_key"] for row in deltas]
+    values = [row.get(f"transfer_delta_{metric}") for row in deltas]
+
+    colors = []
+    bar_values = []
+    for val in values:
+        if val is None:
+            colors.append("#cccccc")
+            bar_values.append(0.0)
+        elif val > 0:
+            colors.append("#d73027")
+            bar_values.append(val)
+        elif val < 0:
+            colors.append("#1a9850")
+            bar_values.append(val)
+        else:
+            colors.append("#4575b4")
+            bar_values.append(val)
+
+    bars = ax.bar(keys, bar_values, color=colors, zorder=3)
+    ax.axhline(y=0, color="black", linewidth=0.8, zorder=2)
+    ax.set_ylabel(f"Transfer delta ({metric})")
+    ax.set_title("Benchmark-set vs held-out-family transfer delta")
+    ax.grid(axis="y", alpha=0.25, zorder=1)
+    for bar, val in zip(bars, values, strict=False):
+        if val is not None:
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                val + (0.005 if val >= 0 else -0.005),
+                f"{val:.3f}",
+                ha="center",
+                va="bottom" if val >= 0 else "top",
+                fontsize=7,
+            )
+        elif val is None:
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                0.003,
+                "N/A",
+                ha="center",
+                va="bottom",
+                fontsize=7,
+            )
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Preliminary claim card
+# ---------------------------------------------------------------------------
+
+
+def _build_claim_card(
+    *,
+    classification: str,
+    reasons: list[str],
+    seed_analysis_path: Path | None,
+    baseline_table_path: Path | None,
+    transfer_delta_path: Path | None,
+    figure_path: Path | None,
+    partition_manifests: list[Path] | None,
+    output_dir: Path,
+) -> dict[str, Any]:
+    """Build a preliminary claim-card payload."""
+    card: dict[str, Any] = {
+        "schema_version": "package_a_claim_card.v1",
+        "issue": 3078,
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "classification": classification,
+        "classification_vocabulary": list(PACKAGE_A_CLASSIFICATION),
+        "reasons": reasons,
+        "artifacts": {
+            "seed_sufficiency_analysis": (str(seed_analysis_path) if seed_analysis_path else None),
+            "baseline_table": str(baseline_table_path) if baseline_table_path else None,
+            "transfer_delta_table": str(transfer_delta_path) if transfer_delta_path else None,
+            "transfer_delta_figure": str(figure_path) if figure_path else None,
+        },
+        "partition_manifests": [str(p) for p in (partition_manifests or [])],
+        "output_dir": str(output_dir),
+        "claim_boundary": (
+            "Diagnostic evidence only. Claim-card review and real campaign "
+            "execution required before benchmark-classification promotion."
+        ),
+        "promotion_allowed": False,
+    }
+    return card
+
+
+# ---------------------------------------------------------------------------
+# Markdown summary
+# ---------------------------------------------------------------------------
+
+
+def _build_markdown_summary(
+    *,
+    classification: str,
+    reasons: list[str],
+    seed_analysis_summary: dict[str, Any] | None,
+    deltas: list[dict[str, Any]] | None,
+    partition_ok: bool | None,
+    output_dir: Path,
+) -> str:
+    """Render a compact Markdown summary of the Package A pipeline run."""
+    lines = [
+        "# Package A Pipeline Output",
+        "",
+        "- Issue: `#3078`",
+        f"- Classification: `{classification}`",
+        f"- Generated: `{datetime.now(UTC).isoformat()}`",
+        "",
+        "## Artifacts",
+        "",
+        "- `seed_sufficiency_analysis.json`",
+        "- `baseline_table.csv`",
+        "- `transfer_delta.csv`",
+        "- `fig_transfer_delta.png`",
+        "- `claim_card.json`",
+        "",
+        "## Seed Sufficiency",
+        "",
+    ]
+    if seed_analysis_summary:
+        for key, value in sorted(seed_analysis_summary.items()):
+            lines.append(f"- {key}: `{value}`")
+    else:
+        lines.append("- No seed-sufficiency analysis available (no campaign data).")
+
+    lines.extend(
+        [
+            "",
+            "## Transfer Delta",
+            "",
+        ]
+    )
+    if deltas:
+        lines.append("| Planner | Transfer Delta (SNQI) | Direction |")
+        lines.append("|---|---|---|")
+        for row in deltas:
+            delta = row.get("transfer_delta_snqi")
+            delta_str = f"{delta:.4f}" if delta is not None else "N/A"
+            lines.append(
+                f"| {row['planner_key']} | {delta_str} | {row.get('transfer_direction', 'N/A')} |"
+            )
+    else:
+        lines.append("- Transfer delta not computed (insufficient cross-surface data).")
+
+    lines.extend(
+        [
+            "",
+            "## Partition Validation",
+            "",
+        ]
+    )
+    if partition_ok is True:
+        lines.append("- Held-out-family partition manifest: **valid**")
+    elif partition_ok is False:
+        lines.append("- Held-out-family partition manifest: **validation errors detected**")
+    else:
+        lines.append("- Held-out-family partition manifest: **not checked**")
+
+    if reasons:
+        lines.extend(
+            [
+                "",
+                "## Reasons for Classification",
+                "",
+            ]
+        )
+        for reason in reasons:
+            lines.append(f"- {reason}")
+
+    lines.extend(
+        [
+            "",
+            "---",
+            "",
+            "This output is diagnostic evidence. Real campaign execution is required "
+            "before benchmark-level classification.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CSV helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_csv_rows(path: Path, rows: list[dict[str, Any]]) -> None:
+    """Write CSV rows with deterministic field order."""
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    fieldnames = list(rows[0].keys())
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write indented JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+
+def run_pipeline(  # noqa: PLR0915
+    output_dir: Path,
+    *,
+    campaign_roots: list[Path] | None = None,
+    benchmark_families: list[str] | None = None,
+    heldout_families: list[str] | None = None,
+    partition_manifest: Path | None = None,
+    metrics: tuple[str, ...] = ("success", "collisions", "snqi"),
+) -> dict[str, Any]:
+    """Execute the Package A pipeline and write deliverables to ``output_dir``.
+
+    When ``campaign_roots`` is empty the pipeline generates synthetic fixture
+    campaigns and classifies the result as ``diagnostic``.
+
+    Returns:
+        Pipeline payload with artifact paths and classification.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    reasons: list[str] = []
+    is_synthetic = campaign_roots is None or not campaign_roots
+
+    # --- 1. Seed-sufficiency analysis ---
+    seed_analysis_path: Path | None = None
+    seed_analysis_summary: dict[str, Any] | None = None
+
+    if campaign_roots:
+        from scripts.tools.analyze_seed_sufficiency import analyze_seed_sufficiency
+
+        seed_out = output_dir / "seed_sufficiency"
+        payload = analyze_seed_sufficiency(
+            campaign_roots,
+            seed_out,
+            metrics=metrics,
+        )
+        seed_analysis_path = seed_out / "seed_sufficiency_analysis.json"
+        seed_analysis_summary = payload.get("summary")
+    else:
+        # Generate synthetic fixture campaigns
+        reasons.append("synthetic_fixture_campaigns_used")
+        fixture_dir = output_dir / "fixture_campaigns"
+        benchmark_planners = {
+            "goal": {"success": 0.9, "collisions": 0.05, "snqi": 0.72},
+            "social_force": {"success": 0.75, "collisions": 0.15, "snqi": 0.65},
+            "orca": {"success": 0.6, "collisions": 0.25, "snqi": 0.5},
+        }
+        s5 = _create_campaign_fixture(
+            fixture_dir / "s5",
+            seed_count=5,
+            planners=benchmark_planners,
+            scenario_families=benchmark_families or ["classic_bottleneck", "classic_cross_trap"],
+            ci_half_width=0.15,
+        )
+        s10 = _create_campaign_fixture(
+            fixture_dir / "s10",
+            seed_count=10,
+            planners={
+                "goal": {"success": 0.92, "collisions": 0.04, "snqi": 0.74},
+                "social_force": {"success": 0.78, "collisions": 0.13, "snqi": 0.67},
+                "orca": {"success": 0.62, "collisions": 0.22, "snqi": 0.52},
+            },
+            scenario_families=benchmark_families or ["classic_bottleneck", "classic_cross_trap"],
+            ci_half_width=0.08,
+        )
+        campaign_roots = [s5, s10]
+
+        from scripts.tools.analyze_seed_sufficiency import analyze_seed_sufficiency
+
+        seed_out = output_dir / "seed_sufficiency"
+        payload = analyze_seed_sufficiency(
+            campaign_roots,
+            seed_out,
+            metrics=metrics,
+        )
+        seed_analysis_path = seed_out / "seed_sufficiency_analysis.json"
+        seed_analysis_summary = payload.get("summary")
+
+    # --- 2. Baseline table ---
+    benchmark_rows = _build_baseline_table(campaign_roots, metrics=metrics)
+    baseline_table_path = output_dir / "baseline_table.csv"
+    _write_csv_rows(baseline_table_path, benchmark_rows)
+
+    # --- 3. Transfer delta ---
+    heldout_rows: list[dict[str, Any]] = []
+    if heldout_families:
+        reasons.append("synthetic_fixture_heldout_used")
+        fixture_dir = output_dir / "fixture_campaigns"
+        heldout_planners = {
+            "goal": {"success": 0.85, "collisions": 0.08, "snqi": 0.68},
+            "social_force": {"success": 0.70, "collisions": 0.18, "snqi": 0.60},
+            "orca": {"success": 0.55, "collisions": 0.28, "snqi": 0.45},
+        }
+        heldout_campaign = _create_campaign_fixture(
+            fixture_dir / "heldout_pilot",
+            seed_count=5,
+            planners=heldout_planners,
+            scenario_families=heldout_families,
+            ci_half_width=0.2,
+        )
+        heldout_rows = _build_baseline_table([heldout_campaign], metrics=metrics)
+
+    deltas = _build_transfer_delta(benchmark_rows, heldout_rows, metric="snqi")
+    transfer_delta_path = output_dir / "transfer_delta.csv"
+    _write_csv_rows(transfer_delta_path, deltas)
+
+    transfer_figure_path = output_dir / "fig_transfer_delta.png"
+    _write_transfer_delta_figure(transfer_figure_path, deltas, metric="snqi")
+
+    # --- 4. Partition validation ---
+    partition_ok: bool | None = None
+    if partition_manifest and partition_manifest.is_file():
+        from scripts.tools.validate_heldout_transfer_partitions import (
+            validate_partition_manifest,
+        )
+
+        errors = validate_partition_manifest(partition_manifest)
+        partition_ok = len(errors) == 0
+        if not partition_ok:
+            reasons.extend(f"partition_error: {e}" for e in errors)
+
+    # --- 5. Claim card ---
+    if is_synthetic:
+        classification = "diagnostic"
+        reasons.append("diagnostic: synthetic fixture data, not real campaign evidence")
+    elif partition_ok is False:
+        classification = "invalid"
+        reasons.append("invalid: held-out-family partition manifest has errors")
+    else:
+        classification = "diagnostic"
+        reasons.append("diagnostic: claim-card review required before promotion")
+
+    claim_card = _build_claim_card(
+        classification=classification,
+        reasons=reasons,
+        seed_analysis_path=seed_analysis_path,
+        baseline_table_path=baseline_table_path,
+        transfer_delta_path=transfer_delta_path,
+        figure_path=transfer_figure_path,
+        partition_manifests=[partition_manifest] if partition_manifest else None,
+        output_dir=output_dir,
+    )
+    claim_card_path = output_dir / "claim_card.json"
+    _write_json(claim_card_path, claim_card)
+
+    # --- 6. Markdown summary ---
+    summary_md = _build_markdown_summary(
+        classification=classification,
+        reasons=reasons,
+        seed_analysis_summary=seed_analysis_summary,
+        deltas=deltas,
+        partition_ok=partition_ok,
+        output_dir=output_dir,
+    )
+    (output_dir / "package_a_summary.md").write_text(summary_md, encoding="utf-8")
+
+    # --- 7. Top-level payload ---
+    output_payload = {
+        "schema_version": SCHEMA_VERSION,
+        "classification": classification,
+        "classification_vocabulary": list(PACKAGE_A_CLASSIFICATION),
+        "reasons": reasons,
+        "artifacts": {
+            "seed_sufficiency_analysis": str(seed_analysis_path),
+            "baseline_table": str(baseline_table_path),
+            "transfer_delta": str(transfer_delta_path),
+            "transfer_delta_figure": str(transfer_figure_path),
+            "claim_card": str(claim_card_path),
+            "summary_markdown": str(output_dir / "package_a_summary.md"),
+        },
+    }
+    _write_json(output_dir / "pipeline_output.json", output_payload)
+    return output_payload
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Output directory for Package A deliverables.",
+    )
+    parser.add_argument(
+        "--campaign-root",
+        type=Path,
+        action="append",
+        default=None,
+        help="Campaign root (with reports/). Repeat for multiple seed schedules.",
+    )
+    parser.add_argument(
+        "--benchmark-families",
+        nargs="+",
+        default=["classic_bottleneck", "classic_cross_trap"],
+        help="Benchmark-set scenario families (used for synthetic fixtures).",
+    )
+    parser.add_argument(
+        "--heldout-families",
+        nargs="+",
+        default=["classic_station_platform", "francis2023_intersection_wait"],
+        help="Held-out-family scenario families (used for synthetic fixtures).",
+    )
+    parser.add_argument(
+        "--partition-manifest",
+        type=Path,
+        default=None,
+        help=(
+            "Held-out-family transfer partition manifest YAML "
+            "(runs validate_heldout_transfer_partitions.py against it)."
+        ),
+    )
+    parser.add_argument(
+        "--metric",
+        dest="metrics",
+        action="append",
+        default=["success", "collisions", "snqi"],
+        help="Metrics to analyze. Defaults to success, collisions, snqi.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
+    output_dir = args.output_dir
+    campaign_roots = list(args.campaign_root) if args.campaign_root else None
+    partition_manifest = args.partition_manifest
+    metrics = tuple(args.metrics)
+
+    try:
+        payload = run_pipeline(
+            output_dir,
+            campaign_roots=campaign_roots,
+            benchmark_families=args.benchmark_families,
+            heldout_families=args.heldout_families,
+            partition_manifest=partition_manifest,
+            metrics=metrics,
+        )
+        print(f"Package A pipeline output: {output_dir}")
+        print(f"Classification: {payload['classification']}")
+        for reason in payload.get("reasons", []):
+            print(f" reason: {reason}")
+        return 0
+    except (ValueError, FileNotFoundError, OSError, RuntimeError) as exc:
+        print(f"Pipeline failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_run_package_a_pipeline.py
+++ b/tests/tools/test_run_package_a_pipeline.py
@@ -1,0 +1,334 @@
+"""Tests for the Package A pipeline orchestrator (issue #3078).
+
+Tests exercise the synthetic-fixture pathway and the partition-manifest
+integration without running real benchmark campaigns.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.tools.run_package_a_pipeline import (
+    PACKAGE_A_CLASSIFICATION,
+    SCHEMA_VERSION,
+    _build_baseline_table,
+    _build_claim_card,
+    _build_transfer_delta,
+    _safe_float,
+    _write_transfer_delta_figure,
+    run_pipeline,
+)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    """Write an indented JSON fixture."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _campaign_fixture(
+    root: Path,
+    *,
+    seed_count: int,
+    planner_snqi: float,
+    planner_success: float = 0.9,
+) -> Path:
+    """Create a minimal campaign fixture directory."""
+    reports = root / "reports"
+    root.mkdir(parents=True, exist_ok=True)
+    reports.mkdir(parents=True, exist_ok=True)
+
+    _write_json(
+        reports / "seed_variability_by_scenario.json",
+        {
+            "schema_version": "benchmark-seed-variability-by-scenario.v1",
+            "metrics": ["success", "collisions", "snqi"],
+            "rows": [
+                {
+                    "scenario_id": "family_a_s1",
+                    "scenario_family": "family_a",
+                    "planner_key": "goal",
+                    "kinematics": "differential_drive",
+                    "seed_count": seed_count,
+                    "summary": {
+                        "success": {
+                            "mean": planner_success,
+                            "ci_low": planner_success - 0.1,
+                            "ci_high": planner_success + 0.1,
+                            "ci_half_width": 0.1,
+                        },
+                        "collisions": {
+                            "mean": 0.05,
+                            "ci_low": 0.0,
+                            "ci_high": 0.1,
+                            "ci_half_width": 0.05,
+                        },
+                        "snqi": {
+                            "mean": planner_snqi,
+                            "ci_low": planner_snqi - 0.1,
+                            "ci_high": planner_snqi + 0.1,
+                            "ci_half_width": 0.1,
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
+    episodes = []
+    for seed_index in range(seed_count):
+        episodes.append(
+            {
+                "episode_id": f"goal-{seed_index}",
+                "scenario_id": "family_a_s1",
+                "scenario_family": "family_a",
+                "planner_key": "goal",
+                "seed": 111 + seed_index,
+                "success": "1",
+                "collision": "0",
+                "snqi": f"{planner_snqi:.4f}",
+            }
+        )
+    fieldnames = [
+        "episode_id",
+        "scenario_id",
+        "scenario_family",
+        "planner_key",
+        "seed",
+        "success",
+        "collision",
+        "snqi",
+    ]
+    with (reports / "seed_episode_rows.csv").open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(episodes)
+
+    _write_json(reports / "statistical_sufficiency.json", {"bootstrap": {"seed": 123}})
+    return root
+
+
+class TestSafeFloat:
+    """Tests for the _safe_float utility."""
+
+    def test_finite_value(self) -> None:
+        assert _safe_float("0.7") == 0.7
+        assert _safe_float(0.7) == 0.7
+        assert _safe_float("1.0") == 1.0
+
+    def test_non_finite(self) -> None:
+        assert _safe_float(float("inf")) is None
+        assert _safe_float(float("nan")) is None
+        assert _safe_float(float("-inf")) is None
+
+    def test_invalid(self) -> None:
+        assert _safe_float("not_a_number") is None
+        assert _safe_float(None) is None
+        assert _safe_float("") is None
+
+
+class TestBaselineTable:
+    """Tests for the _build_baseline_table utility."""
+
+    def test_empty_campaign(self, tmp_path: Path) -> None:
+        rows = _build_baseline_table([])
+        assert rows == []
+
+    def test_single_campaign(self, tmp_path: Path) -> None:
+        campaign = _campaign_fixture(
+            tmp_path / "s5",
+            seed_count=5,
+            planner_snqi=0.72,
+            planner_success=0.9,
+        )
+        rows = _build_baseline_table([campaign])
+        assert len(rows) == 1
+        assert rows[0]["planner_key"] == "goal"
+        assert rows[0]["snqi_mean"] == pytest.approx(0.72, abs=0.001)
+        assert rows[0]["success_mean"] == pytest.approx(0.9, abs=0.001)
+        assert rows[0]["campaign"] == "s5"
+        assert rows[0]["snqi_ci_low"] is not None
+
+
+class TestTransferDelta:
+    """Tests for the _build_transfer_delta utility."""
+
+    def test_identical_surfaces(self) -> None:
+        benchmark = [{"planner_key": "goal", "snqi_mean": 0.7}]
+        heldout = [{"planner_key": "goal", "snqi_mean": 0.7}]
+        deltas = _build_transfer_delta(benchmark, heldout)
+        assert len(deltas) == 1
+        assert deltas[0]["transfer_direction"] == "identical"
+        assert deltas[0]["transfer_delta_snqi"] == 0.0
+
+    def test_positive_transfer(self) -> None:
+        benchmark = [{"planner_key": "goal", "snqi_mean": 0.75}]
+        heldout = [{"planner_key": "goal", "snqi_mean": 0.65}]
+        deltas = _build_transfer_delta(benchmark, heldout)
+        assert deltas[0]["transfer_direction"] == "positive_transfer"
+        assert deltas[0]["transfer_delta_snqi"] == pytest.approx(0.1, abs=0.001)
+
+    def test_missing_heldout(self) -> None:
+        benchmark = [{"planner_key": "goal", "snqi_mean": 0.7}]
+        heldout = []
+        deltas = _build_transfer_delta(benchmark, heldout)
+        assert deltas[0]["transfer_direction"] == "incomplete"
+        assert deltas[0]["transfer_delta_snqi"] is None
+
+
+class TestTransferDeltaFigure:
+    """Tests for the _write_transfer_delta_figure utility."""
+
+    def test_writes_png(self, tmp_path: Path) -> None:
+        deltas = [
+            {"planner_key": "goal", "transfer_delta_snqi": 0.1},
+            {"planner_key": "orca", "transfer_delta_snqi": None},
+        ]
+        path = tmp_path / "fig.png"
+        _write_transfer_delta_figure(path, deltas)
+        assert path.is_file()
+        assert path.stat().st_size > 0
+
+
+class TestClaimCard:
+    """Tests for the _build_claim_card utility."""
+
+    def test_diagnostic_card(self, tmp_path: Path) -> None:
+        card = _build_claim_card(
+            classification="diagnostic",
+            reasons=["synthetic fixture data"],
+            seed_analysis_path=tmp_path / "seed.json",
+            baseline_table_path=tmp_path / "baseline.csv",
+            transfer_delta_path=tmp_path / "transfer.csv",
+            figure_path=tmp_path / "fig.png",
+            partition_manifests=[],
+            output_dir=tmp_path,
+        )
+        assert card["classification"] == "diagnostic"
+        assert card["promotion_allowed"] is False
+        assert "synthetic fixture data" in card["reasons"]
+        assert card["schema_version"] == "package_a_claim_card.v1"
+
+
+class TestSyntheticPipeline:
+    """Full pipeline tests with synthetic fixture data (no real campaigns)."""
+
+    def test_synthetic_pipeline_produces_artifacts(self, tmp_path: Path) -> None:
+        out = tmp_path / "output"
+        payload = run_pipeline(
+            out,
+            benchmark_families=["classic_bottleneck", "classic_cross_trap"],
+            heldout_families=["classic_station_platform"],
+        )
+
+        assert payload["schema_version"] == SCHEMA_VERSION
+        assert payload["classification"] == "diagnostic"
+
+        for artifact_key in (
+            "seed_sufficiency_analysis",
+            "baseline_table",
+            "transfer_delta",
+            "transfer_delta_figure",
+            "claim_card",
+            "summary_markdown",
+        ):
+            path = Path(payload["artifacts"][artifact_key])
+            assert path.is_file(), f"Missing artifact: {artifact_key}"
+
+    def test_synthetic_pipeline_classification_vocabulary(self, tmp_path: Path) -> None:
+        out = tmp_path / "output"
+        payload = run_pipeline(out)
+        assert set(payload["classification_vocabulary"]) == set(PACKAGE_A_CLASSIFICATION)
+
+    def test_baseline_table_has_expected_planners(self, tmp_path: Path) -> None:
+        out = tmp_path / "output"
+        run_pipeline(out)
+        table_path = out / "baseline_table.csv"
+        with table_path.open(newline="", encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+        planners = {r["planner_key"] for r in rows}
+        assert planners == {"goal", "social_force", "orca"}
+
+    def test_transfer_delta_computed_for_all_planners(self, tmp_path: Path) -> None:
+        out = tmp_path / "output"
+        run_pipeline(out)
+        delta_path = out / "transfer_delta.csv"
+        with delta_path.open(newline="", encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+        planners = {r["planner_key"] for r in rows}
+        assert planners == {"goal", "social_force", "orca"}
+        for row in rows:
+            assert row["transfer_direction"] in (
+                "positive_transfer",
+                "negative_transfer",
+                "identical",
+                "incomplete",
+            )
+
+    def test_output_json_roundtrips(self, tmp_path: Path) -> None:
+        out = tmp_path / "output"
+        run_pipeline(out)
+        payload_path = out / "pipeline_output.json"
+        payload = json.loads(payload_path.read_text(encoding="utf-8"))
+        assert payload["classification"] == "diagnostic"
+        assert "synthetic_fixture_campaigns_used" in payload["reasons"]
+
+    def test_claim_card_includes_all_artifacts(self, tmp_path: Path) -> None:
+        out = tmp_path / "output"
+        run_pipeline(out)
+        card = json.loads((out / "claim_card.json").read_text(encoding="utf-8"))
+        assert card["classification"] == "diagnostic"
+        assert card["promotion_allowed"] is False
+        assert card["artifacts"]["seed_sufficiency_analysis"] is not None
+        assert card["artifacts"]["baseline_table"] is not None
+        assert card["artifacts"]["transfer_delta_table"] is not None
+        assert card["artifacts"]["transfer_delta_figure"] is not None
+
+    def test_markdown_summary_contains_classification(self, tmp_path: Path) -> None:
+        out = tmp_path / "output"
+        run_pipeline(out)
+        md = (out / "package_a_summary.md").read_text(encoding="utf-8")
+        assert "diagnostic" in md
+        assert "#3078" in md
+
+
+class TestPartitionManifestIntegration:
+    """Test with a real shipped partition manifest."""
+
+    def test_with_valid_partition_manifest(self, tmp_path: Path) -> None:
+        manifest = Path("configs/benchmarks/issue_2128_heldout_family_transfer_partitions.yaml")
+        if not manifest.exists():
+            pytest.skip("partition manifest not available in test environment")
+
+        out = tmp_path / "output"
+        payload = run_pipeline(
+            out,
+            partition_manifest=manifest,
+        )
+        assert payload["classification"] == "diagnostic"
+        card = json.loads((out / "claim_card.json").read_text(encoding="utf-8"))
+        assert len(card.get("partition_manifests", [])) == 1
+
+
+class TestRealCampaignPipeline:
+    """Pipeline tests with real fixture campaigns (not synthetic fixtures)."""
+
+    def test_with_real_campaign_roots(self, tmp_path: Path) -> None:
+        c5 = _campaign_fixture(tmp_path / "s5", seed_count=5, planner_snqi=0.72)
+        out = tmp_path / "output"
+        payload = run_pipeline(
+            out,
+            campaign_roots=[c5],
+            heldout_families=["heldout_a"],
+        )
+        assert payload["classification"] == "diagnostic"
+        assert "synthetic_fixture_heldout_used" in payload["reasons"]
+
+        seed_path = out / "seed_sufficiency" / "seed_sufficiency_analysis.json"
+        assert seed_path.is_file()
+        seed_payload = json.loads(seed_path.read_text(encoding="utf-8"))
+        assert seed_payload["schema_version"] == "seed_sufficiency_analysis.v1"


### PR DESCRIPTION
## What / Why

Adds `scripts/tools/run_package_a_pipeline.py`, the canonical entry point that assembles
all Package A deliverables from issue #3078:

- **Seed-sufficiency analysis**: interval widths, rank stability, and interval-width figure via `analyze_seed_sufficiency.py`
- **Baseline table**: per-planner metric means with confidence intervals
- **Transfer-delta table + figure**: benchmark-set vs held-out-family per planner
- **Preliminary claim card**: classification under the issue #3078 fail-closed vocabulary

When real campaign data is absent the pipeline generates synthetic fixture campaigns and
classifies the result as `diagnostic`. When real campaign roots are supplied it still
classifies as `diagnostic` until claim-card review authorizes promotion.

## Deliverables

| Artifact | Artifact | Description |
|---|---|---|
| `pipeline_output.json` | Top-level payload | classification, artifact paths, reasons |
| `seed_sufficiency_analysis.json` | Seed-sufficiency analysis | rank stability, interval widths |
| `baseline_table.csv` | Baseline table | per-planner metric means |
| `transfer_delta.csv` | Transfer delta | benchmark vs held-out per planner |
| `fig_transfer_delta.png` | Transfer-delta figure | bar chart of deltas |
| `claim_card.json` | Preliminary claim card | classification and evidence |
| `package_a_summary.md` | Markdown summary | human-readable report |

## Validation

```
tests/tools/test_run_package_a_pipeline.py: 19 passed
tests/tools/test_analyze_seed_sufficiency.py: 11 passed (no regressions)
tests/validation/test_check_package_a_readiness.py: 18 passed (no regressions)
ruff check: clean
ruff format: applied
```

## What Remains (out of scope for this PR)

- Actual benchmark campaign execution on real data (requires P0 result-store preflight
  resolution and authorized compute submission)
- Promotion of classification from `diagnostic` to `benchmark` or stronger (requires
  claim-card review of real campaign evidence)
- Package B adversarial-falsification and Package C prediction/observation work

Refs #3078

This PR was produced by the SAIA/Qwen3.6-27B cheap implementation lane; the review gate hardens and merges.