### PR TITLE
fix(catalog): mark 41 legacy evidence entries to unblock catalog updates (#5116)

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -28,10 +28,12 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_1126_final_integration_2026-07-06.md
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_1134_closure_audit_2026-07-06.md
   status: evidence
   freshness: evidence
@@ -60,6 +62,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4018_density_curriculum_matched_smoke_2026-07-06/README.md
   status: evidence
   freshness: evidence
@@ -108,6 +111,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/issue_1475_state.yaml
   status: current
   freshness: maintained
@@ -165,6 +169,7 @@ entries:
   status: evidence
   freshness: evidence
   area: workflow_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/issue_4164_state.yaml
   status: current
   freshness: dated
@@ -193,6 +198,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4216_licca_full_suite_env_failures
   status: evidence
   freshness: evidence
@@ -221,6 +227,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4013_learned_model_based_planning/training_metrics.v1.json
   status: evidence
   freshness: evidence
@@ -229,6 +236,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4013_learned_model_based_planning/comparison_report.v1.md
   status: evidence
   freshness: evidence
@@ -245,6 +253,7 @@ entries:
   status: evidence
   freshness: evidence
   area: training
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4016_distributional_rl_smoke/distributional_rl_risk_comparison.md
   status: evidence
   freshness: evidence
@@ -253,22 +262,27 @@ entries:
   status: evidence
   freshness: evidence
   area: training
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4016_distributional_rl_smoke/acceptance_audit.md
   status: evidence
   freshness: evidence
   area: training
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4016_distributional_rl_smoke/qr_dqn_cvar_manifest.json
   status: evidence
   freshness: evidence
   area: training
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4016_distributional_rl_smoke/qr_dqn_mean_manifest.json
   status: evidence
   freshness: evidence
   area: training
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4016_distributional_rl_smoke/summary.json
   status: evidence
   freshness: evidence
   area: training
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4013_learned_model_based_planning/real_trajectory_readiness.v1.json
   status: evidence
   freshness: evidence
@@ -317,10 +331,12 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4163_static_constriction_rare_event_smoke/summary.json
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4166_release_gates/README.md
   status: evidence
   freshness: evidence
@@ -393,6 +409,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4183_hybrid_global_rl_diagnostic/paired_rows.csv
   status: evidence
   freshness: evidence
@@ -401,6 +418,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_3484_feasibility_diagnostics_2026-07-02/README.md
   status: evidence
   freshness: evidence
@@ -449,10 +467,12 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_3952_robustness_smoke/summary.json
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_3952_robustness_smoke/robustness_delta.csv
   status: evidence
   freshness: evidence
@@ -469,6 +489,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4011_rl_trajectory_dataset_smoke_2026-07-02/issue_4011_smoke.preview.jsonl
   status: evidence
   freshness: evidence
@@ -3387,6 +3408,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4245_offline_pretrain_finetune_smoke/README.md
   status: evidence
   freshness: evidence
@@ -3435,14 +3457,17 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_3556_seed_sufficiency_closure_2026-07-03/README.md
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_3556_seed_sufficiency_closure_2026-07-03/summary.json
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_3275_rerun_closure_2026-07-03/README.md
   status: evidence
   freshness: evidence
@@ -3451,14 +3476,17 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4328_h600_seed_sufficiency_candidates_2026-07-03/README.md
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4328_h600_seed_sufficiency_candidates_2026-07-03/summary.json
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4328_terminality_2026-07-04/README.md
   status: evidence
   freshness: evidence
@@ -3479,6 +3507,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_5034_control_action_latency_sweep_blocked_2026-07-10/README.md
   status: evidence
   freshness: evidence
@@ -3487,10 +3516,12 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4302_snqi_provenance_terminality_2026-07-04.md
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4366_manuscript_asserted_numbers_report.md
   status: evidence
   freshness: evidence
@@ -3503,6 +3534,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_3300_structured_false_positive_actor_injection_2026-07-04/false_positive_replay_report.md
   status: evidence
   freshness: evidence
@@ -3515,6 +3547,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_3190_closure_audit_2026-07-04/README.md
   status: evidence
   freshness: evidence
@@ -3535,6 +3568,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_3300_stronger_matrix_closure_audit_2026-07-04/false_positive_replay_report.md
   status: evidence
   freshness: evidence
@@ -3547,6 +3581,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4400_closure_audit_2026-07-04.md
   status: evidence
   freshness: evidence
@@ -3559,6 +3594,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_3207_integration_status_2026-07-05.md
   status: evidence
   freshness: evidence
@@ -3595,10 +3631,12 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_3204_closure_audit_20260705.json
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_2312_closure_audit.md
   status: evidence
   freshness: evidence
@@ -3615,6 +3653,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_4232_closure_audit_2026-07-06/README.md
   status: evidence
   freshness: evidence
@@ -4111,6 +4150,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_5020_dwa_archetype_matrix_2026-07-10
   status: evidence
   freshness: evidence
@@ -4119,6 +4159,7 @@ entries:
   status: evidence
   freshness: evidence
   area: benchmark_evidence
+  legacy_dirty_evidence: true
 - path: docs/context/evidence/issue_5020_dwa_archetype_matrix_2026-07-10/dwa_archetype_matrix_status_rows.csv
   status: evidence
   freshness: evidence

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -878,6 +878,89 @@ entries:
     assert diagnostics == []
 
 
+def test_clean_new_catalog_entry_passes_when_legacy_entries_exist(tmp_path: Path) -> None:
+    """A new clean evidence entry must not inherit failures from legacy dirty entries.
+
+    Regression for issue #5116: catalog updates inherited 41 pre-existing
+    ``output/`` evidence failures, blocking any otherwise-valid new row.
+    """
+    repo_root = tmp_path
+    (repo_root / "docs/context/evidence").mkdir(parents=True)
+
+    # Pre-existing entry that references output/ — marked legacy_dirty_evidence.
+    legacy = repo_root / "docs/context/evidence/legacy_report.json"
+    legacy.write_text('{"source": "output/local/report.json"}\n', encoding="utf-8")
+
+    # New clean entry with no output/ references.
+    clean = repo_root / "docs/context/evidence/new_clean_summary.json"
+    clean.write_text('{"status": "ok", "note": "no local paths here"}\n', encoding="utf-8")
+
+    catalog = repo_root / "docs/context/catalog.yaml"
+    catalog.write_text(
+        "version: 1\n"
+        "entries:\n"
+        "- path: docs/context/evidence/legacy_report.json\n"
+        "  status: evidence\n"
+        "  freshness: evidence\n"
+        "  legacy_dirty_evidence: true\n"
+        "- path: docs/context/evidence/new_clean_summary.json\n"
+        "  status: evidence\n"
+        "  freshness: evidence\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = _context_catalog_diagnostics(
+        Path("docs/context/catalog.yaml"),
+        repo_root=repo_root,
+    )
+
+    assert diagnostics == [], (
+        "Expected no diagnostics: legacy entry is marked and new entry is clean, "
+        f"but got: {diagnostics}"
+    )
+
+
+def test_new_dirty_evidence_entry_fails_even_with_legacy_entries(tmp_path: Path) -> None:
+    """A new dirty entry must still fail even when other legacy entries are marked.
+
+    Regression for issue #5116: the legacy_dirty_evidence escape hatch must not
+    suppress failures for newly added dirty entries.
+    """
+    repo_root = tmp_path
+    (repo_root / "docs/context/evidence").mkdir(parents=True)
+
+    # Pre-existing entry correctly marked as legacy.
+    legacy = repo_root / "docs/context/evidence/legacy_report.json"
+    legacy.write_text('{"source": "output/local/report.json"}\n', encoding="utf-8")
+
+    # New entry that also references output/ — but NOT marked legacy_dirty_evidence.
+    new_dirty = repo_root / "docs/context/evidence/new_dirty_report.json"
+    new_dirty.write_text('{"artifact": "output/run_123/result.json"}\n', encoding="utf-8")
+
+    catalog = repo_root / "docs/context/catalog.yaml"
+    catalog.write_text(
+        "version: 1\n"
+        "entries:\n"
+        "- path: docs/context/evidence/legacy_report.json\n"
+        "  status: evidence\n"
+        "  freshness: evidence\n"
+        "  legacy_dirty_evidence: true\n"
+        "- path: docs/context/evidence/new_dirty_report.json\n"
+        "  status: evidence\n"
+        "  freshness: evidence\n",
+        encoding="utf-8",
+    )
+
+    diagnostics = _context_catalog_diagnostics(
+        Path("docs/context/catalog.yaml"),
+        repo_root=repo_root,
+    )
+
+    assert any("ignored output/ artifacts" in d.message for d in diagnostics), (
+        "Expected a diagnostic for the new dirty entry, but none was reported."
+    )
+
+
 def test_context_catalog_skips_binary_evidence_scan(tmp_path: Path) -> None:
     """Binary evidence entries should not crash text-only provenance checks."""
     repo_root = tmp_path


### PR DESCRIPTION
## Reviewer-critical summary

**What changed**: Added `legacy_dirty_evidence: true` to 41 pre-existing catalog entries in
`docs/context/catalog.yaml` that contain `output/` paths in their evidence files. Added two
regression tests.

**Why now**: Issue #5116 — any PR adding a new catalog row was blocked by 41 pre-existing
failures from `check_docs_proof_consistency --check-context-catalog`. The `legacy_dirty_evidence`
escape hatch already existed in the validator (and had tests) but the 41 offending entries were
never marked.

**Claim boundary**: Catalog/validation metadata only. No benchmark metrics, no semantic change to
evidence content, no runtime behavior change.

**Required validation**:
```
BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh  # OK
uv run pytest tests/validation/test_check_docs_proof_consistency.py     # 48 passed
```

**Remaining blocker**: None. New clean catalog entries now pass without inheriting legacy failures.

## Contract delta

- `docs/context/catalog.yaml`: 41 entries with `status: evidence` now have `legacy_dirty_evidence: true`. No other fields changed.
- No new schema fields introduced (field pre-existed at line 431 of `check_docs_proof_consistency.py`).
- Strict rejection of newly added dirty evidence rows is unchanged (regression test confirms).

## Validation output

```
BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
OK docs/proof consistency check passed for 2 changed file(s).

uv run pytest tests/validation/test_check_docs_proof_consistency.py -x
48 passed in 0.55s
```

## Out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

CHANGELOG.md intentionally omitted: adding a CHANGELOG entry triggers pre-existing bare
issue-reference failures in old CHANGELOG entries (same class of inherited-debt). Tracked in
friction issue #5124.

Closes #5116


## Follow-Up Issues

- #5124 tracks the pre-existing CHANGELOG bare-issue-reference debt that makes a release-note update out of scope for this catalog repair.
