### PR TITLE
Issue #5148: point ready-queue guidance at REST issue-thread fallback (cheap-lane worker)

### DIFF
--- a/.agents/skills/gh-issue-clarifier/SKILL.md
+++ b/.agents/skills/gh-issue-clarifier/SKILL.md
@@ -24,7 +24,10 @@ decision trail. Keep the issue small, stable, and ready for implementation.
 
 ## Workflow
 
-1. Read issue state (`gh issue view`) and linked context (PRs, comments, labels, milestone).
+1. Read issue state with the canonical complete-thread read
+   `uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7` (issue
+   #5148: plain `gh issue view --comments` fails on some GitHub CLI versions because it requests
+   the deprecated classic-Projects field) and linked context (PRs, comments, labels, milestone).
 2. Classify ambiguity:
    - Problem, scope, solution, or validation ambiguity.
 3. If multiple valid options exist, draft a minimal options set:

--- a/.agents/skills/gh-issue-priority-assessor/SKILL.md
+++ b/.agents/skills/gh-issue-priority-assessor/SKILL.md
@@ -28,7 +28,10 @@ inputs, not as hard authority.
    - `docs/project_prioritization.md` (includes the **Research-Leverage Interpretation** and the
      **verify-before-scoring gate** — apply both).
    - `docs/context/issue_713_batch_first_issue_workflow.md` for batch-first Project #5 writes.
-   - issue body/metadata from GitHub MCP / GitHub app tools or `gh issue view`.
+   - issue body/metadata from GitHub MCP / GitHub app tools or the canonical complete-thread read
+     `uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7`
+     (issue #5148: plain `gh issue view --comments` fails on some GitHub CLI versions because it
+     requests the deprecated classic-Projects field).
    - current Project #5 field values from MCP or `gh project item-list`.
 2. Run the **verify-before-scoring gate**: confirm the issue is still open work (no covering/merged
    PR, no tooling already landed under another issue). If it is already done or superseded, route to

--- a/.agents/skills/gh-issue-template-auditor/SKILL.md
+++ b/.agents/skills/gh-issue-template-auditor/SKILL.md
@@ -31,7 +31,10 @@ writes when available.
    - Preserve the `## Archetype Metadata` YAML block from
     `docs/context/issue_1512_issue_archetypes.md`; repair or flag missing keys and invalid
     `archetype` / `evidence_tier` values conservatively instead of inventing replacements.
-2. Load issue body and metadata with GitHub MCP / GitHub app tools when available, or `gh issue view`.
+2. Load issue body and metadata with GitHub MCP / GitHub app tools when available, or the canonical
+   complete-thread read `uv run python scripts/dev/gh_issue_rest.py thread <number> --repo
+   ll7/robot_sf_ll7` (issue #5148: plain `gh issue view --comments` fails on some GitHub CLI
+   versions because it requests the deprecated classic-Projects field).
 3. Compare required sections (problem statement, scope/non-goals, estimates, risks, acceptance, validation, metadata).
 4. If gaps are limited and obvious:
    - generate repaired body with missing sections,

--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -421,7 +421,10 @@ reviewed the output, integrated any edits, run the required validation, updated 
 recorded cleanup.
 
 For delegated queue scouts, keep the scout output in the ledger as route evidence only until the
-main agent verifies issue state in `ll7/robot_sf_ll7` with local `gh issue view` or REST evidence.
+main agent verifies issue state in `ll7/robot_sf_ll7` with the canonical complete-thread read
+`uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7` (issue #5148:
+plain `gh issue view --comments` fails on some GitHub CLI versions because it requests the
+deprecated classic-Projects field) or equivalent REST evidence.
 Do not claim or branch from scout text alone; stale state, wrong repo-owner URLs, missing recent
 comments, and duplicate PR coverage are known failure modes.
 

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -225,13 +225,21 @@ If these local filters appear exhausted or dominated by blocked/SLURM-only work,
 broad queue scout before declaring the queue empty. Prefer a cheap local or Qwen scan plus one
 substantial Copilot pass when available; treat scout output as route evidence only until the main
 agent verifies it locally. Before selecting, claiming, branching for, or reporting a scout-proposed
