### PR TITLE
Issue #4972: decouple pedestrian desired speed from spawn speed + speed-tier axis (cheap-lane worker)

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -12,6 +12,37 @@ The RobotSF benchmark system uses a consolidated schema management approach to e
 
 **See also**: [SNQI Weight Tools](./snqi-weight-tools/README.md) for weight recomputation and optimization, and [Distribution Plots](./distribution_plots.md) for visualization guidance.
 
+## Pedestrian Walking-Speed Calibration
+
+**Caveat for interpreting benchmark results.** The default simulated pedestrian
+walks at approximately **0.65 m/s** for the whole episode. This is a side effect
+of coupling the desired (preferred) walking speed to the spawn speed: the
+spawn velocity defaults to 0.5 m/s (`PedSpawnConfig.initial_speed`) and the
+goal-driving speed is derived as `peds_speed_mult * initial_speed` (1.3 × 0.5).
+This is roughly **half** the ~1.3 m/s preferred walking speed reported for
+unimpeded adults (Moussaïd et al. 2010, "The walking behaviour of pedestrian
+social groups", doi:10.1371/journal.pone.0010047). Two consequences:
+
+1. The default interaction regime is systematically gentler/slower than typical
+   sidewalk traffic, which flatters reactive planners (more time to react).
+2. Coupling desired speed to *spawn* speed is surprising: making pedestrians
+   walk faster required spawning them faster.
+
+Until a major campaign re-base, the **legacy default is intentionally preserved**
+so existing benchmark numbers stay reproducible. Issue #4972 adds a decoupled
+*desired-speed* axis and a **speed-tier** selector (`slow` / `typical` / `brisk`)
+on `SimulationSettings` (`ped_speed_tier`) and `SceneConfig`
+(`desired_speed_mean` / `desired_speed_std`):
+
+- `slow` (~0.65 m/s) reproduces the legacy default as an explicit tier value;
+- `typical` (~1.3 m/s) matches the literature preferred walking speed;
+- `brisk` (~1.6 m/s) stress-tests reactive planners.
+
+Benchmark reports and comparisons that vary pedestrian pace **must** record the
+speed tier or desired-speed distribution alongside results, and should treat any
+ranking computed only at the slow default as conditional on that regime. See
+`robot_sf/sim/pedestrian_speed_tiers.py` for the tier mapping.
+
 ## Local Smoke Benchmark Demo
 
 For a quick local sanity check that the benchmark runner can execute a small map scenario with two

--- a/fast-pysf/pysocialforce/config.py
+++ b/fast-pysf/pysocialforce/config.py
@@ -13,12 +13,29 @@ class SceneConfig:
         enable_group: Enable group-related forces (coherence, repulsion, gaze).
         agent_radius: Pedestrian radius used for collision/interaction geometry (meters).
         dt_secs: Integration step size in seconds.
-        max_speed_multiplier: Upper bound multiplier for desired speeds.
+        max_speed_multiplier: Upper bound multiplier for desired speeds. Used to
+            derive desired speeds from the spawn speed when ``desired_speed_mean``
+            is not set (legacy behavior, ~0.65 m/s for default spawning).
         tau: Relaxation time constant used by force models (seconds).
         resolution: Spatial resolution used for obstacle preprocessing.
         integration_scheme: Pedestrian position-update scheme. ``semi_implicit_euler``
             advances position with the newly integrated velocity; ``explicit_euler``
             advances with the pre-step velocity.
+        desired_speed_mean: Optional per-pedestrian desired (preferred) walking
+            speed mean in m/s, decoupled from the spawn speed (issue #4972). When
+            set, each pedestrian's goal-driving speed is drawn from a truncated
+            normal distribution ``N(desired_speed_mean, desired_speed_std)`` clipped
+            to ``[0, desired_speed_high]`` instead of ``max_speed_multiplier *
+            initial_speed``. ``None`` preserves the legacy spawn-coupled default.
+        desired_speed_std: Optional standard deviation (m/s) of the desired-speed
+            distribution. Ignored unless ``desired_speed_mean`` is set; defaults to
+            a small spread when ``desired_speed_mean`` is set without an explicit
+            ``desired_speed_std``.
+        desired_speed_high: Inclusive upper bound (m/s) for the truncated desired-
+            speed distribution. Defaults to a high ceiling so only the non-negative
+            side is truncated in practice.
+        desired_speed_seed: Optional RNG seed for deterministic desired-speed
+            sampling. When ``None`` the global NumPy RNG is used.
     """
 
     enable_group: bool = True
@@ -28,6 +45,10 @@ class SceneConfig:
     tau: float = 0.5
     resolution: float = 10
     integration_scheme: str = "semi_implicit_euler"
+    desired_speed_mean: float | None = None
+    desired_speed_std: float | None = None
+    desired_speed_high: float = 3.0
+    desired_speed_seed: int | None = None
 
 
 @dataclass

--- a/fast-pysf/pysocialforce/scene.py
+++ b/fast-pysf/pysocialforce/scene.py
@@ -46,6 +46,12 @@ def sample_truncated_normal_speeds(
     Returns:
         np.ndarray: Non-negative desired speeds with shape ``(num_peds,)``.
     """
+    if not np.isfinite(mean) or mean < 0:
+        raise ValueError("desired speed mean must be finite and non-negative")
+    if not np.isfinite(std) or std < 0:
+        raise ValueError("desired speed std must be finite and non-negative")
+    if not np.isfinite(high) or high < 0:
+        raise ValueError("desired speed high bound must be finite and non-negative")
     if num_peds <= 0:
         return np.zeros((0,), dtype=float)
     rng = np.random.default_rng(seed)
@@ -124,7 +130,7 @@ class PedState:
         self.state = state
         self.groups = groups
 
-    def assign_desired_speeds(self, desired_speeds: np.ndarray) -> None:
+    def assign_desired_speeds(self, desired_speeds: np.ndarray | None) -> None:
         """Assign per-pedestrian desired speeds decoupled from the spawn speed.
 
         When set, these speeds drive the goal-directed force (``max_speeds``)
@@ -137,16 +143,19 @@ class PedState:
         Args:
             desired_speeds: Non-negative desired speeds in m/s, one per pedestrian.
         """
+        if desired_speeds is None:
+            self.clear_desired_speeds()
+            return
         speeds = np.asarray(desired_speeds, dtype=float)
         if speeds.ndim != 1 or speeds.shape[0] != self.size():
             raise ValueError(
                 "desired_speeds must be a 1D array with one entry per pedestrian "
                 f"(got shape {speeds.shape} for {self.size()} pedestrians)"
             )
-        if np.any(speeds < 0):
-            raise ValueError("desired_speeds must be non-negative")
+        if not np.all(np.isfinite(speeds)) or np.any(speeds < 0):
+            raise ValueError("desired_speeds must be finite and non-negative")
         self._explicit_desired_speeds = speeds
-        self.max_speeds = speeds.copy()
+        self._refresh_max_speeds()
 
     def clear_desired_speeds(self) -> None:
         """Restore the legacy spawn-coupled desired-speed derivation.
@@ -155,7 +164,14 @@ class PedState:
         ``max_speed_multiplier * initial_speed`` (issue #4972).
         """
         self._explicit_desired_speeds = None
-        self.max_speeds = self.max_speed_multiplier * self.initial_speeds
+        self._refresh_max_speeds()
+
+    def _refresh_max_speeds(self) -> None:
+        """Refresh the goal-driving cap from explicit or legacy desired speeds."""
+        if self._explicit_desired_speeds is not None:
+            self.max_speeds = self._explicit_desired_speeds.copy()
+        else:
+            self.max_speeds = self.max_speed_multiplier * self.initial_speeds
 
     def _update_state(self, state: np.ndarray) -> None:
         """Normalize and cache state-derived fields.
@@ -174,10 +190,7 @@ class PedState:
             self._state = state
         if self.initial_speeds is None:
             self.initial_speeds = self.speeds()
-        if self._explicit_desired_speeds is not None:
-            self.max_speeds = self._explicit_desired_speeds.copy()
-        else:
-            self.max_speeds = self.max_speed_multiplier * self.initial_speeds
+        self._refresh_max_speeds()
 
     @property
     def state(self) -> np.ndarray:

--- a/fast-pysf/pysocialforce/scene.py
+++ b/fast-pysf/pysocialforce/scene.py
@@ -16,6 +16,46 @@ EXPLICIT_EULER = "explicit_euler"
 SEMI_IMPLICIT_EULER = "semi_implicit_euler"
 SUPPORTED_INTEGRATION_SCHEMES = frozenset({EXPLICIT_EULER, SEMI_IMPLICIT_EULER})
 
+#: Default spread (m/s) for the desired-speed distribution when a mean is
+#: configured without an explicit standard deviation.
+DEFAULT_DESIRED_SPEED_STD = 0.2
+
+
+def sample_truncated_normal_speeds(
+    num_peds: int,
+    mean: float,
+    std: float,
+    high: float,
+    seed: int | None = None,
+) -> np.ndarray:
+    """Sample non-negative desired walking speeds from a truncated normal.
+
+    Speeds are drawn from ``N(mean, std)`` and truncated to ``[0, high]``. This
+    decouples the preferred walking speed from the spawn velocity (issue #4972).
+    Negative samples are clipped to ``0`` and samples above ``high`` are clipped
+    to ``high``; for literature-calibrated means (~1.3 m/s) with a 0.2 m/s spread
+    the truncation is negligible in practice.
+
+    Args:
+        num_peds: Number of pedestrian desired speeds to sample.
+        mean: Desired-speed distribution mean in m/s.
+        std: Desired-speed distribution standard deviation in m/s.
+        high: Inclusive upper bound for the truncated distribution (m/s).
+        seed: Optional RNG seed for deterministic sampling.
+
+    Returns:
+        np.ndarray: Non-negative desired speeds with shape ``(num_peds,)``.
+    """
+    if num_peds <= 0:
+        return np.zeros((0,), dtype=float)
+    rng = np.random.default_rng(seed)
+    std_eff = std if std is not None and std > 0 else 0.0
+    if std_eff > 0.0:
+        speeds = rng.normal(loc=mean, scale=std_eff, size=num_peds)
+    else:
+        speeds = np.full(num_peds, float(mean), dtype=float)
+    return np.clip(speeds, 0.0, float(high))
+
 
 def normalize_integration_scheme(value: str | None) -> str:
     """Return a supported pedestrian integration scheme or raise a clear error."""
@@ -44,10 +84,35 @@ class PedState:
         self.integration_scheme = normalize_integration_scheme(config.integration_scheme)
         self.agent_radius = config.agent_radius
         self.max_speed_multiplier = config.max_speed_multiplier
+        self.desired_speed_mean = config.desired_speed_mean
+        self.desired_speed_std = config.desired_speed_std
+        self.desired_speed_high = config.desired_speed_high
+        self.desired_speed_seed = config.desired_speed_seed
 
         self.max_speeds: np.ndarray | None = None
         self.initial_speeds: np.ndarray | None = None
+        # Explicitly assigned desired speeds decouple the goal-driving speed
+        # (``max_speeds``) from the spawn speed (issue #4972). When ``None`` the
+        # legacy ``max_speed_multiplier * initial_speed`` derivation is used.
+        self._explicit_desired_speeds: np.ndarray | None = None
         self.update(state, groups)
+        # After the initial state is cached, optionally sample a decoupled
+        # desired-speed distribution from the scene configuration.
+        if self.desired_speed_mean is not None:
+            std = (
+                self.desired_speed_std
+                if self.desired_speed_std is not None
+                else DEFAULT_DESIRED_SPEED_STD
+            )
+            self.assign_desired_speeds(
+                sample_truncated_normal_speeds(
+                    self.size(),
+                    float(self.desired_speed_mean),
+                    float(std),
+                    float(self.desired_speed_high),
+                    seed=self.desired_speed_seed,
+                )
+            )
 
     def update(self, state: np.ndarray, groups: list[list[int]]) -> None:
         """Update pedestrian state and group memberships.
@@ -59,8 +124,45 @@ class PedState:
         self.state = state
         self.groups = groups
 
+    def assign_desired_speeds(self, desired_speeds: np.ndarray) -> None:
+        """Assign per-pedestrian desired speeds decoupled from the spawn speed.
+
+        When set, these speeds drive the goal-directed force (``max_speeds``)
+        instead of the legacy ``max_speed_multiplier * initial_speed`` derivation.
+        Pass ``None`` (or call :meth:`clear_desired_speeds`) to restore the
+        legacy behavior. The assignment is length-checked against the current
+        pedestrian count and re-applied on every state refresh so it survives
+        repeated integration steps (issue #4972).
+
+        Args:
+            desired_speeds: Non-negative desired speeds in m/s, one per pedestrian.
+        """
+        speeds = np.asarray(desired_speeds, dtype=float)
+        if speeds.ndim != 1 or speeds.shape[0] != self.size():
+            raise ValueError(
+                "desired_speeds must be a 1D array with one entry per pedestrian "
+                f"(got shape {speeds.shape} for {self.size()} pedestrians)"
+            )
+        if np.any(speeds < 0):
+            raise ValueError("desired_speeds must be non-negative")
+        self._explicit_desired_speeds = speeds
+        self.max_speeds = speeds.copy()
+
+    def clear_desired_speeds(self) -> None:
+        """Restore the legacy spawn-coupled desired-speed derivation.
+
+        Clears any explicit desired speeds and recomputes ``max_speeds`` from
+        ``max_speed_multiplier * initial_speed`` (issue #4972).
+        """
+        self._explicit_desired_speeds = None
+        self.max_speeds = self.max_speed_multiplier * self.initial_speeds
+
     def _update_state(self, state: np.ndarray) -> None:
         """Normalize and cache state-derived fields.
+
+        When explicit desired speeds are assigned they drive ``max_speeds``
+        directly (decoupled from spawn speed, issue #4972); otherwise the legacy
+        ``max_speed_multiplier * initial_speed`` derivation is preserved.
 
         Args:
             state: Pedestrian state matrix with or without explicit ``tau`` column.
@@ -72,7 +174,10 @@ class PedState:
             self._state = state
         if self.initial_speeds is None:
             self.initial_speeds = self.speeds()
-        self.max_speeds = self.max_speed_multiplier * self.initial_speeds
+        if self._explicit_desired_speeds is not None:
+            self.max_speeds = self._explicit_desired_speeds.copy()
+        else:
+            self.max_speeds = self.max_speed_multiplier * self.initial_speeds
 
     @property
     def state(self) -> np.ndarray:

--- a/fast-pysf/tests/test_desired_speed.py
+++ b/fast-pysf/tests/test_desired_speed.py
@@ -1,0 +1,101 @@
+"""Tests for decoupled pedestrian desired speed (issue #4972).
+
+Covers :class:`pysocialforce.scene.PedState` decoupling of the goal-driving
+speed (``max_speeds``) from the spawn speed, plus the truncated-normal sampler.
+"""
+
+import numpy as np
+import pytest
+from pysocialforce.config import SceneConfig
+from pysocialforce.scene import PedState, sample_truncated_normal_speeds
+
+
+def _state(num_peds: int, speed: float = 0.5) -> np.ndarray:
+    """Build a pedestrian state matrix with a fixed spawn speed heading +x."""
+    state = np.zeros((num_peds, 7))
+    state[:, 2] = speed  # vx = spawn speed
+    state[:, 4] = 10.0  # goal x far away so peds keep moving
+    return state
+
+
+def test_legacy_default_couples_max_speed_to_spawn_speed():
+    """Without desired-speed config, max_speeds = multiplier * initial_speed."""
+    peds = PedState(_state(3, speed=0.5), [], SceneConfig())
+    # Default multiplier is 1.3; spawn speed 0.5 -> 0.65 m/s (the slow regime).
+    np.testing.assert_allclose(peds.max_speeds, np.full(3, 0.65))
+
+
+def test_desired_speed_mean_decouples_from_spawn_speed():
+    """Configured desired_speed_mean overrides the spawn-coupled derivation."""
+    config = SceneConfig(desired_speed_mean=1.3, desired_speed_std=0.0, desired_speed_seed=7)
+    peds = PedState(_state(4, speed=0.5), [], config)
+    # Spawn speed is 0.5, but desired speed is decoupled to 1.3 (std=0 -> deterministic).
+    np.testing.assert_allclose(peds.max_speeds, np.full(4, 1.3))
+    # initial_speeds still reflect the spawn velocity (decoupling is one-way).
+    np.testing.assert_allclose(peds.initial_speeds, np.full(4, 0.5))
+
+
+def test_desired_speed_sampling_is_deterministic_with_seed():
+    """Same seed must reproduce the sampled desired-speed distribution."""
+    cfg = lambda: SceneConfig(  # noqa: E731
+        desired_speed_mean=1.3, desired_speed_std=0.2, desired_speed_seed=42
+    )
+    peds_a = PedState(_state(50), [], cfg())
+    peds_b = PedState(_state(50), [], cfg())
+    np.testing.assert_array_equal(peds_a.max_speeds, peds_b.max_speeds)
+
+
+def test_desired_speed_distribution_mean_near_configured():
+    """The sampled distribution should center near the configured mean."""
+    config = SceneConfig(desired_speed_mean=1.3, desired_speed_std=0.2, desired_speed_seed=1)
+    peds = PedState(_state(2000), [], config)
+    assert abs(float(np.mean(peds.max_speeds)) - 1.3) < 0.05
+    # Truncation keeps speeds non-negative and below the configured high bound.
+    assert np.all(peds.max_speeds >= 0.0)
+    assert np.all(peds.max_speeds <= config.desired_speed_high)
+
+
+def test_desired_speed_persists_across_integration_steps():
+    """Explicit desired speeds must survive repeated _update_state calls (step())."""
+    config = SceneConfig(desired_speed_mean=1.3, desired_speed_std=0.0, desired_speed_seed=0)
+    peds = PedState(_state(2, speed=0.5), [], config)
+    # Simulate a state refresh like PedState.step does via the state setter.
+    new_state = peds.state.copy()
+    new_state[:, 2] = 0.9  # velocity changes during stepping
+    peds.state = new_state
+    np.testing.assert_allclose(peds.max_speeds, np.full(2, 1.3))
+
+
+def test_assign_desired_speeds_overrides_and_validates():
+    """assign_desired_speeds sets max_speeds and rejects bad inputs."""
+    peds = PedState(_state(3), [], SceneConfig())
+    peds.assign_desired_speeds(np.array([0.8, 1.0, 1.2]))
+    np.testing.assert_allclose(peds.max_speeds, [0.8, 1.0, 1.2])
+
+    with pytest.raises(ValueError, match="one entry per pedestrian"):
+        peds.assign_desired_speeds(np.array([0.8, 1.0]))  # wrong length
+
+    with pytest.raises(ValueError, match="non-negative"):
+        peds.assign_desired_speeds(np.array([-0.1, 1.0, 1.2]))  # negative
+
+
+def test_clear_desired_speeds_restores_legacy_derivation():
+    """clear_desired_speeds returns to multiplier * initial_speed."""
+    peds = PedState(_state(3, speed=0.5), [], SceneConfig())
+    peds.assign_desired_speeds(np.array([1.3, 1.3, 1.3]))
+    np.testing.assert_allclose(peds.max_speeds, 1.3)
+    peds.clear_desired_speeds()
+    np.testing.assert_allclose(peds.max_speeds, np.full(3, 0.65))
+
+
+def test_sample_truncated_normal_speeds_clips_and_handles_zero():
+    """The sampler clips to bounds and returns empty for zero pedestrians."""
+    speeds = sample_truncated_normal_speeds(1000, mean=1.0, std=0.3, high=1.2, seed=3)
+    assert speeds.shape == (1000,)
+    assert np.all(speeds >= 0.0)
+    assert np.all(speeds <= 1.2)
+    assert sample_truncated_normal_speeds(0, mean=1.0, std=0.2, high=3.0).shape == (0,)
+    # std=0 collapses to the mean (clipped to the bound).
+    np.testing.assert_allclose(
+        sample_truncated_normal_speeds(5, mean=0.7, std=0.0, high=3.0, seed=None), 0.7
+    )

--- a/fast-pysf/tests/test_desired_speed.py
+++ b/fast-pysf/tests/test_desired_speed.py
@@ -75,8 +75,11 @@ def test_assign_desired_speeds_overrides_and_validates():
     with pytest.raises(ValueError, match="one entry per pedestrian"):
         peds.assign_desired_speeds(np.array([0.8, 1.0]))  # wrong length
 
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(ValueError, match="finite and non-negative"):
         peds.assign_desired_speeds(np.array([-0.1, 1.0, 1.2]))  # negative
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        peds.assign_desired_speeds(np.array([0.8, np.nan, 1.2]))
 
 
 def test_clear_desired_speeds_restores_legacy_derivation():
@@ -85,6 +88,14 @@ def test_clear_desired_speeds_restores_legacy_derivation():
     peds.assign_desired_speeds(np.array([1.3, 1.3, 1.3]))
     np.testing.assert_allclose(peds.max_speeds, 1.3)
     peds.clear_desired_speeds()
+    np.testing.assert_allclose(peds.max_speeds, np.full(3, 0.65))
+
+
+def test_assign_none_restores_legacy_derivation():
+    """The documented None shortcut must restore the legacy speed derivation."""
+    peds = PedState(_state(3, speed=0.5), [], SceneConfig())
+    peds.assign_desired_speeds(np.array([1.3, 1.3, 1.3]))
+    peds.assign_desired_speeds(None)
     np.testing.assert_allclose(peds.max_speeds, np.full(3, 0.65))
 
 
@@ -99,3 +110,15 @@ def test_sample_truncated_normal_speeds_clips_and_handles_zero():
     np.testing.assert_allclose(
         sample_truncated_normal_speeds(5, mean=0.7, std=0.0, high=3.0, seed=None), 0.7
     )
+
+
+@pytest.mark.parametrize(
+    ("mean", "std", "high"),
+    [(-0.1, 0.2, 3.0), (1.0, -0.2, 3.0), (1.0, 0.2, -0.1), (np.nan, 0.2, 3.0)],
+)
+def test_sample_truncated_normal_speeds_rejects_invalid_parameters(
+    mean: float, std: float, high: float
+) -> None:
+    """Invalid distribution parameters fail before they can enter the integrator."""
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        sample_truncated_normal_speeds(2, mean=mean, std=std, high=high)

--- a/robot_sf/sim/pedestrian_speed_tiers.py
+++ b/robot_sf/sim/pedestrian_speed_tiers.py
@@ -1,0 +1,81 @@
+"""Pedestrian desired-speed tier axis (issue #4972).
+
+This module exposes a speed-tier *axis* that scenarios and campaigns can use to
+quantify how planner rankings shift with pedestrian pace. Each tier maps to a
+literature-calibrated desired (preferred) walking-speed distribution, decoupled
+from the spawn speed.
+
+Tiers:
+    - ``slow``: ~0.65 m/s. Matches the legacy spawn-coupled default
+      (``max_speed_multiplier * initial_speed`` = 1.3 * 0.5). Keep this tier so
+      existing benchmark numbers remain reproducible as an explicit axis value.
+    - ``typical``: ~1.3 m/s. Preferred walking speed reported for unimpeded
+      adults (Moussaïd et al. 2010, "The walking behaviour of pedestrian
+      social groups", doi:10.1371/journal.pone.0010047).
+    - ``brisk``: ~1.6 m/s. Fast walkers; stress-tests reactive planners.
+
+All tiers use a 0.2 m/s truncated-normal spread. The legacy default
+(``ped_speed_tier is None``) preserves the spawn-coupled ~0.65 m/s behavior
+unchanged until a major campaign re-base.
+"""
+
+from __future__ import annotations
+
+PED_SPEED_TIER_SLOW = "slow"
+PED_SPEED_TIER_TYPICAL = "typical"
+PED_SPEED_TIER_BRISK = "brisk"
+SUPPORTED_PED_SPEED_TIERS = frozenset(
+    {PED_SPEED_TIER_SLOW, PED_SPEED_TIER_TYPICAL, PED_SPEED_TIER_BRISK}
+)
+
+#: Shared truncated-normal spread (m/s) for all tiers.
+PED_SPEED_TIER_STD = 0.2
+
+#: Inclusive upper bound (m/s) for the truncated desired-speed distribution.
+PED_SPEED_TIER_HIGH = 3.0
+
+#: Tier -> (desired_speed_mean, desired_speed_std). ``slow`` mirrors the legacy
+#: ~0.65 m/s default so existing benchmark numbers stay reproducible as a tier.
+_PED_SPEED_TIER_PARAMS: dict[str, tuple[float, float]] = {
+    PED_SPEED_TIER_SLOW: (0.65, PED_SPEED_TIER_STD),
+    PED_SPEED_TIER_TYPICAL: (1.3, PED_SPEED_TIER_STD),
+    PED_SPEED_TIER_BRISK: (1.6, PED_SPEED_TIER_STD),
+}
+
+
+def normalize_ped_speed_tier(value: str | None) -> str | None:
+    """Return a supported pedestrian speed-tier key, ``None``, or raise.
+
+    Args:
+        value: Tier key (``slow``/``typical``/``brisk``) or ``None`` for the
+            legacy spawn-coupled default.
+
+    Returns:
+        The normalized tier key, or ``None`` when ``value`` is ``None``.
+    """
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if normalized in SUPPORTED_PED_SPEED_TIERS:
+        return normalized
+    supported = ", ".join(sorted(SUPPORTED_PED_SPEED_TIERS))
+    raise ValueError(f"Unsupported ped_speed_tier {value!r}. Supported values: {supported}.")
+
+
+def desired_speed_params_for_tier(tier: str | None) -> tuple[float | None, float | None]:
+    """Map a speed tier to a ``(desired_speed_mean, desired_speed_std)`` pair.
+
+    Args:
+        tier: Tier key (``slow``/``typical``/``brisk``) or ``None`` for the
+            legacy spawn-coupled default.
+
+    Returns:
+        ``(mean, std)`` for the tier, or ``(None, None)`` when ``tier`` is
+        ``None`` (signals: keep the legacy ``max_speed_multiplier * initial_speed``
+        derivation).
+    """
+    normalized = normalize_ped_speed_tier(tier)
+    if normalized is None:
+        return None, None
+    mean, std = _PED_SPEED_TIER_PARAMS[normalized]
+    return mean, std

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -14,6 +14,10 @@ from robot_sf.sim.pedestrian_model_variants import (
     HSFM_TTC_PREDICTIVE_V1,
     normalize_pedestrian_model,
 )
+from robot_sf.sim.pedestrian_speed_tiers import (
+    desired_speed_params_for_tier,
+    normalize_ped_speed_tier,
+)
 
 
 @dataclass(frozen=True)
@@ -265,6 +269,23 @@ class SimulationSettings:
 
     peds_reset_follow_route_at_start: bool = False
     """Whether pedestrians following routes should reset to the start of their routes"""
+    ped_speed_tier: str | None = None
+    """Pedestrian desired-speed tier axis (issue #4972): ``slow`` (~0.65 m/s,
+    matches the legacy default), ``typical`` (~1.3 m/s preferred walking speed,
+    Moussaïd et al. 2010), or ``brisk`` (~1.6 m/s). ``None`` (default)
+    preserves the legacy spawn-coupled ``peds_speed_mult * initial_speed``
+    derivation. Explicit ``desired_speed_mean``/``desired_speed_std`` override
+    the tier mapping."""
+    desired_speed_mean: float | None = None
+    """Optional decoupled per-pedestrian desired (preferred) walking speed mean
+    (m/s). When set, the goal-driving speed is drawn from a truncated normal
+    distribution instead of ``peds_speed_mult * initial_speed`` (issue #4972)."""
+    desired_speed_std: float | None = None
+    """Optional standard deviation (m/s) of the decoupled desired-speed
+    distribution. Ignored unless ``desired_speed_mean`` (or ``ped_speed_tier``)
+    is set."""
+    desired_speed_seed: int | None = None
+    """Optional RNG seed for deterministic desired-speed sampling (issue #4972)."""
     debug_without_robot_movement: bool = False
     """Whether to disable robot movement in the simulator for debugging purposes"""
 
@@ -330,6 +351,7 @@ class SimulationSettings:
         if self.apf_config is None or not isinstance(self.apf_config, AdversarialPedForceConfig):
             raise ValueError("Adversarial-ped-force settings need to be specified!")
         self._validate_route_spawn_config()
+        self._validate_desired_speed_config()
 
     def _validate_pedestrian_uncertainty_envelope_config(self) -> None:
         """Validate planner-facing uncertainty-envelope simulation settings."""
@@ -345,6 +367,32 @@ class SimulationSettings:
             )
         if self.route_spawn_jitter_frac < 0:
             raise ValueError("route_spawn_jitter_frac must be >= 0")
+
+    def _validate_desired_speed_config(self) -> None:
+        """Validate and normalize the decoupled desired-speed / tier config (issue #4972).
+
+        Normalizes ``ped_speed_tier`` to a canonical key, validates explicit
+        desired-speed mean/std, and derives ``desired_speed_mean``/``desired_speed_std``
+        from the tier when the tier is set and the explicit values are not. Explicit
+        ``desired_speed_mean``/``desired_speed_std`` always take precedence over the
+        tier mapping.
+        """
+        tier = normalize_ped_speed_tier(self.ped_speed_tier)
+        # ``object.__setattr__`` is unnecessary for a non-frozen dataclass, but we
+        # assign via the field name to stay robust against future freezing.
+        self.ped_speed_tier = tier
+        if self.desired_speed_mean is not None:
+            if not isfinite(self.desired_speed_mean) or self.desired_speed_mean < 0:
+                raise ValueError("desired_speed_mean must be a finite value >= 0!")
+        if self.desired_speed_std is not None:
+            if not isfinite(self.desired_speed_std) or self.desired_speed_std < 0:
+                raise ValueError("desired_speed_std must be a finite value >= 0!")
+        if tier is not None and self.desired_speed_mean is None:
+            tier_mean, tier_std = desired_speed_params_for_tier(tier)
+            self.desired_speed_mean = tier_mean
+            self.desired_speed_std = (
+                self.desired_speed_std if self.desired_speed_std is not None else tier_std
+            )
 
     @property
     def max_sim_steps(self) -> int:

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -87,6 +87,22 @@ def _heading_from_velocity(velocity_xy: np.ndarray, fallback_heading: float) -> 
     return float(atan2(float(velocity_xy[1]), float(velocity_xy[0])))
 
 
+def _apply_ped_desired_speed_config(
+    pysf_config: PySFSimConfig, settings: SimulationSettings
+) -> None:
+    """Propagate decoupled desired-speed settings onto the PySF scene config.
+
+    Forwards the optional ``desired_speed_mean``/``desired_speed_std``/``desired_speed_seed``
+    from :class:`SimulationSettings` (which may have been derived from ``ped_speed_tier``)
+    onto ``pysf_config.scene_config`` so :class:`pysocialforce.scene.PedState` samples a
+    decoupled preferred walking speed instead of ``peds_speed_mult * initial_speed``
+    (issue #4972). A ``None`` mean preserves the legacy spawn-coupled default.
+    """
+    pysf_config.scene_config.desired_speed_mean = settings.desired_speed_mean
+    pysf_config.scene_config.desired_speed_std = settings.desired_speed_std
+    pysf_config.scene_config.desired_speed_seed = settings.desired_speed_seed
+
+
 def _make_ped_forces(
     sim: PySFSimulator,
     config: PySFSimConfig,
@@ -196,6 +212,7 @@ class Simulator:
         pysf_config = PySFSimConfig()
         pysf_config.scene_config.dt_secs = self.config.time_per_step_in_secs
         pysf_config.scene_config.integration_scheme = self.config.pedestrian_integration_scheme
+        _apply_ped_desired_speed_config(pysf_config, self.config)
         spawn_config = PedSpawnConfig(
             self.config.peds_per_area_m2,
             self.config.max_peds_per_group,
@@ -652,6 +669,7 @@ class PedSimulator(Simulator):
         pysf_config = PySFSimConfig()
         pysf_config.scene_config.dt_secs = self.config.time_per_step_in_secs
         pysf_config.scene_config.integration_scheme = self.config.pedestrian_integration_scheme
+        _apply_ped_desired_speed_config(pysf_config, self.config)
         spawn_config = PedSpawnConfig(
             self.config.peds_per_area_m2,
             self.config.max_peds_per_group,

--- a/tests/sim/test_pedestrian_desired_speed.py
+++ b/tests/sim/test_pedestrian_desired_speed.py
@@ -1,0 +1,116 @@
+"""End-to-end tests for decoupled pedestrian desired speed (issue #4972).
+
+Verifies the decoupling reaches ``peds.max_speeds`` through the real
+``init_simulators`` construction path, and that the legacy default is preserved.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from robot_sf.common.types import Line2D, Rect
+from robot_sf.gym_env.unified_config import RobotSimulationConfig
+from robot_sf.nav.global_route import GlobalRoute
+from robot_sf.nav.map_config import MapDefinition, MapDefinitionPool
+from robot_sf.sim.sim_config import SimulationSettings
+from robot_sf.sim.simulator import init_simulators
+
+
+def _minimal_map() -> MapDefinition:
+    """Build a compact map with one robot route and a pedestrian spawn zone."""
+    width = 20.0
+    height = 20.0
+    spawn_zone: Rect = ((1.0, 1.0), (2.0, 1.0), (1.0, 2.0))
+    goal_zone: Rect = ((16.0, 16.0), (17.0, 16.0), (16.0, 17.0))
+    bounds: list[Line2D] = [
+        ((0.0, 0.0), (width, 0.0)),
+        ((width, 0.0), (width, height)),
+        ((width, height), (0.0, height)),
+        ((0.0, height), (0.0, 0.0)),
+    ]
+    route = GlobalRoute(
+        spawn_id=0,
+        goal_id=0,
+        waypoints=[(1.2, 1.2), (16.8, 16.8)],
+        spawn_zone=spawn_zone,
+        goal_zone=goal_zone,
+    )
+    return MapDefinition(
+        width=width,
+        height=height,
+        obstacles=[],
+        robot_spawn_zones=[spawn_zone],
+        ped_spawn_zones=[spawn_zone],
+        robot_goal_zones=[goal_zone],
+        bounds=bounds,
+        robot_routes=[route],
+        ped_goal_zones=[goal_zone],
+        ped_crowded_zones=[],
+        ped_routes=[route],
+        single_pedestrians=[],
+    )
+
+
+def _build_simulator(sim_config: SimulationSettings):
+    """Construct a single robot simulator for the minimal map."""
+    map_def = _minimal_map()
+    config = RobotSimulationConfig(
+        map_pool=MapDefinitionPool(map_defs={"test": map_def}),
+        sim_config=sim_config,
+    )
+    return init_simulators(
+        config,
+        map_def,
+        num_robots=1,
+        random_start_pos=False,
+        peds_have_obstacle_forces=True,
+    )[0]
+
+
+def test_default_simulator_keeps_legacy_slow_regime():
+    """Default config must leave peds at the ~0.65 m/s spawn-coupled speed."""
+    sim = _build_simulator(
+        SimulationSettings(
+            difficulty=0,
+            ped_density_by_difficulty=[0.04],
+            population_size=8,
+        )
+    )
+    peds = sim.pysf_sim.peds
+    # initial_speed=0.5 default, multiplier 1.3 -> 0.65 m/s for every pedestrian.
+    np.testing.assert_allclose(peds.max_speeds, np.full(peds.size(), 0.65))
+
+
+def test_typical_tier_decouples_desired_speed_from_spawn():
+    """ped_speed_tier='typical' should drive peds toward ~1.3 m/s, not 0.65 m/s."""
+    sim = _build_simulator(
+        SimulationSettings(
+            difficulty=0,
+            ped_density_by_difficulty=[0.04],
+            population_size=200,
+            ped_speed_tier="typical",
+            desired_speed_seed=123,
+        )
+    )
+    peds = sim.pysf_sim.peds
+    # Decoupled: the mean desired speed must be near 1.3, well above the 0.65 legacy.
+    assert float(np.mean(peds.max_speeds)) > 1.0
+    assert abs(float(np.mean(peds.max_speeds)) - 1.3) < 0.15
+    # No pedestrian should be stuck at the legacy 0.65 m/s spawn-coupled value.
+    assert not np.any(np.isclose(peds.max_speeds, 0.65))
+
+
+def test_explicit_desired_speed_decouples_deterministically():
+    """Explicit desired_speed_mean/std=0 pins every ped to the configured speed."""
+    sim = _build_simulator(
+        SimulationSettings(
+            difficulty=0,
+            ped_density_by_difficulty=[0.04],
+            population_size=12,
+            desired_speed_mean=1.5,
+            desired_speed_std=0.0,
+            desired_speed_seed=0,
+        )
+    )
+    peds = sim.pysf_sim.peds
+    np.testing.assert_allclose(peds.max_speeds, np.full(peds.size(), 1.5))

--- a/tests/sim/test_pedestrian_speed_tiers.py
+++ b/tests/sim/test_pedestrian_speed_tiers.py
@@ -1,0 +1,36 @@
+"""Tests for the pedestrian speed-tier axis (issue #4972)."""
+
+import pytest
+
+from robot_sf.sim.pedestrian_speed_tiers import (
+    PED_SPEED_TIER_BRISK,
+    PED_SPEED_TIER_SLOW,
+    PED_SPEED_TIER_TYPICAL,
+    desired_speed_params_for_tier,
+    normalize_ped_speed_tier,
+)
+
+
+def test_tier_mapping_matches_literature_calibration():
+    """slow mirrors the legacy default; typical matches Moussaïd et al. 2010."""
+    assert desired_speed_params_for_tier(PED_SPEED_TIER_SLOW) == (0.65, pytest.approx(0.2))
+    assert desired_speed_params_for_tier(PED_SPEED_TIER_TYPICAL) == (1.3, pytest.approx(0.2))
+    assert desired_speed_params_for_tier(PED_SPEED_TIER_BRISK) == (1.6, pytest.approx(0.2))
+
+
+def test_none_tier_yields_legacy_default_params():
+    """A None tier must signal the legacy spawn-coupled derivation."""
+    assert desired_speed_params_for_tier(None) == (None, None)
+
+
+def test_normalize_ped_speed_tier_accepts_known_and_none():
+    """Known tiers normalize to canonical lowercase keys; None passes through."""
+    assert normalize_ped_speed_tier(None) is None
+    assert normalize_ped_speed_tier("Typical") == "typical"
+    assert normalize_ped_speed_tier("  Brisk  ") == "brisk"
+
+
+def test_normalize_ped_speed_tier_rejects_unknown():
+    """Unknown tier values must raise a clear ValueError."""
+    with pytest.raises(ValueError, match="Unsupported ped_speed_tier"):
+        normalize_ped_speed_tier("sprint")

--- a/tests/sim_config_test.py
+++ b/tests/sim_config_test.py
@@ -80,3 +80,54 @@ def test_non_reactive_response_multiplier_default_and_validation():
 
     with pytest.raises(ValueError, match="non_reactive_response_multiplier"):
         SimulationSettings(non_reactive_response_multiplier=float("inf"))
+
+
+def test_desired_speed_default_preserves_legacy_behavior():
+    """Default SimulationSettings must not set a decoupled desired speed (issue #4972).
+
+    With no tier / explicit mean, desired_speed_mean stays None so the simulator
+    keeps the legacy ``peds_speed_mult * initial_speed`` derivation.
+    """
+    settings = SimulationSettings()
+    assert settings.ped_speed_tier is None
+    assert settings.desired_speed_mean is None
+    assert settings.desired_speed_std is None
+
+
+def test_ped_speed_tier_derives_desired_speed_params():
+    """A speed tier should derive literature-calibrated desired-speed params (issue #4972)."""
+    settings = SimulationSettings(ped_speed_tier="typical")
+    assert settings.ped_speed_tier == "typical"
+    assert settings.desired_speed_mean == pytest.approx(1.3)
+    assert settings.desired_speed_std == pytest.approx(0.2)
+
+    slow = SimulationSettings(ped_speed_tier="slow")
+    assert slow.desired_speed_mean == pytest.approx(0.65)
+
+    brisk = SimulationSettings(ped_speed_tier="Brisk")
+    assert brisk.ped_speed_tier == "brisk"
+    assert brisk.desired_speed_mean == pytest.approx(1.6)
+
+
+def test_explicit_desired_speed_overrides_tier():
+    """Explicit desired_speed_mean/std must take precedence over the tier mapping."""
+    settings = SimulationSettings(
+        ped_speed_tier="typical", desired_speed_mean=1.0, desired_speed_std=0.1
+    )
+    assert settings.desired_speed_mean == pytest.approx(1.0)
+    assert settings.desired_speed_std == pytest.approx(0.1)
+
+
+def test_desired_speed_validation_rejects_invalid_values():
+    """Bad tier keys and negative/non-finite desired-speed values must raise."""
+    with pytest.raises(ValueError, match="Unsupported ped_speed_tier"):
+        SimulationSettings(ped_speed_tier="sprint")
+
+    with pytest.raises(ValueError, match="desired_speed_mean"):
+        SimulationSettings(desired_speed_mean=-0.1)
+
+    with pytest.raises(ValueError, match="desired_speed_mean"):
+        SimulationSettings(desired_speed_mean=float("inf"))
+
+    with pytest.raises(ValueError, match="desired_speed_std"):
+        SimulationSettings(desired_speed_mean=1.3, desired_speed_std=-0.2)


### PR DESCRIPTION
## What & why

Implements issue #4972 — **decouple pedestrian desired (preferred) walking speed from the spawn speed and add literature-calibrated speed defaults + a speed-tier axis.**

The default simulated pedestrian previously walked at **~0.65 m/s for the whole episode** because the goal-driving speed was derived as `max_speed_multiplier * initial_speed` (`1.3 * 0.5`), roughly **half** the ~1.3 m/s preferred walking speed reported for unimpeded adults (Moussaïd et al. 2010, doi:10.1371/journal.pone.0010047). This (1) makes the interaction regime systematically gentler/slower, flattering reactive planners, and (2) surprisingly couples desired speed to *spawn* speed. Per the issue's sequencing, this lands as an **explicit config axis, not a silent default flip**.

This PR fully resolves all three parts of the issue's proposal:
1. Introduce an explicit decoupled `desired_speed` (distribution: mean/std, truncated normal) decoupled from initial velocity; keep the current derivation as backward-compatible default.
2. Document the slow-regime default prominently where benchmark results are described.
3. Add a speed-tier axis (`slow` / `typical` / `brisk`) to scenario configs.

Closes #4972

## Changes

- **`fast-pysf/pysocialforce/config.py`** — `SceneConfig` gains optional `desired_speed_mean` / `desired_speed_std` / `desired_speed_high` / `desired_speed_seed` (all default `None` → legacy behavior).
- **`fast-pysf/pysocialforce/scene.py`** — `PedState` can now sample/assign a decoupled desired-speed distribution that drives `max_speeds` directly (the quantity the goal-force steers toward in `forces.py`). Adds `assign_desired_speeds()` / `clear_desired_speeds()` and a `sample_truncated_normal_speeds()` helper. The legacy `max_speed_multiplier * initial_speeds` path is preserved exactly when no desired speed is configured.
- **`robot_sf/sim/sim_config.py`** — `SimulationSettings` gains a `ped_speed_tier` selector (`slow` ~0.65 m/s, `typical` ~1.3 m/s, `brisk` ~1.6 m/s) plus explicit `desired_speed_mean` / `desired_speed_std` / `desired_speed_seed`, with validation and tier-derived defaults (explicit values override the tier).
- **`robot_sf/sim/pedestrian_speed_tiers.py`** (new) — the reusable speed-tier axis + literature-calibrated mapping.
- **`robot_sf/sim/simulator.py`** — `Simulator` and `PedSimulator` propagate the desired-speed config onto the PySF `scene_config` via a new `_apply_ped_desired_speed_config` helper.
- **`docs/benchmark.md`** — prominent "Pedestrian Walking-Speed Calibration" caveat section at the top of the canonical benchmark doc.
- **Tests** — `fast-pysf/tests/test_desired_speed.py` (PedState decoupling, sampler, persistence across steps, validation), `tests/sim/test_pedestrian_speed_tiers.py` (tier mapping + validation), `tests/sim_config_test.py` (SimulationSettings plumbing + tier-derived defaults + override), and `tests/sim/test_pedestrian_desired_speed.py` (end-to-end `init_simulators` proof).

## Backward compatibility

With no `ped_speed_tier` / `desired_speed_mean` set, `max_speeds == peds_speed_mult * initial_speed` is byte-for-byte unchanged — proven by `test_default_simulator_keeps_legacy_slow_regime` (peds pinned at 0.65 m/s). The legacy `~0.65 m/s` default is intentionally preserved until a major campaign re-base, as the issue requires.

## Validation (CPU only — no campaigns/Slurm/training)

```
# PedState decoupling core (8 tests)
uv run python -m pytest fast-pysf/tests/test_desired_speed.py -v  # 8 passed

# Speed-tier axis + SimulationSettings plumbing (13 tests)
uv run python -m pytest tests/sim/test_pedestrian_speed_tiers.py tests/sim_config_test.py -v  # 13 passed

# End-to-end init_simulators integration (3 tests)
uv run python -m pytest tests/sim/test_pedestrian_desired_speed.py -v  # 3 passed

# Regression: fast-pysf forces/simulator + sim suite + force factory
uv run python -m pytest fast-pysf/tests/ tests/sim/ tests/sim_config_test.py tests/test_simulator_force_factory.py -q  # 123 passed

# Regression: ped_npc population + integration scheme + simulator action count
uv run python -m pytest tests/ped_npc/ tests/sim/test_pedestrian_integration_scheme.py tests/sim/test_simulator_action_count.py -q  # 49 passed

# Lint/format on changed files
uv run ruff check <changed files>   # All checks passed
uv run ruff format --check <changed files>  # all formatted
```

Key evidence: with `ped_speed_tier='typical'`, the end-to-end simulator drives pedestrians toward ~1.3 m/s (mean of `peds.max_speeds` within 0.15 of 1.3, none stuck at 0.65); with explicit `desired_speed_mean=1.5, std=0`, every pedestrian is pinned to exactly 1.5 m/s — confirming the decoupling reaches the real physics path.

## Evidence / artifact classification (repo PR convention)

- **Target claim:** decouple pedestrian desired speed from spawn speed; add speed-tier axis; preserve legacy default. **Hypothesis:** the new axis changes `peds.max_speeds` without altering default behavior. ✅ proven by focused + integration tests.
- **Comparator/baseline:** legacy spawn-coupled derivation.
- **Evidence tier:** executable focused + integration tests on the real `init_simulators` path (CPU only).
- **Result classification:** success — new capability works, default unchanged.
- **Decision/stop rule:** issue's three-part proposal fully delivered in one reviewable slice; no campaigns run (out of scope for this lane).
- **`output/` propagation:** NA — no evidence-producing artifacts generated; this PR adds capability + docs + tests only.

## Notes for the review gate

- The `slow` tier is calibrated to **0.65 m/s** to reproduce the legacy default as an explicit axis value, so existing benchmark numbers remain reproducible when a campaign records `ped_speed_tier: slow`.
- Campaigns that vary pedestrian pace should record the tier / desired-speed distribution alongside results and treat any ranking computed only at the slow default as conditional on that regime (documented in `docs/benchmark.md`).

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

## Domain-Aware Approval

- Required for this PR: yes — pedestrian desired-speed calibration changes the interpretation of interaction-regime benchmark results.
- Domains reviewed: benchmark interpretation and claim boundary.
- Status: approved for implementation integrity only by the gate review at head `5349e1adc`; no campaign result is approved or claimed.
- Comparator / validity: the legacy spawn-coupled slow regime remains the default; any speed-tier comparison must record tier/distribution and exclude fallback/degraded rows.
- Claim boundary: focused CPU tests prove configuration and runtime wiring, not planner ranking or safety improvement.
