### PR TITLE
Issue #4079: document Kaggle-reduced SDD provenance decision (local BYO only) (cheap-lane worker)

### DIFF
--- a/configs/data/sdd_staging_manifest.yaml
+++ b/configs/data/sdd_staging_manifest.yaml
@@ -89,10 +89,16 @@ expected_total_size_bytes: 524288000  # ~500 MiB headroom for annotations + extr
 # tree checksum over the matched annotation files and records it under `tree_sha256` in the
 # generated staging-status manifest written to the staging_dir. They are intentionally empty here
 # because no data is bundled with the repository.
+#
+# NOTE (Issue #4079): The Kaggle-reduced SDD checksum (66dec2c82b0a01b23bf9fa9acef352af86549e7ea749811ea4ef9c47003d4acf)
+# is NOT promoted to canonical status because byte-equivalence to the official Stanford archive
+# cannot be verified (the official archive is unreachable as of 2026-07-02). See docs/context/issue_2657_sdd_staging.md
+# for the provenance decision. This checksum may be used locally for BYO staging but must not be
+# treated as an official-equivalent canonical checksum.
 checksums:
   algorithm: SHA-256
   tree_sha256: null            # filled on real staging (aggregate over matched files)
-  expected_tree_sha256: 66dec2c82b0a01b23bf9fa9acef352af86549e7ea749811ea4ef9c47003d4acf # pinned reviewed SDD annotations tree, 60 files, 444959624 bytes
+  expected_tree_sha256: null  # NOT promoted to canonical; see Issue #4079 provenance decision
 
 # --- Availability gate -----------------------------------------------------------------------
 # `missing` until the staging script validates a local copy. Scenario-prior generation reads this

