### PR TITLE
Issue #4989: extract SimViewTextOverlay (bounded first slice) (cheap-lane worker)

### DIFF
--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -15,7 +15,6 @@ import numpy as np
 import pygame
 from loguru import logger
 
-from robot_sf.common.geometry import euclid_dist
 from robot_sf.common.types import PedPose, RgbColor, RobotPose, Vec2D
 from robot_sf.nav.map_config import MapDefinition, Obstacle
 from robot_sf.nav.occupancy_grid import (
@@ -36,6 +35,8 @@ except ImportError:
     logger.warning(
         "MoviePy is not available. Video recording is disabled. Have you installed ffmpeg?",
     )
+
+from robot_sf.render.sim_view_text_overlay import SimViewTextOverlay
 
 ## Note: PYGAME_HIDE_SUPPORT_PROMPT is set before importing pygame above
 
@@ -305,6 +306,10 @@ class SimulationView:
             )
             pygame.display.set_caption(self.caption)
         self.font = pygame.font.Font(None, 36)
+        # Text-overlay collaborator (god-class split, see #4989/#4770). Held as
+        # an instance attribute and reached through delegating methods so the
+        # public/protected text-overlay surface stays on SimulationView.
+        self._text_overlay = SimViewTextOverlay(self)
         self._validate_render_modes()
 
     def _validate_render_modes(self) -> None:
@@ -1273,133 +1278,82 @@ class SimulationView:
     def _add_text(self, timestep: int, state: VisualizableSimState):
         """Render diagnostic overlay text for the current frame.
 
+        Delegates to the :class:`~robot_sf.render.sim_view_text_overlay.SimViewTextOverlay`
+        collaborator (god-class split, see #4989/#4770). Behavior is unchanged.
+        Kept as an overridable method so subclasses (e.g. ``InteractivePlayback``)
+        can extend it via ``super()._add_text(...)``.
+
         Args:
             timestep: Simulation step index shown in the overlay.
             state: Current visualizable state used to build display lines.
         """
-        info_lines = self._get_display_info_lines(state)
-        text_lines = self._build_text_lines(timestep, state, info_lines)
-        self._render_text_display(text_lines)
+        self._text_overlay._add_text(timestep, state)
 
     def _get_display_info_lines(self, state: VisualizableSimState) -> list[str]:
         """Get lines for robot/pedestrian info display based on display mode.
 
+        Delegates to the text-overlay collaborator; behavior is unchanged.
+
         Returns:
             list[str]: Info lines for robot (mode 1), pedestrian (mode 2), or empty (mode 0).
         """
-        if self.display_robot_info == 1:
-            return self._get_robot_info_lines(state)
-        elif self.display_robot_info == 2:
-            return self._get_pedestrian_info_lines(state)
-        return []
+        return self._text_overlay._get_display_info_lines(state)
 
     def _get_robot_info_lines(self, state: VisualizableSimState) -> list[str]:
         """Get robot information lines for display.
 
+        Delegates to the text-overlay collaborator; behavior is unchanged.
+
         Returns:
             list[str]: Robot pose, action, and goal info lines, or empty list if unavailable.
         """
-        if hasattr(state, "robot_action") and state.robot_action:
-            return [
-                f"RobotPose: {state.robot_pose}",
-                f"RobotAction: {state.robot_action.action if state.robot_action else None}",
-                f"RobotGoal: {state.robot_action.goal if state.robot_action else None}",
-            ]
-        return []
+        return self._text_overlay._get_robot_info_lines(state)
 
     def _get_pedestrian_info_lines(self, state: VisualizableSimState) -> list[str]:
         """Get pedestrian information lines for display.
 
+        Delegates to the text-overlay collaborator; behavior is unchanged.
+
         Returns:
             list[str]: Ego pedestrian pose, action, goal, and distance info, or empty list if unavailable.
         """
