### PR TITLE
Issue #4856: centralize robot_radius default constant (cheap-lane worker)

### DIFF
--- a/robot_sf/common/robot_defaults.py
+++ b/robot_sf/common/robot_defaults.py
@@ -1,0 +1,48 @@
+"""Central default values for robot configuration.
+
+This module provides the authoritative default robot radius used across
+the codebase. All robot-radius defaults should reference this constant
+to ensure consistency and make future changes easier.
+
+IMPORTANT: The robot_radius default currently diverges across modules
+for historical reasons. Any change that would alter computed benchmark
+metrics is deferred per issue #4856. This module documents the current
+state and provides the authoritative value.
+
+Current State:
+    Authoritative default: DEFAULT_ROBOT_RADIUS = 1.0 (meters)
+    Used by:
+        - DifferentialDriveSettings.radius (robot_sf/robot/differential_drive.py)
+        - BicycleDriveSettings.radius (robot_sf/robot/bicycle_drive.py)
+        - HolonomicDriveSettings.radius (robot_sf/robot/holonomic_drive.py)
+        - StepSNQIProxy._DEFAULT_ROBOT_RADIUS (robot_sf/gym_env/snqi_proxy.py)
+
+    Divergent defaults (metric-affecting changes deferred):
+        - GridConfig.robot_radius = 0.3 (robot_sf/nav/occupancy_grid.py)
+          Reason: Historical; affects grid rasterization visualization.
+        - base_env planner setup fallback = 0.4 (robot_sf/gym_env/base_env.py)
+          Reason: Historical; affects planner clearance margins.
+
+To align all defaults to the authoritative value, propose a separate issue
+after 2026-07-18 with benchmark impact analysis.
+"""
+
+from __future__ import annotations
+
+# Authoritative default robot radius in meters.
+# This is the collision radius used by physics and metrics computations.
+DEFAULT_ROBOT_RADIUS: float = 1.0
+
+
+def get_default_robot_radius() -> float:
+    """Return the authoritative default robot radius in meters.
+
+    Returns:
+        float: Default robot radius (1.0 meters).
+
+    Example:
+        >>> from robot_sf.common.robot_defaults import get_default_robot_radius
+        >>> radius = get_default_robot_radius()
+        >>> assert radius == 1.0
+    """
+    return DEFAULT_ROBOT_RADIUS

--- a/robot_sf/gym_env/base_env.py
+++ b/robot_sf/gym_env/base_env.py
@@ -298,6 +298,9 @@ def attach_planner_to_map(map_def, env_config) -> None:
 
     clearance = getattr(env_config, "planner_clearance_margin", 0.3)
     robot_cfg = getattr(env_config, "robot_config", None)
+    # NOTE: This fallback (0.4m) differs from the authoritative robot radius (1.0m)
+    # defined in robot_sf.common.robot_defaults. Changing this would affect planner
+    # clearance margins and benchmark metrics. See issue #4856 for details.
     robot_radius = getattr(robot_cfg, "radius", 0.4) if robot_cfg else 0.4
 
     planner_cfg = PlannerConfig(robot_radius=robot_radius, min_safe_clearance=clearance)

--- a/robot_sf/gym_env/snqi_proxy.py
+++ b/robot_sf/gym_env/snqi_proxy.py
@@ -9,10 +9,11 @@ from typing import Any
 
 import numpy as np
 
+from robot_sf.common.robot_defaults import DEFAULT_ROBOT_RADIUS
+
 _DEFAULT_COLLISION_DIST = 0.25
 _DEFAULT_NEAR_MISS_DIST = 0.50
 _DEFAULT_COMFORT_FORCE_THRESHOLD = 2.0
-_DEFAULT_ROBOT_RADIUS = 1.0
 _DEFAULT_PED_RADIUS = 0.4
 _SNQI_THRESHOLD_CACHE: tuple[float, float, float] | None = None
 
