### PR TITLE
feat(planner): add opt-in DWA prediction scoring (#4983)

### DIFF
--- a/configs/algos/dwa_prediction_scoring.yaml
+++ b/configs/algos/dwa_prediction_scoring.yaml
@@ -1,5 +1,5 @@
-# Classical Dynamic Window Approach baseline. This is experimental/testing-only:
-# it is runnable for controlled evaluation but is not paper-facing benchmark evidence.
+# DWA with opt-in constant-velocity pedestrian prediction scoring. Experimental/testing-only:
+# this changes pedestrian clearance scoring, not benchmark or paper claim status.
 allow_testing_algorithms: true
 max_linear_speed: 1.0
 max_angular_speed: 1.2
@@ -21,5 +21,4 @@ heading_weight: 0.8
 clearance_weight: 1.2
 velocity_weight: 0.25
 progress_weight: 1.0
-# Opt-in only: the base DWA scores pedestrians at their observed positions.
-prediction_scoring_enabled: false
+prediction_scoring_enabled: true

--- a/docs/baselines/dwa.md
+++ b/docs/baselines/dwa.md
@@ -37,6 +37,32 @@ The implementation is deterministic: it does not sample random commands, and tie
 the fixed command lattice order. Its parameters are documented in
 [`configs/algos/dwa_classic.yaml`](../../configs/algos/dwa_classic.yaml).
 
+## Optional constant-velocity prediction scoring
+
+[`configs/algos/dwa_prediction_scoring.yaml`](../../configs/algos/dwa_prediction_scoring.yaml)
+enables `prediction_scoring_enabled: true`. At each DWA rollout step, the variant scores robot
+clearance against each pedestrian's time-aligned constant-velocity position forecast. Pedestrian
+positions are world-frame observations; their observed ego-frame velocities are rotated into the
+world frame before forecasting. The forecast horizon and interval are the existing
+`prediction_steps` and `prediction_dt` values.
+
+Use the same `algo=dwa` planner key with the enabling config:
+
+```bash
+uv run robot_sf_bench run \
+  --matrix configs/scenarios/planner_sanity_matrix_v1.yaml \
+  --out output/benchmarks/dwa_prediction_scoring_smoke/episodes.jsonl \
+  --algo dwa \
+  --algo-config configs/algos/dwa_prediction_scoring.yaml \
+  --benchmark-profile experimental \
+  --workers 1 --no-video --no-resume
+```
+
+The base config explicitly keeps `prediction_scoring_enabled: false`, so existing DWA behavior is
+unchanged. When prediction scoring is enabled, every active pedestrian must provide one finite
+two-dimensional velocity; malformed or missing forecast inputs fail closed. This opt-in variant is
+an experimental implementation capability, not evidence that it improves outcomes.
+
 This planner is intentionally gated by `allow_testing_algorithms: true`. It is an implemented
 classical baseline, but no full benchmark campaign or paper/dissertation claim is established by
 this configuration. It emits differential-drive unicycle `(v, omega)` commands and is not available

--- a/robot_sf/planner/dwa.py
+++ b/robot_sf/planner/dwa.py
@@ -42,6 +42,7 @@ class DWAPlannerConfig:
     clearance_weight: float = 1.2
     velocity_weight: float = 0.25
     progress_weight: float = 1.0
+    prediction_scoring_enabled: bool = False
 
     def __post_init__(self) -> None:
         """Reject invalid dynamics and rollout parameters before planning begins."""
@@ -96,8 +97,8 @@ class DWAPlannerAdapter(OccupancyAwarePlannerMixin):
 
     def _extract_state(
         self, observation: dict[str, Any]
-    ) -> tuple[np.ndarray, float, float, float, np.ndarray, np.ndarray]:
-        """Return robot pose/command state, active goal, and pedestrian positions."""
+    ) -> tuple[np.ndarray, float, float, float, np.ndarray, np.ndarray, np.ndarray]:
+        """Return robot state, active goal, and pedestrian positions/world velocities."""
         robot, goal, pedestrians = self._socnav_fields(observation)
         robot = robot or {}
         goal = goal or {}
@@ -126,7 +127,47 @@ class DWAPlannerAdapter(OccupancyAwarePlannerMixin):
             int(self._as_1d_float(pedestrians.get("count", [raw_positions.shape[0]]), pad=1)[0]),
             0,
         )