--- a/docs/context/issue_2657_sdd_staging.md
+++ b/docs/context/issue_2657_sdd_staging.md
@@ -152,6 +152,69 @@ staging; license CC BY-NC-SA 3.0 (manual, license-gated, no approved download UR
 uv run python scripts/tools/manage_external_data.py --json sdd-preflight
 ```
 
+## Issue #4079 — Kaggle-reduced SDD Provenance Decision (2026-07-08)
+
+Issue #4079 investigates whether the Kaggle-reduced SDD annotation package (aryashah2k/stanford-drone-dataset)
+is byte/content-equivalent to the official Stanford SDD archive. The conclusion is that the Kaggle
+source remains a **local BYO staging option only**; canonical equivalence cannot be verified because
+the official archive is unreachable.
+
+### Official Source Availability
+
+- Official archive URL: `http://vatic2.stanford.edu/stanford_campus_dataset.zip`
+- Official project page: <https://cvgl.stanford.edu/projects/uav_data/>
+- Availability status: **blocked_official_source_unavailable**
+- Verification date: 2026-07-02 (verified from two independent networks)
+- Network observation: TCP 80 and 443 refused/filtered; DNS resolves (171.64.68.58) but host does
+  not serve HTTP/HTTPS traffic. The archive is unreachable and cannot be fetched for comparison.
+
+### Kaggle-Reduced Source
+
+- Kaggle source: <https://www.kaggle.com/datasets/aryashah2k/stanford-drone-dataset>
+- Staged local checksum (annotations only, 60 files):
+  ```
+  66dec2c82b0a01b23bf9fa9acef352af86549e7ea749811ea4ef9c47003d4acf
+  ```
+- Source classification: `local_byo_staging_only`
+- Byte-equivalence to official archive: **unknown and unverified** (official archive unavailable)
+
+### Provenance Decision
+
+Because the official Stanford SDD archive is unreachable, byte-equivalence between the Kaggle-reduced
+package and the canonical source cannot be established. The project treats the Kaggle-staged files as
+a local bring-your-own staging convenience only, not as a canonical-equivalent source.
+
+This means:
+
+1. The Kaggle checksum (`66dec2c82...`) is **NOT** promoted to `configs/data/sdd_staging_manifest.yaml`
+   as an accepted canonical checksum.
+2. Any benchmark-facing claim using SDD-derived priors **MUST** cite the provenance caveat that the
+   annotation source is a non-canonical Kaggle-reduced copy, not the official Stanford archive.
+3. If the official archive becomes available in the future, a fresh equivalence comparison should be
+   run before promoting any checksum to canonical status.
+
+### Benchmark Claim Caveat
+
+When using SDD-derived scenario priors or any benchmark result that depends on SDD annotations,
+the provenance caveat must be stated:
+
+> "Annotation source: Kaggle-reduced SDD (aryashah2k/stanford-drone-dataset), local BYO staging
+> only. Byte-equivalence to the official Stanford SDD archive (cvgl.stanford.edu) is unverified;
+> the official archive was unreachable as of 2026-07-02."
+
+No claim may state or imply that the staged annotations are from the official Stanford source without
+explicit qualification.
+
+### Validation Commands
+
+```bash
+# Check current SDD staging status (including provenance note):
+uv run python scripts/tools/manage_external_data.py --json sdd-status
+
+# Validate any locally-staged copy (official or Kaggle-derived):
+uv run python scripts/tools/manage_external_data.py --json sdd-validate
+```
+
 ## Validation Checklist
 
 - [x] Source URL and version tag are recorded.
@@ -161,3 +224,5 @@ uv run python scripts/tools/manage_external_data.py --json sdd-preflight
 - [x] Robot SF use decision is reference-only / smoke-only until hydrated.
 - [x] Missing artifacts fail closed with an actionable message and force `proxy_schema_smoke`.
 - [x] No restricted raw data is committed; staging dir is git-ignored.
+- [x] Official SDD archive unavailability is documented with verification date.
+- [x] Kaggle-reduced source is classified as local BYO only (not canonical-equivalent).

--- a/tests/tools/test_sdd_provenance_decision_issue_4079.py
+++ b/tests/tools/test_sdd_provenance_decision_issue_4079.py
@@ -85,8 +85,12 @@ def test_sdd_staging_doc_excludes_kaggle_checksum_from_manifest() -> None:
     manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
     assert isinstance(manifest, dict), "Manifest must be a mapping"
 
-    checksums = manifest.get("checksums", {})
-    expected_tree_sha256 = checksums.get("expected_tree_sha256") if isinstance(checksums, dict) else None
+    checksums = manifest.get("checksums")
+    assert isinstance(checksums, dict), "Manifest must contain a 'checksums' mapping"
+    assert "expected_tree_sha256" in checksums, (
+        "Manifest checksums must include expected_tree_sha256"
+    )
+    expected_tree_sha256 = checksums["expected_tree_sha256"]
 
     # The Kaggle checksum must NOT be pinned as the expected checksum
     kaggle_checksum = "66dec2c82b0a01b23bf9fa9acef352af86549e7ea749811ea4ef9c47003d4acf"

--- a/tests/tools/test_sdd_provenance_decision_issue_4079.py
+++ b/tests/tools/test_sdd_provenance_decision_issue_4079.py
@@ -1,0 +1,120 @@
+"""Documentation tests for SDD provenance decision (Issue #4079).
+
+Issue #4079 investigates whether the Kaggle-reduced SDD annotation package is
+byte-equivalent to the official Stanford SDD archive. These tests validate that
+the documentation correctly records the provenance decision: the official archive
+is unreachable, and the Kaggle source remains local BYO staging only.
+
+They never touch the network and never download anything.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Test file is at tests/tools/test_xxx.py, so repo root is parents[2]
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_sdd_staging_doc_records_kaggle_provenance_decision() -> None:
+    """Validate that the SDD staging documentation records the Kaggle provenance decision.
+
+    Issue #4079 documents that the official Stanford SDD archive is unreachable and
+    the Kaggle-reduced source remains local BYO staging only. This test validates
+    that the documentation explicitly states this decision so future contributors
+    understand the provenance boundary.
+
+    Regression test for: https://github.com/ll7/robot_sf_ll7/issues/4079
+    """
+    doc_path = REPO_ROOT / "docs" / "context" / "issue_2657_sdd_staging.md"
+    assert doc_path.is_file(), "SDD staging documentation must exist"
+
+    content = doc_path.read_text(encoding="utf-8")
+
+    # The documentation must explicitly mention issue #4079
+    assert "Issue #4079" in content, (
+        "Documentation must cite issue #4079 for the provenance decision"
+    )
+
+    # Must record the official archive unavailability
+    assert "blocked_official_source_unavailable" in content, (
+        "Documentation must classify the official source as unavailable"
+    )
+    assert "http://vatic2.stanford.edu/stanford_campus_dataset.zip" in content, (
+        "Documentation must record the official archive URL for future verification"
+    )
+
+    # Must record the Kaggle source and its classification
+    assert "aryashah2k/stanford-drone-dataset" in content, (
+        "Documentation must cite the Kaggle source"
+    )
+    assert "local_byo_staging_only" in content or "local BYO staging only" in content, (
+        "Documentation must classify Kaggle source as local BYO only"
+    )
+
+    # Must include the Kaggle checksum for reference
+    assert "66dec2c82b0a01b23bf9fa9acef352af86549e7ea749811ea4ef9c47003d4acf" in content, (
+        "Documentation must record the Kaggle checksum (even if not canonical)"
+    )
+
+    # Must state that the Kaggle checksum is NOT promoted to canonical
+    assert "NOT" in content and "canonical" in content, (
+        "Documentation must explicitly state that Kaggle is not canonical-equivalent"
+    )
+
+    # Must include the benchmark claim caveat
+    assert "provenance caveat" in content or "caveat" in content, (
+        "Documentation must include a benchmark claim caveat"
+    )
+
+
+def test_sdd_staging_doc_excludes_kaggle_checksum_from_manifest() -> None:
+    """Validate that the SDD manifest does NOT promote the Kaggle checksum.
+
+    Issue #4079 explicitly rejects promoting the Kaggle checksum to canonical status
+    because byte-equivalence cannot be verified. This test validates that the
+    committed manifest does not carry the Kaggle checksum as `expected_tree_sha256`.
+
+    Regression test for: https://github.com/ll7/robot_sf_ll7/issues/4079
+    """
+    manifest_path = REPO_ROOT / "configs" / "data" / "sdd_staging_manifest.yaml"
+    assert manifest_path.is_file(), "SDD staging manifest must exist"
+
+    import yaml
+
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    assert isinstance(manifest, dict), "Manifest must be a mapping"
+
+    checksums = manifest.get("checksums", {})
+    expected_tree_sha256 = checksums.get("expected_tree_sha256") if isinstance(checksums, dict) else None
+
+    # The Kaggle checksum must NOT be pinned as the expected checksum
+    kaggle_checksum = "66dec2c82b0a01b23bf9fa9acef352af86549e7ea749811ea4ef9c47003d4acf"
+    assert expected_tree_sha256 != kaggle_checksum, (
+        "The Kaggle checksum must not be promoted to canonical status. "
+        "The manifest should either leave expected_tree_sha256 as null/placeholder "
+        "or use a checksum verified against the official Stanford archive."
+    )
+
+
+def test_sdd_staging_doc_has_verification_date() -> None:
+    """Validate that the documentation records when the official archive was verified unreachable.
+
+    The provenance decision depends on when the official archive was last verified as
+    unavailable. This test ensures the documentation includes a verification date so
+    future contributors can judge whether a re-verification attempt is warranted.
+
+    Regression test for: https://github.com/ll7/robot_sf_ll7/issues/4079
+    """
+    doc_path = REPO_ROOT / "docs" / "context" / "issue_2657_sdd_staging.md"
+    content = doc_path.read_text(encoding="utf-8")
+
+    # Must include a verification date (2026-07-02 or later)
+    assert "2026-07-02" in content or "2026-" in content, (
+        "Documentation must record the verification date for the official source unavailability"
+    )
+
+    # Must describe the network observation
+    assert "TCP" in content or "refused" in content or "filtered" in content, (
+        "Documentation must describe the network failure mode (TCP refused/filtered)"
+    )


### PR DESCRIPTION
## Summary

Implements issue #4079 by documenting the provenance decision for the Kaggle-reduced Stanford Drone Dataset (SDD) annotation package.

## What/Why

Issue #4079 investigates whether the Kaggle-reduced SDD package is byte-equivalent to the official Stanford SDD archive. The official archive `http://vatic2.stanford.edu/stanford_campus_dataset.zip` is unreachable (verified 2026-07-02 from two independent networks), so byte-equivalence cannot be established.

This change documents that the Kaggle source remains a **local BYO staging option only**, not canonical-equivalent.

## Changes

1. **docs/context/issue_2657_sdd_staging.md**: Added "Issue #4079 — Kaggle-reduced SDD Provenance Decision (2026-07-08)" section documenting:
   - Official source availability status (`blocked_official_source_unavailable`)
   - Kaggle source classification (`local_byo_staging_only`)
   - Kaggle checksum (for reference, not canonical)
   - Provenance decision (Kaggle NOT promoted to canonical)
   - Benchmark claim caveat wording

2. **configs/data/sdd_staging_manifest.yaml**:
   - Removed Kaggle checksum from `expected_tree_sha256` (set to `null`)
   - Added comment explaining why the Kaggle checksum is not canonical (Issue #4079 provenance)

3. **tests/tools/test_sdd_provenance_decision_issue_4079.py**: Added regression tests validating:
   - Documentation records the Kaggle provenance decision
   - Manifest does NOT promote Kaggle checksum to canonical
   - Documentation includes verification date and network observation

## Validation

```bash
# Test validation:
uv run python -m pytest tests/tools/test_sdd_provenance_decision_issue_4079.py -v
# 3 passed in 0.03s

# Related SDD tests still pass:
uv run python -m pytest tests/tools/test_sdd_preflight_issue_1497.py tests/tools/test_sdd_staging_consolidation_issue_3473.py -v
# 31 passed in 0.12s

# Ruff formatting:
uv run ruff check tests/tools/test_sdd_provenance_decision_issue_4079.py
# All checks passed!
```

## Successor Statement

This PR fully resolves issue #4079 (Phase 4 of the implementation plan): it documents the blocker explicitly because the official source is unavailable, and updates the documentation to state that Kaggle remains local BYO only. No further work is needed unless the official archive becomes accessible for comparison.

## Benchmark/Paper-Grade Evidence

This is a documentation-only change with no benchmark or metric implications. The change enforces proper provenance discipline: any future SDD-derived benchmark claims must cite the caveat that the annotation source is a non-canonical Kaggle-reduced copy, not the official Stanford archive.

---

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.