### PR TITLE
test(tooling): ratify exemplar evidence budget (#5005)

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -758,10 +758,11 @@ decision-disagreement CSV, Markdown, Pareto SVG, and provenance; raw episode JSO
   for head-on corridor scenarios (3 planners x 3 density/selection combos). Same format
   as issue_4848. Total: ~5.5 MB. Illustrative-only, no benchmark or dissertation claim.
 
-## Exemplar-Bundle Artifact Policy (Issue #4920)
+## Exemplar-Bundle Artifact Policy (Issues #4920 and #5005)
 
-Audited 2026-07-09. The following policy governs future exemplar-bundle additions to
-`docs/context/evidence/`.
+Re-audited on 2026-07-10 after #4938 regenerated the committed exemplar bundles. The 50 MiB
+cumulative budget is ratified for tracked exemplar-bundle classes only; it is not a cap on the
+whole `docs/context/evidence/` tree.
 
 ### Size Budget
 
@@ -769,8 +770,13 @@ Audited 2026-07-09. The following policy governs future exemplar-bundle addition
 |------------|-------|---------------|
 | Per-bundle size cap | 5 MB | max 2.06 MB |
 | Per-class bundle count | 12 bundles | 9 per class |
-| Cumulative exemplar budget | 50 MB | 13.20 MB |
-| `docs/context/evidence/` total | advisory | 47.50 MB |
+| Cumulative exemplar budget | 50 MiB (52,428,800 bytes) | 16.36 MiB |
+| `docs/context/evidence/` total | advisory, not this budget's scope | 53.93 MiB |
+
+Before committing a derived trace that would bring the cumulative exemplar total to **45 MiB or
+more**, move the trace to release assets or external artifact storage and retain only a compact,
+checksummed manifest/provenance pointer in git. This preserves 5 MiB of headroom below the hard
+50 MiB cap. The current 16.36 MiB exemplar total is below that trigger.
 
 ### Content Rules
 

--- a/scripts/audit_exemplar_bundles.py
+++ b/scripts/audit_exemplar_bundles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Audit exemplar-bundle artifact policy for issue #4920.
+"""Audit the ratified exemplar-bundle artifact policy for issues #4920 and #5005.
 
 Verifies SHA256SUMS, computes size accounting, confirms derived/compact contents,
 and checks metadata provenance for the issue_4848 and issue_4891 exemplar bundles.
@@ -54,6 +54,13 @@ REQUIRED_METADATA_FIELDS = {
 }
 
 RAW_DUMP_EXTENSIONS = {".jsonl"}
+
+# The cap applies only to tracked exemplar-bundle classes, not the whole evidence tree.
+MEBIBYTE = 1024 * 1024
+EXEMPLAR_BUDGET_BYTES = 50 * MEBIBYTE
+# Reserve one worst-case bundle of headroom before the hard cap. New derived traces at this
+# threshold belong in release assets or external artifact storage with a compact git manifest.
+OFF_TREE_MIGRATION_TRIGGER_BYTES = 45 * MEBIBYTE
 
 
 @dataclass
@@ -250,6 +257,15 @@ def format_size(n: int) -> str:
     return f"{n / (1024 * 1024):.2f} MB"
 
 
+def assess_exemplar_budget(total_bytes: int) -> tuple[str, bool]:
+    """Classify a total against the ratified cap and pre-commit migration trigger."""
+    if total_bytes > EXEMPLAR_BUDGET_BYTES:
+        return "EXCEEDS_BUDGET", True
+    if total_bytes >= OFF_TREE_MIGRATION_TRIGGER_BYTES:
+        return "OFF_TREE_MIGRATION_REQUIRED", True
+    return "WITHIN_BUDGET", False
+
+
 def _render_sha_section(classes: list[ClassAuditResult]) -> list[str]:
     """Render SHA256SUMS verification section."""
     lines: list[str] = []
@@ -413,9 +429,9 @@ def _render_metadata_section(classes: list[ClassAuditResult]) -> list[str]:
 def _render_policy_section(
     grand_total: int, total_bundles: int, evidence_total: int, classes: list[ClassAuditResult]
 ) -> list[str]:
-    """Render policy proposal section."""
+    """Render the ratified policy and current budget classification."""
     lines: list[str] = []
-    lines.append("## 5. Exemplar-Bundle Size Budget Policy Proposal")
+    lines.append("## 5. Ratified Exemplar-Bundle Size Budget Policy")
     lines.append("")
     lines.append("### Current State")
     lines.append(f"- 2 exemplar classes, {total_bundles} bundles, {format_size(grand_total)} total")
@@ -427,7 +443,18 @@ def _render_policy_section(
         lines.append(f"- Smallest bundle: {format_size(min(all_sizes))}")
     lines.append("")
 
-    lines.append("### Proposed Policy")
+    budget_status, off_tree_migration_required = assess_exemplar_budget(grand_total)
+    lines.append(
+        f"- Ratified 50 MiB exemplar-bundle cap: **{budget_status}** "
+        f"({format_size(grand_total)} / {format_size(EXEMPLAR_BUDGET_BYTES)})"
+    )
+    lines.append(
+        "- Pre-commit off-tree migration trigger (45 MiB): "
+        f"**{'REQUIRED' if off_tree_migration_required else 'not required'}**"
+    )
+    lines.append("")
+
+    lines.append("### Ratified Policy")
     lines.append("")
     lines.append(
         "1. **Per-bundle size cap**: 5 MB per bundle directory (current max ~2 MB, safe headroom)."
@@ -437,30 +464,37 @@ def _render_policy_section(
         "(3 planners x 4 selection modes is the natural maximum)."
     )
     lines.append(
-        "3. **Cumulative exemplar budget**: 50 MB for all exemplar-bundle classes "
-        f"combined (current: {format_size(grand_total)})."
+        "3. **Cumulative exemplar budget**: 50 MiB (52,428,800 bytes) for all tracked "
+        "exemplar-bundle classes combined. This does not cap the entire "
+        "`docs/context/evidence/` tree."
     )
     lines.append(
-        "4. **Derived-only content rule**: bundles must contain only derived/compact "
+        "4. **Off-tree migration trigger**: before committing a derived trace that would bring "
+        "the cumulative exemplar total to 45 MiB or more, store that trace in release assets "
+        "or external artifact storage and commit only its compact manifest/provenance pointer. "
+        "The 50 MiB cap remains a hard limit for tracked exemplar bundles."
+    )
+    lines.append(
+        "5. **Derived-only content rule**: bundles must contain only derived/compact "
         "files (CSV, JSON, Markdown). No raw JSONL episode dumps, Slurm logs, "
         "model checkpoints, or binary artifacts."
     )
     lines.append(
-        "5. **LFS threshold**: if a single file exceeds 1 MB, evaluate whether it "
+        "6. **LFS threshold**: if a single file exceeds 1 MB, evaluate whether it "
         "can be summarized or split before considering LFS. Current largest files "
-        "are trace_series.json (~1.9 MB); these are within the proposed cap."
+        "are trace_series.json (~1.9 MB); these are within the ratified cap."
     )
     lines.append(
-        "6. **SHA256SUMS mandatory**: every bundle must include a SHA256SUMS file "
+        "7. **SHA256SUMS mandatory**: every bundle must include a SHA256SUMS file "
         "covering all data files (excluding itself)."
     )
     lines.append(
-        "7. **Metadata contract**: every bundle must include metadata.json with "
+        "8. **Metadata contract**: every bundle must include metadata.json with "
         "campaign_id, campaign_job, claim_boundary (with illustrative-only guard), "
         "review_marker, and schema_version."
     )
     lines.append(
-        "8. **No restamping in this audit**: marker restamping is owned by "
+        "9. **No restamping in this audit**: marker restamping is owned by "
         "PR #4910/#4903. This policy defines future requirements only."
     )
     lines.append("")
@@ -498,7 +532,7 @@ def _render_summary(
 def generate_report(classes: list[ClassAuditResult], repo_root: Path) -> str:
     """Generate the full audit report as Markdown."""
     lines: list[str] = []
-    lines.append("# Exemplar-Bundle Artifact Policy Audit (Issue #4920)")
+    lines.append("# Exemplar-Bundle Artifact Policy Audit (Issues #4920 and #5005)")
     lines.append("")
 
     lines.extend(_render_sha_section(classes))
@@ -548,10 +582,20 @@ def main() -> None:
         classes.append(audit_class(class_path, repo_root))
 
     if args.json:
+        grand_total = sum(c.total_size_bytes for c in classes)
+        evidence_tree_total = compute_docs_context_size(repo_root)
+        budget_status, off_tree_migration_required = assess_exemplar_budget(grand_total)
         data: dict[str, Any] = {
             "classes": [],
-            "grand_total_bytes": sum(c.total_size_bytes for c in classes),
+            "grand_total_bytes": grand_total,
             "total_bundles": sum(len(c.bundles) for c in classes),
+            "evidence_tree_total_bytes": evidence_tree_total,
+            "ratified_policy": {
+                "exemplar_budget_bytes": EXEMPLAR_BUDGET_BYTES,
+                "off_tree_migration_trigger_bytes": OFF_TREE_MIGRATION_TRIGGER_BYTES,
+                "budget_status": budget_status,
+                "off_tree_migration_required": off_tree_migration_required,
+            },
         }
         for cls in classes:
             cls_data: dict[str, Any] = {

--- a/scripts/audit_exemplar_bundles.py
+++ b/scripts/audit_exemplar_bundles.py
@@ -259,6 +259,8 @@ def format_size(n: int) -> str:
 
 def assess_exemplar_budget(total_bytes: int) -> tuple[str, bool]:
     """Classify a total against the ratified cap and pre-commit migration trigger."""
+    if total_bytes < 0:
+        raise ValueError("total_bytes must not be negative")
     if total_bytes > EXEMPLAR_BUDGET_BYTES:
         return "EXCEEDS_BUDGET", True
     if total_bytes >= OFF_TREE_MIGRATION_TRIGGER_BYTES:

--- a/tests/tools/test_audit_exemplar_bundles.py
+++ b/tests/tools/test_audit_exemplar_bundles.py
@@ -8,6 +8,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "audit_exemplar_bundles.py"
 SPEC = importlib.util.spec_from_file_location("audit_exemplar_bundles", SCRIPT_PATH)
 assert SPEC is not None
@@ -179,10 +181,16 @@ def test_assess_exemplar_budget_preserves_migration_headroom() -> None:
         "OFF_TREE_MIGRATION_REQUIRED",
         True,
     )
+    assert audit_mod.assess_exemplar_budget(50 * audit_mod.MEBIBYTE) == (
+        "OFF_TREE_MIGRATION_REQUIRED",
+        True,
+    )
     assert audit_mod.assess_exemplar_budget(50 * audit_mod.MEBIBYTE + 1) == (
         "EXCEEDS_BUDGET",
         True,
     )
+    with pytest.raises(ValueError, match="must not be negative"):
+        audit_mod.assess_exemplar_budget(-1)
 
 
 def test_parse_sha256sums(tmp_path: Path) -> None:

--- a/tests/tools/test_audit_exemplar_bundles.py
+++ b/tests/tools/test_audit_exemplar_bundles.py
@@ -172,6 +172,19 @@ def test_format_size() -> None:
     assert "MB" in audit_mod.format_size(5_000_000)
 
 
+def test_assess_exemplar_budget_preserves_migration_headroom() -> None:
+    """Verify the 45 MiB trigger reserves headroom below the hard 50 MiB cap."""
+    assert audit_mod.assess_exemplar_budget(44 * audit_mod.MEBIBYTE) == ("WITHIN_BUDGET", False)
+    assert audit_mod.assess_exemplar_budget(45 * audit_mod.MEBIBYTE) == (
+        "OFF_TREE_MIGRATION_REQUIRED",
+        True,
+    )
+    assert audit_mod.assess_exemplar_budget(50 * audit_mod.MEBIBYTE + 1) == (
+        "EXCEEDS_BUDGET",
+        True,
+    )
+
+
 def test_parse_sha256sums(tmp_path: Path) -> None:
     """Verify SHA256SUMS file parsing."""
     sums_file = tmp_path / "SHA256SUMS"


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** re-audited post-#4938 exemplar storage, ratified the existing 50 MiB cap for
  tracked exemplar classes, and made the audit expose budget/migration status in Markdown and JSON.
- **Why now:** the previous 13.20 MiB / 47.50 MiB figures predated #4938 regeneration; current
  values are 16.36 MiB of exemplars and 53.93 MiB for the broader evidence tree.
- **Claim boundary:** tooling and storage-policy evidence only; no benchmark, planner, metric, paper,
  or dissertation result is asserted.
- **Required validation:** focused audit tests, Ruff, the audit against tracked bundles, and the
  repository readiness gate.
- **Remaining blocker:** none for #5005. All 18 bundle checksum validations pass and the current
  exemplar total is below the new 45 MiB migration trigger.

## Contract delta

- Additive JSON fields: evidence_tree_total_bytes and ratified_policy (50 MiB cap, 45 MiB migration
  trigger, status, and migration-required boolean).
- New policy: before a derived trace would bring tracked exemplars to 45 MiB or more, keep only a
  compact checksummed manifest/provenance pointer in git and store the trace in release assets or
  external artifact storage.
- Compatibility: no CLI arguments, benchmark semantics, or existing JSON fields change.

## Linked issue

Closes #5005

Issue: https://github.com/ll7/robot_sf_ll7/issues/5005

<details>
<summary>Implementation, evidence, and review appendix</summary>

## What changed

- Updated scripts/audit_exemplar_bundles.py with the ratified policy constants and additive
  machine-readable audit fields.
- Added boundary tests for the 45 MiB migration trigger and 50 MiB hard cap.
- Recorded the fresh post-#4938 size measurements and ratified policy in
  docs/context/evidence/README.md.

## Validation / proof

- uv run pytest tests/tools/test_audit_exemplar_bundles.py -q — 12 passed.
- uv run ruff check scripts/audit_exemplar_bundles.py tests/tools/test_audit_exemplar_bundles.py
  — passed.
- uv run python scripts/audit_exemplar_bundles.py --json — 18 bundles; checksums green;
  17,154,905 exemplar bytes; 56,545,868 evidence-tree bytes; WITHIN_BUDGET; migration false.
- PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh — required body-aware
  final readiness gate is run immediately before opening this PR.

## Assumption

The regenerated exemplar total is 16.36 MiB, so retaining the 50 MiB cap is the most conservative
reversible decision. A 45 MiB pre-commit trigger reserves 5 MiB of headroom for one large future
bundle; a maintainer can revise either threshold without changing stored evidence.

## Scope and propagation

- No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.
- Research result fields: NA — this is a support-tooling and storage-policy change only.
- Domain-aware approval: not required — no evidence classification or experimental interpretation
  changes.
- Downstream propagation: not applicable — #5005 is fully closed by this PR. Issue-comment
  propagation is not performed because this task's authorization excludes comments; no residual,
  high-churn state requires a separate state table.
- Artifacts: none created under output/; tracked evidence was read and checksum-validated only.

## Risks / reviewer focus

- The audit currently enumerates the two established exemplar classes. Future class additions must
  join that registry before their bytes can count toward this cap.
- Review the explicit policy boundary: the 50 MiB cap applies to exemplar classes, not the entire
  evidence tree.

</details>
