### PR TITLE
fix(dev): let lightweight docs checks use stale shared env (#5095)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -184,12 +184,22 @@ pinning imports to the current worktree:
 ```bash
 scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -q
 scripts/dev/run_worktree_shared_venv.sh --venv ../robot_sf_ll7/.venv -- ruff check scripts/dev
+scripts/dev/run_worktree_shared_venv.sh --standalone -- \
+  python scripts/dev/check_docs_evidence_integrity.py --files docs/dev_guide.md
 ```
 
-The helper runs from `git rev-parse --show-toplevel`, prepends that root to `PYTHONPATH`, sets
-`UV_PROJECT_ENVIRONMENT` to the shared `.venv`, and sets `UV_NO_SYNC=1`. This is intended for fast
-local feedback when dependencies are already current. It should fail if the shared virtualenv is
-missing instead of silently installing into the wrong checkout.
+The helper runs from `git rev-parse --show-toplevel`, sets `UV_PROJECT_ENVIRONMENT` to the shared
+`.venv`, and sets `UV_NO_SYNC=1`. By default it also prepends the worktree root to `PYTHONPATH`.
+This is intended for fast local feedback when dependencies are already current. It should fail if
+the shared virtualenv is missing instead of silently installing into the wrong checkout.
+
+Use `--standalone` for a dependency-light command whose tests verify that it does not import
+`robot_sf` or other project packages. This mode still reuses third-party dependencies from the
+shared environment, but it skips the project-source freshness check and does not add the worktree
+root to `PYTHONPATH`. For example, `check_docs_evidence_integrity.py` has a minimal-environment
+import guard in `tests/tooling/test_docs_evidence_import_boundary.py`, so it remains safe to run when
+an unrelated installed `pysocialforce` copy is stale. Do not use this mode for tests or commands
+that import project code; refresh the owning checkout environment for those commands instead.
 
 If a fresh linked worktree fails to collect a focused test because an optional dependency such as
 `torch` is not installed in that worktree, rerun the same focused command through

--- a/scripts/dev/run_worktree_shared_venv.sh
+++ b/scripts/dev/run_worktree_shared_venv.sh
@@ -19,9 +19,16 @@ therefore runs a cheap freshness check comparing the installed `pysocialforce` p
 checkout's fast-pysf/pysocialforce source and fails early with an actionable message when they
 diverge. Refresh the owning checkout with `uv sync --all-extras` to clear the divergence.
 
+Standalone commands with a verified boundary that does not import project packages can use
+--standalone. That mode skips the project-source freshness check and does not add the worktree root
+to PYTHONPATH, while still reusing the shared environment for third-party dependencies.
+
 Options:
   --venv PATH            Shared virtualenv path exported as UV_PROJECT_ENVIRONMENT. Defaults to the
                          main checkout .venv for linked worktrees.
+  --standalone           Run a command that is verified not to import project packages. This skips
+                         the project-source freshness check and does not prepend the worktree root
+                         to PYTHONPATH.
   --no-freshness-check   Skip the shared-venv freshness check. Use only when you have confirmed the
                          reused env matches this checkout (e.g. an editable install that already
                          points at this source). Also skippable via
@@ -31,6 +38,8 @@ Options:
 Examples:
   scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -q
   scripts/dev/run_worktree_shared_venv.sh --venv ../robot_sf_ll7/.venv -- ruff check scripts/dev
+  scripts/dev/run_worktree_shared_venv.sh --standalone -- \
+    python scripts/dev/check_docs_evidence_integrity.py --files docs/dev_guide.md
 
 Use a full local .venv plus PR_READY_MODE=final for final PR proof; this helper is for quick,
 targeted validation in sibling worktrees.
@@ -39,6 +48,7 @@ EOF
 
 venv_override=""
 skip_freshness=""
+standalone=""
 cmd=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -49,6 +59,10 @@ while [[ $# -gt 0 ]]; do
       fi
       venv_override="$2"
       shift 2
+      ;;
+    --standalone)
+      standalone=1
+      shift
       ;;
     --no-freshness-check)
       skip_freshness=1
@@ -133,15 +147,16 @@ Shared virtualenv is stale relative to this checkout: $venv
   diverging module: pysocialforce/$rel_path
 The reused env (UV_NO_SYNC=1) lacks source present in fast-pysf/pysocialforce, so imports can
 fail mid-run with a confusing ImportError. Refresh the owning checkout with 'uv sync --all-extras',
-or rerun with --no-freshness-check (or ROBOT_SF_VENV_FRESHNESS_CHECK=skip) once you have confirmed
-the env matches this checkout.
+use --standalone for a command verified not to import project packages, or rerun with
+--no-freshness-check (or ROBOT_SF_VENV_FRESHNESS_CHECK=skip) once you have confirmed the env matches
+this checkout.
 EOF
       return 1
     fi
   done < <(find "$src_pkg" -type f -name '*.py' -print0)
 }
 
