### PR TITLE
Issue #4944: decompose map_runner god-functions (4770-s4, cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -2029,7 +2029,113 @@ def _build_socnav_family_adapter(  # noqa: C901, PLR0912, PLR0915
     return adapter
 
 
-def _build_policy(  # noqa: C901, PLR0912, PLR0915
+def _build_common_adapter_policy(  # noqa: C901
+    adapter: Any,
+    *,
+    algo_key: str,
+    algo_config: dict[str, Any],
+    meta: dict[str, Any],
+    robot_kinematics: str | None,
+    normalized_robot_command_mode: str | None,
+) -> tuple[Callable[[dict[str, Any]], Any], dict[str, Any]]:
+    """Finalize adapter metadata and build the common SocNav-family adapter policy.
+
+    Applies the shared adapter metadata (status/config/provenance/config_hash,
+    enrichment, feasibility, planner command space), resolves the planner bind-env
+    hook, and returns either the holonomic world-velocity policy (early return) or
+    the generic adapter policy closure with feasibility projection.
+
+    Returns:
+        tuple[Callable, dict[str, Any]]: Policy callable and enriched metadata.
+    """
+    if "status" not in meta:
+        meta["status"] = "ok"
+    meta["config"] = algo_config
+    provenance = algo_config.get("provenance")
+    if isinstance(provenance, dict):
+        meta["provenance"] = provenance
+    meta["config_hash"] = _config_hash(algo_config)
+    meta = enrich_algorithm_metadata(
+        algo=algo_key,
+        metadata=meta,
+        execution_mode="adapter",
+        robot_kinematics=robot_kinematics,
+    )
+    _init_feasibility_metadata(meta)
+    planner_meta = meta.get("planner_kinematics")
+    if isinstance(planner_meta, dict):
+        planner_meta["planner_command_space"] = _default_robot_command_space(
+            robot_kinematics,
+            algo_config,
+            robot_command_mode=normalized_robot_command_mode,
+        )
+    adapter_kinematics_model = resolve_benchmark_kinematics_model(
+        robot_kinematics=robot_kinematics,
+        command_limits=algo_config,
+    )
+    planner_bind_env = None
+    if algo_key in {"hrvo", "socnav_hrvo"} and hasattr(adapter, "bind_static_obstacle_points"):
+
+        def _bind_env(env: Any) -> None:
+            """Bind sampled static obstacle points from the environment to HRVO."""
+            simulator = getattr(env, "simulator", None)
+            if simulator is None or not hasattr(simulator, "iter_obstacle_segments"):
+                return
+            spacing = max(
+                float(getattr(adapter.config, "orca_obstacle_margin", 0.12)) * 2.0,
+                0.25,
+            )
+            points = sample_obstacle_points(
+                simulator.iter_obstacle_segments(),
+                spacing=spacing,
+            )
+            adapter.bind_static_obstacle_points(points, spacing=spacing)
+
+        planner_bind_env = _bind_env
+    elif hasattr(adapter, "bind_env"):
+        planner_bind_env = adapter.bind_env
+    if _is_holonomic_world_velocity_mode(
+        algo_key, robot_kinematics, normalized_robot_command_mode
+    ):
+        return _build_holonomic_world_velocity_policy(
+            adapter,
+            algo_key=algo_key,
+            meta=meta,
+            planner_bind_env=planner_bind_env,
+        )
+
+    def _policy(obs: dict[str, Any]) -> tuple[float, float]:
+        """Run a generic SocNav adapter and project command feasibility.
+
+        Returns:
+            tuple[float, float]: Projected linear and angular command.
+        """
+        linear, angular = adapter.plan(obs)
+        return _project_with_feasibility(
+            model=adapter_kinematics_model,
+            command=(float(linear), float(angular)),
+            meta=meta,
+        )
+
+    _attach_planner_reset(_policy, adapter)
+    _policy._planner_adapter = adapter
+    if planner_bind_env is not None:
+        _policy._planner_bind_env = planner_bind_env
+    if hasattr(adapter, "diagnostics"):
+
+        def _planner_stats() -> dict[str, Any]:
+            """Expose generic adapter diagnostics for episode metadata.
+
+            Returns:
+                dict[str, Any]: Adapter diagnostic payload.
+            """
+            return adapter.diagnostics()
+
+        _policy._planner_stats = _planner_stats
+    return _policy, meta
+
+
+def _build_policy(  # noqa: C901
     algo: str,
     algo_config: dict[str, Any],
     *,
@@ -2198,92 +2304,14 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             meta=meta,
         )
 
-    if "status" not in meta:
-        meta["status"] = "ok"
-    meta["config"] = algo_config
-    provenance = algo_config.get("provenance")
-    if isinstance(provenance, dict):
-        meta["provenance"] = provenance
-    meta["config_hash"] = _config_hash(algo_config)
-    meta = enrich_algorithm_metadata(
-        algo=algo_key,
-        metadata=meta,
-        execution_mode="adapter",
+    return _build_common_adapter_policy(
+        adapter,
+        algo_key=algo_key,
+        algo_config=algo_config,
+        meta=meta,
         robot_kinematics=robot_kinematics,
+        normalized_robot_command_mode=normalized_robot_command_mode,
     )
-    _init_feasibility_metadata(meta)
-    planner_meta = meta.get("planner_kinematics")
-    if isinstance(planner_meta, dict):
-        planner_meta["planner_command_space"] = _default_robot_command_space(
-            robot_kinematics,
-            algo_config,
-            robot_command_mode=normalized_robot_command_mode,
-        )
-    adapter_kinematics_model = resolve_benchmark_kinematics_model(
-        robot_kinematics=robot_kinematics,
-        command_limits=algo_config,
-    )
-    planner_bind_env = None
-    if algo_key in {"hrvo", "socnav_hrvo"} and hasattr(adapter, "bind_static_obstacle_points"):
-
-        def _bind_env(env: Any) -> None:
-            """Bind sampled static obstacle points from the environment to HRVO."""
-            simulator = getattr(env, "simulator", None)
-            if simulator is None or not hasattr(simulator, "iter_obstacle_segments"):
-                return
-            spacing = max(
-                float(getattr(adapter.config, "orca_obstacle_margin", 0.12)) * 2.0,
-                0.25,
-            )
-            points = sample_obstacle_points(
-                simulator.iter_obstacle_segments(),
-                spacing=spacing,
-            )
-            adapter.bind_static_obstacle_points(points, spacing=spacing)
-
-        planner_bind_env = _bind_env
-    elif hasattr(adapter, "bind_env"):
-        planner_bind_env = adapter.bind_env
-    holonomic_world_velocity_mode = _is_holonomic_world_velocity_mode(
-        algo_key, robot_kinematics, normalized_robot_command_mode
-    )
-    if holonomic_world_velocity_mode:
-        return _build_holonomic_world_velocity_policy(
-            adapter,
-            algo_key=algo_key,
-            meta=meta,
-            planner_bind_env=planner_bind_env,
-        )
-
-    def _policy(obs: dict[str, Any]) -> tuple[float, float]:
-        """Run a generic SocNav adapter and project command feasibility.
-
-        Returns:
-            tuple[float, float]: Projected linear and angular command.
-        """
-        linear, angular = adapter.plan(obs)
-        return _project_with_feasibility(
-            model=adapter_kinematics_model,
-            command=(float(linear), float(angular)),
-            meta=meta,
-        )
-
-    _attach_planner_reset(_policy, adapter)
-    _policy._planner_adapter = adapter
-    if planner_bind_env is not None:
-        _policy._planner_bind_env = planner_bind_env
-    if hasattr(adapter, "diagnostics"):
-
-        def _planner_stats() -> dict[str, Any]:
-            """Expose generic adapter diagnostics for episode metadata.
-
-            Returns:
-                dict[str, Any]: Adapter diagnostic payload.
-            """
-            return adapter.diagnostics()
-
-        _policy._planner_stats = _planner_stats
-    return _policy, meta
 
 
 def build_map_policy(

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -1393,6 +1393,170 @@ def _build_drl_vo_policy(
     return _policy, meta
 
 
+def _build_guarded_ppo_policy(  # noqa: C901, PLR0915
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    meta: dict[str, Any],
+    robot_kinematics: str | None,
+    normalized_robot_command_mode: str | None,
+    adapter_impact_eval: bool,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build the Guarded-PPO mixed-adapter policy and enriched metadata.
+
+    Returns:
+        tuple[Callable, dict[str, Any]]: Policy callable and enriched metadata.
+    """
+    ppo_allowed = {field.name for field in fields(PPOPlannerConfig)}
+    ppo_config = {key: value for key, value in algo_config.items() if key in ppo_allowed}
+    ppo_planner = PPOPlanner(ppo_config, seed=None)
+    guard_adapter = GuardedPPOAdapter(
+        config=build_guarded_ppo_config(algo_config),
+        fallback_adapter=build_guarded_ppo_fallback(algo_config),
+        prior_adapter=build_guarded_ppo_prior(algo_config),
+    )
+    ppo_obs_mode = _resolve_planner_obs_mode(ppo_planner, "vector")
+    if hasattr(ppo_planner, "get_metadata"):
+        planner_meta = ppo_planner.get_metadata()
+        if isinstance(planner_meta, dict):
+            meta.update(planner_meta)
+    meta = enrich_algorithm_metadata(
+        algo=algo_key,
+        metadata=meta,
+        execution_mode="mixed",
+        adapter_name="guarded_ppo_action_to_unicycle",
+        robot_kinematics=robot_kinematics,
+        adapter_impact_requested=adapter_impact_eval,
+    )
+    _init_feasibility_metadata(meta)
+    meta["guard_stats"] = {
+        "ppo_clear": 0,
+        "ppo_safe": 0,
+        "fallback_safe": 0,
+        "prior_blend_safe": 0,
+        "prior_residual_safe": 0,
+        "prior_safe": 0,
+        "stop_safe": 0,
+        "fallback_best_effort": 0,
+        "stop_best_effort": 0,
+        "uncertainty_fallback_stop": 0,
+        "uncertainty_fallback_slow_down": 0,
+        "uncertainty_fallback_configured": 0,
+        "goal_reached": 0,
+    }
+    meta["residual_clipping_stats"] = {
+        "schema_version": "orca-residual-clipping-stats.v1",
+        "decision_count": 0,
+        "clipped_count": 0,
+    }
+    meta["safety_shield_contract"] = shield_contract_metadata(
+        shield_name="GuardedPPOAdapter",
+        prediction_source="short_horizon_rollout",
+        fallback_policy=type(guard_adapter.fallback_adapter).__name__,
+    )
+    meta["shield_stats"] = new_shield_stats()
+    planner_meta = meta.get("planner_kinematics")
+    if isinstance(planner_meta, dict):
+        planner_meta["planner_command_space"] = _default_robot_command_space(
+            robot_kinematics,
+            algo_config,
+            robot_command_mode=normalized_robot_command_mode,
+        )
+    ppo_kinematics_model = resolve_benchmark_kinematics_model(
+        robot_kinematics=robot_kinematics,
+        command_limits=algo_config,
+    )
+
+    def _policy(obs: dict[str, Any]) -> tuple[float, float]:
+        """Run Guarded PPO and apply the short-horizon safety gate.
+
+        Returns:
+            tuple[float, float]: Selected and projected command.
+        """
+        if ppo_obs_mode in {"dict", "native_dict", "multi_input"}:
+            ppo_obs = obs
+        else:
+            ppo_obs = _obs_to_ppo_format(obs)
+        action = ppo_planner.step(ppo_obs)
+        if not isinstance(action, dict):
+            raise TypeError(f"Guarded PPO planner returned non-dict action: {type(action)}")
+        linear, angular, conversion_mode = _ppo_action_to_unicycle(
+            action,
+            obs,
+            algo_config,
+            robot_kinematics=robot_kinematics,
+            kinematics_model=ppo_kinematics_model,
+            project_command=False,
+        )
+        shield_decision = _choose_shield_command(
+            guard_adapter,
+            obs,
+            (float(linear), float(angular)),
+        )
+        chosen, decision = shield_decision.as_command_result()
+        linear, angular = _project_with_feasibility(
+            model=ppo_kinematics_model,
+            command=(float(chosen[0]), float(chosen[1])),
+            meta=meta,
+        )
+        guard_stats = meta.get("guard_stats")
+        if isinstance(guard_stats, dict):
+            guard_stats[decision] = int(guard_stats.get(decision, 0)) + 1
+        shield_stats = meta.get("shield_stats")
+        if isinstance(shield_stats, dict):
+            update_shield_stats(shield_stats, shield_decision)
+        residual_stats = meta.get("residual_clipping_stats")
+        if isinstance(residual_stats, dict):
+            decision_metadata = shield_decision.to_metadata()
+            fallback_state = decision_metadata.get("fallback_controller_state")
+            action_adaptation = (
+                fallback_state.get("action_adaptation")
+                if isinstance(fallback_state, dict)
+                else None
+            )
+            if isinstance(action_adaptation, dict):
+                residual_stats["decision_count"] = (
+                    int(residual_stats.get("decision_count", 0)) + 1
+                )
+                if bool(action_adaptation.get("residual_clipped", False)):
+                    residual_stats["clipped_count"] = (
+                        int(residual_stats.get("clipped_count", 0)) + 1
+                    )
+        _update_adapter_impact_metrics(
+            meta,
+            conversion_mode,
+            count_native=conversion_mode == "native" and decision in {"ppo_clear", "ppo_safe"},
+        )
+        return linear, angular
+
+    _attach_planner_reset(_policy, guard_adapter)
+
+    def _close_guarded_ppo() -> None:
+        """Close PPO and guard adapter resources when present."""
+        ppo_planner.close()
+        guard_close = getattr(guard_adapter, "close", None)
+        if callable(guard_close):
+            guard_close()
+
+    _policy._planner_close = _close_guarded_ppo
+    ppo_bind_env = getattr(ppo_planner, "bind_env", None)
+    guard_bind_env = getattr(guard_adapter, "bind_env", None)
+    bind_hooks = [hook for hook in (ppo_bind_env, guard_bind_env) if callable(hook)]
+    if bind_hooks:
+
+        def _bind_guarded_ppo_env(env: Any) -> None:
+            """Bind PPO runtime observation space and guard map context."""
+            for hook in bind_hooks:
+                hook(env)
+
+        _policy._planner_bind_env = _bind_guarded_ppo_env
+    meta.setdefault("algorithm", "guarded_ppo")
+    meta.setdefault("status", "ok")
+    meta.setdefault("config", algo_config)
+    meta["config_hash"] = _config_hash(meta.get("config", algo_config))
+    return _policy, meta
+
+
 def _build_policy(  # noqa: C901, PLR0912, PLR0915
     algo: str,
     algo_config: dict[str, Any],
@@ -1540,158 +1704,14 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             adapter_impact_eval=adapter_impact_eval,
         )
     elif algo_key in {"guarded_ppo"}:
-        ppo_allowed = {field.name for field in fields(PPOPlannerConfig)}
-        ppo_config = {key: value for key, value in algo_config.items() if key in ppo_allowed}
-        ppo_planner = PPOPlanner(ppo_config, seed=None)
-        guard_adapter = GuardedPPOAdapter(
-            config=build_guarded_ppo_config(algo_config),
-            fallback_adapter=build_guarded_ppo_fallback(algo_config),
-            prior_adapter=build_guarded_ppo_prior(algo_config),
-        )
-        planner_cfg = getattr(ppo_planner, "config", None)
-        if isinstance(planner_cfg, dict):
-            ppo_obs_mode = str(planner_cfg.get("obs_mode", "vector")).strip().lower()
-        else:
-            ppo_obs_mode = str(getattr(planner_cfg, "obs_mode", "vector")).strip().lower()
-        if hasattr(ppo_planner, "get_metadata"):
-            planner_meta = ppo_planner.get_metadata()
-            if isinstance(planner_meta, dict):
-                meta.update(planner_meta)
-        meta = enrich_algorithm_metadata(
-            algo=algo_key,
-            metadata=meta,
-            execution_mode="mixed",
-            adapter_name="guarded_ppo_action_to_unicycle",
+        return _build_guarded_ppo_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
             robot_kinematics=robot_kinematics,
-            adapter_impact_requested=adapter_impact_eval,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            adapter_impact_eval=adapter_impact_eval,
         )
-        _init_feasibility_metadata(meta)
-        meta["guard_stats"] = {
-            "ppo_clear": 0,
-            "ppo_safe": 0,
-            "fallback_safe": 0,
-            "prior_blend_safe": 0,
-            "prior_residual_safe": 0,
-            "prior_safe": 0,
-            "stop_safe": 0,
-            "fallback_best_effort": 0,
-            "stop_best_effort": 0,
-            "uncertainty_fallback_stop": 0,
-            "uncertainty_fallback_slow_down": 0,
-            "uncertainty_fallback_configured": 0,
-            "goal_reached": 0,
-        }
-        meta["residual_clipping_stats"] = {
-            "schema_version": "orca-residual-clipping-stats.v1",
-            "decision_count": 0,
-            "clipped_count": 0,
-        }
-        meta["safety_shield_contract"] = shield_contract_metadata(
-            shield_name="GuardedPPOAdapter",
-            prediction_source="short_horizon_rollout",
-            fallback_policy=type(guard_adapter.fallback_adapter).__name__,
-        )
-        meta["shield_stats"] = new_shield_stats()
-        planner_meta = meta.get("planner_kinematics")
-        if isinstance(planner_meta, dict):
-            planner_meta["planner_command_space"] = _default_robot_command_space(
-                robot_kinematics,
-                algo_config,
-                robot_command_mode=normalized_robot_command_mode,
-            )
-        ppo_kinematics_model = resolve_benchmark_kinematics_model(
-            robot_kinematics=robot_kinematics,
-            command_limits=algo_config,
-        )
-
-        def _policy(obs: dict[str, Any]) -> tuple[float, float]:
-            """Run Guarded PPO and apply the short-horizon safety gate.
-
-            Returns:
-                tuple[float, float]: Selected and projected command.
-            """
-            if ppo_obs_mode in {"dict", "native_dict", "multi_input"}:
-                ppo_obs = obs
-            else:
-                ppo_obs = _obs_to_ppo_format(obs)
-            action = ppo_planner.step(ppo_obs)
-            if not isinstance(action, dict):
-                raise TypeError(f"Guarded PPO planner returned non-dict action: {type(action)}")
-            linear, angular, conversion_mode = _ppo_action_to_unicycle(
-                action,
-                obs,
-                algo_config,
-                robot_kinematics=robot_kinematics,
-                kinematics_model=ppo_kinematics_model,
-                project_command=False,
-            )
-            shield_decision = _choose_shield_command(
-                guard_adapter,
-                obs,
-                (float(linear), float(angular)),
-            )
-            chosen, decision = shield_decision.as_command_result()
-            linear, angular = _project_with_feasibility(
-                model=ppo_kinematics_model,
-                command=(float(chosen[0]), float(chosen[1])),
-                meta=meta,
-            )
-            guard_stats = meta.get("guard_stats")
-            if isinstance(guard_stats, dict):
-                guard_stats[decision] = int(guard_stats.get(decision, 0)) + 1
-            shield_stats = meta.get("shield_stats")
-            if isinstance(shield_stats, dict):
-                update_shield_stats(shield_stats, shield_decision)
-            residual_stats = meta.get("residual_clipping_stats")
-            if isinstance(residual_stats, dict):
-                decision_metadata = shield_decision.to_metadata()
-                fallback_state = decision_metadata.get("fallback_controller_state")
-                action_adaptation = (
-                    fallback_state.get("action_adaptation")
-                    if isinstance(fallback_state, dict)
-                    else None
-                )
-                if isinstance(action_adaptation, dict):
-                    residual_stats["decision_count"] = (
-                        int(residual_stats.get("decision_count", 0)) + 1
-                    )
-                    if bool(action_adaptation.get("residual_clipped", False)):
-                        residual_stats["clipped_count"] = (
-                            int(residual_stats.get("clipped_count", 0)) + 1
-                        )
-            _update_adapter_impact_metrics(
-                meta,
-                conversion_mode,
-                count_native=conversion_mode == "native" and decision in {"ppo_clear", "ppo_safe"},
-            )
-            return linear, angular
-
-        _attach_planner_reset(_policy, guard_adapter)
-
-        def _close_guarded_ppo() -> None:
-            """Close PPO and guard adapter resources when present."""
-            ppo_planner.close()
-            guard_close = getattr(guard_adapter, "close", None)
-            if callable(guard_close):
-                guard_close()
-
-        _policy._planner_close = _close_guarded_ppo
-        ppo_bind_env = getattr(ppo_planner, "bind_env", None)
-        guard_bind_env = getattr(guard_adapter, "bind_env", None)
-        bind_hooks = [hook for hook in (ppo_bind_env, guard_bind_env) if callable(hook)]
-        if bind_hooks:
-
-            def _bind_guarded_ppo_env(env: Any) -> None:
-                """Bind PPO runtime observation space and guard map context."""
-                for hook in bind_hooks:
-                    hook(env)
-
-            _policy._planner_bind_env = _bind_guarded_ppo_env
-        meta.setdefault("algorithm", "guarded_ppo")
-        meta.setdefault("status", "ok")
-        meta.setdefault("config", algo_config)
-        meta["config_hash"] = _config_hash(meta.get("config", algo_config))
-        return _policy, meta
     elif algo_key in {
         "gensafenav_ours_gst_guarded",
         "ours_gst_guarded",

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -1696,117 +1696,30 @@ def _build_sonic_guarded_policy(
     return _policy, meta
 
 
-def _build_policy(  # noqa: C901, PLR0912, PLR0915
+def _build_socnav_family_adapter(  # noqa: C901, PLR0912, PLR0915
+    algo_key: str,
     algo: str,
     algo_config: dict[str, Any],
     *,
-    robot_kinematics: str | None = None,
-    robot_command_mode: str | None = None,
-    adapter_impact_eval: bool = False,
-) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
-    """Build an action policy and algorithm metadata for map-based benchmarking.
+    meta: dict[str, Any],
+) -> Any:
+    """Construct the SocNav-family planner adapter for ``algo_key``.
+
+    Covers the classical/adapter planners that build an adapter object and share the
+    common adapter policy tail (ORCA/HRVO, force models, SoNIC/GenSafeNav/CrowdNav,
+    SACADRL, prediction, hybrid portfolios, NMPC, RVO/DWA placeholders). A couple of
+    branches mutate ``meta`` in place (prediction overrides, selector boundary,
+    placeholder status).
 
     Args:
-        algo: Algorithm key to instantiate.
+        algo_key: Lowercased algorithm key used for branching.
+        algo: Original algorithm label (used only for the unknown-algorithm error).
         algo_config: Algorithm configuration payload.
-        robot_kinematics: Runtime robot kinematics label for metadata enrichment.
-        robot_command_mode: Runtime robot command mode (for holonomic metadata labels).
-        adapter_impact_eval: Whether to collect native-vs-adapter step counters.
+        meta: Algorithm metadata dict; mutated in place for a few planner variants.
 
     Returns:
-        tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
-        Policy callable and enriched metadata dictionary. For PPO, adapter-impact
-        counters are mutated in-place in the returned metadata during episode rollout.
+        Any: The constructed planner adapter.
     """
-    algo_key = algo.lower().strip()
-    meta: dict[str, Any] = {"algorithm": algo_key}
-    registered_policy = _policy_builder_registry.build_registered_policy(
-        algo_key,
-        algo_config,
-        builders=_POLICY_BUILDERS,
-        robot_kinematics=robot_kinematics,
-        robot_command_mode=robot_command_mode,
-        adapter_impact_eval=adapter_impact_eval,
-    )
-    if registered_policy is not None:
-        return registered_policy
-
-    normalized_robot_command_mode = (
-        str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
-    )
-    registered_adapter_spec = build_registered_adapter_policy_spec(algo_key, algo_config)
-    if registered_adapter_spec is not None:
-        meta["algorithm"] = registered_adapter_spec.algo_key
-        return _build_adapter_policy(
-            algo_key=registered_adapter_spec.algo_key,
-            algo_config=registered_adapter_spec.algo_config,
-            meta=meta,
-            adapter=registered_adapter_spec.adapter,
-            adapter_name=registered_adapter_spec.adapter_name,
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            limitations=registered_adapter_spec.limitations,
-        )
-
-    if algo_key == "mppi_social":
-        adapter = MPPISocialPlannerAdapter(config=build_mppi_social_config(algo_config))
-        return _build_adapter_policy(
-            algo_key=algo_key,
-            algo_config=algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="MPPISocialPlannerAdapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-        )
-
-    if algo_key == "predictive_mppi":
-        return _build_predictive_mppi_policy(
-            algo_key,
-            algo_config,
-            meta=meta,
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-        )
-
-    if algo_key == "sicnav":
-        planner = SICNavPlanner(build_sicnav_config(algo_config), seed=None)
-        planner_meta = planner.get_metadata()
-        if planner_meta.get("status") != "ok":
-            raise RuntimeError(
-                "SICNav dependency is missing or unresolved. "
-                "Point `repo_root` at a checked-out upstream repo or install the package."
-            )
-        return _build_external_mpc_policy(
-            planner,
-            algo_key=algo_key,
-            algo_config=algo_config,
-            meta=meta,
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            planner_name="SICNavPlanner",
-            limitations="external_mpc_dependency_sensitive",
-        )
-
-    if algo_key == "dr_mpc":
-        planner = DRMPCPlanner(build_dr_mpc_config(algo_config), seed=None)
-        planner_meta = planner.get_metadata()
-        if planner_meta.get("status") != "ok":
-            raise RuntimeError(
-                "DR-MPC dependency is missing or unresolved. "
-                "Point `repo_root` at a checked-out upstream repo or install the package."
-            )
-        return _build_external_mpc_policy(
-            planner,
-            algo_key=algo_key,
-            algo_config=algo_config,
-            meta=meta,
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            planner_name="DRMPCPlanner",
-            limitations="external_mpc_dependency_sensitive",
-        )
-
     socnav_cfg = _build_socnav_config(algo_config)
 
     if algo_key in {"socnav_sampling", "sampling"}:
@@ -1815,56 +1728,6 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
         adapter = SamplingPlannerAdapter(config=socnav_cfg)
     elif algo_key in {"social_force", "sf"}:
         adapter = SocialForcePlannerAdapter(config=socnav_cfg)
-    elif algo_key in {"ppo"}:
-        return _build_ppo_policy(
-            algo_key,
-            algo_config,
-            meta=meta,
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            adapter_impact_eval=adapter_impact_eval,
-        )
-    elif algo_key in {"sac"}:
-        return _build_sac_policy(
-            algo_key,
-            algo_config,
-            meta=meta,
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            adapter_impact_eval=adapter_impact_eval,
-        )
-    elif algo_key == "drl_vo":
-        return _build_drl_vo_policy(
-            algo_key,
-            algo_config,
-            meta=meta,
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            adapter_impact_eval=adapter_impact_eval,
-        )
-    elif algo_key in {"guarded_ppo"}:
-        return _build_guarded_ppo_policy(
-            algo_key,
-            algo_config,
-            meta=meta,
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            adapter_impact_eval=adapter_impact_eval,
-        )
-    elif algo_key in {
-        "gensafenav_ours_gst_guarded",
-        "ours_gst_guarded",
-        "gensafenav_gst_predictor_rand_guarded",
-        "gst_predictor_rand_guarded",
-    }:
-        return _build_sonic_guarded_policy(
-            algo_key,
-            algo_config,
-            meta=meta,
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            adapter_impact_eval=adapter_impact_eval,
-        )
     elif algo_key in {"orca"}:
         allow_fallback = bool(algo_config.get("allow_fallback", False))
         adapter = ORCAPlannerAdapter(config=socnav_cfg, allow_fallback=allow_fallback)
@@ -2012,6 +1875,177 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
         meta.update({"status": "placeholder", "fallback_reason": "unimplemented"})
     else:
         raise ValueError(f"Unknown map-based algorithm '{algo}'.")
+    return adapter
+
+
+def _build_policy(  # noqa: C901, PLR0912, PLR0915
+    algo: str,
+    algo_config: dict[str, Any],
+    *,
+    robot_kinematics: str | None = None,
+    robot_command_mode: str | None = None,
+    adapter_impact_eval: bool = False,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build an action policy and algorithm metadata for map-based benchmarking.
+
+    Args:
+        algo: Algorithm key to instantiate.
+        algo_config: Algorithm configuration payload.
+        robot_kinematics: Runtime robot kinematics label for metadata enrichment.
+        robot_command_mode: Runtime robot command mode (for holonomic metadata labels).
+        adapter_impact_eval: Whether to collect native-vs-adapter step counters.
+
+    Returns:
+        tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+        Policy callable and enriched metadata dictionary. For PPO, adapter-impact
+        counters are mutated in-place in the returned metadata during episode rollout.
+    """
+    algo_key = algo.lower().strip()
+    meta: dict[str, Any] = {"algorithm": algo_key}
+    registered_policy = _policy_builder_registry.build_registered_policy(
+        algo_key,
+        algo_config,
+        builders=_POLICY_BUILDERS,
+        robot_kinematics=robot_kinematics,
+        robot_command_mode=robot_command_mode,
+        adapter_impact_eval=adapter_impact_eval,
+    )
+    if registered_policy is not None:
+        return registered_policy
+
+    normalized_robot_command_mode = (
+        str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
+    )
+    registered_adapter_spec = build_registered_adapter_policy_spec(algo_key, algo_config)
+    if registered_adapter_spec is not None:
+        meta["algorithm"] = registered_adapter_spec.algo_key
+        return _build_adapter_policy(
+            algo_key=registered_adapter_spec.algo_key,
+            algo_config=registered_adapter_spec.algo_config,
+            meta=meta,
+            adapter=registered_adapter_spec.adapter,
+            adapter_name=registered_adapter_spec.adapter_name,
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            limitations=registered_adapter_spec.limitations,
+        )
+
+    if algo_key == "mppi_social":
+        adapter = MPPISocialPlannerAdapter(config=build_mppi_social_config(algo_config))
+        return _build_adapter_policy(
+            algo_key=algo_key,
+            algo_config=algo_config,
+            meta=meta,
+            adapter=adapter,
+            adapter_name="MPPISocialPlannerAdapter",
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+        )
+
+    if algo_key == "predictive_mppi":
+        return _build_predictive_mppi_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+        )
+
+    if algo_key == "sicnav":
+        planner = SICNavPlanner(build_sicnav_config(algo_config), seed=None)
+        planner_meta = planner.get_metadata()
+        if planner_meta.get("status") != "ok":
+            raise RuntimeError(
+                "SICNav dependency is missing or unresolved. "
+                "Point `repo_root` at a checked-out upstream repo or install the package."
+            )
+        return _build_external_mpc_policy(
+            planner,
+            algo_key=algo_key,
+            algo_config=algo_config,
+            meta=meta,
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            planner_name="SICNavPlanner",
+            limitations="external_mpc_dependency_sensitive",
+        )
+
+    if algo_key == "dr_mpc":
+        planner = DRMPCPlanner(build_dr_mpc_config(algo_config), seed=None)
+        planner_meta = planner.get_metadata()
+        if planner_meta.get("status") != "ok":
+            raise RuntimeError(
+                "DR-MPC dependency is missing or unresolved. "
+                "Point `repo_root` at a checked-out upstream repo or install the package."
+            )
+        return _build_external_mpc_policy(
+            planner,
+            algo_key=algo_key,
+            algo_config=algo_config,
+            meta=meta,
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            planner_name="DRMPCPlanner",
+            limitations="external_mpc_dependency_sensitive",
+        )
+
+    if algo_key in {"ppo"}:
+        return _build_ppo_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            adapter_impact_eval=adapter_impact_eval,
+        )
+    elif algo_key in {"sac"}:
+        return _build_sac_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            adapter_impact_eval=adapter_impact_eval,
+        )
+    elif algo_key == "drl_vo":
+        return _build_drl_vo_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            adapter_impact_eval=adapter_impact_eval,
+        )
+    elif algo_key in {"guarded_ppo"}:
+        return _build_guarded_ppo_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            adapter_impact_eval=adapter_impact_eval,
+        )
+    elif algo_key in {
+        "gensafenav_ours_gst_guarded",
+        "ours_gst_guarded",
+        "gensafenav_gst_predictor_rand_guarded",
+        "gst_predictor_rand_guarded",
+    }:
+        return _build_sonic_guarded_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            adapter_impact_eval=adapter_impact_eval,
+        )
+    else:
+        adapter = _build_socnav_family_adapter(
+            algo_key,
+            algo,
+            algo_config,
+            meta=meta,
+        )
 
     if "status" not in meta:
         meta["status"] = "ok"

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -1557,6 +1557,145 @@ def _build_guarded_ppo_policy(  # noqa: C901, PLR0915
     return _policy, meta
 
 
+def _build_sonic_guarded_policy(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    meta: dict[str, Any],
+    robot_kinematics: str | None,
+    normalized_robot_command_mode: str | None,
+    adapter_impact_eval: bool,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build the guarded SoNIC / GenSafeNav policy and enriched metadata.
+
+    Returns:
+        tuple[Callable, dict[str, Any]]: Policy callable and enriched metadata.
+    """
+    holonomic_vx_vy_mode = (
+        str(robot_kinematics or "").strip().lower() in {"holonomic", "omni", "omnidirectional"}
+        and normalized_robot_command_mode == "vx_vy"
+    )
+    if holonomic_vx_vy_mode:
+        raise ValueError(
+            "Guarded SoNIC / GenSafeNav wrappers do not support holonomic vx_vy benchmark "
+            "action space yet. The upstream checkpoint emits ActionXY world velocities, but "
+            "the current short-horizon guard and goal fallback only evaluate unicycle_vw "
+            "commands, so this path fails closed instead of collapsing ActionXY through a "
+            "lossy (v, w) round-trip."
+        )
+
+    guarded_root = {
+        "gensafenav_ours_gst_guarded",
+        "ours_gst_guarded",
+    }
+    model_name = (
+        str(algo_config.get("model_name", "Ours_GST"))
+        if algo_key in guarded_root
+        else str(algo_config.get("model_name", "GST_predictor_rand"))
+    )
+    sonic_adapter_cls, sonic_config_builder = _sonic_crowdnav_symbols()
+    sonic_adapter = sonic_adapter_cls(
+        config=sonic_config_builder(
+            {
+                **algo_config,
+                "repo_root": algo_config.get("repo_root", "output/repos/GenSafeNav"),
+                "model_name": model_name,
+                "checkpoint_name": algo_config.get("checkpoint_name", "05207.pt"),
+            }
+        )
+    )
+    guard_adapter = GuardedPPOAdapter(
+        config=build_guarded_ppo_config(algo_config),
+        fallback_adapter=_GoalFallbackAdapter(
+            max_speed=float(algo_config.get("guard_fallback_max_speed", 1.0)),
+        ),
+    )
+    meta.update(
+        {
+            "status": "ok",
+            "config": algo_config,
+            "config_hash": _config_hash(algo_config),
+        }
+    )
+    meta = enrich_algorithm_metadata(
+        algo=algo_key,
+        metadata=meta,
+        execution_mode="mixed",
+        adapter_name="sonic_guarded_goal_fallback",
+        robot_kinematics=robot_kinematics,
+        adapter_impact_requested=adapter_impact_eval,
+    )
+    _init_feasibility_metadata(meta)
+    meta["guard_stats"] = {
+        "ppo_clear": 0,
+        "ppo_safe": 0,
+        "fallback_safe": 0,
+        "stop_safe": 0,
+        "fallback_best_effort": 0,
+        "stop_best_effort": 0,
+        "uncertainty_fallback_stop": 0,
+        "uncertainty_fallback_slow_down": 0,
+        "uncertainty_fallback_configured": 0,
+        "goal_reached": 0,
+    }
+    meta["safety_shield_contract"] = shield_contract_metadata(
+        shield_name="GuardedPPOAdapter",
+        prediction_source="short_horizon_rollout",
+        fallback_policy="goal",
+    )
+    meta["shield_stats"] = new_shield_stats()
+    planner_meta = meta.get("planner_kinematics")
+    if isinstance(planner_meta, dict):
+        planner_meta["planner_command_space"] = _default_robot_command_space(
+            robot_kinematics,
+            algo_config,
+            robot_command_mode=normalized_robot_command_mode,
+        )
+        planner_meta["guard_strategy"] = "short_horizon_safety_gate"
+        planner_meta["fallback_policy"] = "goal"
+
+    guarded_kinematics_model = resolve_benchmark_kinematics_model(
+        robot_kinematics=robot_kinematics,
+        command_limits=algo_config,
+    )
+
+    def _policy(obs: dict[str, Any]) -> tuple[float, float]:
+        """Run SONIC behind the short-horizon safety guard.
+
+        Returns:
+            tuple[float, float]: Guard-selected and projected command.
+        """
+        sonic_command = sonic_adapter.plan(obs)
+        shield_decision = _choose_shield_command(
+            guard_adapter,
+            obs,
+            (float(sonic_command[0]), float(sonic_command[1])),
+        )
+        chosen, decision = shield_decision.as_command_result()
+        linear, angular = _project_with_feasibility(
+            model=guarded_kinematics_model,
+            command=(float(chosen[0]), float(chosen[1])),
+            meta=meta,
+        )
+        guard_stats = meta.get("guard_stats")
+        if isinstance(guard_stats, dict):
+            guard_stats[decision] = int(guard_stats.get(decision, 0)) + 1
+        shield_stats = meta.get("shield_stats")
+        if isinstance(shield_stats, dict):
+            update_shield_stats(shield_stats, shield_decision)
+        _update_adapter_impact_metrics(
+            meta,
+            "adapter",
+            count_native=False,
+        )
+        return linear, angular
+
+    _attach_planner_reset(_policy, sonic_adapter)
+    if hasattr(sonic_adapter, "close"):
+        _policy._planner_close = sonic_adapter.close
+    return _policy, meta
+
+
 def _build_policy(  # noqa: C901, PLR0912, PLR0915
     algo: str,
     algo_config: dict[str, Any],
@@ -1718,129 +1857,14 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
         "gensafenav_gst_predictor_rand_guarded",
         "gst_predictor_rand_guarded",
     }:
-        holonomic_vx_vy_mode = (
-            str(robot_kinematics or "").strip().lower() in {"holonomic", "omni", "omnidirectional"}
-            and normalized_robot_command_mode == "vx_vy"
-        )
-        if holonomic_vx_vy_mode:
-            raise ValueError(
-                "Guarded SoNIC / GenSafeNav wrappers do not support holonomic vx_vy benchmark "
-                "action space yet. The upstream checkpoint emits ActionXY world velocities, but "
-                "the current short-horizon guard and goal fallback only evaluate unicycle_vw "
-                "commands, so this path fails closed instead of collapsing ActionXY through a "
-                "lossy (v, w) round-trip."
-            )
-
-        guarded_root = {
-            "gensafenav_ours_gst_guarded",
-            "ours_gst_guarded",
-        }
-        model_name = (
-            str(algo_config.get("model_name", "Ours_GST"))
-            if algo_key in guarded_root
-            else str(algo_config.get("model_name", "GST_predictor_rand"))
-        )
-        sonic_adapter_cls, sonic_config_builder = _sonic_crowdnav_symbols()
-        sonic_adapter = sonic_adapter_cls(
-            config=sonic_config_builder(
-                {
-                    **algo_config,
-                    "repo_root": algo_config.get("repo_root", "output/repos/GenSafeNav"),
-                    "model_name": model_name,
-                    "checkpoint_name": algo_config.get("checkpoint_name", "05207.pt"),
-                }
-            )
-        )
-        guard_adapter = GuardedPPOAdapter(
-            config=build_guarded_ppo_config(algo_config),
-            fallback_adapter=_GoalFallbackAdapter(
-                max_speed=float(algo_config.get("guard_fallback_max_speed", 1.0)),
-            ),
-        )
-        meta.update(
-            {
-                "status": "ok",
-                "config": algo_config,
-                "config_hash": _config_hash(algo_config),
-            }
-        )
-        meta = enrich_algorithm_metadata(
-            algo=algo_key,
-            metadata=meta,
-            execution_mode="mixed",
-            adapter_name="sonic_guarded_goal_fallback",
+        return _build_sonic_guarded_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
             robot_kinematics=robot_kinematics,
-            adapter_impact_requested=adapter_impact_eval,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            adapter_impact_eval=adapter_impact_eval,
         )
-        _init_feasibility_metadata(meta)
-        meta["guard_stats"] = {
-            "ppo_clear": 0,
-            "ppo_safe": 0,
-            "fallback_safe": 0,
-            "stop_safe": 0,
-            "fallback_best_effort": 0,
-            "stop_best_effort": 0,
-            "uncertainty_fallback_stop": 0,
-            "uncertainty_fallback_slow_down": 0,
-            "uncertainty_fallback_configured": 0,
-            "goal_reached": 0,
-        }
-        meta["safety_shield_contract"] = shield_contract_metadata(
-            shield_name="GuardedPPOAdapter",
-            prediction_source="short_horizon_rollout",
-            fallback_policy="goal",
-        )
-        meta["shield_stats"] = new_shield_stats()
-        planner_meta = meta.get("planner_kinematics")
-        if isinstance(planner_meta, dict):
-            planner_meta["planner_command_space"] = _default_robot_command_space(
-                robot_kinematics,
-                algo_config,
-                robot_command_mode=normalized_robot_command_mode,
-            )
-            planner_meta["guard_strategy"] = "short_horizon_safety_gate"
-            planner_meta["fallback_policy"] = "goal"
-
-        guarded_kinematics_model = resolve_benchmark_kinematics_model(
-            robot_kinematics=robot_kinematics,
-            command_limits=algo_config,
-        )
-
-        def _policy(obs: dict[str, Any]) -> tuple[float, float]:
-            """Run SONIC behind the short-horizon safety guard.
-
-            Returns:
-                tuple[float, float]: Guard-selected and projected command.
-            """
-            sonic_command = sonic_adapter.plan(obs)
-            shield_decision = _choose_shield_command(
-                guard_adapter,
-                obs,
-                (float(sonic_command[0]), float(sonic_command[1])),
-            )
-            chosen, decision = shield_decision.as_command_result()
-            linear, angular = _project_with_feasibility(
-                model=guarded_kinematics_model,
-                command=(float(chosen[0]), float(chosen[1])),
-                meta=meta,
-            )
-            guard_stats = meta.get("guard_stats")
-            if isinstance(guard_stats, dict):
-                guard_stats[decision] = int(guard_stats.get(decision, 0)) + 1
-            shield_stats = meta.get("shield_stats")
-            if isinstance(shield_stats, dict):
-                update_shield_stats(shield_stats, shield_decision)
-            _update_adapter_impact_metrics(
-                meta,
-                "adapter",
-                count_native=False,
-            )
-            return linear, angular
-
-        _attach_planner_reset(_policy, sonic_adapter)
-        if hasattr(sonic_adapter, "close"):
-            _policy._planner_close = sonic_adapter.close
-        return _policy, meta
     elif algo_key in {"orca"}:
         allow_fallback = bool(algo_config.get("allow_fallback", False))
         adapter = ORCAPlannerAdapter(config=socnav_cfg, allow_fallback=allow_fallback)

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -1696,6 +1696,157 @@ def _build_sonic_guarded_policy(
     return _policy, meta
 
 
+_HOLONOMIC_WORLD_VELOCITY_ALGO_KEYS = frozenset(
+    {
+        "orca",
+        "hrvo",
+        "socnav_hrvo",
+        "social_force",
+        "sf",
+        "social_navigation_pyenvs_orca",
+        "social_nav_pyenvs_orca",
+        "social_navigation_pyenvs_socialforce",
+        "social_nav_pyenvs_socialforce",
+        "social_navigation_pyenvs_sfm_helbing",
+        "social_nav_pyenvs_sfm_helbing",
+        "sonic_crowdnav",
+        "sonic_gst",
+        "gensafenav_ours_gst",
+        "gensafe_ours_gst",
+        "ours_gst",
+        "gensafenav_gst_predictor_rand",
+        "gensafe_gst_predictor_rand",
+        "gst_predictor_rand",
+    }
+)
+
+
+def _is_holonomic_world_velocity_mode(
+    algo_key: str,
+    robot_kinematics: str | None,
+    normalized_robot_command_mode: str | None,
+) -> bool:
+    """Return whether a planner runs in holonomic world-velocity (vx_vy) mode.
+
+    Args:
+        algo_key: Lowercased algorithm key.
+        robot_kinematics: Runtime robot kinematics label.
+        normalized_robot_command_mode: Lowercased robot command mode (e.g. ``vx_vy``).
+
+    Returns:
+        bool: True when the planner emits ActionXY world velocities forwarded directly
+        into the holonomic vx_vy benchmark action space.
+    """
+    return (
+        algo_key in _HOLONOMIC_WORLD_VELOCITY_ALGO_KEYS
+        and str(robot_kinematics or "").strip().lower() in {"holonomic", "omni", "omnidirectional"}
+        and normalized_robot_command_mode == "vx_vy"
+    )
+
+
+def _holonomic_world_velocity_boundary(algo_key: str) -> str:
+    """Return the provenance boundary description for a holonomic world-velocity planner.
+
+    Args:
+        algo_key: Lowercased algorithm key.
+
+    Returns:
+        str: Human-readable boundary describing how the planner's world velocity reaches
+        the holonomic vx_vy benchmark action space.
+    """
+    if algo_key == "orca":
+        return (
+            "Use upstream Python-RVO2 to solve reciprocal-avoidance velocity in world "
+            "coordinates, then forward that world-frame velocity directly into the "
+            "holonomic vx_vy benchmark action space."
+        )
+    if algo_key in {"hrvo", "socnav_hrvo"}:
+        return (
+            "Run the local HRVO geometry solver in world velocity space, then forward the "
+            "selected world-frame velocity directly into the holonomic vx_vy benchmark "
+            "action space."
+        )
+    if algo_key == "social_force":
+        return (
+            "Compute the local social-force translational command as a world-frame velocity "
+            "vector, then forward that world-frame velocity directly into the holonomic "
+            "vx_vy benchmark action space."
+        )
+    if algo_key in {"social_navigation_pyenvs_orca", "social_nav_pyenvs_orca"}:
+        return (
+            "Map Robot SF SocNav observations into the upstream Social-Navigation-PyEnvs "
+            "JointState contract, run upstream ORCA predict(), and forward the resulting "
+            "ActionXY world velocity directly into the holonomic vx_vy benchmark action space."
+        )
+    if algo_key in {"sonic_crowdnav", "sonic_gst"}:
+        return (
+            "Run the upstream SoNIC checkpoint through the model-only Robot SF wrapper and "
+            "forward the resulting ActionXY world velocity directly into the holonomic vx_vy "
+            "benchmark action space."
+        )
+    if algo_key in {"gensafenav_ours_gst", "gensafe_ours_gst", "ours_gst"}:
+        return (
+            "Run the upstream GenSafeNav Ours_GST checkpoint through the model-only Robot SF "
+            "wrapper and forward the resulting ActionXY world velocity directly into the "
+            "holonomic vx_vy benchmark action space."
+        )
+    if algo_key in {
+        "gensafenav_gst_predictor_rand",
+        "gensafe_gst_predictor_rand",
+        "gst_predictor_rand",
+    }:
+        return (
+            "Run the upstream GenSafeNav GST_predictor_rand checkpoint through the model-only "
+            "Robot SF wrapper and forward the resulting ActionXY world velocity directly into "
+            "the holonomic vx_vy benchmark action space."
+        )
+    return (
+        "Map Robot SF SocNav observations into the upstream Social-Navigation-PyEnvs "
+        "JointState contract, run the upstream force-model policy predict(), and forward "
+        "the resulting ActionXY world velocity directly into the holonomic vx_vy "
+        "benchmark action space."
+    )
+
+
+def _build_holonomic_world_velocity_policy(
+    adapter: Any,
+    *,
+    algo_key: str,
+    meta: dict[str, Any],
+    planner_bind_env: Any,
+) -> tuple[Callable[[dict[str, Any]], dict[str, float | str]], dict[str, Any]]:
+    """Build the holonomic world-velocity (vx_vy) policy and metadata for a planner.
+
+    Returns:
+        tuple[Callable, dict[str, Any]]: Policy callable returning a holonomic
+        world-velocity command payload, and enriched metadata.
+    """
+    adapter_boundary = _holonomic_world_velocity_boundary(algo_key)
+    _apply_direct_world_velocity_metadata(meta, adapter_boundary=adapter_boundary)
+
+    def _policy(obs: dict[str, Any]) -> dict[str, float | str]:
+        """Run holonomic upstream ORCA and return world-velocity action payload.
+
+        Returns:
+            dict[str, float | str]: Holonomic world-velocity command.
+        """
+        velocity_world = np.asarray(adapter.plan_velocity_world(obs), dtype=float).reshape(-1)
+        if velocity_world.size < 2:
+            raise ValueError(
+                "Holonomic ORCA path expected a world-frame velocity with two components."
+            )
+        return _holonomic_world_velocity_command(
+            float(velocity_world[0]),
+            float(velocity_world[1]),
+        )
+
+    _attach_planner_reset(_policy, adapter)
+    _policy._planner_adapter = adapter
+    if planner_bind_env is not None:
+        _policy._planner_bind_env = planner_bind_env
+    return _policy, meta
+
+
 def _build_socnav_family_adapter(  # noqa: C901, PLR0912, PLR0915
     algo_key: str,
     algo: str,
@@ -2093,109 +2244,16 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
         planner_bind_env = _bind_env
     elif hasattr(adapter, "bind_env"):
         planner_bind_env = adapter.bind_env
-    holonomic_world_velocity_mode = (
-        algo_key
-        in {
-            "orca",
-            "hrvo",
-            "socnav_hrvo",
-            "social_force",
-            "sf",
-            "social_navigation_pyenvs_orca",
-            "social_nav_pyenvs_orca",
-            "social_navigation_pyenvs_socialforce",
-            "social_nav_pyenvs_socialforce",
-            "social_navigation_pyenvs_sfm_helbing",
-            "social_nav_pyenvs_sfm_helbing",
-            "sonic_crowdnav",
-            "sonic_gst",
-            "gensafenav_ours_gst",
-            "gensafe_ours_gst",
-            "ours_gst",
-            "gensafenav_gst_predictor_rand",
-            "gensafe_gst_predictor_rand",
-            "gst_predictor_rand",
-        }
-        and str(robot_kinematics or "").strip().lower() in {"holonomic", "omni", "omnidirectional"}
-        and normalized_robot_command_mode == "vx_vy"
+    holonomic_world_velocity_mode = _is_holonomic_world_velocity_mode(
+        algo_key, robot_kinematics, normalized_robot_command_mode
     )
     if holonomic_world_velocity_mode:
-        if algo_key == "orca":
-            adapter_boundary = (
-                "Use upstream Python-RVO2 to solve reciprocal-avoidance velocity in world "
-                "coordinates, then forward that world-frame velocity directly into the "
-                "holonomic vx_vy benchmark action space."
-            )
-        elif algo_key in {"hrvo", "socnav_hrvo"}:
-            adapter_boundary = (
-                "Run the local HRVO geometry solver in world velocity space, then forward the "
-                "selected world-frame velocity directly into the holonomic vx_vy benchmark "
-                "action space."
-            )
-        elif algo_key == "social_force":
-            adapter_boundary = (
-                "Compute the local social-force translational command as a world-frame velocity "
-                "vector, then forward that world-frame velocity directly into the holonomic "
-                "vx_vy benchmark action space."
-            )
-        elif algo_key in {"social_navigation_pyenvs_orca", "social_nav_pyenvs_orca"}:
-            adapter_boundary = (
-                "Map Robot SF SocNav observations into the upstream Social-Navigation-PyEnvs "
-                "JointState contract, run upstream ORCA predict(), and forward the resulting "
-                "ActionXY world velocity directly into the holonomic vx_vy benchmark action space."
-            )
-        elif algo_key in {"sonic_crowdnav", "sonic_gst"}:
-            adapter_boundary = (
-                "Run the upstream SoNIC checkpoint through the model-only Robot SF wrapper and "
-                "forward the resulting ActionXY world velocity directly into the holonomic vx_vy "
-                "benchmark action space."
-            )
-        elif algo_key in {"gensafenav_ours_gst", "gensafe_ours_gst", "ours_gst"}:
-            adapter_boundary = (
-                "Run the upstream GenSafeNav Ours_GST checkpoint through the model-only Robot SF "
-                "wrapper and forward the resulting ActionXY world velocity directly into the "
-                "holonomic vx_vy benchmark action space."
-            )
-        elif algo_key in {
-            "gensafenav_gst_predictor_rand",
-            "gensafe_gst_predictor_rand",
-            "gst_predictor_rand",
-        }:
-            adapter_boundary = (
-                "Run the upstream GenSafeNav GST_predictor_rand checkpoint through the model-only "
-                "Robot SF wrapper and forward the resulting ActionXY world velocity directly into "
-                "the holonomic vx_vy benchmark action space."
-            )
-        else:
-            adapter_boundary = (
-                "Map Robot SF SocNav observations into the upstream Social-Navigation-PyEnvs "
-                "JointState contract, run the upstream force-model policy predict(), and forward "
-                "the resulting ActionXY world velocity directly into the holonomic vx_vy "
-                "benchmark action space."
-            )
-        _apply_direct_world_velocity_metadata(meta, adapter_boundary=adapter_boundary)
-
-        def _policy(obs: dict[str, Any]) -> dict[str, float | str]:
-            """Run holonomic upstream ORCA and return world-velocity action payload.
-
-            Returns:
-                dict[str, float | str]: Holonomic world-velocity command.
-            """
-            velocity_world = np.asarray(adapter.plan_velocity_world(obs), dtype=float).reshape(-1)
-            if velocity_world.size < 2:
-                raise ValueError(
-                    "Holonomic ORCA path expected a world-frame velocity with two components."
-                )
-            return _holonomic_world_velocity_command(
-                float(velocity_world[0]),
-                float(velocity_world[1]),
-            )
-
-        _attach_planner_reset(_policy, adapter)
-        _policy._planner_adapter = adapter
-        if planner_bind_env is not None:
-            _policy._planner_bind_env = planner_bind_env
-        return _policy, meta
+        return _build_holonomic_world_velocity_policy(
+            adapter,
+            algo_key=algo_key,
+            meta=meta,
+            planner_bind_env=planner_bind_env,
+        )
 
     def _policy(obs: dict[str, Any]) -> tuple[float, float]:
         """Run a generic SocNav adapter and project command feasibility.

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -990,6 +990,102 @@ _POLICY_BUILDERS: dict[str, _policy_builder_registry.PolicyBuilder] = {
 }
 
 
+def _build_predictive_mppi_policy(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    meta: dict[str, Any],
+    robot_kinematics: str | None,
+    normalized_robot_command_mode: str | None,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build the PredictiveMPPI adapter policy and enriched metadata.
+
+    Returns:
+        tuple[Callable, dict[str, Any]]: Policy callable and enriched metadata.
+    """
+    allow_fallback = bool(algo_config.get("allow_fallback", False))
+    adapter = PredictiveMPPIAdapter(
+        config=build_predictive_mppi_config(algo_config),
+        allow_fallback=allow_fallback,
+    )
+    meta.update(
+        {
+            "status": "ok",
+            "config": algo_config,
+            "config_hash": _config_hash(algo_config),
+        }
+    )
+    meta = enrich_algorithm_metadata(
+        algo=algo_key,
+        metadata=meta,
+        execution_mode="adapter",
+        adapter_name="PredictiveMPPIAdapter",
+        robot_kinematics=robot_kinematics,
+    )
+    _init_feasibility_metadata(meta)
+    planner_meta = meta.get("planner_kinematics")
+    if isinstance(planner_meta, dict):
+        planner_meta["planner_command_space"] = _default_robot_command_space(
+            robot_kinematics,
+            algo_config,
+            robot_command_mode=normalized_robot_command_mode,
+        )
+    adapter_kinematics_model = resolve_benchmark_kinematics_model(
+        robot_kinematics=robot_kinematics,
+        command_limits=algo_config,
+    )
+
+    def _policy(obs: dict[str, Any]) -> tuple[float, float]:
+        """Run a SocNav adapter and project command feasibility.
+
+        Returns:
+            tuple[float, float]: Projected linear and angular command.
+        """
+        linear, angular = adapter.plan(obs)
+        return _project_with_feasibility(
+            model=adapter_kinematics_model,
+            command=(float(linear), float(angular)),
+            meta=meta,
+        )
+
+    _attach_planner_reset(_policy, adapter)
+    return _policy, meta
+
+
+def _build_external_mpc_policy(
+    planner: Any,
+    *,
+    algo_key: str,
+    algo_config: dict[str, Any],
+    meta: dict[str, Any],
+    robot_kinematics: str | None,
+    normalized_robot_command_mode: str | None,
+    planner_name: str,
+    limitations: str,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Wrap an external MPC planner (SICNav / DR-MPC) in the adapter policy path.
+
+    Returns:
+        tuple[Callable, dict[str, Any]]: Policy callable and enriched metadata.
+    """
+    adapter = _ExternalMPCAdapter(
+        planner,
+        algo_config=algo_config,
+        robot_kinematics=robot_kinematics,
+        planner_name=planner_name,
+    )
+    return _build_adapter_policy(
+        algo_key=algo_key,
+        algo_config=algo_config,
+        meta=meta,
+        adapter=adapter,
+        adapter_name=planner_name,
+        robot_kinematics=robot_kinematics,
+        normalized_robot_command_mode=normalized_robot_command_mode,
+        limitations=limitations,
+    )
+
+
 def _build_policy(  # noqa: C901, PLR0912, PLR0915
     algo: str,
     algo_config: dict[str, Any],
@@ -1055,53 +1151,13 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
         )
 
     if algo_key == "predictive_mppi":
-        allow_fallback = bool(algo_config.get("allow_fallback", False))
-        adapter = PredictiveMPPIAdapter(
-            config=build_predictive_mppi_config(algo_config),
-            allow_fallback=allow_fallback,
-        )
-        meta.update(
-            {
-                "status": "ok",
-                "config": algo_config,
-                "config_hash": _config_hash(algo_config),
-            }
-        )
-        meta = enrich_algorithm_metadata(
-            algo=algo_key,
-            metadata=meta,
-            execution_mode="adapter",
-            adapter_name="PredictiveMPPIAdapter",
+        return _build_predictive_mppi_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
             robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
         )
-        _init_feasibility_metadata(meta)
-        planner_meta = meta.get("planner_kinematics")
-        if isinstance(planner_meta, dict):
-            planner_meta["planner_command_space"] = _default_robot_command_space(
-                robot_kinematics,
-                algo_config,
-                robot_command_mode=normalized_robot_command_mode,
-            )
-        adapter_kinematics_model = resolve_benchmark_kinematics_model(
-            robot_kinematics=robot_kinematics,
-            command_limits=algo_config,
-        )
-
-        def _policy(obs: dict[str, Any]) -> tuple[float, float]:
-            """Run a SocNav adapter and project command feasibility.
-
-            Returns:
-                tuple[float, float]: Projected linear and angular command.
-            """
-            linear, angular = adapter.plan(obs)
-            return _project_with_feasibility(
-                model=adapter_kinematics_model,
-                command=(float(linear), float(angular)),
-                meta=meta,
-            )
-
-        _attach_planner_reset(_policy, adapter)
-        return _policy, meta
 
     if algo_key == "sicnav":
         planner = SICNavPlanner(build_sicnav_config(algo_config), seed=None)
@@ -1111,20 +1167,14 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
                 "SICNav dependency is missing or unresolved. "
                 "Point `repo_root` at a checked-out upstream repo or install the package."
             )
-        adapter = _ExternalMPCAdapter(
+        return _build_external_mpc_policy(
             planner,
-            algo_config=algo_config,
-            robot_kinematics=robot_kinematics,
-            planner_name="SICNavPlanner",
-        )
-        return _build_adapter_policy(
             algo_key=algo_key,
             algo_config=algo_config,
             meta=meta,
-            adapter=adapter,
-            adapter_name="SICNavPlanner",
             robot_kinematics=robot_kinematics,
             normalized_robot_command_mode=normalized_robot_command_mode,
+            planner_name="SICNavPlanner",
             limitations="external_mpc_dependency_sensitive",
         )
 
@@ -1136,20 +1186,14 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
                 "DR-MPC dependency is missing or unresolved. "
                 "Point `repo_root` at a checked-out upstream repo or install the package."
             )
-        adapter = _ExternalMPCAdapter(
+        return _build_external_mpc_policy(
             planner,
-            algo_config=algo_config,
-            robot_kinematics=robot_kinematics,
-            planner_name="DRMPCPlanner",
-        )
-        return _build_adapter_policy(
             algo_key=algo_key,
             algo_config=algo_config,
             meta=meta,
-            adapter=adapter,
-            adapter_name="DRMPCPlanner",
             robot_kinematics=robot_kinematics,
             normalized_robot_command_mode=normalized_robot_command_mode,
+            planner_name="DRMPCPlanner",
             limitations="external_mpc_dependency_sensitive",
         )
 

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -1515,9 +1515,7 @@ def _build_guarded_ppo_policy(  # noqa: C901, PLR0915
                 else None
             )
             if isinstance(action_adaptation, dict):
-                residual_stats["decision_count"] = (
-                    int(residual_stats.get("decision_count", 0)) + 1
-                )
+                residual_stats["decision_count"] = int(residual_stats.get("decision_count", 0)) + 1
                 if bool(action_adaptation.get("residual_clipped", False)):
                     residual_stats["clipped_count"] = (
                         int(residual_stats.get("clipped_count", 0)) + 1
@@ -2094,9 +2092,7 @@ def _build_common_adapter_policy(  # noqa: C901
         planner_bind_env = _bind_env
     elif hasattr(adapter, "bind_env"):
         planner_bind_env = adapter.bind_env
-    if _is_holonomic_world_velocity_mode(
-        algo_key, robot_kinematics, normalized_robot_command_mode
-    ):
+    if _is_holonomic_world_velocity_mode(algo_key, robot_kinematics, normalized_robot_command_mode):
         return _build_holonomic_world_velocity_policy(
             adapter,
             algo_key=algo_key,

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -590,6 +590,48 @@ def _ppo_paper_gate_status(config: dict[str, Any]) -> tuple[bool, str | None]:
     return True, None
 
 
+def _resolve_planner_obs_mode(planner: Any, default: str) -> str:
+    """Return the lowercased ``obs_mode`` from a planner config (dict or attribute).
+
+    Args:
+        planner: Planner exposing a ``config`` dict or attribute object.
+        default: Fallback obs-mode when the planner config does not specify one.
+
+    Returns:
+        str: Lowercased obs-mode label.
+    """
+    planner_cfg = getattr(planner, "config", None)
+    if isinstance(planner_cfg, dict):
+        return str(planner_cfg.get("obs_mode", default)).strip().lower()
+    return str(getattr(planner_cfg, "obs_mode", default)).strip().lower()
+
+
+def _enforce_ppo_paper_profile(
+    algo_config: dict[str, Any],
+) -> tuple[bool, str | None]:
+    """Validate the PPO paper profile gate, raising if it fails.
+
+    Returns:
+        tuple[bool, str | None]: ``(paper_ready, paper_reason)`` for metadata recording.
+        Raises ``ValueError`` when a paper/paper-baseline profile is requested but the
+        provenance/quality gate is not satisfied.
+    """
+    paper_ready, paper_reason = _ppo_paper_gate_status(algo_config)
+    if (
+        str(algo_config.get("profile", "experimental")).strip().lower()
+        in {
+            "paper",
+            "paper-baseline",
+        }
+        and not paper_ready
+    ):
+        raise ValueError(
+            "PPO paper profile requested but gate failed: "
+            f"{paper_reason}. Provide provenance + quality_gate in algo config.",
+        )
+    return paper_ready, paper_reason
+
+
 def _evaluate_learned_policy_contract(
     *,
     algo: str,
@@ -1086,6 +1128,271 @@ def _build_external_mpc_policy(
     )
 
 
+def _build_ppo_policy(  # noqa: C901
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    meta: dict[str, Any],
+    robot_kinematics: str | None,
+    normalized_robot_command_mode: str | None,
+    adapter_impact_eval: bool,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build the PPO mixed-adapter policy and enriched metadata.
+
+    Returns:
+        tuple[Callable, dict[str, Any]]: Policy callable and enriched metadata.
+    """
+    paper_ready, paper_reason = _enforce_ppo_paper_profile(algo_config)
+    ppo_planner = PPOPlanner(algo_config, seed=None)
+    ppo_obs_mode = _resolve_planner_obs_mode(ppo_planner, "vector")
+    if hasattr(ppo_planner, "get_metadata"):
+        planner_meta = ppo_planner.get_metadata()
+        if isinstance(planner_meta, dict):
+            meta.update(planner_meta)
+    meta = enrich_algorithm_metadata(
+        algo=algo_key,
+        metadata=meta,
+        execution_mode="mixed",
+        adapter_name="ppo_action_to_unicycle",
+        robot_kinematics=robot_kinematics,
+        adapter_impact_requested=adapter_impact_eval,
+    )
+    _init_feasibility_metadata(meta)
+    planner_meta = meta.get("planner_kinematics")
+    if isinstance(planner_meta, dict):
+        planner_meta["planner_command_space"] = _default_robot_command_space(
+            robot_kinematics,
+            algo_config,
+            robot_command_mode=normalized_robot_command_mode,
+        )
+    ppo_kinematics_model = resolve_benchmark_kinematics_model(
+        robot_kinematics=robot_kinematics,
+        command_limits=algo_config,
+    )
+
+    def _policy(obs: dict[str, Any]) -> tuple[float, float]:
+        """Run PPO planner inference and convert output into benchmark command space.
+
+        Returns:
+            tuple[float, float]: Linear and angular command after conversion/projection.
+        """
+        if ppo_obs_mode in {"dict", "native_dict", "multi_input"}:
+            ppo_obs = obs
+        else:
+            ppo_obs = _obs_to_ppo_format(obs)
+        action = ppo_planner.step(ppo_obs)
+        if not isinstance(action, dict):
+            raise TypeError(f"PPO planner returned non-dict action: {type(action)}")
+        linear, angular, conversion_mode = _ppo_action_to_unicycle(
+            action,
+            obs,
+            algo_config,
+            robot_kinematics=robot_kinematics,
+            kinematics_model=ppo_kinematics_model,
+            project_command=False,
+        )
+        linear, angular = _project_with_feasibility(
+            model=ppo_kinematics_model,
+            command=(float(linear), float(angular)),
+            meta=meta,
+        )
+        _update_adapter_impact_metrics(meta, conversion_mode)
+        return linear, angular
+
+    _policy._planner_close = ppo_planner.close
+    ppo_bind_env = getattr(ppo_planner, "bind_env", None)
+    if callable(ppo_bind_env):
+        _policy._planner_bind_env = ppo_bind_env
+    if "status" not in meta:
+        meta["status"] = "ok"
+    meta.setdefault("algorithm", "ppo")
+    meta.setdefault("config", algo_config)
+    meta["profile"] = str(algo_config.get("profile", "experimental")).strip().lower()
+    provenance = algo_config.get("provenance")
+    if isinstance(provenance, dict):
+        meta["provenance"] = provenance
+    quality_gate = algo_config.get("quality_gate")
+    if isinstance(quality_gate, dict):
+        meta["quality_gate"] = quality_gate
+    meta["paper_ready"] = bool(paper_ready)
+    if paper_reason:
+        meta["paper_gate_reason"] = paper_reason
+    meta["config_hash"] = _config_hash(meta.get("config", algo_config))
+    return _policy, meta
+
+
+def _build_sac_policy(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    meta: dict[str, Any],
+    robot_kinematics: str | None,
+    normalized_robot_command_mode: str | None,
+    adapter_impact_eval: bool,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build the SAC mixed-adapter policy and enriched metadata.
+
+    Returns:
+        tuple[Callable, dict[str, Any]]: Policy callable and enriched metadata.
+    """
+    sac_planner = SACPlanner(algo_config, seed=None)
+    sac_obs_mode = _resolve_planner_obs_mode(sac_planner, "dict")
+    if hasattr(sac_planner, "get_metadata"):
+        planner_meta = sac_planner.get_metadata()
+        if isinstance(planner_meta, dict):
+            meta.update(planner_meta)
+    meta = enrich_algorithm_metadata(
+        algo=algo_key,
+        metadata=meta,
+        execution_mode="mixed",
+        adapter_name="ppo_action_to_unicycle",
+        robot_kinematics=robot_kinematics,
+        adapter_impact_requested=adapter_impact_eval,
+    )
+    _init_feasibility_metadata(meta)
+    planner_meta = meta.get("planner_kinematics")
+    if isinstance(planner_meta, dict):
+        planner_meta["planner_command_space"] = _default_robot_command_space(
+            robot_kinematics,
+            algo_config,
+            robot_command_mode=normalized_robot_command_mode,
+        )
+    sac_kinematics_model = resolve_benchmark_kinematics_model(
+        robot_kinematics=robot_kinematics,
+        command_limits=algo_config,
+    )
+
+    sac_action_semantics = str(algo_config.get("action_semantics", "delta")).strip().lower()
+    sac_action_space = str(algo_config.get("action_space", "unicycle")).strip().lower()
+    # Native bypass is only valid for delta-unicycle outputs from the SAC model itself.
+    # Fallback steps emit absolute goal-directed commands that must go through the
+    # command→env-action conversion path.  We decide per step by checking the planner
+    # status *after* each sac_planner.step() call.
+    _sac_can_be_native = sac_action_semantics == "delta" and sac_action_space == "unicycle"
+
+    def _policy(obs: dict[str, Any]) -> tuple[float, float]:
+        """Run SAC planner inference and handle native-vs-fallback action semantics.
+
+        Returns:
+            tuple[float, float]: Linear and angular command for the environment.
+        """
+        if sac_obs_mode in {"dict", "native_dict", "multi_input"}:
+            sac_obs = obs
+        else:
+            sac_obs = _obs_to_ppo_format(obs)
+        action = sac_planner.step(sac_obs)
+        if not isinstance(action, dict):
+            raise TypeError(f"SAC planner returned non-dict action: {type(action)}")
+        # Track per step whether this output is a native env action (model ran) or an
+        # absolute goal-directed fallback command (planner in fallback mode).
+        _policy._last_step_native = (
+            _sac_can_be_native and getattr(sac_planner, "_status", "fallback") == "ok"
+        )
+        linear, angular, conversion_mode = _ppo_action_to_unicycle(
+            action,
+            obs,
+            algo_config,
+            robot_kinematics=robot_kinematics,
+            kinematics_model=sac_kinematics_model,
+            project_command=False,
+        )
+        linear, angular = _project_with_feasibility(
+            model=sac_kinematics_model,
+            command=(float(linear), float(angular)),
+            meta=meta,
+        )
+        _update_adapter_impact_metrics(meta, conversion_mode)
+        return linear, angular
+
+    _policy._planner_close = sac_planner.close
+    _policy._planner_native_env_action = _sac_can_be_native
+    if "status" not in meta:
+        meta["status"] = "ok"
+    meta.setdefault("algorithm", "sac")
+    meta.setdefault("config", algo_config)
+    meta["profile"] = str(algo_config.get("profile", "experimental")).strip().lower()
+    meta["config_hash"] = _config_hash(meta.get("config", algo_config))
+    return _policy, meta
+
+
+def _build_drl_vo_policy(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    meta: dict[str, Any],
+    robot_kinematics: str | None,
+    normalized_robot_command_mode: str | None,
+    adapter_impact_eval: bool,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build the DRL-VO mixed-adapter policy and enriched metadata.
+
+    Returns:
+        tuple[Callable, dict[str, Any]]: Policy callable and enriched metadata.
+    """
+    drl_planner = DrlVoPlanner(algo_config, seed=None)
+    if hasattr(drl_planner, "get_metadata"):
+        planner_meta = drl_planner.get_metadata()
+        if isinstance(planner_meta, dict):
+            meta.update(planner_meta)
+
+    meta = enrich_algorithm_metadata(
+        algo=algo_key,
+        metadata=meta,
+        execution_mode="mixed",
+        adapter_name="drl_vo_action_to_unicycle",
+        robot_kinematics=robot_kinematics,
+        adapter_impact_requested=adapter_impact_eval,
+    )
+    _init_feasibility_metadata(meta)
+    planner_meta = meta.get("planner_kinematics")
+    if isinstance(planner_meta, dict):
+        planner_meta["planner_command_space"] = _default_robot_command_space(
+            robot_kinematics,
+            algo_config,
+            robot_command_mode=normalized_robot_command_mode,
+        )
+
+    drl_kinematics_model = resolve_benchmark_kinematics_model(
+        robot_kinematics=robot_kinematics,
+        command_limits=algo_config,
+    )
+
+    def _policy(obs: dict[str, Any]) -> tuple[float, float]:
+        """Run DRL-VO inference through the PPO-format observation adapter.
+
+        Returns:
+            tuple[float, float]: Linear and angular command after conversion/projection.
+        """
+        drl_obs = _obs_to_ppo_format(obs)
+        action = drl_planner.step(drl_obs)
+        if not isinstance(action, dict):
+            raise TypeError(f"DRL-VO planner returned non-dict action: {type(action)}")
+        linear, angular, conversion_mode = _ppo_action_to_unicycle(
+            action,
+            obs,
+            algo_config,
+            robot_kinematics=robot_kinematics,
+            kinematics_model=drl_kinematics_model,
+            project_command=False,
+        )
+        linear, angular = _project_with_feasibility(
+            model=drl_kinematics_model,
+            command=(float(linear), float(angular)),
+            meta=meta,
+        )
+        _update_adapter_impact_metrics(meta, conversion_mode)
+        return linear, angular
+
+    _policy._planner_close = drl_planner.close
+    _attach_planner_reset(_policy, drl_planner)
+    if "status" not in meta:
+        meta["status"] = "ok"
+    meta.setdefault("algorithm", "drl_vo")
+    meta.setdefault("config", algo_config)
+    meta["config_hash"] = _config_hash(meta.get("config", algo_config))
+    return _policy, meta
+
+
 def _build_policy(  # noqa: C901, PLR0912, PLR0915
     algo: str,
     algo_config: dict[str, Any],
@@ -1206,245 +1513,32 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
     elif algo_key in {"social_force", "sf"}:
         adapter = SocialForcePlannerAdapter(config=socnav_cfg)
     elif algo_key in {"ppo"}:
-        paper_ready, paper_reason = _ppo_paper_gate_status(algo_config)
-        if (
-            str(algo_config.get("profile", "experimental")).strip().lower()
-            in {
-                "paper",
-                "paper-baseline",
-            }
-            and not paper_ready
-        ):
-            raise ValueError(
-                "PPO paper profile requested but gate failed: "
-                f"{paper_reason}. Provide provenance + quality_gate in algo config.",
-            )
-        ppo_planner = PPOPlanner(algo_config, seed=None)
-        planner_cfg = getattr(ppo_planner, "config", None)
-        if isinstance(planner_cfg, dict):
-            ppo_obs_mode = str(planner_cfg.get("obs_mode", "vector")).strip().lower()
-        else:
-            ppo_obs_mode = str(getattr(planner_cfg, "obs_mode", "vector")).strip().lower()
-        if hasattr(ppo_planner, "get_metadata"):
-            planner_meta = ppo_planner.get_metadata()
-            if isinstance(planner_meta, dict):
-                meta.update(planner_meta)
-        meta = enrich_algorithm_metadata(
-            algo=algo_key,
-            metadata=meta,
-            execution_mode="mixed",
-            adapter_name="ppo_action_to_unicycle",
+        return _build_ppo_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
             robot_kinematics=robot_kinematics,
-            adapter_impact_requested=adapter_impact_eval,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            adapter_impact_eval=adapter_impact_eval,
         )
-        _init_feasibility_metadata(meta)
-        planner_meta = meta.get("planner_kinematics")
-        if isinstance(planner_meta, dict):
-            planner_meta["planner_command_space"] = _default_robot_command_space(
-                robot_kinematics,
-                algo_config,
-                robot_command_mode=normalized_robot_command_mode,
-            )
-        ppo_kinematics_model = resolve_benchmark_kinematics_model(
-            robot_kinematics=robot_kinematics,
-            command_limits=algo_config,
-        )
-
-        def _policy(obs: dict[str, Any]) -> tuple[float, float]:
-            """Run PPO planner inference and convert output into benchmark command space.
-
-            Returns:
-                tuple[float, float]: Linear and angular command after conversion/projection.
-            """
-            if ppo_obs_mode in {"dict", "native_dict", "multi_input"}:
-                ppo_obs = obs
-            else:
-                ppo_obs = _obs_to_ppo_format(obs)
-            action = ppo_planner.step(ppo_obs)
-            if not isinstance(action, dict):
-                raise TypeError(f"PPO planner returned non-dict action: {type(action)}")
-            linear, angular, conversion_mode = _ppo_action_to_unicycle(
-                action,
-                obs,
-                algo_config,
-                robot_kinematics=robot_kinematics,
-                kinematics_model=ppo_kinematics_model,
-                project_command=False,
-            )
-            linear, angular = _project_with_feasibility(
-                model=ppo_kinematics_model,
-                command=(float(linear), float(angular)),
-                meta=meta,
-            )
-            _update_adapter_impact_metrics(meta, conversion_mode)
-            return linear, angular
-
-        _policy._planner_close = ppo_planner.close
-        ppo_bind_env = getattr(ppo_planner, "bind_env", None)
-        if callable(ppo_bind_env):
-            _policy._planner_bind_env = ppo_bind_env
-        if "status" not in meta:
-            meta["status"] = "ok"
-        meta.setdefault("algorithm", "ppo")
-        meta.setdefault("config", algo_config)
-        meta["profile"] = str(algo_config.get("profile", "experimental")).strip().lower()
-        provenance = algo_config.get("provenance")
-        if isinstance(provenance, dict):
-            meta["provenance"] = provenance
-        quality_gate = algo_config.get("quality_gate")
-        if isinstance(quality_gate, dict):
-            meta["quality_gate"] = quality_gate
-        meta["paper_ready"] = bool(paper_ready)
-        if paper_reason:
-            meta["paper_gate_reason"] = paper_reason
-        meta["config_hash"] = _config_hash(meta.get("config", algo_config))
-        return _policy, meta
     elif algo_key in {"sac"}:
-        sac_planner = SACPlanner(algo_config, seed=None)
-        planner_cfg = getattr(sac_planner, "config", None)
-        if isinstance(planner_cfg, dict):
-            sac_obs_mode = str(planner_cfg.get("obs_mode", "dict")).strip().lower()
-        else:
-            sac_obs_mode = str(getattr(planner_cfg, "obs_mode", "dict")).strip().lower()
-        if hasattr(sac_planner, "get_metadata"):
-            planner_meta = sac_planner.get_metadata()
-            if isinstance(planner_meta, dict):
-                meta.update(planner_meta)
-        meta = enrich_algorithm_metadata(
-            algo=algo_key,
-            metadata=meta,
-            execution_mode="mixed",
-            adapter_name="ppo_action_to_unicycle",
+        return _build_sac_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
             robot_kinematics=robot_kinematics,
-            adapter_impact_requested=adapter_impact_eval,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            adapter_impact_eval=adapter_impact_eval,
         )
-        _init_feasibility_metadata(meta)
-        planner_meta = meta.get("planner_kinematics")
-        if isinstance(planner_meta, dict):
-            planner_meta["planner_command_space"] = _default_robot_command_space(
-                robot_kinematics,
-                algo_config,
-                robot_command_mode=normalized_robot_command_mode,
-            )
-        sac_kinematics_model = resolve_benchmark_kinematics_model(
-            robot_kinematics=robot_kinematics,
-            command_limits=algo_config,
-        )
-
-        sac_action_semantics = str(algo_config.get("action_semantics", "delta")).strip().lower()
-        sac_action_space = str(algo_config.get("action_space", "unicycle")).strip().lower()
-        # Native bypass is only valid for delta-unicycle outputs from the SAC model itself.
-        # Fallback steps emit absolute goal-directed commands that must go through the
-        # command→env-action conversion path.  We decide per step by checking the planner
-        # status *after* each sac_planner.step() call.
-        _sac_can_be_native = sac_action_semantics == "delta" and sac_action_space == "unicycle"
-
-        def _policy(obs: dict[str, Any]) -> tuple[float, float]:
-            """Run SAC planner inference and handle native-vs-fallback action semantics.
-
-            Returns:
-                tuple[float, float]: Linear and angular command for the environment.
-            """
-            if sac_obs_mode in {"dict", "native_dict", "multi_input"}:
-                sac_obs = obs
-            else:
-                sac_obs = _obs_to_ppo_format(obs)
-            action = sac_planner.step(sac_obs)
-            if not isinstance(action, dict):
-                raise TypeError(f"SAC planner returned non-dict action: {type(action)}")
-            # Track per step whether this output is a native env action (model ran) or an
-            # absolute goal-directed fallback command (planner in fallback mode).
-            _policy._last_step_native = (
-                _sac_can_be_native and getattr(sac_planner, "_status", "fallback") == "ok"
-            )
-            linear, angular, conversion_mode = _ppo_action_to_unicycle(
-                action,
-                obs,
-                algo_config,
-                robot_kinematics=robot_kinematics,
-                kinematics_model=sac_kinematics_model,
-                project_command=False,
-            )
-            linear, angular = _project_with_feasibility(
-                model=sac_kinematics_model,
-                command=(float(linear), float(angular)),
-                meta=meta,
-            )
-            _update_adapter_impact_metrics(meta, conversion_mode)
-            return linear, angular
-
-        _policy._planner_close = sac_planner.close
-        _policy._planner_native_env_action = _sac_can_be_native
-        if "status" not in meta:
-            meta["status"] = "ok"
-        meta.setdefault("algorithm", "sac")
-        meta.setdefault("config", algo_config)
-        meta["profile"] = str(algo_config.get("profile", "experimental")).strip().lower()
-        meta["config_hash"] = _config_hash(meta.get("config", algo_config))
-        return _policy, meta
     elif algo_key == "drl_vo":
-        drl_planner = DrlVoPlanner(algo_config, seed=None)
-        if hasattr(drl_planner, "get_metadata"):
-            planner_meta = drl_planner.get_metadata()
-            if isinstance(planner_meta, dict):
-                meta.update(planner_meta)
-
-        meta = enrich_algorithm_metadata(
-            algo=algo_key,
-            metadata=meta,
-            execution_mode="mixed",
-            adapter_name="drl_vo_action_to_unicycle",
+        return _build_drl_vo_policy(
+            algo_key,
+            algo_config,
+            meta=meta,
             robot_kinematics=robot_kinematics,
-            adapter_impact_requested=adapter_impact_eval,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            adapter_impact_eval=adapter_impact_eval,
         )
-        _init_feasibility_metadata(meta)
-        planner_meta = meta.get("planner_kinematics")
-        if isinstance(planner_meta, dict):
-            planner_meta["planner_command_space"] = _default_robot_command_space(
-                robot_kinematics,
-                algo_config,
-                robot_command_mode=normalized_robot_command_mode,
-            )
-
-        drl_kinematics_model = resolve_benchmark_kinematics_model(
-            robot_kinematics=robot_kinematics,
-            command_limits=algo_config,
-        )
-
-        def _policy(obs: dict[str, Any]) -> tuple[float, float]:
-            """Run DRL-VO inference through the PPO-format observation adapter.
-
-            Returns:
-                tuple[float, float]: Linear and angular command after conversion/projection.
-            """
-            drl_obs = _obs_to_ppo_format(obs)
-            action = drl_planner.step(drl_obs)
-            if not isinstance(action, dict):
-                raise TypeError(f"DRL-VO planner returned non-dict action: {type(action)}")
-            linear, angular, conversion_mode = _ppo_action_to_unicycle(
-                action,
-                obs,
-                algo_config,
-                robot_kinematics=robot_kinematics,
-                kinematics_model=drl_kinematics_model,
-                project_command=False,
-            )
-            linear, angular = _project_with_feasibility(
-                model=drl_kinematics_model,
-                command=(float(linear), float(angular)),
-                meta=meta,
-            )
-            _update_adapter_impact_metrics(meta, conversion_mode)
-            return linear, angular
-
-        _policy._planner_close = drl_planner.close
-        _attach_planner_reset(_policy, drl_planner)
-        if "status" not in meta:
-            meta["status"] = "ok"
-        meta.setdefault("algorithm", "drl_vo")
-        meta.setdefault("config", algo_config)
-        meta["config_hash"] = _config_hash(meta.get("config", algo_config))
-        return _policy, meta
     elif algo_key in {"guarded_ppo"}:
         ppo_allowed = {field.name for field in fields(PPOPlannerConfig)}
         ppo_config = {key: value for key, value in algo_config.items() if key in ppo_allowed}

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -954,6 +954,126 @@ def _topology_guided_episode_diagnostics(
     }
 
 
+def _apply_safety_wrapper_step(
+    command: Any,
+    *,
+    runtime: Any,
+    env: Any,
+    config: Any,
+    step_idx: int,
+    step_is_native: bool,
+    previous_ped_positions: np.ndarray | None,
+    deadlock_monitor: Any,
+) -> tuple[Any, dict[str, Any]]:
+    """Run one safety-wrapper correction or record an ineligible step.
+
+    Error/fallback path for ``safety_wrapper``: native actions and unsupported command
+    shapes either raise (when the runtime is configured to fail closed) or emit an
+    ineligible step record; otherwise the runtime corrects the command in place.
+
+    Returns:
+        tuple[Any, dict[str, Any]]: ``(command, record)`` where ``command`` is the
+        corrected command (tail preserved) on the applied path, or the unchanged
+        command on an ineligible path; ``record`` is appended to the wrapper trace.
+    """
+    if step_is_native:
+        if runtime.fail_on_native_action:
+            raise ValueError(
+                "safety_wrapper.enabled requires absolute commands; "
+                "native environment actions cannot be wrapped safely"
+            )
+        return command, ineligible_safety_wrapper_step_record(
+            runtime=runtime,
+            step_idx=step_idx,
+            reason="native_environment_action",
+        )
+    if not isinstance(command, (tuple, list, np.ndarray)) or len(command) < 2:
+        if runtime.fail_on_unsupported_command:
+            raise TypeError(
+                "safety_wrapper.enabled expects commands shaped like "
+                "(linear_velocity, angular_velocity)"
+            )
+        return command, ineligible_safety_wrapper_step_record(
+            runtime=runtime,
+            step_idx=step_idx,
+            reason="unsupported_command_shape",
+        )
+    corrected_command, wrapper_record = apply_runtime_safety_wrapper(
+        command=command,
+        env=env,
+        config=config,
+        runtime=runtime,
+        previous_ped_positions=previous_ped_positions,
+        step_idx=step_idx,
+        deadlock_monitor=deadlock_monitor,
+    )
+    corrected = (
+        corrected_command[0],
+        corrected_command[1],
+        *tuple(command[2:]),
+    )
+    return corrected, wrapper_record
+
+
+def _apply_cbf_safety_filter_step(
+    command: Any,
+    *,
+    runtime: Any,
+    env: Any,
+    config: Any,
+    step_idx: int,
+    step_is_native: bool,
+    previous_ped_positions: np.ndarray | None,
+) -> tuple[Any, dict[str, Any]]:
+    """Run one CBF safety-filter correction or record an ineligible step.
+
+    Error/fallback path for ``cbf_safety_filter``: native actions and unsupported
+    command shapes either raise (when the runtime is configured to fail closed) or
+    emit an ineligible step record; otherwise the CBF filter corrects the command.
+
+    Returns:
+        tuple[Any, dict[str, Any]]: ``(command, record)`` where ``command`` is the
+        corrected command (tail preserved) on the applied path, or the unchanged
+        command on an ineligible path; ``record`` is appended to the filter trace.
+    """
+    if step_is_native:
+        if runtime.fail_on_native_action:
+            raise ValueError(
+                "cbf_safety_filter.enabled requires absolute commands; "
+                "native environment actions cannot be filtered safely"
+            )
+        return command, ineligible_cbf_safety_filter_step_record(
+            runtime=runtime,
+            step_idx=step_idx,
+            reason="native_environment_action",
+        )
+    if not isinstance(command, (tuple, list, np.ndarray)) or len(command) < 2:
+        if runtime.fail_on_unsupported_command:
+            raise TypeError(
+                "cbf_safety_filter.enabled expects commands shaped like "
+                "(linear_velocity, angular_velocity)"
+            )
+        return command, ineligible_cbf_safety_filter_step_record(
+            runtime=runtime,
+            step_idx=step_idx,
+            reason="unsupported_command_shape",
+        )
+    corrected_command, cbf_record = apply_runtime_cbf_safety_filter(
+        command=command,
+        env=env,
+        config=config,
+        runtime=runtime,
+        previous_ped_positions=previous_ped_positions,
+        step_idx=step_idx,
+    )
+    corrected = (
+        corrected_command[0],
+        corrected_command[1],
+        *tuple(command[2:]),
+    )
+    return corrected, cbf_record
+
+
 @dataclass(frozen=True, slots=True)
 class _EpisodeRunContext:
     """Resolved inputs and runtime config for one episode run.
@@ -1420,96 +1540,28 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 )
                 tracking_precision_records.append(tracking_record)
             if safety_wrapper_runtime.enabled:
-                if step_is_native:
-                    if safety_wrapper_runtime.fail_on_native_action:
-                        raise ValueError(
-                            "safety_wrapper.enabled requires absolute commands; "
-                            "native environment actions cannot be wrapped safely"
-                        )
-                    safety_wrapper_trace.append(
-                        ineligible_safety_wrapper_step_record(
-                            runtime=safety_wrapper_runtime,
-                            step_idx=step_idx,
-                            reason="native_environment_action",
-                        )
-                    )
-                elif (
-                    not isinstance(policy_command, (tuple, list, np.ndarray))
-                    or len(policy_command) < 2
-                ):
-                    if safety_wrapper_runtime.fail_on_unsupported_command:
-                        raise TypeError(
-                            "safety_wrapper.enabled expects commands shaped like "
-                            "(linear_velocity, angular_velocity)"
-                        )
-                    safety_wrapper_trace.append(
-                        ineligible_safety_wrapper_step_record(
-                            runtime=safety_wrapper_runtime,
-                            step_idx=step_idx,
-                            reason="unsupported_command_shape",
-                        )
-                    )
-                else:
-                    corrected_command, wrapper_record = apply_runtime_safety_wrapper(
-                        command=policy_command,
-                        env=env,
-                        config=config,
-                        runtime=safety_wrapper_runtime,
-                        previous_ped_positions=previous_trace_ped_pos,
-                        step_idx=step_idx,
-                        deadlock_monitor=safety_wrapper_deadlock_monitor,
-                    )
-                    policy_command = (
-                        corrected_command[0],
-                        corrected_command[1],
-                        *tuple(policy_command[2:]),
-                    )
-                    safety_wrapper_trace.append(wrapper_record)
+                policy_command, wrapper_record = _apply_safety_wrapper_step(
+                    policy_command,
+                    runtime=safety_wrapper_runtime,
+                    env=env,
+                    config=config,
+                    step_idx=step_idx,
+                    step_is_native=step_is_native,
+                    previous_ped_positions=previous_trace_ped_pos,
+                    deadlock_monitor=safety_wrapper_deadlock_monitor,
+                )
+                safety_wrapper_trace.append(wrapper_record)
             if cbf_runtime.enabled:
-                if step_is_native:
-                    if cbf_runtime.fail_on_native_action:
-                        raise ValueError(
-                            "cbf_safety_filter.enabled requires absolute commands; "
-                            "native environment actions cannot be filtered safely"
-                        )
-                    cbf_filter_trace.append(
-                        ineligible_cbf_safety_filter_step_record(
-                            runtime=cbf_runtime,
-                            step_idx=step_idx,
-                            reason="native_environment_action",
-                        )
-                    )
-                elif (
-                    not isinstance(policy_command, (tuple, list, np.ndarray))
-                    or len(policy_command) < 2
-                ):
-                    if cbf_runtime.fail_on_unsupported_command:
-                        raise TypeError(
-                            "cbf_safety_filter.enabled expects commands shaped like "
-                            "(linear_velocity, angular_velocity)"
-                        )
-                    cbf_filter_trace.append(
-                        ineligible_cbf_safety_filter_step_record(
-                            runtime=cbf_runtime,
-                            step_idx=step_idx,
-                            reason="unsupported_command_shape",
-                        )
-                    )
-                else:
-                    corrected_command, cbf_record = apply_runtime_cbf_safety_filter(
-                        command=policy_command,
-                        env=env,
-                        config=config,
-                        runtime=cbf_runtime,
-                        previous_ped_positions=previous_trace_ped_pos,
-                        step_idx=step_idx,
-                    )
-                    policy_command = (
-                        corrected_command[0],
-                        corrected_command[1],
-                        *tuple(policy_command[2:]),
-                    )
-                    cbf_filter_trace.append(cbf_record)
+                policy_command, cbf_record = _apply_cbf_safety_filter_step(
+                    policy_command,
+                    runtime=cbf_runtime,
+                    env=env,
+                    config=config,
+                    step_idx=step_idx,
+                    step_is_native=step_is_native,
+                    previous_ped_positions=previous_trace_ped_pos,
+                )
+                cbf_filter_trace.append(cbf_record)
             selected_action_payload = _command_action_payload(policy_command)
             ammv_command_actions.append(selected_action_payload)
             if step_is_native:

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -954,41 +954,71 @@ def _topology_guided_episode_diagnostics(
     }
 
 
-def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
+@dataclass(frozen=True, slots=True)
+class _EpisodeRunContext:
+    """Resolved inputs and runtime config for one episode run.
+
+    Bundles the normalization/env-config/horizon/profile/policy-cfg resolution phase of
+    ``run_map_episode`` so the episode loop and metadata assembly receive a single
+    immutable context object instead of recomputing the same locals inline.
+    """
+
+    scenario: dict[str, Any]
+    scenario_id: str
+    ts_start: str
+    start_time: float
+    ped_impact_radius_m: float
+    ped_impact_window_steps: int
+    benchmark_track: str | None
+    track_schema_version: str | None
+    noise_spec: dict[str, Any]
+    noise_rng: Any
+    noise_state: Any
+    noise_stats: Any
+    tracking_precision_spec: dict[str, Any]
+    tracking_precision_rng: Any
+    safety_wrapper_runtime: Any
+    cbf_runtime: Any
+    safety_wrapper_deadlock_monitor: Any
+    config: Any
+    horizon_val: int
+    robot_kinematics: str
+    robot_command_mode: str
+    actuation_profile: Any
+    latency_profile: Any
+    algo: str
+    policy_cfg: dict[str, Any]
+
+
+def _resolve_episode_run_context(  # noqa: PLR0913
+    *,
     scenario: dict[str, Any],
     seed: int,
-    *,
     horizon: int | None,
     dt: float | None,
-    record_forces: bool,
-    snqi_weights: dict[str, float] | None,
-    snqi_baseline: dict[str, dict[str, float]] | None,
     algo: str,
     scenario_path: Path,
-    algo_config: dict[str, Any] | None = None,
-    algo_config_path: str | None = None,
-    adapter_impact_eval: bool = False,
-    experimental_ped_impact: bool = False,
-    ped_impact_radius_m: float = 2.0,
-    ped_impact_window_steps: int = 5,
-    observation_mode: str | None = None,
-    observation_level: str | None = None,
-    benchmark_track: str | None = None,
-    track_schema_version: str | None = None,
-    observation_noise: dict[str, Any] | None = None,
-    tracking_precision: dict[str, Any] | None = None,
-    synthetic_actuation_profile: dict[str, Any] | None = None,
-    latency_stress_profile: dict[str, Any] | None = None,
-    safety_wrapper: dict[str, Any] | None = None,
-    cbf_safety_filter: dict[str, Any] | None = None,
-    record_planner_decision_trace: bool = False,
-    record_simulation_step_trace: bool = False,
-    policy_builder: PolicyBuilder,
-) -> dict[str, Any]:
-    """Run one scenario/seed episode and return a benchmark JSONL record.
+    algo_config: dict[str, Any] | None,
+    algo_config_path: str | None,
+    experimental_ped_impact: bool,
+    ped_impact_radius_m: float,
+    ped_impact_window_steps: int,
+    observation_mode: str | None,
+    observation_level: str | None,
+    benchmark_track: str | None,
+    track_schema_version: str | None,
+    observation_noise: dict[str, Any] | None,
+    tracking_precision: dict[str, Any] | None,
+    synthetic_actuation_profile: dict[str, Any] | None,
+    latency_stress_profile: dict[str, Any] | None,
+    safety_wrapper: dict[str, Any] | None,
+    cbf_safety_filter: dict[str, Any] | None,
+) -> _EpisodeRunContext:
+    """Normalize episode inputs, build the env config, and resolve the policy cfg.
 
     Returns:
-        dict[str, Any]: Episode record with metrics, provenance, and planner metadata.
+        _EpisodeRunContext: Immutable bundle of resolved scenario/track/noise/profile/
+        kinematics/policy-cfg values consumed by the rest of ``run_map_episode``.
     """
     ped_impact_radius_m, ped_impact_window_steps = _normalize_pedestrian_impact_controls(
         experimental_ped_impact=experimental_ped_impact,
@@ -1022,12 +1052,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         raise ValueError(
             "safety_wrapper and cbf_safety_filter cannot both be enabled in #3948 first slice"
         )
-    tracking_precision_records: list[dict[str, Any]] = []
-    safety_wrapper_trace: list[dict[str, Any]] = []
-    # Stateful fourth wrapper stage; one monitor per episode (no-op while disabled).
     safety_wrapper_deadlock_monitor = make_deadlock_recovery_monitor(safety_wrapper_runtime)
-    cbf_filter_trace: list[dict[str, Any]] = []
-    min_separation_corrupted_values: list[float] = []
     config = _build_env_config(scenario, scenario_path=scenario_path)
     max_steps = int(scenario.get("simulation_config", {}).get("max_episode_steps", 0) or 0)
     horizon_val = int(horizon) if horizon and horizon > 0 else max_steps
@@ -1072,6 +1097,123 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         seed=int(seed),
     )
     policy_cfg = _apply_scenario_uncertainty_envelope_config(algo, policy_cfg, scenario)
+    return _EpisodeRunContext(
+        scenario=scenario,
+        scenario_id=scenario_id,
+        ts_start=ts_start,
+        start_time=start_time,
+        ped_impact_radius_m=ped_impact_radius_m,
+        ped_impact_window_steps=ped_impact_window_steps,
+        benchmark_track=benchmark_track,
+        track_schema_version=track_schema_version,
+        noise_spec=noise_spec,
+        noise_rng=noise_rng,
+        noise_state=noise_state,
+        noise_stats=noise_stats,
+        tracking_precision_spec=tracking_precision_spec,
+        tracking_precision_rng=tracking_precision_rng,
+        safety_wrapper_runtime=safety_wrapper_runtime,
+        cbf_runtime=cbf_runtime,
+        safety_wrapper_deadlock_monitor=safety_wrapper_deadlock_monitor,
+        config=config,
+        horizon_val=horizon_val,
+        robot_kinematics=robot_kinematics,
+        robot_command_mode=robot_command_mode,
+        actuation_profile=actuation_profile,
+        latency_profile=latency_profile,
+        algo=algo,
+        policy_cfg=policy_cfg,
+    )
+
+
+def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
+    scenario: dict[str, Any],
+    seed: int,
+    *,
+    horizon: int | None,
+    dt: float | None,
+    record_forces: bool,
+    snqi_weights: dict[str, float] | None,
+    snqi_baseline: dict[str, dict[str, float]] | None,
+    algo: str,
+    scenario_path: Path,
+    algo_config: dict[str, Any] | None = None,
+    algo_config_path: str | None = None,
+    adapter_impact_eval: bool = False,
+    experimental_ped_impact: bool = False,
+    ped_impact_radius_m: float = 2.0,
+    ped_impact_window_steps: int = 5,
+    observation_mode: str | None = None,
+    observation_level: str | None = None,
+    benchmark_track: str | None = None,
+    track_schema_version: str | None = None,
+    observation_noise: dict[str, Any] | None = None,
+    tracking_precision: dict[str, Any] | None = None,
+    synthetic_actuation_profile: dict[str, Any] | None = None,
+    latency_stress_profile: dict[str, Any] | None = None,
+    safety_wrapper: dict[str, Any] | None = None,
+    cbf_safety_filter: dict[str, Any] | None = None,
+    record_planner_decision_trace: bool = False,
+    record_simulation_step_trace: bool = False,
+    policy_builder: PolicyBuilder,
+) -> dict[str, Any]:
+    """Run one scenario/seed episode and return a benchmark JSONL record.
+
+    Returns:
+        dict[str, Any]: Episode record with metrics, provenance, and planner metadata.
+    """
+    ctx = _resolve_episode_run_context(
+        scenario=scenario,
+        seed=seed,
+        horizon=horizon,
+        dt=dt,
+        algo=algo,
+        scenario_path=scenario_path,
+        algo_config=algo_config,
+        algo_config_path=algo_config_path,
+        experimental_ped_impact=experimental_ped_impact,
+        ped_impact_radius_m=ped_impact_radius_m,
+        ped_impact_window_steps=ped_impact_window_steps,
+        observation_mode=observation_mode,
+        observation_level=observation_level,
+        benchmark_track=benchmark_track,
+        track_schema_version=track_schema_version,
+        observation_noise=observation_noise,
+        tracking_precision=tracking_precision,
+        synthetic_actuation_profile=synthetic_actuation_profile,
+        latency_stress_profile=latency_stress_profile,
+        safety_wrapper=safety_wrapper,
+        cbf_safety_filter=cbf_safety_filter,
+    )
+    scenario = ctx.scenario
+    scenario_id = ctx.scenario_id
+    ts_start = ctx.ts_start
+    start_time = ctx.start_time
+    ped_impact_radius_m = ctx.ped_impact_radius_m
+    ped_impact_window_steps = ctx.ped_impact_window_steps
+    benchmark_track = ctx.benchmark_track
+    track_schema_version = ctx.track_schema_version
+    noise_spec = ctx.noise_spec
+    noise_rng = ctx.noise_rng
+    noise_state = ctx.noise_state
+    noise_stats = ctx.noise_stats
+    tracking_precision_spec = ctx.tracking_precision_spec
+    tracking_precision_rng = ctx.tracking_precision_rng
+    safety_wrapper_runtime = ctx.safety_wrapper_runtime
+    cbf_runtime = ctx.cbf_runtime
+    safety_wrapper_deadlock_monitor = ctx.safety_wrapper_deadlock_monitor
+    config = ctx.config
+    horizon_val = ctx.horizon_val
+    robot_kinematics = ctx.robot_kinematics
+    actuation_profile = ctx.actuation_profile
+    latency_profile = ctx.latency_profile
+    robot_command_mode = ctx.robot_command_mode
+    algo = ctx.algo
+    policy_cfg = ctx.policy_cfg
+    tracking_precision_records: list[dict[str, Any]] = []
+    safety_wrapper_trace: list[dict[str, Any]] = []
+    cbf_filter_trace: list[dict[str, Any]] = []
+    min_separation_corrupted_values: list[float] = []
     learned_observation_contract = resolve_learned_checkpoint_observation_contract(
         algo,
         policy_cfg,

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -1074,6 +1074,49 @@ def _apply_cbf_safety_filter_step(
     return corrected, cbf_record
 
 
+def _build_tracking_precision_summary(
+    *,
+    spec: dict[str, Any],
+    records: list[dict[str, Any]],
+    min_separation_corrupted_values: list[float],
+) -> dict[str, Any]:
+    """Build the tracking-precision summary block for episode algorithm metadata.
+
+    Args:
+        spec: Normalized tracking-precision spec.
+        records: Per-step tracking-precision records emitted during the episode loop.
+        min_separation_corrupted_values: Per-step min robot-ped separation under corrupted obs.
+
+    Returns:
+        dict[str, Any]: Tracking-precision summary with contract-honored rates and the
+        last step record (when present).
+    """
+    summary: dict[str, Any] = {
+        "spec": spec,
+        "hash": tracking_precision_hash(spec),
+        "step_count": len(records),
+        "min_separation_corrupted_m": (
+            float(min(min_separation_corrupted_values))
+            if min_separation_corrupted_values
+            else float("inf")
+        ),
+        "contract_honored": (
+            all(bool(record.get("contract_honored", False)) for record in records)
+            if records
+            else True
+        ),
+        "contract_honored_rate": (
+            float(sum(bool(record.get("contract_honored", False)) for record in records))
+            / float(len(records))
+            if records
+            else 1.0
+        ),
+    }
+    if records:
+        summary["last_step"] = dict(records[-1])
+    return summary
+
+
 @dataclass(frozen=True, slots=True)
 class _EpisodeRunContext:
     """Resolved inputs and runtime config for one episode run.
@@ -2069,36 +2112,11 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
             robot_radius=float(getattr(robot_config, "radius", 1.0)),
             ped_radius=float(getattr(config.sim_config, "ped_radius", 0.4)),
         )
-    tracking_precision_summary: dict[str, Any] = {
-        "spec": tracking_precision_spec,
-        "hash": tracking_precision_hash(tracking_precision_spec),
-        "step_count": len(tracking_precision_records),
-        "min_separation_corrupted_m": (
-            float(min(min_separation_corrupted_values))
-            if min_separation_corrupted_values
-            else float("inf")
-        ),
-        "contract_honored": (
-            all(
-                bool(record.get("contract_honored", False)) for record in tracking_precision_records
-            )
-            if tracking_precision_records
-            else True
-        ),
-        "contract_honored_rate": (
-            float(
-                sum(
-                    bool(record.get("contract_honored", False))
-                    for record in tracking_precision_records
-                )
-            )
-            / float(len(tracking_precision_records))
-            if tracking_precision_records
-            else 1.0
-        ),
-    }
-    if tracking_precision_records:
-        tracking_precision_summary["last_step"] = dict(tracking_precision_records[-1])
+    tracking_precision_summary = _build_tracking_precision_summary(
+        spec=tracking_precision_spec,
+        records=tracking_precision_records,
+        min_separation_corrupted_values=min_separation_corrupted_values,
+    )
     algo_meta["tracking_precision"] = tracking_precision_summary
     safety_wrapper_summary: dict[str, Any] | None = None
     if safety_wrapper_runtime.enabled:

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -1246,6 +1246,161 @@ def _resolve_episode_run_context(  # noqa: PLR0913
     )
 
 
+@dataclass(frozen=True, slots=True)
+class _EpisodePostLoopResult:
+    """Trajectory arrays and raw metrics computed after the episode step loop.
+
+    Bundles the post-loop phase of ``run_map_episode``: trajectory stacking, visibility
+    evidence reduction, safety predicates, obstacle sampling, and raw metric computation.
+    """
+
+    robot_pos_arr: np.ndarray
+    robot_vel_arr: np.ndarray
+    robot_acc_arr: np.ndarray
+    ped_pos_arr: np.ndarray
+    ped_forces_arr: np.ndarray
+    safety_predicates: dict[str, Any]
+    obstacles: Any
+    shortest_path: float
+    metrics_raw: dict[str, Any]
+
+
+def _compute_post_loop_metrics(  # noqa: PLR0913
+    *,
+    robot_positions: list[np.ndarray],
+    robot_headings: list[float],
+    ped_positions: list[np.ndarray],
+    ped_forces: list[np.ndarray],
+    visibility_trace: list[np.ndarray | None],
+    track_confidence_trace: list[np.ndarray | None],
+    visibility_evidence_statuses: list[str],
+    visibility_evidence_reasons: list[str | None],
+    reached_goal_step: int | None,
+    collision_seen: bool,
+    ped_collision_seen: bool,
+    obstacle_collision_seen: bool,
+    robot_collision_seen: bool,
+    map_def: Any,
+    goal_vec: np.ndarray,
+    scenario: dict[str, Any],
+    config: Any,
+    horizon_val: int,
+    record_forces: bool,
+    experimental_ped_impact: bool,
+    ped_impact_radius_m: float,
+    ped_impact_window_steps: int,
+) -> _EpisodePostLoopResult:
+    """Stack the episode trajectory, derive safety predicates, and compute raw metrics.
+
+    Returns:
+        _EpisodePostLoopResult: Trajectory arrays plus safety predicates, sampled
+        obstacles, shortest-path length, and the raw (pre-post-process) metrics dict.
+    """
+    robot_pos_arr = np.asarray(robot_positions, dtype=float)
+    robot_vel_arr, robot_acc_arr = _vel_and_acc(
+        robot_pos_arr, config.sim_config.time_per_step_in_secs
+    )
+    ped_pos_arr = _stack_ped_positions(ped_positions)
+    ped_forces_arr = (
+        _stack_ped_positions(ped_forces, fill_value=np.nan)
+        if record_forces
+        else np.zeros_like(ped_pos_arr, dtype=float)
+    )
+    visibility_arr = _stack_visibility_values(
+        visibility_trace,
+        fill_value=False,
+        dtype=bool,
+    )
+    track_confidence_arr = _stack_visibility_values(
+        track_confidence_trace,
+        fill_value=0.0,
+        dtype=float,
+    )
+    if "unavailable" in visibility_evidence_statuses:
+        visibility_evidence_status = "unavailable"
+    elif visibility_evidence_statuses and all(
+        status == "not_applicable" for status in visibility_evidence_statuses
+    ):
+        visibility_evidence_status = "not_applicable"
+    else:
+        visibility_evidence_status = "available"
+    visibility_evidence_reason = next(
+        (reason for reason in visibility_evidence_reasons if reason),
+        None,
+    )
+    safety_predicates = _safety_predicates_for_episode(
+        robot_pos_arr=robot_pos_arr,
+        robot_vel_arr=robot_vel_arr,
+        robot_headings=robot_headings,
+        ped_pos_arr=ped_pos_arr,
+        dt=float(config.sim_config.time_per_step_in_secs),
+        visibility_evidence=VisibilityEvidenceTrace(
+            visibility=visibility_arr,
+            track_confidence=track_confidence_arr,
+            status=visibility_evidence_status,
+            reason=visibility_evidence_reason,
+        ),
+    )
+
+    obstacles = (
+        sample_obstacle_points(map_def.obstacles, map_def.bounds) if map_def is not None else None
+    )
+    if robot_pos_arr.size:
+        shortest_path = compute_shortest_path_length(map_def, robot_pos_arr[0], goal_vec)
+    else:
+        shortest_path = float("nan")
+
+    if robot_pos_arr.size == 0:
+        metrics_raw = {
+            "success": 0.0,
+            "time_to_goal_norm": float("nan"),
+            "collisions": 0.0,
+        }
+    else:
+        robot_config = getattr(config, "robot_config", None)
+        ep = EpisodeData(
+            robot_pos=robot_pos_arr,
+            robot_vel=robot_vel_arr,
+            robot_acc=robot_acc_arr,
+            peds_pos=ped_pos_arr,
+            ped_forces=ped_forces_arr,
+            obstacles=obstacles,
+            goal=goal_vec,
+            dt=float(config.sim_config.time_per_step_in_secs),
+            reached_goal_step=reached_goal_step,
+            robot_radius=float(getattr(robot_config, "radius", 1.0)),
+            ped_radius=float(getattr(config.sim_config, "ped_radius", 0.4)),
+            episode_metadata=_episode_metadata_for_benchmark_metrics(scenario, map_def),
+        )
+        metrics_raw = compute_all_metrics(
+            ep,
+            horizon=horizon_val,
+            shortest_path_len=shortest_path,
+            robot_max_speed=_robot_max_speed(config),
+            experimental_ped_impact=experimental_ped_impact,
+            ped_impact_radius_m=ped_impact_radius_m,
+            ped_impact_window_steps=ped_impact_window_steps,
+        )
+    _floor_collision_metrics_from_flags(
+        metrics_raw,
+        collision_seen=collision_seen,
+        ped_collision_seen=ped_collision_seen,
+        obstacle_collision_seen=obstacle_collision_seen,
+        robot_collision_seen=robot_collision_seen,
+    )
+    return _EpisodePostLoopResult(
+        robot_pos_arr=robot_pos_arr,
+        robot_vel_arr=robot_vel_arr,
+        robot_acc_arr=robot_acc_arr,
+        ped_pos_arr=ped_pos_arr,
+        ped_forces_arr=ped_forces_arr,
+        safety_predicates=safety_predicates,
+        obstacles=obstacles,
+        shortest_path=shortest_path,
+        metrics_raw=metrics_raw,
+    )
+
+
 def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     scenario: dict[str, Any],
     seed: int,
@@ -1823,98 +1978,38 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 logger.debug("Planner close hook failed", exc_info=True)
         env.close()
 
-    robot_pos_arr = np.asarray(robot_positions, dtype=float)
-    robot_vel_arr, robot_acc_arr = _vel_and_acc(
-        robot_pos_arr, config.sim_config.time_per_step_in_secs
-    )
-    ped_pos_arr = _stack_ped_positions(ped_positions)
-    ped_forces_arr = (
-        _stack_ped_positions(ped_forces, fill_value=np.nan)
-        if record_forces
-        else np.zeros_like(ped_pos_arr, dtype=float)
-    )
-    visibility_arr = _stack_visibility_values(
-        visibility_trace,
-        fill_value=False,
-        dtype=bool,
-    )
-    track_confidence_arr = _stack_visibility_values(
-        track_confidence_trace,
-        fill_value=0.0,
-        dtype=float,
-    )
-    if "unavailable" in visibility_evidence_statuses:
-        visibility_evidence_status = "unavailable"
-    elif visibility_evidence_statuses and all(
-        status == "not_applicable" for status in visibility_evidence_statuses
-    ):
-        visibility_evidence_status = "not_applicable"
-    else:
-        visibility_evidence_status = "available"
-    visibility_evidence_reason = next(
-        (reason for reason in visibility_evidence_reasons if reason),
-        None,
-    )
-    safety_predicates = _safety_predicates_for_episode(
-        robot_pos_arr=robot_pos_arr,
-        robot_vel_arr=robot_vel_arr,
+    post_loop = _compute_post_loop_metrics(
+        robot_positions=robot_positions,
         robot_headings=robot_headings,
-        ped_pos_arr=ped_pos_arr,
-        dt=float(config.sim_config.time_per_step_in_secs),
-        visibility_evidence=VisibilityEvidenceTrace(
-            visibility=visibility_arr,
-            track_confidence=track_confidence_arr,
-            status=visibility_evidence_status,
-            reason=visibility_evidence_reason,
-        ),
-    )
-
-    obstacles = (
-        sample_obstacle_points(map_def.obstacles, map_def.bounds) if map_def is not None else None
-    )
-    if robot_pos_arr.size:
-        shortest_path = compute_shortest_path_length(map_def, robot_pos_arr[0], goal_vec)
-    else:
-        shortest_path = float("nan")
-
-    if robot_pos_arr.size == 0:
-        metrics_raw = {
-            "success": 0.0,
-            "time_to_goal_norm": float("nan"),
-            "collisions": 0.0,
-        }
-    else:
-        robot_config = getattr(config, "robot_config", None)
-        ep = EpisodeData(
-            robot_pos=robot_pos_arr,
-            robot_vel=robot_vel_arr,
-            robot_acc=robot_acc_arr,
-            peds_pos=ped_pos_arr,
-            ped_forces=ped_forces_arr,
-            obstacles=obstacles,
-            goal=goal_vec,
-            dt=float(config.sim_config.time_per_step_in_secs),
-            reached_goal_step=reached_goal_step,
-            robot_radius=float(getattr(robot_config, "radius", 1.0)),
-            ped_radius=float(getattr(config.sim_config, "ped_radius", 0.4)),
-            episode_metadata=_episode_metadata_for_benchmark_metrics(scenario, map_def),
-        )
-        metrics_raw = compute_all_metrics(
-            ep,
-            horizon=horizon_val,
-            shortest_path_len=shortest_path,
-            robot_max_speed=_robot_max_speed(config),
-            experimental_ped_impact=experimental_ped_impact,
-            ped_impact_radius_m=ped_impact_radius_m,
-            ped_impact_window_steps=ped_impact_window_steps,
-        )
-    _floor_collision_metrics_from_flags(
-        metrics_raw,
+        ped_positions=ped_positions,
+        ped_forces=ped_forces,
+        visibility_trace=visibility_trace,
+        track_confidence_trace=track_confidence_trace,
+        visibility_evidence_statuses=visibility_evidence_statuses,
+        visibility_evidence_reasons=visibility_evidence_reasons,
+        reached_goal_step=reached_goal_step,
         collision_seen=collision_seen,
         ped_collision_seen=ped_collision_seen,
         obstacle_collision_seen=obstacle_collision_seen,
         robot_collision_seen=robot_collision_seen,
+        map_def=map_def,
+        goal_vec=goal_vec,
+        scenario=scenario,
+        config=config,
+        horizon_val=horizon_val,
+        record_forces=record_forces,
+        experimental_ped_impact=experimental_ped_impact,
+        ped_impact_radius_m=ped_impact_radius_m,
+        ped_impact_window_steps=ped_impact_window_steps,
     )
+    robot_pos_arr = post_loop.robot_pos_arr
+    robot_vel_arr = post_loop.robot_vel_arr
+    ped_pos_arr = post_loop.ped_pos_arr
+    ped_forces_arr = post_loop.ped_forces_arr
+    safety_predicates = post_loop.safety_predicates
+    metrics_raw = post_loop.metrics_raw
+    if robot_pos_arr.size:
+        robot_config = getattr(config, "robot_config", None)
     impact = algo_meta.get("adapter_impact")
     if isinstance(impact, dict) and bool(impact.get("requested", False)):
         native_steps = int(impact.get("native_steps", 0))

--- a/tests/benchmark/test_map_runner_decomposition_helpers.py
+++ b/tests/benchmark/test_map_runner_decomposition_helpers.py
@@ -1,0 +1,453 @@
+"""Direct characterization of the helpers extracted from the map_runner god-functions.
+
+Issue #4944 / #4770-s4 decomposes ``map_runner._build_policy`` and
+``map_runner_episode.run_map_episode`` into named single-responsibility helpers.
+The #4927 baseline (``test_map_runner_characterization.py``) pins the god-function
+behavior end-to-end; this module pins the extracted helpers' contracts directly so
+the decomposition itself is characterized and behavior-preserving.
+
+These tests are CPU-only, deterministic, and use tiny synthetic inputs. They must
+stay green across further decomposition of the same helpers.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from robot_sf.benchmark.cbf_safety_filter_runtime import CBFSafetyFilterRuntimeConfig
+from robot_sf.benchmark.map_runner import (
+    _build_policy,
+    _build_socnav_family_adapter,
+    _enforce_ppo_paper_profile,
+    _holonomic_world_velocity_boundary,
+    _is_holonomic_world_velocity_mode,
+    _resolve_planner_obs_mode,
+)
+from robot_sf.benchmark.map_runner_episode import (
+    _apply_cbf_safety_filter_step,
+    _apply_safety_wrapper_step,
+    _build_tracking_precision_summary,
+)
+from robot_sf.benchmark.safety_wrapper_runtime import SafetyWrapperRuntimeConfig
+
+# ---------------------------------------------------------------------------
+# map_runner: holonomic world-velocity helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHolonomicWorldVelocityHelpers:
+    """Pin the holonomic world-velocity (vx_vy) predicate and boundary strings."""
+
+    @pytest.mark.parametrize(
+        ("algo_key", "kinematics", "command_mode", "expected"),
+        [
+            ("orca", "holonomic", "vx_vy", True),
+            ("social_force", "omni", "vx_vy", True),
+            ("sonic_crowdnav", "omnidirectional", "vx_vy", True),
+            ("orca", "differential_drive", "vx_vy", False),
+            ("orca", "holonomic", "v_theta", False),
+            ("goal", "holonomic", "vx_vy", False),
+            ("ppo", "holonomic", "vx_vy", False),
+        ],
+    )
+    def test_mode_predicate_matches_expected(
+        self,
+        algo_key: str,
+        kinematics: str,
+        command_mode: str,
+        expected: bool,
+    ) -> None:
+        """Predicate must be true only for eligible planners in holonomic vx_vy mode."""
+        assert _is_holonomic_world_velocity_mode(algo_key, kinematics, command_mode) is expected
+
+    def test_mode_predicate_treats_none_command_mode_as_not_vx_vy(self) -> None:
+        """A None command mode must never select holonomic world-velocity mode."""
+        assert _is_holonomic_world_velocity_mode("orca", "holonomic", None) is False
+
+    @pytest.mark.parametrize(
+        "algo_key",
+        [
+            "orca",
+            "hrvo",
+            "socnav_hrvo",
+            "social_force",
+            "social_navigation_pyenvs_orca",
+            "social_nav_pyenvs_orca",
+            "sonic_crowdnav",
+            "sonic_gst",
+            "gensafenav_ours_gst",
+            "ours_gst",
+            "gensafenav_gst_predictor_rand",
+            "gst_predictor_rand",
+            "social_navigation_pyenvs_socialforce",
+            "unknown_planner",
+        ],
+    )
+    def test_boundary_string_is_non_empty_for_all_paths(self, algo_key: str) -> None:
+        """Every branch (including the fallback else) must yield a non-empty string."""
+        boundary = _holonomic_world_velocity_boundary(algo_key)
+        assert isinstance(boundary, str)
+        assert boundary.strip()
+        assert "holonomic vx_vy benchmark action space" in boundary
+
+    def test_boundary_mentions_upstream_name_for_known_planners(self) -> None:
+        """Known planners must mention their upstream solver in the boundary string."""
+        assert "Python-RVO2" in _holonomic_world_velocity_boundary("orca")
+        assert "HRVO" in _holonomic_world_velocity_boundary("hrvo")
+        assert "social-force" in _holonomic_world_velocity_boundary("social_force")
+        assert "SoNIC" in _holonomic_world_velocity_boundary("sonic_crowdnav")
+        assert "GenSafeNav Ours_GST" in _holonomic_world_velocity_boundary("gensafenav_ours_gst")
+
+
+# ---------------------------------------------------------------------------
+# map_runner: planner obs-mode + PPO paper-gate helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPlannerObsModeAndPaperGate:
+    """Pin the planner obs-mode resolver and PPO paper-profile gate."""
+
+    def test_resolve_obs_mode_from_dict_config(self) -> None:
+        """A dict config must resolve obs_mode with the given default fallback."""
+        planner = SimpleNamespace(config={"obs_mode": "DICT"})
+        assert _resolve_planner_obs_mode(planner, "vector") == "dict"
+
+    def test_resolve_obs_mode_from_attribute_config(self) -> None:
+        """A non-dict config object must resolve obs_mode via attribute access."""
+        planner = SimpleNamespace(config=SimpleNamespace(obs_mode="Multi_Input"))
+        assert _resolve_planner_obs_mode(planner, "vector") == "multi_input"
+
+    def test_resolve_obs_mode_uses_default_when_missing(self) -> None:
+        """When obs_mode is absent, the provided default must be returned lowercased."""
+        planner = SimpleNamespace(config={})
+        assert _resolve_planner_obs_mode(planner, "vector") == "vector"
+        planner_attr = SimpleNamespace(config=SimpleNamespace())
+        assert _resolve_planner_obs_mode(planner_attr, "Dict") == "dict"
+
+    def test_resolve_obs_mode_handles_none_config(self) -> None:
+        """A planner with no config attribute must fall back to the default."""
+        planner = SimpleNamespace(spec=1)
+        assert _resolve_planner_obs_mode(planner, "vector") == "vector"
+
+    def test_paper_gate_passes_for_experimental_profile(self) -> None:
+        """An experimental profile must pass the gate with no reason."""
+        ready, reason = _enforce_ppo_paper_profile({"profile": "experimental"})
+        assert ready is False
+        assert reason is None
+
+    def test_paper_gate_raises_for_paper_profile_without_provenance(self) -> None:
+        """A paper profile without provenance must raise and not return."""
+        with pytest.raises(ValueError, match="PPO paper profile requested but gate failed"):
+            _enforce_ppo_paper_profile({"profile": "paper"})
+
+
+# ---------------------------------------------------------------------------
+# map_runner: socnav-family adapter dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestSocnavFamilyAdapterDispatch:
+    """Pin the classical/adapter planner construction dispatch."""
+
+    @pytest.mark.parametrize(
+        ("algo_key", "expected_adapter_type"),
+        [
+            ("orca", "ORCAPlannerAdapter"),
+            ("hrvo", "HRVOPlannerAdapter"),
+            ("socnav_hrvo", "HRVOPlannerAdapter"),
+            ("social_force", "SocialForcePlannerAdapter"),
+            ("sf", "SocialForcePlannerAdapter"),
+            ("socnav_sampling", "SamplingPlannerAdapter"),
+            ("sampling", "SamplingPlannerAdapter"),
+            ("rvo", "SamplingPlannerAdapter"),
+            ("dwa", "SamplingPlannerAdapter"),
+        ],
+    )
+    def test_classical_adapter_constructed_for_key(
+        self,
+        algo_key: str,
+        expected_adapter_type: str,
+    ) -> None:
+        """Known classical keys must construct the expected adapter type."""
+        meta: dict[str, Any] = {"algorithm": algo_key}
+        adapter = _build_socnav_family_adapter(algo_key, algo_key, {}, meta=meta)
+        assert type(adapter).__name__ == expected_adapter_type
+
+    def test_rvo_dwa_marks_placeholder_status_in_meta(self) -> None:
+        """RVO/DWA must record the placeholder + unimplemented status in metadata."""
+        meta: dict[str, Any] = {"algorithm": "rvo"}
+        _build_socnav_family_adapter("rvo", "rvo", {}, meta=meta)
+        assert meta["status"] == "placeholder"
+        assert meta["fallback_reason"] == "unimplemented"
+
+    def test_planner_selector_v2_records_claim_boundary(self) -> None:
+        """The diagnostic selector must stamp its diagnostic-only claim boundary.
+
+        The selector adapter requires a full candidate config (out of scope for this
+        unit test), so this case is covered end-to-end via the #4927 characterization
+        baseline; here we only assert the dispatch routes the key by checking that the
+        unknown-algorithm raise is NOT triggered for the selector key.
+        """
+        # The selector needs candidates we do not construct here; the dispatch is
+        # exercised by test_classical_adapter_constructed_for_key for the simple keys.
+        pytest.skip("selector adapter requires full candidate config; covered by #4927 baseline")
+
+    def test_unknown_algorithm_raises(self) -> None:
+        """An unknown algorithm key must raise ValueError mentioning the original label."""
+        with pytest.raises(ValueError, match="Unknown map-based algorithm 'totally_bogus'"):
+            _build_socnav_family_adapter("totally_bogus", "totally_bogus", {}, meta={})
+
+
+# ---------------------------------------------------------------------------
+# map_runner: end-to-end build_policy still wires the decomposed helpers
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPolicyUsesDecomposedHelpers:
+    """Confirm _build_policy still resolves classical planners through the helpers."""
+
+    def test_orca_policy_returns_projecting_callable(self) -> None:
+        """The ORCA policy built via the decomposed tail must project commands."""
+        policy, meta = _build_policy("orca", {}, robot_kinematics="differential_drive")
+        assert callable(policy)
+        assert meta["algorithm"] == "orca"
+        assert meta["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# map_runner_episode: tracking-precision summary helper
+# ---------------------------------------------------------------------------
+
+
+class TestTrackingPrecisionSummary:
+    """Pin the tracking-precision summary block shape and rates."""
+
+    def test_empty_records_yield_default_honored_rate(self) -> None:
+        """With no step records, contract_honored must be True and rate 1.0."""
+        summary = _build_tracking_precision_summary(
+            spec={"enabled": False, "target_motp_m": 0.05},
+            records=[],
+            min_separation_corrupted_values=[],
+        )
+        assert summary["step_count"] == 0
+        assert summary["contract_honored"] is True
+        assert summary["contract_honored_rate"] == 1.0
+        assert summary["min_separation_corrupted_m"] == float("inf")
+        assert "last_step" not in summary
+
+    def test_records_compute_rates_and_last_step(self) -> None:
+        """Records must compute the honored rate and carry the last step record."""
+        records = [
+            {"contract_honored": True, "step": 0},
+            {"contract_honored": False, "step": 1},
+            {"contract_honored": True, "step": 2},
+        ]
+        summary = _build_tracking_precision_summary(
+            spec={"enabled": True, "target_motp_m": 0.05},
+            records=records,
+            min_separation_corrupted_values=[1.0, 0.5, 0.25],
+        )
+        assert summary["step_count"] == 3
+        assert summary["contract_honored"] is False
+        assert summary["contract_honored_rate"] == pytest.approx(2 / 3)
+        assert summary["min_separation_corrupted_m"] == 0.25
+        assert summary["last_step"] == {"contract_honored": True, "step": 2}
+
+
+# ---------------------------------------------------------------------------
+# map_runner_episode: safety-wrapper + CBF filter step helpers (error/fallback)
+# ---------------------------------------------------------------------------
+
+
+def _runtime(*, enabled: bool = True, **overrides: Any) -> SafetyWrapperRuntimeConfig:
+    """Build a safety-wrapper runtime config with test-friendly defaults."""
+    base = {"fail_on_native_action": False, "fail_on_unsupported_command": False}
+    base.update(overrides)
+    return SafetyWrapperRuntimeConfig(enabled=enabled, **base)
+
+
+def _cbf_runtime(*, enabled: bool = True, **overrides: Any) -> CBFSafetyFilterRuntimeConfig:
+    """Build a CBF safety-filter runtime config with test-friendly defaults."""
+    base = {"fail_on_native_action": False, "fail_on_unsupported_command": False}
+    base.update(overrides)
+    return CBFSafetyFilterRuntimeConfig(enabled=enabled, **base)
+
+
+class TestSafetyWrapperStepHelper:
+    """Pin the safety-wrapper error/fallback step helper."""
+
+    def test_native_action_records_ineligible_when_not_failing(self) -> None:
+        """A native action with fail_on_native_action=False must emit an ineligible record."""
+        runtime = _runtime(fail_on_native_action=False)
+        command, record = _apply_safety_wrapper_step(
+            (1.0, 0.0),
+            runtime=runtime,
+            env=SimpleNamespace(),
+            config=SimpleNamespace(),
+            step_idx=3,
+            step_is_native=True,
+            previous_ped_positions=None,
+            deadlock_monitor=None,
+        )
+        assert command == (1.0, 0.0)
+        assert record["step"] == 3
+        assert record["ineligible_reason"] == "native_environment_action"
+        assert record["eligible_for_wrapper"] is False
+
+    def test_native_action_raises_when_failing(self) -> None:
+        """A native action with fail_on_native_action=True must raise ValueError."""
+        runtime = _runtime(fail_on_native_action=True)
+        with pytest.raises(ValueError, match="safety_wrapper.enabled requires absolute commands"):
+            _apply_safety_wrapper_step(
+                (1.0, 0.0),
+                runtime=runtime,
+                env=SimpleNamespace(),
+                config=SimpleNamespace(),
+                step_idx=0,
+                step_is_native=True,
+                previous_ped_positions=None,
+                deadlock_monitor=None,
+            )
+
+    def test_unsupported_command_shape_records_ineligible(self) -> None:
+        """A non-(linear, angular) command must emit an unsupported-command-shape record."""
+        runtime = _runtime(fail_on_unsupported_command=False)
+        command, record = _apply_safety_wrapper_step(
+            "not_a_command",
+            runtime=runtime,
+            env=SimpleNamespace(),
+            config=SimpleNamespace(),
+            step_idx=5,
+            step_is_native=False,
+            previous_ped_positions=None,
+            deadlock_monitor=None,
+        )
+        assert command == "not_a_command"
+        assert record["ineligible_reason"] == "unsupported_command_shape"
+        assert record["eligible_for_wrapper"] is False
+
+    def test_unsupported_command_shape_raises_when_failing(self) -> None:
+        """An unsupported command shape with fail_on_unsupported_command=True must raise."""
+        runtime = _runtime(fail_on_unsupported_command=True)
+        with pytest.raises(TypeError, match="safety_wrapper.enabled expects commands shaped like"):
+            _apply_safety_wrapper_step(
+                [1.0],
+                runtime=runtime,
+                env=SimpleNamespace(),
+                config=SimpleNamespace(),
+                step_idx=0,
+                step_is_native=False,
+                previous_ped_positions=None,
+                deadlock_monitor=None,
+            )
+
+    def test_applied_path_corrects_command_and_preserves_tail(self) -> None:
+        """The applied path must return the corrected (v,w) and preserve the command tail."""
+        runtime = _runtime()
+
+        def fake_apply(
+            *, command, env, config, runtime, previous_ped_positions, step_idx, deadlock_monitor
+        ):
+            return (0.5, 0.25), {"corrected": True, "step_idx": step_idx}
+
+        # The helper calls module-level apply_runtime_safety_wrapper; patch it for this test.
+        import robot_sf.benchmark.map_runner_episode as mod
+
+        original = mod.apply_runtime_safety_wrapper
+        mod.apply_runtime_safety_wrapper = fake_apply
+        try:
+            command, record = _apply_safety_wrapper_step(
+                (1.0, 0.0, 9.0, 9.0),
+                runtime=runtime,
+                env=SimpleNamespace(),
+                config=SimpleNamespace(),
+                step_idx=7,
+                step_is_native=False,
+                previous_ped_positions=None,
+                deadlock_monitor=None,
+            )
+        finally:
+            mod.apply_runtime_safety_wrapper = original
+        assert command == (0.5, 0.25, 9.0, 9.0)
+        assert record == {"corrected": True, "step_idx": 7}
+
+
+class TestCbfSafetyFilterStepHelper:
+    """Pin the CBF safety-filter error/fallback step helper."""
+
+    def test_native_action_records_ineligible_when_not_failing(self) -> None:
+        """A native action with fail_on_native_action=False must emit an ineligible record."""
+        runtime = _cbf_runtime(fail_on_native_action=False)
+        command, record = _apply_cbf_safety_filter_step(
+            (1.0, 0.0),
+            runtime=runtime,
+            env=SimpleNamespace(),
+            config=SimpleNamespace(),
+            step_idx=2,
+            step_is_native=True,
+            previous_ped_positions=None,
+        )
+        assert command == (1.0, 0.0)
+        assert record["ineligible_reason"] == "native_environment_action"
+        assert record["eligible_for_cbf_filter"] is False
+
+    def test_native_action_raises_when_failing(self) -> None:
+        """A native action with fail_on_native_action=True must raise ValueError."""
+        runtime = _cbf_runtime(fail_on_native_action=True)
+        with pytest.raises(
+            ValueError, match="cbf_safety_filter.enabled requires absolute commands"
+        ):
+            _apply_cbf_safety_filter_step(
+                (1.0, 0.0),
+                runtime=runtime,
+                env=SimpleNamespace(),
+                config=SimpleNamespace(),
+                step_idx=0,
+                step_is_native=True,
+                previous_ped_positions=None,
+            )
+
+    def test_unsupported_command_shape_raises_when_failing(self) -> None:
+        """An unsupported command shape with fail_on_unsupported_command=True must raise."""
+        runtime = _cbf_runtime(fail_on_unsupported_command=True)
+        with pytest.raises(
+            TypeError, match="cbf_safety_filter.enabled expects commands shaped like"
+        ):
+            _apply_cbf_safety_filter_step(
+                None,
+                runtime=runtime,
+                env=SimpleNamespace(),
+                config=SimpleNamespace(),
+                step_idx=0,
+                step_is_native=False,
+                previous_ped_positions=None,
+            )
+
+    def test_applied_path_corrects_command_and_preserves_tail(self) -> None:
+        """The applied path must return the corrected (v,w) and preserve the command tail."""
+        runtime = _cbf_runtime()
+
+        def fake_apply(*, command, env, config, runtime, previous_ped_positions, step_idx):
+            return (0.3, -0.1), {"filtered": True, "step_idx": step_idx}
+
+        import robot_sf.benchmark.map_runner_episode as mod
+
+        original = mod.apply_runtime_cbf_safety_filter
+        mod.apply_runtime_cbf_safety_filter = fake_apply
+        try:
+            command, record = _apply_cbf_safety_filter_step(
+                (1.0, 0.0, "tail"),
+                runtime=runtime,
+                env=SimpleNamespace(),
+                config=SimpleNamespace(),
+                step_idx=4,
+                step_is_native=False,
+                previous_ped_positions=None,
+            )
+        finally:
+            mod.apply_runtime_cbf_safety_filter = original
+        assert command == (0.3, -0.1, "tail")
+        assert record == {"filtered": True, "step_idx": 4}


### PR DESCRIPTION
## What & Why

Resolves issue #4944 (4770-s4): decompose the two map_runner god-functions into named, single-responsibility helpers, behavior-preserving, with the #4927 characterization baseline kept green with **zero edits** to it.

- `robot_sf/benchmark/map_runner.py::_build_policy` (~1021 → **177 lines**, ~83% smaller)
- `robot_sf/benchmark/map_runner_episode.py::run_map_episode` (~1089 → **904 lines**, with the input-resolution, safety error/fallback, and post-loop metrics phases extracted)

All extraction is pure **extract-method**: each helper reproduces the exact prior control flow and metadata; closures capture helper-local state. No behavior change. The #4927 characterization tests pin the god-function behavior end-to-end and stay green.

## noqa complexity suppressions removed where decomposition made them unnecessary

- `_build_policy`: `# noqa: C901, PLR0912, PLR0915` → **`# noqa: C901`** only. Complexity dropped from **60 → 14**; too-many-branches (PLR0912) and too-many-statements (PLR0915) no longer needed. (C901 remains because the dispatch hub is inherently branchy; PLR0913 is untouched — public signature.)
- `run_map_episode`: input-resolution, safety error/fallback, and post-loop metrics phases extracted; the function retains its noqa (the episode step-loop + metadata-finalization phases remain inline and are the remaining decomposition surface — see "What remains").

New per-planner/per-phase helpers carry targeted noqlas only where the extracted unit is inherently branch/statement-heavy (e.g. `_build_guarded_ppo_policy`, `_build_socnav_family_adapter`), matching the repo's existing per-builder convention (`_preflight_policy`, `_scenario_identity_payload`, etc.). `_build_sonic_guarded_policy` and `_build_holonomic_world_velocity_policy` needed **no** complexity noqa.

## Extracted helpers

**`map_runner._build_policy` decomposition (policy construction per planner type + common tail):**
- `_resolve_planner_obs_mode` — dict-vs-attr `obs_mode` resolution (shared by ppo/sac)
- `_enforce_ppo_paper_profile` — PPO paper-profile gate check + raise
- `_build_predictive_mppi_policy`, `_build_external_mpc_policy` (shared SICNav/DR-MPC)
- `_build_ppo_policy`, `_build_sac_policy`, `_build_drl_vo_policy`
- `_build_guarded_ppo_policy`, `_build_sonic_guarded_policy`
- `_build_socnav_family_adapter` — classical/adapter dispatch (ORCA/HRVO, force models, SoNIC/GenSafeNav/CrowdNav, SACADRL, prediction, hybrid portfolios, NMPC, RVO/DWA, unknown-algorithm raise)
- `_HOLONOMIC_WORLD_VELOCITY_ALGO_KEYS`, `_is_holonomic_world_velocity_mode`, `_holonomic_world_velocity_boundary`
- `_build_holonomic_world_velocity_policy`
- `_build_common_adapter_policy` — shared adapter metadata finalization + bind-env + generic adapter closure

**`map_runner_episode.run_map_episode` decomposition (episode-loop phases + error/fallback paths):**
- `_EpisodeRunContext` + `_resolve_episode_run_context` — input normalization, env config, horizon/profile/policy-cfg resolution
- `_apply_safety_wrapper_step`, `_apply_cbf_safety_filter_step` — error/fallback paths (native/unsupported → raise or ineligible record; applied → correct command, tail preserved)
- `_EpisodePostLoopResult` + `_compute_post_loop_metrics` — trajectory stacking, visibility evidence, safety predicates, obstacle sampling, raw metrics
- `_build_tracking_precision_summary` — tracking-precision summary block

## Tests

New `tests/benchmark/test_map_runner_decomposition_helpers.py` (52 passed, 1 skipped) directly characterizes the extracted helpers' contracts, complementing the #4927 god-function baseline.

## Validation (CPU-only; no campaigns/Slurm/training/benchmark claims)

Run in an isolated worktree via `scripts/dev/run_worktree_shared_venv.sh` (shared main-checkout venv, `PYTHONPATH` pinned to the worktree):

```
# ruff + format on all changed files
ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_map_runner_decomposition_helpers.py  -> All checks passed!
ruff format --check <same>  -> 3 files already formatted

# #4927 characterization baseline (binding: zero edits)
pytest tests/benchmark/test_map_runner_characterization.py -q  -> 34 passed

# new decomposition-helper tests
pytest tests/benchmark/test_map_runner_decomposition_helpers.py -q  -> 52 passed, 1 skipped

# broad map_runner / planner / contract suite (end-to-end episode execution across planner types)
pytest tests/benchmark/test_map_runner_utils.py tests/test_map_runner_ppo.py tests/test_map_runner_sac.py \
  tests/benchmark/test_map_runner_diffusion_policy.py tests/benchmark/test_map_runner_hybrid_global_rl.py \
  tests/benchmark/test_map_runner_preflight_profiles.py tests/benchmark/test_map_runner_result_provenance.py \
  tests/benchmark/test_map_runner_view_integrity.py tests/benchmark/test_map_runner_safety_predicates.py \
  tests/benchmark/test_map_runner_distributional_rl.py tests/benchmark/test_map_runner_resume_identity.py \
  tests/benchmark/test_orca_preflight.py tests/benchmark/test_lidar_social_force_contract.py \
  tests/benchmark/test_planner_command_contract.py tests/benchmark/test_algorithm_metadata_contract.py \
  tests/benchmark/test_ammv_feasibility.py tests/benchmark/test_cbf_safety_filter_policy.py \
  tests/benchmark/test_cbf_safety_filter_runtime.py tests/benchmark/test_safety_wrapper_runtime.py \
  tests/benchmark/test_map_runner_episode_schema.py tests/tools/test_probe_python_rvo2_integration.py -q
  -> 484 passed, 1 skipped
```

Branch was rebased onto the latest `origin/main` (no conflicts; main did not touch the two decomposed files) and re-validated.

## What remains (partial slice)

This PR is a **partial slice** of #4944. The remaining decomposition surface (not done, to keep this PR reviewable and risk-bounded):

- `run_map_episode` episode **step loop** body (`for step_idx in range(horizon_val)`) — the largest remaining inline phase; extraction would require a loop-state bundle or returning many mutated locals.
- `run_map_episode` **metadata-finalization** phase (adapter-impact finalization, planner/decision/simulation traces, intent/VRU/actuation/latency/visibility summaries, shield metrics, `post_process_metrics`) — large and heavily intertwined with locals.
- `run_map_episode` **record assembly** phase (final `record` dict + provenance + event ledger).
- Removing the remaining `_build_policy` C901 noqa (complexity 14 → ≤10) and the `run_map_episode` noqlas (71 branches / 358 statements still inline).
- The single skipped test (`planner_selector_v2_diagnostic` direct-adapter construction needs a full candidate config; covered end-to-end by the #4927 baseline).

Each remaining phase is a natural follow-up commit; none change the behavior-preservation contract.

## Artifact handling

No `output/` artifacts produced. No campaigns, Slurm, training runs, or benchmark/paper claims. Change class: runtime code (refactor only, no semantic change) + tests; validation is the focused test suite above.

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Refs #4944


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved map-runner support for more policy types and planner configurations, including better handling of holonomic modes and PPO profile checks.
  * Episode runs now produce richer, more consistent tracking and safety metrics.

* **Bug Fixes**
  * Made command correction and safety filtering more reliable during episode execution.
  * Improved fallback behavior when planner settings or trajectory data are missing.

* **Tests**
  * Added coverage for policy selection, safety helpers, and post-episode metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->