### PR TITLE
Issue #4908: diagnostic CLI --help canonical uv run invocation (cheap-lane worker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **issue #4908 diagnostic CLI `--help` omits the canonical `uv run` invocation.** The seven
+  developer-facing diagnostic CLIs under `scripts/tools/` (`validate_scenario`,
+  `validate_socnav_map_batch`, `validate_experiment_registry`, `validate_report`,
+  `check_artifact_root`, `preflight_scenario_perturbations`, `preflight_adversarial_package_b`) now
+  end `--help` with an `Example:` block showing the copy-pasteable
+  `uv run python scripts/tools/<name>.py <required-arg>` command, so a new contributor no longer has
+  to guess the invocation (the bare `python scripts/tools/<name>.py ...` path still dies with
+  `ModuleNotFoundError: No module named 'scripts'` because these tools import `scripts.tools.*`).
+  Help-text only: each parser gained an `epilog` plus `RawDescriptionHelpFormatter`; no runtime
+  behavior, exit codes, or non-`--help` output changed. New
+  `tests/tools/test_diagnostic_cli_help.py` asserts each `--help` contains `Example:` and the exact
+  canonical line.
 * **issue #4896 three pre-existing failures in tests/dev/test_pr_ready_preflight.py on main.**
   PR #4865 ("allowlist triplication") made `scripts/dev/pr_ready_check.sh` hard-require
   `tests/support/optional_test_allowlist.txt` — `is_optional_readiness_path` reads it to classify

--- a/scripts/tools/check_artifact_root.py
+++ b/scripts/tools/check_artifact_root.py
@@ -119,7 +119,11 @@ def _build_parser() -> argparse.ArgumentParser:
     Returns:
         TODO docstring.
     """
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=("Example:\n  uv run python scripts/tools/check_artifact_root.py"),
+    )
     parser.add_argument(
         "--repo-root",
         type=Path,

--- a/scripts/tools/preflight_adversarial_package_b.py
+++ b/scripts/tools/preflight_adversarial_package_b.py
@@ -15,7 +15,14 @@ from robot_sf.benchmark.adversarial_package_b_preflight import (
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse package-B preflight CLI arguments."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Example:\n"
+            "  uv run python scripts/tools/preflight_adversarial_package_b.py [--manifest <path>]"
+        ),
+    )
     parser.add_argument(
         "--manifest",
         type=Path,

--- a/scripts/tools/preflight_scenario_perturbations.py
+++ b/scripts/tools/preflight_scenario_perturbations.py
@@ -15,7 +15,14 @@ from robot_sf.scenario_certification import (
 
 def _build_parser() -> argparse.ArgumentParser:
     """Build the scenario perturbation preflight parser."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Example:\n"
