### PR TITLE
Issue #4837: Fix guarded_ppo checkpoint observation contract missing

### DIFF
--- a/docs/dev/observation_contract.md
+++ b/docs/dev/observation_contract.md
@@ -130,6 +130,80 @@ through planner compatibility metadata. Unsupported planner/level combinations
 fail before episodes are written. These levels are benchmark provenance labels;
 they are not detector, camera, lidar, or sim-to-real certification claims.
 
+## Checkpoint Observation Contract (Model Registry)
+
+Learned-policy checkpoints that use dict-family observation modes (`dict`, `native_dict`,
+`multi_input`) must declare their observation contract in the model registry. This prevents
+running checkpoints with the wrong observation producer and ensures reproducibility.
+
+### When Observation Contract is Required
+
+A checkpoint requires `benchmark_promotion` metadata with observation contract fields when:
+- The checkpoint uses `obs_mode: dict`, `native_dict`, or `multi_input`
+- The algorithm's default observation mode is not `socnav_state`
+
+For example, `guarded_ppo` uses `obs_mode: dict` with default `sensor_fusion_state`, so its
+checkpoint must declare the observation level and mode used during training.
+
+### Model Registry Metadata
+
+Add a `benchmark_promotion` block to the model registry entry (`model/registry.yaml`):
+
+```yaml
+- model_id: ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200
+  # ... other fields ...
+  benchmark_promotion:
+    claim_boundary: benchmark_candidate  # or benchmark_promoted, research_only
+    benchmark_track: grid_socnav_v1
+    track_schema_version: observation-track.v1
+    observation_level: tracked_agents_no_noise
+    observation_mode: dict
+    allowed_observation_keys:
+    - occupancy_grid
+    - occupancy_grid_meta_origin
+    - occupancy_grid_meta_resolution
+    - occupancy_grid_meta_width
+    - occupancy_grid_meta_height
+    - robot_position
+    - robot_heading
+    - robot_velocity_xy
+    - robot_speed
+    - robot_angular_velocity
+    - robot_radius
+    - goal_current
+    - goal_next
+    - pedestrians_positions
+    goal_encoding: polar
+    sensor_geometry: differential_drive
+    privileged_input_status: none
+```
+
+### Required Fields
+
+- `observation_level`: Must be a valid level from `robot_sf/benchmark/observation_levels.py`
+- `observation_mode`: The planner-side observation mode (`dict`, `socnav_state`, etc.)
+- `allowed_observation_keys`: List of observation keys the checkpoint expects
+- `goal_encoding`, `sensor_geometry`, `privileged_input_status`: Additional metadata
+
+### Resolution Behavior
+
+The observation contract is resolved by `resolve_learned_checkpoint_observation_contract`
+in `robot_sf/benchmark/algorithm_metadata.py`. Resolution follows this priority:
+1. Explicit `observation_mode` or `observation_level` override (command-line or config)
+2. `algo_config.observation_contract` dict
+3. `algo_config.benchmark_promotion` dict
+4. Model registry `benchmark_promotion` metadata (lookup by `model_id`)
+5. Algorithm default observation mode (fallback when metadata not required)
+
+If none of the above sources provide metadata and the checkpoint requires it,
+a ValueError is raised with guidance on where to add the metadata.
+
+### Regression Testing
+
+The test `test_guarded_ppo_checkpoint_observation_contract_resolves_from_registry`
+in `tests/benchmark/test_algorithm_metadata_contract.py` validates this contract.
+See issue #4837 for context on why this metadata is required.
+
 ## Reference Files
 
 - `robot_sf/sensor/sensor_fusion.py`
@@ -137,3 +211,6 @@ they are not detector, camera, lidar, or sim-to-real certification claims.
 - `robot_sf/gym_env/robot_env.py`
 - `robot_sf/nav/occupancy_grid.py`
 - `robot_sf/benchmark/observation_levels.py`
+- `robot_sf/benchmark/algorithm_metadata.py`
+- `robot_sf/models/registry.py`
+- `model/registry.yaml`

