### PR TITLE
fix(ci): repair main fast-feedback regressions (#5201)

### DIFF
--- a/robot_sf/benchmark/identity/hash_utils.py
+++ b/robot_sf/benchmark/identity/hash_utils.py
@@ -159,7 +159,10 @@ def read_jsonl(path: Path) -> list[dict[str, Any]]:
             line = raw.strip()
             if not line:
                 continue
-            record = json.loads(line)
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_no} is not valid JSON") from exc
             if not isinstance(record, dict):
                 raise ValueError(f"{path}:{line_no} is not a JSON object")
             records.append(record)

--- a/tests/benchmark/test_hash_utils_read_jsonl.py
+++ b/tests/benchmark/test_hash_utils_read_jsonl.py
@@ -11,8 +11,6 @@ explode later as ``AttributeError`` downstream.
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from robot_sf.benchmark.identity.hash_utils import read_jsonl
@@ -38,12 +36,10 @@ def test_read_jsonl_rejects_non_object_line_with_context(tmp_path):
     assert f"{path}:2" in message
 
 
-def test_read_jsonl_propagates_malformed_json(tmp_path):
-    """Malformed JSON keeps the standard json decode error (a ValueError subclass)."""
+def test_read_jsonl_rejects_malformed_json_with_context(tmp_path):
+    """Malformed JSON fails closed with the source path and line number."""
     path = tmp_path / "bad.jsonl"
     path.write_text('{"a": 1}\n{"b": oops}\n', encoding="utf-8")
 
-    # Malformed JSON keeps the standard json decode error (a ValueError subclass),
-    # matching the pre-consolidation behavior.
-    with pytest.raises(json.JSONDecodeError):
+    with pytest.raises(ValueError, match=r"bad\.jsonl:2 is not valid JSON"):
         read_jsonl(path)

--- a/tests/fixtures/optional_import_guards.json
+++ b/tests/fixtures/optional_import_guards.json
@@ -6,7 +6,7 @@
     "ModuleNotFoundError"
   ],
   "spelling_key": "Caught exception type names, sorted and joined by '+'. The 'as <alias>' name is intentionally NOT part of the key.",
