### PR TITLE
Issue #4941: seed_distribution_report.v1 schema and builder (cheap-lane worker)

### DIFF
--- a/docs/context/issue_4941_seed_distribution_report.md
+++ b/docs/context/issue_4941_seed_distribution_report.md
@@ -9,14 +9,26 @@ simulations.
 
 ## Supported inputs
 
-The builder currently adapts three existing report surfaces:
+The builder searches for supported artifacts in the campaign root **and** its
+`reports/` subdirectory (the layout real campaigns use). It currently adapts
+three existing report surfaces, reading their real on-disk shapes:
 
-1. **seed_variability.json** (from camera-ready campaign)
-   Provides per-scenario/planner seed means, across-seed CI, and raw counts.
-2. **statistical_sufficiency.json** (from campaign sufficiency rows)
-   Provides CI half-widths and sufficiency status per scenario/planner/metric.
-3. **issue_3216_headline_ci_rank_stability.json** (from CI rank stability report)
-   Provides bootstrap CI and rank-unstable flags per scenario/planner/metric.
+1. **`seed_variability_by_scenario.json`** (camera-ready seed-variability export)
+   Provides per-scenario/planner `summary` stat dicts (`mean`, `std`, `ci_low`,
+   `ci_high`, `ci_half_width`) and the per-seed means list from `per_seed`.
+   Schema version `benchmark-seed-variability-by-scenario.v1`.
+2. **`statistical_sufficiency.json`** (seed-sufficiency gate output)
+   Provides per-metric CI half-widths (`ci_half_width`) and sufficiency status
+   per scenario/planner. This surface reports precision, not point estimates, so
+   `point_estimate` is null and the interval records `half_width`. Schema version
+   `benchmark-seed-statistical-sufficiency.v1`.
+3. **headline CI rank-stability report** (`result.json` or
+   `issue_3216_headline_ci_rank_stability.json`)
+   Provides a flat `cells` list; each cell carries per-metric
+   `mean`/`ci_low`/`ci_high` and a `counted` flag. Cells excluded from the
+   headline ranking (`counted == false`) are retained and flagged `advisory_only`.
+   The generic `result.json` name is accepted only when its `schema_version`
+   starts with `issue_3216`, so an unrelated `result.json` is ignored.
 
 ## Diagnostic fields
 
@@ -25,15 +37,19 @@ Each surface entry includes a `diagnostics` block with boolean flags:
 - **`insufficient_seed_count`**: `true` when `seed_count < 10`. Low seed counts make
   point estimates unreliable for comparison. Treat these as preliminary evidence only.
 - **`unstable_rank`**: `true` when rank ordering changed across seed resamples.
-  This means the scenario winner or planner ordering is not reproducible under the
-  current seed budget.
+  Today's source artifacts do not emit per-surface rank drift, so this field is
+  null (collapsed to `false`) unless a future/source row provides
+  `rank_changed_across_seeds` (seed-variability) or `rank_unstable` (CI rank cell).
+  Campaign-level rank stability remains available in the CI rank report's
+  `rank_stability` / `decision_packet` blocks.
 - **`wide_interval`**: `true` when the confidence interval width exceeds a
   metric-specific threshold. Thresholds are tuned per metric type (e.g., 0.15 for
-  success, 0.10 for collisions). Wide intervals indicate high uncertainty in the
+  success, 0.10 for collisions); for sufficiency surfaces the width is taken as
+  `2 * ci_half_width`. Wide intervals indicate high uncertainty in the
   point estimate.
 - **`advisory_only`**: `true` when the source surface reported its evidence as
-  insufficient or diagnostic-only. These entries should not be cited as definitive
-  benchmark evidence.
+  insufficient or was excluded from the headline ranking. These entries should not
+  be cited as definitive benchmark evidence.
 
 ## Evidence boundary
 

--- a/docs/context/issue_4941_seed_distribution_report.md
+++ b/docs/context/issue_4941_seed_distribution_report.md
@@ -1,0 +1,73 @@
+# Seed Distribution Report (Issue #4941)
+
+## What this report standardizes
+
+The `seed_distribution_report.v1` schema normalizes multi-seed benchmark evidence from
+different report surfaces into a common, auditable format. It lets benchmark consumers
+compare seed-level outcomes across campaigns, planners, and scenarios without re-running
+simulations.
+
+## Supported inputs
+
+The builder currently adapts three existing report surfaces:
+
+1. **seed_variability.json** (from camera-ready campaign)
+   Provides per-scenario/planner seed means, across-seed CI, and raw counts.
+2. **statistical_sufficiency.json** (from campaign sufficiency rows)
+   Provides CI half-widths and sufficiency status per scenario/planner/metric.
+3. **issue_3216_headline_ci_rank_stability.json** (from CI rank stability report)
+   Provides bootstrap CI and rank-unstable flags per scenario/planner/metric.
+
+## Diagnostic fields
+
+Each surface entry includes a `diagnostics` block with boolean flags:
+
+- **`insufficient_seed_count`**: `true` when `seed_count < 10`. Low seed counts make
+  point estimates unreliable for comparison. Treat these as preliminary evidence only.
+- **`unstable_rank`**: `true` when rank ordering changed across seed resamples.
+  This means the scenario winner or planner ordering is not reproducible under the
+  current seed budget.
+- **`wide_interval`**: `true` when the confidence interval width exceeds a
+  metric-specific threshold. Thresholds are tuned per metric type (e.g., 0.15 for
+  success, 0.10 for collisions). Wide intervals indicate high uncertainty in the
+  point estimate.
+- **`advisory_only`**: `true` when the source surface reported its evidence as
+  insufficient or diagnostic-only. These entries should not be cited as definitive
+  benchmark evidence.
+
+## Evidence boundary
+
+A normalized `seed_distribution_report.v1` supports the claim:
+
+> Existing multi-seed benchmark outputs can be normalized into a common, auditable
+> statistical-robustness report.
+
+It does **not** support claims that:
+
+- the benchmark scenario catalog is complete;
+- the simulator is calibrated to real-world behavior;
+- narrower confidence intervals imply external validity;
+- a single campaign is publication-ready without its original evidence review.
+
+Statistical repeatability is not evidence of simulator fidelity, scenario coverage,
+or real-world validity. This report is analysis tooling, not a benchmark result.
+
+## Adding new adapters
+
+Future campaign types should add adapters without changing the v1 schema. An adapter
+reads one input format and returns a list of surface dictionaries matching the v1 schema
+contract. Steps:
+
+1. Add an `_adapt_<format>(path: Path) -> list[dict[str, Any]]` function in
+   `seed_distribution_report.py`.
+2. Register it in the adapter loop inside `build_seed_distribution_report()`.
+3. Add fixture-backed tests covering the new adapter's stable and edge cases.
+
+Nullable fields in the schema (e.g., `scenario_id`, `raw_counts`, `seed_distribution`)
+accommodate incompatible input shapes without silent data loss. Use `None` when a field
+cannot be populated, and set the appropriate diagnostic flag.
+
+## Related issues
+
+- #4932: rare-event / accelerated stress testing
+- #4933, #4934: referenced by the acceptance checklist

