### PR TITLE
feat(validation): add CPU VecEnv worker-mode throughput comparator (#5118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* **issue #5118 CPU VecEnv worker-mode throughput comparator.**
+* **issue #5118 CPU vectorized environment (VecEnv) worker-mode throughput comparator.**
   `scripts/validation/run_vecenv_worker_mode_throughput.py` accepts a standard training config YAML,
   constructs `dummy`, `subproc`, and `threaded` VecEnv modes, runs configurable warmup and step
   loops, and writes a machine-readable JSON artifact (`vecenv_throughput_comparator.v1`) with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* **issue #5118 CPU VecEnv worker-mode throughput comparator.**
+  `scripts/validation/run_vecenv_worker_mode_throughput.py` accepts a standard training config YAML,
+  constructs `dummy`, `subproc`, and `threaded` VecEnv modes, runs configurable warmup and step
+  loops, and writes a machine-readable JSON artifact (`vecenv_throughput_comparator.v1`) with
+  transitions-per-second, speedup vs. the dummy baseline, config SHA-256, git commit, and host
+  provenance. Focused tests in `tests/validation/test_run_vecenv_worker_mode_throughput.py` cover
+  helper contracts and CLI output schema. The `threaded_lidar_batch` mode awaits PR #5123.
+
 ### Fixed
 
 * **issue #4988 benchmark CLI surfaces typed errors (not raw tracebacks) for malformed input.**

--- a/scripts/validation/run_vecenv_worker_mode_throughput.py
+++ b/scripts/validation/run_vecenv_worker_mode_throughput.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""CPU VecEnv worker-mode throughput comparator.
+
+Loads a standard training config, constructs ``dummy``, ``subproc``, and
+``threaded`` VecEnv modes, runs bounded warmup and step loops, and writes
+machine-readable JSON with throughput and host/config provenance.
+
+Usage
+-----
+::
+
+    # default smoke config, 4 envs, 20 warmup + 100 measured steps
+    uv run python scripts/validation/run_vecenv_worker_mode_throughput.py
+
+    # explicit config and env count
+    uv run python scripts/validation/run_vecenv_worker_mode_throughput.py \\
+        --config configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml \\
+        --num-envs 4 --warmup-steps 10 --measure-steps 50 \\
+        --output output/vecenv_throughput.json
+
+Output schema (``vecenv_throughput_comparator.v1``)
+----------------------------------------------------
+::
+
+    {
+      "schema": "vecenv_throughput_comparator.v1",
+      "config_path": "...",
+      "config_sha256": "...",
+      "commit": "...",
+      "host": "...",
+      "num_envs": 4,
+      "warmup_steps": 20,
+      "measure_steps": 100,
+      "baseline_mode": "dummy",
+      "results": [
+        {
+          "mode": "dummy",
+          "transitions_per_second": 42.3,
+          "speedup_vs_baseline": 1.0,
+          "status": "ok",
+          "error": null
+        },
+        ...
+      ]
+    }
+
+Notes
+-----
+- ``subproc`` mode spawns sub-processes; the script uses ``spawn`` start
+  method and must be invoked as an executable file (not via ``python -c``).
+- ``threaded_lidar_batch`` mode is not included here; it awaits the merge of
+  PR #5123 (``worker_mode: threaded_lidar_batch``).
+
+Found while implementing #4981; tracked as issue #5118.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import platform
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+_DEFAULT_CONFIG = _REPO_ROOT / "configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml"
+_SCHEMA = "vecenv_throughput_comparator.v1"
+_SUPPORTED_MODES = ("dummy", "subproc", "threaded")
+
+
+# ---------------------------------------------------------------------------
+# Picklable env factory (needed for SubprocVecEnv spawn workers)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class _EnvFactory:
+    """Picklable callable that constructs one training environment."""
+
+    scenario_path: Path
+    env_factory_kwargs: dict[str, Any]
+    seed: int | None
+
+    def __call__(self):
+        from robot_sf.gym_env.environment_factory import make_robot_env
+        from robot_sf.training.scenario_loader import (
+            build_robot_config_from_scenario,
+            load_scenarios,
+        )
+
+        scenarios = load_scenarios(self.scenario_path)
+        if not scenarios:
+            raise RuntimeError(f"No scenarios found in {self.scenario_path}")
+        config = build_robot_config_from_scenario(
+            scenarios[0],
+            scenario_path=self.scenario_path,
+        )
+        return make_robot_env(
+            config=config,
+            seed=self.seed,
+            **self.env_factory_kwargs,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config loading helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml_raw(path: Path) -> dict[str, Any]:
+    import yaml
+
+    with path.open() as fh:
+        return dict(yaml.safe_load(fh))
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return digest
+
+
+def _git_commit(repo_root: Path) -> str:
+    try:
+        result = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        return result.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def _resolve_scenario_path(config: dict[str, Any], config_path: Path) -> Path:
+    """Resolve the scenario_config path relative to the config file."""
+    raw = config.get("scenario_config", "")
+    scenario = Path(str(raw))
+    if scenario.is_absolute():
+        return scenario
+    return (config_path.parent / scenario).resolve()
+
+
+def _resolve_num_envs(config: dict[str, Any], override: int | None) -> int:
+    if override is not None:
+        return max(1, int(override))
+    raw = config.get("num_envs")
+    if raw is None or str(raw).strip().lower().startswith("auto"):
+        return 4
+    return max(1, int(raw))
+
+
+def _env_factory_kwargs(config: dict[str, Any]) -> dict[str, Any]:
+    raw = config.get("env_factory_kwargs") or {}
+    return dict(raw)
+
+
+# ---------------------------------------------------------------------------
+# VecEnv construction
+# ---------------------------------------------------------------------------
+
+
+def _build_env_fns(
+    scenario_path: Path,
+    env_factory_kwargs: dict[str, Any],
+    num_envs: int,
+    base_seed: int,
+) -> list[_EnvFactory]:
+    return [
+        _EnvFactory(
+            scenario_path=scenario_path,
+            env_factory_kwargs=env_factory_kwargs,
+            seed=base_seed + i,
+        )
+        for i in range(num_envs)
+    ]
+
+
+def _build_vec_env(mode: str, env_fns: list[_EnvFactory]):
+    from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
+
+    from robot_sf.training.threaded_vec_env import ThreadedVecEnv
+
+    if mode == "dummy":
+        return DummyVecEnv(env_fns)
+    if mode == "subproc":
+        return SubprocVecEnv(env_fns, start_method="spawn")
+    if mode == "threaded":
+        return ThreadedVecEnv(env_fns)
+    raise ValueError(f"Unsupported mode: {mode!r}; expected one of {_SUPPORTED_MODES}")
+
+
+# ---------------------------------------------------------------------------
+# Measurement
+# ---------------------------------------------------------------------------
+
+
+def _measure_mode(
+    mode: str,
+    env_fns: list[_EnvFactory],
+    warmup_steps: int,
+    measure_steps: int,
+) -> dict[str, Any]:
+    """Run warmup then measured steps; return throughput record."""
+    import numpy as np
+
+    try:
+        vec_env = _build_vec_env(mode, env_fns)
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "mode": mode,
+            "transitions_per_second": None,
+            "speedup_vs_baseline": None,
+            "status": "construction_failed",
+            "error": str(exc),
+        }
+
+    num_envs = vec_env.num_envs
+    try:
+        vec_env.reset()
+        action_space = vec_env.action_space
+        for _ in range(warmup_steps):
+            actions = np.array([action_space.sample() for _ in range(num_envs)])
+            vec_env.step(actions)
+
+        vec_env.reset()
+        t0 = time.perf_counter()
+        for _ in range(measure_steps):
+            actions = np.array([action_space.sample() for _ in range(num_envs)])
+            vec_env.step(actions)
+        elapsed = time.perf_counter() - t0
+
+        transitions = num_envs * measure_steps
+        tps = transitions / elapsed if elapsed > 0 else float("inf")
+        return {
+            "mode": mode,
+            "transitions_per_second": round(tps, 2),
+            "speedup_vs_baseline": None,  # filled in by caller
+            "status": "ok",
+            "error": None,
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "mode": mode,
+            "transitions_per_second": None,
+            "speedup_vs_baseline": None,
+            "status": "step_failed",
+            "error": str(exc),
+        }
+    finally:
+        vec_env.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser for the VecEnv throughput comparator."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare CPU VecEnv worker-mode throughput (dummy / subproc / threaded). "
+            "Writes machine-readable JSON with provenance for acceptance audits."
+        )
+    )
+    parser.add_argument(
+        "--config",
+        default=str(_DEFAULT_CONFIG),
+        metavar="YAML",
+        help="Training config YAML (default: lidar_ppo_mlp_smoke_issue_1662.yaml).",
+    )
+    parser.add_argument(
+        "--num-envs",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Number of parallel environments (overrides config; default: config value or 4).",
+    )
+    parser.add_argument(
+        "--warmup-steps",
+        type=int,
+        default=20,
+        metavar="N",
+        help="Steps to discard before measuring (default: 20).",
+    )
+    parser.add_argument(
+        "--measure-steps",
+        type=int,
+        default=100,
+        metavar="N",
+        help="Steps to time per mode (default: 100).",
+    )
+    parser.add_argument(
+        "--modes",
+        nargs="+",
+        default=list(_SUPPORTED_MODES),
+        choices=list(_SUPPORTED_MODES),
+        metavar="MODE",
+        help=f"Worker modes to test (default: all; choices: {_SUPPORTED_MODES}).",
+    )
+    parser.add_argument(
+        "--skip-subproc",
+        action="store_true",
+        help="Skip subproc mode (useful when calling from python -c or import context).",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        metavar="PATH",
+        help="JSON output path (default: output/vecenv_throughput_<host>.json).",
+    )
+    return parser
+
+
+def _run_modes(
+    modes: list[str],
+    env_fns: list[_EnvFactory],
+    warmup_steps: int,
+    measure_steps: int,
+) -> tuple[list[dict[str, Any]], float | None]:
+    """Measure throughput for each mode; return results and baseline TPS."""
+    results: list[dict[str, Any]] = []
+    baseline_tps: float | None = None
+    baseline_mode = modes[0] if modes else "dummy"
+
+    for mode in modes:
+        print(f"  measuring mode={mode} ...", file=sys.stderr)
+        record = _measure_mode(mode, env_fns, warmup_steps, measure_steps)
+        results.append(record)
+        if mode == baseline_mode and record["transitions_per_second"] is not None:
+            baseline_tps = record["transitions_per_second"]
+
+    for record in results:
+        tps = record["transitions_per_second"]
+        if tps is not None and baseline_tps is not None and baseline_tps > 0:
+            record["speedup_vs_baseline"] = round(tps / baseline_tps, 3)
+
+    return results, baseline_tps
+
+
+def _write_results(
+    output_data: dict[str, Any],
+    args_output: str | None,
+    host: str,
+) -> Path:
+    """Write JSON output; return the path written."""
+    if args_output:
+        output_path = Path(args_output)
+    else:
+        out_dir = _REPO_ROOT / "output"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        output_path = out_dir / f"vecenv_throughput_{host}.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(output_data, indent=2))
+    return output_path
+
+
+def _print_table(results: list[dict[str, Any]]) -> None:
+    """Print a human-readable summary table to stdout."""
+    print(f"\n{'mode':<20} {'tps':>12} {'speedup':>10} {'status':<20}")
+    print("-" * 66)
+    for rec in results:
+        tps = rec["transitions_per_second"]
+        speedup = rec["speedup_vs_baseline"]
+        tps_str = f"{tps:.1f}" if tps is not None else "N/A"
+        speedup_str = f"{speedup:.3f}x" if speedup is not None else "N/A"
+        print(f"{rec['mode']:<20} {tps_str:>12} {speedup_str:>10} {rec['status']:<20}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: measure and report VecEnv worker-mode throughput."""
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    config_path = Path(args.config).resolve()
+    if not config_path.exists():
+        print(f"ERROR: config not found: {config_path}", file=sys.stderr)
+        return 1
+
+    raw_config = _load_yaml_raw(config_path)
+    scenario_path = _resolve_scenario_path(raw_config, config_path)
+    if not scenario_path.exists():
+        print(f"ERROR: scenario not found: {scenario_path}", file=sys.stderr)
+        return 1
+
+    num_envs = _resolve_num_envs(raw_config, args.num_envs)
+    env_factory_kwargs = _env_factory_kwargs(raw_config)
+
+    modes = list(args.modes)
+    if args.skip_subproc and "subproc" in modes:
+        modes.remove("subproc")
+        print("INFO: subproc mode skipped via --skip-subproc", file=sys.stderr)
+
+    host = socket.gethostname()
+    commit = _git_commit(_REPO_ROOT)
+
+    print(
+        f"VecEnv throughput comparator | "
+        f"host={host} commit={commit[:12]} "
+        f"num_envs={num_envs} warmup={args.warmup_steps} measure={args.measure_steps}",
+        file=sys.stderr,
+    )
+
+    env_fns = _build_env_fns(scenario_path, env_factory_kwargs, num_envs, base_seed=42)
+    results, _ = _run_modes(modes, env_fns, args.warmup_steps, args.measure_steps)
+
+    output_data: dict[str, Any] = {
+        "schema": _SCHEMA,
+        "config_path": str(config_path),
+        "config_sha256": _sha256_file(config_path),
+        "commit": commit,
+        "host": host,
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        "platform": platform.platform(),
+        "num_envs": num_envs,
+        "warmup_steps": args.warmup_steps,
+        "measure_steps": args.measure_steps,
+        "baseline_mode": modes[0] if modes else "dummy",
+        "results": results,
+    }
+
+    output_path = _write_results(output_data, args.output, host)
+    print(f"  wrote: {output_path}", file=sys.stderr)
+    _print_table(results)
+
+    failed = [r for r in results if r["status"] != "ok"]
+    if failed:
+        modes_str = ", ".join(r["mode"] for r in failed)
+        print(f"\nWARN: failed modes: {modes_str}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/run_vecenv_worker_mode_throughput.py
+++ b/scripts/validation/run_vecenv_worker_mode_throughput.py
@@ -57,6 +57,7 @@ Found while implementing #4981; tracked as issue #5118.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import dataclasses
 import hashlib
 import json
@@ -72,6 +73,15 @@ _REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
 _DEFAULT_CONFIG = _REPO_ROOT / "configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml"
 _SCHEMA = "vecenv_throughput_comparator.v1"
 _SUPPORTED_MODES = ("dummy", "subproc", "threaded")
+_RECOVERABLE_MODE_ERRORS = (
+    EOFError,
+    BrokenPipeError,
+    ImportError,
+    OSError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -116,8 +126,14 @@ class _EnvFactory:
 def _load_yaml_raw(path: Path) -> dict[str, Any]:
     import yaml
 
-    with path.open() as fh:
-        return dict(yaml.safe_load(fh))
+    try:
+        with path.open(encoding="utf-8") as fh:
+            payload = yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError) as exc:
+        raise ValueError(f"could not load config {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"config {path} must contain a YAML mapping")
+    return dict(payload)
 
 
 def _sha256_file(path: Path) -> str:
@@ -140,24 +156,32 @@ def _git_commit(repo_root: Path) -> str:
 
 def _resolve_scenario_path(config: dict[str, Any], config_path: Path) -> Path:
     """Resolve the scenario_config path relative to the config file."""
-    raw = config.get("scenario_config", "")
-    scenario = Path(str(raw))
+    raw = config.get("scenario_config")
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError("config scenario_config must be a non-empty path string")
+    scenario = Path(raw)
     if scenario.is_absolute():
         return scenario
     return (config_path.parent / scenario).resolve()
 
 
 def _resolve_num_envs(config: dict[str, Any], override: int | None) -> int:
-    if override is not None:
-        return max(1, int(override))
-    raw = config.get("num_envs")
+    raw = override if override is not None else config.get("num_envs")
     if raw is None or str(raw).strip().lower().startswith("auto"):
         return 4
-    return max(1, int(raw))
+    try:
+        num_envs = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"num_envs must be a positive integer, got {raw!r}") from exc
+    if num_envs < 1:
+        raise ValueError(f"num_envs must be a positive integer, got {num_envs}")
+    return num_envs
 
 
 def _env_factory_kwargs(config: dict[str, Any]) -> dict[str, Any]:
     raw = config.get("env_factory_kwargs") or {}
+    if not isinstance(raw, dict):
+        raise ValueError("config env_factory_kwargs must be a mapping when provided")
     return dict(raw)
 
 
@@ -212,7 +236,7 @@ def _measure_mode(
 
     try:
         vec_env = _build_vec_env(mode, env_fns)
-    except Exception as exc:  # noqa: BLE001
+    except _RECOVERABLE_MODE_ERRORS as exc:
         return {
             "mode": mode,
             "transitions_per_second": None,
@@ -245,7 +269,7 @@ def _measure_mode(
             "status": "ok",
             "error": None,
         }
-    except Exception as exc:  # noqa: BLE001
+    except _RECOVERABLE_MODE_ERRORS as exc:
         return {
             "mode": mode,
             "transitions_per_second": None,
@@ -254,7 +278,8 @@ def _measure_mode(
             "error": str(exc),
         }
     finally:
-        vec_env.close()
+        with contextlib.suppress(OSError, RuntimeError):
+            vec_env.close()
 
 
 # ---------------------------------------------------------------------------
@@ -374,6 +399,16 @@ def _print_table(results: list[dict[str, Any]]) -> None:
         print(f"{rec['mode']:<20} {tps_str:>12} {speedup_str:>10} {rec['status']:<20}")
 
 
+def _validate_run_parameters(args: argparse.Namespace) -> None:
+    """Reject invalid timing inputs instead of silently emitting misleading measurements."""
+    if not args.modes or args.modes[0] != "dummy":
+        raise ValueError("--modes must begin with dummy so speedup has a stable baseline")
+    if args.warmup_steps < 0:
+        raise ValueError("--warmup-steps must be >= 0")
+    if args.measure_steps < 1:
+        raise ValueError("--measure-steps must be >= 1")
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point: measure and report VecEnv worker-mode throughput."""
     parser = build_arg_parser()
@@ -384,14 +419,18 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: config not found: {config_path}", file=sys.stderr)
         return 1
 
-    raw_config = _load_yaml_raw(config_path)
-    scenario_path = _resolve_scenario_path(raw_config, config_path)
+    try:
+        _validate_run_parameters(args)
+        raw_config = _load_yaml_raw(config_path)
+        scenario_path = _resolve_scenario_path(raw_config, config_path)
+        num_envs = _resolve_num_envs(raw_config, args.num_envs)
+        env_factory_kwargs = _env_factory_kwargs(raw_config)
+    except ValueError as exc:
+        print(f"ERROR: invalid comparator configuration: {exc}", file=sys.stderr)
+        return 1
     if not scenario_path.exists():
         print(f"ERROR: scenario not found: {scenario_path}", file=sys.stderr)
         return 1
-
-    num_envs = _resolve_num_envs(raw_config, args.num_envs)
-    env_factory_kwargs = _env_factory_kwargs(raw_config)
 
     modes = list(args.modes)
     if args.skip_subproc and "subproc" in modes:

--- a/tests/validation/test_run_vecenv_worker_mode_throughput.py
+++ b/tests/validation/test_run_vecenv_worker_mode_throughput.py
@@ -47,8 +47,10 @@ class TestResolveNumEnvs:
     def test_missing_returns_default(self):
         assert _resolve_num_envs({}, None) == 4
 
-    def test_clamp_to_one(self):
-        assert _resolve_num_envs({}, 0) == 1
+    def test_nonpositive_override_is_rejected(self):
+        """A zero environment count is invalid, not a request for one environment."""
+        with pytest.raises(ValueError, match="positive integer"):
+            _resolve_num_envs({}, 0)
 
 
 class TestEnvFactoryKwargs:
@@ -272,3 +274,29 @@ def test_main_missing_config_returns_1(tmp_path):
     out = tmp_path / "result.json"
     rc = main(["--config", str(tmp_path / "nonexistent.yaml"), "--output", str(out)])
     assert rc == 1
+
+
+@pytest.mark.parametrize(
+    ("flag", "value", "expected"),
+    [
+        ("--num-envs", "0", "num_envs must be a positive integer"),
+        ("--modes", "threaded", "--modes must begin with dummy"),
+        ("--warmup-steps", "-1", "--warmup-steps must be >= 0"),
+        ("--measure-steps", "0", "--measure-steps must be >= 1"),
+    ],
+)
+def test_main_rejects_invalid_measurement_parameters(tmp_path, capsys, flag, value, expected):
+    """Invalid inputs must fail instead of being silently normalized into a measurement."""
+    rc = main(
+        [
+            "--config",
+            str(_SMOKE_CONFIG),
+            flag,
+            value,
+            "--output",
+            str(tmp_path / "result.json"),
+        ]
+    )
+
+    assert rc == 1
+    assert expected in capsys.readouterr().err

--- a/tests/validation/test_run_vecenv_worker_mode_throughput.py
+++ b/tests/validation/test_run_vecenv_worker_mode_throughput.py
@@ -1,0 +1,274 @@
+"""Tests for the VecEnv worker-mode throughput comparator (issue #5118)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+
+# scripts/ is not a package; insert repo root so the script is importable.
+sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.validation.run_vecenv_worker_mode_throughput import (  # noqa: E402
+    _build_env_fns,
+    _env_factory_kwargs,
+    _EnvFactory,
+    _resolve_num_envs,
+    _sha256_file,
+    main,
+)
+
+_SMOKE_CONFIG = _REPO_ROOT / "configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for config helpers
+# ---------------------------------------------------------------------------
+
+
+class TestResolveNumEnvs:
+    """Tests for _resolve_num_envs helper."""
+
+    def test_override_wins(self):
+        assert _resolve_num_envs({}, 7) == 7
+
+    def test_config_fallback(self):
+        assert _resolve_num_envs({"num_envs": 3}, None) == 3
+
+    def test_auto_string_returns_default(self):
+        assert _resolve_num_envs({"num_envs": "auto"}, None) == 4
+
+    def test_missing_returns_default(self):
+        assert _resolve_num_envs({}, None) == 4
+
+    def test_clamp_to_one(self):
+        assert _resolve_num_envs({}, 0) == 1
+
+
+class TestEnvFactoryKwargs:
+    """Tests for _env_factory_kwargs helper."""
+
+    def test_empty_config(self):
+        assert _env_factory_kwargs({}) == {}
+
+    def test_passthrough(self):
+        cfg = {"env_factory_kwargs": {"reward_name": "route_completion_v2"}}
+        kw = _env_factory_kwargs(cfg)
+        assert kw["reward_name"] == "route_completion_v2"
+
+    def test_none_value_returns_empty(self):
+        assert _env_factory_kwargs({"env_factory_kwargs": None}) == {}
+
+
+class TestSha256File:
+    """Tests for _sha256_file helper."""
+
+    def test_deterministic(self, tmp_path):
+        f = tmp_path / "a.txt"
+        f.write_bytes(b"hello")
+        assert _sha256_file(f) == _sha256_file(f)
+
+    def test_different_content_differs(self, tmp_path):
+        a = tmp_path / "a.txt"
+        b = tmp_path / "b.txt"
+        a.write_bytes(b"x")
+        b.write_bytes(b"y")
+        assert _sha256_file(a) != _sha256_file(b)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _EnvFactory picklability
+# ---------------------------------------------------------------------------
+
+
+class TestEnvFactory:
+    """Tests for _EnvFactory picklability contract."""
+
+    def test_picklable(self, tmp_path):
+        import pickle
+
+        f = _EnvFactory(
+            scenario_path=tmp_path / "scenario.yaml",
+            env_factory_kwargs={},
+            seed=1,
+        )
+        dumped = pickle.dumps(f)
+        restored = pickle.loads(dumped)
+        assert restored.seed == 1
+        assert restored.scenario_path == tmp_path / "scenario.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Integration contract: _build_env_fns length
+# ---------------------------------------------------------------------------
+
+
+def test_build_env_fns_length():
+    """_build_env_fns returns the requested factory count with consecutive seeds."""
+    scenario_path = Path("/tmp/scenario.yaml")
+    env_fns = _build_env_fns(scenario_path, {}, num_envs=3, base_seed=10)
+    assert len(env_fns) == 3
+    assert env_fns[0].seed == 10
+    assert env_fns[2].seed == 12
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: main() with a fake DummyVecEnv (no real env construction)
+# ---------------------------------------------------------------------------
+
+
+class _FakeActionSpace:
+    def sample(self):
+        return np.zeros(2, dtype=np.float32)
+
+
+class _FakeVecEnv:
+    """Minimal VecEnv double for CLI smoke tests."""
+
+    def __init__(self, env_fns):
+        self.num_envs = len(env_fns)
+        self.action_space = _FakeActionSpace()
+        self.closed = False
+
+    def reset(self):
+        return np.zeros((self.num_envs, 1))
+
+    def step(self, actions):
+        obs = np.zeros((self.num_envs, 1))
+        rewards = np.zeros(self.num_envs)
+        dones = np.zeros(self.num_envs, dtype=bool)
+        infos = [{} for _ in range(self.num_envs)]
+        return obs, rewards, dones, infos
+
+    def close(self):
+        self.closed = True
+
+
+def _patch_build_vec_env(mode: str, env_fns):
+    return _FakeVecEnv(env_fns)
+
+
+@pytest.mark.skipif(
+    not _SMOKE_CONFIG.exists(),
+    reason="smoke config not found",
+)
+def test_main_dummy_mode_writes_json(tmp_path):
+    """main() with fake DummyVecEnv writes valid JSON output."""
+    out = tmp_path / "result.json"
+    with patch(
+        "scripts.validation.run_vecenv_worker_mode_throughput._build_vec_env",
+        side_effect=_patch_build_vec_env,
+    ):
+        rc = main(
+            [
+                "--config",
+                str(_SMOKE_CONFIG),
+                "--modes",
+                "dummy",
+                "--num-envs",
+                "2",
+                "--warmup-steps",
+                "2",
+                "--measure-steps",
+                "5",
+                "--output",
+                str(out),
+            ]
+        )
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert data["schema"] == "vecenv_throughput_comparator.v1"
+    assert data["num_envs"] == 2
+    assert len(data["results"]) == 1
+    rec = data["results"][0]
+    assert rec["mode"] == "dummy"
+    assert rec["status"] == "ok"
+    assert rec["transitions_per_second"] > 0
+    assert rec["speedup_vs_baseline"] == pytest.approx(1.0)
+
+
+@pytest.mark.skipif(
+    not _SMOKE_CONFIG.exists(),
+    reason="smoke config not found",
+)
+def test_main_threaded_mode_writes_json(tmp_path):
+    """main() measures dummy and threaded, both succeed."""
+    out = tmp_path / "result.json"
+    with patch(
+        "scripts.validation.run_vecenv_worker_mode_throughput._build_vec_env",
+        side_effect=_patch_build_vec_env,
+    ):
+        rc = main(
+            [
+                "--config",
+                str(_SMOKE_CONFIG),
+                "--modes",
+                "dummy",
+                "threaded",
+                "--num-envs",
+                "2",
+                "--warmup-steps",
+                "2",
+                "--measure-steps",
+                "5",
+                "--output",
+                str(out),
+            ]
+        )
+    assert rc == 0
+    data = json.loads(out.read_text())
+    modes = {r["mode"] for r in data["results"]}
+    assert modes == {"dummy", "threaded"}
+    for rec in data["results"]:
+        assert rec["status"] == "ok"
+
+
+@pytest.mark.skipif(
+    not _SMOKE_CONFIG.exists(),
+    reason="smoke config not found",
+)
+def test_main_construction_failure_reflected_in_output(tmp_path):
+    """Construction failure status is recorded; main returns 2."""
+    out = tmp_path / "result.json"
+
+    def _fail_build(mode, env_fns):
+        raise RuntimeError("simulated env build failure")
+
+    with patch(
+        "scripts.validation.run_vecenv_worker_mode_throughput._build_vec_env",
+        side_effect=_fail_build,
+    ):
+        rc = main(
+            [
+                "--config",
+                str(_SMOKE_CONFIG),
+                "--modes",
+                "dummy",
+                "--num-envs",
+                "2",
+                "--warmup-steps",
+                "1",
+                "--measure-steps",
+                "2",
+                "--output",
+                str(out),
+            ]
+        )
+    assert rc == 2
+    data = json.loads(out.read_text())
+    rec = data["results"][0]
+    assert rec["status"] == "construction_failed"
+    assert "simulated" in rec["error"]
+
+
+def test_main_missing_config_returns_1(tmp_path):
+    """main() returns 1 for a missing config path (no env construction attempted)."""
+    out = tmp_path / "result.json"
+    rc = main(["--config", str(tmp_path / "nonexistent.yaml"), "--output", str(out)])
+    assert rc == 1


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Added `scripts/validation/run_vecenv_worker_mode_throughput.py` — a bounded CPU comparator that constructs `dummy`, `subproc`, and `threaded` VecEnv modes from a standard training config, runs configurable warmup + step loops, and writes machine-readable JSON with throughput, speedup vs. baseline, config SHA-256, commit, and host provenance.
- **Why now:** PR #5123 (threaded-LiDAR-batch mode) identified the missing reproducible comparator as the concrete next blocker for #4981's `>3x` acceptance criterion. Issue #5118 tracks this gap.
- **Claim boundary:** CPU tooling only — this script produces *diagnostic-only* evidence. Establishing the `>3x` throughput claim requires running the comparator on a benchmark-grade configuration and reporting results separately; that is out of scope here.
- **Required validation:** `uv run pytest tests/validation/test_run_vecenv_worker_mode_throughput.py -v` (16 tests pass). End-to-end smoke run (2 envs, `dummy`+`threaded`, 20 warmup + 100 steps) succeeds on this host.
- **Remaining blocker:** `threaded_lidar_batch` remains unavailable until open PR #5123 merges; open parent issue #4981 owns the required four-mode comparison and >3x acceptance decision.

## Contract delta

- **New script:** `scripts/validation/run_vecenv_worker_mode_throughput.py` — standalone CLI, no new package imports at module level.
- **New output schema:** `vecenv_throughput_comparator.v1` JSON artifact (written to `output/` by default; git-ignored).
- **New test file:** `tests/validation/test_run_vecenv_worker_mode_throughput.py` — 16 unit + contract + CLI smoke tests.
- **Compatibility:** additive only; no existing behavior changed.

## Validation results

```
uv run pytest tests/validation/test_run_vecenv_worker_mode_throughput.py -v
# 16 passed in 1.1s

BASE_REF=origin/main scripts/dev/pr_ready_check.sh
# All checks passed! 2132 passed, 1 skipped
```

End-to-end smoke (host: auxme-imech036, 2 envs, 20 warmup, 100 measured steps):

```json
{
  "schema": "vecenv_throughput_comparator.v1",
  "commit": "2bf5cfb949b1...",
  "host": "auxme-imech036",
  "num_envs": 2,
  "results": [
    {"mode": "dummy",    "transitions_per_second": 3843.29, "speedup_vs_baseline": 1.0,   "status": "ok"},
    {"mode": "threaded", "transitions_per_second": 3155.76, "speedup_vs_baseline": 0.821, "status": "ok"}
  ]
}
```

(subproc excluded from quick smoke; use `--modes dummy subproc threaded` from a proper entrypoint.)

## Out of scope

- No full benchmark campaign run; no Slurm/GPU submission.
- No paper/dissertation claim edits.
- No `threaded_lidar_batch` mode (awaits PR #5123 merge).
- No `>3x` throughput claim established here; that requires running the comparator under benchmark-grade conditions.

## Friction issues filed

None this session beyond the issue itself.

Refs #5118
Refs #4981

<details>
<summary>State propagation</summary>

This PR completes comparator tooling for dummy, subproc, and threaded modes. Issue #5118 remains open until open PR #5123 enables `threaded_lidar_batch`; the four-mode acceptance comparison and >3x decision remain tracked by #4981.
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CPU throughput comparison tool for dummy, subprocess, and threaded environment modes.
  * Reports transitions per second, relative speedups, run configuration, and execution details in a JSON file.
  * Provides configurable environment counts, warmup and measurement steps, selected modes, and output location.
  * Displays a readable results table and indicates failed benchmark modes.

* **Tests**
  * Added coverage for configuration validation, output structure, successful runs, and failure handling.

* **Documentation**
  * Added an unreleased changelog entry describing the throughput comparator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
