### PR TITLE
Issue #5141: explicit distance_convention field on series/metric exports + lint (cheap-lane worker)

### DIFF
--- a/docs/ped_metrics/metrics_spec.md
+++ b/docs/ped_metrics/metrics_spec.md
@@ -24,6 +24,36 @@ Threshold provenance and reproducibility contract:
 - The sensitivity workflow in `scripts/benchmark_threshold_sensitivity.py` quantifies
   how metric summaries change across threshold grids per scenario family.
 
+## Distance Conventions
+
+Distance quantities cross this benchmark in three incompatible conventions. A
+value with no stated convention is ambiguous and has already caused a misreading
+(a center-to-center distance of 1.37 m was read as surface clearance, flipping a
+collision attribution, issue #5141). Every exported distance-like series and
+metric must therefore carry an explicit `distance_convention` field drawn from
+this enum:
+
+| Convention | Meaning | Where it is used |
+| --- | --- | --- |
+| `center_center` | Euclidean distance between two point centers (footprint radii are NOT subtracted). The runtime collision trigger compares center distance against the summed radii. | Trace export `min_robot_ped_distance_m` columns (`min_distance_series.csv`); the `center_distance_m` geometric diagnostic; `agent_collisions` / `wall_collisions` legacy predicates. |
+| `surface_clearance` | Center-to-center distance minus the summed footprint radii: `clearance = center_distance - robot_radius - ped_radius`. A collision is `clearance < 0`. | The canonical pedestrian safety metric `surface_clearance_m`; `collisions`, `near_misses`, `min_clearance`, `mean_clearance`; SNQI and policy-search near-miss metrics. |
+| `center_segment` | Shortest distance from a point center to a wall/obstacle segment. | Wall/obstacle collision geometry (`min_m ||robot_pos - obstacles[m]||`) and wall-collision tests. |
+
+### Required metadata field
+
+The enum and field name are canonicalized in
+`robot_sf/evidence/distance_convention.py` (`DistanceConvention`, field
+`distance_convention`). Export scripts attach the field to their series/metric
+metadata (`metadata.json` and the embedded `trace_series.json` metadata), and the
+distance-series CSVs carry a `# distance_convention: <value>` header line.
+
+The evidence-writer lint (`scripts/ci/pr_contract_check.py` rule 4, paired with
+the evidence-writer adoption plan #4921) fails new distance-like series under
+`docs/context/evidence/` that omit the field — either in the file itself or in a
+sibling `metadata.json`. Use `robot_sf.evidence.writers.write_distance_series_csv`
+for new distance-series exports so the field and review marker are written
+consistently.
+
 ## Core Metrics
 
 ### Safety Metrics

--- a/robot_sf/evidence/__init__.py
+++ b/robot_sf/evidence/__init__.py
@@ -1,1 +1,23 @@
 """Evidence tree utilities for reproducible exports."""
+
+from robot_sf.evidence.distance_convention import (
+    DISTANCE_CONVENTION_FIELD,
+    DISTANCE_LIKE_COLUMN_TOKENS,
+    DISTANCE_LIKE_FILENAME_TOKENS,
+    DistanceConvention,
+    has_distance_like_columns,
+    is_distance_like_filename,
+    require_distance_convention,
+    validate_distance_convention,
+)
+
+__all__ = [
+    "DISTANCE_CONVENTION_FIELD",
+    "DISTANCE_LIKE_COLUMN_TOKENS",
+    "DISTANCE_LIKE_FILENAME_TOKENS",
+    "DistanceConvention",
+    "has_distance_like_columns",
+    "is_distance_like_filename",
+    "require_distance_convention",
+    "validate_distance_convention",
+]

--- a/robot_sf/evidence/distance_convention.py
+++ b/robot_sf/evidence/distance_convention.py
@@ -1,0 +1,165 @@
+"""Explicit distance-convention vocabulary for exported series and metrics.
+
+Issue #5141: distance quantities cross the codebase in at least three
+incompatible conventions, and exports historically did not state which one they
+carry. That ambiguity already caused a trace bundle misreading (1.37 m of
+center-to-center distance read as surface clearance, flipping a collision
+attribution).
+
+This module is the single source of truth for the convention enum and the
+metadata field name. Export scripts attach ``distance_convention`` to their
+series/metric metadata, and the evidence-writer lint
+(``scripts/ci/pr_contract_check.py`` rule 4) fails distance-like series that
+omit it.
+
+Conventions:
+
+- ``center_center``: Euclidean distance between two point centers (e.g. robot
+  center to pedestrian center, or the runtime collision trigger = radius sum).
+  The trace export ``min_robot_ped_distance_m`` column is center-to-center.
+- ``surface_clearance``: center-to-center distance minus the summed footprint
+  radii (clearance = center_distance - robot_radius - ped_radius). The
+  benchmark pedestrian safety metric ``surface_clearance_m`` uses this; a
+  collision is ``clearance < 0``.
+- ``center_segment``: shortest distance from a point center to a wall/obstacle
+  segment (e.g. robot center to obstacle point/segment in wall-collision
+  tests).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+#: Canonical metadata field name carried by series/metric export payloads.
+DISTANCE_CONVENTION_FIELD: str = "distance_convention"
+
+#: Filename substrings that mark an exported file as a distance-like series.
+#: The evidence-writer lint requires these to carry the convention field.
+DISTANCE_LIKE_FILENAME_TOKENS: tuple[str, ...] = ("distance", "clearance")
+
+#: Column-header substrings that mark a CSV column as distance-like.
+DISTANCE_LIKE_COLUMN_TOKENS: tuple[str, ...] = (
+    "distance",
+    "clearance",
+    "_dist",
+    "min_clearance",
+)
+
+
+class DistanceConvention(StrEnum):
+    """The three distance conventions used by exported series and metrics.
+
+    Inherits ``str`` so values serialize directly into JSON metadata and
+    compare equal to their plain string value (``center_center`` etc.).
+    """
+
+    CENTER_CENTER = "center_center"
+    SURFACE_CLEARANCE = "surface_clearance"
+    CENTER_SEGMENT = "center_segment"
+
+
+#: Human-readable description of each convention, used by docs and lint messages.
+CONVENTION_DESCRIPTIONS: dict[DistanceConvention, str] = {
+    DistanceConvention.CENTER_CENTER: (
+        "center-to-center Euclidean distance between two point centers "
+        "(e.g. robot-to-pedestrian center distance; the runtime collision "
+        "trigger is the radius sum). Surface footprint is NOT subtracted."
+    ),
+    DistanceConvention.SURFACE_CLEARANCE: (
+        "surface clearance = center-to-center distance minus the summed "
+        "footprint radii (clearance = center_distance - robot_radius - "
+        "ped_radius). Collisions are clearance < 0."
+    ),
+    DistanceConvention.CENTER_SEGMENT: (
+        "shortest distance from a point center to a wall/obstacle segment "
+        "(e.g. robot center to obstacle point/segment in wall-collision tests)."
+    ),
+}
+
+
+def validate_distance_convention(value: Any) -> DistanceConvention:
+    """Return the :class:`DistanceConvention` for ``value`` or raise ``ValueError``.
+
+    Accepts a :class:`DistanceConvention`, or its string value
+    (``center_center`` / ``surface_clearance`` / ``center_segment``).
+
+    Raises:
+        ValueError: If ``value`` is not a recognized convention.
+    """
+    if isinstance(value, DistanceConvention):
+        return value
+    if isinstance(value, str):
+        try:
+            return DistanceConvention(value)
+        except ValueError as exc:
+            valid = ", ".join(c.value for c in DistanceConvention)
+            raise ValueError(
+                f"Unknown {DISTANCE_CONVENTION_FIELD}={value!r}; expected one of: {valid}"
+            ) from exc
+    raise ValueError(
+        f"{DISTANCE_CONVENTION_FIELD} must be a string or DistanceConvention, "
+        f"got {type(value).__name__}"
+    )
+
+
+def require_distance_convention(metadata: dict[str, Any], series_name: str) -> DistanceConvention:
+    """Assert that ``metadata`` carries a valid ``distance_convention`` field.
+
+    Used by export scripts to fail closed at write time when a distance-like
+    series omits the field, and by the evidence-writer lint.
+
+    Args:
+        metadata: The series/metric export metadata mapping.
+        series_name: Human-readable series identifier for the error message
+            (e.g. ``"min_distance_series.csv"``).
+
+    Returns:
+        The validated :class:`DistanceConvention`.
+
+    Raises:
+        ValueError: If the field is missing or not a recognized convention.
+    """
+    if DISTANCE_CONVENTION_FIELD not in metadata:
+        raise ValueError(
+            f"distance-like series {series_name!r} is missing the required "
+            f"{DISTANCE_CONVENTION_FIELD!r} metadata field; set one of: "
+            + ", ".join(c.value for c in DistanceConvention)
+        )
+    return validate_distance_convention(metadata[DISTANCE_CONVENTION_FIELD])
+
+
+def describe_distance_convention(convention: DistanceConvention | str) -> str:
+    """Return the human-readable description for a convention value."""
+    resolved = validate_distance_convention(convention)
+    return CONVENTION_DESCRIPTIONS[resolved]
+
+
+def is_distance_like_filename(name: str) -> bool:
+    """Return True if a filename looks like a distance-like series export.
+
+    Matches filenames such as ``min_distance_series.csv`` or
+    ``robot_clearance_series.csv``.
+    """
+    lowered = name.lower()
+    return any(token in lowered for token in DISTANCE_LIKE_FILENAME_TOKENS)
+
+
+def has_distance_like_columns(header_line: str) -> bool:
+    """Return True if a CSV header line declares a distance-like column."""
+    lowered = header_line.lower()
+    return any(token in lowered for token in DISTANCE_LIKE_COLUMN_TOKENS)
+
+
+__all__ = [
+    "CONVENTION_DESCRIPTIONS",
+    "DISTANCE_CONVENTION_FIELD",
+    "DISTANCE_LIKE_COLUMN_TOKENS",
+    "DISTANCE_LIKE_FILENAME_TOKENS",
+    "DistanceConvention",
+    "describe_distance_convention",
+    "has_distance_like_columns",
+    "is_distance_like_filename",
+    "require_distance_convention",
+    "validate_distance_convention",
+]

--- a/robot_sf/evidence/writers.py
+++ b/robot_sf/evidence/writers.py
@@ -13,6 +13,12 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from robot_sf.evidence.distance_convention import (
+    DISTANCE_CONVENTION_FIELD,
+    DistanceConvention,
+    require_distance_convention,
+)
+
 
 def _repo_root() -> Path:
     """Return the current git worktree root."""
@@ -107,6 +113,41 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         raise ValueError(f"cannot write empty CSV: {path}")
     with path.open("w", newline="", encoding="utf-8") as handle:
         handle.write(review_marker_comment() + "\n")
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()), lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_distance_series_csv(
+    path: Path,
+    rows: list[dict[str, Any]],
+    *,
+    convention: DistanceConvention | str,
+    series_name: str | None = None,
+) -> None:
+    """Write a distance-like series CSV with an explicit convention annotation.
+
+    Issue #5141: distance-like series exports must declare which distance
+    convention they carry so a center-to-center value is never misread as
+    surface clearance. This writer prepends a ``# distance_convention: <x>``
+    header line next to the review marker and validates the convention value.
+
+    Args:
+        path: Output CSV path.
+        rows: CSV rows (must be non-empty).
+        convention: A :class:`DistanceConvention` or its string value
+            (``center_center`` / ``surface_clearance`` / ``center_segment``).
+        series_name: Optional series identifier for error messages; defaults
+            to the file name.
+    """
+    resolved = require_distance_convention(
+        {DISTANCE_CONVENTION_FIELD: convention}, series_name or path.name
+    )
+    if not rows:
+        raise ValueError(f"cannot write empty CSV: {path}")
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        handle.write(review_marker_comment() + "\n")
+        handle.write(f"# {DISTANCE_CONVENTION_FIELD}: {resolved.value}\n")
         writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()), lineterminator="\n")
         writer.writeheader()
         writer.writerows(rows)

--- a/scripts/ci/pr_contract_check.py
+++ b/scripts/ci/pr_contract_check.py
@@ -24,6 +24,12 @@ from pathlib import Path
 # OSError covers FileNotFoundError when git/gh is absent.
 _BEST_EFFORT_ERRORS = (OSError, subprocess.SubprocessError, ValueError, KeyError, TypeError)
 
+from robot_sf.evidence.distance_convention import (  # noqa: E402
+    DISTANCE_CONVENTION_FIELD,
+    has_distance_like_columns,
+    is_distance_like_filename,
+)
+
 # Match keywords followed by #N or a GitHub issue URL
 CLOSING_PATTERN = re.compile(
     r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+`?(?:#(\d+)|https?://github\.com/[^/\s]+/[^/\s]+/issues/(\d+))\b",
@@ -183,7 +189,7 @@ def check_state_refresh_only(changed_files: list[str], title: str, body: str) ->
     return []
 
 
-def check_evidence_tree_hygiene(changed_files: list[str], base_ref: str) -> list[str]:  # noqa: C901
+def check_evidence_tree_hygiene(changed_files: list[str], base_ref: str) -> list[str]:  # noqa: C901, PLR0912
     """Rule 4: Evidence tree marker and provenance checks."""
     blockers = []
     new_files = get_new_files(base_ref)
@@ -244,7 +250,70 @@ def check_evidence_tree_hygiene(changed_files: list[str], base_ref: str) -> list
                         f"BLOCKER: Evidence README '{f}' contains claim '{claim}', "
                         f"but is missing required provenance fields: {', '.join(missing)}."
                     )
+
+        # 3. Distance-convention field on distance-like series (issue #5141).
+        # Only enforced for NEW evidence files so the pre-existing evidence tree
+        # (which predates the field) is not retroactively flagged.
+        if is_new:
+            blocker = _check_distance_convention_for_file(f, content)
+            if blocker is not None:
+                blockers.append(blocker)
     return blockers
+
+
+def _check_distance_convention_for_file(path: str, content: str) -> str | None:
+    """Issue #5141: require a ``distance_convention`` declaration on distance-like series.
+
+    A distance-like series is either (a) a file whose name carries a distance
+    token (``distance``/``clearance``), or (b) a CSV whose header line declares a
+    distance-like column. The declaration is satisfied when the file itself
+    contains the ``distance_convention`` key/header, or a sibling ``metadata.json``
+    carries it.
+
+    Returns a BLOCKER message string when the field is missing, else ``None``.
+    """
+    basename = os.path.basename(path)
+    lowered = basename.lower()
+
+    name_is_distance_like = is_distance_like_filename(basename)
+    column_is_distance_like = False
+    if lowered.endswith(".csv"):
+        # The first non-comment, non-marker line is the CSV header.
+        header_line = ""
+        for line in content.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            header_line = stripped
+            break
+        column_is_distance_like = has_distance_like_columns(header_line)
+
+    if not (name_is_distance_like or column_is_distance_like):
+        return None
+
+    field_key = DISTANCE_CONVENTION_FIELD
+    # In-file declaration: JSON key, or a `# distance_convention:` CSV/text header line.
+    if f'"{field_key}"' in content or f"{field_key}:" in content:
+        return None
+
+    # Fallback: a sibling metadata.json carries the declaration for the bundle.
+    try:
+        directory = os.path.dirname(path) or "."
+        metadata_path = os.path.join(directory, "metadata.json")
+        if os.path.exists(metadata_path):
+            with open(metadata_path, encoding="utf-8") as meta_handle:
+                meta_content = meta_handle.read()
+            if f'"{field_key}"' in meta_content:
+                return None
+    except _BEST_EFFORT_ERRORS:
+        pass
+
+    return (
+        f"BLOCKER: New evidence series '{path}' is a distance-like series but does not "
+        f"declare the required '{field_key}' metadata field (issue #5141). Set "
+        f"distance_convention in the file or a sibling metadata.json to one of: "
+        f"center_center, surface_clearance, center_segment."
+    )
 
 
 def check_successor_discipline(title: str, body: str, repo: str) -> list[str]:

--- a/scripts/export_issue_4268_trace_episode.py
+++ b/scripts/export_issue_4268_trace_episode.py
@@ -21,6 +21,10 @@ from typing import Any
 
 from robot_sf.benchmark.classic_interactions_loader import load_classic_matrix, select_scenario
 from robot_sf.benchmark.map_runner import _run_map_episode
+from robot_sf.evidence.distance_convention import (
+    DISTANCE_CONVENTION_FIELD,
+    DistanceConvention,
+)
 
 DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_4253_trace_episode_2026-07")
 DEFAULT_SCENARIO_MATRIX = Path("configs/scenarios/classic_interactions.yaml")
@@ -193,6 +197,26 @@ def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         writer.writerows(rows)
 
 
+def _write_distance_csv(
+    path: Path,
+    rows: list[dict[str, Any]],
+    *,
+    convention: DistanceConvention,
+) -> None:
+    """Write a distance-like series CSV with an explicit convention header.
+
+    Issue #5141: distance-like series must declare their convention so a
+    center-to-center value is not misread as surface clearance.
+    """
+    if not rows:
+        raise ValueError(f"cannot write empty CSV: {path}")
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        handle.write(f"# {DISTANCE_CONVENTION_FIELD}: {convention.value}\n")
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()), lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
     """Write deterministic JSON."""
 
@@ -250,6 +274,10 @@ def write_bundle(
         "horizon": horizon,
         "dt": dt,
         "recording_path": "robot_sf.benchmark.map_runner._run_map_episode(record_simulation_step_trace=True)",
+        # Issue #5141: min_robot_ped_distance_m is computed as math.dist(robot_xy,
+        # ped_position), i.e. center-to-center; declared explicitly to prevent a
+        # surface-clearance misreading of the exported series.
+        DISTANCE_CONVENTION_FIELD: DistanceConvention.CENTER_CENTER.value,
         "status": record.get("status"),
         "termination_reason": record.get("termination_reason"),
         "steps": record.get("steps"),
@@ -266,7 +294,11 @@ def write_bundle(
     _write_json(output_dir / "metadata.json", metadata)
     _write_json(output_dir / "trace_series.json", trace_payload)
     _write_csv(output_dir / "trace_timeseries.csv", derived.trace_rows)
-    _write_csv(output_dir / "min_distance_series.csv", derived.min_distance_rows)
+    _write_distance_csv(
+        output_dir / "min_distance_series.csv",
+        derived.min_distance_rows,
+        convention=DistanceConvention.CENTER_CENTER,
+    )
     _write_readme(output_dir, metadata)
     _write_sha256sums(output_dir)
     return metadata
@@ -286,6 +318,8 @@ statistical benchmark or dissertation claim.
 - `trace_timeseries.csv`: per-timestep robot state, commanded action, executed velocity, pedestrian
   positions, and nearest robot-pedestrian distance.
 - `min_distance_series.csv`: figure-ready `(step, time_s, min_robot_ped_distance_m)` series.
+  Distance convention: `center_center` (robot-to-pedestrian center distance; footprint radii
+  are NOT subtracted). Do not read these values as surface clearance.
 - `trace_series.json`: raw recorded frames plus derived rows.
 - `metadata.json`: scenario, seed, planner, commit, matrix hash, and claim boundary.
 - `SHA256SUMS`: checksums for the files above.

--- a/scripts/export_issue_4848_group_crossing_exemplars.py
+++ b/scripts/export_issue_4848_group_crossing_exemplars.py
@@ -18,10 +18,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from robot_sf.evidence.distance_convention import DistanceConvention
 from robot_sf.evidence.writers import (
     extract_marker_date,
     review_marker,
     write_csv,
+    write_distance_series_csv,
     write_json,
     write_sha256sums,
 )
@@ -305,6 +307,10 @@ def write_bundle(
         "selection_metric_value": selection.metric_value,
         "episode_id": selection.episode_id,
         "episode_status": selection.status,
+        # Issue #5141: min_robot_ped_distance_m is computed as math.dist(robot_xy,
+        # ped_position), i.e. center-to-center; declared explicitly to prevent a
+        # surface-clearance misreading of the exported series.
+        "distance_convention": DistanceConvention.CENTER_CENTER.value,
         "summary": derived.summary,
     }
 
@@ -318,7 +324,11 @@ def write_bundle(
     write_json(output_dir / "metadata.json", metadata)
     write_json(output_dir / "trace_series.json", trace_payload)
     write_csv(output_dir / "trace_timeseries.csv", derived.trace_rows)
-    write_csv(output_dir / "min_distance_series.csv", derived.min_distance_rows)
+    write_distance_series_csv(
+        output_dir / "min_distance_series.csv",
+        derived.min_distance_rows,
+        convention=DistanceConvention.CENTER_CENTER,
+    )
     _write_readme(output_dir, metadata)
     write_sha256sums(output_dir)
     return metadata
@@ -340,6 +350,8 @@ statistical benchmark or dissertation claim.
 - `trace_timeseries.csv`: per-timestep robot state, commanded action, executed velocity,
   pedestrian positions, and nearest robot-pedestrian distance.
 - `min_distance_series.csv`: figure-ready `(step, time_s, min_robot_ped_distance_m)` series.
+  Distance convention: `center_center` (robot-to-pedestrian center distance; footprint radii
+  are NOT subtracted). Do not read these values as surface clearance.
 - `trace_series.json`: raw recorded frames plus derived rows.
 - `metadata.json`: provenance, selection criteria, and claim boundary.
 - `SHA256SUMS`: checksums for the files above.

--- a/scripts/export_issue_4891_head_on_corridor_exemplars.py
+++ b/scripts/export_issue_4891_head_on_corridor_exemplars.py
@@ -18,10 +18,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from robot_sf.evidence.distance_convention import DistanceConvention
 from robot_sf.evidence.writers import (
     extract_marker_date,
     review_marker,
     write_csv,
+    write_distance_series_csv,
     write_json,
     write_sha256sums,
 )
@@ -358,6 +360,10 @@ def write_bundle(
         "selection_metric_value": selection.metric_value,
         "episode_id": selection.episode_id,
         "episode_status": selection.status,
+        # Issue #5141: min_robot_ped_distance_m is computed as math.dist(robot_xy,
+        # ped_position), i.e. center-to-center; declared explicitly to prevent a
+        # surface-clearance misreading of the exported series.
+        "distance_convention": DistanceConvention.CENTER_CENTER.value,
         "summary": derived.summary,
     }
 
@@ -371,7 +377,11 @@ def write_bundle(
     write_json(output_dir / "metadata.json", metadata)
     write_json(output_dir / "trace_series.json", trace_payload)
     write_csv(output_dir / "trace_timeseries.csv", derived.trace_rows)
-    write_csv(output_dir / "min_distance_series.csv", derived.min_distance_rows)
+    write_distance_series_csv(
+        output_dir / "min_distance_series.csv",
+        derived.min_distance_rows,
+        convention=DistanceConvention.CENTER_CENTER,
+    )
     _write_readme(output_dir, metadata)
     write_sha256sums(output_dir)
     return metadata
@@ -393,6 +403,8 @@ statistical benchmark or dissertation claim.
 - `trace_timeseries.csv`: per-timestep robot state, commanded action, executed velocity,
   pedestrian positions, and nearest robot-pedestrian distance.
 - `min_distance_series.csv`: figure-ready `(step, time_s, min_robot_ped_distance_m)` series.
+  Distance convention: `center_center` (robot-to-pedestrian center distance; footprint radii
+  are NOT subtracted). Do not read these values as surface clearance.
 - `trace_series.json`: raw recorded frames plus derived rows.
 - `metadata.json`: provenance, selection criteria, and claim boundary.
 - `SHA256SUMS`: checksums for the files above.

--- a/tests/evidence/test_distance_convention.py
+++ b/tests/evidence/test_distance_convention.py
@@ -1,0 +1,176 @@
+"""Tests for the explicit distance-convention vocabulary (issue #5141).
+
+Covers:
+- the ``DistanceConvention`` enum and metadata field name,
+- ``validate_distance_convention`` / ``require_distance_convention`` fail-closed paths,
+- ``write_distance_series_csv`` annotates the CSV with the convention header,
+- filename/column distance-like detection used by the lint.
+"""
+
+from __future__ import annotations
+
+import csv
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.evidence import writers
+from robot_sf.evidence.distance_convention import (
+    CONVENTION_DESCRIPTIONS,
+    DISTANCE_CONVENTION_FIELD,
+    DistanceConvention,
+    describe_distance_convention,
+    has_distance_like_columns,
+    is_distance_like_filename,
+    require_distance_convention,
+    validate_distance_convention,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestDistanceConventionEnum:
+    """The enum carries exactly the three conventions named in issue #5141."""
+
+    def test_has_three_expected_values(self) -> None:
+        values = {c.value for c in DistanceConvention}
+        assert values == {"center_center", "surface_clearance", "center_segment"}
+
+    def test_str_enum_serializes_to_plain_string(self) -> None:
+        # str-Enum: the value round-trips as a plain JSON-serializable string.
+        assert DistanceConvention.CENTER_CENTER.value == "center_center"
+        assert DistanceConvention("center_center") is DistanceConvention.CENTER_CENTER
+
+
+class TestValidateDistanceConvention:
+    """Validation accepts enum/string and rejects unknown or mistyped values."""
+
+    def test_accepts_enum_and_string(self) -> None:
+        assert validate_distance_convention("center_center") is DistanceConvention.CENTER_CENTER
+        assert (
+            validate_distance_convention(DistanceConvention.SURFACE_CLEARANCE)
+            is DistanceConvention.SURFACE_CLEARANCE
+        )
+
+    @pytest.mark.parametrize("bad", ["center", "center-to-center", "clearance", ""])
+    def test_rejects_unknown_string_value(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="Unknown distance_convention"):
+            validate_distance_convention(bad)
+
+    @pytest.mark.parametrize("bad", [1, 1.5, None, ["center_center"]])
+    def test_rejects_non_string_non_enum_value(self, bad: object) -> None:
+        with pytest.raises(ValueError, match="distance_convention"):
+            validate_distance_convention(bad)
+
+
+class TestRequireDistanceConvention:
+    """The fail-closed helper demands a valid convention on distance-like metadata."""
+
+    def test_missing_field_raises(self) -> None:
+        with pytest.raises(ValueError, match="missing the required 'distance_convention'"):
+            require_distance_convention({}, "min_distance_series.csv")
+
+    def test_returns_resolved_convention_when_present(self) -> None:
+        resolved = require_distance_convention(
+            {DISTANCE_CONVENTION_FIELD: "center_center"}, "min_distance_series.csv"
+        )
+        assert resolved is DistanceConvention.CENTER_CENTER
+
+    def test_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            require_distance_convention(
+                {DISTANCE_CONVENTION_FIELD: "nope"}, "min_distance_series.csv"
+            )
+
+
+class TestConventionDescriptions:
+    """Every convention has a human-readable description for docs/lint messages."""
+
+    def test_all_conventions_described(self) -> None:
+        for convention in DistanceConvention:
+            assert convention in CONVENTION_DESCRIPTIONS
+            assert len(describe_distance_convention(convention)) > 0
+
+    def test_describe_accepts_string(self) -> None:
+        assert "surface" in describe_distance_convention("surface_clearance").lower()
+
+
+class TestDistanceLikeDetection:
+    """Filename/column heuristics identify distance-like series for the lint."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "min_distance_series.csv",
+            "robot_clearance_series.csv",
+            "MIN_DISTANCE_SERIES.CSV",
+            "head_on_clearance.csv",
+        ],
+    )
+    def test_distance_like_filenames(self, name: str) -> None:
+        assert is_distance_like_filename(name) is True
+
+    @pytest.mark.parametrize("name", ["metadata.json", "trace_timeseries.csv", "README.md"])
+    def test_non_distance_filenames(self, name: str) -> None:
+        assert is_distance_like_filename(name) is False
+
+    def test_distance_like_columns(self) -> None:
+        assert has_distance_like_columns("step,time_s,min_robot_ped_distance_m") is True
+        assert has_distance_like_columns("step,min_clearance") is True
+
+    def test_non_distance_columns(self) -> None:
+        assert has_distance_like_columns("step,time_s,speed_m_s") is False
+
+
+class TestWriteDistanceSeriesCsv:
+    """The shared writer annotates the CSV with the convention header."""
+
+    """The shared writer annotates the CSV with the convention header."""
+
+    def test_writes_convention_header_line(self, tmp_path: Path) -> None:
+        path = tmp_path / "min_distance_series.csv"
+        writers.write_distance_series_csv(
+            path,
+            [{"step": 0, "min_robot_ped_distance_m": 1.37}],
+            convention="center_center",
+        )
+        content = path.read_text(encoding="utf-8")
+        assert "# AI-GENERATED NEEDS-REVIEW" in content
+        assert "# distance_convention: center_center" in content
+
+    def test_header_line_precedes_csv_header(self, tmp_path: Path) -> None:
+        path = tmp_path / "min_distance_series.csv"
+        writers.write_distance_series_csv(
+            path,
+            [{"step": 0, "min_robot_ped_distance_m": 1.37}],
+            convention=DistanceConvention.CENTER_CENTER,
+        )
+        with path.open(encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+        # Lines 1-2 are marker + convention; line 3 is the CSV header.
+        assert lines[0] == "# AI-GENERATED NEEDS-REVIEW"
+        assert lines[1] == "# distance_convention: center_center"
+        assert "step" in lines[2]
+
+    def test_rejects_invalid_convention(self, tmp_path: Path) -> None:
+        path = tmp_path / "min_distance_series.csv"
+        with pytest.raises(ValueError, match="Unknown distance_convention"):
+            writers.write_distance_series_csv(
+                path,
+                [{"step": 0, "min_robot_ped_distance_m": 1.37}],
+                convention="clearance",
+            )
+
+    def test_rows_preserved(self, tmp_path: Path) -> None:
+        path = tmp_path / "min_distance_series.csv"
+        writers.write_distance_series_csv(
+            path,
+            [{"step": 0, "min_robot_ped_distance_m": 1.37}],
+            convention="center_center",
+        )
+        # Skip the marker/convention comment lines before CSV parsing.
+        with path.open(encoding="utf-8") as handle:
+            data_lines = [line for line in handle if not line.lstrip().startswith("#")]
+        rows = list(csv.DictReader(data_lines))
+        assert rows == [{"step": "0", "min_robot_ped_distance_m": "1.37"}]

--- a/tests/test_export_issue_4848.py
+++ b/tests/test_export_issue_4848.py
@@ -292,6 +292,35 @@ class TestWriteBundleFixture:
             content = (bundle_dir / csv_name).read_text(encoding="utf-8")
             assert content.startswith("# AI-GENERATED NEEDS-REVIEW\n")
 
+    def test_distance_convention_field_is_center_center(self, tmp_path: Path) -> None:
+        """Issue #5141: min_robot_ped_distance_m is center-to-center; declare it."""
+        record = self._make_minimal_record()
+        sel = _export_module.SelectedEpisode(
+            planner="orca",
+            scenario_id="classic_group_crossing_low",
+            seed=42,
+            selection_mode="best",
+            metric_value=0.85,
+            episode_id="classic_group_crossing_low_s42",
+            status="success",
+        )
+        bundle_dir = tmp_path / "bundle"
+        bundle_dir.mkdir()
+        _export_module.write_bundle(
+            episode_record=record,
+            selection=sel,
+            output_dir=bundle_dir,
+        )
+        # metadata.json carries the explicit convention.
+        meta = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
+        assert meta["distance_convention"] == "center_center"
+        # The embedded trace_series.json metadata mirrors it.
+        trace = json.loads((bundle_dir / "trace_series.json").read_text(encoding="utf-8"))
+        assert trace["metadata"]["distance_convention"] == "center_center"
+        # The distance-series CSV carries an in-file convention header line.
+        csv_content = (bundle_dir / "min_distance_series.csv").read_text(encoding="utf-8")
+        assert "# distance_convention: center_center" in csv_content
+
     def test_readme_has_review_marker_with_date(self, tmp_path: Path) -> None:
         """README marker includes issue ref and provenance-pinned date (not wall-clock)."""
         record = self._make_minimal_record()

--- a/tests/test_export_issue_4891.py
+++ b/tests/test_export_issue_4891.py
@@ -407,6 +407,32 @@ class TestPinGeneratedAt:
         meta = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
         assert "2026" in meta["generated_at_utc"]
 
+    def test_distance_convention_field_is_center_center(self, tmp_path: Path) -> None:
+        """Issue #5141: min_robot_ped_distance_m is center-to-center; declare it."""
+        record = self._make_minimal_record()
+        sel = _export_module.SelectedEpisode(
+            planner="goal",
+            scenario_id="classic_head_on_corridor_low",
+            seed=20,
+            selection_mode="median",
+            metric_value=1.0,
+            episode_id="test_episode",
+            status="collision",
+        )
+        bundle_dir = tmp_path / "bundle"
+        bundle_dir.mkdir()
+        _export_module.write_bundle(
+            episode_record=record,
+            selection=sel,
+            output_dir=bundle_dir,
+        )
+        meta = json.loads((bundle_dir / "metadata.json").read_text(encoding="utf-8"))
+        assert meta["distance_convention"] == "center_center"
+        trace = json.loads((bundle_dir / "trace_series.json").read_text(encoding="utf-8"))
+        assert trace["metadata"]["distance_convention"] == "center_center"
+        csv_content = (bundle_dir / "min_distance_series.csv").read_text(encoding="utf-8")
+        assert "# distance_convention: center_center" in csv_content
+
 
 class TestSelectionReportDeterminism:
     """write_selection_report must be byte-stable when generated_at is pinned.

--- a/tests/tools/test_export_issue_4268_trace_episode.py
+++ b/tests/tools/test_export_issue_4268_trace_episode.py
@@ -121,3 +121,26 @@ def test_csv_and_checksum_outputs_are_stable(tmp_path: Path) -> None:
     assert "metadata.json" in checksums
     assert "trace_timeseries.csv" in checksums
     assert "SHA256SUMS" not in checksums
+
+
+def test_min_distance_series_carries_center_center_convention(tmp_path: Path) -> None:
+    """Issue #5141: min_distance_series.csv must declare its distance convention.
+
+    min_robot_ped_distance_m is computed via math.dist(robot_xy, ped_position),
+    i.e. center-to-center; the export must annotate the CSV so the value is not
+    misread as surface clearance.
+    """
+    derived = exporter.derive_trace_rows(_sample_record())
+    csv_path = tmp_path / "min_distance_series.csv"
+
+    exporter._write_distance_csv(
+        csv_path, derived.min_distance_rows, convention=exporter.DistanceConvention.CENTER_CENTER
+    )
+
+    content = csv_path.read_text(encoding="utf-8")
+    assert "# distance_convention: center_center" in content
+    # CSV header and rows are still intact below the convention line.
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        data_lines = [line for line in handle if not line.lstrip().startswith("#")]
+    rows = list(csv.DictReader(data_lines))
+    assert rows[0]["min_robot_ped_distance_m"] == str(2**0.5)

--- a/tests/validation/test_pr_contract_check.py
+++ b/tests/validation/test_pr_contract_check.py
@@ -122,6 +122,112 @@ def test_check_evidence_tree_hygiene(
     assert not blockers
 
 
+@patch("scripts.ci.pr_contract_check.is_file_new")
+@patch("scripts.ci.pr_contract_check.get_new_files")
+def test_check_evidence_tree_hygiene_distance_convention_missing(
+    mock_new_files: MagicMock, mock_is_new: MagicMock, tmp_path: Path
+) -> None:
+    """Issue #5141: a new distance-like series without distance_convention is blocked."""
+    mock_new_files.return_value = set()
+    mock_is_new.return_value = True
+
+    # New distance-series CSV with a marker but NO convention declaration.
+    f = tmp_path / "docs/context/evidence/min_distance_series.csv"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(
+        "# AI-GENERATED NEEDS-REVIEW\nstep,min_robot_ped_distance_m\n0,1.37\n",
+        encoding="utf-8",
+    )
+    blockers = pr_contract_check.check_evidence_tree_hygiene([str(f)], "origin/main")
+    distance_blockers = [b for b in blockers if "distance_convention" in b]
+    assert len(distance_blockers) == 1
+    assert "distance-like series" in distance_blockers[0]
+
+
+@patch("scripts.ci.pr_contract_check.is_file_new")
+@patch("scripts.ci.pr_contract_check.get_new_files")
+def test_check_evidence_tree_hygiene_distance_convention_present_in_file(
+    mock_new_files: MagicMock, mock_is_new: MagicMock, tmp_path: Path
+) -> None:
+    """Issue #5141: an in-file `# distance_convention:` header satisfies the lint."""
+    mock_new_files.return_value = set()
+    mock_is_new.return_value = True
+
+    f = tmp_path / "docs/context/evidence/min_distance_series.csv"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(
+        "# AI-GENERATED NEEDS-REVIEW\n"
+        "# distance_convention: center_center\n"
+        "step,min_robot_ped_distance_m\n0,1.37\n",
+        encoding="utf-8",
+    )
+    blockers = pr_contract_check.check_evidence_tree_hygiene([str(f)], "origin/main")
+    assert not blockers
+
+
+@patch("scripts.ci.pr_contract_check.is_file_new")
+@patch("scripts.ci.pr_contract_check.get_new_files")
+def test_check_evidence_tree_hygiene_distance_convention_present_in_sibling_metadata(
+    mock_new_files: MagicMock, mock_is_new: MagicMock, tmp_path: Path
+) -> None:
+    """Issue #5141: a sibling metadata.json carrying the field satisfies the lint."""
+    mock_new_files.return_value = set()
+    mock_is_new.return_value = True
+
+    bundle = tmp_path / "docs/context/evidence/bundle"
+    bundle.mkdir(parents=True, exist_ok=True)
+    # Distance CSV has no in-file declaration...
+    csv_path = bundle / "min_distance_series.csv"
+    csv_path.write_text(
+        "# AI-GENERATED NEEDS-REVIEW\nstep,min_robot_ped_distance_m\n0,1.37\n",
+        encoding="utf-8",
+    )
+    # ...but the sibling metadata.json declares it.
+    (bundle / "metadata.json").write_text(
+        '{"distance_convention": "center_center"}\n', encoding="utf-8"
+    )
+    blockers = pr_contract_check.check_evidence_tree_hygiene([str(csv_path)], "origin/main")
+    assert not blockers
+
+
+@patch("scripts.ci.pr_contract_check.is_file_new")
+@patch("scripts.ci.pr_contract_check.get_new_files")
+def test_check_evidence_tree_hygiene_distance_convention_not_retroactive(
+    mock_new_files: MagicMock, mock_is_new: MagicMock, tmp_path: Path
+) -> None:
+    """Issue #5141: the lint only applies to NEW evidence files."""
+    mock_new_files.return_value = set()
+    mock_is_new.return_value = False  # pre-existing file
+
+    f = tmp_path / "docs/context/evidence/old_min_distance_series.csv"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(
+        "# AI-GENERATED NEEDS-REVIEW\nstep,min_robot_ped_distance_m\n0,1.37\n",
+        encoding="utf-8",
+    )
+    blockers = pr_contract_check.check_evidence_tree_hygiene([str(f)], "origin/main")
+    assert not any("distance_convention" in b for b in blockers)
+
+
+@patch("scripts.ci.pr_contract_check.is_file_new")
+@patch("scripts.ci.pr_contract_check.get_new_files")
+def test_check_evidence_tree_hygiene_non_distance_series_unaffected(
+    mock_new_files: MagicMock, mock_is_new: MagicMock, tmp_path: Path
+) -> None:
+    """Issue #5141: files that are not distance-like are not flagged."""
+    mock_new_files.return_value = set()
+    mock_is_new.return_value = True
+
+    f = tmp_path / "docs/context/evidence/README.md"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(
+        "<!-- AI-GENERATED NEEDS-REVIEW -->\nSummary text without distance data.\n",
+        encoding="utf-8",
+    )
+    blockers = pr_contract_check.check_evidence_tree_hygiene([str(f)], "origin/main")
+    assert not any("distance_convention" in b for b in blockers)
+
+
 @patch("subprocess.run")
 def test_check_successor_discipline(mock_run: MagicMock) -> None:
     """Test check_successor_discipline warns on lack of successor statement."""


### PR DESCRIPTION
## What & Why

Issue #5141: distance quantities cross this benchmark in three incompatible conventions (`center_center`, `surface_clearance`, `center_segment`), and exports historically did not state which one they carry. That ambiguity already caused a trace-bundle misreading — a **center-to-center** distance of 1.37 m was read as **surface clearance**, flipping a collision attribution.

This PR makes distance-like series/metric exports self-describing so the misreading class cannot recur, and adds a lint that fails new distance-like evidence series that omit the field.

This fully resolves the three deliverables in the issue:
1. **`distance_convention` field on series/metric export metadata** (enum: `center_center | surface_clearance | center_segment`).
2. **One documentation section** defining the conventions and which metric uses which.
3. **Lint**: exports of distance-like series without the field fail the evidence-writer checks (pairs with #4921).

## Changes

- **`robot_sf/evidence/distance_convention.py`** (new): canonical `DistanceConvention` `StrEnum` (`center_center | surface_clearance | center_segment`), the `distance_convention` field-name constant, distance-like filename/column heuristics, and `validate_distance_convention` / `require_distance_convention` fail-closed helpers. Single source of truth for the vocabulary.
- **`robot_sf/evidence/writers.py`**: `write_distance_series_csv()` writes the CSV with the review marker **and** a `# distance_convention: <value>` header line, validating the convention at write time.
- **Export scripts** (`scripts/export_issue_4268_trace_episode.py`, `..._4848_...`, `..._4891_...`): attach `"distance_convention": "center_center"` to the bundle `metadata` (flows into both `metadata.json` and the embedded `trace_series.json` metadata), annotate `min_distance_series.csv` with the convention header, and note the convention in the generated README. (`min_robot_ped_distance_m` is computed via `math.dist(robot_xy, ped_position)`, i.e. center-to-center.)
- **`scripts/ci/pr_contract_check.py`** (rule 4, evidence-tree hygiene): new sub-check fails **NEW** distance-like evidence series under `docs/context/evidence/` that omit the `distance_convention` field — satisfied either in-file or via a sibling `metadata.json`. Not retroactive, so the pre-existing evidence tree is not flagged.
- **`docs/ped_metrics/metrics_spec.md`**: new "Distance Conventions" section with a table mapping each convention to its meaning and where it is used (center_center → trace `min_robot_ped_distance_m`, center-distance diagnostic; surface_clearance → `surface_clearance_m`, collisions/near-misses/SNQI; center_segment → wall/obstacle collision geometry).
- **Tests**: new `tests/evidence/test_distance_convention.py` (enum, validation, writer, detection); new lint tests in `tests/validation/test_pr_contract_check.py` (missing / in-file / sibling-metadata / not-retroactive / non-distance); new field assertions in the three exporter test files.

## Validation (CPU only; no campaigns/Slurm/training/benchmark claims)

```
# Worktree-local venv (uv sync --all-extras), Python 3.12
$ python -m pytest \
    tests/evidence/test_distance_convention.py \
    tests/test_evidence_writers.py \
    tests/validation/test_pr_contract_check.py \
    tests/test_export_issue_4848.py \
    tests/test_export_issue_4891.py \
    tests/tools/test_export_issue_4268_trace_episode.py \
    tests/tools/test_audit_exemplar_bundles.py \
    tests/test_ci_script_contract.py \
    -q -k "not regression_last_20"
=> 221 passed, 1 deselected
```

Targeted run on the directly affected suites (148 tests, all green):

```
$ python -m pytest tests/tools/test_export_issue_4268_trace_episode.py tests/evidence/test_distance_convention.py \
    tests/test_evidence_writers.py tests/validation/test_pr_contract_check.py \
    tests/test_export_issue_4848.py tests/test_export_issue_4891.py tests/tools/test_audit_exemplar_bundles.py \
    -q -k "not regression_last_20"
=> 148 passed, 1 deselected
```

Including the new distance-convention assertions:
- `tests/test_export_issue_4848.py::TestWriteBundleFixture::test_distance_convention_field_is_center_center`
- `tests/test_export_issue_4891.py::TestPinGeneratedAt::test_distance_convention_field_is_center_center`
- `tests/tools/test_export_issue_4268_trace_episode.py::test_min_distance_series_carries_center_center_convention`
- 5 new `test_check_evidence_tree_hygiene_distance_convention_*` lint tests

Lint/format on all changed files:
```
$ ruff check <changed files>  => All checks passed!
$ ruff format --check <changed files>  => clean
$ python scripts/validation/check_broad_exceptions.py  => Broad exception ratchet passed with 170 entries.
```

End-to-end lint spot-check (new distance-like CSV without convention → BLOCKED; with in-file `# distance_convention:` → PASS).

Note: a pre-existing stale-`pysocialforce` import error in the shared main-checkout venv blocks collection of `test_export_issue_4268_trace_episode.py` when run via `run_worktree_shared_venv.sh`; this is unrelated to this change (confirmed identical on `origin/main` with my changes stashed) and resolves with a worktree-local `uv sync --all-extras`, under which all tests pass as shown above.

## Evidence/artifact handling

No committed evidence files under `docs/context/evidence/` are modified (only the scripts that generate them, plus the docs spec). The lint is deliberately non-retroactive (new files only), so existing bundles are not invalidated. No `output/` artifacts produced. `NA` for downstream research-claim propagation — this is a docs/lint/metadata change with no benchmark, metric-value, schema-version, or model-provenance claim.

## Research-claim fields

- Target claim/hypothesis/blocker: N/A — auditability/docs change, not a research claim.
- Comparator/baseline: N/A.
- Evidence tier: N/A (CPU unit-test + lint only).
- Result classification: N/A.
- Decision/stop rule: N/A.
- Synthesis/update target: N/A.

Closes #5141

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
