### PR TITLE
Issue #2910: release suite reference dereference validation (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/release_suite_reference_validation.py
+++ b/robot_sf/benchmark/release_suite_reference_validation.py
@@ -1,0 +1,237 @@
+"""Dereference validation for benchmark release suite metadata references.
+
+This module confirms that the six metadata references declared by each release
+suite manifest (see :mod:`robot_sf.benchmark.release_suite_contract`) resolve to
+existing, non-empty, parseable records under a caller-supplied base directory.
+It upgrades the structural presence check from issue #2910 / PR #5134 from
+"is a non-empty string" to "points at a real record that parses".
+
+Claim boundary
+--------------
+Dereference validation only. A pass confirms each reference resolves to a real,
+non-empty, parseable file **without** escaping the base directory. It does not
+interpret the referenced content, enforce per-owner schemas, freeze a suite, run
+a campaign, establish benchmark evidence, or authorize publication. Passing is
+necessary but not sufficient for benchmark release readiness.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.release_suite_contract import (
+    REQUIRED_SUITE_METADATA_FIELDS,
+    ReleaseSuiteContractManifest,
+    ReleaseSuiteDeclaration,
+)
+
+RELEASE_SUITE_REFERENCE_REPORT_SCHEMA_VERSION = "benchmark-release-suite-reference-report.v0.1"
+REFERENCE_VALIDATION_CLAIM_BOUNDARY = (
+    "Dereference validation only; a pass does not interpret referenced content, enforce per-owner "
+    "schemas, freeze suites, validate campaigns, establish benchmark evidence, or authorize "
+    "publication."
+)
+
+
+class ReleaseSuiteReferenceError(ValueError):
+    """Raised when reference validation cannot be evaluated safely."""
+
+
+@dataclass(frozen=True)
+class ReferenceResolution:
+    """Outcome of resolving a single metadata reference under the base directory."""
+
+    field: str
+    reference: str
+    status: str
+    detail: str = ""
+
+
+def _parse_record(path: Path) -> Any:
+    """Parse a JSON or YAML record from ``path``.
+
+    Returns:
+        Parsed JSON or YAML value.
+
+    Raises:
+        ValueError: If the payload is empty or cannot be parsed.
+    """
+
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        raise ValueError("referenced file is empty")
+    if path.suffix.lower() == ".json":
+        return json.loads(text)
+    return yaml.safe_load(text)
+
+
+def _resolve_reference(
+    base_dir: Path,
+    suite: ReleaseSuiteDeclaration,
+    field: str,
+) -> ReferenceResolution:
+    """Resolve one metadata reference against ``base_dir`` fail-closed.
+
+    A reference is accepted only when it resolves to an existing, non-empty,
+    parseable regular file **inside** ``base_dir``. Path traversal outside the
+    base directory fails closed rather than following an escaped reference.
+
+    Returns:
+        The resolution outcome (``resolved``) or a blocked/not-available outcome
+        with a human-readable detail string.
+    """
+
+    reference = suite.metadata.get(field)
+    if not isinstance(reference, str) or not reference.strip():
+        return ReferenceResolution(
+            field=field,
+            reference=str(reference),
+            status="blocked",
+            detail="reference is missing or is not a non-empty string",
+        )
+    reference = reference.strip()
+
+    candidate = (base_dir / reference).resolve()
+    try:
+        base_resolved = base_dir.resolve()
+    except OSError as exc:
+        raise ReleaseSuiteReferenceError(f"Could not resolve base_dir {base_dir}: {exc}") from exc
+    try:
+        candidate.relative_to(base_resolved)
+    except ValueError:
+        return ReferenceResolution(
+            field=field,
+            reference=reference,
+            status="blocked",
+            detail="reference escapes the base directory",
+        )
+
+    if not candidate.exists():
+        return ReferenceResolution(
+            field=field,
+            reference=reference,
+            status="not_available",
+            detail=f"referenced file does not exist: {candidate}",
+        )
+    if not candidate.is_file():
+        return ReferenceResolution(
+            field=field,
+            reference=reference,
+            status="blocked",
+            detail="referenced path is not a regular file",
+        )
+
+    try:
+        parsed = _parse_record(candidate)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        return ReferenceResolution(
+            field=field,
+            reference=reference,
+            status="blocked",
+            detail=f"referenced file is not parseable: {exc}",
+        )
+    if parsed is None:
+        return ReferenceResolution(
+            field=field,
+            reference=reference,
+            status="blocked",
+            detail="referenced file parses to null",
+        )
+
+    return ReferenceResolution(field=field, reference=reference, status="resolved")
+
+
+def evaluate_release_suite_references(
+    manifest: ReleaseSuiteContractManifest,
+    base_dir: str | Path,
+) -> dict[str, Any]:
+    """Return a deterministic, fail-closed dereference report for all suites.
+
+    Every reference for every suite is resolved. Missing references and any
+    resolution failure accumulate as blockers so callers receive a complete
+    report instead of only the first failure.
+
+    Args:
+        manifest: A structurally loaded release suite manifest.
+        base_dir: Directory against which each metadata reference is resolved.
+
+    Returns:
+        Deterministic dereference report. ``status`` is ``"pass"`` only when
+        every required reference on every suite resolves to a real, non-empty,
+        parseable file inside ``base_dir``.
+
+    Raises:
+        ReleaseSuiteReferenceError: If ``base_dir`` does not exist or is not a
+            directory.
+    """
+
+    base_path = Path(base_dir)
+    if not base_path.exists():
+        raise ReleaseSuiteReferenceError(f"base_dir does not exist: {base_path}")
+    if not base_path.is_dir():
+        raise ReleaseSuiteReferenceError(f"base_dir is not a directory: {base_path}")
+
+    suite_results: list[dict[str, Any]] = []
+    blockers: list[str] = []
+    resolved_count = 0
+    total_count = 0
+    for suite in manifest.suites:
+        resolutions: list[dict[str, Any]] = []
+        suite_blocked = False
+        for field in REQUIRED_SUITE_METADATA_FIELDS:
+            total_count += 1
+            resolution = _resolve_reference(base_path, suite, field)
+            resolutions.append(
+                {
+                    "field": resolution.field,
+                    "reference": resolution.reference,
+                    "status": resolution.status,
+                    "detail": resolution.detail,
+                }
+            )
+            if resolution.status == "resolved":
+                resolved_count += 1
+            else:
+                suite_blocked = True
+                blockers.append(
+                    f"{suite.suite_id}.{resolution.field} ({resolution.reference}): {resolution.detail}"
+                )
+        suite_results.append(
+            {
+                "suite_id": suite.suite_id,
+                "status": "blocked" if suite_blocked else "resolved",
+                "references": resolutions,
+            }
+        )
+
+    return {
+        "schema_version": RELEASE_SUITE_REFERENCE_REPORT_SCHEMA_VERSION,
+        "manifest_schema_version": manifest.schema_version,
+        "release_id": manifest.release_id,
+        "base_dir": str(base_path),
+        "status": "blocked" if blockers else "pass",
+        "claim_boundary": REFERENCE_VALIDATION_CLAIM_BOUNDARY,
+        "required_suite_metadata_fields": list(REQUIRED_SUITE_METADATA_FIELDS),
+        "suite_count": len(suite_results),
+        "resolved_suite_count": sum(result["status"] == "resolved" for result in suite_results),
+        "blocked_suite_count": sum(result["status"] == "blocked" for result in suite_results),
+        "reference_count": total_count,
+        "resolved_reference_count": resolved_count,
+        "blocked_reference_count": total_count - resolved_count,
+        "blockers": blockers,
+        "suites": suite_results,
+    }
+
+
+__all__ = [
+    "REFERENCE_VALIDATION_CLAIM_BOUNDARY",
+    "RELEASE_SUITE_REFERENCE_REPORT_SCHEMA_VERSION",
+    "ReferenceResolution",
+    "ReleaseSuiteReferenceError",
+    "evaluate_release_suite_references",
+]

--- a/scripts/validation/check_release_suite_contract.py
+++ b/scripts/validation/check_release_suite_contract.py
@@ -2,8 +2,10 @@
 """Check structural metadata completeness for a benchmark release suite manifest.
 
 The checker can block on incomplete declarations, but it cannot freeze suites,
