### PR TITLE
fix: cap xdist workers on low-CPU CI runners to prevent OOM (#4942) (cheap-lane worker)

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run xdist race validation
         env:
-          XDIST_RACE_WORKERS: "32"
+          XDIST_RACE_WORKERS: "auto"
           XDIST_RACE_TIMEOUT_SECONDS: "7200"
           PYTEST_XDIST_DIST: worksteal
         run: scripts/dev/run_xdist_race_validation.sh

--- a/scripts/dev/resolve_pytest_workers.py
+++ b/scripts/dev/resolve_pytest_workers.py
@@ -43,6 +43,10 @@ def _cap_workers_for_host(
                 f"capped explicit from {requested} to {capped} "
                 f"(macOS max={MACOS_MAX_WORKERS}, floor={MACOS_MIN_WORKERS})"
             )
+        # macOS uses its own explicit caps; return early so the low-CPU cap
+        # below can never shadow the platform-specific strategy if the two
+        # constants are ever reordered.
+        return requested, ""
 
     if cpu_count < LOW_CPU_THRESHOLD:
         capped = min(requested, LOW_CPU_WORKER_CAP)

--- a/scripts/dev/resolve_pytest_workers.py
+++ b/scripts/dev/resolve_pytest_workers.py
@@ -11,10 +11,16 @@ import sys
 MACOS_MAX_WORKERS = 8
 MACOS_MIN_WORKERS = 2
 
-# GitHub Actions ubuntu-latest runners (and other compact CI hosts) have 2 vCPUs
-# and limited memory. Spawning more workers than this cap will OOM the runner.
-# Only applies to low-CPU hosts (fewer than 8 logical CPUs); high-CPU hosts keep
-# the explicit value so local CI or larger runners are unaffected.
+# GitHub Actions ubuntu-latest runners are compact shared hosts (currently
+# 4 vCPUs, ~16 GB RAM per the Nightly Performance run logs). Spawning far more
+# xdist workers than cores — e.g. the old hardcoded 32 on a 4-core runner —
+# saturates runner memory and triggers GitHub's runner eviction: the job
+# receives a "shutdown signal" and exits 143 (SIGTERM), which is what repeatedly
+# killed the Nightly Performance xdist-race job. (Note: this is the runner
+# watchdog reclaiming the VM under pressure, not the kernel OOM-killer, which
+# would deliver SIGKILL / exit 137.) Cap explicit integer overrides on low-CPU
+# hosts; high-CPU hosts keep the explicit value so local CI and larger runners
+# are unaffected. "auto" always bypasses these caps.
 LOW_CPU_WORKER_CAP = 16
 LOW_CPU_THRESHOLD = 8
 

--- a/scripts/dev/resolve_pytest_workers.py
+++ b/scripts/dev/resolve_pytest_workers.py
@@ -11,6 +11,43 @@ import sys
 MACOS_MAX_WORKERS = 8
 MACOS_MIN_WORKERS = 2
 
+# GitHub Actions ubuntu-latest runners (and other compact CI hosts) have 2 vCPUs
+# and limited memory. Spawning more workers than this cap will OOM the runner.
+# Only applies to low-CPU hosts (fewer than 8 logical CPUs); high-CPU hosts keep
+# the explicit value so local CI or larger runners are unaffected.
+LOW_CPU_WORKER_CAP = 16
+LOW_CPU_THRESHOLD = 8
+
+
+def _cap_workers_for_host(
+    *,
+    requested: int,
+    cpu_count: int,
+    system: str,
+) -> tuple[int, str]:
+    """Apply host-resource caps to an explicit worker request.
+
+    Returns the possibly-capped worker count and an explanation of any change.
+    """
+    normalized_system = system.lower()
+    if normalized_system == "darwin":
+        capped = max(MACOS_MIN_WORKERS, min(MACOS_MAX_WORKERS, requested))
+        if capped != requested:
+            return capped, (
+                f"capped explicit from {requested} to {capped} "
+                f"(macOS max={MACOS_MAX_WORKERS}, floor={MACOS_MIN_WORKERS})"
+            )
+
+    if cpu_count < LOW_CPU_THRESHOLD:
+        capped = min(requested, LOW_CPU_WORKER_CAP)
+        if capped != requested:
+            return capped, (
+                f"capped explicit from {requested} to {capped} "
+                f"(low-CPU host with {cpu_count} CPUs, max={LOW_CPU_WORKER_CAP})"
+            )
+
+    return requested, ""
+
 
 def _resolve_worker_spec(
     *,
@@ -28,8 +65,17 @@ def _resolve_worker_spec(
         except ValueError:
             raise ValueError("PYTEST_NUM_WORKERS must be a positive integer or 'auto'") from None
         if workers <= 0:
-            raise ValueError("PYTEST_NUM_WORKERS must be a positive integer or 'auto'")
-        return str(workers), "explicit override via PYTEST_NUM_WORKERS"
+            raise ValueError("PYTEST_NUM_WORKERS must be a positive integer or 'auto'") from None
+
+        logical_cpus = max(1, int(cpu_count or 1))
+        capped, cap_reason = _cap_workers_for_host(
+            requested=workers,
+            cpu_count=logical_cpus,
+            system=system,
+        )
+        if cap_reason:
+            return str(capped), f"explicit override ({cap_reason})"
+        return str(capped), "explicit override via PYTEST_NUM_WORKERS"
 
     logical_cpus = max(1, int(cpu_count or 1))
     normalized_system = system.lower()

--- a/tests/dev/test_resolve_pytest_workers.py
+++ b/tests/dev/test_resolve_pytest_workers.py
@@ -1,10 +1,14 @@
-"""Tests for macOS-safe pytest worker resolution in scripts/dev."""
+"""Tests for host-safe pytest worker resolution in scripts/dev."""
 
 from __future__ import annotations
 
 import pytest
 
-from scripts.dev.resolve_pytest_workers import _resolve_worker_spec
+from scripts.dev.resolve_pytest_workers import (
+    LOW_CPU_THRESHOLD,
+    _cap_workers_for_host,
+    _resolve_worker_spec,
+)
 
 
 def test_resolve_worker_spec_defaults_to_auto_on_linux() -> None:
@@ -28,11 +32,45 @@ def test_resolve_worker_spec_applies_macos_floor() -> None:
     assert "macOS-safe default" in reason
 
 
-def test_resolve_worker_spec_honors_explicit_override() -> None:
-    """Explicit worker overrides should win over host-derived defaults."""
+def test_resolve_worker_spec_caps_explicit_override_on_macos() -> None:
+    """Explicit overrides above the macOS cap should be capped, not blindly passed through."""
     workers, reason = _resolve_worker_spec(requested="14", cpu_count=32, system="Darwin")
-    assert workers == "14"
+    assert workers == "8"
     assert "explicit override" in reason
+    assert "capped" in reason
+
+
+def test_resolve_worker_spec_caps_low_cpu_linux_explicit() -> None:
+    """Explicit overrides on low-CPU Linux (e.g. GitHub Actions 2-vCPU runner) should be capped."""
+    workers, reason = _resolve_worker_spec(requested="32", cpu_count=2, system="Linux")
+    assert workers == "16"
+    assert "explicit override" in reason
+    assert "low-CPU" in reason
+
+
+def test_resolve_worker_spec_allows_high_cpu_linux_explicit() -> None:
+    """High-CPU Linux hosts (>=8 CPUs) should not cap explicit overrides."""
+    workers, reason = _resolve_worker_spec(requested="32", cpu_count=32, system="Linux")
+    assert workers == "32"
+    assert reason == "explicit override via PYTEST_NUM_WORKERS"
+
+
+def test_resolve_worker_spec_no_cap_at_threshold() -> None:
+    """A host exactly at LOW_CPU_THRESHOLD should not trigger the low-CPU cap."""
+    workers, reason = _resolve_worker_spec(
+        requested="32", cpu_count=LOW_CPU_THRESHOLD, system="Linux"
+    )
+    assert workers == "32"
+    assert reason == "explicit override via PYTEST_NUM_WORKERS"
+
+
+def test_resolve_worker_spec_caps_just_below_threshold() -> None:
+    """A host one below LOW_CPU_THRESHOLD should cap explicit overrides."""
+    workers, reason = _resolve_worker_spec(
+        requested="32", cpu_count=LOW_CPU_THRESHOLD - 1, system="Linux"
+    )
+    assert workers == "16"
+    assert "low-CPU" in reason
 
 
 def test_resolve_worker_spec_rejects_non_positive_counts() -> None:
@@ -45,3 +83,17 @@ def test_resolve_worker_spec_rejects_non_numeric_counts() -> None:
     """Non-numeric worker overrides should raise the same user-facing error."""
     with pytest.raises(ValueError, match="positive integer"):
         _resolve_worker_spec(requested="foo", cpu_count=32, system="Darwin")
+
+
+def test_resolve_worker_spec_honors_auto_override() -> None:
+    """An explicit auto override should bypass all caps."""
+    workers, reason = _resolve_worker_spec(requested="auto", cpu_count=2, system="Linux")
+    assert workers == "auto"
+    assert reason == "explicit override via PYTEST_NUM_WORKERS=auto"
+
+
+def test_cap_workers_for_host_no_change_when_within_limit() -> None:
+    """_cap_workers_for_host returns unchanged value when requested is within cap."""
+    capped, reason = _cap_workers_for_host(requested=8, cpu_count=2, system="Linux")
+    assert capped == 8
+    assert reason == ""

--- a/tests/dev/test_resolve_pytest_workers.py
+++ b/tests/dev/test_resolve_pytest_workers.py
@@ -6,6 +6,7 @@ import pytest
 
 from scripts.dev.resolve_pytest_workers import (
     LOW_CPU_THRESHOLD,
+    MACOS_MAX_WORKERS,
     _cap_workers_for_host,
     _resolve_worker_spec,
 )
@@ -97,3 +98,16 @@ def test_cap_workers_for_host_no_change_when_within_limit() -> None:
     capped, reason = _cap_workers_for_host(requested=8, cpu_count=2, system="Linux")
     assert capped == 8
     assert reason == ""
+
+
+def test_cap_workers_macos_low_cpu_uses_macos_cap_not_low_cpu_cap() -> None:
+    """A low-CPU macOS host must be governed by the macOS cap, never the low-CPU cap.
+
+    Regression guard for the platform-isolation early return: even with a CPU
+    count below LOW_CPU_THRESHOLD, macOS overrides must collapse to
+    MACOS_MAX_WORKERS (8) rather than LOW_CPU_WORKER_CAP (16).
+    """
+    capped, reason = _cap_workers_for_host(requested=12, cpu_count=2, system="Darwin")
+    assert capped == MACOS_MAX_WORKERS
+    assert "macOS" in reason
+    assert "low-CPU" not in reason


### PR DESCRIPTION
## What

The Nightly Performance workflow's `xdist race validation` job was killed with exit 143 (SIGTERM) ~5 min in. It has failed the same way on 5 consecutive nights (2026-07-05 … 2026-07-09).

## Why (observed in the run logs)

> ⚠️ Pre-gate review corrected the original diagnosis. The original body claimed
> the runner was "2 vCPUs / ~7 GB" and that the "OOM killer sends SIGTERM".
> The actual failing-run logs show otherwise — see below.

The failing run (run 29000140740, 2026-07-09) reports `nproc=4` and
`mem_available_kb=15265212` (~15 GB), i.e. the standard `ubuntu-latest` runner
is **4 vCPUs / ~16 GB**, not 2 vCPUs / 7 GB. The kill line is:

```
##[error]The runner has received a shutdown signal. This can happen when the
runner service is stopped, or a manually started runner is canceled.
##[error]Process completed with exit code 143.
```

This is **GitHub's runner-eviction watchdog reclaiming the VM under resource
pressure** (SIGTERM / 143), **not** the Linux kernel OOM-killer (which would
deliver SIGKILL / exit 137). The job's own `timeout-minutes: 45` and the
compact-validation `XDIST_RACE_TIMEOUT_SECONDS: 7200` (2 h) both rule out a
configured timeout, so the ~5 min kill is the runner reclaim, not a timeout.

The strongest available hypothesis: 32 xdist workers (each a full Python
subprocess importing the whole suite) on a 4-core / ~16 GB box saturates memory
and trips the reclaim. This is consistent with the symptom but is **not yet
conclusively root-caused** (see Status).

## Changes

- **scripts/dev/resolve_pytest_workers.py**: Added `_cap_workers_for_host()` to apply host-resource caps to *explicit* integer overrides:
  - macOS: explicit overrides capped to max 8 / floor 2 (previously explicit overrides passed through uncapped — behavior change, now consistent with the default path)
  - Low-CPU Linux (<8 CPUs): explicit overrides capped to max 16
  - High-CPU Linux (>=8 CPUs): explicit overrides pass through unchanged
  - `"auto"` override bypasses all caps
  - (Pre-gate follow-up commit `0322d09` corrected the in-code comment, which had claimed the runner was "2 vCPUs".)

- **.github/workflows/perf-nightly.yml**: Changed `XDIST_RACE_WORKERS` from `"32"` to `"auto"` so the runner auto-scales to available CPUs (**4 workers** on the 4-vCPU `ubuntu-latest`, down from 32 — an 8× memory reduction). End-to-end verified: `auto` → `PYTEST_NUM_WORKERS=auto` → `pytest -n auto` → `os.cpu_count()`.

- **tests/dev/test_resolve_pytest_workers.py**: Updated the macOS explicit-override test (now asserts capping) and added 7 new tests for macOS/low-CPU/high-CPU/threshold-boundary/auto-bypass.

## Validation

```
$ uv run pytest tests/dev/test_resolve_pytest_workers.py -v   # 12 passed
$ uv run pytest tests/test_ci_script_contract.py -q           # 57 passed
$ uv run ruff check scripts/dev/resolve_pytest_workers.py tests/dev/test_resolve_pytest_workers.py   # All checks passed
$ uv run ruff format --check <changed files>                  # already formatted
```
(Re-run by the pre-gate reviewer; all green.)

## Impact

- Expected to relieve the memory pressure that trips the runner reclaim: 4 workers instead of 32 on the CI runner.
- Local machines / larger runners (>=8 CPUs) are unaffected for explicit overrides; `"auto"` everywhere scales to core count.

## Status & remaining work (pre-gate)

The issue's acceptance is: **Nightly Performance completes green**, *or* **the race is root-caused + a bounded config documented**. This PR ships a sound bounded-config mitigation (`auto`), but:

- [ ] **Not yet verified green.** The nightly has not been re-run with `auto`; the fix is a strong hypothesis, not a confirmed green run.
- [ ] **Not conclusively root-caused.** No explicit OOM line appears in the logs; the kill is the generic runner "shutdown signal". The issue explicitly asked for *local reproduction at reduced worker count* and *identification of the failing test(s) / resource ceiling* — neither was done.
- [ ] (Minor) `LOW_CPU_WORKER_CAP = 16` is a conservative backstop for explicit overrides; on the actual 4-vCPU runner an explicit override >16 would still be cut to 16, which is 4× core oversubscription. CI now uses `auto` so this path is not exercised, but the cap value is a judgment call the auditor may want to revisit.

Switched the issue-linking keyword from the auto-closing form to `Refs #4942` pending a green nightly re-run or a completed diagnosis. The auditor may restore the auto-closing keyword if they judge the bounded-config fix sufficient.

This PR was produced by the SAIA/Qwen3.6-27B cheap implementation lane; the review gate hardens and merges.

Refs #4942
