### PR TITLE
Issue #4895: SNQI git_sha provenance always 'unknown' — invalid capture_output+stderr subprocess combination (cheap-lane worker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **issue #4895 SNQI weights `git_sha` provenance always recorded as `"unknown"`.** The
+  `recompute_snqi_weights` SHA lookup passed BOTH `capture_output=True` and `stderr=DEVNULL` to
+  `subprocess.run` — an invalid combination that raises `ValueError` at call time, which the
+  provenance handler swallowed, so every weight config produced via the recompute path silently
+  recorded `git_sha: "unknown"` even inside a real git checkout. Removed the incompatible
+  `stderr=DEVNULL` (`capture_output=True` already captures stderr); the output contract is preserved
+  (real short SHA when git is available, `"unknown"` only on genuine failure such as no repo/timeout).
+  Regression tests pin both the in-repo resolution and the out-of-repo fallback, plus a static guard
+  against reintroducing the invalid argument combination.
 * **issue #4873 user-facing docs drift audit — corrected stale claims against current code (docs-only).**
   Verified `README.md` and `docs/*.md` top-level docs against the current codebase and fixed incorrect
   statements in place across 13 files: renamed module path `robot_sf/sim/FastPysfWrapper.py` →

--- a/robot_sf/benchmark/snqi/compute.py
+++ b/robot_sf/benchmark/snqi/compute.py
@@ -30,7 +30,7 @@ import hashlib
 import json
 from collections.abc import Mapping
 from datetime import datetime
-from subprocess import DEVNULL, run
+from subprocess import run
 
 from robot_sf.benchmark.snqi.types import SNQIWeights
 