@@ -161,12 +162,12 @@ def _resolve_robot_radius(simulator: Any) -> float:
     """
     direct = getattr(simulator, "robot_radius", None)
     if direct is not None:
-        return _coerce_positive_float(direct, _DEFAULT_ROBOT_RADIUS)
+        return _coerce_positive_float(direct, DEFAULT_ROBOT_RADIUS)
     robots = getattr(simulator, "robots", None)
     if robots:
         config = getattr(robots[0], "config", None)
-        return _coerce_positive_float(getattr(config, "radius", None), _DEFAULT_ROBOT_RADIUS)
-    return _DEFAULT_ROBOT_RADIUS
+        return _coerce_positive_float(getattr(config, "radius", None), DEFAULT_ROBOT_RADIUS)
+    return DEFAULT_ROBOT_RADIUS
 
 
 def _resolve_ped_radius(simulator: Any) -> float:

--- a/robot_sf/nav/occupancy_grid.py
+++ b/robot_sf/nav/occupancy_grid.py
@@ -184,6 +184,9 @@ class GridConfig:
     dtype: type = np.float32
     max_distance: float = 0.5
     use_ego_frame: bool = False
+    # NOTE: This default (0.3m) differs from the authoritative robot radius (1.0m)
+    # defined in robot_sf.common.robot_defaults. Changing this would affect grid
+    # rasterization and benchmark metrics. See issue #4856 for details.
     robot_radius: float = 0.3
     center_on_robot: bool = False
 

--- a/robot_sf/robot/bicycle_drive.py
+++ b/robot_sf/robot/bicycle_drive.py
@@ -7,6 +7,7 @@ import numpy as np
 from gymnasium import spaces
 
 from robot_sf.common.math_utils import clip_scalar, normalize_angle_atan2
+from robot_sf.common.robot_defaults import DEFAULT_ROBOT_RADIUS
 from robot_sf.common.types import BicycleAction, PolarVec2D, RobotPose, Vec2D
 
 
@@ -16,7 +17,9 @@ class BicycleDriveSettings:
     A class that defines the settings for a bicycle drive robot.
     """
 
-    radius: float = 1.0  # Collision radius for physics/metrics, not used in kinematics
+    # Collision radius for physics/metrics, not used in kinematics.
+    # References the authoritative default from robot_sf.common.robot_defaults.
+    radius: float = DEFAULT_ROBOT_RADIUS
     wheelbase: float = 1.0  # Distance between front and rear wheels
     max_steer: float = 0.78  # Maximum steering angle (45 degrees in radians)
     max_velocity: float = 3.0  # Maximum forward velocity

--- a/robot_sf/robot/differential_drive.py
+++ b/robot_sf/robot/differential_drive.py
@@ -7,6 +7,7 @@ import numpy as np
 from gymnasium import spaces
 
 from robot_sf.common.math_utils import clip_scalar
+from robot_sf.common.robot_defaults import DEFAULT_ROBOT_RADIUS
 from robot_sf.common.types import DifferentialDriveAction, PolarVec2D, RobotPose, Vec2D
 
 WheelSpeedState = tuple[float, float]
