### PR TITLE
test(scenarios): guard archetype manifest completeness (#4971)

### DIFF
--- a/configs/scenarios/README.md
+++ b/configs/scenarios/README.md
@@ -20,6 +20,29 @@ This directory supports a mix of **per-scenario**, **per-archetype**, and
 scaffold. It is disabled from default benchmark campaigns and records only synthetic proxy intent,
 not real-world user-group evidence or paper-facing results.
 
+## Classic-archetype campaign dispositions
+
+Every `archetypes/classic_*.yaml` scenario config is either admitted by the standard
+`classic_interactions.yaml` manifest or declares why it is not. This keeps a designed classic
+scenario from silently dropping out of the campaign definition; it does not say that a campaign
+was executed or establish benchmark evidence.
+
+Configs outside the manifest must use this header-level metadata:
+
+```yaml
+evaluation: excluded # or planned
+evaluation_reason: Why the config is excluded or which next campaign wave will admit it.
+```
+
+For an excluded compatibility alias, also record the replacement config when one exists:
+
+```yaml
+evaluation_replacement: classic_cross_trap.yaml
+```
+
+`tests/test_classic_archetype_density_index.py` checks this contract. A new classic config that is
+neither in the manifest nor explicitly dispositioned fails the test.
+
 ## Plausibility tracking
 
 Scenario metadata includes a `plausibility` block used to record verification

--- a/configs/scenarios/archetypes/classic_crossing.yaml
+++ b/configs/scenarios/archetypes/classic_crossing.yaml
@@ -1,6 +1,12 @@
 # Deprecated compatibility aliases for issue #594.
 # Prefer configs/scenarios/archetypes/classic_cross_trap.yaml and
 # classic_cross_trap_{low,medium,high} in new configs.
+#
+# Evaluation disposition (issue #4971): excluded from the standard classic
+# interaction campaign because these aliases duplicate classic_cross_trap.
+evaluation: excluded
+evaluation_reason: Deprecated compatibility aliases; use classic_cross_trap.yaml in new campaigns.
+evaluation_replacement: classic_cross_trap.yaml
 scenarios:
 - name: classic_crossing_low
   map_file: ../../../maps/svg_maps/classic_crossing.svg

--- a/tests/test_classic_archetype_density_index.py
+++ b/tests/test_classic_archetype_density_index.py
@@ -11,6 +11,9 @@ assert anything about benchmark results.
 What is guarded:
   * every in-directory ``classic_*.yaml`` config (and every density tier inside
     it) is covered by the index (missing-coverage guard, both directions);
+  * every classic archetype config is either admitted by
+    ``classic_interactions.yaml`` or explicitly marked ``evaluation: excluded``
+    or ``evaluation: planned`` with a reason (issue #4971);
   * each tier's ``ped_density`` and ``density_advisory`` match the config;
   * each config's ``spawn_mode`` / ``in_matrix`` flags match what the configs and
     ``classic_interactions.yaml`` actually say;
@@ -152,6 +155,28 @@ def test_in_matrix_flag_matches_includes() -> None:
     matrix_files = _matrix_config_filenames()
     for config, entry in _index_entries_by_config().items():
         assert entry["in_matrix"] == (config in matrix_files), config
+
+
+def test_every_classic_archetype_is_admitted_or_explicitly_dispositioned() -> None:
+    """Fail closed when a classic config is outside the standard manifest silently."""
+    matrix_files = _matrix_config_filenames()
+    allowed_dispositions = {"excluded", "planned"}
+
+    for config_path in _classic_config_paths():
+        if config_path.name in matrix_files:
+            continue
+
+        config = _load_yaml(config_path)
+        disposition = config.get("evaluation")
+        reason = config.get("evaluation_reason")
+        assert disposition in allowed_dispositions, (
+            f"{config_path.name}: not included by {MATRIX_FILE.name}; add it to the manifest or "
+            "set evaluation to 'excluded' or 'planned'."
+        )
+        assert isinstance(reason, str) and reason.strip(), (
+            f"{config_path.name}: evaluation={disposition!r} requires a non-empty "
+            "evaluation_reason."
+        )
 
 
 def test_marker_spawn_density_zero_semantics() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Explicitly marks the deprecated `classic_crossing.yaml` compatibility alias as
excluded from the standard classic-interaction manifest, with its replacement, and adds a
fail-closed catalog check.

**Why now:** At current `main`, `classic_station_platform.yaml` is already admitted. The only
classic archetype config outside `classic_interactions.yaml` is `classic_crossing.yaml`; its
exclusion was implicit despite duplicating `classic_cross_trap.yaml`.

**Claim boundary:** This is configuration-governance and load-compatibility proof only. It neither
runs a campaign nor establishes a benchmark, metric, paper, or dissertation claim.

**Required validation:** `uv run pytest tests/test_classic_archetype_density_index.py
tests/test_classic_interactions_matrix.py -q` (22 passed), Ruff, YAML parsing, loader compatibility,
and the final repository readiness gate.

**Remaining blocker:** None for #4971's classic-archetype catalog scope. No full benchmark campaign
run, Slurm/GPU submission, or paper/dissertation claim edit is included.

## Contract delta

- New header-level fields for classic configs outside the standard manifest:
  `evaluation: excluded|planned` and a non-empty `evaluation_reason`.
- `evaluation_replacement` documents the successor for an excluded compatibility alias when one
  exists.
- New fail-closed blocker: a `classic_*.yaml` file not included by `classic_interactions.yaml`
  must carry one of those explicit dispositions and a reason.
- Compatibility: `load_scenarios()` continues to load `classic_crossing.yaml` as its original three
  scenarios; the new header fields are catalog metadata, not scenario behavior.

## Linked issue

- Closes #4971
- Issue: https://github.com/ll7/robot_sf_ll7/issues/4971

<details>
<summary>Implementation, validation, and governance details</summary>

## Scope summary

- Added an explicit exclusion and replacement for the deprecated crossing alias.
- Extended the existing classic archetype density-index test, which already enumerates every
  `classic_*.yaml` config and the standard manifest, to enforce the admission/disposition contract.
- Documented the metadata and its non-evidence boundary in `configs/scenarios/README.md`.

Assumption: the issue's “archetype” catalog is the established `classic_*.yaml` set, because the
issue names `classic_crossing.yaml` and `classic_interactions.yaml`, and the existing checked index
defines exactly that catalog. This is reversible configuration metadata; it does not generalize the
policy to unrelated issue-specific scenario packs.

## Validation / proof

| Command | Result |
| --- | --- |
| `uv run pytest tests/test_classic_archetype_density_index.py tests/test_classic_interactions_matrix.py -q` | 22 passed |
| `uv run ruff check tests/test_classic_archetype_density_index.py` | passed |
| `uv run ruff format --check tests/test_classic_archetype_density_index.py` | passed |
| `uv run python scripts/dev/check_docs_evidence_integrity.py` | passed (no docs/evidence integrity scope) |
| YAML/header assertion and `load_scenarios(classic_crossing.yaml)` compatibility probe | passed; 3 original scenarios load |
| `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` | passed; 2,008 tests and clean-HEAD freshness stamp |

The new test derives the canonical classic-config set and manifest include set. A future config
outside the manifest therefore fails unless it explicitly records `excluded` or `planned` plus a
reason.

## Research result guidance

NA — support/configuration contract only; no research result or campaign evidence was produced.

## Risks / rollback

- The catalog boundary is intentionally limited to `classic_*.yaml`; extending this governance
  contract to other scenario families requires a separate catalog decision.
- Rollback is safe: remove the header metadata and test/documentation additions together.

## Docs / provenance

- Updated `configs/scenarios/README.md`.
- The existing `classic_density_tier_index.yaml` remains the canonical checked inventory.

## Downstream propagation

- Parent issue updated: no separate comment; this PR uses `Closes #4971`, and the task authorization
  does not permit issue comments.
- Claim map / benchmark report / leaderboard / artifact catalog: NA — no evidence-producing change.
- Registry or config index: NA — existing classic density/tier index is unchanged.
- Context index / memory note: NA — no durable research result or handoff state beyond this PR.
- Follow-up issue: none.

## Reviewer notes

- Confirm that treating the deprecated crossing alias as `excluded` (rather than scheduling it) is
  correct because it has an explicit `classic_cross_trap.yaml` replacement.
- No output artifacts were generated or added.

</details>
