### PR TITLE
Issue #5025: drop ignored frequency_episodes from canonical v3 PPO config (cheap-lane worker)

### DIFF
--- a/configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
+++ b/configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
@@ -48,8 +48,6 @@ convergence:
   collision_rate: 0.05
   plateau_window: 2000
 evaluation:
-  # Deprecated/ignored by train_ppo.py; cadence is controlled by step_schedule.
-  frequency_episodes: 10
   evaluation_episodes: 100
   hold_out_scenarios: []
   step_schedule:

--- a/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
+++ b/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
@@ -75,7 +75,7 @@ training_starting_points:
   # only modify density/complexity sampling; architecture, reward and seeds are held fixed.
   resume_policy_id: ppo_expert_br06_v3_15m_all_maps_randomized
   checksums:
-    configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml: a374a624eb38402e5e4e2612f92440c0f80ff1eb0554a34f33dd36c16920a426
+    configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml: 91f9d9a7c0bcb54f3628beef9140181a64277ab8bdf9b12dcdc37f0251a7d437
     configs/algos/ppo_v3_camera_ready.yaml: 6e7efd7bef68d4cdbac23bda7a0fa12d206229d5c0566c1e38f84cd9122a73c8
     configs/algos/guarded_ppo_relaxed_v2.yaml: 666eda5a47de6e452eba9b2f3cb15bda16fc97abcd7137434661a87ac9ff85d8
     configs/scenarios/classic_interactions_francis2023.yaml: d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5

--- a/configs/training/shielded_ppo_issue_1396_launch_packet.yaml
+++ b/configs/training/shielded_ppo_issue_1396_launch_packet.yaml
@@ -24,7 +24,7 @@ training_starting_points:
   guarded_algo_config: configs/algos/guarded_ppo_relaxed_v2.yaml
   resume_policy_id: ppo_expert_br06_v3_15m_all_maps_randomized
   checksums:
-    configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml: a374a624eb38402e5e4e2612f92440c0f80ff1eb0554a34f33dd36c16920a426
+    configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml: 91f9d9a7c0bcb54f3628beef9140181a64277ab8bdf9b12dcdc37f0251a7d437
     configs/policy_search/candidates/risk_guarded_ppo_v1.yaml: 69030a865be80be5e3ba98db447551c3707f966de8ac5f216e66044d9ea50735
 runtime_guard:
   active_in_all_evaluations: true

