### PR TITLE
Issue #4974: field-observed ped-robot archetypes + calibratable force (cheap-lane worker)

### DIFF
--- a/configs/scenarios/archetypes/issue_4974_field_observed_ped_robot.yaml
+++ b/configs/scenarios/archetypes/issue_4974_field_observed_ped_robot.yaml
@@ -1,0 +1,193 @@
+## Issue #4974 — field-observation-informed pedestrian-robot interaction archetypes
+#
+# Purpose:
+#   Add three field-informed interaction archetypes that are absent from the current
+#   scenario set: robot-blocking-narrow-path, pedestrian-hesitation (stop-and-wait near
+#   robot), and give-way asymmetry. These are modeled on qualitative behavior documented
+#   in field observations of sidewalk delivery robots:
+#     * Weinberg et al. 2023, "Sharing the Sidewalk: Observing Delivery Robot
+#       Interactions with Pedestrians" — larger clearance margins, hesitation/uncertainty
+#       about robot intent, path changes differing from person-person passing.
+#     * Gehrke et al. 2023 — observed sidewalk autonomous-delivery-robot PET study.
+#
+# Claim boundary (HONEST):
+#   These scenarios are mechanism/exploratory evidence only. They prove the new
+#   calibration surface (per-scenario ped-robot force coefficient + effective radius,
+#   issue #4974 model side) and the `hesitating` response law (issue #4974 optional
+#   hesitation state) reach scenario definitions. They are NOT calibrated against the
+#   cited field studies and make NO realism, benchmark, or planner-ranking claim. The
+#   cited studies are qualitative references for plausible ranges only. Calibration to
+#   real trajectory data is deferred to the trajectory-dataset validation pipeline
+#   (issue sequencing note).
+#
+# Evidence tier: exploratory / mechanism. Lives under the data-driven scenario epic #4932.
+# Sibling: vulnerable-user pack #3654.
+scenarios:
+  - name: issue_4974_robot_blocks_narrow_path
+    map_file: ../../../maps/svg_maps/classic_doorway.svg
+    simulation_config:
+      max_episode_steps: 300
+      ped_density: 0.04
+      route_spawn_distribution: spread
+      route_spawn_jitter_frac: 0.2
+      max_peds_per_group: 1
+      # Calibration surface (model side, issue #4974): a robot blocking a narrow path
+      # produces a larger effective repulsion footprint. Tune coefficient and effective
+      # radius per-scenario without touching defaults.
+      prf_config:
+        force_multiplier: 15.0
+        robot_radius: 1.2
+        activation_threshold: 2.5
+    robot_config: {}
+    metadata:
+      archetype: robot_blocks_narrow_path
+      issue: 4974
+      pack_id: field_observed_ped_robot_v0
+      epic: 4932
+      density: medium
+      flow: bi
+      groups: 0.0
+      interaction_basis: >
+        Field observations (Weinberg et al. 2023; Gehrke et al. 2023) document larger
+        clearance margins around sidewalk robots. This archetype raises the ped-robot
+        force coefficient and effective radius so a robot in a narrow doorway blocks the
+        path and pedestrians must negotiate larger margins.
+      evidence_tier: exploratory
+      benchmark_evidence: false
+      claim_boundary: >
+        Mechanism-only: proves the per-scenario prf_config calibration surface reaches
+        runtime. Not a calibrated fit to field data; not benchmark or realism evidence.
+      plausible_ranges_source:
+        - "Weinberg et al. 2023, Sharing the Sidewalk"
+        - "Gehrke et al. 2023, sidewalk delivery-robot PET study"
+      plausibility:
+        status: unverified
+        verified_on: null
+        verified_by: null
+        method: null
+        notes: "Metadata-only field-observed archetype; no benchmark evidence."
+        metrics:
+          min_distance: null
+          mean_distance: null
+          robot_ped_within_5m_frac: null
+          ped_force_mean: null
+          force_q95: null
+        metrics_updated_on: null
+    seeds: [4974, 4975, 4976]
+
+  - name: issue_4974_pedestrian_hesitation
+    map_file: ../../../maps/svg_maps/classic_head_on_corridor.svg
+    simulation_config:
+      max_episode_steps: 300
+      ped_density: 0.03
+      route_spawn_distribution: spread
+      route_spawn_jitter_frac: 0.2
+      max_peds_per_group: 1
+      # Model-side optional hesitation state (issue #4974): a fraction of pedestrians
+      # hesitate (heightened robot awareness / larger clearance) near the robot. The
+      # `hesitating` response law maps to hesitating_response_multiplier (default 1.0,
+      # here raised to model larger clearance margins per the field studies).
+      response_law_composition:
+        reactive: 0.6
+        hesitating: 0.4
+      hesitating_response_multiplier: 1.8
+      response_law_seed: 4974
+      prf_config:
+        force_multiplier: 10.0
+        robot_radius: 1.0
+        activation_threshold: 2.5
+    robot_config: {}
+    metadata:
+      archetype: pedestrian_hesitation
+      issue: 4974
+      pack_id: field_observed_ped_robot_v0
+      epic: 4932
+      density: medium
+      flow: head_on
+      groups: 0.0
+      interaction_basis: >
+        Field observations document pedestrian hesitation/uncertainty about robot intent
+        and stop-and-wait behavior near sidewalk robots (Weinberg et al. 2023). This
+        archetype marks a fraction of pedestrians as `hesitating`, raising their robot
+        repulsion to model larger clearance margins and heightened robot awareness.
+      evidence_tier: exploratory
+      benchmark_evidence: false
+      claim_boundary: >
+        Mechanism-only: proves the `hesitating` response law and
+        hesitating_response_multiplier reach runtime. The clearance-margin multiplier is
+        a modeling proxy, not true stop-and-wait kinematics; not calibrated to field data.
+      plausible_ranges_source:
+        - "Weinberg et al. 2023, Sharing the Sidewalk"
+        - "Gehrke et al. 2023, sidewalk delivery-robot PET study"
+      plausibility:
+        status: unverified
+        verified_on: null
+        verified_by: null
+        method: null
+        notes: "Metadata-only field-observed archetype; no benchmark evidence."
+        metrics:
+          min_distance: null
+          mean_distance: null
+          robot_ped_within_5m_frac: null
+          ped_force_mean: null
+          force_q95: null
+        metrics_updated_on: null
+    seeds: [4974, 4975, 4976]
+
+  - name: issue_4974_give_way_asymmetry
+    map_file: ../../../maps/svg_maps/classic_t_intersection.svg
+    simulation_config:
+      max_episode_steps: 300
+      ped_density: 0.03
+      route_spawn_distribution: spread
+      route_spawn_jitter_frac: 0.2
+      max_peds_per_group: 1
+      # Give-way asymmetry (issue #4974): an asymmetric population where most
+      # pedestrians yield (hesitate) to the robot and a minority do not react. Models
+      # the asymmetric path-change behavior documented in field studies, where pedestrian
+      # yielding to robots is common but not universal.
+      response_law_composition:
+        hesitating: 0.7
+        non_reactive: 0.3
+      hesitating_response_multiplier: 1.6
+      response_law_seed: 4975
+      prf_config:
+        force_multiplier: 10.0
+        robot_radius: 1.0
+        activation_threshold: 2.5
+    robot_config: {}
+    metadata:
+      archetype: give_way_asymmetry
+      issue: 4974
+      pack_id: field_observed_ped_robot_v0
+      epic: 4932
+      density: medium
+      flow: t_intersection
+      groups: 0.0
+      interaction_basis: >
+        Field observations document that pedestrian yielding to sidewalk robots is common
+        but not universal, producing an asymmetric give-way pattern (Weinberg et al. 2023;
+        Gehrke et al. 2023). This archetype mixes a hesitating (yielding) majority with a
+        non-reactive minority to model that asymmetry.
+      evidence_tier: exploratory
+      benchmark_evidence: false
+      claim_boundary: >
+        Mechanism-only: proves the hesitating + non_reactive response-law mixture reaches
+        runtime on one scenario. Not calibrated to field data; not benchmark evidence.
+      plausible_ranges_source:
+        - "Weinberg et al. 2023, Sharing the Sidewalk"
+        - "Gehrke et al. 2023, sidewalk delivery-robot PET study"
+      plausibility:
+        status: unverified
+        verified_on: null
+        verified_by: null
+        method: null
+        notes: "Metadata-only field-observed archetype; no benchmark evidence."
+        metrics:
+          min_distance: null
+          mean_distance: null
+          robot_ped_within_5m_frac: null
+          ped_force_mean: null
+          force_q95: null
+        metrics_updated_on: null
+    seeds: [4974, 4975, 4976]

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -278,6 +278,19 @@ class SimulationSettings:
     to the robot at all.
     """
 
+    hesitating_response_multiplier: float = 1.0
+    """Repulsion multiplier for hesitating pedestrians (issue #4974).
+
+    Controls the strength of pedestrian-robot repulsion for pedestrians configured
+    with response_law='hesitating'. This is the model-side "optional hesitation
+    state": a value greater than 1.0 models the larger robot-clearance margins
+    documented in field observations of sidewalk delivery robots (Weinberg et al.
+    2023; Gehrke et al. 2023). The default of 1.0 preserves the existing force for
+    any pedestrian not explicitly marked hesitating. This is a clearance-margin
+    modeling proxy, not a calibrated dataset fit; plausible ranges are documented
+    in ``configs/scenarios/archetypes/issue_4974_field_observed_ped_robot.yaml``.
+    """
+
     peds_reset_follow_route_at_start: bool = False
     """Whether pedestrians following routes should reset to the start of their routes"""
     ped_speed_tier: str | None = None
@@ -395,6 +408,12 @@ class SimulationSettings:
             or self.non_reactive_response_multiplier < 0
         ):
             raise ValueError("non_reactive_response_multiplier must be a finite value >= 0!")
+        # Check that the hesitating response multiplier is finite and >= 0 (issue #4974)
+        if (
+            not isfinite(self.hesitating_response_multiplier)
+            or self.hesitating_response_multiplier < 0
+        ):
+            raise ValueError("hesitating_response_multiplier must be a finite value >= 0!")
         # Check that the goal radius is positive
         if self.goal_radius <= 0:
             raise ValueError("Goal radius mustn't be negative or zero!")

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -261,6 +261,8 @@ class Simulator:
                 if sim_idx is not None and 0 <= sim_idx < num_peds:
                     if resp_law in ("non_reactive", "non_yielding"):
                         multipliers[sim_idx] = self.config.non_reactive_response_multiplier
+                    elif resp_law == "hesitating":
+                        multipliers[sim_idx] = self.config.hesitating_response_multiplier
         elif getattr(self.config, "response_law_composition", None) and num_peds > 0:
             response_laws = assign_archetype_labels(
                 num_peds,
@@ -270,6 +272,8 @@ class Simulator:
             for idx, law in enumerate(response_laws):
                 if law in ("non_reactive", "non_yielding"):
                     multipliers[idx] = self.config.non_reactive_response_multiplier
+                elif law == "hesitating":
+                    multipliers[idx] = self.config.hesitating_response_multiplier
 
         self.pedestrian_response_multipliers = multipliers
 

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -29,6 +29,7 @@ from robot_sf.nav.map_config import (
     serialize_map,
 )
 from robot_sf.nav.svg_map_parser import convert_map
+from robot_sf.ped_npc.ped_robot_force import PedRobotForceConfig
 from robot_sf.robot.bicycle_drive import BicycleDriveSettings
 from robot_sf.robot.differential_drive import DifferentialDriveSettings
 from robot_sf.robot.holonomic_drive import HolonomicDriveSettings
@@ -2145,6 +2146,60 @@ def _set_simulation_override_attr(
         setattr(config.sim_config, attr, overrides[attr])
 
 
+_PRF_CONFIG_OVERRIDE_FIELDS = (
+    "is_active",
+    "robot_radius",
+    "activation_threshold",
+    "force_multiplier",
+)
+
+
+def _apply_prf_config_override(
+    config: RobotSimulationConfig,
+    overrides: Mapping[str, Any] | None,
+) -> None:
+    """Apply scenario-level pedestrian-robot force calibration overrides (issue #4974).
+
+    Exposes the ped-robot force's coefficient (``force_multiplier``), effective
+    radius (``robot_radius``), activation distance (``activation_threshold``), and
+    active flag (``is_active``) as a per-scenario calibration surface. Defaults are
+    preserved when a field is omitted, so existing scenarios are unchanged.
+    """
+    if overrides is None:
+        return
+    if not isinstance(overrides, Mapping):
+        raise ValueError("simulation_config.prf_config must be a mapping.")
+    unknown = sorted(set(overrides) - set(_PRF_CONFIG_OVERRIDE_FIELDS))
+    if unknown:
+        raise ValueError(
+            f"simulation_config.prf_config contains unknown keys: {', '.join(unknown)}."
+        )
+    base = config.sim_config.prf_config
+    kwargs: dict[str, Any] = {
+        "is_active": base.is_active,
+        "robot_radius": base.robot_radius,
+        "activation_threshold": base.activation_threshold,
+        "force_multiplier": base.force_multiplier,
+    }
+    if "is_active" in overrides:
+        kwargs["is_active"] = _coerce_bool(
+            overrides["is_active"], field_name="prf_config.is_active"
+        )
+    if "robot_radius" in overrides:
+        kwargs["robot_radius"] = _coerce_positive_float(
+            overrides["robot_radius"], field_name="prf_config.robot_radius"
+        )
+    if "activation_threshold" in overrides:
+        kwargs["activation_threshold"] = _coerce_positive_float(
+            overrides["activation_threshold"], field_name="prf_config.activation_threshold"
+        )
+    if "force_multiplier" in overrides:
+        kwargs["force_multiplier"] = _coerce_finite_float(
+            overrides["force_multiplier"], field_name="prf_config.force_multiplier"
+        )
+    config.sim_config.prf_config = PedRobotForceConfig(**kwargs)
+
+
 def _apply_simulation_overrides(
     config: RobotSimulationConfig,
     overrides: Mapping[str, Any] | None,
@@ -2190,9 +2245,15 @@ def _apply_simulation_overrides(
         "response_law_seed",
         "population_size",
         "non_reactive_response_multiplier",
+        "hesitating_response_multiplier",
     ):
         if attr in overrides:
             _set_simulation_override_attr(config, attr, overrides)
+    # Expose the pedestrian-robot force as a calibration surface (issue #4974):
+    # coefficient (force_multiplier), effective radius (robot_radius), activation
+    # distance, and active flag can be tuned per-scenario without touching defaults.
+    if "prf_config" in overrides:
+        _apply_prf_config_override(config, overrides["prf_config"])
 
 
 def _apply_map_pool(

--- a/tests/ped_npc/test_issue_4974_field_observed_ped_robot.py
+++ b/tests/ped_npc/test_issue_4974_field_observed_ped_robot.py
@@ -1,0 +1,283 @@
+"""Tests for issue #4974: field-observation-informed ped-robot interaction.
+
+Covers both halves of the issue:
+
+Model side (calibration surface):
+  * Per-scenario ``simulation_config.prf_config`` override exposes the ped-robot
+    force coefficient, effective radius, activation distance, and active flag.
+  * The ``hesitating`` response law maps to ``hesitating_response_multiplier``
+    (the "optional hesitation state").
+  * Backward compatibility: defaults are unchanged when fields are omitted.
+
+Scenario side:
+  * The new archetype file loads, has the three required archetypes, valid
+    structure, existing map references, and uses the new calibration surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from robot_sf.ped_npc.ped_archetypes import assign_archetype_labels
+from robot_sf.ped_npc.ped_robot_force import PedRobotForce, PedRobotForceConfig
+from robot_sf.sim.sim_config import SimulationSettings
+from robot_sf.training.scenario_loader import (
+    build_robot_config_from_scenario,
+    load_scenarios,
+)
+
+WORKTREE = Path(__file__).resolve().parents[2]
+ARCHETYPE_FILE = (
+    WORKTREE / "configs" / "scenarios" / "archetypes" / "issue_4974_field_observed_ped_robot.yaml"
+)
+
+
+class _DummyPedState:
+    """Minimal mock of PySocialForce ``PedState`` for force unit tests."""
+
+    def __init__(self, positions: np.ndarray, radius: float = 0.3):
+        self._pos = positions
+        self.agent_radius = radius
+
+    def pos(self) -> np.ndarray:
+        return self._pos
+
+    def size(self) -> int:
+        return self._pos.shape[0]
+
+
+# ---------------------------------------------------------------------------
+# Model side: prf_config calibration surface
+# ---------------------------------------------------------------------------
+
+
+def _build_config(scenario_name: str) -> SimulationSettings:
+    """Load one scenario from the issue #4974 archetype file into sim settings."""
+    scenarios = load_scenarios(ARCHETYPE_FILE, base_dir=ARCHETYPE_FILE)
+    scenario = next(s for s in scenarios if s["name"] == scenario_name)
+    robot_cfg = build_robot_config_from_scenario(scenario, scenario_path=ARCHETYPE_FILE)
+    return robot_cfg.sim_config
+
+
+def test_prf_config_override_applies_coefficient_and_radius() -> None:
+    """Per-scenario prf_config overrides reach SimulationSettings.prf_config."""
+    sim_cfg = _build_config("issue_4974_robot_blocks_narrow_path")
+    prf = sim_cfg.prf_config
+    assert prf.force_multiplier == pytest.approx(15.0)
+    assert prf.robot_radius == pytest.approx(1.2)
+    assert prf.activation_threshold == pytest.approx(2.5)
+    assert prf.is_active is True
+
+
+def test_prf_config_override_preserves_omitted_defaults() -> None:
+    """A scenario that omits a prf_config field keeps the field default."""
+    scenarios = load_scenarios(ARCHETYPE_FILE, base_dir=ARCHETYPE_FILE)
+    # Build a minimal override payload that sets only force_multiplier.
+    scenario = {**scenarios[0]}
+    scenario = {**scenario}
+    scenario["simulation_config"] = {"prf_config": {"force_multiplier": 7.5}}
+    robot_cfg = build_robot_config_from_scenario(scenario, scenario_path=ARCHETYPE_FILE)
+    prf = robot_cfg.sim_config.prf_config
+    assert prf.force_multiplier == pytest.approx(7.5)
+    # Omitted fields fall back to PedRobotForceConfig defaults.
+    assert prf.robot_radius == pytest.approx(1.0)
+    assert prf.activation_threshold == pytest.approx(2.0)
+    assert prf.is_active is True
+
+
+def test_prf_config_override_rejects_unknown_keys() -> None:
+    """Unknown prf_config keys fail closed."""
+    scenario = {
+        "name": "bogus",
+        "map_file": "../../../maps/svg_maps/classic_doorway.svg",
+        "simulation_config": {"prf_config": {"not_a_field": 1.0}},
+        "robot_config": {},
+        "metadata": {},
+        "seeds": [1, 2, 3],
+    }
+    with pytest.raises(ValueError, match="prf_config contains unknown keys"):
+        build_robot_config_from_scenario(scenario, scenario_path=ARCHETYPE_FILE)
+
+
+def test_prf_config_override_rejects_negative_radius() -> None:
+    """Negative effective radius fails closed via positive-float coercion."""
+    scenario = {
+        "name": "bogus",
+        "map_file": "../../../maps/svg_maps/classic_doorway.svg",
+        "simulation_config": {"prf_config": {"robot_radius": -1.0}},
+        "robot_config": {},
+        "metadata": {},
+        "seeds": [1, 2, 3],
+    }
+    with pytest.raises(ValueError, match="robot_radius must be > 0"):
+        build_robot_config_from_scenario(scenario, scenario_path=ARCHETYPE_FILE)
+
+
+# ---------------------------------------------------------------------------
+# Model side: hesitating response law (optional hesitation state)
+# ---------------------------------------------------------------------------
+
+
+def test_hesitating_response_multiplier_default_preserves_behavior() -> None:
+    """Default hesitating_response_multiplier is 1.0 (no-op vs reactive default)."""
+    sim = SimulationSettings()
+    assert sim.hesitating_response_multiplier == pytest.approx(1.0)
+
+
+def test_hesitating_response_multiplier_validation_rejects_negative() -> None:
+    """Negative hesitating multipliers are rejected at construction time."""
+    with pytest.raises(ValueError, match="hesitating_response_multiplier must be a finite value"):
+        SimulationSettings(hesitating_response_multiplier=-0.1)
+
+
+def test_hesitating_response_multiplier_reaches_scenario_config() -> None:
+    """The hesitation archetype's multiplier and composition reach sim settings."""
+    sim_cfg = _build_config("issue_4974_pedestrian_hesitation")
+    assert sim_cfg.hesitating_response_multiplier == pytest.approx(1.8)
+    assert sim_cfg.response_law_composition == {
+        "reactive": pytest.approx(0.6),
+        "hesitating": pytest.approx(0.4),
+    }
+
+
+def test_ped_robot_force_applies_hesitating_multiplier_above_reactive() -> None:
+    """A hesitating pedestrian (multiplier > 1) feels stronger repulsion than reactive (1.0)."""
+    peds = _DummyPedState(np.array([[1.0, 0.0]], dtype=float))
+    config = PedRobotForceConfig(
+        is_active=True,
+        robot_radius=0.5,
+        activation_threshold=5.0,
+        force_multiplier=10.0,
+    )
+
+    reactive = PedRobotForce(
+        config, peds, get_robot_pos=lambda: np.array([0.0, 0.0], dtype=float)
+    )()
+    reactive_mag = float(np.linalg.norm(reactive[0]))
+
+    hesitating = PedRobotForce(
+        config,
+        peds,
+        get_robot_pos=lambda: np.array([0.0, 0.0], dtype=float),
+        get_ped_response_multipliers=lambda: np.array([1.8], dtype=float),
+    )()
+    hesitating_mag = float(np.linalg.norm(hesitating[0]))
+
+    assert hesitating_mag == pytest.approx(1.8 * reactive_mag, rel=1e-6)
+
+
+def test_hesitating_label_assignment_is_deterministic() -> None:
+    """Seeded hesitating/reactive assignment is deterministic with the right counts."""
+    comp = {"reactive": 0.6, "hesitating": 0.4}
+    labels_1 = assign_archetype_labels(10, comp, seed=4974)
+    labels_2 = assign_archetype_labels(10, comp, seed=4974)
+    assert np.array_equal(labels_1, labels_2)
+    assert int(np.count_nonzero(labels_1 == "hesitating")) == 4
+    assert int(np.count_nonzero(labels_1 == "reactive")) == 6
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: existing scenarios unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_existing_scenario_without_prf_override_uses_defaults() -> None:
+    """A scenario without prf_config keeps the default PedRobotForceConfig."""
+    classic_doorway = WORKTREE / "configs" / "scenarios" / "archetypes" / "classic_doorway.yaml"
+    scenarios = load_scenarios(classic_doorway, base_dir=classic_doorway)
+    sim_cfg = build_robot_config_from_scenario(
+        scenarios[0], scenario_path=classic_doorway
+    ).sim_config
+    default = PedRobotForceConfig()
+    prf = sim_cfg.prf_config
+    assert prf.force_multiplier == pytest.approx(default.force_multiplier)
+    assert prf.robot_radius == pytest.approx(default.robot_radius)
+    assert prf.activation_threshold == pytest.approx(default.activation_threshold)
+    assert prf.is_active == default.is_active
+
+
+# ---------------------------------------------------------------------------
+# Scenario side: archetype file structure
+# ---------------------------------------------------------------------------
+
+REQUIRED_SCENARIO_KEYS = {
+    "name",
+    "map_file",
+    "simulation_config",
+    "robot_config",
+    "metadata",
+    "seeds",
+}
+EXPECTED_ARCHETYPES = {
+    "robot_blocks_narrow_path",
+    "pedestrian_hesitation",
+    "give_way_asymmetry",
+}
+
+
+@pytest.fixture(scope="module")
+def scenarios() -> list[dict]:
+    """Load the issue #4974 archetype file once for the scenario-side tests."""
+    return list(load_scenarios(ARCHETYPE_FILE, base_dir=ARCHETYPE_FILE))
+
+
+def test_archetype_file_loads(scenarios: list[dict]) -> None:
+    """The archetype file parses and defines three scenarios."""
+    assert len(scenarios) == 3
+
+
+def test_archetype_names_match_field_observed_set(scenarios: list[dict]) -> None:
+    """The three required field-observed archetypes are present and named correctly."""
+    archetypes = {s["metadata"]["archetype"] for s in scenarios}
+    assert archetypes == EXPECTED_ARCHETYPES
+
+
+def test_each_scenario_has_required_structure(scenarios: list[dict]) -> None:
+    """Each scenario has required keys and an existing map file."""
+    for scenario in scenarios:
+        missing = REQUIRED_SCENARIO_KEYS - scenario.keys()
+        assert not missing, f"Scenario {scenario.get('name')} missing keys: {missing}"
+        map_file = (ARCHETYPE_FILE.parent / scenario["map_file"]).resolve()
+        assert map_file.exists(), f"Map file does not exist: {map_file}"
+
+
+def test_each_scenario_uses_calibration_surface(scenarios: list[dict]) -> None:
+    """Each scenario exercises the new prf_config calibration surface."""
+    for scenario in scenarios:
+        prf = scenario["simulation_config"].get("prf_config")
+        assert isinstance(prf, dict), f"{scenario['name']} must define simulation_config.prf_config"
+        assert "force_multiplier" in prf
+        assert "robot_radius" in prf
+
+
+def test_hesitation_and_giveway_use_hesitating_response_law(scenarios: list[dict]) -> None:
+    """The hesitation and give-way archetypes declare a hesitating response-law mix."""
+    by_name = {s["metadata"]["archetype"]: s for s in scenarios}
+    for archetype in ("pedestrian_hesitation", "give_way_asymmetry"):
+        comp = by_name[archetype]["simulation_config"]["response_law_composition"]
+        assert "hesitating" in comp, f"{archetype} must include a hesitating response law"
+        mult = by_name[archetype]["simulation_config"]["hesitating_response_multiplier"]
+        assert mult > 1.0, (
+            f"{archetype} hesitating_response_multiplier should model larger clearance"
+        )
+
+
+def test_scenario_metadata_marks_exploratory_no_benchmark_claim(scenarios: list[dict]) -> None:
+    """All archetypes honestly label themselves exploratory with no benchmark claim."""
+    for scenario in scenarios:
+        meta = scenario["metadata"]
+        assert meta["evidence_tier"] == "exploratory"
+        assert meta["benchmark_evidence"] is False
+        assert "claim_boundary" in meta
+        assert "4974" in str(meta.get("issue", ""))
+
+
+def test_scenario_seeds_are_int_lists(scenarios: list[dict]) -> None:
+    """Each scenario carries an integer seed list of length >= 3."""
+    for scenario in scenarios:
+        seeds = scenario["seeds"]
+        assert isinstance(seeds, list) and len(seeds) >= 3
+        assert all(isinstance(seed, int) for seed in seeds)


### PR DESCRIPTION
## What & why

Closes #4974 — field-observation-informed pedestrian-robot interaction archetypes and a calibratable ped-robot force.

This backwards-compatible slice adds the requested scenario and model surfaces; it is exploratory mechanism support only, not a calibrated realism, benchmark, or planner-ranking result.

## What changed

- Exposes per-scenario `prf_config` overrides for active state, effective radius, activation threshold, and force multiplier, preserving omitted defaults and rejecting malformed/unknown geometry input.
- Adds a validated `hesitating_response_multiplier` and wires the `hesitating` response law for trace labels and composition assignment.
- Adds three field-informed, explicitly exploratory archetypes plus focused regression coverage.

## Validation

- `uv run pytest tests/ped_npc/test_issue_4974_field_observed_ped_robot.py -q` — 17 passed.
- `uv run ruff check robot_sf/sim/sim_config.py robot_sf/sim/simulator.py robot_sf/training/scenario_loader.py tests/ped_npc/test_issue_4974_field_observed_ped_robot.py` — passed.

## Claim boundary and deferred work

The cited studies inform plausible mechanism ranges only. This PR does not claim calibration to field trajectories, realism validation, benchmark evidence, or stop-and-wait kinematics. Calibration/trajectory-dataset validation is explicitly tracked by #4975.

## Artifact handling

No generated artifacts, campaigns, Slurm runs, maps, or model assets. Evidence tier: exploratory mechanism support; no benchmark claim.

## Downstream propagation

Parent issue: updated at merge with the acceptance-criteria evidence and closure decision. Other propagation: NA — no benchmark, metric, registry, or paper-facing surface changed.
