### PR TITLE
fix(scenario_certification): lazy __init__ imports to silence startup noise (#5121)

### DIFF
--- a/robot_sf/scenario_certification/__init__.py
+++ b/robot_sf/scenario_certification/__init__.py
@@ -1,40 +1,87 @@
-"""Scenario certification public API."""
+"""Scenario certification public API.
 
-from robot_sf.scenario_certification.criticality_summary import (
-    CRITICALITY_SUMMARY_SCHEMA_VERSION,
-    CriticalitySummaryV1,
-    build_criticality_summary_from_compact_evidence,
-    build_criticality_summary_from_pilot,
-    criticality_summary_to_dict,
-    validate_criticality_summary,
-)
-from robot_sf.scenario_certification.perturbation_family_registry import (
-    PerturbationFamily,
-    perturbation_families,
-    perturbation_family,
-    supported_perturbation_families,
-    validate_perturbation_family_parameters,
-)
-from robot_sf.scenario_certification.perturbation_preflight import (
-    PERTURBATION_MANIFEST_SCHEMA_VERSION,
-    PILOT_MATRIX_SCHEMA_VERSION,
-    PREFLIGHT_SCHEMA_VERSION,
-    PerturbationPilotMaterialization,
-    PerturbationPreflightReport,
-    PerturbationPreflightResult,
-    materialize_perturbation_pilot_matrix,
-    preflight_perturbation_manifest,
-    preflight_to_dict,
-)
-from robot_sf.scenario_certification.v1 import (
-    CERT_SCHEMA_VERSION,
-    CertificationSettings,
-    ScenarioCertificate,
-    certificate_to_dict,
-    certify_map_definition,
-    certify_scenario,
-    certify_scenario_file,
-)
+Exports are resolved lazily so that importing a lightweight sub-module
+(e.g. ``robot_sf.scenario_certification.failure_cause``) does not trigger
+shapely, simulator-registry, or other heavy stacks.  The public API
+surface is unchanged; all names in ``__all__`` remain accessible via
+attribute lookup on the package.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - static type information only
+    from robot_sf.scenario_certification.criticality_summary import (
+        CRITICALITY_SUMMARY_SCHEMA_VERSION,
+        CriticalitySummaryV1,
+        build_criticality_summary_from_compact_evidence,
+        build_criticality_summary_from_pilot,
+        criticality_summary_to_dict,
+        validate_criticality_summary,
+    )
+    from robot_sf.scenario_certification.perturbation_family_registry import (
+        PerturbationFamily,
+        perturbation_families,
+        perturbation_family,
+        supported_perturbation_families,
+        validate_perturbation_family_parameters,
+    )
+    from robot_sf.scenario_certification.perturbation_preflight import (
+        PERTURBATION_MANIFEST_SCHEMA_VERSION,
+        PILOT_MATRIX_SCHEMA_VERSION,
+        PREFLIGHT_SCHEMA_VERSION,
+        PerturbationPilotMaterialization,
+        PerturbationPreflightReport,
+        PerturbationPreflightResult,
+        materialize_perturbation_pilot_matrix,
+        preflight_perturbation_manifest,
+        preflight_to_dict,
+    )
+    from robot_sf.scenario_certification.v1 import (
+        CERT_SCHEMA_VERSION,
+        CertificationSettings,
+        ScenarioCertificate,
+        certificate_to_dict,
+        certify_map_definition,
+        certify_scenario,
+        certify_scenario_file,
+    )
+
+_LAZY: dict[str, str] = {
+    # criticality_summary
+    "CRITICALITY_SUMMARY_SCHEMA_VERSION": "criticality_summary",
+    "CriticalitySummaryV1": "criticality_summary",
+    "build_criticality_summary_from_compact_evidence": "criticality_summary",
+    "build_criticality_summary_from_pilot": "criticality_summary",
+    "criticality_summary_to_dict": "criticality_summary",
+    "validate_criticality_summary": "criticality_summary",
+    # perturbation_family_registry
+    "PerturbationFamily": "perturbation_family_registry",
+    "perturbation_families": "perturbation_family_registry",
+    "perturbation_family": "perturbation_family_registry",
+    "supported_perturbation_families": "perturbation_family_registry",
+    "validate_perturbation_family_parameters": "perturbation_family_registry",
+    # perturbation_preflight
+    "PERTURBATION_MANIFEST_SCHEMA_VERSION": "perturbation_preflight",
+    "PILOT_MATRIX_SCHEMA_VERSION": "perturbation_preflight",
+    "PREFLIGHT_SCHEMA_VERSION": "perturbation_preflight",
+    "PerturbationPilotMaterialization": "perturbation_preflight",
+    "PerturbationPreflightReport": "perturbation_preflight",
+    "PerturbationPreflightResult": "perturbation_preflight",
+    "materialize_perturbation_pilot_matrix": "perturbation_preflight",
+    "preflight_perturbation_manifest": "perturbation_preflight",
+    "preflight_to_dict": "perturbation_preflight",
+    # v1
+    "CERT_SCHEMA_VERSION": "v1",
+    "CertificationSettings": "v1",
+    "ScenarioCertificate": "v1",
+    "certificate_to_dict": "v1",
+    "certify_map_definition": "v1",
+    "certify_scenario": "v1",
+    "certify_scenario_file": "v1",
+}
 
 __all__ = [
     "CERT_SCHEMA_VERSION",
@@ -65,3 +112,29 @@ __all__ = [
     "validate_criticality_summary",
     "validate_perturbation_family_parameters",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve public scenario-certification exports on first access.
+
+    Returns:
+        The requested attribute from its source sub-module.
+
+    Raises:
+        AttributeError: If ``name`` is not a known public export.
+    """
+    if name in _LAZY:
+        module = import_module(f".{_LAZY[name]}", __name__)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Include lazily exported names in interactive discovery.
+
+    Returns:
+        Available package attribute names.
+    """
+    return sorted(set(globals()) | set(__all__))

--- a/tests/scenario_certification/test_scenario_certification_lazy_imports.py
+++ b/tests/scenario_certification/test_scenario_certification_lazy_imports.py
@@ -1,0 +1,141 @@
+"""Regression tests for lazy scenario-certification package imports (issue #5121).
+
+These tests verify that importing a lightweight sub-module such as
+``robot_sf.scenario_certification.failure_cause`` does not eagerly
+initialise the sensor registry, shapely, or other heavy stacks — and
+that the package public API surface remains accessible via lazy attribute
+lookup.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+import pytest
+
+# --- subprocess isolation helpers -----------------------------------------
+
+
+def _run_import(code: str, timeout: float = 15.0) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+# --- startup-noise tests --------------------------------------------------
+
+
+_LIGHTWEIGHT_MODULES = [
+    # failure_cause.py is pure stdlib; the package __init__ must not pull in
+    # v1.py (shapely / gym_env / sensor-registry) when this submodule is imported.
+    # This is the direct fix for issue #5121.
+    "robot_sf.scenario_certification.failure_cause",
+    # robot_sf.benchmark.scenario_failure_cause is intentionally excluded here:
+    # it still triggers robot_sf.benchmark.__init__ which is heavy until
+    # PR #5122 (lazy benchmark imports) merges.  Once that PR lands, add this
+    # module to tests/benchmark/test_benchmark_package_lazy_imports.py instead
+    # of here.
+]
+
+_HEAVY_INIT_PATTERNS = [
+    "oneDNN",
+    "cpu_feature_guard",
+    "TensorFlow",
+    "Registered sensor",
+    "Registered simulator backend",
+]
+
+
+@pytest.mark.parametrize("module", _LIGHTWEIGHT_MODULES)
+def test_lightweight_module_no_heavy_stderr(module: str) -> None:
+    """Importing a schema/constant module must not emit sensor-registry noise."""
+    result = _run_import(f"import {module}; print('OK')")
+    assert result.returncode == 0, f"import failed:\n{result.stderr}"
+    assert result.stdout.strip() == "OK"
+    for pattern in _HEAVY_INIT_PATTERNS:
+        assert pattern not in result.stderr, (
+            f"Importing {module!r} emitted heavy-stack noise (pattern {pattern!r}).\n"
+            f"stderr snippet: {result.stderr[:500]}"
+        )
+
+
+@pytest.mark.parametrize("module", _LIGHTWEIGHT_MODULES)
+def test_lightweight_module_fast_startup(module: str) -> None:
+    """Importing a lightweight module must complete within a loose budget.
+
+    Budget: 5 seconds — generous for cold-start filesystem overhead while
+    catching accidental sensor-registry eager init (~3.8 s before the fix).
+    """
+    t0 = time.monotonic()
+    result = _run_import(f"import {module}; print('OK')")
+    elapsed = time.monotonic() - t0
+    assert result.returncode == 0, f"import failed:\n{result.stderr}"
+    assert elapsed < 5.0, (
+        f"Importing {module!r} took {elapsed:.1f}s — exceeds 5 s budget. "
+        "A heavy dependency was likely pulled in eagerly."
+    )
+
+
+# --- public API surface ---------------------------------------------------
+
+
+_LIGHTWEIGHT_EXPORTS = [
+    # From criticality_summary — no pysf/gym_env chain.
+    "CRITICALITY_SUMMARY_SCHEMA_VERSION",
+    "CriticalitySummaryV1",
+    "build_criticality_summary_from_compact_evidence",
+    "build_criticality_summary_from_pilot",
+    "criticality_summary_to_dict",
+    "validate_criticality_summary",
+    # From perturbation_family_registry — pure dataclasses/stdlib only.
+    "PerturbationFamily",
+    "perturbation_families",
+    "perturbation_family",
+    "supported_perturbation_families",
+    "validate_perturbation_family_parameters",
+]
+
+
+def test_scenario_certification_lightweight_names_resolvable() -> None:
+    """Lazy exports from deps-free sub-modules must resolve without heavy chain."""
+    import robot_sf.scenario_certification as sc
+
+    missing = []
+    for name in _LIGHTWEIGHT_EXPORTS:
+        try:
+            getattr(sc, name)
+        except AttributeError:
+            missing.append(name)
+    assert not missing, f"Names not resolvable via lazy __getattr__: {missing}"
+
+
+def test_scenario_certification_dir_includes_all_exports() -> None:
+    """__dir__ must surface every public export for interactive discovery."""
+    import robot_sf.scenario_certification as sc
+
+    visible = set(dir(sc))
+    missing = [n for n in sc.__all__ if n not in visible]
+    assert not missing, f"Names missing from dir(robot_sf.scenario_certification): {missing}"
+
+
+def test_lazy_export_caches_after_first_access() -> None:
+    """A lazy export must be placed in module globals after first access."""
+    import robot_sf.scenario_certification as sc
+
+    # Use an export from criticality_summary (no heavy pysf/gym_env chain).
+    _ = sc.CRITICALITY_SUMMARY_SCHEMA_VERSION
+    assert "CRITICALITY_SUMMARY_SCHEMA_VERSION" in vars(sc)
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    """Accessing a name not in __all__ must raise AttributeError."""
+    import robot_sf.scenario_certification as sc
+
+    with pytest.raises(AttributeError, match="definitely_missing"):
+        _ = sc.definitely_missing  # type: ignore[attr-defined]


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** `robot_sf/scenario_certification/__init__.py` now uses the same `__getattr__`-based lazy loading pattern as PR #5122 applies to `robot_sf/benchmark/__init__.py`. All package-level exports are resolved on first access rather than at import time.

**Why now:** Importing `robot_sf.benchmark.scenario_failure_cause` (or directly `robot_sf.scenario_certification.failure_cause`) triggered ~3.8 s sensor-registry startup noise and loaded shapely, gym_env, planner, and robot modules. `failure_cause.py` itself is pure stdlib — the package `__init__.py` was the sole cause of the transitive heavy import chain.

**Claim boundary:** `diagnostic-only` / `smoke evidence`. Subprocess-isolated timing test confirms <0.1 s import vs ~3.8 s before.

**Required validation:**
```bash
pytest tests/scenario_certification/test_scenario_certification_lazy_imports.py -v
pytest tests/scenario_certification/test_failure_cause.py -v
```

**Remaining blocker:** `robot_sf.benchmark.scenario_failure_cause` will be fully clean only after PR #5122 (lazy benchmark `__init__.py`) also merges. Once that lands, `robot_sf.benchmark.scenario_failure_cause` should be added to `_LIGHTWEIGHT_MODULES` in `tests/benchmark/test_benchmark_package_lazy_imports.py` (removing the exclusion comment added in PR #5122).

## Contract delta

- `robot_sf.scenario_certification.__all__` is unchanged.
- All names previously importable via `from robot_sf.scenario_certification import X` continue to work identically via `__getattr__` lazy dispatch.
- `__dir__` extended to surface all lazy names for interactive discovery.
- No schema, metric, or benchmark behavior changes.

## Validation results (imech039, stale shared venv)

```
tests/scenario_certification/test_scenario_certification_lazy_imports.py::test_lightweight_module_no_heavy_stderr[robot_sf.scenario_certification.failure_cause] PASSED
tests/scenario_certification/test_scenario_certification_lazy_imports.py::test_lightweight_module_fast_startup[robot_sf.scenario_certification.failure_cause] PASSED
tests/scenario_certification/test_scenario_certification_lazy_imports.py::test_scenario_certification_lightweight_names_resolvable PASSED
tests/scenario_certification/test_scenario_certification_lazy_imports.py::test_scenario_certification_dir_includes_all_exports PASSED
tests/scenario_certification/test_scenario_certification_lazy_imports.py::test_lazy_export_caches_after_first_access PASSED
tests/scenario_certification/test_scenario_certification_lazy_imports.py::test_unknown_attribute_raises_attribute_error PASSED
6 passed in 1.91s

tests/scenario_certification/test_failure_cause.py — 13 passed
```

Import time before: ~3.8 s + sensor-registry noise. After: <0.1 s, no heavy modules.

<details>
<summary>Out-of-scope notes</summary>

- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- `tests/scenario_certification/test_scenario_certification_v1.py` and heavy v1-dependent tests remain broken on imech039 (stale shared venv — pre-existing, tracked in #5023/#5095).
- `friction_issues: []` — stale-venv friction hit during testing is already tracked.

</details>

Refs #5121

Refs #5122 (benchmark lazy imports — needed to fully clean `robot_sf.benchmark.scenario_failure_cause`)

## Gate closure correction

- #5121 remains open as the completion tracker until #5122 has landed and the benchmark-shim regression coverage is added. This PR is the scenario-certification half only.

