### PR TITLE
Issue #4880: narrow remaining broad-except sites in benchmark layer (cheap-lane worker)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -462,17 +462,11 @@ max-statements = 60
 "robot_sf/benchmark/cli.py" = ["BLE001", "T201"]
 "robot_sf/benchmark/doctor.py" = ["BLE001"]
 "robot_sf/benchmark/failure_extractor.py" = ["BLE001"]
-"robot_sf/benchmark/figure_qa.py" = ["BLE001"]
-"robot_sf/benchmark/full_classic/orchestrator.py" = ["BLE001"]
-"robot_sf/benchmark/full_classic/plots.py" = ["BLE001"]
-"robot_sf/benchmark/full_classic/render_sim_view.py" = ["BLE001", "C901"]
-"robot_sf/benchmark/full_classic/validation.py" = ["BLE001"]
-"robot_sf/benchmark/full_classic/visual_deps.py" = ["BLE001"]
+"robot_sf/benchmark/full_classic/render_sim_view.py" = ["C901"]
 "robot_sf/benchmark/full_classic/visuals.py" = ["C901"]
 "robot_sf/benchmark/helper_catalog.py" = ["BLE001"]
 "robot_sf/benchmark/map_runner.py" = ["BLE001"]
 "robot_sf/benchmark/map_runner_batch_runner.py" = ["BLE001"]
-"robot_sf/benchmark/plots.py" = ["BLE001"]
 "robot_sf/benchmark/runner.py" = ["BLE001"]
 "robot_sf/benchmark/snqi/cli.py" = ["BLE001", "T201"]
 "robot_sf/benchmark/snqi/compute.py" = ["BLE001"]
@@ -482,6 +476,10 @@ max-statements = 60
 # Kept broad on purpose (CLI boundary / diagnostic / batch-isolation / policy handlers):
 # cli.py, snqi/cli.py, doctor.py, helper_catalog.py, map_runner*.py, runner.py,
 # snqi/compute.py (latent capture_output+stderr ValueError masked by handler; see PR body).
