### PR TITLE
Issue #4995: normalize except (ImportError, ModuleNotFoundError) to except ImportError (cheap-lane worker)

### DIFF
--- a/robot_sf/adversarial/samplers.py
+++ b/robot_sf/adversarial/samplers.py
@@ -227,7 +227,7 @@ def _import_optuna() -> Any:
     """Import Optuna or raise an actionable optional-dependency error."""
     try:
         return import_module("optuna")
-    except (ImportError, ModuleNotFoundError) as exc:
+    except ImportError as exc:
         raise RuntimeError(
             "OptunaCandidateSampler requires optuna. Install project dependencies with "
             "`uv sync --all-extras` before using the optimizer-backed adversarial sampler."

--- a/robot_sf/benchmark/distributions.py
+++ b/robot_sf/benchmark/distributions.py
@@ -128,7 +128,7 @@ def _maybe_kde(ax, data: np.ndarray, color: str) -> None:
             alpha=0.8,
             linewidth=1.0,
         )
-    except (ImportError, ModuleNotFoundError):
+    except ImportError:
         # scipy optional; silently skip KDE if unavailable
         pass
     except (TypeError, ValueError):

--- a/robot_sf/benchmark/full_classic/visual_deps.py
+++ b/robot_sf/benchmark/full_classic/visual_deps.py
@@ -55,7 +55,7 @@ def simulation_view_ready() -> bool:  # T030
         try:
             logger = importlib.import_module("loguru").logger
             logger.debug("simulation_view_ready probe failed: %s", exc)
-        except (ImportError, ModuleNotFoundError):
+        except ImportError:
             # If logger import fails, silently ignore to remain graceful
             pass
         return False

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -38,7 +38,7 @@ from loguru import logger
 
 try:
     from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
-except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     ImageSequenceClip = None  # type: ignore[assignment]
 
 try:

--- a/robot_sf/benchmark/visualization.py
+++ b/robot_sf/benchmark/visualization.py
@@ -1186,7 +1186,7 @@ def _episode_record_to_replay_episode(episode: dict):
     """
     try:
         ReplayEpisode, ReplayStep = _load_replay_types()
-    except (ImportError, ModuleNotFoundError) as exc:
+    except ImportError as exc:
         raise VisualizationError("ReplayEpisode not available", "video") from exc
 
     episode_id = episode["episode_id"]

--- a/robot_sf/gym_env/environment_factory.py
+++ b/robot_sf/gym_env/environment_factory.py
@@ -54,7 +54,7 @@ try:  # pragma: no cover - import errors would surface in tests
 
     # Intentionally do NOT import robot_env_with_image here to avoid heavy first-call cost.
     RobotEnvWithImage = None  # type: ignore
-except (ImportError, ModuleNotFoundError):
+except ImportError:
     # Defer errors until factory invocation (lazy fallback)
     RobotEnv = None  # type: ignore
     RobotEnvWithImage = None  # type: ignore
@@ -172,7 +172,7 @@ def _optional_import(module_name: str):
     """
     try:
         return importlib.import_module(module_name)
-    except (ImportError, ModuleNotFoundError):
+    except ImportError:
         return None
 
 

--- a/robot_sf/models/registry.py
+++ b/robot_sf/models/registry.py
@@ -16,7 +16,7 @@ from loguru import logger
 
 try:  # pragma: no cover - optional dependency
     import wandb  # type: ignore
-except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     wandb = None  # type: ignore[assignment]
 
 DEFAULT_REGISTRY_PATH = Path("model/registry.yaml")

--- a/robot_sf/planner/socnav.py
+++ b/robot_sf/planner/socnav.py
@@ -23,24 +23,26 @@ from loguru import logger
 from robot_sf.common.forecast_variants import FORECAST_VARIANT_CHOICES
 from robot_sf.common.math_utils import wrap_angle_pi, wrap_angle_pi_closed
 
+# Convention: optional-import guards catch ImportError only (ModuleNotFoundError is a
+# subclass); bind the exception as `exc` for consistency across the codebase.
 try:  # pragma: no cover - optional dependency
     import torch
-except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     torch = None  # type: ignore[assignment]
 
 try:  # pragma: no cover - optional dependency
     import tensorflow.compat.v1 as tf  # type: ignore
