### PR TITLE
fix(tests): stabilize xdist scratch isolation (#4992)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,28 @@ jobs:
           CI_STEP_TIMEOUT_SECONDS: "300"
         run: bash scripts/dev/ci_step_timer.sh "Enforce artifact root policy" scripts/dev/ci_driver.sh artifact-policy
 
+  xdist-scratch-isolation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up CI Python environment
+        uses: ./.github/actions/setup-ci-python
+
+      - name: Run xdist scratch-isolation guard
+        run: |
+          uv run pytest -n 4 --dist worksteal \
+            tests/test_runner_policy_timeout.py::test_planner_step_timeout_fails_fast_and_reports_metadata \
+            tests/tools/test_release_evidence_gate.py::test_archive_integrity_pass_and_fail \
+            tests/benchmark/test_scenario_criticality_optimization.py::test_effective_workers_capped_at_candidate_count \
+            'tests/analysis/test_recenter_topology_panels_issue_2227.py::test_both_arm_traces_validate_against_schema[topology_result]' \
+            'tests/analysis/test_recenter_topology_panels_issue_2227.py::test_both_arm_traces_validate_against_schema[static_recenter_result]' \
+            tests/validation/test_evaluate_predictive_planner_smoke.py::test_evaluate_predictive_planner_fails_closed_without_collision_metric \
+            tests/validation/test_predictive_success_campaign_tags.py::test_main_writes_failure_summary_for_missing_jsonl \
+            tests/validation/test_predictive_success_campaign_tags.py::test_main_writes_failure_summary_for_malformed_jsonl
+
   wheel-smoke-install:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -237,6 +259,7 @@ jobs:
     needs:
       - fast-feedback
       - smoke-artifacts
+      - xdist-scratch-isolation
       - wheel-smoke-install
       - examples-smoke
     if: always()
@@ -253,6 +276,10 @@ jobs:
           fi
           if [[ "${{ needs.smoke-artifacts.result }}" != "success" ]]; then
             echo "smoke-artifacts finished with ${{ needs.smoke-artifacts.result }}" >&2
+            exit 1
+          fi
+          if [[ "${{ needs.xdist-scratch-isolation.result }}" != "success" ]]; then
+            echo "xdist-scratch-isolation finished with ${{ needs.xdist-scratch-isolation.result }}" >&2
             exit 1
           fi
           if [[ "${{ needs.examples-smoke.result }}" != "success" ]]; then

--- a/tests/validation/test_evaluate_predictive_planner_smoke.py
+++ b/tests/validation/test_evaluate_predictive_planner_smoke.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import torch
+
 from scripts.validation import evaluate_predictive_planner as mod
 
 
 def test_evaluate_predictive_planner_smoke(monkeypatch, tmp_path: Path) -> None:
     """Evaluation CLI should run with mocked map runner and produce summary artifacts."""
     checkpoint = tmp_path / "predictive_model.pt"
-    checkpoint.write_text("stub", encoding="utf-8")
+    torch.save({}, checkpoint)
     scenario_matrix = tmp_path / "scenarios.yaml"
     scenario_matrix.write_text("scenarios: []\n", encoding="utf-8")
     output_dir = tmp_path / "eval_out"
@@ -78,7 +80,7 @@ def test_evaluate_predictive_planner_fails_closed_without_collision_metric(
 ) -> None:
     """Evaluation quality gates should reject rows without explicit collision metrics."""
     checkpoint = tmp_path / "predictive_model.pt"
-    checkpoint.write_text("stub", encoding="utf-8")
+    torch.save({}, checkpoint)
     scenario_matrix = tmp_path / "scenarios.yaml"
     scenario_matrix.write_text("scenarios: []\n", encoding="utf-8")
     output_dir = tmp_path / "eval_out"

--- a/tests/validation/test_predictive_success_campaign_tags.py
+++ b/tests/validation/test_predictive_success_campaign_tags.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
+import torch
 import yaml
 
 from scripts.validation import predictive_eval_common
@@ -366,7 +367,7 @@ def test_main_writes_failure_summary_for_missing_jsonl(
     """Campaign main should leave a structured failure summary before exiting nonzero."""
 
     checkpoint = tmp_path / "predictive_model.pt"
-    checkpoint.write_text("stub", encoding="utf-8")
+    torch.save({}, checkpoint)
     output_dir = tmp_path / "campaign"
 
     def _fake_run_map_batch(*_args, **_kwargs) -> None:
@@ -416,7 +417,7 @@ def test_main_writes_failure_summary_for_malformed_jsonl(
     """Malformed runner JSONL should still leave a structured failure summary."""
 
     checkpoint = tmp_path / "predictive_model.pt"
-    checkpoint.write_text("stub", encoding="utf-8")
+    torch.save({}, checkpoint)
     output_dir = tmp_path / "campaign"
 
     def _fake_run_map_batch(_scenarios_or_path, jsonl_path: Path, **_kwargs) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Replaced four invalid text checkpoint stubs with valid, empty Torch checkpoints in their own `tmp_path` directories and added an always-run, eight-node `pytest-xdist --dist worksteal` CI guard.

**Why now:** The Nightly Performance xdist detector is red for this slice; on the locked local Torch version, the text stubs also fail serially during safe checkpoint schema inference. The valid per-test artifacts preserve the tested evaluation paths without changing any assertion or production behavior.

**Claim boundary:** This PR proves only test-scratch isolation and the targeted xdist guard. It makes no benchmark, metric, model, or performance claim.

**Required validation:** The exact eight-node guard passed twice under worksteal, including once through `scripts/dev/run_xdist_race_validation.sh`; the core readiness lane passed 2,001 tests.

**Remaining blocker:** None for issue #4992. GitHub Actions must execute the new required guard after this PR opens.

## Contract delta

- New CI contract: every PR runs the eight issue-4992 regression node IDs with four xdist workers in `worksteal` mode.
- Test artifacts: four predictive-planner tests now write valid empty Torch checkpoint files under their existing per-test `tmp_path` directories.
- Compatibility: no public schema, benchmark semantics, product code, or assertion behavior changes.

Closes #4992

Issue: https://github.com/ll7/robot_sf_ll7/issues/4992

<details>
<summary>Implementation, validation, and governance appendix</summary>

## Scope summary

- In scope: test-only scratch artifacts and a targeted CI regression guard.
- Out of scope: full benchmark campaign run, Slurm/GPU submission, and paper/dissertation claim edits.

## Validation / proof

- `uv run pytest -n 4 --dist worksteal <the eight issue node IDs> -q` — passed: 8 passed in 71.31s.
- `XDIST_RACE_WORKERS=2 scripts/dev/run_xdist_race_validation.sh --timeout-seconds 180 <the eight issue node IDs>` — passed: test command exit 0; artifact scan passed with 0 violations.
- `uv run pytest -n 4 --dist worksteal tests/validation/test_evaluate_predictive_planner_smoke.py tests/validation/test_predictive_success_campaign_tags.py -q` — passed: 16 passed in 9.92s.
- `uv run ruff check ...`, `uv run ruff format --check ...`, `git diff --check`, and YAML parsing of `.github/workflows/ci.yml` — passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed: core readiness lane 2,001 passed in 113.85s; final committed-head freshness will be recorded before opening.

## Risks / rollout

- The new guard takes about 71 seconds locally before GitHub setup overhead; it is intentionally narrow and runs independently of the broader test shards.
- Ignored `output/coverage/`, `output/validation/`, and `output/tmp_criticality/` files are local validation artifacts only; none are committed or required for future runs.

## Downstream propagation

- Parent issue comment: no — authorization excludes issue/PR comments; this PR is the canonical delivery record.
- Claim map / benchmark report / leaderboard / registry / context index: NA — no research evidence or durable artifact was produced.
- No propagation is needed beyond the required CI guard.

## Reviewer notes

- Verify the CI job contains exactly the eight node IDs from #4992 and is included in the required aggregate `ci` job.
- Assumption: valid empty Torch checkpoints are the smallest reversible scratch-artifact representation for tests that mock map execution; they prevent checkpoint-schema inference from failing before the intended assertions execute.

</details>
