### PR TITLE
feat(sim): pedestrian integrator scheme sensitivity (#4979)

### DIFF
--- a/configs/research/fidelity_sensitivity_v1.yaml
+++ b/configs/research/fidelity_sensitivity_v1.yaml
@@ -79,6 +79,18 @@ axes:
       - key: dt_0_20
         patch:
           dt: 0.20
+  - key: pedestrian_integration_scheme
+    rationale: Detect whether planner rankings depend on explicit versus semi-implicit pedestrian updates.
+    variants:
+      - key: semi_implicit_euler_nominal
+        baseline: true
+        patch:
+          sim_config:
+            pedestrian_integration_scheme: semi_implicit_euler
+      - key: explicit_euler
+        patch:
+          sim_config:
+            pedestrian_integration_scheme: explicit_euler
   - key: social_force_speed_archetypes
     rationale: Detect whether pedestrian speed heterogeneity changes ranking stability.
     variants:

--- a/fast-pysf/pysocialforce/config.py
+++ b/fast-pysf/pysocialforce/config.py
@@ -16,6 +16,9 @@ class SceneConfig:
         max_speed_multiplier: Upper bound multiplier for desired speeds.
         tau: Relaxation time constant used by force models (seconds).
         resolution: Spatial resolution used for obstacle preprocessing.
+        integration_scheme: Pedestrian position-update scheme. ``semi_implicit_euler``
+            advances position with the newly integrated velocity; ``explicit_euler``
+            advances with the pre-step velocity.
     """
 
     enable_group: bool = True
@@ -24,6 +27,7 @@ class SceneConfig:
     max_speed_multiplier: float = 1.3
     tau: float = 0.5
     resolution: float = 10
+    integration_scheme: str = "semi_implicit_euler"
 
 
 @dataclass

--- a/fast-pysf/pysocialforce/scene.py
+++ b/fast-pysf/pysocialforce/scene.py
@@ -17,8 +17,10 @@ SEMI_IMPLICIT_EULER = "semi_implicit_euler"
 SUPPORTED_INTEGRATION_SCHEMES = frozenset({EXPLICIT_EULER, SEMI_IMPLICIT_EULER})
 
 
-def normalize_integration_scheme(value: str) -> str:
+def normalize_integration_scheme(value: str | None) -> str:
     """Return a supported pedestrian integration scheme or raise a clear error."""
+    if value is None:
+        value = SEMI_IMPLICIT_EULER
     normalized = str(value).strip()
     if normalized in SUPPORTED_INTEGRATION_SCHEMES:
         return normalized

--- a/fast-pysf/pysocialforce/scene.py
+++ b/fast-pysf/pysocialforce/scene.py
@@ -12,6 +12,19 @@ Line2D = tuple[float, float, float, float]
 Point2D = tuple[float, float]
 Group = list[int]
 
+EXPLICIT_EULER = "explicit_euler"
+SEMI_IMPLICIT_EULER = "semi_implicit_euler"
+SUPPORTED_INTEGRATION_SCHEMES = frozenset({EXPLICIT_EULER, SEMI_IMPLICIT_EULER})
+
+
+def normalize_integration_scheme(value: str) -> str:
+    """Return a supported pedestrian integration scheme or raise a clear error."""
+    normalized = str(value).strip()
+    if normalized in SUPPORTED_INTEGRATION_SCHEMES:
+        return normalized
+    supported = ", ".join(sorted(SUPPORTED_INTEGRATION_SCHEMES))
+    raise ValueError(f"Unsupported integration_scheme {value!r}. Supported values: {supported}.")
+
 
 class PedState:
     """Track pedestrian kinematic state and optional social groups."""
@@ -26,6 +39,7 @@ class PedState:
         """
         self.default_tau = config.tau
         self.d_t = config.dt_secs
+        self.integration_scheme = normalize_integration_scheme(config.integration_scheme)
         self.agent_radius = config.agent_radius
         self.max_speed_multiplier = config.max_speed_multiplier
 
@@ -107,15 +121,18 @@ class PedState:
             force: Per-pedestrian force vectors.
             groups: Optional updated group assignments.
         """
-        # desired velocity
-        desired_velocity = self.vel() + self.d_t * force
+        previous_velocity = self.vel().copy()
+        desired_velocity = previous_velocity + self.d_t * force
         desired_velocity = self.capped_velocity(desired_velocity, self.max_speeds)
         # stop when arrived
         # desired_velocity[stateutils.desired_directions(self.state)[1] < 0.5] = [0, 0]
 
         # update state
         next_state = self.state
-        next_state[:, 0:2] += desired_velocity * self.d_t
+        position_velocity = (
+            previous_velocity if self.integration_scheme == EXPLICIT_EULER else desired_velocity
+        )
+        next_state[:, 0:2] += position_velocity * self.d_t
         next_state[:, 2:4] = desired_velocity
         next_groups = groups if groups is not None else self.groups
         self.update(next_state, next_groups)

--- a/robot_sf/sim/pedestrian_model_variants.py
+++ b/robot_sf/sim/pedestrian_model_variants.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from math import atan2
 
 import numpy as np
+from pysocialforce.scene import EXPLICIT_EULER, normalize_integration_scheme
 
 SOCIAL_FORCE_DEFAULT = "social_force_default"
 HSFM_TOTAL_FORCE_V1 = "hsfm_total_force_v1"
@@ -658,6 +659,7 @@ def step_hsfm_total_force(
     *,
     dt: float,
     max_speeds: np.ndarray,
+    integration_scheme: str = "semi_implicit_euler",
     epsilon: float = 1e-9,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Step PySocialForce state while orienting pedestrians by total force.
@@ -685,7 +687,13 @@ def step_hsfm_total_force(
     np.minimum(factors, 1.0, out=factors)
     capped_velocity = desired_velocity * np.expand_dims(factors, axis=-1)
 
-    next_state[:, PYSF_POSITION_SLICE] += capped_velocity * float(dt)
+    normalized_scheme = normalize_integration_scheme(integration_scheme)
+    position_velocity = (
+        next_state[:, PYSF_VELOCITY_SLICE]
+        if normalized_scheme == EXPLICIT_EULER
+        else capped_velocity
+    )
+    next_state[:, PYSF_POSITION_SLICE] += position_velocity * float(dt)
     next_state[:, PYSF_VELOCITY_SLICE] = capped_velocity
     force_norms = np.linalg.norm(force_array, axis=-1)
     force_headings = np.arctan2(force_array[:, 1], force_array[:, 0])

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field, replace
 from math import ceil, isfinite
 from typing import Any
 
+from pysocialforce.scene import normalize_integration_scheme
+
 from robot_sf.ped_npc.adversial_ped_force import AdversarialPedForceConfig
 from robot_sf.ped_npc.ped_robot_force import PedRobotForceConfig
 from robot_sf.sim.pedestrian_model_variants import (
@@ -169,6 +171,9 @@ class SimulationSettings:
     time_per_step_in_secs: float = 0.1
     """Time per step in seconds"""
 
+    pedestrian_integration_scheme: str = "semi_implicit_euler"
+    """Pedestrian position-update scheme; defaults to the historical semi-implicit update."""
+
     peds_speed_mult: float = 1.3
     """Pedestrian speed multiplier"""
 
@@ -276,6 +281,9 @@ class SimulationSettings:
         # Check that the time per step is positive
         if self.time_per_step_in_secs <= 0:
             raise ValueError("Step time mustn't be negative or zero!")
+        self.pedestrian_integration_scheme = normalize_integration_scheme(
+            self.pedestrian_integration_scheme
+        )
         # Check that the pedestrian speed multiplier is positive
         if self.peds_speed_mult <= 0:
             raise ValueError("Pedestrian speed mustn't be negative or zero!")

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -194,6 +194,8 @@ class Simulator:
         Route spawning honors SimulationSettings route spawn options when provided.
         """
         pysf_config = PySFSimConfig()
+        pysf_config.scene_config.dt_secs = self.config.time_per_step_in_secs
+        pysf_config.scene_config.integration_scheme = self.config.pedestrian_integration_scheme
         spawn_config = PedSpawnConfig(
             self.config.peds_per_area_m2,
             self.config.max_peds_per_group,
@@ -269,7 +271,6 @@ class Simulator:
                 self.pedestrian_response_multipliers,
             ),
         )
