### PR TITLE
fix: CI red — replace ripgrep dependency in audit_schema_version_coverage.py with stdlib (Closes #4930)

### DIFF
--- a/scripts/analysis/audit_schema_version_coverage.py
+++ b/scripts/analysis/audit_schema_version_coverage.py
@@ -16,10 +16,11 @@ Output: output/schema_version_audit_inventory.json
 from __future__ import annotations
 
 import json
+import os
 import re
-import subprocess
 from collections import defaultdict
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -28,15 +29,60 @@ EXCLUDE_DIRS = {".venv", ".claude", "output", "__pycache__", ".git"}
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 
+def _iter_py_files(root: Path):
+    """Yield every ``*.py`` file under ``root``, pruning excluded/hidden dirs.
+
+    Directories in :data:`EXCLUDE_DIRS` and any dot-prefixed directory are
+    skipped. This mirrors ripgrep's default behaviour (respect the excludes and
+    skip hidden paths), so the scan sees the same file set the previous ``rg``
+    calls did.
+    """
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune in place so os.walk does not descend into skipped trees.
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS and not d.startswith(".")]
+        for fn in filenames:
+            if fn.endswith(".py"):
+                yield Path(dirpath) / fn
+
+
+@lru_cache(maxsize=4)
+def _py_file_index(root_str: str) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Return ``((relpath, lines), ...)`` for every ``*.py`` file under root.
+
+    Files are read once and cached so the multiple pattern scans below do not
+    re-read the tree. Undecodable files are skipped (ripgrep skips them too).
+    """
+    root = Path(root_str)
+    index: list[tuple[str, tuple[str, ...]]] = []
+    for path in _iter_py_files(root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        rel = path.relative_to(root).as_posix()
+        index.append((rel, tuple(text.splitlines())))
+    # Sort by relative path for deterministic, byte-reproducible output
+    # (ripgrep's parallel traversal order was not stable across runs).
+    index.sort(key=lambda item: item[0])
+    return tuple(index)
+
+
 def _rg(pattern: str, globs: list[str] | None = None, cwd: Path = REPO_ROOT) -> str:
-    """Run ripgrep and return stdout."""
-    cmd = ["rg", "--no-heading", "-n", pattern]
-    if globs:
-        cmd += globs
-    for d in EXCLUDE_DIRS:
-        cmd += ["--glob", f"!{d}/*"]
-    result = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd, check=False)
-    return result.stdout
+    """Grep ``*.py`` files with the stdlib and emit ripgrep-style records.
+
+    Drop-in replacement for the former ripgrep subprocess: for every line
+    matching ``pattern`` it emits ``relpath:lineno:line`` (1-based line
+    numbers), joined by newlines — the exact format the downstream parsers
+    expect. Requires no external binary. ``globs`` is retained for call-site
+    compatibility; every caller scans ``*.py``, which is what this does.
+    """
+    regex = re.compile(pattern)
+    out: list[str] = []
+    for rel, lines in _py_file_index(str(cwd)):
+        for lineno, line in enumerate(lines, start=1):
+            if regex.search(line):
+                out.append(f"{rel}:{lineno}:{line}")
+    return "\n".join(out) + "\n" if out else ""
 
 
 # ── Phase 1: collect all inline schema_version string-literal writers ────────


### PR DESCRIPTION
## Root cause (Closes #4930)

`scripts/analysis/audit_schema_version_coverage.py` shelled out to `rg`
(ripgrep) through `subprocess` (former `_rg()` helper). CI runners do not have
ripgrep installed and no workflow installs it, so
`tests/analysis/test_schema_version_audit_issue_4909.py::test_script_runs_without_error`
failed on every run with `FileNotFoundError: [Errno 2] No such file or
directory: 'rg'`, keeping `main` red for 12+ hours. Introduced by PR #4918 /
issue #4909.

## Fix — stdlib rewrite (no external binary)

Replaced the ripgrep subprocess with a stdlib `os.walk` + `re` scanner:

- `_iter_py_files()` walks the repo, pruning `EXCLUDE_DIRS` and hidden
  (dot-prefixed) directories in place — this matches ripgrep's default
  behaviour (honour the excludes, skip hidden paths), so the scan sees the
  **same file set** the `rg --glob '*.py'` calls did.
- `_py_file_index()` reads each `*.py` file once (cached via `lru_cache`) so the
  six pattern scans don't re-read the tree; undecodable files are skipped, as
  ripgrep skips them.
- `_rg(pattern, ...)` keeps its original signature (drop-in) and emits the exact
  ripgrep record format the downstream parsers expect:
  `relpath:lineno:line`, 1-based line numbers, newline-joined.
- Output is **sorted by path** for byte-reproducibility. Ripgrep's parallel
  traversal order was never stable across runs, so the previous inventory
  ordering was non-deterministic; the new scan is deterministic.

No `subprocess` / ripgrep usage remains, so **CI needs nothing installed** —
this is the primary and complete fix (no `skipif` guard needed because there is
no longer an optional external tool to guard).

## Test evidence

- Inventory parity: regenerated the inventory with the stdlib version and
  diffed against an `rg`-generated baseline. All 276 distinct values,
  every classification count, and all writer/reader/constant/jsonschema
  records are **identical** modulo list ordering. The only entry that changes
  is the script's self-referential `"value"` match, whose line numbers shifted
  only because the file was edited — a benign self-scan artifact.
- `classification_counts`: `provenance-write-only-by-design: 120`,
  `named-const-backed: 65`, `genuinely-orphaned-needs-validator: 58`,
  `jsonschema-validated: 31`, `test-asserted: 2` (total 276).
- `uv run pytest tests/analysis/test_schema_version_audit_issue_4909.py -q` →
  **8 passed**.
- Re-ran the full test file with `rg` removed from `PATH` (simulating CI) →
  **8 passed**, confirming the ripgrep dependency is gone.
- Two consecutive script runs produce byte-identical inventory (determinism
  confirmed).
- `ruff check` and `ruff format --check` clean; pre-commit hooks passed on
  commit.

## Behaviour delta

None for the audit result. The only intentional change beyond removing the
external dependency is deterministic (sorted) output ordering, which the tests
do not depend on and which strictly improves reproducibility over ripgrep's
unstable traversal order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal repository scanning for schema version coverage checks.
  * The scan now runs more efficiently and consistently by using a local file index instead of relying on an external command.
  * Hidden and excluded folders are skipped more reliably during analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->