### PR TITLE
fix(tooling): target an explicit bootstrap worktree (#5209)

### DIFF
--- a/scripts/dev/bootstrap_worktree.sh
+++ b/scripts/dev/bootstrap_worktree.sh
@@ -11,24 +11,26 @@
 # silently succeeding and leaving the caller without a working .venv.
 #
 # Usage:
-#   scripts/dev/bootstrap_worktree.sh [--extra NAME] [--no-symlink-machine] [--help|-h]
+#   scripts/dev/bootstrap_worktree.sh [--extra NAME] [--no-symlink-machine] [WORKTREE_DIR]
 #
 # Options:
 #   --extra NAME          Include an optional dependency extra (repeatable), such as training.
 #   --no-symlink-machine  Skip symlinking local.machine.md from the main checkout.
 #   -h, --help            Show this help and exit.
+#   WORKTREE_DIR          An explicit linked worktree to bootstrap.
 #
-# The script must be run from the root of the worktree to bootstrap.
-# Example:
-#   cd /path/to/robot_sf_ll7.worktrees/my-branch
+# The script normally bootstraps the current worktree. An explicit WORKTREE_DIR lets callers
+# bootstrap a newly created linked worktree from another checkout.
+# Examples:
 #   scripts/dev/bootstrap_worktree.sh
+#   scripts/dev/bootstrap_worktree.sh /path/to/robot_sf_ll7.worktrees/my-branch
 #   source .venv/bin/activate
 
 set -euo pipefail
 
 show_help() {
     cat <<'EOF'
-Usage: scripts/dev/bootstrap_worktree.sh [--extra NAME] [--no-symlink-machine] [--help|-h]
+Usage: scripts/dev/bootstrap_worktree.sh [--extra NAME] [--no-symlink-machine] [WORKTREE_DIR]
 
 Bootstrap a fresh linked Git worktree: run `uv venv .venv` and then, by default,
 `uv sync --all-extras`. Verify .venv/bin/python exists before returning. Fails
@@ -46,16 +48,20 @@ Options:
   --extra NAME          Include an optional dependency extra (repeatable), such as training.
   --no-symlink-machine  Skip symlinking local.machine.md from the main checkout.
   -h, --help            Show this help and exit.
+  WORKTREE_DIR          An explicit linked worktree to bootstrap.
 
-Run from the worktree root you want to bootstrap. Example:
+Without WORKTREE_DIR, run from the worktree root you want to bootstrap. To bootstrap an
+explicit linked worktree from another checkout, pass its path. Examples:
   cd ../robot_sf_ll7.worktrees/issue-1234-my-branch
   scripts/dev/bootstrap_worktree.sh --extra training
+  scripts/dev/bootstrap_worktree.sh ../robot_sf_ll7.worktrees/issue-1234-my-branch
   source .venv/bin/activate
 EOF
 }
 
 symlink_machine=1
 sync_extras=()
+worktree_dir=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --extra)
@@ -75,15 +81,35 @@ while [[ $# -gt 0 ]]; do
             show_help
             exit 0
             ;;
-        *)
+        -*)
             echo "bootstrap_worktree: unknown argument: $1" >&2
             show_help >&2
             exit 2
             ;;
+        *)
+            if [[ -n "$worktree_dir" ]]; then
+                echo "bootstrap_worktree: expected at most one WORKTREE_DIR" >&2
+                show_help >&2
+                exit 2
+            fi
+            worktree_dir="$1"
+            shift
+            ;;
     esac
 done
 
-repo_root="$(git rev-parse --show-toplevel)"
+if [[ -n "$worktree_dir" ]]; then
+    if [[ ! -d "$worktree_dir" ]]; then
+        echo "bootstrap_worktree: WORKTREE_DIR is not a directory: $worktree_dir" >&2
+        exit 2
+    fi
+    repo_root="$(git -C "$worktree_dir" rev-parse --show-toplevel 2>/dev/null)" || {
+        echo "bootstrap_worktree: WORKTREE_DIR is not a Git worktree: $worktree_dir" >&2
+        exit 2
+    }
+else
+    repo_root="$(git rev-parse --show-toplevel)"
+fi
 cd "$repo_root"
 
 # Derive the main checkout path from the git common dir.
