### PR TITLE
Issue #4991: guard against silent gh list truncation (cheap-lane worker)

### DIFF
--- a/scripts/dev/_gh_pagination.py
+++ b/scripts/dev/_gh_pagination.py
@@ -1,0 +1,74 @@
+"""Guard against silent truncation in bounded `gh ... list --limit N` calls.
+
+GitHub CLI list commands such as `gh pr list` and `gh issue list` accept a numeric
+`--limit N` and return at most ``N`` rows. When exactly ``N`` rows come back, the
+caller cannot tell whether the page was complete or silently capped. This module
+makes that ambiguity loud instead of silent.
+
+Two complementary entry points:
+
+- :func:`assert_not_truncated` raises :class:`GhListTruncated` for callers that
+  want to fail closed.
+- :func:`is_likely_truncated` returns a boolean for callers that prefer to record
+  a ``truncated: true`` marker in their structured snapshot JSON.
+
+The motivation and contract are tracked in issue #4991.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sized
+
+
+class GhListTruncated(RuntimeError):
+    """Raised when a bounded ``gh ... list --limit N`` result may be truncated.
+
+    A result containing exactly ``limit`` rows is treated as potentially
+    truncated because a full page and a capped page are indistinguishable.
+    """
+
+
+def is_likely_truncated(row_count: int, *, limit: int) -> bool:
+    """Return ``True`` when a bounded gh list result may be truncated.
+
+    A non-positive ``limit`` never reports truncation: there is no cap to hit
+    when pagination is effectively unbounded.
+    """
+    return limit > 0 and row_count >= limit
+
+
+def assert_not_truncated(
+    rows: Sized,
+    *,
+    limit: int,
+    context: str = "",
+) -> None:
+    """Raise :class:`GhListTruncated` when ``rows`` may be truncated by the cap.
+
+    Parameters
+    ----------
+    rows:
+        The sized container of rows returned by ``gh ... list --limit``.
+    limit:
+        The numeric ``--limit`` value passed to ``gh``.
+    context:
+        Optional short label (for example, the gh subcommand and search) that is
+        included in the error message to aid diagnosis.
+
+    Raises
+    ------
+    GhListTruncated
+        If ``len(rows) >= limit`` and ``limit > 0``.
+    """
+    count = len(rows)
+    if is_likely_truncated(count, limit=limit):
+        detail = (
+            f"gh list may be truncated: got {count} rows at --limit {limit}; "
+            "raise --limit or paginate"
+        )
+        if context:
+            detail = f"{detail} ({context})"
+        raise GhListTruncated(detail)

--- a/scripts/dev/_gh_pagination.py
+++ b/scripts/dev/_gh_pagination.py
@@ -31,19 +31,19 @@ class GhListTruncated(RuntimeError):
     """
 
 
-def is_likely_truncated(row_count: int, *, limit: int) -> bool:
+def is_likely_truncated(row_count: int, *, limit: int | None) -> bool:
     """Return ``True`` when a bounded gh list result may be truncated.
 
-    A non-positive ``limit`` never reports truncation: there is no cap to hit
+    A non-positive or ``None`` ``limit`` never reports truncation: there is no cap to hit
     when pagination is effectively unbounded.
     """