@@ -20,8 +21,9 @@ class DifferentialDriveSettings:
     characteristics and speed limitations.
     """
 
-    # Robot collision radius used by physics/metrics (not kinematics or grid rasterization)
-    radius: float = 1.0
+    # Robot collision radius used by physics/metrics (not kinematics or grid rasterization).
+    # References the authoritative default from robot_sf.common.robot_defaults.
+    radius: float = DEFAULT_ROBOT_RADIUS
     # Maximum linear velocity the robot can achieve
     max_linear_speed: float = 2.0
     # Maximum angular velocity the robot can achieve

--- a/robot_sf/robot/holonomic_drive.py
+++ b/robot_sf/robot/holonomic_drive.py
@@ -10,6 +10,7 @@ import numpy as np
 from gymnasium import spaces
 
 from robot_sf.common.math_utils import clip_scalar, wrap_angle_pi
+from robot_sf.common.robot_defaults import DEFAULT_ROBOT_RADIUS
 
 if TYPE_CHECKING:
     from robot_sf.common.types import PolarVec2D, RobotPose
@@ -21,7 +22,9 @@ _COMMAND_MODES = {"vx_vy", "unicycle_vw"}
 class HolonomicDriveSettings:
     """Configuration settings for a holonomic robot."""
 
-    radius: float = 1.0
+    # Collision radius for physics/metrics.
+    # References the authoritative default from robot_sf.common.robot_defaults.
+    radius: float = DEFAULT_ROBOT_RADIUS
     max_speed: float = 2.0
     max_angular_speed: float = 1.0
     command_mode: str = "vx_vy"

--- a/tests/test_robot_defaults.py
+++ b/tests/test_robot_defaults.py
@@ -39,17 +39,23 @@ class TestRobotSettingsUseConstant:
     def test_differential_drive_settings_default_radius(self) -> None:
         """T003: Verify DifferentialDriveSettings uses the central constant."""
         settings = DifferentialDriveSettings()
-        assert settings.radius == DEFAULT_ROBOT_RADIUS, "DifferentialDriveSettings should use DEFAULT_ROBOT_RADIUS"
+        assert settings.radius == DEFAULT_ROBOT_RADIUS, (
+            "DifferentialDriveSettings should use DEFAULT_ROBOT_RADIUS"
+        )
 
     def test_bicycle_drive_settings_default_radius(self) -> None:
         """T004: Verify BicycleDriveSettings uses the central constant."""
         settings = BicycleDriveSettings()
-        assert settings.radius == DEFAULT_ROBOT_RADIUS, "BicycleDriveSettings should use DEFAULT_ROBOT_RADIUS"
+        assert settings.radius == DEFAULT_ROBOT_RADIUS, (
+            "BicycleDriveSettings should use DEFAULT_ROBOT_RADIUS"
+        )
 
     def test_holonomic_drive_settings_default_radius(self) -> None:
         """T005: Verify HolonomicDriveSettings uses the central constant."""
         settings = HolonomicDriveSettings()
-        assert settings.radius == DEFAULT_ROBOT_RADIUS, "HolonomicDriveSettings should use DEFAULT_ROBOT_RADIUS"
+        assert settings.radius == DEFAULT_ROBOT_RADIUS, (
+            "HolonomicDriveSettings should use DEFAULT_ROBOT_RADIUS"
+        )
 
 
 class TestDivergentDefaultsDocumented:
@@ -62,19 +68,31 @@ class TestDivergentDefaultsDocumented:
         config = GridConfig()
         # The occupancy grid default is 0.3m, which differs from DEFAULT_ROBOT_RADIUS
         # This is intentional to avoid changing benchmark metrics
-        assert config.robot_radius == 0.3, "GridConfig robot_radius should be 0.3m (divergent, documented)"
+        assert config.robot_radius == 0.3, (
+            "GridConfig robot_radius should be 0.3m (divergent, documented)"
+        )
 
     def test_base_env_planner_fallback_is_documented(self) -> None:
-        """T007: Verify base_env.py documents its divergent fallback (0.4m)."""
-        # This test verifies documentation exists; the actual fallback is in code
-        # The documentation is a comment in base_env.py near line 299-307
-        import inspect
+        """T007: Verify base_env.py keeps its divergent fallback behavior (0.4m)."""
+        from unittest.mock import MagicMock, patch
 
         from robot_sf.gym_env.base_env import attach_planner_to_map
 
-        source = inspect.getsource(attach_planner_to_map)
-        assert "0.4" in source and "fallback" in source.lower(), \
-            "base_env.py should document the 0.4m fallback default"
+        map_def = MagicMock()
+        map_def._use_planner = False
+        map_def._global_planner = None
+
+        env_config = MagicMock()
+        env_config.use_planner = True
+        env_config.planner_backend = "custom"
+        env_config.planner_clearance_margin = 0.3
+        env_config.robot_config = None
+
+        with patch("robot_sf.gym_env.base_env.GlobalPlanner") as mock_global_planner:
+            attach_planner_to_map(map_def, env_config)
+
+        planner_config = mock_global_planner.call_args[0][1]
+        assert planner_config.robot_radius == 0.4
 
 
 class TestSNQIProxyUsesConstant:
@@ -83,8 +101,10 @@ class TestSNQIProxyUsesConstant:
     def test_snqi_proxy_imports_constant(self) -> None:
         """T008: Verify snqi_proxy.py imports DEFAULT_ROBOT_RADIUS."""
         import robot_sf.gym_env.snqi_proxy as snqi_proxy_module
-        assert hasattr(snqi_proxy_module, 'DEFAULT_ROBOT_RADIUS'), \
+
+        assert hasattr(snqi_proxy_module, "DEFAULT_ROBOT_RADIUS"), (
             "snqi_proxy should import DEFAULT_ROBOT_RADIUS from robot_sf.common.robot_defaults"
+        )
 
     def test_snqi_proxy_default_matches_constant(self) -> None:
         """T009: Verify SNQI proxy's _resolve_robot_radius uses DEFAULT_ROBOT_RADIUS."""
