### PR TITLE
fix(benchmark): fail closed on missing latency rows (#5098)

### DIFF
--- a/robot_sf/benchmark/control_action_latency_evidence.py
+++ b/robot_sf/benchmark/control_action_latency_evidence.py
@@ -596,19 +596,22 @@ def load_latency_rows(raw_rows_path: str | Path) -> list[dict[str, Any]]:
     """
     path = Path(raw_rows_path)
     rows: list[dict[str, Any]] = []
-    with path.open("r", encoding="utf-8") as handle:
-        for line_number, line in enumerate(handle, start=1):
-            stripped = line.strip()
-            if not stripped:
-                continue
-            try:
-                row = json.loads(stripped)
-            except json.JSONDecodeError as exc:
-                raise LatencyEvidenceError(
-                    f"raw rows file {path} has invalid JSON on line {line_number}: {exc}"
-                ) from exc
-            if isinstance(row, dict):
-                rows.append(row)
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    row = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    raise LatencyEvidenceError(
+                        f"raw rows file {path} has invalid JSON on line {line_number}: {exc}"
+                    ) from exc
+                if isinstance(row, dict):
+                    rows.append(row)
+    except OSError as exc:
+        raise LatencyEvidenceError(f"raw rows file {path} cannot be read: {exc}") from exc
     return rows
 
 

--- a/tests/benchmark/test_control_action_latency_evidence.py
+++ b/tests/benchmark/test_control_action_latency_evidence.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import csv
 import json
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +21,7 @@ from robot_sf.benchmark.control_action_latency_evidence import (
     build_latency_evidence,
     classify_latency_row,
     extract_latency_cells,
+    load_latency_rows,
     promote_latency_evidence,
     write_latency_evidence,
 )
@@ -26,6 +29,7 @@ from robot_sf.benchmark.control_action_latency_preflight import AXIS_KEY
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REAL_CONFIG = REPO_ROOT / "configs/research/fidelity_sensitivity_v1.yaml"
+PROMOTER = REPO_ROOT / "scripts/benchmark/promote_control_action_latency_evidence.py"
 
 
 def _latency_row(
@@ -320,6 +324,54 @@ def test_build_evidence_records_exclusions_without_promoting_them() -> None:
 
 
 # --- write_latency_evidence + promote_latency_evidence --------------------
+
+
+def test_load_rows_fails_closed_when_raw_rows_path_is_missing(tmp_path: Path) -> None:
+    """A missing raw-row file becomes a promotion error, never a filesystem traceback."""
+    missing_path = tmp_path / "missing_episode_rows.jsonl"
+    with pytest.raises(LatencyEvidenceError, match="cannot be read"):
+        load_latency_rows(missing_path)
+
+
+def test_load_rows_fails_closed_when_raw_rows_path_is_not_a_file(tmp_path: Path) -> None:
+    """An unreadable raw-row path becomes the same fail-closed promotion error."""
+    with pytest.raises(LatencyEvidenceError, match="cannot be read"):
+        load_latency_rows(tmp_path)
+
+
+def test_load_rows_fails_closed_when_raw_rows_contain_invalid_json(tmp_path: Path) -> None:
+    """Malformed JSONL reports a promotion error with its source line."""
+    raw_path = tmp_path / "malformed_episode_rows.jsonl"
+    raw_path.write_text("not-json\n", encoding="utf-8")
+
+    with pytest.raises(LatencyEvidenceError, match="invalid JSON on line 1"):
+        load_latency_rows(raw_path)
+
+
+def test_cli_missing_raw_rows_emits_blocked_json_without_traceback(tmp_path: Path) -> None:
+    """The check-only CLI reports a missing input as a compact fail-closed status."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PROMOTER),
+            "--raw-rows",
+            str(tmp_path / "missing_episode_rows.jsonl"),
+            "--check-only",
+            "--require-ready",
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stdout
+    assert "Traceback" not in result.stderr
+    status = json.loads(result.stdout)
+    assert status["schema_version"] == PROMOTION_SCHEMA_VERSION
+    assert status["status"] == "blocked"
+    assert status["issue"] == 5034
+    assert "cannot be read" in status["reason"]
 
 
 def test_write_latency_evidence_writes_bundle(tmp_path: Path) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

`load_latency_rows()` now converts missing or unreadable raw-row paths into
`LatencyEvidenceError`, so the promoter emits its established compact
`status: blocked` JSON rather than an uncaught traceback. This closes the normal
"campaign rows not yet present" path reported in #5098. The claim boundary is
CLI error handling only: this PR does not create, validate, or promote latency
benchmark evidence. Validation: focused promotion tests, Ruff, and the final
repository readiness gate. Remaining blocker: native campaign rows remain
required before any evidence can be promoted; their collection belongs to #5034,
and this command now reports their absence safely.

## Contract delta

- **Schema:** none; blocked JSON keeps the existing schema version and fields.
- **Fail-closed blocker:** any `OSError` while opening or reading raw latency
  rows is normalized to `LatencyEvidenceError`, yielding `status: blocked` and
  exit 1 under `--require-ready`.
- **Compatibility:** valid JSONL paths behave unchanged; callers that already
  handle `LatencyEvidenceError` now receive that documented error type for
  filesystem failures too.

Closes #5098

<details>
<summary>Scope, validation, and governance details</summary>

Issue: https://github.com/ll7/robot_sf_ll7/issues/5098

Scope: normalize raw-row filesystem errors at the evidence-loader boundary and
add direct plus CLI regressions for missing/non-file paths. This fully resolves
the issue's fail-closed error-handling ask.

Validation:

- `uv run pytest tests/benchmark/test_control_action_latency_evidence.py -q` — 20 passed.
- `uv run ruff check robot_sf/benchmark/control_action_latency_evidence.py tests/benchmark/test_control_action_latency_evidence.py` — passed.
- `uv run ruff format --check robot_sf/benchmark/control_action_latency_evidence.py tests/benchmark/test_control_action_latency_evidence.py` — passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue-5098-pr-body.md scripts/dev/pr_ready_check.sh` — passed: 2,111 core tests passed (1 skipped), 6,227 optional tests passed (17 skipped), and changed-line coverage was 92.9% (80% floor).

Artifact decision: no durable artifacts added; ignored coverage output from
validation is disposable local cache.

Downstream propagation: not applicable because this is a local error-handling
contract, not evidence-producing research. No issue status comment is added:
the issue closes through this PR and the task authorization excludes comments.

## Follow-Up Issues

- Deferred work: run the native control-action-latency campaign and supply its
  raw rows for promotion.
- Issues opened for follow-up: #5034 (already open; no duplicate issue created).

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no
paper/dissertation claim edits.

Friction issues: none. The only test adjustment was to tolerate unrelated
import-time logging on stderr while explicitly rejecting tracebacks; it did not
meet the threshold for a separate actionable issue.

</details>
