### PR TITLE
test(benchmark): verify hybrid arbitration activation + classify 0/1165 telemetry (#5001)

### DIFF
--- a/docs/context/issue_5001_state.yaml
+++ b/docs/context/issue_5001_state.yaml
@@ -1,0 +1,106 @@
+# Canonical durable state surface for issue #5001.
+#
+# Purpose: classify the retained-trace result of "0 command_source_changes across
+# 1,165 episodes" (from issue #4914) as genuine non-activation vs telemetry failure,
+# and record the deterministic activation evidence delivered by this slice.
+#
+# Scope discipline: this file tracks durable issue state only. It does not encode
+# transient ready-queue routing, target hosts, packet lineage pointers, campaign
+# launch state, benchmark results, or paper/dissertation claims.
+issue: 5001
+state_surface: hybrid_arbitration_activation_telemetry
+entries:
+  - recorded_at_utc: "2026-07-10T12:59:18Z"
+    host: auxme-imech036
+    lane: implementation_cpu_only
+    base_commit: "81a8cc1f1"
+    status: telemetry_gap_classified__deterministic_activation_proven__runner_wiring_deferred
+    classification: telemetry_failure
+    classification_summary: >-
+      The retained-trace "0 command_source_changes across 1,165 episodes" is a
+      TELEMETRY WIRING GAP, not genuine non-activation. The hybrid arbitration
+      mechanism is reachable and, when its per-step source labels are threaded into
+      the predicate, produces a nonzero command_source_changes count. The episode
+      runner never supplies the required per-step signal, so the field result is
+      structurally forced to 0 for every episode.
+    evidence:
+      - claim: "Hybrid arbitration activates and changes its selected source across regimes."
+        evidence: >-
+          robot_sf/planner/hybrid_portfolio.py:88-120,176-200 selects a planner head
+          per step (`_desired_head` -> `_switch_head` -> `_record_decision`) and stores
+          the per-step `selected_head`. The new test
+          tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py drives the
+          real arbitration through open-cruise -> emergency -> caution regimes and
+          observes 3 head handoffs (risk_dwa -> orca -> prediction -> risk_dwa).
+      - claim: "The mechanism yields a nonzero count when the telemetry is wired."
+        evidence: >-
+          Feeding the captured per-step source sequence into
+          robot_sf/benchmark/safety_predicates.py::oscillatory_control_predicate
+          (via the optional `command_sources` argument) reports
+          command_source_changes == 3.
+      - claim: "The episode runner never supplies command_sources, forcing 0."
+        evidence: >-
+          robot_sf/benchmark/map_runner_episode.py:597 calls
+          `oscillatory_control_predicate(positions, headings, speeds, dt=dt)` with no
+          `command_sources`. When that optional signal is absent,
+          safety_predicates.py:98-100 hard-wires command_source_changes to 0 for every
+          episode regardless of real handoffs. The per-step `selected_source` is read
+          into the planner decision trace at map_runner_episode.py:1974 but is never
+          collected into a list and passed to the predicate.
+      - claim: "hybrid_portfolio uses `selected_head`; hybrid_rule_local uses `selected_source`."
+        evidence: >-
+          robot_sf/planner/hybrid_portfolio.py:153-161 records `selected_head`, while
+          robot_sf/planner/hybrid_rule_local_planner.py:2741 records `selected_source`.
+          Both are affected identically by the missing runner wiring.
+    claim_boundary: >-
+      Deterministic activation + telemetry-classification slice only. This slice adds a
+      focused fixture-backed test and this durable classification. It does NOT change
+      benchmark metric semantics and attaches NO hybrid-effectiveness claim to the
+      retained-trace surface. No full benchmark campaign, Slurm/GPU submission, issue
+      comment, paper/dissertation claim edit, release, merge, or deletion was performed.
+    remaining_work:
+      - item: episode_runner_command_source_wiring
+        why: >-
+          Threading the hybrid planner's per-step selected source into
+          oscillatory_control_predicate inside map_runner_episode.py would change
+          benchmark telemetry output (command_source_changes would become nonzero for
+          real handoffs). That is a benchmark-metric-semantics change and is therefore
+          deferred to POST-FREEZE work (freeze 2026-07-18) per the issue's freeze-safe
+          scope.
+        expected_next_surface: >-
+          A post-freeze PR that collects per-step `selected_source`/`selected_head`
+          during episode execution and passes it as `command_sources`, plus a re-run of
+          the retained-trace analysis to obtain the genuine per-episode handoff counts.
+    acceptance_evidence:
+      - criterion: >-
+          A deterministic test triggers at least one hybrid source handoff and observes
+          a nonzero command_source_changes.
+        status: met
+        evidence: >-
+          tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py::
+          test_hybrid_portfolio_arbitration_produces_source_handoff (3 handoffs) and
+          test_command_source_changes_counted_when_wired (command_source_changes == 3).
+      - criterion: >-
+          The 0/1,165 result is classified as genuine-non-activation OR
+          telemetry-failure, with evidence.
+        status: met
+        evidence: >-
+          Classified as telemetry_failure. See the `evidence` block above and
+          test_episode_runner_callsite_always_reports_zero, which pins the structural
+          zero produced by the runner call signature.
+      - criterion: >-
+          No hybrid-effectiveness claim is attached to the retained-trace surface until
+          activation is demonstrated.
+        status: met
+        evidence: >-
+          This slice attaches no effectiveness claim; it records only mechanism
+          reachability and the telemetry gap. Effectiveness interpretation stays blocked
+          until the post-freeze runner wiring produces genuine per-episode counts.
+    out_of_scope_confirmed:
+      full_benchmark_campaign_run: false
+      slurm_or_gpu_submission: false
+      paper_or_dissertation_claim_edit: false
+      issue_comment: false
+      release: false
+      merge: false
+      deletion: false

--- a/tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py
+++ b/tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py
@@ -1,0 +1,228 @@
+"""Hybrid arbitration activation + command-source telemetry check (issue #5001).
+
+Context
+-------
+The retained-trace analysis from issue #4914 reported **0 ``command_source_changes``
+across all 1,165 episodes** for the hybrid planners. Zero handoffs is consistent with
+three very different explanations:
+
+1. the hybrid arbitration mechanism never activating (genuine non-activation);
+2. the ``command_source`` telemetry not capturing the switch (a wiring gap);
+3. the tested scenario distribution never crossing an activation threshold.
+
+Until mechanism activation is verified independently, the 0/1,165 result must **not**
+be read as evidence about hybrid effectiveness (issue #5001 acceptance criterion 3).
+
+What this module proves
+-----------------------
+* ``test_hybrid_portfolio_arbitration_produces_source_handoff`` drives the *real*
+  :class:`~robot_sf.planner.hybrid_portfolio.HybridPortfolioAdapter` arbitration through
+  regime changes (open cruise -> emergency clearance -> caution density) and shows the
+  per-step ``selected_head`` label genuinely changes. Only the child planner heads are
+  stubbed; the head-selection logic (``_desired_head`` / ``_switch_head`` /
+  ``_record_decision``) under test is the production code path.
+* ``test_command_source_changes_counted_when_wired`` feeds that captured per-step
+  source sequence into
+  :func:`~robot_sf.benchmark.safety_predicates.oscillatory_control_predicate` and shows a
+  **nonzero** ``command_source_changes`` — the mechanism *does* produce a countable
+  handoff when the telemetry is actually populated.
+* ``test_episode_runner_callsite_always_reports_zero`` pins the root cause of the
+  0/1,165 field result: the episode runner
+  (``robot_sf/benchmark/map_runner_episode.py:597``) calls
+  ``oscillatory_control_predicate(positions, headings, speeds, dt=dt)`` and never passes
+  ``command_sources``. With that optional signal absent, ``command_source_changes`` is
+  hard-wired to 0 (``safety_predicates.py:98-100``) for *every* episode, regardless of
+  how many real head handoffs occurred.
+
+Classification of the 0/1,165 result
+-------------------------------------
+**Telemetry failure (wiring gap), not genuine non-activation.** The arbitration mechanism
+is reachable and, when its per-step source labels are threaded through, yields a nonzero
+count (first two tests). The retained-trace surface reports 0 only because the runner
+never supplies ``command_sources`` to the predicate (third test). Wiring the per-step
+planner source into the episode runner changes benchmark telemetry output and is therefore
+deferred as post-freeze work (freeze 2026-07-18); see
+``docs/context/issue_5001_state.yaml``.
+
+This module changes no benchmark metric semantics: it only reads existing production code
+and the existing optional predicate signal.
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark.safety_predicates import oscillatory_control_predicate
+from robot_sf.planner.hybrid_portfolio import (
+    HybridPortfolioAdapter,
+    HybridPortfolioConfig,
+)
+
+
+class _StubHead:
+    """Minimal planner head that returns a fixed command and supports reset().
+
+    Only the hybrid *arbitration* logic is under test here; the child heads merely
+    need to return a distinct, deterministic command so we can confirm the selected
+    command tracks the selected head.
+    """
+
+    def __init__(self, command: tuple[float, float]) -> None:
+        self.command = command
+        self.reset_calls = 0
+
+    def plan(self, observation: dict[str, Any]) -> tuple[float, float]:
+        """Return the fixed command for this head."""
+        return self.command
+
+    def reset(self) -> None:
+        """Count resets so the adapter's reset fan-out stays observable."""
+        self.reset_calls += 1
+
+
+def _observation(ped_xy: list[list[float]] | None) -> dict[str, Any]:
+    """Build a hybrid-portfolio observation with the robot at the origin.
+
+    Args:
+        ped_xy: Pedestrian ``(x, y)`` positions, or ``None`` for an empty crowd.
+
+    Returns:
+        Observation dict consumed by ``HybridPortfolioAdapter._extract_ped_clearance``.
+    """
+    return {
+        "robot": {"position": [0.0, 0.0]},
+        "pedestrians": {"positions": ped_xy if ped_xy is not None else []},
+    }
+
+
+# Head-distinct commands so a source handoff is also a command handoff.
+_RISK_DWA_CMD = (1.0, 0.0)
+_ORCA_CMD = (0.0, 0.0)
+_PREDICTION_CMD = (0.5, 0.2)
+
+
+def _build_adapter() -> HybridPortfolioAdapter:
+    """Construct a hybrid adapter with deterministic stub heads and no hysteresis.
+
+    ``hysteresis_steps=0`` makes every step re-evaluate the desired head, so the
+    regime sequence deterministically maps to a head sequence.
+
+    Returns:
+        A ready-to-drive :class:`HybridPortfolioAdapter`.
+    """
+    config = HybridPortfolioConfig(hysteresis_steps=0)
+    return HybridPortfolioAdapter(
+        hybrid_config=config,
+        risk_dwa=_StubHead(_RISK_DWA_CMD),  # type: ignore[arg-type]
+        orca=_StubHead(_ORCA_CMD),  # type: ignore[arg-type]
+        prediction=_StubHead(_PREDICTION_CMD),  # type: ignore[arg-type]
+        mppi=None,
+    )
+
+
+# Regime observations chosen to cross the documented arbitration thresholds
+# (emergency_clearance=0.55, caution_clearance=1.0, near_field_distance=2.5):
+#   - open cruise       -> risk_dwa   (no pedestrian in the near field)
+#   - emergency clearance-> orca       (pedestrian at 0.4 m <= 0.55 m)
+#   - caution density    -> prediction (pedestrian at 0.9 m in (0.55, 1.0])
+_REGIME_SEQUENCE = [
+    _observation([[100.0, 100.0]]),  # open cruise -> risk_dwa
+    _observation([[0.4, 0.0]]),  # emergency -> orca
+    _observation([[0.9, 0.0]]),  # caution -> prediction
+    _observation([[100.0, 100.0]]),  # open cruise -> risk_dwa
+]
+_EXPECTED_HEADS = ["risk_dwa", "orca", "prediction", "risk_dwa"]
+_EXPECTED_COMMANDS = [_RISK_DWA_CMD, _ORCA_CMD, _PREDICTION_CMD, _RISK_DWA_CMD]
+
+
+def _drive(adapter: HybridPortfolioAdapter) -> tuple[list[str], list[tuple[float, float]]]:
+    """Run the regime sequence and capture per-step selected head and command.
+
+    Returns:
+        ``(selected_heads, selected_commands)`` aligned to ``_REGIME_SEQUENCE``.
+    """
+    heads: list[str] = []
+    commands: list[tuple[float, float]] = []
+    for observation in _REGIME_SEQUENCE:
+        command = adapter.plan(observation)
+        assert adapter._last_decision is not None
+        heads.append(str(adapter._last_decision["selected_head"]))
+        commands.append(command)
+    return heads, commands
+
+
+def test_hybrid_portfolio_arbitration_produces_source_handoff() -> None:
+    """The real arbitration path must change its selected source across regimes."""
+    adapter = _build_adapter()
+    heads, commands = _drive(adapter)
+
+    assert heads == _EXPECTED_HEADS
+    assert commands == _EXPECTED_COMMANDS
+    # At least one handoff is the whole point: the mechanism activates.
+    handoffs = sum(1 for a, b in pairwise(heads) if a != b)
+    assert handoffs >= 1
+    assert handoffs == 3  # risk_dwa->orca->prediction->risk_dwa
+
+
+def test_selected_command_tracks_selected_head() -> None:
+    """The selected command must change consistently with the selected head."""
+    adapter = _build_adapter()
+    heads, commands = _drive(adapter)
+
+    # Every distinct head maps to a distinct command, so a source change implies
+    # a command (trajectory) change — the two telemetry views stay consistent.
+    for step in range(1, len(heads)):
+        head_changed = heads[step] != heads[step - 1]
+        command_changed = commands[step] != commands[step - 1]
+        assert head_changed == command_changed
+
+
+def test_command_source_changes_counted_when_wired() -> None:
+    """Threading the captured source sequence yields a nonzero change count."""
+    adapter = _build_adapter()
+    heads, _commands = _drive(adapter)
+
+    # A benign straight trajectory of matching length; only command_source_changes
+    # is under test here.
+    n = len(heads)
+    positions = np.array([[float(i), 0.0] for i in range(n)])
+    headings = np.zeros(n)
+    velocities = np.ones(n)
+
+    result = oscillatory_control_predicate(
+        positions,
+        headings,
+        velocities,
+        dt=0.1,
+        command_sources=heads,
+    )
+    assert result["fields"]["command_source_changes"] == 3
+    assert result["fields"]["command_source_changes"] > 0
+
+
+def test_episode_runner_callsite_always_reports_zero() -> None:
+    """The runner's argument signature structurally forces a zero change count.
+
+    This replicates ``map_runner_episode.py:597`` — ``oscillatory_control_predicate``
+    is called with positions/headings/speeds and ``dt`` but *without*
+    ``command_sources``. This is the root cause of the 0/1,165 field result: with the
+    optional signal absent, ``command_source_changes`` is 0 for every episode no matter
+    how many real head handoffs occurred, so the retained-trace 0/1,165 is a telemetry
+    gap, not evidence of genuine non-activation.
+    """
+    adapter = _build_adapter()
+    heads, _commands = _drive(adapter)
+    # Sanity: the underlying mechanism genuinely handed off in this scenario.
+    assert any(a != b for a, b in pairwise(heads))
+
+    n = len(heads)
+    positions = np.array([[float(i), 0.0] for i in range(n)])
+    headings = np.zeros(n)
+    speeds = np.ones(n)
+
+    # Exact episode-runner call signature (no command_sources).
+    result = oscillatory_control_predicate(positions, headings, speeds, dt=0.1)
+    assert result["fields"]["command_source_changes"] == 0

--- a/tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py
+++ b/tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py
@@ -154,6 +154,23 @@ def _drive(adapter: HybridPortfolioAdapter) -> tuple[list[str], list[tuple[float
     return heads, commands
 
 
+def _integrate_commands(commands: list[tuple[float, float]], *, dt: float = 0.1) -> np.ndarray:
+    """Integrate the selected unicycle commands into a deterministic trajectory.
+
+    The fixture deliberately uses a small, transparent integrator rather than a
+    second planner: this makes the causal chain under test explicit — selected
+    source changes the selected command, which changes the next trajectory step.
+    """
+    position = np.zeros(2)
+    heading = 0.0
+    positions: list[np.ndarray] = []
+    for linear_speed, angular_speed in commands:
+        position = position + dt * linear_speed * np.array([np.cos(heading), np.sin(heading)])
+        heading += dt * angular_speed
+        positions.append(position.copy())
+    return np.asarray(positions)
+
+
 def test_hybrid_portfolio_arbitration_produces_source_handoff() -> None:
     """The real arbitration path must change its selected source across regimes."""
     adapter = _build_adapter()
@@ -168,29 +185,32 @@ def test_hybrid_portfolio_arbitration_produces_source_handoff() -> None:
 
 
 def test_selected_command_tracks_selected_head() -> None:
-    """The selected command must change consistently with the selected head."""
+    """Source transitions must consistently change selected commands and trajectory."""
     adapter = _build_adapter()
     heads, commands = _drive(adapter)
+    trajectory = _integrate_commands(commands)
+    trajectory_steps = np.diff(np.vstack([np.zeros(2), trajectory]), axis=0)
 
-    # Every distinct head maps to a distinct command, so a source change implies
-    # a command (trajectory) change — the two telemetry views stay consistent.
+    # Every distinct head maps to a distinct command, so a source change must
+    # change both the command and the resulting unicycle trajectory step.
     for step in range(1, len(heads)):
         head_changed = heads[step] != heads[step - 1]
         command_changed = commands[step] != commands[step - 1]
-        assert head_changed == command_changed
+        trajectory_changed = not np.allclose(trajectory_steps[step], trajectory_steps[step - 1])
+        assert head_changed == command_changed == trajectory_changed
 
 
 def test_command_source_changes_counted_when_wired() -> None:
     """Threading the captured source sequence yields a nonzero change count."""
     adapter = _build_adapter()
-    heads, _commands = _drive(adapter)
+    heads, commands = _drive(adapter)
 
-    # A benign straight trajectory of matching length; only command_source_changes
-    # is under test here.
+    # The production-selected commands generate this deterministic trajectory;
+    # source handoffs therefore feed both source telemetry and motion evidence.
+    positions = _integrate_commands(commands)
     n = len(heads)
-    positions = np.array([[float(i), 0.0] for i in range(n)])
     headings = np.zeros(n)
-    velocities = np.ones(n)
+    velocities = np.asarray([command[0] for command in commands])
 
     result = oscillatory_control_predicate(
         positions,


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** A deterministic fixture-backed test proving the hybrid planner's arbitration mechanism activates, plus a durable classification of the retained-trace "0 `command_source_changes` across 1,165 episodes" result (from #4914).
- **Why now:** Until mechanism activation is verified, the 0/1,165 result must not be read as evidence about hybrid effectiveness. This slice supplies that verification, freeze-safe before 2026-07-18.
- **Claim boundary:** No benchmark metric semantics change; no hybrid-effectiveness claim attached to the retained-trace surface. The mechanism is shown reachable and countable-when-wired; the field telemetry itself is unchanged.
- **Required validation:** `pytest tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py` (+ issue-declared command below).
- **Remaining blocker:** The episode runner never threads the per-step source into the predicate. Fixing that changes benchmark telemetry output, so it is deferred as **post-freeze** follow-up work (see below).

## Classification: telemetry failure (wiring gap), not genuine non-activation

The 0/1,165 field result is a **telemetry wiring gap**:

1. The hybrid arbitration mechanism *is* reachable. `robot_sf/planner/hybrid_portfolio.py:88-120,176-200` selects a planner head per step (`_desired_head` → `_switch_head` → `_record_decision`) and records a per-step `selected_head`. The new test drives this real path through open-cruise → emergency → caution regimes and observes **3 head handoffs** (`risk_dwa → orca → prediction → risk_dwa`).
2. When the captured per-step source sequence is threaded into `oscillatory_control_predicate` (via its optional `command_sources` arg), `command_source_changes == 3` — i.e. **nonzero when wired**.
3. The episode runner never supplies that signal: `robot_sf/benchmark/map_runner_episode.py:597` calls `oscillatory_control_predicate(positions, headings, speeds, dt=dt)` with no `command_sources`, and `safety_predicates.py:98-100` then hard-wires `command_source_changes` to `0` for **every** episode regardless of real handoffs. The per-step `selected_source` is read into the planner decision trace at `map_runner_episode.py:1974` but never collected into a list and passed to the predicate.

Both hybrid families are affected identically: `hybrid_portfolio` records `selected_head` (`:153-161`); `hybrid_rule_local_planner` records `selected_source` (`:2741`); neither reaches the predicate.

## Contract delta

- **New test:** `tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py` (4 cases: handoff activation, command↔head consistency, nonzero-when-wired, and a regression pin that the runner's call signature structurally forces `0`).
- **New durable state surface:** `docs/context/issue_5001_state.yaml` — telemetry-failure classification with file:line evidence and the post-freeze remainder.
- **No schema fields, no fail-closed blockers, no runtime behavior changes.** Fully backward compatible.

## Acceptance criteria

- [x] A deterministic test triggers ≥1 hybrid source handoff and observes a nonzero `command_source_changes` — `test_hybrid_portfolio_arbitration_produces_source_handoff` (3 handoffs) + `test_command_source_changes_counted_when_wired` (`== 3`).
- [x] The 0/1,165 result is classified as genuine-non-activation **or** telemetry-failure, with evidence — classified **telemetry-failure**; pinned by `test_episode_runner_callsite_always_reports_zero`.
- [x] No hybrid-effectiveness claim is attached to the retained-trace surface until activation is demonstrated — this slice attaches none.

## Validation

| Command | Result |
| --- | --- |
| `ruff check … && ruff format --check …` (new test) | pass (all checks passed; already formatted) |
| `pytest tests/benchmark/test_mechanism_trace.py tests/benchmark/test_goal_posterior_planner_input_smoke_issue_4164.py tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py tests/benchmark/test_safety_predicates.py -q` | **48 passed** |
| `check_docs_evidence_integrity.py --files docs/context/issue_5001_state.yaml tests/…` | pass (2 changed files) |

(Issue-declared command: `scripts/dev/run_tests_parallel.sh tests/benchmark/test_mechanism_trace.py tests/benchmark/test_goal_posterior_planner_input_smoke_issue_4164.py` — covered above via `pytest`, plus the new module.)

## Post-freeze follow-up (out of scope here)

Threading the hybrid planner's per-step `selected_source`/`selected_head` into `oscillatory_control_predicate` inside `map_runner_episode.py`, then re-running the retained-trace analysis to obtain genuine per-episode handoff counts. This changes benchmark telemetry output and is therefore **post-freeze** work (freeze 2026-07-18). Recorded in `docs/context/issue_5001_state.yaml`.

## Follow-up tracking

- Post-freeze episode-runner telemetry wiring: #5081

## Closure

Closes #5001 — all three acceptance criteria (deterministic activation, telemetry-failure classification with evidence, no effectiveness claim) are met within the issue's freeze-safe scope. The gate on `imech156-u` may demote this keyword if it judges the field-telemetry wiring to be in-scope; that wiring is the recorded post-freeze follow-up.

<details>
<summary>Governance appendix</summary>

- **Out of scope confirmed:** no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no issue comments, no merge, no release, no deletion.
- **Evidence tier:** smoke/diagnostic — targeted deterministic unit evidence for the arbitration + predicate contract; not a benchmark campaign result. The retained-trace field values are unchanged by this PR.
- **State propagation:** single canonical durable surface updated (`docs/context/issue_5001_state.yaml`); no issue comment (comment authorization off; low-churn issue).
- **Fragmentation guard:** no prior guardrail/checker PRs for #5001; this is a progression slice adding a nameable new capability (deterministic hybrid-arbitration activation verification + telemetry-gap classification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>

