### PR TITLE
feat(validation): make four-mode VecEnv throughput auditable (#4981)

### DIFF
--- a/docs/dev/issues/4981-vectorized-rollouts/design.md
+++ b/docs/dev/issues/4981-vectorized-rollouts/design.md
@@ -43,7 +43,17 @@ closed instead of falling back silently. Reset-time and automatic-reset scans re
 
 The implementation is proven by Stable-Baselines3 lifecycle tests, a real Robot SF reset/step smoke,
 and a coordinated rollout test that compares complete LiDAR observations bit for bit with scalar
-threaded execution. This is implementation-integrity evidence, not throughput evidence. The
-remaining acceptance step is a reproducible standard-PPO configuration measurement that compares
-dummy, subprocess, threaded, and threaded-LiDAR-batch modes. The issue's >3x claim may only be
-promoted if the exact configuration, host, and sample duration support it.
+threaded execution. This is implementation-integrity evidence, not throughput evidence.
+
+Run the bounded four-mode central processing unit (CPU) comparator with:
+
+```bash
+uv run python scripts/validation/run_vecenv_worker_mode_throughput.py \
+  --config configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml \
+  --output output/vecenv_throughput.json
+```
+
+The JSON records repeated throughput samples, median speedup against a separately measured
+one-environment dummy fallback, failures, and config/scenario/commit/host provenance. Its explicit
+claim boundary is diagnostic-only. The issue's >3x claim may only be promoted after a reviewed,
+sufficiently long standard-config measurement supports it; a bounded smoke is not that evidence.

--- a/scripts/validation/run_vecenv_worker_mode_throughput.py
+++ b/scripts/validation/run_vecenv_worker_mode_throughput.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """CPU VecEnv worker-mode throughput comparator.
 
-Loads a standard training config, constructs ``dummy``, ``subproc``,
-``threaded``, and ``threaded_lidar_batch`` VecEnv modes, runs bounded warmup
-and step loops, and writes machine-readable JSON with throughput and
-host/config provenance.
+Loads a standard expert Proximal Policy Optimization (PPO) training config,
+constructs ``dummy``, ``subproc``, ``threaded``, and
+``threaded_lidar_batch`` VecEnv modes through the training environment
+contract, runs repeated bounded warmup and step loops, and writes
+machine-readable JSON with throughput and host/config provenance.
 
 Usage
 -----
@@ -16,30 +17,39 @@ Usage
     # explicit config and env count
     uv run python scripts/validation/run_vecenv_worker_mode_throughput.py \\
         --config configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml \\
-        --num-envs 4 --warmup-steps 10 --measure-steps 50 \\
+        --num-envs 4 --repetitions 3 --warmup-steps 10 --measure-steps 50 \\
         --output output/vecenv_throughput.json
 
-Output schema (``vecenv_throughput_comparator.v1``)
+Output schema (``vecenv_throughput_comparator.v2``)
 ----------------------------------------------------
 ::
 
     {
-      "schema": "vecenv_throughput_comparator.v1",
+      "schema": "vecenv_throughput_comparator.v2",
+      "status": "ok",
       "config_path": "...",
       "config_sha256": "...",
       "commit": "...",
       "host": "...",
       "num_envs": 4,
+      "repetitions": 3,
+      "base_seed": 42,
       "warmup_steps": 20,
       "measure_steps": 100,
       "baseline_mode": "dummy",
+      "baseline_num_envs": 1,
+      "baseline": {
+        "transitions_per_second": 10.2,
+        "status": "ok"
+      },
       "results": [
         {
           "mode": "dummy",
           "transitions_per_second": 42.3,
-          "speedup_vs_baseline": 1.0,
+          "speedup_vs_baseline": 4.147,
           "status": "ok",
-          "error": null
+          "error": null,
+          "repetition_results": []
         },
         ...
       ]
@@ -51,6 +61,12 @@ Notes
   method and must be invoked as an executable file (not via ``python -c``).
 - ``threaded_lidar_batch`` uses the same in-process workers as ``threaded``
   while enabling its cross-environment LiDAR batch coordinator.
+- Speedups use a separately measured one-environment ``DummyVecEnv`` fallback
+  as the baseline. The four requested mode rows all use ``num_envs``.
+- The first scenario definition in the training config's scenario manifest is
+  held fixed across modes; the JSON records that selection and the manifest hash.
+- Results are diagnostic until a sufficiently long, reviewed measurement
+  supports the parent issue's acceptance gate.
 
 Found while implementing #4981; tracked as issue #5118.
 """
@@ -64,6 +80,7 @@ import hashlib
 import json
 import platform
 import socket
+import statistics
 import subprocess
 import sys
 import time
@@ -72,7 +89,7 @@ from typing import Any
 
 _REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
 _DEFAULT_CONFIG = _REPO_ROOT / "configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml"
-_SCHEMA = "vecenv_throughput_comparator.v1"
+_SCHEMA = "vecenv_throughput_comparator.v2"
 _SUPPORTED_MODES = ("dummy", "subproc", "threaded", "threaded_lidar_batch")
 _RECOVERABLE_MODE_ERRORS = (
     EOFError,
@@ -97,6 +114,7 @@ class _EnvFactory:
     scenario_path: Path
     env_factory_kwargs: dict[str, Any]
     seed: int | None
+    env_overrides: dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __call__(self):
         from robot_sf.gym_env.environment_factory import make_robot_env
@@ -104,6 +122,7 @@ class _EnvFactory:
             build_robot_config_from_scenario,
             load_scenarios,
         )
+        from scripts.training.train_ppo import _apply_env_overrides
 
         scenarios = load_scenarios(self.scenario_path)
         if not scenarios:
@@ -112,6 +131,9 @@ class _EnvFactory:
             scenarios[0],
             scenario_path=self.scenario_path,
         )
