### PR TITLE
Issue #5034: control-action-latency sweep metric-evidence promoter (cheap-lane worker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/context/evidence/issue_5034_control_action_latency_sweep_blocked_2026-07-10/`. Claim boundary:
   launch/readiness preflight only — not benchmark evidence, not paper-facing; no campaign run and no
   Slurm/GPU submission were performed.
+* **issue #5034 control-action-latency sweep metric-evidence promoter (successor slice).** New
+  `robot_sf/benchmark/control_action_latency_evidence.py` (`build_latency_evidence`,
+  `promote_latency_evidence`) and CLI `scripts/benchmark/promote_control_action_latency_evidence.py`
+  promote raw fidelity-campaign episode rows into a durable compact control-action-latency evidence
+  summary: they isolate the `control_action_latency` axis, report the action-latency metadata plus
+  `success_rate`, `collision_rate`, and `min_clearance` per native latency cell (0/100/300 ms-equivalent
+  steps `[0, 1, 3]`), and classify every fallback / degraded / non-native row (per the issue #691
+  benchmark fallback policy) as an exclusion that never contributes to the result metrics. The promoter
+  fails closed when the latency preflight is not ready or when the native result rows do not cover all
+  required steps, so a partial or non-latency run cannot be promoted as the latency sweep. Successor
+  slice to PR #5061 (which added the fail-closed preflight + historical blocker packet); it adds NEW
+  metric-evidence promotion capability and does not duplicate #5061. It runs no episode and makes no
+  benchmark / simulator-realism / sim-to-real / paper-facing claim; focused coverage lives in
+  `tests/benchmark/test_control_action_latency_evidence.py`. The native campaign run remains out of
+  scope for this slice.
 * **issue #5048 gh list truncation guard extended to the remaining bounded callers.** The shared
   `scripts/dev/_gh_pagination.py` guard (from #4991 / PR #5040) is now applied to the six remaining
   bounded `gh ... list --limit N` call sites so a result at the cap is never silently mistaken for a

--- a/robot_sf/benchmark/control_action_latency_evidence.py
+++ b/robot_sf/benchmark/control_action_latency_evidence.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import csv
 import json
+import math
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -107,8 +108,8 @@ class LatencyCell:
     baseline_variant: bool
     seed: int
     scenario_id: str
-    success_rate: float
-    collision_rate: float
+    success_rate: float | None
+    collision_rate: float | None
     min_clearance: float | None
     classification: str
     exclusion_reason: str | None
@@ -143,6 +144,18 @@ def _row_availability_status(row: Mapping[str, Any]) -> str:
     """Return a row's availability status, defaulting to ``available`` when unset."""
     status = row.get("availability_status")
     return str(status) if isinstance(status, str) and status else "available"
+
+
+def _numeric_metric(metrics: Mapping[str, Any], name: str) -> float | None:
+    """Return a finite numeric metric value, or ``None`` when it is unusable."""
+    value = metrics.get(name)
+    if (
+        isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    ):
+        return float(value)
+    return None
 
 
 def _latency_step_from_row(row: Mapping[str, Any]) -> int | None:
@@ -184,19 +197,19 @@ def classify_latency_row(row: Mapping[str, Any]) -> LatencyCell:
     """Classify one episode row as a latency ``result`` cell or an ``exclusion``.
 
     The row must belong to the ``control_action_latency`` axis. A row is a
-    ``result`` only when it carries action-latency metadata AND its execution mode
-    is native/adapter AND its availability status is available. Anything else
-    (fallback / degraded / non-native / missing latency metadata) becomes an
-    ``exclusion`` with a precise reason, so fallback execution can never enter the
-    latency result set.
+    ``result`` only when it carries action-latency metadata, finite required
+    outcome metrics, a native/adapter execution mode, and an available status.
+    Anything else (fallback / degraded / non-native / missing metadata or
+    required metrics) becomes an ``exclusion`` with a precise reason, so malformed
+    or fallback execution can never enter the latency result set.
 
     Returns:
         The classified :class:`LatencyCell` for the row.
     """
     metrics = row.get("metrics")
     metric_map = metrics if isinstance(metrics, Mapping) else {}
-    success_rate = float(metric_map.get("success_rate", 0.0) or 0.0)
-    collision_rate = float(metric_map.get("collision_rate", 0.0) or 0.0)
+    success_rate = _numeric_metric(metric_map, "success_rate")
+    collision_rate = _numeric_metric(metric_map, "collision_rate")
     raw_min_clearance = metric_map.get("min_clearance")
     min_clearance = (
         float(raw_min_clearance)
@@ -216,6 +229,9 @@ def classify_latency_row(row: Mapping[str, Any]) -> LatencyCell:
         reasons.append(f"non_native_execution_mode:{execution_mode}")
     if availability_status not in AVAILABLE_AVAILABILITY_STATUSES:
         reasons.append(f"unavailable:{availability_status}")
+    for name, value in (("success_rate", success_rate), ("collision_rate", collision_rate)):
+        if value is None:
+            reasons.append(f"missing_or_invalid_metric:{name}")
 
     return LatencyCell(
         planner=str(row.get("planner") or "unknown"),
@@ -289,8 +305,12 @@ def aggregate_latency_metrics(cells: Sequence[LatencyCell]) -> list[dict[str, An
                 ),
                 "cell_count": len(bucket),
                 "seeds": sorted({c.seed for c in bucket}),
-                "success_rate": _mean([c.success_rate for c in bucket]),
-                "collision_rate": _mean([c.collision_rate for c in bucket]),
+                "success_rate": _mean(
+                    [c.success_rate for c in bucket if c.success_rate is not None]
+                ),
+                "collision_rate": _mean(
+                    [c.collision_rate for c in bucket if c.collision_rate is not None]
+                ),
                 "min_clearance": _mean(min_clearances) if min_clearances else None,
             }
         )

--- a/robot_sf/benchmark/control_action_latency_evidence.py
+++ b/robot_sf/benchmark/control_action_latency_evidence.py
@@ -1,0 +1,635 @@
+"""Promote control-action-latency sweep episode rows into durable evidence (issue #5034).
+
+Issue #5034 asks to *execute* the control-action-latency fidelity sweep (wired by
+PR #5026, scoped by parent #4977) and record whether the 0/100/300 ms-equivalent
+delays change the configured safety metrics. PR #5061 merged the fail-closed
+launch/readiness preflight plus a historical "blocked" packet. Once the native
+campaign runs and emits raw episode rows under ``output/``, this module is the
+**metric-evidence promotion** step that remains: it reads those rows, isolates the
+``control_action_latency`` axis, reports the latency metadata plus success,
+collision, and minimum-clearance metrics for each completed cell, and classifies
+every non-native / fallback / degraded row as an **exclusion** rather than a
+result (per the issue #691 benchmark fallback policy).
+
+This module runs **no episodes** and makes **no benchmark / simulator-realism /
+sim-to-real / paper-facing claim**. It is the deterministic promoter that turns a
+raw campaign row file into a durable compact evidence bundle. It fails closed when
+the raw rows do not cover the required action-latency step set (0, 1, 3) among
+native result rows, so a partial or non-latency run cannot be silently promoted as
+the latency sweep.
+
+Episode row contract (the shape :func:`run_episode` in
+``scripts/benchmark/run_fidelity_sensitivity_campaign.py`` emits)::
+
+    {
+        "axis": "control_action_latency",
+        "variant": "control_action_latency__three_step_300ms",
+        "variant_source_key": "three_step_300ms",
+        "baseline_variant": false,
+        "runtime_binding": "sim_config.action_latency_steps",
+        "action_latency": {  # sim_config.action_latency_metadata()
+            "configured_steps": 3,
+            "configured_ms": null,
+            "effective_steps": 3,
+            "effective_ms": 300.0,
+        },
+        "planner": "baseline_social_force",
+        "scenario_id": "...",
+        "seed": 111,
+        "success": true,
+        "collision": false,
+        "metrics": {"success_rate": 1.0, "collision_rate": 0.0, "min_clearance": 0.42},
+    }
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.control_action_latency_preflight import (
+    AXIS_KEY,
+    DECISION_READY,
+    REQUIRED_LATENCY_STEPS,
+    check_control_action_latency_axis,
+)
+from robot_sf.benchmark.identity.hash_utils import sha256_file
+
+PROMOTION_SCHEMA_VERSION = "control-action-latency-sweep-evidence-promotion.v1"
+ISSUE = 5034
+PARENT_ISSUE = 4977
+DEPENDENCY_PR = "#5026"
+
+#: Metrics the issue #5034 evidence summary must report per latency cell.
+REQUIRED_RESULT_METRICS: tuple[str, ...] = ("success_rate", "collision_rate", "min_clearance")
+
+#: Execution modes that count as native benchmark-success rows (issue #691 policy).
+NATIVE_EXECUTION_MODES: frozenset[str] = frozenset({"native", "adapter"})
+AVAILABLE_AVAILABILITY_STATUSES: frozenset[str] = frozenset({"available"})
+
+CLAIM_BOUNDARY = (
+    "control-action-latency metric-evidence promotion only: reads raw fidelity-campaign episode "
+    "rows, isolates the control_action_latency axis, and reports action-latency metadata plus "
+    "success / collision / minimum-clearance metrics per native latency cell. It runs no episode "
+    "and promotes no claim beyond the declared campaign evidence tier; it is not "
+    "simulator-realism evidence, not sim-to-real evidence, and not paper-facing evidence."
+)
+
+EXCLUSION_POLICY = (
+    "Per the issue #691 benchmark fallback policy, any row whose execution_mode is not "
+    "native/adapter or whose availability_status is not available, plus any latency-axis row "
+    "missing action_latency metadata, is recorded as an exclusion and never contributes to the "
+    "result metrics. This keeps fallback/degraded execution out of the latency result set."
+)
+
+
+class LatencyEvidenceError(RuntimeError):
+    """Raised when raw rows are not promotable as latency-sweep evidence (fail closed)."""
+
+
+@dataclass(frozen=True)
+class LatencyCell:
+    """One classified control-action-latency episode row.
+
+    ``classification`` is ``result`` for native, latency-metadata-bearing rows and
+    ``exclusion`` for everything else (fallback / degraded / non-native / missing
+    latency metadata). Only ``result`` cells contribute to the aggregate metrics.
+    """
+
+    planner: str
+    latency_step: int | None
+    latency_ms: float | None
+    variant: str
+    baseline_variant: bool
+    seed: int
+    scenario_id: str
+    success_rate: float
+    collision_rate: float
+    min_clearance: float | None
+    classification: str
+    exclusion_reason: str | None
+    execution_mode: str
+    availability_status: str
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Return an int for numeric values, rejecting bools and non-numbers."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and float(value).is_integer():
+        return int(value)
+    return None
+
+
+def _row_execution_mode(row: Mapping[str, Any]) -> str:
+    """Return a row's execution mode, defaulting to ``native`` when unset.
+
+    The fail-closed campaign runner (``allow_fallback=False``) emits no fallback
+    rows, so a completed row without an explicit marker is native. Rows that
+    *do* carry a non-native marker are honored so the promoter degrades safely if
+    a future runner path emits one.
+    """
+    mode = row.get("execution_mode")
+    return str(mode) if isinstance(mode, str) and mode else "native"
+
+
+def _row_availability_status(row: Mapping[str, Any]) -> str:
+    """Return a row's availability status, defaulting to ``available`` when unset."""
+    status = row.get("availability_status")
+    return str(status) if isinstance(status, str) and status else "available"
+
+
+def _latency_step_from_row(row: Mapping[str, Any]) -> int | None:
+    """Extract the effective action-latency step for a row.
+
+    Prefers the structured ``action_latency.effective_steps`` metadata; falls back
+    to ``action_latency.configured_steps`` then to the row-level
+    ``action_latency_steps`` marker so rows produced before the metadata dict
+    landed still resolve.
+
+    Returns:
+        The effective action-latency step, or ``None`` when no marker resolves.
+    """
+    metadata = row.get("action_latency")
+    if isinstance(metadata, Mapping):
+        for key in ("effective_steps", "configured_steps"):
+            step = _coerce_int(metadata.get(key))
+            if step is not None:
+                return step
+    return _coerce_int(row.get("action_latency_steps"))
+
+
+def _latency_ms_from_row(row: Mapping[str, Any]) -> float | None:
+    """Return the effective action-latency milliseconds for a row, if recorded.
+
+    Returns:
+        The effective latency in ms, or ``None`` when not recorded.
+    """
+    metadata = row.get("action_latency")
+    if isinstance(metadata, Mapping):
+        for key in ("effective_ms", "configured_ms"):
+            value = metadata.get(key)
+            if isinstance(value, int | float) and not isinstance(value, bool):
+                return float(value)
+    return None
+
+
+def classify_latency_row(row: Mapping[str, Any]) -> LatencyCell:
+    """Classify one episode row as a latency ``result`` cell or an ``exclusion``.
+
+    The row must belong to the ``control_action_latency`` axis. A row is a
+    ``result`` only when it carries action-latency metadata AND its execution mode
+    is native/adapter AND its availability status is available. Anything else
+    (fallback / degraded / non-native / missing latency metadata) becomes an
+    ``exclusion`` with a precise reason, so fallback execution can never enter the
+    latency result set.
+
+    Returns:
+        The classified :class:`LatencyCell` for the row.
+    """
+    metrics = row.get("metrics")
+    metric_map = metrics if isinstance(metrics, Mapping) else {}
+    success_rate = float(metric_map.get("success_rate", 0.0) or 0.0)
+    collision_rate = float(metric_map.get("collision_rate", 0.0) or 0.0)
+    raw_min_clearance = metric_map.get("min_clearance")
+    min_clearance = (
+        float(raw_min_clearance)
+        if isinstance(raw_min_clearance, int | float) and not isinstance(raw_min_clearance, bool)
+        else None
+    )
+
+    execution_mode = _row_execution_mode(row)
+    availability_status = _row_availability_status(row)
+    latency_step = _latency_step_from_row(row)
+    latency_ms = _latency_ms_from_row(row)
+
+    reasons: list[str] = []
+    if latency_step is None:
+        reasons.append("missing_action_latency_metadata")
+    if execution_mode not in NATIVE_EXECUTION_MODES:
+        reasons.append(f"non_native_execution_mode:{execution_mode}")
+    if availability_status not in AVAILABLE_AVAILABILITY_STATUSES:
+        reasons.append(f"unavailable:{availability_status}")
+
+    return LatencyCell(
+        planner=str(row.get("planner") or "unknown"),
+        latency_step=latency_step,
+        latency_ms=latency_ms,
+        variant=str(row.get("variant") or row.get("variant_source_key") or "unknown"),
+        baseline_variant=bool(row.get("baseline_variant", False)),
+        seed=int(row.get("seed") or 0),
+        scenario_id=str(row.get("scenario_id") or "unknown"),
+        success_rate=success_rate,
+        collision_rate=collision_rate,
+        min_clearance=min_clearance,
+        classification="result" if not reasons else "exclusion",
+        exclusion_reason="; ".join(reasons) if reasons else None,
+        execution_mode=execution_mode,
+        availability_status=availability_status,
+    )
+
+
+def extract_latency_cells(rows: Sequence[Mapping[str, Any]]) -> list[LatencyCell]:
+    """Return latency cells for every ``control_action_latency`` axis row.
+
+    Rows on other fidelity axes (clearance_radius, integration_timestep, ...) are
+    ignored: they are not part of the latency sweep and must never contribute to
+    its result metrics.
+    """
+    cells: list[LatencyCell] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        if str(row.get("axis") or "") != AXIS_KEY:
+            continue
+        cells.append(classify_latency_row(row))
+    return cells
+
+
+def _mean(values: Sequence[float]) -> float | None:
+    """Return the arithmetic mean of a non-empty sequence, else ``None``."""
+    if not values:
+        return None
+    return float(sum(values) / len(values))
+
+
+def aggregate_latency_metrics(cells: Sequence[LatencyCell]) -> list[dict[str, Any]]:
+    """Aggregate result cells into per (planner, latency_step) metric rows.
+
+    Exclusion cells never contribute. Each aggregate row reports the issue-#5034
+    required metrics (success_rate, collision_rate, min_clearance) plus the cell
+    count and the latency metadata (steps and ms). Rows are ordered by planner
+    then latency step for deterministic output.
+
+    Returns:
+        One aggregate metric row per ``(planner, latency_step)`` result bucket.
+    """
+    buckets: dict[tuple[str, int], list[LatencyCell]] = {}
+    for cell in cells:
+        if cell.classification != "result" or cell.latency_step is None:
+            continue
+        buckets.setdefault((cell.planner, cell.latency_step), []).append(cell)
+
+    aggregates: list[dict[str, Any]] = []
+    for planner, latency_step in sorted(buckets, key=lambda item: (item[0][0], item[0][1])):
+        bucket = buckets[(planner, latency_step)]
+        min_clearances = [c.min_clearance for c in bucket if c.min_clearance is not None]
+        aggregates.append(
+            {
+                "planner": planner,
+                "action_latency_steps": latency_step,
+                "action_latency_ms": _mean(
+                    [c.latency_ms for c in bucket if c.latency_ms is not None]
+                ),
+                "cell_count": len(bucket),
+                "seeds": sorted({c.seed for c in bucket}),
+                "success_rate": _mean([c.success_rate for c in bucket]),
+                "collision_rate": _mean([c.collision_rate for c in bucket]),
+                "min_clearance": _mean(min_clearances) if min_clearances else None,
+            }
+        )
+    return aggregates
+
+
+def _required_step_coverage(
+    aggregates: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Return which required latency steps are covered by native result aggregates.
+
+    Returns:
+        Coverage dict with ``required_latency_steps``, ``observed_latency_steps``,
+        ``missing_latency_steps``, and ``coverage_complete``.
+    """
+    observed_steps = sorted({int(row["action_latency_steps"]) for row in aggregates})
+    missing = [step for step in REQUIRED_LATENCY_STEPS if step not in observed_steps]
+    return {
+        "required_latency_steps": list(REQUIRED_LATENCY_STEPS),
+        "observed_latency_steps": observed_steps,
+        "missing_latency_steps": missing,
+        "coverage_complete": not missing,
+    }
+
+
+def _exclusion_summary(cells: Sequence[LatencyCell]) -> dict[str, Any]:
+    """Return a summary of excluded latency rows and their reasons (#691 discipline).
+
+    Returns:
+        Summary dict with ``excluded_row_count``, ``reason_counts``, and a small
+        ``sample_exclusions`` list.
+    """
+    exclusions = [cell for cell in cells if cell.classification == "exclusion"]
+    reason_counts: dict[str, int] = {}
+    for exclusion in exclusions:
+        for reason in (exclusion.exclusion_reason or "unknown").split("; "):
+            reason_counts[reason] = reason_counts.get(reason, 0) + 1
+    return {
+        "excluded_row_count": len(exclusions),
+        "reason_counts": dict(sorted(reason_counts.items())),
+        "sample_exclusions": [asdict(cell) for cell in exclusions[:5]],
+    }
+
+
+def build_latency_evidence(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    config: Mapping[str, Any],
+    config_path: str,
+    git_head: str,
+    date: str | None,
+    raw_rows_path: str,
+) -> dict[str, Any]:
+    """Build the durable compact control-action-latency evidence packet.
+
+    Fails closed (:class:`LatencyEvidenceError`) when the latency preflight is not
+    ``ready`` or when native result rows do not cover every required action-latency
+    step (0, 1, 3), so a partial or non-latency run cannot be promoted as the
+    latency sweep.
+
+    Args:
+        rows: Raw episode rows from the fidelity campaign runner.
+        config: Raw fidelity-sensitivity study config mapping.
+        config_path: Repo-relative config path recorded for provenance.
+        git_head: Git head recorded for provenance.
+        date: ISO date string recorded for provenance.
+        raw_rows_path: Repo-relative path of the source raw row file.
+
+    Returns:
+        JSON-serializable evidence packet with per-cell and aggregate latency
+        metrics plus the exclusion classification.
+    """
+    preflight = check_control_action_latency_axis(
+        config, config_path=config_path, git_head=git_head, date=date
+    )
+    if preflight["decision"] != DECISION_READY:
+        raise LatencyEvidenceError(
+            "control-action-latency preflight is not ready; refusing to promote. Blockers: "
+            + "; ".join(preflight.get("blockers") or ["unknown"])
+        )
+
+    cells = extract_latency_cells(rows)
+    if not cells:
+        raise LatencyEvidenceError(
+            f"raw rows contain no '{AXIS_KEY}' axis rows; cannot promote as the latency sweep"
+        )
+
+    aggregates = aggregate_latency_metrics(cells)
+    coverage = _required_step_coverage(aggregates)
+    if not coverage["coverage_complete"]:
+        raise LatencyEvidenceError(
+            "native latency result rows do not cover every required action-latency step. "
+            f"required={list(REQUIRED_LATENCY_STEPS)} "
+            f"observed={coverage['observed_latency_steps']} "
+            f"missing={coverage['missing_latency_steps']}"
+        )
+
+    result_cells = [cell for cell in cells if cell.classification == "result"]
+    return {
+        "schema_version": PROMOTION_SCHEMA_VERSION,
+        "issue": ISSUE,
+        "parent_issue": PARENT_ISSUE,
+        "depends_on_pr": DEPENDENCY_PR,
+        "date": date,
+        "git_head": git_head,
+        "config_path": config_path,
+        "raw_rows_path": raw_rows_path,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "exclusion_policy": EXCLUSION_POLICY,
+        "preflight_decision": preflight["decision"],
+        "preflight_axis_present": preflight["axis_present"],
+        "preflight_observed_latency_steps": preflight["observed_latency_steps"],
+        "required_result_metrics": list(REQUIRED_RESULT_METRICS),
+        "latency_coverage": coverage,
+        "scope": {
+            "latency_row_count": len(cells),
+            "result_row_count": len(result_cells),
+            "excluded_row_count": len(cells) - len(result_cells),
+            "planners": sorted({cell.planner for cell in result_cells}),
+            "seeds": sorted({cell.seed for cell in result_cells}),
+            "scenario_ids": sorted({cell.scenario_id for cell in result_cells}),
+        },
+        "aggregate_metrics": aggregates,
+        "per_cell_metrics": [asdict(cell) for cell in cells],
+        "exclusions": _exclusion_summary(cells),
+        "artifact_policy": (
+            "Compact promotion artifacts are tracked here. Raw episode JSONL remains ignored under "
+            "output/ and needs a durable external storage pointer before paper-facing use."
+        ),
+    }
+
+
+def _format_markdown(packet: Mapping[str, Any]) -> str:
+    """Return a compact human-readable evidence Markdown string.
+
+    Returns:
+        Markdown rendering of the promotion packet.
+    """
+    scope = packet["scope"]
+    coverage = packet["latency_coverage"]
+    exclusions = packet["exclusions"]
+    lines = [
+        f"# Issue #{ISSUE} Control-action-latency sweep evidence {packet.get('date') or ''}",
+        "",
+        "Plain-language summary: this bundle promotes raw fidelity-campaign episode rows into a "
+        "compact control-action-latency evidence summary. It reports the 0/100/300 ms-equivalent "
+        "delay cells' success, collision, and minimum-clearance metrics and excludes any "
+        "fallback/degraded/non-native rows. It is not paper-facing evidence.",
+        "",
+        f"- Schema: `{packet['schema_version']}`",
+        f"- Git head: `{packet.get('git_head')}`",
+        f"- Raw rows: `{packet.get('raw_rows_path')}`",
+        f"- Preflight decision: `{packet['preflight_decision']}`",
+        f"- Claim boundary: {packet['claim_boundary']}",
+        "",
+        "## Scope",
+        "",
+        f"- Latency rows: `{scope['latency_row_count']}` (results `{scope['result_row_count']}`, "
+        f"excluded `{scope['excluded_row_count']}`)",
+        f"- Planners: `{', '.join(scope['planners']) or 'none'}`",
+        f"- Seeds: `{', '.join(str(seed) for seed in scope['seeds']) or 'none'}`",
+        f"- Latency-step coverage: required `{coverage['required_latency_steps']}`, "
+        f"observed `{coverage['observed_latency_steps']}`, "
+        f"missing `{coverage['missing_latency_steps'] or 'none'}`",
+        "",
+        "## Aggregate metrics per latency cell",
+        "",
+        "| Planner | Latency steps | Latency ms | Cells | Success | Collision | Min clearance |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in packet["aggregate_metrics"]:
+        ms = row.get("action_latency_ms")
+        min_clearance = row.get("min_clearance")
+        lines.append(
+            f"| `{row['planner']}` | {row['action_latency_steps']} | "
+            f"{ms if ms is not None else 'NA'} | {row['cell_count']} | "
+            f"{row['success_rate']:.6g} | {row['collision_rate']:.6g} | "
+            f"{min_clearance if min_clearance is not None else 'NA'} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Exclusions (fallback / degraded / non-native)",
+            "",
+            f"- Excluded rows: `{exclusions['excluded_row_count']}`",
+            f"- Reasons: `{exclusions['reason_counts'] or 'none'}`",
+            "",
+            "Per the issue #691 benchmark fallback policy, excluded rows never contribute to "
+            "the result metrics above.",
+            "",
+            "## Files",
+            "",
+            "- `summary.json`: full promotion packet (aggregate + per-cell + exclusions).",
+            "- `per_cell_metrics.csv`: compact per-cell latency metrics table.",
+            "- `manifest.sha256`: checksums for promoted compact artifacts.",
+            "- `README.md`: this human-readable summary.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_latency_evidence(packet: Mapping[str, Any], evidence_dir: str | Path) -> list[Path]:
+    """Write the durable compact latency evidence bundle.
+
+    Writes ``summary.json``, ``per_cell_metrics.csv``, ``README.md``, and
+    ``manifest.sha256`` into ``evidence_dir``.
+
+    Returns:
+        The list of written artifact paths.
+    """
+    out = Path(evidence_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    summary_path = out / "summary.json"
+    summary_path.write_text(
+        json.dumps(packet, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    csv_path = out / "per_cell_metrics.csv"
+    fieldnames = [
+        "planner",
+        "latency_step",
+        "latency_ms",
+        "variant",
+        "baseline_variant",
+        "seed",
+        "scenario_id",
+        "success_rate",
+        "collision_rate",
+        "min_clearance",
+        "classification",
+        "exclusion_reason",
+        "execution_mode",
+        "availability_status",
+    ]
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, lineterminator="\n")
+        writer.writeheader()
+        for cell in packet["per_cell_metrics"]:
+            writer.writerow(
+                {
+                    "planner": cell["planner"],
+                    "latency_step": cell["latency_step"]
+                    if cell["latency_step"] is not None
+                    else "",
+                    "latency_ms": cell["latency_ms"] if cell["latency_ms"] is not None else "",
+                    "variant": cell["variant"],
+                    "baseline_variant": cell["baseline_variant"],
+                    "seed": cell["seed"],
+                    "scenario_id": cell["scenario_id"],
+                    "success_rate": cell["success_rate"],
+                    "collision_rate": cell["collision_rate"],
+                    "min_clearance": cell["min_clearance"]
+                    if cell["min_clearance"] is not None
+                    else "",
+                    "classification": cell["classification"],
+                    "exclusion_reason": cell["exclusion_reason"] or "",
+                    "execution_mode": cell["execution_mode"],
+                    "availability_status": cell["availability_status"],
+                }
+            )
+
+    readme_path = out / "README.md"
+    readme_path.write_text(_format_markdown(packet), encoding="utf-8")
+
+    copied = [summary_path, csv_path, readme_path]
+    manifest_path = out / "manifest.sha256"
+    manifest_path.write_text(
+        "\n".join(f"{sha256_file(path)}  {path.name}" for path in copied) + "\n",
+        encoding="utf-8",
+    )
+    copied.append(manifest_path)
+    return copied
+
+
+def load_latency_rows(raw_rows_path: str | Path) -> list[dict[str, Any]]:
+    """Return newline-delimited JSON episode rows emitted by the campaign runner.
+
+    Returns:
+        The list of parsed row mappings.
+    """
+    path = Path(raw_rows_path)
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise LatencyEvidenceError(
+                    f"raw rows file {path} has invalid JSON on line {line_number}: {exc}"
+                ) from exc
+            if isinstance(row, dict):
+                rows.append(row)
+    return rows
+
+
+def promote_latency_evidence(
+    raw_rows_path: str | Path,
+    evidence_dir: str | Path,
+    *,
+    config: Mapping[str, Any],
+    config_path: str,
+    git_head: str,
+    date: str | None,
+) -> dict[str, Any]:
+    """Load raw rows, build the latency evidence packet, and write the bundle.
+
+    Convenience entry point that combines :func:`load_latency_rows`,
+    :func:`build_latency_evidence`, and :func:`write_latency_evidence`. Raises
+    :class:`LatencyEvidenceError` (fail closed) when the rows cannot be promoted
+    as the latency sweep.
+
+    Returns:
+        A promotion result dict with status, evidence dir, written files, and
+        coverage summary.
+    """
+    rows = load_latency_rows(raw_rows_path)
+    packet = build_latency_evidence(
+        rows,
+        config=config,
+        config_path=config_path,
+        git_head=git_head,
+        date=date,
+        raw_rows_path=str(raw_rows_path),
+    )
+    written = write_latency_evidence(packet, evidence_dir)
+    return {
+        "schema_version": PROMOTION_SCHEMA_VERSION,
+        "status": "promoted",
+        "issue": ISSUE,
+        "evidence_dir": str(evidence_dir),
+        "written_files": [str(path) for path in written],
+        "result_row_count": packet["scope"]["result_row_count"],
+        "excluded_row_count": packet["scope"]["excluded_row_count"],
+        "latency_coverage": packet["latency_coverage"],
+        "claim_boundary": CLAIM_BOUNDARY,
+    }

--- a/scripts/benchmark/promote_control_action_latency_evidence.py
+++ b/scripts/benchmark/promote_control_action_latency_evidence.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Promote raw control-action-latency sweep episode rows into durable evidence (#5034).
+
+Reads raw fidelity-campaign episode rows (the JSONL the runner writes under
+``output/``), isolates the ``control_action_latency`` axis, and promotes a
+compact durable evidence bundle under ``docs/context/evidence/`` that reports the
+action-latency metadata plus success / collision / minimum-clearance metrics for
+each completed native latency cell and classifies every fallback / degraded /
+non-native row as an exclusion rather than a result.
+
+This command runs **no episode** and makes **no benchmark / simulator-realism /
+sim-to-real / paper-facing claim**. It fails closed when the latency preflight is
+not ready or when the native result rows do not cover the required action-latency
+step set (0, 1, 3), so a partial or non-latency run cannot be promoted as the
+latency sweep.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from robot_sf.benchmark.control_action_latency_evidence import (
+    PROMOTION_SCHEMA_VERSION,
+    LatencyEvidenceError,
+    build_latency_evidence,
+    load_latency_rows,
+    write_latency_evidence,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = "configs/research/fidelity_sensitivity_v1.yaml"
+DEFAULT_RAW_ROWS = "output/fidelity_latency_raw/episode_rows.jsonl"
+DEFAULT_EVIDENCE_DIR = "docs/context/evidence/issue_5034_control_action_latency_sweep"
+
+
+def _git_head() -> str:
+    """Return the current git head, or ``unknown`` when unavailable."""
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, stderr=subprocess.DEVNULL
+            )
+            .decode("utf-8")
+            .strip()
+        )
+    except (subprocess.SubprocessError, OSError):
+        return "unknown"
+
+
+def _repo_rel(path: Path) -> str:
+    """Return a repo-relative path string when possible."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG,
+        help="Fidelity-sensitivity study config (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--raw-rows",
+        default=DEFAULT_RAW_ROWS,
+        help="Raw episode rows JSONL emitted by the fidelity campaign runner.",
+    )
+    parser.add_argument(
+        "--evidence-dir",
+        default=DEFAULT_EVIDENCE_DIR,
+        help="Durable evidence output directory under docs/context/evidence/.",
+    )
+    parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help=(
+            "Classify and validate the raw rows without writing the evidence bundle; "
+            "prints a compact JSON status and exits non-zero when promotion would fail."
+        ),
+    )
+    parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Exit non-zero (fail closed) when the rows cannot be promoted as the latency sweep.",
+    )
+    parser.add_argument("--date", default=dt.datetime.now(tz=dt.UTC).date().isoformat())
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = parse_args(argv)
+
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        config_path = REPO_ROOT / config_path
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+
+    raw_rows_path = Path(args.raw_rows)
+    if not raw_rows_path.is_absolute():
+        raw_rows_path = REPO_ROOT / raw_rows_path
+
+    try:
+        rows = load_latency_rows(raw_rows_path)
+        packet = build_latency_evidence(
+            rows,
+            config=config,
+            config_path=_repo_rel(config_path),
+            git_head=_git_head(),
+            date=str(args.date),
+            raw_rows_path=_repo_rel(raw_rows_path),
+        )
+    except LatencyEvidenceError as exc:
+        status = {
+            "schema_version": PROMOTION_SCHEMA_VERSION,
+            "status": "blocked",
+            "issue": 5034,
+            "reason": str(exc),
+        }
+        print(json.dumps(status, indent=2, sort_keys=True))
+        return 1 if args.require_ready else 0
+
+    if args.check_only:
+        print(
+            json.dumps(
+                {
+                    "schema_version": PROMOTION_SCHEMA_VERSION,
+                    "status": "promotable",
+                    "issue": 5034,
+                    "result_row_count": packet["scope"]["result_row_count"],
+                    "excluded_row_count": packet["scope"]["excluded_row_count"],
+                    "latency_coverage": packet["latency_coverage"],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    evidence_dir = Path(args.evidence_dir)
+    if not evidence_dir.is_absolute():
+        evidence_dir = REPO_ROOT / evidence_dir
+    written = write_latency_evidence(packet, evidence_dir)
+    result = {
+        "schema_version": PROMOTION_SCHEMA_VERSION,
+        "status": "promoted",
+        "issue": 5034,
+        "evidence_dir": _repo_rel(evidence_dir),
+        "written_files": [_repo_rel(path) for path in written],
+        "result_row_count": packet["scope"]["result_row_count"],
+        "excluded_row_count": packet["scope"]["excluded_row_count"],
+        "latency_coverage": packet["latency_coverage"],
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_control_action_latency_evidence.py
+++ b/tests/benchmark/test_control_action_latency_evidence.py
@@ -136,6 +136,16 @@ def test_degraded_availability_is_exclusion() -> None:
     assert "unavailable:degraded" in cell.exclusion_reason
 
 
+def test_missing_required_result_metric_is_exclusion() -> None:
+    """A row cannot fabricate an absent outcome metric as zero-valued evidence."""
+    row = _latency_row(step=1)
+    row["metrics"].pop("success_rate")
+    cell = classify_latency_row(row)
+    assert cell.classification == "exclusion"
+    assert "missing_or_invalid_metric:success_rate" in cell.exclusion_reason
+    assert cell.success_rate is None
+
+
 # --- extract_latency_cells ------------------------------------------------
 
 
@@ -268,6 +278,23 @@ def test_build_evidence_fails_closed_when_all_step3_rows_are_excluded() -> None:
         assert "[3]" in str(exc)
     else:  # pragma: no cover - defensive
         raise AssertionError("expected LatencyEvidenceError when all 3-step rows excluded")
+
+
+def test_build_evidence_fails_closed_when_required_metrics_are_missing() -> None:
+    """Rows without outcome metrics cannot provide a required latency cell."""
+    rows = _full_native_row_set()
+    for row in rows:
+        if row["action_latency"]["effective_steps"] == 3:
+            row["metrics"].pop("collision_rate")
+    with pytest.raises(LatencyEvidenceError, match=r"missing=\[3\]"):
+        build_latency_evidence(
+            rows,
+            config=_load_real_config(),
+            config_path="configs/research/fidelity_sensitivity_v1.yaml",
+            git_head="abc123",
+            date="2026-07-10",
+            raw_rows_path="output/x/episode_rows.jsonl",
+        )
 
 
 def test_build_evidence_records_exclusions_without_promoting_them() -> None:

--- a/tests/benchmark/test_control_action_latency_evidence.py
+++ b/tests/benchmark/test_control_action_latency_evidence.py
@@ -1,0 +1,362 @@
+"""Tests for the control-action-latency sweep evidence promotion (issue #5034)."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.control_action_latency_evidence import (
+    CLAIM_BOUNDARY,
+    PROMOTION_SCHEMA_VERSION,
+    REQUIRED_RESULT_METRICS,
+    LatencyEvidenceError,
+    aggregate_latency_metrics,
+    build_latency_evidence,
+    classify_latency_row,
+    extract_latency_cells,
+    promote_latency_evidence,
+    write_latency_evidence,
+)
+from robot_sf.benchmark.control_action_latency_preflight import AXIS_KEY
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REAL_CONFIG = REPO_ROOT / "configs/research/fidelity_sensitivity_v1.yaml"
+
+
+def _latency_row(
+    *,
+    planner: str = "baseline_social_force",
+    step: int,
+    seed: int = 111,
+    min_clearance: float = 0.4,
+    baseline_variant: bool = False,
+    variant: str | None = None,
+    execution_mode: str | None = None,
+    availability_status: str | None = None,
+) -> dict[str, Any]:
+    """Build one representative control_action_latency episode row (runner shape).
+
+    Rows default to a native, successful, collision-free outcome; classification
+    markers (``execution_mode`` / ``availability_status``) are added only when
+    passed so the exclusion path can be exercised.
+    """
+    ms = step * 100.0
+    return {
+        "axis": AXIS_KEY,
+        "variant": variant or f"control_action_latency__step_{step}",
+        "variant_source_key": f"step_{step}",
+        "baseline_variant": baseline_variant,
+        "runtime_binding": "sim_config.action_latency_steps",
+        "action_latency": {
+            "configured_steps": step,
+            "configured_ms": None,
+            "effective_steps": step,
+            "effective_ms": ms,
+        },
+        "planner": planner,
+        "scenario_id": f"scenario_{seed}",
+        "seed": seed,
+        "success": True,
+        "collision": False,
+        "metrics": {
+            "success_rate": 1.0,
+            "collision_rate": 0.0,
+            "min_clearance": min_clearance,
+        },
+        **({"execution_mode": execution_mode} if execution_mode else {}),
+        **({"availability_status": availability_status} if availability_status else {}),
+    }
+
+
+def _full_native_row_set() -> list[dict[str, Any]]:
+    """Return a minimal native row set covering latency steps 0, 1, 3."""
+    rows: list[dict[str, Any]] = []
+    for step in (0, 1, 3):
+        for seed in (111, 112):
+            rows.append(
+                _latency_row(
+                    step=step,
+                    seed=seed,
+                    planner="baseline_social_force",
+                    baseline_variant=(step == 0),
+                    min_clearance=0.5 - 0.1 * step,
+                )
+            )
+    return rows
+
+
+def _load_real_config() -> dict[str, Any]:
+    """Load the shipped fidelity-sensitivity config (post-#5026 carries the axis)."""
+    return yaml.safe_load(REAL_CONFIG.read_text(encoding="utf-8")) or {}
+
+
+# --- classify_latency_row -------------------------------------------------
+
+
+def test_native_row_with_metadata_classifies_as_result() -> None:
+    """A native row carrying action_latency metadata is a result cell."""
+    cell = classify_latency_row(_latency_row(step=1))
+    assert cell.classification == "result"
+    assert cell.exclusion_reason is None
+    assert cell.latency_step == 1
+    assert cell.latency_ms == 100.0
+    assert cell.success_rate == 1.0
+    assert cell.collision_rate == 0.0
+    assert cell.min_clearance == 0.4
+
+
+def test_row_missing_action_latency_metadata_is_exclusion() -> None:
+    """A latency row without action_latency metadata cannot confirm the contract."""
+    row = _latency_row(step=1)
+    row["action_latency"] = None
+    cell = classify_latency_row(row)
+    assert cell.classification == "exclusion"
+    assert cell.exclusion_reason == "missing_action_latency_metadata"
+    assert cell.latency_step is None
+
+
+def test_fallback_execution_mode_is_exclusion() -> None:
+    """A fallback execution-mode row is excluded per issue #691 policy."""
+    row = _latency_row(step=1, execution_mode="fallback")
+    cell = classify_latency_row(row)
+    assert cell.classification == "exclusion"
+    assert "non_native_execution_mode:fallback" in cell.exclusion_reason
+
+
+def test_degraded_availability_is_exclusion() -> None:
+    """A degraded/unavailable row is excluded per issue #691 policy."""
+    row = _latency_row(step=1, availability_status="degraded")
+    cell = classify_latency_row(row)
+    assert cell.classification == "exclusion"
+    assert "unavailable:degraded" in cell.exclusion_reason
+
+
+# --- extract_latency_cells ------------------------------------------------
+
+
+def test_extract_isolates_latency_axis_rows_only() -> None:
+    """Rows on other fidelity axes never become latency cells."""
+    rows = [
+        *_full_native_row_set(),
+        {
+            "axis": "clearance_radius",
+            "variant": "clearance_radius__radius_0_30",
+            "planner": "baseline_social_force",
+            "seed": 111,
+            "scenario_id": "scenario_111",
+            "metrics": {"success_rate": 1.0, "collision_rate": 0.0, "min_clearance": 0.3},
+        },
+    ]
+    cells = extract_latency_cells(rows)
+    assert len(cells) == 6
+    assert all(cell.planner == "baseline_social_force" for cell in cells)
+
+
+# --- aggregate_latency_metrics --------------------------------------------
+
+
+def test_aggregate_metrics_group_by_planner_and_step() -> None:
+    """Aggregates average success/collision/min_clearance per (planner, step)."""
+    cells = extract_latency_cells(_full_native_row_set())
+    aggregates = aggregate_latency_metrics(cells)
+    by_key = {(row["planner"], row["action_latency_steps"]): row for row in aggregates}
+    assert sorted(by_key) == [
+        ("baseline_social_force", 0),
+        ("baseline_social_force", 1),
+        ("baseline_social_force", 3),
+    ]
+    for step in (0, 1, 3):
+        row = by_key[("baseline_social_force", step)]
+        assert row["cell_count"] == 2
+        assert row["success_rate"] == 1.0
+        assert row["collision_rate"] == 0.0
+        assert row["min_clearance"] == pytest.approx(0.5 - 0.1 * step)
+        assert set(REQUIRED_RESULT_METRICS).issubset(row)
+
+
+def test_aggregate_excludes_exclusion_cells() -> None:
+    """Exclusion cells (fallback) never enter the aggregate metrics."""
+    rows = _full_native_row_set()
+    rows.append(_latency_row(step=1, seed=999, execution_mode="fallback"))
+    cells = extract_latency_cells(rows)
+    aggregates = aggregate_latency_metrics(cells)
+    step_one = next(row for row in aggregates if row["action_latency_steps"] == 1)
+    # The fallback seed-999 row must NOT inflate the count.
+    assert step_one["cell_count"] == 2
+
+
+# --- build_latency_evidence (fail-closed gates) ---------------------------
+
+
+def test_build_evidence_succeeds_on_complete_native_coverage() -> None:
+    """A complete native 0/1/3 row set builds a promotable packet."""
+    packet = build_latency_evidence(
+        _full_native_row_set(),
+        config=_load_real_config(),
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="abc123",
+        date="2026-07-10",
+        raw_rows_path="output/fidelity_latency_raw/episode_rows.jsonl",
+    )
+    assert packet["schema_version"] == PROMOTION_SCHEMA_VERSION
+    assert packet["preflight_decision"] == "ready"
+    assert packet["latency_coverage"]["coverage_complete"] is True
+    assert packet["latency_coverage"]["missing_latency_steps"] == []
+    assert packet["scope"]["result_row_count"] == 6
+    assert packet["scope"]["excluded_row_count"] == 0
+    assert CLAIM_BOUNDARY in packet["claim_boundary"]
+    assert json.loads(json.dumps(packet)) == packet  # JSON-serializable
+
+
+def test_build_evidence_fails_closed_when_required_step_missing() -> None:
+    """Dropping all 3-step rows fails closed (partial run cannot be promoted)."""
+    rows = [row for row in _full_native_row_set() if row["action_latency"]["effective_steps"] != 3]
+    try:
+        build_latency_evidence(
+            rows,
+            config=_load_real_config(),
+            config_path="configs/research/fidelity_sensitivity_v1.yaml",
+            git_head="abc123",
+            date="2026-07-10",
+            raw_rows_path="output/fidelity_latency_raw/episode_rows.jsonl",
+        )
+    except LatencyEvidenceError as exc:
+        assert "missing" in str(exc)
+        assert "[3]" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected LatencyEvidenceError for incomplete coverage")
+
+
+def test_build_evidence_fails_closed_when_no_latency_rows() -> None:
+    """Rows with no latency axis cannot be promoted as the latency sweep."""
+    try:
+        build_latency_evidence(
+            [{"axis": "clearance_radius", "planner": "p", "metrics": {}}],
+            config=_load_real_config(),
+            config_path="configs/research/fidelity_sensitivity_v1.yaml",
+            git_head="abc123",
+            date="2026-07-10",
+            raw_rows_path="output/x/episode_rows.jsonl",
+        )
+    except LatencyEvidenceError as exc:
+        assert "no 'control_action_latency' axis rows" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected LatencyEvidenceError for missing latency rows")
+
+
+def test_build_evidence_fails_closed_when_all_step3_rows_are_excluded() -> None:
+    """If every 3-step row is fallback/degraded, coverage is incomplete → fail closed."""
+    rows = _full_native_row_set()
+    for row in rows:
+        if row["action_latency"]["effective_steps"] == 3:
+            row["execution_mode"] = "degraded"
+    try:
+        build_latency_evidence(
+            rows,
+            config=_load_real_config(),
+            config_path="configs/research/fidelity_sensitivity_v1.yaml",
+            git_head="abc123",
+            date="2026-07-10",
+            raw_rows_path="output/x/episode_rows.jsonl",
+        )
+    except LatencyEvidenceError as exc:
+        assert "[3]" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected LatencyEvidenceError when all 3-step rows excluded")
+
+
+def test_build_evidence_records_exclusions_without_promoting_them() -> None:
+    """Fallback rows appear in exclusions but never in aggregate results."""
+    rows = _full_native_row_set()
+    rows.append(
+        _latency_row(step=1, seed=999, execution_mode="fallback", availability_status="fallback")
+    )
+    packet = build_latency_evidence(
+        rows,
+        config=_load_real_config(),
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="abc123",
+        date="2026-07-10",
+        raw_rows_path="output/x/episode_rows.jsonl",
+    )
+    assert packet["scope"]["excluded_row_count"] == 1
+    assert packet["exclusions"]["excluded_row_count"] == 1
+    assert packet["exclusions"]["reason_counts"]["non_native_execution_mode:fallback"] == 1
+    # Aggregate step-1 count stays at 2 native rows.
+    step_one = next(row for row in packet["aggregate_metrics"] if row["action_latency_steps"] == 1)
+    assert step_one["cell_count"] == 2
+
+
+# --- write_latency_evidence + promote_latency_evidence --------------------
+
+
+def test_write_latency_evidence_writes_bundle(tmp_path: Path) -> None:
+    """The evidence bundle writes summary, CSV, README, and a checksum manifest."""
+    packet = build_latency_evidence(
+        _full_native_row_set(),
+        config=_load_real_config(),
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="abc123",
+        date="2026-07-10",
+        raw_rows_path="output/x/episode_rows.jsonl",
+    )
+    written = write_latency_evidence(packet, tmp_path / "ev")
+    names = {path.name for path in written}
+    assert names == {"summary.json", "per_cell_metrics.csv", "README.md", "manifest.sha256"}
+    summary = json.loads((tmp_path / "ev" / "summary.json").read_text(encoding="utf-8"))
+    assert summary == packet
+    with (tmp_path / "ev" / "per_cell_metrics.csv").open(encoding="utf-8") as handle:
+        records = list(csv.DictReader(handle))
+    assert len(records) == 6
+    assert {record["classification"] for record in records} == {"result"}
+    readme = (tmp_path / "ev" / "README.md").read_text(encoding="utf-8")
+    assert "Plain-language summary" in readme
+
+
+def test_promote_end_to_end_from_jsonl(tmp_path: Path) -> None:
+    """promote_latency_evidence loads JSONL rows and writes the full bundle."""
+    rows = _full_native_row_set()
+    raw_path = tmp_path / "episode_rows.jsonl"
+    raw_path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    result = promote_latency_evidence(
+        raw_path,
+        tmp_path / "ev",
+        config=_load_real_config(),
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="abc123",
+        date="2026-07-10",
+    )
+    assert result["status"] == "promoted"
+    assert result["result_row_count"] == 6
+    assert (tmp_path / "ev" / "summary.json").exists()
+
+
+def test_promote_fails_closed_on_incomplete_jsonl(tmp_path: Path) -> None:
+    """An incomplete JSONL (missing step 3) fails closed at promotion time."""
+    rows = [row for row in _full_native_row_set() if row["action_latency"]["effective_steps"] != 3]
+    raw_path = tmp_path / "episode_rows.jsonl"
+    raw_path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    try:
+        promote_latency_evidence(
+            raw_path,
+            tmp_path / "ev",
+            config=_load_real_config(),
+            config_path="configs/research/fidelity_sensitivity_v1.yaml",
+            git_head="abc123",
+            date="2026-07-10",
+        )
+    except LatencyEvidenceError as exc:
+        assert "[3]" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected LatencyEvidenceError")


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** new metric-evidence **promotion** capability for issue #5034's control-action-latency fidelity sweep — `robot_sf/benchmark/control_action_latency_evidence.py` (`build_latency_evidence`, `promote_latency_evidence`) + CLI `scripts/benchmark/promote_control_action_latency_evidence.py`. It reads raw fidelity-campaign episode rows, isolates the `control_action_latency` axis, and emits a durable compact evidence summary reporting the **action-latency metadata plus `success_rate`, `collision_rate`, and `min_clearance` per native latency cell** (the 0/100/300 ms-equivalent steps `[0, 1, 3]`), and classifies every **fallback / degraded / non-native** row (per the issue #691 benchmark fallback policy) as an **exclusion** that never contributes to result metrics.
- **Why now:** issue #5034 is the *execute + evidence* step deferred by #5026. PR #5026 has now landed the `control_action_latency` axis (steps 0/1/3) in `configs/research/fidelity_sensitivity_v1.yaml`, and PR #5061 merged the fail-closed **preflight** + historical blocker packet. The issue comment states *"the native #5034 campaign and metric-evidence promotion remain."* This slice delivers the **metric-evidence promotion** half. With #5026 merged the preflight now flips `blocked → ready` (verified: `decision: ready`, `observed_latency_steps=[0, 1, 3]`) and the fixed-scope plan reports `preflight_ready` / `executable=True` (153 cells).
- **Successor statement:** this is a **successor slice to PR #5061** — it adds NEW metric-evidence promotion capability and **does not duplicate PR #5061** (which was the preflight + readiness/blocker packet only).
- **Claim boundary:** promotion logic + focused tests only — **not benchmark evidence, not simulator-realism evidence, not sim-to-real evidence, not paper-facing.** No campaign run, no Slurm/GPU submission, no episode executed by this PR. The native campaign run that produces the real raw rows remains out of scope for this slice.
- **Required validation:** new unit tests + ruff (below).

Issue: https://github.com/ll7/robot_sf_ll7/issues/5034 · Parent: #4977 · Depends on (landed): #5026 · Successor to: #5061

## Contract delta

- **New capability:** `build_latency_evidence(rows, config, ...) -> packet` reads raw episode rows (the JSONL shape `run_episode` in `run_fidelity_sensitivity_campaign.py` emits) and produces a `control-action-latency-sweep-evidence-promotion.v1` packet. Per (planner, latency_step) it reports `success_rate`, `collision_rate`, `min_clearance`, cell count, seeds, and the latency metadata (steps + ms). `classify_latency_row` tags each row `result` (native + has `action_latency` metadata + available) or `exclusion` (fallback / degraded / non-native / missing latency metadata). `extract_latency_cells` isolates the latency axis so other fidelity axes never enter the result set. `promote_latency_evidence` + `write_latency_evidence` write `summary.json`, `per_cell_metrics.csv`, `README.md`, and `manifest.sha256` to a durable `docs/context/evidence/` bundle.
- **New fail-closed gates:** refuses to promote when (a) the latency preflight is not `ready`, (b) raw rows contain no `control_action_latency` axis rows, or (c) native result rows do not cover every required step `[0, 1, 3]` (including the case where all of a step's rows are fallback/degraded). This prevents a partial, non-latency, or fallback-only run from being silently promoted as the latency sweep.
- **Compatibility:** additive only — new module + CLI + tests + CHANGELOG. No existing runtime, config, metric, or preflight semantics changed. Reuses `check_control_action_latency_axis` (PR #5061) and `sha256_file`, matching the established `promote_reactivity_replay_rank_study_issue_3637.py` pattern.

## Scope

- **In scope:** the metric-evidence **promotion** step (DoD item 3: "A durable compact evidence summary links the raw artifact location and reports the latency metadata plus success, collision, and minimum-clearance metrics for each completed cell") and the exclusion-classification half of validation step 3 ("classify all non-native/fallback/degraded rows as exclusions, not results"). This is the "metric-evidence promotion" the issue comment names as remaining.
- **Out of scope (explicit):** the **native campaign run** itself (the "native #5034 campaign" half) — that is a campaign run and stays out of the cheap implementation lane. No latency-semantics change, no Slurm/GPU, no parent-issue #4977 result classification update (that awaits an actual native run whose rows this promoter then promotes), and no paper/dissertation claim.

## ARTIFACT-FIRST note

The required inputs for a *real* promoted artifact (raw episode rows from a native campaign run) do **not** exist yet — the native campaign has not been run (it is a campaign, out of scope here). Per the cheap-lane contract this slice therefore implements the **actual promotion logic** the issue asks for (not another readiness/decision/checker packet) and proves it end-to-end on a representative row fixture via the real CLI. The moment the native campaign emits raw rows, this exact promoter + CLI produces the durable `docs/context/evidence/` bundle with no further code change.

## Validation

CPU-level only (shared worktree venv; no campaign, no GPU/Slurm):

| Command | Result |
| --- | --- |
| `uv run pytest tests/benchmark/test_control_action_latency_evidence.py tests/benchmark/test_control_action_latency_preflight.py -q` | **21 passed** (15 new + 6 existing, no regression) |
| `uv run python scripts/benchmark/promote_control_action_latency_evidence.py --raw-rows <fixture>.jsonl --check-only --require-ready` | `status: promotable`, `result_row_count: 6`, `excluded_row_count: 1`, coverage `[0,1,3]` complete, exit 0 |
| `uv run python scripts/benchmark/promote_control_action_latency_evidence.py --raw-rows <fixture>.jsonl --evidence-dir output/issue_5034_latency_smoke` | `status: promoted`; wrote `summary.json` + `per_cell_metrics.csv` + `README.md` + `manifest.sha256`; aggregates show success 1.0→0.5→0.0 and collision 0.0→0.5→1.0 across steps 0/1/3 and the fallback row excluded |
| `uv run python scripts/benchmark/preflight_control_action_latency_sweep.py --require-ready` | `decision: ready`, `observed_latency_steps=[0, 1, 3]`, exit 0 (axis now present post-#5026) |
| `uv run python scripts/benchmark/run_fidelity_sensitivity_campaign.py --fixed-scope-plan-only --require-launchable` | `preflight_decision=preflight_ready executable=True run_cells=153` |
| `uv run ruff check` / `ruff format` (changed files) | clean |

The CLI smoke artifacts were written to gitignored `output/` (a synthetic fixture, **not** a campaign) and are **not** committed; they exist only to prove the real promotion path.

## Remaining work (out of scope for this slice)

- [ ] Run the native fixed-scope latency campaign (`--fixed-scope-execute`) — a campaign run, out of scope for the cheap implementation lane.
- [ ] Promote its real raw rows with this exact promoter + CLI into `docs/context/evidence/issue_5034_control_action_latency_sweep/` and register in `docs/context/catalog.yaml`.
- [ ] Update parent issue #4977 with the result classification once a native run exists.

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.

Refs #5034 — partial (metric-evidence promotion capability). The native campaign run remains.
