### PR TITLE
Issue #4906: per-planner oscillatory control profile (cheap-lane worker)

### DIFF
--- a/scripts/analysis/oscillatory_control_profile.py
+++ b/scripts/analysis/oscillatory_control_profile.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Per-planner control-wandering + hybrid command-source-switch profile.
+
+Parses retained h600 oscillation predicates from issue4206 trace-capable rerun
+(6480 episodes) and produces:
+  1. Per-planner percentile CSV for progress_ratio, heading_rate_sign_changes,
+     command_source_changes (with N per cell).
+  2. Per-scenario-family wandering + command-source-switch profile for hybrid planners.
+  3. Two PNGs: progress_ratio distribution (planners overlaid) and per-planner
+     command-source-change rate bar chart.
+
+CPU-only, no simulation, no GPU, no campaign/Slurm, no metric writes.
+"""
+
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+BASE_RUNS = "output/benchmarks/camera_ready/issue4206_trace_capable_h600_rerun_20260704/runs"
+OUTPUT_DIR = "output/oscillatory_control_profile"
+
+FIELDS = [
+    "progress_ratio",
+    "command_source_changes",
+    "heading_rate_sign_changes",
+    "linear_velocity_sign_changes",
+    "mean_abs_jerk",
+    "path_length_m",
+    "net_progress_m",
+]
+
+HYBRID_PLANNERS = [
+    "scenario_adaptive_hybrid_orca_v1",
+    "hybrid_rule_v3_fast_progress_static_escape",
+]
+
+
+def scenario_family_from_id(scenario_id: str) -> str:
+    """Extract scenario_family from scenario_id."""
+    if scenario_id.startswith("classic_"):
+        # Remove 'classic_' prefix and difficulty suffix (_high, _low, _medium)
+        parts = scenario_id[len("classic_"):].rsplit("_", 1)
+        return parts[0]
+    elif scenario_id.startswith("francis2023_"):
+        return scenario_id[len("francis2023_"):]
+    return scenario_id
+
+
+def load_episodes(base_runs: str) -> list[dict]:
+    """Load all episodes from all planners."""
+    episodes = []
+    for planner_dir in sorted(os.listdir(base_runs)):
+        episodes_file = os.path.join(base_runs, planner_dir, "episodes.jsonl")
+        if not os.path.exists(episodes_file):
+            continue
+        # Planner name is directory without __differential_drive suffix
+        planner = planner_dir.replace("__differential_drive", "")
+        with open(episodes_file) as f:
+            for line in f:
+                ep = json.loads(line)
+                fields = (
+                    ep.get("safety_predicates", {})
+                    .get("oscillatory_control_predicate", {})
+                    .get("fields", {})
+                )
+                if not fields:
+                    continue
+                row = {
+                    "planner": planner,
+                    "scenario_id": ep.get("scenario_id", ""),
+                    "scenario_family": scenario_family_from_id(
+                        ep.get("scenario_id", "")
+                    ),
+                    "seed": ep.get("seed"),
+                }
+                for field in FIELDS:
+                    row[field] = fields.get(field)
+                episodes.append(row)
+    return episodes
+
+
+def percentile_table(
+    episodes: list[dict], group_col: str, value_col: str
+) -> dict[str, dict]:
+    """Compute percentile stats per group."""
+    grouped = defaultdict(list)
+    for ep in episodes:
+        val = ep.get(value_col)
+        if val is not None:
+            grouped[ep[group_col]].append(val)
+    result = {}
+    for group, values in sorted(grouped.items()):
+        arr = np.array(values, dtype=float)
+        result[group] = {
+            "N": len(arr),
+            "p10": float(np.percentile(arr, 10)),
+            "p25": float(np.percentile(arr, 25)),
+            "p50": float(np.percentile(arr, 50)),
+            "p75": float(np.percentile(arr, 75)),
+            "p90": float(np.percentile(arr, 90)),
+            "mean": float(np.mean(arr)),
+        }
+    return result
+
+
+def write_per_planner_csv(episodes: list[dict], output_path: Path):
+    """Write per-planner percentile CSV for key metrics."""
+    rows = []
+    planners = sorted({ep["planner"] for ep in episodes})
+    for planner in planners:
+        pl_eps = [ep for ep in episodes if ep["planner"] == planner]
+        row = {"planner": planner, "N": len(pl_eps)}
+        for col in ["progress_ratio", "heading_rate_sign_changes", "command_source_changes"]:
+            vals = [ep[col] for ep in pl_eps if ep[col] is not None]
+            if vals:
+                arr = np.array(vals, dtype=float)
+                row[f"{col}_mean"] = round(float(np.mean(arr)), 4)
+                row[f"{col}_p10"] = round(float(np.percentile(arr, 10)), 4)
+                row[f"{col}_p25"] = round(float(np.percentile(arr, 25)), 4)
+                row[f"{col}_p50"] = round(float(np.percentile(arr, 50)), 4)
+                row[f"{col}_p75"] = round(float(np.percentile(arr, 75)), 4)
+                row[f"{col}_p90"] = round(float(np.percentile(arr, 90)), 4)
+        rows.append(row)
+
+    headers = list(rows[0].keys())
+    with open(output_path, "w") as f:
+        f.write(",".join(headers) + "\n")
+        for row in rows:
+            f.write(",".join(str(row.get(h, "")) for h in headers) + "\n")
+    print(f"Wrote {output_path} ({len(rows)} planners)")
+
+
+def write_hybrid_scenario_csv(episodes: list[dict], output_path: Path):
+    """Write per-scenario-family profile for hybrid planners."""
+    hybrid_eps = [ep for ep in episodes if ep["planner"] in HYBRID_PLANNERS]
+    families = sorted({ep["scenario_family"] for ep in hybrid_eps})
+
+    rows = []
+    for family in families:
+        fam_eps = [ep for ep in hybrid_eps if ep["scenario_family"] == family]
+        for planner in HYBRID_PLANNERS:
+            pl_eps = [ep for ep in fam_eps if ep["planner"] == planner]
+            if not pl_eps:
+                continue
+            row = {
+                "scenario_family": family,
+                "planner": planner,
+                "N": len(pl_eps),
+            }
+            for col in ["progress_ratio", "command_source_changes"]:
+                vals = [ep[col] for ep in pl_eps if ep[col] is not None]
+                if vals:
+                    arr = np.array(vals, dtype=float)
+                    row[f"{col}_median"] = round(float(np.median(arr)), 4)
+                    row[f"{col}_mean"] = round(float(np.mean(arr)), 4)
+            rows.append(row)
+
+    headers = list(rows[0].keys()) if rows else []
+    with open(output_path, "w") as f:
+        if headers:
+            f.write(",".join(headers) + "\n")
+            for row in rows:
+                f.write(",".join(str(row.get(h, "")) for h in headers) + "\n")
+    print(f"Wrote {output_path} ({len(rows)} rows)")
+
+
+def plot_progress_ratio_distribution(episodes: list[dict], output_path: Path):
+    """Plot overlaid progress_ratio histograms per planner."""
+    planners = sorted({ep["planner"] for ep in episodes})
+    fig, ax = plt.subplots(figsize=(12, 6))
+    bins = np.linspace(0, 1.05, 50)
+    for planner in planners:
+        vals = [
+            ep["progress_ratio"]
+            for ep in episodes
+            if ep["planner"] == planner and ep["progress_ratio"] is not None
+        ]
+        if vals:
+            ax.hist(vals, bins=bins, alpha=0.4, label=planner, density=True)
+    ax.set_xlabel("progress_ratio")
+    ax.set_ylabel("Density")
+    ax.set_title("Progress Ratio Distribution by Planner")
+    ax.legend(fontsize=7, loc="upper left")
+    ax.set_xlim(0, 1.05)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+    print(f"Wrote {output_path}")
+
+
+def plot_command_source_changes(episodes: list[dict], output_path: Path):
+    """Bar chart of mean command_source_changes per planner."""
+    planners = sorted({ep["planner"] for ep in episodes})
+    means = []
+    for planner in planners:
+        vals = [
+            ep["command_source_changes"]
+            for ep in episodes
+            if ep["planner"] == planner and ep["command_source_changes"] is not None
+        ]
+        means.append(float(np.mean(vals)) if vals else 0.0)
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+    bars = ax.bar(planners, means, color="steelblue")
+    ax.set_xlabel("Planner")
+    ax.set_ylabel("Mean command_source_changes")
+    ax.set_title("Mean Command Source Changes per Planner")
+    ax.tick_params(axis="x", rotation=45)
+    # Highlight hybrid planners
+    for i, planner in enumerate(planners):
+        if planner in HYBRID_PLANNERS:
+            bars[i].set_color("darkorange")
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+    print(f"Wrote {output_path}")
+
+
+def _planner_progress_table(episodes: list[dict]) -> list[str]:
+    """Build per-planner progress_ratio table lines."""
+    lines = ["### Per-Planner Progress Ratio\n"]
+    lines.append("| Planner | N | p10 | p25 | Median | p75 | p90 | Mean |")
+    lines.append("|---------|---|-----|-----|--------|-----|-----|------|")
+    planners = sorted({ep["planner"] for ep in episodes})
+    for planner in planners:
+        vals = [
+            ep["progress_ratio"]
+            for ep in episodes
+            if ep["planner"] == planner and ep["progress_ratio"] is not None
+        ]
+        if vals:
+            arr = np.array(vals, dtype=float)
+            lines.append(
+                f"| {planner} | {len(arr)} | "
+                f"{np.percentile(arr, 10):.3f} | "
+                f"{np.percentile(arr, 25):.3f} | "
+                f"{np.median(arr):.3f} | "
+                f"{np.percentile(arr, 75):.3f} | "
+                f"{np.percentile(arr, 90):.3f} | "
+                f"{np.mean(arr):.3f} |"
+            )
+    return lines
+
+
+def _worst_wanderers(episodes: list[dict]) -> list[str]:
+    """Build worst wanderers section."""
+    lines = ["\n### Worst Wanderers (lowest median progress_ratio)\n"]
+    planners = sorted({ep["planner"] for ep in episodes})
+    planner_medians = {}
+    for planner in planners:
+        vals = [
+            ep["progress_ratio"]
+            for ep in episodes
+            if ep["planner"] == planner and ep["progress_ratio"] is not None
+        ]
+        if vals:
+            planner_medians[planner] = float(np.median(vals))
+    worst = sorted(planner_medians.items(), key=lambda x: x[1])[:3]
+    for planner, median in worst:
+        lines.append(f"- **{planner}**: median progress_ratio = {median:.3f}")
+    return lines
+
+
+def _hybrid_command_source_table(episodes: list[dict]) -> list[str]:
+    """Build hybrid planner command source switches table."""
+    lines = ["\n### Hybrid Planner Command Source Switches\n"]
+    lines.append("| Planner | N | Mean | Median | p90 |")
+    lines.append("|---------|---|------|--------|-----|")
+    for planner in HYBRID_PLANNERS:
+        vals = [
+            ep["command_source_changes"]
+            for ep in episodes
+            if ep["planner"] == planner and ep["command_source_changes"] is not None
+        ]
+        if vals:
+            arr = np.array(vals, dtype=float)
+            lines.append(
+                f"| {planner} | {len(arr)} | "
+                f"{np.mean(arr):.2f} | "
+                f"{np.median(arr):.1f} | "
+                f"{np.percentile(arr, 90):.1f} |"
+            )
+    return lines
+
+
+def _hybrid_scenario_family_table(episodes: list[dict]) -> list[str]:
+    """Build hybrid planners per-scenario-family table."""
+    lines = ["\n### Hybrid Planners: Per-Scenario-Family Profile\n"]
+    lines.append("| Scenario Family | Planner | N | progress_ratio median | command_source_changes mean |")
+    lines.append("|-----------------|---------|---|----------------------|----------------------------|")
+    hybrid_eps = [ep for ep in episodes if ep["planner"] in HYBRID_PLANNERS]
+    families = sorted({ep["scenario_family"] for ep in hybrid_eps})
+    for family in families:
+        for planner in HYBRID_PLANNERS:
+            vals_pr = [
+                ep["progress_ratio"]
+                for ep in hybrid_eps
+                if ep["scenario_family"] == family
+                and ep["planner"] == planner
+                and ep["progress_ratio"] is not None
+            ]
+            vals_csc = [
+                ep["command_source_changes"]
+                for ep in hybrid_eps
+                if ep["scenario_family"] == family
+                and ep["planner"] == planner
+                and ep["command_source_changes"] is not None
+            ]
+            if vals_pr and vals_csc:
+                lines.append(
+                    f"| {family} | {planner} | {len(vals_pr)} | "
+                    f"{np.median(vals_pr):.3f} | "
+                    f"{np.mean(vals_csc):.2f} |"
+                )
+    return lines
+
+
+def build_summary(episodes: list[dict]) -> str:
+    """Build summary text for issue comment."""
+    lines = ["## Oscillatory Control Profile Summary\n"]
+    lines.extend(_planner_progress_table(episodes))
+    lines.extend(_worst_wanderers(episodes))
+    lines.extend(_hybrid_command_source_table(episodes))
+    lines.extend(_hybrid_scenario_family_table(episodes))
+    return "\n".join(lines)
+
+
+def main():
+    """Run the oscillatory control profile analysis."""
+    print("Loading episodes...")
+    episodes = load_episodes(BASE_RUNS)
+    print(f"Loaded {len(episodes)} episodes")
+
+    if not episodes:
+        print("ERROR: No episodes found", file=sys.stderr)
+        sys.exit(1)
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    output_dir = Path(OUTPUT_DIR)
+
+    # 1. Per-planner CSV
+    write_per_planner_csv(episodes, output_dir / "per_planner_percentiles.csv")
+
+    # 2. Hybrid per-scenario-family CSV
+    write_hybrid_scenario_csv(
+        episodes, output_dir / "hybrid_scenario_family_profile.csv"
+    )
+
+    # 3. Plots
+    plot_progress_ratio_distribution(
+        episodes, output_dir / "progress_ratio_distribution.png"
+    )
+    plot_command_source_changes(
+        episodes, output_dir / "command_source_changes_rate.png"
+    )
+
+    # 4. Summary text
+    summary = build_summary(episodes)
+    summary_path = output_dir / "summary.md"
+    with open(summary_path, "w") as f:
+        f.write(summary)
+    print(f"Wrote {summary_path}")
+
+    # Print summary to stdout
+    print("\n" + summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis/oscillatory_control_profile.py
+++ b/scripts/analysis/oscillatory_control_profile.py
@@ -47,10 +47,10 @@ def scenario_family_from_id(scenario_id: str) -> str:
     """Extract scenario_family from scenario_id."""
     if scenario_id.startswith("classic_"):
         # Remove 'classic_' prefix and difficulty suffix (_high, _low, _medium)
-        parts = scenario_id[len("classic_"):].rsplit("_", 1)
+        parts = scenario_id[len("classic_") :].rsplit("_", 1)
         return parts[0]
     elif scenario_id.startswith("francis2023_"):
-        return scenario_id[len("francis2023_"):]
+        return scenario_id[len("francis2023_") :]
     return scenario_id
 
 
@@ -76,9 +76,7 @@ def load_episodes(base_runs: str) -> list[dict]:
                 row = {
                     "planner": planner,
                     "scenario_id": ep.get("scenario_id", ""),
-                    "scenario_family": scenario_family_from_id(
-                        ep.get("scenario_id", "")
-                    ),
+                    "scenario_family": scenario_family_from_id(ep.get("scenario_id", "")),
                     "seed": ep.get("seed"),
                 }
                 for field in FIELDS:
@@ -87,9 +85,7 @@ def load_episodes(base_runs: str) -> list[dict]:
     return episodes
 
 
-def percentile_table(
-    episodes: list[dict], group_col: str, value_col: str
-) -> dict[str, dict]:
+def percentile_table(episodes: list[dict], group_col: str, value_col: str) -> dict[str, dict]:
     """Compute percentile stats per group."""
     grouped = defaultdict(list)
     for ep in episodes:
@@ -294,8 +290,12 @@ def _hybrid_command_source_table(episodes: list[dict]) -> list[str]:
 def _hybrid_scenario_family_table(episodes: list[dict]) -> list[str]:
     """Build hybrid planners per-scenario-family table."""
     lines = ["\n### Hybrid Planners: Per-Scenario-Family Profile\n"]
-    lines.append("| Scenario Family | Planner | N | progress_ratio median | command_source_changes mean |")
-    lines.append("|-----------------|---------|---|----------------------|----------------------------|")
+    lines.append(
+        "| Scenario Family | Planner | N | progress_ratio median | command_source_changes mean |"
+    )
+    lines.append(
+        "|-----------------|---------|---|----------------------|----------------------------|"
+    )
     hybrid_eps = [ep for ep in episodes if ep["planner"] in HYBRID_PLANNERS]
     families = sorted({ep["scenario_family"] for ep in hybrid_eps})
     for family in families:
@@ -350,17 +350,11 @@ def main():
     write_per_planner_csv(episodes, output_dir / "per_planner_percentiles.csv")
 
     # 2. Hybrid per-scenario-family CSV
-    write_hybrid_scenario_csv(
-        episodes, output_dir / "hybrid_scenario_family_profile.csv"
-    )
+    write_hybrid_scenario_csv(episodes, output_dir / "hybrid_scenario_family_profile.csv")
 
     # 3. Plots
-    plot_progress_ratio_distribution(
-        episodes, output_dir / "progress_ratio_distribution.png"
-    )
-    plot_command_source_changes(
-        episodes, output_dir / "command_source_changes_rate.png"
-    )
+    plot_progress_ratio_distribution(episodes, output_dir / "progress_ratio_distribution.png")
+    plot_command_source_changes(episodes, output_dir / "command_source_changes_rate.png")
 
     # 4. Summary text
     summary = build_summary(episodes)

--- a/scripts/analysis/oscillatory_control_profile.py
+++ b/scripts/analysis/oscillatory_control_profile.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Per-planner control-wandering + hybrid command-source-switch profile.
 
-Parses retained h600 oscillation predicates from issue4206 trace-capable rerun
-(6480 episodes) and produces:
+Parses oscillation predicates from the retained issue4206 trace-capable h600 rerun
+(6291 of 6480 episodes carry a populated oscillatory_control_predicate) and produces:
   1. Per-planner percentile CSV for progress_ratio, heading_rate_sign_changes,
      command_source_changes (with N per cell).
   2. Per-scenario-family wandering + command-source-switch profile for hybrid planners.

--- a/tests/test_oscillatory_control_profile.py
+++ b/tests/test_oscillatory_control_profile.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Tests for oscillatory_control_profile.py"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Add parent directory to path so we can import the script
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+from scripts.analysis.oscillatory_control_profile import (
+    build_summary,
+    load_episodes,
+    percentile_table,
+    scenario_family_from_id,
+    write_hybrid_scenario_csv,
+    write_per_planner_csv,
+)
+
+
+def test_scenario_family_from_id_classic():
+    """Test extracting scenario family from classic scenario IDs."""
+    assert scenario_family_from_id("classic_bottleneck_high") == "bottleneck"
+    assert scenario_family_from_id("classic_bottleneck_low") == "bottleneck"
+    assert scenario_family_from_id("classic_cross_trap_medium") == "cross_trap"
+
+
+def test_scenario_family_from_id_francis():
+    """Test extracting scenario family from francis2023 scenario IDs."""
+    assert scenario_family_from_id("francis2023_accompanying_peer") == "accompanying_peer"
+    assert scenario_family_from_id("francis2023_blind_corner") == "blind_corner"
+
+
+def test_scenario_family_from_id_other():
+    """Test extracting scenario family from unknown scenario IDs."""
+    assert scenario_family_from_id("unknown_scenario") == "unknown_scenario"
+
+
+def test_load_episodes_empty_dir():
+    """Test loading episodes from an empty directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        episodes = load_episodes(tmpdir)
+        assert episodes == []
+
+
+def test_load_episodes_with_data():
+    """Test loading episodes with mock data."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a mock planner directory
+        planner_dir = os.path.join(tmpdir, "test_planner__differential_drive")
+        os.makedirs(planner_dir)
+        episodes_file = os.path.join(planner_dir, "episodes.jsonl")
+
+        # Write a mock episode
+        episode = {
+            "scenario_id": "classic_bottleneck_high",
+            "seed": 20,
+            "safety_predicates": {
+                "oscillatory_control_predicate": {
+                    "fields": {
+                        "progress_ratio": 0.95,
+                        "command_source_changes": 3,
+                        "heading_rate_sign_changes": 5,
+                        "linear_velocity_sign_changes": 2,
+                        "mean_abs_jerk": 0.5,
+                        "path_length_m": 20.0,
+                        "net_progress_m": 19.0,
+                    }
+                }
+            },
+        }
+        with open(episodes_file, "w") as f:
+            f.write(json.dumps(episode) + "\n")
+
+        episodes = load_episodes(tmpdir)
+        assert len(episodes) == 1
+        assert episodes[0]["planner"] == "test_planner"
+        assert episodes[0]["scenario_family"] == "bottleneck"
+        assert episodes[0]["progress_ratio"] == 0.95
+
+
+def test_percentile_table():
+    """Test percentile table computation."""
+    episodes = [
+        {"planner": "A", "progress_ratio": 0.9},
+        {"planner": "A", "progress_ratio": 0.8},
+        {"planner": "A", "progress_ratio": 0.7},
+        {"planner": "B", "progress_ratio": 0.5},
+        {"planner": "B", "progress_ratio": 0.6},
+    ]
+    result = percentile_table(episodes, "planner", "progress_ratio")
+    assert "A" in result
+    assert "B" in result
+    assert result["A"]["N"] == 3
+    assert result["B"]["N"] == 2
+    assert abs(result["A"]["p50"] - 0.8) < 0.01
+
+
+def test_write_per_planner_csv():
+    """Test writing per-planner percentile CSV."""
+    episodes = [
+        {
+            "planner": "test_planner",
+            "scenario_id": "classic_bottleneck_high",
+            "scenario_family": "bottleneck",
+            "seed": 20,
+            "progress_ratio": 0.95,
+            "command_source_changes": 3,
+            "heading_rate_sign_changes": 5,
+            "linear_velocity_sign_changes": 2,
+            "mean_abs_jerk": 0.5,
+            "path_length_m": 20.0,
+            "net_progress_m": 19.0,
+        }
+    ]
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        output_path = Path(f.name)
+
+    try:
+        write_per_planner_csv(episodes, output_path)
+        assert output_path.exists()
+        with open(output_path) as f:
+            content = f.read()
+            assert "test_planner" in content
+            assert "progress_ratio_mean" in content
+    finally:
+        output_path.unlink()
+
+
+def test_write_hybrid_scenario_csv():
+    """Test writing hybrid scenario family CSV."""
+    episodes = [
+        {
+            "planner": "scenario_adaptive_hybrid_orca_v1",
+            "scenario_id": "classic_bottleneck_high",
+            "scenario_family": "bottleneck",
+            "seed": 20,
+            "progress_ratio": 0.95,
+            "command_source_changes": 3,
+        }
+    ]
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        output_path = Path(f.name)
+
+    try:
+        write_hybrid_scenario_csv(episodes, output_path)
+        assert output_path.exists()
+        with open(output_path) as f:
+            content = f.read()
+            assert "bottleneck" in content
+            assert "scenario_adaptive_hybrid_orca_v1" in content
+    finally:
+        output_path.unlink()
+
+
+def test_build_summary():
+    """Test building summary text for issue comment."""
+    episodes = [
+        {
+            "planner": "test_planner",
+            "scenario_id": "classic_bottleneck_high",
+            "scenario_family": "bottleneck",
+            "seed": 20,
+            "progress_ratio": 0.95,
+            "command_source_changes": 3,
+            "heading_rate_sign_changes": 5,
+            "linear_velocity_sign_changes": 2,
+            "mean_abs_jerk": 0.5,
+            "path_length_m": 20.0,
+            "net_progress_m": 19.0,
+        }
+    ]
+    summary = build_summary(episodes)
+    assert "Per-Planner Progress Ratio" in summary
+    assert "test_planner" in summary
+    assert "Worst Wanderers" in summary
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What/Why

This PR implements the oscillatory control profile analysis requested in #4906. It parses 6291 episodes from the retained h600 trace-capable rerun and produces:

1. **Per-planner percentile CSV** (`per_planner_percentiles.csv`): progress_ratio, heading_rate_sign_changes, command_source_changes with N, mean, p10, p25, p50, p75, p90 per planner.
2. **Hybrid scenario family CSV** (`hybrid_scenario_family_profile.csv`): progress_ratio median and command_source_changes mean per scenario family for the two hybrid planners.
3. **Two PNGs**: progress_ratio distribution (planners overlaid) and per-planner command_source_changes rate bar chart.
4. **Summary markdown** with worst wanderers and hybrid command-source handoff stats.

## Key Findings

- **Worst wanderer**: social_force (median progress_ratio = 0.222)
- **Hybrid command_source_changes**: Both hybrid planners show 0 command source switches across all 1165 episodes
- **Lowest progress_ratio scenarios for hybrids**: merging (0.484), overtaking (0.790), blind_corner (0.727)

## Validation

```
uv run pytest tests/test_oscillatory_control_profile.py -v  # 9/9 passed
uv run ruff check scripts/analysis/oscillatory_control_profile.py tests/test_oscillatory_control_profile.py  # All checks passed
uv run python scripts/analysis/oscillatory_control_profile.py  # Produces all outputs
```

## Output Artifacts

All outputs written to `output/oscillatory_control_profile/`:
- `per_planner_percentiles.csv`
- `hybrid_scenario_family_profile.csv`
- `progress_ratio_distribution.png`
- `command_source_changes_rate.png`
- `summary.md`

## Acceptance Criteria

- [x] One CSV with per-planner progress_ratio + sign-change + command_source_changes percentiles/means (N per cell)
- [x] One CSV with per-scenario-family wandering + command-source-switch profile for hybrid planners
- [x] Two PNGs: progress_ratio distribution (planners overlaid); per-planner command-source-change rate
- [x] Summary with worst wanderers and hybrid command-source handoff quantification
- [x] No edits to code, metrics, evidence, docs, or context; no campaign or Slurm activity

Closes #4906

---

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.