### PR TITLE
feat(benchmark): complete scenario-generation MVP (#4932)

### DIFF
--- a/configs/benchmarks/scenario_generation_mvp.yaml
+++ b/configs/benchmarks/scenario_generation_mvp.yaml
@@ -1,0 +1,23 @@
+schema_version: data-driven-scenario-generation.v1
+seed: 4932
+source_scenarios: configs/scenarios/sets/classic_cross_trap_subset.yaml
+episode_budget: 2
+sampler:
+  type: monte_carlo
+  robot_start_goal_policy: sampled_map_route_pairs
+  pedestrian_policy: sampled_map_routes_and_population
+  obstacle_policy: disabled_for_mvp
+  episode_seed_min: 1
+  episode_seed_max: 2147483647
+runner:
+  algo: goal
+  algo_config: null
+  horizon: 20
+  dt: null
+extraction:
+  pre_margin_s: 1.0
+  post_margin_s: 1.0
+deduplication:
+  distance_threshold: 1.0
+output_root: output/issue_4932_generation_mvp
+claim_boundary: generated scenario hypotheses only

--- a/robot_sf/benchmark/scenario_generation/catalog_writer.py
+++ b/robot_sf/benchmark/scenario_generation/catalog_writer.py
@@ -1,0 +1,199 @@
+"""Aggregate and deterministically deduplicate generated scenario hypotheses."""
+
+from __future__ import annotations
+
+import json
+import math
+from copy import deepcopy
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from robot_sf.benchmark.scenario_generation.catalog_schema import validate_catalog_entry
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+CATALOG_SCHEMA_VERSION = "generated-scenario-catalog.v1"
+DEDUP_SCHEMA_VERSION = "generated-scenario-dedup.v1"
+
+
+def deduplicate_catalog_entries(
+    entries: Sequence[Mapping[str, Any]],
+    *,
+    distance_threshold: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Keep the most critical exemplar in each nearby deterministic feature group.
+
+    Grouping uses source map, criticality signal, and actor count.  Within a
+    group, the feature distance combines closest-approach location and robot
+    route orientation.  For minimum clearance, a smaller value is more critical.
+
+    Returns:
+        Kept entries and dropped-duplicate provenance records.
+    """
+
+    if not isinstance(distance_threshold, int | float) or isinstance(distance_threshold, bool):
+        raise ValueError("distance_threshold must be a finite number")
+    distance_threshold = float(distance_threshold)
+    if not math.isfinite(distance_threshold) or distance_threshold < 0.0:
+        raise ValueError("distance_threshold must be finite and >= 0")
+
+    ordered = sorted((deepcopy(dict(entry)) for entry in entries), key=_stable_order_key)
+    kept: list[dict[str, Any]] = []
+    dropped: list[dict[str, Any]] = []
+    for candidate in ordered:
+        validate_catalog_entry(candidate)
+        duplicate_index = next(
+            (
+                index
+                for index, exemplar in enumerate(kept)
+                if _dedup_group(candidate) == _dedup_group(exemplar)
+                and _feature_distance(candidate, exemplar) <= distance_threshold
+            ),
+            None,
+        )
+        if duplicate_index is None:
+            kept.append(candidate)
+            continue
+
+        exemplar = kept[duplicate_index]
+        if _criticality_rank(candidate) < _criticality_rank(exemplar):
+            kept[duplicate_index] = candidate
+            dropped.append(_dropped_record(exemplar, candidate, distance_threshold))
+        else:
+            dropped.append(_dropped_record(candidate, exemplar, distance_threshold))
+
+    kept.sort(key=lambda entry: entry["scenario_id"])
+    dropped.sort(key=lambda record: record["dropped_scenario_id"])
+    return kept, dropped
+
+
+def write_generated_catalog(
+    output_root: Path,
+    entries: Sequence[Mapping[str, Any]],
+    *,
+    dropped_duplicates: Sequence[Mapping[str, Any]],
+    run_manifest_path: Path,
+) -> tuple[Path, Path]:
+    """Write a generated-only catalog and one-entry-per-row provenance sidecar.
+
+    Returns:
+        Paths to the YAML catalog and JSON provenance sidecar.
+    """
+
+    output_root.mkdir(parents=True, exist_ok=True)
+    normalized = [deepcopy(dict(entry)) for entry in entries]
+    for entry in normalized:
+        validate_catalog_entry(entry)
+    catalog_path = output_root / "generated_catalog.yaml"
+    provenance_path = output_root / "generated_catalog.provenance.json"
+    catalog = {
+        "schema_version": CATALOG_SCHEMA_VERSION,
+        "metadata": {
+            "source": "auto_generated",
+            "required_manual_review": True,
+            "benchmark_evidence": False,
+            "claim_boundary": "generated scenario hypotheses only",
+            "release_matrix_inclusion": False,
+        },
+        "entries": normalized,
+        "deduplication": {
+            "schema_version": DEDUP_SCHEMA_VERSION,
+            "dropped_count": len(dropped_duplicates),
+            "dropped": [dict(record) for record in dropped_duplicates],
+        },
+    }
+    catalog_path.write_text(yaml.safe_dump(catalog, sort_keys=True), encoding="utf-8")
+    provenance = {
+        "schema_version": "generated-scenario-catalog-provenance.v1",
+        "claim_boundary": "generated scenario hypotheses only",
+        "run_manifest": run_manifest_path.as_posix(),
+        "entries": [
+            {
+                "scenario_id": entry["scenario_id"],
+                "source_episode_id": entry["source_episode"]["episode_id"],
+                "source_seed": entry["source_episode"]["source_seed"],
+                "source_map": entry["source_episode"]["source_map"],
+                "replay_status": entry["replay"]["status"],
+            }
+            for entry in normalized
+        ],
+    }
+    provenance_path.write_text(
+        json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return catalog_path, provenance_path
+
+
+def _stable_order_key(entry: Mapping[str, Any]) -> tuple[float, str]:
+    return (_criticality_rank(entry), str(entry.get("scenario_id", "")))
+
+
+def _criticality_rank(entry: Mapping[str, Any]) -> float:
+    return float(entry["criticality"]["source_metrics"]["min_clearance_m"])
+
+
+def _critical_frame(entry: Mapping[str, Any]) -> Mapping[str, Any]:
+    observed_at = float(entry["criticality"]["observed_at_s"])
+    return min(
+        entry["segment"]["trace_frames"],
+        key=lambda frame: abs(float(frame["time_s"]) - observed_at),
+    )
+
+
+def _dedup_group(entry: Mapping[str, Any]) -> tuple[str, str, int]:
+    frame = _critical_frame(entry)
+    return (
+        Path(entry["source_episode"]["source_map"]).stem,
+        str(entry["criticality"]["signal"]),
+        len(frame["pedestrians"]),
+    )
+
+
+def _feature_vector(entry: Mapping[str, Any]) -> tuple[float, float, float, float]:
+    frames = entry["segment"]["trace_frames"]
+    critical = _critical_frame(entry)
+    x, y = (float(value) for value in critical["robot"]["position"])
+    start = frames[0]["robot"]["position"]
+    end = frames[-1]["robot"]["position"]
+    dx = float(end[0]) - float(start[0])
+    dy = float(end[1]) - float(start[1])
+    norm = math.hypot(dx, dy)
+    if norm == 0.0:
+        return x, y, 0.0, 0.0
+    return x, y, dx / norm, dy / norm
+
+
+def _feature_distance(left: Mapping[str, Any], right: Mapping[str, Any]) -> float:
+    left_feature = _feature_vector(left)
+    right_feature = _feature_vector(right)
+    return math.dist(left_feature, right_feature)
+
+
+def _dropped_record(
+    dropped: Mapping[str, Any],
+    kept: Mapping[str, Any],
+    threshold: float,
+) -> dict[str, Any]:
+    return {
+        "dropped_scenario_id": dropped["scenario_id"],
+        "kept_scenario_id": kept["scenario_id"],
+        "reason": "near_duplicate_lower_criticality",
+        "feature_distance": _feature_distance(dropped, kept),
+        "distance_threshold": threshold,
+        "group": {
+            "source_map_family": _dedup_group(dropped)[0],
+            "criticality_signal": _dedup_group(dropped)[1],
+            "actor_count": _dedup_group(dropped)[2],
+        },
+    }
+
+
+__all__ = [
+    "CATALOG_SCHEMA_VERSION",
+    "DEDUP_SCHEMA_VERSION",
+    "deduplicate_catalog_entries",
+    "write_generated_catalog",
+]

--- a/robot_sf/benchmark/scenario_generation/pipeline.py
+++ b/robot_sf/benchmark/scenario_generation/pipeline.py
@@ -1,0 +1,339 @@
+"""CPU-only stage 1--3 data-driven scenario-generation pipeline."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.map_runner import run_map_batch
+from robot_sf.benchmark.scenario_generation.catalog_writer import (
+    deduplicate_catalog_entries,
+    write_generated_catalog,
+)
+from robot_sf.benchmark.scenario_generation.random_sampler import (
+    SampledEpisode,
+    sample_episode_jobs,
+)
+from robot_sf.benchmark.scenario_generation.replay_validation import assess_replay_status
+from robot_sf.benchmark.scenario_generation.segment_extraction import extract_critical_segment
+from robot_sf.training.scenario_loader import load_scenarios
+
+CONFIG_SCHEMA_VERSION = "data-driven-scenario-generation.v1"
+RUN_SCHEMA_VERSION = "scenario-generation-run.v1"
+CLAIM_BOUNDARY = "generated scenario hypotheses only"
+_EPISODE_SCHEMA = Path("robot_sf/benchmark/schemas/episode.schema.v1.json")
+
+
+def load_generation_config(path: Path) -> dict[str, Any]:
+    """Load and fail closed on the small stage-1 configuration contract.
+
+    Returns:
+        The validated YAML configuration as a mutable mapping.
+    """
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("scenario-generation config must be a mapping")
+    config = dict(payload)
+    _validate_generation_contract(config)
+    return config
+
+
+def _validate_generation_contract(config: Mapping[str, Any]) -> None:
+    """Validate top-level identity plus each nested configuration section."""
+
+    if config.get("schema_version") != CONFIG_SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {CONFIG_SCHEMA_VERSION!r}")
+    if config.get("claim_boundary") != CLAIM_BOUNDARY:
+        raise ValueError(f"claim_boundary must be {CLAIM_BOUNDARY!r}")
+    _required_string(config, "source_scenarios")
+    _required_int(config, "seed")
+    if _required_int(config, "episode_budget") <= 0:
+        raise ValueError("episode_budget must be > 0")
+    _validate_sampler_config(config.get("sampler"))
+    _validate_runner_config(config.get("runner"))
+    _validate_dedup_config(config.get("deduplication"))
+
+
+def _validate_sampler_config(raw_sampler: object) -> None:
+    """Validate the conservative Monte Carlo sampler contract."""
+
+    sampler = raw_sampler
+    if not isinstance(sampler, Mapping) or sampler.get("type") != "monte_carlo":
+        raise ValueError("sampler.type must be 'monte_carlo'")
+    if sampler.get("obstacle_policy") != "disabled_for_mvp":
+        raise ValueError("sampler.obstacle_policy must be 'disabled_for_mvp'")
+
+
+def _validate_runner_config(raw_runner: object) -> None:
+    """Validate the bounded existing-runner configuration."""
+
+    runner = raw_runner
+    if not isinstance(runner, Mapping):
+        raise ValueError("runner must be a mapping")
+    if not isinstance(runner.get("horizon"), int) or runner["horizon"] <= 0:
+        raise ValueError("runner.horizon must be a positive integer")
+    if not isinstance(runner.get("algo"), str) or not runner["algo"].strip():
+        raise ValueError("runner.algo must be a non-empty string")
+
+
+def _validate_dedup_config(raw_dedup: object) -> None:
+    """Validate deterministic feature-distance deduplication controls."""
+
+    dedup = raw_dedup
+    if not isinstance(dedup, Mapping):
+        raise ValueError("deduplication must be a mapping")
+    threshold = dedup.get("distance_threshold")
+    if not isinstance(threshold, int | float) or isinstance(threshold, bool):
+        raise ValueError("deduplication.distance_threshold must be numeric")
+
+
+def run_generation_pipeline(
+    config_path: Path,
+    *,
+    output_root: Path | None = None,
+    scenario_loader: Callable[[Path], Sequence[Mapping[str, Any]]] = load_scenarios,
+    batch_runner: Callable[..., Mapping[str, Any]] = run_map_batch,
+    replay_config_builder: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    """Run seeded sampling, trace distillation, deduplication, and load validation.
+
+    Returns:
+        The persisted run manifest payload.
+    """
+
+    config = load_generation_config(config_path)
+    output_root = output_root or Path(_required_string(config, "output_root"))
+    _prepare_output_root(output_root)
+    source_path = Path(_required_string(config, "source_scenarios"))
+    source_scenarios = list(scenario_loader(source_path))
+    sampler = dict(config["sampler"])
+    sampled = sample_episode_jobs(
+        source_scenarios,
+        seed=int(config["seed"]),
+        episode_budget=int(config["episode_budget"]),
+        episode_seed_min=int(sampler.get("episode_seed_min", 1)),
+        episode_seed_max=int(sampler.get("episode_seed_max", 2_147_483_647)),
+    )
+    sampled_matrix_path = output_root / "sampled_scenarios.yaml"
+    sampled_matrix_path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "generated-scenario-sample-matrix.v1",
+                "claim_boundary": CLAIM_BOUNDARY,
+                "scenarios": [sample.scenario for sample in sampled],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    episodes_path = output_root / "episodes.jsonl"
+    runner_config = dict(config["runner"])
+    summary = dict(
+        batch_runner(
+            [sample.scenario for sample in sampled],
+            episodes_path,
+            _EPISODE_SCHEMA,
+            scenario_path=source_path,
+            horizon=int(runner_config["horizon"]),
+            dt=runner_config.get("dt"),
+            record_forces=False,
+            algo=str(runner_config["algo"]),
+            algo_config_path=runner_config.get("algo_config"),
+            benchmark_profile="experimental",
+            workers=1,
+            resume=False,
+            record_simulation_step_trace=True,
+        )
+    )
+    if int(summary.get("failed_jobs", 0)) or int(summary.get("written", 0)) != len(sampled):
+        raise RuntimeError(
+            "map runner did not produce every sampled episode: "
+            f"written={summary.get('written')} expected={len(sampled)} "
+            f"failures={summary.get('failures')}"
+        )
+
+    records = _load_jsonl(episodes_path)
+    records_by_name = {str(record["scenario_id"]): record for record in records}
+    source_by_name = {_source_scenario_name(scenario): scenario for scenario in source_scenarios}
+    extraction = dict(config.get("extraction") or {})
+    entries: list[dict[str, Any]] = []
+    outcomes: list[dict[str, Any]] = []
+    for sample in sampled:
+        materialized_name = str(sample.scenario["name"])
+        if materialized_name not in records_by_name:
+            raise RuntimeError(f"missing map-runner record for {materialized_name}")
+        record = records_by_name[materialized_name]
+        trace_episode = _distiller_episode(record, sample)
+        entry = extract_critical_segment(
+            trace_episode,
+            pre_margin_s=float(extraction.get("pre_margin_s", 1.0)),
+            post_margin_s=float(extraction.get("post_margin_s", 1.0)),
+        )
+        replay_kwargs: dict[str, Any] = {}
+        if replay_config_builder is not None:
+            replay_kwargs["config_builder"] = replay_config_builder
+        entry = assess_replay_status(
+            entry,
+            source_scenario=source_by_name[sample.source_scenario_name],
+            scenario_path=source_path,
+            **replay_kwargs,
+        )
+        entries.append(entry)
+        outcomes.append(_outcome_record(record, sample, trace_episode["steps"]))
+
+    outcomes_path = output_root / "episode_outcomes.jsonl"
+    _write_jsonl(outcomes_path, outcomes)
+    kept, dropped = deduplicate_catalog_entries(
+        entries,
+        distance_threshold=float(config["deduplication"]["distance_threshold"]),
+    )
+    run_manifest_path = output_root / "run_manifest.json"
+    catalog_path, provenance_path = write_generated_catalog(
+        output_root,
+        kept,
+        dropped_duplicates=dropped,
+        run_manifest_path=run_manifest_path,
+    )
+    manifest = {
+        "schema_version": RUN_SCHEMA_VERSION,
+        "seed": int(config["seed"]),
+        "sampler": "monte_carlo.v1",
+        "source_scenarios": source_path.as_posix(),
+        "episode_count": len(sampled),
+        "claim_boundary": CLAIM_BOUNDARY,
+        "sampled_parameters": [sample.manifest_record() for sample in sampled],
+        "sampling_policies": {
+            "robot_start_goal_policy": sampler.get("robot_start_goal_policy"),
+            "pedestrian_policy": sampler.get("pedestrian_policy"),
+            "obstacle_policy": sampler.get("obstacle_policy"),
+        },
+        "runner_summary": summary,
+        "catalog": {
+            "candidate_count": len(entries),
+            "kept_count": len(kept),
+            "dropped_duplicate_count": len(dropped),
+        },
+        "artifacts": {
+            "sampled_scenarios": sampled_matrix_path.as_posix(),
+            "episodes": episodes_path.as_posix(),
+            "episode_outcomes": outcomes_path.as_posix(),
+            "generated_catalog": catalog_path.as_posix(),
+            "catalog_provenance": provenance_path.as_posix(),
+        },
+        "governance": {
+            "required_manual_review": True,
+            "benchmark_evidence": False,
+            "release_matrix_inclusion": False,
+        },
+    }
+    run_manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+def _prepare_output_root(output_root: Path) -> None:
+    if output_root.exists() and any(output_root.iterdir()):
+        raise FileExistsError(f"output_root must be empty: {output_root}")
+    output_root.mkdir(parents=True, exist_ok=True)
+
+
+def _required_string(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value.strip()
+
+
+def _required_int(payload: Mapping[str, Any], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
+def _source_scenario_name(scenario: Mapping[str, Any]) -> str:
+    return _required_string(scenario, "name")
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        record = json.loads(line)
+        if not isinstance(record, dict):
+            raise ValueError(f"{path}:{line_number} must contain a JSON object")
+        records.append(record)
+    return records
+
+
+def _write_jsonl(path: Path, records: Sequence[Mapping[str, Any]]) -> None:
+    path.write_text(
+        "".join(json.dumps(dict(record), sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def _distiller_episode(record: Mapping[str, Any], sample: SampledEpisode) -> dict[str, Any]:
+    metadata = record.get("algorithm_metadata")
+    trace = metadata.get("simulation_step_trace") if isinstance(metadata, Mapping) else None
+    if not isinstance(trace, Mapping) or trace.get("schema_version") != "simulation-step-trace.v1":
+        raise ValueError("episode record is missing simulation-step-trace.v1")
+    steps = trace.get("steps")
+    if not isinstance(steps, list) or not steps:
+        raise ValueError("episode record has no simulation trace steps")
+    return {
+        "episode_id": _required_string(record, "episode_id"),
+        "seed": int(record["seed"]),
+        "source_map": sample.source_map,
+        "steps": steps,
+    }
+
+
+def _criticality_series(steps: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    series: list[dict[str, Any]] = []
+    for step in steps:
+        robot = step["robot"]["position"]
+        peds = step["pedestrians"]
+        clearances = [math.dist(robot, pedestrian["position"]) for pedestrian in peds]
+        series.append(
+            {
+                "time_s": float(step["time_s"]),
+                "min_clearance_m": min(clearances) if clearances else None,
+            }
+        )
+    return series
+
+
+def _outcome_record(
+    record: Mapping[str, Any],
+    sample: SampledEpisode,
+    steps: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "scenario-generation-episode-outcome.v1",
+        "sample": sample.manifest_record(),
+        "episode_id": record["episode_id"],
+        "status": record.get("status"),
+        "termination_reason": record.get("termination_reason"),
+        "metrics": record.get("metrics", {}),
+        "criticality_time_series": _criticality_series(steps),
+        "benchmark_evidence": False,
+    }
+
+
+__all__ = [
+    "CLAIM_BOUNDARY",
+    "CONFIG_SCHEMA_VERSION",
+    "RUN_SCHEMA_VERSION",
+    "load_generation_config",
+    "run_generation_pipeline",
+]

--- a/robot_sf/benchmark/scenario_generation/pipeline.py
+++ b/robot_sf/benchmark/scenario_generation/pipeline.py
@@ -89,8 +89,13 @@ def _validate_dedup_config(raw_dedup: object) -> None:
     if not isinstance(dedup, Mapping):
         raise ValueError("deduplication must be a mapping")
     threshold = dedup.get("distance_threshold")
-    if not isinstance(threshold, int | float) or isinstance(threshold, bool):
-        raise ValueError("deduplication.distance_threshold must be numeric")
+    if (
+        not isinstance(threshold, int | float)
+        or isinstance(threshold, bool)
+        or not math.isfinite(float(threshold))
+        or threshold < 0
+    ):
+        raise ValueError("deduplication.distance_threshold must be finite and >= 0")
 
 
 def run_generation_pipeline(

--- a/robot_sf/benchmark/scenario_generation/random_sampler.py
+++ b/robot_sf/benchmark/scenario_generation/random_sampler.py
@@ -1,0 +1,127 @@
+"""Deterministically sample source scenarios and episode seeds for generation runs."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SampledEpisode:
+    """One reproducible map-runner job selected by the Monte Carlo sampler."""
+
+    sample_index: int
+    source_scenario_name: str
+    source_map: str
+    episode_seed: int
+    scenario: dict[str, Any]
+
+    def manifest_record(self) -> dict[str, Any]:
+        """Return all random choices needed to reproduce this sampled job."""
+
+        return {
+            "sample_index": self.sample_index,
+            "source_scenario_name": self.source_scenario_name,
+            "source_map": self.source_map,
+            "episode_seed": self.episode_seed,
+            "materialized_scenario_name": self.scenario["name"],
+        }
+
+
+def sample_episode_jobs(
+    scenarios: Sequence[Mapping[str, Any]],
+    *,
+    seed: int,
+    episode_budget: int,
+    episode_seed_min: int = 1,
+    episode_seed_max: int = 2_147_483_647,
+) -> list[SampledEpisode]:
+    """Sample scenario templates and unique runtime seeds with a local RNG.
+
+    The source scenario's map routes remain the start/goal and pedestrian-route
+    proposal space.  The sampled episode seed drives the existing map runner's
+    route, point-of-interest, and population randomization.
+
+    Returns:
+        Materialized one-seed scenario jobs in deterministic sample order.
+    """
+
+    if not isinstance(seed, int) or isinstance(seed, bool):
+        raise ValueError("seed must be an integer")
+    if not isinstance(episode_budget, int) or isinstance(episode_budget, bool):
+        raise ValueError("episode_budget must be an integer")
+    if episode_budget <= 0:
+        raise ValueError("episode_budget must be > 0")
+    if episode_seed_min < 0 or episode_seed_max < episode_seed_min:
+        raise ValueError("episode seed range must be non-negative and ordered")
+
+    candidates = [dict(scenario) for scenario in scenarios if _is_supported(scenario)]
+    if not candidates:
+        raise ValueError("source scenario set contains no supported scenarios")
+    seed_capacity = episode_seed_max - episode_seed_min + 1
+    if episode_budget > seed_capacity:
+        raise ValueError("episode_budget exceeds the unique episode-seed range")
+
+    rng = random.Random(seed)
+    used_seeds: set[int] = set()
+    sampled: list[SampledEpisode] = []
+    for sample_index in range(episode_budget):
+        source = candidates[rng.randrange(len(candidates))]
+        source_name = _scenario_name(source)
+        source_map = _source_map(source)
+        episode_seed = rng.randint(episode_seed_min, episode_seed_max)
+        while episode_seed in used_seeds:
+            episode_seed = rng.randint(episode_seed_min, episode_seed_max)
+        used_seeds.add(episode_seed)
+
+        materialized = deepcopy(source)
+        materialized["name"] = f"generated-sample-{sample_index:04d}-{source_name}"
+        materialized["seeds"] = [episode_seed]
+        metadata = dict(materialized.get("metadata") or {})
+        metadata["scenario_generation"] = {
+            "source": "auto_generated",
+            "required_manual_review": True,
+            "benchmark_evidence": False,
+            "source_scenario_name": source_name,
+            "sample_index": sample_index,
+        }
+        materialized["metadata"] = metadata
+        sampled.append(
+            SampledEpisode(
+                sample_index=sample_index,
+                source_scenario_name=source_name,
+                source_map=source_map,
+                episode_seed=episode_seed,
+                scenario=materialized,
+            )
+        )
+    return sampled
+
+
+def _is_supported(scenario: Mapping[str, Any]) -> bool:
+    metadata = scenario.get("metadata")
+    return scenario.get("supported") is not False and not (
+        isinstance(metadata, Mapping) and metadata.get("supported") is False
+    )
+
+
+def _scenario_name(scenario: Mapping[str, Any]) -> str:
+    value = scenario.get("name") or scenario.get("id")
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("every source scenario must have a non-empty name or id")
+    return value.strip()
+
+
+def _source_map(scenario: Mapping[str, Any]) -> str:
+    value = scenario.get("map_file") or scenario.get("map_id")
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"source scenario '{_scenario_name(scenario)}' has no map reference")
+    value = value.strip()
+    return Path(value).as_posix() if Path(value).is_absolute() else value
+
+
+__all__ = ["SampledEpisode", "sample_episode_jobs"]

--- a/robot_sf/benchmark/scenario_generation/replay_validation.py
+++ b/robot_sf/benchmark/scenario_generation/replay_validation.py
@@ -1,0 +1,51 @@
+"""Record explicit replay/load status for generated scenario hypotheses."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.scenario_generation.catalog_schema import validate_catalog_entry
+from robot_sf.training.scenario_loader import build_robot_config_from_scenario
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+    from pathlib import Path
+
+
+def assess_replay_status(
+    entry: Mapping[str, Any],
+    *,
+    source_scenario: Mapping[str, Any],
+    scenario_path: Path,
+    config_builder: Callable[..., Any] = build_robot_config_from_scenario,
+) -> dict[str, Any]:
+    """Load-check the source scenario and preserve the exact-state replay gap.
+
+    A successful source load is recorded as a warning detail, but the generated
+    segment remains ``not_representable_yet`` until a standalone scenario can be
+    constructed.  Source-template loading does not prove segment replay.
+
+    Returns:
+        A validated copy of the entry with an explicit replay status.
+    """
+
+    updated = deepcopy(dict(entry))
+    try:
+        config_builder(source_scenario, scenario_path=scenario_path)
+    except (OSError, RuntimeError, TypeError, ValueError, NotImplementedError) as exc:
+        updated["replay"]["status"] = "not_representable_yet"
+        updated["replay"]["warnings"] = [
+            f"replay_gap: source scenario load failed: {type(exc).__name__}: {exc}"
+        ]
+    else:
+        updated["replay"]["status"] = "not_representable_yet"
+        updated["replay"]["warnings"] = [
+            "replay_gap: source scenario load passed, but distilled mid-episode state is not "
+            "representable as standalone scenario YAML"
+        ]
+    validate_catalog_entry(updated)
+    return updated
+
+
+__all__ = ["assess_replay_status"]

--- a/scripts/benchmark/run_data_driven_scenario_generation.py
+++ b/scripts/benchmark/run_data_driven_scenario_generation.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Run the review-pending data-driven scenario-generation MVP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.scenario_generation.pipeline import run_generation_pipeline
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sample CPU map episodes, distill critical windows, and write a generated-only "
+            "scenario hypothesis catalog. This does not update benchmark release matrices."
+        )
+    )
+    parser.add_argument("--config", type=Path, required=True, help="Tracked MVP YAML config")
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=None,
+        help="Override the config output directory; it must be empty",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the configured pipeline and print its compact artifact summary."""
+
+    args = _parse_args(argv)
+    manifest = run_generation_pipeline(args.config, output_root=args.output_root)
+    print(
+        json.dumps(
+            {
+                "status": "complete",
+                "claim_boundary": manifest["claim_boundary"],
+                "episode_count": manifest["episode_count"],
+                "catalog": manifest["catalog"],
+                "artifacts": manifest["artifacts"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_data_driven_scenario_generation.py
+++ b/tests/benchmark/test_data_driven_scenario_generation.py
@@ -12,7 +12,10 @@ import yaml
 from robot_sf.benchmark.scenario_generation.catalog_writer import (
     deduplicate_catalog_entries,
 )
-from robot_sf.benchmark.scenario_generation.pipeline import run_generation_pipeline
+from robot_sf.benchmark.scenario_generation.pipeline import (
+    load_generation_config,
+    run_generation_pipeline,
+)
 from robot_sf.benchmark.scenario_generation.random_sampler import sample_episode_jobs
 from robot_sf.benchmark.scenario_generation.replay_validation import assess_replay_status
 from robot_sf.benchmark.scenario_generation.segment_extraction import extract_critical_segment
@@ -276,3 +279,23 @@ def test_pipeline_refuses_to_mix_with_existing_output(tmp_path: Path) -> None:
 
     with pytest.raises(FileExistsError, match="must be empty"):
         run_generation_pipeline(config_path)
+
+
+def test_generation_config_rejects_negative_deduplication_threshold(tmp_path: Path) -> None:
+    """A negative threshold fails before it can silently disable deduplication."""
+
+    config = {
+        "schema_version": "data-driven-scenario-generation.v1",
+        "seed": 4932,
+        "source_scenarios": "unused.yaml",
+        "episode_budget": 1,
+        "sampler": {"type": "monte_carlo", "obstacle_policy": "disabled_for_mvp"},
+        "runner": {"algo": "goal", "horizon": 1},
+        "deduplication": {"distance_threshold": -0.1},
+        "claim_boundary": "generated scenario hypotheses only",
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be finite and >= 0"):
+        load_generation_config(config_path)

--- a/tests/benchmark/test_data_driven_scenario_generation.py
+++ b/tests/benchmark/test_data_driven_scenario_generation.py
@@ -1,0 +1,278 @@
+"""CPU-only tests for issue #4932's stage 1--3 generation MVP."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.scenario_generation.catalog_writer import (
+    deduplicate_catalog_entries,
+)
+from robot_sf.benchmark.scenario_generation.pipeline import run_generation_pipeline
+from robot_sf.benchmark.scenario_generation.random_sampler import sample_episode_jobs
+from robot_sf.benchmark.scenario_generation.replay_validation import assess_replay_status
+from robot_sf.benchmark.scenario_generation.segment_extraction import extract_critical_segment
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _source_scenarios() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "crossing-low",
+            "map_file": "maps/svg_maps/classic_crossing.svg",
+            "simulation_config": {"ped_density": 0.02},
+            "metadata": {"archetype": "crossing"},
+        },
+        {
+            "name": "crossing-high",
+            "map_file": "maps/svg_maps/classic_crossing.svg",
+            "simulation_config": {"ped_density": 0.08},
+            "metadata": {"archetype": "crossing"},
+        },
+    ]
+
+
+def _trace_episode(
+    episode_id: str,
+    *,
+    clearance_m: float,
+    offset_x: float = 0.0,
+) -> dict[str, Any]:
+    return {
+        "episode_id": episode_id,
+        "seed": 4932,
+        "source_map": "maps/svg_maps/classic_crossing.svg",
+        "steps": [
+            {
+                "time_s": 0.0,
+                "robot": {"position": [offset_x, 0.0]},
+                "pedestrians": [{"position": [offset_x + 3.0, 0.0]}],
+            },
+            {
+                "time_s": 1.0,
+                "robot": {"position": [offset_x + 1.0, 0.0]},
+                "pedestrians": [{"position": [offset_x + 1.0 + clearance_m, 0.0]}],
+            },
+            {
+                "time_s": 2.0,
+                "robot": {"position": [offset_x + 2.0, 0.0]},
+                "pedestrians": [{"position": [offset_x + 5.0, 0.0]}],
+            },
+        ],
+    }
+
+
+def test_fixed_seed_produces_identical_sampled_scenarios() -> None:
+    """The sampler owns a local RNG and records every selected random parameter."""
+
+    first = sample_episode_jobs(_source_scenarios(), seed=4932, episode_budget=8)
+    second = sample_episode_jobs(_source_scenarios(), seed=4932, episode_budget=8)
+
+    assert [sample.manifest_record() for sample in first] == [
+        sample.manifest_record() for sample in second
+    ]
+    assert [sample.scenario for sample in first] == [sample.scenario for sample in second]
+    assert len({sample.episode_seed for sample in first}) == 8
+    assert all(
+        sample.scenario["metadata"]["scenario_generation"]["benchmark_evidence"] is False
+        for sample in first
+    )
+
+
+def test_dedup_keeps_higher_criticality_near_duplicate() -> None:
+    """Nearby features retain the smaller-clearance exemplar with a reason record."""
+
+    less_critical = extract_critical_segment(
+        _trace_episode("episode-less", clearance_m=0.6, offset_x=0.2)
+    )
+    more_critical = extract_critical_segment(
+        _trace_episode("episode-more", clearance_m=0.2, offset_x=0.0)
+    )
+
+    kept, dropped = deduplicate_catalog_entries(
+        [less_critical, more_critical], distance_threshold=1.0
+    )
+
+    assert [entry["scenario_id"] for entry in kept] == [more_critical["scenario_id"]]
+    assert dropped == [
+        {
+            "dropped_scenario_id": less_critical["scenario_id"],
+            "kept_scenario_id": more_critical["scenario_id"],
+            "reason": "near_duplicate_lower_criticality",
+            "feature_distance": pytest.approx(0.2),
+            "distance_threshold": 1.0,
+            "group": {
+                "source_map_family": "classic_crossing",
+                "criticality_signal": "min_clearance",
+                "actor_count": 1,
+            },
+        }
+    ]
+
+
+def test_replay_status_distinguishes_source_load_from_exact_replay(tmp_path: Path) -> None:
+    """A source loader pass cannot promote an unrepresentable generated segment."""
+
+    entry = extract_critical_segment(_trace_episode("episode-load", clearance_m=0.2))
+    loaded = assess_replay_status(
+        entry,
+        source_scenario=_source_scenarios()[0],
+        scenario_path=tmp_path / "source.yaml",
+        config_builder=lambda *_args, **_kwargs: object(),
+    )
+
+    assert loaded["replay"]["status"] == "not_representable_yet"
+    assert loaded["replay"]["warnings"][0].startswith("replay_gap:")
+    assert "source scenario load passed" in loaded["replay"]["warnings"][0]
+    assert "not representable" in loaded["replay"]["warnings"][0]
+
+
+def test_replay_status_records_loader_failure_without_overclaim(tmp_path: Path) -> None:
+    """An unrepresentable source records the concrete loader failure."""
+
+    def fail_loader(*_args: Any, **_kwargs: Any) -> None:
+        raise ValueError("bad map reference")
+
+    entry = extract_critical_segment(_trace_episode("episode-fail", clearance_m=0.2))
+    failed = assess_replay_status(
+        entry,
+        source_scenario=_source_scenarios()[0],
+        scenario_path=tmp_path / "source.yaml",
+        config_builder=fail_loader,
+    )
+
+    assert failed["replay"]["status"] == "not_representable_yet"
+    assert "bad map reference" in failed["replay"]["warnings"][0]
+
+
+def test_pipeline_writes_deterministic_hypothesis_catalog_and_provenance(
+    tmp_path: Path,
+) -> None:
+    """One CLI-level function joins sampling, distillation, catalog, and replay status."""
+
+    config_path = tmp_path / "config.yaml"
+    output_root = tmp_path / "output"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "data-driven-scenario-generation.v1",
+                "seed": 4932,
+                "source_scenarios": "unused-source.yaml",
+                "episode_budget": 2,
+                "sampler": {
+                    "type": "monte_carlo",
+                    "robot_start_goal_policy": "sampled_map_route_pairs",
+                    "pedestrian_policy": "sampled_map_routes_and_population",
+                    "obstacle_policy": "disabled_for_mvp",
+                },
+                "runner": {"algo": "goal", "horizon": 3, "dt": 1.0},
+                "extraction": {"pre_margin_s": 1.0, "post_margin_s": 1.0},
+                "deduplication": {"distance_threshold": 0.0},
+                "output_root": output_root.as_posix(),
+                "claim_boundary": "generated scenario hypotheses only",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_batch_runner(
+        scenarios: list[dict[str, Any]], out_path: Path, *_args: Any, **_kwargs: Any
+    ) -> dict[str, Any]:
+        rows = []
+        for index, scenario in enumerate(scenarios):
+            seed = scenario["seeds"][0]
+            episode = _trace_episode(
+                f"episode-{index}", clearance_m=0.2 + index, offset_x=index * 10.0
+            )
+            steps = []
+            for step in episode["steps"]:
+                expanded = deepcopy(step)
+                expanded["robot"].update({"heading": 0.0, "velocity": [1.0, 0.0]})
+                steps.append(expanded)
+            rows.append(
+                {
+                    "episode_id": episode["episode_id"],
+                    "scenario_id": scenario["name"],
+                    "seed": seed,
+                    "status": "failure",
+                    "termination_reason": "timeout",
+                    "metrics": {"min_distance": 0.2 + index},
+                    "algorithm_metadata": {
+                        "simulation_step_trace": {
+                            "schema_version": "simulation-step-trace.v1",
+                            "steps": steps,
+                        }
+                    },
+                }
+            )
+        out_path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+        return {
+            "total_jobs": len(rows),
+            "written": len(rows),
+            "successful_jobs": len(rows),
+            "failed_jobs": 0,
+            "failures": [],
+        }
+
+    manifest = run_generation_pipeline(
+        config_path,
+        scenario_loader=lambda _path: _source_scenarios(),
+        batch_runner=fake_batch_runner,
+        replay_config_builder=lambda *_args, **_kwargs: object(),
+    )
+
+    catalog = yaml.safe_load((output_root / "generated_catalog.yaml").read_text())
+    provenance = json.loads((output_root / "generated_catalog.provenance.json").read_text())
+    outcomes = [
+        json.loads(line)
+        for line in (output_root / "episode_outcomes.jsonl").read_text().splitlines()
+    ]
+    assert manifest["schema_version"] == "scenario-generation-run.v1"
+    assert manifest["episode_count"] == 2
+    assert manifest["catalog"] == {
+        "candidate_count": 2,
+        "kept_count": 2,
+        "dropped_duplicate_count": 0,
+    }
+    assert catalog["metadata"] == {
+        "source": "auto_generated",
+        "required_manual_review": True,
+        "benchmark_evidence": False,
+        "claim_boundary": "generated scenario hypotheses only",
+        "release_matrix_inclusion": False,
+    }
+    assert all(entry["replay"]["status"] == "not_representable_yet" for entry in catalog["entries"])
+    assert all(entry["metadata"]["benchmark_evidence"] is False for entry in catalog["entries"])
+    assert all(outcome["benchmark_evidence"] is False for outcome in outcomes)
+    assert all(outcome["criticality_time_series"] for outcome in outcomes)
+    assert len(provenance["entries"]) == 2
+
+
+def test_pipeline_refuses_to_mix_with_existing_output(tmp_path: Path) -> None:
+    """Existing output fails closed instead of mixing run provenance."""
+
+    output_root = tmp_path / "output"
+    output_root.mkdir()
+    (output_root / "old-run.json").write_text("{}", encoding="utf-8")
+    config = {
+        "schema_version": "data-driven-scenario-generation.v1",
+        "seed": 1,
+        "source_scenarios": "unused.yaml",
+        "episode_budget": 1,
+        "sampler": {"type": "monte_carlo", "obstacle_policy": "disabled_for_mvp"},
+        "runner": {"algo": "goal", "horizon": 1},
+        "deduplication": {"distance_threshold": 1.0},
+        "output_root": output_root.as_posix(),
+        "claim_boundary": "generated scenario hypotheses only",
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="must be empty"):
+        run_generation_pipeline(config_path)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** completes the stage 1–3 minimum viable pipeline over PR #4962's distiller: deterministic source-scenario/seed sampling, native map-runner trace capture, critical-window extraction, generated-only catalog aggregation, deterministic feature deduplication, and explicit replay-gap status.
- **Why now:** PR #4962 established the trace-to-entry contract; this progression slice connects the remaining CPU-only components end to end without introducing a simulator loop or touching release matrices.
- **Claim boundary:** generated entries are hypotheses requiring manual review, always carry `benchmark_evidence: false`, and remain `not_representable_yet` even when their pinned source scenario passes the production loader. This is software smoke evidence, not benchmark or research-result evidence.
- **Required validation:** review the map-runner trace adapter, sampled-parameter manifest, lower-clearance dedup retention, and the distinction between source-loader success and standalone replay. Focused tests, two real CPU smokes, repeat determinism, and the final repository readiness gate are reported below.
- **Remaining blocker:** exact mid-episode state reconstruction as standalone scenario YAML and criticality-reproduction campaigns remain future sophistication; they are not claimed by this MVP.

## Contract delta

- **New contracts:** `data-driven-scenario-generation.v1` config, `scenario-generation-run.v1` manifest, `scenario-generation-episode-outcome.v1` outcome rows with per-step minimum clearance, `generated-scenario-catalog.v1`, `generated-scenario-dedup.v1`, and `generated-scenario-catalog-provenance.v1`.
- **New fail-closed blockers:** invalid sampler/runner/dedup config, no supported source scenarios, non-unique seed capacity, non-empty output roots, missing native `simulation-step-trace.v1`, incomplete/failed map-runner batches, missing sampled episode rows, and invalid catalog entries abort the pipeline.
- **Replay classification:** the production loader is exercised against each pinned source scenario; both source-load pass and failure retain `not_representable_yet` plus a concrete `replay_gap` warning because no standalone distilled scenario is asserted.
- **Compatibility impact:** additive namespace/config/script only. Hand-authored scenario schemas, release and paper matrices, benchmark gates, metric semantics, and existing distillation entry schema are unchanged.

## Linked issue and scope

Refs #4932 — https://github.com/ll7/robot_sf_ll7/issues/4932

The reversible MVP assumption is that existing scenario templates plus newly sampled episode seeds are the proposal space: the existing map runner performs route, point-of-interest, and pedestrian-population randomization. Independent obstacle perturbation is disabled. The pipeline consumes the runner's native trace and PR #4962's existing minimum-clearance distiller rather than adding another simulation or criticality implementation.

This is a nameable progression capability, not a micro-guard: one CLI now runs seeded generation through generated-catalog output end to end.

## Validation

- `uv run ruff check robot_sf/benchmark/scenario_generation scripts/benchmark/run_data_driven_scenario_generation.py tests/benchmark/test_data_driven_scenario_generation.py` — pass.
- `uv run ruff format --check robot_sf/benchmark/scenario_generation scripts/benchmark/run_data_driven_scenario_generation.py tests/benchmark/test_data_driven_scenario_generation.py` — pass.
- `uv run pytest tests/benchmark/test_generated_scenario_catalog.py tests/benchmark/test_data_driven_scenario_generation.py -q` — pass, 15 tests.
- `uv run python scripts/benchmark/run_data_driven_scenario_generation.py --help` — pass.
- Tracked two-episode CPU smoke using `configs/benchmarks/scenario_generation_mvp.yaml` — pass: 2/2 runner rows, 2 candidates kept, all entries `benchmark_evidence: false`, all source-loader checks passed, all replay statuses conservatively `not_representable_yet`.
- Repeated real CPU smoke — pass: `sampled_scenarios.yaml` and `generated_catalog.yaml` were byte-identical across independent output directories (SHA-256 `cc231fc…` and `b271313f…` for the first run before the replay-label tightening; focused tests and the final smoke cover the tightened status).
- `uv run python scripts/dev/check_docs_evidence_integrity.py --files docs/context/INDEX.md docs/context/issue_4932_data_driven_scenario_generation.md` — pass.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — interim pass: 2,184 passed, 1 skipped; Ruff/coverage/docstring/broad-exception gates passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue-4932-pr-body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — pass on committed `HEAD`: 6,433 passed, 17 skipped; changed-file coverage 86.2–100%, all above the 80% minimum; clean-tree freshness stamp recorded.

## Explicitly out of scope

- No full benchmark campaign run.
- No Slurm or GPU submission.
- No paper/dissertation claim edits.
- No importance/rare-event sampler, learned proposal model, exact mid-episode scenario-YAML reconstruction, certification/promotion into hand-authored families, or criticality-reproduction campaign.

## Follow-Up Issues

- #5203 — materialize generated critical segments as standalone replay scenarios and validate the
  exact entry → YAML → production-loader/CPU-runner path.
- #2921 — existing learned proposal model over a certified failure archive (future stage 5).
- Rare-event/importance-sampling campaign work remains outside this implementation PR; no campaign
  was submitted or promoted from the local smoke.

<details>
<summary>Governance, artifacts, propagation, and residual risk</summary>

### Evidence classification

- Target: prove the stage 1–3 software path can sample, execute, distill, deduplicate, and classify generated hypotheses reproducibly.
- Comparator/baseline: independent rerun with the same tracked seed/config for deterministic output comparison.
- Evidence tier: focused tests plus CPU smoke evidence.
- Result classification: implementation proof only; not benchmark evidence.
- Stop rule: every configured sample produces a native trace, outcome/criticality series, validated catalog candidate, provenance row, dedup decision, and explicit replay gap; any missing row/trace or failed job aborts.
- Fallback/degraded exclusions: no fallback or degraded benchmark row is presented as success. The generated entries themselves are explicitly non-evidence.

### Artifacts

Three ignored local `output/issue_4932_generation_mvp_*` smoke directories were inspected. Each contains small reproducible run-local JSONL/YAML/JSON artifacts (about 200 KiB total per run). They are disposable smoke output, not committed or cited as durable benchmark evidence; the tracked config and command reproduce them.

### Downstream propagation

- `docs/context/issue_4932_data_driven_scenario_generation.md` documents the command, outputs, statuses, and claim boundary; `docs/context/INDEX.md` links it.
- No release matrix, claim map, leaderboard, paper/dissertation surface, or artifact catalog is updated because this PR produces no promotable research result.
- Issue-state propagation is intentionally in this PR body only: issue/PR comment authorization is disabled for this task, so adding or editing an issue comment would exceed authority.

### Fragmentation guard

Only PR #4962 directly covered #4932 in the preceding 24 hours; the two-PR micro-guard threshold was not reached. This PR adds the integrated executable pipeline and is independently a progression slice.

### Residual risk

- Minimum clearance is the only distilled criticality signal supported by the merged v1 entry schema. Collision/near-miss/timeout remain in episode outcomes but are not selected as alternate distillation signals.
- Feature deduplication is deliberately simple (map family, signal, actor count, closest-approach position, and route orientation); it needs empirical tuning only after a larger generated archive exists.
- A passed source load proves only that the source template is constructible. Exact standalone segment replay and directional criticality reproduction remain unimplemented and explicitly labeled.

### Friction log

No friction issue filed. The two command corrections encountered (worktree bootstrap must run from its target directory; docs checker requires `--files`) were immediately explained by command usage and did not meet the actionable repository-friction threshold.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CPU-only, data-driven scenario generation MVP.
  * Added deterministic scenario sampling with reproducible episode seeds.
  * Added catalog generation with deduplication, provenance tracking, and replay-status reporting.
  * Added a command-line tool for running generation jobs and producing manifests and output artifacts.
  * Added a ready-to-use benchmark configuration.

* **Tests**
  * Added coverage for deterministic sampling, deduplication, replay validation, output generation, and output-directory safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->