### PR TITLE
Issue #4904: per-planner latency + decel profile from 6480 trace episodes (cheap-lane worker)

### DIFF
--- a/scripts/analysis/issue_4904_latency_decel_profile.py
+++ b/scripts/analysis/issue_4904_latency_decel_profile.py
@@ -10,6 +10,7 @@ CPU-only, no simulation, no GPU, no campaign/Slurm.
 
 import csv
 import json
+import math
 from collections import defaultdict
 from pathlib import Path
 
@@ -35,10 +36,22 @@ def load_episodes(run_dir: Path) -> list[dict]:
             continue
         with open(episodes_file) as f:
             for line in f:
+                if not line.strip():
+                    continue
                 record = json.loads(line)
                 record["_planner"] = planner_name
                 episodes.append(record)
     return episodes
+
+
+def _is_finite_number(value) -> bool:
+    """True only for a real finite number.
+
+    json.loads silently accepts ``NaN``/``Infinity``/``-Infinity`` tokens, so a
+    non-finite field value would otherwise poison np.percentile/np.median. Booleans
+    (a subclass of int) are excluded too — a stray ``true`` must not read as ``1.0``.
+    """
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
 
 
 def extract_profiles(episodes: list[dict]) -> dict:
@@ -72,12 +85,12 @@ def extract_profiles(episodes: list[dict]) -> dict:
         latency = fields.get("response_latency_s")
         decel = fields.get("required_deceleration_m_s2")
 
-        if latency is not None:
+        if _is_finite_number(latency):
             prof["latency_populated"] += 1
-            prof["latencies"].append(latency)
+            prof["latencies"].append(float(latency))
 
-        if decel is not None:
-            prof["decels"].append(decel)
+        if _is_finite_number(decel):
+            prof["decels"].append(float(decel))
 
     return dict(profiles)
 

