### PR TITLE
Issue #4874: characterization baseline tests for core benchmark modules (cheap-lane worker)

### DIFF
--- a/tests/benchmark/test_aggregate_characterization.py
+++ b/tests/benchmark/test_aggregate_characterization.py
@@ -1,0 +1,546 @@
+"""Characterization baseline tests for ``robot_sf/benchmark/aggregate.py``.
+
+These tests pin the *current observable behavior* of the benchmark aggregation
+helpers on small synthetic inputs. They are intentionally table-driven and
+assert exact golden values (including the documented edge cases: empty inputs,
+single episodes, and NaN values where finite-guards exist).
+
+Purpose (issue #4874, Refs #4770): lock a behavioral baseline so the
+post-submission refactor wave can prove behavior-preservation by re-running
+these tests and observing identical results. If a test reveals a genuine bug,
+do NOT fix it here — document it and file a separate fix issue.
+
+These tests are additive: they do not duplicate the SNQI-recompute behavior
+coverage in ``test_aggregate_snqi_recompute.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from robot_sf.benchmark import aggregate
+from robot_sf.benchmark.aggregate import (
+    build_observation_track_meta,
+    compute_aggregates,
+    flatten_metrics,
+    normalize_observation_track_mode,
+    read_jsonl,
+    resolve_benchmark_track,
+    write_episode_csv,
+)
+from robot_sf.benchmark.errors import (
+    AggregationMetadataError,
+    EpisodeRecordInputError,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Radius-aware clearance uses ``robot_radius + ped_radius`` (defaults 1.0 + 0.4).
+
+
+# ---------------------------------------------------------------------------
+# flatten_metrics
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_metrics_extracts_id_fields_and_flat_numbers() -> None:
+    """Top-level id fields and scalar metrics pass through unchanged."""
+    rec = {
+        "episode_id": "ep1",
+        "scenario_id": "sc1",
+        "seed": 7,
+        "metrics": {"success": 1.0, "collisions": 0.0, "avg_speed": 0.9},
+    }
+    flat = flatten_metrics(rec)
+    assert flat["episode_id"] == "ep1"
+    assert flat["scenario_id"] == "sc1"
+    assert flat["seed"] == 7
+    assert flat["success"] == 1.0
+    assert flat["collisions"] == 0.0
+    assert flat["avg_speed"] == 0.9
+
+
+def test_flatten_metrics_promotes_force_quantiles_to_top_level_keys() -> None:
+    """The nested ``force_quantiles`` block is flattened to ``force_q*`` keys."""
+    rec = {
+        "episode_id": "ep1",
+        "scenario_id": "sc1",
+        "seed": 1,
+        "metrics": {"force_quantiles": {"q50": 1.1, "q90": 2.2, "q95": 3.3}},
+    }
+    flat = flatten_metrics(rec)
+    assert flat["force_q50"] == 1.1
+    assert flat["force_q90"] == 2.2
+    assert flat["force_q95"] == 3.3
+    # The original nested block key is not retained as a column.
+    assert "force_quantiles" not in flat
+
+
+def test_flatten_metrics_drops_distributional_disruption_block() -> None:
+    """The ``distributional_disruption`` nested block is intentionally dropped."""
+    rec = {"metrics": {"distributional_disruption": {"foo": 1.0}, "avg_speed": 0.5}}
+    flat = flatten_metrics(rec)
+    assert "distributional_disruption" not in flat
+    assert flat["avg_speed"] == 0.5
+
+
+def test_flatten_metrics_maps_schema_blocks_to_prefixed_columns() -> None:
+    """Each schema-backed nested block maps to a documented prefix family."""
+    rec = {
+        "episode_id": "ep1",
+        "scenario_id": "sc1",
+        "seed": 7,
+        "metrics": {
+            "pedestrian_impact": {
+                "canonical_reductions": {"accel_delta_mean": 0.5, "turn_rate_delta_mean": 0.2},
+                "sample_counts": {
+                    "pedestrians": 3,
+                    "near_samples": 10,
+                    "far_samples": 5,
+                    "near_sample_frac": 0.666,
+                },
+            },
+            "social_acceptability": {
+                "available": 1.0,
+                "parameters": {"proxemic_radius_m": 1.2},
+                "sample_counts": {"pedestrians": 3, "timesteps": 100},
+                "proxemic": {"intrusion_frac": 0.1, "min_clearance_m": 0.3},
+            },
+            "human_interaction_proxy": {
+                "available": 1.0,
+                "parameters": {"proxemic_radius_m": 1.2, "yield_speed_mps": 0.15},
+                "sample_counts": {"pedestrians": 3, "timesteps": 100},
+                "canonical_reductions": {"time_to_yield_s": 1.5},
+            },
+            "social_mini_game": {
+                "status": "available",
+                "rows": [
+                    {
+                        "metric": "cooperation",
+                        "status": "available",
+                        "value": 0.42,
+                        "support_count": 2,
+                    }
+                ],
+            },
+            "clear_tracking_uncertainty": {
+                "enabled": True,
+                "mota": 0.8,
+                "motp_m": 0.1,
+                "counts": {"ground_truth": 5, "detections": 4},
+            },
+            "inter_robot": {"inter_robot_min_distance": 2.0},
+        },
+    }
+    flat = flatten_metrics(rec)
+    # pedestrian-impact reductions
+    assert flat["ped_impact_accel_delta_mean"] == 0.5
+    assert flat["ped_impact_near_sample_frac"] == 0.666
+    assert flat["ped_impact_ped_count"] == 3
+    # social-acceptability proxemic
+    assert flat["social_proxemic_radius_m"] == 1.2
+    assert flat["social_proxemic_intrusion_frac"] == 0.1
+    assert flat["social_proxemic_ped_count"] == 3
+    # human-interaction proxy reductions (keys carried verbatim when present)
+    assert flat["human_proxy_available"] == 1.0
+    assert flat["human_proxy_proxemic_radius_m"] == 1.2
+    assert flat["human_proxy_ped_count"] == 3
+    assert flat["time_to_yield_s"] == 1.5
+    # social mini-game rows get a per-metric prefix
+    assert flat["social_mini_game_cooperation"] == 0.42
+    assert flat["social_mini_game_cooperation_support_count"] == 2
+    assert flat["social_mini_game_cooperation_status"] == "available"
+    # CLEAR tracking
+    assert flat["clear_tracking_enabled"] is True
+    assert flat["clear_mota"] == 0.8
+    assert flat["clear_ground_truth_count"] == 5
+    assert flat["clear_detection_count"] == 4
+    # inter-robot block is flattened key-for-key
+    assert flat["inter_robot_min_distance"] == 2.0
+
+
+def test_flatten_metrics_empty_and_none_metrics_yield_all_none_columns() -> None:
+    """Empty records and ``metrics=None`` flatten to all-None column rows.
+
+    The pedestrian-impact / social-acceptability / human-proxy / force-quantile
+    prefixes are always emitted (so CSV headers stay stable), while CLEAR and
+    Social-Mini-Game columns are conditional and absent from an empty row.
+    """
+    for rec in ({}, {"metrics": None}):
+        flat = flatten_metrics(rec)
+        assert flat["episode_id"] is None
+        assert flat["scenario_id"] is None
+        assert flat["seed"] is None
+        assert flat["force_q50"] is None
+        assert flat["ped_impact_accel_delta_mean"] is None
+        assert flat["social_proxemic_radius_m"] is None
+        assert flat["human_proxy_available"] is None
+        # CLEAR and Social-Mini-Game columns are conditional on the block content.
+        assert "clear_mota" not in flat
+        assert "social_mini_game_status" not in flat
+
+
+# ---------------------------------------------------------------------------
+# compute_aggregates
+# ---------------------------------------------------------------------------
+
+# Records exercising bool->float success coercion, two groups, one metric.
+_TWO_GROUP_RECORDS: list[dict[str, Any]] = [
+    {
+        "episode_id": "a1",
+        "scenario_id": "s1",
+        "seed": 1,
+        "algo": "A",
+        "metrics": {"success": True, "collisions": 0.0, "avg_speed": 1.0},
+    },
+    {
+        "episode_id": "a2",
+        "scenario_id": "s1",
+        "seed": 2,
+        "algo": "A",
+        "metrics": {"success": False, "collisions": 1.0, "avg_speed": 3.0},
+    },
+    {
+        "episode_id": "b1",
+        "scenario_id": "s1",
+        "seed": 1,
+        "algo": "B",
+        "metrics": {"success": True, "collisions": 0.0, "avg_speed": 2.0},
+    },
+]
+
+
+def test_compute_aggregates_coerces_bool_success_and_computes_exact_stats() -> None:
+    """``success`` bools are coerced to 0/1 and aggregated with mean/median/p95."""
+    agg = compute_aggregates(_TWO_GROUP_RECORDS, group_by="algo", fallback_group_by="scenario_id")
+    # Group A: success {1.0, 0.0}; avg_speed {1.0, 3.0}; collisions {0.0, 1.0}
+    assert agg["A"]["success"]["mean"] == pytest.approx(0.5)
+    # numpy linear-interp p95 of [0.0, 1.0] == 0.95
+    assert agg["A"]["success"]["p95"] == pytest.approx(0.95)
+    assert agg["A"]["success"]["median"] == pytest.approx(0.5)
+    assert agg["A"]["avg_speed"]["mean"] == pytest.approx(2.0)
+    assert agg["A"]["avg_speed"]["median"] == pytest.approx(2.0)
+    assert agg["A"]["collisions"]["mean"] == pytest.approx(0.5)
+    # Group B: single successful episode.
+    assert agg["B"]["success"]["mean"] == pytest.approx(1.0)
+    assert agg["B"]["success"]["p95"] == pytest.approx(1.0)
+
+
+def test_compute_aggregates_meta_block_shape_and_defaults() -> None:
+    """The additive ``_meta`` block carries grouping, threshold, and track info."""
+    agg = compute_aggregates(_TWO_GROUP_RECORDS, group_by="algo")
+    meta = agg["_meta"]
+    assert set(meta) >= {
+        "group_by",
+        "effective_group_key",
+        "missing_algorithms",
+        "warnings",
+        "metric_parameters",
+        "observation_tracks",
+    }
+    assert meta["group_by"] == "algo"
+    assert "scenario_params.algo" in meta["effective_group_key"]
+    assert meta["missing_algorithms"] == []
+    assert meta["warnings"] == []
+    assert meta["observation_tracks"]["mode"] == "strict"
+    assert meta["observation_tracks"]["selected_track"] == "unspecified"
+
+
+def test_compute_aggregates_reports_missing_expected_algorithms() -> None:
+    """``expected_algorithms`` not present in records surface as missing + warning."""
+    agg = compute_aggregates(
+        _TWO_GROUP_RECORDS,
+        group_by="algo",
+        expected_algorithms={"A", "B", "C"},
+    )
+    assert agg["_meta"]["missing_algorithms"] == ["C"]
+    assert any("C" in w for w in agg["_meta"]["warnings"])
+
+
+def test_compute_aggregates_empty_records_returns_meta_only() -> None:
+    """An empty record set aggregates to just the ``_meta`` block (no groups)."""
+    agg = compute_aggregates([])
+    assert list(agg.keys()) == ["_meta"]
+    groups = [k for k in agg if k != "_meta"]
+    assert groups == []
+
+
+def test_compute_aggregates_falls_back_to_scenario_id_when_algo_missing() -> None:
+    """Records lacking algorithm metadata group by the fallback key."""
+    records = [
+        {"episode_id": "e1", "scenario_id": "scX", "seed": 1, "metrics": {"avg_speed": 1.0}},
+        {"episode_id": "e2", "scenario_id": "scY", "seed": 1, "metrics": {"avg_speed": 2.0}},
+    ]
+    agg = compute_aggregates(records, group_by="algo", fallback_group_by="scenario_id")
+    assert "scX" in agg and "scY" in agg
+
+
+def test_compute_aggregates_ignores_nan_metric_values_via_nanmean() -> None:
+    """NaN metric values are ignored by the NaN-aware mean/median aggregators."""
+    records = [
+        {
+            "episode_id": "a1",
+            "scenario_id": "s1",
+            "seed": 1,
+            "algo": "A",
+            "metrics": {"avg_speed": 2.0},
+        },
+        {
+            "episode_id": "a2",
+            "scenario_id": "s1",
+            "seed": 2,
+            "algo": "A",
+            "metrics": {"avg_speed": float("nan")},
+        },
+        {
+            "episode_id": "a3",
+            "scenario_id": "s1",
+            "seed": 3,
+            "algo": "A",
+            "metrics": {"avg_speed": 4.0},
+        },
+    ]
+    agg = compute_aggregates(records, group_by="algo")
+    # nan ignored -> mean of {2.0, 4.0}
+    assert agg["A"]["avg_speed"]["mean"] == pytest.approx(3.0)
+    assert agg["A"]["avg_speed"]["median"] == pytest.approx(3.0)
+
+
+def test_compute_aggregates_single_episode_statistics_equal_the_value() -> None:
+    """A single-episode group has mean == median == p95 == the value."""
+    records = [
+        {
+            "episode_id": "a1",
+            "scenario_id": "s1",
+            "seed": 1,
+            "algo": "A",
+            "metrics": {"avg_speed": 1.5},
+        },
+    ]
+    agg = compute_aggregates(records, group_by="algo")
+    stats = agg["A"]["avg_speed"]
+    assert stats["mean"] == pytest.approx(1.5)
+    assert stats["median"] == pytest.approx(1.5)
+    assert stats["p95"] == pytest.approx(1.5)
+
+
+# ---------------------------------------------------------------------------
+# observation-track helpers
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_benchmark_track_falls_back_to_unspecified() -> None:
+    """Records without any track declaration resolve to ``"unspecified"``."""
+    assert resolve_benchmark_track({"episode_id": "x"}) == "unspecified"
+    assert (
+        resolve_benchmark_track({"scenario_params": {"benchmark_track": "  odometry  "}})
+        == "odometry"
+    )
+
+
+def test_normalize_observation_track_mode_canonicalizes_inputs() -> None:
+    """Mode strings are lowercased and dash-normalized; invalid modes raise."""
+    assert normalize_observation_track_mode("strict") == "strict"
+    assert normalize_observation_track_mode("Diagnostic-Cross-Track") == "diagnostic_cross_track"
+    with pytest.raises(ValueError):
+        normalize_observation_track_mode("bogus")
+
+
+def test_build_observation_track_meta_single_track_no_mixed_caveat() -> None:
+    """A single declared track yields no mixed-track caveat."""
+    meta = build_observation_track_meta([{"benchmark_track": "A"}, {"benchmark_track": "A"}])
+    assert meta["tracks"] == {"A": 2}
+    assert meta["mixed_tracks"] is False
+    assert meta["selected_track"] == "A"
+    assert meta["caveat_record_count"] == 0
+    assert "cross_track_caveat" not in meta
+
+
+def test_build_observation_track_meta_counts_caveat_statuses() -> None:
+    """Fallback/degraded/failed statuses are counted as caveats."""
+    meta = build_observation_track_meta(
+        [
+            {"benchmark_track": "A", "availability_status": "fallback"},
+            {"benchmark_track": "A", "availability_status": "ok"},
+            {"benchmark_track": "A", "algorithm_metadata": {"execution_mode": "degraded"}},
+        ]
+    )
+    assert meta["caveat_record_count"] == 2
+
+
+def test_build_observation_track_meta_mixed_tracks_adds_cross_track_caveat() -> None:
+    """Mixed tracks set ``mixed_tracks`` and add a cross-track caveat."""
+    meta = build_observation_track_meta([{"benchmark_track": "A"}, {"benchmark_track": "B"}])
+    assert meta["mixed_tracks"] is True
+    assert meta["selected_track"] is None
+    assert "cross_track_caveat" in meta
+
+
+def test_compute_aggregates_strict_mode_rejects_mixed_tracks() -> None:
+    """Mixed benchmark tracks cannot be pooled under the default strict policy."""
+    mixed = [
+        {"episode_id": "m1", "benchmark_track": "A", "algo": "X", "metrics": {}},
+        {"episode_id": "m2", "benchmark_track": "B", "algo": "X", "metrics": {}},
+    ]
+    with pytest.raises(AggregationMetadataError):
+        compute_aggregates(mixed, group_by="algo")
+
+
+def test_compute_aggregates_diagnostic_cross_track_keeps_groups_separate() -> None:
+    """Diagnostic mode pools mixed tracks but labels each group with its track."""
+    mixed = [
+        {"episode_id": "m1", "benchmark_track": "A", "algo": "X", "metrics": {}},
+        {"episode_id": "m2", "benchmark_track": "B", "algo": "X", "metrics": {}},
+    ]
+    agg = compute_aggregates(
+        mixed, group_by="algo", observation_track_mode="diagnostic-cross-track"
+    )
+    groups = sorted(k for k in agg if k != "_meta")
+    assert groups == ["A :: X", "B :: X"]
+
+
+# ---------------------------------------------------------------------------
+# write_episode_csv
+# ---------------------------------------------------------------------------
+
+
+def test_write_episode_csv_header_orders_id_fields_first(tmp_path: Path) -> None:
+    """CSV header is ``[episode_id, scenario_id, seed]`` then sorted metric keys."""
+    out = tmp_path / "out.csv"
+    records = [
+        {
+            "episode_id": "a1",
+            "scenario_id": "s1",
+            "seed": 1,
+            "algo": "A",
+            "metrics": {"success": 1.0, "collisions": 2},
+        },
+        {
+            "episode_id": "b1",
+            "scenario_id": "s2",
+            "seed": 9,
+            "algo": "B",
+            "metrics": {"success": 0.0, "near_misses": 1},
+        },
+    ]
+    returned = write_episode_csv(records, str(out))
+    assert returned == str(out)
+    text = out.read_text(encoding="utf-8").splitlines()
+    header = text[0].split(",")
+    assert header[:3] == ["episode_id", "scenario_id", "seed"]
+    # All non-id keys are present and sorted.
+    metric_keys = header[3:]
+    assert metric_keys == sorted(metric_keys)
+    # The union of metrics across both rows is represented.
+    assert "success" in metric_keys
+    assert "collisions" in metric_keys
+    assert "near_misses" in metric_keys
+
+
+def test_write_episode_csv_rows_carry_values_and_blank_for_missing(tmp_path: Path) -> None:
+    """CSV rows carry present values and leave absent metrics as empty cells."""
+    out = tmp_path / "out.csv"
+    write_episode_csv(
+        [
+            {
+                "episode_id": "a1",
+                "scenario_id": "s1",
+                "seed": 1,
+                "metrics": {"collisions": 2, "success": 1.0},
+            },
+            {
+                "episode_id": "b1",
+                "scenario_id": "s2",
+                "seed": 2,
+                "metrics": {"success": 0.0, "near_misses": 1},
+            },
+        ],
+        str(out),
+    )
+    rows = list(out.read_text(encoding="utf-8").splitlines())
+    header = {col: i for i, col in enumerate(rows[0].split(","))}
+    a_row = rows[1].split(",")
+    assert a_row[header["episode_id"]] == "a1"
+    assert a_row[header["collisions"]] == "2"
+    assert a_row[header["success"]] == "1.0"
+    # ``near_misses`` is absent from the first record -> empty cell.
+    assert a_row[header["near_misses"]] == ""
+
+
+# ---------------------------------------------------------------------------
+# read_jsonl
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path: Path, lines: list[str]) -> Path:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_read_jsonl_strict_skips_blank_lines_and_parses_records(tmp_path: Path) -> None:
+    """Blank and whitespace-only lines are skipped; valid records parse in strict mode."""
+    path = _write_jsonl(
+        tmp_path / "r.jsonl",
+        ['{"episode_id": "x"}', "", "   ", '{"episode_id": "y"}'],
+    )
+    records = read_jsonl(path, strict=True)
+    assert [r["episode_id"] for r in records] == ["x", "y"]
+
+
+def test_read_jsonl_strict_raises_on_malformed_line(tmp_path: Path) -> None:
+    """A malformed JSONL line raises ``EpisodeRecordInputError`` in strict mode."""
+    path = _write_jsonl(tmp_path / "r.jsonl", ['{"episode_id": "x"}', '{"bad json'])
+    with pytest.raises(EpisodeRecordInputError):
+        read_jsonl(path, strict=True)
+
+
+def test_read_jsonl_non_strict_skips_malformed_lines(tmp_path: Path) -> None:
+    """Non-strict mode skips malformed lines and returns only parsed records."""
+    path = _write_jsonl(
+        tmp_path / "r.jsonl", ['{"episode_id": "x"}', '{"bad json', '{"episode_id": "y"}']
+    )
+    records = read_jsonl(path, strict=False)
+    assert [r["episode_id"] for r in records] == ["x", "y"]
+
+
+def test_read_jsonl_strict_raises_on_missing_path(tmp_path: Path) -> None:
+    """A missing file raises ``EpisodeRecordInputError`` in strict mode."""
+    with pytest.raises(EpisodeRecordInputError):
+        read_jsonl(tmp_path / "nope.jsonl", strict=True)
+
+
+def test_read_jsonl_non_strict_silently_skips_missing_path(tmp_path: Path) -> None:
+    """Non-strict mode silently skips a missing path and returns an empty list."""
+    assert read_jsonl(tmp_path / "nope.jsonl", strict=False) == []
+
+
+def test_read_jsonl_accepts_single_path_argument(tmp_path: Path) -> None:
+    """A single path argument is accepted, not only sequences of paths."""
+    path = _write_jsonl(tmp_path / "r.jsonl", ['{"episode_id": "x"}'])
+    assert read_jsonl(path, strict=True)[0]["episode_id"] == "x"
+
+
+def test_aggregate_module_exports_stable_public_surface() -> None:
+    """The ``__all__`` exports are the locked public surface of aggregate.py."""
+    expected = {
+        "build_observation_track_meta",
+        "compute_aggregates",
+        "compute_aggregates_with_ci",
+        "ensure_observation_track_policy",
+        "flatten_metrics",
+        "normalize_observation_track_mode",
+        "observation_track_group_label",
+        "read_jsonl",
+        "resolve_benchmark_track",
+        "resolve_report_group_key",
+        "write_episode_csv",
+    }
+    assert expected <= set(aggregate.__all__)
+
+
+# Keep json imported symbol referenced for static analyzers in case of expansion.
+_ = json

--- a/tests/benchmark/test_aggregate_characterization.py
+++ b/tests/benchmark/test_aggregate_characterization.py
@@ -16,6 +16,7 @@ coverage in ``test_aggregate_snqi_recompute.py``.
 
 from __future__ import annotations
 
+import copy
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -25,6 +26,7 @@ from robot_sf.benchmark import aggregate
 from robot_sf.benchmark.aggregate import (
     build_observation_track_meta,
     compute_aggregates,
+    compute_aggregates_with_ci,
     flatten_metrics,
     normalize_observation_track_mode,
     read_jsonl,
@@ -216,7 +218,11 @@ _TWO_GROUP_RECORDS: list[dict[str, Any]] = [
 
 def test_compute_aggregates_coerces_bool_success_and_computes_exact_stats() -> None:
     """``success`` bools are coerced to 0/1 and aggregated with mean/median/p95."""
-    agg = compute_aggregates(_TWO_GROUP_RECORDS, group_by="algo", fallback_group_by="scenario_id")
+    agg = compute_aggregates(
+        copy.deepcopy(_TWO_GROUP_RECORDS),
+        group_by="algo",
+        fallback_group_by="scenario_id",
+    )
     # Group A: success {1.0, 0.0}; avg_speed {1.0, 3.0}; collisions {0.0, 1.0}
     assert agg["A"]["success"]["mean"] == pytest.approx(0.5)
     # numpy linear-interp p95 of [0.0, 1.0] == 0.95
@@ -232,7 +238,7 @@ def test_compute_aggregates_coerces_bool_success_and_computes_exact_stats() -> N
 
 def test_compute_aggregates_meta_block_shape_and_defaults() -> None:
     """The additive ``_meta`` block carries grouping, threshold, and track info."""
-    agg = compute_aggregates(_TWO_GROUP_RECORDS, group_by="algo")
+    agg = compute_aggregates(copy.deepcopy(_TWO_GROUP_RECORDS), group_by="algo")
     meta = agg["_meta"]
     assert set(meta) >= {
         "group_by",
@@ -253,12 +259,66 @@ def test_compute_aggregates_meta_block_shape_and_defaults() -> None:
 def test_compute_aggregates_reports_missing_expected_algorithms() -> None:
     """``expected_algorithms`` not present in records surface as missing + warning."""
     agg = compute_aggregates(
-        _TWO_GROUP_RECORDS,
+        copy.deepcopy(_TWO_GROUP_RECORDS),
         group_by="algo",
         expected_algorithms={"A", "B", "C"},
     )
     assert agg["_meta"]["missing_algorithms"] == ["C"]
     assert any("C" in w for w in agg["_meta"]["warnings"])
+
+
+def test_compute_aggregates_with_ci_pins_pairwise_bootstrap_shape() -> None:
+    """CI aggregation adds deterministic bootstrap intervals and paired contrasts."""
+    records = [
+        {
+            "episode_id": "e1",
+            "scenario_id": "s1",
+            "seed": 1,
+            "algo": "A",
+            "metrics": {"success": 1.0, "avg_speed": 1.0},
+        },
+        {
+            "episode_id": "e2",
+            "scenario_id": "s2",
+            "seed": 2,
+            "algo": "A",
+            "metrics": {"success": 0.0, "avg_speed": 3.0},
+        },
+        {
+            "episode_id": "e1",
+            "scenario_id": "s1",
+            "seed": 1,
+            "algo": "B",
+            "metrics": {"success": 1.0, "avg_speed": 2.0},
+        },
+        {
+            "episode_id": "e2",
+            "scenario_id": "s2",
+            "seed": 2,
+            "algo": "B",
+            "metrics": {"success": 1.0, "avg_speed": 5.0},
+        },
+    ]
+
+    agg = compute_aggregates_with_ci(
+        records,
+        group_by="algo",
+        fallback_group_by="scenario_id",
+        bootstrap_samples=20,
+        bootstrap_seed=123,
+    )
+
+    assert agg["A"]["avg_speed"]["mean"] == pytest.approx(2.0)
+    assert agg["A"]["avg_speed"]["mean_ci"] == pytest.approx([1.0, 3.0])
+    assert agg["B"]["success"]["p95"] == pytest.approx(1.0)
+    contrast = agg["pairwise_contrasts"]["A__vs__B"]
+    assert contrast["left"] == "A"
+    assert contrast["right"] == "B"
+    assert contrast["metrics"]["avg_speed"]["n_pairs"] == 2
+    assert contrast["metrics"]["avg_speed"]["delta_mean"] == pytest.approx(1.5)
+    assert contrast["metrics"]["avg_speed"]["delta_ci"] == pytest.approx([1.0, 2.0])
+    assert contrast["metrics"]["success"]["p_value_holm"] == pytest.approx(0.4)
+    assert agg["pairwise_contrasts"]["_meta"]["bootstrap_samples"] == 20
 
 
 def test_compute_aggregates_empty_records_returns_meta_only() -> None:

--- a/tests/benchmark/test_constraints_first_characterization.py
+++ b/tests/benchmark/test_constraints_first_characterization.py
@@ -1,0 +1,284 @@
+"""Characterization baseline tests for ``robot_sf/benchmark/constraints_first_scoring.py``.
+
+These tests pin the *current observable behavior* of the constraints-first
+(non-compensatory) scoring layer on small synthetic episode sets. They are
+table-driven and assert exact golden values, including edge cases (empty
+planner set, single episode, None/non-numeric metric values).
+
+Purpose (issue #4874, Refs #4770): lock a behavioral baseline so the
+post-submission refactor wave can prove behavior-preservation. If a test
+reveals a genuine bug, do NOT fix it here — document it and file a separate
+fix issue.
+
+These tests are additive: they focus on exact golden-value pinning of the
+summary/report shape and do not duplicate the property coverage in
+``test_constraints_first_scoring.py``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+from robot_sf.benchmark.constraints_first_scoring import (
+    CONSTRAINTS_FIRST_SCHEMA,
+    AdmissibilityGates,
+    build_constraints_first_report,
+    collision_upper_confidence_bound,
+    constraints_first_planner_summary,
+    group_episodes_by_planner,
+    is_episode_admissible,
+    ranking_inversion,
+    survivorship_aware_metric,
+)
+
+# Shared synthetic episode set: one admissible safe episode, one collision
+# episode, one timed-out episode with a None comfort value.
+_EPISODES: list[dict[str, Any]] = [
+    {
+        "comfort": 2.0,
+        "efficiency": 0.5,
+        "collisions": 0,
+        "safe_success": True,
+        "near_miss_severity": 0.1,
+        "timeout": False,
+        "deadlock": False,
+    },
+    {
+        "comfort": 4.0,
+        "efficiency": 0.4,
+        "collisions": 1,
+        "safe_success": False,
+        "near_miss_severity": 0.9,
+        "timeout": False,
+        "deadlock": False,
+    },
+    {
+        "comfort": None,  # non-numeric -> excluded from means
+        "efficiency": 0.6,
+        "collisions": 0,
+        "safe_success": True,
+        "near_miss_severity": 0.05,
+        "timeout": True,
+        "deadlock": False,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# collision_upper_confidence_bound exact values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("n_events", "n_episodes", "confidence", "expected"),
+    [
+        (0, 20, 0.95, 0.13910834066826516),  # near rule-of-three, exact beta.ppf
+        (1, 4, 0.95, 0.7513953742698181),
+        (0, 1, 0.95, 0.95),  # 0 of 1 at 0.95 -> 0.95
+        (2, 2, 0.95, 1.0),  # all collide -> 1.0
+    ],
+)
+def test_collision_ucb_exact_values(
+    n_events: int, n_episodes: int, confidence: float, expected: float
+) -> None:
+    """Pin exact Clopper-Pearson upper bounds for representative inputs."""
+    assert collision_upper_confidence_bound(n_events, n_episodes, confidence=confidence) == (
+        pytest.approx(expected)
+    )
+
+
+def test_collision_ucb_rejects_invalid_arguments() -> None:
+    """Out-of-range event/episode counts and confidence raise ``ValueError``."""
+    with pytest.raises(ValueError):
+        collision_upper_confidence_bound(0, 0)
+    with pytest.raises(ValueError):
+        collision_upper_confidence_bound(5, 3)  # n_events > n_episodes
+    with pytest.raises(ValueError):
+        collision_upper_confidence_bound(0, 10, confidence=1.0)
+
+
+# ---------------------------------------------------------------------------
+# survivorship_aware_metric
+# ---------------------------------------------------------------------------
+
+
+def test_survivorship_aware_metric_exposes_conditioning_bias() -> None:
+    """Unconditional vs safe-conditioned means and their signed delta."""
+    out = survivorship_aware_metric(_EPISODES, "comfort")
+    assert out["metric"] == "comfort"
+    # unconditional: mean of {2.0, 4.0} (None excluded) = 3.0
+    assert out["unconditional_mean"] == pytest.approx(3.0)
+    # conditioned on safe_success: only ep1 (comfort=2.0)
+    assert out["conditioned_on_safe_success_mean"] == pytest.approx(2.0)
+    # delta = conditioned - unconditional = -1.0
+    assert out["survivorship_delta"] == pytest.approx(-1.0)
+    assert out["n_all"] == 2
+    assert out["n_safe_success"] == 1
+
+
+def test_survivorship_aware_metric_empty_when_all_non_numeric() -> None:
+    """When no numeric values are present, both means and delta are None."""
+    episodes = [{"comfort": "bad"}, {"comfort": None}]
+    out = survivorship_aware_metric(episodes, "comfort")
+    assert out["unconditional_mean"] is None
+    assert out["conditioned_on_safe_success_mean"] is None
+    assert out["survivorship_delta"] is None
+    assert out["n_all"] == 0
+
+
+# ---------------------------------------------------------------------------
+# constraints_first_planner_summary
+# ---------------------------------------------------------------------------
+
+
+def test_planner_summary_exact_rates_and_schema() -> None:
+    """Admissibility and collision rates on the shared episode set."""
+    s = constraints_first_planner_summary(_EPISODES)
+    # admissible: ep1 yes; ep2 has collision>0 -> no; ep3 timed out -> no  => 1/3
+    assert s["admissible_rate"] == pytest.approx(1 / 3)
+    # collision episodes: ep2 only => 1/3
+    assert s["collision_rate"] == pytest.approx(1 / 3)
+    assert s["schema_version"] == CONSTRAINTS_FIRST_SCHEMA
+    assert s["evidence_kind"] == "diagnostic_proxy"
+    assert s["n_episodes"] == 3
+    assert set(s) == {
+        "schema_version",
+        "evidence_kind",
+        "n_episodes",
+        "admissible_rate",
+        "collision_rate",
+        "collision_upper_confidence_bound",
+        "comfort",
+        "efficiency",
+    }
+
+
+def test_planner_summary_rejects_empty_input() -> None:
+    """An empty episode list is rejected."""
+    with pytest.raises(ValueError):
+        constraints_first_planner_summary([])
+
+
+def test_is_episode_admissible_respects_gates() -> None:
+    """Collision, timeout, and deadlock gates each gate admissibility."""
+    assert is_episode_admissible({"collisions": 0, "timeout": False, "deadlock": False}) is True
+    assert is_episode_admissible({"collisions": 1}) is False
+    assert is_episode_admissible({"collisions": 0, "timeout": True}) is False
+    assert is_episode_admissible({"collisions": 0, "deadlock": True}) is False
+    # Near-miss severity cap is opt-in via gates.
+    gated = AdmissibilityGates(max_near_miss_severity=0.2)
+    assert is_episode_admissible({"collisions": 0, "near_miss_severity": 0.5}, gated) is False
+    assert is_episode_admissible({"collisions": 0, "near_miss_severity": 0.1}, gated) is True
+
+
+# ---------------------------------------------------------------------------
+# ranking_inversion
+# ---------------------------------------------------------------------------
+
+
+def test_ranking_inversion_no_change_when_orders_match() -> None:
+    """Identical orderings produce rank_delta 0 and no inverted planners."""
+    scores = {"p3": 0.9, "p1": 0.5, "p2": 0.5}  # tie p1/p2 broken by name
+    out = ranking_inversion(scores, scores)
+    assert out["any_inversion"] is False
+    assert out["inverted_planners"] == []
+    # p3 best (rank 1); p1, p2 tie -> ranks 2, 3 by name
+    assert out["per_planner"]["p3"]["compensatory_rank"] == 1
+    assert out["per_planner"]["p1"]["compensatory_rank"] == 2
+
+
+def test_ranking_inversion_detects_swapped_order() -> None:
+    """A swapped ordering is detected and both planners are inverted."""
+    out = ranking_inversion({"p1": 0.9, "p2": 0.1}, {"p1": 0.1, "p2": 0.9})
+    assert out["inverted_planners"] == ["p1", "p2"]
+    assert out["any_inversion"] is True
+    # p1 compensatory rank 1, constraints-first rank 2 -> delta +1
+    assert out["per_planner"]["p1"]["rank_delta"] == 1
+
+
+def test_ranking_inversion_requires_same_planner_set() -> None:
+    """Mismatched planner sets raise ``ValueError``."""
+    with pytest.raises(ValueError):
+        ranking_inversion({"p1": 1.0}, {"p2": 1.0})
+
+
+# ---------------------------------------------------------------------------
+# build_constraints_first_report
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_shape_and_ranking_inversion_block() -> None:
+    """The report carries versioned metadata, per-planner summaries, and ranking inversion."""
+    report = build_constraints_first_report(
+        {"X": _EPISODES, "Y": [_EPISODES[0]]},
+        compensatory_scores={"X": 0.7, "Y": 0.3},
+    )
+    assert set(report) == {
+        "schema_version",
+        "metric_layer_schema_version",
+        "metric_layer_order",
+        "evidence_kind",
+        "per_planner",
+        "ranking_inversion",
+    }
+    assert report["schema_version"] == CONSTRAINTS_FIRST_SCHEMA
+    assert report["evidence_kind"] == "diagnostic_proxy"
+    # metric_layer_order is the locked layered-evaluation order.
+    assert report["metric_layer_order"] == [
+        "safety_gate",
+        "liveness",
+        "social_compliance",
+        "efficiency",
+        "comfort",
+        "operational",
+    ]
+    assert set(report["per_planner"]) == {"X", "Y"}
+    assert "ranking_inversion" in report
+
+
+def test_build_report_omits_ranking_inversion_without_compensatory_scores() -> None:
+    """The ranking-inversion block is omitted when no compensatory scores are supplied."""
+    report = build_constraints_first_report({"X": [_EPISODES[0]]})
+    assert "ranking_inversion" not in report
+
+
+def test_build_report_rejects_empty_input() -> None:
+    """An empty planner map is rejected."""
+    with pytest.raises(ValueError):
+        build_constraints_first_report({})
+
+
+def test_build_report_uses_admissible_rate_as_constraints_first_score() -> None:
+    """Ranking-inversion contrasts composite vs admissible_rate ordering."""
+    # Planner A: all admissible (admissible_rate=1.0); Planner B: none admissible (0.0).
+    a = [{"collisions": 0, "timeout": False, "deadlock": False}]
+    b = [{"collisions": 1, "timeout": False, "deadlock": False}]
+    report = build_constraints_first_report(
+        {"A": a, "B": b},
+        compensatory_scores={"A": 0.2, "B": 0.8},  # composite favors B
+    )
+    ri = report["ranking_inversion"]
+    # Under constraints-first, A (admissible) ranks above B -> A rank improves.
+    assert ri["per_planner"]["A"]["rank_delta"] < 0
+    assert ri["per_planner"]["B"]["rank_delta"] > 0
+
+
+# ---------------------------------------------------------------------------
+# group_episodes_by_planner
+# ---------------------------------------------------------------------------
+
+
+def test_group_episodes_by_planner_keys_and_missing_key_error() -> None:
+    """Records group by planner key; a record missing the key raises."""
+    grouped = group_episodes_by_planner([{"planner": "A", "x": 1}, {"planner": "A", "x": 2}])
+    assert list(grouped) == ["A"]
+    assert len(grouped["A"]) == 2
+    with pytest.raises(ValueError):
+        group_episodes_by_planner([{"x": 1}])
+
+
+# Keep math referenced for analyzers when NaN assertions expand.
+_ = math

--- a/tests/benchmark/test_exemplar_selection_characterization.py
+++ b/tests/benchmark/test_exemplar_selection_characterization.py
@@ -1,0 +1,255 @@
+"""Characterization baseline tests for ``robot_sf/benchmark/exemplar_selection.py``.
+
+These tests pin the *current observable behavior* of the exemplar selection
+pipeline on small synthetic episode sets. They are table-driven and assert
+exact golden values, including edge cases (empty input, single episode per
+cell, ties, multi-cell ordering).
+
+Purpose (issue #4874, Refs #4770): lock a behavioral baseline so the
+post-submission refactor wave can prove behavior-preservation. If a test
+reveals a genuine bug, do NOT fix it here — document it and file a separate
+fix issue.
+
+These tests are additive: they pin exact full ``SelectedEpisode`` records,
+the grouping-key normalization table, the cell-key construction format, and
+the manifest field set. They do not duplicate the selection-logic class
+coverage in ``test_exemplar_selection.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.benchmark.exemplar_selection import (
+    METRIC_DIRECTIONS,
+    SELECTION_MANIFEST_SCHEMA_VERSION,
+    build_manifest,
+    save_manifest,
+    select_exemplars,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_PLANNER_GROUP = ["planner_key"]
+
+
+def _eps(values: list[float], *, planner: str = "A") -> list[dict[str, object]]:
+    """Build episodes with a single ``collisions`` metric per episode."""
+    return [
+        {"episode_id": f"e{i}", "metrics": {"collisions": float(v)}, "algo": planner}
+        for i, v in enumerate(values)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Exact SelectedEpisode golden records
+# ---------------------------------------------------------------------------
+
+
+def test_full_selected_episode_record_is_pinned() -> None:
+    """Pin every field of a median selection including reason and seed default."""
+    # values [3,1,4,2] -> sorted [1,2,3,4]; median idx = 4//2 = 2 -> value 3.0 (e0)
+    episodes = _eps([3, 1, 4, 2])
+    selected, skipped = select_exemplars(
+        episodes, group_by=_PLANNER_GROUP, metric="collisions", modes=("median",)
+    )
+    assert skipped == []
+    assert len(selected) == 1
+    ep = selected[0]
+    assert ep.episode_id == "e0"
+    assert ep.planner_key == "A"
+    assert ep.scenario_id == ""  # missing field defaults to empty string
+    assert ep.seed == 0  # missing field defaults to 0
+    assert ep.selection_mode == "median"
+    assert ep.selection_rank == 2
+    assert ep.metric_value == pytest.approx(3.0)
+    assert ep.reason == "median within planner_key=A"
+
+
+def test_best_and_worst_indices_respect_lower_is_better() -> None:
+    """For ``collisions`` (lower better): best=min, worst=max after ascending sort."""
+    episodes = _eps([3, 1, 4, 2])  # sorted [1(e1), 2(e3), 3(e0), 4(e2)]
+    selected, _ = select_exemplars(
+        episodes, group_by=_PLANNER_GROUP, metric="collisions", modes=("best", "worst")
+    )
+    by_mode = {s.selection_mode: s for s in selected}
+    assert by_mode["best"].episode_id == "e1"  # value 1.0, rank 0
+    assert by_mode["best"].metric_value == pytest.approx(1.0)
+    assert by_mode["best"].selection_rank == 0
+    assert by_mode["worst"].episode_id == "e2"  # value 4.0, rank 3
+    assert by_mode["worst"].selection_rank == 3
+
+
+def test_all_three_modes_produce_three_selections_per_cell() -> None:
+    """All three modes produce one selection each, in the declared order."""
+    episodes = _eps([1, 2, 3])
+    selected, _ = select_exemplars(
+        episodes, group_by=_PLANNER_GROUP, metric="collisions", modes=("median", "best", "worst")
+    )
+    modes = [s.selection_mode for s in selected]
+    assert modes == ["median", "best", "worst"]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_episodes_returns_empty_selection_and_no_skips() -> None:
+    """An empty episode list yields no selections and no skipped cells."""
+    selected, skipped = select_exemplars([], group_by=_PLANNER_GROUP, metric="collisions")
+    assert selected == []
+    assert skipped == []
+
+
+def test_single_episode_per_cell_all_modes_select_same_episode() -> None:
+    """A single-episode cell selects that episode under every mode at rank 0."""
+    episodes = _eps([5.0])
+    selected, skipped = select_exemplars(
+        episodes, group_by=_PLANNER_GROUP, metric="collisions", modes=("median", "best", "worst")
+    )
+    assert skipped == []
+    assert {s.episode_id for s in selected} == {"e0"}
+    # Each mode lands on rank 0 of a length-1 cell.
+    assert {s.selection_rank for s in selected} == {0}
+
+
+def test_tie_keeps_first_in_input_order_after_stable_sort() -> None:
+    """Equal metric values keep input order; best(lower) selects the first."""
+    episodes = [
+        {"episode_id": "first", "metrics": {"collisions": 2.0}, "algo": "A"},
+        {"episode_id": "second", "metrics": {"collisions": 2.0}, "algo": "A"},
+    ]
+    selected, _ = select_exemplars(
+        episodes, group_by=_PLANNER_GROUP, metric="collisions", modes=("best",)
+    )
+    assert selected[0].episode_id == "first"
+
+
+def test_all_missing_metric_creates_skipped_cell_with_reason() -> None:
+    """A cell whose episodes all lack the metric is skipped with a reason."""
+    episodes = [
+        {"episode_id": "e1", "metrics": {"other": 1.0}, "algo": "A"},
+        {"episode_id": "e2", "metrics": {}, "algo": "A"},
+    ]
+    selected, skipped = select_exemplars(episodes, group_by=_PLANNER_GROUP, metric="collisions")
+    assert selected == []
+    assert len(skipped) == 1
+    assert skipped[0].cell_key == "planner_key=A"
+    assert "collisions" in skipped[0].reason
+
+
+def test_cells_processed_in_sorted_cell_key_order() -> None:
+    """Multi-cell selection emits results in sorted cell-key order (A before B)."""
+    episodes = [
+        {"episode_id": "b1", "metrics": {"collisions": 1.0}, "algo": "B"},
+        {"episode_id": "a1", "metrics": {"collisions": 2.0}, "algo": "A"},
+    ]
+    selected, _ = select_exemplars(
+        episodes, group_by=_PLANNER_GROUP, metric="collisions", modes=("best",)
+    )
+    assert [s.planner_key for s in selected] == ["A", "B"]
+
+
+# ---------------------------------------------------------------------------
+# Grouping-key normalization table
+# ---------------------------------------------------------------------------
+
+
+def test_planner_x_outcome_grouping_cell_key_format() -> None:
+    """The cell key is ``key=value`` pairs sorted and pipe-joined."""
+    episodes = [
+        {
+            "episode_id": "e1",
+            "algo": "A",
+            "outcome": {"route_complete": True},
+            "metrics": {"collisions": 0.0},
+        },
+        {
+            "episode_id": "e2",
+            "algo": "A",
+            "outcome": {"collision_event": True},
+            "metrics": {"collisions": 1.0},
+        },
+    ]
+    selected, _ = select_exemplars(
+        episodes, group_by=["planner_key", "outcome"], metric="collisions", modes=("best",)
+    )
+    cell_keys = {s.reason.split(" within ", 1)[1] for s in selected}
+    assert cell_keys == {"outcome=success|planner_key=A", "outcome=collision|planner_key=A"}
+
+
+def test_metric_direction_auto_detection_mapping_is_locked() -> None:
+    """Pin the documented metric-direction mapping used for best/worst selection."""
+    assert METRIC_DIRECTIONS["collisions"] == "lower"
+    assert METRIC_DIRECTIONS["path_efficiency"] == "higher"
+    assert METRIC_DIRECTIONS["success"] == "higher"
+    assert METRIC_DIRECTIONS["clearing_distance_min"] == "higher"
+    assert METRIC_DIRECTIONS["near_misses"] == "lower"
+    # Unknown metrics default to "lower" via ``.get(metric, "lower")``.
+    assert METRIC_DIRECTIONS.get("totally_unknown_metric", "lower") == "lower"
+
+
+# ---------------------------------------------------------------------------
+# Manifest building and persistence
+# ---------------------------------------------------------------------------
+
+
+def test_build_manifest_pinned_fields_and_auto_direction(tmp_path: Path) -> None:
+    """The manifest carries pinned provenance fields and the auto-detected direction."""
+    episodes = _eps([3, 1, 4, 2])
+    selected, skipped = select_exemplars(
+        episodes, group_by=_PLANNER_GROUP, metric="collisions", modes=("median",)
+    )
+    source = tmp_path / "episodes.jsonl"
+    source.write_text("\n".join(json.dumps(e) for e in episodes), encoding="utf-8")
+
+    manifest = build_manifest(
+        source_episodes_path=source,
+        group_by=_PLANNER_GROUP,
+        metric="collisions",
+        selected=selected,
+        skipped_cells=skipped,
+    )
+    assert manifest.schema_version == SELECTION_MANIFEST_SCHEMA_VERSION
+    assert manifest.metric_direction == "lower"  # auto-detected from METRIC_DIRECTIONS
+    assert manifest.group_by == ["planner_key"]
+    assert manifest.metric == "collisions"
+    assert manifest.source_episodes == str(source)
+    assert len(manifest.source_sha256) == 64  # hex SHA-256 digest
+    assert manifest.selected == selected
+    assert manifest.skipped_cells == skipped
+
+
+def test_save_manifest_roundtrips_to_json(tmp_path: Path) -> None:
+    """Saved manifests round-trip through JSON with the locked field set."""
+    episodes = _eps([1.0])
+    selected, skipped = select_exemplars(episodes, group_by=_PLANNER_GROUP, metric="collisions")
+    source = tmp_path / "episodes.jsonl"
+    source.write_text(json.dumps(episodes[0]), encoding="utf-8")
+    manifest = build_manifest(
+        source_episodes_path=source,
+        group_by=_PLANNER_GROUP,
+        metric="collisions",
+        selected=selected,
+        skipped_cells=skipped,
+    )
+    out = save_manifest(manifest, tmp_path / "nested" / "manifest.json")
+    assert out.exists()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert set(payload) == {
+        "schema_version",
+        "source_episodes",
+        "source_sha256",
+        "group_by",
+        "metric",
+        "metric_direction",
+        "selected",
+        "skipped_cells",
+        "git_hash",
+    }
+    assert payload["selected"][0]["episode_id"] == "e0"

--- a/tests/benchmark/test_metrics_characterization.py
+++ b/tests/benchmark/test_metrics_characterization.py
@@ -196,6 +196,35 @@ def test_path_motion_metrics_on_straight_line() -> None:
     assert socnavbench_path_length(data) == pytest.approx(3.0)
 
 
+def test_path_motion_metrics_on_curved_nonuniform_trajectory() -> None:
+    """Pin non-zero jerk and curvature on a bent trajectory."""
+    data = _episode(
+        robot_pos=np.array(
+            [
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [1.0, 1.0],
+                [0.0, 1.0],
+            ]
+        ),
+        robot_acc=np.array(
+            [
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+            ]
+        ),
+        dt=0.5,
+        goal=np.array([0.0, 1.0]),
+        reached_goal_step=3,
+    )
+
+    assert path_length(data) == pytest.approx(3.0)
+    assert jerk_mean(data) == pytest.approx(1.0)
+    assert curvature_mean(data) == pytest.approx(1.0)
+
+
 def test_path_length_single_timestep_is_zero() -> None:
     """A single-timestep trajectory has zero path length."""
     data = _episode(robot_pos=np.array([[1.0, 1.0]]))

--- a/tests/benchmark/test_metrics_characterization.py
+++ b/tests/benchmark/test_metrics_characterization.py
@@ -1,0 +1,402 @@
+"""Characterization baseline tests for ``robot_sf/benchmark/metrics.py`` public entry points.
+
+These tests pin the *current observable behavior* of the core metric functions
+on small synthetic ``EpisodeData`` inputs. They are table-driven and assert
+exact golden values, including the documented edge cases: empty pedestrian
+sets (K=0), single timestep, and degenerate/NaN force inputs where the
+finite-guards apply.
+
+Purpose (issue #4874, Refs #4770): lock a behavioral baseline so the
+post-submission refactor wave can prove behavior-preservation by re-running
+these tests. If a test reveals a genuine bug, do NOT fix it here — document it
+and file a separate fix issue.
+
+These tests are additive and focus on golden-value pinning; they do not
+duplicate the property/contract coverage in the ``test_*_metric_contract.py``
+files.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.constants import COMFORT_FORCE_THRESHOLD
+from robot_sf.benchmark.metrics import (
+    EpisodeData,
+    avg_speed,
+    comfort_exposure,
+    compute_all_metrics,
+    curvature_mean,
+    energy,
+    evaluate_stability_margin,
+    force_exceed_events,
+    force_quantiles,
+    force_sample_stats,
+    has_force_data,
+    human_collisions,
+    jerk_mean,
+    mean_clearance,
+    mean_distance,
+    min_clearance,
+    min_distance,
+    near_misses,
+    path_efficiency,
+    path_length,
+    ped_force_mean,
+    per_ped_force_quantiles,
+    robot_ped_within_5m_frac,
+    snqi,
+    socnavbench_path_length,
+    success_rate,
+    time_to_goal,
+    timeout,
+)
+
+# EpisodeData default radii: robot_radius=1.0, ped_radius=0.4 -> sum 1.4.
+# Clearance is center-distance minus (robot_radius + ped_radius).
+_RADIUS_SUM = 1.4
+
+
+def _episode(  # noqa: PLR0913
+    *,
+    robot_pos: np.ndarray,
+    robot_vel: np.ndarray | None = None,
+    robot_acc: np.ndarray | None = None,
+    peds_pos: np.ndarray | None = None,
+    ped_forces: np.ndarray | None = None,
+    goal: np.ndarray | None = None,
+    dt: float = 0.25,
+    reached_goal_step: int | None = None,
+    obstacles: np.ndarray | None = None,
+) -> EpisodeData:
+    """Build a minimal ``EpisodeData`` with zero defaults for unused arrays."""
+    t = robot_pos.shape[0]
+    return EpisodeData(
+        robot_pos=robot_pos,
+        robot_vel=robot_vel if robot_vel is not None else np.zeros_like(robot_pos),
+        robot_acc=robot_acc if robot_acc is not None else np.zeros_like(robot_pos),
+        peds_pos=(peds_pos if peds_pos is not None else np.zeros((t, 0, 2))),
+        ped_forces=(ped_forces if ped_forces is not None else np.zeros((t, 0, 2))),
+        goal=goal if goal is not None else np.zeros(2),
+        dt=dt,
+        reached_goal_step=reached_goal_step,
+        obstacles=obstacles,
+    )
+
+
+def _single_ped_episode(ped_offset: float, *, t: int = 1) -> EpisodeData:
+    """One pedestrian fixed at ``(ped_offset, 0)``; robot at origin each step."""
+    robot_pos = np.zeros((t, 2))
+    peds = np.tile([[[ped_offset, 0.0]]], (t, 1, 1))
+    return _episode(robot_pos=robot_pos, peds_pos=peds, ped_forces=np.zeros((t, 1, 2)))
+
+
+# ---------------------------------------------------------------------------
+# Robot-pedestrian distance / clearance / collision / near-miss table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("ped_offset", "exp_human_coll", "exp_near", "exp_min_dist", "exp_min_clearance"),
+    [
+        # clearance = offset - 1.4
+        (1.0, 1.0, 0.0, 1.0, -0.4),  # overlap -> collision
+        (1.5, 0.0, 1.0, 1.5, 0.1),  # 0 <= clearance < 0.5 -> near miss
+        (2.0, 0.0, 0.0, 2.0, 0.6),  # clearance >= 0.5 -> neither
+    ],
+)
+def test_clearance_based_collision_and_near_miss_table(
+    ped_offset: float,
+    exp_human_coll: float,
+    exp_near: float,
+    exp_min_dist: float,
+    exp_min_clearance: float,
+) -> None:
+    """Pin radius-aware human-collision / near-miss / distance outputs."""
+    data = _single_ped_episode(ped_offset)
+    assert human_collisions(data) == exp_human_coll
+    assert near_misses(data) == exp_near
+    assert min_distance(data) == pytest.approx(exp_min_dist)
+    assert min_clearance(data) == pytest.approx(exp_min_clearance)
+    assert robot_ped_within_5m_frac(data) == pytest.approx(1.0)
+
+
+def test_mean_distance_and_clearance_average_min_per_step() -> None:
+    """``mean_distance`` averages the per-step minimum robot-ped distance."""
+    robot_pos = np.zeros((2, 2))
+    # Two peds at distances 1.0 and 3.0 -> per-step min = 1.0 both steps.
+    peds = np.tile([[[1.0, 0.0], [3.0, 0.0]]], (2, 1, 1))
+    data = _episode(robot_pos=robot_pos, peds_pos=peds, ped_forces=np.zeros((2, 2, 2)))
+    assert mean_distance(data) == pytest.approx(1.0)
+    assert mean_clearance(data) == pytest.approx(1.0 - _RADIUS_SUM)
+
+
+def test_empty_pedestrian_set_returns_documented_guards() -> None:
+    """K=0 yields 0 counts and NaN for undefined distances (documented guards)."""
+    data = _episode(robot_pos=np.zeros((3, 2)), peds_pos=np.zeros((3, 0, 2)))
+    assert near_misses(data) == 0.0
+    assert human_collisions(data) == 0.0
+    assert math.isnan(min_distance(data))
+    assert math.isnan(mean_distance(data))
+    assert math.isnan(min_clearance(data))
+    assert math.isnan(robot_ped_within_5m_frac(data))
+
+
+# ---------------------------------------------------------------------------
+# Success / timeout / time-to-goal
+# ---------------------------------------------------------------------------
+
+
+def _straight_line_episode() -> EpisodeData:
+    pos = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]])
+    vel = np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0], [1.0, 0.0]])
+    return _episode(
+        robot_pos=pos,
+        robot_vel=vel,
+        goal=np.array([3.0, 0.0]),
+        dt=0.5,
+        reached_goal_step=3,
+    )
+
+
+def test_success_rate_requires_goal_before_horizon_and_no_collisions() -> None:
+    """Success requires reaching the goal strictly before the horizon."""
+    data = _straight_line_episode()
+    assert success_rate(data, horizon=4) == 1.0
+    assert success_rate(data, horizon=3) == 0.0  # reached_step >= horizon
+    assert timeout(data, horizon=4) == 0.0
+    assert timeout(data, horizon=3) == 1.0
+
+
+def test_time_to_goal_is_step_times_dt() -> None:
+    """``time_to_goal`` is ``reached_goal_step * dt``; NaN when the goal is unreached."""
+    data = _straight_line_episode()
+    assert time_to_goal(data) == pytest.approx(3 * 0.5)
+    no_goal = _episode(robot_pos=np.zeros((3, 2)), reached_goal_step=None)
+    assert math.isnan(time_to_goal(no_goal))
+
+
+# ---------------------------------------------------------------------------
+# Path / motion metrics on a straight line
+# ---------------------------------------------------------------------------
+
+
+def test_path_motion_metrics_on_straight_line() -> None:
+    """Pin path/energy/jerk/curvature/efficiency values on a unit straight-line episode."""
+    data = _straight_line_episode()
+    assert path_length(data) == pytest.approx(3.0)
+    assert avg_speed(data) == pytest.approx(1.0)
+    assert energy(data) == pytest.approx(0.0)  # zero acceleration
+    assert jerk_mean(data) == pytest.approx(0.0)
+    assert curvature_mean(data) == pytest.approx(0.0)
+    assert path_efficiency(data, 3.0) == pytest.approx(1.0)
+    assert socnavbench_path_length(data) == pytest.approx(3.0)
+
+
+def test_path_length_single_timestep_is_zero() -> None:
+    """A single-timestep trajectory has zero path length."""
+    data = _episode(robot_pos=np.array([[1.0, 1.0]]))
+    assert path_length(data) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Force metrics, finite-guards, and degenerate inputs
+# ---------------------------------------------------------------------------
+
+
+def test_force_quantiles_and_mean_on_known_magnitude() -> None:
+    """Single sample of magnitude 5 (3-4-5 force vector) at all quantiles/mean."""
+    forces = np.array([[[3.0, 4.0]]])  # ||(3,4)|| = 5
+    data = _episode(robot_pos=np.zeros((1, 2)), peds_pos=np.zeros((1, 1, 2)), ped_forces=forces)
+    assert has_force_data(data) is True
+    q = force_quantiles(data)
+    assert q["force_q50"] == pytest.approx(5.0)
+    assert q["force_q90"] == pytest.approx(5.0)
+    assert q["force_q95"] == pytest.approx(5.0)
+    assert ped_force_mean(data) == pytest.approx(5.0)
+    # comfort threshold default 2.0 -> 1 exceed event over 1 (t,k) sample.
+    assert force_exceed_events(data) == pytest.approx(1.0)
+    assert comfort_exposure(data) == pytest.approx(1.0)
+
+
+def test_per_ped_force_quantiles_averages_across_pedestrians() -> None:
+    """Per-ped quantiles are computed then averaged across pedestrians.
+
+    ped0 magnitudes all 10 -> q50=10 ; ped1/ped2 all 1 -> q50=1 ; mean = (10+1+1)/3.
+    """
+    forces = np.zeros((3, 3, 2))
+    forces[:, 0, :] = [10.0, 0.0]  # ped0 magnitude 10
+    forces[:, 1, :] = [1.0, 0.0]  # ped1 magnitude 1
+    forces[:, 2, :] = [0.0, 1.0]  # ped2 magnitude 1
+    data = _episode(robot_pos=np.zeros((3, 2)), peds_pos=np.zeros((3, 3, 2)), ped_forces=forces)
+    pq = per_ped_force_quantiles(data)
+    assert pq["ped_force_q50"] == pytest.approx(4.0)  # mean of {10, 1, 1}
+
+
+@pytest.mark.parametrize(
+    ("forces", "expected_status"),
+    [
+        (np.zeros((2, 1, 2)), "all-zero"),
+        (np.full((2, 1, 2), np.nan), "all-invalid"),
+    ],
+)
+def test_has_force_data_false_on_degenerate_forces(
+    forces: np.ndarray, expected_status: str
+) -> None:
+    """All-zero and all-NaN force arrays are treated as no valid force data."""
+    data = _episode(robot_pos=np.zeros((2, 2)), peds_pos=np.zeros((2, 1, 2)), ped_forces=forces)
+    assert has_force_data(data) is False
+    assert force_sample_stats(data)["status"] == expected_status
+
+
+def test_force_metrics_return_nan_without_force_data() -> None:
+    """When force data is absent, force metrics return NaN (not zero)."""
+    data = _episode(
+        robot_pos=np.zeros((2, 2)),
+        peds_pos=np.zeros((2, 1, 2)),
+        ped_forces=np.zeros((2, 1, 2)),
+    )
+    assert math.isnan(ped_force_mean(data))
+    assert math.isnan(force_exceed_events(data))
+    assert math.isnan(comfort_exposure(data))
+    q = force_quantiles(data)
+    assert all(math.isnan(v) for v in q.values())
+
+
+def test_force_sample_stats_no_pedestrians_branch() -> None:
+    """K=0 is reported as ``no-pedestrians`` with zeroed counts."""
+    data = _episode(robot_pos=np.zeros((2, 2)), peds_pos=np.zeros((2, 0, 2)))
+    stats = force_sample_stats(data)
+    assert stats["status"] == "no-pedestrians"
+    assert stats["raw_samples"] == 0
+
+
+def test_comfort_force_threshold_constant() -> None:
+    """Pin the default comfort force threshold used by force-exceed metrics."""
+    assert COMFORT_FORCE_THRESHOLD == 2.0
+
+
+# ---------------------------------------------------------------------------
+# SNQI table (well-defined arithmetic)
+# ---------------------------------------------------------------------------
+
+
+_SNQI_METRICS = {
+    "success": 1.0,
+    "time_to_goal_norm": 0.5,
+    "collisions": 2.0,
+    "near_misses": 1.0,
+    "comfort_exposure": 0.1,
+    "force_exceed_events": 3.0,
+    "jerk_mean": 0.2,
+    "curvature_mean": 0.05,
+}
+_SNQI_WEIGHTS = {
+    "w_success": 1.0,
+    "w_time": 1.0,
+    "w_collisions": 1.0,
+    "w_near": 1.0,
+    "w_comfort": 1.0,
+    "w_force_exceed": 1.0,
+    "w_jerk": 1.0,
+    "w_curvature": 1.0,
+}
+_SNQI_BASELINE = {
+    "collisions": {"med": 1.0, "p95": 3.0},  # (2-1)/(3-1) = 0.5
+    "near_misses": {"med": 0.0, "p95": 2.0},  # (1-0)/(2-0) = 0.5
+    "force_exceed_events": {"med": 1.0, "p95": 5.0},  # (3-1)/(5-1) = 0.5
+    "jerk_mean": {"med": 0.0, "p95": 0.4},  # 0.2/0.4 = 0.5
+    "curvature_mean": {"med": 0.0, "p95": 0.1},  # 0.05/0.1 = 0.5
+}
+
+
+def test_snqi_with_baseline_normalizes_penalties() -> None:
+    """Each penalized metric normalizes to 0.5; score = 1 - 0.5*5 - 0.1 = -2.1."""
+    score = snqi(_SNQI_METRICS, _SNQI_WEIGHTS, baseline_stats=_SNQI_BASELINE)
+    assert score == pytest.approx(-2.1)
+
+
+def test_snqi_without_baseline_treats_penalties_as_zero() -> None:
+    """Without baseline, normalized penalties contribute 0; score = 1 - 0.5 - 0.1."""
+    score = snqi(_SNQI_METRICS, _SNQI_WEIGHTS)
+    assert score == pytest.approx(0.4)
+
+
+def test_snqi_clips_normalized_penalties_to_unit_interval() -> None:
+    """A value above p95 normalizes to 1.0 (clipped), not above 1."""
+    metrics = {"success": 0.0, "collisions": 100.0, "time_to_goal_norm": 1.0}
+    weights = {"w_collisions": 1.0}
+    baseline = {"collisions": {"med": 0.0, "p95": 1.0}}
+    # coll norm clipped to 1.0 -> score = 0 - 1 (time default) - 1 (coll) = -2.0
+    assert snqi(metrics, weights, baseline_stats=baseline) == pytest.approx(-2.0)
+
+
+def test_snqi_safe_falls_back_on_nan_and_none() -> None:
+    """NaN/None metric values fall back to documented defaults, not raise."""
+    metrics = {"success": float("nan"), "time_to_goal_norm": None}
+    # success -> default 0.0 ; time_norm -> default 1.0 ; score = 0 - 1 = -1.0
+    assert snqi(metrics, {"w_success": 1.0, "w_time": 1.0}) == pytest.approx(-1.0)
+
+
+# ---------------------------------------------------------------------------
+# Rollover stability margin
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_stability_margin_zero_lateral_load_is_one() -> None:
+    """Zero yaw-rate gives no lateral load -> margin 1.0 (full stability)."""
+    assert evaluate_stability_margin(1.0, 0.0) == pytest.approx(1.0)
+
+
+def test_evaluate_stability_margin_clamps_to_unit_interval() -> None:
+    """Large lateral acceleration drives the margin to its 0.0 floor."""
+    assert evaluate_stability_margin(1e6, 1e6) == pytest.approx(0.0)
+
+
+def test_evaluate_stability_margin_nan_speed_returns_nan() -> None:
+    """A non-finite speed sample yields NaN rather than raising."""
+    assert math.isnan(evaluate_stability_margin(float("nan"), 1.0))
+
+
+def test_evaluate_stability_margin_rejects_non_positive_geometry() -> None:
+    """Non-positive geometry parameters raise ``ValueError``."""
+    with pytest.raises(ValueError):
+        evaluate_stability_margin(1.0, 1.0, h_c=-0.1)
+
+
+# ---------------------------------------------------------------------------
+# compute_all_metrics orchestrator smoke + key presence
+# ---------------------------------------------------------------------------
+
+
+def test_compute_all_metrics_returns_core_scalar_keys() -> None:
+    """The orchestrator emits the locked set of benchmark-facing scalar keys."""
+    data = _straight_line_episode()
+    values = compute_all_metrics(data, horizon=10, shortest_path_len=3.0, robot_max_speed=1.0)
+    for key in (
+        "success",
+        "time_to_goal_norm",
+        "collisions",
+        "near_misses",
+        "path_efficiency",
+        "avg_speed",
+        "comfort_exposure",
+        "jerk_mean",
+        "curvature_mean",
+        "energy",
+        "socnavbench_path_length",
+    ):
+        assert key in values, f"missing orchestrator key {key!r}"
+    assert values["success"] == 1.0
+
+
+def test_compute_all_metrics_opt_in_keys_absent_by_default() -> None:
+    """Experimental surfaces are absent unless explicitly enabled."""
+    data = _straight_line_episode()
+    values = compute_all_metrics(data, horizon=10, shortest_path_len=3.0)
+    assert "ped_impact_accel_delta_mean" not in values
+    assert "human_proxy_available" not in values
+    assert "near_misses_ttc" not in values


