### PR TITLE
fix: goal-planner late-evasive latency fail-closed instrumentation (#5000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* **issue #5000 goal-planner late-evasive latency instrumentation (fail-closed).** The
+  `late_evasive_predicate` (`robot_sf/benchmark/safety_predicates.py`, schema bumped
+  `safety_predicate.late_evasive.v1` → `.v2`) now emits a `latency_unavailable_reason` alongside
+  `response_latency_s`, so a `late_evasive=true` event is never a silent-empty latency. Root cause of
+  the reported 109/110 goal-planner anomaly: the goal planner almost never produces a
+  clearance-restoring deceleration after the hazard becomes visible, so `late_evasive` fires via the
+  no-action branch (`first_clearance_restoring_action_step is None`) while `response_latency_s` is
+  genuinely undefined — not a false positive and not a missing timestamp. The reason value is
+  `no_clearance_restoring_action` (dominant goal case) or `hazard_never_visible`, and `null` exactly
+  when latency is finite. The trace-surface `_late_evasive_reaction`
+  (`robot_sf/analysis_workbench/trace_failure_predicates.py`) gains a seconds-valued
+  `response_latency_s` companion to its `reaction_delay_steps`. The downstream
+  `scripts/analysis/issue_4904_latency_decel_profile.py` derivation now surfaces the reason tally
+  (`late_evasive_no_latency`, `dominant_latency_unavailable_reason`) instead of a silent gap. Claim
+  boundary: telemetry/analysis-surface correctness only — no benchmark metric semantics change, no
+  hybrid-/goal-planner effectiveness claim on the 0-latency data.
+
 ### Added
 
 * **issue #4871 CrowdNav_Prediction_AttnGraph external learned-baseline feasibility smoke.** New

--- a/docs/context/issue_3483_safety_predicate_producers.md
+++ b/docs/context/issue_3483_safety_predicate_producers.md
@@ -30,15 +30,21 @@ Diagnostic classification: `oscillation = (heading_rate_sign_changes ≥ T_h) an
 overridable, and the raw fields are always emitted so a different threshold can be applied
 downstream without recomputation.
 
-## Producer 2 — `safety_predicate.late_evasive.v1`
+## Producer 2 — `safety_predicate.late_evasive.v2`
 
 `late_evasive_predicate(hazard_distances, hazard_visible, speeds, *, dt, …)` emits
 `first_hazard_visible_step`, `conflict_zone_entry_step`,
 `first_clearance_restoring_action_step`, `minimum_distance_m`,
-`required_deceleration_m_s2`, `response_latency_s`, `n_steps`. The clearance-restoring
+`required_deceleration_m_s2`, `response_latency_s`, `latency_unavailable_reason`,
+`n_steps`. The clearance-restoring
 action is the first deceleration past `decel_threshold_m_s2` at/after the hazard becomes
 visible. Diagnostic classification: `late_evasive` when the hazard is visible and the
 reaction is absent, slower than `max_response_latency_s`, or only after conflict-zone entry.
+`v2` (issue #5000): when `response_latency_s` is `null`, `latency_unavailable_reason` names
+why — `no_clearance_restoring_action` (hazard was visible but the robot never decelerated hard
+enough, the dominant goal-planner case) or `hazard_never_visible`. A late-evasive event thus
+never emits a silent-empty latency; downstream consumers can distinguish "never reacted" from a
+data gap. It is `null` exactly when `response_latency_s` is finite.
 
 ## Producer 3 — `safety_predicate.occlusion_near_miss.v1`
 

--- a/robot_sf/analysis_workbench/trace_failure_predicates.py
+++ b/robot_sf/analysis_workbench/trace_failure_predicates.py
@@ -1658,6 +1658,11 @@ def _late_evasive_reaction(
                     "pressure_distance_m": pressure_distance_m,
                     "near_miss_threshold_m": near_miss_threshold_m,
                     "reaction_delay_steps": reaction_frame.step - pressure_frame.step,
+                    # Seconds-valued companion to reaction_delay_steps so this surface, like the
+                    # benchmark late_evasive_predicate, always carries a latency in seconds when a
+                    # reaction exists (issue #5000). Frames carry time_s, so this is finite here;
+                    # the "no reaction" case returns None above rather than a predicate.
+                    "response_latency_s": reaction_frame.time_s - pressure_frame.time_s,
                     "reaction_frame_index": reaction_index,
                     "angular_velocity": angular,
                     "linear_drop_mps": linear_drop,

--- a/robot_sf/benchmark/safety_predicates.py
+++ b/robot_sf/benchmark/safety_predicates.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 OSCILLATORY_PREDICATE_SCHEMA = "safety_predicate.oscillatory_control.v1"
-LATE_EVASIVE_PREDICATE_SCHEMA = "safety_predicate.late_evasive.v1"
+LATE_EVASIVE_PREDICATE_SCHEMA = "safety_predicate.late_evasive.v2"
 OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA = "safety_predicate.occlusion_near_miss.v1"
 
 
@@ -204,6 +204,17 @@ def late_evasive_predicate(
     if first_visible is not None and action_step is not None:
         response_latency_s = float((action_step - first_visible) * dt)
 
+    # Fail closed: a null response_latency_s must always carry a machine-readable reason so a
+    # late-evasive event is never a silent empty. The dominant goal-planner case is
+    # ``no_clearance_restoring_action`` — the robot never decelerated hard enough after the hazard
+    # became visible, so there is no reaction to time even though ``late_evasive`` fires. See #5000.
+    latency_unavailable_reason: str | None = None
+    if response_latency_s is None:
+        if first_visible is None:
+            latency_unavailable_reason = "hazard_never_visible"
+        else:
+            latency_unavailable_reason = "no_clearance_restoring_action"
+
     # Required deceleration to stop within the visible distance, at first visibility.
     required_deceleration_m_s2 = 0.0
     if first_visible is not None:
@@ -232,6 +243,7 @@ def late_evasive_predicate(
             "minimum_distance_m": minimum_distance,
             "required_deceleration_m_s2": required_deceleration_m_s2,
             "response_latency_s": response_latency_s,
+            "latency_unavailable_reason": latency_unavailable_reason,
             "n_steps": n,
         },
         "thresholds": {

--- a/scripts/analysis/issue_4904_latency_decel_profile.py
+++ b/scripts/analysis/issue_4904_latency_decel_profile.py
@@ -11,7 +11,7 @@ CPU-only, no simulation, no GPU, no campaign/Slurm.
 import csv
 import json
 import math
-from collections import defaultdict
+from collections import Counter, defaultdict
 from pathlib import Path
 
 import matplotlib
@@ -63,6 +63,9 @@ def extract_profiles(episodes: list[dict]) -> dict:
             "late_evasive_true": 0,
             "latency_populated": 0,
             "total_exposure": 0,
+            # Fail-closed reason tally for late_evasive=true episodes with no finite latency
+            # (issue #5000). A silent empty here previously hid the goal-planner anomaly.
+            "latency_unavailable_reasons": Counter(),
         }
     )
 
@@ -88,6 +91,11 @@ def extract_profiles(episodes: list[dict]) -> dict:
         if _is_finite_number(latency):
             prof["latency_populated"] += 1
             prof["latencies"].append(float(latency))
+        elif late_evasive:
+            # Fail closed: a late_evasive event with no finite latency must not be a silent gap.
+            # Record the producer-supplied reason; tag legacy records lacking one as "unspecified".
+            reason = fields.get("latency_unavailable_reason") or "unspecified"
+            prof["latency_unavailable_reasons"][str(reason)] += 1
 
         if _is_finite_number(decel):
             prof["decels"].append(float(decel))
@@ -144,6 +152,8 @@ def write_percentile_csv(profiles: dict, output_path: Path) -> None:
         "late_evasive_rate",
         "latency_populated_rate",
         "anomaly_gap",
+        "late_evasive_no_latency",
+        "dominant_latency_unavailable_reason",
     ]
     with open(output_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
@@ -155,6 +165,9 @@ def write_percentile_csv(profiles: dict, output_path: Path) -> None:
             total = prof["total_exposure"]
             le_rate = prof["late_evasive_true"] / total if total > 0 else 0
             lp_rate = prof["latency_populated"] / total if total > 0 else 0
+            reasons = prof["latency_unavailable_reasons"]
+            no_latency = sum(reasons.values())
+            dominant_reason = reasons.most_common(1)[0][0] if reasons else ""
             writer.writerow(
                 {
                     "planner": planner,
@@ -178,6 +191,8 @@ def write_percentile_csv(profiles: dict, output_path: Path) -> None:
                     "late_evasive_rate": round(le_rate, 4),
                     "latency_populated_rate": round(lp_rate, 4),
                     "anomaly_gap": round(le_rate - lp_rate, 4),
+                    "late_evasive_no_latency": no_latency,
+                    "dominant_latency_unavailable_reason": dominant_reason,
                 }
             )
 
@@ -255,8 +270,16 @@ def print_summary(profiles: dict) -> None:
         lat_pop = prof["latency_populated"]
         anomaly = le_true > 0 and lat_pop == 0
         if anomaly or planner == "goal":
+            reasons = prof["latency_unavailable_reasons"]
+            reason_str = (
+                ", ".join(f"{name}={count}" for name, count in sorted(reasons.items()))
+                if reasons
+                else "none"
+            )
             print(
-                f"  {planner}: exposure>0={total}, late_evasive_true={le_true}, latency_populated={lat_pop}, anomaly={anomaly}"
+                f"  {planner}: exposure>0={total}, late_evasive_true={le_true}, "
+                f"latency_populated={lat_pop}, anomaly={anomaly}; "
+                f"late_evasive_no_latency_reasons=[{reason_str}]"
             )
 
 

--- a/tests/benchmark/test_safety_predicates.py
+++ b/tests/benchmark/test_safety_predicates.py
@@ -122,7 +122,13 @@ _HAZARD_VISIBLE = np.array([False, True, True, True, True, True])
 
 
 def test_late_evasive_when_no_clearance_action_taken() -> None:
-    """Hazard visible but constant speed (no deceleration) ⇒ late evasive."""
+    """Hazard visible but constant speed (no deceleration) ⇒ late evasive.
+
+    This is the dominant goal-planner pattern (issue #5000): the robot never decelerates hard
+    enough after the hazard becomes visible, so ``late_evasive`` fires via the no-action branch
+    while ``response_latency_s`` is genuinely undefined. The event must never be a silent empty —
+    it carries an explicit ``latency_unavailable_reason`` instead.
+    """
     result = late_evasive_predicate(_HAZARD_DISTANCES, _HAZARD_VISIBLE, np.ones(6), dt=_DT)
 
     assert result["late_evasive"] is True
@@ -130,6 +136,9 @@ def test_late_evasive_when_no_clearance_action_taken() -> None:
     assert fields["first_hazard_visible_step"] == 1
     assert fields["first_clearance_restoring_action_step"] is None
     assert fields["minimum_distance_m"] == pytest.approx(0.5)
+    # Fail closed: null latency for a late_evasive event must carry a machine-readable reason.
+    assert fields["response_latency_s"] is None
+    assert fields["latency_unavailable_reason"] == "no_clearance_restoring_action"
 
 
 def test_prompt_deceleration_is_not_late() -> None:
@@ -140,6 +149,29 @@ def test_prompt_deceleration_is_not_late() -> None:
     assert result["late_evasive"] is False
     assert result["fields"]["first_clearance_restoring_action_step"] == 2
     assert result["fields"]["response_latency_s"] == pytest.approx(0.1)
+    # A finite latency implies no unavailability reason.
+    assert result["fields"]["latency_unavailable_reason"] is None
+
+
+def test_latency_unavailable_reason_is_null_when_latency_finite() -> None:
+    """A late-but-finite reaction still populates latency and leaves the reason null (#5000)."""
+    speeds = np.array([1.0, 1.0, 0.5, 0.2, 0.1, 0.0])
+    result = late_evasive_predicate(
+        _HAZARD_DISTANCES, _HAZARD_VISIBLE, speeds, dt=_DT, max_response_latency_s=0.05
+    )
+
+    assert result["late_evasive"] is True
+    assert result["fields"]["response_latency_s"] == pytest.approx(0.1)
+    assert result["fields"]["latency_unavailable_reason"] is None
+
+
+def test_latency_reason_when_hazard_never_visible() -> None:
+    """No visible hazard: not late-evasive, but the null latency is still explained (#5000)."""
+    result = late_evasive_predicate(_HAZARD_DISTANCES, np.zeros(6, dtype=bool), np.ones(6), dt=_DT)
+
+    assert result["late_evasive"] is False
+    assert result["fields"]["response_latency_s"] is None
+    assert result["fields"]["latency_unavailable_reason"] == "hazard_never_visible"
 
 
 def test_latency_threshold_can_flag_a_borderline_reaction() -> None:

--- a/tests/test_issue_4904_latency_decel_profile.py
+++ b/tests/test_issue_4904_latency_decel_profile.py
@@ -122,6 +122,44 @@ class TestExtractProfiles:
         assert p["late_evasive_true"] == 5
         assert p["latency_populated"] == 0
         assert len(p["latencies"]) == 0
+        # Fail closed (issue #5000): late_evasive events with no finite latency are tallied by
+        # reason. Legacy records without a producer reason fall back to "unspecified".
+        assert sum(p["latency_unavailable_reasons"].values()) == 5
+        assert p["latency_unavailable_reasons"]["unspecified"] == 5
+
+    def test_latency_unavailable_reason_is_surfaced(self):
+        episodes = [
+            _make_episode(
+                "goal",
+                exposure_steps=10,
+                late_evasive=True,
+                response_latency_s=None,
+                required_deceleration_m_s2=0.001,
+                seed=i,
+            )
+            for i in range(3)
+        ]
+        for ep in episodes:
+            ep["safety_predicates"]["late_evasive_predicate"]["fields"][
+                "latency_unavailable_reason"
+            ] = "no_clearance_restoring_action"
+        profiles = extract_profiles(episodes)
+        reasons = profiles["goal"]["latency_unavailable_reasons"]
+        assert reasons["no_clearance_restoring_action"] == 3
+        assert "unspecified" not in reasons
+
+    def test_finite_latency_records_no_reason(self):
+        episodes = [
+            _make_episode(
+                "p",
+                exposure_steps=10,
+                late_evasive=True,
+                response_latency_s=2.0,
+                required_deceleration_m_s2=0.5,
+            )
+        ]
+        profiles = extract_profiles(episodes)
+        assert sum(profiles["p"]["latency_unavailable_reasons"].values()) == 0
 
     def test_filters_non_finite_values(self):
         # json.loads silently accepts NaN/Infinity tokens; they must be treated as
@@ -228,6 +266,12 @@ class TestWritePercentileCsv:
         assert goal["late_evasive_rate"] == "1.0"
         assert goal["latency_populated_rate"] == "0.0"
         assert goal["anomaly_gap"] == "1.0"  # 1.0 - 0.0
+        # Fail-closed columns (issue #5000): the silent 0-latency gap is now machine-readable.
+        assert goal["late_evasive_no_latency"] == "10"
+        assert goal["dominant_latency_unavailable_reason"] == "unspecified"
+        # alpha's single late_evasive event carried a finite latency, so nothing is unexplained.
+        assert by_planner["alpha"]["late_evasive_no_latency"] == "0"
+        assert by_planner["alpha"]["dominant_latency_unavailable_reason"] == ""
 
         alpha = by_planner["alpha"]
         assert alpha["exposure_episodes"] == "2"

--- a/tests/validation/test_trace_failure_predicates.py
+++ b/tests/validation/test_trace_failure_predicates.py
@@ -176,6 +176,9 @@ def test_event_and_action_predicates_cover_remaining_contract_ids() -> None:
     predicates = {row["predicate_id"]: row for row in payload["predicates"]}
     assert predicates["late_evasive_reaction"]["validity_status"] == "valid"
     assert predicates["late_evasive_reaction"]["evidence_fields"]["reaction_delay_steps"] == 1
+    # Seconds-valued companion to reaction_delay_steps (issue #5000): frames carry time_s, so a
+    # reacted late-evasive event always exposes a latency in seconds, not only a step count.
+    assert predicates["late_evasive_reaction"]["evidence_fields"]["response_latency_s"] == 1.0
     assert predicates["bottleneck_deadlock"]["validity_status"] == "valid"
     assert predicates["bottleneck_deadlock"]["evidence_fields"]["event"] == "bottleneck_deadlock"
 


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** A `late_evasive=true` event can no longer emit a silent-empty
  `response_latency_s`. The `late_evasive_predicate` now also emits a machine-readable
  `latency_unavailable_reason`; the trace-surface predicate gains a seconds-valued latency; the
  downstream profile surfaces the reason tally.
- **Why now:** Retained-trace profiling (#4916) reported the goal planner flags `late_evasive` in
  109/110 exposure episodes but populates latency in 0 — a telemetry-validity defect blocking any
  latency-based reading of the goal planner. Freeze-safe (analysis surface, not metric semantics).
- **Root cause (documented):** Not a false positive and not a missing timestamp. The goal planner
  almost never produces a clearance-restoring deceleration (`≥ decel_threshold_m_s2`) after the
  hazard becomes visible, so `late_evasive` fires via the **no-action branch**
  (`first_clearance_restoring_action_step is None`). `response_latency_s` is only defined when an
  action step exists, so it is genuinely undefined for those episodes — there was no reaction to
  time. The defect was that this undefined value was a *silent* empty with no reason.
- **Claim boundary:** telemetry/analysis-surface correctness only. No benchmark metric semantics
  change. No hybrid-/goal-planner effectiveness claim is made on the current 0-latency data.
- **Required validation:** `uv run pytest tests/benchmark/test_safety_predicates.py tests/validation/test_trace_failure_predicates.py tests/test_issue_4904_latency_decel_profile.py` → **70 passed**.
- **Remaining blocker:** none for the instrumentation fix. Re-running the trace-capable campaign to
  repopulate episode JSONL with the `.v2` fields is a compute-only follow-up (out of scope here).

## Contract delta

- **New schema field:** `late_evasive_predicate.fields.latency_unavailable_reason`
  (`"no_clearance_restoring_action" | "hazard_never_visible" | null`). `null` **iff**
  `response_latency_s` is finite. Schema version bumped `safety_predicate.late_evasive.v1` → `.v2`.
- **New evidence field:** `_late_evasive_reaction` (trace surface) now emits `response_latency_s`
  (seconds) alongside `reaction_delay_steps`.
- **New profile columns:** `late_evasive_no_latency`, `dominant_latency_unavailable_reason` in
  `issue_4904_latency_decel_percentiles.csv`; the anomaly summary prints the per-reason breakdown.
- **Compatibility:** additive. Existing consumers read `fields` via `.get(...)` and are unaffected;
  the profile tags legacy records lacking a reason as `"unspecified"` rather than dropping them.

## Scope

Issue: #5000. In scope: the three producing/consuming surfaces above + regression coverage across
each + producer doc (`docs/context/issue_3483_safety_predicate_producers.md`) + CHANGELOG.

**Out of scope (explicit):** no full benchmark campaign run, no Slurm/GPU submission, no
paper/dissertation claim edits.

## Validation

```
uv run pytest tests/benchmark/test_safety_predicates.py \
  tests/validation/test_trace_failure_predicates.py \
  tests/test_issue_4904_latency_decel_profile.py -q
# -> 70 passed
uv run ruff check <changed files>   # All checks passed!
uv run ruff format --check <changed files>   # already formatted
uv run pytest tests/benchmark/test_event_ledger.py tests/benchmark/test_map_runner_safety_predicates.py -q
# -> 18 passed (adjacent late_evasive consumers unaffected)
```

## Acceptance criteria

- [x] Root cause documented (no-action branch; genuinely-undefined latency, not a false positive or
  missing timestamp).
- [x] Every `late_evasive=true` event emits a finite latency **or** an explicit unavailability reason.
- [x] New goal-planner regression tests pass (`test_late_evasive_when_no_clearance_action_taken` +
  `test_latency_unavailable_reason_*`; profile reason-surfacing tests).
- [x] No hybrid-/goal-planner effectiveness claim made on the 0-latency data.

Closes #5000

<details>
<summary>Governance / provenance</summary>

- Target claim/hypothesis: telemetry validity defect (late_evasive latency emptiness). Evidence tier:
  code correctness + regression tests (not benchmark evidence). Result: fixed at the instrumentation
  contract; the historical episode JSONL still carries `.v1` records until a re-run.
- Assumption recorded in code comments: the dominant goal-planner emptiness cause is
  `no_clearance_restoring_action`; the profile fallback `"unspecified"` covers pre-`.v2` records.
- State propagation: low-churn issue (no prior PRs in 24h) — this PR body is the single canonical
  surface; no separate issue-state comment added (comment authorization is off for this lane).
- Fragmentation guard: this is a progression slice adding a nameable capability (fail-closed
  latency-availability reason across producer + trace + profile), not a micro-guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
