### PR TITLE
fix(coverage): lazy-load comparator dependencies (#5099)

### DIFF
--- a/robot_sf/__init__.py
+++ b/robot_sf/__init__.py
@@ -1,12 +1,13 @@
-"""Robot SF package bootstrap and telemetry exports."""
+"""Robot SF package bootstrap with lazily resolved telemetry exports."""
 
-from . import telemetry as telemetry
-from .telemetry import (
-    ManifestWriter,
-    RunRegistry,
-    RunTrackerConfig,
-    generate_run_id,
-)
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - static type information only
+    from . import telemetry
+    from .telemetry import ManifestWriter, RunRegistry, RunTrackerConfig, generate_run_id
 
 __all__ = [
     "ManifestWriter",
@@ -15,3 +16,33 @@ __all__ = [
     "generate_run_id",
     "telemetry",
 ]
+
+_TELEMETRY_EXPORTS = frozenset(__all__[:-1])
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve telemetry exports only when a caller requests them.
+
+    Keeping package import light lets standalone tools such as the coverage
+    comparator avoid importing optional visualization and TensorBoard backends.
+
+    Returns:
+        The requested telemetry module or export.
+    """
+    if name == "telemetry":
+        value = import_module(".telemetry", __name__)
+    elif name in _TELEMETRY_EXPORTS:
+        value = getattr(import_module(".telemetry", __name__), name)
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Include lazily exported telemetry names in interactive discovery.
+
+    Returns:
+        Available package attribute names.
+    """
+    return sorted(set(globals()) | set(__all__))

--- a/robot_sf/telemetry/__init__.py
+++ b/robot_sf/telemetry/__init__.py
@@ -4,34 +4,43 @@ The telemetry package centralizes the canonical data models, configuration
 objects, and persistence helpers required by `specs/001-performance-tracking`.
 It intentionally stays lightweight so both CLI tooling and training scripts can
 reuse the same utilities without reimplementing artifact or locking logic.
+
+Exports are resolved lazily so importing a narrow telemetry helper does not
+initialize optional TensorBoard or visualization dependencies.
 """
 
-from .config import RunTrackerConfig
-from .history import RunHistoryEntry, list_runs, load_run
-from .manifest_writer import ManifestWriter
-from .models import (
-    PerformanceRecommendation,
-    PerformanceTestResult,
-    PerformanceTestStatus,
-    PipelineRunRecord,
-    PipelineRunStatus,
-    RecommendationSeverity,
-    StepExecutionEntry,
-    StepStatus,
-    TelemetrySnapshot,
-)
-from .progress import PipelineStepDefinition, ProgressTracker
-from .recommendations import RecommendationEngine, RecommendationRules
-from .run_registry import RunRegistry, generate_run_id
-from .sampler import TelemetrySampler
-from .tensorboard_adapter import TensorBoardAdapter, iter_telemetry_snapshots
-from .visualization import (
-    DEFAULT_TELEMETRY_METRICS,
-    export_combined_image,
-    make_surface_from_rgba,
-    render_metric_panel,
-    save_rgba_png,
-)
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - static type information only
+    from .config import RunTrackerConfig
+    from .history import RunHistoryEntry, list_runs, load_run
+    from .manifest_writer import ManifestWriter
+    from .models import (
+        PerformanceRecommendation,
+        PerformanceTestResult,
+        PerformanceTestStatus,
+        PipelineRunRecord,
+        PipelineRunStatus,
+        RecommendationSeverity,
+        StepExecutionEntry,
+        StepStatus,
+        TelemetrySnapshot,
+    )
+    from .progress import PipelineStepDefinition, ProgressTracker
+    from .recommendations import RecommendationEngine, RecommendationRules
+    from .run_registry import RunRegistry, generate_run_id
+    from .sampler import TelemetrySampler
+    from .tensorboard_adapter import TensorBoardAdapter, iter_telemetry_snapshots
+    from .visualization import (
+        DEFAULT_TELEMETRY_METRICS,
+        export_combined_image,
+        make_surface_from_rgba,
+        render_metric_panel,
+        save_rgba_png,
+    )
 
 __all__ = [
     "DEFAULT_TELEMETRY_METRICS",
@@ -63,3 +72,76 @@ __all__ = [
     "render_metric_panel",
     "save_rgba_png",
 ]
+
+_EXPORT_MODULES = {
+    "DEFAULT_TELEMETRY_METRICS": "visualization",
+    "ManifestWriter": "manifest_writer",
+    "PerformanceRecommendation": "models",
+    "PerformanceTestResult": "models",
+    "PerformanceTestStatus": "models",
+    "PipelineRunRecord": "models",
+    "PipelineRunStatus": "models",
+    "PipelineStepDefinition": "progress",
+    "ProgressTracker": "progress",
+    "RecommendationEngine": "recommendations",
+    "RecommendationRules": "recommendations",
+    "RecommendationSeverity": "models",
+    "RunHistoryEntry": "history",
+    "RunRegistry": "run_registry",
+    "RunTrackerConfig": "config",
+    "StepExecutionEntry": "models",
+    "StepStatus": "models",
+    "TelemetrySampler": "sampler",
+    "TelemetrySnapshot": "models",
+    "TensorBoardAdapter": "tensorboard_adapter",
+    "export_combined_image": "visualization",
+    "generate_run_id": "run_registry",
+    "iter_telemetry_snapshots": "tensorboard_adapter",
+    "list_runs": "history",
+    "load_run": "history",
+    "make_surface_from_rgba": "visualization",
+    "render_metric_panel": "visualization",
+    "save_rgba_png": "visualization",
+}
+_SUBMODULES = frozenset(
+    {
+        "config",
+        "gpu",
+        "history",
+        "manifest_writer",
+        "models",
+        "pane",
+        "progress",
+        "recommendations",
+        "run_registry",
+        "sampler",
+        "tensorboard_adapter",
+        "visualization",
+    }
+)
+
+
+def __getattr__(name: str) -> Any:
+    """Load a public telemetry export or submodule only when it is requested.
+
+    Returns:
+        The requested telemetry module or export.
+    """
+    module_name = _EXPORT_MODULES.get(name)
+    if module_name is not None:
+        value = getattr(import_module(f".{module_name}", __name__), name)
+    elif name in _SUBMODULES:
+        value = import_module(f".{name}", __name__)
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Include lazily exported telemetry names in interactive discovery.
+
+    Returns:
+        Available telemetry attribute names.
+    """
+    return sorted(set(globals()) | set(__all__) | _SUBMODULES)

--- a/tests/contract/test_robot_sf_import_contract.py
+++ b/tests/contract/test_robot_sf_import_contract.py
@@ -1,0 +1,31 @@
+"""Contract coverage for lazy Robot SF package exports."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_root_package_resolves_existing_telemetry_exports_lazily() -> None:
+    """The root package retains its telemetry convenience exports on demand."""
+    import robot_sf
+
+    robot_sf.__dict__.pop("RunTrackerConfig", None)
+    robot_sf.__dict__.pop("telemetry", None)
+
+    assert robot_sf.RunTrackerConfig.__module__ == "robot_sf.telemetry.config"
+    assert robot_sf.telemetry.RunTrackerConfig is robot_sf.RunTrackerConfig
+    assert "ManifestWriter" in dir(robot_sf)
+    with pytest.raises(AttributeError, match="has no attribute 'missing_export'"):
+        _ = robot_sf.missing_export
+
+
+def test_telemetry_package_resolves_submodules_and_attribute_errors_lazily() -> None:
+    """Telemetry discovery preserves lazy submodule and error behavior."""
+    from robot_sf import telemetry
+
+    telemetry.__dict__.pop("models", None)
+
+    assert telemetry.models.__name__ == "robot_sf.telemetry.models"
+    assert "models" in dir(telemetry)
+    with pytest.raises(AttributeError, match="has no attribute 'missing_export'"):
+        _ = telemetry.missing_export

--- a/tests/coverage_tools/test_baseline_comparator.py
+++ b/tests/coverage_tools/test_baseline_comparator.py
@@ -6,6 +6,9 @@ for CI/CD coverage monitoring.
 """
 
 import json
+import subprocess
+import sys
+import time
 
 import pytest
 
@@ -17,6 +20,23 @@ from robot_sf.coverage_tools.baseline_comparator import (
     generate_warning,
     load_baseline,
 )
+
+
+def test_baseline_comparator_import_avoids_optional_startup_dependencies():
+    """The standalone comparator must not initialize TensorFlow-like backends."""
+    started = time.monotonic()
+    result = subprocess.run(
+        [sys.executable, "-c", "import robot_sf.coverage_tools.baseline_comparator"],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=5,
+    )
+    elapsed = time.monotonic() - started
+
+    assert result.returncode == 0, result.stderr
+    assert "tensorflow" not in f"{result.stdout}\n{result.stderr}".lower()
+    assert elapsed < 2.0, f"Comparator import took {elapsed:.2f}s"
 
 
 def test_coverage_snapshot_from_json(sample_coverage_data):


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** `robot_sf` and `robot_sf.telemetry` now resolve their existing telemetry exports lazily. The coverage comparator therefore imports without initializing optional TensorBoard, TensorFlow, Torch, or Matplotlib backends.

**Why now:** this removes the startup cost and unrelated backend diagnostics encountered by the standalone coverage comparator in #5099.

**Claim boundary:** this changes package-import behavior only; it does not change coverage calculation, telemetry APIs, benchmark behavior, or metrics.

**Required validation:** the final repository readiness gate and focused import/telemetry tests pass; the new subprocess contract verifies comparator startup stays below two seconds and emits no TensorFlow text.

**Remaining blocker:** none for #5099. No full benchmark campaign, Slurm/GPU submission, or paper/dissertation claim edits were performed.

Closes #5099

Issue: https://github.com/ll7/robot_sf_ll7/issues/5099

## Contract delta

- **New behavior:** public root and telemetry exports retain their names and resolve on first access; direct telemetry submodule access remains supported.
- **Fail-closed blockers:** none.
- **Compatibility impact:** existing `robot_sf` and `robot_sf.telemetry` convenience exports remain available; optional visualization and TensorBoard dependencies now initialize only when their exports are requested.

## Validation

- `uv run ruff check robot_sf/__init__.py robot_sf/telemetry/__init__.py tests/coverage_tools/test_baseline_comparator.py tests/test_robot_sf_import_smoke.py` — pass
- `uv run ruff format --check robot_sf/__init__.py robot_sf/telemetry/__init__.py tests/coverage_tools/test_baseline_comparator.py tests/test_robot_sf_import_smoke.py` — pass
- `uv run pytest tests/contract/test_robot_sf_import_contract.py tests/coverage_tools/test_baseline_comparator.py tests/test_robot_sf_import_smoke.py` — 17 passed
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — pass

<details>
<summary>Scope, propagation, and artifact appendix</summary>

### Scope

The issue's full implementation ask is complete: lazy package bootstraps plus an isolated comparator import-time smoke test. No benchmark campaign, Slurm/GPU submission, or paper/dissertation claim edits are in scope.

### Artifacts and downstream propagation

No generated artifacts were created or retained. This is a runtime-support change, not evidence-producing research work, so downstream benchmark and claim surfaces are not applicable. Issue-state propagation is not performed because this task's authorization excludes issue and PR comments; this PR is the durable delivery record.

### Friction log

No new friction issue was filed. The only encountered workflow friction was the deprecated classic-Projects field in `gh issue view`; it is already tracked by #5021 and #5092.

</details>
