### PR TITLE
Issue #4903: deterministic bundle regeneration + closing tag alignment (cheap-lane worker)

### DIFF
--- a/scripts/export_issue_4848_group_crossing_exemplars.py
+++ b/scripts/export_issue_4848_group_crossing_exemplars.py
@@ -524,7 +524,9 @@ def main() -> int:
     bundle_metadata: dict[str, Any] | None = None
     for planner in args.planners:
         selections, metadata = _process_planner(
-            planner, campaign_root, output_dir,
+            planner,
+            campaign_root,
+            output_dir,
             pin_generated_at=args.pin_generated_at,
         )
         all_selections.extend(selections)

--- a/scripts/export_issue_4848_group_crossing_exemplars.py
+++ b/scripts/export_issue_4848_group_crossing_exemplars.py
@@ -266,6 +266,7 @@ def write_bundle(
     episode_record: dict[str, Any],
     selection: SelectedEpisode,
     output_dir: Path,
+    pin_generated_at: str | None = None,
 ) -> dict[str, Any]:
     """Write a trace episode bundle for one selected episode."""
     derived = derive_trace_rows(episode_record)
@@ -278,7 +279,7 @@ def write_bundle(
             "illustrative group-crossing interaction only; "
             "no statistical, benchmark, or dissertation claim"
         ),
-        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "generated_at_utc": pin_generated_at or datetime.now(UTC).isoformat(),
         "git_commit": _git_commit(),
         "campaign_id": "issue4206_trace_capable_h600_rerun_20260704",
         "campaign_job": "13334",
@@ -345,6 +346,8 @@ statistical benchmark or dissertation claim.
 This bundle is `illustrative_exemplar` evidence for one group-crossing episode.
 It should be used for visualization and worked example input only. It is not a full
 benchmark campaign, not a Slurm or GPU result, and not a statistical comparison.
+
+<!-- /AI-GENERATED -->
 """
     (output_dir / "README.md").write_text(readme, encoding="utf-8")
 
@@ -403,6 +406,8 @@ def write_selection_report(
             "",
             "These three planners span the classical-to-social spectrum and provide diverse "
             "interaction behaviors for visualization and worked examples.",
+            "",
+            "<!-- /AI-GENERATED -->",
         ]
     )
 
@@ -415,6 +420,7 @@ def _process_planner(
     planner: str,
     campaign_root: Path,
     output_dir: Path,
+    pin_generated_at: str | None = None,
 ) -> tuple[list[SelectedEpisode], dict[str, Any] | None]:
     """Process one planner: read episodes, select exemplars, write bundles."""
     planner_dir = campaign_root / f"{planner}__differential_drive"
@@ -451,6 +457,7 @@ def _process_planner(
             episode_record=episode_record,
             selection=sel,
             output_dir=bundle_dir,
+            pin_generated_at=pin_generated_at,
         )
         if first_metadata is None:
             first_metadata = metadata
@@ -491,6 +498,14 @@ def main() -> int:
         default=TARGET_PLANNERS,
         help=f"Planners to select exemplars from (default: {' '.join(TARGET_PLANNERS)})",
     )
+    parser.add_argument(
+        "--pin-generated-at",
+        default=None,
+        help=(
+            "Override generated_at_utc in all bundle metadata with this ISO 8601 string. "
+            "For deterministic re-runs only; do not use wall-clock time."
+        ),
+    )
     args = parser.parse_args()
 
     repo_root = _repo_root()
@@ -508,7 +523,10 @@ def main() -> int:
     all_selections: list[SelectedEpisode] = []
     bundle_metadata: dict[str, Any] | None = None
     for planner in args.planners:
-        selections, metadata = _process_planner(planner, campaign_root, output_dir)
+        selections, metadata = _process_planner(
+            planner, campaign_root, output_dir,
+            pin_generated_at=args.pin_generated_at,
+        )
         all_selections.extend(selections)
         if bundle_metadata is None and metadata is not None:
             bundle_metadata = metadata

--- a/scripts/export_issue_4891_head_on_corridor_exemplars.py
+++ b/scripts/export_issue_4891_head_on_corridor_exemplars.py
@@ -319,6 +319,7 @@ def write_bundle(
     episode_record: dict[str, Any],
     selection: SelectedEpisode,
     output_dir: Path,
+    pin_generated_at: str | None = None,
 ) -> dict[str, Any]:
     """Write a trace episode bundle for one selected episode."""
     derived = derive_trace_rows(episode_record)
@@ -331,7 +332,7 @@ def write_bundle(
             "illustrative head-on corridor interaction only; "
             "no statistical, benchmark, or dissertation claim"
         ),
-        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "generated_at_utc": pin_generated_at or datetime.now(UTC).isoformat(),
         "git_commit": _git_commit(),
         "campaign_id": "issue4206_trace_capable_h600_rerun_20260704",
         "campaign_job": "13334",
@@ -398,6 +399,8 @@ statistical benchmark or dissertation claim.
 This bundle is `illustrative_exemplar` evidence for one head-on corridor episode.
 It should be used for visualization and worked example input only. It is not a full
 benchmark campaign, not a Slurm or GPU result, and not a statistical comparison.
+
+<!-- /AI-GENERATED -->
 """
     (output_dir / "README.md").write_text(readme, encoding="utf-8")
 
