### PR TITLE
fix(coverage): accept declaration-only proofs (#5191)

### DIFF
--- a/scripts/coverage/check_changed_files_coverage.py
+++ b/scripts/coverage/check_changed_files_coverage.py
@@ -207,7 +207,8 @@ def _added_leading_bases(before: ast.ClassDef, after: ast.ClassDef) -> list[str]
         return None
     if (
         before.name != after.name
-        or _ast_dumps(before.type_params) != _ast_dumps(after.type_params)
+        or _ast_dumps(getattr(before, "type_params", []))
+        != _ast_dumps(getattr(after, "type_params", []))
         or _ast_dumps(before.keywords) != _ast_dumps(after.keywords)
         or _ast_dumps(before.decorator_list) != _ast_dumps(after.decorator_list)
         or _ast_dumps(before.body) != _ast_dumps(after.body)
@@ -400,7 +401,32 @@ def _proofs_from_statements(
     return proofs
 
 
-def _declaration_proofs_from_test_source(source: str) -> set[tuple[str, str]]:
+def _source_module_name(path: Path) -> str | None:
+    """Return the importable module name for a repository-relative Python path."""
+    if path.suffix != ".py" or not path.parts:
+        return None
+    parts = list(path.with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts) or None
+
+
+def _direct_imports_from_module(tree: ast.Module, module_name: str) -> set[str]:
+    """Return unaliased names directly imported from one absolute module."""
+    return {
+        alias.name
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module == module_name
+        for alias in node.names
+        if alias.asname is None
+    }
+
+
+def _declaration_proofs_from_test_source(
+    source: str,
+    *,
+    source_module: str | None = None,
+) -> set[tuple[str, str]]:
     """Collect direct declaration proofs from one test module source."""
     try:
         tree = ast.parse(source)
@@ -427,15 +453,22 @@ def _declaration_proofs_from_test_source(source: str) -> set[tuple[str, str]]:
             "test_"
         ):
             proofs.update(_proofs_from_statements(node.body, parameter_values.get(id(node), {})))
-    return proofs
+    if source_module is None:
+        return proofs
+    source_imports = _direct_imports_from_module(tree, source_module)
+    return {(candidate, base) for candidate, base in proofs if candidate in source_imports}
 
 
 def _changed_tests_prove_declaration_requirements(
     requirements: set[tuple[str, str]],
     changed_files: Iterable[Path],
     repo_root: Path,
+    source_path: Path,
 ) -> bool:
-    """Return whether the PR's changed tests jointly prove a class-base migration."""
+    """Return whether changed tests prove a migration from its source module."""
+    source_module = _source_module_name(source_path)
+    if source_module is None:
+        return False
     proofs: set[tuple[str, str]] = set()
     for path in changed_files:
         if path.suffix != ".py" or not path.parts or path.parts[0] != "tests":
@@ -444,7 +477,7 @@ def _changed_tests_prove_declaration_requirements(
             source = (repo_root / path).read_text(encoding="utf-8")
         except OSError:
             continue
-        proofs.update(_declaration_proofs_from_test_source(source))
+        proofs.update(_declaration_proofs_from_test_source(source, source_module=source_module))
     return requirements <= proofs
 
 
@@ -467,6 +500,7 @@ def _has_declaration_only_test_proof(
         requirements,
         changed_files,
         repo_root,
+        path,
     )
 
 

--- a/scripts/coverage/check_changed_files_coverage.py
+++ b/scripts/coverage/check_changed_files_coverage.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict, cast
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Sequence
 
 
 class _CoverageFileData(TypedDict, total=False):
@@ -182,6 +182,292 @@ def _is_doc_or_comment_only_changed_file(path: Path, base: str, repo_root: Path)
     except OSError:
         return False
     return _is_doc_or_comment_only_python_change(before, after)
+
+
+def _expression_terminal_name(node: ast.expr) -> str | None:
+    """Return the local or attribute name represented by a simple expression."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _ast_dumps(nodes: Sequence[ast.AST]) -> list[str]:
+    """Return attribute-free AST dumps for a node list."""
+    return [ast.dump(node, include_attributes=False) for node in nodes]
+
+
+def _added_leading_bases(before: ast.ClassDef, after: ast.ClassDef) -> list[str] | None:
+    """Return newly prepended class bases when every other class detail is unchanged."""
+    before_bases = [ast.dump(base, include_attributes=False) for base in before.bases]
+    after_bases = [ast.dump(base, include_attributes=False) for base in after.bases]
+    existing_bases_match = not before_bases or after_bases[-len(before_bases) :] == before_bases
+    if len(after_bases) <= len(before_bases) or not existing_bases_match:
+        return None
+    if (
+        before.name != after.name
+        or _ast_dumps(before.type_params) != _ast_dumps(after.type_params)
+        or _ast_dumps(before.keywords) != _ast_dumps(after.keywords)
+        or _ast_dumps(before.decorator_list) != _ast_dumps(after.decorator_list)
+        or _ast_dumps(before.body) != _ast_dumps(after.body)
+    ):
+        return None
+    return [
+        name
+        for base in after.bases[: len(after_bases) - len(before_bases)]
+        if (name := _expression_terminal_name(base)) is not None
+    ]
+
+
+def _import_bindings(node: ast.stmt) -> set[str]:
+    """Return bindings introduced by one import statement."""
+    if isinstance(node, ast.Import):
+        return {alias.asname or alias.name.partition(".")[0] for alias in node.names}
+    if isinstance(node, ast.ImportFrom):
+        return {alias.asname or alias.name for alias in node.names}
+    return set()
+
+
+def _module_imports(tree: ast.Module) -> list[ast.stmt]:
+    """Return top-level import statements from a module."""
+    return [node for node in tree.body if isinstance(node, (ast.Import, ast.ImportFrom))]
+
+
+def _imports_only_add_required_bases(
+    before_imports: list[ast.stmt],
+    after_imports: list[ast.stmt],
+    required_bases: set[str],
+) -> bool:
+    """Return whether imports only add bindings for the new class bases."""
+    before_dumps = {ast.dump(node, include_attributes=False) for node in before_imports}
+    after_dumps = {ast.dump(node, include_attributes=False) for node in after_imports}
+    if not before_dumps <= after_dumps:
+        return False
+    added_bindings = set().union(
+        *(
+            _import_bindings(node)
+            for node in after_imports
+            if ast.dump(node, include_attributes=False) not in before_dumps
+        )
+    )
+    return added_bindings <= required_bases
+
+
+def _class_base_requirements(
+    before_nodes: list[ast.stmt],
+    after_nodes: list[ast.stmt],
+) -> set[tuple[str, str]] | None:
+    """Return new class-base proof requirements when all other nodes are unchanged."""
+    if len(before_nodes) != len(after_nodes):
+        return None
+    requirements: set[tuple[str, str]] = set()
+    for before_node, after_node in zip(before_nodes, after_nodes, strict=True):
+        if isinstance(before_node, ast.ClassDef) and isinstance(after_node, ast.ClassDef):
+            added_bases = _added_leading_bases(before_node, after_node)
+            if added_bases is not None:
+                requirements.update((before_node.name, base) for base in added_bases)
+                continue
+        if ast.dump(before_node, include_attributes=False) != ast.dump(
+            after_node,
+            include_attributes=False,
+        ):
+            return None
+    return requirements or None
+
+
+def _declaration_only_class_base_requirements(
+    before: str,
+    after: str,
+) -> set[tuple[str, str]] | None:
+    """Return direct-test requirements for a pure class-base migration.
+
+    The exemption deliberately accepts only imports required for newly prepended
+    bases and otherwise byte-for-byte equivalent AST statements.  It therefore
+    cannot cover a changed class body, function, decorator, or existing base.
+    """
+    try:
+        before_tree = ast.parse(before)
+        after_tree = ast.parse(after)
+    except SyntaxError:
+        return None
+
+    before_imports = _module_imports(before_tree)
+    after_imports = _module_imports(after_tree)
+    requirements = _class_base_requirements(
+        [node for node in before_tree.body if node not in before_imports],
+        [node for node in after_tree.body if node not in after_imports],
+    )
+    if requirements is None:
+        return None
+    required_bases = {base for _, base in requirements}
+    if not _imports_only_add_required_bases(before_imports, after_imports, required_bases):
+        return None
+    return requirements
+
+
+def _names_in_static_collection(node: ast.expr) -> set[str]:
+    """Return simple names from a tuple, list, or set literal."""
+    if not isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        return set()
+    return {
+        name for element in node.elts if (name := _expression_terminal_name(element)) is not None
+    }
+
+
+def _parametrize_values(
+    tree: ast.Module, bindings: dict[str, set[str]]
+) -> dict[int, dict[str, set[str]]]:
+    """Resolve simple pytest parametrization collections by function node id."""
+    values: dict[int, dict[str, set[str]]] = {}
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            if not (
+                isinstance(decorator, ast.Call)
+                and isinstance(decorator.func, ast.Attribute)
+                and decorator.func.attr == "parametrize"
+                and len(decorator.args) >= 2
+                and isinstance(decorator.args[0], ast.Constant)
+                and isinstance(decorator.args[0].value, str)
+            ):
+                continue
+            parameter_name = decorator.args[0].value
+            if "," in parameter_name:
+                continue
+            collection = decorator.args[1]
+            candidates = (
+                bindings.get(collection.id, set())
+                if isinstance(collection, ast.Name)
+                else _names_in_static_collection(collection)
+            )
+            if candidates:
+                values.setdefault(id(node), {})[parameter_name] = candidates
+    return values
+
+
+def _candidate_names(node: ast.expr, parameters: dict[str, set[str]]) -> set[str]:
+    """Resolve a directly named class or a simple parametrized class name."""
+    name = _expression_terminal_name(node)
+    if name is None:
+        return set()
+    return parameters.get(name, {name})
+
+
+def _proofs_from_statements(
+    statements: list[ast.stmt],
+    parameters: dict[str, set[str]],
+) -> set[tuple[str, str]]:
+    """Collect direct ``issubclass`` and ``pytest.raises`` relationship proofs."""
+    proofs: set[tuple[str, str]] = set()
+    for node in ast.walk(ast.Module(body=statements, type_ignores=[])):
+        if isinstance(node, ast.Assert) and isinstance(node.test, ast.Call):
+            call = node.test
+            if (
+                isinstance(call.func, ast.Name)
+                and call.func.id == "issubclass"
+                and len(call.args) == 2
+            ):
+                base = _expression_terminal_name(call.args[1])
+                if base is not None:
+                    proofs.update(
+                        (candidate, base)
+                        for candidate in _candidate_names(call.args[0], parameters)
+                    )
+        if not isinstance(node, ast.With):
+            continue
+        raised_bases = {
+            _expression_terminal_name(item.context_expr.args[0])
+            for item in node.items
+            if isinstance(item.context_expr, ast.Call)
+            and isinstance(item.context_expr.func, ast.Attribute)
+            and isinstance(item.context_expr.func.value, ast.Name)
+            and item.context_expr.func.value.id == "pytest"
+            and item.context_expr.func.attr == "raises"
+            and item.context_expr.args
+        }
+        for raised_base in raised_bases:
+            if raised_base is None:
+                continue
+            for child in ast.walk(ast.Module(body=node.body, type_ignores=[])):
+                if isinstance(child, ast.Raise) and child.exc is not None:
+                    raised = child.exc.func if isinstance(child.exc, ast.Call) else child.exc
+                    proofs.update(
+                        (candidate, raised_base)
+                        for candidate in _candidate_names(raised, parameters)
+                    )
+    return proofs
+
+
+def _declaration_proofs_from_test_source(source: str) -> set[tuple[str, str]]:
+    """Collect direct declaration proofs from one test module source."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return set()
+    bindings: dict[str, set[str]] = {}
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            bindings[node.targets[0].id] = _names_in_static_collection(node.value)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.value is not None
+        ):
+            bindings[node.target.id] = _names_in_static_collection(node.value)
+    parameter_values = _parametrize_values(tree, bindings)
+    proofs: set[tuple[str, str]] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith(
+            "test_"
+        ):
+            proofs.update(_proofs_from_statements(node.body, parameter_values.get(id(node), {})))
+    return proofs
+
+
+def _changed_tests_prove_declaration_requirements(
+    requirements: set[tuple[str, str]],
+    changed_files: Iterable[Path],
+    repo_root: Path,
+) -> bool:
+    """Return whether the PR's changed tests jointly prove a class-base migration."""
+    proofs: set[tuple[str, str]] = set()
+    for path in changed_files:
+        if path.suffix != ".py" or not path.parts or path.parts[0] != "tests":
+            continue
+        try:
+            source = (repo_root / path).read_text(encoding="utf-8")
+        except OSError:
+            continue
+        proofs.update(_declaration_proofs_from_test_source(source))
+    return requirements <= proofs
+
+
+def _has_declaration_only_test_proof(
+    path: Path,
+    base: str,
+    repo_root: Path,
+    changed_files: Iterable[Path],
+) -> bool:
+    """Return whether a changed source file has bounded, changed-test proof."""
+    before = _file_at_ref(base, path, repo_root)
+    if before is None:
+        return False
+    try:
+        after = (repo_root / path).read_text(encoding="utf-8")
+    except OSError:
+        return False
+    requirements = _declaration_only_class_base_requirements(before, after)
+    return requirements is not None and _changed_tests_prove_declaration_requirements(
+        requirements,
+        changed_files,
+        repo_root,
+    )
 
 
 def _normalize_path(path: Path, repo_root: Path) -> str:
@@ -422,6 +708,7 @@ def _build_results(
     *,
     base: str,
     repo_root: Path,
+    changed_files: Iterable[Path],
 ) -> list[_CoverageResult]:
     """Attach coverage data to selected changed files.
 
@@ -442,6 +729,14 @@ def _build_results(
             if changed_coverage is not None:
                 coverage = changed_coverage
                 scope = changed_scope
+                if _has_declaration_only_test_proof(
+                    Path(path_str),
+                    base,
+                    repo_root,
+                    changed_files,
+                ):
+                    coverage = 100.0
+                    scope = "declaration-only proof"
         results.append(
             {
                 "file": path_str,
@@ -608,6 +903,7 @@ def _run_check(args: argparse.Namespace) -> int:
         coverage_file_data,
         base=args.base,
         repo_root=repo_root,
+        changed_files=changed_files,
     )
 
     _log_header(args)

--- a/scripts/coverage/check_changed_files_coverage.py
+++ b/scripts/coverage/check_changed_files_coverage.py
@@ -214,11 +214,13 @@ def _added_leading_bases(before: ast.ClassDef, after: ast.ClassDef) -> list[str]
         or _ast_dumps(before.body) != _ast_dumps(after.body)
     ):
         return None
-    return [
-        name
+    added_names = [
+        _expression_terminal_name(base)
         for base in after.bases[: len(after_bases) - len(before_bases)]
-        if (name := _expression_terminal_name(base)) is not None
     ]
+    if any(name is None for name in added_names):
+        return None
+    return [name for name in added_names if name is not None]
 
 
 def _import_bindings(node: ast.stmt) -> set[str]:

--- a/tests/coverage/test_check_changed_files_coverage.py
+++ b/tests/coverage/test_check_changed_files_coverage.py
@@ -139,6 +139,18 @@ def retry_count() -> int:
     assert _declaration_only_class_base_requirements(before, after) is None
 
 
+def test_declaration_only_base_change_rejects_an_unrepresentable_added_base() -> None:
+    """An added base without a direct proof name must fail closed."""
+    before = "class DatasetError(RuntimeError):\n    pass\n"
+    after = """from errors import RobotSfError
+
+class DatasetError(RobotSfError, marker(), RuntimeError):
+    pass
+"""
+
+    assert _declaration_only_class_base_requirements(before, after) is None
+
+
 def test_changed_test_proof_enables_declaration_only_coverage(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/coverage/test_check_changed_files_coverage.py
+++ b/tests/coverage/test_check_changed_files_coverage.py
@@ -10,6 +10,9 @@ import pytest
 from scripts.coverage.check_changed_files_coverage import (
     _changed_line_numbers,
     _coverage_for_changed_lines,
+    _declaration_only_class_base_requirements,
+    _declaration_proofs_from_test_source,
+    _has_declaration_only_test_proof,
     _is_doc_or_comment_only_python_change,
 )
 
@@ -60,6 +63,111 @@ def test_changed_line_coverage_treats_non_executable_edits_as_covered() -> None:
 
     assert coverage == 100.0
     assert scope == "changed executable lines 0/0"
+
+
+def test_declaration_only_base_change_accepts_parametrized_issubclass_proof() -> None:
+    """A changed test can prove a safe class-base migration without a module reload."""
+    before = '''from legacy import RuntimeErrorBase
+
+class DatasetError(RuntimeErrorBase):
+    """Dataset failure."""
+'''
+    after = '''from errors import RobotSfError
+from legacy import RuntimeErrorBase
+
+class DatasetError(RobotSfError, RuntimeErrorBase):
+    """Dataset failure."""
+'''
+    proof_test = """import pytest
+
+_ERRORS = (DatasetError,)
+
+@pytest.mark.parametrize("error_type", _ERRORS)
+def test_compatibility(error_type):
+    assert issubclass(error_type, RobotSfError)
+"""
+
+    requirements = _declaration_only_class_base_requirements(before, after)
+
+    assert requirements == {("DatasetError", "RobotSfError")}
+    assert requirements <= _declaration_proofs_from_test_source(proof_test)
+
+
+def test_declaration_only_base_change_accepts_direct_dual_catch_proof() -> None:
+    """A direct shared-base catch is an alternative compatibility proof."""
+    proof_test = """import pytest
+
+def test_compatibility():
+    with pytest.raises(RobotSfError):
+        raise DatasetError("shared catch")
+"""
+
+    assert ("DatasetError", "RobotSfError") in _declaration_proofs_from_test_source(proof_test)
+
+
+def test_declaration_only_base_change_rejects_a_class_body_change() -> None:
+    """The exemption cannot hide changes to behavior inside the class body."""
+    before = '''class DatasetError(RuntimeError):
+    """Dataset failure."""
+'''
+    after = '''from errors import RobotSfError
+
+class DatasetError(RobotSfError, RuntimeError):
+    """Changed behavior."""
+'''
+
+    assert _declaration_only_class_base_requirements(before, after) is None
+
+
+def test_declaration_only_base_change_rejects_runtime_body_changes() -> None:
+    """The exemption cannot hide a changed function beside the class declaration."""
+    before = '''class DatasetError(RuntimeError):
+    """Dataset failure."""
+
+def retry_count() -> int:
+    return 1
+'''
+    after = '''from errors import RobotSfError
+
+class DatasetError(RobotSfError, RuntimeError):
+    """Dataset failure."""
+
+def retry_count() -> int:
+    return 2
+'''
+
+    assert _declaration_only_class_base_requirements(before, after) is None
+
+
+def test_changed_test_proof_enables_declaration_only_coverage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The coverage path requires a changed test, not just a matching source diff."""
+    source_path = tmp_path / "robot_sf" / "errors.py"
+    source_path.parent.mkdir()
+    source_path.write_text(
+        "from errors import RobotSfError\n\nclass DatasetError(RobotSfError, RuntimeError):\n    pass\n",
+        encoding="utf-8",
+    )
+    test_path = tmp_path / "tests" / "test_errors.py"
+    test_path.parent.mkdir()
+    test_path.write_text(
+        "def test_compatibility():\n    assert issubclass(DatasetError, RobotSfError)\n",
+        encoding="utf-8",
+    )
+    before = "class DatasetError(RuntimeError):\n    pass\n"
+    monkeypatch.setattr(
+        "scripts.coverage.check_changed_files_coverage._file_at_ref",
+        lambda *args: before,
+    )
+
+    assert _has_declaration_only_test_proof(
+        Path("robot_sf/errors.py"),
+        "origin/main",
+        tmp_path,
+        [Path("robot_sf/errors.py"), Path("tests/test_errors.py")],
+    )
 
 
 def test_changed_line_parser_ignores_no_newline_marker(

--- a/tests/coverage/test_check_changed_files_coverage.py
+++ b/tests/coverage/test_check_changed_files_coverage.py
@@ -153,6 +153,7 @@ def test_changed_test_proof_enables_declaration_only_coverage(
     test_path = tmp_path / "tests" / "test_errors.py"
     test_path.parent.mkdir()
     test_path.write_text(
+        "from robot_sf.errors import DatasetError\n\n"
         "def test_compatibility():\n    assert issubclass(DatasetError, RobotSfError)\n",
         encoding="utf-8",
     )
@@ -163,6 +164,37 @@ def test_changed_test_proof_enables_declaration_only_coverage(
     )
 
     assert _has_declaration_only_test_proof(
+        Path("robot_sf/errors.py"),
+        "origin/main",
+        tmp_path,
+        [Path("robot_sf/errors.py"), Path("tests/test_errors.py")],
+    )
+
+
+def test_changed_test_proof_rejects_an_unrelated_same_named_class(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A proof must import the declaration from the changed source module."""
+    source_path = tmp_path / "robot_sf" / "errors.py"
+    source_path.parent.mkdir()
+    source_path.write_text(
+        "from errors import RobotSfError\n\nclass DatasetError(RobotSfError, RuntimeError):\n    pass\n",
+        encoding="utf-8",
+    )
+    test_path = tmp_path / "tests" / "test_errors.py"
+    test_path.parent.mkdir()
+    test_path.write_text(
+        "class DatasetError(RobotSfError):\n    pass\n\n"
+        "def test_compatibility():\n    assert issubclass(DatasetError, RobotSfError)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "scripts.coverage.check_changed_files_coverage._file_at_ref",
+        lambda *args: "class DatasetError(RuntimeError):\n    pass\n",
+    )
+
+    assert not _has_declaration_only_test_proof(
         Path("robot_sf/errors.py"),
         "origin/main",
         tmp_path,


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Changed-file coverage can now credit a declaration-only class-base migration when the same PR adds a direct, runnable `issubclass` or `pytest.raises` proof.
- **Why now:** Test-module imports occur during collection outside the worker coverage context, so safe compatibility declarations otherwise appear uncovered.
- **Claim boundary:** This is validation-tooling behavior only; it makes no benchmark, metric, model, paper, or performance claim.
- **Required validation:** Review the AST guardrails and focused tests; core readiness passes after current-`main` integration. The final gate's repository-wide parser check is blocked by #5202.
- **Remaining blocker:** current-`main` broad-exception validation cannot parse an unrelated Python 3.11-invalid f-string in `scripts/reporting/generate_result_card.py:344`; tracked by #5202. This PR's focused and core readiness tests pass, but full readiness remains blocked until #5202 lands.

## Contract delta

- New accepted proof category: an existing class may gain one or more leading base classes, plus only the imports for those bases, when changed tests directly import the changed declaration and prove every new class/base relationship.
- New fail-closed blockers: class bodies, decorators, existing bases, adjacent runtime statements, unrelated imports, unproved relationships, and unparseable sources continue through normal changed-line coverage.
- Compatibility impact: declaration-only changes with a qualifying changed test report `declaration-only proof` at 100%; all other coverage behavior is unchanged.

## Linked issue and scope

Closes #5191

Issue: https://github.com/ll7/robot_sf_ll7/issues/5191

Scope: changed-file coverage classification and its focused tests only.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Validation / proof

- `uv run ruff check scripts/coverage/check_changed_files_coverage.py tests/coverage/test_check_changed_files_coverage.py` — passed.
- `uv run pytest tests/coverage/test_check_changed_files_coverage.py -q` — passed (10 tests) on Python 3.11 and 3.13.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr-5196-body.md scripts/dev/pr_ready_check.sh` — core lane passed (2,184 passed, 1 skipped); final post-check is blocked by the unrelated current-`main` parser failure tracked in #5202.
- Compatibility-shape probe against commit `7b81db5b9` — passed; accepts all five #4993 declaration migrations and their parametrized direct proofs.
- An earlier interim dirty-tree readiness run passed (2,183 passed, 1 skipped); it is superseded by the final clean-head result above.

## Risks / rollout

- The AST proof recognizer intentionally supports only direct names, simple static collections, single-parameter `pytest.mark.parametrize`, `issubclass`, and `pytest.raises`. More dynamic tests fail closed into ordinary coverage.
- No tracked artifacts were generated; `output/` coverage and readiness files are ignored, disposable validation outputs.

<details>
<summary>Governance appendix</summary>

## Downstream Propagation

- Parent issue updated: no separate state update needed because this PR closes #5191 on merge.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: NA; the checker typing work landed in #5199.
- Not applicable because: no evidence-producing artifact or long-lived state changed.

## Follow-Up Issues

- Deferred work: #5202 repairs the unrelated current-`main` parser failure that blocks the repository-wide final post-check.
- Issues opened for follow-up: #5202 (baseline tracking; does not change #5191 scope)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage checks for class inheritance migrations that preserve equivalent behavior.
  * Coverage may now be recognized as complete when changed tests directly prove the required inheritance and exception relationships.
  * Added safeguards to prevent exemptions when class internals or unrelated runtime behavior also change.

* **Tests**
  * Expanded validation for parameterized inheritance checks, exception handling, and unrelated or insufficient test evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->