### PR TITLE
fix(benchmark): reject non-declared strict tuning sources (#5165)

### DIFF
--- a/robot_sf/benchmark/camera_ready/_config.py
+++ b/robot_sf/benchmark/camera_ready/_config.py
@@ -686,8 +686,9 @@ def _validate_campaign_config(cfg: CampaignConfig) -> None:  # noqa: C901, PLR09
             f"Unsupported snqi_contract.enforcement '{cfg.snqi_contract.enforcement}'. {known}"
         )
     # Per-arm tuning-effort enforcement (issue #5143). Validate the vocabulary; the fail-closed
-    # (error) gate below requires every enabled arm to declare a tuning block, mirroring #4970's
-    # checkpoint-provenance fail-closed spirit.
+    # (error) gate below requires every enabled arm to have an author-declared tuning block,
+    # mirroring #4970's checkpoint-provenance fail-closed spirit. A backfilled or unknown record
+    # remains useful auditability metadata, but cannot satisfy this strict new-arm gate.
     if cfg.tuning_effort_enforcement not in _TUNING_EFFORT_ENFORCEMENT:
         known = ", ".join(_TUNING_EFFORT_ENFORCEMENT)
         raise ValueError(
@@ -696,13 +697,16 @@ def _validate_campaign_config(cfg: CampaignConfig) -> None:  # noqa: C901, PLR09
         )
     if cfg.tuning_effort_enforcement == "error":
         missing = [
-            planner.key for planner in cfg.planners if planner.enabled and planner.tuning is None
+            planner.key
+            for planner in cfg.planners
+            if planner.enabled
+            and (planner.tuning is None or planner.tuning.source != TUNING_SOURCE_DECLARED)
         ]
         if missing:
             names = ", ".join(sorted(missing))
             raise ValueError(
-                "tuning_effort_enforcement='error' requires a 'tuning' block for every enabled "
-                f"arm; missing tuning block for: {names}"
+                "tuning_effort_enforcement='error' requires an author-declared 'tuning' block "
+                f"for every enabled arm; missing declared tuning block for: {names}"
             )
     threshold_values = {
         "rank_alignment_warn_threshold": cfg.snqi_contract.rank_alignment_warn_threshold,

--- a/tests/benchmark/test_camera_ready_tuning_effort_issue_5143.py
+++ b/tests/benchmark/test_camera_ready_tuning_effort_issue_5143.py
@@ -283,7 +283,28 @@ def test_validate_campaign_config_error_gate_fails_when_arm_missing_tuning() -> 
         scenario_candidates=ScenarioCandidateSelection(),
         tuning_effort_enforcement="error",
     )
-    with pytest.raises(ValueError, match="missing tuning block for: b"):
+    with pytest.raises(ValueError, match="missing declared tuning block for: b"):
+        _validate_campaign_config(cfg)
+
+
+@pytest.mark.parametrize("source", [TUNING_SOURCE_BACKFILLED, "unknown"])
+def test_validate_campaign_config_error_gate_rejects_non_declared_tuning(source: str) -> None:
+    """Strict enforcement cannot accept a backfilled or unknown record as a new-arm declaration."""
+    cfg = CampaignConfig(
+        name="gate",
+        scenario_matrix_path=Path("does-not-matter.yaml"),
+        planners=(
+            PlannerSpec(
+                key="a",
+                algo="goal",
+                tuning=TuningSpec(source=source),
+            ),
+        ),
+        seed_policy=SeedPolicy(),
+        scenario_candidates=ScenarioCandidateSelection(),
+        tuning_effort_enforcement="error",
+    )
+    with pytest.raises(ValueError, match="missing declared tuning block for: a"):
         _validate_campaign_config(cfg)
 
 
@@ -353,7 +374,7 @@ def test_load_campaign_config_error_gate_rejects_missing_tuning(tmp_path: Path) 
         planners_yaml="  - key: a\n    algo: goal\n    planner_group: core\n",
         extra_top_level="tuning_effort_enforcement: error",
     )
-    with pytest.raises(ValueError, match="missing tuning block for: a"):
+    with pytest.raises(ValueError, match="missing declared tuning block for: a"):
         load_campaign_config(config_path)
 
 
@@ -429,7 +450,7 @@ def test_prepare_campaign_preflight_error_gate_aborts_before_artifacts(tmp_path:
         scenario_candidates=ScenarioCandidateSelection(),
         tuning_effort_enforcement="error",
     )
