### PR TITLE
Issue #5143: per-arm tuning-effort metadata in campaign manifests (cheap-lane worker)

### DIFF
--- a/docs/benchmark_campaign_manifest.md
+++ b/docs/benchmark_campaign_manifest.md
@@ -44,7 +44,7 @@ top-level sections:
 | `schema_version` | Stable string such as `research-campaign-manifest.v0.1`. |
 | `campaign` | Campaign id, parent issue, purpose, evidence tier, and claim boundary. |
 | `scenario_suite` | Scenario matrix/config path, optional scenario ids or families, and suite hash policy. |
-| `planners` | Planner rows, adapter mode, config path, and expected availability. |
+| `planners` | Planner rows, adapter mode, config path, expected availability, and per-arm tuning-effort block (see [Per-arm tuning-effort block](#per-arm-tuning-effort-block)). |
 | `seed_policy` | Seed mode, seed list or seed set path, and repeat policy. |
 | `metrics` | Metric ids, summary fields, and any baseline or weight artifact pointers. |
 | `row_status_policy` | Allowed values and how fallback/degraded/not-available rows are reported. |
@@ -155,3 +155,45 @@ uv run python scripts/benchmark/build_scenario_denominator_manifest.py \
 The table contract is one row per `(config_name, family, planner)` with scenario count, cell count,
 unique seed count, denominator episodes, kinematics count, kinematics-expanded denominator
 episodes, and densities. Markdown tables may also be checked when they expose the same column names.
+
+## Per-arm tuning-effort block
+
+Each planner arm (a row in the campaign `planners` list) carries a `tuning` block in the camera-ready
+`campaign_manifest.json` so that cross-arm tuning asymmetry (e.g. classical vs learned vs MPC arms) is
+visible in the artifacts instead of silent. This directly counters the under-tuning objection:
+a reviewer can see which parameters were tuned for each arm, against which scenarios, with what
+approximate budget, and whether the tuning set is disjoint from the evaluation set.
+
+Declare a block per arm in the campaign config YAML:
+
+```yaml
+planners:
+  - key: learned_a
+    algo: ppo
+    planner_group: core
+    tuning:
+      parameters_touched: [lr, clip_range]
+      tuning_scenario_ids: [tune_a, tune_b]
+      eval_set_disjoint: true
+      budget_runs: 40
+      budget_hours: 3.0
+      tuned_by: j.doe
+      tuned_at_utc: '2026-07-10T00:00:00Z'
+      source: declared
+```
+
+`source` is one of `declared` (author-recorded), `backfilled` (best-effort reconstruction from
+config history), or `unknown`. When an arm declares no block, the manifest synthesizes a
+`backfill_pending` entry with empty fields so the asymmetry is still recorded rather than hidden.
+
+A top-level `tuning_effort_summary` records how many enabled arms are declared vs backfill-pending
+and which arms are still missing a tuning block.
+
+Fail-closed enforcement (mirrors #4970's checkpoint-provenance spirit): set
+`tuning_effort_enforcement: error` on the campaign config to abort preflight when any enabled arm
+lacks a declared `tuning` block. The default is `off` (best-effort, backwards compatible); `warn`
+records missing blocks in the manifest summary without failing. Use `error` for campaigns whose
+cross-arm comparisons must be protected against the under-tuning objection.
+
+This is auditability metadata, not benchmark evidence by itself: it records tuning effort so the
+asymmetry is reviewable; it does not change any measured outcome.

--- a/robot_sf/benchmark/camera_ready/__init__.py
+++ b/robot_sf/benchmark/camera_ready/__init__.py
@@ -18,6 +18,7 @@ from robot_sf.benchmark.camera_ready._config_types import (
     ScenarioCandidateSelection,
     SeedPolicy,
     SnqiContractConfig,
+    TuningSpec,
 )
 
 __all__ = [
@@ -28,5 +29,6 @@ __all__ = [
     "ScenarioCandidateSelection",
     "SeedPolicy",
     "SnqiContractConfig",
+    "TuningSpec",
     "load_campaign_config",
 ]

--- a/robot_sf/benchmark/camera_ready/_config.py
+++ b/robot_sf/benchmark/camera_ready/_config.py
@@ -18,13 +18,17 @@ import yaml
 
 from robot_sf.benchmark.camera_ready._config_types import (
     _AMV_DIMENSIONS,
+    _TUNING_EFFORT_ENFORCEMENT,
+    _TUNING_SOURCES,
     DEFAULT_SEED_SETS_PATH,
+    TUNING_SOURCE_DECLARED,
     AmvProfileConfig,
     CampaignConfig,
     PlannerSpec,
     ScenarioCandidateSelection,
     SeedPolicy,
     SnqiContractConfig,
+    TuningSpec,
 )
 from robot_sf.benchmark.camera_ready._util import _repo_relative
 from robot_sf.benchmark.latency_stress import (
@@ -79,6 +83,131 @@ def _normalize_kinematics_matrix(raw: Any) -> tuple[str, ...]:
         if text:
             normalized.append(text)
     return tuple(normalized)
+
+
+def _tuning_str_tuple(planner_key: str, field_name: str, value: Any) -> tuple[str, ...]:
+    """Coerce a tuning string-list field into a tuple of non-empty strings.
+
+    Returns:
+        Tuple of non-empty stripped string entries; empty when ``value`` is ``None``.
+    """
+    if value is None:
+        return ()
+    if isinstance(value, str | int | float):
+        text = str(value).strip()
+        return (text,) if text else ()
+    if not isinstance(value, list | tuple):
+        raise TypeError(f"Planner '{planner_key}' tuning.{field_name} must be a list of strings")
+    entries: list[str] = []
+    for item in value:
+        if item is None:
+            raise TypeError(f"Planner '{planner_key}' tuning.{field_name} entries must be strings")
+        text = str(item).strip()
+        if text:
+            entries.append(text)
+    return tuple(entries)
+
+
+def _tuning_eval_disjoint(planner_key: str, value: Any) -> bool | None:
+    """Parse the eval-set disjointness flag, requiring a boolean when provided.
+
+    Returns:
+        The disjointness flag, or ``None`` when not provided.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    raise TypeError(
+        f"Planner '{planner_key}' tuning.eval_set_disjoint must be a boolean when provided"
+    )
+
+
+def _tuning_budget_runs(planner_key: str, value: Any) -> int | None:
+    """Parse the approximate run-count budget as a non-negative integer.
+
+    Returns:
+        The non-negative run-count budget, or ``None`` when not provided.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(
+            f"Planner '{planner_key}' tuning.budget_runs must be an integer when provided"
+        )
+    if value < 0:
+        raise ValueError(f"Planner '{planner_key}' tuning.budget_runs must be non-negative")
+    return value
+
+
+def _tuning_budget_hours(planner_key: str, value: Any) -> float | None:
+    """Parse the approximate hours budget as a non-negative float.
+
+    Returns:
+        The non-negative hours budget, or ``None`` when not provided.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool | str):
+        raise TypeError(
+            f"Planner '{planner_key}' tuning.budget_hours must be a number when provided"
+        )
+    try:
+        hours = float(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            f"Planner '{planner_key}' tuning.budget_hours must be a number when provided"
+        ) from exc
+    if hours < 0:
+        raise ValueError(f"Planner '{planner_key}' tuning.budget_hours must be non-negative")
+    return hours
+
+
+def _tuning_optional_str(value: Any) -> str | None:
+    """Coerce an optional provenance string field, treating blank as None.
+
+    Returns:
+        The stripped string, or ``None`` when blank or not provided.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _parse_tuning_spec(raw: Any, *, planner_key: str) -> TuningSpec | None:
+    """Parse an optional per-arm ``tuning`` block (issue #5143).
+
+    Returns ``None`` when no block is declared so the manifest writer can synthesize a best-effort
+    backfill-pending entry. Validates field types and the allowed ``source`` vocabulary.
+
+    Returns:
+        Parsed ``TuningSpec`` or ``None`` when no tuning block was declared.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError(f"Planner '{planner_key}' tuning block must be a mapping when provided")
+
+    source = str(raw.get("source", TUNING_SOURCE_DECLARED)).strip().lower()
+    if source not in _TUNING_SOURCES:
+        known = ", ".join(_TUNING_SOURCES)
+        raise ValueError(f"Planner '{planner_key}' tuning.source '{source}' is not one of: {known}")
+
+    return TuningSpec(
+        parameters_touched=_tuning_str_tuple(
+            planner_key, "parameters_touched", raw.get("parameters_touched")
+        ),
+        tuning_scenario_ids=_tuning_str_tuple(
+            planner_key, "tuning_scenario_ids", raw.get("tuning_scenario_ids")
+        ),
+        eval_set_disjoint=_tuning_eval_disjoint(planner_key, raw.get("eval_set_disjoint")),
+        budget_runs=_tuning_budget_runs(planner_key, raw.get("budget_runs")),
+        budget_hours=_tuning_budget_hours(planner_key, raw.get("budget_hours")),
+        tuned_by=_tuning_optional_str(raw.get("tuned_by")),
+        tuned_at_utc=_tuning_optional_str(raw.get("tuned_at_utc")),
+        source=source,
+    )
 
 
 def _optional_synthetic_actuation_profile_mapping(
@@ -556,6 +685,25 @@ def _validate_campaign_config(cfg: CampaignConfig) -> None:  # noqa: C901, PLR09
         raise ValueError(
             f"Unsupported snqi_contract.enforcement '{cfg.snqi_contract.enforcement}'. {known}"
         )
+    # Per-arm tuning-effort enforcement (issue #5143). Validate the vocabulary; the fail-closed
+    # (error) gate below requires every enabled arm to declare a tuning block, mirroring #4970's
+    # checkpoint-provenance fail-closed spirit.
+    if cfg.tuning_effort_enforcement not in _TUNING_EFFORT_ENFORCEMENT:
+        known = ", ".join(_TUNING_EFFORT_ENFORCEMENT)
+        raise ValueError(
+            f"Unsupported tuning_effort_enforcement '{cfg.tuning_effort_enforcement}'. "
+            f"Expected one of: {known}"
+        )
+    if cfg.tuning_effort_enforcement == "error":
+        missing = [
+            planner.key for planner in cfg.planners if planner.enabled and planner.tuning is None
+        ]
+        if missing:
+            names = ", ".join(sorted(missing))
+            raise ValueError(
+                "tuning_effort_enforcement='error' requires a 'tuning' block for every enabled "
+                f"arm; missing tuning block for: {names}"
+            )
     threshold_values = {
         "rank_alignment_warn_threshold": cfg.snqi_contract.rank_alignment_warn_threshold,
         "rank_alignment_fail_threshold": cfg.snqi_contract.rank_alignment_fail_threshold,
@@ -712,6 +860,7 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
                 enabled=bool(entry.get("enabled", True)),
                 planner_group=planner_group,
                 planner_group_explicit=planner_group_explicit,
+                tuning=_parse_tuning_spec(entry.get("tuning"), planner_key=key),
             ),
         )
 
@@ -973,6 +1122,9 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
         observation_noise=_resolve_observation_noise(
             payload.get("observation_noise"),
             base_dir=config_path.parent,
+        ),
+        tuning_effort_enforcement=(
+            str(payload.get("tuning_effort_enforcement", "off")).strip().lower() or "off"
         ),
     )
     _validate_campaign_config(cfg)

--- a/robot_sf/benchmark/camera_ready/_config.py
+++ b/robot_sf/benchmark/camera_ready/_config.py
@@ -158,7 +158,7 @@ def _tuning_budget_hours(planner_key: str, value: Any) -> float | None:
         raise TypeError(
             f"Planner '{planner_key}' tuning.budget_hours must be a number when provided"
         ) from exc
-    if hours < 0:
+    if not math.isfinite(hours) or hours < 0:
         raise ValueError(f"Planner '{planner_key}' tuning.budget_hours must be non-negative")
     return hours
 

--- a/robot_sf/benchmark/camera_ready/_config_types.py
+++ b/robot_sf/benchmark/camera_ready/_config_types.py
@@ -18,6 +18,20 @@ if TYPE_CHECKING:
 DEFAULT_SEED_SETS_PATH = Path("configs/benchmarks/seed_sets_v1.yaml")
 _AMV_DIMENSIONS = ("use_case", "context", "speed_regime", "maneuver_type")
 
+# Per-arm tuning-effort provenance (issue #5143). A tuning block is "declared" when an author
+# records it explicitly in the campaign config; "backfilled" marks a best-effort reconstruction
+# from config history (asymmetry still visible, not silent); "unknown" is the honest placeholder
+# for arms whose tuning effort has not yet been recorded.
+TUNING_SOURCE_DECLARED = "declared"
+TUNING_SOURCE_BACKFILLED = "backfilled"
+TUNING_SOURCE_UNKNOWN = "unknown"
+_TUNING_SOURCES = (TUNING_SOURCE_DECLARED, TUNING_SOURCE_BACKFILLED, TUNING_SOURCE_UNKNOWN)
+# Campaign-level enforcement for the per-arm tuning-effort block (issue #5143, fail-closed spirit
+# of #4970's checkpoint provenance). "off" = best-effort, never fail; "warn" = record missing
+# blocks in the manifest but do not fail; "error" = fail closed when any enabled arm lacks a
+# declared tuning block.
+_TUNING_EFFORT_ENFORCEMENT = ("off", "warn", "error")
+
 
 @dataclass(frozen=True)
 class AmvProfileConfig:
@@ -50,6 +64,29 @@ class ScenarioCandidateSelection:
 
 
 @dataclass(frozen=True)
+class TuningSpec:
+    """Per-arm tuning-effort provenance block (issue #5143).
+
+    Records which parameters were tuned for an arm, against which scenarios, with what
+    approximate budget, and whether the tuning set is disjoint from the evaluation set. This
+    makes cross-arm tuning asymmetry (e.g. classical vs learned vs MPC arms) visible in campaign
+    artifacts instead of silent, countering the under-tuning objection.
+
+    A block is ``None`` on ``PlannerSpec`` when the config did not declare one; the manifest writer
+    synthesizes a best-effort ``backfill_pending`` block so the asymmetry is always recorded.
+    """
+
+    parameters_touched: tuple[str, ...] = ()
+    tuning_scenario_ids: tuple[str, ...] = ()
+    eval_set_disjoint: bool | None = None
+    budget_runs: int | None = None
+    budget_hours: float | None = None
+    tuned_by: str | None = None
+    tuned_at_utc: str | None = None
+    source: str = TUNING_SOURCE_UNKNOWN
+
+
+@dataclass(frozen=True)
 class PlannerSpec:
     """One planner entry in a benchmark campaign matrix."""
 
@@ -70,6 +107,10 @@ class PlannerSpec:
     enabled: bool = True
     planner_group: str = "experimental"
     planner_group_explicit: bool = False
+    # Per-arm tuning-effort provenance (issue #5143). ``None`` means the config did not declare a
+    # block; the manifest synthesizes a best-effort backfill-pending entry so the asymmetry is
+    # always visible. Required (fail-closed) when ``tuning_effort_enforcement == "error"``.
+    tuning: TuningSpec | None = None
 
 
 @dataclass(frozen=True)
@@ -135,3 +176,8 @@ class CampaignConfig:
     route_clearance_certifications_path: Path | None = None
     observation_noise: dict[str, Any] | None = None
     arm_isolation: str = "in_process"  # "in_process" or "subprocess" (issue #4826)
+    # Per-arm tuning-effort enforcement (issue #5143, fail-closed spirit of #4970's checkpoint
+    # provenance). "off" = best-effort (default, backwards compatible); "warn" = record missing
+    # blocks in the manifest but do not fail; "error" = fail closed when any enabled arm lacks a
+    # declared tuning block.
+    tuning_effort_enforcement: str = "off"

--- a/robot_sf/benchmark/camera_ready/_legacy_campaign_facade.py
+++ b/robot_sf/benchmark/camera_ready/_legacy_campaign_facade.py
@@ -56,13 +56,19 @@ from robot_sf.benchmark.camera_ready._config import (  # noqa: F401 - re-exporte
 )
 from robot_sf.benchmark.camera_ready._config_types import (  # noqa: F401 - re-exported for back-compat
     _AMV_DIMENSIONS,
+    _TUNING_EFFORT_ENFORCEMENT,
+    _TUNING_SOURCES,
     DEFAULT_SEED_SETS_PATH,
+    TUNING_SOURCE_BACKFILLED,
+    TUNING_SOURCE_DECLARED,
+    TUNING_SOURCE_UNKNOWN,
     AmvProfileConfig,
     CampaignConfig,
     PlannerSpec,
     ScenarioCandidateSelection,
     SeedPolicy,
     SnqiContractConfig,
+    TuningSpec,
 )
 from robot_sf.benchmark.camera_ready._preflight import (  # noqa: F401 - re-exported back-compat
     _build_preflight_preview_payload,
@@ -272,6 +278,7 @@ __all__ = [
     "RouteClearanceError",
     "SeedPolicy",
     "SnqiContractConfig",
+    "TuningSpec",
     "build_campaign_credibility_scorecard",
     "load_campaign_config",
     "prepare_campaign_preflight",

--- a/robot_sf/benchmark/camera_ready/_preflight.py
+++ b/robot_sf/benchmark/camera_ready/_preflight.py
@@ -18,6 +18,9 @@ from robot_sf.benchmark.camera_ready._config import (
     _resolved_seed_inventory,
     _scenario_horizon_summary,
 )
+from robot_sf.benchmark.camera_ready._config_types import (
+    TUNING_SOURCE_DECLARED,
+)
 from robot_sf.benchmark.camera_ready._route_clearance import (
     _assert_route_clearance_feasible,
     _build_route_clearance_warnings,
@@ -56,13 +59,85 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
-    from robot_sf.benchmark.camera_ready._config_types import CampaignConfig
+    from robot_sf.benchmark.camera_ready._config_types import CampaignConfig, PlannerSpec
 
 CheckpointPreflightMode = Literal["metadata_only", "enforced_staged"]
 _CHECKPOINT_PREFLIGHT_REPORT_NAME: dict[str, str] = {
     "metadata_only": "checkpoint_resolvability.json",
     "enforced_staged": "checkpoint_staging.json",
 }
+
+# Honest label for an arm whose tuning effort has not been recorded or reconstructed yet. This is
+# distinct from a declared ``backfilled`` source: it makes the cross-arm asymmetry visible in the
+# manifest without inventing tuning parameters the author never recorded (issue #5143).
+_TUNING_BACKFILL_PENDING = "backfill_pending"
+
+
+def _tuning_effort_block(planner: PlannerSpec) -> dict[str, Any]:
+    """Return the per-arm tuning-effort manifest block (issue #5143).
+
+    When an arm declares no ``tuning`` block, synthesize a best-effort ``backfill_pending`` entry
+    so the under-tuning asymmetry is always visible in campaign artifacts rather than silent. A
+    declared block is emitted verbatim.
+
+    Returns:
+        JSON-serializable tuning-effort manifest block for one arm.
+    """
+    tuning = planner.tuning
+    if tuning is None:
+        return {
+            "parameters_touched": [],
+            "tuning_scenario_ids": [],
+            "eval_set_disjoint": None,
+            "budget_runs": None,
+            "budget_hours": None,
+            "tuned_by": None,
+            "tuned_at_utc": None,
+            "source": _TUNING_BACKFILL_PENDING,
+            "note": (
+                "No tuning block declared for this arm; tuning effort is unrecorded. "
+                "Synthesized as backfill_pending so the cross-arm asymmetry is visible."
+            ),
+        }
+    block: dict[str, Any] = {
+        "parameters_touched": list(tuning.parameters_touched),
+        "tuning_scenario_ids": list(tuning.tuning_scenario_ids),
+        "eval_set_disjoint": tuning.eval_set_disjoint,
+        "budget_runs": tuning.budget_runs,
+        "budget_hours": tuning.budget_hours,
+        "tuned_by": tuning.tuned_by,
+        "tuned_at_utc": tuning.tuned_at_utc,
+        "source": tuning.source,
+    }
+    if tuning.source != TUNING_SOURCE_DECLARED:
+        block["note"] = (
+            "Tuning block is recorded as best-effort reconstruction or unknown; not author-declared."
+        )
+    return block
+
+
+def _tuning_effort_summary(planners: tuple[PlannerSpec, ...]) -> dict[str, Any]:
+    """Summarize per-arm tuning-effort coverage for the manifest (issue #5143).
+
+    Returns:
+        JSON-serializable summary of declared vs backfill-pending arm counts.
+    """
+    enabled = [planner for planner in planners if planner.enabled]
+    declared = [planner for planner in enabled if planner.tuning is not None]
+    backfill_pending = [planner for planner in enabled if planner.tuning is None]
+    by_source: dict[str, int] = {}
+    for planner in declared:
+        source = planner.tuning.source if planner.tuning is not None else _TUNING_BACKFILL_PENDING
+        by_source[source] = by_source.get(source, 0) + 1
+    for planner in backfill_pending:
+        by_source[_TUNING_BACKFILL_PENDING] = by_source.get(_TUNING_BACKFILL_PENDING, 0) + 1
+    return {
+        "enabled_arm_count": len(enabled),
+        "declared_count": len(declared),
+        "backfill_pending_count": len(backfill_pending),
+        "arms_missing_tuning": sorted(planner.key for planner in backfill_pending),
+        "by_source": by_source,
+    }
 
 
 def _scenario_display_name(scenario: dict[str, Any]) -> str:
@@ -546,9 +621,12 @@ def prepare_campaign_preflight(  # noqa: PLR0913
                 ),
                 "observation_mode": planner.observation_mode,
                 "enabled": planner.enabled,
+                "tuning": _tuning_effort_block(planner),
             }
             for planner in cfg.planners
         ],
+        "tuning_effort_enforcement": cfg.tuning_effort_enforcement,
+        "tuning_effort_summary": _tuning_effort_summary(cfg.planners),
         "kinematics_matrix": list(cfg.kinematics_matrix),
         "holonomic_command_mode": cfg.holonomic_command_mode,
         "observation_mode": cfg.observation_mode,

--- a/robot_sf/benchmark/camera_ready_campaign_config.py
+++ b/robot_sf/benchmark/camera_ready_campaign_config.py
@@ -14,6 +14,7 @@ from robot_sf.benchmark.camera_ready import (  # noqa: F401
     ScenarioCandidateSelection,
     SeedPolicy,
     SnqiContractConfig,
+    TuningSpec,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "ScenarioCandidateSelection",
     "SeedPolicy",
     "SnqiContractConfig",
+    "TuningSpec",
 ]

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -127,6 +127,7 @@ def test_camera_ready_config_types_keep_legacy_import_identity() -> None:
         "ScenarioCandidateSelection",
         "SeedPolicy",
         "SnqiContractConfig",
+        "TuningSpec",
     )
 
     for name in public_names:

--- a/tests/benchmark/test_camera_ready_tuning_effort_issue_5143.py
+++ b/tests/benchmark/test_camera_ready_tuning_effort_issue_5143.py
@@ -1,0 +1,430 @@
+"""Tests for per-arm tuning-effort metadata in campaign manifests (issue #5143).
+
+Covers the declared ``tuning`` block parsing, the best-effort ``backfill_pending`` synthesis that
+makes cross-arm tuning asymmetry visible, the manifest emission of the per-arm block plus a
+tuning-effort summary, and the fail-closed ``tuning_effort_enforcement='error'`` gate (mirroring
+#4970's checkpoint-provenance fail-closed spirit).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.camera_ready._config import _parse_tuning_spec, _validate_campaign_config
+from robot_sf.benchmark.camera_ready._config_types import (
+    TUNING_SOURCE_BACKFILLED,
+    TUNING_SOURCE_DECLARED,
+    CampaignConfig,
+    PlannerSpec,
+    ScenarioCandidateSelection,
+    SeedPolicy,
+    TuningSpec,
+)
+from robot_sf.benchmark.camera_ready._preflight import (
+    _tuning_effort_block,
+    _tuning_effort_summary,
+    prepare_campaign_preflight,
+)
+from robot_sf.benchmark.camera_ready_campaign import load_campaign_config
+
+
+def _parse_tuning(raw: object) -> TuningSpec | None:
+    return _parse_tuning_spec(raw, planner_key="arm")
+
+
+def test_parse_tuning_spec_returns_none_when_absent() -> None:
+    """An absent tuning block parses to None so the manifest can backfill later."""
+    assert _parse_tuning(None) is None
+
+
+def test_parse_tuning_spec_reads_declared_block() -> None:
+    """A fully-declared tuning block round-trips into a TuningSpec with source='declared'."""
+    tuning = _parse_tuning(
+        {
+            "parameters_touched": ["v_max", "time_horizon"],
+            "tuning_scenario_ids": ["tune_a", "tune_b"],
+            "eval_set_disjoint": True,
+            "budget_runs": 50,
+            "budget_hours": 2.5,
+            "tuned_by": "j.doe",
+            "tuned_at_utc": "2026-07-10T00:00:00Z",
+            "source": "declared",
+        }
+    )
+    assert tuning is not None
+    assert tuning.parameters_touched == ("v_max", "time_horizon")
+    assert tuning.tuning_scenario_ids == ("tune_a", "tune_b")
+    assert tuning.eval_set_disjoint is True
+    assert tuning.budget_runs == 50
+    assert tuning.budget_hours == pytest.approx(2.5)
+    assert tuning.tuned_by == "j.doe"
+    assert tuning.tuned_at_utc == "2026-07-10T00:00:00Z"
+    assert tuning.source == TUNING_SOURCE_DECLARED
+
+
+def test_parse_tuning_spec_defaults_source_to_declared() -> None:
+    """Omitting source defaults to 'declared' (the author declared it)."""
+    tuning = _parse_tuning({"parameters_touched": ["v_max"]})
+    assert tuning is not None
+    assert tuning.source == TUNING_SOURCE_DECLARED
+
+
+def test_parse_tuning_spec_marks_backfilled_source() -> None:
+    """A best-effort reconstruction records source='backfilled' honestly."""
+    tuning = _parse_tuning({"parameters_touched": ["v_max"], "source": "backfilled"})
+    assert tuning is not None
+    assert tuning.source == TUNING_SOURCE_BACKFILLED
+
+
+@pytest.mark.parametrize("field", ["parameters_touched", "tuning_scenario_ids"])
+def test_parse_tuning_spec_rejects_non_list_field(field: str) -> None:
+    """A dict for a string-list field is rejected; scalars are coerced (codebase pattern)."""
+    with pytest.raises(TypeError, match="must be a list of strings"):
+        _parse_tuning({field: {"not": "a list"}})
+
+
+@pytest.mark.parametrize("field", ["parameters_touched", "tuning_scenario_ids"])
+def test_parse_tuning_spec_coerces_scalar_to_single_entry(field: str) -> None:
+    """Scalar entries are coerced to a single-element tuple (matches scenario_candidates pattern)."""
+    tuning = _parse_tuning({field: "v_max"})
+    assert tuning is not None
+    assert getattr(tuning, field) == ("v_max",)
+
+
+def test_parse_tuning_spec_rejects_invalid_source_vocabulary() -> None:
+    """An unknown tuning.source value is rejected to keep the provenance vocabulary honest."""
+    with pytest.raises(ValueError, match="is not one of"):
+        _parse_tuning({"parameters_touched": ["v_max"], "source": "guessed"})
+
+
+def test_parse_tuning_spec_rejects_non_mapping_block() -> None:
+    """A non-mapping tuning block is rejected with a clear planner-scoped message."""
+    with pytest.raises(ValueError, match="must be a mapping"):
+        _parse_tuning_spec(["not", "a", "mapping"], planner_key="arm")  # type: ignore[arg-type]
+
+
+def test_parse_tuning_spec_rejects_negative_budget() -> None:
+    """Negative tuning budgets are rejected since budget is an approximate but non-negative cost."""
+    with pytest.raises(ValueError, match="non-negative"):
+        _parse_tuning({"budget_runs": -1})
+    with pytest.raises(ValueError, match="non-negative"):
+        _parse_tuning({"budget_hours": -0.5})
+
+
+def test_parse_tuning_spec_rejects_non_bool_disjoint_flag() -> None:
+    """The eval-set disjointness flag must be a boolean when provided."""
+    with pytest.raises(TypeError, match="eval_set_disjoint must be a boolean"):
+        _parse_tuning({"eval_set_disjoint": "yes"})
+
+
+def test_tuning_effort_block_synthesizes_backfill_pending_when_undeclared() -> None:
+    """An undeclared arm still gets a manifest block so asymmetry is visible (not silent)."""
+    planner = PlannerSpec(key="classical_a", algo="goal")
+    block = _tuning_effort_block(planner)
+    assert block["source"] == "backfill_pending"
+    assert block["parameters_touched"] == []
+    assert block["tuning_scenario_ids"] == []
+    assert "note" in block
+    assert planner.tuning is None
+
+
+def test_tuning_effort_block_emits_declared_block_verbatim() -> None:
+    """A declared tuning block is emitted verbatim with no caveat note."""
+    planner = PlannerSpec(
+        key="learned_a",
+        algo="ppo",
+        tuning=TuningSpec(parameters_touched=("lr",), source=TUNING_SOURCE_DECLARED),
+    )
+    block = _tuning_effort_block(planner)
+    assert block["source"] == TUNING_SOURCE_DECLARED
+    assert block["parameters_touched"] == ["lr"]
+    assert "note" not in block
+
+
+def test_tuning_effort_block_flags_non_declared_source_with_note() -> None:
+    """A backfilled (non-declared) source is still emitted but flagged with a caveat note."""
+    planner = PlannerSpec(
+        key="mpc_a",
+        algo="mpc",
+        tuning=TuningSpec(parameters_touched=("horizon",), source=TUNING_SOURCE_BACKFILLED),
+    )
+    block = _tuning_effort_block(planner)
+    assert block["source"] == TUNING_SOURCE_BACKFILLED
+    assert "note" in block
+
+
+def test_tuning_effort_summary_counts_declared_vs_backfill_pending() -> None:
+    """The summary exposes how many arms are declared vs backfill-pending and which are missing."""
+    planners = (
+        PlannerSpec(
+            key="a",
+            algo="goal",
+            tuning=TuningSpec(source=TUNING_SOURCE_DECLARED),
+        ),
+        PlannerSpec(key="b", algo="orca"),
+        PlannerSpec(
+            key="c",
+            algo="mpc",
+            enabled=False,
+            tuning=TuningSpec(source=TUNING_SOURCE_BACKFILLED),
+        ),
+    )
+    summary = _tuning_effort_summary(planners)
+    assert summary["enabled_arm_count"] == 2
+    assert summary["declared_count"] == 1
+    assert summary["backfill_pending_count"] == 1
+    assert summary["arms_missing_tuning"] == ["b"]
+    assert summary["by_source"] == {TUNING_SOURCE_DECLARED: 1, "backfill_pending": 1}
+
+
+def _write_minimal_campaign(
+    tmp_path: Path,
+    *,
+    planners_yaml: str,
+    extra_top_level: str = "",
+) -> Path:
+    """Write a minimal valid campaign config with the given planners block."""
+    scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")
+    scenario_abs = (tmp_path / scenario_rel).resolve()
+    scenario_abs.parent.mkdir(parents=True, exist_ok=True)
+    scenario_abs.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: tuning_effort_cfg",
+                "seed_policy:",
+                "  mode: fixed-list",
+                "  seeds: [111]",
+                f"scenario_matrix: {scenario_rel.as_posix()}",
+                extra_top_level,
+                "planners:",
+                planners_yaml,
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_load_campaign_config_parses_tuning_block(tmp_path: Path) -> None:
+    """A declared per-arm tuning block round-trips through the YAML config loader."""
+    config_path = _write_minimal_campaign(
+        tmp_path,
+        planners_yaml=(
+            "  - key: learned_a\n"
+            "    algo: ppo\n"
+            "    planner_group: core\n"
+            "    tuning:\n"
+            "      parameters_touched: [lr, clip_range]\n"
+            "      tuning_scenario_ids: [tune_a, tune_b]\n"
+            "      eval_set_disjoint: true\n"
+            "      budget_runs: 40\n"
+            "      budget_hours: 3.0\n"
+            "      tuned_by: j.doe\n"
+            "      tuned_at_utc: '2026-07-10T00:00:00Z'\n"
+            "      source: declared\n"
+            "  - key: classical_a\n"
+            "    algo: goal\n"
+            "    planner_group: core\n"
+        ),
+    )
+    cfg = load_campaign_config(config_path)
+    learned, classical = cfg.planners
+    assert learned.tuning is not None
+    assert learned.tuning.parameters_touched == ("lr", "clip_range")
+    assert learned.tuning.tuning_scenario_ids == ("tune_a", "tune_b")
+    assert learned.tuning.eval_set_disjoint is True
+    assert learned.tuning.budget_runs == 40
+    assert learned.tuning.budget_hours == pytest.approx(3.0)
+    assert learned.tuning.tuned_by == "j.doe"
+    assert learned.tuning.source == TUNING_SOURCE_DECLARED
+    assert classical.tuning is None
+
+
+def test_load_campaign_config_defaults_tuning_effort_enforcement_off(tmp_path: Path) -> None:
+    """Backwards compatibility: configs without the new field load with enforcement='off'."""
+    config_path = _write_minimal_campaign(
+        tmp_path,
+        planners_yaml="  - key: a\n    algo: goal\n    planner_group: core\n",
+    )
+    cfg = load_campaign_config(config_path)
+    assert cfg.tuning_effort_enforcement == "off"
+
+
+def test_validate_campaign_config_error_gate_fails_when_arm_missing_tuning() -> None:
+    """tuning_effort_enforcement='error' fails closed when any enabled arm lacks a tuning block."""
+    cfg = CampaignConfig(
+        name="gate",
+        scenario_matrix_path=Path("does-not-matter.yaml"),
+        planners=(
+            PlannerSpec(
+                key="a",
+                algo="goal",
+                tuning=TuningSpec(source=TUNING_SOURCE_DECLARED),
+            ),
+            PlannerSpec(key="b", algo="orca"),
+        ),
+        seed_policy=SeedPolicy(),
+        scenario_candidates=ScenarioCandidateSelection(),
+        tuning_effort_enforcement="error",
+    )
+    with pytest.raises(ValueError, match="missing tuning block for: b"):
+        _validate_campaign_config(cfg)
+
+
+def test_validate_campaign_config_error_gate_passes_when_all_enabled_arms_declared() -> None:
+    """When every enabled arm declares tuning, the error gate passes; disabled arms are exempt."""
+    cfg = CampaignConfig(
+        name="gate",
+        scenario_matrix_path=Path("does-not-matter.yaml"),
+        planners=(
+            PlannerSpec(
+                key="a",
+                algo="goal",
+                tuning=TuningSpec(source=TUNING_SOURCE_DECLARED),
+            ),
+            PlannerSpec(
+                key="b",
+                algo="orca",
+                enabled=False,
+            ),
+        ),
+        seed_policy=SeedPolicy(),
+        scenario_candidates=ScenarioCandidateSelection(),
+        tuning_effort_enforcement="error",
+    )
+    # A disabled arm is exempt; should not raise.
+    _validate_campaign_config(cfg)
+
+
+def test_validate_campaign_config_error_gate_ignores_disabled_arms() -> None:
+    """A disabled arm missing a tuning block does not trigger the error gate."""
+    cfg = CampaignConfig(
+        name="gate",
+        scenario_matrix_path=Path("does-not-matter.yaml"),
+        planners=(
+            PlannerSpec(key="a", algo="goal", enabled=False),
+            PlannerSpec(
+                key="b",
+                algo="orca",
+                tuning=TuningSpec(source=TUNING_SOURCE_DECLARED),
+            ),
+        ),
+        seed_policy=SeedPolicy(),
+        scenario_candidates=ScenarioCandidateSelection(),
+        tuning_effort_enforcement="error",
+    )
+    _validate_campaign_config(cfg)
+
+
+def test_validate_campaign_config_rejects_unknown_enforcement_value() -> None:
+    """An unrecognized enforcement vocabulary value is rejected at validation time."""
+    cfg = CampaignConfig(
+        name="gate",
+        scenario_matrix_path=Path("does-not-matter.yaml"),
+        planners=(PlannerSpec(key="a", algo="goal"),),
+        seed_policy=SeedPolicy(),
+        scenario_candidates=ScenarioCandidateSelection(),
+        tuning_effort_enforcement="strict",
+    )
+    with pytest.raises(ValueError, match="Unsupported tuning_effort_enforcement 'strict'"):
+        _validate_campaign_config(cfg)
+
+
+def test_load_campaign_config_error_gate_rejects_missing_tuning(tmp_path: Path) -> None:
+    """The error gate fires during config load, before any campaign artifact exists."""
+    config_path = _write_minimal_campaign(
+        tmp_path,
+        planners_yaml="  - key: a\n    algo: goal\n    planner_group: core\n",
+        extra_top_level="tuning_effort_enforcement: error",
+    )
+    with pytest.raises(ValueError, match="missing tuning block for: a"):
+        load_campaign_config(config_path)
+
+
+def test_prepare_campaign_preflight_writes_tuning_blocks_and_summary(tmp_path: Path) -> None:
+    """The campaign manifest must carry a per-arm tuning block for every arm plus a coverage summary."""
+    config_path = _write_minimal_campaign(
+        tmp_path,
+        planners_yaml=(
+            "  - key: learned_a\n"
+            "    algo: ppo\n"
+            "    planner_group: core\n"
+            "    tuning:\n"
+            "      parameters_touched: [lr]\n"
+            "      tuning_scenario_ids: [tune_a]\n"
+            "      eval_set_disjoint: true\n"
+            "      budget_runs: 40\n"
+            "      budget_hours: 3.0\n"
+            "      tuned_by: j.doe\n"
+            "      tuned_at_utc: '2026-07-10T00:00:00Z'\n"
+            "      source: declared\n"
+            "  - key: classical_a\n"
+            "    algo: goal\n"
+            "    planner_group: core\n"
+        ),
+    )
+    cfg = load_campaign_config(config_path)
+    prepared = prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="issue5143")
+    manifest = json.loads(
+        (Path(prepared["campaign_root"]) / "campaign_manifest.json").read_text(encoding="utf-8")
+    )
+
+    planners = {planner["key"]: planner for planner in manifest["planners"]}
+    # Declared arm emits its block verbatim.
+    learned = planners["learned_a"]
+    assert learned["tuning"]["source"] == TUNING_SOURCE_DECLARED
+    assert learned["tuning"]["parameters_touched"] == ["lr"]
+    assert learned["tuning"]["tuning_scenario_ids"] == ["tune_a"]
+    assert learned["tuning"]["eval_set_disjoint"] is True
+    assert learned["tuning"]["budget_runs"] == 40
+    assert learned["tuning"]["budget_hours"] == pytest.approx(3.0)
+    assert learned["tuning"]["tuned_by"] == "j.doe"
+    assert learned["tuning"]["tuned_at_utc"] == "2026-07-10T00:00:00Z"
+    # Undeclared classical arm still carries a backfill_pending block (asymmetry visible).
+    classical = planners["classical_a"]
+    assert classical["tuning"]["source"] == "backfill_pending"
+    assert classical["tuning"]["parameters_touched"] == []
+    # Top-level summary surfaces coverage.
+    assert manifest["tuning_effort_enforcement"] == "off"
+    summary = manifest["tuning_effort_summary"]
+    assert summary["enabled_arm_count"] == 2
+    assert summary["declared_count"] == 1
+    assert summary["backfill_pending_count"] == 1
+    assert summary["arms_missing_tuning"] == ["classical_a"]
+
+
+def test_prepare_campaign_preflight_error_gate_aborts_before_artifacts(tmp_path: Path) -> None:
+    """Fail-closed enforcement must abort preflight before producing artifacts (issue #5143)."""
+    # Construct a config directly (bypassing load_campaign_config) with enforcement='error' and an
+    # enabled arm missing its tuning block. Preflight injects _validate_campaign_config, so the
+    # fail-closed gate must fire before any campaign artifact is written.
+    scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")
+    scenario_abs = (tmp_path / scenario_rel).resolve()
+    scenario_abs.parent.mkdir(parents=True, exist_ok=True)
+    scenario_abs.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+    cfg = CampaignConfig(
+        name="gate_campaign",
+        scenario_matrix_path=scenario_abs,
+        planners=(PlannerSpec(key="a", algo="goal", planner_group="core"),),
+        seed_policy=SeedPolicy(mode="fixed-list", seeds=(111,)),
+        scenario_candidates=ScenarioCandidateSelection(),
+        tuning_effort_enforcement="error",
+    )
+    with pytest.raises(ValueError, match="missing tuning block for: a"):
+        prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="issue5143")
+    # No campaign root should have been created on the fail-closed path.
+    assert not (tmp_path / "out").exists() or not list(
+        (tmp_path / "out").rglob("campaign_manifest.json")
+    )

--- a/tests/benchmark/test_camera_ready_tuning_effort_issue_5143.py
+++ b/tests/benchmark/test_camera_ready_tuning_effort_issue_5143.py
@@ -114,6 +114,13 @@ def test_parse_tuning_spec_rejects_negative_budget() -> None:
         _parse_tuning({"budget_hours": -0.5})
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_parse_tuning_spec_rejects_non_finite_budget_hours(value: float) -> None:
+    """Non-finite values must not reach JSON campaign-manifest output."""
+    with pytest.raises(ValueError, match="budget_hours must be non-negative"):
+        _parse_tuning({"budget_hours": value})
+
+
 def test_parse_tuning_spec_rejects_non_bool_disjoint_flag() -> None:
     """The eval-set disjointness flag must be a boolean when provided."""
     with pytest.raises(TypeError, match="eval_set_disjoint must be a boolean"):


### PR DESCRIPTION
## What

Implements issue #5143: per-arm **tuning-effort metadata** in camera-ready campaign manifests, so that cross-arm tuning asymmetry (classical vs learned vs MPC arms) is **visible in the artifacts instead of silent**. This directly counters the under-tuning objection: a reviewer can see which parameters were tuned for each arm, against which scenarios, with what approximate budget, and whether the tuning set is disjoint from the evaluation set.

This PR delivers the phase-1 schema, parsing, manifest emission, visible backfill-pending state, and fail-closed enforcement gate. Best-effort reconstruction from config history remains tracked by #5143.

Refs #5143

## Why

The issue states: "Campaign arms carry no record of tuning effort … Cross-arm comparisons are therefore open to the under-tuning objection, and the asymmetry is invisible in the artifacts." This PR makes the asymmetry reviewable. It pairs with #4970 (still open) and reuses the same fail-closed provenance spirit as #4970's checkpoint provenance and the existing `amv_profile.coverage_enforcement` / `snqi_contract.enforcement` patterns.

## Changes

- **`TuningSpec` dataclass** (`robot_sf/benchmark/camera_ready/_config_types.py`): `parameters_touched`, `tuning_scenario_ids`, `eval_set_disjoint`, `budget_runs`, `budget_hours`, `tuned_by`, `tuned_at_utc`, and a `source` vocabulary (`declared` | `backfilled` | `unknown`).
- **`PlannerSpec.tuning`** field (optional; `None` when undeclared) and **`CampaignConfig.tuning_effort_enforcement`** (`off` | `warn` | `error`, default `off` for backwards compatibility).
- **Config parsing** (`_config.py`): a `tuning:` block per arm is parsed and validated; `tuning_effort_enforcement` parsed from YAML.
- **Manifest emission** (`_preflight.py`): every arm gets a `tuning` block in `campaign_manifest.json`; undeclared arms get a synthesized **`backfill_pending`** block so the asymmetry is always recorded. A top-level `tuning_effort_summary` reports declared vs backfill-pending counts and which arms are missing a block.
- **Fail-closed gate**: `tuning_effort_enforcement: error` aborts preflight (during config validation, before any artifact is written) when any enabled arm lacks a declared `tuning` block — mirroring #4970's checkpoint-provenance fail-closed spirit. `warn` records missing blocks without failing; `off` is best-effort (default).
- **Docs**: new "Per-arm tuning-effort block" section in `docs/benchmark_campaign_manifest.md`.
- **Re-exports**: `TuningSpec` added to the package `__init__`, the legacy `camera_ready_campaign` facade, and `camera_ready_campaign_config.py`; the existing identity test now also covers `TuningSpec`.

### Backfill note (issue: "Backfill best-effort for existing arms from config history")

Generic reconstruction of each arm's historical tuning from git history is out of scope for one session. Instead, this PR makes backfill **representable and visible**: an undeclared arm is honestly labeled `backfill_pending` (distinct from author-declared `backfilled`), so the asymmetry is surfaced without inventing tuning parameters the author never recorded. A future slice can populate real `backfilled` entries from config history; the schema, manifest, and review surface are ready for it.

## Validation (CPU only)

Focused tests; no campaigns, no Slurm, no training runs.

```
uv run pytest tests/benchmark/test_camera_ready_tuning_effort_issue_5143.py -v   # 25 passed
uv run pytest tests/benchmark/test_camera_ready_campaign.py                       # 135 passed (no regressions; +1 identity assertion)
uv run pytest tests/benchmark/test_camera_ready_checkpoint_submit_preflight.py \
              tests/benchmark/test_campaign_checkpoint_preflight.py \
              tests/benchmark/test_confirmation_v1_matrix.py                     # 23 passed
uv run pytest tests/unit/benchmark/                                              # 84 passed
uv run ruff check <changed files>                                                # All checks passed
uv run ruff format <changed files>                                               # clean
```

End-to-end smoke: loading `configs/benchmarks/confirmation_v1_smoke.yaml` (no tuning blocks) yields `tuning_effort_enforcement: off` and `tuning=None` for all arms — confirming backwards compatibility. (The config's separate pre-existing route-clearance failure for atomic test scenarios is unrelated to this change.)

## Evidence grade

Exploratory **auditability metadata** (not benchmark evidence by itself): it records tuning effort so the asymmetry is reviewable; it does not change any measured outcome. No paper-facing or benchmark-result claim is made.

## Artifact handling

No `output/*` artifacts produced or tracked. Worktree-local venv only.

## Downstream propagation

NA — support/tooling change (manifest metadata schema + enforcement gate); no research claim, no measured result, no benchmark/metric change.

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-planner tuning-effort metadata to campaign manifests, including tuned parameters, scenarios, budgets, provenance, and timestamps.
  * Added tuning-effort summaries showing declared and pending metadata across planners.
  * Added configurable enforcement modes: off, warn, or error.
  * Added public `TuningSpec` configuration support and compatibility exports.
* **Bug Fixes**
  * Campaign validation now fails safely when required tuning metadata is missing under strict enforcement.
* **Documentation**
  * Documented the tuning-effort manifest format, backfilling behavior, and enforcement options.
* **Tests**
  * Added coverage for parsing, validation, manifest generation, and enforcement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->