### PR TITLE
refactor(errors): complete RobotSfError migration for all remaining exception families (#4993)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* **issue #4993 complete RobotSfError migration.** Re-parents the remaining 76 ad-hoc
+  exception classes across `analysis_workbench`, `benchmark` (individual files), `common`,
+  `data_ingestion`, `examples`, `nav`, `planner`, `research`, and `training` subpackages onto
+  `RobotSfError` while preserving all existing `ValueError` / `RuntimeError` / `Exception`
+  ancestry. `except ValueError` and `except SpecificError` clauses are unaffected; new code
+  can now also target `except RobotSfError` for broad-package catches. Covered by
+  `tests/test_robot_sf_error_migration_4993.py` (59 compatibility tests).
+
 ### Added
 
 * **issue #4978 scenario flakiness audit applied to a real multi-planner campaign.** Ships a

--- a/robot_sf/analysis_workbench/real_trace_source_discovery.py
+++ b/robot_sf/analysis_workbench/real_trace_source_discovery.py
@@ -19,6 +19,7 @@ import yaml
 from jsonschema import Draft202012Validator
 
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 REAL_TRACE_SOURCE_DISCOVERY_SCHEMA_VERSION = "real_trace_source_discovery.v1"
 SOURCE_DISCOVERY_EVIDENCE_BOUNDARY = "public_source_discovery_only_no_real_world_validation"
@@ -37,7 +38,7 @@ USABLE_COVERAGE_STATUSES = {"direct"}
 SCHEMA_FILE = Path(__file__).resolve().parent / "schemas" / "real_trace_source_discovery.v1.json"
 
 
-class RealTraceSourceDiscoveryError(ValueError):
+class RealTraceSourceDiscoveryError(RobotSfError, ValueError):
     """Raised when a real-trace source discovery ledger is malformed."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/analysis_workbench/real_trace_validation_contract.py
+++ b/robot_sf/analysis_workbench/real_trace_validation_contract.py
@@ -44,6 +44,7 @@ from robot_sf.analysis_workbench.trace_failure_predicates import (
     matrix_required_fields_for_predicate,
 )
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 REAL_TRACE_VALIDATION_CONTRACT_SCHEMA_VERSION = "real_trace_validation_contract.v1"
 REAL_TRACE_VALIDATION_CONTRACT_SCHEMA_FILE = (
@@ -94,7 +95,7 @@ CONTRACT_STATUS_READY = "ready"
 CONTRACT_STATUS_BLOCKED = "blocked"
 
 
-class RealTraceValidationContractError(ValueError):
+class RealTraceValidationContractError(RobotSfError, ValueError):
     """Raised when a real-trace validation-contract descriptor fails schema checks."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/analysis_workbench/simulation_timeline.py
+++ b/robot_sf/analysis_workbench/simulation_timeline.py
@@ -17,6 +17,7 @@ from robot_sf.analysis_workbench.simulation_trace_export import (
     SimulationTraceFrame,
     load_simulation_trace_export,
 )
+from robot_sf.errors import RobotSfError
 
 SIMULATION_TIMELINE_SCHEMA_VERSION = "simulation_timeline.v1"
 SIMULATION_TIMELINE_SCHEMA_FILE = (
@@ -36,7 +37,7 @@ DEFAULT_FIXTURE = (
 )
 
 
-class SimulationTimelineValidationError(ValueError):
+class SimulationTimelineValidationError(RobotSfError, ValueError):
     """Raised when a ``simulation_timeline.v1`` payload fails schema validation."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/analysis_workbench/simulation_trace_export.py
+++ b/robot_sf/analysis_workbench/simulation_trace_export.py
@@ -12,6 +12,7 @@ from typing import Any
 from jsonschema import Draft202012Validator
 
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 SIMULATION_TRACE_EXPORT_SCHEMA_VERSION = "simulation_trace_export.v1"
 SIMULATION_TRACE_EXPORT_SCHEMA_FILE = (
@@ -63,7 +64,7 @@ class SimulationTraceExport:
         return asdict(self)
 
 
-class SimulationTraceExportValidationError(ValueError):
+class SimulationTraceExportValidationError(RobotSfError, ValueError):
     """Raised when a simulation trace export fails validation."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/analysis_workbench/trace_annotation.py
+++ b/robot_sf/analysis_workbench/trace_annotation.py
@@ -18,6 +18,7 @@ from robot_sf.analysis_workbench.simulation_trace_export import (
     load_simulation_trace_export,
 )
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 TRACE_ANNOTATION_SET_SCHEMA_VERSION = "trace_annotation_set.v1"
 TRACE_ANNOTATION_SET_SCHEMA_FILE = (
@@ -99,7 +100,7 @@ class TraceAnnotationSet:
         return payload
 
 
-class TraceAnnotationSetValidationError(ValueError):
+class TraceAnnotationSetValidationError(RobotSfError, ValueError):
     """Raised when a trace annotation set fails validation."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/benchmark/actuation_latency_measurement_manifest.py
+++ b/robot_sf/benchmark/actuation_latency_measurement_manifest.py
@@ -48,6 +48,7 @@ import yaml
 from jsonschema import Draft202012Validator
 
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 AMV_ACTUATION_LATENCY_MEASUREMENT_MANIFEST_SCHEMA_VERSION = (
     "amv_actuation_latency_measurement_manifest.v1"
@@ -140,7 +141,7 @@ ISSUE_3283_NEXT_EMPIRICAL_ACTION = (
 )
 
 
-class AmvActuationLatencyManifestError(ValueError):
+class AmvActuationLatencyManifestError(RobotSfError, ValueError):
     """Raised when an AMV actuation-latency measurement manifest fails schema checks."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/benchmark/amv_calibration_source_manifest.py
+++ b/robot_sf/benchmark/amv_calibration_source_manifest.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 import yaml
 
 from robot_sf.benchmark.synthetic_actuation import actuation_variability_fields
+from robot_sf.errors import RobotSfError
 
 AMV_CALIBRATION_SOURCE_MANIFEST_SCHEMA_VERSION = "amv_calibration_source_manifest.v1"
 AMV_CALIBRATION_SOURCE_EVIDENCE_BOUNDARY = (
@@ -65,7 +66,7 @@ _FIELD_STATUSES = {
 }
 
 
-class AmvCalibrationSourceManifestError(ValueError):
+class AmvCalibrationSourceManifestError(RobotSfError, ValueError):
     """Raised when an AMV calibration source manifest cannot be parsed."""
 
 

--- a/robot_sf/benchmark/artifact_catalog.py
+++ b/robot_sf/benchmark/artifact_catalog.py
@@ -16,6 +16,7 @@ import yaml
 from jsonschema import Draft202012Validator
 
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 ARTIFACT_CATALOG_SCHEMA_VERSION = "artifact_catalog.v1"
 ARTIFACT_CATALOG_SCHEMA_FILE = Path(__file__).with_name("schemas") / "artifact_catalog.v1.json"
@@ -80,7 +81,7 @@ class ArtifactCatalog:
         return asdict(self)
 
 
-class ArtifactCatalogValidationError(ValueError):
+class ArtifactCatalogValidationError(RobotSfError, ValueError):
     """Raised when an artifact catalog fails validation."""
 
     def __init__(self, issues: list[ArtifactCatalogIssue], *, source: str | Path | None = None):

--- a/robot_sf/benchmark/benchmark_claim.py
+++ b/robot_sf/benchmark/benchmark_claim.py
@@ -17,13 +17,14 @@ from jsonschema import Draft202012Validator
 
 from robot_sf.benchmark.identity.hash_utils import sha256_file
 from robot_sf.common.artifact_paths import get_repository_root
+from robot_sf.errors import RobotSfError
 
 BENCHMARK_CLAIM_SCHEMA_VERSION = "benchmark_claim.v1"
 BENCHMARK_CLAIM_SCHEMA_PATH = Path("robot_sf/benchmark/schemas/benchmark_claim.schema.v1.json")
 _HEX_SHA256_LENGTH = 64
 
 
-class BenchmarkClaimError(ValueError):
+class BenchmarkClaimError(RobotSfError, ValueError):
     """Raised when claim inputs cannot support a benchmark claim artifact."""
 
 

--- a/robot_sf/benchmark/benchmark_protocol.py
+++ b/robot_sf/benchmark/benchmark_protocol.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from robot_sf.common.artifact_paths import get_repository_root
+from robot_sf.errors import RobotSfError
 
 #: Default path to the AMMV benchmark protocol manifest, relative to the
 #: repository root.
@@ -32,7 +33,7 @@ _REQUIRED_CLAIM_RULES = frozenset(
 )
 
 
-class BenchmarkProtocolError(ValueError):
+class BenchmarkProtocolError(RobotSfError, ValueError):
     """Raised when a benchmark protocol manifest is missing or invalid."""
 
 

--- a/robot_sf/benchmark/benchmark_row_claim.py
+++ b/robot_sf/benchmark/benchmark_row_claim.py
@@ -16,6 +16,7 @@ from jsonschema import Draft202012Validator
 from jsonschema import ValidationError as JsonSchemaValidationError
 
 from robot_sf.common.artifact_paths import get_repository_root
+from robot_sf.errors import RobotSfError
 
 BENCHMARK_ROW_CLAIM_SCHEMA_VERSION = "benchmark_row_claim.v1"
 BENCHMARK_ROW_CLAIM_SCHEMA_PATH = Path("robot_sf/benchmark/schemas/benchmark_row_claim.v1.json")
@@ -61,7 +62,7 @@ _NON_SUCCESS_WORDING = {
 }
 
 
-class BenchmarkRowClaimError(ValueError):
+class BenchmarkRowClaimError(RobotSfError, ValueError):
     """Raised when a leaderboard row claim violates the v1 contract."""
 
 

--- a/robot_sf/benchmark/camera_ready/_route_clearance.py
+++ b/robot_sf/benchmark/camera_ready/_route_clearance.py
@@ -11,6 +11,7 @@ from loguru import logger
 from shapely.geometry import LineString, Polygon
 
 from robot_sf.common.artifact_paths import get_repository_root
+from robot_sf.errors import RobotSfError
 from robot_sf.nav.svg_map_parser import convert_map
 
 _ROUTE_CLEARANCE_WARN_THRESHOLD_M = 0.5
@@ -26,7 +27,7 @@ _ROUTE_CLEARANCE_CERTIFICATION_STATUSES = {
 }
 
 
-class RouteClearanceError(RuntimeError):
+class RouteClearanceError(RobotSfError, RuntimeError):
     """Raised when a scenario route is geometrically impossible for the robot footprint.
 
     This signals a fail-closed condition: at least one route centerline lies closer to a static

--- a/robot_sf/benchmark/campaign_checkpoint_preflight.py
+++ b/robot_sf/benchmark/campaign_checkpoint_preflight.py
@@ -43,6 +43,7 @@ from robot_sf.models import get_registry_entry, resolve_model_path
 
 if TYPE_CHECKING:
     from robot_sf.benchmark.camera_ready._config_types import CampaignConfig, PlannerSpec
+from robot_sf.errors import RobotSfError
 
 # Config keys, at any nesting depth of an arm's algo_config, that name a policy checkpoint.
 # ``model_id`` resolves through the registry; ``model_path`` is a direct filesystem reference.
@@ -57,7 +58,7 @@ _REMOTE_SOURCE_KEYS: tuple[str, ...] = (
 )
 
 
-class CampaignCheckpointPreflightError(RuntimeError):
+class CampaignCheckpointPreflightError(RobotSfError, RuntimeError):
     """Typed campaign checkpoint preflight failure for library-facing callers."""
 
     def __init__(

--- a/robot_sf/benchmark/control_action_latency_evidence.py
+++ b/robot_sf/benchmark/control_action_latency_evidence.py
@@ -59,6 +59,7 @@ from robot_sf.benchmark.control_action_latency_preflight import (
     check_control_action_latency_axis,
 )
 from robot_sf.benchmark.identity.hash_utils import sha256_file
+from robot_sf.errors import RobotSfError
 
 PROMOTION_SCHEMA_VERSION = "control-action-latency-sweep-evidence-promotion.v1"
 ISSUE = 5034
@@ -88,7 +89,7 @@ EXCLUSION_POLICY = (
 )
 
 
-class LatencyEvidenceError(RuntimeError):
+class LatencyEvidenceError(RobotSfError, RuntimeError):
     """Raised when raw rows are not promotable as latency-sweep evidence (fail closed)."""
 
 

--- a/robot_sf/benchmark/exemplar_selection.py
+++ b/robot_sf/benchmark/exemplar_selection.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+from robot_sf.errors import RobotSfError
 
 SELECTION_MANIFEST_SCHEMA_VERSION = "exemplar-selection.v1"
 
@@ -46,7 +47,7 @@ METRIC_DIRECTIONS: dict[str, MetricDirection] = {
 }
 
 
-class ExemplarSelectionError(Exception):
+class ExemplarSelectionError(RobotSfError):
     """Raised when exemplar selection inputs are malformed."""
 
 

--- a/robot_sf/benchmark/failure_mechanism_classifier.py
+++ b/robot_sf/benchmark/failure_mechanism_classifier.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from robot_sf.benchmark.aggregate import read_jsonl
+from robot_sf.errors import RobotSfError
 
 SCHEMA_VERSION = "failure_mechanism_classification.v1"
 CLASSIFICATION_SOURCE = "failure_mechanism_classifier.v1"
@@ -54,7 +55,7 @@ _REQUIRED_PAIRED_METRICS = (
 )
 
 
-class FailureMechanismClassificationError(ValueError):
+class FailureMechanismClassificationError(RobotSfError, ValueError):
     """Raised when failure-mechanism classification inputs are malformed."""
 
 

--- a/robot_sf/benchmark/failure_mechanism_taxonomy.py
+++ b/robot_sf/benchmark/failure_mechanism_taxonomy.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from typing import Any
+from robot_sf.errors import RobotSfError
 
 MECHANISM_SCHEMA_VERSION = "failure_mechanism_taxonomy.v1"
 
@@ -61,7 +62,7 @@ REQUIRED_MECHANISM_FIELDS = (
 )
 
 
-class FailureMechanismTaxonomyError(ValueError):
+class FailureMechanismTaxonomyError(RobotSfError, ValueError):
     """Raised when a failure-mechanism taxonomy record violates the contract."""
 
 

--- a/robot_sf/benchmark/hazard_traceability.py
+++ b/robot_sf/benchmark/hazard_traceability.py
@@ -13,6 +13,7 @@ import yaml
 from jsonschema import Draft202012Validator
 
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 HAZARD_TRACEABILITY_SCHEMA_VERSION = "hazard_traceability.v1"
 HAZARD_COVERAGE_SUMMARY_SCHEMA_VERSION = "hazard-traceability-coverage.v1"
@@ -78,7 +79,7 @@ class HazardTraceability:
         return payload
 
 
-class HazardTraceabilityValidationError(ValueError):
+class HazardTraceabilityValidationError(RobotSfError, ValueError):
     """Raised when a hazard traceability mapping fails validation."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/benchmark/hybrid_evidence_matrix.py
+++ b/robot_sf/benchmark/hybrid_evidence_matrix.py
@@ -11,6 +11,7 @@ from typing import Any
 import yaml
 
 from robot_sf.common.artifact_paths import get_repository_root
+from robot_sf.errors import RobotSfError
 
 EVALUATION_SLICES = frozenset({"not_run", "smoke", "nominal_sanity", "stress_slice", "full_matrix"})
 EVIDENCE_TIERS = frozenset(
@@ -104,7 +105,7 @@ _ISSUE_RE = re.compile(r"^#\d+$")
 _GIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
 
 
-class HybridEvidenceMatrixValidationError(ValueError):
+class HybridEvidenceMatrixValidationError(RobotSfError, ValueError):
     """Raised when the validator cannot parse the input payload."""
 
 

--- a/robot_sf/benchmark/hybrid_global_rl_diagnostic.py
+++ b/robot_sf/benchmark/hybrid_global_rl_diagnostic.py
@@ -17,6 +17,7 @@ from typing import Any
 import yaml
 
 from robot_sf.benchmark.identity.hash_utils import sha256_file as _sha256_file
+from robot_sf.errors import RobotSfError
 from robot_sf.models import get_registry_entry
 
 SCHEMA_VERSION = "issue-4183-hybrid-global-rl-diagnostic.v1"
@@ -48,7 +49,7 @@ CSV_FIELDS = [
 ]
 
 
-class HybridGlobalRLDiagnosticError(ValueError):
+class HybridGlobalRLDiagnosticError(RobotSfError, ValueError):
     """Raised when issue #4183 diagnostic inputs violate the pairing contract."""
 
 

--- a/robot_sf/benchmark/interaction_exposure.py
+++ b/robot_sf/benchmark/interaction_exposure.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any
+from robot_sf.errors import RobotSfError
 
 INTERACTION_EXPOSURE_SCHEMA_VERSION = "interaction_exposure.v1"
 
@@ -37,7 +38,7 @@ def is_not_derivable_status(status: object) -> bool:
     return isinstance(status, str) and status.strip().startswith(NOT_DERIVABLE_STATUS_PREFIX)
 
 
-class InteractionExposureError(ValueError):
+class InteractionExposureError(RobotSfError, ValueError):
     """Raised when interaction-exposure inputs are malformed."""
 
 

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_readiness.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_readiness.py
@@ -52,6 +52,7 @@ from robot_sf.benchmark.cbf_safety_filter_runtime import (
     CBF_OFF_ARM,
     runtime_config_from_mapping,
 )
+from robot_sf.errors import RobotSfError
 
 #: Output-contract schema for this readiness surface.
 SCHEMA_VERSION = "issue-4142-dpcbf-dense-readiness.v1"
@@ -104,7 +105,7 @@ CAMPAIGN_GATES: tuple[str, ...] = (
 )
 
 
-class DpcbfDenseReadinessError(ValueError):
+class DpcbfDenseReadinessError(RobotSfError, ValueError):
     """Raised when the packet cannot be loaded or parsed at all."""
 
 

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
@@ -57,6 +57,7 @@ from robot_sf.benchmark.issue_4142_dpcbf_dense_readiness import (
     evaluate_readiness,
     load_packet,
 )
+from robot_sf.errors import RobotSfError
 
 #: Output-contract schema for the resolved run plan.
 PLAN_SCHEMA_VERSION = "robot_sf.issue_4142_dpcbf_dense_comparison_plan.v1"
@@ -84,11 +85,11 @@ RUNNER_GATES: tuple[str, ...] = (
 )
 
 
-class DenseComparisonRunnerError(ValueError):
+class DenseComparisonRunnerError(RobotSfError, ValueError):
     """Raised when the packet cannot be consumed into a run plan at all."""
 
 
-class DenseComparisonExecutionGatedError(RuntimeError):
+class DenseComparisonExecutionGatedError(RobotSfError, RuntimeError):
     """Raised when execution is attempted; execution stays authorization-gated here."""
 
 

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_summary.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_summary.py
@@ -61,6 +61,7 @@ from robot_sf.benchmark.issue_4142_dpcbf_dense_runner import (
     DenseComparisonRunnerError,
     build_run_plan,
 )
+from robot_sf.errors import RobotSfError
 
 #: Output-contract schema for this comparison summary surface.
 SUMMARY_SCHEMA_VERSION = "robot_sf.issue_4142_dpcbf_dense_comparison_summary.v1"
@@ -83,7 +84,7 @@ CLAIM_BOUNDARY = (
 )
 
 
-class DenseComparisonSummaryError(ValueError):
+class DenseComparisonSummaryError(RobotSfError, ValueError):
     """Raised when the run plan cannot be built into a summary at all."""
 
 

--- a/robot_sf/benchmark/live_forecast_replay_gate.py
+++ b/robot_sf/benchmark/live_forecast_replay_gate.py
@@ -56,6 +56,7 @@ from robot_sf.benchmark.pedestrian_forecast import (
 )
 from robot_sf.common.forecast_variants import FORECAST_VARIANT_CHOICES
 from robot_sf.common.issue_provenance import LIVE_FORECAST_REPLAY_GATE_CONTRACT_ISSUE
+from robot_sf.errors import RobotSfError
 from robot_sf.gym_env.unified_config import EnvSettings
 from robot_sf.nav.baseline_probabilistic_predictor import BaselineProbabilisticPredictor
 from robot_sf.nav.predictive_types import ProbabilisticPrediction, ProbabilisticPredictor
@@ -128,7 +129,7 @@ class LiveForecastReplayGateConfig:
     )
 
 
-class LiveForecastReplayGateError(ValueError):
+class LiveForecastReplayGateError(RobotSfError, ValueError):
     """Raised when the gate cannot produce a valid report."""
 
 

--- a/robot_sf/benchmark/long_horizon_route.py
+++ b/robot_sf/benchmark/long_horizon_route.py
@@ -12,8 +12,10 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
+from robot_sf.errors import RobotSfError
 
-class LongHorizonRouteError(ValueError):
+
+class LongHorizonRouteError(RobotSfError, ValueError):
     """Raised when a route definition or metric input cannot be scored safely."""
 
 

--- a/robot_sf/benchmark/map_runner_view_integrity.py
+++ b/robot_sf/benchmark/map_runner_view_integrity.py
@@ -41,12 +41,13 @@ import numpy as np
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+from robot_sf.errors import RobotSfError
 
 #: Canonical degraded-reason code recorded when the guard trips (named in issue #3634/#3568).
 DEGENERATE_PLANNER_VIEW_REASON = "degenerate_planner_view"
 
 
-class DegeneratePlannerViewError(RuntimeError):
+class DegeneratePlannerViewError(RobotSfError, RuntimeError):
     """Raised to fail a benchmark episode closed when a planner's effective view is degenerate.
 
     Carrying the structured diagnostic lets callers record an explicit non-success row

--- a/robot_sf/benchmark/mechanism_trace.py
+++ b/robot_sf/benchmark/mechanism_trace.py
@@ -10,10 +10,12 @@ from typing import Any
 
 import jsonschema
 
+from robot_sf.errors import RobotSfError
+
 SCHEMA_VERSION = "mechanism_trace.v1"
 
 
-class MechanismTraceValidationError(ValueError):
+class MechanismTraceValidationError(RobotSfError, ValueError):
     """Raised when mechanism trace inputs violate the JSON schema or constraints."""
 
 

--- a/robot_sf/benchmark/multi_planner_overlay.py
+++ b/robot_sf/benchmark/multi_planner_overlay.py
@@ -48,12 +48,12 @@ from robot_sf.benchmark.figures.style import (
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
+from robot_sf.errors import RobotSfError
 
 OVERLAY_PROVENANCE_SCHEMA = "multi_planner_overlay.v1"
 
 
-class MultiPlannerOverlayError(Exception):
+class MultiPlannerOverlayError(RobotSfError):
     """Raised when overlay inputs are invalid or incomplete."""
 
 

--- a/robot_sf/benchmark/near_miss_ttc.py
+++ b/robot_sf/benchmark/near_miss_ttc.py
@@ -60,6 +60,7 @@ from robot_sf.benchmark.metrics import _compute_ped_velocities
 
 if TYPE_CHECKING:
     from robot_sf.benchmark.metrics import EpisodeData
+from robot_sf.errors import RobotSfError
 
 # Uncalibrated diagnostic placeholder (decision-required, issue #3700). This is
 # NOT a benchmark-calibrated threshold; it only gives the diagnostic a concrete
@@ -76,7 +77,7 @@ _MIN_RELATIVE_SPEED: float = 1e-9
 _MIN_APPROACH_DISTANCE: float = 1e-9
 
 
-class NearMissTtcInputError(RuntimeError):
+class NearMissTtcInputError(RobotSfError, RuntimeError):
     """Raised when TTC near-miss inputs fail the fail-closed readiness contract.
 
     Carries the structured readiness report so callers can surface exactly which

--- a/robot_sf/benchmark/odd_contract.py
+++ b/robot_sf/benchmark/odd_contract.py
@@ -14,6 +14,7 @@ from jsonschema import Draft202012Validator
 
 from robot_sf.benchmark.observation_quality import ObservationQuality
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 ODD_CONTRACT_SCHEMA_VERSION = "odd_contract.v1"
 ODD_CONTRACT_SCHEMA_FILE = Path(__file__).with_name("schemas") / "odd_contract.v1.json"
@@ -117,7 +118,7 @@ class OddContract:
         return payload
 
 
-class OddContractValidationError(ValueError):
+class OddContractValidationError(RobotSfError, ValueError):
     """Raised when an ODD contract fails schema or semantic validation."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/benchmark/odd_hazard_coverage_matrix.py
+++ b/robot_sf/benchmark/odd_hazard_coverage_matrix.py
@@ -17,6 +17,7 @@ import yaml
 from jsonschema import Draft202012Validator
 
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 ODD_HAZARD_COVERAGE_SCHEMA_VERSION = "odd_hazard_coverage.v1"
 ODD_HAZARD_COVERAGE_SCHEMA_FILE = (
@@ -93,7 +94,7 @@ class OddHazardCoverageMatrix:
         return payload
 
 
-class OddHazardCoverageValidationError(ValueError):
+class OddHazardCoverageValidationError(RobotSfError, ValueError):
     """Raised when an ODD hazard coverage matrix fails validation."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/benchmark/orca_preflight.py
+++ b/robot_sf/benchmark/orca_preflight.py
@@ -15,12 +15,13 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from robot_sf.benchmark.camera_ready_campaign import CampaignConfig, PlannerSpec
+from robot_sf.errors import RobotSfError
 
 _SYNC_COMMAND_EXTRA = "uv sync --extra orca"
 _SYNC_COMMAND_ALL = "uv sync --all-extras"
 
 
-class OrcaRvo2PreflightError(RuntimeError):
+class OrcaRvo2PreflightError(RobotSfError, RuntimeError):
     """Typed ORCA preflight failure for library-facing campaign callers."""
 
     def __init__(

--- a/robot_sf/benchmark/pedestrian_prior_extraction.py
+++ b/robot_sf/benchmark/pedestrian_prior_extraction.py
@@ -22,11 +22,12 @@ from robot_sf.benchmark.pedestrian_prior_extraction_manifest import (
     PRIOR_EXTRACTION_EVIDENCE_BOUNDARY,
     REQUIRED_PRIOR_PARAMETERS,
 )
+from robot_sf.errors import RobotSfError
 
 PEDESTRIAN_PRIOR_EXTRACTION_REPORT_SCHEMA_VERSION = "pedestrian_prior_extraction_report.v1"
 
 
-class PedestrianPriorExtractionError(ValueError):
+class PedestrianPriorExtractionError(RobotSfError, ValueError):
     """Raised when trajectory input cannot support prior extraction."""
 
 

--- a/robot_sf/benchmark/pedestrian_prior_extraction_manifest.py
+++ b/robot_sf/benchmark/pedestrian_prior_extraction_manifest.py
@@ -52,6 +52,7 @@ import yaml
 from jsonschema import Draft202012Validator
 
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 PEDESTRIAN_PRIOR_EXTRACTION_MANIFEST_SCHEMA_VERSION = "pedestrian_prior_extraction_manifest.v1"
 PEDESTRIAN_PRIOR_EXTRACTION_MANIFEST_SCHEMA_FILE = (
@@ -118,7 +119,7 @@ CONTRACT_STATUS_PROXY_ONLY = "proxy-only"
 _PLACEHOLDER_VALUES = frozenset({"", "tbd", "unknown", "unspecified", "n/a", "pending"})
 
 
-class PedestrianPriorExtractionManifestError(ValueError):
+class PedestrianPriorExtractionManifestError(RobotSfError, ValueError):
     """Raised when a pedestrian-prior extraction manifest fails schema checks."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/benchmark/planner_command_contract.py
+++ b/robot_sf/benchmark/planner_command_contract.py
@@ -8,11 +8,12 @@ from robot_sf.benchmark.algorithm_metadata import planner_contract_for_algorithm
 
 if TYPE_CHECKING:
     from robot_sf.planner.kinematics_model import KinematicsModel
+from robot_sf.errors import RobotSfError
 
 _DEFAULT_KINEMATICS = "differential_drive"
 
 
-class PlannerContractValidationError(ValueError):
+class PlannerContractValidationError(RobotSfError, ValueError):
     """Raised when planner observation/action metadata does not match a run request."""
 
 

--- a/robot_sf/benchmark/predictive_same_seed_row_summary.py
+++ b/robot_sf/benchmark/predictive_same_seed_row_summary.py
@@ -11,6 +11,7 @@ from typing import Any
 import yaml
 
 from robot_sf.common.artifact_paths import get_repository_root
+from robot_sf.errors import RobotSfError
 from robot_sf.planner.obstacle_features import (
     ObstacleFeatureSchemaError,
     predictive_ego_motion_channel_producer_key,
@@ -59,7 +60,7 @@ _ISSUE_RE = re.compile(r"^#\d+$")
 _GIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
 
 
-class PredictiveSameSeedRowSummaryValidationError(ValueError):
+class PredictiveSameSeedRowSummaryValidationError(RobotSfError, ValueError):
     """Raised when a predictive same-seed row-summary payload cannot be loaded."""
 
 

--- a/robot_sf/benchmark/predictive_v2_comparison_readiness.py
+++ b/robot_sf/benchmark/predictive_v2_comparison_readiness.py
@@ -43,6 +43,8 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
+
 # Stage status vocabulary shared with sibling readiness validators
 # (see scripts/validation/validate_learned_prediction_readiness.py).
 STATUS_PASSED = "passed"
@@ -153,7 +155,7 @@ _PUBLIC_SURFACE_SNAPSHOT: tuple[dict[str, str], ...] = (
 )
 
 
-class PredictiveV2ComparisonReadinessError(Exception):
+class PredictiveV2ComparisonReadinessError(RobotSfError):
     """Raised when the comparison contract cannot be loaded or parsed."""
 
 

--- a/robot_sf/benchmark/rare_event_sampling.py
+++ b/robot_sf/benchmark/rare_event_sampling.py
@@ -17,10 +17,12 @@ from dataclasses import dataclass
 from statistics import NormalDist
 from typing import Any
 
+from robot_sf.errors import RobotSfError
+
 SCHEMA_VERSION = "rare_event_sampling.v1"
 
 
-class RareEventSamplingError(ValueError):
+class RareEventSamplingError(RobotSfError, ValueError):
     """Raised when the rare-event sampling contract is malformed or unsafe."""
 
 

--- a/robot_sf/benchmark/release_gates.py
+++ b/robot_sf/benchmark/release_gates.py
@@ -21,6 +21,7 @@ from typing import Any
 import yaml
 
 from robot_sf.benchmark.identity.hash_utils import sha256_file as _sha256_file
+from robot_sf.errors import RobotSfError
 
 RELEASE_GATE_REPORT_SCHEMA_VERSION = "benchmark_release_gate_report.v1"
 RELEASE_GATE_SPEC_SCHEMA_VERSION = "benchmark_release_gate_spec.v1"
@@ -45,7 +46,7 @@ _DEFAULT_FAMILY_KEYS = (
 )
 
 
-class ReleaseGateSpecError(ValueError):
+class ReleaseGateSpecError(RobotSfError, ValueError):
     """Raised when release-gate YAML cannot be evaluated safely."""
 
 

--- a/robot_sf/benchmark/release_preflight.py
+++ b/robot_sf/benchmark/release_preflight.py
@@ -38,6 +38,7 @@ from typing import Any
 import yaml
 
 from robot_sf.benchmark.identity.hash_utils import sha256_file as _sha256_file
+from robot_sf.errors import RobotSfError
 
 SCHEMA_VERSION = "release_preflight_checklist.v1"
 
@@ -108,7 +109,7 @@ ALLOWED_ISSUE_CLASSIFICATIONS = frozenset(
 )
 
 
-class ReleasePreflightError(ValueError):
+class ReleasePreflightError(RobotSfError, ValueError):
     """Raised when a checklist definition is structurally invalid."""
 
 

--- a/robot_sf/benchmark/release_suite_contract.py
+++ b/robot_sf/benchmark/release_suite_contract.py
@@ -16,6 +16,8 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
+
 RELEASE_SUITE_CONTRACT_SCHEMA_VERSION = "benchmark-release-suite-contract.v0.1"
 RELEASE_SUITE_CONTRACT_REPORT_SCHEMA_VERSION = "benchmark-release-suite-contract-report.v0.1"
 REQUIRED_SUITE_METADATA_FIELDS = (
@@ -32,7 +34,7 @@ CLAIM_BOUNDARY = (
 )
 
 
-class ReleaseSuiteContractError(ValueError):
+class ReleaseSuiteContractError(RobotSfError, ValueError):
     """Raised when a release suite manifest cannot be evaluated safely."""
 
 

--- a/robot_sf/benchmark/release_suite_reference_validation.py
+++ b/robot_sf/benchmark/release_suite_reference_validation.py
@@ -29,6 +29,7 @@ from robot_sf.benchmark.release_suite_contract import (
     ReleaseSuiteContractManifest,
     ReleaseSuiteDeclaration,
 )
+from robot_sf.errors import RobotSfError
 
 RELEASE_SUITE_REFERENCE_REPORT_SCHEMA_VERSION = "benchmark-release-suite-reference-report.v0.1"
 REFERENCE_VALIDATION_CLAIM_BOUNDARY = (
@@ -38,7 +39,7 @@ REFERENCE_VALIDATION_CLAIM_BOUNDARY = (
 )
 
 
-class ReleaseSuiteReferenceError(ValueError):
+class ReleaseSuiteReferenceError(RobotSfError, ValueError):
     """Raised when reference validation cannot be evaluated safely."""
 
 

--- a/robot_sf/benchmark/result_provenance.py
+++ b/robot_sf/benchmark/result_provenance.py
@@ -24,6 +24,7 @@ from robot_sf.benchmark.utils import _config_hash, _git_hash_fallback
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+from robot_sf.errors import RobotSfError
 
 SCHEMA_VERSION = "benchmark_result_provenance.v1"
 ROW_SCHEMA_VERSION = "benchmark_row_provenance.v1"
@@ -35,7 +36,7 @@ _REQUIRED_CAMPAIGN = ("scenario_matrix_hash", "total_jobs", "written")
 _REQUIRED_ROW = ("episode_id", "scenario_id", "seed", "config_hash", "repo_commit")
 
 
-class ProvenanceValidationError(ValueError):
+class ProvenanceValidationError(RobotSfError, ValueError):
     """Raised when a provenance manifest fails validation."""
 
 

--- a/robot_sf/benchmark/scenario_contract.py
+++ b/robot_sf/benchmark/scenario_contract.py
@@ -13,6 +13,7 @@ import yaml
 from jsonschema import Draft202012Validator
 
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 CONTRACT_SCHEMA_VERSION = "scenario_contract.v1"
 CERT_SCHEMA_VERSION = "scenario_cert.v1"
@@ -162,7 +163,7 @@ class ScenarioContract:
         return payload
 
 
-class ScenarioContractValidationError(ValueError):
+class ScenarioContractValidationError(RobotSfError, ValueError):
     """Raised when a scenario contract fails schema or reference validation."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/benchmark/scenario_denominator_manifest.py
+++ b/robot_sf/benchmark/scenario_denominator_manifest.py
@@ -16,6 +16,7 @@ from typing import Any
 import yaml
 
 from robot_sf.benchmark.identity.hash_utils import sha256_file as _sha256_file
+from robot_sf.errors import RobotSfError
 from robot_sf.training.scenario_loader import load_scenarios
 
 SCENARIO_DENOMINATOR_SCHEMA_VERSION = "scenario_denominator_manifest.v1"
@@ -46,7 +47,7 @@ _TABLE_INT_COLUMNS = {
 }
 
 
-class DenominatorManifestError(ValueError):
+class DenominatorManifestError(RobotSfError, ValueError):
     """Raised when configs or consumer tables cannot produce a closed denominator audit."""
 
 

--- a/robot_sf/benchmark/scenario_generation/catalog_schema.py
+++ b/robot_sf/benchmark/scenario_generation/catalog_schema.py
@@ -14,13 +14,15 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
+from robot_sf.errors import RobotSfError
+
 CATALOG_ENTRY_SCHEMA_VERSION = "generated-scenario-catalog-entry.v1"
 _SCHEMA_PATH = (
     Path(__file__).resolve().parents[1] / "schemas" / "generated_scenario_catalog_entry.v1.json"
 )
 
 
-class GeneratedScenarioCatalogValidationError(ValueError):
+class GeneratedScenarioCatalogValidationError(RobotSfError, ValueError):
     """Raised when a catalog entry cannot safely be stored as a hypothesis."""
 
 

--- a/robot_sf/benchmark/snqi/weights_inventory.py
+++ b/robot_sf/benchmark/snqi/weights_inventory.py
@@ -47,6 +47,7 @@ from robot_sf.common.artifact_paths import get_repository_root
 
 if TYPE_CHECKING:
     from pathlib import Path
+from robot_sf.errors import RobotSfError
 
 # Tolerance for "weights sum to 1" (normalized simplex) detection.
 _SIMPLEX_TOL = 1e-3
@@ -331,7 +332,7 @@ class WeightInventoryReport:
         }
 
 
-class SNQIWeightProvenanceError(RuntimeError):
+class SNQIWeightProvenanceError(RobotSfError, RuntimeError):
     """Raised by the fail-closed preflight when a blocking conflict exists."""
 
 

--- a/robot_sf/benchmark/social_preference_labels.py
+++ b/robot_sf/benchmark/social_preference_labels.py
@@ -16,6 +16,8 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
+
 SOCIAL_PREFERENCE_LABEL_SCHEMA_VERSION = "social-preference-labels.v1"
 REQUIRED_LABEL_IDS = frozenset(
     {
@@ -46,7 +48,7 @@ REQUIRED_LABEL_FIELDS = frozenset(
 ANNOTATION_METHODS = frozenset({"threshold_band", "manual", "not_available"})
 
 
-class SocialPreferenceLabelConfigError(ValueError):
+class SocialPreferenceLabelConfigError(RobotSfError, ValueError):
     """Raised when a social preference label config violates the v1 contract."""
 
 

--- a/robot_sf/benchmark/stress_uncertainty_coverage.py
+++ b/robot_sf/benchmark/stress_uncertainty_coverage.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from robot_sf.benchmark.aggregate import read_jsonl
+from robot_sf.errors import RobotSfError
 
 SCHEMA_VERSION = "stress_uncertainty_coverage.v1"
 LEGACY_AGGREGATE_SCHEMA_VERSION = "aggregate.schema.v1"
@@ -44,7 +45,7 @@ _SCENARIO_PARAMETER_KEYS = (
 )
 
 
-class StressUncertaintyCoverageError(ValueError):
+class StressUncertaintyCoverageError(RobotSfError, ValueError):
     """Raised when a stress/uncertainty coverage report fails closed."""
 
 

--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -8,6 +8,7 @@ from itertools import pairwise
 from pathlib import Path
 from typing import Any
 
+from robot_sf.errors import RobotSfError
 from robot_sf.scenario_certification.sustained_flow import (
     EXPECTED_CONTINUOUS_SPAWN_DEFINITION,
     EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG,
@@ -112,7 +113,7 @@ class SustainedFlowPreflight:
         }
 
 
-class SustainedFlowPreflightError(ValueError):
+class SustainedFlowPreflightError(RobotSfError, ValueError):
     """Raised when a sustained-flow matrix is malformed enough to fail."""
 
 

--- a/robot_sf/benchmark/sustained_flow_revival_gate.py
+++ b/robot_sf/benchmark/sustained_flow_revival_gate.py
@@ -17,6 +17,7 @@ from robot_sf.benchmark.interaction_exposure import (
     INTERACTION_EXPOSURE_REQUIRED_FIELDS,
     is_not_derivable_status,
 )
+from robot_sf.errors import RobotSfError
 
 SUSTAINED_FLOW_REVIVAL_GATE_SCHEMA_VERSION = "issue_3813.sustained_flow_revival_gate.v1"
 
@@ -77,7 +78,7 @@ class SustainedFlowRevivalGateReport:
         return payload
 
 
-class SustainedFlowRevivalGateError(ValueError):
+class SustainedFlowRevivalGateError(RobotSfError, ValueError):
     """Raised when the revival-gate inputs are structurally invalid."""
 
 

--- a/robot_sf/benchmark/visualization.py
+++ b/robot_sf/benchmark/visualization.py
@@ -31,6 +31,7 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from multiprocessing.connection import Connection
+from robot_sf.errors import RobotSfError
 
 
 def frame_shape_from_map(map_svg_path: str) -> tuple[int, int]:
@@ -161,7 +162,7 @@ class ValidationResult:
     details: dict | None = None
 
 
-class VisualizationError(Exception):
+class VisualizationError(RobotSfError):
     """Raised when visualization generation fails."""
 
     def __init__(self, message: str, artifact_type: str, details: dict | None = None):

--- a/robot_sf/common/safe_pickle.py
+++ b/robot_sf/common/safe_pickle.py
@@ -17,9 +17,10 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path
+from robot_sf.errors import RobotSfError
 
 
-class UnsafePickleError(RuntimeError):
+class UnsafePickleError(RobotSfError, RuntimeError):
     """Raised when a restricted unpickler rejects a pickle global."""
 
 

--- a/robot_sf/data_ingestion/real_trajectory_contract.py
+++ b/robot_sf/data_ingestion/real_trajectory_contract.py
@@ -29,6 +29,7 @@ import jsonschema
 import yaml
 
 from robot_sf.common.artifact_paths import get_repository_root
+from robot_sf.errors import RobotSfError
 
 MANIFEST_SCHEMA_ID = "robot_sf_real_trajectory_ingestion_manifest.v1"
 
@@ -214,7 +215,7 @@ def _validated_staging_issues(staging_dir: str, checksums: dict[str, Any]) -> li
     return issues
 
 
-class ContractError(RuntimeError):
+class ContractError(RobotSfError, RuntimeError):
     """Raised when a manifest cannot be loaded or fails structural schema validation."""
 
 

--- a/robot_sf/examples/manifest_loader.py
+++ b/robot_sf/examples/manifest_loader.py
@@ -16,6 +16,8 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
+
 __all__ = [
     "ExampleCategory",
     "ExampleManifest",
@@ -25,7 +27,7 @@ __all__ = [
 ]
 
 
-class ManifestValidationError(ValueError):
+class ManifestValidationError(RobotSfError, ValueError):
     """Raised when the manifest data fails structural or semantic validation."""
 
 

--- a/robot_sf/nav/footprint_diagnostic.py
+++ b/robot_sf/nav/footprint_diagnostic.py
@@ -36,6 +36,7 @@ from shapely.ops import unary_union
 
 if TYPE_CHECKING:
     from robot_sf.common.types import Vec2D
+from robot_sf.errors import RobotSfError
 
 FOOTPRINT_ORIENTATION_SCHEMA_VERSION = "footprint-orientation.v1"
 FOOTPRINT_KIND_CIRCULAR = "circular"
@@ -51,7 +52,7 @@ REQUIRED_SCENARIO_FAMILY_IDS = frozenset(
 )
 
 
-class FootprintOrientationConfigError(ValueError):
+class FootprintOrientationConfigError(RobotSfError, ValueError):
     """Raised when a footprint-orientation diagnostic config violates the v1 contract."""
 
 

--- a/robot_sf/planner/classic_global_planner.py
+++ b/robot_sf/planner/classic_global_planner.py
@@ -46,6 +46,7 @@ try:
     from python_motion_planning.common import Visualizer
 except ImportError:
     from python_motion_planning.common.visualizer import Visualizer2D as Visualizer
+from robot_sf.errors import RobotSfError
 
 
 def _plot_grid_map_supports_alpha_3d() -> bool:
@@ -642,7 +643,7 @@ class ClassicPlannerConfig:
             )
 
 
-class PlanningError(Exception):
+class PlanningError(RobotSfError):
     """Raised when path planning fails."""
 
     pass

--- a/robot_sf/planner/learned_policy_adapter.py
+++ b/robot_sf/planner/learned_policy_adapter.py
@@ -11,9 +11,10 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+from robot_sf.errors import RobotSfError
 
 
-class LearnedPolicyAdapterContractError(ValueError):
+class LearnedPolicyAdapterContractError(RobotSfError, ValueError):
     """Raised when a learned-policy adapter request violates its declared contract."""
 
 

--- a/robot_sf/planner/learned_risk_surface.py
+++ b/robot_sf/planner/learned_risk_surface.py
@@ -15,12 +15,13 @@ from typing import Any
 import numpy as np
 
 from robot_sf.common.math_utils import wrap_angle_pi
+from robot_sf.errors import RobotSfError
 from robot_sf.nav.occupancy_grid_utils import world_to_ego
 from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter
 from robot_sf.planner.socnav_occupancy import OccupancyAwarePlannerMixin
 
 
-class RiskSurfaceUnavailable(ValueError):
+class RiskSurfaceUnavailable(RobotSfError, ValueError):
     """Raised when a local risk surface cannot satisfy the runtime contract."""
 
 

--- a/robot_sf/planner/lidar_occupancy.py
+++ b/robot_sf/planner/lidar_occupancy.py
@@ -8,6 +8,8 @@ from typing import Any
 
 import numpy as np
 
+from robot_sf.errors import RobotSfError
+
 
 @dataclass(frozen=True)
 class LidarOccupancyGridConfig:
@@ -27,7 +29,7 @@ class LidarOccupancyGridConfig:
     robot_radius: float = 0.3
 
 
-class LidarOccupancyAdapterError(ValueError):
+class LidarOccupancyAdapterError(RobotSfError, ValueError):
     """Raised when a LiDAR observation cannot be converted safely."""
 
 

--- a/robot_sf/planner/obstacle_features.py
+++ b/robot_sf/planner/obstacle_features.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from robot_sf.common.types import Line2D, Vec2D
+from robot_sf.errors import RobotSfError
 
 PREDICTIVE_OBSTACLE_FEATURE_SCHEMA = "predictive_obstacle_features_v1"
 PREDICTIVE_OBSTACLE_FEATURE_DIM = 6
@@ -24,7 +25,7 @@ PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME = "same_seed_hardcase_runtime_robot_speed
 PREDICTIVE_EGO_MOTION_PRODUCER_STANDALONE = "standalone_rollout_velocity_xy_preferred_v1"
 
 
-class ObstacleFeatureSchemaError(ValueError):
+class ObstacleFeatureSchemaError(RobotSfError, ValueError):
     """Raised when obstacle-feature metadata is incompatible with the expected schema."""
 
 

--- a/robot_sf/planner/visibility_planner.py
+++ b/robot_sf/planner/visibility_planner.py
@@ -15,6 +15,7 @@ from shapely.geometry import LineString, Point, Polygon
 from shapely.ops import nearest_points
 
 from robot_sf.common.types import Vec2D
+from robot_sf.errors import RobotSfError
 from robot_sf.nav.map_config import MapDefinition
 from robot_sf.planner.path_smoother import douglas_peucker
 from robot_sf.planner.visibility_graph import VisibilityGraph
@@ -83,7 +84,7 @@ def _prune_collinear(points: list[Vec2D], tol: float = 1e-6) -> list[Vec2D]:
     return pruned
 
 
-class PlanningFailedError(Exception):
+class PlanningFailedError(RobotSfError):
     """Raised when no valid path exists between start and goal."""
 
     def __init__(self, start: Vec2D, goal: Vec2D, reason: str):

--- a/robot_sf/research/amv_command_response_trace_manifest.py
+++ b/robot_sf/research/amv_command_response_trace_manifest.py
@@ -52,6 +52,7 @@ import yaml
 from jsonschema import Draft202012Validator
 
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 AMV_TRACE_MANIFEST_SCHEMA_VERSION = "amv_command_response_trace_manifest.v1"
 AMV_TRACE_MANIFEST_SCHEMA_FILE = (
@@ -80,7 +81,7 @@ MANIFEST_STATUS_INVALID = "invalid"
 _LIVE_AVAILABLE_STATUSES = frozenset({"available", "staged"})
 
 
-class AmvTraceManifestError(ValueError):
+class AmvTraceManifestError(RobotSfError, ValueError):
     """Raised when an AMV command-response trace manifest fails schema checks."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/research/scenario_prior_staging_contract.py
+++ b/robot_sf/research/scenario_prior_staging_contract.py
@@ -44,6 +44,7 @@ import yaml
 from jsonschema import Draft202012Validator
 
 from robot_sf.common.json_pointer import json_pointer
+from robot_sf.errors import RobotSfError
 
 SCENARIO_PRIOR_STAGING_CONTRACT_SCHEMA_VERSION = "scenario_prior_staging_contract.v1"
 SCENARIO_PRIOR_STAGING_CONTRACT_SCHEMA_FILE = (
@@ -72,7 +73,7 @@ CONTRACT_STATUS_INVALID = "invalid"
 _LIVE_AVAILABLE_STATUSES = frozenset({"available", "staged"})
 
 
-class ScenarioPriorStagingContractError(ValueError):
+class ScenarioPriorStagingContractError(RobotSfError, ValueError):
     """Raised when a scenario-prior staging contract fails schema checks."""
 
     def __init__(self, errors: list[str], *, source: str | Path | None = None):

--- a/robot_sf/training/learned_risk_campaign_readiness.py
+++ b/robot_sf/training/learned_risk_campaign_readiness.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from robot_sf.errors import RobotSfError
 from robot_sf.training.learned_risk_launch_packet import (
     LearnedRiskLaunchPacketError,
     validate_launch_packet,
@@ -58,7 +59,7 @@ _GATE_PASSED = "passed"
 _GATE_BLOCKED = "blocked"
 
 
-class LearnedRiskCampaignReadinessError(ValueError):
+class LearnedRiskCampaignReadinessError(RobotSfError, ValueError):
     """Raised when a campaign-readiness input file is missing or unreadable.
 
     This is reserved for operator error (a config path that does not point at a

--- a/robot_sf/training/learned_risk_launch_packet.py
+++ b/robot_sf/training/learned_risk_launch_packet.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
+
 _SCHEMA_VERSION = "learned-risk-launch-packet.v1"
 _GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _DURABLE_URI_PREFIXES = ("wandb-artifact://", "artifact://", "s3://", "gs://", "https://")
@@ -22,7 +24,7 @@ _REQUIRED_DIAGNOSTICS = (
 )
 
 
-class LearnedRiskLaunchPacketError(ValueError):
+class LearnedRiskLaunchPacketError(RobotSfError, ValueError):
     """Raised when a learned-risk launch packet fails validation."""
 
 

--- a/robot_sf/training/learned_risk_trace_manifest.py
+++ b/robot_sf/training/learned_risk_trace_manifest.py
@@ -32,6 +32,7 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
 from robot_sf.training.learned_risk_launch_packet import (
     _DURABLE_URI_PREFIXES,
     _REQUIRED_LABELS,
@@ -54,7 +55,7 @@ _LABEL_PRESENT = "present"
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
-class LearnedRiskTraceManifestError(ValueError):
+class LearnedRiskTraceManifestError(RobotSfError, ValueError):
     """Raised when a learned-risk trace manifest is structurally invalid."""
 
 

--- a/robot_sf/training/learned_risk_trainer.py
+++ b/robot_sf/training/learned_risk_trainer.py
@@ -34,6 +34,7 @@ from typing import Any
 import numpy as np
 import yaml
 
+from robot_sf.errors import RobotSfError
 from robot_sf.training.learned_risk_campaign_readiness import (
     CAMPAIGN_READY,
     evaluate_campaign_readiness,
@@ -72,7 +73,7 @@ _REQUIRED_EPISODE_FIELDS = (
 )
 
 
-class LearnedRiskTrainerError(ValueError):
+class LearnedRiskTrainerError(RobotSfError, ValueError):
     """Raised when the trainer config or its input traces are contract-invalid.
 
     This is reserved for operator/contract error (a malformed config, a config

--- a/robot_sf/training/oracle_imitation_launch_packet.py
+++ b/robot_sf/training/oracle_imitation_launch_packet.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
 from robot_sf.training.oracle_trace_uri_registry import (
     OracleTraceUriRegistryError,
     validate_trace_uri_registry,
@@ -23,7 +24,7 @@ _DURABLE_URI_PREFIXES = ("wandb-artifact://", "artifact://", "s3://", "gs://", "
 _REQUIRED_COLLECTION_ROOTS = ("log_root", "dataset_output_root", "manifest_destination")
 
 
-class LaunchPacketError(ValueError):
+class LaunchPacketError(RobotSfError, ValueError):
     """Raised when an oracle-imitation launch packet fails validation."""
 
 

--- a/robot_sf/training/oracle_imitation_warm_start_readiness.py
+++ b/robot_sf/training/oracle_imitation_warm_start_readiness.py
@@ -38,6 +38,7 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
 from robot_sf.training.oracle_imitation_launch_packet import (
     LaunchPacketError,
     validate_launch_packet,
@@ -77,7 +78,7 @@ _DURABLE_OUTPUT_MANIFEST_PREFIX = "docs/context/evidence/"
 _DURABLE_OUTPUT_MANIFEST_SUFFIXES: tuple[str, ...] = (".json", ".yaml", ".yml")
 
 
-class WarmStartReadinessError(ValueError):
+class WarmStartReadinessError(RobotSfError, ValueError):
     """Raised when a warm-start readiness manifest is malformed.
 
     This is distinct from an unmet prerequisite: a missing dataset or config is a

--- a/robot_sf/training/oracle_trace_uri_registry.py
+++ b/robot_sf/training/oracle_trace_uri_registry.py
@@ -23,6 +23,7 @@ from typing import Any
 import yaml
 
 from robot_sf.benchmark.artifact_catalog import sha256_file
+from robot_sf.errors import RobotSfError
 
 _SCHEMA_VERSION = "oracle-trace-uri-registry.v1"
 _REQUIRED_SPLITS = ("train", "validation", "evaluation")
@@ -34,7 +35,7 @@ _HEX_DIGITS = frozenset("0123456789abcdef")
 _PENDING_SHA256 = "pending"
 
 
-class OracleTraceUriRegistryError(ValueError):
+class OracleTraceUriRegistryError(RobotSfError, ValueError):
     """Raised when an oracle-imitation trace-URI registry fails validation."""
 
 

--- a/robot_sf/training/orca_residual_lineage_packet.py
+++ b/robot_sf/training/orca_residual_lineage_packet.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
+
 _SCHEMA_VERSION = "orca-residual-bc-lineage-packet.v1"
 _GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _DURABLE_URI_PREFIXES = ("wandb-artifact://", "artifact://", "s3://", "gs://", "https://")
@@ -80,7 +82,7 @@ _ALLOWED_OBJECTIVE_TARGETS = (
 )
 
 
-class OrcaResidualLineagePacketError(ValueError):
+class OrcaResidualLineagePacketError(RobotSfError, ValueError):
     """Raised when an ORCA-residual lineage packet fails validation."""
 
 

--- a/robot_sf/training/predictive_retrain_preflight.py
+++ b/robot_sf/training/predictive_retrain_preflight.py
@@ -23,6 +23,8 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
+
 # Mirror the weighting rule accepted by build_predictive_mixed_dataset.py so the
 # preflight fails closed on specs the dataset builder would reject downstream.
 _SUPPORTED_WEIGHTING_RULE = "repeat_hardcase_rows"
@@ -45,7 +47,7 @@ _EXPECTED_PROVENANCE_KEYS = (
 _PROVENANCE_PRETRAINING_STATUS = "expected_missing_until_training"
 
 
-class PredictiveRetrainPreflightError(ValueError):
+class PredictiveRetrainPreflightError(RobotSfError, ValueError):
     """Raised when a predictive retraining launch config fails preflight."""
 
 

--- a/robot_sf/training/predictive_retraining_readiness.py
+++ b/robot_sf/training/predictive_retraining_readiness.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
+
 SCHEMA_VERSION = "predictive-retraining-readiness.v1"
 DECISION_BLOCKED = "retraining_blocked"
 DECISION_READY = "retraining_launch_ready"
@@ -40,7 +42,7 @@ _REQUIRED_PIPELINE_PROVENANCE = {
 }
 
 
-class PredictiveRetrainingReadinessError(ValueError):
+class PredictiveRetrainingReadinessError(RobotSfError, ValueError):
     """Raised when a predictive retraining readiness packet cannot be evaluated."""
 
 

--- a/robot_sf/training/shielded_ppo_launch_packet.py
+++ b/robot_sf/training/shielded_ppo_launch_packet.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import yaml
 
+from robot_sf.errors import RobotSfError
+
 _SCHEMA_VERSION = "shielded-ppo-repair-launch-packet.v1"
 _GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _DURABLE_URI_PREFIXES = ("wandb-artifact://", "artifact://", "s3://", "gs://", "https://")
@@ -23,7 +25,7 @@ _REQUIRED_STOP_STAGES = ("smoke", "nominal_sanity")
 _REQUIRED_REFERENCES = ("ppo_baseline", "risk_guarded_ppo_v1")
 
 
-class ShieldedPPOLaunchPacketError(ValueError):
+class ShieldedPPOLaunchPacketError(RobotSfError, ValueError):
     """Raised when a shielded-PPO launch packet fails validation."""
 
 

--- a/scripts/dev/migrate_exceptions_4993.py
+++ b/scripts/dev/migrate_exceptions_4993.py
@@ -1,0 +1,164 @@
+"""One-shot migration script: re-parent remaining ad-hoc exception families onto RobotSfError.
+
+Run from repo root in the issue-4993 worktree:
+    uv run python scripts/dev/migrate_exceptions_4993.py
+
+Transformation rules:
+- class Foo(ValueError)  -> class Foo(RobotSfError, ValueError)
+- class Foo(RuntimeError) -> class Foo(RobotSfError, RuntimeError)
+- class Foo(Exception)   -> class Foo(RobotSfError)
+- class Foo(SomeCustomError) -> no change (covered transitively once parent migrated)
+
+Already-migrated files are skipped automatically.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+SKIP = {
+    ROOT / "robot_sf/errors.py",
+    ROOT / "robot_sf/benchmark/errors.py",
+    ROOT / "robot_sf/data/external/recording_shape_contract.py",
+    ROOT / "robot_sf/data/external/atc.py",
+    ROOT / "robot_sf/data/external/eth_ucy.py",
+    ROOT / "robot_sf/data/external/ind.py",
+    ROOT / "robot_sf/data/external/socnavbench_eth.py",
+    ROOT / "robot_sf/data/external/crowdbot.py",
+    ROOT / "robot_sf/data/external/scand.py",
+    ROOT / "robot_sf/research/exceptions.py",
+}
+
+_CLASS_RE = re.compile(
+    r"^(class\s+\w+)\((ValueError|RuntimeError|Exception)\)\s*:",
+    re.MULTILINE,
+)
+
+_IMPORT_LINE = "from robot_sf.errors import RobotSfError"
+
+
+def _needs_import(src: str) -> bool:
+    return _IMPORT_LINE not in src
+
+
+def _has_target_class(src: str) -> bool:
+    return bool(_CLASS_RE.search(src))
+
+
+def _add_import(src: str) -> str:
+    """Insert the RobotSfError import safely, after all complete import blocks.
+
+    Handles multi-line imports by tracking open parentheses depth so we never
+    insert into the middle of a 'from X import (\n  ...\n)' block.
+    """
+    lines = src.splitlines(keepends=True)
+    insert_after = -1
+    in_docstring = False
+    docstring_char = None
+    paren_depth = 0
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+
+        # Track module-level triple-quoted docstrings
+        if not in_docstring and paren_depth == 0 and (
+            stripped.startswith('"""') or stripped.startswith("'''")
+        ):
+            docstring_char = stripped[:3]
+            count = stripped.count(docstring_char)
+            if count >= 2 and len(stripped) > 3:
+                insert_after = i  # single-line docstring
+            else:
+                in_docstring = True
+            continue
+        if in_docstring:
+            if docstring_char and docstring_char in line:
+                in_docstring = False
+                insert_after = i
+            continue
+
+        # Track parenthesis depth across multi-line imports
+        paren_depth += line.count("(") - line.count(")")
+
+        if paren_depth > 0:
+            # Inside a multi-line statement — do not mark as a completed import
+            continue
+
+        # At top level (paren_depth == 0 after the line)
+        if stripped.startswith("from __future__"):
+            insert_after = i
+        elif stripped.startswith("from ") or stripped.startswith("import "):
+            insert_after = i
+        elif stripped.startswith("class ") or stripped.startswith("def ") or (
+            stripped and not stripped.startswith("#") and not stripped.startswith("@")
+            and not stripped.startswith("__")
+        ):
+            # First non-import, non-decorator, non-dunder-assignment line
+            if insert_after >= 0:
+                break
+
+    new_lines = list(lines)
+    if insert_after >= 0:
+        new_lines.insert(insert_after + 1, _IMPORT_LINE + "\n")
+    else:
+        new_lines.insert(0, _IMPORT_LINE + "\n")
+
+    return "".join(new_lines)
+
+
+def _rewrite_classes(src: str) -> str:
+    _builtins = {
+        "ValueError": "RobotSfError, ValueError",
+        "RuntimeError": "RobotSfError, RuntimeError",
+        "Exception": "RobotSfError",
+    }
+
+    def _replacement(m: re.Match) -> str:
+        prefix = m.group(1)
+        parent = m.group(2)
+        new_parent = _builtins[parent]
+        return f"{prefix}({new_parent}):"
+
+    return _CLASS_RE.sub(_replacement, src)
+
+
+def process_file(path: Path) -> bool:
+    src = path.read_text()
+    if not _has_target_class(src):
+        return False
+
+    new_src = _rewrite_classes(src)
+    if _needs_import(new_src):
+        new_src = _add_import(new_src)
+
+    if new_src == src:
+        return False
+
+    path.write_text(new_src)
+    return True
+
+
+def main() -> None:
+    target_files = sorted(
+        p
+        for p in (ROOT / "robot_sf").rglob("*.py")
+        if "__pycache__" not in str(p) and p not in SKIP
+    )
+
+    changed: list[Path] = []
+    for path in target_files:
+        if process_file(path):
+            changed.append(path)
+            print(f"  migrated: {path.relative_to(ROOT)}")
+
+    print(f"\nTotal files modified: {len(changed)}")
+    if not changed:
+        print("Nothing to do — all exceptions already migrated or no targets found.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/migrate_exceptions_4993.py
+++ b/scripts/dev/migrate_exceptions_4993.py
@@ -11,6 +11,7 @@ Transformation rules:
 
 Already-migrated files are skipped automatically.
 """
+
 from __future__ import annotations
 
 import re
@@ -48,7 +49,7 @@ def _has_target_class(src: str) -> bool:
     return bool(_CLASS_RE.search(src))
 
 
-def _add_import(src: str) -> str:
+def _add_import(src: str) -> str:  # noqa: C901
     """Insert the RobotSfError import safely, after all complete import blocks.
 
     Handles multi-line imports by tracking open parentheses depth so we never
@@ -64,8 +65,10 @@ def _add_import(src: str) -> str:
         stripped = line.strip()
 
         # Track module-level triple-quoted docstrings
-        if not in_docstring and paren_depth == 0 and (
-            stripped.startswith('"""') or stripped.startswith("'''")
+        if (
+            not in_docstring
+            and paren_depth == 0
+            and (stripped.startswith('"""') or stripped.startswith("'''"))
         ):
             docstring_char = stripped[:3]
             count = stripped.count(docstring_char)
@@ -92,9 +95,15 @@ def _add_import(src: str) -> str:
             insert_after = i
         elif stripped.startswith("from ") or stripped.startswith("import "):
             insert_after = i
-        elif stripped.startswith("class ") or stripped.startswith("def ") or (
-            stripped and not stripped.startswith("#") and not stripped.startswith("@")
-            and not stripped.startswith("__")
+        elif (
+            stripped.startswith("class ")
+            or stripped.startswith("def ")
+            or (
+                stripped
+                and not stripped.startswith("#")
+                and not stripped.startswith("@")
+                and not stripped.startswith("__")
+            )
         ):
             # First non-import, non-decorator, non-dunder-assignment line
             if insert_after >= 0:
@@ -126,6 +135,7 @@ def _rewrite_classes(src: str) -> str:
 
 
 def process_file(path: Path) -> bool:
+    """Migrate direct builtin exception bases in one source file."""
     src = path.read_text()
     if not _has_target_class(src):
         return False
@@ -142,6 +152,7 @@ def process_file(path: Path) -> bool:
 
 
 def main() -> None:
+    """Apply the one-shot migration to every remaining eligible source file."""
     target_files = sorted(
         p
         for p in (ROOT / "robot_sf").rglob("*.py")

--- a/tests/test_robot_sf_error_migration_4993.py
+++ b/tests/test_robot_sf_error_migration_4993.py
@@ -40,40 +40,48 @@ def _assert_triple_catch(cls: type, base: type, msg: str = "test") -> None:
 
 
 class TestAnalysisWorkbenchExceptions:
+    """Compatibility coverage for analysis-workbench exception classes."""
+
     def test_real_trace_source_discovery_error(self) -> None:
         from robot_sf.analysis_workbench.real_trace_source_discovery import (
             RealTraceSourceDiscoveryError,
         )
+
         _assert_triple_catch(RealTraceSourceDiscoveryError, ValueError)
 
     def test_real_trace_validation_contract_error(self) -> None:
         from robot_sf.analysis_workbench.real_trace_validation_contract import (
             RealTraceValidationContractError,
         )
+
         _assert_triple_catch(RealTraceValidationContractError, ValueError)
 
     def test_simulation_timeline_validation_error(self) -> None:
         from robot_sf.analysis_workbench.simulation_timeline import (
             SimulationTimelineValidationError,
         )
+
         _assert_triple_catch(SimulationTimelineValidationError, ValueError)
 
     def test_simulation_trace_export_validation_error(self) -> None:
         from robot_sf.analysis_workbench.simulation_trace_export import (
             SimulationTraceExportValidationError,
         )
+
         _assert_triple_catch(SimulationTraceExportValidationError, ValueError)
 
     def test_trace_annotation_set_validation_error(self) -> None:
         from robot_sf.analysis_workbench.trace_annotation import (
             TraceAnnotationSetValidationError,
         )
+
         _assert_triple_catch(TraceAnnotationSetValidationError, ValueError)
 
     def test_analysis_workbench_errors_catchable_by_robot_sf_error(self) -> None:
         from robot_sf.analysis_workbench.real_trace_source_discovery import (
             RealTraceSourceDiscoveryError,
         )
+
         with pytest.raises(RobotSfError):
             raise RealTraceSourceDiscoveryError("no sources found")
 
@@ -81,6 +89,7 @@ class TestAnalysisWorkbenchExceptions:
         from robot_sf.analysis_workbench.simulation_timeline import (
             SimulationTimelineValidationError,
         )
+
         with pytest.raises(ValueError):
             raise SimulationTimelineValidationError("bad timeline")
 
@@ -91,32 +100,40 @@ class TestAnalysisWorkbenchExceptions:
 
 
 class TestBenchmarkIndividualFileExceptions:
+    """Compatibility coverage for benchmark exception classes outside errors.py."""
+
     def test_artifact_catalog_validation_error(self) -> None:
         from robot_sf.benchmark.artifact_catalog import ArtifactCatalogValidationError
+
         # Custom constructor requires ArtifactCatalogIssue objects; test subclass only.
         assert issubclass(ArtifactCatalogValidationError, RobotSfError)
         assert issubclass(ArtifactCatalogValidationError, ValueError)
 
     def test_benchmark_claim_error(self) -> None:
         from robot_sf.benchmark.benchmark_claim import BenchmarkClaimError
+
         _assert_triple_catch(BenchmarkClaimError, ValueError)
 
     def test_benchmark_protocol_error(self) -> None:
         from robot_sf.benchmark.benchmark_protocol import BenchmarkProtocolError
+
         _assert_triple_catch(BenchmarkProtocolError, ValueError)
 
     def test_campaign_checkpoint_preflight_error(self) -> None:
         from robot_sf.benchmark.campaign_checkpoint_preflight import (
             CampaignCheckpointPreflightError,
         )
+
         _assert_triple_catch(CampaignCheckpointPreflightError, RuntimeError)
 
     def test_latency_evidence_error(self) -> None:
         from robot_sf.benchmark.control_action_latency_evidence import LatencyEvidenceError
+
         _assert_triple_catch(LatencyEvidenceError, RuntimeError)
 
     def test_exemplar_selection_error_is_robot_sf_error(self) -> None:
         from robot_sf.benchmark.exemplar_selection import ExemplarSelectionError
+
         # Was Exception; now inherits directly from RobotSfError
         assert issubclass(ExemplarSelectionError, RobotSfError)
         assert issubclass(ExemplarSelectionError, Exception)
@@ -125,40 +142,49 @@ class TestBenchmarkIndividualFileExceptions:
         from robot_sf.benchmark.failure_mechanism_classifier import (
             FailureMechanismClassificationError,
         )
+
         _assert_triple_catch(FailureMechanismClassificationError, ValueError)
 
     def test_near_miss_ttc_input_error(self) -> None:
         from robot_sf.benchmark.near_miss_ttc import NearMissTtcInputError
+
         _assert_triple_catch(NearMissTtcInputError, RuntimeError)
 
     def test_odd_contract_validation_error(self) -> None:
         from robot_sf.benchmark.odd_contract import OddContractValidationError
+
         _assert_triple_catch(OddContractValidationError, ValueError)
 
     def test_orca_rvo2_preflight_error(self) -> None:
         from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError
+
         _assert_triple_catch(OrcaRvo2PreflightError, RuntimeError)
 
     def test_release_gates_spec_error(self) -> None:
         from robot_sf.benchmark.release_gates import ReleaseGateSpecError
+
         _assert_triple_catch(ReleaseGateSpecError, ValueError)
 
     def test_release_preflight_error(self) -> None:
         from robot_sf.benchmark.release_preflight import ReleasePreflightError
+
         _assert_triple_catch(ReleasePreflightError, ValueError)
 
     def test_visualization_error_is_robot_sf_error(self) -> None:
         from robot_sf.benchmark.visualization import VisualizationError
+
         assert issubclass(VisualizationError, RobotSfError)
         assert issubclass(VisualizationError, Exception)
 
     def test_multi_planner_overlay_error_is_robot_sf_error(self) -> None:
         from robot_sf.benchmark.multi_planner_overlay import MultiPlannerOverlayError
+
         assert issubclass(MultiPlannerOverlayError, RobotSfError)
         assert issubclass(MultiPlannerOverlayError, Exception)
 
     def test_snqi_weight_provenance_error(self) -> None:
         from robot_sf.benchmark.snqi.weights_inventory import SNQIWeightProvenanceError
+
         _assert_triple_catch(SNQIWeightProvenanceError, RuntimeError)
 
     def test_provenance_validation_error_hierarchy(self) -> None:
@@ -169,6 +195,7 @@ class TestBenchmarkIndividualFileExceptions:
             ProvenanceRowLinkError,
             ProvenanceValidationError,
         )
+
         for cls in (
             ProvenanceValidationError,
             ProvenanceRequiredFieldError,
@@ -183,16 +210,19 @@ class TestBenchmarkIndividualFileExceptions:
             ProvenanceRequiredFieldError,
             ProvenanceValidationError,
         )
+
         with pytest.raises(ProvenanceValidationError):
             raise ProvenanceRequiredFieldError("required field absent")
 
     def test_benchmark_errors_catchable_by_robot_sf_error(self) -> None:
         from robot_sf.benchmark.benchmark_claim import BenchmarkClaimError
+
         with pytest.raises(RobotSfError):
             raise BenchmarkClaimError("invalid claim")
 
     def test_benchmark_runtime_errors_catchable_by_robot_sf_error(self) -> None:
         from robot_sf.benchmark.near_miss_ttc import NearMissTtcInputError
+
         with pytest.raises(RobotSfError):
             raise NearMissTtcInputError("bad input")
 
@@ -200,6 +230,7 @@ class TestBenchmarkIndividualFileExceptions:
         from robot_sf.benchmark.campaign_checkpoint_preflight import (
             CampaignCheckpointPreflightError,
         )
+
         with pytest.raises(RuntimeError):
             raise CampaignCheckpointPreflightError("preflight failed")
 
@@ -210,17 +241,22 @@ class TestBenchmarkIndividualFileExceptions:
 
 
 class TestCommonExceptions:
+    """Compatibility coverage for common exception classes."""
+
     def test_unsafe_pickle_error(self) -> None:
         from robot_sf.common.safe_pickle import UnsafePickleError
+
         _assert_triple_catch(UnsafePickleError, RuntimeError)
 
     def test_unsafe_pickle_error_catchable_by_robot_sf_error(self) -> None:
         from robot_sf.common.safe_pickle import UnsafePickleError
+
         with pytest.raises(RobotSfError):
             raise UnsafePickleError("unsafe pickle detected")
 
     def test_unsafe_pickle_error_legacy_catch_preserved(self) -> None:
         from robot_sf.common.safe_pickle import UnsafePickleError
+
         with pytest.raises(RuntimeError):
             raise UnsafePickleError("unsafe pickle detected")
 
@@ -231,17 +267,22 @@ class TestCommonExceptions:
 
 
 class TestDataIngestionExceptions:
+    """Compatibility coverage for data-ingestion exception classes."""
+
     def test_contract_error(self) -> None:
         from robot_sf.data_ingestion.real_trajectory_contract import ContractError
+
         _assert_triple_catch(ContractError, RuntimeError)
 
     def test_contract_error_catchable_by_robot_sf_error(self) -> None:
         from robot_sf.data_ingestion.real_trajectory_contract import ContractError
+
         with pytest.raises(RobotSfError):
             raise ContractError("contract violated")
 
     def test_contract_error_legacy_catch_preserved(self) -> None:
         from robot_sf.data_ingestion.real_trajectory_contract import ContractError
+
         with pytest.raises(RuntimeError):
             raise ContractError("contract violated")
 
@@ -252,12 +293,16 @@ class TestDataIngestionExceptions:
 
 
 class TestExamplesExceptions:
+    """Compatibility coverage for example manifest exception classes."""
+
     def test_manifest_validation_error(self) -> None:
         from robot_sf.examples.manifest_loader import ManifestValidationError
+
         _assert_triple_catch(ManifestValidationError, ValueError)
 
     def test_manifest_validation_error_catchable_by_robot_sf_error(self) -> None:
         from robot_sf.examples.manifest_loader import ManifestValidationError
+
         with pytest.raises(RobotSfError):
             raise ManifestValidationError("manifest invalid")
 
@@ -268,12 +313,16 @@ class TestExamplesExceptions:
 
 
 class TestNavExceptions:
+    """Compatibility coverage for navigation exception classes."""
+
     def test_footprint_orientation_config_error(self) -> None:
         from robot_sf.nav.footprint_diagnostic import FootprintOrientationConfigError
+
         _assert_triple_catch(FootprintOrientationConfigError, ValueError)
 
     def test_footprint_error_catchable_by_robot_sf_error(self) -> None:
         from robot_sf.nav.footprint_diagnostic import FootprintOrientationConfigError
+
         with pytest.raises(RobotSfError):
             raise FootprintOrientationConfigError("bad config")
 
@@ -284,39 +333,49 @@ class TestNavExceptions:
 
 
 class TestPlannerExceptions:
+    """Compatibility coverage for planner exception classes."""
+
     def test_planning_error_is_robot_sf_error(self) -> None:
         from robot_sf.planner.classic_global_planner import PlanningError
+
         assert issubclass(PlanningError, RobotSfError)
         assert issubclass(PlanningError, Exception)
 
     def test_planning_failed_error_is_robot_sf_error(self) -> None:
         from robot_sf.planner.visibility_planner import PlanningFailedError
+
         assert issubclass(PlanningFailedError, RobotSfError)
         assert issubclass(PlanningFailedError, Exception)
 
     def test_learned_policy_adapter_contract_error(self) -> None:
         from robot_sf.planner.learned_policy_adapter import LearnedPolicyAdapterContractError
+
         _assert_triple_catch(LearnedPolicyAdapterContractError, ValueError)
 
     def test_risk_surface_unavailable(self) -> None:
         from robot_sf.planner.learned_risk_surface import RiskSurfaceUnavailable
+
         _assert_triple_catch(RiskSurfaceUnavailable, ValueError)
 
     def test_lidar_occupancy_adapter_error(self) -> None:
         from robot_sf.planner.lidar_occupancy import LidarOccupancyAdapterError
+
         _assert_triple_catch(LidarOccupancyAdapterError, ValueError)
 
     def test_obstacle_feature_schema_error(self) -> None:
         from robot_sf.planner.obstacle_features import ObstacleFeatureSchemaError
+
         _assert_triple_catch(ObstacleFeatureSchemaError, ValueError)
 
     def test_planning_error_catchable_by_robot_sf_error(self) -> None:
         from robot_sf.planner.classic_global_planner import PlanningError
+
         with pytest.raises(RobotSfError):
             raise PlanningError("no path found")
 
     def test_risk_surface_unavailable_legacy_catch(self) -> None:
         from robot_sf.planner.learned_risk_surface import RiskSurfaceUnavailable
+
         with pytest.raises(ValueError):
             raise RiskSurfaceUnavailable("surface missing")
 
@@ -327,18 +386,23 @@ class TestPlannerExceptions:
 
 
 class TestResearchIndividualFileExceptions:
+    """Compatibility coverage for research exception classes outside exceptions.py."""
+
     def test_amv_trace_manifest_error(self) -> None:
         from robot_sf.research.amv_command_response_trace_manifest import AmvTraceManifestError
+
         _assert_triple_catch(AmvTraceManifestError, ValueError)
 
     def test_scenario_prior_staging_contract_error(self) -> None:
         from robot_sf.research.scenario_prior_staging_contract import (
             ScenarioPriorStagingContractError,
         )
+
         _assert_triple_catch(ScenarioPriorStagingContractError, ValueError)
 
     def test_research_individual_errors_catchable_by_robot_sf_error(self) -> None:
         from robot_sf.research.amv_command_response_trace_manifest import AmvTraceManifestError
+
         with pytest.raises(RobotSfError):
             raise AmvTraceManifestError("trace manifest invalid")
 
@@ -349,22 +413,28 @@ class TestResearchIndividualFileExceptions:
 
 
 class TestTrainingExceptions:
+    """Compatibility coverage for training exception classes."""
+
     def test_learned_risk_campaign_readiness_error(self) -> None:
         from robot_sf.training.learned_risk_campaign_readiness import (
             LearnedRiskCampaignReadinessError,
         )
+
         _assert_triple_catch(LearnedRiskCampaignReadinessError, ValueError)
 
     def test_learned_risk_launch_packet_error(self) -> None:
         from robot_sf.training.learned_risk_launch_packet import LearnedRiskLaunchPacketError
+
         _assert_triple_catch(LearnedRiskLaunchPacketError, ValueError)
 
     def test_learned_risk_trace_manifest_error(self) -> None:
         from robot_sf.training.learned_risk_trace_manifest import LearnedRiskTraceManifestError
+
         _assert_triple_catch(LearnedRiskTraceManifestError, ValueError)
 
     def test_launch_packet_error(self) -> None:
         from robot_sf.training.oracle_imitation_launch_packet import LaunchPacketError
+
         _assert_triple_catch(LaunchPacketError, ValueError)
 
     def test_warm_start_readiness_error_hierarchy(self) -> None:
@@ -372,6 +442,7 @@ class TestTrainingExceptions:
             PrerequisitesNotReadyError,
             WarmStartReadinessError,
         )
+
         assert issubclass(WarmStartReadinessError, RobotSfError)
         assert issubclass(WarmStartReadinessError, ValueError)
         # Subclass is covered transitively
@@ -384,29 +455,35 @@ class TestTrainingExceptions:
             PrerequisitesNotReadyError,
             WarmStartReadinessError,
         )
+
         with pytest.raises(WarmStartReadinessError):
             raise PrerequisitesNotReadyError("prerequisites missing")
 
     def test_oracle_trace_uri_registry_error(self) -> None:
         from robot_sf.training.oracle_trace_uri_registry import OracleTraceUriRegistryError
+
         _assert_triple_catch(OracleTraceUriRegistryError, ValueError)
 
     def test_predictive_retraining_readiness_error(self) -> None:
         from robot_sf.training.predictive_retraining_readiness import (
             PredictiveRetrainingReadinessError,
         )
+
         _assert_triple_catch(PredictiveRetrainingReadinessError, ValueError)
 
     def test_shielded_ppo_launch_packet_error(self) -> None:
         from robot_sf.training.shielded_ppo_launch_packet import ShieldedPPOLaunchPacketError
+
         _assert_triple_catch(ShieldedPPOLaunchPacketError, ValueError)
 
     def test_training_errors_catchable_by_robot_sf_error(self) -> None:
         from robot_sf.training.learned_risk_trainer import LearnedRiskTrainerError
+
         with pytest.raises(RobotSfError):
             raise LearnedRiskTrainerError("training failed")
 
     def test_training_errors_legacy_catch_preserved(self) -> None:
         from robot_sf.training.orca_residual_lineage_packet import OrcaResidualLineagePacketError
+
         with pytest.raises(ValueError):
             raise OrcaResidualLineagePacketError("lineage error")

--- a/tests/test_robot_sf_error_migration_4993.py
+++ b/tests/test_robot_sf_error_migration_4993.py
@@ -1,0 +1,412 @@
+"""Compatibility tests for the remaining RobotSfError migration (#4993).
+
+Covers every subpackage family migrated in this PR:
+- analysis_workbench, benchmark (individual files), common, data_ingestion,
+  examples, nav, planner, research (individual files), training.
+
+For each representative class the contract is:
+  1. is_a(RobotSfError)  -- new catch target works
+  2. is_a(OriginalBase)  -- legacy catch still works
+  3. is_a(ConcreteClass) -- specific catch still works
+
+For hierarchy members (ProvenanceRequiredFieldError ← ProvenanceValidationError)
+we also assert transitive RobotSfError membership.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.errors import RobotSfError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_triple_catch(cls: type, base: type, msg: str = "test") -> None:
+    """Assert cls is a subclass of RobotSfError, base, and itself."""
+    assert issubclass(cls, RobotSfError), f"{cls.__name__} not a subclass of RobotSfError"
+    assert issubclass(cls, base), f"{cls.__name__} not a subclass of {base.__name__}"
+    assert issubclass(cls, cls)
+    obj = cls(msg)
+    assert isinstance(obj, RobotSfError)
+    assert isinstance(obj, base)
+
+
+# ---------------------------------------------------------------------------
+# analysis_workbench
+# ---------------------------------------------------------------------------
+
+
+class TestAnalysisWorkbenchExceptions:
+    def test_real_trace_source_discovery_error(self) -> None:
+        from robot_sf.analysis_workbench.real_trace_source_discovery import (
+            RealTraceSourceDiscoveryError,
+        )
+        _assert_triple_catch(RealTraceSourceDiscoveryError, ValueError)
+
+    def test_real_trace_validation_contract_error(self) -> None:
+        from robot_sf.analysis_workbench.real_trace_validation_contract import (
+            RealTraceValidationContractError,
+        )
+        _assert_triple_catch(RealTraceValidationContractError, ValueError)
+
+    def test_simulation_timeline_validation_error(self) -> None:
+        from robot_sf.analysis_workbench.simulation_timeline import (
+            SimulationTimelineValidationError,
+        )
+        _assert_triple_catch(SimulationTimelineValidationError, ValueError)
+
+    def test_simulation_trace_export_validation_error(self) -> None:
+        from robot_sf.analysis_workbench.simulation_trace_export import (
+            SimulationTraceExportValidationError,
+        )
+        _assert_triple_catch(SimulationTraceExportValidationError, ValueError)
+
+    def test_trace_annotation_set_validation_error(self) -> None:
+        from robot_sf.analysis_workbench.trace_annotation import (
+            TraceAnnotationSetValidationError,
+        )
+        _assert_triple_catch(TraceAnnotationSetValidationError, ValueError)
+
+    def test_analysis_workbench_errors_catchable_by_robot_sf_error(self) -> None:
+        from robot_sf.analysis_workbench.real_trace_source_discovery import (
+            RealTraceSourceDiscoveryError,
+        )
+        with pytest.raises(RobotSfError):
+            raise RealTraceSourceDiscoveryError("no sources found")
+
+    def test_analysis_workbench_errors_catchable_by_value_error(self) -> None:
+        from robot_sf.analysis_workbench.simulation_timeline import (
+            SimulationTimelineValidationError,
+        )
+        with pytest.raises(ValueError):
+            raise SimulationTimelineValidationError("bad timeline")
+
+
+# ---------------------------------------------------------------------------
+# benchmark individual files
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkIndividualFileExceptions:
+    def test_artifact_catalog_validation_error(self) -> None:
+        from robot_sf.benchmark.artifact_catalog import ArtifactCatalogValidationError
+        # Custom constructor requires ArtifactCatalogIssue objects; test subclass only.
+        assert issubclass(ArtifactCatalogValidationError, RobotSfError)
+        assert issubclass(ArtifactCatalogValidationError, ValueError)
+
+    def test_benchmark_claim_error(self) -> None:
+        from robot_sf.benchmark.benchmark_claim import BenchmarkClaimError
+        _assert_triple_catch(BenchmarkClaimError, ValueError)
+
+    def test_benchmark_protocol_error(self) -> None:
+        from robot_sf.benchmark.benchmark_protocol import BenchmarkProtocolError
+        _assert_triple_catch(BenchmarkProtocolError, ValueError)
+
+    def test_campaign_checkpoint_preflight_error(self) -> None:
+        from robot_sf.benchmark.campaign_checkpoint_preflight import (
+            CampaignCheckpointPreflightError,
+        )
+        _assert_triple_catch(CampaignCheckpointPreflightError, RuntimeError)
+
+    def test_latency_evidence_error(self) -> None:
+        from robot_sf.benchmark.control_action_latency_evidence import LatencyEvidenceError
+        _assert_triple_catch(LatencyEvidenceError, RuntimeError)
+
+    def test_exemplar_selection_error_is_robot_sf_error(self) -> None:
+        from robot_sf.benchmark.exemplar_selection import ExemplarSelectionError
+        # Was Exception; now inherits directly from RobotSfError
+        assert issubclass(ExemplarSelectionError, RobotSfError)
+        assert issubclass(ExemplarSelectionError, Exception)
+
+    def test_failure_mechanism_classification_error(self) -> None:
+        from robot_sf.benchmark.failure_mechanism_classifier import (
+            FailureMechanismClassificationError,
+        )
+        _assert_triple_catch(FailureMechanismClassificationError, ValueError)
+
+    def test_near_miss_ttc_input_error(self) -> None:
+        from robot_sf.benchmark.near_miss_ttc import NearMissTtcInputError
+        _assert_triple_catch(NearMissTtcInputError, RuntimeError)
+
+    def test_odd_contract_validation_error(self) -> None:
+        from robot_sf.benchmark.odd_contract import OddContractValidationError
+        _assert_triple_catch(OddContractValidationError, ValueError)
+
+    def test_orca_rvo2_preflight_error(self) -> None:
+        from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError
+        _assert_triple_catch(OrcaRvo2PreflightError, RuntimeError)
+
+    def test_release_gates_spec_error(self) -> None:
+        from robot_sf.benchmark.release_gates import ReleaseGateSpecError
+        _assert_triple_catch(ReleaseGateSpecError, ValueError)
+
+    def test_release_preflight_error(self) -> None:
+        from robot_sf.benchmark.release_preflight import ReleasePreflightError
+        _assert_triple_catch(ReleasePreflightError, ValueError)
+
+    def test_visualization_error_is_robot_sf_error(self) -> None:
+        from robot_sf.benchmark.visualization import VisualizationError
+        assert issubclass(VisualizationError, RobotSfError)
+        assert issubclass(VisualizationError, Exception)
+
+    def test_multi_planner_overlay_error_is_robot_sf_error(self) -> None:
+        from robot_sf.benchmark.multi_planner_overlay import MultiPlannerOverlayError
+        assert issubclass(MultiPlannerOverlayError, RobotSfError)
+        assert issubclass(MultiPlannerOverlayError, Exception)
+
+    def test_snqi_weight_provenance_error(self) -> None:
+        from robot_sf.benchmark.snqi.weights_inventory import SNQIWeightProvenanceError
+        _assert_triple_catch(SNQIWeightProvenanceError, RuntimeError)
+
+    def test_provenance_validation_error_hierarchy(self) -> None:
+        """ProvenanceValidationError and its children are all RobotSfError."""
+        from robot_sf.benchmark.result_provenance import (
+            ProvenanceArtifactError,
+            ProvenanceRequiredFieldError,
+            ProvenanceRowLinkError,
+            ProvenanceValidationError,
+        )
+        for cls in (
+            ProvenanceValidationError,
+            ProvenanceRequiredFieldError,
+            ProvenanceArtifactError,
+            ProvenanceRowLinkError,
+        ):
+            assert issubclass(cls, RobotSfError), f"{cls.__name__} not RobotSfError"
+            assert issubclass(cls, ValueError), f"{cls.__name__} not ValueError"
+
+    def test_provenance_subclasses_still_caught_by_parent(self) -> None:
+        from robot_sf.benchmark.result_provenance import (
+            ProvenanceRequiredFieldError,
+            ProvenanceValidationError,
+        )
+        with pytest.raises(ProvenanceValidationError):
+            raise ProvenanceRequiredFieldError("required field absent")
+
+    def test_benchmark_errors_catchable_by_robot_sf_error(self) -> None:
+        from robot_sf.benchmark.benchmark_claim import BenchmarkClaimError
+        with pytest.raises(RobotSfError):
+            raise BenchmarkClaimError("invalid claim")
+
+    def test_benchmark_runtime_errors_catchable_by_robot_sf_error(self) -> None:
+        from robot_sf.benchmark.near_miss_ttc import NearMissTtcInputError
+        with pytest.raises(RobotSfError):
+            raise NearMissTtcInputError("bad input")
+
+    def test_benchmark_runtime_errors_legacy_catch_preserved(self) -> None:
+        from robot_sf.benchmark.campaign_checkpoint_preflight import (
+            CampaignCheckpointPreflightError,
+        )
+        with pytest.raises(RuntimeError):
+            raise CampaignCheckpointPreflightError("preflight failed")
+
+
+# ---------------------------------------------------------------------------
+# common
+# ---------------------------------------------------------------------------
+
+
+class TestCommonExceptions:
+    def test_unsafe_pickle_error(self) -> None:
+        from robot_sf.common.safe_pickle import UnsafePickleError
+        _assert_triple_catch(UnsafePickleError, RuntimeError)
+
+    def test_unsafe_pickle_error_catchable_by_robot_sf_error(self) -> None:
+        from robot_sf.common.safe_pickle import UnsafePickleError
+        with pytest.raises(RobotSfError):
+            raise UnsafePickleError("unsafe pickle detected")
+
+    def test_unsafe_pickle_error_legacy_catch_preserved(self) -> None:
+        from robot_sf.common.safe_pickle import UnsafePickleError
+        with pytest.raises(RuntimeError):
+            raise UnsafePickleError("unsafe pickle detected")
+
+
+# ---------------------------------------------------------------------------
+# data_ingestion
+# ---------------------------------------------------------------------------
+
+
+class TestDataIngestionExceptions:
+    def test_contract_error(self) -> None:
+        from robot_sf.data_ingestion.real_trajectory_contract import ContractError
+        _assert_triple_catch(ContractError, RuntimeError)
+
+    def test_contract_error_catchable_by_robot_sf_error(self) -> None:
+        from robot_sf.data_ingestion.real_trajectory_contract import ContractError
+        with pytest.raises(RobotSfError):
+            raise ContractError("contract violated")
+
+    def test_contract_error_legacy_catch_preserved(self) -> None:
+        from robot_sf.data_ingestion.real_trajectory_contract import ContractError
+        with pytest.raises(RuntimeError):
+            raise ContractError("contract violated")
+
+
+# ---------------------------------------------------------------------------
+# examples
+# ---------------------------------------------------------------------------
+
+
+class TestExamplesExceptions:
+    def test_manifest_validation_error(self) -> None:
+        from robot_sf.examples.manifest_loader import ManifestValidationError
+        _assert_triple_catch(ManifestValidationError, ValueError)
+
+    def test_manifest_validation_error_catchable_by_robot_sf_error(self) -> None:
+        from robot_sf.examples.manifest_loader import ManifestValidationError
+        with pytest.raises(RobotSfError):
+            raise ManifestValidationError("manifest invalid")
+
+
+# ---------------------------------------------------------------------------
+# nav
+# ---------------------------------------------------------------------------
+
+
+class TestNavExceptions:
+    def test_footprint_orientation_config_error(self) -> None:
+        from robot_sf.nav.footprint_diagnostic import FootprintOrientationConfigError
+        _assert_triple_catch(FootprintOrientationConfigError, ValueError)
+
+    def test_footprint_error_catchable_by_robot_sf_error(self) -> None:
+        from robot_sf.nav.footprint_diagnostic import FootprintOrientationConfigError
+        with pytest.raises(RobotSfError):
+            raise FootprintOrientationConfigError("bad config")
+
+
+# ---------------------------------------------------------------------------
+# planner
+# ---------------------------------------------------------------------------
+
+
+class TestPlannerExceptions:
+    def test_planning_error_is_robot_sf_error(self) -> None:
+        from robot_sf.planner.classic_global_planner import PlanningError
+        assert issubclass(PlanningError, RobotSfError)
+        assert issubclass(PlanningError, Exception)
+
+    def test_planning_failed_error_is_robot_sf_error(self) -> None:
+        from robot_sf.planner.visibility_planner import PlanningFailedError
+        assert issubclass(PlanningFailedError, RobotSfError)
+        assert issubclass(PlanningFailedError, Exception)
+
+    def test_learned_policy_adapter_contract_error(self) -> None:
+        from robot_sf.planner.learned_policy_adapter import LearnedPolicyAdapterContractError
+        _assert_triple_catch(LearnedPolicyAdapterContractError, ValueError)
+
+    def test_risk_surface_unavailable(self) -> None:
+        from robot_sf.planner.learned_risk_surface import RiskSurfaceUnavailable
+        _assert_triple_catch(RiskSurfaceUnavailable, ValueError)
+
+    def test_lidar_occupancy_adapter_error(self) -> None:
+        from robot_sf.planner.lidar_occupancy import LidarOccupancyAdapterError
+        _assert_triple_catch(LidarOccupancyAdapterError, ValueError)
+
+    def test_obstacle_feature_schema_error(self) -> None:
+        from robot_sf.planner.obstacle_features import ObstacleFeatureSchemaError
+        _assert_triple_catch(ObstacleFeatureSchemaError, ValueError)
+
+    def test_planning_error_catchable_by_robot_sf_error(self) -> None:
+        from robot_sf.planner.classic_global_planner import PlanningError
+        with pytest.raises(RobotSfError):
+            raise PlanningError("no path found")
+
+    def test_risk_surface_unavailable_legacy_catch(self) -> None:
+        from robot_sf.planner.learned_risk_surface import RiskSurfaceUnavailable
+        with pytest.raises(ValueError):
+            raise RiskSurfaceUnavailable("surface missing")
+
+
+# ---------------------------------------------------------------------------
+# research (individual files)
+# ---------------------------------------------------------------------------
+
+
+class TestResearchIndividualFileExceptions:
+    def test_amv_trace_manifest_error(self) -> None:
+        from robot_sf.research.amv_command_response_trace_manifest import AmvTraceManifestError
+        _assert_triple_catch(AmvTraceManifestError, ValueError)
+
+    def test_scenario_prior_staging_contract_error(self) -> None:
+        from robot_sf.research.scenario_prior_staging_contract import (
+            ScenarioPriorStagingContractError,
+        )
+        _assert_triple_catch(ScenarioPriorStagingContractError, ValueError)
+
+    def test_research_individual_errors_catchable_by_robot_sf_error(self) -> None:
+        from robot_sf.research.amv_command_response_trace_manifest import AmvTraceManifestError
+        with pytest.raises(RobotSfError):
+            raise AmvTraceManifestError("trace manifest invalid")
+
+
+# ---------------------------------------------------------------------------
+# training
+# ---------------------------------------------------------------------------
+
+
+class TestTrainingExceptions:
+    def test_learned_risk_campaign_readiness_error(self) -> None:
+        from robot_sf.training.learned_risk_campaign_readiness import (
+            LearnedRiskCampaignReadinessError,
+        )
+        _assert_triple_catch(LearnedRiskCampaignReadinessError, ValueError)
+
+    def test_learned_risk_launch_packet_error(self) -> None:
+        from robot_sf.training.learned_risk_launch_packet import LearnedRiskLaunchPacketError
+        _assert_triple_catch(LearnedRiskLaunchPacketError, ValueError)
+
+    def test_learned_risk_trace_manifest_error(self) -> None:
+        from robot_sf.training.learned_risk_trace_manifest import LearnedRiskTraceManifestError
+        _assert_triple_catch(LearnedRiskTraceManifestError, ValueError)
+
+    def test_launch_packet_error(self) -> None:
+        from robot_sf.training.oracle_imitation_launch_packet import LaunchPacketError
+        _assert_triple_catch(LaunchPacketError, ValueError)
+
+    def test_warm_start_readiness_error_hierarchy(self) -> None:
+        from robot_sf.training.oracle_imitation_warm_start_readiness import (
+            PrerequisitesNotReadyError,
+            WarmStartReadinessError,
+        )
+        assert issubclass(WarmStartReadinessError, RobotSfError)
+        assert issubclass(WarmStartReadinessError, ValueError)
+        # Subclass is covered transitively
+        assert issubclass(PrerequisitesNotReadyError, RobotSfError)
+        assert issubclass(PrerequisitesNotReadyError, ValueError)
+        assert issubclass(PrerequisitesNotReadyError, WarmStartReadinessError)
+
+    def test_prerequisites_not_ready_caught_by_warm_start_readiness(self) -> None:
+        from robot_sf.training.oracle_imitation_warm_start_readiness import (
+            PrerequisitesNotReadyError,
+            WarmStartReadinessError,
+        )
+        with pytest.raises(WarmStartReadinessError):
+            raise PrerequisitesNotReadyError("prerequisites missing")
+
+    def test_oracle_trace_uri_registry_error(self) -> None:
+        from robot_sf.training.oracle_trace_uri_registry import OracleTraceUriRegistryError
+        _assert_triple_catch(OracleTraceUriRegistryError, ValueError)
+
+    def test_predictive_retraining_readiness_error(self) -> None:
+        from robot_sf.training.predictive_retraining_readiness import (
+            PredictiveRetrainingReadinessError,
+        )
+        _assert_triple_catch(PredictiveRetrainingReadinessError, ValueError)
+
+    def test_shielded_ppo_launch_packet_error(self) -> None:
+        from robot_sf.training.shielded_ppo_launch_packet import ShieldedPPOLaunchPacketError
+        _assert_triple_catch(ShieldedPPOLaunchPacketError, ValueError)
+
+    def test_training_errors_catchable_by_robot_sf_error(self) -> None:
+        from robot_sf.training.learned_risk_trainer import LearnedRiskTrainerError
+        with pytest.raises(RobotSfError):
+            raise LearnedRiskTrainerError("training failed")
+
+    def test_training_errors_legacy_catch_preserved(self) -> None:
+        from robot_sf.training.orca_residual_lineage_packet import OrcaResidualLineagePacketError
+        with pytest.raises(ValueError):
+            raise OrcaResidualLineagePacketError("lineage error")


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Re-parents 76 ad-hoc exception classes across 9 subpackages (`analysis_workbench`, `benchmark` individual files, `common`, `data_ingestion`, `examples`, `nav`, `planner`, `research`, `training`) onto `RobotSfError` while preserving every existing `ValueError` / `RuntimeError` / `Exception` ancestry. Closes #4993.

**Why now:** PRs #5073 (base + benchmark/errors.py), #5180 (research/exceptions.py), and #5192 (external-data loaders) established the pattern; this PR applies it exhaustively to all remaining families.

**Claim boundary:** Behavior-preserving refactor only — no semantic change to any exception message, constructor, or catch semantics.

**Required validation:** `uv run pytest tests/test_robot_sf_error_migration_4993.py -v` → 59 passed. `uv run ruff check robot_sf/ tests/test_robot_sf_error_migration_4993.py scripts/dev/migrate_exceptions_4993.py` → 0 issues.

**Remaining blocker:** None — #4880-owned `except` narrowing is explicitly out of scope for this PR.

## Contract delta

New: every listed exception class additionally satisfies `issubclass(E, RobotSfError)`.
Preserved: all existing `except ValueError`, `except RuntimeError`, `except Exception`, and `except SpecificError` clauses continue to match unchanged.

Migration rules applied:
- `class Foo(ValueError)` → `class Foo(RobotSfError, ValueError)`
- `class Foo(RuntimeError)` → `class Foo(RobotSfError, RuntimeError)`
- `class Foo(Exception)` → `class Foo(RobotSfError)`
- Classes that inherit a custom parent already migrated → no change (covered transitively)

## Validation results

```
uv run pytest tests/test_robot_sf_error_migration_4993.py -v
59 passed in 3.45s

uv run ruff check robot_sf/ tests/test_robot_sf_error_migration_4993.py scripts/dev/migrate_exceptions_4993.py
All checks passed!

uv run ruff format --check robot_sf/ tests/test_robot_sf_error_migration_4993.py scripts/dev/migrate_exceptions_4993.py
695 files already formatted

uv run python -m compileall -q robot_sf scripts/dev/migrate_exceptions_4993.py
```

## Out of scope

- No full benchmark campaign run
- No Slurm/GPU submission
- No paper/dissertation claim edits
- `except` narrowing (#4880)

## Integration proof (fragmentation gate)

The parent accumulated the three cohesive guardrail slices #5073, #5180, and #5192 within 24 hours. This PR is the integration proof for the remaining application exception families.

- Blockers remaining: none for the `RobotSfError` hierarchy migration.
- New blockers: none found by the exhaustive source audit (95 application `*Error` / `*Exception` classes now reach `RobotSfError`, excluding the base itself).
- Intentional boundary: existing `except` clauses remain unchanged; their narrowing is owned by #4880.
- Next empirical action: #4880 should narrow eligible broad catches using this shared hierarchy and run its own targeted catch-path tests. This refactor has no benchmark or simulator claim requiring an empirical campaign.

## State propagation

PR fully resolves #4993 after merge. The parent issue receives a durable completion update before merge; no follow-up slice is needed for the hierarchy migration itself.

## Friction issues

None filed (`friction_issues: []`). The one issue hit (import insertion breaking mid-file multi-line imports) was a bug in the one-shot migration helper I wrote; fixed in the same session, not a pre-existing repo defect.

Closes #4993
