### PR TITLE
Issue #3574: realized-distribution audit (configured vs. realized per-archetype) for heterogeneous population

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #3574 realized-distribution audit for heterogeneous-population traces.**
+  `robot_sf/benchmark/heterogeneous_population_metrics.py` gains `realized_distribution_audit` and
+  `summarize_distribution` (plus a `RealizedDistributionSpec`), covering DoD item 5: configured
+  target vs. realized per-step distributions (overall and per-archetype) from one control trace, so
+  the interaction/truncation shift the #3206 smoke could not compute is made explicit. A numeric
+  configured→realized mean shift is reported only when the caller declares the two sides comparable,
+  and missing or non-finite trace fields fail closed as blockers. Pure analysis only — no ablation
+  campaign, Slurm submission, or heterogeneity/realism claim. Tests in
+  `tests/benchmark/test_heterogeneous_population_distribution_audit.py`.
 * **issue #4871 CrowdNav_Prediction_AttnGraph external learned-baseline feasibility smoke.** New
   `robot_sf/planner/crowdnav_pred_attng.py` is the thinnest model-only adapter proving the shipped
   ICRA 2023 attention-graph SRNN checkpoint (`41200.pt`, MIT, pinned at upstream `3907731`) loads and

--- a/docs/context/issue_3574_heterogeneous_population_metrics.md
+++ b/docs/context/issue_3574_heterogeneous_population_metrics.md
@@ -24,6 +24,16 @@ not isolate heterogeneity from a population-mean shift and could not compute per
 - `mean_matched_heterogeneity_effect(homogeneous_mean, heterogeneous_mean,
   homogeneous_is_mean_matched)`: effect delta, flagged `isolated` only when the homogeneous arm uses
   the population mean (`theta_i = E[theta]`); otherwise `confounded_by_mean_shift`.
+- `realized_distribution_audit(control_trace, metric_specs)`: configured-target vs. realized
+  per-step distributions (overall and per-archetype) from one control trace, covering DoD item 5
+  ("log configured vs. realized speed/clearance/yielding distributions"). Each `RealizedDistributionSpec`
+  names a realized per-step field (e.g. `speed_m_s`) and an optional per-pedestrian configured label
+  (e.g. `desired_speed_factor`). The realized side reports the distribution the #3206 smoke could not
+  compute; the configured side is drawn one-per-pedestrian from trace labels. A numeric
+  configured→realized mean shift is reported only when the caller sets `configured_is_comparable`
+  (both sides same-unit), so a unitless factor vs. a metric observation is never reported as a real
+  shift. Missing or non-finite fields fail closed as blockers; `summarize_distribution` supplies the
+  `n/mean/std/min/max/p05/p50/p95` summary and rejects empty or non-finite samples.
 
 ## Per-Pedestrian Control Trace (`pedestrian-control-trace.v1`)
 
@@ -53,6 +63,9 @@ does not submit Slurm jobs, and does not claim heterogeneous-population effects.
 - `tests/benchmark/test_heterogeneous_population_metrics.py`: Conditional Value at Risk tail
   direction and alpha validation, plus per-archetype aggregation for higher- and lower-is-safer
   metrics.
+- `tests/benchmark/test_heterogeneous_population_distribution_audit.py`: realized-distribution audit
+  summaries, per-archetype breakdown, comparable-shift computation, and fail-closed handling of
+  missing realized/configured fields, empty traces, and duplicate spec names.
 - `tests/benchmark/test_pedestrian_control_trace.py`: emitted control-trace shape, archetype
   detection, and fail-closed non-finite or missing-archetype handling.
 - `tests/benchmark/test_map_runner_utils.py`: episode metadata integration for the map-runner trace

--- a/robot_sf/benchmark/heterogeneous_population_metrics.py
+++ b/robot_sf/benchmark/heterogeneous_population_metrics.py
@@ -11,10 +11,12 @@ heterogeneity effect can be claimed:
 2. **mean-matched heterogeneity-effect isolation** — comparing a heterogeneous population against a
    homogeneous one whose parameter is the population mean (``theta_i = E[theta]``), so the effect is
    separated from a mean shift.
