### PR TITLE
fix(tooling): fail-closed fresh-worktree virtualenv bootstrap (#5091)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,13 @@ Treat a checkout as linked when `.git` is a file pointing into `.git/worktrees/.
 `git rev-parse --git-common-dir` differs from `git rev-parse --git-dir`.
 
 A linked worktree is fresh only when it lacks both `local.machine.md` and `.venv` plus any
-team-specific initialized marker. In a fresh worktree, derive the main checkout from the common Git
-dir, symlink the main `local.machine.md` when present, run `uv sync --all-extras`, then
+team-specific initialized marker. In a fresh worktree, run
+`scripts/dev/bootstrap_worktree.sh` (preferred) or manually: derive the main checkout from the
+common Git dir, symlink the main `local.machine.md` when present, then run
+`uv venv .venv && uv sync --all-extras`. The `uv venv .venv` step is required: `uv sync --all-extras`
+alone may silently detect and reuse the main checkout's `.venv` without creating one locally,
+leaving `.venv/bin/activate` missing. After sync, verify `.venv/bin/python` exists before
+continuing; if absent, the environment is not usable and the caller must fail closed. Then
 `source .venv/bin/activate` before Python tooling. For quick targeted validation that intentionally
 reuses the main checkout virtualenv, prefer `scripts/dev/run_worktree_shared_venv.sh -- <uv-run-command>`
 so `PYTHONPATH` points at the active worktree. Use a full local `.venv` and final PR readiness for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **issue #5091 fresh worktree virtualenv bootstrap now fails closed.** Added
+  `scripts/dev/bootstrap_worktree.sh`, a helper that runs `uv venv .venv` before
+  `uv sync --all-extras` and verifies `.venv/bin/python` exists afterward. Without the
+  explicit `uv venv .venv` step, `uv sync` in a fresh linked worktree may silently reuse the
+  main checkout's `.venv` without creating one locally, leaving `.venv/bin/activate` missing.
+  Updated `AGENTS.md` Fresh Worktree Bootstrap instructions to document the required order and
+  reference the new helper. Nine targeted contract tests added to
+  `tests/test_ci_script_contract.py`. No benchmark metric or schema changes.
+
 * **issue #4988 benchmark CLI surfaces typed errors (not raw tracebacks) for malformed input.**
   `robot_sf/benchmark/parquet_export.py` now raises the canonical `EpisodeRecordInputError`
   (a `ValueError` subclass, so backward-compatible) instead of a bare `ValueError` when a JSONL line

--- a/scripts/dev/bootstrap_worktree.sh
+++ b/scripts/dev/bootstrap_worktree.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Bootstrap a fresh linked Git worktree so that `source .venv/bin/activate` works.
+#
+# Problem: `uv sync --all-extras` in a fresh linked worktree may detect and
+# reuse the main checkout's .venv instead of creating one locally, leaving the
+# worktree without a .venv/bin/activate to source (issue #5091).
+#
+# Fix: explicitly create a local virtual environment with `uv venv .venv` first,
+# then sync packages into it, then verify the environment exists before returning.
+# This makes the bootstrap fail closed with an actionable message rather than
+# silently succeeding and leaving the caller without a working .venv.
+#
+# Usage:
+#   scripts/dev/bootstrap_worktree.sh [--no-symlink-machine] [--help|-h]
+#
+# Options:
+#   --no-symlink-machine  Skip symlinking local.machine.md from the main checkout.
+#   -h, --help            Show this help and exit.
+#
+# The script must be run from the root of the worktree to bootstrap.
+# Example:
+#   cd /path/to/robot_sf_ll7.worktrees/my-branch
+#   scripts/dev/bootstrap_worktree.sh
+#   source .venv/bin/activate
+
+set -euo pipefail
+
+show_help() {
+    cat <<'EOF'
+Usage: scripts/dev/bootstrap_worktree.sh [--no-symlink-machine] [--help|-h]
+
+Bootstrap a fresh linked Git worktree: run `uv venv .venv && uv sync --all-extras`,
+then verify .venv/bin/python exists before returning. Fails closed with an
+actionable error message if the environment is not usable after sync.
+
+The explicit `uv venv .venv` step is required: `uv sync --all-extras` alone may
+silently reuse the main checkout's .venv without creating one in the worktree,
+leaving .venv/bin/activate missing (issue #5091).
+
+Options:
+  --no-symlink-machine  Skip symlinking local.machine.md from the main checkout.
+  -h, --help            Show this help and exit.
+
+Run from the worktree root you want to bootstrap. Example:
+  cd ../robot_sf_ll7.worktrees/issue-1234-my-branch
+  scripts/dev/bootstrap_worktree.sh
+  source .venv/bin/activate
+EOF
+}
+
+symlink_machine=1
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-symlink-machine)
+            symlink_machine=0
+            shift
+            ;;
+        -h | --help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "bootstrap_worktree: unknown argument: $1" >&2
+            show_help >&2
+            exit 2
+            ;;
+    esac
+done
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# Derive the main checkout path from the git common dir.
+git_common_dir="$(git rev-parse --git-common-dir)"
+if [[ "$git_common_dir" != /* ]]; then
+    git_common_dir="$(cd "$repo_root/$git_common_dir" && pwd)"
+fi
+main_repo_root="$(cd "$git_common_dir/.." && pwd)"
+
+is_linked=0
+if [[ "$git_common_dir" != "$repo_root/.git" ]]; then
+    is_linked=1
+fi
+
+# Symlink local.machine.md from the main checkout when requested and not already present.
+if [[ "$symlink_machine" -eq 1 && "$is_linked" -eq 1 ]]; then
+    main_machine="$main_repo_root/local.machine.md"
+    if [[ -f "$main_machine" && ! -e "$repo_root/local.machine.md" ]]; then
+        ln -s "$main_machine" "$repo_root/local.machine.md"
+        echo "bootstrap_worktree: symlinked local.machine.md from $main_machine"
+    fi
+fi
+
+# Create a local virtual environment explicitly.
+# `uv sync --all-extras` alone may silently reuse the main checkout's .venv
+# (detectable because it prints no "Creating virtual environment" line and runs
+# in ~1ms). Creating .venv explicitly first guarantees packages land here.
+if [[ ! -d "$repo_root/.venv" ]]; then
+    echo "bootstrap_worktree: creating local .venv ..."
+    uv venv .venv
+fi
+
+echo "bootstrap_worktree: syncing dependencies (uv sync --all-extras) ..."
+uv sync --all-extras
+
+# Fail closed: verify the environment is actually usable.
+if [[ ! -x "$repo_root/.venv/bin/python" ]]; then
+    cat >&2 <<'EOF'
+bootstrap_worktree: ERROR — .venv/bin/python not found after uv sync --all-extras.
+
+Suggested recovery:
+  rm -rf .venv
+  uv venv .venv
+  uv sync --all-extras
+  source .venv/bin/activate
+
+If uv is not on PATH, ensure the main checkout's .venv/bin is in PATH or
+install uv via your system package manager.
+EOF
+    exit 1
+fi
+
+echo "bootstrap_worktree: .venv/bin/python is ready."
+echo "bootstrap_worktree: run 'source .venv/bin/activate' to activate."

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -7,10 +7,11 @@ handle both forms as cheap success paths: exit 0, print usage to stdout,
 and return before sourcing common_setup.sh or invoking heavy dependencies
 (uv, ruff, pytest, gh, etc.).
 
-Covered scripts (10 total):
+Covered scripts (11 total):
   pr_ready_check.sh, gh_comment.sh, run_worktree_shared_venv.sh,
   run_tests_parallel.sh, run_xdist_race_validation.sh, run_ci_local.sh, local_signoff.sh,
-  ci_driver.sh, check_runtime_requirements.sh, check_carla_runtime.sh
+  ci_driver.sh, check_runtime_requirements.sh, check_carla_runtime.sh,
+  bootstrap_worktree.sh
 
 Also covered (in tests/dev/): ci_step_timer.sh
 
@@ -43,6 +44,7 @@ LOCAL_SIGNOFF = ROOT / "scripts" / "dev" / "local_signoff.sh"
 PR_READY_CHECK = ROOT / "scripts" / "dev" / "pr_ready_check.sh"
 PR_BODY_CONTRACTS_WORKFLOW = ROOT / ".github" / "workflows" / "pr-body-contracts.yml"
 RUN_WORKTREE_SHARED_VENV = ROOT / "scripts" / "dev" / "run_worktree_shared_venv.sh"
+BOOTSTRAP_WORKTREE = ROOT / "scripts" / "dev" / "bootstrap_worktree.sh"
 CHECK_RUNTIME_REQUIREMENTS = ROOT / "scripts" / "dev" / "check_runtime_requirements.sh"
 CHECK_CARLA_RUNTIME = ROOT / "scripts" / "dev" / "check_carla_runtime.sh"
 
@@ -1138,6 +1140,292 @@ def test_run_ci_local_help_does_not_invoke_setup(tmp_path: Path) -> None:
     )
     result = subprocess.run(
         [str(script_dir / "run_ci_local.sh"), "--help"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "uv should not be called" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_worktree.sh contract tests (issue #5091)
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_worktree_script_exists() -> None:
+    """bootstrap_worktree.sh must exist and be executable."""
+    assert BOOTSTRAP_WORKTREE.exists(), f"Missing: {BOOTSTRAP_WORKTREE}"
+    assert BOOTSTRAP_WORKTREE.stat().st_mode & 0o111, "bootstrap_worktree.sh is not executable"
+
+
+def test_bootstrap_worktree_shell_syntax_is_valid() -> None:
+    """bootstrap_worktree.sh must pass bash -n (no syntax errors)."""
+    result = subprocess.run(
+        ["bash", "-n", str(BOOTSTRAP_WORKTREE)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_bootstrap_worktree_help_long() -> None:
+    """bootstrap_worktree.sh --help prints usage and exits 0."""
+    result = subprocess.run(
+        [str(BOOTSTRAP_WORKTREE), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "uv venv .venv" in result.stdout  # must document the explicit venv-create step
+    assert "uv sync --all-extras" in result.stdout  # must document the sync step
+    assert "source .venv/bin/activate" in result.stdout
+
+
+def test_bootstrap_worktree_help_short() -> None:
+    """bootstrap_worktree.sh -h prints usage and exits 0."""
+    result = subprocess.run(
+        [str(BOOTSTRAP_WORKTREE), "-h"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+
+
+def test_bootstrap_worktree_rejects_unknown_flag() -> None:
+    """bootstrap_worktree.sh rejects unknown flags with exit 2."""
+    result = subprocess.run(
+        [str(BOOTSTRAP_WORKTREE), "--not-a-real-flag"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "unknown argument" in result.stderr
+
+
+def test_bootstrap_worktree_creates_venv_before_sync() -> None:
+    """bootstrap_worktree.sh must call `uv venv .venv` before `uv sync --all-extras` in code.
+
+    Searches only the code body (after the show_help function definition) to avoid
+    false positives from comment or help-text occurrences of these strings.
+    """
+    script_text = BOOTSTRAP_WORKTREE.read_text(encoding="utf-8")
+
+    # Isolate the code body: everything after the show_help function definition ends.
+    # The help function closes with `}` on its own line; the main code follows.
+    help_end_marker = "\nshow_help"
+    code_start = script_text.find(help_end_marker)
+    assert code_start != -1, "Could not locate show_help function in bootstrap_worktree.sh"
+    # Advance past the show_help block to the arg-parsing / main code body.
+    body = script_text[code_start:]
+
+    venv_create = "uv venv .venv"
+    sync_cmd = "uv sync --all-extras"
+    assert venv_create in body, "bootstrap_worktree.sh code body must contain 'uv venv .venv'"
+    assert sync_cmd in body, "bootstrap_worktree.sh code body must contain 'uv sync --all-extras'"
+    assert body.find(venv_create) < body.find(sync_cmd), (
+        "In the code body, 'uv venv .venv' must appear before 'uv sync --all-extras'"
+    )
+
+
+def test_bootstrap_worktree_fails_closed_on_missing_python(tmp_path: Path) -> None:
+    """bootstrap_worktree.sh must exit 1 with an actionable message when .venv/bin/python
+    is absent after uv sync (the core fail-closed contract for issue #5091).
+
+    Simulated with a fake `uv` that prints the expected sync output but does NOT
+    create .venv/bin/python, reproducing the exact failure mode from the issue.
+    """
+    repo = tmp_path / "repo"
+    script_dir = repo / "scripts" / "dev"
+    fake_bin = repo / "fake-bin"
+    script_dir.mkdir(parents=True)
+    fake_bin.mkdir()
+
+    (script_dir / "bootstrap_worktree.sh").write_text(
+        BOOTSTRAP_WORKTREE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (script_dir / "bootstrap_worktree.sh").chmod(0o755)
+
+    # Fake uv: prints plausible sync output but never creates .venv/bin/python.
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'if [[ "$1" == "venv" ]]; then',
+                '  mkdir -p "$2"',
+                "  exit 0",
+                "fi",
+                'if [[ "$1" == "sync" ]]; then',
+                '  echo "Resolved 302 packages in 1ms"',
+                '  echo "Checked 256 packages in 12ms"',
+                "  exit 0",
+                "fi",
+                'echo "unexpected uv invocation: $*" >&2',
+                "exit 99",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "agent@example.invalid"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Agent"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "bootstrap test fixture"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [str(script_dir / "bootstrap_worktree.sh"), "--no-symlink-machine"],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 1, (
+        f"Expected exit 1 (fail-closed) but got {result.returncode}. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert ".venv/bin/python" in result.stderr
+    assert "uv venv .venv" in result.stderr
+    assert "uv sync --all-extras" in result.stderr
+
+
+def test_bootstrap_worktree_succeeds_when_python_present(tmp_path: Path) -> None:
+    """bootstrap_worktree.sh exits 0 when .venv/bin/python exists after uv sync."""
+    repo = tmp_path / "repo"
+    script_dir = repo / "scripts" / "dev"
+    fake_bin = repo / "fake-bin"
+    script_dir.mkdir(parents=True)
+    fake_bin.mkdir()
+
+    (script_dir / "bootstrap_worktree.sh").write_text(
+        BOOTSTRAP_WORKTREE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (script_dir / "bootstrap_worktree.sh").chmod(0o755)
+
+    # Fake uv: creates .venv/bin/python on `uv venv .venv`, succeeds on sync.
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'if [[ "$1" == "venv" ]]; then',
+                '  venv_dir="$2"',
+                '  mkdir -p "$venv_dir/bin"',
+                "  # Create a working python stub so the -x check passes.",
+                '  printf "#!/usr/bin/env bash\\nexit 0\\n" > "$venv_dir/bin/python"',
+                '  chmod 0755 "$venv_dir/bin/python"',
+                "  exit 0",
+                "fi",
+                'if [[ "$1" == "sync" ]]; then',
+                '  echo "Resolved 302 packages in 1ms"',
+                '  echo "Checked 256 packages in 12ms"',
+                "  exit 0",
+                "fi",
+                'echo "unexpected uv invocation: $*" >&2',
+                "exit 99",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "agent@example.invalid"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Agent"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "bootstrap success fixture"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [str(script_dir / "bootstrap_worktree.sh"), "--no-symlink-machine"],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        },
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"Expected success but got {result.returncode}. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert ".venv/bin/python is ready" in result.stdout
+    assert "source .venv/bin/activate" in result.stdout
+
+
+def test_bootstrap_worktree_help_does_not_invoke_uv(tmp_path: Path) -> None:
+    """bootstrap_worktree.sh --help exits 0 before invoking uv."""
+    repo, script_dir, env = _make_help_fixture_repo(
+        tmp_path,
+        ("bootstrap_worktree.sh",),
+    )
+    result = subprocess.run(
+        [str(script_dir / "bootstrap_worktree.sh"), "--help"],
         cwd=repo,
         env=env,
         capture_output=True,


### PR DESCRIPTION
## Reviewer-critical summary

**What changed**: Added `scripts/dev/bootstrap_worktree.sh` — a fail-closed helper for fresh
linked worktree setup — and updated `AGENTS.md` to document the required `uv venv .venv &&
uv sync --all-extras` ordering. Nine contract tests added to `tests/test_ci_script_contract.py`.

**Why now**: The current AGENTS.md fresh-worktree instructions say "run `uv sync --all-extras`",
but in a fresh linked worktree `uv sync` may silently detect and reuse the main checkout's
`.venv` without creating one locally (observed: runs in ~1ms, prints "Checked 256 packages",
no "Creating virtual environment" line, `.venv/bin/activate` missing). The caller gets no
error — they only discover the failure when trying to `source .venv/bin/activate`.

**Claim boundary**: Tooling/documentation change only. No benchmark metrics, schema, or
runtime behavior changes.

**Required validation**: `pytest tests/test_ci_script_contract.py -k "bootstrap_worktree"` — 9
tests all pass (verified locally).

**Remaining blocker**: None.

## Contract delta

- New script: `scripts/dev/bootstrap_worktree.sh` (executable, `--help/-h`, `--no-symlink-machine`)
  - Calls `uv venv .venv` before `uv sync --all-extras`
  - Fails closed (exit 1) with actionable message when `.venv/bin/python` is absent after sync
  - Symlinks `local.machine.md` from the main checkout when present in a linked worktree
- `AGENTS.md` Fresh Worktree Bootstrap section updated: documents explicit `uv venv .venv` step,
  references `scripts/dev/bootstrap_worktree.sh`, explains why the step is required
- `tests/test_ci_script_contract.py`: 9 new tests; existing 62 tests unaffected
- `CHANGELOG.md`: entry added under `[Unreleased]` → `Fixed`

No new schema fields. No compatibility impact beyond fixing a silent bootstrap failure.

## Validation

```
$ scripts/dev/run_worktree_shared_venv.sh --no-freshness-check -- \
    python -m pytest tests/test_ci_script_contract.py -v
...
71 passed in 1.77s
```

All 9 new bootstrap tests pass; all 62 pre-existing tests pass.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

Closes #5091

## State propagation

This PR fully resolves #5091 (the friction issue). No follow-up required.

<details>
<summary>Governance / Downstream Propagation</summary>

Not applicable: this is a tooling/docs-only change with no research claim.

Evidence tier: `smoke evidence` — script syntax validation and behavioral contract tests.
Result classification: tooling fix.
Downstream propagation: None required.
</details>
