### PR TITLE
feat(validation): add non-empty guard and per-scenario geometry mapping for #4206 packet (#5093)

### DIFF
--- a/scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py
+++ b/scripts/validation/build_issue_4206_policy_structure_mechanism_crosscut.py
@@ -678,6 +678,7 @@ def _blocked_outputs(
     loaded_row_count: int,
     input_provenance: Mapping[str, Any],
     status: str = BLOCKED_STATUS,
+    all_loaded_rows: Sequence[Mapping[str, Any]] = (),
 ) -> dict[str, Any]:
     output_dir.mkdir(parents=True, exist_ok=True)
     reason = _blocked_reason(status, config, missing_rows)
@@ -758,6 +759,16 @@ def _blocked_outputs(
         ],
     }.items():
         _write_csv(output_dir / filename, [], fieldnames)
+    # Per-scenario geometry mapping: extracted independently of mechanism labels so the
+    # scenario → bucket structure is re-derivable even while the builder is blocked. The
+    # mapping is populated when episode rows carry geometry_bucket / geometry_label fields,
+    # and left header-only when no geometry data is present in the loaded rows.
+    geometry_mapping = _extract_scenario_geometry_mapping(all_loaded_rows)
+    _write_csv(
+        output_dir / "scenario_geometry_bucket_mapping.csv",
+        geometry_mapping,
+        list(_SCENARIO_GEOMETRY_MAPPING_FIELDS),
+    )
     (output_dir / "mechanism_crosscut_report.md").write_text(
         _markdown_report(status, []), encoding="utf-8"
     )
@@ -805,6 +816,63 @@ edits, and no causal-mechanism claim from geometry buckets alone.
 """
     (output_dir / "README.md").write_text(readme, encoding="utf-8")
     (output_dir / "claim_boundary.md").write_text(claim_boundary, encoding="utf-8")
+
+
+def _extract_scenario_geometry_mapping(
+    rows: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Extract per-scenario geometry bucket mapping without requiring mechanism labels.
+
+    Captures (scenario_id, geometry_bucket, scenario_family) from episode rows so the
+    geometry structure is re-derivable even when the mechanism-level cross-cut is blocked.
+    Each (scenario_id, geometry_bucket, scenario_family) triple is de-duplicated.
+    Returns an empty list when no rows carry geometry data.
+    """
+    seen: set[tuple[str, str, str]] = set()
+    mapping: list[dict[str, Any]] = []
+    for row in rows:
+        scenario_id = str(row.get("scenario_id") or "")
+        geometry_bucket = str(
+            row.get("geometry_bucket")
+            or row.get("scenario_geometry_bucket")
+            or row.get("geometry_label")
+            or ""
+        )
+        scenario_family = str(row.get("scenario_family") or "")
+        if not geometry_bucket:
+            continue
+        key = (scenario_id, geometry_bucket, scenario_family)
+        if key in seen:
+            continue
+        seen.add(key)
+        mapping.append(
+            {
+                "scenario_id": scenario_id,
+                "geometry_bucket": geometry_bucket,
+                "scenario_family": scenario_family,
+            }
+        )
+    return sorted(mapping, key=lambda r: (r["geometry_bucket"], r["scenario_id"]))
+
+
+def check_geometry_export_nonempty(path: Path) -> None:
+    """Fail-closed guard: raise BuildError when the geometry CSV has no data rows.
+
+    The geometry_vs_mechanism_agreement.csv starts header-only while the builder is
+    blocked on mechanism labels. Once inputs are available and the builder produces a
+    populated export, this guard prevents a silent regression to a header-only state.
+    """
+    if not path.exists():
+        raise BuildError(f"geometry export not found: {path}")
+    rows = _read_csv(path)
+    if not rows:
+        raise BuildError(
+            f"geometry export is header-only (no data rows): {path} — "
+            "re-run the builder with trace-verified mechanism labels to populate it"
+        )
+
+
+_SCENARIO_GEOMETRY_MAPPING_FIELDS = ("scenario_id", "geometry_bucket", "scenario_family")
 
 
 def _write_sha256sums(output_dir: Path) -> None:
