### PR TITLE
Issue #4944: extract run_map_episode step-loop + finalization phases (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -1444,94 +1444,52 @@ def _compute_post_loop_metrics(  # noqa: PLR0913
     )
 
 
-def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
-    scenario: dict[str, Any],
-    seed: int,
+@dataclass(frozen=True, slots=True)
+class _PolicyContract:
+    """Resolved policy callable, planner lifecycle hooks, and observation contract.
+
+    Bundles the policy/observation-contract preparation phase of ``run_map_episode``
+    so the step-loop and metadata-finalization phases receive a single immutable
+    object instead of recomputing these inline.
+    """
+
+    policy_fn: Any
+    algo_meta: dict[str, Any]
+    planner_close: Any
+    planner_reset: Any
+    planner_bind_env: Any
+    planner_stats: Any
+    planner_native_action: bool
+    actuation_controller: Any
+    active_observation_mode: str
+    active_observation_level: str
+    single_pedestrian_intent_metadata: Any
+    single_pedestrian_vru_metadata: Any
+
+
+def _prepare_policy_and_observation_contract(  # noqa: PLR0913
     *,
-    horizon: int | None,
-    dt: float | None,
-    record_forces: bool,
-    snqi_weights: dict[str, float] | None,
-    snqi_baseline: dict[str, dict[str, float]] | None,
+    scenario: dict[str, Any],
     algo: str,
-    scenario_path: Path,
-    algo_config: dict[str, Any] | None = None,
-    algo_config_path: str | None = None,
-    adapter_impact_eval: bool = False,
-    experimental_ped_impact: bool = False,
-    ped_impact_radius_m: float = 2.0,
-    ped_impact_window_steps: int = 5,
-    observation_mode: str | None = None,
-    observation_level: str | None = None,
-    benchmark_track: str | None = None,
-    track_schema_version: str | None = None,
-    observation_noise: dict[str, Any] | None = None,
-    tracking_precision: dict[str, Any] | None = None,
-    synthetic_actuation_profile: dict[str, Any] | None = None,
-    latency_stress_profile: dict[str, Any] | None = None,
-    safety_wrapper: dict[str, Any] | None = None,
-    cbf_safety_filter: dict[str, Any] | None = None,
-    record_planner_decision_trace: bool = False,
-    record_simulation_step_trace: bool = False,
+    policy_cfg: dict[str, Any],
+    config: Any,
+    observation_mode: str | None,
+    observation_level: str | None,
+    robot_kinematics: str,
+    robot_command_mode: str,
+    adapter_impact_eval: bool,
+    benchmark_track: str | None,
+    track_schema_version: str | None,
+    actuation_profile: Any,
     policy_builder: PolicyBuilder,
-) -> dict[str, Any]:
-    """Run one scenario/seed episode and return a benchmark JSONL record.
+) -> _PolicyContract:
+    """Resolve the learned observation contract, build the policy, and derive hooks.
 
     Returns:
