### PR TITLE
fix(ci): prevent oversized uv cache restore (#5087)

### DIFF
--- a/.github/actions/setup-ci-python/action.yml
+++ b/.github/actions/setup-ci-python/action.yml
@@ -19,24 +19,17 @@ runs:
   using: composite
   steps:
     - name: Install uv
+      id: setup-uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         version: ${{ inputs.uv-version }}
-
-    - name: Cache uv sync package payloads
-      id: cache-uv
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: |
-          ${{ runner.temp }}/setup-uv-cache/archive-v0
-          ${{ runner.temp }}/setup-uv-cache/wheels-v6
-        key: uv-sync-payloads-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+        enable-cache: "true"
+        prune-cache: "true"
 
     - name: Report uv cache state before sync
       shell: bash
       run: |
-        echo "cache-hit=${{ steps.cache-uv.outputs.cache-hit }}"
-        echo "cache-matched-key=${{ steps.cache-uv.outputs.cache-matched-key }}"
+        echo "cache-hit=${{ steps.setup-uv.outputs.cache-hit }}"
         bash scripts/dev/ci_uv_sync_diag.sh "uv-cache-pre-sync"
 
     - name: Set up Python

--- a/scripts/dev/ci_uv_sync_diag.sh
+++ b/scripts/dev/ci_uv_sync_diag.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Diagnostic probe for uv sync steps in CI.
 #
-# Prints runner, uv cache, and virtual-environment state in a compact,
+# Prints runner, disk, uv cache, and virtual-environment state in a compact,
 # GitHub-Actions-friendly grouped log. Safe to run before and after sync.
 # All errors are advisory: the script exits 0 so a diagnostic step never
 # masks a real CI failure.
@@ -35,7 +35,6 @@ else
     echo "  uv_version=not_installed"
 fi
 
-echo "uv_sync_diag cache_size"
 # Respect UV_CACHE_DIR if set; otherwise fall back to what uv reports, then ~/.cache/uv.
 cache_dir=""
 if [[ -n "${UV_CACHE_DIR:-}" ]]; then
@@ -47,6 +46,26 @@ if [[ -z "${cache_dir:-}" ]]; then
     cache_dir="${HOME:-}/.cache/uv"
 fi
 
+echo "uv_sync_diag disk_info"
+disk_target="."
+if [[ -e "$cache_dir" ]]; then
+    disk_target="$cache_dir"
+fi
+disk_info="$(df -Pk "$disk_target" 2>/dev/null | awk '
+    NR == 2 {
+        print "  filesystem_size_kb=" $2
+        print "  filesystem_used_kb=" $3
+        print "  filesystem_available_kb=" $4
+        print "  filesystem_used_percent=" $5
+    }
+' || true)"
+if [[ -n "$disk_info" ]]; then
+    printf '%s\n' "$disk_info"
+else
+    echo "  filesystem_probe=unavailable"
+fi
+
+echo "uv_sync_diag cache_size"
 if [[ -d "$cache_dir" ]]; then
     echo "  cache_dir=${cache_dir}"
     # Single-pass cache sizing (issue #3703): `du -h -d 1` walks the cache tree

--- a/tests/dev/test_ci_uv_sync_diag.py
+++ b/tests/dev/test_ci_uv_sync_diag.py
@@ -112,6 +112,8 @@ def test_ci_uv_sync_diag_reports_runner_and_uv_state() -> None:
     assert "::group::uv-available-test" in output
     assert "uv_sync_diag runner_info" in output
     assert "uv_sync_diag uv_info" in output
+    assert "uv_sync_diag disk_info" in output
+    assert "filesystem_available_kb=" in output
     assert "uv_sync_diag cache_size" in output
     assert "uv_sync_diag venv_info" in output
     assert "::endgroup::" in output
@@ -182,34 +184,28 @@ def test_ci_uv_sync_diag_cache_sizing_is_single_pass(tmp_path: Path) -> None:
     assert "cache_git-v0_size=1.0K" in output
 
 
-def test_workflow_uv_cache_paths_match_setup_uv_cache_dir() -> None:
-    """uv payload caching must live at the setup-uv cache dir, centralized in setup-ci-python.
+def test_workflow_uv_cache_is_pruned_by_setup_uv() -> None:
+    """CI must use setup-uv's pruned cache without a second unbounded payload cache.
 
     perf-nightly and pr-promoted-planner-smoke delegate to the shared
-    ``setup-ci-python`` composite action, which owns the uv payload cache. The
-    cache paths must match the UV_CACHE_DIR configured by setup-uv (never the
-    user-local ``~/.cache/uv`` default) so a restored cache is actually reused
-    by the subsequent ``uv sync``.
+    ``setup-ci-python`` composite action, which owns the uv cache contract.
+    A second actions/cache layer previously saved setup-uv's unpruned
+    ``archive-v0`` tree and restored 11 GB into hosted runners (issue #5087).
     """
     delegated_workflows = [
         ".github/workflows/ci.yml",
         ".github/workflows/perf-nightly.yml",
         ".github/workflows/pr-promoted-planner-smoke.yml",
     ]
-    expected_archive = "${{ runner.temp }}/setup-uv-cache/archive-v0"
-    expected_wheels = "${{ runner.temp }}/setup-uv-cache/wheels-v6"
-
     action_text = (_repo_root() / ".github/actions/setup-ci-python/action.yml").read_text(
         encoding="utf-8"
     )
-    # The shared action owns the cache and must pin it to setup-uv's location.
     assert "astral-sh/setup-uv@" in action_text
-    assert expected_archive in action_text
-    assert expected_wheels in action_text
-    assert (
-        "uv-sync-payloads-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}"
-        in action_text
-    )
+    assert 'enable-cache: "true"' in action_text
+    assert 'prune-cache: "true"' in action_text
+    assert "actions/cache@" not in action_text
+    assert "archive-v0" not in action_text
+    assert "uv-sync-payloads-" not in action_text
     assert "~/.cache/uv" not in action_text
 
     # Every consumer delegates to the shared action and must not re-declare a

--- a/tests/dev/test_ci_uv_sync_retry.py
+++ b/tests/dev/test_ci_uv_sync_retry.py
@@ -324,22 +324,21 @@ def test_setup_ci_python_uses_uv_sync_retry_wrapper() -> None:
     assert "uv sync --all-extras --frozen\n" not in action_text
 
 
-def test_setup_ci_python_caches_setup_uv_payloads() -> None:
-    """The setup action must cache uv payloads at the setup-uv cache location."""
+def test_setup_ci_python_uses_pruned_setup_uv_cache() -> None:
+    """Use setup-uv's pruned cache, never the unbounded duplicate payload cache."""
     action_text = _action_path().read_text(encoding="utf-8")
-    assert "${{ runner.temp }}/setup-uv-cache/archive-v0" in action_text
-    assert "${{ runner.temp }}/setup-uv-cache/wheels-v6" in action_text
-    assert (
-        "uv-sync-payloads-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}"
-        in action_text
-    )
+    assert 'enable-cache: "true"' in action_text
+    assert 'prune-cache: "true"' in action_text
+    assert "actions/cache@" not in action_text
+    assert "archive-v0" not in action_text
+    assert "uv-sync-payloads-" not in action_text
 
 
 def test_setup_ci_python_reports_cache_restore_outputs() -> None:
-    """The pre-sync diagnostic must surface the actions/cache restore outputs."""
+    """The pre-sync diagnostic must surface setup-uv's cache-hit output."""
     action_text = _action_path().read_text(encoding="utf-8")
-    assert "steps.cache-uv.outputs.cache-hit" in action_text
-    assert "steps.cache-uv.outputs.cache-matched-key" in action_text
+    assert "id: setup-uv" in action_text
+    assert "steps.setup-uv.outputs.cache-hit" in action_text
 
 
 def test_setup_ci_python_has_no_local_uv_cache_path() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** removed the redundant `actions/cache` layer that saved and restored uv's
  unpruned `archive-v0` payloads, made the pinned `setup-uv` action's pruned cache explicit, and
  added available-disk fields to the existing uv sync diagnostic.
- **Why now:** the affected job restored a 4.468 GB archive that expanded `archive-v0` to 11 GB and
  exhausted the hosted runner before pytest started; `setup-uv`'s own pruned restore was ~2 MB.
- **Claim boundary:** CI dependency-cache and diagnostics only. Dependency selection, retry behavior,
  test selection, xdist behavior, and research/benchmark semantics are unchanged.
- **Required validation:** focused cache contracts, the exact eight-test xdist scratch lane, clean
  committed-HEAD PR readiness, and the hosted `xdist-scratch-isolation` job on this PR.
- **Remaining blocker:** no implementation blocker; hosted CI must confirm the affected job no
  longer restores the removed oversized cache key.

## Contract delta

- **Schema fields:** the advisory diagnostic now emits `filesystem_size_kb`,
  `filesystem_used_kb`, `filesystem_available_kb`, and `filesystem_used_percent` (or
  `filesystem_probe=unavailable`).
- **New fail-closed blockers:** none. The diagnostic remains advisory and exits zero.
- **Compatibility impact:** the shared action keeps cache reuse through `setup-uv`, explicitly with
  pruning enabled. Its pre-sync log retains `cache-hit`; the duplicate cache's
  `cache-matched-key` line and `uv-sync-payloads-*` cache key are intentionally removed. The
  locked all-extras sync and bounded retry are unchanged.

Closes #5087

Issue: https://github.com/ll7/robot_sf_ll7/issues/5087

<details>
<summary>Implementation, validation, and governance appendix</summary>

## Scope

- Removed the second cache action from `.github/actions/setup-ci-python/action.yml`.
- Explicitly enabled `setup-uv` caching and its pre-save pruning, and routed cache-hit diagnostics
  through that action's output.
- Added filesystem-capacity diagnostics and regression coverage preventing an unpruned
  `archive-v0` cache from returning.
- Reversible assumption: the pinned `setup-uv` v8.1.0 cache is the canonical dependency cache; its
  checked-in action contract defaults to `prune-cache: true`, and the failed job showed its own
  restore was ~2 MB. Revert this PR if hosted runs show a material dependency-download regression
  without curing disk pressure.

## Validation / Proof

- `uv run python -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path(".github/actions/setup-ci-python/action.yml").read_text())'` — passed.
- `bash -n scripts/dev/ci_uv_sync_diag.sh` — passed.
- `uv run ruff check tests/dev/test_ci_uv_sync_diag.py tests/dev/test_ci_uv_sync_retry.py` and
  `uv run ruff format --check ...` — passed.
- `uv run pytest tests/dev/test_ci_uv_sync_diag.py tests/dev/test_ci_uv_sync_retry.py tests/test_ci_driver_contract.py -q` — 42 passed.
- Exact `xdist-scratch-isolation` pytest selection with `-n 4 --dist worksteal` after
  `uv sync --all-extras` — 8 passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — interim gate passed:
  2,124 passed, 1 skipped.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=<this body> scripts/dev/pr_ready_check.sh` — passed: 2,124 tests passed, 1 skipped; clean-head freshness recorded at `1f65d4dda`.

The local diagnostic reported a 27 GB uv cache with 26 GB in `archive-v0` and 5.8 MB in
`wheels-v6`, matching the affected job's unpruned-archive failure mechanism. The hosted PR job is
the acceptance check for GitHub cache restore behavior.

## Risks / Rollout

- Cache restores may contain fewer prebuilt payloads and dependency sync may download more data.
  The existing bounded retry still protects transient downloads.
- Rollback: revert this commit if hosted sync reliability regresses without resolving disk use.

## Research and domain guidance

- Research Result Guidance: `NA` — support/CI tooling only; no research evidence is interpreted.
- Domain-Aware Approval: not required — no evidence classification, comparison, metric, or
  paper-facing behavior changes.
- Falsification / Non-Transfer Check: `NA` — no research mechanism claim.
- Next Empirical Action: hosted PR CI runs the affected job with the standard all-extras sync.

## Artifacts and downstream propagation

- No generated artifact is committed. Local `output/` contains 690 ignored coverage/readiness files
  (100 MB), classified as disposable validation cache.
- Parent issue comment: no — issue/PR comments are not authorized for this task, and this closing PR
  body is the canonical low-churn delivery/remaining-work surface.
- Claim map, benchmark report, leaderboard, artifact catalog, registry/config index, context index,
  and memory note: not applicable because this PR creates no research evidence or tracked
  operational state.
- No transient queue host or packet-lineage state is written to tracked files.

## Follow-Up Issues

- Deferred work: none
- Issues opened for follow-up: none

## Friction log

- No new friction issue filed. The encountered `gh issue view --comments` classic-project failure
  is already tracked by the open issue #5092.

## Reviewer notes

- Confirm the hosted `xdist-scratch-isolation` setup does not request `uv-sync-payloads-*` and the
  job reaches all eight tests.
- Publication race guard: no issue comments were added after this run started, no open PR covered
  #5087, and the only 24-hour merged search hit was affected PR #5069 rather than a prior #5087
  guardrail/checker slice.
- Shared-helper migration table: inapplicable; no call-site return schema, file reader, or process
  output consumer is migrated.
- Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no
  paper/dissertation claim edits.

</details>
