### PR TITLE
Issue #4969: define ped_density unit in schema docs, YAML comments, and CLI warning (cheap-lane worker)

### DIFF
--- a/configs/scenarios/archetypes/classic_bottleneck.yaml
+++ b/configs/scenarios/archetypes/classic_bottleneck.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
 - name: classic_bottleneck_low
   map_file: ../../../maps/svg_maps/classic_bottleneck.svg

--- a/configs/scenarios/archetypes/classic_cross_trap.yaml
+++ b/configs/scenarios/archetypes/classic_cross_trap.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
 - name: classic_cross_trap_low
   map_id: classic_cross_trap

--- a/configs/scenarios/archetypes/classic_crossing.yaml
+++ b/configs/scenarios/archetypes/classic_crossing.yaml
@@ -4,6 +4,9 @@
 #
 # Evaluation disposition (issue #4971): excluded from the standard classic
 # interaction campaign because these aliases duplicate classic_cross_trap.
+#
+# simulation_config.ped_density unit: pedestrians per m^2 of spawnable
+# route/zone (sidewalk) area (not whole-map); 0.0 + markers is a placeholder.
 evaluation: excluded
 evaluation_reason: Deprecated compatibility aliases; use classic_cross_trap.yaml in new campaigns.
 evaluation_replacement: classic_cross_trap.yaml

--- a/configs/scenarios/archetypes/classic_density_tier_index.yaml
+++ b/configs/scenarios/archetypes/classic_density_tier_index.yaml
@@ -17,9 +17,14 @@
 #   from them or omits a config/tier (missing-coverage guard).
 #
 # `density` semantics — read this before counting the matrix
+#   `simulation_config.ped_density` unit: pedestrians per m^2 of SPAWNABLE
+#   route/zone (sidewalk) area, NOT whole-map area and NOT per route meter.
+#   Spawn count = ceil(total_sidewalks_area * ped_density)
+#   (robot_sf/ped_npc/ped_population.py). Classic band: 0.02/0.05/0.08.
 #   `simulation_config.ped_density` is NOT uniform in meaning across configs:
 #     * route_density               -> `ped_density` is a real route-spawn
-#                                       pedestrian density (peds/m of route area).
+#                                       pedestrian density (peds per m^2 of
+#                                       spawnable sidewalk area).
 #     * markers                     -> `ped_density: 0.0` is a PLACEHOLDER, not
 #                                       "no pedestrians". Pedestrians are placed
 #                                       from fixed markers (SVG `single_ped`

--- a/configs/scenarios/archetypes/classic_doorway.yaml
+++ b/configs/scenarios/archetypes/classic_doorway.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
 - name: classic_doorway_low
   map_file: ../../../maps/svg_maps/classic_doorway.svg

--- a/configs/scenarios/archetypes/classic_group_crossing.yaml
+++ b/configs/scenarios/archetypes/classic_group_crossing.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
 - name: classic_group_crossing_low
   map_file: ../../../maps/svg_maps/classic_group_crossing.svg

--- a/configs/scenarios/archetypes/classic_head_on_corridor.yaml
+++ b/configs/scenarios/archetypes/classic_head_on_corridor.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
 - name: classic_head_on_corridor_low
   map_file: ../../../maps/svg_maps/classic_head_on_corridor.svg

--- a/configs/scenarios/archetypes/classic_merging.yaml
+++ b/configs/scenarios/archetypes/classic_merging.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
 - name: classic_merging_low
   map_file: ../../../maps/svg_maps/classic_merging.svg

--- a/configs/scenarios/archetypes/classic_overtaking.yaml
+++ b/configs/scenarios/archetypes/classic_overtaking.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
 - name: classic_overtaking_low
   map_file: ../../../maps/svg_maps/classic_overtaking.svg

--- a/configs/scenarios/archetypes/classic_realworld_bottleneck.yaml
+++ b/configs/scenarios/archetypes/classic_realworld_bottleneck.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
 - name: classic_realworld_double_bottleneck_high
   map_file: ../../../maps/svg_maps/classic_realworld_bottleneck.svg

