### PR TITLE
Issue #4893: characterization wave 3 — scripts/tools evidence-flow layer (cheap-lane worker)

### DIFF
--- a/tests/scripts/test_replay_episode_figure_wave3.py
+++ b/tests/scripts/test_replay_episode_figure_wave3.py
@@ -1,0 +1,463 @@
+"""Characterization wave 3 tests for scripts/replay_episode_figure.py.
+
+Focuses on the argument contract (parse_args validation, defaults, choices).
+NEW tests only, zero production changes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.replay_episode_figure import main, parse_args
+
+# ---------------------------------------------------------------------------
+# parse_args validation
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    """Tests for parse_args argument validation and defaults."""
+
+    def test_required_args(self) -> None:
+        """All required arguments must be provided."""
+        with pytest.raises(SystemExit):
+            parse_args([])
+
+    def test_missing_episodes(self) -> None:
+        """--episodes is required."""
+        with pytest.raises(SystemExit):
+            parse_args(["--episode-id", "ep1", "--outputs", "trajectory", "--out-dir", "/tmp"])
+
+    def test_missing_episode_id(self) -> None:
+        """--episode-id is required."""
+        with pytest.raises(SystemExit):
+            parse_args(["--episodes", "ep.jsonl", "--outputs", "trajectory", "--out-dir", "/tmp"])
+
+    def test_missing_outputs(self) -> None:
+        """--outputs is required."""
+        with pytest.raises(SystemExit):
+            parse_args(["--episodes", "ep.jsonl", "--episode-id", "ep1", "--out-dir", "/tmp"])
+
+    def test_missing_out_dir(self) -> None:
+        """--out-dir is required."""
+        with pytest.raises(SystemExit):
+            parse_args(["--episodes", "ep.jsonl", "--episode-id", "ep1", "--outputs", "trajectory"])
+
+    def test_all_required_args(self) -> None:
+        """All required args parsed correctly."""
+        args = parse_args(
+            [
+                "--episodes",
+                "episodes.jsonl",
+                "--episode-id",
+                "ep_001",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                "/tmp/output",
+            ]
+        )
+        assert args.episodes == Path("episodes.jsonl")
+        assert args.episode_id == "ep_001"
+        assert args.outputs == "trajectory"
+        assert args.out_dir == Path("/tmp/output")
+
+    def test_defaults(self) -> None:
+        """Default values are correct."""
+        args = parse_args(
+            [
+                "--episodes",
+                "ep.jsonl",
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                "/tmp",
+            ]
+        )
+        assert args.campaign_root is None
+        assert args.scenario_matrix is None
+        assert args.config_hash is None
+        assert args.tolerance_m == 0.1
+        assert args.frame_steps is None
+        assert args.format == "png"
+        assert args.no_determinism_check is False
+        assert args.verbose is False
+
+    def test_format_choices(self) -> None:
+        """--format accepts only png, pdf, svg."""
+        args = parse_args(
+            [
+                "--episodes",
+                "ep.jsonl",
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                "/tmp",
+                "--format",
+                "pdf",
+            ]
+        )
+        assert args.format == "pdf"
+
+        with pytest.raises(SystemExit):
+            parse_args(
+                [
+                    "--episodes",
+                    "ep.jsonl",
+                    "--episode-id",
+                    "ep1",
+                    "--outputs",
+                    "trajectory",
+                    "--out-dir",
+                    "/tmp",
+                    "--format",
+                    "gif",
+                ]
+            )
+
+    def test_tolerance_m_option(self) -> None:
+        """--tolerance-m is parsed correctly."""
+        args = parse_args(
+            [
+                "--episodes",
+                "ep.jsonl",
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                "/tmp",
+                "--tolerance-m",
+                "0.05",
+            ]
+        )
+        assert args.tolerance_m == 0.05
+
+    def test_frame_steps_option(self) -> None:
+        """--frame-steps is parsed as string."""
+        args = parse_args(
+            [
+                "--episodes",
+                "ep.jsonl",
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "filmstrip",
+                "--out-dir",
+                "/tmp",
+                "--frame-steps",
+                "0,10,20,30",
+            ]
+        )
+        assert args.frame_steps == "0,10,20,30"
+
+    def test_no_determinism_check_flag(self) -> None:
+        """--no-determinism-check flag is parsed correctly."""
+        args = parse_args(
+            [
+                "--episodes",
+                "ep.jsonl",
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                "/tmp",
+                "--no-determinism-check",
+            ]
+        )
+        assert args.no_determinism_check is True
+
+    def test_verbose_flag(self) -> None:
+        """--verbose flag is parsed correctly."""
+        args = parse_args(
+            [
+                "--episodes",
+                "ep.jsonl",
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                "/tmp",
+                "--verbose",
+            ]
+        )
+        assert args.verbose is True
+
+    def test_campaign_root_option(self) -> None:
+        """--campaign-root is parsed as Path."""
+        args = parse_args(
+            [
+                "--episodes",
+                "ep.jsonl",
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                "/tmp",
+                "--campaign-root",
+                "/campaign/root",
+            ]
+        )
+        assert args.campaign_root == Path("/campaign/root")
+
+    def test_scenario_matrix_option(self) -> None:
+        """--scenario-matrix is parsed as Path."""
+        args = parse_args(
+            [
+                "--episodes",
+                "ep.jsonl",
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                "/tmp",
+                "--scenario-matrix",
+                "/path/to/matrix.yaml",
+            ]
+        )
+        assert args.scenario_matrix == Path("/path/to/matrix.yaml")
+
+    def test_config_hash_option(self) -> None:
+        """--config is parsed as string (config hash)."""
+        args = parse_args(
+            [
+                "--episodes",
+                "ep.jsonl",
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                "/tmp",
+                "--config",
+                "abc123def",
+            ]
+        )
+        assert args.config_hash == "abc123def"
+
+    def test_all_options(self) -> None:
+        """All options can be set simultaneously."""
+        args = parse_args(
+            [
+                "--episodes",
+                "ep.jsonl",
+                "--episode-id",
+                "ep_001",
+                "--outputs",
+                "still,filmstrip,trajectory",
+                "--out-dir",
+                "/tmp/output",
+                "--campaign-root",
+                "/campaign",
+                "--scenario-matrix",
+                "/matrix.yaml",
+                "--config",
+                "hash123",
+                "--tolerance-m",
+                "0.05",
+                "--frame-steps",
+                "0,5,10",
+                "--format",
+                "svg",
+                "--no-determinism-check",
+                "--verbose",
+            ]
+        )
+        assert args.episodes == Path("ep.jsonl")
+        assert args.episode_id == "ep_001"
+        assert args.outputs == "still,filmstrip,trajectory"
+        assert args.out_dir == Path("/tmp/output")
+        assert args.campaign_root == Path("/campaign")
+        assert args.scenario_matrix == Path("/matrix.yaml")
+        assert args.config_hash == "hash123"
+        assert args.tolerance_m == 0.05
+        assert args.frame_steps == "0,5,10"
+        assert args.format == "svg"
+        assert args.no_determinism_check is True
+        assert args.verbose is True
+
+
+# ---------------------------------------------------------------------------
+# main() argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestMainArgumentValidation:
+    """Tests for main() argument validation at the CLI level."""
+
+    def test_invalid_output_type(self, tmp_path: Path) -> None:
+        """Invalid output type returns exit code 1."""
+        episodes_file = tmp_path / "episodes.jsonl"
+        episodes_file.write_text(
+            '{"episode_id": "ep1", "scenario_id": "s", "seed": 1}\n',
+            encoding="utf-8",
+        )
+
+        ret = main(
+            [
+                "--episodes",
+                str(episodes_file),
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "invalid_type",
+                "--out-dir",
+                str(tmp_path / "out"),
+            ]
+        )
+        assert ret == 1
+
+    def test_missing_episodes_file(self, tmp_path: Path) -> None:
+        """Missing episodes file returns exit code 1."""
+        ret = main(
+            [
+                "--episodes",
+                str(tmp_path / "nonexistent.jsonl"),
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                str(tmp_path / "out"),
+            ]
+        )
+        assert ret == 1
+
+    def test_missing_episode_id_in_file(self, tmp_path: Path) -> None:
+        """Non-existent episode ID in file returns exit code 1."""
+        episodes_file = tmp_path / "episodes.jsonl"
+        episodes_file.write_text(
+            '{"episode_id": "ep1", "scenario_id": "s", "seed": 1}\n',
+            encoding="utf-8",
+        )
+
+        ret = main(
+            [
+                "--episodes",
+                str(episodes_file),
+                "--episode-id",
+                "nonexistent",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                str(tmp_path / "out"),
+            ]
+        )
+        assert ret == 1
+
+    def test_invalid_frame_steps_format(self, tmp_path: Path) -> None:
+        """Invalid frame-steps format returns exit code 1."""
+        episodes_file = tmp_path / "episodes.jsonl"
+        episodes_file.write_text(
+            json.dumps(
+                {
+                    "episode_id": "ep1",
+                    "scenario_id": "s",
+                    "seed": 1,
+                    "replay_steps": [
+                        {"t": 0, "x": 0, "y": 0, "heading": 0},
+                        {"t": 1, "x": 1, "y": 0.5, "heading": 0.1},
+                    ],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        ret = main(
+            [
+                "--episodes",
+                str(episodes_file),
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "filmstrip",
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--frame-steps",
+                "0,abc,2",
+            ]
+        )
+        assert ret == 1
+
+    def test_multiple_output_types(self, tmp_path: Path) -> None:
+        """Multiple comma-separated output types are accepted."""
+        episodes_file = tmp_path / "episodes.jsonl"
+        episodes_file.write_text(
+            json.dumps(
+                {
+                    "episode_id": "ep1",
+                    "scenario_id": "s",
+                    "seed": 1,
+                    "final_robot_position": [1.0, 0.5],
+                    "replay_steps": [
+                        {"t": 0, "x": 0, "y": 0, "heading": 0},
+                        {"t": 1, "x": 1, "y": 0.5, "heading": 0.1},
+                    ],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        ret = main(
+            [
+                "--episodes",
+                str(episodes_file),
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "still,trajectory",
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--no-determinism-check",
+            ]
+        )
+        assert ret == 0
+
+    def test_verbose_mode(self, tmp_path: Path) -> None:
+        """Verbose mode does not affect exit code."""
+        episodes_file = tmp_path / "episodes.jsonl"
+        episodes_file.write_text(
+            json.dumps(
+                {
+                    "episode_id": "ep1",
+                    "scenario_id": "s",
+                    "seed": 1,
+                    "final_robot_position": [1.0, 0.5],
+                    "replay_steps": [
+                        {"t": 0, "x": 0, "y": 0, "heading": 0},
+                        {"t": 1, "x": 1, "y": 0.5, "heading": 0.1},
+                    ],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        ret = main(
+            [
+                "--episodes",
+                str(episodes_file),
+                "--episode-id",
+                "ep1",
+                "--outputs",
+                "trajectory",
+                "--out-dir",
+                str(tmp_path / "out"),
+                "--verbose",
+                "--no-determinism-check",
+            ]
+        )
+        assert ret == 0

--- a/tests/scripts/tools/test_mapf_oracle_wave3.py
+++ b/tests/scripts/tools/test_mapf_oracle_wave3.py
@@ -158,10 +158,10 @@ class TestSippTimeEdgesBlockedPropagation:
         )
         assert path is not None
         # The direct swap move must be avoided
-        if len(path) >= 2:
-            assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
-                "SIPP allowed a swap collision with time_edges_blocked"
-            )
+        assert len(path) >= 2, "expected a multi-step path (start != goal)"
+        assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
+            "SIPP allowed a swap collision with time_edges_blocked"
+        )
 
     def test_sipp_with_two_obstacles_no_false_swap(self) -> None:
         """Two independent obstacles must not cause a false swap block."""
@@ -247,10 +247,10 @@ class TestSippTimeEdgesBlockedPropagation:
         )
         assert path is not None
         # Must avoid swap with obstacle 0: (0,0)->(1,0) is a swap
-        if len(path) >= 2:
-            assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
-                "Swap with obstacle 0 not detected"
-            )
+        assert len(path) >= 2, "expected a multi-step path (start != goal)"
+        assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
+            "Swap with obstacle 0 not detected"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -273,10 +273,10 @@ class TestCbsTimeEdgesBlockedPropagation:
         assert result is not None
         path = result["solution"][0]
         # The direct swap move must be avoided
-        if len(path) >= 2:
-            assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
-                "CBS allowed a swap collision with a dynamic obstacle"
-            )
+        assert len(path) >= 2, "expected a multi-step path (start != goal)"
+        assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
+            "CBS allowed a swap collision with a dynamic obstacle"
+        )
 
     def test_cbs_two_agents_with_obstacle_swap(self) -> None:
         """CBS with two agents avoids dynamic obstacle swap collision."""
@@ -354,10 +354,10 @@ class TestCbsTimeEdgesBlockedPropagation:
         assert result is not None
         path = result["solution"][0]
         # Must avoid swap with obstacle 0
-        if len(path) >= 2:
-            assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
-                "Swap with obstacle 0 not detected"
-            )
+        assert len(path) >= 2, "expected a multi-step path (start != goal)"
+        assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
+            "Swap with obstacle 0 not detected"
+        )
 
     def test_cbs_three_agents_with_obstacle_edges(self) -> None:
         """CBS with three agents and obstacle edge collisions."""

--- a/tests/scripts/tools/test_mapf_oracle_wave3.py
+++ b/tests/scripts/tools/test_mapf_oracle_wave3.py
@@ -1,0 +1,422 @@
+"""Characterization wave 3 tests for scripts/tools/mapf_oracle_diagnostic.py.
+
+Focuses on CBS/SIPP paths beyond the existing suite, specifically the
+time_edges_blocked propagation cases.  NEW tests only, zero production
+changes.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from scripts.tools.mapf_oracle_diagnostic import (
+    _build_time_blocked,
+    _build_time_edges_blocked,
+    _has_collision,
+    cbs_search,
+    sipp_search,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_svg(width: float, height: float, rects: list[dict]) -> Path:
+    """Write a minimal SVG with obstacle rects and return the path."""
+    lines = [
+        f'<svg width="{width}" height="{height}" xmlns="http://www.w3.org/2000/svg">',
+    ]
+    for r in rects:
+        label = r.get("label", "")
+        attrs = f'x="{r["x"]}" y="{r["y"]}" width="{r["w"]}" height="{r["h"]}"'
+        if label:
+            attrs += f' inkscape:label="{label}"'
+        lines.append(f"  <rect {attrs} />")
+    lines.append("</svg>")
+
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".svg", delete=False, encoding="utf-8")
+    tmp.write("\n".join(lines))
+    tmp.close()
+    return Path(tmp.name)
+
+
+def _make_dynamic_obstacles_json(obstacles: list[dict]) -> Path:
+    """Write a dynamic obstacles JSON file and return the path."""
+    data = {"dynamic_obstacles": obstacles}
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8")
+    json.dump(data, tmp)
+    tmp.close()
+    return Path(tmp.name)
+
+
+# ---------------------------------------------------------------------------
+# _build_time_edges_blocked unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTimeEdgesBlocked:
+    """Direct unit tests for _build_time_edges_blocked."""
+
+    def test_single_obstacle_single_edge(self) -> None:
+        """One obstacle with one transition produces one edge."""
+        obstacles = [{"id": 0, "trajectory": [[1, 0], [0, 0]]}]
+        result = _build_time_edges_blocked(obstacles)
+        assert result == {0: {((1, 0), (0, 0))}}
+
+    def test_single_obstacle_multiple_edges(self) -> None:
+        """Obstacle with multiple transitions produces edges at each time step."""
+        obstacles = [{"id": 0, "trajectory": [[0, 0], [0, 1], [0, 2]]}]
+        result = _build_time_edges_blocked(obstacles)
+        assert 0 in result
+        assert 1 in result
+        assert ((0, 0), (0, 1)) in result[0]
+        assert ((0, 1), (0, 2)) in result[1]
+
+    def test_stationary_obstacle_produces_no_edges(self) -> None:
+        """Obstacle that stays in place produces no edges."""
+        obstacles = [{"id": 0, "trajectory": [[5, 5], [5, 5], [5, 5]]}]
+        result = _build_time_edges_blocked(obstacles)
+        assert result == {}
+
+    def test_multiple_obstacles_same_transition(self) -> None:
+        """Multiple obstacles on the same edge merge into one set."""
+        obstacles = [
+            {"id": 0, "trajectory": [[1, 0], [0, 0]]},
+            {"id": 1, "trajectory": [[1, 0], [0, 0]]},
+        ]
+        result = _build_time_edges_blocked(obstacles)
+        assert result == {0: {((1, 0), (0, 0))}}
+
+    def test_multiple_obstacles_different_transitions(self) -> None:
+        """Multiple obstacles with different transitions produce separate edges."""
+        obstacles = [
+            {"id": 0, "trajectory": [[1, 0], [0, 0]]},
+            {"id": 1, "trajectory": [[0, 1], [1, 1]]},
+        ]
+        result = _build_time_edges_blocked(obstacles)
+        assert ((1, 0), (0, 0)) in result[0]
+        assert ((0, 1), (1, 1)) in result[0]
+
+    def test_empty_obstacles(self) -> None:
+        """No obstacles produces empty dict."""
+        result = _build_time_edges_blocked([])
+        assert result == {}
+
+    def test_single_position_trajectory(self) -> None:
+        """Obstacle with single position produces no edges."""
+        obstacles = [{"id": 0, "trajectory": [[3, 3]]}]
+        result = _build_time_edges_blocked(obstacles)
+        assert result == {}
+
+    def test_diagonal_movement(self) -> None:
+        """Obstacle moving diagonally produces diagonal edge."""
+        obstacles = [{"id": 0, "trajectory": [[0, 0], [1, 1]]}]
+        result = _build_time_edges_blocked(obstacles)
+        assert result == {0: {((0, 0), (1, 1))}}
+
+    def test_reverse_path_edges(self) -> None:
+        """Obstacle traversing path in reverse produces correct edges."""
+        obstacles = [{"id": 0, "trajectory": [[0, 0], [0, 1], [0, 0]]}]
+        result = _build_time_edges_blocked(obstacles)
+        assert ((0, 0), (0, 1)) in result[0]
+        assert ((0, 1), (0, 0)) in result[1]
+
+
+# ---------------------------------------------------------------------------
+# _has_collision with time_edges_blocked
+# ---------------------------------------------------------------------------
+
+
+class TestHasCollision:
+    """Direct unit tests for _has_collision with time_edges_blocked."""
+
+    def test_vertex_collision_detected(self) -> None:
+        """Vertex collision when destination is blocked at arrival time."""
+        time_blocked = {1: {(2, 2)}}
+        time_edges: dict[int, set[tuple[tuple[int, int], tuple[int, int]]]] = {}
+        assert _has_collision(2, 2, 1, 1, 0, 1, time_blocked, time_edges) is True
+
+    def test_no_collision_when_clear(self) -> None:
+        """No collision when destination is clear."""
+        time_blocked: dict[int, set[tuple[int, int]]] = {}
+        time_edges: dict[int, set[tuple[tuple[int, int], tuple[int, int]]]] = {}
+        assert _has_collision(2, 2, 1, 1, 0, 1, time_blocked, time_edges) is False
+
+    def test_edge_collision_detected(self) -> None:
+        """Edge (swap) collision detected when obstacle traverses reverse edge."""
+        time_blocked: dict[int, set[tuple[int, int]]] = {}
+        time_edges = {0: {((2, 2), (1, 1))}}
+        assert _has_collision(2, 2, 1, 1, 0, 1, time_blocked, time_edges) is True
+
+    def test_no_edge_collision_when_different_edge(self) -> None:
+        """No edge collision when obstacle traverses a different edge."""
+        time_blocked: dict[int, set[tuple[int, int]]] = {}
+        time_edges = {0: {((3, 3), (4, 4))}}
+        assert _has_collision(2, 2, 1, 1, 0, 1, time_blocked, time_edges) is False
+
+    def test_edge_collision_none_time_edges(self) -> None:
+        """No edge collision check when time_edges_blocked is None."""
+        time_blocked: dict[int, set[tuple[int, int]]] = {}
+        assert _has_collision(2, 2, 1, 1, 0, 1, time_blocked, None) is False
+
+    def test_vertex_collision_takes_precedence(self) -> None:
+        """Vertex collision is checked before edge collision."""
+        time_blocked = {1: {(2, 2)}}
+        time_edges = {0: {((2, 2), (1, 1))}}
+        assert _has_collision(2, 2, 1, 1, 0, 1, time_blocked, time_edges) is True
+
+    def test_edge_collision_at_different_time(self) -> None:
+        """Edge collision at different time step not detected."""
+        time_blocked: dict[int, set[tuple[int, int]]] = {}
+        time_edges = {1: {((2, 2), (1, 1))}}
+        assert _has_collision(2, 2, 1, 1, 0, 1, time_blocked, time_edges) is False
+
+
+# ---------------------------------------------------------------------------
+# SIPP time_edges_blocked propagation
+# ---------------------------------------------------------------------------
+
+
+class TestSippTimeEdgesBlockedPropagation:
+    """Tests for SIPP search with time_edges_blocked propagation."""
+
+    def test_sipp_with_edge_collision_avoids_swap(self) -> None:
+        """SIPP avoids swap collision when time_edges_blocked is provided."""
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        obstacles = [{"id": 0, "trajectory": [[1, 0], [0, 0]]}]
+        time_blocked = _build_time_blocked(obstacles)
+        time_edges = _build_time_edges_blocked(obstacles)
+
+        path = sipp_search(
+            grid, (0, 0), (1, 0), time_blocked, max_time=50, time_edges_blocked=time_edges
+        )
+        assert path is not None
+        # The direct swap move must be avoided
+        if len(path) >= 2:
+            assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
+                "SIPP allowed a swap collision with time_edges_blocked"
+            )
+
+    def test_sipp_with_two_obstacles_no_false_swap(self) -> None:
+        """Two independent obstacles must not cause a false swap block."""
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        obstacles = [
+            {"id": 0, "trajectory": [[0, 1], [1, 1]]},
+            {"id": 1, "trajectory": [[1, 0], [0, 0]]},
+        ]
+        time_blocked = _build_time_blocked(obstacles)
+        time_edges = _build_time_edges_blocked(obstacles)
+
+        path = sipp_search(
+            grid, (0, 0), (0, 2), time_blocked, max_time=50, time_edges_blocked=time_edges
+        )
+        assert path is not None
+        # Optimal direct path should be allowed
+        assert path == [(0, 0, 0), (0, 1, 1), (0, 2, 2)]
+
+    def test_sipp_with_stationary_obstacle_no_edge_collisions(self) -> None:
+        """Stationary obstacles produce no edges, only vertex collisions."""
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        obstacles = [{"id": 0, "trajectory": [[1, 1], [1, 1], [1, 1]]}]
+        time_blocked = _build_time_blocked(obstacles)
+        time_edges = _build_time_edges_blocked(obstacles)
+
+        path = sipp_search(
+            grid, (0, 0), (2, 2), time_blocked, max_time=50, time_edges_blocked=time_edges
+        )
+        assert path is not None
+        # Path must avoid (1,1) at all time steps
+        for r, c, t in path:
+            if t < 3:
+                assert (r, c) != (1, 1)
+
+    def test_sipp_edge_collision_with_wait(self) -> None:
+        """SIPP can wait to avoid a swap collision."""
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        # Obstacle moves (0,1)->(1,1) at t=0->t=1
+        # Robot wants (0,0)->(0,1) - no swap here
+        # Then obstacle moves (1,1)->(0,1) at t=1->t=2
+        # Robot wants (0,1)->(0,2) - no swap here either
+        obstacles = [{"id": 0, "trajectory": [[0, 1], [1, 1], [0, 1]]}]
+        time_blocked = _build_time_blocked(obstacles)
+        time_edges = _build_time_edges_blocked(obstacles)
+
+        path = sipp_search(
+            grid, (0, 0), (0, 2), time_blocked, max_time=50, time_edges_blocked=time_edges
+        )
+        assert path is not None
+        # Must avoid (0,1) at t=0 and t=2
+        for r, c, t in path:
+            if t == 0:
+                assert (r, c) != (0, 1)
+            if t == 2:
+                assert (r, c) != (0, 1)
+
+    def test_sipp_without_time_edges_uses_vertex_only(self) -> None:
+        """Without time_edges_blocked, SIPP uses vertex collision only."""
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        obstacles = [{"id": 0, "trajectory": [[0, 1], [1, 1]]}]
+        time_blocked = _build_time_blocked(obstacles)
+
+        # Without time_edges, swap detection is not possible
+        path = sipp_search(grid, (0, 0), (0, 2), time_blocked, max_time=50)
+        assert path is not None
+        # (0,1) is only blocked at t=0, so at t=1 it's free
+        assert path[0] == (0, 0, 0)
+        # The path should be able to use (0,1) at t=1
+
+    def test_sipp_multiple_edge_collisions_same_time(self) -> None:
+        """Multiple obstacles can produce multiple edges at same time step."""
+        grid = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+        obstacles = [
+            {"id": 0, "trajectory": [[1, 0], [0, 0]]},
+            {"id": 1, "trajectory": [[0, 1], [1, 1]]},
+        ]
+        time_blocked = _build_time_blocked(obstacles)
+        time_edges = _build_time_edges_blocked(obstacles)
+
+        # Robot at (0,0) wants to go to (2,2)
+        path = sipp_search(
+            grid, (0, 0), (2, 2), time_blocked, max_time=50, time_edges_blocked=time_edges
+        )
+        assert path is not None
+        # Must avoid swap with obstacle 0: (0,0)->(1,0) is a swap
+        if len(path) >= 2:
+            assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
+                "Swap with obstacle 0 not detected"
+            )
+
+
+# ---------------------------------------------------------------------------
+# CBS time_edges_blocked propagation
+# ---------------------------------------------------------------------------
+
+
+class TestCbsTimeEdgesBlockedPropagation:
+    """Tests for CBS search propagating time_edges_blocked to SIPP."""
+
+    def test_cbs_with_single_obstacle_swap(self) -> None:
+        """CBS avoids swap collision with a single moving obstacle."""
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        agents = [{"id": 0, "start": [0, 0], "goal": [2, 0]}]
+        obstacles = [{"id": 0, "trajectory": [[1, 0], [0, 0]]}]
+        time_blocked = _build_time_blocked(obstacles)
+        time_edges = _build_time_edges_blocked(obstacles)
+
+        result = cbs_search(grid, agents, time_blocked, max_time=50, time_edges_blocked=time_edges)
+        assert result is not None
+        path = result["solution"][0]
+        # The direct swap move must be avoided
+        if len(path) >= 2:
+            assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
+                "CBS allowed a swap collision with a dynamic obstacle"
+            )
+
+    def test_cbs_two_agents_with_obstacle_swap(self) -> None:
+        """CBS with two agents avoids dynamic obstacle swap collision."""
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        agents = [
+            {"id": 0, "start": [0, 0], "goal": [2, 0]},
+            {"id": 1, "start": [2, 0], "goal": [0, 0]},
+        ]
+        obstacles = [{"id": 0, "trajectory": [[1, 0], [1, 1]]}]
+        time_blocked = _build_time_blocked(obstacles)
+        time_edges = _build_time_edges_blocked(obstacles)
+
+        result = cbs_search(grid, agents, time_blocked, max_time=50, time_edges_blocked=time_edges)
+        assert result is not None
+        assert result["solution"][0][-1][:2] == (2, 0)
+        assert result["solution"][1][-1][:2] == (0, 0)
+
+    def test_cbs_two_independent_obstacles_no_false_swap(self) -> None:
+        """Two independent obstacles must not cause a false swap block."""
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        agents = [{"id": 0, "start": [0, 0], "goal": [0, 2]}]
+        obstacles = [
+            {"id": 0, "trajectory": [[0, 1], [1, 1]]},
+            {"id": 1, "trajectory": [[1, 0], [0, 0]]},
+        ]
+        time_blocked = _build_time_blocked(obstacles)
+        time_edges = _build_time_edges_blocked(obstacles)
+
+        result = cbs_search(grid, agents, time_blocked, max_time=50, time_edges_blocked=time_edges)
+        assert result is not None
+        path = result["solution"][0]
+        # Optimal direct path should be allowed
+        assert path == [(0, 0, 0), (0, 1, 1), (0, 2, 2)]
+
+    def test_cbs_with_stationary_obstacle(self) -> None:
+        """CBS with stationary obstacle uses vertex collision only."""
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        agents = [{"id": 0, "start": [0, 0], "goal": [2, 2]}]
+        obstacles = [{"id": 0, "trajectory": [[1, 1], [1, 1], [1, 1]]}]
+        time_blocked = _build_time_blocked(obstacles)
+        time_edges = _build_time_edges_blocked(obstacles)
+
+        result = cbs_search(grid, agents, time_blocked, max_time=50, time_edges_blocked=time_edges)
+        assert result is not None
+        path = result["solution"][0]
+        # Path must avoid (1,1) at all time steps
+        for r, c, t in path:
+            if t < 3:
+                assert (r, c) != (1, 1)
+
+    def test_cbs_without_time_edges_uses_vertex_only(self) -> None:
+        """Without time_edges_blocked, CBS uses vertex collision only."""
+        grid = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        agents = [{"id": 0, "start": [0, 0], "goal": [2, 0]}]
+        obstacles = [{"id": 0, "trajectory": [[1, 0], [0, 0]]}]
+        time_blocked = _build_time_blocked(obstacles)
+
+        # Without time_edges, swap detection is not possible
+        result = cbs_search(grid, agents, time_blocked, max_time=50)
+        assert result is not None
+        # The path may or may not avoid the swap - it's not detected without time_edges
+
+    def test_cbs_multiple_obstacles_with_edges(self) -> None:
+        """CBS with multiple obstacles and edge collisions."""
+        grid = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+        agents = [{"id": 0, "start": [0, 0], "goal": [3, 3]}]
+        obstacles = [
+            {"id": 0, "trajectory": [[1, 0], [0, 0]]},
+            {"id": 1, "trajectory": [[0, 1], [1, 1]]},
+        ]
+        time_blocked = _build_time_blocked(obstacles)
+        time_edges = _build_time_edges_blocked(obstacles)
+
+        result = cbs_search(grid, agents, time_blocked, max_time=50, time_edges_blocked=time_edges)
+        assert result is not None
+        path = result["solution"][0]
+        # Must avoid swap with obstacle 0
+        if len(path) >= 2:
+            assert not (path[0] == (0, 0, 0) and path[1] == (1, 0, 1)), (
+                "Swap with obstacle 0 not detected"
+            )
+
+    def test_cbs_three_agents_with_obstacle_edges(self) -> None:
+        """CBS with three agents and obstacle edge collisions."""
+        grid = [
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+        ]
+        agents = [
+            {"id": 0, "start": [0, 0], "goal": [0, 4]},
+            {"id": 1, "start": [2, 0], "goal": [2, 4]},
+            {"id": 2, "start": [4, 0], "goal": [4, 4]},
+        ]
+        obstacles = [{"id": 0, "trajectory": [[2, 2], [2, 3]]}]
+        time_blocked = _build_time_blocked(obstacles)
+        time_edges = _build_time_edges_blocked(obstacles)
+
+        result = cbs_search(grid, agents, time_blocked, max_time=50, time_edges_blocked=time_edges)
+        assert result is not None
+        # All agents should reach their goals
+        assert result["solution"][0][-1][:2] == (0, 4)
+        assert result["solution"][1][-1][:2] == (2, 4)
+        assert result["solution"][2][-1][:2] == (4, 4)