--- a/robot_sf/benchmark/seed_distribution_report.py
+++ b/robot_sf/benchmark/seed_distribution_report.py
@@ -169,7 +169,7 @@ def _load_json(path: Path) -> dict[str, Any] | None:
         Loaded mapping, or None on read/parse failure / non-object content.
     """
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError):
         return None
@@ -569,7 +569,7 @@ def _get_git_commit(campaign_root: Path) -> str | None:
     metadata_path = campaign_root / "metadata.json"
     if metadata_path.exists():
         try:
-            with open(metadata_path) as f:
+            with open(metadata_path, encoding="utf-8") as f:
                 metadata = json.load(f)
             return metadata.get("git_commit") or metadata.get("commit")
         except (OSError, json.JSONDecodeError):

--- a/robot_sf/benchmark/seed_distribution_report.py
+++ b/robot_sf/benchmark/seed_distribution_report.py
@@ -1,0 +1,541 @@
+"""Seed distribution report generator for multi-seed benchmark evidence.
+
+This module defines the seed_distribution_report.v1 schema and provides adapters
+to normalize existing seed-level artifacts into a common, auditable format.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION = "seed_distribution_report.v1"
+_SUPPORTED_SCHEMA_VERSIONS = frozenset({SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION})
+
+_INSUFFICIENT_SEED_THRESHOLD = 10
+_WIDE_INTERVAL_THRESHOLDS: dict[str, float] = {
+    "success": 0.15,
+    "collision": 0.10,
+    "collisions": 0.10,
+    "near_miss": 0.20,
+    "near_misses": 0.20,
+    "snqi": 0.25,
+}
+_DEFAULT_WIDE_INTERVAL_THRESHOLD = 0.20
+
+
+def validate_schema_version(payload: dict[str, Any]) -> None:
+    """Fail closed on unknown schema versions.
+
+    Args:
+        payload: Dictionary with a ``schema_version`` key.
+
+    Raises:
+        ValueError: If the schema version is missing or not supported.
+    """
+    version = payload.get("schema_version")
+    if version is None:
+        raise ValueError(
+            "payload is missing required field 'schema_version'; "
+            "refusing to process an unversioned seed distribution report"
+        )
+    if version not in _SUPPORTED_SCHEMA_VERSIONS:
+        raise ValueError(
+            f"unsupported seed distribution report schema version: {version!r}; "
+            f"supported versions: {sorted(_SUPPORTED_SCHEMA_VERSIONS)}"
+        )
+
+
+def build_seed_distribution_report(
+    campaign_root: str | Path,
+    *,
+    generated_by: str = "build_seed_distribution_report",
+) -> dict[str, Any]:
+    """Build a seed distribution report from existing campaign artifacts.
+
+    Searches for supported input artifacts (seed_variability.json,
+    statistical_sufficiency.json, CI rank stability reports) and normalizes
+    them into the seed_distribution_report.v1 schema.
+
+    Args:
+        campaign_root: Path to the campaign root directory.
+        generated_by: Identifier for the generating tool.
+
+    Returns:
+        Dictionary conforming to seed_distribution_report.v1 schema.
+
+    Raises:
+        FileNotFoundError: If no supported input artifacts are found.
+    """
+    campaign_root = Path(campaign_root)
+    if not campaign_root.exists():
+        raise FileNotFoundError(f"Campaign root does not exist: {campaign_root}")
+
+    surfaces: list[dict[str, Any]] = []
+    report_paths: list[str] = []
+
+    for adapter, filename in [
+        (_adapt_seed_variability, "seed_variability.json"),
+        (_adapt_statistical_sufficiency, "statistical_sufficiency.json"),
+        (_adapt_ci_rank_stability, "issue_3216_headline_ci_rank_stability.json"),
+    ]:
+        path = campaign_root / filename
+        if path.exists():
+            surfaces.extend(adapter(path))
+            report_paths.append(filename)
+
+    if not surfaces:
+        raise FileNotFoundError(
+            f"No supported seed-level artifacts found in {campaign_root}. "
+            "Expected one or more of: seed_variability.json, "
+            "statistical_sufficiency.json, or "
+            "issue_3216_headline_ci_rank_stability.json"
+        )
+
+    return {
+        "schema_version": SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION,
+        "source": {
+            "campaign_root": str(campaign_root),
+            "report_paths": report_paths,
+            "generated_by": generated_by,
+            "commit": _get_git_commit(campaign_root),
+        },
+        "surfaces": surfaces,
+    }
+
+
+def _build_surface(  # noqa: PLR0913
+    *,
+    surface_name: str,
+    scenario_id: str | None,
+    planner_id: str | None,
+    metric: str,
+    unit: str | None,
+    seed_count: int | None,
+    episode_count: int | None,
+    raw_counts: dict[str, Any] | None,
+    point_estimate: float | None,
+    interval: dict[str, Any] | None,
+    seed_distribution: dict[str, Any] | None,
+    diagnostics: dict[str, Any],
+    provenance: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a single surface entry with canonical field order.
+
+    Returns:
+        Dictionary with all required seed_distribution_report.v1 surface fields.
+    """
+    return {
+        "surface_id": surface_name,
+        "scenario_id": scenario_id,
+        "planner_id": planner_id,
+        "metric": metric,
+        "unit": unit,
+        "seed_count": seed_count,
+        "episode_count": episode_count,
+        "raw_counts": raw_counts,
+        "point_estimate": point_estimate,
+        "interval": interval,
+        "seed_distribution": seed_distribution,
+        "diagnostics": diagnostics,
+        "provenance": provenance,
+    }
+
+
+def _adapt_seed_variability(path: Path) -> list[dict[str, Any]]:
+    """Adapt seed_variability.json to seed_distribution_report.v1 surfaces.
+
+    Returns:
+        List of normalized surface dictionaries.
+    """
+    with open(path) as f:
+        data = json.load(f)
+
+    surfaces: list[dict[str, Any]] = []
+    provenance_base = {"input_artifact": "seed_variability.json"}
+
+    for row in data.get("rows", []):
+        scenario_id = row.get("scenario_id")
+        planner_id = row.get("planner_id", row.get("planner"))
+        seed_count = row.get("seed_count")
+        episode_count = row.get("episode_count")
+
+        for metric_name, metric_data in row.get("metrics", {}).items():
+            per_seed_means = metric_data.get("per_seed_means", [])
+            mean = metric_data.get("mean")
+            std = metric_data.get("std")
+            ci_low = metric_data.get("ci_low")
+            ci_high = metric_data.get("ci_high")
+            confidence_level = metric_data.get("confidence_level", 0.95)
+            method = metric_data.get("method", "bootstrap")
+
+            raw_counts = None
+            if metric_data.get("raw_numerator") is not None:
+                raw_counts = {
+                    "numerator": metric_data["raw_numerator"],
+                    "denominator": metric_data["raw_denominator"],
+                }
+
+            interval = None
+            if ci_low is not None and ci_high is not None:
+                interval = {
+                    "method": method,
+                    "lower": ci_low,
+                    "upper": ci_high,
+                    "confidence_level": confidence_level,
+                }
+
+            seed_distribution = None
+            if per_seed_means:
+                seed_distribution = {
+                    "values": per_seed_means,
+                    "mean": mean,
+                    "std": std,
+                    "min": min(per_seed_means),
+                    "max": max(per_seed_means),
+                }
+
+            diag = _compute_diagnostics(
+                seed_count=seed_count,
+                unstable_rank=metric_data.get("rank_changed_across_seeds"),
+                wide_interval=_is_interval_wide(ci_low, ci_high, metric_name),
+            )
+
+            surfaces.append(
+                _build_surface(
+                    surface_name="seed_variability",
+                    scenario_id=scenario_id,
+                    planner_id=planner_id,
+                    metric=metric_name,
+                    unit=metric_data.get("unit"),
+                    seed_count=seed_count,
+                    episode_count=episode_count,
+                    raw_counts=raw_counts,
+                    point_estimate=mean,
+                    interval=interval,
+                    seed_distribution=seed_distribution,
+                    diagnostics=diag,
+                    provenance={
+                        **provenance_base,
+                        "input_schema_version": row.get("schema_version"),
+                    },
+                )
+            )
+
+    return surfaces
+
+
+def _adapt_statistical_sufficiency(path: Path) -> list[dict[str, Any]]:
+    """Adapt statistical_sufficiency.json to seed_distribution_report.v1 surfaces.
+
+    Returns:
+        List of normalized surface dictionaries.
+    """
+    with open(path) as f:
+        data = json.load(f)
+
+    surfaces: list[dict[str, Any]] = []
+    provenance_base = {"input_artifact": "statistical_sufficiency.json"}
+
+    for row in data.get("rows", []):
+        scenario_id = row.get("scenario_id")
+        planner_id = row.get("planner_id", row.get("planner"))
+        sufficiency_status = row.get("sufficiency_status", "unknown")
+        seed_count = row.get("seed_count")
+        episode_count = row.get("episode_count")
+
+        for metric_name, metric_data in row.get("metrics", {}).items():
+            ci_low = metric_data.get("ci_low")
+            ci_high = metric_data.get("ci_high")
+            confidence_level = metric_data.get("confidence_level", 0.95)
+            mean = metric_data.get("mean")
+
+            interval = None
+            if ci_low is not None and ci_high is not None:
+                interval = {
+                    "method": "bootstrap",
+                    "lower": ci_low,
+                    "upper": ci_high,
+                    "confidence_level": confidence_level,
+                }
+
+            diag = _compute_diagnostics(
+                seed_count=seed_count,
+                unstable_rank=None,
+                wide_interval=_is_interval_wide(ci_low, ci_high, metric_name),
+                advisory_only=sufficiency_status == "insufficient",
+            )
+
+            surfaces.append(
+                _build_surface(
+                    surface_name="statistical_sufficiency",
+                    scenario_id=scenario_id,
+                    planner_id=planner_id,
+                    metric=metric_name,
+                    unit=metric_data.get("unit"),
+                    seed_count=seed_count,
+                    episode_count=episode_count,
+                    raw_counts=metric_data.get("raw_counts"),
+                    point_estimate=mean,
+                    interval=interval,
+                    seed_distribution=None,
+                    diagnostics=diag,
+                    provenance={
+                        **provenance_base,
+                        "input_schema_version": row.get("schema_version"),
+                    },
+                )
+            )
+
+    return surfaces
+
+
+def _adapt_ci_rank_stability(path: Path) -> list[dict[str, Any]]:
+    """Adapt CI rank stability report to seed_distribution_report.v1 surfaces.
+
+    Returns:
+        List of normalized surface dictionaries.
+    """
+    with open(path) as f:
+        data = json.load(f)
+
+    surfaces: list[dict[str, Any]] = []
+    provenance_base = {"input_artifact": "issue_3216_headline_ci_rank_stability.json"}
+
+    for planner_data in data.get("planners", []):
+        planner_id = planner_data.get("planner_id", planner_data.get("planner"))
+
+        for scenario_data in planner_data.get("scenarios", []):
+            scenario_id = scenario_data.get("scenario_id")
+
+            for metric_name, metric_data in scenario_data.get("metrics", {}).items():
+                ci_low = metric_data.get("ci_low")
+                ci_high = metric_data.get("ci_high")
+                confidence_level = metric_data.get("confidence_level", 0.95)
+                mean = metric_data.get("mean")
+                unstable_rank = metric_data.get("rank_unstable", False)
+                seed_count = metric_data.get("seed_count")
+                episode_count = metric_data.get("episode_count")
+
+                interval = None
+                if ci_low is not None and ci_high is not None:
+                    interval = {
+                        "method": "bootstrap",
+                        "lower": ci_low,
+                        "upper": ci_high,
+                        "confidence_level": confidence_level,
+                    }
+
+                diag = _compute_diagnostics(
+                    seed_count=seed_count,
+                    unstable_rank=unstable_rank,
+                    wide_interval=_is_interval_wide(ci_low, ci_high, metric_name),
+                )
+
+                surfaces.append(
+                    _build_surface(
+                        surface_name="ci_rank_stability",
+                        scenario_id=scenario_id,
+                        planner_id=planner_id,
+                        metric=metric_name,
+                        unit=metric_data.get("unit"),
+                        seed_count=seed_count,
+                        episode_count=episode_count,
+                        raw_counts=metric_data.get("raw_counts"),
+                        point_estimate=mean,
+                        interval=interval,
+                        seed_distribution=None,
+                        diagnostics=diag,
+                        provenance={
+                            **provenance_base,
+                            "input_schema_version": data.get("schema_version"),
+                        },
+                    )
+                )
+
+    return surfaces
+
+
+def _compute_diagnostics(
+    *,
+    seed_count: int | None,
+    unstable_rank: bool | None,
+    wide_interval: bool,
+    advisory_only: bool = False,
+) -> dict[str, Any]:
+    """Compute diagnostic flags for a surface.
+
+    Args:
+        seed_count: Number of seeds used in the measurement.
+        unstable_rank: Whether rank ordering changed across seed resampling.
+        wide_interval: Whether confidence interval is considered wide.
+        advisory_only: Whether the measurement is advisory-only due to insufficient evidence.
+
+    Returns:
+        Diagnostic dictionary with boolean flags.
+    """
+    insufficient = seed_count is not None and seed_count < _INSUFFICIENT_SEED_THRESHOLD
+
+    return {
+        "insufficient_seed_count": insufficient,
+        "unstable_rank": bool(unstable_rank) if unstable_rank is not None else False,
+        "wide_interval": wide_interval,
+        "advisory_only": advisory_only,
+    }
+
+
+def _is_interval_wide(
+    ci_low: float | None,
+    ci_high: float | None,
+    metric_name: str,
+) -> bool:
+    """Determine if a confidence interval is wide for the given metric.
+
+    Returns:
+        True when the interval width exceeds the metric-specific threshold.
+    """
+    if ci_low is None or ci_high is None:
+        return False
+
+    width = ci_high - ci_low
+    threshold = _WIDE_INTERVAL_THRESHOLDS.get(metric_name, _DEFAULT_WIDE_INTERVAL_THRESHOLD)
+    return width > threshold
+
+
+def _get_git_commit(campaign_root: Path) -> str | None:
+    """Attempt to extract git commit hash from campaign metadata.
+
+    Returns:
+        Git commit hash string when available, or ``None``.
+    """
+    metadata_path = campaign_root / "metadata.json"
+    if metadata_path.exists():
+        try:
+            with open(metadata_path) as f:
+                metadata = json.load(f)
+            return metadata.get("git_commit") or metadata.get("commit")
+        except (OSError, json.JSONDecodeError):
+            pass
+    return None
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    """Render a seed distribution report as a compact Markdown summary.
+
+    Args:
+        report: Seed distribution report dictionary.
+
+    Returns:
+        Markdown string with the report summary.
+    """
+    validate_schema_version(report)
+
+    source = report.get("source", {})
+    surfaces = report.get("surfaces", [])
+
+    lines: list[str] = []
+    lines.append("# Seed Distribution Report")
+    lines.append("")
+    lines.append(f"**Schema version:** {report.get('schema_version')}")
+    lines.append(f"**Campaign root:** {source.get('campaign_root')}")
+    lines.append(f"**Generated by:** {source.get('generated_by')}")
+    if source.get("commit"):
+        lines.append(f"**Commit:** {source.get('commit')}")
+    lines.append(f"**Report paths:** {', '.join(source.get('report_paths', []))}")
+    lines.append("")
+
+    scenario_count = len({s.get("scenario_id") for s in surfaces if s.get("scenario_id")})
+    planner_count = len({s.get("planner_id") for s in surfaces if s.get("planner_id")})
+    lines.append(
+        f"**Total surfaces:** {len(surfaces)} | "
+        f"**Scenarios:** {scenario_count} | "
+        f"**Planners:** {planner_count}"
+    )
+    lines.append("")
+
+    diag_insufficient = sum(
+        1 for s in surfaces if s.get("diagnostics", {}).get("insufficient_seed_count")
+    )
+    diag_unstable = sum(1 for s in surfaces if s.get("diagnostics", {}).get("unstable_rank"))
+    diag_wide = sum(1 for s in surfaces if s.get("diagnostics", {}).get("wide_interval"))
+    diag_advisory = sum(1 for s in surfaces if s.get("diagnostics", {}).get("advisory_only"))
+    lines.append("## Diagnostics Summary")
+    lines.append("")
+    lines.append(f"- Insufficient seed count: {diag_insufficient}")
+    lines.append(f"- Unstable rank: {diag_unstable}")
+    lines.append(f"- Wide interval: {diag_wide}")
+    lines.append(f"- Advisory only: {diag_advisory}")
+    lines.append("")
+
+    lines.append("## Surfaces")
+    lines.append("")
+    for surface in surfaces:
+        sid = surface.get("surface_id", "unknown")
+        scenario = surface.get("scenario_id") or "aggregate"
+        planner = surface.get("planner_id") or "aggregate"
+        metric = surface.get("metric")
+        pe = surface.get("point_estimate")
+        seeds = surface.get("seed_count")
+        interval = surface.get("interval")
+
+        pe_str = f"{pe:.4f}" if pe is not None else "N/A"
+        ci_str = ""
+        if interval:
+            ci_str = f" (CI: [{interval['lower']:.4f}, {interval['upper']:.4f}])"
+
+        diag = surface.get("diagnostics", {})
+        diag_flags = [k for k, v in diag.items() if v and k != "advisory_only"]
+        diag_str = ""
+        if diag_flags:
+            diag_str = f" [{', '.join(diag_flags)}]"
+
+        lines.append(
+            f"- **{sid}** | {scenario} | {planner} | {metric} "
+            f"| seeds={seeds} | est={pe_str}{ci_str}{diag_str}"
+        )
+
+    lines.append("")
+    lines.append(
+        "Note: Statistical repeatability does not imply simulator fidelity, "
+        "scenario coverage, or real-world validity."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_report(
+    report: dict[str, Any],
+    *,
+    out_json: str | Path | None = None,
+    out_md: str | Path | None = None,
+) -> dict[str, Path]:
+    """Write a seed distribution report to JSON and optionally Markdown files.
+
+    Args:
+        report: Seed distribution report dictionary.
+        out_json: Path to write JSON output.
+        out_md: Path to write Markdown output.
+
+    Returns:
+        Dictionary mapping output type to written file path.
+    """
+    validate_schema_version(report)
+
+    written: dict[str, Path] = {}
+
+    if out_json is not None:
+        path = Path(out_json)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(report, indent=2, sort_keys=True, default=str) + "\n",
+            encoding="utf-8",
+        )
+        written["json"] = path
+
+    if out_md is not None:
+        path = Path(out_md)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(render_markdown(report), encoding="utf-8")
+        written["md"] = path
+
+    return written

--- a/robot_sf/benchmark/seed_distribution_report.py
+++ b/robot_sf/benchmark/seed_distribution_report.py
@@ -2,11 +2,23 @@
 
 This module defines the seed_distribution_report.v1 schema and provides adapters
 to normalize existing seed-level artifacts into a common, auditable format.
+
+The adapters consume the *real* on-disk artifact shapes emitted by the existing
+benchmark pipeline:
+
+- ``seed_variability_by_scenario.json`` (camera-ready seed-variability export)
+- ``statistical_sufficiency.json`` (seed-sufficiency gate output)
+- the headline CI rank-stability report (``result.json`` /
+  ``issue_3216_headline_ci_rank_stability.json``)
+
+Each adapter is a pure reader over the loaded JSON document and emits a list of
+normalized ``surface`` dictionaries conforming to ``seed_distribution_report.v1``.
 """
 
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 from typing import Any
 
@@ -54,9 +66,10 @@ def build_seed_distribution_report(
 ) -> dict[str, Any]:
     """Build a seed distribution report from existing campaign artifacts.
 
-    Searches for supported input artifacts (seed_variability.json,
-    statistical_sufficiency.json, CI rank stability reports) and normalizes
-    them into the seed_distribution_report.v1 schema.
+    Searches for supported input artifacts in ``campaign_root`` and its
+    ``reports/`` subdirectory and normalizes them into the
+    ``seed_distribution_report.v1`` schema. No simulations or campaign runs are
+    launched.
 
     Args:
         campaign_root: Path to the campaign root directory.
@@ -66,31 +79,62 @@ def build_seed_distribution_report(
         Dictionary conforming to seed_distribution_report.v1 schema.
 
     Raises:
-        FileNotFoundError: If no supported input artifacts are found.
+        FileNotFoundError: If the campaign root does not exist or no supported
+            input artifacts are found.
     """
     campaign_root = Path(campaign_root)
     if not campaign_root.exists():
         raise FileNotFoundError(f"Campaign root does not exist: {campaign_root}")
 
+    # (candidate filenames, adapter, accept-predicate). Candidate filenames are
+    # checked in <root>/<name> then <root>/reports/<name>; the first existing
+    # match wins. The accept-predicate guards generic names (e.g. result.json)
+    # so an unrelated file with the same name is not mis-parsed.
+    specs: list[
+        tuple[
+            tuple[str, ...],
+            Any,
+            Any,
+        ]
+    ] = [
+        (
+            ("seed_variability_by_scenario.json", "seed_variability.json"),
+            _adapt_seed_variability,
+            lambda data: True,
+        ),
+        (("statistical_sufficiency.json",), _adapt_statistical_sufficiency, lambda data: True),
+        (
+            (
+                "issue_3216_headline_ci_rank_stability.json",
+                "result.json",
+            ),
+            _adapt_ci_rank_stability,
+            _is_ci_rank_stability_report,
+        ),
+    ]
+
     surfaces: list[dict[str, Any]] = []
     report_paths: list[str] = []
 
-    for adapter, filename in [
-        (_adapt_seed_variability, "seed_variability.json"),
-        (_adapt_statistical_sufficiency, "statistical_sufficiency.json"),
-        (_adapt_ci_rank_stability, "issue_3216_headline_ci_rank_stability.json"),
-    ]:
-        path = campaign_root / filename
-        if path.exists():
-            surfaces.extend(adapter(path))
-            report_paths.append(filename)
+    for filenames, adapt, accept in specs:
+        path = _find_artifact(campaign_root, filenames)
+        if path is None:
+            continue
+        data = _load_json(path)
+        if data is None or not accept(data):
+            continue
+        produced = adapt(data)
+        if produced:
+            surfaces.extend(produced)
+            report_paths.append(path.name)
 
     if not surfaces:
         raise FileNotFoundError(
             f"No supported seed-level artifacts found in {campaign_root}. "
-            "Expected one or more of: seed_variability.json, "
-            "statistical_sufficiency.json, or "
-            "issue_3216_headline_ci_rank_stability.json"
+            "Expected one or more of: seed_variability_by_scenario.json, "
+            "statistical_sufficiency.json, or a headline CI rank-stability "
+            "report (result.json / issue_3216_headline_ci_rank_stability.json) "
+            "in the root or its reports/ subdirectory."
         )
 
     return {
@@ -103,6 +147,33 @@ def build_seed_distribution_report(
         },
         "surfaces": surfaces,
     }
+
+
+def _find_artifact(root: Path, filenames: tuple[str, ...]) -> Path | None:
+    """Return the first existing artifact path for the given candidate names.
+
+    Each candidate is searched at ``root/<name>`` then ``root/reports/<name>`` to
+    match both layout conventions used by the benchmark pipeline.
+    """
+    for name in filenames:
+        for candidate in (root / name, root / "reports" / name):
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    """Load a JSON object, returning None on read/parse failure.
+
+    Returns:
+        Loaded mapping, or None on read/parse failure / non-object content.
+    """
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def _build_surface(  # noqa: PLR0913
@@ -143,39 +214,83 @@ def _build_surface(  # noqa: PLR0913
     }
 
 
-def _adapt_seed_variability(path: Path) -> list[dict[str, Any]]:
-    """Adapt seed_variability.json to seed_distribution_report.v1 surfaces.
+def _finite_float(value: Any) -> float | None:
+    """Coerce a value to float, returning None when missing or non-finite.
+
+    Returns:
+        The value as a finite float, or None when missing/non-finite/uncoercible.
+    """
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _confidence_block(data: dict[str, Any]) -> dict[str, Any]:
+    """Return the method/confidence block from a seed-level artifact."""
+    confidence = data.get("confidence")
+    if isinstance(confidence, dict):
+        return confidence
+    return {}
+
+
+def _adapt_seed_variability(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Adapt ``seed_variability_by_scenario.json`` to v1 surfaces.
+
+    The canonical input shape is::
+
+        {"schema_version": ..., "confidence": {method, confidence, ...},
+         "rows": [{
+            scenario_id, planner_key, algo, seed_count, episode_count,
+            "per_seed": [{"seed", "episode_count", "metrics": {metric: value}}],
+            "summary": {metric: {mean, std, ci_low, ci_high, ci_half_width, count}},
+            ...}]}
 
     Returns:
         List of normalized surface dictionaries.
     """
-    with open(path) as f:
-        data = json.load(f)
+    confidence = _confidence_block(data)
+    method = confidence.get("method", "bootstrap")
+    confidence_level = confidence.get("confidence", 0.95)
+    provenance_base = {
+        "input_artifact": "seed_variability_by_scenario.json",
+        "input_schema_version": data.get("schema_version"),
+    }
 
     surfaces: list[dict[str, Any]] = []
-    provenance_base = {"input_artifact": "seed_variability.json"}
 
     for row in data.get("rows", []):
         scenario_id = row.get("scenario_id")
-        planner_id = row.get("planner_id", row.get("planner"))
+        planner_id = (
+            row.get("planner_key") or row.get("planner_id") or row.get("planner") or row.get("algo")
+        )
         seed_count = row.get("seed_count")
         episode_count = row.get("episode_count")
+        per_seed_entries = row.get("per_seed") or []
+        summary = row.get("summary") if isinstance(row.get("summary"), dict) else row.get("metrics")
 
-        for metric_name, metric_data in row.get("metrics", {}).items():
-            per_seed_means = metric_data.get("per_seed_means", [])
-            mean = metric_data.get("mean")
-            std = metric_data.get("std")
-            ci_low = metric_data.get("ci_low")
-            ci_high = metric_data.get("ci_high")
-            confidence_level = metric_data.get("confidence_level", 0.95)
-            method = metric_data.get("method", "bootstrap")
+        for metric_name, metric_data in (summary or {}).items():
+            if not isinstance(metric_data, dict):
+                continue
+            mean = _finite_float(metric_data.get("mean"))
+            std = _finite_float(metric_data.get("std"))
+            ci_low = _finite_float(metric_data.get("ci_low"))
+            ci_high = _finite_float(metric_data.get("ci_high"))
 
-            raw_counts = None
-            if metric_data.get("raw_numerator") is not None:
-                raw_counts = {
-                    "numerator": metric_data["raw_numerator"],
-                    "denominator": metric_data["raw_denominator"],
-                }
+            per_seed_means: list[float] = []
+            for entry in per_seed_entries:
+                if isinstance(entry, dict):
+                    value = (
+                        entry.get("metrics", {}).get(metric_name)
+                        if isinstance(entry.get("metrics"), dict)
+                        else None
+                    )
+                    coerced = _finite_float(value)
+                    if coerced is not None:
+                        per_seed_means.append(coerced)
 
             interval = None
             if ci_low is not None and ci_high is not None:
@@ -186,7 +301,7 @@ def _adapt_seed_variability(path: Path) -> list[dict[str, Any]]:
                     "confidence_level": confidence_level,
                 }
 
-            seed_distribution = None
+            seed_distribution: dict[str, Any] | None = None
             if per_seed_means:
                 seed_distribution = {
                     "values": per_seed_means,
@@ -198,6 +313,9 @@ def _adapt_seed_variability(path: Path) -> list[dict[str, Any]]:
 
             diag = _compute_diagnostics(
                 seed_count=seed_count,
+                # Per-surface rank drift is not emitted by the current
+                # seed-variability export; honor it when a future/source row
+                # provides ``rank_changed_across_seeds`` (nullable otherwise).
                 unstable_rank=metric_data.get("rank_changed_across_seeds"),
                 wide_interval=_is_interval_wide(ci_low, ci_high, metric_name),
             )
@@ -208,62 +326,71 @@ def _adapt_seed_variability(path: Path) -> list[dict[str, Any]]:
                     scenario_id=scenario_id,
                     planner_id=planner_id,
                     metric=metric_name,
-                    unit=metric_data.get("unit"),
+                    unit=None,
                     seed_count=seed_count,
                     episode_count=episode_count,
-                    raw_counts=raw_counts,
+                    raw_counts=None,
                     point_estimate=mean,
                     interval=interval,
                     seed_distribution=seed_distribution,
                     diagnostics=diag,
-                    provenance={
-                        **provenance_base,
-                        "input_schema_version": row.get("schema_version"),
-                    },
+                    provenance=dict(provenance_base),
                 )
             )
 
     return surfaces
 
 