-validate the referenced records, establish benchmark evidence, or publish a
-release.
+establish benchmark evidence, or publish a release. Passing ``--base-dir``
+additionally dereferences each metadata reference against that directory
+(see :mod:`robot_sf.benchmark.release_suite_reference_validation`); it still
+does not interpret the referenced content or authorize publication.
 """
 
 from __future__ import annotations
@@ -18,6 +20,10 @@ from robot_sf.benchmark.release_suite_contract import (
     ReleaseSuiteContractError,
     evaluate_release_suite_contract,
     load_release_suite_contract,
+)
+from robot_sf.benchmark.release_suite_reference_validation import (
+    ReleaseSuiteReferenceError,
+    evaluate_release_suite_references,
 )
 
 if TYPE_CHECKING:
@@ -36,6 +42,13 @@ def _render_text(report: dict[str, object]) -> str:
             f"{report['blocked_suite_count']} blocked"
         ),
     ]
+    reference_report = report.get("reference_validation")
+    if isinstance(reference_report, dict):
+        lines.append(
+            "reference validation: "
+            f"{reference_report['resolved_reference_count']} resolved, "
+            f"{reference_report['blocked_reference_count']} blocked"
+        )
     blockers = report["blockers"]
     if isinstance(blockers, list):
         lines.extend(f"blocker: {blocker}" for blocker in blockers)
@@ -47,13 +60,29 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument(
+        "--base-dir",
+        type=Path,
+        help=(
+            "When set, additionally dereference every metadata reference against this "
+            "directory. Confirms each reference resolves to a real, non-empty, parseable "
+            "file without escaping the directory."
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="Emit the report as JSON.")
     args = parser.parse_args(argv)
 
     try:
         manifest = load_release_suite_contract(args.manifest)
         report = evaluate_release_suite_contract(manifest)
-    except ReleaseSuiteContractError as exc:
+        if args.base_dir is not None:
+            reference_report = evaluate_release_suite_references(manifest, args.base_dir)
+            report["reference_validation"] = reference_report
+            if reference_report["status"] != "pass":
+                report["status"] = "blocked"
+                report.setdefault("blockers", [])
+                report["blockers"].extend(reference_report["blockers"])
+    except (ReleaseSuiteContractError, ReleaseSuiteReferenceError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 

--- a/tests/benchmark/test_release_suite_reference_validation.py
+++ b/tests/benchmark/test_release_suite_reference_validation.py
@@ -1,0 +1,438 @@
+"""Tests for benchmark release suite metadata reference dereference validation."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.release_suite_contract import (
+    RELEASE_SUITE_CONTRACT_SCHEMA_VERSION,
+    load_release_suite_contract,
+)
+from robot_sf.benchmark.release_suite_reference_validation import (
+    REFERENCE_VALIDATION_CLAIM_BOUNDARY,
+    RELEASE_SUITE_REFERENCE_REPORT_SCHEMA_VERSION,
+    ReleaseSuiteReferenceError,
+    evaluate_release_suite_references,
+)
+from scripts.validation import check_release_suite_contract
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Reuse the canonical six metadata-owner field names.
+REQUIRED_FIELDS = (
+    "odd_contract",
+    "scenario_contract",
+    "scenario_certification",
+    "planner_row_status",
+    "seed_schedule",
+    "artifact_manifest",
+)
+
+
+def _suite(suite_id: str = "nominal") -> dict[str, str]:
+    """Build one structurally complete suite declaration."""
+
+    return {
+        "suite_id": suite_id,
+        "odd_contract": f"contracts/{suite_id}/odd.yaml",
+        "scenario_contract": f"contracts/{suite_id}/scenarios.yaml",
+        "scenario_certification": f"certification/{suite_id}.json",
+        "planner_row_status": f"rows/{suite_id}.json",
+        "seed_schedule": f"seeds/{suite_id}.yaml",
+        "artifact_manifest": f"artifacts/{suite_id}.json",
+    }
+
+
+def _manifest_payload(suites: list[object]) -> dict[str, object]:
+    """Build a minimal suite-contract manifest payload."""
+
+    return {
+        "schema_version": RELEASE_SUITE_CONTRACT_SCHEMA_VERSION,
+        "release_id": "benchmark-v0.1-candidate",
+        "suites": suites,
+    }
+
+
+def _write_manifest(path: Path, payload: object) -> None:
+    """Write a YAML or JSON manifest fixture."""
+
+    if path.suffix == ".json":
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    else:
+        path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _materialize_suite_records(base_dir: Path, suite_id: str = "nominal") -> dict[str, str]:
+    """Materialize parseable record files for every reference of one suite."""
+
+    records = _suite(suite_id)
+    for field in REQUIRED_FIELDS:
+        relative = records[field]
+        target = base_dir / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        payload: object = {"suite_id": suite_id, "field": field}
+        if target.suffix == ".json":
+            target.write_text(json.dumps(payload), encoding="utf-8")
+        else:
+            target.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return records
+
+
+def _load_manifest(tmp_path: Path, suites: list[object]) -> object:
+    """Write and structurally load a suite manifest fixture."""
+
+    manifest_path = tmp_path / "release_suites.yaml"
+    _write_manifest(manifest_path, _manifest_payload(suites))
+    return load_release_suite_contract(manifest_path)
+
+
+def test_all_resolved_references_pass(tmp_path: Path) -> None:
+    """Every reference resolving to a parseable file yields a pass."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    _materialize_suite_records(base_dir, "nominal")
+    manifest = _load_manifest(tmp_path, [_suite("nominal")])
+
+    report = evaluate_release_suite_references(manifest, base_dir)
+
+    assert report["status"] == "pass"
+    assert report["schema_version"] == RELEASE_SUITE_REFERENCE_REPORT_SCHEMA_VERSION
+    assert report["claim_boundary"] == REFERENCE_VALIDATION_CLAIM_BOUNDARY
+    assert report["release_id"] == "benchmark-v0.1-candidate"
+    assert report["base_dir"] == str(base_dir)
+    assert report["suite_count"] == 1
+    assert report["resolved_suite_count"] == 1
+    assert report["blocked_suite_count"] == 0
+    assert report["reference_count"] == 6
+    assert report["resolved_reference_count"] == 6
+    assert report["blocked_reference_count"] == 0
+    assert report["blockers"] == []
+    assert report["suites"][0]["status"] == "resolved"
+    assert len(report["suites"][0]["references"]) == 6
+    assert all(ref["status"] == "resolved" for ref in report["suites"][0]["references"])
+
+
+def test_missing_reference_file_is_not_available_and_blocks(tmp_path: Path) -> None:
+    """A reference pointing at a non-existent file fails closed as not_available."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    manifest = _load_manifest(tmp_path, [_suite("nominal")])
+
+    report = evaluate_release_suite_references(manifest, base_dir)
+
+    assert report["status"] == "blocked"
+    assert report["blocked_reference_count"] == 6
+    assert report["resolved_reference_count"] == 0
+    nominal_refs = report["suites"][0]["references"]
+    assert all(ref["status"] == "not_available" for ref in nominal_refs)
+    assert all("does not exist" in ref["detail"] for ref in nominal_refs)
+    assert len(report["blockers"]) == 6
+
+
+@pytest.mark.parametrize("field", REQUIRED_FIELDS)
+def test_single_unresolvable_reference_blocks_whole_suite(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    """A single bad reference among five good ones blocks only its suite."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    _materialize_suite_records(base_dir, "nominal")
+    suite = _suite("nominal")
+    suite[field] = "contracts/nominal/missing.yaml"
+    manifest = _load_manifest(tmp_path, [suite])
+
+    report = evaluate_release_suite_references(manifest, base_dir)
+
+    assert report["status"] == "blocked"
+    assert report["resolved_reference_count"] == 5
+    assert report["blocked_reference_count"] == 1
+    bad = next(ref for ref in report["suites"][0]["references"] if ref["field"] == field)
+    assert bad["status"] == "not_available"
+    assert len(report["blockers"]) == 1
+    assert report["blockers"][0].startswith(f"nominal.{field} ")
+
+
+def test_path_traversal_outside_base_dir_fails_closed(tmp_path: Path) -> None:
+    """References that escape the base directory must not be followed."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    outside = tmp_path / "outside.json"
+    outside.write_text(json.dumps({"escaped": True}), encoding="utf-8")
+    suite = _suite("nominal")
+    # All references resolve except one that escapes the base directory.
+    suite["artifact_manifest"] = str(outside)
+    manifest = _load_manifest(tmp_path, [suite])
+
+    report = evaluate_release_suite_references(manifest, base_dir)
+
+    assert report["status"] == "blocked"
+    escaped = next(
+        ref for ref in report["suites"][0]["references"] if ref["field"] == "artifact_manifest"
+    )
+    assert escaped["status"] == "blocked"
+    assert escaped["detail"] == "reference escapes the base directory"
+    assert escaped["reference"] == str(outside)
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["", "   \n  \t  "],
+)
+def test_empty_referenced_file_blocks(tmp_path: Path, content: str) -> None:
+    """A referenced file that is empty or whitespace-only fails closed."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    _materialize_suite_records(base_dir, "nominal")
+    # Overwrite one record with empty content.
+    (base_dir / _suite("nominal")["seed_schedule"]).write_text(content, encoding="utf-8")
+    manifest = _load_manifest(tmp_path, [_suite("nominal")])
+
+    report = evaluate_release_suite_references(manifest, base_dir)
+
+    assert report["status"] == "blocked"
+    bad = next(ref for ref in report["suites"][0]["references"] if ref["field"] == "seed_schedule")
+    assert bad["status"] == "blocked"
+    assert "empty" in bad["detail"]
+
+
+def test_malformed_referenced_file_blocks(tmp_path: Path) -> None:
+    """A referenced file that does not parse fails closed."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    _materialize_suite_records(base_dir, "nominal")
+    # Write malformed JSON into a .json record.
+    (base_dir / _suite("nominal")["planner_row_status"]).write_text(
+        "{not valid json", encoding="utf-8"
+    )
+    manifest = _load_manifest(tmp_path, [_suite("nominal")])
+
+    report = evaluate_release_suite_references(manifest, base_dir)
+
+    assert report["status"] == "blocked"
+    bad = next(
+        ref for ref in report["suites"][0]["references"] if ref["field"] == "planner_row_status"
+    )
+    assert bad["status"] == "blocked"
+    assert "not parseable" in bad["detail"]
+
+
+def test_null_parsed_payload_blocks(tmp_path: Path) -> None:
+    """A referenced YAML/JSON file that parses to null fails closed."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    _materialize_suite_records(base_dir, "nominal")
+    (base_dir / _suite("nominal")["odd_contract"]).write_text("null", encoding="utf-8")
+    manifest = _load_manifest(tmp_path, [_suite("nominal")])
+
+    report = evaluate_release_suite_references(manifest, base_dir)
+
+    assert report["status"] == "blocked"
+    bad = next(ref for ref in report["suites"][0]["references"] if ref["field"] == "odd_contract")
+    assert bad["status"] == "blocked"
+    assert "null" in bad["detail"]
+
+
+def test_directory_reference_blocks(tmp_path: Path) -> None:
+    """A reference that resolves to a directory rather than a file fails closed."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    _materialize_suite_records(base_dir, "nominal")
+    # Make the certification reference point at a directory.
+    suite = _suite("nominal")
+    cert_dir = base_dir / "certification" / "nominal_dir"
+    cert_dir.mkdir(parents=True)
+    suite["scenario_certification"] = "certification/nominal_dir"
+    manifest = _load_manifest(tmp_path, [suite])
+
+    report = evaluate_release_suite_references(manifest, base_dir)
+
+    assert report["status"] == "blocked"
+    bad = next(
+        ref for ref in report["suites"][0]["references"] if ref["field"] == "scenario_certification"
+    )
+    assert bad["status"] == "blocked"
+    assert bad["detail"] == "referenced path is not a regular file"
+
+
+def test_blockers_accumulate_across_multiple_suites(tmp_path: Path) -> None:
+    """Reference failures accumulate across every suite instead of stopping early."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    _materialize_suite_records(base_dir, "nominal")
+    # Second suite references nothing materialized.
+    manifest = _load_manifest(tmp_path, [_suite("nominal"), _suite("stress")])
+
+    report = evaluate_release_suite_references(manifest, base_dir)
+
+    assert report["status"] == "blocked"
+    assert report["suite_count"] == 2
+    assert report["resolved_suite_count"] == 1
+    assert report["blocked_suite_count"] == 1
+    assert report["resolved_reference_count"] == 6
+    assert report["blocked_reference_count"] == 6
+    assert len(report["blockers"]) == 6
+    assert all(blocker.startswith("stress.") for blocker in report["blockers"])
+
+
+def test_structurally_missing_reference_field_blocks(tmp_path: Path) -> None:
+    """A reference field that is not a non-empty string fails closed at dereference time."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    suite = _suite("nominal")
+    suite["seed_schedule"] = None
+    manifest = _load_manifest(tmp_path, [suite])
+
+    report = evaluate_release_suite_references(manifest, base_dir)
+
+    assert report["status"] == "blocked"
+    bad = next(ref for ref in report["suites"][0]["references"] if ref["field"] == "seed_schedule")
+    assert bad["status"] == "blocked"
+    assert "non-empty string" in bad["detail"]
+
+
+def test_nonexistent_base_dir_raises(tmp_path: Path) -> None:
+    """Evaluation must fail closed when the base directory does not exist."""
+
+    base_dir = tmp_path / "missing"
+    manifest = _load_manifest(tmp_path, [_suite("nominal")])
+
+    with pytest.raises(ReleaseSuiteReferenceError, match="base_dir does not exist"):
+        evaluate_release_suite_references(manifest, base_dir)
+
+
+def test_file_base_dir_raises(tmp_path: Path) -> None:
+    """Evaluation must fail closed when the base dir path is a file."""
+
+    base_dir = tmp_path / "not_a_dir.json"
+    base_dir.write_text("{}", encoding="utf-8")
+    manifest = _load_manifest(tmp_path, [_suite("nominal")])
+
+    with pytest.raises(ReleaseSuiteReferenceError, match="not a directory"):
+        evaluate_release_suite_references(manifest, base_dir)
+
+
+def test_report_is_deterministic_for_repeated_evaluation(tmp_path: Path) -> None:
+    """Repeated evaluation of the same manifest yields identical reports."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    _materialize_suite_records(base_dir, "nominal")
+    manifest = _load_manifest(tmp_path, [_suite("nominal")])
+
+    first = evaluate_release_suite_references(manifest, base_dir)
+    second = evaluate_release_suite_references(manifest, base_dir)
+
+    assert first == second
+
+
+def test_cli_base_dir_pass_when_all_references_resolve(tmp_path: Path) -> None:
+    """The CLI passes only when --base-dir dereferences resolve every reference."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    _materialize_suite_records(base_dir, "nominal")
+    manifest_path = tmp_path / "release_suites.yaml"
+    _write_manifest(manifest_path, _manifest_payload([_suite("nominal")]))
+
+    exit_code = check_release_suite_contract.main(
+        ["--manifest", str(manifest_path), "--base-dir", str(base_dir), "--json"]
+    )
+
+    assert exit_code == 0
+
+
+def test_cli_base_dir_blocks_on_missing_reference(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The CLI exits blocked when --base-dir dereferences find a missing file."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    manifest_path = tmp_path / "release_suites.yaml"
+    _write_manifest(manifest_path, _manifest_payload([_suite("nominal")]))
+
+    exit_code = check_release_suite_contract.main(
+        ["--manifest", str(manifest_path), "--base-dir", str(base_dir)]
+    )
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "reference validation: 0 resolved, 6 blocked" in out
+    assert "blocker: nominal." in out
+
+
+def test_cli_without_base_dir_unchanged_and_ignores_references(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Without --base-dir the structural-only behavior is backward-compatible."""
+
+    manifest_path = tmp_path / "release_suites.yaml"
+    _write_manifest(manifest_path, _manifest_payload([_suite("nominal")]))
+
+    exit_code = check_release_suite_contract.main(["--manifest", str(manifest_path), "--json"])
+
+    assert exit_code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "pass"
+    assert "reference_validation" not in out
+
+
+def test_cli_base_dir_with_malformed_base_dir_errors(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A malformed base directory surfaces as the malformed exit code (2)."""
+
+    base_dir = tmp_path / "missing"
+    manifest_path = tmp_path / "release_suites.yaml"
+    _write_manifest(manifest_path, _manifest_payload([_suite("nominal")]))
+
+    exit_code = check_release_suite_contract.main(
+        ["--manifest", str(manifest_path), "--base-dir", str(base_dir)]
+    )
+
+    assert exit_code == 2
+    assert "error:" in capsys.readouterr().err
+
+
+def test_reference_resolution_handles_symlink_inside_base_dir(tmp_path: Path) -> None:
+    """A symlink that stays within the base directory resolves normally."""
+
+    base_dir = tmp_path / "evidence"
+    base_dir.mkdir()
+    _materialize_suite_records(base_dir, "nominal")
+    # Replace the artifact manifest with a symlink to an in-base-dir file.
+    real = base_dir / "artifacts" / "nominal_real.json"
+    real.write_text(json.dumps({"via": "symlink"}), encoding="utf-8")
+    link = base_dir / "artifacts" / "nominal.json"
+    link.unlink()
+    link.symlink_to(real)
+    manifest = _load_manifest(tmp_path, [_suite("nominal")])
+
+    report = evaluate_release_suite_references(manifest, base_dir)
+
+    assert report["status"] == "pass"
+    bad = [
+        ref
+        for ref in report["suites"][0]["references"]
+        if ref["field"] == "artifact_manifest" and ref["status"] != "resolved"
+    ]
+    assert bad == []


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Adds dereference validation for benchmark release suite metadata references. The merged #5134 checker only confirmed each of the six required metadata references (ODD contract, scenario contract, scenario certification, planner-row status, seed schedule, artifact manifest) was a non-empty string. This slice upgrades that to confirm each reference resolves to a real, non-empty, parseable file under a caller-supplied base directory — without escaping it.

**Why now:** The latest #2910 gate update (PR #5134) names the remaining epic work as **"real suite freeze, reference validation, and publication gates."** This delivers the named **"reference validation"** capability — the next unimplemented, bounded, CPU-only slice.

**Claim boundary:** Dereference validation only. A pass confirms each reference resolves to a real, non-empty, parseable file inside the base directory. It does **not** interpret referenced content, enforce per-owner schemas, freeze a suite, run a campaign, establish benchmark evidence, or authorize publication. Passing is necessary but not sufficient for benchmark release readiness.

## Successor statement

**Successor slice: reference validation; does not duplicate PR #5134** (structural completeness), **#3732** (release-prerequisite presence preflight), or **#3296** (release claim matrix). It adds NEW capability: actually dereferencing the metadata references instead of only checking string presence.

## New capability

- `robot_sf/benchmark/release_suite_reference_validation.py` — `evaluate_release_suite_references(manifest, base_dir)`:
  - Resolves every one of the six required references for every declared suite.
  - Accepts a reference only when it resolves to an existing, non-empty, parseable (JSON or YAML), non-null regular file.
  - **Fails closed on path traversal** outside the base directory (does not follow escaped references).
  - Accumulates blockers across all suites and all references (does not stop at the first failure).
  - Distinguishes `not_available` (file missing) from `blocked` (malformed/empty/directory/escape/non-string) in per-reference status.
- `scripts/validation/check_release_suite_contract.py` gains an optional `--base-dir DIR`:
  - Composes dereference validation on top of the structural check.
  - When `--base-dir` is supplied, the final status is `blocked` if **either** gate blocks; blockers from both are surfaced.
  - **Without** `--base-dir`, the structural-only behavior is unchanged (backward-compatible) — verified by the existing structural test suite still passing.

## Validation (CPU-only, local venv)

```
uv run python -m pytest tests/benchmark/test_release_suite_reference_validation.py tests/benchmark/test_release_suite_contract.py -q
  -> 58 passed (24 new + 34 existing, unchanged)

uv run ruff check robot_sf/benchmark/release_suite_reference_validation.py scripts/validation/check_release_suite_contract.py tests/benchmark/test_release_suite_reference_validation.py
  -> All checks passed

uv run ruff format <changed files>
  -> applied
```

CLI end-to-end smoke (fail-closed confirmed):

```
# All references resolve -> exit 0
scripts/validation/check_release_suite_contract.py --manifest <m> --base-dir <e>
  status: pass
  suites: 1 complete, 0 blocked
  reference validation: 6 resolved, 0 blocked

# References missing -> exit 1, 6 enumerated blockers
  status: blocked
  suites: 1 complete, 0 blocked
  reference validation: 0 resolved, 6 blocked
  blocker: nominal.odd_contract (...): referenced file does not exist: ...
  ...

# Without --base-dir -> unchanged structural-only output (exit 0)
```

New test coverage (24 tests) includes: all-resolved pass; missing file → `not_available`; single bad reference among good ones blocks the suite; path-traversal escape fails closed; empty/whitespace file blocks; malformed JSON blocks; null-parsed payload blocks; directory reference blocks; blockers accumulate across multiple suites; structurally-missing field blocks; nonexistent/file base-dir raises; deterministic repeated evaluation; CLI pass/blocked/malformed exit codes; backward-compatible no-`--base-dir` path; symlink inside base dir resolves.

## Explicitly out of scope

- No content/schema interpretation of referenced records (later slice).
- No suite freeze, release publication, tag, upload, or readiness promotion.
- No full benchmark campaign run; no Slurm/GPU.
- No paper/dissertation claim edits.
- Pre-existing CLI startup log noise (registry/TensorFlow warnings) is tracked by #5090 per #5134's notes; not introduced here.

Refs #2910

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
