### PR TITLE
fix(benchmark): handle aggregate metadata errors (#5103)

### DIFF
--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -57,7 +57,7 @@ from robot_sf.benchmark.collision_scenario_similarity import (
 from robot_sf.benchmark.distributions import collect_grouped_values as _dist_collect
 from robot_sf.benchmark.distributions import save_distributions as _dist_save
 from robot_sf.benchmark.doctor import collect_doctor_report, doctor_exit_code
-from robot_sf.benchmark.errors import EpisodeRecordInputError
+from robot_sf.benchmark.errors import AggregationMetadataError, EpisodeRecordInputError
 from robot_sf.benchmark.failure_extractor import extract_failures as _extract_failures
 from robot_sf.benchmark.failure_mechanism_classifier import (
     classify_failure_mechanisms_from_jsonl,
@@ -128,6 +128,7 @@ _CLI_INPUT_ERRORS = (
     OSError,
     json.JSONDecodeError,
     yaml.YAMLError,
+    AggregationMetadataError,
     EpisodeRecordInputError,
 )
 # AttributeError is limited to the optional tqdm API probe below; ordinary CLI


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** The `aggregate` CLI now treats `AggregationMetadataError` as a typed input error and returns exit code 2 instead of leaking the exception.

**Why now:** Mixed `benchmark_track` inputs correctly fail closed in aggregation, but their expected CLI boundary was missing.

**Claim boundary:** This changes only CLI error translation. It does not permit cross-track pooling, change aggregation metadata semantics, or constitute benchmark evidence.

**Required validation:** The existing mixed-track CLI regression test proves exit code 2 and no output; the final repository readiness gate is run on this committed head.

**Remaining blocker:** None for #5103.

## Contract delta

- New fail-closed CLI boundary: `AggregationMetadataError` is classified with malformed aggregate input and returns exit code 2.
- Schema fields: none.
- Compatibility impact: valid aggregation behavior and diagnostic cross-track mode are unchanged; invalid mixed-track strict-mode input no longer escapes as a Python exception.

## Linked issue

Closes #5103.

Issue: https://github.com/ll7/robot_sf_ll7/issues/5103

## Scope

- Add the existing aggregate metadata validation error to the aggregate CLI's narrow typed-input boundary.
- Preserve visible programmer errors; no broad exception catch is added.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## Validation

- `uv run pytest tests/test_cli_aggregate.py -q` — 4 passed.
- `uv run ruff check robot_sf/benchmark/cli.py tests/test_cli_aggregate.py` — passed.
- `uv run ruff format --check robot_sf/benchmark/cli.py tests/test_cli_aggregate.py` — passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed (core lane, 2,112 tests collected; 1 skipped).
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on the latest rebased committed head: core 2,124 passed / 1 skipped; optional 6,223 passed / 17 skipped; changed-line coverage 100%.

## Risks / rollout

- Risk: `AggregationMetadataError` is shared by aggregation code paths, so this changes matching CLI handlers from traceback behavior to exit code 2.
- Mitigation: the exception remains a narrow, explicit value-error subtype and the existing mixed-track strict-mode test exercises the intended boundary.
- Rollback: remove this one error type from `_CLI_INPUT_ERRORS`.

## Downstream propagation

Not applicable: this is a CLI boundary fix with no benchmark, registry, claim-map, artifact, or context-schema change. No issue comment was posted because the task authorization explicitly prohibits issue/PR comments; the linked closing PR is the canonical delivery status.

## Friction log

No new friction issue filed. The shared-worktree virtual-environment freshness guard was encountered, but the same concrete failure is already tracked in #5095.

<details>
<summary>Governance appendix</summary>

### Research result guidance

- Target blocker: aggregate CLI leaked a known typed aggregate metadata error.
- Comparator/baseline: pre-fix strict mixed-track aggregate behavior.
- Evidence tier: NA - support CLI error translation only.
- Result classification: NA - no research result is asserted.
- Decision/stop rule: complete when the existing test returns 2 without writing strict-mode output.
- Research analysis tool: NA — support CLI error translation only.

### Domain-aware approval

- Required for this PR: no — no evidence classification, experimental comparison, figure eligibility, benchmark interpretation, or paper-facing claim changes.
- Status: not required.

### Falsification / non-transfer

NA — no research-result mechanism is claimed.

### Next empirical action

NA — the issue is fully resolved by deterministic CLI behavior; no campaign is required.

### Artifacts

`output/coverage/` (91 MB) was generated by readiness checks and remains ignored, disposable local coverage output. `output/repos/` is ignored local cache. Neither is committed or relied upon as durable evidence.

### Follow-up issues

- Deferred work: NA.
- Issues opened for follow-up: none - the fully resolved issue has no deferred work.

### Reviewer notes

- Verify the boundary remains narrow: only `AggregationMetadataError` was added, not a catch-all exception.

</details>
