### PR TITLE
docs: exclude dense evidence from routine searches (#5094)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -501,6 +501,18 @@ Use the snapshot JSON to seed worker prompts and active ledgers. Redirect broad
 search output or raw GitHub bodies to private agent-run artifacts; return only
 the compact snapshot, context capsule path, validation command, exit status, and
 short evidence excerpt to the parent Codex thread.
+
+For routine repository discovery, exclude the dense tracked evidence archive unless the archive is
+the explicit search target. Start with a focused command such as:
+
+```bash
+rg -n "<concept>" AGENTS.md docs scripts tests robot_sf .agents \
+  --glob '!docs/context/evidence/**' --glob '!output/**'
+```
+
+Omit the evidence exclusion only when the task is to inspect or validate evidence artifacts. This
+keeps ordinary code and workflow matches visible without treating the archive as unimportant.
+
 For implementation-thread validation, prefer `scripts/dev/run_focused_tests.sh`
 for focused pytest targets. It stores the full pytest log under the common
 Git-dir agent-run artifacts and prints only a bounded pass/fail summary by


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Documents a default `rg` command for routine repository discovery that excludes `docs/context/evidence/**` and ignored `output/**`.

**Why now:** The 60 MB / 1,641-file evidence archive previously flooded broad discovery searches, obscuring ordinary workflow and code matches.

**Claim boundary:** Documentation/workflow guidance only. It changes no search implementation, benchmark behavior, metric, schema, evidence classification, or research claim.

**Required validation:** Diff whitespace check, the changed-path docs/evidence integrity checker, and a direct assertion that the documented glob excludes evidence paths.

**Remaining blocker:** None for this issue. Evidence-archive searches remain explicitly supported by omitting the exclusion when that archive is the target.

## Contract delta

- New default: routine discovery searches exclude `docs/context/evidence/**` and `output/**`.
- New fail-closed blockers: none.
- Compatibility: evidence-artifact inspection remains available by intentionally omitting the evidence exclusion.

Closes #5094

<details>
<summary>Implementation, validation, and governance appendix</summary>

## Linked issue and scope

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5094
- Scope: one documentation addition in `docs/dev_guide.md`; no search helper or runtime behavior was added.
- Stack / dependency: none; safe to review independently.

## Validation / Proof

- `python3 scripts/dev/check_docs_evidence_integrity.py --files docs/dev_guide.md` — passed: `1 changed file(s) passed`.
- `git diff --check` — passed.
- Direct shell contract check using the documented `rg` glob — passed: it returned routine `worktree` matches and no `docs/context/evidence/` paths.

## Research Result Guidance

- Target claim / hypothesis / blocker: NA — docs-only workflow guidance.
- Evidence tier / result classification: NA.
- New research, benchmark, metric, or paper-facing tool: NA.

## Domain-Aware Approval

- Required for this PR: no — it does not alter experimental validity or evidence interpretation.
- Status: not required.

## Falsification / Non-Transfer Check

- NA — no research result or behavioral mechanism is claimed.

## Next Empirical Action

- NA — no evidence is missing or blocked.

## Risks / Rollout

- Compatibility risk: a user who needs evidence artifacts must omit the documented exclusion; that exception is stated next to the command.
- Rollback: revert the documentation paragraph.

## Docs / Provenance

- Updated docs: `docs/dev_guide.md`.
- Assumption: documentation is the smallest complete implementation of the issue's suggested bounded change; no helper is needed because `rg` supports the exclusion natively.

## Downstream Propagation

- Parent issue / claim map / benchmark report / leaderboard / registry / context index: NA — this PR creates no research evidence.
- State propagation: no separate issue comment is needed; `Closes #5094` is the canonical closure linkage, avoiding duplicate status updates.

## Follow-up issues

- #5095 records a separately encountered shared-worktree docs-checker friction; it is not part of this PR's scope.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the developer guide with clearer repository discovery guidance.
  * Added recommendations for excluding dense evidence and output directories during routine searches, with guidance on when to include them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->