### PR TITLE
Issue #4993: RobotSfError base + re-parent benchmark errors (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/errors.py
+++ b/robot_sf/benchmark/errors.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from robot_sf.errors import RobotSfError
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
 
-class AggregationMetadataError(ValueError):
+class AggregationMetadataError(RobotSfError, ValueError):
     """Raised when algorithm metadata required for aggregation is missing or invalid."""
 
     def __init__(
@@ -44,7 +46,7 @@ class AggregationMetadataError(ValueError):
         return payload
 
 
-class EpisodeRecordInputError(ValueError):
+class EpisodeRecordInputError(RobotSfError, ValueError):
     """Raised when benchmark episode JSONL input is missing or malformed."""
 
 

--- a/robot_sf/errors.py
+++ b/robot_sf/errors.py
@@ -1,0 +1,34 @@
+"""Shared exception hierarchy for the ``robot_sf`` package.
+
+This module defines :class:`RobotSfError`, the common base for the ad-hoc
+``*Error`` / ``*Exception`` classes scattered across subpackages. Migrating
+those onto a shallow, catchable hierarchy lets callers (and the broad-except
+narrowing work in #4880) target ``except RobotSfError`` instead of a bare
+``except Exception``.
+
+Behavior-preservation principle
+-------------------------------
+Re-parenting an exception onto :class:`RobotSfError` is behavior-preserving
+only when the MRO still makes every existing ``except`` clause match. A class
+that previously inherited a builtin (for example ``ValueError``) becomes
+``class FooError(RobotSfError, ValueError)`` so that existing
+``except ValueError`` and ``except FooError`` sites keep catching it. Any
+re-parent that would stop an existing ``except`` from matching is out of scope
+for this slice.
+
+See issue #4993.
+"""
+
+from __future__ import annotations
+
+__all__ = ["RobotSfError"]
+
+
+class RobotSfError(Exception):
+    """Base class for all ``robot_sf`` exception types.
+
+    Subpackages should re-parent their ad-hoc errors onto this base while
+    preserving any existing builtin ancestry (e.g.
+    ``class FooError(RobotSfError, ValueError)``) so that existing ``except``
+    clauses keep matching.
+    """

--- a/tests/benchmark/test_robot_sf_error_base.py
+++ b/tests/benchmark/test_robot_sf_error_base.py
@@ -1,0 +1,106 @@
+"""Contract tests for the shared ``RobotSfError`` base (#4993).
+
+These tests pin the behavior-preservation contract described in issue #4993:
+
+* ``RobotSfError`` is an ``Exception`` subclass.
+* The re-parented benchmark exceptions are *both* ``RobotSfError`` and
+  ``ValueError`` subclasses, so existing ``except ValueError`` /
+  ``except <SpecificError>`` clauses still catch them while new code can also
+  target ``except RobotSfError``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.errors import (
+    AggregationMetadataError,
+    EpisodeRecordInputError,
+)
+from robot_sf.errors import RobotSfError
+
+
+class TestRobotSfErrorBase:
+    """The base exception class itself."""
+
+    def test_robot_sf_error_is_exception_subclass(self) -> None:
+        assert issubclass(RobotSfError, Exception)
+
+    def test_robot_sf_error_can_be_raised_and_caught(self) -> None:
+        with pytest.raises(RobotSfError):
+            raise RobotSfError("boom")
+
+    def test_robot_sf_error_is_not_caught_by_value_error(self) -> None:
+        # The plain base must not accidentally be a ValueError subclass; the
+        # benchmark classes opt into that ancestry explicitly.
+        assert not issubclass(RobotSfError, ValueError)
+
+
+class TestAggregationMetadataErrorContract:
+    """``AggregationMetadataError`` keeps its ValueError MRO after re-parenting."""
+
+    def test_is_robot_sf_error_subclass(self) -> None:
+        assert issubclass(AggregationMetadataError, RobotSfError)
+
+    def test_remains_value_error_subclass(self) -> None:
+        assert issubclass(AggregationMetadataError, ValueError)
+
+    def test_dual_isinstance(self) -> None:
+        err = AggregationMetadataError("missing algo metadata")
+        assert isinstance(err, RobotSfError)
+        assert isinstance(err, ValueError)
+
+    def test_raised_instance_caught_by_robot_sf_error(self) -> None:
+        with pytest.raises(RobotSfError):
+            raise AggregationMetadataError("missing algo metadata")
+
+    def test_raised_instance_caught_by_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            raise AggregationMetadataError("missing algo metadata")
+
+    def test_raised_instance_caught_by_own_type(self) -> None:
+        with pytest.raises(AggregationMetadataError):
+            raise AggregationMetadataError("missing algo metadata")
+
+    def test_mro_value_error_precedes_robot_sf_error(self) -> None:
+        # Re-parenting to (RobotSfError, ValueError) is behavior-preserving
+        # because ValueError stays in the MRO. Assert the builtin is present.
+        assert ValueError in AggregationMetadataError.__mro__
+
+    def test_init_context_preserved(self) -> None:
+        err = AggregationMetadataError(
+            "missing algo metadata",
+            episode_id="ep-1",
+            missing_fields=["algo"],
+            advice="regenerate the episode",
+        )
+        assert err.episode_id == "ep-1"
+        assert err.missing_fields == ("algo",)
+        assert err.advice == "regenerate the episode"
+
+
+class TestEpisodeRecordInputErrorContract:
+    """``EpisodeRecordInputError`` keeps its ValueError MRO after re-parenting."""
+
+    def test_is_robot_sf_error_subclass(self) -> None:
+        assert issubclass(EpisodeRecordInputError, RobotSfError)
+
+    def test_remains_value_error_subclass(self) -> None:
+        assert issubclass(EpisodeRecordInputError, ValueError)
+
+    def test_dual_isinstance(self) -> None:
+        err = EpisodeRecordInputError("malformed jsonl")
+        assert isinstance(err, RobotSfError)
+        assert isinstance(err, ValueError)
+
+    def test_raised_instance_caught_by_robot_sf_error(self) -> None:
+        with pytest.raises(RobotSfError):
+            raise EpisodeRecordInputError("malformed jsonl")
+
+    def test_raised_instance_caught_by_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            raise EpisodeRecordInputError("malformed jsonl")
+
+    def test_raised_instance_caught_by_own_type(self) -> None:
+        with pytest.raises(EpisodeRecordInputError):
+            raise EpisodeRecordInputError("malformed jsonl")


### PR DESCRIPTION
## What

Implements the bounded first slice of #4993: introduce a shared `RobotSfError` base exception and re-parent the two exceptions in `robot_sf/benchmark/errors.py` onto it, **without changing which exceptions any current `except` clause catches**. This gives the broad-except narrowing work (#4880) typed, catchable targets (e.g. `except RobotSfError`) instead of bare `Exception`.

## Why

Today there is no shared base (`grep 'class RobotSfError' robot_sf/` returned nothing) and each subpackage rolls its own error classes. A shallow, catchable hierarchy lets future narrowing land on `except RobotSfError` cleanly. This slice only *adds* a base and re-parents a bounded set; it does not touch `except` clauses that #4880 owns.

## Changes

1. **`robot_sf/errors.py`** (new): defines `class RobotSfError(Exception)` with a docstring, the behavior-preservation principle, and `__all__ = ["RobotSfError"]`.
2. **`robot_sf/benchmark/errors.py`**: re-parent the two exceptions to also inherit `RobotSfError` while keeping the `ValueError` MRO position:
   - `class AggregationMetadataError(RobotSfError, ValueError)`
   - `class EpisodeRecordInputError(RobotSfError, ValueError)`
3. **`tests/benchmark/test_robot_sf_error_base.py`** (new): contract tests for the dual-isinstance / dual-catch behavior.

### Behavior preservation (critical)

Re-parenting to `(RobotSfError, ValueError)` is behavior-preserving because the MRO still makes every existing `except` clause match. Concretely:

- `issubclass(AggregationMetadataError, ValueError)` stays `True` → existing `except ValueError` sites (e.g. `robot_sf/benchmark/cli.py` catches `(EpisodeRecordInputError, OSError, TypeError, ValueError)`) are unaffected.
- `issubclass(*Error, RobotSfError)` is now also `True` → new `except RobotSfError` catches them too.
- No `except` clause is changed in this slice.

## Validation (CPU only)

No campaigns, Slurm, training runs, or benchmark/paper claims. Run in an isolated worktree off `origin/main` via `scripts/dev/run_worktree_shared_venv.sh --no-freshness-check` (the pysocialforce freshness guard flagged an unrelated `config.py` drift; these exception-base tests do not import pysocialforce, confirmed by the green run below).

Issue's exact test command:
```
uv run pytest tests/benchmark/ -q -k "error or aggregation or exception"
```
Result: **65 passed, 4148 deselected in 14.27s** (includes all existing `pytest.raises(AggregationMetadataError)` / `EpisodeRecordInputError` sites).

New contract test:
```
uv run pytest tests/benchmark/test_robot_sf_error_base.py -q
```
Result: **17 passed**.

Characterization baselines referenced by the issue (must stay green):
```
uv run pytest tests/benchmark/test_aggregate_characterization.py tests/test_aggregate.py tests/test_summary.py -q
```
Result: **63 passed**.

Lint / format / type:
```
ruff check <changed files>          -> All checks passed!
ruff format --check <changed files> -> 3 files already formatted
mypy robot_sf/errors.py robot_sf/benchmark/errors.py -> Success: no issues found in 2 source files
```

## Scope / slicing

This PR fully delivers the bounded first slice defined in the issue body (steps 1–3 of "Bounded first slice"): the `RobotSfError` base exists, the `benchmark/errors.py` classes inherit `RobotSfError` while remaining `ValueError` subclasses, and a test proves both `except RobotSfError` and `except ValueError` still catch instances. The remaining ~90 ad-hoc error classes migrate in follow-up PRs on this issue, subpackage by subpackage (explicitly out of scope per the issue).

Successor statement: this is the initial slice of #4993; no prior PRs merged slices of this issue, so it does not duplicate any PR.

## Acceptance criteria

- [x] `robot_sf/errors.py` with `RobotSfError` exists.
- [x] `benchmark/errors.py` classes inherit `RobotSfError` while remaining `ValueError` subclasses (MRO unchanged for existing catches).
- [x] New test proves both `except RobotSfError` and `except ValueError` still catch instances.
- [x] Lint + typecheck clean.

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Refs #4993