-    with pytest.raises(ValueError, match="missing tuning block for: a"):
+    with pytest.raises(ValueError, match="missing declared tuning block for: a"):
         prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="issue5143")
     # No campaign root should have been created on the fail-closed path.
     assert not (tmp_path / "out").exists() or not list(


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** strict `tuning_effort_enforcement: error` now accepts only an
author-declared tuning record for each enabled arm. `backfilled`, `unknown`, and absent records
fail before campaign artifacts are created.

**Why now:** this closes the fail-closed gap discovered after #5155 merged.

**Claim boundary:** this is implementation-integrity evidence for configuration validation only;
it makes no benchmark-performance or paper-facing claim.

**Issue:** https://github.com/ll7/robot_sf_ll7/issues/5165

**Required validation:** the focused tuning-effort regression tests and final repository readiness
gate pass locally.

**Remaining blocker:** none for #5165. No full benchmark campaign was run.

## Contract delta

- New fail-closed blocker: with `tuning_effort_enforcement: error`, an enabled arm must carry
  `tuning.source: declared`; absent, `backfilled`, and `unknown` sources are rejected.
- Compatibility: `off` mode and its best-effort manifest representation are unchanged.
- Refs #5165; this PR fully resolves the stated acceptance criteria.
- Closes #5165.

<details>
<summary>Implementation, validation, and governance appendix</summary>

## Summary

Make strict tuning-effort enforcement reject enabled arms whose provenance is not author-declared.

## Linked Issues

- Closes #5165
- Related: #5143, #5155

## Stack / Dependency

- Base dependency: none
- Required prior PRs: #5155
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: none

## What Changed

- Changed `robot_sf/benchmark/camera_ready/_config.py` so strict mode requires
  `TUNING_SOURCE_DECLARED`, not merely a non-null tuning block.
- Added parameterized regression coverage for `backfilled` and `unknown` sources and updated
  strict-mode error assertions.

## Why It Matters

- Added value: strict campaigns cannot treat reconstructed or unknown provenance as a declaration.
- Expected impact: invalid strict configurations fail before campaign artifacts are produced.
- Why this is worth merging now: it restores the contract documented by #5155 without changing
  best-effort mode.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #5165 configuration-contract blocker.
- Comparator or baseline, if applicable: pre-fix strict validation accepted non-declared sources.
- Evidence tier: NA - implementation-integrity regression tests only; no research evidence.
- Result classification: NA - no benchmark or research result is claimed.
- Decision or stop rule, if applicable: strict validation must reject all non-declared sources.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #5165.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no analysis tool added.

## Domain-Aware Approval

- Required for this PR: no - this changes validation semantics, not evidence classification,
  comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claims.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: code review plus regression tests.
- Validity checklist:
  - Target claim/hypothesis: strict configuration rejects non-declared provenance.
  - Comparator or split/evidence validity: NA.
  - Fallback/degraded exclusions: no benchmark execution is claimed.
  - Claim boundary: implementation integrity only.
  - Implementation integrity vs experimental validity: only implementation integrity is shown.

## Falsification / Non-Transfer Check

- Did the mechanism activate? NA - no research result.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action

- Rerun needed: NA - no empirical result is introduced.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue with normal campaign validation when one is planned.
- Proposed child issue or existing follow-up: none.

## Validation / Proof

- Commands run:
  - `uv run pytest tests/benchmark/test_camera_ready_tuning_effort_issue_5143.py -q` (30 passed)
  - `uv run ruff check robot_sf/benchmark/camera_ready/_config.py tests/benchmark/test_camera_ready_tuning_effort_issue_5143.py`
  - `uv run ruff format --check robot_sf/benchmark/camera_ready/_config.py tests/benchmark/test_camera_ready_tuning_effort_issue_5143.py`
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: parameterized regression tests prove both `backfilled` and
  `unknown` sources raise under strict enforcement; existing tests retain best-effort manifest
  coverage outside strict mode.
- Benchmarks or smoke tests, if applicable: no full benchmark campaign run and no Slurm/GPU
  submission.

## Risks / Rollout

- Compatibility risks: only strict configurations with previously accepted non-declared provenance
  now fail, as intended.
- Failure modes: an existing strict config using `backfilled` or `unknown` must be corrected to
  `declared` before it can run.
- Rollback or fallback plan: revert this two-file change; no data, artifacts, or migrations are
  involved.

## Docs / Provenance

- Updated docs: none; the existing strict-mode contract is clarified in the code comment.
- Relevant design or provenance notes: #5143 and #5155.
- Any assumptions that need to be preserved: only author-declared tuning records satisfy a new-arm
  strict gate; non-declared records remain audit metadata outside strict mode.

## Downstream Propagation

- Parent issue updated: no - task authorization prohibits issue comments; this PR is the durable
  GitHub trace and closes the fully resolved issue.
- Claim map / benchmark report updated: NA - no benchmark result or interpretation changed.
- Leaderboard / artifact catalog updated: NA - no artifacts produced.
- Registry or config index updated: NA - no config schema additions.
- Context index / memory note updated: NA - the issue and PR contain the bounded contract change.
- Follow-up issue opened for deferred propagation: NA.
- Not applicable because: no research evidence, artifact, registry, or documentation propagation
  is created by this validation-only fix.

## Follow-Up Issues

- Deferred work: none.
- Issues opened for follow-up: none. No friction issue was filed: the only readiness interruption
  was caused by initially syncing the primary checkout rather than this new worktree, not a
  repository defect.

## Reviewer Notes

- Verify the predicate rejects `None`, `backfilled`, and `unknown` only when enforcement is
  `error`; disabled arms and non-strict behavior remain unchanged.
- Known limitation: no full benchmark campaign run, no Slurm/GPU submission, and no
  paper/dissertation claim edits were performed.

</details>