-if [[ -z "$skip_freshness" && "${ROBOT_SF_VENV_FRESHNESS_CHECK:-}" != "skip" ]]; then
+if [[ -z "$standalone" && -z "$skip_freshness" && "${ROBOT_SF_VENV_FRESHNESS_CHECK:-}" != "skip" ]]; then
   if ! check_shared_venv_freshness "$venv_path"; then
     exit 2
   fi
@@ -149,7 +164,9 @@ fi
 
 export UV_PROJECT_ENVIRONMENT="$venv_path"
 export UV_NO_SYNC=1
-export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
+if [[ -z "$standalone" ]]; then
+  export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
+fi
 
 if [[ -z "${COVERAGE_FILE:-}" && "$git_common_dir" != "$repo_root/.git" ]]; then
   worktree_id="$(printf '%s' "$repo_root" | git hash-object --stdin | cut -c1-12)"

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -629,6 +629,10 @@ def test_worktree_shared_venv_helper_has_freshness_check_wiring() -> None:
     assert 'cmp -s "$src_file" "$installed_file"' in script_text
     assert "Shared virtualenv is stale relative to this checkout" in script_text
     assert "diverging module: pysocialforce/" in script_text
+    # Standalone commands with a verified no-project-import boundary can skip project drift safely.
+    assert "--standalone" in script_text
+    assert "use --standalone for a command verified not to import project packages" in script_text
+    assert 'if [[ -z "$standalone" ]]; then' in script_text
     # The gate is skippable for advanced users with a confirmed-matching env.
     assert "--no-freshness-check" in script_text
     assert "ROBOT_SF_VENV_FRESHNESS_CHECK:-" in script_text
