### PR TITLE
Issue #4960: restore codesign runner missing-manifest fail-closed (cheap-lane worker)

### DIFF
--- a/scripts/benchmark/run_issue_4205_codesign_loop_campaign.py
+++ b/scripts/benchmark/run_issue_4205_codesign_loop_campaign.py
@@ -679,7 +679,7 @@ def run_campaign(args: argparse.Namespace) -> dict[str, Any]:
     manifest_path = Path(args.hydration_manifest)
     try:
         manifest_payload = _load_json(manifest_path)
-    except (FileNotFoundError, OSError) as exc:
+    except OSError as exc:
         # Fail closed on a missing/unreadable private hydration manifest instead
         # of letting the raw OSError propagate (#4960: regression after the
         # local _load_json was consolidated onto hash_utils.load_json, which

--- a/scripts/benchmark/run_issue_4205_codesign_loop_campaign.py
+++ b/scripts/benchmark/run_issue_4205_codesign_loop_campaign.py
@@ -677,9 +677,18 @@ def run_campaign(args: argparse.Namespace) -> dict[str, Any]:
         research_report,
     )
     manifest_path = Path(args.hydration_manifest)
+    try:
+        manifest_payload = _load_json(manifest_path)
+    except (FileNotFoundError, OSError) as exc:
+        # Fail closed on a missing/unreadable private hydration manifest instead
+        # of letting the raw OSError propagate (#4960: regression after the
+        # local _load_json was consolidated onto hash_utils.load_json, which
+        # dropped the path.exists() -> ContractError guard). main() converts
+        # ContractError into exit code 2 before any campaign output is written.
+        raise ContractError(f"missing or unreadable hydration manifest: {manifest_path}") from exc
     hydration = _validate_checkpoint_hydration_manifest(
         research_report,
-        _load_json(manifest_path),
+        manifest_payload,
         manifest_path=manifest_path,
     )
     if hydration.get("schema_version") != HYDRATION_MANIFEST_SCHEMA:

--- a/tests/benchmark/test_issue_4367_codesign_campaign_runner.py
+++ b/tests/benchmark/test_issue_4367_codesign_campaign_runner.py
@@ -346,6 +346,27 @@ def test_missing_hydration_manifest_fails_before_outputs(tmp_path: Path) -> None
     assert not output_root.exists()
 
 
+def test_unreadable_hydration_manifest_fails_before_outputs(tmp_path: Path) -> None:
+    """Campaign execution is fail-closed when the manifest cannot be read."""
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.mkdir()
+    output_root = tmp_path / "campaign"
+
+    exit_code = _MODULE.main(
+        [
+            "--config",
+            str(BENCHMARK_CONFIG),
+            "--hydration-manifest",
+            str(manifest_path),
+            "--output-root",
+            str(output_root),
+            "--smoke",
+        ]
+    )
+    assert exit_code == 2
+    assert not output_root.exists()
+
+
 def test_missing_hydrated_checkpoint_fails_before_outputs(tmp_path: Path) -> None:
     """Submit contract rejects a manifest pointing at a missing checkpoint."""
     manifest_path = _hydration_manifest(tmp_path)


### PR DESCRIPTION
## Summary

Restore the issue #4367 co-design campaign runner's fail-closed behavior when its private hydration manifest is missing or unreadable. The runner now returns exit code 2 before creating campaign outputs.

## Linked Issues

- Closes #4960

## What Changed

- Convert `OSError` from loading the hydration manifest into the runner's existing `ContractError` boundary.
- Add regression coverage for an unreadable manifest as well as the existing missing-manifest case.

## Why It Matters

Main CI regressed because the missing-manifest test received a raw `FileNotFoundError`. This restores the preflight safety contract without broad exception handling or changes to advisory type checking.

## Root Cause

The issue body's broad-exception hypothesis was not the cause. PR #4929 / merge commit `9293786cc` replaced the validation module's local `_load_json` helper with `robot_sf.benchmark.identity.hash_utils.load_json`. The removed helper converted a missing path to `ContractError`; the canonical helper intentionally propagates file-read `OSError`. The campaign runner imports that helper through the validation module, so the error bypassed `main()`'s `ContractError` handler.

The fix catches only `OSError`. `FileNotFoundError` is already an `OSError` subclass, so listing both would be redundant. JSON shape and parse errors are outside #4960's missing/unreadable file contract and are not hidden by this change.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: main-CI fail-closed regression #4960
- Comparator or baseline, if applicable: behavior before PR #4929
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: both missing and unreadable manifests return 2 before outputs; required focused suites and CI pass
- Parent issue, claim map, registry, context note, or synthesis surface to update: #4960, merge-driven close
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - runtime contract repair only

## Domain-Aware Approval

- Required for this PR: no - it changes no evidence classification, comparison method, figure eligibility, benchmark interpretation, or paper-facing claim
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: repository contract

## Falsification / Non-Transfer Check

NA - support/runtime bug fix with no research-result claim.

## Next Empirical Action

NA - focused executable proof is complete; wait for deterministic CI.

## Validation / Proof

- `PYTHONPATH=$PWD uv run pytest tests/benchmark/test_issue_4367_codesign_campaign_runner.py::test_missing_hydration_manifest_fails_before_outputs -q` -> 1 passed
- `PYTHONPATH=$PWD uv run pytest tests/benchmark/test_issue_4367_codesign_campaign_runner.py -q` -> 9 passed
- `PYTHONPATH=$PWD uv run pytest tests/validation/test_issue_4205_static_constriction_codesign_loop.py -q` -> 16 passed
- `PYTHONPATH=$PWD uv run python scripts/validation/check_broad_exceptions.py` -> passed with 217 entries
- `uv run ruff check scripts/benchmark/run_issue_4205_codesign_loop_campaign.py tests/benchmark/test_issue_4367_codesign_campaign_runner.py` -> passed
- `uv run ruff format --check scripts/benchmark/run_issue_4205_codesign_loop_campaign.py tests/benchmark/test_issue_4367_codesign_campaign_runner.py` -> passed

## Risks / Rollout

- Compatibility risk: low; only file-read `OSError` at the hydration-manifest boundary is translated.
- Failure mode: malformed JSON continues to raise its specific parse/type error, matching the intentionally narrow issue scope.
- Rollback: revert this PR; no schema, artifact, or dependency migration is involved.

## Docs / Provenance

- Updated docs: none
- Relevant provenance: PR #4929 / commit `9293786cc`
- Preserved assumptions: no Slurm/GPU/campaign run, claim promotion, typecheck configuration, or broad-exception ratchet change

## Downstream Propagation

- Parent issue updated: merge-driven close
- Claim map / benchmark report updated: NA
- Leaderboard / artifact catalog updated: NA
- Registry or config index updated: NA
- Context index / memory note updated: NA
- Follow-up issue opened for deferred propagation: NA
- Not applicable because: this is a focused runtime/CI contract repair and produces no benchmark evidence.

## Follow-Up Issues

- Deferred work: none required for #4960
- Issues opened for follow-up: none

## Reviewer Notes

- Verify the handler remains `except OSError`, with no bare or broad `Exception` catch.
- The candidate was produced by the Pi/GLM-5.2 lane and corrected by the strong Codex gate.