-    return limit > 0 and row_count >= limit
+    return limit is not None and limit > 0 and row_count >= limit
 
 
 def assert_not_truncated(
     rows: Sized,
     *,
-    limit: int,
+    limit: int | None,
     context: str = "",
 ) -> None:
     """Raise :class:`GhListTruncated` when ``rows`` may be truncated by the cap.
@@ -53,7 +53,8 @@ def assert_not_truncated(
     rows:
         The sized container of rows returned by ``gh ... list --limit``.
     limit:
-        The numeric ``--limit`` value passed to ``gh``.
+        The numeric ``--limit`` value passed to ``gh``, or ``None`` for an
+        unbounded query.
     context:
         Optional short label (for example, the gh subcommand and search) that is
         included in the error message to aid diagnosis.

--- a/scripts/dev/autopilot_state_snapshot.py
+++ b/scripts/dev/autopilot_state_snapshot.py
@@ -16,6 +16,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from scripts.dev._gh_pagination import is_likely_truncated
+
 FAILURE_CONCLUSIONS = {
     "action_required",
     "cancelled",
@@ -369,11 +371,17 @@ def claim_snapshot(
 
 def issue_queue_snapshot(
     searches: list[str], *, limit: int
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
-    """Return compact issue rows for one or more GitHub issue searches."""
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str], list[dict[str, Any]]]:
+    """Return compact issue rows for one or more GitHub issue searches.
+
+    The fourth tuple element records, per search, whether the bounded
+    ``gh issue list --limit`` result may have been silently capped. Downstream
+    consumers should treat any ``truncated: true`` marker as incomplete evidence.
+    """
     rows: list[dict[str, Any]] = []
     sources: list[dict[str, Any]] = []
     errors: list[str] = []
+    truncations: list[dict[str, Any]] = []
     seen: set[int] = set()
     for search in searches:
         command = [
@@ -393,7 +401,24 @@ def issue_queue_snapshot(
         if error:
             errors.append(f"issue search {search!r}: {error}")
             continue
-        for issue in data if isinstance(data, list) else []:
+        search_rows = data if isinstance(data, list) else []
+        row_count = len(search_rows)
+        truncated = is_likely_truncated(row_count, limit=limit)
+        truncations.append(
+            {
+                "search": search,
+                "truncated": truncated,
+                "row_count": row_count,
+                "limit": limit,
+                "note": (
+                    "gh issue list may be capped: got "
+                    f"{row_count} rows at --limit {limit}; raise --limit or paginate"
+                    if truncated
+                    else ""
+                ),
+            }
+        )
+        for issue in search_rows:
             number = issue.get("number")
             if not isinstance(number, int) or number in seen:
                 continue
@@ -413,7 +438,7 @@ def issue_queue_snapshot(
                     "url": issue.get("url", ""),
                 }
             )
-    return rows, sources, errors
+    return rows, sources, errors, truncations
 
 
 def _rollup_conclusion(check: dict[str, Any]) -> str:
@@ -517,7 +542,9 @@ def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
     sources.extend(claim_sources)
     errors.extend(claim_errors)
 
-    issues, issue_sources, issue_errors = issue_queue_snapshot(args.issue_search, limit=args.limit)
+    issues, issue_sources, issue_errors, issue_truncations = issue_queue_snapshot(
+        args.issue_search, limit=args.limit
+    )
     sources.extend(issue_sources)
     errors.extend(issue_errors)
 
@@ -543,6 +570,8 @@ def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
         "git": git,
         "claims": claims,
         "issues": issues,
+        "issues_truncated_any": any(marker.get("truncated") for marker in issue_truncations),
+        "issues_truncated": issue_truncations,
         "prs": prs,
         "controller_checkpoint": checkpoint,
         "errors": errors,

--- a/scripts/dev/autopilot_state_snapshot.py
+++ b/scripts/dev/autopilot_state_snapshot.py
@@ -401,7 +401,12 @@ def issue_queue_snapshot(
         if error:
             errors.append(f"issue search {search!r}: {error}")
             continue
-        search_rows = data if isinstance(data, list) else []
+        if not isinstance(data, list):
+            errors.append(
+                f"issue search {search!r}: expected JSON array, got {type(data).__name__}"
+            )
+            continue
+        search_rows = data
         row_count = len(search_rows)
         truncated = is_likely_truncated(row_count, limit=limit)
         truncations.append(

--- a/scripts/dev/snapshot_pr_queue.py
+++ b/scripts/dev/snapshot_pr_queue.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from scripts.dev._gh_pagination import is_likely_truncated
 from scripts.dev.check_pr_ci_status import (
     FAILURE_CONCLUSIONS,
     PENDING_STATUSES,
@@ -490,6 +491,8 @@ def snapshot_active_prs(*, repo: str, limit: int) -> dict[str, Any]:
             "schema": SCHEMA_VERSION,
             "repo": repo,
             "mode": "active",
+            "truncated": False,
+            "truncation_note": "",
             "route_health_overview": {"healthy": 0, "stale": 0, "blocked": 0, "unknown": 0},
             "prs": [
                 {
@@ -505,6 +508,8 @@ def snapshot_active_prs(*, repo: str, limit: int) -> dict[str, Any]:
             "schema": SCHEMA_VERSION,
             "repo": repo,
             "mode": "active",
+            "truncated": False,
+            "truncation_note": "",
             "route_health_overview": {"healthy": 0, "stale": 0, "blocked": 0, "unknown": 0},
             "prs": [
                 {
@@ -518,6 +523,8 @@ def snapshot_active_prs(*, repo: str, limit: int) -> dict[str, Any]:
             "schema": SCHEMA_VERSION,
             "repo": repo,
             "mode": "active",
+            "truncated": False,
+            "truncation_note": "",
             "route_health_overview": {"healthy": 0, "stale": 0, "blocked": 0, "unknown": 0},
             "prs": [
                 {
@@ -532,10 +539,18 @@ def snapshot_active_prs(*, repo: str, limit: int) -> dict[str, Any]:
         for pr in listed
         if isinstance(pr, dict)
     ]
+    truncated = is_likely_truncated(len(listed), limit=limit)
     return {
         "schema": SCHEMA_VERSION,
         "repo": repo,
         "mode": "active",
+        "truncated": truncated,
+        "truncation_note": (
+            "gh pr list may be capped: got "
+            f"{len(listed)} rows at --limit {limit}; raise --limit or paginate"
+            if truncated
+            else ""
+        ),
         "route_health_overview": _route_health_overview(prs),
         "prs": prs,
     }

--- a/tests/dev/test_gh_pagination_guard.py
+++ b/tests/dev/test_gh_pagination_guard.py
@@ -43,11 +43,12 @@ def test_is_likely_truncated_false_when_below_limit() -> None:
     assert is_likely_truncated(0, limit=20) is False
 
 
-def test_is_likely_truncated_false_for_non_positive_limit() -> None:
-    """A non-positive limit means no cap was applied."""
+def test_is_likely_truncated_false_for_non_positive_or_none_limit() -> None:
+    """A non-positive or None limit means no cap was applied."""
     assert is_likely_truncated(0, limit=0) is False
     assert is_likely_truncated(100, limit=0) is False
     assert is_likely_truncated(100, limit=-1) is False
+    assert is_likely_truncated(100, limit=None) is False
 
 
 def test_assert_not_truncated_raises_when_rows_equal_limit() -> None:
@@ -74,10 +75,11 @@ def test_assert_not_truncated_message_without_context() -> None:
     assert "raise --limit or paginate" in str(exc_info.value)
 
 
-def test_assert_not_truncated_zero_limit_never_raises() -> None:
-    """A non-positive limit is unbounded and never reports truncation."""
+def test_assert_not_truncated_unbounded_limit_never_raises() -> None:
+    """A non-positive or None limit is unbounded and never reports truncation."""
     assert_not_truncated(list(range(100)), limit=0)
     assert_not_truncated(list(range(100)), limit=-5)
+    assert_not_truncated(list(range(100)), limit=None)
 
 
 # ---------------------------------------------------------------------------
@@ -273,6 +275,24 @@ def test_issue_queue_snapshot_no_truncation_marker_for_failed_search() -> None:
 
     assert truncations == []
     assert errors and "not found" in errors[0]
+
+
+def test_issue_queue_snapshot_rejects_non_list_json() -> None:
+    """A successful but malformed gh JSON response must not silently omit issues."""
+    with patch("scripts.dev.autopilot_state_snapshot._run") as mock_run:
+        mock_run.return_value = snapshot.CommandResult(
+            command=("gh", "issue", "list"),
+            returncode=0,
+            stdout=json.dumps({"number": 1}),
+            stderr="",
+        )
+        rows, _sources, errors, truncations = snapshot.issue_queue_snapshot(
+            ["is:issue is:open"], limit=20
+        )
+
+    assert rows == []
+    assert truncations == []
+    assert errors == ["issue search 'is:issue is:open': expected JSON array, got dict"]
 
 
 def test_build_snapshot_surfaces_issues_truncated_markers(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/dev/test_gh_pagination_guard.py
+++ b/tests/dev/test_gh_pagination_guard.py
@@ -1,0 +1,317 @@
+"""Tests for the gh list truncation guard (issue #4991).
+
+Covers the shared helper plus the two highest-risk evidence/reporting call sites:
+``snapshot_pr_queue.snapshot_active_prs`` and
+``autopilot_state_snapshot.issue_queue_snapshot``. A mocked ``gh ... list`` that
+returns exactly ``limit`` rows must record a ``truncated: true`` marker (or raise);
+returning fewer rows must pass cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.dev import autopilot_state_snapshot as snapshot
+from scripts.dev._gh_pagination import (
+    GhListTruncated,
+    assert_not_truncated,
+    is_likely_truncated,
+)
+from scripts.dev.snapshot_pr_queue import snapshot_active_prs
+
+# ---------------------------------------------------------------------------
+# Shared helper
+# ---------------------------------------------------------------------------
+
+
+def test_is_likely_truncated_true_when_row_count_equals_limit() -> None:
+    """A result of exactly `limit` rows is ambiguous and treated as truncated."""
+    assert is_likely_truncated(20, limit=20) is True
+
+
+def test_is_likely_truncated_true_when_row_count_exceeds_limit() -> None:
+    """More than `limit` rows (possible with dedup-free raw counts) is truncated."""
+    assert is_likely_truncated(21, limit=20) is True
+
+
+def test_is_likely_truncated_false_when_below_limit() -> None:
+    """Fewer rows than the cap cannot have been truncated."""
+    assert is_likely_truncated(19, limit=20) is False
+    assert is_likely_truncated(0, limit=20) is False
+
+
+def test_is_likely_truncated_false_for_non_positive_limit() -> None:
+    """A non-positive limit means no cap was applied."""
+    assert is_likely_truncated(0, limit=0) is False
+    assert is_likely_truncated(100, limit=0) is False
+    assert is_likely_truncated(100, limit=-1) is False
+
+
+def test_assert_not_truncated_raises_when_rows_equal_limit() -> None:
+    """Exactly `limit` rows must raise so callers fail closed."""
+    rows = list(range(20))
+    with pytest.raises(GhListTruncated) as exc_info:
+        assert_not_truncated(rows, limit=20, context="gh pr list")
+    message = str(exc_info.value)
+    assert "20" in message
+    assert "--limit 20" in message
+    assert "gh pr list" in message
+
+
+def test_assert_not_truncated_passes_when_below_limit() -> None:
+    """Fewer rows than the cap pass cleanly with no raise."""
+    assert_not_truncated(list(range(19)), limit=20)
+    assert_not_truncated([], limit=20)
+
+
+def test_assert_not_truncated_message_without_context() -> None:
+    """A missing context still produces a clear, actionable message."""
+    with pytest.raises(GhListTruncated) as exc_info:
+        assert_not_truncated([1, 2, 3], limit=3)
+    assert "raise --limit or paginate" in str(exc_info.value)
+
+
+def test_assert_not_truncated_zero_limit_never_raises() -> None:
+    """A non-positive limit is unbounded and never reports truncation."""
+    assert_not_truncated(list(range(100)), limit=0)
+    assert_not_truncated(list(range(100)), limit=-5)
+
+
+# ---------------------------------------------------------------------------
+# snapshot_active_prs (gh pr list)
+# ---------------------------------------------------------------------------
+
+
+def _pr_payloads(count: int) -> list[dict]:
+    """Return `count` minimal open-PR payloads."""
+    return [
+        {
+            "number": 5000 + index,
+            "title": f"PR {index}",
+            "state": "OPEN",
+            "isDraft": False,
+            "url": f"https://github.test/pull/{5000 + index}",
+            "labels": [],
+            "headRefName": "feature",
+            "headRefOid": f"abc{index:03d}",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [{"name": "ci", "status": "completed", "conclusion": "success"}],
+            "reviews": [],
+            "comments": [],
+        }
+        for index in range(count)
+    ]
+
+
+def test_snapshot_active_prs_records_truncated_when_at_limit() -> None:
+    """Exactly `limit` rows from `gh pr list` record a `truncated: true` marker."""
+    limit = 3
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(
+            returncode=0, stdout=json.dumps(_pr_payloads(limit)), stderr=""
+        )
+        payload = snapshot_active_prs(repo="ll7/robot_sf_ll7", limit=limit)
+
+    assert payload["truncated"] is True
+    assert payload["truncation_note"]
+    assert "--limit 3" in payload["truncation_note"]
+    assert len(payload["prs"]) == limit
+
+
+def test_snapshot_active_prs_clean_when_below_limit() -> None:
+    """Fewer rows than the cap pass cleanly with a false truncated marker."""
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(
+            returncode=0, stdout=json.dumps(_pr_payloads(2)), stderr=""
+        )
+        payload = snapshot_active_prs(repo="ll7/robot_sf_ll7", limit=5)
+
+    assert payload["truncated"] is False
+    assert payload["truncation_note"] == ""
+    assert len(payload["prs"]) == 2
+
+
+def test_snapshot_active_prs_clean_when_zero_rows() -> None:
+    """An empty `gh pr list` result is not truncated."""
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps([]), stderr="")
+        payload = snapshot_active_prs(repo="ll7/robot_sf_ll7", limit=20)
+
+    assert payload["truncated"] is False
+    assert payload["truncation_note"] == ""
+    assert payload["prs"] == []
+
+
+def test_snapshot_active_prs_error_path_reports_not_truncated() -> None:
+    """A gh failure must not report truncation; it reports the error instead."""
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=1, stdout="", stderr="rate limited")
+        payload = snapshot_active_prs(repo="ll7/robot_sf_ll7", limit=20)
+
+    assert payload["truncated"] is False
+    assert payload["truncation_note"] == ""
+    assert payload["prs"][0]["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# issue_queue_snapshot (gh issue list)
+# ---------------------------------------------------------------------------
+
+
+def _issue_payloads(count: int) -> list[dict]:
+    """Return `count` minimal issue payloads."""
+    return [
+        {
+            "number": 4900 + index,
+            "title": f"Issue {index}",
+            "state": "OPEN",
+            "labels": [{"name": "agent"}],
+            "updatedAt": "2026-07-10T00:00:00Z",
+            "url": f"https://github.test/issues/{4900 + index}",
+        }
+        for index in range(count)
+    ]
+
+
+def test_issue_queue_snapshot_records_truncation_when_at_limit() -> None:
+    """Exactly `limit` rows per search record a `truncated: true` marker."""
+    limit = 4
+    with patch("scripts.dev.autopilot_state_snapshot._run") as mock_run:
+        mock_run.return_value = snapshot.CommandResult(
+            command=("gh", "issue", "list"),
+            returncode=0,
+            stdout=json.dumps(_issue_payloads(limit)),
+            stderr="",
+        )
+        rows, _sources, errors, truncations = snapshot.issue_queue_snapshot(
+            ["is:issue is:open"], limit=limit
+        )
+
+    assert errors == []
+    assert len(rows) == limit
+    assert truncations
+    marker = truncations[0]
+    assert marker["truncated"] is True
+    assert marker["row_count"] == limit
+    assert marker["limit"] == limit
+    assert "--limit 4" in marker["note"]
+
+
+def test_issue_queue_snapshot_clean_when_below_limit() -> None:
+    """Fewer rows than the cap pass cleanly with truncated markers set False."""
+    with patch("scripts.dev.autopilot_state_snapshot._run") as mock_run:
+        mock_run.return_value = snapshot.CommandResult(
+            command=("gh", "issue", "list"),
+            returncode=0,
+            stdout=json.dumps(_issue_payloads(2)),
+            stderr="",
+        )
+        rows, _sources, errors, truncations = snapshot.issue_queue_snapshot(
+            ["is:issue is:open"], limit=20
+        )
+
+    assert errors == []
+    assert len(rows) == 2
+    assert truncations[0]["truncated"] is False
+    assert truncations[0]["row_count"] == 2
+    assert truncations[0]["note"] == ""
+
+
+def test_issue_queue_snapshot_per_search_truncation_is_independent() -> None:
+    """A truncated search and a clean search produce independent markers."""
+    with patch("scripts.dev.autopilot_state_snapshot._run") as mock_run:
+        mock_run.side_effect = [
+            snapshot.CommandResult(
+                command=("gh", "issue", "list"),
+                returncode=0,
+                stdout=json.dumps(_issue_payloads(3)),
+                stderr="",
+            ),
+            snapshot.CommandResult(
+                command=("gh", "issue", "list"),
+                returncode=0,
+                stdout=json.dumps(_issue_payloads(1)),
+                stderr="",
+            ),
+        ]
+        _rows, _sources, _errors, truncations = snapshot.issue_queue_snapshot(
+            ["full:truncated", "sparse:clean"], limit=3
+        )
+
+    assert len(truncations) == 2
+    assert truncations[0] == {
+        "search": "full:truncated",
+        "truncated": True,
+        "row_count": 3,
+        "limit": 3,
+        "note": ("gh issue list may be capped: got 3 rows at --limit 3; raise --limit or paginate"),
+    }
+    assert truncations[1] == {
+        "search": "sparse:clean",
+        "truncated": False,
+        "row_count": 1,
+        "limit": 3,
+        "note": "",
+    }
+
+
+def test_issue_queue_snapshot_no_truncation_marker_for_failed_search() -> None:
+    """A failed gh call must not emit a truncation marker; it records an error."""
+    with patch("scripts.dev.autopilot_state_snapshot._run") as mock_run:
+        mock_run.return_value = snapshot.CommandResult(
+            command=("gh", "issue", "list"),
+            returncode=1,
+            stdout="",
+            stderr="not found",
+        )
+        _rows, _sources, errors, truncations = snapshot.issue_queue_snapshot(
+            ["is:issue is:open"], limit=20
+        )
+
+    assert truncations == []
+    assert errors and "not found" in errors[0]
+
+
+def test_build_snapshot_surfaces_issues_truncated_markers(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """The full snapshot payload must expose issue-search truncation markers."""
+    captured: dict[str, object] = {}
+
+    def fake_issue_queue_snapshot(searches, *, limit):  # type: ignore[no-untyped-def]
+        captured["searches"] = searches
+        captured["limit"] = limit
+        marker = {
+            "search": searches[0],
+            "truncated": True,
+            "row_count": limit,
+            "limit": limit,
+            "note": "gh issue list may be capped",
+        }
+        return [], [], [], [marker]
+
+    monkeypatch.setattr(snapshot, "issue_queue_snapshot", fake_issue_queue_snapshot)
+    # Short-circuit the git/claim/pr collection so the test stays focused.
+    monkeypatch.setattr(
+        snapshot,
+        "git_snapshot",
+        lambda **_kw: ({}, [], []),
+    )
+    monkeypatch.setattr(
+        snapshot,
+        "claim_snapshot",
+        lambda *_a, **_kw: ([], [], []),
+    )
+    monkeypatch.setattr(
+        snapshot,
+        "pr_snapshot",
+        lambda *_a, **_kw: ([], [], []),
+    )
+
+    args = snapshot._build_parser().parse_args(["--issue-search", "is:issue is:open"])
+    payload = snapshot.build_snapshot(args)
+
+    assert payload["issues_truncated_any"] is True
+    assert payload["issues_truncated"][0]["truncated"] is True
+    assert captured["limit"] == 20


### PR DESCRIPTION
## What

Implements the **bounded first slice** of issue #4991: guard against silent list truncation in bounded `gh ... list --limit N` reporting calls. When exactly `--limit` rows come back from `gh pr list` / `gh issue list`, the result is indistinguishable from a capped page — so it is currently impossible to tell whether more rows exist. This PR makes that ambiguity **loud** instead of **silent**.

Refs #4991 for the bounded slice it defines (helper + test + the two named call sites).

## Why

This class of bug was hit twice recently (a merged-PR count silently capped at the default 30; a fleet enumeration silently missing entries past the cap). A repo-wide grep confirms there is **no** `len(...) == limit` / truncation guard anywhere in `scripts/`. This strengthens evidence integrity in CLI/reporting scripts and their JSON status envelopes; it touches **no benchmark metric code path**.

## Changes

- **New** `scripts/dev/_gh_pagination.py` — shared helper:
  - `GhListTruncated` exception.
  - `is_likely_truncated(row_count, *, limit) -> bool` — `True` when `limit > 0 and row_count >= limit`.
  - `assert_not_truncated(rows, *, limit, context="")` — raises `GhListTruncated` for fail-closed callers.
- **Wired** `snapshot_pr_queue.snapshot_active_prs` (`gh pr list --limit`) — adds top-level `truncated: bool` and `truncation_note: str` markers to the snapshot JSON (all return paths, including error paths which report `False`).
- **Wired** `autopilot_state_snapshot.issue_queue_snapshot` (`gh issue list --search ... --limit`) — returns a 4th tuple element of per-search truncation markers, surfaced in the payload as `issues_truncated_any: bool` and `issues_truncated: list`. This matches the existing house style (`tracked_or_staged_truncated`, `worktrees_truncated` markers).
- **New** `tests/dev/test_gh_pagination_guard.py` — 17 tests covering the helper (raise/clean/edge cases) and both wired call sites (exactly-limit fires, below-limit passes, empty passes, errors are not false truncation, per-search independence).

This is **marker mode** (record a `truncated: true` flag in the structured JSON) rather than hard-failing, which is consistent with the existing `_truncated` markers in these scripts and keeps `rc == 0` so existing automation isn't broken. The raising `assert_not_truncated` helper is also provided for any future caller that prefers fail-closed behavior.

## Acceptance criteria

- [x] A mocked `gh pr list` returning exactly `limit` rows makes the guarded call record a `truncated: true` marker in its snapshot JSON.
- [x] Returning fewer than `limit` rows passes cleanly (`truncated: false`, empty note).
- [x] A mocked `gh issue list` at the cap records per-search truncation markers surfaced in the snapshot payload.
- [x] No change to any benchmark output (CLI/reporting scripts and JSON envelopes only).

## Validation

```
uv run pytest tests/dev/test_gh_pagination_guard.py -v
# 17 passed in 0.11s

uv run pytest tests/dev/test_snapshot_pr_queue.py tests/dev/test_autopilot_state_snapshot.py
# 22 passed in 0.12s  (no regressions in the two modified scripts' existing tests)

uv run ruff check <changed files>   # All checks passed!
uv run ruff format --check <changed files>  # 4 files already formatted
```

Exact command from the issue:
```
uv run pytest tests/dev/test_gh_pagination_guard.py -v
```
→ 17 passed.

## Scope (bounded first slice)

Per the issue's "Bounded first slice (one PR)" and the maintainer plan comment:
- Land the helper + test. ✅
- Wire it into `snapshot_pr_queue.snapshot_active_prs` and `autopilot_state_snapshot` only. ✅
- **Follow-up work (NOT in this PR):** apply the guard to the remaining `--limit`-defaulted callers listed in the issue: `snapshot_issue_batch.py`, `closed_state_label_hygiene.py`, `open_issue_closure_audit.py`, `watch_pr_ci_status.py`, `compact_ci_snapshot.py`, `scripts/tools/project_priority_score.py`. Tracked in #5048.

## Evidence handling

- `output/` propagation: **NA** — no evidence produced; this is a test/tooling change to reporting scripts. No benchmark, metric, schema, or model-provenance claim.
- Claim/hypothesis: NA (tooling).

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Refs #4991
