### PR TITLE
Issue #4894: branch-coverage report + phased threshold proposal (cheap-lane worker)

### DIFF
--- a/docs/dev/branch_coverage_analysis.md
+++ b/docs/dev/branch_coverage_analysis.md
@@ -1,0 +1,119 @@
+# Branch-Coverage Threshold Analysis Report
+
+**Date**: 2026-07-09
+**Method**: CPU-only pytest with `--cov-branch` on `robot_sf` and `pysocialforce`.
+**Report script**: `scripts/dev/branch_coverage_report.py`
+**Coverage data**: `output/coverage/coverage.json` (worktree-local, not committed)
+
+## Overall
+
+| Metric | Value |
+|---|---|
+| Branch coverage | 7.3% (2,418 / 33,248) |
+| Line coverage | 24.5% (30,219 / 99,716) |
+| robot_sf files tested | 654 |
+| Files with 0% branch coverage | 462 (70.6%) |
+| Test files skipped (missing optional deps) | 57 |
+
+**Context caveat**: 57 test files could not collect (missing `torch`, `stable-baselines3`, `optuna`, `duckdb`, `pyarrow`). Modules exercised only by those tests report 0% branch coverage even though they may have tests in CI. This report reflects the CPU-only subset only.
+
+## Per-Package Branch Coverage
+
+| Package | Branch % | Covered | Total |
+|---|---|---|---|
+| robot_sf/sim | 63.5% | 216 | 340 |
+| robot_sf/examples | 57.7% | 60 | 104 |
+| robot_sf/common | 47.3% | 53 | 112 |
+| robot_sf/sensor | 28.0% | 80 | 286 |
+| robot_sf/robot | 27.2% | 25 | 92 |
+| robot_sf/ped_npc | 26.6% | 82 | 308 |
+| robot_sf/gym_env | 33.3% | 284 | 852 |
+| robot_sf/research | 15.7% | 111 | 708 |
+| robot_sf/nav | 14.7% | 213 | 1,450 |
+| robot_sf/baselines | 10.5% | 62 | 592 |
+| robot_sf/benchmark | 5.9% | 984 | 16,634 |
+| robot_sf/training | 6.7% | 170 | 2,534 |
+| robot_sf/prediction | 5.0% | 3 | 60 |
+| robot_sf/render | 1.5% | 12 | 782 |
+| robot_sf/planner | 0.9% | 36 | 3,938 |
+| robot_sf/adversarial | 0.1% | 1 | 1,042 |
+| robot_sf/analysis | 0.0% | 0 | 140 |
+| robot_sf/analysis_workbench | 0.0% | 0 | 454 |
+| robot_sf/scenario_certification | 0.0% | 0 | 744 |
+| robot_sf/telemetry | 0.0% | 0 | 392 |
+| robot_sf/maps | 0.0% | 0 | 556 |
+| robot_sf/manual_control | 0.0% | 0 | 248 |
+| robot_sf/feature_extractors | 0.0% | 0 | 118 |
+| robot_sf/models | 0.0% | 0 | 124 |
+
+## 10 Worst-Covered Evidence-Critical Modules
+
+These modules are in packages that produce or validate benchmark, planner, or
+scenario-certification evidence. All have 0% branch coverage in the CPU-only
+run (57 test collection errors due to missing optional dependencies).
+
+| # | Module | Branches | Lines |
+|---|---|---|---|
+| 1 | `robot_sf/planner/socnav.py` | 0/674 | 381/2,274 |
+| 2 | `robot_sf/planner/hybrid_rule_local_planner.py` | 0/430 | 241/1,261 |
+| 3 | `robot_sf/benchmark/map_runner.py` | 0/362 | 188/1,030 |
+| 4 | `robot_sf/scenario_certification/perturbation_preflight.py` | 0/302 | 106/728 |
+| 5 | `robot_sf/benchmark/map_runner_episode.py` | 0/300 | 112/797 |
+| 6 | `robot_sf/analysis_workbench/trace_failure_predicates.py` | 0/294 | 113/667 |
+| 7 | `robot_sf/benchmark/camera_ready/_config.py` | 0/244 | 37/431 |
+| 8 | `robot_sf/benchmark/artifact_publication.py` | 0/228 | 96/557 |
+| 9 | `robot_sf/benchmark/live_forecast_replay_gate.py` | 0/196 | 82/485 |
+| 10 | `robot_sf/benchmark/snqi_scalarization_sensitivity.py` | 0/190 | 87/485 |
+
+## Proposed Phased Threshold Schedule
+
+### Phase 1 — Measure-only (current)
+
+No threshold enforcement. Goal: establish a reproducible baseline and identify
+blind spots. This report serves as the Phase 1 deliverable.
+
+### Phase 2 — Floor at current baseline (~7%)
+
+- Enforce: `--cov-fail-under=7` on the CPU test subset.
+- Prevents regressions on already-tested code paths.
+- **Target**: Q3 2026, after optional-dep tests are integrated into CPU CI.
+
+### Phase 3 — Raise to 35%
+
+- Focus on the 10 worst evidence-critical modules above.
+- Priority: `benchmark/map_runner.py`, `planner/socnav.py`, `scenario_certification/perturbation_preflight.py`.
+- **Target**: Q4 2026.
+
+### Phase 4 — Raise to 50%
+
+- Requires branch-coverage tests for planner, benchmark, and scenario_certification.
+- Address the 462 robot_sf files with 0% branch coverage.
+- **Target**: Q1 2027.
+
+### Phase 5 — Target 70%+ (evidence-critical only)
+
+- Enforce per-package thresholds on evidence-critical packages only.
+- Non-evidence packages (render, manual_control, telemetry) excluded.
+- **Target**: Q2 2027.
+
+## Recommended Immediate Actions
+
+1. Add `--cov-fail-under=25` to the CPU test runner to lock the baseline
+   (after optional-dep tests are integrated).
+2. Open follow-up issues for the 10 worst evidence-critical modules.
+3. Integrate optional-dep tests into CPU CI with `--ignore` guards for
+   GPU-only tests.
+
+## Reproduction
+
+```bash
+# In any fresh worktree:
+uv sync --all-extras
+DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests fast-pysf/tests \
+    -m "not slow" --cov=robot_sf --cov=pysocialforce --cov-branch \
+    --cov-report=json:output/coverage/coverage.json \
+    --cov-report=term-missing -q --continue-on-collection-errors
+
+# Generate the report:
+uv run python scripts/dev/branch_coverage_report.py
+```

