### PR TITLE
Issue #5006: post-merge review-thread sweep + enumerated drift (#4934/#4854/#4671) (cheap-lane worker)

### DIFF
--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -19,6 +19,24 @@ Check these in order:
 
 Reject changes that only add code or docs without task-appropriate proof.
 
+## Post-Merge Review-Thread Sweep
+
+Merge does not mean "all review findings adjudicated." Inline review threads left unresolved
+on a merged PR are easily lost, and some are later fixed by successor PRs without ever being
+linked. After merge, run a short sweep so the thread ledger reflects reality:
+
+1. Re-query unresolved review threads on the merged PR (`gh api graphql` on `reviewThreads`,
+   filtering `isResolved == false`).
+2. For each unresolved thread, either resolve it (if the merge or a successor commit addressed
+   the comment) or link the fixing PR/commit/issue in a one-line reply. Threads whose substance
+   is still open get a dedicated follow-up issue instead of a silent resolve.
+3. Record the sweep outcome in the merge note or the issue thread so the count of unresolved
+   threads is auditable.
+
+Treat substantive threads that need real work (for example a fail-closed contract gap or an
+end-to-end assertion gap) as follow-up issues, not as items to resolve with a link. This sweep is
+bookkeeping: it does not change benchmark, metric, or schema semantics.
+
 ## Intended Design Alignment
 
 Before treating CI or targeted tests as sufficient, compare the PR against the linked issue,

--- a/docs/context/evidence/issue_2910_publication_suite_certification_report/report.json
+++ b/docs/context/evidence/issue_2910_publication_suite_certification_report/report.json
@@ -17,12 +17,12 @@
     },
     {
       "criterion": "Release summary states exactly what benchmark supports.",
-      "evidence": "Report states claim boundary and lists blockers that prevent publication readiness.",
+      "evidence": "Report states claim boundary; publication-suite policy is applied but the release badge is deferred pending the #4364 release re-base.",
       "result": "improved_but_release_publication_still_blocked"
     },
     {
       "criterion": "If intended evidence cannot be produced, fail closed.",
-      "evidence": "status remains blocked while excluded/stress-only scenarios and matrix certification blockers remain.",
+      "evidence": "status remains blocked_pending_rebase; excluded/stress-only scenarios are policy-handled but the release badge is deferred until the #4364 release re-base.",
       "result": "met"
     }
   ],

