### PR TITLE
feat(benchmark): scenario flakiness audit — exact-repeat determinism + per-cell outcome-stability (#4978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regression coverage lives in `tests/dev/test_gh_list_truncation_remaining.py` and
   `tests/tools/test_project_priority_score_truncation.py`. Tooling/evidence-integrity only — no
   benchmark, metric, or paper-facing claim.
+* **issue #4978 scenario flakiness audit — exact-repeat determinism + per-cell outcome-stability.**
+  New `robot_sf/benchmark/scenario_flakiness.py` (`compute_flakiness_audit`, schema
+  `scenario_flakiness.v1`) and a `robot_sf_bench flakiness-audit` CLI subcommand measure two forms of
+  outcome instability from existing episode JSONL: (1) exact-repeat determinism — when a
+  `(scenario, planner, seed)` cell is executed more than once, whether repeats share the same binary
+  outcome (a `False` verdict is a reproducibility bug the audit doubles as a detector for); and
+  (2) per-cell outcome stability — the fraction of seeds in a `(scenario, planner)` cell that agree
+  with the majority outcome, flagging `knife_edge` cells below a configurable threshold (default
+  0.8). The audit is advisory and read-only: it emits a schema-versioned report and does not change
+  rankings, campaign summaries, or metric semantics. Fail-closed by design — empty input raises,
+  cells below `min_seeds` are reported as not assessable rather than counted as stable, and
+  determinism is reported as `null` (unknown) when no exact-repeat data exists. Claim boundary:
+  new diagnostic capability validated on synthetic and CPU fixtures; no benchmark campaign run.
 * **issue #3574 realized-distribution audit for heterogeneous-population traces.**
   `robot_sf/benchmark/heterogeneous_population_metrics.py` gains `realized_distribution_audit` and
   `summarize_distribution` (plus a `RealizedDistributionSpec`), covering DoD item 5: configured

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -87,6 +87,9 @@ from robot_sf.benchmark.report_table import format_latex_booktabs as _tbl_format
 from robot_sf.benchmark.report_table import format_markdown as _tbl_format_md
 from robot_sf.benchmark.report_table import to_json as _tbl_to_json
 from robot_sf.benchmark.runner import load_scenario_matrix, run_batch
+from robot_sf.benchmark.scenario_flakiness import (
+    compute_flakiness_audit as _compute_flakiness_audit,
+)
 from robot_sf.benchmark.scenario_schema import (
     validate_scenario_list,
     validate_scenario_matrix_metadata,
@@ -822,6 +825,48 @@ def _handle_seed_variance(args) -> int:
         except _CLI_LOGGING_ERRORS:  # pragma: no cover - defensive logging boundary
             logging.debug("Logging 'Seed-variance summary' failed", exc_info=True)
         return 0
+    except _CLI_INPUT_ERRORS:  # pragma: no cover - error path
+        return 2
+
+
+def _handle_flakiness_audit(args) -> int:
+    """Audit scenario outcome flakiness and write a JSON report.
+
+    Returns:
+        Exit code (0 success, 2 failure).
+    """
+    try:
+        records = _agg_read_jsonl(args.in_path)
+        report = _compute_flakiness_audit(
+            records,
+            outcome_metric=str(args.outcome_metric),
+            group_by=args.group_by,
+            fallback_group_by=args.fallback_group_by,
+            seed_field=str(args.seed_field),
+            stability_threshold=float(args.stability_threshold),
+            min_seeds=int(args.min_seeds),
+        )
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+        try:
+            summary = report["summary"]
+            logging.info(
+                "Flakiness audit written to %s (%s cells, %s knife-edge, determinism=%s)",
+                out_path,
+                summary["n_cells"],
+                summary["n_knife_edge_cells"],
+                report["exact_repeat"]["is_deterministic"],
+            )
+        except _CLI_LOGGING_ERRORS:  # pragma: no cover - defensive logging boundary
+            logging.debug("Logging 'Flakiness audit' failed", exc_info=True)
+        return 0
+    except ValueError:
+        # Fail closed on an empty/invalid audit request rather than emit a report
+        # that asserts stability without evidence.
+        logging.exception("Flakiness audit failed")
+        return 2
     except _CLI_INPUT_ERRORS:  # pragma: no cover - error path
         return 2
 
@@ -2321,6 +2366,57 @@ def _add_seed_variance_subparser(
     p.set_defaults(cmd="seed-variance")
 
 
+def _add_flakiness_audit_subparser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the flakiness-audit subcommand parser."""
+    p = subparsers.add_parser(
+        "flakiness-audit",
+        help=(
+            "Audit scenario outcome flakiness: exact-repeat determinism and "
+            "per-cell (scenario, planner) outcome-stability; writes a JSON report"
+        ),
+    )
+    p.add_argument("--in", dest="in_path", required=True, help="Input episodes JSONL path")
+    p.add_argument("--out", required=True, help="Output JSON report path")
+    p.add_argument(
+        "--outcome-metric",
+        default="success",
+        help="Binary outcome metric name (default: success)",
+    )
+    p.add_argument(
+        "--group-by",
+        default=DEFAULT_REPORT_GROUP_BY,
+        help="Planner grouping key (dotted path). Default: scenario_params.algo",
+    )
+    p.add_argument(
+        "--fallback-group-by",
+        default=DEFAULT_REPORT_FALLBACK_GROUP_BY,
+        help="Fallback grouping key when group-by is missing. Default: scenario_id",
+    )
+    p.add_argument(
+        "--seed-field",
+        default="seed",
+        help="Dotted path to the seed field (default: seed)",
+    )
+    p.add_argument(
+        "--stability-threshold",
+        type=float,
+        default=0.8,
+        help=(
+            "Majority-agreement fraction below which a cell is flagged knife-edge "
+            "(range (0, 1]; default 0.8)"
+        ),
+    )
+    p.add_argument(
+        "--min-seeds",
+        type=int,
+        default=2,
+        help="Minimum distinct seeds before a cell's stability is assessed (default: 2)",
+    )
+    p.set_defaults(cmd="flakiness-audit")
+
+
 def _add_extract_failures_subparser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -2730,6 +2826,7 @@ def _attach_core_subcommands(parser: argparse.ArgumentParser) -> None:  # noqa: 
     _add_validate_row_claims_subparser(subparsers)
     _add_export_parquet_subparser(subparsers)
     _add_seed_variance_subparser(subparsers)
+    _add_flakiness_audit_subparser(subparsers)
     _add_extract_failures_subparser(subparsers)
     _add_snqi_ablate_subparser(subparsers)
     _add_rank_subparser(subparsers)
@@ -3238,6 +3335,7 @@ def cli_main(argv: list[str] | None = None) -> int:
         "validate-row-claims": _handle_validate_row_claims,
         "export-parquet": _handle_export_parquet,
         "seed-variance": _handle_seed_variance,
+        "flakiness-audit": _handle_flakiness_audit,
         "extract-failures": _handle_extract_failures,
         "snqi-ablate": _handle_snqi_ablate,
         "rank": _handle_rank,

--- a/robot_sf/benchmark/scenario_flakiness.py
+++ b/robot_sf/benchmark/scenario_flakiness.py
@@ -1,0 +1,347 @@
+"""Scenario flakiness audit for the Social Navigation Benchmark.
+
+This module measures two distinct forms of outcome instability from benchmark
+episode records (see issue #4978):
+
+1. **Exact-repeat determinism** — when the same ``(scenario, planner, seed)``
+   cell is executed more than once, do the repeated runs produce the *same*
+   binary outcome? If not, exact-repeat runs are non-deterministic, which is a
+   reproducibility bug the audit doubles as a detector for.
+2. **Per-cell outcome stability** — within a ``(scenario, planner)`` cell, how
+   consistently do independent seeds agree on the binary outcome? A cell whose
+   seeds flip between success and failure is *knife-edge*: campaign comparisons
+   on it carry hidden variance that per-seed confidence intervals understate.
+
+The audit is intentionally advisory and read-only: it emits a schema-versioned
+report describing stability, and never mutates existing rankings, campaign
+summaries, or metric semantics. Downstream tooling may *choose* to exclude or
+down-weight flagged knife-edge cells, but that decision stays out of scope here.
+
+The audit fails closed: an empty record set raises, cells with too few seeds are
+reported as *not assessable* rather than silently counted as stable, and
+determinism is reported as ``None`` (unknown) when no exact-repeat data exists
+instead of being asserted without evidence.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.grouping import (
+    DEFAULT_REPORT_FALLBACK_GROUP_BY,
+    DEFAULT_REPORT_GROUP_BY,
+    get_nested,
+    resolve_report_group_key,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+SCHEMA_VERSION = "scenario_flakiness.v1"
+
+#: Default metric treated as the binary episode outcome. ``success`` is already
+#: recorded as 0/1 in benchmark episode records.
+DEFAULT_OUTCOME_METRIC = "success"
+
+#: Default fraction of seeds that must agree with the majority outcome for a
+#: cell to be considered stable. Cells below this are flagged ``knife_edge``.
+DEFAULT_STABILITY_THRESHOLD = 0.8
+
+#: Minimum distinct seeds required before a cell's stability can be assessed.
+DEFAULT_MIN_SEEDS = 2
+
+#: Cap on how many concrete examples are embedded in the report for each list so
+#: the JSON stays compact on large campaigns.
+_MAX_EXAMPLES = 25
+
+
+def _binary_outcome(value: Any) -> int | None:
+    """Coerce an outcome metric value into a binary 0/1 label.
+
+    A ``success``-style metric is already 0/1, but records may carry booleans or
+    floats (e.g. an averaged success rate). Values ``>= 0.5`` map to 1, finite
+    values below map to 0, and non-numeric/missing values map to ``None`` so the
+    caller can fail closed instead of guessing.
+
+    Returns:
+        ``1``, ``0``, or ``None`` when the value cannot be interpreted.
+    """
+    if value is None or isinstance(value, bool):
+        return int(value) if isinstance(value, bool) else None
+    if isinstance(value, int | float):
+        f = float(value)
+        if math.isnan(f):
+            return None
+        return 1 if f >= 0.5 else 0
+    return None
+
+
+def _outcome_from_record(record: dict[str, Any], outcome_metric: str) -> int | None:
+    """Extract the binary outcome for a record from its metrics block.
+
+    Accepts both ``metrics.<outcome_metric>`` and a top-level ``<outcome_metric>``
+    fallback so the audit works on flattened and nested record shapes.
+
+    Returns:
+        Binary outcome, or ``None`` when the outcome metric is absent/uninterpretable.
+    """
+    metrics = record.get("metrics")
+    if isinstance(metrics, dict) and outcome_metric in metrics:
+        return _binary_outcome(metrics[outcome_metric])
+    # Fall back to a dotted/top-level path for already-flattened rows.
+    return _binary_outcome(get_nested(record, outcome_metric))
+
+
+def _seed_key(record: dict[str, Any], seed_field: str) -> str:
+    """Return a stable string key for a record's seed (``"__missing__"`` if absent)."""
+    value = get_nested(record, seed_field)
+    if value is None:
+        return "__missing__"
+    return str(value)
+
+
+def _cell_stability(seed_outcomes: dict[str, int]) -> tuple[float, float]:
+    """Compute the success rate and stability score for a cell's seed votes.
+
+    Args:
+        seed_outcomes: Mapping of seed key to that seed's representative binary outcome.
+
+    Returns:
+        ``(success_rate, stability_score)`` where ``success_rate`` is the fraction
+        of seeds with outcome 1 and ``stability_score`` is the fraction of seeds
+        agreeing with the majority outcome (range ``[0.5, 1.0]``; 1.0 == unanimous).
+    """
+    n = len(seed_outcomes)
+    ones = sum(1 for v in seed_outcomes.values() if v == 1)
+    success_rate = ones / n
+    stability_score = max(success_rate, 1.0 - success_rate)
+    return success_rate, stability_score
+
+
+def _ingest_records(
+    records: Sequence[dict[str, Any]],
+    *,
+    outcome_metric: str,
+    group_by: str,
+    fallback_group_by: str,
+    seed_field: str,
+) -> tuple[dict[str, tuple[str, str]], dict[str, dict[str, list[int]]], int, int]:
+    """Group episode outcomes into ``(scenario, planner)`` cells by seed.
+
+    Returns:
+        ``(cell_meta, cell_seed_outcomes, n_missing_outcome, n_missing_scenario)``
+        where ``cell_seed_outcomes[cell][seed]`` lists that seed's binary outcomes.
+    """
+    cell_meta: dict[str, tuple[str, str]] = {}
+    cell_seed_outcomes: dict[str, dict[str, list[int]]] = defaultdict(lambda: defaultdict(list))
+    n_missing_outcome = 0
+    n_missing_scenario = 0
+
+    for record in records:
+        scenario_id = get_nested(record, "scenario_id")
+        if scenario_id is None:
+            n_missing_scenario += 1
+            continue
+        planner = (
+            resolve_report_group_key(
+                record,
+                group_by=group_by,
+                fallback_group_by=fallback_group_by,
+                missing="unknown",
+            )
+            or "unknown"
+        )
+        outcome = _outcome_from_record(record, outcome_metric)
+        if outcome is None:
+            n_missing_outcome += 1
+            continue
+        cell_key = f"{scenario_id}::{planner}"
+        cell_meta[cell_key] = (str(scenario_id), str(planner))
+        cell_seed_outcomes[cell_key][_seed_key(record, seed_field)].append(outcome)
+
+    return cell_meta, cell_seed_outcomes, n_missing_outcome, n_missing_scenario
+
+
+def _audit_cell(
+    cell_key: str,
+    scenario_id: str,
+    planner: str,
+    seed_map: dict[str, list[int]],
+    *,
+    stability_threshold: float,
+    min_seeds: int,
+) -> tuple[dict[str, Any], list[dict[str, Any]], int, int]:
+    """Score a single cell's stability and detect within-seed non-determinism.
+
+    Returns:
+        ``(cell_report, determinism_examples, checked_repeat_groups,
+        nondeterministic_repeat_groups)``.
+    """
+    seed_votes: dict[str, int] = {}
+    examples: list[dict[str, Any]] = []
+    nondeterministic_seeds = 0
+    has_within_seed_repeats = False
+    checked_repeat_groups = 0
+    nondeterministic_repeat_groups = 0
+    n_episodes = 0
+
+    for seed_key, outcomes in seed_map.items():
+        n_episodes += len(outcomes)
+        if len(outcomes) >= 2:
+            has_within_seed_repeats = True
+            checked_repeat_groups += 1
+            if len(set(outcomes)) > 1:
+                nondeterministic_repeat_groups += 1
+                nondeterministic_seeds += 1
+                examples.append(
+                    {
+                        "scenario_id": scenario_id,
+                        "planner": planner,
+                        "seed": seed_key,
+                        "n_repeats": len(outcomes),
+                        "outcomes": list(outcomes),
+                    }
+                )
+        # Representative vote for this seed: majority (ties -> 1, matching
+        # `_binary_outcome`'s >= 0.5 rule) so within-seed repeats collapse to one
+        # cross-seed vote.
+        seed_votes[seed_key] = 1 if (sum(outcomes) / len(outcomes)) >= 0.5 else 0
+
+    n_seeds = len(seed_votes)
+    ones = sum(seed_votes.values())
+    assessable = n_seeds >= min_seeds
+    if assessable:
+        success_rate, stability_score = _cell_stability(seed_votes)
+        knife_edge = stability_score < stability_threshold
+    else:
+        success_rate = ones / n_seeds if n_seeds else None
+        stability_score = None
+        knife_edge = False
+
+    cell_report = {
+        "cell_key": cell_key,
+        "scenario_id": scenario_id,
+        "planner": planner,
+        "n_seeds": n_seeds,
+        "n_episodes": n_episodes,
+        "success_rate": success_rate,
+        "stability_score": stability_score,
+        "knife_edge": knife_edge,
+        "assessable": assessable,
+        "outcome_counts": {"1": ones, "0": n_seeds - ones},
+        "has_within_seed_repeats": has_within_seed_repeats,
+        "nondeterministic_seeds": nondeterministic_seeds,
+    }
+    return cell_report, examples, checked_repeat_groups, nondeterministic_repeat_groups
+
+
+def compute_flakiness_audit(
+    records: Sequence[dict[str, Any]],
+    *,
+    outcome_metric: str = DEFAULT_OUTCOME_METRIC,
+    group_by: str = DEFAULT_REPORT_GROUP_BY,
+    fallback_group_by: str = DEFAULT_REPORT_FALLBACK_GROUP_BY,
+    seed_field: str = "seed",
+    stability_threshold: float = DEFAULT_STABILITY_THRESHOLD,
+    min_seeds: int = DEFAULT_MIN_SEEDS,
+) -> dict[str, Any]:
+    """Audit scenario-level outcome flakiness from benchmark episode records.
+
+    Builds ``(scenario, planner)`` cells and, within each cell, groups episodes
+    by seed. It measures exact-repeat determinism (repeated runs of the same
+    seed) and per-cell outcome stability (agreement across seeds).
+
+    Args:
+        records: Episode records with a ``scenario_id``, a planner-identifying
+            field resolvable via ``group_by``/``fallback_group_by``, a seed, and
+            the binary ``outcome_metric`` (typically under ``metrics``).
+        outcome_metric: Metric name treated as the binary outcome.
+        group_by: Primary dotted path identifying the planner dimension.
+        fallback_group_by: Fallback dotted path when ``group_by`` is missing.
+        seed_field: Dotted path to the seed field.
+        stability_threshold: Majority-agreement fraction below which a cell is
+            flagged ``knife_edge``.
+        min_seeds: Minimum distinct seeds before a cell's stability is assessed.
+
+    Returns:
+        A schema-versioned audit report (see module docstring for structure).
+
+    Raises:
+        ValueError: When ``records`` is empty (an audit of nothing is not
+            evidence) or when ``stability_threshold`` is outside ``(0, 1]``.
+    """
+    if not records:
+        raise ValueError(
+            "scenario flakiness audit requires at least one episode record; "
+            "refusing to report stability with no evidence"
+        )
+    if not (0.0 < stability_threshold <= 1.0):
+        raise ValueError(f"stability_threshold must be in (0, 1], got {stability_threshold}")
+
+    cell_meta, cell_seed_outcomes, n_missing_outcome, n_missing_scenario = _ingest_records(
+        records,
+        outcome_metric=outcome_metric,
+        group_by=group_by,
+        fallback_group_by=fallback_group_by,
+        seed_field=seed_field,
+    )
+
+    cells: list[dict[str, Any]] = []
+    determinism_examples: list[dict[str, Any]] = []
+    checked_repeat_groups = 0
+    nondeterministic_repeat_groups = 0
+
+    for cell_key in sorted(cell_seed_outcomes):
+        scenario_id, planner = cell_meta[cell_key]
+        cell_report, examples, checked, nondeterministic = _audit_cell(
+            cell_key,
+            scenario_id,
+            planner,
+            cell_seed_outcomes[cell_key],
+            stability_threshold=stability_threshold,
+            min_seeds=min_seeds,
+        )
+        cells.append(cell_report)
+        checked_repeat_groups += checked
+        nondeterministic_repeat_groups += nondeterministic
+        for example in examples:
+            if len(determinism_examples) < _MAX_EXAMPLES:
+                determinism_examples.append(example)
+
+    assessable_cells = [c for c in cells if c["assessable"]]
+    knife_edge_cells = [c for c in assessable_cells if c["knife_edge"]]
+
+    # Determinism verdict fails closed: unknown when no repeat data exists.
+    if checked_repeat_groups == 0:
+        is_deterministic: bool | None = None
+    else:
+        is_deterministic = nondeterministic_repeat_groups == 0
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "outcome_metric": outcome_metric,
+        "group_by": group_by,
+        "fallback_group_by": fallback_group_by,
+        "stability_threshold": stability_threshold,
+        "min_seeds": min_seeds,
+        "exact_repeat": {
+            "checked_repeat_groups": checked_repeat_groups,
+            "nondeterministic_repeat_groups": nondeterministic_repeat_groups,
+            "is_deterministic": is_deterministic,
+            "examples": determinism_examples,
+        },
+        "summary": {
+            "n_records": len(records),
+            "n_cells": len(cells),
+            "n_assessable_cells": len(assessable_cells),
+            "n_knife_edge_cells": len(knife_edge_cells),
+            "knife_edge_fraction": (
+                len(knife_edge_cells) / len(assessable_cells) if assessable_cells else None
+            ),
+            "n_records_missing_outcome": n_missing_outcome,
+            "n_records_missing_scenario": n_missing_scenario,
+        },
+        "cells": cells,
+    }

--- a/robot_sf/benchmark/scenario_flakiness.py
+++ b/robot_sf/benchmark/scenario_flakiness.py
@@ -269,8 +269,9 @@ def compute_flakiness_audit(
         A schema-versioned audit report (see module docstring for structure).
 
     Raises:
-        ValueError: When ``records`` is empty (an audit of nothing is not
-            evidence) or when ``stability_threshold`` is outside ``(0, 1]``.
+        ValueError: When ``records`` has no usable episode evidence, when
+            ``stability_threshold`` is outside ``(0, 1]``, or when
+            ``min_seeds`` is not positive.
     """
     if not records:
         raise ValueError(
@@ -279,6 +280,8 @@ def compute_flakiness_audit(
         )
     if not (0.0 < stability_threshold <= 1.0):
         raise ValueError(f"stability_threshold must be in (0, 1], got {stability_threshold}")
+    if min_seeds < 1:
+        raise ValueError(f"min_seeds must be at least 1, got {min_seeds}")
 
     cell_meta, cell_seed_outcomes, n_missing_outcome, n_missing_scenario = _ingest_records(
         records,
@@ -287,6 +290,11 @@ def compute_flakiness_audit(
         fallback_group_by=fallback_group_by,
         seed_field=seed_field,
     )
+    if not cell_seed_outcomes:
+        raise ValueError(
+            "scenario flakiness audit requires at least one record with a scenario and "
+            "interpretable outcome; refusing to report stability with no usable evidence"
+        )
 
     cells: list[dict[str, Any]] = []
     determinism_examples: list[dict[str, Any]] = []

--- a/tests/benchmark/test_scenario_flakiness.py
+++ b/tests/benchmark/test_scenario_flakiness.py
@@ -181,3 +181,20 @@ def test_invalid_threshold_rejected():
     """A threshold outside (0, 1] is rejected."""
     with pytest.raises(ValueError, match="stability_threshold"):
         compute_flakiness_audit([_rec("s1", "ppo", 0, 1)], stability_threshold=1.5)
+
+
+@pytest.mark.parametrize("min_seeds", [0, -1])
+def test_nonpositive_min_seeds_rejected(min_seeds: int):
+    """A nonpositive evidence minimum cannot silently assess every cell."""
+    with pytest.raises(ValueError, match="min_seeds"):
+        compute_flakiness_audit([_rec("s1", "ppo", 0, 1)], min_seeds=min_seeds)
+
+
+def test_all_unusable_records_fail_closed():
+    """Records without a usable scenario/outcome cannot yield an empty success report."""
+    records = [
+        {"scenario_id": "s1", "algo": "ppo", "seed": 0, "metrics": {}},
+        {"algo": "ppo", "seed": 1, "metrics": {"success": 1}},
+    ]
+    with pytest.raises(ValueError, match="no usable evidence"):
+        compute_flakiness_audit(records, group_by="algo")

--- a/tests/benchmark/test_scenario_flakiness.py
+++ b/tests/benchmark/test_scenario_flakiness.py
@@ -1,0 +1,183 @@
+"""Tests for the scenario flakiness audit (issue #4978).
+
+Covers exact-repeat determinism detection, per-cell outcome-stability scoring,
+knife-edge flagging, fail-closed behavior, and planner-cell separation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.scenario_flakiness import (
+    SCHEMA_VERSION,
+    compute_flakiness_audit,
+)
+
+
+def _rec(scenario_id: str, planner: str, seed: int, success: int) -> dict:
+    """Build a minimal episode record with a binary ``success`` outcome."""
+    return {
+        "episode_id": f"{scenario_id}-{planner}-{seed}",
+        "scenario_id": scenario_id,
+        "algo": planner,
+        "seed": seed,
+        "metrics": {"success": success},
+    }
+
+
+def _cell(report: dict, cell_key: str) -> dict:
+    """Return the cell dict for ``cell_key`` from an audit report."""
+    return next(c for c in report["cells"] if c["cell_key"] == cell_key)
+
+
+def test_stable_cell_scores_full_stability():
+    """A cell whose seeds all agree is fully stable and not knife-edge."""
+    records = [_rec("s1", "ppo", seed, 1) for seed in range(4)]
+    report = compute_flakiness_audit(records, group_by="algo")
+    cell = _cell(report, "s1::ppo")
+    assert cell["stability_score"] == pytest.approx(1.0)
+    assert cell["success_rate"] == pytest.approx(1.0)
+    assert cell["knife_edge"] is False
+    assert cell["assessable"] is True
+    assert report["summary"]["n_knife_edge_cells"] == 0
+
+
+def test_knife_edge_cell_is_flagged():
+    """A 50/50 success/failure split across seeds is a knife-edge cell."""
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 1, 1),
+        _rec("s1", "ppo", 2, 0),
+        _rec("s1", "ppo", 3, 0),
+    ]
+    report = compute_flakiness_audit(records, group_by="algo", stability_threshold=0.8)
+    cell = _cell(report, "s1::ppo")
+    assert cell["success_rate"] == pytest.approx(0.5)
+    assert cell["stability_score"] == pytest.approx(0.5)
+    assert cell["knife_edge"] is True
+    assert report["summary"]["n_knife_edge_cells"] == 1
+    assert report["summary"]["knife_edge_fraction"] == pytest.approx(1.0)
+
+
+def test_threshold_boundary_excludes_equal_stability():
+    """Stability exactly at the threshold is not flagged (strict less-than)."""
+    # 4 seeds, 3 success / 1 fail -> dominant fraction 0.75.
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 1, 1),
+        _rec("s1", "ppo", 2, 1),
+        _rec("s1", "ppo", 3, 0),
+    ]
+    report = compute_flakiness_audit(records, group_by="algo", stability_threshold=0.75)
+    cell = _cell(report, "s1::ppo")
+    assert cell["stability_score"] == pytest.approx(0.75)
+    assert cell["knife_edge"] is False
+
+
+def test_exact_repeat_determinism_pass():
+    """Repeated runs of a seed that agree count as deterministic repeat groups."""
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 0, 1),  # exact repeat, same outcome
+        _rec("s1", "ppo", 1, 1),
+        _rec("s1", "ppo", 1, 1),
+    ]
+    report = compute_flakiness_audit(records, group_by="algo")
+    er = report["exact_repeat"]
+    assert er["checked_repeat_groups"] == 2
+    assert er["nondeterministic_repeat_groups"] == 0
+    assert er["is_deterministic"] is True
+    assert er["examples"] == []
+
+
+def test_exact_repeat_nondeterminism_detected():
+    """Repeated runs of a seed that disagree are flagged as non-deterministic."""
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 0, 0),  # same seed, flipped outcome -> reproducibility bug
+        _rec("s1", "ppo", 1, 1),
+        _rec("s1", "ppo", 2, 1),
+    ]
+    report = compute_flakiness_audit(records, group_by="algo")
+    er = report["exact_repeat"]
+    assert er["checked_repeat_groups"] == 1
+    assert er["nondeterministic_repeat_groups"] == 1
+    assert er["is_deterministic"] is False
+    assert len(er["examples"]) == 1
+    example = er["examples"][0]
+    assert example["scenario_id"] == "s1"
+    assert example["seed"] == "0"
+    assert sorted(example["outcomes"]) == [0, 1]
+    # The nondeterministic seed is recorded on the cell too.
+    cell = _cell(report, "s1::ppo")
+    assert cell["nondeterministic_seeds"] == 1
+    assert cell["has_within_seed_repeats"] is True
+
+
+def test_determinism_unknown_without_repeat_data():
+    """With no exact-repeat data, determinism is unknown (fail closed, not True)."""
+    records = [_rec("s1", "ppo", seed, 1) for seed in range(3)]
+    report = compute_flakiness_audit(records, group_by="algo")
+    er = report["exact_repeat"]
+    assert er["checked_repeat_groups"] == 0
+    assert er["is_deterministic"] is None
+
+
+def test_single_seed_cell_not_assessable():
+    """A cell with fewer than min_seeds is reported but not scored or flagged."""
+    records = [_rec("s1", "ppo", 0, 0)]
+    report = compute_flakiness_audit(records, group_by="algo", min_seeds=2)
+    cell = _cell(report, "s1::ppo")
+    assert cell["assessable"] is False
+    assert cell["stability_score"] is None
+    assert cell["knife_edge"] is False
+    assert report["summary"]["n_assessable_cells"] == 0
+    assert report["summary"]["knife_edge_fraction"] is None
+
+
+def test_planner_cells_are_separated():
+    """Records for different planners on the same scenario form distinct cells."""
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 1, 1),
+        _rec("s1", "orca", 0, 0),
+        _rec("s1", "orca", 1, 0),
+    ]
+    report = compute_flakiness_audit(records, group_by="algo")
+    keys = {c["cell_key"] for c in report["cells"]}
+    assert keys == {"s1::ppo", "s1::orca"}
+    assert _cell(report, "s1::ppo")["success_rate"] == pytest.approx(1.0)
+    assert _cell(report, "s1::orca")["success_rate"] == pytest.approx(0.0)
+
+
+def test_missing_outcome_records_counted_not_scored():
+    """Records lacking the outcome metric are counted, not silently scored."""
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 1, 1),
+        {"episode_id": "x", "scenario_id": "s1", "algo": "ppo", "seed": 2, "metrics": {}},
+    ]
+    report = compute_flakiness_audit(records, group_by="algo")
+    assert report["summary"]["n_records_missing_outcome"] == 1
+    # The scored cell only reflects the two records that carried an outcome.
+    assert _cell(report, "s1::ppo")["n_seeds"] == 2
+
+
+def test_schema_version_and_metadata_present():
+    """The report advertises its schema version and audit parameters."""
+    report = compute_flakiness_audit([_rec("s1", "ppo", 0, 1)], group_by="algo")
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["outcome_metric"] == "success"
+    assert report["stability_threshold"] == pytest.approx(0.8)
+
+
+def test_empty_records_fail_closed():
+    """An audit of no records raises rather than asserting stability."""
+    with pytest.raises(ValueError, match="at least one episode record"):
+        compute_flakiness_audit([])
+
+
+def test_invalid_threshold_rejected():
+    """A threshold outside (0, 1] is rejected."""
+    with pytest.raises(ValueError, match="stability_threshold"):
+        compute_flakiness_audit([_rec("s1", "ppo", 0, 1)], stability_threshold=1.5)

