### PR TITLE
Issue #4859: narrow the worst broad-except sites in benchmark layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -451,8 +451,8 @@ max-statements = 60
 # CLI tools: allow prints to stdout.
 # Existing broad benchmark exception handlers are ratcheted by
 # scripts/validation/check_broad_exceptions.py; keep BLE001 scoped current files.
+# Issue #4859: aggregate.py worst sites fixed, BLE001 removed to enforce lint guard.
 "robot_sf/benchmark/ablation.py" = ["BLE001"]
-"robot_sf/benchmark/aggregate.py" = ["BLE001"]
 "robot_sf/benchmark/artifact_catalog.py" = ["BLE001"]
 "robot_sf/benchmark/camera_ready_campaign.py" = ["BLE001"]
 "robot_sf/benchmark/camera_ready/campaign.py" = ["BLE001"]
@@ -472,7 +472,7 @@ max-statements = 60
 "robot_sf/benchmark/imitation_manifest.py" = ["BLE001"]
 "robot_sf/benchmark/map_runner.py" = ["BLE001"]
 "robot_sf/benchmark/map_runner_batch_runner.py" = ["BLE001"]
-"robot_sf/benchmark/metrics.py" = ["BLE001"]
+# Issue #4859: metrics.py worst sites fixed, BLE001 removed to enforce lint guard.
 "robot_sf/benchmark/orca_preflight.py" = ["BLE001"]
 "robot_sf/benchmark/planner_inclusion.py" = ["BLE001"]
 "robot_sf/benchmark/plots.py" = ["BLE001"]
@@ -488,7 +488,7 @@ max-statements = 60
 "robot_sf/benchmark/summary.py" = ["BLE001"]
 "robot_sf/benchmark/validation/trajectory_dataset.py" = ["BLE001"]
 "robot_sf/benchmark/validation_utils.py" = ["BLE001"]
-"robot_sf/benchmark/visualization.py" = ["BLE001"]
+# Issue #4859: visualization.py worst sites fixed, BLE001 removed to enforce lint guard.
 "robot_sf/adversarial/**/*.py" = ["D417", "DOC201", "TC001", "TC003"]
 "robot_sf/adversarial/config.py" = ["C901", "PLR0913"]
 # trajectory_verifier: verify_trajectory has 9 keyword-only args as specified by issue #4757 API contract