+3. a **realized-distribution audit** — configured target vs. realized per-step distributions
+   (overall and per-archetype) from a control trace, so the interaction/truncation shift the smoke
+   could not see is made explicit (issue #3574 DoD item 5).
 
-The per-pedestrian control-trace logging that feeds the per-archetype harness, and the mean-matched
-paired ablation runs, are deferred; this module is pure and side-effect free, mirroring the accepted
-analysis layers in this run (#3484, #3558, #3557, #3573).
+The mean-matched paired ablation *runs* are deferred; this module is pure and side-effect free,
+mirroring the accepted analysis layers in this run (#3484, #3558, #3557, #3573).
 """
 
 from __future__ import annotations
@@ -413,14 +415,343 @@ def mean_matched_heterogeneity_effect(
     }
 
 
+_DISTRIBUTION_QUANTILES: tuple[float, ...] = (0.05, 0.5, 0.95)
+
+
+@dataclass(frozen=True, slots=True)
+class RealizedDistributionSpec:
+    """One realized-vs-configured distribution audit request for a control trace.
+
+    Attributes:
+        name: Stable audit key (e.g. ``speed``, ``clearance``).
+        realized_step_key: Per-step control-trace field holding the *realized* value
+            (e.g. ``speed_m_s``, ``clearance_m``); interaction and truncation shift it
+            away from the configured target.
+        configured_label_key: Optional per-pedestrian label field holding the *configured*
+            target (e.g. ``desired_speed_factor``). ``None`` audits the realized side only.
+        configured_is_comparable: When true, the configured target and the realized value
+            are on the same scale, so a numeric configured→realized shift is meaningful.
+            Left false by default because a target like ``desired_speed_factor`` (a unitless
+            multiplier) is not directly comparable to a realized ``speed_m_s`` observation.
+    """
+
+    name: str
+    realized_step_key: str
+    configured_label_key: str | None = None
+    configured_is_comparable: bool = False
+
+
+def summarize_distribution(name: str, values: Sequence[float]) -> dict[str, Any]:
+    """Summarize a non-empty finite sample with mean/std/min/max and 5/50/95 quantiles.
+
+    Fails closed on empty or non-finite input so a degraded trace cannot masquerade as a
+    populated distribution.
+
+    Returns:
+        dict[str, Any]: JSON-serializable distribution summary.
+    """
+
+    arr = require_finite_array(name, values)
+    if arr.size == 0:
+        raise ValueError(f"{name} must be non-empty")
+    quantiles = np.quantile(arr, _DISTRIBUTION_QUANTILES)
+    return {
+        "n": int(arr.size),
+        "mean": float(np.mean(arr)),
+        "std": float(np.std(arr)),
+        "min": float(np.min(arr)),
+        "max": float(np.max(arr)),
+        "p05": float(quantiles[0]),
+        "p50": float(quantiles[1]),
+        "p95": float(quantiles[2]),
+    }
+
+
+def _coerce_distribution_specs(
+    metric_specs: Sequence[RealizedDistributionSpec | Mapping[str, Any]],
+) -> list[RealizedDistributionSpec]:
+    if not isinstance(metric_specs, Sequence) or isinstance(metric_specs, str) or not metric_specs:
+        raise ValueError("metric_specs must be a non-empty sequence")
+    specs: list[RealizedDistributionSpec] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(metric_specs):
+        if isinstance(raw, RealizedDistributionSpec):
+            spec = raw
+        elif isinstance(raw, Mapping):
+            try:
+                spec = RealizedDistributionSpec(
+                    name=str(raw["name"]).strip(),
+                    realized_step_key=str(raw["realized_step_key"]).strip(),
+                    configured_label_key=(
+                        None
+                        if raw.get("configured_label_key") is None
+                        else str(raw["configured_label_key"]).strip()
+                    ),
+                    configured_is_comparable=bool(raw.get("configured_is_comparable", False)),
+                )
+            except KeyError as exc:
+                raise ValueError(f"metric_specs[{index}] missing key: {exc.args[0]}") from exc
+        else:
+            raise TypeError(f"metric_specs[{index}] must be RealizedDistributionSpec or mapping")
+        if not spec.name:
+            raise ValueError(f"metric_specs[{index}].name must be non-empty")
+        if not spec.realized_step_key:
+            raise ValueError(f"metric_specs[{index}].realized_step_key must be non-empty")
+        if spec.configured_label_key == "":
+            raise ValueError(
+                f"metric_specs[{index}].configured_label_key must be non-empty or None"
+            )
+        if spec.name in seen:
+            raise ValueError(f"metric_specs duplicate name {spec.name!r}")
+        seen.add(spec.name)
+        specs.append(spec)
+    return specs
+
+
+def _configured_pedestrian_value(
+    pedestrian: Mapping[str, Any],
+    pedestrian_index: int,
+    configured_label_key: str,
+) -> float:
+    """Return one finite configured target for a pedestrian, failing closed on gaps."""
+
+    if configured_label_key not in pedestrian:
+        raise ValueError(
+            f"control_trace.pedestrians[{pedestrian_index}] missing configured "
+            f"label {configured_label_key!r}"
+        )
+    raw = pedestrian[configured_label_key]
+    if raw is None:
+        raise ValueError(
+            f"control_trace.pedestrians[{pedestrian_index}].{configured_label_key} must not be null"
+        )
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"control_trace.pedestrians[{pedestrian_index}].{configured_label_key} must be numeric"
+        ) from exc
+    return require_finite_scalar(
+        f"control_trace.pedestrians[{pedestrian_index}].{configured_label_key}",
+        value,
+    )
+
+
+def _collect_distribution_side(
+    pedestrians: Sequence[Any],
+    extract: Any,
+) -> tuple[list[float], dict[str, list[float]], list[str]]:
+    """Collect one distribution side by applying ``extract`` per pedestrian.
+
+    ``extract(pedestrian, pedestrian_index)`` returns the finite sample values for that
+    pedestrian (a per-step list for the realized side, a one-element list for the
+    configured side) and raises ``ValueError``/``TypeError`` on a missing or degraded
+    field so the offending pedestrian becomes a fail-closed blocker.
+
+    Returns:
+        tuple: ``(overall, per_archetype, blockers)`` collected across pedestrians.
+    """
+
+    overall: list[float] = []
+    by_archetype: dict[str, list[float]] = {}
+    blockers: list[str] = []
+    for pedestrian_index, pedestrian in enumerate(pedestrians):
+        if not isinstance(pedestrian, Mapping):
+            blockers.append(f"control_trace.pedestrians[{pedestrian_index}] must be a mapping")
+            continue
+        try:
+            archetype: str | None = _control_trace_archetype(pedestrian, pedestrian_index)
+        except ValueError as exc:
+            blockers.append(str(exc))
+            archetype = None
+        try:
+            values = list(extract(pedestrian, pedestrian_index))
+        except (TypeError, ValueError) as exc:
+            blockers.append(str(exc))
+            continue
+        overall.extend(values)
+        if archetype is not None:
+            by_archetype.setdefault(archetype, []).extend(values)
+    return overall, by_archetype, blockers
+
+
+def _distribution_side(
+    *,
+    overall: list[float],
+    by_archetype: dict[str, list[float]],
+    blockers: list[str],
+    label: str,
+) -> dict[str, Any]:
+    """Build one (realized or configured) side of a distribution audit, failing closed.
+
+    Returns:
+        dict[str, Any]: Side payload with summaries when ready, or fail-closed blockers.
+    """
+
+    if blockers or not overall:
+        return {
+            "status": "blocked",
+            "ready": False,
+            "overall": None,
+            "per_archetype": {},
+            "blockers": list(blockers) if blockers else [f"{label} distribution is empty"],
+        }
+    return {
+        "status": "ready",
+        "ready": True,
+        "overall": summarize_distribution(f"{label}.overall", overall),
+        "per_archetype": {
+            archetype: summarize_distribution(f"{label}.{archetype}", by_archetype[archetype])
+            for archetype in sorted(by_archetype)
+        },
+        "blockers": [],
+    }
+
+
+def _audit_one_distribution_spec(
+    pedestrians: Sequence[Any],
+    spec: RealizedDistributionSpec,
+) -> dict[str, Any]:
+    realized_overall, realized_by_archetype, realized_blockers = _collect_distribution_side(
+        pedestrians,
+        lambda pedestrian, index: _control_trace_metric_values(
+            pedestrian, index, spec.realized_step_key
+        ).tolist(),
+    )
+    realized_side = _distribution_side(
+        overall=realized_overall,
+        by_archetype=realized_by_archetype,
+        blockers=realized_blockers,
+        label="realized",
+    )
+
+    configured_side: dict[str, Any] | None = None
+    configured_blockers: list[str] = []
+    if spec.configured_label_key is not None:
+        configured_key = spec.configured_label_key
+        configured_overall, configured_by_archetype, configured_blockers = (
+            _collect_distribution_side(
+                pedestrians,
+                lambda pedestrian, index: [
+                    _configured_pedestrian_value(pedestrian, index, configured_key)
+                ],
+            )
+        )
+        configured_side = _distribution_side(
+            overall=configured_overall,
+            by_archetype=configured_by_archetype,
+            blockers=configured_blockers,
+            label="configured",
+        )
+
+    shift = _configured_to_realized_shift(spec, realized_side, configured_side)
+    ready = realized_side["ready"] and (configured_side is None or configured_side["ready"])
+    combined_blockers = [*realized_blockers, *configured_blockers]
+
+    return {
+        "name": spec.name,
+        "realized_step_key": spec.realized_step_key,
+        "configured_label_key": spec.configured_label_key,
+        "configured_is_comparable": spec.configured_is_comparable,
+        "status": "ready" if ready else "blocked",
+        "ready": ready,
+        "realized": realized_side,
+        "configured": configured_side,
+        "configured_to_realized_shift": shift,
+        "blockers": combined_blockers,
+    }
+
+
+def _configured_to_realized_shift(
+    spec: RealizedDistributionSpec,
+    realized_side: Mapping[str, Any],
+    configured_side: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return the configured→realized mean shift, or a reason it is not computed.
+
+    The shift is only numeric when the caller declares the two sides comparable
+    (``configured_is_comparable``) and both sides are ready; otherwise a diagnostic
+    reason string is returned so a unit-mismatched or blocked comparison is never
+    silently reported as a real distribution shift.
+    """
+
+    if configured_side is None:
+        return None
+    if not spec.configured_is_comparable:
+        return {
+            "status": "not_computed",
+            "reason": "configured and realized values not declared comparable",
+        }
+    if not (realized_side["ready"] and configured_side["ready"]):
+        return {
+            "status": "not_computed",
+            "reason": "realized or configured distribution is blocked",
+        }
+
+    realized_archetypes = realized_side["per_archetype"]
+    configured_archetypes = configured_side["per_archetype"]
+    per_archetype = {
+        archetype: float(
+            realized_archetypes[archetype]["mean"] - configured_archetypes[archetype]["mean"]
+        )
+        for archetype in sorted(set(realized_archetypes) & set(configured_archetypes))
+    }
+    return {
+        "status": "computed",
+        "overall_mean_delta": float(
+            realized_side["overall"]["mean"] - configured_side["overall"]["mean"]
+        ),
+        "per_archetype_mean_delta": per_archetype,
+    }
+
+
+def realized_distribution_audit(
+    control_trace: Mapping[str, Any],
+    *,
+    metric_specs: Sequence[RealizedDistributionSpec | Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Audit configured target vs. realized per-step distributions from a control trace.
+
+    For each requested metric this reports the realized distribution (overall and
+    per-archetype) that the #3206 smoke could not compute, the configured target
+    distribution drawn from per-pedestrian trace labels, and — only when the caller
+    declares the two comparable — the configured→realized mean shift. Missing or
+    non-finite trace fields become fail-closed blockers rather than degraded evidence.
+
+    Returns:
+        dict[str, Any]: Versioned realized-distribution audit with per-metric readiness.
+    """
+
+    pedestrians = _control_trace_pedestrians(control_trace)
+    specs = _coerce_distribution_specs(metric_specs)
+    spec_reports = {spec.name: _audit_one_distribution_spec(pedestrians, spec) for spec in specs}
+    status = "ready" if all(report["ready"] for report in spec_reports.values()) else "blocked"
+    return {
+        "schema_version": HETEROGENEOUS_POPULATION_METRICS_SCHEMA,
+        "evidence_kind": "realized_distribution_audit",
+        "source": "pedestrian_control_trace",
+        "status": status,
+        "claim_boundary": (
+            "Summarizes configured vs. realized per-step distributions from a single "
+            "control trace; does not run an ablation campaign or establish a "
+            "heterogeneity or realism claim."
+        ),
+        "pedestrian_count": len(pedestrians),
+        "metrics": spec_reports,
+    }
+
+
 __all__ = [
     "HETEROGENEOUS_POPULATION_METRICS_SCHEMA",
     "ControlTraceReadiness",
     "PedestrianMetric",
+    "RealizedDistributionSpec",
     "assess_control_trace_readiness",
     "cvar",
     "mean_matched_heterogeneity_effect",
     "pedestrian_metric_observations_from_control_trace",
     "per_archetype_metrics",
     "per_archetype_metrics_from_control_trace",
+    "realized_distribution_audit",
+    "summarize_distribution",
 ]

--- a/tests/benchmark/test_heterogeneous_population_distribution_audit.py
+++ b/tests/benchmark/test_heterogeneous_population_distribution_audit.py
@@ -1,0 +1,213 @@
+"""Tests for the realized-distribution audit (issue #3574 DoD item 5).
+
+The audit summarizes configured target vs. realized per-step distributions from a
+per-pedestrian control trace, so the interaction/truncation shift the #3206 smoke
+could not compute is made explicit while failing closed on missing trace metadata.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from robot_sf.benchmark.heterogeneous_population_metrics import (
+    HETEROGENEOUS_POPULATION_METRICS_SCHEMA,
+    RealizedDistributionSpec,
+    realized_distribution_audit,
+    summarize_distribution,
+)
+
+
+def _pedestrian(
+    *,
+    simulator_index: int,
+    archetype: str,
+    speeds: list[float],
+    clearances: list[float],
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    steps = [
+        {"step": step, "speed_m_s": speed, "clearance_m": clearance}
+        for step, (speed, clearance) in enumerate(zip(speeds, clearances, strict=True))
+    ]
+    payload: dict[str, Any] = {
+        "id": f"pedestrian_{simulator_index}",
+        "simulator_index": simulator_index,
+        "archetype": archetype,
+        "steps": steps,
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def _control_trace() -> dict[str, Any]:
+    return {
+        "schema_version": "pedestrian-control-trace.v1",
+        "pedestrians": [
+            _pedestrian(
+                simulator_index=0,
+                archetype="cooperative",
+                speeds=[1.0, 1.0],
+                clearances=[2.0, 3.0],
+                extra={"desired_speed_factor": 1.0, "target_speed_m_s": 1.0},
+            ),
+            _pedestrian(
+                simulator_index=1,
+                archetype="cooperative",
+                speeds=[1.0, 1.0],
+                clearances=[1.0, 1.0],
+                extra={"desired_speed_factor": 1.0, "target_speed_m_s": 1.0},
+            ),
+            _pedestrian(
+                simulator_index=2,
+                archetype="rushed",
+                speeds=[2.0, 2.0],
+                clearances=[0.5, 0.5],
+                extra={"desired_speed_factor": 1.5, "target_speed_m_s": 2.5},
+            ),
+        ],
+    }
+
+
+def test_summarize_distribution_reports_expected_stats() -> None:
+    """The summary must report the sample size, mean, and median."""
+    summary = summarize_distribution("sample", [1.0, 2.0, 3.0, 4.0])
+    assert summary["n"] == 4
+    assert summary["mean"] == pytest.approx(2.5)
+    assert summary["p50"] == pytest.approx(2.5)
+    assert summary["min"] == pytest.approx(1.0)
+    assert summary["max"] == pytest.approx(4.0)
+
+
+@pytest.mark.parametrize("values", [[], [1.0, float("nan")], [float("inf")]])
+def test_summarize_distribution_fails_closed(values: list[float]) -> None:
+    """Empty or non-finite samples must fail closed rather than degrade."""
+    with pytest.raises(ValueError):
+        summarize_distribution("sample", values)
+
+
+def test_realized_audit_reports_per_archetype_distributions() -> None:
+    """A ready trace yields realized + configured distributions per archetype."""
+    audit = realized_distribution_audit(
+        _control_trace(),
+        metric_specs=[
+            RealizedDistributionSpec(
+                name="speed",
+                realized_step_key="speed_m_s",
+                configured_label_key="desired_speed_factor",
+            ),
+            RealizedDistributionSpec(name="clearance", realized_step_key="clearance_m"),
+        ],
+    )
+
+    assert audit["schema_version"] == HETEROGENEOUS_POPULATION_METRICS_SCHEMA
+    assert audit["evidence_kind"] == "realized_distribution_audit"
+    assert audit["status"] == "ready"
+    assert audit["pedestrian_count"] == 3
+
+    speed = audit["metrics"]["speed"]
+    assert speed["ready"] is True
+    assert speed["realized"]["overall"]["mean"] == pytest.approx(8.0 / 6.0)
+    assert speed["realized"]["per_archetype"]["cooperative"]["mean"] == pytest.approx(1.0)
+    assert speed["realized"]["per_archetype"]["rushed"]["mean"] == pytest.approx(2.0)
+    # Configured target distribution is drawn one-per-pedestrian from trace labels.
+    assert speed["configured"]["overall"]["n"] == 3
+    assert speed["configured"]["overall"]["mean"] == pytest.approx(3.5 / 3.0)
+    # desired_speed_factor is a unitless multiplier -> no numeric shift by default.
+    assert speed["configured_to_realized_shift"]["status"] == "not_computed"
+
+    clearance = audit["metrics"]["clearance"]
+    assert clearance["configured"] is None
+    assert clearance["configured_to_realized_shift"] is None
+    assert clearance["realized"]["per_archetype"]["rushed"]["mean"] == pytest.approx(0.5)
+
+
+def test_realized_audit_computes_shift_when_comparable() -> None:
+    """When the caller declares comparability, the mean shift is computed per archetype."""
+    audit = realized_distribution_audit(
+        _control_trace(),
+        metric_specs=[
+            RealizedDistributionSpec(
+                name="speed",
+                realized_step_key="speed_m_s",
+                configured_label_key="target_speed_m_s",
+                configured_is_comparable=True,
+            )
+        ],
+    )
+    shift = audit["metrics"]["speed"]["configured_to_realized_shift"]
+    assert shift["status"] == "computed"
+    # realized overall mean 1.3333 - configured overall mean 1.5.
+    assert shift["overall_mean_delta"] == pytest.approx(8.0 / 6.0 - 1.5)
+    assert shift["per_archetype_mean_delta"]["cooperative"] == pytest.approx(0.0)
+    assert shift["per_archetype_mean_delta"]["rushed"] == pytest.approx(-0.5)
+
+
+def test_realized_audit_blocks_on_missing_realized_field() -> None:
+    """A missing realized step field fails closed for that metric and the audit."""
+    audit = realized_distribution_audit(
+        _control_trace(),
+        metric_specs=[
+            RealizedDistributionSpec(name="force", realized_step_key="force_norm"),
+        ],
+    )
+    force = audit["metrics"]["force"]
+    assert audit["status"] == "blocked"
+    assert force["ready"] is False
+    assert force["realized"]["status"] == "blocked"
+    assert force["realized"]["overall"] is None
+    assert any("force_norm" in blocker for blocker in force["blockers"])
+
+
+def test_realized_audit_blocks_configured_but_keeps_realized_ready() -> None:
+    """A missing configured label blocks only the configured side; realized stays ready."""
+    trace = _control_trace()
+    del trace["pedestrians"][2]["desired_speed_factor"]
+    audit = realized_distribution_audit(
+        trace,
+        metric_specs=[
+            RealizedDistributionSpec(
+                name="speed",
+                realized_step_key="speed_m_s",
+                configured_label_key="desired_speed_factor",
+            )
+        ],
+    )
+    speed = audit["metrics"]["speed"]
+    assert audit["status"] == "blocked"
+    assert speed["ready"] is False
+    assert speed["realized"]["ready"] is True
+    assert speed["configured"]["ready"] is False
+    assert any("desired_speed_factor" in blocker for blocker in speed["configured"]["blockers"])
+
+
+def test_realized_audit_rejects_empty_pedestrians() -> None:
+    """A control trace with no pedestrians must fail closed."""
+    with pytest.raises(ValueError):
+        realized_distribution_audit(
+            {"pedestrians": []},
+            metric_specs=[RealizedDistributionSpec(name="speed", realized_step_key="speed_m_s")],
+        )
+
+
+def test_realized_audit_rejects_duplicate_spec_names() -> None:
+    """Duplicate metric names must fail closed to avoid silent overwrite."""
+    with pytest.raises(ValueError):
+        realized_distribution_audit(
+            _control_trace(),
+            metric_specs=[
+                RealizedDistributionSpec(name="speed", realized_step_key="speed_m_s"),
+                RealizedDistributionSpec(name="speed", realized_step_key="clearance_m"),
+            ],
+        )
+
+
+def test_realized_audit_accepts_mapping_specs() -> None:
+    """Specs may be plain mappings so callers can drive the audit from config."""
+    audit = realized_distribution_audit(
+        _control_trace(),
+        metric_specs=[{"name": "clearance", "realized_step_key": "clearance_m"}],
+    )
+    assert audit["metrics"]["clearance"]["ready"] is True


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds a **realized-distribution audit** to `heterogeneous_population_metrics.v1` — a new pure-analysis capability (`realized_distribution_audit`, `summarize_distribution`, `RealizedDistributionSpec`) that summarizes *configured target vs. realized per-step distributions* (overall and per-archetype) from one pedestrian control trace.
- **Why now:** Issue #3574 DoD item 5 ("log configured vs. realized speed/clearance/yielding distributions") was the last unbuilt analysis primitive. The #3206 smoke could not compute per-archetype realized distributions or see how interaction/truncation shift them away from the configured target; this makes that shift explicit.
- **Claim boundary:** `diagnostic-only` pure analysis. No ablation campaign, no Slurm/GPU submission, no heterogeneity or realism claim. A numeric configured→realized mean shift is emitted **only** when the caller declares the two sides comparable (same unit), so a unitless target (e.g. `desired_speed_factor`) vs. a metric observation (`speed_m_s`) is never reported as a real shift.
- **Required validation:** focused fixture tests below (all green); ruff check/format clean.
- **Remaining blocker:** the mean-matched paired ablation **runs** (θ_i = E[θ] vs θ_i ∼ p(θ)) and rank-reversal/bootstrap analysis still need a benchmark campaign — out of scope for a CPU analysis slice.

Issue link: https://github.com/ll7/robot_sf_ll7/issues/3574

## Contract delta

- **New public API** in `robot_sf/benchmark/heterogeneous_population_metrics.py`:
  - `realized_distribution_audit(control_trace, *, metric_specs)` → versioned audit (`evidence_kind="realized_distribution_audit"`) with per-metric `realized` / `configured` sides and an optional `configured_to_realized_shift`.
  - `summarize_distribution(name, values)` → `n/mean/std/min/max/p05/p50/p95`, fail-closed on empty or non-finite input.
  - `RealizedDistributionSpec(name, realized_step_key, configured_label_key=None, configured_is_comparable=False)`.
- **New fail-closed blockers:** missing/null/non-numeric/non-finite realized step field or configured label field, non-mapping pedestrians, empty pedestrians, and duplicate spec names each become blockers rather than degraded evidence. Realized and configured sides fail closed independently (a missing configured label does not hide a ready realized distribution).
- **Compatibility:** purely additive — reuses existing control-trace helpers; no signature or schema changes to existing functions; schema string `heterogeneous_population_metrics.v1` unchanged.

## Scope summary

- **In scope (delivered):** DoD item 5 realized-distribution audit as a pure analysis primitive, following the accepted analysis-layer pattern (#3484/#3558/#3557/#3573) already used across this issue.
- **New capability named:** realized-vs-configured per-archetype distribution audit (progression slice toward the issue's implementation plan).

## Validation

```
uv run pytest tests/benchmark/test_heterogeneous_population_distribution_audit.py \
  tests/benchmark/test_heterogeneous_population_metrics.py \
  tests/benchmark/test_heterogeneous_population_ablation.py \
  tests/benchmark/test_pedestrian_control_trace.py -q
# -> 86 passed

uv run ruff check robot_sf/benchmark/heterogeneous_population_metrics.py \
  tests/benchmark/test_heterogeneous_population_distribution_audit.py
# -> All checks passed!
```

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

Refs #3574 — DoD item 5 (realized-distribution audit) delivered as a pure analysis primitive. Remaining DoD items require benchmark campaign runs (mean-matched paired ablation runs, bootstrap P(A beats B), rank-reversal test), so the issue stays open.

<details>
<summary>Governance</summary>

- Research/evidence PR fields: target = DoD item 5 analysis primitive; comparator = configured target vs. realized trace distribution; evidence tier = `diagnostic-only`; result classification = tooling (no metric claim); decision/stop rule = fail-closed on missing trace metadata; synthesis target = `docs/context/issue_3574_heterogeneous_population_metrics.md` (updated).
- State propagation: PR body is the durable surface for this low-churn slice (no PRs merged for #3574 in the prior 24h); no new issue-state comment added to avoid a comment stream.
- Fragmentation guard: this is a progression slice adding a nameable new capability (realized-distribution audit), not a micro-guard; proceeds at full throttle per the exemption.
- Worked in isolated worktree `robot_sf_ll7.worktrees/issue-3574-realized-distribution-audit` off `origin/main`.

</details>