@@ -672,7 +676,8 @@ def _make_freshness_fixture_repo(
 
     fake_uv = fake_bin / "uv"
     fake_uv.write_text(
-        '#!/usr/bin/env bash\nprintf "uv-reached %s\\n" "$*" >&2\nexit 7\n',
+        '#!/usr/bin/env bash\nprintf "uv-reached %s\\n" "$*" >&2\n'
+        'printf "pythonpath=%s\\n" "${PYTHONPATH-}" >&2\nexit 7\n',
         encoding="utf-8",
     )
     fake_uv.chmod(0o755)
@@ -705,6 +710,7 @@ def _make_freshness_fixture_repo(
         **os.environ,
         "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
     }
+    env.pop("PYTHONPATH", None)
     return repo, venv, env
 
 
@@ -803,6 +809,40 @@ def test_worktree_shared_venv_freshness_check_flag_bypasses_stale_env(
     assert result.returncode == 7
     assert "uv-reached" in result.stderr
     assert "Shared virtualenv is stale" not in result.stderr
+
+
+def test_worktree_shared_venv_standalone_mode_bypasses_stale_project_env(
+    tmp_path: Path,
+) -> None:
+    """--standalone reaches dependency-light tools without exposing project source."""
+    repo, venv, env = _make_freshness_fixture_repo(
+        tmp_path,
+        installed_scene="# stale install without normalize_integration_scheme\n",
+    )
+
+    result = subprocess.run(
+        [
+            str(RUN_WORKTREE_SHARED_VENV),
+            "--venv",
+            str(venv),
+            "--standalone",
+            "--",
+            "python",
+            "scripts/dev/check_docs_evidence_integrity.py",
+            "--help",
+        ],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 7
+    assert "uv-reached" in result.stderr
+    assert "Shared virtualenv is stale" not in result.stderr
+    assert "pythonpath=\n" in result.stderr
 
 
 def test_worktree_shared_venv_freshness_check_env_var_bypasses_stale_env(


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Adds an explicit `--standalone` mode to the shared-worktree virtual-environment
wrapper. The mode skips project-source freshness checks and does not inject the worktree root into
`PYTHONPATH`, allowing verified dependency-light tools such as the docs/evidence integrity checker
to reuse third-party packages from a stale shared environment.

**Why now:** Issue #5095 reproduced a lightweight docs check being prevented by unrelated
`pysocialforce` source drift in the shared environment.

**Claim boundary:** Support-tooling behavior only. The mode is safe only for commands with a tested
no-project-import boundary; it does not make stale project packages safe to import.

**Required validation:** The stale-environment acceptance reproduction, the checker import-boundary
test, focused wrapper tests, and the committed-head PR readiness gate.

**Remaining blocker:** None.

## Contract delta

- New CLI flag: `run_worktree_shared_venv.sh --standalone -- <command>`.
- Default behavior remains fail-closed when installed `pysocialforce` differs from the worktree.
- Standalone mode continues to require a valid shared virtual environment and uses `UV_NO_SYNC=1`.
- Compatibility impact: additive; existing commands and escape hatches are unchanged.

Closes #5095

<details>
<summary>Implementation, validation, and governance appendix</summary>

## Linked issue and scope

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5095
- Scope: wrapper behavior, focused regression coverage, and developer guidance.
- Assumption: an explicit standalone mode is the smallest complete implementation because the
  checker already has an executable minimal-environment import guard.
- Safe to review independently: yes; no stacked dependency.

## What changed

- Added `--standalone` parsing, help text, and an actionable stale-environment hint.
- Kept the shared-environment existence check while bypassing only project-source freshness.
- Avoided adding the checkout root to `PYTHONPATH` in standalone mode.
- Added a stale-environment regression proving the wrapper reaches the command without exposing the
  checkout root, while retaining the existing default fail-closed test.
- Documented the exact docs-checker command and its tested import boundary.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/dev/check_docs_evidence_integrity.py --help`
  — expected exit 2 against the stale shared environment; default fail-closed behavior retained.
- `scripts/dev/run_worktree_shared_venv.sh --standalone -- python scripts/dev/check_docs_evidence_integrity.py --files docs/dev_guide.md`
  — passed against the same stale shared environment: `1 changed file(s) passed`.
- `uv run pytest -q tests/test_ci_script_contract.py tests/tooling/test_docs_evidence_import_boundary.py`
  — 64 passed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed after merging the
  latest `origin/main`: 2,112 passed, 1 skipped; clean head `b12ff5b3979f176006cf3a7ee9756b21c9db3ebc`.
- `git diff --check` and `bash -n scripts/dev/run_worktree_shared_venv.sh` — passed.

## Research and domain guidance

- Target claim / hypothesis / blocker: NA — support tooling only.
- Evidence tier / result classification: NA — no research or benchmark claim.
- Domain-aware approval: not required; no evidence classification, experimental comparison,
  benchmark interpretation, metric, or paper-facing surface changes.
- Falsification / non-transfer check: NA — no research mechanism is claimed.
- Next empirical action: NA — the local stale-environment reproduction directly exercises the
  support-tool contract.

## Domain-Aware Approval

- Required for this PR: no - support tooling does not alter evidence validity.
- Domains reviewed: NA - support tooling only.
- Status: not required.
- Approver/review source or waiver: repository template opt-out for support-only changes.

## Risks / Rollout

- Compatibility risk: callers could misuse `--standalone` for project-importing commands. The help,
  failure message, docs, and test contract restrict the mode to tools with verified import boundaries.
- Rollback: revert this commit; existing default behavior is otherwise unchanged.
- Generated artifacts: local `output/` test and coverage files are ignored cache, not durable evidence.

## Downstream propagation

- Parent issue / claim map / benchmark report / leaderboard / artifact catalog / registry / context
  index: NA — this PR creates no research evidence or tracked operational state.
- State propagation: no separate issue comment is needed; `Closes #5095` is the canonical status
  linkage, and issue/PR comments were not authorized for this task.

## Follow-Up Issues

- Deferred work: none
- Issues opened for follow-up: none

## Friction log

- No friction issue filed. The encountered `gh issue view --comments` classic-project GraphQL failure
  is already tracked by #5092 (and historical #5021), so filing another would be a duplicate.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Reviewer notes

- Verify that default stale-package calls remain rejected and only `--standalone` omits the freshness
  gate and worktree `PYTHONPATH` injection.
- Shared-helper migration call-site table: inapplicable. This adds an opt-in execution mode and does
  not migrate or consolidate call sites, return schemas, file readers, or process outputs.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone mode for shared virtual-environment commands that reuse dependencies without exposing project source files.
  * Added guidance and clearer help text describing when standalone mode is appropriate.

* **Documentation**
  * Updated developer guidance with standalone-mode behavior, setup details, and usage examples.

* **Tests**
  * Added coverage verifying standalone mode bypasses stale project-environment checks and runs dependency-only commands correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->