-        return robot_pos, heading, linear_speed, angular_speed, active_goal, raw_positions[:count]
+        pedestrian_positions = raw_positions[:count]
+        pedestrian_velocities = np.zeros_like(pedestrian_positions)
+        if self.config.prediction_scoring_enabled and count:
+            if pedestrian_positions.shape[0] < count or not np.all(
+                np.isfinite(pedestrian_positions)
+            ):
+                raise ValueError(
+                    "DWA prediction scoring requires one finite (x, y) world position "
+                    "for every active pedestrian"
+                )
+            raw_velocities = np.asarray(pedestrians.get("velocities", []), dtype=float)
+            if raw_velocities.ndim == 1 and raw_velocities.size % 2 == 0:
+                raw_velocities = raw_velocities.reshape(-1, 2)
+            if (
+                raw_velocities.ndim != 2
+                or raw_velocities.shape[-1] != 2
+                or raw_velocities.shape[0] < count
+                or not np.all(np.isfinite(raw_velocities[:count]))
+            ):
+                raise ValueError(
+                    "DWA prediction scoring requires one finite (vx, vy) ego-frame velocity "
+                    "for every active pedestrian"
+                )
+            velocities_ego = raw_velocities[:count]
+            cos_h = float(np.cos(heading))
+            sin_h = float(np.sin(heading))
+            pedestrian_velocities[:, 0] = (
+                cos_h * velocities_ego[:, 0] - sin_h * velocities_ego[:, 1]
+            )
+            pedestrian_velocities[:, 1] = (
+                sin_h * velocities_ego[:, 0] + cos_h * velocities_ego[:, 1]
+            )
+        return (
+            robot_pos,
+            heading,
+            linear_speed,
+            angular_speed,
+            active_goal,
+            pedestrian_positions,
+            pedestrian_velocities,
+        )
 
     def _dynamic_window(
         self, linear_speed: float, angular_speed: float
@@ -189,6 +230,7 @@ class DWAPlannerAdapter(OccupancyAwarePlannerMixin):
         heading: float,
         goal: np.ndarray,
         pedestrian_positions: np.ndarray,
+        pedestrian_velocities: np.ndarray,
         command: tuple[float, float],
         observation: dict[str, Any],
     ) -> float:
@@ -201,7 +243,7 @@ class DWAPlannerAdapter(OccupancyAwarePlannerMixin):
         orientation = float(heading)
         start_distance = float(np.linalg.norm(goal - position))
         min_clearance = float("inf")