+        # Reuse the production PPO override path so this measures the training
+        # config's declared environment rather than the raw scenario defaults.
+        _apply_env_overrides(config, self.env_overrides)
         return make_robot_env(
             config=config,
             seed=self.seed,
@@ -155,6 +177,15 @@ def _git_commit(repo_root: Path) -> str:
         return "unknown"
 
 
+def _provenance_path(path: Path) -> str:
+    """Prefer a checkout-independent repository-relative provenance path."""
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(_REPO_ROOT))
+    except ValueError:
+        return str(resolved)
+
+
 def _resolve_scenario_path(config: dict[str, Any], config_path: Path) -> Path:
     """Resolve the scenario_config path relative to the config file."""
     raw = config.get("scenario_config")
@@ -186,6 +217,13 @@ def _env_factory_kwargs(config: dict[str, Any]) -> dict[str, Any]:
     return dict(raw)
 
 
+def _env_overrides(config: dict[str, Any]) -> dict[str, Any]:
+    raw = config.get("env_overrides") or {}
+    if not isinstance(raw, dict):
+        raise ValueError("config env_overrides must be a mapping when provided")
+    return dict(raw)
+
+
 # ---------------------------------------------------------------------------
 # VecEnv construction
 # ---------------------------------------------------------------------------
@@ -196,12 +234,14 @@ def _build_env_fns(
     env_factory_kwargs: dict[str, Any],
     num_envs: int,
     base_seed: int,
+    env_overrides: dict[str, Any] | None = None,
 ) -> list[_EnvFactory]:
     return [
         _EnvFactory(
             scenario_path=scenario_path,
             env_factory_kwargs=env_factory_kwargs,
             seed=base_seed + i,
+            env_overrides=dict(env_overrides or {}),
         )
         for i in range(num_envs)
     ]
@@ -228,13 +268,14 @@ def _build_vec_env(mode: str, env_fns: list[_EnvFactory]):
 # ---------------------------------------------------------------------------
 
 
