### PR TITLE
Issue #4831: fail-closed metrics + complete artifact packet (cheap-lane worker)

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -4099,15 +4099,3 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
-- path: docs/context/evidence/issue_4831_trace_verified_failure_mechanisms/input_audit.json
-  status: evidence
-  freshness: evidence
-  area: benchmark_evidence
-- path: docs/context/evidence/issue_4831_trace_verified_failure_mechanisms/crosscut_interpretation.json
-  status: evidence
-  freshness: evidence
-  area: benchmark_evidence
-- path: docs/context/evidence/issue_4831_trace_verified_failure_mechanisms/SHA256SUMS
-  status: evidence
-  freshness: evidence
-  area: benchmark_evidence

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -4087,3 +4087,27 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+- path: docs/context/evidence/issue_4831_trace_verified_failure_mechanisms/mechanism_labels.csv
+  status: evidence
+  freshness: evidence
+  area: benchmark_evidence
+- path: docs/context/evidence/issue_4831_trace_verified_failure_mechanisms/mechanism_labels.jsonl
+  status: evidence
+  freshness: evidence
+  area: benchmark_evidence
+- path: docs/context/evidence/issue_4831_trace_verified_failure_mechanisms/label_coverage.json
+  status: evidence
+  freshness: evidence
+  area: benchmark_evidence
+- path: docs/context/evidence/issue_4831_trace_verified_failure_mechanisms/input_audit.json
+  status: evidence
+  freshness: evidence
+  area: benchmark_evidence
+- path: docs/context/evidence/issue_4831_trace_verified_failure_mechanisms/crosscut_interpretation.json
+  status: evidence
+  freshness: evidence
+  area: benchmark_evidence
+- path: docs/context/evidence/issue_4831_trace_verified_failure_mechanisms/SHA256SUMS
+  status: evidence
+  freshness: evidence
+  area: benchmark_evidence

--- a/scripts/analysis/derive_issue_4206_trace_verified_failure_mechanisms.py
+++ b/scripts/analysis/derive_issue_4206_trace_verified_failure_mechanisms.py
@@ -126,7 +126,109 @@ def _to_float(v: Any) -> float | None:
     return None if math.isnan(f) else f
 
 
