### PR TITLE
Issue #4889: durable CI dependency-cache + uv sync retry (cheap-lane worker)

### DIFF
--- a/.github/actions/setup-ci-python/action.yml
+++ b/.github/actions/setup-ci-python/action.yml
@@ -20,9 +20,21 @@ runs:
       with:
         version: ${{ inputs.uv-version }}
 
+    - name: Cache uv sync package payloads
+      id: cache-uv
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          ${{ runner.temp }}/setup-uv-cache/archive-v0
+          ${{ runner.temp }}/setup-uv-cache/wheels-v6
+        key: uv-sync-payloads-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+
     - name: Report uv cache state before sync
       shell: bash
-      run: bash scripts/dev/ci_uv_sync_diag.sh "uv-cache-pre-sync"
+      run: |
+        echo "cache-hit=${{ steps.cache-uv.outputs.cache-hit }}"
+        echo "cache-matched-key=${{ steps.cache-uv.outputs.cache-matched-key }}"
+        bash scripts/dev/ci_uv_sync_diag.sh "uv-cache-pre-sync"
 
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -42,11 +54,11 @@ runs:
       shell: bash
       run: bash scripts/dev/free_github_runner_space.sh
 
-    - name: Sync dependencies (locked)
+    - name: Sync dependencies (locked, with transient-failure retry)
       shell: bash
       env:
         CI_STEP_TIMEOUT_SECONDS: "1200"
-      run: bash scripts/dev/ci_step_timer.sh "Sync dependencies (locked)" uv sync --all-extras --frozen
+      run: bash scripts/dev/ci_step_timer.sh "Sync dependencies (locked)" bash scripts/dev/uv_sync_retry.sh -- --all-extras --frozen
 
     - name: Report uv cache state after sync
       if: always()

--- a/scripts/dev/uv_sync_retry.sh
+++ b/scripts/dev/uv_sync_retry.sh
@@ -33,6 +33,20 @@ if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
   max_attempts=3
 fi
 
+# Validate the backoff knobs the same way: a non-numeric value (e.g. ``5s``)
+# would otherwise be treated as an unbound variable in the arithmetic
+# expansion below and abort the wrapper under ``set -u`` with a confusing
+# error. Fall back to the documented defaults instead.
+if ! [[ "$backoff_base" =~ ^[0-9]+$ ]]; then
+  echo "uv_sync_retry: UV_SYNC_BACKOFF_BASE='${backoff_base}' is not a non-negative integer; defaulting to 5" >&2
+  backoff_base=5
+fi
+
+if ! [[ "$backoff_cap" =~ ^[0-9]+$ ]]; then
+  echo "uv_sync_retry: UV_SYNC_BACKOFF_CAP='${backoff_cap}' is not a non-negative integer; defaulting to 30" >&2
+  backoff_cap=30
+fi
+
 # Drop an optional leading ``--`` separator so callers can write the wrapper as
 # ``uv_sync_retry.sh -- --all-extras --frozen`` for unambiguous arg forwarding.
 if [[ "${1:-}" == "--" ]]; then

