### PR TITLE
feat(benchmark): generated scenario catalog contract (#4932)

### DIFF
--- a/robot_sf/benchmark/scenario_generation/__init__.py
+++ b/robot_sf/benchmark/scenario_generation/__init__.py
@@ -1,0 +1,18 @@
+"""Distill replay-pending catalog entries from critical episode trace windows.
+
+Entries produced here are generated scenario hypotheses, never benchmark evidence.
+"""
+
+from robot_sf.benchmark.scenario_generation.catalog_schema import (
+    CATALOG_ENTRY_SCHEMA_VERSION,
+    GeneratedScenarioCatalogValidationError,
+    validate_catalog_entry,
+)
+from robot_sf.benchmark.scenario_generation.segment_extraction import extract_critical_segment
+
+__all__ = [
+    "CATALOG_ENTRY_SCHEMA_VERSION",
+    "GeneratedScenarioCatalogValidationError",
+    "extract_critical_segment",
+    "validate_catalog_entry",
+]

--- a/robot_sf/benchmark/scenario_generation/catalog_schema.py
+++ b/robot_sf/benchmark/scenario_generation/catalog_schema.py
@@ -1,0 +1,128 @@
+"""Validate generated-scenario catalog entries before they can be persisted.
+
+The contract intentionally marks every entry as a review-pending hypothesis.  It
+does not make generated scenarios part of the benchmark matrix or evidence base.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+CATALOG_ENTRY_SCHEMA_VERSION = "generated-scenario-catalog-entry.v1"
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[1] / "schemas" / "generated_scenario_catalog_entry.v1.json"
+)
+
+
+class GeneratedScenarioCatalogValidationError(ValueError):
+    """Raised when a catalog entry cannot safely be stored as a hypothesis."""
+
+
+def load_catalog_entry_schema() -> dict[str, Any]:
+    """Return the versioned JSON Schema for generated catalog entries."""
+
+    with _SCHEMA_PATH.open(encoding="utf-8") as schema_file:
+        return json.load(schema_file)
+
+
+def validate_catalog_entry(entry: Mapping[str, Any]) -> None:
+    """Fail closed unless *entry* is a non-benchmark, replay-pending catalog entry.
+
+    Raises:
+        GeneratedScenarioCatalogValidationError: If JSON Schema or temporal
+            invariants reject the entry.
+    """
+
+    if not isinstance(entry, Mapping):
+        raise GeneratedScenarioCatalogValidationError("catalog entry must be a mapping")
+
+    _validate_json_schema(entry)
+    _validate_temporal_contract(entry)
+    _validate_replay_contract(entry)
+    _validate_trace_frames(entry)
+
+
+def _validate_json_schema(entry: Mapping[str, Any]) -> None:
+    errors = sorted(
+        Draft202012Validator(load_catalog_entry_schema()).iter_errors(dict(entry)),
+        key=lambda error: list(error.absolute_path),
+    )
+    if errors:
+        formatted = "; ".join(
+            f"/{'/'.join(str(part) for part in error.absolute_path)}: {error.message}"
+            for error in errors
+        )
+        raise GeneratedScenarioCatalogValidationError(formatted)
+
+
+def _validate_temporal_contract(entry: Mapping[str, Any]) -> None:
+    segment = entry["segment"]
+    start_s = float(segment["window_start_s"])
+    end_s = float(segment["window_end_s"])
+    observed_at_s = float(entry["criticality"]["observed_at_s"])
+    if not all(math.isfinite(value) for value in (start_s, end_s, observed_at_s)):
+        raise GeneratedScenarioCatalogValidationError("segment times must be finite")
+    if end_s < start_s:
+        raise GeneratedScenarioCatalogValidationError(
+            "segment.window_end_s must be >= window_start_s"
+        )
+    if not start_s <= observed_at_s <= end_s:
+        raise GeneratedScenarioCatalogValidationError(
+            "criticality.observed_at_s must lie inside the extracted segment"
+        )
+
+
+def _validate_replay_contract(entry: Mapping[str, Any]) -> None:
+    if entry["replay"]["source_seed"] != entry["source_episode"]["source_seed"]:
+        raise GeneratedScenarioCatalogValidationError(
+            "replay.source_seed must equal source_episode.source_seed"
+        )
+    if entry["replay"]["status"] == "not_representable_yet" and not any(
+        warning.startswith("replay_gap:") for warning in entry["replay"]["warnings"]
+    ):
+        raise GeneratedScenarioCatalogValidationError(
+            "not_representable_yet entries must include a replay_gap warning"
+        )
+
+
+def _validate_trace_frames(entry: Mapping[str, Any]) -> None:
+    segment = entry["segment"]
+    start_s = float(segment["window_start_s"])
+    end_s = float(segment["window_end_s"])
+    frames = segment["trace_frames"]
+    frame_times = [float(frame["time_s"]) for frame in frames]
+    if frame_times != sorted(frame_times) or len(set(frame_times)) != len(frame_times):
+        raise GeneratedScenarioCatalogValidationError(
+            "segment.trace_frames must have increasing time_s"
+        )
+    if frame_times[0] != start_s or frame_times[-1] != end_s:
+        raise GeneratedScenarioCatalogValidationError(
+            "segment bounds must equal the first and last trace-frame timestamps"
+        )
+    if segment["initial_robot_state"] != frames[0]["robot"]:
+        raise GeneratedScenarioCatalogValidationError(
+            "segment.initial_robot_state must equal the first trace-frame robot state"
+        )
+    for frame in frames:
+        _require_finite_position(frame["robot"]["position"])
+        for pedestrian in frame["pedestrians"]:
+            _require_finite_position(pedestrian["position"])
+
+
+def _require_finite_position(position: list[object]) -> None:
+    if not all(isinstance(value, int | float) and math.isfinite(value) for value in position):
+        raise GeneratedScenarioCatalogValidationError("trace positions must be finite numbers")
+
+
+__all__ = [
+    "CATALOG_ENTRY_SCHEMA_VERSION",
+    "GeneratedScenarioCatalogValidationError",
+    "load_catalog_entry_schema",
+    "validate_catalog_entry",
+]

--- a/robot_sf/benchmark/scenario_generation/segment_extraction.py
+++ b/robot_sf/benchmark/scenario_generation/segment_extraction.py
@@ -17,8 +17,8 @@ _CLAIM_BOUNDARY = "generated scenario hypotheses only"
 def extract_critical_segment(
     episode: Mapping[str, Any],
     *,
-    pre_margin_s: float = 1.0,
-    post_margin_s: float = 1.0,
+    pre_margin_s: float | None = None,
+    post_margin_s: float | None = None,
 ) -> dict[str, Any]:
     """Extract the closest robot--pedestrian window into a catalog entry.
 
@@ -36,6 +36,8 @@ def extract_critical_segment(
         ValueError: If the trace lacks a finite, ordered robot/pedestrian record.
     """
 
+    pre_margin_s = 1.0 if pre_margin_s is None else pre_margin_s
+    post_margin_s = 1.0 if post_margin_s is None else post_margin_s
     _validate_margin("pre_margin_s", pre_margin_s)
     _validate_margin("post_margin_s", post_margin_s)
     episode_id = _required_string(episode, "episode_id")
@@ -188,7 +190,9 @@ def _first_frame_at_or_after(frames: list[dict[str, Any]], threshold_s: float) -
 
 
 def _last_frame_at_or_before(frames: list[dict[str, Any]], threshold_s: float) -> int:
-    return max(index for index, frame in enumerate(frames) if frame["time_s"] <= threshold_s)
+    return next(
+        index for index in reversed(range(len(frames))) if frames[index]["time_s"] <= threshold_s
+    )
 
 
 def _stable_scenario_id(

--- a/robot_sf/benchmark/scenario_generation/segment_extraction.py
+++ b/robot_sf/benchmark/scenario_generation/segment_extraction.py
@@ -1,0 +1,207 @@
+"""Extract a conservative, replay-pending critical segment from one episode trace."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from robot_sf.benchmark.scenario_generation.catalog_schema import validate_catalog_entry
+
+_DISTILLER_ID = "critical_segment_min_clearance.v1"
+_CLAIM_BOUNDARY = "generated scenario hypotheses only"
+
+
+def extract_critical_segment(
+    episode: Mapping[str, Any],
+    *,
+    pre_margin_s: float = 1.0,
+    post_margin_s: float = 1.0,
+) -> dict[str, Any]:
+    """Extract the closest robot--pedestrian window into a catalog entry.
+
+    The input is a narrow, JSON-compatible trace contract: ``episode_id``,
+    ``seed``, ``source_map``, and ordered ``steps`` with ``time_s``,
+    ``robot.position``, and ``pedestrians[].position``.  The result preserves
+    sampled states but reports ``not_representable_yet`` because this slice does
+    not claim that trace states can already be replayed as scenario YAML.
+
+    Returns:
+        A JSON-compatible generated catalog entry with a pinned source seed and
+        the closest robot--pedestrian trace segment.
+
+    Raises:
+        ValueError: If the trace lacks a finite, ordered robot/pedestrian record.
+    """
+
+    _validate_margin("pre_margin_s", pre_margin_s)
+    _validate_margin("post_margin_s", post_margin_s)
+    episode_id = _required_string(episode, "episode_id")
+    source_map = _required_string(episode, "source_map")
+    seed = _required_seed(episode)
+    frames = _normalize_frames(episode.get("steps"))
+
+    critical_index, min_clearance_m = _critical_frame(frames)
+    critical_time_s = frames[critical_index]["time_s"]
+    start_index = _first_frame_at_or_after(frames, critical_time_s - pre_margin_s)
+    end_index = _last_frame_at_or_before(frames, critical_time_s + post_margin_s)
+    selected_frames = frames[start_index : end_index + 1]
+    start_s = selected_frames[0]["time_s"]
+    end_s = selected_frames[-1]["time_s"]
+
+    scenario_id = _stable_scenario_id(episode_id, seed, start_s, end_s, critical_time_s)
+    entry = {
+        "schema_version": "generated-scenario-catalog-entry.v1",
+        "scenario_id": scenario_id,
+        "metadata": {
+            "source": "auto_generated",
+            "generated_by": "robot_sf.benchmark.scenario_generation.segment_extraction",
+            "required_manual_review": True,
+            "benchmark_evidence": False,
+        },
+        "source_episode": {
+            "episode_id": episode_id,
+            "source_seed": seed,
+            "source_map": source_map,
+        },
+        "criticality": {
+            "signal": "min_clearance",
+            "observed_at_s": critical_time_s,
+            "source_metrics": {"min_clearance_m": min_clearance_m},
+        },
+        "segment": {
+            "window_start_s": start_s,
+            "window_end_s": end_s,
+            "initial_robot_state": selected_frames[0]["robot"],
+            "trace_frames": selected_frames,
+        },
+        "replay": {
+            "schema_version": "generated-scenario-replay.v1",
+            "source_seed": seed,
+            "replay_contract": "source_episode_seed_pinned.v1",
+            "status": "not_representable_yet",
+            "warnings": [
+                "replay_gap: sampled trace states are not yet representable as standalone scenario YAML"
+            ],
+        },
+        "provenance": {
+            "schema_version": "generated-scenario-provenance.v1",
+            "source_issue": "#4932",
+            "distiller": _DISTILLER_ID,
+            "claim_boundary": _CLAIM_BOUNDARY,
+        },
+    }
+    validate_catalog_entry(entry)
+    return entry
+
+
+def _validate_margin(name: str, value: float) -> None:
+    if not isinstance(value, int | float) or isinstance(value, bool) or not math.isfinite(value):
+        raise ValueError(f"{name} must be a finite number")
+    if value < 0.0:
+        raise ValueError(f"{name} must be >= 0")
+
+
+def _required_string(payload: Mapping[str, Any], name: str) -> str:
+    value = payload.get(name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"episode.{name} must be a non-empty string")
+    return value.strip()
+
+
+def _required_seed(episode: Mapping[str, Any]) -> int:
+    seed = episode.get("seed")
+    if not isinstance(seed, int) or isinstance(seed, bool):
+        raise ValueError("episode.seed must be an integer")
+    return seed
+
+
+def _normalize_frames(raw_steps: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_steps, Sequence) or isinstance(raw_steps, str | bytes) or not raw_steps:
+        raise ValueError("episode.steps must be a non-empty sequence")
+
+    frames: list[dict[str, Any]] = []
+    previous_time_s = -math.inf
+    for index, raw_step in enumerate(raw_steps):
+        if not isinstance(raw_step, Mapping):
+            raise ValueError(f"episode.steps[{index}] must be a mapping")
+        time_s = _finite_number(raw_step.get("time_s"), f"episode.steps[{index}].time_s")
+        if time_s <= previous_time_s:
+            raise ValueError("episode.steps time_s must be strictly increasing")
+        previous_time_s = time_s
+        robot = _state(raw_step.get("robot"), f"episode.steps[{index}].robot")
+        raw_pedestrians = raw_step.get("pedestrians")
+        if not isinstance(raw_pedestrians, Sequence) or isinstance(raw_pedestrians, str | bytes):
+            raise ValueError(f"episode.steps[{index}].pedestrians must be a sequence")
+        pedestrians = [
+            _state(pedestrian, f"episode.steps[{index}].pedestrians[{pedestrian_index}]")
+            for pedestrian_index, pedestrian in enumerate(raw_pedestrians)
+        ]
+        frames.append({"time_s": time_s, "robot": robot, "pedestrians": pedestrians})
+    return frames
+
+
+def _state(raw_state: object, path: str) -> dict[str, list[float]]:
+    if not isinstance(raw_state, Mapping):
+        raise ValueError(f"{path} must be a mapping")
+    raw_position = raw_state.get("position")
+    if (
+        not isinstance(raw_position, Sequence)
+        or isinstance(raw_position, str | bytes)
+        or len(raw_position) != 2
+    ):
+        raise ValueError(f"{path}.position must contain exactly two numbers")
+    return {
+        "position": [
+            _finite_number(raw_position[0], f"{path}.position[0]"),
+            _finite_number(raw_position[1], f"{path}.position[1]"),
+        ]
+    }
+
+
+def _finite_number(value: object, path: str) -> float:
+    if not isinstance(value, int | float) or isinstance(value, bool) or not math.isfinite(value):
+        raise ValueError(f"{path} must be a finite number")
+    return float(value)
+
+
+def _critical_frame(frames: list[dict[str, Any]]) -> tuple[int, float]:
+    best: tuple[int, float] | None = None
+    for frame_index, frame in enumerate(frames):
+        robot_position = frame["robot"]["position"]
+        for pedestrian in frame["pedestrians"]:
+            pedestrian_position = pedestrian["position"]
+            clearance_m = math.dist(robot_position, pedestrian_position)
+            if best is None or clearance_m < best[1]:
+                best = (frame_index, clearance_m)
+    if best is None:
+        raise ValueError(
+            "episode trace contains no pedestrian positions for min_clearance extraction"
+        )
+    return best
+
+
+def _first_frame_at_or_after(frames: list[dict[str, Any]], threshold_s: float) -> int:
+    return next(index for index, frame in enumerate(frames) if frame["time_s"] >= threshold_s)
+
+
+def _last_frame_at_or_before(frames: list[dict[str, Any]], threshold_s: float) -> int:
+    return max(index for index, frame in enumerate(frames) if frame["time_s"] <= threshold_s)
+
+
+def _stable_scenario_id(
+    episode_id: str,
+    seed: int,
+    start_s: float,
+    end_s: float,
+    observed_at_s: float,
+) -> str:
+    identity = json.dumps(
+        [episode_id, seed, start_s, end_s, observed_at_s], separators=(",", ":"), ensure_ascii=True
+    )
+    return f"generated-{hashlib.sha256(identity.encode()).hexdigest()[:16]}"
+
+
+__all__ = ["extract_critical_segment"]

--- a/robot_sf/benchmark/schemas/generated_scenario_catalog_entry.v1.json
+++ b/robot_sf/benchmark/schemas/generated_scenario_catalog_entry.v1.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/generated_scenario_catalog_entry.v1.json",
+  "title": "RobotSF Generated Scenario Catalog Entry (v1)",
+  "description": "A trace-distilled scenario hypothesis. It is never benchmark evidence and requires manual review before promotion.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "scenario_id", "metadata", "source_episode", "criticality", "segment", "replay", "provenance"],
+  "properties": {
+    "schema_version": {"const": "generated-scenario-catalog-entry.v1"},
+    "scenario_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "generated_by", "required_manual_review", "benchmark_evidence"],
+      "properties": {
+        "source": {"const": "auto_generated"},
+        "generated_by": {"type": "string", "minLength": 1},
+        "required_manual_review": {"const": true},
+        "benchmark_evidence": {"const": false}
+      }
+    },
+    "source_episode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["episode_id", "source_seed", "source_map"],
+      "properties": {
+        "episode_id": {"type": "string", "minLength": 1},
+        "source_seed": {"type": "integer"},
+        "source_map": {"type": "string", "minLength": 1}
+      }
+    },
+    "criticality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["signal", "observed_at_s", "source_metrics"],
+      "properties": {
+        "signal": {"const": "min_clearance"},
+        "observed_at_s": {"type": "number", "minimum": 0},
+        "source_metrics": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["min_clearance_m"],
+          "properties": {"min_clearance_m": {"type": "number", "minimum": 0}}
+        }
+      }
+    },
+    "segment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["window_start_s", "window_end_s", "initial_robot_state", "trace_frames"],
+      "properties": {
+        "window_start_s": {"type": "number", "minimum": 0},
+        "window_end_s": {"type": "number", "minimum": 0},
+        "initial_robot_state": {"$ref": "#/$defs/state"},
+        "trace_frames": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/frame"}}
+      }
+    },
+    "replay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "source_seed", "replay_contract", "status", "warnings"],
+      "properties": {
+        "schema_version": {"const": "generated-scenario-replay.v1"},
+        "source_seed": {"type": "integer"},
+        "replay_contract": {"const": "source_episode_seed_pinned.v1"},
+        "status": {"enum": ["replay_validated", "loads_only", "not_representable_yet"]},
+        "warnings": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "source_issue", "distiller", "claim_boundary"],
+      "properties": {
+        "schema_version": {"const": "generated-scenario-provenance.v1"},
+        "source_issue": {"const": "#4932"},
+        "distiller": {"type": "string", "minLength": 1},
+        "claim_boundary": {"const": "generated scenario hypotheses only"}
+      }
+    }
+  },
+  "$defs": {
+    "state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["position"],
+      "properties": {"position": {"type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2}}
+    },
+    "frame": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["time_s", "robot", "pedestrians"],
+      "properties": {
+        "time_s": {"type": "number", "minimum": 0},
+        "robot": {"$ref": "#/$defs/state"},
+        "pedestrians": {"type": "array", "items": {"$ref": "#/$defs/state"}}
+      }
+    }
+  }
+}

