### PR TITLE
fix(sensor): restore deterministic LiDAR observations (#5184)

### DIFF
--- a/robot_sf/sensor/range_sensor.py
+++ b/robot_sf/sensor/range_sensor.py
@@ -151,7 +151,6 @@ class LidarScannerSettings:
     angle_opening: Range = field(init=False)
     scan_noise_array: np.ndarray = field(init=False)
     ray_offsets: np.ndarray = field(init=False)
-    _ray_angles_buffer: np.ndarray = field(init=False)
 
     def __post_init__(self):
         """Validate scanner settings and derive derived fields.
@@ -177,7 +176,6 @@ class LidarScannerSettings:
         scan_noise_arr = np.array(self.scan_noise, dtype=np.float64)
         scan_noise_arr.flags.writeable = False
         self.scan_noise_array = scan_noise_arr
-        self._ray_angles_buffer = np.zeros(self.num_rays, dtype=np.float64)
 
     @classmethod
     def ego_pedestrian_lidar(cls) -> "LidarScannerSettings":
@@ -546,6 +544,7 @@ class _LidarBatchBinding:
 
 
 _LIDAR_BATCH_CONTEXT = local()
+_LIDAR_RANGES_ONLY_CONTEXT = local()
 
 
 @contextmanager
@@ -822,10 +821,10 @@ def lidar_ray_scan_ranges_only(
 ) -> np.ndarray:
     """Simulate a radial LiDAR scan returning only ranges, no ray angles.
 
-    This lightweight variant of :func:`lidar_ray_scan` reuses a private work
-    buffer on the settings object to avoid allocating a new ray_angles array
-    on every call. Intended for hot env-internal closures that discard the
-    directional information.
+    This lightweight variant of :func:`lidar_ray_scan` reuses a thread-local
+    work buffer to avoid allocating a new ray_angles array on every call.
+    The buffer is isolated per thread so parallel environment observations
+    cannot overwrite each other's angles.
 
     Args:
         pose: ``((x, y), heading)`` scanner pose in world coordinates and radians.
@@ -836,7 +835,11 @@ def lidar_ray_scan_ranges_only(
     Returns:
         numpy.ndarray: Per-ray distances with shape ``(settings.num_rays,)``.
     """
-    ranges, _ray_angles = _lidar_ray_scan_impl(pose, occ, settings, settings._ray_angles_buffer)
+    ray_angles = getattr(_LIDAR_RANGES_ONLY_CONTEXT, "ray_angles", None)
+    if ray_angles is None or ray_angles.shape != (settings.num_rays,):
+        ray_angles = np.empty(settings.num_rays, dtype=np.float64)
+        _LIDAR_RANGES_ONLY_CONTEXT.ray_angles = ray_angles
+    ranges, _ray_angles = _lidar_ray_scan_impl(pose, occ, settings, ray_angles)
     return ranges
 
 

--- a/tests/test_range_sensor.py
+++ b/tests/test_range_sensor.py
@@ -674,8 +674,8 @@ def test_lidar_ray_scan_ranges_only_matches_first_element():
         np.testing.assert_array_equal(ranges_only, ranges_ref)
 
 
-def test_lidar_ray_scan_ranges_only_buffer_reuse():
-    """Repeated calls with different headings correctly overwrite the buffer."""
+def test_lidar_ray_scan_ranges_only_thread_local_buffer_reuse():
+    """Repeated calls with different headings correctly reuse the thread-local buffer."""
     obstacle_coords = np.array([[3.0, -1.0, 3.0, 1.0]])
     ped_coords = np.empty((0, 2), dtype=np.float64)
     occ = ContinuousOccupancy(
@@ -702,7 +702,7 @@ def test_lidar_ray_scan_ranges_only_buffer_reuse():
 
 
 def test_lidar_ray_scan_angles_isolated_from_ranges_only_buffer():
-    """Public lidar_ray_scan returned angles remain correct after buffer mutation."""
+    """Public lidar_ray_scan returned angles remain correct after thread-local buffer mutation."""
     obstacle_coords = np.array([[3.0, -1.0, 3.0, 1.0]])
     ped_coords = np.empty((0, 2), dtype=np.float64)
     occ = ContinuousOccupancy(
@@ -726,10 +726,10 @@ def test_lidar_ray_scan_angles_isolated_from_ranges_only_buffer():
     # First scan with full API
     _ranges_1, angles_1 = lidar_ray_scan(((1.0, 1.0), heading_1), occ, settings)
 
-    # Ranges-only call mutates private buffer
+    # Ranges-only call mutates the active thread's private buffer.
     lidar_ray_scan_ranges_only(((1.0, 1.0), heading_2), occ, settings)
 
-    # Second full scan — must not alias or be contaminated by the buffer
+    # Second full scan — must not alias or be contaminated by that buffer.
     _ranges_2, angles_2 = lidar_ray_scan(((1.0, 1.0), heading_1), occ, settings)
 
     expected = np.mod(heading_1 + settings.ray_offsets, 2.0 * np.pi)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** LiDAR's internal ranges-only scan cache is now thread-local instead of shared by a `LidarScannerSettings` instance.
- **Why now:** Parallel multi-robot observation workers were overwriting the shared angle buffer, causing Gymnasium's same-seed deterministic-step checker to fail.
- **Claim boundary:** This restores deterministic zero-noise LiDAR observations; it makes no throughput, benchmark, or paper-facing claim.
- **Required validation:** The original Gymnasium checker regression test, three consecutive reruns of it, focused LiDAR/threaded-VecEnv tests, and the full repository readiness gate.
- **Remaining blocker:** None. The issue's reported CI regression is resolved.

## Contract delta

- **Schema:** unchanged.
- **Behavior:** `lidar_ray_scan_ranges_only` retains allocation reuse, now per active thread rather than per settings object.
- **Fail-closed blockers:** unchanged.
- **Compatibility:** public LiDAR ranges and angle-returning scans are unchanged; concurrent internal scans no longer alias temporary angle storage.

Issue: https://github.com/ll7/robot_sf_ll7/issues/5184

Closes #5184

## What changed

- Replaced the mutable settings-owned temporary ray-angle buffer with a thread-local ranges-only buffer.
- Updated ranges-only buffer terminology in targeted LiDAR tests.

## Validation / proof

- `uv run pytest tests/gym_env/test_multi_robot_gymnasium_contract.py tests/test_range_sensor.py -q` — passed, 47 tests.
- Original checker regression executed three consecutive times — passed each time; summary: `/tmp/issue-5184-gym-checker-repeat.log`.
- `uv run pytest tests/training/test_threaded_vec_env.py -q` — passed, 4 tests.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on the implementation tree.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue-5184-pr-body.md scripts/dev/pr_ready_check.sh` — passed on the committed branch tip.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Review, provenance, and propagation appendix</summary>

## Stack / dependency

- Base dependency: none.
- Required prior PRs: none.
- Safe to review independently: yes.

## Research result guidance

- Evidence tier: NA — runtime correctness fix, not research evidence.
- Result classification: NA — restores an existing Gymnasium contract only.
- Domain-aware approval: not required; no evidence classification, comparison methodology, or paper-facing surface changed.
- Next empirical action: NA.

## Risks / rollout

- Compatibility risk: internal temporary-buffer ownership only; the public API and returned array shapes are unchanged.
- Failure mode addressed: parallel scans can no longer overwrite each other's transient angle values.
- Rollback: restore the settings-owned buffer if a measured allocation regression requires a different concurrency-safe cache design.

## Provenance and artifacts

- Root cause: the performance ranges-only path introduced by #2371 reused one mutable buffer through a configuration object shared by parallel multi-robot observation workers.
- Generated `output/coverage/` and `output/validation/` files are ignored local validation artifacts and are not committed.

## Downstream propagation

- No issue status comment was added because this task authorizes no issue/PR comments; `Closes #5184` provides the durable merge-time state transition.
- Claim map / benchmark report / leaderboard / artifact catalog / registry / context index: not applicable; this PR creates no research artifact or evidence claim.
- Friction follow-up: #5188 records the broken required `gh issue view --comments` path and its REST workaround.

## Reviewer notes

- Verify that the work buffer is obtained from `_LIDAR_RANGES_ONLY_CONTEXT`, while `lidar_ray_scan` continues to allocate and return independent angles.
- Assumption: calls on one worker thread are not recursively nested; existing scan paths are non-reentrant.
</details>
