### PR TITLE
Issue #5144: robot speed-band campaign axis toward micromobility (cheap-lane worker)

### DIFF
--- a/configs/research/robot_speed_band_v1.yaml
+++ b/configs/research/robot_speed_band_v1.yaml
@@ -1,0 +1,199 @@
+# Robot speed-band campaign axis (issue #5144).
+#
+# Sweeps the drive-model peak forward speed upward toward the micromobility
+# regime (~25 km/h). Evaluated robot operating speeds today sit near 1.0-2.0 m/s
+# (~3.6-7.2 km/h); this axis raises the band in steps so interaction metrics,
+# near-miss exposure, and planner rankings can be measured at vehicle-class
+# closing speeds. The bicycle drive model is the primary target because it
+# already allows 3.0 m/s (`BicycleDriveSettings.max_velocity`); the differential
+# drive caps at 2.0 m/s and is supported as a fallback drive model.
+#
+# Prerequisite / sequencing (per issue #5144):
+# - #4976 (first-class acceleration/braking actuation limits + stopping-distance
+#   envelope) is closed and is a required prerequisite: braking realism must
+#   scale with the speed band. Each `robot_speed_band` variant therefore carries
+#   an explicit `max_decel` so the #4976 actuation envelope
+#   (`stopping_distance = v^2 / (2 * max_decel)`) grows with the swept cap.
+# - #4972 (decouple pedestrian desired speed from spawn speed + calibrated
+#   defaults) is closed. Both the robot speed-band axis and the pedestrian-speed
+#   axis shift closing speeds, so they are modeled as INDEPENDENT axes here
+#   (varied separately, not confounded).
+# - Campaign-scale execution is gated on #4826 (GPU VRAM lifecycle) like other
+#   sweeps. This file is the axis contract / launch packet, not benchmark
+#   evidence until the sweep is run and promoted through a compact evidence
+#   bundle.
+#
+# This config carries the same two compatible surfaces as
+# `fidelity_sensitivity_v1.yaml`: launch-packet metadata consumed by
+# `robot_sf.benchmark.fidelity_sensitivity` and analysis-contract metadata
+# consumed by `robot_sf.benchmark.fidelity_rank_stability`.
+schema_version: fidelity-sensitivity.v1
+issue: 5144
+study_id: issue_5144_robot_speed_band_v1
+status: launch_packet
+
+claim_boundary: >
+  Protocol and metric contract only. This config defines a robot speed-band
+  campaign axis that sweeps the drive-model peak forward speed toward the
+  micromobility regime, plus independent pedestrian-speed and actuation-latency
+  co-axes. It is not benchmark evidence, sensor-realism evidence, sim-to-real
+  evidence, or a paper-facing planner-ranking result until the sweep is run
+  (gated on #4826) and promoted through a compact evidence bundle.
+
+baseline:
+  key: nominal_speed_band
+  benchmark_config: configs/benchmarks/paper_experiment_matrix_v1.yaml
+  interpretation: current_nominal_robot_speed_band
+
+fixed_scope:
+  scenario_set: configs/benchmarks/paper_experiment_matrix_v1.yaml
+  seeds: [111, 112, 113]
+  planner_groups:
+    - orca
+    - default_social_force
+    - hybrid_rule_v0_minimal
+  planner_algorithms:
+    orca: orca
+    default_social_force: social_force
+    hybrid_rule_v0_minimal: hybrid_rule_v0_minimal
+  planner_configs:
+    hybrid_rule_v0_minimal: configs/algos/hybrid_rule_v0_minimal.yaml
+  planner_opt_ins:
+    hybrid_rule_v0_minimal:
+      allow_testing_algorithms: true
+      rationale: issue_5144_fixed_scope_prelaunch_opt_in
+
+ranking:
+  metric: snqi
+  higher_is_better: true
+  stability_min_kendall_tau: 0.8
+  rank_flip_requires_caveat: true
+
+metrics:
+  - name: snqi
+    direction: higher_is_better
+  - name: success
+    direction: higher_is_better
+  - name: collisions
+    direction: lower_is_better
+  - name: near_misses
+    direction: lower_is_better
+  - name: time_to_goal_norm
+    direction: lower_is_better
+
+axes:
+  # PRIMARY axis (issue #5144): sweep the drive-model peak forward speed upward.
+  # Bicycle model first; braking authority scales with the band via #4976.
+  - key: robot_speed_band
+    rationale: >
+      Detect how interaction metrics, near-miss exposure, and planner rankings
+      shift as the robot's drive-model speed cap rises toward the micromobility
+      regime. Bicycle drive first (it already allows 3.0 m/s); braking authority
+      (max_decel) is set per band so #4976 stopping-distance realism scales with
+      speed. Independent of the pedestrian-speed axis (#4972).
+    variants:
+      - key: bicycle_2_0_mps
+        baseline: true
+        patch:
+          robot_config:
+            type: bicycle_drive
+            max_velocity: 2.0
+            max_accel: 1.0
+            max_decel: 2.0
+      - key: bicycle_3_0_mps_nominal
+        patch:
+          robot_config:
+            type: bicycle_drive
+            max_velocity: 3.0
+            max_accel: 1.5
+            max_decel: 3.0
+      - key: bicycle_4_0_mps_micromobility
+        patch:
+          robot_config:
+            type: bicycle_drive
+            max_velocity: 4.0
+            max_accel: 2.0
+            max_decel: 4.0
+  # Co-axis (#4972): pedestrian desired-speed heterogeneity. Varied
+  # independently from the robot speed band so closing-speed shifts decompose
+  # into robot-side and pedestrian-side contributions.
+  - key: social_force_speed_archetypes
+    rationale: >
+      Detect whether pedestrian speed heterogeneity (issue #4972 surface)
+      changes ranking stability independently of the robot speed band.
+    variants:
+      - key: homogeneous_standard_nominal
+        baseline: true
+        patch:
+          pedestrian_archetypes:
+            standard: 1.0
+      - key: rush_hour
+        patch:
+          pedestrian_archetypes:
+            cautious: 0.20
+            standard: 0.30
+            hurried: 0.50
+  # Co-axis (#4976 prerequisite): actuation-latency queue. Ensures the
+  # braking-realism prerequisite is represented as an independent axis.
+  - key: control_action_latency
+    rationale: >
+      Measure how a reset-safe control-to-actuation queue (#4976 prerequisite)
+      changes safety outcomes independently of the robot speed band.
+    variants:
+      - key: zero_step_nominal
+        baseline: true
+        patch:
+          sim_config:
+            action_latency_steps: 0
+      - key: three_step_300ms
+        patch:
+          sim_config:
+            action_latency_steps: 3
+
+result_contract:
+  required_outputs:
+    - axis
+    - variant
+    - planner
+    - seed
+    - scenario_id
+    - metric_values
+    - rank_metric
+    - kendall_tau_vs_baseline
+    - rank_flip_count
+    - per_metric_drift_vs_baseline
+  caveat_rule: >
+    Any axis with a rank_flip_count greater than zero must be reported as a
+    validity-boundary caveat and calibration candidate before paper-facing
+    benchmark use. The robot speed-band axis additionally reports the resolved
+    drive model, peak forward speed, and #4976 actuation envelope per variant so
+    per-band metric shifts are attributable to the speed band.
+
+primary_metric: success_rate
+higher_is_better: true
+
+drift_metrics:
+  - success_rate
+  - collision_rate
+  - min_clearance
+
+nominal:
+  description: nominal robot speed band (current reporting baseline)
+
+# Robot speed-band axis values swept by the parent campaign. The bicycle drive
+# model is primary; 4.0 m/s is the first step toward the ~25 km/h micromobility
+# class (faster bands remain future work pending #4976 braking calibration).
+speed_band_axes:
+  robot_peak_forward_speed_mps:
+    description: drive-model peak forward speed (m/s) swept toward micromobility
+    drive_model: bicycle_drive
+    nominal: 2.0
+    values: [2.0, 3.0, 4.0]
+    braking_decel_m_s2: [2.0, 3.0, 4.0]
+
+decision_rule: >
+  If the planner ranking is stable across the robot speed-band axis (no rank
+  flips vs the nominal band), record the speed-band validity boundary as
+  benchmark-strengthening. Any ranking-flipping band is a required reporting
+  caveat and a candidate calibration target before paper-facing use at
+  vehicle-class closing speeds.

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -44,6 +44,9 @@ from robot_sf.planner.hybrid_rule_local_planner import (
     build_hybrid_rule_local_planner_config,
 )
 from robot_sf.planner.socnav import ORCAPlannerAdapter, SocNavPlannerConfig
+from robot_sf.robot.actuation_envelope import actuation_envelope_from_drive_config
+from robot_sf.robot.bicycle_drive import BicycleDriveSettings
+from robot_sf.robot.differential_drive import DifferentialDriveSettings
 from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
 
 if TYPE_CHECKING:
@@ -629,6 +632,8 @@ def _runtime_binding(
         return "sim_config.archetype_composition"
     if axis == "observation_noise" and observation_noise:
         return "planner_observation_noise"
+    if axis == "robot_speed_band" and isinstance(patch.get("robot_config"), Mapping):
+        return "robot_config.drive_speed_cap"
     return "unsupported"
 
 
@@ -657,6 +662,111 @@ def apply_variant(config: Any, variant: VariantSpec, *, seed: int) -> None:
         }
         config.sim_config.archetype_speed_factors = dict(ARCHETYPE_SPEED_FACTORS)
         config.sim_config.archetype_seed = int(seed)
+    elif variant.runtime_binding == "robot_config.drive_speed_cap":
+        _apply_robot_speed_band_variant(config, variant.patch["robot_config"])
+
+
+def _robot_speed_cap(robot_config: Any) -> float:
+    """Return the active drive model's peak forward speed (m/s).
+
+    The bicycle drive model exposes ``max_velocity``; the differential drive
+    exposes ``max_linear_speed``; the holonomic drive exposes ``max_speed``.
+    This keeps the robot speed-band axis drive-model-agnostic at the read site so
+    a swept cap flows to planner command limits regardless of the active model.
+    """
+    for attr in ("max_velocity", "max_linear_speed", "max_speed"):
+        value = getattr(robot_config, attr, None)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    raise ValueError(
+        "robot_config exposes no recognized peak-forward-speed field "
+        "(max_velocity / max_linear_speed / max_speed)"
+    )
+
+
+def _robot_drive_model_name(robot_config: Any) -> str:
+    """Return a stable drive-model label for the active robot config."""
+    if isinstance(robot_config, BicycleDriveSettings):
+        return "bicycle_drive"
+    if isinstance(robot_config, DifferentialDriveSettings):
+        return "differential_drive"
+    return type(robot_config).__name__
+
+
+def _apply_robot_speed_band_variant(config: Any, robot_overrides: Mapping[str, Any]) -> None:
+    """Apply a robot speed-band variant to the active drive model.
+
+    Sweeps the drive-model peak forward speed upward toward the micromobility
+    regime (issue #5144). The bicycle drive model is the primary target because
+    it already allows 3.0 m/s; the axis is drive-model-agnostic so a raised cap
+    also binds to a differential drive when the scenario uses one.
+
+    Braking authority (``max_decel`` / ``max_linear_decel``) is carried from the
+    variant so stopping-distance realism scales with the speed band via the
+    #4976 actuation envelope (``stopping_distance = v^2 / (2 * max_decel)``).
+    The robot speed-band axis is independent of the pedestrian-speed axis
+    (#4972): it only mutates ``robot_config``, never pedestrian speed state.
+    """
+    current = config.robot_config
+    raw_type = str(robot_overrides.get("type", robot_overrides.get("model", ""))).strip().lower()
+    if raw_type:
+        target_type = "bicycle_drive" if raw_type in {"bicycle", "bicycle_drive"} else raw_type
+    else:
+        target_type = _robot_drive_model_name(current)
+
+    if target_type == "bicycle_drive":
+        config.robot_config = _bicycle_speed_band_settings(current, robot_overrides)
+    elif target_type == "differential_drive":
+        config.robot_config = _differential_speed_band_settings(current, robot_overrides)
+    else:
+        raise ValueError(
+            "robot_speed_band axis only supports 'bicycle_drive' and 'differential_drive' "
+            f"drive models; got {target_type!r}"
+        )
+
+
+def _bicycle_speed_band_settings(
+    current: Any, overrides: Mapping[str, Any]
+) -> BicycleDriveSettings:
+    """Build bicycle-drive settings with a swept speed cap and braking authority."""
+    base_radius = float(getattr(current, "radius", 0.35))
+    base_wheelbase = float(getattr(current, "wheelbase", 1.0))
+    base_steer = float(getattr(current, "max_steer", 0.78))
+    base_accel = float(getattr(current, "max_accel", 1.0))
+    base_decel = float(getattr(current, "max_decel", base_accel))
+    return BicycleDriveSettings(
+        radius=float(overrides.get("radius", base_radius)),
+        wheelbase=float(overrides.get("wheelbase", base_wheelbase)),
+        max_steer=float(overrides.get("max_steer", base_steer)),
+        max_velocity=float(overrides["max_velocity"]),
+        max_accel=float(overrides.get("max_accel", base_accel)),
+        max_decel=float(overrides.get("max_decel", base_decel)),
+        allow_backwards=bool(overrides.get("allow_backwards", False)),
+    )
+
+
+def _differential_speed_band_settings(
+    current: Any, overrides: Mapping[str, Any]
+) -> DifferentialDriveSettings:
+    """Build differential-drive settings with a swept speed cap and braking authority."""
+    base_radius = float(getattr(current, "radius", 0.35))
+    base_angular = float(getattr(current, "max_angular_speed", 1.0))
+    base_wheel_radius = float(getattr(current, "wheel_radius", 0.05))
+    base_interaxis = float(getattr(current, "interaxis_length", 0.3))
+    base_accel = float(getattr(current, "max_linear_accel", 1.0))
+    base_angular_accel = float(getattr(current, "max_angular_accel", 1.0))
+    base_decel = float(getattr(current, "max_linear_decel", base_accel))
+    return DifferentialDriveSettings(
+        radius=float(overrides.get("radius", base_radius)),
+        max_linear_speed=float(overrides["max_linear_speed"]),
+        max_angular_speed=float(overrides.get("max_angular_speed", base_angular)),
+        wheel_radius=float(overrides.get("wheel_radius", base_wheel_radius)),
+        interaxis_length=float(overrides.get("interaxis_length", base_interaxis)),
+        allow_backwards=bool(overrides.get("allow_backwards", False)),
+        max_linear_accel=float(overrides.get("max_linear_accel", base_accel)),
+        max_angular_accel=float(overrides.get("max_angular_accel", base_angular_accel)),
+        max_linear_decel=float(overrides.get("max_linear_decel", base_decel)),
+    )
 
 
 def _build_observation(
@@ -765,19 +875,33 @@ def _load_yaml_mapping(path: pathlib.Path) -> dict[str, Any]:
     return data
 
 
+def _robot_angular_cap(robot_config: Any) -> float:
+    """Return the active drive model's angular command bound.
+
+    The bicycle drive has no angular-velocity cap; its steering bound
+    (``max_steer``) is the closest command limit and is fed as the angular
+    command bound so the unicycle-style planner command stays finite.
+    """
+    return float(
+        getattr(robot_config, "max_angular_speed", None) or getattr(robot_config, "max_steer", 0.0)
+    )
+
+
 def _socnav_config(config: Any) -> SocNavPlannerConfig:
     """Build a SocNav adapter config using the active scenario speed caps."""
     return SocNavPlannerConfig(
-        max_linear_speed=float(config.robot_config.max_linear_speed),
-        max_angular_speed=float(config.robot_config.max_angular_speed),
+        max_linear_speed=_robot_speed_cap(config.robot_config),
+        max_angular_speed=_robot_angular_cap(config.robot_config),
     )
 
 
 def _planner(planner: str, config: Any, *, seed: int) -> Any:
+    speed_cap = _robot_speed_cap(config.robot_config)
+    angular_cap = _robot_angular_cap(config.robot_config)
     if planner == "goal_seek":
         return GoalSeekPlanner(
-            max_linear_speed=float(config.robot_config.max_linear_speed),
-            max_angular_speed=float(config.robot_config.max_angular_speed),
+            max_linear_speed=speed_cap,
+            max_angular_speed=angular_cap,
         )
     if planner == "baseline_social_force":
         return SocialForcePlanner(
@@ -785,8 +909,8 @@ def _planner(planner: str, config: Any, *, seed: int) -> Any:
                 action_space="unicycle",
                 mode="unicycle",
                 dt=float(config.sim_config.time_per_step_in_secs),
-                v_max=float(config.robot_config.max_linear_speed),
-                omega_max=float(config.robot_config.max_angular_speed),
+                v_max=speed_cap,
+                omega_max=angular_cap,
             ),
             seed=seed,
         )
@@ -900,12 +1024,21 @@ def run_episode(
     )
     success = route_success and not collision
     min_clearance = min(clearances) if clearances else None
+    speed_band = _robot_speed_cap(config.robot_config)
     return {
         "variant": variant.key,
         "axis": variant.axis,
         "variant_source_key": variant.source_key,
         "baseline_variant": variant.baseline,
         "runtime_binding": variant.runtime_binding,
+        "speed_band": {
+            "drive_model": _robot_drive_model_name(config.robot_config),
+            "peak_forward_speed_mps": speed_band,
+            # #4976 actuation envelope so stopping-distance realism scales with
+            # the swept speed band; ``None`` for drive models without braking
+            # authority.
+            "actuation_envelope": actuation_envelope_from_drive_config(config.robot_config),
+        },
         "action_latency": reset_info.get("action_latency")
         if isinstance(reset_info, Mapping)
         else None,

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -45,7 +45,7 @@ from robot_sf.planner.hybrid_rule_local_planner import (
 )
 from robot_sf.planner.socnav import ORCAPlannerAdapter, SocNavPlannerConfig
 from robot_sf.robot.actuation_envelope import actuation_envelope_from_drive_config
-from robot_sf.robot.bicycle_drive import BicycleDriveSettings
+from robot_sf.robot.bicycle_drive import BicycleDriveRobot, BicycleDriveSettings
 from robot_sf.robot.differential_drive import DifferentialDriveSettings
 from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
 
@@ -878,13 +878,20 @@ def _load_yaml_mapping(path: pathlib.Path) -> dict[str, Any]:
 def _robot_angular_cap(robot_config: Any) -> float:
     """Return the active drive model's angular command bound.
 
-    The bicycle drive has no angular-velocity cap; its steering bound
-    (``max_steer``) is the closest command limit and is fed as the angular
-    command bound so the unicycle-style planner command stays finite.
+    A bicycle drive accepts a steering angle, but planners emit angular velocity.
+    Its maximum planner-facing yaw rate therefore derives from the speed cap,
+    steering bound, and wheelbase (``v * tan(steer) / wheelbase``).
     """
-    return float(
-        getattr(robot_config, "max_angular_speed", None) or getattr(robot_config, "max_steer", 0.0)
-    )
+    max_angular_speed = getattr(robot_config, "max_angular_speed", None)
+    if max_angular_speed is not None:
+        return float(max_angular_speed)
+    if isinstance(robot_config, BicycleDriveSettings):
+        return float(
+            robot_config.max_velocity
+            * math.tan(robot_config.max_steer)
+            / max(robot_config.wheelbase, 1e-6)
+        )
+    return float(getattr(robot_config, "max_steer", 0.0))
 
 
 def _socnav_config(config: Any) -> SocNavPlannerConfig:
@@ -931,9 +938,23 @@ def _planner(planner: str, config: Any, *, seed: int) -> Any:
 
 
 def _env_action(env: Any, command: Mapping[str, float]) -> np.ndarray:
-    current_linear, current_angular = env.simulator.robots[0].current_speed
+    robot = env.simulator.robots[0]
+    current_linear, current_angular = robot.current_speed
     desired_linear = float(command.get("v", command.get("linear", 0.0)))
     desired_angular = float(command.get("omega", command.get("angular", 0.0)))
+    if isinstance(robot, BicycleDriveRobot):
+        config = robot.config
+        target_speed = float(np.clip(desired_linear, config.min_velocity, config.max_velocity))
+        time_step = float(env.env_config.sim_config.time_per_step_in_secs)
+        acceleration = (target_speed - float(current_linear)) / max(time_step, 1e-6)
+        if abs(target_speed) < 1e-6:
+            steering = 0.0
+        else:
+            steering = math.atan(
+                desired_angular * config.wheelbase / max(abs(target_speed), 1e-6)
+            ) * np.sign(target_speed)
+        action = np.array([acceleration, steering], dtype=float)
+        return np.clip(action, env.action_space.low, env.action_space.high)
     return np.array(
         [desired_linear - float(current_linear), desired_angular - float(current_angular)],
         dtype=float,

--- a/tests/benchmark/test_robot_speed_band_campaign.py
+++ b/tests/benchmark/test_robot_speed_band_campaign.py
@@ -1,0 +1,267 @@
+"""Tests for the robot speed-band campaign axis (issue #5144).
+
+These tests prove the ``robot_speed_band`` campaign axis is a real runtime-bound
+capability, not a metadata-only launch packet: the swept drive-model speed cap
+flows to the actual drive settings, the bicycle model is selected, #4976 braking
+realism scales with the band, the axis is independent of the pedestrian-speed
+axis (#4972), and the cap reaches the real ``BicycleDriveRobot`` action space.
+
+This is a capability/binding test, not benchmark evidence: no campaign is run
+and no planner-ranking claim is made.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.fidelity_sensitivity import validate_fidelity_sensitivity_config
+from robot_sf.robot.actuation_envelope import actuation_envelope_from_drive_config
+from robot_sf.robot.bicycle_drive import BicycleDriveRobot, BicycleDriveSettings
+from robot_sf.robot.differential_drive import DifferentialDriveSettings
+from robot_sf.sim.sim_config import SimulationSettings
+from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs" / "research" / "robot_speed_band_v1.yaml"
+SCENARIO_SET = REPO_ROOT / "configs" / "scenarios" / "sets" / "paper_cross_kinematics_v1.yaml"
+
+
+def _load_campaign_runner() -> ModuleType:
+    module_path = REPO_ROOT / "scripts" / "benchmark" / "run_fidelity_sensitivity_campaign.py"
+    spec = importlib.util.spec_from_file_location("robot_speed_band_campaign_runner", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load campaign runner module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["robot_speed_band_campaign_runner"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+campaign_runner = _load_campaign_runner()
+
+
+def _variant_map() -> dict[str, campaign_runner.VariantSpec]:
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    return {
+        variant.key: variant
+        for variant in campaign_runner.load_variant_specs(config, include_all_variants=True)
+    }
+
+
+def _real_config() -> object:
+    scenarios = list(load_scenarios(SCENARIO_SET))
+    assert scenarios, f"scenario set produced no scenarios: {SCENARIO_SET}"
+    return build_robot_config_from_scenario(scenarios[0], scenario_path=SCENARIO_SET)
+
+
+def test_speed_band_config_validates_against_fidelity_schema() -> None:
+    """The robot speed-band launch packet must satisfy the campaign schema."""
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    validated = validate_fidelity_sensitivity_config(config)
+    assert validated["schema_version"] == "fidelity-sensitivity.v1"
+    assert validated["issue"] == 5144
+    axis_keys = {axis["key"] for axis in validated["axes"]}
+    assert "robot_speed_band" in axis_keys
+
+
+def test_robot_speed_band_axis_binds_to_drive_speed_cap_not_unsupported() -> None:
+    """The axis must resolve to a real runtime binding, not 'unsupported'."""
+    variants = _variant_map()
+    band_variants = [v for v in variants.values() if v.axis == "robot_speed_band"]
+    assert band_variants, "config must define robot_speed_band variants"
+    for variant in band_variants:
+        assert variant.runtime_binding == "robot_config.drive_speed_cap"
+        assert variant.runtime_binding != "unsupported"
+
+
+def test_speed_band_variant_switches_to_bicycle_and_sweeps_max_velocity() -> None:
+    """The variant must select the bicycle drive model and raise the speed cap."""
+    variants = _variant_map()
+    config = _real_config()
+    # Baseline bicycle band at 2.0 m/s.
+    campaign_runner.apply_variant(config, variants["baseline"], seed=111)
+    assert isinstance(config.robot_config, BicycleDriveSettings)
+    assert config.robot_config.max_velocity == pytest.approx(2.0)
+    # Nominal bicycle band at 3.0 m/s (the bicycle model's existing ceiling).
+    campaign_runner.apply_variant(
+        config, variants["robot_speed_band__bicycle_3_0_mps_nominal"], seed=111
+    )
+    assert isinstance(config.robot_config, BicycleDriveSettings)
+    assert config.robot_config.max_velocity == pytest.approx(3.0)
+    # Micromobility-direction band at 4.0 m/s (above the differential-drive cap).
+    campaign_runner.apply_variant(
+        config, variants["robot_speed_band__bicycle_4_0_mps_micromobility"], seed=111
+    )
+    assert isinstance(config.robot_config, BicycleDriveSettings)
+    assert config.robot_config.max_velocity == pytest.approx(4.0)
+
+
+def test_braking_authority_and_stopping_distance_scale_with_speed_band() -> None:
+    """#4976 actuation envelope must grow with the swept speed band."""
+    variants = _variant_map()
+    config = _real_config()
+    stopping_distances: list[float] = []
+    for key in (
+        "baseline",
+        "robot_speed_band__bicycle_3_0_mps_nominal",
+        "robot_speed_band__bicycle_4_0_mps_micromobility",
+    ):
+        campaign_runner.apply_variant(config, variants[key], seed=111)
+        envelope = actuation_envelope_from_drive_config(config.robot_config)
+        assert envelope is not None, f"actuation envelope missing for {key}"
+        # Braking must be distinct from forward acceleration so it is a real
+        # #4976 deceleration cap, not the legacy symmetric default.
+        assert envelope["braking_distinct_from_accel"] is True
+        assert envelope["peak_forward_speed_m_s"] == pytest.approx(config.robot_config.max_velocity)
+        stopping_distances.append(float(envelope["stopping_distance_envelope_m"]))
+    # v^2 / (2*decel) with decel == speed => 2/2, 3/2, 4/2 -> strictly increasing.
+    assert stopping_distances == sorted(stopping_distances)
+    assert stopping_distances[0] < stopping_distances[-1]
+
+
+def test_robot_speed_band_axis_is_independent_of_pedestrian_speed_axis() -> None:
+    """The robot speed-band axis must not mutate pedestrian-speed state (#4972)."""
+    variants = _variant_map()
+    config = _real_config()
+    # Capture pedestrian-speed state before applying the robot speed band.
+    config.sim_config = SimulationSettings(ped_speed_tier="typical", ped_radius=0.4)
+    before_tier = config.sim_config.ped_speed_tier
+    before_desired_mean = config.sim_config.desired_speed_mean
+    before_ped_radius = config.sim_config.ped_radius
+
+    campaign_runner.apply_variant(
+        config, variants["robot_speed_band__bicycle_4_0_mps_micromobility"], seed=111
+    )
+    # The robot speed band mutated robot_config only.
+    assert isinstance(config.robot_config, BicycleDriveSettings)
+    assert config.robot_config.max_velocity == pytest.approx(4.0)
+    # Pedestrian-speed state is untouched by the robot speed-band axis.
+    assert config.sim_config.ped_speed_tier == before_tier
+    assert config.sim_config.desired_speed_mean == before_desired_mean
+    assert config.sim_config.ped_radius == before_ped_radius
+
+    # Conversely, the pedestrian-speed archetype axis must not change the
+    # robot's resolved speed cap.
+    arch_variant = variants["social_force_speed_archetypes__rush_hour"]
+    cap_before = campaign_runner._robot_speed_cap(config.robot_config)
+    campaign_runner.apply_variant(config, arch_variant, seed=111)
+    assert campaign_runner._robot_speed_cap(config.robot_config) == pytest.approx(cap_before)
+    assert isinstance(config.robot_config, BicycleDriveSettings)
+
+
+def test_robot_speed_cap_reader_is_drive_model_agnostic() -> None:
+    """The cap reader must read max_velocity (bicycle) and max_linear_speed (diff)."""
+    assert campaign_runner._robot_speed_cap(
+        BicycleDriveSettings(max_velocity=5.0)
+    ) == pytest.approx(5.0)
+    assert campaign_runner._robot_speed_cap(
+        DifferentialDriveSettings(max_linear_speed=2.5)
+    ) == pytest.approx(2.5)
+
+
+def test_speed_band_variant_flows_to_real_bicycle_robot_action_space() -> None:
+    """The swept cap must reach the actual BicycleDriveRobot via make_robot_env."""
+    pytest.importorskip("gymnasium")
+    from robot_sf.gym_env.environment_factory import make_robot_env
+
+    variants = _variant_map()
+    config = _real_config()
+    campaign_runner.apply_variant(
+        config, variants["robot_speed_band__bicycle_4_0_mps_micromobility"], seed=111
+    )
+    env = make_robot_env(config=config, seed=111, debug=False)
+    try:
+        robot = env.simulator.robots[0]
+        assert isinstance(robot, BicycleDriveRobot)
+        assert robot.config.max_velocity == pytest.approx(4.0)
+        # The bicycle action space is [acceleration, steering]; the accel bound
+        # carries the band-scaled braking-authority prerequisite (#4976).
+        assert env.action_space.high[0] == pytest.approx(robot.config.max_accel)
+        env.reset(seed=111)
+        obs, _reward, terminated, _truncated, _info = env.step(env.action_space.sample())
+        assert obs is not None
+        assert terminated is False
+    finally:
+        env.close()
+
+
+def test_differential_drive_speed_band_sweeps_max_linear_speed() -> None:
+    """The axis must also bind a raised cap to a differential-drive fallback."""
+    config = _real_config()
+    assert isinstance(config.robot_config, DifferentialDriveSettings)
+    variant = campaign_runner.VariantSpec(
+        axis="robot_speed_band",
+        key="robot_speed_band__diff_3_0_mps",
+        source_key="diff_3_0_mps",
+        baseline=False,
+        patch={
+            "robot_config": {
+                "type": "differential_drive",
+                "max_linear_speed": 3.0,
+                "max_linear_decel": 3.0,
+            }
+        },
+        observation_noise={},
+        runtime_binding="robot_config.drive_speed_cap",
+    )
+    campaign_runner.apply_variant(config, variant, seed=111)
+    assert isinstance(config.robot_config, DifferentialDriveSettings)
+    assert config.robot_config.max_linear_speed == pytest.approx(3.0)
+    assert config.robot_config.max_linear_decel == pytest.approx(3.0)
+    envelope = actuation_envelope_from_drive_config(config.robot_config)
+    assert envelope is not None
+    assert envelope["drive_model"] == "differential_drive"
+    assert envelope["peak_forward_speed_m_s"] == pytest.approx(3.0)
+
+
+def test_speed_band_axis_rejects_unsupported_drive_model() -> None:
+    """A drive model outside bicycle/differential must fail closed."""
+    config = SimpleNamespace(
+        robot_config=SimpleNamespace(max_velocity=1.0, radius=0.3),  # not a drive settings type
+        sim_config=SimulationSettings(),
+    )
+    variant = campaign_runner.VariantSpec(
+        axis="robot_speed_band",
+        key="robot_speed_band__holonomic",
+        source_key="holonomic",
+        baseline=False,
+        patch={"robot_config": {"type": "holonomic", "max_velocity": 5.0}},
+        observation_noise={},
+        runtime_binding="robot_config.drive_speed_cap",
+    )
+    with pytest.raises(ValueError, match="only supports"):
+        campaign_runner.apply_variant(config, variant, seed=111)
+
+
+def test_run_episode_records_speed_band_metadata_with_actuation_envelope() -> None:
+    """Episode rows must carry the resolved drive model, speed, and #4976 envelope."""
+    variants = _variant_map()
+    scenario = next(iter(load_scenarios(SCENARIO_SET)))
+    row = campaign_runner.run_episode(
+        scenario,
+        scenario_path=SCENARIO_SET,
+        variant=variants["robot_speed_band__bicycle_4_0_mps_micromobility"],
+        planner_name="goal_seek",
+        seed=111,
+        horizon=8,
+    )
+    assert row["axis"] == "robot_speed_band"
+    assert row["runtime_binding"] == "robot_config.drive_speed_cap"
+    speed_band = row["speed_band"]
+    assert speed_band["drive_model"] == "bicycle_drive"
+    assert speed_band["peak_forward_speed_mps"] == pytest.approx(4.0)
+    envelope = speed_band["actuation_envelope"]
+    assert envelope["drive_model"] == "bicycle_drive"
+    assert envelope["peak_forward_speed_m_s"] == pytest.approx(4.0)
+    assert envelope["stopping_distance_envelope_m"] == pytest.approx(2.0)
+    assert envelope["braking_distinct_from_accel"] is True

--- a/tests/benchmark/test_robot_speed_band_campaign.py
+++ b/tests/benchmark/test_robot_speed_band_campaign.py
@@ -13,6 +13,7 @@ and no planner-ranking claim is made.
 from __future__ import annotations
 
 import importlib.util
+import math
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -188,6 +189,14 @@ def test_speed_band_variant_flows_to_real_bicycle_robot_action_space() -> None:
         # carries the band-scaled braking-authority prerequisite (#4976).
         assert env.action_space.high[0] == pytest.approx(robot.config.max_accel)
         env.reset(seed=111)
+        action = campaign_runner._env_action(env, {"v": 2.0, "omega": 1.5})
+        # The runner consumes unicycle-style velocity commands, whereas the
+        # bicycle environment consumes [acceleration, steering_angle]. A direct
+        # omega-as-steering pass-through would be a different (and incorrect)
+        # value for this non-zero target speed.
+        assert action[0] == pytest.approx(robot.config.max_accel)
+        assert action[1] == pytest.approx(math.atan(1.5 * robot.config.wheelbase / 2.0))
+        assert action[1] != pytest.approx(1.5)
         obs, _reward, terminated, _truncated, _info = env.step(env.action_space.sample())
         assert obs is not None
         assert terminated is False


### PR DESCRIPTION
## What

Implements issue #5144: a **robot speed-band campaign axis** that sweeps the drive-model peak forward speed upward toward the micromobility regime (bicycle model first: 2 → 3 → 4 m/s), so interaction metrics, near-miss exposure, and planner rankings become measurable at vehicle-class closing speeds.

Today's evaluated robot operating speeds sit near 1.0–2.0 m/s (~3.6–7.2 km/h); the micromobility class of interest operates up to ~25 km/h. There was no campaign axis that raised the robot's speed band. This PR adds that capability as a first-class, runtime-bound campaign axis — not a metadata-only launch packet.

## Why

The axis is the actual artifact issue #5144 asks for. It is implemented in the canonical campaign runner (the existing `run_fidelity_sensitivity_campaign.py` "campaign axis" machinery) by extending it rather than duplicating it:

- `_runtime_binding` resolves `robot_speed_band` → `robot_config.drive_speed_cap` (a real runtime binding, not `unsupported`).
- `apply_variant` switches the active drive model to `BicycleDriveSettings` (primary — it already allows 3.0 m/s) or `DifferentialDriveSettings` (fallback), sets the swept speed cap, and carries a **band-scaled braking authority** (`max_decel`) so #4976 stopping-distance realism scales with the band: `stopping_distance = v² / (2·max_decel)` grows 1.0 → 1.5 → 2.0 m across the 2/3/4 m/s bands.
- New `_robot_speed_cap` / `_robot_angular_cap` helpers make planner command limits **drive-model-agnostic**, so a swept bicycle `max_velocity` flows to planners. Previously the runner only read differential `max_linear_speed`, which would have `AttributeError`-ed on a bicycle config — this also fixes that latent gap.
- Episode rows carry a `speed_band` block (resolved `drive_model`, `peak_forward_speed_mps`, and the full #4976 `actuation_envelope`) so per-band metric shifts are attributable downstream.

New config `configs/research/robot_speed_band_v1.yaml` is a **schema-valid** fidelity-sensitivity launch packet with `robot_speed_band` as the primary axis, plus independent pedestrian-speed (#4972) and actuation-latency (#4976) co-axes — directly matching the issue's sequencing notes ("vary them independently"). Campaign-scale execution remains gated on #4826 (GPU VRAM lifecycle); this PR is the **axis contract / capability**, not benchmark evidence.

## Validation (CPU only)

```
$ ruff check scripts/benchmark/run_fidelity_sensitivity_campaign.py tests/benchmark/test_robot_speed_band_campaign.py
All checks passed!
$ ruff format --check <same files>
2 files already formatted

$ DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy python -m pytest \
    tests/benchmark/test_robot_speed_band_campaign.py \
    tests/benchmark/test_fidelity_sensitivity_campaign.py \
    tests/benchmark/test_fidelity_fixed_scope_run_plan.py -q
41 passed in 8.95s
```

The 10 new tests in `test_robot_speed_band_campaign.py` prove the axis binds to the **real runtime**:
- config validates against the `fidelity-sensitivity.v1` schema
- axis resolves to `robot_config.drive_speed_cap` (not `unsupported`)
- `apply_variant` selects `BicycleDriveSettings` and sweeps `max_velocity` 2 → 3 → 4
- #4976 actuation envelope (stopping distance) **scales** with the band and braking is distinct from accel
- axis is **independent** of the pedestrian-speed axis (#4972): robot-speed-band mutates only `robot_config`; the pedestrian archetype axis does not change the resolved robot speed cap
- the swept cap flows through `make_robot_env` to the real `BicycleDriveRobot` action space (end-to-end binding smoke)
- differential-drive fallback sweeps `max_linear_speed`
- unsupported drive models fail closed
- `run_episode` rows record `speed_band` metadata with the #4976 envelope

No campaigns, Slurm, training runs, or benchmark/paper claims were made. The existing fidelity campaign + fixed-scope plan tests (31 tests) remain green — changes are backward-compatible.

## Scope / claim boundary

This PR delivers the **campaign-axis capability** (config + runner binding + runtime proof). It does **not** run the campaign-scale sweep (gated on #4826) and makes no benchmark, planner-ranking, or sim-to-real claim. The bicycle action path uses the existing unicycle-style planner command; a dedicated bicycle action adapter (steering vs. angular-velocity) is a separable follow-up if high-fidelity bicycle navigation is needed — the axis binding and speed-cap enforcement are proven regardless.

Closes #5144

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
