### PR TITLE
Issue #4957: fix subprocess-isolation serialization so isolation+cleanup metrics emit (cheap-lane worker)

### DIFF
--- a/docs/context/issue_4826_camera_ready_gpu_lifecycle.md
+++ b/docs/context/issue_4826_camera_ready_gpu_lifecycle.md
@@ -51,6 +51,18 @@ Implementation:
 - Worker entrypoint runs one arm and writes `summary.json` + `episodes.jsonl` to the planned `planner_dir`
 - Parent launches one subprocess per arm, waits, reads summary, and continues
 - Parent still owns campaign-level artifacts, aggregation, report generation, and stop-on-failure policy
+- Parent->worker handoff serializes `_SubprocessArmParams` via `_serialize_subprocess_arm_params` (str-converts the `pathlib.Path` fields); the worker re-parses str->Path. The run entry emits `subprocess_isolation: true` + `gpu_cleanup` (per-arm `cleanup_metrics`).
+
+> **Note (#4957):** the Phase 2 code landed in PR #4846 but had *never run end-to-end*
+> until #4957. A 2026-07-09 GPU smoke (job 13344) found the parent's
+> `json.dumps(asdict(arm_params))` crashed with
+> `TypeError: Object of type PosixPath is not JSON serializable` *before* the
+> subprocess spawned, so no `subprocess_isolation`/`cleanup_metrics` evidence
+> was ever produced. #4957 moves serialization into
+> `_serialize_subprocess_arm_params` (str-converting the four Path fields) and
+> adds a regression test that exercises the real serialization + emission path.
+> The at-scale GPU smoke (Phase 5) still must be re-run to confirm VRAM release;
+> this code fix only unblocks that smoke.
 
 ### Phase 3: PYTORCH_ALLOC_CONF hardening
 Status: Complete (PR #4836)

--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -670,6 +670,7 @@ def _run_campaign_planner_variant_subprocess(
 
     # Import subprocess worker module
     from robot_sf.benchmark.camera_ready.resource_lifecycle import (  # noqa: PLC0415
+        _serialize_subprocess_arm_params,
         _SubprocessArmParams,
     )
 
@@ -710,8 +711,11 @@ def _run_campaign_planner_variant_subprocess(
         algo_config_path=planner.algo_config_path,
     )
 
-    # Serialize parameters for subprocess
-    arm_params_json = json.dumps(asdict(arm_params))
+    # Serialize parameters for subprocess. The Path-typed fields on
+    # _SubprocessArmParams must be str-converted before json.dumps or the
+    # handoff crashes (issue #4957); _serialize_subprocess_arm_params is the
+    # single serialization point and is covered by a regression test.
+    arm_params_json = _serialize_subprocess_arm_params(arm_params)
     proc = subprocess.run(
         [sys.executable, "-m", "robot_sf.benchmark.camera_ready.resource_lifecycle"],
         input=arm_params_json,

--- a/robot_sf/benchmark/camera_ready/resource_lifecycle.py
+++ b/robot_sf/benchmark/camera_ready/resource_lifecycle.py
@@ -21,7 +21,7 @@ import json
 # Set PyTorch allocator policy for subprocess isolation (defense-in-depth)
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
@@ -57,6 +57,46 @@ class _SubprocessArmParams:
     snqi_weights: dict[str, Any] | None
     snqi_baseline: dict[str, Any] | None
     algo_config_path: Path | None
+
+
+# Path-typed fields on _SubprocessArmParams. dataclasses.asdict() returns these as
+# PosixPath objects, which json.dumps cannot serialize, so the serializer below
+# str-converts them first. The subprocess worker (_main_subprocess_worker)
+# re-parses str->Path for these same fields. This is the single serialization
+# point for the subprocess-isolation parent->worker handoff (issue #4826 / #4957);
+# tests must exercise THIS function rather than a hand-converted copy so a
+# regression here is caught.
+_SUBPROCESS_ARM_PATH_FIELDS: tuple[str, ...] = (
+    "scenario_matrix_path",
+    "episodes_path",
+    "summary_path",
+    "algo_config_path",
+)
+
+
+def _serialize_subprocess_arm_params(params: _SubprocessArmParams) -> str:
+    """Serialize arm params to JSON for handoff to the subprocess worker.
+
+    ``_SubprocessArmParams`` holds ``pathlib.Path`` fields
+    (``scenario_matrix_path``, ``episodes_path``, ``summary_path``,
+    ``algo_config_path``). ``dataclasses.asdict`` returns those as ``PosixPath``
+    objects, which ``json.dumps`` cannot serialize (this was the crash at
+    ``campaign.py`` that prevented ``--arm-isolation subprocess`` from ever
+    running end-to-end — issue #4957). This helper str-converts the path fields
+    first so the parent->worker handoff is JSON-safe.
+
+    Args:
+        params: Arm execution parameters built by the parent campaign process.
+
+    Returns:
+        JSON string consumable by ``_main_subprocess_worker``.
+    """
+    params_dict = asdict(params)
+    for field_name in _SUBPROCESS_ARM_PATH_FIELDS:
+        value = params_dict.get(field_name)
+        if value is not None:
+            params_dict[field_name] = str(value)
+    return json.dumps(params_dict)
 
 
 def _cleanup_gpu_memory_before_exit(

--- a/tests/benchmark/test_camera_ready_subprocess_isolation.py
+++ b/tests/benchmark/test_camera_ready_subprocess_isolation.py
@@ -6,11 +6,14 @@ These tests verify that:
 3. In-process mode still works with arm_isolation="in_process"
 4. CLI flag for arm-isolation is recognized
 5. Resource lifecycle cleanup is called in subprocess mode
+6. The parent->worker serialization is JSON-safe and the subprocess path emits
+   the ``subprocess_isolation`` + ``cleanup_metrics`` evidence (issue #4957).
 """
 
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -20,8 +23,40 @@ import pytest
 from robot_sf.benchmark.camera_ready.resource_lifecycle import (
     _cleanup_gpu_memory_before_exit,
     _main_subprocess_worker,
+    _serialize_subprocess_arm_params,
     _SubprocessArmParams,
 )
+
+
+def _make_arm_params(*, algo_config_path: Path | None = None) -> _SubprocessArmParams:
+    """Build a representative _SubprocessArmParams for serialization tests."""
+    return _SubprocessArmParams(
+        planner_key="test",
+        planner_algo="test_algo",
+        planner_human_model_variant=None,
+        planner_human_model_source=None,
+        planner_group="core",
+        benchmark_profile="speed",
+        socnav_missing_prereq_policy="error",
+        adapter_impact_eval="disabled",
+        kinematics="differential_drive",
+        observation_mode="lidar",
+        workers=1,
+        horizon=100,
+        dt=0.1,
+        scenario_matrix_path=Path("scenarios.yaml"),
+        episodes_path=Path("/tmp/episodes.jsonl"),
+        summary_path=Path("/tmp/summary.json"),
+        record_forces=True,
+        record_planner_decision_trace=False,
+        record_simulation_step_trace=False,
+        observation_noise=None,
+        synthetic_actuation_profile=None,
+        latency_stress_profile=None,
+        snqi_weights=None,
+        snqi_baseline=None,
+        algo_config_path=algo_config_path,
+    )
 
 
 class TestSubprocessIsolationEntryPoints:
@@ -300,48 +335,60 @@ class TestSubprocessIsolationIntegration:
         assert hasattr(rl, "_cleanup_gpu_memory_before_exit")
         assert hasattr(rl, "_main_subprocess_worker")
 
-    def test_subprocess_arm_params_is_serializable(self):
-        """Verify _SubprocessArmParams can be serialized to JSON."""
-        params = _SubprocessArmParams(
-            planner_key="test",
-            planner_algo="test_algo",
-            planner_human_model_variant=None,
-            planner_human_model_source=None,
-            planner_group="core",
-            benchmark_profile="speed",
-            socnav_missing_prereq_policy="error",
-            adapter_impact_eval="disabled",
-            kinematics="differential_drive",
-            observation_mode="lidar",
-            workers=1,
-            horizon=100,
-            dt=0.1,
-            scenario_matrix_path=Path("scenarios.yaml"),
-            episodes_path=Path("/tmp/episodes.jsonl"),
-            summary_path=Path("/tmp/summary.json"),
-            record_forces=True,
-            record_planner_decision_trace=False,
-            record_simulation_step_trace=False,
-            observation_noise=None,
-            synthetic_actuation_profile=None,
-            latency_stress_profile=None,
-            snqi_weights=None,
-            snqi_baseline=None,
-            algo_config_path=None,
-        )
+    @pytest.mark.parametrize("algo_config_path", [None, Path("/tmp/algo.yaml")])
+    def test_subprocess_arm_params_is_serializable(self, algo_config_path):
+        """Verify _SubprocessArmParams serializes to JSON via the real serializer.
 
-        # Should be serializable with dataclass.asdict after converting paths to strings
-        from dataclasses import asdict
+        This is the regression guard for issue #4957: the production
+        serialization at ``campaign.py`` previously called
+        ``json.dumps(asdict(arm_params))`` directly, which crashes with
+        ``TypeError: Object of type PosixPath is not JSON serializable`` because
+        ``_SubprocessArmParams`` holds ``pathlib.Path`` fields. The smoke worker
+        (issue #4826 comment) found that the prior version of this test
+        hand-converted the Path fields *inside the test*, so it never exercised
+        the implementation's own serialization and missed the crash.
 
-        params_dict = asdict(params)
+        This test calls the REAL ``_serialize_subprocess_arm_params`` helper (the
+        single serialization point used by production) with no hand-conversion,
+        and covers both the ``algo_config_path=None`` and ``Path`` branches.
+        """
+        params = _make_arm_params(algo_config_path=algo_config_path)
+
+        # Must not raise; exercises the production serialization path directly.
+        serialized = _serialize_subprocess_arm_params(params)
+        assert isinstance(serialized, str)
+
+        # Round-trips through json.loads and every path field is a JSON string.
+        params_dict = json.loads(serialized)
         assert isinstance(params_dict, dict)
-        # Convert Path objects to strings for JSON serialization
-        params_dict["scenario_matrix_path"] = str(params_dict["scenario_matrix_path"])
-        params_dict["episodes_path"] = str(params_dict["episodes_path"])
-        params_dict["summary_path"] = str(params_dict["summary_path"])
+        for field_name in ("scenario_matrix_path", "episodes_path", "summary_path"):
+            assert isinstance(params_dict[field_name], str)
+        if algo_config_path is not None:
+            assert isinstance(params_dict["algo_config_path"], str)
+            assert params_dict["algo_config_path"] == str(algo_config_path)
+        else:
+            assert params_dict["algo_config_path"] is None
+
+    def test_subprocess_arm_params_serialization_round_trips_to_worker(self):
+        """Parent-sends-strings / worker-parses-strings contract (issue #4957).
+
+        The parent serializes with ``_serialize_subprocess_arm_params`` (path
+        fields become JSON strings); the worker (``_main_subprocess_worker``)
+        re-parses str->Path for the same fields. This test verifies the full
+        round trip so a mismatch between the two sides cannot regress silently.
+        """
+        params = _make_arm_params(algo_config_path=Path("/tmp/algo.yaml"))
+        serialized = _serialize_subprocess_arm_params(params)
+
+        # Mirror the worker's str->Path re-parse (resource_lifecycle.py).
+        params_dict = json.loads(serialized)
+        for field_name in ("scenario_matrix_path", "episodes_path", "summary_path"):
+            params_dict[field_name] = Path(params_dict[field_name])
         if params_dict["algo_config_path"] is not None:
-            params_dict["algo_config_path"] = str(params_dict["algo_config_path"])
-        assert json.dumps(params_dict)  # Should not raise
+            params_dict["algo_config_path"] = Path(params_dict["algo_config_path"])
+
+        rebuilt = _SubprocessArmParams(**params_dict)
+        assert rebuilt == params
 
     def test_cleanup_metrics_attached_to_subprocess_result(self):
         """Verify cleanup_metrics are included in subprocess result."""
@@ -369,6 +416,203 @@ class TestSubprocessIsolationIntegration:
         assert "cleanup_metrics" in result
         assert "torch_available" in result["cleanup_metrics"]
         assert "cuda_available" in result["cleanup_metrics"]
+
+
+class TestSubprocessIsolationMetricEmission:
+    """Regression tests for issue #4957: the subprocess path must emit the
+    ``subprocess_isolation`` + ``cleanup_metrics`` evidence that #4826's
+    acceptance criteria require.
+
+    Before the #4957 fix, ``_run_campaign_planner_variant_subprocess`` crashed
+    at the ``json.dumps(asdict(arm_params))`` serialization (PosixPath not JSON
+    serializable) *before* the subprocess was ever spawned, so neither
+    ``subprocess_isolation: true`` nor ``cleanup_metrics`` could be produced.
+    These tests exercise the real production path (serialization + subprocess
+    dispatch + result parsing + run-entry emission) and assert the metrics land
+    in the run entry.
+    """
+
+    def _make_context(self, tmp_path):
+        from robot_sf.benchmark.camera_ready._config_types import (
+            CampaignConfig,
+            PlannerSpec,
+        )
+        from robot_sf.benchmark.camera_ready.campaign import (
+            _CampaignPlannerMatrixContext,
+            _CampaignPlannerVariantRun,
+            _CampaignRuntimeDependencies,
+        )
+
+        planner = PlannerSpec(
+            key="test_planner",
+            algo="test_algo",
+            planner_group="core",
+            benchmark_profile="speed",
+            enabled=True,
+        )
+        cfg = CampaignConfig(
+            name="test",
+            scenario_matrix_path=Path("scenarios.yaml"),
+            planners=(planner,),
+        )
+        dependencies = _CampaignRuntimeDependencies(
+            prepare_campaign_preflight=Mock(return_value={}),
+            run_batch=Mock(return_value={}),
+            compute_aggregates_with_ci=Mock(return_value=None),
+            export_publication_bundle=Mock(return_value=None),
+        )
+        context = _CampaignPlannerMatrixContext(
+            cfg=cfg,
+            scenarios=[],
+            snqi_weights=None,
+            snqi_baseline=None,
+            runs_dir=tmp_path,
+            dependencies=dependencies,
+        )
+        episodes_path = tmp_path / "episodes.jsonl"
+        run = _CampaignPlannerVariantRun(
+            kinematics="differential_drive",
+            active_observation_mode="lidar",
+            planner_dir=tmp_path,
+            episodes_path=episodes_path,
+            effective_workers=1,
+            effective_horizon=100,
+            effective_dt=0.1,
+            scoped_scenarios=[],
+        )
+        return planner, context, run
+
+    def test_subprocess_path_emits_isolation_and_cleanup_metrics(self, tmp_path):
+        """Assert ``subprocess_isolation: True`` + ``cleanup_metrics`` are emitted.
+
+        Exercises the real ``_run_campaign_planner_variant_subprocess`` path with
+        ``subprocess.run`` mocked to return a successful arm result carrying
+        ``cleanup_metrics``. This proves the serialization fix (#4957) lets the
+        path reach the emission code that was previously unreachable, and that
+        the per-arm cleanup metrics propagate into the run entry.
+        """
+        from robot_sf.benchmark.camera_ready.campaign import (
+            _run_campaign_planner_variant_subprocess,
+        )
+
+        planner, context, run = self._make_context(tmp_path)
+
+        cleanup_metrics = {
+            "planner_key": planner.key,
+            "kinematics": "differential_drive",
+            "torch_available": True,
+            "cuda_available": True,
+            "allocated_mb": 1.0,
+            "reserved_mb": 2.0,
+            "high_water_mark_mb": 3.0,
+            "allocated_freed_mb": 0.5,
+            "reserved_freed_mb": 1.5,
+        }
+        worker_stdout = json.dumps(
+            {
+                "summary": {
+                    "status": "ok",
+                    "total_jobs": 1,
+                    "written": 1,
+                    "failed_jobs": 0,
+                    "failures": [],
+                },
+                "cleanup_metrics": cleanup_metrics,
+                "warnings": [],
+                "episodes_total": 1,
+            }
+        )
+
+        captured_input = {}
+
+        def fake_subprocess_run(cmd, *, input, capture_output, text, check):  # noqa: A002
+            captured_input["json"] = input
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=worker_stdout, stderr=""
+            )
+
+        with (
+            patch(
+                "robot_sf.benchmark.camera_ready.campaign._prepare_campaign_planner_variant_run",
+                return_value=run,
+            ),
+            patch(
+                "robot_sf.benchmark.camera_ready.campaign.subprocess.run",
+                side_effect=fake_subprocess_run,
+            ),
+            patch(
+                "robot_sf.benchmark.camera_ready.campaign._planner_report_row",
+                return_value={"planner_key": planner.key, "status": "ok"},
+            ),
+            patch("robot_sf.benchmark.camera_ready.campaign.read_jsonl", return_value=[]),
+            patch(
+                "robot_sf.benchmark.camera_ready.campaign.classify_planner_row_status",
+                return_value="ok",
+            ),
+        ):
+            result = _run_campaign_planner_variant_subprocess(
+                context,
+                planner=planner,
+                kinematics="differential_drive",
+                active_observation_mode="lidar",
+            )
+
+        # The serialization fix is in effect: the handoff JSON the parent built
+        # is valid JSON (would have raised TypeError before #4957) and the path
+        # fields are strings, not PosixPath.
+        handoff = json.loads(captured_input["json"])
+        assert isinstance(handoff["scenario_matrix_path"], str)
+        assert isinstance(handoff["episodes_path"], str)
+        assert isinstance(handoff["summary_path"], str)
+
+        # Issue #4957 acceptance: the metrics are emitted in the run entry.
+        assert len(result.run_entries) == 1
+        entry = result.run_entries[0]
+        assert entry["subprocess_isolation"] is True
+        assert entry["gpu_cleanup"] == cleanup_metrics
+        assert entry["gpu_cleanup"]["allocated_freed_mb"] == 0.5
+        assert entry["gpu_cleanup"]["reserved_freed_mb"] == 1.5
+        assert entry["status"] == "ok"
+
+    def test_subprocess_path_emits_isolation_marker_on_failure(self, tmp_path):
+        """The ``subprocess_isolation: True`` marker is emitted even when the
+        subprocess arm fails, so the evidence that isolation was engaged is
+        never lost (issue #4957 / #4826).
+        """
+        from robot_sf.benchmark.camera_ready.campaign import (
+            _run_campaign_planner_variant_subprocess,
+        )
+
+        planner, context, run = self._make_context(tmp_path)
+
+        with (
+            patch(
+                "robot_sf.benchmark.camera_ready.campaign._prepare_campaign_planner_variant_run",
+                return_value=run,
+            ),
+            patch(
+                "robot_sf.benchmark.camera_ready.campaign.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=[], returncode=1, stdout="", stderr="boom"
+                ),
+            ),
+            patch("robot_sf.benchmark.camera_ready.campaign.read_jsonl", return_value=[]),
+            patch(
+                "robot_sf.benchmark.camera_ready.campaign.classify_planner_row_status",
+                return_value="unexpected_failure",
+            ),
+        ):
+            result = _run_campaign_planner_variant_subprocess(
+                context,
+                planner=planner,
+                kinematics="differential_drive",
+                active_observation_mode="lidar",
+            )
+
+        assert len(result.run_entries) == 1
+        entry = result.run_entries[0]
+        assert entry["subprocess_isolation"] is True
+        assert entry["status"] == "failed"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Fixes the `--arm-isolation subprocess` path so it can actually run end-to-end and emit the `subprocess_isolation: true` + per-arm `cleanup_metrics` evidence that #4826's acceptance criteria require. Issue #4957.

**Root cause (found by the 2026-07-09 S30 option-B GPU smoke, job 13344 — see #4826 thread):** PR #4846's subprocess isolation had **never run end-to-end**. `_run_campaign_planner_variant_subprocess` crashed at the parent→worker handoff (`campaign.py:714`) with:

```
TypeError: Object of type PosixPath is not JSON serializable
```

`json.dumps(asdict(arm_params))` serialized the four `pathlib.Path` fields of `_SubprocessArmParams` (`scenario_matrix_path`, `episodes_path`, `summary_path`, `algo_config_path`) as `PosixPath`, which `json.dumps` cannot handle. The crash happened on the **first arm, before any subprocess spawned**, so the success-path code that emits `subprocess_isolation: true` + `gpu_cleanup` (`cleanup_metrics`) was unreachable — meaning #4826's cross-arm VRAM-leak fix was unmitigated by #4846 as merged, and no isolation/cleanup evidence could ever be produced even with `--arm-isolation subprocess` pinned.

The regression suite missed it because `test_subprocess_arm_params_is_serializable` hand-converted the Path fields *inside the test* before calling `json.dumps`, so it never exercised the implementation's own serialization.

## Why it matters

This is the gate before S30 attempt 6. Without this fix, attempt 6 would hit the same crash at serialization (or, with the flag off, the same VRAM-exhaustion class as attempts 4–5 / jobs 13333, 13340). Once merged, the ops lane re-runs job 13344's exact submit command to harvest the live `subprocess_isolation: true` + `cleanup_metrics` (`allocated_freed_mb` / `reserved_freed_mb`) evidence.

## Changes

- **`robot_sf/benchmark/camera_ready/resource_lifecycle.py`**: add `_serialize_subprocess_arm_params()` as the single serialization point — str-converts the four Path fields before `json.dumps(asdict(...))`. The worker (`_main_subprocess_worker`) already re-parses str→Path for these fields, so the parent-sends-strings / worker-parses-strings contract is now honored on both sides.
- **`robot_sf/benchmark/camera_ready/campaign.py`**: call the helper instead of the crashing inline `json.dumps(asdict(arm_params))`.
- **`tests/benchmark/test_camera_ready_subprocess_isolation.py`**:
  - Replaced the flagged `test_subprocess_arm_params_is_serializable` (hand-converted Paths inside the test) with one that calls the **real** `_serialize_subprocess_arm_params` helper, parametrized over `algo_config_path=None|Path`.
  - Added a round-trip test (parent serialize → worker str→Path re-parse → `_SubprocessArmParams`) guarding the handoff contract.
  - Added `TestSubprocessIsolationMetricEmission`: exercises the real `_run_campaign_planner_variant_subprocess` path with mocked `subprocess.run` and asserts the run entry emits `subprocess_isolation: True` + `gpu_cleanup == cleanup_metrics` (incl. `allocated_freed_mb` / `reserved_freed_mb`), on both success and failure.
- **`docs/context/issue_4826_camera_ready_gpu_lifecycle.md`**: recorded the #4957 fix and the "never ran end-to-end until #4957" caveat in Phase 2.

## Regression proof

The new emission test **fails against the pre-fix code** with the exact smoke-worker error, confirming it is a genuine guard:

```
FAILED ...::test_subprocess_path_emits_isolation_and_cleanup_metrics
TypeError: Object of type PosixPath is not JSON serializable
```

With the fix in place, all tests pass.

## Validation (CPU only, shared venv — no campaigns/Slurm/training)

```
ruff check robot_sf/benchmark/camera_ready/campaign.py \
  robot_sf/benchmark/camera_ready/resource_lifecycle.py \
  tests/benchmark/test_camera_ready_subprocess_isolation.py
All checks passed!

ruff format --check <same files>
3 files already formatted

DISPLAY= SDL_VIDEODRIVER=dummy MPLBACKEND=Agg pytest \
  tests/benchmark/test_camera_ready_subprocess_isolation.py \
  tests/benchmark/test_camera_ready_gpu_cleanup.py -q
28 passed in 5.34s
```

## Scope / successor statement

This PR **fully resolves issue #4957** as stated (patch `campaign.py:714` so the subprocess path can emit the isolation + cleanup metrics; add a regression test asserting the metrics are emitted when `--arm-isolation subprocess`). It does **not** duplicate PRs #4836 / #4846 / #4854 — those landed Phase 0–4 of #4826; this slice adds new capability: the serialization fix that has prevented #4846 from ever running end-to-end, plus a real-path regression test.

The at-scale GPU smoke (Phase 5 of #4826) is explicitly the ops lane's job per the #4957 ask ("Then the ops lane re-runs the smoke (job 13344's exact command) to harvest the evidence #4826 needs before S30 attempt 6"). That live VRAM-return-to-baseline evidence is outside cheap-lane scope (CPU-only, no GPU/Slurm); #4826 stays open for it.

No metric/row/schema/planner semantics changed.

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Closes #4957
Refs #4826, #4365


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a subprocess setup issue that could fail when path values were included, allowing camera-ready benchmark runs to start reliably.
  * Improved isolation reporting so run results continue to show cleanup and subprocess-isolation evidence even when a subprocess fails.

* **Tests**
  * Added broader regression coverage for subprocess handling and metric emission.

* **Documentation**
  * Updated the camera-ready GPU lifecycle notes with the latest failure analysis and follow-up status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->