### PR TITLE
fix(tools): repair manifest backfill reconstruction (#5100)

### DIFF
--- a/scripts/tools/backfill_training_run_manifest.py
+++ b/scripts/tools/backfill_training_run_manifest.py
@@ -28,6 +28,7 @@ root). Pass ``--benchmarks-dir`` to point directly at a ``benchmarks`` tree.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -47,6 +48,23 @@ from robot_sf.common import (
 
 class BackfillError(RuntimeError):
     """Raised when the retained artefacts are insufficient to rebuild a manifest."""
+
+
+def _load_eval_by_scenario(path: Path) -> list[dict[str, Any]]:
+    """Load the row-array retained by the evaluation-by-scenario writer."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BackfillError(f"Unable to read eval-by-scenario JSON at {path}") from exc
+    if not isinstance(payload, list):
+        raise BackfillError(f"Expected JSON array in {path}")
+
+    rows: list[dict[str, Any]] = []
+    for index, row in enumerate(payload):
+        if not isinstance(row, dict):
+            raise BackfillError(f"Expected JSON object at index {index} in {path}")
+        rows.append(row)
+    return rows
 
 
 def _single(paths: list[Path], label: str, *, required: bool = True) -> Path | None:
@@ -131,7 +149,7 @@ def build_artifact(
 
     perf = _load_json(perf_path)
     expert = _load_json(expert_path)
-    eval_by_scenario = _load_json(eval_scenario_path)
+    eval_by_scenario = _load_eval_by_scenario(eval_scenario_path)
 
     run_id = perf.get("run_id") or episode_path.stem
     wall_sec = perf.get("total_wall_clock_sec")

--- a/tests/test_backfill_training_run_manifest.py
+++ b/tests/test_backfill_training_run_manifest.py
@@ -99,3 +99,13 @@ def test_backfill_dry_run_writes_nothing(tmp_path: Path) -> None:
     _make_run_tree(tmp_path, run_id)
     target = backfill.backfill(run_dir=tmp_path, dry_run=True)
     assert not target.exists()
+
+
+def test_backfill_rejects_object_eval_by_scenario_artifact(tmp_path: Path) -> None:
+    """The retained evaluation artifact must preserve its row-array contract."""
+    run_id = "ppo_expert_demo_20260622T142053"
+    bench = _make_run_tree(tmp_path, run_id)
+    _write(bench / "ppo_imitation" / "eval_by_scenario" / f"{run_id}.json", {})
+
+    with pytest.raises(backfill.BackfillError, match="Expected JSON array"):
+        backfill.backfill(run_dir=tmp_path)

--- a/tests/test_backfill_training_run_manifest.py
+++ b/tests/test_backfill_training_run_manifest.py
@@ -109,3 +109,16 @@ def test_backfill_rejects_object_eval_by_scenario_artifact(tmp_path: Path) -> No
 
     with pytest.raises(backfill.BackfillError, match="Expected JSON array"):
         backfill.backfill(run_dir=tmp_path)
+
+
+def test_backfill_rejects_non_object_eval_by_scenario_row(tmp_path: Path) -> None:
+    """Every retained evaluation row must be a JSON object."""
+    run_id = "ppo_expert_demo_20260622T142053"
+    bench = _make_run_tree(tmp_path, run_id)
+    _write(
+        bench / "ppo_imitation" / "eval_by_scenario" / f"{run_id}.json",
+        [{"scenario_id": "classic_doorway_low", "eval_step": 1000000, "episodes": 7}, 3],
+    )
+
+    with pytest.raises(backfill.BackfillError, match="Expected JSON object at index 1"):
+        backfill.backfill(run_dir=tmp_path)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** the manifest-backfill tool now reads the retained
  `eval_by_scenario/<run_id>.json` artifact as its documented JSON row array,
  instead of passing it to the shared object-only loader.
- **Why now:** main fast-feedback currently fails the reconstruction test with
  `TypeError: Expected JSON object` for the normal array-shaped artifact.
- **Claim boundary:** this repairs manifest reconstruction and validates input
  shape only; it makes no benchmark, metric, model-provenance, or research claim.
- **Required validation:** focused regression tests plus the clean-HEAD
  repository readiness pipeline.
- **Remaining blocker:** none for #5100.

## Contract delta

- `eval_by_scenario` is explicitly parsed as a JSON array of JSON objects.
- Non-array payloads and non-object rows now fail closed with `BackfillError`
  and their artifact path/index; valid retained evaluation rows rebuild the
  manifest as before.
- Compatibility impact: additive validation only; no manifest schema or
  serialized output changes.

## Linked issue

- Closes #5100
- Issue: https://github.com/ll7/robot_sf_ll7/issues/5100

<details>
<summary>Scope, proof, and governance appendix</summary>

## Scope

- In scope: repair the array/object loader mismatch in
  `backfill_training_run_manifest.py` and cover both valid and invalid artifact
  shapes.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and
  no paper/dissertation claim edits.

## Why it matters

The retained evaluation artifact has always been row-oriented. Restoring that
reader contract unblocks reconstruction of a completed training-run manifest
without rerunning training or evaluation.

## Research result guidance

- Target blocker: CI-only manifest-backfill crash in #5100.
- Comparator or baseline: the existing row-array fixture from the failing test.
- Evidence tier: NA — support-tool bug fix, not research evidence.
- Result classification: NA — no benchmark or metric interpretation.
- Decision or stop rule: the focused reconstruction and full readiness gates
  must pass.
- Parent issue, claim map, registry, context note, or synthesis surface: NA.
- New analysis tool: NA — existing support helper only.

## Domain-aware approval

- Required for this PR: no — no evidence classification, experimental
  comparison, figure eligibility, benchmark interpretation, or paper-facing
  surface changes.
- Status: not required.

## Falsification / non-transfer check

NA — this change repairs JSON shape handling only.

## Next empirical action

NA — the issue is fully resolved by the code and CPU validation; no campaign
or empirical evidence is involved.

## Validation / proof

- `uv run ruff format --check scripts/tools/backfill_training_run_manifest.py tests/test_backfill_training_run_manifest.py` — passed.
- `uv run ruff check scripts/tools/backfill_training_run_manifest.py tests/test_backfill_training_run_manifest.py` — passed.
- `uv run pytest tests/test_backfill_training_run_manifest.py -q` — 4 passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed (core readiness lane).
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/issue-5100-pr-body.md scripts/dev/pr_ready_check.sh` — required clean-HEAD readiness proof.

## Risks / rollout

- Compatibility risk: low; only the input reader for a file whose expected
  shape is already an array changes.
- Failure mode: malformed evaluation artifacts now stop with an explicit
  `BackfillError` rather than a leaked object-loader `TypeError`.
- Rollback: revert this two-file change to restore prior strict behavior.

## Docs / provenance

- Updated docs: none; the supported artifact shape is already exercised by the
  existing fixture.
- Assumption: `eval_by_scenario` is a list of per-scenario evaluation rows, as
  produced by the training/evaluation flow and represented in the regression
  fixture.

## Downstream propagation

- Parent issue updated: no — commenting is outside this task's authorization.
- Claim map / benchmark report updated: NA — no research claim.
- Leaderboard / artifact catalog updated: NA — no durable artifact.
- Registry or config index updated: NA — no schema/config change.
- Context index / memory note updated: NA — no durable context change.
- Follow-up issue opened for propagation: no.
- Not applicable because: this self-contained CI repair closes #5100; separate
  issue-state propagation is unnecessary and issue/PR comments are not
  authorized for this task.

## Follow-Up Issues

- Deferred work: none
- Issues opened for follow-up: none — no follow-up is needed.

## Reviewer notes

- Verify that the successful fixture uses the exact array shape named in the CI
  failure, while the added test keeps object-shaped payloads fail-closed.
- No shared-helper migration applies.

</details>
