### PR TITLE
Issue #4903: provenance-pinned marker dates for export bundles (cheap-lane worker)

### DIFF
--- a/robot_sf/evidence/writers.py
+++ b/robot_sf/evidence/writers.py
@@ -68,6 +68,22 @@ def review_marker(issue_ref: str, marker_date: str | None = None) -> str:
     return f"<!-- AI-GENERATED ({issue_ref}) - NEEDS-REVIEW -->"
 
 
+def extract_marker_date(metadata: dict[str, Any]) -> str | None:
+    """Extract YYYY-MM-DD from a bundle's ``generated_at_utc`` provenance field.
+
+    Deterministic per the maintainer decision on #4903: the marker date is
+    pinned to the bundle's provenance timestamp and never falls back to
+    wall-clock time. When the provenance field is absent or empty, returns
+    ``None`` so the marker omits the date rather than fabricating one from the
+    current time.
+
+    Returns:
+        The ``YYYY-MM-DD`` date string, or ``None`` when provenance is absent.
+    """
+    generated_at = metadata.get("generated_at_utc", "")
+    return generated_at[:10] if generated_at else None
+
+
 def review_marker_json() -> str:
     """Return the review marker value for JSON metadata."""
     return "AI-GENERATED NEEDS-REVIEW"

--- a/robot_sf/evidence/writers.py
+++ b/robot_sf/evidence/writers.py
@@ -52,12 +52,19 @@ def sha256_file(path: Path) -> str:
     return hasher.hexdigest()
 
 
-def review_marker(issue_ref: str) -> str:
+def review_marker(issue_ref: str, marker_date: str | None = None) -> str:
     """Return the standard review marker comment for a given issue reference.
 
     Args:
         issue_ref: Issue identifier like "robot_sf#4891" or "robot_sf#4848"
+        marker_date: Optional ISO date (YYYY-MM-DD) pinned to the bundle's
+            provenance timestamp.  When provided the marker includes the date
+            so that re-runs from the same bundle produce byte-identical output.
+            Must never be wall-clock time; derive from metadata or pass
+            explicitly via ``--marker-date``.
     """
+    if marker_date is not None:
+        return f"<!-- AI-GENERATED ({issue_ref}, {marker_date}) - NEEDS-REVIEW -->"
     return f"<!-- AI-GENERATED ({issue_ref}) - NEEDS-REVIEW -->"
 
 

--- a/scripts/export_issue_4848_group_crossing_exemplars.py
+++ b/scripts/export_issue_4848_group_crossing_exemplars.py
@@ -25,6 +25,16 @@ from robot_sf.evidence.writers import (
     write_sha256sums,
 )
 
+
+def _extract_marker_date(metadata: dict[str, Any]) -> str:
+    """Extract YYYY-MM-DD from the bundle's generated_at_utc provenance field.
+
+    This is the deterministic marker-date per the maintainer decision on #4903:
+    pinned to the bundle's provenance timestamp, never wall-clock.
+    """
+    generated_at = metadata.get("generated_at_utc", "")
+    return generated_at[:10] if generated_at else datetime.now(UTC).strftime("%Y-%m-%d")
+
 # Target planners for exemplar selection (classical + social navigation diversity)
 TARGET_PLANNERS = ["goal", "orca", "social_force"]
 