-        if self._has_pedestrian_data(state):
-            assert state.ego_ped_pose is not None, "ego_ped_pose must be set"
-            distance_to_robot = euclid_dist(state.ego_ped_pose[0], state.robot_pose[0])
-            assert state.ego_ped_action is not None, "ego_ped_action must be set"
-            return [
-                f"PedestrianPose: {state.ego_ped_pose}",
-                f"PedestrianAction: {state.ego_ped_action.action}",
-                f"PedestrianGoal: {state.ego_ped_action.goal}",
-                f"DistanceRobot: {distance_to_robot:.2f}",
-            ]
-        else:
-            self.display_robot_info = 0
-            return []
+        return self._text_overlay._get_pedestrian_info_lines(state)
 
     def _has_pedestrian_data(self, state: VisualizableSimState) -> bool:
         """Check if the state has complete pedestrian data.
 
+        Delegates to the text-overlay collaborator; behavior is unchanged.
+
         Returns:
             bool: True if state has valid ego_ped_pose and ego_ped_action.
         """
-        return bool(
-            hasattr(state, "ego_ped_pose")
-            and state.ego_ped_pose
-            and hasattr(state, "ego_ped_action")
-            and state.ego_ped_action
-        )
+        return self._text_overlay._has_pedestrian_data(state)
 
     def _build_text_lines(
         self, timestep: int, state: VisualizableSimState, info_lines: list[str]
     ) -> list[str]:
         """Build the complete list of text lines for display.
 
+        Delegates to the text-overlay collaborator; behavior is unchanged.
+
         Returns:
             list[str]: Combined list of timestep, scaling, speedup, and optional robot/ped info lines.
         """
-        # Calculate speedup factor safely
-        actual_fps = self.clock.get_fps()
-        time_per_step = getattr(state, "time_per_step_in_secs", 0.1)
-        speedup = actual_fps * time_per_step
-
-        text_lines = [
-            f"step: {timestep}",
-            f"scaling: {self.scaling}",
-        ]
-
-        # Add FPS and speedup information if not recording
-        if not self.record_video:
-            text_lines += [
-                f"target fps: {actual_fps:.1f}/{getattr(self, 'current_target_fps', 60):.1f}",
-                f"speedup: {speedup:.1f}x",
-            ]
-
-        text_lines += [
-            f"x-offset: {self.offset[0] / self.scaling:.2f}",
-            f"y-offset: {self.offset[1] / self.scaling:.2f}",
-        ]
-
-        text_lines += info_lines
-        text_lines += ["(Press h for help)"]
-        return text_lines
+        return self._text_overlay._build_text_lines(timestep, state, info_lines)
 
     def _render_text_display(self, text_lines: list[str]):
-        """Render the text display on screen."""
-        # Create a surface for the text background
-        max_width = max(self.font.size(line)[0] for line in text_lines)
-        text_height = len(text_lines) * self.font.get_linesize()
-        text_surface = pygame.Surface((max_width + 10, text_height + 10), pygame.SRCALPHA)
-        text_surface.fill(TEXT_BACKGROUND)
+        """Render the text display on screen.
 
-        for i, text in enumerate(text_lines):
-            self._render_text_line(text_surface, text, i)
-
-        self.screen.blit(text_surface, self._timestep_text_pos)
+        Delegates to the text-overlay collaborator; behavior is unchanged.
+        """
+        self._text_overlay._render_text_display(text_lines)
 
     def _render_text_line(self, surface, text: str, line_index: int):
-        """Render a single text line with outline effect."""
-        text_render = self.font.render(text, True, TEXT_COLOR)
-        text_outline = self.font.render(text, True, TEXT_OUTLINE_COLOR)
+        """Render a single text line with outline effect.
 
-        pos = (5, line_index * self.font.get_linesize() + 5)
-
-        # Draw text outline
-        for dx, dy in [(-1, -1), (-1, 1), (1, -1), (1, 1)]:
-            surface.blit(text_outline, (pos[0] + dx, pos[1] + dy))
-
-        # Draw main text
-        surface.blit(text_render, pos)
+        Delegates to the text-overlay collaborator; behavior is unchanged.
+        """
+        self._text_overlay._render_text_line(surface, text, line_index)
 
     def _add_minimal_hint(self):
         """Show a minimal hint when text display is disabled."""

