### PR TITLE
Issue #5004: ty advisory baseline + per-module downward ratchet (cheap-lane worker)

### DIFF
--- a/.github/workflows/ty-advisory-ratchet.yml
+++ b/.github/workflows/ty-advisory-ratchet.yml
@@ -1,0 +1,67 @@
+name: ty advisory ratchet
+
+# Non-gating downward ratchet over the ty advisory type-check baseline (issue #5004).
+# Re-runs `ty check`, diffs the per-module general-bucket counts against the committed
+# baseline at scripts/validation/ty_advisory_baseline.json, and reports net-new findings
+# (regressions in clean modules, or any per-module increase) as a non-blocking failure.
+# Promote to gating by removing `continue-on-error: true` once the ratchet has settled.
+#
+# Scope boundary: the optional-dependency import-resolution subset of ty findings
+# (check_name `unresolved-import`, "Cannot resolve imported module ...") is recorded
+# for visibility but EXCLUDED from the gate; it is owned by #4990/#4995. See the
+# baseline `exclusion` block and scripts/dev/ty_advisory_ratchet.py.
+
+on:
+  pull_request:
+    paths:
+      - "**/*.py"
+      - "pyproject.toml"
+      - "scripts/dev/ty_advisory_ratchet.py"
+      - "scripts/validation/ty_advisory_baseline.json"
+      - "tests/dev/test_ty_advisory_ratchet.py"
+      - ".github/workflows/ty-advisory-ratchet.yml"
+  schedule:
+    - cron: "23 5 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ty-advisory-ratchet:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up CI Python environment
+        uses: ./.github/actions/setup-ci-python
+
+      - name: Run ty advisory ratchet
+        id: ty_ratchet
+        continue-on-error: true
+        run: |
+          mkdir -p output/ty
+          uv run python scripts/dev/ty_advisory_ratchet.py --check 2>&1 | tee output/ty/ratchet.log
+
+      - name: Summarize ty ratchet outcome
+        if: always()
+        run: |
+          printf 'ty advisory ratchet exit: %s\n' "${{ steps.ty_ratchet.outcome }}"
+          printf 'Committed baseline general findings: '
+          python -c "import json;print(sum(m['general'] for m in json.load(open('scripts/validation/ty_advisory_baseline.json'))['modules'].values()))" || true
+
+      - name: Upload ty ratchet log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ty-advisory-ratchet-log
+          path: output/ty/ratchet.log
+          if-no-files-found: warn

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1083,6 +1083,8 @@ parser-smoke validation for `maps/svg_maps/socnavbench/socnavbench_eth.svg`.
   [issue_1436_reproducibility_flaky_acceptance.md](issue_1436_reproducibility_flaky_acceptance.md)
 * Issue #1363 Learned Local Policy Eligibility Checklist:
   [policy_search/contracts/learned_local_policy_eligibility.md](policy_search/contracts/learned_local_policy_eligibility.md)
+* Issue #5004 ty advisory diagnostic baseline + per-module downward ratchet:
+  [issue_5004_ty_advisory_ratchet.md](issue_5004_ty_advisory_ratchet.md)
 * Note-maintenance skill:
   [.agents/skills/context-note-maintainer/SKILL.md](../../.agents/skills/context-note-maintainer/SKILL.md)
 

--- a/docs/context/issue_5004_ty_advisory_ratchet.md
+++ b/docs/context/issue_5004_ty_advisory_ratchet.md
@@ -1,0 +1,82 @@
+# Issue #5004 ty Advisory Diagnostic Baseline + Per-Module Downward Ratchet
+
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/5004>
+
+## Goal
+
+Make the ~2.7k pre-existing `ty` advisory type-check findings visible and
+monotone-decreasing per module, without turning the full legacy backlog into an
+immediate cleanup blocker. This is the type-safety counterpart to the security
+baseline ratchet (#3477/#3529) and the TODO-docstring ratchet (#1285).
+
+## Implementation
+
+`scripts/dev/ty_advisory_ratchet.py` re-runs `uvx ty check .` (gitlab-JSON,
+advisory `--exit-zero`), aggregates findings per module, and diffs against the
+committed baseline at `scripts/validation/ty_advisory_baseline.json`.
+
+Modes:
+
+* `--check` — the downward-ratchet gate. Fails when a clean module (baseline
+  general count 0) gains any finding, or when any tracked module's general count
+  increases. Decreases pass and emit a "ratchet opportunity" notice.
+* `--write-baseline` — refresh the baseline after intentionally reducing findings.
+* `--aggregate-only` — print per-module counts without reading/writing a baseline.
+* `--ty-output FILE` — parse a pre-rendered ty gitlab-JSON report instead of
+  re-running ty (offline / test / no-network mode).
+
+The downward ratchet gates on the **general** bucket. The
+**optional-import** category is recorded for visibility but EXCLUDED from the
+gate to avoid overlap with sibling issues:
+
+* A finding is the optional-import category when
+  `check_name == "unresolved-import"` and its description starts with
+  `unresolved-import: Cannot resolve imported module` (a whole-module resolution
+  failure such as `GPUtil`, `cairosvg`, `adjustText`, `rvo2`, `ompl`, or vendored
+  relative imports).
+* First-party member-resolution errors
+  (`unresolved-import: Module X has no member Y`) are KEPT in the general bucket
+  because they are real type errors, not optional-dependency noise.
+
+Sibling issues that own the excluded categories: #4990 (optional-import guard
+inventory), #4995 (guard-spelling standardization), #4988 (benchmark-CLI typed
+errors).
+
+## CI wiring
+
+* `.github/workflows/ty-advisory-ratchet.yml` runs `--check` as a non-gating
+  (`continue-on-error`) companion on PRs that touch Python/config/baseline
+  paths, plus a weekly schedule. Promote to gating by removing
+  `continue-on-error` once the ratchet has settled.
+* `scripts/dev/ci_driver.sh` typecheck phase surfaces the ratchet result as
+  advisory (non-failing), matching the existing `uvx ty check . --exit-zero`
+  advisory posture.
+
+## Worked example (acceptance criterion)
+
+`robot_sf/data` was driven to zero general findings and removed from the
+baseline via two genuine, non-optional-import type fixes:
+
+* `robot_sf/data/external/ind.py` — narrow `Path | None` -> `Path` after the
+  `missing`-sibling guard (the guard already proved non-None).
+* `robot_sf/data/external/socnavbench_eth.py` — build the 2-D
+  `traversible_shape` as an explicit `tuple[int, int]` (the `ndim == 2`
+  validation already guarantees a 2-element shape).
+
+## Boundary
+
+This does NOT fix all 2.5k+ general findings. It only prevents new or increased
+per-module debt relative to the tracked baseline, and demonstrates one module
+cleared. Baseline updates should happen after intentional cleanup or explicit
+maintainer approval. It does not touch benchmark metric semantics, and it
+deliberately excludes the optional-import subset owned by #4990/#4995.
+
+## Validation
+
+```bash
+uv run pytest tests/dev/test_ty_advisory_ratchet.py -v
+uv run python scripts/dev/ty_advisory_ratchet.py --check
+uv run python scripts/dev/ty_advisory_ratchet.py --aggregate-only | head
+uv run ruff check scripts/dev/ty_advisory_ratchet.py tests/dev/test_ty_advisory_ratchet.py
+BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```