--- a/tests/training/test_shielded_ppo_launch_packet.py
+++ b/tests/training/test_shielded_ppo_launch_packet.py
@@ -51,7 +51,7 @@ def _valid_packet(tmp_path: Path) -> dict[str, object]:
             "guarded_algo_config": "configs/algos/guarded_ppo_relaxed_v2.yaml",
             "checksums": {
                 "configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml": (
-                    "a374a624eb38402e5e4e2612f92440c0f80ff1eb0554a34f33dd36c16920a426"
+                    "91f9d9a7c0bcb54f3628beef9140181a64277ab8bdf9b12dcdc37f0251a7d437"
                 ),
                 "configs/policy_search/candidates/risk_guarded_ppo_v1.yaml": (
                     "69030a865be80be5e3ba98db447551c3707f966de8ac5f216e66044d9ea50735"

--- a/tests/training/test_train_expert_ppo_contract.py
+++ b/tests/training/test_train_expert_ppo_contract.py
@@ -6,7 +6,7 @@ import json
 import pickle
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 from robot_sf.feature_extractors.grid_socnav_extractor import GridSocNavExtractor
 from robot_sf.training.imitation_config import (
@@ -17,9 +17,6 @@ from robot_sf.training.imitation_config import (
 from robot_sf.training.ppo_policy import AsymmetricGridSocNavPolicy
 from robot_sf.training.snqi_utils import default_training_snqi_context
 from scripts.training import train_ppo
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_resolve_worker_mode_accepts_threaded_and_keeps_single_env_fallback() -> None:
@@ -84,6 +81,62 @@ def test_warn_frequency_episodes_deprecated_warns_once(monkeypatch) -> None:
 
     assert len(calls) == 1
     assert "ignored" in calls[0]
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CANONICAL_V3_CONFIG = (
+    _REPO_ROOT / "configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml"
+)
+
+
+def _assert_no_frequency_episodes_warning(monkeypatch, load_callable) -> None:
+    """Fail if loading a config emits the ignored frequency_episodes deprecation warning."""
+    warnings: list[str] = []
+
+    def _record_warning(msg: str, *args) -> None:
+        warnings.append(msg.format(*args) if args else msg)
+
+    monkeypatch.setattr(train_ppo.logger, "warning", _record_warning)
+    monkeypatch.setattr(train_ppo, "_FREQUENCY_EPISODES_DEPRECATION_WARNED", False)
+
+    load_callable()
+
+    stale = [w for w in warnings if "frequency_episodes" in w and "ignored" in w]
+    assert not stale, f"canonical config emitted stale deprecation warning: {stale}"
+    assert train_ppo._FREQUENCY_EPISODES_DEPRECATION_WARNED is False
+
+
+def test_canonical_v3_ppo_config_emits_no_frequency_episodes_warning(monkeypatch) -> None:
+    """Regression for issue #5025: canonical v3 PPO config must not declare frequency_episodes."""
+    assert _CANONICAL_V3_CONFIG.is_file(), f"canonical v3 config missing: {_CANONICAL_V3_CONFIG}"
+
+    _assert_no_frequency_episodes_warning(
+        monkeypatch, lambda: train_ppo.load_expert_training_config(_CANONICAL_V3_CONFIG)
+    )
+
+
+def test_child_config_with_step_schedule_emits_no_frequency_episodes_warning(
+    monkeypatch, tmp_path
+) -> None:
+    """Regression for issue #5025: a child config using step_schedule inherits no stale warning."""
+    child = tmp_path / "child_step_schedule.yaml"
+    child.write_text(
+        "\n".join(
+            [
+                f"base_config: {_CANONICAL_V3_CONFIG}",
+                "policy_id: ppo_child_step_schedule_regression_issue_5025",
+                "total_timesteps: 1000",
+                "evaluation:",
+                "  step_schedule:",
+                "    - every_steps: 500",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    _assert_no_frequency_episodes_warning(
+        monkeypatch, lambda: train_ppo.load_expert_training_config(child)
+    )
 
 
 def test_prepare_seed_state_relaxes_determinism_for_lightweight_cnn(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## What / Why

Fixes the friction reported in #5025: the canonical v3 PPO base config
`configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml`
declared `evaluation.frequency_episodes`, which `scripts/training/train_ppo.py`
**ignores** (checkpoint cadence is controlled by `evaluation.step_schedule`) while
emitting a deprecation warning. Any child config that inherits from this base via
`base_config` therefore inherited the stale warning, even when it correctly
declared `step_schedule`.

This is the exact bounded change requested in the issue: configuration cleanup
that **must not change evaluation cadence or benchmark metric semantics**.

## Changes

1. Removed the ignored `evaluation.frequency_episodes` key (and its comment) from
   the canonical v3 PPO base config. `frequency_episodes` was already ignored by
   the loader and defaults to `0`; `step_schedule` is unchanged, so cadence is
   identical.
2. Updated the sha256 checksum of the v3 config in the three places that pin it
   (old `a374a624…` → new `91f9d9a7…`):
   - `configs/training/shielded_ppo_issue_1396_launch_packet.yaml`
   - `configs/training/ppo_curriculum_issue_3068_launch_packet.yaml`
   - `tests/training/test_shielded_ppo_launch_packet.py` (the `_valid_packet`
     fixture checksum)
3. Added two regression assertions in
   `tests/training/test_train_expert_ppo_contract.py`:
   - `test_canonical_v3_ppo_config_emits_no_frequency_episodes_warning` — the
     canonical config loads without the stale warning.
   - `test_child_config_with_step_schedule_emits_no_frequency_episodes_warning` —
     a child config that uses `base_config` + `step_schedule` loads without the
     stale warning.

## Validation (CPU only)

Worktree `local.machine.md` symlinked from the main checkout; fresh local
`.venv` via `uv sync --all-extras` (the shared main venv had a pre-existing
`pysocialforce` 2.0.0 import break unrelated to this change).

```
# New regression tests + existing warning test + the two checksum tests
uv run pytest tests/training/test_train_expert_ppo_contract.py \
  tests/training/test_shielded_ppo_launch_packet.py \
  tests/training/test_ppo_curriculum_launch_packet_issue_3068.py -q
# -> 40 passed

# Broader regression sweep (training + pretraining pipeline)
uv run pytest tests/training/ tests/integration/test_ppo_pretraining_pipeline.py -q
# -> 715 passed

uv run ruff check <changed .py files>     # All checks passed!
uv run ruff format --check <changed .py>  # already formatted
```

Positive control confirms the warning mechanism is intact: a throwaway child
config that re-introduces `frequency_episodes: 7` still triggers the warning, so
the new regression tests fail for the right reason before the config fix and pass
after it.

## Artifact handling / evidence propagation

Configuration cleanup only — no benchmark, metric, schema, or model-provenance
claim. No `output/*` artifacts produced. Evaluation cadence is unchanged
(`frequency_episodes` was already ignored; `step_schedule` is identical).
Checksums in launch packets are regenerated against the edited file content and
validated by the existing packet validators.

Closes #5025

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