@@ -96,5 +116,6 @@ class TestSNQIProxyUsesConstant:
 
         sim = MockSimulator()
         radius = _resolve_robot_radius(sim)
-        assert radius == DEFAULT_ROBOT_RADIUS, \
+        assert radius == DEFAULT_ROBOT_RADIUS, (
             "SNQI proxy fallback should use DEFAULT_ROBOT_RADIUS (1.0m)"
+        )

--- a/tests/test_robot_defaults.py
+++ b/tests/test_robot_defaults.py
@@ -1,0 +1,100 @@
+"""Tests for robot_radius default centralization (issue #4856).
+
+This module verifies that:
+1. The central DEFAULT_ROBOT_RADIUS constant is defined and has the correct value
+2. Robot settings classes reference the central constant
+3. SNQI proxy references the central constant
+4. Divergent defaults are documented
+
+Claim boundary: Single-source-of-truth for robot_radius defaults (plumbing-only).
+Evidence status: Smoke evidence (unit tests verify constant usage and documentation).
+Caveats: Does not change runtime behavior; divergent defaults in occupancy_grid and
+base_env planner setup are preserved to avoid altering benchmark metrics.
+Uncertainty: None expected - this is mechanical constant centralization.
+"""
+
+from __future__ import annotations
+
+from robot_sf.common.robot_defaults import DEFAULT_ROBOT_RADIUS, get_default_robot_radius
+from robot_sf.robot.bicycle_drive import BicycleDriveSettings
+from robot_sf.robot.differential_drive import DifferentialDriveSettings
+from robot_sf.robot.holonomic_drive import HolonomicDriveSettings
+
+
+class TestDefaultRobotRadiusConstant:
+    """Tests for the central DEFAULT_ROBOT_RADIUS constant."""
+
+    def test_constant_has_expected_value(self) -> None:
+        """T001: Verify DEFAULT_ROBOT_RADIUS is 1.0 meters."""
+        assert DEFAULT_ROBOT_RADIUS == 1.0, "Authoritative robot radius should be 1.0 meters"
+
+    def test_get_default_robot_radius_returns_constant(self) -> None:
+        """T002: Verify get_default_robot_radius() returns the constant."""
+        assert get_default_robot_radius() == DEFAULT_ROBOT_RADIUS
+
+
+class TestRobotSettingsUseConstant:
+    """Tests that robot settings classes use the central constant."""
+
+    def test_differential_drive_settings_default_radius(self) -> None:
+        """T003: Verify DifferentialDriveSettings uses the central constant."""
+        settings = DifferentialDriveSettings()
+        assert settings.radius == DEFAULT_ROBOT_RADIUS, "DifferentialDriveSettings should use DEFAULT_ROBOT_RADIUS"
+
+    def test_bicycle_drive_settings_default_radius(self) -> None:
+        """T004: Verify BicycleDriveSettings uses the central constant."""
+        settings = BicycleDriveSettings()
+        assert settings.radius == DEFAULT_ROBOT_RADIUS, "BicycleDriveSettings should use DEFAULT_ROBOT_RADIUS"
+
+    def test_holonomic_drive_settings_default_radius(self) -> None:
+        """T005: Verify HolonomicDriveSettings uses the central constant."""
+        settings = HolonomicDriveSettings()
+        assert settings.radius == DEFAULT_ROBOT_RADIUS, "HolonomicDriveSettings should use DEFAULT_ROBOT_RADIUS"
+
+
+class TestDivergentDefaultsDocumented:
+    """Tests that divergent defaults are documented."""
+
+    def test_occupancy_grid_default_is_documented(self) -> None:
+        """T006: Verify occupancy_grid.py documents its divergent default (0.3m)."""
+        from robot_sf.nav.occupancy_grid import GridConfig
+
+        config = GridConfig()
+        # The occupancy grid default is 0.3m, which differs from DEFAULT_ROBOT_RADIUS
+        # This is intentional to avoid changing benchmark metrics
+        assert config.robot_radius == 0.3, "GridConfig robot_radius should be 0.3m (divergent, documented)"
+
+    def test_base_env_planner_fallback_is_documented(self) -> None:
+        """T007: Verify base_env.py documents its divergent fallback (0.4m)."""
+        # This test verifies documentation exists; the actual fallback is in code
+        # The documentation is a comment in base_env.py near line 299-307
+        import inspect
+
+        from robot_sf.gym_env.base_env import attach_planner_to_map
+
+        source = inspect.getsource(attach_planner_to_map)
+        assert "0.4" in source and "fallback" in source.lower(), \
+            "base_env.py should document the 0.4m fallback default"
+
+
+class TestSNQIProxyUsesConstant:
+    """Tests that SNQI proxy uses the central constant."""
+
+    def test_snqi_proxy_imports_constant(self) -> None:
+        """T008: Verify snqi_proxy.py imports DEFAULT_ROBOT_RADIUS."""
+        import robot_sf.gym_env.snqi_proxy as snqi_proxy_module
+        assert hasattr(snqi_proxy_module, 'DEFAULT_ROBOT_RADIUS'), \
+            "snqi_proxy should import DEFAULT_ROBOT_RADIUS from robot_sf.common.robot_defaults"
+
+    def test_snqi_proxy_default_matches_constant(self) -> None:
+        """T009: Verify SNQI proxy's _resolve_robot_radius uses DEFAULT_ROBOT_RADIUS."""
+        from robot_sf.gym_env.snqi_proxy import DEFAULT_ROBOT_RADIUS, _resolve_robot_radius
+
+        # Mock simulator with no robot_radius attribute
+        class MockSimulator:
+            pass
+
+        sim = MockSimulator()
+        radius = _resolve_robot_radius(sim)
+        assert radius == DEFAULT_ROBOT_RADIUS, \
+            "SNQI proxy fallback should use DEFAULT_ROBOT_RADIUS (1.0m)"