--- a/scripts/analysis/issue_4904_latency_decel_profile.py
+++ b/scripts/analysis/issue_4904_latency_decel_profile.py
@@ -1,0 +1,278 @@
+"""Issue #4904: per-planner response-latency + decel-demand intervention profile.
+
+Parses episodes.jsonl from the trace-capable h600 rerun, extracts
+response_latency_s and required_deceleration_m_s2 for episodes with
+interaction_exposure_steps > 0, computes per-planner percentile tables,
+and flags the goal-planner latency-null anomaly.
+
+CPU-only, no simulation, no GPU, no campaign/Slurm.
+"""
+
+import csv
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+RUN_DIR = Path("output/benchmarks/camera_ready/issue4206_trace_capable_h600_rerun_20260704/runs")
+OUTPUT_DIR = Path("output")
+
+
+def load_episodes(run_dir: Path) -> list[dict]:
+    """Load all episodes from all planners."""
+    episodes = []
+    for planner_dir in sorted(run_dir.iterdir()):
+        if not planner_dir.is_dir():
+            continue
+        planner_name = planner_dir.name.replace("__differential_drive", "")
+        episodes_file = planner_dir / "episodes.jsonl"
+        if not episodes_file.exists():
+            continue
+        with open(episodes_file) as f:
+            for line in f:
+                record = json.loads(line)
+                record["_planner"] = planner_name
+                episodes.append(record)
+    return episodes
+
+
+def extract_profiles(episodes: list[dict]) -> dict:
+    """Extract latency/decel profiles per planner, only exposure > 0."""
+    profiles = defaultdict(
+        lambda: {
+            "latencies": [],
+            "decels": [],
+            "late_evasive_true": 0,
+            "latency_populated": 0,
+            "total_exposure": 0,
+        }
+    )
+
+    for ep in episodes:
+        exposure = ep.get("interaction_exposure", {})
+        exposure_steps = exposure.get("interaction_exposure_steps", 0)
+        if exposure_steps <= 0:
+            continue
+
+        planner = ep["_planner"]
+        prof = profiles[planner]
+        prof["total_exposure"] += 1
+
+        sp = ep.get("safety_predicates", {}).get("late_evasive_predicate", {})
+        late_evasive = sp.get("late_evasive", False)
+        if late_evasive:
+            prof["late_evasive_true"] += 1
+
+        fields = sp.get("fields", {})
+        latency = fields.get("response_latency_s")
+        decel = fields.get("required_deceleration_m_s2")
+
+        if latency is not None:
+            prof["latency_populated"] += 1
+            prof["latencies"].append(latency)
+
+        if decel is not None:
+            prof["decels"].append(decel)
+
+    return dict(profiles)
+
+
+def compute_percentiles(values: list[float]) -> dict:
+    """Compute p10/p25/p50/p75/p90/max for a list of values."""
+    if not values:
+        return {
+            "N": 0,
+            "p10": None,
+            "p25": None,
+            "p50": None,
+            "p75": None,
+            "p90": None,
+            "max": None,
+        }
+    arr = np.array(values)
+    pcts = np.percentile(arr, [10, 25, 50, 75, 90])
+    return {
+        "N": len(arr),
+        "p10": round(float(pcts[0]), 6),
+        "p25": round(float(pcts[1]), 6),
+        "p50": round(float(pcts[2]), 6),
+        "p75": round(float(pcts[3]), 6),
+        "p90": round(float(pcts[4]), 6),
+        "max": round(float(np.max(arr)), 6),
+    }
+
+
+def write_percentile_csv(profiles: dict, output_path: Path) -> None:
+    """Write per-planner percentile CSV."""
+    fieldnames = [
+        "planner",
+        "exposure_episodes",
+        "late_evasive_true",
+        "latency_populated",
+        "lat_N",
+        "lat_p10",
+        "lat_p25",
+        "lat_p50",
+        "lat_p75",
+        "lat_p90",
+        "lat_max",
+        "decel_N",
+        "decel_p10",
+        "decel_p25",
+        "decel_p50",
+        "decel_p75",
+        "decel_p90",
+        "decel_max",
+        "late_evasive_rate",
+        "latency_populated_rate",
+        "anomaly_gap",
+    ]
+    with open(output_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for planner in sorted(profiles):
+            prof = profiles[planner]
+            lat_pct = compute_percentiles(prof["latencies"])
+            dec_pct = compute_percentiles(prof["decels"])
+            total = prof["total_exposure"]
+            le_rate = prof["late_evasive_true"] / total if total > 0 else 0
+            lp_rate = prof["latency_populated"] / total if total > 0 else 0
+            writer.writerow(
+                {
+                    "planner": planner,
+                    "exposure_episodes": total,
+                    "late_evasive_true": prof["late_evasive_true"],
+                    "latency_populated": prof["latency_populated"],
+                    "lat_N": lat_pct["N"],
+                    "lat_p10": lat_pct["p10"],
+                    "lat_p25": lat_pct["p25"],
+                    "lat_p50": lat_pct["p50"],
+                    "lat_p75": lat_pct["p75"],
+                    "lat_p90": lat_pct["p90"],
+                    "lat_max": lat_pct["max"],
+                    "decel_N": dec_pct["N"],
+                    "decel_p10": dec_pct["p10"],
+                    "decel_p25": dec_pct["p25"],
+                    "decel_p50": dec_pct["p50"],
+                    "decel_p75": dec_pct["p75"],
+                    "decel_p90": dec_pct["p90"],
+                    "decel_max": dec_pct["max"],
+                    "late_evasive_rate": round(le_rate, 4),
+                    "latency_populated_rate": round(lp_rate, 4),
+                    "anomaly_gap": round(le_rate - lp_rate, 4),
+                }
+            )
+
+
+def plot_latency_histogram(profiles: dict, output_path: Path) -> None:
+    """Plot overlaid response-latency histograms per planner."""
+    fig, ax = plt.subplots(figsize=(10, 6))
+    planners_sorted = sorted(profiles, key=lambda p: -len(profiles[p]["latencies"]))
+    for planner in planners_sorted:
+        lats = profiles[planner]["latencies"]
+        if not lats:
+            continue
+        ax.hist(lats, bins=30, alpha=0.5, label=f"{planner} (n={len(lats)})")
+    ax.set_xlabel("Response Latency (s)")
+    ax.set_ylabel("Episode Count")
+    ax.set_title("Per-Planner Response Latency Distribution (exposure>0, non-null)")
+    ax.legend(fontsize=7, loc="upper right")
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+
+
+def plot_decel_histogram(profiles: dict, output_path: Path) -> None:
+    """Plot overlaid decel-demand histograms per planner."""
+    fig, ax = plt.subplots(figsize=(10, 6))
+    planners_sorted = sorted(profiles, key=lambda p: -len(profiles[p]["decels"]))
+    for planner in planners_sorted:
+        decels = profiles[planner]["decels"]
+        if not decels:
+            continue
+        ax.hist(decels, bins=30, alpha=0.5, label=f"{planner} (n={len(decels)})")
+    ax.set_xlabel("Required Deceleration (m/s²)")
+    ax.set_ylabel("Episode Count")
+    ax.set_title("Per-Planner Decel-Demand Distribution (exposure>0, non-null)")
+    ax.legend(fontsize=7, loc="upper right")
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+
+
+def print_summary(profiles: dict) -> None:
+    """Print summary stats for the issue comment."""
+    # Find fastest/slowest reactors (by median latency among planners with latency data)
+    median_latencies = {}
+    for planner, prof in profiles.items():
+        if prof["latencies"]:
+            median_latencies[planner] = float(np.median(prof["latencies"]))
+
+    if median_latencies:
+        fastest = min(median_latencies, key=median_latencies.get)
+        slowest = max(median_latencies, key=median_latencies.get)
+        print("\n=== Response Latency (median, among planners with latency data) ===")
+        print(f"  Fastest reactor: {fastest} (median={median_latencies[fastest]:.3f}s)")
+        print(f"  Slowest reactor: {slowest} (median={median_latencies[slowest]:.3f}s)")
+
+    # Find hardest brakers (by median decel)
+    median_decels = {}
+    for planner, prof in profiles.items():
+        if prof["decels"]:
+            median_decels[planner] = float(np.median(prof["decels"]))
+
+    if median_decels:
+        hardest = max(median_decels, key=median_decels.get)
+        softest = min(median_decels, key=median_decels.get)
+        print("\n=== Required Deceleration (median, among planners with decel data) ===")
+        print(f"  Hardest braker: {hardest} (median={median_decels[hardest]:.6f} m/s²)")
+        print(f"  Softest braker: {softest} (median={median_decels[softest]:.6f} m/s²)")
+
+    # Goal-planner anomaly
+    print("\n=== Goal-Planner Latency-Null Anomaly ===")
+    for planner in sorted(profiles):
+        prof = profiles[planner]
+        total = prof["total_exposure"]
+        le_true = prof["late_evasive_true"]
+        lat_pop = prof["latency_populated"]
+        anomaly = le_true > 0 and lat_pop == 0
+        if anomaly or planner == "goal":
+            print(
+                f"  {planner}: exposure>0={total}, late_evasive_true={le_true}, latency_populated={lat_pop}, anomaly={anomaly}"
+            )
+
+
+def main() -> None:
+    """Run the full analysis: parse, compute percentiles, plot, and summarize."""
+    print(f"Loading episodes from {RUN_DIR}...")
+    episodes = load_episodes(RUN_DIR)
+    print(f"Loaded {len(episodes)} episodes total.")
+
+    profiles = extract_profiles(episodes)
+    print(f"Planners with exposure>0 episodes: {len(profiles)}")
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    csv_path = OUTPUT_DIR / "issue_4904_latency_decel_percentiles.csv"
+    write_percentile_csv(profiles, csv_path)
+    print(f"Wrote percentile CSV: {csv_path}")
+
+    lat_plot = OUTPUT_DIR / "issue_4904_response_latency_histogram.png"
+    plot_latency_histogram(profiles, lat_plot)
+    print(f"Wrote latency histogram: {lat_plot}")
+
+    dec_plot = OUTPUT_DIR / "issue_4904_decel_demand_histogram.png"
+    plot_decel_histogram(profiles, dec_plot)
+    print(f"Wrote decel histogram: {dec_plot}")
+
+    print_summary(profiles)
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_issue_4904_latency_decel_profile.py
+++ b/tests/test_issue_4904_latency_decel_profile.py
@@ -1,5 +1,6 @@
 """Tests for issue_4904_latency_decel_profile.py."""
 
+import csv
 import json
 from pathlib import Path
 
@@ -7,6 +8,7 @@ from scripts.analysis.issue_4904_latency_decel_profile import (
     compute_percentiles,
     extract_profiles,
     load_episodes,
+    write_percentile_csv,
 )
 
 
@@ -121,6 +123,24 @@ class TestExtractProfiles:
         assert p["latency_populated"] == 0
         assert len(p["latencies"]) == 0
 
+    def test_filters_non_finite_values(self):
+        # json.loads silently accepts NaN/Infinity tokens; they must be treated as
+        # missing so they cannot poison the percentile inputs downstream.
+        raw = [
+            '{"_planner":"p","interaction_exposure":{"interaction_exposure_steps":1},'
+            '"safety_predicates":{"late_evasive_predicate":{"late_evasive":true,"fields":'
+            '{"response_latency_s":NaN,"required_deceleration_m_s2":Infinity}}}}',
+            '{"_planner":"p","interaction_exposure":{"interaction_exposure_steps":1},'
+            '"safety_predicates":{"late_evasive_predicate":{"late_evasive":true,"fields":'
+            '{"response_latency_s":2.0,"required_deceleration_m_s2":0.5}}}}',
+        ]
+        episodes = [json.loads(line) for line in raw]
+        profiles = extract_profiles(episodes)
+        p = profiles["p"]
+        assert p["latency_populated"] == 1  # NaN excluded; only the 2.0 counts
+        assert p["latencies"] == [2.0]
+        assert p["decels"] == [0.5]  # Infinity excluded
+
 
 class TestLoadEpisodes:
     """Tests for load_episodes helper."""
@@ -139,3 +159,122 @@ class TestLoadEpisodes:
         pdir.mkdir(parents=True, exist_ok=True)
         loaded = load_episodes(tmp_path)
         assert len(loaded) == 0
+
+    def test_skips_blank_trailing_line(self, tmp_path):
+        # A trailing blank line (common from editors) must not raise.
+        pdir = tmp_path / "pp__differential_drive"
+        pdir.mkdir(parents=True, exist_ok=True)
+        episode = _make_episode("pp", exposure_steps=1, seed=0)
+        (pdir / "episodes.jsonl").write_text(json.dumps(episode) + "\n\n")
+        loaded = load_episodes(tmp_path)
+        assert len(loaded) == 1
+
+
+class TestWritePercentileCsv:
+    """Tests for the CSV deliverable and the anomaly_gap/rate formulas."""
+
+    def test_anomaly_gap_rates_and_n(self, tmp_path):
+        episodes = [
+            # goal: late_evasive on every exposure episode, latency never populated
+            *_make_episodes(
+                "goal",
+                count=10,
+                exposure_steps=5,
+                late_evasive=True,
+                response_latency_s=None,
+                required_deceleration_m_s2=0.001,
+            ),
+            # alpha: 2 exposure episodes, 1 late_evasive, both latency populated
+            _make_episode(
+                "alpha",
+                exposure_steps=5,
+                late_evasive=True,
+                response_latency_s=2.0,
+                required_deceleration_m_s2=0.5,
+                seed=1,
+            ),
+            _make_episode(
+                "alpha",
+                exposure_steps=5,
+                late_evasive=False,
+                response_latency_s=4.0,
+                required_deceleration_m_s2=0.2,
+                seed=2,
+            ),
+        ]
+        profiles = extract_profiles(episodes)
+        out = tmp_path / "pct.csv"
+        write_percentile_csv(profiles, out)
+
+        rows = out.read_text().splitlines()
+        header = rows[0].split(",")
+        for col in (
+            "planner",
+            "lat_N",
+            "anomaly_gap",
+            "late_evasive_rate",
+            "latency_populated_rate",
+            "lat_p50",
+        ):
+            assert col in header
+
+        by_planner = {r["planner"]: r for r in csv.DictReader(rows)}
+
+        goal = by_planner["goal"]
+        assert goal["exposure_episodes"] == "10"
+        assert goal["late_evasive_true"] == "10"
+        assert goal["latency_populated"] == "0"
+        assert goal["lat_N"] == "0"
+        assert goal["late_evasive_rate"] == "1.0"
+        assert goal["latency_populated_rate"] == "0.0"
+        assert goal["anomaly_gap"] == "1.0"  # 1.0 - 0.0
+
+        alpha = by_planner["alpha"]
+        assert alpha["exposure_episodes"] == "2"
+        assert alpha["lat_N"] == "2"
+        assert alpha["decel_N"] == "2"
+        assert abs(float(alpha["lat_p50"]) - 3.0) < 1e-6  # median of [2.0, 4.0]
+        assert alpha["late_evasive_rate"] == "0.5"
+        assert alpha["latency_populated_rate"] == "1.0"
+        assert abs(float(alpha["anomaly_gap"]) - (-0.5)) < 1e-6  # 0.5 - 1.0
+
+    def test_csv_is_deterministic(self, tmp_path):
+        episodes = _make_episodes(
+            "p",
+            count=20,
+            exposure_steps=5,
+            response_latency_s=0.0,  # overridden per-episode below
+            required_deceleration_m_s2=0.1,
+        )
+        for i, ep in enumerate(episodes):
+            ep["safety_predicates"]["late_evasive_predicate"]["fields"]["response_latency_s"] = (
+                float(i)
+            )
+        profiles = extract_profiles(episodes)
+        out_a = tmp_path / "a.csv"
+        out_b = tmp_path / "b.csv"
+        write_percentile_csv(profiles, out_a)
+        write_percentile_csv(profiles, out_b)
+        assert out_a.read_text() == out_b.read_text()
+
+
+def _make_episodes(
+    planner: str,
+    count: int,
+    exposure_steps: int = 0,
+    late_evasive: bool = False,
+    response_latency_s: float | None = None,
+    required_deceleration_m_s2: float | None = None,
+) -> list[dict]:
+    """Build N minimal episode records with distinct seeds."""
+    return [
+        _make_episode(
+            planner,
+            exposure_steps=exposure_steps,
+            late_evasive=late_evasive,
+            response_latency_s=response_latency_s,
+            required_deceleration_m_s2=required_deceleration_m_s2,
+            seed=i,
+        )
+        for i in range(count)
+    ]

--- a/tests/test_issue_4904_latency_decel_profile.py
+++ b/tests/test_issue_4904_latency_decel_profile.py
@@ -1,0 +1,141 @@
+"""Tests for issue_4904_latency_decel_profile.py."""
+
+import json
+from pathlib import Path
+
+from scripts.analysis.issue_4904_latency_decel_profile import (
+    compute_percentiles,
+    extract_profiles,
+    load_episodes,
+)
+
+
+def _make_episode(
+    planner: str,
+    exposure_steps: int = 0,
+    late_evasive: bool = False,
+    response_latency_s: float | None = None,
+    required_deceleration_m_s2: float | None = None,
+    seed: int = 1,
+) -> dict:
+    """Build a minimal episode record."""
+    return {
+        "_planner": planner,
+        "algo": planner,
+        "seed": seed,
+        "interaction_exposure": {"interaction_exposure_steps": exposure_steps},
+        "safety_predicates": {
+            "late_evasive_predicate": {
+                "late_evasive": late_evasive,
+                "fields": {
+                    "response_latency_s": response_latency_s,
+                    "required_deceleration_m_s2": required_deceleration_m_s2,
+                    "minimum_distance_m": 1.0,
+                },
+            }
+        },
+    }
+
+
+def _write_episodes_jsonl(tmpdir: Path, planner: str, episodes: list[dict]) -> Path:
+    """Write episodes to a planner dir."""
+    pdir = tmpdir / f"{planner}__differential_drive"
+    pdir.mkdir(parents=True, exist_ok=True)
+    with open(pdir / "episodes.jsonl", "w") as f:
+        for ep in episodes:
+            f.write(json.dumps(ep) + "\n")
+    return tmpdir
+
+
+class TestComputePercentiles:
+    """Tests for compute_percentiles helper."""
+
+    def test_empty(self):
+        result = compute_percentiles([])
+        assert result["N"] == 0
+        assert result["p50"] is None
+
+    def test_single_value(self):
+        result = compute_percentiles([5.0])
+        assert result["N"] == 1
+        assert result["p50"] == 5.0
+        assert result["max"] == 5.0
+
+    def test_known_distribution(self):
+        values = list(range(1, 101))  # 1..100
+        result = compute_percentiles(values)
+        assert result["N"] == 100
+        assert abs(result["p50"] - 50.5) < 0.1
+        assert result["max"] == 100
+
+
+class TestExtractProfiles:
+    """Tests for extract_profiles helper."""
+
+    def test_skips_zero_exposure(self):
+        episodes = [_make_episode("test_planner", exposure_steps=0)]
+        profiles = extract_profiles(episodes)
+        assert "test_planner" not in profiles
+
+    def test_extracts_with_exposure(self):
+        episodes = [
+            _make_episode(
+                "p1",
+                exposure_steps=10,
+                late_evasive=True,
+                response_latency_s=3.0,
+                required_deceleration_m_s2=0.5,
+            ),
+            _make_episode(
+                "p1",
+                exposure_steps=5,
+                late_evasive=False,
+                response_latency_s=None,
+                required_deceleration_m_s2=0.1,
+            ),
+        ]
+        profiles = extract_profiles(episodes)
+        assert "p1" in profiles
+        p = profiles["p1"]
+        assert p["total_exposure"] == 2
+        assert p["late_evasive_true"] == 1
+        assert p["latency_populated"] == 1
+        assert len(p["latencies"]) == 1
+        assert len(p["decels"]) == 2  # decel is 0.1 even when late_evasive=False
+
+    def test_goal_anomaly_pattern(self):
+        episodes = [
+            _make_episode(
+                "goal",
+                exposure_steps=10,
+                late_evasive=True,
+                response_latency_s=None,
+                required_deceleration_m_s2=0.001,
+                seed=i,
+            )
+            for i in range(5)
+        ]
+        profiles = extract_profiles(episodes)
+        p = profiles["goal"]
+        assert p["late_evasive_true"] == 5
+        assert p["latency_populated"] == 0
+        assert len(p["latencies"]) == 0
+
+
+class TestLoadEpisodes:
+    """Tests for load_episodes helper."""
+
+    def test_reads_all_planners(self, tmp_path):
+        for planner in ["planner_a", "planner_b"]:
+            episodes = [_make_episode(planner, exposure_steps=10, seed=i) for i in range(3)]
+            _write_episodes_jsonl(tmp_path, planner, episodes)
+        loaded = load_episodes(tmp_path)
+        assert len(loaded) == 6
+        planners = {ep["_planner"] for ep in loaded}
+        assert planners == {"planner_a", "planner_b"}
+
+    def test_skips_missing_jsonl(self, tmp_path):
+        pdir = tmp_path / "empty_planner__differential_drive"
+        pdir.mkdir(parents=True, exist_ok=True)
+        loaded = load_episodes(tmp_path)
+        assert len(loaded) == 0


### PR DESCRIPTION
## What

Parses all 6480 trace-rich episodes from the issue4206 h600 rerun, extracts `response_latency_s` and `required_deceleration_m_s2` from `safety_predicates.late_evasive_predicate.fields` for episodes with `interaction_exposure_steps > 0`, computes per-planner percentile tables (p10/p25/p50/p75/p90/max), and flags the `goal`-planner latency-null anomaly.

## Why

These continuous per-episode fields exist in the trace data but were never surfaced into a report or sidecar. This is the temporal counterpart to #4831's categorical failure-mechanism labels.

## Outputs (generated at runtime, not committed)

- `output/issue_4904_latency_decel_percentiles.csv` — per-planner percentiles with N, late_evasive rate, latency_populated rate, anomaly gap
- `output/issue_4904_response_latency_histogram.png` — overlaid latency distributions
- `output/issue_4904_decel_demand_histogram.png` — overlaid decel-demand distributions

## Key findings

| Metric | Fastest / Softest | Slowest / Hardest |
|---|---|---|
| Response latency (median) | social_force (2.8s) | prediction_mpc (14.2s) |
| Decel demand (median) | prediction_mpc (7.0e-4 m/s²) | social_force (1.8e-3 m/s²) |

**Goal-planner anomaly:** `goal` flags `late_evasive=true` on 109/110 exposure episodes but populates `response_latency_s` on **0** of them (anomaly_gap = 0.9909). All other planners with late_evasive events have nonzero latency population.

## Validation

```
8/8 tests passed (tests/test_issue_4904_latency_decel_profile.py)
ruff check + format: clean
CPU-only, no simulation, no campaigns, no Slurm, no metric writes
```

## Acceptance criteria (from issue)

- [x] One CSV in `output/` with per-planner latency + decel percentiles (exposure>0, non-null, N per cell)
- [x] Two PNGs in `output/`: response-latency distribution, decel-demand distribution, planners overlaid
- [x] Summary: fastest/slowest reactors, hardest brakers, goal-planner anomaly with counts
- [x] No edits to code, metrics, evidence, docs, or context; no campaign or Slurm activity

Closes #4904

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.