### PR TITLE
fix(dev): expose interim dirty readiness scope (#5190)

### DIFF
--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -200,6 +200,29 @@ fi
 
 resolve_base_ref
 
+if [[ "$pr_ready_final" != "1" && "$(worktree_state)" != "clean" ]]; then
+  dirty_paths=()
+  while IFS= read -r dirty_path; do
+    [[ -z "$dirty_path" ]] && continue
+    dirty_paths+=("$dirty_path")
+  done < <(
+    {
+      git diff --name-only HEAD
+      git ls-files --others --exclude-standard
+    } | LC_ALL=C sort -u
+  )
+
+  printf 'Interim changed-file scope is committed HEAD vs %s.\n' "$BASE_REF" >&2
+  if [[ ${#dirty_paths[@]} -gt 0 ]]; then
+    printf 'Dirty paths excluded from diff-scoped gates:\n' >&2
+    max_dirty_paths=30
+    printf '%s\n' "${dirty_paths[@]:0:max_dirty_paths}" >&2
+    if (( ${#dirty_paths[@]} > max_dirty_paths )); then
+      printf '... truncated (%d more dirty paths)\n' "$(( ${#dirty_paths[@]} - max_dirty_paths ))" >&2
+    fi
+  fi
+fi
+
 changed_files=()
 core_changed_files=()
 optional_changed_files=()
@@ -214,7 +237,11 @@ while IFS= read -r changed_file; do
 done < <(git diff --name-only --diff-filter=ACMRT "$BASE_REF...HEAD")
 
 if [[ ${#changed_files[@]} -gt 0 ]]; then
-  printf 'Changed files vs %s:\n' "$BASE_REF" >&2
+  if [[ "$pr_ready_final" == "1" ]]; then
+    printf 'Changed files vs %s:\n' "$BASE_REF" >&2
+  else
+    printf 'Committed changed files vs %s:\n' "$BASE_REF" >&2
+  fi
   printf '%s\n' "${changed_files[@]}" >&2
 fi
 if [[ ${#core_changed_files[@]} -gt 0 ]]; then
@@ -251,7 +278,11 @@ if [[ ${#optional_changed_files[@]} -gt 0 ]]; then
   fi
   PYTEST_ADDOPTS="$optional_pytest_addopts" ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=optional "$SCRIPT_DIR/run_tests_parallel.sh" --lane optional
 else
-  printf 'No changed files require the optional-extra lane.\n' >&2
+  if [[ "$pr_ready_final" == "1" ]]; then
+    printf 'No changed files require the optional-extra lane.\n' >&2
+  else
+    printf 'No committed changed files require the optional-extra lane.\n' >&2
+  fi
 fi
 "$SCRIPT_DIR/check_changed_coverage.sh"
 "$SCRIPT_DIR/check_docstring_todos_diff.sh"
@@ -263,6 +294,7 @@ if [[ "$pr_ready_final" == "1" ]]; then
   freshness_args+=(--require-clean-tree)
 elif [[ "$(worktree_state)" != "clean" ]]; then
   printf 'Warning: recording interim PR readiness from a dirty non-ignored worktree.\n' >&2
+  printf 'Interim readiness is not changed-file proof for the dirty paths listed above.\n' >&2
   printf 'Use PR_READY_MODE=final BASE_REF=%q %q for final committed-HEAD PR proof.\n' "$BASE_REF" "$0" >&2
 fi
 uv run python "$SCRIPT_DIR/pr_ready_freshness.py" "${freshness_args[@]}"

--- a/tests/dev/test_pr_ready_preflight.py
+++ b/tests/dev/test_pr_ready_preflight.py
@@ -274,7 +274,40 @@ def test_pr_ready_check_keeps_core_only_changes_on_the_core_lane(preflight_repo:
     assert result.returncode == 0, result.stderr
     lane_lines = lane_log.read_text(encoding="utf-8").splitlines()
     assert lane_lines == ["core --lane core"]
-    assert "No changed files require the optional-extra lane." in result.stderr
+    assert "No committed changed files require the optional-extra lane." in result.stderr
+
+
+def test_interim_mode_reports_dirty_paths_excluded_from_changed_file_gates(
+    preflight_repo: Path,
+) -> None:
+    """Dirty paths are explicit when interim diff-scoped gates only inspect HEAD."""
+    lane_log = _write_lane_logging_stub(preflight_repo)
+    tracked_file = preflight_repo / "tests" / "unit" / "test_dirty_tracked.py"
+    tracked_file.parent.mkdir(parents=True, exist_ok=True)
+    tracked_file.write_text("print('baseline')\n", encoding="utf-8")
+    _git(preflight_repo, "add", "-A")
+    _git(preflight_repo, "commit", "-q", "-m", "tracked dirty fixture")
+    tracked_file.write_text("print('dirty tracked path')\n", encoding="utf-8")
+
+    dirty_file = preflight_repo / "tests" / "planner" / "test_dirty_optional.py"
+    dirty_file.parent.mkdir(parents=True, exist_ok=True)
+    dirty_file.write_text("print('dirty optional lane')\n", encoding="utf-8")
+
+    result = _run_pr_ready(
+        preflight_repo,
+        help_flag=False,
+        env_overrides={
+            "BASE_REF": "HEAD",
+            "PR_READY_MODE": "interim",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert lane_log.read_text(encoding="utf-8").splitlines() == ["core --lane core"]
+    assert "Interim changed-file scope is committed HEAD vs HEAD." in result.stderr
+    assert "Dirty paths excluded from diff-scoped gates:" in result.stderr
+    assert "tests/unit/test_dirty_tracked.py" in result.stderr
+    assert "tests/planner/test_dirty_optional.py" in result.stderr
 
 
 def test_core_lane_collection_hook_skips_optional_paths(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Interim `pr_ready_check.sh` now states that changed-file gates inspect committed `HEAD`, lists dirty tracked/untracked paths excluded from that scope (capped at 30), and labels committed-only optional-lane decisions. A regression test covers modified tracked and untracked optional-lane files.
- **Why now:** The previous successful interim summary could be read as coverage of dirty implementation files even when every diff-scoped gate saw an empty committed diff.
- **Claim boundary:** This is workflow transparency only. It does not make interim diff-scoped coverage, docstring, or optional-lane checks validate dirty files.
- **Required validation:** `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` on the clean committed head; focused readiness and script-contract tests also pass.
- **Remaining blocker:** None for this issue's explicit committed-HEAD disclosure alternative.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none; final mode remains the clean committed-HEAD proof path.
- Compatibility impact: interim output is more explicit and caps long dirty-path listings; commands and environment variables are unchanged.

## Linked issue and scope

Closes #5190

Scope: readiness-wrapper messaging and its contract tests only.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Validation, governance, and reviewer appendix</summary>

## Validation / Proof

- `uv run pytest tests/dev/test_pr_ready_preflight.py tests/test_ci_script_contract.py -q` — 88 passed.
- `uv run ruff format --check tests/dev/test_pr_ready_preflight.py` — passed.
- `uv run ruff check tests/dev/test_pr_ready_preflight.py` — passed.
- `bash -n scripts/dev/pr_ready_check.sh` and `git diff --check` — passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=interim BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — 2,184 passed, 1 skipped; diagnostic-only interim result recorded in `output/validation/issue-5190-interim-pr-ready.log` (not durable evidence).
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue-5190-pr-body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on the clean committed head: 2,184 passed, 1 skipped; fresh readiness stamp recorded.

## Research Result Guidance

- Target claim / hypothesis / blocker: NA — support workflow clarity only.
- Comparator or baseline: NA.
- Evidence tier: NA — no research, benchmark, metric, or paper-facing claim.
- Result classification: NA
- Decision or stop rule: final readiness must pass on the committed head.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #5190 closes on merge.
- New research/benchmark/metric/paper-facing analysis tool: NA — support helper behavior only.

## Domain-Aware Approval

- Required for this PR: no — no evidence classification or benchmark interpretation changes.
- Domains reviewed: NA.
- Status: not required.
- Approver/review source or waiver: support/tooling-only change.

## Falsification / Non-Transfer Check

NA — no research result or measured mechanism is claimed.

## Next Empirical Action

NA — the issue is fully resolved by the workflow-contract change; no campaign is needed.

## Risks / Rollout

- Compatibility risks: low; only stderr wording changes in interim mode.
- Failure modes: dirty paths beyond 30 are summarized by count rather than printed individually.
- Rollback: revert the wrapper and regression test together.

## Docs / Provenance

- Updated docs: none; the executable wrapper is the canonical contract.
- Relevant design or provenance notes: issue #5190.
- Preserved assumption: final mode is the sole clean committed-HEAD PR proof path.

## Downstream Propagation

- Parent issue updated: NA — `Closes #5190` is the canonical state transition on merge.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: NA.
- Not applicable because: support/tooling-only change with no durable research artifact or downstream evidence surface.

## Follow-Up Issues

- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes

- Verify that the new warning appears before diff-scoped gates and that final mode retains its existing output and fail-closed clean-tree requirement.
- Known limitation: interim mode intentionally still excludes dirty paths from diff-scoped checks; it now says so explicitly.
- Shared-helper migration: not applicable; no shared helper was added or migrated.
- Friction note: no issue filed; the broken `gh issue view --comments` fallback is already tracked by #5186 and #5188.

</details>
