### PR TITLE
feat(training): batch lidar across threaded rollouts (#4981)

### DIFF
--- a/docs/dev/issues/4981-vectorized-rollouts/design.md
+++ b/docs/dev/issues/4981-vectorized-rollouts/design.md
@@ -4,7 +4,7 @@
 
 Issue #4981 needs a Stable-Baselines3-compatible way to collect several Robot SF rollout steps
 without requiring one Python process per environment. This design adds opt-in in-process threaded
-execution and an opt-in cross-environment light detection and ranging (LiDAR) kernel adapter while
+execution and coordinated cross-environment light detection and ranging (LiDAR) collection while
 keeping the established `DummyVecEnv`, `SubprocVecEnv`, and scalar LiDAR paths unchanged.
 
 ## Contract delta
@@ -15,9 +15,14 @@ keeping the established `DummyVecEnv`, `SubprocVecEnv`, and scalar LiDAR paths u
   observations, and information dictionaries.
 - With one environment, `threaded` resolves to `dummy`, preserving the existing single-environment
   fallback.
+- `worker_mode: threaded_lidar_batch` uses the same threaded vector-environment lifecycle and
+  coordinates homogeneous static-obstacle LiDAR rows during each environment step. The mode also
+  resolves to `dummy` for one environment.
 - `robot_sf.sensor.range_sensor.raycast_obstacles_batch` accepts padded static-obstacle arrays for
-  several environments and evaluates them in one compiled central processing unit (CPU) dispatch.
-  Callers opt in explicitly; no environment or trainer selects it by default.
+  several environments and evaluates them in one compiled central processing unit (CPU)
+  dispatch. The coordinator selects it only for the explicit `threaded_lidar_batch` mode.
+- The compiled LiDAR raycast and postprocessing entry points release the Python global interpreter
+  lock while executing, so independent scalar threaded scans can make progress concurrently.
 - A one-environment LiDAR batch calls the existing `raycast_obstacles` kernel directly, preserving
   its output bit for bit.
 
@@ -28,16 +33,17 @@ concurrently when their numerical kernels release the Python global interpreter 
 workers share a process, so callers needing process isolation should continue using
 `worker_mode: subproc`.
 
-The LiDAR adapter batches only the static-obstacle raycast and requires a common ray count plus
-padded obstacle storage with explicit per-environment counts. It deliberately uses one sequential
-Numba dispatch rather than nested CPU parallelism, and it is not yet wired into environment step
-coordination. This contract establishes numerical equivalence, not a throughput improvement.
+The LiDAR coordinator batches only the static-obstacle raycast. All participating workers must
+reach the same number of LiDAR calls per step with a common ray count and homogeneous array dtypes.
+It pads obstacle rows, then uses one Numba dispatch while the other environment workers wait,
+avoiding nested worker dispatches. A timeout or incompatible row fails the coordinated mode
+closed instead of falling back silently. Reset-time and automatic-reset scans remain scalar.
 
 ## Proof and follow-up
 
 The implementation is proven by Stable-Baselines3 lifecycle tests, a real Robot SF reset/step smoke,
-and synthetic multi-environment tests that compare every batched LiDAR row with the scalar kernel.
-It is not throughput evidence. The remaining acceptance steps are integration of batch collection
-into a rollout path and a reproducible standard-PPO configuration measurement that compares worker
-and kernel modes. The issue's >3x claim may only be promoted if the exact configuration, host, and
-sample duration support it.
+and a coordinated rollout test that compares complete LiDAR observations bit for bit with scalar
+threaded execution. This is implementation-integrity evidence, not throughput evidence. The
+remaining acceptance step is a reproducible standard-PPO configuration measurement that compares
+dummy, subprocess, threaded, and threaded-LiDAR-batch modes. The issue's >3x claim may only be
+promoted if the exact configuration, host, and sample duration support it.

--- a/docs/training/vectorized_env_support.md
+++ b/docs/training/vectorized_env_support.md
@@ -5,7 +5,7 @@ targeted tests.
 
 | Entry point | DummyVecEnv | SubprocVecEnv | ThreadedVecEnv | Start method | Status |
 | --- | --- | --- | --- | --- | --- |
-| `scripts/training/train_ppo.py` | Supported | Supported | Supported with `worker_mode: threaded` | `spawn` for subprocess mode | Primary PPO path; threaded mode is an opt-in in-process rollout path. |
+| `scripts/training/train_ppo.py` | Supported | Supported | Supported with `worker_mode: threaded` or `threaded_lidar_batch` | `spawn` for subprocess mode | Primary PPO path; both threaded modes are opt-in in-process rollout paths. |
 | `scripts/training/train_ppo_with_pretrained_policy.py` | Supported | Supported | Not exposed | `spawn` | Supported PPO fine-tuning path. |
 | `scripts/training/train_sac_sb3.py` | Supported | Supported when `num_envs > 1` | Not exposed | `spawn` | Supported SAC path. |
 | `scripts/multi_extractor_training.py` | Supported for `single-thread` | Supported for `vectorized` | Not exposed | `spawn` | Legacy extractor-sweep path; retained for compatibility. |
@@ -14,8 +14,10 @@ targeted tests.
 preserving Stable-Baselines3's `VecEnv` result, auto-reset, and terminal-observation behavior. Use it
 only when each environment is safe to step concurrently in one process. It avoids subprocess
 serialization, but it does not provide process isolation and does not by itself establish a rollout
-throughput improvement. The default `worker_mode: auto` remains unchanged and chooses subprocess
-workers when more than one environment is requested.
+throughput improvement. The compiled LiDAR raycast and postprocessing sections release the Python
+global interpreter lock during execution; the surrounding environment step remains ordinary Python.
+The default `worker_mode: auto` remains unchanged and chooses subprocess workers when more than one
+environment is requested.
 
 Select the mode explicitly in a primary PPO config:
 
@@ -24,8 +26,17 @@ num_envs: 4
 worker_mode: threaded
 ```
 
-With `num_envs: 1`, `threaded` resolves to the existing `DummyVecEnv` fallback. This preserves the
-single-environment execution path; no performance result is implied by this configuration.
+To coordinate homogeneous static-obstacle LiDAR rows into one compiled batch during each threaded
+environment step, select the separate opt-in mode:
+
+```yaml
+num_envs: 4
+worker_mode: threaded_lidar_batch
+```
+
+With `num_envs: 1`, both threaded modes resolve to the existing `DummyVecEnv` fallback. This
+preserves the single-environment execution path; no performance result is implied by either
+configuration.
 
 `spawn` is the portable subprocess contract. It exercises actual child-process imports and catches
 closures, globals, and environment factories that only work under `fork`. Tests should cover
@@ -43,7 +54,14 @@ It accepts one padded static-obstacle tensor, explicit obstacle counts, scanner 
 angles, then invokes the established obstacle-raycast arithmetic for every environment in one
 compiled dispatch.
 
-The adapter is opt-in and is not selected automatically by `ThreadedVecEnv` or any training config.
-A batch of one calls the scalar `raycast_obstacles` kernel directly. Multi-environment contract
-tests require bit-identical rows compared with independent scalar calls. These tests establish
-compatibility only; no rollout throughput or speedup claim is attached to this path.
+The `threaded_lidar_batch` worker mode binds one coordinator to its environment-step workers. Each
+worker computes dynamic-object raycasts independently, submits its static-obstacle inputs, and waits
+while the coordinator pads obstacle rows and invokes the batch kernel once. Participating
+rows must share one ray count and array dtypes, and each worker must reach the same number of LiDAR
+calls per step. Incompatible or incomplete batches fail closed; reset-time scans remain scalar.
+
+A batch of one calls the scalar `raycast_obstacles` kernel directly, and primary PPO training
+resolves the one-environment worker mode to `DummyVecEnv` before constructing a coordinator.
+Multi-environment tests require complete LiDAR observations to be bit-identical to scalar threaded
+execution. These checks establish compatibility and rollout integration only; the standard-config
+throughput comparison required by issue #4981 remains separate.

--- a/robot_sf/sensor/range_sensor.py
+++ b/robot_sf/sensor/range_sensor.py
@@ -6,9 +6,12 @@ reported in world units and clipped/noised to match the configured scanner
 settings before they are exposed as Gymnasium observation spaces.
 """
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import lru_cache
 from math import cos, sin
+from threading import Barrier, BrokenBarrierError, Lock, local
 
 import numba
 import numpy as np
@@ -199,7 +202,7 @@ class LidarScannerSettings:
         return cls()
 
 
-@numba.njit(fastmath=True)
+@numba.njit(fastmath=True, nogil=True)
 def raycast_pedestrians(
     out_ranges: np.ndarray,
     scanner_pos: Vec2D,
@@ -231,7 +234,7 @@ def raycast_pedestrians(
     raycast_circles(out_ranges, scanner_pos, max_scan_range, circles, ray_angles)
 
 
-@numba.njit(fastmath=True)
+@numba.njit(fastmath=True, nogil=True)
 def raycast_circles(
     out_ranges: np.ndarray,
     scanner_pos: Vec2D,
@@ -278,7 +281,7 @@ def raycast_circles(
         out_ranges[i] = best_range
 
 
-@numba.njit(fastmath=True)
+@numba.njit(fastmath=True, nogil=True)
 def raycast_obstacles(
     out_ranges: np.ndarray,
     scanner_pos: Vec2D,
@@ -307,7 +310,10 @@ def raycast_obstacles(
             out_ranges[i] = min(coll_dist, out_ranges[i])
 
 
-@numba.njit(fastmath=True)  # pragma: no cover - exercised via caller; not line-traceable.
+@numba.njit(  # pragma: no cover - exercised via caller; not line-traceable.
+    fastmath=True,
+    nogil=True,
+)
 def _raycast_obstacles_batch_kernel(
     out_ranges: np.ndarray,
     scanner_positions: np.ndarray,
@@ -402,7 +408,164 @@ def raycast_obstacles_batch(
     )
 
 
-@numba.njit()
+@dataclass(slots=True)
+class _LidarBatchEntry:
+    """One environment's static-obstacle raycast inputs for a coordinated step."""
+
+    out_ranges: np.ndarray
+    scanner_position: np.ndarray
+    obstacles: np.ndarray
+    ray_angles: np.ndarray
+
+
+class LidarBatchCoordinator:
+    """Collect one homogeneous LiDAR request per environment and dispatch it together.
+
+    The coordinator is intended for a fixed group of in-process rollout workers. Each
+    worker owns one ``env_index`` and submits exactly one request per coordination cycle.
+    A timeout or incompatible row aborts the coordinator so partial batches cannot hang
+    or silently fall back to scalar execution.
+    """
+
+    def __init__(self, batch_size: int, *, timeout_seconds: float = 30.0) -> None:
+        """Initialize a reusable fixed-size synchronization barrier."""
+        if batch_size < 2:
+            raise ValueError("LiDAR batch coordination requires at least two environments")
+        if timeout_seconds <= 0:
+            raise ValueError("LiDAR batch coordination timeout must be positive")
+        self.batch_size = int(batch_size)
+        self.timeout_seconds = float(timeout_seconds)
+        self._entries: list[_LidarBatchEntry | None] = [None] * self.batch_size
+        self._error: BaseException | None = None
+        self._error_lock = Lock()
+        self._barrier = Barrier(self.batch_size, action=self._dispatch)
+
+    def submit(
+        self,
+        env_index: int,
+        out_ranges: np.ndarray,
+        scanner_position: np.ndarray,
+        obstacles: np.ndarray,
+        ray_angles: np.ndarray,
+    ) -> None:
+        """Submit one row and wait until the complete batch has been dispatched."""
+        if not 0 <= env_index < self.batch_size:
+            raise ValueError(f"env_index must be within [0, {self.batch_size})")
+        self._raise_if_failed()
+        self._entries[env_index] = _LidarBatchEntry(
+            out_ranges=out_ranges,
+            scanner_position=np.asarray(scanner_position),
+            obstacles=np.asarray(obstacles),
+            ray_angles=np.asarray(ray_angles),
+        )
+        try:
+            self._barrier.wait(timeout=self.timeout_seconds)
+        except BrokenBarrierError as exc:
+            self._raise_if_failed()
+            raise RuntimeError("coordinated LiDAR batch did not receive every environment") from exc
+        self._raise_if_failed()
+
+    def abort(self, error: BaseException) -> None:
+        """Abort pending and future batches after an environment-step failure."""
+        self._record_error(error)
+        self._barrier.abort()
+
+    def _dispatch(self) -> None:
+        """Validate, pad, and dispatch the complete barrier generation."""
+        try:
+            entries = list(self._entries)
+            if any(entry is None for entry in entries):
+                raise RuntimeError("coordinated LiDAR batch is missing an environment row")
+            rows = [entry for entry in entries if entry is not None]
+            first = rows[0]
+            num_rays = first.out_ranges.shape
+            out_dtype = first.out_ranges.dtype
+            ray_dtype = first.ray_angles.dtype
+            scanner_dtype = first.scanner_position.dtype
+            obstacle_dtype = first.obstacles.dtype
+            for row in rows:
+                if row.out_ranges.shape != num_rays or row.ray_angles.shape != num_rays:
+                    raise ValueError("coordinated LiDAR rows must use one common ray count")
+                if row.scanner_position.shape != (2,):
+                    raise ValueError("coordinated LiDAR scanner positions must have shape (2,)")
+                if row.obstacles.ndim != 2 or row.obstacles.shape[1] != 4:
+                    raise ValueError("coordinated LiDAR obstacles must have shape (N, 4)")
+                if (
+                    row.out_ranges.dtype != out_dtype
+                    or row.ray_angles.dtype != ray_dtype
+                    or row.scanner_position.dtype != scanner_dtype
+                    or row.obstacles.dtype != obstacle_dtype
+                ):
+                    raise TypeError("coordinated LiDAR rows must use homogeneous dtypes")
+
+            out_ranges = np.stack([row.out_ranges for row in rows])
+            scanner_positions = np.stack([row.scanner_position for row in rows])
+            ray_angles = np.stack([row.ray_angles for row in rows])
+            obstacle_counts = np.asarray(
+                [row.obstacles.shape[0] for row in rows],
+                dtype=np.int64,
+            )
+            max_obstacles = int(obstacle_counts.max(initial=0))
+            padded_obstacles = np.zeros(
+                (self.batch_size, max_obstacles, 4),
+                dtype=obstacle_dtype,
+            )
+            for env_index, row in enumerate(rows):
+                padded_obstacles[env_index, : row.obstacles.shape[0]] = row.obstacles
+
+            raycast_obstacles_batch(
+                out_ranges,
+                scanner_positions,
+                padded_obstacles,
+                obstacle_counts,
+                ray_angles,
+            )
+            for env_index, row in enumerate(rows):
+                row.out_ranges[:] = out_ranges[env_index]
+        except BaseException as exc:  # noqa: BLE001 - propagate one batch failure to every worker.
+            self._record_error(exc)
+
+    def _record_error(self, error: BaseException) -> None:
+        """Retain the first failure as the canonical batch error."""
+        with self._error_lock:
+            if self._error is None:
+                self._error = error
+
+    def _raise_if_failed(self) -> None:
+        """Raise the canonical failure for all participating workers."""
+        if self._error is not None:
+            raise RuntimeError("coordinated LiDAR batch failed") from self._error
+
+
+@dataclass(frozen=True, slots=True)
+class _LidarBatchBinding:
+    """Thread-local coordinator binding for one vector-environment worker."""
+
+    coordinator: LidarBatchCoordinator
+    env_index: int
+
+
+_LIDAR_BATCH_CONTEXT = local()
+
+
+@contextmanager
+def lidar_batch_context(
+    coordinator: LidarBatchCoordinator,
+    env_index: int,
+) -> Iterator[None]:
+    """Bind a rollout worker's LiDAR calls to a shared batch coordinator."""
+    previous = getattr(_LIDAR_BATCH_CONTEXT, "binding", None)
+    _LIDAR_BATCH_CONTEXT.binding = _LidarBatchBinding(coordinator, env_index)
+    try:
+        yield
+    finally:
+        if previous is None:
+            del _LIDAR_BATCH_CONTEXT.binding
+        else:
+            _LIDAR_BATCH_CONTEXT.binding = previous
+
+
+@numba.njit(nogil=True)
 def raycast(  # noqa: PLR0913
     scanner_pos: Vec2D,
     obstacles: np.ndarray,
@@ -491,7 +654,7 @@ def _dynamic_objects_to_circle_array(occ: ContinuousOccupancy) -> np.ndarray | N
     return np.array(rows, dtype=np.float64)
 
 
-@numba.njit(fastmath=True)
+@numba.njit(fastmath=True, nogil=True)
 def range_postprocessing(out_ranges: np.ndarray, scan_noise: np.ndarray, max_scan_dist: float):
     """Clip and optionally corrupt ray ranges in place.
 
@@ -569,8 +732,12 @@ def _lidar_ray_scan_impl(
     np.add(robot_orient, settings.ray_offsets, out=ray_angles_out)
     np.mod(ray_angles_out, 2.0 * np.pi, out=ray_angles_out)
 
-    if isinstance(occ, EgoPedContinuousOccupancy):
-        enemy_pos = np.array([occ.enemy_coords])
+    binding: _LidarBatchBinding | None = getattr(_LIDAR_BATCH_CONTEXT, "binding", None)
+    if binding is None:
+        enemy_pos = (
+            np.array([occ.enemy_coords]) if isinstance(occ, EgoPedContinuousOccupancy) else None
+        )
+        enemy_radius = occ.enemy_radius if isinstance(occ, EgoPedContinuousOccupancy) else 0.0
         ranges = raycast(
             (pos_x, pos_y),
             obstacles,
@@ -579,19 +746,43 @@ def _lidar_ray_scan_impl(
             occ.ped_radius,
             ray_angles_out,
             enemy_pos=enemy_pos,
-            enemy_radius=occ.enemy_radius,
+            enemy_radius=enemy_radius,
             other_robot_circles=dynamic_robot_circles,
         )
     else:
-        ranges = raycast(
+        ranges = np.full(ray_angles_out.shape[0], np.inf)
+        raycast_pedestrians(
+            ranges,
             (pos_x, pos_y),
-            obstacles,
             scan_dist,
             ped_pos,
             occ.ped_radius,
             ray_angles_out,
-            other_robot_circles=dynamic_robot_circles,
         )
+        binding.coordinator.submit(
+            binding.env_index,
+            ranges,
+            np.asarray((pos_x, pos_y)),
+            obstacles,
+            ray_angles_out,
+        )
+        if isinstance(occ, EgoPedContinuousOccupancy):
+            raycast_pedestrians(
+                ranges,
+                (pos_x, pos_y),
+                scan_dist,
+                np.array([occ.enemy_coords]),
+                occ.enemy_radius,
+                ray_angles_out,
+            )
+        if dynamic_robot_circles is not None:
+            raycast_circles(
+                ranges,
+                (pos_x, pos_y),
+                scan_dist,
+                dynamic_robot_circles,
+                ray_angles_out,
+            )
     range_postprocessing(ranges, scan_noise, scan_dist)
     return ranges, ray_angles_out
 

--- a/robot_sf/training/threaded_vec_env.py
+++ b/robot_sf/training/threaded_vec_env.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from stable_baselines3.common.vec_env import DummyVecEnv
 
+from robot_sf.sensor.range_sensor import LidarBatchCoordinator, lidar_batch_context
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -33,6 +35,8 @@ class ThreadedVecEnv(DummyVecEnv):
         env_fns: Factories that each create a distinct Gymnasium environment.
         max_workers: Maximum concurrent reset/step calls. Defaults to one worker
             per environment and must be positive.
+        batch_lidar: Coordinate homogeneous static-obstacle LiDAR rows from each
+            step through one cross-environment kernel dispatch. Disabled by default.
 
     Raises:
         ValueError: If ``max_workers`` is not positive.
@@ -45,18 +49,26 @@ class ThreadedVecEnv(DummyVecEnv):
         env_fns: list[Callable[[], gym.Env]],
         *,
         max_workers: int | None = None,
+        batch_lidar: bool = False,
     ) -> None:
         """Initialize independent environments and a bounded in-process worker pool."""
         super().__init__(env_fns)
         resolved_workers = self.num_envs if max_workers is None else int(max_workers)
         if resolved_workers < 1:
             raise ValueError("max_workers must be at least 1")
+        if batch_lidar and self.num_envs > 1 and resolved_workers < self.num_envs:
+            raise ValueError(
+                "batch_lidar requires at least one worker per environment to reach the batch"
+            )
         self._executor = ThreadPoolExecutor(
             max_workers=min(resolved_workers, self.num_envs),
             thread_name_prefix="robot-sf-vec-env",
         )
         self._step_futures: list[Future[Any]] | None = None
         self._closed = False
+        self._lidar_batch_coordinator = (
+            LidarBatchCoordinator(self.num_envs) if batch_lidar and self.num_envs > 1 else None
+        )
 
     def reset(self) -> Any:
         """Reset all environments concurrently.
@@ -85,7 +97,12 @@ class ThreadedVecEnv(DummyVecEnv):
         self._ensure_no_pending_step("step_async")
         copied_actions = np.asarray(actions).copy()
         self._step_futures = [
-            self._executor.submit(env.step, copied_actions[env_idx].copy())
+            self._executor.submit(
+                self._step_env,
+                env_idx,
+                env,
+                copied_actions[env_idx].copy(),
+            )
             for env_idx, env in enumerate(self.envs)
         ]
 
@@ -128,8 +145,26 @@ class ThreadedVecEnv(DummyVecEnv):
             for future in self._step_futures:
                 future.cancel()
             self._step_futures = None
+        if self._lidar_batch_coordinator is not None:
+            self._lidar_batch_coordinator.abort(RuntimeError("ThreadedVecEnv closed"))
         self._executor.shutdown(wait=True, cancel_futures=True)
         super().close()
+
+    def _step_env(self, env_idx: int, env: gym.Env, action: np.ndarray) -> Any:
+        """Step one environment with its optional coordinated LiDAR binding.
+
+        Returns:
+            The Gymnasium step transition emitted by ``env``.
+        """
+        coordinator = self._lidar_batch_coordinator
+        if coordinator is None:
+            return env.step(action)
+        try:
+            with lidar_batch_context(coordinator, env_idx):
+                return env.step(action)
+        except BaseException as exc:
+            coordinator.abort(exc)
+            raise
 
     def _ensure_no_pending_step(self, operation: str) -> None:
         """Reject operations that would race an outstanding asynchronous step."""

--- a/scripts/training/train_ppo.py
+++ b/scripts/training/train_ppo.py
@@ -556,9 +556,12 @@ def _resolve_worker_mode(config: ExpertTrainingConfig, num_envs: int) -> str:
     mode = config.worker_mode.lower()
     if mode == "auto":
         return "subproc" if num_envs > 1 else "dummy"
-    if mode not in {"dummy", "subproc", "threaded"}:
-        raise ValueError("worker_mode must be one of {'auto', 'dummy', 'subproc', 'threaded'}")
-    if mode in {"subproc", "threaded"} and num_envs == 1:
+    if mode not in {"dummy", "subproc", "threaded", "threaded_lidar_batch"}:
+        raise ValueError(
+            "worker_mode must be one of "
+            "{'auto', 'dummy', 'subproc', 'threaded', 'threaded_lidar_batch'}"
+        )
+    if mode in {"subproc", "threaded", "threaded_lidar_batch"} and num_envs == 1:
         return "dummy"
     return mode
 
@@ -2553,8 +2556,11 @@ def _init_training_model(
     if worker_mode == "subproc":
         with _subproc_worker_log_environment(worker_mode):
             vec_env = SubprocVecEnv(env_fns, start_method="spawn")
-    elif worker_mode == "threaded":
-        vec_env = ThreadedVecEnv(env_fns)
+    elif worker_mode in {"threaded", "threaded_lidar_batch"}:
+        vec_env = ThreadedVecEnv(
+            env_fns,
+            batch_lidar=worker_mode == "threaded_lidar_batch",
+        )
     else:
         vec_env = DummyVecEnv(env_fns)
     policy_class, policy_kwargs, critic_profile = _resolve_policy_selection(config)

--- a/tests/sensor/test_batched_lidar_kernel.py
+++ b/tests/sensor/test_batched_lidar_kernel.py
@@ -1,5 +1,7 @@
 """Contracts for opt-in cross-environment LiDAR obstacle batching."""
 
+from concurrent.futures import ThreadPoolExecutor
+
 import numpy as np
 import pytest
 
@@ -127,3 +129,23 @@ def test_batch_contract_rejects_read_only_output() -> None:
             obstacle_counts,
             ray_angles,
         )
+
+
+def test_coordinator_fails_closed_for_heterogeneous_ray_counts() -> None:
+    """Rollout coordination must reject incompatible rows instead of using scalar fallback."""
+    coordinator = range_sensor.LidarBatchCoordinator(2, timeout_seconds=1.0)
+
+    def _submit(env_index: int, num_rays: int) -> None:
+        coordinator.submit(
+            env_index,
+            np.full(num_rays, np.inf, dtype=np.float64),
+            np.zeros(2, dtype=np.float64),
+            np.empty((0, 4), dtype=np.float64),
+            np.zeros(num_rays, dtype=np.float64),
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(_submit, 0, 4), executor.submit(_submit, 1, 5)]
+        for future in futures:
+            with pytest.raises(RuntimeError, match="coordinated LiDAR batch failed"):
+                future.result()

--- a/tests/training/test_threaded_vec_env.py
+++ b/tests/training/test_threaded_vec_env.py
@@ -9,6 +9,8 @@ import numpy as np
 import pytest
 from gymnasium import spaces
 
+from robot_sf.sensor import range_sensor
+from robot_sf.sensor.range_sensor import LidarScannerSettings, lidar_ray_scan_ranges_only
 from robot_sf.training.threaded_vec_env import ThreadedVecEnv
 
 
@@ -33,6 +35,51 @@ class _BarrierEnv(gym.Env):
         self._barrier.wait(timeout=2)
         observation = np.asarray(action, dtype=np.float32)
         return observation, float(observation[0]), self._terminate, False, {"stepped": True}
+
+
+class _StaticOccupancy:
+    """Minimal continuous-occupancy contract for deterministic LiDAR tests."""
+
+    def __init__(self, obstacles: np.ndarray) -> None:
+        self.obstacle_coords = obstacles
+        self.pedestrian_coords = np.array([[1.5, 0.25]], dtype=np.float64)
+        self.ped_radius = 0.2
+
+
+class _LidarEnv(gym.Env):
+    """Environment whose step observation is one real Robot SF LiDAR scan."""
+
+    def __init__(self, env_index: int) -> None:
+        self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32)
+        self.observation_space = spaces.Box(low=0.0, high=10.0, shape=(16,), dtype=np.float64)
+        self._settings = LidarScannerSettings(
+            max_scan_dist=10.0,
+            num_rays=16,
+            scan_noise=[0.0, 0.0],
+        )
+        obstacle_rows = [
+            [2.0 + env_index, -1.0, 2.0 + env_index, 1.0],
+            [-1.0, 3.0 + env_index, 1.0, 3.0 + env_index],
+        ]
+        if env_index == 0:
+            obstacle_rows.pop()
+        self._occupancy = _StaticOccupancy(np.asarray(obstacle_rows, dtype=np.float64))
+        self._pose = ((float(env_index), 0.0), 0.2 * env_index)
+
+    def reset(self, *, seed=None, options=None):
+        """Return a deterministic placeholder without invoking LiDAR batching."""
+        super().reset(seed=seed)
+        return np.zeros(16, dtype=np.float64), {}
+
+    def step(self, action):
+        """Return a deterministic scan that exercises static and pedestrian raycasts."""
+        del action
+        observation = lidar_ray_scan_ranges_only(
+            self._pose,
+            self._occupancy,
+            self._settings,
+        )
+        return observation, 0.0, False, False, {}
 
 
 def test_threaded_vec_env_steps_sibling_environments_concurrently() -> None:
@@ -72,11 +119,49 @@ def test_threaded_vec_env_preserves_sb3_terminal_observation_and_auto_reset() ->
         vec_env.close()
 
 
+def test_threaded_vec_env_batches_real_lidar_without_changing_observations(monkeypatch) -> None:
+    """Opt-in rollout coordination should dispatch once and preserve scalar scan rows exactly."""
+    scalar_env = ThreadedVecEnv([lambda: _LidarEnv(0), lambda: _LidarEnv(1)])
+    try:
+        scalar_env.reset()
+        scalar_observations, *_ = scalar_env.step(np.zeros((2, 1), dtype=np.float32))
+    finally:
+        scalar_env.close()
+
+    dispatch_count = 0
+    original_dispatch = range_sensor._raycast_obstacles_batch_kernel
+
+    def _record_dispatch(*args):
+        nonlocal dispatch_count
+        dispatch_count += 1
+        return original_dispatch(*args)
+
+    monkeypatch.setattr(range_sensor, "_raycast_obstacles_batch_kernel", _record_dispatch)
+    batch_env = ThreadedVecEnv(
+        [lambda: _LidarEnv(0), lambda: _LidarEnv(1)],
+        batch_lidar=True,
+    )
+    try:
+        batch_env.reset()
+        batch_observations, *_ = batch_env.step(np.zeros((2, 1), dtype=np.float32))
+    finally:
+        batch_env.close()
+
+    assert dispatch_count == 1
+    np.testing.assert_array_equal(batch_observations, scalar_observations)
+
+
 def test_threaded_vec_env_rejects_overlapping_steps_and_invalid_worker_count() -> None:
     """The asynchronous VecEnv lifecycle must fail closed on invalid concurrent use."""
     barrier = Barrier(1)
     with pytest.raises(ValueError, match="at least 1"):
         ThreadedVecEnv([lambda: _BarrierEnv(barrier)], max_workers=0)
+    with pytest.raises(ValueError, match="one worker per environment"):
+        ThreadedVecEnv(
+            [lambda: _BarrierEnv(barrier), lambda: _BarrierEnv(barrier)],
+            max_workers=1,
+            batch_lidar=True,
+        )
 
     vec_env = ThreadedVecEnv([lambda: _BarrierEnv(barrier)])
     try:

--- a/tests/training/test_train_expert_ppo_contract.py
+++ b/tests/training/test_train_expert_ppo_contract.py
@@ -309,6 +309,30 @@ def test_dummy_worker_log_environment_leaves_log_level_unchanged(monkeypatch) ->
     assert train_ppo.os.environ["LOGURU_LEVEL"] == "INFO"
 
 
+def test_threaded_lidar_batch_mode_uses_dummy_single_environment_fallback(tmp_path: Path) -> None:
+    """The batch mode must preserve the established scalar worker for one environment."""
+    config = ExpertTrainingConfig.from_raw(
+        scenario_config=tmp_path / "scenarios.yaml",
+        seeds=(123,),
+        total_timesteps=32,
+        policy_id="ppo_threaded_lidar_batch_test",
+        convergence=ConvergenceCriteria(
+            success_rate=0.9,
+            collision_rate=0.05,
+            plateau_window=1000,
+        ),
+        evaluation=EvaluationSchedule(
+            frequency_episodes=0,
+            evaluation_episodes=1,
+            step_schedule=((None, 32),),
+        ),
+        worker_mode="threaded_lidar_batch",
+    )
+
+    assert train_ppo._resolve_worker_mode(config, num_envs=1) == "dummy"
+    assert train_ppo._resolve_worker_mode(config, num_envs=2) == "threaded_lidar_batch"
+
+
 def test_init_training_model_quiets_loguru_while_spawning_subproc_workers(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/training/test_vector_env_matrix.py
+++ b/tests/training/test_vector_env_matrix.py
@@ -70,3 +70,10 @@ def test_ppo_training_factory_supports_threaded_vec_env() -> None:
     env_fns = [_ppo_training_env_factory(300), _ppo_training_env_factory(301)]
 
     _assert_vec_env_reset_step_close(ThreadedVecEnv(env_fns))
+
+
+def test_ppo_training_factory_supports_threaded_lidar_batch_vec_env() -> None:
+    """Primary PPO rollouts should execute the opt-in coordinated LiDAR batch path."""
+    env_fns = [_ppo_training_env_factory(400), _ppo_training_env_factory(401)]
+
+    _assert_vec_env_reset_step_close(ThreadedVecEnv(env_fns, batch_lidar=True))

--- a/tests/training/test_vector_env_matrix.py
+++ b/tests/training/test_vector_env_matrix.py
@@ -11,7 +11,8 @@ from robot_sf.training.scenario_loader import load_scenarios
 from robot_sf.training.threaded_vec_env import ThreadedVecEnv
 from scripts.training import train_ppo
 
-_SCENARIO_PATH = Path("configs/scenarios/single/planner_sanity_simple.yaml").resolve()
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCENARIO_PATH = _REPO_ROOT / "configs/scenarios/single/planner_sanity_simple.yaml"
 
 
 def _ppo_training_env_factory(seed: int):


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Added the opt-in `worker_mode: threaded_lidar_batch` primary-PPO path. Its
  `ThreadedVecEnv` workers coordinate homogeneous static-obstacle light detection and ranging
  (LiDAR) rows into the merged batch kernel during real environment steps. Existing compiled LiDAR
  sections now release the Python global interpreter lock so independent threaded scans can make
  progress concurrently.
- **Why now:** PR #5017 delivered threaded Stable-Baselines3 vector-environment stepping and PR
  #5102 delivered the scalar-equivalent batch kernel. The live #4981 thread identifies rollout-side
  collection as the next remaining capability before a standard-config throughput comparison.
- **Claim boundary:** CPU implementation-integrity and diagnostic evidence only. Complete LiDAR
  observations are bit-identical to scalar threaded execution in focused tests, but a short local
  diagnostic did not show speedup and does not satisfy the parent issue's `>3x` acceptance target.
- **Required validation:** focused LiDAR/vector-environment contracts and the clean committed-HEAD
  repository readiness gate against current `origin/main`.
- **Remaining blocker:** add/use a reproducible CPU comparator covering dummy, subprocess, threaded,
  and threaded-LiDAR-batch modes, then establish or reject `>3x` on a predeclared standard training
  configuration. Issue #5118 tracks the missing comparator helper.

## Contract delta

- **New config value:** `worker_mode: threaded_lidar_batch` for primary PPO with `num_envs > 1`.
- **New runtime behavior:** one fixed coordinator batches the static-obstacle portion of homogeneous
  LiDAR scans reached by all threaded environment-step workers; reset-time scans remain scalar.
- **New fail-closed blockers:** incompatible ray counts/dtypes/shapes, incomplete batches, insufficient
  worker count, and environment-step failures abort coordination rather than silently falling back.
- **Compatibility:** defaults remain unchanged. `auto` still selects subprocess mode for multiple
  environments; `threaded` remains unbatched; one-environment threaded modes resolve to the existing
  `DummyVecEnv` scalar fallback. Existing LiDAR arithmetic is unchanged.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4981

Refs #4981

## Scope and remaining acceptance

- [x] Stable-Baselines3-compatible multi-environment stepping exists (PR #5017).
- [x] Cross-environment static-obstacle LiDAR kernel is scalar-equivalent (PR #5102).
- [x] Homogeneous LiDAR collection is wired into an opt-in real rollout execution path (this PR).
- [x] Focused tests cover complete-observation equivalence, primary-PPO reset/step/close, malformed
  batch rejection, worker-count rejection, and the single-environment scalar fallback.
- [ ] A reproducible standard-config comparison includes dummy, subprocess, threaded, and
  threaded-LiDAR-batch modes.
- [ ] Measured rollout throughput exceeds the single-environment baseline by more than `3x`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation
claim edits.

## Validation / proof

- `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest -q
  tests/sensor/test_batched_lidar_kernel.py tests/test_range_sensor.py
  tests/training/test_threaded_vec_env.py tests/training/test_train_expert_ppo_contract.py
  tests/training/test_vector_env_matrix.py` — passed: 86 tests.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8
  PR_READY_PR_BODY_FILE=<body> scripts/dev/pr_ready_check.sh` — passed on clean committed head
  `0694c2915`: core 2,131 passed and 1 skipped; optional-extra 6,230 passed and 17 skipped; changed-file
  coverage 87.7% for `range_sensor.py` and 81.2% for `threaded_vec_env.py`, above the 80% floor;
  Ruff, docstring, broad-exception, and freshness gates passed.
- CPU diagnostic on `imech036`, `NUMBA_NUM_THREADS=8`, existing
  `configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml`, 10 warmup steps, 3 repetitions of 200
  VecEnv steps: single-env dummy median 4,737.7 transitions/s; four-env threaded median 3,435.1
  transitions/s (`0.73x`); four-env threaded-LiDAR-batch median 1,196.5 transitions/s (`0.25x`).
  This omitted subprocess mode and is **diagnostic-only, not acceptance evidence**.

## Risks and rollout

- Coordinated batching adds synchronization and per-step padding/copy overhead; the short diagnostic
  indicates it should remain experimental and opt-in.
- All participating environments must execute the same number of homogeneous LiDAR calls per step.
- The coordinator timeout is a failure bound, not a scalar fallback. Process isolation remains
  available through `worker_mode: subproc`.
- Rollback is removal of the new worker mode/coordinator binding; existing worker and sensor defaults
  do not depend on it.

## Domain-Aware Approval

- Required for this PR: yes - the PR reports a negative diagnostic timing result and preserves the
  parent throughput claim boundary.
- Domains reviewed: evidence classification, experimental comparison, benchmark interpretation
- Status: waived
- Approver/review source or waiver: author self-review waiver because no benchmark result is promoted;
  the diagnostic is explicitly incomplete and #4981 remains open for the predeclared four-mode run.
- Validity checklist:
  - Target claim/hypothesis: `>3x` standard-config rollout throughput remains unproven.
  - Comparator or split/evidence validity: the three-mode local loop is incomplete because it omits
    subprocess mode and uses a short smoke config; it is not acceptance evidence.
  - Fallback/degraded exclusions: no fallback or degraded execution is counted as success.
  - Claim boundary: tests prove integration/equivalence only; timing reports a negative diagnostic.
  - Implementation integrity vs experimental validity: focused/full tests prove behavior, while the
    eventual predeclared four-mode run must establish experimental validity.

<details>
<summary>Governance and reviewer appendix</summary>

### Acceptance evidence map

| Criterion | Evidence | Status |
| --- | --- | --- |
| VecEnv-compatible batched stepping | PR #5017 plus primary-PPO vector matrix test | Met |
| Numba LiDAR kernel batched across environments where explicitly selected | PR #5102 plus this PR's rollout coordinator and one-dispatch test | Met as opt-in capability |
| Bit-identical single-environment fallback | `threaded_lidar_batch` resolves to `DummyVecEnv`; scalar kernel fallback test | Met |
| `>3x` standard-config rollout throughput | No qualifying artifact; local three-mode diagnostic was below baseline | Not met |

### Research result guidance

- Target claim / hypothesis / blocker: blocker resolution for rollout integration; no positive
  throughput claim.
- Comparator or baseline: existing scalar LiDAR and one-environment dummy stepping.
- Evidence tier: implementation-integrity tests plus diagnostic-only timing.
- Result classification: partial progression; throughput acceptance remains open.
- Decision / stop rule: keep #4981 open until a four-mode reproducible comparison supports `>3x` or
  the implementation plan is revised from evidence.
- Synthesis/update target: #4981 and the vectorized-environment design/support notes.

### Fragmentation and progression

PRs #5017 and #5102 are progression slices, not guardrail/checker/packet refreshes. This successor
slice does not duplicate them; it adds the nameable capability **coordinated LiDAR collection during
real threaded rollouts**. The remaining work is one empirical comparison, not another micro-guard.

### State propagation and artifacts

- No separate issue comment is posted because this task explicitly disables issue/PR comments. The
  linked PR body is the only authorized durable status surface and records the remaining checklist.
- Generated `output/coverage/` data is disposable local validation output and is not committed.
- No benchmark, model, dataset, checkpoint, or paper-facing artifact is promoted.
- Friction issue #5118 tracks the missing reusable CPU VecEnv comparator.

### Forbidden actions

No compute submission, merge, release, deletion, or issue/PR comment was performed.

</details>