--- a/tests/scripts/tools/test_mapf_oracle_wave3.py
+++ b/tests/scripts/tools/test_mapf_oracle_wave3.py
@@ -7,10 +7,6 @@ changes.
 
 from __future__ import annotations
 
-import json
-import tempfile
-from pathlib import Path
-
 from scripts.tools.mapf_oracle_diagnostic import (
     _build_time_blocked,
     _build_time_edges_blocked,
@@ -18,39 +14,6 @@ from scripts.tools.mapf_oracle_diagnostic import (
     cbs_search,
     sipp_search,
 )
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_svg(width: float, height: float, rects: list[dict]) -> Path:
-    """Write a minimal SVG with obstacle rects and return the path."""
-    lines = [
-        f'<svg width="{width}" height="{height}" xmlns="http://www.w3.org/2000/svg">',
-    ]
-    for r in rects:
-        label = r.get("label", "")
-        attrs = f'x="{r["x"]}" y="{r["y"]}" width="{r["w"]}" height="{r["h"]}"'
-        if label:
-            attrs += f' inkscape:label="{label}"'
-        lines.append(f"  <rect {attrs} />")
-    lines.append("</svg>")
-
-    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".svg", delete=False, encoding="utf-8")
-    tmp.write("\n".join(lines))
-    tmp.close()
-    return Path(tmp.name)
-
-
-def _make_dynamic_obstacles_json(obstacles: list[dict]) -> Path:
-    """Write a dynamic obstacles JSON file and return the path."""
-    data = {"dynamic_obstacles": obstacles}
-    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8")
-    json.dump(data, tmp)
-    tmp.close()
-    return Path(tmp.name)
-
 
 # ---------------------------------------------------------------------------
 # _build_time_edges_blocked unit tests

