### PR TITLE
fix(reporting): restore Python 3.11 parsing for result-card LaTeX rendering (#5202)

### DIFF
--- a/scripts/reporting/generate_result_card.py
+++ b/scripts/reporting/generate_result_card.py
@@ -341,7 +341,9 @@ def render_latex_table(card: ResultCard) -> str:
     """Render a compact LaTeX tabular snippet for the metric list."""
     rows = ["\\begin{tabular}{ll}", "Metric & Value \\\\", "\\hline"]
     for key, value in card.metrics.items():
-        rows.append(f"{key.replace('_', '\\_')} & {str(value).replace('_', '\\_')} \\\\")
+        escaped_key = key.replace("_", "\\_")
+        escaped_value = str(value).replace("_", "\\_")
+        rows.append(f"{escaped_key} & {escaped_value} \\\\")
     rows.append("\\end{tabular}")
     return "\n".join(rows) + "\n"
 

--- a/tests/reporting/test_generate_result_card.py
+++ b/tests/reporting/test_generate_result_card.py
@@ -53,6 +53,27 @@ def test_generates_forecast_result_card_with_latex(tmp_path: Path) -> None:
     assert "\\begin{tabular}" in latex
 
 
+def test_render_latex_table_escapes_underscores() -> None:
+    """LaTeX metric cells escape underscores without f-string expressions."""
+    card = cards.ResultCard(
+        title="Synthetic",
+        source_summary="summary.json",
+        evidence_tier="smoke",
+        decision="diagnostic",
+        comparator="baseline",
+        claim_boundary="Synthetic renderer regression test.",
+        metrics={"metric_key": "value_with_underscore"},
+        commands=["python script.py"],
+        artifacts=["summary.json"],
+        caveats=["Synthetic fixture."],
+        non_transfer_notes=[],
+    )
+
+    latex = cards.render_latex_table(card)
+
+    assert "metric\\_key & value\\_with\\_underscore \\\\" in latex
+
+
 def test_generates_runtime_result_card_from_count_metrics(tmp_path: Path) -> None:
     """Runtime evidence summaries expose useful count/status metrics."""
     cards.main(


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** moved metric-key and metric-value underscore escaping out of the
LaTeX row f-string expression, and added a direct renderer regression test.

**Why now:** the prior expression is invalid Python 3.11 syntax, which blocks the
broad-exception readiness parser even though Python 3.12+ accepts it.

**Claim boundary:** this restores parser compatibility and preserves the existing
LaTeX output; it makes no benchmark, metric, or research claim.

**Required validation:** Python 3.11 compile/import plus the reporting tests and
the broad-exception ratchet passed locally; the final repository readiness gate
also passed.

**Remaining blocker:** none for [issue #5202](https://github.com/ll7/robot_sf_ll7/issues/5202).

Closes #5202

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: restores Python 3.11 parsing; rendered metric rows retain
  the same underscore escaping.

<details>
<summary>Scope, validation, and governance appendix</summary>

## Linked Issues

- Closes #5202

## Scope

- Refs: https://github.com/ll7/robot_sf_ll7/issues/5202
- Changed only `render_latex_table()` and its focused reporting test.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no
  paper/dissertation claim edits.

## Validation / Proof

- `uv sync --all-extras --python 3.11`
- `.venv/bin/python -m py_compile scripts/reporting/generate_result_card.py`
- `.venv/bin/python -m pytest tests/reporting/test_generate_result_card.py -q`
  — 12 passed.
- `.venv/bin/python scripts/validation/check_broad_exceptions.py` — passed with
  170 entries.
- `.venv/bin/ruff check scripts/reporting/generate_result_card.py tests/reporting/test_generate_result_card.py`
  — passed.
- `.venv/bin/ruff format --check scripts/reporting/generate_result_card.py tests/reporting/test_generate_result_card.py`
  — passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  — 2,184 passed, 1 skipped; changed-file coverage, docstring, and broad-exception
  gates passed.

## Research and downstream propagation

- Research result guidance: NA — support fix with no evidence interpretation.
- Domain-aware approval: not required — no benchmark, metric, schema, or
  paper-facing contract changed.
- Falsification/non-transfer and next empirical action: NA — no research result.
- Artifacts: generated `output/coverage/` and `output/validation/` remain ignored,
  local validation caches; no artifact is committed.
- State propagation: no issue-state comment was added because this task explicitly
  disallows issue/PR comments; closure is carried by `Closes #5202` in this PR.
- Downstream propagation: not applicable — no durable evidence or registry surface
  changed.

## Risks / rollout

- Risk is limited to this renderer; the added test asserts escaped key/value output
  and the Python 3.11 compile/import path.
- Rollback is a one-commit revert with no data or schema migration.

## Follow-up issues

- None. The GitHub CLI Projects Classic issue-read failure encountered during this
  work is already tracked by
  https://github.com/ll7/robot_sf_ll7/issues/5186 and
  https://github.com/ll7/robot_sf_ll7/issues/5188, so no duplicate friction issue
  was opened.

</details>