@@ -464,6 +467,8 @@ def write_selection_report(
             "",
             "These three planners span the classical-to-social spectrum and provide diverse "
             "interaction behaviors for visualization and worked examples.",
+            "",
+            "<!-- /AI-GENERATED -->",
         ]
     )
 
@@ -476,6 +481,7 @@ def _process_planner(
     planner: str,
     campaign_root: Path,
     output_dir: Path,
+    pin_generated_at: str | None = None,
 ) -> tuple[list[SelectedEpisode], dict[str, Any] | None]:
     """Process one planner: read episodes, select exemplars, write bundles."""
     planner_dir = campaign_root / f"{planner}__differential_drive"
@@ -512,6 +518,7 @@ def _process_planner(
             episode_record=episode_record,
             selection=sel,
             output_dir=bundle_dir,
+            pin_generated_at=pin_generated_at,
         )
         if first_metadata is None:
             first_metadata = metadata
@@ -552,6 +559,14 @@ def main() -> int:
         default=TARGET_PLANNERS,
         help=f"Planners to select exemplars from (default: {' '.join(TARGET_PLANNERS)})",
     )
+    parser.add_argument(
+        "--pin-generated-at",
+        default=None,
+        help=(
+            "Override generated_at_utc in all bundle metadata with this ISO 8601 string. "
+            "For deterministic re-runs only; do not use wall-clock time."
+        ),
+    )
     args = parser.parse_args()
 
     repo_root = _repo_root()
@@ -569,7 +584,10 @@ def main() -> int:
     all_selections: list[SelectedEpisode] = []
     bundle_metadata: dict[str, Any] | None = None
     for planner in args.planners:
-        selections, metadata = _process_planner(planner, campaign_root, output_dir)
+        selections, metadata = _process_planner(
+            planner, campaign_root, output_dir,
+            pin_generated_at=args.pin_generated_at,
+        )
         all_selections.extend(selections)
         if bundle_metadata is None and metadata is not None:
             bundle_metadata = metadata

--- a/scripts/export_issue_4891_head_on_corridor_exemplars.py
+++ b/scripts/export_issue_4891_head_on_corridor_exemplars.py
@@ -585,7 +585,9 @@ def main() -> int:
     bundle_metadata: dict[str, Any] | None = None
     for planner in args.planners:
         selections, metadata = _process_planner(
-            planner, campaign_root, output_dir,
+            planner,
+            campaign_root,
+            output_dir,
             pin_generated_at=args.pin_generated_at,
         )
         all_selections.extend(selections)

--- a/tests/test_export_issue_4848.py
+++ b/tests/test_export_issue_4848.py
@@ -321,6 +321,8 @@ class TestWriteBundleFixture:
         assert f", {marker_date})" in readme
         # Must contain NEEDS-REVIEW
         assert "NEEDS-REVIEW" in readme
+        # Must end with closing tag
+        assert "<!-- /AI-GENERATED -->" in readme
 
     def test_sha256sums_has_marker(self, tmp_path: Path) -> None:
         record = self._make_minimal_record()
@@ -437,6 +439,25 @@ class TestWriteSelectionReport:
         report = (out / "SELECTION_REPORT.md").read_text(encoding="utf-8")
         assert report.lstrip().startswith("<!-- AI-GENERATED")
 