--- a/docs/dev/branch_coverage_analysis.md
+++ b/docs/dev/branch_coverage_analysis.md
@@ -98,8 +98,9 @@ blind spots. This report serves as the Phase 1 deliverable.
 
 ## Recommended Immediate Actions
 
-1. Add `--cov-fail-under=25` to the CPU test runner to lock the baseline
-   (after optional-dep tests are integrated).
+1. Add `--cov-fail-under=7` to the CPU test runner to lock the baseline
+   (matches the Phase 2 floor; must stay at or below the ~7.3% baseline or CI
+   fails immediately — so 7, not 25).
 2. Open follow-up issues for the 10 worst evidence-critical modules.
 3. Integrate optional-dep tests into CPU CI with `--ignore` guards for
    GPU-only tests.

--- a/scripts/dev/branch_coverage_report.py
+++ b/scripts/dev/branch_coverage_report.py
@@ -177,7 +177,9 @@ subset.
 - Target: Q2 2027.
 
 ### Recommended immediate actions
-1. Add ``--cov-fail-under=25`` to the CPU test runner to lock the baseline.
+1. Add ``--cov-fail-under={int(current_pct)}`` to the CPU test runner to lock the
+   baseline (must match the Phase 2 floor; a value above the current {current_pct:.1f}%
+   baseline would fail CI immediately).
 2. Open follow-up issues for the 10 worst evidence-critical modules.
 3. Integrate optional-dep tests into CPU CI with ``--ignore`` guards for GPU-only tests.
 """

--- a/scripts/dev/branch_coverage_report.py
+++ b/scripts/dev/branch_coverage_report.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Branch-coverage threshold analysis report.
+
+Reads a coverage.json produced by ``pytest --cov-branch --cov-report=json``
+and prints:
+
+* Overall branch-coverage summary
+* Per-package (``robot_sf/<pkg>``) branch-coverage table
+* The 10 worst-covered evidence-critical modules
+* A proposed phased threshold schedule
+
+Usage::
+
+    uv run python scripts/dev/branch_coverage_report.py [--json path/to/coverage.json]
+
+Default ``--json`` is ``output/coverage/coverage.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+EVIDENCE_CRITICAL_PREFIXES: list[str] = [
+    "robot_sf/benchmark/",
+    "robot_sf/scenario_certification/",
+    "robot_sf/analysis/",
+    "robot_sf/analysis_workbench/",
+    "robot_sf/coverage_tools/",
+    "robot_sf/research/",
+    "robot_sf/planner/",
+    "robot_sf/sensor/",
+    "robot_sf/gym_env/",
+    "robot_sf/nav/",
+]
+
+
+def _branch_pct(summary: dict[str, int]) -> float:
+    covered = summary.get("covered_branches", 0)
+    total = covered + summary.get("missing_branches", 0)
+    return (covered / total * 100) if total > 0 else 100.0
+
+
+def load_coverage(path: Path) -> dict:
+    """Load coverage.json from disk."""
+    with path.open() as f:
+        return json.load(f)
+
+
+def overall_summary(data: dict) -> str:
+    """Return overall branch-coverage summary line."""
+    t = data["totals"]
+    total_b = t["covered_branches"] + t["missing_branches"]
+    pct = t["covered_branches"] / total_b * 100 if total_b > 0 else 100.0
+    lines = (
+        f"Overall branch coverage: {pct:.1f}%  "
+        f"({t['covered_branches']}/{total_b} branches)\n"
+        f"Line coverage: {t['covered_lines']}/{t['covered_lines'] + t['missing_lines']} "
+        f"({t['percent_covered']:.1f}%)"
+    )
+    return lines
+
+
+def per_package_table(data: dict) -> str:
+    """Return Markdown table of per-package branch coverage."""
+    pkg_stats: dict[str, dict[str, int]] = defaultdict(lambda: {"covered": 0, "missing": 0})
+    for fpath, info in data["files"].items():
+        if not fpath.startswith("robot_sf/"):
+            continue
+        parts = fpath.split("/")
+        if len(parts) >= 3 and not parts[1].endswith(".py"):
+            pkg = "/".join(parts[:2])
+        elif len(parts) >= 2:
+            pkg = "robot_sf/_root"
+        else:
+            pkg = "robot_sf/_root"
+        s = info["summary"]
+        pkg_stats[pkg]["covered"] += s.get("covered_branches", 0)
+        pkg_stats[pkg]["missing"] += s.get("missing_branches", 0)
+
+    rows: list[tuple[str, float, int, int]] = []
+    for pkg, s in sorted(pkg_stats.items()):
+        total = s["covered"] + s["missing"]
+        pct = s["covered"] / total * 100 if total > 0 else 100.0
+        rows.append((pkg, pct, s["covered"], total))
+
+    lines = ["| Package | Branch % | Covered | Total |", "|---|---|---|---|"]
+    for pkg, pct, cov, total in rows:
+        lines.append(f"| {pkg} | {pct:.1f}% | {cov} | {total} |")
+    return "\n".join(lines)
+
+
+def worst_evidence_critical(data: dict, n: int = 10) -> str:
+    """Return Markdown table of the n worst-covered evidence-critical modules."""
+    rows: list[tuple[str, float, int, int, int, int]] = []
+    for fpath, info in data["files"].items():
+        if not fpath.startswith("robot_sf/"):
+            continue
+        is_ec = any(fpath.startswith(p) for p in EVIDENCE_CRITICAL_PREFIXES)
+        if not is_ec:
+            continue
+        s = info["summary"]
+        total_b = s.get("covered_branches", 0) + s.get("missing_branches", 0)
+        pct = _branch_pct(s)
+        rows.append(
+            (
+                fpath,
+                pct,
+                s.get("covered_branches", 0),
+                total_b,
+                s["covered_lines"],
+                s["covered_lines"] + s["missing_lines"],
+            )
+        )
+
+    rows.sort(key=lambda r: (r[1], -r[3]))
+    lines = [
+        "| # | Module | Branch % | Branches | Lines |",
+        "|---|---|---|---|---|",
+    ]
+    for i, (path, pct, bc, bt, lc, lt) in enumerate(rows[:n], 1):
+        lines.append(f"| {i} | {path} | {pct:.1f}% | {bc}/{bt} | {lc}/{lt} |")
+    return "\n".join(lines)
+
+
+def threshold_proposal(data: dict) -> str:
+    """Return Markdown text with a proposed phased threshold schedule."""
+    t = data["totals"]
+    total_b = t["covered_branches"] + t["missing_branches"]
+    current_pct = t["covered_branches"] / total_b * 100 if total_b > 0 else 100.0
+
+    zero_count = 0
+    for fpath, info in data["files"].items():
+        if not fpath.startswith("robot_sf/"):
+            continue
+        s = info["summary"]
+        total = s.get("covered_branches", 0) + s.get("missing_branches", 0)
+        if total > 0 and _branch_pct(s) == 0.0:
+            zero_count += 1
+
+    proposal = f"""## Proposed Phased Threshold Schedule
+
+**Current baseline** (2026-07-09, CPU-only pytest with optional-dep tests excluded):
+{current_pct:.1f}% branch coverage across {total_b} branches.
+
+**Context caveat**: 57 test files could not collect (missing torch, stable-baselines3,
+optuna, duckdb, pyarrow). Modules exercised only by those tests report 0% branch
+coverage even though they may have tests in CI. This report reflects the CPU-only
+subset.
+
+### Phase 1 — Measure-only (current)
+- No threshold enforcement.
+- Goal: establish a reproducible baseline and identify blind spots.
+
+### Phase 2 — Floor at current baseline (~{current_pct:.0f}%)
+- Enforce: ``--cov-fail-under={int(current_pct)}`` on the CPU test subset.
+- Prevent regressions on already-tested code paths.
+- Target: Q3 2026, after optional-dep tests are integrated into CPU CI.
+
+### Phase 3 — Raise to 35%
+- Focus on the 10 worst evidence-critical modules listed above.
+- Priority: ``benchmark/map_runner.py``, ``planner/socnav.py``,
+  ``scenario_certification/perturbation_preflight.py``.
+- Target: Q4 2026.
+
+### Phase 4 — Raise to 50%
+- Requires branch-coverage tests for planner, benchmark, and scenario_certification.
+- Address the {zero_count} robot_sf files with 0% branch coverage.
+- Target: Q1 2027.
+
+### Phase 5 — Target 70%+ (evidence-critical only)
+- Enforce per-package thresholds on evidence-critical packages only.
+- Non-evidence packages (render, manual_control, telemetry) excluded.
+- Target: Q2 2027.
+
+### Recommended immediate actions
+1. Add ``--cov-fail-under=25`` to the CPU test runner to lock the baseline.
+2. Open follow-up issues for the 10 worst evidence-critical modules.
+3. Integrate optional-dep tests into CPU CI with ``--ignore`` guards for GPU-only tests.
+"""
+    return proposal
+
+
+def main() -> None:
+    """Parse args and print the branch-coverage report."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        type=Path,
+        default=Path("output/coverage/coverage.json"),
+        help="Path to coverage.json",
+    )
+    args = parser.parse_args()
+
+    if not args.json.exists():
+        print(
+            f"ERROR: {args.json} not found. Run pytest with --cov-report=json first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    data = load_coverage(args.json)
+
+    print("# Branch-Coverage Threshold Analysis Report")
+    print()
+    print(overall_summary(data))
+    print()
+    print("## Per-Package Branch Coverage")
+    print(per_package_table(data))
+    print()
+    print("## 10 Worst-Covered Evidence-Critical Modules")
+    print(worst_evidence_critical(data))
+    print()
+    print(threshold_proposal(data))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dev/test_branch_coverage_report.py
+++ b/tests/dev/test_branch_coverage_report.py
@@ -1,0 +1,137 @@
+"""Tests for scripts/dev/branch_coverage_report.py."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.dev.branch_coverage_report import (
+    _branch_pct,
+    load_coverage,
+    overall_summary,
+    per_package_table,
+    threshold_proposal,
+    worst_evidence_critical,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture()
+def sample_coverage(tmp_path: Path) -> Path:
+    """Create a minimal coverage.json for testing."""
+    data = {
+        "totals": {
+            "covered_lines": 100,
+            "missing_lines": 200,
+            "covered_branches": 30,
+            "missing_branches": 70,
+            "percent_covered": 33.33,
+        },
+        "files": {
+            "robot_sf/sim/core.py": {
+                "summary": {
+                    "covered_lines": 50,
+                    "missing_lines": 10,
+                    "covered_branches": 20,
+                    "missing_branches": 5,
+                }
+            },
+            "robot_sf/benchmark/map_runner.py": {
+                "summary": {
+                    "covered_lines": 10,
+                    "missing_lines": 90,
+                    "covered_branches": 0,
+                    "missing_branches": 40,
+                }
+            },
+            "robot_sf/planner/socnav.py": {
+                "summary": {
+                    "covered_lines": 5,
+                    "missing_lines": 95,
+                    "covered_branches": 0,
+                    "missing_branches": 60,
+                }
+            },
+            "robot_sf/render/draw.py": {
+                "summary": {
+                    "covered_lines": 35,
+                    "missing_lines": 5,
+                    "covered_branches": 10,
+                    "missing_branches": 0,
+                }
+            },
+        },
+    }
+    path = tmp_path / "coverage.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_branch_pct_with_branches() -> None:
+    """Branch pct returns correct percentage when branches exist."""
+    assert _branch_pct({"covered_branches": 10, "missing_branches": 10}) == 50.0
+
+
+def test_branch_pct_no_branches() -> None:
+    """Branch pct returns 100 when no branches exist."""
+    assert _branch_pct({"covered_branches": 0, "missing_branches": 0}) == 100.0
+
+
+def test_load_coverage(sample_coverage: Path) -> None:
+    """Load coverage returns dict with expected top-level keys."""
+    data = load_coverage(sample_coverage)
+    assert "totals" in data
+    assert "files" in data
+
+
+def test_overall_summary(sample_coverage: Path) -> None:
+    """Overall summary contains expected percentages."""
+    data = load_coverage(sample_coverage)
+    text = overall_summary(data)
+    assert "30.0%" in text
+    assert "33.3%" in text
+
+
+def test_per_package_table(sample_coverage: Path) -> None:
+    """Per-package table contains expected package names."""
+    data = load_coverage(sample_coverage)
+    table = per_package_table(data)
+    assert "robot_sf/sim" in table
+    assert "robot_sf/benchmark" in table
+    assert "robot_sf/planner" in table
+
+
+def test_worst_evidence_critical(sample_coverage: Path) -> None:
+    """Worst evidence-critical table lists lowest-coverage modules first."""
+    data = load_coverage(sample_coverage)
+    table = worst_evidence_critical(data, n=2)
+    assert "socnav.py" in table
+    assert "map_runner.py" in table
+
+
+def test_threshold_proposal(sample_coverage: Path) -> None:
+    """Threshold proposal contains all five phases."""
+    data = load_coverage(sample_coverage)
+    text = threshold_proposal(data)
+    assert "Phase 1" in text
+    assert "Phase 5" in text
+    assert "462" not in text  # should use actual count from data
+
+
+def test_report_script_runs(sample_coverage: Path, capsys: pytest.CaptureFixture) -> None:
+    """Main entrypoint produces expected report sections."""
+    import sys
+    from unittest.mock import patch
+
+    from scripts.dev.branch_coverage_report import main
+
+    with patch.object(sys, "argv", ["branch_coverage_report.py", "--json", str(sample_coverage)]):
+        main()
+    out = capsys.readouterr().out
+    assert "Branch-Coverage Threshold Analysis Report" in out
+    assert "Per-Package" in out
+    assert "Worst-Covered" in out


### PR DESCRIPTION
## What

Branch-coverage threshold analysis report for the CPU-only test subset, as
requested in issue #4894. Produces the report artifact (not another readiness
checker) and a proposed phased threshold schedule the maintainer could adopt.

## Files changed

- `scripts/dev/branch_coverage_report.py` — reusable script that reads
  `coverage.json` and prints per-package, worst-evidence-critical, and phased
  threshold schedule output.
- `docs/dev/branch_coverage_analysis.md` — full report with current baseline,
  per-package table, 10 worst evidence-critical modules, and 5-phase threshold
  proposal.
- `tests/dev/test_branch_coverage_report.py` — 8 focused tests for the report
  script.

## Key findings

| Metric | Value |
|---|---|
| Overall branch coverage | 7.3% (2,418 / 33,248) |
| robot_sf files with 0% branch coverage | 462 / 654 (70.6%) |
| Test files skipped (missing optional deps) | 57 |

**Context caveat**: 57 test files could not collect (missing torch, stable-baselines3,
optuna, duckdb, pyarrow). Modules exercised only by those tests report 0% branch
coverage even though they may have tests in CI. This report reflects the CPU-only
subset only.

10 worst evidence-critical modules: `planner/socnav.py`, `planner/hybrid_rule_local_planner.py`,
`benchmark/map_runner.py`, `scenario_certification/perturbation_preflight.py`,
`benchmark/map_runner_episode.py`, `analysis_workbench/trace_failure_predicates.py`,
`benchmark/camera_ready/_config.py`, `benchmark/artifact_publication.py`,
`benchmark/live_forecast_replay_gate.py`, `benchmark/snqi_scalarization_sensitivity.py`.

## Validation

```
uv run ruff check scripts/dev/branch_coverage_report.py tests/dev/test_branch_coverage_report.py
# All checks passed!

uv run pytest tests/dev/test_branch_coverage_report.py -v
# 8 passed in 0.03s

uv run python scripts/dev/branch_coverage_report.py
# Produces full report (see docs/dev/branch_coverage_analysis.md)
```

## Why

The 2026-07-08 test-infra bundle enabled `branch = true` in coverage config but
no analysis existed to show where the repo stands. This report fills that gap
and gives the maintainer a concrete baseline + phased threshold plan to consider.

Closes #4894

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