-issue as ready, run:
+issue as ready, run the canonical complete-thread read (issue #5148):
 
 ```bash
-gh issue view <number> --repo ll7/robot_sf_ll7 --json number,title,state,labels,body,comments,url
+uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7
 ```
 
-or an equivalent REST read. Confirm the repository
+This tries the concise `gh issue view --comments` path and falls back to paginated REST only for
+the known `repository.issue.projectCards` GraphQL failure that breaks `gh issue view --comments`
+and `gh issue view --json ...comments` on some GitHub CLI versions. For structured fields, use
+`uv run python scripts/dev/gh_issue_rest.py view <number> --json number title state url labels
+comments` (REST-only, normalized). Plain `gh issue view <number> --repo ll7/robot_sf_ll7 --json
+number,title,state,labels,body,comments,url` is NOT a reliable first-step read because it requests
+the deprecated classic-Projects field and exits before returning content on affected hosts; treat
+it as an equivalent REST read only when you have already confirmed it works on the host. Confirm
+the repository
 owner/name, open state, labels, body, recent comments, linked/covering PRs, and ready eligibility
 against current GitHub state. Known scout failure modes include stale open/closed/blocked state,
 wrong repo-owner URLs, missing recent comments, and duplicate PR coverage; do not acquire

--- a/tests/test_ai_prompt_surfaces.py
+++ b/tests/test_ai_prompt_surfaces.py
@@ -15,6 +15,19 @@ COPILOT_INSTRUCTIONS = ROOT / ".github" / "copilot-instructions.md"
 ADAPTATION_NOTE = ROOT / "docs" / "ai" / "awesome_copilot_adaptation.md"
 CODING_AGENTS_NOTE = ROOT / "docs" / "context" / "issue_728_coding_agents_compatibility.md"
 AGENTS_MD = ROOT / "AGENTS.md"
+GH_ISSUE_REST_HELPER = ROOT / "scripts" / "dev" / "gh_issue_rest.py"
+# Ready-queue skills that instruct reading a complete live issue thread (body + comments)
+# before claiming, branching, clarifying, prioritizing, or auditing an issue. Issue #5148
+# requires these surfaces to point at the canonical REST-fallback helper instead of the
+# broken raw `gh issue view --comments` first-step command.
+ISSUE_THREAD_READ_SKILLS = (
+    "gh-issue-autopilot",
+    "gh-issue-clarifier",
+    "gh-issue-priority-assessor",
+    "gh-issue-template-auditor",
+    "goal-issue-implementation",
+    "goal-autopilot",
+)
 
 
 def test_ai_skill_files_exist() -> None:
@@ -182,3 +195,40 @@ def test_coding_agents_compatibility_note_is_discoverable() -> None:
 
     dev_guide_text = DEV_GUIDE.read_text(encoding="utf-8")
     assert note_ref in dev_guide_text, f"{note_ref!r} not linked from docs/dev_guide.md"
+
+
+def test_ready_queue_skills_use_issue_thread_rest_fallback() -> None:
+    """Ready-queue skills must read live issue threads via the canonical REST fallback.
+
+    Issue #5148: ``gh issue view <number> --comments`` (and ``--json ...comments``) fails on
+    some GitHub CLI versions because it requests the deprecated classic-Projects GraphQL
+    field ``repository.issue.projectCards`` and exits before returning content. Skills that
+    instruct reading a complete live issue thread before claiming, branching, clarifying,
+    prioritizing, or auditing an issue must therefore point at the shared helper
+    ``scripts/dev/gh_issue_rest.py thread <number>`` (native-first with a targeted REST
+    fallback) instead of mandating the broken raw command as the first-step read.
+    """
+
+    assert GH_ISSUE_REST_HELPER.exists(), (
+        "canonical issue-thread helper missing: scripts/dev/gh_issue_rest.py"
+    )
+
+    helper_text = GH_ISSUE_REST_HELPER.read_text(encoding="utf-8")
+    # The helper must still own the targeted fallback for the known GraphQL failure.
+    assert "repository.issue.projectCards" in helper_text, (
+        "gh_issue_rest.py no longer documents the projectCards fallback contract"
+    )
+    assert "def read_complete_issue_thread" in helper_text, (
+        "gh_issue_rest.py no longer exposes read_complete_issue_thread"
+    )
+
+    canonical_ref = "scripts/dev/gh_issue_rest.py"
+    for skill_name in ISSUE_THREAD_READ_SKILLS:
+        skill_path = SKILL_DIR / skill_name / "SKILL.md"
+        assert skill_path.exists(), f"missing ready-queue skill: {skill_path}"
+        text = skill_path.read_text(encoding="utf-8")
+        assert canonical_ref in text, (
+            f"ready-queue skill {skill_name} does not reference the canonical issue-thread "
+            f"helper {canonical_ref} (issue #5148); live-issue review is unreliable on hosts "
+            f"where `gh issue view --comments` hits the deprecated projectCards field"
+        )


### PR DESCRIPTION
## What / Why

Issue #5148 records friction: the ready-queue first-step command `gh issue view <number> --comments` (and `gh issue view --json ...comments`) fails on GitHub CLI versions that request the deprecated classic-Projects GraphQL field `repository.issue.projectCards`, exiting before returning any issue content. This breaks autonomous live-issue review.

A canonical REST-fallback helper already exists at `scripts/dev/gh_issue_rest.py` (landed in PRs #5049 / #5107 for #5021 / #5092): the `thread` command is native-first and falls back to paginated REST only for the known `projectCards` failure. **However, five ready-queue skill surfaces still mandated the broken raw `gh issue view --comments` as the first-step read**, without pointing at the fallback — so live-issue review remained unreliable on affected hosts. This PR propagates the canonical fallback into those remaining guidance surfaces and locks the contract with a regression test.

## Changes

Updated five ready-queue skills to read live issue threads via the canonical helper `uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7` instead of mandating the broken raw command:

- `.agents/skills/goal-issue-implementation/SKILL.md` — the "ready-queue first-step contract" that issue #5136 was following; replaced the broken `gh issue view --json ...comments` command with the helper and noted `--json ...comments` is not reliable as a first-step read.
- `.agents/skills/goal-autopilot/SKILL.md` — delegated queue-scout verification now points at the canonical helper.
- `.agents/skills/gh-issue-clarifier/SKILL.md` — step 1 issue-state read.
- `.agents/skills/gh-issue-priority-assessor/SKILL.md` — issue body/metadata read.
- `.agents/skills/gh-issue-template-auditor/SKILL.md` — issue body/metadata load.

Added a regression test in `tests/test_ai_prompt_surfaces.py` (`test_ready_queue_skills_use_issue_thread_rest_fallback`) that asserts every ready-queue issue-thread-read skill references `scripts/dev/gh_issue_rest.py` and that the helper still owns the `projectCards` fallback, so the guidance cannot drift back to the broken command.

## Validation (CPU-level)

Reproduced and resolved the issue #5148 friction on this host (`gh version 2.45.0`):

```text
$ gh issue view 5148 --comments
GraphQL: Projects (classic) is being deprecated in favor of the new Projects experience ... (repository.issue.projectCards)

$ uv run python scripts/dev/gh_issue_rest.py thread 5148
title:	friction: add a REST fallback for gh issue view comments after Projects Classic removal
state:	OPEN
... (full body returned via REST fallback)
```

Focused tests:

```text
$ pytest tests/test_ai_prompt_surfaces.py tests/dev/test_gh_issue_rest.py -q
28 passed in 1.43s
```

Related surface tests (skill references, AI config drift, issue templates):

```text
$ pytest tests/test_ai_prompt_surfaces.py tests/test_issue_templates.py tests/tools/test_sync_ai_config.py -q
24 passed in 1.35s
```

Lightweight gates for skill/AI-surface changes:

```text
$ python scripts/dev/check_skills.py
Validated 54 skills, typed registry, generated README, and routing tests.

$ python scripts/tools/sync_ai_config.py --check
AI config links validated: 7 symlinks.

$ ruff check tests/test_ai_prompt_surfaces.py && ruff format --check tests/test_ai_prompt_surfaces.py
All checks passed!
1 file already formatted
```

No campaigns, Slurm, training runs, or benchmark/paper claims.

## Successor statement

Successor slice: the REST-fallback helper itself landed in PR #5049 (#5021, `view` command + library API) and PR #5107 (#5092, `thread` command with native-first targeted fallback). **This PR does not duplicate PR #5049 or #5107.** It adds new capability by propagating that fallback into the five remaining ready-queue skill surfaces that still mandated the broken raw `gh issue view --comments` first-step read, and by adding a regression test that locks the "ready-queue guidance uses the fallback" contract from issue #5148.

This PR fully resolves issue #5148's remaining ask ("Update ready-queue guidance to use that fallback so required live-issue review remains reliable on hosts with this `gh` version"). The helper portion of #5148 was already satisfied by #5049/#5107; this PR completes the guidance-update portion.

Closes #5148

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
