### PR TITLE
test(ci): add xdist-scratch-isolation to CI timeout contract (#5033)

### DIFF
--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -21,6 +21,7 @@ WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 CI_JOB_TIMEOUTS = {
     "fast-feedback": 45,
     "smoke-artifacts": 30,
+    "xdist-scratch-isolation": 15,
     "wheel-smoke-install": 20,
     "examples-smoke": 30,
     "ci": 5,


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Add `"xdist-scratch-isolation": 15` to `CI_JOB_TIMEOUTS` in `tests/test_ci_driver_contract.py`.
- **Why now:** PR #5008 added the `xdist-scratch-isolation` job to `.github/workflows/ci.yml` (`timeout-minutes: 15`) but the contract map was not updated, so `test_ci_workflow_jobs_have_explicit_timeout_bounds` is red on fresh `origin/main` (the friction reported in #5033).
- **Claim boundary:** diagnostic-only test-contract fix; no runtime, benchmark, metric, or workflow-behavior change. The workflow itself is unchanged.
- **Required validation:** `pytest tests/test_ci_driver_contract.py` (16 passed).
- **Remaining blocker:** none.

## Contract delta

- `CI_JOB_TIMEOUTS` now enumerates all 6 CI jobs (was 5). The new entry's value (15) matches the job's declared `timeout-minutes` in `.github/workflows/ci.yml:199`, and it is positioned to mirror workflow job order (after `smoke-artifacts`, before `wheel-smoke-install`).
- No new fail-closed blockers; the existing `set(CI_JOB_TIMEOUTS) == set(jobs)` guard now passes because the map is complete again. This keeps every time-bounded CI job covered by the contract, restoring fail-closed coverage that had silently dropped.
- Backward compatible: no existing entries changed.

## Validation

```
$ scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_ci_driver_contract.py -q
16 passed in 1.21s
$ uv run ruff check tests/test_ci_driver_contract.py
All checks passed!
```

Before the change, `test_ci_workflow_jobs_have_explicit_timeout_bounds` failed on `origin/main` with:

```
E   AssertionError: assert set(CI_JOB_TIMEOUTS) == set(jobs)
E     Extra items in the right set:
E     'xdist-scratch-isolation'
```

## Scope

- Issue: #5033
- In scope: single-line addition to the CI timeout contract map + validation.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no `.github/workflows/ci.yml` change.

Closes #5033

<details>
<summary>Governance</summary>

- **Evidence tier:** diagnostic-only (test-contract guard). Research claim: `NA` — tooling/test fix with no benchmark semantics.
- **Fragmentation guard:** first PR for #5033; this is the exact bounded fix named in the issue's implementation plan (progression slice), not a redundant micro-guard.
- **State propagation:** low-churn issue; `Closes #5033` in this PR body is the single canonical surface. No tracked queue-routing state added.
- **Freshness:** branch cut from `origin/main` @ `7c0432421`; issue re-checked immediately before PR open — no maintainer comments newer than session start (only the implementation-plan comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