@@ -96,6 +122,11 @@ main_repo_root="$(cd "$git_common_dir/.." && pwd)"
 is_linked=0
 if [[ "$git_common_dir" != "$repo_root/.git" ]]; then
     is_linked=1
+fi
+
+if [[ -n "$worktree_dir" && "$is_linked" -ne 1 ]]; then
+    echo "bootstrap_worktree: WORKTREE_DIR must be a linked Git worktree: $worktree_dir" >&2
+    exit 2
 fi
 
 # Symlink local.machine.md from the main checkout when requested and not already present.

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -1360,6 +1360,20 @@ def test_bootstrap_worktree_rejects_unknown_flag() -> None:
     assert "unknown argument" in result.stderr
 
 
+def test_bootstrap_worktree_rejects_multiple_worktree_directories() -> None:
+    """bootstrap_worktree.sh accepts at most one explicit worktree directory."""
+    result = subprocess.run(
+        [str(BOOTSTRAP_WORKTREE), "one", "two"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "expected at most one WORKTREE_DIR" in result.stderr
+
+
 def test_bootstrap_worktree_rejects_extra_without_name() -> None:
     """bootstrap_worktree.sh should reject an incomplete --extra option before syncing."""
     result = subprocess.run(
@@ -1459,6 +1473,107 @@ def test_bootstrap_worktree_forwards_repeatable_extras_to_uv_sync(tmp_path: Path
 
     assert result.returncode == 0, result.stderr
     assert captured_args.read_text(encoding="utf-8") == "sync --extra training --extra gpu\n"
+
+
+def test_bootstrap_worktree_targets_an_explicit_linked_worktree(tmp_path: Path) -> None:
+    """An explicit target runs the bootstrap flow in that linked worktree."""
+    main_repo = tmp_path / "main-repo"
+    linked_worktree = tmp_path / "linked-worktree"
+    script_dir = main_repo / "scripts" / "dev"
+    fake_bin = main_repo / "fake-bin"
+    captured_cwds = main_repo / "uv-cwds.txt"
+    script_dir.mkdir(parents=True)
+    fake_bin.mkdir()
+
+    script = script_dir / "bootstrap_worktree.sh"
+    script.write_text(BOOTSTRAP_WORKTREE.read_text(encoding="utf-8"), encoding="utf-8")
+    script.chmod(0o755)
+
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'printf "%s\\n" "$PWD" >> "$UV_CAPTURED_CWDS"',
+                'if [[ "$1" == "venv" ]]; then',
+                '  mkdir -p "$2/bin"',
+                '  printf "#!/usr/bin/env bash\\nexit 0\\n" > "$2/bin/python"',
+                '  chmod 0755 "$2/bin/python"',
+                "  exit 0",
+                "fi",
+                'if [[ "$1" == "sync" ]]; then',
+                "  exit 0",
+                "fi",
+                'echo "unexpected uv invocation: $*" >&2',
+                "exit 99",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    subprocess.run(["git", "init"], cwd=main_repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "agent@example.invalid"],
+        cwd=main_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Agent"],
+        cwd=main_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=main_repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "bootstrap target fixture"],
+        cwd=main_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "UV_CAPTURED_CWDS": str(captured_cwds),
+    }
+    non_linked_result = subprocess.run(
+        [str(script), "--no-symlink-machine", str(main_repo)],
+        cwd=main_repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert non_linked_result.returncode == 2
+    assert "must be a linked Git worktree" in non_linked_result.stderr
+    assert not captured_cwds.exists()
+
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "target-worktree", str(linked_worktree)],
+        cwd=main_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [str(script), "--no-symlink-machine", str(linked_worktree)],
+        cwd=main_repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (linked_worktree / ".venv" / "bin" / "python").is_file()
+    assert captured_cwds.read_text(encoding="utf-8") == f"{linked_worktree}\n{linked_worktree}\n"
 
 
 def test_bootstrap_worktree_creates_venv_before_sync() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `bootstrap_worktree.sh` now accepts one optional `WORKTREE_DIR` positional argument and runs its existing bootstrap flow in that linked worktree.

Why now: callers can bootstrap a newly created linked worktree from another checkout without changing directories first.

Claim boundary: this changes only the local developer-worktree helper; it makes no benchmark, metric, model, paper, or performance claim.

Required validation: the full bootstrap shell-contract module (77 tests), an actual explicit-target smoke invocation, Bash syntax validation, and the repository final readiness pipeline all pass.

Remaining blocker: none. The scope in #5209 is fully implemented.

## Contract delta

- New interface: `scripts/dev/bootstrap_worktree.sh [--extra NAME] [--no-symlink-machine] [WORKTREE_DIR]`.
- New fail-closed checks: an explicit path must exist, resolve to a Git checkout, and be a *linked* worktree; a second positional path exits 2.
- Compatibility: no-argument and existing option forms preserve their prior behavior.

Closes #5209

<details>
<summary>Implementation, validation, and governance appendix</summary>

## Scope and dependency

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5209
- Base dependency: none
- Required prior PRs: none
- Safe to review independently: yes
- Capability added: bootstrap an explicitly named linked worktree from another checkout.

## What changed

- Parse at most one non-option `WORKTREE_DIR` while preserving repeatable `--extra` options.
- Resolve the target with Git, reject non-directories, non-Git paths, and primary/non-linked checkouts before `uv` runs.
- Document the new syntax in the script help and add a shell-contract fixture proving both rejection and successful linked-target execution.

## Validation / proof

- `scripts/dev/bootstrap_worktree.sh --no-symlink-machine "$PWD"` — passed; explicit target synced and verified `.venv/bin/python`.
- `uv run pytest tests/test_ci_script_contract.py -k 'bootstrap_worktree' -q` — 13 passed.
- `uv run pytest tests/test_ci_script_contract.py -q` — 77 passed.
- `uv run ruff check tests/test_ci_script_contract.py` — passed.
- `uv run ruff format --check tests/test_ci_script_contract.py` — passed.
- `bash -n scripts/dev/bootstrap_worktree.sh` — passed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed after this body was supplied to the gate.

## Research result guidance

- Target claim / hypothesis / blocker: NA — local developer tooling only.
- Evidence tier: NA — no research claim.
- Result classification: NA — no research result.
- Domain-aware approval: not required — no benchmark, metric, evidence classification, or paper-facing surface changed.
- Falsification / non-transfer check: NA — no research result.
- Next empirical action: NA — support tooling scope is complete.

## Risks / rollout

- Compatibility risk: callers who previously supplied a stray non-option argument now receive explicit target validation instead of the prior generic unknown-argument error; this is the requested interface addition.
- Rollback: revert this commit to restore the no-positional-argument parser.

## Docs / provenance

- Updated documentation: script header and `--help` text.
- Assumption: the intended target is a Git linked worktree, as requested by #5209; primary checkouts remain invalid when passed explicitly.

## Downstream propagation

- Parent issue updated: no — the task authorization prohibits issue/PR comments, and no issue-state table exists.
- Claim map / benchmark report / leaderboard / registry / context index: NA — no research or evidence surface changed.
- Not applicable because: this is a self-contained local developer-helper behavior change.

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper or dissertation claim edits.

## Reviewer notes

- Verify that the explicit target path is checked before any environment mutation, and that no-argument invocation still targets the current checkout.
- No generated `output/` artifacts were created or retained.
</details>