-def _adapt_statistical_sufficiency(path: Path) -> list[dict[str, Any]]:
-    """Adapt statistical_sufficiency.json to seed_distribution_report.v1 surfaces.
+def _adapt_statistical_sufficiency(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Adapt ``statistical_sufficiency.json`` to v1 surfaces.
+
+    The sufficiency report carries CI *half-widths* (precision) rather than point
+    estimates, so ``point_estimate`` is None and the interval records the
+    ``half_width``. Point-estimate information is not synthesized.
 
     Returns:
         List of normalized surface dictionaries.
     """
-    with open(path) as f:
-        data = json.load(f)
+    confidence = _confidence_block(data)
+    method = confidence.get("method", "bootstrap")
+    confidence_level = confidence.get("confidence", 0.95)
+    provenance_base = {
+        "input_artifact": "statistical_sufficiency.json",
+        "input_schema_version": data.get("schema_version"),
+    }
 
     surfaces: list[dict[str, Any]] = []
-    provenance_base = {"input_artifact": "statistical_sufficiency.json"}
 
     for row in data.get("rows", []):
         scenario_id = row.get("scenario_id")
-        planner_id = row.get("planner_id", row.get("planner"))
-        sufficiency_status = row.get("sufficiency_status", "unknown")
+        planner_id = (
+            row.get("planner_key") or row.get("planner_id") or row.get("planner") or row.get("algo")
+        )
         seed_count = row.get("seed_count")
         episode_count = row.get("episode_count")
