### PR TITLE
fix(benchmark): include metric key in count coercion warning (#5106)

### DIFF
--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -3077,7 +3077,11 @@ def post_process_metrics(
                     event="metrics_count_coercion_failed",
                     metric_key=count_key,
                     metric_value=repr(invalid_value),
-                ).warning("Dropping metric count value that could not be coerced to int.")
+                ).warning(
+                    "Dropping metric count value for key {!r}: {!r} could not be coerced to int.",
+                    count_key,
+                    invalid_value,
+                )
     for valid_key in (
         "time_to_goal_success_only_valid",
         "time_to_goal_ideal_ratio_valid",

--- a/tests/unit/benchmark/test_metrics_post_process.py
+++ b/tests/unit/benchmark/test_metrics_post_process.py
@@ -61,3 +61,10 @@ def test_post_process_metrics_logs_and_drops_invalid_count_and_flag_values():
     assert metrics["near_misses"] == 2
     logged_keys = {msg.record["extra"].get("metric_key") for msg in captured}
     assert {"collisions", "social_proxemic_available"} <= logged_keys
+    count_warning = next(
+        msg.record["message"]
+        for msg in captured
+        if msg.record["extra"].get("metric_key") == "collisions"
+    )
+    assert "collisions" in count_warning
+    assert "'not-a-count'" in count_warning


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Count-coercion warnings now name the rejected metric key and value; a focused test locks that console-visible diagnostic down.

**Why now:** The standard console formatter does not render the existing structured `metric_key` binding, making malformed count input impossible to identify from ordinary benchmark logs.

**Claim boundary:** Observability-only change. Count coercion, drop behavior, structured fields, metric schema, and benchmark semantics are unchanged.

**Required validation:** `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` with this body; targeted metric post-processing test passes.

**Remaining blocker:** None. No full benchmark campaign is needed for a warning-message-only fix.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: warnings for rejected count values now include the key and `repr()` of the value; all coercion and output behavior is unchanged.

## Summary

Make count-coercion warnings actionable in ordinary console logs without altering benchmark metric behavior.

## Linked Issues

- Closes #5106
- Issue: https://github.com/ll7/robot_sf_ll7/issues/5106

## What Changed

- Include `count_key` and the rejected value directly in count-coercion warning text while retaining the existing structured Loguru bindings.
- Assert the warning message contains both for an invalid `collisions` payload.

## Why It Matters

- Added value: an operator can identify the malformed metric directly from the emitted console warning.
- Expected impact: faster diagnosis of invalid metric payloads.
- Why this is worth merging now: it completes the scoped friction fix with no semantic or schema change.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - support observability only; no research or benchmark claim.
- Comparator or baseline, if applicable: NA.
- Evidence tier: NA - targeted runtime diagnostic test only.
- Result classification: NA - no research result.
- Decision or stop rule, if applicable: the focused assertion must prove the key and rejected value are console-visible.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #5106 only.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper behavior only.

## Domain-Aware Approval

- Required for this PR: no - does not change metric semantics, evidence classification, comparisons, or claims.
- Domains reviewed: NA.
- Status: not required.
- Approver/review source or waiver: observability-only scope verified against #5106.
- Validity checklist:
  - Target claim/hypothesis: NA.
  - Comparator or split/evidence validity: NA.
  - Fallback/degraded exclusions: NA.
  - Claim boundary: warning text only.
  - Implementation integrity vs experimental validity: targeted warning assertion proves implementation; experimental validity is unaffected.

## Falsification / Non-Transfer Check

NA - no research result or mechanism claim.

## Next Empirical Action

NA - no empirical evidence is claimed or required.

## Validation / Proof

- Commands run:
  - `uv run pytest tests/unit/benchmark/test_metrics_post_process.py -q` — 3 passed.
  - `uv run ruff check robot_sf/benchmark/metrics.py tests/unit/benchmark/test_metrics_post_process.py` — passed.
  - `uv run ruff format --check robot_sf/benchmark/metrics.py tests/unit/benchmark/test_metrics_post_process.py` — passed.
  - `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue-5106-pr-body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed: 2,111 passed, 1 skipped.
- Evidence that the change works here: the focused test captures the count warning and asserts it includes `collisions` and `'not-a-count'`.
- Benchmarks or smoke tests, if applicable: no full benchmark campaign run; not needed because the coercion and output contract are unchanged.

## Risks / Rollout

- Compatibility risks: log parsers that expect the old free-text warning may need to tolerate its added context; structured event fields remain unchanged.
- Failure modes: none beyond the prior warning path.
- Rollback or fallback plan: revert the warning-text change; metric behavior is independent of it.

## Docs / Provenance

- Updated docs: none; the issue and focused test describe the diagnostic contract.
- Relevant design or provenance notes: #5106.
- Any assumptions that need to be preserved: the standard console formatter omits Loguru structured bindings, so critical identifiers must appear in warning text.

## Downstream Propagation

- Parent issue updated: no - `Closes #5106` supplies the durable closure linkage once merged.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: no.
- Not applicable because: this is a complete observability fix with no remaining research, benchmark, schema, or provenance state to propagate; a separate issue comment would only duplicate the closure PR.

## Follow-Up Issues

- Deferred work: none.
- Issues opened for follow-up: none; the known `gh issue view --comments` classic-project limitation is unrelated to this change.

## Reviewer Notes

- Verify the count warning still preserves `event`, `metric_key`, and `metric_value` structured bindings while exposing the key and value in its text.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits; all are intentionally out of scope.

<details>
<summary>Process appendix</summary>

- Live issue state was reviewed via GitHub REST after the required `gh issue view --comments` command hit the known classic-project GraphQL limitation. The issue had no comments as of 2026-07-10T16:05:01Z.
- No open PR covers #5106 or this exact scope. No guardrail/checker/packet-refresh PRs for #5106 were merged in the preceding 24 hours, so the fragmentation guard does not apply.
- State propagation is intentionally satisfied by the complete closure PR, rather than a redundant issue comment; the issue is low-churn and has no remaining work.
- Artifact classification: no generated artifacts are part of this PR; local `output/` remains ignored cache only.

</details>
