### PR TITLE
feat(validation): add threaded LiDAR comparator mode (#5118)

### DIFF
--- a/scripts/validation/run_vecenv_worker_mode_throughput.py
+++ b/scripts/validation/run_vecenv_worker_mode_throughput.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """CPU VecEnv worker-mode throughput comparator.
 
-Loads a standard training config, constructs ``dummy``, ``subproc``, and
-``threaded`` VecEnv modes, runs bounded warmup and step loops, and writes
-machine-readable JSON with throughput and host/config provenance.
+Loads a standard training config, constructs ``dummy``, ``subproc``,
+``threaded``, and ``threaded_lidar_batch`` VecEnv modes, runs bounded warmup
+and step loops, and writes machine-readable JSON with throughput and
+host/config provenance.
 
 Usage
 -----
@@ -48,8 +49,8 @@ Notes
 -----
 - ``subproc`` mode spawns sub-processes; the script uses ``spawn`` start
   method and must be invoked as an executable file (not via ``python -c``).
-- ``threaded_lidar_batch`` mode is not included here; it awaits the merge of
-  PR #5123 (``worker_mode: threaded_lidar_batch``).
+- ``threaded_lidar_batch`` uses the same in-process workers as ``threaded``
+  while enabling its cross-environment LiDAR batch coordinator.
 
 Found while implementing #4981; tracked as issue #5118.
 """
@@ -72,7 +73,7 @@ from typing import Any
 _REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
 _DEFAULT_CONFIG = _REPO_ROOT / "configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml"
 _SCHEMA = "vecenv_throughput_comparator.v1"
-_SUPPORTED_MODES = ("dummy", "subproc", "threaded")
+_SUPPORTED_MODES = ("dummy", "subproc", "threaded", "threaded_lidar_batch")
 _RECOVERABLE_MODE_ERRORS = (
     EOFError,
     BrokenPipeError,
@@ -217,6 +218,8 @@ def _build_vec_env(mode: str, env_fns: list[_EnvFactory]):
         return SubprocVecEnv(env_fns, start_method="spawn")
     if mode == "threaded":
         return ThreadedVecEnv(env_fns)
+    if mode == "threaded_lidar_batch":
+        return ThreadedVecEnv(env_fns, batch_lidar=True)
     raise ValueError(f"Unsupported mode: {mode!r}; expected one of {_SUPPORTED_MODES}")
 
 
@@ -291,7 +294,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser for the VecEnv throughput comparator."""
     parser = argparse.ArgumentParser(
         description=(
-            "Compare CPU VecEnv worker-mode throughput (dummy / subproc / threaded). "
+            "Compare CPU VecEnv worker-mode throughput "
+            "(dummy / subproc / threaded / threaded_lidar_batch). "
             "Writes machine-readable JSON with provenance for acceptance audits."
         )
     )

--- a/tests/validation/test_run_vecenv_worker_mode_throughput.py
+++ b/tests/validation/test_run_vecenv_worker_mode_throughput.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+from gymnasium import Env, spaces
 
 _REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
 
@@ -17,6 +18,7 @@ sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.validation.run_vecenv_worker_mode_throughput import (  # noqa: E402
     _build_env_fns,
+    _build_vec_env,
     _env_factory_kwargs,
     _EnvFactory,
     _resolve_num_envs,
@@ -118,6 +120,46 @@ def test_build_env_fns_length():
     assert len(env_fns) == 3
     assert env_fns[0].seed == 10
     assert env_fns[2].seed == 12
+
+
+class _SyntheticEnv(Env):
+    """Deterministic environment for worker-mode transition equivalence tests."""
+
+    metadata = {"render_modes": []}
+
+    def __init__(self, offset: float) -> None:
+        self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32)
+        self.observation_space = spaces.Box(low=-10.0, high=10.0, shape=(1,), dtype=np.float32)
+        self._offset = offset
+
+    def reset(self, *, seed: int | None = None, options: dict | None = None):
+        super().reset(seed=seed)
+        return np.array([self._offset], dtype=np.float32), {}
+
+    def step(self, action: np.ndarray):
+        observation = np.asarray(action, dtype=np.float32) + self._offset
+        return observation, float(observation[0]), False, False, {}
+
+
+def test_threaded_lidar_batch_matches_threaded_synthetic_transitions():
+    """The comparator's batch mode preserves synthetic threaded transitions exactly."""
+    env_fns = [lambda: _SyntheticEnv(0.0), lambda: _SyntheticEnv(1.0)]
+    actions = np.array([[0.25], [0.75]], dtype=np.float32)
+    threaded = _build_vec_env("threaded", env_fns)
+    batched = _build_vec_env("threaded_lidar_batch", env_fns)
+    try:
+        np.testing.assert_array_equal(batched.reset(), threaded.reset())
+        batched_transition = batched.step(actions)
+        threaded_transition = threaded.step(actions)
+    finally:
+        batched.close()
+        threaded.close()
+
+    for batched_value, threaded_value in zip(batched_transition, threaded_transition, strict=True):
+        if isinstance(batched_value, np.ndarray):
+            np.testing.assert_array_equal(batched_value, threaded_value)
+        else:
+            assert batched_value == threaded_value
 
 
 # ---------------------------------------------------------------------------
@@ -235,6 +277,43 @@ def test_main_threaded_mode_writes_json(tmp_path):
     not _SMOKE_CONFIG.exists(),
     reason="smoke config not found",
 )
+def test_main_threaded_lidar_batch_mode_writes_json(tmp_path):
+    """The comparator accepts the batched LiDAR worker mode and records it unchanged."""
+    out = tmp_path / "result.json"
+    with patch(
+        "scripts.validation.run_vecenv_worker_mode_throughput._build_vec_env",
+        side_effect=_patch_build_vec_env,
+    ):
+        rc = main(
+            [
+                "--config",
+                str(_SMOKE_CONFIG),
+                "--modes",
+                "dummy",
+                "threaded_lidar_batch",
+                "--num-envs",
+                "2",
+                "--warmup-steps",
+                "2",
+                "--measure-steps",
+                "5",
+                "--output",
+                str(out),
+            ]
+        )
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert [record["mode"] for record in data["results"]] == [
+        "dummy",
+        "threaded_lidar_batch",
+    ]
+    assert all(record["status"] == "ok" for record in data["results"])
+
+
+@pytest.mark.skipif(
+    not _SMOKE_CONFIG.exists(),
+    reason="smoke config not found",
+)
 def test_main_construction_failure_reflected_in_output(tmp_path):
     """Construction failure status is recorded; main returns 2."""
     out = tmp_path / "result.json"
@@ -274,6 +353,17 @@ def test_main_missing_config_returns_1(tmp_path):
     out = tmp_path / "result.json"
     rc = main(["--config", str(tmp_path / "nonexistent.yaml"), "--output", str(out)])
     assert rc == 1
+
+
+def test_main_missing_scenario_config_returns_1(tmp_path, capsys):
+    """A config without its required scenario input must fail before env construction."""
+    config = tmp_path / "missing_scenario_config.yaml"
+    config.write_text("num_envs: 2\n", encoding="utf-8")
+
+    rc = main(["--config", str(config), "--output", str(tmp_path / "result.json")])
+
+    assert rc == 1
+    assert "scenario_config must be a non-empty path string" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Added `threaded_lidar_batch` to the CPU VecEnv comparator and route it to `ThreadedVecEnv(..., batch_lidar=True)`.
- **Why now:** PR #5130 established the three-mode comparator and issue #5118's maintainer update identifies this remaining bounded mode.
- **Claim boundary:** This proves the local comparator contract only. The two-step CPU smoke is diagnostic-only; it makes no throughput or acceptance-campaign claim.
- **Required validation:** Focused synthetic equivalence and missing-input tests, real LiDAR batching coverage, a bounded CPU comparator smoke, and the final repository readiness gate.
- **Remaining blocker:** None for #5118. Four-mode acceptance measurement remains owned by #4981 and is intentionally not run here.

## Contract delta

- **New accepted mode:** `threaded_lidar_batch` is an additive `--modes` choice.
- **Construction contract:** it uses the existing in-process threaded VecEnv with `batch_lidar=True`.
- **Schema:** unchanged (`vecenv_throughput_comparator.v1`); result records retain the existing fields.
- **Fail-closed behavior:** missing `scenario_config`, invalid mode selections, and construction/step failures retain their non-success paths.
- **Compatibility:** `dummy`, `subproc`, and `threaded` behavior is unchanged.

## Linked Issues

- Closes #5118
- Four-mode acceptance campaign: #4981 (out of scope)

## Stack / Dependency

- Base dependency: PR #5130
- Required prior PRs: #5123, #5130
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `threaded_lidar_batch` is already implemented by #5123; this PR only exposes it to the existing comparator.

## What Changed

- Added the fourth comparator mode and its `ThreadedVecEnv(batch_lidar=True)` construction.
- Updated CLI/help documentation without changing the result schema.
- Added synthetic threaded-vs-batched transition equivalence, comparator JSON, and missing-scenario-input tests.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: comparator support for the pre-existing threaded LiDAR batch worker mode.
- Comparator or baseline, if applicable: `dummy` remains the comparator's baseline; no performance interpretation is made.
- Evidence tier: NA - support helper contract, not benchmark evidence.
- Result classification: NA - implementation integrity only.
- Decision or stop rule, if applicable: #5118 is complete when all four selectable modes construct or fail through the existing explicit status contract.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #5118 closes on merge; #4981 owns empirical acceptance evidence.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - existing support comparator extended by one mode.

## Domain-Aware Approval

- Required for this PR: no - it does not change evidence classification, comparison methodology, or paper-facing claims.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: implementation-only comparator contract.
- Validity checklist:
  - Target claim/hypothesis: NA
  - Comparator or split/evidence validity: no campaign claim
  - Fallback/degraded exclusions: no fallback/degraded result is presented as success
  - Claim boundary: diagnostic smoke only
  - Implementation integrity vs experimental validity: implementation integrity only

## Falsification / Non-Transfer Check

NA - no research result or performance-transfer claim.

## Next Empirical Action

- Rerun needed: NA - no campaign requested by this issue slice.
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop; #5118's implementation contract is complete.
- Proposed child issue or existing follow-up: #4981 for the excluded four-mode acceptance campaign.

## Validation / Proof

- `uv run ruff format --check scripts/validation/run_vecenv_worker_mode_throughput.py tests/validation/test_run_vecenv_worker_mode_throughput.py` — passed.
- `uv run ruff check scripts/validation/run_vecenv_worker_mode_throughput.py tests/validation/test_run_vecenv_worker_mode_throughput.py` — passed.
- `uv run pytest tests/validation/test_run_vecenv_worker_mode_throughput.py tests/training/test_threaded_vec_env.py -q` — 27 passed.
- `uv run python scripts/validation/run_vecenv_worker_mode_throughput.py --modes dummy threaded_lidar_batch --num-envs 2 --warmup-steps 1 --measure-steps 2 --output output/issue_5118_threaded_lidar_batch_smoke.json` — passed; bounded diagnostic smoke only.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on the final branch tip.

## Risks / Rollout

- Compatibility risks: additive CLI choice only; existing choices and JSON schema are unchanged.
- Failure modes: environment/configuration failures continue to emit an explicit non-success status and nonzero exit.
- Rollback or fallback plan: remove the new mode choice; no stored results or configs require migration.

## Docs / Provenance

- Updated docs: comparator module docstring and CLI help.
- Relevant design or provenance notes: #5123 provides the underlying LiDAR-batch implementation; #5130 provides the comparator contract.
- Any assumptions that need to be preserved: the mode's `batch_lidar=True` routing is the reversible implementation assumption, verified by synthetic equivalence plus existing real-LiDAR batching coverage.

## Downstream Propagation

- Parent issue updated: no - authorization prohibits issue/PR comments; `Closes #5118` is the durable merge-time propagation.
- Claim map / benchmark report updated: NA - no empirical result or claim.
- Leaderboard / artifact catalog updated: NA - no durable benchmark artifact.
- Registry or config index updated: NA - no config/default change.
- Context index / memory note updated: NA - no durable research context produced.
- Follow-up issue opened for deferred propagation: no - #4981 already owns the excluded campaign.
- Not applicable because: this PR is a bounded support-tool contract change; no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## Follow-Up Issues

- Deferred work: four-mode acceptance campaign in #4981.
- Issues opened for follow-up: #5178 records the fresh-worktree training-extra bootstrap friction encountered during validation.

## Reviewer Notes

- Verify that the new mode reaches `ThreadedVecEnv` with `batch_lidar=True` and that the existing three modes remain untouched.
- Known limitation: the included CPU smoke uses only two measured steps and must not be interpreted as a throughput comparison.

<details>
<summary>Scope and artifact appendix</summary>

- Scope deliberately excludes four-mode acceptance campaigns, performance tuning, Slurm execution, GPU submission, and paper/dissertation claim edits.
- The generated `output/issue_5118_threaded_lidar_batch_smoke.json` is an ignored, disposable local diagnostic artifact and is not part of the PR.
- No state comment is added because the authorization explicitly prohibits issue/PR comments; no transient routing or host state is tracked.
</details>