--- a/tests/tools/test_run_camera_ready_benchmark_wave3.py
+++ b/tests/tools/test_run_camera_ready_benchmark_wave3.py
@@ -1,0 +1,599 @@
+"""Characterization wave 3 tests for scripts/tools/run_camera_ready_benchmark.py.
+
+Focuses on argument/manifest handling at dry-run level (preflight mode).
+NEW tests only, zero production changes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.tools import run_camera_ready_benchmark
+
+# ---------------------------------------------------------------------------
+# Parser argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    """Tests for _build_parser argument validation."""
+
+    def test_parser_requires_config(self) -> None:
+        """--config is required."""
+        parser = run_camera_ready_benchmark._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args([])
+
+    def test_parser_defaults(self) -> None:
+        """Parser defaults are correct."""
+        parser = run_camera_ready_benchmark._build_parser()
+        args = parser.parse_args(["--config", "test.yaml"])
+        assert args.config == Path("test.yaml")
+        assert args.output_root is None
+        assert args.label is None
+        assert args.campaign_id is None
+        assert args.skip_publication_bundle is False
+        assert args.mode == "run"
+        assert args.checkpoint_preflight_mode == "metadata_only"
+        assert args.checkpoint_cache_dir is None
+        assert args.checkpoint_registry_path is None
+        assert args.log_level == "INFO"
+        assert args.arm_isolation == "in_process"
+
+    def test_parser_mode_choices(self) -> None:
+        """--mode accepts only 'run' and 'preflight'."""
+        parser = run_camera_ready_benchmark._build_parser()
+        args = parser.parse_args(["--config", "test.yaml", "--mode", "preflight"])
+        assert args.mode == "preflight"
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--config", "test.yaml", "--mode", "invalid"])
+
+    def test_parser_checkpoint_preflight_mode_choices(self) -> None:
+        """--checkpoint-preflight-mode accepts only valid choices."""
+        parser = run_camera_ready_benchmark._build_parser()
+        args = parser.parse_args(
+            ["--config", "test.yaml", "--checkpoint-preflight-mode", "enforced_staged"]
+        )
+        assert args.checkpoint_preflight_mode == "enforced_staged"
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--config", "test.yaml", "--checkpoint-preflight-mode", "invalid"])
+
+    def test_parser_log_level_choices(self) -> None:
+        """--log-level accepts only valid choices."""
+        parser = run_camera_ready_benchmark._build_parser()
+        args = parser.parse_args(["--config", "test.yaml", "--log-level", "DEBUG"])
+        assert args.log_level == "DEBUG"
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--config", "test.yaml", "--log-level", "INVALID"])
+
+    def test_parser_arm_isolation_choices(self) -> None:
+        """--arm-isolation accepts only valid choices."""
+        parser = run_camera_ready_benchmark._build_parser()
+        args = parser.parse_args(["--config", "test.yaml", "--arm-isolation", "subprocess"])
+        assert args.arm_isolation == "subprocess"
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--config", "test.yaml", "--arm-isolation", "invalid"])
+
+    def test_parser_skip_publication_bundle_flag(self) -> None:
+        """--skip-publication-bundle flag is parsed correctly."""
+        parser = run_camera_ready_benchmark._build_parser()
+        args = parser.parse_args(["--config", "test.yaml", "--skip-publication-bundle"])
+        assert args.skip_publication_bundle is True
+
+    def test_parser_all_options(self) -> None:
+        """All options can be set simultaneously."""
+        parser = run_camera_ready_benchmark._build_parser()
+        args = parser.parse_args(
+            [
+                "--config",
+                "my_config.yaml",
+                "--output-root",
+                "/tmp/output",
+                "--label",
+                "test_label",
+                "--campaign-id",
+                "camp_123",
+                "--skip-publication-bundle",
+                "--mode",
+                "preflight",
+                "--checkpoint-preflight-mode",
+                "enforced_staged",
+                "--checkpoint-cache-dir",
+                "/tmp/cache",
+                "--checkpoint-registry-path",
+                "/tmp/registry",
+                "--log-level",
+                "WARNING",
+                "--arm-isolation",
+                "subprocess",
+            ]
+        )
+        assert args.config == Path("my_config.yaml")
+        assert args.output_root == Path("/tmp/output")
+        assert args.label == "test_label"
+        assert args.campaign_id == "camp_123"
+        assert args.skip_publication_bundle is True
+        assert args.mode == "preflight"
+        assert args.checkpoint_preflight_mode == "enforced_staged"
+        assert args.checkpoint_cache_dir == Path("/tmp/cache")
+        assert args.checkpoint_registry_path == Path("/tmp/registry")
+        assert args.log_level == "WARNING"
+        assert args.arm_isolation == "subprocess"
+
+
+# ---------------------------------------------------------------------------
+# Preflight manifest handling
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightManifestHandling:
+    """Tests for preflight manifest handling."""
+
+    def test_preflight_manifest_keys(self, tmp_path: Path, monkeypatch) -> None:
+        """Preflight mode returns all required manifest keys."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+
+        sentinel_cfg = object()
+
+        def _fake_load(path: Path):
+            return sentinel_cfg
+
+        def _fake_preflight(cfg, **kwargs):
+            return {
+                "campaign_id": "cid",
+                "campaign_root": tmp_path / "out",
+                "validate_config_path": tmp_path / "out" / "validate.json",
+                "preview_scenarios_path": tmp_path / "out" / "preview.json",
+                "matrix_summary_json_path": tmp_path / "out" / "summary.json",
+                "matrix_summary_csv_path": tmp_path / "out" / "summary.csv",
+                "amv_coverage_json_path": tmp_path / "out" / "amv.json",
+                "amv_coverage_md_path": tmp_path / "out" / "amv.md",
+                "comparability_json_path": tmp_path / "out" / "comp.json",
+                "comparability_md_path": tmp_path / "out" / "comp.md",
+            }
+
+        monkeypatch.setattr(run_camera_ready_benchmark, "load_campaign_config", _fake_load)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "prepare_campaign_preflight", _fake_preflight
+        )
+        monkeypatch.setattr(
+            run_camera_ready_benchmark,
+            "run_campaign",
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError("unreachable")),
+        )
+
+        rc = run_camera_ready_benchmark.main(["--config", str(config_path), "--mode", "preflight"])
+        assert rc == 0
+
+    def test_preflight_manifest_campaign_id_forwarded(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """Preflight forwards campaign_id to the preflight function."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+
+        sentinel_cfg = object()
+        received_kwargs: dict = {}
+
+        def _fake_load(path: Path):
+            return sentinel_cfg
+
+        def _fake_preflight(cfg, **kwargs):
+            received_kwargs.update(kwargs)
+            return {
+                "campaign_id": "cid",
+                "campaign_root": tmp_path / "out",
+                "validate_config_path": tmp_path / "out" / "v.json",
+                "preview_scenarios_path": tmp_path / "out" / "p.json",
+                "matrix_summary_json_path": tmp_path / "out" / "s.json",
+                "matrix_summary_csv_path": tmp_path / "out" / "s.csv",
+                "amv_coverage_json_path": tmp_path / "out" / "a.json",
+                "amv_coverage_md_path": tmp_path / "out" / "a.md",
+                "comparability_json_path": None,
+                "comparability_md_path": None,
+            }
+
+        monkeypatch.setattr(run_camera_ready_benchmark, "load_campaign_config", _fake_load)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "prepare_campaign_preflight", _fake_preflight
+        )
+        monkeypatch.setattr(
+            run_camera_ready_benchmark,
+            "run_campaign",
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError("unreachable")),
+        )
+
+        rc = run_camera_ready_benchmark.main(
+            [
+                "--config",
+                str(config_path),
+                "--mode",
+                "preflight",
+                "--campaign-id",
+                "my_campaign",
+            ]
+        )
+        assert rc == 0
+        assert received_kwargs.get("campaign_id") == "my_campaign"
+
+    def test_preflight_manifest_output_root_forwarded(self, tmp_path: Path, monkeypatch) -> None:
+        """Preflight forwards output_root to the preflight function."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+
+        sentinel_cfg = object()
+        received_kwargs: dict = {}
+
+        def _fake_load(path: Path):
+            return sentinel_cfg
+
+        def _fake_preflight(cfg, **kwargs):
+            received_kwargs.update(kwargs)
+            return {
+                "campaign_id": "cid",
+                "campaign_root": tmp_path / "out",
+                "validate_config_path": tmp_path / "out" / "v.json",
+                "preview_scenarios_path": tmp_path / "out" / "p.json",
+                "matrix_summary_json_path": tmp_path / "out" / "s.json",
+                "matrix_summary_csv_path": tmp_path / "out" / "s.csv",
+                "amv_coverage_json_path": tmp_path / "out" / "a.json",
+                "amv_coverage_md_path": tmp_path / "out" / "a.md",
+                "comparability_json_path": None,
+                "comparability_md_path": None,
+            }
+
+        monkeypatch.setattr(run_camera_ready_benchmark, "load_campaign_config", _fake_load)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "prepare_campaign_preflight", _fake_preflight
+        )
+        monkeypatch.setattr(
+            run_camera_ready_benchmark,
+            "run_campaign",
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError("unreachable")),
+        )
+
+        custom_root = tmp_path / "custom_output"
+        rc = run_camera_ready_benchmark.main(
+            [
+                "--config",
+                str(config_path),
+                "--mode",
+                "preflight",
+                "--output-root",
+                str(custom_root),
+            ]
+        )
+        assert rc == 0
+        assert received_kwargs.get("output_root") == custom_root
+
+    def test_preflight_manifest_label_forwarded(self, tmp_path: Path, monkeypatch) -> None:
+        """Preflight forwards label to the preflight function."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+
+        sentinel_cfg = object()
+        received_kwargs: dict = {}
+
+        def _fake_load(path: Path):
+            return sentinel_cfg
+
+        def _fake_preflight(cfg, **kwargs):
+            received_kwargs.update(kwargs)
+            return {
+                "campaign_id": "cid",
+                "campaign_root": tmp_path / "out",
+                "validate_config_path": tmp_path / "out" / "v.json",
+                "preview_scenarios_path": tmp_path / "out" / "p.json",
+                "matrix_summary_json_path": tmp_path / "out" / "s.json",
+                "matrix_summary_csv_path": tmp_path / "out" / "s.csv",
+                "amv_coverage_json_path": tmp_path / "out" / "a.json",
+                "amv_coverage_md_path": tmp_path / "out" / "a.md",
+                "comparability_json_path": None,
+                "comparability_md_path": None,
+            }
+
+        monkeypatch.setattr(run_camera_ready_benchmark, "load_campaign_config", _fake_load)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "prepare_campaign_preflight", _fake_preflight
+        )
+        monkeypatch.setattr(
+            run_camera_ready_benchmark,
+            "run_campaign",
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError("unreachable")),
+        )
+
+        rc = run_camera_ready_benchmark.main(
+            [
+                "--config",
+                str(config_path),
+                "--mode",
+                "preflight",
+                "--label",
+                "my_label",
+            ]
+        )
+        assert rc == 0
+        assert received_kwargs.get("label") == "my_label"
+
+    def test_preflight_manifest_checkpoint_options_forwarded(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Preflight forwards checkpoint options to the preflight function."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+
+        sentinel_cfg = object()
+        received_kwargs: dict = {}
+
+        def _fake_load(path: Path):
+            return sentinel_cfg
+
+        def _fake_preflight(cfg, **kwargs):
+            received_kwargs.update(kwargs)
+            return {
+                "campaign_id": "cid",
+                "campaign_root": tmp_path / "out",
+                "validate_config_path": tmp_path / "out" / "v.json",
+                "preview_scenarios_path": tmp_path / "out" / "p.json",
+                "matrix_summary_json_path": tmp_path / "out" / "s.json",
+                "matrix_summary_csv_path": tmp_path / "out" / "s.csv",
+                "amv_coverage_json_path": tmp_path / "out" / "a.json",
+                "amv_coverage_md_path": tmp_path / "out" / "a.md",
+                "comparability_json_path": None,
+                "comparability_md_path": None,
+            }
+
+        monkeypatch.setattr(run_camera_ready_benchmark, "load_campaign_config", _fake_load)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "prepare_campaign_preflight", _fake_preflight
+        )
+        monkeypatch.setattr(
+            run_camera_ready_benchmark,
+            "run_campaign",
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError("unreachable")),
+        )
+
+        rc = run_camera_ready_benchmark.main(
+            [
+                "--config",
+                str(config_path),
+                "--mode",
+                "preflight",
+                "--checkpoint-preflight-mode",
+                "enforced_staged",
+                "--checkpoint-cache-dir",
+                "/tmp/cache",
+                "--checkpoint-registry-path",
+                "/tmp/registry",
+            ]
+        )
+        assert rc == 0
+        assert received_kwargs.get("checkpoint_preflight_mode") == "enforced_staged"
+        assert received_kwargs.get("checkpoint_cache_dir") == Path("/tmp/cache")
+        assert received_kwargs.get("checkpoint_registry_path") == Path("/tmp/registry")
+
+    def test_preflight_manifest_comparability_fields_optional(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """Preflight handles None comparability fields gracefully."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+
+        sentinel_cfg = object()
+
+        def _fake_load(path: Path):
+            return sentinel_cfg
+
+        def _fake_preflight(cfg, **kwargs):
+            return {
+                "campaign_id": "cid",
+                "campaign_root": tmp_path / "out",
+                "validate_config_path": tmp_path / "out" / "v.json",
+                "preview_scenarios_path": tmp_path / "out" / "p.json",
+                "matrix_summary_json_path": tmp_path / "out" / "s.json",
+                "matrix_summary_csv_path": tmp_path / "out" / "s.csv",
+                "amv_coverage_json_path": tmp_path / "out" / "a.json",
+                "amv_coverage_md_path": tmp_path / "out" / "a.md",
+                "comparability_json_path": None,
+                "comparability_md_path": None,
+            }
+
+        monkeypatch.setattr(run_camera_ready_benchmark, "load_campaign_config", _fake_load)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "prepare_campaign_preflight", _fake_preflight
+        )
+        monkeypatch.setattr(
+            run_camera_ready_benchmark,
+            "run_campaign",
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError("unreachable")),
+        )
+
+        rc = run_camera_ready_benchmark.main(["--config", str(config_path), "--mode", "preflight"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["comparability_json"] is None
+        assert payload["comparability_md"] is None
+
+
+# ---------------------------------------------------------------------------
+# Run mode manifest handling
+# ---------------------------------------------------------------------------
+
+
+class TestRunModeManifestHandling:
+    """Tests for run mode manifest handling."""
+
+    def test_run_mode_forwards_all_options(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        """Run mode forwards all CLI options to run_campaign."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+
+        sentinel_cfg = object()
+        received_kwargs: dict = {}
+
+        def _fake_load(path: Path):
+            return sentinel_cfg
+
+        def _fake_run(cfg, **kwargs):
+            received_kwargs.update(kwargs)
+            return {
+                "campaign_id": "cid",
+                "campaign_root": str(tmp_path / "out"),
+                "benchmark_success": True,
+                "status": "benchmark_success",
+                "campaign_execution_status": "completed",
+                "evidence_status": "valid",
+                "row_status_summary": {
+                    "successful_evidence_rows": 1,
+                    "accepted_unavailable_rows": 0,
+                    "unexpected_failed_rows": 0,
+                    "fallback_or_degraded_rows": 0,
+                },
+                "status_reason": "all planner rows were benchmark-success",
+                "successful_runs": 1,
+                "accepted_unavailable_runs": 0,
+                "unexpected_failed_runs": 0,
+                "non_success_runs": 0,
+                "total_runs": 1,
+            }
+
+        monkeypatch.setattr(run_camera_ready_benchmark, "load_campaign_config", _fake_load)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "prepare_campaign_preflight", lambda *a, **kw: {}
+        )
+        monkeypatch.setattr(run_camera_ready_benchmark, "run_campaign", _fake_run)
+
+        rc = run_camera_ready_benchmark.main(
+            [
+                "--config",
+                str(config_path),
+                "--campaign-id",
+                "my_camp",
+                "--skip-publication-bundle",
+                "--arm-isolation",
+                "subprocess",
+            ]
+        )
+        assert rc == 0
+        assert received_kwargs.get("campaign_id") == "my_camp"
+        assert received_kwargs.get("skip_publication_bundle") is True
+        assert received_kwargs.get("arm_isolation") == "subprocess"
+
+    def test_run_mode_invoked_command_contains_args(self, tmp_path: Path, monkeypatch) -> None:
+        """Run mode constructs invoked_command from CLI arguments."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+
+        sentinel_cfg = object()
+        received_kwargs: dict = {}
+
+        def _fake_load(path: Path):
+            return sentinel_cfg
+
+        def _fake_run(cfg, **kwargs):
+            received_kwargs.update(kwargs)
+            return {
+                "campaign_id": "cid",
+                "campaign_root": str(tmp_path / "out"),
+                "benchmark_success": True,
+                "successful_runs": 1,
+                "non_success_runs": 0,
+                "total_runs": 1,
+            }
+
+        monkeypatch.setattr(run_camera_ready_benchmark, "load_campaign_config", _fake_load)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "prepare_campaign_preflight", lambda *a, **kw: {}
+        )
+        monkeypatch.setattr(run_camera_ready_benchmark, "run_campaign", _fake_run)
+
+        rc = run_camera_ready_benchmark.main(
+            [
+                "--config",
+                str(config_path),
+                "--campaign-id",
+                "test_camp",
+            ]
+        )
+        assert rc == 0
+        invoked = received_kwargs.get("invoked_command", "")
+        assert "test_camp" in invoked
+
+
+# ---------------------------------------------------------------------------
+# OrcaRvo2PreflightError handling
+# ---------------------------------------------------------------------------
+
+
+class TestOrcaPreflightErrorHandling:
+    """Tests for OrcaRvo2PreflightError handling in main."""
+
+    def test_orca_error_produces_structured_payload(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """OrcaRvo2PreflightError is caught and produces structured JSON."""
+        from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+
+        sentinel_cfg = object()
+
+        def _fake_load(path: Path):
+            return sentinel_cfg
+
+        def _fake_run(cfg, **kwargs):
+            raise OrcaRvo2PreflightError("rvo2 not installed")
+
+        monkeypatch.setattr(run_camera_ready_benchmark, "load_campaign_config", _fake_load)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "prepare_campaign_preflight", lambda *a, **kw: {}
+        )
+        monkeypatch.setattr(run_camera_ready_benchmark, "run_campaign", _fake_run)
+
+        rc = run_camera_ready_benchmark.main(["--config", str(config_path)])
+        assert rc == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "orca_preflight_failed"
+        assert payload["benchmark_success"] is False
+        assert payload["exit_code"] == 2
+        assert "rvo2 not installed" in payload["status_reason"]
+
+    def test_orca_error_in_preflight_mode(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        """OrcaRvo2PreflightError in preflight mode produces structured JSON."""
+        from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("name: test\n", encoding="utf-8")
+
+        sentinel_cfg = object()
+
+        def _fake_load(path: Path):
+            return sentinel_cfg
+
+        def _fake_preflight(cfg, **kwargs):
+            raise OrcaRvo2PreflightError("rvo2 not available")
+
+        monkeypatch.setattr(run_camera_ready_benchmark, "load_campaign_config", _fake_load)
+        monkeypatch.setattr(
+            run_camera_ready_benchmark, "prepare_campaign_preflight", _fake_preflight
+        )
+        monkeypatch.setattr(
+            run_camera_ready_benchmark,
+            "run_campaign",
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError("unreachable")),
+        )
+
+        rc = run_camera_ready_benchmark.main(["--config", str(config_path), "--mode", "preflight"])
+        assert rc == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["mode"] == "preflight"
+        assert payload["status"] == "orca_preflight_failed"

--- a/tests/tools/test_run_camera_ready_benchmark_wave3.py
+++ b/tests/tools/test_run_camera_ready_benchmark_wave3.py
@@ -136,7 +136,7 @@ class TestBuildParser:
 class TestPreflightManifestHandling:
     """Tests for preflight manifest handling."""
 
-    def test_preflight_manifest_keys(self, tmp_path: Path, monkeypatch) -> None:
+    def test_preflight_manifest_keys(self, tmp_path: Path, monkeypatch, capsys) -> None:
         """Preflight mode returns all required manifest keys."""
         config_path = tmp_path / "config.yaml"
         config_path.write_text("name: test\n", encoding="utf-8")
@@ -172,6 +172,23 @@ class TestPreflightManifestHandling:
 
         rc = run_camera_ready_benchmark.main(["--config", str(config_path), "--mode", "preflight"])
         assert rc == 0
+
+        # Verify the emitted manifest payload actually carries every required key
+        # (rc == 0 alone would pass even if main() dropped keys from the payload).
+        payload = json.loads(capsys.readouterr().out)
+        out = tmp_path / "out"
+        assert payload == {
+            "campaign_id": "cid",
+            "campaign_root": str(out),
+            "validate_config_path": str(out / "validate.json"),
+            "preview_scenarios_path": str(out / "preview.json"),
+            "matrix_summary_json": str(out / "summary.json"),
+            "matrix_summary_csv": str(out / "summary.csv"),
+            "amv_coverage_json": str(out / "amv.json"),
+            "amv_coverage_md": str(out / "amv.md"),
+            "comparability_json": str(out / "comp.json"),
+            "comparability_md": str(out / "comp.md"),
+        }
 
     def test_preflight_manifest_campaign_id_forwarded(
         self, tmp_path: Path, monkeypatch, capsys


### PR DESCRIPTION
## What

Characterization-test wave 3: behavior-lock the scripts/tools evidence-flow layer. NEW tests only, zero production changes.

### Tests added

1. **`tests/scripts/tools/test_mapf_oracle_wave3.py`** (29 tests) — behavior-lock `time_edges_blocked` propagation in CBS/SIPP paths:
   - Direct unit tests for `_build_time_edges_blocked` (9 tests: single/multi obstacle, stationary, empty, diagonal, reverse)
   - Direct unit tests for `_has_collision` with `time_edges_blocked` (7 tests: vertex/edge collision, precedence, time offset)
   - SIPP propagation tests (6 tests: swap avoidance, false-swap rejection, stationary, wait, vertex-only fallback, multiple edges)
   - CBS propagation tests (7 tests: single/two/three agents, swap, false-swap, stationary, vertex-only, multi-obstacle)

2. **`tests/tools/test_run_camera_ready_benchmark_wave3.py`** (18 tests) — argument/manifest handling at dry-run level:
   - Parser validation (8 tests: required, defaults, mode/checkpoint/arm-isolation/log-level choices, skip-publication-bundle, all-options)
   - Preflight manifest forwarding (6 tests: keys, campaign_id, output_root, label, checkpoint options, optional comparability)
   - Run mode manifest handling (2 tests: option forwarding, invoked_command)
   - OrcaRvo2PreflightError handling (2 tests: run mode, preflight mode)

3. **`tests/scripts/test_replay_episode_figure_wave3.py`** (22 tests) — argument contract:
   - `parse_args` validation (16 tests: required args, missing each required, all-required, defaults, format choices, tolerance/frame-steps/flags/options, all-options)
   - `main()` argument validation (6 tests: invalid output type, missing file, missing episode ID, invalid frame-steps, multiple output types, verbose mode)

## Why

Issue #4893 requests characterization tests for the scripts/tools evidence-flow layer. The existing test suite had good coverage for CBS/SIPP basics but lacked direct unit tests for `_build_time_edges_blocked` and `_has_collision`, and had no tests for the argument contract of `scripts/replay_episode_figure.py` or the manifest forwarding of `scripts/tools/run_camera_ready_benchmark.py`.

## Validation

============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0 -- /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-4893-20260708T230921Z/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-4893-20260708T230921Z
configfile: pyproject.toml
plugins: cov-7.0.0, timeout-2.4.0, split-0.11.0, xdist-3.8.0, anyio-4.12.1
collecting ... collected 69 items

tests/scripts/tools/test_mapf_oracle_wave3.py::TestBuildTimeEdgesBlocked::test_single_obstacle_single_edge PASSED [  1%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestBuildTimeEdgesBlocked::test_single_obstacle_multiple_edges PASSED [  2%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestBuildTimeEdgesBlocked::test_stationary_obstacle_produces_no_edges PASSED [  4%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestBuildTimeEdgesBlocked::test_multiple_obstacles_same_transition PASSED [  5%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestBuildTimeEdgesBlocked::test_multiple_obstacles_different_transitions PASSED [  7%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestBuildTimeEdgesBlocked::test_empty_obstacles PASSED [  8%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestBuildTimeEdgesBlocked::test_single_position_trajectory PASSED [ 10%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestBuildTimeEdgesBlocked::test_diagonal_movement PASSED [ 11%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestBuildTimeEdgesBlocked::test_reverse_path_edges PASSED [ 13%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestHasCollision::test_vertex_collision_detected PASSED [ 14%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestHasCollision::test_no_collision_when_clear PASSED [ 15%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestHasCollision::test_edge_collision_detected PASSED [ 17%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestHasCollision::test_no_edge_collision_when_different_edge PASSED [ 18%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestHasCollision::test_edge_collision_none_time_edges PASSED [ 20%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestHasCollision::test_vertex_collision_takes_precedence PASSED [ 21%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestHasCollision::test_edge_collision_at_different_time PASSED [ 23%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestSippTimeEdgesBlockedPropagation::test_sipp_with_edge_collision_avoids_swap PASSED [ 24%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestSippTimeEdgesBlockedPropagation::test_sipp_with_two_obstacles_no_false_swap PASSED [ 26%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestSippTimeEdgesBlockedPropagation::test_sipp_with_stationary_obstacle_no_edge_collisions PASSED [ 27%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestSippTimeEdgesBlockedPropagation::test_sipp_edge_collision_with_wait PASSED [ 28%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestSippTimeEdgesBlockedPropagation::test_sipp_without_time_edges_uses_vertex_only PASSED [ 30%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestSippTimeEdgesBlockedPropagation::test_sipp_multiple_edge_collisions_same_time PASSED [ 31%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestCbsTimeEdgesBlockedPropagation::test_cbs_with_single_obstacle_swap PASSED [ 33%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestCbsTimeEdgesBlockedPropagation::test_cbs_two_agents_with_obstacle_swap PASSED [ 34%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestCbsTimeEdgesBlockedPropagation::test_cbs_two_independent_obstacles_no_false_swap PASSED [ 36%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestCbsTimeEdgesBlockedPropagation::test_cbs_with_stationary_obstacle PASSED [ 37%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestCbsTimeEdgesBlockedPropagation::test_cbs_without_time_edges_uses_vertex_only PASSED [ 39%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestCbsTimeEdgesBlockedPropagation::test_cbs_multiple_obstacles_with_edges PASSED [ 40%]
tests/scripts/tools/test_mapf_oracle_wave3.py::TestCbsTimeEdgesBlockedPropagation::test_cbs_three_agents_with_obstacle_edges PASSED [ 42%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestBuildParser::test_parser_requires_config PASSED [ 43%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestBuildParser::test_parser_defaults PASSED [ 44%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestBuildParser::test_parser_mode_choices PASSED [ 46%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestBuildParser::test_parser_checkpoint_preflight_mode_choices PASSED [ 47%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestBuildParser::test_parser_log_level_choices PASSED [ 49%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestBuildParser::test_parser_arm_isolation_choices PASSED [ 50%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestBuildParser::test_parser_skip_publication_bundle_flag PASSED [ 52%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestBuildParser::test_parser_all_options PASSED [ 53%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestPreflightManifestHandling::test_preflight_manifest_keys PASSED [ 55%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestPreflightManifestHandling::test_preflight_manifest_campaign_id_forwarded PASSED [ 56%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestPreflightManifestHandling::test_preflight_manifest_output_root_forwarded PASSED [ 57%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestPreflightManifestHandling::test_preflight_manifest_label_forwarded PASSED [ 59%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestPreflightManifestHandling::test_preflight_manifest_checkpoint_options_forwarded PASSED [ 60%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestPreflightManifestHandling::test_preflight_manifest_comparability_fields_optional PASSED [ 62%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestRunModeManifestHandling::test_run_mode_forwards_all_options PASSED [ 63%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestRunModeManifestHandling::test_run_mode_invoked_command_contains_args PASSED [ 65%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestOrcaPreflightErrorHandling::test_orca_error_produces_structured_payload PASSED [ 66%]
tests/tools/test_run_camera_ready_benchmark_wave3.py::TestOrcaPreflightErrorHandling::test_orca_error_in_preflight_mode PASSED [ 68%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_required_args PASSED [ 69%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_missing_episodes PASSED [ 71%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_missing_episode_id PASSED [ 72%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_missing_outputs PASSED [ 73%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_missing_out_dir PASSED [ 75%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_all_required_args PASSED [ 76%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_defaults PASSED [ 78%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_format_choices PASSED [ 79%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_tolerance_m_option PASSED [ 81%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_frame_steps_option PASSED [ 82%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_no_determinism_check_flag PASSED [ 84%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_verbose_flag PASSED [ 85%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_campaign_root_option PASSED [ 86%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_scenario_matrix_option PASSED [ 88%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_config_hash_option PASSED [ 89%]
tests/scripts/test_replay_episode_figure_wave3.py::TestParseArgs::test_all_options PASSED [ 91%]
tests/scripts/test_replay_episode_figure_wave3.py::TestMainArgumentValidation::test_invalid_output_type PASSED [ 92%]
tests/scripts/test_replay_episode_figure_wave3.py::TestMainArgumentValidation::test_missing_episodes_file PASSED [ 94%]
tests/scripts/test_replay_episode_figure_wave3.py::TestMainArgumentValidation::test_missing_episode_id_in_file PASSED [ 95%]
tests/scripts/test_replay_episode_figure_wave3.py::TestMainArgumentValidation::test_invalid_frame_steps_format PASSED [ 97%]
tests/scripts/test_replay_episode_figure_wave3.py::TestMainArgumentValidation::test_multiple_output_types PASSED [ 98%]
tests/scripts/test_replay_episode_figure_wave3.py::TestMainArgumentValidation::test_verbose_mode PASSED [100%]

============================= slowest 10 durations =============================
0.17s call     tests/scripts/test_replay_episode_figure_wave3.py::TestMainArgumentValidation::test_multiple_output_types
0.09s call     tests/scripts/test_replay_episode_figure_wave3.py::TestMainArgumentValidation::test_verbose_mode

(8 durations < 0.005s hidden.  Use -vv to show these durations.)

Slow Test Report (soft<20s hard=60s, top 10)
1) tests/scripts/test_replay_episode_figure_wave3.py::TestMainArgumentValidation::test_multiple_output_types  0.17s
2) tests/scripts/test_replay_episode_figure_wave3.py::TestMainArgumentValidation::test_verbose_mode  0.09s
3) tests/tools/test_run_camera_ready_benchmark_wave3.py::TestPreflightManifestHandling::test_preflight_manifest_comparability_fields_optional  0.00s
4) tests/tools/test_run_camera_ready_benchmark_wave3.py::TestPreflightManifestHandling::test_preflight_manifest_keys  0.00s
5) tests/scripts/test_replay_episode_figure_wave3.py::TestMainArgumentValidation::test_invalid_frame_steps_format  0.00s
6) tests/tools/test_run_camera_ready_benchmark_wave3.py::TestPreflightManifestHandling::test_preflight_manifest_campaign_id_forwarded  0.00s
7) tests/tools/test_run_camera_ready_benchmark_wave3.py::TestPreflightManifestHandling::test_preflight_manifest_checkpoint_options_forwarded  0.00s
8) tests/tools/test_run_camera_ready_benchmark_wave3.py::TestRunModeManifestHandling::test_run_mode_forwards_all_options  0.00s
9) tests/tools/test_run_camera_ready_benchmark_wave3.py::TestOrcaPreflightErrorHandling::test_orca_error_in_preflight_mode  0.00s
10) tests/tools/test_run_camera_ready_benchmark_wave3.py::TestPreflightManifestHandling::test_preflight_manifest_output_root_forwarded  0.00s

============================== 69 passed in 1.30s ==============================
All checks passed!

## Successor statement

This PR fully resolves issue #4893. All three target scripts are covered by the new characterization tests.

Closes #4893

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broader CLI and behavior coverage for episode replay, mapf oracle diagnostics, and camera-ready benchmark tooling.
  * Verified argument parsing defaults, allowed options, and error handling for invalid or missing inputs.
  * Added coverage for time-aware collision and path-blocking behavior in routing scenarios.
  * Confirmed dry-run and run-mode handling, including structured error responses and command forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
