### PR TITLE
feat(sim): configurable action latency (#4977)

### DIFF
--- a/configs/research/fidelity_sensitivity_v1.yaml
+++ b/configs/research/fidelity_sensitivity_v1.yaml
@@ -143,6 +143,22 @@ axes:
         patch:
           sim_config:
             ped_radius: 0.50
+  - key: control_action_latency
+    rationale: Measure how a reset-safe control-to-actuation queue changes safety outcomes.
+    variants:
+      - key: zero_step_nominal
+        baseline: true
+        patch:
+          sim_config:
+            action_latency_steps: 0
+      - key: one_step_100ms
+        patch:
+          sim_config:
+            action_latency_steps: 1
+      - key: three_step_300ms
+        patch:
+          sim_config:
+            action_latency_steps: 3
 
 result_contract:
   required_outputs:

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import time
 import uuid
+from collections import deque
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import asdict, is_dataclass
@@ -564,6 +565,9 @@ class RobotEnv(BaseEnv):
 
         # Store last action executed by the robot
         self.last_action = None
+        self._action_latency_steps = env_config.sim_config.resolved_action_latency_steps
+        self._action_latency_queue: deque[tuple[Any, ...]] = deque()
+        self._reset_action_latency_queue()
         self.applied_seed: int | None = None
         self._latest_observation: Any = None
         # Enable occupancy grid overlay visualization if requested
@@ -579,6 +583,26 @@ class RobotEnv(BaseEnv):
         self._grid_obstacle_cache_key: _GridObstacleCacheKey | None = None
         self._grid_obstacle_cache_value: _GridObstacleCacheValue | None = None
         self._prime_snqi_proxy_state()
+
+    def _reset_action_latency_queue(self) -> None:
+        """Clear queued controls and prime the configured delay with zero commands."""
+        zero_raw = np.zeros(self.action_space.shape, dtype=self.action_space.dtype)
+        zero_action = tuple(self.simulator.robots[0].parse_action(zero_raw))
+        self._action_latency_queue = deque(
+            [zero_action] * self._action_latency_steps,
+            maxlen=None,
+        )
+
+    def _apply_action_latency(self, requested_action: tuple[Any, ...]) -> tuple[Any, ...]:
+        """Enqueue one requested action and return the command due this simulation step.
+
+        Returns:
+            The action to execute in the current simulator step.
+        """
+        if self._action_latency_steps == 0:
+            return requested_action
+        self._action_latency_queue.append(requested_action)
+        return self._action_latency_queue.popleft()
 
     def _prime_snqi_proxy_state(self) -> None:
         """Reset and prime step-level SNQI proxy state for a fresh episode."""
@@ -957,10 +981,11 @@ class RobotEnv(BaseEnv):
             tuple: ``(obs, reward, terminated, truncated, info)`` per Gymnasium API.
         """
         if self.debug_without_robot_movement:
-            action = (0.0, 0.0)
+            requested_action = (0.0, 0.0)
         else:
             # Process the action through the simulator only when debug mode is disabled.
-            action = self.simulator.robots[0].parse_action(action)
+            requested_action = tuple(self.simulator.robots[0].parse_action(action))
+        action = self._apply_action_latency(requested_action)
 
         # Perform simulation step
         self.simulator.step_once([action])
@@ -1018,6 +1043,8 @@ class RobotEnv(BaseEnv):
         reward_dict["action_space"] = self.action_space
         # add action to dict
         reward_dict["action"] = action
+        reward_dict["requested_action"] = requested_action
+        reward_dict["action_latency"] = self.env_config.sim_config.action_latency_metadata()
         # Add last_action to reward_dict
         reward_dict["last_action"] = self.last_action
         # Determine if the episode has reached terminal state
@@ -1084,6 +1111,7 @@ class RobotEnv(BaseEnv):
             self._telemetry_episode_id += 1
             # Reset last_action
             self.last_action = None
+            self._reset_action_latency_queue()
             # Reset internal simulator state
             self.simulator.reset_state()
             # Reset the environment's state and return the initial observation
@@ -1166,6 +1194,7 @@ class RobotEnv(BaseEnv):
                 map_def=self.map_def,
                 applied_seed=self.applied_seed,
             )
+            info["action_latency"] = self.env_config.sim_config.action_latency_metadata()
             _attach_goal_posterior_planner_input(info, self.env_config, self.simulator)
             # Reset telemetry timing on new episode
             self._last_wall_time = time.perf_counter()

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -171,6 +171,17 @@ class SimulationSettings:
     time_per_step_in_secs: float = 0.1
     """Time per step in seconds"""
 
+    action_latency_steps: int = 0
+    """Discrete control-to-actuation delay; zero preserves immediate action execution."""
+
+    action_latency_ms: float | None = None
+    """Optional requested control-to-actuation delay in milliseconds.
+
+    The simulator executes only whole steps. When this field is set, it takes
+    precedence over ``action_latency_steps`` and is rounded up to the first
+    whole step that does not understate the requested delay.
+    """
+
     pedestrian_integration_scheme: str = "semi_implicit_euler"
     """Pedestrian position-update scheme; defaults to the historical semi-implicit update."""
 
@@ -268,6 +279,50 @@ class SimulationSettings:
     debug_without_robot_movement: bool = False
     """Whether to disable robot movement in the simulator for debugging purposes"""
 
+    @property
+    def resolved_action_latency_steps(self) -> int:
+        """Return the whole-step delay enforced by the environment action queue."""
+        if self.action_latency_ms is None:
+            return int(self.action_latency_steps)
+        step_ms = float(self.time_per_step_in_secs) * 1000.0
+        return ceil(float(self.action_latency_ms) / step_ms)
+
+    def action_latency_metadata(self) -> dict[str, int | float | None]:
+        """Return JSON-safe requested and effective action-latency settings."""
+        effective_steps = self.resolved_action_latency_steps
+        return {
+            "configured_steps": int(self.action_latency_steps),
+            "configured_ms": (
+                None if self.action_latency_ms is None else float(self.action_latency_ms)
+            ),
+            "effective_steps": effective_steps,
+            "effective_ms": round(
+                float(effective_steps * self.time_per_step_in_secs * 1000.0),
+                12,
+            ),
+        }
+
+    def _validate_action_latency_config(self) -> None:
+        """Reject ambiguous or non-realizable action-latency configuration values."""
+        if isinstance(self.action_latency_steps, bool) or not isinstance(
+            self.action_latency_steps,
+            int,
+        ):
+            raise TypeError("action_latency_steps must be an integer")
+        if self.action_latency_steps < 0:
+            raise ValueError("action_latency_steps must be >= 0")
+        if self.action_latency_ms is None:
+            return
+        if isinstance(self.action_latency_ms, bool) or not isinstance(
+            self.action_latency_ms,
+            int | float,
+        ):
+            raise TypeError("action_latency_ms must be a number when set")
+        if not isfinite(float(self.action_latency_ms)) or self.action_latency_ms < 0:
+            raise ValueError("action_latency_ms must be finite and >= 0 when set")
+        if self.action_latency_steps != 0:
+            raise ValueError("action_latency_steps and action_latency_ms cannot both be configured")
+
     def __post_init__(self):  # noqa: C901
         """
         Validate the simulation settings.
@@ -281,6 +336,7 @@ class SimulationSettings:
         # Check that the time per step is positive
         if self.time_per_step_in_secs <= 0:
             raise ValueError("Step time mustn't be negative or zero!")
+        self._validate_action_latency_config()
         self.pedestrian_integration_scheme = normalize_integration_scheme(
             self.pedestrian_integration_scheme
         )

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -2138,6 +2138,9 @@ def _set_simulation_override_attr(
         if alpha < 0.0:
             raise ValueError("simulation_config.pedestrian_uncertainty_alpha_mps must be >= 0.")
         setattr(config.sim_config, attr, alpha)
+    elif attr in {"action_latency_steps", "action_latency_ms"}:
+        setattr(config.sim_config, attr, overrides[attr])
+        config.sim_config._validate_action_latency_config()
     else:
         setattr(config.sim_config, attr, overrides[attr])
 
@@ -2166,6 +2169,8 @@ def _apply_simulation_overrides(
         config.sim_config.max_peds_per_group = int(overrides["max_peds_per_group"])
     for attr in (
         "peds_speed_mult",
+        "action_latency_steps",
+        "action_latency_ms",
         "pedestrian_integration_scheme",
         "ped_radius",
         "pedestrian_uncertainty_envelope_enabled",

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -623,6 +623,8 @@ def _runtime_binding(
         return "sim_config.pedestrian_integration_scheme"
     if axis == "clearance_radius" and isinstance(patch.get("sim_config"), Mapping):
         return "sim_config.ped_radius"
+    if axis == "control_action_latency" and isinstance(patch.get("sim_config"), Mapping):
+        return "sim_config.action_latency_steps"
     if axis == "social_force_speed_archetypes" and "pedestrian_archetypes" in patch:
         return "sim_config.archetype_composition"
     if axis == "observation_noise" and observation_noise:
@@ -642,6 +644,10 @@ def apply_variant(config: Any, variant: VariantSpec, *, seed: int) -> None:
     elif variant.runtime_binding == "sim_config.pedestrian_integration_scheme":
         config.sim_config.pedestrian_integration_scheme = str(
             variant.patch["sim_config"]["pedestrian_integration_scheme"]
+        )
+    elif variant.runtime_binding == "sim_config.action_latency_steps":
+        config.sim_config.action_latency_steps = int(
+            variant.patch["sim_config"]["action_latency_steps"]
         )
     elif variant.runtime_binding == "sim_config.archetype_composition":
         config.sim_config.archetype_composition = {
@@ -856,7 +862,14 @@ def run_episode(
     info: dict[str, Any] = {}
     steps = 0
     try:
-        env.reset(seed=seed)
+        reset_result = env.reset(seed=seed)
+        reset_info = (
+            reset_result[1]
+            if isinstance(reset_result, tuple)
+            and len(reset_result) == 2
+            and isinstance(reset_result[1], Mapping)
+            else {}
+        )
         for step_idx in range(max_steps):
             obs = _build_observation(env, noise=variant.observation_noise, rng=rng)
             command = planner.step(obs)
@@ -891,6 +904,9 @@ def run_episode(
         "variant_source_key": variant.source_key,
         "baseline_variant": variant.baseline,
         "runtime_binding": variant.runtime_binding,
+        "action_latency": reset_info.get("action_latency")
+        if isinstance(reset_info, Mapping)
+        else None,
         "planner": planner_name,
         "scenario_id": str(scenario.get("name") or scenario.get("scenario_id") or "unknown"),
         "seed": int(seed),

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -20,7 +20,7 @@ import math
 import pathlib
 import subprocess
 from collections.abc import Mapping
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -646,8 +646,10 @@ def apply_variant(config: Any, variant: VariantSpec, *, seed: int) -> None:
             variant.patch["sim_config"]["pedestrian_integration_scheme"]
         )
     elif variant.runtime_binding == "sim_config.action_latency_steps":
-        config.sim_config.action_latency_steps = int(
-            variant.patch["sim_config"]["action_latency_steps"]
+        config.sim_config = replace(
+            config.sim_config,
+            action_latency_steps=int(variant.patch["sim_config"]["action_latency_steps"]),
+            action_latency_ms=None,
         )
     elif variant.runtime_binding == "sim_config.archetype_composition":
         config.sim_config.archetype_composition = {

--- a/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
+++ b/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
@@ -99,6 +99,7 @@ def test_run_cells_carry_resolved_algorithm_and_scope_axes() -> None:
         "social_force_speed_archetypes",
         "observation_noise",
         "clearance_radius",
+        "control_action_latency",
     } <= axes
     assert seeds == {111, 112, 113}
     # default_social_force resolves to the canonical social_force algorithm.

--- a/tests/benchmark/test_fidelity_sensitivity_campaign.py
+++ b/tests/benchmark/test_fidelity_sensitivity_campaign.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 import pytest
 import yaml
 
+from robot_sf.sim.sim_config import SimulationSettings
+
 if TYPE_CHECKING:
     from types import ModuleType
 
@@ -65,7 +67,7 @@ def test_variant_specs_bind_all_declared_fidelity_axes_to_runtime_effects() -> N
 
 def test_action_latency_variant_binds_to_the_environment_configuration() -> None:
     """The latency campaign axis changes the env-loop queue rather than metadata only."""
-    config = SimpleNamespace(sim_config=SimpleNamespace(action_latency_steps=0))
+    config = SimpleNamespace(sim_config=SimulationSettings(action_latency_ms=250.0))
     variant = campaign_runner.VariantSpec(
         axis="control_action_latency",
         key="control_action_latency__three_step_300ms",
@@ -79,6 +81,8 @@ def test_action_latency_variant_binds_to_the_environment_configuration() -> None
     campaign_runner.apply_variant(config, variant, seed=111)
 
     assert config.sim_config.action_latency_steps == 3
+    assert config.sim_config.action_latency_ms is None
+    assert config.sim_config.resolved_action_latency_steps == 3
 
 
 def test_timestep_variant_preserves_simulated_duration() -> None:

--- a/tests/benchmark/test_fidelity_sensitivity_campaign.py
+++ b/tests/benchmark/test_fidelity_sensitivity_campaign.py
@@ -49,12 +49,36 @@ def test_variant_specs_bind_all_declared_fidelity_axes_to_runtime_effects() -> N
     axes = {variant.axis for variant in variants if not variant.baseline}
     bindings = {variant.runtime_binding for variant in variants}
 
-    assert {"integration_timestep", "social_force_speed_archetypes", "observation_noise"} <= axes
+    assert {
+        "integration_timestep",
+        "social_force_speed_archetypes",
+        "observation_noise",
+        "control_action_latency",
+    } <= axes
     assert "clearance_radius" in axes
     assert "sim_config.time_per_step_in_secs" in bindings
     assert "sim_config.archetype_composition" in bindings
     assert "planner_observation_noise" in bindings
+    assert "sim_config.action_latency_steps" in bindings
     assert "unsupported" not in bindings
+
+
+def test_action_latency_variant_binds_to_the_environment_configuration() -> None:
+    """The latency campaign axis changes the env-loop queue rather than metadata only."""
+    config = SimpleNamespace(sim_config=SimpleNamespace(action_latency_steps=0))
+    variant = campaign_runner.VariantSpec(
+        axis="control_action_latency",
+        key="control_action_latency__three_step_300ms",
+        source_key="three_step_300ms",
+        baseline=False,
+        patch={"sim_config": {"action_latency_steps": 3}},
+        observation_noise={},
+        runtime_binding="sim_config.action_latency_steps",
+    )
+
+    campaign_runner.apply_variant(config, variant, seed=111)
+
+    assert config.sim_config.action_latency_steps == 3
 
 
 def test_timestep_variant_preserves_simulated_duration() -> None:

--- a/tests/sim/test_action_latency.py
+++ b/tests/sim/test_action_latency.py
@@ -1,0 +1,53 @@
+"""Regression coverage for configurable robot control-to-actuation latency."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.sim.sim_config import SimulationSettings
+
+
+def test_action_latency_defaults_to_zero_steps_for_backward_compatibility() -> None:
+    """The default environment contract keeps immediate action execution."""
+    settings = SimulationSettings()
+
+    assert settings.resolved_action_latency_steps == 0
+    assert settings.action_latency_metadata() == {
+        "configured_steps": 0,
+        "configured_ms": None,
+        "effective_steps": 0,
+        "effective_ms": 0.0,
+    }
+
+
+def test_action_latency_ms_rounds_up_to_an_honest_whole_step_delay() -> None:
+    """A millisecond request never understates the delay realizable by a fixed-step loop."""
+    settings = SimulationSettings(time_per_step_in_secs=0.1, action_latency_ms=250.0)
+
+    assert settings.resolved_action_latency_steps == 3
+    assert settings.action_latency_metadata() == {
+        "configured_steps": 0,
+        "configured_ms": 250.0,
+        "effective_steps": 3,
+        "effective_ms": 300.0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error"),
+    [
+        ({"action_latency_steps": -1}, "must be >= 0"),
+        ({"action_latency_steps": 1.5}, "must be an integer"),
+        ({"action_latency_ms": -1.0}, "must be finite and >= 0"),
+        (
+            {"action_latency_steps": 1, "action_latency_ms": 100.0},
+            "cannot both be configured",
+        ),
+    ],
+)
+def test_invalid_action_latency_settings_fail_closed(
+    kwargs: dict[str, float | int], error: str
+) -> None:
+    """Ambiguous or invalid delay settings cannot silently change episode semantics."""
+    with pytest.raises((TypeError, ValueError), match=error):
+        SimulationSettings(**kwargs)

--- a/tests/test_socnav_env_integration.py
+++ b/tests/test_socnav_env_integration.py
@@ -10,6 +10,37 @@ from robot_sf.gym_env.unified_config import RobotSimulationConfig
 from robot_sf.planner.socnav import SocNavPlannerPolicy
 from robot_sf.robot.bicycle_drive import BicycleDriveSettings
 from robot_sf.robot.holonomic_drive import HolonomicDriveSettings
+from robot_sf.sim.sim_config import SimulationSettings
+
+
+def test_robot_env_delays_actions_and_resets_the_queue_between_episodes() -> None:
+    """The configured delay applies in the environment loop, not just campaign provenance."""
+    env = RobotEnv(
+        env_config=RobotSimulationConfig(
+            sim_config=SimulationSettings(action_latency_steps=1),
+        )
+    )
+    _obs, reset_info = env.reset(seed=123)
+
+    assert reset_info["action_latency"]["effective_steps"] == 1
+    _obs, _reward, _terminated, _truncated, first_info = env.step(
+        np.array([1.0, 0.0], dtype=np.float32)
+    )
+    assert first_info["meta"]["requested_action"] == pytest.approx((1.0, 0.0))
+    assert first_info["meta"]["action"] == pytest.approx((0.0, 0.0))
+    assert env.simulator.robots[0].current_speed == pytest.approx((0.0, 0.0))
+
+    _obs, _reward, _terminated, _truncated, second_info = env.step(
+        np.array([0.0, 0.0], dtype=np.float32)
+    )
+    assert second_info["meta"]["action"] == pytest.approx((1.0, 0.0))
+    assert env.simulator.robots[0].current_speed[0] > 0.0
+
+    env.reset(seed=123)
+    _obs, _reward, _terminated, _truncated, reset_step_info = env.step(
+        np.array([0.0, 0.0], dtype=np.float32)
+    )
+    assert reset_step_info["meta"]["action"] == pytest.approx((0.0, 0.0))
 
 
 def test_socnav_policy_runs_single_step():

--- a/tests/training/test_scenario_loader.py
+++ b/tests/training/test_scenario_loader.py
@@ -280,6 +280,38 @@ def test_build_robot_config_applies_pedestrian_uncertainty_envelope_fields(
     assert config.sim_config.pedestrian_uncertainty_alpha_mps == 0.1
 
 
+def test_build_robot_config_applies_action_latency_overrides(tmp_path: Path) -> None:
+    """Scenario configuration exposes both discrete and millisecond action delay forms."""
+    step_config = build_robot_config_from_scenario(
+        {
+            "name": "action-latency-step-runtime-smoke",
+            "simulation_config": {"action_latency_steps": 2},
+        },
+        scenario_path=tmp_path / "scenario.yaml",
+    )
+    ms_config = build_robot_config_from_scenario(
+        {
+            "name": "action-latency-ms-runtime-smoke",
+            "simulation_config": {"action_latency_ms": 250.0},
+        },
+        scenario_path=tmp_path / "scenario.yaml",
+    )
+
+    assert step_config.sim_config.resolved_action_latency_steps == 2
+    assert ms_config.sim_config.resolved_action_latency_steps == 3
+
+
+def test_build_robot_config_rejects_ambiguous_action_latency_overrides(tmp_path: Path) -> None:
+    """A scenario cannot choose both step and millisecond delay representations."""
+    scenario = {
+        "name": "ambiguous-action-latency",
+        "simulation_config": {"action_latency_steps": 1, "action_latency_ms": 100.0},
+    }
+
+    with pytest.raises(ValueError, match="cannot both be configured"):
+        build_robot_config_from_scenario(scenario, scenario_path=tmp_path / "scenario.yaml")
+
+
 def test_build_robot_config_rejects_negative_uncertainty_alpha(tmp_path: Path) -> None:
     """Negative scenario alpha fails closed at config-construction time."""
     scenario = {


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Adds a reset-safe control-to-actuation queue to `RobotEnv`, configured as exact whole steps or a millisecond request rounded up to whole simulation steps. The existing fidelity-sensitivity campaign now sweeps 0, 100, and 300 ms-equivalent action latency and records the resolved configuration in each run row.

**Why now:** #4977 identifies zero-latency control as a missing actuation-realism factor, preventing controlled measurement of its effect on safety outcomes.

**Claim boundary:** This is executable environment and campaign wiring with CPU-test evidence only. It makes no claim about observed safety degradation until the configured diagnostic sweep is run.

**Required validation:** `PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (after `uv sync --all-extras`), plus `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree`.

**Remaining blocker:** No full benchmark campaign has been run; empirical degradation and any broader benchmark conclusion remain unestablished. Execution and durable evidence are tracked in #5034.

Refs #4977

## Contract delta

- New `SimulationSettings.action_latency_steps` (default `0`) and mutually exclusive `action_latency_ms`; millisecond requests round up, and reset/step metadata records configured and effective latency.
- `RobotEnv.step()` now records `requested_action` separately from the executed `action`; each episode starts with zero-valued delayed actions so controls cannot leak across resets.
- Scenario `simulation_config` accepts both latency forms. The fidelity-sensitivity campaign adds an executable `control_action_latency` axis with 0/1/3-step variants.
- Compatibility: default zero latency retains immediate execution. Existing `latency_stress_profile` remains preflight/provenance-only, avoiding an unreviewed change to its diagnostic semantics.

## Scope and validation

- Issue: https://github.com/ll7/robot_sf_ll7/issues/4977
- Scope: env-loop latency configuration, metadata, scenario overrides, and diagnostic campaign axis.
- Validation passed:
  - `uv run pytest tests/sim/test_action_latency.py tests/test_socnav_env_integration.py::test_robot_env_delays_actions_and_resets_the_queue_between_episodes tests/benchmark/test_fidelity_sensitivity_campaign.py tests/training/test_scenario_loader.py -q` — 53 passed.
  - `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed (2,014 core tests).
  - Final committed-head freshness gate is rerun immediately before PR creation.
- Out of scope: campaign execution and its Slurm/GPU decision are tracked in #5034; no paper/dissertation claim edits.
- State propagation: after merge, #4977 will receive a one-line partial-completion update naming #5034.

## Domain-Aware Approval

- Required for this PR: yes - the diagnostic-only claim boundary and campaign contract need explicit review context.
- Domains reviewed: experimental comparison, benchmark interpretation
- Status: waived
- Approver/review source or waiver: issue #4977 authorizes implementation and CPU validation only; this PR makes no empirical result claim.
- Validity checklist:
  - Target claim/hypothesis: latency is a configurable actuation-realism factor.
  - Comparator or split/evidence validity: the tracked sweep compares fixed 0/1/3-step variants only after an external run.
  - Fallback/degraded exclusions: no fallback or degraded run is presented as evidence.
  - Claim boundary: executable wiring and tests only; no benchmark conclusion.
  - Implementation integrity vs experimental validity: tests prove queue/config wiring; campaign execution is required for empirical validity.

## Follow-Up Issues

- Deferred work: execute the configured latency campaign and promote a durable evidence summary.
- Issues opened for follow-up: #5034.

<details>
<summary>Evidence and governance appendix</summary>

The latency sweep is diagnostic-only until executed. It uses the existing fidelity-sensitivity study’s scenario, seed, planner, metric-drift, and rank-stability contract; its new values do not constitute benchmark evidence. Generated coverage output remains ignored and was not committed.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable control-action latency in simulation steps or milliseconds.
  * Added scenario-level overrides and latency details in reset and step metadata.
  * Added a fidelity-sensitivity axis covering baseline, 100 ms, and 300 ms latency.
  * Action queues now reset safely between episodes.

* **Validation**
  * Invalid or ambiguous latency settings are rejected with clear errors.
  * Expanded fidelity-sensitivity run coverage and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->