### PR TITLE
Issue #5132: zero-weighted SNQI terms no longer propagate NaN (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/snqi/compute.py
+++ b/robot_sf/benchmark/snqi/compute.py
@@ -61,6 +61,29 @@ Weights = Mapping[str, float]
 Metrics = Mapping[str, float | int | bool]
 
 
+def _weighted_term(weight: float, value: float) -> float:
+    """Weighted contribution of one SNQI term with an explicit zero-weight contract.
+
+    A zero weight means the term is excluded from the score, so it must contribute
+    exactly ``0.0`` -- even when ``value`` is ``NaN``. IEEE 754 makes ``0.0 * NaN``
+    equal ``NaN``, which would otherwise silently collapse the whole score (issue
+    #5132: a legitimately absent ``comfort_exposure`` with ``w_comfort = 0.0``).
+    Short-circuiting on a zero weight keeps the score finite without masking real
+    signals: a non-zero weight still multiplies through, so a genuine ``NaN`` under
+    a non-zero weight still propagates as before.
+
+    Args:
+        weight: Weight coefficient for the term.
+        value: Pre-normalized (or raw) metric value for the term.
+
+    Returns:
+        ``weight * value``, or ``0.0`` when ``weight == 0.0``.
+    """
+    if weight == 0.0:
+        return 0.0
+    return weight * value
+
+
 def normalize_metric(name: str, value: float | int | bool, baseline_stats: BaselineStats) -> float:
     """Normalize a raw metric using median/p95 baseline statistics.
 
@@ -104,6 +127,13 @@ def compute_snqi_v0(metrics: Metrics, weights: Weights, baseline_stats: Baseline
 
     Returns:
         SNQI score (higher is better).
+
+    Notes:
+        - A term whose weight is ``0.0`` is excluded from the score and never
+          propagates ``NaN`` (e.g. a legitimately absent ``comfort_exposure``
+          when ``w_comfort = 0.0``). A non-zero weight still multiplies through,
+          so a genuine ``NaN`` under a non-zero weight propagates as before
+          (issue #5132).
     """
     success_raw = metrics.get("success", 0.0)
     success = 1.0 if isinstance(success_raw, bool) and success_raw else float(success_raw)
