### PR TITLE
Issue #4871: CrowdNav_Prediction_AttnGraph feasibility smoke (cheap-lane worker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #4871 CrowdNav_Prediction_AttnGraph external learned-baseline feasibility smoke.** New
+  `robot_sf/planner/crowdnav_pred_attng.py` is the thinnest model-only adapter proving the shipped
+  ICRA 2023 attention-graph SRNN checkpoint (`41200.pt`, MIT, pinned at upstream `3907731`) loads and
+  acts on synthetic Robot SF observations, plus the per-step wall-clock measurement. The repo is
+  registered in `scripts/tools/manage_external_repos.py` (`stage crowdnav_pred_attng`) and the
+  PyTorch-only inference path is exercised via a `tests/planner/test_crowdnav_pred_attng.py` smoke
+  that skips cleanly when the repo is not staged. The adapter reconstructs the upstream dict
+  observation (5-step constant-velocity future edges, holonomic `ActionXY`) and reports ~1–2 ms/step
+  on CPU, flat in neighbor count. Verdict recorded in `docs/benchmark_experimental_planners.md` with
+  the full contract + transfer-caveat analysis in
+  `docs/context/issue_4871_crowdnav_pred_attng_smoke.md`. Claim boundary: `smoke evidence` only —
+  no roster addition (not in `algorithm_metadata`/`algorithm_readiness`), no benchmark campaign, no
+  retraining; zero-shot transfer into Robot SF is documented as not defensible without an
+  out-of-training-distribution caveat (holonomic vs unicycle, ORCA vs social-force crowd, GST
+  prediction variant needs TensorFlow).
 * **issue #3501 safety-wrapper deadlock-recovery stage wired into benchmark runtime.** The stateful
   fourth wrapper stage (`DeadlockRecoveryMonitor`) is now bound into the benchmark episode step loop
   via `robot_sf/benchmark/safety_wrapper_runtime.py`. `SafetyWrapperRuntimeConfig` gains an opt-in

--- a/docs/benchmark_experimental_planners.md
+++ b/docs/benchmark_experimental_planners.md
@@ -136,3 +136,16 @@ testing-only planners. None of them currently meet the promotion bar.
 - Keep all testing-only planners behind `allow_testing_algorithms: true`.
 - Treat their existing benchmark notes as negative evidence, not missing paperwork.
 - Do not remove the guard for documentation completeness alone.
