### PR TITLE
fix: suppress successful validation failure excerpts (#5169)

### DIFF
--- a/scripts/dev/run_compact_validation.py
+++ b/scripts/dev/run_compact_validation.py
@@ -152,7 +152,10 @@ def run_compact_validation(
         log_path.write_text(f"{timeout_message}\n", encoding="utf-8", errors="replace")
     elapsed = time.monotonic() - started
     combined = log_path.read_text(encoding="utf-8", errors="replace")
-    excerpt, truncated = _failure_lines(combined, limit=excerpt_lines, width=excerpt_width)
+    if returncode == 0:
+        excerpt, truncated = [], False
+    else:
+        excerpt, truncated = _failure_lines(combined, limit=excerpt_lines, width=excerpt_width)
     failing_node_ids = _pytest_node_ids(combined) if returncode != 0 else []
     summary: dict[str, Any] = {
         "schema": SCHEMA_VERSION,
@@ -231,9 +234,10 @@ def _print_human_summary(summary: dict[str, Any]) -> None:
         print("Failing node ids:")
         for node_id in summary["failing_node_ids"]:
             print(f"- {node_id}")
-    print("Failure excerpt:")
-    for line in summary["failure_excerpt"]:
-        print(line)
+    if summary["failure_excerpt"]:
+        print("Failure excerpt:")
+        for line in summary["failure_excerpt"]:
+            print(line)
     if summary["excerpt_truncated"]:
         print("... additional matching lines omitted; see full log")
 

--- a/tests/dev/test_run_compact_validation.py
+++ b/tests/dev/test_run_compact_validation.py
@@ -57,7 +57,7 @@ def test_run_compact_validation_bounds_failure_output(tmp_path: Path, capsys) ->
 
 
 def test_run_compact_validation_json_summary_for_success(tmp_path: Path, capsys) -> None:
-    """Successful commands should still save full logs and emit summary JSON."""
+    """Successful commands should save logs without a failure-labelled excerpt."""
     artifact_dir = tmp_path / "artifacts"
     command = [sys.executable, "-c", "print('ok')"]
 
@@ -67,12 +67,16 @@ def test_run_compact_validation_json_summary_for_success(tmp_path: Path, capsys)
     payload = json.loads(stdout)
     assert rc == 0
     assert payload["exit_code"] == 0
-    assert payload["failure_excerpt"] == ["ok"]
+    assert payload["failure_excerpt"] == []
+    assert payload["excerpt_line_count"] == 0
+    assert payload["excerpt_truncated"] is False
     assert Path(payload["log_path"]).read_text(encoding="utf-8") == "ok\n"
     assert Path(payload["summary_path"]).exists()
 
 
-def test_run_compact_validation_suppresses_node_ids_on_success(tmp_path: Path) -> None:
+def test_run_compact_validation_suppresses_failure_details_on_success(
+    tmp_path: Path, capsys
+) -> None:
     """Passing pytest-like logs should not look like failed test summaries."""
     artifact_dir = tmp_path / "artifacts"
     command = [
@@ -89,11 +93,15 @@ def test_run_compact_validation_suppresses_node_ids_on_success(tmp_path: Path) -
         ),
     ]
 
-    summary = run_compact_validation(command, artifact_dir=artifact_dir)
+    rc = main(["--artifact-dir", str(artifact_dir), "--", *command])
+    stdout = capsys.readouterr().out
+    summary = json.loads(next(artifact_dir.glob("*.summary.json")).read_text(encoding="utf-8"))
 
+    assert rc == 0
     assert summary["exit_code"] == 0
     assert summary["failing_node_ids"] == []
-    assert "test_policy_stack_runs_atomic_topology_smoke" in "\n".join(summary["failure_excerpt"])
+    assert summary["failure_excerpt"] == []
+    assert "Failure excerpt:" not in stdout
 
 
 def test_run_compact_validation_keeps_node_ids_on_failure(tmp_path: Path) -> None:
@@ -117,8 +125,8 @@ def test_run_compact_validation_keeps_node_ids_on_failure(tmp_path: Path) -> Non
     assert summary["failing_node_ids"] == ["tests/dev/test_compact.py::test_real_failure"]
 
 
-def test_run_compact_validation_marks_truncated_plain_output(tmp_path: Path) -> None:
-    """Large output without failure keywords should still report truncation."""
+def test_run_compact_validation_suppresses_plain_output_on_success(tmp_path: Path) -> None:
+    """Successful output should not create a failure excerpt."""
     artifact_dir = tmp_path / "artifacts"
     command = [
         sys.executable,
@@ -129,12 +137,8 @@ def test_run_compact_validation_marks_truncated_plain_output(tmp_path: Path) -> 
     summary = run_compact_validation(command, artifact_dir=artifact_dir, excerpt_lines=3)
 
     assert summary["exit_code"] == 0
-    assert summary["excerpt_truncated"] is True
-    assert summary["failure_excerpt"] == [
-        "plain output line 27",
-        "plain output line 28",
-        "plain output line 29",
-    ]
+    assert summary["excerpt_truncated"] is False
+    assert summary["failure_excerpt"] == []
 
 
 def test_run_compact_validation_emits_summary_on_timeout(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** successful compact-validation runs now keep `failure_excerpt` empty and omit the human `Failure excerpt:` block; failed and timed-out runs retain their excerpts.
- **Why now:** issue #5169 reproduced successful pytest duration output being presented as a failure.
- **Claim boundary:** this is reporting-only behavior for `scripts/dev/run_compact_validation.py`; it changes no benchmark, metric, schema, or research claim.
- **Required validation:** focused wrapper tests, Ruff, diff check, and the final repository readiness gate.
- **Remaining blocker:** none for this issue.

## Contract delta

- **Successful command (`exit_code == 0`):** `failure_excerpt: []`, `excerpt_line_count: 0`, and `excerpt_truncated: false`; the full log remains available at `log_path`.
- **Nonzero or timed-out command:** existing failure excerpt and failing-node behavior is unchanged.
- **Compatibility impact:** `failure_excerpt` remains in the existing `compact_validation_summary.v2` payload, so consumers receive an empty list rather than a removed or renamed field.
- **New fail-closed blockers:** none.

Closes #5169

<details>
<summary>Implementation, validation, and governance appendix</summary>

## Linked issue and scope

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5169
- Scope: suppress failure-labelled excerpts for successful compact validation only.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## What changed

- Gate failure-excerpt extraction on a nonzero wrapped-command exit code.
- Print the human failure-excerpt heading only when an excerpt exists.
- Extend regression coverage for JSON and human summaries of ordinary and pytest-like successful output.

## Validation / proof

- ` .venv/bin/python -m pytest tests/dev/test_run_compact_validation.py -q` — passed, 9 tests.
- ` .venv/bin/python -m ruff check scripts/dev/run_compact_validation.py tests/dev/test_run_compact_validation.py` — passed.
- ` .venv/bin/python -m ruff format --check scripts/dev/run_compact_validation.py tests/dev/test_run_compact_validation.py` — passed.
- `git diff --check` — passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=<this body> PYTEST_NUM_WORKERS=16 scripts/dev/pr_ready_check.sh` — passed: 2,150 passed, 1 skipped; coverage, changed-file, docstring, broad-exception, and PR-body checks passed.

The focused tests prove that successful logs containing pytest node IDs, slow-test durations, or plain output no longer emit a failure payload or heading, while the pre-existing failure and timeout tests retain failure evidence.

## Risks / rollout

- Compatibility risk: consumers that treated success-run `failure_excerpt` as a generic log tail will now receive `[]`; the field name and issue contract make that behavior intentional.
- Rollback: revert this small conditional if a distinct success-log-tail field is required later.

## Downstream propagation

No issue comment is added because this task does not authorize issue/PR comments. This support-tooling fix has no benchmark, model, registry, artifact, or research-result propagation; the closing PR link is the single durable state update for this low-churn issue.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA — support helper only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: NA
- Result classification: NA
- Decision or stop rule, if applicable: the regression is resolved when successful output has no failure-labelled payload.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #5169 only.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA — this helper does not interpret research evidence.

## Domain-Aware Approval

- Required for this PR: no — support-tooling reporting fix with no evidence-validity change.
- Domains reviewed: NA — no evidence classification, experimental comparison, benchmark interpretation, or paper-facing claim changes.
- Status: not required.
- Approver/review source or waiver: NA — the issue contract and targeted regression tests define this non-research behavior.
- Validity checklist:
  - Target claim/hypothesis: NA — no research claim.
  - Comparator or split/evidence validity: NA — no experiment or comparison.
  - Fallback/degraded exclusions: NA — no benchmark execution.
  - Claim boundary: wrapper reporting only.
  - Implementation integrity vs experimental validity: focused tests prove the reporting contract; experimental validity is not implicated.

## Falsification / Non-Transfer Check

NA — no research mechanism.

## Next Empirical Action

NA — issue is complete when the regression behavior is validated.

## Follow-Up Issues

- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer notes

Please verify the deliberate compatibility boundary: preserve the existing field and full log, but reserve the failure-labelled payload for nonzero exits.

</details>
