### PR TITLE
Issue #4886: fix heading_oscillation straight-path baseline (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/critical_intervals.py
+++ b/robot_sf/benchmark/critical_intervals.py
@@ -773,13 +773,29 @@ def _compute_interval_metrics_in_window(  # noqa: C901, PLR0912, PLR0915
         result["mean_speed_ms"] = None
         result["max_speed_ms"] = None
 
-    # Heading oscillation proxy (variance of heading direction)
+    # Heading oscillation proxy: total variance of the per-step unit heading
+    # direction vectors. ``dirs`` is shape (n_steps, 2); we take the variance
+    # *per component* (axis=0) and sum, i.e. the trace of the 2x2 covariance of
+    # the unit directions == mean |dir_i - mean_dir|^2 == 1 - |mean_dir|^2.
+    #
+    # This is the multivariate generalization of "variance of heading
+    # direction" and is 0.0 for any perfectly straight (constant-heading) path,
+    # regardless of which axis it travels along. It rises toward 1.0 as the
+    # heading disperses (e.g. reversals, full circles).
+    #
+    # NOTE (issue #4886): do NOT use ``np.var(dirs)`` without an axis. That
+    # flattens the x and y components into one population and measures variance
+    # across the structurally different components (x vs y of a unit vector),
+    # not within a component. For straight (1, 0) motion that flattened form
+    # returns 0.25 (the variance of [1, 0, 1, 0, ...] around its 0.5 mean) --
+    # indistinguishable from a small wiggle -- so it could not separate straight
+    # motion from genuine oscillation. See test_heading_oscillation_straight_*.
     if sub_robot_pos.shape[0] >= 2:
         deltas = np.diff(sub_robot_pos, axis=0)
         norms = np.linalg.norm(deltas, axis=1, keepdims=True)
         norms = np.where(norms < 1e-9, 1.0, norms)
         dirs = deltas / norms
-        result["heading_oscillation"] = float(np.var(dirs))
+        result["heading_oscillation"] = float(np.var(dirs, axis=0).sum())
 
     return result
 

--- a/robot_sf/benchmark/critical_intervals.py
+++ b/robot_sf/benchmark/critical_intervals.py
@@ -790,12 +790,21 @@ def _compute_interval_metrics_in_window(  # noqa: C901, PLR0912, PLR0915
     # returns 0.25 (the variance of [1, 0, 1, 0, ...] around its 0.5 mean) --
     # indistinguishable from a small wiggle -- so it could not separate straight
     # motion from genuine oscillation. See test_heading_oscillation_straight_*.
+    # Stationary steps (displacement norm ~0) have no defined heading; a naive
+    # guard that maps their delta to a zero vector would inject ``[0, 0]`` rows
+    # into ``dirs`` and inflate the variance -- a straight path that merely
+    # pauses for one step would then read as "oscillating". Filter stationary
+    # steps out before computing the direction variance, and default to 0.0
+    # when the whole window is stationary (no heading to disperse).
     if sub_robot_pos.shape[0] >= 2:
         deltas = np.diff(sub_robot_pos, axis=0)
-        norms = np.linalg.norm(deltas, axis=1, keepdims=True)
-        norms = np.where(norms < 1e-9, 1.0, norms)
-        dirs = deltas / norms
-        result["heading_oscillation"] = float(np.var(dirs, axis=0).sum())
+        norms = np.linalg.norm(deltas, axis=1)
+        moving_mask = norms >= 1e-9
+        if np.any(moving_mask):
+            dirs = deltas[moving_mask] / norms[moving_mask, np.newaxis]
+            result["heading_oscillation"] = float(np.var(dirs, axis=0).sum())
+        else:
+            result["heading_oscillation"] = 0.0
 
     return result
 

--- a/tests/benchmark/test_critical_intervals.py
+++ b/tests/benchmark/test_critical_intervals.py
@@ -8,6 +8,7 @@ opt-in only.
 from __future__ import annotations
 
 import json
+import math
 import tempfile
 
 import numpy as np
@@ -940,3 +941,119 @@ class TestPhysicalTTC:
             ped_vel=np.array([-1.0, 0.0]),
         )
         assert ttc == pytest.approx(5.0 / 2.4, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# heading_oscillation straight-path baseline (issue #4886)
+# ---------------------------------------------------------------------------
+
+
+class TestHeadingOscillationBaseline:
+    """``heading_oscillation`` must be ~0 for straight, constant-heading motion.
+
+    Regression coverage for issue #4886. The previous implementation used
+    ``np.var(dirs)`` over the *flattened* unit-direction vectors, which mixes
+    the structurally different x and y components of a unit vector into one
+    population. For a straight ``(1, 0)`` path that flattened variance is
+    ``0.25`` (variance of ``[1, 0, 1, 0, ...]`` around its ``0.5`` mean) --
+    indistinguishable from a small wiggle, and wildly different from a straight
+    ``(1, 1)`` path (which scored ``0.0``). The metric therefore measured axis
+    alignment, not heading oscillation.
+
+    The fix computes variance *per component* (``axis=0``) and sums it (the
+    trace of the 2x2 covariance of the unit directions == ``1 - |mean_dir|^2``),
+    which is ``0.0`` for any constant-heading path and rises with dispersion.
+    """
+
+    def test_straight_x_axis_is_zero(self) -> None:
+        """Constant ``(1, 0)`` motion must score 0.0 (was 0.25 before #4886)."""
+        n = 10
+        robot_pos = np.zeros((n, 2), dtype=float)
+        robot_pos[:, 0] = np.arange(n) * 0.5
+        trace = _make_trace(robot_pos)
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        assert whole["heading_oscillation"] == pytest.approx(0.0, abs=1e-12)
+
+    def test_straight_diagonal_is_zero(self) -> None:
+        """Constant ``(1, 1)`` motion must also score 0.0 -- axis independent."""
+        n = 10
+        robot_pos = np.zeros((n, 2), dtype=float)
+        step = np.arange(n) * 0.5
+        robot_pos[:, 0] = step
+        robot_pos[:, 1] = step
+        trace = _make_trace(robot_pos)
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        assert whole["heading_oscillation"] == pytest.approx(0.0, abs=1e-12)
+
+    def test_axis_alignment_does_not_change_score(self) -> None:
+        """Straight motion scores identically along any heading."""
+        n = 10
+        cases = {
+            "x_axis": np.array([[i * 0.5, 0.0] for i in range(n)]),
+            "diagonal": np.array([[i * 0.5, i * 0.5] for i in range(n)]),
+            "y_axis": np.array([[0.0, i * 0.5] for i in range(n)]),
+        }
+        scores = {
+            name: _compute_interval_metrics_in_window(_make_trace(pos), start=0, end=None)[
+                "heading_oscillation"
+            ]
+            for name, pos in cases.items()
+        }
+        # All constant-heading paths score 0.0; none is privileged by axis.
+        for name, score in scores.items():
+            assert score == pytest.approx(0.0, abs=1e-12), name
+
+    def test_small_wiggle_is_small_and_nonzero(self) -> None:
+        """A +-5 deg heading wiggle scores a small value (~0.0076)."""
+        angles_deg = [5.0, -5.0, 5.0, -5.0]
+        dirs = np.array(
+            [[math.cos(math.radians(a)), math.sin(math.radians(a))] for a in angles_deg]
+        )
+        robot_pos = np.vstack([[0.0, 0.0], np.cumsum(dirs, axis=0)])
+        trace = _make_trace(robot_pos)
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        wiggle = whole["heading_oscillation"]
+        # Real oscillation, but small -- tightly matches the closed-form value.
+        assert wiggle == pytest.approx(0.0075961, abs=1e-6)
+
+    def test_straight_is_distinguishable_from_wiggle(self) -> None:
+        """The defining property the old metric violated: straight < wiggle.
+
+        Under the buggy flattened-variance metric, straight ``(1, 0)`` scored
+        0.25 while a +-5 deg wiggle scored ~0.252 -- the metric could not tell
+        them apart. The fixed per-component metric restores the ordering.
+        """
+        n = 10
+        straight_pos = np.zeros((n, 2), dtype=float)
+        straight_pos[:, 0] = np.arange(n) * 0.5
+        straight = _compute_interval_metrics_in_window(
+            _make_trace(straight_pos), start=0, end=None
+        )["heading_oscillation"]
+
+        angles_deg = [5.0, -5.0, 5.0, -5.0]
+        dirs = np.array(
+            [[math.cos(math.radians(a)), math.sin(math.radians(a))] for a in angles_deg]
+        )
+        wiggle_pos = np.vstack([[0.0, 0.0], np.cumsum(dirs, axis=0)])
+        wiggle = _compute_interval_metrics_in_window(_make_trace(wiggle_pos), start=0, end=None)[
+            "heading_oscillation"
+        ]
+
+        assert straight < wiggle
+        assert straight == pytest.approx(0.0, abs=1e-12)
+
+    def test_full_reversal_scores_high(self) -> None:
+        """Back-and-forth ``(1, 0) <-> (-1, 0)`` reversals score ~1.0."""
+        dirs = np.array([[1.0, 0.0], [-1.0, 0.0], [1.0, 0.0], [-1.0, 0.0]])
+        robot_pos = np.vstack([[0.0, 0.0], np.cumsum(dirs, axis=0)])
+        trace = _make_trace(robot_pos)
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        # x component alternates +-1 (variance 1.0), y stays 0 -> total 1.0.
+        assert whole["heading_oscillation"] == pytest.approx(1.0, abs=1e-12)
+
+    def test_single_step_window_omits_metric(self) -> None:
+        """With fewer than 2 positions the metric key is absent (boundary)."""
+        robot_pos = np.zeros((1, 2), dtype=float)
+        trace = _make_trace(robot_pos)
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        assert "heading_oscillation" not in whole

--- a/tests/benchmark/test_critical_intervals.py
+++ b/tests/benchmark/test_critical_intervals.py
@@ -1057,3 +1057,24 @@ class TestHeadingOscillationBaseline:
         trace = _make_trace(robot_pos)
         whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
         assert "heading_oscillation" not in whole
+
+    def test_straight_path_with_pause_is_zero(self) -> None:
+        """A straight path that pauses for a step must still score 0.0.
+
+        Stationary steps have no defined heading; injecting their ``[0, 0]``
+        delta into the direction population would inflate the variance and make
+        a merely-paused straight path read as "oscillating". A straight
+        ``(1, 0)`` path with a single repeated (stationary) position must score
+        the same 0.0 as the uninterrupted path.
+        """
+        robot_pos = np.array([[0.0, 0.0], [0.5, 0.0], [0.5, 0.0], [1.0, 0.0]], dtype=float)
+        trace = _make_trace(robot_pos)
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        assert whole["heading_oscillation"] == pytest.approx(0.0, abs=1e-12)
+
+    def test_fully_stationary_window_is_zero(self) -> None:
+        """A window with no movement at all defaults to 0.0 (no heading)."""
+        robot_pos = np.zeros((5, 2), dtype=float)
+        trace = _make_trace(robot_pos)
+        whole = _compute_interval_metrics_in_window(trace, start=0, end=None)
+        assert whole["heading_oscillation"] == pytest.approx(0.0, abs=1e-12)

--- a/tests/benchmark/test_critical_intervals_characterization.py
+++ b/tests/benchmark/test_critical_intervals_characterization.py
@@ -204,11 +204,15 @@ def test_window_metrics_full_straight_trace_table() -> None:
     assert result["mean_speed_ms"] == pytest.approx(1.0)
     assert result["max_speed_ms"] == pytest.approx(1.0)
     assert result["max_deceleration_mps2"] == pytest.approx(0.0)  # constant speed
-    # ``heading_oscillation`` is ``np.var`` over the *flattened* unit-direction
-    # vectors, so a perfectly straight (constant (1, 0)) path yields 0.25 (the
-    # variance between the constant 1 and 0 components), NOT 0.0. This is the
-    # pinned current behavior; the PR body flags it as a candidate follow-up bug.
-    assert result["heading_oscillation"] == pytest.approx(0.25)
+    # ``heading_oscillation`` is now computed per-component (``np.var`` over
+    # ``axis=0`` of the unit-direction vectors, summed), so a perfectly
+    # straight (constant (1, 0)) path yields 0.0, as an oscillation metric
+    # should. Issue #4886 fixed the earlier flattened-variance form, which
+    # returned 0.25 here (variance of [1, 0, 1, 0, ...] around its 0.5 mean)
+    # and could not separate straight motion from a small wiggle. Focused
+    # proof of the fix lives in ``TestHeadingOscillationBaseline`` in
+    # ``test_critical_intervals.py``.
+    assert result["heading_oscillation"] == pytest.approx(0.0)
 
 
 def test_window_metrics_subwindow_slicing() -> None:


### PR DESCRIPTION
## What

Fixes the `heading_oscillation` metric in `robot_sf/benchmark/critical_intervals.py` so that perfectly straight, constant-heading motion scores `0.0` instead of `0.25`.

Resolves issue **#4886** (decision branch: the flattened-component variance was **unintended** → fix the metric and adjust characterization tests with focused proof).

## Why (the bug)

The metric was:

```python
result["heading_oscillation"] = float(np.var(dirs))
```

where `dirs` is the `(n_steps, 2)` array of per-step unit heading vectors. `np.var` with no axis **flattens x and y into one population**, so it measures variance *across the structurally different components of a unit vector* (x vs y), not *within* a component. For a constant `(1, 0)` path the flattened array is `[1, 0, 1, 0, ...]`, mean `0.5`, variance **`0.25`**.

Two consequences that prove this measured axis alignment, not oscillation:

| path | old metric | what it should be |
| --- | --- | --- |
| straight `(1, 0)` | **0.25** | ~0.0 |
| straight `(1, 1)` (identical non-oscillation) | **0.0** | ~0.0 |
| small wiggle ±5° | **0.252** | small |

The metric literally could not distinguish a straight line from a ±5° wiggle, and gave wildly different scores to identical straight motion depending on which axis it travelled along.

## The fix

```python
result["heading_oscillation"] = float(np.var(dirs, axis=0).sum())
```

Variance is now computed **per component** (`axis=0`) and summed — i.e. the trace of the 2×2 covariance of the unit directions, equal to `mean|dir_i − mean_dir|²` = `1 − |mean_dir|²`. This is the multivariate generalization of "variance of heading direction": `0.0` for any constant-heading path, rising toward `1.0` as the heading disperses.

| path | fixed metric |
| --- | --- |
| straight `(1, 0)` / `(1, 1)` / `(0, 1)` | **0.0** |
| wiggle ±5° | **0.0076** |
| quarter arc 0°→90° | 0.352 |
| full reversal `(1,0)↔(−1,0)` | **1.0** |

### Safety of the scale change

`heading_oscillation` is only computed → stored in `IntervalMetrics` → serialized via `report_to_dict`. `git grep` confirms **no downstream gating, scoring, or threshold consumes this field** (the unrelated `max_heading_oscillation_count` in `trajectory_verifier.py` is a separate sign-change counter that does not read this value). So the scale change `[0, ~0.5] → [0, 1]` has no behavioral gating impact — it only corrects a reported metric.

## Characterization test adjustment

PR **#4885** (merged during this work) pinned the pre-fix `0.25` value in `test_window_metrics_full_straight_trace_table` and explicitly flagged it as the #4886 follow-up. This PR updates that pin to `0.0` with the corrected rationale — exactly the "adjust characterization tests" step the issue's acceptance criteria call for.

This PR is **not a duplicate** of #4885: #4885 added new characterization coverage and *deferred* this bug; this PR *fixes* the metric and updates the one pin that encoded the buggy value. Successor statement: this fixes the metric bug that PR #4885 documented and deferred; it does not duplicate #4885's characterization coverage (which remains, with the single pinned value corrected).

## Validation

CPU-level only — no campaigns / Slurm / training / benchmark runs.

```
$ uv run pytest tests/benchmark/test_critical_intervals.py \
                 tests/benchmark/test_critical_intervals_characterization.py \
                 tests/benchmark/test_trajectory_verifier.py \
                 tests/benchmark/test_scenario_criticality_objective.py -q
119 passed in 1.35s

$ uv run pytest tests/benchmark/test_critical_intervals.py::TestHeadingOscillationBaseline -v
# 7/7 PASSED (straight→0, diagonal→0, axis-independence, wiggle~0.0076,
#  straight-distinguishable-from-wiggle, reversal→1.0, single-step boundary)

$ uv run ruff check tests/benchmark/test_critical_intervals.py \
                    tests/benchmark/test_critical_intervals_characterization.py \
                    robot_sf/benchmark/critical_intervals.py
All checks passed!

$ uv run ruff format --check <same 3 files>
3 files already formatted
```

Pre-existing, unrelated environment failures (not caused by this change, not touched by it):
- `test_scenario_criticality_optimization.py::test_cma_es_*` — `ModuleNotFoundError: No module named 'cma'` (optional `[criticality]` extra not installed in the fresh venv; the file has 0 references to `heading_oscillation`/`critical_intervals`).

## Diff scope

- `robot_sf/benchmark/critical_intervals.py` — 1-line metric fix + explanatory comment.
- `tests/benchmark/test_critical_intervals.py` — new `TestHeadingOscillationBaseline` (7 focused regression tests).
- `tests/benchmark/test_critical_intervals_characterization.py` — update the one pinned value `0.25 → 0.0` and its rationale.

Test/metric fix only; no user-facing CLI/config surface, so no CHANGELOG entry.

Closes #4886.

---

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heading-oscillation calculations so stationary pauses no longer inflate motion metrics.
  * Straight-line movement now correctly scores near zero, while back-and-forth motion produces a high oscillation value.
  * Better handles edge cases such as duplicated positions, fully stationary windows, and short traces.

* **Tests**
  * Added broader regression coverage for heading-oscillation behavior across straight, wiggly, paused, and reversing motion.
  * Updated expected baseline values to match the corrected metric calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->