### PR TITLE
Issue #5021: REST-backed issue-with-comments helper (cheap-lane worker)

### DIFF
--- a/docs/context/issue_713_batch_first_issue_workflow.md
+++ b/docs/context/issue_713_batch_first_issue_workflow.md
@@ -46,13 +46,36 @@ Use the cheapest source of truth for the question:
 | --- | --- | --- |
 | Working tree, branch, changed files, merge base, commits | local `git` | Do not ask GitHub for state already present locally. |
 | Interactive issue, PR, and project inspection | GitHub MCP / GitHub app tools | Prefer this for ad-hoc triage, review context, commenting, and linking when authorized. Fall back to REST, local `git`, or narrow GraphQL when MCP/app tools are unavailable or would hide a costly GraphQL path. |
-| Issue body, labels, comments, assignees, open/closed state | REST via `gh api repos/ll7/robot_sf_ll7/issues/...` | Avoid `gh issue view/list` if GraphQL quota is low because those commands may use GraphQL. |
+| Issue body, labels, comments, assignees, open/closed state | `scripts/dev/gh_issue_rest.py view <n> --comments`, or REST via `gh api repos/ll7/robot_sf_ll7/issues/...` directly | Avoid `gh issue view/list` for autonomous workflows: those commands request the deprecated `repository.issue.projectCards` GraphQL field and fail on some `gh` versions (issue #5021). `gh_issue_rest.py` is the shared REST-backed issue-with-comments helper that never touches that field. |
 | PR metadata, branch refs, commits, workflow runs | REST via `gh api` | Poll sparingly; use event/check URLs from known PRs when available. |
 | Project #5 item status, priority, duration, reviewed date | GraphQL / `gh project item-*` | Projects v2 is GraphQL-only; batch and cache aggressively. |
 | Review-thread resolution or nested review data | GraphQL | Keep queries narrow and use known node IDs. |
 
 Do not use a broad GraphQL query for ordinary issue or PR cleanup when a REST endpoint or local
 Git command can answer the same question.
+
+### Issue-with-comments helper
+
+`gh issue view <number> --comments` fails on some GitHub CLI versions because it requests the
+deprecated classic-Projects GraphQL field `repository.issue.projectCards` (issue #5021). Autonomous
+workflows that must read an issue together with its comment thread should use the shared REST-backed
+helper instead:
+
+```bash
+# human-readable thread (drop-in for `gh issue view <n> --comments`)
+uv run python scripts/dev/gh_issue_rest.py view <number> --comments --plain
+
+# selected JSON fields, normalized to match `gh issue view --json`
+uv run python scripts/dev/gh_issue_rest.py view <number> --json number title state url labels
+
+# library use for Python callers
+from scripts.dev.gh_issue_rest import fetch_issue_with_comments
+payload = fetch_issue_with_comments(<number>)
+```
+
+The helper reads through `gh api` (REST only), paginates comments, fails closed on errors or when a
+thread exceeds the page budget, and normalizes `state`/`url` to the shapes `gh issue view --json`
+consumers already expect.
 
 ## Project #5 Cache
 

--- a/scripts/dev/gh_issue_rest.py
+++ b/scripts/dev/gh_issue_rest.py
@@ -84,7 +84,17 @@ def _gh_api(
     args = ["gh", "api", path]
     if params:
         args.extend(params)
-    return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+    try:
+        return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+    except FileNotFoundError:
+        # gh CLI not installed / not on PATH. Return a failed result instead of
+        # raising so callers keep the documented "returns error payload" contract.
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=127,
+            stdout="",
+            stderr="gh CLI not found on PATH; install GitHub CLI (https://cli.github.com/)",
+        )
 
 
 def _parse_json(
@@ -102,6 +112,16 @@ def _parse_json(
     except json.JSONDecodeError as exc:
         snippet = result.stdout.strip()[:200]
         return None, f"{what} returned invalid JSON: {exc}; stdout snippet: {snippet!r}"
+
+
+def _as_str(raw: Any) -> str:
+    """Coerce a JSON value to ``str``, mapping explicit ``None`` to ``""``.
+
+    Guards against ``str(None) -> "None"`` when a REST field is present but
+    ``null`` (e.g. an issue with an empty body), while preserving valid falsy
+    values such as ``0`` or ``""``.
+    """
+    return "" if raw is None else str(raw)
 
 
 def _normalize_state(raw: Any) -> str:
@@ -124,16 +144,16 @@ def _normalize_issue(raw: dict[str, Any]) -> dict[str, Any]:
     user = raw.get("user") or {}
     return {
         "number": int(raw.get("number", 0)),
-        "title": str(raw.get("title", "")),
-        "body": str(raw.get("body", "") or ""),
+        "title": _as_str(raw.get("title")),
+        "body": _as_str(raw.get("body")),
         "state": _normalize_state(raw.get("state", "")),
-        "url": str(raw.get("html_url", raw.get("url", ""))),
-        "user": str(user.get("login", "") if isinstance(user, dict) else ""),
-        "author_association": str(raw.get("author_association", "")),
+        "url": _as_str(raw.get("html_url", raw.get("url", ""))),
+        "user": _as_str(user.get("login") if isinstance(user, dict) else ""),
+        "author_association": _as_str(raw.get("author_association")),
         "labels": labels,
         "assignees": assignees,
-        "created_at": str(raw.get("created_at", "")),
-        "updated_at": str(raw.get("updated_at", "")),
+        "created_at": _as_str(raw.get("created_at")),
+        "updated_at": _as_str(raw.get("updated_at")),
     }
 
 
@@ -142,12 +162,12 @@ def _normalize_comment(raw: dict[str, Any]) -> dict[str, Any]:
     user = raw.get("user") or {}
     return {
         "id": int(raw.get("id", 0)),
-        "user": str(user.get("login", "") if isinstance(user, dict) else ""),
-        "author_association": str(raw.get("author_association", "")),
-        "created_at": str(raw.get("created_at", "")),
-        "updated_at": str(raw.get("updated_at", "")),
-        "url": str(raw.get("html_url", raw.get("url", ""))),
-        "body": str(raw.get("body", "") or ""),
+        "user": _as_str(user.get("login") if isinstance(user, dict) else ""),
+        "author_association": _as_str(raw.get("author_association")),
+        "created_at": _as_str(raw.get("created_at")),
+        "updated_at": _as_str(raw.get("updated_at")),
+        "url": _as_str(raw.get("html_url", raw.get("url", ""))),
+        "body": _as_str(raw.get("body")),
     }
 
 
@@ -305,7 +325,10 @@ def _cmd_view(args: argparse.Namespace) -> int:
     if payload.get("status") != "ok":
         print(payload.get("error", "unknown error"), file=sys.stderr)
         return 1
-    if not args.comments:
+    # Comments are opt-in (mirroring `gh issue view`, which omits them without
+    # --comments). Keep them when --comments is passed, or when --json explicitly
+    # requests the "comments" field (so `--json comments` returns the thread, not {}).
+    if not args.comments and "comments" not in args.fields:
         payload.pop("comments", None)
     if args.plain:
         sys.stdout.write(render_issue_plain(payload))
@@ -341,7 +364,7 @@ def _build_parser() -> argparse.ArgumentParser:
     view.add_argument(
         "--comments",
         action="store_true",
-        help="Include the comments thread (default unless --json restricts fields).",
+        help="Include the comments thread (also included when --json requests 'comments').",
     )
     view.add_argument(
         "--json",

--- a/scripts/dev/gh_issue_rest.py
+++ b/scripts/dev/gh_issue_rest.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Shared REST-backed GitHub issue-with-comments helper for autonomous workflows.
+
+Why this exists
+---------------
+``gh issue view <number> --comments`` requests the deprecated
+``repository.issue.projectCards`` GraphQL field, which fails on some GitHub CLI
+versions with an error like::
+
+    GraphQL: Projects (classic) is being deprecated ... (repository.issue.projectCards)
+
+That breaks autonomous workflows that read an issue and its comments before
+editing (see issue #5021). This module reads issues and comments through the
+REST API via ``gh api``, which never touches the deprecated classic-Projects
+GraphQL field, so callers get a deterministic issue-with-comments read
+regardless of the installed ``gh`` version. This aligns with the repository's
+batch-first GitHub workflow, which already prefers REST-backed reads for
+ordinary issue/PR objects (see ``docs/context/issue_713_batch_first_issue_workflow.md``).
+
+Public library API
+------------------
+- :func:`fetch_issue`           -- normalized issue body via REST
+- :func:`fetch_comments`        -- all comments via REST (paginated)
+- :func:`fetch_issue_with_comments` -- combined issue + comments payload
+- :func:`render_issue_plain`    -- gh-like human-readable thread rendering
+
+CLI
+---
+::
+
+    python scripts/dev/gh_issue_rest.py view <number> [--repo <owner/repo>]
+        [--comments] [--json <fields>] [--plain] [--max-comment-pages N]
+
+Use this as a drop-in replacement for ``gh issue view <number> --comments`` in
+autonomous workflows. It fails closed (nonzero exit, clear stderr) when the REST
+read fails or returns malformed JSON.
+
+Field normalization
+-------------------
+REST returns lowercase ``state`` (``open``/``closed``) and ``html_url``. To be a
+drop-in for ``gh issue view --json`` consumers, the normalized output exposes
+``state`` uppercased (``OPEN``/``CLOSED``) and ``url`` equal to ``html_url``.
+Comment entries use ``user`` (login) and ``url`` (``html_url``) for the same
+reason.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+DEFAULT_MAX_COMMENT_PAGES = 10
+COMMENTS_PAGE_SIZE = 100
+
+# Fields exposed in the normalized issue payload, in a stable order.
+ISSUE_FIELDS = (
+    "number",
+    "title",
+    "body",
+    "state",
+    "url",
+    "user",
+    "author_association",
+    "labels",
+    "assignees",
+    "created_at",
+    "updated_at",
+)
+COMMENT_FIELDS = ("id", "user", "author_association", "created_at", "updated_at", "url", "body")
+
+
+def _gh_api(
+    path: str, *, params: list[str] | None = None, timeout: int = 30
+) -> subprocess.CompletedProcess:
+    """Run a ``gh api`` REST read and return the completed process.
+
+    Failures are returned (not raised) so callers can render clear errors. The
+    params list lets callers add ``--field``/``-q`` style ``gh api`` flags.
+    """
+    args = ["gh", "api", path]
+    if params:
+        args.extend(params)
+    return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+
+
+def _parse_json(
+    result: subprocess.CompletedProcess, *, what: str
+) -> tuple[dict[str, Any] | list[Any] | None, str]:
+    """Parse JSON from a ``gh api`` result, returning ``(data, error)``.
+
+    On failure ``data`` is ``None`` and ``error`` is a human-readable message.
+    """
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"gh api exited with code {result.returncode}"
+        return None, f"{what} failed: {detail}"
+    try:
+        return json.loads(result.stdout), ""
+    except json.JSONDecodeError as exc:
+        snippet = result.stdout.strip()[:200]
+        return None, f"{what} returned invalid JSON: {exc}; stdout snippet: {snippet!r}"
+
+
+def _normalize_state(raw: Any) -> str:
+    """Return an uppercase state string matching ``gh issue view --json``."""
+    return str(raw).upper() if raw else ""
+
+
+def _normalize_issue(raw: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a raw REST issue payload to the stable output shape."""
+    labels = sorted(
+        str(label.get("name", ""))
+        for label in raw.get("labels", [])
+        if isinstance(label, dict) and label.get("name")
+    )
+    assignees = sorted(
+        str(user.get("login", ""))
+        for user in raw.get("assignees", [])
+        if isinstance(user, dict) and user.get("login")
+    )
+    user = raw.get("user") or {}
+    return {
+        "number": int(raw.get("number", 0)),
+        "title": str(raw.get("title", "")),
+        "body": str(raw.get("body", "") or ""),
+        "state": _normalize_state(raw.get("state", "")),
+        "url": str(raw.get("html_url", raw.get("url", ""))),
+        "user": str(user.get("login", "") if isinstance(user, dict) else ""),
+        "author_association": str(raw.get("author_association", "")),
+        "labels": labels,
+        "assignees": assignees,
+        "created_at": str(raw.get("created_at", "")),
+        "updated_at": str(raw.get("updated_at", "")),
+    }
+
+
+def _normalize_comment(raw: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a raw REST comment payload to the stable output shape."""
+    user = raw.get("user") or {}
+    return {
+        "id": int(raw.get("id", 0)),
+        "user": str(user.get("login", "") if isinstance(user, dict) else ""),
+        "author_association": str(raw.get("author_association", "")),
+        "created_at": str(raw.get("created_at", "")),
+        "updated_at": str(raw.get("updated_at", "")),
+        "url": str(raw.get("html_url", raw.get("url", ""))),
+        "body": str(raw.get("body", "") or ""),
+    }
+
+
+def fetch_issue(number: int, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:
+    """Fetch a single issue via REST and return the normalized payload.
+
+    On failure returns ``{"number": number, "status": "error", "error": ...}``
+    rather than raising, mirroring :func:`scripts.dev.snapshot_issue_batch.fetch_issue`.
+    """
+    result = _gh_api(f"repos/{repo}/issues/{number}")
+    data, error = _parse_json(result, what=f"issue {number}")
+    if error:
+        return {"number": number, "status": "error", "error": error}
+    if not isinstance(data, dict):
+        return {
+            "number": number,
+            "status": "error",
+            "error": f"issue {number} payload was not an object",
+        }
+    payload = _normalize_issue(data)
+    payload["status"] = "ok"
+    return payload
+
+
+def fetch_comments(
+    number: int,
+    *,
+    repo: str = DEFAULT_REPO,
+    max_pages: int = DEFAULT_MAX_COMMENT_PAGES,
+) -> dict[str, Any]:
+    """Fetch all comments for an issue via REST, paginating up to ``max_pages``.
+
+    Returns ``{"status": "ok", "comments": [...]}`` on success. Fails closed with
+    ``{"status": "error", "error": ...}`` when the REST read fails, the payload
+    is malformed, or the comment count exceeds the page budget (so autonomous
+    workflows never silently truncate a long thread).
+    """
+    if max_pages < 1:
+        return {"status": "error", "error": f"max_pages must be >= 1, got {max_pages}"}
+    comments: list[dict[str, Any]] = []
+    for page in range(1, max_pages + 1):
+        # Query parameters go in the path for a GET: gh api treats --field as a
+        # request body (POST/JSON), which would 422 on this read-only endpoint.
+        result = _gh_api(
+            f"repos/{repo}/issues/{number}/comments?per_page={COMMENTS_PAGE_SIZE}&page={page}",
+        )
+        data, error = _parse_json(result, what=f"comments page {page} for issue {number}")
+        if error:
+            return {"status": "error", "error": error}
+        if not isinstance(data, list):
+            return {
+                "status": "error",
+                "error": f"comments payload for issue {number} page {page} was not a list",
+            }
+        page_items = [_normalize_comment(item) for item in data if isinstance(item, dict)]
+        comments.extend(page_items)
+        if len(page_items) < COMMENTS_PAGE_SIZE:
+            return {"status": "ok", "comments": comments}
+    # Exhausted the page budget with a full last page: there may be more comments.
+    return {
+        "status": "error",
+        "error": (
+            f"issue {number} has more than {max_pages * COMMENTS_PAGE_SIZE} comments; "
+            f"increase --max-comment-pages to read the full thread"
+        ),
+    }
+
+
+def fetch_issue_with_comments(
+    number: int,
+    *,
+    repo: str = DEFAULT_REPO,
+    max_comment_pages: int = DEFAULT_MAX_COMMENT_PAGES,
+) -> dict[str, Any]:
+    """Fetch an issue together with all of its comments via REST.
+
+    The returned payload has the normalized issue fields plus a ``comments`` list
+    and a top-level ``status`` of ``ok``. On any failure, returns
+    ``{"number": number, "status": "error", "error": ...}``.
+    """
+    issue = fetch_issue(number, repo=repo)
+    if issue.get("status") != "ok":
+        return issue
+    comment_result = fetch_comments(number, repo=repo, max_pages=max_comment_pages)
+    if comment_result.get("status") != "ok":
+        return {
+            "number": number,
+            "status": "error",
+            "error": str(comment_result.get("error", "unknown comments error")),
+        }
+    issue["comments"] = comment_result["comments"]
+    return issue
+
+
+def render_issue_plain(payload: dict[str, Any]) -> str:
+    """Render a normalized issue-with-comments payload as a gh-like thread.
+
+    Intended as a drop-in for ``gh issue view <number> --comments`` plain output
+    in shell pipelines that expect human-readable text rather than JSON.
+    """
+    title = payload.get("title", "")
+    state = payload.get("state", "")
+    url = payload.get("url", "")
+    author = payload.get("user", "")
+    association = payload.get("author_association", "")
+    labels = payload.get("labels", []) or []
+    body = payload.get("body", "") or ""
+    lines: list[str] = []
+    lines.append(f"title:\t{title}")
+    lines.append(f"state:\t{state}")
+    if association:
+        lines.append(f"association:\t{association}")
+    if author:
+        lines.append(f"author:\t{author}")
+    if labels:
+        lines.append("labels:\t" + ", ".join(labels))
+    lines.append(f"url:\t{url}")
+    lines.append("--")
+    lines.append(body.rstrip())
+    for comment in payload.get("comments", []) or []:
+        c_author = comment.get("user", "")
+        c_assoc = comment.get("author_association", "")
+        c_created = comment.get("created_at", "")
+        c_body = (comment.get("body", "") or "").rstrip()
+        header = c_author
+        if c_assoc:
+            header = f"{c_author} ({c_assoc})"
+        if c_created:
+            header = f"{header} commented on {c_created}"
+        lines.append("--")
+        lines.append(header)
+        lines.append("--")
+        lines.append(c_body)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _select_fields(payload: dict[str, Any], fields: list[str]) -> dict[str, Any]:
+    """Return only the requested fields from a normalized payload."""
+    if not fields:
+        return payload
+    known = set(ISSUE_FIELDS) | {"comments", "status", "number"}
+    unknown = [field for field in fields if field not in known]
+    if unknown:
+        raise ValueError(f"unknown field(s): {', '.join(unknown)}")
+    return {field: payload[field] for field in fields if field in payload}
+
+
+def _cmd_view(args: argparse.Namespace) -> int:
+    """Implement the ``view`` subcommand."""
+    payload = fetch_issue_with_comments(
+        args.number,
+        repo=args.repo,
+        max_comment_pages=args.max_comment_pages,
+    )
+    if payload.get("status") != "ok":
+        print(payload.get("error", "unknown error"), file=sys.stderr)
+        return 1
+    if not args.comments:
+        payload.pop("comments", None)
+    if args.plain:
+        sys.stdout.write(render_issue_plain(payload))
+        return 0
+    try:
+        selected = _select_fields(payload, args.fields)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(selected, indent=2, ensure_ascii=False))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="gh_issue_rest.py",
+        description=(
+            "REST-backed GitHub issue-with-comments helper. Drop-in replacement "
+            "for 'gh issue view <number> --comments' that avoids the deprecated "
+            "classic-Projects GraphQL field (issue #5021)."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    view = sub.add_parser("view", help="Read an issue and (optionally) its comments via REST.")
+    view.add_argument("number", type=int, help="Issue number.")
+    view.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help=f"owner/repo to read (default: {DEFAULT_REPO}).",
+    )
+    view.add_argument(
+        "--comments",
+        action="store_true",
+        help="Include the comments thread (default unless --json restricts fields).",
+    )
+    view.add_argument(
+        "--json",
+        dest="fields",
+        default=[],
+        nargs="*",
+        metavar="FIELD",
+        help="Emit only these JSON fields (space-separated). Implies JSON output.",
+    )
+    view.add_argument(
+        "--plain",
+        action="store_true",
+        help="Render a gh-like human-readable thread instead of JSON.",
+    )
+    view.add_argument(
+        "--max-comment-pages",
+        type=int,
+        default=DEFAULT_MAX_COMMENT_PAGES,
+        help=f"Maximum comment pages to read (each {COMMENTS_PAGE_SIZE} comments).",
+    )
+    view.set_defaults(func=_cmd_view)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns a process exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/dev/test_gh_issue_rest.py
+++ b/tests/dev/test_gh_issue_rest.py
@@ -1,0 +1,248 @@
+"""Tests for the REST-backed GitHub issue-with-comments helper (issue #5021).
+
+These tests mock ``gh api`` so they run offline and never hit the network. They
+cover the success path, comment pagination, field normalization (the drop-in
+contract for ``gh issue view --json`` consumers), fail-closed error handling,
+and the CLI render modes.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.dev.gh_issue_rest import (
+    COMMENTS_PAGE_SIZE,
+    fetch_comments,
+    fetch_issue,
+    fetch_issue_with_comments,
+    main,
+    render_issue_plain,
+)
+
+
+def _proc(*, stdout: str = "", stderr: str = "", returncode: int = 0) -> MagicMock:
+    """Build a fake ``subprocess.CompletedProcess`` for ``gh api``."""
+    return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def _raw_issue(*, number: int = 5021, state: str = "open") -> dict:
+    """Return a raw REST issue payload with REST-native field shapes."""
+    return {
+        "number": number,
+        "title": "friction: gh issue view fails on deprecated classic-project field",
+        "body": "## What I was doing\n\nReading the live issue",
+        "state": state,
+        "html_url": f"https://github.com/ll7/robot_sf_ll7/issues/{number}",
+        "url": f"graphql://issues/{number}",
+        "user": {"login": "ll7"},
+        "author_association": "OWNER",
+        "labels": [{"name": "workflow"}, {"name": "bug"}],
+        "assignees": [{"login": "alice"}, {"login": "bob"}],
+        "created_at": "2026-07-10T08:45:56Z",
+        "updated_at": "2026-07-10T09:00:00Z",
+    }
+
+
+def _raw_comment(*, cid: int = 1, login: str = "ll7") -> dict:
+    """Return a raw REST comment payload with REST-native field shapes."""
+    return {
+        "id": cid,
+        "body": "## Implementation plan",
+        "html_url": f"https://github.com/ll7/robot_sf_ll7/issues/5021#issuecomment-{cid}",
+        "url": f"graphql://issues/comments/{cid}",
+        "user": {"login": login},
+        "author_association": "OWNER",
+        "created_at": "2026-07-10T11:12:48Z",
+        "updated_at": "2026-07-10T11:12:48Z",
+    }
+
+
+def test_fetch_issue_normalizes_rest_fields_to_gh_json_shape() -> None:
+    """REST ``state``/``html_url`` should be normalized to gh ``--json`` shape."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.return_value = _proc(stdout=json.dumps(_raw_issue(state="open")))
+        payload = fetch_issue(5021)
+    assert payload["status"] == "ok"
+    assert payload["number"] == 5021
+    # state uppercased to match gh issue view --json
+    assert payload["state"] == "OPEN"
+    # url equals html_url, not the graphql url
+    assert payload["url"] == "https://github.com/ll7/robot_sf_ll7/issues/5021"
+    # labels/assignees flattened and sorted
+    assert payload["labels"] == ["bug", "workflow"]
+    assert payload["assignees"] == ["alice", "bob"]
+    assert payload["user"] == "ll7"
+    assert payload["author_association"] == "OWNER"
+
+
+def test_fetch_issue_fails_closed_on_nonzero_exit() -> None:
+    """A nonzero gh api exit should surface as a clear error payload, not raise."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.return_value = _proc(returncode=1, stderr="GraphQL: deprecation error")
+        payload = fetch_issue(5021)
+    assert payload["status"] == "error"
+    assert "deprecation error" in payload["error"]
+    assert payload["number"] == 5021
+
+
+def test_fetch_issue_fails_closed_on_invalid_json() -> None:
+    """Malformed JSON should fail closed with a helpful snippet."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.return_value = _proc(stdout="not-json{")
+        payload = fetch_issue(5021)
+    assert payload["status"] == "error"
+    assert "invalid JSON" in payload["error"]
+
+
+def test_fetch_comments_paginates_until_short_page() -> None:
+    """Comments should paginate by page size and stop on a short final page."""
+    full_page = [_raw_comment(cid=i) for i in range(COMMENTS_PAGE_SIZE)]
+    short_page = [_raw_comment(cid=COMMENTS_PAGE_SIZE + 1)]
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.side_effect = [
+            _proc(stdout=json.dumps(full_page)),
+            _proc(stdout=json.dumps(short_page)),
+        ]
+        result = fetch_comments(5021, max_pages=5)
+    assert result["status"] == "ok"
+    assert len(result["comments"]) == COMMENTS_PAGE_SIZE + 1
+    # normalization applied
+    assert result["comments"][0]["user"] == "ll7"
+    assert result["comments"][0]["url"].startswith("https://github.com/")
+    # only two pages fetched (stopped early on short page)
+    assert mock_api.call_count == 2
+
+
+def test_fetch_comments_fails_closed_when_page_budget_exceeded() -> None:
+    """A full last page must fail closed rather than silently truncate."""
+    full_page = [_raw_comment(cid=i) for i in range(COMMENTS_PAGE_SIZE)]
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.return_value = _proc(stdout=json.dumps(full_page))
+        result = fetch_comments(5021, max_pages=1)
+    assert result["status"] == "error"
+    assert "more than 100 comments" in result["error"]
+
+
+def test_fetch_comments_rejects_invalid_max_pages() -> None:
+    """A non-positive page budget should fail closed without any API call."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        result = fetch_comments(5021, max_pages=0)
+    assert result["status"] == "error"
+    assert "max_pages" in result["error"]
+    mock_api.assert_not_called()
+
+
+def test_fetch_issue_with_comments_combines_issue_and_thread() -> None:
+    """The combined helper should attach a normalized comments list."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.side_effect = [
+            _proc(stdout=json.dumps(_raw_issue())),
+            _proc(stdout=json.dumps([_raw_comment(cid=10, login="reviewer")])),
+        ]
+        payload = fetch_issue_with_comments(5021)
+    assert payload["status"] == "ok"
+    assert payload["state"] == "OPEN"
+    assert len(payload["comments"]) == 1
+    assert payload["comments"][0]["user"] == "reviewer"
+    # issue endpoint read first, then comments endpoint
+    assert mock_api.call_count == 2
+    assert "issues/5021" in mock_api.call_args_list[0].args[0]
+    assert "issues/5021/comments" in mock_api.call_args_list[1].args[0]
+
+
+def test_fetch_issue_with_comments_propagates_issue_error() -> None:
+    """If the issue read fails, the combined helper must not fetch comments."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.return_value = _proc(returncode=1, stderr="not found")
+        payload = fetch_issue_with_comments(999)
+    assert payload["status"] == "error"
+    assert "not found" in payload["error"]
+    assert mock_api.call_count == 1
+
+
+def test_render_issue_plain_resembles_gh_issue_view_comments() -> None:
+    """Plain rendering should expose title, state, url, body, and the thread."""
+    payload = {
+        "number": 5021,
+        "title": "friction",
+        "state": "OPEN",
+        "url": "https://github.com/ll7/robot_sf_ll7/issues/5021",
+        "author_association": "OWNER",
+        "user": "ll7",
+        "labels": ["workflow"],
+        "body": "## What I was doing",
+        "comments": [
+            {
+                "id": 1,
+                "user": "ll7",
+                "author_association": "OWNER",
+                "created_at": "2026-07-10T11:12:48Z",
+                "url": "https://github.com/ll7/robot_sf_ll7/issues/5021#issuecomment-1",
+                "body": "## Implementation plan",
+            }
+        ],
+    }
+    text = render_issue_plain(payload)
+    assert "title:\tfriction" in text
+    assert "state:\tOPEN" in text
+    assert "url:\thttps://github.com/ll7/robot_sf_ll7/issues/5021" in text
+    assert "## What I was doing" in text
+    assert "ll7 (OWNER) commented on 2026-07-10T11:12:48Z" in text
+    assert "## Implementation plan" in text
+
+
+def test_cli_view_plain_outputs_thread(capsys: pytest.CaptureFixture[str]) -> None:
+    """``view --plain`` should print the human-readable thread and exit 0."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.side_effect = [
+            _proc(stdout=json.dumps(_raw_issue())),
+            _proc(stdout=json.dumps([_raw_comment(cid=7)])),
+        ]
+        rc = main(["view", "5021", "--repo", "ll7/robot_sf_ll7", "--plain", "--comments"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "friction" in captured.out
+    assert "## Implementation plan" in captured.out
+
+
+def test_cli_view_json_without_comments_omits_thread(capsys: pytest.CaptureFixture[str]) -> None:
+    """Without ``--comments`` the JSON output must not include a comments key."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.side_effect = [
+            _proc(stdout=json.dumps(_raw_issue())),
+            _proc(stdout=json.dumps([_raw_comment(cid=7)])),
+        ]
+        rc = main(["view", "5021", "--json", "number", "title", "state"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert set(payload.keys()) == {"number", "title", "state"}
+    assert payload["state"] == "OPEN"
+
+
+def test_cli_view_fails_closed_on_rest_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """A REST failure should print the error to stderr and exit nonzero."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.return_value = _proc(
+            returncode=1, stderr="GraphQL: Projects (classic) is being deprecated"
+        )
+        rc = main(["view", "5021", "--comments"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "deprecated" in captured.err
+
+
+def test_cli_view_rejects_unknown_json_field(capsys: pytest.CaptureFixture[str]) -> None:
+    """Unknown --json fields should fail fast with exit code 2, not emit partial JSON."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.side_effect = [
+            _proc(stdout=json.dumps(_raw_issue())),
+            _proc(stdout=json.dumps([])),
+        ]
+        rc = main(["view", "5021", "--json", "bogus"])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "unknown field" in captured.err

--- a/tests/dev/test_gh_issue_rest.py
+++ b/tests/dev/test_gh_issue_rest.py
@@ -223,6 +223,41 @@ def test_cli_view_json_without_comments_omits_thread(capsys: pytest.CaptureFixtu
     assert payload["state"] == "OPEN"
 
 
+def test_cli_view_json_comments_returns_thread(capsys: pytest.CaptureFixture[str]) -> None:
+    """``--json comments`` must return the thread, not an empty object (gate #5049 fix)."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.side_effect = [
+            _proc(stdout=json.dumps(_raw_issue())),
+            _proc(stdout=json.dumps([_raw_comment(cid=7)])),
+        ]
+        rc = main(["view", "5021", "--json", "comments"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert set(payload.keys()) == {"comments"}
+    assert len(payload["comments"]) == 1
+    assert payload["comments"][0]["id"] == 7
+
+
+def test_fetch_issue_maps_null_body_to_empty_string() -> None:
+    """A REST ``null`` body must normalize to ``""``, never the string ``"None"`` (gate #5049)."""
+    raw = _raw_issue()
+    raw["body"] = None
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.return_value = _proc(stdout=json.dumps(raw))
+        payload = fetch_issue(5021)
+    assert payload["status"] == "ok"
+    assert payload["body"] == ""
+
+
+def test_fetch_issue_fails_closed_when_gh_cli_missing() -> None:
+    """A missing gh CLI must return an error payload, not raise (gate #5049 fix)."""
+    with patch("scripts.dev.gh_issue_rest.subprocess.run", side_effect=FileNotFoundError("gh")):
+        payload = fetch_issue(5021)
+    assert payload["status"] == "error"
+    assert "gh CLI not found" in payload["error"]
+
+
 def test_cli_view_fails_closed_on_rest_error(capsys: pytest.CaptureFixture[str]) -> None:
     """A REST failure should print the error to stderr and exit nonzero."""
     with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:


### PR DESCRIPTION
## What / Why

`gh issue view <number> --comments` requests the deprecated classic-Projects GraphQL field `repository.issue.projectCards`, which fails on some GitHub CLI versions with:

```
GraphQL: Projects (classic) is being deprecated ... (repository.issue.projectCards)
```

That breaks autonomous workflows that read an issue together with its comment thread before editing (the exact path reported in #5021 while implementing #4973). This PR delivers the artifact the issue explicitly requests: **a shared REST-backed issue-with-comments helper for autonomous workflows**.

## Change

- **`scripts/dev/gh_issue_rest.py`** — shared REST-backed issue-with-comments helper (library + CLI).
  - Reads the issue and its comments through `gh api` (REST only) — it never touches the deprecated `repository.issue.projectCards` GraphQL field, so it works regardless of the installed `gh` version.
  - Library API: `fetch_issue`, `fetch_comments` (paginated), `fetch_issue_with_comments`, `render_issue_plain`.
  - CLI: `view <number> [--repo R] [--comments] [--json FIELDS] [--plain] [--max-comment-pages N]` — a drop-in replacement for `gh issue view <number> --comments`.
  - Fails closed (nonzero exit, clear stderr; `status: "error"` payload from the library) on REST failures, malformed JSON, invalid page budget, and over-long threads (no silent truncation).
  - Normalizes REST fields (`state` → uppercase, `html_url` → `url`, flattened/`sorted` `labels`/`assignees`) to the shapes `gh issue view --json` consumers already expect, so it is a true drop-in.
- **`tests/dev/test_gh_issue_rest.py`** — 13 focused tests: normalization to the `gh --json` shape, comment pagination (stops on a short page; fails closed when the page budget is exceeded), fail-closed error paths, the combined helper, and CLI plain/JSON/error/unknown-field modes. All `gh api` calls are mocked, so the suite runs offline.
- **`docs/context/issue_713_batch_first_issue_workflow.md`** — wires the helper in as the recommended issue-with-comments source in the canonical GitHub-API workflow note (table row + a dedicated "Issue-with-comments helper" subsection with usage examples).

## Validation

CPU-only, no campaigns / Slurm / training / benchmark runs.

```
$ uv run python -m pytest tests/dev/test_gh_issue_rest.py -q
13 passed in 0.07s

$ uv run ruff check scripts/dev/gh_issue_rest.py tests/dev/test_gh_issue_rest.py
All checks passed!

$ uv run ruff format --check scripts/dev/gh_issue_rest.py tests/dev/test_gh_issue_rest.py
2 files already formatted
```

Existing related suites still green (no behavior change to them):
```
$ uv run python -m pytest tests/dev/test_snapshot_issue_batch.py tests/test_issue_workflow_batching.py tests/test_github_workflow_guidance.py -q
22 passed in 0.14s
```

Live end-to-end against the real GitHub issues (proof the helper resolves the reported friction), including the originally-failing issue from the report:
```
$ uv run python scripts/dev/gh_issue_rest.py view 5021 --comments --plain   # EXIT 0
$ uv run python scripts/dev/gh_issue_rest.py view 4973 --comments --plain   # EXIT 0 (original failing issue)
$ uv run python scripts/dev/gh_issue_rest.py view 5021 --json number state url labels   # EXIT 0
```

## Acceptance gates (#5021)

- [x] The requested behavior is covered by focused automated checks (13 tests).
- [x] Existing default behavior remains unchanged outside this issue's scope (no consumer migrated; only an additive helper + docs).
- [x] Validation results posted here.

## Scope / what remains

This PR fully resolves the issue via the second option the issue offered ("provide a shared REST-backed issue-with-comments helper for autonomous workflows"). It does not migrate existing `gh issue view` call sites (e.g. `scripts/dev/snapshot_issue_batch.py`) — that is intentionally left as follow-up to keep this slice's behavior boundary clean and because those call sites use `--json` with explicit fields, which is a separate, lower-risk path than the `--comments` thread read reported here. A follow-up issue can migrate consumers opportunistically.

Evidence/artifact handling: NA — no research claim; this is a support/tooling/docs change with no `output/` artifacts produced.

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Closes #5021
