### PR TITLE
Issue #4954: isolate finalized algo_meta from builder-provided dict (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -2066,6 +2066,16 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     metrics_raw = post_loop.metrics_raw
     if robot_pos_arr.size:
         robot_config = getattr(config, "robot_config", None)
+    # Finalization phase: isolate the episode metadata from the builder-provided
+    # ``algo_meta`` so the finalization writes below (adapter_impact status,
+    # tracking_precision, safety_wrapper, planner_runtime, etc.) cannot leak back
+    # into a builder that reuses/caches the same dict across episodes (#4954).
+    # The episode loop has finished, so every runtime write the policy made into
+    # ``algo_meta`` (e.g. adapter_impact counters, shield_stats) is already present
+    # and is captured by this deep copy. ``enrich_algorithm_metadata`` only shallow-
+    # copies, so nested mutable structures (notably ``adapter_impact``) would
+    # otherwise still be shared with the builder and mutated in place here.
+    algo_meta = deepcopy(algo_meta)
     impact = algo_meta.get("adapter_impact")
     if isinstance(impact, dict) and bool(impact.get("requested", False)):
         native_steps = int(impact.get("native_steps", 0))

--- a/tests/benchmark/test_map_runner_episode_algo_meta_isolation.py
+++ b/tests/benchmark/test_map_runner_episode_algo_meta_isolation.py
@@ -27,10 +27,6 @@ import numpy as np
 from robot_sf.benchmark import map_runner_episode
 
 
-class _Robot:
-    theta = np.array([0.0], dtype=float)
-
-
 class _EpisodeSim:
     def __init__(self) -> None:
         self.robot_pos = [np.array([0.0, 0.0], dtype=float)]