+            "  uv run python scripts/tools/preflight_scenario_perturbations.py <manifest.yaml>"
+        ),
+    )
     parser.add_argument("manifest", type=Path, help="Scenario perturbation manifest YAML.")
     parser.add_argument("--output", type=Path, help="Write the JSON preflight report to this path.")
     parser.add_argument(

--- a/scripts/tools/validate_experiment_registry.py
+++ b/scripts/tools/validate_experiment_registry.py
@@ -920,7 +920,15 @@ def _apply_labels_from_cli_args(
 
 def main(argv: list[str] | None = None) -> int:
     """Run the experiment registry validator CLI."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Example:\n"
+            "  uv run python scripts/tools/validate_experiment_registry.py "
+            "[experiments/registry.yaml]"
+        ),
+    )
     parser.add_argument(
         "registry",
         nargs="?",

--- a/scripts/tools/validate_report.py
+++ b/scripts/tools/validate_report.py
@@ -144,7 +144,9 @@ def validate_report(report_dir: Path) -> bool:
 def main() -> None:
     """CLI entry point for report validation."""
     parser = argparse.ArgumentParser(
-        description="Validate research report structure and schema compliance."
+        description="Validate research report structure and schema compliance.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=("Example:\n  uv run python scripts/tools/validate_report.py --report-dir <dir>"),
     )
     parser.add_argument("--report-dir", type=str, required=True, help="Path to report directory")
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose output")

--- a/scripts/tools/validate_scenario.py
+++ b/scripts/tools/validate_scenario.py
@@ -15,7 +15,13 @@ from scripts.tools.scenario_authoring import (
 def _build_parser() -> argparse.ArgumentParser:
     """Build the scenario validation CLI parser."""
 
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Example:\n  uv run python scripts/tools/validate_scenario.py <scenario_config.yaml>"
+        ),
+    )
     parser.add_argument("scenario_config", type=Path, help="Scenario YAML file to validate.")
     parser.add_argument(
         "--allow-legacy-metadata",

--- a/scripts/tools/validate_socnav_map_batch.py
+++ b/scripts/tools/validate_socnav_map_batch.py
@@ -239,7 +239,13 @@ def conversion_readiness(
 
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Example:\n  uv run python scripts/tools/validate_socnav_map_batch.py [--batch-id <id>]"
+        ),
+    )
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument("--socnav-root", type=Path, default=DEFAULT_SOCNAV_ROOT)
     parser.add_argument("--batch-id", default="eth_first")

--- a/tests/tools/test_diagnostic_cli_help.py
+++ b/tests/tools/test_diagnostic_cli_help.py
@@ -1,0 +1,71 @@
+"""Diagnostic CLI ``--help`` must expose the canonical ``uv run`` invocation.
+
+Each developer-facing diagnostic CLI under ``scripts/tools/`` ends its
+``--help`` with an ``Example:`` block showing the canonical
+``uv run python scripts/tools/<name>.py <required-arg>`` command, so a new
+contributor has a copy-pasteable invocation (issue #4908).
+
+These checks run the real CLI ``--help`` (via ``python -m``) and assert the
+full canonical example line is present, which also guards acceptance criterion
+#2: the example must match the tool's actual required positional/flag.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+#: (module dotted path, exact canonical example line expected in ``--help``)
+DIAGNOSTIC_CLIS: list[tuple[str, str]] = [
+    (
+        "scripts.tools.validate_scenario",
+        "uv run python scripts/tools/validate_scenario.py <scenario_config.yaml>",
+    ),
+    (
+        "scripts.tools.validate_socnav_map_batch",
+        "uv run python scripts/tools/validate_socnav_map_batch.py [--batch-id <id>]",
+    ),
+    (
+        "scripts.tools.validate_experiment_registry",
+        "uv run python scripts/tools/validate_experiment_registry.py [experiments/registry.yaml]",
+    ),
+    (
+        "scripts.tools.validate_report",
+        "uv run python scripts/tools/validate_report.py --report-dir <dir>",
+    ),
+    (
+        "scripts.tools.check_artifact_root",
+        "uv run python scripts/tools/check_artifact_root.py",
+    ),
+    (
+        "scripts.tools.preflight_scenario_perturbations",
+        "uv run python scripts/tools/preflight_scenario_perturbations.py <manifest.yaml>",
+    ),
+    (
+        "scripts.tools.preflight_adversarial_package_b",
+        "uv run python scripts/tools/preflight_adversarial_package_b.py [--manifest <path>]",
+    ),
+]
+
+
+def _run_help(module: str) -> subprocess.CompletedProcess[str]:
+    """Run ``<python> -m <module> --help`` and capture stdout/stderr."""
+    return subprocess.run(
+        [sys.executable, "-m", module, "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("module, example_line", DIAGNOSTIC_CLIS)
+def test_diagnostic_cli_help_exposes_canonical_invocation(module: str, example_line: str) -> None:
+    """Each diagnostic CLI ``--help`` ends with the canonical ``uv run`` example."""
+    result = _run_help(module)
+    assert result.returncode == 0, f"{module} --help failed:\n{result.stderr}"
+    assert "Example:" in result.stdout, f"{module} --help has no Example: block"
+    assert example_line in result.stdout, (
+        f"{module} --help missing canonical line {example_line!r}; got:\n{result.stdout}"
+    )


### PR DESCRIPTION
## What

Fixes issue #4908. The seven developer-facing diagnostic CLIs under `scripts/tools/` gave a new contributor **no copy-pasteable invocation** in `--help`, and the natural first attempt — bare `python scripts/tools/<name>.py ...` — dies with a confusing `ModuleNotFoundError: No module named 'scripts'` because these tools do `from scripts.tools.* import ...` (which needs the repo root on `sys.path`, which `uv run` provides but a bare `python` does not).

This PR adds an `Example:` block to each tool's `--help` showing the canonical `uv run python scripts/tools/<name>.py <required-arg>` command — the exact convention already baked into 130+ doc references and into actionable error strings (e.g. `scripts/dev/check_skills.py`).

Closes #4908.

## Changes (help-text only)

Each listed CLI's `argparse.ArgumentParser` gains an `epilog` plus `formatter_class=argparse.RawDescriptionHelpFormatter` so `--help` ends with a cleanly-rendered `Example:` block:

| CLI | Example line now in `--help` |
| --- | --- |
| `scripts/tools/validate_scenario.py` | `uv run python scripts/tools/validate_scenario.py <scenario_config.yaml>` |
| `scripts/tools/validate_socnav_map_batch.py` | `uv run python scripts/tools/validate_socnav_map_batch.py [--batch-id <id>]` |
| `scripts/tools/validate_experiment_registry.py` | `uv run python scripts/tools/validate_experiment_registry.py [experiments/registry.yaml]` |
| `scripts/tools/validate_report.py` | `uv run python scripts/tools/validate_report.py --report-dir <dir>` |
| `scripts/tools/check_artifact_root.py` | `uv run python scripts/tools/check_artifact_root.py` |
| `scripts/tools/preflight_scenario_perturbations.py` | `uv run python scripts/tools/preflight_scenario_perturbations.py <manifest.yaml>` |
| `scripts/tools/preflight_adversarial_package_b.py` | `uv run python scripts/tools/preflight_adversarial_package_b.py [--manifest <path>]` |

**No runtime behavior, exit codes, or output format changed for any non-`--help` invocation** — this is help-text only (acceptance criterion #3).

### Accuracy note vs. the issue text (acceptance criterion #2)

The issue suggested `<manifest.json>` for `preflight_scenario_perturbations.py`, but that tool's own help text says *"Scenario perturbation manifest YAML"* and the loader (`preflight_perturbation_manifest` → `yaml.safe_load`) plus every existing fixture (`configs/scenarios/perturbations/*.yaml`) are YAML. I used `<manifest.yaml>` to match the actual required input, satisfying "the example commands are accurate against the current argparse."

### Optional criterion #4 (bare-`python` hint) — deliberately not done

The issue marks "make bare `python scripts/tools/<name>.py` emit a hint instead of the raw `ModuleNotFoundError`" as **optional / lower priority**. Implementing it (a `sys.path` bootstrap or import-guard) would change the behavior/output of a non-`--help` invocation, which directly conflicts with acceptance criterion #3 ("no runtime behavior, exit codes, or output format changes for any non-`--help` invocation") and the issue's `no architectural refactor` constraint. The required, night-safe deliverable is the `--help` epilog, which this PR delivers. Left for a follow-up if the maintainers want the bare-invocation ergonomics.

## Test

New `tests/tools/test_diagnostic_cli_help.py` — parametrized over the 7 CLIs; runs the real `python -m <module> --help` and asserts each output contains `Example:` and the exact canonical `uv run ...` line (also guards criterion #2: the required arg matches argparse).

```
$ uv run pytest tests/tools/test_diagnostic_cli_help.py -q
7 passed in 11.74s
```

No regressions in pre-existing tests that touch these scripts:

```
$ uv run pytest tests/research/test_cli.py tests/test_guard/test_check_artifact_root.py -q
8 passed in 11.18s
```

`ruff check` + `ruff format --check` clean on all 8 changed files. Example rendered output:

```
$ uv run python scripts/tools/validate_scenario.py --help
usage: validate_scenario.py [-h] [--allow-legacy-metadata] [--verbose] scenario_config
...
options:
  -h, --help            show this help message and exit
  ...

Example:
  uv run python scripts/tools/validate_scenario.py <scenario_config.yaml>
```

## Validation scope

CPU-level / local only. No campaigns, no Slurm, no training, no benchmark/paper claims. Evidence grade: `smoke evidence` (narrow execution proof that each `--help` renders the canonical command).

This PR fully resolves issue #4908.

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.
