### PR TITLE
Issue #4950: fix pre-existing robustness latents in map_runner (NaN min, obs_mode=None, return-type, sf provenance) (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -593,6 +593,10 @@ def _ppo_paper_gate_status(config: dict[str, Any]) -> tuple[bool, str | None]:
 def _resolve_planner_obs_mode(planner: Any, default: str) -> str:
     """Return the lowercased ``obs_mode`` from a planner config (dict or attribute).
 
+    An explicit ``None`` or empty value is normalized to ``default``. ``dict.get``
+    only substitutes ``default`` for a *missing* key, so an explicit ``obs_mode: None``
+    in config would otherwise stringify to ``"none"`` instead of the intended default.
+
     Args:
         planner: Planner exposing a ``config`` dict or attribute object.
         default: Fallback obs-mode when the planner config does not specify one.
@@ -602,8 +606,12 @@ def _resolve_planner_obs_mode(planner: Any, default: str) -> str:
     """
     planner_cfg = getattr(planner, "config", None)
     if isinstance(planner_cfg, dict):
-        return str(planner_cfg.get("obs_mode", default)).strip().lower()
-    return str(getattr(planner_cfg, "obs_mode", default)).strip().lower()
+        raw_obs_mode = planner_cfg.get("obs_mode", default)
+    else:
+        raw_obs_mode = getattr(planner_cfg, "obs_mode", default)
+    if raw_obs_mode is None or str(raw_obs_mode).strip() == "":
+        raw_obs_mode = default
+    return str(raw_obs_mode).strip().lower()
 
 
 def _enforce_ppo_paper_profile(
@@ -1764,7 +1772,7 @@ def _holonomic_world_velocity_boundary(algo_key: str) -> str:
             "selected world-frame velocity directly into the holonomic vx_vy benchmark "
             "action space."
         )
