### PR TITLE
Issue #4990: optional-import guard inventory ratchet + canonical try_import helper (cheap-lane worker)

### DIFF
--- a/robot_sf/common/optional_import.py
+++ b/robot_sf/common/optional_import.py
@@ -1,0 +1,81 @@
+"""Canonical optional-dependency import guard (see issue #4990).
+
+Optional-dependency import guards in ``robot_sf`` had drifted into ~40 distinct
+spellings. This module provides the single blessed spelling for the *common*
+case so that reviews can focus scrutiny on the (few) guards that legitimately
+catch more than ``ImportError``.
+
+The common case
+---------------
+Most optional imports are of the form "import a module if it is available,
+otherwise bind the name to ``None`` and degrade gracefully". Use
+:func:`try_import`::
+
+    from robot_sf.common.optional_import import try_import
+
+    yaml = try_import("yaml")
+    if yaml is None:
+        ...  # degrade gracefully
+
+:func:`try_import` catches **only** :class:`ImportError` (which includes
+:class:`ModuleNotFoundError`). It never swallows broader failures, so a buggy
+optional dependency cannot hide behind an "optional import".
+
+When is a broader ``except`` legitimate?
+----------------------------------------
+Some optional imports intentionally catch more than ``ImportError``. Do **not**
+use :func:`try_import` for these; keep the explicit broad ``except`` and add a
+``# pragma: no cover`` plus a one-line justification:
+
+* **Native/extension libraries** (OMPL, NVML/pynvml, pygame) may raise
+  ``RuntimeError`` or ``OSError`` during a partially-broken install even when
+  the package is importable by name.
+* **Matplotlib backend selection** can raise ``RuntimeError``.
+* **Compiled-backend entry points** (shapely/scipy) may raise ``AttributeError``
+  when a native wheel component is absent.
+
+The AST inventory ratchet in
+``tests/test_optional_import_guard_inventory.py`` must be updated to bless any
+new (justified) broad spelling; otherwise the test fails and blocks the change
+in review.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def try_import(name: str) -> ModuleType | None:
+    """Import ``name`` if available, otherwise return ``None``.
+
+    This is the canonical spelling for the common optional-dependency case. It
+    catches only :class:`ImportError` (which includes
+    :class:`ModuleNotFoundError`) and never swallows broader failures such as
+    ``RuntimeError``/``OSError``/``AttributeError`` -- those indicate a broken
+    install and should surface, not be masked as "missing dependency".
+
+    Parameters
+    ----------
+    name:
+        Dotted module name to import, e.g. ``"yaml"`` or
+        ``"shapely.geometry"``.
+
+    Returns
+    -------
+    ModuleType | None
+        The imported module, or ``None`` if it is not installed.
+
+    Examples
+    --------
+    >>> yaml = try_import("yaml")
+    >>> if yaml is None:
+    ...     pass  # degrade gracefully without the YAML backend
+    """
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        return None

--- a/robot_sf/research/orchestrator.py
+++ b/robot_sf/research/orchestrator.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 import psutil
 from loguru import logger
 
+from robot_sf.common.optional_import import try_import
 from robot_sf.research.aggregation import (
     aggregate_metrics,
     compute_completeness_score,
@@ -48,10 +49,7 @@ from robot_sf.research.metadata import collect_reproducibility_metadata
 from robot_sf.research.report_template import MarkdownReportRenderer
 from robot_sf.research.statistics import evaluate_hypothesis
 
-try:
-    import yaml  # type: ignore
-except ImportError:  # pragma: no cover - optional dependency
-    yaml = None  # type: ignore[assignment]
+yaml = try_import("yaml")  # optional dependency; None when unavailable
 
 
 def _iso() -> str:  # small helper

--- a/robot_sf/telemetry/recommendations.py
+++ b/robot_sf/telemetry/recommendations.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from robot_sf.common.optional_import import try_import
 from robot_sf.telemetry.models import (
     PerformanceRecommendation,
     RecommendationSeverity,
@@ -17,10 +18,7 @@ from robot_sf.telemetry.models import (
 if TYPE_CHECKING:  # pragma: no cover - hints only
     from collections.abc import Iterable
 
-try:  # pragma: no cover - optional dependency
-    import psutil  # type: ignore
-except ImportError:  # pragma: no cover - psutil not installed
-    psutil = None  # type: ignore
+psutil = try_import("psutil")  # optional dependency; None when unavailable
 
 
 @dataclass(slots=True)

--- a/robot_sf/telemetry/sampler.py
+++ b/robot_sf/telemetry/sampler.py
@@ -11,23 +11,17 @@ from typing import TYPE_CHECKING, Protocol
 
 from loguru import logger
 
-try:  # pragma: no cover - optional dependency
-    import psutil  # type: ignore
-except ImportError:  # pragma: no cover - psutil not installed
-    psutil = None  # type: ignore
+from robot_sf.common.optional_import import try_import
+from robot_sf.telemetry.gpu import collect_gpu_sample
+from robot_sf.telemetry.models import TelemetrySnapshot
 
-try:  # pragma: no cover - platform dependent fallback
-    import resource
-except ImportError:  # pragma: no cover - resource missing on some platforms
-    resource = None  # type: ignore
+psutil = try_import("psutil")  # optional dependency; None when unavailable
+resource = try_import("resource")  # platform-dependent stdlib (Unix); None elsewhere
 
 if psutil is not None:  # pragma: no branch - constant per interpreter
     _PSUTIL_ERRORS: tuple[type[Exception], ...] = (psutil.Error, OSError)
 else:  # pragma: no cover - psutil missing
     _PSUTIL_ERRORS = (OSError,)
-
-from robot_sf.telemetry.gpu import collect_gpu_sample
-from robot_sf.telemetry.models import TelemetrySnapshot
 
 if TYPE_CHECKING:  # pragma: no cover - import hints only
     from collections.abc import Callable

--- a/scripts/dev/generate_optional_import_snapshot.py
+++ b/scripts/dev/generate_optional_import_snapshot.py
@@ -59,9 +59,16 @@ NOTES = {
     "AttributeError+ImportError+OSError": ("Blessed broad catch: optional registry boundary."),
     "AttributeError+ImportError+RuntimeError": ("Blessed broad catch: optional native boundary."),
     "AttributeError+ImportError+TypeError": ("Blessed broad catch: optional dispatch boundary."),
+    "AttributeError+ImportError+OSError+RuntimeError+TypeError+ValueError": (
+        "Blessed broad catch: defensive visualization ingest boundary."
+    ),
     "ImportError+OSError+RuntimeError+TypeError+ValueError": (
         "Blessed broad catch: defensive JSON/config ingest boundary. Review "
         "carefully before adding more."
+    ),
+    "ImportError+OSError+RuntimeError+TypeError+ValueError+json.JSONDecodeError": (
+        "Blessed broad catch: defensive resource-lifecycle ingest boundary. "
+        "Review carefully before adding more."
     ),
     "ImportError+OSError+RuntimeError+ValueError": (
         "Blessed broad catch: defensive ingest boundary. Review carefully."

--- a/scripts/dev/generate_optional_import_snapshot.py
+++ b/scripts/dev/generate_optional_import_snapshot.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Regenerate the optional-import guard snapshot (issue #4990).
+
+Walks ``robot_sf/`` with the same AST collector used by
+``tests/test_optional_import_guard_inventory.py`` and rewrites
+``tests/fixtures/optional_import_guards.json`` in place.
+
+Usage::
+
+    uv run python scripts/dev/generate_optional_import_snapshot.py
+
+Use this after intentionally adding/removing/blessing an optional-import guard.
+The PR must explain the delta (new dependency, justified broad catch, or a
+migration onto ``robot_sf.common.optional_import.try_import``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "optional_import_guards.json"
+TEST_MODULE = REPO_ROOT / "tests" / "test_optional_import_guard_inventory.py"
+
+# Human-readable justification for each observed spelling. New broad catches
+# must be added here when blessed, so the snapshot explains *why* the broad
+# catch is legitimate rather than a swallowed bug.
+NOTES = {
+    "ImportError": (
+        "Pure optional-import. Prefer "
+        "robot_sf.common.optional_import.try_import for new plain cases."
+    ),
+    "ModuleNotFoundError": (
+        "Pure optional-import (ModuleNotFoundError spelling). Prefer "
+        "robot_sf.common.optional_import.try_import for new plain cases."
+    ),
+    "ImportError+ModuleNotFoundError": (
+        "Optional-import covering both ImportError spellings; acceptable. "
+        "Prefer try_import for new plain cases."
+    ),
+    "ImportError+RuntimeError": (
+        "Blessed broad catch: guarded plotting / native-lib load may raise "
+        "RuntimeError. Do not collapse to ImportError."
+    ),
+    "ImportError+OSError": ("Blessed broad catch: native-lib / filesystem load may raise OSError."),
+    "ImportError+SyntaxError": (
+        "Blessed broad catch: parser/extension load may surface SyntaxError."
+    ),
+    "AttributeError+ImportError": (
+        "Blessed broad catch: compiled-backend entry point may raise "
+        "AttributeError when a native wheel component is absent."
+    ),
+    "AttributeError+ImportError+ModuleNotFoundError": (
+        "Blessed broad catch: registry/compiled-backend boundary."
+    ),
+    "AttributeError+ImportError+OSError": ("Blessed broad catch: optional registry boundary."),
+    "AttributeError+ImportError+RuntimeError": ("Blessed broad catch: optional native boundary."),
+    "AttributeError+ImportError+TypeError": ("Blessed broad catch: optional dispatch boundary."),
+    "ImportError+OSError+RuntimeError+TypeError+ValueError": (
+        "Blessed broad catch: defensive JSON/config ingest boundary. Review "
+        "carefully before adding more."
+    ),
+    "ImportError+OSError+RuntimeError+ValueError": (
+        "Blessed broad catch: defensive ingest boundary. Review carefully."
+    ),
+    "AttributeError+ImportError+IndexError+KeyError+OSError+RuntimeError+TypeError+ValueError": (
+        "Blessed broad catch: defensive best-effort ingest boundary. Very broad; "
+        "do not extend further without strong justification."
+    ),
+    "AttributeError+ImportError+ModuleNotFoundError+OSError+RuntimeError+SyntaxError+TypeError+ValueError": (
+        "Blessed broad catch: defensive best-effort boundary. Very broad; do not "
+        "extend further without strong justification."
+    ),
+}
+
+
+def _load_collector() -> tuple[Path, object]:
+    """Import the collector from the test module without a package context."""
+    spec = importlib.util.spec_from_file_location("_optional_import_ratchet_collector", TEST_MODULE)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load collector from {TEST_MODULE}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return REPO_ROOT / "robot_sf", module.collect_optional_import_guards
+
+
+def main() -> int:
+    """Regenerate the optional-import guard snapshot fixture from robot_sf/."""
+    scanned_root, collect = _load_collector()
+    inventory = collect(scanned_root)
+
+    spellings = {}
+    for key, info in sorted(inventory.items()):
+        spellings[key] = {
+            "count_ceiling": info["count"],
+            "has_as_count": info["has_as_count"],
+            "pragma_no_cover_count": info["pragma_no_cover_count"],
+            "blessed": True,
+            "note": NOTES.get(
+                key,
+                "Blessed broad catch. Add a justification note in "
+                "scripts/dev/generate_optional_import_snapshot.py when blessing.",
+            ),
+            "samples": info["samples"],
+        }
+
+    document = {
+        "description": (
+            "AST inventory snapshot of optional-import guards in robot_sf/ "
+            "(issue #4990). Enforced by "
+            "tests/test_optional_import_guard_inventory.py. Regenerate with "
+            "scripts/dev/generate_optional_import_snapshot.py. Each 'count_ceiling' "
+            "is pinned to the exact observed count; growth fails the ratchet."
+        ),
+        "scanned_root": "robot_sf",
+        "tracked_exceptions": ["ImportError", "ModuleNotFoundError"],
+        "spelling_key": (
+            "Caught exception type names, sorted and joined by '+'. The "
+            "'as <alias>' name is intentionally NOT part of the key."
+        ),
+        "total_guards": sum(int(v["count_ceiling"]) for v in spellings.values()),
+        "spellings": spellings,
+    }
+
+    FIXTURE.write_text(json.dumps(document, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    print(f"Wrote {FIXTURE.relative_to(REPO_ROOT)}")
+    print(f"  total guards: {document['total_guards']}")
+    print(f"  distinct spellings: {len(spellings)}")
+    for key, info in sorted(spellings.items()):
+        print(f"    {int(info['count_ceiling']):3d}  {key}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/optional_import_guards.json
+++ b/tests/fixtures/optional_import_guards.json
@@ -64,7 +64,7 @@
       "has_as_count": 1,
       "pragma_no_cover_count": 0,
       "blessed": true,
-      "note": "Blessed broad catch. Add a justification note in scripts/dev/generate_optional_import_snapshot.py when blessing.",
+      "note": "Blessed broad catch: defensive visualization ingest boundary.",
       "samples": [
         "robot_sf/benchmark/visualization.py:466"
       ]
@@ -191,12 +191,12 @@
         "robot_sf/benchmark/orca_preflight.py:89"
       ]
     },
-    "ImportError+OSError+RuntimeError+TypeError+ValueError": {
+    "ImportError+OSError+RuntimeError+TypeError+ValueError+json.JSONDecodeError": {
       "count_ceiling": 1,
       "has_as_count": 1,
       "pragma_no_cover_count": 0,
       "blessed": true,
-      "note": "Blessed broad catch: defensive JSON/config ingest boundary. Review carefully before adding more.",
+      "note": "Blessed broad catch: defensive resource-lifecycle ingest boundary. Review carefully before adding more.",
       "samples": [
         "robot_sf/benchmark/camera_ready/resource_lifecycle.py:345"
       ]

--- a/tests/fixtures/optional_import_guards.json
+++ b/tests/fixtures/optional_import_guards.json
@@ -1,0 +1,256 @@
+{
+  "description": "AST inventory snapshot of optional-import guards in robot_sf/ (issue #4990). Enforced by tests/test_optional_import_guard_inventory.py. Regenerate with scripts/dev/generate_optional_import_snapshot.py. Each 'count_ceiling' is pinned to the exact observed count; growth fails the ratchet.",
+  "scanned_root": "robot_sf",
+  "tracked_exceptions": [
+    "ImportError",
+    "ModuleNotFoundError"
+  ],
+  "spelling_key": "Caught exception type names, sorted and joined by '+'. The 'as <alias>' name is intentionally NOT part of the key.",
+  "total_guards": 100,
+  "spellings": {
+    "AttributeError+ImportError": {
+      "count_ceiling": 2,
+      "has_as_count": 1,
+      "pragma_no_cover_count": 0,
+      "blessed": true,
+      "note": "Blessed broad catch: compiled-backend entry point may raise AttributeError when a native wheel component is absent.",
+      "samples": [
+        "robot_sf/baselines/sicnav.py:376",
+        "robot_sf/planner/socnav.py:777"
+      ]
+    },
+    "AttributeError+ImportError+IndexError+KeyError+OSError+RuntimeError+TypeError+ValueError": {
+      "count_ceiling": 1,
+      "has_as_count": 1,
+      "pragma_no_cover_count": 0,
+      "blessed": true,
+      "note": "Blessed broad catch: defensive best-effort ingest boundary. Very broad; do not extend further without strong justification.",
+      "samples": [
+        "robot_sf/benchmark/full_classic/render_sim_view.py:285"
+      ]
+    },
+    "AttributeError+ImportError+ModuleNotFoundError": {
+      "count_ceiling": 1,
+      "has_as_count": 0,
+      "pragma_no_cover_count": 0,
+      "blessed": true,
+      "note": "Blessed broad catch: registry/compiled-backend boundary.",
+      "samples": [
+        "robot_sf/gym_env/snqi_proxy.py:139"
+      ]
+    },
+    "AttributeError+ImportError+ModuleNotFoundError+OSError+RuntimeError+SyntaxError+TypeError+ValueError": {
+      "count_ceiling": 1,
+      "has_as_count": 1,
+      "pragma_no_cover_count": 0,
+      "blessed": true,
+      "note": "Blessed broad catch: defensive best-effort boundary. Very broad; do not extend further without strong justification.",
+      "samples": [
+        "robot_sf/planner/socnav.py:642"
+      ]
+    },
+    "AttributeError+ImportError+OSError": {
+      "count_ceiling": 1,
+      "has_as_count": 0,
+      "pragma_no_cover_count": 1,
+      "blessed": true,
+      "note": "Blessed broad catch: optional registry boundary.",
+      "samples": [
+        "robot_sf/benchmark/cli.py:203"
+      ]
+    },
+    "AttributeError+ImportError+OSError+RuntimeError+TypeError+ValueError": {
+      "count_ceiling": 1,
+      "has_as_count": 1,
+      "pragma_no_cover_count": 0,
+      "blessed": true,
+      "note": "Blessed broad catch. Add a justification note in scripts/dev/generate_optional_import_snapshot.py when blessing.",
+      "samples": [
+        "robot_sf/benchmark/visualization.py:466"
+      ]
+    },
+    "AttributeError+ImportError+RuntimeError": {
+      "count_ceiling": 1,
+      "has_as_count": 0,
+      "pragma_no_cover_count": 0,
+      "blessed": true,
+      "note": "Blessed broad catch: optional native boundary.",
+      "samples": [
+        "robot_sf/benchmark/full_classic/render_sim_view.py:145"
+      ]
+    },
+    "AttributeError+ImportError+TypeError": {
+      "count_ceiling": 1,
+      "has_as_count": 1,
+      "pragma_no_cover_count": 0,
+      "blessed": true,
+      "note": "Blessed broad catch: optional dispatch boundary.",
+      "samples": [
+        "robot_sf/benchmark/uncertainty_source_readiness.py:333"
+      ]
+    },
+    "ImportError": {
+      "count_ceiling": 57,
+      "has_as_count": 11,
+      "pragma_no_cover_count": 17,
+      "blessed": true,
+      "note": "Pure optional-import. Prefer robot_sf.common.optional_import.try_import for new plain cases.",
+      "samples": [
+        "robot_sf/adversarial/certification.py:99",
+        "robot_sf/baselines/dr_mpc.py:109",
+        "robot_sf/baselines/dr_mpc.py:91",
+        "robot_sf/baselines/drl_vo.py:24",
+        "robot_sf/baselines/ppo.py:41",
+        "robot_sf/baselines/sac.py:14",
+        "robot_sf/baselines/sicnav.py:420",
+        "robot_sf/baselines/sicnav.py:298",
+        "robot_sf/benchmark/cli.py:191",
+        "robot_sf/benchmark/episode_replay_figure.py:37",
+        "robot_sf/benchmark/episode_replay_figure.py:50",
+        "robot_sf/benchmark/episode_replay_figure.py:57",
+        "robot_sf/benchmark/episode_replay_figure.py:852",
+        "robot_sf/benchmark/episode_replay_figure.py:890",
+        "robot_sf/benchmark/figures/export.py:155",
+        "robot_sf/benchmark/full_classic/encode.py:36",
+        "robot_sf/benchmark/full_classic/encode.py:86",
+        "robot_sf/benchmark/full_classic/orchestrator.py:72",
+        "robot_sf/benchmark/full_classic/plots.py:20",
+        "robot_sf/benchmark/full_classic/plots.py:52",
+        "robot_sf/benchmark/full_classic/plots.py:91",
+        "robot_sf/benchmark/full_classic/render_sim_view.py:46",
+        "robot_sf/benchmark/full_classic/render_sim_view.py:99",
+        "robot_sf/benchmark/full_classic/render_sim_view.py:157",
+        "robot_sf/benchmark/full_classic/validation.py:52",
+        "robot_sf/benchmark/full_classic/videos.py:28",
+        "robot_sf/benchmark/full_classic/videos.py:34",
+        "robot_sf/benchmark/full_classic/visual_deps.py:79",
+        "robot_sf/benchmark/full_classic/visual_deps.py:93",
+        "robot_sf/benchmark/full_classic/visuals.py:49",
+        "robot_sf/benchmark/helper_catalog.py:73",
+        "robot_sf/benchmark/live_forecast_replay_gate.py:953",
+        "robot_sf/benchmark/plots.py:28",
+        "robot_sf/benchmark/runner.py:47",
+        "robot_sf/benchmark/scenario_generator.py:48",
+        "robot_sf/benchmark/scenario_schema.py:25",
+        "robot_sf/benchmark/schema_validator.py:20",
+        "robot_sf/common/matplotlib_utils.py:62",
+        "robot_sf/common/optional_import.py:80",
+        "robot_sf/common/seed.py:47",
+        "robot_sf/feature_extractors/mamba_extractor.py:98",
+        "robot_sf/gym_env/env_config.py:302",
+        "robot_sf/maps/osm_zones_editor.py:72",
+        "robot_sf/nav/occupancy_grid.py:107",
+        "robot_sf/planner/classic_global_planner.py:47",
+        "robot_sf/planner/diffusion_policy.py:20",
+        "robot_sf/planner/ompl_geometric_adapter.py:193",
+        "robot_sf/planner/ompl_smoke.py:42",
+        "robot_sf/planner/ompl_smoke.py:252",
+        "robot_sf/planner/theta_star_v2.py:33",
+        "robot_sf/render/sim_view.py:34",
+        "robot_sf/sim/registry.py:145",
+        "robot_sf/telemetry/gpu.py:11",
+        "robot_sf/telemetry/tensorboard_adapter.py:20",
+        "robot_sf/telemetry/tensorboard_adapter.py:23",
+        "robot_sf/telemetry/visualization.py:100",
+        "robot_sf/training/diffusion_policy.py:33"
+      ]
+    },
+    "ImportError+ModuleNotFoundError": {
+      "count_ceiling": 14,
+      "has_as_count": 3,
+      "pragma_no_cover_count": 7,
+      "blessed": true,
+      "note": "Optional-import covering both ImportError spellings; acceptable. Prefer try_import for new plain cases.",
+      "samples": [
+        "robot_sf/adversarial/samplers.py:230",
+        "robot_sf/benchmark/distributions.py:131",
+        "robot_sf/benchmark/full_classic/visual_deps.py:58",
+        "robot_sf/benchmark/runner.py:41",
+        "robot_sf/benchmark/visualization.py:1189",
+        "robot_sf/gym_env/environment_factory.py:57",
+        "robot_sf/gym_env/environment_factory.py:175",
+        "robot_sf/models/registry.py:19",
+        "robot_sf/planner/socnav.py:28",
+        "robot_sf/planner/socnav.py:33",
+        "robot_sf/planner/socnav.py:38",
+        "robot_sf/planner/socnav.py:43",
+        "robot_sf/planner/socnav.py:67",
+        "robot_sf/planner/socnav.py:3467"
+      ]
+    },
+    "ImportError+OSError": {
+      "count_ceiling": 4,
+      "has_as_count": 1,
+      "pragma_no_cover_count": 2,
+      "blessed": true,
+      "note": "Blessed broad catch: native-lib / filesystem load may raise OSError.",
+      "samples": [
+        "robot_sf/benchmark/cli.py:3042",
+        "robot_sf/benchmark/cli.py:3076",
+        "robot_sf/benchmark/full_classic/visual_deps.py:45",
+        "robot_sf/benchmark/orca_preflight.py:89"
+      ]
+    },
+    "ImportError+OSError+RuntimeError+TypeError+ValueError": {
+      "count_ceiling": 1,
+      "has_as_count": 1,
+      "pragma_no_cover_count": 0,
+      "blessed": true,
+      "note": "Blessed broad catch: defensive JSON/config ingest boundary. Review carefully before adding more.",
+      "samples": [
+        "robot_sf/benchmark/camera_ready/resource_lifecycle.py:345"
+      ]
+    },
+    "ImportError+OSError+RuntimeError+ValueError": {
+      "count_ceiling": 1,
+      "has_as_count": 1,
+      "pragma_no_cover_count": 0,
+      "blessed": true,
+      "note": "Blessed broad catch: defensive ingest boundary. Review carefully.",
+      "samples": [
+        "robot_sf/benchmark/camera_ready/resource_lifecycle.py:245"
+      ]
+    },
+    "ImportError+RuntimeError": {
+      "count_ceiling": 5,
+      "has_as_count": 0,
+      "pragma_no_cover_count": 2,
+      "blessed": true,
+      "note": "Blessed broad catch: guarded plotting / native-lib load may raise RuntimeError. Do not collapse to ImportError.",
+      "samples": [
+        "robot_sf/baselines/dr_mpc.py:187",
+        "robot_sf/baselines/sicnav.py:344",
+        "robot_sf/baselines/sicnav.py:530",
+        "robot_sf/benchmark/cli.py:3211",
+        "robot_sf/training/multi_extractor_analysis.py:22"
+      ]
+    },
+    "ImportError+SyntaxError": {
+      "count_ceiling": 3,
+      "has_as_count": 1,
+      "pragma_no_cover_count": 0,
+      "blessed": true,
+      "note": "Blessed broad catch: parser/extension load may surface SyntaxError.",
+      "samples": [
+        "robot_sf/benchmark/uncertainty_source_readiness.py:251",
+        "robot_sf/benchmark/uncertainty_source_readiness.py:401",
+        "robot_sf/benchmark/uncertainty_source_readiness.py:417"
+      ]
+    },
+    "ModuleNotFoundError": {
+      "count_ceiling": 6,
+      "has_as_count": 2,
+      "pragma_no_cover_count": 3,
+      "blessed": true,
+      "note": "Pure optional-import (ModuleNotFoundError spelling). Prefer robot_sf.common.optional_import.try_import for new plain cases.",
+      "samples": [
+        "robot_sf/benchmark/parquet_export.py:18",
+        "robot_sf/common/hardware.py:129",
+        "robot_sf/planner/learned_short_horizon_predictor.py:424",
+        "robot_sf/planner/social_navigation_pyenvs_force_model.py:39",
+        "robot_sf/research/metadata.py:54",
+        "robot_sf/training/hardware_probe.py:21"
+      ]
+    }
+  }
+}

--- a/tests/test_optional_import_guard_inventory.py
+++ b/tests/test_optional_import_guard_inventory.py
@@ -1,0 +1,305 @@
+"""AST inventory ratchet for optional-import guards (issue #4990).
+
+This test walks ``robot_sf/`` and collects every ``except`` handler whose caught
+exception types include ``ImportError`` or ``ModuleNotFoundError``. It then
+compares the observed inventory against a committed allow-list snapshot at
+``tests/fixtures/optional_import_guards.json``.
+
+Why an inventory ratchet instead of a mass rewrite?
+---------------------------------------------------
+A blanket rewrite to a single ``except ImportError`` is **not** safe: several
+guards intentionally also catch ``RuntimeError``/``OSError``/``AttributeError``
+for real reasons (guarded plotting, native-lib load failures). So this test is a
+*ratchet*: it characterizes today's tree and fails only when a **new, un-blessed
+spelling** appears or when the count of an existing spelling **grows**, forcing a
+reviewer to either adopt :func:`robot_sf.common.optional_import.try_import` or
+explicitly bless a justified broad catch in the snapshot.
+
+Acceptance contract (issue #4990)
+---------------------------------
+* Introducing a new optional-import guard spelling not in the allow-list makes
+  the test fail with a clear message.
+* Existing intentional broad catches remain unchanged and blessed in the
+  snapshot.
+* No runtime behavior change (this is a static AST check).
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCANNED_ROOT = REPO_ROOT / "robot_sf"
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "optional_import_guards.json"
+
+# Exception type names this ratchet tracks. ``ModuleNotFoundError`` is a
+# subclass of ``ImportError``, but the codebase spells both; we track either.
+_TRACKED = {"ImportError", "ModuleNotFoundError"}
+
+
+def _caught_type_names(node: ast.ExceptHandler) -> list[str]:
+    """Return the sorted, de-duplicated names of exceptions a handler catches.
+
+    Returns an empty list for handlers whose catch clause is not a simple name
+    or tuple of names (e.g. ``except SomeError()``); those are out of scope.
+    """
+    t = node.type
+    if t is None:
+        return []
+    if isinstance(t, ast.Name):
+        names = [t.id]
+    elif isinstance(t, ast.Tuple):
+        names = [e.id for e in t.elts if isinstance(e, ast.Name)]
+    else:
+        return []
+    return sorted(set(names))
+
+
+def _spelling_key(names: list[str]) -> str:
+    """Normalize a caught-type-set into a stable allow-list key.
+
+    The alias name (``as exc`` vs ``as e``) is deliberately *not* part of the
+    key: it is cosmetic and does not change which exceptions are swallowed. The
+    meaningful axis -- "does this guard swallow too much?" -- is the set of
+    caught types.
+    """
+    return "+".join(names)
+
+
+def _has_pragma(line: str) -> bool:
+    """True if a source line carries a ``# pragma: no cover`` marker."""
+    return bool(re.search(r"#\s*pragma:\s*no cover", line))
+
+
+def collect_optional_import_guards(root: Path) -> dict[str, dict[str, object]]:
+    """Walk ``root`` and return the optional-import guard inventory.
+
+    The returned mapping is keyed by spelling (caught-type-set) and records the
+    current count plus one sample ``file:line`` location per occurrence.
+    """
+    occurrences: dict[str, list[str]] = defaultdict(list)
+    has_as_counts: Counter[str] = Counter()
+    pragma_counts: Counter[str] = Counter()
+
+    for path in sorted(root.rglob("*.py")):
+        try:
+            src = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        try:
+            tree = ast.parse(src, filename=str(path))
+        except SyntaxError:
+            continue
+        lines = src.splitlines()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ExceptHandler):
+                continue
+            names = _caught_type_names(node)
+            if not (_TRACKED & set(names)):
+                continue
+            key = _spelling_key(names)
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            occurrences[key].append(f"{rel}:{node.lineno}")
+            if node.name:
+                has_as_counts[key] += 1
+            handler_line = lines[node.lineno - 1] if node.lineno <= len(lines) else ""
+            if _has_pragma(handler_line):
+                pragma_counts[key] += 1
+
+    inventory: dict[str, dict[str, object]] = {}
+    for key, locs in sorted(occurrences.items()):
+        inventory[key] = {
+            "count": len(locs),
+            "has_as_count": has_as_counts[key],
+            "pragma_no_cover_count": pragma_counts[key],
+            "samples": locs,
+        }
+    return inventory
+
+
+def _load_fixture() -> dict[str, object]:
+    if not FIXTURE.exists():
+        pytest.fail(
+            f"Snapshot fixture missing: {FIXTURE.relative_to(REPO_ROOT)}.\n"
+            "Generate it with: "
+            "`uv run python scripts/dev/generate_optional_import_snapshot.py`."
+        )
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+class TestOptionalImportGuardInventory:
+    """Characterization ratchet over optional-import guards in ``robot_sf/``."""
+
+    def test_no_new_unblessed_spelling_and_no_count_growth(self) -> None:
+        """The inventory must stay within the blessed snapshot envelope.
+
+        Fails (with an actionable message) when:
+          * a caught-type-set appears that is not in the allow-list, or
+          * the count of an existing spelling exceeds its blessed ceiling.
+
+        Decreasing a count is allowed (the ratchet only blocks regression); the
+        message will note the lower observed number so the snapshot can be
+        tightened at leisure.
+        """
+        fixture = _load_fixture()
+        spellings = fixture.get("spellings", {})
+        if not isinstance(spellings, dict) or not spellings:
+            pytest.fail(
+                f"Snapshot fixture {FIXTURE.relative_to(REPO_ROOT)} has no "
+                "'spellings' mapping; regenerate it."
+            )
+
+        observed = collect_optional_import_guards(SCANNED_ROOT)
+
+        problems: list[str] = []
+
+        # 1. New or grown spellings -> fail.
+        for key, info in sorted(observed.items()):
+            observed_count = int(info["count"])  # type: ignore[arg-type]
+            if key not in spellings:
+                problems.append(
+                    f"NEW unblessed optional-import spelling '{key}' "
+                    f"({observed_count} occurrence(s)). Either rewrite the plain "
+                    "optional-import case(s) using "
+                    "`robot_sf.common.optional_import.try_import`, or bless this "
+                    "spelling in tests/fixtures/optional_import_guards.json with a "
+                    "one-line justification. Locations:\n    "
+                    + "\n    ".join(str(x) for x in info["samples"])  # type: ignore[arg-type]
+                )
+                continue
+            blessed = spellings[key]
+            ceiling = int(blessed.get("count_ceiling", blessed.get("count", 0)))
+            if observed_count > ceiling:
+                problems.append(
+                    f"RATCHET VIOLATION: spelling '{key}' grew from ceiling "
+                    f"{ceiling} to {observed_count}. Prefer "
+                    "`robot_sf.common.optional_import.try_import` for new plain "
+                    "optional imports, or raise the ceiling with justification. "
+                    "Locations:\n    " + "\n    ".join(str(x) for x in info["samples"])  # type: ignore[arg-type]
+                )
+
+        # 2. Stale fixture entries (spelling no longer present) and lower counts
+        #    are informational only: they never fail CI so removing guards is
+        #    always safe. Surface them via the assertion message when something
+        #    else already failed, to help tighten the snapshot.
+        shrink_notes: list[str] = []
+        for key, blessed in sorted(spellings.items()):
+            ceiling = int(blessed.get("count_ceiling", blessed.get("count", 0)))
+            if key not in observed:
+                shrink_notes.append(
+                    f"  - spelling '{key}' no longer present in robot_sf/ "
+                    f"(ceiling was {ceiling}); safe to remove from snapshot."
+                )
+            elif int(observed[key]["count"]) < ceiling:  # type: ignore[index,arg-type]
+                shrink_notes.append(
+                    f"  - spelling '{key}' shrank from ceiling {ceiling} to "
+                    f"{observed[key]['count']}; safe to lower the ceiling."  # type: ignore[index]
+                )
+
+        if problems:
+            msg = "\n".join(problems)
+            if shrink_notes:
+                msg += "\n\nShrink opportunities (not failures):\n" + "\n".join(shrink_notes)
+            pytest.fail(msg)
+
+    def test_snapshot_matches_collector_output(self) -> None:
+        """The committed counts must equal what the collector reports today.
+
+        This keeps the snapshot honest: every ceiling is pinned to the exact
+        current count (a true characterization), so any single addition or
+        removal surfaces as a diff the author must consciously update. When the
+        change is intentional, regenerate the fixture with
+        ``scripts/dev/generate_optional_import_snapshot.py`` and explain the
+        delta in the PR.
+        """
+        fixture = _load_fixture()
+        spellings = fixture.get("spellings", {})
+        observed = collect_optional_import_guards(SCANNED_ROOT)
+
+        mismatches: list[str] = []
+        all_keys = sorted(set(spellings) | set(observed))
+        for key in all_keys:
+            observed_count = int(observed.get(key, {}).get("count", 0))  # type: ignore[union-attr]
+            if key in spellings:
+                ceiling = int(spellings[key].get("count_ceiling", spellings[key].get("count", 0)))
+            else:
+                ceiling = -1
+            if observed_count != ceiling:
+                mismatches.append(f"  - '{key}': snapshot={ceiling} observed={observed_count}")
+
+        if mismatches:
+            pytest.fail(
+                "Optional-import guard snapshot is out of sync with robot_sf/.\n"
+                "If this change is intentional, regenerate and commit:\n"
+                "  uv run python scripts/dev/generate_optional_import_snapshot.py\n"
+                "Delta (snapshot_ceiling -> observed_count):\n" + "\n".join(mismatches)
+            )
+
+
+class TestTryImportHelper:
+    """Direct contract tests for the canonical helper."""
+
+    def test_returns_module_when_available(self) -> None:
+        from robot_sf.common.optional_import import try_import
+
+        module = try_import("json")
+        import json as stdlib_json
+
+        assert module is stdlib_json
+
+    def test_returns_none_when_missing(self) -> None:
+        from robot_sf.common.optional_import import try_import
+
+        result = try_import("definitely_not_a_real_module_zzz_4990")
+        assert result is None
+
+    def test_returns_submodule_when_available(self) -> None:
+        import json as stdlib_json
+
+        from robot_sf.common.optional_import import try_import
+
+        decoder = try_import("json.decoder")
+        assert decoder is stdlib_json.decoder
+
+    def test_does_not_swallow_runtime_error(self) -> None:
+        """A broken-but-importable dependency must surface, not be masked.
+
+        This is the core safety property: ``try_import`` catches only
+        ``ImportError`` and never broader failures.
+        """
+        import sys
+
+        from robot_sf.common.optional_import import try_import
+
+        # Inject a fake module that raises RuntimeError on attribute access to
+        # simulate a broken native dependency, then prove RuntimeError survives.
+        fake_name = "_fake_broken_optional_dep_4990"
+
+        class _BrokenLoader:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == fake_name:
+                    from importlib.machinery import ModuleSpec
+
+                    return ModuleSpec(fake_name, self)
+                return None
+
+            def create_module(self, spec):
+                raise RuntimeError("simulated broken native dependency")
+
+            def exec_module(self, module):
+                raise RuntimeError("simulated broken native dependency")
+
+        loader = _BrokenLoader()
+        sys.meta_path.insert(0, loader)
+        try:
+            with pytest.raises(RuntimeError, match="simulated broken native dependency"):
+                try_import(fake_name)
+        finally:
+            sys.meta_path.remove(loader)
+            sys.modules.pop(fake_name, None)

--- a/tests/test_optional_import_guard_inventory.py
+++ b/tests/test_optional_import_guard_inventory.py
@@ -43,19 +43,35 @@ FIXTURE = REPO_ROOT / "tests" / "fixtures" / "optional_import_guards.json"
 _TRACKED = {"ImportError", "ModuleNotFoundError"}
 
 
+def _exception_name(node: ast.expr) -> str | None:
+    """Return a dotted exception name for a simple AST exception expression."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _exception_name(node.value)
+        return f"{parent}.{node.attr}" if parent is not None else None
+    return None
+
+
 def _caught_type_names(node: ast.ExceptHandler) -> list[str]:
     """Return the sorted, de-duplicated names of exceptions a handler catches.
 
-    Returns an empty list for handlers whose catch clause is not a simple name
-    or tuple of names (e.g. ``except SomeError()``); those are out of scope.
+    Returns an empty list for handlers whose catch clause is not a simple name,
+    dotted attribute, or tuple of them (e.g. ``except SomeError()``); those are
+    out of scope.
     """
     t = node.type
     if t is None:
         return []
-    if isinstance(t, ast.Name):
-        names = [t.id]
+    if isinstance(t, (ast.Name, ast.Attribute)):
+        name = _exception_name(t)
+        names = [name] if name is not None else []
     elif isinstance(t, ast.Tuple):
-        names = [e.id for e in t.elts if isinstance(e, ast.Name)]
+        names = []
+        for element in t.elts:
+            name = _exception_name(element)
+            if name is not None:
+                names.append(name)
     else:
         return []
     return sorted(set(names))
@@ -135,6 +151,18 @@ def _load_fixture() -> dict[str, object]:
 
 class TestOptionalImportGuardInventory:
     """Characterization ratchet over optional-import guards in ``robot_sf/``."""
+
+    def test_collector_preserves_dotted_exception_names(self) -> None:
+        """A qualified broad exception must not be collapsed into ImportError."""
+        tree = ast.parse(
+            "try:\n"
+            "    import optional_dep\n"
+            "except (ImportError, native_loader.LoadError):\n"
+            "    optional_dep = None\n"
+        )
+        handler = next(node for node in ast.walk(tree) if isinstance(node, ast.ExceptHandler))
+
+        assert _caught_type_names(handler) == ["ImportError", "native_loader.LoadError"]
 
     def test_no_new_unblessed_spelling_and_no_count_growth(self) -> None:
         """The inventory must stay within the blessed snapshot envelope.


### PR DESCRIPTION
## What

Implements issue #4990 — an **AST inventory ratchet** for optional-import guards in `robot_sf/` plus a **canonical `try_import` helper** and a small demonstration migration. Closes #4990.

The optional-dependency import guards in `robot_sf/` had drifted into ~40 distinct spellings (96+ occurrences). The inconsistency makes it easy to introduce a guard that *silently swallows too much* (a bug hiding as an "optional import"), with nothing flagging a new variant in review. This PR adds that gate. Per the issue's explicit scoping constraint, this is a **ratchet + canonical helper, not a mass rewrite**: intentional broad catches (RuntimeError/OSError/AttributeError) remain unchanged and blessed.

## Why

- **Catch the dangerous case in review.** A new guard that swallows `Exception`/`RuntimeError`/`SystemExit` under the label "optional import" is exactly the bug class this prevents. The ratchet now fails CI on any new, unblessed spelling.
- **Standardize the safe case.** The common "import if available else `None`" pattern gets one blessed spelling (`try_import`), so review attention concentrates on the few legitimately-broad catches.
- **No behavior change.** This is a static AST characterization plus a no-semantic-change migration.

## Changes

| File | Change |
| --- | --- |
| `robot_sf/common/optional_import.py` | New canonical `try_import(name) -> ModuleType \| None` helper + doc note on when a broader `except` is legitimate (native-lib load, matplotlib backend, compiled-backend entry points). |
| `tests/test_optional_import_guard_inventory.py` | New AST ratchet: walks `robot_sf/`, collects every `except` handler catching `ImportError`/`ModuleNotFoundError`, compares normalized caught-type-sets against the snapshot. Plus direct contract tests for `try_import` (incl. a "does not swallow RuntimeError" property test). |
| `tests/fixtures/optional_import_guards.json` | Committed snapshot of the current tree (100 guards, 16 distinct spellings), each with a `count_ceiling`, justification `note`, and sample locations. |
| `scripts/dev/generate_optional_import_snapshot.py` | Regenerator that reuses the test's collector, so the fixture can never drift from what the test enforces. |
| `robot_sf/research/orchestrator.py` | Migrate `yaml` onto `try_import`. |
| `robot_sf/telemetry/recommendations.py` | Migrate `psutil` onto `try_import`. |
| `robot_sf/telemetry/sampler.py` | Migrate `psutil` and `resource` onto `try_import` (also moved two first-party imports into the import block to keep ruff `E402` clean). |

The snapshot is keyed on the **caught exception type-set** (sorted, joined by `+`). The `as <alias>` name is deliberately *not* part of the key — it is cosmetic and does not change which exceptions are swallowed; the meaningful axis for "does this guard swallow too much?" is the set of caught types.

## Acceptance criteria (from #4990)

- [x] **Introducing a new optional-import guard spelling not in the allow-list makes the test fail with a clear message.** Verified by temporarily adding `except (ImportError, SystemExit):` → the test failed with:
  > `NEW unblessed optional-import spelling 'ImportError+SystemExit' (1 occurrence(s)). Either rewrite the plain optional-import case(s) using robot_sf.common.optional_import.try_import, or bless this spelling in tests/fixtures/optional_import_guards.json with a one-line justification. Locations: robot_sf/_tmp_ratchet_probe.py:4`
- [x] **Existing intentional broad catches remain unchanged and blessed in the snapshot.** All `ImportError+RuntimeError`, `ImportError+OSError`, `AttributeError+ImportError`, the defensive ingest boundaries, etc. are untouched in source and blessed with justification notes in the fixture.
- [x] **No runtime behavior change.** `try_import` catches only `ImportError` (which includes `ModuleNotFoundError`) — identical to the migrated `except ImportError:` guards — and the property test proves it does *not* swallow `RuntimeError` from a broken native dependency.

## Evidence / validation (CPU only)

Exact command from the issue:
```
uv run pytest tests/test_optional_import_guard_inventory.py -v
# 6 passed in ~3.3s
```

Ratchet negative checks (run during development, then reverted — not committed):
- New spelling `ImportError+SystemExit` → `test_no_new_unblessed_spelling_and_no_count_growth` FAILED with the message shown above.
- Count growth of `ImportError` (61 → 62) → `test_snapshot_matches_collector_output` FAILED with `'ImportError': snapshot=61 observed=62`.

Ruff (changed files):
```
ruff check robot_sf/common/optional_import.py robot_sf/research/orchestrator.py \
  robot_sf/telemetry/recommendations.py robot_sf/telemetry/sampler.py \
  tests/test_optional_import_guard_inventory.py scripts/dev/generate_optional_import_snapshot.py
# All checks passed!
```

Behavior-preservation smoke (migrated modules import identically; psutil present resolves to real module, psutil-missing path still degrades):
```
python -c "import robot_sf.telemetry.recommendations, robot_sf.telemetry.sampler, robot_sf.research.orchestrator; ..."
# recommendations.psutil/sampler.psutil/sampler.resource/orchestrator.yaml all resolve correctly;
# sampler._PSUTIL_ERRORS == (psutil.Error, OSError)
```
Existing module tests still green, including the psutil-missing degradation path:
```
pytest tests/test_tracking/test_telemetry.py tests/test_tracking/test_gpu_telemetry.py tests/test_optional_import_guard_inventory.py -q
# 10 passed
```
Notably `test_sampler_emits_fallback_notes_when_psutil_missing` passes, confirming the `try_import` migration preserves degraded behavior.

## Snapshot delta

Pre-migration tree had **104** tracked guards; post-migration the committed snapshot pins **100** (16 distinct spellings). The 4-guard reduction is exactly the demonstration migration onto `try_import` (`yaml`, `psutil` ×2, `resource`) — those no longer appear as `except ImportError` handlers. The intentional broad catches are unchanged.

## Scope / what is NOT done (follow-up, not required by this issue)

- No mass migration of the remaining ~57 plain `except ImportError` cases onto `try_import`. The issue explicitly scoped this to "a small, clearly-safe handful" to demonstrate the helper; a follow-up issue can migrate more incrementally (each batch lowers the `ImportError` ceiling, which the ratchet tracks).
- `robot_sf/telemetry/gpu.py` was deliberately left as-is: its `try/except/else` captures the import error string (`_NVML_ERROR`), which is not the plain `name = None` pattern. This is a good example (cited in the helper docstring) of when *not* to use `try_import`.

## Mode classification

`native` — real AST analysis of the actual `robot_sf/` source tree; no fallback/degraded execution. Snapshot is a characterization of current `main` (commit in branch history).

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Closes #4990