-        for _ in range(max(int(self.config.prediction_steps), 1)):
+        for step_idx in range(max(int(self.config.prediction_steps), 1)):
             position += np.array(
                 [
                     command[0] * np.cos(orientation) * float(self.config.prediction_dt),
@@ -210,8 +252,12 @@ class DWAPlannerAdapter(OccupancyAwarePlannerMixin):
             )
             orientation = wrap_angle_pi(orientation + command[1] * float(self.config.prediction_dt))
             if pedestrian_positions.size:
+                scored_positions = pedestrian_positions
+                if self.config.prediction_scoring_enabled:
+                    forecast_time = float(step_idx + 1) * float(self.config.prediction_dt)
+                    scored_positions = pedestrian_positions + pedestrian_velocities * forecast_time
                 pedestrian_clearance = (
-                    float(np.min(np.linalg.norm(pedestrian_positions - position[None, :], axis=1)))
+                    float(np.min(np.linalg.norm(scored_positions - position[None, :], axis=1)))
                     - float(self.config.robot_radius)
                     - float(self.config.pedestrian_radius)
                 )
@@ -243,9 +289,15 @@ class DWAPlannerAdapter(OccupancyAwarePlannerMixin):
         Returns:
             Bounded linear and angular velocity command ``(v, omega)``.
         """
-        robot_pos, heading, linear_speed, angular_speed, goal, pedestrians = self._extract_state(
-            observation
-        )
+        (
+            robot_pos,
+            heading,
+            linear_speed,
+            angular_speed,
+            goal,
+            pedestrians,
+            pedestrian_velocities,
+        ) = self._extract_state(observation)
         if np.linalg.norm(goal - robot_pos) <= float(self.config.goal_tolerance):
             return 0.0, 0.0
         v_min, v_max, w_min, w_max = self._dynamic_window(linear_speed, angular_speed)
@@ -261,6 +313,7 @@ class DWAPlannerAdapter(OccupancyAwarePlannerMixin):
                     heading=heading,
                     goal=goal,
                     pedestrian_positions=pedestrians,
+                    pedestrian_velocities=pedestrian_velocities,
                     command=command,
                     observation=observation,
                 )
@@ -318,4 +371,25 @@ def build_dwa_config(cfg: dict[str, Any] | None) -> DWAPlannerConfig:
         clearance_weight=float(cfg.get("clearance_weight", defaults.clearance_weight)),
         velocity_weight=float(cfg.get("velocity_weight", defaults.velocity_weight)),
         progress_weight=float(cfg.get("progress_weight", defaults.progress_weight)),
+        prediction_scoring_enabled=_parse_bool(
+            cfg.get("prediction_scoring_enabled", defaults.prediction_scoring_enabled),
+            name="prediction_scoring_enabled",
+        ),
     )
+
+
+def _parse_bool(value: Any, *, name: str) -> bool:
+    """Parse a config boolean without treating arbitrary non-empty strings as true.
+
+    Returns:
+        Parsed boolean value.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    raise ValueError(f"{name} must be a boolean")

--- a/tests/planner/test_dwa.py
+++ b/tests/planner/test_dwa.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pytest
+import yaml
 
 from robot_sf.planner.dwa import DWAPlannerAdapter, DWAPlannerConfig, build_dwa_config
 
@@ -16,6 +19,7 @@ def _observation(
     angular_velocity: float = 0.0,
     goal: tuple[float, float] = (3.0, 0.0),
     pedestrians: list[tuple[float, float]] | None = None,
+    pedestrian_velocities: list[tuple[float, float]] | None = None,
 ) -> dict[str, object]:
     """Build a minimal structured observation accepted by DWA."""
     positions = [] if pedestrians is None else pedestrians
@@ -32,6 +36,9 @@ def _observation(
         },
         "pedestrians": {
             "positions": np.asarray(positions, dtype=float),
+            "velocities": np.asarray(
+                [] if pedestrian_velocities is None else pedestrian_velocities, dtype=float
+            ),
             "count": np.asarray([len(positions)], dtype=float),
         },
     }
@@ -90,6 +97,105 @@ def test_dwa_config_builder_applies_explicit_acceleration_parameters() -> None:
     assert config.max_angular_acceleration == pytest.approx(0.9)
     assert config.linear_samples == 4
     assert config.angular_samples == 6
