### PR TITLE
test(replay-figure): make E2E fixture text I/O explicitly UTF-8 (#5058)

### DIFF
--- a/tests/benchmark/test_episode_replay_figure.py
+++ b/tests/benchmark/test_episode_replay_figure.py
@@ -411,7 +411,7 @@ class TestProvenanceSidecar:
         write_provenance_sidecar(out_path, sidecar)
 
         assert out_path.exists()
-        with open(out_path) as f:
+        with open(out_path, encoding="utf-8") as f:
             data = json.load(f)
         assert data["episode_id"] == "ep_001"
         assert data["seed"] == 42
@@ -420,7 +420,7 @@ class TestProvenanceSidecar:
     def test_compute_file_sha256(self, tmp_path):
         """Test file SHA-256 computation."""
         test_file = tmp_path / "test.txt"
-        test_file.write_text("hello world")
+        test_file.write_text("hello world", encoding="utf-8")
         sha = compute_file_sha256(test_file)
         assert len(sha) == 64
         assert isinstance(sha, str)
@@ -616,7 +616,9 @@ class TestCLI:
         from scripts.replay_episode_figure import main as cli_main
 
         episodes_file = tmp_path / "episodes.jsonl"
-        episodes_file.write_text('{"episode_id": "ep1", "scenario_id": "s", "seed": 1}\n')
+        episodes_file.write_text(
+            '{"episode_id": "ep1", "scenario_id": "s", "seed": 1}\n', encoding="utf-8"
+        )
 
         ret = cli_main(
             [
@@ -769,7 +771,7 @@ class TestCLI:
         episodes_jsonl = tmp_path / "episodes.jsonl"
         import json
 
-        with open(episodes_jsonl, "w") as f:
+        with open(episodes_jsonl, "w", encoding="utf-8") as f:
             json.dump(episode_data, f)
             f.write("\n")
 
@@ -808,7 +810,7 @@ class TestCLI:
         provenance_path = output_dir / "replay_provenance.json"
         assert provenance_path.exists(), "Provenance sidecar should be generated"
 
-        with open(provenance_path) as f:
+        with open(provenance_path, encoding="utf-8") as f:
             provenance = json.load(f)
 
         # Required provenance fields per issue acceptance criteria
@@ -847,7 +849,7 @@ class TestCLI:
         caption_path = output_dir / "caption_fragment.tex"
         assert caption_path.exists(), "Caption fragment should be generated"
 
-        with open(caption_path) as f:
+        with open(caption_path, encoding="utf-8") as f:
             caption_content = f.read()
         assert len(caption_content) > 0, "Caption fragment should not be empty"
         assert "e2e_test_ep" in caption_content or "crossing_scenario" in caption_content
@@ -895,7 +897,7 @@ class TestCLI:
         }
 
         episodes_jsonl = tmp_path / "episodes.jsonl"
-        with open(episodes_jsonl, "w") as f:
+        with open(episodes_jsonl, "w", encoding="utf-8") as f:
             json.dump(episode_data, f)
             f.write("\n")
 
@@ -925,9 +927,9 @@ class TestCLI:
             for name in figure_names:
                 assert (out_dir / name).exists(), f"run {run_idx}: {name} should exist"
 
-            with open(out_dir / "replay_provenance.json") as f:
+            with open(out_dir / "replay_provenance.json", encoding="utf-8") as f:
                 provenances.append(json.load(f))
-            captions.append((out_dir / "caption_fragment.tex").read_text())
+            captions.append((out_dir / "caption_fragment.tex").read_text(encoding="utf-8"))
 
         # --- Invariant 1: deterministic figure output (byte-identity via content hash) ---
         run1_fig_hashes = {
@@ -1002,7 +1004,7 @@ class TestResimulation:
         matrix_path = tmp_path / "scenarios.yaml"
         import yaml
 
-        with open(matrix_path, "w") as f:
+        with open(matrix_path, "w", encoding="utf-8") as f:
             yaml.dump(scenarios, f)
         return matrix_path
 
@@ -1030,7 +1032,7 @@ class TestResimulation:
                 "n_agents": 0,
             }
         ]
-        with open(matrix_path, "w") as f:
+        with open(matrix_path, "w", encoding="utf-8") as f:
             yaml.dump(scenarios, f)
 
         scenario = _resolve_scenario_from_matrix("test_scenario", matrix_path)
@@ -1141,7 +1143,7 @@ class TestResimulation:
         episodes_jsonl = tmp_path / "episodes.jsonl"
         import json
 
-        with open(episodes_jsonl, "w") as f:
+        with open(episodes_jsonl, "w", encoding="utf-8") as f:
             json.dump(row_dict, f)
             f.write("\n")
 
@@ -1161,7 +1163,7 @@ class TestResimulation:
         assert Path(result["provenance_sidecar"]).exists()
 
         # Check that provenance shows resimulation occurred
-        with open(result["provenance_sidecar"]) as f:
+        with open(result["provenance_sidecar"], encoding="utf-8") as f:
             provenance = json.load(f)
         assert provenance["resimulated"] is True
         assert provenance["scenario_id"] == "test_scenario"
@@ -1187,7 +1189,7 @@ class TestResimulation:
         matrix_path = tmp_path / "scenarios.yaml"
         import yaml
 
-        with open(matrix_path, "w") as f:
+        with open(matrix_path, "w", encoding="utf-8") as f:
             yaml.dump(scenarios, f)
 
         # Create episode row with expected final position after the finite 100-step replay horizon.
@@ -1202,7 +1204,7 @@ class TestResimulation:
         episodes_jsonl = tmp_path / "episodes.jsonl"
         import json
 
-        with open(episodes_jsonl, "w") as f:
+        with open(episodes_jsonl, "w", encoding="utf-8") as f:
             json.dump(row_dict, f)
             f.write("\n")
 
@@ -1237,7 +1239,7 @@ class TestResimulation:
         episodes_jsonl = tmp_path / "episodes.jsonl"
         import json
 
-        with open(episodes_jsonl, "w") as f:
+        with open(episodes_jsonl, "w", encoding="utf-8") as f:
             json.dump(row_dict, f)
             f.write("\n")
 
@@ -1263,7 +1265,7 @@ class TestResimulation:
         matrix_path = tmp_path / "scenarios.yaml"
         import yaml
 
-        with open(matrix_path, "w") as f:
+        with open(matrix_path, "w", encoding="utf-8") as f:
             yaml.dump(scenarios, f)
 
         # Create episode row for non-existent scenario
@@ -1277,7 +1279,7 @@ class TestResimulation:
         episodes_jsonl = tmp_path / "episodes.jsonl"
         import json
 
-        with open(episodes_jsonl, "w") as f:
+        with open(episodes_jsonl, "w", encoding="utf-8") as f:
             json.dump(row_dict, f)
             f.write("\n")
 


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** every platform-default text I/O call in
  `tests/benchmark/test_episode_replay_figure.py` now passes `encoding="utf-8"`
  (17 sites: `open()` read/write, `read_text()`, `write_text()`).
- **Why now:** PR #5043 merged before the gate's validated phase-2 patch could
  reach its deleted head branch, so the new replay-figure E2E test still relied
  on the host's default text encoding when writing `episodes.jsonl` and reading
  `replay_provenance.json` / `caption_fragment.tex` (two MEDIUM Gemini review
  threads on #5043).
- **Claim boundary:** test-only change; no runtime, benchmark, metric, schema,
  or model-provenance behavior is touched. `smoke evidence` — targeted + full
  file test run and Ruff clean.
- **Required validation:** see below (acceptance test passes, Ruff check/format
  clean, full file 54 passed).
- **Remaining blocker:** none.

## Scope

Resolves issue #5058: make the E2E fixture text I/O explicitly UTF-8 so the
suite does not depend on the host's default text encoding.

The issue's "Required fix" named three sites (the referenced commit
`91608e195` for the `determinism_and_caption_completeness` test). Per the
COMPLETE-FIRST maintainer directive I realized the issue's title-level ask in
full: the same mechanical `encoding="utf-8"` change is applied to **every**
platform-default text I/O site in the file, not just those three, so the whole
suite is encoding-independent. This is bounded, low-risk (test file only), and
removes the entire class of latent bug the issue describes.

## Contract delta

None. No new schema fields, no new fail-closed blockers, no compatibility
impact. Byte-identical fixture contents (ASCII JSON/YAML/tex) — `utf-8` is a
superset of the previous ASCII-safe default, so figure/provenance/caption
outputs are unchanged.

## Validation

Run from an isolated worktree off `origin/main` (`75e554ff0`), reusing the main
checkout venv via `scripts/dev/run_worktree_shared_venv.sh`:

```
$ uv run pytest tests/benchmark/test_episode_replay_figure.py \
    -k "determinism_and_caption_completeness" -q
1 passed, 53 deselected in 3.16s

$ uv run pytest tests/benchmark/test_episode_replay_figure.py -q
54 passed in 7.96s

$ uv run ruff check tests/benchmark/test_episode_replay_figure.py
All checks passed!

$ uv run ruff format --check tests/benchmark/test_episode_replay_figure.py
1 file already formatted
```

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

Closes #5058

<details>
<summary>Governance / propagation</summary>

- **State propagation:** low-churn issue (0 prior PRs). No durable state surface
  needs updating beyond this PR; `comment_issue_or_pr` is not authorized for
  this worker, so no issue comment is posted.
- **Fragmentation guard:** first PR for #5058; a progression slice delivering the
  actual fix (the named new capability), not a micro-guard.
- **Freshness:** re-checked `gh issue view 5058 --comments` immediately before
  opening — 0 comments, no maintainer guidance newer than session start, no
  existing PR covering the scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized test fixture file handling to use explicit UTF-8 encoding.
  * Improved consistency across episode, scenario, provenance, caption, and CLI test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->