### PR TITLE
docs: clarify scenario file path contract (issue #5131)

### DIFF
--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -1216,6 +1216,13 @@ def build_robot_config_from_scenario(
 ) -> RobotSimulationConfig:
     """Create a ``RobotSimulationConfig`` derived from a scenario definition.
 
+    Args:
+        scenario: A single scenario definition mapping, such as one returned by
+            ``load_scenarios``.
+        scenario_path: Path to the scenario YAML file, not its containing directory.
+            Relative map and route-override references are resolved from
+            ``scenario_path.parent``.
+
     Returns:
         RobotSimulationConfig: Config populated with overrides and map pool.
     """


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Documented `build_robot_config_from_scenario`'s `scenario_path` as the scenario YAML file, not its containing directory.
- **Why now:** Passing a directory makes relative map and route-override references resolve from the wrong parent directory; issue #5131 captured that undocumented contract.
- **Claim boundary:** Documentation-only clarification. Runtime path resolution, schemas, and benchmark behavior are unchanged.
- **Required validation:** Ruff lint/format checks, AST inspection of the committed docstring, and a whitespace-diff check all pass.
- **Remaining blocker:** None; this is the complete issue scope.

Closes #5131

## Contract delta

- **New schema fields:** None.
- **New fail-closed blockers:** None.
- **Compatibility impact:** No runtime/API behavior changes. Callers now have an explicit file-vs-directory requirement for `scenario_path`.

<details>
<summary>Implementation, validation, and governance details</summary>

## Linked issue and scope

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5131
- Scope: Add `Args:` documentation for the scenario mapping and the scenario YAML-file path contract.
- Full issue resolution: Yes; the requested docstring clarification is complete.

## Validation / proof

- `scripts/dev/run_worktree_shared_venv.sh --standalone -- uv run ruff check robot_sf/training/scenario_loader.py` — passed.
- `scripts/dev/run_worktree_shared_venv.sh --standalone -- uv run ruff format --check robot_sf/training/scenario_loader.py` — passed.
- `scripts/dev/run_worktree_shared_venv.sh --standalone -- uv run python -c '<AST docstring assertions>'` — passed; verified the file-vs-directory wording and `scenario_path.parent` resolution explanation.
- `git diff --check origin/main...HEAD` — passed.

`--standalone` is appropriate here because Ruff and the AST check do not import project packages; the shared environment's project-package freshness guard is otherwise stale. That known friction is already tracked in #5095.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No runtime behavior, schema, or path-resolution changes.

## Risks / artifacts / propagation

- Risk: The clarified contract still relies on callers reading the docstring; this PR intentionally does not add runtime directory validation because issue #5131 is documentation-only.
- Artifacts: No generated artifacts. `output/repos/README.md` is a tracked, pre-existing file and was untouched.
- Downstream propagation: Not applicable for this docs-only clarification; no research, benchmark, registry, or context index surface changes.
- State propagation: No issue comment was posted because this task explicitly does not authorize issue/PR comments. The closing PR is the durable delivery record; no high-churn state table exists or is needed for this completed low-churn issue.
- Late-guidance check: Re-read the live issue immediately before opening. It has no comments, and `updated_at` (2026-07-10T17:18:17Z) predates this work's start time (2026-07-10T17:38:43Z).

## Review focus

Confirm that the wording accurately states the existing `scenario_path.parent` behavior without implying a runtime validation change.

</details>