-def _measure_mode(
+def _measure_mode_once(
     mode: str,
     env_fns: list[_EnvFactory],
     warmup_steps: int,
     measure_steps: int,
+    action_seed: int,
 ) -> dict[str, Any]:
-    """Run warmup then measured steps; return throughput record."""
+    """Run one warmup and measurement repetition; return its throughput record."""
     import numpy as np
 
     try:
@@ -252,6 +293,7 @@ def _measure_mode(
     try:
         vec_env.reset()
         action_space = vec_env.action_space
+        action_space.seed(action_seed)
         for _ in range(warmup_steps):
             actions = np.array([action_space.sample() for _ in range(num_envs)])
             vec_env.step(actions)
@@ -285,6 +327,50 @@ def _measure_mode(
             vec_env.close()
 
 
+def _measure_mode(
+    mode: str,
+    env_fns: list[_EnvFactory],
+    warmup_steps: int,
+    measure_steps: int,
+    repetitions: int,
+    base_seed: int,
+) -> dict[str, Any]:
+    """Measure one mode repeatedly and summarize successful samples by median."""
+    repetition_results: list[dict[str, Any]] = []
+    for repetition in range(repetitions):
+        record = _measure_mode_once(
+            mode,
+            env_fns,
+            warmup_steps,
+            measure_steps,
+            action_seed=base_seed + repetition,
+        )
+        record["repetition"] = repetition
+        repetition_results.append(record)
+
+    failures = [record for record in repetition_results if record["status"] != "ok"]
+    if failures:
+        first = failures[0]
+        return {
+            "mode": mode,
+            "transitions_per_second": None,
+            "speedup_vs_baseline": None,
+            "status": first["status"],
+            "error": first["error"],
+            "repetition_results": repetition_results,
+        }
+
+    samples = [float(record["transitions_per_second"]) for record in repetition_results]
+    return {
+        "mode": mode,
+        "transitions_per_second": round(statistics.median(samples), 2),
+        "speedup_vs_baseline": None,
+        "status": "ok",
+        "error": None,
+        "repetition_results": repetition_results,
+    }
+
+
 # ---------------------------------------------------------------------------
 # CLI entry point
 # ---------------------------------------------------------------------------
@@ -311,6 +397,20 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="N",
         help="Number of parallel environments (overrides config; default: config value or 4).",
+    )
+    parser.add_argument(
+        "--repetitions",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Independent measurements per baseline/mode (default: 3; median is reported).",
+    )
+    parser.add_argument(
+        "--base-seed",
+        type=int,
+        default=42,
+        metavar="N",
+        help="First environment and action-sampling seed (default: 42).",
     )
     parser.add_argument(
         "--warmup-steps",
@@ -351,27 +451,46 @@ def build_arg_parser() -> argparse.ArgumentParser:
 def _run_modes(
     modes: list[str],
     env_fns: list[_EnvFactory],
+    baseline_env_fns: list[_EnvFactory],
     warmup_steps: int,
     measure_steps: int,
-) -> tuple[list[dict[str, Any]], float | None]:
-    """Measure throughput for each mode; return results and baseline TPS."""
+    repetitions: int,
+    base_seed: int,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Measure the single-env baseline and every requested target worker mode."""
     results: list[dict[str, Any]] = []
-    baseline_tps: float | None = None
-    baseline_mode = modes[0] if modes else "dummy"
+
+    print("  measuring baseline=dummy num_envs=1 ...", file=sys.stderr)
+    baseline = _measure_mode(
+        "dummy",
+        baseline_env_fns,
+        warmup_steps,
+        measure_steps,
+        repetitions,
+        base_seed,
+    )
+    baseline_tps = baseline["transitions_per_second"]
+    if baseline_tps is not None:
+        baseline["speedup_vs_baseline"] = 1.0
 
     for mode in modes:
         print(f"  measuring mode={mode} ...", file=sys.stderr)
-        record = _measure_mode(mode, env_fns, warmup_steps, measure_steps)
+        record = _measure_mode(
+            mode,
+            env_fns,
+            warmup_steps,
+            measure_steps,
+            repetitions,
+            base_seed,
+        )
         results.append(record)
-        if mode == baseline_mode and record["transitions_per_second"] is not None:
-            baseline_tps = record["transitions_per_second"]
 
     for record in results:
         tps = record["transitions_per_second"]
         if tps is not None and baseline_tps is not None and baseline_tps > 0:
             record["speedup_vs_baseline"] = round(tps / baseline_tps, 3)
 
-    return results, baseline_tps
+    return baseline, results
 
 
 def _write_results(
@@ -411,6 +530,48 @@ def _validate_run_parameters(args: argparse.Namespace) -> None:
         raise ValueError("--warmup-steps must be >= 0")
     if args.measure_steps < 1:
         raise ValueError("--measure-steps must be >= 1")
+    if args.repetitions < 1:
+        raise ValueError("--repetitions must be >= 1")
+
+
+def _write_preflight_failure(
+    *,
+    args: argparse.Namespace,
+    config_path: Path,
+    error: str,
+    host: str,
+) -> Path:
+    """Persist configuration failures through the same machine-readable contract."""
+    config_sha256 = None
+    if config_path.is_file():
+        with contextlib.suppress(OSError):
+            config_sha256 = _sha256_file(config_path)
+    payload = {
+        "schema": _SCHEMA,
+        "status": "failed",
+        "config_path": _provenance_path(config_path),
+        "config_sha256": config_sha256,
+        "scenario_path": None,
+        "scenario_sha256": None,
+        "scenario_selection": None,
+        "commit": _git_commit(_REPO_ROOT),
+        "host": host,
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        "platform": platform.platform(),
+        "num_envs": args.num_envs,
+        "repetitions": args.repetitions,
+        "base_seed": args.base_seed,
+        "warmup_steps": args.warmup_steps,
+        "measure_steps": args.measure_steps,
+        "modes": list(args.modes),
+        "baseline_mode": "dummy",
+        "baseline_num_envs": 1,
+        "baseline": None,
+        "results": [],
+        "failures": [{"scope": "configuration", "error": error}],
+        "claim_boundary": "diagnostic_only_not_benchmark_evidence",
+    }
+    return _write_results(payload, args.output, host)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -418,9 +579,17 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
 
+    host = socket.gethostname()
     config_path = Path(args.config).resolve()
     if not config_path.exists():
-        print(f"ERROR: config not found: {config_path}", file=sys.stderr)
+        error = f"config not found: {config_path}"
+        output_path = _write_preflight_failure(
+            args=args,
+            config_path=config_path,
+            error=error,
+            host=host,
+        )
+        print(f"ERROR: {error}; wrote: {output_path}", file=sys.stderr)
         return 1
 
     try:
@@ -429,11 +598,26 @@ def main(argv: list[str] | None = None) -> int:
         scenario_path = _resolve_scenario_path(raw_config, config_path)
         num_envs = _resolve_num_envs(raw_config, args.num_envs)
         env_factory_kwargs = _env_factory_kwargs(raw_config)
+        env_overrides = _env_overrides(raw_config)
     except ValueError as exc:
-        print(f"ERROR: invalid comparator configuration: {exc}", file=sys.stderr)
+        error = f"invalid comparator configuration: {exc}"
+        output_path = _write_preflight_failure(
+            args=args,
+            config_path=config_path,
+            error=error,
+            host=host,
+        )
+        print(f"ERROR: {error}; wrote: {output_path}", file=sys.stderr)
         return 1
     if not scenario_path.exists():
-        print(f"ERROR: scenario not found: {scenario_path}", file=sys.stderr)
+        error = f"scenario not found: {scenario_path}"
+        output_path = _write_preflight_failure(
+            args=args,
+            config_path=config_path,
+            error=error,
+            host=host,
+        )
+        print(f"ERROR: {error}; wrote: {output_path}", file=sys.stderr)
         return 1
 
     modes = list(args.modes)
@@ -441,42 +625,84 @@ def main(argv: list[str] | None = None) -> int:
         modes.remove("subproc")
         print("INFO: subproc mode skipped via --skip-subproc", file=sys.stderr)
 
-    host = socket.gethostname()
     commit = _git_commit(_REPO_ROOT)
 
     print(
         f"VecEnv throughput comparator | "
         f"host={host} commit={commit[:12]} "
-        f"num_envs={num_envs} warmup={args.warmup_steps} measure={args.measure_steps}",
+        f"num_envs={num_envs} repetitions={args.repetitions} "
+        f"warmup={args.warmup_steps} measure={args.measure_steps}",
         file=sys.stderr,
     )
 
-    env_fns = _build_env_fns(scenario_path, env_factory_kwargs, num_envs, base_seed=42)
-    results, _ = _run_modes(modes, env_fns, args.warmup_steps, args.measure_steps)
+    env_fns = _build_env_fns(
+        scenario_path,
+        env_factory_kwargs,
+        num_envs,
+        base_seed=args.base_seed,
+        env_overrides=env_overrides,
+    )
+    baseline_env_fns = _build_env_fns(
+        scenario_path,
+        env_factory_kwargs,
+        1,
+        base_seed=args.base_seed,
+        env_overrides=env_overrides,
+    )
+    baseline, results = _run_modes(
+        modes,
+        env_fns,
+        baseline_env_fns,
+        args.warmup_steps,
+        args.measure_steps,
+        args.repetitions,
+        args.base_seed,
+    )
+
+    failures = []
+    if baseline["status"] != "ok":
+        failures.append({"scope": "baseline", "mode": "dummy", "error": baseline["error"]})
+    failures.extend(
+        {"scope": "mode", "mode": record["mode"], "error": record["error"]}
+        for record in results
+        if record["status"] != "ok"
+    )
 
     output_data: dict[str, Any] = {
         "schema": _SCHEMA,
-        "config_path": str(config_path),
+        "status": "failed" if failures else "ok",
+        "config_path": _provenance_path(config_path),
         "config_sha256": _sha256_file(config_path),
+        "scenario_path": _provenance_path(scenario_path),
+        "scenario_sha256": _sha256_file(scenario_path),
+        "scenario_selection": {"strategy": "first", "index": 0},
         "commit": commit,
         "host": host,
         "python": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
         "platform": platform.platform(),
         "num_envs": num_envs,
+        "repetitions": args.repetitions,
+        "base_seed": args.base_seed,
         "warmup_steps": args.warmup_steps,
         "measure_steps": args.measure_steps,
-        "baseline_mode": modes[0] if modes else "dummy",
+        "modes": modes,
+        "baseline_mode": "dummy",
+        "baseline_num_envs": 1,
+        "baseline": baseline,
         "results": results,
+        "failures": failures,
+        "claim_boundary": "diagnostic_only_not_benchmark_evidence",
     }
 
     output_path = _write_results(output_data, args.output, host)
     print(f"  wrote: {output_path}", file=sys.stderr)
     _print_table(results)
 
-    failed = [r for r in results if r["status"] != "ok"]
-    if failed:
-        modes_str = ", ".join(r["mode"] for r in failed)
-        print(f"\nWARN: failed modes: {modes_str}", file=sys.stderr)
+    if failures:
+        scopes = ", ".join(
+            f"{failure['scope']}:{failure.get('mode', 'configuration')}" for failure in failures
+        )
+        print(f"\nWARN: failed measurements: {scopes}", file=sys.stderr)
         return 2
     return 0
 

--- a/tests/validation/test_run_vecenv_worker_mode_throughput.py
+++ b/tests/validation/test_run_vecenv_worker_mode_throughput.py
@@ -20,7 +20,9 @@ from scripts.validation.run_vecenv_worker_mode_throughput import (  # noqa: E402
     _build_env_fns,
     _build_vec_env,
     _env_factory_kwargs,
+    _env_overrides,
     _EnvFactory,
+    _measure_mode,
     _resolve_num_envs,
     _sha256_file,
     main,
@@ -70,6 +72,12 @@ class TestEnvFactoryKwargs:
         assert _env_factory_kwargs({"env_factory_kwargs": None}) == {}
 
 
+def test_env_overrides_passthrough():
+    """Training environment overrides remain part of the measured workload."""
+    overrides = {"observation_mode": "socnav_struct", "use_occupancy_grid": True}
+    assert _env_overrides({"env_overrides": overrides}) == overrides
+
+
 class TestSha256File:
     """Tests for _sha256_file helper."""
 
@@ -107,6 +115,40 @@ class TestEnvFactory:
         assert restored.seed == 1
         assert restored.scenario_path == tmp_path / "scenario.yaml"
 
+    def test_applies_production_training_overrides(self, tmp_path):
+        """The comparator builds the same overridden workload declared by PPO training."""
+        config = object()
+        expected_env = object()
+        factory = _EnvFactory(
+            scenario_path=tmp_path / "scenario.yaml",
+            env_factory_kwargs={"reward_name": "route_completion_v2"},
+            seed=7,
+            env_overrides={"observation_mode": "socnav_struct"},
+        )
+
+        with (
+            patch(
+                "robot_sf.training.scenario_loader.load_scenarios",
+                return_value=[{"scenario_id": "smoke"}],
+            ),
+            patch(
+                "robot_sf.training.scenario_loader.build_robot_config_from_scenario",
+                return_value=config,
+            ),
+            patch("scripts.training.train_ppo._apply_env_overrides") as apply_overrides,
+            patch(
+                "robot_sf.gym_env.environment_factory.make_robot_env",
+                return_value=expected_env,
+            ),
+        ):
+            env = factory()
+
+        apply_overrides.assert_called_once_with(
+            config,
+            {"observation_mode": "socnav_struct"},
+        )
+        assert env is expected_env
+
 
 # ---------------------------------------------------------------------------
 # Integration contract: _build_env_fns length
@@ -120,6 +162,21 @@ def test_build_env_fns_length():
     assert len(env_fns) == 3
     assert env_fns[0].seed == 10
     assert env_fns[2].seed == 12
+
+
+def test_build_env_fns_copies_training_overrides():
+    """Each worker receives an independent copy of the training overrides."""
+    overrides = {"observation_mode": "socnav_struct"}
+    env_fns = _build_env_fns(
+        Path("/tmp/scenario.yaml"),
+        {},
+        num_envs=2,
+        base_seed=10,
+        env_overrides=overrides,
+    )
+
+    assert all(factory.env_overrides == overrides for factory in env_fns)
+    assert env_fns[0].env_overrides is not env_fns[1].env_overrides
 
 
 class _SyntheticEnv(Env):
@@ -162,12 +219,38 @@ def test_threaded_lidar_batch_matches_threaded_synthetic_transitions():
             assert batched_value == threaded_value
 
 
+def test_measure_mode_reports_median_and_repetition_records():
+    """Repeated measurements retain samples and summarize them with the median."""
+    samples = [10.0, 30.0, 20.0]
+
+    def _fake_measure(*args, **kwargs):
+        return {
+            "mode": "dummy",
+            "transitions_per_second": samples.pop(0),
+            "speedup_vs_baseline": None,
+            "status": "ok",
+            "error": None,
+        }
+
+    with patch(
+        "scripts.validation.run_vecenv_worker_mode_throughput._measure_mode_once",
+        side_effect=_fake_measure,
+    ):
+        record = _measure_mode("dummy", [], 1, 2, repetitions=3, base_seed=42)
+
+    assert record["transitions_per_second"] == pytest.approx(20.0)
+    assert [sample["repetition"] for sample in record["repetition_results"]] == [0, 1, 2]
+
+
 # ---------------------------------------------------------------------------
 # Smoke test: main() with a fake DummyVecEnv (no real env construction)
 # ---------------------------------------------------------------------------
 
 
 class _FakeActionSpace:
+    def seed(self, seed):
+        self.seed_value = seed
+
     def sample(self):
         return np.zeros(2, dtype=np.float32)
 
@@ -227,14 +310,26 @@ def test_main_dummy_mode_writes_json(tmp_path):
         )
     assert rc == 0
     data = json.loads(out.read_text())
-    assert data["schema"] == "vecenv_throughput_comparator.v1"
+    assert data["schema"] == "vecenv_throughput_comparator.v2"
+    assert data["status"] == "ok"
+    assert data["config_path"] == ("configs/training/lidar/lidar_ppo_mlp_smoke_issue_1662.yaml")
+    assert len(data["config_sha256"]) == 64
+    assert data["scenario_path"] == "configs/scenarios/classic_interactions.yaml"
+    assert len(data["scenario_sha256"]) == 64
+    assert data["scenario_selection"] == {"strategy": "first", "index": 0}
+    assert data["host"]
+    assert data["commit"]
     assert data["num_envs"] == 2
+    assert data["baseline_num_envs"] == 1
+    assert data["baseline"]["status"] == "ok"
+    assert data["baseline"]["speedup_vs_baseline"] == pytest.approx(1.0)
     assert len(data["results"]) == 1
     rec = data["results"][0]
     assert rec["mode"] == "dummy"
     assert rec["status"] == "ok"
     assert rec["transitions_per_second"] > 0
-    assert rec["speedup_vs_baseline"] == pytest.approx(1.0)
+    assert rec["speedup_vs_baseline"] > 0
+    assert len(rec["repetition_results"]) == 3
 
 
 @pytest.mark.skipif(
@@ -314,6 +409,40 @@ def test_main_threaded_lidar_batch_mode_writes_json(tmp_path):
     not _SMOKE_CONFIG.exists(),
     reason="smoke config not found",
 )
+def test_main_default_matrix_contains_all_four_modes(tmp_path):
+    """The default matrix emits every parent-issue worker mode in stable order."""
+    out = tmp_path / "result.json"
+    with patch(
+        "scripts.validation.run_vecenv_worker_mode_throughput._build_vec_env",
+        side_effect=_patch_build_vec_env,
+    ):
+        rc = main(
+            [
+                "--config",
+                str(_SMOKE_CONFIG),
+                "--num-envs",
+                "2",
+                "--repetitions",
+                "1",
+                "--warmup-steps",
+                "0",
+                "--measure-steps",
+                "1",
+                "--output",
+                str(out),
+            ]
+        )
+
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert data["modes"] == ["dummy", "subproc", "threaded", "threaded_lidar_batch"]
+    assert [record["mode"] for record in data["results"]] == data["modes"]
+
+
+@pytest.mark.skipif(
+    not _SMOKE_CONFIG.exists(),
+    reason="smoke config not found",
+)
 def test_main_construction_failure_reflected_in_output(tmp_path):
     """Construction failure status is recorded; main returns 2."""
     out = tmp_path / "result.json"
@@ -343,6 +472,11 @@ def test_main_construction_failure_reflected_in_output(tmp_path):
         )
     assert rc == 2
     data = json.loads(out.read_text())
+    assert data["status"] == "failed"
+    assert data["failures"] == [
+        {"scope": "baseline", "mode": "dummy", "error": "simulated env build failure"},
+        {"scope": "mode", "mode": "dummy", "error": "simulated env build failure"},
+    ]
     rec = data["results"][0]
     assert rec["status"] == "construction_failed"
     assert "simulated" in rec["error"]
@@ -353,6 +487,9 @@ def test_main_missing_config_returns_1(tmp_path):
     out = tmp_path / "result.json"
     rc = main(["--config", str(tmp_path / "nonexistent.yaml"), "--output", str(out)])
     assert rc == 1
+    data = json.loads(out.read_text())
+    assert data["status"] == "failed"
+    assert data["failures"][0]["scope"] == "configuration"
 
 
 def test_main_missing_scenario_config_returns_1(tmp_path, capsys):
@@ -373,6 +510,7 @@ def test_main_missing_scenario_config_returns_1(tmp_path, capsys):
         ("--modes", "threaded", "--modes must begin with dummy"),
         ("--warmup-steps", "-1", "--warmup-steps must be >= 0"),
         ("--measure-steps", "0", "--measure-steps must be >= 1"),
+        ("--repetitions", "0", "--repetitions must be >= 1"),
     ],
 )
 def test_main_rejects_invalid_measurement_parameters(tmp_path, capsys, flag, value, expected):


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** upgrades the existing CPU VecEnv helper into a reproducible four-mode comparator: one-environment dummy baseline, target-size dummy/subprocess/threaded/batched-threaded rows, repeated samples and median throughput, deterministic workload seeds, production PPO environment overrides, and complete success/failure provenance JSON.
- **Why now:** PRs #5130 and #5179 supplied selectable modes, but #4981 still lacked the single-environment baseline, repetitions, training-override fidelity, and fail-closed artifact contract needed for an acceptance audit.
- **Claim boundary:** implementation integrity plus a bounded diagnostic smoke only. No >3× throughput claim is promoted; the short smoke is not benchmark evidence.
- **Required validation:** focused comparator and real batched-LiDAR equivalence tests, a bounded all-four-mode CPU smoke on `imech039`, and the final committed-head repository readiness gate.
- **Remaining blocker:** a reviewed, sufficiently long standard-config measurement must adjudicate the parent issue's >3× acceptance gate.

## Contract delta

- **Schema:** `vecenv_throughput_comparator.v1` becomes `vecenv_throughput_comparator.v2`.
- **New fields/semantics:** top-level `status`, `repetitions`, `base_seed`, `modes`, scenario path/hash/selection, `baseline_num_envs`, a separate `baseline` record, `failures`, and `claim_boundary`; each mode retains every `repetition_result`, while `transitions_per_second` is their median.
- **Baseline:** `speedup_vs_baseline` now means speedup over a separately measured one-environment `DummyVecEnv`, matching the acceptance question. All four mode rows use the requested target environment count.
- **Workload fidelity:** comparator workers apply the same `env_overrides` path as PPO training and hold the scenario manifest's first scenario fixed across modes.
- **Fail-closed behavior:** invalid comparator inputs write a failed v2 JSON artifact and return 1; baseline/construction/step failures are retained in JSON and return 2.
- **Compatibility impact:** consumers pinned to v1 or its same-size dummy baseline semantics must migrate explicitly to v2; the training/runtime defaults are unchanged.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4981

Refs #4981

## Scope summary

- Consolidates the already merged mode-selection slices into one acceptance-auditable comparator contract.
- Documents the canonical bounded CPU command and diagnostic-only boundary.
- Adds focused success, provenance, repetition/median, four-mode matrix, override-fidelity, invalid-input, and failure-JSON checks.
- This is the nameable progression capability exempt from the fragmentation guard: **reproducible four-mode acceptance measurement JSON**.

Remaining parent work:

- [ ] Run and review a sufficiently long standard-config four-mode measurement.
- [ ] Adjudicate the >3× acceptance gate from that evidence; optimize or narrow the claim if it is not met.

## Validation / proof

- `uv run ruff format --check scripts/validation/run_vecenv_worker_mode_throughput.py tests/validation/test_run_vecenv_worker_mode_throughput.py` — passed.
- `uv run ruff check scripts/validation/run_vecenv_worker_mode_throughput.py tests/validation/test_run_vecenv_worker_mode_throughput.py` — passed.
- `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/validation/test_run_vecenv_worker_mode_throughput.py tests/training/test_threaded_vec_env.py -q` — 33 passed; includes real batched-LiDAR observation equivalence.
- `uv run python scripts/validation/run_vecenv_worker_mode_throughput.py --num-envs 2 --repetitions 2 --warmup-steps 5 --measure-steps 10 --output output/issue_4981_four_mode_final_smoke.json` — passed on `auxme-imech039`; baseline and all four modes `ok`, two samples each, zero failures. Diagnostic smoke only; timing values are intentionally not promoted.
- `jq -e '<v2 schema/status/four-mode/repetition/failure/claim-boundary assertions>' output/issue_4981_four_mode_final_smoke.json` — passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue-4981-pr-body.md scripts/dev/pr_ready_check.sh` — final committed-head proof required before opening.

## Explicitly out of scope

No full benchmark campaign run, no training campaign, no Slurm/GPU submission, and no paper/dissertation claim edits. This PR does not promote the >3× claim.

<details>
<summary>Review, provenance, and governance appendix</summary>

### Research result guidance

- Target blocker: reproducible adjudication of #4981's throughput gate.
- Comparator/baseline: one-environment dummy fallback versus target-size dummy, subprocess, threaded, and batched-threaded modes.
- Evidence tier: targeted smoke.
- Result classification: diagnostic-only; implementation integrity, not performance acceptance.
- Decision rule: the comparator is successful only when every requested row is `ok`; the parent claim remains open until a sufficiently long reviewed run supports or rejects it.
- Synthesis surface: issue #4981 and the v2 JSON output from the eventual acceptance run.

### Domain-aware approval

- Required for this PR: yes — it clarifies the experimental baseline and comparison methodology.
- Domains reviewed: experimental comparison and evidence classification.
- Status: approved.
- Approver/review source or waiver: the maintainer-authored #5118 issue body explicitly requires speedup versus a single-environment baseline, and the full #4981 thread assigns the reproducible four-mode acceptance comparison; Claude Code on `imech156-u` remains the independent post-open merge gate.
- Validity checklist:
  - Target claim/hypothesis: whether vectorized rollout collection exceeds the one-environment fallback by >3× on the standard workload; this PR does not adjudicate it.
  - Comparator or split/evidence validity: one-environment dummy baseline versus the same target-size workload under all four worker modes, with fixed scenario selection and repeated samples.
  - Fallback/degraded exclusions: any failed baseline, construction, step, or repetition makes the artifact non-success and returns nonzero.
  - Claim boundary: bounded smoke is diagnostic-only and not benchmark evidence.
  - Implementation integrity vs experimental validity: tests/smoke prove the comparator contract; the later sufficiently long measurement and domain review own experimental validity.

### Risks and assumptions

- The reversible workload assumption is to fix the scenario manifest's first scenario for every mode, avoiding scenario-sampling drift while retaining the training config's environment overrides.
- Short samples remain sensitive to warmup/JIT and host contention. The output preserves each repetition so reviewers can reject an underpowered run instead of relying only on the median.
- Rollback is to retain the v1 helper; no stored training artifact or runtime default depends on v2.

### Artifacts and downstream propagation

- `output/issue_4981_*` JSON/log files and readiness output are ignored, disposable local diagnostics; none is committed or treated as durable benchmark evidence.
- No issue comment was posted because this run is not authorized to comment, and no `docs/context/issue_4981_state.yaml` canonical state table exists. The PR body is the durable delivery/remaining-work surface; no transient host or packet-routing state is added to tracked files.
- Claim map, leaderboard, artifact catalog, registry, and context index updates are deferred because no benchmark-strength result exists yet.

### Dedupe, fragmentation, and friction

- Start-time audit found no open PR covering #4981 or this exact scope.
- Recent #4981 PRs #5017, #5102, and #5123, plus comparator prerequisites #5130/#5179, are progression slices. This PR integrates them into a coherent measurement contract instead of adding a micro-guard.
- Friction issues filed: none. The encountered `gh issue view --comments` Projects Classic failure is already tracked/resolved by #5021/#5092/#5148 and the repository REST helper; no duplicate was filed.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Throughput comparisons now support repeated measurements and report median performance with per-run details.
  * Results include structured JSON output with configuration, environment, platform, and provenance information.
  * Comparisons use a separately measured single-environment baseline for speedup reporting.
  * Environment overrides from training configurations are applied consistently.

* **Bug Fixes**
  * Configuration and measurement failures now produce structured, machine-readable error reports.
  * Validation covers invalid repetition settings and expanded comparison scenarios.

* **Documentation**
  * Updated validation guidance to describe the bounded four-mode CPU comparison and diagnostic-only throughput claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->