+
+
+def test_dwa_prediction_scoring_is_opt_in_in_canonical_configs() -> None:
+    """The classic config retains static scoring while the variant opts into forecasts."""
+    config_dir = Path(__file__).resolve().parents[2] / "configs" / "algos"
+    classic = yaml.safe_load((config_dir / "dwa_classic.yaml").read_text(encoding="utf-8"))
+    predictive = yaml.safe_load(
+        (config_dir / "dwa_prediction_scoring.yaml").read_text(encoding="utf-8")
+    )
+
+    assert build_dwa_config(classic).prediction_scoring_enabled is False
+    assert build_dwa_config(predictive).prediction_scoring_enabled is True
+    assert {
+        key: value for key, value in classic.items() if key != "prediction_scoring_enabled"
+    } == {key: value for key, value in predictive.items() if key != "prediction_scoring_enabled"}
+
+
+def test_dwa_prediction_scoring_avoids_a_future_crossing() -> None:
+    """Time-aligned constant-velocity scoring rejects a pedestrian's future crossing point."""
+    observation = _observation(
+        goal=(3.0, 0.0),
+        pedestrians=[(0.6, 0.8)],
+        pedestrian_velocities=[(0.0, -1.0)],
+    )
+    base_command = DWAPlannerAdapter(DWAPlannerConfig()).plan(observation)
+    predictive_command = DWAPlannerAdapter(DWAPlannerConfig(prediction_scoring_enabled=True)).plan(
+        observation
+    )
+    repeated_command = DWAPlannerAdapter(DWAPlannerConfig(prediction_scoring_enabled=True)).plan(
+        observation
+    )
+
+    assert base_command[0] > 0.0
+    assert repeated_command == predictive_command
+    assert predictive_command != base_command
+    assert predictive_command[0] <= base_command[0]
+
+
+def test_dwa_prediction_scoring_rotates_ego_velocity_to_world() -> None:
+    """Pedestrian ego-frame velocities are rotated using the current robot heading."""
+    planner = DWAPlannerAdapter(DWAPlannerConfig(prediction_scoring_enabled=True))
+    *_, velocities_world = planner._extract_state(
+        _observation(
+            heading=np.pi / 2,
+            pedestrians=[(1.0, 0.0)],
+            pedestrian_velocities=[(1.0, 0.0)],
+        )
+    )
+
+    np.testing.assert_allclose(velocities_world, [[0.0, 1.0]], atol=1e-12)
+
+
+def test_dwa_prediction_scoring_requires_active_pedestrian_velocities() -> None:
+    """The opt-in variant fails closed when an active forecast input is absent."""
+    planner = DWAPlannerAdapter(DWAPlannerConfig(prediction_scoring_enabled=True))
+
+    with pytest.raises(ValueError, match="one finite .* velocity"):
+        planner.plan(_observation(pedestrians=[(1.0, 0.0)]))
+
+
+def test_dwa_prediction_scoring_requires_finite_active_pedestrian_positions() -> None:
+    """The opt-in variant rejects malformed current state before forecasting."""
+    planner = DWAPlannerAdapter(DWAPlannerConfig(prediction_scoring_enabled=True))
+
+    with pytest.raises(ValueError, match="one finite .* world position"):
+        planner.plan(
+            _observation(
+                pedestrians=[(float("nan"), 0.0)],
+                pedestrian_velocities=[(0.0, 0.0)],
+            )
+        )
+
+
+@pytest.mark.parametrize(("raw", "expected"), [("yes", True), ("off", False)])
+def test_dwa_config_builder_parses_boolean_strings(raw: str, expected: bool) -> None:
+    """Text config values use explicit boolean parsing rather than string truthiness."""
+    assert (
+        build_dwa_config({"prediction_scoring_enabled": raw}).prediction_scoring_enabled is expected
+    )
+
+
+def test_dwa_config_builder_rejects_non_boolean_prediction_flag() -> None:
+    """Ambiguous prediction-scoring flag values fail closed."""
+    with pytest.raises(ValueError, match="prediction_scoring_enabled must be a boolean"):
+        build_dwa_config({"prediction_scoring_enabled": 1})
+
+
+def test_dwa_base_scoring_ignores_pedestrian_velocities() -> None:
+    """Velocity payloads do not alter the disabled-by-default base DWA contract."""
+    planner = DWAPlannerAdapter(DWAPlannerConfig())
+    without_velocity = planner.plan(_observation(pedestrians=[(0.6, 0.8)]))
+    with_velocity = planner.plan(
+        _observation(
+            pedestrians=[(0.6, 0.8)],
+            pedestrian_velocities=[(0.0, -1.0)],
+        )
+    )
+
+    assert with_velocity == without_velocity
 
 
 def test_dwa_dynamic_window_preserves_reachability_outside_speed_limits() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds a disabled-by-default DWA (Dynamic Window Approach) scoring mode that evaluates each robot rollout against time-aligned, short-horizon constant-velocity pedestrian forecasts, plus a canonical enabling config and deterministic synthetic tests.