@@ -928,6 +996,7 @@ def build_packet(  # noqa: C901
             loaded_row_count=len(rows),
             input_provenance=input_provenance,
             status=_resolve_block_status(missing_rows),
+            all_loaded_rows=rows,
         )
 
     accepted_confidences = {
@@ -959,6 +1028,7 @@ def build_packet(  # noqa: C901
             ],
             loaded_row_count=len(rows),
             input_provenance=input_provenance,
+            all_loaded_rows=rows,
         )
 
     observed_count = sum(
@@ -1068,6 +1138,15 @@ def build_packet(  # noqa: C901
             "conclusion_survives",
             "caveat",
         ],
+    )
+    # Fail-closed guard: a successful build must not silently produce a header-only agreement table.
+    check_geometry_export_nonempty(output_dir / "geometry_vs_mechanism_agreement.csv")
+    # Per-scenario geometry mapping: always written from all loaded rows (with or without mechanism
+    # labels) so the scenario → bucket structure is independently re-derivable.
+    _write_csv(
+        output_dir / "scenario_geometry_bucket_mapping.csv",
+        _extract_scenario_geometry_mapping(enriched),
+        list(_SCENARIO_GEOMETRY_MAPPING_FIELDS),
     )
     if not (output_dir / "missing_instrumentation.json").exists():
         _write_json(

--- a/tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py
+++ b/tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 from robot_sf.benchmark.failure_mechanism_taxonomy import (
@@ -113,6 +114,7 @@ def test_happy_path_writes_expected_outputs_and_checksums(tmp_path: Path) -> Non
         "f_c4ii_probe_predictive_dominance.csv",
         "f_c4ii_probe_local_minimum_failures.csv",
         "geometry_vs_mechanism_agreement.csv",
+        "scenario_geometry_bucket_mapping.csv",
         "missing_instrumentation.json",
         "claim_boundary.md",
         "SHA256SUMS",
@@ -812,3 +814,181 @@ def test_declared_sidecar_supplies_trace_labels_unblocks_tables(tmp_path: Path) 
     assert summary["accepted_rows"] >= len(planners)
     probe = _read_csv(output / "f_c4ii_probe_predictive_dominance.csv")
     assert probe != []
+
+
+# --- geometry_vs_mechanism_agreement.csv non-empty guard ---
+
+
+def test_nonempty_guard_raises_on_header_only_csv(tmp_path: Path) -> None:
+    """check_geometry_export_nonempty fails closed when the CSV has no data rows."""
+    path = tmp_path / "geometry_vs_mechanism_agreement.csv"
+    path.write_text(
+        "geometry_bucket,mechanism_label,planner_key,structural_class,"
+        "old_geometry_rank,new_mechanism_rank,agreement_status,conclusion_survives,caveat\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(_MODULE.BuildError, match="header-only"):
+        _MODULE.check_geometry_export_nonempty(path)
+
+
+def test_nonempty_guard_passes_on_populated_csv(tmp_path: Path) -> None:
+    """check_geometry_export_nonempty passes when the CSV has at least one data row."""
+    path = tmp_path / "geometry_vs_mechanism_agreement.csv"
+    path.write_text(
+        "geometry_bucket,mechanism_label,planner_key,structural_class,"
+        "old_geometry_rank,new_mechanism_rank,agreement_status,conclusion_survives,caveat\n"
+        "cross_trap,static_deadlock_or_local_minimum,ppo,learned_policy,,1,"
+        "geometry_present_not_rank_compared,,old ranks not recomputed\n",
+        encoding="utf-8",
+    )
+
+    _MODULE.check_geometry_export_nonempty(path)  # must not raise
+
+
+def test_nonempty_guard_raises_when_file_missing(tmp_path: Path) -> None:
+    """check_geometry_export_nonempty fails closed when the CSV is absent."""
+    with pytest.raises(_MODULE.BuildError, match="not found"):
+        _MODULE.check_geometry_export_nonempty(tmp_path / "geometry_vs_mechanism_agreement.csv")
+
+
+def test_geometry_vs_mechanism_csv_nonempty_after_successful_build(tmp_path: Path) -> None:
+    """A successful build writes a populated geometry_vs_mechanism_agreement.csv (guard passes)."""
+    confirm = tmp_path / "confirm"
+    extended = tmp_path / "extended"
+    rows = [
+        _base_row("prediction_planner", 1.0),
+        _base_row("ppo", 0.7),
+    ]
+    _write_rows(confirm, rows)
+    _write_rows(extended, rows)
+    output = tmp_path / "evidence"
+
+    summary = _MODULE.build_packet(
+        config_path=CONFIG,
+        confirm_root=confirm,
+        extended_root=extended,
+        job13175_packet=tmp_path / "packet.json",
+        output_dir=output,
+        generated_at="2026-07-10T00:00:00Z",
+    )
+
+    assert summary["status"] == "analysis_ready_trace_verified"
+    agreement = _read_csv(output / "geometry_vs_mechanism_agreement.csv")
+    assert agreement, (
+        "geometry_vs_mechanism_agreement.csv must not be header-only after a successful build"
+    )
+    assert all(row["geometry_bucket"] for row in agreement)
+
+
+# --- per-scenario geometry bucket mapping ---
+
+
+def test_scenario_geometry_mapping_extracted_from_blocked_rows(tmp_path: Path) -> None:
+    """Per-scenario geometry mapping is written even when mechanism labels are absent."""
+    confirm = tmp_path / "confirm"
+    extended = tmp_path / "extended"
+    row = _base_row("prediction_planner", 1.0)
+    for field in _MODULE.REQUIRED_MECHANISM_FIELDS:
+        row.pop(field, None)
+    _write_rows(confirm, [row])
+    _write_rows(extended, [row])
+    output = tmp_path / "evidence"
+
+    summary = _MODULE.build_packet(
+        config_path=CONFIG,
+        confirm_root=confirm,
+        extended_root=extended,
+        job13175_packet=tmp_path / "packet.json",
+        output_dir=output,
+        generated_at="2026-07-10T00:00:00Z",
+    )
+
+    assert summary["status"] == "blocked_missing_trace_verified_mechanism_labels"
+    mapping = _read_csv(output / "scenario_geometry_bucket_mapping.csv")
+    assert mapping, (
+        "scenario_geometry_bucket_mapping.csv must be non-empty when rows carry geometry data"
+    )
+    assert mapping[0]["geometry_bucket"] == "cross_trap"
+    assert mapping[0]["scenario_id"] == "classic_static_deadlock"
+
+
+def test_scenario_geometry_mapping_header_only_when_no_geometry_data(tmp_path: Path) -> None:
+    """When episode rows carry no geometry fields, the mapping CSV is header-only (fail-closed)."""
+    confirm = tmp_path / "confirm"
+    extended = tmp_path / "extended"
+    row = _base_row("prediction_planner", 1.0)
+    row.pop("geometry_bucket", None)
+    for field in _MODULE.REQUIRED_MECHANISM_FIELDS:
+        row.pop(field, None)
+    _write_rows(confirm, [row])
+    _write_rows(extended, [row])
+    output = tmp_path / "evidence"
+
+    _MODULE.build_packet(
+        config_path=CONFIG,
+        confirm_root=confirm,
+        extended_root=extended,
+        job13175_packet=tmp_path / "packet.json",
+        output_dir=output,
+        generated_at="2026-07-10T00:00:00Z",
+    )
+
+    mapping = _read_csv(output / "scenario_geometry_bucket_mapping.csv")
+    assert mapping == [], "mapping must be empty when no geometry fields are present in loaded rows"
+
+
+def test_extract_scenario_geometry_mapping_deduplicates_same_bucket(tmp_path: Path) -> None:
+    """_extract_scenario_geometry_mapping deduplicates identical (scenario_id, bucket) pairs."""
+    rows = [
+        {
+            "scenario_id": "scen_a",
+            "geometry_bucket": "cross_trap",
+            "scenario_family": "trap",
+        },
+        {
+            "scenario_id": "scen_a",
+            "geometry_bucket": "cross_trap",
+            "scenario_family": "trap",
+        },
+        {
+            "scenario_id": "scen_b",
+            "geometry_bucket": "bottleneck",
+            "scenario_family": "",
+        },
+    ]
+
+    result = _MODULE._extract_scenario_geometry_mapping(rows)
+
+    assert len(result) == 2
+    buckets = {row["geometry_bucket"] for row in result}
+    assert buckets == {"cross_trap", "bottleneck"}
+
+
+def test_extract_scenario_geometry_mapping_skips_rows_without_geometry() -> None:
+    """_extract_scenario_geometry_mapping ignores rows with no geometry_bucket field."""
+    rows = [
+        {"scenario_id": "scen_a", "mechanism_label": "static_deadlock_or_local_minimum"},
+        {"scenario_id": "scen_b", "geometry_bucket": ""},
+        {"scenario_id": "scen_c", "geometry_bucket": "portal"},
+    ]
+
+    result = _MODULE._extract_scenario_geometry_mapping(rows)
+
+    assert len(result) == 1
+    assert result[0]["geometry_bucket"] == "portal"
+
+
+def test_scenario_geometry_mapping_uses_fallback_geometry_fields() -> None:
+    """_extract_scenario_geometry_mapping accepts geometry_label and scenario_geometry_bucket."""
+    rows = [
+        {"scenario_id": "scen_a", "geometry_label": "crowding"},
+        {"scenario_id": "scen_b", "scenario_geometry_bucket": "portal"},
+        {"scenario_id": "scen_c", "geometry_bucket": "bottleneck"},
+    ]
+
+    result = _MODULE._extract_scenario_geometry_mapping(rows)
+
+    assert len(result) == 3
+    buckets = {row["geometry_bucket"] for row in result}
+    assert buckets == {"crowding", "portal", "bottleneck"}


### PR DESCRIPTION
## Reviewer-critical summary

**What changed**: Added `check_geometry_export_nonempty()` fail-closed guard and
`_extract_scenario_geometry_mapping()` per-scenario geometry mapping extractor to the issue
#4206 mechanism cross-cut builder.

**Why now**: The committed `geometry_vs_mechanism_agreement.csv` is header-only because the
builder is blocked on trace-verified mechanism labels. Issue #5093 asks for a fail-closed
non-empty guard so a header-only regression cannot recur silently once mechanism labels are
available, and for a per-scenario geometry mapping that is re-derivable independently of
mechanism labels.

**Claim boundary**: Executable guard and fixture coverage only. The committed
`geometry_vs_mechanism_agreement.csv` remains header-only (the build is still blocked on
trace-verified h600 mechanism labels). The non-empty guard fires only in the success path;
the per-scenario geometry mapping is written in both paths when rows carry geometry data.

**Required validation**: `uv run pytest tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py -q`
→ 33 passed (9 new + 24 existing). All clean on committed HEAD.

**Remaining blocker**: The geometry_vs_mechanism_agreement.csv will only become non-empty
(and the non-empty guard relevant) once the trace-capable h600 campaign runs and produces
trace-verified mechanism labels (outside scope per issue #4206 / #5093).

## Contract delta

### New public functions (builder module)
- `check_geometry_export_nonempty(path: Path) -> None` — raises `BuildError` if the CSV is
  absent or has no data rows. Called immediately after writing
  `geometry_vs_mechanism_agreement.csv` in the success path.
- `_extract_scenario_geometry_mapping(rows) -> list[dict]` — extracts
  `(scenario_id, geometry_bucket, scenario_family)` from episode rows without requiring
  mechanism labels. De-duplicates, sorts deterministically.
- `_SCENARIO_GEOMETRY_MAPPING_FIELDS` — tuple of the three field names above.

### New output file
- `scenario_geometry_bucket_mapping.csv` — written in both blocked and success paths:
  - **blocked path**: populated when episode rows carry geometry_bucket / geometry_label /
    scenario_geometry_bucket fields (making the structure re-derivable while blocked).
  - **success path**: populated from the accepted enriched rows.
  - **fail-closed**: header-only when no geometry data is present in loaded rows.

### Compatibility
- All 24 existing tests still pass; no existing output schema changed.
- `_blocked_outputs()` gains an optional keyword arg `all_loaded_rows=()` with a safe default.

## Validation evidence

```
uv run pytest tests/validation/test_issue_4206_policy_structure_mechanism_crosscut.py -q
33 passed in 8.20s
```

New tests:
- `test_nonempty_guard_raises_on_header_only_csv` — guard rejects header-only CSV
- `test_nonempty_guard_passes_on_populated_csv` — guard passes with data row
- `test_nonempty_guard_raises_when_file_missing` — guard fails closed on absent file
- `test_geometry_vs_mechanism_csv_nonempty_after_successful_build` — end-to-end: success path produces non-empty CSV; guard passes
- `test_scenario_geometry_mapping_extracted_from_blocked_rows` — geometry mapping written even when mechanism labels are absent
- `test_scenario_geometry_mapping_header_only_when_no_geometry_data` — fail-closed: empty mapping when no geometry fields
- `test_extract_scenario_geometry_mapping_deduplicates_same_bucket` — deduplication
- `test_extract_scenario_geometry_mapping_skips_rows_without_geometry` — skip rows with blank geometry_bucket
- `test_scenario_geometry_mapping_uses_fallback_geometry_fields` — geometry_label and scenario_geometry_bucket accepted

## Out of scope

- No full benchmark campaign run; no Slurm/GPU submission.
- No paper/dissertation claim edits.
- The committed `geometry_vs_mechanism_agreement.csv` remains header-only — the per-scenario
  mapping in `scenario_geometry_bucket_mapping.csv` is likewise header-only on this host
  because the h600 episode rows are not present (blocked on trace-capable campaign run per
  #4206). Both files will be populated once the trace-capable h600 campaign completes.

Refs #5093
Refs #4206

<details>
<summary>Downstream propagation</summary>

Not applicable: no new benchmark evidence is produced. The per-scenario geometry mapping CSV
is a new output artifact that is currently header-only (same state as the issue's retained
packet), so no evidence catalog or context index update is warranted until the file is
populated by a campaign run.
</details>

