### PR TITLE
fix(workflow): docs-only PRs can select domain approval not required (#5031)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -43,7 +43,9 @@ Required when `Evidence tier` is not `NA`/`docs-only`, or `Result classification
 Use this for PRs that change evidence classification, experimental comparison methodology, figure
 eligibility, benchmark interpretation, or paper-facing claim surfaces. This approval concerns
 experimental validity and claim boundaries; normal implementation integrity still comes from code
-review, tests, and CI.
+review, tests, and CI. Docs-only/support PRs that only *mention* an evidence concept in prose (and do
+not fill a concrete `Evidence tier`/`Result classification`) may opt out with
+`Required for this PR: no - reason` and `Status: not required`.
 
 - Required for this PR: yes / no - reason
 - Domains reviewed: evidence classification / experimental comparison / figure eligibility / benchmark interpretation / paper-facing claims / NA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* **issue #5031 docs-only PR bodies can now select "domain approval not required".** The PR
+  follow-up checker (`scripts/dev/check_pr_followups.py::analyze_domain_approval`) previously forced
+  `domain_approval_required` on any body that merely *mentioned* an evidence concept in prose (e.g. a
+  docs page discussing "benchmark interpretation" or "diagnostic-only"), so a genuinely docs-only PR
+  could not use the template's documented `Required for this PR: no - reason` / `Status: not required`
+  opt-out. `analyze_domain_approval` now accepts that opt-out when the only triggers are weak
+  free-form prose mentions. A filled Research Result Guidance declaration (a concrete `Evidence tier`
+  / `Result classification`) remains a strong self-declaration and keeps the strict approval path, so
+  this cannot wave through an evidence-sensitive PR. Found while implementing #4967. No benchmark
+  metric semantics change.
+
 ### Added
 
 * **issue #4871 CrowdNav_Prediction_AttnGraph external learned-baseline feasibility smoke.** New

--- a/scripts/dev/check_pr_followups.py
+++ b/scripts/dev/check_pr_followups.py
@@ -77,6 +77,10 @@ FREEFORM_DOMAIN_TRIGGER_RE = re.compile(
 # because describing the absence of a claim is the opposite of making one. Without this, honestly
 # stating an evidence boundary in a PR body would (perversely) require domain approval.
 _NEGATED_TRIGGER_RE = re.compile(r"\b(no|not|without|never|non)\b[\s\w-]{0,24}$", re.IGNORECASE)
+# Free-form triggers are prose *mentions* of an evidence concept (e.g. a docs page that discusses
+# "benchmark interpretation"), a weaker signal than a filled Research Result Guidance declaration.
+# Only free-form triggers may be opted out of with the documented docs-only/not-required branch.
+_FREEFORM_TRIGGER_PREFIX = "free-form evidence marker: "
 BOT_ONLY_MARKERS = (
     "auto-generated comment: release notes by coderabbit.ai",
     "auto-generated comment: summarize by coderabbit.ai",
@@ -328,6 +332,57 @@ def _domain_value_not_required(text: str) -> bool:
     return any(_has_value_prefix(value, prefix) for prefix in DOMAIN_APPROVAL_NOT_REQUIRED)
 
 
+def _domain_required_opts_out(required: str) -> bool:
+    """Return whether the 'Required for this PR' field explicitly opts out with a reason.
+
+    The PR template documents ``Required for this PR: no - reason`` as the docs-only branch. A bare
+    empty value or an unselected ``yes / no`` option list is *not* a deliberate opt-out, so those
+    stay on the strict path that demands an explicit answer.
+    """
+    if _is_empty_or_option_placeholder(required):
+        return False
+    value = _clean_value(required).lower()
+    return any(
+        _has_value_prefix(value, prefix)
+        for prefix in ("no", "n/a", "na", "not applicable", "docs-only", "docs only")
+    )
+
+
+def _domain_status_opts_out(status_value: str) -> bool:
+    """Return whether an approval status explicitly selects the not-required/waived branch."""
+    if re.search(r"\bnot\s+required\b", status_value) or re.search(r"\bwaiv", status_value):
+        return True
+    return status_value in {"na", "n/a", "not applicable", "none"}
+
+
+def _domain_triggers_are_freeform_only(sensitive_terms: tuple[str, ...]) -> bool:
+    """Return whether every trigger is a weak free-form prose mention (never a structured field).
+
+    Structured Research Result Guidance declarations (a filled ``Evidence tier`` / ``Result
+    classification``) are a strong self-declaration and must keep the strict approval path. Only
+    prose *mentions* of an evidence concept are eligible for the docs-only opt-out.
+    """
+    return bool(sensitive_terms) and all(
+        term.startswith(_FREEFORM_TRIGGER_PREFIX) for term in sensitive_terms
+    )
+
+
+def _is_docs_only_domain_opt_out(
+    sensitive_terms: tuple[str, ...], required: str, status_value: str
+) -> bool:
+    """Return whether the documented docs-only / not-required approval opt-out applies.
+
+    True only when every trigger is a weak free-form prose mention, the ``Required for this PR``
+    field explicitly opts out with a reason, and the ``Status`` selects the not-required/waived
+    branch. This keeps structured Research Result Guidance declarations on the strict path.
+    """
+    return (
+        _domain_triggers_are_freeform_only(sensitive_terms)
+        and _domain_required_opts_out(required)
+        and _domain_status_opts_out(status_value)
+    )
+
+
 def _has_value_prefix(value: str, prefix: str) -> bool:
     """Return whether *value* starts with *prefix* as a standalone token."""
     if not value.startswith(prefix):
@@ -341,7 +396,7 @@ def _domain_approval_triggers(body: str) -> tuple[str, ...]:
     section = _extract_section(body, "Research Result Guidance")
     if not section:
         return tuple(
-            f"free-form evidence marker: {match.group(1)}"
+            f"{_FREEFORM_TRIGGER_PREFIX}{match.group(1)}"
             for match in FREEFORM_DOMAIN_TRIGGER_RE.finditer(body)
             if not _NEGATED_TRIGGER_RE.search(body[: match.start()])
         )
@@ -508,6 +563,35 @@ def analyze_body(body: str, *, source: str, require_open_issues: bool = False) -
     )
 
 
+def _domain_status_report(
+    status_value: str,
+    *,
+    source: str,
+    sensitive_terms: tuple[str, ...],
+    required: str,
+    approval_status: str,
+    approval_note: str,
+    checklist_errors: tuple[str, ...],
+) -> DomainApprovalReport | None:
+    """Return a report when the approval status is not a clean approved/waived value, else None."""
+    unapproved = re.search(r"\b(blocked?|blocker|no|not|pending|awaiting)\b", status_value)
+    if unapproved or not re.search(r"\b(approved?|waived|waiver)\b", status_value):
+        pending = bool(re.search(r"\b(blocked?|blocker|pending|awaiting)\b", status_value))
+        return DomainApprovalReport(
+            status="pending_domain_approval" if pending else "invalid_domain_approval_status",
+            source=source,
+            sensitive_terms=sensitive_terms,
+            required=required,
+            approval_status=approval_status,
+            approval_note=approval_note,
+            checklist_errors=checklist_errors,
+            message=(
+                "Domain-aware approval status must say approved or waived before final readiness."
+            ),
+        )
+    return None
+
+
 def analyze_domain_approval(body: str, *, source: str) -> DomainApprovalReport:
     """Return whether domain-sensitive PR bodies carry explicit approval or blocker status."""
     sensitive_terms = _domain_approval_triggers(body)
@@ -551,6 +635,26 @@ def analyze_domain_approval(body: str, *, source: str) -> DomainApprovalReport:
     required_value = _clean_value(required).lower()
     status_value = _clean_value(approval_status).lower()
     note_value = _clean_value(approval_note)
+
+    # Documented docs-only / not-required branch. A PR that only *mentions* an evidence concept in
+    # prose (a free-form trigger, e.g. a docs page discussing "benchmark interpretation") may take
+    # the template's opt-out: `Required for this PR: no - reason` with `Status: not required`. A
+    # structured Research Result Guidance declaration is a stronger self-declaration and stays on the
+    # strict path below, so this cannot be used to wave through a genuinely evidence-sensitive PR.
+    if _is_docs_only_domain_opt_out(sensitive_terms, required, status_value):
+        return DomainApprovalReport(
+            status="ok",
+            source=source,
+            sensitive_terms=sensitive_terms,
+            required=required,
+            approval_status=approval_status,
+            approval_note=note_value,
+            checklist_errors=(),
+            message=(
+                "Domain-aware approval is explicitly not required for this docs-only/support PR; "
+                "the evidence term is a prose mention, not a structured evidence declaration."
+            ),
+        )
 
     if _is_empty_or_option_placeholder(required) or any(
         _has_value_prefix(required_value, prefix)
@@ -603,36 +707,17 @@ def analyze_domain_approval(body: str, *, source: str) -> DomainApprovalReport:
                 f"{', '.join(checklist_errors)}."
             ),
         )
-    if re.search(r"\b(blocked?|blocker|no|not|pending|awaiting)\b", status_value):
-        return DomainApprovalReport(
-            status=(
-                "pending_domain_approval"
-                if re.search(r"\b(blocked?|blocker|pending|awaiting)\b", status_value)
-                else "invalid_domain_approval_status"
-            ),
-            source=source,
-            sensitive_terms=sensitive_terms,
-            required=required,
-            approval_status=approval_status,
-            approval_note=approval_note,
-            checklist_errors=checklist_errors,
-            message=(
-                "Domain-aware approval status must say approved or waived before final readiness."
-            ),
-        )
-    if not re.search(r"\b(approved?|waived|waiver)\b", status_value):
-        return DomainApprovalReport(
-            status="invalid_domain_approval_status",
-            source=source,
-            sensitive_terms=sensitive_terms,
-            required=required,
-            approval_status=approval_status,
-            approval_note=approval_note,
-            checklist_errors=checklist_errors,
-            message=(
-                "Domain-aware approval status must say approved or waived before final readiness."
-            ),
-        )
+    status_report = _domain_status_report(
+        status_value,
+        source=source,
+        sensitive_terms=sensitive_terms,
+        required=required,
+        approval_status=approval_status,
+        approval_note=approval_note,
+        checklist_errors=checklist_errors,
+    )
+    if status_report is not None:
+        return status_report
 
     return DomainApprovalReport(
         status="ok",

--- a/tests/dev/test_check_pr_followups.py
+++ b/tests/dev/test_check_pr_followups.py
@@ -432,6 +432,84 @@ def test_domain_approval_rejects_not_required_for_sensitive_result() -> None:
     assert report.status == "domain_approval_required"
 
 
+def test_domain_approval_accepts_docs_only_opt_out_for_freeform_prose_trigger() -> None:
+    """A docs-only PR that only *mentions* an evidence concept may take the not-required branch.
+
+    Regression for #5031: PR #4967-style docs pages discuss terms like "benchmark interpretation" in
+    prose, tripping the free-form trigger. The template documents `Required for this PR: no - reason`
+    with `Status: not required`; that opt-out must be accepted when the trigger is a prose mention
+    rather than a filled Research Result Guidance declaration.
+    """
+    body = """## Summary
+Adds a single reference table for reward profiles to aid benchmark interpretation.
+
+## Domain-Aware Approval
+- Required for this PR: no - docs-only reference table, no evidence classification change
+- Domains reviewed: NA
+- Status: not required
+- Approver/review source or waiver: NA - docs-only
+"""
+    report = analyze_domain_approval(body, source="fixture")
+
+    assert report.status == "ok"
+    assert report.sensitive_terms == ("free-form evidence marker: benchmark interpretation",)
+
+
+def test_domain_approval_docs_only_opt_out_uses_default_template_values() -> None:
+    """The template's documented docs-only opt-out values pass when the trigger is prose-only."""
+    body = """## Summary
+Documentation-only update discussing paper-facing claim wording.
+
+## Domain-Aware Approval
+- Required for this PR: no - docs-only, no research claim
+- Domains reviewed: NA
+- Status: not required
+- Approver/review source or waiver:
+- Validity checklist:
+  - Target claim/hypothesis: NA
+  - Comparator or split/evidence validity: NA
+  - Fallback/degraded exclusions: NA
+  - Claim boundary: NA
+  - Implementation integrity vs experimental validity: NA
+"""
+    report = analyze_domain_approval(body, source="fixture")
+
+    assert report.status == "ok"
+
+
+def test_domain_approval_docs_only_opt_out_requires_not_required_status() -> None:
+    """A free-form trigger with a contradictory (pending) status is not waved through."""
+    body = """## Summary
+Adds notes on benchmark interpretation.
+
+## Domain-Aware Approval
+- Required for this PR: no - docs-only
+- Domains reviewed: NA
+- Status: pending
+- Approver/review source or waiver: waiting for reviewer
+"""
+    report = analyze_domain_approval(body, source="fixture")
+
+    assert report.status == "domain_approval_required"
+
+
+def test_domain_approval_structured_declaration_cannot_use_docs_only_opt_out() -> None:
+    """A filled Research Result Guidance declaration keeps the strict path even with prose mentions."""
+    body = _domain_body(
+        evidence_tier="targeted smoke",
+        result_classification="blocker-resolution",
+        domain_section="""## Domain-Aware Approval
+- Required for this PR: no - docs-only
+- Domains reviewed: NA
+- Status: not required
+- Approver/review source or waiver: NA
+""",
+    )
+    report = analyze_domain_approval(body, source="fixture")
+
+    assert report.status == "domain_approval_required"
+
+
 def test_domain_approval_required_value_does_not_treat_nominal_as_no() -> None:
     """Required explanations starting with nominal/narrowed stay in the required path."""
     report = analyze_domain_approval(


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** `analyze_domain_approval()` in `scripts/dev/check_pr_followups.py` now accepts the PR template's documented docs-only opt-out (`Required for this PR: no - reason` + `Status: not required`) when the *only* domain-approval triggers are weak free-form **prose mentions** of an evidence concept.
- **Why now:** Closes #5031. On `main`, a genuinely docs-only PR that merely *mentions* a term like "benchmark interpretation" or "diagnostic-only" in prose is forced into `domain_approval_required` and cannot select the "not required" branch the template offers. Reproduced concretely below.
- **Claim boundary:** Workflow/tooling change only. No benchmark metric semantics change; no evidence-producing claim.
- **Required validation:** `uv run pytest tests/dev/test_check_pr_followups.py` (53 passed) + `uv run ruff check/format`.
- **Remaining blocker:** none.

Closes #5031.

## Contract delta

- **Behavior change (loosening, backward-compatible):** A body whose domain-approval triggers are *all* free-form prose mentions may now opt out with `Required for this PR: no - <reason>` and `Status: not required`. Previously this returned `domain_approval_required`.
- **Preserved fail-closed guarantee:** A body with a filled Research Result Guidance declaration (a concrete `Evidence tier` / `Result classification`) is a strong self-declaration and stays on the strict path — the opt-out **cannot** wave it through. Existing test `test_domain_approval_rejects_not_required_for_sensitive_result` still asserts `domain_approval_required`.
- **Guards on the opt-out:** it applies only when (a) every trigger is a free-form prose mention, (b) `Required for this PR` explicitly opts out with a reason (a bare empty/unselected field does not qualify), and (c) `Status` selects not-required/waived/NA. A contradictory `Status: pending` is not waved through.
- **New helpers:** `_domain_required_opts_out`, `_domain_status_opts_out`, `_domain_triggers_are_freeform_only`, `_is_docs_only_domain_opt_out`, and `_domain_status_report` (the last a behavior-preserving extraction to keep `analyze_domain_approval` within the C901 complexity limit).
- **No new fail-closed blocker added.** No schema field added.

## Reproduction (on `main`)

```
docs-only PR mentioning "benchmark interpretation" in prose,
Required for this PR: no - docs-only ...; Status: not required
  -> main: domain_approval_required   (friction)
  -> this PR: ok
structured Evidence tier: targeted smoke / Result classification: blocker-resolution,
Required: no; Status: not required
  -> main and this PR: domain_approval_required   (preserved)
```

## Scope

- In scope: `scripts/dev/check_pr_followups.py` (behavior + refactor), `tests/dev/test_check_pr_followups.py` (regression tests), `.github/PULL_REQUEST_TEMPLATE/pr_default.md` (one-line clarification), `CHANGELOG.md`.
- Assumption recorded: the friction's "docs-only / negated evidence statement" is realized as a free-form **prose mention** trigger; structured declarations are excluded. Reproduced against issue #4967's docs-only shape.

## Validation

| Command | Result |
| --- | --- |
| `uv run pytest tests/dev/test_check_pr_followups.py -q` | 53 passed (49 existing + 4 new) |
| `uv run ruff check scripts/dev/check_pr_followups.py tests/dev/test_check_pr_followups.py` | All checks passed |
| `uv run ruff format --check ...` | already formatted |
| `uv run python scripts/tools/sync_ai_config.py --check` | AI config links validated: 7 symlinks |

## Out of scope / not done

- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- No change to benchmark metric semantics.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - workflow/tooling gate fix
- Comparator or baseline, if applicable: NA
- Evidence tier: NA - workflow guard only
- Result classification: NA - no research claim
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #5031 (status comment)

## Domain-Aware Approval

- Required for this PR: no - docs-only/support workflow fix, no evidence classification change
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: NA - support tooling; dogfoods the opt-out this PR adds

<details>
<summary>Governance appendix</summary>

- State propagation: a compact status comment will be posted to issue #5031 by the reviewer/gate lane (this worker's authorization excludes `comment_issue_or_pr`); low-churn issue, single surface.
- No transient queue-routing state is encoded in tracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