-        self.pysf_sim.peds.step_width = self.config.time_per_step_in_secs
         self.pysf_sim.peds.max_speed_multiplier = self.config.peds_speed_mult
         self.robot_navs = [
             RouteNavigator(proximity_threshold=self.goal_proximity_threshold) for _ in self.robots
@@ -350,6 +351,9 @@ class Simulator:
             self.ped_headings,
             dt=self.config.time_per_step_in_secs,
             max_speeds=max_speeds,
+            integration_scheme=getattr(
+                self.config, "pedestrian_integration_scheme", "semi_implicit_euler"
+            ),
         )
         if self.pedestrian_model == HSFM_ALIGNMENT_TORQUE_V1:
             # Decouple body orientation from the instantaneous force direction (issue #3481):
@@ -646,6 +650,8 @@ class PedSimulator(Simulator):
         forces and robot interactions, and prepares robot navigation paths.
         """
         pysf_config = PySFSimConfig()
+        pysf_config.scene_config.dt_secs = self.config.time_per_step_in_secs
+        pysf_config.scene_config.integration_scheme = self.config.pedestrian_integration_scheme
         spawn_config = PedSpawnConfig(
             self.config.peds_per_area_m2,
             self.config.max_peds_per_group,
@@ -693,7 +699,6 @@ class PedSimulator(Simulator):
                 pedestrian_response_multipliers=None,
             ),
         )
-        self.pysf_sim.peds.step_width = self.config.time_per_step_in_secs
         self.pysf_sim.peds.max_speed_multiplier = self.config.peds_speed_mult
 
         self.robot_navs = [

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -2166,6 +2166,7 @@ def _apply_simulation_overrides(
         config.sim_config.max_peds_per_group = int(overrides["max_peds_per_group"])
     for attr in (
         "peds_speed_mult",
+        "pedestrian_integration_scheme",
         "ped_radius",
         "pedestrian_uncertainty_envelope_enabled",
         "pedestrian_uncertainty_alpha_mps",

--- a/scripts/analysis/measure_pedestrian_integrator_scheme_sensitivity.py
+++ b/scripts/analysis/measure_pedestrian_integrator_scheme_sensitivity.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Measure explicit versus semi-implicit pedestrian trajectory divergence.
+
+This CPU-only diagnostic runs the native PySocialForce pedestrian interaction
+law at the standard 0.1-second timestep for the repository's cautious,
+standard, and hurried speed archetypes.  It reports numerical trajectory
+divergence only: it is not a benchmark campaign, a realism calibration, or a
+planner-ranking claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+from pysocialforce import Simulator
+from pysocialforce.config import SceneConfig, SimulatorConfig
+from pysocialforce.scene import EXPLICIT_EULER, SEMI_IMPLICIT_EULER
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+SCHEMA_VERSION = "pedestrian-integrator-scheme-sensitivity.v1"
+CLAIM_BOUNDARY = (
+    "diagnostic_only: native two-pedestrian Social Force trajectories at a fixed timestep; "
+    "not a full benchmark campaign, pedestrian-realism calibration, or planner-ranking claim."
+)
+ARCHETYPE_SPEED_FACTORS = {"cautious": 0.7, "standard": 1.0, "hurried": 1.4}
+
+
+@dataclass(frozen=True)
+class DivergenceSummary:
+    """One archetype's explicit-versus-semi-implicit trajectory divergence."""
+
+    archetype: str
+    desired_speed_factor: float
+    final_mean_position_divergence_m: float
+    max_position_divergence_m: float
+    rms_position_divergence_m: float
+
+
+def _initial_state(speed: float) -> np.ndarray:
+    """Return a deterministic opposing-pedestrian interaction state."""
+    return np.array(
+        [
+            [-1.0, 0.0, speed, 0.0, 4.0, 0.0],
+            [1.0, 0.0, -speed, 0.0, -4.0, 0.0],
+        ],
+        dtype=float,
+    )
+
+
+def _trajectory(*, speed: float, dt: float, steps: int, integration_scheme: str) -> np.ndarray:
+    """Run one native Social Force trajectory and return positions for every step."""
+    config = SimulatorConfig(
+        scene_config=SceneConfig(dt_secs=dt, integration_scheme=integration_scheme)
+    )
+    simulator = Simulator(_initial_state(speed), config=config)
+    positions = [simulator.peds.pos().copy()]
+    for _ in range(steps):
+        simulator.step_once()
+        positions.append(simulator.peds.pos().copy())
+    return np.asarray(positions, dtype=float)
+
+
+def measure_scheme_sensitivity(*, dt: float = 0.1, steps: int = 60) -> dict[str, object]:
+    """Measure named-archetype trajectory divergence at one fixed timestep.
+
+    Args:
+        dt: Positive timestep in seconds. The standard comparison uses ``0.1``.
+        steps: Positive number of native simulator steps per archetype.
+
+    Returns:
+        A JSON-serializable diagnostic report with per-archetype divergence metrics.
+    """
+    if not np.isfinite(dt) or dt <= 0:
+        raise ValueError("dt must be finite and > 0")
+    if steps <= 0:
+        raise ValueError("steps must be > 0")
+
+    summaries: list[DivergenceSummary] = []
+    for archetype, speed_factor in ARCHETYPE_SPEED_FACTORS.items():
+        explicit = _trajectory(
+            speed=speed_factor,
+            dt=dt,
+            steps=steps,
+            integration_scheme=EXPLICIT_EULER,
+        )
+        semi_implicit = _trajectory(
+            speed=speed_factor,
+            dt=dt,
+            steps=steps,
+            integration_scheme=SEMI_IMPLICIT_EULER,
+        )
+        divergence = np.linalg.norm(explicit - semi_implicit, axis=-1)
+        summaries.append(
+            DivergenceSummary(
+                archetype=archetype,
+                desired_speed_factor=speed_factor,
+                final_mean_position_divergence_m=float(np.mean(divergence[-1])),
+                max_position_divergence_m=float(np.max(divergence)),
+                rms_position_divergence_m=float(np.sqrt(np.mean(divergence**2))),
+            )
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "evidence_status": "diagnostic-only",
+        "timestep_s": dt,
+        "steps": steps,
+        "schemes": {"baseline": SEMI_IMPLICIT_EULER, "comparison": EXPLICIT_EULER},
+        "archetype_source": "configs/research/pedestrian_archetypes_v1.yaml",
+        "trajectory_divergence": [asdict(summary) for summary in summaries],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dt", type=float, default=0.1, help="Fixed timestep in seconds.")
+    parser.add_argument("--steps", type=int, default=60, help="Steps per archetype.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the scheme-sensitivity diagnostic."""
+    args = build_parser().parse_args(argv)
+    report = measure_scheme_sensitivity(dt=args.dt, steps=args.steps)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print("Pedestrian integrator scheme sensitivity (diagnostic-only)")
+        for summary in report["trajectory_divergence"]:
+            print(
+                f"{summary['archetype']}: max={summary['max_position_divergence_m']:.6f} m, "
+                f"final_mean={summary['final_mean_position_divergence_m']:.6f} m"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analysis/measure_pedestrian_integrator_scheme_sensitivity.py
+++ b/scripts/analysis/measure_pedestrian_integrator_scheme_sensitivity.py
@@ -66,7 +66,9 @@ def _trajectory(*, speed: float, dt: float, steps: int, integration_scheme: str)
     return np.asarray(positions, dtype=float)
 
 
-def measure_scheme_sensitivity(*, dt: float = 0.1, steps: int = 60) -> dict[str, object]:
+def measure_scheme_sensitivity(
+    *, dt: float | None = None, steps: int | None = None
+) -> dict[str, object]:
     """Measure named-archetype trajectory divergence at one fixed timestep.
 
     Args:
@@ -76,6 +78,8 @@ def measure_scheme_sensitivity(*, dt: float = 0.1, steps: int = 60) -> dict[str,
     Returns:
         A JSON-serializable diagnostic report with per-archetype divergence metrics.
     """
+    dt = 0.1 if dt is None else dt
+    steps = 60 if steps is None else steps
     if not np.isfinite(dt) or dt <= 0:
         raise ValueError("dt must be finite and > 0")
     if steps <= 0:
@@ -96,6 +100,8 @@ def measure_scheme_sensitivity(*, dt: float = 0.1, steps: int = 60) -> dict[str,
             integration_scheme=SEMI_IMPLICIT_EULER,
         )
         divergence = np.linalg.norm(explicit - semi_implicit, axis=-1)
+        if not np.all(np.isfinite(divergence)):
+            raise ValueError(f"Non-finite trajectory divergence for archetype {archetype}")
         summaries.append(
             DivergenceSummary(
                 archetype=archetype,
@@ -121,8 +127,8 @@ def measure_scheme_sensitivity(*, dt: float = 0.1, steps: int = 60) -> dict[str,
 def build_parser() -> argparse.ArgumentParser:
     """Build the command-line parser."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--dt", type=float, default=0.1, help="Fixed timestep in seconds.")
-    parser.add_argument("--steps", type=int, default=60, help="Steps per archetype.")
+    parser.add_argument("--dt", type=float, default=None, help="Fixed timestep in seconds.")
+    parser.add_argument("--steps", type=int, default=None, help="Steps per archetype.")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     return parser
 

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -619,6 +619,8 @@ def _runtime_binding(
 ) -> str:
     if axis == "integration_timestep" and "dt" in patch:
         return "sim_config.time_per_step_in_secs"
+    if axis == "pedestrian_integration_scheme" and isinstance(patch.get("sim_config"), Mapping):
+        return "sim_config.pedestrian_integration_scheme"
     if axis == "clearance_radius" and isinstance(patch.get("sim_config"), Mapping):
         return "sim_config.ped_radius"
     if axis == "social_force_speed_archetypes" and "pedestrian_archetypes" in patch:
@@ -637,6 +639,10 @@ def apply_variant(config: Any, variant: VariantSpec, *, seed: int) -> None:
         config.sim_config.sim_time_in_secs = original_duration
     elif variant.runtime_binding == "sim_config.ped_radius":
         config.sim_config.ped_radius = float(variant.patch["sim_config"]["ped_radius"])
+    elif variant.runtime_binding == "sim_config.pedestrian_integration_scheme":
+        config.sim_config.pedestrian_integration_scheme = str(
+            variant.patch["sim_config"]["pedestrian_integration_scheme"]
+        )
     elif variant.runtime_binding == "sim_config.archetype_composition":
         config.sim_config.archetype_composition = {
             str(key): float(value) for key, value in variant.patch["pedestrian_archetypes"].items()

--- a/tests/sim/test_pedestrian_integration_scheme.py
+++ b/tests/sim/test_pedestrian_integration_scheme.py
@@ -1,0 +1,83 @@
+"""Regression coverage for pedestrian integration-scheme selection (issue #4979)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pysocialforce.config import SceneConfig
+from pysocialforce.scene import PedState
+
+from robot_sf.sim.pedestrian_model_variants import step_hsfm_total_force
+from robot_sf.sim.sim_config import SimulationSettings
+from scripts.analysis.measure_pedestrian_integrator_scheme_sensitivity import (
+    SCHEMA_VERSION,
+    measure_scheme_sensitivity,
+)
+
+
+def _ped_state(scheme: str) -> PedState:
+    """Build a one-pedestrian fixture with a known acceleration."""
+    state = np.array([[0.0, 0.0, 1.0, 0.0, 10.0, 0.0]], dtype=float)
+    return PedState(state, [], SceneConfig(dt_secs=0.1, integration_scheme=scheme))
+
+
+def test_explicit_and_semi_implicit_euler_use_different_position_velocities() -> None:
+    """Explicit uses pre-step velocity while semi-implicit uses the updated velocity."""
+    explicit = _ped_state("explicit_euler")
+    semi_implicit = _ped_state("semi_implicit_euler")
+
+    explicit.step(np.array([[-2.0, 0.0]], dtype=float))
+    semi_implicit.step(np.array([[-2.0, 0.0]], dtype=float))
+
+    assert explicit.pos()[0] == pytest.approx([0.1, 0.0])
+    assert semi_implicit.pos()[0] == pytest.approx([0.08, 0.0])
+    assert explicit.vel()[0] == pytest.approx(semi_implicit.vel()[0])
+
+
+def test_default_scheme_preserves_historical_semi_implicit_update_order() -> None:
+    """The default names and retains the repository's existing position update order."""
+    settings = SimulationSettings()
+
+    assert settings.pedestrian_integration_scheme == "semi_implicit_euler"
+    default = PedState(
+        np.array([[0.0, 0.0, 1.0, 0.0, 10.0, 0.0]], dtype=float), [], SceneConfig(dt_secs=0.1)
+    )
+    default.step(np.array([[-2.0, 0.0]], dtype=float))
+    assert default.pos()[0] == pytest.approx([0.08, 0.0])
+
+
+def test_invalid_integration_scheme_fails_closed() -> None:
+    """Unknown scheme names are rejected before simulation construction."""
+    with pytest.raises(ValueError, match="Unsupported integration_scheme"):
+        SimulationSettings(pedestrian_integration_scheme="rk4")
+
+
+def test_hsfm_total_force_honors_explicit_position_update() -> None:
+    """Opt-in headed variants share the same selected position-update contract."""
+    state = np.array([[0.0, 0.0, 1.0, 0.0, 10.0, 0.0, 0.5]], dtype=float)
+    next_state, _ = step_hsfm_total_force(
+        state,
+        np.array([[2.0, 0.0]], dtype=float),
+        np.array([0.0], dtype=float),
+        dt=0.1,
+        max_speeds=np.array([10.0], dtype=float),
+        integration_scheme="explicit_euler",
+    )
+
+    assert next_state[0, :4] == pytest.approx([0.1, 0.0, 1.2, 0.0])
+
+
+def test_scheme_sensitivity_report_covers_all_speed_archetypes() -> None:
+    """The diagnostic emits finite divergence metrics for the three configured archetypes."""
+    report = measure_scheme_sensitivity(dt=0.1, steps=12)
+
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["evidence_status"] == "diagnostic-only"
+    assert report["schemes"] == {
+        "baseline": "semi_implicit_euler",
+        "comparison": "explicit_euler",
+    }
+    rows = report["trajectory_divergence"]
+    assert [row["archetype"] for row in rows] == ["cautious", "standard", "hurried"]
+    assert all(np.isfinite(row["max_position_divergence_m"]) for row in rows)
+    assert any(row["max_position_divergence_m"] > 0 for row in rows)

--- a/tests/sim/test_pedestrian_integration_scheme.py
+++ b/tests/sim/test_pedestrian_integration_scheme.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from pysocialforce.config import SceneConfig
-from pysocialforce.scene import PedState
+from pysocialforce.scene import PedState, normalize_integration_scheme
 
 from robot_sf.sim.pedestrian_model_variants import step_hsfm_total_force
 from robot_sf.sim.sim_config import SimulationSettings
@@ -52,6 +52,12 @@ def test_invalid_integration_scheme_fails_closed() -> None:
         SimulationSettings(pedestrian_integration_scheme="rk4")
 
 
+def test_none_integration_scheme_preserves_compatibility_default() -> None:
+    """A nullable configuration seam retains the historical semi-implicit behavior."""
+
+    assert normalize_integration_scheme(None) == "semi_implicit_euler"
+
+
 def test_hsfm_total_force_honors_explicit_position_update() -> None:
     """Opt-in headed variants share the same selected position-update contract."""
     state = np.array([[0.0, 0.0, 1.0, 0.0, 10.0, 0.0, 0.5]], dtype=float)
@@ -81,3 +87,16 @@ def test_scheme_sensitivity_report_covers_all_speed_archetypes() -> None:
     assert [row["archetype"] for row in rows] == ["cautious", "standard", "hurried"]
     assert all(np.isfinite(row["max_position_divergence_m"]) for row in rows)
     assert any(row["max_position_divergence_m"] > 0 for row in rows)
+
+
+def test_scheme_sensitivity_fails_closed_for_non_finite_divergence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A diagnostic report cannot silently summarize non-finite trajectories."""
+
+    import scripts.analysis.measure_pedestrian_integrator_scheme_sensitivity as diagnostic
+
+    monkeypatch.setattr(diagnostic, "_trajectory", lambda **_kwargs: np.array([[[np.nan, 0.0]]]))
+
+    with pytest.raises(ValueError, match="Non-finite trajectory divergence"):
+        diagnostic.measure_scheme_sensitivity(steps=1)


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** adds named `explicit_euler` and `semi_implicit_euler` pedestrian
position-update schemes, wires the selected scheme and timestep through both simulator paths and
headed variants, adds the scheme to the fidelity-sensitivity config/runner, and provides a
deterministic archetype diagnostic reporting trajectory divergence.

**Why now:** #4979 needs a reproducible scheme-sensitivity surface before any default-policy
decision or campaign re-base. Source review found that the historical update already advances
position with the newly integrated velocity, i.e. semi-implicit Euler; this PR names and preserves
that behavior rather than changing trajectories under an inaccurate `explicit` label.

**Claim boundary:** the CPU report is diagnostic-only native two-pedestrian Social Force evidence at
0.1 s. It demonstrates numerical divergence, not pedestrian realism, benchmark ranking, or a
recommendation to change the default.

**Required validation:** inspect the two update branches and run the final readiness command plus
the diagnostic command below. The diagnostic reports maximum position divergence of 0.0634 m
(cautious), 0.2835 m (standard), and 0.3123 m (hurried) across 60 steps.

**Remaining blocker:** no implementation blocker remains for #4979. A full benchmark campaign is
intentionally excluded and is the only evidence needed before considering a future default change.

Closes #4979

Issue: https://github.com/ll7/robot_sf_ll7/issues/4979

## Contract delta

- New config field: `SimulationSettings.pedestrian_integration_scheme`, accepting only
  `semi_implicit_euler` (default) and `explicit_euler`.
- New fail-closed blocker: unknown scheme values raise `ValueError` before pedestrian state setup.
- Compatibility: the default keeps the historical semi-implicit trajectory update; explicit Euler is
  opt-in. The simulator now also propagates its configured timestep to PySocialForce, correcting the
  previously unused `step_width` attribute.

## Scope and validation

- Implements the full CPU-testable ask: selectable scheme, sensitivity-fidelity axis, and a
  deterministic archetype measurement command.
- `uv run pytest tests/sim/test_pedestrian_integration_scheme.py tests/sim/test_hsfm_total_force_model.py tests/benchmark/test_fidelity_sensitivity_campaign.py fast-pysf/tests/test_simulator.py -q` — 33 passed.
- `uv run python scripts/analysis/measure_pedestrian_integrator_scheme_sensitivity.py --json` — pass;
  diagnostic-only report with finite divergence for cautious, standard, and hurried archetypes.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — pass (final
  committed-HEAD freshness recorded).

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no
paper/dissertation claim edits.

<details>
<summary>Governance appendix</summary>

## Stack / dependency

- Base dependency: none.
- Required prior PRs: none.
- Safe to review independently: yes.

## Research result guidance

- Target blocker: scheme sensitivity was not a configurable/measurable fidelity axis.
- Comparator: explicit Euler versus the historical semi-implicit update at 0.1 s.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Decision/stop rule: keep the compatibility default; use a future campaign, not this report, before
  proposing any default change.
- Analysis tool: `scripts/analysis/measure_pedestrian_integrator_scheme_sensitivity.py`, exercised
  against native deterministic Social Force state generated from versioned archetype factors.

## Domain-Aware Approval

- Required for this PR: yes — this PR adds a diagnostic comparison method and explicitly classifies
  its evidence.
- Domains reviewed: evidence classification, experimental comparison.
- Status: waived.
- Approver/review source or waiver: waiver reason: this task authorizes CPU implementation and
  local validation but explicitly excludes a full benchmark campaign; targeted tests and the
  diagnostic prove software behavior only.
- Validity checklist:
  - Target claim/hypothesis: explicit and semi-implicit updates produce measurable numerical
    divergence at the standard timestep.
  - Comparator or split/evidence validity: fixed initial state, timestep, force law, and archetype
    speed factor; only the named integration scheme changes.
  - Fallback/degraded exclusions: no fallback/degraded benchmark execution was run or counted.
  - Claim boundary: diagnostic-only native force-field probe, not a benchmark or realism claim.
  - Implementation integrity vs experimental validity: tests prove dispatch and report shape; a full
    campaign remains required for any default-policy decision.

## Risks / rollback

- The diagnostic is a two-pedestrian force-field probe, not a benchmark-matrix result.
- Timestep propagation may reveal the intended timestep sensitivity in callers that previously
  changed only the outer simulator clock; it is directly covered by the selected settings seam.
- Rollback: revert commit `2402138b8`.

## Docs, artifacts, and propagation

- Updated docs/config: the versioned fidelity-sensitivity config is the canonical experiment surface;
  the diagnostic's docstring states its claim boundary and command.
- No `output/` files or generated artifacts are committed; `/tmp/issue-4979-scheme-sensitivity.json`
  is disposable local validation output.
- Parent issue update: no comment, because this task does not authorize issue comments. The PR's
  `Closes #4979` link is the permitted durable state transition on merge.
- Claim map, leaderboard, artifact catalog, context index: not applicable; no benchmark or
  paper-facing result is promoted.

## Reviewer notes

- Verify that the default is intentionally `semi_implicit_euler`: it preserves the repository's
  pre-existing `position += updated_velocity * dt` behavior despite the issue's older label.
- The next empirical action, only if a default change is contemplated, is a predeclared full
  scheme-sensitivity campaign with the new fidelity axis.

## Follow-Up Issues

- Deferred work: none for #4979. Maintainer waiver: the task explicitly excludes a full benchmark
  campaign, and no default change is proposed by this PR; any future default-policy decision needs
  a separately scoped campaign issue.
- Issues opened for follow-up: none.

</details>
