### PR TITLE
Issue #4956: silence ty optional-dep import findings + fix bar_label type error (cheap-lane worker)

### DIFF
--- a/SLURM/log_gpu_cpu_usage.py
+++ b/SLURM/log_gpu_cpu_usage.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-import GPUtil  # type: ignore[import]
+import GPUtil  # type: ignore  # optional GPU dep; absent in CI/ty environment
 import psutil
 from loguru import logger
 from stable_baselines3 import PPO

--- a/docs/dev/issues/classic-interactions-ppo/imitation_progress.ipynb
+++ b/docs/dev/issues/classic-interactions-ppo/imitation_progress.ipynb
@@ -12,6 +12,7 @@
     "import json\n",
     "from pathlib import Path\n",
     "\n",
+    "from matplotlib.container import BarContainer\n",
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
     "import seaborn as sns\n",
@@ -176,7 +177,8 @@
     "ax.set_ylabel(\"Timesteps\")\n",
     "ax.set_xlabel(\"Run Type\")\n",
     "for container in ax.containers:\n",
-    "    ax.bar_label(container, fmt=\"{:.0f}\")\n",
+    "    if isinstance(container, BarContainer):\n",
+    "        ax.bar_label(container, fmt=\"{:.0f}\")\n",
     "plt.tight_layout()\n",
     "plt.show()"
    ]

--- a/docs/tooling/svg_conv/svg_conv.py
+++ b/docs/tooling/svg_conv/svg_conv.py
@@ -9,7 +9,7 @@ import json
 import os
 import sys
 
-from svgelements import SVG, Path, Point  # type: ignore[attr-defined]
+from svgelements import SVG, Path, Point  # type: ignore  # members not statically resolvable
 
 from robot_sf.common.types import RgbColor, Vec2D
 