### PR DESCRIPTION
Issue #4856: Centralize robot_radius default constant

## Summary

This PR centralizes the authoritative robot_radius default constant without altering runtime behavior or benchmark metrics.

## Changes

- **New module**: 
  - Defines  (meters) as the authoritative default
  - Includes  helper function
  - Documents current divergence and future alignment path

- **Updated robot settings** (all now reference the central constant):
  -  (was 1.0, stays 1.0)
  -  (was 1.0, stays 1.0)
  -  (was 1.0, stays 1.0)

- **Updated SNQI proxy**:
  -  now uses 
  - Removed local  constant

- **Documented divergent defaults** (preserved to avoid changing metrics):
  -  (rasterization visualization)
  -  (clearance margins)

- **Tests**: Added  with 9 tests verifying:
  - Constant has expected value (1.0m)
  - Robot settings use the constant
  - SNQI proxy uses the constant
  - Divergent defaults are documented

## Validation

### Test Output (9 passed)
```
tests/test_robot_defaults.py::TestDefaultRobotRadiusConstant::test_constant_has_expected_value PASSED
tests/test_robot_defaults.py::TestDefaultRobotRadiusConstant::test_get_default_robot_radius_returns_constant PASSED
tests/test_robot_defaults.py::TestRobotSettingsUseConstant::test_differential_drive_settings_default_radius PASSED
tests/test_robot_defaults.py::TestRobotSettingsUseConstant::test_bicycle_drive_settings_default_radius PASSED
tests/test_robot_defaults.py::TestRobotSettingsUseConstant::test_holonomic_drive_settings_default_radius PASSED
tests/test_robot_defaults.py::TestDivergentDefaultsDocumented::test_occupancy_grid_default_is_documented PASSED
tests/test_robot_defaults.py::TestDivergentDefaultsDocumented::test_base_env_planner_fallback_is_documented PASSED
tests/test_robot_defaults.py::TestSNQIProxyUsesConstant::test_snqi_proxy_imports_constant PASSED
tests/test_robot_defaults.py::TestSNQIProxyUsesConstant::test_snqi_proxy_default_matches_constant PASSED
```

### Linting
- Ruff passed (all imports sorted, no unused imports)

## Evidence Status

**Claim boundary**: Single-source-of-truth for robot_radius defaults (plumbing-only).
**Evidence status**: Smoke evidence (unit tests verify constant usage and documentation).
**Caveats**: Does not change runtime behavior; divergent defaults in occupancy_grid and base_env planner setup are preserved to avoid altering benchmark metrics.
**Uncertainty**: None expected — this is mechanical constant centralization.

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.

Closes #4856