-  "total_guards": 100,
+  "total_guards": 101,
   "spellings": {
     "AttributeError+ImportError": {
       "count_ceiling": 2,
@@ -56,7 +56,7 @@
       "blessed": true,
       "note": "Blessed broad catch: optional registry boundary.",
       "samples": [
-        "robot_sf/benchmark/cli.py:203"
+        "robot_sf/benchmark/cli.py:210"
       ]
     },
     "AttributeError+ImportError+OSError+RuntimeError+TypeError+ValueError": {
@@ -66,7 +66,7 @@
       "blessed": true,
       "note": "Blessed broad catch: defensive visualization ingest boundary.",
       "samples": [
-        "robot_sf/benchmark/visualization.py:466"
+        "robot_sf/benchmark/visualization.py:467"
       ]
     },
     "AttributeError+ImportError+RuntimeError": {
@@ -90,9 +90,9 @@
       ]
     },
     "ImportError": {
-      "count_ceiling": 71,
+      "count_ceiling": 70,
       "has_as_count": 14,
-      "pragma_no_cover_count": 24,
+      "pragma_no_cover_count": 23,
       "blessed": true,
       "note": "Pure optional-import. Prefer robot_sf.common.optional_import.try_import for new plain cases.",
       "samples": [
@@ -105,7 +105,7 @@
         "robot_sf/baselines/sac.py:14",
         "robot_sf/baselines/sicnav.py:420",
         "robot_sf/baselines/sicnav.py:298",
-        "robot_sf/benchmark/cli.py:191",
+        "robot_sf/benchmark/cli.py:198",
         "robot_sf/benchmark/distributions.py:131",
         "robot_sf/benchmark/episode_replay_figure.py:37",
         "robot_sf/benchmark/episode_replay_figure.py:50",
@@ -130,14 +130,15 @@
         "robot_sf/benchmark/full_classic/visual_deps.py:58",
         "robot_sf/benchmark/full_classic/visuals.py:49",
         "robot_sf/benchmark/helper_catalog.py:73",
-        "robot_sf/benchmark/live_forecast_replay_gate.py:953",
+        "robot_sf/benchmark/live_forecast_replay_gate.py:954",
+        "robot_sf/benchmark/near_miss_determinism.py:394",
         "robot_sf/benchmark/plots.py:28",
         "robot_sf/benchmark/runner.py:41",
         "robot_sf/benchmark/runner.py:47",
         "robot_sf/benchmark/scenario_generator.py:48",
         "robot_sf/benchmark/scenario_schema.py:25",
         "robot_sf/benchmark/schema_validator.py:20",
-        "robot_sf/benchmark/visualization.py:1189",
+        "robot_sf/benchmark/visualization.py:1190",
         "robot_sf/common/matplotlib_utils.py:62",
         "robot_sf/common/optional_import.py:80",
         "robot_sf/common/seed.py:47",
@@ -160,11 +161,9 @@
         "robot_sf/planner/socnav.py:69",
         "robot_sf/planner/socnav.py:3469",
         "robot_sf/planner/theta_star_v2.py:33",
-        "robot_sf/render/sim_view.py:34",
+        "robot_sf/render/sim_view.py:33",
         "robot_sf/sim/registry.py:145",
         "robot_sf/telemetry/gpu.py:11",
-        "robot_sf/telemetry/tensorboard_adapter.py:20",
-        "robot_sf/telemetry/tensorboard_adapter.py:23",
         "robot_sf/telemetry/visualization.py:100",
         "robot_sf/training/diffusion_policy.py:33"
       ]
@@ -176,10 +175,10 @@
       "blessed": true,
       "note": "Blessed broad catch: native-lib / filesystem load may raise OSError.",
       "samples": [
-        "robot_sf/benchmark/cli.py:3042",
-        "robot_sf/benchmark/cli.py:3076",
+        "robot_sf/benchmark/cli.py:3198",
+        "robot_sf/benchmark/cli.py:3232",
         "robot_sf/benchmark/full_classic/visual_deps.py:45",
-        "robot_sf/benchmark/orca_preflight.py:89"
+        "robot_sf/benchmark/orca_preflight.py:90"
       ]
     },
     "ImportError+OSError+RuntimeError+TypeError+ValueError+json.JSONDecodeError": {
@@ -203,16 +202,18 @@
       ]
     },
     "ImportError+RuntimeError": {
-      "count_ceiling": 5,
+      "count_ceiling": 7,
       "has_as_count": 0,
-      "pragma_no_cover_count": 2,
+      "pragma_no_cover_count": 3,
       "blessed": true,
       "note": "Blessed broad catch: guarded plotting / native-lib load may raise RuntimeError. Do not collapse to ImportError.",
       "samples": [
         "robot_sf/baselines/dr_mpc.py:187",
         "robot_sf/baselines/sicnav.py:344",
         "robot_sf/baselines/sicnav.py:530",
-        "robot_sf/benchmark/cli.py:3211",
+        "robot_sf/benchmark/cli.py:3367",
+        "robot_sf/telemetry/tensorboard_adapter.py:20",
+        "robot_sf/telemetry/tensorboard_adapter.py:26",
         "robot_sf/training/multi_extractor_analysis.py:22"
       ]
     },