--- a/configs/scenarios/archetypes/classic_station_platform.yaml
+++ b/configs/scenarios/archetypes/classic_station_platform.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
 - name: classic_station_platform_medium
   map_file: ../../../maps/svg_maps/classic_station_platform.svg

--- a/configs/scenarios/archetypes/classic_t_intersection.yaml
+++ b/configs/scenarios/archetypes/classic_t_intersection.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
 - name: classic_t_intersection_low
   map_file: ../../../maps/svg_maps/classic_t_intersection.svg

--- a/configs/scenarios/archetypes/classic_urban_crossing.yaml
+++ b/configs/scenarios/archetypes/classic_urban_crossing.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
 - name: classic_urban_crossing_medium
   map_file: ../../../maps/svg_maps/classic_urban_crossing.svg

--- a/configs/scenarios/archetypes/social_mini_games.yaml
+++ b/configs/scenarios/archetypes/social_mini_games.yaml
@@ -1,3 +1,9 @@
+# simulation_config.ped_density unit: pedestrians per m^2 of SPAWNABLE
+# route/zone (sidewalk) area, not whole-map area and not per route meter.
+# Spawn count = ceil(total_sidewalks_area * ped_density). Classic band:
+# 0.02 (low) / 0.05 (medium) / 0.08 (high). ped_density: 0.0 with
+# metadata.spawn_mode: markers is a marker-controlled placeholder (peds
+# come from fixed single_ped markers), NOT an empty scene.
 scenarios:
   - name: smg_curb_ramp_conflict
     map_file: ../../../maps/svg_maps/smg_curb_ramp_conflict.svg

--- a/docs/dev/scenario-schema/README.md
+++ b/docs/dev/scenario-schema/README.md
@@ -31,6 +31,27 @@ Notes:
 - The CLI also checks for duplicate `id` values.
 - The validator uses Draft-07 JSON Schema.
 