+
+## External learned-baseline feasibility smokes
+
+These are go/no-go records for reusing third-party learned planners as external
+baselines. They are **pre-roster**: a smoke PASS means the upstream loads and acts
+locally, not that the planner is benchmark-ready or rostered. Zero-shot transfer
+into Robot SF scenarios requires the documented out-of-training-distribution
+caveats; roster/campaign decisions are separate maintainer calls.
+
+| External baseline | Upstream | Smoke verdict | Per-step | Blocker for any future comparison | Detail |
+| --- | --- | --- | --- | --- | --- |
+| CrowdNav_Prediction_AttnGraph | `Shuijing725/CrowdNav_Prediction_AttnGraph` @ `3907731` (MIT, ICRA 2023) | PASS — checkpoint loads and acts on synthetic observations (model-only adapter, PyTorch path only) | ~1–2 ms CPU, flat in neighbor count | Holonomic `ActionXY` vs Robot SF unicycle; trained on ORCA pedestrians vs default social-force crowd; GST-inferred prediction variant needs TensorFlow. Results need an "evaluated out-of-training-distribution" caveat until reconciled. | `docs/context/issue_4871_crowdnav_pred_attng_smoke.md` (issue #4871) |
+

--- a/docs/context/issue_4871_crowdnav_pred_attng_smoke.md
+++ b/docs/context/issue_4871_crowdnav_pred_attng_smoke.md
@@ -1,0 +1,160 @@
+# Issue #4871 — CrowdNav_Prediction_AttnGraph external learned baseline feasibility smoke
+
+**Status:** smoke PASS (go). Checkpoint loads and acts on synthetic Robot SF
+observations; per-step inference is trivially fast. Zero-shot transfer into Robot
+SF scenarios is **not** scientifically defensible without an explicit
+out-of-training-distribution caveat (see Transfer caveats). This note records the
+go/no-go data only — **no roster addition, no campaign, no retraining**.
+
+**Upstream:** `Shuijing725/CrowdNav_Prediction_AttnGraph` (ICRA 2023, "Intention
+Aware Robot Crowd Navigation with Attention-Based Interaction Graph"), pinned at
+commit `390773137be04ed14e27620dc5fd7c5e1a5b1f62` (MIT). Staged via
+`scripts/tools/manage_external_repos.py stage crowdnav_pred_attng`.
+
+**Artifact:** `robot_sf/planner/crowdnav_pred_attng.py` (model-only adapter) +
+`tests/planner/test_crowdnav_pred_attng.py` (staged-checkout smoke).
+
+## Verdict by issue step
+
+| Step | Gate | Result |
+| --- | --- | --- |
+| 1. Prior art | No prior assessment of this repo; no dormant in-tree scaffold | PASS. The same author's `CrowdNav_HEIGHT` is already integrated as the `crowdnav_height` planner and was used as the template pattern. `grep crowdnav/attn/graph` in `robot_sf/baselines/` and `algorithm_metadata.py` returned no Prediction_AttnGraph entry. |
+| 2. License | MIT permits academic benchmark reuse | PASS. `LICENSE` at the pinned commit is MIT. |
+| 3. Pretrained checkpoints | Authors ship a trained RL navigation policy | PASS (no retraining needed). The "Ours" attention-graph SRNN policy ships as `trained_models/GST_predictor_non_rand/checkpoints/41200.pt` (no randomized humans) and `.../GST_predictor_rand/checkpoints/41665.pt` (randomized humans). The `00000.pt` files under `ORCA_no_rand`/`SF_no_rand` are the non-learning ORCA/SF baselines, not learned weights. |
+| 4. Stage + inference path | Repo stages; checkpoint loads and runs | PASS. Staged at the pinned SHA. The PyTorch policy path loads and runs (model-only adapter; no OpenAI Baselines / `crowd_sim` / Python-RVO2 / TensorFlow install required). |
+| 5. Contract + timing | Thinnest adapter produces actions; per-step wall-clock measured | PASS. Adapter reconstructs the upstream dict observation and calls `policy.act`. Per-step ≈ 1–2 ms on CPU, flat in observed neighbor count. |
+| 6. Record verdict | Gate-doc row written | PASS. See `docs/benchmark_experimental_planners.md`. |
+
+A documented negative at any step would have been a complete deliverable; none of
+the gates failed.
+
+## What was actually exercised (and what was deliberately not)
+
+**Exercised:** the PyTorch RL navigation policy only. The adapter imports
+`rl/networks/model.Policy`, loads `41200.pt` via `torch.load(weights_only=False)`,
+pins `base.nenv = 1` (matching the upstream `test.py` entrypoint), reconstructs
+the upstream dict observation from world-frame Robot SF state, and calls
+`policy.act(..., deterministic=True)`. The import context short-circuits the one
+transitive heavy import (`rl.networks.envs`, which otherwise pulls in `gym` +
+OpenAI Baselines + `crowd_sim`) with a minimal `VecNormalize` stub, so the network
+loads against PyTorch alone.
+
+**Deliberately NOT exercised (follow-up cost classes):**
+- The **TensorFlow GST trajectory-predictor** inference path
+  (`CrowdSimPredRealGST-v0`, `gst_updated/`). The smoke reconstructs the 5-step
+  future positions with a **constant-velocity** model instead, which needs no GST
+  model and no TensorFlow.
+- The full `crowd_sim` rollout / `test.py` evaluation path (OpenAI Baselines,
+  Python-RVO2 for ORCA humans, gym 0.15.7). The smoke is model-only.
+- The randomized-humans checkpoint `41665.pt` (same architecture; not needed for
+  the go/no-go).
+
+## Checkpoint architecture (state_dict is authoritative)
+
+The bundled `trained_models/GST_predictor_non_rand/configs/config.py` sets
+`predict_method='none'` and `arguments.py` sets `env_name='CrowdSimVarNum-v0'`,
+which would build the spatial-attention input with width 2. **That does not match
+the shipped weights.** `load_state_dict` fails with
+`base.spatial_attn.embedding_layer.0` = `Linear(12→128)`, i.e. the checkpoint was
+trained with the 5-step **prediction** variant. The adapter therefore uses
+`env_name='CrowdSimPred-v0'` (spatial input width `2*(predict_steps+1) = 12`),
+which loads cleanly. The directory name `GST_predictor_*` is consistent with the
+weights; the bundled test config is simply inconsistent and would need editing to
+run upstream `test.py` against this checkpoint.
+
+Confirmed architecture (`human_num=20`, holonomic 2-D action):
+
+- `base.spatial_attn.embedding_layer.0` `Linear(12→128)` → 5-step prediction edges
+- `base.robot_linear.0` `Linear(9→256)` → `cat(temporal_edges[2], robot_node[7])`
+- `base.spatial_linear.0` `Linear(512→256)` → human-human self-attention (`use_self_attn`)
+- `base.attn` `EdgeAttention_M` → robot-human attention (`use_hr_attn`)
+- `base.humanNodeRNN` (`EndRNN`, GRU size 128) → recurrent node state
+- `dist.fc_mean` `Linear(256→2)` + `dist.logstd` → `DiagGaussian` holonomic `ActionXY(vx,vy)`
+- recurrent state: dict with `human_node_rnn` `(1,1,128)` and `human_human_edge_rnn` `(1,21,256)`
+
+## Observation contract mapping (Robot SF → upstream)
+
+Upstream `crowd_sim/envs/crowd_sim_pred.py generate_ob`, reconstructed in the adapter:
+
+| Upstream field | Shape | Source from Robot SF `Observation` |
+| --- | --- | --- |
+| `robot_node` | `(1,7)` `[px,py,r,gx,gy,v_pref,theta]` | `robot.position`, `robot.radius`, `robot.goal`, `v_pref=1.0`, `theta=atan2(vy,vx)` |
+| `temporal_edges` | `(1,2)` `[vx,vy]` | `robot.velocity` |
+| `spatial_edges` | `(20,12)` | per closest-20 pedestrian: current + 5 const-velocity future positions, world-frame relative to robot, sorted by current distance, padded with sentinel 15 |
+| `detected_human_num` | `(1,)` | `min(agent_count, 20)`, floored at 1 |
+
+Action mapping: upstream emits holonomic `ActionXY(vx,vy)`, clipped to magnitude
+`v_pref=1.0` (upstream `clip_action`). This is a valid Robot SF `velocity`-space
+command. **Projection to a unicycle `(v, ω)` command is an explicit transfer
+caveat, not a silent transform** — the adapter returns `(vx, vy)`.
+
+## Per-step inference wall-clock
+
+CPU (single thread, `torch.set_num_threads(1)`), 30-step mean after 3 warmup
+steps, from `tests/planner/test_crowdnav_pred_attng.py`:
+
+| Observed neighbors | ms/step |
+| --- | --- |
+| 2 | ~2.2 |
+| 5 | ~2.2 |
+| 10 | ~2.2 |
+| 20 | ~2.2 |
+
+Flat in observed neighbor count because `human_num` is fixed at 20 (padding), so
+the attention cost is constant. Standalone (outside pytest) ≈ 1.1 ms/step. Either
+way this is far below any Robot SF benchmark step budget; **runtime is not the
+blocker for this planner family**.
+
+Sanity signal: with the robot at the origin and the goal at `(5, 0)` in open
+space, the deterministic action is `≈ (0.98, -0.18)` — strongly toward the goal,
+i.e. the loaded weights compute meaningful navigation, not noise.
+
+## Transfer caveats (the real question — zero-shot into Robot SF is NOT defensible)
+
+Any future comparison slice must frame results as **policy evaluated
+out-of-training-distribution** until the mismatches below are reconciled:
+
+1. **Kinematics: holonomic vs differential-drive.** Upstream trains/outputs
+   holonomic `ActionXY(vx,vy)`. Robot SF default robots are unicycle `(v, ω)`.
+   A holonomic→unicycle projection (e.g. align linear speed along heading, derive
+   `ω` from heading error) changes the reachable action set and must be a
+   deliberate, documented decision, not a silent remap.
+2. **Pedestrian model: ORCA vs social-force.** Upstream trains against ORCA
+   pedestrians (`humans.policy="orca"`); Robot SF default crowd is social-force.
+   The learned interaction graph encodes ORCA avoidance dynamics, so zero-shot
+   transfer to social-force crowds is the headline OOD risk. The SICNav smoke
+   (#4870) carries the same caveat; a future comparison would need an ORCA
+   pedestrian mode in Robot SF and explicit framing.
+3. **Prediction variant vs the paper's headline.** The smoke uses a
+   **constant-velocity** 5-step prediction (no GST/TensorFlow). The paper's
+   "intention-aware" contribution is the GST-inferred prediction. Exercising the
+   GST variant is a separate, heavier dependency path (TensorFlow + GST weights).
+4. **Sensing radius / FOV.** Upstream `robot.sensor_range=5`, `FOV=2π` (full).
+   Robot SF sensor models differ; any radius/FOV mismatch changes which humans
+   populate the spatial edges.
+5. **Human-count cap.** Upstream `human_num=20` fixed; denser Robot SF scenarios
+   truncate to the 20 closest, sparser ones pad with the sentinel. The
+   attention mask (`detected_human_num`) handles this correctly, but it is a
+   capacity assumption.
+6. **Control cadence.** Upstream `env.time_step=0.25s`; the recurrent policy was
+   trained at that cadence. The adapter enforces 0.25s and rejects other `dt`.
+   Robot SF typically steps at a different cadence; running the recurrent policy
+   at the wrong cadence changes its dynamics.
+7. **Preferred speed.** Upstream `v_pref=1.0 m/s`; Robot SF robots have different
+   speed envelopes. The clip normalizes to 1.0, which may under-use a faster robot
+   or over-command a slower one.
+8. **Reward / arena.** Upstream is open-space circle-crossing (arena radius 6,
+   discomfort dist 0.25, collision penalty −20). Robot SF scenarios include
+   static obstacles and doorway geometry that this open-space policy never saw.
+
+## What this issue is NOT
+
+- **Not a roster addition.** The planner is not registered in
+  `algorithm_metadata`, `algorithm_readiness`, or the testing-only list. It must
+  not enter benchmark sweeps.
+- **Not a campaign / benchmark claim.** No success/collision numbers are claimed
+  for Robot SF scenarios. The upstream test log (0.92 success, 0.07 collision on
+  their 20-human ORCA circle-crossing) is upstream-environment context only.
+- **Not a retraining.** The shipped checkpoint is used as-is.
+
+Roster/campaign/retraining decisions are separate maintainer calls after this smoke.

--- a/robot_sf/planner/crowdnav_pred_attng.py
+++ b/robot_sf/planner/crowdnav_pred_attng.py
@@ -1,0 +1,568 @@
+"""Feasibility-smoke adapter for the CrowdNav_Prediction_AttnGraph learned baseline.
+
+Issue #4871 asked for a go/no-go feasibility smoke for reusing
+``Shuijing725/CrowdNav_Prediction_AttnGraph`` (ICRA 2023, intention-aware crowd
+navigation with an attention-based interaction graph) as an external *learned*
+baseline planner. This module is the thinnest model-only adapter that proves the
+shipped checkpoint loads and produces an action on synthetic Robot SF
+observations, plus the per-step wall-clock measurement the issue asks for.
+
+Scope guardrails (carry into every downstream doc):
+
+* This is a **smoke**, not a roster addition. It is intentionally NOT registered
+  in ``algorithm_metadata`` / ``algorithm_readiness`` and must not enter benchmark
+  sweeps without a separate maintainer decision.
+* Only the **PyTorch RL navigation policy** path is exercised. The shipped
+  ``41200.pt`` checkpoint ("Ours without randomized humans") trains/runs as the
+  ``CrowdSimPred-v0`` attention-graph policy with a 5-step future-position edge.
+  The smoke reconstructs those futures with a constant-velocity model, so the
+  checkpoint needs nothing beyond PyTorch at inference (no TensorFlow/GST model).
+  Note: the bundled test config mismatches the weights (it declares
+  ``CrowdSimVarNum-v0`` / ``predict_method='none'``); the state_dict is
+  authoritative — see ``docs/context/issue_4871_crowdnav_pred_attng_smoke.md``.
+* The **TensorFlow GST trajectory-predictor** variant (``CrowdSimPredRealGST-v0``,
+  ``41665.pt``) and the full ``crowd_sim`` / OpenAI Baselines / Python-RVO2 stack
+  are out of scope for this smoke and are documented as a higher-fidelity
+  follow-up cost class in ``docs/context/issue_4871_crowdnav_pred_attng_smoke.md``.
+
+The adapter mirrors the established CrowdNav_HEIGHT pattern (``crowdnav_height.py``):
+reconstruct the upstream dict observation from world-frame Robot SF state, load the
+upstream ``Policy`` checkpoint with ``torch.load``, and call ``policy.act`` directly.
+No simulator, no ORCA/RVO2, no OpenAI Baselines install is required to run the
+network forward.
+"""
+
+from __future__ import annotations
+
+import importlib
+import math
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import torch
+from gymnasium import spaces
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Staged checkout written by ``scripts/tools/manage_external_repos.py stage
+# crowdnav_pred_attng`` (gitignored under third_party/external_repos/).
+_DEFAULT_REPO_ROOT = Path("third_party/external_repos/crowdnav_pred_attng")
+# Shipped "Ours without randomized humans" checkpoint. The state_dict is the
+# CrowdSimPred-v0 attention-graph policy (5-step future-position edge, width 12);
+# the bundled test config mismatches it (declares CrowdSimVarNum-v0 / width 2).
+# The smoke reconstructs the 5 futures with a constant-velocity model, so no
+# TensorFlow/GST model is needed at inference.
+_DEFAULT_MODEL_SUBDIR = Path("trained_models/GST_predictor_non_rand")
+_DEFAULT_CHECKPOINT_NAME = "41200.pt"
+
+# Architecture + sim constants frozen by the pinned commit and the bundled
+# trained_models/GST_predictor_non_rand/{arguments.py,configs/config.py}.
+# Cite those files as the source of truth; they are fixed for a pinned SHA.
+_DEFAULT_HUMAN_NUM = 20
+_DEFAULT_TIME_STEP = 0.25
+_DEFAULT_V_PREF = 1.0
+_DEFAULT_SENSOR_RANGE = 5.0
+_DEFAULT_ROBOT_RADIUS = 0.3
+# Number of predicted future steps baked into each spatial edge. The checkpoint's
+# spatial_attn input is 2*(predict_steps+1) = 12, so predict_steps=5.
+_DEFAULT_PREDICT_STEPS = 5
+# Sentinel the upstream env uses to pad invisible / missing humans in the sorted
+# spatial-edge tensor (see crowd_sim/envs/crowd_sim_var_num.py generate_ob).
+_PAD_DISTANCE = 15.0
+
+
+@dataclass(frozen=True)
+class CrowdNavPredAttnGraphConfig:
+    """Configuration for loading one upstream CrowdNav_Prediction_AttnGraph checkpoint."""
+
+    repo_root: Path = _DEFAULT_REPO_ROOT
+    model_subdir: Path = _DEFAULT_MODEL_SUBDIR
+    checkpoint_name: str = _DEFAULT_CHECKPOINT_NAME
+    device: str = "cpu"
+    human_num: int = _DEFAULT_HUMAN_NUM
+    time_step: float = _DEFAULT_TIME_STEP
+    v_pref: float = _DEFAULT_V_PREF
+    sensor_range: float = _DEFAULT_SENSOR_RANGE
+    robot_radius: float = _DEFAULT_ROBOT_RADIUS
+    predict_steps: int = _DEFAULT_PREDICT_STEPS
+
+
+def build_crowdnav_pred_attng_config(data: dict[str, Any] | None) -> CrowdNavPredAttnGraphConfig:
+    """Build adapter config from a benchmark algo-config payload.
+
+    Returns:
+        CrowdNavPredAttnGraphConfig resolved from the payload with smoke defaults.
+    """
+    payload = data or {}
+    device = str(payload.get("device", "cpu")).strip() or "cpu"
+    human_num = int(payload.get("human_num", _DEFAULT_HUMAN_NUM))
+    time_step = float(payload.get("time_step", _DEFAULT_TIME_STEP))
+    v_pref = float(payload.get("v_pref", _DEFAULT_V_PREF))
+    if human_num <= 0:
+        raise ValueError("human_num must be positive")
+    if time_step <= 0.0:
+        raise ValueError("time_step must be positive")
+    if v_pref <= 0.0:
+        raise ValueError("v_pref must be positive")
+    return CrowdNavPredAttnGraphConfig(
+        repo_root=Path(str(payload.get("repo_root", _DEFAULT_REPO_ROOT))),
+        model_subdir=Path(str(payload.get("model_subdir", _DEFAULT_MODEL_SUBDIR))),
+        checkpoint_name=str(payload.get("checkpoint_name", _DEFAULT_CHECKPOINT_NAME)),
+        device=device,
+        human_num=human_num,
+        time_step=time_step,
+        v_pref=v_pref,
+        sensor_range=float(payload.get("sensor_range", _DEFAULT_SENSOR_RANGE)),
+        robot_radius=float(payload.get("robot_radius", _DEFAULT_ROBOT_RADIUS)),
+        predict_steps=int(payload.get("predict_steps", _DEFAULT_PREDICT_STEPS)),
+    )
+
+
+@lru_cache(maxsize=1)
+def _default_args_namespace() -> Any:
+    """Return the upstream ``args`` namespace for the no_rand checkpoint.
+
+    Values are frozen by the pinned commit and the bundled
+    ``trained_models/GST_predictor_non_rand/arguments.py``. They reconstruct the
+    ``selfAttn_merge_SRNN`` architecture that the ``41200.pt`` state_dict expects.
+
+    Returns:
+        A ``types.SimpleNamespace`` matching the upstream args contract.
+    """
+    return _build_args_namespace(
+        # env_name=CrowdSimPred-v0 selects SpatialEdgeSelfAttn.input_size=12
+        # (current + 5 const-velocity predicted positions), which is what the
+        # 41200.pt state_dict was trained with. The bundled test config's
+        # env_name=CrowdSimVarNum-v0 / predict_method='none' does NOT match the
+        # shipped weights (input_size=2); the checkpoint is authoritative.
+        # CrowdSimPred-v0 uses constant-velocity OR ground-truth prediction and
+        # needs NO TensorFlow/GST model at inference.
+        env_name="CrowdSimPred-v0",
+        use_self_attn=True,
+        use_hr_attn=True,
+        sort_humans=True,
+        no_cuda=True,
+        num_processes=1,
+    )
+
+
+def _build_args_namespace(
+    *,
+    env_name: str,
+    use_self_attn: bool,
+    use_hr_attn: bool,
+    sort_humans: bool,
+    no_cuda: bool,
+    num_processes: int,
+) -> Any:
+    """Build an upstream-compatible args namespace for the SRNN policy family.
+
+    Returns:
+        ``types.SimpleNamespace`` carrying the network-architecture fields read
+        by ``rl/networks/{model,srnn_model,selfAttn_srnn_temp_node}.py``.
+    """
+    # env_type is read by the plain SRNN base (robot_size branch); the
+    # selfAttn_merge_SRNN network hardcodes robot_size=9, so this only matters
+    # for faithful args completeness.
+    return SimpleNamespace(
+        env_name=env_name,
+        env_type="crowd_sim",
+        use_self_attn=use_self_attn,
+        use_hr_attn=use_hr_attn,
+        sort_humans=sort_humans,
+        no_cuda=no_cuda,
+        cuda=False,
+        # Recurrent graph sizes.
+        human_node_rnn_size=128,
+        human_human_edge_rnn_size=256,
+        human_node_output_size=256,
+        # Input / output / embedding sizes.
+        human_node_input_size=3,
+        human_human_edge_input_size=2,
+        human_node_embedding_size=64,
+        human_human_edge_embedding_size=64,
+        attention_size=64,
+        # Rollout bookkeeping (only nenv=1 matters at infer time).
+        seq_length=30,
+        num_processes=num_processes,
+        num_mini_batch=2,
+    )
+
+
+@contextmanager
+def _pred_attng_import_context(repo_root: Path) -> Iterator[None]:
+    """Expose the upstream checkout and short-circuit the heavy env import.
+
+    ``rl/networks/network_utils.py`` imports ``VecNormalize`` from
+    ``rl.networks.envs``, which otherwise drags in ``gym`` + OpenAI Baselines +
+    the crowd_sim stack. The model-only smoke never touches that runtime path, so
+    we pre-inject a minimal stub for ``rl.networks.envs`` and let the real
+    ``rl.networks.model`` / ``srnn_model`` / ``selfAttn_srnn_temp_node`` modules
+    load against PyTorch only.
+
+    Yields:
+        None; the upstream package is importable for the duration of the block.
+    """
+    repo_str = str(repo_root)
+    original_path = list(sys.path)
+    injected: set[str] = set()
+    stub_keys: tuple[str, ...] = ("rl.networks.envs",)
+    original_modules = {key: sys.modules[key] for key in stub_keys if key in sys.modules}
+    for key in stub_keys:
+        sys.modules.pop(key, None)
+    sys.path.insert(0, repo_str)
+    # Minimal stub: network_utils only needs the VecNormalize name bound.
+    envs_stub = ModuleType("rl.networks.envs")
+
+    class _VecNormalize:  # pragma: no cover - never instantiated by the smoke
+        """Placeholder satisfying ``from rl.networks.envs import VecNormalize``."""
+
+    envs_stub.VecNormalize = _VecNormalize  # type: ignore[attr-defined]
+    sys.modules["rl.networks.envs"] = envs_stub
+    injected.add("rl.networks.envs")
+    try:
+        yield
+    finally:
+        for key in injected:
+            sys.modules.pop(key, None)
+        sys.modules.update(original_modules)
+        sys.path[:] = original_path
+
+
+def _build_observation_space(human_num: int, predict_steps: int) -> spaces.Dict:
+    """Mirror the upstream CrowdSimPred dict observation layout.
+
+    Returns:
+        Gymnasium dict space matching the checkpoint input contract. Only
+        ``spatial_edges`` shape[0] (human_num) is read by the network
+        constructor; the per-edge width 2*(predict_steps+1) is recorded for
+        faithfulness.
+    """
+    edge_width = 2 * (predict_steps + 1)
+    return spaces.Dict(
+        {
+            # robot_node: px, py, r, gx, gy, v_pref, theta
+            "robot_node": spaces.Box(low=-np.inf, high=np.inf, shape=(1, 7), dtype=np.float32),
+            "temporal_edges": spaces.Box(low=-np.inf, high=np.inf, shape=(1, 2), dtype=np.float32),
+            "spatial_edges": spaces.Box(
+                low=-np.inf, high=np.inf, shape=(human_num, edge_width), dtype=np.float32
+            ),
+            "detected_human_num": spaces.Box(
+                low=-np.inf, high=np.inf, shape=(1,), dtype=np.float32
+            ),
+            "visible_masks": spaces.Box(
+                low=-np.inf, high=np.inf, shape=(human_num,), dtype=np.float32
+            ),
+        }
+    )
+
+
+def _xy_rows(value: Any) -> np.ndarray:
+    """Normalize arbitrary XY payloads to an ``(N, 2)`` array.
+
+    Returns:
+        Two-column float array with one row per vector (empty when no data).
+    """
+    arr = np.asarray([] if value is None else value, dtype=float)
+    if arr.size == 0:
+        return np.zeros((0, 2), dtype=float)
+    arr = arr.reshape(-1, arr.shape[-1] if arr.ndim > 1 else 1)
+    if arr.shape[1] < 2:
+        return np.zeros((0, 2), dtype=float)
+    return arr[:, :2]
+
+
+def _require_xy(value: Any, field: str) -> np.ndarray:
+    """Return a required 2-vector or raise a contract error.
+
+    Accepts flat ``[x, y]`` or nested ``[[x, y]]`` payloads uniformly.
+
+    Returns:
+        Two-element float array.
+    """
+    arr = np.asarray([] if value is None else value, dtype=float).reshape(-1)
+    if arr.size < 2:
+        raise ValueError(f"Missing or malformed required field: {field}")
+    return arr[:2]
+
+
+class CrowdNavPredAttnGraphAdapter:
+    """Stateful model-only adapter around one upstream AttnGraph checkpoint.
+
+    The adapter reconstructs the upstream dict observation from world-frame
+    Robot SF state and runs one recurrent forward pass per step. It emits a
+    holonomic ``(vx, vy)`` velocity command (the upstream ``ActionXY``), which is
+    a valid Robot SF ``velocity``-space action; projection to a unicycle command
+    is an explicit transfer caveat documented in the smoke note, not a silent
+    transform.
+    """
+
+    upstream_policy = "rl.networks.model.Policy[selfAttn_merge_SRNN]"
+    projection_policy = "holonomic_velocity_xy_clipped_to_v_pref"
+
+    def __init__(self, config: CrowdNavPredAttnGraphConfig | None = None) -> None:
+        """Initialize the adapter and load the upstream checkpoint."""
+        self.config = config or CrowdNavPredAttnGraphConfig()
+        self.repo_root = self.config.repo_root.resolve()
+        self.checkpoint_path = (
+            self.repo_root / self.config.model_subdir / "checkpoints" / self.config.checkpoint_name
+        ).resolve()
+        if not self.repo_root.exists():
+            raise FileNotFoundError(
+                "CrowdNav_Prediction_AttnGraph checkout not found: "
+                f"{self.config.repo_root}. Run "
+                "`uv run python scripts/tools/manage_external_repos.py stage crowdnav_pred_attng`."
+            )
+        if not self.checkpoint_path.exists():
+            raise FileNotFoundError(
+                "Checkpoint not found in staged checkout: "
+                f"{self.checkpoint_path}. Restage the pinned commit."
+            )
+
+        self._device = torch.device(self.config.device)
+        self._human_num = int(self.config.human_num)
+        self._args = _default_args_namespace()
+        observation_space = _build_observation_space(self._human_num, self.config.predict_steps)
+        # Holonomic ActionXY -> 2D continuous Box; DiagGaussian head in the Policy.
+        action_space = spaces.Box(low=-np.inf, high=np.inf, shape=(2,), dtype=np.float32)
+        with _pred_attng_import_context(self.repo_root):
+            policy_mod = importlib.import_module("rl.networks.model")
+            self._policy = policy_mod.Policy(
+                observation_space.spaces,
+                action_space,
+                base="selfAttn_merge_srnn",  # upstream Policy selects the base CLASS by this name
+                base_kwargs=self._args,
+            )
+        # Match the upstream test entrypoint: load weights then pin nenv=1.
+        # weights_only=False because these are legacy torch.save checkpoints
+        # (saved under torch 1.12.1) that may carry non-tensor objects.
+        state_dict = torch.load(self.checkpoint_path, map_location=self._device, weights_only=False)
+        self._policy.load_state_dict(state_dict)
+        self._policy.base.nenv = 1
+        self._policy.to(self._device)
+        self._policy.eval()
+        self.reset()
+
+    def reset(self, seed: int | None = None) -> None:
+        """Reset the two SRNN recurrent hidden-state tensors to zeros."""
+        del seed
+        base = self._policy.base
+        self._hidden_state = {
+            "human_node_rnn": torch.zeros(
+                (1, 1, int(base.human_node_rnn_size)), dtype=torch.float32, device=self._device
+            ),
+            "human_human_edge_rnn": torch.zeros(
+                (1, self._human_num + 1, int(base.human_human_edge_rnn_size)),
+                dtype=torch.float32,
+                device=self._device,
+            ),
+        }
+        self._mask = torch.zeros((1, 1), dtype=torch.float32, device=self._device)
+
+    def _extract_robot_sf_fields(
+        self, observation: dict[str, Any]
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, float, np.ndarray, np.ndarray]:
+        """Extract world-frame Robot SF state from a benchmark observation payload.
+
+        Accepts either the canonical ``robot_sf.baselines.interface.Observation``
+        field layout (``robot``/``agents``/``dt``) or the planner nested
+        ``robot``/``goal``/``pedestrians`` layout used elsewhere in the tree.
+
+        Returns:
+            Tuple of (robot_position, robot_velocity, robot_goal, robot_radius,
+            pedestrian ``(N, 2)`` positions, pedestrian ``(N, 2)`` velocities).
+        """
+        robot = observation.get("robot", {})
+        agents = observation.get("agents")
+        if robot and (agents is not None or "pedestrians" in observation):
+            robot_pos = _require_xy(robot.get("position"), "robot.position")
+            robot_vel = _require_xy(robot.get("velocity"), "robot.velocity")
+            robot_goal = _require_xy(robot.get("goal", robot.get("current")), "robot.goal")
+            robot_radius = float(
+                np.asarray(robot.get("radius", self.config.robot_radius)).reshape(-1)[0]
+            )
+            if agents is not None:
+                ped_positions = _xy_rows([a.get("position") for a in agents])
+                ped_velocities = _xy_rows([a.get("velocity", [0.0, 0.0]) for a in agents])
+            else:
+                ped = observation.get("pedestrians", {})
+                ped_positions = _xy_rows(ped.get("positions"))
+                ped_velocities = _xy_rows(ped.get("velocities"))
+            return robot_pos, robot_vel, robot_goal, robot_radius, ped_positions, ped_velocities
+
+        # Flat benchmark fallback.
+        robot_pos = _require_xy(observation.get("robot_position"), "robot_position")
+        robot_vel = _require_xy(observation.get("robot_velocity_xy"), "robot_velocity_xy")
+        robot_goal = _require_xy(observation.get("goal_current"), "goal_current")
+        robot_radius = float(
+            np.asarray(observation.get("robot_radius", self.config.robot_radius)).reshape(-1)[0]
+        )
+        ped_positions = _xy_rows(observation.get("pedestrians_positions"))
+        ped_velocities = _xy_rows(observation.get("pedestrians_velocities"))
+        return robot_pos, robot_vel, robot_goal, robot_radius, ped_positions, ped_velocities
+
+    def _build_model_inputs(
+        self, observation: dict[str, Any]
+    ) -> tuple[dict[str, torch.Tensor], dict[str, Any]]:
+        """Reconstruct the upstream dict observation as batched torch tensors.
+
+        Spatial edges follow the upstream ``crowd_sim_pred.CrowdSimPred.generate_ob``
+        layout: per human, the current position followed by ``predict_steps``
+        constant-velocity future positions (all world-frame deltas relative to the
+        robot), sorted by current-position distance ascending, capped at
+        ``human_num`` and padded with the sentinel.
+
+        Returns:
+            Batched torch tensors (num_processes=1) and a metadata dict for tracing.
+        """
+        (
+            robot_pos,
+            robot_vel,
+            robot_goal,
+            robot_radius,
+            ped_positions,
+            ped_velocities,
+        ) = self._extract_robot_sf_fields(observation)
+
+        # Holonomic heading from velocity (upstream robot_node carries theta but
+        # the spatial edges are world-frame deltas, so theta only informs the
+        # robot node, not a frame rotation).
+        speed = float(np.linalg.norm(robot_vel))
+        theta = float(np.arctan2(robot_vel[1], robot_vel[0])) if speed > 1e-8 else 0.0
+        robot_node = np.array(
+            [
+                [
+                    float(robot_pos[0]),
+                    float(robot_pos[1]),
+                    float(robot_radius),
+                    float(robot_goal[0]),
+                    float(robot_goal[1]),
+                    float(self.config.v_pref),
+                    theta,
+                ]
+            ],
+            dtype=np.float32,
+        )
+        temporal_edges = np.array([[float(robot_vel[0]), float(robot_vel[1])]], dtype=np.float32)
+
+        # Build (current + predict_steps) const-velocity positions per human,
+        # relative to the robot, then sort by current distance and cap/pad.
+        n = int(ped_positions.shape[0])
+        if n > 0:
+            steps = np.arange(0, self.config.predict_steps + 1, dtype=float)  # [0..5]
+            # pos_k = pos_0 + vel * k * time_step (pred_interval=1).
+            future = ped_positions[:, None, :] + ped_velocities[:, None, :] * (
+                steps[None, :, None] * float(self.config.time_step)
+            )  # (n, predict_steps+1, 2)
+            rel = future - np.asarray(robot_pos, dtype=float).reshape(1, 1, 2)  # robot-relative
+            order = np.argsort(np.linalg.norm(rel[:, 0, :], axis=1))  # by current position
+            rel = rel[order][: self._human_num].reshape(-1, 2 * (self.config.predict_steps + 1))
+        else:
+            rel = np.zeros((0, 2 * (self.config.predict_steps + 1)), dtype=np.float32)
+        detected = max(1, int(rel.shape[0]))
+        spatial = np.full(
+            (self._human_num, 2 * (self.config.predict_steps + 1)),
+            _PAD_DISTANCE,
+            dtype=np.float32,
+        )
+        spatial[: rel.shape[0]] = rel.astype(np.float32)
+
+        payload = {
+            "robot_node": robot_node,
+            "temporal_edges": temporal_edges,
+            "spatial_edges": spatial,
+            "detected_human_num": np.asarray([float(detected)], dtype=np.float32),
+            "visible_masks": np.zeros((self._human_num,), dtype=np.float32),
+        }
+        tensors = {
+            key: torch.from_numpy(np.ascontiguousarray(value)).unsqueeze(0).to(self._device)
+            for key, value in payload.items()
+        }
+        meta = {
+            "detected_human_num": detected,
+            "raw_pedestrian_count": int(ped_positions.shape[0]),
+            "checkpoint_path": str(self.checkpoint_path),
+        }
+        return tensors, meta
+
+    def act(
+        self, observation: dict[str, Any], *, time_step: float
+    ) -> tuple[float, float, dict[str, Any]]:
+        """Run one recurrent inference step and return a holonomic ``(vx, vy)`` command.
+
+        The command is clipped to the upstream preferred-speed envelope
+        (magnitude <= ``v_pref``) to match the upstream ``clip_action`` behavior.
+
+        Returns:
+            Holonomic ``(vx, vy)`` command plus debug metadata.
+        """
+        if self._hidden_state is None:
+            self.reset()
+        if not np.isfinite(time_step) or time_step <= 0.0:
+            raise ValueError(f"Invalid time_step: {time_step}")
+        # The recurrent policy was trained at a fixed 0.25s cadence; surface a
+        # contract mismatch rather than silently running at another dt.
+        expected = float(self.config.time_step)
+        if not math.isclose(float(time_step), expected, rel_tol=0.0, abs_tol=1e-6):
+            raise ValueError(
+                "CrowdNav_Prediction_AttnGraph adapter expects a fixed time_step of "
+                f"{expected:.6f}s (training cadence), got {float(time_step):.6f}s"
+            )
+        obs_tensors, meta = self._build_model_inputs(observation)
+        with torch.no_grad():
+            _value, action, _log_prob, self._hidden_state = self._policy.act(
+                obs_tensors,
+                self._hidden_state,
+                self._mask,
+                deterministic=True,
+            )
+        # First done step keeps mask=0 (fresh episode); subsequent steps mask=1.
+        self._mask = torch.ones((1, 1), dtype=torch.float32, device=self._device)
+        vx_raw = float(action.reshape(-1)[0].item())
+        vy_raw = float(action.reshape(-1)[1].item())
+        vx, vy = _clip_holonomic_to_v_pref(vx_raw, vy_raw, self.config.v_pref)
+        meta.update(
+            {
+                "raw_action_xy": [vx_raw, vy_raw],
+                "clipped_action_xy": [vx, vy],
+                "projection_policy": self.projection_policy,
+            }
+        )
+        return vx, vy, meta
+
+    def plan(self, observation: dict[str, Any]) -> tuple[float, float]:
+        """Map-runner entrypoint returning only the holonomic ``(vx, vy)`` command.
+
+        Returns:
+            Clipped holonomic velocity command pair.
+        """
+        dt = float(np.asarray(observation.get("dt", self.config.time_step)).reshape(-1)[0])
+        vx, vy, _meta = self.act(observation, time_step=dt)
+        return vx, vy
+
+
+def _clip_holonomic_to_v_pref(vx: float, vy: float, v_pref: float) -> tuple[float, float]:
+    """Replicate the upstream holonomic clip_action (normalize to v_pref).
+
+    Returns:
+        Velocity pair whose magnitude does not exceed ``v_pref``.
+    """
+    norm = float(np.hypot(vx, vy))
+    if norm > v_pref and norm > 0.0:
+        scale = v_pref / norm
+        return vx * scale, vy * scale
+    return vx, vy
+
+
+__all__ = [
+    "CrowdNavPredAttnGraphAdapter",
+    "CrowdNavPredAttnGraphConfig",
+    "build_crowdnav_pred_attng_config",
+]

--- a/scripts/tools/manage_external_repos.py
+++ b/scripts/tools/manage_external_repos.py
@@ -72,6 +72,41 @@ REPOS: tuple[RepoSpec, ...] = (
         ),
         related_issues=(3347, 3366),
     ),
+    RepoSpec(
+        name="crowdnav_pred_attng",
+        title=(
+            "CrowdNav_Prediction_AttnGraph: intention-aware crowd navigation with an "
+            "attention-based interaction graph (ICRA 2023) reference implementation"
+        ),
+        upstream_url="https://github.com/Shuijing725/CrowdNav_Prediction_AttnGraph",
+        fork_url=None,
+        pinned_sha="390773137be04ed14e27620dc5fd7c5e1a5b1f62",
+        stage_path=DEFAULT_STAGE_ROOT / "crowdnav_pred_attng",
+        source_access_date="2026-07-08",
+        license_note=(
+            "MIT License, as reported by GitHub repository license metadata (LICENSE file at the "
+            "pinned commit)."
+        ),
+        license_compatibility_decision=(
+            "compatible for local research/reference staging; MIT permits academic benchmark reuse"
+        ),
+        redistribution_decision=(
+            "public fork allowed by MIT after maintainer review; this registry stages from "
+            "upstream until an ll7 fork is created"
+        ),
+        intended_use=(
+            "Reference checkout for the CrowdNav_Prediction_AttnGraph learned-baseline feasibility "
+            "smoke (issue #4871). Only the PyTorch RL navigation policy path is exercised; the "
+            "TensorFlow GST trajectory-predictor path and OpenAI Baselines/crowd_sim stack are out "
+            "of scope for the smoke. Benchmark roster eligibility remains a separate maintainer "
+            "gate."
+        ),
+        validation_command=(
+            "uv run pytest tests/planner/test_crowdnav_pred_attng.py "
+            "-k crowdnav_pred_attng_skip_without_external_repo -q"
+        ),
+        related_issues=(4871, 1617),
+    ),
 )
 
 

--- a/tests/planner/test_crowdnav_pred_attng.py
+++ b/tests/planner/test_crowdnav_pred_attng.py
@@ -1,0 +1,148 @@
+"""Feasibility-smoke test for the CrowdNav_Prediction_AttnGraph learned baseline adapter.
+
+Issue #4871 asked for a go/no-go smoke that the shipped checkpoint loads and
+produces an action on synthetic Robot SF observations, plus the per-step
+wall-clock measurement. The staged-checkout smoke is skipped unless the external
+repo has been staged with
+``uv run python scripts/tools/manage_external_repos.py stage crowdnav_pred_attng``,
+mirroring the SICNav external-repo smoke convention.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from pathlib import Path
+
+import pytest
+
+from robot_sf.planner.crowdnav_pred_attng import (
+    CrowdNavPredAttnGraphAdapter,
+    CrowdNavPredAttnGraphConfig,
+    build_crowdnav_pred_attng_config,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAGE_PATH = REPO_ROOT / "third_party" / "external_repos" / "crowdnav_pred_attng"
+# Training cadence of the shipped checkpoint (env.time_step). The recurrent
+# policy was trained at 0.25s steps; the adapter enforces this contract.
+TIME_STEP = 0.25
+V_PREF = 1.0
+
+
+def _synthetic_obs(agent_count: int) -> dict[str, object]:
+    """Return a world-frame observation with ``agent_count`` nearby pedestrians.
+
+    The robot starts at the origin heading toward a goal on +x with pedestrians
+    placed beside/ahead so the open-space optimum is to move toward the goal.
+
+    Returns:
+        Benchmark-style observation payload accepted by the adapter.
+    """
+    agents = [
+        {
+            "position": [1.5 + 0.45 * (i % 6), 0.6 * ((i % 3) - 1)],
+            "velocity": [0.1 * ((-1) ** i), 0.0],
+        }
+        for i in range(agent_count)
+    ]
+    return {
+        "dt": TIME_STEP,
+        "robot": {
+            "position": [0.0, 0.0],
+            "velocity": [0.0, 0.0],
+            "goal": [5.0, 0.0],
+            "radius": 0.3,
+        },
+        "agents": agents,
+        "obstacles": [],
+    }
+
+
+def test_config_builder_defaults_point_at_staged_repo() -> None:
+    """Config defaults should point at the license-staged external repo path."""
+    cfg = build_crowdnav_pred_attng_config({})
+    assert cfg.repo_root == Path("third_party/external_repos/crowdnav_pred_attng")
+    assert cfg.checkpoint_name == "41200.pt"
+    assert cfg.human_num == 20
+    assert cfg.time_step == pytest.approx(TIME_STEP)
+    assert cfg.predict_steps == 5
+
+
+def test_config_builder_rejects_invalid_values() -> None:
+    """Invalid human_num / time_step / v_pref should raise immediately."""
+    with pytest.raises(ValueError, match="human_num"):
+        build_crowdnav_pred_attng_config({"human_num": 0})
+    with pytest.raises(ValueError, match="time_step"):
+        build_crowdnav_pred_attng_config({"time_step": 0.0})
+    with pytest.raises(ValueError, match="v_pref"):
+        build_crowdnav_pred_attng_config({"v_pref": -1.0})
+
+
+def test_crowdnav_pred_attng_skip_without_external_repo() -> None:
+    """Smoke the staged CrowdNav_Prediction_AttnGraph checkpoint when present.
+
+    Asserts the checkpoint loads as the attention-graph SRNN policy, produces a
+    finite holonomic command clipped to the preferred-speed envelope, and runs
+    well under any benchmark step budget. The per-step wall-clock table is
+    printed as smoke evidence. A documented negative (repo not staged, or load /
+    action failure) is itself a valid smoke outcome.
+    """
+    if not STAGE_PATH.exists():
+        pytest.skip(f"CrowdNav_Prediction_AttnGraph repo is not staged at {STAGE_PATH}")
+
+    adapter = CrowdNavPredAttnGraphAdapter(CrowdNavPredAttnGraphConfig(device="cpu"))
+
+    # The shipped "Ours" checkpoint is the attention-graph SRNN policy.
+    base = adapter._policy.base
+    assert type(base).__name__ == "selfAttn_merge_SRNN"
+    assert int(base.human_num) == 20
+    assert int(base.nenv) == 1
+
+    obs = _synthetic_obs(agent_count=5)
+    vx, vy, meta = adapter.act(obs, time_step=TIME_STEP)
+
+    # Hard smoke contract: a finite command clipped to the v_pref envelope.
+    assert math.isfinite(vx) and math.isfinite(vy)
+    assert math.hypot(vx, vy) <= V_PREF + 1e-6
+    assert meta["detected_human_num"] == 5
+    assert "raw_action_xy" in meta and "clipped_action_xy" in meta
+
+    # Goal-direction evidence (soft): in open space the policy should make
+    # progress toward the +x goal. Reported, not hard-asserted, to avoid flakiness.
+    print(f"\n[smoke] action toward goal (+x): vx={vx:.4f} vy={vy:.4f}")
+
+    # Per-step wall-clock across neighbor counts (issue #4871 decisive metric).
+    # human_num is fixed at 20 so the cost is flat in observed neighbor count;
+    # the bound is generous to stay machine-tolerant while catching regressions.
+    print("[smoke] per-step wall-clock (30-step mean after 3 warmup steps):")
+    per_step: dict[int, float] = {}
+    for agent_count in (2, 5, 10, 20):
+        adapter.reset()
+        step_obs = _synthetic_obs(agent_count=agent_count)
+        for _ in range(3):
+            adapter.act(step_obs, time_step=TIME_STEP)
+        start = time.perf_counter()
+        for _ in range(30):
+            adapter.act(step_obs, time_step=TIME_STEP)
+        elapsed_ms = (time.perf_counter() - start) / 30.0 * 1000.0
+        per_step[agent_count] = elapsed_ms
+        print(f"[smoke]   neighbors={agent_count:2d}: {elapsed_ms:.3f} ms/step")
+    assert max(per_step.values()) < 100.0  # trivially fast vs any step budget
+
+    # Reset must clear recurrent state so a fresh episode is deterministic.
+    adapter.reset()
+    vx_a, vy_a, _ = adapter.act(obs, time_step=TIME_STEP)
+    adapter.reset()
+    vx_b, vy_b, _ = adapter.act(obs, time_step=TIME_STEP)
+    assert vx_a == pytest.approx(vx_b, abs=1e-6)
+    assert vy_a == pytest.approx(vy_b, abs=1e-6)
+
+
+def test_crowdnav_pred_attng_skip_time_step_guard() -> None:
+    """The adapter must reject a dt that breaks the 0.25s training cadence."""
+    if not STAGE_PATH.exists():
+        pytest.skip(f"CrowdNav_Prediction_AttnGraph repo is not staged at {STAGE_PATH}")
+    adapter = CrowdNavPredAttnGraphAdapter(CrowdNavPredAttnGraphConfig(device="cpu"))
+    with pytest.raises(ValueError, match="fixed time_step"):
+        adapter.act(_synthetic_obs(agent_count=3), time_step=0.1)


### PR DESCRIPTION
## What

Feasibility smoke for reusing `Shuijing725/CrowdNav_Prediction_AttnGraph` (ICRA 2023, intention-aware crowd navigation with an attention-based interaction graph) as an external **learned** baseline planner. This is the learned-class counterpart to the SICNav smoke (#4870). Go/no-go data only — **no campaign, no roster addition, no retraining**.

**Verdict: smoke PASS (go).** All six issue gates pass; the shipped checkpoint loads and acts on synthetic Robot SF observations, and per-step inference is trivially fast.

## Why

Issue #4871 asked for an ordered go/no-go: prior-art → license → checkpoints → stage+inference → contract+timing → verdict row. Each step can end the issue early with a documented negative; none did.

## Per-gate result

| Step | Gate | Result |
| --- | --- | --- |
| 1. Prior art | No prior assessment; no dormant scaffold | **PASS.** Same author's `CrowdNav_HEIGHT` is already integrated (`crowdnav_height`) and was the template. |
| 2. License | MIT | **PASS.** |
| 3. Checkpoints | Trained RL navigation policy ships | **PASS** — no retraining. `41200.pt` ("Ours no-rand") + `41665.pt` ("Ours rand"); `00000.pt` files are the non-learning ORCA/SF baselines. |
| 4. Stage + inference | Loads and acts | **PASS.** Pinned SHA `3907731`; model-only PyTorch path (no OpenAI Baselines / `crowd_sim` / Python-RVO2 / TensorFlow). |
| 5. Contract + timing | Thinnest adapter + wall-clock | **PASS.** ~1–2 ms/step CPU, flat in neighbor count. |
| 6. Verdict row | Gate doc | **PASS.** |

## How it works

`robot_sf/planner/crowdnav_pred_attng.py` is the thinnest model-only adapter, mirroring the established `crowdnav_height.py` pattern:
- reconstructs the upstream `CrowdSimPred-v0` dict observation (5-step constant-velocity future edges + holonomic `ActionXY`) from world-frame Robot SF `Observation`,
- loads the shipped `41200.pt` attention-graph SRNN checkpoint via `torch.load(weights_only=False)` and calls `policy.act(..., deterministic=True)` directly,
- short-circuits the one heavy transitive import (`rl.networks.envs`, which otherwise drags in `gym` + Baselines + `crowd_sim`) with a minimal `VecNormalize` stub, so the network loads against PyTorch alone.

The repo is registered in `scripts/tools/manage_external_repos.py` (`uv run python scripts/tools/manage_external_repos.py stage crowdnav_pred_attng`). `tests/planner/test_crowdnav_pred_attng.py` runs the staged-checkout smoke (skips cleanly when unstaged, matching the SICNav convention).

## Validation (CPU-only, this host)

```
$ uv run pytest tests/planner/test_crowdnav_pred_attng.py -q
4 passed in 0.98s

[smoke] action toward goal (+x): vx=0.9840 vy=-0.1782
[smoke] per-step wall-clock (30-step mean after 3 warmup steps):
[smoke]   neighbors= 2: 2.226 ms/step
[smoke]   neighbors= 5: 2.215 ms/step
[smoke]   neighbors=10: 2.220 ms/step
[smoke]   neighbors=20: 2.227 ms/step
```
The deterministic action `≈ (0.98, -0.18)` for a robot at the origin with goal `(5, 0)` points strongly toward the goal — the loaded weights compute meaningful navigation, not noise. (standalone outside pytest ≈ 1.1 ms/step).

```
$ uv run pytest tests/tools/test_manage_external_repos.py -q
6 passed
$ uv run ruff check <changed files>        # All checks passed
```

## Notable finding (honest)

The bundled `trained_models/GST_predictor_non_rand/{configs/config.py,arguments.py}` **mismatches its own weights**: it declares `env_name=CrowdSimVarNum-v0` / `predict_method='none'` (spatial-edge width 2), but the `41200.pt` `state_dict` is width 12 (`base.spatial_attn.embedding_layer.0 = Linear(12→128)`), i.e. the 5-step **prediction** variant. `load_state_dict` fails under the bundled config. The adapter trusts the **state_dict** (authoritative) and uses `CrowdSimPred-v0` with constant-velocity futures (needs no TensorFlow/GST model). Documented in the smoke note so this is never re-discovered blind.

## Claim boundary (smoke evidence only)

This is a **smoke, not a roster addition**: the planner is intentionally NOT registered in `algorithm_metadata` / `algorithm_readiness` / the testing-only list, and must not enter benchmark sweeps. No campaign, no success/collision numbers for Robot SF scenarios, no retraining.

**Zero-shot transfer into Robot SF is NOT scientifically defensible** without an out-of-distribution caveat. The blockers documented in `docs/context/issue_4871_crowdnav_pred_attng_smoke.md`:
1. Holonomic `ActionXY` vs Robot SF unicycle kinematics.
2. Trained on ORCA pedestrians vs default social-force crowd (the headline OOD risk; same caveat as #4870).
3. The smoke uses constant-velocity prediction; the paper's GST-inferred prediction needs TensorFlow.
4. Sensing radius/FOV, human-count cap (20), 0.25 s control cadence, `v_pref=1.0`, open-space arena differ from Robot SF.

Roster/campaign/retraining decisions are separate maintainer calls after this smoke.

## Files

- `robot_sf/planner/crowdnav_pred_attng.py` — model-only adapter (new).
- `tests/planner/test_crowdnav_pred_attng.py` — staged-checkout smoke (new).
- `scripts/tools/manage_external_repos.py` — `crowdnav_pred_attng` RepoSpec (pinned SHA, MIT, validation command).
- `docs/context/issue_4871_crowdnav_pred_attng_smoke.md` — full contract + transfer-caveat analysis (new).
- `docs/benchmark_experimental_planners.md` — new "External learned-baseline feasibility smokes" verdict row.
- `CHANGELOG.md` — entry under Unreleased/Added.

This fully resolves issue #4871 (the smoke's required inputs all existed and were exercised; the GST/TF variant and any comparison slice are explicitly out of scope for this issue).

Closes #4871. Refs #4870, #1617.

---

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.