+        sufficiency_status = row.get("sufficiency_status", "unknown")
 
-        for metric_name, metric_data in row.get("metrics", {}).items():
-            ci_low = metric_data.get("ci_low")
-            ci_high = metric_data.get("ci_high")
-            confidence_level = metric_data.get("confidence_level", 0.95)
-            mean = metric_data.get("mean")
+        for metric_name, metric_data in (row.get("metrics") or {}).items():
+            if not isinstance(metric_data, dict):
+                continue
+            half_width = _finite_float(metric_data.get("ci_half_width"))
 
             interval = None
-            if ci_low is not None and ci_high is not None:
+            if half_width is not None:
                 interval = {
-                    "method": "bootstrap",
-                    "lower": ci_low,
-                    "upper": ci_high,
+                    "method": method,
+                    "lower": None,
+                    "upper": None,
+                    "half_width": half_width,
                     "confidence_level": confidence_level,
                 }
 
             diag = _compute_diagnostics(
                 seed_count=seed_count,
                 unstable_rank=None,
-                wide_interval=_is_interval_wide(ci_low, ci_high, metric_name),
+                wide_interval=_width_is_wide(
+                    half_width * 2 if half_width is not None else None, metric_name
+                ),
                 advisory_only=sufficiency_status == "insufficient",
             )
 
@@ -273,86 +400,101 @@ def _adapt_statistical_sufficiency(path: Path) -> list[dict[str, Any]]:
                     scenario_id=scenario_id,
                     planner_id=planner_id,
                     metric=metric_name,
-                    unit=metric_data.get("unit"),
+                    unit=None,
                     seed_count=seed_count,
                     episode_count=episode_count,
-                    raw_counts=metric_data.get("raw_counts"),
-                    point_estimate=mean,
+                    raw_counts=None,
+                    point_estimate=None,
                     interval=interval,
                     seed_distribution=None,
                     diagnostics=diag,
-                    provenance={
-                        **provenance_base,
-                        "input_schema_version": row.get("schema_version"),
-                    },
+                    provenance=dict(provenance_base),
                 )
             )
 
     return surfaces
 
 
-def _adapt_ci_rank_stability(path: Path) -> list[dict[str, Any]]:
-    """Adapt CI rank stability report to seed_distribution_report.v1 surfaces.
+def _is_ci_rank_stability_report(data: dict[str, Any]) -> bool:
+    """Return True when a loaded document is a headline CI rank-stability report."""
+    schema_version = str(data.get("schema_version", ""))
+    return schema_version.startswith("issue_3216")
+
+
+def _adapt_ci_rank_stability(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Adapt the headline CI rank-stability report to v1 surfaces.
+
+    The report stores a flat ``cells`` list (one per scenario/planner); each
+    cell's ``metrics`` use the canonical per-metric stat dict
+    (``mean``/``std``/``ci_low``/``ci_high``/``ci_half_width``). Cells excluded
+    from the headline ranking (``counted == false``) are retained and flagged
+    ``advisory_only``. Per-cell rank instability is not a field in the source
+    report, so ``unstable_rank`` is left null.
 
     Returns:
         List of normalized surface dictionaries.
     """
-    with open(path) as f:
-        data = json.load(f)
+    confidence = _confidence_block(data) or (data.get("config") or {})
+    method = confidence.get("method", "bootstrap")
+    confidence_level = confidence.get("confidence", 0.95)
+    provenance_base = {
+        "input_artifact": "issue_3216_headline_ci_rank_stability",
+        "input_schema_version": data.get("schema_version"),
+    }
 
     surfaces: list[dict[str, Any]] = []
-    provenance_base = {"input_artifact": "issue_3216_headline_ci_rank_stability.json"}
 
-    for planner_data in data.get("planners", []):
-        planner_id = planner_data.get("planner_id", planner_data.get("planner"))
+    for cell in data.get("cells", []):
+        if not isinstance(cell, dict):
+            continue
+        scenario_id = cell.get("scenario_id")
+        planner_id = cell.get("planner_key") or cell.get("planner_id") or cell.get("planner")
+        seed_count = cell.get("seed_count")
+        counted = cell.get("counted")
+        advisory_only = counted is False
 
-        for scenario_data in planner_data.get("scenarios", []):
-            scenario_id = scenario_data.get("scenario_id")
+        for metric_name, metric_data in (cell.get("metrics") or {}).items():
+            if not isinstance(metric_data, dict):
+                continue
+            mean = _finite_float(metric_data.get("mean"))
+            ci_low = _finite_float(metric_data.get("ci_low"))
+            ci_high = _finite_float(metric_data.get("ci_high"))
 
-            for metric_name, metric_data in scenario_data.get("metrics", {}).items():
-                ci_low = metric_data.get("ci_low")
-                ci_high = metric_data.get("ci_high")
-                confidence_level = metric_data.get("confidence_level", 0.95)
-                mean = metric_data.get("mean")
-                unstable_rank = metric_data.get("rank_unstable", False)
-                seed_count = metric_data.get("seed_count")
-                episode_count = metric_data.get("episode_count")
+            interval = None
+            if ci_low is not None and ci_high is not None:
+                interval = {
+                    "method": method,
+                    "lower": ci_low,
+                    "upper": ci_high,
+                    "confidence_level": confidence_level,
+                }
 
-                interval = None
-                if ci_low is not None and ci_high is not None:
-                    interval = {
-                        "method": "bootstrap",
-                        "lower": ci_low,
-                        "upper": ci_high,
-                        "confidence_level": confidence_level,
-                    }
+            diag = _compute_diagnostics(
+                seed_count=seed_count,
+                # Per-cell rank instability is not a field in the source report;
+                # honor ``rank_unstable`` when a future/source cell provides it.
+                unstable_rank=metric_data.get("rank_unstable"),
+                wide_interval=_is_interval_wide(ci_low, ci_high, metric_name),
+                advisory_only=advisory_only,
+            )
 
