### PR TITLE
fix: fail closed exemplar exporters (#5003)

### DIFF
--- a/scripts/export_issue_4848_group_crossing_exemplars.py
+++ b/scripts/export_issue_4848_group_crossing_exemplars.py
@@ -45,6 +45,10 @@ DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_4848_group_crossing_exemp
 DEFAULT_CAMPAIGN_ROOT = Path("output/issue4206-trace-rerun/13334/runs")
 
 
+class ExemplarExportInputError(ValueError):
+    """Raised when an exemplar export input cannot support valid evidence output."""
+
+
 @dataclass(frozen=True)
 class SelectedEpisode:
     """One selected exemplar episode."""
@@ -199,13 +203,18 @@ def derive_trace_rows(record: dict[str, Any]) -> TraceRows:
 
 
 def read_jsonl(path: Path) -> list[dict[str, Any]]:
-    """Read JSONL file into a list of dicts."""
+    """Read a non-empty JSONL file or fail before an empty export can be emitted."""
+    if not path.is_file():
+        raise ExemplarExportInputError(f"episodes JSONL is not a file: {path}")
+
     records = []
     with path.open("r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if line:
                 records.append(json.loads(line))
+    if not records:
+        raise ExemplarExportInputError(f"episodes JSONL is empty: {path}")
     return records
 
 
@@ -231,7 +240,10 @@ def select_exemplars_for_planner(
                 scored.append((float(val), ep))
 
     if not scored:
-        return []
+        raise ExemplarExportInputError(
+            f"planner {planner!r}: no finite selection metric {SELECTION_METRIC!r} "
+            f"among {len(group_crossing_eps)} eligible episodes"
+        )
 
     # Sort by metric value (ascending for median index invariance)
     scored.sort(key=lambda x: x[0])
@@ -431,15 +443,14 @@ def _process_planner(
     pin_generated_at: str | None = None,
 ) -> tuple[list[SelectedEpisode], dict[str, Any] | None]:
     """Process one planner: read episodes, select exemplars, write bundles."""
+    if not campaign_root.is_dir():
+        raise ExemplarExportInputError(f"campaign root is not a directory: {campaign_root}")
+
     planner_dir = campaign_root / f"{planner}__differential_drive"
-    if not planner_dir.exists():
-        print(f"Warning: planner directory not found: {planner_dir}")
-        return [], None
+    if not planner_dir.is_dir():
+        raise ExemplarExportInputError(f"planner directory is not a directory: {planner_dir}")
 
     episodes_path = planner_dir / "episodes.jsonl"
-    if not episodes_path.exists():
-        print(f"Warning: episodes.jsonl not found: {episodes_path}")
-        return [], None
 
     print(f"Reading episodes from {episodes_path}")
     episodes = read_jsonl(episodes_path)
@@ -524,22 +535,22 @@ def main() -> int:
     if not output_dir.is_absolute():
         output_dir = repo_root / output_dir
 
-    if not campaign_root.exists():
-        print(f"Error: campaign root not found: {campaign_root}", file=sys.stderr)
-        return 1
-
-    all_selections: list[SelectedEpisode] = []
-    bundle_metadata: dict[str, Any] | None = None
-    for planner in args.planners:
-        selections, metadata = _process_planner(
-            planner,
-            campaign_root,
-            output_dir,
-            pin_generated_at=args.pin_generated_at,
-        )
-        all_selections.extend(selections)
-        if bundle_metadata is None and metadata is not None:
-            bundle_metadata = metadata
+    try:
+        all_selections: list[SelectedEpisode] = []
+        bundle_metadata: dict[str, Any] | None = None
+        for planner in args.planners:
+            selections, metadata = _process_planner(
+                planner,
+                campaign_root,
+                output_dir,
+                pin_generated_at=args.pin_generated_at,
+            )
+            all_selections.extend(selections)
+            if bundle_metadata is None and metadata is not None:
+                bundle_metadata = metadata
+    except ExemplarExportInputError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
 
     marker_date = extract_marker_date(bundle_metadata) if bundle_metadata else None
     generated_at = bundle_metadata.get("generated_at_utc") if bundle_metadata else None

--- a/scripts/export_issue_4848_group_crossing_exemplars.py
+++ b/scripts/export_issue_4848_group_crossing_exemplars.py
@@ -228,7 +228,9 @@ def select_exemplars_for_planner(
     ]
 
     if not group_crossing_eps:
-        return []
+        raise ExemplarExportInputError(
+            f"planner {planner!r}: no eligible group-crossing episodes for exemplar selection"
+        )
 
     # Extract metric values
     scored: list[tuple[float, dict[str, Any]]] = []

--- a/scripts/export_issue_4891_head_on_corridor_exemplars.py
+++ b/scripts/export_issue_4891_head_on_corridor_exemplars.py
@@ -48,6 +48,10 @@ DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_4891_head_on_corridor_exe
 DEFAULT_CAMPAIGN_ROOT = Path("output/issue4206-trace-rerun/13334/runs")
 
 
+class ExemplarExportInputError(ValueError):
+    """Raised when an exemplar export input cannot support valid evidence output."""
+
+
 @dataclass(frozen=True)
 class SelectedEpisode:
     """One selected exemplar episode."""
@@ -202,13 +206,18 @@ def derive_trace_rows(record: dict[str, Any]) -> TraceRows:
 
 
 def read_jsonl(path: Path) -> list[dict[str, Any]]:
-    """Read JSONL file into a list of dicts."""
+    """Read a non-empty JSONL file or fail before an empty export can be emitted."""
+    if not path.is_file():
+        raise ExemplarExportInputError(f"episodes JSONL is not a file: {path}")
+
     records = []
     with path.open("r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if line:
                 records.append(json.loads(line))
+    if not records:
+        raise ExemplarExportInputError(f"episodes JSONL is empty: {path}")
     return records
 
 
@@ -239,7 +248,10 @@ def select_exemplars_for_planner(
                 scored.append((float(val), step_count or 0, ep))
 
     if not scored:
-        return []
+        raise ExemplarExportInputError(
+            f"planner {planner!r}: no finite selection metric {SELECTION_METRIC!r} "
+            f"among {len(corridor_eps)} eligible episodes"
+        )
 
     # Filter out single-step episodes (no visualization content)
     MIN_STEP_COUNT = 2
@@ -492,15 +504,14 @@ def _process_planner(
     pin_generated_at: str | None = None,
 ) -> tuple[list[SelectedEpisode], dict[str, Any] | None]:
     """Process one planner: read episodes, select exemplars, write bundles."""
+    if not campaign_root.is_dir():
+        raise ExemplarExportInputError(f"campaign root is not a directory: {campaign_root}")
+
     planner_dir = campaign_root / f"{planner}__differential_drive"
-    if not planner_dir.exists():
-        print(f"Warning: planner directory not found: {planner_dir}")
-        return [], None
+    if not planner_dir.is_dir():
+        raise ExemplarExportInputError(f"planner directory is not a directory: {planner_dir}")
 
     episodes_path = planner_dir / "episodes.jsonl"
-    if not episodes_path.exists():
-        print(f"Warning: episodes.jsonl not found: {episodes_path}")
-        return [], None
 
     print(f"Reading episodes from {episodes_path}")
     episodes = read_jsonl(episodes_path)
@@ -585,22 +596,22 @@ def main() -> int:
     if not output_dir.is_absolute():
         output_dir = repo_root / output_dir
 
-    if not campaign_root.exists():
-        print(f"Error: campaign root not found: {campaign_root}", file=sys.stderr)
-        return 1
-
-    all_selections: list[SelectedEpisode] = []
-    bundle_metadata: dict[str, Any] | None = None
-    for planner in args.planners:
-        selections, metadata = _process_planner(
-            planner,
-            campaign_root,
-            output_dir,
-            pin_generated_at=args.pin_generated_at,
-        )
-        all_selections.extend(selections)
-        if bundle_metadata is None and metadata is not None:
-            bundle_metadata = metadata
+    try:
+        all_selections: list[SelectedEpisode] = []
+        bundle_metadata: dict[str, Any] | None = None
+        for planner in args.planners:
+            selections, metadata = _process_planner(
+                planner,
+                campaign_root,
+                output_dir,
+                pin_generated_at=args.pin_generated_at,
+            )
+            all_selections.extend(selections)
+            if bundle_metadata is None and metadata is not None:
+                bundle_metadata = metadata
+    except ExemplarExportInputError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
 
     marker_date = extract_marker_date(bundle_metadata) if bundle_metadata else None
     generated_at = bundle_metadata.get("generated_at_utc") if bundle_metadata else None

--- a/scripts/export_issue_4891_head_on_corridor_exemplars.py
+++ b/scripts/export_issue_4891_head_on_corridor_exemplars.py
@@ -234,7 +234,9 @@ def select_exemplars_for_planner(
     corridor_eps = [ep for ep in episodes if ep.get("scenario_id") in HEAD_ON_CORRIDOR_SCENARIOS]
 
     if not corridor_eps:
-        return []
+        raise ExemplarExportInputError(
+            f"planner {planner!r}: no eligible head-on-corridor episodes for exemplar selection"
+        )
 
     # Extract metric values with step count for quality filtering
     scored: list[tuple[float, int, dict[str, Any]]] = []

--- a/tests/test_export_issue_4848.py
+++ b/tests/test_export_issue_4848.py
@@ -102,13 +102,13 @@ class TestSelectExemplars:
         assert median.metric_value == 0.7
 
     def test_empty_episodes(self) -> None:
-        selected = _export_module.select_exemplars_for_planner([], "goal")
-        assert selected == []
+        with pytest.raises(_export_module.ExemplarExportInputError, match="no eligible"):
+            _export_module.select_exemplars_for_planner([], "goal")
 
     def test_no_group_crossing(self) -> None:
         episodes = [self._make_episode("classic_doorway_low", 1, 0.8)]
-        selected = _export_module.select_exemplars_for_planner(episodes, "goal")
-        assert selected == []
+        with pytest.raises(_export_module.ExemplarExportInputError, match="no eligible"):
+            _export_module.select_exemplars_for_planner(episodes, "goal")
 
     def test_no_quality_aware_filter(self) -> None:
         """4848 does NOT filter single-step episodes (unlike 4891).
@@ -576,6 +576,13 @@ class TestFailClosedInputs:
         with pytest.raises(
             _export_module.ExemplarExportInputError, match="no finite selection metric"
         ):
+            _export_module.select_exemplars_for_planner(episodes, "goal")
+
+    def test_no_eligible_scenarios_fail_closed(self) -> None:
+        """A campaign cannot emit an empty successful report when it lacks this scenario family."""
+        episodes = [self._episode("classic_head_on_corridor_low", 1, 0.5)]
+
+        with pytest.raises(_export_module.ExemplarExportInputError, match="no eligible"):
             _export_module.select_exemplars_for_planner(episodes, "goal")
 
     @staticmethod

--- a/tests/test_export_issue_4848.py
+++ b/tests/test_export_issue_4848.py
@@ -512,22 +512,82 @@ class TestSelectionReportDeterminism:
         assert "Generated:" in report
 
 
-class TestTupleReturnProcessPlanner:
-    """Verify _process_planner returns tuple[list[SelectedEpisode], dict | None].
+class TestProcessPlanner:
+    """Verify the 4848 planner-processing input contract."""
 
-    The 4848 export script was migrated to return a tuple (PR #4910/#4925),
-    matching the 4891 contract.  This regression test ensures the signature
-    remains correct.
-    """
+    def test_missing_planner_dir_fails_closed(self, tmp_path: Path) -> None:
+        """A missing planner directory raises the typed exporter input error."""
+        campaign_root = tmp_path / "runs"
+        campaign_root.mkdir()
+        with pytest.raises(_export_module.ExemplarExportInputError, match="planner directory"):
+            _export_module._process_planner("nonexistent", campaign_root, tmp_path / "output")
 
-    def test_returns_tuple_with_empty_planner_dir(self, tmp_path: Path) -> None:
-        """When planner dir doesn't exist, returns ([], None)."""
-        selections, metadata = _export_module._process_planner(
-            "nonexistent", tmp_path / "runs", tmp_path / "output"
+
+class TestFailClosedInputs:
+    """Regression coverage for issue #5003 evidence-input failure paths."""
+
+    def test_missing_campaign_root_returns_nonzero(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """The CLI reports a missing campaign root and exits with a nonzero status."""
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "export",
+                "--campaign-root",
+                str(tmp_path / "missing"),
+                "--output-dir",
+                str(tmp_path / "out"),
+            ],
         )
-        assert isinstance(selections, list)
-        assert selections == []
-        assert metadata is None
+        assert _export_module.main() == 2
+        assert "campaign root is not a directory" in capsys.readouterr().err
+
+    def test_missing_episodes_jsonl_fails_closed(self, tmp_path: Path) -> None:
+        """A planner directory without episodes.jsonl is rejected as a typed input error."""
+        campaign_root = tmp_path / "runs"
+        (campaign_root / "goal__differential_drive").mkdir(parents=True)
+        with pytest.raises(_export_module.ExemplarExportInputError, match="not a file"):
+            _export_module._process_planner("goal", campaign_root, tmp_path / "output")
+
+    def test_directory_at_episodes_jsonl_path_fails_closed(self, tmp_path: Path) -> None:
+        """A directory named episodes.jsonl cannot be accepted as an episode file."""
+        campaign_root = tmp_path / "runs"
+        (campaign_root / "goal__differential_drive" / "episodes.jsonl").mkdir(parents=True)
+        with pytest.raises(_export_module.ExemplarExportInputError, match="not a file"):
+            _export_module._process_planner("goal", campaign_root, tmp_path / "output")
+
+    def test_empty_episodes_jsonl_fails_closed(self, tmp_path: Path) -> None:
+        """An empty episode file cannot yield an empty-but-successful export."""
+        episodes_path = tmp_path / "runs" / "goal__differential_drive" / "episodes.jsonl"
+        episodes_path.parent.mkdir(parents=True)
+        episodes_path.write_text("\n", encoding="utf-8")
+        with pytest.raises(_export_module.ExemplarExportInputError, match="is empty"):
+            _export_module._process_planner("goal", episodes_path.parents[1], tmp_path / "output")
+
+    def test_all_nonfinite_selection_metrics_fail_closed(self) -> None:
+        """NaN and infinity cannot silently produce a selected exemplar."""
+        episodes = [
+            self._episode("classic_group_crossing_low", 1, float("nan")),
+            self._episode("classic_group_crossing_low", 2, float("inf")),
+            self._episode("classic_group_crossing_low", 3, float("-inf")),
+        ]
+        with pytest.raises(
+            _export_module.ExemplarExportInputError, match="no finite selection metric"
+        ):
+            _export_module.select_exemplars_for_planner(episodes, "goal")
+
+    @staticmethod
+    def _episode(scenario_id: str, seed: int, value: float) -> dict[str, Any]:
+        """Build a minimally valid group-crossing episode for selection tests."""
+        return {
+            "scenario_id": scenario_id,
+            "seed": seed,
+            "episode_id": f"{scenario_id}_s{seed}",
+            "status": "success",
+            "metrics": {"path_efficiency": value},
+        }
 
 
 class TestBundleReproducibleByteIdentical:

--- a/tests/test_export_issue_4891.py
+++ b/tests/test_export_issue_4891.py
@@ -97,13 +97,13 @@ class TestSelectExemplars:
         assert median.metric_value == 0.7
 
     def test_empty_episodes(self) -> None:
-        selected = _export_module.select_exemplars_for_planner([], "goal")
-        assert selected == []
+        with pytest.raises(_export_module.ExemplarExportInputError, match="no eligible"):
+            _export_module.select_exemplars_for_planner([], "goal")
 
     def test_no_head_on_corridor(self) -> None:
         episodes = [self._make_episode("classic_doorway_low", 1, 0.8)]
-        selected = _export_module.select_exemplars_for_planner(episodes, "goal")
-        assert selected == []
+        with pytest.raises(_export_module.ExemplarExportInputError, match="no eligible"):
+            _export_module.select_exemplars_for_planner(episodes, "goal")
 
     def test_tie_break_prefers_richer_trace_for_best(self) -> None:
         """When path_efficiency ties, best gets the MOST steps, worst the FEWEST.
@@ -206,6 +206,13 @@ class TestFailClosedInputs:
         with pytest.raises(
             _export_module.ExemplarExportInputError, match="no finite selection metric"
         ):
+            _export_module.select_exemplars_for_planner(episodes, "goal")
+
+    def test_no_eligible_scenarios_fail_closed(self) -> None:
+        """A campaign cannot emit an empty successful report when it lacks this scenario family."""
+        episodes = [self._episode("classic_group_crossing_low", 1, 0.5)]
+
+        with pytest.raises(_export_module.ExemplarExportInputError, match="no eligible"):
             _export_module.select_exemplars_for_planner(episodes, "goal")
 
     @staticmethod

--- a/tests/test_export_issue_4891.py
+++ b/tests/test_export_issue_4891.py
@@ -146,6 +146,80 @@ class TestSelectExemplars:
         assert len(selected) == 3
 
 
+class TestFailClosedInputs:
+    """Regression coverage for issue #5003 evidence-input failure paths."""
+
+    def test_missing_campaign_root_returns_nonzero(
+        self, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        """The CLI reports a missing campaign root and exits with a nonzero status."""
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "export",
+                "--campaign-root",
+                str(tmp_path / "missing"),
+                "--output-dir",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert _export_module.main() == 2
+        assert "campaign root is not a directory" in capsys.readouterr().err
+
+    def test_missing_planner_dir_fails_closed(self, tmp_path: Path) -> None:
+        """A missing planner directory raises the typed exporter input error."""
+        campaign_root = tmp_path / "runs"
+        campaign_root.mkdir()
+        with pytest.raises(_export_module.ExemplarExportInputError, match="planner directory"):
+            _export_module._process_planner("goal", campaign_root, tmp_path / "output")
+
+    def test_missing_episodes_jsonl_fails_closed(self, tmp_path: Path) -> None:
+        """A planner directory without episodes.jsonl is rejected as a typed input error."""
+        campaign_root = tmp_path / "runs"
+        (campaign_root / "goal__differential_drive").mkdir(parents=True)
+        with pytest.raises(_export_module.ExemplarExportInputError, match="not a file"):
+            _export_module._process_planner("goal", campaign_root, tmp_path / "output")
+
+    def test_directory_at_episodes_jsonl_path_fails_closed(self, tmp_path: Path) -> None:
+        """A directory named episodes.jsonl cannot be accepted as an episode file."""
+        campaign_root = tmp_path / "runs"
+        (campaign_root / "goal__differential_drive" / "episodes.jsonl").mkdir(parents=True)
+        with pytest.raises(_export_module.ExemplarExportInputError, match="not a file"):
+            _export_module._process_planner("goal", campaign_root, tmp_path / "output")
+
+    def test_empty_episodes_jsonl_fails_closed(self, tmp_path: Path) -> None:
+        """An empty episode file cannot yield an empty-but-successful export."""
+        episodes_path = tmp_path / "runs" / "goal__differential_drive" / "episodes.jsonl"
+        episodes_path.parent.mkdir(parents=True)
+        episodes_path.write_text("\n", encoding="utf-8")
+        with pytest.raises(_export_module.ExemplarExportInputError, match="is empty"):
+            _export_module._process_planner("goal", episodes_path.parents[1], tmp_path / "output")
+
+    def test_all_nonfinite_selection_metrics_fail_closed(self) -> None:
+        """NaN and infinity cannot silently produce a selected exemplar."""
+        episodes = [
+            self._episode("classic_head_on_corridor_low", 1, float("nan")),
+            self._episode("classic_head_on_corridor_low", 2, float("inf")),
+            self._episode("classic_head_on_corridor_low", 3, float("-inf")),
+        ]
+        with pytest.raises(
+            _export_module.ExemplarExportInputError, match="no finite selection metric"
+        ):
+            _export_module.select_exemplars_for_planner(episodes, "goal")
+
+    @staticmethod
+    def _episode(scenario_id: str, seed: int, value: float) -> dict[str, Any]:
+        """Build a minimally valid corridor episode for selection tests."""
+        return {
+            "scenario_id": scenario_id,
+            "seed": seed,
+            "episode_id": f"{scenario_id}_s{seed}",
+            "status": "success",
+            "metrics": {"path_efficiency": value},
+        }
+
+
 class TestDeriveTraceRows:
     """Test the derive_trace_rows function."""
 


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Both maintained exemplar exporters now reject missing campaign/planner directories, missing/non-file/empty `episodes.jsonl` inputs, and eligible episode sets with no finite `path_efficiency` selection value.
- **Why now:** #5003 records the unresolved #4898 review finding that these evidence exporters could report successful empty output for invalid inputs.
- **Claim boundary:** This is exporter input-contract hardening only; it does not alter benchmark metric semantics or establish benchmark, paper, or dissertation results.
- **Required validation:** Targeted exporter tests, the exemplar benchmark-selector lane, and the repository final PR-readiness gate.
- **Remaining blocker:** None for #5003's scoped acceptance criteria.

## Contract delta

- New typed error: `ExemplarExportInputError` in each exporter; the CLI prints the reason and returns exit code `2`.
- New fail-closed blockers: campaign root or planner path is not a directory; `episodes.jsonl` is missing, not a regular file, or empty; all eligible selection-metric values are non-finite.
- Compatibility: valid exports are unchanged; invalid inputs now fail instead of writing an empty selection report.

Closes #5003.

<details>
<summary>Scope, validation, and governance details</summary>

### Scope

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5003
- Updated the group-crossing (#4848) and head-on-corridor (#4891) exemplar exporters plus their regression tests.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

### Validation

- `uv run pytest tests/test_export_issue_4848.py tests/test_export_issue_4891.py -q` — 71 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/run_tests_parallel.sh tests/benchmark -k exemplar` — 33 passed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — final gate run with this body as input.

### Research result

- Target blocker: invalid evidence-export inputs must not produce successful empty exports.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.

## Domain-Aware Approval

- Required for this PR: yes — conservative body validation requires this checklist when benchmark or paper-facing boundaries are named.
- Domains reviewed: evidence classification, benchmark interpretation, paper-facing claims.
- Status: waived
- Approver/review source or waiver: Waiver reason — scope review against #5003 confirms implementation integrity only.
- Validity checklist:
  - Target claim/hypothesis: invalid evidence-export inputs must fail instead of producing an empty successful export.
  - Comparator or split/evidence validity: not applicable; no campaign or comparison is run.
  - Fallback/degraded exclusions: not applicable; no benchmark execution is claimed.
  - Claim boundary: exporter input validation only; no benchmark, paper, or dissertation result.
  - Implementation integrity vs experimental validity: targeted contract tests prove the former; the latter is unchanged and not claimed.

### Risks and propagation

- Risk: callers that relied on silent empty exports will now receive exit code 2 and an actionable reason; this is the intended fail-closed compatibility change.
- Artifacts: no `output/` artifact was created or promoted.
- Downstream propagation: no separate issue-state update is needed because this PR closes #5003; authorization also forbids issue comments, avoiding a redundant comment stream.
- Follow-up: none.

</details>