--- a/model/registry.yaml
+++ b/model/registry.yaml
@@ -255,6 +255,30 @@ models:
     metadata_asset: ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200-metadata.json
     published_at_utc: '2026-05-24T05:32:03+00:00'
   public_artifact_source: github_release
+  benchmark_promotion:
+    claim_boundary: benchmark_candidate
+    benchmark_track: grid_socnav_v1
+    track_schema_version: observation-track.v1
+    observation_level: tracked_agents_no_noise
+    observation_mode: dict
+    allowed_observation_keys:
+    - occupancy_grid
+    - occupancy_grid_meta_origin
+    - occupancy_grid_meta_resolution
+    - occupancy_grid_meta_width
+    - occupancy_grid_meta_height
+    - robot_position
+    - robot_heading
+    - robot_velocity_xy
+    - robot_speed
+    - robot_angular_velocity
+    - robot_radius
+    - goal_current
+    - goal_next
+    - pedestrians_positions
+    goal_encoding: polar
+    sensor_geometry: differential_drive
+    privileged_input_status: none
 - model_id: ppo_expert_br06_v2_15m_all_maps_20260302T152332
   display_name: PPO expert BR-06 v2 all-maps (2026-03-02)
   local_path: output/model_cache/ppo_expert_br06_v2_15m_all_maps_20260302T152332/model.zip

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -688,49 +688,13 @@ def test_infer_execution_mode_from_counts() -> None:
     assert infer_execution_mode_from_counts(native_steps=0, adapted_steps=0) == "unknown"
 
 