-except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     tf = None  # type: ignore[assignment]
 
 try:  # pragma: no cover - optional dependency
     import rvo2  # type: ignore
-except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     rvo2 = None  # type: ignore[assignment]
 
 try:  # pragma: no cover - optional dependency
     from pysocialforce import forces as sf_forces  # type: ignore
-except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     sf_forces = None  # type: ignore[assignment]
 
 from robot_sf.models import resolve_model_path
@@ -64,7 +66,7 @@ try:  # pragma: no cover - exercised in minimal environments without torch
         PredictiveTrajectoryModel,
         load_predictive_checkpoint,
     )
-except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     PredictiveTrajectoryModel = Any  # type: ignore[misc,assignment]
     load_predictive_checkpoint = None  # type: ignore[assignment]
 from robot_sf.planner.socnav_occupancy import OccupancyAwarePlannerMixin
@@ -3464,7 +3466,7 @@ class PredictionPlannerAdapter(SamplingPlannerAdapter):
             raise RuntimeError(
                 f"PredictionPlannerAdapter: forecast predictor initialization failed for {variant!r}"
             ) from exc
-        except (ImportError, ModuleNotFoundError) as exc:
+        except ImportError as exc:
             logger.warning(
                 f"PredictionPlannerAdapter: forecast predictor unavailable for {variant!r}: {exc}"
             )

