### PR TITLE
fix(dev): name vendored pysocialforce refresh command (#5167)

### DIFF
--- a/scripts/dev/run_worktree_shared_venv.sh
+++ b/scripts/dev/run_worktree_shared_venv.sh
@@ -17,7 +17,9 @@ fast-pysf/pysocialforce and NOT shadowed by PYTHONPATH=$PWD) is especially drift
 a newer API from a stale install fails mid-collection with a confusing ImportError. The helper
 therefore runs a cheap freshness check comparing the installed `pysocialforce` package against this
 checkout's fast-pysf/pysocialforce source and fails early with an actionable message when they
-diverge. Refresh the owning checkout with `uv sync --all-extras` to clear the divergence.
+diverge. Refresh the owning checkout with
+`uv sync --all-extras --reinstall-package robot-sf`; a plain sync does not rebuild this
+force-included source.
 
 Standalone commands with a verified boundary that does not import project packages can use
 --standalone. That mode skips the project-source freshness check and does not add the worktree root
@@ -146,8 +148,9 @@ check_shared_venv_freshness() {
 Shared virtualenv is stale relative to this checkout: $venv
   diverging module: pysocialforce/$rel_path
 The reused env (UV_NO_SYNC=1) lacks source present in fast-pysf/pysocialforce, so imports can
-fail mid-run with a confusing ImportError. Refresh the owning checkout with 'uv sync --all-extras',
-use --standalone for a command verified not to import project packages, or rerun with
+fail mid-run with a confusing ImportError. Refresh the owning checkout with
+'uv sync --all-extras --reinstall-package robot-sf'; a plain sync does not rebuild this
+force-included source; use --standalone for a command verified not to import project packages, or rerun with
 --no-freshness-check (or ROBOT_SF_VENV_FRESHNESS_CHECK=skip) once you have confirmed the env matches
 this checkout.
 EOF

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -729,6 +729,7 @@ def test_worktree_shared_venv_helper_has_freshness_check_wiring() -> None:
     assert 'cmp -s "$src_file" "$installed_file"' in script_text
     assert "Shared virtualenv is stale relative to this checkout" in script_text
     assert "diverging module: pysocialforce/" in script_text
+    assert "uv sync --all-extras --reinstall-package robot-sf" in script_text
     # Standalone commands with a verified no-project-import boundary can skip project drift safely.
     assert "--standalone" in script_text
     assert "use --standalone for a command verified not to import project packages" in script_text
@@ -844,7 +845,7 @@ def test_worktree_shared_venv_freshness_check_fails_early_on_stale_env(
     assert result.returncode == 2
     assert "Shared virtualenv is stale relative to this checkout" in result.stderr
     assert "diverging module: pysocialforce/scene.py" in result.stderr
-    assert "uv sync --all-extras" in result.stderr
+    assert "uv sync --all-extras --reinstall-package robot-sf" in result.stderr
     # The freshness gate must fire before the underlying command is executed.
     assert "uv-reached" not in result.stderr
 


### PR DESCRIPTION
## Reviewer-critical summary

**What changed.** The shared-worktree virtual-environment freshness failure now gives the working
recovery command: `uv sync --all-extras --reinstall-package robot-sf` in the owning checkout.

**Why now.** Plain `uv sync --all-extras` can exit successfully while retaining the force-included
`fast-pysf/pysocialforce` source. The existing fail-closed detector found this state but suggested
that ineffective plain sync.

**Claim boundary.** This does not change installation, package layout, or automatic rebuild behavior.
It corrects the remediation shown after the existing stale-source detector fires.

**Required validation.** The stale-venv fixture asserts the exact command; the full core readiness
pipeline passed on CPU.

**Remaining blocker.** Users must run the displayed command in the checkout that owns the reused
virtual environment; the helper intentionally does not mutate that environment itself.

## Contract delta

- **New schema fields:** none.
- **New fail-closed blockers:** none; the existing stale-source blocker is unchanged.
- **Compatibility impact:** only the actionable error/help text changes. It now explicitly says that
  a plain sync does not rebuild the force-included `pysocialforce` source.

Closes #5167

<details>
<summary>Implementation, proof, and governance details</summary>

## Linked issue and scope

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5167
- Scope: correct the shared-venv helper's stale vendored-source remediation and lock it in with the
  existing shell-contract test fixture.
- Assumption: rebuilding the root `robot-sf` distribution is the reversible, supported recovery,
  confirmed by reproducing the stale install and then comparing source and installed files after the
  rebuild.

## What changed

- `scripts/dev/run_worktree_shared_venv.sh` now directs users to
  `uv sync --all-extras --reinstall-package robot-sf` and explains why a plain sync is insufficient.
- `tests/test_ci_script_contract.py` verifies that both the helper contract and its stale-fixture
  error output contain that exact remediation.

## Validation / proof

- `uv sync --all-extras` — reproduced the issue: exit 0, but source/install comparison was stale.
- `uv sync --all-extras --reinstall-package robot-sf` — rebuilt `robot-sf`; source/install comparison
  matched.
- `bash -n scripts/dev/run_worktree_shared_venv.sh` — passed.
- `uv run pytest tests/test_ci_script_contract.py -q` — 73 passed.
- `uv run ruff check tests/test_ci_script_contract.py` — passed.
- `uv run ruff format --check tests/test_ci_script_contract.py` — passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed: lint/format,
  2,150-test core lane, coverage, and ratchets.

## Research / rollout

- Target claim / hypothesis / blocker: stale vendored `pysocialforce` source must receive a recovery
  command that actually rebuilds it.
- Comparator: plain `uv sync --all-extras`.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Domain-aware approval: not required; support-tooling text and test contract only, with no benchmark,
  metric, evidence-classification, or paper-facing change.
- Compatibility risk: users may still invoke the command in a different checkout; the message retains
  the owning-checkout qualifier.
- Rollback: revert the two message/test edits; no persisted environment or package change is made.

## Artifacts and downstream propagation

- Generated `output/coverage/` is ignored local validation cache and is not committed.
- Parent issue updated: no — current authorization disallows issue or PR comments.
- Claim map / benchmark report / leaderboard / registry / context index: NA — no research evidence,
  configuration, schema, or durable artifact changed.
- State propagation: no separate issue status comment was added because comments are not authorized;
  this PR body is the reviewable delivery record.

## Explicitly out of scope

- No full benchmark campaign run.
- No Slurm or GPU submission.
- No paper or dissertation claim edits.
- No automatic environment mutation or package-install behavior change.

</details>
