### PR TITLE
ci: queue main workflows without cancellation (#5029)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   PYTHONUNBUFFERED: "1"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   analyze:

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -16,6 +16,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CI_DRIVER = ROOT / "scripts" / "dev" / "ci_driver.sh"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 CI_SETUP_ACTION = ROOT / ".github" / "actions" / "setup-ci-python" / "action.yml"
+CODEQL_WORKFLOW = ROOT / ".github" / "workflows" / "codeql.yml"
 WHEEL_INSTALL_SMOKE = ROOT / "scripts" / "validation" / "wheel_install_smoke.sh"
 PYPROJECT = ROOT / "pyproject.toml"
 WORKFLOWS_DIR = ROOT / ".github" / "workflows"
@@ -98,6 +99,19 @@ def _workflow_job_phases(job_name: str) -> set[str]:
 def _workflow_text() -> str:
     """Return the raw CI workflow text."""
     return CI_WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_main_push_workflows_queue_while_pull_request_runs_supersede() -> None:
+    """Keep post-merge validation from being starved while retaining fast PR feedback.
+
+    GitHub Actions groups all runs for ``refs/heads/main`` together.  The explicit
+    expression queues those main runs, but still cancels superseded pull-request runs.
+    """
+
+    expected = "${{ github.ref != 'refs/heads/main' }}"
+    for workflow_file in (CI_WORKFLOW, CODEQL_WORKFLOW):
+        workflow = yaml.safe_load(workflow_file.read_text(encoding="utf-8")) or {}
+        assert workflow["concurrency"]["cancel-in-progress"] == expected
 
 
 def _workflow_files() -> list[Path]:

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -111,7 +111,9 @@ def test_main_push_workflows_queue_while_pull_request_runs_supersede() -> None:
     expected = "${{ github.ref != 'refs/heads/main' }}"
     for workflow_file in (CI_WORKFLOW, CODEQL_WORKFLOW):
         workflow = yaml.safe_load(workflow_file.read_text(encoding="utf-8")) or {}
-        assert workflow["concurrency"]["cancel-in-progress"] == expected
+        concurrency = workflow.get("concurrency", {})
+        assert isinstance(concurrency, dict)
+        assert concurrency.get("cancel-in-progress") == expected
 
 
 def _workflow_files() -> list[Path]:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** CI and CodeQL now queue runs on `main` while still cancelling superseded pull-request runs; a regression test locks that shared contract.
- **Why now:** the constant `refs/heads/main` concurrency group was cancelling every in-flight post-merge run, starving `main` validation.
- **Claim boundary:** workflow configuration only. It proves the configured cancellation policy, not an observed post-merge GitHub Actions outcome.
- **Required validation:** review the two concurrency expressions and the focused YAML contract test; local canonical readiness passed (2,014 core tests).
- **Remaining verification:** After merge, #5029 retains the GitHub Actions run-history acceptance check.

## Contract delta

- **New schema fields:** none.
- **New fail-closed blockers:** none.
- **Behavior:** `CI` and `CodeQL` retain their existing concurrency groups. `main` runs now queue; pull-request runs remain cancellable when superseded.
- **Compatibility impact:** none outside GitHub Actions scheduling.

## Summary

Prevent post-merge validation on `main` from being cancelled by later merges, without slowing feedback on updated pull requests.

## Linked Issues

- Refs #5029

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #5033
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed

- Changed `.github/workflows/ci.yml` and `.github/workflows/codeql.yml` so `cancel-in-progress` is false only for `refs/heads/main`.
- Added a focused workflow contract test covering both workflows.
- Audited every workflow that both pushes to `main` and had `cancel-in-progress: true`: CI changed; CodeQL changed. No other workflow met both conditions.

## Why It Matters

- Added value: post-merge CI can complete even when merges arrive faster than a workflow run.
- Expected impact: `main` records a success or failure instead of repeatedly reporting cancellation.
- Why this is worth merging now: it restores the repository's post-merge regression signal while retaining fast PR feedback.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - GitHub Actions scheduling only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: NA - support/workflow configuration.
- Result classification: NA - no research claim
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #5029 only.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no research-evidence surface.

## Domain-Aware Approval

- Required for this PR: no - no benchmark, metric, or paper-facing change.
- Domains reviewed: NA.
- Status: not required.
- Approver/review source or waiver: NA.
- Validity checklist: NA.

## Falsification / Non-Transfer Check

- Did the mechanism activate? NA.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action

- Rerun needed: no local rerun; observe the next overlapping `main` runs after merge.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: GitHub Actions run history is unavailable until the workflow reaches `main`.
- Stop / revise / continue decision: continue; revert the expression if it fails to preserve PR cancellation.
- Proposed child issue or existing follow-up: #5033 tracks the unrelated timeout-contract test mismatch found during validation.

## Validation / Proof

- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_ci_driver_contract.py::test_main_push_workflows_queue_while_pull_request_runs_supersede -q` — passed (1 test).
  - `uv run ruff check tests/test_ci_driver_contract.py` — passed.
  - `uv run ruff format --check tests/test_ci_driver_contract.py` — passed.
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed (2,014 core tests; formatting, coverage, docstring, and broad-exception gates).
- Evidence that the change works here: direct PyYAML assertion confirmed the exact conditional in CI and CodeQL.
- Benchmarks or smoke tests, if applicable: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout

- Compatibility risks: GitHub Actions evaluates the documented ref expression; no application runtime contract changes.
- Failure modes: an expression typo could disable PR cancellation, covered by the new exact-expression test.
- Rollback or fallback plan: revert the two workflow lines to restore prior cancellation behavior.

## Docs / Provenance

- Updated docs: none needed; the workflow contract test documents the scheduling behavior.
- Relevant design or provenance notes: issue #5029 contains the observed cancellation history and acceptance command.
- Any assumptions that need to be preserved: `github.ref` is exactly `refs/heads/main` for main-branch push runs.

## Downstream Propagation

- Parent issue updated: pending merge; this gate will post the outcome to #5029.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: yes - #5033.
- Not applicable because: all non-issue propagation surfaces are workflow-configuration NAs; #5029 carries the remaining operational verification.

## Follow-Up Issues

- Deferred work: no deferred implementation. #5029 retains the required post-merge run-history observation; #5033 tracks an unrelated fresh-base failure in the broader CI workflow-contract test.
- Issues opened for follow-up: #5033

## Reviewer Notes

- Verify both affected push-to-main workflows (CI and CodeQL) use the same conditional while preserving their existing concurrency-group names.
- Known limitation: local validation cannot demonstrate the future GitHub Actions run history on `main`.

