### PR TITLE
Issue #4976: first-class braking authority + stopping-distance envelope (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/run_config_provenance.py
+++ b/robot_sf/benchmark/run_config_provenance.py
@@ -31,6 +31,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from robot_sf.robot.actuation_envelope import (
+    ACTUATION_ENVELOPE_INTERPRETATION,
+    ACTUATION_ENVELOPE_SCHEMA,
+    actuation_envelope_for_run_config,
+)
+
 #: Collision-handling regime where any collision ends the episode (the robot
 #: benchmark contract). See ``robot_sf/robot/robot_state.py``.
 COLLISION_REGIME_TERMINATE_ON_CONTACT = "terminate_on_contact"
@@ -133,7 +139,14 @@ def metric_affecting_run_config(
     static_obstacle_forces = getattr(config, "peds_have_static_obstacle_forces", None)
     robot_repulsion = getattr(config, "peds_have_robot_repulsion", None)
 
-    return {
+    # The braking-feasibility envelope is a metric-affecting setting: near-miss /
+    # TTC readings are only interpretable against the robot's actual braking
+    # authority (issue #4976). Surfaced here so per-run metadata records it
+    # alongside sensor noise and collision regime. Omitted (None) when the drive
+    # model exposes no first-class deceleration cap.
+    envelope = actuation_envelope_for_run_config(config)
+
+    result: dict[str, Any] = {
         "schema": METRIC_AFFECTING_CONFIG_SCHEMA,
         "sensor_noise": {
             "scan_noise": scan_noise,
@@ -150,3 +163,10 @@ def metric_affecting_run_config(
         },
         "interpretation": METRIC_AFFECTING_CONFIG_INTERPRETATION,
     }
+    if envelope is not None:
+        result["actuation_envelope"] = {
+            "schema": ACTUATION_ENVELOPE_SCHEMA,
+            **envelope,
+            "interpretation": ACTUATION_ENVELOPE_INTERPRETATION,
+        }
+    return result

--- a/robot_sf/robot/actuation_envelope.py
+++ b/robot_sf/robot/actuation_envelope.py
@@ -1,0 +1,216 @@
+"""Stopping-distance envelope helpers for actuation-realism provenance (issue #4976).
+
+A near-miss or time-to-collision (TTC) reading is only interpretable against the
+*braking capability* the robot actually has. A policy that can decelerate at
+``5 m/s^2`` and one capped at ``1 m/s^2`` produce very different
+stopping-distance envelopes for the same approach speed, so reporting a near-miss
+count without the braking envelope hides a safety-critical degree of freedom.
+
+This module owns the small, pure, JSON-safe helpers that:
+
+* compute the worst-case stopping distance ``d = v^2 / (2a)`` from a peak speed
+  ``v`` and a braking-deceleration magnitude ``a``, and
+* extract the per-drive-model envelope (forward acceleration, braking
+  authority, peak speed, and the resulting stopping distance) from a
+  drive-settings object via duck typing, so benchmark run metadata can record
+  the envelope alongside sensor-noise and collision-regime provenance.
+
+These helpers are deliberately standard-library only so they can be imported
+without simulator dependencies, and they degrade to explicit ``not_available``
+sentinels when a drive model exposes no deceleration authority (e.g. a
+velocity-level model), instead of silently emitting a meaningless envelope.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+#: Human-readable note explaining how the envelope block should be interpreted.
+ACTUATION_ENVELOPE_INTERPRETATION = (
+    "actuation_envelope: enforced acceleration/braking authority and the resulting "
+    "worst-case stopping distance v^2/(2a); near-miss / TTC readings must be "
+    "interpreted against this braking capability, not in isolation"
+)
+
+#: Schema tag for the emitted envelope block, so downstream readers can version it.
+ACTUATION_ENVELOPE_SCHEMA = "actuation_envelope.v1"
+
+#: Sentinel for envelope values that cannot be computed from a drive model.
+NOT_AVAILABLE = "not_available"
+
+
+def stopping_distance(speed: float, deceleration: float) -> float:
+    """Return the worst-case stopping distance ``v^2 / (2a)`` from constant braking.
+
+    The envelope is the distance required to bring the robot to rest from
+    ``speed`` when braking at the constant deceleration magnitude
+    ``deceleration``. It is the kinematic lower bound on the braking-feasibility
+    envelope central to safety interpretations of near-miss / TTC metrics.
+
+    Args:
+        speed: Forward speed magnitude in m/s (must be finite and non-negative).
+        deceleration: Braking deceleration magnitude in m/s^2 (must be finite and
+            strictly positive).
+
+    Returns:
+        The stopping distance in meters.
+
+    Raises:
+        ValueError: If ``speed`` is negative or non-finite, or ``deceleration``
+            is not finite and strictly positive.
+    """
+    speed_value = float(speed)
+    decel_value = float(deceleration)
+    if not math.isfinite(speed_value) or speed_value < 0.0:
+        raise ValueError(f"speed must be finite and non-negative (got {speed!r})")
+    if not math.isfinite(decel_value) or decel_value <= 0.0:
+        raise ValueError(
+            f"deceleration must be finite and strictly positive (got {deceleration!r})"
+        )
+    return speed_value * speed_value / (2.0 * decel_value)
+
+
+def _as_finite_float(value: Any) -> float | None:
+    """Return ``value`` as a finite float, or ``None`` when it cannot be coerced."""
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _resolve_diff_drive_envelope(robot_config: Any) -> dict[str, Any] | None:
+    """Extract the envelope from a differential-drive settings object.
+
+    Returns:
+        The differential-drive envelope block, or ``None`` when the object does
+        not expose the differential-drive braking-authority field
+        (``max_linear_decel``).
+    """
+    max_accel = _as_finite_float(getattr(robot_config, "max_linear_accel", None))
+    max_decel = _as_finite_float(getattr(robot_config, "max_linear_decel", None))
+    # ``max_linear_speed`` is the differential-drive peak forward speed.
+    max_speed = _as_finite_float(getattr(robot_config, "max_linear_speed", None))
+    if max_accel is None or max_decel is None:
+        return None
+    return _build_envelope(
+        drive_model="differential_drive",
+        max_accel=max_accel,
+        max_decel=max_decel,
+        max_speed=max_speed,
+    )
+
+
+def _resolve_bicycle_envelope(robot_config: Any) -> dict[str, Any] | None:
+    """Extract the envelope from a bicycle-drive settings object.
+
+    Returns:
+        The bicycle-drive envelope block, or ``None`` when the object does not
+        expose the bicycle braking-authority field (``max_decel``).
+    """
+    max_accel = _as_finite_float(getattr(robot_config, "max_accel", None))
+    max_decel = _as_finite_float(getattr(robot_config, "max_decel", None))
+    # ``max_velocity`` is the bicycle-drive peak forward speed.
+    max_speed = _as_finite_float(getattr(robot_config, "max_velocity", None))
+    if max_accel is None or max_decel is None:
+        return None
+    return _build_envelope(
+        drive_model="bicycle_drive",
+        max_accel=max_accel,
+        max_decel=max_decel,
+        max_speed=max_speed,
+    )
+
+
+def _build_envelope(
+    *,
+    drive_model: str,
+    max_accel: float,
+    max_decel: float,
+    max_speed: float | None,
+) -> dict[str, Any]:
+    """Assemble a JSON-safe envelope block from resolved scalar limits.
+
+    The worst-case stopping distance is computed at the drive model's peak
+    forward speed when that speed is available and finite; otherwise it is
+    reported as ``not_available`` so a reader is never given a distance that was
+    not actually bounded by a peak speed.
+
+    Returns:
+        A JSON-safe actuation-envelope dictionary.
+    """
+    stopping_dist: float | str
+    if max_speed is not None and max_speed > 0.0:
+        stopping_dist = stopping_distance(max_speed, max_decel)
+    else:
+        stopping_dist = NOT_AVAILABLE
+    payload: dict[str, Any] = {
+        "drive_model": drive_model,
+        "max_forward_accel_m_s2": max_accel,
+        "max_braking_decel_m_s2": max_decel,
+        "braking_distinct_from_accel": max_decel != max_accel,
+        "stopping_distance_envelope_m": stopping_dist,
+        "envelope_formula": "v^2 / (2a) at peak forward speed and max braking deceleration",
+    }
+    if max_speed is not None:
+        payload["peak_forward_speed_m_s"] = max_speed
+    return payload
+
+
+def actuation_envelope_from_drive_config(robot_config: Any) -> dict[str, Any] | None:
+    """Extract a JSON-safe actuation-envelope block from a drive-settings object.
+
+    Reads the drive model's enforced acceleration / braking authority and peak
+    forward speed via duck typing. The bicycle drive exposes ``max_accel``,
+    ``max_decel`` and ``max_velocity``; the differential drive exposes
+    ``max_linear_accel``, ``max_linear_decel`` and ``max_linear_speed``.
+
+    Returns ``None`` when ``robot_config`` exposes neither braking-authority field
+    (e.g. a holonomic / velocity-level model with no first-class deceleration
+    cap), so callers can omit the block rather than emit a meaningless envelope.
+
+    Args:
+        robot_config: A drive-settings-like object (e.g.
+            ``DifferentialDriveSettings`` or ``BicycleDriveSettings``), or any
+            object exposing the relevant attributes.
+
+    Returns:
+        A JSON-safe envelope dictionary, or ``None`` when the drive model exposes
+        no braking authority.
+    """
+    if robot_config is None:
+        return None
+    # The differential-drive braking-authority field is the discriminator: only
+    # the differential drive exposes ``max_linear_decel``.
+    if hasattr(robot_config, "max_linear_decel"):
+        return _resolve_diff_drive_envelope(robot_config)
+    # The bicycle-drive braking-authority field is the discriminator.
+    if hasattr(robot_config, "max_decel") and hasattr(robot_config, "max_velocity"):
+        return _resolve_bicycle_envelope(robot_config)
+    return None
+
+
+def actuation_envelope_for_run_config(config: Any) -> dict[str, Any] | None:
+    """Extract the envelope from an environment config-like object.
+
+    Reads ``config.robot_config`` via duck typing so the helper works on any
+    environment config exposing that attribute (e.g. ``EnvSettings`` /
+    ``RobotSimulationConfig``).
+
+    Returns:
+        The envelope block, or ``None`` when ``config`` has no ``robot_config``
+        or the drive model exposes no braking authority.
+    """
+    robot_config = getattr(config, "robot_config", None)
+    return actuation_envelope_from_drive_config(robot_config)
+
+
+__all__ = [
+    "ACTUATION_ENVELOPE_INTERPRETATION",
+    "ACTUATION_ENVELOPE_SCHEMA",
+    "NOT_AVAILABLE",
+    "actuation_envelope_for_run_config",
+    "actuation_envelope_from_drive_config",
+    "stopping_distance",
+]

--- a/robot_sf/robot/bicycle_drive.py
+++ b/robot_sf/robot/bicycle_drive.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 from math import cos, isfinite, sin, tan
+from numbers import Real
 
 import numpy as np
 from gymnasium import spaces
@@ -46,7 +47,8 @@ class BicycleDriveSettings:
             self.max_decel = self.max_accel
         if (
             isinstance(self.max_decel, bool)
-            or not isfinite(float(self.max_decel))
+            or not isinstance(self.max_decel, Real)
+            or not isfinite(self.max_decel)
             or self.max_decel <= 0.0
         ):
             raise ValueError("max_decel must be positive")

--- a/robot_sf/robot/bicycle_drive.py
+++ b/robot_sf/robot/bicycle_drive.py
@@ -23,8 +23,24 @@ class BicycleDriveSettings:
     wheelbase: float = 1.0  # Distance between front and rear wheels
     max_steer: float = 0.78  # Maximum steering angle (45 degrees in radians)
     max_velocity: float = 3.0  # Maximum forward velocity
-    max_accel: float = 1.0  # Maximum acceleration
+    max_accel: float = 1.0  # Maximum forward acceleration (m/s^2)
+    # Maximum braking deceleration magnitude (m/s^2), i.e. the most negative
+    # commanded acceleration the model will honor. ``None`` (default) keeps the
+    # legacy symmetric behavior where braking authority equals forward
+    # acceleration; set explicitly to decouple braking from forward acceleration
+    # (issue #4976).
+    max_decel: float | None = None
     allow_backwards: bool = False  # Whether backwards movement is allowed
+
+    def __post_init__(self) -> None:
+        """Resolve the braking-authority default for backward compatibility.
+
+        When ``max_decel`` is unset, braking authority defaults to the forward
+        acceleration so existing symmetric-clip behavior is preserved. Only an
+        explicit ``max_decel`` decouples braking from forward acceleration.
+        """
+        if self.max_decel is None:
+            self.max_decel = self.max_accel
 
     @property
     def min_velocity(self) -> float:
@@ -95,8 +111,11 @@ class BicycleMotion:
         (x, y), orient = state.pose
         velocity = state.velocity
 
-        # Apply limits to the acceleration and calculate new velocity
-        acceleration = clip_scalar(acceleration, -self.config.max_accel, self.config.max_accel)
+        # Apply asymmetric acceleration/braking authority and calculate new
+        # velocity. Braking (negative command) is capped by ``max_decel``, which
+        # may exceed forward ``max_accel`` so the model can stop harder than it
+        # accelerates (issue #4976).
+        acceleration = clip_scalar(acceleration, -self.config.max_decel, self.config.max_accel)
         new_velocity = velocity + d_t * acceleration
         new_velocity = clip_scalar(new_velocity, self.config.min_velocity, self.config.max_velocity)
 
@@ -154,7 +173,7 @@ class BicycleDriveRobot:
             acceleration and steering limits.
         """
         high = np.array([self.config.max_accel, self.config.max_steer], dtype=np.float32)
-        low = np.array([-self.config.max_accel, -self.config.max_steer], dtype=np.float32)
+        low = np.array([-self.config.max_decel, -self.config.max_steer], dtype=np.float32)
         return spaces.Box(low=low, high=high, dtype=np.float32)
 
     @property

--- a/robot_sf/robot/bicycle_drive.py
+++ b/robot_sf/robot/bicycle_drive.py
@@ -1,7 +1,7 @@
 """Bicycle drive model for vehicle dynamics simulation."""
 
 from dataclasses import dataclass, field
-from math import cos, sin, tan
+from math import cos, isfinite, sin, tan
 
 import numpy as np
 from gymnasium import spaces
@@ -24,13 +24,16 @@ class BicycleDriveSettings:
     max_steer: float = 0.78  # Maximum steering angle (45 degrees in radians)
     max_velocity: float = 3.0  # Maximum forward velocity
     max_accel: float = 1.0  # Maximum forward acceleration (m/s^2)
+    allow_backwards: bool = False  # Whether backwards movement is allowed
+    # Keep this new field after the existing positional settings so callers using
+    # the prior dataclass positional form still pass ``allow_backwards`` in its
+    # original slot.
     # Maximum braking deceleration magnitude (m/s^2), i.e. the most negative
     # commanded acceleration the model will honor. ``None`` (default) keeps the
     # legacy symmetric behavior where braking authority equals forward
     # acceleration; set explicitly to decouple braking from forward acceleration
     # (issue #4976).
     max_decel: float | None = None
-    allow_backwards: bool = False  # Whether backwards movement is allowed
 
     def __post_init__(self) -> None:
         """Resolve the braking-authority default for backward compatibility.
@@ -41,6 +44,12 @@ class BicycleDriveSettings:
         """
         if self.max_decel is None:
             self.max_decel = self.max_accel
+        if (
+            isinstance(self.max_decel, bool)
+            or not isfinite(float(self.max_decel))
+            or self.max_decel <= 0.0
+        ):
+            raise ValueError("max_decel must be positive")
 
     @property
     def min_velocity(self) -> float:

--- a/robot_sf/robot/differential_drive.py
+++ b/robot_sf/robot/differential_drive.py
@@ -37,15 +37,18 @@ class DifferentialDriveSettings:
     # Maximum linear acceleration (m/s^2) accepted as an action; the per-step
     # velocity delta is max_linear_accel * d_t (see issue #3711)
     max_linear_accel: float = 1.0
+    # Maximum angular acceleration (rad/s^2) accepted as an action; the per-step
+    # angular velocity delta is max_angular_accel * d_t (see issue #3711)
+    max_angular_accel: float = 1.0
+    # Keep this new field after the existing positional settings so callers using
+    # the prior dataclass positional form still pass ``max_angular_accel`` in its
+    # original slot.
     # Maximum linear braking deceleration magnitude (m/s^2), i.e. the most
     # negative commanded linear acceleration honored. ``None`` (default) keeps
     # the legacy symmetric behavior where braking authority equals forward
     # acceleration; set explicitly to decouple braking from forward acceleration
     # (issue #4976).
     max_linear_decel: float | None = None
-    # Maximum angular acceleration (rad/s^2) accepted as an action; the per-step
-    # angular velocity delta is max_angular_accel * d_t (see issue #3711)
-    max_angular_accel: float = 1.0
 
     def __post_init__(self):
         """

--- a/robot_sf/robot/differential_drive.py
+++ b/robot_sf/robot/differential_drive.py
@@ -37,6 +37,12 @@ class DifferentialDriveSettings:
     # Maximum linear acceleration (m/s^2) accepted as an action; the per-step
     # velocity delta is max_linear_accel * d_t (see issue #3711)
     max_linear_accel: float = 1.0
+    # Maximum linear braking deceleration magnitude (m/s^2), i.e. the most
+    # negative commanded linear acceleration honored. ``None`` (default) keeps
+    # the legacy symmetric behavior where braking authority equals forward
+    # acceleration; set explicitly to decouple braking from forward acceleration
+    # (issue #4976).
+    max_linear_decel: float | None = None
     # Maximum angular acceleration (rad/s^2) accepted as an action; the per-step
     # angular velocity delta is max_angular_accel * d_t (see issue #3711)
     max_angular_accel: float = 1.0
@@ -60,6 +66,16 @@ class DifferentialDriveSettings:
         if self.max_linear_accel <= 0 or self.max_angular_accel <= 0:
             raise ValueError(
                 "Robot's max. linear and angular accelerations must be positive and non-zero!",
+            )
+        # Resolve the braking-authority default for backward compatibility:
+        # when unset, braking equals forward acceleration (legacy symmetric
+        # clip). Only an explicit max_linear_decel decouples them (issue #4976).
+        if self.max_linear_decel is None:
+            self.max_linear_decel = self.max_linear_accel
+        if self.max_linear_decel <= 0:
+            raise ValueError(
+                "Robot's max. linear braking deceleration (max_linear_decel) "
+                "must be positive and non-zero!",
             )
         if self.interaxis_length <= 0:
             raise ValueError("Robot's interaxis length must be positive and non-zero!")
@@ -133,7 +149,7 @@ class DifferentialDriveMotion:
             PolarVec2D: The new velocity clipped by configured accel and speed limits.
         """
         linear_accel = clip_scalar(
-            action[0], -self.config.max_linear_accel, self.config.max_linear_accel
+            action[0], -self.config.max_linear_decel, self.config.max_linear_accel
         )
         angular_accel = clip_scalar(
             action[1], -self.config.max_angular_accel, self.config.max_angular_accel
@@ -291,7 +307,7 @@ class DifferentialDriveRobot:
             dtype=np.float32,
         )
         low = np.array(
-            [-self.config.max_linear_accel, -self.config.max_angular_accel],
+            [-self.config.max_linear_decel, -self.config.max_angular_accel],
             dtype=np.float32,
         )
         return spaces.Box(low=low, high=high, dtype=np.float32)

--- a/robot_sf/robot/differential_drive.py
+++ b/robot_sf/robot/differential_drive.py
@@ -1,7 +1,8 @@
 """Differential Drive Robot Model"""
 
 from dataclasses import dataclass, field
-from math import cos, sin
+from math import cos, isfinite, sin
+from numbers import Real
 
 import numpy as np
 from gymnasium import spaces
@@ -75,7 +76,12 @@ class DifferentialDriveSettings:
         # clip). Only an explicit max_linear_decel decouples them (issue #4976).
         if self.max_linear_decel is None:
             self.max_linear_decel = self.max_linear_accel
-        if self.max_linear_decel <= 0:
+        if (
+            isinstance(self.max_linear_decel, bool)
+            or not isinstance(self.max_linear_decel, Real)
+            or not isfinite(self.max_linear_decel)
+            or self.max_linear_decel <= 0
+        ):
             raise ValueError(
                 "Robot's max. linear braking deceleration (max_linear_decel) "
                 "must be positive and non-zero!",

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -1401,6 +1401,18 @@ def _differential_robot_settings(overrides: Mapping[str, Any]) -> DifferentialDr
         kwargs["max_angular_speed"] = _coerce_finite_float(
             overrides["max_angular_speed"], field_name="max_angular_speed"
         )
+    if "max_linear_accel" in overrides:
+        kwargs["max_linear_accel"] = _coerce_finite_float(
+            overrides["max_linear_accel"], field_name="max_linear_accel"
+        )
+    if "max_linear_decel" in overrides:
+        kwargs["max_linear_decel"] = _coerce_finite_float(
+            overrides["max_linear_decel"], field_name="max_linear_decel"
+        )
+    if "max_angular_accel" in overrides:
+        kwargs["max_angular_accel"] = _coerce_finite_float(
+            overrides["max_angular_accel"], field_name="max_angular_accel"
+        )
     if "wheel_radius" in overrides:
         kwargs["wheel_radius"] = _coerce_finite_float(
             overrides["wheel_radius"], field_name="wheel_radius"
@@ -1436,6 +1448,8 @@ def _bicycle_robot_settings(overrides: Mapping[str, Any]) -> BicycleDriveSetting
         )
     if "max_accel" in overrides:
         kwargs["max_accel"] = _coerce_finite_float(overrides["max_accel"], field_name="max_accel")
+    if "max_decel" in overrides:
+        kwargs["max_decel"] = _coerce_finite_float(overrides["max_decel"], field_name="max_decel")
     if "allow_backwards" in overrides:
         kwargs["allow_backwards"] = _coerce_bool(
             overrides["allow_backwards"],

--- a/tests/test_actuation_envelope_issue_4976.py
+++ b/tests/test_actuation_envelope_issue_4976.py
@@ -220,6 +220,26 @@ def test_bicycle_rejects_non_positive_braking_authority() -> None:
         BicycleDriveSettings(max_decel=0.0)
 
 
+@pytest.mark.parametrize("invalid_braking", [True, float("inf"), float("nan"), "1.0"])
+def test_bicycle_rejects_non_numeric_or_non_finite_braking_authority(
+    invalid_braking: object,
+) -> None:
+    """Bicycle braking authority is validated before motion code consumes it."""
+
+    with pytest.raises(ValueError, match="max_decel"):
+        BicycleDriveSettings(max_decel=invalid_braking)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("invalid_braking", [True, float("inf"), float("nan"), "1.0"])
+def test_diff_drive_rejects_non_numeric_or_non_finite_braking_authority(
+    invalid_braking: object,
+) -> None:
+    """Differential-drive braking authority is validated before action clipping."""
+
+    with pytest.raises(ValueError, match="max_linear_decel"):
+        DifferentialDriveSettings(max_linear_decel=invalid_braking)  # type: ignore[arg-type]
+
+
 # ---------------------------------------------------------------------------
 # Stopping-distance envelope surfaces in run metadata (issue #4976 acceptance)
 # ---------------------------------------------------------------------------

--- a/tests/test_actuation_envelope_issue_4976.py
+++ b/tests/test_actuation_envelope_issue_4976.py
@@ -1,0 +1,302 @@
+"""Tests for first-class acceleration/braking actuation limits and the
+stopping-distance envelope in run metadata (issue #4976).
+
+These are focused unit tests only -- they exercise the drive models' deceleration
+caps directly and the JSON-safe envelope helper, without running any campaign.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from robot_sf.benchmark.run_config_provenance import metric_affecting_run_config
+from robot_sf.robot.actuation_envelope import (
+    ACTUATION_ENVELOPE_INTERPRETATION,
+    ACTUATION_ENVELOPE_SCHEMA,
+    actuation_envelope_from_drive_config,
+    stopping_distance,
+)
+from robot_sf.robot.bicycle_drive import (
+    BicycleDriveRobot,
+    BicycleDriveSettings,
+    BicycleDriveState,
+    BicycleMotion,
+)
+from robot_sf.robot.differential_drive import (
+    DifferentialDriveMotion,
+    DifferentialDriveRobot,
+    DifferentialDriveSettings,
+    DifferentialDriveState,
+)
+
+# ---------------------------------------------------------------------------
+# Stopping-distance envelope math
+# ---------------------------------------------------------------------------
+
+
+def test_stopping_distance_formula() -> None:
+    """The envelope is the kinematic ``v^2 / (2a)`` braking distance."""
+    # v=2 m/s, a=1 m/s^2 -> d = 4 / 2 = 2 m
+    assert stopping_distance(2.0, 1.0) == pytest.approx(2.0)
+    # v=3 m/s, a=3 m/s^2 -> d = 9 / 6 = 1.5 m
+    assert stopping_distance(3.0, 3.0) == pytest.approx(1.5)
+    # At rest, no distance needed.
+    assert stopping_distance(0.0, 1.0) == pytest.approx(0.0)
+
+
+def test_stopping_distance_rejects_invalid_inputs() -> None:
+    """Non-positive deceleration and negative speed fail closed instead of dividing badly."""
+    with pytest.raises(ValueError, match="deceleration"):
+        stopping_distance(2.0, 0.0)
+    with pytest.raises(ValueError, match="deceleration"):
+        stopping_distance(2.0, -1.0)
+    with pytest.raises(ValueError, match="speed"):
+        stopping_distance(-1.0, 1.0)
+
+
+def test_stronger_braking_shrinks_stopping_distance() -> None:
+    """Doubling braking authority roughly halves the worst-case stopping distance."""
+    weak = stopping_distance(3.0, 1.0)
+    strong = stopping_distance(3.0, 2.0)
+    assert strong == pytest.approx(weak / 2.0)
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: symmetric default (braking == acceleration)
+# ---------------------------------------------------------------------------
+
+
+def test_bicycle_default_braking_equals_acceleration() -> None:
+    """Default bicycle braking authority equals forward acceleration (legacy)."""
+    settings = BicycleDriveSettings(max_accel=2.0)
+    assert settings.max_decel == 2.0
+
+
+def test_diff_drive_default_braking_equals_acceleration() -> None:
+    """Default differential braking authority equals forward acceleration (legacy)."""
+    settings = DifferentialDriveSettings(max_linear_accel=0.4)
+    assert settings.max_linear_decel == 0.4
+
+
+def test_diff_drive_default_action_space_unchanged() -> None:
+    """Without explicit braking, the action-space low bound stays symmetric."""
+    robot = DifferentialDriveRobot(
+        DifferentialDriveSettings(
+            max_linear_speed=3.0,
+            max_angular_speed=2.0,
+            max_linear_accel=0.4,
+            max_angular_accel=0.3,
+        )
+    )
+    # Legacy symmetric bound: low == -high.
+    assert tuple(robot.action_space.low) == pytest.approx((-0.4, -0.3))
+
+
+# ---------------------------------------------------------------------------
+# Commanded stops respect the deceleration cap (issue #4976 acceptance)
+# ---------------------------------------------------------------------------
+
+
+def test_bicycle_commanded_stop_respects_deceleration_cap() -> None:
+    """A bicycle hard-stop command cannot decelerate harder than ``max_decel``."""
+    # Asymmetric authority: forward accel 1.0, braking decel 0.5 (weaker brakes).
+    motion = BicycleMotion(BicycleDriveSettings(max_velocity=5.0, max_accel=1.0, max_decel=0.5))
+    state = BicycleDriveState(((0.0, 0.0), 0.0), 2.0)  # cruising at 2 m/s
+
+    # Command an extreme brake (-1000 m/s^2). The deceleration cap must clamp it.
+    motion.move(state, (-1000.0, 0.0), 1.0)
+
+    # Only 0.5 m/s of speed can be bled in one second.
+    assert state.velocity == pytest.approx(1.5)
+
+
+def test_bicycle_braking_can_exceed_forward_acceleration() -> None:
+    """Asymmetric braking authority lets the model stop harder than it accelerates."""
+    # Strong brakes (5.0) but weak forward accel (1.0).
+    motion = BicycleMotion(BicycleDriveSettings(max_velocity=5.0, max_accel=1.0, max_decel=5.0))
+
+    # Forward command of 1000 m/s^2 is clamped to the weak forward cap (1.0).
+    forward_state = BicycleDriveState(((0.0, 0.0), 0.0), 0.0)
+    motion.move(forward_state, (1000.0, 0.0), 1.0)
+    assert forward_state.velocity == pytest.approx(1.0)
+
+    # Brake command of -1000 m/s^2 from 5 m/s is clamped to the strong brake cap (5.0),
+    # stopping in a single second.
+    brake_state = BicycleDriveState(((0.0, 0.0), 0.0), 5.0)
+    motion.move(brake_state, (-1000.0, 0.0), 1.0)
+    assert brake_state.velocity == pytest.approx(0.0)
+
+
+def test_diff_drive_commanded_stop_respects_deceleration_cap() -> None:
+    """A differential-drive hard-stop command cannot brake harder than ``max_linear_decel``."""
+    motion = DifferentialDriveMotion(
+        DifferentialDriveSettings(
+            max_linear_speed=10.0,
+            max_linear_accel=1.0,
+            max_linear_decel=0.5,  # weaker brakes than forward thrust
+        )
+    )
+    state = DifferentialDriveState(((0.0, 0.0), 0.0), (2.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+
+    # Command an extreme linear brake (-1000 m/s^2); it must clamp to the brake cap.
+    motion.move(state, (-1000.0, 0.0), 1.0)
+
+    # Only 0.5 m/s of speed can be bled in one second.
+    assert state.velocity[0] == pytest.approx(1.5)
+
+
+def test_diff_drive_braking_can_exceed_forward_acceleration() -> None:
+    """Asymmetric braking authority lets the diff drive stop harder than it accelerates."""
+    motion = DifferentialDriveMotion(
+        DifferentialDriveSettings(
+            max_linear_speed=10.0,
+            max_linear_accel=1.0,
+            max_linear_decel=5.0,
+        )
+    )
+    # Forward command clamped to the weak forward cap (1.0).
+    forward_state = DifferentialDriveState(((0.0, 0.0), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+    motion.move(forward_state, (1000.0, 0.0), 1.0)
+    assert forward_state.velocity[0] == pytest.approx(1.0)
+
+    # Brake command clamped to the strong brake cap (5.0): stops from 5 m/s in 1s.
+    brake_state = DifferentialDriveState(((0.0, 0.0), 0.0), (5.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+    motion.move(brake_state, (-1000.0, 0.0), 1.0)
+    assert brake_state.velocity[0] == pytest.approx(0.0)
+
+
+def test_diff_drive_action_space_reflects_asymmetric_braking() -> None:
+    """The action-space low bound tracks braking authority when it is explicit."""
+    robot = DifferentialDriveRobot(
+        DifferentialDriveSettings(
+            max_linear_speed=3.0,
+            max_angular_speed=2.0,
+            max_linear_accel=0.4,
+            max_linear_decel=2.0,
+            max_angular_accel=0.3,
+        )
+    )
+    # Linear low reflects the 2.0 brake cap; angular low stays symmetric.
+    assert tuple(robot.action_space.low) == pytest.approx((-2.0, -0.3))
+    assert tuple(robot.action_space.high) == pytest.approx((0.4, 0.3))
+
+
+def test_bicycle_action_space_reflects_asymmetric_braking() -> None:
+    """The bicycle action-space low bound tracks braking authority when explicit."""
+    robot = BicycleDriveRobot(
+        BicycleDriveSettings(max_velocity=3.0, max_accel=1.0, max_decel=2.5, max_steer=0.5)
+    )
+    assert tuple(robot.action_space.low) == pytest.approx((-2.5, -0.5))
+    assert tuple(robot.action_space.high) == pytest.approx((1.0, 0.5))
+
+
+def test_diff_drive_rejects_non_positive_braking_authority() -> None:
+    """An explicit non-positive braking authority fails closed at construction."""
+    with pytest.raises(ValueError, match="max_linear_decel"):
+        DifferentialDriveSettings(max_linear_decel=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Stopping-distance envelope surfaces in run metadata (issue #4976 acceptance)
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_omitted_for_velocity_level_drive_model() -> None:
+    """A drive model with no first-class deceleration cap omits the envelope."""
+    # Holonomic-style config exposes no braking-authority field.
+    config = SimpleNamespace(robot_config=SimpleNamespace(max_speed=2.0))
+    assert actuation_envelope_from_drive_config(config.robot_config) is None
+
+
+def test_envelope_omitted_when_config_has_no_robot_config() -> None:
+    """A config without a robot_config yields no envelope block."""
+    block = metric_affecting_run_config(SimpleNamespace())
+    assert "actuation_envelope" not in block
+
+
+def test_diff_drive_envelope_surfaces_in_run_metadata() -> None:
+    """The differential-drive envelope appears in the metric-affecting run config."""
+    config = SimpleNamespace(
+        robot_config=DifferentialDriveSettings(
+            max_linear_speed=3.0, max_linear_accel=1.0, max_linear_decel=3.0
+        )
+    )
+    block = metric_affecting_run_config(config)
+
+    envelope = block["actuation_envelope"]
+    assert envelope["schema"] == ACTUATION_ENVELOPE_SCHEMA
+    assert envelope["drive_model"] == "differential_drive"
+    assert envelope["max_forward_accel_m_s2"] == pytest.approx(1.0)
+    assert envelope["max_braking_decel_m_s2"] == pytest.approx(3.0)
+    assert envelope["braking_distinct_from_accel"] is True
+    assert envelope["peak_forward_speed_m_s"] == pytest.approx(3.0)
+    # v=3, a=3 -> d = 9 / 6 = 1.5 m
+    assert envelope["stopping_distance_envelope_m"] == pytest.approx(1.5)
+    assert envelope["interpretation"] == ACTUATION_ENVELOPE_INTERPRETATION
+
+
+def test_bicycle_envelope_surfaces_in_run_metadata() -> None:
+    """The bicycle-drive envelope appears in the metric-affecting run config."""
+    config = SimpleNamespace(
+        robot_config=BicycleDriveSettings(max_velocity=3.0, max_accel=1.0, max_decel=2.0)
+    )
+    block = metric_affecting_run_config(config)
+
+    envelope = block["actuation_envelope"]
+    assert envelope["drive_model"] == "bicycle_drive"
+    assert envelope["max_forward_accel_m_s2"] == pytest.approx(1.0)
+    assert envelope["max_braking_decel_m_s2"] == pytest.approx(2.0)
+    # v=3, a=2 -> d = 9 / 4 = 2.25 m
+    assert envelope["stopping_distance_envelope_m"] == pytest.approx(2.25)
+
+
+def test_default_envelope_is_symmetric_and_not_distinct() -> None:
+    """Default braking (== acceleration) is recorded as not distinct from accel."""
+    config = SimpleNamespace(
+        robot_config=DifferentialDriveSettings(max_linear_speed=2.0, max_linear_accel=0.5)
+    )
+    block = metric_affecting_run_config(config)
+    envelope = block["actuation_envelope"]
+    assert envelope["braking_distinct_from_accel"] is False
+    assert envelope["max_braking_decel_m_s2"] == pytest.approx(0.5)
+    # v=2, a=0.5 -> d = 4 / 1 = 4 m
+    assert envelope["stopping_distance_envelope_m"] == pytest.approx(4.0)
+
+
+def test_envelope_block_is_json_serializable() -> None:
+    """The envelope block round-trips through JSON without custom encoders."""
+    config = SimpleNamespace(
+        robot_config=BicycleDriveSettings(max_velocity=3.0, max_accel=1.0, max_decel=2.0)
+    )
+    block = metric_affecting_run_config(config)
+    # Must not raise; values must be plain JSON types.
+    round_tripped = json.loads(json.dumps(block))
+    assert round_tripped == block
+    assert isinstance(round_tripped["actuation_envelope"]["stopping_distance_envelope_m"], float)
+
+
+def test_weaker_braking_larger_envelope_changes_metric_meaning() -> None:
+    """Weaker braking produces a larger stopping envelope -- the metric-affecting point."""
+    strong_brakes = metric_affecting_run_config(
+        SimpleNamespace(
+            robot_config=DifferentialDriveSettings(
+                max_linear_speed=3.0, max_linear_accel=1.0, max_linear_decel=3.0
+            )
+        )
+    )
+    weak_brakes = metric_affecting_run_config(
+        SimpleNamespace(
+            robot_config=DifferentialDriveSettings(
+                max_linear_speed=3.0, max_linear_accel=1.0, max_linear_decel=1.0
+            )
+        )
+    )
+    strong_d = strong_brakes["actuation_envelope"]["stopping_distance_envelope_m"]
+    weak_d = weak_brakes["actuation_envelope"]["stopping_distance_envelope_m"]
+    # Weak brakes need more room to stop -> larger envelope.
+    assert weak_d > strong_d
+    assert math.isclose(weak_d / strong_d, 3.0)

--- a/tests/test_actuation_envelope_issue_4976.py
+++ b/tests/test_actuation_envelope_issue_4976.py
@@ -82,6 +82,19 @@ def test_diff_drive_default_braking_equals_acceleration() -> None:
     assert settings.max_linear_decel == 0.4
 
 
+def test_new_braking_fields_preserve_existing_positional_settings_order() -> None:
+    """Adding braking authority does not reinterpret legacy positional arguments."""
+
+    bicycle = BicycleDriveSettings(0.2, 1.0, 0.78, 3.0, 0.4, True)
+    differential = DifferentialDriveSettings(0.2, 3.0, 2.0, 0.05, 0.3, True, 0.4, 0.3)
+
+    assert bicycle.allow_backwards is True
+    assert bicycle.max_decel == pytest.approx(0.4)
+    assert differential.allow_backwards is True
+    assert differential.max_angular_accel == pytest.approx(0.3)
+    assert differential.max_linear_decel == pytest.approx(0.4)
+
+
 def test_diff_drive_default_action_space_unchanged() -> None:
     """Without explicit braking, the action-space low bound stays symmetric."""
     robot = DifferentialDriveRobot(
@@ -198,6 +211,13 @@ def test_diff_drive_rejects_non_positive_braking_authority() -> None:
     """An explicit non-positive braking authority fails closed at construction."""
     with pytest.raises(ValueError, match="max_linear_decel"):
         DifferentialDriveSettings(max_linear_decel=0.0)
+
+
+def test_bicycle_rejects_non_positive_braking_authority() -> None:
+    """An explicit non-positive bicycle braking authority fails closed."""
+
+    with pytest.raises(ValueError, match="max_decel"):
+        BicycleDriveSettings(max_decel=0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scenario_loader_route_overrides.py
+++ b/tests/test_scenario_loader_route_overrides.py
@@ -204,6 +204,57 @@ def test_build_robot_config_applies_bicycle_robot_overrides() -> None:
     assert bool(config.robot_config.allow_backwards) is True
 
 
+def test_build_robot_config_applies_braking_authority_overrides() -> None:
+    """Scenario overrides should expose the decoupled braking-authority fields (issue #4976)."""
+    scenario_path = Path("configs/scenarios/classic_interactions.yaml").resolve()
+
+    bike = build_robot_config_from_scenario(
+        {
+            "name": "demo",
+            "robot_config": {
+                "type": "bicycle_drive",
+                "max_accel": 0.8,
+                "max_decel": 2.0,
+            },
+        },
+        scenario_path=scenario_path,
+    )
+    assert bike.robot_config.__class__.__name__ == "BicycleDriveSettings"
+    assert float(bike.robot_config.max_accel) == 0.8
+    assert float(bike.robot_config.max_decel) == 2.0
+
+    diff = build_robot_config_from_scenario(
+        {
+            "name": "demo",
+            "robot_config": {
+                "type": "differential_drive",
+                "max_linear_accel": 0.6,
+                "max_linear_decel": 1.8,
+            },
+        },
+        scenario_path=scenario_path,
+    )
+    assert diff.robot_config.__class__.__name__ == "DifferentialDriveSettings"
+    assert float(diff.robot_config.max_linear_accel) == 0.6
+    assert float(diff.robot_config.max_linear_decel) == 1.8
+
+
+def test_build_robot_config_braking_defaults_to_accel_when_unset() -> None:
+    """Unset braking authority keeps the legacy symmetric default (issue #4976)."""
+    scenario_path = Path("configs/scenarios/classic_interactions.yaml").resolve()
+    diff = build_robot_config_from_scenario(
+        {
+            "name": "demo",
+            "robot_config": {
+                "type": "differential_drive",
+                "max_linear_accel": 0.4,
+            },
+        },
+        scenario_path=scenario_path,
+    )
+    assert float(diff.robot_config.max_linear_decel) == 0.4
+
+
 def test_build_robot_config_applies_holonomic_overrides() -> None:
     """Scenario robot_config should instantiate holonomic settings with command mode."""
     scenario_path = Path("configs/scenarios/classic_interactions.yaml").resolve()


### PR DESCRIPTION
## Summary

Adds first-class asymmetric braking authority for bicycle and differential-drive robots, and records the resulting stopping-distance envelope in metric-affecting run provenance. This makes near-miss and time-to-collision (TTC) readings interpretable against the robot's enforced braking capability.

## Linked Issues

- Refs #4976
- Follow-up campaign smoke: #5088

## What Changed

- `BicycleDriveSettings.max_decel` and `DifferentialDriveSettings.max_linear_decel` default to the forward acceleration limit, preserving the legacy symmetric clip unless explicitly overridden.
- Motion and action-space bounds apply distinct positive/negative acceleration caps.
- Scenario overrides accept both braking fields.
- `actuation_envelope.v1` records forward acceleration, braking deceleration, peak speed, and `v² / (2a)` stopping distance when the drive exposes a braking cap.
- The new fields are appended after the legacy dataclass positional parameters, so existing positional construction remains compatible.

## Validation

```text
DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest \
  tests/test_actuation_envelope_issue_4976.py tests/test_bicycle_drive.py \
  tests/differential_drive_test.py tests/benchmark/test_run_config_provenance.py \
  tests/test_scenario_loader_route_overrides.py -q
# 67 passed

uv run ruff check robot_sf/robot/actuation_envelope.py robot_sf/robot/bicycle_drive.py \
  robot_sf/robot/differential_drive.py robot_sf/benchmark/run_config_provenance.py \
  robot_sf/training/scenario_loader.py tests/test_actuation_envelope_issue_4976.py \
  tests/test_scenario_loader_route_overrides.py
uv run ruff format --check <same files>
```

## Research Result Guidance

- Target: enforce and make visible the braking-feasibility envelope used to interpret safety-adjacent metrics.
- Comparator: default symmetric braking versus an explicit braking cap.
- Evidence tier: targeted CPU smoke / implementation integrity.
- Result classification: blocker-resolution for runtime/provenance; no campaign result.
- Decision / stop rule: #5088 must establish whether a controlled campaign produces the expected metric-sensitivity signal.
- Update surface: #4976 and #5088.

## Domain-Aware Approval

- Required for this PR: no — this changes runtime and provenance but does not alter metric computation, evidence classification, comparison methodology, or paper-facing claims.
- Status: not required.

## Scope And Closure

This PR completes the code and provenance slice only. The parent issue's campaign-smoke acceptance criterion is intentionally deferred to #5088; therefore this PR references, rather than closes, #4976. The emitted envelope is diagnostic provenance, not a calibrated safety threshold or benchmark claim.
