### PR TITLE
refactor(data): migrate external errors to RobotSfError (#4993)

### DIFF
--- a/robot_sf/data/external/atc.py
+++ b/robot_sf/data/external/atc.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from robot_sf.errors import RobotSfError
 from scripts.tools.manage_external_data import (
     EXTERNAL_DATA_ROOT_ENV,
     check_asset,
@@ -54,7 +55,7 @@ _ATC_COLUMNS = len(ATC_COLUMN_NAMES)
 _DEFAULT_MAX_SCAN_ROWS = 10_000
 
 
-class AtcDataError(RuntimeError):
+class AtcDataError(RobotSfError, RuntimeError):
     """Raised when staged ATC data is present but structurally invalid."""
 
 

--- a/robot_sf/data/external/eth_ucy.py
+++ b/robot_sf/data/external/eth_ucy.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from robot_sf.errors import RobotSfError
 from scripts.tools.manage_external_data import (
     EXTERNAL_DATA_ROOT_ENV,
     resolve_asset_local_path_by_id,
@@ -36,7 +37,7 @@ ACQUISITION_DOC = "docs/datasets/eth-ucy.md"
 _MIN_NUMERIC_COLUMNS = 4
 
 
-class EthUcyDataError(RuntimeError):
+class EthUcyDataError(RobotSfError, RuntimeError):
     """Raised when staged ETH/UCY data is present but structurally invalid."""
 
 

--- a/robot_sf/data/external/ind.py
+++ b/robot_sf/data/external/ind.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from robot_sf.errors import RobotSfError
 from scripts.tools.manage_external_data import (
     EXTERNAL_DATA_ROOT_ENV,
     resolve_asset_local_path_by_id,
@@ -56,7 +57,7 @@ _RECORDING_META_REQUIRED_COLUMNS = ("recordingId", "frameRate")
 _TRACKS_FINITE_COLUMNS = ("frame", "xCenter", "yCenter")
 
 
-class IndDataError(RuntimeError):
+class IndDataError(RobotSfError, RuntimeError):
     """Raised when staged inD data is present but structurally invalid."""
 
 

--- a/robot_sf/data/external/recording_shape_contract.py
+++ b/robot_sf/data/external/recording_shape_contract.py
@@ -27,6 +27,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any
 
+from robot_sf.errors import RobotSfError
 from scripts.tools.manage_external_data import (
     EXTERNAL_DATA_ROOT_ENV,
     check_asset,
@@ -56,7 +57,7 @@ __all__ = [
 ]
 
 
-class RecordingDatasetError(RuntimeError):
+class RecordingDatasetError(RobotSfError, RuntimeError):
     """Raised when a staged recording-style dataset is present but invalid.
 
     Per-dataset modules subclass this so their tests and callers can match a

--- a/robot_sf/data/external/socnavbench_eth.py
+++ b/robot_sf/data/external/socnavbench_eth.py
@@ -22,6 +22,7 @@ from robot_sf.common.safe_pickle import (
     UnsafePickleError,
     restricted_pickle_load,
 )
+from robot_sf.errors import RobotSfError
 from scripts.tools.manage_external_data import (
     EXTERNAL_DATA_ROOT_ENV,
     check_asset,
@@ -35,7 +36,7 @@ ETH_TRAVERSIBLE_RELATIVE_PATH = _S3DIS_BASE / "traversibles" / "ETH" / "data.pkl
 ACQUISITION_DOC = "docs/datasets/socnavbench-s3dis-eth.md"
 
 
-class SocNavBenchEthDataError(RuntimeError):
+class SocNavBenchEthDataError(RobotSfError, RuntimeError):
     """Raised when staged SocNavBench ETH data is absent or structurally invalid."""
 
 

--- a/tests/data/external/test_robot_sf_error_compatibility.py
+++ b/tests/data/external/test_robot_sf_error_compatibility.py
@@ -1,0 +1,38 @@
+"""Compatibility tests for external-dataset exceptions under ``RobotSfError``."""
+
+import pytest
+
+from robot_sf.data.external.atc import AtcDataError
+from robot_sf.data.external.crowdbot import CrowdBotDataError
+from robot_sf.data.external.eth_ucy import EthUcyDataError
+from robot_sf.data.external.ind import IndDataError
+from robot_sf.data.external.recording_shape_contract import RecordingDatasetError
+from robot_sf.data.external.scand import ScandDataError
+from robot_sf.data.external.socnavbench_eth import SocNavBenchEthDataError
+from robot_sf.errors import RobotSfError
+
+_EXTERNAL_DATA_ERROR_TYPES = (
+    AtcDataError,
+    CrowdBotDataError,
+    EthUcyDataError,
+    IndDataError,
+    RecordingDatasetError,
+    ScandDataError,
+    SocNavBenchEthDataError,
+)
+
+
+@pytest.mark.parametrize("error_type", _EXTERNAL_DATA_ERROR_TYPES)
+def test_external_data_errors_support_shared_and_builtin_catches(
+    error_type: type[Exception],
+) -> None:
+    """Each public error remains a RuntimeError while gaining the shared base."""
+
+    assert issubclass(error_type, RobotSfError)
+    assert issubclass(error_type, RuntimeError)
+
+    with pytest.raises(RobotSfError):
+        raise error_type("shared catch")
+
+    with pytest.raises(RuntimeError):
+        raise error_type("builtin catch")


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** migrated the seven public external-dataset loader exceptions onto `RobotSfError`, including the shared CrowdBot/SCAND recording hierarchy.
- **Why now:** the base and research-family migrations are merged; external-data loaders are the next cohesive remaining family and provide a typed catch target without touching #4880-owned `except` clauses.
- **Claim boundary:** exception hierarchy compatibility only. Loader behavior, validation rules, data schemas, benchmark metrics, and research claims are unchanged.
- **Required validation:** focused dual-catch tests, the external-data regression suite, Ruff, MyPy, and the final repository readiness gate.
- **Remaining blocker:** other ad-hoc exception families remain on #4993; `except`-clause narrowing remains on #4880.

## Contract delta

- **Schema fields:** none.
- **New fail-closed blockers:** none.
- **Compatibility impact:** `AtcDataError`, `EthUcyDataError`, `IndDataError`, `RecordingDatasetError`, `CrowdBotDataError`, `ScandDataError`, and `SocNavBenchEthDataError` are now catchable as `RobotSfError` while remaining catchable as `RuntimeError` and through their existing public import paths.
- **Behavior:** exception messages, raise sites, concrete classes, and current builtin-exception catches are unchanged.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4993

Refs #4993

Remaining work:

- [ ] Migrate other cohesive ad-hoc exception families under `robot_sf/` in bounded compatibility-preserving slices.
- [ ] Keep #4880-owned `except` narrowing separate.

## Scope and assumption

This progression slice adds the nameable capability **shared catching for external-dataset loader failures**. The reversible selection assumption is that the seven errors under `robot_sf.data.external` form one cohesive family because they expose the package's staged-dataset validation failures and all preserve the same `RuntimeError` contract. CrowdBot and SCAND inherit the shared base through `RecordingDatasetError`.

The fragmentation guard does not block this PR: #5073 and #5180 are progression migrations, not guardrail/checker/packet-refresh PRs, and this PR adds another distinct catchable family.

## Validation

- `.venv/bin/pytest tests/data/external/test_robot_sf_error_compatibility.py -q` — 7 passed. Before implementation, the same test failed for all 7 classes, proving the characterization detects the missing hierarchy.
- `.venv/bin/pytest tests/data/external tests/data/test_socnavbench_eth_safe_pickle.py tests/benchmark/test_pedestrian_realism_validation.py -q` — 86 passed, 6 skipped.
- `.venv/bin/ruff check robot_sf/data/external tests/data/external/test_robot_sf_error_compatibility.py` — passed.
- `.venv/bin/ruff format --check robot_sf/data/external tests/data/external/test_robot_sf_error_compatibility.py` — passed.
- `.venv/bin/mypy robot_sf/data/external` — passed, 9 source files.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on the interim implementation tree; 2,183 passed, 1 skipped.
- `MIN_COVERAGE=0 GOAL_COVERAGE=0 PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue-4993-pr-body.md scripts/dev/pr_ready_check.sh` — passed on committed `HEAD`. The changed-line threshold override is limited to declaration-only import/class lines that execute during test collection; direct dual-catch tests, the external-data regression suite, full core tests, Ruff, and MyPy remain required. #5191 tracks coverage support for this case.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no #4880-owned `except`-clause narrowing, and no unrelated exception families.

<details>
<summary>Review, provenance, and propagation appendix</summary>

## Research boundary

- Evidence tier/result classification: NA — runtime compatibility refactor, not research evidence.
- Fallback/degraded execution: NA; no benchmark execution occurred.
- Next empirical action: NA; compatibility is directly covered by CPU tests.

## Domain-Aware Approval

- Required for this PR: no - this runtime compatibility refactor does not change evidence classification, experimental comparisons, figure eligibility, benchmark interpretation, or paper-facing claims.
- Domains reviewed: NA.
- Status: not required.
- Approver/review source or waiver: repository support-code opt-out.
- Validity checklist:
  - Target claim/hypothesis: NA.
  - Comparator or split/evidence validity: NA.
  - Fallback/degraded exclusions: no benchmark execution occurred.
  - Claim boundary: exception inheritance compatibility only.
  - Implementation integrity vs experimental validity: focused and repository tests prove implementation integrity; no experimental-validity claim is made.

## Risks and rollback

- Compatibility risk is limited to Python method resolution order. Focused tests prove every migrated public class is both `RobotSfError` and `RuntimeError`, including the derived CrowdBot/SCAND classes.
- Public modules and names are unchanged; no central re-export was introduced or removed.
- Rollback is the five direct base-class declarations and imports; no data or schema migration is involved.

## Artifacts and downstream propagation

- `output/coverage/` and `output/validation/` are ignored, disposable local validation artifacts and are not committed.
- Parent issue propagation: no separate issue comment is added because this run explicitly does not authorize issue/PR comments. `Refs #4993`, the remaining-work checklist, and this PR body provide the durable handoff; the issue remains open.
- Claim map, benchmark report, leaderboard, artifact catalog, registry/config index, context index, and memory note: not applicable because this PR creates no research artifact, schema, or evidence claim.
- No transient host or queue-routing state is encoded in tracked files.

## Follow-up and friction

- Deferred implementation remains on #4993; no new implementation issue is needed.
- #5190 records the interim-readiness dirty-tree reporting friction encountered during this work.
- #5191 records the declaration-only changed-coverage limitation and unsafe-reload reproduction. Both are intentionally not fixed here.

## Reviewer notes

- Verify the multiple-inheritance order remains `(RobotSfError, RuntimeError)` for each direct base, preserving builtin catches.
- Verify CrowdBot and SCAND gain `RobotSfError` transitively through `RecordingDatasetError` and retain their existing public classes.
</details>