@@ -235,7 +236,7 @@
       "blessed": true,
       "note": "Pure optional-import (ModuleNotFoundError spelling). Prefer robot_sf.common.optional_import.try_import for new plain cases.",
       "samples": [
-        "robot_sf/benchmark/parquet_export.py:18",
+        "robot_sf/benchmark/parquet_export.py:20",
         "robot_sf/common/hardware.py:129",
         "robot_sf/planner/learned_short_horizon_predictor.py:424",
         "robot_sf/planner/social_navigation_pyenvs_force_model.py:39",

--- a/tests/test_rollover_proxy.py
+++ b/tests/test_rollover_proxy.py
@@ -243,6 +243,7 @@ def _make_step_env(
     env._snqi_proxy = SimpleNamespace(compute_step_metrics=lambda *args, **kwargs: {})
     env.action_space = SimpleNamespace()
     env.last_action = None
+    env._action_latency_steps = 0
     env.reward_func = lambda _meta: 1.0
     env._telemetry_session = None
     env.recording_enabled = False
@@ -338,7 +339,7 @@ def test_robot_simulation_config_rollover_proxy_default_keeps_step_semantics() -
 
 def test_missing_rollover_config_attributes_keep_proxy_disabled() -> None:
     """Older/minimal config objects without rollover attributes stay compatible."""
-    env = _make_step_env(env_config=SimpleNamespace())
+    env = _make_step_env(env_config=SimpleNamespace(sim_config=EnvSettings().sim_config))
 
     _obs, reward, terminated, truncated, info = env.step(np.array([2.0, 2.0]))
 


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Repaired three deterministic fast-feedback failures: the rollover test fixture
now supplies the default zero-step action-latency setting; the optional-import inventory snapshot
matches the current tree; and the canonical JSONL reader preserves `path:line` context for malformed
input used by the debug-export CLI.

**Why now:** Main CI was failing on the rollover fixture and optional-import ratchet. The canonical
full test phase also exposed the JSONL diagnostic regression caused by the recent helper consolidation.

**Claim boundary:** Unit and CI-contract repair only. This does not make a benchmark, model, or
research-performance claim.

**Required validation:** The focused regression suite, Ruff checks, and the final PR-readiness gate
listed below.

**Remaining blocker:** None known.

## Contract delta

- `read_jsonl` now raises `ValueError("<path>:<line> is not valid JSON")` for malformed JSON, as
  its documented fail-closed contract states. Callers that caught the more specific
  `JSONDecodeError` should catch `ValueError` instead; repository callers are covered by the
  canonical regression tests.
- No schema fields or benchmark semantics change.
- The rollover test double explicitly represents the default zero-step action latency; the inventory
  snapshot records the currently blessed 101 guards, including the two justified telemetry guards.

## Linked issue

Closes #5201

## Validation / proof

- `uv run pytest tests/test_rollover_proxy.py tests/test_optional_import_guard_inventory.py tests/tools/test_rerun_debug_export.py tests/benchmark/test_hash_utils_read_jsonl.py -q` — passed.
- `uv run ruff check robot_sf/benchmark/identity/hash_utils.py tests/benchmark/test_hash_utils_read_jsonl.py tests/test_rollover_proxy.py` — passed.
- `uv run ruff format --check robot_sf/benchmark/identity/hash_utils.py tests/benchmark/test_hash_utils_read_jsonl.py tests/test_rollover_proxy.py` — passed.
- `PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — run after this body is prepared.

## Scope and propagation

- State propagation: no issue comment was added because this task does not authorize issue/PR comments; this PR’s closure link is the canonical visible state update.
- Downstream propagation: not applicable — this repairs CI/test contracts only and produces no benchmark or research evidence.
- Artifact decision: ignored `output/` files created by validation are disposable local test/cache artifacts and are not committed.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Implementation and governance appendix</summary>

The JSONL behavior restores diagnostics that the debug-export CLI had before the helper
consolidation. The existing CLI test and a canonical-reader test establish the boundary. Friction
found during validation is tracked separately in #5204; it is not part of this PR.

Research Result Guidance: NA — support/CI repair with no research claim.

Domain-Aware Approval: not required — no evidence classification, experimental comparison, or
paper-facing surface changes.

Falsification / Non-Transfer Check: NA — no measured research mechanism.

Next Empirical Action: NA — no missing empirical evidence.

</details>