--- a/robot_sf/render/sim_view_text_overlay.py
+++ b/robot_sf/render/sim_view_text_overlay.py
@@ -1,0 +1,193 @@
+"""Text/info-panel collaborator extracted from ``SimulationView``.
+
+This module is part of the god-class split of ``robot_sf/render/sim_view.py``
+(see issues #4770 / #4989 / characterization baseline #4965). It owns the
+text-overlay cluster: the surface-independent content builders
+(``_build_text_lines``, ``_get_display_info_lines``, ``_get_robot_info_lines``,
+``_get_pedestrian_info_lines``, ``_has_pedestrian_data``) plus the rendering
+methods (``_render_text_display``, ``_render_text_line``, ``_add_text``).
+
+Behavior is preserved verbatim from the pre-split ``SimulationView``: a
+``SimulationView`` holds a :class:`SimViewTextOverlay` instance and delegates
+the text-overlay methods to it. The collaborator reads shared render state
+(clock, font, screen, scaling, offset, recording flag, display mode) through a
+back-reference to its host view, so dynamic state stays authoritative on the
+host exactly as before the split. Public method signatures are unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pygame
+
+from robot_sf.common.geometry import euclid_dist
+
+# Text-overlay colors must match the pre-split constants in ``sim_view`` so the
+# rendered output is pixel-identical. They are duplicated here (rather than
+# imported) deliberately: the collaborator must not import the heavyweight
+# ``sim_view`` module (pygame init side effects, moviepy, map config) at import
+# time, which would create a circular import and re-trigger pygame startup.
+TEXT_COLOR = (255, 255, 255)  # White text
+TEXT_BACKGROUND = (0, 0, 0, 180)  # Semi-transparent black background
+TEXT_OUTLINE_COLOR = (0, 0, 0)  # Black outline
+
+if TYPE_CHECKING:
+    from robot_sf.render.sim_state import VisualizableSimState
+    from robot_sf.render.sim_view import SimulationView
+
+
+class SimViewTextOverlay:
+    """Text/info-panel collaborator for :class:`~robot_sf.render.sim_view.SimulationView`.
+
+    Owns the diagnostic text-overlay content builders and rendering. A single
+    instance is held by its host ``SimulationView`` (created in
+    ``__post_init__``) and reached through delegating methods on the host, so
+    existing call sites (including the ``InteractivePlayback`` subclass override
+    of ``_add_text`` and the #4965 characterization golden lines) keep working
+    unchanged.
+
+    Shared, mutable render state (``screen``, ``font``, ``clock``, ``scaling``,
+    ``offset``, ``record_video``, ``display_robot_info``, ``current_target_fps``)
+    is accessed through the ``host`` back-reference rather than copied, so the
+    host remains the single source of truth exactly as before the split.
+    """
+
+    def __init__(self, host: SimulationView) -> None:
+        """Bind the overlay to its host view.
+
+        The host back-reference is how the collaborator reaches shared, mutable
+        render state (screen, font, clock, scaling, offset, display mode).
+        """
+        self._host = host
+
+    def _add_text(self, timestep: int, state: VisualizableSimState) -> None:
+        """Render diagnostic overlay text for the current frame.
+
+        Args:
+            timestep: Simulation step index shown in the overlay.
+            state: Current visualizable state used to build display lines.
+        """
+        info_lines = self._get_display_info_lines(state)
+        text_lines = self._build_text_lines(timestep, state, info_lines)
+        self._render_text_display(text_lines)
+
+    def _get_display_info_lines(self, state: VisualizableSimState) -> list[str]:
+        """Get lines for robot/pedestrian info display based on display mode.
+
+        Returns:
+            list[str]: Info lines for robot (mode 1), pedestrian (mode 2), or empty (mode 0).
+        """
+        if self._host.display_robot_info == 1:
+            return self._get_robot_info_lines(state)
+        elif self._host.display_robot_info == 2:
+            return self._get_pedestrian_info_lines(state)
+        return []
+
+    def _get_robot_info_lines(self, state: VisualizableSimState) -> list[str]:
+        """Get robot information lines for display.
+
+        Returns:
+            list[str]: Robot pose, action, and goal info lines, or empty list if unavailable.
+        """
+        if hasattr(state, "robot_action") and state.robot_action:
+            return [
+                f"RobotPose: {state.robot_pose}",
+                f"RobotAction: {state.robot_action.action if state.robot_action else None}",
+                f"RobotGoal: {state.robot_action.goal if state.robot_action else None}",
+            ]
+        return []
+
+    def _get_pedestrian_info_lines(self, state: VisualizableSimState) -> list[str]:
+        """Get pedestrian information lines for display.
+
+        Returns:
+            list[str]: Ego pedestrian pose, action, goal, and distance info, or empty list if unavailable.
+        """
+        if self._has_pedestrian_data(state):
+            assert state.ego_ped_pose is not None, "ego_ped_pose must be set"
+            distance_to_robot = euclid_dist(state.ego_ped_pose[0], state.robot_pose[0])
+            assert state.ego_ped_action is not None, "ego_ped_action must be set"
+            return [
+                f"PedestrianPose: {state.ego_ped_pose}",
+                f"PedestrianAction: {state.ego_ped_action.action}",
+                f"PedestrianGoal: {state.ego_ped_action.goal}",
+                f"DistanceRobot: {distance_to_robot:.2f}",
+            ]
+        else:
+            self._host.display_robot_info = 0
+            return []
+
+    def _has_pedestrian_data(self, state: VisualizableSimState) -> bool:
+        """Check if the state has complete pedestrian data.
+
+        Returns:
+            bool: True if state has valid ego_ped_pose and ego_ped_action.
+        """
+        return bool(
+            hasattr(state, "ego_ped_pose")
+            and state.ego_ped_pose
+            and hasattr(state, "ego_ped_action")
+            and state.ego_ped_action
+        )
+
+    def _build_text_lines(
+        self, timestep: int, state: VisualizableSimState, info_lines: list[str]
+    ) -> list[str]:
+        """Build the complete list of text lines for display.
+
+        Returns:
+            list[str]: Combined list of timestep, scaling, speedup, and optional robot/ped info lines.
+        """
+        # Calculate speedup factor safely
+        actual_fps = self._host.clock.get_fps()
+        time_per_step = getattr(state, "time_per_step_in_secs", 0.1)
+        speedup = actual_fps * time_per_step
+
+        text_lines = [
+            f"step: {timestep}",
+            f"scaling: {self._host.scaling}",
+        ]
+
+        # Add FPS and speedup information if not recording
+        if not self._host.record_video:
+            text_lines += [
+                f"target fps: {actual_fps:.1f}/{getattr(self._host, 'current_target_fps', 60):.1f}",
+                f"speedup: {speedup:.1f}x",
+            ]
+
+        text_lines += [
+            f"x-offset: {self._host.offset[0] / self._host.scaling:.2f}",
+            f"y-offset: {self._host.offset[1] / self._host.scaling:.2f}",
+        ]
+
+        text_lines += info_lines
+        text_lines += ["(Press h for help)"]
+        return text_lines
+
+    def _render_text_display(self, text_lines: list[str]) -> None:
+        """Render the text display on screen."""
+        # Create a surface for the text background
+        max_width = max(self._host.font.size(line)[0] for line in text_lines)
+        text_height = len(text_lines) * self._host.font.get_linesize()
+        text_surface = pygame.Surface((max_width + 10, text_height + 10), pygame.SRCALPHA)
+        text_surface.fill(TEXT_BACKGROUND)
+
+        for i, text in enumerate(text_lines):
+            self._render_text_line(text_surface, text, i)
+
+        self._host.screen.blit(text_surface, self._host._timestep_text_pos)
+
+    def _render_text_line(self, surface, text: str, line_index: int) -> None:
+        """Render a single text line with outline effect."""
+        text_render = self._host.font.render(text, True, TEXT_COLOR)
+        text_outline = self._host.font.render(text, True, TEXT_OUTLINE_COLOR)
+
+        pos = (5, line_index * self._host.font.get_linesize() + 5)
+
+        # Draw text outline
+        for dx, dy in [(-1, -1), (-1, 1), (1, -1), (1, 1)]:
+            surface.blit(text_outline, (pos[0] + dx, pos[1] + dy))
+
+        # Draw main text
+        surface.blit(text_render, pos)

--- a/tests/render/test_sim_view_text_overlay.py
+++ b/tests/render/test_sim_view_text_overlay.py
@@ -1,0 +1,187 @@
+"""Focused tests for the ``SimViewTextOverlay`` collaborator (god-class split #4989).
+
+These complement the behavior-preservation golden lines in
+``test_sim_view_characterization.py`` (#4965), which pin the *delegating* surface
+on ``SimulationView``. Here we cover the split-specific contract directly:
+
+* the new collaborator module exists and is wired into ``SimulationView``;
+* delegation forwards every extracted method with identical results;
+* the host remains authoritative for shared mutable render state
+  (``display_robot_info`` is written back through the host back-reference);
+* the ``InteractivePlayback`` subclass ``super()._add_text(...)`` chain still
+  works after the delegation refactor.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+pygame = pytest.importorskip("pygame")  # skip if pygame is missing
+
+from robot_sf.render.sim_view import (  # noqa: E402
+    SimulationView,
+    VisualizableAction,
+    VisualizableSimState,
+)
+from robot_sf.render.sim_view_text_overlay import (  # noqa: E402
+    TEXT_BACKGROUND,
+    TEXT_COLOR,
+    TEXT_OUTLINE_COLOR,
+    SimViewTextOverlay,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_pygame() -> Iterator[None]:
+    yield
+    pygame.quit()
+
+
+@pytest.fixture
+def view() -> SimulationView:
+    """A deterministic, headless SimulationView with small dimensions."""
+    return SimulationView(width=64, height=64, scaling=10.0)
+
+
+def _state_with_robot(*, timestep: int = 7) -> VisualizableSimState:
+    robot_action = VisualizableAction(
+        pose=((1.0, 1.0), 0.2),
+        action=(0.5, 0.1),
+        goal=(3.0, 3.0),
+    )
+    return VisualizableSimState(
+        timestep=timestep,
+        robot_action=robot_action,
+        robot_pose=((1.0, 1.0), 0.2),
+        pedestrian_positions=np.zeros((0, 2)),
+        ray_vecs=np.zeros((0, 2, 2)),
+        ped_actions=np.zeros((0, 2, 2)),
+        time_per_step_in_secs=0.1,
+    )
+
+
+def _state_with_pedestrian() -> VisualizableSimState:
+    robot_action = VisualizableAction(
+        pose=((1.0, 1.0), 0.2),
+        action=(0.5, 0.1),
+        goal=(3.0, 3.0),
+    )
+    ego_action = VisualizableAction(
+        pose=((2.0, 2.0), 1.0),
+        action=(1.0, 0.0),
+        goal=(0.0, 0.0),
+    )
+    return VisualizableSimState(
+        timestep=7,
+        robot_action=robot_action,
+        robot_pose=((1.0, 1.0), 0.2),
+        pedestrian_positions=np.zeros((0, 2)),
+        ray_vecs=np.zeros((0, 2, 2)),
+        ped_actions=np.zeros((0, 2, 2)),
+        ego_ped_pose=((2.0, 2.0), 1.0),
+        ego_ped_action=ego_action,
+        time_per_step_in_secs=0.1,
+    )
+
+
+class TestCollaboratorWiring:
+    """The collaborator exists, is the right type, and holds a host back-reference."""
+
+    def test_host_holds_text_overlay_instance(self, view: SimulationView) -> None:
+        assert isinstance(view._text_overlay, SimViewTextOverlay)
+
+    def test_collaborator_back_references_host(self, view: SimulationView) -> None:
+        assert view._text_overlay._host is view
+
+    def test_collaborator_module_constants_match_host(self) -> None:
+        """Color constants must be identical to the pre-split ``sim_view`` values."""
+        from robot_sf.render import sim_view
+
+        assert TEXT_COLOR == sim_view.TEXT_COLOR
+        assert TEXT_BACKGROUND == sim_view.TEXT_BACKGROUND
+        assert TEXT_OUTLINE_COLOR == sim_view.TEXT_OUTLINE_COLOR
+
+
+class TestDelegation:
+    """Every extracted method delegates with identical results to the collaborator."""
+
+    def test_get_robot_info_lines_delegates(self, view: SimulationView) -> None:
+        state = _state_with_robot()
+        assert view._get_robot_info_lines(state) == view._text_overlay._get_robot_info_lines(state)
+
+    def test_has_pedestrian_data_delegates_both_branches(self, view: SimulationView) -> None:
+        assert view._has_pedestrian_data(_state_with_pedestrian()) is True
+        assert view._has_pedestrian_data(_state_with_robot()) is False
+        # matches the collaborator directly
+        assert view._has_pedestrian_data(
+            _state_with_pedestrian()
+        ) == view._text_overlay._has_pedestrian_data(_state_with_pedestrian())
+
+    def test_build_text_lines_delegates(self, view: SimulationView) -> None:
+        view.current_target_fps = 60.0
+        state = _state_with_robot(timestep=7)
+        assert view._build_text_lines(7, state, []) == view._text_overlay._build_text_lines(
+            7, state, []
+        )
+
+    def test_get_display_info_lines_delegates_all_modes(self, view: SimulationView) -> None:
+        state = _state_with_robot()
+        for mode in (0, 1):
+            view.display_robot_info = mode
+            assert view._get_display_info_lines(
+                state
+            ) == view._text_overlay._get_display_info_lines(state)
+
+    def test_pedestrian_info_lines_writes_back_through_host(self, view: SimulationView) -> None:
+        """The ``display_robot_info`` reset side-effect lands on the host, not a copy."""
+        state = _state_with_robot()  # no pedestrian data
+        view.display_robot_info = 2
+        assert view._get_pedestrian_info_lines(state) == []
+        # The collaborator wrote back to the host's attribute (single source of truth).
+        assert view.display_robot_info == 0
+
+
+class TestRenderingDelegation:
+    """``_render_text_*`` and ``_add_text`` run end-to-end through the collaborator."""
+
+    def test_add_text_renders_without_error(self, view: SimulationView) -> None:
+        # Exercises _add_text -> _get_display_info_lines -> _build_text_lines
+        # -> _render_text_display -> _render_text_line, all through the host delegator.
+        view.display_robot_info = 1
+        view._add_text(7, _state_with_robot())  # must not raise
+
+    def test_render_text_display_blits_to_host_screen(self, view: SimulationView) -> None:
+        before = view.screen.copy()
+        view._render_text_display(["step: 1", "scaling: 10.0"])
+        after = view.screen.copy()
+        # The overlay is drawn onto the host's screen surface (pixels changed).
+        assert not np.array_equal(pygame.surfarray.array3d(before), pygame.surfarray.array3d(after))
+
+
+class TestSubclassCompatibility:
+    """The ``InteractivePlayback`` ``super()._add_text(...)`` chain still works."""
+
+    def test_subclass_super_add_text_still_works(self, view: SimulationView) -> None:
+        """A subclass overriding ``_add_text`` and calling ``super()`` must not regress.
+
+        ``InteractivePlayback._add_text`` calls ``super()._add_text(...)`` which now
+        delegates to the collaborator; this synthesises that pattern to lock it in.
+        """
+
+        class _Sub(SimulationView):
+            def _add_text(self, timestep, state):  # type: ignore[override]
+                super()._add_text(timestep, state)
+
+        sub = _Sub(width=64, height=64, scaling=10.0)
+        sub.display_robot_info = 1
+        # Should not raise: super() delegation reaches the collaborator.
+        sub._add_text(3, _state_with_robot())
+        assert isinstance(sub._text_overlay, SimViewTextOverlay)


### PR DESCRIPTION
## What

Split the text/info-overlay cluster out of the 68-method `SimulationView` god-class (`robot_sf/render/sim_view.py`, 1,793 LOC) into a new **`SimViewTextOverlay`** collaborator in `robot_sf/render/sim_view_text_overlay.py`.

This is the **bounded first slice** of issue #4989 (epic #4770, s7). Structural only — no metric/render semantics.

## Why

`SimulationView` is a god-class blocking maintainability. Per the #4989 decomposition plan, this slice extracts one cohesive responsibility (the text/info-overlay cluster) into its own collaborator while keeping the public `SimulationView` surface and its rendered output **unchanged**. The characterization baseline from #4965 (now on `main`) pins the behavior this refactor must preserve.

## Changes

- **New** `robot_sf/render/sim_view_text_overlay.py` — `SimViewTextOverlay` collaborator owning:
  - content builders: `_build_text_lines`, `_get_display_info_lines`, `_get_robot_info_lines`, `_get_pedestrian_info_lines`, `_has_pedestrian_data`
  - rendering: `_render_text_display`, `_render_text_line`, `_add_text`
- **`robot_sf/render/sim_view.py`** — `SimulationView` now holds a `SimViewTextOverlay` instance (wired in `__post_init__`) and delegates the 8 methods to it; signatures unchanged. `sim_view.py` drops from **1,793 → 1,747 LOC**.
- **New** `tests/render/test_sim_view_text_overlay.py` — focused tests for the split contract (collaborator wiring, delegation equivalence, host-authoritative shared state, subclass `super()._add_text()` chain).

### Design notes

- The collaborator reaches shared, mutable render state (`screen`, `font`, `clock`, `scaling`, `offset`, `record_video`, `display_robot_info`, `current_target_fps`) through a **host back-reference** (`self._host`), so the host remains the single source of truth exactly as before the split. This is what makes the move behavior-identical (e.g. `display_robot_info = 0` reset in `_get_pedestrian_info_lines` still lands on the host).
- Text color constants are duplicated in the collaborator (rather than imported from `sim_view`) to avoid a circular import / re-triggering pygame startup at import time; values are byte-identical and asserted in tests.
- `_add_text` is kept as an overridable delegating method so the `InteractivePlayback` subclass (`super()._add_text(...)`) keeps working through the delegation chain.
- Out of this bounded slice (left for the text-overlay seam's later expansion, per the #4989 end-state): `_add_minimal_hint`, `_add_help_text`.

## Behavior preservation

`tests/render/test_sim_view_characterization.py` (#4965 golden lines) stays **green and unchanged** — it still calls `view._build_text_lines(...)`, `view._has_pedestrian_data(...)`, etc. on `SimulationView`, which now delegate to the collaborator and return identical results.

## Validation

Exact test command from the issue (headless):
```
SDL_VIDEODRIVER=dummy uv run pytest tests/render/test_sim_view_characterization.py tests/visuals/ tests/render/ -q
→ 126 passed
```
Plus the new focused test file (137 total):
```
SDL_VIDEODRIVER=dummy uv run pytest tests/render/test_sim_view_text_overlay.py -q
→ 11 passed
```
Also green: `tests/test_interactive_playback_enhanced.py` (subclass override path), 3 passed.

Lint / format / type:
```
uv run ruff check  <changed files>   → All checks passed!
uv run ruff format --check <changed> → 3 files already formatted
uv run mypy robot_sf/render/sim_view_text_overlay.py → Success: no issues
uv run mypy robot_sf/render/sim_view.py → 8 errors, all pre-existing on origin/main
                                          (line-shifted equivalents; 0 new errors introduced)
```

## Artifact handling

NA — refactor only; no campaigns, training runs, or benchmark artifacts produced. No `output/` generated.

---

**Successor statement:** This PR implements the full bounded first slice of #4989 as written (the 8 text-overlay methods). The remaining #4989 decomposition seams (`SimViewEntityRenderer`, `SimViewObservationPanels`, and the rest of the text-overlay seam `_add_minimal_hint`/`_add_help_text`) are named in the issue for subsequent PRs and are **not** done here. This slice does not duplicate any prior merged PR.

**Proof tier:** structural refactor; behavior-preservation evidence via the #4965 characterization golden lines (unchanged and green) plus focused split-contract tests. CPU/headless only.

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Refs #4989
Refs #4770