--- a/tests/dev/test_issue_4956_ty_optional_dep_suppressions.py
+++ b/tests/dev/test_issue_4956_ty_optional_dep_suppressions.py
@@ -1,0 +1,160 @@
+"""Regression tests for issue #4956: fast-feedback ``ty`` findings on optional-dep imports.
+
+Main CI reported three classes of ``ty`` diagnostics that the issue names explicitly:
+
+* ``error[unresolved-import]: Cannot resolve imported module GPUtil`` — the
+  ``# type: ignore[import]`` suppression used a mypy code that ``ty`` does not
+  honour for an ``unresolved-import`` on the import statement itself.
+* ``error[unresolved-import]: Module svgelements has no member SVG/Path/Point`` —
+  same root cause: ``# type: ignore[attr-defined]`` is the wrong code for an
+  ``unresolved-import`` member-resolution diagnostic.
+* ``error[invalid-argument-type]: Argument to bound method Axes.bar_label is
+  incorrect`` — a real type error: ``ax.containers`` is ``list[Container]`` but
+  ``Axes.bar_label`` declares ``container: BarContainer``.
+
+These tests pin the fix at the source level (fast and deterministic) and, when
+``uvx``/``ty`` is available locally, run the exact ``ty check`` invocation the
+fast-feedback job uses against the three touched files to prove the named
+diagnostics no longer appear.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GPUTIL_SCRIPT = REPO_ROOT / "SLURM" / "log_gpu_cpu_usage.py"
+SVG_CONV_SCRIPT = REPO_ROOT / "docs" / "tooling" / "svg_conv" / "svg_conv.py"
+IMITATION_NOTEBOOK = (
+    REPO_ROOT / "docs" / "dev" / "issues" / "classic-interactions-ppo" / "imitation_progress.ipynb"
+)
+
+# The three named diagnostics from issue #4956. Each must be absent from a ``ty``
+# run over the touched files.
+NAMED_DIAGNOSTIC_SUBSTRINGS = (
+    "Cannot resolve imported module `GPUtil`",
+    "Module `svgelements` has no member `SVG`",
+    "Module `svgelements` has no member `Path`",
+    "Module `svgelements` has no member `Point`",
+    "Argument to bound method `Axes.bar_label` is incorrect",
+)
+
+# mypy-style codes that ``ty`` does NOT honour for ``unresolved-import`` on the
+# import statement. They must not come back on the fixed lines.
+REJECTED_MYPY_CODES = ("type: ignore[import]", "type: ignore[attr-defined]")
+
+
+def test_gputil_import_uses_ty_honoured_suppression() -> None:
+    """GPUtil import must use a bare ``# type: ignore`` (ty-honoured), not ``[import]``."""
+    source = GPUTIL_SCRIPT.read_text(encoding="utf-8")
+    assert "import GPUtil  # type: ignore[import]" not in source
+    assert "import GPUtil  # type: ignore" in source
+
+
+def test_svgelements_import_uses_ty_honoured_suppression() -> None:
+    """svgelements import must use a bare ``# type: ignore``, not ``[attr-defined]``."""
+    source = SVG_CONV_SCRIPT.read_text(encoding="utf-8")
+    assert "from svgelements import SVG, Path, Point  # type: ignore[attr-defined]" not in source
+    assert "from svgelements import SVG, Path, Point  # type: ignore" in source
+
+
+def test_bar_label_call_is_guarded_by_barcontainer_isinstance() -> None:
+    """``ax.bar_label`` must only be called on ``BarContainer`` instances (real type fix).
+
+    ``ax.containers`` is typed ``list[Container]`` while ``Axes.bar_label`` declares
+    ``container: BarContainer``. Filtering to ``BarContainer`` is both type-correct
+    and runtime-correct (bar labels only make sense for bar containers).
+    """
+    nb = json.loads(IMITATION_NOTEBOOK.read_text(encoding="utf-8"))
+    sources = [
+        "".join(cell.get("source", [])) for cell in nb["cells"] if cell.get("cell_type") == "code"
+    ]
+    joined = "\n".join(sources)
+
+    # The import must be present so the isinstance guard resolves at runtime.
+    assert "from matplotlib.container import BarContainer" in joined
+    # The unguarded call must not come back.
+    assert 'ax.bar_label(container, fmt="{:.0f}")' in joined
+    # The loop body must guard bar_label with a BarContainer isinstance check.
+    assert "isinstance(container, BarContainer)" in joined
+    # The previously-unguarded pattern (bar_label directly under the for-loop) is gone.
+    assert "for container in ax.containers:\n    ax.bar_label(" not in joined
+
+
+@pytest.mark.parametrize("rejected_code", REJECTED_MYPY_CODES)
+def test_no_reintroduced_mypy_ignore_codes_on_fixed_lines(rejected_code: str) -> None:
+    """Neither fixed ``.py`` file should reintroduce the mypy codes ty ignores."""
+    for path in (GPUTIL_SCRIPT, SVG_CONV_SCRIPT):
+        assert rejected_code not in path.read_text(encoding="utf-8"), path
+
+
+def _uvx_available() -> bool:
+    return shutil.which("uvx") is not None
+
+
+def _resolve_ty_python() -> Path | None:
+    """Resolve a Python environment for ``ty``.
+
+    ``ty`` only emits the issue #4956 diagnostics when it can resolve the project
+    site-packages (so optional deps like GPUtil are confirmed absent and
+    svgelements/matplotlib members are checked). In a linked worktree the local
+    ``./.venv`` may not exist, so fall back to the shared/main checkout venv the
+    same way the worktree shared-venv helper does.
+    """
+    candidates: list[Path] = []
+    local_venv = REPO_ROOT / ".venv"
+    if local_venv.exists():
+        candidates.append(local_venv)
+    env_override = os.environ.get("UV_PROJECT_ENVIRONMENT")
+    if env_override:
+        candidates.append(Path(env_override))
+    # Linked worktree: derive the main checkout venv from the common git dir.
+    try:
+        common_dir = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout.strip()
+        if common_dir:
+            main_root = Path(common_dir).resolve().parent
+            candidates.append(main_root / ".venv")
+    except (subprocess.CalledProcessError, OSError, FileNotFoundError):
+        pass
+    for cand in candidates:
+        if (cand / "bin" / "python").exists():
+            return cand
+    return None
+
+
+@pytest.mark.skipif(not _uvx_available(), reason="uvx/ty not installed in this environment")
+def test_ty_check_touched_files_reports_no_named_diagnostics() -> None:
+    """Run the exact fast-feedback ``ty check`` over the three touched files.
+
+    This is the executable acceptance for issue #4956: the named diagnostics
+    (GPUtil unresolved-import, svgelements member resolution, Axes.bar_label
+    argument type) must not appear. ``ty`` is advisory in CI (``--exit-zero``);
+    this assertion is about the named findings being absent, not the exit code.
+    """
+    venv = _resolve_ty_python()
+    if venv is None:
+        pytest.skip("no resolvable Python environment for ty (venv missing)")
+    cmd = ["uvx", "ty", "check", "--exit-zero", "--python", str(venv)]
+    cmd += [str(GPUTIL_SCRIPT), str(SVG_CONV_SCRIPT), str(IMITATION_NOTEBOOK)]
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=300)
+    combined = result.stdout + result.stderr
+    # Guard against a vacuous pass: ty must actually have run against a real env.
+    # A non-vacuous run always mentions either a clean result or a diagnostic count.
+    assert combined.strip(), f"ty produced no output; env={venv}\nstderr={result.stderr!r}"
+    missing = [needle for needle in NAMED_DIAGNOSTIC_SUBSTRINGS if needle in combined]
+    assert not missing, (
+        f"named issue #4956 diagnostics reappeared: {missing}\nty output:\n{combined}"
+    )