--- a/scripts/benchmark/distill_generated_scenario_segment.py
+++ b/scripts/benchmark/distill_generated_scenario_segment.py
@@ -1,0 +1,41 @@
+"""Distill one JSON episode trace into a review-pending generated catalog entry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.scenario_generation import extract_critical_segment
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--episode-json", type=Path, required=True, help="Input episode trace JSON file."
+    )
+    parser.add_argument(
+        "--output", type=Path, required=True, help="Output catalog-entry JSON file."
+    )
+    parser.add_argument("--pre-margin-s", type=float, default=1.0)
+    parser.add_argument("--post-margin-s", type=float, default=1.0)
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Write one validated catalog entry and no benchmark or replay result."""
+
+    args = _parse_args()
+    episode: Any = json.loads(args.episode_json.read_text(encoding="utf-8"))
+    entry = extract_critical_segment(
+        episode,
+        pre_margin_s=args.pre_margin_s,
+        post_margin_s=args.post_margin_s,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(entry, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/distill_generated_scenario_segment.py
+++ b/scripts/benchmark/distill_generated_scenario_segment.py
@@ -18,8 +18,8 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--output", type=Path, required=True, help="Output catalog-entry JSON file."
     )
-    parser.add_argument("--pre-margin-s", type=float, default=1.0)
-    parser.add_argument("--post-margin-s", type=float, default=1.0)
+    parser.add_argument("--pre-margin-s", type=float, default=None)
+    parser.add_argument("--post-margin-s", type=float, default=None)
     return parser.parse_args()
 
 

--- a/tests/benchmark/test_generated_scenario_catalog.py
+++ b/tests/benchmark/test_generated_scenario_catalog.py
@@ -77,6 +77,15 @@ def test_distiller_is_deterministic_for_one_trace() -> None:
     assert extract_critical_segment(_episode()) == extract_critical_segment(_episode())
 
 
+def test_distiller_preserves_explicit_zero_margins() -> None:
+    """An explicit zero margin selects only the critical frame, not the default window."""
+
+    entry = extract_critical_segment(_episode(), pre_margin_s=0.0, post_margin_s=0.0)
+
+    assert entry["segment"]["window_start_s"] == 1.0
+    assert entry["segment"]["window_end_s"] == 1.0
+
+
 def test_catalog_entry_schema_is_a_valid_json_schema() -> None:
     """The stored contract is itself valid before an entry relies on it."""
 

--- a/tests/benchmark/test_generated_scenario_catalog.py
+++ b/tests/benchmark/test_generated_scenario_catalog.py
@@ -1,0 +1,157 @@
+"""Tests for issue #4932's review-pending generated scenario catalog contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from robot_sf.benchmark.scenario_generation import (
+    GeneratedScenarioCatalogValidationError,
+    extract_critical_segment,
+    validate_catalog_entry,
+)
+from robot_sf.benchmark.scenario_generation.catalog_schema import load_catalog_entry_schema
+
+
+def _episode() -> dict:
+    """Return a synthetic randomized episode trace with a known closest approach."""
+
+    return {
+        "episode_id": "random-campus-0007",
+        "seed": 4932,
+        "source_map": "maps/svg_maps/classic_crossing.svg",
+        "steps": [
+            {
+                "time_s": 0.0,
+                "robot": {"position": [0.0, 0.0]},
+                "pedestrians": [{"position": [4.0, 0.0]}],
+            },
+            {
+                "time_s": 1.0,
+                "robot": {"position": [1.0, 0.0]},
+                "pedestrians": [{"position": [1.3, 0.0]}],
+            },
+            {
+                "time_s": 2.0,
+                "robot": {"position": [2.0, 0.0]},
+                "pedestrians": [{"position": [5.0, 0.0]}],
+            },
+        ],
+    }
+
+
+def test_distiller_extracts_known_minimum_window_with_provenance() -> None:
+    """A synthetic minimum-clearance frame yields a valid, bounded catalog entry."""
+
+    entry = extract_critical_segment(_episode(), pre_margin_s=1.0, post_margin_s=1.0)
+
+    assert entry["criticality"] == {
+        "signal": "min_clearance",
+        "observed_at_s": 1.0,
+        "source_metrics": {"min_clearance_m": pytest.approx(0.3)},
+    }
+    assert entry["segment"]["window_start_s"] == 0.0
+    assert entry["segment"]["window_end_s"] == 2.0
+    assert entry["segment"]["initial_robot_state"] == {"position": [0.0, 0.0]}
+    assert entry["metadata"]["required_manual_review"] is True
+    assert entry["metadata"]["benchmark_evidence"] is False
+    assert entry["source_episode"] == {
+        "episode_id": "random-campus-0007",
+        "source_seed": 4932,
+        "source_map": "maps/svg_maps/classic_crossing.svg",
+    }
+    assert entry["replay"]["status"] == "not_representable_yet"
+    assert entry["replay"]["warnings"][0].startswith("replay_gap:")
+    validate_catalog_entry(entry)
+
+
+def test_distiller_is_deterministic_for_one_trace() -> None:
+    """A catalog identity is stable for the same episode and extraction bounds."""
+
+    assert extract_critical_segment(_episode()) == extract_critical_segment(_episode())
+
+
+def test_catalog_entry_schema_is_a_valid_json_schema() -> None:
+    """The stored contract is itself valid before an entry relies on it."""
+
+    Draft202012Validator.check_schema(load_catalog_entry_schema())
+
+
+def test_validator_rejects_benchmark_evidence_marker() -> None:
+    """Generated entries fail closed if they assert benchmark evidence."""
+
+    entry = extract_critical_segment(_episode())
+    entry["metadata"]["benchmark_evidence"] = True
+
+    with pytest.raises(GeneratedScenarioCatalogValidationError, match="False was expected"):
+        validate_catalog_entry(entry)
+
+
+def test_validator_rejects_criticality_outside_segment_bounds() -> None:
+    """A stored event timestamp cannot fall outside its extracted trace window."""
+
+    entry = extract_critical_segment(_episode())
+    entry["criticality"]["observed_at_s"] = 3.0
+
+    with pytest.raises(GeneratedScenarioCatalogValidationError, match="must lie inside"):
+        validate_catalog_entry(entry)
+
+
+def test_validator_requires_a_pinned_replay_seed_and_replay_gap() -> None:
+    """A replay-pending entry cannot silently lose its source replay contract."""
+
+    entry = extract_critical_segment(_episode())
+    entry["replay"]["source_seed"] = 1
+    with pytest.raises(GeneratedScenarioCatalogValidationError, match="must equal"):
+        validate_catalog_entry(entry)
+
+    entry = extract_critical_segment(_episode())
+    entry["replay"]["warnings"] = []
+    with pytest.raises(GeneratedScenarioCatalogValidationError, match="replay_gap"):
+        validate_catalog_entry(entry)
+
+
+def test_distiller_requires_pedestrian_trace_for_minimum_clearance() -> None:
+    """The min-clearance extractor rejects traces without an observable counterpart."""
+
+    episode = deepcopy(_episode())
+    for step in episode["steps"]:
+        step["pedestrians"] = []
+
+    with pytest.raises(ValueError, match="no pedestrian positions"):
+        extract_critical_segment(episode)
+
+
+def test_cli_writes_validated_catalog_entry(tmp_path: Path) -> None:
+    """The narrow CLI turns a JSON trace into one review-pending entry."""
+
+    input_path = tmp_path / "episode.json"
+    output_path = tmp_path / "catalog-entry.json"
+    input_path.write_text(json.dumps(_episode()), encoding="utf-8")
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "scripts/benchmark/distill_generated_scenario_segment.py"
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--episode-json",
+            str(input_path),
+            "--output",
+            str(output_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    entry = json.loads(output_path.read_text(encoding="utf-8"))
+    validate_catalog_entry(entry)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** adds a versioned, fail-closed generated-scenario catalog-entry schema plus a deterministic CLI/function that distills the minimum-clearance window from one JSON episode trace.
- **Why now:** this establishes the trace-to-catalog contract needed before sampling, deduplication, or replay work can safely produce generated scenarios.
- **Claim boundary:** entries are generated scenario hypotheses only. They require manual review, assert `benchmark_evidence: false`, and this PR records `not_representable_yet` rather than claiming standalone replay.
- **Required validation:** review the replay-gap and seed-pinning checks; focused tests cover schema validity, deterministic IDs, known-window extraction, fail-closed metadata/temporal/replay checks, and the CLI round trip.
- **Remaining blocker:** the stage 1 randomized sampler, catalog aggregation/deduplication, and scenario-YAML replay adapter do not yet exist, so this partial slice cannot run the full stage 1–3 MVP by itself.

## Contract delta

- New `generated-scenario-catalog-entry.v1` fields: source episode id/seed/map, minimum-clearance signal and source metric, extracted frame-aligned bounds, initial robot state, pinned replay contract/status, and issue/distiller provenance.
- New fail-closed blockers: benchmark-evidence markers, unreviewed entries, mismatched replay seeds, missing `replay_gap` for non-representable entries, non-finite positions, event/window mismatch, and non-monotonic trace frames are rejected.
- Compatibility: no hand-authored scenario schema, benchmark matrix, release gate, or paper/dissertation surface changes. The new namespace is additive and isolated.

## Linked issue

- Refs #4932 — [epic: data-driven scenario generation](https://github.com/ll7/robot_sf_ll7/issues/4932)

## Scope and assumption

This is the ready-queue **catalog-schema first slice**: it implements a nameable new capability, deterministic critical-segment distillation from one existing randomized episode trace. The reversible draft assumption is that exact simulation state cannot yet be represented as standalone scenario YAML; the contract therefore makes the replay gap explicit instead of implying replay fidelity.

## Validation / proof

- `uv run ruff check robot_sf/benchmark/scenario_generation scripts/benchmark/distill_generated_scenario_segment.py tests/benchmark/test_generated_scenario_catalog.py` — pass.
- `uv run ruff format --check robot_sf/benchmark/scenario_generation scripts/benchmark/distill_generated_scenario_segment.py tests/benchmark/test_generated_scenario_catalog.py` — pass.
- `uv run pytest tests/benchmark/test_generated_scenario_catalog.py -q` — pass, 8 tests.
- `uv run python scripts/benchmark/distill_generated_scenario_segment.py --help` — pass.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — pass (interim gate).
- Final committed-HEAD readiness is run immediately before opening this PR.

## Explicitly out of scope

- No full benchmark campaign run.
- No Slurm or GPU submission.
- No paper/dissertation claim edits.
- No randomized sampler, catalog aggregation/deduplication, or standalone replay validation.

## Remaining work

- [ ] Stage 1 deterministic Monte Carlo episode generation and run manifest.
- [ ] Stage 3 catalog writer/aggregation and deterministic deduplication.
- [ ] Stage 5 scenario-loader replay adapter and smoke-status recording.

<details>
<summary>Governance, risk, and propagation appendix</summary>

### Research result guidance

- Target blocker: establish a safe trace-to-catalog entry contract for #4932.
- Evidence tier: targeted smoke / contract probe.
- Result classification: blocker-resolution; not benchmark evidence.

### Domain-Aware Approval

- Required for this PR: yes — the body reports a targeted contract probe and uses the `not benchmark evidence` classification.
- Domains reviewed: evidence classification.
- Status: waived.
- Approver/review source or waiver: implementation review plus fail-closed contract tests; the schema makes generated entries explicitly non-evidence.
- Validity checklist:
  - Target claim/hypothesis: a generated trace segment can be stored with explicit provenance and no implicit benchmark claim.
  - Comparator or split/evidence validity: no comparator, dataset split, or research result is interpreted.
  - Fallback/degraded exclusions: no fallback/degraded benchmark execution was run or counted as success.
  - Claim boundary: generated scenario hypotheses only; manual review and replay work remain required.
  - Implementation integrity vs experimental validity: focused tests and final readiness prove software behavior only, not scenario validity.

### Risks and rollback

- The v1 distiller only supports minimum robot–pedestrian clearance and a narrow JSON trace shape. Other signals and native map-runner adaptation remain future work.
- Rollback is removal of the additive package/schema/script; no production benchmark consumer changes.

### Artifacts and downstream propagation

- No `output/` artifacts were created or committed.
- Parent issue update: no. Issue-comment authority is explicitly disabled for this task, and the PR body is the allowed durable handoff surface.
- Claim map, leaderboard, artifact catalog, registry/config index, context index: not applicable; this PR records no research or benchmark result.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic extraction of critical robot–pedestrian episode segments based on minimum clearance.
  * Added deterministic, review-pending scenario catalog entries with provenance, replay status, and trace data.
  * Added strict schema and consistency validation for generated catalog entries.
  * Added a command-line tool to convert episode trace files into validated JSON catalog entries.

* **Tests**
  * Added coverage for deterministic extraction, validation rules, missing data, and command-line output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->