### PR TITLE
fix(orchestration): disjoint modulo scopes for concurrent PR gates (#5059)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regression coverage lives in `tests/dev/test_gh_list_truncation_remaining.py` and
   `tests/tools/test_project_priority_score_truncation.py`. Tooling/evidence-integrity only — no
   benchmark, metric, or paper-facing claim.
+* **issue #5059 disjoint modulo scopes for concurrent PR gates.** New
+  `scripts/tools/pr_gate_scopes.py` gives the autonomous PR-gate orchestrator a canonical,
+  immutable dispatch contract: an active gate owns a *residue class* (`pr % modulus == residue`)
+  rather than an ad-hoc PR range, so a gate told to "process newly appearing PRs" can never drift
+  into another gate's PRs on a re-list pass. `validate_active_gates()` is the fail-closed regression
+  check — it rejects any non-residue (range) scope as non-immutable and reports any pair of live
+  gates that could own the same PR (with the smallest crossing PR as a witness); residue
+  disjointness is decided exactly by the CRT criterion `(r_a - r_b) % gcd(N_a, N_b) != 0`. Includes a
+  CLI (`python -m scripts.tools.pr_gate_scopes --gates gates.json`) for checking a live gate manifest
+  before admitting a second gate, and a docs note at
+  `docs/dev/agents/pr_gate_scope_contract.md`. Pure arithmetic over gate descriptors — no GitHub
+  calls, no benchmark/metric semantics. Tests in `tests/tools/test_pr_gate_scopes.py`.
 * **issue #3574 realized-distribution audit for heterogeneous-population traces.**
   `robot_sf/benchmark/heterogeneous_population_metrics.py` gains `realized_distribution_audit` and
   `summarize_distribution` (plus a `RealizedDistributionSpec`), covering DoD item 5: configured

--- a/docs/dev/agents/pr_gate_scope_contract.md
+++ b/docs/dev/agents/pr_gate_scope_contract.md
@@ -1,0 +1,52 @@
+# PR Gate Scope Contract (Disjoint Modulo Scopes)
+
+_Issue #5059._ The autonomous PR-gate orchestrator can run more than one **gate** at a time — each
+gate is a worker prompt that shepherds a set of pull requests. This note defines the dispatch
+contract that keeps two concurrent gates from ever owning the same PR, and points at the checker that
+enforces it.
+
+## The hazard
+
+When a gate claims PRs by an ad-hoc **range** ("gate A owns #5044/#5037", "gate B owns #5047–#5057")
+the ranges can look disjoint in one snapshot yet **cross** on a later re-list pass. A gate whose
+prompt tells it to "process newly appearing PRs" has, in effect, an *open-ended* range: on its final
+re-list it will happily pick up a number that a newer gate already owns. Two gates shepherding the
+same PR is a double-dispatch bug (duplicate reviews, racing pushes, conflicting merges).
+
+## The contract
+
+An **active gate owns a residue class**: it claims PR `n` iff `n % modulus == residue`.
+
+- **Immutable.** A residue class does not depend on which PR numbers currently exist, so a gate can
+  re-list as often as it likes and never reach into another gate's residue.
+- **Disjoint by construction.** Two residue classes `(N_a, r_a)` and `(N_b, r_b)` share a PR iff the
+  Chinese Remainder Theorem solvability condition holds: `(r_a - r_b) % gcd(N_a, N_b) == 0`. The
+  simplest safe cohort is a shared modulus `N` with distinct residues (e.g. two gates split even/odd
+  PRs under `modulus = 2`).
+- **Second gate rule.** Before admitting a second gate, either give it a residue class disjoint from
+  every active gate, **or** revoke/rewrite the old gate first. Never leave a legacy range scope
+  active alongside a new gate.
+
+## The checker
+
+`scripts/tools/pr_gate_scopes.py` is the canonical implementation and the fail-closed regression
+check:
+
+```bash
+# Manifest: a JSON list of {gate_id, scope}. Residue scope: {"modulus": N, "residue": r}.
+python -m scripts.tools.pr_gate_scopes --gates gates.json
+```
+
+`validate_active_gates(gates)`:
+
+1. rejects any non-residue (range) scope as **non-immutable** (`non_residue_scope` violation), and
+2. reports any pair of live gates that could own the same PR (`overlap` violation, with the smallest
+   crossing PR as a witness).
+
+Exit codes: `0` disjoint & conforming, `1` violation found, `2` malformed manifest / IO error. Pass
+`--allow-range-scopes` only to diagnose a legacy cohort mid-migration (overlap is still checked);
+`--json` emits the schema-tagged report.
+
+The module is pure arithmetic over gate descriptors — no GitHub calls, no state mutation — so it is
+safe to call inline in a dispatcher or run as a pre-admission gate. Tests:
+`tests/tools/test_pr_gate_scopes.py` (includes the exact issue #5059 scenario).

--- a/scripts/tools/pr_gate_scopes.py
+++ b/scripts/tools/pr_gate_scopes.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Disjoint modulo scopes for concurrent PR gates (issue #5059).
+
+Background
+----------
+The autonomous PR-gate orchestrator can run more than one *gate* at a time. Each
+gate is a worker prompt that claims a set of pull requests to shepherd. When
+gates claim PRs by an ad-hoc *range* (for example "gate A owns #5044/#5037" and
+"gate B owns #5047-#5057"), the ranges can look disjoint in one snapshot yet
+*cross* on a later re-list pass: a gate told to "process newly appearing PRs"
+will happily pick up a number that a newer gate already owns. Two gates
+shepherding the same PR is a double-dispatch bug.
+
+The dispatch contract this module enforces is simple and immutable: an active
+gate owns a **residue class** ``pr_number % modulus == residue``. Residue classes
+are stable regardless of which PRs currently exist, so a gate can re-list as
+often as it likes and never reach into another gate's residue. Two residue
+classes are disjoint iff no integer satisfies both congruences; that is decided
+exactly by the classic CRT criterion ``(r_a - r_b) % gcd(N_a, N_b) != 0``.
+
+What this module provides
+-------------------------
+* :class:`ResidueScope` - the canonical, immutable gate scope.
+* :class:`RangeScope` - the legacy non-modulo scope, modelled only so the checker
+  can *reject* it (and, for an open-ended range, prove it must eventually cross
+  any residue scope).
+* :func:`validate_active_gates` - the fail-closed regression check: it refuses a
+  gate cohort in which any two live gates could own the same PR, and (by default)
+  refuses any non-residue scope because such a scope is not immutable.
+* A small CLI (``python -m scripts.tools.pr_gate_scopes --gates gates.json``) so
+  the orchestrator can run the check against a live gate manifest before it
+  admits a second gate.
+
+Nothing here mutates state or talks to GitHub; it is pure arithmetic over gate
+descriptors so it is cheap to unit-test and safe to call inline in a dispatcher.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from math import gcd
+from pathlib import Path
+from typing import Any, Union
+
+REPORT_SCHEMA = "pr_gate_scope_disjointness_report.v1"
+
+
+class GateScopeError(ValueError):
+    """A gate scope descriptor is malformed or violates the dispatch contract."""
+
+
+@dataclass(frozen=True)
+class ResidueScope:
+    """Canonical immutable gate scope: owns ``pr`` iff ``pr % modulus == residue``.
+
+    A residue class does not depend on which PR numbers currently exist, so a
+    gate bound to one cannot drift into another gate's PRs on a re-list pass.
+    """
+
+    modulus: int
+    residue: int
+
+    def __post_init__(self) -> None:
+        """Validate that modulus and residue form a well-formed residue class."""
+        if not isinstance(self.modulus, int) or isinstance(self.modulus, bool):
+            raise GateScopeError(f"modulus must be an int, got {self.modulus!r}")
+        if not isinstance(self.residue, int) or isinstance(self.residue, bool):
+            raise GateScopeError(f"residue must be an int, got {self.residue!r}")
+        if self.modulus < 1:
+            raise GateScopeError(f"modulus must be >= 1, got {self.modulus}")
+        if not 0 <= self.residue < self.modulus:
+            raise GateScopeError(
+                f"residue {self.residue} out of range for modulus {self.modulus} "
+                f"(expected 0 <= residue < {self.modulus})"
+            )
+
+    def owns(self, pr_number: int) -> bool:
+        """Return whether this residue class claims ``pr_number``."""
+        return pr_number % self.modulus == self.residue
+
+    def describe(self) -> str:
+        """Human-readable one-line rendering of the scope predicate."""
+        return f"pr % {self.modulus} == {self.residue}"
+
+
+@dataclass(frozen=True)
+class RangeScope:
+    """Legacy non-modulo scope: owns ``pr`` iff ``low <= pr <= high``.
+
+    ``high is None`` models an *open-ended* range - a gate told to keep picking
+    up newly appearing PRs. Range scopes are not immutable (their membership
+    depends on which numbers exist) and are rejected by the contract; they are
+    modelled here only so the checker can explain why and produce a crossing
+    witness.
+    """
+
+    low: int
+    high: Union[int, None] = None
+
+    def __post_init__(self) -> None:
+        """Validate that ``low``/``high`` are ints (or ``None``) and ordered."""
+        for name, value in (("low", self.low), ("high", self.high)):
+            if value is None:
+                continue
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise GateScopeError(f"{name} must be an int or null, got {value!r}")
+        if self.high is not None and self.high < self.low:
+            raise GateScopeError(f"high {self.high} must be >= low {self.low}")
+
+    def owns(self, pr_number: int) -> bool:
+        """Return whether ``pr_number`` falls inside the (possibly open) range."""
+        if pr_number < self.low:
+            return False
+        return self.high is None or pr_number <= self.high
+
+    @property
+    def open_ended(self) -> bool:
+        """Whether the range has no upper bound (claims all future PRs)."""
+        return self.high is None
+
+    def describe(self) -> str:
+        """Human-readable one-line rendering of the scope predicate."""
+        hi = "inf" if self.high is None else str(self.high)
+        return f"{self.low} <= pr <= {hi}"
+
+
+Scope = Union[ResidueScope, RangeScope]
+
+
+@dataclass(frozen=True)
+class Gate:
+    """An active PR gate: an identifier plus the scope of PRs it shepherds."""
+
+    gate_id: str
+    scope: Scope
+
+    def describe(self) -> str:
+        """Human-readable ``gate <id> [<scope>]`` rendering for messages."""
+        return f"gate {self.gate_id} [{self.scope.describe()}]"
+
+
+@dataclass
+class Violation:
+    """A single contract breach found by :func:`validate_active_gates`."""
+
+    kind: str  # "non_residue_scope" | "overlap"
+    gate_ids: list[str]
+    message: str
+    witness_pr: Union[int, None] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise the violation to a plain JSON-friendly dict."""
+        return {
+            "kind": self.kind,
+            "gate_ids": list(self.gate_ids),
+            "message": self.message,
+            "witness_pr": self.witness_pr,
+        }
+
+
+@dataclass
+class DisjointnessReport:
+    """Result of validating an active gate cohort."""
+
+    ok: bool
+    gate_count: int
+    violations: list[Violation] = field(default_factory=list)
+    schema: str = REPORT_SCHEMA
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise the report (and its violations) to a plain dict."""
+        return {
+            "schema": self.schema,
+            "ok": self.ok,
+            "gate_count": self.gate_count,
+            "violations": [v.to_dict() for v in self.violations],
+        }
+
+
+def residue_scopes_disjoint(a: ResidueScope, b: ResidueScope) -> bool:
+    """Return ``True`` iff no integer belongs to both residue classes.
+
+    Two congruences ``x == r_a (mod N_a)`` and ``x == r_b (mod N_b)`` have a
+    common solution iff ``(r_a - r_b)`` is divisible by ``gcd(N_a, N_b)`` (the
+    Chinese Remainder Theorem solvability condition). They are therefore disjoint
+    iff that divisibility fails.
+    """
+
+    return (a.residue - b.residue) % gcd(a.modulus, b.modulus) != 0
+
+
+def _shared_residue_witness(a: ResidueScope, b: ResidueScope) -> Union[int, None]:
+    """Smallest non-negative PR number owned by both residue classes, if any."""
+
+    if residue_scopes_disjoint(a, b):
+        return None
+    lcm = a.modulus // gcd(a.modulus, b.modulus) * b.modulus
+    for candidate in range(lcm):
+        if a.owns(candidate) and b.owns(candidate):
+            return candidate
+    return None  # pragma: no cover - unreachable when a solution exists
+
+
+def _range_residue_witness(rng: RangeScope, res: ResidueScope) -> Union[int, None]:
+    """Smallest PR number owned by both a range and a residue class, if any.
+
+    For an open-ended range this always exists (a residue class is unbounded), so
+    an open range provably crosses every residue scope - which is exactly the
+    re-list hazard from issue #5059.
+    """
+
+    start = rng.low
+    first = start + ((res.residue - start) % res.modulus)
+    if rng.high is not None and first > rng.high:
+        return None
+    return first
+
+
+def _range_ranges_witness(a: RangeScope, b: RangeScope) -> Union[int, None]:
+    low = max(a.low, b.low)
+    highs = [h for h in (a.high, b.high) if h is not None]
+    high = min(highs) if highs else None
+    if high is None or low <= high:
+        return low
+    return None
+
+
+def _scopes_overlap_witness(a: Scope, b: Scope) -> Union[int, None]:
+    """Smallest PR number owned by both scopes, or ``None`` if disjoint."""
+
+    if isinstance(a, ResidueScope) and isinstance(b, ResidueScope):
+        return _shared_residue_witness(a, b)
+    if isinstance(a, RangeScope) and isinstance(b, ResidueScope):
+        return _range_residue_witness(a, b)
+    if isinstance(a, ResidueScope) and isinstance(b, RangeScope):
+        return _range_residue_witness(b, a)
+    if isinstance(a, RangeScope) and isinstance(b, RangeScope):
+        return _range_ranges_witness(a, b)
+    raise GateScopeError(f"unsupported scope types: {type(a)!r}, {type(b)!r}")
+
+
+def validate_active_gates(gates: list[Gate], *, require_residue: bool = True) -> DisjointnessReport:
+    """Fail-closed regression check for a concurrent gate cohort.
+
+    Two rules, both required by issue #5059:
+
+    1. **Immutable residue scopes.** With ``require_residue=True`` (default) every
+       active gate must use a :class:`ResidueScope`. A :class:`RangeScope` is not
+       immutable - its membership shifts as PRs appear - so it is reported as a
+       ``non_residue_scope`` violation and must be converted to a residue class
+       (or the gate revoked) before another gate is admitted.
+    2. **Pairwise disjoint.** No two active gates may own the same PR. Any pair
+       that shares a PR number is reported as an ``overlap`` violation with the
+       smallest crossing PR as a witness.
+
+    The returned report's ``ok`` is ``True`` only when no violation is found.
+    """
+
+    seen_ids: set[str] = set()
+    for gate in gates:
+        if gate.gate_id in seen_ids:
+            raise GateScopeError(f"duplicate gate_id {gate.gate_id!r} in cohort")
+        seen_ids.add(gate.gate_id)
+
+    violations: list[Violation] = []
+
+    if require_residue:
+        for gate in gates:
+            if not isinstance(gate.scope, ResidueScope):
+                reason = (
+                    "open-ended range crosses every residue scope on re-list"
+                    if isinstance(gate.scope, RangeScope) and gate.scope.open_ended
+                    else "non-modulo scope is not immutable and can drift on re-list"
+                )
+                violations.append(
+                    Violation(
+                        kind="non_residue_scope",
+                        gate_ids=[gate.gate_id],
+                        message=(
+                            f"{gate.describe()} is not a residue scope: {reason}. "
+                            f"Convert to `pr % N == residue` or revoke the gate."
+                        ),
+                    )
+                )
+
+    for i in range(len(gates)):
+        for j in range(i + 1, len(gates)):
+            g_a, g_b = gates[i], gates[j]
+            witness = _scopes_overlap_witness(g_a.scope, g_b.scope)
+            if witness is not None:
+                violations.append(
+                    Violation(
+                        kind="overlap",
+                        gate_ids=[g_a.gate_id, g_b.gate_id],
+                        message=(
+                            f"{g_a.describe()} and {g_b.describe()} can both own "
+                            f"PR #{witness}; active gate scopes must be disjoint."
+                        ),
+                        witness_pr=witness,
+                    )
+                )
+
+    return DisjointnessReport(ok=not violations, gate_count=len(gates), violations=violations)
+
+
+def _scope_from_dict(data: dict[str, Any]) -> Scope:
+    if "modulus" in data or "residue" in data:
+        try:
+            return ResidueScope(modulus=int(data["modulus"]), residue=int(data["residue"]))
+        except KeyError as exc:
+            raise GateScopeError(
+                f"residue scope requires 'modulus' and 'residue': {data!r}"
+            ) from exc
+    if "low" in data or "high" in data or "range" in data:
+        if "range" in data:
+            rng = data["range"]
+            low, high = rng[0], (rng[1] if len(rng) > 1 else None)
+        else:
+            low, high = data.get("low"), data.get("high")
+        if low is None:
+            raise GateScopeError(f"range scope requires 'low': {data!r}")
+        return RangeScope(low=int(low), high=None if high is None else int(high))
+    raise GateScopeError(
+        f"scope must declare a residue (modulus/residue) or range (low/high): {data!r}"
+    )
+
+
+def load_gates(payload: Any) -> list[Gate]:
+    """Build :class:`Gate` objects from a decoded manifest.
+
+    Accepts either a list of gate objects or an object with a ``gates`` list.
+    Each gate object needs ``gate_id`` (or ``id``) and a ``scope`` object.
+    """
+
+    if isinstance(payload, dict) and "gates" in payload:
+        entries = payload["gates"]
+    else:
+        entries = payload
+    if not isinstance(entries, list):
+        raise GateScopeError("gate manifest must be a list or have a 'gates' list")
+
+    gates: list[Gate] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise GateScopeError(f"gate entry must be an object, got {entry!r}")
+        gate_id = entry.get("gate_id", entry.get("id"))
+        if gate_id is None:
+            raise GateScopeError(f"gate entry requires 'gate_id': {entry!r}")
+        scope_data = entry.get("scope")
+        if not isinstance(scope_data, dict):
+            raise GateScopeError(f"gate {gate_id!r} requires a 'scope' object")
+        gates.append(Gate(gate_id=str(gate_id), scope=_scope_from_dict(scope_data)))
+    return gates
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    """Construct the CLI argument parser for the disjointness checker."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail-closed check that concurrent PR gates own disjoint, immutable "
+            "residue scopes (issue #5059)."
+        )
+    )
+    parser.add_argument(
+        "--gates",
+        type=Path,
+        required=True,
+        help="Path to a JSON gate manifest (list of {gate_id, scope}).",
+    )
+    parser.add_argument(
+        "--allow-range-scopes",
+        action="store_true",
+        help=(
+            "Do not reject non-residue (range) scopes. Overlap is still checked. "
+            "Use only for diagnosing a legacy cohort mid-migration."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the report as JSON on stdout.",
+    )
+    return parser
+
+
+def main(argv: Union[list[str], None] = None) -> int:
+    """Validate a gate manifest file; exit 0 (ok), 1 (violation), or 2 (error)."""
+    args = build_argparser().parse_args(argv)
+    try:
+        payload = json.loads(args.gates.read_text(encoding="utf-8"))
+        gates = load_gates(payload)
+        report = validate_active_gates(gates, require_residue=not args.allow_range_scopes)
+    except (GateScopeError, json.JSONDecodeError, OSError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+    elif report.ok:
+        print(f"OK: {report.gate_count} active gate(s) own disjoint residue scopes.")
+    else:
+        print(
+            f"FAIL: {len(report.violations)} violation(s) across "
+            f"{report.gate_count} active gate(s):",
+            file=sys.stderr,
+        )
+        for violation in report.violations:
+            print(f"  - [{violation.kind}] {violation.message}", file=sys.stderr)
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/pr_gate_scopes.py
+++ b/scripts/tools/pr_gate_scopes.py
@@ -309,7 +309,7 @@ def validate_active_gates(gates: list[Gate], *, require_residue: bool = True) ->
 def _scope_from_dict(data: dict[str, Any]) -> Scope:
     if "modulus" in data or "residue" in data:
         try:
-            return ResidueScope(modulus=int(data["modulus"]), residue=int(data["residue"]))
+            return ResidueScope(modulus=data["modulus"], residue=data["residue"])
         except KeyError as exc:
             raise GateScopeError(
                 f"residue scope requires 'modulus' and 'residue': {data!r}"
@@ -322,7 +322,7 @@ def _scope_from_dict(data: dict[str, Any]) -> Scope:
             low, high = data.get("low"), data.get("high")
         if low is None:
             raise GateScopeError(f"range scope requires 'low': {data!r}")
-        return RangeScope(low=int(low), high=None if high is None else int(high))
+        return RangeScope(low=low, high=high)
     raise GateScopeError(
         f"scope must declare a residue (modulus/residue) or range (low/high): {data!r}"
     )

--- a/tests/tools/test_pr_gate_scopes.py
+++ b/tests/tools/test_pr_gate_scopes.py
@@ -194,6 +194,12 @@ def test_load_gates_requires_scope():
         load_gates([{"gate_id": "a"}])
 
 
+def test_load_gates_rejects_boolean_scope_values():
+    """Boolean JSON values must not normalize into a valid residue scope."""
+    with pytest.raises(GateScopeError):
+        load_gates([{"gate_id": "a", "scope": {"modulus": True, "residue": False}}])
+
+
 def test_cli_passes_on_disjoint_residue_manifest(tmp_path, capsys):
     """CLI exits 0 on a disjoint residue-scope manifest."""
     manifest = tmp_path / "gates.json"

--- a/tests/tools/test_pr_gate_scopes.py
+++ b/tests/tools/test_pr_gate_scopes.py
@@ -1,0 +1,250 @@
+"""Tests for the disjoint-modulo PR-gate scope contract (issue #5059).
+
+The headline regression is the issue's own scenario: an older gate holding an
+open-ended range scope can cross into a newer gate's range on a re-list pass.
+The contract must (a) reject the non-immutable range scopes and (b) certify the
+residue-class fix as disjoint.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.tools.pr_gate_scopes import (
+    Gate,
+    GateScopeError,
+    RangeScope,
+    ResidueScope,
+    load_gates,
+    main,
+    residue_scopes_disjoint,
+    validate_active_gates,
+)
+
+# --- ResidueScope construction / ownership ---------------------------------
+
+
+def test_residue_scope_owns_by_modulo():
+    """A residue scope claims exactly the PR numbers matching its residue."""
+    even = ResidueScope(modulus=2, residue=0)
+    assert even.owns(5044) and even.owns(5058)
+    assert not even.owns(5057)
+
+
+@pytest.mark.parametrize(
+    "modulus, residue",
+    [(0, 0), (-2, 0), (2, 2), (2, -1), (3, 3)],
+)
+def test_residue_scope_rejects_bad_params(modulus, residue):
+    """Out-of-range or non-positive modulus/residue values are rejected."""
+    with pytest.raises(GateScopeError):
+        ResidueScope(modulus=modulus, residue=residue)
+
+
+def test_residue_scope_rejects_bool_params():
+    """bool is an int subclass; guard against True/False sneaking in as modulus."""
+    with pytest.raises(GateScopeError):
+        ResidueScope(modulus=True, residue=0)
+
+
+def test_residue_scope_is_immutable():
+    """Frozen dataclass: the scope cannot be mutated after construction."""
+    scope = ResidueScope(modulus=2, residue=1)
+    with pytest.raises(Exception):
+        scope.modulus = 4  # type: ignore[misc]
+
+
+# --- residue disjointness arithmetic ---------------------------------------
+
+
+def test_same_modulus_distinct_residues_disjoint():
+    """Distinct residues under a shared modulus never share a PR."""
+    assert residue_scopes_disjoint(ResidueScope(2, 0), ResidueScope(2, 1))
+
+
+def test_same_modulus_same_residue_overlaps():
+    """Identical residue classes are not disjoint."""
+    assert not residue_scopes_disjoint(ResidueScope(2, 0), ResidueScope(2, 0))
+
+
+def test_coprime_moduli_always_overlap():
+    """2 and 3 are coprime => CRT guarantees a common solution for any residues."""
+    assert not residue_scopes_disjoint(ResidueScope(2, 0), ResidueScope(3, 1))
+
+
+def test_shared_factor_disjoint_when_residues_incompatible():
+    """Shared factor, incompatible residues (gcd rule fails) => disjoint.
+
+    mod 4 residue 0 (0,4,8,...) vs mod 6 residue 3 (3,9,15,...): gcd=2,
+    (0-3) % 2 == 1 != 0 => disjoint.
+    """
+    assert residue_scopes_disjoint(ResidueScope(4, 0), ResidueScope(6, 3))
+
+
+def test_shared_factor_overlap_when_residues_compatible():
+    """Shared factor, compatible residues => overlap.
+
+    mod 4 residue 2 (2,6,10,...) vs mod 6 residue 0 (0,6,12,...): both hit 6.
+    """
+    a, b = ResidueScope(4, 2), ResidueScope(6, 0)
+    assert not residue_scopes_disjoint(a, b)
+
+
+# --- the issue #5059 scenario ----------------------------------------------
+
+
+def test_issue_5059_open_ended_range_gates_rejected_and_crossing():
+    """Reproduce the hazard: an older open-ended gate + a newer bounded gate.
+
+    Gate 999997 processes newly appearing PRs (open-ended range from #5037);
+    gate 999996 owns #5047-#5057. They look disjoint in a snapshot but the open
+    range crosses into the newer gate's range.
+    """
+    gates = [
+        Gate("999997", RangeScope(low=5037, high=None)),
+        Gate("999996", RangeScope(low=5047, high=5057)),
+    ]
+    report = validate_active_gates(gates)
+    assert report.ok is False
+    kinds = {v.kind for v in report.violations}
+    # Both non-residue scopes are flagged, and the open range overlaps the newer one.
+    assert "non_residue_scope" in kinds
+    overlaps = [v for v in report.violations if v.kind == "overlap"]
+    assert overlaps, "open-ended range must be caught crossing the newer gate"
+    assert overlaps[0].witness_pr == 5047
+
+
+def test_issue_5059_residue_fix_is_disjoint_and_passes():
+    """The fix: express both gates as residue classes under a shared modulus."""
+    gates = [
+        Gate("999997", ResidueScope(modulus=2, residue=0)),  # even PRs
+        Gate("999996", ResidueScope(modulus=2, residue=1)),  # odd PRs
+    ]
+    report = validate_active_gates(gates)
+    assert report.ok is True
+    assert report.violations == []
+    # And they genuinely never share a PR across the disputed range.
+    even, odd = gates[0].scope, gates[1].scope
+    for pr in range(5037, 5058):
+        assert not (even.owns(pr) and odd.owns(pr))
+
+
+def test_two_residue_gates_same_residue_overlap_reported_with_witness():
+    """Two gates on the same residue class report an overlap with a witness PR."""
+    gates = [
+        Gate("a", ResidueScope(3, 1)),
+        Gate("b", ResidueScope(3, 1)),
+    ]
+    report = validate_active_gates(gates)
+    assert not report.ok
+    overlap = next(v for v in report.violations if v.kind == "overlap")
+    assert overlap.witness_pr == 1
+    assert set(overlap.gate_ids) == {"a", "b"}
+
+
+def test_disjoint_range_gates_pass_when_ranges_allowed():
+    """With require_residue=False, non-overlapping range gates are accepted."""
+    gates = [
+        Gate("a", RangeScope(low=5000, high=5010)),
+        Gate("b", RangeScope(low=5011, high=5020)),
+    ]
+    report = validate_active_gates(gates, require_residue=False)
+    assert report.ok
+
+
+def test_overlapping_range_gates_fail_even_when_ranges_allowed():
+    """Overlap is checked even when range scopes are permitted."""
+    gates = [
+        Gate("a", RangeScope(low=5000, high=5010)),
+        Gate("b", RangeScope(low=5010, high=5020)),
+    ]
+    report = validate_active_gates(gates, require_residue=False)
+    assert not report.ok
+    assert report.violations[0].witness_pr == 5010
+
+
+def test_duplicate_gate_id_rejected():
+    """A cohort with a repeated gate_id is rejected outright."""
+    with pytest.raises(GateScopeError):
+        validate_active_gates([Gate("x", ResidueScope(2, 0)), Gate("x", ResidueScope(2, 1))])
+
+
+# --- manifest loading + CLI ------------------------------------------------
+
+
+def test_load_gates_residue_and_range():
+    """Manifest loader builds residue and range scopes and accepts 'id' alias."""
+    payload = {
+        "gates": [
+            {"gate_id": "999996", "scope": {"modulus": 2, "residue": 1}},
+            {"id": "999997", "scope": {"range": [5037]}},
+        ]
+    }
+    gates = load_gates(payload)
+    assert isinstance(gates[0].scope, ResidueScope)
+    assert isinstance(gates[1].scope, RangeScope)
+    assert gates[1].scope.open_ended
+
+
+def test_load_gates_requires_scope():
+    """A gate entry with no scope object is rejected."""
+    with pytest.raises(GateScopeError):
+        load_gates([{"gate_id": "a"}])
+
+
+def test_cli_passes_on_disjoint_residue_manifest(tmp_path, capsys):
+    """CLI exits 0 on a disjoint residue-scope manifest."""
+    manifest = tmp_path / "gates.json"
+    manifest.write_text(
+        json.dumps(
+            [
+                {"gate_id": "999997", "scope": {"modulus": 2, "residue": 0}},
+                {"gate_id": "999996", "scope": {"modulus": 2, "residue": 1}},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    rc = main(["--gates", str(manifest)])
+    assert rc == 0
+    assert "disjoint residue scopes" in capsys.readouterr().out
+
+
+def test_cli_fails_on_crossing_range_manifest(tmp_path, capsys):
+    """CLI exits 1 and explains the violation on the issue #5059 range manifest."""
+    manifest = tmp_path / "gates.json"
+    manifest.write_text(
+        json.dumps(
+            [
+                {"gate_id": "999997", "scope": {"low": 5037}},
+                {"gate_id": "999996", "scope": {"low": 5047, "high": 5057}},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    rc = main(["--gates", str(manifest)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "non_residue_scope" in err or "overlap" in err
+
+
+def test_cli_json_output(tmp_path, capsys):
+    """CLI --json emits the schema-tagged report on stdout."""
+    manifest = tmp_path / "gates.json"
+    manifest.write_text(
+        json.dumps([{"gate_id": "a", "scope": {"modulus": 1, "residue": 0}}]),
+        encoding="utf-8",
+    )
+    rc = main(["--gates", str(manifest), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == "pr_gate_scope_disjointness_report.v1"
+    assert payload["ok"] is True
+
+
+def test_cli_missing_file_fails_closed(tmp_path, capsys):
+    """CLI exits 2 (error) when the manifest file is missing."""
+    rc = main(["--gates", str(tmp_path / "nope.json")])
+    assert rc == 2
+    assert "ERROR" in capsys.readouterr().err


### PR DESCRIPTION
## Reviewer-critical summary

This PR adds a fail-closed, immutable modulo-scope contract for concurrent PR gates. It is pure orchestration arithmetic; it makes no simulation, benchmark, metric, schema, or GitHub-state claim.

## What changed

- Adds `scripts/tools/pr_gate_scopes.py` with immutable `ResidueScope`, legacy `RangeScope` diagnostics, exact CRT overlap detection, and `validate_active_gates()`.
- Adds the `python -m scripts.tools.pr_gate_scopes --gates gates.json` checker (0=valid, 1=contract violation, 2=malformed manifest).
- Adds contract documentation, CHANGELOG entry, and regression tests including the original open-ended-range double-dispatch scenario and boolean-manifest rejection.

## Scope and closure

Refs #5059.

This PR provides the requested enforceable contract and pre-admission checker. Applying residue scopes to the live private-ops gate prompts remains an operational action tracked by #5059; therefore this PR does not close that issue.

## Validation

- `uv run pytest tests/tools/test_pr_gate_scopes.py -q` — 26 passed.
- `uv run ruff check scripts/tools/pr_gate_scopes.py tests/tools/test_pr_gate_scopes.py` — passed.
- `uv run ruff format --check scripts/tools/pr_gate_scopes.py tests/tools/test_pr_gate_scopes.py` — passed.

The checker rejects the issue’s legacy open-ended/range-scope scenario and accepts the disjoint even/odd modulo fix. No generated artifacts or benchmark evidence are involved.

## Downstream propagation

Parent #5059 will receive the merged-contract evidence and its remaining live-adoption action. Other propagation is NA: no benchmark, metric, registry, or paper-facing surface changed.