@@ -264,14 +264,17 @@ def recompute_snqi_weights(
         msg = f"Unknown weight computation method: {method}"
         raise ValueError(msg)
 
-    # Get git SHA for provenance
+    # Get git SHA for provenance. NOTE: ``capture_output=True`` is equivalent to
+    # ``stdout=PIPE, stderr=PIPE``, so also passing ``stderr=DEVNULL`` is an
+    # invalid combination that always raises ``ValueError`` (swallowed by the
+    # handler below) -- which silently degraded ``git_sha`` to ``"unknown"`` for
+    # every recorded weight config (issue #4895). Do not reintroduce it.
     try:
         result = run(
             ["git", "rev-parse", "HEAD"],
             capture_output=True,
             text=True,
             check=False,
-            stderr=DEVNULL,
         )
         git_sha = result.stdout.strip()[:8] if result.returncode == 0 else "unknown"
     except Exception:

--- a/tests/unit/test_snqi_weights_git_sha_provenance.py
+++ b/tests/unit/test_snqi_weights_git_sha_provenance.py
@@ -1,0 +1,125 @@
+"""Regression tests for SNQI weights ``git_sha`` provenance (issue #4895).
+
+``recompute_snqi_weights`` looked up the repo SHA via ``subprocess.run`` with
+BOTH ``capture_output=True`` AND ``stderr=DEVNULL`` -- an invalid combination
+that always raises ``ValueError``. The handler swallowed it, so ``git_sha`` was
+silently degraded to ``"unknown"`` for *every* recorded weight config, even in a
+real git checkout. These tests pin the output contract:
+
+* the real short SHA is recorded when git is available inside a repo, and
+* the field falls back cleanly to ``"unknown"`` outside any repo.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.snqi.compute import recompute_snqi_weights
+
+_BASELINE_STATS = {"collisions": {"median": 0.5, "p95": 2.0}}
+
+
+def _git_available() -> bool:
+    """Whether a usable ``git`` executable is on PATH."""
+    return subprocess.run(["git", "--version"], capture_output=True, check=False).returncode == 0
+
+
+def test_git_sha_resolves_in_a_git_checkout(monkeypatch, tmp_path):
+    """Inside a real git repo, ``git_sha`` must be the actual short SHA.
+
+    Previously this returned ``"unknown"`` because the subprocess call raised
+    ``ValueError`` (capture_output + stderr=DEVNULL) and the handler swallowed it.
+    """
+    if not _git_available():
+        pytest.skip("git executable not available")
+
+    # Build a throwaway repo with at least one commit so rev-parse resolves.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.example"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=repo, check=True, capture_output=True
+    )
+    (repo / "README").write_text("init\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+
+    expected = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout.strip()[:8]
+
+    # Run the lookup from inside the repo so ``git rev-parse`` resolves to it.
+    monkeypatch.chdir(repo)
+    weights = recompute_snqi_weights(baseline_stats=_BASELINE_STATS, method="canonical", seed=42)
+
+    assert weights.git_sha == expected
+    assert weights.git_sha != "unknown"
+    assert len(weights.git_sha) == 8  # short SHA width
+
+
+def test_git_sha_falls_back_to_unknown_outside_a_repo(monkeypatch, tmp_path):
+    """In a directory that is not a git repo, fall back cleanly to ``"unknown"``.
+
+    This must not raise: genuine failure (no repo) yields ``"unknown"`` per the
+    output contract.
+    """
+    if not _git_available():
+        pytest.skip("git executable not available")
+
+    non_repo = tmp_path / "not-a-repo"
+    non_repo.mkdir()
+    # Sanity check: this tmpdir is genuinely outside any git repo.
+    assert (
+        subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=non_repo,
+            capture_output=True,
+            check=False,
+        ).returncode
+        != 0
+    )
+
+    monkeypatch.chdir(non_repo)
+    weights = recompute_snqi_weights(baseline_stats=_BASELINE_STATS, method="canonical", seed=42)
+
+    assert weights.git_sha == "unknown"
+
+
+def test_git_sha_lookup_never_uses_invalid_capture_stderr_combo():
+    """Guard against regressing the invalid subprocess argument combination.
+
+    ``capture_output=True`` sets ``stderr=PIPE``; passing ``stderr=DEVNULL`` (or
+    any explicit ``stderr``) at the same time raises ``ValueError`` at call time.
+    This static check ensures the source no longer combines them.
+    """
+    source = (
+        Path(__file__).resolve().parents[2] / "robot_sf" / "benchmark" / "snqi" / "compute.py"
+    ).read_text(encoding="utf-8")
+
+    # Find the git rev-parse lookup block and assert it does not pass stderr=
+    # alongside capture_output=True. We scope to the provenance block so an
+    # unrelated stderr= elsewhere cannot mask the regression.
+    marker = '["git", "rev-parse", "HEAD"]'
+    assert marker in source, "git rev-parse provenance lookup moved or removed"
+    start = source.index(marker)
+    # The call spans from the argv list to the closing paren of run(...).
+    end = source.index(")", start)
+    block = source[start:end]
+    assert "capture_output=True" in block
+    assert "stderr=" not in block, (
+        "git_sha provenance lookup must not pass stderr= together with "
+        "capture_output=True (issue #4895)"
+    )


### PR DESCRIPTION
## What & why

Fixes issue #4895: `recompute_snqi_weights` recorded `git_sha: "unknown"` for **every** SNQI weight config — even inside a real git checkout.

**Root cause.** The provenance lookup called `subprocess.run` with BOTH `capture_output=True` AND `stderr=DEVNULL`:

```python
result = run(
    ["git", "rev-parse", "HEAD"],
    capture_output=True,
    text=True,
    check=False,
    stderr=DEVNULL,   # <-- invalid combo
)
```

`capture_output=True` is equivalent to `stdout=PIPE, stderr=PIPE`, so also passing `stderr=DEVNULL` raises `ValueError("stdout and stderr arguments may not be used with capture_output.")` **at call time**. The surrounding `except Exception:` handler swallowed it, so `git_sha` always fell through to `"unknown"`. The defect was latent and masked until #4887's broad-except work drew attention to the block.

## Fix

Removed the incompatible `stderr=DEVNULL` (`capture_output=True` already captures stderr) and the now-unused `DEVNULL` import. Added an inline comment documenting why the combination must not be reintroduced. **Output contract preserved**: real short SHA when git is available, `"unknown"` only on genuine failure (no repo, timeout).

Surface: `robot_sf/benchmark/snqi/compute.py` only (`recompute_snqi_weights`).

## Validation (CPU-level only)

**Reproduce → confirm fix (real git checkout, this worktree HEAD `bb59e8b51`):**

| | before | after |
| --- | --- | --- |
| `git_sha` | `'unknown'` | `'bb59e8b5'` |

**New regression suite** (`tests/unit/test_snqi_weights_git_sha_provenance.py`, 3 tests):
- `test_git_sha_resolves_in_a_git_checkout` — builds a throwaway repo, asserts `git_sha` equals the actual short SHA (not `"unknown"`, length 8).
- `test_git_sha_falls_back_to_unknown_outside_a_repo` — `chdir` into a non-repo tmpdir, asserts clean `"unknown"` fallback, no raise.
- `test_git_sha_lookup_never_uses_invalid_capture_stderr_combo` — static source guard: within the provenance call block, `capture_output=True` and `stderr=` must not co-occur.

```
tests/unit/test_snqi_weights_git_sha_provenance.py ....   (3 passed)
+ recompute_determinism + snqi_weights + weights_load_validation  → 28 passed
ruff check + format: clean
AI config drift (sync_ai_config.py --check): 7 symlinks validated
```

**Repo-wide scan:** no sibling occurrences of the invalid `capture_output=True` + `stderr=` combination remain (only the explanatory comment/docstrings match).

## Blast radius (assessed, per issue; no retroactive rewriting)

`git_sha` is written into `SNQIWeights.to_dict()` → saved weight-config JSON via the recompute path (`robot_sf/benchmark/snqi/cli.py: recompute_snqi_weights(...).save(...)`). Assessment of committed artifacts:

- **No committed evidence artifact carries the field at all.** `git grep "git_sha"` over `docs/context/evidence/**` returns nothing.
- **Committed SNQI weight configs do not carry `git_sha`.** `configs/benchmarks/snqi_weights_camera_ready_v{1,2,3}.json`, `model/snqi_canonical_weights_v1.json`, and the `issue_3810`/`issue_3978` evidence fixtures have no `git_sha` key (hand-authored / different generation path), so nothing committed needs rewriting.

Conclusion: the degraded value only ever affected **runtime-generated** weight configs from the recompute path. Per the issue's instruction, no retroactive rewriting of evidence artifacts is performed.

## Observed but out of scope

While validating, `tests/benchmark/test_aggregate_snqi_recompute.py::test_compute_aggregates_logs_{key_error,unexpected}_snqi_failure_in_diagnostic_mode` fail — but they fail **identically on pristine `origin/main`** (verified by stashing this change and re-running). They are a separate defect surfaced by #4887's broad-except narrowing (`AttributeError`/`KeyError` from the monkeypatched `snqi_fn` no longer caught/logged in `aggregate._ensure_snqi`), unrelated to the `git_sha` provenance path this PR fixes. Noting for transparency; not addressed here.

## CHANGELOG

Added a `### Fixed` entry under `[Unreleased]`.

Closes #4895.

---

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation
lane; the review gate hardens and merges.