+### `simulation_config.ped_density` unit
+
+`ped_density` is a pedestrian spawn density in **pedestrians per square meter of
+spawnable route/zone (sidewalk) area** — not per whole-map area and not per route
+meter. The runtime spawn count is computed as
+`ceil(total_sidewalks_area * ped_density)`
+(`robot_sf/ped_npc/ped_population.py`), where `total_sidewalks_area` is the
+spawnable sidewalk area derived from the map routes. The classic archetypes use
+`0.02` (low) / `0.05` (medium) / `0.08` (high) on this unit; the CLI flags values
+outside the recommended `[0.02, 0.08]` band and flags values above `0.15` as
+likely unit confusion (e.g. a value meant per whole-map area or per route meter).
+
+The value `0.0` is a **marker-controlled placeholder**, not an empty scene. When
+`metadata.spawn_mode` is `markers`, pedestrians are placed from fixed map
+(`single_ped`) markers and/or config `single_pedestrians`, and `ped_density: 0.0`
+simply disables route-density spawning. This is how the bottleneck archetypes
+control pedestrian counts. Outside marker mode, `ped_density: 0.0` means no
+route-spawned pedestrians.
+
+The schema enforces `ped_density >= 0`; negative values fail validation.
+
 Example:
 
 ```bash

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -1395,7 +1395,22 @@ def _collect_scenario_warnings(  # noqa: PLR0912,PLR0915
                         scenario_id,
                         (
                             "ped_density outside recommended [0.02, 0.08]; "
+                            "unit is peds per m^2 of spawnable area "
+                            "(route/zone sidewalk area, not whole-map); "
                             "may reduce benchmark comparability"
+                        ),
+                        "/simulation_config/ped_density",
+                    )
+                if not marker_placeholder_density and density_val > 0.15:
+                    warn(
+                        idx,
+                        scenario_id,
+                        (
+                            f"ped_density={density_val} is high; unit is "
+                            "peds per m^2 of spawnable area (recommended "
+                            "0.02-0.08). If this value was meant per "
+                            "whole-map area or per route meter, it is likely "
+                            "a unit confusion."
                         ),
                         "/simulation_config/ped_density",
                     )

--- a/robot_sf/benchmark/schema/scenarios.schema.json
+++ b/robot_sf/benchmark/schema/scenarios.schema.json
@@ -110,7 +110,14 @@
                 "minLength": 1
             },
             "simulation_config": {
-                "type": "object"
+                "type": "object",
+                "properties": {
+                    "ped_density": {
+                        "description": "Pedestrian spawn density, in pedestrians per square meter of SPAWNABLE route/zone (sidewalk) area; NOT whole-map area. The spawn count is ceil(total_sidewalks_area * ped_density). Classic archetypes use 0.02 (low) / 0.05 (medium) / 0.08 (high). The value 0.0 is a marker-controlled placeholder: with metadata.spawn_mode == 'markers', pedestrians come from fixed map/config markers and 0.0 does NOT mean an empty scene. Must be >= 0.",
+                        "type": "number",
+                        "minimum": 0
+                    }
+                }
             },
             "robot_config": {
                 "type": "object"

--- a/robot_sf/ped_npc/ped_population.py
+++ b/robot_sf/ped_npc/ped_population.py
@@ -115,7 +115,12 @@ class PedSpawnConfig:
     """Configuration for pedestrian spawning in a simulation environment.
 
     Attributes:
-        peds_per_area_m2: The density of pedestrians per square meter area.
+        peds_per_area_m2: Pedestrian spawn density, in pedestrians per square
+            meter of SPAWNABLE route/zone (sidewalk) area; NOT whole-map area.
+            The runtime spawn count is
+            ``ceil(total_sidewalks_area * peds_per_area_m2)``. The value ``0.0``
+            is a marker-controlled placeholder (with marker spawning, pedestrians
+            come from fixed markers), not an empty scene.
         max_group_members: Maximum number of members allowed in a pedestrian group.
         group_member_probs: A list representing the probability distribution for the
                             number of members in a group. Each index corresponds to

--- a/tests/benchmark/test_issue_4969_ped_density_unit.py
+++ b/tests/benchmark/test_issue_4969_ped_density_unit.py
@@ -1,0 +1,180 @@
+"""Focused tests for issue #4969: ``ped_density`` unit documentation and validation.
+
+Issue #4969 asks to (1) document the ``simulation_config.ped_density`` unit
+(pedestrians per square meter of SPAWNABLE route/zone sidewalk area) and the
+marker-controlled ``0.0`` convention in the scenario schema docs and archetype
+YAML comments, (2) make the CLI ``validate-config`` warning self-explanatory by
+stating the unit, and (3) add schema-level validation that rejects negative
+values and flags very high values (``> 0.15``) as likely unit confusion.
+
+These tests cover the behavioral contract: schema rejection of negatives, the
+self-explanatory CLI warning text, the ``> 0.15`` unit-confusion flag, and the
+preserved marker-mode ``0.0`` behavior (no false "empty scene" warning).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import yaml
+
+from robot_sf.benchmark.cli import cli_main
+from robot_sf.benchmark.scenario_schema import validate_scenario_list
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_matrix(tmp_path: Path, scenarios: list[dict]) -> Path:
+    """Write a scenario matrix YAML file and return its path."""
+    matrix_path = tmp_path / "matrix.yaml"
+    with matrix_path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump({"scenarios": scenarios}, f)
+    return matrix_path
+
+
+def _validate_config_warnings(matrix_path: Path, capsys) -> list[str]:
+    """Run ``validate-config`` and return the list of warning message strings."""
+    rc = cli_main(["validate-config", "--matrix", str(matrix_path)])
+    captured = capsys.readouterr()
+    assert rc == 0, f"validate-config failed: {captured.out}"
+    report = json.loads(captured.out)
+    return [w["warning"] for w in report["warnings"]]
+
+
+# --- Schema-level validation (part 3: reject negative ped_density) ---
+
+
+def test_schema_rejects_negative_ped_density() -> None:
+    """A negative ``ped_density`` must fail JSON-Schema validation."""
+    scenarios = [
+        {
+            "name": "neg-density",
+            "map_file": "x.svg",
+            "simulation_config": {"ped_density": -0.1},
+            "metadata": {"archetype": "crossing", "density": "low"},
+        }
+    ]
+    errors = validate_scenario_list(scenarios)
+    ped_density_errors = [e for e in errors if "ped_density" in e.get("path", "")]
+    assert ped_density_errors, f"Expected a schema error for negative ped_density, got: {errors}"
+
+
+def test_schema_accepts_zero_and_positive_ped_density() -> None:
+    """``0.0`` and positive ``ped_density`` must pass JSON-Schema validation."""
+    scenarios = [
+        {
+            "name": "zero-density",
+            "map_file": "x.svg",
+            "simulation_config": {"ped_density": 0.0},
+            "metadata": {"archetype": "bottleneck", "density": "low"},
+        },
+        {
+            "name": "pos-density",
+            "map_file": "x.svg",
+            "simulation_config": {"ped_density": 0.08},
+            "metadata": {"archetype": "crossing", "density": "high"},
+        },
+    ]
+    errors = validate_scenario_list(scenarios)
+    assert errors == [], f"Expected no schema errors for valid densities, got: {errors}"
+
+
+# --- CLI self-explanatory warning (part 2: state the unit) ---
+
+
+def test_cli_warning_states_spawnable_area_unit(tmp_path: Path, capsys) -> None:
+    """Out-of-range density warning must state the unit (peds/m^2 of spawnable area)."""
+    scenarios = [
+        {
+            "name": "sparse",
+            "map_file": "x.svg",
+            "simulation_config": {"ped_density": 0.001},
+            "metadata": {"archetype": "crossing", "density": "low"},
+        }
+    ]
+    matrix_path = _write_matrix(tmp_path, scenarios)
+    warnings = _validate_config_warnings(matrix_path, capsys)
+    range_warnings = [w for w in warnings if "ped_density outside recommended" in w]
+    assert range_warnings, f"Expected an out-of-range warning, got: {warnings}"
+    # The warning must now be self-explanatory about the unit.
+    assert any("peds per m^2 of spawnable area" in w for w in range_warnings), (
+        f"Warning must state the spawnable-area unit; got: {range_warnings}"
+    )
+
+
+def test_cli_flags_high_density_as_likely_unit_confusion(tmp_path: Path, capsys) -> None:
+    """A ``ped_density`` above 0.15 must be flagged as likely unit confusion."""
+    scenarios = [
+        {
+            "name": "very-dense",
+            "map_file": "x.svg",
+            "simulation_config": {"ped_density": 0.2},
+            "metadata": {"archetype": "crowd", "density": "high"},
+        }
+    ]
+    matrix_path = _write_matrix(tmp_path, scenarios)
+    warnings = _validate_config_warnings(matrix_path, capsys)
+    assert any("likely a unit confusion" in w for w in warnings), (
+        f"Expected a unit-confusion flag for ped_density>0.15; got: {warnings}"
+    )
+
+
+def test_cli_does_not_flag_band_edge_0_15_as_unit_confusion(tmp_path: Path, capsys) -> None:
+    """``ped_density == 0.15`` is at the edge and must NOT trigger the >0.15 flag."""
+    scenarios = [
+        {
+            "name": "edge",
+            "map_file": "x.svg",
+            "simulation_config": {"ped_density": 0.15},
+            "metadata": {"archetype": "crowd", "density": "high"},
+        }
+    ]
+    matrix_path = _write_matrix(tmp_path, scenarios)
+    warnings = _validate_config_warnings(matrix_path, capsys)
+    assert not any("likely a unit confusion" in w for w in warnings), (
+        f"0.15 must not trigger the >0.15 flag; got: {warnings}"
+    )
+
+
+# --- Preserved default behavior (marker-mode 0.0 convention) ---
+
+
+def test_cli_marker_mode_zero_density_is_not_warned_as_empty(tmp_path: Path, capsys) -> None:
+    """Marker-spawned ``0.0`` must NOT warn as an empty scene (regression guard)."""
+    scenarios = [
+        {
+            "name": "marker-spawn",
+            "map_file": "x.svg",
+            "simulation_config": {"ped_density": 0.0},
+            "metadata": {
+                "archetype": "bottleneck",
+                "density": "low",
+                "spawn_mode": "markers",
+                "density_advisory": "zero_baseline_route_spawn",
+            },
+        }
+    ]
+    matrix_path = _write_matrix(tmp_path, scenarios)
+    warnings = _validate_config_warnings(matrix_path, capsys)
+    assert "ped_density=0.0 means no pedestrians spawn" not in warnings
+    assert not any("ped_density outside recommended" in w for w in warnings)
+    assert not any("likely a unit confusion" in w for w in warnings)
+
+
+def test_cli_recommended_band_density_emits_no_ped_density_warnings(tmp_path: Path, capsys) -> None:
+    """A density inside the recommended band must emit no ped_density warnings."""
+    scenarios = [
+        {
+            "name": "in-band",
+            "map_file": "x.svg",
+            "simulation_config": {"ped_density": 0.05},
+            "metadata": {"archetype": "crossing", "density": "medium"},
+        }
+    ]
+    matrix_path = _write_matrix(tmp_path, scenarios)
+    warnings = _validate_config_warnings(matrix_path, capsys)
+    assert not any("ped_density" in w for w in warnings), (
+        f"Expected no ped_density warnings for in-band density; got: {warnings}"
+    )


### PR DESCRIPTION
## What / Why

Resolves **issue #4969** — *docs: define `ped_density` unit (peds per m² of spawnable area) in schema docs, YAML comments, and CLI warning*.

`simulation_config.ped_density` carried no unit anywhere user-facing. The unit is defined only in a docstring: **pedestrians per square meter of SPAWNABLE route/zone (sidewalk) area**, where the spawn count is `ceil(total_sidewalks_area * peds_per_area_m2)` (`robot_sf/ped_npc/ped_population.py`). Map-marker-controlled families (bottlenecks) use `0.0` by convention. This PR documents the unit and the `0.0` convention on every user-facing surface named in the issue, makes the CLI warning self-explanatory, and adds the optional schema-level negative-value rejection plus a `>0.15` unit-confusion flag.

This implements the issue's full three-part proposal (including the part labeled "Optional"). No prior PR addressed this issue, so this is the complete slice, not a successor slice.

## Changes

### Part 1 — Document the unit and the marker-controlled `0.0` convention
- **Scenario schema docs** (`docs/dev/scenario-schema/README.md`): added a dedicated "`simulation_config.ped_density` unit" section covering the unit, the spawn-count formula, the classic `0.02`/`0.05`/`0.08` band, the CLI flags, and the marker-controlled `0.0` placeholder convention.
- **JSON Schema description** (`robot_sf/benchmark/schema/scenarios.schema.json`): added a `ped_density` property under `simulation_config` with a `description` documenting the unit, the spawn-count formula, the `0.0` marker convention, and the classic band.
- **Archetype YAML comments**: added a concise unit/`0.0`-convention header comment to the classic archetypes (`classic_bottleneck`, `classic_cross_trap`, `classic_doorway`, `classic_group_crossing`, `classic_head_on_corridor`, `classic_merging`, `classic_overtaking`, `classic_realworld_bottleneck`, `classic_station_platform`, `classic_t_intersection`, `classic_urban_crossing`), `classic_crossing` (deprecated alias), and `social_mini_games`. Also corrected the slightly inaccurate "peds/m of route area" wording in `classic_density_tier_index.yaml` to the accurate per-m²-of-spawnable-area unit.
- **`PedSpawnConfig` docstring** (`robot_sf/ped_npc/ped_population.py`): made the `peds_per_area_m2` unit explicit and documented the `0.0` marker placeholder.

### Part 2 — Self-explanatory CLI warning
- **`robot_sf/benchmark/cli.py`**: the out-of-range warning now states the unit — `"ped_density outside recommended [0.02, 0.08]; unit is peds per m^2 of spawnable area (route/zone sidewalk area, not whole-map); may reduce benchmark comparability"`. The recognizable `"ped_density outside recommended"` prefix is preserved so existing substring assertions keep passing.

### Part 3 (optional) — Schema-level validation + high-value flag
- **Negative rejection (schema)**: added `"minimum": 0` to the `ped_density` schema property, so negative `ped_density` now fails JSON-Schema validation. This is safe — no existing config uses a negative value.
- **`>0.15` unit-confusion flag (CLI)**: added a non-blocking advisory warning for `ped_density > 0.15` ("likely a unit confusion"). It is a *warning*, not an error, so legitimate high-density scenarios (e.g. `dense_pedestrian_stress` at `0.15`, `event_disruption_public_exit` at `0.2`) keep validating with exit code 0. The flag is strictly `> 0.15`, so `0.15` itself does not trigger it.

## Validation

Focused CPU-level validation only (no campaigns/Slurm/training).

**New tests** (`tests/benchmark/test_issue_4969_ped_density_unit.py`, 7 tests, all pass):
```
uv run python -m pytest tests/benchmark/test_issue_4969_ped_density_unit.py -v
============================== 7 passed in 3.59s ==============================
```
Covered: schema rejects negative `ped_density`; schema accepts `0.0` and positive; CLI out-of-range warning contains the spawnable-area unit text; CLI flags `0.2` as likely unit confusion; CLI does **not** flag the `0.15` band edge; marker-mode `0.0` is not warned as an empty scene; in-band `0.05` emits no `ped_density` warnings.

**Regression sweep** (existing tests touching the changed surfaces, plus the new tests, all pass):
```
uv run python -m pytest tests/test_cli.py tests/test_classic_archetype_density_index.py \
  tests/scenarios/test_event_disruption_scenarios.py tests/test_classic_interactions_matrix.py \
  tests/training/test_scenario_loader.py tests/benchmark/test_scenario_coverage.py \
  tests/benchmark/test_scenario_difficulty.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py \
  tests/benchmark/test_issue_4969_ped_density_unit.py -q
