### PR TITLE
fix(validation): ignore SHA256SUMS comment markers in SLURM claim checklist (#5197)

### DIFF
--- a/scripts/tools/slurm_to_claim_trace_checklist.py
+++ b/scripts/tools/slurm_to_claim_trace_checklist.py
@@ -139,7 +139,7 @@ def _parse_sha256s(path: Path) -> dict[str, str]:
     entries: dict[str, str] = {}
     for line in path.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
-        if not stripped:
+        if not stripped or stripped.startswith("#"):
             continue
         digest, _, relpath = stripped.partition("  ")
         if not relpath:

--- a/tests/tools/test_slurm_to_claim_trace_checklist.py
+++ b/tests/tools/test_slurm_to_claim_trace_checklist.py
@@ -122,6 +122,69 @@ def test_complete_trace_checklist_passes(tmp_path: Path) -> None:
     assert report["retrieval"]["run"]["job_id"] == "13268"
 
 
+def test_sha256sums_comment_markers_are_ignored(tmp_path: Path) -> None:
+    """SHA256SUMS with # comment header does not produce a synthetic missing-artifact blocker.
+
+    Regression for issue #5197: PR #5187 adds '# AI-GENERATED NEEDS-REVIEW' headers
+    to SHA256SUMS files; the parser must skip them rather than treating them as entries.
+    """
+
+    evidence_dir = tmp_path / "docs/context/evidence/issue_3425_trace"
+    readme = evidence_dir / "README.md"
+    readme.parent.mkdir(parents=True, exist_ok=True)
+    readme.write_text("# Trace\n", encoding="utf-8")
+    relpath = readme.relative_to(tmp_path).as_posix()
+    digest = _sha256(readme)
+    # Write SHA256SUMS with a leading comment line (as added by PR #5187)
+    (evidence_dir / "SHA256SUMS").write_text(
+        f"# AI-GENERATED NEEDS-REVIEW\n{digest}  {relpath}\n",
+        encoding="utf-8",
+    )
+
+    entries = slurm_to_claim_trace_checklist._parse_sha256s(evidence_dir / "SHA256SUMS")
+
+    assert "AI-GENERATED NEEDS-REVIEW" not in entries
+    assert relpath in entries
+    assert entries[relpath] == digest
+
+
+def test_sha256sums_comment_markers_do_not_block_checklist(tmp_path: Path) -> None:
+    """Evidence dir whose SHA256SUMS has a comment header passes checksum verification."""
+
+    evidence_dir = tmp_path / "docs/context/evidence/issue_3425_trace"
+    readme = evidence_dir / "README.md"
+    readme.parent.mkdir(parents=True, exist_ok=True)
+    readme.write_text("# Trace\n", encoding="utf-8")
+    relpath = readme.relative_to(tmp_path).as_posix()
+    digest = _sha256(readme)
+    (evidence_dir / "SHA256SUMS").write_text(
+        f"# AI-GENERATED NEEDS-REVIEW\n{digest}  {relpath}\n",
+        encoding="utf-8",
+    )
+    source_manifest = _write_source_manifest(tmp_path)
+
+    report = slurm_to_claim_trace_checklist.build_checklist(
+        job_id="13268",
+        issue=3425,
+        source_manifest=source_manifest,
+        evidence_dir=evidence_dir,
+        finalizer_manifest=None,
+        reconciliation=None,
+        spine_pointer="docs/context/evidence/issue_3425_trace/README.md",
+        claim_boundary="workflow trace only; no benchmark claim",
+        repo_root=tmp_path,
+        generated_at="2026-07-11T00:00:00+00:00",
+    )
+
+    # The comment should not appear as a synthetic missing-artifact blocker
+    blocker_details = " ".join(b["detail"] for b in report["blockers"])
+    assert "AI-GENERATED" not in blocker_details
+    assert "NEEDS-REVIEW" not in blocker_details
+    # Evidence checksums should pass (comment line is skipped, real entry verified)
+    check_statuses = {c["name"]: c["status"] for c in report["checks"]}
+    assert check_statuses.get("evidence_checksums") == "pass"
+
+
 def test_missing_finalizer_and_reconciliation_block_without_losing_retrieval(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** `_parse_sha256s` in `scripts/tools/slurm_to_claim_trace_checklist.py` now skips lines starting with `#` in addition to blank lines.
- **Why now:** PR #5187 added `# AI-GENERATED NEEDS-REVIEW` headers to SHA256SUMS files. The old parser treated this comment line as a checksum entry with path `AI-GENERATED NEEDS-REVIEW`, producing a synthetic "missing artifact" blocker in the SLURM claim trace checklist.
- **Claim boundary:** tooling/validation fix only. No benchmark metrics, schema, or paper/dissertation claims are touched.
- **Required validation:** focused tests pass; verified against 20 real SHA256SUMS files with comment markers in `docs/context/evidence/`.
- **Remaining blocker:** none — issue is fully resolved by this one-line fix + regression tests.

## Contract delta

No schema changes. The `_parse_sha256s` function now ignores `#`-prefixed comment lines:

```python
# Before
if not stripped:
    continue
# After
if not stripped or stripped.startswith("#"):
    continue
```

Two regression tests added:
1. `test_sha256sums_comment_markers_are_ignored` — parser unit test: comment line absent from returned dict, real entry present with correct digest.
2. `test_sha256sums_comment_markers_do_not_block_checklist` — integration test: `build_checklist` with a comment-prefixed SHA256SUMS does not produce a synthetic blocker and reports `evidence_checksums: pass`.

## Validation results

```
tests/tools/test_slurm_to_claim_trace_checklist.py::test_complete_trace_checklist_passes PASSED
tests/tools/test_slurm_to_claim_trace_checklist.py::test_sha256sums_comment_markers_are_ignored PASSED
tests/tools/test_slurm_to_claim_trace_checklist.py::test_sha256sums_comment_markers_do_not_block_checklist PASSED
tests/tools/test_slurm_to_claim_trace_checklist.py::test_missing_finalizer_and_reconciliation_block_without_losing_retrieval PASSED
4 passed in 3.27s
```

Real-SHA256SUMS sweep: 20 files with `# AI-GENERATED NEEDS-REVIEW` headers all pass — no synthetic entries, no missing-artifact report.

Ruff check + format: `All checks passed!` / `2 files already formatted`.

## Out of scope

- No full benchmark campaign run
- No Slurm/GPU submission
- No paper/dissertation claim edits

Closes #5197