### PR TITLE
Issue #4858: fix test-infra gaps (silent timeouts, dormant perf enforcement, allowlist triplication, branch coverage) (cheap-lane worker)

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -17,6 +17,7 @@ jobs:
       SDL_VIDEODRIVER: dummy
       MPLBACKEND: Agg
       PYGAME_HIDE_SUPPORT_PROMPT: "1"
+      ROBOT_SF_PERF_ENFORCE: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -556,7 +556,7 @@ omit = [
     "*/__pycache__/*",
 ]
 parallel = true
-branch = false
+branch = true
 data_file = "output/coverage/.coverage"
 
 [tool.coverage.report]
@@ -611,6 +611,7 @@ markers = [
 dev = [
     # Development tools
     "pytest>=9.1.1",
+    "pytest-timeout>=2.3.1",
     "pytest-cov>=6.0.0",
     "scalene>=1.5.48",
     "ruff==0.15.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -611,7 +611,7 @@ markers = [
 dev = [
     # Development tools
     "pytest>=9.1.1",
-    "pytest-timeout>=2.3.1",
+    "pytest-timeout>=2.4.0",
     "pytest-cov>=6.0.0",
     "scalene>=1.5.48",
     "ruff==0.15.12",

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -127,6 +127,7 @@ resolve_base_ref() {
 }
 
 is_optional_readiness_path() {
+  # Code paths that require optional extras (hardcoded for readiness scope)
   case "$1" in
     robot_sf/benchmark/*|\
     robot_sf/baselines/drl_vo.py|\
@@ -139,36 +140,27 @@ is_optional_readiness_path() {
     scripts/tools/benchmark_feature_extractors.py|\
     scripts/tools/probe_social_navigation_pyenvs_socialforce_runtime.py|\
     scripts/tools/probe_sonic_model_inference.py|\
-    scripts/training/*|\
-    tests/benchmark/*|\
-    tests/benchmark_full/*|\
-    tests/carla_bridge/*|\
-    tests/integration/*|\
-    tests/planner/*|\
-    tests/render/*|\
-    tests/training/*|\
-    tests/visuals/*|\
-    tests/sb3_test.py|\
-    tests/tools/test_probe_sonic_model_inference.py|\
-    tests/test_baseline_ppo_smoke.py|\
-    tests/test_benchmark_visualization_integration.py|\
-    tests/test_feature_extractors.py|\
-    tests/test_grid_socnav_extractor.py|\
-    tests/test_map_runner_ppo.py|\
-    tests/test_map_runner_sac.py|\
-    tests/test_output_root_migration.py|\
-    tests/test_ppo_diagnostics.py|\
-    tests/test_predictive_model.py|\
-    tests/unit/test_cli_logging_flags.py|\
-    tests/unit/test_figure_orchestrator_requirements.py|\
-    tests/unit/test_runner_helper_coverage.py|\
-    tests/unit/test_runner_video.py)
+    scripts/training/*)
       return 0
       ;;
-    *)
-      return 1
-      ;;
   esac
+
+  # Test paths from the single source of truth
+  local allowlist_file="${SCRIPT_DIR}/../tests/support/optional_test_allowlist.txt"
+  if [[ -f "$allowlist_file" ]]; then
+    local test_path="$1"
+    while IFS= read -r line; do
+      [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+      # Remove trailing slash for pattern matching
+      line="${line%/}"
+      # Check if test_path matches the pattern
+      if [[ "$test_path" == "$line" || "$test_path" == "$line"/* ]]; then
+        return 0
+      fi
+    done < "$allowlist_file"
+  fi
+
+  return 1
 }
 
 pr_ready_mode_lower=$(printf '%s' "$PR_READY_MODE" | tr '[:upper:]' '[:lower:]')

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -146,19 +146,22 @@ is_optional_readiness_path() {
   esac
 
   # Test paths from the single source of truth
-  local allowlist_file="${SCRIPT_DIR}/../tests/support/optional_test_allowlist.txt"
-  if [[ -f "$allowlist_file" ]]; then
-    local test_path="$1"
-    while IFS= read -r line; do
-      [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
-      # Remove trailing slash for pattern matching
-      line="${line%/}"
-      # Check if test_path matches the pattern
-      if [[ "$test_path" == "$line" || "$test_path" == "$line"/* ]]; then
-        return 0
-      fi
-    done < "$allowlist_file"
+  local allowlist_file="${SCRIPT_DIR}/../../tests/support/optional_test_allowlist.txt"
+  if [[ ! -f "$allowlist_file" ]]; then
+    printf 'Error: optional test allowlist file not found: %s\n' "$allowlist_file" >&2
+    exit 1
   fi
+
+  local test_path="$1"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    # Remove trailing slash for pattern matching
+    line="${line%/}"
+    # Check if test_path matches the pattern
+    if [[ "$test_path" == "$line" || "$test_path" == "$line"/* ]]; then
+      return 0
+    fi
+  done < "$allowlist_file"
 
   return 1
 }

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -89,45 +89,19 @@ core_test_paths=(
 )
 # Optional test allowlist is loaded from the single source of truth
 # tests/support/optional_test_allowlist.txt
-allowlist_file="$(dirname "${BASH_SOURCE[0]}")/../tests/support/optional_test_allowlist.txt"
-if [[ -f "$allowlist_file" ]]; then
-  optional_test_paths=()
-  while IFS= read -r line; do
+allowlist_file="${SCRIPT_DIR}/../../tests/support/optional_test_allowlist.txt"
+if [[ ! -f "$allowlist_file" ]]; then
+  echo "Error: optional test allowlist file not found: $allowlist_file" >&2
+  exit 1
+fi
+optional_test_paths=()
+while IFS= read -r line || [[ -n "$line" ]]; do
     # Skip empty lines and comments
     [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
     # Remove trailing slash for shell pattern matching
     line="${line%/}"
     optional_test_paths+=("$line")
-  done < "$allowlist_file"
-else
-  # Fallback to hardcoded list if file is missing
-  optional_test_paths=(
-    tests/benchmark
-    tests/benchmark_full
-    tests/carla_bridge
-    tests/integration
-    tests/planner
-    tests/render
-    tests/training
-    tests/visuals
-    tests/tools/test_probe_sonic_model_inference.py
-    tests/sb3_test.py
-    tests/test_baseline_ppo_smoke.py
-    tests/test_benchmark_visualization_integration.py
-    tests/test_feature_extractors.py
-    tests/test_grid_socnav_extractor.py
-    tests/test_map_runner_ppo.py
-    tests/test_map_runner_sac.py
-    tests/test_output_root_migration.py
-    tests/test_ppo_diagnostics.py
-    tests/test_predictive_model.py
-    tests/unit/test_cli_logging_flags.py
-    tests/unit/test_figure_orchestrator_requirements.py
-    tests/unit/test_runner_helper_coverage.py
-    tests/unit/test_runner_video.py
-  )
-fi
-
+done < "$allowlist_file"
 normalize_pytest_target_path() {
   local path="${1#./}"
   path="${path%%::*}"

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -141,11 +141,8 @@ is_optional_test_path() {
   # Check against the loaded optional_test_paths array
   for pattern in "${optional_test_paths[@]}"; do
     # Directory pattern: check if path is the directory or under it
+    # Exact file match: path equals pattern
     if [[ "$path" == "$pattern" || "$path" == "$pattern"/* ]]; then
-      return 0
-    fi
-    # Exact file match
-    if [[ "$path" == "$pattern" ]]; then
       return 0
     fi
   done

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -87,31 +87,46 @@ core_test_paths=(
   tests/unicycle_drive_test.py
   tests/zone_sampling_test.py
 )
-optional_test_paths=(
-  tests/benchmark
-  tests/benchmark_full
-  tests/carla_bridge
-  tests/integration
-  tests/planner
-  tests/render
-  tests/training
-  tests/visuals
-  tests/tools/test_probe_sonic_model_inference.py
-  tests/sb3_test.py
-  tests/test_baseline_ppo_smoke.py
-  tests/test_benchmark_visualization_integration.py
-  tests/test_feature_extractors.py
-  tests/test_grid_socnav_extractor.py
-  tests/test_map_runner_ppo.py
-  tests/test_map_runner_sac.py
-  tests/test_output_root_migration.py
-  tests/test_ppo_diagnostics.py
-  tests/test_predictive_model.py
-  tests/unit/test_cli_logging_flags.py
-  tests/unit/test_figure_orchestrator_requirements.py
-  tests/unit/test_runner_helper_coverage.py
-  tests/unit/test_runner_video.py
-)
+# Optional test allowlist is loaded from the single source of truth
+# tests/support/optional_test_allowlist.txt
+allowlist_file="$(dirname "${BASH_SOURCE[0]}")/../tests/support/optional_test_allowlist.txt"
+if [[ -f "$allowlist_file" ]]; then
+  optional_test_paths=()
+  while IFS= read -r line; do
+    # Skip empty lines and comments
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    # Remove trailing slash for shell pattern matching
+    line="${line%/}"
+    optional_test_paths+=("$line")
+  done < "$allowlist_file"
+else
+  # Fallback to hardcoded list if file is missing
+  optional_test_paths=(
+    tests/benchmark
+    tests/benchmark_full
+    tests/carla_bridge
+    tests/integration
+    tests/planner
+    tests/render
+    tests/training
+    tests/visuals
+    tests/tools/test_probe_sonic_model_inference.py
+    tests/sb3_test.py
+    tests/test_baseline_ppo_smoke.py
+    tests/test_benchmark_visualization_integration.py
+    tests/test_feature_extractors.py
+    tests/test_grid_socnav_extractor.py
+    tests/test_map_runner_ppo.py
+    tests/test_map_runner_sac.py
+    tests/test_output_root_migration.py
+    tests/test_ppo_diagnostics.py
+    tests/test_predictive_model.py
+    tests/unit/test_cli_logging_flags.py
+    tests/unit/test_figure_orchestrator_requirements.py
+    tests/unit/test_runner_helper_coverage.py
+    tests/unit/test_runner_video.py
+  )
+fi
 
 normalize_pytest_target_path() {
   local path="${1#./}"
@@ -122,36 +137,20 @@ normalize_pytest_target_path() {
 is_optional_test_path() {
   local path
   path="$(normalize_pytest_target_path "$1")"
-  case "$path" in
-    tests/benchmark|tests/benchmark/*|\
-    tests/benchmark_full|tests/benchmark_full/*|\
-    tests/carla_bridge|tests/carla_bridge/*|\
-    tests/integration|tests/integration/*|\
-    tests/planner|tests/planner/*|\
-    tests/render|tests/render/*|\
-    tests/training|tests/training/*|\
-    tests/visuals|tests/visuals/*|\
-    tests/tools/test_probe_sonic_model_inference.py|\
-    tests/sb3_test.py|\
-    tests/test_baseline_ppo_smoke.py|\
-    tests/test_benchmark_visualization_integration.py|\
-    tests/test_feature_extractors.py|\
-    tests/test_grid_socnav_extractor.py|\
-    tests/test_map_runner_ppo.py|\
-    tests/test_map_runner_sac.py|\
-    tests/test_output_root_migration.py|\
-    tests/test_ppo_diagnostics.py|\
-    tests/test_predictive_model.py|\
-    tests/unit/test_cli_logging_flags.py|\
-    tests/unit/test_figure_orchestrator_requirements.py|\
-    tests/unit/test_runner_helper_coverage.py|\
-    tests/unit/test_runner_video.py)
+
+  # Check against the loaded optional_test_paths array
+  for pattern in "${optional_test_paths[@]}"; do
+    # Directory pattern: check if path is the directory or under it
+    if [[ "$path" == "$pattern" || "$path" == "$pattern"/* ]]; then
       return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+    fi
+    # Exact file match
+    if [[ "$path" == "$pattern" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 pytest_args=()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,9 +305,8 @@ def _load_optional_allowlist() -> tuple[set[str], set[str]]:
         - file_paths: set of specific file paths
     """
     allowlist_path = _OPTIONAL_ALLOWLIST_PATH
-    if not allowlist_path.exists():
-        # Fallback to hardcoded patterns if the file is missing
-        return set(), set()
+    if not allowlist_path.is_file():
+        raise FileNotFoundError(f"Optional test allowlist file not found: {allowlist_path}")
 
     directory_patterns = set()
     file_paths = set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -293,33 +293,42 @@ _TEST_LANE_ENV = "ROBOT_SF_TEST_LANE"
 _TEST_LANE_ALL = "all"
 _TEST_LANE_CORE = "core"
 _TEST_LANE_OPTIONAL = "optional"
-_OPTIONAL_TEST_PATH_FRAGMENTS = (
-    "tests/benchmark/",
-    "tests/benchmark_full/",
-    "tests/carla_bridge/",
-    "tests/integration/",
-    "tests/planner/",
-    "tests/render/",
-    "tests/training/",
-    "tests/visuals/",
-)
-_OPTIONAL_TEST_FILES = {
-    "tests/sb3_test.py",
-    "tests/tools/test_probe_sonic_model_inference.py",
-    "tests/test_baseline_ppo_smoke.py",
-    "tests/test_benchmark_visualization_integration.py",
-    "tests/test_feature_extractors.py",
-    "tests/test_grid_socnav_extractor.py",
-    "tests/test_map_runner_ppo.py",
-    "tests/test_map_runner_sac.py",
-    "tests/test_output_root_migration.py",
-    "tests/test_ppo_diagnostics.py",
-    "tests/test_predictive_model.py",
-    "tests/unit/test_cli_logging_flags.py",
-    "tests/unit/test_figure_orchestrator_requirements.py",
-    "tests/unit/test_runner_helper_coverage.py",
-    "tests/unit/test_runner_video.py",
-}
+_OPTIONAL_ALLOWLIST_PATH = Path(__file__).parent / "support" / "optional_test_allowlist.txt"
+
+
+def _load_optional_allowlist() -> tuple[set[str], set[str]]:
+    """Load the optional test allowlist from the single source of truth.
+
+    Returns:
+        A tuple of (directory_patterns, file_paths) where:
+        - directory_patterns: set of directory patterns (with trailing /)
+        - file_paths: set of specific file paths
+    """
+    allowlist_path = _OPTIONAL_ALLOWLIST_PATH
+    if not allowlist_path.exists():
+        # Fallback to hardcoded patterns if the file is missing
+        return set(), set()
+
+    directory_patterns = set()
+    file_paths = set()
+
+    with open(allowlist_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            # Skip empty lines and comments
+            if not line or line.startswith("#"):
+                continue
+            # Directory patterns end with /
+            if line.endswith("/"):
+                directory_patterns.add(line)
+            else:
+                file_paths.add(line)
+
+    return directory_patterns, file_paths
+
+
+# Load the allowlist once at module load time
+_OPTIONAL_TEST_PATH_FRAGMENTS, _OPTIONAL_TEST_FILES = _load_optional_allowlist()
 
 
 @pytest.fixture

--- a/tests/support/optional_test_allowlist.txt
+++ b/tests/support/optional_test_allowlist.txt
@@ -1,0 +1,35 @@
+# Optional test allowlist: tests that require optional-extra readiness dependencies.
+# Each line is either a directory pattern (with trailing /) or a file path.
+# This file is the single source of truth; consumers:
+# - tests/conftest.py (Python, _is_optional_readiness_test_path)
+# - scripts/dev/run_tests_parallel.sh (bash, is_optional_test_path)
+# - scripts/dev/pr_ready_check.sh (bash, optional_test_patterns)
+#
+# To add a new optional test path, add it here. Do NOT edit the three consumers directly.
+
+# Directory patterns (all tests under these paths are optional)
+tests/benchmark/
+tests/benchmark_full/
+tests/carla_bridge/
+tests/integration/
+tests/planner/
+tests/render/
+tests/training/
+tests/visuals/
+
+# Individual test files (optional even when outside optional directories)
+tests/sb3_test.py
+tests/tools/test_probe_sonic_model_inference.py
+tests/test_baseline_ppo_smoke.py
+tests/test_benchmark_visualization_integration.py
+tests/test_feature_extractors.py
+tests/test_grid_socnav_extractor.py
+tests/test_map_runner_ppo.py
+tests/test_map_runner_sac.py
+tests/test_output_root_migration.py
+tests/test_ppo_diagnostics.py
+tests/test_predictive_model.py
+tests/unit/test_cli_logging_flags.py
+tests/unit/test_figure_orchestrator_requirements.py
+tests/unit/test_runner_helper_coverage.py
+tests/unit/test_runner_video.py

--- a/tests/support/process_teardown.py
+++ b/tests/support/process_teardown.py
@@ -10,12 +10,10 @@ recorded for issue #4216 (PR #4276): the suite reaches 100%, but a nested pytest
 child survives holding device handles and pytest never emits its final summary
 or exits.
 
-Two facts make the hang silent on this repo:
-
-* ``pytest-timeout`` is **not** installed, so ``@pytest.mark.timeout(...)`` is a
-  no-op decoration -- the intended per-test bound is never enforced.
-* the spawning test used ``subprocess.run(...)`` without a ``timeout=`` argument,
-  so nothing bounds the nested child.
+Note: ``pytest-timeout`` is now installed (added to dev dependencies in
+issue #4858), so ``@pytest.mark.timeout(...)`` markers are active. This helper
+remains useful as a fallback for subprocess-level timeout enforcement and as
+a process-group cleanup mechanism for wedged children.
 
 This helper runs the child in its own session/process group and, on timeout,
 terminates the *whole* group (SIGTERM -> SIGKILL) so descendants holding device

--- a/uv.lock
+++ b/uv.lock
@@ -4515,6 +4515,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4984,6 +4996,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-split" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "scalene" },
@@ -5057,6 +5070,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-split", specifier = ">=0.9.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = "==0.15.12" },
     { name = "scalene", specifier = ">=1.5.48" },

--- a/uv.lock
+++ b/uv.lock
@@ -5070,7 +5070,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-split", specifier = ">=0.9.0" },
-    { name = "pytest-timeout", specifier = ">=2.3.1" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = "==0.15.12" },
     { name = "scalene", specifier = ">=1.5.48" },


### PR DESCRIPTION
## Issue #4858: Test-infra fixes

This PR addresses all four acceptance criteria from issue #4858:

### (a) Add `pytest-timeout` dependency so timeout markers actually work
- Added `pytest-timeout>=2.3.1` to `dependency-groups.dev` in `pyproject.toml`
- Updated `tests/support/process_teardown.py` docstring to reflect that pytest-timeout is now installed
- Previously, all `@pytest.mark.timeout(...)` markers were silent no-ops (13+ tests affected)

### (b) Enable `ROBOT_SF_PERF_ENFORCE=1` in NIGHTLY lane only
- Added `ROBOT_SF_PERF_ENFORCE: "1"` to `.github/workflows/perf-nightly.yml`
- Performance breaches now fail the NIGHTLY CI run (not PR CI, preserving quick iteration on PRs)
- The enforcement harness existed but was dormant because the env var was never set

### (c) Consolidate three copies of optional-test-path allowlist to single source
- Created `tests/support/optional_test_allowlist.txt` as the single source of truth
- Updated `tests/conftest.py` to load from file via `_load_optional_allowlist()` function
- Updated `scripts/dev/run_tests_parallel.sh` to load from file at runtime
- Updated `scripts/dev/pr_ready_check.sh` to load from file (test paths only; code paths remain hardcoded)
- Previously, there were three independent copies that could drift apart

### (d) Enable branch coverage measurement without raising fail threshold
- Changed `branch = false` to `branch = true` in `[tool.coverage.run]` in `pyproject.toml`
- Branch coverage is now measured; thresholds remain unchanged (threshold changes are a separate decision)

## Validation

All changes validated:
- ✅ pytest-timeout 2.4.0 is installed and functional
- ✅ Allowlist loading works correctly (Python: `_is_optional_readiness_test_path()`, shell: `is_optional_test_path()`)
- ✅ Branch coverage setting is enabled
- ✅ Ruff checks pass on modified Python files
- ✅ All validation tests passed

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.

Closes #4858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared allowlist for optional tests, making test selection consistent across local and nightly workflows.
  * Enabled branch coverage and added test timeout support for development runs.

* **Bug Fixes**
  * Improved readiness checks so optional test paths are detected more reliably.
  * Added a fail-fast check when the shared allowlist file is missing.

* **Documentation**
  * Updated test helper notes to reflect active timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->