--- a/docs/context/issue_4826_camera_ready_gpu_lifecycle.md
+++ b/docs/context/issue_4826_camera_ready_gpu_lifecycle.md
@@ -31,7 +31,7 @@ A 2 MiB allocation failing on a 44 GiB card after 14 hours means the leak is sev
 ### Phase 0: CPU-safe telemetry abstraction
 Status: Complete (PR #4836)
 
-A `cleanup_gpu_memory_between_arms()` helper in `scripts/tools/run_camera_ready_benchmark.py` provides:
+The `_cleanup_gpu_memory_between_arms()` helper in `robot_sf/benchmark/camera_ready/campaign.py` provides:
 - RSS measurement via `psutil.Process().memory_info().rss`
 - CUDA allocated/reserved/max allocated tracking when PyTorch is available
 - `torch.cuda.empty_cache()` and `torch.cuda.synchronize()` calls
@@ -40,7 +40,7 @@ A `cleanup_gpu_memory_between_arms()` helper in `scripts/tools/run_camera_ready_
 ### Phase 1: Per-arm cleanup in in-process runner
 Status: Complete (PR #4836)
 
-`_run_campaign_planner_matrix()` in `robot_sf/benchmark/camera_ready/campaign.py` now calls `cleanup_gpu_memory_between_arms()` after each planner/kinematics variant completes.
+`_run_campaign_planner_matrix()` in `robot_sf/benchmark/camera_ready/campaign.py` now calls `_cleanup_gpu_memory_between_arms()` after each planner/kinematics variant completes.
 
 ### Phase 2: Subprocess isolation per arm
 Status: Complete (PR #4846)

--- a/docs/context/issue_4933_virtual_validation_mitigation_feasibility.md
+++ b/docs/context/issue_4933_virtual_validation_mitigation_feasibility.md
@@ -1,4 +1,4 @@
-# Issue 4933: Virtual-Validation Mitigation Techniques — Feasibility and Effort Assessment
+# Issue #4933 — Virtual-Validation Mitigation Techniques — Feasibility and Effort Assessment
 
 This assessment evaluates five mitigation techniques from the autonomous-driving virtual-validation
 literature, mapped onto robot_sf_ll7's existing infrastructure. For each technique: what it adds,
@@ -103,8 +103,8 @@ unit than naive random. Overlaps with the scenario-generation epic (#4932).
   rare-event smoke runs.
 - **`configs/benchmarks/rare_event/`**: YAML specs for crossing and static-constriction
   rare-event scenarios.
-- **`robot_sf/benchmark/scenario_certification.py`**: feasibility checks ensure mutated
-  scenarios remain valid.
+- **`robot_sf/scenario_certification/feasibility_diagnostics.py`**: feasibility checks ensure
+  mutated scenarios remain valid.
 - **`scripts/benchmark/run_scenario_criticality_optimization.py`**: criticality search as
   baseline for learned/adaptive stress-testing approaches.
 

--- a/scripts/analysis/build_issue_2910_publication_suite_certification_report.py
+++ b/scripts/analysis/build_issue_2910_publication_suite_certification_report.py
@@ -324,8 +324,13 @@ def build_report(
                     "blockers after policy application."
                     if status == "pass"
                     else (
-                        "Report states claim boundary and lists blockers that prevent "
-                        "publication readiness."
+                        "Report states claim boundary; publication-suite policy is applied "
+                        "but the release badge is deferred pending the #4364 release re-base."
+                        if status == "blocked_pending_rebase"
+                        else (
+                            "Report states claim boundary and lists blockers that prevent "
+                            "publication readiness."
+                        )
                     )
                 ),
                 "result": "met"
@@ -339,8 +344,14 @@ def build_report(
                     "versioned suite policy."
                     if status == "pass"
                     else (
-                        "status remains blocked while excluded/stress-only scenarios and "
-                        "matrix certification blockers remain."
+                        "status remains blocked_pending_rebase; excluded/stress-only scenarios "
+                        "are policy-handled but the release badge is deferred until the #4364 "
+                        "release re-base."
+                        if status == "blocked_pending_rebase"
+                        else (
+                            "status remains blocked while excluded/stress-only scenarios and "
+                            "matrix certification blockers remain."
+                        )
                     )
                 ),
                 "result": "met",


### PR DESCRIPTION
## What and why

Resolves the **first bounded slice** of #5006 (workflow/docs: post-merge review-thread sweep + resolve enumerated drift #4934/#4854/#4671). Bookkeeping + documentation edits only; does **not** change benchmark/metric/schema semantics. Safe before the 2026-07-18 freeze.

Three acceptance criteria in #5006; this PR fully closes two and substantially advances the third:

- ✅ **#4934 / #4854 / #4671 drift corrected on `main`.**
- ✅ **Post-merge "sweep unresolved threads" step added to the review-gate checklist.**
- 🟡 **Sweep of open inline threads:** the 12 directly-adjudicable threads are now **resolved on GitHub with linking replies** (verified: unresolved-thread count dropped **45 → 33** across **18 → 13 PRs**). The **complete classified ledger** of the residual 33 advisory threads is below so they can be adjudicated next. Those 33 need maintainer won't-fix/follow-up calls (see "What remains").

## Changes

### 1. Enumerated documentation drift (criterion 1)

**#4934 — `docs/context/issue_4933_virtual_validation_mitigation_feasibility.md`**
- H1 heading now follows the `docs/context/` convention: `# Issue 4933: …` → `# Issue #4933 — …` (adds the `#` issue prefix and the em-dash separator).
- Stale path `robot_sf/benchmark/scenario_certification.py` (verified **non-existent**) → `robot_sf/scenario_certification/feasibility_diagnostics.py` (verified present).

**#4854 — `docs/context/issue_4826_camera_ready_gpu_lifecycle.md`**
- `_cleanup_gpu_memory_between_arms()` location corrected from `scripts/tools/run_camera_ready_benchmark.py` to its real definition site `robot_sf/benchmark/camera_ready/campaign.py` (verified at `campaign.py:255`).
- Added the leading underscore so the Phase 1 call-site prose matches the real symbol `_cleanup_gpu_memory_between_arms()`.

**#4671 — `scripts/analysis/build_issue_2910_publication_suite_certification_report.py` + regenerated `report.json`**
- The generator previously emitted `"…lists blockers that prevent publication readiness."` and `"…matrix certification blockers remain."` for **every** non-`pass` status, including `blocked_pending_rebase` — where `blockers == []` and `release_claim_matrix_blocked_rows == []`. Added a dedicated `blocked_pending_rebase` branch so the evidence strings reflect the policy-applied, badge-deferred-to-#4364 state. `report.json` regenerated from the generator (only the two evidence strings change; `report.md` is byte-identical).

### 2. Review-gate checklist (criterion 3)

`docs/code_review.md` — new **"Post-Merge Review-Thread Sweep"** section right after "Review Priorities": re-query unresolved threads, resolve-or-link each, and record the sweep outcome so "merged" comes to mean "findings adjudicated".

### 3. Thread sweep (criterion 2)

After opening this PR I resolved the 12 directly-adjudicable threads on GitHub with one-line linking replies (verified recount: unresolved 45 → 33). The substantive threads #5006 explicitly calls out were **linked, not re-done**: #4898 → fix #5013 (issue #5003); #4845 → dedicated issue #5007.

## Validation

```
uv run ruff check scripts/analysis/build_issue_2910_publication_suite_certification_report.py   -> All checks passed
uv run ruff format (changed files)                                                                 -> clean
python -m py_compile scripts/analysis/build_issue_2910_publication_suite_certification_report.py   -> OK
# report.json regenerated by executing the real generator logic on the real tracked inputs (see env note)
uv run pytest tests/docs/test_module_doctests.py -q                                                -> 11 passed
```

- Existing analysis test `tests/analysis/test_build_issue_2910_publication_suite_certification_report.py` asserts `status == blocked_pending_rebase`, `blocker_count == 0`, `policy_status == applied` but **does not** assert on the evidence-string wording, so this change is compatible. `render_markdown` does not render `acceptance_evidence`, so markdown output is unaffected.
- **Environment caveat (pre-existing, not introduced here):** on `origin/main` the import chain `robot_sf.benchmark` → `gym_env` → `sim_config` → `from pysocialforce.scene import normalize_integration_scheme` fails because the installed `pysocialforce 2.0.0` lacks that symbol. This blocks collection of `tests/analysis/...` and direct `uv run` of the generator in this worktree. To regenerate `report.json` I executed the **real generator logic on the real tracked inputs**, stubbing only the trivial `load_json` (= `json.load`) dependency to avoid the unrelated `robot_sf/benchmark/__init__.py` heavy import. The regenerated diff is exactly the two evidence strings. The drift fixes and the new `blocked_pending_rebase` branch are independent of this env issue.

## Post-merge unresolved-thread ledger (18 merged PRs, 45 threads)

Directly adjudicated in this slice (resolved/linked on GitHub):

| PR | Thread(s) | Disposition |
| --- | --- | --- |
| #4934 | heading; cert path | **Fixed by this PR** — resolved |
| #4854 | fn location; fn name | **Fixed by this PR** — resolved |
| #4671 | evidence text | **Fixed by this PR** — resolved |
| #4898 | NaN/blank skip; fail-closed on missing input | **Fixed by #5013** (issue #5003) — linked |
| #4845 | 5 replay-figure E2E/caption/encoding threads | **Tracked in #5007** — linked (not re-done, per #5006) |

Residual advisory threads needing maintainer adjudication (won't-fix vs follow-up issue vs implement). These are CodeRabbit/Gemini medium/high nits on already-merged PRs; I did **not** silently resolve them since that is a maintainer call, and most have no successor fix:

- **#4890 (4):** cache `restore-keys` for `setup-ci-python`; validate `backoff_base`/`backoff_cap` in `uv_sync_retry.sh`; two matching contract-test assertions.
- **#4928 (1):** `kinematics_feasibility` inconsistency in `TestMultiPlannerMetadataKeyStability`.
- **#4931 (1):** `TestBundleReproducibleByteIdentical` docstring/exclusion accuracy.
- **#4936 (5):** deterministic timestamps in record-builder tests; `pin_generated_at or …` None-vs-falsy distinction (×2); non-deterministic `Generated:` timestamp in `SELECTION_REPORT.md` (×2).
- **#4940 (3):** redundant `planner_failures` recomputation (high); missing `_planner_run` None-guard; `_derive_mechanism_label` return-type mismatch.
- **#4945 (4):** NaN/Inf filtering in `seed_distribution_report.py` (import `math` + 3 filter sites).
- **#4948 (1):** macOS worker-cap message vs `MACOS_MIN/MAX_WORKERS` consistency.
- **#4949 (4):** non-finite filtering in `min_separation_*` (high); `obs_mode` None normalization (high); `_build_policy` return-type vs holonomic; missing `"sf"` alias in holonomic boundary text.
- **#4951 (1):** `obs_mode` explicit-None handling.
- **#4952 (5):** exception-safe pytest-tree cleanup (high); redundant `is_running()` check; catch `psutil.AccessDenied`; early config validation; test child-process cleanup.
- **#4953 (1):** `deepcopy` of `algo_meta` to prevent caller mutation.
- **#5022 (1):** assert `evaluation_replacement` points to an existing file.
- **#5024 (2):** wrap literals in backticks / exact float representation in `docs/lidar_configuration.md`.

## What remains (successor work)

- **Criterion 2 remainder:** adjudicate the ~33 residual advisory threads above (resolve-as-wont-fix, implement, or open follow-up issues). This PR provides the classified ledger so that work is mechanical. A few may already be covered by later map_runner/test PRs and can be linked on verification.
- **Env issue (out of scope here):** reconcile `pysocialforce` version with the `normalize_integration_scheme` import added on `origin/main` so `tests/analysis` collects again.

## Successor slice statement

Successor slice: this is the first slice for #5006 and does not duplicate any prior merged PR. It fully closes criteria 1 and 3, resolves/links the 12 directly-adjudicable threads for criterion 2, and produces the full classified ledger for the remainder.

Refs #5006

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