--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -528,7 +528,7 @@ def _ensure_snqi(
         return
     try:
         rec["metrics"]["snqi"] = float(snqi_fn(rec["metrics"], weights, baseline_stats=baseline))
-    except Exception:
+    except (ValueError, TypeError):
         logger.bind(
             event="aggregation_snqi_compute_failed",
             episode_id=rec.get("episode_id"),
@@ -735,7 +735,12 @@ def _bootstrap_ci(
         xb = x[idx]
         try:
             stats[i] = float(stat_fn(xb))
-        except Exception:
+        except (ValueError, TypeError) as exc:
+            logger.debug(
+                "Bootstrap resample {i} failed: {exc}. Treating as NaN.",
+                i=i,
+                exc=exc,
+            )
             stats[i] = float("nan")
     stats = stats[~np.isnan(stats)]
     if stats.size == 0:

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -49,6 +49,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from loguru import logger
+from shapely.errors import ShapelyError
 
 # Centralized constants imported from benchmark.constants to avoid drift.
 from robot_sf.benchmark.constants import (
@@ -2902,7 +2903,7 @@ def compute_all_metrics(  # noqa: PLR0913, PLR0915
         values["_episode_metadata"] = dict(data.episode_metadata)
     try:
         values.update(calculate_signal_metrics(data))
-    except (ValueError, TypeError, KeyError, AttributeError):
+    except (ValueError, TypeError, KeyError, AttributeError, ShapelyError):
         logger.exception("Failed to compute signal metrics; falling back to unavailable defaults.")
         values.update(
             {

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -2902,7 +2902,7 @@ def compute_all_metrics(  # noqa: PLR0913, PLR0915
         values["_episode_metadata"] = dict(data.episode_metadata)
     try:
         values.update(calculate_signal_metrics(data))
-    except Exception:
+    except (ValueError, TypeError, KeyError, AttributeError):
         logger.exception("Failed to compute signal metrics; falling back to unavailable defaults.")
         values.update(
             {

--- a/robot_sf/benchmark/visualization.py
+++ b/robot_sf/benchmark/visualization.py
@@ -57,7 +57,7 @@ def frame_shape_from_map(map_svg_path: str) -> tuple[int, int]:
     if width and height:
         try:
             return int(float(width)), int(float(height))
-        except Exception:
+        except (ValueError, TypeError):
             # fallthrough to try viewBox
             pass
 
@@ -68,7 +68,7 @@ def frame_shape_from_map(map_svg_path: str) -> tuple[int, int]:
             try:
                 _, _, w, h = parts
                 return int(float(w)), int(float(h))
-            except Exception:
+            except (ValueError, TypeError):
                 pass
 
     raise ValueError("SVG missing width/height or valid viewBox")
@@ -237,7 +237,7 @@ def generate_benchmark_plots_from_data(
         # Update source_data to include filter info
         artifact.source_data = f"{len(filtered_episodes)} episodes{filter_str}"
         artifacts.append(artifact)
-    except Exception as e:
+    except (ValueError, TypeError, RuntimeError, AttributeError) as e:
         logger.warning(f"Failed to generate metrics plot: {e}")
         artifacts.append(
             VisualArtifact(
@@ -266,7 +266,7 @@ def generate_benchmark_plots_from_data(
         # Update source_data to include filter info
         artifact.source_data = f"{len(filtered_episodes)} episodes{filter_str}"
         artifacts.append(artifact)
-    except Exception as e:
+    except (ValueError, TypeError, RuntimeError, AttributeError) as e:
         logger.warning(f"Failed to generate scenario comparison plot: {e}")
         artifacts.append(
             VisualArtifact(
@@ -463,7 +463,7 @@ def _plot_subprocess_worker(  # noqa: PLR0913
             size=size,
         )
         conn.send(("ok", artifacts))
-    except Exception as exc:  # pragma: no cover - defensive fallback
+    except (ValueError, TypeError, RuntimeError, AttributeError) as exc:  # pragma: no cover - defensive fallback
         conn.send(("err", f"{type(exc).__name__}: {exc}"))
     finally:
         conn.close()
@@ -780,7 +780,7 @@ def _generate_metrics_plot(
         # Ensure figures are fully released and memory returned to OS where possible
         try:
             gc.collect()
-        except Exception:
+        except (RuntimeError, TypeError):
             pass
 
         # Create artifact
@@ -940,7 +940,7 @@ def _generate_scenario_comparison_plot(
         # Ensure figures are fully released and memory returned to OS where possible
         try:
             gc.collect()
-        except Exception:
+        except (RuntimeError, TypeError):
             pass
 
         # Create artifact

--- a/robot_sf/benchmark/visualization.py
+++ b/robot_sf/benchmark/visualization.py
@@ -463,7 +463,14 @@ def _plot_subprocess_worker(  # noqa: PLR0913
             size=size,
         )
         conn.send(("ok", artifacts))
-    except Exception as exc:  # noqa: BLE001  # pragma: no cover - subprocess boundary
+    except (
+        ValueError,
+        TypeError,
+        RuntimeError,
+        AttributeError,
+        OSError,
+        ImportError,
+    ) as exc:  # pragma: no cover - subprocess boundary
         conn.send(("err", f"{type(exc).__name__}: {exc}"))
     finally:
         conn.close()

--- a/robot_sf/benchmark/visualization.py
+++ b/robot_sf/benchmark/visualization.py
@@ -237,7 +237,7 @@ def generate_benchmark_plots_from_data(
         # Update source_data to include filter info
         artifact.source_data = f"{len(filtered_episodes)} episodes{filter_str}"
         artifacts.append(artifact)
-    except (ValueError, TypeError, RuntimeError, AttributeError) as e:
+    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as e:
         logger.warning(f"Failed to generate metrics plot: {e}")
         artifacts.append(
             VisualArtifact(
@@ -266,7 +266,7 @@ def generate_benchmark_plots_from_data(
         # Update source_data to include filter info
         artifact.source_data = f"{len(filtered_episodes)} episodes{filter_str}"
         artifacts.append(artifact)
-    except (ValueError, TypeError, RuntimeError, AttributeError) as e:
+    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as e:
         logger.warning(f"Failed to generate scenario comparison plot: {e}")
         artifacts.append(
             VisualArtifact(

--- a/robot_sf/benchmark/visualization.py
+++ b/robot_sf/benchmark/visualization.py
@@ -463,7 +463,7 @@ def _plot_subprocess_worker(  # noqa: PLR0913
             size=size,
         )
         conn.send(("ok", artifacts))
-    except (ValueError, TypeError, RuntimeError, AttributeError) as exc:  # pragma: no cover - defensive fallback
+    except Exception as exc:  # noqa: BLE001  # pragma: no cover - subprocess boundary
         conn.send(("err", f"{type(exc).__name__}: {exc}"))
     finally:
         conn.close()

--- a/scripts/validation/broad_exception_baseline.json
+++ b/scripts/validation/broad_exception_baseline.json
@@ -2,7 +2,6 @@
   "counts": {
     "by_path": {
       "robot_sf/benchmark/ablation.py": 1,
-      "robot_sf/benchmark/aggregate.py": 2,
       "robot_sf/benchmark/artifact_catalog.py": 1,
       "robot_sf/benchmark/camera_ready/campaign.py": 3,
       "robot_sf/benchmark/cli.py": 47,
@@ -23,7 +22,6 @@
       "robot_sf/benchmark/map_runner.py": 2,
       "robot_sf/benchmark/map_runner_batch_runner.py": 3,
       "robot_sf/benchmark/map_runner_env.py": 1,
-      "robot_sf/benchmark/metrics.py": 1,
       "robot_sf/benchmark/orca_preflight.py": 1,
       "robot_sf/benchmark/planner_inclusion.py": 2,
       "robot_sf/benchmark/plots.py": 1,
@@ -39,7 +37,6 @@
       "robot_sf/benchmark/summary.py": 2,
       "robot_sf/benchmark/validation/trajectory_dataset.py": 1,
       "robot_sf/benchmark/validation_utils.py": 2,
-      "robot_sf/benchmark/visualization.py": 7,
       "scripts/analysis/amv_timeout_trace_analyzer.py": 1,
       "scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py": 2,
       "scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py": 2,
@@ -129,7 +126,7 @@
       "scripts/validation/verify_maps.py": 1,
       "scripts/validation/verify_sf_implementation.py": 4
     },
-    "total": 288
+    "total": 278
   },
   "description": "Broad exception handler baseline for benchmark/script surfaces. Run scripts/validation/check_broad_exceptions.py --write-baseline to refresh after intentionally removing or approving entries.",
   "entries": [
@@ -140,24 +137,6 @@
       "handler": "Exception",
       "lineno": 117,
       "path": "robot_sf/benchmark/ablation.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
-      "context": "_ensure_snqi",
-      "fingerprint": "ff569cb256fbb14e",
-      "handler": "Exception",
-      "lineno": 531,
-      "path": "robot_sf/benchmark/aggregate.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 8,
-      "context": "_bootstrap_ci",
-      "fingerprint": "d9b9f1646cba1615",
-      "handler": "Exception",
-      "lineno": 738,
-      "path": "robot_sf/benchmark/aggregate.py",
       "source": "except Exception:"
     },
     {
@@ -1044,15 +1023,6 @@
     },
     {
       "col_offset": 4,
-      "context": "compute_all_metrics",
-      "fingerprint": "e2db220ea97bb25c",
-      "handler": "Exception",
-      "lineno": 2905,
-      "path": "robot_sf/benchmark/metrics.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
       "context": "_ensure_rvo2_importable",
       "fingerprint": "761e86439e262801",
       "handler": "Exception",
@@ -1338,69 +1308,6 @@
       "lineno": 90,
       "path": "robot_sf/benchmark/validation_utils.py",
       "source": "except Exception as e:"
-    },
-    {
-      "col_offset": 8,
-      "context": "frame_shape_from_map",
-      "fingerprint": "bba45879be658dd5",
-      "handler": "Exception",
-      "lineno": 60,
-      "path": "robot_sf/benchmark/visualization.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 12,
-      "context": "frame_shape_from_map",
-      "fingerprint": "bba45879be658dd5",
-      "handler": "Exception",
-      "lineno": 71,
-      "path": "robot_sf/benchmark/visualization.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
-      "context": "generate_benchmark_plots_from_data",
-      "fingerprint": "8f539027d1a9c59a",
-      "handler": "Exception",
-      "lineno": 240,
-      "path": "robot_sf/benchmark/visualization.py",
-      "source": "except Exception as e:"
-    },
-    {
-      "col_offset": 4,
-      "context": "generate_benchmark_plots_from_data",
-      "fingerprint": "8f539027d1a9c59a",
-      "handler": "Exception",
-      "lineno": 269,
-      "path": "robot_sf/benchmark/visualization.py",
-      "source": "except Exception as e:"
-    },
-    {
-      "col_offset": 4,
-      "context": "_plot_subprocess_worker",
-      "fingerprint": "bba1e9e83de4d87b",
-      "handler": "Exception",
-      "lineno": 466,
-      "path": "robot_sf/benchmark/visualization.py",
-      "source": "except Exception as exc:  # pragma: no cover - defensive fallback"
-    },
-    {
-      "col_offset": 8,
-      "context": "_generate_metrics_plot",
-      "fingerprint": "c90db09c9215e774",
-      "handler": "Exception",
-      "lineno": 783,
-      "path": "robot_sf/benchmark/visualization.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 8,
-      "context": "_generate_scenario_comparison_plot",
-      "fingerprint": "fe958e2b9ee653e9",
-      "handler": "Exception",
-      "lineno": 943,
-      "path": "robot_sf/benchmark/visualization.py",
-      "source": "except Exception:"
     },
     {
       "col_offset": 4,


### PR DESCRIPTION
Issue #4859: narrow the worst broad-except sites in benchmark layer

## What/Why
Fixed ~10 worst broad `except Exception` sites in the benchmark layer that mask errors and violate reproducibility requirements.

## Changes

### Code fixes:
- **aggregate.py:531** (SNQI compute): narrowed to `(ValueError, TypeError)`
- **aggregate.py:738** (bootstrap CI): narrowed to `(ValueError, TypeError)` + added debug logging (was silently converting any exception to NaN)
- **metrics.py:2905** (signal metrics): narrowed to `(ValueError, TypeError, KeyError, AttributeError)`
- **visualization.py:60,71** (SVG parsing): narrowed to `(ValueError, TypeError)`
- **visualization.py:240,269,466** (plot generation fallbacks): narrowed to `(ValueError, TypeError, RuntimeError, AttributeError)`
- **visualization.py:783,943** (gc.collect cleanup): narrowed to `(RuntimeError, TypeError)`

### Lint guard:
- Removed BLE001 ignore from aggregate.py, metrics.py, visualization.py in pyproject.toml
- New broad-except handlers in these files will now fail CI

## Validation

**Tests**: All 136 relevant tests passed:
- tests/test_metrics.py (72 tests)
- tests/test_cli_aggregate.py (4 tests)  
- tests/test_aggregate_threshold_meta.py (2 tests)
- tests/test_eval_env_metrics.py (22 tests)
- tests/test_visualization_helpers.py (22 tests)
- tests/test_benchmark_visualization_integration.py (14 tests)

**Ruff**: No BLE001 violations on modified files:
```
uv run ruff check robot_sf/benchmark/aggregate.py robot_sf/benchmark/metrics.py robot_sf/benchmark/visualization.py --select BLE
All checks passed!
```

**Behavior**: No behavior change for success path; only improved error handling for failure path.

Closes #4859

---
This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.