- **Why now:** The base DWA arm (#5012) and its standard-archetype execution evidence (#5053 / #5020) are merged; this delivers the remaining nameable optional capability from #4983 without rerunning a campaign.
- **Claim boundary:** Implementation integrity and CPU smoke evidence only. This PR makes no planner-performance, benchmark-strength, paper, or dissertation claim.
- **Required validation:** Focused planner/config/benchmark-contract tests, real map-runner CPU smoke, and the final committed-head repository readiness gate.
- **Remaining blocker:** None for #4983 after merge. Any comparative evaluation of the variant would be separate research work, not acceptance scope for this implementation.

## Contract delta

- New schema field: `prediction_scoring_enabled: bool`, defaulting to `false` in code and `configs/algos/dwa_classic.yaml`.
- New canonical opt-in config: `configs/algos/dwa_prediction_scoring.yaml`; it uses the existing `algo=dwa` key and existing `prediction_steps` / `prediction_dt` rollout horizon.
- New fail-closed blocker: with prediction scoring enabled, each active pedestrian must have a finite world-frame position and finite two-dimensional ego-frame velocity. Velocities are rotated to world frame before constant-velocity forecasting.
- Compatibility impact: base DWA command selection remains unchanged because pedestrian velocity data is ignored while the flag is disabled. No benchmark default, readiness status, metric, or command interface changes.

Closes #4983

Issue: https://github.com/ll7/robot_sf_ll7/issues/4983

## Scope summary

- Extended `DWAPlannerAdapter` with opt-in, time-aligned forecast clearance scoring.
- Added the explicit base default and a complete enabling config.
- Documented the config, observation-frame, horizon, failure, and claim-boundary contracts.
- Added deterministic synthetic coverage for a future crossing, ego-to-world velocity rotation, missing-input failure, canonical config parity, and unchanged base scoring.

Assumption: "second arm" is implemented reversibly as the existing `dwa` planner plus a dedicated algorithm config, rather than a new algorithm alias. This keeps planner metadata and command semantics unified while config identity distinguishes the variant.

## Validation

- `uv run pytest -q tests/planner/test_dwa.py tests/benchmark/test_algorithm_readiness_contract.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_planner_command_contract.py tests/benchmark/test_map_runner_preflight_profiles.py tests/benchmark/test_map_runner_decomposition_helpers.py tests/benchmark/test_planner_readiness_matrix.py` — passed: 159 passed, 1 skipped.
- `uv run python scripts/validation/check_active_doc_examples.py` — exit 0; no finding in `docs/baselines/dwa.md` (10 pre-existing diagnostics elsewhere).
- `DISPLAY= SDL_VIDEODRIVER=dummy MPLBACKEND=Agg uv run robot_sf_bench run --matrix configs/scenarios/planner_sanity_matrix_v1.yaml --out output/benchmarks/dwa_prediction_scoring_issue4983_smoke/episodes.jsonl --algo dwa --algo-config configs/algos/dwa_prediction_scoring.yaml --benchmark-profile experimental --workers 1 --horizon 80 --no-video --no-resume --structured-output json` — passed: 3/3 jobs written, 0 failed; diagnostic smoke only.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue-4983-pr-body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on clean committed HEAD: core 2184 passed, 1 skipped; predictive optional 6436 passed, 17 skipped; changed-line coverage 100% (33/33); Ruff, docstring, and exception ratchets passed.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Evidence, artifacts, propagation, and governance appendix</summary>

### Evidence and stop rule

- Target: prove that the opt-in config constructs and executes the time-aligned constant-velocity scoring path while the base default is unchanged.
- Comparator: direct synthetic base-versus-opt-in command contract; no outcome or performance comparator.
- Evidence tier: automated implementation proof plus diagnostic CPU smoke.
- Result classification: implementation capability only; not benchmark evidence.
- Stop rule: focused synthetic/config/integration proof and final readiness must pass; no campaign escalation is authorized or needed.

### Artifacts

`output/benchmarks/dwa_prediction_scoring_issue4983_smoke/` and readiness coverage output are ignored, disposable local validation artifacts. No episode JSONL, video, coverage output, or model artifact is committed.

### Fragmentation and dedupe

- No open PR covered #4983 or the exact prediction-scoring scope at the start audit.
- Two directly related PRs merged in the preceding 24 hours (#5012 and #5053), but this PR is exempt from the micro-guard threshold because it adds the nameable new prediction-scoring capability rather than another guardrail/checker/packet refresh.

### Downstream propagation

No separate issue comment or tracked queue-state file is added: this run is explicitly unauthorized to comment, and transient queue routing must not be encoded in tracked files. `Closes #4983`, the config/docs contract, and this PR body are the durable delivery/closure surfaces.

### Follow-up and research boundaries

- No implementation acceptance scope remains after merge.
- Comparative evaluation is intentionally not opened or claimed by this PR.
- No benchmark metric semantics, readiness classification, paper claim, or dissertation claim changes.

</details>

## Follow-Up Issues

- Deferred work: None. Comparative evaluation is optional future research and the maintainer task explicitly excludes campaign execution from this implementation closure.
- Issues opened for follow-up: NA - maintainer waiver for the campaign-excluded closure boundary.