### PR DESCRIPTION
## What

Adds **NEW characterization-test baselines only — zero production-code changes** for the four most-depended-on benchmark modules listed in #4874, in value order. These pin the *current observable behavior* on small synthetic inputs so the post-submission refactor wave (#4770) can prove behavior-preservation by re-running these tests and observing identical results.

This **fully resolves #4874**: every named target module gets table-driven, exact-golden-value characterization tests including the required edge cases (empty inputs, single episode, NaN/Inf where finite-guards exist).

Closes #4874

## Why

#4770 is a behavior-preserving refactor wave. Without a locked behavioral baseline, "behavior-preserving" is an uncheckable claim. These tests turn current observable behavior into an executable contract: if the refactor drifts, a characterization test fails with a concrete numeric diff. They are additive and deliberately do **not** duplicate existing property/contract coverage (e.g. `test_aggregate_snqi_recompute.py`, `test_constraints_first_scoring.py`, `test_exemplar_selection.py`, the `*_metric_contract.py` files).

## Files added (all under `tests/`, 1487 lines, no production code touched)

- `tests/benchmark/test_aggregate_characterization.py` (28 tests)
  - `flatten_metrics`: id fields, force-quantile promotion, schema-block → prefixed-column mapping (pedestrian-impact / social-acceptability / human-interaction-proxy / social-mini-game / CLEAR / inter-robot), `distributional_disruption` drop, empty/`None`-metrics → all-None rows.
  - `compute_aggregates`: exact mean/median/p95, bool→float `success` coercion, NaN-aware aggregation, `_meta` block shape, `expected_algorithms` missing-reporting, empty-records → `_meta`-only, dotted-path `group_by` + scenario fallback, mixed-track strict rejection vs diagnostic-cross-track separation.
  - Observation-track helpers (`build_observation_track_meta`, `resolve_benchmark_track`, `normalize_observation_track_mode`), `read_jsonl` strict/non-strict, `write_episode_csv` header ordering + blank cells, locked `__all__`.