-                diag = _compute_diagnostics(
+            surfaces.append(
+                _build_surface(
+                    surface_name="ci_rank_stability",
+                    scenario_id=scenario_id,
+                    planner_id=planner_id,
+                    metric=metric_name,
+                    unit=None,
                     seed_count=seed_count,
-                    unstable_rank=unstable_rank,
-                    wide_interval=_is_interval_wide(ci_low, ci_high, metric_name),
+                    episode_count=None,
+                    raw_counts=None,
+                    point_estimate=mean,
+                    interval=interval,
+                    seed_distribution=None,
+                    diagnostics=diag,
+                    provenance=dict(provenance_base),
                 )
-
-                surfaces.append(
-                    _build_surface(
-                        surface_name="ci_rank_stability",
-                        scenario_id=scenario_id,
-                        planner_id=planner_id,
-                        metric=metric_name,
-                        unit=metric_data.get("unit"),
-                        seed_count=seed_count,
-                        episode_count=episode_count,
-                        raw_counts=metric_data.get("raw_counts"),
-                        point_estimate=mean,
-                        interval=interval,
-                        seed_distribution=None,
-                        diagnostics=diag,
-                        provenance={
-                            **provenance_base,
-                            "input_schema_version": data.get("schema_version"),
-                        },
-                    )
-                )
+            )
 
     return surfaces
 
@@ -385,6 +527,21 @@ def _compute_diagnostics(
     }
 
 
+def _width_is_wide(width: float | None, metric_name: str) -> bool:
+    """Classify an interval width as wide for the given metric.
+
+    Returns:
+        True when the width exceeds the metric-specific threshold.
+    """
+    if width is None:
+        return False
+    threshold = _WIDE_INTERVAL_THRESHOLDS.get(metric_name, _DEFAULT_WIDE_INTERVAL_THRESHOLD)
+    try:
+        return float(width) > threshold
+    except (TypeError, ValueError):
+        return False
+
+
 def _is_interval_wide(
     ci_low: float | None,
     ci_high: float | None,
@@ -397,10 +554,10 @@ def _is_interval_wide(
     """
     if ci_low is None or ci_high is None:
         return False
-
-    width = ci_high - ci_low
-    threshold = _WIDE_INTERVAL_THRESHOLDS.get(metric_name, _DEFAULT_WIDE_INTERVAL_THRESHOLD)
-    return width > threshold
+    try:
+        return _width_is_wide(float(ci_high) - float(ci_low), metric_name)
+    except (TypeError, ValueError):
+        return False
 
 
 def _get_git_commit(campaign_root: Path) -> str | None:
@@ -477,12 +634,18 @@ def render_markdown(report: dict[str, Any]) -> str:
         metric = surface.get("metric")
         pe = surface.get("point_estimate")
         seeds = surface.get("seed_count")
-        interval = surface.get("interval")
+        interval = surface.get("interval") or {}
 
-        pe_str = f"{pe:.4f}" if pe is not None else "N/A"
-        ci_str = ""
-        if interval:
-            ci_str = f" (CI: [{interval['lower']:.4f}, {interval['upper']:.4f}])"
+        pe_str = f"{pe:.4f}" if isinstance(pe, (int, float)) else "N/A"
+        lo = interval.get("lower")
+        hi = interval.get("upper")
+        half_width = interval.get("half_width")
+        if isinstance(lo, (int, float)) and isinstance(hi, (int, float)):
+            ci_str = f" (CI: [{lo:.4f}, {hi:.4f}])"
+        elif isinstance(half_width, (int, float)):
+            ci_str = f" (CI half-width: {half_width:.4f})"
+        else:
+            ci_str = ""
 
         diag = surface.get("diagnostics", {})
         diag_flags = [k for k, v in diag.items() if v and k != "advisory_only"]
@@ -527,7 +690,7 @@ def write_report(
         path = Path(out_json)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
-            json.dumps(report, indent=2, sort_keys=True, default=str) + "\n",
+            json.dumps(report, indent=2, sort_keys=True, default=str, allow_nan=True) + "\n",
             encoding="utf-8",
         )
         written["json"] = path

--- a/scripts/benchmark/build_seed_distribution_report.py
+++ b/scripts/benchmark/build_seed_distribution_report.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Build a seed distribution report from existing campaign artifacts.
+
+Normalizes seed-level benchmark outputs into the seed_distribution_report.v1
+common schema. Runs entirely on local artifacts -- no simulations, no SLURM,
+no campaigns are launched.
+
+Usage:
+    uv run python scripts/benchmark/build_seed_distribution_report.py \\
+        --campaign-root output/example-campaign \\
+        --out-json output/example-campaign/reports/seed_distribution_report.json \\
+        --out-md output/example-campaign/reports/seed_distribution_report.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.seed_distribution_report import (
+    build_seed_distribution_report,
+    validate_schema_version,
+    write_report,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a seed_distribution_report.v1 from existing campaign artifacts.",
+    )
+    parser.add_argument(
+        "--campaign-root",
+        type=Path,
+        required=True,
+        help="Path to the campaign root directory containing seed-level artifacts.",
+    )
+    parser.add_argument(
+        "--out-json",
+        type=Path,
+        default=None,
+        help="Path to write the JSON report.",
+    )
+    parser.add_argument(
+        "--out-md",
+        type=Path,
+        default=None,
+        help="Path to write the Markdown summary report.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Returns:
+        Exit code: 0 on success, 1 on missing/invalid inputs, 2 on write failure.
+    """
+    args = _parse_args(argv)
+
+    if args.out_json is None and args.out_md is None:
+        print(
+            "error: at least one of --out-json or --out-md is required",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        report = build_seed_distribution_report(args.campaign_root)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    validate_schema_version(report)
+
+    try:
+        written = write_report(report, out_json=args.out_json, out_md=args.out_md)
+    except (OSError, ValueError) as exc:
+        print(f"error writing report: {exc}", file=sys.stderr)
+        return 2
+
+    for kind, path in written.items():
+        print(f"wrote {kind}: {path}")
+
+    surface_count = len(report.get("surfaces", []))
+    print(f"seed_distribution_report.v1: {surface_count} surfaces normalized")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmark/test_seed_distribution_report.py
+++ b/tests/benchmark/test_seed_distribution_report.py
@@ -1,0 +1,624 @@
+"""Tests for seed_distribution_report v1 schema, adapters, and builder.
+
+Fixture-backed tests cover stable, unstable, insufficient-seed, and missing-artifact
+cases without requiring retained campaign roots or live benchmark outputs.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from robot_sf.benchmark.seed_distribution_report import (
+    SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION,
+    _compute_diagnostics,
+    _is_interval_wide,
+    build_seed_distribution_report,
+    render_markdown,
+    validate_schema_version,
+    write_report,
+)
+
+
+@pytest.fixture()
+def stable_seed_variability(tmp_path: Path) -> Path:
+    """Create a synthetic seed_variability.json with stable multi-seed evidence."""
+    data = {
+        "rows": [
+            {
+                "scenario_id": "urban_crossing",
+                "planner_id": "orca",
+                "seed_count": 20,
+                "episode_count": 100,
+                "metrics": {
+                    "success": {
+                        "per_seed_means": [
+                            0.95,
+                            0.93,
+                            0.94,
+                            0.96,
+                            0.92,
+                            0.95,
+                            0.93,
+                            0.94,
+                            0.96,
+                            0.95,
+                            0.94,
+                            0.93,
+                            0.95,
+                            0.94,
+                            0.93,
+                            0.96,
+                            0.95,
+                            0.94,
+                            0.93,
+                            0.95,
+                        ],
+                        "mean": 0.942,
+                        "std": 0.012,
+                        "ci_low": 0.935,
+                        "ci_high": 0.949,
+                        "confidence_level": 0.95,
+                        "method": "bootstrap_mean_over_seed_means",
+                        "seed_count": 20,
+                        "episode_count": 100,
+                    },
+                    "collision": {
+                        "per_seed_means": [
+                            0.02,
+                            0.03,
+                            0.02,
+                            0.01,
+                            0.03,
+                            0.02,
+                            0.02,
+                            0.03,
+                            0.02,
+                            0.02,
+                            0.02,
+                            0.03,
+                            0.02,
+                            0.02,
+                            0.03,
+                            0.02,
+                            0.02,
+                            0.03,
+                            0.02,
+                            0.02,
+                        ],
+                        "mean": 0.023,
+                        "std": 0.006,
+                        "ci_low": 0.020,
+                        "ci_high": 0.026,
+                        "confidence_level": 0.95,
+                        "method": "bootstrap_mean_over_seed_means",
+                        "seed_count": 20,
+                        "episode_count": 100,
+                    },
+                },
+            },
+            {
+                "scenario_id": "urban_crossing",
+                "planner_id": "social_force",
+                "seed_count": 20,
+                "episode_count": 100,
+                "metrics": {
+                    "success": {
+                        "per_seed_means": [
+                            0.88,
+                            0.87,
+                            0.89,
+                            0.86,
+                            0.88,
+                            0.87,
+                            0.89,
+                            0.88,
+                            0.87,
+                            0.88,
+                            0.87,
+                            0.89,
+                            0.88,
+                            0.87,
+                            0.88,
+                            0.87,
+                            0.89,
+                            0.88,
+                            0.87,
+                            0.88,
+                        ],
+                        "mean": 0.877,
+                        "std": 0.008,
+                        "ci_low": 0.873,
+                        "ci_high": 0.881,
+                        "confidence_level": 0.95,
+                        "method": "bootstrap_mean_over_seed_means",
+                        "seed_count": 20,
+                        "episode_count": 100,
+                    },
+                },
+            },
+        ],
+    }
+    path = tmp_path / "seed_variability.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def unstable_seed_variability(tmp_path: Path) -> Path:
+    """Create a synthetic seed_variability.json with unstable rank evidence."""
+    data = {
+        "rows": [
+            {
+                "scenario_id": "narrow_corridor",
+                "planner_id": "orca",
+                "seed_count": 15,
+                "episode_count": 75,
+                "metrics": {
+                    "success": {
+                        "per_seed_means": [
+                            0.80,
+                            0.40,
+                            0.75,
+                            0.45,
+                            0.82,
+                            0.38,
+                            0.78,
+                            0.42,
+                            0.81,
+                            0.39,
+                            0.76,
+                            0.44,
+                            0.83,
+                            0.37,
+                            0.79,
+                        ],
+                        "mean": 0.615,
+                        "std": 0.198,
+                        "ci_low": 0.501,
+                        "ci_high": 0.729,
+                        "confidence_level": 0.95,
+                        "method": "bootstrap_mean_over_seed_means",
+                        "seed_count": 15,
+                        "episode_count": 75,
+                        "rank_changed_across_seeds": True,
+                    },
+                },
+            },
+        ],
+    }
+    path = tmp_path / "seed_variability.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def insufficient_seed_variability(tmp_path: Path) -> Path:
+    """Create a synthetic seed_variability.json with single-seed insufficient data."""
+    data = {
+        "rows": [
+            {
+                "scenario_id": "rare_event",
+                "planner_id": "orca",
+                "seed_count": 1,
+                "episode_count": 5,
+                "metrics": {
+                    "success": {
+                        "per_seed_means": [0.60],
+                        "mean": 0.60,
+                        "std": 0.0,
+                        "ci_low": 0.60,
+                        "ci_high": 0.60,
+                        "confidence_level": 0.95,
+                        "method": "bootstrap_mean_over_seed_means",
+                        "seed_count": 1,
+                        "episode_count": 5,
+                    },
+                },
+            },
+        ],
+    }
+    path = tmp_path / "seed_variability.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def sufficiency_data(tmp_path: Path) -> Path:
+    """Create a synthetic statistical_sufficiency.json."""
+    data = {
+        "rows": [
+            {
+                "scenario_id": "urban_crossing",
+                "planner_id": "orca",
+                "seed_count": 20,
+                "episode_count": 100,
+                "sufficiency_status": "reported",
+                "metrics": {
+                    "snqi": {
+                        "mean": 0.85,
+                        "ci_low": 0.82,
+                        "ci_high": 0.88,
+                        "confidence_level": 0.95,
+                        "seed_count": 20,
+                        "episode_count": 100,
+                    },
+                },
+            },
+        ],
+    }
+    path = tmp_path / "statistical_sufficiency.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def ci_rank_stability_data(tmp_path: Path) -> Path:
+    """Create a synthetic CI rank stability report."""
+    data = {
+        "schema_version": "issue_3216_headline_ci_rank_stability.v1",
+        "planners": [
+            {
+                "planner_id": "orca",
+                "scenarios": [
+                    {
+                        "scenario_id": "urban_crossing",
+                        "metrics": {
+                            "success": {
+                                "mean": 0.94,
+                                "ci_low": 0.93,
+                                "ci_high": 0.95,
+                                "confidence_level": 0.95,
+                                "seed_count": 20,
+                                "episode_count": 100,
+                                "rank_unstable": False,
+                            },
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+    path = tmp_path / "issue_3216_headline_ci_rank_stability.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def empty_campaign(tmp_path: Path) -> Path:
+    """Create an empty campaign directory with no supported artifacts."""
+    return tmp_path / "empty_campaign"
+
+
+class TestSchemaVersionValidation:
+    """Test schema version validation (fail-closed behavior)."""
+
+    def test_valid_schema_version_accepted(self) -> None:
+        payload = {"schema_version": SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION}
+        validate_schema_version(payload)
+
+    def test_unsupported_schema_version_rejected(self) -> None:
+        payload = {"schema_version": "seed_distribution_report.v2"}
+        with pytest.raises(ValueError, match="unsupported seed distribution report schema version"):
+            validate_schema_version(payload)
+
+    def test_missing_schema_version_rejected(self) -> None:
+        payload = {"data": "something"}
+        with pytest.raises(ValueError, match="missing required field"):
+            validate_schema_version(payload)
+
+    def test_unknown_schema_version_rejected(self) -> None:
+        payload = {"schema_version": "completely_unknown_schema.v99"}
+        with pytest.raises(ValueError, match="unsupported"):
+            validate_schema_version(payload)
+
+
+class TestDiagnostics:
+    """Test diagnostic flag computation."""
+
+    def test_sufficient_seeds_no_insufficient_flag(self) -> None:
+        diag = _compute_diagnostics(seed_count=20, unstable_rank=False, wide_interval=False)
+        assert diag["insufficient_seed_count"] is False
+        assert diag["unstable_rank"] is False
+        assert diag["wide_interval"] is False
+        assert diag["advisory_only"] is False
+
+    def test_insufficient_seeds_detected(self) -> None:
+        diag = _compute_diagnostics(seed_count=5, unstable_rank=False, wide_interval=False)
+        assert diag["insufficient_seed_count"] is True
+
+    def test_unstable_rank_detected(self) -> None:
+        diag = _compute_diagnostics(seed_count=20, unstable_rank=True, wide_interval=False)
+        assert diag["unstable_rank"] is True
+
+    def test_wide_interval_detected(self) -> None:
+        diag = _compute_diagnostics(seed_count=20, unstable_rank=False, wide_interval=True)
+        assert diag["wide_interval"] is True
+
+    def test_advisory_only_flag(self) -> None:
+        diag = _compute_diagnostics(
+            seed_count=20, unstable_rank=False, wide_interval=False, advisory_only=True
+        )
+        assert diag["advisory_only"] is True
+
+
+class TestIntervalWidth:
+    """Test interval width classification."""
+
+    def test_success_metric_wide(self) -> None:
+        assert _is_interval_wide(0.40, 0.80, "success") is True
+
+    def test_success_metric_narrow(self) -> None:
+        assert _is_interval_wide(0.93, 0.96, "success") is False
+
+    def test_collision_metric_wide(self) -> None:
+        assert _is_interval_wide(0.01, 0.15, "collision") is True
+
+    def test_none_ci_not_wide(self) -> None:
+        assert _is_interval_wide(None, None, "success") is False
+
+    def test_unknown_metric_uses_default(self) -> None:
+        assert _is_interval_wide(0.0, 0.50, "some_unknown_metric") is True
+        assert _is_interval_wide(0.40, 0.50, "some_unknown_metric") is False
+
+
+class TestStableMultiSeedReport:
+    """Test stable multi-seed evidence with narrow intervals."""
+
+    def test_stable_report_schema(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        assert report["schema_version"] == SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION
+
+    def test_stable_report_surfaces(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        surfaces = report["surfaces"]
+        assert len(surfaces) == 3
+
+    def test_stable_report_point_estimates(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        success_surface = next(
+            s for s in report["surfaces"] if s["metric"] == "success" and s["planner_id"] == "orca"
+        )
+        assert success_surface["point_estimate"] == 0.942
+
+    def test_stable_report_ci_preserved(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        success_surface = next(
+            s for s in report["surfaces"] if s["metric"] == "success" and s["planner_id"] == "orca"
+        )
+        assert success_surface["interval"]["lower"] == 0.935
+        assert success_surface["interval"]["upper"] == 0.949
+        assert success_surface["interval"]["confidence_level"] == 0.95
+
+    def test_stable_report_seed_distribution(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        success_surface = next(
+            s for s in report["surfaces"] if s["metric"] == "success" and s["planner_id"] == "orca"
+        )
+        sd = success_surface["seed_distribution"]
+        assert len(sd["values"]) == 20
+        assert sd["mean"] == 0.942
+        assert sd["min"] <= sd["mean"] <= sd["max"]
+
+    def test_stable_report_seed_count_preserved(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        for surface in report["surfaces"]:
+            assert surface["seed_count"] >= 1
+
+    def test_stable_report_diagnostics_clean(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        orca_success = next(
+            s for s in report["surfaces"] if s["metric"] == "success" and s["planner_id"] == "orca"
+        )
+        diag = orca_success["diagnostics"]
+        assert diag["insufficient_seed_count"] is False
+        assert diag["unstable_rank"] is False
+        assert diag["wide_interval"] is False
+        assert diag["advisory_only"] is False
+
+    def test_stable_report_deterministic_ordering(self, stable_seed_variability: Path) -> None:
+        report_a = build_seed_distribution_report(stable_seed_variability.parent)
+        report_b = build_seed_distribution_report(stable_seed_variability.parent)
+        assert json.dumps(report_a, sort_keys=True) == json.dumps(report_b, sort_keys=True)
+
+
+class TestUnstableEvidenceReport:
+    """Test unstable evidence with rank or scenario-winner drift."""
+
+    def test_unstable_rank_detected(self, unstable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(unstable_seed_variability.parent)
+        surface = report["surfaces"][0]
+        assert surface["diagnostics"]["unstable_rank"] is True
+
+    def test_unstable_wide_interval(self, unstable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(unstable_seed_variability.parent)
+        surface = report["surfaces"][0]
+        assert surface["diagnostics"]["wide_interval"] is True
+
+
+class TestInsufficientDataReport:
+    """Test single-seed or incomplete seed coverage."""
+
+    def test_insufficient_seed_flag(self, insufficient_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(insufficient_seed_variability.parent)
+        surface = report["surfaces"][0]
+        assert surface["diagnostics"]["insufficient_seed_count"] is True
+
+    def test_insufficient_seed_distribution_single_value(
+        self, insufficient_seed_variability: Path
+    ) -> None:
+        report = build_seed_distribution_report(insufficient_seed_variability.parent)
+        surface = report["surfaces"][0]
+        assert len(surface["seed_distribution"]["values"]) == 1
+
+    def test_insufficient_raw_counts_preserved(self, insufficient_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(insufficient_seed_variability.parent)
+        surface = report["surfaces"][0]
+        assert surface["seed_count"] == 1
+        assert surface["episode_count"] == 5
+
+
+class TestMissingOptionalArtifacts:
+    """Test that missing optional artifacts produce advisory diagnostics."""
+
+    def test_only_seed_variability_present(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        assert len(report["surfaces"]) == 3
+        assert "seed_variability.json" in report["source"]["report_paths"]
+
+    def test_only_sufficiency_present(self, sufficiency_data: Path) -> None:
+        report = build_seed_distribution_report(sufficiency_data.parent)
+        assert len(report["surfaces"]) == 1
+        assert "statistical_sufficiency.json" in report["source"]["report_paths"]
+
+    def test_only_ci_rank_stability_present(self, ci_rank_stability_data: Path) -> None:
+        report = build_seed_distribution_report(ci_rank_stability_data.parent)
+        assert len(report["surfaces"]) == 1
+        assert "issue_3216_headline_ci_rank_stability.json" in report["source"]["report_paths"]
+
+
+class TestNoSupportedArtifacts:
+    """Test behavior when no supported seed evidence is present."""
+
+    def test_empty_campaign_raises(self, empty_campaign: Path) -> None:
+        empty_campaign.mkdir(parents=True)
+        with pytest.raises(FileNotFoundError, match="No supported seed-level artifacts"):
+            build_seed_distribution_report(empty_campaign)
+
+    def test_nonexistent_campaign_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            build_seed_distribution_report(tmp_path / "nonexistent")
+
+
+class TestMultipleAdaptersCombined:
+    """Test combining multiple adapter inputs."""
+
+    def test_all_three_adapters(
+        self,
+        stable_seed_variability: Path,
+        sufficiency_data: Path,
+        ci_rank_stability_data: Path,
+    ) -> None:
+        import shutil
+
+        campaign = stable_seed_variability.parent
+        dst_suff = campaign / "statistical_sufficiency.json"
+        dst_ci = campaign / "issue_3216_headline_ci_rank_stability.json"
+        if sufficiency_data.resolve() != dst_suff.resolve():
+            shutil.copy2(sufficiency_data, dst_suff)
+        if ci_rank_stability_data.resolve() != dst_ci.resolve():
+            shutil.copy2(ci_rank_stability_data, dst_ci)
+
+        report = build_seed_distribution_report(campaign)
+        assert len(report["surfaces"]) == 3 + 1 + 1
+        assert len(report["source"]["report_paths"]) == 3
+
+
+class TestMarkdownRendering:
+    """Test Markdown report generation."""
+
+    def test_render_markdown_contains_header(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        md = render_markdown(report)
+        assert "# Seed Distribution Report" in md
+
+    def test_render_markdown_contains_schema_version(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        md = render_markdown(report)
+        assert SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION in md
+
+    def test_render_markdown_contains_diagnostics(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        md = render_markdown(report)
+        assert "Diagnostics Summary" in md
+
+    def test_render_markdown_contains_surfaces(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        md = render_markdown(report)
+        assert "Surfaces" in md
+        assert "urban_crossing" in md
+        assert "orca" in md
+
+    def test_render_markdown_contains_validity_caveat(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        md = render_markdown(report)
+        assert "not imply simulator fidelity" in md
+
+
+class TestWriteReport:
+    """Test JSON and Markdown file writing."""
+
+    def test_write_json(self, stable_seed_variability: Path, tmp_path: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        out_json = tmp_path / "report.json"
+        written = write_report(report, out_json=out_json)
+        assert "json" in written
+        assert written["json"].exists()
+
+        with open(out_json) as f:
+            loaded = json.load(f)
+        assert loaded["schema_version"] == SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION
+
+    def test_write_md(self, stable_seed_variability: Path, tmp_path: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        out_md = tmp_path / "report.md"
+        written = write_report(report, out_md=out_md)
+        assert "md" in written
+        assert written["md"].exists()
+        content = out_md.read_text()
+        assert "Seed Distribution Report" in content
+
+    def test_write_both(self, stable_seed_variability: Path, tmp_path: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        written = write_report(
+            report,
+            out_json=tmp_path / "r.json",
+            out_md=tmp_path / "r.md",
+        )
+        assert "json" in written
+        assert "md" in written
+
+    def test_write_report_validates_schema(self, tmp_path: Path) -> None:
+        bad_report = {"schema_version": "bad.v1"}
+        with pytest.raises(ValueError, match="unsupported"):
+            write_report(bad_report, out_json=tmp_path / "bad.json")
+
+
+class TestProvenanceFields:
+    """Test that provenance metadata is preserved."""
+
+    def test_source_campaign_root(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        assert report["source"]["campaign_root"] == str(stable_seed_variability.parent)
+
+    def test_source_report_paths(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        assert "seed_variability.json" in report["source"]["report_paths"]
+
+    def test_source_generated_by(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(
+            stable_seed_variability.parent, generated_by="test_tool"
+        )
+        assert report["source"]["generated_by"] == "test_tool"
+
+    def test_surface_provenance(self, stable_seed_variability: Path) -> None:
+        report = build_seed_distribution_report(stable_seed_variability.parent)
+        surface = report["surfaces"][0]
+        assert "input_artifact" in surface["provenance"]
+
+
+class TestSchemaVersionConstant:
+    """Test the schema version constant is set correctly."""
+
+    def test_schema_version_string(self) -> None:
+        assert SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION == "seed_distribution_report.v1"
+
+    def test_schema_version_in_supported_set(self) -> None:
+        from robot_sf.benchmark.seed_distribution_report import _SUPPORTED_SCHEMA_VERSIONS
+
+        assert SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION in _SUPPORTED_SCHEMA_VERSIONS

--- a/tests/benchmark/test_seed_distribution_report.py
+++ b/tests/benchmark/test_seed_distribution_report.py
@@ -1,167 +1,202 @@
 """Tests for seed_distribution_report v1 schema, adapters, and builder.
 
-Fixture-backed tests cover stable, unstable, insufficient-seed, and missing-artifact
-cases without requiring retained campaign roots or live benchmark outputs.
+Fixture-backed tests cover stable, unstable, insufficient-seed, and
+missing-artifact cases without requiring retained campaign roots or live
+benchmark outputs. Fixtures mirror the *real* on-disk artifact shapes emitted by
+the benchmark pipeline so they exercise the same parsing paths used on real
+campaign folders.
 """
 
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import Any
 
 import pytest
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 from robot_sf.benchmark.seed_distribution_report import (
     SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION,
     _compute_diagnostics,
     _is_interval_wide,
+    _width_is_wide,
     build_seed_distribution_report,
     render_markdown,
     validate_schema_version,
     write_report,
 )
 
+# A real evidence folder that ships both seed-variability and sufficiency
+# artifacts under reports/. Used for an optional real-data smoke test; skipped
+# when absent so the suite stays self-contained in stripped checkouts.
+_REAL_EVIDENCE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "docs"
+    / "context"
+    / "evidence"
+    / "issue_1484_broader_cross_kinematics_2026-05-28"
+)
 
-@pytest.fixture()
-def stable_seed_variability(tmp_path: Path) -> Path:
-    """Create a synthetic seed_variability.json with stable multi-seed evidence."""
-    data = {
-        "rows": [
-            {
-                "scenario_id": "urban_crossing",
-                "planner_id": "orca",
-                "seed_count": 20,
-                "episode_count": 100,
-                "metrics": {
-                    "success": {
-                        "per_seed_means": [
-                            0.95,
-                            0.93,
-                            0.94,
-                            0.96,
-                            0.92,
-                            0.95,
-                            0.93,
-                            0.94,
-                            0.96,
-                            0.95,
-                            0.94,
-                            0.93,
-                            0.95,
-                            0.94,
-                            0.93,
-                            0.96,
-                            0.95,
-                            0.94,
-                            0.93,
-                            0.95,
-                        ],
-                        "mean": 0.942,
-                        "std": 0.012,
-                        "ci_low": 0.935,
-                        "ci_high": 0.949,
-                        "confidence_level": 0.95,
-                        "method": "bootstrap_mean_over_seed_means",
-                        "seed_count": 20,
-                        "episode_count": 100,
-                    },
-                    "collision": {
-                        "per_seed_means": [
-                            0.02,
-                            0.03,
-                            0.02,
-                            0.01,
-                            0.03,
-                            0.02,
-                            0.02,
-                            0.03,
-                            0.02,
-                            0.02,
-                            0.02,
-                            0.03,
-                            0.02,
-                            0.02,
-                            0.03,
-                            0.02,
-                            0.02,
-                            0.03,
-                            0.02,
-                            0.02,
-                        ],
-                        "mean": 0.023,
-                        "std": 0.006,
-                        "ci_low": 0.020,
-                        "ci_high": 0.026,
-                        "confidence_level": 0.95,
-                        "method": "bootstrap_mean_over_seed_means",
-                        "seed_count": 20,
-                        "episode_count": 100,
-                    },
-                },
-            },
-            {
-                "scenario_id": "urban_crossing",
-                "planner_id": "social_force",
-                "seed_count": 20,
-                "episode_count": 100,
-                "metrics": {
-                    "success": {
-                        "per_seed_means": [
-                            0.88,
-                            0.87,
-                            0.89,
-                            0.86,
-                            0.88,
-                            0.87,
-                            0.89,
-                            0.88,
-                            0.87,
-                            0.88,
-                            0.87,
-                            0.89,
-                            0.88,
-                            0.87,
-                            0.88,
-                            0.87,
-                            0.89,
-                            0.88,
-                            0.87,
-                            0.88,
-                        ],
-                        "mean": 0.877,
-                        "std": 0.008,
-                        "ci_low": 0.873,
-                        "ci_high": 0.881,
-                        "confidence_level": 0.95,
-                        "method": "bootstrap_mean_over_seed_means",
-                        "seed_count": 20,
-                        "episode_count": 100,
-                    },
-                },
-            },
-        ],
+
+def _stat(
+    mean: float,
+    *,
+    std: float = 0.0,
+    ci_low: float | None = None,
+    ci_high: float | None = None,
+    count: float = 12.0,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a canonical per-metric stat dict (matches seed_variance._stats_for_vals)."""
+    ci_low = mean if ci_low is None else ci_low
+    ci_high = mean if ci_high is None else ci_high
+    payload: dict[str, Any] = {
+        "mean": mean,
+        "std": std,
+        "cv": 0.0 if mean else float("nan"),
+        "count": count,
+        "ci_low": ci_low,
+        "ci_high": ci_high,
+        "ci_half_width": (ci_high - ci_low) / 2,
     }
-    path = tmp_path / "seed_variability.json"
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def _write_json(path: Path, data: Any) -> Path:
     path.write_text(json.dumps(data), encoding="utf-8")
     return path
 
 
 @pytest.fixture()
-def unstable_seed_variability(tmp_path: Path) -> Path:
-    """Create a synthetic seed_variability.json with unstable rank evidence."""
+def stable_seed_variability(tmp_path: Path) -> Path:
+    """Synthetic seed_variability_by_scenario.json with stable multi-seed evidence."""
+    orca_success_per_seed = [
+        0.95,
+        0.93,
+        0.94,
+        0.96,
+        0.92,
+        0.95,
+        0.93,
+        0.94,
+        0.96,
+        0.95,
+        0.94,
+        0.93,
+    ]
+    orca_collision_per_seed = [
+        0.02,
+        0.03,
+        0.02,
+        0.01,
+        0.03,
+        0.02,
+        0.02,
+        0.03,
+        0.02,
+        0.02,
+        0.02,
+        0.03,
+    ]
+    social_success_per_seed = [
+        0.88,
+        0.87,
+        0.89,
+        0.86,
+        0.88,
+        0.87,
+        0.89,
+        0.88,
+        0.87,
+        0.88,
+        0.87,
+        0.89,
+    ]
     data = {
+        "schema_version": "benchmark-seed-variability-by-scenario.v1",
+        "campaign_id": "stable-fixture",
+        "confidence": {
+            "method": "bootstrap_mean_over_seed_means",
+            "confidence": 0.95,
+            "bootstrap_samples": 100,
+            "bootstrap_seed": 123,
+        },
+        "row_count": 2,
+        "rows": [
+            {
+                "scenario_id": "urban_crossing",
+                "planner_key": "orca",
+                "algo": "orca",
+                "planner_group": "core",
+                "kinematics": "differential_drive",
+                "benchmark_profile": "baseline-safe",
+                "n": 12,
+                "seed_count": 12,
+                "episode_count": 60,
+                "seed_list": list(range(12)),
+                "per_seed": [
+                    {
+                        "seed": i,
+                        "episode_count": 5,
+                        "metrics": {
+                            "success": orca_success_per_seed[i],
+                            "collisions": orca_collision_per_seed[i],
+                        },
+                    }
+                    for i in range(12)
+                ],
+                "summary": {
+                    "success": _stat(0.942, std=0.012, ci_low=0.935, ci_high=0.949),
+                    "collisions": _stat(0.023, std=0.006, ci_low=0.020, ci_high=0.026),
+                },
+            },
+            {
+                "scenario_id": "urban_crossing",
+                "planner_key": "social_force",
+                "algo": "social_force",
+                "planner_group": "core",
+                "kinematics": "differential_drive",
+                "benchmark_profile": "baseline-safe",
+                "n": 12,
+                "seed_count": 12,
+                "episode_count": 60,
+                "seed_list": list(range(12)),
+                "per_seed": [
+                    {
+                        "seed": i,
+                        "episode_count": 5,
+                        "metrics": {"success": social_success_per_seed[i]},
+                    }
+                    for i in range(12)
+                ],
+                "summary": {
+                    "success": _stat(0.877, std=0.008, ci_low=0.873, ci_high=0.881),
+                },
+            },
+        ],
+    }
+    return _write_json(tmp_path / "seed_variability_by_scenario.json", data)
+
+
+@pytest.fixture()
+def unstable_seed_variability(tmp_path: Path) -> Path:
+    """Synthetic seed_variability_by_scenario.json with wide CI + rank drift."""
+    data = {
+        "schema_version": "benchmark-seed-variability-by-scenario.v1",
+        "confidence": {"method": "bootstrap_mean_over_seed_means", "confidence": 0.95},
         "rows": [
             {
                 "scenario_id": "narrow_corridor",
-                "planner_id": "orca",
+                "planner_key": "orca",
+                "algo": "orca",
                 "seed_count": 15,
                 "episode_count": 75,
-                "metrics": {
-                    "success": {
-                        "per_seed_means": [
+                "per_seed": [
+                    {"seed": i, "episode_count": 5, "metrics": {"success": v}}
+                    for i, v in enumerate(
+                        [
                             0.80,
                             0.40,
                             0.75,
@@ -177,116 +212,104 @@ def unstable_seed_variability(tmp_path: Path) -> Path:
                             0.83,
                             0.37,
                             0.79,
-                        ],
-                        "mean": 0.615,
-                        "std": 0.198,
-                        "ci_low": 0.501,
-                        "ci_high": 0.729,
-                        "confidence_level": 0.95,
-                        "method": "bootstrap_mean_over_seed_means",
-                        "seed_count": 15,
-                        "episode_count": 75,
-                        "rank_changed_across_seeds": True,
-                    },
+                        ]
+                    )
+                ],
+                "summary": {
+                    # width 0.228 > 0.15 success threshold -> wide
+                    "success": _stat(
+                        0.615,
+                        std=0.198,
+                        ci_low=0.501,
+                        ci_high=0.729,
+                        extra={"rank_changed_across_seeds": True},
+                    ),
                 },
-            },
+            }
         ],
     }
-    path = tmp_path / "seed_variability.json"
-    path.write_text(json.dumps(data), encoding="utf-8")
-    return path
+    return _write_json(tmp_path / "seed_variability_by_scenario.json", data)
 
 
 @pytest.fixture()
 def insufficient_seed_variability(tmp_path: Path) -> Path:
-    """Create a synthetic seed_variability.json with single-seed insufficient data."""
+    """Synthetic seed_variability_by_scenario.json with single-seed insufficient data."""
     data = {
+        "schema_version": "benchmark-seed-variability-by-scenario.v1",
+        "confidence": {"method": "bootstrap_mean_over_seed_means", "confidence": 0.95},
         "rows": [
             {
                 "scenario_id": "rare_event",
-                "planner_id": "orca",
+                "planner_key": "orca",
+                "algo": "orca",
                 "seed_count": 1,
                 "episode_count": 5,
-                "metrics": {
-                    "success": {
-                        "per_seed_means": [0.60],
-                        "mean": 0.60,
-                        "std": 0.0,
-                        "ci_low": 0.60,
-                        "ci_high": 0.60,
-                        "confidence_level": 0.95,
-                        "method": "bootstrap_mean_over_seed_means",
-                        "seed_count": 1,
-                        "episode_count": 5,
-                    },
-                },
-            },
+                "per_seed": [{"seed": 111, "episode_count": 5, "metrics": {"success": 0.60}}],
+                "summary": {"success": _stat(0.60, std=0.0, ci_low=0.60, ci_high=0.60, count=1)},
+            }
         ],
     }
-    path = tmp_path / "seed_variability.json"
-    path.write_text(json.dumps(data), encoding="utf-8")
-    return path
+    return _write_json(tmp_path / "seed_variability_by_scenario.json", data)
 
 
 @pytest.fixture()
 def sufficiency_data(tmp_path: Path) -> Path:
-    """Create a synthetic statistical_sufficiency.json."""
+    """Synthetic statistical_sufficiency.json with real shape (ci_half_width, planner_key)."""
     data = {
+        "schema_version": "benchmark-seed-statistical-sufficiency.v1",
+        "campaign_id": "sufficiency-fixture",
+        "confidence": {
+            "method": "bootstrap_mean_over_seed_means",
+            "confidence": 0.95,
+            "bootstrap_samples": 300,
+            "bootstrap_seed": 123,
+        },
+        "row_count": 1,
         "rows": [
             {
                 "scenario_id": "urban_crossing",
-                "planner_id": "orca",
+                "planner_key": "orca",
+                "kinematics": "differential_drive",
+                "algo": "orca",
                 "seed_count": 20,
                 "episode_count": 100,
                 "sufficiency_status": "reported",
-                "metrics": {
-                    "snqi": {
-                        "mean": 0.85,
-                        "ci_low": 0.82,
-                        "ci_high": 0.88,
-                        "confidence_level": 0.95,
-                        "seed_count": 20,
-                        "episode_count": 100,
-                    },
-                },
-            },
+                "metric_half_widths": {"snqi": 0.03},
+                "metrics": {"snqi": {"n": 20.0, "ci_half_width": 0.03}},
+            }
         ],
     }
-    path = tmp_path / "statistical_sufficiency.json"
-    path.write_text(json.dumps(data), encoding="utf-8")
-    return path
+    return _write_json(tmp_path / "statistical_sufficiency.json", data)
 
 
 @pytest.fixture()
 def ci_rank_stability_data(tmp_path: Path) -> Path:
-    """Create a synthetic CI rank stability report."""
+    """Synthetic headline CI rank-stability report with the real flat-cells shape."""
     data = {
         "schema_version": "issue_3216_headline_ci_rank_stability.v1",
-        "planners": [
+        "classification": "rank_stable",
+        "cells": [
             {
-                "planner_id": "orca",
-                "scenarios": [
-                    {
-                        "scenario_id": "urban_crossing",
-                        "metrics": {
-                            "success": {
-                                "mean": 0.94,
-                                "ci_low": 0.93,
-                                "ci_high": 0.95,
-                                "confidence_level": 0.95,
-                                "seed_count": 20,
-                                "episode_count": 100,
-                                "rank_unstable": False,
-                            },
-                        },
-                    },
-                ],
+                "scenario_id": "urban_crossing",
+                "planner_key": "orca",
+                "row_status": "ok",
+                "counted": True,
+                "exclusion_reason": None,
+                "seed_count": 20,
+                "metrics": {"success": _stat(0.94, ci_low=0.93, ci_high=0.95, count=20)},
+            },
+            {
+                "scenario_id": "urban_crossing",
+                "planner_key": "goal",
+                "row_status": "excluded_insufficient_seeds",
+                "counted": False,
+                "exclusion_reason": "insufficient_seeds",
+                "seed_count": 2,
+                "metrics": {"success": _stat(0.70, ci_low=0.40, ci_high=1.00, count=2)},
             },
         ],
     }
-    path = tmp_path / "issue_3216_headline_ci_rank_stability.json"
-    path.write_text(json.dumps(data), encoding="utf-8")
-    return path
+    return _write_json(tmp_path / "result.json", data)
 
 
 @pytest.fixture()
@@ -346,6 +369,10 @@ class TestDiagnostics:
         )
         assert diag["advisory_only"] is True
 
+    def test_unstable_rank_null_collapses_to_false(self) -> None:
+        diag = _compute_diagnostics(seed_count=20, unstable_rank=None, wide_interval=False)
+        assert diag["unstable_rank"] is False
+
 
 class TestIntervalWidth:
     """Test interval width classification."""
@@ -366,6 +393,11 @@ class TestIntervalWidth:
         assert _is_interval_wide(0.0, 0.50, "some_unknown_metric") is True
         assert _is_interval_wide(0.40, 0.50, "some_unknown_metric") is False
 
+    def test_width_is_wide_from_half_width(self) -> None:
+        # snqi threshold 0.25; width 0.30 -> wide
+        assert _width_is_wide(0.30, "snqi") is True
+        assert _width_is_wide(None, "snqi") is False
+
 
 class TestStableMultiSeedReport:
     """Test stable multi-seed evidence with narrow intervals."""
@@ -384,15 +416,15 @@ class TestStableMultiSeedReport:
         success_surface = next(
             s for s in report["surfaces"] if s["metric"] == "success" and s["planner_id"] == "orca"
         )
-        assert success_surface["point_estimate"] == 0.942
+        assert success_surface["point_estimate"] == pytest.approx(0.942)
 
     def test_stable_report_ci_preserved(self, stable_seed_variability: Path) -> None:
         report = build_seed_distribution_report(stable_seed_variability.parent)
         success_surface = next(
             s for s in report["surfaces"] if s["metric"] == "success" and s["planner_id"] == "orca"
         )
-        assert success_surface["interval"]["lower"] == 0.935
-        assert success_surface["interval"]["upper"] == 0.949
+        assert success_surface["interval"]["lower"] == pytest.approx(0.935)
+        assert success_surface["interval"]["upper"] == pytest.approx(0.949)
         assert success_surface["interval"]["confidence_level"] == 0.95
 
     def test_stable_report_seed_distribution(self, stable_seed_variability: Path) -> None:
@@ -401,8 +433,8 @@ class TestStableMultiSeedReport:
             s for s in report["surfaces"] if s["metric"] == "success" and s["planner_id"] == "orca"
         )
         sd = success_surface["seed_distribution"]
-        assert len(sd["values"]) == 20
-        assert sd["mean"] == 0.942
+        assert len(sd["values"]) == 12
+        assert sd["mean"] == pytest.approx(0.942)
         assert sd["min"] <= sd["mean"] <= sd["max"]
 
     def test_stable_report_seed_count_preserved(self, stable_seed_variability: Path) -> None:
@@ -428,7 +460,7 @@ class TestStableMultiSeedReport:
 
 
 class TestUnstableEvidenceReport:
-    """Test unstable evidence with rank or scenario-winner drift."""
+    """Test unstable evidence with wide intervals and rank drift."""
 
     def test_unstable_rank_detected(self, unstable_seed_variability: Path) -> None:
         report = build_seed_distribution_report(unstable_seed_variability.parent)
@@ -469,7 +501,7 @@ class TestMissingOptionalArtifacts:
     def test_only_seed_variability_present(self, stable_seed_variability: Path) -> None:
         report = build_seed_distribution_report(stable_seed_variability.parent)
         assert len(report["surfaces"]) == 3
-        assert "seed_variability.json" in report["source"]["report_paths"]
+        assert "seed_variability_by_scenario.json" in report["source"]["report_paths"]
 
     def test_only_sufficiency_present(self, sufficiency_data: Path) -> None:
         report = build_seed_distribution_report(sufficiency_data.parent)
@@ -478,8 +510,17 @@ class TestMissingOptionalArtifacts:
 
     def test_only_ci_rank_stability_present(self, ci_rank_stability_data: Path) -> None:
         report = build_seed_distribution_report(ci_rank_stability_data.parent)
-        assert len(report["surfaces"]) == 1
-        assert "issue_3216_headline_ci_rank_stability.json" in report["source"]["report_paths"]
+        # Two cells x one metric each.
+        assert len(report["surfaces"]) == 2
+        assert "result.json" in report["source"]["report_paths"]
+
+    def test_sufficiency_preserves_half_width(self, sufficiency_data: Path) -> None:
+        report = build_seed_distribution_report(sufficiency_data.parent)
+        surface = report["surfaces"][0]
+        interval = surface["interval"]
+        assert interval is not None
+        assert interval["half_width"] == pytest.approx(0.03)
+        assert surface["point_estimate"] is None
 
 
 class TestNoSupportedArtifacts:
@@ -493,6 +534,29 @@ class TestNoSupportedArtifacts:
     def test_nonexistent_campaign_raises(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError, match="does not exist"):
             build_seed_distribution_report(tmp_path / "nonexistent")
+
+    def test_unrelated_result_json_is_skipped(self, tmp_path: Path) -> None:
+        # A result.json that is NOT an issue_3216 CI rank report must be ignored,
+        # and with no other supported artifacts the builder must fail closed.
+        _write_json(tmp_path / "result.json", {"schema_version": "something_else.v1", "cells": []})
+        with pytest.raises(FileNotFoundError, match="No supported seed-level artifacts"):
+            build_seed_distribution_report(tmp_path)
+
+
+class TestArtifactDiscovery:
+    """Test artifact discovery across root and reports/ subdirectory layouts."""
+
+    def test_finds_artifact_in_reports_subdir(
+        self, stable_seed_variability: Path, tmp_path: Path
+    ) -> None:
+        campaign = tmp_path / "campaign"
+        reports = campaign / "reports"
+        reports.mkdir(parents=True)
+        target = reports / "seed_variability_by_scenario.json"
+        target.write_text(stable_seed_variability.read_text(), encoding="utf-8")
+        report = build_seed_distribution_report(campaign)
+        assert len(report["surfaces"]) == 3
+        assert report["source"]["campaign_root"] == str(campaign)
 
 
 class TestMultipleAdaptersCombined:
@@ -508,15 +572,22 @@ class TestMultipleAdaptersCombined:
 
         campaign = stable_seed_variability.parent
         dst_suff = campaign / "statistical_sufficiency.json"
-        dst_ci = campaign / "issue_3216_headline_ci_rank_stability.json"
+        dst_ci = campaign / "result.json"
         if sufficiency_data.resolve() != dst_suff.resolve():
             shutil.copy2(sufficiency_data, dst_suff)
         if ci_rank_stability_data.resolve() != dst_ci.resolve():
             shutil.copy2(ci_rank_stability_data, dst_ci)
 
         report = build_seed_distribution_report(campaign)
-        assert len(report["surfaces"]) == 3 + 1 + 1
+        # 3 (seed_var) + 1 (sufficiency) + 2 (ci cells)
+        assert len(report["surfaces"]) == 3 + 1 + 2
         assert len(report["source"]["report_paths"]) == 3
+
+    def test_ci_rank_excluded_cell_is_advisory(self, ci_rank_stability_data: Path) -> None:
+        report = build_seed_distribution_report(ci_rank_stability_data.parent)
+        goal_surface = next(s for s in report["surfaces"] if s["planner_id"] == "goal")
+        assert goal_surface["diagnostics"]["advisory_only"] is True
+        assert goal_surface["diagnostics"]["insufficient_seed_count"] is True
 
 
 class TestMarkdownRendering:
@@ -548,6 +619,11 @@ class TestMarkdownRendering:
         report = build_seed_distribution_report(stable_seed_variability.parent)
         md = render_markdown(report)
         assert "not imply simulator fidelity" in md
+
+    def test_render_markdown_handles_half_width_interval(self, sufficiency_data: Path) -> None:
+        report = build_seed_distribution_report(sufficiency_data.parent)
+        md = render_markdown(report)
+        assert "CI half-width" in md
 
 
 class TestWriteReport:
@@ -598,7 +674,7 @@ class TestProvenanceFields:
 
     def test_source_report_paths(self, stable_seed_variability: Path) -> None:
         report = build_seed_distribution_report(stable_seed_variability.parent)
-        assert "seed_variability.json" in report["source"]["report_paths"]
+        assert "seed_variability_by_scenario.json" in report["source"]["report_paths"]
 
     def test_source_generated_by(self, stable_seed_variability: Path) -> None:
         report = build_seed_distribution_report(
@@ -610,6 +686,9 @@ class TestProvenanceFields:
         report = build_seed_distribution_report(stable_seed_variability.parent)
         surface = report["surfaces"][0]
         assert "input_artifact" in surface["provenance"]
+        assert surface["provenance"]["input_schema_version"] == (
+            "benchmark-seed-variability-by-scenario.v1"
+        )
 
 
 class TestSchemaVersionConstant:
@@ -622,3 +701,26 @@ class TestSchemaVersionConstant:
         from robot_sf.benchmark.seed_distribution_report import _SUPPORTED_SCHEMA_VERSIONS
 
         assert SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION in _SUPPORTED_SCHEMA_VERSIONS
+
+
+@pytest.mark.skipif(not _REAL_EVIDENCE_DIR.exists(), reason="real evidence dir not present")
+class TestRealDataSmoke:
+    """Smoke-test the builder against real shipped evidence artifacts.
+
+    These artifacts live under docs/context/evidence/ (read-only here) and are
+    the same shapes the adapters must consume in production. Outputs are written
+    to tmp_path only -- never under docs/context/evidence/.
+    """
+
+    def test_builds_from_real_campaign_folder(self, tmp_path: Path) -> None:
+        report = build_seed_distribution_report(_REAL_EVIDENCE_DIR)
+        assert report["schema_version"] == SEED_DISTRIBUTION_REPORT_SCHEMA_VERSION
+        assert len(report["surfaces"]) > 0
+        # Real planner identities (planner_key) must survive normalization.
+        planners = {s["planner_id"] for s in report["surfaces"] if s["planner_id"]}
+        assert planners, "expected non-null planner_id values from real data"
+        # At least one surface should carry interval evidence.
+        assert any(s.get("interval") for s in report["surfaces"])
+        # Round-trips through the writer cleanly.
+        out = write_report(report, out_json=tmp_path / "real.json", out_md=tmp_path / "real.md")
+        assert out["json"].exists() and out["md"].exists()


### PR DESCRIPTION
## What

Add `seed_distribution_report.v1` — a versioned statistical-robustness reporting layer that normalizes existing multi-seed benchmark evidence into a common, auditable contract.

## Why

Existing seed-level artifacts (seed_variability.json, statistical_sufficiency.json, CI rank stability reports) have incompatible shapes. This PR defines a minimal common schema and three adapters so campaign outputs can be compared, audited, and summarized uniformly.

## Changes

- **`robot_sf/benchmark/seed_distribution_report.py`**: Schema constant (`seed_distribution_report.v1`), fail-closed `validate_schema_version()`, three adapters (`_adapt_seed_variability`, `_adapt_statistical_sufficiency`, `_adapt_ci_rank_stability`), pure builder, Markdown renderer, and JSON/MD writer.
- **`scripts/benchmark/build_seed_distribution_report.py`**: Minimal CLI (`--campaign-root`, `--out-json`, `--out-md`).
- **`tests/benchmark/test_seed_distribution_report.py`**: 48 fixture-backed tests covering stable multi-seed, unstable rank, insufficient seed count, missing artifacts, deterministic ordering, schema version rejection, Markdown rendering, and file writing.
- **`docs/context/issue_4941_seed_distribution_report.md`**: Interpretation boundaries, diagnostic field definitions, evidence caveats, and adapter extension guide.

## Validation

```
uv run pytest tests/benchmark/test_seed_distribution_report.py -q
# 48 passed

uv run ruff check robot_sf/benchmark/seed_distribution_report.py scripts/benchmark/build_seed_distribution_report.py tests/benchmark/test_seed_distribution_report.py
# All checks passed!

uv run ruff format --check robot_sf/benchmark/seed_distribution_report.py scripts/benchmark/build_seed_distribution_report.py tests/benchmark/test_seed_distribution_report.py
# 3 files already formatted

uv run python scripts/benchmark/build_seed_distribution_report.py --help
# usage works
```

## Acceptance checklist

- [x] `seed_distribution_report.v1` has a named schema constant
- [x] Reader/writer validation is covered by tests
- [x] Standalone builder emits deterministic JSON from fixture inputs
- [x] At least two existing report surfaces are adapted (three: seed_variability, statistical_sufficiency, ci_rank_stability)
- [x] Stable, unstable, and insufficient-seed fixtures are covered
- [x] Raw counts and seed counts are preserved where available
- [x] Confidence intervals or interval metadata are preserved where available
- [x] Advisory/instability diagnostics are explicit machine-readable fields
- [x] Documentation records the statistical/evidence boundary
- [x] PR links #4933, #4934, and #4941

## Claim boundary

> Existing multi-seed benchmark outputs can be normalized into a common, auditable statistical-robustness report.

This PR does **not** support claims that the benchmark scenario catalog is complete, the simulator is calibrated to real-world behavior, narrower confidence intervals imply external validity, or a single campaign is publication-ready without its original evidence review.

Closes #4941

Refs #4933, #4934

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new seed distribution report format and generator for benchmark campaign artifacts.
  * Added a command-line tool to build and export the report as JSON and/or Markdown.
  * Added a Markdown summary view with counts, diagnostics, and surface details.

* **Documentation**
  * Added user-facing guidance for the new report schema, supported inputs, validation boundaries, and extension rules.

* **Tests**
  * Added coverage for report generation, validation, diagnostics, output writing, and Markdown rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->