--- a/tests/dev/test_issue_4956_ty_optional_dep_suppressions.py
+++ b/tests/dev/test_issue_4956_ty_optional_dep_suppressions.py
@@ -130,7 +130,8 @@ def _resolve_ty_python() -> Path | None:
     except (subprocess.CalledProcessError, OSError, FileNotFoundError):
         pass
     for cand in candidates:
-        if (cand / "bin" / "python").exists():
+        # POSIX venvs use ``bin/python``; Windows venvs use ``Scripts/python.exe``.
+        if (cand / "bin" / "python").exists() or (cand / "Scripts" / "python.exe").exists():
             return cand
     return None
 
@@ -147,7 +148,10 @@ def test_ty_check_touched_files_reports_no_named_diagnostics() -> None:
     venv = _resolve_ty_python()
     if venv is None:
         pytest.skip("no resolvable Python environment for ty (venv missing)")
-    cmd = ["uvx", "ty", "check", "--exit-zero", "--python", str(venv)]
+    # Resolve uvx to an absolute path for robustness (Windows: uvx may be a
+    # batch/cmd script that subprocess cannot launch by bare name without a shell).
+    uvx_path = shutil.which("uvx") or "uvx"
+    cmd = [uvx_path, "ty", "check", "--exit-zero", "--python", str(venv)]
     cmd += [str(GPUTIL_SCRIPT), str(SVG_CONV_SCRIPT), str(IMITATION_NOTEBOOK)]
     result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=300)
     combined = result.stdout + result.stderr


### PR DESCRIPTION
## What / Why

Closes #4956 — main CI's fast-feedback `ty` type-check reported three named diagnostics. All three are fixed so the named findings no longer appear, while the advisory `--exit-zero` policy (PR #1372) is intentionally preserved (the issue explicitly says: do NOT weaken ty to `--exit-zero` if it was made enforcing — fix the actual errors).

| Finding | File | Root cause | Fix |
| --- | --- | --- | --- |
| `error[unresolved-import]: Cannot resolve imported module GPUtil` | `SLURM/log_gpu_cpu_usage.py` | `# type: ignore[import]` is a **mypy** code; ty does not honour it for an `unresolved-import` on the import statement | bare `# type: ignore` (matches repo convention in `robot_sf/telemetry/*`) |
| `error[unresolved-import]: Module svgelements has no member SVG/Path/Point` | `docs/tooling/svg_conv/svg_conv.py` | `# type: ignore[attr-defined]` is the wrong code for an `unresolved-import` member-resolution diagnostic | bare `# type: ignore` |
| `error[invalid-argument-type]: Argument to bound method Axes.bar_label is incorrect` | `docs/dev/issues/.../imitation_progress.ipynb` | **real type error**: `ax.containers` is `list[Container]` but `Axes.bar_label` declares `container: BarContainer` | import `BarContainer`, guard the call with `isinstance(container, BarContainer)` — type-correct **and** runtime-correct (bar labels only apply to bar containers) |

## Why the suppressions were wrong

