### PR TITLE
docs(fast-pysf): clarify obstacle distance offset (#4966)

### DIFF
--- a/docs/fast_pysf_wrapper.md
+++ b/docs/fast_pysf_wrapper.md
@@ -2,6 +2,20 @@
 
 This document shows how to use the `FastPysfWrapper` to sample forces from the bundled `fast-pysf` simulator and how to plot the force field using the example script.
 
+## Obstacle-force semantics
+
+`ObstacleForceConfig.threshold` is an additive distance offset in meters, not an
+activation threshold. Before evaluating the potential field, fast-pysf combines it with
+`agent_radius * sigma` and subtracts the result from the distance to an obstacle segment:
+`d = max(distance_to_segment - (threshold + agent_radius * sigma), 1e-5)`. The default
+value of `-0.57` therefore adds 0.57 m to the effective distance and softens near-wall
+repulsion; it does not turn the force on or off.
+
+The obstacle potential is inverse-square in `d`; its force uses the corresponding
+inverse-cubic distance-gradient term (proportional to `d^-3`). This differs from the
+exponential pedestrian-pedestrian social force: both obstacle and pedestrian-robot
+repulsion use potential-field forces instead.
+
 ## Using the wrapper
 
 ```python

--- a/fast-pysf/pysocialforce/config.py
+++ b/fast-pysf/pysocialforce/config.py
@@ -106,7 +106,9 @@ class ObstacleForceConfig:
     Attributes:
         factor: Scaling factor for obstacle force magnitude.
         sigma: Additional radius inflation term for obstacle interaction.
-        threshold: Base distance offset used in obstacle activation logic.
+        threshold: Additive distance offset (m), subtracted like a radius from
+            the pedestrian-obstacle distance. Negative values inflate the
+            effective distance and soften near-wall repulsion.
     """
 
     factor: float = 10.0


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Corrected `ObstacleForceConfig.threshold` and added the bundled fast-pysf obstacle-force semantics to `docs/fast_pysf_wrapper.md`.
- **Why now:** The existing wording falsely implied spatial activation; a negative default instead increases effective obstacle distance and softens repulsion.
- **Claim boundary:** Documentation only. No simulator behavior, configuration schema, or public field name changed.
- **Required validation:** `git diff --check`; Ruff check/format for the edited Python file; worktree-source docstring import check; and the canonical PR readiness gate.
- **Remaining blocker:** None. I considered the proposed `obstacle_distance_offset` rename and intentionally deferred it because it would change the public configuration API beyond this documentation fix.

Closes #4966

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: none; `threshold` remains the supported configuration field.

## Scope and validation

- Issue: https://github.com/ll7/robot_sf_ll7/issues/4966
- Scope: document the additive-offset formula and the inverse-square-potential / inverse-cubic-gradient force form.
- Passed: `git diff --check`
- Passed: `uv run ruff check fast-pysf/pysocialforce/config.py`
- Passed: `uv run ruff format --check fast-pysf/pysocialforce/config.py`
- Passed: `PYTHONPATH=fast-pysf uv run python -` (imports `ObstacleForceConfig` and asserts the corrected docstring)
- Passed: `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Governance and handoff appendix</summary>

### Research result guidance

- Evidence tier: docs-only
- Result classification: NA — this PR makes no research, benchmark, metric, or paper-facing result claim.
- Domain-aware approval, falsification/non-transfer, and next empirical action: NA for the same reason.

### Risks, artifacts, and propagation

- Risk: documentation is tied to the current `threshold + agent_radius * sigma` implementation; any future force-model change must update this paragraph.
- Artifacts: none created; `output/` is not involved.
- Downstream propagation: no separate issue-state update is needed. This is a low-churn, single-scope documentation correction; the closing PR-to-issue link is the durable canonical state.

</details>