@@ -310,7 +320,8 @@ def write_bundle(
 
 def _write_readme(output_dir: Path, metadata: dict[str, Any]) -> None:
     """Write the human-facing evidence bundle README."""
-    readme = f"""{review_marker("robot_sf#4848")}
+    date = _extract_marker_date(metadata)
+    readme = f"""{review_marker("robot_sf#4848", marker_date=date)}
 # Issue #4848 Exemplar Trace: {metadata["scenario_id"]} ({metadata["planner"]})
 
 Plain-language summary: this directory contains one exemplar trace episode from the
@@ -350,10 +361,11 @@ benchmark campaign, not a Slurm or GPU result, and not a statistical comparison.
 def write_selection_report(
     all_selections: list[SelectedEpisode],
     output_dir: Path,
+    marker_date: str | None = None,
 ) -> None:
     """Write the selection report listing all selected episodes."""
     report_lines = [
-        review_marker("robot_sf#4848"),
+        review_marker("robot_sf#4848", marker_date=marker_date),
         "# Issue #4848 Group-Crossing Exemplar Selection Report",
         "",
         f"Generated: {datetime.now(UTC).isoformat()}",
@@ -412,17 +424,17 @@ def _process_planner(
     planner: str,
     campaign_root: Path,
     output_dir: Path,
-) -> list[SelectedEpisode]:
+) -> tuple[list[SelectedEpisode], dict[str, Any] | None]:
     """Process one planner: read episodes, select exemplars, write bundles."""
     planner_dir = campaign_root / f"{planner}__differential_drive"
     if not planner_dir.exists():
         print(f"Warning: planner directory not found: {planner_dir}")
-        return []
+        return [], None
 
     episodes_path = planner_dir / "episodes.jsonl"
     if not episodes_path.exists():
         print(f"Warning: episodes.jsonl not found: {episodes_path}")
-        return []
+        return [], None
 
     print(f"Reading episodes from {episodes_path}")
     episodes = read_jsonl(episodes_path)
@@ -431,6 +443,7 @@ def _process_planner(
     selections = select_exemplars_for_planner(episodes, planner)
     print(f"Selected {len(selections)} exemplars for {planner}")
 
+    first_metadata: dict[str, Any] | None = None
     for sel in selections:
         episode_record = _find_episode(episodes, sel)
         if episode_record is None:
@@ -443,13 +456,15 @@ def _process_planner(
         bundle_dir.mkdir(parents=True, exist_ok=True)
 
         print(f"Writing bundle to {bundle_dir}")
-        write_bundle(
+        metadata = write_bundle(
             episode_record=episode_record,
             selection=sel,
             output_dir=bundle_dir,
         )
+        if first_metadata is None:
+            first_metadata = metadata
 
-    return selections
+    return selections, first_metadata
 
 
 def _find_episode(episodes: list[dict[str, Any]], sel: SelectedEpisode) -> dict[str, Any] | None:
@@ -500,10 +515,15 @@ def main() -> int:
         return 1
 
     all_selections: list[SelectedEpisode] = []
+    bundle_metadata: dict[str, Any] | None = None
     for planner in args.planners:
-        all_selections.extend(_process_planner(planner, campaign_root, output_dir))
+        selections, metadata = _process_planner(planner, campaign_root, output_dir)
+        all_selections.extend(selections)
+        if bundle_metadata is None and metadata is not None:
+            bundle_metadata = metadata
 
-    write_selection_report(all_selections, output_dir)
+    marker_date = _extract_marker_date(bundle_metadata) if bundle_metadata else None
+    write_selection_report(all_selections, output_dir, marker_date=marker_date)
 
     print(f"\nExport complete. {len(all_selections)} exemplar bundles written to {output_dir}")
     print(f"Selection report: {output_dir / 'SELECTION_REPORT.md'}")

--- a/scripts/export_issue_4848_group_crossing_exemplars.py
+++ b/scripts/export_issue_4848_group_crossing_exemplars.py
@@ -26,14 +26,18 @@ from robot_sf.evidence.writers import (
 )
 
 
-def _extract_marker_date(metadata: dict[str, Any]) -> str:
+def _extract_marker_date(metadata: dict[str, Any]) -> str | None:
     """Extract YYYY-MM-DD from the bundle's generated_at_utc provenance field.
 
-    This is the deterministic marker-date per the maintainer decision on #4903:
-    pinned to the bundle's provenance timestamp, never wall-clock.
+    Deterministic per the maintainer decision on #4903: the marker date is
+    pinned to the bundle's provenance timestamp and never falls back to
+    wall-clock time. When the provenance field is absent or empty, returns
+    ``None`` so the marker omits the date rather than fabricating one from the
+    current time.
     """
     generated_at = metadata.get("generated_at_utc", "")
-    return generated_at[:10] if generated_at else datetime.now(UTC).strftime("%Y-%m-%d")
+    return generated_at[:10] if generated_at else None
+
 
 # Target planners for exemplar selection (classical + social navigation diversity)
 TARGET_PLANNERS = ["goal", "orca", "social_force"]

--- a/scripts/export_issue_4848_group_crossing_exemplars.py
+++ b/scripts/export_issue_4848_group_crossing_exemplars.py
@@ -19,25 +19,12 @@ from pathlib import Path
 from typing import Any
 
 from robot_sf.evidence.writers import (
+    extract_marker_date,
     review_marker,
     write_csv,
     write_json,
     write_sha256sums,
 )
-
-
-def _extract_marker_date(metadata: dict[str, Any]) -> str | None:
-    """Extract YYYY-MM-DD from the bundle's generated_at_utc provenance field.
-
-    Deterministic per the maintainer decision on #4903: the marker date is
-    pinned to the bundle's provenance timestamp and never falls back to
-    wall-clock time. When the provenance field is absent or empty, returns
-    ``None`` so the marker omits the date rather than fabricating one from the
-    current time.
-    """
-    generated_at = metadata.get("generated_at_utc", "")
-    return generated_at[:10] if generated_at else None
-
 
 # Target planners for exemplar selection (classical + social navigation diversity)
 TARGET_PLANNERS = ["goal", "orca", "social_force"]
@@ -324,7 +311,7 @@ def write_bundle(
 
 def _write_readme(output_dir: Path, metadata: dict[str, Any]) -> None:
     """Write the human-facing evidence bundle README."""
-    date = _extract_marker_date(metadata)
+    date = extract_marker_date(metadata)
     readme = f"""{review_marker("robot_sf#4848", marker_date=date)}
 # Issue #4848 Exemplar Trace: {metadata["scenario_id"]} ({metadata["planner"]})
 
@@ -526,7 +513,7 @@ def main() -> int:
         if bundle_metadata is None and metadata is not None:
             bundle_metadata = metadata
 
-    marker_date = _extract_marker_date(bundle_metadata) if bundle_metadata else None
+    marker_date = extract_marker_date(bundle_metadata) if bundle_metadata else None
     write_selection_report(all_selections, output_dir, marker_date=marker_date)
 
     print(f"\nExport complete. {len(all_selections)} exemplar bundles written to {output_dir}")

--- a/scripts/export_issue_4891_head_on_corridor_exemplars.py
+++ b/scripts/export_issue_4891_head_on_corridor_exemplars.py
@@ -25,6 +25,16 @@ from robot_sf.evidence.writers import (
     write_sha256sums,
 )
 
+
+def _extract_marker_date(metadata: dict[str, Any]) -> str:
+    """Extract YYYY-MM-DD from the bundle's generated_at_utc provenance field.
+
+    This is the deterministic marker-date per the maintainer decision on #4903:
+    pinned to the bundle's provenance timestamp, never wall-clock.
+    """
+    generated_at = metadata.get("generated_at_utc", "")
+    return generated_at[:10] if generated_at else datetime.now(UTC).strftime("%Y-%m-%d")
+
 # Target planners for exemplar selection (classical + social navigation diversity)
 TARGET_PLANNERS = ["goal", "orca", "social_force"]
 
@@ -359,7 +369,8 @@ def write_bundle(
 
 def _write_readme(output_dir: Path, metadata: dict[str, Any]) -> None:
     """Write the human-facing evidence bundle README."""
-    readme = f"""{review_marker("robot_sf#4891")}
+    date = _extract_marker_date(metadata)
+    readme = f"""{review_marker("robot_sf#4891", marker_date=date)}
 # Issue #4891 Exemplar Trace: {metadata["scenario_id"]} ({metadata["planner"]})
 
 Plain-language summary: this directory contains one exemplar trace episode from the
@@ -399,10 +410,11 @@ benchmark campaign, not a Slurm or GPU result, and not a statistical comparison.
 def write_selection_report(
     all_selections: list[SelectedEpisode],
     output_dir: Path,
+    marker_date: str | None = None,
 ) -> None:
     """Write the selection report listing all selected episodes."""
     report_lines = [
-        review_marker("robot_sf#4891"),
+        review_marker("robot_sf#4891", marker_date=marker_date),
         "# Issue #4891 Head-On Corridor Exemplar Selection Report",
         "",
         f"Generated: {datetime.now(UTC).isoformat()}",
@@ -469,17 +481,17 @@ def _process_planner(
     planner: str,
     campaign_root: Path,
     output_dir: Path,
-) -> list[SelectedEpisode]:
+) -> tuple[list[SelectedEpisode], dict[str, Any] | None]:
     """Process one planner: read episodes, select exemplars, write bundles."""
     planner_dir = campaign_root / f"{planner}__differential_drive"
     if not planner_dir.exists():
         print(f"Warning: planner directory not found: {planner_dir}")
-        return []
+        return [], None
 
     episodes_path = planner_dir / "episodes.jsonl"
     if not episodes_path.exists():
         print(f"Warning: episodes.jsonl not found: {episodes_path}")
-        return []
+        return [], None
 
     print(f"Reading episodes from {episodes_path}")
     episodes = read_jsonl(episodes_path)
@@ -488,6 +500,7 @@ def _process_planner(
     selections = select_exemplars_for_planner(episodes, planner)
     print(f"Selected {len(selections)} exemplars for {planner}")
 
+    first_metadata: dict[str, Any] | None = None
     for sel in selections:
         episode_record = _find_episode(episodes, sel)
         if episode_record is None:
@@ -500,13 +513,15 @@ def _process_planner(
         bundle_dir.mkdir(parents=True, exist_ok=True)
 
         print(f"Writing bundle to {bundle_dir}")
-        write_bundle(
+        metadata = write_bundle(
             episode_record=episode_record,
             selection=sel,
             output_dir=bundle_dir,
         )
+        if first_metadata is None:
+            first_metadata = metadata
 
-    return selections
+    return selections, first_metadata
 
 
 def _find_episode(episodes: list[dict[str, Any]], sel: SelectedEpisode) -> dict[str, Any] | None:
@@ -557,10 +572,15 @@ def main() -> int:
         return 1
 
     all_selections: list[SelectedEpisode] = []
+    bundle_metadata: dict[str, Any] | None = None
     for planner in args.planners:
-        all_selections.extend(_process_planner(planner, campaign_root, output_dir))
+        selections, metadata = _process_planner(planner, campaign_root, output_dir)
+        all_selections.extend(selections)
+        if bundle_metadata is None and metadata is not None:
+            bundle_metadata = metadata
 
-    write_selection_report(all_selections, output_dir)
+    marker_date = _extract_marker_date(bundle_metadata) if bundle_metadata else None
+    write_selection_report(all_selections, output_dir, marker_date=marker_date)
 
     print(f"\nExport complete. {len(all_selections)} exemplar bundles written to {output_dir}")
     print(f"Selection report: {output_dir / 'SELECTION_REPORT.md'}")

--- a/scripts/export_issue_4891_head_on_corridor_exemplars.py
+++ b/scripts/export_issue_4891_head_on_corridor_exemplars.py
@@ -19,24 +19,15 @@ from pathlib import Path
 from typing import Any
 
 from robot_sf.evidence.writers import (
+    extract_marker_date,
     review_marker,
     write_csv,
     write_json,
     write_sha256sums,
 )
 
-
-def _extract_marker_date(metadata: dict[str, Any]) -> str | None:
-    """Extract YYYY-MM-DD from the bundle's generated_at_utc provenance field.
-
-    Deterministic per the maintainer decision on #4903: the marker date is
-    pinned to the bundle's provenance timestamp and never falls back to
-    wall-clock time. When the provenance field is absent or empty, returns
-    ``None`` so the marker omits the date rather than fabricating one from the
-    current time.
-    """
-    generated_at = metadata.get("generated_at_utc", "")
-    return generated_at[:10] if generated_at else None
+# Back-compat alias for the shared helper (kept for the module-attribute tests).
+_extract_marker_date = extract_marker_date
 
 
 # Target planners for exemplar selection (classical + social navigation diversity)
@@ -373,7 +364,7 @@ def write_bundle(
 
 def _write_readme(output_dir: Path, metadata: dict[str, Any]) -> None:
     """Write the human-facing evidence bundle README."""
-    date = _extract_marker_date(metadata)
+    date = extract_marker_date(metadata)
     readme = f"""{review_marker("robot_sf#4891", marker_date=date)}
 # Issue #4891 Exemplar Trace: {metadata["scenario_id"]} ({metadata["planner"]})
 
@@ -583,7 +574,7 @@ def main() -> int:
         if bundle_metadata is None and metadata is not None:
             bundle_metadata = metadata
 
-    marker_date = _extract_marker_date(bundle_metadata) if bundle_metadata else None
+    marker_date = extract_marker_date(bundle_metadata) if bundle_metadata else None
     write_selection_report(all_selections, output_dir, marker_date=marker_date)
 
     print(f"\nExport complete. {len(all_selections)} exemplar bundles written to {output_dir}")

--- a/scripts/export_issue_4891_head_on_corridor_exemplars.py
+++ b/scripts/export_issue_4891_head_on_corridor_exemplars.py
@@ -26,14 +26,18 @@ from robot_sf.evidence.writers import (
 )
 
 
-def _extract_marker_date(metadata: dict[str, Any]) -> str:
+def _extract_marker_date(metadata: dict[str, Any]) -> str | None:
     """Extract YYYY-MM-DD from the bundle's generated_at_utc provenance field.
 
-    This is the deterministic marker-date per the maintainer decision on #4903:
-    pinned to the bundle's provenance timestamp, never wall-clock.
+    Deterministic per the maintainer decision on #4903: the marker date is
+    pinned to the bundle's provenance timestamp and never falls back to
+    wall-clock time. When the provenance field is absent or empty, returns
+    ``None`` so the marker omits the date rather than fabricating one from the
+    current time.
     """
     generated_at = metadata.get("generated_at_utc", "")
-    return generated_at[:10] if generated_at else datetime.now(UTC).strftime("%Y-%m-%d")
+    return generated_at[:10] if generated_at else None
+
 
 # Target planners for exemplar selection (classical + social navigation diversity)
 TARGET_PLANNERS = ["goal", "orca", "social_force"]

--- a/tests/test_evidence_writers.py
+++ b/tests/test_evidence_writers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from robot_sf.evidence.writers import (
+    extract_marker_date,
     review_marker,
     review_marker_comment,
     review_marker_json,
@@ -38,6 +39,21 @@ class TestReviewMarker:
 
     def test_review_marker_comment(self) -> None:
         assert review_marker_comment() == "# AI-GENERATED NEEDS-REVIEW"
+
+
+class TestExtractMarkerDate:
+    """Test the shared extract_marker_date provenance helper."""
+
+    def test_extracts_date_from_iso_timestamp(self) -> None:
+        assert (
+            extract_marker_date({"generated_at_utc": "2026-07-08T12:34:56+00:00"}) == "2026-07-08"
+        )
+
+    def test_missing_generated_at_returns_none(self) -> None:
+        assert extract_marker_date({}) is None
+
+    def test_empty_generated_at_returns_none(self) -> None:
+        assert extract_marker_date({"generated_at_utc": ""}) is None
 
 
 class TestSha256File:

--- a/tests/test_evidence_writers.py
+++ b/tests/test_evidence_writers.py
@@ -25,6 +25,14 @@ class TestReviewMarker:
         marker = review_marker("robot_sf#4891")
         assert marker == "<!-- AI-GENERATED (robot_sf#4891) - NEEDS-REVIEW -->"
 
+    def test_review_marker_with_date(self) -> None:
+        marker = review_marker("robot_sf#4891", marker_date="2026-07-09")
+        assert marker == "<!-- AI-GENERATED (robot_sf#4891, 2026-07-09) - NEEDS-REVIEW -->"
+
+    def test_review_marker_none_date_omits_date(self) -> None:
+        marker = review_marker("robot_sf#4891", marker_date=None)
+        assert marker == "<!-- AI-GENERATED (robot_sf#4891) - NEEDS-REVIEW -->"
+
     def test_review_marker_json(self) -> None:
         assert review_marker_json() == "AI-GENERATED NEEDS-REVIEW"
 

--- a/tests/test_export_issue_4891.py
+++ b/tests/test_export_issue_4891.py
@@ -195,6 +195,22 @@ class TestSha256File:
         assert digest == "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
 
 
+class TestExtractMarkerDate:
+    """Test the _extract_marker_date helper."""
+
+    def test_extracts_date_from_iso_timestamp(self) -> None:
+        metadata = {"generated_at_utc": "2026-07-08T23:13:18.867110+00:00"}
+        assert _export_module._extract_marker_date(metadata) == "2026-07-08"
+
+    def test_empty_generated_at_uses_today(self) -> None:
+        metadata: dict[str, str] = {}
+        result = _export_module._extract_marker_date(metadata)
+        # Should be a valid YYYY-MM-DD string (today's date)
+        assert len(result) == 10
+        assert result[4] == "-"
+        assert result[7] == "-"
+
+
 class TestConstants:
     """Test module constants are set correctly."""
 

--- a/tests/test_export_issue_4891.py
+++ b/tests/test_export_issue_4891.py
@@ -202,13 +202,14 @@ class TestExtractMarkerDate:
         metadata = {"generated_at_utc": "2026-07-08T23:13:18.867110+00:00"}
         assert _export_module._extract_marker_date(metadata) == "2026-07-08"
 
-    def test_empty_generated_at_uses_today(self) -> None:
-        metadata: dict[str, str] = {}
-        result = _export_module._extract_marker_date(metadata)
-        # Should be a valid YYYY-MM-DD string (today's date)
-        assert len(result) == 10
-        assert result[4] == "-"
-        assert result[7] == "-"
+    def test_missing_generated_at_returns_none(self) -> None:
+        # Per #4903 the marker date is provenance-pinned with no wall-clock
+        # fallback: missing provenance must yield no date, not today's date.
+        assert _export_module._extract_marker_date({}) is None
+
+    def test_empty_generated_at_returns_none(self) -> None:
+        metadata: dict[str, str] = {"generated_at_utc": ""}
+        assert _export_module._extract_marker_date(metadata) is None
 
 
 class TestConstants:


### PR DESCRIPTION
## What

Add `marker_date` parameter to `review_marker()` so that AI-GENERATED/NEEDS-REVIEW HTML comment dates in README and SELECTION_REPORT files are pinned to the bundle's provenance timestamp (`generated_at_utc`), never wall-clock time.

## Why

PR #4910 landed the shared evidence writers but `review_marker()` did not carry the date component. The committed #4848 and #4891 bundles have dates in their markers (`<!-- AI-GENERATED (robot_sf#4891, 2026-07-09) - NEEDS-REVIEW -->`), but the writer function omitted them. This PR completes that gap per the maintainer decision on #4903.

## Changes

- `robot_sf/evidence/writers.py`: `review_marker()` accepts optional `marker_date: str | None` parameter
- `scripts/export_issue_4848_group_crossing_exemplars.py`: add `_extract_marker_date()`, pass marker date from bundle metadata to `_write_readme()` and `write_selection_report()`
- `scripts/export_issue_4891_head_on_corridor_exemplars.py`: same changes as above
- `tests/test_evidence_writers.py`: tests for `review_marker()` with/without `marker_date`
- `tests/test_export_issue_4891.py`: tests for `_extract_marker_date()` extraction logic

## Validation

```
uv run pytest tests/test_evidence_writers.py tests/test_export_issue_4891.py -q
uv run ruff check robot_sf/evidence/writers.py scripts/export_issue_4891_head_on_corridor_exemplars.py scripts/export_issue_4848_group_crossing_exemplars.py tests/test_evidence_writers.py tests/test_export_issue_4891.py
```

All 30 tests pass. Ruff clean.

## Successor slice / remaining work

Bundle reconciliation (re-run exports against retained campaign data and update committed bundles) is deferred because seed selections changed due to #4912's quality-aware tie-breaking, which is a content-level change beyond the marker-date scope of this PR. That reconciliation should be a separate issue or a continuation of #4903.

## Refs #4903

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated evidence markers now support a pinned date, making exported READMEs and selection reports consistent with the bundle’s timestamp.
  * Exports now carry a stable date in marker comments when available, with a fallback to the current date if needed.

* **Tests**
  * Added coverage for date-aware marker generation and date extraction from bundle metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->