--- a/robot_sf/data/external/ind.py
+++ b/robot_sf/data/external/ind.py
@@ -177,6 +177,11 @@ def _resolve_dataset_paths(root: Path) -> tuple[IndDatasetPaths | None, list[str
         if missing:
             issues.append(f"recording '{recording_id or '<root>'}' missing {', '.join(missing)}")
             continue
+        # The ``missing`` guard above guarantees these three siblings resolved
+        # to real paths; narrow ``Path | None`` -> ``Path`` for the constructor.
+        assert tracks_meta is not None
+        assert recording_meta is not None
+        assert background is not None
         recordings.append(
             IndRecordingPaths(
                 recording_id=recording_id,

--- a/robot_sf/data/external/socnavbench_eth.py
+++ b/robot_sf/data/external/socnavbench_eth.py
@@ -166,6 +166,6 @@ def load_shape_contract(root: Path | str | None = None) -> SocNavBenchEthShapeCo
 
     return SocNavBenchEthShapeContract(
         resolution=resolution_float,
-        traversible_shape=tuple(int(axis) for axis in traversible.shape),
+        traversible_shape=(int(traversible.shape[0]), int(traversible.shape[1])),
         traversible_dtype=str(traversible.dtype),
     )

--- a/scripts/dev/ci_driver.sh
+++ b/scripts/dev/ci_driver.sh
@@ -244,6 +244,14 @@ run_phase() {
     typecheck)
       echo "Running ty in advisory mode (--exit-zero); findings are reported but do not fail this phase."
       uvx ty check . --exit-zero
+      # Advisory downward ratchet over the ty baseline (issue #5004). Surfaced but
+      # non-gating here to match the advisory --exit-zero posture above; promote to
+      # gating via the dedicated .github/workflows/ty-advisory-ratchet.yml workflow.
+      if uv run python scripts/dev/ty_advisory_ratchet.py --check; then
+        echo "ty advisory ratchet: held (no per-module increase)."
+      else
+        echo "ty advisory ratchet: net-new findings detected (advisory, not failing this phase); see scripts/dev/ty_advisory_ratchet.py."
+      fi
       ;;
     test)
       "$SCRIPT_DIR/check_event_ledger_reconciliation_guard.sh"

--- a/scripts/dev/ty_advisory_ratchet.py
+++ b/scripts/dev/ty_advisory_ratchet.py
@@ -125,13 +125,16 @@ def run_ty(repo_root: Path) -> list[dict[str, Any]]:
     non-zero ty exit that is not advisory, or on unparseable output.
     """
     cmd = ["uvx", "ty", "check", ".", "--output-format", "gitlab", "--exit-zero"]
-    proc = subprocess.run(
-        cmd,
-        cwd=repo_root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:  # e.g. uvx not installed / not on PATH
+        raise RuntimeError(f"Could not invoke '{' '.join(cmd)}': {exc}") from exc
     if proc.returncode != 0:
         raise RuntimeError(
             f"ty exited {proc.returncode} (expected 0 with --exit-zero).\n"
@@ -161,7 +164,7 @@ def aggregate(findings: list[dict[str, Any]]) -> dict[str, Any]:
     general_total = 0
     optional_total = 0
     for finding in findings:
-        path = finding.get("location", {}).get("path", "<unknown>")
+        path = (finding.get("location") or {}).get("path", "<unknown>")
         mod = module_of(path)
         rules[str(finding.get("check_name", "unknown"))] += 1
         category = classify_finding(finding)
@@ -227,25 +230,31 @@ def build_baseline_payload(
 def load_baseline(path: Path) -> dict[str, Any]:
     """Load and minimally validate a baseline file."""
     data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Baseline {path} must be a JSON object, got {type(data).__name__}.")
     if data.get("schema_version") != SCHEMA_VERSION:
         raise ValueError(
             f"Unsupported baseline schema_version in {path}: "
             f"got {data.get('schema_version')}, expected {SCHEMA_VERSION}"
         )
-    if "modules" not in data:
-        raise ValueError(f"Baseline {path} is missing the 'modules' mapping.")
+    if not isinstance(data.get("modules"), dict):
+        raise ValueError(f"Baseline {path} is missing a valid 'modules' mapping.")
     return data
 
 
 def _detect_ty_version(repo_root: Path) -> str | None:
     """Best-effort detect the ty version for baseline provenance."""
-    proc = subprocess.run(
-        ["uvx", "ty", "--version"],
-        cwd=repo_root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        proc = subprocess.run(
+            ["uvx", "ty", "--version"],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        # Best-effort provenance only; uvx may be absent in offline/test modes.
+        return None
     if proc.returncode == 0:
         return proc.stdout.strip() or None
     return None

--- a/scripts/dev/ty_advisory_ratchet.py
+++ b/scripts/dev/ty_advisory_ratchet.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""ty advisory diagnostic baseline + per-module downward ratchet (issue #5004).
+
+This helper turns the existing *advisory* ``ty check`` scan (run in CI via
+``uvx ty check . --exit-zero``) into a **monotone downward ratchet**: the total
+``ty`` finding count per module may stay the same or decrease, but never increase.
+
+What this owns (issue #5004)
+----------------------------
+The *general* ``ty`` advisory baseline + per-module ratchet over the ~2.7k
+pre-existing findings. It is the type-safety counterpart to the security baseline
+(``scripts/validation/check_broad_exceptions.py`` style ratchet).
+
+Scope boundary — what is intentionally EXCLUDED
+-----------------------------------------------
+To avoid overlap with three sibling issues, the **optional-dependency import
+resolution** subset of ``ty`` findings is recorded in the baseline but EXCLUDED
+from the ratchet gate:
+
+* ``#4990`` owns the optional-import *guard inventory* (AST ratchet on
+  ``except ImportError`` spellings).
+* ``#4995`` owns standardizing those guard spellings.
+* ``#4988`` owns benchmark-CLI typed-error contracts.
+
+Concretely, a finding is treated as the **optional-import category** (excluded
+from the gate, tracked informationally) when::
+
+    check_name == "unresolved-import"
+    and description starts with "unresolved-import: Cannot resolve imported module"
+
+i.e. a module that cannot be resolved at all (``GPUtil``, ``cairosvg``,
+``adjustText``, ``rvo2``, ``ompl``, vendored relative imports, ...). Genuine
+first-party *member-resolution* errors (``unresolved-import: Module X has no
+member Y``) are KEPT in the general bucket because they are real type errors,
+not optional-dependency noise. See ``exclusion`` in the baseline JSON.
+
+Ratchet contract
+----------------
+* A **clean module** (general baseline count == 0) that gains any finding -> FAIL.
+* A **tracked module** whose general count *increases* beyond its baseline -> FAIL.
+* A **decrease** never fails; the helper prints a "ratchet opportunity" notice so
+  the baseline can be refreshed to lock in the improvement (``--write-baseline``).
+* A module NOT present in the baseline is treated as clean (baseline 0), so a
+  brand-new module with findings fails until it is explicitly baselined.
+
+Exit codes
+----------
+* ``0`` — ratchet holds (no per-module increase; clean modules stayed clean).
+* ``1`` — a clean module regressed, or a tracked module's count increased.
+* ``2`` — ``ty`` could not be run / produced unparseable output (infra error).
+
+Usage
+-----
+::
+
+    # Re-run ty and check against the committed baseline (CI / local gate).
+    uv run python scripts/dev/ty_advisory_ratchet.py --check
+
+    # Refresh the baseline after intentionally reducing findings.
+    uv run python scripts/dev/ty_advisory_ratchet.py --write-baseline
+
+    # Parse a pre-rendered ty gitlab-JSON report (offline / test / no-network).
+    uv run python scripts/dev/ty_advisory_ratchet.py --check --ty-output report.json
+
+The committed baseline lives at ``scripts/validation/ty_advisory_baseline.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_BASELINE = Path("scripts/validation/ty_advisory_baseline.json")
+SCHEMA_VERSION = 1
+
+# A finding is the "optional-import category" (excluded from the ratchet gate,
+# owned by #4990/#4995) when it is an unresolved whole-module import. Member
+# resolution errors ("Module X has no member Y") are NOT optional-import noise
+# and stay in the general bucket.
+OPTIONAL_IMPORT_RULE = "unresolved-import"
+OPTIONAL_IMPORT_DESC_PREFIX = "unresolved-import: Cannot resolve imported module"
+
+# Sibling issues that own the excluded categories. Recorded in the baseline so
+# future contributors know where to take cross-cutting reductions.
+OWNED_BY_OTHER_ISSUES = ["#4990", "#4995", "#4988"]
+
+
+def module_of(path: str) -> str:
+    """Return the per-module key for a repository-relative ``path``.
+
+    ``robot_sf`` is grouped two levels deep (``robot_sf/<subpkg>``) because that
+    matches how the package is reviewed and how the worked example in #5004 is
+    scoped. ``robot_sf_carla_bridge`` and top-level dirs use one level.
+    """
+    parts = path.split("/")
+    if parts[0] == "robot_sf" and len(parts) > 2:
+        return "/".join(parts[:2])
+    return parts[0]
+
+
+def classify_finding(finding: dict[str, Any]) -> str:
+    """Return ``"optional_import"`` or ``"general"`` for one ty gitlab finding.
+
+    The optional-import category is excluded from the ratchet gate to avoid
+    overlap with #4990/#4995 (see module docstring).
+    """
+    if finding.get("check_name") == OPTIONAL_IMPORT_RULE and str(
+        finding.get("description", "")
+    ).startswith(OPTIONAL_IMPORT_DESC_PREFIX):
+        return "optional_import"
+    return "general"
+
+
+def run_ty(repo_root: Path) -> list[dict[str, Any]]:
+    """Run ``ty check`` in gitlab-JSON mode and return parsed findings.
+
+    Uses ``--exit-zero`` so advisory findings never fail the ty invocation
+    itself; only this ratchet decides pass/fail. Raises ``RuntimeError`` on a
+    non-zero ty exit that is not advisory, or on unparseable output.
+    """
+    cmd = ["uvx", "ty", "check", ".", "--output-format", "gitlab", "--exit-zero"]
+    proc = subprocess.run(
+        cmd,
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"ty exited {proc.returncode} (expected 0 with --exit-zero).\n"
+            f"stderr:\n{proc.stderr[:2000]}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Could not parse ty gitlab JSON output: {exc}\nstdout head:\n{proc.stdout[:1000]}"
+        ) from exc
+
+
+def load_ty_output(path: Path) -> list[dict[str, Any]]:
+    """Load a pre-rendered ty gitlab-JSON report from ``path``."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def aggregate(findings: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate raw findings into baseline modules + rule summary.
+
+    Returns a dict with ``modules`` (per-module general/optional/total counts),
+    ``rules`` (per-rule counts), and scalar summaries.
+    """
+    modules: dict[str, dict[str, int]] = {}
+    rules: Counter[str] = Counter()
+    general_total = 0
+    optional_total = 0
+    for finding in findings:
+        path = finding.get("location", {}).get("path", "<unknown>")
+        mod = module_of(path)
+        rules[str(finding.get("check_name", "unknown"))] += 1
+        category = classify_finding(finding)
+        entry = modules.setdefault(mod, {"general": 0, "optional_import_excluded": 0, "total": 0})
+        entry["total"] += 1
+        if category == "optional_import":
+            entry["optional_import_excluded"] += 1
+            optional_total += 1
+        else:
+            entry["general"] += 1
+            general_total += 1
+    # Stable ordering for reviewable diffs.
+    modules_sorted = {k: modules[k] for k in sorted(modules)}
+    rules_sorted = {k: rules[k] for k in sorted(rules)}
+    return {
+        "modules": modules_sorted,
+        "rules": rules_sorted,
+        "general_total": general_total,
+        "optional_import_total": optional_total,
+        "total": len(findings),
+    }
+
+
+def build_baseline_payload(
+    findings: list[dict[str, Any]],
+    *,
+    ty_version: str | None,
+) -> dict[str, Any]:
+    """Build the versioned baseline JSON payload from raw findings."""
+    agg = aggregate(findings)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "ty_version": ty_version,
+        "description": (
+            "ty advisory diagnostic baseline + per-module downward ratchet "
+            "(issue #5004). The ratchet gates on the 'general' bucket; the "
+            "'optional_import_excluded' bucket is recorded for visibility but "
+            "owned by #4990/#4995. Refresh with "
+            "`scripts/dev/ty_advisory_ratchet.py --write-baseline` after "
+            "intentionally reducing findings."
+        ),
+        "exclusion": {
+            "rule": (
+                f"Findings with check_name='{OPTIONAL_IMPORT_RULE}' and "
+                f"description prefix '{OPTIONAL_IMPORT_DESC_PREFIX}...' are "
+                "treated as the optional-import category: recorded but EXCLUDED "
+                "from the ratchet gate (owned by #4990/#4995)."
+            ),
+            "owned_by_other_issues": OWNED_BY_OTHER_ISSUES,
+        },
+        "summary": {
+            "total_findings": agg["total"],
+            "general_findings": agg["general_total"],
+            "optional_import_findings_excluded": agg["optional_import_total"],
+            "module_count": len(agg["modules"]),
+        },
+        "modules": agg["modules"],
+        "rules": agg["rules"],
+    }
+
+
+def load_baseline(path: Path) -> dict[str, Any]:
+    """Load and minimally validate a baseline file."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported baseline schema_version in {path}: "
+            f"got {data.get('schema_version')}, expected {SCHEMA_VERSION}"
+        )
+    if "modules" not in data:
+        raise ValueError(f"Baseline {path} is missing the 'modules' mapping.")
+    return data
+
+
+def _detect_ty_version(repo_root: Path) -> str | None:
+    """Best-effort detect the ty version for baseline provenance."""
+    proc = subprocess.run(
+        ["uvx", "ty", "--version"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 0:
+        return proc.stdout.strip() or None
+    return None
+
+
+def check_against_baseline(
+    current_findings: list[dict[str, Any]],
+    baseline: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    """Return (failures, notices) for the downward ratchet.
+
+    ``failures`` is non-empty -> the ratchet is broken (exit 1). ``notices`` are
+    informational ratchet-opportunity hints (counts decreased) and are always
+    advisory.
+    """
+    current_agg = aggregate(current_findings)
+    current_modules = current_agg["modules"]
+    baseline_modules = baseline.get("modules", {})
+
+    failures: list[str] = []
+    notices: list[str] = []
+
+    all_modules = sorted(set(current_modules) | set(baseline_modules))
+    for mod in all_modules:
+        base_general = int(baseline_modules.get(mod, {}).get("general", 0))
+        cur_general = int(current_modules.get(mod, {}).get("general", 0))
+        if cur_general > base_general:
+            if base_general == 0:
+                failures.append(
+                    f"clean module regressed: '{mod}' went from 0 to "
+                    f"{cur_general} general ty findings."
+                )
+            else:
+                failures.append(
+                    f"module '{mod}' general ty findings increased from "
+                    f"{base_general} to {cur_general} (downward ratchet)."
+                )
+        elif cur_general < base_general:
+            notices.append(
+                f"ratchet opportunity: '{mod}' dropped from {base_general} to "
+                f"{cur_general} general findings; refresh the baseline to lock "
+                f"in the improvement."
+            )
+
+    # Overall monotonicity summary (advisory; the per-module gate is authoritative).
+    base_general_total = sum(int(m.get("general", 0)) for m in baseline_modules.values())
+    if current_agg["general_total"] > base_general_total:
+        failures.append(
+            f"total general findings increased from {base_general_total} to "
+            f"{current_agg['general_total']}."
+        )
+    return failures, notices
+
+
+def write_json(path: Path, payload: dict[str, Any] | list[Any]) -> None:
+    """Write stable, reviewable, sort-keyed JSON."""
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _repo_root() -> Path:
+    """Return the current Git repository root."""
+    proc = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError("Could not determine git repository root.")
+    return Path(proc.stdout.strip())
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="Run the ratchet gate.")
+    mode.add_argument(
+        "--write-baseline",
+        action="store_true",
+        help="Recompute findings and (re)write the baseline file.",
+    )
+    mode.add_argument(
+        "--aggregate-only",
+        action="store_true",
+        help="Print the aggregate (per-module counts) without reading/writing a baseline.",
+    )
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Repository root (defaults to git toplevel).",
+    )
+    parser.add_argument(
+        "--ty-output",
+        type=Path,
+        default=None,
+        help=(
+            "Path to a pre-rendered ty gitlab-JSON report. When set, ty is NOT "
+            "re-run; the report is parsed instead (offline / test mode)."
+        ),
+    )
+    parser.add_argument(
+        "--emit-findings",
+        type=Path,
+        default=None,
+        help="Optional path to write the raw ty findings (gitlab JSON) for offline reuse.",
+    )
+    return parser.parse_args(argv)
+
+
+def _gather_findings(args: argparse.Namespace, repo_root: Path) -> list[dict[str, Any]]:
+    """Resolve raw findings either by running ty or by parsing --ty-output."""
+    if args.ty_output is not None:
+        return load_ty_output(args.ty_output)
+    return run_ty(repo_root)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the ratchet gate, baseline refresh, or aggregate report."""
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    repo_root = args.root.resolve() if args.root is not None else _repo_root()
+    baseline_path = args.baseline if args.baseline.is_absolute() else repo_root / args.baseline
+
+    try:
+        findings = _gather_findings(args, repo_root)
+    except RuntimeError as exc:
+        print(f"ERROR: could not obtain ty findings: {exc}", file=sys.stderr)
+        return 2
+
+    if args.emit_findings is not None:
+        write_json(args.emit_findings, findings)
+
+    if args.aggregate_only:
+        agg = aggregate(findings)
+        print(
+            f"total={agg['total']} general={agg['general_total']} "
+            f"optional_import_excluded={agg['optional_import_total']} "
+            f"modules={len(agg['modules'])}"
+        )
+        for mod, counts in agg["modules"].items():
+            print(f"  {counts['general']:5d} general  ({counts['total']:5d} total)  {mod}")
+        return 0
+
+    payload = build_baseline_payload(findings, ty_version=_detect_ty_version(repo_root))
+
+    if args.write_baseline:
+        baseline_path.parent.mkdir(parents=True, exist_ok=True)
+        write_json(baseline_path, payload)
+        print(
+            f"Wrote ty baseline to {baseline_path}: "
+            f"{payload['summary']['general_findings']} general / "
+            f"{payload['summary']['total_findings']} total findings across "
+            f"{payload['summary']['module_count']} modules."
+        )
+        return 0
+
+    # --check
+    if not baseline_path.exists():
+        print(
+            f"ERROR: baseline not found at {baseline_path}. "
+            f"Generate it with --write-baseline first.",
+            file=sys.stderr,
+        )
+        return 2
+    baseline = load_baseline(baseline_path)
+    failures, notices = check_against_baseline(findings, baseline)
+
+    print(
+        f"ty advisory ratchet: general={payload['summary']['general_findings']} "
+        f"(baseline general={sum(int(m.get('general', 0)) for m in baseline.get('modules', {}).values())}), "
+        f"optional_import_excluded={payload['summary']['optional_import_findings_excluded']}."
+    )
+    for notice in notices:
+        print(f"NOTICE: {notice}")
+    if failures:
+        print("\nty advisory ratchet FAILED (downward ratchet violated):", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        print(
+            "\nFix the new findings, or refresh the baseline with "
+            "`scripts/dev/ty_advisory_ratchet.py --write-baseline` if the "
+            "increase is intentional and reviewed.",
+            file=sys.stderr,
+        )
+        return 1
+    print("ty advisory ratchet passed: no per-module increase; clean modules stayed clean.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/ty_advisory_baseline.json
+++ b/scripts/validation/ty_advisory_baseline.json
@@ -1,0 +1,201 @@
+{
+  "description": "ty advisory diagnostic baseline + per-module downward ratchet (issue #5004). The ratchet gates on the 'general' bucket; the 'optional_import_excluded' bucket is recorded for visibility but owned by #4990/#4995. Refresh with `scripts/dev/ty_advisory_ratchet.py --write-baseline` after intentionally reducing findings.",
+  "exclusion": {
+    "owned_by_other_issues": [
+      "#4990",
+      "#4995",
+      "#4988"
+    ],
+    "rule": "Findings with check_name='unresolved-import' and description prefix 'unresolved-import: Cannot resolve imported module...' are treated as the optional-import category: recorded but EXCLUDED from the ratchet gate (owned by #4990/#4995)."
+  },
+  "generated_at": "2026-07-10T11:46:32Z",
+  "modules": {
+    "examples": {
+      "general": 151,
+      "optional_import_excluded": 2,
+      "total": 153
+    },
+    "experiments": {
+      "general": 3,
+      "optional_import_excluded": 0,
+      "total": 3
+    },
+    "fast-pysf": {
+      "general": 2,
+      "optional_import_excluded": 6,
+      "total": 8
+    },
+    "robot_sf": {
+      "general": 3,
+      "optional_import_excluded": 0,
+      "total": 3
+    },
+    "robot_sf/adversarial": {
+      "general": 48,
+      "optional_import_excluded": 0,
+      "total": 48
+    },
+    "robot_sf/analysis": {
+      "general": 6,
+      "optional_import_excluded": 0,
+      "total": 6
+    },
+    "robot_sf/analysis_workbench": {
+      "general": 2,
+      "optional_import_excluded": 0,
+      "total": 2
+    },
+    "robot_sf/baselines": {
+      "general": 16,
+      "optional_import_excluded": 0,
+      "total": 16
+    },
+    "robot_sf/benchmark": {
+      "general": 510,
+      "optional_import_excluded": 2,
+      "total": 512
+    },
+    "robot_sf/common": {
+      "general": 2,
+      "optional_import_excluded": 0,
+      "total": 2
+    },
+    "robot_sf/data_analysis": {
+      "general": 6,
+      "optional_import_excluded": 0,
+      "total": 6
+    },
+    "robot_sf/feature_extractors": {
+      "general": 3,
+      "optional_import_excluded": 0,
+      "total": 3
+    },
+    "robot_sf/gym_env": {
+      "general": 57,
+      "optional_import_excluded": 0,
+      "total": 57
+    },
+    "robot_sf/manual_control": {
+      "general": 1,
+      "optional_import_excluded": 0,
+      "total": 1
+    },
+    "robot_sf/maps": {
+      "general": 19,
+      "optional_import_excluded": 0,
+      "total": 19
+    },
+    "robot_sf/models": {
+      "general": 2,
+      "optional_import_excluded": 0,
+      "total": 2
+    },
+    "robot_sf/nav": {
+      "general": 52,
+      "optional_import_excluded": 0,
+      "total": 52
+    },
+    "robot_sf/ped_ego": {
+      "general": 4,
+      "optional_import_excluded": 0,
+      "total": 4
+    },
+    "robot_sf/ped_npc": {
+      "general": 5,
+      "optional_import_excluded": 0,
+      "total": 5
+    },
+    "robot_sf/planner": {
+      "general": 347,
+      "optional_import_excluded": 6,
+      "total": 353
+    },
+    "robot_sf/render": {
+      "general": 22,
+      "optional_import_excluded": 0,
+      "total": 22
+    },
+    "robot_sf/research": {
+      "general": 10,
+      "optional_import_excluded": 0,
+      "total": 10
+    },
+    "robot_sf/robot": {
+      "general": 8,
+      "optional_import_excluded": 0,
+      "total": 8
+    },
+    "robot_sf/scenario_certification": {
+      "general": 3,
+      "optional_import_excluded": 0,
+      "total": 3
+    },
+    "robot_sf/sensor": {
+      "general": 3,
+      "optional_import_excluded": 0,
+      "total": 3
+    },
+    "robot_sf/sim": {
+      "general": 14,
+      "optional_import_excluded": 0,
+      "total": 14
+    },
+    "robot_sf/telemetry": {
+      "general": 11,
+      "optional_import_excluded": 0,
+      "total": 11
+    },
+    "robot_sf/training": {
+      "general": 74,
+      "optional_import_excluded": 0,
+      "total": 74
+    },
+    "robot_sf_carla_bridge": {
+      "general": 2,
+      "optional_import_excluded": 0,
+      "total": 2
+    },
+    "scripts": {
+      "general": 960,
+      "optional_import_excluded": 19,
+      "total": 979
+    },
+    "third_party": {
+      "general": 194,
+      "optional_import_excluded": 114,
+      "total": 308
+    }
+  },
+  "rules": {
+    "call-non-callable": 10,
+    "deprecated": 1,
+    "index-out-of-bounds": 4,
+    "invalid-argument-type": 1443,
+    "invalid-assignment": 121,
+    "invalid-key": 1,
+    "invalid-method-override": 5,
+    "invalid-parameter-default": 4,
+    "invalid-return-type": 80,
+    "invalid-syntax": 7,
+    "invalid-type-form": 43,
+    "no-matching-overload": 59,
+    "not-iterable": 41,
+    "not-subscriptable": 80,
+    "redundant-cast": 4,
+    "too-many-positional-arguments": 1,
+    "unknown-argument": 5,
+    "unresolved-attribute": 498,
+    "unresolved-import": 168,
+    "unresolved-reference": 1,
+    "unsupported-operator": 71,
+    "unused-type-ignore-comment": 42
+  },
+  "schema_version": 1,
+  "summary": {
+    "general_findings": 2540,
+    "module_count": 31,
+    "optional_import_findings_excluded": 149,
+    "total_findings": 2689
+  },
+  "ty_version": "ty 0.0.58"
+}

--- a/tests/dev/test_ty_advisory_ratchet.py
+++ b/tests/dev/test_ty_advisory_ratchet.py
@@ -15,6 +15,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "dev" / "ty_advisory_ratchet.py"
 BASELINE = ROOT / "scripts" / "validation" / "ty_advisory_baseline.json"
@@ -326,3 +328,30 @@ def test_committed_baseline_reproduces_on_clean_checkout() -> None:
 def test_ratchet_helper_is_registered_in_repo() -> None:
     """The ratchet helper exists at the documented path."""
     assert SCRIPT.exists(), f"ty ratchet helper missing at {SCRIPT}"
+
+
+def test_aggregate_tolerates_null_location() -> None:
+    """A finding with an explicit null location must not crash aggregation (gate #5052 fix)."""
+    finding = {"check_name": "invalid-argument-type", "location": None}
+    agg = tyratchet.aggregate([finding])
+    # The finding is bucketed under the '<unknown>' path module, not an AttributeError.
+    assert agg["modules"]["<unknown>"]["total"] == 1
+
+
+def test_load_baseline_rejects_non_object_json(tmp_path: Path) -> None:
+    """A baseline whose top-level JSON is not an object must fail closed (gate #5052 fix)."""
+    bad = tmp_path / "baseline.json"
+    bad.write_text("[]", encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        tyratchet.load_baseline(bad)
+
+
+def test_load_baseline_rejects_non_dict_modules(tmp_path: Path) -> None:
+    """A baseline whose 'modules' is not a mapping must fail closed (gate #5052 fix)."""
+    bad = tmp_path / "baseline.json"
+    bad.write_text(
+        json.dumps({"schema_version": tyratchet.SCHEMA_VERSION, "modules": []}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="valid 'modules' mapping"):
+        tyratchet.load_baseline(bad)

--- a/tests/dev/test_ty_advisory_ratchet.py
+++ b/tests/dev/test_ty_advisory_ratchet.py
@@ -1,0 +1,328 @@
+"""Tests for the ty advisory diagnostic baseline + per-module downward ratchet (#5004).
+
+These tests cover the pure ratchet logic directly (classification, module keying,
+the downward-ratchet gate) and the CLI end-to-end via ``--ty-output`` so no live
+``ty`` invocation is required in the unit suite. They also assert the acceptance
+criteria: a committed baseline exists, the worked-example module was driven to
+zero, and the ratchet fails on a net-new finding in a clean module.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "dev" / "ty_advisory_ratchet.py"
+BASELINE = ROOT / "scripts" / "validation" / "ty_advisory_baseline.json"
+
+# Import the helper as a source module (it lives under scripts/dev, not a package).
+_spec = importlib.util.spec_from_file_location("ty_advisory_ratchet", SCRIPT)
+assert _spec is not None and _spec.loader is not None
+tyratchet = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(tyratchet)
+
+
+def _finding(
+    path: str,
+    line: int = 1,
+    *,
+    check_name: str = "invalid-argument-type",
+    description: str = "invalid-argument-type: Argument is incorrect",
+    severity: str = "major",
+) -> dict:
+    """Build one synthetic ty gitlab-JSON finding for deterministic tests."""
+    return {
+        "check_name": check_name,
+        "description": description,
+        "severity": severity,
+        "fingerprint": f"{path}:{line}:{check_name}",
+        "location": {
+            "path": path,
+            "positions": {"begin": {"line": line, "column": 1}},
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# classify_finding
+# --------------------------------------------------------------------------- #
+
+
+def test_classify_general_finding() -> None:
+    """A normal type rule is part of the general (ratcheted) bucket."""
+    assert (
+        tyratchet.classify_finding(
+            _finding("robot_sf/nav/x.py", check_name="invalid-argument-type")
+        )
+        == "general"
+    )
+
+
+def test_classify_optional_import_whole_module_resolution_is_excluded() -> None:
+    """'Cannot resolve imported module' is the optional-import category (excluded)."""
+    finding = _finding(
+        "robot_sf/planner/ompl.py",
+        check_name="unresolved-import",
+        description="unresolved-import: Cannot resolve imported module `ompl`",
+    )
+    assert tyratchet.classify_finding(finding) == "optional_import"
+
+
+def test_classify_member_resolution_is_kept_in_general() -> None:
+    """First-party member-resolution errors are real bugs, not optional imports."""
+    finding = _finding(
+        "robot_sf/benchmark/_preflight.py",
+        check_name="unresolved-import",
+        description="unresolved-import: Module `robot_sf.benchmark.camera_ready_campaign` has no member `_x`",
+    )
+    assert tyratchet.classify_finding(finding) == "general"
+
+
+# --------------------------------------------------------------------------- #
+# module_of
+# --------------------------------------------------------------------------- #
+
+
+def test_module_of_robot_sf_subpackage() -> None:
+    """robot_sf groups two levels deep (robot_sf/<subpkg>)."""
+    assert tyratchet.module_of("robot_sf/data/external/ind.py") == "robot_sf/data"
+    assert tyratchet.module_of("robot_sf/benchmark/cli.py") == "robot_sf/benchmark"
+
+
+def test_module_of_top_level_dir() -> None:
+    """Non-robot_sf paths use the single top-level segment."""
+    assert tyratchet.module_of("scripts/dev/foo.py") == "scripts"
+    assert tyratchet.module_of("examples/plot/x.py") == "examples"
+
+
+# --------------------------------------------------------------------------- #
+# check_against_baseline (the downward ratchet gate)
+# --------------------------------------------------------------------------- #
+
+
+def test_ratchet_passes_when_counts_unchanged() -> None:
+    """No per-module change -> pass, no failures."""
+    findings = [_finding("robot_sf/nav/a.py"), _finding("robot_sf/nav/b.py")]
+    baseline = {"modules": {"robot_sf/nav": {"general": 2, "total": 2}}}
+    failures, notices = tyratchet.check_against_baseline(findings, baseline)
+    assert failures == []
+    assert notices == []
+
+
+def test_ratchet_fails_on_clean_module_regression() -> None:
+    """A clean module gaining any finding fails (net-new in clean territory)."""
+    findings = [_finding("robot_sf/data/external/ind.py")]
+    baseline = {"modules": {}}  # robot_sf/data is clean / absent
+    failures, _notices = tyratchet.check_against_baseline(findings, baseline)
+    assert any("clean module regressed" in m and "robot_sf/data" in m for m in failures)
+
+
+def test_ratchet_fails_on_tracked_module_increase() -> None:
+    """A tracked module's count increasing violates the downward ratchet."""
+    findings = [
+        _finding("robot_sf/nav/a.py"),
+        _finding("robot_sf/nav/b.py"),
+        _finding("robot_sf/nav/c.py"),
+    ]
+    baseline = {"modules": {"robot_sf/nav": {"general": 2, "total": 2}}}
+    failures, _notices = tyratchet.check_against_baseline(findings, baseline)
+    assert any("increased from 2 to 3" in m for m in failures)
+
+
+def test_ratchet_passes_on_decrease_and_emits_refresh_notice() -> None:
+    """A decrease passes and hints at refreshing the baseline (downward motion)."""
+    findings = [_finding("robot_sf/nav/a.py")]
+    baseline = {"modules": {"robot_sf/nav": {"general": 2, "total": 2}}}
+    failures, notices = tyratchet.check_against_baseline(findings, baseline)
+    assert failures == []
+    assert any("ratchet opportunity" in n and "robot_sf/nav" in n for n in notices)
+
+
+def test_ratchet_ignores_optional_import_findings_in_gate() -> None:
+    """Optional-import findings do not count toward the general-bucket gate."""
+    findings = [
+        _finding(
+            "robot_sf/nav/a.py",
+            check_name="unresolved-import",
+            description="unresolved-import: Cannot resolve imported module `ompl`",
+        )
+    ]
+    baseline = {"modules": {}}  # robot_sf/nav treated as clean
+    failures, _notices = tyratchet.check_against_baseline(findings, baseline)
+    # Optional-import finding must NOT trip the clean-module gate.
+    assert failures == []
+
+
+# --------------------------------------------------------------------------- #
+# aggregate
+# --------------------------------------------------------------------------- #
+
+
+def test_aggregate_splits_optional_and_general_buckets() -> None:
+    """Optional-import findings land in the excluded bucket; others in general."""
+    findings = [
+        _finding("robot_sf/nav/a.py"),
+        _finding(
+            "robot_sf/nav/b.py",
+            check_name="unresolved-import",
+            description="unresolved-import: Cannot resolve imported module `rvo2`",
+        ),
+        _finding("scripts/x.py"),
+    ]
+    agg = tyratchet.aggregate(findings)
+    assert agg["general_total"] == 2
+    assert agg["optional_import_total"] == 1
+    assert agg["total"] == 3
+    nav = agg["modules"]["robot_sf/nav"]
+    assert nav == {"general": 1, "optional_import_excluded": 1, "total": 2}
+
+
+# --------------------------------------------------------------------------- #
+# build_baseline_payload
+# --------------------------------------------------------------------------- #
+
+
+def test_baseline_payload_records_exclusion_and_sibling_issues() -> None:
+    """The baseline must document the optional-import exclusion and sibling owners."""
+    payload = tyratchet.build_baseline_payload(
+        [_finding("robot_sf/nav/a.py")], ty_version="ty 0.0.99"
+    )
+    assert payload["schema_version"] == tyratchet.SCHEMA_VERSION
+    assert payload["ty_version"] == "ty 0.0.99"
+    assert "#4990" in payload["exclusion"]["owned_by_other_issues"]
+    assert "#4995" in payload["exclusion"]["owned_by_other_issues"]
+    assert "#4988" in payload["exclusion"]["owned_by_other_issues"]
+    assert "Cannot resolve imported module" in payload["exclusion"]["rule"]
+
+
+# --------------------------------------------------------------------------- #
+# CLI end-to-end via --ty-output (no live ty run)
+# --------------------------------------------------------------------------- #
+
+
+def _run_cli(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    """Invoke the ratchet helper in ``repo`` with the given args."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(repo), *args],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_write_then_check_roundtrip(tmp_path: Path) -> None:
+    """A generated baseline from a ty report must reproduce and pass (--check)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    report = repo / "report.json"
+    report.write_text(json.dumps([_finding("robot_sf/nav/a.py")]) + "\n", encoding="utf-8")
+    baseline_rel = Path("scripts/validation/ty_advisory_baseline.json")
+
+    write_res = _run_cli(
+        repo,
+        "--write-baseline",
+        "--ty-output",
+        str(report),
+        "--baseline",
+        str(baseline_rel),
+    )
+    assert write_res.returncode == 0, write_res.stderr
+    assert (repo / baseline_rel).exists()
+
+    check_res = _run_cli(
+        repo, "--check", "--ty-output", str(report), "--baseline", str(baseline_rel)
+    )
+    assert check_res.returncode == 0, check_res.stderr
+    assert "ty advisory ratchet passed" in check_res.stdout
+
+
+def test_cli_check_fails_on_clean_module_regression(tmp_path: Path) -> None:
+    """A clean baseline + a ty report with a new finding fails with exit 1."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    empty_report = repo / "empty.json"
+    empty_report.write_text("[]\n", encoding="utf-8")
+    baseline_rel = Path("b.json")
+    _run_cli(
+        repo,
+        "--write-baseline",
+        "--ty-output",
+        str(empty_report),
+        "--baseline",
+        str(baseline_rel),
+    )
+
+    dirty_report = repo / "dirty.json"
+    dirty_report.write_text(json.dumps([_finding("robot_sf/nav/a.py")]) + "\n", encoding="utf-8")
+    res = _run_cli(
+        repo, "--check", "--ty-output", str(dirty_report), "--baseline", str(baseline_rel)
+    )
+    assert res.returncode == 1, res.stdout + res.stderr
+    assert "clean module regressed" in res.stderr
+    assert "robot_sf/nav" in res.stderr
+
+
+# --------------------------------------------------------------------------- #
+# Acceptance criteria against the committed baseline
+# --------------------------------------------------------------------------- #
+
+
+def test_committed_baseline_exists_and_is_valid() -> None:
+    """Acceptance: a checked-in per-module ty baseline exists and parses."""
+    assert BASELINE.exists(), "ty advisory baseline is missing from the repo"
+    data = json.loads(BASELINE.read_text(encoding="utf-8"))
+    assert data["schema_version"] == tyratchet.SCHEMA_VERSION
+    assert data.get("modules"), "baseline must contain a non-empty modules mapping"
+    assert "general_findings" in data["summary"]
+
+
+def test_worked_example_module_robot_sf_data_is_driven_to_zero() -> None:
+    """Acceptance: the worked-example module was cleared and removed from baseline."""
+    data = json.loads(BASELINE.read_text(encoding="utf-8"))
+    assert "robot_sf/data" not in data["modules"], (
+        "robot_sf/data should have been driven to zero and removed from the ty "
+        "baseline as the #5004 worked example"
+    )
+
+
+def test_committed_baseline_reproduces_on_clean_checkout() -> None:
+    """Acceptance: re-running ty and diffing against the baseline passes.
+
+    Runs the real ``uvx ty check`` (advisory) and asserts the committed baseline
+    reproduces with no per-module increase. Skipped when ``ty`` / network for
+    ``uvx`` is unavailable so this remains a CPU-only, offline-friendly suite.
+    """
+    import shutil
+
+    if shutil.which("uvx") is None:
+        import pytest
+
+        pytest.skip("uvx not available; cannot run live ty check")
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), "--check"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert res.returncode == 0, (
+        "ty advisory ratchet did not reproduce on a clean checkout:\n"
+        f"stdout:\n{res.stdout}\nstderr:\n{res.stderr}"
+    )
+    assert "ty advisory ratchet passed" in res.stdout
+
+
+# --------------------------------------------------------------------------- #
+# CI wiring (mirror the broad-exception ratchet wiring test)
+# --------------------------------------------------------------------------- #
+
+
+def test_ratchet_helper_is_registered_in_repo() -> None:
+    """The ratchet helper exists at the documented path."""
+    assert SCRIPT.exists(), f"ty ratchet helper missing at {SCRIPT}"


### PR DESCRIPTION
## What / Why

Closes #5004 — establishes a **ty advisory diagnostic baseline + per-module downward ratchet** over the ~2.7k pre-existing `ty` findings, turning the existing advisory `ty check` scan (already run in CI as `uvx ty check . --exit-zero`) into a **monotone-decreasing per-module gate**. This is the type-safety counterpart to the security baseline ratchet (#3477/#3529) and the TODO-docstring ratchet (#1285).

### Acceptance criteria

- [x] A checked-in `ty` baseline (per-module) exists and reproduces on a clean checkout — `scripts/validation/ty_advisory_baseline.json`; the live `--check` and the `test_committed_baseline_reproduces_on_clean_checkout` test both pass.
- [x] A ratchet check fails on newly-introduced findings in a clean module and passes otherwise — `scripts/dev/ty_advisory_ratchet.py --check`; verified with a deliberate regression (returns exit 1; reverted) and the `test_cli_check_fails_on_clean_module_regression` / `test_ratchet_fails_on_clean_module_regression` tests.
- [x] At least one module is driven to zero and removed from the baseline — `robot_sf/data` cleared via two genuine type fixes and removed from the baseline (module count 32 → 31).
- [x] No overlap with #4990/#4995 (optional imports) or #4988 (CLI typed errors) — the optional-import category is recorded but **excluded** from the gate (see Boundary).

## How it works

`scripts/dev/ty_advisory_ratchet.py` re-runs `uvx ty check .` (gitlab-JSON, advisory `--exit-zero`), aggregates findings per module, and diffs against the committed baseline.

- **`--check`** (the gate): fails when a clean module (baseline general count 0) gains any finding, or when any tracked module's general count increases. Decreases pass and emit a "ratchet opportunity" refresh hint.
- **`--write-baseline`**: refresh after intentionally reducing findings.
- **`--aggregate-only`** / **`--ty-output FILE`**: report-only / parse a pre-rendered report (offline + tests, no live `ty` run).

### Boundary — no overlap with sibling issues

The ratchet gates on the **general** bucket (2540 findings). The **optional-import category** (149 findings) is recorded in the baseline for visibility but **excluded** from the gate. A finding is the optional-import category when:

```
check_name == "unresolved-import"
and description starts with "unresolved-import: Cannot resolve imported module"
```

(whole-module resolution failures: `GPUtil`, `cairosvg`, `adjustText`, `rvo2`, `ompl`, vendored relative imports). First-party **member-resolution** errors (`unresolved-import: Module X has no member Y`) are **kept** in the general bucket — they are real type errors, not optional-dependency noise. Sibling owners recorded in the baseline: **#4990**, **#4995**, **#4988**. No optional-import `except` guards were modified.

## Worked example (criterion: one module to zero)

`robot_sf/data` was driven to 0 general findings via two genuine, non-optional-import type fixes:

- `robot_sf/data/external/ind.py` — narrow `Path | None` → `Path` with assertions after the `missing`-sibling guard (the guard already proved the siblings were non-None).
- `robot_sf/data/external/socnavbench_eth.py` — build the 2-D `traversible_shape` as an explicit `tuple[int, int]` (the `ndim == 2` validation at line 156 already guarantees a 2-element shape).

Both are behaviour-preserving (the runtime invariants already held) and covered by the existing `tests/data/` suite.

## CI wiring

- `.github/workflows/ty-advisory-ratchet.yml` — non-gating (`continue-on-error`) companion on PRs that touch Python/config/baseline paths + weekly schedule; uploads the ratchet log. Promote to gating by removing `continue-on-error` once settled.
- `scripts/dev/ci_driver.sh` typecheck phase — surfaces the ratchet result as advisory (non-failing), matching the existing `uvx ty check . --exit-zero` posture.

## Files

- `scripts/dev/ty_advisory_ratchet.py` (new) — the ratchet helper.
- `scripts/validation/ty_advisory_baseline.json` (new) — committed baseline.
- `tests/dev/test_ty_advisory_ratchet.py` (new) — 18 tests.
- `.github/workflows/ty-advisory-ratchet.yml` (new) — non-gating CI.
- `scripts/dev/ci_driver.sh` — advisory wiring.
- `robot_sf/data/external/{ind,socnavbench_eth}.py` — worked-example fixes.
- `docs/context/issue_5004_ty_advisory_ratchet.md` + README index.

## Validation (CPU-only; no campaigns/Slurm/training)

```
uv run pytest tests/dev/test_ty_advisory_ratchet.py -q
# 18 passed in ~3s (incl. live baseline reproduction test)

uv run pytest tests/data/ -q
# 102 passed, 6 skipped (worked-example regression)

uv run ruff check scripts/dev/ty_advisory_ratchet.py tests/dev/test_ty_advisory_ratchet.py robot_sf/data/external/ind.py robot_sf/data/external/socnavbench_eth.py
# All checks passed!

uv run ruff format --check <same files>
# 4 files already formatted

uv run python scripts/dev/ty_advisory_ratchet.py --check
# ty advisory ratchet: general=2540 (baseline general=2540), optional_import_excluded=149.
# ty advisory ratchet passed: no per-module increase; clean modules stayed clean. (exit 0)
```

Negative-path verification: a deliberate type error added to the now-clean `robot_sf/data` made `--check` print `clean module regressed: 'robot_sf/data' went from 0 to 1` and return **exit 1**; reverted.

## Evidence / artifact propagation

- Target claim: a reproducible per-module ty baseline + downward ratchet (tooling/test only). Comparator/baseline: the pre-PR advisory `ty` scan (no baseline). Evidence tier: executable proof (`--check` + tests). Result classification: native — the ratchet runs the real `uvx ty check` and passes on a clean checkout.
- `output/` not relied upon; the baseline is a tracked JSON file. No raw episode/video/log/checkpoint artifacts produced.

## Notes / uncertainty

- The optional-import exclusion is deliberately **conservative**: a handful of first-party `Cannot resolve imported module robot_sf....` findings (genuinely missing modules) are also excluded from the gate. They remain recorded in the baseline and can be pulled into the general bucket in a follow-up if desired. Uncertainty: low (~95%) that this scoping matches the issue intent ("excluding the optional-import categories owned by #4990/#4995").
- `ty` version at baseline time: `0.0.58` (fetched via `uvx`); recorded in the baseline `ty_version` field. ty minor-version drift can shift counts slightly (issue text said ~2711; this baseline captured 2689 total / 2540 general).
- This PR fully resolves issue #5004 (all four acceptance criteria met).

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Closes #5004
