### PR TITLE
Issue #4919: SNQI aggregate diagnostic-mode logging regression from exception narrowing (cheap-lane worker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **issue #4919 SNQI aggregate diagnostic-mode logging regression from exception narrowing.** The
+  `robot_sf/benchmark/aggregate.py::_ensure_snqi` exception handler, narrowed from a bare
+  `except Exception:` to `except (ValueError, TypeError):` by #4887's broad-except ratchet, dropped
+  the diagnostic-mode logging contract: in `observation_track_mode="diagnostic-cross-track"`,
+  `KeyError` (missing metric keys) and `AttributeError` (the "unexpected SNQI failure" class) from
+  `snqi_fn` now propagated uncaught instead of being logged and swallowed, failing
+  `test_aggregate_snqi_recompute.py::test_compute_aggregates_logs_key_error_snqi_failure_in_diagnostic_mode`
+  and `..._logs_unexpected_snqi_failure_in_diagnostic_mode`. The handler now catches the explicit,
+  finite tuple `(ValueError, TypeError, KeyError, AttributeError)` — diagnostic mode logs and
+  continues, strict mode logs and re-raises — without re-widening to a broad `except Exception:`.
+  Acceptance met: both named tests pass; the broad-exception ratchet baseline stays at 217 and
+  `ruff check --select BLE001` on `robot_sf/benchmark/` remains clean (a named tuple is not a
+  broad-except site). Refs #4887, #4900.
 * **issue #4908 diagnostic CLI `--help` omits the canonical `uv run` invocation.** The seven
   developer-facing diagnostic CLIs under `scripts/tools/` (`validate_scenario`,
   `validate_socnav_map_batch`, `validate_experiment_registry`, `validate_report`,

--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -528,7 +528,15 @@ def _ensure_snqi(
         return
     try:
         rec["metrics"]["snqi"] = float(snqi_fn(rec["metrics"], weights, baseline_stats=baseline))
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, KeyError, AttributeError):
+        # Diagnostic-mode logging contract (#4919): this is the explicit, named
+        # set of failures ``snqi_fn`` can surface — ``ValueError``/``TypeError``
+        # for malformed numeric inputs, ``KeyError`` for missing metric keys, and
+        # ``AttributeError`` for unexpected record shapes (the "unexpected SNQI
+        # failure" class). Diagnostic mode (``strict=False``) logs and continues
+        # below; strict mode logs and re-raises. This must stay a finite tuple —
+        # widening to a bare ``except Exception:`` would re-introduce the
+        # broad-except class #4887 eliminated and regress the BLE001 ratchet.
         logger.bind(
             event="aggregation_snqi_compute_failed",
             episode_id=rec.get("episode_id"),

--- a/tests/benchmark/test_aggregate_snqi_recompute.py
+++ b/tests/benchmark/test_aggregate_snqi_recompute.py
@@ -135,6 +135,94 @@ def test_compute_aggregates_logs_record_id_and_reraises_snqi_failure_in_strict_m
     )
 
 
+def test_compute_aggregates_logs_and_reraises_key_error_snqi_failure_in_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Strict aggregation should log a missing-key SNQI failure and fail closed (#4919).
+
+    ``KeyError`` is one of the exception types the narrowed tuple (#4887) dropped and
+    this fix re-added; without strict-mode coverage a future narrowing could silently
+    let it propagate uncaught (without the ``aggregation_snqi_compute_failed`` event).
+    """
+
+    def _missing_metric_snqi(
+        metrics: dict[str, float],
+        weights: dict[str, float],
+        *,
+        baseline_stats: dict[str, dict[str, float]] | None = None,
+    ) -> float:
+        raise KeyError("renamed_metric")
+
+    monkeypatch.setattr(aggregate, "snqi_fn", _missing_metric_snqi)
+    records = [
+        {
+            "episode_id": "ep-snqi-key-fail",
+            "scenario_id": "sc-1",
+            "seed": 1,
+            "algo": "planner-a",
+            "metrics": {"score": 2.0},
+        }
+    ]
+    captured: list = []
+    handle = logger.add(captured.append, level="ERROR")
+    try:
+        with pytest.raises(KeyError, match="renamed_metric"):
+            compute_aggregates(records, group_by="algo", snqi_weights={"score": 3.0})
+    finally:
+        logger.remove(handle)
+
+    assert any(
+        msg.record["extra"].get("event") == "aggregation_snqi_compute_failed"
+        and msg.record["extra"].get("episode_id") == "ep-snqi-key-fail"
+        and msg.record["extra"].get("strict") is True
+        for msg in captured
+    )
+
+
+def test_compute_aggregates_logs_and_reraises_unexpected_snqi_failure_in_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Strict aggregation should log an unexpected-shape SNQI failure and fail closed (#4919).
+
+    ``AttributeError`` (the "unexpected SNQI failure" class) is one of the exception
+    types the narrowed tuple (#4887) dropped and this fix re-added; strict mode must
+    log it via ``aggregation_snqi_compute_failed`` before re-raising.
+    """
+
+    def _unexpected_snqi(
+        metrics: dict[str, float],
+        weights: dict[str, float],
+        *,
+        baseline_stats: dict[str, dict[str, float]] | None = None,
+    ) -> float:
+        raise AttributeError("unexpected snqi shape")
+
+    monkeypatch.setattr(aggregate, "snqi_fn", _unexpected_snqi)
+    records = [
+        {
+            "episode_id": "ep-snqi-attr-fail",
+            "scenario_id": "sc-1",
+            "seed": 1,
+            "algo": "planner-a",
+            "metrics": {"score": 2.0},
+        }
+    ]
+    captured: list = []
+    handle = logger.add(captured.append, level="ERROR")
+    try:
+        with pytest.raises(AttributeError, match="unexpected snqi shape"):
+            compute_aggregates(records, group_by="algo", snqi_weights={"score": 3.0})
+    finally:
+        logger.remove(handle)
+
+    assert any(
+        msg.record["extra"].get("event") == "aggregation_snqi_compute_failed"
+        and msg.record["extra"].get("episode_id") == "ep-snqi-attr-fail"
+        and msg.record["extra"].get("strict") is True
+        for msg in captured
+    )
+
+
 def test_compute_aggregates_logs_key_error_snqi_failure_in_diagnostic_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Issue #4919: SNQI aggregate diagnostic-mode logging regression from exception narrowing (cheap-lane worker)

Closes #4919. Fully resolves the issue (both failing tests pass; ratchet held).

## What / why

`tests/benchmark/test_aggregate_snqi_recompute.py::test_compute_aggregates_logs_key_error_snqi_failure_in_diagnostic_mode` and `..._logs_unexpected_snqi_failure_in_diagnostic_mode` both FAILED on pristine `origin/main`. Root cause: #4887's broad-except ratchet narrowed the `robot_sf/benchmark/aggregate.py::_ensure_snqi` handler from a bare `except Exception:` down to `except (ValueError, TypeError):`. That dropped the diagnostic-mode logging contract — in `observation_track_mode="diagnostic-cross-track"`, a `KeyError` (missing metric keys) or `AttributeError` (the "unexpected SNQI failure" class) raised by `snqi_fn` now propagated uncaught instead of being logged and swallowed. (Surfaced during #4900's validation.)

The fix reconciles the narrowed handler with the diagnostic-mode contract **without re-widening it into the broad-except class #4887 eliminated**: the tuple becomes the explicit, finite set `(ValueError, TypeError, KeyError, AttributeError)`.

- `ValueError` / `TypeError` — malformed numeric inputs (the realistic `snqi_fn` coercion failures).
- `KeyError` — missing metric keys.
- `AttributeError` — unexpected record shapes (the "unexpected SNQI failure" class the test encodes).

Behavior by mode is unchanged in spirit: diagnostic mode (`strict=False`) logs via the existing `aggregation_snqi_compute_failed` event and continues; strict mode logs and re-raises (still fails closed). A code comment documents why this must stay a finite tuple.

## Changes

- `robot_sf/benchmark/aggregate.py` — one logical change: widen the `_ensure_snqi` `except` tuple; rationale comment added.
- `CHANGELOG.md` — `### Fixed` entry under `[Unreleased]`.

## Validation (CPU-level only; no campaigns/Slurm/training/benchmarks)

Targeted + adjacent regression suites:
```
$ uv run pytest tests/benchmark/test_aggregate_snqi_recompute.py -q
5 passed, 1 skipped in 1.19s   # skip = test_aggregate_cli_passes_recompute_snqi_flag (torch-gated)

$ uv run pytest tests/benchmark/test_aggregate_characterization.py \
                 tests/benchmark/test_aggregate_snqi_recompute.py \
                 tests/benchmark/test_aggregation_algorithms.py -q
37 passed, 1 skipped in 1.30s
```

Broad-exception ratchet gate (acceptance: baseline ≤ 217, held):
```
$ uv run python scripts/validation/check_broad_exceptions.py
Broad exception ratchet passed with 217 entries.
```

Ruff BLE001 (a named exception tuple is **not** a broad-except site):
```
$ uv run ruff check robot_sf/benchmark/ --select BLE001
All checks passed!
$ uv run ruff check robot_sf/benchmark/aggregate.py
All checks passed!
```

## Acceptance criteria (from the issue)

- [x] Both named tests pass.
- [x] Diagnostic-mode logging remains explicit (`aggregation_snqi_compute_failed` event with `episode_id`/`algo` context).
- [x] No regression in the broad-exception ratchet count — baseline stays ≤ 217 (217 observed).
- [x] Handler not re-widened to a broad `except Exception:`.

This is a single-session complete fix, not a slice.

This PR was produced by the ClaudeCode-harness/GLM-Coding-Pro cheap implementation lane; the review gate hardens and merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where diagnostic-mode SNQI aggregation could miss or stop logging certain exceptions during recomputation.
  * Improved error handling so more relevant failures are handled consistently in diagnostic mode, while strict mode still re-raises errors as expected.
  * Verified the affected diagnostic aggregation checks continue to pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->