-    if algo_key == "social_force":
+    if algo_key in {"social_force", "sf"}:
         return (
             "Compute the local social-force translational command as a world-frame velocity "
             "vector, then forward that world-frame velocity directly into the holonomic "
@@ -2138,7 +2146,7 @@ def _build_policy(  # noqa: C901
     robot_kinematics: str | None = None,
     robot_command_mode: str | None = None,
     adapter_impact_eval: bool = False,
-) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+) -> tuple[Callable[[dict[str, Any]], Any], dict[str, Any]]:
     """Build an action policy and algorithm metadata for map-based benchmarking.
 
     Args:
@@ -2149,9 +2157,12 @@ def _build_policy(  # noqa: C901
         adapter_impact_eval: Whether to collect native-vs-adapter step counters.
 
     Returns:
-        tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
-        Policy callable and enriched metadata dictionary. For PPO, adapter-impact
-        counters are mutated in-place in the returned metadata during episode rollout.
+        tuple[Callable[[dict[str, Any]], Any], dict[str, Any]]:
+        Policy callable and enriched metadata dictionary. The callable's return payload
+        is intentionally ``Any`` because the holonomic world-velocity path returns a
+        ``dict[str, float | str]`` command while other paths return ``tuple[float, float]``.
+        For PPO, adapter-impact counters are mutated in-place in the returned metadata
+        during episode rollout.
     """
     algo_key = algo.lower().strip()
     meta: dict[str, Any] = {"algorithm": algo_key}

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -1074,6 +1074,23 @@ def _apply_cbf_safety_filter_step(
     return corrected, cbf_record
 
 
+def _min_finite_or_inf(values: list[float]) -> float:
+    """Return the minimum finite value, falling back to ``+inf`` when none are finite.
+
+    Non-finite entries (NaN, +inf, -inf) are filtered out so a stray NaN in the
+    per-step separation stream cannot produce order-dependent, non-deterministic
+    results from ``min()``. An empty or all-non-finite list yields ``+inf``.
+
+    Args:
+        values: Per-step float measurements (may contain non-finite values).
+
+    Returns:
+        float: The minimum finite value, or ``float("inf")`` when no finite value exists.
+    """
+    finite = [v for v in values if math.isfinite(v)]
+    return float(min(finite)) if finite else float("inf")
+
+
 def _build_tracking_precision_summary(
     *,
     spec: dict[str, Any],
@@ -1095,11 +1112,7 @@ def _build_tracking_precision_summary(
         "spec": spec,
         "hash": tracking_precision_hash(spec),
         "step_count": len(records),
-        "min_separation_corrupted_m": (
-            float(min(min_separation_corrupted_values))
-            if min_separation_corrupted_values
-            else float("inf")
-        ),
+        "min_separation_corrupted_m": _min_finite_or_inf(min_separation_corrupted_values),
         "contract_honored": (
             all(bool(record.get("contract_honored", False)) for record in records)
             if records

--- a/tests/benchmark/test_map_runner_decomposition_helpers.py
+++ b/tests/benchmark/test_map_runner_decomposition_helpers.py
@@ -12,9 +12,11 @@ stay green across further decomposition of the same helpers.
 
 from __future__ import annotations
 
+import math
 from types import SimpleNamespace
 from typing import Any
 
+import numpy as np
 import pytest
 
 from robot_sf.benchmark.cbf_safety_filter_runtime import CBFSafetyFilterRuntimeConfig
@@ -30,6 +32,7 @@ from robot_sf.benchmark.map_runner_episode import (
     _apply_cbf_safety_filter_step,
     _apply_safety_wrapper_step,
     _build_tracking_precision_summary,
+    _min_finite_or_inf,
 )
 from robot_sf.benchmark.safety_wrapper_runtime import SafetyWrapperRuntimeConfig
 
@@ -74,6 +77,7 @@ class TestHolonomicWorldVelocityHelpers:
             "hrvo",
             "socnav_hrvo",
             "social_force",
+            "sf",
             "social_navigation_pyenvs_orca",
             "social_nav_pyenvs_orca",
             "sonic_crowdnav",
@@ -100,6 +104,21 @@ class TestHolonomicWorldVelocityHelpers:
         assert "social-force" in _holonomic_world_velocity_boundary("social_force")
         assert "SoNIC" in _holonomic_world_velocity_boundary("sonic_crowdnav")
         assert "GenSafeNav Ours_GST" in _holonomic_world_velocity_boundary("gensafenav_ours_gst")
+
+    def test_sf_alias_yields_social_force_provenance(self) -> None:
+        """The ``sf`` alias must resolve to the social-force provenance string.
+
+        Regression for issue #4950 item 4: ``_HOLONOMIC_WORLD_VELOCITY_ALGO_KEYS``
+        treats ``sf`` as an alias of ``social_force``, so the boundary text must also
+        resolve it to the social-force description instead of falling through to the
+        generic Social-Navigation-PyEnvs text.
+        """
+        sf_boundary = _holonomic_world_velocity_boundary("sf")
+        social_force_boundary = _holonomic_world_velocity_boundary("social_force")
+        assert sf_boundary == social_force_boundary
+        assert "social-force" in sf_boundary
+        # It must NOT fall through to the generic SocNav-PyEnvs force-model text.
+        assert "Social-Navigation-PyEnvs" not in sf_boundary
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +150,25 @@ class TestPlannerObsModeAndPaperGate:
         """A planner with no config attribute must fall back to the default."""
         planner = SimpleNamespace(spec=1)
         assert _resolve_planner_obs_mode(planner, "vector") == "vector"
+
+    def test_resolve_obs_mode_normalizes_explicit_none_to_default(self) -> None:
+        """An explicit ``obs_mode: None`` must normalize to the default, not ``"none"``.
+
+        Regression for issue #4950 item 2: ``dict.get`` only substitutes the default
+        for a *missing* key, so an explicit ``None`` would stringify to ``"none"``.
+        Both dict and attribute configs must coerce ``None`` to the supplied default.
+        """
+        dict_planner = SimpleNamespace(config={"obs_mode": None})
+        assert _resolve_planner_obs_mode(dict_planner, "vector") == "vector"
+        attr_planner = SimpleNamespace(config=SimpleNamespace(obs_mode=None))
+        assert _resolve_planner_obs_mode(attr_planner, "dict") == "dict"
+
+    def test_resolve_obs_mode_normalizes_empty_string_to_default(self) -> None:
+        """An explicit empty/whitespace ``obs_mode`` must normalize to the default."""
+        dict_planner = SimpleNamespace(config={"obs_mode": "   "})
+        assert _resolve_planner_obs_mode(dict_planner, "vector") == "vector"
+        attr_planner = SimpleNamespace(config=SimpleNamespace(obs_mode=""))
+        assert _resolve_planner_obs_mode(attr_planner, "Dict") == "dict"
 
     def test_paper_gate_passes_for_experimental_profile(self) -> None:
         """An experimental profile must pass the gate with no reason."""
@@ -216,6 +254,29 @@ class TestBuildPolicyUsesDecomposedHelpers:
         assert meta["algorithm"] == "orca"
         assert meta["status"] == "ok"
 
+    def test_holonomic_path_returns_dict_command_payload(self) -> None:
+        """The holonomic world-velocity path must return a dict (not tuple[float, float]).
+
+        Regression for issue #4950 item 3: ``_build_policy`` is annotated to return a
+        ``tuple[float, float]`` command callable, but the holonomic world-velocity path
+        returns a ``dict[str, float | str]`` command payload. The annotation was widened
+        to ``Callable[..., Any]``; this test exercises the dict-returning path so the
+        widening stays justified and the holonomic policy stays callable end-to-end.
+        """
+        policy, meta = _build_policy(
+            "social_force",
+            {},
+            robot_kinematics="holonomic",
+            robot_command_mode="vx_vy",
+        )
+        assert meta["algorithm"] == "social_force"
+        assert meta["status"] == "ok"
+        command = policy({"goal_in_robot_frame": np.array([5.0, 0.0, 0.0], dtype=float)})
+        # The holonomic path returns a dict command payload, not a (v, w) tuple.
+        assert isinstance(command, dict)
+        assert command["command_kind"] == "holonomic_vxy_world"
+        assert {"vx", "vy"}.issubset(command.keys())
+
 
 # ---------------------------------------------------------------------------
 # map_runner_episode: tracking-precision summary helper
@@ -255,6 +316,37 @@ class TestTrackingPrecisionSummary:
         assert summary["contract_honored_rate"] == pytest.approx(2 / 3)
         assert summary["min_separation_corrupted_m"] == 0.25
         assert summary["last_step"] == {"contract_honored": True, "step": 2}
+
+    def test_min_finite_filters_nan_and_nonfinite(self) -> None:
+        """The finite-filter helper must ignore NaN/inf and return the min finite value.
+
+        Regression for issue #4950 item 1: an unfiltered ``min()`` over a list
+        containing NaN is order-dependent and non-deterministic.
+        """
+        # NaN present alongside a finite value must not propagate.
+        assert _min_finite_or_inf([float("nan"), 0.5, 0.25]) == 0.25
+        # Order independence: NaN-first must give the same answer as NaN-last.
+        assert _min_finite_or_inf([float("nan"), 0.5]) == 0.5
+        assert _min_finite_or_inf([0.5, float("nan")]) == 0.5
+        # +inf and -inf must be filtered out too.
+        assert _min_finite_or_inf([float("inf"), float("-inf"), 1.0]) == 1.0
+        # All-non-finite must fall back to +inf.
+        assert _min_finite_or_inf([float("nan"), float("inf")]) == float("inf")
+        assert math.isinf(_min_finite_or_inf([float("nan"), float("inf")]))
+
+    def test_min_finite_empty_yields_inf(self) -> None:
+        """An empty list must yield +inf."""
+        assert _min_finite_or_inf([]) == float("inf")
+
+    def test_summary_ignores_nan_in_min_separation_stream(self) -> None:
+        """The summary must compute min_separation_corrupted_m from finite values only."""
+        records = [{"contract_honored": True, "step": 0}]
+        summary = _build_tracking_precision_summary(
+            spec={"enabled": True, "target_motp_m": 0.05},
+            records=records,
+            min_separation_corrupted_values=[float("nan"), 0.8, 0.4],
+        )
+        assert summary["min_separation_corrupted_m"] == 0.4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What / Why

Fixes all four pre-existing latent robustness issues in `robot_sf/benchmark/map_runner.py` and `map_runner_episode.py` catalogued in issue #4950. These were surfaced by review bots on PR #4949 (the #4944 god-function decomposition), which was intentionally **behavior-preserving** — so these behavior-changing fixes were deferred there and fixed here.

Each item was verified to exist identically in `origin/main` before the refactor. Evidence status: **diagnostic-only** (pre-existing behavior; no benchmark/paper/metric-semantics claim). Not release-blocking.

## Changes

### 1. [HIGH] `min_separation_corrupted_m` NaN filter — `map_runner_episode.py`
`float(min(min_separation_corrupted_values))` did not filter non-finite values; a `NaN` in the per-step separation stream yielded order-dependent, non-deterministic results. Added `_min_finite_or_inf()` helper that filters with `math.isfinite` before `min()`, falling back to `float("inf")` when empty/all-non-finite. `_build_tracking_precision_summary` now calls it.

Empirical red/green: `min([nan, 0.5, 0.25])` → `nan` (old) vs `0.25` (new).

### 2. [HIGH] `obs_mode` null coercion → `"none"` — `map_runner.py` `_resolve_planner_obs_mode`
`str(planner_cfg.get("obs_mode", default))` returned the string `"none"` when `obs_mode` was explicitly `None` in config (`.get` default only applies to a missing key). Now normalizes `None`/empty/whitespace to the supplied default before `str().strip().lower()`. All three call sites (PPO/SAC/holonomic) route through this helper.

Empirical red/green: `obs_mode=None` → `"none"` (old) vs `"vector"` (new).

### 3. [MEDIUM] `_build_policy` return annotation too narrow — `map_runner.py`
Annotated `-> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]`, but the holonomic world-velocity path returns `dict[str, float | str]`. Widened the callable return to `Any` (matching `_build_common_adapter_policy`). **No runtime change.**

### 4. [MINOR] `"sf"` alias provenance — `map_runner.py` `_holonomic_world_velocity_boundary`
`_HOLONOMIC_WORLD_VELOCITY_ALGO_KEYS` treats `"sf"` as an alias of `"social_force"`, but the boundary/provenance text only matched `algo_key == "social_force"`, so `"sf"` fell through to the generic Social-Navigation-PyEnvs text — wrong provenance for the native `SocialForcePlannerAdapter`. Now matches `algo_key in {"social_force", "sf"}`.

Empirical red/green: `_holonomic_world_velocity_boundary("sf")` → generic PyEnvs text without "social-force" (old) vs identical to `"social_force"` provenance (new).

## Validation (CPU-only)

```
# Focused regression tests (this issue) — 60 passed, 1 pre-existing skip
pytest tests/benchmark/test_map_runner_decomposition_helpers.py -q  =>  60 passed, 1 skipped

# Behavior-preserving guards: characterization baseline (#4927) + social_force/ppo/sac
pytest tests/benchmark/test_map_runner_characterization.py \
       tests/integration/test_social_force_map_runner.py \
       tests/test_map_runner_ppo.py tests/test_map_runner_sac.py -q  =>  51 passed

# Lint/format on changed files
ruff check  <changed files>  =>  All checks passed!
ruff format --check <changed files>  =>  3 files already formatted
```

No campaigns, no Slurm, no training runs, no benchmark/paper claims. Each new test was confirmed to catch the original bug (NaN propagation, `obs_mode=None`→`"none"`, `sf` fall-through).

## Acceptance (from issue)

- [x] Item 1 — finite-filter regression test
- [x] Item 2 — explicit `obs_mode=None` → default regression test
- [x] Item 3 — annotation widened; no runtime change
- [x] Item 4 — `"sf"` produces the social-force provenance string; covered by a test

This is not a successor slice — no prior PR merged a slice of this issue. It fully resolves #4950.

Closes #4950

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
