### PR TITLE
Issue #5023: shared-venv freshness check before focused tests (cheap-lane worker)

### DIFF
--- a/scripts/dev/run_worktree_shared_venv.sh
+++ b/scripts/dev/run_worktree_shared_venv.sh
@@ -11,10 +11,22 @@ The helper pins imports to this worktree by prepending PYTHONPATH=$PWD and sets 
 For linked worktrees, the helper also derives a per-worktree COVERAGE_FILE unless one is already
 set, preventing parallel focused pytest runs from sharing output/coverage/.coverage state.
 
+Because the shared env is reused without resync (UV_NO_SYNC=1), a stale owning-checkout .venv can
+lag the current worktree source. The vendored `pysocialforce` package (force-included from
+fast-pysf/pysocialforce and NOT shadowed by PYTHONPATH=$PWD) is especially drift-prone: importing
+a newer API from a stale install fails mid-collection with a confusing ImportError. The helper
+therefore runs a cheap freshness check comparing the installed `pysocialforce` package against this
+checkout's fast-pysf/pysocialforce source and fails early with an actionable message when they
+diverge. Refresh the owning checkout with `uv sync --all-extras` to clear the divergence.
+
 Options:
-  --venv PATH   Shared virtualenv path exported as UV_PROJECT_ENVIRONMENT. Defaults to the main
-                checkout .venv for linked worktrees.
-  -h, --help    Show this help message.
+  --venv PATH            Shared virtualenv path exported as UV_PROJECT_ENVIRONMENT. Defaults to the
+                         main checkout .venv for linked worktrees.
+  --no-freshness-check   Skip the shared-venv freshness check. Use only when you have confirmed the
+                         reused env matches this checkout (e.g. an editable install that already
+                         points at this source). Also skippable via
+                         ROBOT_SF_VENV_FRESHNESS_CHECK=skip.
+  -h, --help             Show this help message.
 
 Examples:
   scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -q
@@ -26,6 +38,7 @@ EOF
 }
 
 venv_override=""
+skip_freshness=""
 cmd=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -36,6 +49,10 @@ while [[ $# -gt 0 ]]; do
       fi
       venv_override="$2"
       shift 2
+      ;;
+    --no-freshness-check)
+      skip_freshness=1
+      shift
       ;;
     -h|--help)
       show_help
@@ -76,6 +93,58 @@ if [[ ! -x "$venv_path/bin/python" ]]; then
   echo "Shared virtualenv not found or incomplete: $venv_path" >&2
   echo "Create it with 'uv sync --all-extras' in the owning checkout, or use a local .venv." >&2
   exit 2
+fi
+
+check_shared_venv_freshness() {
+  # Guard the shared-venv fast path against a stale owning-checkout environment.
+  #
+  # The vendored `pysocialforce` package is force-included from fast-pysf/pysocialforce and is NOT
+  # shadowed by PYTHONPATH=$PWD (the package lives at fast-pysf/pysocialforce, not at the repo
+  # root). With UV_NO_SYNC=1 a reused env can lag the current worktree source, so importing a newer
+  # API from a stale install fails mid-collection with a confusing ImportError. Compare the
+  # installed package's .py files against this checkout's source and fail early on divergence.
+  local venv="$1"
+  local src_pkg="$repo_root/fast-pysf/pysocialforce"
+
+  if [[ ! -d "$src_pkg" ]]; then
+    return 0
+  fi
+
+  local installed_pkg=""
+  local candidate
+  for candidate in "$venv"/lib/python*/site-packages/pysocialforce; do
+    if [[ -d "$candidate" ]]; then
+      installed_pkg="$candidate"
+      break
+    fi
+  done
+
+  if [[ -z "$installed_pkg" ]]; then
+    return 0
+  fi
+
+  local src_file rel_path installed_file
+  while IFS= read -r -d '' src_file; do
+    rel_path="${src_file#"$src_pkg"/}"
+    installed_file="$installed_pkg/$rel_path"
+    if [[ ! -f "$installed_file" ]] || ! cmp -s "$src_file" "$installed_file"; then
+      cat >&2 <<EOF
+Shared virtualenv is stale relative to this checkout: $venv
+  diverging module: pysocialforce/$rel_path
+The reused env (UV_NO_SYNC=1) lacks source present in fast-pysf/pysocialforce, so imports can
+fail mid-run with a confusing ImportError. Refresh the owning checkout with 'uv sync --all-extras',
+or rerun with --no-freshness-check (or ROBOT_SF_VENV_FRESHNESS_CHECK=skip) once you have confirmed
+the env matches this checkout.
+EOF
+      return 1
+    fi
+  done < <(find "$src_pkg" -type f -name '*.py' -print0)
+}
+
+if [[ -z "$skip_freshness" && "${ROBOT_SF_VENV_FRESHNESS_CHECK:-}" != "skip" ]]; then
+  if ! check_shared_venv_freshness "$venv_path"; then
+    exit 2
+  fi
 fi
 
 export UV_PROJECT_ENVIRONMENT="$venv_path"

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -618,6 +618,225 @@ def test_worktree_shared_venv_helper_reports_relative_missing_env() -> None:
     assert "cd:" not in result.stderr
 
 
