### PR TITLE
Issue #5072: flakiness audit observation-track handling fail-closed (cheap-lane worker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cells below `min_seeds` are reported as not assessable rather than counted as stable, and
   determinism is reported as `null` (unknown) when no exact-repeat data exists. Claim boundary:
   new diagnostic capability validated on synthetic and CPU fixtures; no benchmark campaign run.
+  *(Issue #5072 adds fail-closed observation-track handling to this audit; see the #5072 entry
+  below.)*
+* **issue #5072 flakiness audit observation-track handling is now fail-closed.** The
+  `robot_sf_bench flakiness-audit` audit (`robot_sf/benchmark/scenario_flakiness.py` from #4978)
+  now enforces the benchmark observation-track boundary it previously deferred. By default
+  (`--observation-track-mode strict`) it refuses to pool records that declare different
+  `benchmark_track` values into one stability cell, raising `AggregationMetadataError` (CLI exit
+  code 2) so rows with incompatible observation contracts are never silently compared. An opt-in
+  `--observation-track-mode diagnostic-cross-track` mode partitions cells per track
+  (`track :: scenario :: planner`) and emits an explicit `cross_track_caveat` for an explicitly
+  caveated cross-track diagnostic. This reuses the canonical `observation-track` policy helpers
+  shared by the aggregate/report CLIs (`robot_sf/benchmark/aggregate.py`) so the behavior is
+  consistent across benchmark subcommands. Reports gain an `observation_track_mode` field and an
+  `observation_tracks` metadata block, and each cell gains a `benchmark_track` field, making the
+  track policy reproducible. Single-track and undeclared-track fixtures remain compatible in
+  strict mode. Read-only diagnostic claim boundary is preserved; no ranking, summary, or metric
+  semantics change. Deferred from PR #5069 as a distinct benchmark-input contract; validated on
+  CPU fixtures only.
 * **issue #3574 realized-distribution audit for heterogeneous-population traces.**
   `robot_sf/benchmark/heterogeneous_population_metrics.py` gains `realized_distribution_audit` and
   `summarize_distribution` (plus a `RealizedDistributionSpec`), covering DoD item 5: configured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regression coverage lives in `tests/dev/test_gh_list_truncation_remaining.py` and
   `tests/tools/test_project_priority_score_truncation.py`. Tooling/evidence-integrity only — no
   benchmark, metric, or paper-facing claim.
+* **issue #4978 scenario flakiness audit — exact-repeat determinism + per-cell outcome-stability.**
+  New `robot_sf/benchmark/scenario_flakiness.py` (`compute_flakiness_audit`, schema
+  `scenario_flakiness.v1`) and a `robot_sf_bench flakiness-audit` CLI subcommand measure two forms of
+  outcome instability from existing episode JSONL: (1) exact-repeat determinism — when a
+  `(scenario, planner, seed)` cell is executed more than once, whether repeats share the same binary
+  outcome (a `False` verdict is a reproducibility bug the audit doubles as a detector for); and
+  (2) per-cell outcome stability — the fraction of seeds in a `(scenario, planner)` cell that agree
+  with the majority outcome, flagging `knife_edge` cells below a configurable threshold (default
+  0.8). The audit is advisory and read-only: it emits a schema-versioned report and does not change
+  rankings, campaign summaries, or metric semantics. Fail-closed by design — empty input raises,
+  cells below `min_seeds` are reported as not assessable rather than counted as stable, and
+  determinism is reported as `null` (unknown) when no exact-repeat data exists. Claim boundary:
+  new diagnostic capability validated on synthetic and CPU fixtures; no benchmark campaign run.
 * **issue #3574 realized-distribution audit for heterogeneous-population traces.**
   `robot_sf/benchmark/heterogeneous_population_metrics.py` gains `realized_distribution_audit` and
   `summarize_distribution` (plus a `RealizedDistributionSpec`), covering DoD item 5: configured

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -88,6 +88,9 @@ from robot_sf.benchmark.report_table import format_markdown as _tbl_format_md
 from robot_sf.benchmark.report_table import to_json as _tbl_to_json
 from robot_sf.benchmark.runner import load_scenario_matrix, run_batch
 from robot_sf.benchmark.scenario_flakiness import (
+    DEFAULT_OBSERVATION_TRACK_MODE as _DEFAULT_FLAKINESS_TRACK_MODE,
+)
+from robot_sf.benchmark.scenario_flakiness import (
     compute_flakiness_audit as _compute_flakiness_audit,
 )
 from robot_sf.benchmark.scenario_schema import (
@@ -845,6 +848,7 @@ def _handle_flakiness_audit(args) -> int:
             seed_field=str(args.seed_field),
             stability_threshold=float(args.stability_threshold),
             min_seeds=int(args.min_seeds),
+            observation_track_mode=str(args.observation_track_mode),
         )
         out_path = Path(args.out)
         out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2413,6 +2417,16 @@ def _add_flakiness_audit_subparser(
         type=int,
         default=2,
         help="Minimum distinct seeds before a cell's stability is assessed (default: 2)",
+    )
+    p.add_argument(
+        "--observation-track-mode",
+        choices=["strict", "diagnostic-cross-track"],
+        default=_DEFAULT_FLAKINESS_TRACK_MODE,
+        help=(
+            "How to handle mixed benchmark_track values. Default strict fails closed "
+            "rather than pooling incompatible observation contracts; "
+            "diagnostic-cross-track partitions cells per track with an explicit caveat."
+        ),
     )
     p.set_defaults(cmd="flakiness-audit")
 

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -87,6 +87,9 @@ from robot_sf.benchmark.report_table import format_latex_booktabs as _tbl_format
 from robot_sf.benchmark.report_table import format_markdown as _tbl_format_md
 from robot_sf.benchmark.report_table import to_json as _tbl_to_json
 from robot_sf.benchmark.runner import load_scenario_matrix, run_batch
+from robot_sf.benchmark.scenario_flakiness import (
+    compute_flakiness_audit as _compute_flakiness_audit,
+)
 from robot_sf.benchmark.scenario_schema import (
     validate_scenario_list,
     validate_scenario_matrix_metadata,
@@ -822,6 +825,48 @@ def _handle_seed_variance(args) -> int:
         except _CLI_LOGGING_ERRORS:  # pragma: no cover - defensive logging boundary
             logging.debug("Logging 'Seed-variance summary' failed", exc_info=True)
         return 0
+    except _CLI_INPUT_ERRORS:  # pragma: no cover - error path
+        return 2
+
+
+def _handle_flakiness_audit(args) -> int:
+    """Audit scenario outcome flakiness and write a JSON report.
+
+    Returns:
+        Exit code (0 success, 2 failure).
+    """
+    try:
+        records = _agg_read_jsonl(args.in_path)
+        report = _compute_flakiness_audit(
+            records,
+            outcome_metric=str(args.outcome_metric),
+            group_by=args.group_by,
+            fallback_group_by=args.fallback_group_by,
+            seed_field=str(args.seed_field),
+            stability_threshold=float(args.stability_threshold),
+            min_seeds=int(args.min_seeds),
+        )
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+        try:
+            summary = report["summary"]
+            logging.info(
+                "Flakiness audit written to %s (%s cells, %s knife-edge, determinism=%s)",
+                out_path,
+                summary["n_cells"],
+                summary["n_knife_edge_cells"],
+                report["exact_repeat"]["is_deterministic"],
+            )
+        except _CLI_LOGGING_ERRORS:  # pragma: no cover - defensive logging boundary
+            logging.debug("Logging 'Flakiness audit' failed", exc_info=True)
+        return 0
+    except ValueError:
+        # Fail closed on an empty/invalid audit request rather than emit a report
+        # that asserts stability without evidence.
+        logging.exception("Flakiness audit failed")
+        return 2
     except _CLI_INPUT_ERRORS:  # pragma: no cover - error path
         return 2
 
@@ -2321,6 +2366,57 @@ def _add_seed_variance_subparser(
     p.set_defaults(cmd="seed-variance")
 
 
+def _add_flakiness_audit_subparser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the flakiness-audit subcommand parser."""
+    p = subparsers.add_parser(
+        "flakiness-audit",
+        help=(
+            "Audit scenario outcome flakiness: exact-repeat determinism and "
+            "per-cell (scenario, planner) outcome-stability; writes a JSON report"
+        ),
+    )
+    p.add_argument("--in", dest="in_path", required=True, help="Input episodes JSONL path")
+    p.add_argument("--out", required=True, help="Output JSON report path")
+    p.add_argument(
+        "--outcome-metric",
+        default="success",
+        help="Binary outcome metric name (default: success)",
+    )
+    p.add_argument(
+        "--group-by",
+        default=DEFAULT_REPORT_GROUP_BY,
+        help="Planner grouping key (dotted path). Default: scenario_params.algo",
+    )
+    p.add_argument(
+        "--fallback-group-by",
+        default=DEFAULT_REPORT_FALLBACK_GROUP_BY,
+        help="Fallback grouping key when group-by is missing. Default: scenario_id",
+    )
+    p.add_argument(
+        "--seed-field",
+        default="seed",
+        help="Dotted path to the seed field (default: seed)",
+    )
+    p.add_argument(
+        "--stability-threshold",
+        type=float,
+        default=0.8,
+        help=(
+            "Majority-agreement fraction below which a cell is flagged knife-edge "
+            "(range (0, 1]; default 0.8)"
+        ),
+    )
+    p.add_argument(
+        "--min-seeds",
+        type=int,
+        default=2,
+        help="Minimum distinct seeds before a cell's stability is assessed (default: 2)",
+    )
+    p.set_defaults(cmd="flakiness-audit")
+
+
 def _add_extract_failures_subparser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -2730,6 +2826,7 @@ def _attach_core_subcommands(parser: argparse.ArgumentParser) -> None:  # noqa: 
     _add_validate_row_claims_subparser(subparsers)
     _add_export_parquet_subparser(subparsers)
     _add_seed_variance_subparser(subparsers)
+    _add_flakiness_audit_subparser(subparsers)
     _add_extract_failures_subparser(subparsers)
     _add_snqi_ablate_subparser(subparsers)
     _add_rank_subparser(subparsers)
@@ -3238,6 +3335,7 @@ def cli_main(argv: list[str] | None = None) -> int:
         "validate-row-claims": _handle_validate_row_claims,
         "export-parquet": _handle_export_parquet,
         "seed-variance": _handle_seed_variance,
+        "flakiness-audit": _handle_flakiness_audit,
         "extract-failures": _handle_extract_failures,
         "snqi-ablate": _handle_snqi_ablate,
         "rank": _handle_rank,

--- a/robot_sf/benchmark/scenario_flakiness.py
+++ b/robot_sf/benchmark/scenario_flakiness.py
@@ -1,0 +1,347 @@
+"""Scenario flakiness audit for the Social Navigation Benchmark.
+
+This module measures two distinct forms of outcome instability from benchmark
+episode records (see issue #4978):
+
+1. **Exact-repeat determinism** — when the same ``(scenario, planner, seed)``
+   cell is executed more than once, do the repeated runs produce the *same*
+   binary outcome? If not, exact-repeat runs are non-deterministic, which is a
+   reproducibility bug the audit doubles as a detector for.
+2. **Per-cell outcome stability** — within a ``(scenario, planner)`` cell, how
+   consistently do independent seeds agree on the binary outcome? A cell whose
+   seeds flip between success and failure is *knife-edge*: campaign comparisons
+   on it carry hidden variance that per-seed confidence intervals understate.
+
+The audit is intentionally advisory and read-only: it emits a schema-versioned
+report describing stability, and never mutates existing rankings, campaign
+summaries, or metric semantics. Downstream tooling may *choose* to exclude or
+down-weight flagged knife-edge cells, but that decision stays out of scope here.
+
+The audit fails closed: an empty record set raises, cells with too few seeds are
+reported as *not assessable* rather than silently counted as stable, and
+determinism is reported as ``None`` (unknown) when no exact-repeat data exists
+instead of being asserted without evidence.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.grouping import (
+    DEFAULT_REPORT_FALLBACK_GROUP_BY,
+    DEFAULT_REPORT_GROUP_BY,
+    get_nested,
+    resolve_report_group_key,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+SCHEMA_VERSION = "scenario_flakiness.v1"
+
+#: Default metric treated as the binary episode outcome. ``success`` is already
+#: recorded as 0/1 in benchmark episode records.
+DEFAULT_OUTCOME_METRIC = "success"
+
+#: Default fraction of seeds that must agree with the majority outcome for a
+#: cell to be considered stable. Cells below this are flagged ``knife_edge``.
+DEFAULT_STABILITY_THRESHOLD = 0.8
+
+#: Minimum distinct seeds required before a cell's stability can be assessed.
+DEFAULT_MIN_SEEDS = 2
+
+#: Cap on how many concrete examples are embedded in the report for each list so
+#: the JSON stays compact on large campaigns.
+_MAX_EXAMPLES = 25
+
+
+def _binary_outcome(value: Any) -> int | None:
+    """Coerce an outcome metric value into a binary 0/1 label.
+
+    A ``success``-style metric is already 0/1, but records may carry booleans or
+    floats (e.g. an averaged success rate). Values ``>= 0.5`` map to 1, finite
+    values below map to 0, and non-numeric/missing values map to ``None`` so the
+    caller can fail closed instead of guessing.
+
+    Returns:
+        ``1``, ``0``, or ``None`` when the value cannot be interpreted.
+    """
+    if value is None or isinstance(value, bool):
+        return int(value) if isinstance(value, bool) else None
+    if isinstance(value, int | float):
+        f = float(value)
+        if math.isnan(f):
+            return None
+        return 1 if f >= 0.5 else 0
+    return None
+
+
+def _outcome_from_record(record: dict[str, Any], outcome_metric: str) -> int | None:
+    """Extract the binary outcome for a record from its metrics block.
+
+    Accepts both ``metrics.<outcome_metric>`` and a top-level ``<outcome_metric>``
+    fallback so the audit works on flattened and nested record shapes.
+
+    Returns:
+        Binary outcome, or ``None`` when the outcome metric is absent/uninterpretable.
+    """
+    metrics = record.get("metrics")
+    if isinstance(metrics, dict) and outcome_metric in metrics:
+        return _binary_outcome(metrics[outcome_metric])
+    # Fall back to a dotted/top-level path for already-flattened rows.
+    return _binary_outcome(get_nested(record, outcome_metric))
+
+
+def _seed_key(record: dict[str, Any], seed_field: str) -> str:
+    """Return a stable string key for a record's seed (``"__missing__"`` if absent)."""
+    value = get_nested(record, seed_field)
+    if value is None:
+        return "__missing__"
+    return str(value)
+
+
+def _cell_stability(seed_outcomes: dict[str, int]) -> tuple[float, float]:
+    """Compute the success rate and stability score for a cell's seed votes.
+
+    Args:
+        seed_outcomes: Mapping of seed key to that seed's representative binary outcome.
+
+    Returns:
+        ``(success_rate, stability_score)`` where ``success_rate`` is the fraction
+        of seeds with outcome 1 and ``stability_score`` is the fraction of seeds
+        agreeing with the majority outcome (range ``[0.5, 1.0]``; 1.0 == unanimous).
+    """
+    n = len(seed_outcomes)
+    ones = sum(1 for v in seed_outcomes.values() if v == 1)
+    success_rate = ones / n
+    stability_score = max(success_rate, 1.0 - success_rate)
+    return success_rate, stability_score
+
+
+def _ingest_records(
+    records: Sequence[dict[str, Any]],
+    *,
+    outcome_metric: str,
+    group_by: str,
+    fallback_group_by: str,
+    seed_field: str,
+) -> tuple[dict[str, tuple[str, str]], dict[str, dict[str, list[int]]], int, int]:
+    """Group episode outcomes into ``(scenario, planner)`` cells by seed.
+
+    Returns:
+        ``(cell_meta, cell_seed_outcomes, n_missing_outcome, n_missing_scenario)``
+        where ``cell_seed_outcomes[cell][seed]`` lists that seed's binary outcomes.
+    """
+    cell_meta: dict[str, tuple[str, str]] = {}
+    cell_seed_outcomes: dict[str, dict[str, list[int]]] = defaultdict(lambda: defaultdict(list))
+    n_missing_outcome = 0
+    n_missing_scenario = 0
+
+    for record in records:
+        scenario_id = get_nested(record, "scenario_id")
+        if scenario_id is None:
+            n_missing_scenario += 1
+            continue
+        planner = (
+            resolve_report_group_key(
+                record,
+                group_by=group_by,
+                fallback_group_by=fallback_group_by,
+                missing="unknown",
+            )
+            or "unknown"
+        )
+        outcome = _outcome_from_record(record, outcome_metric)
+        if outcome is None:
+            n_missing_outcome += 1
+            continue
+        cell_key = f"{scenario_id}::{planner}"
+        cell_meta[cell_key] = (str(scenario_id), str(planner))
+        cell_seed_outcomes[cell_key][_seed_key(record, seed_field)].append(outcome)
+
+    return cell_meta, cell_seed_outcomes, n_missing_outcome, n_missing_scenario
+
+
+def _audit_cell(
+    cell_key: str,
+    scenario_id: str,
+    planner: str,
+    seed_map: dict[str, list[int]],
+    *,
+    stability_threshold: float,
+    min_seeds: int,
+) -> tuple[dict[str, Any], list[dict[str, Any]], int, int]:
+    """Score a single cell's stability and detect within-seed non-determinism.
+
+    Returns:
+        ``(cell_report, determinism_examples, checked_repeat_groups,
+        nondeterministic_repeat_groups)``.
+    """
+    seed_votes: dict[str, int] = {}
+    examples: list[dict[str, Any]] = []
+    nondeterministic_seeds = 0
+    has_within_seed_repeats = False
+    checked_repeat_groups = 0
+    nondeterministic_repeat_groups = 0
+    n_episodes = 0
+
+    for seed_key, outcomes in seed_map.items():
+        n_episodes += len(outcomes)
+        if len(outcomes) >= 2:
+            has_within_seed_repeats = True
+            checked_repeat_groups += 1
+            if len(set(outcomes)) > 1:
+                nondeterministic_repeat_groups += 1
+                nondeterministic_seeds += 1
+                examples.append(
+                    {
+                        "scenario_id": scenario_id,
+                        "planner": planner,
+                        "seed": seed_key,
+                        "n_repeats": len(outcomes),
+                        "outcomes": list(outcomes),
+                    }
+                )
+        # Representative vote for this seed: majority (ties -> 1, matching
+        # `_binary_outcome`'s >= 0.5 rule) so within-seed repeats collapse to one
+        # cross-seed vote.
+        seed_votes[seed_key] = 1 if (sum(outcomes) / len(outcomes)) >= 0.5 else 0
+
+    n_seeds = len(seed_votes)
+    ones = sum(seed_votes.values())
+    assessable = n_seeds >= min_seeds
+    if assessable:
+        success_rate, stability_score = _cell_stability(seed_votes)
+        knife_edge = stability_score < stability_threshold
+    else:
+        success_rate = ones / n_seeds if n_seeds else None
+        stability_score = None
+        knife_edge = False
+
+    cell_report = {
+        "cell_key": cell_key,
+        "scenario_id": scenario_id,
+        "planner": planner,
+        "n_seeds": n_seeds,
+        "n_episodes": n_episodes,
+        "success_rate": success_rate,
+        "stability_score": stability_score,
+        "knife_edge": knife_edge,
+        "assessable": assessable,
+        "outcome_counts": {"1": ones, "0": n_seeds - ones},
+        "has_within_seed_repeats": has_within_seed_repeats,
+        "nondeterministic_seeds": nondeterministic_seeds,
+    }
+    return cell_report, examples, checked_repeat_groups, nondeterministic_repeat_groups
+
+
+def compute_flakiness_audit(
+    records: Sequence[dict[str, Any]],
+    *,
+    outcome_metric: str = DEFAULT_OUTCOME_METRIC,
+    group_by: str = DEFAULT_REPORT_GROUP_BY,
+    fallback_group_by: str = DEFAULT_REPORT_FALLBACK_GROUP_BY,
+    seed_field: str = "seed",
+    stability_threshold: float = DEFAULT_STABILITY_THRESHOLD,
+    min_seeds: int = DEFAULT_MIN_SEEDS,
+) -> dict[str, Any]:
+    """Audit scenario-level outcome flakiness from benchmark episode records.
+
+    Builds ``(scenario, planner)`` cells and, within each cell, groups episodes
+    by seed. It measures exact-repeat determinism (repeated runs of the same
+    seed) and per-cell outcome stability (agreement across seeds).
+
+    Args:
+        records: Episode records with a ``scenario_id``, a planner-identifying
+            field resolvable via ``group_by``/``fallback_group_by``, a seed, and
+            the binary ``outcome_metric`` (typically under ``metrics``).
+        outcome_metric: Metric name treated as the binary outcome.
+        group_by: Primary dotted path identifying the planner dimension.
+        fallback_group_by: Fallback dotted path when ``group_by`` is missing.
+        seed_field: Dotted path to the seed field.
+        stability_threshold: Majority-agreement fraction below which a cell is
+            flagged ``knife_edge``.
+        min_seeds: Minimum distinct seeds before a cell's stability is assessed.
+
+    Returns:
+        A schema-versioned audit report (see module docstring for structure).
+
+    Raises:
+        ValueError: When ``records`` is empty (an audit of nothing is not
+            evidence) or when ``stability_threshold`` is outside ``(0, 1]``.
+    """
+    if not records:
+        raise ValueError(
+            "scenario flakiness audit requires at least one episode record; "
+            "refusing to report stability with no evidence"
+        )
+    if not (0.0 < stability_threshold <= 1.0):
+        raise ValueError(f"stability_threshold must be in (0, 1], got {stability_threshold}")
+
+    cell_meta, cell_seed_outcomes, n_missing_outcome, n_missing_scenario = _ingest_records(
+        records,
+        outcome_metric=outcome_metric,
+        group_by=group_by,
+        fallback_group_by=fallback_group_by,
+        seed_field=seed_field,
+    )
+
+    cells: list[dict[str, Any]] = []
+    determinism_examples: list[dict[str, Any]] = []
+    checked_repeat_groups = 0
+    nondeterministic_repeat_groups = 0
+
+    for cell_key in sorted(cell_seed_outcomes):
+        scenario_id, planner = cell_meta[cell_key]
+        cell_report, examples, checked, nondeterministic = _audit_cell(
+            cell_key,
+            scenario_id,
+            planner,
+            cell_seed_outcomes[cell_key],
+            stability_threshold=stability_threshold,
+            min_seeds=min_seeds,
+        )
+        cells.append(cell_report)
+        checked_repeat_groups += checked
+        nondeterministic_repeat_groups += nondeterministic
+        for example in examples:
+            if len(determinism_examples) < _MAX_EXAMPLES:
+                determinism_examples.append(example)
+
+    assessable_cells = [c for c in cells if c["assessable"]]
+    knife_edge_cells = [c for c in assessable_cells if c["knife_edge"]]
+
+    # Determinism verdict fails closed: unknown when no repeat data exists.
+    if checked_repeat_groups == 0:
+        is_deterministic: bool | None = None
+    else:
+        is_deterministic = nondeterministic_repeat_groups == 0
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "outcome_metric": outcome_metric,
+        "group_by": group_by,
+        "fallback_group_by": fallback_group_by,
+        "stability_threshold": stability_threshold,
+        "min_seeds": min_seeds,
+        "exact_repeat": {
+            "checked_repeat_groups": checked_repeat_groups,
+            "nondeterministic_repeat_groups": nondeterministic_repeat_groups,
+            "is_deterministic": is_deterministic,
+            "examples": determinism_examples,
+        },
+        "summary": {
+            "n_records": len(records),
+            "n_cells": len(cells),
+            "n_assessable_cells": len(assessable_cells),
+            "n_knife_edge_cells": len(knife_edge_cells),
+            "knife_edge_fraction": (
+                len(knife_edge_cells) / len(assessable_cells) if assessable_cells else None
+            ),
+            "n_records_missing_outcome": n_missing_outcome,
+            "n_records_missing_scenario": n_missing_scenario,
+        },
+        "cells": cells,
+    }

--- a/robot_sf/benchmark/scenario_flakiness.py
+++ b/robot_sf/benchmark/scenario_flakiness.py
@@ -21,6 +21,19 @@ The audit fails closed: an empty record set raises, cells with too few seeds are
 reported as *not assessable* rather than silently counted as stable, and
 determinism is reported as ``None`` (unknown) when no exact-repeat data exists
 instead of being asserted without evidence.
+
+Observation-track policy
+------------------------
+The audit enforces the benchmark observation-track boundary (issue #5072). By
+default (``strict`` mode) it refuses to pool records that declare different
+``benchmark_track`` values into one stability cell, because those rows use
+incompatible observation contracts and must not be compared. Callers that
+*intentionally* want a cross-track diagnostic may opt in with
+``observation_track_mode="diagnostic-cross-track"``: the audit then keeps the
+tracks visibly separated by partitioning cells per track (``track :: scenario ::
+planner``) and emits a cross-track caveat. This reuses the canonical
+``observation-track`` policy helpers shared by the aggregate/report CLIs so the
+behavior is consistent across benchmark subcommands.
 """
 
 from __future__ import annotations
@@ -29,6 +42,11 @@ import math
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
+from robot_sf.benchmark.aggregate import (
+    ensure_observation_track_policy,
+    normalize_observation_track_mode,
+    resolve_benchmark_track,
+)
 from robot_sf.benchmark.grouping import (
     DEFAULT_REPORT_FALLBACK_GROUP_BY,
     DEFAULT_REPORT_GROUP_BY,
@@ -51,6 +69,11 @@ DEFAULT_STABILITY_THRESHOLD = 0.8
 
 #: Minimum distinct seeds required before a cell's stability can be assessed.
 DEFAULT_MIN_SEEDS = 2
+
+#: Default observation-track pooling policy. ``strict`` refuses to compare rows
+#: that declare different ``benchmark_track`` values; opt in to
+#: ``diagnostic-cross-track`` for an explicitly caveated per-track partition.
+DEFAULT_OBSERVATION_TRACK_MODE = "strict"
 
 #: Cap on how many concrete examples are embedded in the report for each list so
 #: the JSON stays compact on large campaigns.
@@ -127,14 +150,31 @@ def _ingest_records(
     group_by: str,
     fallback_group_by: str,
     seed_field: str,
-) -> tuple[dict[str, tuple[str, str]], dict[str, dict[str, list[int]]], int, int]:
-    """Group episode outcomes into ``(scenario, planner)`` cells by seed.
+    observation_track_mode: str,
+) -> tuple[
+    dict[str, tuple[str, str, str]],
+    dict[str, dict[str, list[int]]],
+    int,
+    int,
+]:
+    """Group episode outcomes into ``(scenario, planner[, track])`` cells by seed.
+
+    In ``diagnostic-cross-track`` mode each cell is additionally partitioned by
+    its resolved ``benchmark_track`` so stability numbers are never computed
+    across incompatible observation contracts. In ``strict`` mode the caller has
+    already guaranteed a single pooled track, so the cell key stays
+    ``scenario::planner``.
 
     Returns:
-        ``(cell_meta, cell_seed_outcomes, n_missing_outcome, n_missing_scenario)``
-        where ``cell_seed_outcomes[cell][seed]`` lists that seed's binary outcomes.
+        ``(cell_meta, cell_seed_outcomes, n_missing_outcome,
+        n_missing_scenario)`` where ``cell_meta[cell]`` is
+        ``(scenario_id, planner, track)`` and
+        ``cell_seed_outcomes[cell][seed]`` lists that seed's binary outcomes.
     """
-    cell_meta: dict[str, tuple[str, str]] = {}
+    cross_track = (
+        normalize_observation_track_mode(observation_track_mode) == "diagnostic_cross_track"
+    )
+    cell_meta: dict[str, tuple[str, str, str]] = {}
     cell_seed_outcomes: dict[str, dict[str, list[int]]] = defaultdict(lambda: defaultdict(list))
     n_missing_outcome = 0
     n_missing_scenario = 0
@@ -157,8 +197,12 @@ def _ingest_records(
         if outcome is None:
             n_missing_outcome += 1
             continue
-        cell_key = f"{scenario_id}::{planner}"
-        cell_meta[cell_key] = (str(scenario_id), str(planner))
+        track = resolve_benchmark_track(record)
+        if cross_track:
+            cell_key = f"{track}::{scenario_id}::{planner}"
+        else:
+            cell_key = f"{scenario_id}::{planner}"
+        cell_meta[cell_key] = (str(scenario_id), str(planner), track)
         cell_seed_outcomes[cell_key][_seed_key(record, seed_field)].append(outcome)
 
     return cell_meta, cell_seed_outcomes, n_missing_outcome, n_missing_scenario
@@ -168,6 +212,7 @@ def _audit_cell(
     cell_key: str,
     scenario_id: str,
     planner: str,
+    benchmark_track: str,
     seed_map: dict[str, list[int]],
     *,
     stability_threshold: float,
@@ -224,6 +269,7 @@ def _audit_cell(
         "cell_key": cell_key,
         "scenario_id": scenario_id,
         "planner": planner,
+        "benchmark_track": benchmark_track,
         "n_seeds": n_seeds,
         "n_episodes": n_episodes,
         "success_rate": success_rate,
@@ -246,6 +292,7 @@ def compute_flakiness_audit(
     seed_field: str = "seed",
     stability_threshold: float = DEFAULT_STABILITY_THRESHOLD,
     min_seeds: int = DEFAULT_MIN_SEEDS,
+    observation_track_mode: str = DEFAULT_OBSERVATION_TRACK_MODE,
 ) -> dict[str, Any]:
     """Audit scenario-level outcome flakiness from benchmark episode records.
 
@@ -264,14 +311,19 @@ def compute_flakiness_audit(
         stability_threshold: Majority-agreement fraction below which a cell is
             flagged ``knife_edge``.
         min_seeds: Minimum distinct seeds before a cell's stability is assessed.
+        observation_track_mode: ``strict`` (default) fails closed when records
+            declare mixed ``benchmark_track`` values; ``diagnostic-cross-track``
+            partitions cells per track and emits an explicit caveat.
 
     Returns:
         A schema-versioned audit report (see module docstring for structure).
 
     Raises:
         ValueError: When ``records`` has no usable episode evidence, when
-            ``stability_threshold`` is outside ``(0, 1]``, or when
-            ``min_seeds`` is not positive.
+            ``stability_threshold`` is outside ``(0, 1]``, when ``min_seeds``
+            is not positive, when ``observation_track_mode`` is neither
+            ``strict`` nor ``diagnostic-cross-track``, or when a mixed-track
+            input is supplied in strict mode.
     """
     if not records:
         raise ValueError(
@@ -282,6 +334,12 @@ def compute_flakiness_audit(
         raise ValueError(f"stability_threshold must be in (0, 1], got {stability_threshold}")
     if min_seeds < 1:
         raise ValueError(f"min_seeds must be at least 1, got {min_seeds}")
+    # Validate the mode early and, in strict mode, refuse to pool incompatible
+    # observation contracts into one stability cell (fail closed).
+    track_meta = ensure_observation_track_policy(
+        records,
+        observation_track_mode=observation_track_mode,
+    )
 
     cell_meta, cell_seed_outcomes, n_missing_outcome, n_missing_scenario = _ingest_records(
         records,
@@ -289,6 +347,7 @@ def compute_flakiness_audit(
         group_by=group_by,
         fallback_group_by=fallback_group_by,
         seed_field=seed_field,
+        observation_track_mode=observation_track_mode,
     )
     if not cell_seed_outcomes:
         raise ValueError(
@@ -302,11 +361,12 @@ def compute_flakiness_audit(
     nondeterministic_repeat_groups = 0
 
     for cell_key in sorted(cell_seed_outcomes):
-        scenario_id, planner = cell_meta[cell_key]
+        scenario_id, planner, benchmark_track = cell_meta[cell_key]
         cell_report, examples, checked, nondeterministic = _audit_cell(
             cell_key,
             scenario_id,
             planner,
+            benchmark_track,
             cell_seed_outcomes[cell_key],
             stability_threshold=stability_threshold,
             min_seeds=min_seeds,
@@ -334,6 +394,8 @@ def compute_flakiness_audit(
         "fallback_group_by": fallback_group_by,
         "stability_threshold": stability_threshold,
         "min_seeds": min_seeds,
+        "observation_track_mode": track_meta["mode"],
+        "observation_tracks": track_meta,
         "exact_repeat": {
             "checked_repeat_groups": checked_repeat_groups,
             "nondeterministic_repeat_groups": nondeterministic_repeat_groups,

--- a/robot_sf/benchmark/scenario_flakiness.py
+++ b/robot_sf/benchmark/scenario_flakiness.py
@@ -269,8 +269,9 @@ def compute_flakiness_audit(
         A schema-versioned audit report (see module docstring for structure).
 
     Raises:
-        ValueError: When ``records`` is empty (an audit of nothing is not
-            evidence) or when ``stability_threshold`` is outside ``(0, 1]``.
+        ValueError: When ``records`` has no usable episode evidence, when
+            ``stability_threshold`` is outside ``(0, 1]``, or when
+            ``min_seeds`` is not positive.
     """
     if not records:
         raise ValueError(
@@ -279,6 +280,8 @@ def compute_flakiness_audit(
         )
     if not (0.0 < stability_threshold <= 1.0):
         raise ValueError(f"stability_threshold must be in (0, 1], got {stability_threshold}")
+    if min_seeds < 1:
+        raise ValueError(f"min_seeds must be at least 1, got {min_seeds}")
 
     cell_meta, cell_seed_outcomes, n_missing_outcome, n_missing_scenario = _ingest_records(
         records,
@@ -287,6 +290,11 @@ def compute_flakiness_audit(
         fallback_group_by=fallback_group_by,
         seed_field=seed_field,
     )
+    if not cell_seed_outcomes:
+        raise ValueError(
+            "scenario flakiness audit requires at least one record with a scenario and "
+            "interpretable outcome; refusing to report stability with no usable evidence"
+        )
 
     cells: list[dict[str, Any]] = []
     determinism_examples: list[dict[str, Any]] = []

--- a/tests/benchmark/test_scenario_flakiness.py
+++ b/tests/benchmark/test_scenario_flakiness.py
@@ -181,3 +181,20 @@ def test_invalid_threshold_rejected():
     """A threshold outside (0, 1] is rejected."""
     with pytest.raises(ValueError, match="stability_threshold"):
         compute_flakiness_audit([_rec("s1", "ppo", 0, 1)], stability_threshold=1.5)
+
+
+@pytest.mark.parametrize("min_seeds", [0, -1])
+def test_nonpositive_min_seeds_rejected(min_seeds: int):
+    """A nonpositive evidence minimum cannot silently assess every cell."""
+    with pytest.raises(ValueError, match="min_seeds"):
+        compute_flakiness_audit([_rec("s1", "ppo", 0, 1)], min_seeds=min_seeds)
+
+
+def test_all_unusable_records_fail_closed():
+    """Records without a usable scenario/outcome cannot yield an empty success report."""
+    records = [
+        {"scenario_id": "s1", "algo": "ppo", "seed": 0, "metrics": {}},
+        {"algo": "ppo", "seed": 1, "metrics": {"success": 1}},
+    ]
+    with pytest.raises(ValueError, match="no usable evidence"):
+        compute_flakiness_audit(records, group_by="algo")

--- a/tests/benchmark/test_scenario_flakiness.py
+++ b/tests/benchmark/test_scenario_flakiness.py
@@ -1,0 +1,183 @@
+"""Tests for the scenario flakiness audit (issue #4978).
+
+Covers exact-repeat determinism detection, per-cell outcome-stability scoring,
+knife-edge flagging, fail-closed behavior, and planner-cell separation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.scenario_flakiness import (
+    SCHEMA_VERSION,
+    compute_flakiness_audit,
+)
+
+
+def _rec(scenario_id: str, planner: str, seed: int, success: int) -> dict:
+    """Build a minimal episode record with a binary ``success`` outcome."""
+    return {
+        "episode_id": f"{scenario_id}-{planner}-{seed}",
+        "scenario_id": scenario_id,
+        "algo": planner,
+        "seed": seed,
+        "metrics": {"success": success},
+    }
+
+
+def _cell(report: dict, cell_key: str) -> dict:
+    """Return the cell dict for ``cell_key`` from an audit report."""
+    return next(c for c in report["cells"] if c["cell_key"] == cell_key)
+
+
+def test_stable_cell_scores_full_stability():
+    """A cell whose seeds all agree is fully stable and not knife-edge."""
+    records = [_rec("s1", "ppo", seed, 1) for seed in range(4)]
+    report = compute_flakiness_audit(records, group_by="algo")
+    cell = _cell(report, "s1::ppo")
+    assert cell["stability_score"] == pytest.approx(1.0)
+    assert cell["success_rate"] == pytest.approx(1.0)
+    assert cell["knife_edge"] is False
+    assert cell["assessable"] is True
+    assert report["summary"]["n_knife_edge_cells"] == 0
+
+
+def test_knife_edge_cell_is_flagged():
+    """A 50/50 success/failure split across seeds is a knife-edge cell."""
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 1, 1),
+        _rec("s1", "ppo", 2, 0),
+        _rec("s1", "ppo", 3, 0),
+    ]
+    report = compute_flakiness_audit(records, group_by="algo", stability_threshold=0.8)
+    cell = _cell(report, "s1::ppo")
+    assert cell["success_rate"] == pytest.approx(0.5)
+    assert cell["stability_score"] == pytest.approx(0.5)
+    assert cell["knife_edge"] is True
+    assert report["summary"]["n_knife_edge_cells"] == 1
+    assert report["summary"]["knife_edge_fraction"] == pytest.approx(1.0)
+
+
+def test_threshold_boundary_excludes_equal_stability():
+    """Stability exactly at the threshold is not flagged (strict less-than)."""
+    # 4 seeds, 3 success / 1 fail -> dominant fraction 0.75.
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 1, 1),
+        _rec("s1", "ppo", 2, 1),
+        _rec("s1", "ppo", 3, 0),
+    ]
+    report = compute_flakiness_audit(records, group_by="algo", stability_threshold=0.75)
+    cell = _cell(report, "s1::ppo")
+    assert cell["stability_score"] == pytest.approx(0.75)
+    assert cell["knife_edge"] is False
+
+
+def test_exact_repeat_determinism_pass():
+    """Repeated runs of a seed that agree count as deterministic repeat groups."""
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 0, 1),  # exact repeat, same outcome
+        _rec("s1", "ppo", 1, 1),
+        _rec("s1", "ppo", 1, 1),
+    ]
+    report = compute_flakiness_audit(records, group_by="algo")
+    er = report["exact_repeat"]
+    assert er["checked_repeat_groups"] == 2
+    assert er["nondeterministic_repeat_groups"] == 0
+    assert er["is_deterministic"] is True
+    assert er["examples"] == []
+
+
+def test_exact_repeat_nondeterminism_detected():
+    """Repeated runs of a seed that disagree are flagged as non-deterministic."""
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 0, 0),  # same seed, flipped outcome -> reproducibility bug
+        _rec("s1", "ppo", 1, 1),
+        _rec("s1", "ppo", 2, 1),
+    ]
+    report = compute_flakiness_audit(records, group_by="algo")
+    er = report["exact_repeat"]
+    assert er["checked_repeat_groups"] == 1
+    assert er["nondeterministic_repeat_groups"] == 1
+    assert er["is_deterministic"] is False
+    assert len(er["examples"]) == 1
+    example = er["examples"][0]
+    assert example["scenario_id"] == "s1"
+    assert example["seed"] == "0"
+    assert sorted(example["outcomes"]) == [0, 1]
+    # The nondeterministic seed is recorded on the cell too.
+    cell = _cell(report, "s1::ppo")
+    assert cell["nondeterministic_seeds"] == 1
+    assert cell["has_within_seed_repeats"] is True
+
+
+def test_determinism_unknown_without_repeat_data():
+    """With no exact-repeat data, determinism is unknown (fail closed, not True)."""
+    records = [_rec("s1", "ppo", seed, 1) for seed in range(3)]
+    report = compute_flakiness_audit(records, group_by="algo")
+    er = report["exact_repeat"]
+    assert er["checked_repeat_groups"] == 0
+    assert er["is_deterministic"] is None
+
+
+def test_single_seed_cell_not_assessable():
+    """A cell with fewer than min_seeds is reported but not scored or flagged."""
+    records = [_rec("s1", "ppo", 0, 0)]
+    report = compute_flakiness_audit(records, group_by="algo", min_seeds=2)
+    cell = _cell(report, "s1::ppo")
+    assert cell["assessable"] is False
+    assert cell["stability_score"] is None
+    assert cell["knife_edge"] is False
+    assert report["summary"]["n_assessable_cells"] == 0
+    assert report["summary"]["knife_edge_fraction"] is None
+
+
+def test_planner_cells_are_separated():
+    """Records for different planners on the same scenario form distinct cells."""
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 1, 1),
+        _rec("s1", "orca", 0, 0),
+        _rec("s1", "orca", 1, 0),
+    ]
+    report = compute_flakiness_audit(records, group_by="algo")
+    keys = {c["cell_key"] for c in report["cells"]}
+    assert keys == {"s1::ppo", "s1::orca"}
+    assert _cell(report, "s1::ppo")["success_rate"] == pytest.approx(1.0)
+    assert _cell(report, "s1::orca")["success_rate"] == pytest.approx(0.0)
+
+
+def test_missing_outcome_records_counted_not_scored():
+    """Records lacking the outcome metric are counted, not silently scored."""
+    records = [
+        _rec("s1", "ppo", 0, 1),
+        _rec("s1", "ppo", 1, 1),
+        {"episode_id": "x", "scenario_id": "s1", "algo": "ppo", "seed": 2, "metrics": {}},
+    ]
+    report = compute_flakiness_audit(records, group_by="algo")
+    assert report["summary"]["n_records_missing_outcome"] == 1
+    # The scored cell only reflects the two records that carried an outcome.
+    assert _cell(report, "s1::ppo")["n_seeds"] == 2
+
+
+def test_schema_version_and_metadata_present():
+    """The report advertises its schema version and audit parameters."""
+    report = compute_flakiness_audit([_rec("s1", "ppo", 0, 1)], group_by="algo")
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["outcome_metric"] == "success"
+    assert report["stability_threshold"] == pytest.approx(0.8)
+
+
+def test_empty_records_fail_closed():
+    """An audit of no records raises rather than asserting stability."""
+    with pytest.raises(ValueError, match="at least one episode record"):
+        compute_flakiness_audit([])
+
+
+def test_invalid_threshold_rejected():
+    """A threshold outside (0, 1] is rejected."""
+    with pytest.raises(ValueError, match="stability_threshold"):
+        compute_flakiness_audit([_rec("s1", "ppo", 0, 1)], stability_threshold=1.5)

--- a/tests/benchmark/test_scenario_flakiness.py
+++ b/tests/benchmark/test_scenario_flakiness.py
@@ -198,3 +198,106 @@ def test_all_unusable_records_fail_closed():
     ]
     with pytest.raises(ValueError, match="no usable evidence"):
         compute_flakiness_audit(records, group_by="algo")
+
+
+def _track_rec(scenario_id: str, planner: str, seed: int, success: int, track: str) -> dict:
+    """Build an episode record that declares a ``benchmark_track`` observation contract."""
+    rec = _rec(scenario_id, planner, seed, success)
+    rec["benchmark_track"] = track
+    return rec
+
+
+def test_strict_mode_fails_closed_for_mixed_observation_tracks():
+    """Issue #5072: default strict mode refuses to pool incompatible observation tracks."""
+    from robot_sf.benchmark.errors import AggregationMetadataError
+
+    records = [
+        _track_rec("s1", "ppo", 0, 1, "lidar_2d_v1"),
+        _track_rec("s1", "ppo", 1, 1, "lidar_2d_v1"),
+        _track_rec("s1", "ppo", 2, 0, "grid_socnav_v1"),
+        _track_rec("s1", "ppo", 3, 0, "grid_socnav_v1"),
+    ]
+    with pytest.raises(AggregationMetadataError, match="Mixed benchmark_track values") as excinfo:
+        compute_flakiness_audit(records, group_by="algo")
+    assert "lidar_2d_v1" in str(excinfo.value)
+    assert "grid_socnav_v1" in str(excinfo.value)
+    assert "diagnostic-cross-track" in (excinfo.value.advice or "")
+
+
+def test_strict_mode_allows_single_declared_track():
+    """Issue #5072: a homogeneous-track fixture remains compatible in strict mode."""
+    records = [
+        _track_rec("s1", "ppo", 0, 1, "lidar_2d_v1"),
+        _track_rec("s1", "ppo", 1, 1, "lidar_2d_v1"),
+    ]
+    report = compute_flakiness_audit(records, group_by="algo")
+    assert report["observation_track_mode"] == "strict"
+    assert report["observation_tracks"]["mixed_tracks"] is False
+    assert report["observation_tracks"]["selected_track"] == "lidar_2d_v1"
+    cell = _cell(report, "s1::ppo")
+    assert cell["benchmark_track"] == "lidar_2d_v1"
+    assert cell["stability_score"] == pytest.approx(1.0)
+
+
+def test_undeclared_track_single_track_fixture_remains_compatible():
+    """Issue #5072: records with no benchmark_track stay a single (unspecified) track."""
+    records = [_rec("s1", "ppo", seed, 1) for seed in range(3)]
+    report = compute_flakiness_audit(records, group_by="algo")
+    assert report["observation_tracks"]["mixed_tracks"] is False
+    assert report["summary"]["n_cells"] == 1
+
+
+def test_diagnostic_cross_track_partitions_cells_per_track():
+    """Issue #5072: opt-in diagnostic mode keeps mixed tracks as separate per-track cells."""
+    records = [
+        _track_rec("s1", "ppo", 0, 1, "lidar_2d_v1"),
+        _track_rec("s1", "ppo", 1, 1, "lidar_2d_v1"),
+        _track_rec("s1", "ppo", 2, 0, "grid_socnav_v1"),
+        _track_rec("s1", "ppo", 3, 0, "grid_socnav_v1"),
+    ]
+    report = compute_flakiness_audit(
+        records,
+        group_by="algo",
+        observation_track_mode="diagnostic-cross-track",
+    )
+    assert report["observation_track_mode"] == "diagnostic_cross_track"
+    assert report["observation_tracks"]["mixed_tracks"] is True
+    assert "cross_track_caveat" in report["observation_tracks"]
+    keys = {c["cell_key"] for c in report["cells"]}
+    assert keys == {"lidar_2d_v1::s1::ppo", "grid_socnav_v1::s1::ppo"}
+    by_key = {c["cell_key"]: c for c in report["cells"]}
+    assert by_key["lidar_2d_v1::s1::ppo"]["benchmark_track"] == "lidar_2d_v1"
+    assert by_key["lidar_2d_v1::s1::ppo"]["success_rate"] == pytest.approx(1.0)
+    assert by_key["grid_socnav_v1::s1::ppo"]["benchmark_track"] == "grid_socnav_v1"
+    assert by_key["grid_socnav_v1::s1::ppo"]["success_rate"] == pytest.approx(0.0)
+    # The two tracks are never pooled into one false knife-edge cell.
+    assert all(c["knife_edge"] is False for c in report["cells"])
+
+
+def test_diagnostic_cross_track_does_not_mask_a_true_knife_edge():
+    """Issue #5072: per-track partitioning still flags genuinely knife-edge cells."""
+    records = [
+        _track_rec("s1", "ppo", 0, 1, "lidar_2d_v1"),
+        _track_rec("s1", "ppo", 1, 0, "lidar_2d_v1"),
+        _track_rec("s1", "ppo", 2, 1, "grid_socnav_v1"),
+        _track_rec("s1", "ppo", 3, 1, "grid_socnav_v1"),
+    ]
+    report = compute_flakiness_audit(
+        records,
+        group_by="algo",
+        observation_track_mode="diagnostic-cross-track",
+        stability_threshold=0.8,
+    )
+    by_key = {c["cell_key"]: c for c in report["cells"]}
+    assert by_key["lidar_2d_v1::s1::ppo"]["knife_edge"] is True
+    assert by_key["grid_socnav_v1::s1::ppo"]["knife_edge"] is False
+
+
+def test_invalid_observation_track_mode_rejected():
+    """Issue #5072: an unknown track mode fails closed rather than silently pooling."""
+    with pytest.raises(ValueError, match="observation_track_mode"):
+        compute_flakiness_audit(
+            [_rec("s1", "ppo", 0, 1)],
+            group_by="algo",
+            observation_track_mode="bogus",
+        )

--- a/tests/test_cli_flakiness_audit.py
+++ b/tests/test_cli_flakiness_audit.py
@@ -72,3 +72,25 @@ def test_cli_flakiness_audit_missing_input_fails_closed(tmp_path: Path):
     )
     assert rc == 2
     assert not out_json.exists()
+
+
+def test_cli_flakiness_audit_rejects_nonpositive_min_seeds(tmp_path: Path):
+    """The CLI rejects a semantic configuration that removes the evidence floor."""
+    episodes = tmp_path / "episodes.jsonl"
+    _write_episodes(episodes)
+    out_json = tmp_path / "flakiness.json"
+
+    rc = cli_main(
+        [
+            "flakiness-audit",
+            "--in",
+            str(episodes),
+            "--out",
+            str(out_json),
+            "--min-seeds",
+            "0",
+        ],
+    )
+
+    assert rc == 2
+    assert not out_json.exists()

--- a/tests/test_cli_flakiness_audit.py
+++ b/tests/test_cli_flakiness_audit.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import pytest
+
 from robot_sf.benchmark.cli import cli_main
 
 if TYPE_CHECKING:
@@ -94,3 +96,133 @@ def test_cli_flakiness_audit_rejects_nonpositive_min_seeds(tmp_path: Path):
 
     assert rc == 2
     assert not out_json.exists()
+
+
+def _write_mixed_track_episodes(path: Path) -> None:
+    """Write episodes that mix two ``benchmark_track`` observation contracts on one cell."""
+    records = [
+        # lidar_2d_v1 track on s1/ppo: unanimous success
+        {
+            "scenario_id": "s1",
+            "algo": "ppo",
+            "seed": 0,
+            "benchmark_track": "lidar_2d_v1",
+            "metrics": {"success": 1},
+        },
+        {
+            "scenario_id": "s1",
+            "algo": "ppo",
+            "seed": 1,
+            "benchmark_track": "lidar_2d_v1",
+            "metrics": {"success": 1},
+        },
+        # grid_socnav_v1 track on s1/ppo: unanimous failure
+        {
+            "scenario_id": "s1",
+            "algo": "ppo",
+            "seed": 2,
+            "benchmark_track": "grid_socnav_v1",
+            "metrics": {"success": 0},
+        },
+        {
+            "scenario_id": "s1",
+            "algo": "ppo",
+            "seed": 3,
+            "benchmark_track": "grid_socnav_v1",
+            "metrics": {"success": 0},
+        },
+    ]
+    with path.open("w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+
+
+def test_cli_flakiness_audit_strict_fails_closed_for_mixed_tracks(tmp_path: Path, capsys):
+    """Issue #5072: mixed observation tracks fail closed by default (exit code 2)."""
+    episodes = tmp_path / "mixed.jsonl"
+    _write_mixed_track_episodes(episodes)
+    out_json = tmp_path / "flakiness.json"
+
+    rc = cli_main(
+        [
+            "flakiness-audit",
+            "--in",
+            str(episodes),
+            "--out",
+            str(out_json),
+            "--group-by",
+            "algo",
+        ],
+    )
+    assert rc == 2
+    assert not out_json.exists()
+
+
+def test_cli_flakiness_audit_diagnostic_cross_track_partitions_per_track(tmp_path: Path, capsys):
+    """Issue #5072: opt-in diagnostic mode separates mixed tracks into per-track cells."""
+    episodes = tmp_path / "mixed.jsonl"
+    _write_mixed_track_episodes(episodes)
+    out_json = tmp_path / "flakiness.json"
+
+    rc = cli_main(
+        [
+            "flakiness-audit",
+            "--in",
+            str(episodes),
+            "--out",
+            str(out_json),
+            "--group-by",
+            "algo",
+            "--observation-track-mode",
+            "diagnostic-cross-track",
+        ],
+    )
+    cap = capsys.readouterr()
+    assert rc == 0, f"flakiness-audit failed: {cap.err}"
+
+    report = json.loads(out_json.read_text(encoding="utf-8"))
+    assert report["observation_track_mode"] == "diagnostic_cross_track"
+    assert report["observation_tracks"]["mixed_tracks"] is True
+    keys = {c["cell_key"] for c in report["cells"]}
+    assert keys == {"lidar_2d_v1::s1::ppo", "grid_socnav_v1::s1::ppo"}
+    # The two tracks are never pooled into one false knife-edge cell.
+    assert all(c["knife_edge"] is False for c in report["cells"])
+
+
+def test_cli_flakiness_audit_rejects_unknown_track_mode(tmp_path: Path):
+    """Issue #5072: an invalid track mode is rejected before any report is written.
+
+    argparse rejects unknown ``choices`` at parse time with a non-zero exit, so no
+    report file is produced. We assert the process fails closed rather than emit.
+    """
+    episodes = tmp_path / "mixed.jsonl"
+    _write_mixed_track_episodes(episodes)
+    out_json = tmp_path / "flakiness.json"
+
+    with pytest.raises(SystemExit):
+        cli_main(
+            [
+                "flakiness-audit",
+                "--in",
+                str(episodes),
+                "--out",
+                str(out_json),
+                "--group-by",
+                "algo",
+                "--observation-track-mode",
+                "bogus",
+            ],
+        )
+    assert not out_json.exists()
+
+
+def test_cli_flakiness_audit_help_documents_track_policy(capsys):
+    """Issue #5072: the ``flakiness-audit`` help makes the observation-track policy reproducible."""
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main(["flakiness-audit", "--help"])
+    # ``--help`` exits 0 after printing usage; never a failure.
+    assert excinfo.value.code in (0, None)
+    help_text = capsys.readouterr().out
+    assert "--observation-track-mode" in help_text
+    assert "diagnostic-cross-track" in help_text
+    assert "benchmark_track" in help_text

--- a/tests/test_cli_flakiness_audit.py
+++ b/tests/test_cli_flakiness_audit.py
@@ -1,0 +1,74 @@
+"""CLI tests for the ``flakiness-audit`` benchmark subcommand (issue #4978)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.cli import cli_main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_episodes(path: Path) -> None:
+    """Write a small episode JSONL with one stable and one knife-edge cell."""
+    records = [
+        # s1/ppo: unanimous success -> stable
+        {"scenario_id": "s1", "algo": "ppo", "seed": 0, "metrics": {"success": 1}},
+        {"scenario_id": "s1", "algo": "ppo", "seed": 1, "metrics": {"success": 1}},
+        # s2/ppo: 50/50 split across seeds -> knife-edge
+        {"scenario_id": "s2", "algo": "ppo", "seed": 0, "metrics": {"success": 1}},
+        {"scenario_id": "s2", "algo": "ppo", "seed": 1, "metrics": {"success": 0}},
+    ]
+    with path.open("w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+
+
+def test_cli_flakiness_audit_writes_report(tmp_path: Path, capsys):
+    """The subcommand loads JSONL, scores cells, and writes a JSON report."""
+    episodes = tmp_path / "episodes.jsonl"
+    _write_episodes(episodes)
+    out_json = tmp_path / "flakiness.json"
+
+    rc = cli_main(
+        [
+            "flakiness-audit",
+            "--in",
+            str(episodes),
+            "--out",
+            str(out_json),
+            "--group-by",
+            "algo",
+        ],
+    )
+    cap = capsys.readouterr()
+    assert rc == 0, f"flakiness-audit failed: {cap.err}"
+
+    report = json.loads(out_json.read_text(encoding="utf-8"))
+    assert report["schema_version"] == "scenario_flakiness.v1"
+    assert report["summary"]["n_cells"] == 2
+    assert report["summary"]["n_knife_edge_cells"] == 1
+    # No exact-repeat data present -> determinism unknown, fail closed.
+    assert report["exact_repeat"]["is_deterministic"] is None
+
+    by_key = {c["cell_key"]: c for c in report["cells"]}
+    assert by_key["s1::ppo"]["knife_edge"] is False
+    assert by_key["s2::ppo"]["knife_edge"] is True
+
+
+def test_cli_flakiness_audit_missing_input_fails_closed(tmp_path: Path):
+    """A missing input path fails closed with a non-zero exit code."""
+    out_json = tmp_path / "flakiness.json"
+    rc = cli_main(
+        [
+            "flakiness-audit",
+            "--in",
+            str(tmp_path / "does_not_exist.jsonl"),
+            "--out",
+            str(out_json),
+        ],
+    )
+    assert rc == 2
+    assert not out_json.exists()


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** `compute_flakiness_audit` (`robot_sf/benchmark/scenario_flakiness.py`, from #4978) and the `robot_sf_bench flakiness-audit` CLI now enforce the benchmark observation-track boundary they previously deferred (#5072). A new `--observation-track-mode` flag (default `strict`) refuses to pool records that declare different `benchmark_track` values into one stability cell; an opt-in `diagnostic-cross-track` mode partitions cells per track with an explicit caveat.
- **Why now:** Issue #5072 — the flakiness audit grouped episode JSONL into `(scenario, planner)` cells without enforcing the observation-track boundary, so a mixed `benchmark_track` input could combine rows that should not be compared into one stability cell. This was explicitly deferred from PR #5069 during gate review ("distinct benchmark-input contract").
- **Claim boundary:** Read-only diagnostic capability only. Reuses the canonical `observation-track` policy helpers already shared by the aggregate/report CLIs (`robot_sf/benchmark/aggregate.py`), so behavior is consistent across benchmark subcommands. **No change to rankings, campaign summaries, or any benchmark/metric semantics.** Validated on CPU fixtures only; no campaign/Slurm/GPU run.
- **Required validation:** `ruff check` + `ruff format` clean on all changed files; 28 focused tests pass (18 existing + 10 new).
- **Remaining blocker:** None for the coded slice.

## ⚠️ Stacked PR — depends on PR #5069 (base = `issue-4978-scenario-flakiness-audit`)

The flakiness audit code (`scenario_flakiness.py`) lives **only** in the open, unmerged PR #5069 (`issue-4978-scenario-flakiness-audit`). It is **not** on `origin/main`. Issue #5072 is "deferred from PR #5069 during gate review because it is a distinct benchmark-input contract" — i.e. a follow-up that builds on #5069's code.

Therefore this PR is a **stacked PR with base `issue-4978-scenario-flakiness-audit`** (PR #5069's branch) so the diff shows **only** the new observation-track handling and does **not** duplicate #5069. It should be reviewed/merged **after/with** #5069; when #5069 merges to `main`, GitHub auto-retargets this PR to `main`. (If the reviewer prefers, the single commit here can also be cherry-picked directly into #5069.)

This is a **successor slice** of the flakiness-audit work; it **does not duplicate PR #5069** — it adds the new observation-track fail-closed capability that #5069 explicitly deferred.

## Contract delta

- **`compute_flakiness_audit` gains `observation_track_mode: str = "strict"`** (reuses `ensure_observation_track_policy` / `resolve_benchmark_track` / `normalize_observation_track_mode` from `robot_sf/benchmark/aggregate.py`):
  - **`strict` (default):** fails closed — raises `AggregationMetadataError` (a `ValueError` subclass) when the input declares mixed `benchmark_track` values, with advice pointing to the opt-in mode. The CLI handler catches `ValueError` → exit code 2.
  - **`diagnostic-cross-track` (opt-in):** partitions cells per track (`track :: scenario :: planner`) so stability numbers are never computed across incompatible observation contracts, and the report's `observation_tracks` block carries an explicit `cross_track_caveat`.
- **Report metadata (reproducibility):** reports gain a top-level `observation_track_mode` and an `observation_tracks` block (`mode`, `tracks`, `mixed_tracks`, `selected_track`, caveat count/policy); each cell gains a `benchmark_track` field.
- **CLI:** `--observation-track-mode {strict,diagnostic-cross-track}` (default `strict`) added to `flakiness-audit`, with help text documenting the policy.
- **Compatibility:** additive and policy-only. Single-track and undeclared-track fixtures remain compatible in strict mode (all 18 pre-existing #4978 tests still pass unchanged).

## Acceptance criteria (#5072)

- [x] A mixed-track fixture fails closed (strict mode raises `AggregationMetadataError` / CLI exit code 2); **or** produces explicitly separated per-track reports under the opt-in `diagnostic-cross-track` mode.
- [x] A single-track fixture remains compatible (strict mode passes; existing tests unchanged).
- [x] CLI/help and report metadata make the track policy reproducible (`--observation-track-mode` help documents it; report carries `observation_track_mode` + `observation_tracks` block + per-cell `benchmark_track`).

## Validation

Run in an isolated worktree reusing the shared venv (`scripts/dev/run_worktree_shared_venv.sh`):

```
ruff check robot_sf/benchmark/scenario_flakiness.py robot_sf/benchmark/cli.py \
  tests/benchmark/test_scenario_flakiness.py tests/test_cli_flakiness_audit.py
# -> All checks passed!

ruff format --check robot_sf/benchmark/scenario_flakiness.py robot_sf/benchmark/cli.py \
  tests/benchmark/test_scenario_flakiness.py tests/test_cli_flakiness_audit.py
# -> 4 files already formatted

python -m pytest tests/benchmark/test_scenario_flakiness.py tests/test_cli_flakiness_audit.py -q
# -> 28 passed in 2.49s  (18 existing + 10 new)
```

End-to-end smoke on a mixed-track fixture (same `scenario`/`planner`, two tracks): strict raises `Mixed benchmark_track values cannot be pooled by default: grid_socnav_v1, lidar_2d_v1`; `diagnostic-cross-track` yields two separate cells `lidar_2d_v1::s1::ppo` (stability 1.0, success 1.0) and `grid_socnav_v1::s1::ppo` (stability 1.0, success 0.0) instead of one false knife-edge cell, with `observation_tracks.mixed_tracks=true` and a `cross_track_caveat`.

**Pre-existing failure (out of scope, not caused by this PR):** `tests/test_cli_table.py::test_cli_table_diagnostic_cross_track_labels_benchmark_track` fails identically on the clean PR #5069 branch tip (verified in a throwaway worktree); it concerns the unrelated `table` command / `report_table.py`, which this PR does not touch.

New tests (10): module-level — strict fail-closed for mixed tracks; strict allows single declared track; undeclared-track single-track fixture remains compatible; diagnostic-cross-track partitions per track (and does not mask a true knife-edge); invalid mode rejected. CLI — strict fails closed (exit 2) for mixed tracks; diagnostic-cross-track partitions per track; unknown mode rejected before output; `--help` documents the policy.

## Downstream propagation

Low-churn follow-up (issue #5072 had 0 prior PRs). State surface: this PR body is the canonical status. No transient queue-routing state is written to tracked files.

Refs #5072

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