+# Issue #4880 (commit 3): viz/figure/full_classic group; BLE001 removed for figure_qa,
+# plots, full_classic/{orchestrator,plots,render_sim_view(C901 kept),validation,visual_deps}.
+# camera_ready/campaign.py keeps BLE001: its full-benchmark-run handler is campaign fault isolation.
+# cli.py remains a future slice (47 CLI-boundary handlers).
 # Issue #4859: visualization.py worst sites fixed, BLE001 removed to enforce lint guard.
 "robot_sf/adversarial/**/*.py" = ["D417", "DOC201", "TC001", "TC003"]
 "robot_sf/adversarial/config.py" = ["C901", "PLR0913"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -469,19 +469,19 @@ max-statements = 60
 "robot_sf/benchmark/full_classic/validation.py" = ["BLE001"]
 "robot_sf/benchmark/full_classic/visual_deps.py" = ["BLE001"]
 "robot_sf/benchmark/full_classic/visuals.py" = ["C901"]
-"robot_sf/benchmark/hazard_odd_coverage.py" = ["BLE001"]
 "robot_sf/benchmark/helper_catalog.py" = ["BLE001"]
 "robot_sf/benchmark/map_runner.py" = ["BLE001"]
 "robot_sf/benchmark/map_runner_batch_runner.py" = ["BLE001"]
-"robot_sf/benchmark/orca_preflight.py" = ["BLE001"]
-"robot_sf/benchmark/planner_inclusion.py" = ["BLE001"]
 "robot_sf/benchmark/plots.py" = ["BLE001"]
-"robot_sf/benchmark/predictive_planner_config.py" = ["BLE001"]
 "robot_sf/benchmark/runner.py" = ["BLE001"]
-"robot_sf/benchmark/snqi/campaign_contract.py" = ["BLE001"]
 "robot_sf/benchmark/snqi/cli.py" = ["BLE001", "T201"]
 "robot_sf/benchmark/snqi/compute.py" = ["BLE001"]
-"robot_sf/benchmark/snqi/weights_validation.py" = ["BLE001"]
+# Issue #4880 (commit 2): runner/map/snqi/planner group; BLE001 removed for
+# hazard_odd_coverage, orca_preflight, planner_inclusion, predictive_planner_config,
+# snqi/campaign_contract, snqi/weights_validation.
+# Kept broad on purpose (CLI boundary / diagnostic / batch-isolation / policy handlers):
+# cli.py, snqi/cli.py, doctor.py, helper_catalog.py, map_runner*.py, runner.py,
+# snqi/compute.py (latent capture_output+stderr ValueError masked by handler; see PR body).
 # Issue #4859: visualization.py worst sites fixed, BLE001 removed to enforce lint guard.
 "robot_sf/adversarial/**/*.py" = ["D417", "DOC201", "TC001", "TC003"]
 "robot_sf/adversarial/config.py" = ["C901", "PLR0913"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -451,16 +451,18 @@ max-statements = 60
 # CLI tools: allow prints to stdout.
 # Existing broad benchmark exception handlers are ratcheted by
 # scripts/validation/check_broad_exceptions.py; keep BLE001 scoped current files.
-# Issue #4859: aggregate.py worst sites fixed, BLE001 removed to enforce lint guard.
-"robot_sf/benchmark/ablation.py" = ["BLE001"]
-"robot_sf/benchmark/artifact_catalog.py" = ["BLE001"]
+# Issue #4859: aggregate.py/metrics.py/visualization.py worst sites fixed; BLE001 removed.
+# Issue #4880 (commit 1): schema/contract/manifest/catalog group fully narrowed; BLE001
+# removed for ablation, artifact_catalog, freeze_manifest, imitation_manifest,
+# scenario_contract, scenario_schema, schema_reference, summary,
+# validation/trajectory_dataset, validation_utils.
+# helper_catalog.py keeps BLE001: its wrappers intentionally convert any failure to RuntimeError.
 "robot_sf/benchmark/camera_ready_campaign.py" = ["BLE001"]
 "robot_sf/benchmark/camera_ready/campaign.py" = ["BLE001"]
 "robot_sf/benchmark/cli.py" = ["BLE001", "T201"]
 "robot_sf/benchmark/doctor.py" = ["BLE001"]
 "robot_sf/benchmark/failure_extractor.py" = ["BLE001"]
 "robot_sf/benchmark/figure_qa.py" = ["BLE001"]
-"robot_sf/benchmark/freeze_manifest.py" = ["BLE001"]
 "robot_sf/benchmark/full_classic/orchestrator.py" = ["BLE001"]
 "robot_sf/benchmark/full_classic/plots.py" = ["BLE001"]
 "robot_sf/benchmark/full_classic/render_sim_view.py" = ["BLE001", "C901"]
@@ -469,25 +471,17 @@ max-statements = 60
 "robot_sf/benchmark/full_classic/visuals.py" = ["C901"]
 "robot_sf/benchmark/hazard_odd_coverage.py" = ["BLE001"]
 "robot_sf/benchmark/helper_catalog.py" = ["BLE001"]
-"robot_sf/benchmark/imitation_manifest.py" = ["BLE001"]
 "robot_sf/benchmark/map_runner.py" = ["BLE001"]
 "robot_sf/benchmark/map_runner_batch_runner.py" = ["BLE001"]
-# Issue #4859: metrics.py worst sites fixed, BLE001 removed to enforce lint guard.
 "robot_sf/benchmark/orca_preflight.py" = ["BLE001"]
 "robot_sf/benchmark/planner_inclusion.py" = ["BLE001"]
 "robot_sf/benchmark/plots.py" = ["BLE001"]
 "robot_sf/benchmark/predictive_planner_config.py" = ["BLE001"]
 "robot_sf/benchmark/runner.py" = ["BLE001"]
-"robot_sf/benchmark/scenario_contract.py" = ["BLE001"]
-"robot_sf/benchmark/scenario_schema.py" = ["BLE001"]
-"robot_sf/benchmark/schema_reference.py" = ["BLE001"]
 "robot_sf/benchmark/snqi/campaign_contract.py" = ["BLE001"]
 "robot_sf/benchmark/snqi/cli.py" = ["BLE001", "T201"]
 "robot_sf/benchmark/snqi/compute.py" = ["BLE001"]
 "robot_sf/benchmark/snqi/weights_validation.py" = ["BLE001"]
-"robot_sf/benchmark/summary.py" = ["BLE001"]
-"robot_sf/benchmark/validation/trajectory_dataset.py" = ["BLE001"]
-"robot_sf/benchmark/validation_utils.py" = ["BLE001"]
 # Issue #4859: visualization.py worst sites fixed, BLE001 removed to enforce lint guard.
 "robot_sf/adversarial/**/*.py" = ["D417", "DOC201", "TC001", "TC003"]
 "robot_sf/adversarial/config.py" = ["C901", "PLR0913"]

--- a/robot_sf/benchmark/ablation.py
+++ b/robot_sf/benchmark/ablation.py
@@ -114,7 +114,7 @@ def _compute_group_means(
         for rec in rows:
             try:
                 vals.append(_episode_snqi(rec, weights, baseline))
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, KeyError):
                 continue
         if vals:
             means[gid] = _mean(vals)

--- a/robot_sf/benchmark/ablation.py
+++ b/robot_sf/benchmark/ablation.py
@@ -114,7 +114,7 @@ def _compute_group_means(
         for rec in rows:
             try:
                 vals.append(_episode_snqi(rec, weights, baseline))
-            except Exception:
+            except (ValueError, TypeError):
                 continue
         if vals:
             means[gid] = _mean(vals)

--- a/robot_sf/benchmark/artifact_catalog.py
+++ b/robot_sf/benchmark/artifact_catalog.py
@@ -146,7 +146,7 @@ def validate_artifact_catalog(path: Path) -> list[ArtifactCatalogIssue]:
     try:
         text = path.read_text(encoding="utf-8")
         payload = json.loads(text) if path.suffix.lower() == ".json" else yaml.safe_load(text)
-    except Exception as exc:  # pragma: no cover - defensive CLI path
+    except (OSError, ValueError, yaml.YAMLError) as exc:  # pragma: no cover - defensive CLI path
         return [ArtifactCatalogIssue("/", f"failed to load catalog: {exc}")]
     if not isinstance(payload, Mapping):
         return [ArtifactCatalogIssue("/", "expected a mapping payload")]

--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -1932,7 +1932,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
                 "total_bytes": bundle.total_bytes,
             }
             campaign_summary["publication_bundle"] = publication_payload
-        except Exception as exc:
+        except (OSError, ValueError, KeyError, TypeError, RuntimeError) as exc:
             warnings.append(f"Publication bundle export failed: {exc}")
     elif (
         cfg.export_publication_bundle
@@ -1967,7 +1967,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
         )
         validate_assurance_fragment(fragment)
         write_assurance_fragment(reports_dir, fragment, repo_root=get_repository_root())
-    except Exception as exc:
+    except (OSError, ValueError, KeyError, TypeError, RuntimeError) as exc:
         warnings.append(f"Assurance fragment export failed: {exc}")
 
     if snqi_hard_fail:

--- a/robot_sf/benchmark/episode_replay_figure.py
+++ b/robot_sf/benchmark/episode_replay_figure.py
@@ -1140,7 +1140,7 @@ def replay_episode_and_generate_figures(  # noqa: PLR0913
             "output_dir": str(out_dir),
         }
 
-    except Exception as e:
+    except (ValueError, TypeError, RuntimeError, OSError, KeyError, AttributeError) as e:
         raise RuntimeError(f"Figure generation failed: {e}") from e
 
 

--- a/robot_sf/benchmark/figure_qa.py
+++ b/robot_sf/benchmark/figure_qa.py
@@ -270,7 +270,7 @@ def _check_image_content(path: Path, artifact_id: str, issues: list[FigureQA]) -
         with Image.open(path) as img:
             width, height = img.size
             img.verify()
-    except Exception as exc:
+    except (OSError, ValueError) as exc:
         issues.append(FigureQA(artifact_id, "valid_image", f"cannot verify image: {exc}"))
         return
 
@@ -318,7 +318,7 @@ def _check_caption_file(path: Path, artifact_id: str, issues: list[FigureQA]) ->
         return
     try:
         text = path.read_text(encoding="utf-8")
-    except Exception as exc:
+    except OSError as exc:
         issues.append(FigureQA(artifact_id, "caption_file", f"cannot read caption file: {exc}"))
         return
     if not text.strip():

--- a/robot_sf/benchmark/freeze_manifest.py
+++ b/robot_sf/benchmark/freeze_manifest.py
@@ -403,7 +403,7 @@ def evaluate_freeze_manifest(
     )
     try:
         freeze_contract = load_freeze_manifest(freeze_manifest_path)
-    except Exception as exc:
+    except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as exc:
         return {
             "path": str(Path(freeze_manifest_path)),
             "status": "error",

--- a/robot_sf/benchmark/full_classic/orchestrator.py
+++ b/robot_sf/benchmark/full_classic/orchestrator.py
@@ -883,7 +883,7 @@ def _rollout_episode(env, horizon: int, dt: float, replay_cap):
                 env.sim_ui, "record_video", False
             ):
                 env.render()
-        except (RuntimeError, ValueError, TypeError, AttributeError, OSError):
+        except (RuntimeError, ValueError, TypeError, AttributeError, OSError, IndexError, KeyError):
             # Rendering is best-effort; ignore to keep rollout running
             pass
         step_meta = info.get("meta", {}) if isinstance(info, dict) else {}

--- a/robot_sf/benchmark/full_classic/orchestrator.py
+++ b/robot_sf/benchmark/full_classic/orchestrator.py
@@ -829,7 +829,13 @@ def _init_env_for_job(job, cfg, horizon: int, *, episode_id: str, scenario):
     if sim is not None:
         try:
             goal_vec = np.asarray(sim.goal_pos[0], dtype=float)
-        except (ValueError, TypeError, IndexError, KeyError, AttributeError):  # pragma: no cover - defensive fallback
+        except (
+            ValueError,
+            TypeError,
+            IndexError,
+            KeyError,
+            AttributeError,
+        ):  # pragma: no cover - defensive fallback
             goal_vec = np.zeros(2, dtype=float)
     return env, dt, replay_cap, goal_vec
 
@@ -896,7 +902,12 @@ def _close_env(env):
         pass
     try:
         env.close()
-    except (RuntimeError, AttributeError, TypeError, OSError):  # pragma: no cover - gym close best-effort
+    except (
+        RuntimeError,
+        AttributeError,
+        TypeError,
+        OSError,
+    ):  # pragma: no cover - gym close best-effort
         pass
 
 

--- a/robot_sf/benchmark/full_classic/orchestrator.py
+++ b/robot_sf/benchmark/full_classic/orchestrator.py
@@ -527,7 +527,7 @@ def _build_env_config(scenario, cfg, horizon: int):
     )
     try:
         dt = float(config.sim_config.time_per_step_in_secs)
-    except Exception:  # pragma: no cover - defensive
+    except (ValueError, TypeError, AttributeError):  # pragma: no cover - defensive
         dt = 0.1
     # Ensure sim horizon matches requested horizon
     config.sim_config.sim_time_in_secs = horizon * dt
@@ -591,7 +591,7 @@ def _extract_ped_forces(simulator, ped_pos: np.ndarray) -> np.ndarray:
         return np.full_like(ped_pos, np.nan)
     try:
         arr = np.asarray(forces, dtype=float)
-    except Exception:
+    except (ValueError, TypeError):
         return np.full_like(ped_pos, np.nan)
 
     if arr.shape == ped_pos.shape:
@@ -651,10 +651,10 @@ def _capture_visual_state(env):
             try:
                 goal_val = vis_state.robot_action.goal  # type: ignore[attr-defined]
                 robot_goal = (float(goal_val[0]), float(goal_val[1]))
-            except Exception:
+            except (AttributeError, TypeError, ValueError, IndexError, KeyError):
                 robot_goal = None
         return ray_vecs, ped_actions, robot_goal
-    except Exception:
+    except (ValueError, TypeError, KeyError, AttributeError):
         return None, None, None
 
 
@@ -685,7 +685,7 @@ def _compute_episode_metrics(  # noqa: PLR0913
     if map_path:
         try:
             map_def = resolve_map_definition(str(map_path), scenario_path=Path(str(map_path)))
-        except Exception:  # pragma: no cover - defensive fallback
+        except (OSError, ValueError, KeyError):  # pragma: no cover - defensive fallback
             map_def = None
     shortest_path = (
         compute_shortest_path_length(map_def, robot_pos[0], goal)
@@ -731,7 +731,7 @@ def _compute_episode_metrics(  # noqa: PLR0913
     weights = _load_snqi_weights(getattr(cfg, "snqi_weights_path", None))
     try:
         metrics["snqi"] = snqi(metrics_raw, weights, baseline_stats=None)
-    except Exception:  # pragma: no cover - defensive
+    except (ValueError, TypeError, KeyError):  # pragma: no cover - defensive
         metrics["snqi"] = float("nan")
     serializable: dict[str, float] = {}
     for key, value in metrics.items():
@@ -829,7 +829,7 @@ def _init_env_for_job(job, cfg, horizon: int, *, episode_id: str, scenario):
     if sim is not None:
         try:
             goal_vec = np.asarray(sim.goal_pos[0], dtype=float)
-        except Exception:  # pragma: no cover - defensive fallback
+        except (ValueError, TypeError, IndexError, KeyError, AttributeError):  # pragma: no cover - defensive fallback
             goal_vec = np.zeros(2, dtype=float)
     return env, dt, replay_cap, goal_vec
 
@@ -877,7 +877,7 @@ def _rollout_episode(env, horizon: int, dt: float, replay_cap):
                 env.sim_ui, "record_video", False
             ):
                 env.render()
-        except Exception:
+        except (RuntimeError, ValueError, TypeError, AttributeError, OSError):
             # Rendering is best-effort; ignore to keep rollout running
             pass
         step_meta = info.get("meta", {}) if isinstance(info, dict) else {}
@@ -892,11 +892,11 @@ def _close_env(env):
     """Best-effort environment cleanup."""
     try:
         env.exit()
-    except Exception:  # pragma: no cover
+    except (RuntimeError, AttributeError, TypeError, OSError):  # pragma: no cover
         pass
     try:
         env.close()
-    except Exception:  # pragma: no cover - gym close best-effort
+    except (RuntimeError, AttributeError, TypeError, OSError):  # pragma: no cover - gym close best-effort
         pass
 
 
@@ -1493,7 +1493,7 @@ def run_full_benchmark(  # noqa: C901,PLR0912,PLR0915
         for jb in jobs:
             try:
                 jb.horizon = min(int(getattr(jb, "horizon", horizon_cap)), horizon_cap)
-            except Exception:
+            except (ValueError, TypeError, AttributeError):
                 jb.horizon = horizon_cap
 
     # Manifest & initial execution

--- a/robot_sf/benchmark/full_classic/plots.py
+++ b/robot_sf/benchmark/full_classic/plots.py
@@ -137,7 +137,7 @@ def _distribution_plot(groups, out_dir: Path) -> _PlotArtifact:
     try:
         fig.savefig(pdf_path, bbox_inches="tight")
         status = "generated"
-    except Exception as exc:  # pragma: no cover - defensive
+    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as exc:  # pragma: no cover - defensive
         note = f"savefig-error:{exc}"
     finally:
         _safe_fig_close(fig)
@@ -183,7 +183,7 @@ def _trajectory_plot(records: Iterable[dict], out_dir: Path) -> _PlotArtifact:
     try:
         fig.savefig(pdf_path, bbox_inches="tight")
         status = "generated"
-    except Exception as exc:  # pragma: no cover - defensive
+    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as exc:  # pragma: no cover - defensive
         note = f"savefig-error:{exc}"
     finally:
         _safe_fig_close(fig)
@@ -217,7 +217,7 @@ def _path_efficiency_distribution_plot(groups, out_dir: Path) -> _PlotArtifact:
     try:
         fig.savefig(pdf_path, bbox_inches="tight")
         status = "generated"
-    except Exception as exc:  # pragma: no cover - defensive
+    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as exc:  # pragma: no cover - defensive
         note = f"savefig-error:{exc}"
     finally:
         _safe_fig_close(fig)
@@ -265,7 +265,7 @@ def _success_collision_scatter_plot(groups, out_dir: Path) -> _PlotArtifact:
     try:
         fig.savefig(pdf_path, bbox_inches="tight")
         status = "generated"
-    except Exception as exc:  # pragma: no cover - defensive
+    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as exc:  # pragma: no cover - defensive
         note = f"savefig-error:{exc}"
     finally:
         _safe_fig_close(fig)
@@ -295,7 +295,7 @@ def _episode_length_histogram(out_dir: Path, records: Iterable[dict]) -> _PlotAr
     try:
         fig.savefig(pdf_path, bbox_inches="tight")
         status = "generated"
-    except Exception as exc:  # pragma: no cover - defensive
+    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as exc:  # pragma: no cover - defensive
         note = f"savefig-error:{exc}"
     finally:
         _safe_fig_close(fig)

--- a/robot_sf/benchmark/full_classic/plots.py
+++ b/robot_sf/benchmark/full_classic/plots.py
@@ -137,7 +137,13 @@ def _distribution_plot(groups, out_dir: Path) -> _PlotArtifact:
     try:
         fig.savefig(pdf_path, bbox_inches="tight")
         status = "generated"
-    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as exc:  # pragma: no cover - defensive
+    except (
+        ValueError,
+        TypeError,
+        RuntimeError,
+        AttributeError,
+        OSError,
+    ) as exc:  # pragma: no cover - defensive
         note = f"savefig-error:{exc}"
     finally:
         _safe_fig_close(fig)
@@ -183,7 +189,13 @@ def _trajectory_plot(records: Iterable[dict], out_dir: Path) -> _PlotArtifact:
     try:
         fig.savefig(pdf_path, bbox_inches="tight")
         status = "generated"
-    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as exc:  # pragma: no cover - defensive
+    except (
+        ValueError,
+        TypeError,
+        RuntimeError,
+        AttributeError,
+        OSError,
+    ) as exc:  # pragma: no cover - defensive
         note = f"savefig-error:{exc}"
     finally:
         _safe_fig_close(fig)
@@ -217,7 +229,13 @@ def _path_efficiency_distribution_plot(groups, out_dir: Path) -> _PlotArtifact:
     try:
         fig.savefig(pdf_path, bbox_inches="tight")
         status = "generated"
-    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as exc:  # pragma: no cover - defensive
+    except (
+        ValueError,
+        TypeError,
+        RuntimeError,
+        AttributeError,
+        OSError,
+    ) as exc:  # pragma: no cover - defensive
         note = f"savefig-error:{exc}"
     finally:
         _safe_fig_close(fig)
@@ -265,7 +283,13 @@ def _success_collision_scatter_plot(groups, out_dir: Path) -> _PlotArtifact:
     try:
         fig.savefig(pdf_path, bbox_inches="tight")
         status = "generated"
-    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as exc:  # pragma: no cover - defensive
+    except (
+        ValueError,
+        TypeError,
+        RuntimeError,
+        AttributeError,
+        OSError,
+    ) as exc:  # pragma: no cover - defensive
         note = f"savefig-error:{exc}"
     finally:
         _safe_fig_close(fig)
@@ -295,7 +319,13 @@ def _episode_length_histogram(out_dir: Path, records: Iterable[dict]) -> _PlotAr
     try:
         fig.savefig(pdf_path, bbox_inches="tight")
         status = "generated"
-    except (ValueError, TypeError, RuntimeError, AttributeError, OSError) as exc:  # pragma: no cover - defensive
+    except (
+        ValueError,
+        TypeError,
+        RuntimeError,
+        AttributeError,
+        OSError,
+    ) as exc:  # pragma: no cover - defensive
         note = f"savefig-error:{exc}"
     finally:
         _safe_fig_close(fig)

--- a/robot_sf/benchmark/full_classic/render_sim_view.py
+++ b/robot_sf/benchmark/full_classic/render_sim_view.py
@@ -86,7 +86,13 @@ def generate_frames(  # noqa: PLR0912
     if getattr(episode, "map_path", None):
         try:
             map_def = convert_map(str(episode.map_path))  # type: ignore[arg-type]
-        except (OSError, ValueError, KeyError, TypeError, RuntimeError) as exc:  # pragma: no cover - fallback path
+        except (
+            OSError,
+            ValueError,
+            KeyError,
+            TypeError,
+            RuntimeError,
+        ) as exc:  # pragma: no cover - fallback path
             try:
                 logger = importlib.import_module("loguru").logger
                 logger.debug("convert_map failed for %s: %s", episode.map_path, exc)
@@ -138,7 +144,13 @@ def generate_frames(  # noqa: PLR0912
                     frame = np.zeros((360, 640, 3), dtype=np.uint8)
             except (AttributeError, RuntimeError, ImportError):
                 frame = np.zeros((360, 640, 3), dtype=np.uint8)
-            except (ValueError, IndexError, TypeError, KeyError, OSError) as exc:  # pragma: no cover - defensive
+            except (
+                ValueError,
+                IndexError,
+                TypeError,
+                KeyError,
+                OSError,
+            ) as exc:  # pragma: no cover - defensive
                 try:
                     logger = importlib.import_module("loguru").logger
                     logger.debug("generate_frames render capture failed: %s", exc)

--- a/robot_sf/benchmark/full_classic/render_sim_view.py
+++ b/robot_sf/benchmark/full_classic/render_sim_view.py
@@ -46,7 +46,7 @@ try:  # lightweight import gate
 except ImportError as e:
     SimulationView = None  # type: ignore
     _SIM_VIEW_IMPORT_ERROR = e
-except Exception as e:  # pragma: no cover - defensive
+except (OSError, RuntimeError) as e:  # pragma: no cover - defensive
     # Keep prior behavior for unexpected import-time errors: record and continue.
     SimulationView = None  # type: ignore
     _SIM_VIEW_IMPORT_ERROR = e
@@ -86,11 +86,11 @@ def generate_frames(  # noqa: PLR0912
     if getattr(episode, "map_path", None):
         try:
             map_def = convert_map(str(episode.map_path))  # type: ignore[arg-type]
-        except Exception as exc:  # pragma: no cover - fallback path
+        except (OSError, ValueError, KeyError, TypeError, RuntimeError) as exc:  # pragma: no cover - fallback path
             try:
                 logger = importlib.import_module("loguru").logger
                 logger.debug("convert_map failed for %s: %s", episode.map_path, exc)
-            except Exception:
+            except ImportError:
                 pass
             map_def = None
     view_kwargs: dict = {
@@ -118,7 +118,7 @@ def generate_frames(  # noqa: PLR0912
                     ped_actions=np.zeros_like(ped_positions),
                     time_per_step_in_secs=dt,
                 )
-            except Exception:
+            except (ValueError, TypeError, KeyError, AttributeError):
                 state = step  # fallback to replay step if construction fails
             try:
                 if hasattr(_sim_view, "render"):
@@ -138,7 +138,7 @@ def generate_frames(  # noqa: PLR0912
                     frame = np.zeros((360, 640, 3), dtype=np.uint8)
             except (AttributeError, RuntimeError, ImportError):
                 frame = np.zeros((360, 640, 3), dtype=np.uint8)
-            except Exception as exc:  # pragma: no cover - defensive
+            except (ValueError, IndexError, TypeError, KeyError, OSError) as exc:  # pragma: no cover - defensive
                 try:
                     logger = importlib.import_module("loguru").logger
                     logger.debug("generate_frames render capture failed: %s", exc)
@@ -207,11 +207,11 @@ def _load_map_def(ep: ReplayEpisode) -> MapDefinition | None:
     if getattr(ep, "map_path", None):
         try:
             map_def = convert_map(str(ep.map_path))  # type: ignore[arg-type]
-        except Exception:  # pragma: no cover - fallback
+        except (OSError, ValueError, KeyError):  # pragma: no cover - fallback
             map_def = None
     try:
         ep._map_def_cache = map_def
-    except Exception:
+    except (AttributeError, TypeError):
         pass
     return map_def
 
@@ -270,10 +270,19 @@ def generate_video_file(
         status = "success" if size > 0 else "skipped"
         if size == 0:
             note = "moviepy-missing" if not MOVIEPY_AVAILABLE else "encode-empty"
-    except Exception as exc:  # pragma: no cover - defensive
+    except (
+        ValueError,
+        IndexError,
+        TypeError,
+        RuntimeError,
+        OSError,
+        KeyError,
+        AttributeError,
+        ImportError,
+    ) as exc:  # pragma: no cover - defensive
         try:
             view.exit_simulation()
-        except Exception:
+        except (RuntimeError, AttributeError, TypeError, OSError):
             pass
         status = "failed"
         note = f"render-error:{exc.__class__.__name__}"

--- a/robot_sf/benchmark/full_classic/validation.py
+++ b/robot_sf/benchmark/full_classic/validation.py
@@ -80,7 +80,7 @@ def validate_visual_manifests(base_dir: Path, contracts_dir: Path) -> list[str]:
             raise ValueError(
                 f"Validation failed for {manifest_name}: {exc.message} at path {'/'.join(str(p) for p in exc.path)}",
             ) from exc
-        except Exception as exc:
+        except (jsonschema.SchemaError, OSError, ValueError, TypeError) as exc:
             raise ValueError(
                 f"Error validating {manifest_name}: {exc.__class__.__name__}: {exc}",
             ) from exc

--- a/robot_sf/benchmark/full_classic/visual_deps.py
+++ b/robot_sf/benchmark/full_classic/visual_deps.py
@@ -44,7 +44,12 @@ def simulation_view_ready() -> bool:  # T030
         ready = width > 0 and height > 0
     except (ImportError, OSError):
         return False
-    except (RuntimeError, AttributeError, TypeError, ValueError) as exc:  # pragma: no cover - defensive
+    except (
+        RuntimeError,
+        AttributeError,
+        TypeError,
+        ValueError,
+    ) as exc:  # pragma: no cover - defensive
         # Unexpected failure during lightweight sim view probe -> treat as not ready
         # but log at debug level for diagnostics.
         try:

--- a/robot_sf/benchmark/full_classic/visual_deps.py
+++ b/robot_sf/benchmark/full_classic/visual_deps.py
@@ -44,7 +44,7 @@ def simulation_view_ready() -> bool:  # T030
         ready = width > 0 and height > 0
     except (ImportError, OSError):
         return False
-    except Exception as exc:  # pragma: no cover - defensive
+    except (RuntimeError, AttributeError, TypeError, ValueError) as exc:  # pragma: no cover - defensive
         # Unexpected failure during lightweight sim view probe -> treat as not ready
         # but log at debug level for diagnostics.
         try:

--- a/robot_sf/benchmark/hazard_odd_coverage.py
+++ b/robot_sf/benchmark/hazard_odd_coverage.py
@@ -244,7 +244,7 @@ def _load_hazard_mapping(path: Path | None) -> tuple[HazardTraceability | None, 
         return load_hazard_traceability(path), _input_ref(
             path, "available", "loaded hazard mapping"
         )
-    except Exception as exc:
+    except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as exc:
         return None, _input_ref(path, "unavailable", f"could not load hazard mapping: {exc}")
 
 
@@ -258,7 +258,7 @@ def _load_odd_contracts(paths: Sequence[Path]) -> tuple[list[OddContract], list[
     for path in paths:
         try:
             loaded = load_odd_contracts(path)
-        except Exception as exc:
+        except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as exc:
             inputs.append(_input_ref(path, "unavailable", f"could not load ODD contracts: {exc}"))
             continue
         contracts.extend(loaded)
@@ -278,7 +278,7 @@ def _load_scenario_contracts(
     for path in paths:
         try:
             loaded = load_scenario_contracts(path)
-        except Exception as exc:
+        except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as exc:
             inputs.append(
                 _input_ref(path, "unavailable", f"could not load scenario contracts: {exc}")
             )
@@ -300,7 +300,7 @@ def _load_scenario_certificates(
     for path in paths:
         try:
             raw = yaml.safe_load(path.read_text(encoding="utf-8"))
-        except Exception as exc:
+        except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as exc:
             inputs.append(_input_ref(path, "unavailable", f"could not load scenario certs: {exc}"))
             continue
         loaded = _as_record_list(raw)

--- a/robot_sf/benchmark/imitation_manifest.py
+++ b/robot_sf/benchmark/imitation_manifest.py
@@ -133,7 +133,7 @@ def _to_json_ready(value: Any) -> Any:
     if hasattr(value, "isoformat"):
         try:
             return value.isoformat()  # type: ignore[return-value]
-        except Exception:  # pragma: no cover - best effort fallback
+        except (TypeError, ValueError, AttributeError):  # pragma: no cover - best effort fallback
             pass
     return str(value)
 

--- a/robot_sf/benchmark/orca_preflight.py
+++ b/robot_sf/benchmark/orca_preflight.py
@@ -86,7 +86,7 @@ def _ensure_rvo2_importable(*, planner_keys: list[str] | None = None) -> None:
     """Raise a typed preflight error when ``rvo2`` is unavailable."""
     try:
         import rvo2  # type: ignore[import-untyped,unused-ignore]  # noqa: F401, PLC0415
-    except Exception as exc:
+    except (ImportError, OSError) as exc:
         message = _missing_rvo2_message(planner_keys=planner_keys, error=exc)
         logger.error(message)
         raise OrcaRvo2PreflightError(

--- a/robot_sf/benchmark/planner_inclusion.py
+++ b/robot_sf/benchmark/planner_inclusion.py
@@ -69,7 +69,7 @@ def _unwrap_json_value(value: Any) -> Any:
             try:
                 current = item()
                 continue
-            except Exception:
+            except (ValueError, TypeError, AttributeError):
                 pass
 
         tolist = getattr(current, "tolist", None)
@@ -77,7 +77,7 @@ def _unwrap_json_value(value: Any) -> Any:
             try:
                 current = tolist()
                 continue
-            except Exception:
+            except (ValueError, TypeError, AttributeError):
                 pass
 
         break

--- a/robot_sf/benchmark/plots.py
+++ b/robot_sf/benchmark/plots.py
@@ -282,7 +282,7 @@ def save_pareto_png(  # noqa: PLR0913
     # Force garbage collection to reduce memory footprint in long CI runs
     try:
         gc.collect()
-    except Exception:
+    except (RuntimeError, TypeError):
         pass
 
     front_labels = [labels[i] for i in front]

--- a/robot_sf/benchmark/predictive_planner_config.py
+++ b/robot_sf/benchmark/predictive_planner_config.py
@@ -43,7 +43,7 @@ def infer_predictive_checkpoint_feature_schema_name(
 
     try:
         payload = torch.load(path, map_location="cpu", weights_only=True)
-    except Exception:
+    except (OSError, EOFError, RuntimeError, ValueError, KeyError):
         return None
     if not isinstance(payload, dict):
         return None

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -953,7 +953,12 @@ def _annotate_and_check_video_perf(
                     seed=record.get("seed"),
                     renderer=vid.get("renderer"),
                 )
-            except (ValueError, TypeError, KeyError, AttributeError):  # pragma: no cover - logging optional
+            except (
+                ValueError,
+                TypeError,
+                KeyError,
+                AttributeError,
+            ):  # pragma: no cover - logging optional
                 pass
     elif overhead_ratio > soft:
         if enforce:
@@ -975,7 +980,12 @@ def _annotate_and_check_video_perf(
                     seed=record.get("seed"),
                     renderer=vid.get("renderer"),
                 )
-            except (ValueError, TypeError, KeyError, AttributeError):  # pragma: no cover - logging optional
+            except (
+                ValueError,
+                TypeError,
+                KeyError,
+                AttributeError,
+            ):  # pragma: no cover - logging optional
                 pass
 
 
@@ -1586,7 +1596,12 @@ def _run_batch_parallel(  # noqa: C901
         try:
             _write_validated_record(out_path, schema, results_by_idx[idx])
             wrote += 1
-        except (OSError, ValueError, TypeError, KeyError) as e:  # pragma: no cover - write/validate path
+        except (
+            OSError,
+            ValueError,
+            TypeError,
+            KeyError,
+        ) as e:  # pragma: no cover - write/validate path
             logger.exception(
                 "Benchmark batch write/validation failed for scenario_id={} seed={}",
                 results_by_idx[idx].get("scenario_id", "unknown"),

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -953,7 +953,7 @@ def _annotate_and_check_video_perf(
                     seed=record.get("seed"),
                     renderer=vid.get("renderer"),
                 )
-            except Exception:  # pragma: no cover - logging optional
+            except (ValueError, TypeError, KeyError, AttributeError):  # pragma: no cover - logging optional
                 pass
     elif overhead_ratio > soft:
         if enforce:
@@ -975,7 +975,7 @@ def _annotate_and_check_video_perf(
                     seed=record.get("seed"),
                     renderer=vid.get("renderer"),
                 )
-            except Exception:  # pragma: no cover - logging optional
+            except (ValueError, TypeError, KeyError, AttributeError):  # pragma: no cover - logging optional
                 pass
 
 
@@ -1586,7 +1586,7 @@ def _run_batch_parallel(  # noqa: C901
         try:
             _write_validated_record(out_path, schema, results_by_idx[idx])
             wrote += 1
-        except Exception as e:  # pragma: no cover - write/validate path
+        except (OSError, ValueError, TypeError, KeyError) as e:  # pragma: no cover - write/validate path
             logger.exception(
                 "Benchmark batch write/validation failed for scenario_id={} seed={}",
                 results_by_idx[idx].get("scenario_id", "unknown"),
@@ -1800,7 +1800,7 @@ def _finalize_batch(
             perf_path.parent.mkdir(parents=True, exist_ok=True)
             with perf_path.open("w", encoding="utf-8") as f:
                 json.dump(snap, f, indent=2)
-    except Exception:
+    except (OSError, ValueError, TypeError, KeyError):
         # Best-effort; ignore snapshot errors
         pass
 

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -31,6 +31,7 @@ from datetime import (
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+import jsonschema
 import numpy as np
 import yaml
 from loguru import logger
@@ -1601,6 +1602,7 @@ def _run_batch_parallel(  # noqa: C901
             ValueError,
             TypeError,
             KeyError,
+            jsonschema.ValidationError,
         ) as e:  # pragma: no cover - write/validate path
             logger.exception(
                 "Benchmark batch write/validation failed for scenario_id={} seed={}",

--- a/robot_sf/benchmark/scenario_contract.py
+++ b/robot_sf/benchmark/scenario_contract.py
@@ -249,7 +249,7 @@ def validate_scenario_contract_references(
 
     try:
         scenarios = load_scenarios(scenario_path)
-    except Exception as exc:
+    except (OSError, ValueError, KeyError, TypeError, yaml.YAMLError) as exc:
         return [f"scenario_ref.source '{contract.scenario_ref.source}' could not be loaded: {exc}"]
 
     scenario_names = set(_scenario_names_from_payload(scenarios))

--- a/robot_sf/benchmark/scenario_schema.py
+++ b/robot_sf/benchmark/scenario_schema.py
@@ -22,7 +22,7 @@ from robot_sf.common.json_pointer import json_pointer
 
 try:
     from jsonschema import Draft7Validator
-except Exception as e:  # pragma: no cover - jsonschema is project dependency
+except ImportError as e:  # pragma: no cover - jsonschema is project dependency
     raise RuntimeError("jsonschema package is required for scenario validation") from e
 
 SCENARIO_MATRIX_SCHEMA_VERSION = "robot_sf.scenario_matrix.v1"
@@ -81,7 +81,7 @@ def validate_scenario_list(scenarios: list[dict[str, Any]]) -> list[dict[str, An
                             "path": "/repeats",
                         },
                     )
-            except Exception:
+            except (ValueError, TypeError):
                 errors.append(
                     {
                         "index": i,

--- a/robot_sf/benchmark/schema_reference.py
+++ b/robot_sf/benchmark/schema_reference.py
@@ -91,7 +91,7 @@ class SchemaReference:
 
             return schema
 
-        except Exception:
+        except (OSError, ValueError, KeyError, TypeError):
             logger.exception(f"Failed to load schema from {full_path}")
             raise
 

--- a/robot_sf/benchmark/snqi/campaign_contract.py
+++ b/robot_sf/benchmark/snqi/campaign_contract.py
@@ -899,7 +899,7 @@ def collect_episodes_from_campaign_runs(
                     continue
                 try:
                     payload = json.loads(line)
-                except Exception:
+                except (ValueError, TypeError):
                     continue
                 if not isinstance(payload, dict):
                     continue

--- a/robot_sf/benchmark/snqi/weights_validation.py
+++ b/robot_sf/benchmark/snqi/weights_validation.py
@@ -60,7 +60,7 @@ def _apply_weight_aliases(working: dict[str, object]) -> None:
         try:
             alias_val = float(working[alias])  # type: ignore[arg-type]
             canon_val = float(working[canonical])  # type: ignore[arg-type]
-        except Exception:
+        except (ValueError, TypeError):
             logger.warning(
                 f"Alias '{alias}' provided alongside '{canonical}'; "
                 "ignoring alias due to non-numeric values"
@@ -98,7 +98,7 @@ def validate_weights_mapping(raw: Mapping[str, object]) -> dict[str, float]:
         v = working[k]
         try:
             fv = float(v)  # type: ignore[arg-type]
-        except Exception as e:
+        except (ValueError, TypeError) as e:
             raise ValueError(f"Non-numeric weight for {k}: {v}") from e
         # Accept zero as a valid weight to disable a term; reject negatives and non-finite.
         if not np.isfinite(fv) or fv < 0:

--- a/robot_sf/benchmark/summary.py
+++ b/robot_sf/benchmark/summary.py
@@ -154,7 +154,7 @@ def _safe_number(x: Any) -> float | None:
         if math.isnan(v):
             return None
         return v
-    except Exception:
+    except (ValueError, TypeError):
         return None
 
 
@@ -196,7 +196,7 @@ def collect_values(
                     s = np.linalg.norm(arr, axis=1).mean()
                     if np.isfinite(s):
                         speeds.append(float(s))
-                except Exception as exc:
+                except (ValueError, TypeError) as exc:
                     if strict:
                         record_id = rec.get("episode_id") or rec.get("scenario_id") or "<unknown>"
                         fallback_errors.append(f"{record_id}: {exc}")

--- a/robot_sf/benchmark/validation/trajectory_dataset.py
+++ b/robot_sf/benchmark/validation/trajectory_dataset.py
@@ -401,6 +401,6 @@ class TrajectoryDatasetValidator:
         if hasattr(raw, "item"):
             try:
                 return raw.item()
-            except (ValueError, AttributeError):
+            except (ValueError, AttributeError, TypeError):
                 pass
         return {}

--- a/robot_sf/benchmark/validation/trajectory_dataset.py
+++ b/robot_sf/benchmark/validation/trajectory_dataset.py
@@ -401,6 +401,6 @@ class TrajectoryDatasetValidator:
         if hasattr(raw, "item"):
             try:
                 return raw.item()
-            except Exception:
+            except (ValueError, AttributeError):
                 pass
         return {}

--- a/robot_sf/benchmark/validation_utils.py
+++ b/robot_sf/benchmark/validation_utils.py
@@ -66,7 +66,7 @@ def validate_schema_integrity(schema: dict[str, Any]) -> list[str]:
 
     except jsonschema.ValidationError as e:
         errors.append(f"Schema validation error: {e.message}")
-    except Exception as e:
+    except (jsonschema.SchemaError, RecursionError, TypeError) as e:
         errors.append(f"Schema validation failed: {e!s}")
 
     return errors
@@ -87,7 +87,7 @@ def validate_schema_compatibility(schema: dict[str, Any]) -> tuple[bool, list[st
         # In a real implementation, you'd fetch and use the actual meta-schema
         errors = validate_schema_integrity(schema)
         return len(errors) == 0, errors
-    except Exception as e:
+    except (TypeError, KeyError, ValueError) as e:
         return False, [f"Compatibility validation failed: {e!s}"]
 
 

--- a/scripts/validation/broad_exception_baseline.json
+++ b/scripts/validation/broad_exception_baseline.json
@@ -1,23 +1,15 @@
 {
   "counts": {
     "by_path": {
-      "robot_sf/benchmark/camera_ready/campaign.py": 3,
+      "robot_sf/benchmark/camera_ready/campaign.py": 1,
       "robot_sf/benchmark/cli.py": 47,
       "robot_sf/benchmark/doctor.py": 1,
-      "robot_sf/benchmark/episode_replay_figure.py": 1,
-      "robot_sf/benchmark/figure_qa.py": 2,
       "robot_sf/benchmark/forecast_lane_inventory.py": 1,
-      "robot_sf/benchmark/full_classic/orchestrator.py": 11,
-      "robot_sf/benchmark/full_classic/plots.py": 5,
-      "robot_sf/benchmark/full_classic/render_sim_view.py": 9,
-      "robot_sf/benchmark/full_classic/validation.py": 1,
-      "robot_sf/benchmark/full_classic/visual_deps.py": 1,
       "robot_sf/benchmark/helper_catalog.py": 2,
       "robot_sf/benchmark/learned_predictor_capability_inventory.py": 1,
       "robot_sf/benchmark/map_runner.py": 2,
       "robot_sf/benchmark/map_runner_batch_runner.py": 3,
       "robot_sf/benchmark/map_runner_env.py": 1,
-      "robot_sf/benchmark/plots.py": 1,
       "robot_sf/benchmark/runner.py": 7,
       "robot_sf/benchmark/snqi/cli.py": 3,
       "robot_sf/benchmark/snqi/compute.py": 1,
@@ -110,7 +102,7 @@
       "scripts/validation/verify_maps.py": 1,
       "scripts/validation/verify_sf_implementation.py": 4
     },
-    "total": 250
+    "total": 217
   },
   "description": "Broad exception handler baseline for benchmark/script surfaces. Run scripts/validation/check_broad_exceptions.py --write-baseline to refresh after intentionally removing or approving entries.",
   "entries": [
@@ -120,24 +112,6 @@
       "fingerprint": "ba3cb2a07fb0c63c",
       "handler": "Exception",
       "lineno": 374,
-      "path": "robot_sf/benchmark/camera_ready/campaign.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 8,
-      "context": "_run_campaign_orchestrator",
-      "fingerprint": "b57306be9066573d",
-      "handler": "Exception",
-      "lineno": 1935,
-      "path": "robot_sf/benchmark/camera_ready/campaign.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 4,
-      "context": "_run_campaign_orchestrator",
-      "fingerprint": "b57306be9066573d",
-      "handler": "Exception",
-      "lineno": 1970,
       "path": "robot_sf/benchmark/camera_ready/campaign.py",
       "source": "except Exception as exc:"
     },
@@ -575,282 +549,12 @@
     },
     {
       "col_offset": 4,
-      "context": "replay_episode_and_generate_figures",
-      "fingerprint": "d47c045067cd76f5",
-      "handler": "Exception",
-      "lineno": 1143,
-      "path": "robot_sf/benchmark/episode_replay_figure.py",
-      "source": "except Exception as e:"
-    },
-    {
-      "col_offset": 4,
-      "context": "_check_image_content",
-      "fingerprint": "c007497d97e35eac",
-      "handler": "Exception",
-      "lineno": 273,
-      "path": "robot_sf/benchmark/figure_qa.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 4,
-      "context": "_check_caption_file",
-      "fingerprint": "c9adf7d39f8f03c4",
-      "handler": "Exception",
-      "lineno": 321,
-      "path": "robot_sf/benchmark/figure_qa.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 4,
       "context": "_probe_capability",
       "fingerprint": "b5dcc0004133d42e",
       "handler": "Exception",
       "lineno": 621,
       "path": "robot_sf/benchmark/forecast_lane_inventory.py",
       "source": "except Exception as exc:  # noqa: BLE001 - report any import failure as a blocker"
-    },
-    {
-      "col_offset": 4,
-      "context": "_build_env_config",
-      "fingerprint": "a87cf0cec699225e",
-      "handler": "Exception",
-      "lineno": 530,
-      "path": "robot_sf/benchmark/full_classic/orchestrator.py",
-      "source": "except Exception:  # pragma: no cover - defensive"
-    },
-    {
-      "col_offset": 4,
-      "context": "_extract_ped_forces",
-      "fingerprint": "921f8e264570e4ff",
-      "handler": "Exception",
-      "lineno": 594,
-      "path": "robot_sf/benchmark/full_classic/orchestrator.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 12,
-      "context": "_capture_visual_state",
-      "fingerprint": "9a396f2b7625ac4b",
-      "handler": "Exception",
-      "lineno": 654,
-      "path": "robot_sf/benchmark/full_classic/orchestrator.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
-      "context": "_capture_visual_state",
-      "fingerprint": "9a396f2b7625ac4b",
-      "handler": "Exception",
-      "lineno": 657,
-      "path": "robot_sf/benchmark/full_classic/orchestrator.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 8,
-      "context": "_compute_episode_metrics",
-      "fingerprint": "e8f83d1aed7ada47",
-      "handler": "Exception",
-      "lineno": 688,
-      "path": "robot_sf/benchmark/full_classic/orchestrator.py",
-      "source": "except Exception:  # pragma: no cover - defensive fallback"
-    },
-    {
-      "col_offset": 4,
-      "context": "_compute_episode_metrics",
-      "fingerprint": "ad28fe15d3a24332",
-      "handler": "Exception",
-      "lineno": 734,
-      "path": "robot_sf/benchmark/full_classic/orchestrator.py",
-      "source": "except Exception:  # pragma: no cover - defensive"
-    },
-    {
-      "col_offset": 8,
-      "context": "_init_env_for_job",
-      "fingerprint": "2731243b5c87bda2",
-      "handler": "Exception",
-      "lineno": 832,
-      "path": "robot_sf/benchmark/full_classic/orchestrator.py",
-      "source": "except Exception:  # pragma: no cover - defensive fallback"
-    },
-    {
-      "col_offset": 8,
-      "context": "_rollout_episode",
-      "fingerprint": "ddd9bb86d1581525",
-      "handler": "Exception",
-      "lineno": 880,
-      "path": "robot_sf/benchmark/full_classic/orchestrator.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
-      "context": "_close_env",
-      "fingerprint": "482da461ca3da12e",
-      "handler": "Exception",
-      "lineno": 895,
-      "path": "robot_sf/benchmark/full_classic/orchestrator.py",
-      "source": "except Exception:  # pragma: no cover"
-    },
-    {
-      "col_offset": 4,
-      "context": "_close_env",
-      "fingerprint": "3b6e4bb855daada8",
-      "handler": "Exception",
-      "lineno": 899,
-      "path": "robot_sf/benchmark/full_classic/orchestrator.py",
-      "source": "except Exception:  # pragma: no cover - gym close best-effort"
-    },
-    {
-      "col_offset": 12,
-      "context": "run_full_benchmark",
-      "fingerprint": "205fd8fcd5306170",
-      "handler": "Exception",
-      "lineno": 1496,
-      "path": "robot_sf/benchmark/full_classic/orchestrator.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
-      "context": "_distribution_plot",
-      "fingerprint": "a6d60484d2662990",
-      "handler": "Exception",
-      "lineno": 140,
-      "path": "robot_sf/benchmark/full_classic/plots.py",
-      "source": "except Exception as exc:  # pragma: no cover - defensive"
-    },
-    {
-      "col_offset": 4,
-      "context": "_trajectory_plot",
-      "fingerprint": "5d3e077df5633bd8",
-      "handler": "Exception",
-      "lineno": 186,
-      "path": "robot_sf/benchmark/full_classic/plots.py",
-      "source": "except Exception as exc:  # pragma: no cover - defensive"
-    },
-    {
-      "col_offset": 4,
-      "context": "_path_efficiency_distribution_plot",
-      "fingerprint": "ee804f785f712654",
-      "handler": "Exception",
-      "lineno": 220,
-      "path": "robot_sf/benchmark/full_classic/plots.py",
-      "source": "except Exception as exc:  # pragma: no cover - defensive"
-    },
-    {
-      "col_offset": 4,
-      "context": "_success_collision_scatter_plot",
-      "fingerprint": "806de78d4095b388",
-      "handler": "Exception",
-      "lineno": 268,
-      "path": "robot_sf/benchmark/full_classic/plots.py",
-      "source": "except Exception as exc:  # pragma: no cover - defensive"
-    },
-    {
-      "col_offset": 4,
-      "context": "_episode_length_histogram",
-      "fingerprint": "434b219b3b5a5f55",
-      "handler": "Exception",
-      "lineno": 298,
-      "path": "robot_sf/benchmark/full_classic/plots.py",
-      "source": "except Exception as exc:  # pragma: no cover - defensive"
-    },
-    {
-      "col_offset": 0,
-      "context": "<module>",
-      "fingerprint": "1618b1f7363ea5e6",
-      "handler": "Exception",
-      "lineno": 49,
-      "path": "robot_sf/benchmark/full_classic/render_sim_view.py",
-      "source": "except Exception as e:  # pragma: no cover - defensive"
-    },
-    {
-      "col_offset": 8,
-      "context": "generate_frames",
-      "fingerprint": "4e51bbab03ab9a12",
-      "handler": "Exception",
-      "lineno": 89,
-      "path": "robot_sf/benchmark/full_classic/render_sim_view.py",
-      "source": "except Exception as exc:  # pragma: no cover - fallback path"
-    },
-    {
-      "col_offset": 12,
-      "context": "generate_frames",
-      "fingerprint": "62858d37bb4cf445",
-      "handler": "Exception",
-      "lineno": 93,
-      "path": "robot_sf/benchmark/full_classic/render_sim_view.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 12,
-      "context": "generate_frames",
-      "fingerprint": "62858d37bb4cf445",
-      "handler": "Exception",
-      "lineno": 121,
-      "path": "robot_sf/benchmark/full_classic/render_sim_view.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 12,
-      "context": "generate_frames",
-      "fingerprint": "6dac2e99534cca0a",
-      "handler": "Exception",
-      "lineno": 141,
-      "path": "robot_sf/benchmark/full_classic/render_sim_view.py",
-      "source": "except Exception as exc:  # pragma: no cover - defensive"
-    },
-    {
-      "col_offset": 8,
-      "context": "_load_map_def",
-      "fingerprint": "3994519d144d2ffd",
-      "handler": "Exception",
-      "lineno": 210,
-      "path": "robot_sf/benchmark/full_classic/render_sim_view.py",
-      "source": "except Exception:  # pragma: no cover - fallback"
-    },
-    {
-      "col_offset": 4,
-      "context": "_load_map_def",
-      "fingerprint": "ec4714e26dcafcd2",
-      "handler": "Exception",
-      "lineno": 214,
-      "path": "robot_sf/benchmark/full_classic/render_sim_view.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
-      "context": "generate_video_file",
-      "fingerprint": "d00f6e0a48596269",
-      "handler": "Exception",
-      "lineno": 273,
-      "path": "robot_sf/benchmark/full_classic/render_sim_view.py",
-      "source": "except Exception as exc:  # pragma: no cover - defensive"
-    },
-    {
-      "col_offset": 8,
-      "context": "generate_video_file",
-      "fingerprint": "b60122e1cd8eeb3b",
-      "handler": "Exception",
-      "lineno": 276,
-      "path": "robot_sf/benchmark/full_classic/render_sim_view.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 8,
-      "context": "validate_visual_manifests",
-      "fingerprint": "3378f7f6a723a3e5",
-      "handler": "Exception",
-      "lineno": 83,
-      "path": "robot_sf/benchmark/full_classic/validation.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 4,
-      "context": "simulation_view_ready",
-      "fingerprint": "0f180077da5f9831",
-      "handler": "Exception",
-      "lineno": 47,
-      "path": "robot_sf/benchmark/full_classic/visual_deps.py",
-      "source": "except Exception as exc:  # pragma: no cover - defensive"
     },
     {
       "col_offset": 4,
@@ -932,15 +636,6 @@
       "lineno": 84,
       "path": "robot_sf/benchmark/map_runner_env.py",
       "source": "except Exception as exc:  # noqa: BLE001 - provenance must never break a benchmark run."
-    },
-    {
-      "col_offset": 4,
-      "context": "save_pareto_png",
-      "fingerprint": "861c2653b1eadcf2",
-      "handler": "Exception",
-      "lineno": 285,
-      "path": "robot_sf/benchmark/plots.py",
-      "source": "except Exception:"
     },
     {
       "col_offset": 12,

--- a/scripts/validation/broad_exception_baseline.json
+++ b/scripts/validation/broad_exception_baseline.json
@@ -1,15 +1,12 @@
 {
   "counts": {
     "by_path": {
-      "robot_sf/benchmark/ablation.py": 1,
-      "robot_sf/benchmark/artifact_catalog.py": 1,
       "robot_sf/benchmark/camera_ready/campaign.py": 3,
       "robot_sf/benchmark/cli.py": 47,
       "robot_sf/benchmark/doctor.py": 1,
       "robot_sf/benchmark/episode_replay_figure.py": 1,
       "robot_sf/benchmark/figure_qa.py": 2,
       "robot_sf/benchmark/forecast_lane_inventory.py": 1,
-      "robot_sf/benchmark/freeze_manifest.py": 1,
       "robot_sf/benchmark/full_classic/orchestrator.py": 11,
       "robot_sf/benchmark/full_classic/plots.py": 5,
       "robot_sf/benchmark/full_classic/render_sim_view.py": 9,
@@ -17,7 +14,6 @@
       "robot_sf/benchmark/full_classic/visual_deps.py": 1,
       "robot_sf/benchmark/hazard_odd_coverage.py": 4,
       "robot_sf/benchmark/helper_catalog.py": 2,
-      "robot_sf/benchmark/imitation_manifest.py": 1,
       "robot_sf/benchmark/learned_predictor_capability_inventory.py": 1,
       "robot_sf/benchmark/map_runner.py": 2,
       "robot_sf/benchmark/map_runner_batch_runner.py": 3,
@@ -27,16 +23,10 @@
       "robot_sf/benchmark/plots.py": 1,
       "robot_sf/benchmark/predictive_planner_config.py": 1,
       "robot_sf/benchmark/runner.py": 11,
-      "robot_sf/benchmark/scenario_contract.py": 1,
-      "robot_sf/benchmark/scenario_schema.py": 2,
-      "robot_sf/benchmark/schema_reference.py": 1,
       "robot_sf/benchmark/snqi/campaign_contract.py": 1,
       "robot_sf/benchmark/snqi/cli.py": 3,
       "robot_sf/benchmark/snqi/compute.py": 1,
       "robot_sf/benchmark/snqi/weights_validation.py": 2,
-      "robot_sf/benchmark/summary.py": 2,
-      "robot_sf/benchmark/validation/trajectory_dataset.py": 1,
-      "robot_sf/benchmark/validation_utils.py": 2,
       "scripts/analysis/amv_timeout_trace_analyzer.py": 1,
       "scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py": 2,
       "scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py": 2,
@@ -126,28 +116,10 @@
       "scripts/validation/verify_maps.py": 1,
       "scripts/validation/verify_sf_implementation.py": 4
     },
-    "total": 278
+    "total": 265
   },
   "description": "Broad exception handler baseline for benchmark/script surfaces. Run scripts/validation/check_broad_exceptions.py --write-baseline to refresh after intentionally removing or approving entries.",
   "entries": [
-    {
-      "col_offset": 12,
-      "context": "_compute_group_means",
-      "fingerprint": "60216f7fa12e0cf5",
-      "handler": "Exception",
-      "lineno": 117,
-      "path": "robot_sf/benchmark/ablation.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
-      "context": "validate_artifact_catalog",
-      "fingerprint": "e75c62376f8fc9a9",
-      "handler": "Exception",
-      "lineno": 149,
-      "path": "robot_sf/benchmark/artifact_catalog.py",
-      "source": "except Exception as exc:  # pragma: no cover - defensive CLI path"
-    },
     {
       "col_offset": 4,
       "context": "_execute_campaign_planner_batch",
@@ -645,15 +617,6 @@
     },
     {
       "col_offset": 4,
-      "context": "evaluate_freeze_manifest",
-      "fingerprint": "008f678c74196298",
-      "handler": "Exception",
-      "lineno": 406,
-      "path": "robot_sf/benchmark/freeze_manifest.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 4,
       "context": "_build_env_config",
       "fingerprint": "a87cf0cec699225e",
       "handler": "Exception",
@@ -950,15 +913,6 @@
       "source": "except Exception as e:"
     },
     {
-      "col_offset": 8,
-      "context": "_to_json_ready",
-      "fingerprint": "282c0ddbbcb7b444",
-      "handler": "Exception",
-      "lineno": 136,
-      "path": "robot_sf/benchmark/imitation_manifest.py",
-      "source": "except Exception:  # pragma: no cover - best effort fallback"
-    },
-    {
       "col_offset": 4,
       "context": "_resolve_importable",
       "fingerprint": "1146768a3efa6c55",
@@ -1053,7 +1007,7 @@
       "context": "save_pareto_png",
       "fingerprint": "861c2653b1eadcf2",
       "handler": "Exception",
-      "lineno": 272,
+      "lineno": 285,
       "path": "robot_sf/benchmark/plots.py",
       "source": "except Exception:"
     },
@@ -1166,42 +1120,6 @@
       "source": "except Exception:"
     },
     {
-      "col_offset": 4,
-      "context": "validate_scenario_contract_references",
-      "fingerprint": "46f2dafa4976cf9e",
-      "handler": "Exception",
-      "lineno": 252,
-      "path": "robot_sf/benchmark/scenario_contract.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 0,
-      "context": "<module>",
-      "fingerprint": "4e4a2ebe1c5c72f3",
-      "handler": "Exception",
-      "lineno": 25,
-      "path": "robot_sf/benchmark/scenario_schema.py",
-      "source": "except Exception as e:  # pragma: no cover - jsonschema is project dependency"
-    },
-    {
-      "col_offset": 12,
-      "context": "validate_scenario_list",
-      "fingerprint": "1242f11b6c534c27",
-      "handler": "Exception",
-      "lineno": 84,
-      "path": "robot_sf/benchmark/scenario_schema.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 8,
-      "context": "SchemaReference.load_schema",
-      "fingerprint": "344c925437a4b5ff",
-      "handler": "Exception",
-      "lineno": 94,
-      "path": "robot_sf/benchmark/schema_reference.py",
-      "source": "except Exception:"
-    },
-    {
       "col_offset": 16,
       "context": "collect_episodes_from_campaign_runs",
       "fingerprint": "1a9d7eba8297c18d",
@@ -1262,51 +1180,6 @@
       "handler": "Exception",
       "lineno": 101,
       "path": "robot_sf/benchmark/snqi/weights_validation.py",
-      "source": "except Exception as e:"
-    },
-    {
-      "col_offset": 4,
-      "context": "_safe_number",
-      "fingerprint": "c74837031cfec3c5",
-      "handler": "Exception",
-      "lineno": 157,
-      "path": "robot_sf/benchmark/summary.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 16,
-      "context": "collect_values",
-      "fingerprint": "46c7db4b5011dffa",
-      "handler": "Exception",
-      "lineno": 199,
-      "path": "robot_sf/benchmark/summary.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 12,
-      "context": "TrajectoryDatasetValidator._extract_metadata",
-      "fingerprint": "7fcf1922b7362bcc",
-      "handler": "Exception",
-      "lineno": 404,
-      "path": "robot_sf/benchmark/validation/trajectory_dataset.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
-      "context": "validate_schema_integrity",
-      "fingerprint": "5a709887610eb255",
-      "handler": "Exception",
-      "lineno": 69,
-      "path": "robot_sf/benchmark/validation_utils.py",
-      "source": "except Exception as e:"
-    },
-    {
-      "col_offset": 4,
-      "context": "validate_schema_compatibility",
-      "fingerprint": "f8b5d8c3ffa8c1ef",
-      "handler": "Exception",
-      "lineno": 90,
-      "path": "robot_sf/benchmark/validation_utils.py",
       "source": "except Exception as e:"
     },
     {
@@ -1944,7 +1817,7 @@
       "context": "stage_repo",
       "fingerprint": "8b5f4a2c9bce3c5d",
       "handler": "Exception",
-      "lineno": 313,
+      "lineno": 348,
       "path": "scripts/tools/manage_external_repos.py",
       "source": "except Exception:"
     },

--- a/scripts/validation/broad_exception_baseline.json
+++ b/scripts/validation/broad_exception_baseline.json
@@ -12,21 +12,15 @@
       "robot_sf/benchmark/full_classic/render_sim_view.py": 9,
       "robot_sf/benchmark/full_classic/validation.py": 1,
       "robot_sf/benchmark/full_classic/visual_deps.py": 1,
-      "robot_sf/benchmark/hazard_odd_coverage.py": 4,
       "robot_sf/benchmark/helper_catalog.py": 2,
       "robot_sf/benchmark/learned_predictor_capability_inventory.py": 1,
       "robot_sf/benchmark/map_runner.py": 2,
       "robot_sf/benchmark/map_runner_batch_runner.py": 3,
       "robot_sf/benchmark/map_runner_env.py": 1,
-      "robot_sf/benchmark/orca_preflight.py": 1,
-      "robot_sf/benchmark/planner_inclusion.py": 2,
       "robot_sf/benchmark/plots.py": 1,
-      "robot_sf/benchmark/predictive_planner_config.py": 1,
-      "robot_sf/benchmark/runner.py": 11,
-      "robot_sf/benchmark/snqi/campaign_contract.py": 1,
+      "robot_sf/benchmark/runner.py": 7,
       "robot_sf/benchmark/snqi/cli.py": 3,
       "robot_sf/benchmark/snqi/compute.py": 1,
-      "robot_sf/benchmark/snqi/weights_validation.py": 2,
       "scripts/analysis/amv_timeout_trace_analyzer.py": 1,
       "scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py": 2,
       "scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py": 2,
@@ -116,7 +110,7 @@
       "scripts/validation/verify_maps.py": 1,
       "scripts/validation/verify_sf_implementation.py": 4
     },
-    "total": 265
+    "total": 250
   },
   "description": "Broad exception handler baseline for benchmark/script surfaces. Run scripts/validation/check_broad_exceptions.py --write-baseline to refresh after intentionally removing or approving entries.",
   "entries": [
@@ -860,42 +854,6 @@
     },
     {
       "col_offset": 4,
-      "context": "_load_hazard_mapping",
-      "fingerprint": "9ab50e04f2a5e782",
-      "handler": "Exception",
-      "lineno": 247,
-      "path": "robot_sf/benchmark/hazard_odd_coverage.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 8,
-      "context": "_load_odd_contracts",
-      "fingerprint": "a24b38fa0af705d5",
-      "handler": "Exception",
-      "lineno": 261,
-      "path": "robot_sf/benchmark/hazard_odd_coverage.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 8,
-      "context": "_load_scenario_contracts",
-      "fingerprint": "93471f0401df2f51",
-      "handler": "Exception",
-      "lineno": 281,
-      "path": "robot_sf/benchmark/hazard_odd_coverage.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 8,
-      "context": "_load_scenario_certificates",
-      "fingerprint": "ffa074136b70ece5",
-      "handler": "Exception",
-      "lineno": 303,
-      "path": "robot_sf/benchmark/hazard_odd_coverage.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 4,
       "context": "prepare_classic_env",
       "fingerprint": "e66074fd967da159",
       "handler": "Exception",
@@ -977,47 +935,11 @@
     },
     {
       "col_offset": 4,
-      "context": "_ensure_rvo2_importable",
-      "fingerprint": "761e86439e262801",
-      "handler": "Exception",
-      "lineno": 89,
-      "path": "robot_sf/benchmark/orca_preflight.py",
-      "source": "except Exception as exc:"
-    },
-    {
-      "col_offset": 12,
-      "context": "_unwrap_json_value",
-      "fingerprint": "2ec5a13f47a89ec0",
-      "handler": "Exception",
-      "lineno": 72,
-      "path": "robot_sf/benchmark/planner_inclusion.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 12,
-      "context": "_unwrap_json_value",
-      "fingerprint": "2ec5a13f47a89ec0",
-      "handler": "Exception",
-      "lineno": 80,
-      "path": "robot_sf/benchmark/planner_inclusion.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
       "context": "save_pareto_png",
       "fingerprint": "861c2653b1eadcf2",
       "handler": "Exception",
       "lineno": 285,
       "path": "robot_sf/benchmark/plots.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
-      "context": "infer_predictive_checkpoint_feature_schema_name",
-      "fingerprint": "7d7ce771bf209840",
-      "handler": "Exception",
-      "lineno": 46,
-      "path": "robot_sf/benchmark/predictive_planner_config.py",
       "source": "except Exception:"
     },
     {
@@ -1028,24 +950,6 @@
       "lineno": 291,
       "path": "robot_sf/benchmark/runner.py",
       "source": "except Exception as exc:  # pragma: no cover - defensive child-process path"
-    },
-    {
-      "col_offset": 12,
-      "context": "_annotate_and_check_video_perf",
-      "fingerprint": "dcd523fc21c608fb",
-      "handler": "Exception",
-      "lineno": 956,
-      "path": "robot_sf/benchmark/runner.py",
-      "source": "except Exception:  # pragma: no cover - logging optional"
-    },
-    {
-      "col_offset": 12,
-      "context": "_annotate_and_check_video_perf",
-      "fingerprint": "dcd523fc21c608fb",
-      "handler": "Exception",
-      "lineno": 978,
-      "path": "robot_sf/benchmark/runner.py",
-      "source": "except Exception:  # pragma: no cover - logging optional"
     },
     {
       "col_offset": 16,
@@ -1102,33 +1006,6 @@
       "source": "except Exception:  # pragma: no cover"
     },
     {
-      "col_offset": 8,
-      "context": "_run_batch_parallel",
-      "fingerprint": "baa1af696f71b54a",
-      "handler": "Exception",
-      "lineno": 1589,
-      "path": "robot_sf/benchmark/runner.py",
-      "source": "except Exception as e:  # pragma: no cover - write/validate path"
-    },
-    {
-      "col_offset": 4,
-      "context": "_finalize_batch",
-      "fingerprint": "fc7a1ebf15707983",
-      "handler": "Exception",
-      "lineno": 1803,
-      "path": "robot_sf/benchmark/runner.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 16,
-      "context": "collect_episodes_from_campaign_runs",
-      "fingerprint": "1a9d7eba8297c18d",
-      "handler": "Exception",
-      "lineno": 902,
-      "path": "robot_sf/benchmark/snqi/campaign_contract.py",
-      "source": "except Exception:"
-    },
-    {
       "col_offset": 4,
       "context": "cmd_recompute_weights",
       "fingerprint": "ca9342b89ea033bf",
@@ -1163,24 +1040,6 @@
       "lineno": 277,
       "path": "robot_sf/benchmark/snqi/compute.py",
       "source": "except Exception:"
-    },
-    {
-      "col_offset": 8,
-      "context": "_apply_weight_aliases",
-      "fingerprint": "f487adc20721c664",
-      "handler": "Exception",
-      "lineno": 63,
-      "path": "robot_sf/benchmark/snqi/weights_validation.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 8,
-      "context": "validate_weights_mapping",
-      "fingerprint": "6b684be37b2257bb",
-      "handler": "Exception",
-      "lineno": 101,
-      "path": "robot_sf/benchmark/snqi/weights_validation.py",
-      "source": "except Exception as e:"
     },
     {
       "col_offset": 4,


### PR DESCRIPTION
Issue #4880: narrow the remaining broad-except sites in the benchmark layer (cheap-lane worker)

Successor slice to #4859 (merged). #4859 fixed the ~10 worst sites in aggregate/metrics/visualization and ratcheted BLE001. This PR continues that work across the rest of `robot_sf/benchmark/`, narrowing **61 bare `except Exception` swallow sites across 24 files** in 3 commits by module group, with no success-path behavior change. It does **not** duplicate #4859 — every site here is a new file or a site #4859 did not touch.

## What / why

Broad `except Exception` handlers in the benchmark layer mask unexpected errors (AttributeError, KeyError, IndexError, …) that indicate real bugs, violating the reproducibility requirement. Each narrowed site now catches only its realistic failure types; the broad-exception ratchet baseline drops and BLE001 lint scope widens to enforce the new floor.

Two mechanisms are updated in lockstep:
- `scripts/validation/broad_exception_baseline.json` (count ratchet): **278 → 217 entries**.
- `pyproject.toml` per-file BLE001 ignores: removed for the 21 files that are now fully clean; retained only where a broad catch is intentional.

## Changes by commit

**Commit 1 — schema/contract/manifest/catalog group (13 sites, 10 files cleaned):**
scenario_schema, scenario_contract, schema_reference, freeze_manifest, imitation_manifest, artifact_catalog, summary, validation_utils, validation/trajectory_dataset, ablation. Examples: float/int coercions → `(ValueError, TypeError)`; YAML/JSON loaders that report "unavailable"/error dicts → `(OSError, ValueError, KeyError, TypeError, yaml.YAMLError)`; jsonschema import guard → `ImportError`.

**Commit 2 — runner/map/snqi/planner group (15 sites, 7 files cleaned):**
planner_inclusion (duck-typed `.item()/.tolist()`), predictive_planner_config (torch.load sniff), orca_preflight (rvo2 import), snqi/campaign_contract (json.loads), snqi/weights_validation (float coercion), hazard_odd_coverage (4 best-effort metadata loaders), runner (best-effort logging / write-validate / perf-snapshot).

**Commit 3 — viz/figure/full_classic group (33 sites, 8 files cleaned):**
plots, figure_qa, episode_replay_figure, camera_ready/campaign (2 of 3), full_classic/{orchestrator, plots, render_sim_view, validation, visual_deps}. Matplotlib savefig, PIL image verify, numpy coerce, sim-view render, env cleanup, jsonschema validate.

## Notable findings (caught by tests, not by inspection)

1. **orca_preflight** — rvo2 import must catch `(ImportError, OSError)`, not just `ImportError`: a *present but broken* native extension (missing `libRVO.so`) raises `OSError`. Covered by `test_raises_when_native_extension_import_fails`.
2. **full_classic/render_sim_view** — render/numpy paths raise `IndexError` (scalar-variable indexing in `sim_view.render`); the render-capture and video handlers must include it. Covered by `test_renderer_field_present` / `test_full_classic_visuals_edge_cases`.
3. **snqi/compute (left broad, latent bug flagged)** — its `git rev-parse` call passes both `capture_output=True` and `stderr=DEVNULL`, which *always* raises `ValueError`; the handler masks it so `SNQIWeights.git_sha` is always `"unknown"`. Narrowing would surface the `ValueError`, break `recompute_snqi_weights` (13 tests), and change `git_sha` output → violates the "identical success-path results" rule. Left broad with a comment; the underlying subprocess arg conflict is a separate fix.

## Kept broad on purpose (BLE001 ignore retained)

These handlers don't mask — they report, isolate, or convert-and-rethrow — and narrowing them would turn a graceful/reported failure into a crash or change a documented contract:
- `cli.py` (47), `snqi/cli.py` (3): CLI top-level command handlers (catch → structured log → error exit code).
- `doctor.py` (1): diagnostic that reports any env-smoke failure as a "failed" check.
- `helper_catalog.py` (2): wrappers that convert any failure to `RuntimeError` (test-enforced by `test_run_episodes_with_recording_error`).
- `map_runner.py` (2), `map_runner_batch_runner.py` (3), `runner.py` (7): SocNav preflight policy handler and per-episode/per-scenario batch isolation; also child-process boundary and user-supplied `progress_cb`.
- `map_runner_env.py` (1): noqa-justified provenance handler.
- `camera_ready/campaign.py` (1): full-benchmark-run campaign fault isolation.
- `forecast_lane_inventory.py`, `learned_predictor_capability_inventory.py`: noqa-justified single sites.

## What remains (future slice)

`robot_sf/benchmark/cli.py` — 47 CLI-boundary handlers. These are a distinct surface (catch → log → exit) and the lowest masking concern; they warrant their own focused pass rather than a bulk narrowing here.

## Validation

CPU-level only (no campaigns/Slurm/training/benchmarks).

**Broad-exception ratchet (CI gate):**
```
$ uv run python scripts/validation/check_broad_exceptions.py
Broad exception ratchet passed with 217 entries.   # was 278
```

**Ruff BLE001 (whole benchmark dir, after ignore removals):**
```
$ uv run ruff check robot_sf/benchmark/ --select BLE001
All checks passed!
```

**Tests (151 passed across touched modules):** scenario_schema, summary, snqi_ablation, scenario_contract, schema_runtime_entities, schema_validation, integration_freeze_manifest, figure_qa, orca_preflight, planner_inclusion, render_sim_view, full_classic visuals (basic + edge_cases), snqi weights_inventory, snqi weight_aliases, hazard_odd_coverage_rollup, helper_catalog (`run_episodes`/`prepare_classic_env`).

**Pre-existing / environmental failures (not caused by this PR):**
- `test_helper_catalog.py::test_load_trained_policy_*` and `integration/test_helper_orchestrator_flow.py::test_quickstart_orchestrator_flow` — `stable_baselines3` is not installed in this CPU env (confirmed failing on the clean `origin/main` tree).
- `test_prediction_planner_audit_contract.py` — collection error, `torch` not installed.
These exercise `load_trained_policy` / sb3 / torch code paths this PR never touches.

Refs #4880

---

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.



## Gate addendum (2026-07-08)
- Gate fix: pushed `09cfa4138` to apply `uv run ruff format` output for the CI lint failure in five touched benchmark files.
- Exact local validation run by gate after the fix:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run python scripts/validation/check_broad_exceptions.py`
  - `uv run pytest tests/benchmark/test_scenario_contract.py tests/benchmark/test_schema_runtime_entities.py tests/unit/test_schema_validation.py tests/benchmark_full/test_integration_freeze_manifest.py tests/benchmark/test_figure_qa.py tests/benchmark/test_orca_preflight.py tests/benchmark/test_planner_inclusion.py tests/benchmark/test_render_sim_view.py tests/test_full_classic_visuals_basic.py tests/test_full_classic_visuals_edge_cases.py tests/test_snqi_weights_inventory.py tests/test_snqi_weight_aliases.py tests/tools/test_hazard_odd_coverage_rollup.py tests/test_snqi_ablation.py tests/test_summary.py -q`
  - `uv run pytest tests/benchmark/test_helper_catalog.py -q`
- Review-bot note: CodeRabbit posted a rate-limit warning, so this gate findings comment is the review of record.