--- a/tests/fixtures/optional_import_guards.json
+++ b/tests/fixtures/optional_import_guards.json
@@ -16,7 +16,7 @@
       "note": "Blessed broad catch: compiled-backend entry point may raise AttributeError when a native wheel component is absent.",
       "samples": [
         "robot_sf/baselines/sicnav.py:376",
-        "robot_sf/planner/socnav.py:777"
+        "robot_sf/planner/socnav.py:779"
       ]
     },
     "AttributeError+ImportError+IndexError+KeyError+OSError+RuntimeError+TypeError+ValueError": {
@@ -46,7 +46,7 @@
       "blessed": true,
       "note": "Blessed broad catch: defensive best-effort boundary. Very broad; do not extend further without strong justification.",
       "samples": [
-        "robot_sf/planner/socnav.py:642"
+        "robot_sf/planner/socnav.py:644"
       ]
     },
     "AttributeError+ImportError+OSError": {
@@ -90,13 +90,14 @@
       ]
     },
     "ImportError": {
-      "count_ceiling": 57,
-      "has_as_count": 11,
-      "pragma_no_cover_count": 17,
+      "count_ceiling": 71,
+      "has_as_count": 14,
+      "pragma_no_cover_count": 24,
       "blessed": true,
       "note": "Pure optional-import. Prefer robot_sf.common.optional_import.try_import for new plain cases.",
       "samples": [
         "robot_sf/adversarial/certification.py:99",
+        "robot_sf/adversarial/samplers.py:230",
         "robot_sf/baselines/dr_mpc.py:109",
         "robot_sf/baselines/dr_mpc.py:91",
         "robot_sf/baselines/drl_vo.py:24",
@@ -105,6 +106,7 @@
         "robot_sf/baselines/sicnav.py:420",
         "robot_sf/baselines/sicnav.py:298",
         "robot_sf/benchmark/cli.py:191",
+        "robot_sf/benchmark/distributions.py:131",
         "robot_sf/benchmark/episode_replay_figure.py:37",
         "robot_sf/benchmark/episode_replay_figure.py:50",
         "robot_sf/benchmark/episode_replay_figure.py:57",
@@ -125,26 +127,38 @@
         "robot_sf/benchmark/full_classic/videos.py:34",
         "robot_sf/benchmark/full_classic/visual_deps.py:79",
         "robot_sf/benchmark/full_classic/visual_deps.py:93",
+        "robot_sf/benchmark/full_classic/visual_deps.py:58",
         "robot_sf/benchmark/full_classic/visuals.py:49",
         "robot_sf/benchmark/helper_catalog.py:73",
         "robot_sf/benchmark/live_forecast_replay_gate.py:953",
         "robot_sf/benchmark/plots.py:28",
+        "robot_sf/benchmark/runner.py:41",
         "robot_sf/benchmark/runner.py:47",
         "robot_sf/benchmark/scenario_generator.py:48",
         "robot_sf/benchmark/scenario_schema.py:25",
         "robot_sf/benchmark/schema_validator.py:20",
+        "robot_sf/benchmark/visualization.py:1189",
         "robot_sf/common/matplotlib_utils.py:62",
         "robot_sf/common/optional_import.py:80",
         "robot_sf/common/seed.py:47",
         "robot_sf/feature_extractors/mamba_extractor.py:98",
         "robot_sf/gym_env/env_config.py:302",
+        "robot_sf/gym_env/environment_factory.py:57",
+        "robot_sf/gym_env/environment_factory.py:175",
         "robot_sf/maps/osm_zones_editor.py:72",
+        "robot_sf/models/registry.py:19",
         "robot_sf/nav/occupancy_grid.py:107",
         "robot_sf/planner/classic_global_planner.py:47",
         "robot_sf/planner/diffusion_policy.py:20",
         "robot_sf/planner/ompl_geometric_adapter.py:193",
         "robot_sf/planner/ompl_smoke.py:42",
         "robot_sf/planner/ompl_smoke.py:252",
+        "robot_sf/planner/socnav.py:30",
+        "robot_sf/planner/socnav.py:35",
+        "robot_sf/planner/socnav.py:40",
+        "robot_sf/planner/socnav.py:45",
+        "robot_sf/planner/socnav.py:69",
+        "robot_sf/planner/socnav.py:3469",
         "robot_sf/planner/theta_star_v2.py:33",
         "robot_sf/render/sim_view.py:34",
         "robot_sf/sim/registry.py:145",
@@ -153,29 +167,6 @@
         "robot_sf/telemetry/tensorboard_adapter.py:23",
         "robot_sf/telemetry/visualization.py:100",
         "robot_sf/training/diffusion_policy.py:33"
-      ]
-    },
-    "ImportError+ModuleNotFoundError": {
-      "count_ceiling": 14,
-      "has_as_count": 3,
-      "pragma_no_cover_count": 7,
-      "blessed": true,
-      "note": "Optional-import covering both ImportError spellings; acceptable. Prefer try_import for new plain cases.",
-      "samples": [
-        "robot_sf/adversarial/samplers.py:230",
-        "robot_sf/benchmark/distributions.py:131",
-        "robot_sf/benchmark/full_classic/visual_deps.py:58",
-        "robot_sf/benchmark/runner.py:41",
-        "robot_sf/benchmark/visualization.py:1189",
-        "robot_sf/gym_env/environment_factory.py:57",
-        "robot_sf/gym_env/environment_factory.py:175",
-        "robot_sf/models/registry.py:19",
-        "robot_sf/planner/socnav.py:28",
-        "robot_sf/planner/socnav.py:33",
-        "robot_sf/planner/socnav.py:38",
-        "robot_sf/planner/socnav.py:43",
-        "robot_sf/planner/socnav.py:67",
-        "robot_sf/planner/socnav.py:3467"
       ]
     },
     "ImportError+OSError": {


### PR DESCRIPTION
## What / Why

Implements the bounded first slice of #4995 (part of #4770): collapse the **provably-equivalent** `except (ImportError, ModuleNotFoundError)` optional-import guards onto the canonical `except ImportError`, **without changing which import failures are tolerated**.

`ModuleNotFoundError` is a subclass of `ImportError`, so `except ImportError` already catches it — the pair spelling is pure redundancy. This is a mechanical, behavior-preserving spelling change.

### Scope (exactly the issue's acceptance boundary)

- The **14** sites spelled `except (ImportError, ModuleNotFoundError)` → normalized to `except ImportError`.
  - 11 bare (`:`) sites.
  - 3 `... as exc:` variants → `except ImportError as exc:` (binding name `exc` preserved, consistent with the converge-to-`as exc` convention).
- Files touched (8 source files):
  - `robot_sf/planner/socnav.py` (6 sites), `robot_sf/gym_env/environment_factory.py` (2 sites),
  - `robot_sf/adversarial/samplers.py`, `robot_sf/benchmark/distributions.py`,
  - `robot_sf/benchmark/full_classic/visual_deps.py`, `robot_sf/benchmark/runner.py`,
  - `robot_sf/benchmark/visualization.py`, `robot_sf/models/registry.py` (1 site each).
- **Not touched (correctly preserved):** every compound guard involving a non-`ImportError` type — the `RuntimeError`/`OSError`/`SyntaxError`/`AttributeError` variants, including the 3-type `except (ImportError, ModuleNotFoundError, AttributeError)` guard at `robot_sf/gym_env/snqi_proxy.py:139`. None of these appear in the diff. The bare `except ModuleNotFoundError:` sites (6) are also out of scope for this slice.
- Adopted a **one-line convention comment** on the canonical module-level guard in `socnav.py`, anchoring the convention for follow-up slices to converge `as e` → `as exc`.

### Optional-dependency fallbacks unchanged

No `X = None` fallback, `# type: ignore`, or `# pragma` semantics changed; only the caught-type-set spelling on the 14 lines.

## Validation

Exact issue test command:
`uv run pytest tests/ -q -k "import or optional or doctor or extras"` → **175 passed, 13432 deselected** (incl. both `test_optional_import_guard_inventory.py` ratchet tests).

```
175 passed, 13432 deselected, 1 warning in 71.77s
```

Lint/format on all changed source files:
```
uv run ruff check <8 source files>   -> All checks passed!
uv run ruff format --check <8 files> -> 8 files already formatted
```

Module import check (with full venv, optional backends present):
```
import robot_sf.planner.socnav / benchmark.runner / benchmark.distributions /
       benchmark.full_classic.visual_deps / gym_env.environment_factory /
       models.registry / adversarial.samplers   -> all import cleanly
```

The #4956 ty optional-dep suppression test (`tests/dev/test_issue_4956_ty_optional_dep_suppressions.py`) passed within the `-k` selection.

### Snapshot regeneration (mechanical, sanctioned path)

This slice intentionally moves 14 guards out of the `ImportError+ModuleNotFoundError` bucket into the `ImportError` bucket. The AST inventory ratchet (`tests/test_optional_import_guard_inventory.py`, issue #4990) enforces exact equality against `tests/fixtures/optional_import_guards.json`, so the fixture was regenerated with the sanctioned script `scripts/dev/generate_optional_import_snapshot.py`:

| spelling | ceiling before | ceiling after |
| --- | --- | --- |
| `ImportError` | 57 | **71** (has_as_count 11 → 14, pragma 17 → 24) |
| `ImportError+ModuleNotFoundError` | 14 | **0** (removed from snapshot) |

`total_guards` is **unchanged at 100** — confirming this is a pure spelling change with no guard added or removed. Distinct spellings drop 16 → 15. All other (blessed broad-catch) ceilings are unchanged.

## Classification (research/evidence block: NA)

This is a refactor / technical-debt slice with no research, benchmark, metric, schema, or paper-facing claim.
- Target claim/hypothesis: NA (refactor).
- Comparator/baseline: NA.
- Evidence tier: characterization-test + AST inventory ratchet (static behavior preservation; `ModuleNotFoundError` subclass relationship guarantees identical catch behavior).
- Result classification: refactor, behavior-preserving.
- Decision/stop rule: acceptance criteria of #4995 met (all 14 sites normalized; no non-ImportError compound guard modified; fallbacks unchanged; lint + tests clean).
- Synthesis/update target: enables a future follow-up slice to converge the remaining `as e` naming and review the intentionally-broad `RuntimeError`/`OSError`/`SyntaxError`/`AttributeError` guards separately.

## Downstream propagation

NA — no durable artifacts, no `output/` produced, no benchmark/metric/provenance surface changed. Worktree-local `.venv` was created for validation only and is not tracked.

## Successor statement

This is the **first** PR for #4995; no prior PRs targeted this issue (the merged `#5052` targeted a different issue, #5004). This slice fully delivers the issue's stated bounded first slice. Remaining (separate, deliberately out-of-scope) follow-ups, to be tracked as new issues rather than here:
- converge the bare `except ModuleNotFoundError:` (6 sites) and the `as e` alias naming onto `as exc`;
- a separately-reviewed pass over the intentionally-broad `RuntimeError`/`OSError`/`SyntaxError`/`AttributeError` compound guards (these change semantics and must not be collapsed).

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Closes #4995