=> 132 passed
```
Notably the machine-checked `tests/test_classic_archetype_density_index.py` passes (comment-only change to the index), and `tests/scenarios/test_event_disruption_scenarios.py` (which exercises the `0.2`-density config) passes — confirming the `minimum: 0` schema change and the `>0.15` flag do not break existing configs.

**Lint/format** on changed Python files:
```
uv run ruff check robot_sf/benchmark/cli.py robot_sf/ped_npc/ped_population.py tests/benchmark/test_issue_4969_ped_density_unit.py
All checks passed!
uv run ruff format --check <same files>
3 files already formatted
```

**Smoke on real configs:**
- `validate-config configs/scenarios/classic_interactions.yaml` → `rc=0`, no errors; the self-explanatory warning fires for `classic_group_crossing_high` (`0.12`, outside band, below the `0.15` flag); bottleneck marker configs (`0.0`) produce no warnings.
- `validate-config configs/scenarios/single/event_disruption_public_exit.yaml` (`0.2`) → `rc=0` (non-blocking), both the self-explanatory out-of-range warning and the `>0.15` unit-confusion flag appear.

## Backward compatibility

- `simulation_config` remains an open object (no `additionalProperties: false`); only the now-defined `ped_density` key is constrained.
- No existing config uses a negative `ped_density`, so the `minimum: 0` addition breaks nothing.
- The `>0.15` flag is a non-blocking warning; it adds no errors and does not change any exit code.
- Marker-mode `0.0` and in-band densities emit no new warnings — default behavior outside the issue scope is unchanged.

## Evidence-producing PR fields (per AGENTS.md)

- Target claim/hypothesis/blocker: documentation/auditability of the `ped_density` unit (Phase 1, prerequisite hygiene for scenario-generation work, #4932).
- Comparator/baseline: N/A (docs + schema/validation contract change).
- Evidence tier: focused automated checks + smoke validation on real configs.
- Result classification: documentation/contract change, behavior-preserving outside scope.
- Decision/stop rule: the unit and `0.0` convention are documented on all three requested surfaces (schema docs, archetype YAML comments, CLI warning) and the optional schema-level negative rejection + `>0.15` flag are implemented; covered by focused tests.
- Synthesis/update target: this PR + issue #4969 closure.

Closes #4969.

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