- `tests/benchmark/test_metrics_characterization.py` (26 tests)
  - Radius-aware clearance/collision/near-miss **parametrized table** (overlap / near-miss / clear), mean distance/clearance, K=0 documented guards (0 counts, NaN distances).
  - `success_rate`/`timeout`/`time_to_goal`, straight-line path/energy/jerk/curvature/efficiency golden values, single-timestep path length.
  - Force metrics on known magnitudes, `per_ped_force_quantiles` averaging, **finite-guards** for all-zero/all-NaN forces (`has_force_data`, `force_sample_stats` statuses), NaN-return-on-missing-force-data.
  - `snqi` normalization table (with/without baseline, unit-interval clipping, NaN/None safe-fallback), `evaluate_stability_margin` clamping/NaN/geometry validation, `compute_all_metrics` key surface + opt-in absence.

- `tests/benchmark/test_constraints_first_characterization.py` (18 tests)
  - Exact Clopper-Pearson UCB values, invalid-argument rejection.
  - `survivorship_aware_metric` conditioning-bias delta + non-numeric exclusion, planner-summary exact rates/schema, admissibility gates, ranking-inversion (match/swap/mismatched-set), report shape + ranking-inversion omission + admissible-rate-as-cf-score, planner grouping.

- `tests/benchmark/test_exemplar_selection_characterization.py` (12 tests)
  - Full `SelectedEpisode` golden record (all fields incl. `reason`/`seed` defaults), best/worst index + rank pinning, all-three-modes ordering.
  - Edge cases: empty input, single-episode-per-cell, ties, all-missing-metric → skipped cell, sorted multi-cell order.
  - Grouping-key normalization + cell-key format, locked `METRIC_DIRECTIONS` mapping, manifest pinned fields + auto-direction + JSON round-trip.

## Validation

CPU-level only (no campaigns / Slurm / training / benchmark or paper claims):

```
$ uv run pytest tests/benchmark/test_aggregate_characterization.py \
    tests/benchmark/test_metrics_characterization.py \
    tests/benchmark/test_constraints_first_characterization.py \
    tests/benchmark/test_exemplar_selection_characterization.py -q
84 passed in 0.94s

$ uv run ruff check <the four files>
All checks passed!

$ uv run ruff format --check <the four files>
4 files already formatted
```

Golden values were anchored empirically against current behavior before being baked in (e.g. numpy linear-interp `p95([0,1])=0.95`, `beta.ppf(0.95,1,20)=0.139108…`, radius-sum clearance `d−1.4`, `snqi` normalization arithmetic). No test revealed a genuine bug; nothing to file separately.

## Scope statement

- Production code: unchanged (`git diff` is empty outside `tests/`).
- No campaign/Slurm/training runs; no benchmark or paper-grade claims. These are characterization locks, evidence-grade `smoke evidence` at most.

---

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.
