### PR TITLE
refactor(4770-s2): fix layering-inversion runtime imports (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/pedestrian_forecast.py
+++ b/robot_sf/benchmark/pedestrian_forecast.py
@@ -12,56 +12,10 @@ from typing import Any
 
 import numpy as np
 
+from robot_sf.nav.predictive_types import NeighborContext, PedestrianState
+
 DEFAULT_FORECAST_HORIZONS_S = (0.5, 1.0, 2.0)
 PEDESTRIAN_ACTOR_TYPES = frozenset({"pedestrian", "person"})
-
-
-@dataclass(frozen=True)
-class PedestrianState:
-    """One trace-compatible pedestrian state at a single timestep."""
-
-    id: int
-    position: np.ndarray
-    velocity: np.ndarray
-    intent: str | None = None
-    signal: str | None = None
-    signal_available: bool = False
-    actor_type: str = "pedestrian"
-
-    @classmethod
-    def from_trace(cls, payload: dict[str, Any]) -> PedestrianState:
-        """Build a state from ``simulation_step_trace.steps[].pedestrians[]``.
-
-        Returns:
-            Trace-compatible pedestrian state.
-        """
-
-        signal_state = payload.get("signal_state")
-        signal_available = False
-        signal: str | None = None
-        if isinstance(signal_state, dict):
-            signal_available = bool(
-                signal_state.get("available")
-                if "available" in signal_state
-                else signal_state.get("label") is not None
-            )
-            if signal_available and signal_state.get("label") is not None:
-                signal = str(signal_state["label"])
-        elif payload.get("signal_label") is not None:
-            signal_available = True
-            signal = str(payload["signal_label"])
-
-        return cls(
-            id=int(payload["id"]),
-            position=np.asarray(payload["position"], dtype=float),
-            velocity=np.asarray(payload["velocity"], dtype=float),
-            intent=str(payload["intent_label"])
-            if payload.get("intent_label") is not None
-            else None,
-            signal=signal,
-            signal_available=signal_available,
-            actor_type=str(payload.get("actor_type") or "pedestrian"),
-        )
 
 
 def is_pedestrian_actor(actor_type: str | None) -> bool:
@@ -115,15 +69,6 @@ ForecastBaselineFunction = Callable[
     [PedestrianState, list[float] | tuple[float, ...]],
     PedestrianForecast,
 ]
-
-
-@dataclass(frozen=True)
-class NeighborContext:
-    """Snapshot of a neighboring pedestrian's state for interaction-aware forecasts."""
-
-    position: np.ndarray
-    velocity: np.ndarray
-    actor_type: str = "pedestrian"
 
 
 def constant_velocity_gaussian_baseline(

--- a/robot_sf/nav/baseline_probabilistic_predictor.py
+++ b/robot_sf/nav/baseline_probabilistic_predictor.py
@@ -13,24 +13,27 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from robot_sf.benchmark.pedestrian_forecast import (
-    ForecastBaselineFunction,
-    NeighborContext,
-    PedestrianState,
-    constant_velocity_gaussian_baseline,
-    interaction_aware_cv_baseline,
-    risk_filtered_cv_baseline,
-    semantic_cv_baseline,
-)
 from robot_sf.common.forecast_variants import FORECAST_VARIANT_CHOICES
 from robot_sf.nav.predictive_types import (
+    NeighborContext,
+    PedestrianState,
     ProbabilisticPrediction,
     TrajectoryDistribution,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from robot_sf.benchmark.pedestrian_forecast import PedestrianForecast
+
+    ForecastBaselineFunction = Callable[
+        [PedestrianState, list[float] | tuple[float, ...]],
+        PedestrianForecast,
+    ]
 
 DEFAULT_BASELINE_HORIZONS_S: tuple[float, ...] = (0.5, 1.0, 2.0)
 DEFAULT_BASELINE_DT_S: float = 0.1
@@ -48,6 +51,12 @@ def _baseline_for_variant(variant: str) -> ForecastBaselineFunction:
         additional keyword arguments required by interaction-aware and risk-filtered
         variants (``neighbors`` and ``robot_position`` respectively).
     """
+    from robot_sf.benchmark.pedestrian_forecast import (  # noqa: PLC0415
+        constant_velocity_gaussian_baseline,
+        interaction_aware_cv_baseline,
+        risk_filtered_cv_baseline,
+        semantic_cv_baseline,
+    )
 
     if variant == "cv":
         return constant_velocity_gaussian_baseline

--- a/robot_sf/nav/predictive_types.py
+++ b/robot_sf/nav/predictive_types.py
@@ -196,7 +196,71 @@ class ProbabilisticPredictor(Protocol):
         """
 
 
+@dataclass(frozen=True)
+class PedestrianState:
+    """One pedestrian state at a single timestep.
+
+    Canonical pedestrian state used by nav predictors and benchmark baselines.
+    Intent and signal fields are optional semantic context; when absent the
+    state reduces to position + velocity.
+    """
+
+    id: int
+    position: np.ndarray
+    velocity: np.ndarray
+    intent: str | None = None
+    signal: str | None = None
+    signal_available: bool = False
+    actor_type: str = "pedestrian"
+
+    @classmethod
+    def from_trace(cls, payload: dict[str, Any]) -> PedestrianState:
+        """Build a state from ``simulation_step_trace.steps[].pedestrians[]``.
+
+        Returns:
+            Trace-compatible pedestrian state.
+        """
+
+        signal_state = payload.get("signal_state")
+        signal_available = False
+        signal: str | None = None
+        if isinstance(signal_state, dict):
+            signal_available = bool(
+                signal_state.get("available")
+                if "available" in signal_state
+                else signal_state.get("label") is not None
+            )
+            if signal_available and signal_state.get("label") is not None:
+                signal = str(signal_state["label"])
+        elif payload.get("signal_label") is not None:
+            signal_available = True
+            signal = str(payload["signal_label"])
+
+        return cls(
+            id=int(payload["id"]),
+            position=np.asarray(payload["position"], dtype=float),
+            velocity=np.asarray(payload["velocity"], dtype=float),
+            intent=str(payload["intent_label"])
+            if payload.get("intent_label") is not None
+            else None,
+            signal=signal,
+            signal_available=signal_available,
+            actor_type=str(payload.get("actor_type") or "pedestrian"),
+        )
+
+
+@dataclass(frozen=True)
+class NeighborContext:
+    """Snapshot of a neighboring pedestrian's state for interaction-aware forecasts."""
+
+    position: np.ndarray
+    velocity: np.ndarray
+    actor_type: str = "pedestrian"
+
+
 __all__ = [
+    "NeighborContext",
+    "PedestrianState",
     "ProbabilisticPrediction",
     "ProbabilisticPredictor",
     "TrajectoryDistribution",

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -22,9 +22,12 @@ Example:
     >>> for sim in sims:
     ...     sim.step_once([action1, action2])"""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field, replace
 from math import atan2, ceil, cos, pi, sin
 from random import sample, uniform
+from typing import TYPE_CHECKING
 
 import numpy as np
 from loguru import logger
@@ -35,8 +38,11 @@ from pysocialforce.forces import ObstacleForce, SocialForce
 from pysocialforce.simulator import make_forces as pysf_make_forces
 
 from robot_sf.common.types import Line2D, PedPose, RobotAction, RobotPose, Vec2D
-from robot_sf.gym_env.env_config import EnvSettings, PedEnvSettings, SimulationSettings
-from robot_sf.gym_env.unified_config import PedestrianSimulationConfig, RobotSimulationConfig
+
+if TYPE_CHECKING:
+    from robot_sf.gym_env.env_config import EnvSettings, PedEnvSettings, SimulationSettings
+    from robot_sf.gym_env.unified_config import PedestrianSimulationConfig, RobotSimulationConfig
+
 from robot_sf.nav.map_config import MapDefinition, SocialGroupDefinition
 from robot_sf.nav.navigation import RouteNavigator, get_prepared_obstacles, sample_route
 from robot_sf.nav.occupancy import circle_collides_any_lines

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -37,27 +37,26 @@ from pysocialforce.forces import Force as PySFForce
 from pysocialforce.forces import ObstacleForce, SocialForce
 from pysocialforce.simulator import make_forces as pysf_make_forces
 
-from robot_sf.common.types import Line2D, PedPose, RobotAction, RobotPose, Vec2D
-
 if TYPE_CHECKING:
+    from robot_sf.common.types import Line2D, PedPose, RobotAction, RobotPose, Vec2D
     from robot_sf.gym_env.env_config import EnvSettings, PedEnvSettings, SimulationSettings
     from robot_sf.gym_env.unified_config import PedestrianSimulationConfig, RobotSimulationConfig
+    from robot_sf.ped_ego.unicycle_drive import UnicycleAction, UnicycleDrivePedestrian
+    from robot_sf.ped_npc.ped_grouping import PedestrianGroupings, PedestrianStates
+    from robot_sf.robot.robot_state import Robot
 
 from robot_sf.nav.map_config import MapDefinition, SocialGroupDefinition
 from robot_sf.nav.navigation import RouteNavigator, get_prepared_obstacles, sample_route
 from robot_sf.nav.occupancy import circle_collides_any_lines
-from robot_sf.ped_ego.unicycle_drive import UnicycleAction, UnicycleDrivePedestrian
 from robot_sf.ped_npc.adversial_ped_force import (
     AdversarialPedForce,
     AdversarialPedForceConfig,
 )
 from robot_sf.ped_npc.ped_archetypes import assign_archetype_labels
 from robot_sf.ped_npc.ped_behavior import PedestrianBehavior, SinglePedestrianBehavior
-from robot_sf.ped_npc.ped_grouping import PedestrianGroupings, PedestrianStates
 from robot_sf.ped_npc.ped_population import PedSpawnConfig, populate_simulation
 from robot_sf.ped_npc.ped_robot_force import PedRobotForce, PedRobotForceConfig
 from robot_sf.ped_npc.ped_zone import sample_zone
-from robot_sf.robot.robot_state import Robot
 from robot_sf.sim.pedestrian_model_variants import (
     HSFM_ALIGNMENT_TORQUE_V1,
     HSFM_ANISOTROPIC_FOV_V1,

--- a/tests/nav/test_baseline_probabilistic_predictor.py
+++ b/tests/nav/test_baseline_probabilistic_predictor.py
@@ -159,8 +159,8 @@ class TestBaselineProbabilisticPredictor:
 
         monkeypatch.setattr(
             baseline_predictor_module,
-            "constant_velocity_gaussian_baseline",
-            fake_baseline,
+            "_baseline_for_variant",
+            lambda _variant: fake_baseline,
         )
         predictor = BaselineProbabilisticPredictor(variant="cv", horizons_s=(0.2,), dt_s=0.1)
 
@@ -191,8 +191,8 @@ class TestBaselineProbabilisticPredictor:
 
         monkeypatch.setattr(
             baseline_predictor_module,
-            "constant_velocity_gaussian_baseline",
-            fake_baseline,
+            "_baseline_for_variant",
+            lambda _variant: fake_baseline,
         )
         predictor = BaselineProbabilisticPredictor(variant="cv", horizons_s=(0.2,), dt_s=0.1)
         result = predictor.predict(_make_socnav_obs(ped_count=1))


### PR DESCRIPTION
## What / Why

Fixes the two upward/runtime import dependencies flagged in the #4770 layering-inversion survey:

1. **`robot_sf/sim/simulator.py:38-39`** — `gym_env.env_config` and `gym_env.unified_config` imported at runtime (upward dep from `sim` → `gym_env`). Converted to `TYPE_CHECKING`-guarded imports mirroring the existing `sim/facade.py:16` pattern: added `from __future__ import annotations` and moved `EnvSettings`, `PedEnvSettings`, `SimulationSettings`, `PedestrianSimulationConfig`, `RobotSimulationConfig` behind `if TYPE_CHECKING:`.

2. **`robot_sf/nav/baseline_probabilistic_predictor.py:20`** — `nav` imported `benchmark` at module level. Restructured so nav no longer imports benchmark:
   - Moved `PedestrianState` and `NeighborContext` to `robot_sf/nav/predictive_types.py` (canonical nav-level pedestrian state types).
   - `robot_sf/benchmark/pedestrian_forecast.py` re-exports both for full backward compatibility — no downstream import changes needed.
   - `ForecastBaselineFunction` type alias moved behind `TYPE_CHECKING`.
   - Baseline function imports (`constant_velocity_gaussian_baseline`, `semantic_cv_baseline`, `interaction_aware_cv_baseline`, `risk_filtered_cv_baseline`) made lazy inside `_baseline_for_variant()` so the module-level nav→benchmark dependency is eliminated.

## Validation

```
# Predictor tests (15/15 passed)
uv run pytest tests/nav/test_baseline_probabilistic_predictor.py -v

# Benchmark forecast backward compat (32/32 passed)
uv run pytest tests/benchmark/test_pedestrian_forecast.py -v

# Full suite (759 passed, 3 pre-existing collection errors from missing duckdb/pyarrow)
uv run pytest tests/ -m "not slow" --timeout=60 --continue-on-collection-errors

# Runtime import verification — no NameError or import cycle
python -c "from robot_sf.sim.simulator import Simulator, PedSimulator, init_simulators"
python -c "from robot_sf.nav.baseline_probabilistic_predictor import BaselineProbabilisticPredictor; ..."

# Ruff format
uv run ruff format robot_sf/sim/simulator.py robot_sf/nav/predictive_types.py robot_sf/nav/baseline_probabilistic_predictor.py robot_sf/benchmark/pedestrian_forecast.py tests/nav/test_baseline_probabilistic_predictor.py
```

**Note:** Ruff TC001 now correctly flags 10 pre-existing annotation-only imports in `simulator.py` that were previously invisible without `from __future__ import annotations`. These are not introduced by this PR; they were always annotation-only uses. Fixing them is out of scope for this issue.

## Test changes

Only `tests/nav/test_baseline_probabilistic_predictor.py` monkeypatch targets updated: `constant_velocity_gaussian_baseline` → `_baseline_for_variant` to match the new lazy-import structure. All behavioral assertions unchanged.

Closes #4943
Refs #4770

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.