### PR TITLE
Issue #4881: characterization baseline wave 2 (cheap-lane worker)

### DIFF
--- a/tests/benchmark/test_critical_intervals_characterization.py
+++ b/tests/benchmark/test_critical_intervals_characterization.py
@@ -1,0 +1,314 @@
+"""Characterization baseline tests for ``robot_sf/benchmark/critical_intervals.py``.
+
+These tests pin the *current observable behavior* of the critical-interval metric
+helpers on tiny synthetic traces/arrays. They are table-driven and assert exact
+golden values, including edge cases (single sample, NaN/Inf at the serialization
+finite guard, overlap/contact TTC, receding/perpendicular non-closing pairs,
+empty pedestrian sets, strict threshold boundaries).
+
+Purpose (issue #4881, wave 2; Refs #4874, #4770): lock a behavioral baseline so
+the post-submission refactor wave can prove behavior-preservation. If a test
+reveals a genuine bug, do NOT fix it here — document it and file a separate fix
+issue.
+
+These tests are additive: they pin the TTC convention/constants, the exact
+``_pairwise_ttc_s`` closing-speed formula, the
+``_compute_max_braking_deceleration_mps2`` output for constructed velocity
+profiles, the ``_compute_interval_metrics_in_window`` aggregation table, and the
+``report_to_dict`` NaN/Inf -> ``None`` serialization guard. They do not
+duplicate the anchor-detection, window-clamping, or whole-run pipeline coverage
+in ``test_critical_intervals.py``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.critical_intervals import (
+    _TTC_EPS_DIST,
+    _TTC_EPS_SPEED,
+    DEFAULT_NEAR_MISS_DIST,
+    SCHEMA_VERSION,
+    TTC_CONVENTION,
+    VALID_ANCHORS,
+    CriticalIntervalReport,
+    IntervalMetrics,
+    _compute_interval_metrics_in_window,
+    _compute_max_braking_deceleration_mps2,
+    _pairwise_ttc_s,
+    report_to_dict,
+)
+
+# ---------------------------------------------------------------------------
+# Constants / convention table
+# ---------------------------------------------------------------------------
+
+
+def test_constants_and_convention_are_pinned() -> None:
+    """Pin the schema, TTC convention, near-miss distance, and tolerances."""
+    assert SCHEMA_VERSION == "critical-intervals.v1"
+    assert TTC_CONVENTION == "line_of_sight_closing_speed_seconds.v1"
+    assert DEFAULT_NEAR_MISS_DIST == 0.7
+    assert _TTC_EPS_DIST == 1e-9
+    assert _TTC_EPS_SPEED == 1e-9
+
+
+def test_valid_anchors_set_is_pinned() -> None:
+    """The accepted anchor name set is exactly the documented frozenset."""
+    assert VALID_ANCHORS == frozenset(
+        {
+            "closest_approach",
+            "ttc_threshold_crossing",
+            "first_braking_event",
+            "collision_or_near_miss",
+            "recovery_after_avoidance",
+            "planner_mode_switch",
+            "pedestrian_deviation_onset",
+            "stuck_oscillation_onset",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# _pairwise_ttc_s: physical closing-speed TTC (exact)
+# ---------------------------------------------------------------------------
+
+
+def test_pairwise_ttc_head_on_closing_is_exact_distance_over_speed() -> None:
+    """Stationary ped dead ahead of a closing robot -> TTC == distance / speed."""
+    ttc = _pairwise_ttc_s(
+        robot_pos=np.array([0.0, 0.0]),
+        robot_vel=np.array([1.0, 0.0]),
+        ped_pos=np.array([5.0, 0.0]),
+        ped_vel=np.array([0.0, 0.0]),
+    )
+    assert ttc == pytest.approx(5.0)
+
+
+def test_pairwise_ttc_3_4_5_triangle_closing_is_exact() -> None:
+    """Non-axis-aligned geometry pins the closing-speed formula numerically."""
+    # dist = 5 (3-4-5), closing speed = dot([2,0],[3,4])/5 = 6/5 = 1.2 -> ttc = 5/1.2
+    ttc = _pairwise_ttc_s(
+        robot_pos=np.array([0.0, 0.0]),
+        robot_vel=np.array([2.0, 0.0]),
+        ped_pos=np.array([3.0, 4.0]),
+        ped_vel=np.array([0.0, 0.0]),
+    )
+    assert ttc == pytest.approx(5.0 / 1.2)
+
+
+def test_pairwise_ttc_receding_pair_is_none() -> None:
+    """A pair moving apart (negative closing speed) -> ``None``."""
+    ttc = _pairwise_ttc_s(
+        robot_pos=np.array([0.0, 0.0]),
+        robot_vel=np.array([1.0, 0.0]),
+        ped_pos=np.array([5.0, 0.0]),
+        ped_vel=np.array([2.0, 0.0]),  # ped outruns robot -> receding
+    )
+    assert ttc is None
+
+
+def test_pairwise_ttc_perpendicular_motion_is_none() -> None:
+    """Motion perpendicular to the separation vector has zero closing speed -> ``None``."""
+    ttc = _pairwise_ttc_s(
+        robot_pos=np.array([0.0, 0.0]),
+        robot_vel=np.array([0.0, 1.0]),  # perpendicular to [5,0] separation
+        ped_pos=np.array([5.0, 0.0]),
+        ped_vel=np.array([0.0, 0.0]),
+    )
+    assert ttc is None
+
+
+def test_pairwise_ttc_stationary_pair_is_none() -> None:
+    """Both stationary -> zero closing speed -> ``None`` (not zero, not inf)."""
+    ttc = _pairwise_ttc_s(
+        robot_pos=np.array([0.0, 0.0]),
+        robot_vel=np.array([0.0, 0.0]),
+        ped_pos=np.array([5.0, 0.0]),
+        ped_vel=np.array([0.0, 0.0]),
+    )
+    assert ttc is None
+
+
+def test_pairwise_ttc_overlap_is_zero() -> None:
+    """Contact/overlap (dist below the epsilon) -> ``0.0`` regardless of velocity."""
+    ttc = _pairwise_ttc_s(
+        robot_pos=np.array([0.0, 0.0]),
+        robot_vel=np.array([1.0, 0.0]),
+        ped_pos=np.array([1e-12, 0.0]),  # dist < _TTC_EPS_DIST
+        ped_vel=np.array([0.0, 0.0]),
+    )
+    assert ttc == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _compute_max_braking_deceleration_mps2 (exact velocity profiles)
+# ---------------------------------------------------------------------------
+
+
+def test_braking_deceleration_single_sample_is_none() -> None:
+    """Fewer than two velocity samples -> ``None``."""
+    assert _compute_max_braking_deceleration_mps2(np.array([[1.0, 0.0]]), dt=1.0) is None
+
+
+def test_braking_deceleration_two_sample_uniform_decel_is_one() -> None:
+    """A uniform 1 m/s deceleration over two samples yields max decel 1.0 m/s^2."""
+    vel = np.array([[2.0, 0.0], [1.0, 0.0]])
+    assert _compute_max_braking_deceleration_mps2(vel, dt=1.0) == pytest.approx(1.0)
+
+
+def test_braking_deceleration_three_sample_non_uniform_is_two() -> None:
+    """Pins the central-difference + one-sided-boundary scheme on a mixed profile."""
+    # Boundary one-sided diffs give decel 2.0 at t0; interior central diff 0.5 at t1.
+    vel = np.array([[4.0, 0.0], [2.0, 0.0], [3.0, 0.0]])
+    assert _compute_max_braking_deceleration_mps2(vel, dt=1.0) == pytest.approx(2.0)
+
+
+def test_braking_deceleration_pure_acceleration_is_zero() -> None:
+    """A purely accelerating profile has no braking component -> 0.0."""
+    vel = np.array([[1.0, 0.0], [2.0, 0.0], [3.0, 0.0]])
+    assert _compute_max_braking_deceleration_mps2(vel, dt=1.0) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# _compute_interval_metrics_in_window: aggregation table (exact)
+# ---------------------------------------------------------------------------
+
+
+def _straight_trace() -> dict[str, object]:
+    """Robot drives +x at 1 m/s past a stationary ped at (0, 0.5)."""
+    return {
+        "robot_pos": [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]],
+        "peds_pos": [
+            [[0.0, 0.5]],
+            [[0.0, 0.5]],
+            [[0.0, 0.5]],
+            [[0.0, 0.5]],
+        ],
+        "robot_vel": [[1.0, 0.0], [1.0, 0.0], [1.0, 0.0], [1.0, 0.0]],
+        "dt": 1.0,
+    }
+
+
+def test_window_metrics_full_straight_trace_table() -> None:
+    """Pin the aggregated window metrics for the straight-line trace."""
+    result = _compute_interval_metrics_in_window(_straight_trace(), start=0, end=4)
+    assert result["n_steps"] == 4
+    assert result["min_distance_m"] == pytest.approx(0.5)
+    assert result["min_clearance_m"] == pytest.approx(0.5)
+    assert result["near_miss_count"] == 1  # only the 0.5 m step is < 0.7 m
+    assert result["collision_flag"] is False  # nothing < 0.3 m
+    assert result["mean_speed_ms"] == pytest.approx(1.0)
+    assert result["max_speed_ms"] == pytest.approx(1.0)
+    assert result["max_deceleration_mps2"] == pytest.approx(0.0)  # constant speed
+    # ``heading_oscillation`` is ``np.var`` over the *flattened* unit-direction
+    # vectors, so a perfectly straight (constant (1, 0)) path yields 0.25 (the
+    # variance between the constant 1 and 0 components), NOT 0.0. This is the
+    # pinned current behavior; the PR body flags it as a candidate follow-up bug.
+    assert result["heading_oscillation"] == pytest.approx(0.25)
+
+
+def test_window_metrics_subwindow_slicing() -> None:
+    """A sub-slice [1, 3) aggregates only those two steps."""
+    result = _compute_interval_metrics_in_window(_straight_trace(), start=1, end=3)
+    assert result["n_steps"] == 2
+    # steps 1 and 2: distances sqrt(1.25)=1.118 and sqrt(4.25)=2.062 -> min 1.118
+    assert result["min_distance_m"] == pytest.approx(math.sqrt(1.25))
+    assert result["near_miss_count"] == 0  # both > 0.7 m
+
+
+def test_window_metrics_no_pedestrians_drops_distance_fields() -> None:
+    """With no pedestrians, distance fields are ``None`` and event counts are absent."""
+    trace = {
+        "robot_pos": [[0.0, 0.0], [1.0, 0.0]],
+        "peds_pos": [],
+        "robot_vel": [[1.0, 0.0], [1.0, 0.0]],
+        "dt": 1.0,
+    }
+    result = _compute_interval_metrics_in_window(trace, start=0, end=2)
+    assert result["min_distance_m"] is None
+    assert result["min_clearance_m"] is None
+    assert "near_miss_count" not in result  # only set when pedestrians present
+    assert "collision_flag" not in result
+
+
+@pytest.mark.parametrize("ped_y,expected_collision", [(0.29, True), (0.30, False)])
+def test_window_metrics_collision_boundary_is_strict(
+    ped_y: float, expected_collision: bool
+) -> None:
+    """The collision flag uses strict ``dist < 0.3 m`` (0.30 m is NOT a collision)."""
+    trace = {
+        "robot_pos": [[0.0, 0.0], [1.0, 0.0]],
+        "peds_pos": [[[0.0, ped_y]], [[0.0, ped_y]]],
+        "dt": 1.0,
+    }
+    result = _compute_interval_metrics_in_window(trace, start=0, end=2)
+    assert result["collision_flag"] is expected_collision
+
+
+@pytest.mark.parametrize("ped_y,expected_count", [(0.69, 1), (0.70, 0)])
+def test_window_metrics_near_miss_boundary_is_strict(ped_y: float, expected_count: int) -> None:
+    """The near-miss count uses strict ``dist < 0.7 m`` (0.70 m is NOT a near miss)."""
+    trace = {
+        "robot_pos": [[0.0, 0.0], [5.0, 0.0]],  # step 1 is far, only step 0 can qualify
+        "peds_pos": [[[0.0, ped_y]], [[0.0, ped_y]]],
+        "dt": 1.0,
+    }
+    result = _compute_interval_metrics_in_window(trace, start=0, end=2)
+    assert result["near_miss_count"] == expected_count
+
+
+# ---------------------------------------------------------------------------
+# report_to_dict: NaN/Inf -> None serialization guard
+# ---------------------------------------------------------------------------
+
+
+def test_report_to_dict_top_level_keys_and_convention() -> None:
+    """``report_to_dict`` exposes the pinned top-level key set and TTC convention."""
+    report = CriticalIntervalReport()
+    out = report_to_dict(report)
+    assert set(out) == {
+        "ttc_convention",
+        "whole_run",
+        "critical_intervals",
+        "interval_metrics",
+        "missing_anchors",
+    }
+    assert out["ttc_convention"] == TTC_CONVENTION
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+def test_report_to_dict_coerces_non_finite_metric_to_none(bad_value: float) -> None:
+    """NaN/Inf interval-metric floats serialize to ``None``; finite floats pass through."""
+    report = CriticalIntervalReport(
+        interval_metrics=[
+            IntervalMetrics(anchor="closest_approach", min_ttc_s=bad_value, min_distance_m=1.25),
+        ]
+    )
+    metrics = report_to_dict(report)["interval_metrics"][0]
+    assert metrics["min_ttc_s"] is None
+    assert metrics["min_distance_m"] == pytest.approx(1.25)
+
+
+def test_report_to_dict_interval_metric_field_set_is_pinned() -> None:
+    """Each serialized interval metric carries exactly the documented field set."""
+    report = CriticalIntervalReport(
+        interval_metrics=[IntervalMetrics(anchor="closest_approach", n_steps=3)]
+    )
+    metrics = report_to_dict(report)["interval_metrics"][0]
+    assert set(metrics) == {
+        "anchor",
+        "n_steps",
+        "min_clearance_m",
+        "min_distance_m",
+        "min_ttc_s",
+        "mean_speed_ms",
+        "max_speed_ms",
+        "max_deceleration_mps2",
+        "heading_oscillation",
+        "near_miss_count",
+        "collision_flag",
+    }

--- a/tests/benchmark/test_episode_replay_figure_characterization.py
+++ b/tests/benchmark/test_episode_replay_figure_characterization.py
@@ -1,0 +1,248 @@
+"""Characterization baseline tests for ``robot_sf/benchmark/episode_replay_figure.py``.
+
+These tests pin the *current observable behavior* of the CPU-only episode-replay
+bridge on tiny synthetic inputs, focusing on the pure, rendering-free helpers:
+finite-float coercion, final-position parsing, episode-row validation, the
+determinism-check state machine, and the SHA-256 helpers. They are table-driven
+and assert exact golden values, including edge cases (NaN/Inf at the finite
+guard, malformed/missing fields, empty steps, the documented
+``final_progress``-is-informational regression).
+
+Purpose (issue #4881, wave 2; Refs #4874, #4770): lock a behavioral baseline so
+the post-submission refactor wave can prove behavior-preservation. If a test
+reveals a genuine bug, do NOT fix it here — document it and file a separate fix
+issue.
+
+These tests are additive: they pin the pure-helper contract and the exact
+determinism-check transitions / error messages without rendering matplotlib
+figures. They do not duplicate the rendering, provenance-sidecar, or full
+re-simulation workflow coverage in ``test_episode_replay_figure.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.benchmark.episode_replay_figure import (
+    OPTIONAL_PROVENANCE_FIELDS,
+    REQUIRED_EPISODE_FIELDS,
+    EpisodeRow,
+    _finite_floats,
+    _parse_final_position,
+    check_determinism,
+    compute_bytes_sha256,
+    compute_file_sha256,
+)
+from robot_sf.benchmark.full_classic.replay import ReplayEpisode, ReplayStep
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _replay_episode(steps: list[tuple[float, float, float, float]]) -> ReplayEpisode:
+    """Build a minimal ``ReplayEpisode`` from ``(t, x, y, heading)`` tuples."""
+    return ReplayEpisode(
+        episode_id="ep",
+        scenario_id="scn",
+        steps=[ReplayStep(t=t, x=x, y=y, heading=h) for (t, x, y, h) in steps],
+        dt=1.0,
+        map_path=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constant tables
+# ---------------------------------------------------------------------------
+
+
+def test_required_and_optional_field_tables_are_pinned() -> None:
+    """Pin the exact required-field set and the optional-provenance field set."""
+    assert REQUIRED_EPISODE_FIELDS == ["episode_id", "scenario_id", "seed"]
+    assert "final_robot_position" in OPTIONAL_PROVENANCE_FIELDS
+    assert "final_progress" in OPTIONAL_PROVENANCE_FIELDS
+    assert "campaign_id" in OPTIONAL_PROVENANCE_FIELDS
+    # Required fields are NOT also listed as optional provenance.
+    assert not (set(REQUIRED_EPISODE_FIELDS) & set(OPTIONAL_PROVENANCE_FIELDS))
+
+
+# ---------------------------------------------------------------------------
+# _finite_floats: finite-guard coercion
+# ---------------------------------------------------------------------------
+
+
+def test_finite_floats_coerces_mixed_numeric_types() -> None:
+    """Ints, floats, and numeric strings are coerced to finite floats in order."""
+    assert _finite_floats(1, 2.5, "3.0") == (1.0, 2.5, 3.0)
+
+
+def test_finite_floats_rejects_nan_or_inf() -> None:
+    """Any non-finite value short-circuits the whole tuple to ``None``."""
+    assert _finite_floats(1.0, float("nan"), 3.0) is None
+    assert _finite_floats(1.0, float("inf"), 3.0) is None
+    assert _finite_floats(1.0, float("-inf"), 3.0) is None
+
+
+def test_finite_floats_rejects_non_numeric() -> None:
+    """A non-numeric value short-circuits to ``None``."""
+    assert _finite_floats(1.0, "bad", 3.0) is None
+    assert _finite_floats(None) is None
+
+
+def test_finite_floats_empty_call_returns_empty_tuple() -> None:
+    """No arguments -> empty tuple (not ``None``)."""
+    assert _finite_floats() == ()
+
+
+# ---------------------------------------------------------------------------
+# _parse_final_position: 2-tuple finite-guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw", [[1.5, 2.5], (1.5, 2.5), ["1.5", "2.5"]])
+def test_parse_final_position_accepts_two_finite_elements(raw: object) -> None:
+    """List, tuple, and numeric-string pairs coerce to a finite ``(x, y)``."""
+    assert _parse_final_position(raw) == (1.5, 2.5)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        [1.5, float("nan")],  # non-finite component
+        [1.5, float("inf")],  # non-finite component
+        "not_a_list",  # wrong type
+        None,  # absent
+        [1.5],  # wrong length (too few)
+        [1.5, 2.5, 3.5],  # wrong length (too many)
+        ["good", "bad"],  # non-numeric component
+    ],
+)
+def test_parse_final_position_rejects_malformed(raw: object) -> None:
+    """Malformed positions return ``None`` so downstream checks skip gracefully."""
+    assert _parse_final_position(raw) is None
+
+
+# ---------------------------------------------------------------------------
+# EpisodeRow.from_dict: validation + coercion
+# ---------------------------------------------------------------------------
+
+
+def test_episode_row_minimal_fields_and_seed_int_coercion() -> None:
+    """Required fields populate; seed is coerced to int; raw is preserved."""
+    row = EpisodeRow.from_dict({"episode_id": "e1", "scenario_id": "s1", "seed": "42"})
+    assert row.episode_id == "e1"
+    assert row.scenario_id == "s1"
+    assert row.seed == 42
+    assert isinstance(row.seed, int)
+    assert row.final_robot_position is None  # absent -> None
+    assert row.raw == {"episode_id": "e1", "scenario_id": "s1", "seed": "42"}
+
+
+def test_episode_row_missing_required_fields_raises_with_field_list() -> None:
+    """Missing required fields raise ``ValueError`` naming exactly the missing ones."""
+    with pytest.raises(ValueError) as excinfo:
+        EpisodeRow.from_dict({"episode_id": "e1"})  # scenario_id + seed missing
+    msg = str(excinfo.value)
+    assert "missing required fields" in msg
+    assert "scenario_id" in msg
+    assert "seed" in msg
+    assert "episode_id" not in msg  # present field is not in the missing list
+
+
+def test_episode_row_parses_final_robot_position() -> None:
+    """A valid ``final_robot_position`` list is parsed to a finite 2-tuple."""
+    row = EpisodeRow.from_dict(
+        {"episode_id": "e1", "scenario_id": "s1", "seed": 0, "final_robot_position": [3.0, 1.5]}
+    )
+    assert row.final_robot_position == (3.0, 1.5)
+
+
+# ---------------------------------------------------------------------------
+# check_determinism: state-machine transitions (exact)
+# ---------------------------------------------------------------------------
+
+
+def _row(**kwargs: object) -> EpisodeRow:
+    """Build an EpisodeRow with required fields plus overrides."""
+    base: dict[str, object] = {"episode_id": "e1", "scenario_id": "s1", "seed": 0}
+    base.update(kwargs)
+    return EpisodeRow.from_dict(base)
+
+
+def test_check_determinism_no_steps_is_not_evaluable() -> None:
+    """Empty replay steps -> ``not_evaluable`` with the pinned reason."""
+    status, details = check_determinism(_replay_episode([]), _row(), tolerance_m=0.1)
+    assert status == "not_evaluable"
+    assert details["reason"] == "no replay steps"
+    assert details["checks_performed"] == []
+
+
+def test_check_determinism_position_within_tolerance_is_pass() -> None:
+    """Final position within tolerance -> ``pass`` with the check recorded."""
+    episode = _replay_episode([(0.0, 0.0, 0.0, 0.0), (1.0, 3.0, 1.5, 0.0)])
+    row = _row(final_robot_position=[3.0, 1.5])
+    status, details = check_determinism(episode, row, tolerance_m=0.1)
+    assert status == "pass"
+    assert details["checks_performed"] == ["final_robot_position"]
+    assert details["checks_passed"] == ["final_robot_position"]
+    assert details["position_error_m"] == pytest.approx(0.0)
+    assert details["replay_final_position"] == (3.0, 1.5)
+    assert details["original_final_position"] == (3.0, 1.5)
+
+
+def test_check_determinism_position_outside_tolerance_is_fail() -> None:
+    """Final position outside tolerance -> ``fail`` with a formatted failure line."""
+    episode = _replay_episode([(0.0, 0.0, 0.0, 0.0), (1.0, 3.0, 1.5, 0.0)])
+    row = _row(final_robot_position=[3.0, 2.0])  # 0.5 m off
+    status, details = check_determinism(episode, row, tolerance_m=0.1)
+    assert status == "fail"
+    assert details["checks_failed"] == ["position error 0.500m > tolerance 0.1m"]
+
+
+def test_check_determinism_progress_only_is_not_evaluable() -> None:
+    """``final_progress`` alone is informational and must NOT yield ``pass``.
+
+    Regression guard: previously an episode carrying only ``final_progress``
+    reported determinism ``pass`` while verifying nothing.
+    """
+    episode = _replay_episode([(0.0, 0.0, 0.0, 0.0), (1.0, 1.0, 0.0, 0.0)])
+    row = _row(final_progress=0.85)
+    status, details = check_determinism(episode, row, tolerance_m=0.1)
+    assert status == "not_evaluable"
+    assert details["reason"] == "no evaluable endpoints in episode row"
+    assert details["checks_performed"] == []
+    assert details["checks_informational"] == ["final_progress recorded"]
+    assert details["original_final_progress"] == 0.85
+
+
+def test_check_determinism_no_endpoints_is_not_evaluable() -> None:
+    """No position and no progress -> ``not_evaluable`` with the pinned reason."""
+    episode = _replay_episode([(0.0, 0.0, 0.0, 0.0), (1.0, 1.0, 0.0, 0.0)])
+    status, details = check_determinism(episode, _row(), tolerance_m=0.1)
+    assert status == "not_evaluable"
+    assert details["reason"] == "no evaluable endpoints in episode row"
+
+
+# ---------------------------------------------------------------------------
+# SHA-256 helpers: exact digests
+# ---------------------------------------------------------------------------
+
+
+def test_compute_bytes_sha256_known_digests() -> None:
+    """Pin the exact SHA-256 digests for known byte inputs."""
+    assert compute_bytes_sha256(b"") == (
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    )
+    assert compute_bytes_sha256(b"test") == (
+        "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    )
+
+
+def test_compute_file_sha256_matches_bytes_helper(tmp_path: Path) -> None:
+    """File hashing over the same bytes matches the bytes helper exactly."""
+    payload = b"deterministic-replay-bytes"
+    path = tmp_path / "episode.jsonl"
+    path.write_bytes(payload)
+    assert compute_file_sha256(path) == compute_bytes_sha256(payload)
+    assert len(compute_file_sha256(path)) == 64  # hex digest length

--- a/tests/benchmark/test_heterogeneous_rank_sensitivity_characterization.py
+++ b/tests/benchmark/test_heterogeneous_rank_sensitivity_characterization.py
@@ -1,0 +1,472 @@
+"""Characterization baseline tests for ``robot_sf/benchmark/heterogeneous_rank_sensitivity.py``.
+
+These tests pin the *current observable behavior* of
+``compute_bootstrap_rank_sensitivity`` on small synthetic record sets. They are
+table-driven and assert exact golden values, including edge cases (empty input,
+single paired seed, NaN/Inf metrics at the finite-guard boundary, missing
+metric, seed coercion, whitespace stripping) and the exact blocked / ready
+result shapes.
+
+Purpose (issue #4881, wave 2; Refs #4874, #4770): lock a behavioral baseline so
+the post-submission refactor wave can prove behavior-preservation. If a test
+reveals a genuine bug, do NOT fix it here — document it and file a separate fix
+issue.
+
+These tests are additive: they pin the error contract, the exact blocked-status
+shapes and messages, the ``scenario_params`` fallback path, finite-guard
+skipping, ranking direction, exact ``observed_means``, the pairwise-key
+contract, the reversal-dict shape, arm sorting, and same-seed determinism. They
+do not duplicate the ranking/probability/reversal happy-path coverage or the
+#4618 falsy-field regression in ``test_heterogeneous_rank_sensitivity.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from robot_sf.benchmark.heterogeneous_rank_sensitivity import (
+    compute_bootstrap_rank_sensitivity,
+)
+
+_SCHEMA = "heterogeneous_rank_sensitivity.v1"
+_METRIC = "clearance_m"
+
+
+def _rec(
+    arm: str,
+    planner: str,
+    seed: Any,
+    value: float,
+    *,
+    metric: str = _METRIC,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Build a minimal episode record; ``extra`` overrides/extends fields."""
+    rec: dict[str, Any] = {
+        "population_arm": arm,
+        "planner": planner,
+        "seed": seed,
+        "metrics": {metric: value},
+    }
+    rec.update(extra)
+    return rec
+
+
+def _two_planner_two_seed() -> list[dict[str, Any]]:
+    """Arm ``het``: A mean=11.0, B mean=6.0 (A strictly dominates B)."""
+    return [
+        _rec("het", "A", 1, 10.0),
+        _rec("het", "A", 2, 12.0),
+        _rec("het", "B", 1, 5.0),
+        _rec("het", "B", 2, 7.0),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Error contract
+# ---------------------------------------------------------------------------
+
+
+def test_fewer_than_two_planners_raises_value_error_with_pinned_message() -> None:
+    """The guard requires >=2 planners and raises a pinned message."""
+    with pytest.raises(ValueError, match="At least 2 planners are required to compare ranks"):
+        compute_bootstrap_rank_sensitivity([], metric_key=_METRIC, planners=["A"])
+
+
+# ---------------------------------------------------------------------------
+# Blocked-status shapes (exact)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_records_returns_blocked_no_data_shape() -> None:
+    """No records at all -> blocked with the exact 'no valid data' blocker."""
+    result = compute_bootstrap_rank_sensitivity([], metric_key=_METRIC, planners=["A", "B"])
+    assert set(result) == {"schema_version", "metric_key", "status", "blockers"}
+    assert result["schema_version"] == _SCHEMA
+    assert result["metric_key"] == _METRIC
+    assert result["status"] == "blocked"
+    assert result["blockers"] == ["No valid episode data matches configuration"]
+
+
+def test_records_all_filtered_out_returns_blocked_no_data() -> None:
+    """Records that all fail parsing (unknown planner) -> same blocked shape."""
+    records = [
+        _rec("het", "C", 1, 10.0),  # planner C not in planners list -> dropped
+        _rec("het", "C", 2, 12.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(records, metric_key=_METRIC, planners=["A", "B"])
+    assert result["status"] == "blocked"
+    assert result["blockers"] == ["No valid episode data matches configuration"]
+
+
+def test_insufficient_paired_seeds_blocks_with_exact_interpolated_message() -> None:
+    """Only one common seed -> blocked with the exact count-interpolated message."""
+    records = [
+        _rec("het", "A", 1, 10.0),
+        _rec("het", "B", 1, 5.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(records, metric_key=_METRIC, planners=["A", "B"])
+    assert result["status"] == "blocked"
+    assert result["blockers"] == [
+        "Insufficient paired seeds across planners/arms (found 1, need >=2)"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Record-parsing contract (finite guards, fallbacks, coercion)
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_params_fallback_path_is_used_when_top_level_absent() -> None:
+    """Top-level arm/planner/seed absent -> scenario_params supplies them."""
+    records = [
+        {
+            "scenario_params": {"population_arm": "het", "planner": "A", "seed": 1},
+            "metrics": {"clearance_m": 10.0},
+        },
+        {
+            "scenario_params": {"population_arm": "het", "planner": "A", "seed": 2},
+            "metrics": {"clearance_m": 12.0},
+        },
+        {
+            "scenario_params": {"population_arm": "het", "planner": "B", "seed": 1},
+            "metrics": {"clearance_m": 5.0},
+        },
+        {
+            "scenario_params": {"population_arm": "het", "planner": "B", "seed": 2},
+            "metrics": {"clearance_m": 7.0},
+        },
+    ]
+    result = compute_bootstrap_rank_sensitivity(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=10, seed=42
+    )
+    assert result["status"] == "ready"
+    assert list(result["arms"]) == ["het"]  # fallback arm name used verbatim
+    assert result["arms"]["het"]["ranking"] == ["A", "B"]
+
+
+def test_nan_metric_record_is_dropped_from_window() -> None:
+    """A NaN metric fails the finite guard and is dropped; mean is over the rest."""
+    records = [
+        _rec("het", "A", 1, 10.0),
+        _rec("het", "A", 2, 12.0),
+        _rec("het", "A", 3, float("nan")),  # dropped by math.isfinite guard
+        _rec("het", "B", 1, 5.0),
+        _rec("het", "B", 2, 7.0),
+        _rec("het", "B", 3, 9.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=10, seed=42
+    )
+    assert result["status"] == "ready"
+    # Seed 3 disappears from A -> common seeds {1, 2}; A mean = (10+12)/2 = 11.0.
+    assert result["common_seeds_count"] == 2
+    assert result["arms"]["het"]["observed_means"]["A"] == pytest.approx(11.0)
+
+
+def test_inf_metric_record_is_dropped_from_window() -> None:
+    """An Inf metric fails the finite guard and is dropped (not propagated)."""
+    records = [
+        _rec("het", "A", 1, 10.0),
+        _rec("het", "A", 2, 12.0),
+        _rec("het", "A", 3, float("inf")),  # dropped
+        _rec("het", "B", 1, 5.0),
+        _rec("het", "B", 2, 7.0),
+        _rec("het", "B", 3, 9.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=10, seed=42
+    )
+    assert result["status"] == "ready"
+    assert result["arms"]["het"]["observed_means"]["A"] == pytest.approx(11.0)
+
+
+def test_missing_metric_key_skips_record() -> None:
+    """A record whose metrics lack the key (or metrics is not a mapping) is dropped."""
+    records = [
+        _rec("het", "A", 1, 10.0),
+        _rec("het", "A", 2, 12.0),
+        {"population_arm": "het", "planner": "A", "seed": 3, "metrics": {"other": 1.0}},
+        _rec("het", "B", 1, 5.0),
+        _rec("het", "B", 2, 7.0),
+        _rec("het", "B", 3, 9.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=10, seed=42
+    )
+    assert result["status"] == "ready"
+    assert result["common_seeds_count"] == 2  # seed 3 dropped from A
+
+
+def test_float_seed_is_coerced_to_int_for_pairing() -> None:
+    """``int(s_val)`` coerces a float seed so it pairs with an int seed."""
+    records = [
+        _rec("het", "A", 1, 10.0),  # int seed 1
+        _rec("het", "A", 2, 12.0),
+        _rec("het", "B", 1.0, 5.0),  # float seed 1.0 -> coerced to 1
+        _rec("het", "B", 2, 7.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=10, seed=42
+    )
+    # Without coercion, B would have keys {1.0, 2} and common with A's {1, 2} would
+    # be just {2} -> blocked. Ready-with-2 proves the float->int coercion.
+    assert result["status"] == "ready"
+    assert result["common_seeds_count"] == 2
+
+
+def test_arm_and_planner_whitespace_is_stripped() -> None:
+    """``str(x).strip()`` normalizes surrounding whitespace on arm and planner."""
+    records = [
+        _rec(" het ", " A ", 1, 10.0),
+        _rec(" het ", " A ", 2, 12.0),
+        _rec(" het ", " B ", 1, 5.0),
+        _rec(" het ", " B ", 2, 7.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=10, seed=42
+    )
+    assert result["status"] == "ready"
+    assert list(result["arms"]) == ["het"]
+
+
+def test_unknown_planner_records_are_ignored() -> None:
+    """Records for a planner not in the list are dropped; result is unaffected."""
+    base = _two_planner_two_seed()
+    extra = [_rec("het", "C", 1, 99.0), _rec("het", "C", 2, 99.0)]
+    result = compute_bootstrap_rank_sensitivity(
+        base + extra, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=10, seed=42
+    )
+    assert result["status"] == "ready"
+    assert result["planners"] == ["A", "B"]  # C never admitted
+    assert set(result["arms"]["het"]["pairwise_probabilities"]) == {
+        "A_beats_B",
+        "B_beats_A",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Ranking direction, observed means, pairwise-key contract
+# ---------------------------------------------------------------------------
+
+
+def test_observed_means_are_exact_python_floats() -> None:
+    """Observed means are the plain per-planner mean over common seeds."""
+    result = compute_bootstrap_rank_sensitivity(
+        _two_planner_two_seed(),
+        metric_key=_METRIC,
+        planners=["A", "B"],
+        num_bootstrap=10,
+        seed=42,
+    )
+    means = result["arms"]["het"]["observed_means"]
+    assert means == {"A": pytest.approx(11.0), "B": pytest.approx(6.0)}
+    assert isinstance(means["A"], float)  # coerced via float(...)
+
+
+@pytest.mark.parametrize("higher_is_safer,expected", [(True, ["A", "B"]), (False, ["B", "A"])])
+def test_ranking_direction_respects_higher_is_safer(
+    higher_is_safer: bool, expected: list[str]
+) -> None:
+    """``higher_is_safer`` flips the observed-mean sort order."""
+    result = compute_bootstrap_rank_sensitivity(
+        _two_planner_two_seed(),
+        metric_key=_METRIC,
+        planners=["A", "B"],
+        higher_is_safer=higher_is_safer,
+        num_bootstrap=10,
+        seed=42,
+    )
+    assert result["arms"]["het"]["ranking"] == expected
+    assert result["higher_is_safer"] is higher_is_safer
+
+
+def test_dominant_planner_has_unit_and_zero_pairwise_probabilities() -> None:
+    """A strictly-dominant planner yields P=1.0 forward and P=0.0 reverse."""
+    result = compute_bootstrap_rank_sensitivity(
+        _two_planner_two_seed(),
+        metric_key=_METRIC,
+        planners=["A", "B"],
+        num_bootstrap=50,
+        seed=7,
+    )
+    pair = result["arms"]["het"]["pairwise_probabilities"]
+    assert pair["A_beats_B"] == 1.0  # A > B at every seed -> always
+    assert pair["B_beats_A"] == 0.0
+
+
+def test_three_planners_yield_six_directed_pairwise_keys() -> None:
+    """Pairwise keys cover all ordered i!=j pairs; self-pairs are excluded."""
+    records = [
+        _rec("het", "A", 1, 30.0),
+        _rec("het", "A", 2, 32.0),
+        _rec("het", "B", 1, 20.0),
+        _rec("het", "B", 2, 22.0),
+        _rec("het", "C", 1, 10.0),
+        _rec("het", "C", 2, 12.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(
+        records, metric_key=_METRIC, planners=["A", "B", "C"], num_bootstrap=10, seed=42
+    )
+    keys = set(result["arms"]["het"]["pairwise_probabilities"])
+    assert keys == {"A_beats_B", "A_beats_C", "B_beats_A", "B_beats_C", "C_beats_A", "C_beats_B"}
+    assert len(keys) == 3 * 2  # n * (n - 1)
+
+
+def test_planners_order_is_preserved_and_echoed() -> None:
+    """``result['planners']`` echoes the input order (not re-sorted)."""
+    records = [
+        _rec("het", "B", 1, 10.0),
+        _rec("het", "B", 2, 12.0),
+        _rec("het", "A", 1, 5.0),
+        _rec("het", "A", 2, 7.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(
+        records, metric_key=_METRIC, planners=["B", "A"], num_bootstrap=10, seed=42
+    )
+    assert result["planners"] == ["B", "A"]
+    # observed_means keys preserve the declared planner order.
+    assert list(result["arms"]["het"]["observed_means"]) == ["B", "A"]
+
+
+# ---------------------------------------------------------------------------
+# Reversal detection (exact shape)
+# ---------------------------------------------------------------------------
+
+
+def _reversal_dataset() -> list[dict[str, Any]]:
+    """het ranks A>B; mean_matched_homogeneous ranks B>A -> one reversal."""
+    return [
+        # heterogeneous: A mean 11, B mean 6 -> [A, B]
+        _rec("heterogeneous", "A", 1, 10.0),
+        _rec("heterogeneous", "A", 2, 12.0),
+        _rec("heterogeneous", "B", 1, 5.0),
+        _rec("heterogeneous", "B", 2, 7.0),
+        # mean_matched_homogeneous: A mean 6, B mean 11 -> [B, A]
+        _rec("mean_matched_homogeneous", "A", 1, 5.0),
+        _rec("mean_matched_homogeneous", "A", 2, 7.0),
+        _rec("mean_matched_homogeneous", "B", 1, 10.0),
+        _rec("mean_matched_homogeneous", "B", 2, 12.0),
+    ]
+
+
+def test_rank_reversal_dict_shape_is_pinned() -> None:
+    """When the two special arms disagree, the exact reversal dict is emitted."""
+    result = compute_bootstrap_rank_sensitivity(
+        _reversal_dataset(), metric_key=_METRIC, planners=["A", "B"], num_bootstrap=10, seed=42
+    )
+    assert len(result["reversals"]) == 1
+    rev = result["reversals"][0]
+    assert set(rev) == {
+        "type",
+        "heterogeneous_ranking",
+        "mean_matched_homogeneous_ranking",
+        "description",
+    }
+    assert rev["type"] == "rank_order_disagreement"
+    assert rev["heterogeneous_ranking"] == ["A", "B"]
+    assert rev["mean_matched_homogeneous_ranking"] == ["B", "A"]
+    assert rev["description"] == (
+        "Heterogeneous ranking ['A', 'B'] differs from homogeneous ['B', 'A']"
+    )
+
+
+def test_no_reversal_when_special_arms_absent() -> None:
+    """Arms not named heterogeneous / mean_matched_homogeneous never trigger reversals."""
+    # alpha ranks A>B, beta ranks B>A, but neither special arm name is present.
+    records = [
+        _rec("alpha", "A", 1, 10.0),
+        _rec("alpha", "A", 2, 12.0),
+        _rec("alpha", "B", 1, 5.0),
+        _rec("alpha", "B", 2, 7.0),
+        _rec("beta", "A", 1, 5.0),
+        _rec("beta", "A", 2, 7.0),
+        _rec("beta", "B", 1, 10.0),
+        _rec("beta", "B", 2, 12.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=10, seed=42
+    )
+    assert result["reversals"] == []
+
+
+def test_no_reversal_when_special_arms_agree() -> None:
+    """Both special arms ranking identically -> no reversal."""
+    records = [
+        _rec("heterogeneous", "A", 1, 10.0),
+        _rec("heterogeneous", "A", 2, 12.0),
+        _rec("heterogeneous", "B", 1, 5.0),
+        _rec("heterogeneous", "B", 2, 7.0),
+        _rec("mean_matched_homogeneous", "A", 1, 10.0),
+        _rec("mean_matched_homogeneous", "A", 2, 12.0),
+        _rec("mean_matched_homogeneous", "B", 1, 5.0),
+        _rec("mean_matched_homogeneous", "B", 2, 7.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=10, seed=42
+    )
+    assert result["reversals"] == []
+
+
+def test_arms_emitted_in_sorted_key_order() -> None:
+    """Multiple arms are emitted in sorted (alphabetical) key order."""
+    records = [
+        _rec("zeta", "A", 1, 10.0),
+        _rec("zeta", "A", 2, 12.0),
+        _rec("zeta", "B", 1, 5.0),
+        _rec("zeta", "B", 2, 7.0),
+        _rec("alpha", "A", 1, 10.0),
+        _rec("alpha", "A", 2, 12.0),
+        _rec("alpha", "B", 1, 5.0),
+        _rec("alpha", "B", 2, 7.0),
+    ]
+    result = compute_bootstrap_rank_sensitivity(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=10, seed=42
+    )
+    assert list(result["arms"]) == ["alpha", "zeta"]
+
+
+# ---------------------------------------------------------------------------
+# Ready-status shape + determinism
+# ---------------------------------------------------------------------------
+
+
+def test_ready_status_top_level_field_set_is_pinned() -> None:
+    """The ready result exposes exactly the documented top-level field set."""
+    result = compute_bootstrap_rank_sensitivity(
+        _two_planner_two_seed(),
+        metric_key=_METRIC,
+        planners=["A", "B"],
+        num_bootstrap=10,
+        seed=42,
+    )
+    assert set(result) == {
+        "schema_version",
+        "status",
+        "metric_key",
+        "higher_is_safer",
+        "common_seeds_count",
+        "planners",
+        "arms",
+        "reversals",
+    }
+    assert result["schema_version"] == _SCHEMA
+    assert result["status"] == "ready"
+    assert result["common_seeds_count"] == 2
+
+
+def test_same_seed_is_bit_for_bit_deterministic() -> None:
+    """Same input + same seed -> identical pairwise probabilities (locks the RNG contract)."""
+    kwargs = {
+        "records": _two_planner_two_seed(),
+        "metric_key": _METRIC,
+        "planners": ["A", "B"],
+        "num_bootstrap": 50,
+        "seed": 123,
+    }
+    a = compute_bootstrap_rank_sensitivity(**kwargs)
+    b = compute_bootstrap_rank_sensitivity(**kwargs)
+    assert a["arms"]["het"]["pairwise_probabilities"] == b["arms"]["het"]["pairwise_probabilities"]
+    assert a["arms"]["het"]["observed_means"] == b["arms"]["het"]["observed_means"]

--- a/tests/benchmark/test_snqi_scalarization_sensitivity_characterization.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity_characterization.py
@@ -1,0 +1,315 @@
+"""Characterization baseline tests for ``robot_sf/benchmark/snqi_scalarization_sensitivity.py``.
+
+These tests pin the *current observable behavior* of the scalarization-sensitivity
+math on tiny synthetic inputs. They are table-driven and assert exact golden
+values for the refactor-sensitive core: the metric-coercion helper, the
+constraints-first score formula, the pairwise rank-reversal / disagreement
+arithmetic, the Pareto-front classification, and the rank-disagreement /
+weight-variant summaries. They also pin the module constant tables.
+
+Purpose (issue #4881, wave 2; Refs #4874, #4770): lock a behavioral baseline so
+the post-submission refactor wave can prove behavior-preservation. If a test
+reveals a genuine bug, do NOT fix it here — document it and file a separate fix
+issue.
+
+These tests are additive: they lock the pure math helpers and constant tables
+directly with golden values. They do not duplicate the preflight-status,
+end-to-end report-export, or CLI coverage in
+``test_snqi_scalarization_sensitivity.py`` and
+``test_snqi_scalarization_sensitivity_issue_3653.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from robot_sf.benchmark.snqi_scalarization_sensitivity import (
+    BOUNDED_NORMALIZED_SENSITIVITY_METRICS,
+    DEFAULT_SWEEP_FACTORS,
+    OPTIONAL_SENSITIVITY_METRICS,
+    OPTIONAL_WEIGHTED_SENSITIVITY_METRICS,
+    REQUIRED_SENSITIVITY_METRICS,
+    SCALARIZATION_SENSITIVITY_PREFLIGHT_SCHEMA,
+    SCALARIZATION_SENSITIVITY_SCHEMA,
+    SENSITIVITY_PREFLIGHT_BLOCKED,
+    SENSITIVITY_PREFLIGHT_MALFORMED,
+    SENSITIVITY_PREFLIGHT_READY,
+    _constraints_first_endpoint,
+    _metric_float,
+    _pairwise_disagreement_rate,
+    _pairwise_reversal_count,
+    _pareto_points,
+    _rank_disagreement,
+    _variant_summary,
+)
+
+# ---------------------------------------------------------------------------
+# Constant tables
+# ---------------------------------------------------------------------------
+
+
+def test_schema_and_status_constants_are_pinned() -> None:
+    """Pin the schema-version strings and the three preflight status literals."""
+    assert SCALARIZATION_SENSITIVITY_SCHEMA == "snqi_scalarization_sensitivity.v1"
+    assert SCALARIZATION_SENSITIVITY_PREFLIGHT_SCHEMA == (
+        "snqi_scalarization_sensitivity_preflight.v1"
+    )
+    assert (
+        SENSITIVITY_PREFLIGHT_READY,
+        SENSITIVITY_PREFLIGHT_BLOCKED,
+        SENSITIVITY_PREFLIGHT_MALFORMED,
+    ) == (
+        "ready",
+        "blocked",
+        "malformed",
+    )
+
+
+def test_default_sweep_factors_table_is_pinned() -> None:
+    """The default weight-sweep factor grid is exactly this tuple."""
+    assert DEFAULT_SWEEP_FACTORS == (0.0, 0.25, 0.5, 1.0, 1.5, 2.0)
+
+
+def test_required_and_optional_metric_tables_are_pinned() -> None:
+    """Pin the required/optional metric tuples and the weighted-optional map."""
+    assert REQUIRED_SENSITIVITY_METRICS == (
+        "success",
+        "time_to_goal_norm",
+        "collisions",
+        "near_misses",
+        "comfort_exposure",
+    )
+    assert OPTIONAL_SENSITIVITY_METRICS == ("force_exceed_events", "jerk_mean")
+    assert OPTIONAL_WEIGHTED_SENSITIVITY_METRICS == {
+        "force_exceed_events": "w_force_exceed",
+        "jerk_mean": "w_jerk",
+    }
+    # Bounded-normalized terms are a subset of the required terms.
+    assert BOUNDED_NORMALIZED_SENSITIVITY_METRICS == (
+        "success",
+        "time_to_goal_norm",
+        "comfort_exposure",
+    )
+    assert set(BOUNDED_NORMALIZED_SENSITIVITY_METRICS).issubset(REQUIRED_SENSITIVITY_METRICS)
+
+
+# ---------------------------------------------------------------------------
+# _metric_float: coercion + finite guard
+# ---------------------------------------------------------------------------
+
+
+def test_metric_float_coerces_numeric_strings_and_numbers() -> None:
+    """Numeric values (incl. strings) coerce to float; the default is unused."""
+    assert _metric_float({"x": "1.5"}, "x", 0.0) == 1.5
+    assert _metric_float({"x": 2}, "x", 0.0) == 2.0
+
+
+def test_metric_float_bool_is_special_cased_before_default() -> None:
+    """``True`` -> 1.0 and ``False`` -> 0.0; bool never falls through to default."""
+    assert _metric_float({"x": True}, "x", 7.0) == 1.0
+    assert _metric_float({"x": False}, "x", 7.0) == 0.0
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+def test_metric_float_non_finite_returns_default(bad_value: float) -> None:
+    """Non-finite values fall through to the provided default."""
+    assert _metric_float({"x": bad_value}, "x", 2.0) == 2.0
+
+
+def test_metric_float_missing_or_non_numeric_returns_default() -> None:
+    """Missing keys and non-numeric values both fall through to the default."""
+    assert _metric_float({}, "x", 2.0) == 2.0
+    assert _metric_float({"x": "bad"}, "x", 2.0) == 2.0
+
+
+# ---------------------------------------------------------------------------
+# _constraints_first_endpoint: exact score formula
+# ---------------------------------------------------------------------------
+
+
+def test_constraints_first_score_single_clean_episode() -> None:
+    """One clean episode: score = 1 - 0.01*time = 0.995 for time_to_goal_norm=0.5."""
+    row = {
+        "success": 1.0,
+        "time_to_goal_norm": 0.5,
+        "collisions": 0,
+        "near_misses": 0,
+        "timeout": 0,
+        "deadlock": 0,
+    }
+    out = _constraints_first_endpoint([row])
+    assert out["constraints_first_score"] == pytest.approx(0.995)
+    assert out["episodes"] == 1
+
+
+def test_constraints_first_score_two_mixed_episodes() -> None:
+    """Two episodes (one clean, one all-events) pin every penalty coefficient."""
+    rows = [
+        {
+            "success": 1.0,
+            "collisions": 0,
+            "near_misses": 0,
+            "timeout": 0,
+            "deadlock": 0,
+            "time_to_goal_norm": 0.4,
+        },
+        {
+            "success": 0.0,
+            "collisions": 2,
+            "near_misses": 1,
+            "timeout": 1,
+            "deadlock": 1,
+            "time_to_goal_norm": 0.6,
+        },
+    ]
+    out = _constraints_first_endpoint(rows)
+    assert out["success_rate"] == pytest.approx(0.5)
+    assert out["collision_event_rate"] == pytest.approx(0.5)
+    assert out["near_miss_event_rate"] == pytest.approx(0.5)
+    assert out["timeout_rate"] == pytest.approx(0.5)
+    assert out["deadlock_rate"] == pytest.approx(0.5)
+    assert out["time_to_goal_norm_mean"] == pytest.approx(0.5)
+    # 0.5 - 0.5 - 0.5*0.5 - 0.25*0.5 - 0.25*0.5 - 0.01*0.5 = -0.505
+    assert out["constraints_first_score"] == pytest.approx(-0.505)
+
+
+def test_constraints_first_score_missing_time_defaults_to_one() -> None:
+    """A missing ``time_to_goal_norm`` defaults to 1.0, contributing -0.01."""
+    out = _constraints_first_endpoint([{"success": 1.0}])
+    assert out["time_to_goal_norm_mean"] == pytest.approx(1.0)
+    assert out["constraints_first_score"] == pytest.approx(0.99)
+
+
+def test_constraints_first_endpoint_field_set_is_pinned() -> None:
+    """The endpoint exposes exactly the documented field set."""
+    out = _constraints_first_endpoint([{"success": 1.0}])
+    assert set(out) == {
+        "episodes",
+        "success_rate",
+        "collision_event_rate",
+        "near_miss_event_rate",
+        "timeout_rate",
+        "deadlock_rate",
+        "time_to_goal_norm_mean",
+        "constraints_first_score",
+    }
+
+
+def test_constraints_first_endpoint_empty_raises() -> None:
+    """An empty episode set raises the pinned ``ValueError``."""
+    with pytest.raises(ValueError, match="planner must have at least one episode"):
+        _constraints_first_endpoint([])
+
+
+# ---------------------------------------------------------------------------
+# _pairwise_reversal_count / _pairwise_disagreement_rate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "left,right,expected",
+    [
+        (["A", "B", "C"], ["A", "B", "C"], 0),
+        (["A", "B", "C"], ["C", "B", "A"], 3),
+        (["A", "B", "C"], ["A", "C", "B"], 1),
+        (["A", "B"], ["B", "A"], 1),
+    ],
+)
+def test_pairwise_reversal_count_goldens(left: list[str], right: list[str], expected: int) -> None:
+    """Pin the inversion count for identical, reversed, and partially-shuffled orders."""
+    assert _pairwise_reversal_count(left, right) == expected
+
+
+def test_pairwise_reversal_count_set_mismatch_raises() -> None:
+    """Orders with different planner sets raise the pinned ``ValueError``."""
+    with pytest.raises(ValueError, match="rank orders must contain the same planners"):
+        _pairwise_reversal_count(["A", "B"], ["A", "C"])
+
+
+@pytest.mark.parametrize(
+    "left,right,expected",
+    [
+        (["A", "B", "C"], ["C", "B", "A"], 1.0),
+        (["A", "B", "C"], ["A", "C", "B"], 1 / 3),
+        (["A", "B"], ["B", "A"], 1.0),
+        (["A", "B", "C"], ["A", "B", "C"], 0.0),
+    ],
+)
+def test_pairwise_disagreement_rate_goldens(
+    left: list[str], right: list[str], expected: float
+) -> None:
+    """Pin the normalized disagreement rate over the possible pair count."""
+    assert _pairwise_disagreement_rate(left, right) == pytest.approx(expected)
+
+
+def test_pairwise_disagreement_rate_single_or_empty_is_zero() -> None:
+    """With fewer than two planners (possible == 0) the rate is defined as 0.0."""
+    assert _pairwise_disagreement_rate(["A"], ["A"]) == 0.0
+    assert _pairwise_disagreement_rate([], []) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _pareto_points: front classification
+# ---------------------------------------------------------------------------
+
+
+def _rows(points: list[tuple[str, float, float]]) -> list[dict[str, Any]]:
+    """Build planner rows from ``(name, constraints_first_score, snqi_mean)``."""
+    return [
+        {"planner": name, "constraints_first_score": x, "snqi_mean": y} for name, x, y in points
+    ]
+
+
+def test_pareto_points_two_non_dominated_sorted_by_score() -> None:
+    """Two non-dominating planners are both kept, sorted by constraints score."""
+    front = _pareto_points(_rows([("A", 0.8, 0.6), ("B", 0.6, 0.8)]))
+    assert [p["planner"] for p in front] == ["B", "A"]
+    assert front[0] == {"planner": "B", "constraints_first_score": 0.6, "snqi_mean": 0.8}
+
+
+def test_pareto_points_dominated_point_excluded() -> None:
+    """A strictly-dominated planner is dropped from the front."""
+    front = _pareto_points(_rows([("A", 0.8, 0.8), ("B", 0.6, 0.6)]))
+    assert [p["planner"] for p in front] == ["A"]
+
+
+def test_pareto_points_equal_points_both_kept() -> None:
+    """Two identical points neither dominate the other -> both kept."""
+    front = _pareto_points(_rows([("A", 0.5, 0.5), ("B", 0.5, 0.5)]))
+    assert [p["planner"] for p in front] == ["A", "B"]
+
+
+# ---------------------------------------------------------------------------
+# _rank_disagreement / _variant_summary: winner + reversal summaries
+# ---------------------------------------------------------------------------
+
+
+def test_rank_disagreement_winner_and_reversal_goldens() -> None:
+    """Pin winner disagreement, winners, and reversal count for swapped orders."""
+    out = _rank_disagreement(["A", "B"], ["B", "A"])
+    assert out["snqi_winner"] == "A"
+    assert out["constraints_first_winner"] == "B"
+    assert out["winner_disagreement"] is True
+    assert out["pairwise_reversal_count"] == 1
+    assert out["pairwise_disagreement_rate"] == pytest.approx(1.0)
+
+
+def test_rank_disagreement_agreement_has_no_winner_change() -> None:
+    """Identical orders -> no winner disagreement and zero reversals."""
+    out = _rank_disagreement(["A", "B"], ["A", "B"])
+    assert out["winner_disagreement"] is False
+    assert out["pairwise_reversal_count"] == 0
+
+
+@pytest.mark.parametrize(
+    "base,variant,changed", [(["A", "B"], ["B", "A"], True), (["A", "B"], ["A", "B"], False)]
+)
+def test_variant_summary_winner_changed_flag(
+    base: list[str], variant: list[str], changed: bool
+) -> None:
+    """``winner_changed`` tracks whether the top-ranked planner differs from base."""
+    out = _variant_summary(base, variant)
+    assert out["winner_changed"] is changed
+    assert out["order"] == list(variant)


### PR DESCRIPTION
## What

Characterization-test **wave 2** for issue #4881: four additive, behavior-locking test modules that pin the *current observable behavior* of the next tier of depended-on benchmark modules on tiny synthetic inputs, ahead of the post-submission refactor wave (#4770). Continuation of wave 1 (#4874 / PR #4876) under the same rules: **NEW tests only, zero production-code changes, any discovered bug documented + filed separately and never fixed inline.**

Successor slice: this PR adds **new capability** — it characterizes four modules wave 1 did not touch (`episode_replay_figure.py`, `critical_intervals.py`, `heterogeneous_rank_sensitivity.py`, `snqi_scalarization_sensitivity.py`). It does not duplicate PR #4876, which covered `aggregate.py`, `metrics.py`, `constraints_first_scoring.py`, `exemplar_selection.py`. The new files are `*_characterization.py` siblings alongside the pre-existing `test_*.py` files for each module, so there is no overlap with existing coverage.

## Why

Lock a behavioral baseline so the post-submission refactor wave (#4770 — god-file/module splits, metrics dedup, exception-hierarchy migration) can prove behavior-preservation. Each module is heavily depended-on and refactor-hostile; these table-driven golden-value tests make silent semantic drift immediately visible.

## Coverage added (103 new tests)

| Module (file) | What is pinned |
| --- | --- |
| `heterogeneous_rank_sensitivity.py` | error contract (`<2 planners`); exact blocked/ready shapes + interpolated messages; `scenario_params` fallback path; NaN/Inf/missing-metric finite-guard skipping; float-seed int coercion; whitespace stripping; ranking direction (`higher_is_safer`); exact `observed_means`; pairwise-key contract (`n·(n-1)` directed keys); reversal-dict shape; arm sorting; same-seed determinism |
| `episode_replay_figure.py` | `_finite_floats` / `_parse_final_position` finite guards; `EpisodeRow` validation + seed int coercion; full `check_determinism` state machine incl. the documented `final_progress`-is-informational regression; SHA-256 helpers (known digests). Rendering-free — no matplotlib |
| `critical_intervals.py` | TTC convention + constants/anchor set; `_pairwise_ttc_s` closing-speed formula (head-on exact, 3-4-5 triangle, receding/perpendicular/stationary → None, overlap → 0.0); `_compute_max_braking_deceleration_mps2` on constructed velocity profiles; window-metric aggregation table + strict `< 0.3` / `< 0.7` boundaries; `report_to_dict` NaN/Inf → `None` serialization guard |
| `snqi_scalarization_sensitivity.py` | constant tables (schema versions, status literals, required/optional metric tuples, sweep factors); `_metric_float` coercion (bool special-case, non-finite/missing → default); `_constraints_first_endpoint` exact score formula (every penalty coefficient); pairwise reversal/disagreement arithmetic; Pareto-front classification; rank-disagreement / variant-summary winners |

Edge cases required by the issue are covered throughout: empty input, single-row/single-seed, and NaN/Inf at every finite-guard boundary.

## Observed quirk (not fixed inline, per issue rules)

`heading_oscillation` for a perfectly straight-line (constant `(1,0)`) path is **0.25, not 0.0**, because the metric is `np.var` over the *flattened* unit-direction vectors (variance between the constant x=1 and y=0 components). This is pinned as current behavior in `test_critical_intervals_characterization.py` with an explanatory comment. It is a candidate follow-up bug filed separately: #4886 (the metric arguably should be ~0 for straight motion); it is **not** fixed here, and no production code is touched in this PR.

## Validation

CPU-level only (no campaigns / Slurm / training / benchmark runs):

```
$ uv run pytest tests/benchmark/test_heterogeneous_rank_sensitivity_characterization.py \
                 tests/benchmark/test_episode_replay_figure_characterization.py \
                 tests/benchmark/test_critical_intervals_characterization.py \
                 tests/benchmark/test_snqi_scalarization_sensitivity_characterization.py -q
103 passed in 0.79s

$ uv run ruff check <4 files>        # All checks passed!
$ uv run ruff format --check <4 files>  # all formatted
```

Diff vs `origin/main` is exclusively four new files under `tests/benchmark/` — no `robot_sf/` production changes. Test-only; no user-facing change, so no CHANGELOG entry.

Closes #4881.

---

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added characterization test coverage for benchmark behavior, pinning current outputs for critical interval calculations, episode replay checks, rank-sensitivity analysis, and scalarization sensitivity helpers.
  * Expanded validation around parsing, filtering, ranking, serialization, and determinism, including edge cases like empty inputs, non-finite values, missing fields, and reversal detection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->


