### PR TITLE
Issue #4792: update close-out note to reflect PR #4839 timing profiling (cheap-lane worker)

### DIFF
--- a/docs/context/issue_4792_scenario_criticality_real_runner_closeout.md
+++ b/docs/context/issue_4792_scenario_criticality_real_runner_closeout.md
@@ -27,6 +27,8 @@ The following PRs landed the core functionality:
 | [#4821](https://github.com/ll7/robot_sf_ll7/pull/4821) | 2026-07-08 | `differential_evolution` optimizer type behind the shared interface |
 | [#4822](https://github.com/ll7/robot_sf_ll7/pull/4822) | 2026-07-08 | CPU validation confirming objective responsiveness and real-runner integration |
 | [#4823](https://github.com/ll7/robot_sf_ll7/pull/4823) | 2026-07-08 | `cma_es` optimizer type (CMA-ES) with dependency and formatting fixes |
+| [#4835](https://github.com/ll7/robot_sf_ll7/pull/4835) | 2026-07-08 | Close-out policy note documenting implementation state and residuals |
+| [#4839](https://github.com/ll7/robot_sf_ll7/pull/4839) | 2026-07-08 | Per-candidate timing breakdown profiling (patch_s, simulation_s, score_s) |
 
 ## Canonical Evaluator Policy
 
@@ -137,7 +139,7 @@ From PR #4822 CPU validation:
 ### Current Limitations
 
 - No batch-mode execution (each candidate runs full `run_map_batch` independently)
-- No profiling/timing fields per candidate
+- Timing breakdown available (patch_s, simulation_s, score_s) but batch-mode not yet implemented
 - No shared planner batch optimization beyond the pre-resolution step
 
 ## Collision-Key Schema Policy
@@ -169,19 +171,20 @@ COLLISION_KEY_FALLBACKS = ("agent_collision_count", "total_collision_count", "co
 
 ### Post-Submission Follow-ups (Out of Scope for #4792)
 
-1. **Parallel-batch profiling and tuning**
-   - Add timing/profiling fields per candidate (patch, setup, simulation, score times)
-   - Implement batch execution if profiling shows repeated setup dominates
-   - Current parallelization is sufficient for bounded optimization sweeps
+1. **Parallel-batch tuning**
+   - Timing/profiling fields per candidate implemented (PR #4839: patch_s, simulation_s, score_s)
+   - Batch-mode execution not yet implemented (would require grouping candidates and sharing more state)
+   - Current parallelization (ProcessPoolExecutor with shared planner resolution) is sufficient for bounded optimization sweeps
+   - Batch-mode should be implemented only if profiling data shows clear bottlenecks
 
 2. **Collision-key schema finalization**
    - Migrate all fixtures to use `collision_count`
    - Remove fallback acceptance or add explicit legacy flag
-   - Depends on external schema settlement
+   - Depends on external episode-metrics schema settlement
 
 3. **Bayesian optimizer** (stretch)
    - Not required for #4792 close-out
-   - Can be added post-submission if needed for comparison
+   - Can be added post-submission if needed for optimizer comparison
 
 ## Claim Boundary
 

--- a/docs/context/issue_4792_scenario_criticality_real_runner_closeout.md
+++ b/docs/context/issue_4792_scenario_criticality_real_runner_closeout.md
@@ -139,7 +139,6 @@ From PR #4822 CPU validation:
 ### Current Limitations
 
 - No batch-mode execution (each candidate runs full `run_map_batch` independently)
-- Timing breakdown available (patch_s, simulation_s, score_s) but batch-mode not yet implemented
 - No shared planner batch optimization beyond the pre-resolution step
 
 ## Collision-Key Schema Policy


### PR DESCRIPTION
## Summary

Updates the scenario criticality real-runner close-out note to reflect
that PR #4839 added per-candidate timing breakdown profiling (patch_s,
simulation_s, score_s), which was previously listed as a residual item.

### What

This PR updates the close-out documentation in
`docs/context/issue_4792_scenario_criticality_real_runner_closeout.md`:

- Adds PR #4835 (close-out policy note) and PR #4839 (timing profiling)
  to the PR ledger
- Updates "Current Limitations" to reflect that timing profiling is now
  implemented
- Updates "Remaining Residuals" to clarify that timing/profiling fields
  are implemented, but batch-mode execution is not

### Why

The close-out note was written before PR #4839 landed, so it listed
"timing/profiling fields per candidate" as a residual item. PR #4839
implemented that residual by adding patch_s, simulation_s, and score_s
fields to CandidateResult and the output artifacts.

This update ensures the documentation accurately reflects the current
implementation state and makes it clear what remains (batch-mode
execution if profiling justifies it, collision-key schema finalization
blocked externally, Bayesian optimizer as a stretch item).

### Validation

```bash
# Ruff checks
$ uv run ruff check docs/context/issue_4792_scenario_criticality_real_runner_closeout.md
All checks passed!

# Tests (all pass)
$ uv run pytest tests/benchmark/test_scenario_criticality_objective.py -q
18 passed in 0.65s

$ uv run pytest tests/benchmark/test_scenario_criticality_optimization.py -q -k "not cma_es"
37 passed, 2 skipped, 6 deselected in 133.11s (0:02:13)
```

### Residuals Deferred

The following residuals remain for issue #4792 and are NOT addressed by
this PR:

1. **Parallel-batch tuning** - Timing profiling is done; batch-mode
   execution should be implemented only if profiling data shows clear
   bottlenecks

2. **Collision-key schema finalization** - Depends on external
   episode-metrics schema settlement

3. **Bayesian optimizer** - Stretch item, not required for #4792
   close-out

### Related Work

This is a documentation-only follow-up to the #4792 implementation:
- PR #4804: Real-runner integration (mock metrics → run_map_batch)
- PR #4812: Canonical collision-key handling + optional parallel
- PR #4819: Shared planner resolution
- PR #4821: differential_evolution optimizer
- PR #4822: CPU validation (objective responsiveness)
- PR #4823: cma_es optimizer
- PR #4835: Close-out policy note
- PR #4839: Per-candidate timing breakdown profiling

This PR does not add new functionality; it updates documentation to
accurately reflect the state after PR #4839.

### Claim Boundary

**Documentation-only update.** No functional changes to the criticality
optimizer implementation. The feature remains diagnostic/research-only
per the original close-out note.

Refs #4792

---

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap
implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Issue `#4792` scenario criticality close-out notes with the latest landed items and timing breakdown coverage.
  * Clarified current limitations around batch-mode/shared planner optimization.
  * Refined the remaining follow-up items to reflect improved profiling visibility and updated optimization priorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->