+def test_worktree_shared_venv_helper_has_freshness_check_wiring() -> None:
+    """The shared-venv helper must guard the reused env against source drift (issue #5023)."""
+    script_text = RUN_WORKTREE_SHARED_VENV.read_text(encoding="utf-8")
+
+    # The freshness gate compares the vendored pysocialforce install against fast-pysf source.
+    assert "check_shared_venv_freshness()" in script_text
+    assert 'local src_pkg="$repo_root/fast-pysf/pysocialforce"' in script_text
+    assert 'for candidate in "$venv"/lib/python*/site-packages/pysocialforce' in script_text
+    assert 'cmp -s "$src_file" "$installed_file"' in script_text
+    assert "Shared virtualenv is stale relative to this checkout" in script_text
+    assert "diverging module: pysocialforce/" in script_text
+    # The gate is skippable for advanced users with a confirmed-matching env.
+    assert "--no-freshness-check" in script_text
+    assert "ROBOT_SF_VENV_FRESHNESS_CHECK:-" in script_text
+    assert "ROBOT_SF_VENV_FRESHNESS_CHECK=skip" in script_text
+
+
+def _make_freshness_fixture_repo(
+    tmp_path: Path,
+    *,
+    installed_scene: str,
+) -> tuple[Path, Path, dict[str, str]]:
+    """Build a git repo + shared venv whose installed pysocialforce/scene.py is ``installed_scene``.
+
+    The worktree source fast-pysf/pysocialforce/scene.py carries a newer API (normalize_integration_scheme)
+    while the installed copy may or may not match it. A fake ``uv`` on PATH proves whether the helper
+    reached the underlying command or failed earlier in the freshness gate.
+    """
+    repo = tmp_path / "repo"
+    fake_bin = repo / "fake-bin"
+    venv = repo / "shared-venv"
+    site_packages = venv / "lib" / "python3.12" / "site-packages"
+    installed_pkg = site_packages / "pysocialforce"
+    src_pkg = repo / "fast-pysf" / "pysocialforce"
+    fake_bin.mkdir(parents=True)
+    installed_pkg.mkdir(parents=True)
+    src_pkg.mkdir(parents=True)
+    (venv / "bin").mkdir(parents=True)
+
+    # Worktree source scene.py carries the newer API the helper must detect drift against.
+    newer_scene = "def normalize_integration_scheme(value=None):\n    return value\n"
+    (src_pkg / "scene.py").write_text(newer_scene, encoding="utf-8")
+    (src_pkg / "__init__.py").write_text("", encoding="utf-8")
+    # Installed copy is whatever the caller passes (matching = fresh, divergent = stale).
+    (installed_pkg / "scene.py").write_text(installed_scene, encoding="utf-8")
+    (installed_pkg / "__init__.py").write_text("", encoding="utf-8")
+
+    # The helper only checks venv presence via bin/python executability.
+    py = venv / "bin" / "python"
+    py.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    py.chmod(0o755)
+
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        '#!/usr/bin/env bash\nprintf "uv-reached %s\\n" "$*" >&2\nexit 7\n',
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "agent@example.invalid"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Agent"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "freshness fixture"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+    }
+    return repo, venv, env
+
+
+def test_worktree_shared_venv_freshness_check_fails_early_on_stale_env(
+    tmp_path: Path,
+) -> None:
+    """A stale shared env (missing the newer source API) must fail before uv runs (issue #5023)."""
+    repo, venv, env = _make_freshness_fixture_repo(
+        tmp_path,
+        installed_scene="# stale install without normalize_integration_scheme\n",
+    )
+
+    result = subprocess.run(
+        [
+            str(RUN_WORKTREE_SHARED_VENV),
+            "--venv",
+            str(venv),
+            "--",
+            "python",
+            "-c",
+            "from pysocialforce.scene import normalize_integration_scheme",
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "Shared virtualenv is stale relative to this checkout" in result.stderr
+    assert "diverging module: pysocialforce/scene.py" in result.stderr
+    assert "uv sync --all-extras" in result.stderr
+    # The freshness gate must fire before the underlying command is executed.
+    assert "uv-reached" not in result.stderr
+
+
+def test_worktree_shared_venv_freshness_check_passes_on_fresh_env(
+    tmp_path: Path,
+) -> None:
+    """A shared env whose installed pysocialforce matches the source must proceed to the command."""
+    matching_scene = "def normalize_integration_scheme(value=None):\n    return value\n"
+    repo, venv, env = _make_freshness_fixture_repo(tmp_path, installed_scene=matching_scene)
+
+    result = subprocess.run(
+        [
+            str(RUN_WORKTREE_SHARED_VENV),
+            "--venv",
+            str(venv),
+            "--",
+            "python",
+            "-V",
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    # The freshness gate passes, so the helper reaches the underlying command (fake uv exits 7).
+    assert result.returncode == 7
+    assert "uv-reached" in result.stderr
+    assert "Shared virtualenv is stale" not in result.stderr
+
+
+def test_worktree_shared_venv_freshness_check_flag_bypasses_stale_env(
+    tmp_path: Path,
+) -> None:
+    """--no-freshness-check lets a confirmed-matching env skip the drift gate."""
+    repo, venv, env = _make_freshness_fixture_repo(
+        tmp_path,
+        installed_scene="# stale install without normalize_integration_scheme\n",
+    )
+
+    result = subprocess.run(
+        [
+            str(RUN_WORKTREE_SHARED_VENV),
+            "--venv",
+            str(venv),
+            "--no-freshness-check",
+            "--",
+            "python",
+            "-V",
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 7
+    assert "uv-reached" in result.stderr
+    assert "Shared virtualenv is stale" not in result.stderr
+
+
+def test_worktree_shared_venv_freshness_check_env_var_bypasses_stale_env(
+    tmp_path: Path,
+) -> None:
+    """ROBOT_SF_VENV_FRESHNESS_CHECK=skip lets a confirmed-matching env skip the drift gate."""
+    repo, venv, env = _make_freshness_fixture_repo(
+        tmp_path,
+        installed_scene="# stale install without normalize_integration_scheme\n",
+    )
+    env = {**env, "ROBOT_SF_VENV_FRESHNESS_CHECK": "skip"}
+
+    result = subprocess.run(
+        [
+            str(RUN_WORKTREE_SHARED_VENV),
+            "--venv",
+            str(venv),
+            "--",
+            "python",
+            "-V",
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 7
+    assert "uv-reached" in result.stderr
+    assert "Shared virtualenv is stale" not in result.stderr
+
+
 def test_gh_comment_has_valid_shell_syntax() -> None:
     """gh_comment.sh should pass bash -n syntax check."""
     syntax = subprocess.run(


### PR DESCRIPTION
## What / Why

Issue #5023 — `friction: validate shared worktree venv freshness before focused tests`.

`scripts/dev/run_worktree_shared_venv.sh` reuses the owning checkout's `.venv` with `UV_NO_SYNC=1`. A stale env can lag the current worktree source: the vendored `pysocialforce` package is force-included from `fast-pysf/pysocialforce` and is **not** shadowed by `PYTHONPATH=$PWD` (it lives under `fast-pysf/`, not the repo root), so importing a newer API such as `pysocialforce.scene.normalize_integration_scheme` from a stale install fails mid-collection with a confusing `ImportError`:

```
ImportError: cannot import name 'normalize_integration_scheme' from 'pysocialforce.scene'
```

This PR makes the helper **fail early with an actionable freshness check** (the issue's primary suggested change).

## Change

- Added `check_shared_venv_freshness()`: compares the shared venv's installed `pysocialforce` package `.py` files against this checkout's `fast-pysf/pysocialforce` source. On divergence it fails early (exit 2) with a message naming the diverging module and the remediation command (`uv sync --all-extras`).
- The gate runs after the missing-venv check and before `exec uv run`, so a stale shared env is reported before any test collection can trip over a confusing import error.
- Skippable for confirmed-matching envs via `--no-freshness-check` or `ROBOT_SF_VENV_FRESHNESS_CHECK=skip`.
- `--help` documents the check and refresh procedure; it remains a cheap path that does not invoke `uv`.

Design notes:
- The comparison is content-based (`cmp -s`) over all source `.py` files rather than hardcoding the `normalize_integration_scheme` symbol. That symbol was transient (added in #4979/#5009); a content comparison is robust to future drift in the same drift-prone vendored package.
- Only `pysocialforce` is checked: `robot_sf` resolves from the active worktree via `PYTHONPATH=$PWD` and is therefore not stale-venv-risk, while `pysocialforce` (nested under `fast-pysf/` and force-included as a site-packages copy) is the package that actually drifts.

## Reproduced the issue failure on `main`

Running the helper from a fresh linked worktree (on `origin/main`, whose `fast-pysf/pysocialforce/scene.py` has `normalize_integration_scheme`) against a stale main-checkout `.venv`:

Before this PR (confusing mid-collection failure):
```
$ scripts/dev/run_worktree_shared_venv.sh -- python -c "from pysocialforce.scene import normalize_integration_scheme"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'normalize_integration_scheme' from 'pysocialforce.scene' (.../.venv/lib/python3.12/site-packages/pysocialforce/scene.py)
```

After this PR (early, actionable failure):
```
$ scripts/dev/run_worktree_shared_venv.sh -- python -c "from pysocialforce.scene import normalize_integration_scheme"
Shared virtualenv is stale relative to this checkout: /home/luttkule/git/robot_sf_ll7/.venv
  diverging module: pysocialforce/config.py
The reused env (UV_NO_SYNC=1) lacks source present in fast-pysf/pysocialforce, so imports can
fail mid-run with a confusing ImportError. Refresh the owning checkout with 'uv sync --all-extras',
or rerun with --no-freshness-check (or ROBOT_SF_VENV_FRESHNESS_CHECK=skip) once you have confirmed
the env matches this checkout.
$ echo $?
2
```

## Validation

CPU-only; no campaigns, Slurm, training, benchmark, or paper claims. Ran via the shared-venv wrapper against the main checkout `.venv` (`--no-freshness-check` was used to run *these* tests, since the test file does not import `pysocialforce`).

```
$ scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- pytest tests/test_ci_script_contract.py -q -p no:cacheprovider
62 passed in 0.96s
```

New focused tests (all passing):
- `test_worktree_shared_venv_helper_has_freshness_check_wiring` — source-text wiring assertion
- `test_worktree_shared_venv_freshness_check_fails_early_on_stale_env` — stale env fails (exit 2) before `uv` runs
- `test_worktree_shared_venv_freshness_check_passes_on_fresh_env` — fresh env proceeds to the command
- `test_worktree_shared_venv_freshness_check_flag_bypasses_stale_env` — `--no-freshness-check` bypass
- `test_worktree_shared_venv_freshness_check_env_var_bypasses_stale_env` — `ROBOT_SF_VENV_FRESHNESS_CHECK=skip` bypass

Lint/format on the changed Python file:
```
$ ruff check tests/test_ci_script_contract.py      # All checks passed!
$ ruff format --check tests/test_ci_script_contract.py  # clean after apply
```

Existing default behavior is preserved: `--help`/`-h` stay cheap (no `uv`), the missing-venv and relative-missing-env actionable errors are unchanged, and existing `test_worktree_shared_venv_helper_*` contract tests still pass.

## Acceptance gates (from the issue plan)

- [x] The requested behavior is covered by focused automated checks.
- [x] Existing default behavior remains unchanged outside this issue's scope.
- [x] Validation results and any remaining blockers are posted to this issue.

This fully resolves the issue's suggested change (the "fail early with an actionable freshness check" option), so the merge should close it.

Closes #5023

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
