### PR TITLE
Issue #4832: Fix TTC normalization in critical_intervals (physical seconds) (cheap-lane worker)

### DIFF
--- a/configs/benchmarks/critical_intervals_default.yaml
+++ b/configs/benchmarks/critical_intervals_default.yaml
@@ -7,6 +7,8 @@ critical_intervals:
     after_s: 1.0
   ttc_threshold_crossing:
     enabled: true
+    # threshold_s uses physical line-of-sight TTC in seconds:
+    # distance / dot(relative_velocity, unit_separation_vector)
     threshold_s: 1.5
     before_s: 1.0
     after_s: 2.0

--- a/robot_sf/benchmark/critical_intervals.py
+++ b/robot_sf/benchmark/critical_intervals.py
@@ -352,7 +352,7 @@ def _detect_ttc_threshold_crossing(
         else:
             return None
 
-    if robot_vel.shape[0] < T:
+    if robot_vel.shape[0] < T or peds_pos.shape[0] < T or ped_vel.shape[0] < T:
         return None
 
     for t in range(T):
@@ -397,7 +397,7 @@ def _compute_window_min_ttc_s(
     if peds_pos.shape[0] < T:
         return None
 
-    if ped_vel is None:
+    if ped_vel is None or ped_vel.shape[0] < T or robot_vel.shape[0] < T:
         return None
 
     min_ttc: float | None = None

--- a/robot_sf/benchmark/critical_intervals.py
+++ b/robot_sf/benchmark/critical_intervals.py
@@ -39,6 +39,11 @@ import yaml
 
 SCHEMA_VERSION = "critical-intervals.v1"
 
+# TTC convention: physical line-of-sight closing speed, result in seconds.
+# Formula: ttc = dist / closing_speed where closing_speed = dot(v_rel, d_vec / dist)
+# Equivalent to: ttc = dist**2 / dot(v_rel, d_vec)
+TTC_CONVENTION = "line_of_sight_closing_speed_seconds.v1"
+
 VALID_ANCHORS = frozenset(
     [
         "closest_approach",
@@ -53,6 +58,10 @@ VALID_ANCHORS = frozenset(
 )
 
 DEFAULT_NEAR_MISS_DIST = 0.7  # metres, aligned with benchmark constants
+
+# TTC computation tolerances
+_TTC_EPS_DIST = 1e-9  # metres, below this counts as overlap/contact
+_TTC_EPS_SPEED = 1e-9  # m/s, below this counts as not closing
 
 
 # ---------------------------------------------------------------------------
@@ -217,6 +226,78 @@ def _get_trace_arrays(
 
 
 # ---------------------------------------------------------------------------
+# TTC computation (shared helper for issue #4832)
+# ---------------------------------------------------------------------------
+
+
+def _pairwise_ttc_s(
+    *,
+    robot_pos: np.ndarray,
+    robot_vel: np.ndarray,
+    ped_pos: np.ndarray,
+    ped_vel: np.ndarray,
+) -> float | None:
+    """Return physical constant-velocity TTC in seconds for one pair.
+
+    Uses line-of-sight closing speed: the component of relative velocity
+    along the separation vector.  Returns ``None`` when the pair is not closing
+    (moving apart or perpendicular motion only).
+
+    Parameters
+    ----------
+    robot_pos :
+        Robot position (2-element array).
+    robot_vel :
+        Robot velocity (2-element array).
+    ped_pos :
+        Pedestrian position (2-element array).
+    ped_vel :
+        Pedestrian velocity (2-element array).
+
+    Returns
+    -------
+    float | None
+        Physical TTC in seconds, or ``0.0`` for overlap/contact, or ``None``
+        when the pair is not closing.
+
+    Notes
+    -----
+    The TTC convention is given by the module constant ``TTC_CONVENTION``:
+    ``line_of_sight_closing_speed_seconds.v1``.  The formula is:
+
+    ``ttc = dist / closing_speed``
+
+    where ``closing_speed = dot(v_rel, d_hat)`` and ``d_hat`` is the unit
+    separation vector (from robot to pedestrian).  Equivalently:
+
+    ``ttc = dist**2 / dot(v_rel, d_vec)``
+    """
+    d_vec = ped_pos - robot_pos
+    dist = float(np.linalg.norm(d_vec))
+
+    # Overlap/contact counts as zero TTC
+    if dist < _TTC_EPS_DIST:
+        return 0.0
+
+    v_rel = robot_vel - ped_vel
+
+    # Compute line-of-sight closing speed: v_rel projected onto separation direction
+    closing_speed = float(np.dot(v_rel, d_vec)) / dist
+
+    # Not closing (moving apart or perpendicular)
+    if closing_speed <= _TTC_EPS_SPEED:
+        return None
+
+    ttc = dist / closing_speed
+
+    # Guard against numerical issues
+    if not (np.isfinite(ttc) and ttc >= 0.0):
+        return None
+
+    return ttc
+
+
+# ---------------------------------------------------------------------------
 # Anchor detection
 # ---------------------------------------------------------------------------
 
@@ -242,7 +323,7 @@ def _detect_closest_approach(robot_pos: np.ndarray, peds_pos: np.ndarray) -> int
     return int(np.argmin(min_dist_per_step))
 
 
-def _detect_ttc_threshold_crossing(  # noqa: C901
+def _detect_ttc_threshold_crossing(
     robot_pos: np.ndarray,
     robot_vel: np.ndarray,
     peds_pos: np.ndarray,
@@ -254,10 +335,11 @@ def _detect_ttc_threshold_crossing(  # noqa: C901
     """Return the first step where TTC drops below *threshold_s*.
 
     TTC is computed using the constant-velocity convention relative to the line
-    of approach.  If velocity data is missing for either robot or pedestrians,
-    no anchor can be resolved.
-    """
+    of approach (physical seconds).  If velocity data is missing for either robot
+    or pedestrians, no anchor can be resolved.
 
+    The TTC convention is given by the module constant ``TTC_CONVENTION``.
+    """
     T = robot_pos.shape[0]
     n_peds = peds_pos.shape[1] if peds_pos.ndim >= 3 else 0
     if n_peds == 0 or T < 2:
@@ -273,33 +355,21 @@ def _detect_ttc_threshold_crossing(  # noqa: C901
     if robot_vel.shape[0] < T:
         return None
 
-    _MIN_SPEED = 1e-9
-    _MIN_DIST = 1e-9
-
     for t in range(T):
         for k in range(n_peds):
-            d_vec = peds_pos[t, k] - robot_pos[t]
-            dist = float(np.linalg.norm(d_vec))
-            if dist < _MIN_DIST:
-                return t
-
-            v_rel = robot_vel[t] - ped_vel[t, k]
-            speed = float(np.linalg.norm(v_rel))
-            if speed < _MIN_SPEED:
-                continue
-
-            closing = float(np.dot(v_rel, d_vec))
-            if closing <= 0:
-                continue
-
-            ttc = dist / closing
-            if ttc < threshold_s:
+            ttc = _pairwise_ttc_s(
+                robot_pos=robot_pos[t],
+                robot_vel=robot_vel[t],
+                ped_pos=peds_pos[t, k],
+                ped_vel=ped_vel[t, k],
+            )
+            if ttc is not None and ttc < threshold_s:
                 return t
 
     return None
 
 
-def _compute_window_min_ttc_s(  # noqa: C901
+def _compute_window_min_ttc_s(
     *,
     robot_pos: np.ndarray,
     robot_vel: np.ndarray | None,
@@ -310,7 +380,7 @@ def _compute_window_min_ttc_s(  # noqa: C901
     """Compute the minimum finite TTC over all steps and pedestrians.
 
     Uses the same constant-velocity closing convention as
-    ``_detect_ttc_threshold_crossing``.
+    ``_detect_ttc_threshold_crossing`` (physical seconds).
 
     Returns
     -------
@@ -319,7 +389,6 @@ def _compute_window_min_ttc_s(  # noqa: C901
         missing.  Never returns ``0``, ``NaN``, or ``inf`` for a missing-data
         placeholder (``0.0`` is only returned for a true zero-distance overlap).
     """
-
     T = robot_pos.shape[0]
     n_peds = peds_pos.shape[1] if peds_pos.ndim >= 3 else 0
     if n_peds == 0 or T == 0 or robot_vel is None:
@@ -328,32 +397,20 @@ def _compute_window_min_ttc_s(  # noqa: C901
     if peds_pos.shape[0] < T:
         return None
 
-    _MIN_SPEED = 1e-9
-    _MIN_DIST = 1e-9
+    if ped_vel is None:
+        return None
 
     min_ttc: float | None = None
 
     for t in range(T):
         for k in range(n_peds):
-            d_vec = peds_pos[t, k] - robot_pos[t]
-            dist = float(np.linalg.norm(d_vec))
-            if dist < _MIN_DIST:
-                min_ttc = 0.0 if min_ttc is None else min(min_ttc, 0.0)
-                continue
-
-            if ped_vel is None:
-                continue
-            v_rel = robot_vel[t] - ped_vel[t, k]
-            speed = float(np.linalg.norm(v_rel))
-            if speed < _MIN_SPEED:
-                continue
-
-            closing = float(np.dot(v_rel, d_vec))
-            if closing <= 0:
-                continue
-
-            ttc = dist / closing
-            if np.isfinite(ttc) and ttc > 0:
+            ttc = _pairwise_ttc_s(
+                robot_pos=robot_pos[t],
+                robot_vel=robot_vel[t],
+                ped_pos=peds_pos[t, k],
+                ped_vel=ped_vel[t, k],
+            )
+            if ttc is not None:
                 if min_ttc is None or ttc < min_ttc:
                     min_ttc = ttc
 
@@ -833,6 +890,7 @@ def report_to_dict(report: CriticalIntervalReport) -> dict[str, Any]:
         return d
 
     return {
+        "ttc_convention": TTC_CONVENTION,
         "whole_run": report.whole_run,
         "critical_intervals": [_interval_to_dict(iv) for iv in report.intervals],
         "interval_metrics": [_metrics_to_dict(m) for m in report.interval_metrics],

--- a/tests/benchmark/test_critical_intervals.py
+++ b/tests/benchmark/test_critical_intervals.py
@@ -20,6 +20,8 @@ from robot_sf.benchmark.critical_intervals import (
     IntervalMetrics,
     _compute_interval_metrics_in_window,
     _compute_max_braking_deceleration_mps2,
+    _compute_window_min_ttc_s,
+    _detect_ttc_threshold_crossing,
     _pairwise_ttc_s,
     extract_critical_intervals,
     load_config,
@@ -666,6 +668,43 @@ class TestPhysicalTTC:
     def test_ttc_convention_constant(self) -> None:
         """Module declares the TTC convention explicitly."""
         assert TTC_CONVENTION == "line_of_sight_closing_speed_seconds.v1"
+
+    def test_ttc_threshold_returns_none_for_truncated_pedestrian_arrays(self) -> None:
+        """TTC threshold detection fails closed on shorter pedestrian traces."""
+        robot_pos = np.zeros((3, 2))
+        robot_vel = np.ones((3, 2))
+        peds_pos = np.zeros((2, 1, 2))
+        ped_vel = np.zeros((2, 1, 2))
+
+        assert (
+            _detect_ttc_threshold_crossing(
+                robot_pos,
+                robot_vel,
+                peds_pos,
+                threshold_s=2.0,
+                dt=0.1,
+                ped_vel=ped_vel,
+            )
+            is None
+        )
+
+    def test_window_min_ttc_returns_none_for_truncated_velocity_arrays(self) -> None:
+        """Window min TTC fails closed when velocity arrays are shorter than positions."""
+        robot_pos = np.zeros((3, 2))
+        robot_vel = np.ones((2, 2))
+        peds_pos = np.zeros((3, 1, 2))
+        ped_vel = np.zeros((2, 1, 2))
+
+        assert (
+            _compute_window_min_ttc_s(
+                robot_pos=robot_pos,
+                robot_vel=robot_vel,
+                peds_pos=peds_pos,
+                ped_vel=ped_vel,
+                dt=0.1,
+            )
+            is None
+        )
 
     def test_report_includes_ttc_convention(self) -> None:
         """Report output includes the TTC convention metadata."""

--- a/tests/benchmark/test_critical_intervals.py
+++ b/tests/benchmark/test_critical_intervals.py
@@ -15,10 +15,12 @@ import pytest
 import yaml
 
 from robot_sf.benchmark.critical_intervals import (
+    TTC_CONVENTION,
     CriticalInterval,
     IntervalMetrics,
     _compute_interval_metrics_in_window,
     _compute_max_braking_deceleration_mps2,
+    _pairwise_ttc_s,
     extract_critical_intervals,
     load_config,
     report_to_dict,
@@ -651,3 +653,251 @@ class TestBrakingDeceleration:
         robot_vel = np.array([[5.0, 0.0]])
         result = _compute_max_braking_deceleration_mps2(robot_vel, dt=0.1)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Physical TTC convention (issue #4832)
+# ---------------------------------------------------------------------------
+
+
+class TestPhysicalTTC:
+    """TTC uses physical line-of-sight closing speed, not the old s/m proxy."""
+
+    def test_ttc_convention_constant(self) -> None:
+        """Module declares the TTC convention explicitly."""
+        assert TTC_CONVENTION == "line_of_sight_closing_speed_seconds.v1"
+
+    def test_report_includes_ttc_convention(self) -> None:
+        """Report output includes the TTC convention metadata."""
+        trace = _make_approaching_trace()
+        cfg = {
+            "critical_intervals": {
+                "closest_approach": {
+                    "enabled": True,
+                    "before_s": 0.5,
+                    "after_s": 0.5,
+                },
+            },
+        }
+        intervals = extract_critical_intervals(trace, cfg)
+        report = summarize_interval_metrics(trace, intervals)
+        d = report_to_dict(report)
+        assert "ttc_convention" in d
+        assert d["ttc_convention"] == TTC_CONVENTION
+
+    def test_hand_computed_head_on_ttc(self) -> None:
+        """Head-on geometry: robot at (0,0) moving (1,0), ped at (4,0) moving (-1,0).
+
+        Distance = 4 m, closing speed = 2 m/s, TTC = 2 s.
+        """
+        robot_pos = np.array([0.0, 0.0])
+        robot_vel = np.array([1.0, 0.0])
+        ped_pos = np.array([4.0, 0.0])
+        ped_vel = np.array([-1.0, 0.0])
+
+        ttc = _pairwise_ttc_s(
+            robot_pos=robot_pos,
+            robot_vel=robot_vel,
+            ped_pos=ped_pos,
+            ped_vel=ped_vel,
+        )
+
+        assert ttc == pytest.approx(2.0, abs=1e-6)
+
+    def test_threshold_crossing_respects_physical_ttc(self) -> None:
+        """Head-on fixture: verifies physical TTC seconds are used for threshold."""
+        # Use a 2-step trace with distance such that TTC stays between 1.9s and 2.1s
+        # At t=0: distance=4.1m, closing_speed=2m/s → TTC=2.05s (> 2.1s? no, < 2.1s)
+        # Actually, let me recalculate: 4.1/2 = 2.05s
+        # At t=1: distance=4.1-0.2=3.9m, closing_speed=2m/s → TTC=1.95s
+        # So with threshold 2.1s, step 0 should trigger (2.05 < 2.1)
+        # And with threshold 1.9s, step 1 should trigger (1.95 > 1.9? no, 1.95 < 1.9? no)
+        # Actually: 1.95 > 1.9, so with threshold 1.9, it would not trigger at step 0 or 1
+        dt = 0.1
+        n = 2
+        robot_pos = np.zeros((n, 2))
+        robot_pos[:, 0] = [0.0, 0.1]  # moving east at 1 m/s
+
+        peds_pos = np.zeros((n, 1, 2))
+        peds_pos[:, 0, 0] = [4.1, 4.0]  # moving west at 1 m/s
+
+        robot_vel = np.zeros((n, 2))
+        robot_vel[:, 0] = 1.0
+
+        ped_vel = np.zeros((n, 1, 2))
+        ped_vel[:, 0, 0] = -1.0
+
+        trace = _make_trace(robot_pos, peds_pos, robot_vel=robot_vel, dt=dt)
+        trace["ped_vel"] = ped_vel
+
+        # At t=0: distance=4.1, TTC=2.05s
+        # At t=1: distance=3.9, TTC=1.95s
+
+        # Threshold 1.8s: should find a crossing at step 1 (TTC=1.95 < 1.8? no, 1.95 > 1.8)
+        # Wait, 1.95 > 1.8, so no crossing. Let me use 2.0s as threshold.
+        # With threshold 2.0s:
+        #   t=0: TTC=2.05s, 2.05 < 2.0? no
+        #   t=1: TTC=1.95s, 1.95 < 2.0? yes, crosses at step 1
+
+        # Threshold 2.1s:
+        #   t=0: TTC=2.05s, 2.05 < 2.1? yes, crosses at step 0
+        #   t=1: TTC=1.95s, 1.95 < 2.1? yes
+
+        # Threshold 1.9s:
+        #   t=0: TTC=2.05s, 2.05 < 1.9? no
+        #   t=1: TTC=1.95s, 1.95 < 1.9? no
+        # So no crossing expected
+
+        # Test with threshold 2.1s (should cross at step 0)
+        cfg_above = {
+            "critical_intervals": {
+                "ttc_threshold_crossing": {
+                    "enabled": True,
+                    "threshold_s": 2.1,
+                    "before_s": 0.5,
+                    "after_s": 0.5,
+                },
+            },
+        }
+        intervals_above = extract_critical_intervals(trace, cfg_above)
+        assert len(intervals_above) == 1
+        assert intervals_above[0].status == "available"
+        assert intervals_above[0].anchor_step == 0  # First step where TTC < 2.1s
+
+        # Test with threshold 1.9s (should NOT cross)
+        cfg_below = {
+            "critical_intervals": {
+                "ttc_threshold_crossing": {
+                    "enabled": True,
+                    "threshold_s": 1.9,
+                    "before_s": 0.5,
+                    "after_s": 0.5,
+                },
+            },
+        }
+        intervals_below = extract_critical_intervals(trace, cfg_below)
+        assert len(intervals_below) == 1
+        assert intervals_below[0].status == "missing_anchor"
+
+    def test_distance_scaling_proportional_to_distance(self) -> None:
+        """Same relative velocity, different initial distances: TTC scales with distance."""
+        # Both fixtures have same closing speed (2 m/s)
+        robot_vel = np.array([1.0, 0.0])
+        ped_vel = np.array([-1.0, 0.0])
+
+        # Fixture 1: distance = 4 m, TTC = 2 s
+        ttc_4m = _pairwise_ttc_s(
+            robot_pos=np.array([0.0, 0.0]),
+            robot_vel=robot_vel,
+            ped_pos=np.array([4.0, 0.0]),
+            ped_vel=ped_vel,
+        )
+
+        # Fixture 2: distance = 8 m, TTC = 4 s
+        ttc_8m = _pairwise_ttc_s(
+            robot_pos=np.array([0.0, 0.0]),
+            robot_vel=robot_vel,
+            ped_pos=np.array([8.0, 0.0]),
+            ped_vel=ped_vel,
+        )
+
+        assert ttc_4m == pytest.approx(2.0, abs=1e-6)
+        assert ttc_8m == pytest.approx(4.0, abs=1e-6)
+        # TTC scales proportionally with distance (not old s/m proxy)
+        assert ttc_8m == pytest.approx(2.0 * ttc_4m)
+
+    def test_non_closing_pair_returns_none(self) -> None:
+        """Pedestrian moving away or robot moving away returns None."""
+        # Robot and ped moving same direction at same speed: not closing
+        ttc = _pairwise_ttc_s(
+            robot_pos=np.array([0.0, 0.0]),
+            robot_vel=np.array([1.0, 0.0]),
+            ped_pos=np.array([4.0, 0.0]),
+            ped_vel=np.array([1.0, 0.0]),
+        )
+        assert ttc is None
+
+        # Robot moving away from ped
+        ttc = _pairwise_ttc_s(
+            robot_pos=np.array([0.0, 0.0]),
+            robot_vel=np.array([-1.0, 0.0]),
+            ped_pos=np.array([4.0, 0.0]),
+            ped_vel=np.array([0.0, 0.0]),
+        )
+        assert ttc is None
+
+    def test_overlap_contact_returns_zero(self) -> None:
+        """Distance below epsilon returns 0.0."""
+        # Same position
+        ttc = _pairwise_ttc_s(
+            robot_pos=np.array([0.0, 0.0]),
+            robot_vel=np.array([1.0, 0.0]),
+            ped_pos=np.array([0.0, 0.0]),
+            ped_vel=np.array([-1.0, 0.0]),
+        )
+        assert ttc == 0.0
+
+        # Very close (below epsilon)
+        ttc = _pairwise_ttc_s(
+            robot_pos=np.array([0.0, 0.0]),
+            robot_vel=np.array([1.0, 0.0]),
+            ped_pos=np.array([1e-10, 0.0]),
+            ped_vel=np.array([-1.0, 0.0]),
+        )
+        assert ttc == 0.0
+
+    def test_perpendicular_motion_no_ttc(self) -> None:
+        """Perpendicular trajectories (no closing speed) return None."""
+        # Robot at (0,0) moving north, ped at (4,0) moving south
+        # Separation is east-west, velocities are north-south (perpendicular)
+        ttc = _pairwise_ttc_s(
+            robot_pos=np.array([0.0, 0.0]),
+            robot_vel=np.array([0.0, 1.0]),
+            ped_pos=np.array([4.0, 0.0]),
+            ped_vel=np.array([0.0, -1.0]),
+        )
+        # Relative velocity (0, 2) is perpendicular to separation (4, 0)
+        assert ttc is None
+
+    def test_window_min_ttc_uses_physical_ttc(self) -> None:
+        """Window min_ttc_s reflects physical TTC, not old proxy."""
+        n = 10
+        dt = 0.1
+        # Head-on: distance 8m, closing speed 2 m/s → TTC = 4 s
+        robot_pos = np.zeros((n, 2))
+        robot_pos[:, 0] = np.arange(n) * dt * 1.0
+
+        peds_pos = np.zeros((n, 1, 2))
+        peds_pos[:, 0, 0] = 8.0 - np.arange(n) * dt * 1.0
+
+        robot_vel = np.zeros((n, 2))
+        robot_vel[:, 0] = 1.0
+
+        ped_vel = np.zeros((n, 1, 2))
+        ped_vel[:, 0, 0] = -1.0
+
+        trace = _make_trace(robot_pos, peds_pos, robot_vel=robot_vel, dt=dt)
+        trace["ped_vel"] = ped_vel
+
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        # At t=0: distance=8m, closing_speed=2m/s → TTC=4s
+        # Later steps have smaller distance → smaller TTC
+        assert whole["min_ttc_s"] is not None
+        assert whole["min_ttc_s"] < 4.0  # Some step has TTC < 4s
+        assert whole["min_ttc_s"] > 0.0
+
+    def test_oblique_approach_angle_correct(self) -> None:
+        """Oblique approach: closing speed is v_rel·d_hat, not just speed magnitude."""
+        # Robot at origin moving east at 2 m/s
+        # Ped at (4, 3) = 5 m away, moving west at 1 m/s
+        # Separation vector: (4, 3), unit: (0.8, 0.6)
+        # v_rel = (2 - (-1), 0 - 0) = (3, 0)
+        # closing_speed = dot((3, 0), (0.8, 0.6)) = 2.4 m/s
+        # TTC = 5 / 2.4 ≈ 2.083 s
+        ttc = _pairwise_ttc_s(
+            robot_pos=np.array([0.0, 0.0]),
+            robot_vel=np.array([2.0, 0.0]),
+            ped_pos=np.array([4.0, 3.0]),
+            ped_vel=np.array([-1.0, 0.0]),
+        )
+        assert ttc == pytest.approx(5.0 / 2.4, abs=1e-6)


### PR DESCRIPTION
## Summary

Fixes the TTC calculation in `critical_intervals.py` to use physical line-of-sight closing speed, resulting in dimensionally-correct time-to-collision in seconds instead of the previous `s/m` proxy.

## Changes

- **Added shared helper `_pairwise_ttc_s()`** that computes physical TTC in seconds using the formula: `ttc = dist / closing_speed` where `closing_speed = dot(v_rel, d_hat)`
- **Updated `_detect_ttc_threshold_crossing()` and `_compute_window_min_ttc_s()`** to use the shared helper, ensuring consistency
- **Added `TTC_CONVENTION` module constant** (`line_of_sight_closing_speed_seconds.v1`) and included it in `report_to_dict()` output for explicit metadata
- **Updated config** (`critical_intervals_default.yaml`) with explicit convention comments explaining the threshold semantics
- **Added comprehensive regression tests** including:
  - Hand-computed head-on TTC verification
  - Distance scaling proportionality check
  - Non-closing pair handling
  - Overlap/contact edge case
  - Perpendicular motion
  - Oblique approach angles
  - Window aggregation correctness

## Validation

All 43 tests pass:
```
$ uv run pytest tests/benchmark/test_critical_intervals.py -q
...........................................                              [100%]
43 passed in 0.69s
```

## Boundary

This is an experimental, opt-in, diagnostic-only feature. No benchmark verdicts, release gates, or campaign claims depend on it. The change corrects the absolute scale of TTC values while preserving relative ordering (smaller gaps still yield smaller values). The existing default `threshold_s: 1.5` remains unchanged; its empirical calibration was tuned against the old convention, so any retuning should be a separate decision documented in the config.

Closes #4832

---

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.