--- a/scripts/dev/uv_sync_retry.sh
+++ b/scripts/dev/uv_sync_retry.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Run ``uv sync`` with bounded retry + exponential backoff to absorb transient
+# PyPI / index failures (issue #4889: wheel-smoke-install died mid-run with a
+# connection error downloading ``nvidia-cufft-cu12==11.3.3.83``).
+#
+# ``uv sync --frozen`` resolves against a fixed lock, so the only realistic
+# non-zero exits are network/download failures, which are transient. uv caches
+# every wheel it fully downloads, so a retry resumes from the last good wheel
+# rather than re-fetching the whole dependency set. A genuine (non-transient)
+# failure reproduces on every attempt and still fails the step once the retry
+# budget is exhausted. Status 127 (``uv`` not on PATH) is treated as
+# non-transient and fails immediately without burning retries.
+#
+# Configuration (env):
+#   UV_SYNC_MAX_ATTEMPTS  total attempts before giving up (default 3)
+#   UV_SYNC_BACKOFF_BASE  initial backoff in seconds (default 5)
+#   UV_SYNC_BACKOFF_CAP   maximum backoff in seconds (default 30)
+#
+# Usage:
+#   scripts/dev/uv_sync_retry.sh -- <uv sync args...>
+#   scripts/dev/uv_sync_retry.sh            # defaults to --all-extras --frozen
+#
+# The leading ``--`` separator is optional; all args are forwarded to ``uv sync``.
+
+set -euo pipefail
+
+max_attempts="${UV_SYNC_MAX_ATTEMPTS:-3}"
+backoff_base="${UV_SYNC_BACKOFF_BASE:-5}"
+backoff_cap="${UV_SYNC_BACKOFF_CAP:-30}"
+
+if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "uv_sync_retry: UV_SYNC_MAX_ATTEMPTS='${max_attempts}' is not a positive integer; defaulting to 3" >&2
+  max_attempts=3
+fi
+
+# Drop an optional leading ``--`` separator so callers can write the wrapper as
+# ``uv_sync_retry.sh -- --all-extras --frozen`` for unambiguous arg forwarding.
+if [[ "${1:-}" == "--" ]]; then
+  shift
+fi
+
+if [[ $# -eq 0 ]]; then
+  set -- --all-extras --frozen
+fi
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  echo "::group::uv sync (attempt ${attempt}/${max_attempts})"
+  set +e
+  uv sync "$@"
+  status=$?
+  set -e
+  echo "::endgroup::"
+
+  if [[ "$status" -eq 0 ]]; then
+    echo "uv_sync_retry success attempt=${attempt}/${max_attempts}"
+    exit 0
+  fi
+
+  if [[ "$status" -eq 127 ]]; then
+    echo "::error::uv not found on PATH (status 127); not retryable" >&2
+    exit 127
+  fi
+
+  if [[ "$attempt" -ge "$max_attempts" ]]; then
+    echo "::error::uv sync failed after ${attempt} attempt(s) (last status=${status})" >&2
+    exit "$status"
+  fi
+
+  # Exponential backoff capped at UV_SYNC_BACKOFF_CAP.
+  delay=$(( backoff_base * (2 ** (attempt - 1)) ))
+  if [[ "$delay" -gt "$backoff_cap" ]]; then
+    delay="$backoff_cap"
+  fi
+  echo "uv_sync_retry transient status=${status} retry_in=${delay}s next_attempt=$((attempt + 1))/${max_attempts}"
+  sleep "$delay"
+done

--- a/tests/dev/test_ci_uv_sync_diag.py
+++ b/tests/dev/test_ci_uv_sync_diag.py
@@ -183,27 +183,40 @@ def test_ci_uv_sync_diag_cache_sizing_is_single_pass(tmp_path: Path) -> None:
 
 
 def test_workflow_uv_cache_paths_match_setup_uv_cache_dir() -> None:
-    """Workflow uv caching must match the UV_CACHE_DIR configured by setup-uv."""
-    inline_cache_workflows = [
+    """uv payload caching must live at the setup-uv cache dir, centralized in setup-ci-python.
+
+    perf-nightly and pr-promoted-planner-smoke delegate to the shared
+    ``setup-ci-python`` composite action, which owns the uv payload cache. The
+    cache paths must match the UV_CACHE_DIR configured by setup-uv (never the
+    user-local ``~/.cache/uv`` default) so a restored cache is actually reused
+    by the subsequent ``uv sync``.
+    """
+    delegated_workflows = [
+        ".github/workflows/ci.yml",
         ".github/workflows/perf-nightly.yml",
         ".github/workflows/pr-promoted-planner-smoke.yml",
     ]
     expected_archive = "${{ runner.temp }}/setup-uv-cache/archive-v0"
     expected_wheels = "${{ runner.temp }}/setup-uv-cache/wheels-v6"
 
-    ci_workflow_text = (_repo_root() / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-    ci_action_text = (_repo_root() / ".github/actions/setup-ci-python/action.yml").read_text(
+    action_text = (_repo_root() / ".github/actions/setup-ci-python/action.yml").read_text(
         encoding="utf-8"
     )
-    assert "uses: ./.github/actions/setup-ci-python" in ci_workflow_text
-    assert "astral-sh/setup-uv@" in ci_action_text
-    assert "~/.cache/uv" not in ci_workflow_text
-    assert "~/.cache/uv" not in ci_action_text
+    # The shared action owns the cache and must pin it to setup-uv's location.
+    assert "astral-sh/setup-uv@" in action_text
+    assert expected_archive in action_text
+    assert expected_wheels in action_text
+    assert (
+        "uv-sync-payloads-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}"
+        in action_text
+    )
+    assert "~/.cache/uv" not in action_text
 
-    for workflow_path in inline_cache_workflows:
+    # Every consumer delegates to the shared action and must not re-declare a
+    # local uv cache path.
+    for workflow_path in delegated_workflows:
         workflow_text = (_repo_root() / workflow_path).read_text(encoding="utf-8")
-        assert expected_archive in workflow_text, workflow_path
-        assert expected_wheels in workflow_text, workflow_path
+        assert "uses: ./.github/actions/setup-ci-python" in workflow_text, workflow_path
         assert "~/.cache/uv" not in workflow_text, workflow_path
 
 

--- a/tests/dev/test_ci_uv_sync_retry.py
+++ b/tests/dev/test_ci_uv_sync_retry.py
@@ -229,6 +229,43 @@ def test_uv_sync_retry_invalid_max_attempts_defaults_to_three(tmp_path: Path) ->
     assert len(calls) == 3, f"expected default of 3 attempts, got: {calls}"
 
 
+def test_uv_sync_retry_invalid_backoff_base_defaults_gracefully(tmp_path: Path) -> None:
+    """A non-numeric ``UV_SYNC_BACKOFF_BASE`` falls back to 5 with a warning.
+
+    Guards against a ``set -u`` arithmetic crash: previously the malformed value
+    was treated as an unbound variable in the backoff expansion and aborted the
+    wrapper with a confusing error instead of retrying.
+    """
+    fake_bin, env = _fast_retry_env(tmp_path)
+    env["UV_SYNC_BACKOFF_BASE"] = "not-a-number"
+    env["UV_SYNC_BACKOFF_CAP"] = "0"  # keep the defaulted base instant for the test
+    env["UV_SYNC_MAX_ATTEMPTS"] = "2"
+    _write_stub_uv(fake_bin, counter=tmp_path / "counter", log=tmp_path / "uv.log", succeed_on=999)
+
+    result = _run_wrapper(tmp_path, args=["--", "--frozen"], env=env)
+
+    assert result.returncode == 1, f"stdout: {result.stdout}, stderr: {result.stderr}"
+    assert "defaulting to 5" in result.stdout + result.stderr
+    calls = (tmp_path / "uv.log").read_text().splitlines()
+    assert len(calls) == 2, f"expected 2 attempts, got: {calls}"
+
+
+def test_uv_sync_retry_invalid_backoff_cap_defaults_gracefully(tmp_path: Path) -> None:
+    """A non-numeric ``UV_SYNC_BACKOFF_CAP`` falls back to 30 with a warning."""
+    fake_bin, env = _fast_retry_env(tmp_path)
+    env["UV_SYNC_BACKOFF_CAP"] = "not-a-number"
+    env["UV_SYNC_BACKOFF_BASE"] = "0"  # instant base so the defaulted cap is not slept
+    env["UV_SYNC_MAX_ATTEMPTS"] = "2"
+    _write_stub_uv(fake_bin, counter=tmp_path / "counter", log=tmp_path / "uv.log", succeed_on=999)
+
+    result = _run_wrapper(tmp_path, args=["--", "--frozen"], env=env)
+
+    assert result.returncode == 1, f"stdout: {result.stdout}, stderr: {result.stderr}"
+    assert "defaulting to 30" in result.stdout + result.stderr
+    calls = (tmp_path / "uv.log").read_text().splitlines()
+    assert len(calls) == 2, f"expected 2 attempts, got: {calls}"
+
+
 def test_uv_sync_retry_backoff_is_exponential_and_capped(tmp_path: Path) -> None:
     """Backoff doubles per attempt (base, base*2, ...) up to the cap."""
     tmp = tmp_path / "case"

--- a/tests/dev/test_ci_uv_sync_retry.py
+++ b/tests/dev/test_ci_uv_sync_retry.py
@@ -1,0 +1,320 @@
+"""Behavior and contract tests for the uv sync retry helper (issue #4889).
+
+The helper wraps ``uv sync`` with bounded retry + exponential backoff so a
+transient PyPI / index connection error (the ``nvidia-cufft-cu12`` download
+failure that killed ``wheel-smoke-install``) no longer fails a CI run on its
+first occurrence. ``uv sync --frozen`` resolves against a fixed lock, so the
+only realistic non-zero exits are network/download failures, which are
+transient; a genuine failure reproduces on every attempt and still fails the
+step once the retry budget is exhausted.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def _script_path() -> Path:
+    """Return the repository-local uv sync retry helper path."""
+    return Path(__file__).resolve().parents[2] / "scripts" / "dev" / "uv_sync_retry.sh"
+
+
+def _repo_root() -> Path:
+    """Return the repository root for workflow contract checks."""
+    return Path(__file__).resolve().parents[2]
+
+
+def _action_path() -> Path:
+    """Return the shared CI Python setup composite action path."""
+    return _repo_root() / ".github" / "actions" / "setup-ci-python" / "action.yml"
+
+
+def _write_stub_uv(
+    bin_dir: Path,
+    *,
+    counter: Path,
+    log: Path,
+    succeed_on: int,
+) -> None:
+    """Write a fake ``uv`` that fails until the ``succeed_on``-th call.
+
+    Each invocation increments a counter file, appends its args to a log, and
+    exits non-zero (simulating a transient connection error) until the call
+    count reaches ``succeed_on``.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "uv"
+    stub.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            n="$(cat '{counter}' 2>/dev/null || echo 0)"
+            n=$((n + 1))
+            printf '%s\\n' "$n" > '{counter}'
+            printf 'call %s: %s\\n' "$n" "$*" >> '{log}'
+            if [[ "$n" -ge {succeed_on} ]]; then
+              exit 0
+            fi
+            echo "stub uv: simulated transient connection error (call $n)" >&2
+            exit 1
+            """
+        )
+    )
+    stub.chmod(0o755)
+
+
+def _write_stub_sleep(bin_dir: Path, log: Path) -> None:
+    """Write a fake ``sleep`` that records its argument instead of sleeping."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "sleep"
+    stub.write_text(f"#!/usr/bin/env bash\nprintf '%s\\n' \"$1\" >> '{log}'\n")
+    stub.chmod(0o755)
+
+
+def _run_wrapper(
+    tmp_path: Path,
+    *,
+    args: list[str],
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Run the retry helper under bash with the given args and environment."""
+    script = _script_path()
+    bash_path = shutil.which("bash")
+    assert bash_path, "bash is required for these tests"
+    return subprocess.run(
+        [bash_path, str(script), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        cwd=tmp_path,
+        timeout=60,
+    )
+
+
+def _fast_retry_env(tmp_path: Path, *, with_uv: bool = True) -> tuple[Path, dict[str, str]]:
+    """Return a fake-bin dir and an env with instant backoff and a stub uv on PATH."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    # Instant backoff so retry tests do not wait on real sleeps.
+    env["UV_SYNC_BACKOFF_BASE"] = "0"
+    env["UV_SYNC_BACKOFF_CAP"] = "0"
+    env["UV_SYNC_MAX_ATTEMPTS"] = "3"
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    if with_uv:
+        _write_stub_uv(
+            fake_bin,
+            counter=tmp_path / "counter",
+            log=tmp_path / "uv.log",
+            succeed_on=1,
+        )
+    return fake_bin, env
+
+
+def test_uv_sync_retry_shell_syntax() -> None:
+    """The helper must pass bash syntax checks and be executable."""
+    script = _script_path()
+    assert script.exists(), "uv_sync_retry.sh helper is missing"
+    assert subprocess.run(["bash", "-n", str(script)], check=False, timeout=30).returncode == 0
+    assert os.access(script, os.X_OK), "uv_sync_retry.sh must be executable"
+
+
+def test_uv_sync_retry_succeeds_first_try(tmp_path: Path) -> None:
+    """A sync that succeeds immediately must run once and exit 0."""
+    fake_bin, env = _fast_retry_env(tmp_path)
+    _write_stub_uv(fake_bin, counter=tmp_path / "counter", log=tmp_path / "uv.log", succeed_on=1)
+
+    result = _run_wrapper(tmp_path, args=["--", "--all-extras", "--frozen"], env=env)
+
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "uv sync (attempt 1/3)" in result.stdout
+    assert "uv_sync_retry success attempt=1/3" in result.stdout
+    calls = (tmp_path / "uv.log").read_text().splitlines()
+    assert len(calls) == 1, f"expected one uv call, got: {calls}"
+
+
+def test_uv_sync_retry_retries_then_succeeds(tmp_path: Path) -> None:
+    """A transient failure on the first two calls must be absorbed by retry."""
+    fake_bin, env = _fast_retry_env(tmp_path)
+    _write_stub_uv(fake_bin, counter=tmp_path / "counter", log=tmp_path / "uv.log", succeed_on=3)
+
+    result = _run_wrapper(tmp_path, args=["--", "--all-extras", "--frozen"], env=env)
+
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "uv sync (attempt 1/3)" in result.stdout
+    assert "uv sync (attempt 2/3)" in result.stdout
+    assert "uv sync (attempt 3/3)" in result.stdout
+    assert "uv_sync_retry transient status=1" in result.stdout
+    assert "uv_sync_retry success attempt=3/3" in result.stdout
+    calls = (tmp_path / "uv.log").read_text().splitlines()
+    assert len(calls) == 3, f"expected three uv calls, got: {calls}"
+
+
+def test_uv_sync_retry_fails_after_max_attempts(tmp_path: Path) -> None:
+    """Persistent failure must exhaust the retry budget and exit non-zero."""
+    fake_bin, env = _fast_retry_env(tmp_path)
+    env["UV_SYNC_MAX_ATTEMPTS"] = "2"
+    # succeed_on higher than any attempt count -> always fails.
+    _write_stub_uv(fake_bin, counter=tmp_path / "counter", log=tmp_path / "uv.log", succeed_on=999)
+
+    result = _run_wrapper(tmp_path, args=["--", "--frozen"], env=env)
+
+    assert result.returncode == 1, f"expected non-zero exit, stdout: {result.stdout}"
+    assert "uv sync (attempt 1/2)" in result.stdout
+    assert "uv sync (attempt 2/2)" in result.stdout
+    # The terminal failure banner is written to stderr (>&2).
+    assert "failed after 2 attempt(s)" in result.stdout + result.stderr
+    calls = (tmp_path / "uv.log").read_text().splitlines()
+    assert len(calls) == 2, f"expected two uv calls, got: {calls}"
+
+
+def test_uv_sync_retry_status_127_not_retried(tmp_path: Path) -> None:
+    """A missing uv binary (status 127) is non-transient and must not retry."""
+    # No stub uv on PATH at all.
+    _, env = _fast_retry_env(tmp_path, with_uv=False)
+    env["PATH"] = "/usr/bin:/bin"  # coreutils present, no uv.
+
+    result = _run_wrapper(tmp_path, args=["--", "--frozen"], env=env)
+
+    assert result.returncode == 127, (
+        f"expected 127, stdout: {result.stdout}, stderr: {result.stderr}"
+    )
+    assert "not retryable" in result.stdout + result.stderr
+    # Only one attempt group; no transient-retry banner.
+    assert "uv_sync_retry transient" not in result.stdout
+
+
+def test_uv_sync_retry_forwards_args_to_uv(tmp_path: Path) -> None:
+    """Args after the ``--`` separator must be forwarded verbatim to uv sync."""
+    fake_bin, env = _fast_retry_env(tmp_path)
+    _write_stub_uv(fake_bin, counter=tmp_path / "counter", log=tmp_path / "uv.log", succeed_on=1)
+
+    result = _run_wrapper(tmp_path, args=["--", "--all-extras", "--frozen"], env=env)
+
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    log_text = (tmp_path / "uv.log").read_text()
+    assert "call 1: sync --all-extras --frozen" in log_text, log_text
+
+
+def test_uv_sync_retry_defaults_to_locked_sync_args(tmp_path: Path) -> None:
+    """With no args, the helper defaults to ``--all-extras --frozen``."""
+    fake_bin, env = _fast_retry_env(tmp_path)
+    _write_stub_uv(fake_bin, counter=tmp_path / "counter", log=tmp_path / "uv.log", succeed_on=1)
+
+    result = _run_wrapper(tmp_path, args=[], env=env)
+
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    log_text = (tmp_path / "uv.log").read_text()
+    assert "call 1: sync --all-extras --frozen" in log_text, log_text
+
+
+def test_uv_sync_retry_invalid_max_attempts_defaults_to_three(tmp_path: Path) -> None:
+    """A non-positive ``UV_SYNC_MAX_ATTEMPTS`` falls back to 3 with a warning."""
+    fake_bin, env = _fast_retry_env(tmp_path)
+    env["UV_SYNC_MAX_ATTEMPTS"] = "not-a-number"
+    _write_stub_uv(fake_bin, counter=tmp_path / "counter", log=tmp_path / "uv.log", succeed_on=999)
+
+    result = _run_wrapper(tmp_path, args=["--", "--frozen"], env=env)
+
+    assert result.returncode == 1
+    assert "defaulting to 3" in result.stdout + result.stderr
+    calls = (tmp_path / "uv.log").read_text().splitlines()
+    assert len(calls) == 3, f"expected default of 3 attempts, got: {calls}"
+
+
+def test_uv_sync_retry_backoff_is_exponential_and_capped(tmp_path: Path) -> None:
+    """Backoff doubles per attempt (base, base*2, ...) up to the cap."""
+    tmp = tmp_path / "case"
+    fake_bin = tmp / "bin"
+    fake_bin.mkdir(parents=True)
+    sleep_log = tmp / "sleep.log"
+    _write_stub_sleep(fake_bin, sleep_log)
+    _write_stub_uv(fake_bin, counter=tmp / "counter", log=tmp / "uv.log", succeed_on=3)
+
+    env = os.environ.copy()
+    env["UV_SYNC_MAX_ATTEMPTS"] = "3"
+    env["UV_SYNC_BACKOFF_BASE"] = "2"
+    env["UV_SYNC_BACKOFF_CAP"] = "10"
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    result = _run_wrapper(tmp, args=["--", "--frozen"], env=env)
+
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    # attempt 1 -> backoff base*2**0 = 2; attempt 2 -> base*2**1 = 4; attempt 3 is last (no sleep).
+    sleeps = sleep_log.read_text().splitlines() if sleep_log.exists() else []
+    assert sleeps == ["2", "4"], f"expected exponential backoff [2, 4], got: {sleeps}"
+
+
+def test_uv_sync_retry_backoff_caps_at_maximum(tmp_path: Path) -> None:
+    """Backoff must not exceed ``UV_SYNC_BACKOFF_CAP``."""
+    tmp = tmp_path / "case"
+    fake_bin = tmp / "bin"
+    fake_bin.mkdir(parents=True)
+    sleep_log = tmp / "sleep.log"
+    _write_stub_sleep(fake_bin, sleep_log)
+    # Always fail so we exercise several backoff steps within a small cap.
+    _write_stub_uv(fake_bin, counter=tmp / "counter", log=tmp / "uv.log", succeed_on=999)
+
+    env = os.environ.copy()
+    env["UV_SYNC_MAX_ATTEMPTS"] = "4"
+    env["UV_SYNC_BACKOFF_BASE"] = "5"
+    env["UV_SYNC_BACKOFF_CAP"] = "8"
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    result = _run_wrapper(tmp, args=["--", "--frozen"], env=env)
+
+    assert result.returncode == 1
+    # base=5: 5, 10->capped to 8, 20->capped to 8; attempt 4 is last (no sleep).
+    sleeps = sleep_log.read_text().splitlines() if sleep_log.exists() else []
+    assert sleeps == ["5", "8", "8"], f"expected capped backoff [5, 8, 8], got: {sleeps}"
+
+
+# --- Workflow / composite-action contract checks ---
+
+
+def test_setup_ci_python_uses_uv_sync_retry_wrapper() -> None:
+    """The shared setup action must wrap uv sync in the retry helper."""
+    action_text = _action_path().read_text(encoding="utf-8")
+    assert "scripts/dev/uv_sync_retry.sh" in action_text
+    # The original bare `uv sync --all-extras --frozen` invocation is gone.
+    assert "uv sync --all-extras --frozen\n" not in action_text
+
+
+def test_setup_ci_python_caches_setup_uv_payloads() -> None:
+    """The setup action must cache uv payloads at the setup-uv cache location."""
+    action_text = _action_path().read_text(encoding="utf-8")
+    assert "${{ runner.temp }}/setup-uv-cache/archive-v0" in action_text
+    assert "${{ runner.temp }}/setup-uv-cache/wheels-v6" in action_text
+    assert (
+        "uv-sync-payloads-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}"
+        in action_text
+    )
+
+
+def test_setup_ci_python_reports_cache_restore_outputs() -> None:
+    """The pre-sync diagnostic must surface the actions/cache restore outputs."""
+    action_text = _action_path().read_text(encoding="utf-8")
+    assert "steps.cache-uv.outputs.cache-hit" in action_text
+    assert "steps.cache-uv.outputs.cache-matched-key" in action_text
+
+
+def test_setup_ci_python_has_no_local_uv_cache_path() -> None:
+    """The setup action must not use the local ``~/.cache/uv`` cache path.
+
+    Reinforces the convention pinned by ``test_ci_uv_sync_diag``: uv payloads
+    live under ``runner.temp/setup-uv-cache`` (managed by setup-uv), never at
+    the user-local default cache dir.
+    """
+    action_text = _action_path().read_text(encoding="utf-8")
+    assert "~/.cache/uv" not in action_text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Durable CI dependency-cache fix for issue #4889 (transient PyPI connection
error downloading `nvidia-cufft-cu12==11.3.3.83` killed `wheel-smoke-install`
on PR #4887). Two complementary, centralized changes:

1. **Bounded retry + exponential backoff on `uv sync`** — new
   `scripts/dev/uv_sync_retry.sh` wraps `uv sync --all-extras --frozen` and
   retries transient failures (default 3 attempts, backoff 5s→cap 30s, env-
   tunable). Status 127 (`uv` missing) is treated as non-transient and fails
   fast. `uv sync --frozen` resolves against a fixed lock, so the only
   realistic non-zero exits are network/download failures; uv caches every
   wheel it fully downloads, so a retry resumes from the last good wheel.
2. **Cache the uv payloads in the shared `setup-ci-python` action** —
   `${{ runner.temp }}/setup-uv-cache/{archive-v0,wheels-v6}` keyed on
   `pyproject.toml` + `uv.lock` (matching the convention pinned by
   `test_ci_uv_sync_diag`), so already-downloaded wheels are restored instead
   of re-fetched every run.

Both changes live in `.github/actions/setup-ci-python/action.yml`, which is
shared by **every** CI job — `ci.yml` (`fast-feedback` ×4, `smoke-artifacts`,
`wheel-smoke-install`, `examples-smoke`) plus `perf-nightly` and
`pr-promoted-planner-smoke`. So this hardens `wheel-smoke-install` **and**
every other uv-sync job against the transient-download class of failure.

## Why / issue resolution

Issue #4889 acceptance: *"Close this issue once #4887 has a green
`wheel-smoke-install` replacement run **or** a durable CI dependency-cache
fix."* Both closure conditions are now met:

- The immediate block was already cleared operationally — the rerun of
  `wheel-smoke-install` on #4887 is **green** (run `28958426243`,
  job `85925824189`, conclusion `SUCCESS`).
- This PR delivers the second, deeper path: the **durable dependency-cache
  fix** that absorbs recurrence of the exact failure mode the issue tracks.

Hence `Closes #4889`.

## Bonus: fixes a pre-existing contract-test failure on `main`

While validating, I found
`tests/dev/test_ci_uv_sync_diag.py::test_workflow_uv_cache_paths_match_setup_uv_cache_dir`
**already fails on pristine `origin/main`** (verified via `git stash`): a
recent refactor delegated `perf-nightly.yml` and `pr-promoted-planner-smoke.yml`
to `setup-ci-python` and removed their inline uv-cache config, but
`setup-ci-python` had **no** cache — so the test (which expected the inline
paths) broke. This PR completes that centralization by putting the cache in
`setup-ci-python`, and updates the stale test to assert the centralized
contract (cache pinned to setup-uv's `runner.temp` location, never
`~/.cache/uv`; consumers delegate to the shared action). The test's original
intent is preserved.

## Validation (CPU-level only; no campaigns/Slurm/training)

```
$ uv run pytest tests/dev/test_ci_uv_sync_retry.py tests/dev/test_ci_uv_sync_diag.py -q
20 passed in 1.09s

$ uv run pytest tests/dev/ -q
3 failed, 639 passed   # the 3 failures are in test_pr_ready_preflight.py;
                       # confirmed PRE-EXISTING on pristine origin/main
                       # (git stash), unrelated to this change

$ uv run ruff check <changed .py files>      # All checks passed!
$ uv run ruff format <changed .py files>     # applied
$ uv run python -c "import yaml; yaml.safe_load(open('.github/actions/setup-ci-python/action.yml'))"  # OK
$ uv run python scripts/tools/sync_ai_config.py --check   # AI config links validated: 7 symlinks. EXIT=0

# Real-uv integration smoke (worktree venv already synced -> attempt 1 success):
$ bash scripts/dev/ci_step_timer.sh "real-uv smoke" bash scripts/dev/uv_sync_retry.sh -- --all-extras --frozen
::group::uv sync (attempt 1/3)
uv_sync_retry success attempt=1/3
ci_step_timer step_end label="real-uv smoke" status=0 duration_seconds=1
```

New test coverage (`tests/dev/test_ci_uv_sync_retry.py`): retry-then-succeed,
budget exhaustion + non-zero exit, arg-forwarding through `--`, default
locked-sync args, status-127 fast-fail (non-retried), invalid-config fallback
to 3, exponential backoff `[2, 4]`, and capped backoff `[5, 8, 8]`.

shellcheck is not installed on this host; `bash -n` passes and the script
follows shellcheck-clean conventions (all expansions quoted).

## Notes

- `CHANGELOG.md` intentionally not updated: this is CI-reliability hardening,
  not a user-facing/package change (the `## [Unreleased]` section is
  feature/issue-scoped with claim boundaries).
- No benchmark/metric/paper claim — `smoke evidence` only (CI runs green +
  unit tests). The real durability proof lands when CI next runs `uv sync`
  on a cache miss with the retry in place.

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation
lane; the review gate hardens and merges.

Closes #4889


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI dependency setup reliability by retrying transient sync failures automatically.
  * Added better cache reuse during CI runs, which should make checks complete faster and more consistently.

* **Chores**
  * Expanded automated coverage to verify the new CI cache and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->