### PR TITLE
fix(4929): keep check_docs_evidence_integrity robot_sf-free (docs-evidence CI regression)

### DIFF
--- a/scripts/dev/check_docs_evidence_integrity.py
+++ b/scripts/dev/check_docs_evidence_integrity.py
@@ -29,6 +29,7 @@ The check is independent from the full Python test suite.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import subprocess
@@ -38,10 +39,25 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from robot_sf.benchmark.identity.hash_utils import sha256_file as _sha256
-
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
+
+
+def _sha256(path: Path) -> str:
+    """Return sha256 digest for a file.
+
+    Kept local (no ``robot_sf`` import) so this changed-path-scoped guard runs
+    in the lightweight docs-evidence-integrity CI job, which installs only
+    PyYAML and not the package. See #4926/#4929 regression: importing
+    ``robot_sf.benchmark.identity.hash_utils`` here broke every docs/evidence PR
+    with ``ModuleNotFoundError: No module named 'robot_sf'``.
+    """
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
 
 _CATALOG_PATH = Path("docs/context/catalog.yaml")
 _EVIDENCE_DIR = Path("docs/context/evidence")


### PR DESCRIPTION
## What / Why

**CI regression hotfix.** PR #4929 (issue #4926 helper consolidation, squash `9293786cc`) replaced the self-contained `hashlib`-based `_sha256` in `scripts/dev/check_docs_evidence_integrity.py` with a top-level `from robot_sf.benchmark.identity.hash_utils import sha256_file as _sha256`.

The **docs-evidence-integrity** workflow is deliberately lightweight (`Install PyYAML` only — "independent of the full Python test suite", issue #3476). It does **not** install `robot_sf`, so the new top-level import raises:

```
File ".../scripts/dev/check_docs_evidence_integrity.py", line 41, in <module>
    from robot_sf.benchmark.identity.hash_utils import sha256_file as _sha256
ModuleNotFoundError: No module named 'robot_sf'
```

This fails the changed-path-scoped guard on **every** PR touching `docs/**`, `*.md`, `*.json`, `*.yaml`, etc. It surfaced on PR #4934 (a docs-only PR) — [failing run](https://github.com/ll7/robot_sf_ll7/actions/runs/29005511987/job/86076035653). #4929's own CI missed it because that PR touched no evidence paths, so the changed-path-scoped job never triggered.

## Fix

Restore the local `hashlib`-based `_sha256` helper (byte-identical to the pre-#4929 definition) and drop the `robot_sf` import, so the guard is self-contained again. Added a docstring note so the consolidation isn't reapplied here.

## Validation

- Module imports cleanly with `robot_sf` blocked via a `meta_path` finder (simulating the package-less CI job); `_sha256` digest matches `hashlib.sha256`.
- `uv run pytest tests/ -k check_docs_evidence_integrity` → **24 passed**.
- `ruff check` / `ruff format` clean.

Refs #4926

Gate-authored fix (PR review gate) for a regression introduced by a gate-merged PR.
