### PR TITLE
fix(ci): ignore superseded check runs (#5136)

### DIFF
--- a/scripts/dev/check_pr_ci_status.py
+++ b/scripts/dev/check_pr_ci_status.py
@@ -95,6 +95,45 @@ def _rollup_name(check: dict[str, Any]) -> str:
     return str(check.get("name") or check.get("context") or "unknown")
 
 
+def _check_run_identity(check: dict[str, Any]) -> tuple[str, str] | None:
+    """Return a stable identity for timestamped GitHub Actions check runs.
+
+    GitHub's PR rollup retains completed runs when editing a PR body retriggers
+    a workflow on the same commit.  Only runs from the same workflow job can
+    supersede one another; legacy statuses and runs without a timestamp remain
+    independently fail-closed.
+    """
+    if check.get("__typename") != "CheckRun":
+        return None
+    workflow_name = str(check.get("workflowName") or "")
+    started_at = str(check.get("startedAt") or "")
+    if not workflow_name or not started_at:
+        return None
+    return workflow_name, _rollup_name(check)
+
+
+def _latest_check_runs(rollup: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
+    """Keep the newest timestamped run for each duplicate GitHub Actions job."""
+    latest_by_identity: dict[tuple[str, str], dict[str, Any]] = {}
+    for check in rollup:
+        identity = _check_run_identity(check)
+        if identity is None:
+            continue
+        latest = latest_by_identity.get(identity)
+        if latest is None or str(check["startedAt"]) > str(latest["startedAt"]):
+            latest_by_identity[identity] = check
+
+    effective_rollup: list[dict[str, Any]] = []
+    superseded_count = 0
+    for check in rollup:
+        identity = _check_run_identity(check)
+        if identity is not None and latest_by_identity[identity] is not check:
+            superseded_count += 1
+            continue
+        effective_rollup.append(check)
+    return effective_rollup, superseded_count
+
+
 def _fetch_ci_status(
     pr_number: str,
     backoff: float = 0.0,
@@ -133,7 +172,8 @@ def _fetch_ci_status(
             "status": "error",
             "error": parse_error or "gh output is not a JSON object",
         }
-    rollup = data.get("statusCheckRollup", []) or []
+    raw_rollup = data.get("statusCheckRollup", []) or []
+    rollup, superseded_count = _latest_check_runs(raw_rollup)
 
     # Classify overall CI state.
     conclusions: dict[str, int] = {}
@@ -186,6 +226,7 @@ def _fetch_ci_status(
         "head_sha": data.get("headRefOid", ""),
         "checks": {
             "total": len(rollup),
+            "superseded": superseded_count,
             "overall": overall,
             "by_conclusion": conclusions,
             "by_status": states,
@@ -250,6 +291,9 @@ def _format_human(data: dict[str, Any]) -> str:
     lines.append(
         f"  checks: {overall}  |  {total} total  |  {conclusion_str}  |  status: {status_str}"
     )
+    superseded = checks.get("superseded", 0)
+    if superseded:
+        lines.append(f"  ignored {superseded} superseded GitHub Actions check run(s)")
     for check in checks.get("details", []):
         if check.get("status") == "completed" and check.get("conclusion") == "success":
             continue

--- a/tests/dev/test_check_pr_ci_status.py
+++ b/tests/dev/test_check_pr_ci_status.py
@@ -117,6 +117,93 @@ def test_main_with_explicit_pr_and_failure_exit(
     assert "abc123" in captured.out
 
 
+def test_main_ignores_superseded_failed_check_run_after_successful_pr_body_edit(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """A refreshed workflow job should replace its earlier failed run in the CI summary."""
+    mock_data = json.dumps(
+        {
+            "number": 5136,
+            "title": "corrected PR body",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "corrected-pr-body",
+            "statusCheckRollup": [
+                {
+                    "__typename": "CheckRun",
+                    "name": "pr-body-contracts",
+                    "workflowName": "PR body contracts",
+                    "startedAt": "2026-07-10T16:58:58Z",
+                    "status": "completed",
+                    "conclusion": "failure",
+                },
+                {
+                    "__typename": "CheckRun",
+                    "name": "pr-body-contracts",
+                    "workflowName": "PR body contracts",
+                    "startedAt": "2026-07-10T17:29:04Z",
+                    "status": "completed",
+                    "conclusion": "success",
+                },
+            ],
+            "reviews": [],
+        }
+    )
+
+    with patch("scripts.dev.check_pr_ci_status.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=mock_data, stderr="")
+        rc = main(["5136", "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["checks"]["overall"] == "success"
+    assert payload["checks"]["total"] == 1
+    assert payload["checks"]["superseded"] == 1
+
+
+def test_main_keeps_same_named_runs_from_different_workflows(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Matching job names alone must not hide a failure from another workflow."""
+    mock_data = json.dumps(
+        {
+            "number": 5137,
+            "title": "same job name",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "headRefName": "same-job-name",
+            "statusCheckRollup": [
+                {
+                    "__typename": "CheckRun",
+                    "name": "validate",
+                    "workflowName": "PR body contracts",
+                    "startedAt": "2026-07-10T17:00:00Z",
+                    "status": "completed",
+                    "conclusion": "success",
+                },
+                {
+                    "__typename": "CheckRun",
+                    "name": "validate",
+                    "workflowName": "Security Baseline",
+                    "startedAt": "2026-07-10T17:01:00Z",
+                    "status": "completed",
+                    "conclusion": "failure",
+                },
+            ],
+            "reviews": [],
+        }
+    )
+
+    with patch("scripts.dev.check_pr_ci_status.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=mock_data, stderr="")
+        rc = main(["5137", "--json"])
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["checks"]["overall"] == "failure"
+    assert payload["checks"]["superseded"] == 0
+
+
 def test_main_accepts_pr_flag_alias(capsys: pytest.CaptureFixture) -> None:
     """--pr should work as a named alias for the positional PR number."""
     mock_data = json.dumps(


### PR DESCRIPTION
## Reviewer-critical summary

**What changed**: `scripts/dev/check_pr_ci_status.py` now collapses duplicate GitHub Actions check runs from the same workflow job to the newest timestamped run. It reports the number of superseded runs without counting them toward CI failure.

**Why now**: [#5136](https://github.com/ll7/robot_sf_ll7/issues/5136) reproduced a corrected `pr-body-contracts` run being masked by an earlier failed run on the same PR head.

**Claim boundary**: This changes the repository's local CI-status aggregation only. It does not alter GitHub branch protection, workflow execution, or PR-body contract rules.

**Required validation**: Focused regression tests, Ruff, the live #5125 regression query, and the final repository readiness gate.

**Remaining blocker**: None for #5136. Runs without a workflow name or start timestamp remain individually fail-closed.

## Contract delta

- The CI-status JSON now includes `checks.superseded`, the count of older GitHub Actions runs omitted from the effective rollup.
- Only duplicate `CheckRun` entries with the same workflow and job name are collapsed; similarly named jobs from different workflows and legacy statuses remain independent.
- Compatibility: existing `checks.total`, conclusions, and details now describe the effective current rollup. Consumers that do not read `checks.superseded` remain compatible.

## Scope and validation

- Scope: CI-status aggregation and deterministic regression tests only.
- `uv run pytest tests/dev/test_check_pr_ci_status.py -q` — 42 passed.
- `uv run python scripts/dev/check_pr_ci_status.py 5125 --json` — success; 21 effective successful checks and 2 superseded runs.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — 2,149 passed, 1 skipped.
- Final clean-tree readiness is run against this body immediately before opening.

## Out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## State propagation

No issue status comment was added because this task does not authorize issue or PR comments. The PR itself is the durable linked delivery surface.

Closes #5136

<details>
<summary>Implementation and governance appendix</summary>

The reducer is intentionally limited to timestamped GitHub Actions `CheckRun` records. A newer run replaces only an older run with the identical workflow and job name; unknown and legacy status records remain blocking. No generated artifact is committed; local `output/coverage` and `output/validation` are disposable validation output. This is support/tooling work with no research claim, so downstream research propagation is not applicable.

One separate friction issue was filed: #5148 records the mandated `gh issue view --comments` command failing before it can return issue content because the installed GitHub CLI queries the retired Projects Classic field.
</details>

## Follow-Up Issues

- No implementation follow-up is required.
