### PR TITLE
Issue #4907: clean bad-input UX for three preflight/validate CLIs (cheap-lane worker)

### DIFF
--- a/scripts/tools/preflight_adversarial_package_b.py
+++ b/scripts/tools/preflight_adversarial_package_b.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 from robot_sf.benchmark.adversarial_package_b_preflight import (
@@ -40,7 +41,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     """Run preflight and return non-zero when blockers are present."""
     args = parse_args(argv)
-    result = preflight_package_b_manifest(args.manifest, repo_root=args.repo_root)
+    try:
+        result = preflight_package_b_manifest(args.manifest, repo_root=args.repo_root)
+    except FileNotFoundError as exc:
+        # Bad input (nonexistent manifest path): print one actionable line to
+        # stderr and exit non-zero instead of dumping a raw traceback. Mirrors
+        # validate_report.py's clean failure UX. The loader's message is already
+        # path-qualified ("Manifest file not found: ..."), so emit it verbatim.
+        print(f"FAILED: {exc}", file=sys.stderr)
+        return 2
     dump_preflight_payload(result, args.output)
     print(json.dumps(result.to_payload(), sort_keys=True))
     return 0 if result.ready else 1

--- a/scripts/tools/preflight_scenario_perturbations.py
+++ b/scripts/tools/preflight_scenario_perturbations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 from robot_sf.scenario_certification import (
@@ -29,7 +30,17 @@ def _build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     """Run scenario perturbation preflight."""
     args = _build_parser().parse_args()
-    report = preflight_perturbation_manifest(args.manifest)
+    try:
+        report = preflight_perturbation_manifest(args.manifest)
+    except (FileNotFoundError, ValueError) as exc:
+        # Bad input (nonexistent manifest path or malformed/non-mapping
+        # manifest): print one actionable line to stderr and exit non-zero
+        # instead of dumping a raw traceback. Mirrors validate_report.py's clean
+        # failure UX. ``str(exc)`` renders OSError readably (e.g.
+        # ``[Errno 2] No such file or directory: ...``) and the loader's
+        # ValueError wording verbatim.
+        print(f"FAILED: {exc}", file=sys.stderr)
+        return 2
     payload = preflight_to_dict(report)
     output = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     if args.output:

--- a/scripts/tools/validate_socnav_map_batch.py
+++ b/scripts/tools/validate_socnav_map_batch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -259,20 +260,32 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     """Validate or preflight one SocNavBench import batch and return an exit code."""
     args = parse_args()
-    if args.preflight:
-        report = conversion_readiness(
-            manifest_path=args.manifest.resolve(),
-            socnav_root=args.socnav_root.resolve(),
-            batch_id=str(args.batch_id),
-        )
-        ok = bool(report["conversion_ready"])
-    else:
-        report = validate_batch(
-            manifest_path=args.manifest.resolve(),
-            socnav_root=args.socnav_root.resolve(),
-            batch_id=str(args.batch_id),
-        )
-        ok = bool(report["ok"])
+    try:
+        if args.preflight:
+            report = conversion_readiness(
+                manifest_path=args.manifest.resolve(),
+                socnav_root=args.socnav_root.resolve(),
+                batch_id=str(args.batch_id),
+            )
+            ok = bool(report["conversion_ready"])
+        else:
+            report = validate_batch(
+                manifest_path=args.manifest.resolve(),
+                socnav_root=args.socnav_root.resolve(),
+                batch_id=str(args.batch_id),
+            )
+            ok = bool(report["ok"])
+    except (FileNotFoundError, KeyError, TypeError, ValueError) as exc:
+        # Bad input (nonexistent manifest path, non-mapping manifest, or unknown
+        # --batch-id): print one actionable line to stderr and exit non-zero
+        # instead of dumping a raw traceback. Mirrors validate_report.py's clean
+        # failure UX. ``str(exc)`` renders OSError/FileNotFoundError readably
+        # (e.g. ``[Errno 2] No such file or directory: ...``); KeyError
+        # repr-quotes its single message arg, so unwrap it to keep the loader's
+        # verbatim, informative wording.
+        message = str(exc.args[0]) if isinstance(exc, KeyError) and exc.args else str(exc)
+        print(f"FAILED: {message}", file=sys.stderr)
+        return 2
     if args.report_json is not None:
         args.report_json.parent.mkdir(parents=True, exist_ok=True)
         args.report_json.write_text(json.dumps(report, indent=2), encoding="utf-8")

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -639,3 +639,21 @@ def test_package_b_preflight_cli_writes_report_and_returns_nonzero_on_blocker(
     assert exit_code == 1
     assert report["blocked"] is True
     assert report["checks"]["samplers"] is False
+
+
+def test_package_b_preflight_cli_nonexistent_manifest_prints_actionable_error(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """A nonexistent manifest path prints one actionable line and exits non-zero, no traceback."""
+    missing = tmp_path / "does_not_exist.yaml"
+
+    exit_code = preflight_adversarial_package_b.main(
+        ["--manifest", str(missing), "--repo-root", str(tmp_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    # The loader reports the path repo-relative; assert that wording verbatim.
+    assert "FAILED: Manifest file not found: does_not_exist.yaml" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/tools/test_preflight_scenario_perturbations.py
+++ b/tests/tools/test_preflight_scenario_perturbations.py
@@ -1,0 +1,89 @@
+"""CLI tests for the scenario perturbation preflight (issue #4907 bad-input UX)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import yaml
+
+from robot_sf.scenario_certification import PERTURBATION_MANIFEST_SCHEMA_VERSION
+from scripts.tools.preflight_scenario_perturbations import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_valid_manifest(path: Path) -> Path:
+    """Write a tiny perturbation manifest targeting an existing simple scenario."""
+    payload = {
+        "schema_version": PERTURBATION_MANIFEST_SCHEMA_VERSION,
+        "manifest_id": "test_perturbation_manifest",
+        "scenario_config": "configs/scenarios/single/planner_sanity_simple.yaml",
+        "seed_controls": {
+            "baseline_seeds": [101, 102],
+            "replay_seed_policy": "explicit",
+        },
+        "validity": {
+            "require_scenario_certification": True,
+            "max_route_offset_m": 0.5,
+            "invalid_variant_evidence_policy": "exclude_from_success_evidence",
+        },
+        "variants": [
+            {
+                "variant_id": "planner_sanity_simple_noop",
+                "scenario_id": "planner_sanity_simple",
+                "family": "noop",
+                "seeds": [101, 102],
+            },
+        ],
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def test_main_nonexistent_manifest_prints_actionable_error(monkeypatch, capsys) -> None:
+    """A nonexistent manifest path prints one actionable line and exits non-zero."""
+    missing = "/nonexistent/perturbation_manifest.json"
+    monkeypatch.setattr("sys.argv", ["preflight_scenario_perturbations.py", missing])
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "FAILED:" in captured.err
+    assert "No such file or directory" in captured.err
+    assert missing in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_main_non_mapping_manifest_prints_actionable_error(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    """A non-mapping manifest prints one actionable line and exits non-zero."""
+    bad_manifest = tmp_path / "bad.yaml"
+    bad_manifest.write_text("- a\n- b\n", encoding="utf-8")
+    monkeypatch.setattr("sys.argv", ["preflight_scenario_perturbations.py", str(bad_manifest)])
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert f"FAILED: Perturbation manifest must contain a mapping: {bad_manifest}" in (captured.err)
+    assert "Traceback" not in captured.err
+
+
+def test_main_valid_manifest_emits_report_and_exits_zero(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    """A valid manifest still emits the JSON report and exits 0 (happy path unchanged)."""
+    manifest = _write_valid_manifest(tmp_path / "perturbations.yaml")
+    monkeypatch.setattr("sys.argv", ["preflight_scenario_perturbations.py", str(manifest)])
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "FAILED:" not in captured.err
+    payload = json.loads(captured.out)
+    assert payload["manifest_id"] == "test_perturbation_manifest"

--- a/tests/tools/test_validate_socnav_map_batch.py
+++ b/tests/tools/test_validate_socnav_map_batch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 import pytest
@@ -11,6 +12,7 @@ from scripts.tools.validate_socnav_map_batch import (
     BLOCKED,
     READY,
     conversion_readiness,
+    main,
     validate_batch,
 )
 
@@ -214,3 +216,107 @@ def test_validate_batch_rejects_absolute_relative_path(tmp_path: Path) -> None:
             socnav_root=tmp_path / "socnavbench",
             batch_id="eth_first",
         )
+
+
+def test_main_unknown_batch_id_prints_actionable_error(monkeypatch, tmp_path: Path, capsys) -> None:
+    """An unknown --batch-id prints one actionable line and exits non-zero, no traceback."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_manifest(manifest)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "validate_socnav_map_batch.py",
+            "--manifest",
+            str(manifest),
+            "--batch-id",
+            "no_such_batch",
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "FAILED: Unknown SocNavBench import batch: no_such_batch" in captured.err
+    assert "Traceback" not in captured.err
+    assert captured.out == ""
+
+
+def test_main_nonexistent_manifest_prints_actionable_error(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    """A nonexistent manifest path prints one path-qualified line and exits non-zero."""
+    missing = tmp_path / "does_not_exist.yaml"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "validate_socnav_map_batch.py",
+            "--manifest",
+            str(missing),
+            "--batch-id",
+            "eth_first",
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "FAILED:" in captured.err
+    assert "No such file or directory" in captured.err
+    assert str(missing) in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_main_non_mapping_manifest_prints_actionable_error(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    """A non-mapping manifest prints one actionable line and exits non-zero, no traceback."""
+    bad_manifest = tmp_path / "bad.yaml"
+    bad_manifest.write_text("- foo\n- bar\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "validate_socnav_map_batch.py",
+            "--manifest",
+            str(bad_manifest),
+            "--batch-id",
+            "eth_first",
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert f"FAILED: Expected YAML mapping: {bad_manifest}" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_main_valid_batch_emits_report_and_exits_zero(monkeypatch, tmp_path: Path, capsys) -> None:
+    """A valid manifest with staged assets still emits the JSON report and exits 0."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_manifest(manifest)
+    root = tmp_path / "socnavbench"
+    _stage_eth_assets(root)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "validate_socnav_map_batch.py",
+            "--manifest",
+            str(manifest),
+            "--socnav-root",
+            str(root),
+            "--batch-id",
+            "eth_first",
+        ],
+    )
+
+    exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "FAILED:" not in captured.err
+    report = json.loads(captured.out)
+    assert report["ok"] is True
+    assert report["batch_id"] == "eth_first"


### PR DESCRIPTION
## What & why

Closes #4907. Three `scripts/tools/` preflight/validate CLIs emitted a raw multi-frame Python traceback (`FileNotFoundError` / `KeyError` / `TypeError`) when handed exactly the bad-input cases the DX "doctor" lens targets — a **nonexistent manifest path, a malformed (non-mapping) manifest, or an unknown `--batch-id`**. Their sibling validators (`validate_report.py`, `validate_scenario.py`, `validate_experiment_registry.py`) already print one actionable line and exit non-zero with no traceback. This PR brings the three affected CLIs to the same failure UX.

**Root cause (same in all three):** each CLI `main()` calls its loader function with no `try/except`, so a loader exception propagates as a traceback.

**Fix:** wrap each `main()` loader call in `try/except`, print one actionable line to stderr, return non-zero. No architectural refactor.

## Affected CLIs

| CLI | Bad inputs caught | Loader exceptions |
| --- | --- | --- |
| `scripts/tools/validate_socnav_map_batch.py` | nonexistent manifest path; non-mapping manifest; unknown `--batch-id` | `FileNotFoundError`, `TypeError`, `KeyError`, `ValueError` |
| `scripts/tools/preflight_scenario_perturbations.py` | nonexistent manifest path; malformed/non-mapping manifest | `FileNotFoundError`, `ValueError` |
| `scripts/tools/preflight_adversarial_package_b.py` | nonexistent manifest path | `FileNotFoundError` |

Each prints `FAILED: <loader message>` to stderr and exits `2`.

## Acceptance criteria

1. ✅ Bad input → one actionable, human-readable line to stderr naming the bad input, non-zero exit, **no traceback**.
2. ✅ Valid-input behavior is byte-for-byte unchanged — the catch is localized to each `main()` loader call; report construction, JSON output, and exit codes for valid input are untouched (verified end-to-end below).
3. ✅ Regression tests added for every bad-input path, using the existing loader messages verbatim (`Unknown SocNavBench import batch: ...`, `[Errno 2] No such file or directory: ...`, `Expected YAML mapping: ...`, `Perturbation manifest must contain a mapping: ...`, `Manifest file not found: ...`).

**Scope:** the three CLI `main()` entry points only. No verdict/preflight logic and no pass/fail semantics changed — a caught exception still results in a non-zero (failure) exit; only the failure UX (clean line vs. traceback) and the specific non-zero code (2) change. The optional library-side guard sites named in the issue (`perturbation_preflight.py:284`) are left untouched because the CLI-level catch fully satisfies the acceptance criteria with a smaller, more localized change.

## Validation output (CPU-level only; no campaigns/Slurm/training)

Smoke-tested all six bad-input invocations from the issue — each now prints one line and exits 2 with no traceback:

```
$ uv run python scripts/tools/validate_socnav_map_batch.py --batch-id no_such_batch
FAILED: Unknown SocNavBench import batch: no_such_batch            # rc=2

$ uv run python scripts/tools/validate_socnav_map_batch.py --manifest /nonexistent/manifest.yaml --batch-id x
FAILED: [Errno 2] No such file or directory: '/nonexistent/manifest.yaml'   # rc=2

$ uv run python scripts/tools/validate_socnav_map_batch.py --manifest <list.yaml> --batch-id x
FAILED: Expected YAML mapping: <list.yaml>                         # rc=2

$ uv run python scripts/tools/preflight_scenario_perturbations.py /nonexistent/manifest.json
FAILED: [Errno 2] No such file or directory: '/nonexistent/manifest.json'    # rc=2

$ uv run python scripts/tools/preflight_scenario_perturbations.py <list.yaml>
FAILED: Perturbation manifest must contain a mapping: <list.yaml>  # rc=2

$ uv run python scripts/tools/preflight_adversarial_package_b.py --manifest /nonexistent/manifest.json
FAILED: Manifest file not found: /nonexistent/manifest.json        # rc=2
```

Valid-input regression (happy path unchanged):
- `validate_socnav_map_batch.py` default manifest → full JSON report on stdout, `rc=2` (not-staged verdict), no `FAILED:`/traceback on stderr.
- `preflight_scenario_perturbations.py` on a valid manifest → full JSON report (`manifest_id`, `results`, …) on stdout, `rc=0`, no `FAILED:`/traceback.

Test suite (changed/new files only):
```
$ uv run pytest tests/tools/test_validate_socnav_map_batch.py \
                  tests/tools/test_preflight_scenario_perturbations.py \
                  tests/benchmark/test_adversarial_package_b_preflight.py -q
45 passed in 0.89s
```

Lint/format:
```
$ uv run ruff check <6 changed files>   -> All checks passed!
$ uv run ruff format --check <6 files>  -> 6 files already formatted
```

## Files changed

- `scripts/tools/validate_socnav_map_batch.py` — `main()` loader call wrapped in `try/except (FileNotFoundError, KeyError, TypeError, ValueError)`; added `import sys`.
- `scripts/tools/preflight_scenario_perturbations.py` — `main()` loader call wrapped in `try/except (FileNotFoundError, ValueError)`; added `import sys`.
- `scripts/tools/preflight_adversarial_package_b.py` — `main()` loader call wrapped in `try/except FileNotFoundError`; added `import sys`.
- `tests/tools/test_validate_socnav_map_batch.py` — 3 bad-input CLI tests + 1 valid-input guard.
- `tests/tools/test_preflight_scenario_perturbations.py` — new file: 2 bad-input tests + 1 valid-input guard.
- `tests/benchmark/test_adversarial_package_b_preflight.py` — 1 bad-input CLI test.

## Notes

This is a single-session, night-safe, local-only bug fix: no job submission, no state mutation, no Slurm/campaign, no release/re-base surfaces. Not a duplicate of #4893/#4894/#4896 (test/analysis work on different files).

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation
lane; the review gate hardens and merges.

Closes #4907