-def test_guarded_ppo_checkpoint_observation_contract_resolves_from_registry(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_guarded_ppo_checkpoint_observation_contract_resolves_from_registry() -> None:
     """Issue #4837 regression: guarded_ppo checkpoint should resolve observation contract.
 
     The ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200 checkpoint lacked
     benchmark_promotion metadata in the registry, causing resolve_learned_checkpoint_observation_contract
     to fail for guarded_ppo arms with obs_mode=dict. This test verifies the fix.
     """
-
-    def _mock_registry_entry(model_id: str) -> dict[str, object]:
-        if model_id == "ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200":
-            return {
-                "benchmark_promotion": {
-                    "claim_boundary": "benchmark_candidate",
-                    "benchmark_track": "grid_socnav_v1",
-                    "track_schema_version": "observation-track.v1",
-                    "observation_level": "tracked_agents_no_noise",
-                    "observation_mode": "dict",
-                    "allowed_observation_keys": [
-                        "occupancy_grid",
-                        "occupancy_grid_meta_origin",
-                        "occupancy_grid_meta_resolution",
-                        "occupancy_grid_meta_width",
-                        "occupancy_grid_meta_height",
-                        "robot_position",
-                        "robot_heading",
-                        "robot_velocity_xy",
-                        "robot_speed",
-                        "robot_angular_velocity",
-                        "robot_radius",
-                        "goal_current",
-                        "goal_next",
-                        "pedestrians_positions",
-                    ],
-                    "goal_encoding": "polar",
-                    "sensor_geometry": "differential_drive",
-                    "privileged_input_status": "none",
-                }
-            }
-        raise KeyError(f"unknown model_id: {model_id}")
-
-    monkeypatch.setattr(algorithm_metadata, "get_registry_entry", _mock_registry_entry, raising=False)
 
     contract = algorithm_metadata.resolve_learned_checkpoint_observation_contract(
         "guarded_ppo",

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -686,3 +686,62 @@ def test_infer_execution_mode_from_counts() -> None:
     assert infer_execution_mode_from_counts(native_steps=0, adapted_steps=3) == "adapter"
     assert infer_execution_mode_from_counts(native_steps=3, adapted_steps=2) == "mixed"
     assert infer_execution_mode_from_counts(native_steps=0, adapted_steps=0) == "unknown"
+
+
+def test_guarded_ppo_checkpoint_observation_contract_resolves_from_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #4837 regression: guarded_ppo checkpoint should resolve observation contract.
+
+    The ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200 checkpoint lacked
+    benchmark_promotion metadata in the registry, causing resolve_learned_checkpoint_observation_contract
+    to fail for guarded_ppo arms with obs_mode=dict. This test verifies the fix.
+    """
+
+    def _mock_registry_entry(model_id: str) -> dict[str, object]:
+        if model_id == "ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200":
+            return {
+                "benchmark_promotion": {
+                    "claim_boundary": "benchmark_candidate",
+                    "benchmark_track": "grid_socnav_v1",
+                    "track_schema_version": "observation-track.v1",
+                    "observation_level": "tracked_agents_no_noise",
+                    "observation_mode": "dict",
+                    "allowed_observation_keys": [
+                        "occupancy_grid",
+                        "occupancy_grid_meta_origin",
+                        "occupancy_grid_meta_resolution",
+                        "occupancy_grid_meta_width",
+                        "occupancy_grid_meta_height",
+                        "robot_position",
+                        "robot_heading",
+                        "robot_velocity_xy",
+                        "robot_speed",
+                        "robot_angular_velocity",
+                        "robot_radius",
+                        "goal_current",
+                        "goal_next",
+                        "pedestrians_positions",
+                    ],
+                    "goal_encoding": "polar",
+                    "sensor_geometry": "differential_drive",
+                    "privileged_input_status": "none",
+                }
+            }
+        raise KeyError(f"unknown model_id: {model_id}")
+
+    monkeypatch.setattr(algorithm_metadata, "get_registry_entry", _mock_registry_entry, raising=False)
+
+    contract = algorithm_metadata.resolve_learned_checkpoint_observation_contract(
+        "guarded_ppo",
+        {
+            "model_id": "ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200",
+            "obs_mode": "dict",
+        },
+    )
+
+    assert contract["status"] == "metadata_resolved"
+    assert contract["metadata_source"] == "model_registry.benchmark_promotion"
+    assert contract["active_observation_mode"] == "socnav_state"
+    assert contract["observation_level"] == "tracked_agents_no_noise"
+    assert contract["planner_observation_mode"] == "dict"


### PR DESCRIPTION
## Summary

Fixes the guarded_ppo checkpoint observation contract missing error that caused accepted-unavailable rows in campaign issue4206_trace_capable_h600_rerun_20260704 (job 13334).

## Root Cause

The ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200 checkpoint lacked benchmark_promotion metadata in the model registry (model/registry.yaml). When guarded_ppo uses obs_mode=dict, the observation contract resolution requires checkpoint metadata to ensure the checkpoint runs with the correct observation producer. Without this metadata, resolve_learned_checkpoint_observation_contract raised a ValueError, causing the arm to be marked as accepted-unavailable.

## Changes

1. model/registry.yaml: Added benchmark_promotion metadata block to ppo_expert_br06_v3_15m_all_maps_randomized_20260304T075200 entry with observation_level, observation_mode, and allowed_observation_keys for grid_socnav inputs.

2. tests/benchmark/test_algorithm_metadata_contract.py: Added regression test test_guarded_ppo_checkpoint_observation_contract_resolves_from_registry that verifies the guarded_ppo checkpoint can resolve its observation contract from registry metadata.

3. docs/dev/observation_contract.md: Added documentation section explaining when observation contract metadata is required and how to add benchmark_promotion metadata to registry entries.

## Validation

- Regression test passes: test_guarded_ppo_checkpoint_observation_contract_resolves_from_registry
- All 42 algorithm_metadata_contract tests pass
- YAML syntax verified for registry.yaml

## Impact

Future campaigns that include guarded_ppo will no longer fail with checkpoint_observation_contract_missing. The fix applies to all rosters using this checkpoint (h600 reruns, safety-wrapper paired factorial #4830).

Note: The accepted-unavailable row in job 13334 remains valid historical record; this fix applies to future campaigns.

Closes #4837

---
This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.
