### PR TITLE
Issue #4776: improve error messages and document current limitations (cheap-lane worker)

### DIFF
--- a/docs/context/issue_4776_episode_replay_figure_bridge.md
+++ b/docs/context/issue_4776_episode_replay_figure_bridge.md
@@ -170,6 +170,41 @@ Every artifact includes:
 
 Do not use replay-derived figures as evidence of benchmark performance unless the source episode row itself is valid benchmark evidence with full provenance.
 
+## Current Limitations and Future Work
+
+### Re-simulation Not Yet Implemented
+
+**Current state (PR #4796)**: The tool renders replay steps from a pre-existing `replay_steps` field in the episode row. If this field is missing, the tool raises a `ValueError` indicating that trajectory data is required.
+
+**Issue requirement**: The full issue #4776 requires deterministic re-simulation from the recorded seed and planner configuration, not just rendering of pre-recorded steps. This would enable figure generation from any episode row (even those without `replay_steps`) by re-running the episode headless with full-state recording.
+
+**Future work** (successor slice to PR #4796):
+1. Implement headless re-simulation from `scenario_id + seed + planner_config`
+2. Resolve planner configuration via campaign registry or explicit CLI parameters
+3. Record full state during re-simulation for rendering
+4. Assert determinism by comparing re-simulated endpoint to recorded metrics
+5. This would close the gap where campaigns "persist rows but not replayable recordings"
+
+For now, episodes must have `replay_steps` persisted during the original campaign execution to be renderable as figures.
+
+### Determinism Endpoint Comparison
+
+**Current state**: The determinism check compares final robot position when available. This works for rendering-based validation.
+
+**Future work**: When re-simulation is implemented, the comparison should be:
+- Quantitative: compare replay-vs-recorded endpoints with explicit tolerance
+- Comprehensive: check position, success flag, collision flag, and progress metrics
+- Loud failure: report exact drift values when re-simulation diverges
+
+### Input Robustness Hardening
+
+**Current state**: The module already includes:
+- Validation of `final_robot_position` as finite 2-tuple before determinism math (`_parse_final_position`)
+- Filtering of non-finite (NaN/Inf) values during trajectory numeric parsing (`_finite_floats`)
+- Guard against empty `frame_steps` and out-of-range indices in `generate_filmstrip`
+
+These protections were implemented in PR #4796 to address gemini review feedback.
+
 ## Implementation Details
 
 ### Replay Episode Construction

--- a/robot_sf/benchmark/episode_replay_figure.py
+++ b/robot_sf/benchmark/episode_replay_figure.py
@@ -835,8 +835,11 @@ def replay_episode_and_generate_figures(  # noqa: PLR0913
     replay_episode = build_replay_from_episode_row(episode_row)
     if not replay_episode:
         raise ValueError(
-            f"Episode {episode_row.episode_id} has no replay_steps; "
-            "cannot generate figures without trajectory data"
+            f"Episode {episode_row.episode_id} has no replay_steps field in the row; "
+            "cannot generate figures without trajectory data. "
+            "The episode row must include a 'replay_steps' list with robot states. "
+            "Future work will support re-simulation from seed/config when replay_steps "
+            "is not available (see issue #4776 re-simulation bridge)."
         )
 
     if not validate_replay_episode(replay_episode, min_length=2):

--- a/tests/benchmark/test_episode_replay_figure.py
+++ b/tests/benchmark/test_episode_replay_figure.py
@@ -532,14 +532,14 @@ class TestReplayEpisodeAndGenerateFigures:
         assert result["determinism_check_status"] == "skipped"
 
     def test_full_workflow_no_replay_steps(self, output_dir, episodes_jsonl_file):
-        """Test workflow fails without replay steps."""
+        """Test workflow fails without replay steps with helpful error message."""
         row = EpisodeRow(
-            episode_id="test",
+            episode_id="test_missing_replay",
             scenario_id="scen",
             seed=1,
         )
 
-        with pytest.raises(ValueError, match="no replay_steps"):
+        with pytest.raises(ValueError, match="no replay_steps.*Future work will support re-simulation"):
             replay_episode_and_generate_figures(
                 episode_row=row,
                 outputs=["trajectory"],

--- a/tests/benchmark/test_episode_replay_figure.py
+++ b/tests/benchmark/test_episode_replay_figure.py
@@ -539,7 +539,9 @@ class TestReplayEpisodeAndGenerateFigures:
             seed=1,
         )
 
-        with pytest.raises(ValueError, match="no replay_steps.*Future work will support re-simulation"):
+        with pytest.raises(
+            ValueError, match="no replay_steps.*Future work will support re-simulation"
+        ):
             replay_episode_and_generate_figures(
                 episode_row=row,
                 outputs=["trajectory"],


### PR DESCRIPTION
## What

This PR improves the episode replay figure bridge by making current limitations explicit and providing better error messages.

### Changes

1. **Better error message for missing replay_steps** (episode_replay_figure.py:836-841)
   - When an episode row lacks the `replay_steps` field, the error message now clearly explains this is a current limitation
   - References future re-simulation work from issue #4776
   - Helps users understand why figure generation fails and what would be needed

2. **Updated test coverage** (test_episode_replay_figure.py:534-548)
   - Enhanced test for missing replay_steps to verify the improved error message
   - Test now checks for the specific helpful error pattern including "Future work will support re-simulation"

3. **Documentation additions** (docs/context/issue_4776_episode_replay_figure_bridge.md)
   - Added "Current Limitations and Future Work" section documenting:
     - Re-simulation not yet implemented (current state vs requirement)
     - Determinism endpoint comparison current state and future needs  
     - Input robustness hardening already completed in PR #4796

## Why

PR #4796 implemented the figure/provenance layer that renders pre-existing `replay_steps` from episode rows. However, the full issue #4776 requires deterministic re-simulation from seed/config when `replay_steps` is not available. This PR improves usability by making the current limitation clear and documenting what future work is needed.

## Validation

```bash
# 42 tests pass
$ uv run pytest tests/benchmark/test_episode_replay_figure.py -q
..........................................                               [100%]
42 passed in 3.05s

# Ruff checks pass  
$ uv run ruff check scripts/replay_episode_figure.py robot_sf/benchmark/episode_replay_figure.py tests/benchmark/test_episode_replay_figure.py
All checks passed!
```

## Claim boundary

Documentation and usability improvements only. Does not implement re-simulation (remains future work per issue #4776). No benchmark or paper-facing claims.

## Successor statement

This is a successor slice to PR #4796. It does NOT implement the re-simulation bridge (issue keystone). The full deterministic re-simulation from seed/config with endpoint comparison remains as future work for a subsequent PR.

Refs #4776 (does not close — re-simulation bridge remains outstanding)

---
This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section describing current limitations, future improvements, and input robustness safeguards for episode replay figures.

* **Bug Fixes**
  * Improved the error message shown when replay data is missing, making it clearer why figures can’t be generated and what may be supported later.

* **Tests**
  * Updated coverage to verify the more helpful missing-replay-data error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->