--- a/tests/benchmark/test_map_runner_episode_algo_meta_isolation.py
+++ b/tests/benchmark/test_map_runner_episode_algo_meta_isolation.py
@@ -1,0 +1,208 @@
+"""Regression tests for issue #4954.
+
+``run_map_episode`` finalizes episode metadata by writing ~10 keys into the
+``algo_meta`` dict produced by the policy builder (``adapter_impact`` status,
+``tracking_precision``, ``safety_wrapper``, ``planner_runtime``, ...).
+
+``enrich_algorithm_metadata`` only *shallow*-copies that dict, so nested mutable
+structures -- notably the ``adapter_impact`` counters -- stayed shared with the
+builder's original object. A builder that reuses/caches the same ``algo_meta``
+across episodes (an extension point, since ``policy_builder`` is caller-provided)
+would therefore see finalization writes leak back across episodes.
+
+These tests pin the fix: the finalization phase must operate on an isolated copy
+so a builder-provided (and builder-retained) ``algo_meta`` is never mutated in
+place, while the returned record still carries the correctly finalized values.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark import map_runner_episode
+
+
+class _Robot:
+    theta = np.array([0.0], dtype=float)
+
+
+class _EpisodeSim:
+    def __init__(self) -> None:
+        self.robot_pos = [np.array([0.0, 0.0], dtype=float)]
+        self.ped_pos = np.array([[2.0, 0.0]], dtype=float)
+        self.goal_pos = [np.array([1.0, 0.0], dtype=float)]
+        self.map_def = SimpleNamespace(obstacles=[], bounds=(0.0, 0.0, 1.0, 1.0))
+        self.robot_vel = [np.array([0.0, 0.0], dtype=float)]
+
+    def get_pedestrian_forces(self) -> np.ndarray:
+        return np.zeros((1, 2), dtype=float)
+
+
+class _EpisodeEnv:
+    def __init__(self) -> None:
+        self.simulator = _EpisodeSim()
+        self.action_space = None
+
+    def reset(self, seed=None):
+        return (
+            {
+                "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+                "goal": {"current": [1.0, 0.0]},
+                "pedestrians": {"positions": self.simulator.ped_pos},
+            },
+            {},
+        )
+
+    def step(self, _action):
+        return self.reset()[0], 0.0, True, False, {"meta": {"is_route_complete": True}}
+
+    def close(self) -> None:
+        return None
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        sim_config=SimpleNamespace(
+            time_per_step_in_secs=0.1,
+            robot_radius=0.1,
+            ped_radius=0.1,
+        )
+    )
+
+
+def _patch_episode_runtime(monkeypatch) -> None:
+    """Replace the heavy simulator/metrics calls with cheap deterministic stubs."""
+    monkeypatch.setattr(
+        map_runner_episode,
+        "_build_env_config",
+        lambda _scenario, scenario_path: _config(),
+    )
+    monkeypatch.setattr(
+        map_runner_episode,
+        "make_robot_env",
+        lambda config, seed, debug: _EpisodeEnv(),
+    )
+    monkeypatch.setattr(map_runner_episode, "sample_obstacle_points", lambda *args: None)
+    monkeypatch.setattr(map_runner_episode, "compute_shortest_path_length", lambda *args: 1.0)
+    monkeypatch.setattr(
+        map_runner_episode,
+        "compute_all_metrics",
+        lambda *args, **kwargs: {"success": 1.0, "collisions": 0.0},
+    )
+    monkeypatch.setattr(
+        map_runner_episode,
+        "post_process_metrics",
+        lambda metrics, **kwargs: metrics,
+    )
+
+
+def _run_episode(monkeypatch, builder_meta: dict[str, Any]) -> dict[str, Any]:
+    """Run a minimal episode whose builder returns (and retains) ``builder_meta``."""
+    _patch_episode_runtime(monkeypatch)
+
+    def policy_builder(*_args, **_kwargs):
+        def policy(_obs):
+            return (1.0, 0.0)
+
+        # Return the SAME object each call so a retained reference simulates a
+        # builder that caches/reuses algo_meta across episodes.
+        return policy, builder_meta
+
+    return map_runner_episode.run_map_episode(
+        {"name": "algo-meta-isolation-4954", "simulation_config": {"max_episode_steps": 1}},
+        seed=1,
+        horizon=1,
+        dt=0.1,
+        record_forces=False,
+        snqi_weights=None,
+        snqi_baseline=None,
+        algo="goal",
+        scenario_path=Path(__file__),
+        adapter_impact_eval=True,
+        policy_builder=policy_builder,
+    )
+
+
+def test_builder_provided_algo_meta_not_mutated_by_finalization(monkeypatch) -> None:
+    """A builder-retained algo_meta must not be mutated in place (#4954)."""
+    builder_meta = {
+        "algorithm": "goal",
+        "adapter_impact": {
+            "requested": True,
+            "native_steps": 0,
+            "adapted_steps": 0,
+            "status": "pending",
+        },
+    }
+    snapshot_before = copy.deepcopy(builder_meta)
+
+    record = _run_episode(monkeypatch, builder_meta)
+
+    # The builder's retained dict must be byte-for-byte unchanged.
+    assert builder_meta == snapshot_before
+    # Specifically the nested adapter_impact finalization writes must not leak:
+    # status must stay "pending" and adapter_fraction must not be injected.
+    assert builder_meta["adapter_impact"]["status"] == "pending"
+    assert "adapter_fraction" not in builder_meta["adapter_impact"]
+    assert "execution_mode" not in builder_meta["adapter_impact"]
+    # The record, by contrast, must carry the finalized adapter_impact values.
+    finalized = record["algorithm_metadata"]["adapter_impact"]
+    assert "adapter_fraction" in finalized
+    assert finalized["status"] in {"complete", "not_applicable"}
+
+
+def test_finalized_algo_meta_is_independent_object(monkeypatch) -> None:
+    """The record's algo_meta and nested adapter_impact must be fresh objects (#4954)."""
+    builder_meta: dict[str, Any] = {
+        "algorithm": "goal",
+        "adapter_impact": {
+            "requested": True,
+            "native_steps": 0,
+            "adapted_steps": 0,
+            "status": "pending",
+        },
+    }
+
+    record = _run_episode(monkeypatch, builder_meta)
+
+    record_meta = record["algorithm_metadata"]
+    # Top-level dict must be a distinct object.
+    assert record_meta is not builder_meta
+    # Nested adapter_impact must also be a distinct object (deep isolation).
+    assert record_meta["adapter_impact"] is not builder_meta["adapter_impact"]
+    # Mutating the record's nested dict after the fact must not touch the builder.
+    record_meta["adapter_impact"]["status"] = "tampered"
+    assert builder_meta["adapter_impact"]["status"] == "pending"
+
+
+def test_finalization_keys_present_in_record(monkeypatch) -> None:
+    """Regression guard: isolation must not drop the finalized metadata keys."""
+    builder_meta = {"algorithm": "goal"}
+
+    record = _run_episode(monkeypatch, builder_meta)
+
+    meta = record["algorithm_metadata"]
+    # A representative subset of the ~10 finalization-phase writes.
+    for key in (
+        "tracking_precision",
+        "ammv_feasibility",
+        "algorithm",
+        "observation_level",
+    ):
+        assert key in meta, f"finalization key missing from record: {key}"
+
+
+def test_builder_provided_algo_meta_top_level_not_mutated(monkeypatch) -> None:
+    """Even a bare builder meta (no nested structures) must not gain finalization keys."""
+    builder_meta = {"algorithm": "goal"}
+    snapshot_before = copy.deepcopy(builder_meta)
+
+    _run_episode(monkeypatch, builder_meta)
+
+    # No finalization-phase top-level keys should have leaked back.
+    assert builder_meta == snapshot_before


### PR DESCRIPTION
## What & why

Closes #4954.

`run_map_episode`'s finalization phase writes ~10 keys into the `algo_meta` dict produced by the policy builder (`adapter_impact` status, `tracking_precision`, `safety_wrapper`, `planner_runtime`, …). The issue (a pre-existing latent surfaced during #4953 review) flagged that this mutation could leak back into a caller-provided `algo_meta`.

**Investigation result:** `algo_meta` is not a `run_map_episode` parameter — it is created by the caller-provided `policy_builder` (an extension point). `enrich_algorithm_metadata` only does a **shallow** copy of the builder's dict, so while the *top-level* dict is isolated, **nested mutable structures — notably `adapter_impact` — stayed shared** with the builder's original object. I confirmed the leak is real for the nested `adapter_impact` dict: with the origin/main code, a builder that reuses/caches the same `algo_meta` across episodes sees the finalization's `status` (`pending` → `not_applicable`) and `adapter_fraction` writes leak back, and the builder's and record's `adapter_impact` are the same object.

**Fix:** deep-copy `algo_meta` at the start of the finalization phase (after the episode loop finishes, so every runtime write the policy made — `adapter_impact` counters, `shield_stats`, … — is already present and captured). This isolates all subsequent finalization writes from the builder's original object.

This is the issue's "If reuse exists → copy + regression test" branch, implemented as defensive hardening of the `policy_builder` extension point (any registered/custom builder could return a cached dict).

## Evidence grade

diagnostic-only → behavior-preserving hardening. No benchmark/metric/paper claim.

## Change

- `robot_sf/benchmark/map_runner_episode.py`: `algo_meta = deepcopy(algo_meta)` at the start of the finalization phase, with an explanatory comment.
- `tests/benchmark/test_map_runner_episode_algo_meta_isolation.py` (new): regression tests.

## #4927 characterization baseline re-verification

The issue notes the fix is behavior-changing and asks to re-verify the #4927 baseline. The change is **value-preserving**: a deep copy does not alter the serialized record contents — only the object identity of `algo_meta` in the returned record changes, and no current production builder reuses its dict (the legacy `_build_policy` and all registered builders construct a fresh `meta` per call). The existing characterization baseline passes unmodified:

```
tests/benchmark/test_map_runner_characterization.py  34 passed
```

This demonstrates the record contents are unchanged (no campaign/benchmark run required — the change does not affect any metric/claim boundary).

## Validation

CPU-only, headless. Reused the main-checkout venv via `scripts/dev/run_worktree_shared_venv.sh` (quick targeted validation in a fresh sibling worktree).

```
# New regression tests (red-green proof)
# WITHOUT fix: 2 of 4 FAIL (nested adapter_impact mutated in place + shared object identity)
# WITH fix:
tests/benchmark/test_map_runner_episode_algo_meta_isolation.py  4 passed

# Value-preservation across episode-related suites (no regressions)
tests/benchmark/test_map_runner_characterization.py
tests/benchmark/test_cbf_safety_filter_runtime.py
tests/benchmark/test_safety_wrapper_runtime.py
tests/benchmark/test_map_runner_view_integrity.py
tests/benchmark/test_map_runner_episode_algo_meta_isolation.py   127 passed

tests/benchmark/test_map_runner_decomposition_helpers.py
tests/benchmark/test_map_runner_utils.py
tests/test_map_runner_sac.py                                     203 passed, 1 skipped

# Lint/format on changed files
ruff check <changed files>   -> All checks passed!
ruff format --check <changed files> -> 2 files already formatted
```

The red-green proof confirms the two isolation tests fail for the right reason on origin/main (`adapter_impact` status mutated to `not_applicable` in the builder's dict; builder/record `adapter_impact` are the same object) and pass with the fix.

## Artifact handling

NA — no evidence-producing change. Only `output/`-unrelated source + test edits; no campaign/training/benchmark artifacts generated.

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved episode metadata handling so finalization no longer mutates cached or reused algorithm metadata between runs.
  * Ensures returned metadata remains isolated from the original builder-provided data, preventing unintended cross-episode leakage.

* **Tests**
  * Added regression coverage for metadata isolation during episode finalization.
  * Verified nested and top-level metadata stay unchanged while finalized records still include expected fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->