@@ -120,13 +150,13 @@ def compute_snqi_v0(metrics: Metrics, weights: Weights, baseline_stats: Baseline
     jerk_norm = normalize_metric("jerk_mean", metrics.get("jerk_mean", 0.0), baseline_stats)
 
     score = (
-        weights.get("w_success", 1.0) * success
-        - weights.get("w_time", 1.0) * time_norm
-        - weights.get("w_collisions", 1.0) * coll_norm
-        - weights.get("w_near", 1.0) * near_norm
-        - weights.get("w_comfort", 1.0) * comfort_exposure
-        - weights.get("w_force_exceed", 1.0) * force_exceed_norm
-        - weights.get("w_jerk", 1.0) * jerk_norm
+        _weighted_term(weights.get("w_success", 1.0), success)
+        - _weighted_term(weights.get("w_time", 1.0), time_norm)
+        - _weighted_term(weights.get("w_collisions", 1.0), coll_norm)
+        - _weighted_term(weights.get("w_near", 1.0), near_norm)
+        - _weighted_term(weights.get("w_comfort", 1.0), comfort_exposure)
+        - _weighted_term(weights.get("w_force_exceed", 1.0), force_exceed_norm)
+        - _weighted_term(weights.get("w_jerk", 1.0), jerk_norm)
     )
     return float(score)
 
@@ -154,6 +184,10 @@ def compute_snqi_v1(metrics: Metrics, weights: Weights, baseline_stats: Baseline
 
     Returns:
         Versioned SNQI score where every penalty term is baseline-normalized.
+
+    Notes:
+        - Shares the zero-weight contract of :func:`compute_snqi_v0`: a term with
+          weight ``0.0`` never propagates ``NaN`` (issue #5132).
     """
     success_raw = metrics.get("success", 0.0)
     success = 1.0 if isinstance(success_raw, bool) and success_raw else float(success_raw)
@@ -190,13 +224,13 @@ def compute_snqi_v1(metrics: Metrics, weights: Weights, baseline_stats: Baseline
     )
 
     score = (
-        weights.get("w_success", 1.0) * success
-        - weights.get("w_time", 1.0) * time_norm
-        - weights.get("w_collisions", 1.0) * coll_norm
-        - weights.get("w_near", 1.0) * near_norm
-        - weights.get("w_comfort", 1.0) * comfort_norm
-        - weights.get("w_force_exceed", 1.0) * force_exceed_norm
-        - weights.get("w_jerk", 1.0) * jerk_norm
+        _weighted_term(weights.get("w_success", 1.0), success)
+        - _weighted_term(weights.get("w_time", 1.0), time_norm)
+        - _weighted_term(weights.get("w_collisions", 1.0), coll_norm)
+        - _weighted_term(weights.get("w_near", 1.0), near_norm)
+        - _weighted_term(weights.get("w_comfort", 1.0), comfort_norm)
+        - _weighted_term(weights.get("w_force_exceed", 1.0), force_exceed_norm)
+        - _weighted_term(weights.get("w_jerk", 1.0), jerk_norm)
     )
 
     return float(score)

--- a/tests/test_snqi_zero_weight_nan_contract.py
+++ b/tests/test_snqi_zero_weight_nan_contract.py
@@ -1,0 +1,321 @@
+"""SNQI zero-weight NaN contract (issue #5132).
+
+`compute_all_metrics()` emits ``comfort_exposure = NaN`` when pedestrian force
+data is absent. In the SNQI scalarization the term ``w_comfort * comfort_exposure``
+collapsed to ``NaN`` via the IEEE 754 rule ``0.0 * NaN = NaN``, silently poisoning
+the whole score even when ``w_comfort = 0.0`` (the explicit "exclude this term"
+setting).
+
+These tests pin the contract: a zero-weighted term must never propagate ``NaN``,
+while a non-zero weight still multiplies through so genuine ``NaN`` signals are
+not masked.
+"""
+
+from __future__ import annotations
+
+import math
+from math import isclose
+
+import pytest
+
+from robot_sf.benchmark.snqi.compute import (
+    _weighted_term,
+    compute_snqi_v0,
+    compute_snqi_v1,
+)
+from robot_sf.benchmark.snqi.types import SNQIWeights
+
+NaN = float("nan")
+
+
+# A baseline that provides coverage for every metric the two score versions read.
+_BASELINE = {
+    "collisions": {"med": 0.0, "p95": 3.0},
+    "near_misses": {"med": 1.0, "p95": 6.0},
+    "force_exceed_events": {"med": 0.0, "p95": 10.0},
+    "jerk_mean": {"med": 0.05, "p95": 0.55},
+    "comfort_exposure": {"med": 0.0, "p95": 0.5},
+    "time_to_goal_norm": {"med": 0.3, "p95": 1.2},
+}
+
+
+def _zero_comfort_force_weights() -> dict[str, float]:
+    """Canonical weights but with comfort/force terms excluded (issue scenario)."""
+    return {
+        "w_success": 1.0,
+        "w_time": 0.8,
+        "w_collisions": 2.0,
+        "w_near": 1.0,
+        "w_comfort": 0.0,
+        "w_force_exceed": 0.0,
+        "w_jerk": 0.3,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit: helper
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_term_zero_weight_short_circuits_nan():
+    """Zero weight returns 0.0 even when the value is NaN."""
+    assert _weighted_term(0.0, NaN) == 0.0
+    assert _weighted_term(0.0, 1.0) == 0.0
+    assert _weighted_term(0.0, float("inf")) == 0.0
+
+
+def test_weighted_term_nonzero_weight_propagates_nan():
+    """A non-zero weight still multiplies through (NaN signal is not masked)."""
+    assert math.isnan(_weighted_term(1.5, NaN))
+    assert isclose(_weighted_term(2.0, 3.0), 6.0)
+
+
+# ---------------------------------------------------------------------------
+# Regression: the exact issue #5132 scenario (v0)
+# ---------------------------------------------------------------------------
+
+
+def test_v0_zero_weight_nan_comfort_force_yields_finite_score():
+    """Reproduces issue #5132: NaN comfort/force under zero weights must be finite."""
+    metrics = {
+        "success": True,
+        "time_to_goal_norm": 0.5,
+        "collisions": 0,
+        "near_misses": 2,
+        # force data legitimately absent -> NaN metrics, exactly as emitted by
+        # compute_all_metrics() on an episode without pedestrian force data.
+        "comfort_exposure": NaN,
+        "force_exceed_events": NaN,
+        "jerk_mean": 0.2,
+    }
+    weights = _zero_comfort_force_weights()
+    score = compute_snqi_v0(metrics, weights, _BASELINE)
+    assert math.isfinite(score), f"SNQI score must be finite, got {score}"
+
+
+def test_v0_zero_weight_nan_metric_matches_force_free_metrics():
+    """A zero-weighted NaN term must equal the same score computed with 0.0 values.
+
+    This mirrors the maintainer workaround (build a force-free metrics dict) and
+    asserts the two paths now agree.
+    """
+    weights = _zero_comfort_force_weights()
+    metrics_nan = {
+        "success": 1.0,
+        "time_to_goal_norm": 0.6,
+        "collisions": 1,
+        "near_misses": 3,
+        "comfort_exposure": NaN,
+        "force_exceed_events": NaN,
+        "jerk_mean": 0.3,
+    }
+    metrics_zero = {
+        "success": 1.0,
+        "time_to_goal_norm": 0.6,
+        "collisions": 1,
+        "near_misses": 3,
+        "comfort_exposure": 0.0,
+        "force_exceed_events": 0.0,
+        "jerk_mean": 0.3,
+    }
+    assert isclose(
+        compute_snqi_v0(metrics_nan, weights, _BASELINE),
+        compute_snqi_v0(metrics_zero, weights, _BASELINE),
+        rel_tol=0.0,
+        abs_tol=0.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "nan_key",
+    [
+        "comfort_exposure",
+        "time_to_goal_norm",
+        "collisions",
+        "near_misses",
+        "force_exceed_events",
+        "jerk_mean",
+    ],
+)
+def test_v0_each_penalty_term_zero_weight_is_nan_safe(nan_key):
+    """Every penalty term must be NaN-safe when its own weight is zero."""
+    metrics = {
+        "success": True,
+        "time_to_goal_norm": 0.5,
+        "collisions": 0,
+        "near_misses": 0,
+        "comfort_exposure": 0.1,
+        "force_exceed_events": 0,
+        "jerk_mean": 0.1,
+    }
+    metrics[nan_key] = NaN
+    weights = {
+        "w_success": 1.0,
+        "w_time": 0.8,
+        "w_collisions": 2.0,
+        "w_near": 1.0,
+        "w_comfort": 0.5,
+        "w_force_exceed": 1.5,
+        "w_jerk": 0.3,
+    }
+    weight_for = {
+        "comfort_exposure": "w_comfort",
+        "time_to_goal_norm": "w_time",
+        "collisions": "w_collisions",
+        "near_misses": "w_near",
+        "force_exceed_events": "w_force_exceed",
+        "jerk_mean": "w_jerk",
+    }
+    weights[weight_for[nan_key]] = 0.0
+    score = compute_snqi_v0(metrics, weights, _BASELINE)
+    assert math.isfinite(score), f"{nan_key} (weight 0.0) leaked NaN -> {score}"
+
+
+def test_v0_zero_weight_success_term_is_nan_safe():
+    """The success term with zero weight must not propagate a NaN success either."""
+    metrics = {"success": NaN, "time_to_goal_norm": 0.5}
+    weights = {
+        "w_success": 0.0,
+        "w_time": 0.8,
+        "w_collisions": 0.0,
+        "w_near": 0.0,
+        "w_comfort": 0.0,
+        "w_force_exceed": 0.0,
+        "w_jerk": 0.0,
+    }
+    score = compute_snqi_v0(metrics, weights, _BASELINE)
+    assert math.isfinite(score)
+
+
+# ---------------------------------------------------------------------------
+# Regression-free behavior: nonzero weight still propagates NaN (no masking)
+# ---------------------------------------------------------------------------
+
+
+def test_v0_nonzero_weight_propagates_nan():
+    """A NaN metric under a non-zero weight must still collapse the score to NaN.
+
+    Guards against over-broadly masking NaN (which would hide real signals).
+    """
+    metrics = {
+        "success": True,
+        "time_to_goal_norm": 0.5,
+        "comfort_exposure": NaN,
+    }
+    weights = {
+        "w_success": 1.0,
+        "w_time": 0.8,
+        "w_collisions": 0.0,
+        "w_near": 0.0,
+        "w_comfort": 0.5,  # non-zero -> NaN must propagate
+        "w_force_exceed": 0.0,
+        "w_jerk": 0.0,
+    }
+    assert math.isnan(compute_snqi_v0(metrics, weights, _BASELINE))
+
+
+# ---------------------------------------------------------------------------
+# v1 parity of the zero-weight contract
+# ---------------------------------------------------------------------------
+
+
+def test_v1_zero_weight_nan_term_yields_finite_score():
+    """The opt-in v1 scorer shares the zero-weight NaN contract."""
+    metrics = {
+        "success": True,
+        "time_to_goal_norm": 0.5,
+        "collisions": 1,
+        "near_misses": 3,
+        "comfort_exposure": NaN,
+        "force_exceed_events": 0,
+        "jerk_mean": 0.2,
+    }
+    weights = _zero_comfort_force_weights()
+    score = compute_snqi_v1(metrics, weights, _BASELINE)
+    assert math.isfinite(score), f"SNQI-v1 score must be finite, got {score}"
+
+
+def test_v1_zero_weight_nan_matches_force_free():
+    """v1 zero-weight NaN term matches the force-free (0.0) variant."""
+    weights = _zero_comfort_force_weights()
+    common = {
+        "success": 1.0,
+        "time_to_goal_norm": 0.6,
+        "collisions": 1,
+        "near_misses": 3,
+        "jerk_mean": 0.3,
+    }
+    metrics_nan = {**common, "comfort_exposure": NaN, "force_exceed_events": NaN}
+    metrics_zero = {**common, "comfort_exposure": 0.0, "force_exceed_events": 0.0}
+    assert isclose(
+        compute_snqi_v1(metrics_nan, weights, _BASELINE),
+        compute_snqi_v1(metrics_zero, weights, _BASELINE),
+        rel_tol=0.0,
+        abs_tol=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Concrete value: zero weight changes nothing vs plain finite arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_v0_zero_weight_finite_value_unchanged():
+    """For finite values, zero-weight short-circuit equals the old 0*w==0.0 result."""
+    metrics = {
+        "success": True,
+        "time_to_goal_norm": 0.5,
+        "collisions": 1,
+        "near_misses": 2,
+        "comfort_exposure": 0.1,
+        "force_exceed_events": 1,
+        "jerk_mean": 0.2,
+    }
+    full_weights = {
+        "w_success": 1.0,
+        "w_time": 0.8,
+        "w_collisions": 2.0,
+        "w_near": 1.0,
+        "w_comfort": 0.5,
+        "w_force_exceed": 1.5,
+        "w_jerk": 0.3,
+    }
+    expected = (
+        1.0 * 1.0
+        - 0.8 * 0.5
+        - 2.0 * (1.0 / 3.0)
+        - 1.0 * (1.0 / 5.0)
+        - 0.5 * 0.1
+        - 1.5 * (1.0 / 10.0)
+        - 0.3 * ((0.2 - 0.05) / (0.55 - 0.05))
+    )
+    assert isclose(compute_snqi_v0(metrics, full_weights, _BASELINE), expected, rel_tol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# SNQIWeights provenance type still imports/constructs (light smoke)
+# ---------------------------------------------------------------------------
+
+
+def test_snqi_weights_type_smoke():
+    """Cheap import/construct smoke for the provenance type touched by neighbors."""
+    w = SNQIWeights(
+        weights_version="1.0",
+        created_at="2026-07-10T00:00:00",
+        git_sha="abcd1234",
+        baseline_stats_path="computed",
+        baseline_stats_hash="0" * 16,
+        normalization_strategy="median_p95_clamp",
+        bootstrap_params={"method": "canonical"},
+        components=[
+            "w_success",
+            "w_time",
+            "w_collisions",
+            "w_near",
+            "w_comfort",
+            "w_force_exceed",
+            "w_jerk",
+        ],
+        weights={"w_success": 1.0},
+    )
+    assert w.weights["w_success"] == 1.0


### PR DESCRIPTION
## What / Why

Issue #5132 reports that `compute_snqi_v0` returns `NaN` when a **zero-weight** metric is `NaN`.

Root cause: `compute_all_metrics()` legitimately emits `comfort_exposure = NaN` when pedestrian force data is absent. In `compute_snqi_v0`, the term was computed as `- weights.get("w_comfort", 1.0) * comfort_exposure` = `0.0 * NaN = NaN` (IEEE 754), which **silently collapsed the entire SNQI score to `NaN`** — even though `w_comfort = 0.0` is the explicit "exclude this term" setting. The maintainer's workaround was to build a force-free metrics dict to avoid the `NaN` before calling `compute_snqi_v0`.

## Change

Add a private helper `_weighted_term(weight, value)` in `robot_sf/benchmark/snqi/compute.py` that **short-circuits to `0.0` when `weight == 0.0`**, and route every metric term (success, time, collisions, near, comfort, force, jerk) through it in **both `compute_snqi_v0` and `compute_snqi_v1`**.

This makes the zero-weight exclusion contract explicit and consistent across both score versions, implementing the issue's suggested change ("Guard each metric term with a `w == 0.0` short-circuit").

Crucially, the fix does **not** mask real signals: a `NaN` under a **non-zero** weight still multiplies through and propagates as before, so genuine misconfiguration is not silently hidden. The zero-weight contract is the only behavior change, and it is pure improvement (`0.0 * finite == 0.0` already held; now `0.0 * NaN` also yields `0.0`).

## Validation (CPU only)

New focused test file: `tests/test_snqi_zero_weight_nan_contract.py` (16 tests).

Reproduces the exact issue scenario and pins the contract:
- `test_v0_zero_weight_nan_comfort_force_yields_finite_score` — the exact #5132 scenario (`comfort_exposure=NaN`, `force_exceed_events=NaN`, `w_comfort=0.0`, `w_force_exceed=0.0`) now yields a **finite** score.
- `test_v0_zero_weight_nan_metric_matches_force_free_metrics` — a zero-weighted `NaN` term now equals the same score computed with `0.0` values (matches the maintainer workaround).
- `test_v0_each_penalty_term_zero_weight_is_nan_safe[*]` — parametrized over every penalty metric: each is `NaN`-safe when its own weight is `0.0`.
- `test_v0_zero_weight_success_term_is_nan_safe` — success term with zero weight is `NaN`-safe too.
- `test_v0_nonzero_weight_propagates_nan` — guards against over-broad masking: a `NaN` under a non-zero weight still collapses the score to `NaN`.
- `test_v1_*` — the opt-in v1 scorer shares the zero-weight contract.
- `test_v0_zero_weight_finite_value_unchanged` — for finite values, the short-circuit equals the old arithmetic exactly (no numeric drift).

```
$ python -m pytest tests/test_snqi_zero_weight_nan_contract.py -q
16 passed in 8.45s
```

Regression check on existing SNQI compute/contract tests (unchanged behavior confirmed):
```
$ python -m pytest tests/test_snqi_parity.py tests/test_snqi_normalization_comparison.py \
    tests/test_snqi_ablation.py tests/benchmark/test_issue_4247_snqi_canonical_contract.py \
    tests/test_snqi_missing_optional_metrics.py tests/unit/test_snqi_recompute_determinism.py \
    tests/unit/test_snqi_weights.py -q
33 passed in 9.09s
```

Lint/format on changed files:
```
$ ruff check robot_sf/benchmark/snqi/compute.py tests/test_snqi_zero_weight_nan_contract.py
All checks passed!
$ ruff format --check robot_sf/benchmark/snqi/compute.py tests/test_snqi_zero_weight_nan_contract.py
2 files already formatted
```

No campaigns, Slurm, training runs, or benchmark/paper claims. CPU-level validation only.

## Files

- `robot_sf/benchmark/snqi/compute.py` — `_weighted_term` helper + routed both v0 and v1 terms through it; docstrings document the zero-weight `NaN` contract.
- `tests/test_snqi_zero_weight_nan_contract.py` — new focused test file (16 tests).

## Downstream propagation

NA — pure bug fix to the SNQI scalarization NaN contract; no benchmark/metric schema, model provenance, or training-config surface changed. Existing parity tests confirm numeric results are unchanged for finite inputs.

---

This PR fully resolves issue #5132.

Closes #5132

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
