### PR TITLE
fix(benchmark): thread hybrid command sources (#5081)

### DIFF
--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -559,6 +559,7 @@ def _safety_predicates_for_episode(
     robot_headings: list[float],
     ped_pos_arr: np.ndarray,
     dt: float,
+    command_sources: list[str | None] | None = None,
     visibility_evidence: VisibilityEvidenceTrace | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Build diagnostic safety predicate records for a completed episode.
@@ -599,6 +600,7 @@ def _safety_predicates_for_episode(
             headings,
             speeds,
             dt=dt,
+            command_sources=command_sources,
         ),
         "late_evasive_predicate": late_evasive_predicate(
             hazard_distances,
@@ -1325,6 +1327,7 @@ def _compute_post_loop_metrics(  # noqa: PLR0913
     *,
     robot_positions: list[np.ndarray],
     robot_headings: list[float],
+    hybrid_command_sources: list[str | None] | None = None,
     ped_positions: list[np.ndarray],
     ped_forces: list[np.ndarray],
     visibility_trace: list[np.ndarray | None],
@@ -1390,6 +1393,7 @@ def _compute_post_loop_metrics(  # noqa: PLR0913
         robot_headings=robot_headings,
         ped_pos_arr=ped_pos_arr,
         dt=float(config.sim_config.time_per_step_in_secs),
+        command_sources=hybrid_command_sources,
         visibility_evidence=VisibilityEvidenceTrace(
             visibility=visibility_arr,
             track_confidence=track_confidence_arr,
@@ -1620,6 +1624,7 @@ class _EpisodeStepLoopResult:
     cbf_filter_trace: list[dict[str, Any]]
     ammv_command_actions: list[dict[str, Any]]
     synthetic_actuation_trace: list[dict[str, Any]]
+    hybrid_command_sources: list[str | None] | None
     planner_decision_trace: list[dict[str, Any]]
     simulation_step_trace: list[dict[str, Any]]
     view_integrity: dict[str, Any] | None
@@ -1669,6 +1674,16 @@ def _run_episode_step_loop(  # noqa: C901,PLR0912,PLR0913,PLR0915
     planner_runtime_snapshot: dict[str, Any] | None = None
     current_command = (0.0, 0.0)
     synthetic_actuation_trace: list[dict[str, Any]] = []
+    canonical_algorithm = (
+        str(algo_meta.get("canonical_algorithm", algo_meta.get("algorithm", ""))).strip().lower()
+    )
+    hybrid_source_field = {
+        "hybrid_portfolio": "selected_head",
+        "hybrid_rule_local_planner": "selected_source",
+    }.get(canonical_algorithm)
+    hybrid_command_sources: list[str | None] | None = (
+        [] if hybrid_source_field is not None else None
+    )
     planner_decision_trace: list[dict[str, Any]] = []
     simulation_step_trace: list[dict[str, Any]] = []
     visibility_trace: list[np.ndarray | None] = []
@@ -1755,7 +1770,11 @@ def _run_episode_step_loop(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     raise DegeneratePlannerViewError(integrity)
             actuation_step = None
             planner_step_decision = None
-            if record_planner_decision_trace and callable(planner_stats):
+            # Hybrid handoff telemetry is part of the episode predicate contract, so
+            # sample it even when the larger planner-decision trace is not requested.
+            if (record_planner_decision_trace or hybrid_command_sources is not None) and callable(
+                planner_stats
+            ):
                 try:
                     planner_runtime = planner_stats()
                 except (RuntimeError, ValueError, TypeError):
@@ -1764,6 +1783,14 @@ def _run_episode_step_loop(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     planner_runtime.get("last_decision"), dict
                 ):
                     planner_step_decision = dict(planner_runtime["last_decision"])
+            if hybrid_command_sources is not None:
+                source = (
+                    planner_step_decision.get(hybrid_source_field)
+                    if planner_step_decision is not None and hybrid_source_field is not None
+                    else None
+                )
+                normalized_source = str(source).strip() if source is not None else ""
+                hybrid_command_sources.append(normalized_source or None)
             # Use per-step flag when available (e.g. SAC with fallback); fall back to the
             # static cached value for planners that set _planner_native_env_action once.
             step_is_native = getattr(policy_fn, "_last_step_native", planner_native_action)
@@ -1959,7 +1986,7 @@ def _run_episode_step_loop(  # noqa: C901,PLR0912,PLR0913,PLR0915
                         "robot_y_m": float(robot_pos[1]),
                     }
                 )
-            if planner_step_decision is not None:
+            if record_planner_decision_trace and planner_step_decision is not None:
                 selected_terms = planner_step_decision.get("selected_terms")
                 selected_terms = selected_terms if isinstance(selected_terms, dict) else {}
                 progress_windows_raw = planner_step_decision.get("progress_windows")
@@ -2115,6 +2142,7 @@ def _run_episode_step_loop(  # noqa: C901,PLR0912,PLR0913,PLR0915
         cbf_filter_trace=cbf_filter_trace,
         ammv_command_actions=ammv_command_actions,
         synthetic_actuation_trace=synthetic_actuation_trace,
+        hybrid_command_sources=hybrid_command_sources,
         planner_decision_trace=planner_decision_trace,
         simulation_step_trace=simulation_step_trace,
         view_integrity=view_integrity,
@@ -2626,6 +2654,7 @@ def run_map_episode(  # noqa: PLR0913
     post_loop = _compute_post_loop_metrics(
         robot_positions=loop_result.robot_positions,
         robot_headings=loop_result.robot_headings,
+        hybrid_command_sources=loop_result.hybrid_command_sources,
         ped_positions=loop_result.ped_positions,
         ped_forces=loop_result.ped_forces,
         visibility_trace=loop_result.visibility_trace,

--- a/robot_sf/benchmark/safety_predicates.py
+++ b/robot_sf/benchmark/safety_predicates.py
@@ -67,7 +67,9 @@ def oscillatory_control_predicate(
         headings: ``(N,)`` robot headings (radians); unwrapped internally.
         linear_velocities: ``(N,)`` signed forward velocity (m/s).
         dt: Per-step timestep (s, > 0).
-        command_sources: Optional ``(N,)`` per-step command-source labels.
+        command_sources: Optional ``(N,)`` per-step command-source labels. A ``None``
+            label marks unavailable evidence for that step; transitions touching it
+            are not counted.
         min_heading_rate_sign_changes: Classification threshold on heading-rate flips.
         max_progress_ratio: Classification threshold on net/path progress ratio.
 
@@ -97,7 +99,13 @@ def oscillatory_control_predicate(
 
     command_source_changes = 0
     if command_sources is not None:
-        command_source_changes = int(sum(1 for a, b in pairwise(command_sources) if a != b))
+        command_source_changes = int(
+            sum(
+                1
+                for a, b in pairwise(command_sources)
+                if a is not None and b is not None and a != b
+            )
+        )
 
     step_vectors = np.diff(pos, axis=0)
     path_length = float(np.sum(np.linalg.norm(step_vectors, axis=1)))

--- a/tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py
+++ b/tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py
@@ -26,23 +26,17 @@ What this module proves
   :func:`~robot_sf.benchmark.safety_predicates.oscillatory_control_predicate` and shows a
   **nonzero** ``command_source_changes`` — the mechanism *does* produce a countable
   handoff when the telemetry is actually populated.
-* ``test_episode_runner_callsite_always_reports_zero`` pins the root cause of the
-  0/1,165 field result: the episode runner
-  (``robot_sf/benchmark/map_runner_episode.py:597``) calls
-  ``oscillatory_control_predicate(positions, headings, speeds, dt=dt)`` and never passes
-  ``command_sources``. With that optional signal absent, ``command_source_changes`` is
-  hard-wired to 0 (``safety_predicates.py:98-100``) for *every* episode, regardless of
-  how many real head handoffs occurred.
+* ``test_absent_command_sources_remain_backward_compatible`` preserves the predicate's
+  original zero-valued behavior for non-hybrid callers that do not provide the optional
+  command-source signal.
 
 Classification of the 0/1,165 result
 -------------------------------------
 **Telemetry failure (wiring gap), not genuine non-activation.** The arbitration mechanism
 is reachable and, when its per-step source labels are threaded through, yields a nonzero
-count (first two tests). The retained-trace surface reports 0 only because the runner
-never supplies ``command_sources`` to the predicate (third test). Wiring the per-step
-planner source into the episode runner changes benchmark telemetry output and is therefore
-deferred as post-freeze work (freeze 2026-07-18); see
-``docs/context/issue_5001_state.yaml``.
+count (first two tests). The retained-trace surface reported 0 because the runner did not
+supply ``command_sources`` to the predicate. Issue #5081 repairs that runner wiring while
+this predecessor module keeps the original activation and compatibility evidence.
 
 This module changes no benchmark metric semantics: it only reads existing production code
 and the existing optional predicate signal.
@@ -223,26 +217,12 @@ def test_command_source_changes_counted_when_wired() -> None:
     assert result["fields"]["command_source_changes"] > 0
 
 
-def test_episode_runner_callsite_always_reports_zero() -> None:
-    """The runner's argument signature structurally forces a zero change count.
-
-    This replicates ``map_runner_episode.py:597`` — ``oscillatory_control_predicate``
-    is called with positions/headings/speeds and ``dt`` but *without*
-    ``command_sources``. This is the root cause of the 0/1,165 field result: with the
-    optional signal absent, ``command_source_changes`` is 0 for every episode no matter
-    how many real head handoffs occurred, so the retained-trace 0/1,165 is a telemetry
-    gap, not evidence of genuine non-activation.
-    """
-    adapter = _build_adapter()
-    heads, _commands = _drive(adapter)
-    # Sanity: the underlying mechanism genuinely handed off in this scenario.
-    assert any(a != b for a, b in pairwise(heads))
-
-    n = len(heads)
+def test_absent_command_sources_remain_backward_compatible() -> None:
+    """Non-hybrid callers without source telemetry should retain a zero count."""
+    n = len(_EXPECTED_HEADS)
     positions = np.array([[float(i), 0.0] for i in range(n)])
     headings = np.zeros(n)
     speeds = np.ones(n)
 
-    # Exact episode-runner call signature (no command_sources).
     result = oscillatory_control_predicate(positions, headings, speeds, dt=0.1)
     assert result["fields"]["command_source_changes"] == 0

--- a/tests/benchmark/test_map_runner_decomposition_helpers.py
+++ b/tests/benchmark/test_map_runner_decomposition_helpers.py
@@ -681,8 +681,111 @@ class TestRunEpisodeStepLoop:
         assert result.termination_reason == "success"
         assert result.planner_runtime_snapshot is None
         assert result.view_integrity is not None
+        assert result.hybrid_command_sources is None
         # AMMV command actions must record the single selected action payload.
         assert len(result.ammv_command_actions) == 1
+
+    @pytest.mark.parametrize(
+        ("canonical_algorithm", "source_key", "sources"),
+        [
+            ("hybrid_portfolio", "selected_head", ["risk_dwa", "orca", "prediction"]),
+            (
+                "hybrid_rule_local_planner",
+                "selected_source",
+                ["dynamic_window", "path_follow", "dynamic_window"],
+            ),
+        ],
+    )
+    def test_step_loop_collects_aligned_hybrid_sources_without_trace_flag(
+        self,
+        monkeypatch,
+        canonical_algorithm: str,
+        source_key: str,
+        sources: list[str],
+    ) -> None:
+        """Both hybrid families must emit one normalized source per executed step."""
+        import robot_sf.benchmark.map_runner_episode as mod
+
+        class _ThreeStepEnv(_StepLoopDummyEnv):
+            def __init__(self) -> None:
+                super().__init__()
+                self.step_index = 0
+
+            def step(self, action):
+                _ = action
+                self.step_index += 1
+                self.simulator.robot_pos[0] = np.array([0.1 * self.step_index, 0.0])
+                terminated = self.step_index == len(sources)
+                obs = {
+                    "robot": {"position": self.simulator.robot_pos[0].tolist()},
+                    "goal": {"current": [1.0, 1.0]},
+                }
+                return (
+                    obs,
+                    0.0,
+                    terminated,
+                    False,
+                    {
+                        "success": terminated,
+                        "meta": {"is_route_complete": terminated},
+                    },
+                )
+
+        decision: dict[str, str] = {}
+        policy_calls = 0
+
+        def _policy(obs):
+            nonlocal policy_calls
+            _ = obs
+            decision.clear()
+            decision[source_key] = sources[policy_calls]
+            policy_calls += 1
+            return 0.5, 0.0
+
+        def _planner_stats() -> dict[str, object]:
+            return {"last_decision": dict(decision)}
+
+        monkeypatch.setattr(mod, "make_robot_env", lambda config, seed, debug: _ThreeStepEnv())
+        result = _run_episode_step_loop(
+            seed=1,
+            config=_stub_config(),
+            horizon_val=len(sources),
+            policy_fn=_policy,
+            planner_bind_env=None,
+            planner_reset=None,
+            planner_close=None,
+            planner_stats=_planner_stats,
+            planner_native_action=False,
+            noise_spec={"enabled": False},
+            noise_rng=None,
+            noise_state=None,
+            noise_stats={},
+            tracking_precision_spec={"enabled": False, "target_motp_m": 0.05},
+            tracking_precision_rng=None,
+            safety_wrapper_runtime=mod.runtime_config_from_mapping(None),
+            safety_wrapper_deadlock_monitor=None,
+            cbf_runtime=mod.cbf_runtime_config_from_mapping(None),
+            actuation_controller=None,
+            algo_meta={"canonical_algorithm": canonical_algorithm},
+            record_forces=False,
+            record_planner_decision_trace=False,
+            record_simulation_step_trace=False,
+            single_pedestrian_intent_metadata=[],
+            single_pedestrian_vru_metadata=[],
+        )
+
+        assert result.hybrid_command_sources == sources
+        assert len(result.hybrid_command_sources) == len(result.robot_positions)
+        assert result.planner_decision_trace == []
+        predicate = mod._safety_predicates_for_episode(
+            robot_pos_arr=np.asarray(result.robot_positions),
+            robot_vel_arr=np.tile(np.asarray([[0.5, 0.0]]), (len(sources), 1)),
+            robot_headings=result.robot_headings,
+            ped_pos_arr=np.zeros((len(sources), 0, 2), dtype=float),
+            dt=0.1,
+            command_sources=result.hybrid_command_sources,
+        )
+        assert predicate["oscillatory_control_predicate"]["fields"]["command_source_changes"] == 2
 
 
 class TestFinalizeEpisodeRecord:

--- a/tests/benchmark/test_map_runner_safety_predicates.py
+++ b/tests/benchmark/test_map_runner_safety_predicates.py
@@ -65,3 +65,23 @@ def test_map_runner_safety_predicates_feed_event_ledger_surrogates() -> None:
         surrogate_events["oscillatory_control_predicate"]["schema_version"]
         == "safety_predicate.oscillatory_control.v1"
     )
+
+
+def test_map_runner_threads_aligned_command_sources_into_oscillation_fields() -> None:
+    """Hybrid source handoffs should reach the emitted predicate record."""
+    robot_pos_arr = np.asarray([[float(step), 0.0] for step in range(5)])
+    robot_vel_arr = np.tile(np.asarray([[1.0, 0.0]]), (5, 1))
+    ped_pos_arr = np.zeros((5, 0, 2), dtype=float)
+
+    predicates = _safety_predicates_for_episode(
+        robot_pos_arr=robot_pos_arr,
+        robot_vel_arr=robot_vel_arr,
+        robot_headings=[0.0] * 5,
+        ped_pos_arr=ped_pos_arr,
+        dt=0.1,
+        command_sources=["risk_dwa", "orca", None, "prediction", "risk_dwa"],
+    )
+
+    # The missing third-step label blocks only the two transitions touching it;
+    # it must not create artificial handoffs or shift source/trajectory alignment.
+    assert predicates["oscillatory_control_predicate"]["fields"]["command_source_changes"] == 2

--- a/tests/benchmark/test_safety_predicates.py
+++ b/tests/benchmark/test_safety_predicates.py
@@ -73,6 +73,16 @@ def test_command_source_changes_are_counted() -> None:
     assert result["fields"]["command_source_changes"] == 2
 
 
+def test_command_sources_must_align_with_trajectory_steps() -> None:
+    """A shifted or truncated source trace must fail closed instead of miscounting."""
+    with pytest.raises(ValueError, match="command_sources must have length N"):
+        oscillatory_control_predicate(
+            **_straight_trajectory(),
+            dt=_DT,
+            command_sources=["planner", "fallback"],
+        )
+
+
 def test_velocity_sign_changes_counted() -> None:
     """Linear-velocity sign changes must reflect forward/reverse oscillation."""
     result = oscillatory_control_predicate(**_oscillatory_trajectory(), dt=_DT)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** the map episode runner now samples one command-source label per executed step for both supported hybrid families (`selected_head` for `hybrid_portfolio`, `selected_source` for the canonical hybrid-rule family) and passes the aligned sequence into `oscillatory_control_predicate`.
- **Why now:** the retained `0 command_source_changes` result was proven in #5068 to be structurally forced by missing runner wiring; this PR repairs that production path.
- **Claim boundary:** targeted implementation and diagnostic evidence only. This does not establish hybrid effectiveness or produce new benchmark-strength results.
- **Required validation:** focused hybrid/predicate tests plus `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` on the committed head.
- **Remaining blocker:** none for the code/CPU scope. A fresh full campaign through the patched runner was not run and is outside this authorized session.

## Contract delta

- **Schema fields:** none. The existing `safety_predicate.oscillatory_control.v1` field `fields.command_source_changes` now reflects real, adjacent hybrid source handoffs instead of a structurally forced zero.
- **Fail-closed behavior:** source/trajectory length mismatches still raise `ValueError`; unavailable labels stay aligned as `None`, and transitions touching missing evidence are excluded rather than counted as artificial handoffs.
- **Compatibility:** non-hybrid episodes retain the prior optional-source path and zero default. The optional planner-decision trace remains disabled when not requested. Hybrid episodes now sample lightweight planner diagnostics each step even when the larger trace is off.

## Linked issue and scope

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5081
- Closes #5081
- Scope delivered: complete runner wiring, both-family normalization, alignment/missing-evidence safeguards, regression tests, and a CPU-only retained-trace diagnostic.
- Base dependency: #5068 supplied the activation/wiring-gap evidence; this PR is independently reviewable on current `main`.

## What changed

- Added an episode-local `hybrid_command_sources` buffer keyed by canonical algorithm metadata.
- Sampled hybrid diagnostics independently of `record_planner_decision_trace`, while preserving that trace flag's existing behavior.
- Threaded the buffer through post-loop metrics into `oscillatory_control_predicate`.
- Updated predecessor coverage so absent/non-hybrid sources remain backward compatible.
- Added both-family production-loop tests, a missing-label case, and a source/trajectory length-mismatch failure test.

## Validation / proof

- `uv run pytest -q tests/benchmark/test_safety_predicates.py tests/benchmark/test_map_runner_safety_predicates.py tests/benchmark/test_hybrid_arbitration_activation_issue_5001.py tests/benchmark/test_map_runner_decomposition_helpers.py` — **103 passed, 1 skipped**.
- Focused rerun after the trace-flag compatibility fix — **40 passed**.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (interim dirty-tree proof) — **2,124 passed, 1 skipped; Ruff and repository ratchets passed**.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after merging the latest `origin/main` — **2,132 core passed (1 skipped), 6,231 optional passed (17 skipped), 100% changed-line coverage; clean committed-head stamp**.

### Retained-trace diagnostic (not benchmark evidence)

Input: the local retained issue-4206 h600 trace-capable rerun used by #4914. This is a trace backfill through preserved planner-decision labels, **not output from the patched runner**.

- 2,400 episode rows; 240 unique scenario/seed pairs; zero missing source steps.
- `hybrid_rule_v3_fast_progress_static_escape`: 1,165/1,200 episodes with nonzero handoffs, 9,390 total, range 0–31.
- `scenario_adaptive_hybrid_orca_v1`: 1,140/1,200 episodes with nonzero handoffs, 9,235 total, range 0–31.
- Example maximum for both retained lanes: `classic_station_platform_medium`, seed 22, 594 source steps, 31 handoffs.
- Example zero for both retained lanes: `classic_head_on_corridor_low`, seed 20, one source step, zero handoffs.
- Derived per-episode local JSONL checksum: `7fc882af9e4dcdb87696ffd58c2708806616177da3dd77e5adb2369bef956610`.

Artifact classification: the 904 KiB derived JSONL stays ignored under `output/issue_5081/`; it is not durable proof because its retained input is local-only. The summary above is diagnostic-only and no fallback/degraded row is presented as benchmark success.

## Risks / reviewer focus

- Verify hybrid source sampling occurs once per successfully executed step and remains aligned with trajectory arrays.
- Verify `record_planner_decision_trace=False` still leaves the optional trace empty.
- The only runtime overhead change is one existing diagnostics snapshot per hybrid step.
- Rollback is the single runner/predicate commit; no schema migration or stored-data rewrite is required.

<details>
<summary>Governance and propagation appendix</summary>

### Research result guidance

- Target blocker: structurally forced zero hybrid handoff telemetry.
- Comparator: prior runner path without `command_sources`.
- Evidence tier: targeted smoke + diagnostic retained-trace backfill.
- Result classification: blocker-resolution; retained data remains diagnostic-only.
- Decision: close the wiring issue when implementation/CI gates pass. A future campaign may measure patched-runner values but is not needed to prove the wiring contract.
- Parent/synthesis surface: #5081 and predecessor #5001/#5068. No paper or leaderboard surface is updated.

### Domain-aware approval

- Required for this PR: yes - benchmark telemetry values change.
- Domains reviewed: benchmark interpretation and evidence classification.
- Status: waived.
- Approver/review source or waiver: the active maintainer task explicitly assigns full domain/PR approval to the post-open gate on `imech156-u`; this waiver permits PR opening only and is not merge approval.
- Validity checklist:
  - Target claim/hypothesis: hybrid source handoffs reach the existing episode telemetry field.
  - Comparator or split/evidence validity: prior runner omitted the source argument; focused tests compare the repaired path with absent-source compatibility.
  - Fallback/degraded exclusions: none used as success evidence.
  - Claim boundary: implementation correctness and diagnostic backfill only; no effectiveness conclusion.
  - Implementation integrity vs experimental validity: tests/readiness prove wiring integrity; fresh campaign validity remains outside this PR's claim.

### Falsification / next empirical action

- Mechanism activation: yes, deterministic predecessor fixture.
- Command source changed: yes in focused tests and retained trace labels.
- Fresh patched-runner campaign: not run.
- Route: continue with normal review/CI; optionally run a bounded patched-runner sample after merge if a downstream analysis needs fresh telemetry.
- No extractor or child issue is required for closure.

### Follow-Up Issues

- Deferred work: none required for issue closure.
- Issues opened for follow-up: none.
- Maintainer waiver: the active task explicitly excludes full campaigns and declares an issue complete when the only possible remainder is a campaign run; no follow-up issue is required for that optional empirical action.

### Downstream propagation

- Parent issue comment: no; `comment_issue_or_pr` authorization is false.
- Claim map / benchmark report / leaderboard / registry / context index: not applicable because this PR repairs telemetry wiring without promoting a benchmark or paper claim.
- Durable state propagation: this closing PR body is the canonical delivery/diagnostic summary; no tracked queue/host/packet state was added.
- Follow-up issues: none. The only excluded remainder is a fresh campaign run, which the task explicitly excludes from completion.

### Explicit out-of-scope confirmation

- No full benchmark campaign run.
- No Slurm or GPU submission.
- No paper/dissertation claim edits.
- No merge, release, or deletion.
- No transient target-host or packet-lineage state committed.

</details>