--- a/tests/test_cli_flakiness_audit.py
+++ b/tests/test_cli_flakiness_audit.py
@@ -72,3 +72,25 @@ def test_cli_flakiness_audit_missing_input_fails_closed(tmp_path: Path):
     )
     assert rc == 2
     assert not out_json.exists()
+
+
+def test_cli_flakiness_audit_rejects_nonpositive_min_seeds(tmp_path: Path):
+    """The CLI rejects a semantic configuration that removes the evidence floor."""
+    episodes = tmp_path / "episodes.jsonl"
+    _write_episodes(episodes)
+    out_json = tmp_path / "flakiness.json"
+
+    rc = cli_main(
+        [
+            "flakiness-audit",
+            "--in",
+            str(episodes),
+            "--out",
+            str(out_json),
+            "--min-seeds",
+            "0",
+        ],
+    )
+
+    assert rc == 2
+    assert not out_json.exists()

--- a/tests/test_cli_flakiness_audit.py
+++ b/tests/test_cli_flakiness_audit.py
@@ -1,0 +1,74 @@
+"""CLI tests for the ``flakiness-audit`` benchmark subcommand (issue #4978)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.cli import cli_main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_episodes(path: Path) -> None:
+    """Write a small episode JSONL with one stable and one knife-edge cell."""
+    records = [
+        # s1/ppo: unanimous success -> stable
+        {"scenario_id": "s1", "algo": "ppo", "seed": 0, "metrics": {"success": 1}},
+        {"scenario_id": "s1", "algo": "ppo", "seed": 1, "metrics": {"success": 1}},
+        # s2/ppo: 50/50 split across seeds -> knife-edge
+        {"scenario_id": "s2", "algo": "ppo", "seed": 0, "metrics": {"success": 1}},
+        {"scenario_id": "s2", "algo": "ppo", "seed": 1, "metrics": {"success": 0}},
+    ]
+    with path.open("w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+
+
+def test_cli_flakiness_audit_writes_report(tmp_path: Path, capsys):
+    """The subcommand loads JSONL, scores cells, and writes a JSON report."""
+    episodes = tmp_path / "episodes.jsonl"
+    _write_episodes(episodes)
+    out_json = tmp_path / "flakiness.json"
+
+    rc = cli_main(
+        [
+            "flakiness-audit",
+            "--in",
+            str(episodes),
+            "--out",
+            str(out_json),
+            "--group-by",
+            "algo",
+        ],
+    )
+    cap = capsys.readouterr()
+    assert rc == 0, f"flakiness-audit failed: {cap.err}"
+
+    report = json.loads(out_json.read_text(encoding="utf-8"))
+    assert report["schema_version"] == "scenario_flakiness.v1"
+    assert report["summary"]["n_cells"] == 2
+    assert report["summary"]["n_knife_edge_cells"] == 1
+    # No exact-repeat data present -> determinism unknown, fail closed.
+    assert report["exact_repeat"]["is_deterministic"] is None
+
+    by_key = {c["cell_key"]: c for c in report["cells"]}
+    assert by_key["s1::ppo"]["knife_edge"] is False
+    assert by_key["s2::ppo"]["knife_edge"] is True
+
+
+def test_cli_flakiness_audit_missing_input_fails_closed(tmp_path: Path):
+    """A missing input path fails closed with a non-zero exit code."""
+    out_json = tmp_path / "flakiness.json"
+    rc = cli_main(
+        [
+            "flakiness-audit",
+            "--in",
+            str(tmp_path / "does_not_exist.jsonl"),
+            "--out",
+            str(out_json),
+        ],
+    )
+    assert rc == 2
+    assert not out_json.exists()


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** New `robot_sf/benchmark/scenario_flakiness.py` (`compute_flakiness_audit`, schema `scenario_flakiness.v1`) and a `robot_sf_bench flakiness-audit` CLI subcommand that measure scenario outcome flakiness from existing episode JSONL — **exact-repeat determinism** and **per-cell outcome-stability** — and flag knife-edge cells.
- **Why now:** Issue #4978, Phase 4 benchmark robustness. Scenario-level outcome flakiness is currently unmeasured; empirical driving-sim work (Osikowicz et al. 2025) found ~31% of scenarios flaky under exact repetition. Knife-edge cells carry hidden variance that per-seed CIs understate.
- **Claim boundary:** New **advisory, read-only** diagnostic capability. It emits a schema-versioned report and does **not** change rankings, campaign summaries, or any benchmark metric semantics. No benchmark campaign was run; validated on synthetic and CPU fixtures only.
- **Required validation:** `ruff check` (clean) + focused unit/CLI tests (14 new, all pass) + existing benchmark-CLI regression tests (5 pass) + end-to-end CLI smoke.
- **Remaining blocker:** None for the coded slice. Applying the audit to a real release-scale campaign is compute-only follow-up work (out of scope here).

Delivers all three items of the maintainer implementation plan in one end-to-end slice: (1) a flakiness audit mode in the benchmark CLI with N-repetition exact-repeat determinism; (2) a per-cell stability score with knife-edge flagging; (3) the audit doubles as a non-determinism detector.

## Contract delta

- **New module/schema:** `scenario_flakiness.v1` report with:
  - `exact_repeat`: `checked_repeat_groups`, `nondeterministic_repeat_groups`, `is_deterministic` (`true`/`false`/**`null` when no repeat data**), and up to 25 concrete `examples`.
  - `cells[]`: per `(scenario, planner)` cell — `stability_score` (majority-agreement fraction in `[0.5, 1.0]`), `success_rate`, `knife_edge`, `assessable`, `n_seeds`, `outcome_counts`, `nondeterministic_seeds`.
  - `summary`: `n_cells`, `n_assessable_cells`, `n_knife_edge_cells`, `knife_edge_fraction`, missing-record counters.
- **New fail-closed blockers:** empty record set raises `ValueError`; the CLI handler returns exit code 2. Cells below `--min-seeds` (default 2) are reported `assessable=false` and are **not** counted as stable or knife-edge. Determinism is reported as `null` (unknown) rather than asserted when no exact-repeat data exists.
- **Compatibility impact:** additive only. New CLI subcommand `flakiness-audit`; no existing subcommand, schema, or metric changed. Existing benchmark-CLI regression tests still pass.

## Scope

- **In scope:** analysis module + CLI subcommand + tests + CHANGELOG.
- **Out of scope (explicit):** no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no change to ranking/summary/metric semantics.

### Key design assumptions (reversible)
- **Outcome metric** defaults to `success` (already 0/1 in episode records); configurable via `--outcome-metric`. Non-numeric/NaN/missing outcomes are counted, not guessed.
- **Stability score** = fraction of seeds agreeing with the majority outcome (`max(p, 1-p)`, range `[0.5, 1.0]`, 1.0 == unanimous). `knife_edge` = score `< --stability-threshold` (default 0.8, strict less-than).
- **Within-seed repeats** collapse to one cross-seed vote by majority (ties → 1), so exact-repeat non-determinism (a reproducibility signal) is tracked separately from across-seed stability.

### Known limitation
- The audit groups by `(scenario, planner)` via `--group-by`/`--fallback-group-by` but does **not** implement the `--observation-track-mode` cross-track fail-closed behavior of the aggregate/report CLIs. Auditing episode JSONL that mixes `benchmark_track` values is a caveat; run per-track for clean stability numbers. Tracked by #5072.

## Validation

Run in an isolated worktree venv (`uv sync --all-extras`):

```
ruff check robot_sf/benchmark/scenario_flakiness.py robot_sf/benchmark/cli.py \
  tests/benchmark/test_scenario_flakiness.py tests/test_cli_flakiness_audit.py
# -> All checks passed!

python -m pytest tests/benchmark/test_scenario_flakiness.py tests/test_cli_flakiness_audit.py -q
# -> 14 passed

python -m pytest tests/test_cli_seed_variance.py \
  tests/benchmark/test_benchmark_cli_exception_boundaries.py -q
# -> 5 passed (no regression from cli.py edits)
```

End-to-end CLI smoke (`robot_sf_bench flakiness-audit`) on a 5-record fixture with one within-seed flip and one 50/50 cell correctly reported `is_deterministic=false`, one stable cell (`stability=1.0`), one knife-edge cell (`stability=0.5`, `knife_edge=true`), `knife_edge_fraction=0.5`.

## Closure status — partial

This PR delivers the full **audit capability** (all three plan items as code) but not the empirical application. Remaining work (separate, mostly compute-only):

- [ ] Run `flakiness-audit` on a real/recent campaign to identify actually knife-edge archetypes (compute-only; out of scope here).
- [ ] Optional: surface the per-cell stability score inside the existing `summary`/`aggregate` outputs (I emit a standalone `scenario_flakiness.v1` report instead, to avoid touching benchmark metric semantics before the evidence freeze).
- [ ] If a real campaign shows `is_deterministic=false`, open a dedicated reproducibility-bug fix (the audit is the detector, not the fix).

## Downstream propagation

Low-churn issue (0 prior PRs in 24h). State surface: this PR body is the canonical status; a compact status note will follow on issue #4978. No transient queue-routing state is written to tracked files.

Refs #4978

🤖 Generated with [Claude Code](https://claude.com/claude-code)
