### PR TITLE
fix(examples): isolate fast-demo dataset export (#5204)

### DIFF
--- a/examples/plotting/data_analysis_example.py
+++ b/examples/plotting/data_analysis_example.py
@@ -13,6 +13,7 @@ Prerequisites:
 
 Expected Output:
     - Plots written under `robot_sf/data_analysis/plots`
+    - In smoke mode, JSON exports written under `output/examples/datasets/`
     - Console logs describing generated assets
 
 Limitations:
@@ -25,6 +26,7 @@ from pathlib import Path
 from loguru import logger
 
 from examples.demo_utils import fast_demo_enabled
+from robot_sf.common.artifact_paths import get_artifact_root
 from robot_sf.data_analysis.extract_json_from_pickle import (
     extract_timestamp,
     plot_all_data_json,
@@ -96,20 +98,15 @@ if __name__ == "__main__":
             recording_id = extract_timestamp(str(recording_path))
 
             if fast_demo_enabled():
-                dataset_dir = Path("examples/datasets")
-                if dataset_dir.exists():
-                    json_path = dataset_dir / f"{recording_id}.json"
-                    save_to_json(str(recording_path), str(json_path))
-                    logger.info(
-                        "Fast demo mode: exported JSON and skipped plotting "
-                        f"(recording_id={recording_id}, recording_path={recording_path}, "
-                        f"json_path={json_path})"
-                    )
-                else:
-                    raise RuntimeError(
-                        "Fast demo mode requires 'examples/datasets' to exist "
-                        f"(recording_id={recording_id}, recording_path={recording_path})"
-                    )
+                dataset_dir = get_artifact_root() / "examples" / "datasets"
+                dataset_dir.mkdir(parents=True, exist_ok=True)
+                json_path = dataset_dir / f"{recording_id}.json"
+                save_to_json(str(recording_path), str(json_path))
+                logger.info(
+                    "Fast demo mode: exported JSON and skipped plotting "
+                    f"(recording_id={recording_id}, recording_path={recording_path}, "
+                    f"json_path={json_path})"
+                )
             else:
                 show_from_json(str(recording_path), recording_id)
                 show_from_pkl(str(recording_path), recording_id)

--- a/tests/examples/test_examples_run.py
+++ b/tests/examples/test_examples_run.py
@@ -20,6 +20,8 @@ from robot_sf.examples.manifest_loader import ExampleManifest, ExampleScript, lo
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _MANIFEST: ExampleManifest = load_manifest(validate_paths=True)
 _CI_EXAMPLES: tuple[ExampleScript, ...] = tuple(_MANIFEST.iter_ci_enabled_examples())
+_DATA_ANALYSIS_EXAMPLE = _REPO_ROOT / "examples" / "plotting" / "data_analysis_example.py"
+_TRACKED_DATASET = _REPO_ROOT / "examples" / "datasets" / "2024-12-06_15-39-44.json"
 
 
 def _id(example: ExampleScript) -> str:
@@ -150,3 +152,26 @@ def test_example_runs_without_error(
 def test_manifest_has_ci_enabled_entries() -> None:
     """Test that the manifest contains at least one CI-enabled example, ensuring this smoke test is meaningful and not a false positive due to misconfiguration."""
     assert _CI_EXAMPLES, "Expected at least one CI-enabled example in manifest"
+
+
+def test_data_analysis_fast_demo_writes_to_artifact_root(
+    example_env: dict[str, str], tmp_path: Path
+) -> None:
+    """Keep the smoke export from rewriting the tracked example dataset."""
+    tracked_bytes = _TRACKED_DATASET.read_bytes()
+    artifact_root = tmp_path / "artifacts"
+    env = {**example_env, "ROBOT_SF_ARTIFACT_ROOT": str(artifact_root)}
+
+    completed = subprocess.run(
+        [sys.executable, str(_DATA_ANALYSIS_EXAMPLE)],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120.0,
+        check=False,
+    )
+
+    assert completed.returncode == 0, _tail(completed.stdout + "\n" + completed.stderr)
+    assert _TRACKED_DATASET.read_bytes() == tracked_bytes
+    assert (artifact_root / "examples" / "datasets" / _TRACKED_DATASET.name).is_file()


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** The CI fast-demo path for `examples/plotting/data_analysis_example.py` now writes its JSON export to the configured artifact root instead of the tracked `examples/datasets/` fixture. A subprocess regression test proves the fixture remains byte-identical and the temporary artifact is produced.

**Why now:** Issue #5204 reproduced the canonical fast-feedback lane removing the final newline from the tracked example dataset.

**Claim boundary:** This is a test-isolation and artifact-location repair only. It makes no benchmark, model, or research-performance claim.

**Required validation:** Focused regression test, Ruff checks, complete examples-smoke lane, and the final readiness gate listed below.

**Remaining blocker:** None known.

## Contract delta

- In fast-demo mode only, the data-analysis JSON export now goes to `<artifact-root>/examples/datasets/`; normal interactive behavior remains unchanged.
- The artifact root honors `ROBOT_SF_ARTIFACT_ROOT`, so smoke runs can isolate generated files in temporary storage.
- No schema fields, benchmark semantics, or compatibility contracts change.

## Linked issue

Closes #5204

https://github.com/ll7/robot_sf_ll7/issues/5204

## Validation / proof

- `uv run pytest tests/examples/test_examples_run.py::test_data_analysis_fast_demo_writes_to_artifact_root -q` — passed (1 test).
- `uv run ruff check examples/plotting/data_analysis_example.py tests/examples/test_examples_run.py` — passed.
- `uv run ruff format --check examples/plotting/data_analysis_example.py tests/examples/test_examples_run.py` — passed.
- `scripts/dev/ci_driver.sh examples-smoke` — passed (28 tests); the tracked dataset remained unchanged.
- `PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed after this PR body was prepared.

## Scope and propagation

- Scope: only the fast-demo data-analysis export path and its regression coverage.
- State propagation: no separate issue comment is needed because this PR fully resolves the low-churn issue and its closing link is the canonical durable linkage; issue comments are outside this task's authorization.
- Downstream propagation: not applicable because this is CI/example isolation work with no research evidence.
- Artifact decision: validation outputs under `output/` are ignored local artifacts and are not committed.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Implementation and governance appendix</summary>

The normal, non-fast-demo example path continues to write to its existing user-facing dataset location. Only the automated smoke path redirects generated JSON to the canonical artifact root. The regression test checks byte equality rather than merely a final newline, preventing any tracked-fixture mutation.

Research Result Guidance: NA — support/CI repair with no research claim.

Domain-Aware Approval: not required — no evidence classification, experimental comparison, or paper-facing surface changes.

Falsification / Non-Transfer Check: NA — no measured research mechanism.

Next Empirical Action: NA — no missing empirical evidence.

Friction: no new issue filed. The only friction encountered was the fresh-worktree optional-dependency gap, already tracked by #5178.

</details>