-def _derive_mechanism_label(row: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, PLR0915
+def _derive_collision_label(
+    total_collision_count: float,
+    surrogate_late_evasive: bool,
+    surrogate_clearance_breach: bool,
+) -> tuple[str, str, str, str, str]:
+    """Derive mechanism label for collision episodes."""
+    evidence_uri = f"event_ledger.collision_events({total_collision_count})"
+
+    if surrogate_late_evasive and surrogate_clearance_breach:
+        return (
+            "proxemic_or_clearance_tradeoff",
+            "supported_hypothesis",
+            "paired_trace",
+            evidence_uri,
+            "collision with late_evasive and clearance_breach surrogate events "
+            "indicates insufficient clearance response",
+        )
+    if total_collision_count > 0:
+        return (
+            "proxemic_or_clearance_tradeoff",
+            "supported_hypothesis",
+            "paired_trace",
+            evidence_uri,
+            f"collision with {total_collision_count} event(s); "
+            "clearance tradeoff derived from collision evidence",
+        )
+    return (
+        "proxemic_or_clearance_tradeoff",
+        "weak_hypothesis",
+        "paired_trace",
+        evidence_uri,
+        "collision outcome present but limited trace detail",
+    )
+
+
+def _derive_timeout_label(
+    avg_speed_raw: float | None,
+    path_efficiency_raw: float | None,
+    stalled_time: float,
+    surrogate_oscillation: bool,
+) -> tuple[str, str, str, str, str]:
+    """Derive mechanism label for timeout episodes with fail-closed metrics."""
+    evidence_uri = "outcome.timeout_event"
+
+    # Fail-closed: if avg_speed or path_efficiency is missing (None),
+    # do NOT coerce to 0.0 and label as static_deadlock_or_local_minimum.
+    has_avg_speed = avg_speed_raw is not None
+    has_path_efficiency = path_efficiency_raw is not None
+
+    if has_avg_speed and avg_speed_raw < 0.01:
+        return (
+            "static_deadlock_or_local_minimum",
+            "supported_hypothesis",
+            "paired_trace",
+            evidence_uri,
+            f"timeout with avg_speed={avg_speed_raw:.4f}; static deadlock suspected",
+        )
+    if stalled_time > 10.0:
+        return (
+            "static_deadlock_or_local_minimum",
+            "supported_hypothesis",
+            "paired_trace",
+            evidence_uri,
+            f"timeout with stalled_time={stalled_time:.1f}s; robot stalled before timeout",
+        )
+    if has_path_efficiency and path_efficiency_raw < 0.2:
+        return (
+            "static_deadlock_or_local_minimum",
+            "supported_hypothesis",
+            "paired_trace",
+            evidence_uri,
+            f"timeout with path_efficiency={path_efficiency_raw:.4f}; "
+            "severely limited progress indicates local minimum",
+        )
+    if surrogate_oscillation:
+        return (
+            "dynamic_phase_or_order_sensitivity",
+            "supported_hypothesis",
+            "paired_trace",
+            evidence_uri,
+            "timeout with oscillatory behavior; negotiation failure or order sensitivity",
+        )
+    if not has_avg_speed and not has_path_efficiency:
+        return (
+            "unknown",
+            "unknown",
+            "unknown",
+            "",
+            "timeout with missing avg_speed and path_efficiency; insufficient metrics for derivation",
+        )
+    avg_speed_str = f"{avg_speed_raw:.4f}" if has_avg_speed else "missing"
+    path_eff_str = f"{path_efficiency_raw:.4f}" if has_path_efficiency else "missing"
+    return (
+        "time_budget_artifact",
+        "weak_hypothesis",
+        "paired_trace",
+        evidence_uri,
+        f"timeout with avg_speed={avg_speed_str}, path_efficiency={path_eff_str}; "
+        "may be time budget constraint rather than deadlock",
+    )
+
+
+def _derive_mechanism_label(row: dict[str, Any]) -> dict[str, Any]:
     """Derive a trace-verified mechanism label from episode trace surfaces.
 
     Returns a validated taxonomy record, or an unknown record with explicit caveat.
@@ -141,11 +243,18 @@ def _derive_mechanism_label(row: dict[str, Any]) -> dict[str, Any]:  # noqa: C90
     has_collision = _is_collision(outcome)
     has_timeout = _is_timeout(outcome)
 
-    near_miss_count = _to_float(metrics.get("near_misses")) or 0.0
-    total_collision_count = _to_float(metrics.get("total_collision_count")) or 0.0
-    stalled_time = _to_float(metrics.get("stalled_time")) or 0.0
-    avg_speed = _to_float(metrics.get("avg_speed")) or 0.0
-    path_efficiency = _to_float(metrics.get("path_efficiency")) or 0.0
+    near_miss_count_raw = _to_float(metrics.get("near_misses"))
+    total_collision_count_raw = _to_float(metrics.get("total_collision_count"))
+    stalled_time_raw = _to_float(metrics.get("stalled_time"))
+    avg_speed_raw = _to_float(metrics.get("avg_speed"))
+    path_efficiency_raw = _to_float(metrics.get("path_efficiency"))
+
+    # Fail-closed: treat missing metrics as None, not 0.0.
+    near_miss_count = near_miss_count_raw if near_miss_count_raw is not None else 0.0
+    total_collision_count = (
+        total_collision_count_raw if total_collision_count_raw is not None else 0.0
+    )
+    stalled_time = stalled_time_raw if stalled_time_raw is not None else 0.0
 
     surrogate_late_evasive = _get_surrogate(event_ledger, "late_evasive") or False
     surrogate_clearance_breach = _get_surrogate(event_ledger, "clearance_breach") or False
@@ -158,66 +267,13 @@ def _derive_mechanism_label(row: dict[str, Any]) -> dict[str, Any]:  # noqa: C90
     evidence_uri = ""
 
     if has_collision:
-        evidence_uri = f"event_ledger.collision_events({total_collision_count})"
-
-        if surrogate_late_evasive and surrogate_clearance_breach:
-            label = "proxemic_or_clearance_tradeoff"
-            confidence = "supported_hypothesis"
-            evidence_mode = "paired_trace"
-            caveat = (
-                "collision with late_evasive and clearance_breach surrogate events "
-                "indicates insufficient clearance response"
-            )
-        elif total_collision_count > 0:
-            label = "proxemic_or_clearance_tradeoff"
-            confidence = "supported_hypothesis"
-            evidence_mode = "paired_trace"
-            caveat = (
-                f"collision with {total_collision_count} event(s); "
-                "clearance tradeoff derived from collision evidence"
-            )
-        else:
-            label = "proxemic_or_clearance_tradeoff"
-            confidence = "weak_hypothesis"
-            evidence_mode = "paired_trace"
-            caveat = "collision outcome present but limited trace detail"
-
+        label, confidence, evidence_mode, evidence_uri, caveat = _derive_collision_label(
+            total_collision_count, surrogate_late_evasive, surrogate_clearance_breach
+        )
     elif has_timeout:
-        evidence_uri = "outcome.timeout_event"
-
-        if avg_speed < 0.01:
-            label = "static_deadlock_or_local_minimum"
-            confidence = "supported_hypothesis"
-            evidence_mode = "paired_trace"
-            caveat = f"timeout with avg_speed={avg_speed:.4f}; static deadlock suspected"
-        elif stalled_time > 10.0:
-            label = "static_deadlock_or_local_minimum"
-            confidence = "supported_hypothesis"
-            evidence_mode = "paired_trace"
-            caveat = f"timeout with stalled_time={stalled_time:.1f}s; robot stalled before timeout"
-        elif path_efficiency < 0.2:
-            label = "static_deadlock_or_local_minimum"
-            confidence = "supported_hypothesis"
-            evidence_mode = "paired_trace"
-            caveat = (
-                f"timeout with path_efficiency={path_efficiency:.4f}; "
-                "severely limited progress indicates local minimum"
-            )
-        elif surrogate_oscillation:
-            label = "dynamic_phase_or_order_sensitivity"
-            confidence = "supported_hypothesis"
-            evidence_mode = "paired_trace"
-            caveat = "timeout with oscillatory behavior; negotiation failure or order sensitivity"
-        else:
-            label = "time_budget_artifact"
-            confidence = "weak_hypothesis"
-            evidence_mode = "paired_trace"
-            caveat = (
-                f"timeout with moderate path_efficiency={path_efficiency:.4f}; "
-                "may be time budget constraint rather than deadlock"
-            )
-
-    # Failure without explicit collision or timeout marker
+        label, confidence, evidence_mode, evidence_uri, caveat = _derive_timeout_label(
+            avg_speed_raw, path_efficiency_raw, stalled_time, surrogate_oscillation
+        )
     elif surrogate_oscillation:
         label = "dynamic_phase_or_order_sensitivity"
         confidence = "supported_hypothesis"
@@ -317,37 +373,13 @@ def _scan_episode_jsonl(runs_dir: Path) -> list[dict[str, Any]]:
     return all_episodes
 
 
-def build_mechanism_sidecar(  # noqa: C901
-    campaign_root: Path,
-    output_dir: Path,
-    generated_at: str,
-) -> dict[str, Any]:
-    """Build the trace-verified mechanism-label sidecar.
-
-    Args:
-        campaign_root: Campaign output root with runs/{planner}/episodes.jsonl
-        output_dir: Output directory for sidecar artifacts
-        generated_at: ISO 8601 timestamp
-
-    Returns:
-        Summary metadata dictionary.
-    """
-    runs_dir = campaign_root / "runs"
-    manifest_path = campaign_root / "campaign_manifest.json"
-
-    all_episodes = _scan_episode_jsonl(runs_dir)
-    total = len(all_episodes)
-
-    # Phase 1 input audit: block cleanly when campaign artifacts are absent.
-    # A missing/empty campaign must NOT produce a vacuous "completed" packet,
-    # because that would look indistinguishable from a genuine zero-failure run
-    # (anti-fabrication guard for the issue's "blocks cleanly until hydrated" criterion).
-    if not campaign_root.is_dir() or total == 0:
-        return _blocked_input_summary(campaign_root, output_dir, generated_at)
-
-    failure_episodes = []
+def _classify_episodes(
+    all_episodes: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], int, int]:
+    """Classify episodes into failures, successes, and skipped (guarded_ppo)."""
+    failure_episodes: list[dict[str, Any]] = []
     success_episodes = 0
-    skipped_unavailable: int = 0
+    skipped_unavailable = 0
 
     for ep in all_episodes:
         outcome = ep.get("outcome") or {}
@@ -362,13 +394,20 @@ def build_mechanism_sidecar(  # noqa: C901
         else:
             success_episodes += 1
 
+    return failure_episodes, success_episodes, skipped_unavailable
+
+
+def _label_failure_episodes(
+    failure_episodes: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Derive mechanism labels for failure episodes."""
     labeled: list[dict[str, Any]] = []
     unlabeled: list[dict[str, Any]] = []
 
     for ep in failure_episodes:
         record = _derive_mechanism_label(ep)
         if record is None:
-            continue  # Shouldn't happen for failure episodes
+            continue
 
         episode_id = ep.get("episode_id", "")
         scenario_id = ep.get("scenario_id", "")
@@ -392,6 +431,58 @@ def build_mechanism_sidecar(  # noqa: C901
             unlabeled.append({**base_row, **record})
         else:
             labeled.append({**base_row, **record})
+
+    return labeled, unlabeled
+
+
+def _compute_planner_failures(
+    failure_episodes: list[dict[str, Any]],
+    labeled: list[dict[str, Any]],
+) -> dict[str, dict]:
+    """Compute per-planner failure counts."""
+    planner_failures: dict[str, dict] = defaultdict(lambda: {"total": 0, "labeled": 0})
+
+    for ep in failure_episodes:
+        pk = ep.get("algo") or (
+            ep.get("_planner_run", "").split("__")[0] if ep.get("_planner_run") else ""
+        )
+        planner_failures[pk]["total"] += 1
+
+    for r in labeled:
+        pk = r.get("planner_key", "")
+        planner_failures[pk]["labeled"] += 1
+
+    return planner_failures
+
+
+def build_mechanism_sidecar(
+    campaign_root: Path,
+    output_dir: Path,
+    generated_at: str,
+) -> dict[str, Any]:
+    """Build the trace-verified mechanism-label sidecar.
+
+    Args:
+        campaign_root: Campaign output root with runs/{planner}/episodes.jsonl
+        output_dir: Output directory for sidecar artifacts
+        generated_at: ISO 8601 timestamp
+
+    Returns:
+        Summary metadata dictionary.
+    """
+    runs_dir = campaign_root / "runs"
+    manifest_path = campaign_root / "campaign_manifest.json"
+
+    all_episodes = _scan_episode_jsonl(runs_dir)
+    total = len(all_episodes)
+
+    # Phase 1 input audit: block cleanly when campaign artifacts are absent.
+    if not campaign_root.is_dir() or total == 0:
+        return _blocked_input_summary(campaign_root, output_dir, generated_at)
+
+    failure_episodes, success_episodes, skipped_unavailable = _classify_episodes(all_episodes)
+    labeled, unlabeled = _label_failure_episodes(failure_episodes)
+    planner_failures = _compute_planner_failures(failure_episodes, labeled)
 
     label_counts = Counter(r.get("mechanism_label", "unknown") for r in labeled)
     confidence_counts = Counter(r.get("mechanism_confidence", "unknown") for r in labeled)
@@ -480,6 +571,18 @@ def build_mechanism_sidecar(  # noqa: C901
     }
 
     _write_readmes(output_dir, coverage, summary)
+    _write_label_coverage_md(output_dir, coverage)
+    _write_input_audit(
+        output_dir,
+        campaign_root,
+        manifest_path,
+        all_episodes,
+        failure_episodes,
+        skipped_unavailable,
+        generated_at,
+    )
+    _write_crosscut_interpretation(output_dir, coverage, generated_at)
+    _write_sha256sums(output_dir)
     return summary
 
 
@@ -526,6 +629,254 @@ def _write_readmes(
         "Labels are diagnostic, not paper-facing claims.",
     ]
     (output_dir / "README.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_label_coverage_md(output_dir: Path, coverage: Mapping[str, Any]) -> None:
+    """Write label_coverage.md from coverage metadata."""
+    lines = [
+        _README_MARKER_COMMENT,
+        "",
+        "# Issue #4831: Label Coverage Report",
+        "",
+        f"Generated: {coverage.get('generated_at', 'N/A')}",
+        "",
+        f"Campaign root: {coverage.get('campaign_root', 'N/A')}",
+        "",
+        "## Summary",
+        "",
+        f"- Total episodes: {coverage.get('total_episodes', 0)}",
+        f"- Success episodes: {coverage.get('success_episodes', 0)}",
+        f"- Failure episodes: {coverage.get('failure_episodes', 0)}",
+        f"- Labeled failures: {coverage.get('labeled_failure_count', 0)}",
+        f"- Unlabeled residual: {coverage.get('unlabeled_failure_count', 0)}",
+        f"- Coverage fraction: {coverage.get('coverage_fraction', 0):.2%}",
+        "",
+        "## Label Distribution",
+        "",
+    ]
+    for label, count in sorted(
+        (coverage.get("label_distribution") or {}).items(), key=lambda x: -x[1]
+    ):
+        lines.append(f"- {label}: {count}")
+
+    lines += [
+        "",
+        "## Confidence Distribution",
+        "",
+    ]
+    for conf, count in sorted(
+        (coverage.get("confidence_distribution") or {}).items(), key=lambda x: -x[1]
+    ):
+        lines.append(f"- {conf}: {count}")
+
+    lines += [
+        "",
+        "## Planner Failure Counts",
+        "",
+        "| Planner | Total Failures | Labeled |",
+        "|---------|---------------|---------|",
+    ]
+    for pk, counts in sorted((coverage.get("planner_failure_counts") or {}).items()):
+        lines.append(f"| {pk} | {counts.get('total', 0)} | {counts.get('labeled', 0)} |")
+
+    lines += [
+        "",
+        "## Accepted-Unavailable",
+        "",
+        f"- guarded_ppo status: {coverage.get('guarded_ppo_status', 'N/A')}",
+    ]
+    (output_dir / "label_coverage.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_input_audit(
+    output_dir: Path,
+    campaign_root: Path,
+    manifest_path: Path,
+    all_episodes: list[dict[str, Any]],
+    failure_episodes: list[dict[str, Any]],
+    skipped_unavailable: int,
+    generated_at: str,
+) -> None:
+    """Write input_audit.json and input_audit.md."""
+    runs_dir = campaign_root / "runs"
+    planner_dirs = [d for d in runs_dir.iterdir() if d.is_dir()] if runs_dir.is_dir() else []
+
+    # Check for guarded_ppo
+    guarded_ppo_found = False
+    guarded_ppo_accepted_unavailable = False
+    for ep in all_episodes:
+        planner_key = ep.get("algo") or ep.get("_planner_run", "").split("__")[0]
+        if planner_key == "guarded_ppo":
+            guarded_ppo_found = True
+            if ep.get("status") != "ok":
+                guarded_ppo_accepted_unavailable = True
+            break
+
+    # Check trace fields
+    trace_fields_present = 0
+    for ep in all_episodes[:100]:  # Sample check
+        event_ledger = ep.get("event_ledger")
+        if event_ledger and isinstance(event_ledger, dict) and event_ledger:
+            trace_fields_present += 1
+
+    audit = {
+        "review_marker": REVIEW_MARKER,
+        "schema_version": SCHEMA_VERSION,
+        "issue": 4831,
+        "generated_at": generated_at,
+        "campaign_root": _public_path(campaign_root),
+        "campaign_root_exists": campaign_root.is_dir(),
+        "manifest_exists": manifest_path.is_file(),
+        "planner_arm_count": len(planner_dirs),
+        "total_episodes": len(all_episodes),
+        "failure_episodes": len(failure_episodes),
+        "success_episodes": len(all_episodes) - len(failure_episodes) - skipped_unavailable,
+        "skipped_unavailable": skipped_unavailable,
+        "guarded_ppo_found": guarded_ppo_found,
+        "guarded_ppo_accepted_unavailable": guarded_ppo_accepted_unavailable,
+        "trace_fields_sample_present": trace_fields_present,
+        "status": "ok"
+        if campaign_root.is_dir() and len(all_episodes) > 0
+        else "blocked_missing_input_artifacts",
+    }
+
+    _write_jsonl(output_dir / "input_audit.json", [audit])
+
+    # Write markdown version
+    lines = [
+        _README_MARKER_COMMENT,
+        "",
+        "# Issue #4831: Input Audit",
+        "",
+        f"Generated: {generated_at}",
+        "",
+        "## Campaign Root",
+        "",
+        f"- Path: {_public_path(campaign_root)}",
+        f"- Exists: {campaign_root.is_dir()}",
+        f"- Manifest exists: {manifest_path.is_file()}",
+        "",
+        "## Episode Counts",
+        "",
+        f"- Total episodes: {len(all_episodes)}",
+        f"- Failure episodes: {len(failure_episodes)}",
+        f"- Success episodes: {len(all_episodes) - len(failure_episodes) - skipped_unavailable}",
+        f"- Skipped (accepted-unavailable): {skipped_unavailable}",
+        "",
+        "## Planner Arms",
+        "",
+        f"- Planner arm count: {len(planner_dirs)}",
+        f"- guarded_ppo found: {guarded_ppo_found}",
+        f"- guarded_ppo accepted-unavailable: {guarded_ppo_accepted_unavailable}",
+        "",
+        "## Trace Fields",
+        "",
+        f"- Trace fields present in sample: {trace_fields_present}/100",
+        "",
+        "## Status",
+        "",
+        f"- Status: {audit['status']}",
+    ]
+    (output_dir / "input_audit.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_crosscut_interpretation(
+    output_dir: Path,
+    coverage: Mapping[str, Any],
+    generated_at: str,
+) -> None:
+    """Write crosscut_interpretation.json and crosscut_interpretation.md."""
+    interpretation = {
+        "review_marker": REVIEW_MARKER,
+        "schema_version": SCHEMA_VERSION,
+        "issue": 4831,
+        "generated_at": generated_at,
+        "campaign_root": coverage.get("campaign_root", ""),
+        "trace_verified_mechanisms": [],
+        "unresolved_mechanisms": [],
+        "excluded_arms": ["guarded_ppo"],
+        "accepted_unavailable_arms": ["guarded_ppo"],
+        "evidence_type": "diagnostic",
+        "claim_boundary": "Labels are diagnostic, not paper-facing claims.",
+    }
+
+    # Categorize mechanisms
+    label_dist = coverage.get("label_distribution", {})
+    for label, count in label_dist.items():
+        if label != "unknown":
+            interpretation["trace_verified_mechanisms"].append(
+                {
+                    "mechanism": label,
+                    "count": count,
+                    "evidence_mode": "paired_trace",
+                }
+            )
+        else:
+            interpretation["unresolved_mechanisms"].append(
+                {
+                    "mechanism": label,
+                    "count": count,
+                    "reason": "insufficient trace surfaces",
+                }
+            )
+
+    _write_jsonl(output_dir / "crosscut_interpretation.json", [interpretation])
+
+    # Write markdown version
+    lines = [
+        _README_MARKER_COMMENT,
+        "",
+        "# Issue #4831: Crosscut Interpretation Packet",
+        "",
+        f"Generated: {generated_at}",
+        "",
+        f"Campaign root: {coverage.get('campaign_root', 'N/A')}",
+        "",
+        "## Trace-Verified Mechanisms",
+        "",
+    ]
+    for mech in interpretation["trace_verified_mechanisms"]:
+        lines.append(f"- {mech['mechanism']}: {mech['count']} episodes")
+
+    lines += [
+        "",
+        "## Unresolved Mechanisms",
+        "",
+    ]
+    for mech in interpretation["unresolved_mechanisms"]:
+        lines.append(f"- {mech['mechanism']}: {mech['count']} episodes ({mech['reason']})")
+
+    lines += [
+        "",
+        "## Excluded Arms",
+        "",
+        "- guarded_ppo (accepted-unavailable)",
+        "",
+        "## Evidence Type",
+        "",
+        "This packet provides diagnostic evidence only. Labels are derived from",
+        "trace surfaces available in episode JSONL records.",
+        "",
+        "## Claim Boundary",
+        "",
+        interpretation["claim_boundary"],
+    ]
+    (output_dir / "crosscut_interpretation.md").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+
+def _write_sha256sums(output_dir: Path) -> None:
+    """Write SHA256SUMS for all generated artifacts."""
+    import hashlib
+
+    sums = []
+    for file_path in sorted(output_dir.iterdir()):
+        if file_path.is_file() and file_path.name != "SHA256SUMS":
+            sha256 = hashlib.sha256(file_path.read_bytes()).hexdigest()
+            sums.append(f"{sha256}  {file_path.name}")
+
+    (output_dir / "SHA256SUMS").write_text("\n".join(sums) + "\n", encoding="utf-8")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/analysis/derive_issue_4206_trace_verified_failure_mechanisms.py
+++ b/scripts/analysis/derive_issue_4206_trace_verified_failure_mechanisms.py
@@ -228,14 +228,14 @@ def _derive_timeout_label(
     )
 
 
-def _derive_mechanism_label(row: dict[str, Any]) -> dict[str, Any]:
+def _derive_mechanism_label(row: dict[str, Any]) -> dict[str, Any] | None:
     """Derive a trace-verified mechanism label from episode trace surfaces.
 
     Returns a validated taxonomy record, or an unknown record with explicit caveat.
     """
     outcome = row.get("outcome") or {}
     if not _is_failure(outcome):
-        return None  # type: ignore[return-value]
+        return None
 
     event_ledger = _get_event_ledger(row)
     metrics = _get_metrics(row)
@@ -435,6 +435,21 @@ def _label_failure_episodes(
     return labeled, unlabeled
 
 
+def _planner_key_of(ep: dict[str, Any]) -> str:
+    """Resolve the planner key from an episode, checking for None explicitly.
+
+    Falsy-but-valid identifiers (e.g. ``""``) are handled with explicit ``is not None``
+    checks rather than ``or`` so they are not silently replaced by the fallback.
+    """
+    algo = ep.get("algo")
+    if algo is not None:
+        return algo
+    planner_run = ep.get("_planner_run")
+    if planner_run is not None:
+        return planner_run.split("__")[0]
+    return ""
+
+
 def _compute_planner_failures(
     failure_episodes: list[dict[str, Any]],
     labeled: list[dict[str, Any]],
@@ -443,9 +458,7 @@ def _compute_planner_failures(
     planner_failures: dict[str, dict] = defaultdict(lambda: {"total": 0, "labeled": 0})
 
     for ep in failure_episodes:
-        pk = ep.get("algo") or (
-            ep.get("_planner_run", "").split("__")[0] if ep.get("_planner_run") else ""
-        )
+        pk = _planner_key_of(ep)
         planner_failures[pk]["total"] += 1
 
     for r in labeled:
@@ -486,17 +499,6 @@ def build_mechanism_sidecar(
 
     label_counts = Counter(r.get("mechanism_label", "unknown") for r in labeled)
     confidence_counts = Counter(r.get("mechanism_confidence", "unknown") for r in labeled)
-    planner_failures: dict[str, dict] = defaultdict(lambda: {"total": 0, "labeled": 0})
-
-    for ep in failure_episodes:
-        pk = ep.get("algo") or (
-            ep.get("_planner_run", "").split("__")[0] if ep.get("_planner_run") else ""
-        )
-        planner_failures[pk]["total"] += 1
-
-    for r in labeled:
-        pk = r.get("planner_key", "")
-        planner_failures[pk]["labeled"] += 1
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -705,7 +707,7 @@ def _write_input_audit(
     guarded_ppo_found = False
     guarded_ppo_accepted_unavailable = False
     for ep in all_episodes:
-        planner_key = ep.get("algo") or ep.get("_planner_run", "").split("__")[0]
+        planner_key = _planner_key_of(ep)
         if planner_key == "guarded_ppo":
             guarded_ppo_found = True
             if ep.get("status") != "ok":

--- a/tests/analysis/test_derive_trace_verified_failure_mechanisms.py
+++ b/tests/analysis/test_derive_trace_verified_failure_mechanisms.py
@@ -466,5 +466,228 @@ class TestGuardedPPOExclusion:
         assert summary["labeled_count"] == 0
 
 
+class TestFailClosedMetrics:
+    """Tests for fail-closed behavior when metrics are missing."""
+
+    def test_timeout_missing_avg_speed_fails_closed(self) -> None:
+        """Timeout with missing avg_speed must NOT label as static_deadlock."""
+        ep = _make_episode(
+            outcome={
+                "route_complete": False,
+                "collision_event": False,
+                "timeout_event": True,
+            },
+            metrics={
+                "avg_speed": None,
+                "stalled_time": 5.0,
+                "path_efficiency": 0.3,
+            },
+        )
+        result = _derive_mechanism_label(ep)
+        assert result is not None
+        validate_failure_mechanism_record(result)
+        # Missing avg_speed should not trigger static_deadlock_or_local_minimum
+        assert result["mechanism_label"] != "static_deadlock_or_local_minimum"
+
+    def test_timeout_missing_path_efficiency_fails_closed(self) -> None:
+        """Timeout with missing path_efficiency must NOT label as static_deadlock."""
+        ep = _make_episode(
+            outcome={
+                "route_complete": False,
+                "collision_event": False,
+                "timeout_event": True,
+            },
+            metrics={
+                "avg_speed": 0.8,
+                "stalled_time": 2.0,
+                "path_efficiency": None,
+            },
+        )
+        result = _derive_mechanism_label(ep)
+        assert result is not None
+        validate_failure_mechanism_record(result)
+        # Missing path_efficiency should not trigger static_deadlock_or_local_minimum
+        assert result["mechanism_label"] != "static_deadlock_or_local_minimum"
+
+    def test_timeout_both_metrics_missing_fails_closed(self) -> None:
+        """Timeout with both metrics missing must label as unknown."""
+        ep = _make_episode(
+            outcome={
+                "route_complete": False,
+                "collision_event": False,
+                "timeout_event": True,
+            },
+            metrics={
+                "avg_speed": None,
+                "stalled_time": 2.0,
+                "path_efficiency": None,
+            },
+        )
+        result = _derive_mechanism_label(ep)
+        assert result is not None
+        validate_failure_mechanism_record(result)
+        assert result["mechanism_label"] == "unknown"
+        assert result["mechanism_confidence"] == "unknown"
+        assert "insufficient metrics" in result["mechanism_caveat"]
+
+    def test_timeout_present_metrics_works_normally(self) -> None:
+        """Timeout with present metrics should work as before."""
+        ep = _make_episode(
+            outcome={
+                "route_complete": False,
+                "collision_event": False,
+                "timeout_event": True,
+            },
+            metrics={
+                "avg_speed": 0.001,
+                "stalled_time": 5.0,
+                "path_efficiency": 0.3,
+            },
+        )
+        result = _derive_mechanism_label(ep)
+        assert result is not None
+        validate_failure_mechanism_record(result)
+        assert result["mechanism_label"] == "static_deadlock_or_local_minimum"
+
+
+class TestNewOutputFiles:
+    """Tests for new output files: input_audit, crosscut_interpretation, SHA256SUMS, label_coverage.md."""
+
+    def _make_campaign(self, tmp: Path) -> Path:
+        """Create a minimal campaign directory with episode JSONL."""
+        campaign = tmp / "test_campaign"
+        runs = campaign / "runs"
+
+        # Successful planner
+        p1 = runs / "goal__differential_drive"
+        p1.mkdir(parents=True, exist_ok=True)
+        episodes = [
+            _make_episode(
+                episode_id=f"goal-scenario1-seed{s}",
+                outcome={"route_complete": True, "collision_event": False, "timeout_event": False},
+            )
+            for s in range(5)
+        ]
+        with (p1 / "episodes.jsonl").open("w") as f:
+            for ep in episodes:
+                f.write(json.dumps(ep) + "\n")
+
+        # Failed planner with collisions
+        p2 = runs / "social_force__differential_drive"
+        p2.mkdir(parents=True, exist_ok=True)
+        episodes = [
+            _make_episode(
+                episode_id=f"sf-scenario1-seed{s}",
+                algo="social_force",
+                outcome={
+                    "route_complete": False,
+                    "collision_event": True,
+                    "timeout_event": False,
+                },
+                metrics={"total_collision_count": 1, "near_misses": 2},
+            )
+            for s in range(3)
+        ]
+        with (p2 / "episodes.jsonl").open("w") as f:
+            for ep in episodes:
+                f.write(json.dumps(ep) + "\n")
+
+        (campaign / "campaign_manifest.json").write_text(
+            json.dumps(
+                {
+                    "campaign_id": "test_campaign",
+                    "planners": [
+                        {"key": "goal", "status": "ok"},
+                        {"key": "social_force", "status": "ok"},
+                    ],
+                }
+            )
+        )
+        return campaign
+
+    def test_input_audit_files_created(self, tmp_path: Path) -> None:
+        campaign = self._make_campaign(tmp_path)
+        output_dir = tmp_path / "output"
+
+        build_mechanism_sidecar(campaign, output_dir, "2026-01-01T00:00:00Z")
+
+        assert (output_dir / "input_audit.json").is_file()
+        assert (output_dir / "input_audit.md").is_file()
+
+    def test_input_audit_content(self, tmp_path: Path) -> None:
+        campaign = self._make_campaign(tmp_path)
+        output_dir = tmp_path / "output"
+
+        build_mechanism_sidecar(campaign, output_dir, "2026-01-01T00:00:00Z")
+
+        with (output_dir / "input_audit.json").open() as f:
+            audit = json.loads(f.readline())
+            assert audit["status"] == "ok"
+            assert audit["total_episodes"] == 8
+            assert audit["failure_episodes"] == 3
+
+    def test_crosscut_interpretation_files_created(self, tmp_path: Path) -> None:
+        campaign = self._make_campaign(tmp_path)
+        output_dir = tmp_path / "output"
+
+        build_mechanism_sidecar(campaign, output_dir, "2026-01-01T00:00:00Z")
+
+        assert (output_dir / "crosscut_interpretation.json").is_file()
+        assert (output_dir / "crosscut_interpretation.md").is_file()
+
+    def test_crosscut_interpretation_content(self, tmp_path: Path) -> None:
+        campaign = self._make_campaign(tmp_path)
+        output_dir = tmp_path / "output"
+
+        build_mechanism_sidecar(campaign, output_dir, "2026-01-01T00:00:00Z")
+
+        with (output_dir / "crosscut_interpretation.json").open() as f:
+            interp = json.loads(f.readline())
+            assert "trace_verified_mechanisms" in interp
+            assert "unresolved_mechanisms" in interp
+            assert "guarded_ppo" in interp["excluded_arms"]
+
+    def test_sha256sums_created(self, tmp_path: Path) -> None:
+        campaign = self._make_campaign(tmp_path)
+        output_dir = tmp_path / "output"
+
+        build_mechanism_sidecar(campaign, output_dir, "2026-01-01T00:00:00Z")
+
+        assert (output_dir / "SHA256SUMS").is_file()
+
+    def test_sha256sums_content(self, tmp_path: Path) -> None:
+        campaign = self._make_campaign(tmp_path)
+        output_dir = tmp_path / "output"
+
+        build_mechanism_sidecar(campaign, output_dir, "2026-01-01T00:00:00Z")
+
+        with (output_dir / "SHA256SUMS").open() as f:
+            lines = f.readlines()
+            assert len(lines) > 0
+            for line in lines:
+                parts = line.strip().split("  ")
+                assert len(parts) == 2
+                assert len(parts[0]) == 64  # SHA256 hex length
+
+    def test_label_coverage_md_created(self, tmp_path: Path) -> None:
+        campaign = self._make_campaign(tmp_path)
+        output_dir = tmp_path / "output"
+
+        build_mechanism_sidecar(campaign, output_dir, "2026-01-01T00:00:00Z")
+
+        assert (output_dir / "label_coverage.md").is_file()
+
+    def test_label_coverage_md_content(self, tmp_path: Path) -> None:
+        campaign = self._make_campaign(tmp_path)
+        output_dir = tmp_path / "output"
+
+        build_mechanism_sidecar(campaign, output_dir, "2026-01-01T00:00:00Z")
+
+        content = (output_dir / "label_coverage.md").read_text()
+        assert "Label Coverage Report" in content
+        assert "Total episodes" in content
+        assert "Label Distribution" in content
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

This PR implements issue #4831 with the following changes:

1. **Fix fail-open behavior**: Missing `avg_speed`/`path_efficiency` metrics are no longer coerced to `0.0`, which previously caused unmeasured metrics to be labeled as `static_deadlock_or_local_minimum` with `supported_hypothesis` confidence. Now uses fail-closed logic:
   - If `avg_speed` is missing, does not trigger static deadlock label
   - If `path_efficiency` is missing, does not trigger static deadlock label
   - If both metrics are missing, returns `unknown`/`insufficient_metrics` label

2. **Add missing artifact generation**:
   - `input_audit.json`/`input_audit.md` - Campaign input validation
   - `crosscut_interpretation.json`/`crosscut_interpretation.md` - Interpretation packet
   - `SHA256SUMS` - Checksums for all generated artifacts
   - `label_coverage.md` - Human-readable coverage report

3. **Register evidence files in catalog**: Added 6 evidence files to `docs/context/catalog.yaml`

4. **Tests**: Added tests for:
   - Fail-closed behavior when metrics are missing
   - New output files (input_audit, crosscut_interpretation, SHA256SUMS, label_coverage.md)

## Why

The gate triage of PR #4924 identified that the mechanism-label sidecar was blocked on:
- Correctness (fail-open): missing metrics coerced to 0.0
- Missing artifact generation (input_audit, crosscut_interpretation, SHA256SUMS, label_coverage.md)
- Evidence files not registered in catalog.yaml

This PR resolves all blocking items.

## Validation

```bash
uv run ruff check scripts/analysis/derive_issue_4206_trace_verified_failure_mechanisms.py tests/analysis/test_derive_trace_verified_failure_mechanisms.py
uv run pytest tests/analysis/test_derive_trace_verified_failure_mechanisms.py -v
```

All 35 tests pass.

## Successor Statement

This PR is a successor slice to PR #4924 (the mechanism-label sidecar first-slice). It adds:
- Fail-closed metrics behavior (correctness fix)
- Complete artifact packet (input_audit, crosscut_interpretation, SHA256SUMS, label_coverage.md)
- Catalog registration

Does not duplicate PR #4924.

## Note

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

Closes #4831