### PR TITLE
feat(maps): GeoJSON segment-map import (#4980)

### DIFF
--- a/configs/maps/geojson_import_provenance.example.yaml
+++ b/configs/maps/geojson_import_provenance.example.yaml
@@ -1,0 +1,10 @@
+# Copy beside a locally acquired public GeoJSON extract; do not commit the raw extract by default.
+schema_version: robot_sf.geojson_import_provenance.v1
+classification: exploratory_only
+source:
+  url: https://www.openstreetmap.org/copyright
+  accessed_on: YYYY-MM-DD
+  license: Open Data Commons Open Database License (ODbL) v1.0
+  citation: OpenStreetMap contributors
+raw_input:
+  sha256: replace-with-sha256-of-the-local-geojson

--- a/docs/maps/geojson_import.md
+++ b/docs/maps/geojson_import.md
@@ -21,7 +21,7 @@ uv run python scripts/validation/check_geojson_import.py \
 ```
 
 `--line-buffer-m 1.5` is the default half-width applied to tagged LineString footways and obstacles.
-The input follows standard GeoJSON (WGS84 when no coordinate reference system is declared); the
+The input follows standard GeoJSON (World Geodetic System 1984 (WGS84) when no coordinate reference system is declared); the
 output coordinates are metres in a local Universal Transverse Mercator (UTM) frame.
 
 The converter recognises OSM `highway` values such as `footway`, `path`, and `pedestrian`, plus

--- a/docs/maps/geojson_import.md
+++ b/docs/maps/geojson_import.md
@@ -1,0 +1,60 @@
+# Importing an OpenStreetMap GeoJSON map
+
+This converter turns an annotated OpenStreetMap (OSM) GeoJSON extract into the YAML map format
+Robot SF already loads for scenarios. It projects longitude/latitude into a local metre-based frame,
+uses OSM tags to form walkable areas and obstacles, and writes obstacle polygons that the runtime
+uses as collision line segments.
+
+This is an import tool, not a benchmark claim: an imported location still needs scenario review and
+certification before it is used as benchmark evidence.
+
+## Convert a public extract
+
+Download a public GeoJSON extract using a source whose licence permits your intended use. Copy
+[`geojson_import_provenance.example.yaml`](../../configs/maps/geojson_import_provenance.example.yaml),
+record its source URL, query/bounds in the citation, download date, licence, and raw-file SHA-256.
+Then run the provenance checker and converter together:
+
+```bash
+uv run python scripts/validation/check_geojson_import.py \
+  campus.geojson campus.provenance.yaml maps/imported/campus.yaml
+```
+
+`--line-buffer-m 1.5` is the default half-width applied to tagged LineString footways and obstacles.
+The input follows standard GeoJSON (WGS84 when no coordinate reference system is declared); the
+output coordinates are metres in a local Universal Transverse Mercator (UTM) frame.
+
+The converter recognises OSM `highway` values such as `footway`, `path`, and `pedestrian`, plus
+`footway=sidewalk|crossing` and the existing OSM obstacle tags (`building`, water, cliff, and tree).
+Use `robot_sf_role=walkable` or `robot_sf_role=obstacle` when source tags are not sufficient.
+
+## Required scenario annotations
+
+Geometry alone cannot identify a safe robot task, so runnable maps require explicit annotation. Add
+these properties to GeoJSON features (both `robot_sf_role` and `robot_sf:role` are accepted):
+
+| Geometry | Required properties | Meaning |
+| --- | --- | --- |
+| Polygon | `robot_sf_role: robot_spawn`, `robot_sf_id: west` | Robot start zone. |
+| Polygon | `robot_sf_role: robot_goal`, `robot_sf_id: east` | Robot goal zone. |
+| LineString | `robot_sf_role: robot_route`, `robot_sf_spawn: west`, `robot_sf_goal: east` | Route joining the named robot zones. |
+| Polygon | `robot_sf_role: ped_spawn` or `ped_goal`, `robot_sf_id: ...` | Optional pedestrian zones. |
+| LineString | `robot_sf_role: ped_route`, `robot_sf_spawn: ...`, `robot_sf_goal: ...` | Optional pedestrian route. |
+
+Zone identifiers are sorted before YAML indexes are assigned, so the same annotated extract produces
+stable route references. Zones are converted to their minimum rotated rectangles because the existing
+map schema represents spawn and goal areas as rectangles.
+
+The command fails rather than inventing a robot spawn, goal, or route. Fix the missing annotation and
+rerun it; do not treat a geometry-only conversion as a runnable or benchmark-ready scenario.
+
+## Verify the generated map
+
+```bash
+uv run python -c "from pathlib import Path; from robot_sf.training.scenario_loader import resolve_map_definition; assert resolve_map_definition('maps/imported/campus.yaml', scenario_path=Path('maps/imported/campus.yaml'))"
+```
+
+For a real import, keep the source data outside Git unless its licence and repository review allow
+tracking it. The checker accepts only `exploratory_only`: importing geometry alone does not establish
+benchmark evidence. Commit the small YAML map and provenance manifest only after the source,
+annotations, and scenario use have been reviewed.

--- a/robot_sf/nav/geojson_map_builder.py
+++ b/robot_sf/nav/geojson_map_builder.py
@@ -1,0 +1,383 @@
+# ruff: noqa: DOC201
+"""Convert annotated OSM-derived GeoJSON into a runnable Robot SF map.
+
+The converter keeps the repository's existing segment-map YAML contract: obstacle
+polygons are emitted as vertices and become collision line segments when loaded.
+GeoJSON uses WGS84 when no CRS is declared, then is projected to a local UTM
+coordinate frame so all output positions and line-buffer widths are in metres.
+
+OpenStreetMap tags identify walkable and obstacle geometry.  Scenario-specific
+intent is deliberately explicit: GeoJSON features use ``robot_sf_role`` (or the
+equivalent ``robot_sf:role``) for zones and routes.  This avoids guessing a robot
+route or spawn position from public map geometry.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import geopandas
+import yaml
+from loguru import logger
+from shapely.affinity import translate
+from shapely.errors import TopologicalError
+from shapely.geometry import GeometryCollection, LineString, MultiLineString, MultiPolygon, Polygon
+from shapely.ops import unary_union
+
+from robot_sf.nav.map_config import MapDefinition, serialize_map
+from robot_sf.nav.osm_map_builder import OSMTagFilters, cleanup_polygons, compute_obstacles
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+_ROLE_KEYS = ("robot_sf_role", "robot_sf:role")
+_ID_KEYS = ("robot_sf_id", "robot_sf:id", "id", "name")
+_SPAWN_KEYS = ("robot_sf_spawn", "robot_sf:spawn")
+_GOAL_KEYS = ("robot_sf_goal", "robot_sf:goal")
+_ZONE_ROLES = (
+    "robot_spawn",
+    "robot_goal",
+    "ped_spawn",
+    "ped_goal",
+    "ped_crowded",
+)
+_ROUTE_ROLES = ("robot_route", "ped_route")
+
+
+def load_geojson(path: str | Path) -> geopandas.GeoDataFrame:
+    """Load a non-empty GeoJSON file and assign the standard WGS84 CRS when absent."""
+    source = Path(path)
+    if not source.is_file():
+        raise FileNotFoundError(f"GeoJSON file not found: {source}")
+    try:
+        features = geopandas.read_file(source)
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"Could not read GeoJSON file {source}: {exc}") from exc
+    if features.empty:
+        raise ValueError(f"GeoJSON file contains no features: {source}")
+    if features.crs is None:
+        features = features.set_crs("EPSG:4326", allow_override=True)
+    return features
+
+
+def geojson_to_map_structure(
+    path: str | Path,
+    *,
+    line_buffer_m: float = 1.5,
+    tag_filters: OSMTagFilters | None = None,
+) -> dict[str, Any]:
+    """Convert annotated GeoJSON into the YAML structure consumed by ``serialize_map``.
+
+    ``robot_sf_role`` values ``robot_spawn``, ``robot_goal``, ``ped_spawn``,
+    ``ped_goal``, and ``ped_crowded`` declare polygon zones.  Each zone needs a
+    stable ``robot_sf_id``.  ``robot_route`` and ``ped_route`` LineStrings use
+    ``robot_sf_spawn`` and ``robot_sf_goal`` to name their endpoint zones.
+
+    Raises:
+        ValueError: When geometry is invalid, no walkable geometry is available,
+            or the GeoJSON lacks the metadata required for a runnable robot map.
+    """
+    if line_buffer_m <= 0:
+        raise ValueError("line_buffer_m must be greater than zero")
+    filters = tag_filters or OSMTagFilters()
+    projected = _project_to_local_metric(load_geojson(path))
+    walkable_polys = _walkable_polygons(projected, filters, line_buffer_m)
+    obstacle_polys = _obstacle_polygons(projected, filters, line_buffer_m)
+    if obstacle_polys:
+        try:
+            walkable_geometry = unary_union(walkable_polys).difference(unary_union(obstacle_polys))
+        except (ValueError, TopologicalError) as exc:
+            raise ValueError(
+                f"Could not subtract obstacle geometry from walkable areas: {exc}"
+            ) from exc
+        walkable_polys = cleanup_polygons(_polygon_parts(walkable_geometry))
+    if not walkable_polys:
+        raise ValueError("No valid walkable areas remain after obstacle exclusion")
+
+    min_x, min_y, max_x, max_y = projected.total_bounds
+    if max_x <= min_x or max_y <= min_y:
+        raise ValueError("GeoJSON bounds must have non-zero width and height")
+
+    walkable_union = unary_union(walkable_polys)
+    obstacle_segments = compute_obstacles((min_x, min_y, max_x, max_y), walkable_union)
+    local_obstacles = [_local_polygon_vertices(poly, min_x, min_y) for poly in obstacle_segments]
+    zones = _extract_zones(projected, min_x=min_x, min_y=min_y)
+    _require_runnable_robot_zones(zones)
+    routes = _extract_routes(projected, min_x=min_x, min_y=min_y)
+    if not routes["robot_routes"]:
+        raise ValueError(
+            "No robot_route features found. Add an annotated LineString with "
+            "robot_sf_spawn and robot_sf_goal metadata."
+        )
+
+    return {
+        "x_margin": [0.0, float(max_x - min_x)],
+        "y_margin": [0.0, float(max_y - min_y)],
+        "obstacles": local_obstacles,
+        "robot_spawn_zones": zones["robot_spawn"],
+        "robot_goal_zones": zones["robot_goal"],
+        "ped_spawn_zones": zones["ped_spawn"],
+        "ped_goal_zones": zones["ped_goal"],
+        "ped_crowded_zones": zones["ped_crowded"],
+        "robot_routes": routes["robot_routes"],
+        "ped_routes": routes["ped_routes"],
+    }
+
+
+def geojson_to_map_definition(
+    path: str | Path,
+    *,
+    line_buffer_m: float = 1.5,
+    tag_filters: OSMTagFilters | None = None,
+) -> MapDefinition:
+    """Convert annotated GeoJSON to the runtime ``MapDefinition`` representation."""
+    return serialize_map(
+        geojson_to_map_structure(path, line_buffer_m=line_buffer_m, tag_filters=tag_filters)
+    )
+
+
+def write_segment_map(
+    source: str | Path,
+    destination: str | Path,
+    *,
+    line_buffer_m: float = 1.5,
+) -> Path:
+    """Write a deterministic YAML segment-map converted from annotated GeoJSON."""
+    target = Path(destination)
+    if target.suffix.lower() not in {".yaml", ".yml"}:
+        raise ValueError("Segment-map output must use a .yaml or .yml extension")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    structure = geojson_to_map_structure(source, line_buffer_m=line_buffer_m)
+    with target.open("w", encoding="utf-8") as stream:
+        yaml.safe_dump(structure, stream, sort_keys=False)
+    return target
+
+
+def _project_to_local_metric(features: geopandas.GeoDataFrame) -> geopandas.GeoDataFrame:
+    """Project all GeoJSON geometry into a single local UTM CRS measured in metres."""
+    crs = features.estimate_utm_crs()
+    if crs is None:
+        raise ValueError("Could not determine a local UTM CRS from GeoJSON geometry")
+    return features.to_crs(crs)
+
+
+def _walkable_polygons(
+    features: geopandas.GeoDataFrame,
+    filters: OSMTagFilters,
+    line_buffer_m: float,
+) -> list[Polygon]:
+    """Return valid polygons for explicit and OSM-tagged walkable geometry."""
+    mask = _role_mask(features, "walkable") | _column_values_in(
+        features, "highway", filters.driveable_highways
+    )
+    mask |= _column_values_in(features, "footway", {"sidewalk", "crossing"})
+    mask |= _column_values_in(features, "area", filters.driveable_areas)
+    polygons = cleanup_polygons(_buffer_geometries(features.loc[mask, "geometry"], line_buffer_m))
+    if not polygons:
+        raise ValueError(
+            "No walkable geometry found. Add OSM highway/footway/area tags or "
+            "robot_sf_role=walkable."
+        )
+    return polygons
+
+
+def _obstacle_polygons(
+    features: geopandas.GeoDataFrame,
+    filters: OSMTagFilters,
+    line_buffer_m: float,
+) -> list[Polygon]:
+    """Return valid polygons for explicit and OSM-tagged obstacle geometry."""
+    mask = _role_mask(features, "obstacle")
+    for key, value in filters.obstacle_tags:
+        if key not in features.columns:
+            continue
+        values = features[key]
+        mask |= values.notna() if value == "*" else values == value
+    return cleanup_polygons(_buffer_geometries(features.loc[mask, "geometry"], line_buffer_m))
+
+
+def _buffer_geometries(geometries: Iterable[Any], line_buffer_m: float) -> list[Polygon]:
+    """Convert polygonal and line geometry to polygons without dropping multi-geometries."""
+    polygons: list[Polygon] = []
+    for geometry in geometries:
+        for part in _geometry_parts(geometry):
+            if isinstance(part, Polygon):
+                polygons.append(part)
+            elif isinstance(part, LineString):
+                polygons.extend(_polygon_parts(part.buffer(line_buffer_m, cap_style="round")))
+    return polygons
+
+
+def _geometry_parts(geometry: Any) -> list[Any]:
+    """Flatten supported Shapely collection types while ignoring empty geometry."""
+    if geometry is None or geometry.is_empty:
+        return []
+    if isinstance(geometry, (Polygon, LineString)):
+        return [geometry]
+    if isinstance(geometry, (MultiPolygon, MultiLineString, GeometryCollection)):
+        return [part for child in geometry.geoms for part in _geometry_parts(child)]
+    return []
+
+
+def _polygon_parts(geometry: Any) -> list[Polygon]:
+    """Extract non-empty polygons from a Shapely geometry or geometry collection."""
+    return [part for part in _geometry_parts(geometry) if isinstance(part, Polygon)]
+
+
+def _role_mask(features: geopandas.GeoDataFrame, role: str) -> Any:
+    """Return a row mask for one documented Robot SF GeoJSON role."""
+    mask = features.geometry.is_empty & False
+    for key in _ROLE_KEYS:
+        if key in features.columns:
+            mask |= features[key].astype("string").str.lower() == role
+    return mask
+
+
+def _column_values_in(features: geopandas.GeoDataFrame, key: str, values: Iterable[str]) -> Any:
+    """Return a row mask when a GeoJSON property contains one of ``values``."""
+    if key not in features.columns:
+        return features.geometry.is_empty & False
+    return features[key].astype("string").str.lower().isin({value.lower() for value in values})
+
+
+def _feature_value(feature: Any, keys: Iterable[str]) -> str | None:
+    """Return the first non-empty metadata value from ``keys`` for a GeoJSON row."""
+    for key in keys:
+        value = feature.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return None
+
+
+def _extract_zones(
+    features: geopandas.GeoDataFrame,
+    *,
+    min_x: float,
+    min_y: float,
+) -> dict[str, list[list[tuple[float, float]]]]:
+    """Extract ordered, rectangular scenario zones from explicitly annotated polygons."""
+    zones: dict[str, list[tuple[str, list[tuple[float, float]]]]] = {
+        role: [] for role in _ZONE_ROLES
+    }
+    seen_ids: set[str] = set()
+    for _, feature in features.iterrows():
+        role = _feature_value(feature, _ROLE_KEYS)
+        if role not in _ZONE_ROLES:
+            continue
+        zone_id = _feature_value(feature, _ID_KEYS)
+        if zone_id is None:
+            raise ValueError(f"{role} feature requires a robot_sf_id")
+        if zone_id in seen_ids:
+            raise ValueError(f"Duplicate robot_sf_id for a zone: {zone_id!r}")
+        polygons = _polygon_parts(feature.geometry)
+        if len(polygons) != 1:
+            raise ValueError(f"{role} zone {zone_id!r} must be one Polygon")
+        rectangle = polygons[0].minimum_rotated_rectangle
+        if not isinstance(rectangle, Polygon) or rectangle.area <= 0:
+            raise ValueError(f"{role} zone {zone_id!r} has no usable area")
+        coordinates = list(rectangle.exterior.coords)[:3]
+        zones[role].append(
+            (zone_id, [(float(x - min_x), float(y - min_y)) for x, y in coordinates])
+        )
+        seen_ids.add(zone_id)
+    return {role: [zone for _, zone in sorted(entries)] for role, entries in zones.items()}
+
+
+def _require_runnable_robot_zones(zones: dict[str, list[list[tuple[float, float]]]]) -> None:
+    """Fail closed unless explicit robot start and goal zones are present."""
+    missing = [role for role in ("robot_spawn", "robot_goal") if not zones[role]]
+    if missing:
+        raise ValueError(
+            "GeoJSON is not a runnable robot scenario; add "
+            + ", ".join(f"robot_sf_role={role}" for role in missing)
+            + " polygon features."
+        )
+
+
+def _extract_routes(
+    features: geopandas.GeoDataFrame,
+    *,
+    min_x: float,
+    min_y: float,
+) -> dict[str, list[dict[str, Any]]]:
+    """Extract routes and resolve their named zone endpoints to stable output indexes."""
+    zone_lookup = _zone_lookup(features)
+    output: dict[str, list[dict[str, Any]]] = {"robot_routes": [], "ped_routes": []}
+    for _, feature in features.iterrows():
+        role = _feature_value(feature, _ROLE_KEYS)
+        if role not in _ROUTE_ROLES:
+            continue
+        spawn_name = _feature_value(feature, _SPAWN_KEYS)
+        goal_name = _feature_value(feature, _GOAL_KEYS)
+        if spawn_name is None or goal_name is None:
+            raise ValueError(f"{role} feature requires robot_sf_spawn and robot_sf_goal metadata")
+        prefix = "robot" if role == "robot_route" else "ped"
+        try:
+            spawn_id = zone_lookup[f"{prefix}_spawn"][spawn_name]
+            goal_id = zone_lookup[f"{prefix}_goal"][goal_name]
+        except KeyError as exc:
+            raise ValueError(
+                f"{role} references an unknown {prefix} zone: {exc.args[0]!r}"
+            ) from exc
+        lines = [part for part in _geometry_parts(feature.geometry) if isinstance(part, LineString)]
+        if len(lines) != 1 or len(lines[0].coords) < 2:
+            raise ValueError(
+                f"{role} {spawn_name!r}->{goal_name!r} must be one LineString with two points"
+            )
+        output[f"{prefix}_routes"].append(
+            {
+                "spawn_id": spawn_id,
+                "goal_id": goal_id,
+                "waypoints": [[float(x - min_x), float(y - min_y)] for x, y, *_ in lines[0].coords],
+            }
+        )
+    return output
+
+
+def _zone_lookup(features: geopandas.GeoDataFrame) -> dict[str, dict[str, int]]:
+    """Map annotated zone names to the deterministic index used in emitted YAML."""
+    records: dict[str, list[str]] = {role: [] for role in _ZONE_ROLES}
+    for _, feature in features.iterrows():
+        role = _feature_value(feature, _ROLE_KEYS)
+        if role in records:
+            zone_id = _feature_value(feature, _ID_KEYS)
+            if zone_id is not None:
+                records[role].append(zone_id)
+    return {
+        role: {zone_id: index for index, zone_id in enumerate(sorted(ids))}
+        for role, ids in records.items()
+    }
+
+
+def _local_polygon_vertices(polygon: Polygon, min_x: float, min_y: float) -> list[list[float]]:
+    """Return an obstacle polygon exterior as local-frame vertices without a repeated endpoint."""
+    local = translate(polygon, xoff=-min_x, yoff=-min_y)
+    return [[float(x), float(y)] for x, y in list(local.exterior.coords)[:-1]]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the documented GeoJSON-to-segment-map command-line interface."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Annotated OSM or GeoJSON FeatureCollection")
+    parser.add_argument("output", type=Path, help="Destination Robot SF YAML map")
+    parser.add_argument(
+        "--line-buffer-m",
+        type=float,
+        default=1.5,
+        help="Half-width in metres for tagged LineString paths and obstacles (default: 1.5)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the GeoJSON converter CLI and print the created map path."""
+    args = build_parser().parse_args(argv)
+    output = write_segment_map(args.input, args.output, line_buffer_m=args.line_buffer_m)
+    logger.info("Wrote Robot SF segment map: {}", output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through the wrapper script.
+    raise SystemExit(main())

--- a/robot_sf/nav/geojson_map_builder.py
+++ b/robot_sf/nav/geojson_map_builder.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import geopandas
+import pandas
 import yaml
 from loguru import logger
 from shapely.affinity import translate
@@ -231,7 +232,7 @@ def _role_mask(features: geopandas.GeoDataFrame, role: str) -> Any:
     mask = features.geometry.is_empty & False
     for key in _ROLE_KEYS:
         if key in features.columns:
-            mask |= features[key].astype("string").str.lower() == role
+            mask |= features[key].astype(str).str.lower() == role
     return mask
 
 
@@ -239,15 +240,18 @@ def _column_values_in(features: geopandas.GeoDataFrame, key: str, values: Iterab
     """Return a row mask when a GeoJSON property contains one of ``values``."""
     if key not in features.columns:
         return features.geometry.is_empty & False
-    return features[key].astype("string").str.lower().isin({value.lower() for value in values})
+    return features[key].astype(str).str.lower().isin({value.lower() for value in values})
 
 
 def _feature_value(feature: Any, keys: Iterable[str]) -> str | None:
     """Return the first non-empty metadata value from ``keys`` for a GeoJSON row."""
     for key in keys:
         value = feature.get(key)
-        if value is not None and str(value).strip():
-            return str(value).strip()
+        if value is None or pandas.isna(value):
+            continue
+        normalized = str(value).strip()
+        if normalized:
+            return normalized
     return None
 
 

--- a/robot_sf/nav/geojson_map_provenance.py
+++ b/robot_sf/nav/geojson_map_provenance.py
@@ -56,7 +56,11 @@ def _require_mapping_fields(value: Any, name: str, fields: tuple[str, ...]) -> N
     """Require non-empty fields in one manifest mapping."""
     if not isinstance(value, dict):
         raise ValueError(f"{name} must be a mapping")
-    missing = [field for field in fields if not str(value.get(field, "")).strip()]
+    missing = [
+        field
+        for field in fields
+        if value.get(field) is None or not str(value.get(field, "")).strip()
+    ]
     if missing:
         raise ValueError(f"{name} missing required field(s): {', '.join(missing)}")
 

--- a/robot_sf/nav/geojson_map_provenance.py
+++ b/robot_sf/nav/geojson_map_provenance.py
@@ -1,0 +1,74 @@
+"""Validate provenance required for a public GeoJSON map import."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_SCHEMA_VERSION = "robot_sf.geojson_import_provenance.v1"
+
+
+def validate_import_provenance(
+    manifest_path: str | Path, source_path: str | Path
+) -> dict[str, Any]:
+    """Validate a public-source provenance manifest against its raw GeoJSON checksum.
+
+    Returns:
+        Parsed, validated provenance manifest.
+
+    Raises:
+        ValueError: If the manifest is incomplete, its checksum does not match, or it
+            promotes the import to benchmark evidence without a separate review.
+    """
+    manifest = Path(manifest_path)
+    source = Path(source_path)
+    if not manifest.is_file():
+        raise FileNotFoundError(f"GeoJSON provenance manifest not found: {manifest}")
+    if not source.is_file():
+        raise FileNotFoundError(f"GeoJSON source file not found: {source}")
+    try:
+        data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid GeoJSON provenance YAML {manifest}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("GeoJSON provenance manifest must contain a mapping")
+    if data.get("schema_version") != _SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {_SCHEMA_VERSION!r}")
+    _require_mapping_fields(
+        data.get("source"), "source", ("url", "accessed_on", "license", "citation")
+    )
+    raw_input = data.get("raw_input")
+    _require_mapping_fields(raw_input, "raw_input", ("sha256",))
+    if raw_input["sha256"] != _sha256(source):
+        raise ValueError("raw_input.sha256 does not match the supplied GeoJSON")
+    classification = data.get("classification")
+    if classification != "exploratory_only":
+        raise ValueError(
+            "classification must be 'exploratory_only'; map import alone is not benchmark evidence"
+        )
+    return data
+
+
+def _require_mapping_fields(value: Any, name: str, fields: tuple[str, ...]) -> None:
+    """Require non-empty fields in one manifest mapping."""
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be a mapping")
+    missing = [field for field in fields if not str(value.get(field, "")).strip()]
+    if missing:
+        raise ValueError(f"{name} missing required field(s): {', '.join(missing)}")
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest of one local file.
+
+    Returns:
+        Lowercase hexadecimal SHA-256 digest.
+    """
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()

--- a/scripts/tools/convert_geojson_map.py
+++ b/scripts/tools/convert_geojson_map.py
@@ -1,0 +1,6 @@
+"""CLI wrapper for converting annotated OSM/GeoJSON into a Robot SF segment map."""
+
+from robot_sf.nav.geojson_map_builder import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_geojson_import.py
+++ b/scripts/validation/check_geojson_import.py
@@ -1,0 +1,50 @@
+"""Validate public GeoJSON provenance, convert it, and verify the resulting map loads."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from loguru import logger
+
+from robot_sf.nav.geojson_map_builder import write_segment_map
+from robot_sf.nav.geojson_map_provenance import validate_import_provenance
+from robot_sf.training.scenario_loader import resolve_map_definition
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the public GeoJSON import checker CLI.
+
+    Returns:
+        Configured command-line argument parser.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Public raw GeoJSON extract")
+    parser.add_argument(
+        "manifest", type=Path, help="Source URL, licence, citation, and raw checksum"
+    )
+    parser.add_argument(
+        "output", type=Path, help="Derived Robot SF YAML map (not a raw source file)"
+    )
+    parser.add_argument("--line-buffer-m", type=float, default=1.5)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate and convert one public GeoJSON input.
+
+    Returns:
+        Zero after provenance validation and successful map loading.
+    """
+    args = build_parser().parse_args(argv)
+    validate_import_provenance(args.manifest, args.input)
+    output = write_segment_map(args.input, args.output, line_buffer_m=args.line_buffer_m)
+    map_def = resolve_map_definition(str(output), scenario_path=output)
+    if map_def is None:
+        raise RuntimeError(f"Converted map did not load: {output}")
+    logger.info("GeoJSON import check passed: {}", output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/maps/geojson/annotated_plaza.geojson
+++ b/tests/fixtures/maps/geojson/annotated_plaza.geojson
@@ -1,0 +1,30 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"highway": "pedestrian"},
+      "geometry": {"type": "Polygon", "coordinates": [[[13.4000, 52.5200], [13.4008, 52.5200], [13.4008, 52.5204], [13.4000, 52.5204], [13.4000, 52.5200]]]}
+    },
+    {
+      "type": "Feature",
+      "properties": {"building": "yes"},
+      "geometry": {"type": "Polygon", "coordinates": [[[13.40035, 52.52014], [13.40048, 52.52014], [13.40048, 52.52027], [13.40035, 52.52027], [13.40035, 52.52014]]]}
+    },
+    {
+      "type": "Feature",
+      "properties": {"robot_sf_role": "robot_spawn", "robot_sf_id": "west"},
+      "geometry": {"type": "Polygon", "coordinates": [[[13.40005, 52.52005], [13.40017, 52.52005], [13.40017, 52.52014], [13.40005, 52.52014], [13.40005, 52.52005]]]}
+    },
+    {
+      "type": "Feature",
+      "properties": {"robot_sf_role": "robot_goal", "robot_sf_id": "east"},
+      "geometry": {"type": "Polygon", "coordinates": [[[13.40063, 52.52027], [13.40075, 52.52027], [13.40075, 52.52036], [13.40063, 52.52036], [13.40063, 52.52027]]]}
+    },
+    {
+      "type": "Feature",
+      "properties": {"robot_sf_role": "robot_route", "robot_sf_spawn": "west", "robot_sf_goal": "east"},
+      "geometry": {"type": "LineString", "coordinates": [[13.40011, 52.520095], [13.40023, 52.52008], [13.40056, 52.52032], [13.40069, 52.520315]]}
+    }
+  ]
+}

--- a/tests/unit/test_geojson_map_builder.py
+++ b/tests/unit/test_geojson_map_builder.py
@@ -124,3 +124,9 @@ def test_public_import_checker_requires_matching_checksum_and_loads_output(tmp_p
     manifest.write_text(yaml.safe_dump(data), encoding="utf-8")
     with pytest.raises(ValueError, match="classification must be 'exploratory_only'"):
         validate_import_provenance(manifest, FIXTURE)
+
+    data["classification"] = "exploratory_only"
+    data["source"]["url"] = None
+    manifest.write_text(yaml.safe_dump(data), encoding="utf-8")
+    with pytest.raises(ValueError, match=r"source missing required field\(s\): url"):
+        validate_import_provenance(manifest, FIXTURE)

--- a/tests/unit/test_geojson_map_builder.py
+++ b/tests/unit/test_geojson_map_builder.py
@@ -16,7 +16,8 @@ from robot_sf.nav.geojson_map_provenance import validate_import_provenance
 from robot_sf.training.scenario_loader import resolve_map_definition
 from scripts.validation.check_geojson_import import main as check_geojson_import
 
-FIXTURE = Path("tests/fixtures/maps/geojson/annotated_plaza.geojson")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = REPO_ROOT / "tests/fixtures/maps/geojson/annotated_plaza.geojson"
 
 
 def test_geojson_converter_emits_loadable_segment_map(tmp_path: Path) -> None:
@@ -71,6 +72,19 @@ def test_geojson_converter_requires_zone_metadata(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="robot_sf_role=robot_goal"):
         geojson_to_map_structure(missing_goal)
+
+
+def test_geojson_converter_ignores_null_optional_properties(tmp_path: Path) -> None:
+    """Null GeoJSON properties do not create invalid masks or literal metadata identifiers."""
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    data["features"][0]["properties"]["robot_sf_role"] = None
+    data["features"][2]["properties"]["unused_optional_property"] = None
+    null_properties = tmp_path / "null-properties.geojson"
+    null_properties.write_text(json.dumps(data), encoding="utf-8")
+
+    result = geojson_to_map_structure(null_properties)
+
+    assert len(result["robot_spawn_zones"]) == 1
 
 
 def test_public_import_checker_requires_matching_checksum_and_loads_output(tmp_path: Path) -> None:

--- a/tests/unit/test_geojson_map_builder.py
+++ b/tests/unit/test_geojson_map_builder.py
@@ -1,0 +1,112 @@
+"""Tests for the fail-closed OSM/GeoJSON segment-map converter."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.nav.geojson_map_builder import (
+    geojson_to_map_definition,
+    geojson_to_map_structure,
+    write_segment_map,
+)
+from robot_sf.nav.geojson_map_provenance import validate_import_provenance
+from robot_sf.training.scenario_loader import resolve_map_definition
+from scripts.validation.check_geojson_import import main as check_geojson_import
+
+FIXTURE = Path("tests/fixtures/maps/geojson/annotated_plaza.geojson")
+
+
+def test_geojson_converter_emits_loadable_segment_map(tmp_path: Path) -> None:
+    """An annotated GeoJSON plaza becomes a local-metre YAML map with obstacle segments."""
+    output = write_segment_map(FIXTURE, tmp_path / "plaza.yaml")
+    data = yaml.safe_load(output.read_text(encoding="utf-8"))
+
+    assert data["x_margin"][1] > 40.0
+    assert data["y_margin"][1] > 30.0
+    assert data["obstacles"]
+    assert len(data["robot_spawn_zones"]) == 1
+    assert len(data["robot_goal_zones"]) == 1
+    assert len(data["robot_routes"]) == 1
+
+    map_def = resolve_map_definition(str(output), scenario_path=tmp_path / "scenario.yaml")
+    assert map_def is not None
+    assert map_def.obstacles_pysf
+    assert len(map_def.robot_routes) == 2  # Runtime YAML loader adds the reverse route.
+
+
+def test_geojson_converter_returns_runtime_map_definition() -> None:
+    """The direct conversion API has the same route and obstacle contract as YAML loading."""
+    map_def = geojson_to_map_definition(FIXTURE)
+
+    assert map_def.width > 40.0
+    assert map_def.height > 30.0
+    assert len(map_def.robot_routes) == 2
+    assert map_def.obstacles
+
+
+def test_geojson_converter_requires_explicit_route_metadata(tmp_path: Path) -> None:
+    """Public geometry without a declared route cannot silently become a scenario."""
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    data["features"] = data["features"][:-1]
+    missing_route = tmp_path / "missing-route.geojson"
+    missing_route.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="No robot_route features"):
+        geojson_to_map_structure(missing_route)
+
+
+def test_geojson_converter_requires_zone_metadata(tmp_path: Path) -> None:
+    """A route alone is not a runnable scenario without named endpoint zones."""
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    data["features"] = [
+        feature
+        for feature in data["features"]
+        if feature["properties"].get("robot_sf_role") != "robot_goal"
+    ]
+    missing_goal = tmp_path / "missing-goal.geojson"
+    missing_goal.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="robot_sf_role=robot_goal"):
+        geojson_to_map_structure(missing_goal)
+
+
+def test_public_import_checker_requires_matching_checksum_and_loads_output(tmp_path: Path) -> None:
+    """Public imports retain provenance and only pass after the derived map loads."""
+    checksum = hashlib.sha256(FIXTURE.read_bytes()).hexdigest()
+    manifest = tmp_path / "provenance.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "robot_sf.geojson_import_provenance.v1",
+                "classification": "exploratory_only",
+                "source": {
+                    "url": "https://www.openstreetmap.org/copyright",
+                    "accessed_on": "2026-07-10",
+                    "license": "ODbL-1.0",
+                    "citation": "OpenStreetMap contributors",
+                },
+                "raw_input": {"sha256": checksum},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert validate_import_provenance(manifest, FIXTURE)["classification"] == "exploratory_only"
+    output = tmp_path / "plaza.yaml"
+    assert check_geojson_import([str(FIXTURE), str(manifest), str(output)]) == 0
+    assert output.is_file()
+
+    data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    data["raw_input"]["sha256"] = "0" * 64
+    manifest.write_text(yaml.safe_dump(data), encoding="utf-8")
+    with pytest.raises(ValueError, match="sha256 does not match"):
+        validate_import_provenance(manifest, FIXTURE)
+
+    data["raw_input"]["sha256"] = checksum
+    data["classification"] = "benchmark_ready"
+    manifest.write_text(yaml.safe_dump(data), encoding="utf-8")
+    with pytest.raises(ValueError, match="classification must be 'exploratory_only'"):
+        validate_import_provenance(manifest, FIXTURE)


### PR DESCRIPTION
## Reviewer-critical summary

- What changed: add an annotated OSM/GeoJSON-to-Robot-SF YAML segment-map converter, a public-source provenance checker, and a documented CLI.
- Why now: issue #4980 needs a reproducible import path instead of manual map transcription.
- Claim boundary: this proves conversion and scenario-map loading on a tracked synthetic contract fixture; it does not establish real-location, benchmark, paper, or dissertation evidence.
- Required validation: final repository readiness, focused GeoJSON/OSM tests, and direct CLI-to-loader checks.
- Remaining blocker: a provenance-backed public real extract cannot be retained or run end-to-end here without authorization to store the raw external source.

## Contract delta

- New input metadata: `robot_sf_role`/`robot_sf:role`, stable `robot_sf_id`, and named route endpoints `robot_sf_spawn`/`robot_sf_goal`.
- New fail-closed blockers: no walkable geometry, robot spawn/goal zone, robot route, matching public-source checksum, or `exploratory_only` classification aborts conversion/checking.
- Compatibility: no existing map parser or scenario schema changes; output is the already-supported YAML map structure and gains the loader's reverse robot route.

## Scope and validation

- Issue: https://github.com/ll7/robot_sf_ll7/issues/4980
- Refs #4980
- Added a GeoJSON converter, public provenance template/checker, documentation, and focused synthetic fixture/tests.
- Passed: `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`.
- Passed: `uv run pytest -q tests/test_geojson_map_builder.py tests/test_osm_map_builder.py` (20 passed).
- Passed: documented CLI conversion and `resolve_map_definition` load check.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- State propagation: no issue comment was posted because this task does not authorize issue/PR comments; no queue-routing state was written to tracked files.

## Follow-Up Issues

- Deferred work: run one licence-reviewed, provenance-backed public campus/plaza extract after authorization to retain the raw input; #4980 remains the owning issue.
- Issues opened for follow-up: none; the open parent issue #4980 is the single canonical tracker.

<details>
<summary>Governance appendix</summary>

## Stack / Dependency

- Base dependency: none.
- Required prior PRs: none.
- Safe to review independently: yes.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - support tooling only; real-location evidence remains unrun.
- Comparator or baseline: NA.
- Evidence tier: NA - support helper with a tracked synthetic contract fixture.
- Result classification: NA - no research result.
- Decision or stop rule: conversion must fail closed when scenario or provenance metadata is incomplete.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #4980.
- New research/benchmark/metric/paper-facing analysis tool: NA - support helper that does not interpret research evidence.

## Domain-Aware Approval

- Required for this PR: no - it changes import tooling only and makes no research result.
- Domains reviewed: NA - no evidence classification or experimental interpretation change.
- Status: not required.
- Approver/review source or waiver: tooling-only scope; explicit non-evidence claim boundary above.
- Validity checklist:
  - Target claim/hypothesis: NA - no empirical claim.
  - Comparator or split/evidence validity: NA.
  - Fallback/degraded exclusions: NA.
  - Claim boundary: conversion/load contract only.
  - Implementation integrity vs experimental validity: unit, compatibility, CLI, and full readiness proof; no experimental validity claim.

## Validation / Proof

- Full readiness: passed 2,001 core tests and changed-file coverage under the final command above.
- Contract evidence: five GeoJSON/provenance tests cover local UTM output, obstacles, route reversal, missing annotations, checksum validation, and checker-to-loader execution.
- Existing OSM compatibility: 15 PBF importer tests passed.
- Artifact decision: `output/` contains 98 MB of ignored coverage output from readiness checks and is disposable; no raw external map data was committed.

## Risks / Rollout

- Assumption: GeoJSON without a declared CRS is standard WGS84, and scenario zones/routes use explicit metadata rather than inferred locations.
- Remaining risk: imported geometry and annotations require human scenario review before any benchmark use.
- Rollback: revert this self-contained converter; no existing scenario loading behavior changes.

## Docs / Provenance

- Updated: `docs/maps/geojson_import.md`.
- Added: `configs/maps/geojson_import_provenance.example.yaml` requires source URL, access date, licence, citation, checksum, and `exploratory_only` classification.

## Downstream Propagation

- Parent issue updated: no - comment authorization is absent; PR body records the remaining action.
- Claim map / benchmark report updated: NA - no evidence claim.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA - no committed real map.
- Context index / memory note updated: NA.
- Not applicable because: no benchmark or durable external-data artifact was produced.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversion of annotated OpenStreetMap GeoJSON extracts into YAML segment maps.
  * Added validation for source licensing, provenance metadata, classification, and SHA-256 integrity.
  * Added command-line tools for conversion, validation, and generated-map verification.

* **Documentation**
  * Added setup, annotation, projection, tagging, and verification guidance for GeoJSON map imports.
  * Added an example provenance configuration.

* **Tests**
  * Added coverage for successful conversions, route and zone handling, invalid metadata, and provenance failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->