In ty 0.0.57 (the version CI fetches via `uvx ty`), `# type: ignore[unresolved-import]` and `# type: ignore[attr-defined]` do **not** suppress an `unresolved-import` on the `import`/`from ... import` statement, but a bare `# type: ignore` does. The repo already uses bare `# type: ignore` for optional deps (`robot_sf/telemetry/gpu.py`, `sampler.py`, `recommendations.py`), so the fix aligns with existing convention.

## Validation (CPU-level)

Exact fast-feedback invocation: `uvx ty check . --exit-zero` (advisory; reports findings, exits 0).

**Targeted** — the three touched files now report `All checks passed!`:
```
$ uvx ty check SLURM/log_gpu_cpu_usage.py docs/tooling/svg_conv/svg_conv.py \
    docs/dev/issues/classic-interactions-ppo/imitation_progress.ipynb --python .venv
All checks passed!
```

**Full repo** — `uvx ty check . --exit-zero` drops from **2716 → 2711 diagnostics** (exactly the five named-error lines removed; GPUtil + svgelements SVG/Path/Point + bar_label + its "Method defined here" info line). Zero references to `GPUtil`, `svgelements has no member`, or `bar_label` remain. No new findings introduced.

**Tests** — new `tests/dev/test_issue_4956_ty_optional_dep_suppressions.py` (6 tests, all passing):
```
$ uv run pytest tests/dev/test_issue_4956_ty_optional_dep_suppressions.py -q
6 passed in 1.76s
```
- 4 source-level regression guards (fast, deterministic): correct bare `# type: ignore` on both `.py` files; the BarContainer import + `isinstance` guard present; the rejected mypy codes `[import]`/`[attr-defined]` do not return.
- 1 non-vacuous integration test that runs the exact `uvx ty check --exit-zero` over the three touched files and asserts the named diagnostics are absent. It resolves the ty python env in both CI (`./.venv`) and linked worktrees (via `UV_PROJECT_ENVIRONMENT` / common git dir), skips cleanly when no env/uvx is available, and guards against a vacuous pass (empty output).

Regression-proof: verified each guard **fails for the right reason** when its fix is reverted (GPUtil → `Cannot resolve imported module GPUtil`; svgelements → `has no member SVG/Path/Point`; bar_label guard removed → both the `Axes.bar_label` diagnostic and the missing-`isinstance` source assertion fire).

**Runtime sanity** — the bar_label guard executes correctly: `ax.bar` produces a `BarContainer`, the `isinstance` check passes, `bar_label` is called as before (no behavior change for the actual plot).

**Existing contract tests unchanged** — `tests/test_typecheck_advisory_docs.py` + `tests/test_ci_script_contract.py` (59 tests) still pass; the advisory policy contract is untouched.

**Lint/format** — `ruff check` + `ruff format --check` clean on all changed files.

## Scope / What is NOT in this PR

This PR fully resolves the ty type-check errors named in issue #4956 (GPUtil, svgelements, bar_label). It does **not** address:

1. **The other pre-existing `ty` findings** (2711 remaining): `adjustText`, `cairosvg`, `rvo2`, `camera_ready_campaign` member-resolution, `unused-type-ignore-comment` warnings, and numerous `invalid-argument-type`/`invalid-assignment` findings across the codebase. These are **not named in #4956** and are out of scope; each would be a separate effort. The issue specifically scopes to "optional-dep imports (GPUtil/svgelements) + bar_label".
2. **The current main-CI unit-test failure** (`tests/benchmark/test_issue_4367_codesign_campaign_runner.py::test_missing_hydration_manifest_fails_before_outputs` → `FileNotFoundError: .../missing.json`). This is a **separate, pre-existing defect** in the campaign hydration fail-closed path (issue #4367 territory), unrelated to ty type-checking. It fails on the base commit `e8910855` (origin/main HEAD) and this PR's changes do not touch campaign-runner code. It is tracked separately from #4956.

Because this PR resolves exactly the ty errors the issue names and the issue is a `fix:` issue, it uses `Closes #4956`. The separate unit-test failure should be tracked via its own issue/fix.

## Successor statement

This is a complete resolution of issue #4956's named scope (ty optional-dep import suppressions + bar_label type error), not a partial slice. It does not duplicate any prior PR.

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
