### PR TITLE
fix(tooling): add REST fallback for complete issue threads (#5092)

### DIFF
--- a/.agents/skills/gh-issue-autopilot/SKILL.md
+++ b/.agents/skills/gh-issue-autopilot/SKILL.md
@@ -58,10 +58,11 @@ Delegated queue-scout output is only route evidence until verified by the main a
 repository. Before using a scout recommendation to select, claim, or branch for an issue, run:
 
 ```bash
-gh issue view <number> --repo ll7/robot_sf_ll7 --json number,title,state,labels,body,comments,url
+uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7
 ```
 
-or an equivalent REST read. Confirm the URL belongs to
+This tries the concise `gh issue view --comments` path and falls back to paginated REST only for the
+known `repository.issue.projectCards` GraphQL failure. Confirm the URL belongs to
 `ll7/robot_sf_ll7`, the issue is still open, ready labels/state are current, recent comments do not
 block or supersede the work, and no linked/open PR already covers it. Treat stale state, wrong
 repo-owner URLs, omitted recent comments, and duplicate PR coverage as expected scout failure modes.
@@ -71,8 +72,9 @@ repo-owner URLs, omitted recent comments, and duplicate PR coverage as expected 
 1. Run preflight for required local tooling and the Scout publication linter:
    `uv run python scripts/dev/check_skills.py --preflight gh-issue-autopilot`.
    Then refresh credentials and branch baseline (`gh auth status`, `git fetch origin`).
-2. Resolve queue candidate and re-check issue state with local `gh issue view` or REST evidence
-   before claim or branch, especially when a delegated scout proposed the issue.
+2. Resolve the queue candidate and re-check the complete issue thread with
+   `uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7` before claim
+   or branch, especially when a delegated scout proposed the issue.
 3. Check open PRs for duplicate coverage using the linked issue, head branch/scope, and title.
    Stop or update routing when an existing PR covers the work.
 4. If issue statement is ambiguous:

--- a/docs/context/issue_713_batch_first_issue_workflow.md
+++ b/docs/context/issue_713_batch_first_issue_workflow.md
@@ -46,7 +46,8 @@ Use the cheapest source of truth for the question:
 | --- | --- | --- |
 | Working tree, branch, changed files, merge base, commits | local `git` | Do not ask GitHub for state already present locally. |
 | Interactive issue, PR, and project inspection | GitHub MCP / GitHub app tools | Prefer this for ad-hoc triage, review context, commenting, and linking when authorized. Fall back to REST, local `git`, or narrow GraphQL when MCP/app tools are unavailable or would hide a costly GraphQL path. |
-| Issue body, labels, comments, assignees, open/closed state | `scripts/dev/gh_issue_rest.py view <n> --comments`, or REST via `gh api repos/ll7/robot_sf_ll7/issues/...` directly | Avoid `gh issue view/list` for autonomous workflows: those commands request the deprecated `repository.issue.projectCards` GraphQL field and fail on some `gh` versions (issue #5021). `gh_issue_rest.py` is the shared REST-backed issue-with-comments helper that never touches that field. |
+| Complete issue thread before implementation | `scripts/dev/gh_issue_rest.py thread <n>` | Tries concise `gh issue view --comments`, then falls back to paginated REST only for the known `repository.issue.projectCards` failure (issue #5092). |
+| Structured issue fields or explicit REST reads | `scripts/dev/gh_issue_rest.py view <n> --comments`, or REST via `gh api repos/ll7/robot_sf_ll7/issues/...` directly | The `view` interface remains REST-only and normalizes fields for machine consumers (issue #5021). |
 | PR metadata, branch refs, commits, workflow runs | REST via `gh api` | Poll sparingly; use event/check URLs from known PRs when available. |
 | Project #5 item status, priority, duration, reviewed date | GraphQL / `gh project item-*` | Projects v2 is GraphQL-only; batch and cache aggressively. |
 | Review-thread resolution or nested review data | GraphQL | Keep queries narrow and use known node IDs. |
@@ -58,14 +59,13 @@ Git command can answer the same question.
 
 `gh issue view <number> --comments` fails on some GitHub CLI versions because it requests the
 deprecated classic-Projects GraphQL field `repository.issue.projectCards` (issue #5021). Autonomous
-workflows that must read an issue together with its comment thread should use the shared REST-backed
-helper instead:
+workflows that must read an issue together with its comment thread should use the shared helper:
 
 ```bash
-# human-readable thread (drop-in for `gh issue view <n> --comments`)
-uv run python scripts/dev/gh_issue_rest.py view <number> --comments --plain
+# preferred complete read: native CLI first, targeted REST fallback
+uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7
 
-# selected JSON fields, normalized to match `gh issue view --json`
+# explicit REST and normalized JSON fields for machine consumers
 uv run python scripts/dev/gh_issue_rest.py view <number> --json number title state url labels
 
 # library use for Python callers
@@ -73,9 +73,11 @@ from scripts.dev.gh_issue_rest import fetch_issue_with_comments
 payload = fetch_issue_with_comments(<number>)
 ```
 
-The helper reads through `gh api` (REST only), paginates comments, fails closed on errors or when a
-thread exceeds the page budget, and normalizes `state`/`url` to the shapes `gh issue view --json`
-consumers already expect.
+The `thread` command preserves successful native output. It falls back only when stderr names the
+known `repository.issue.projectCards` field; authentication, authorization, and other failures stay
+visible instead of being masked. The REST path preserves API comment order, paginates comments, and
+fails closed when a thread exceeds the page budget. The `view` command remains REST-only and
+normalizes `state`/`url` for `gh issue view --json` consumers.
 
 ## Project #5 Cache
 

--- a/scripts/dev/gh_issue_rest.py
+++ b/scripts/dev/gh_issue_rest.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from typing import Any
@@ -83,7 +84,18 @@ def _gh_issue_view(
     """Run the concise native complete-thread read without raising on missing ``gh``."""
     args = ["gh", "issue", "view", str(number), "--repo", repo, "--comments"]
     try:
-        return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+        # ``gh issue view`` renders nothing when stdout is not a terminal.  Force
+        # its normal human-readable output so a successful native read is never
+        # mistaken for an empty complete thread in automation.
+        env = {**os.environ, "GH_FORCE_TTY": "100%", "GH_PAGER": "cat", "NO_COLOR": "1"}
+        return subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env=env,
+        )
     except FileNotFoundError:
         return subprocess.CompletedProcess(
             args=args,

--- a/scripts/dev/gh_issue_rest.py
+++ b/scripts/dev/gh_issue_rest.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Shared REST-backed GitHub issue-with-comments helper for autonomous workflows.
+"""Shared GitHub issue-with-comments helper with a fail-closed REST fallback.
 
 Why this exists
 ---------------
@@ -10,12 +10,10 @@ versions with an error like::
     GraphQL: Projects (classic) is being deprecated ... (repository.issue.projectCards)
 
 That breaks autonomous workflows that read an issue and its comments before
-editing (see issue #5021). This module reads issues and comments through the
-REST API via ``gh api``, which never touches the deprecated classic-Projects
-GraphQL field, so callers get a deterministic issue-with-comments read
-regardless of the installed ``gh`` version. This aligns with the repository's
-batch-first GitHub workflow, which already prefers REST-backed reads for
-ordinary issue/PR objects (see ``docs/context/issue_713_batch_first_issue_workflow.md``).
+editing (see issues #5021 and #5092). The ``thread`` command first tries the
+concise GitHub CLI route and falls back to paginated REST reads only for the
+known ``repository.issue.projectCards`` failure. The existing ``view`` command
+and library functions remain explicit REST-backed interfaces.
 
 Public library API
 ------------------
@@ -23,17 +21,22 @@ Public library API
 - :func:`fetch_comments`        -- all comments via REST (paginated)
 - :func:`fetch_issue_with_comments` -- combined issue + comments payload
 - :func:`render_issue_plain`    -- gh-like human-readable thread rendering
+- :func:`read_complete_issue_thread` -- native read with targeted REST fallback
 
 CLI
 ---
 ::
 
+    python scripts/dev/gh_issue_rest.py thread <number> [--repo <owner/repo>]
+        [--max-comment-pages N]
+
     python scripts/dev/gh_issue_rest.py view <number> [--repo <owner/repo>]
         [--comments] [--json <fields>] [--plain] [--max-comment-pages N]
 
-Use this as a drop-in replacement for ``gh issue view <number> --comments`` in
-autonomous workflows. It fails closed (nonzero exit, clear stderr) when the REST
-read fails or returns malformed JSON.
+Use ``thread`` as a drop-in replacement for ``gh issue view <number> --comments``
+in autonomous workflows. It fails closed (nonzero exit, clear stderr) when a
+non-matching native error occurs or when the REST fallback cannot read the full
+thread.
 
 Field normalization
 -------------------
@@ -55,6 +58,7 @@ from typing import Any
 DEFAULT_REPO = "ll7/robot_sf_ll7"
 DEFAULT_MAX_COMMENT_PAGES = 10
 COMMENTS_PAGE_SIZE = 100
+PROJECT_CARDS_ERROR_MARKER = "repository.issue.projectCards"
 
 # Fields exposed in the normalized issue payload, in a stable order.
 ISSUE_FIELDS = (
@@ -71,6 +75,22 @@ ISSUE_FIELDS = (
     "updated_at",
 )
 COMMENT_FIELDS = ("id", "user", "author_association", "created_at", "updated_at", "url", "body")
+
+
+def _gh_issue_view(
+    number: int, *, repo: str = DEFAULT_REPO, timeout: int = 30
+) -> subprocess.CompletedProcess:
+    """Run the concise native complete-thread read without raising on missing ``gh``."""
+    args = ["gh", "issue", "view", str(number), "--repo", repo, "--comments"]
+    try:
+        return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=127,
+            stdout="",
+            stderr="gh CLI not found on PATH; install GitHub CLI (https://cli.github.com/)",
+        )
 
 
 def _gh_api(
@@ -304,6 +324,62 @@ def render_issue_plain(payload: dict[str, Any]) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+def read_complete_issue_thread(
+    number: int,
+    *,
+    repo: str = DEFAULT_REPO,
+    max_comment_pages: int = DEFAULT_MAX_COMMENT_PAGES,
+) -> dict[str, Any]:
+    """Read a complete issue thread, falling back to REST for ``projectCards`` failures.
+
+    Other native failures remain errors so authentication, authorization, and
+    connectivity problems are not masked by an unrelated fallback path.
+    """
+    native = _gh_issue_view(number, repo=repo)
+    if native.returncode == 0:
+        return {
+            "number": number,
+            "status": "ok",
+            "source": "gh_issue_view",
+            "text": native.stdout,
+        }
+
+    native_error = (
+        "\n".join(output for output in (native.stderr.strip(), native.stdout.strip()) if output)
+        or f"gh issue view exited with code {native.returncode}"
+    )
+    if PROJECT_CARDS_ERROR_MARKER not in native_error:
+        return {
+            "number": number,
+            "status": "error",
+            "source": "gh_issue_view",
+            "error": f"issue {number} thread read failed: {native_error}",
+        }
+
+    payload = fetch_issue_with_comments(
+        number,
+        repo=repo,
+        max_comment_pages=max_comment_pages,
+    )
+    if payload.get("status") != "ok":
+        fallback_error = str(payload.get("error", "unknown REST fallback error"))
+        return {
+            "number": number,
+            "status": "error",
+            "source": "rest_fallback",
+            "error": (
+                f"issue {number} native thread read hit {PROJECT_CARDS_ERROR_MARKER}; "
+                f"REST fallback failed: {fallback_error}"
+            ),
+        }
+    return {
+        "number": number,
+        "status": "ok",
+        "source": "rest_fallback",
+        "text": render_issue_plain(payload),
+    }
+
+
 def _select_fields(payload: dict[str, Any], fields: list[str]) -> dict[str, Any]:
     """Return only the requested fields from a normalized payload."""
     if not fields:
@@ -342,17 +418,48 @@ def _cmd_view(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_thread(args: argparse.Namespace) -> int:
+    """Implement the native-first complete-thread command."""
+    result = read_complete_issue_thread(
+        args.number,
+        repo=args.repo,
+        max_comment_pages=args.max_comment_pages,
+    )
+    if result.get("status") != "ok":
+        print(result.get("error", "unknown error"), file=sys.stderr)
+        return 1
+    sys.stdout.write(str(result["text"]))
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser."""
     parser = argparse.ArgumentParser(
         prog="gh_issue_rest.py",
         description=(
-            "REST-backed GitHub issue-with-comments helper. Drop-in replacement "
-            "for 'gh issue view <number> --comments' that avoids the deprecated "
-            "classic-Projects GraphQL field (issue #5021)."
+            "GitHub issue-with-comments helper with a targeted REST fallback for "
+            "the deprecated classic-Projects GraphQL field (issues #5021 and #5092)."
         ),
     )
     sub = parser.add_subparsers(dest="command", required=True)
+
+    thread = sub.add_parser(
+        "thread",
+        help="Read a complete thread via gh issue view, with targeted REST fallback.",
+    )
+    thread.add_argument("number", type=int, help="Issue number.")
+    thread.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help=f"owner/repo to read (default: {DEFAULT_REPO}).",
+    )
+    thread.add_argument(
+        "--max-comment-pages",
+        type=int,
+        default=DEFAULT_MAX_COMMENT_PAGES,
+        help=f"Maximum REST fallback pages to read (each {COMMENTS_PAGE_SIZE} comments).",
+    )
+    thread.set_defaults(func=_cmd_thread)
 
     view = sub.add_parser("view", help="Read an issue and (optionally) its comments via REST.")
     view.add_argument("number", type=int, help="Issue number.")

--- a/tests/dev/test_gh_issue_rest.py
+++ b/tests/dev/test_gh_issue_rest.py
@@ -1,4 +1,4 @@
-"""Tests for the REST-backed GitHub issue-with-comments helper (issue #5021).
+"""Tests for the GitHub issue-with-comments helper (issues #5021 and #5092).
 
 These tests mock ``gh api`` so they run offline and never hit the network. They
 cover the success path, comment pagination, field normalization (the drop-in
@@ -15,10 +15,12 @@ import pytest
 
 from scripts.dev.gh_issue_rest import (
     COMMENTS_PAGE_SIZE,
+    PROJECT_CARDS_ERROR_MARKER,
     fetch_comments,
     fetch_issue,
     fetch_issue_with_comments,
     main,
+    read_complete_issue_thread,
     render_issue_plain,
 )
 
@@ -163,6 +165,80 @@ def test_fetch_issue_with_comments_propagates_issue_error() -> None:
     assert mock_api.call_count == 1
 
 
+def test_complete_thread_uses_native_output_when_available() -> None:
+    """The concise CLI path should remain the fast path when it succeeds."""
+    with (
+        patch("scripts.dev.gh_issue_rest._gh_issue_view") as mock_view,
+        patch("scripts.dev.gh_issue_rest.fetch_issue_with_comments") as mock_rest,
+    ):
+        mock_view.return_value = _proc(stdout="native thread\n")
+        result = read_complete_issue_thread(5092)
+    assert result == {
+        "number": 5092,
+        "status": "ok",
+        "source": "gh_issue_view",
+        "text": "native thread\n",
+    }
+    mock_rest.assert_not_called()
+
+
+def test_complete_thread_falls_back_to_rest_and_preserves_comment_order() -> None:
+    """The known projectCards failure should use the complete REST thread in API order."""
+    comments = [
+        {**_raw_comment(cid=10, login="first"), "body": "first comment"},
+        {**_raw_comment(cid=20, login="second"), "body": "second comment"},
+    ]
+    with (
+        patch("scripts.dev.gh_issue_rest._gh_issue_view") as mock_view,
+        patch("scripts.dev.gh_issue_rest._gh_api") as mock_api,
+    ):
+        mock_view.return_value = _proc(
+            returncode=1,
+            stderr=f"GraphQL: Projects (classic) is deprecated ({PROJECT_CARDS_ERROR_MARKER})",
+        )
+        mock_api.side_effect = [
+            _proc(stdout=json.dumps(_raw_issue(number=5092))),
+            _proc(stdout=json.dumps(comments)),
+        ]
+        result = read_complete_issue_thread(5092, max_comment_pages=7)
+    assert result["status"] == "ok"
+    assert result["source"] == "rest_fallback"
+    assert result["text"].index("first comment") < result["text"].index("second comment")
+    assert [call.args[0] for call in mock_api.call_args_list] == [
+        "repos/ll7/robot_sf_ll7/issues/5092",
+        "repos/ll7/robot_sf_ll7/issues/5092/comments?per_page=100&page=1",
+    ]
+
+
+def test_complete_thread_does_not_mask_unrelated_native_failure() -> None:
+    """Authentication and other native errors must fail closed without REST retry."""
+    with (
+        patch("scripts.dev.gh_issue_rest._gh_issue_view") as mock_view,
+        patch("scripts.dev.gh_issue_rest.fetch_issue_with_comments") as mock_rest,
+    ):
+        mock_view.return_value = _proc(returncode=1, stderr="HTTP 401: Bad credentials")
+        result = read_complete_issue_thread(5092)
+    assert result["status"] == "error"
+    assert result["source"] == "gh_issue_view"
+    assert "Bad credentials" in result["error"]
+    mock_rest.assert_not_called()
+
+
+def test_complete_thread_reports_rest_fallback_failure() -> None:
+    """A failed fallback must report both the triggering path and REST error."""
+    with (
+        patch("scripts.dev.gh_issue_rest._gh_issue_view") as mock_view,
+        patch("scripts.dev.gh_issue_rest.fetch_issue_with_comments") as mock_rest,
+    ):
+        mock_view.return_value = _proc(returncode=1, stderr=PROJECT_CARDS_ERROR_MARKER)
+        mock_rest.return_value = {"status": "error", "error": "comments page 2 failed"}
+        result = read_complete_issue_thread(5092)
+    assert result["status"] == "error"
+    assert result["source"] == "rest_fallback"
+    assert PROJECT_CARDS_ERROR_MARKER in result["error"]
+    assert "comments page 2 failed" in result["error"]
+
+
 def test_render_issue_plain_resembles_gh_issue_view_comments() -> None:
     """Plain rendering should expose title, state, url, body, and the thread."""
     payload = {
@@ -206,6 +282,25 @@ def test_cli_view_plain_outputs_thread(capsys: pytest.CaptureFixture[str]) -> No
     assert rc == 0
     assert "friction" in captured.out
     assert "## Implementation plan" in captured.out
+
+
+def test_cli_thread_outputs_rest_fallback(capsys: pytest.CaptureFixture[str]) -> None:
+    """``thread`` should expose fallback output without adding source metadata."""
+    with patch("scripts.dev.gh_issue_rest.read_complete_issue_thread") as mock_read:
+        mock_read.return_value = {
+            "status": "ok",
+            "source": "rest_fallback",
+            "text": "complete fallback thread\n",
+        }
+        rc = main(["thread", "5092", "--repo", "ll7/robot_sf_ll7"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == "complete fallback thread\n"
+    mock_read.assert_called_once_with(
+        5092,
+        repo="ll7/robot_sf_ll7",
+        max_comment_pages=10,
+    )
 
 
 def test_cli_view_json_without_comments_omits_thread(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/dev/test_gh_issue_rest.py
+++ b/tests/dev/test_gh_issue_rest.py
@@ -182,6 +182,19 @@ def test_complete_thread_uses_native_output_when_available() -> None:
     mock_rest.assert_not_called()
 
 
+def test_native_thread_read_forces_human_output_when_stdout_is_captured() -> None:
+    """Automation must receive the native thread instead of a successful empty read."""
+    with patch("scripts.dev.gh_issue_rest.subprocess.run") as mock_run:
+        mock_run.return_value = _proc(stdout="native thread\n")
+        result = read_complete_issue_thread(5092)
+
+    assert result["status"] == "ok"
+    env = mock_run.call_args.kwargs["env"]
+    assert env["GH_FORCE_TTY"] == "100%"
+    assert env["GH_PAGER"] == "cat"
+    assert env["NO_COLOR"] == "1"
+
+
 def test_complete_thread_falls_back_to_rest_and_preserves_comment_order() -> None:
     """The known projectCards failure should use the complete REST thread in API order."""
     comments = [


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** adds a `thread` command and `read_complete_issue_thread()` API to the existing issue helper. They try `gh issue view --comments` first and fall back to the existing paginated REST issue/comment reads only when stderr or stdout names `repository.issue.projectCards`. The issue-to-PR skill and canonical GitHub workflow note now route complete pre-implementation reads through this command.
- **Why now:** merged PR #5049 supplied the explicit REST interface, but did not provide the native-first fallback or route the issue-to-PR skill through it. This PR is the additive progression slice requested by #5092; it keeps #5049's `view` command and library contracts unchanged.
- **Claim boundary:** workflow/tooling reliability only. No benchmark, metric, planner, research-result, or paper-facing semantics change.
- **Required validation:** focused fallback contracts, issue-workflow regression suites, skill/config consistency, a live #5092 fallback read, and the full CPU PR-readiness gate are green.
- **Remaining blocker:** none for the issue contract.

Issue: https://github.com/ll7/robot_sf_ll7/issues/5092

Closes #5092

## Contract delta

- **New API/CLI:** `read_complete_issue_thread(number, repo=..., max_comment_pages=...)` and `gh_issue_rest.py thread <number> --repo <owner/repo>`.
- **New fallback boundary:** only the known `repository.issue.projectCards` native failure activates REST. Authentication, authorization, connectivity, and other native errors remain visible and fail closed.
- **Complete-read behavior:** the fallback performs one issue REST read plus paginated comment reads, preserves API comment order, and retains the existing page-budget truncation guard.
- **Compatibility:** additive. Existing `fetch_issue*`, `fetch_comments`, and REST-only `view` behavior are unchanged.
- **Schema fields:** no tracked schema or configuration fields change.

## Validation / proof

- `uv run pytest tests/dev/test_gh_issue_rest.py -q` — **21 passed**.
- `uv run pytest tests/dev/test_gh_issue_rest.py tests/dev/test_check_skills.py tests/dev/test_snapshot_issue_batch.py tests/test_issue_workflow_batching.py tests/test_github_workflow_guidance.py -q` — **74 passed**.
- `uv run ruff check scripts/dev/gh_issue_rest.py tests/dev/test_gh_issue_rest.py` — passed.
- `uv run ruff format --check scripts/dev/gh_issue_rest.py tests/dev/test_gh_issue_rest.py` — passed.
- `uv run python scripts/dev/check_skills.py` — validated 54 skills, registry, generated README, and routing tests.
- `uv run python scripts/tools/sync_ai_config.py --check` — 7 links validated.
- Live acceptance probe: `read_complete_issue_thread(5092)` — `status=ok`, `source=rest_fallback`, expected issue title present.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed; **2,116 passed, 1 skipped**, Ruff and diff ratchets green.

## Explicitly out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

<details>
<summary>Governance, provenance, and reviewer notes</summary>

### Scope and closure

- Full #5092 ask delivered: native-first read, targeted REST fallback, ordered paginated comments, mocked contract coverage, and issue-to-PR guidance migration.
- Assumption: #5049 is a compatible prerequisite rather than duplicate complete coverage because it intentionally left consumer migration and native-first behavior out of scope.
- Fragmentation guard: no guardrail/checker/packet-refresh PRs for #5092 merged in the prior 24 hours. This PR adds the nameable native-first fallback capability rather than another checker.

### Artifacts and propagation

- `output/` contains only ignored local coverage output from validation (687 files, 99 MiB); it is disposable cache, not durable evidence, and is not committed.
- Parent issue comment propagation is not authorized for this run. The closing PR body is the single delivery/remaining-work surface, so no issue comment or transient host/queue state file was added.
- Claim map, benchmark report, leaderboard, artifact catalog, registry/config index, context index, and memory note: not applicable because this is a support helper with no research claim or generated evidence.

### Research Result Guidance

- Research Result Guidance: `NA` — support helper; no research evidence is interpreted.
- Falsification / Non-Transfer Check: `NA` — no research mechanism claim.
- Next Empirical Action: `NA` — issue contract is complete.

### Domain-Aware Approval

- Required for this PR: no - support helper only; no evidence-validity semantics change.
- Domains reviewed: NA.
- Status: not required.
- Approver/review source or waiver: repository support/tooling exemption.
- Validity checklist:
  - Target claim/hypothesis: NA.
  - Comparator or split/evidence validity: NA.
  - Fallback/degraded exclusions: NA; this transport fallback does not run benchmarks.
  - Claim boundary: workflow reliability only.
  - Implementation integrity vs experimental validity: ordinary code review applies; experimental validity is unaffected.

### Risks / reviewer focus

- The fallback trigger is intentionally narrow. A future GitHub CLI version that reports the same deprecated-field failure without naming `repository.issue.projectCards` will fail visibly instead of silently switching transports.
- Review the non-masking contract and the exact two-endpoint/order assertion in `tests/dev/test_gh_issue_rest.py`.
- Shared-helper migration table: inapplicable. This adds a new complete-thread command and updates its canonical workflow consumer; no existing process-boundary return schema is replaced.

### Friction log

- No new friction issue filed. The raw `gh issue view --comments` failure reproduced during this session is exactly the already-tracked #5092 contract; other work proceeded through documented repository entry points.

</details>
