### PR TITLE
test: prove stub predictor rollout selection (#4013)

### DIFF
--- a/tests/planner/test_prediction_mpc.py
+++ b/tests/planner/test_prediction_mpc.py
@@ -11,6 +11,7 @@ import pytest
 
 from robot_sf.planner.prediction_mpc import (
     ConstantVelocityPedestrianPredictor,
+    PredictedPedestrianFutures,
     PredictionMPCConfig,
     PredictionMPCPlannerAdapter,
     build_prediction_mpc_config,
@@ -163,6 +164,67 @@ def test_prediction_mpc_solver_avoids_or_stops_for_predicted_collision() -> None
     )
 
     assert linear <= 0.1
+
+
+def test_prediction_mpc_selects_constraint_feasible_action_from_stub_predictor() -> None:
+    """An injected predictor drives selection through the hard rollout constraint."""
+
+    class StubPredictor:
+        """Return a fixed short-horizon pedestrian future and record the interface call."""
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[int, float]] = []
+            self.last_futures: PredictedPedestrianFutures | None = None
+
+        def predict(
+            self,
+            observation: dict,
+            *,
+            horizon_steps: int,
+            dt: float,
+        ) -> PredictedPedestrianFutures:
+            del observation
+            self.calls.append((horizon_steps, dt))
+            self.last_futures = PredictedPedestrianFutures(
+                positions_world=np.repeat(
+                    np.asarray([[[0.9, 0.0]]], dtype=float), horizon_steps, axis=1
+                ),
+                mask=np.ones((1,), dtype=float),
+                dt=dt,
+                source="stub_short_horizon",
+            )
+            return self.last_futures
+
+    predictor = StubPredictor()
+    planner = PredictionMPCPlannerAdapter(
+        PredictionMPCConfig(
+            predictor_backend="stub_short_horizon",
+            horizon_steps=3,
+            rollout_dt=0.25,
+            solver_max_iterations=60,
+            pedestrian_safety_margin=0.25,
+        ),
+        predictor=predictor,
+    )
+    observation = _obs(
+        goal=(3.0, 0.0),
+        ped_positions=[(0.9, 0.0)],
+        ped_velocities=[(0.0, 0.0)],
+    )
+
+    linear, angular = planner.plan(observation)
+
+    assert predictor.calls == [(3, 0.25)]
+    assert predictor.last_futures is not None
+    assert planner._last_solution is not None
+    constraint_values = planner._pedestrian_clearance_constraints(
+        planner._last_solution,
+        context=_clearance_context(planner, observation),
+        predicted_futures=predictor.last_futures,
+    )
+    assert np.min(constraint_values) >= -planner.config.solver_ftol
+    assert 0.0 <= linear <= planner.config.max_linear_speed
+    assert abs(angular) <= planner.config.max_angular_speed
 
 
 def test_prediction_mpc_optimizer_failure_stops_deterministically(monkeypatch) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** adds the missing scaffold test that injects a deterministic short-horizon predictor into the existing prediction-aware model predictive control (MPC) adapter and calls `plan()`.
- **Why now:** the interface/config/runtime lane already exists on `main`; this is the smallest non-duplicative acceptance slice from the current ready-queue packet.
- **Claim boundary:** contract evidence only. No learned weights, training, benchmark result, navigation-quality claim, or paper/dissertation claim.
- **Required validation:** focused planner test plus the repository final PR-readiness pipeline.
- **Remaining blocker:** full issue completion still requires the externally blocked real-trajectory training/evaluation lane; this PR uses `Refs #4013` because it is partial.

## Contract delta

- New schema fields: none.
- New fail-closed blockers: none.
- Compatibility impact: none; runtime code and configuration are unchanged.
- Added proof: a structural predictor stub receives the configured `horizon_steps=3` and `dt=0.25`; the selected optimizer rollout satisfies all predicted-pedestrian hard-clearance constraints within `solver_ftol`, and its emitted unicycle command stays bounded.

Refs #4013

Issue: https://github.com/ll7/robot_sf_ll7/issues/4013

## Scope and validation

The existing `PedestrianFuturePredictor`, `PredictedPedestrianFutures`, `PredictionMPCConfig`, and `PredictionMPCPlannerAdapter` contracts remain the implementation under test. The reversible assumption is that these merged interfaces are canonical, so duplicating them under a new package would be harmful; the only uncovered ready-queue criterion was selection from a stub predictor.

- `uv run pytest tests/planner/test_prediction_mpc.py -q` — 17 passed after merging current `origin/main`.
- `uv run ruff check tests/planner/test_prediction_mpc.py` — passed.
- `uv run ruff format --check tests/planner/test_prediction_mpc.py` — passed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on clean merged HEAD: predictive lane 6,437 passed / 17 skipped; lint, coverage/diff, docstring, and broad-exception gates passed.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no model training, no learned weights, and no paper/dissertation claim edits.

Remaining for full issue completion:

- [ ] Stage and checksum-validate the external real pedestrian-trajectory dataset.
- [ ] Train the short-horizon predictor on validated real trajectories.
- [ ] Run representative learned-vs-constant-velocity-vs-model-free evaluation at the appropriate evidence tier.

<details>
<summary>Governance, provenance, and reviewer appendix</summary>

### Research result guidance

- Target: prove the already-merged predictor/MPC seam can select a constraint-feasible action from arbitrary protocol-conforming predicted futures.
- Comparator: none; this is a deterministic contract test.
- Evidence tier / result: targeted smoke, diagnostic-only contract evidence.
- Stop rule: stop at the interface proof; do not infer navigation quality.
- Fallback/degraded exclusion: no fallback is exercised or counted as evidence.
- Domain-aware approval: not required because no experimental validity or evidence classification changes.
- Falsification/non-transfer: the mechanism activated in the test; transfer to learned weights or scenarios is not claimed.

### Risks and artifacts

- Main residual risk: the test uses optimizer internals (`_last_solution` and the existing clearance evaluator) to verify the entire selected rollout; runtime behavior is unchanged.
- Rollback: remove the single test if the canonical selection interface is replaced.
- Generated `output/coverage/` and readiness stamps are ignored local validation caches and are not committed or treated as durable evidence.
- No new external data, model artifact, registry entry, or config index is introduced.

### Downstream propagation

- Parent issue comment: not added because this run explicitly lacks `comment_issue_or_pr` authorization.
- Claim map, benchmark report, leaderboard, catalog, registry, context index, and memory: not applicable because this is test-only contract proof with no research result or runtime delta.
- The PR body is the canonical propagation surface for this slice.

### Follow-up and fragmentation

- No friction issues filed: the only detour was an initially incorrect bootstrap invocation; the script emitted exact usage and the canonical workflow succeeded from the worktree root, so no actionable repository defect was found.
- This is not another guardrail/checker packet refresh. It delivers a specific missing test acceptance criterion against the existing runtime capability.
- Shared-helper migration table: not applicable; no helper or process boundary changed.

</details>