+    def test_report_has_closing_tag(self, tmp_path: Path) -> None:
+        """SELECTION_REPORT.md ends with closing AI-GENERATED tag."""
+        selections = [
+            _export_module.SelectedEpisode(
+                planner="goal",
+                scenario_id="classic_group_crossing_low",
+                seed=1,
+                selection_mode="worst",
+                metric_value=0.4,
+                episode_id="test_s1",
+                status="success",
+            ),
+        ]
+        out = tmp_path / "report_dir"
+        out.mkdir()
+        _export_module.write_selection_report(selections, out, marker_date="2026-07-08")
+        report = (out / "SELECTION_REPORT.md").read_text(encoding="utf-8")
+        assert "<!-- /AI-GENERATED -->" in report
+
 
 class TestTupleReturnProcessPlanner:
     """Verify _process_planner returns tuple[list[SelectedEpisode], dict | None].
@@ -511,6 +532,57 @@ class TestBundleReproducibleByteIdentical:
             h1 = sha256_file(dirs[0] / csv_name)
             h2 = sha256_file(dirs[1] / csv_name)
             assert h1 == h2, f"{csv_name} not byte-identical across runs"
+
+    def test_pin_generated_at_byte_identical_metadata(self, tmp_path: Path) -> None:
+        """pin_generated_at makes metadata.json byte-identical across runs."""
+        pin = "2026-07-08T23:13:18.753884+00:00"
+        record = self._make_minimal_record(pin)
+        sel = _export_module.SelectedEpisode(
+            planner="goal",
+            scenario_id="classic_group_crossing_low",
+            seed=1,
+            selection_mode="best",
+            metric_value=0.8,
+            episode_id="classic_group_crossing_low_s1",
+            status="success",
+        )
+        dirs = [tmp_path / "run1", tmp_path / "run2"]
+        for d in dirs:
+            d.mkdir()
+            _export_module.write_bundle(
+                episode_record=record,
+                selection=sel,
+                output_dir=d,
+                pin_generated_at=pin,
+            )
+        for fname in ("metadata.json", "trace_series.json"):
+            h1 = sha256_file(dirs[0] / fname)
+            h2 = sha256_file(dirs[1] / fname)
+            assert h1 == h2, f"{fname} not byte-identical across runs with pin_generated_at"
+
+    def test_pin_generated_at_overrides_wall_clock(self, tmp_path: Path) -> None:
+        """pin_generated_at replaces datetime.now in the written metadata."""
+        pin = "2025-01-15T10:30:00+00:00"
+        record = self._make_minimal_record(pin)
+        sel = _export_module.SelectedEpisode(
+            planner="orca",
+            scenario_id="classic_group_crossing_low",
+            seed=1,
+            selection_mode="median",
+            metric_value=0.5,
+            episode_id="classic_group_crossing_low_s1",
+            status="success",
+        )
+        bundle_dir = tmp_path / "bundle"
+        bundle_dir.mkdir()
+        _export_module.write_bundle(
+            episode_record=record,
+            selection=sel,
+            output_dir=bundle_dir,
+            pin_generated_at=pin,
+        )
+        meta = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
+        assert meta["generated_at_utc"] == pin
 
 
 class TestExtractMarkerDateShared:

--- a/tests/test_export_issue_4891.py
+++ b/tests/test_export_issue_4891.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 # Import the module under test
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -225,3 +226,102 @@ class TestConstants:
 
     def test_selection_modes(self) -> None:
         assert _export_module.SELECTION_MODES == ["median", "best", "worst"]
+
+
+class TestPinGeneratedAt:
+    """Test the pin_generated_at parameter of write_bundle."""
+
+    def _make_minimal_record(self) -> dict[str, Any]:
+        steps = [
+            {
+                "step": i,
+                "time_s": float(i),
+                "robot": {"position": [float(i), 0.0], "velocity": [1.0, 0.0], "heading": 0.0},
+                "planner": {"selected_action": {"linear_velocity": 1.0, "angular_velocity": 0.0}},
+                "pedestrians": [{"id": "p1", "position": [5.0, 0.0]}],
+            }
+            for i in range(3)
+        ]
+        return {
+            "algorithm_metadata": {
+                "simulation_step_trace": {"steps": steps},
+                "algorithm": "goal",
+            },
+            "scenario_id": "classic_head_on_corridor_low",
+            "seed": 20,
+            "episode_id": "test_episode",
+            "status": "collision",
+        }
+
+    def test_pin_generated_at_overrides_wall_clock(self, tmp_path: Path) -> None:
+        """pin_generated_at replaces datetime.now in the written metadata."""
+        pin = "2025-01-15T10:30:00+00:00"
+        record = self._make_minimal_record()
+        sel = _export_module.SelectedEpisode(
+            planner="goal",
+            scenario_id="classic_head_on_corridor_low",
+            seed=20,
+            selection_mode="median",
+            metric_value=1.0,
+            episode_id="test_episode",
+            status="collision",
+        )
+        bundle_dir = tmp_path / "bundle"
+        bundle_dir.mkdir()
+        _export_module.write_bundle(
+            episode_record=record,
+            selection=sel,
+            output_dir=bundle_dir,
+            pin_generated_at=pin,
+        )
+        meta = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
+        assert meta["generated_at_utc"] == pin
+
+    def test_pin_generated_at_byte_identical(self, tmp_path: Path) -> None:
+        """pin_generated_at makes metadata.json and trace_series.json byte-identical."""
+        pin = "2026-07-08T23:13:18.753884+00:00"
+        record = self._make_minimal_record()
+        sel = _export_module.SelectedEpisode(
+            planner="goal",
+            scenario_id="classic_head_on_corridor_low",
+            seed=20,
+            selection_mode="median",
+            metric_value=1.0,
+            episode_id="test_episode",
+            status="collision",
+        )
+        dirs = [tmp_path / "run1", tmp_path / "run2"]
+        for d in dirs:
+            d.mkdir()
+            _export_module.write_bundle(
+                episode_record=record,
+                selection=sel,
+                output_dir=d,
+                pin_generated_at=pin,
+            )
+        for fname in ("metadata.json", "trace_series.json"):
+            h1 = sha256_file(dirs[0] / fname)
+            h2 = sha256_file(dirs[1] / fname)
+            assert h1 == h2, f"{fname} not byte-identical across runs with pin_generated_at"
+
+    def test_pin_none_uses_wall_clock(self, tmp_path: Path) -> None:
+        """Without pin_generated_at, generated_at_utc is wall-clock (not None)."""
+        record = self._make_minimal_record()
+        sel = _export_module.SelectedEpisode(
+            planner="goal",
+            scenario_id="classic_head_on_corridor_low",
+            seed=20,
+            selection_mode="median",
+            metric_value=1.0,
+            episode_id="test_episode",
+            status="collision",
+        )
+        bundle_dir = tmp_path / "bundle"
+        bundle_dir.mkdir()
+        _export_module.write_bundle(
+            episode_record=record,
+            selection=sel,
+            output_dir=bundle_dir,
+        )
+        meta = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
+        assert "2026" in meta["generated_at_utc"]


### PR DESCRIPTION
## What and why

Issue #4903 has two remaining items: bundle reconciliation and closing tag decision. This PR addresses the **tooling prerequisites** for deterministic bundle regeneration and resolves the closing tag decision.

### Changes

1. **`--pin-generated-at` CLI option** added to both export scripts (`export_issue_4848_group_crossing_exemplars.py`, `export_issue_4891_head_on_corridor_exemplars.py`). When provided with an ISO 8601 timestamp string, it replaces `datetime.now(UTC)` in all bundle metadata, enabling byte-identical `metadata.json` and `trace_series.json` across deterministic re-runs.

2. **Closing tag decision resolved**: both export scripts now emit `<!-- /AI-GENERATED -->` at the end of `README.md` and `SELECTION_REPORT.md`, matching the previously committed 4848 bundle format. The self-closing `review_marker()` function in `writers.py` is unchanged — the closing tag is appended by the export scripts in their markdown templates.

### Validation

```bash
uv run pytest tests/test_export_issue_4848.py tests/test_export_issue_4891.py tests/test_evidence_writers.py -q
# 69 passed in 0.77s

uv run ruff check scripts/export_issue_4891_head_on_corridor_exemplars.py scripts/export_issue_4848_group_crossing_exemplars.py tests/test_export_issue_4891.py tests/test_export_issue_4848.py
# All checks passed!
```

### What remains under #4903

Bundle reconciliation (re-running exports against retained campaign data and updating committed bundles) is deferred because:
- #4912's quality-aware tie-breaking changed seed selections, so the 4891 bundles would produce different episodes
- The 4848 bundles would now include `<!-- /AI-GENERATED -->` closing tags, changing checksums

Both bundle sets should be regenerated in a single commit once this PR merges, using:
```bash
uv run python scripts/export_issue_4848_group_crossing_exemplars.py --pin-generated-at "2026-07-08T10:20:54.728079+00:00"
uv run python scripts/export_issue_4891_head_on_corridor_exemplars.py --pin-generated-at "2026-07-08T23:13:18.753884+00:00"
```

Refs #4903

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.


### Successor slice
This is a successor slice of #4903 (deterministic-regen tooling prerequisite) and does not duplicate the seven prior merged PRs — it adds the `--pin-generated-at` pinning hook and closing-tag alignment that the deferred bundle-reconciliation slice will consume.