-        dict[str, Any]: Episode record with metrics, provenance, and planner metadata.
+        _PolicyContract: Immutable bundle of the policy callable, enriched algorithm
+        metadata, planner lifecycle hooks, the synthetic-actuation controller, and the
+        active observation mode/level plus single-pedestrian intent/VRU metadata.
     """
-    ctx = _resolve_episode_run_context(
-        scenario=scenario,
-        seed=seed,
-        horizon=horizon,
-        dt=dt,
-        algo=algo,
-        scenario_path=scenario_path,
-        algo_config=algo_config,
-        algo_config_path=algo_config_path,
-        experimental_ped_impact=experimental_ped_impact,
-        ped_impact_radius_m=ped_impact_radius_m,
-        ped_impact_window_steps=ped_impact_window_steps,
-        observation_mode=observation_mode,
-        observation_level=observation_level,
-        benchmark_track=benchmark_track,
-        track_schema_version=track_schema_version,
-        observation_noise=observation_noise,
-        tracking_precision=tracking_precision,
-        synthetic_actuation_profile=synthetic_actuation_profile,
-        latency_stress_profile=latency_stress_profile,
-        safety_wrapper=safety_wrapper,
-        cbf_safety_filter=cbf_safety_filter,
-    )
-    scenario = ctx.scenario
-    scenario_id = ctx.scenario_id
-    ts_start = ctx.ts_start
-    start_time = ctx.start_time
-    ped_impact_radius_m = ctx.ped_impact_radius_m
-    ped_impact_window_steps = ctx.ped_impact_window_steps
-    benchmark_track = ctx.benchmark_track
-    track_schema_version = ctx.track_schema_version
-    noise_spec = ctx.noise_spec
-    noise_rng = ctx.noise_rng
-    noise_state = ctx.noise_state
-    noise_stats = ctx.noise_stats
-    tracking_precision_spec = ctx.tracking_precision_spec
-    tracking_precision_rng = ctx.tracking_precision_rng
-    safety_wrapper_runtime = ctx.safety_wrapper_runtime
-    cbf_runtime = ctx.cbf_runtime
-    safety_wrapper_deadlock_monitor = ctx.safety_wrapper_deadlock_monitor
-    config = ctx.config
-    horizon_val = ctx.horizon_val
-    robot_kinematics = ctx.robot_kinematics
-    actuation_profile = ctx.actuation_profile
-    latency_profile = ctx.latency_profile
-    robot_command_mode = ctx.robot_command_mode
-    algo = ctx.algo
-    policy_cfg = ctx.policy_cfg
-    tracking_precision_records: list[dict[str, Any]] = []
-    safety_wrapper_trace: list[dict[str, Any]] = []
-    cbf_filter_trace: list[dict[str, Any]] = []
-    min_separation_corrupted_values: list[float] = []
     learned_observation_contract = resolve_learned_checkpoint_observation_contract(
         algo,
         policy_cfg,
@@ -1587,8 +1545,6 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     planner_bind_env = getattr(policy_fn, "_planner_bind_env", None)
     planner_stats = getattr(policy_fn, "_planner_stats", None)
     planner_native_action = getattr(policy_fn, "_planner_native_env_action", False)
-
-    planner_runtime_snapshot: dict[str, Any] | None = None
     actuation_controller = (
         SyntheticActuationController(
             profile=actuation_profile, dt=config.sim_config.time_per_step_in_secs
@@ -1596,8 +1552,109 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         if actuation_profile is not None
         else None
     )
+    single_pedestrian_intent_metadata = _single_pedestrian_intent_metadata(scenario)
+    single_pedestrian_vru_metadata = _single_pedestrian_vru_metadata(scenario)
+
+    return _PolicyContract(
+        policy_fn=policy_fn,
+        algo_meta=algo_meta,
+        planner_close=planner_close,
+        planner_reset=planner_reset,
+        planner_bind_env=planner_bind_env,
+        planner_stats=planner_stats,
+        planner_native_action=planner_native_action,
+        actuation_controller=actuation_controller,
+        active_observation_mode=active_observation_mode,
+        active_observation_level=active_observation_level,
+        single_pedestrian_intent_metadata=single_pedestrian_intent_metadata,
+        single_pedestrian_vru_metadata=single_pedestrian_vru_metadata,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _EpisodeStepLoopResult:
+    """All outputs of the episode step-loop phase of ``run_map_episode``.
+
+    Bundles the trajectory position/heading/force lists, visibility evidence
+    traces, per-step instrumentation traces, collision/termination outcome flags,
+    the final map_def/goal_vec, the effective-view integrity probe result, and the
+    planner runtime snapshot captured at teardown.
+    """
+
+    map_def: Any
+    goal_vec: np.ndarray
+    initial_robot_pos: np.ndarray
+    initial_goal_distance: float
+    reached_goal_step: int | None
+    termination_reason: str
+    collision_seen: bool
+    ped_collision_seen: bool
+    obstacle_collision_seen: bool
+    robot_collision_seen: bool
+    timeout_seen: bool
+    collision_events: list[dict[str, Any]]
+    robot_positions: list[np.ndarray]
+    robot_headings: list[float]
+    ped_positions: list[np.ndarray]
+    ped_forces: list[np.ndarray]
+    visibility_trace: list[np.ndarray | None]
+    track_confidence_trace: list[np.ndarray | None]
+    visibility_evidence_statuses: list[str]
+    visibility_evidence_reasons: list[str | None]
+    tracking_precision_records: list[dict[str, Any]]
+    min_separation_corrupted_values: list[float]
+    safety_wrapper_trace: list[dict[str, Any]]
+    cbf_filter_trace: list[dict[str, Any]]
+    ammv_command_actions: list[dict[str, Any]]
+    synthetic_actuation_trace: list[dict[str, Any]]
+    planner_decision_trace: list[dict[str, Any]]
+    simulation_step_trace: list[dict[str, Any]]
+    view_integrity: dict[str, Any] | None
+    planner_runtime_snapshot: dict[str, Any] | None
+
+
+def _run_episode_step_loop(  # noqa: C901,PLR0912,PLR0913,PLR0915
+    *,
+    seed: int,
+    config: Any,
+    horizon_val: int,
+    policy_fn: Any,
+    planner_bind_env: Any,
+    planner_reset: Any,
+    planner_close: Any,
+    planner_stats: Any,
+    planner_native_action: bool,
+    noise_spec: dict[str, Any],
+    noise_rng: Any,
+    noise_state: Any,
+    noise_stats: Any,
+    tracking_precision_spec: dict[str, Any],
+    tracking_precision_rng: Any,
+    safety_wrapper_runtime: Any,
+    safety_wrapper_deadlock_monitor: Any,
+    cbf_runtime: Any,
+    actuation_controller: Any,
+    algo_meta: dict[str, Any],
+    record_forces: bool,
+    record_planner_decision_trace: bool,
+    record_simulation_step_trace: bool,
+    single_pedestrian_intent_metadata: Any,
+    single_pedestrian_vru_metadata: Any,
+) -> _EpisodeStepLoopResult:
+    """Run the env reset, the per-step episode loop, and planner/env teardown.
+
+    Returns:
+        _EpisodeStepLoopResult: Immutable bundle of every trajectory, trace, and
+        outcome flag produced by the step loop, plus the planner runtime snapshot
+        captured in the ``finally`` teardown.
+    """
+    # Per-episode instrumentation buffers (populated during the step loop below).
+    tracking_precision_records: list[dict[str, Any]] = []
+    safety_wrapper_trace: list[dict[str, Any]] = []
+    cbf_filter_trace: list[dict[str, Any]] = []
+    min_separation_corrupted_values: list[float] = []
+    planner_runtime_snapshot: dict[str, Any] | None = None
     current_command = (0.0, 0.0)
-    actuation_summary: dict[str, Any] = not_available_saturation_metrics()
     synthetic_actuation_trace: list[dict[str, Any]] = []
     planner_decision_trace: list[dict[str, Any]] = []
     simulation_step_trace: list[dict[str, Any]] = []
@@ -1605,9 +1662,6 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     track_confidence_trace: list[np.ndarray | None] = []
     visibility_evidence_statuses: list[str] = []
     visibility_evidence_reasons: list[str | None] = []
-    single_pedestrian_intent_metadata = _single_pedestrian_intent_metadata(scenario)
-    single_pedestrian_vru_metadata = _single_pedestrian_vru_metadata(scenario)
-
     env = make_robot_env(config=config, seed=int(seed), debug=False)
     try:
         obs, _ = env.reset(seed=int(seed))
@@ -2021,7 +2075,19 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 logger.debug("Planner close hook failed", exc_info=True)
         env.close()
 
-    post_loop = _compute_post_loop_metrics(
+    return _EpisodeStepLoopResult(
+        map_def=map_def,
+        goal_vec=goal_vec,
+        initial_robot_pos=initial_robot_pos,
+        initial_goal_distance=initial_goal_distance,
+        reached_goal_step=reached_goal_step,
+        termination_reason=termination_reason,
+        collision_seen=collision_seen,
+        ped_collision_seen=ped_collision_seen,
+        obstacle_collision_seen=obstacle_collision_seen,
+        robot_collision_seen=robot_collision_seen,
+        timeout_seen=timeout_seen,
+        collision_events=collision_events,
         robot_positions=robot_positions,
         robot_headings=robot_headings,
         ped_positions=ped_positions,
@@ -2030,21 +2096,83 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         track_confidence_trace=track_confidence_trace,
         visibility_evidence_statuses=visibility_evidence_statuses,
         visibility_evidence_reasons=visibility_evidence_reasons,
-        reached_goal_step=reached_goal_step,
-        collision_seen=collision_seen,
-        ped_collision_seen=ped_collision_seen,
-        obstacle_collision_seen=obstacle_collision_seen,
-        robot_collision_seen=robot_collision_seen,
-        map_def=map_def,
-        goal_vec=goal_vec,
-        scenario=scenario,
-        config=config,
-        horizon_val=horizon_val,
-        record_forces=record_forces,
-        experimental_ped_impact=experimental_ped_impact,
-        ped_impact_radius_m=ped_impact_radius_m,
-        ped_impact_window_steps=ped_impact_window_steps,
+        tracking_precision_records=tracking_precision_records,
+        min_separation_corrupted_values=min_separation_corrupted_values,
+        safety_wrapper_trace=safety_wrapper_trace,
+        cbf_filter_trace=cbf_filter_trace,
+        ammv_command_actions=ammv_command_actions,
+        synthetic_actuation_trace=synthetic_actuation_trace,
+        planner_decision_trace=planner_decision_trace,
+        simulation_step_trace=simulation_step_trace,
+        view_integrity=view_integrity,
+        planner_runtime_snapshot=planner_runtime_snapshot,
     )
+
+
+def _finalize_episode_record(  # noqa: C901,PLR0912,PLR0913,PLR0915
+    *,
+    ctx: _EpisodeRunContext,
+    loop_result: _EpisodeStepLoopResult,
+    post_loop: _EpisodePostLoopResult,
+    algo_meta: dict[str, Any],
+    actuation_controller: Any,
+    active_observation_mode: str,
+    active_observation_level: str,
+    single_pedestrian_intent_metadata: Any,
+    single_pedestrian_vru_metadata: Any,
+    seed: int,
+    horizon: int | None,
+    dt: float | None,
+    safety_wrapper: dict[str, Any] | None,
+    cbf_safety_filter: dict[str, Any] | None,
+    snqi_weights: dict[str, float] | None,
+    snqi_baseline: dict[str, dict[str, float]] | None,
+    record_forces: bool,
+    record_planner_decision_trace: bool,
+    record_simulation_step_trace: bool,
+) -> dict[str, Any]:
+    """Assemble the benchmark JSONL record from the step-loop and post-loop results.
+
+    Returns:
+        dict[str, Any]: The finalized episode record with metrics, provenance, and
+        planner metadata, mirroring the prior inline metadata-finalization phase.
+    """
+    scenario = ctx.scenario
+    scenario_id = ctx.scenario_id
+    ts_start = ctx.ts_start
+    start_time = ctx.start_time
+    benchmark_track = ctx.benchmark_track
+    track_schema_version = ctx.track_schema_version
+    noise_spec = ctx.noise_spec
+    noise_stats = ctx.noise_stats
+    tracking_precision_spec = ctx.tracking_precision_spec
+    safety_wrapper_runtime = ctx.safety_wrapper_runtime
+    cbf_runtime = ctx.cbf_runtime
+    config = ctx.config
+    horizon_val = ctx.horizon_val
+    robot_kinematics = ctx.robot_kinematics
+    actuation_profile = ctx.actuation_profile
+    latency_profile = ctx.latency_profile
+    algo = ctx.algo
+    policy_cfg = ctx.policy_cfg
+    ammv_command_actions = loop_result.ammv_command_actions
+    planner_runtime_snapshot = loop_result.planner_runtime_snapshot
+    planner_decision_trace = loop_result.planner_decision_trace
+    simulation_step_trace = loop_result.simulation_step_trace
+    tracking_precision_records = loop_result.tracking_precision_records
+    min_separation_corrupted_values = loop_result.min_separation_corrupted_values
+    safety_wrapper_trace = loop_result.safety_wrapper_trace
+    cbf_filter_trace = loop_result.cbf_filter_trace
+    synthetic_actuation_trace = loop_result.synthetic_actuation_trace
+    initial_goal_distance = loop_result.initial_goal_distance
+    reached_goal_step = loop_result.reached_goal_step
+    termination_reason = loop_result.termination_reason
+    collision_seen = loop_result.collision_seen
+    timeout_seen = loop_result.timeout_seen
+    goal_vec = loop_result.goal_vec
+    view_integrity = loop_result.view_integrity
+    collision_events = loop_result.collision_events
+    actuation_summary: dict[str, Any] = not_available_saturation_metrics()
     robot_pos_arr = post_loop.robot_pos_arr
     robot_vel_arr = post_loop.robot_vel_arr
     ped_pos_arr = post_loop.ped_pos_arr
@@ -2348,6 +2476,175 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     }
     ensure_metric_parameters(record)
     return record
+
+
+def run_map_episode(  # noqa: PLR0913
+    scenario: dict[str, Any],
+    seed: int,
+    *,
+    horizon: int | None,
+    dt: float | None,
+    record_forces: bool,
+    snqi_weights: dict[str, float] | None,
+    snqi_baseline: dict[str, dict[str, float]] | None,
+    algo: str,
+    scenario_path: Path,
+    algo_config: dict[str, Any] | None = None,
+    algo_config_path: str | None = None,
+    adapter_impact_eval: bool = False,
+    experimental_ped_impact: bool = False,
+    ped_impact_radius_m: float = 2.0,
+    ped_impact_window_steps: int = 5,
+    observation_mode: str | None = None,
+    observation_level: str | None = None,
+    benchmark_track: str | None = None,
+    track_schema_version: str | None = None,
+    observation_noise: dict[str, Any] | None = None,
+    tracking_precision: dict[str, Any] | None = None,
+    synthetic_actuation_profile: dict[str, Any] | None = None,
+    latency_stress_profile: dict[str, Any] | None = None,
+    safety_wrapper: dict[str, Any] | None = None,
+    cbf_safety_filter: dict[str, Any] | None = None,
+    record_planner_decision_trace: bool = False,
+    record_simulation_step_trace: bool = False,
+    policy_builder: PolicyBuilder,
+) -> dict[str, Any]:
+    """Run one scenario/seed episode and return a benchmark JSONL record.
+
+    Returns:
+        dict[str, Any]: Episode record with metrics, provenance, and planner metadata.
+    """
+    ctx = _resolve_episode_run_context(
+        scenario=scenario,
+        seed=seed,
+        horizon=horizon,
+        dt=dt,
+        algo=algo,
+        scenario_path=scenario_path,
+        algo_config=algo_config,
+        algo_config_path=algo_config_path,
+        experimental_ped_impact=experimental_ped_impact,
+        ped_impact_radius_m=ped_impact_radius_m,
+        ped_impact_window_steps=ped_impact_window_steps,
+        observation_mode=observation_mode,
+        observation_level=observation_level,
+        benchmark_track=benchmark_track,
+        track_schema_version=track_schema_version,
+        observation_noise=observation_noise,
+        tracking_precision=tracking_precision,
+        synthetic_actuation_profile=synthetic_actuation_profile,
+        latency_stress_profile=latency_stress_profile,
+        safety_wrapper=safety_wrapper,
+        cbf_safety_filter=cbf_safety_filter,
+    )
+    scenario = ctx.scenario
+    ped_impact_radius_m = ctx.ped_impact_radius_m
+    ped_impact_window_steps = ctx.ped_impact_window_steps
+    benchmark_track = ctx.benchmark_track
+    track_schema_version = ctx.track_schema_version
+    noise_spec = ctx.noise_spec
+    noise_rng = ctx.noise_rng
+    noise_state = ctx.noise_state
+    noise_stats = ctx.noise_stats
+    tracking_precision_spec = ctx.tracking_precision_spec
+    tracking_precision_rng = ctx.tracking_precision_rng
+    safety_wrapper_runtime = ctx.safety_wrapper_runtime
+    cbf_runtime = ctx.cbf_runtime
+    safety_wrapper_deadlock_monitor = ctx.safety_wrapper_deadlock_monitor
+    config = ctx.config
+    horizon_val = ctx.horizon_val
+    robot_kinematics = ctx.robot_kinematics
+    actuation_profile = ctx.actuation_profile
+    robot_command_mode = ctx.robot_command_mode
+    algo = ctx.algo
+    policy_cfg = ctx.policy_cfg
+    policy_contract = _prepare_policy_and_observation_contract(
+        scenario=scenario,
+        algo=algo,
+        policy_cfg=policy_cfg,
+        config=config,
+        observation_mode=observation_mode,
+        observation_level=observation_level,
+        robot_kinematics=robot_kinematics,
+        robot_command_mode=robot_command_mode,
+        adapter_impact_eval=adapter_impact_eval,
+        benchmark_track=benchmark_track,
+        track_schema_version=track_schema_version,
+        actuation_profile=actuation_profile,
+        policy_builder=policy_builder,
+    )
+    loop_result = _run_episode_step_loop(
+        seed=seed,
+        config=config,
+        horizon_val=horizon_val,
+        policy_fn=policy_contract.policy_fn,
+        planner_bind_env=policy_contract.planner_bind_env,
+        planner_reset=policy_contract.planner_reset,
+        planner_close=policy_contract.planner_close,
+        planner_stats=policy_contract.planner_stats,
+        planner_native_action=policy_contract.planner_native_action,
+        noise_spec=noise_spec,
+        noise_rng=noise_rng,
+        noise_state=noise_state,
+        noise_stats=noise_stats,
+        tracking_precision_spec=tracking_precision_spec,
+        tracking_precision_rng=tracking_precision_rng,
+        safety_wrapper_runtime=safety_wrapper_runtime,
+        safety_wrapper_deadlock_monitor=safety_wrapper_deadlock_monitor,
+        cbf_runtime=cbf_runtime,
+        actuation_controller=policy_contract.actuation_controller,
+        algo_meta=policy_contract.algo_meta,
+        record_forces=record_forces,
+        record_planner_decision_trace=record_planner_decision_trace,
+        record_simulation_step_trace=record_simulation_step_trace,
+        single_pedestrian_intent_metadata=policy_contract.single_pedestrian_intent_metadata,
+        single_pedestrian_vru_metadata=policy_contract.single_pedestrian_vru_metadata,
+    )
+    post_loop = _compute_post_loop_metrics(
+        robot_positions=loop_result.robot_positions,
+        robot_headings=loop_result.robot_headings,
+        ped_positions=loop_result.ped_positions,
+        ped_forces=loop_result.ped_forces,
+        visibility_trace=loop_result.visibility_trace,
+        track_confidence_trace=loop_result.track_confidence_trace,
+        visibility_evidence_statuses=loop_result.visibility_evidence_statuses,
+        visibility_evidence_reasons=loop_result.visibility_evidence_reasons,
+        reached_goal_step=loop_result.reached_goal_step,
+        collision_seen=loop_result.collision_seen,
+        ped_collision_seen=loop_result.ped_collision_seen,
+        obstacle_collision_seen=loop_result.obstacle_collision_seen,
+        robot_collision_seen=loop_result.robot_collision_seen,
+        map_def=loop_result.map_def,
+        goal_vec=loop_result.goal_vec,
+        scenario=scenario,
+        config=config,
+        horizon_val=horizon_val,
+        record_forces=record_forces,
+        experimental_ped_impact=experimental_ped_impact,
+        ped_impact_radius_m=ped_impact_radius_m,
+        ped_impact_window_steps=ped_impact_window_steps,
+    )
+    return _finalize_episode_record(
+        ctx=ctx,
+        loop_result=loop_result,
+        post_loop=post_loop,
+        algo_meta=policy_contract.algo_meta,
+        actuation_controller=policy_contract.actuation_controller,
+        active_observation_mode=policy_contract.active_observation_mode,
+        active_observation_level=policy_contract.active_observation_level,
+        single_pedestrian_intent_metadata=policy_contract.single_pedestrian_intent_metadata,
+        single_pedestrian_vru_metadata=policy_contract.single_pedestrian_vru_metadata,
+        seed=seed,
+        horizon=horizon,
+        dt=dt,
+        safety_wrapper=safety_wrapper,
+        cbf_safety_filter=cbf_safety_filter,
+        snqi_weights=snqi_weights,
+        snqi_baseline=snqi_baseline,
+        record_forces=record_forces,
+        record_planner_decision_trace=record_planner_decision_trace,
+        record_simulation_step_trace=record_simulation_step_trace,
+    )
 
 
 __all__ = ["run_map_episode"]

--- a/tests/benchmark/test_map_runner_decomposition_helpers.py
+++ b/tests/benchmark/test_map_runner_decomposition_helpers.py
@@ -12,9 +12,11 @@ stay green across further decomposition of the same helpers.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import numpy as np
 import pytest
 
 from robot_sf.benchmark.cbf_safety_filter_runtime import CBFSafetyFilterRuntimeConfig
@@ -30,6 +32,11 @@ from robot_sf.benchmark.map_runner_episode import (
     _apply_cbf_safety_filter_step,
     _apply_safety_wrapper_step,
     _build_tracking_precision_summary,
+    _compute_post_loop_metrics,
+    _finalize_episode_record,
+    _prepare_policy_and_observation_contract,
+    _resolve_episode_run_context,
+    _run_episode_step_loop,
 )
 from robot_sf.benchmark.safety_wrapper_runtime import SafetyWrapperRuntimeConfig
 
@@ -451,3 +458,275 @@ class TestCbfSafetyFilterStepHelper:
             mod.apply_runtime_cbf_safety_filter = original
         assert command == (0.3, -0.1, "tail")
         assert record == {"filtered": True, "step_idx": 4}
+
+
+# ---------------------------------------------------------------------------
+# map_runner_episode: policy-contract / step-loop / record-finalization helpers
+#
+# The successor slice of issue #4944 extracts the episode step-loop and
+# metadata-finalization phases out of ``run_map_episode``. These tests pin the
+# three new single-responsibility helpers directly: the policy-contract builder,
+# the step-loop runner, and the record finalizer. The #4927 baseline still pins
+# the god-function behavior end-to-end; these pin the extracted units.
+# ---------------------------------------------------------------------------
+
+
+def _stub_config() -> SimpleNamespace:
+    """Build a minimal config stub matching the characterization fixtures."""
+    from robot_sf.robot.differential_drive import DifferentialDriveSettings
+
+    return SimpleNamespace(
+        sim_config=SimpleNamespace(time_per_step_in_secs=0.1, ped_radius=0.4),
+        robot_config=DifferentialDriveSettings(max_linear_speed=2.0),
+    )
+
+
+class _StepLoopDummySim:
+    """Simulator stub exposing the attributes read by the step-loop phase."""
+
+    def __init__(self) -> None:
+        self.robot_pos = [np.array([0.0, 0.0], dtype=float)]
+        self.ped_pos = np.zeros((0, 2), dtype=float)
+        self.goal_pos = [np.array([1.0, 1.0], dtype=float)]
+        self.map_def = None
+        self.last_ped_forces = np.zeros((0, 2), dtype=float)
+
+
+class _StepLoopDummyEnv:
+    """Environment stub for direct step-loop helper tests."""
+
+    def __init__(self) -> None:
+        self.simulator = _StepLoopDummySim()
+
+    def reset(self, seed: int | None = None):
+        obs = {"robot": {"position": [0.0, 0.0]}, "goal": {"current": [1.0, 1.0]}}
+        return obs, {}
+
+    def step(self, action):
+        obs = {"robot": {"position": [0.0, 0.0]}, "goal": {"current": [1.0, 1.0]}}
+        return obs, 0.0, True, False, {"success": True, "meta": {"is_route_complete": True}}
+
+    def close(self) -> None:
+        return None
+
+
+class TestPreparePolicyAndObservationContract:
+    """Pin the policy/observation-contract preparation helper output shape."""
+
+    def test_goal_policy_contract_has_required_fields(self) -> None:
+        """The goal planner contract must expose callable policy + metadata fields."""
+        policy_fn, _ = _build_policy("goal", {}, robot_kinematics="differential_drive")
+        contract = _prepare_policy_and_observation_contract(
+            scenario={"name": "t"},
+            algo="goal",
+            policy_cfg={},
+            config=_stub_config(),
+            observation_mode=None,
+            observation_level=None,
+            robot_kinematics="differential_drive",
+            robot_command_mode="vx_vy",
+            adapter_impact_eval=False,
+            benchmark_track=None,
+            track_schema_version=None,
+            actuation_profile=None,
+            policy_builder=lambda *a, **kw: (
+                policy_fn,
+                _build_policy("goal", {}, robot_kinematics="differential_drive")[1],
+            ),
+        )
+        assert callable(contract.policy_fn)
+        assert isinstance(contract.algo_meta, dict)
+        assert contract.algo_meta["algorithm"] == "goal"
+        assert contract.active_observation_mode == "goal_state"
+        assert contract.active_observation_level == "oracle_full_state"
+        # The goal planner sets no synthetic-actuation controller and no lifecycle hooks.
+        assert contract.actuation_controller is None
+        assert contract.planner_native_action is False
+        assert isinstance(contract.single_pedestrian_intent_metadata, list)
+        assert isinstance(contract.single_pedestrian_vru_metadata, list)
+
+
+class TestRunEpisodeStepLoop:
+    """Pin the episode step-loop helper output shape and termination handling."""
+
+    def test_step_loop_returns_result_with_populated_trajectory(self, monkeypatch) -> None:
+        """A one-step stubbed episode must populate trajectory lists and mark success."""
+        import robot_sf.benchmark.map_runner_episode as mod
+
+        monkeypatch.setattr(mod, "make_robot_env", lambda config, seed, debug: _StepLoopDummyEnv())
+        policy_fn, _ = _build_policy("goal", {}, robot_kinematics="differential_drive")
+        result = _run_episode_step_loop(
+            seed=1,
+            config=_stub_config(),
+            horizon_val=1,
+            policy_fn=policy_fn,
+            planner_bind_env=None,
+            planner_reset=None,
+            planner_close=None,
+            planner_stats=None,
+            planner_native_action=False,
+            noise_spec={"enabled": False},
+            noise_rng=None,
+            noise_state=None,
+            noise_stats={},
+            tracking_precision_spec={"enabled": False, "target_motp_m": 0.05},
+            tracking_precision_rng=None,
+            safety_wrapper_runtime=mod.runtime_config_from_mapping(None),
+            safety_wrapper_deadlock_monitor=None,
+            cbf_runtime=mod.cbf_runtime_config_from_mapping(None),
+            actuation_controller=None,
+            algo_meta={"algorithm": "goal"},
+            record_forces=True,
+            record_planner_decision_trace=False,
+            record_simulation_step_trace=False,
+            single_pedestrian_intent_metadata=[],
+            single_pedestrian_vru_metadata=[],
+        )
+        # Trajectory buffers must carry one step (horizon_val=1) and a success break.
+        assert len(result.robot_positions) == 1
+        assert result.robot_headings == [pytest.approx(0.0)]
+        assert result.collision_seen is False
+        assert result.reached_goal_step == 0
+        assert result.termination_reason == "success"
+        assert result.planner_runtime_snapshot is None
+        assert result.view_integrity is not None
+        # AMMV command actions must record the single selected action payload.
+        assert len(result.ammv_command_actions) == 1
+
+
+class TestFinalizeEpisodeRecord:
+    """Pin the record-finalization helper output shape from assembled inputs."""
+
+    def test_finalize_returns_record_with_required_keys(self, monkeypatch) -> None:
+        """The finalizer must assemble a full record from ctx/loop_result/post_loop."""
+        import robot_sf.benchmark.map_runner_episode as mod
+
+        monkeypatch.setattr(mod, "make_robot_env", lambda config, seed, debug: _StepLoopDummyEnv())
+        monkeypatch.setattr(mod, "compute_all_metrics", lambda *a, **kw: {"success": 1.0})
+        monkeypatch.setattr(mod, "post_process_metrics", lambda metrics, **kw: metrics)
+        ctx = _resolve_episode_run_context(
+            scenario={
+                "name": "fin_test",
+                "simulation_config": {"max_episode_steps": 1},
+                "robot_config": {"type": "differential_drive"},
+            },
+            seed=1,
+            horizon=None,
+            dt=0.1,
+            algo="goal",
+            scenario_path=Path("."),
+            algo_config=None,
+            algo_config_path=None,
+            experimental_ped_impact=False,
+            ped_impact_radius_m=2.0,
+            ped_impact_window_steps=5,
+            observation_mode=None,
+            observation_level=None,
+            benchmark_track=None,
+            track_schema_version=None,
+            observation_noise=None,
+            tracking_precision=None,
+            synthetic_actuation_profile=None,
+            latency_stress_profile=None,
+            safety_wrapper=None,
+            cbf_safety_filter=None,
+        )
+        policy_fn, _ = _build_policy("goal", {}, robot_kinematics="differential_drive")
+        contract = _prepare_policy_and_observation_contract(
+            scenario=ctx.scenario,
+            algo=ctx.algo,
+            policy_cfg=ctx.policy_cfg,
+            config=ctx.config,
+            observation_mode=None,
+            observation_level=None,
+            robot_kinematics=ctx.robot_kinematics,
+            robot_command_mode=ctx.robot_command_mode,
+            adapter_impact_eval=False,
+            benchmark_track=ctx.benchmark_track,
+            track_schema_version=ctx.track_schema_version,
+            actuation_profile=ctx.actuation_profile,
+            policy_builder=lambda *a, **kw: (
+                policy_fn,
+                _build_policy("goal", {}, robot_kinematics="differential_drive")[1],
+            ),
+        )
+        loop_result = _run_episode_step_loop(
+            seed=1,
+            config=ctx.config,
+            horizon_val=ctx.horizon_val,
+            policy_fn=contract.policy_fn,
+            planner_bind_env=contract.planner_bind_env,
+            planner_reset=contract.planner_reset,
+            planner_close=contract.planner_close,
+            planner_stats=contract.planner_stats,
+            planner_native_action=contract.planner_native_action,
+            noise_spec=ctx.noise_spec,
+            noise_rng=ctx.noise_rng,
+            noise_state=ctx.noise_state,
+            noise_stats=ctx.noise_stats,
+            tracking_precision_spec=ctx.tracking_precision_spec,
+            tracking_precision_rng=ctx.tracking_precision_rng,
+            safety_wrapper_runtime=ctx.safety_wrapper_runtime,
+            safety_wrapper_deadlock_monitor=ctx.safety_wrapper_deadlock_monitor,
+            cbf_runtime=ctx.cbf_runtime,
+            actuation_controller=contract.actuation_controller,
+            algo_meta=contract.algo_meta,
+            record_forces=True,
+            record_planner_decision_trace=False,
+            record_simulation_step_trace=False,
+            single_pedestrian_intent_metadata=contract.single_pedestrian_intent_metadata,
+            single_pedestrian_vru_metadata=contract.single_pedestrian_vru_metadata,
+        )
+        post_loop = _compute_post_loop_metrics(
+            robot_positions=loop_result.robot_positions,
+            robot_headings=loop_result.robot_headings,
+            ped_positions=loop_result.ped_positions,
+            ped_forces=loop_result.ped_forces,
+            visibility_trace=loop_result.visibility_trace,
+            track_confidence_trace=loop_result.track_confidence_trace,
+            visibility_evidence_statuses=loop_result.visibility_evidence_statuses,
+            visibility_evidence_reasons=loop_result.visibility_evidence_reasons,
+            reached_goal_step=loop_result.reached_goal_step,
+            collision_seen=loop_result.collision_seen,
+            ped_collision_seen=loop_result.ped_collision_seen,
+            obstacle_collision_seen=loop_result.obstacle_collision_seen,
+            robot_collision_seen=loop_result.robot_collision_seen,
+            map_def=loop_result.map_def,
+            goal_vec=loop_result.goal_vec,
+            scenario=ctx.scenario,
+            config=ctx.config,
+            horizon_val=ctx.horizon_val,
+            record_forces=True,
+            experimental_ped_impact=False,
+            ped_impact_radius_m=ctx.ped_impact_radius_m,
+            ped_impact_window_steps=ctx.ped_impact_window_steps,
+        )
+        record = _finalize_episode_record(
+            ctx=ctx,
+            loop_result=loop_result,
+            post_loop=post_loop,
+            algo_meta=contract.algo_meta,
+            actuation_controller=contract.actuation_controller,
+            active_observation_mode=contract.active_observation_mode,
+            active_observation_level=contract.active_observation_level,
+            single_pedestrian_intent_metadata=contract.single_pedestrian_intent_metadata,
+            single_pedestrian_vru_metadata=contract.single_pedestrian_vru_metadata,
+            seed=1,
+            horizon=None,
+            dt=0.1,
+            safety_wrapper=None,
+            cbf_safety_filter=None,
+            snqi_weights=None,
+            snqi_baseline=None,
+            record_forces=True,
+            record_planner_decision_trace=False,
+            record_simulation_step_trace=False,
+        )
+        assert record["scenario_id"] == "fin_test"
+        assert record["seed"] == 1
+        assert record["observation_mode"] == "goal_state"
+        assert record["observation_level"] == "oracle_full_state"
+        assert "metrics" in record and isinstance(record["metrics"], dict)
+        assert "algorithm_metadata" in record
+        assert "result_provenance" in record
+        assert record["result_provenance"]["schema_version"] == "benchmark_row_provenance.v1"


### PR DESCRIPTION
## What & Why

Successor slice for issue #4944 (4770-s4). PR #4949 merged the first slice (it decomposed `_build_policy` fully and partially decomposed `run_map_episode` — input-resolution, safety error/fallback, and post-loop metrics phases). The #4949 gate comment named the **remaining decomposition surface** as: "`run_map_episode` retains its `# noqa` — the episode step-loop phase and metadata-finalization phase are still inline … A follow-up slice should extract those and drop the remaining suppression."

**This PR does exactly that.** It extracts the two remaining inline phases (plus the policy/observation-contract setup, to make `run_map_episode` a clean orchestrator and drop the complexity suppressions) into named single-responsibility helpers:

| New helper | Returns | Phase |
| --- | --- | --- |
| `_prepare_policy_and_observation_contract` | `_PolicyContract` | learned obs contract + `policy_builder` + `enrich_algorithm_metadata` + planner lifecycle hooks + synthetic-actuation controller + single-pedestrian metadata |
| `_run_episode_step_loop` | `_EpisodeStepLoopResult` | env reset, the per-step episode loop, collision/termination outcome capture, and planner/env teardown (`finally`) |
| `_finalize_episode_record` | `dict[str, Any]` | algo_meta enrichment, trace summaries, scenario_params, integrity checks, provenance, and the full benchmark JSONL record assembly |

**`run_map_episode` is now a clean 4-phase orchestrator:**

```
ctx = _resolve_episode_run_context(...)          # (already extracted in #4949)
policy_contract = _prepare_policy_and_observation_contract(...)
loop_result = _run_episode_step_loop(...)
post_loop = _compute_post_loop_metrics(...)       # (already extracted in #4949)
return _finalize_episode_record(...)
```

- **Size:** `run_map_episode` 906 → **167 lines** (~82% smaller). No inline step-loop, no `try/finally`.
- **noqa dropped:** `run_map_episode` complexity suppression goes from `# noqa: C901,PLR0912,PLR0913,PLR0915` → **`# noqa: PLR0913` only** (the 24-arg public signature). ruff confirms `C901`/`PLR0912`/`PLR0915` are no longer needed on `run_map_episode`. The two extracted phases carry targeted `C901,PLR0912,PLR0915` since they contain the inherently branchy loop/finalization logic (same convention #4949 used for `_build_guarded_ppo_policy` etc.).

**Successor statement:** This PR adds **new** decomposition capability (the episode step-loop phase + metadata-finalization phase + policy-contract phase, with the `run_map_episode` complexity noqa dropped). It **does not duplicate** PR #4949, which extracted `_build_policy` + the input-resolution/safety/post-loop-metrics phases of `run_map_episode`.

## Behavior preservation (binding)

This is **pure extract-method**. The episode step-loop body and the metadata-finalization body are lifted **byte-for-byte verbatim** from the prior inline code (verified programmatically: both regions are identical line-for-line to the pre-refactor source). The policy-contract body lifts the same statements in the same order. No control-flow, statement, or metadata change.

The #4927 characterization baseline (`tests/benchmark/test_map_runner_characterization.py`) — which pins the god-function behavior end-to-end — stays green with **ZERO edits** to it.

## Validation (CPU-only; no campaigns/Slurm/training)

All run from the worktree via the main-checkout shared venv (`scripts/dev/run_worktree_shared_venv.sh` pattern), headless:

```
# #4927 baseline + direct helper tests (the binding constraint)
pytest tests/benchmark/test_map_runner_characterization.py \
       tests/benchmark/test_map_runner_decomposition_helpers.py -q
-> 89 passed, 1 skipped   (86 prior + 3 NEW direct helper tests)

# Full map_runner-related surface (end-to-end + schema + safety + batch)
pytest tests/benchmark/test_map_runner_characterization.py \
       tests/benchmark/test_map_runner_decomposition_helpers.py \
       tests/benchmark/test_cbf_safety_filter_runtime.py \
       tests/benchmark/test_safety_wrapper_runtime.py \
       tests/benchmark/test_map_runner_safety_predicates.py \
       tests/benchmark/test_map_runner_episode_schema.py \
       tests/benchmark/test_map_runner_utils.py \
       tests/benchmark/test_group_space_metadata.py \
       tests/benchmark/test_proxemic_ablation_report_issue_4165.py -q
-> 322 passed, 1 skipped

# Lint + format on changed files
ruff check   robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_map_runner_decomposition_helpers.py
ruff format --check robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_map_runner_decomposition_helpers.py
-> All checks passed; 2 files already formatted
```

New direct unit tests added in `tests/benchmark/test_map_runner_decomposition_helpers.py` pin the three new helpers' contracts: `TestPreparePolicyAndObservationContract`, `TestRunEpisodeStepLoop`, `TestFinalizeEpisodeRecord` (the last exercises the integrity-contradiction guard end-to-end through the finalizer).

## Changed files

- `robot_sf/benchmark/map_runner_episode.py` — `run_map_episode` decomposed into orchestrator + 3 named helpers + 2 dataclasses (`_PolicyContract`, `_EpisodeStepLoopResult`).
- `tests/benchmark/test_map_runner_decomposition_helpers.py` — +3 direct helper test classes.

## Downstream propagation (evidence-producing PR section)

This is a behavior-preserving refactor of an internal benchmark runner path. No research/benchmark/metric/schema/model-provenance claim is made or changed; output records are identical.
- Target claim/hypothesis/blocker: NA (refactor).
- Comparator/baseline: the #4927 characterization baseline (unchanged).
- Evidence tier: CPU test suite (characterization + direct helper tests), all green with zero baseline edits.
- Result classification: behavior-preserving (verifiable via byte-for-byte body comparison).
- Decision/stop rule: noqa on `run_map_episode` reduced to `PLR0913` only; baseline green.
- Synthesis/update target: none — issue #4944 decomposition surface for `run_map_episode` is now complete.

Closes #4944.

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined episode handling into smaller, more maintainable steps.
  * Improved consistency in how benchmark records and metrics are assembled.

* **Tests**
  * Added coverage for the updated episode flow.
  * Verified contract setup, step execution, and final record output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->