### PR TITLE
feat(sensor): batch obstacle raycasts across environments (#4981)

### DIFF
--- a/docs/dev/issues/4981-vectorized-rollouts/design.md
+++ b/docs/dev/issues/4981-vectorized-rollouts/design.md
@@ -3,9 +3,9 @@
 ## Goal
 
 Issue #4981 needs a Stable-Baselines3-compatible way to collect several Robot SF rollout steps
-without requiring one Python process per environment. This design adds an opt-in in-process threaded
-mode to the primary PPO trainer while keeping the established `DummyVecEnv` and `SubprocVecEnv`
-paths unchanged.
+without requiring one Python process per environment. This design adds opt-in in-process threaded
+execution and an opt-in cross-environment light detection and ranging (LiDAR) kernel adapter while
+keeping the established `DummyVecEnv`, `SubprocVecEnv`, and scalar LiDAR paths unchanged.
 
 ## Contract delta
 
@@ -15,18 +15,29 @@ paths unchanged.
   observations, and information dictionaries.
 - With one environment, `threaded` resolves to `dummy`, preserving the existing single-environment
   fallback.
+- `robot_sf.sensor.range_sensor.raycast_obstacles_batch` accepts padded static-obstacle arrays for
+  several environments and evaluates them in one compiled central processing unit (CPU) dispatch.
+  Callers opt in explicitly; no environment or trainer selects it by default.
+- A one-environment LiDAR batch calls the existing `raycast_obstacles` kernel directly, preserving
+  its output bit for bit.
 
 ## Assumption and boundary
 
-The reversible implementation assumes independent Robot SF environments can be stepped concurrently
-when their numerical kernels release the Python global interpreter lock. It deliberately does not
-change simulator state layout or claim a batched Numba force/LiDAR kernel. Threaded workers share a
-process, so callers needing process isolation should continue using `worker_mode: subproc`.
+The reversible threaded implementation assumes independent Robot SF environments can be stepped
+concurrently when their numerical kernels release the Python global interpreter lock. Threaded
+workers share a process, so callers needing process isolation should continue using
+`worker_mode: subproc`.
+
+The LiDAR adapter batches only the static-obstacle raycast and requires a common ray count plus
+padded obstacle storage with explicit per-environment counts. It deliberately uses one sequential
+Numba dispatch rather than nested CPU parallelism, and it is not yet wired into environment step
+coordination. This contract establishes numerical equivalence, not a throughput improvement.
 
 ## Proof and follow-up
 
-The implementation is proven by Stable-Baselines3 lifecycle tests plus a real Robot SF reset/step
-smoke. It is not throughput evidence. The remaining acceptance step is a reproducible standard-PPO
-configuration measurement that compares `dummy`, `subproc`, and `threaded`, reports environment
-steps per second, and only promotes the issue's >3x claim if the exact configuration, host, and
+The implementation is proven by Stable-Baselines3 lifecycle tests, a real Robot SF reset/step smoke,
+and synthetic multi-environment tests that compare every batched LiDAR row with the scalar kernel.
+It is not throughput evidence. The remaining acceptance steps are integration of batch collection
+into a rollout path and a reproducible standard-PPO configuration measurement that compares worker
+and kernel modes. The issue's >3x claim may only be promoted if the exact configuration, host, and
 sample duration support it.

--- a/docs/training/vectorized_env_support.md
+++ b/docs/training/vectorized_env_support.md
@@ -34,3 +34,16 @@ the primary training path, plus unit coverage that secondary entry points reques
 
 Supported vector-env smoke tests intentionally use tiny scenario/config slices. They validate
 construction and Gymnasium reset/step/close behavior, not training quality or policy performance.
+
+## Opt-in light detection and ranging (LiDAR) kernel batching
+
+`robot_sf.sensor.range_sensor.raycast_obstacles_batch` provides one central processing unit
+(CPU)-safe cross-environment kernel path for callers that can collect several LiDAR inputs together.
+It accepts one padded static-obstacle tensor, explicit obstacle counts, scanner positions, and ray
+angles, then invokes the established obstacle-raycast arithmetic for every environment in one
+compiled dispatch.
+
+The adapter is opt-in and is not selected automatically by `ThreadedVecEnv` or any training config.
+A batch of one calls the scalar `raycast_obstacles` kernel directly. Multi-environment contract
+tests require bit-identical rows compared with independent scalar calls. These tests establish
+compatibility only; no rollout throughput or speedup claim is attached to this path.

--- a/robot_sf/sensor/range_sensor.py
+++ b/robot_sf/sensor/range_sensor.py
@@ -307,6 +307,101 @@ def raycast_obstacles(
             out_ranges[i] = min(coll_dist, out_ranges[i])
 
 
+@numba.njit(fastmath=True)  # pragma: no cover - exercised via caller; not line-traceable.
+def _raycast_obstacles_batch_kernel(
+    out_ranges: np.ndarray,
+    scanner_positions: np.ndarray,
+    obstacles: np.ndarray,
+    obstacle_counts: np.ndarray,
+    ray_angles: np.ndarray,
+):
+    """Run the scalar obstacle raycast for each row in one compiled dispatch."""
+    for env_idx in range(out_ranges.shape[0]):
+        raycast_obstacles(
+            out_ranges[env_idx],
+            scanner_positions[env_idx],
+            obstacles[env_idx, : obstacle_counts[env_idx]],
+            ray_angles[env_idx],
+        )
+
+
+def raycast_obstacles_batch(
+    out_ranges: np.ndarray,
+    scanner_positions: np.ndarray,
+    obstacles: np.ndarray,
+    obstacle_counts: np.ndarray,
+    ray_angles: np.ndarray,
+) -> None:
+    """Update several environments' light detection and ranging data in one CPU dispatch.
+
+    This opt-in adapter batches the existing :func:`raycast_obstacles` kernel without
+    changing its arithmetic or any environment default. Obstacle rows are padded to a
+    common length; ``obstacle_counts`` marks how many rows belong to each environment.
+    A one-environment batch calls the established scalar kernel directly so its output
+    remains bit-identical to the existing path.
+
+    Args:
+        out_ranges: Mutable floating-point array with shape ``(B, R)``.
+        scanner_positions: Scanner origins with shape ``(B, 2)``.
+        obstacles: Padded obstacle segments with shape ``(B, M, 4)``.
+        obstacle_counts: Integer array with shape ``(B,)`` and values in ``[0, M]``.
+        ray_angles: Absolute ray directions with shape ``(B, R)``.
+
+    Raises:
+        TypeError: If ``out_ranges`` is not a writable floating-point NumPy array or
+            ``obstacle_counts`` does not contain integers.
+        ValueError: If an input shape or obstacle count violates the batch contract.
+    """
+    if not isinstance(out_ranges, np.ndarray) or not np.issubdtype(out_ranges.dtype, np.floating):
+        raise TypeError("out_ranges must be a floating-point NumPy array")
+    if not out_ranges.flags.writeable:
+        raise TypeError("out_ranges must be writable")
+    if out_ranges.ndim != 2 or out_ranges.shape[0] == 0:
+        raise ValueError("out_ranges must have shape (B, R) with B >= 1")
+
+    batch_size, num_rays = out_ranges.shape
+    scanner_positions_array = np.asarray(scanner_positions)
+    obstacles_array = np.asarray(obstacles)
+    obstacle_counts_array = np.asarray(obstacle_counts)
+    ray_angles_array = np.asarray(ray_angles)
+
+    if scanner_positions_array.shape != (batch_size, 2):
+        raise ValueError("scanner_positions must have shape (B, 2)")
+    if (
+        obstacles_array.ndim != 3
+        or obstacles_array.shape[0] != batch_size
+        or obstacles_array.shape[2] != 4
+    ):
+        raise ValueError("obstacles must have shape (B, M, 4)")
+    if obstacle_counts_array.shape != (batch_size,) or not np.issubdtype(
+        obstacle_counts_array.dtype, np.integer
+    ):
+        raise TypeError("obstacle_counts must be an integer array with shape (B,)")
+    if np.any(obstacle_counts_array < 0) or np.any(
+        obstacle_counts_array > obstacles_array.shape[1]
+    ):
+        raise ValueError("obstacle_counts values must be within [0, M]")
+    if ray_angles_array.shape != (batch_size, num_rays):
+        raise ValueError("ray_angles must have shape (B, R) matching out_ranges")
+
+    if batch_size == 1:
+        raycast_obstacles(
+            out_ranges[0],
+            scanner_positions_array[0],
+            obstacles_array[0, : obstacle_counts_array[0]],
+            ray_angles_array[0],
+        )
+        return
+
+    _raycast_obstacles_batch_kernel(
+        out_ranges,
+        scanner_positions_array,
+        obstacles_array,
+        obstacle_counts_array,
+        ray_angles_array,
+    )
+
+
 @numba.njit()
 def raycast(  # noqa: PLR0913
     scanner_pos: Vec2D,

--- a/tests/sensor/test_batched_lidar_kernel.py
+++ b/tests/sensor/test_batched_lidar_kernel.py
@@ -1,0 +1,129 @@
+"""Contracts for opt-in cross-environment LiDAR obstacle batching."""
+
+import numpy as np
+import pytest
+
+from robot_sf.sensor import range_sensor
+
+
+def _synthetic_batch() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    out_ranges = np.array(
+        [
+            [10.0, 10.0, 10.0, 10.0],
+            [8.0, 8.0, 8.0, 8.0],
+            [6.0, 6.0, 6.0, 6.0],
+        ],
+        dtype=np.float64,
+    )
+    scanner_positions = np.array([[0.0, 0.0], [10.0, -2.0], [1.0, 1.0]])
+    obstacles = np.zeros((3, 3, 4), dtype=np.float64)
+    obstacles[0, 0] = [2.0, -1.0, 2.0, 1.0]
+    obstacles[0, 1] = [-3.0, -1.0, -3.0, 1.0]
+    obstacles[1, 0] = [9.0, 1.0, 11.0, 1.0]
+    obstacles[1, 1] = [12.0, -3.0, 12.0, -1.0]
+    obstacles[1, 2] = [100.0, 100.0, 101.0, 101.0]
+    obstacle_counts = np.array([2, 3, 0], dtype=np.int64)
+    ray_angles = np.tile(
+        np.array([0.0, np.pi / 2.0, np.pi, 3.0 * np.pi / 2.0]),
+        (3, 1),
+    )
+    return out_ranges, scanner_positions, obstacles, obstacle_counts, ray_angles
+
+
+def test_multi_environment_batch_is_bit_identical_to_scalar_kernel() -> None:
+    """Every batch row matches an independent call to the established kernel exactly."""
+    actual, scanner_positions, obstacles, obstacle_counts, ray_angles = _synthetic_batch()
+    expected = actual.copy()
+    for env_idx in range(expected.shape[0]):
+        range_sensor.raycast_obstacles(
+            expected[env_idx],
+            scanner_positions[env_idx],
+            obstacles[env_idx, : obstacle_counts[env_idx]],
+            ray_angles[env_idx],
+        )
+
+    range_sensor.raycast_obstacles_batch(
+        actual,
+        scanner_positions,
+        obstacles,
+        obstacle_counts,
+        ray_angles,
+    )
+
+    assert np.array_equal(actual, expected)
+
+
+def test_single_environment_batch_uses_bit_identical_scalar_fallback(monkeypatch) -> None:
+    """A one-row request bypasses the batch kernel and retains scalar output bits."""
+    out_ranges, scanner_positions, obstacles, obstacle_counts, ray_angles = _synthetic_batch()
+    actual = out_ranges[:1].copy()
+    expected = actual.copy()
+    range_sensor.raycast_obstacles(
+        expected[0],
+        scanner_positions[0],
+        obstacles[0, : obstacle_counts[0]],
+        ray_angles[0],
+    )
+
+    def _unexpected_batch_dispatch(*_args) -> None:
+        raise AssertionError("single-environment fallback dispatched the batch kernel")
+
+    monkeypatch.setattr(range_sensor, "_raycast_obstacles_batch_kernel", _unexpected_batch_dispatch)
+    range_sensor.raycast_obstacles_batch(
+        actual,
+        scanner_positions[:1],
+        obstacles[:1],
+        obstacle_counts[:1],
+        ray_angles[:1],
+    )
+
+    assert np.array_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "error", "message"),
+    [
+        ("out_ranges", np.zeros((0, 4)), ValueError, "out_ranges"),
+        ("out_ranges", np.zeros((3, 4), dtype=np.int64), TypeError, "out_ranges"),
+        ("scanner_positions", np.zeros((2, 2)), ValueError, "scanner_positions"),
+        ("obstacles", np.zeros((3, 3, 3)), ValueError, "obstacles"),
+        ("obstacle_counts", np.zeros(3, dtype=np.float64), TypeError, "obstacle_counts"),
+        ("obstacle_counts", np.array([2, 4, 0]), ValueError, "obstacle_counts"),
+        ("obstacle_counts", np.array([2, 3, -1]), ValueError, "obstacle_counts"),
+        ("ray_angles", np.zeros((3, 3)), ValueError, "ray_angles"),
+    ],
+)
+def test_batch_contract_fails_closed_for_invalid_inputs(
+    field: str,
+    replacement: np.ndarray,
+    error: type[Exception],
+    message: str,
+) -> None:
+    """Malformed padded batches fail before entering the compiled kernel."""
+    out_ranges, scanner_positions, obstacles, obstacle_counts, ray_angles = _synthetic_batch()
+    inputs = {
+        "out_ranges": out_ranges,
+        "scanner_positions": scanner_positions,
+        "obstacles": obstacles,
+        "obstacle_counts": obstacle_counts,
+        "ray_angles": ray_angles,
+    }
+    inputs[field] = replacement
+
+    with pytest.raises(error, match=message):
+        range_sensor.raycast_obstacles_batch(**inputs)
+
+
+def test_batch_contract_rejects_read_only_output() -> None:
+    """The mutating adapter rejects an output array that cannot be updated."""
+    out_ranges, scanner_positions, obstacles, obstacle_counts, ray_angles = _synthetic_batch()
+    out_ranges.flags.writeable = False
+
+    with pytest.raises(TypeError, match="writable"):
+        range_sensor.raycast_obstacles_batch(
+            out_ranges,
+            scanner_positions,
+            obstacles,
+            obstacle_counts,
+            ray_angles,
+        )


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Added `raycast_obstacles_batch`, an opt-in Numba-backed adapter that evaluates padded static-obstacle light detection and ranging (LiDAR) inputs for multiple environments in one compiled central processing unit (CPU) dispatch. Synthetic tests compare every row bit-for-bit with independent scalar calls and prove that a one-environment request bypasses the batch kernel.
- **Why now:** PR #5017 delivered threaded Stable-Baselines3 vector-environment execution; #4981's next bounded progression step is a real cross-environment numerical-kernel contract that can be integrated without changing rollout defaults.
- **Claim boundary:** CPU implementation-integrity evidence only. This does not wire batch collection into `ThreadedVecEnv`, run a throughput campaign, or establish any speedup.
- **Required validation:** Focused LiDAR equivalence/fallback tests, vector-environment regression smoke, Ruff, and the clean-HEAD repository readiness gate.
- **Remaining blocker:** A rollout integration must collect homogeneous LiDAR inputs into this contract before a post-freeze standard-config throughput comparison can evaluate #4981's >3x acceptance target.

## Contract delta

- **New API:** `robot_sf.sensor.range_sensor.raycast_obstacles_batch(out_ranges, scanner_positions, obstacles, obstacle_counts, ray_angles)` accepts `(B, R)` ranges/angles, `(B, 2)` scanner positions, and padded `(B, M, 4)` obstacle segments with per-environment counts.
- **New fail-closed blockers:** Empty/mismatched batches, non-integer or out-of-range obstacle counts, and non-writable/non-floating output buffers are rejected before Numba dispatch.
- **Compatibility:** Fully opt-in. Existing environment, training, and scalar LiDAR entry points are unchanged. Batch size one calls `raycast_obstacles` directly and is tested for bit-identical output.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4981

Refs #4981

## Scope and acceptance

- [x] One CPU-safe cross-environment batching path exists for an existing LiDAR kernel.
- [x] Multi-environment synthetic rows are bit-identical to independent scalar kernel calls.
- [x] Single-environment execution directly retains the established scalar fallback.
- [x] The capability is opt-in and existing defaults remain unchanged.
- [ ] Integrate batch input collection into a rollout execution path.
- [ ] Run the post-freeze standard-training-config throughput comparison needed to assess the >3x parent acceptance target.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Validation / proof

- `uv run ruff check robot_sf/sensor/range_sensor.py tests/sensor/test_batched_lidar_kernel.py` — passed.
- `uv run ruff format --check robot_sf/sensor/range_sensor.py tests/sensor/test_batched_lidar_kernel.py` — passed.
- `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/sensor/test_batched_lidar_kernel.py tests/test_range_sensor.py tests/training/test_threaded_vec_env.py tests/training/test_vector_env_matrix.py -q` — 62 passed.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=/tmp/issue-4981-pr-body.md scripts/dev/pr_ready_check.sh` — passed: 2,122 passed, 1 skipped; changed-file coverage 100%; Ruff, docstring, broad-exception, and clean-HEAD freshness gates passed.

## Risks and rollout

- The adapter currently batches only static-obstacle raycasting and requires a common ray count plus padded obstacle storage.
- It uses one sequential compiled dispatch to avoid nested CPU oversubscription; no parallelism or speedup is asserted.
- Rollback is removal of the new opt-in adapter and its docs/tests; no existing caller depends on it.

<details>
<summary>Governance and reviewer appendix</summary>

### Research result guidance

- Target claim / hypothesis / blocker: NA — support capability only; it establishes an implementation contract, not a research result.
- Comparator or baseline: The existing scalar `raycast_obstacles` kernel, used only for exact compatibility proof.
- Evidence tier: NA — focused CPU implementation-integrity tests, not benchmark evidence.
- Research result fields do not apply because this is an opt-in runtime support contract.
- Decision / stop rule: Keep #4981 open until rollout integration and the post-freeze throughput acceptance run exist.
- Update surface: #4981 and the existing vectorized-rollout design/support docs.
- Analysis tool: NA — runtime support helper that does not interpret research evidence.

### Domain-aware approval

- Required for this PR: no — no evidence classification, experimental comparison, metric, benchmark interpretation, figure eligibility, or paper-facing claim changes.
- Status: not required.
- Claim boundary: CPU contract equivalence only; no fallback/degraded row or benchmark result is presented.

### Falsification / non-transfer check

NA — this support PR makes no research-result or performance claim.

### Next empirical action

- Rerun needed: yes, post-freeze only, after rollout integration.
- Extractor or analysis tool needed: no.
- Artifact missing: a standard-config throughput result does not exist and was explicitly excluded from this task.
- Decision: continue with rollout-side collection/integration, then compare worker/kernel modes under the parent issue.
- Tracking: parent issue #4981 remains open; no duplicate child issue was created.

### Docs / provenance

- Updated `docs/dev/issues/4981-vectorized-rollouts/design.md` and `docs/training/vectorized_env_support.md`.
- Preserved assumption: homogeneous ray counts and padded static-obstacle arrays are supplied explicitly by an eventual coordinator.
- Generated artifacts: none; no `output/` result is used as evidence.

### Downstream propagation

- Parent issue comment: no — issue/PR comment authorization is disabled for this task.
- Canonical state surface: this linked PR body records the delivered slice and remaining checklist; #4981 is low-churn and has no issue-state table.
- Claim map / benchmark report / leaderboard / artifact catalog / registry / context index: NA because this PR creates no research or benchmark evidence.
- Transient queue-routing state: not written to tracked files.

### Fragmentation guard and progression

Only PR #5017 merged for #4981 in the preceding 24 hours, so the two-guardrail threshold is not met. This PR is also an exempt progression slice adding the nameable capability **padded cross-environment static-obstacle LiDAR raycasting**.

### Follow-up and friction

- Parent remainder: rollout integration and post-freeze throughput evaluation remain on #4981.
- Friction found during validation: #5101 tracks a pytest-cov/Torch import failure on the fresh Python 3.13 worktree; the canonical readiness gate is used here rather than broadening this PR.

### Reviewer notes

- Verify that the batch-size-one branch continues to call the scalar dispatcher directly.
- Verify that padding is bounded exclusively by `obstacle_counts`, including zero-obstacle rows.
- Shared-helper migration: inapplicable; no existing call site was migrated and no process boundary changed.
- Forbidden actions confirmed: no compute submission, merge, release, or deletion.

</details>
