### PR TITLE
fix(gitignore): ignore .venv/venv symlink in fresh worktrees (#5027)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,10 @@ output/
 wandb
 
 # Python virtual environments
-.venv/
-venv/
+# No trailing slash so a `.venv`/`venv` symlink (e.g. a shared-venv worktree
+# runner) is ignored too; a directory-only rule (`.venv/`) skips symlinks.
+.venv
+venv
 env/
 ENV/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **issue #5027 fresh-worktree `.venv` symlink was untracked.** The `.gitignore` virtual-environment
+  rules (`.venv/`, `venv/`) used a trailing slash, which matches directories but not symlinks, so a
+  linked worktree that points `.venv` at the main checkout's virtualenv via a symlink (a shared-venv
+  runner setup) showed up as untracked (`?? .venv`). Dropped the trailing slash (`.venv`, `venv`) so
+  the ignore rule covers directory, symlink, and file forms. Guarded by
+  `tests/dev/test_gitignore_venv_symlink.py`. No behavior change for the common real-directory `.venv`.
 * **issue #4919 SNQI aggregate diagnostic-mode logging regression from exception narrowing.** The
   `robot_sf/benchmark/aggregate.py::_ensure_snqi` exception handler, narrowed from a bare
   `except Exception:` to `except (ValueError, TypeError):` by #4887's broad-except ratchet, dropped

--- a/tests/dev/test_gitignore_venv_symlink.py
+++ b/tests/dev/test_gitignore_venv_symlink.py
@@ -1,0 +1,59 @@
+"""Regression test: the repo `.gitignore` must ignore a `.venv` symlink.
+
+Fresh linked worktrees may point `.venv` at the main checkout's virtualenv via a
+symlink (a shared-venv runner setup). A directory-only ignore rule (`.venv/`,
+with a trailing slash) matches directories but *not* symlinks, so the symlink
+showed up as untracked (`?? .venv`). See issue #5027.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_repo_gitignore_venv_patterns() -> list[str]:
+    """Return the virtual-environment ignore patterns from the repo `.gitignore`."""
+    lines = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+    return [line.strip() for line in lines if line.strip() in {".venv", "venv"}]
+
+
+def test_repo_gitignore_uses_slashless_venv_patterns() -> None:
+    """The repo ships `.venv`/`venv` without a trailing slash so symlinks match."""
+    patterns = _read_repo_gitignore_venv_patterns()
+    assert ".venv" in patterns, "`.gitignore` must contain slashless `.venv` (see #5027)"
+    assert "venv" in patterns, "`.gitignore` must contain slashless `venv` (see #5027)"
+
+
+def test_venv_symlink_is_ignored_by_repo_patterns(tmp_path: Path) -> None:
+    """A `.venv` symlink is ignored under the repo's virtual-env patterns.
+
+    Behavioral check independent of the repo working tree: build a scratch git
+    repo whose `.gitignore` carries only the repo's venv patterns, create a
+    `.venv` symlink, and assert `git check-ignore` matches it. Under the old
+    directory-only rule (`.venv/`) this returns non-zero (not ignored).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+
+    patterns = _read_repo_gitignore_venv_patterns()
+    (repo / ".gitignore").write_text("\n".join(patterns) + "\n", encoding="utf-8")
+
+    real_venv = repo / "shared-venv"
+    real_venv.mkdir()
+    (repo / ".venv").symlink_to(real_venv)
+
+    result = subprocess.run(
+        ["git", "check-ignore", ".venv"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "`.venv` symlink should be ignored but git check-ignore reported it as "
+        f"tracked (returncode={result.returncode}, stdout={result.stdout!r})"
+    )

--- a/tests/dev/test_gitignore_venv_symlink.py
+++ b/tests/dev/test_gitignore_venv_symlink.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -44,7 +46,12 @@ def test_venv_symlink_is_ignored_by_repo_patterns(tmp_path: Path) -> None:
 
     real_venv = repo / "shared-venv"
     real_venv.mkdir()
-    (repo / ".venv").symlink_to(real_venv)
+    try:
+        # target_is_directory matters on Windows; symlink creation there may also
+        # require Developer Mode / admin, so skip cleanly when unsupported.
+        (repo / ".venv").symlink_to(real_venv, target_is_directory=True)
+    except OSError as exc:  # pragma: no cover - platform-dependent
+        pytest.skip(f"symlink creation unsupported on this platform: {exc}")
 
     result = subprocess.run(
         ["git", "check-ignore", ".venv"],


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Dropped the trailing slash on the `.gitignore` virtual-environment rules (`.venv/` → `.venv`, `venv/` → `venv`) and added a focused regression test.
- **Why now:** A trailing-slash ignore rule matches *directories only*, not symlinks. A linked worktree that points `.venv` at the main checkout's virtualenv via a symlink (a shared-venv runner setup) therefore appeared as untracked (`?? .venv`), which is the friction reported in #5027.
- **Claim boundary:** `smoke evidence` — dev-tooling/config fix, no benchmark, metric, schema, or paper-facing surface touched. No behavior change for the common real-directory `.venv`.
- **Required validation:** `ruff check` + `pytest tests/dev/test_gitignore_venv_symlink.py` (both pass, below).
- **Remaining blocker:** none — fully resolves the issue.

Closes #5027

## Contract delta

- No new schema fields, no new fail-closed blockers, no runtime behavior change.
- Compatibility: `.venv`/`venv` (slashless) match directory, symlink, **and** file forms. Superset of the old directory-only match, so a real-directory virtualenv is still ignored exactly as before. `env/`/`ENV/` are left unchanged (not virtualenv-symlink targets; slashless forms would risk matching unrelated files named `env`/`ENV`).

## Reproduction (on `main`)

```
$ printf '.venv/\n' > .gitignore && mkdir d && ln -s "$PWD/d" .venv
$ git check-ignore .venv; echo "returncode=$?"
returncode=1        # NOT ignored -> shows as '?? .venv'
```

After the fix (`.venv` slashless) `git check-ignore .venv` returns 0 (ignored).

## Validation

| Command | Result |
| --- | --- |
| `ruff check tests/dev/test_gitignore_venv_symlink.py` | exit 0 — All checks passed |
| `ruff format --check tests/dev/test_gitignore_venv_symlink.py` | exit 0 — already formatted |
| `python -m pytest tests/dev/test_gitignore_venv_symlink.py -q` | exit 0 — 2 passed |

Ran via `scripts/dev/run_worktree_shared_venv.sh`. Right-reason check: the new behavioral test returns non-zero (fails) under the old `.venv/` rule, confirming it guards the regression.

## Scope

- **In scope:** `.gitignore` venv symlink fix + regression test + CHANGELOG entry.
- **Out of scope:** no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- **State propagation:** issue-comment authorization is off for this lane, so this PR body is the single durable state surface. No `docs/context/issue_5027_state.yaml` update needed — this is a schema/behavior change, not queue-routing state, and it fully closes the issue.

<details>
<summary>Governance appendix</summary>

- Changed files: `.gitignore`, `tests/dev/test_gitignore_venv_symlink.py`, `CHANGELOG.md`.
- No AI-config surfaces touched (`sync_ai_config` not implicated).
- Evidence tier: smoke/diagnostic-only for dev tooling; no metric semantics affected.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
