### PR TITLE
feat(sim): add opt-in Zanlungo collision prediction (#4973)

### DIFF
--- a/configs/research/zanlungo_collision_prediction_issue_4973.yaml
+++ b/configs/research/zanlungo_collision_prediction_issue_4973.yaml
@@ -1,0 +1,37 @@
+schema_version: zanlungo-collision-prediction.v1
+issue: 4973
+evidence_tier: diagnostic-only
+claim_boundary: >-
+  Opt-in implementation and deterministic CPU contract only; parameters are the
+  paper's trajectory-calibrated values, not a Robot SF realism calibration or
+  benchmark-performance claim.
+simulation_config:
+  pedestrian_model: hsfm_zanlungo_collision_prediction_v1
+  zanlungo_collision_prediction:
+    enabled: true
+    interaction_strength: 1.13
+    interaction_range_m: 0.71
+    anisotropy_lambda: 0.29
+    angle_threshold_rad: 0.7853981633974483
+    max_force: 5.0
+    include_ped_ped: true
+provenance:
+  citation: >-
+    F. Zanlungo, T. Ikeda, and T. Kanda (2011), Social force model with
+    explicit collision prediction, EPL 93 68005.
+  doi: 10.1209/0295-5075/93/68005
+  equation_contract:
+    - earliest eligible pairwise closest-approach time per actor
+    - all neighbors projected to that common time
+    - speed-over-time and exponential projected-distance scaling
+    - anisotropy weighting from equation 11
+  implementation_safeguards:
+    - deterministic current-separation direction at zero projected distance
+    - per-actor maximum-force cap
+validation:
+  focused_test: tests/sim/test_zanlungo_collision_prediction_model.py
+  corridor_acceptance_status: deferred
+  corridor_acceptance_reason: >-
+    The implementation seam is complete, but eliminating freeze/deadlock requires
+    a predeclared scenario comparison and parameter sensitivity run; this config
+    does not promote the paper's calibration to Robot SF benchmark evidence.

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -214,6 +214,13 @@ alignment-torque slice is in
 `hsfm_alignment_torque_v1` selector that decouples pedestrian heading `phi` from the instantaneous
 force direction via a damped second-order torque (diagnostic/prototype).
 
+Recent Zanlungo collision-prediction force prototype:
+[issue_4973_zanlungo_collision_prediction.md](issue_4973_zanlungo_collision_prediction.md)
+records the opt-in common-time closest-approach force, its fail-closed replacement of only the
+pedestrian-to-pedestrian social term, paper-parameter provenance, and the still-deferred corridor
+freeze/deadlock acceptance comparison. It is diagnostic implementation evidence, not a calibrated
+realism or benchmark-performance claim.
+
 Recent heavy forecast-model study/preflight: [forecast_heavy_model_study_2026-06-20.md](forecast_heavy_model_study_2026-06-20.md)
 records the analysis-only inventory of heavy predictor families (transformer, AgentFormer-like,
 CVAE, diffusion) with literature-derived compute/latency/uncertainty/integration estimates, the

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -195,6 +195,10 @@ parser-smoke validation for `maps/svg_maps/socnavbench/socnavbench_eth.svg`.
   [issue_3064_behavior_variants_inventory.md](issue_3064_behavior_variants_inventory.md)
   records the fail-closed classification of native Social Force, AMMV-aware Social Force, and
   Social-Navigation-PyEnvs adapter-backed behavior variants for benchmark selection.
+* Issue #4973 Zanlungo collision-prediction force:
+  [issue_4973_zanlungo_collision_prediction.md](issue_4973_zanlungo_collision_prediction.md)
+  records the opt-in non-additive closest-approach force contract, parameter provenance, and
+  deferred corridor acceptance boundary.
 * Issue #3063 campaign comparison report:
   [issue_3063_campaign_comparison_report.md](issue_3063_campaign_comparison_report.md)
   records the analysis-only result-store report path, fixture proof, row-status caveats, and

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -20,6 +20,10 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+- path: docs/context/issue_4973_zanlungo_collision_prediction.md
+  status: current
+  freshness: maintained
+  area: benchmark_evidence
 - path: docs/context/evidence/issue_5139_hierarchical_bootstrap
   status: evidence
   freshness: evidence

--- a/docs/context/issue_4973_zanlungo_collision_prediction.md
+++ b/docs/context/issue_4973_zanlungo_collision_prediction.md
@@ -1,0 +1,43 @@
+# Issue #4973 — Optional Zanlungo collision-prediction pedestrian force
+
+This opt-in simulator model lets pedestrians react to predicted closest approaches while leaving
+the default pedestrian dynamics unchanged. It is an implementation prototype, not evidence that
+the model is calibrated for Robot SF or that it eliminates freezing across benchmark scenarios.
+
+## Runtime contract
+
+Set `simulation_config.pedestrian_model` to
+`hsfm_zanlungo_collision_prediction_v1`. The selector replaces only the existing
+pedestrian-to-pedestrian `SocialForce` contribution; goal, obstacle, group, and robot forces remain
+in the total. If the baseline social component is unavailable, the opt-in path fails closed instead
+of silently changing the force composition.
+
+The pure helper in `robot_sf/sim/pedestrian_model_variants.py` follows Zanlungo, Ikeda, and Kanda
+(2011), equations 10–11:
+
+1. For each pedestrian, find the earliest eligible straight-line closest-approach time among
+   neighbors within the paper's `pi / 4` approach cone.
+2. Project every neighbor to that one common time. This makes the interaction non-additive: a nearer
+   conflict changes how the same pedestrian responds to all other neighbors.
+3. Scale projected-distance repulsion by the pedestrian's speed divided by that time and by the
+   paper's anisotropy weight.
+
+The canonical opt-in packet is
+`configs/research/zanlungo_collision_prediction_issue_4973.yaml`. Its interaction strength (`1.13`),
+range (`0.71 m`), and anisotropy (`0.29`) reproduce the paper's trajectory-calibrated values. They
+are not calibrated to Robot SF scenarios. A deterministic current-separation fallback resolves the
+equation's exactly centered zero-distance direction, and `max_force` bounds numerical acceleration.
+
+## Compatibility and evidence boundary
+
+- `social_force_default` remains the default and does not read the new config.
+- The existing `hsfm_ttc_predictive_v1` Karamouzas-style pairwise force is separate; it does not use
+  the Zanlungo common-time, non-additive projection.
+- Focused tests prove pure-force geometry, common-time coupling, deterministic degeneracy handling,
+  scenario-config loading, default compatibility, runtime composition, and fail-closed behavior.
+- Corridor-level freeze/deadlock acceptance remains a separate predeclared CPU comparison with
+  parameter sensitivity. No benchmark campaign, Slurm/GPU job, or paper/dissertation claim is part
+  of this implementation slice.
+
+Reference: F. Zanlungo, T. Ikeda, and T. Kanda, “Social force model with explicit collision
+prediction,” *EPL* 93 (2011) 68005, <https://doi.org/10.1209/0295-5075/93/68005>.

--- a/robot_sf/sim/pedestrian_model_variants.py
+++ b/robot_sf/sim/pedestrian_model_variants.py
@@ -10,6 +10,7 @@ from pysocialforce.scene import EXPLICIT_EULER, normalize_integration_scheme
 SOCIAL_FORCE_DEFAULT = "social_force_default"
 HSFM_TOTAL_FORCE_V1 = "hsfm_total_force_v1"
 HSFM_TTC_PREDICTIVE_V1 = "hsfm_ttc_predictive_v1"
+HSFM_ZANLUNGO_COLLISION_PREDICTION_V1 = "hsfm_zanlungo_collision_prediction_v1"
 HSFM_ANISOTROPIC_FOV_V1 = "hsfm_anisotropic_fov_v1"
 HSFM_ALIGNMENT_TORQUE_V1 = "hsfm_alignment_torque_v1"
 SUPPORTED_PEDESTRIAN_MODELS = frozenset(
@@ -17,6 +18,7 @@ SUPPORTED_PEDESTRIAN_MODELS = frozenset(
         SOCIAL_FORCE_DEFAULT,
         HSFM_TOTAL_FORCE_V1,
         HSFM_TTC_PREDICTIVE_V1,
+        HSFM_ZANLUNGO_COLLISION_PREDICTION_V1,
         HSFM_ANISOTROPIC_FOV_V1,
         HSFM_ALIGNMENT_TORQUE_V1,
     }
@@ -650,6 +652,182 @@ def ttc_predictive_repulsion(
     np.divide(max_force, norms, out=factors, where=norms > max_force)
     np.minimum(factors, 1.0, out=factors)
     return repulsion * np.expand_dims(factors, axis=-1)
+
+
+def _validate_zanlungo_inputs(
+    positions: np.ndarray,
+    velocities: np.ndarray,
+    *,
+    interaction_strength: float,
+    interaction_range_m: float,
+    anisotropy_lambda: float,
+    angle_threshold_rad: float,
+    max_force: float,
+    epsilon: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return validated arrays for the Zanlungo force calculation."""
+    position_array = np.asarray(positions, dtype=float)
+    velocity_array = np.asarray(velocities, dtype=float)
+    if position_array.ndim != 2 or position_array.shape[1] != 2:
+        raise ValueError("positions must have shape (N, 2)")
+    if velocity_array.shape != position_array.shape:
+        raise ValueError("velocities must have shape (N, 2) matching positions")
+    if not np.all(np.isfinite(position_array)) or not np.all(np.isfinite(velocity_array)):
+        raise ValueError("positions and velocities must be finite")
+    if not np.isfinite(interaction_strength) or interaction_strength < 0:
+        raise ValueError("interaction_strength must be finite and >= 0")
+    if not np.isfinite(interaction_range_m) or interaction_range_m <= 0:
+        raise ValueError("interaction_range_m must be finite and > 0")
+    if not np.isfinite(anisotropy_lambda) or not 0 <= anisotropy_lambda <= 1:
+        raise ValueError("anisotropy_lambda must be within [0, 1]")
+    if (
+        not np.isfinite(angle_threshold_rad)
+        or angle_threshold_rad <= 0
+        or angle_threshold_rad > np.pi
+    ):
+        raise ValueError("angle_threshold_rad must be within (0, pi]")
+    if not np.isfinite(max_force) or max_force <= 0:
+        raise ValueError("max_force must be finite and > 0")
+    if not np.isfinite(epsilon) or epsilon <= 0:
+        raise ValueError("epsilon must be finite and > 0")
+    return position_array, velocity_array
+
+
+def _zanlungo_actor_force(
+    actor_index: int,
+    positions: np.ndarray,
+    velocities: np.ndarray,
+    *,
+    interaction_strength: float,
+    interaction_range_m: float,
+    anisotropy_lambda: float,
+    angle_threshold_rad: float,
+    epsilon: float,
+) -> np.ndarray:
+    """Compute one actor's non-additive common-time projected force.
+
+    Returns:
+        Two-dimensional force vector for the selected actor.
+    """
+    pedestrian_count = positions.shape[0]
+    displacement = positions[actor_index] - positions
+    relative_velocity = velocities - velocities[actor_index]
+    displacement_norm = np.linalg.norm(displacement, axis=-1)
+    relative_speed = np.linalg.norm(relative_velocity, axis=-1)
+    dot_product = np.sum(displacement * relative_velocity, axis=-1)
+    denominator = displacement_norm * relative_speed
+    cosine = np.full(pedestrian_count, -1.0, dtype=float)
+    np.divide(dot_product, denominator, out=cosine, where=denominator > epsilon)
+    candidate = (
+        (np.arange(pedestrian_count) != actor_index)
+        & (cosine >= float(np.cos(angle_threshold_rad)))
+        & (dot_product > epsilon)
+        & (relative_speed > epsilon)
+    )
+    closest_time = np.full(pedestrian_count, np.inf, dtype=float)
+    np.divide(dot_product, relative_speed**2, out=closest_time, where=candidate)
+    actor_time = float(np.min(closest_time))
+    actor_speed = float(np.linalg.norm(velocities[actor_index]))
+    if not np.isfinite(actor_time) or actor_speed <= epsilon:
+        return np.zeros(2, dtype=float)
+
+    projected_displacement = displacement - relative_velocity * actor_time
+    projected_distance = np.linalg.norm(projected_displacement, axis=-1)
+    directions = np.zeros_like(projected_displacement)
+    np.divide(
+        projected_displacement,
+        projected_distance[:, np.newaxis],
+        out=directions,
+        where=projected_distance[:, np.newaxis] > epsilon,
+    )
+    # Equation (10) is directionally undefined for an exactly centered future
+    # collision. Reusing the current separation direction is deterministic and
+    # keeps the limiting repulsion finite without inventing random symmetry breaking.
+    degenerate = (projected_distance <= epsilon) & (displacement_norm > epsilon)
+    np.divide(
+        displacement,
+        displacement_norm[:, np.newaxis],
+        out=directions,
+        where=degenerate[:, np.newaxis],
+    )
+
+    direction_to_neighbor = -displacement
+    heading_cosine = np.zeros(pedestrian_count, dtype=float)
+    np.divide(
+        direction_to_neighbor @ velocities[actor_index],
+        displacement_norm * actor_speed,
+        out=heading_cosine,
+        where=displacement_norm > epsilon,
+    )
+    np.clip(heading_cosine, -1.0, 1.0, out=heading_cosine)
+    anisotropy = (
+        float(anisotropy_lambda) + (1.0 - float(anisotropy_lambda)) * (1.0 + heading_cosine) / 2.0
+    )
+    weights = anisotropy * np.exp(-projected_distance / float(interaction_range_m))
+    weights[actor_index] = 0.0
+    return (
+        float(interaction_strength)
+        * actor_speed
+        / max(actor_time, epsilon)
+        * np.sum(weights[:, np.newaxis] * directions, axis=0)
+    )
+
+
+def zanlungo_collision_prediction_repulsion(
+    positions: np.ndarray,
+    velocities: np.ndarray,
+    *,
+    interaction_strength: float,
+    interaction_range_m: float,
+    anisotropy_lambda: float,
+    angle_threshold_rad: float,
+    max_force: float,
+    epsilon: float = 1e-9,
+) -> np.ndarray:
+    """Compute the Zanlungo et al. (2011) collision-prediction force.
+
+    Each actor selects its earliest eligible pairwise closest-approach time and
+    projects *all* neighbors to that common time before summing interactions.
+    This common-time projection is the non-additive distinction from the existing
+    pairwise time-to-collision force.
+
+    Returns:
+        Per-pedestrian predictive force array with shape ``(N, 2)``.
+    """
+
+    position_array, velocity_array = _validate_zanlungo_inputs(
+        positions,
+        velocities,
+        interaction_strength=interaction_strength,
+        interaction_range_m=interaction_range_m,
+        anisotropy_lambda=anisotropy_lambda,
+        angle_threshold_rad=angle_threshold_rad,
+        max_force=max_force,
+        epsilon=epsilon,
+    )
+
+    pedestrian_count = position_array.shape[0]
+    result = np.zeros_like(position_array, dtype=float)
+    if pedestrian_count < 2 or interaction_strength == 0:
+        return result
+
+    for actor_index in range(pedestrian_count):
+        result[actor_index] = _zanlungo_actor_force(
+            actor_index,
+            position_array,
+            velocity_array,
+            interaction_strength=interaction_strength,
+            interaction_range_m=interaction_range_m,
+            anisotropy_lambda=anisotropy_lambda,
+            angle_threshold_rad=angle_threshold_rad,
+            epsilon=epsilon,
+        )
+
+    norms = np.linalg.norm(result, axis=-1)
+    factors = np.ones_like(norms, dtype=float)
+    np.divide(max_force, norms, out=factors, where=norms > max_force)
+    np.minimum(factors, 1.0, out=factors)
+    return result * factors[:, np.newaxis]
 
 
 def step_hsfm_total_force(

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -1,7 +1,7 @@
 """Configuration dataclasses for simulator timing and pedestrian behavior."""
 
 from dataclasses import dataclass, field, replace
-from math import ceil, isfinite
+from math import ceil, isfinite, pi
 from typing import Any
 
 from pysocialforce.scene import normalize_integration_scheme
@@ -12,6 +12,7 @@ from robot_sf.sim.pedestrian_model_variants import (
     HSFM_ALIGNMENT_TORQUE_V1,
     HSFM_ANISOTROPIC_FOV_V1,
     HSFM_TTC_PREDICTIVE_V1,
+    HSFM_ZANLUNGO_COLLISION_PREDICTION_V1,
     normalize_pedestrian_model,
 )
 from robot_sf.sim.pedestrian_speed_tiers import (
@@ -55,6 +56,53 @@ def _normalize_ttc_predictive_force_config(
     raise ValueError("ttc_predictive_force must be a TtcPredictiveForceConfig")
 
 
+@dataclass(frozen=True)
+class ZanlungoCollisionPredictionConfig:
+    """Opt-in Zanlungo et al. (2011) collision-prediction force parameters."""
+
+    enabled: bool = False
+    interaction_strength: float = 1.13
+    interaction_range_m: float = 0.71
+    anisotropy_lambda: float = 0.29
+    angle_threshold_rad: float = pi / 4
+    max_force: float = 5.0
+    include_ped_ped: bool = True
+
+    def __post_init__(self) -> None:
+        """Validate finite collision-prediction parameters."""
+        if not isfinite(self.interaction_strength) or self.interaction_strength < 0:
+            raise ValueError("zanlungo_collision_prediction.interaction_strength must be >= 0")
+        if not isfinite(self.interaction_range_m) or self.interaction_range_m <= 0:
+            raise ValueError("zanlungo_collision_prediction.interaction_range_m must be > 0")
+        if not isfinite(self.anisotropy_lambda) or not 0 <= self.anisotropy_lambda <= 1:
+            raise ValueError(
+                "zanlungo_collision_prediction.anisotropy_lambda must be within [0, 1]"
+            )
+        if (
+            not isfinite(self.angle_threshold_rad)
+            or self.angle_threshold_rad <= 0
+            or self.angle_threshold_rad > pi
+        ):
+            raise ValueError(
+                "zanlungo_collision_prediction.angle_threshold_rad must be within (0, pi]"
+            )
+        if not isfinite(self.max_force) or self.max_force <= 0:
+            raise ValueError("zanlungo_collision_prediction.max_force must be > 0")
+
+
+def _normalize_zanlungo_collision_prediction_config(
+    value: ZanlungoCollisionPredictionConfig | dict,
+) -> ZanlungoCollisionPredictionConfig:
+    """Return a validated Zanlungo collision-prediction config."""
+    if isinstance(value, ZanlungoCollisionPredictionConfig):
+        return value
+    if isinstance(value, dict):
+        return ZanlungoCollisionPredictionConfig(**value)
+    raise ValueError(
+        "zanlungo_collision_prediction must be a ZanlungoCollisionPredictionConfig or dict"
+    )
+
+
 def _pedestrian_model_ttc_config(
     pedestrian_model: str,
     ttc_config: TtcPredictiveForceConfig,
@@ -67,6 +115,20 @@ def _pedestrian_model_ttc_config(
     if pedestrian_model == HSFM_TTC_PREDICTIVE_V1 and not ttc_config.enabled:
         return replace(ttc_config, enabled=True)
     return ttc_config
+
+
+def _pedestrian_model_zanlungo_config(
+    pedestrian_model: str,
+    config: ZanlungoCollisionPredictionConfig,
+) -> ZanlungoCollisionPredictionConfig:
+    """Enable Zanlungo provenance when its pedestrian-model selector is active.
+
+    Returns:
+        Original or selector-enabled collision-prediction config.
+    """
+    if pedestrian_model == HSFM_ZANLUNGO_COLLISION_PREDICTION_V1 and not config.enabled:
+        return replace(config, enabled=True)
+    return config
 
 
 @dataclass(frozen=True)
@@ -197,6 +259,11 @@ class SimulationSettings:
 
     ttc_predictive_force: TtcPredictiveForceConfig = field(default_factory=TtcPredictiveForceConfig)
     """TTC predictive force settings used by ``hsfm_ttc_predictive_v1``."""
+
+    zanlungo_collision_prediction: ZanlungoCollisionPredictionConfig = field(
+        default_factory=ZanlungoCollisionPredictionConfig
+    )
+    """Collision-prediction settings used by ``hsfm_zanlungo_collision_prediction_v1``."""
 
     anisotropic_fov: AnisotropicFovConfig = field(default_factory=AnisotropicFovConfig)
     """Anisotropic field-of-view settings used by ``hsfm_anisotropic_fov_v1``."""
@@ -384,6 +451,13 @@ class SimulationSettings:
         self.ttc_predictive_force = _pedestrian_model_ttc_config(
             self.pedestrian_model,
             self.ttc_predictive_force,
+        )
+        self.zanlungo_collision_prediction = _normalize_zanlungo_collision_prediction_config(
+            self.zanlungo_collision_prediction
+        )
+        self.zanlungo_collision_prediction = _pedestrian_model_zanlungo_config(
+            self.pedestrian_model,
+            self.zanlungo_collision_prediction,
         )
         self.anisotropic_fov = _normalize_anisotropic_fov_config(self.anisotropic_fov)
         self.anisotropic_fov = _pedestrian_model_anisotropic_fov_config(

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -62,12 +62,14 @@ from robot_sf.sim.pedestrian_model_variants import (
     HSFM_ANISOTROPIC_FOV_V1,
     HSFM_TOTAL_FORCE_V1,
     HSFM_TTC_PREDICTIVE_V1,
+    HSFM_ZANLUNGO_COLLISION_PREDICTION_V1,
     fov_attenuated_total_force,
     normalize_pedestrian_model,
     pairwise_social_force_contributions,
     step_alignment_torque_heading,
     step_hsfm_total_force,
     ttc_predictive_repulsion,
+    zanlungo_collision_prediction_repulsion,
 )
 
 PYSF_POSITION_SLICE = slice(0, 2)
@@ -323,6 +325,7 @@ class Simulator:
         if self.pedestrian_model not in {
             HSFM_TOTAL_FORCE_V1,
             HSFM_TTC_PREDICTIVE_V1,
+            HSFM_ZANLUNGO_COLLISION_PREDICTION_V1,
             HSFM_ANISOTROPIC_FOV_V1,
             HSFM_ALIGNMENT_TORQUE_V1,
         }:
@@ -350,6 +353,24 @@ class Simulator:
                     horizon_s=ttc_config.horizon_s,
                     force_scale=ttc_config.force_scale,
                     max_force=ttc_config.max_force,
+                )
+        elif self.pedestrian_model == HSFM_ZANLUNGO_COLLISION_PREDICTION_V1:
+            zanlungo_config = self.config.zanlungo_collision_prediction
+            if zanlungo_config.include_ped_ped:
+                pairwise_social = self._pairwise_social_force_contributions(current_state)
+                collision_prediction = zanlungo_collision_prediction_repulsion(
+                    current_state[:, PYSF_POSITION_SLICE],
+                    current_state[:, PYSF_VELOCITY_SLICE],
+                    interaction_strength=zanlungo_config.interaction_strength,
+                    interaction_range_m=zanlungo_config.interaction_range_m,
+                    anisotropy_lambda=zanlungo_config.anisotropy_lambda,
+                    angle_threshold_rad=zanlungo_config.angle_threshold_rad,
+                    max_force=zanlungo_config.max_force,
+                )
+                ped_forces = (
+                    np.asarray(ped_forces, dtype=float)
+                    - pairwise_social.sum(axis=1)
+                    + collision_prediction
                 )
         elif self.pedestrian_model == HSFM_ANISOTROPIC_FOV_V1:
             fov_config = self.config.anisotropic_fov
@@ -398,7 +419,7 @@ class Simulator:
     def _social_force_component(self) -> SocialForce:
         """Return the active PySocialForce ped-ped ``SocialForce`` component.
 
-        The pairwise field-of-view model needs the social force's parameters
+        Pairwise replacement models need the social force's parameters
         (activation threshold, factor, and interaction exponents) so its per-pair
         reconstruction exactly matches the aggregate PySocialForce already sums into the
         total force. Fail closed if the component is missing, mirroring the ``max_speeds``
@@ -411,8 +432,7 @@ class Simulator:
             if isinstance(force, SocialForce):
                 return force
         raise RuntimeError(
-            "PySocialForce SocialForce component is unavailable for the pairwise "
-            "field-of-view pedestrian model"
+            "PySocialForce SocialForce component is unavailable for the pairwise pedestrian model"
         )
 
     def _pairwise_social_force_contributions(self, state: np.ndarray) -> np.ndarray:

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -37,11 +37,13 @@ from robot_sf.sim.pedestrian_model_variants import (
     HSFM_ALIGNMENT_TORQUE_V1,
     HSFM_ANISOTROPIC_FOV_V1,
     HSFM_TTC_PREDICTIVE_V1,
+    HSFM_ZANLUNGO_COLLISION_PREDICTION_V1,
 )
 from robot_sf.sim.sim_config import (
     AlignmentTorqueConfig,
     AnisotropicFovConfig,
     TtcPredictiveForceConfig,
+    ZanlungoCollisionPredictionConfig,
 )
 
 _MAP_REGISTRY_ENV = "ROBOT_SF_MAP_REGISTRY"
@@ -2110,6 +2112,10 @@ def _apply_single_pedestrian_override(
 # selector path below, so adding a new opt-in force model is a single-line change here.
 _OPT_IN_PEDESTRIAN_MODEL_CONFIGS: dict[str, tuple[type, str]] = {
     "ttc_predictive_force": (TtcPredictiveForceConfig, HSFM_TTC_PREDICTIVE_V1),
+    "zanlungo_collision_prediction": (
+        ZanlungoCollisionPredictionConfig,
+        HSFM_ZANLUNGO_COLLISION_PREDICTION_V1,
+    ),
     "anisotropic_fov": (AnisotropicFovConfig, HSFM_ANISOTROPIC_FOV_V1),
     "alignment_torque": (AlignmentTorqueConfig, HSFM_ALIGNMENT_TORQUE_V1),
 }
@@ -2254,6 +2260,7 @@ def _apply_simulation_overrides(
         "goal_radius",
         "pedestrian_model",
         "ttc_predictive_force",
+        "zanlungo_collision_prediction",
         "anisotropic_fov",
         "alignment_torque",
         "route_spawn_distribution",

--- a/tests/sim/test_zanlungo_collision_prediction_model.py
+++ b/tests/sim/test_zanlungo_collision_prediction_model.py
@@ -116,6 +116,51 @@ def test_exact_centered_collision_uses_finite_deterministic_direction_and_cap() 
 
 
 @pytest.mark.parametrize(
+    ("positions", "velocities", "message"),
+    [
+        (np.zeros((2, 3)), np.zeros((2, 2)), "positions"),
+        (np.zeros((2, 2)), np.zeros((3, 2)), "velocities"),
+        (np.array([[0.0, 0.0], [np.nan, 0.0]]), np.zeros((2, 2)), "finite"),
+    ],
+)
+def test_force_state_inputs_fail_closed(
+    positions: np.ndarray,
+    velocities: np.ndarray,
+    message: str,
+) -> None:
+    """Malformed state arrays fail before pairwise projection."""
+    with pytest.raises(ValueError, match=message):
+        _force(positions, velocities)
+
+
+def test_empty_single_actor_disabled_and_invalid_epsilon_paths() -> None:
+    """Trivial populations are no-ops and invalid numerical tolerance fails closed."""
+    np.testing.assert_array_equal(_force(np.empty((0, 2)), np.empty((0, 2))), np.empty((0, 2)))
+    np.testing.assert_array_equal(_force(np.zeros((1, 2)), np.zeros((1, 2))), np.zeros((1, 2)))
+    disabled = zanlungo_collision_prediction_repulsion(
+        np.zeros((2, 2)),
+        np.zeros((2, 2)),
+        interaction_strength=0.0,
+        interaction_range_m=0.71,
+        anisotropy_lambda=0.29,
+        angle_threshold_rad=np.pi / 4,
+        max_force=5.0,
+    )
+    np.testing.assert_array_equal(disabled, np.zeros((2, 2)))
+    with pytest.raises(ValueError, match="epsilon"):
+        zanlungo_collision_prediction_repulsion(
+            np.zeros((2, 2)),
+            np.zeros((2, 2)),
+            interaction_strength=1.13,
+            interaction_range_m=0.71,
+            anisotropy_lambda=0.29,
+            angle_threshold_rad=np.pi / 4,
+            max_force=5.0,
+            epsilon=0.0,
+        )
+
+
+@pytest.mark.parametrize(
     ("kwargs", "message"),
     [
         ({"interaction_strength": -1.0}, "interaction_strength"),
@@ -149,6 +194,16 @@ def test_scenario_selector_enables_validated_config_without_changing_default(tmp
     assert SimulationSettings().zanlungo_collision_prediction.enabled is False
     with pytest.raises(ValueError, match="anisotropy_lambda"):
         ZanlungoCollisionPredictionConfig(anisotropy_lambda=-0.1)
+    with pytest.raises(ValueError, match="interaction_strength"):
+        ZanlungoCollisionPredictionConfig(interaction_strength=-0.1)
+    with pytest.raises(ValueError, match="interaction_range_m"):
+        ZanlungoCollisionPredictionConfig(interaction_range_m=0.0)
+    with pytest.raises(ValueError, match="angle_threshold_rad"):
+        ZanlungoCollisionPredictionConfig(angle_threshold_rad=0.0)
+    with pytest.raises(ValueError, match="max_force"):
+        ZanlungoCollisionPredictionConfig(max_force=0.0)
+    with pytest.raises(ValueError, match="ZanlungoCollisionPredictionConfig"):
+        SimulationSettings(zanlungo_collision_prediction="invalid")  # type: ignore[arg-type]
 
     config = build_robot_config_from_scenario(
         {

--- a/tests/sim/test_zanlungo_collision_prediction_model.py
+++ b/tests/sim/test_zanlungo_collision_prediction_model.py
@@ -1,0 +1,227 @@
+"""Tests for the opt-in Zanlungo collision-prediction pedestrian force."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from pysocialforce.config import SocialForceConfig
+from pysocialforce.forces import SocialForce
+
+from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_ZANLUNGO_COLLISION_PREDICTION_V1,
+    SOCIAL_FORCE_DEFAULT,
+    pairwise_social_force_contributions,
+    step_hsfm_total_force,
+    zanlungo_collision_prediction_repulsion,
+)
+from robot_sf.sim.sim_config import (
+    SimulationSettings,
+    ZanlungoCollisionPredictionConfig,
+)
+from robot_sf.sim.simulator import Simulator
+from robot_sf.training.scenario_loader import build_robot_config_from_scenario
+
+
+class _FakePedState:
+    def __init__(self, state: np.ndarray) -> None:
+        self.state = state
+        self.max_speeds = np.full(state.shape[0], 10.0, dtype=float)
+        self.updated_state: np.ndarray | None = None
+        self.updated_groups: list[list[int]] | None = None
+
+    def update(self, state: np.ndarray, groups: list[list[int]]) -> None:
+        self.updated_state = state.copy()
+        self.updated_groups = groups
+
+
+def _force(positions: np.ndarray, velocities: np.ndarray) -> np.ndarray:
+    return zanlungo_collision_prediction_repulsion(
+        positions,
+        velocities,
+        interaction_strength=1.13,
+        interaction_range_m=0.71,
+        anisotropy_lambda=0.29,
+        angle_threshold_rad=np.pi / 4,
+        max_force=5.0,
+    )
+
+
+def _social_force_kwargs(config: SocialForceConfig) -> dict[str, float | int]:
+    return {
+        "activation_threshold": config.activation_threshold,
+        "n": config.n,
+        "n_prime": config.n_prime,
+        "lambda_importance": config.lambda_importance,
+        "gamma": config.gamma,
+        "factor": config.factor,
+    }
+
+
+def test_offset_head_on_paths_produce_opposite_early_lateral_yield_forces() -> None:
+    """Slightly offset head-on paths turn apart before their closest approach."""
+    positions = np.array([[0.0, 0.0], [2.0, 0.2]], dtype=float)
+    velocities = np.array([[0.5, 0.0], [-0.5, 0.0]], dtype=float)
+
+    force = _force(positions, velocities)
+
+    heading_cosine = 2.0 / np.sqrt(4.04)
+    anisotropy = 0.29 + (1.0 - 0.29) * (1.0 + heading_cosine) / 2.0
+    expected_magnitude = 1.13 * 0.5 / 2.0 * np.exp(-0.2 / 0.71) * anisotropy
+
+    assert force[0, 1] == pytest.approx(-expected_magnitude)
+    assert force[1, 1] == pytest.approx(expected_magnitude)
+    assert force[0, 0] == pytest.approx(0.0, abs=1e-12)
+    assert force[1, 0] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_common_earliest_time_makes_collision_prediction_non_additive() -> None:
+    """A later neighbor is projected at the actor's earlier collision time."""
+    two_positions = np.array([[0.0, 0.0], [2.0, 0.2]], dtype=float)
+    two_velocities = np.array([[0.5, 0.0], [-0.5, 0.0]], dtype=float)
+    three_positions = np.vstack((two_positions, [4.0, 1.0]))
+    three_velocities = np.vstack((two_velocities, [-0.5, 0.0]))
+
+    two_force = _force(two_positions, two_velocities)
+    three_force = _force(three_positions, three_velocities)
+
+    assert two_force[0, 0] == pytest.approx(0.0, abs=1e-12)
+    assert three_force[0, 0] < 0.0
+    assert not np.allclose(three_force[0], two_force[0])
+
+
+def test_separating_and_outside_approach_cone_pairs_are_inactive() -> None:
+    """Only closing pairs inside the paper's pi/4 approach cone contribute."""
+    positions = np.array([[0.0, 0.0], [2.0, 0.0]], dtype=float)
+    separating = np.array([[-0.5, 0.0], [0.5, 0.0]], dtype=float)
+    perpendicular = np.array([[0.5, 0.0], [0.5, 1.0]], dtype=float)
+
+    np.testing.assert_array_equal(_force(positions, separating), np.zeros((2, 2)))
+    np.testing.assert_array_equal(_force(positions, perpendicular), np.zeros((2, 2)))
+
+
+def test_exact_centered_collision_uses_finite_deterministic_direction_and_cap() -> None:
+    """The paper's zero-distance limit uses current separation without random symmetry breaking."""
+    positions = np.array([[0.0, 0.0], [0.2, 0.0]], dtype=float)
+    velocities = np.array([[1.0, 0.0], [-1.0, 0.0]], dtype=float)
+
+    first = _force(positions, velocities)
+    second = _force(positions, velocities)
+
+    np.testing.assert_array_equal(first, second)
+    assert np.all(np.isfinite(first))
+    assert first[0, 0] < 0.0 < first[1, 0]
+    assert np.max(np.linalg.norm(first, axis=-1)) <= 5.0
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"interaction_strength": -1.0}, "interaction_strength"),
+        ({"interaction_range_m": 0.0}, "interaction_range_m"),
+        ({"anisotropy_lambda": 1.1}, "anisotropy_lambda"),
+        ({"angle_threshold_rad": 0.0}, "angle_threshold_rad"),
+        ({"max_force": 0.0}, "max_force"),
+    ],
+)
+def test_force_parameters_fail_closed(kwargs: dict[str, float], message: str) -> None:
+    """Malformed parameters fail before entering the simulator step."""
+    parameters = {
+        "interaction_strength": 1.13,
+        "interaction_range_m": 0.71,
+        "anisotropy_lambda": 0.29,
+        "angle_threshold_rad": np.pi / 4,
+        "max_force": 5.0,
+    }
+    parameters.update(kwargs)
+    with pytest.raises(ValueError, match=message):
+        zanlungo_collision_prediction_repulsion(
+            np.zeros((2, 2)),
+            np.zeros((2, 2)),
+            **parameters,
+        )
+
+
+def test_scenario_selector_enables_validated_config_without_changing_default(tmp_path) -> None:
+    """Scenario YAML opts in explicitly while the default model remains unchanged."""
+    assert SimulationSettings().pedestrian_model == SOCIAL_FORCE_DEFAULT
+    assert SimulationSettings().zanlungo_collision_prediction.enabled is False
+    with pytest.raises(ValueError, match="anisotropy_lambda"):
+        ZanlungoCollisionPredictionConfig(anisotropy_lambda=-0.1)
+
+    config = build_robot_config_from_scenario(
+        {
+            "simulation_config": {
+                "pedestrian_model": HSFM_ZANLUNGO_COLLISION_PREDICTION_V1,
+                "zanlungo_collision_prediction": {
+                    "interaction_strength": 2.0,
+                    "interaction_range_m": 0.8,
+                },
+            }
+        },
+        scenario_path=tmp_path / "scenario.yaml",
+    )
+
+    variant = config.sim_config.zanlungo_collision_prediction
+    assert config.sim_config.pedestrian_model == HSFM_ZANLUNGO_COLLISION_PREDICTION_V1
+    assert variant.enabled is True
+    assert variant.interaction_strength == pytest.approx(2.0)
+    assert variant.interaction_range_m == pytest.approx(0.8)
+
+
+def test_runtime_replaces_only_existing_pedestrian_social_force() -> None:
+    """The selector preserves base forces while replacing the pairwise social aggregate."""
+    state = np.array(
+        [
+            [0.0, 0.0, 0.5, 0.0, 10.0, 0.0, 0.5],
+            [2.0, 0.2, -0.5, 0.0, -10.0, 0.2, 0.5],
+        ],
+        dtype=float,
+    )
+    social_config = SocialForceConfig()
+    pairwise_social = pairwise_social_force_contributions(
+        state[:, :2], state[:, 2:4], **_social_force_kwargs(social_config)
+    )
+    preserved_forces = np.array([[0.3, 0.1], [-0.2, -0.1]], dtype=float)
+    incoming_total = preserved_forces + pairwise_social.sum(axis=1)
+    predicted = _force(state[:, :2], state[:, 2:4])
+    expected_state, expected_headings = step_hsfm_total_force(
+        state.copy(),
+        preserved_forces + predicted,
+        np.array([0.0, np.pi]),
+        dt=0.1,
+        max_speeds=np.full(2, 10.0),
+    )
+
+    peds = _FakePedState(state.copy())
+    sim = object.__new__(Simulator)
+    sim.pedestrian_model = HSFM_ZANLUNGO_COLLISION_PREDICTION_V1
+    sim.pysf_sim = SimpleNamespace(peds=peds, forces=[SocialForce(social_config, None)])
+    sim.config = SimulationSettings(
+        pedestrian_model=HSFM_ZANLUNGO_COLLISION_PREDICTION_V1,
+        time_per_step_in_secs=0.1,
+    )
+    sim.ped_headings = np.array([0.0, np.pi])
+    sim._step_pedestrians(incoming_total, [[0], [1]])
+
+    np.testing.assert_allclose(peds.updated_state, expected_state, rtol=1e-9, atol=1e-9)
+    np.testing.assert_allclose(sim.ped_headings, expected_headings, rtol=1e-9, atol=1e-9)
+
+
+def test_runtime_fails_closed_when_social_component_cannot_be_replaced() -> None:
+    """Missing baseline social provenance never silently changes replacement semantics."""
+    state = np.array(
+        [
+            [0.0, 0.0, 0.5, 0.0, 10.0, 0.0, 0.5],
+            [2.0, 0.2, -0.5, 0.0, -10.0, 0.2, 0.5],
+        ]
+    )
+    sim = object.__new__(Simulator)
+    sim.pedestrian_model = HSFM_ZANLUNGO_COLLISION_PREDICTION_V1
+    sim.pysf_sim = SimpleNamespace(peds=_FakePedState(state), forces=[])
+    sim.config = SimulationSettings(pedestrian_model=HSFM_ZANLUNGO_COLLISION_PREDICTION_V1)
+    sim.ped_headings = np.array([0.0, np.pi])
+
+    with pytest.raises(RuntimeError, match="SocialForce component is unavailable"):
+        sim._step_pedestrians(np.zeros((2, 2)), [[0], [1]])


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds an opt-in `hsfm_zanlungo_collision_prediction_v1` pedestrian model that replaces the ordinary pedestrian-pedestrian social term with the non-additive common-time closest-approach force from Zanlungo, Ikeda, and Kanda (2011), plus validated config loading, focused tests, and a canonical diagnostic config.
- **Why now:** #4973 is ready-queue work, desired-speed decoupling is already present on `main`, and the existing #3481 TTC force is a distinct pairwise Karamouzas-style model rather than the requested Zanlungo formulation.
- **Claim boundary:** Implementation integrity and deterministic CPU smoke evidence only. The paper parameters are provenance, not a Robot SF calibration; this PR does not claim that corridor freezing is eliminated.
- **Required validation:** Published-equation contract tests, scenario/default/runtime/fail-closed tests, a real simulator CPU smoke, and final committed-HEAD repository readiness.
- **Remaining blocker:** A predeclared corridor comparison and parameter-sensitivity run must demonstrate yielding instead of freezing before #4973 can close.

## Contract delta

- New selector: `simulation_config.pedestrian_model: hsfm_zanlungo_collision_prediction_v1`.
- New nested config: `simulation_config.zanlungo_collision_prediction` with `enabled`, `interaction_strength`, `interaction_range_m`, `anisotropy_lambda`, `angle_threshold_rad`, `max_force`, and `include_ped_ped`.
- New runtime behavior: on the opt-in selector only, subtract the existing pedestrian-pedestrian `SocialForce` aggregate and replace it with the Zanlungo common-earliest-time projected force; goal, obstacle, group, and robot forces remain intact.
- New fail-closed blocker: malformed/non-finite parameters and state are rejected, and the runtime raises if the baseline `SocialForce` component is unavailable for exact replacement.
- Compatibility impact: `social_force_default` remains the default; the existing `hsfm_ttc_predictive_v1` path and all non-selected models are unchanged.

Refs #4973

Issue: https://github.com/ll7/robot_sf_ll7/issues/4973

## Scope summary

- Implemented equations 10–11 as pure, bounded helpers: earliest eligible closest-approach time, common-time projection of all neighbors, speed/time and exponential-distance scaling, and anisotropy.
- Added deterministic handling for the equation's exactly centered projected-distance direction and a per-actor force cap.
- Wired scenario loading and runtime replacement behind an explicit selector.
- Added the canonical diagnostic config and discoverable contract/provenance note.

Assumption: “optional variant” is implemented reversibly as a separate pedestrian-model selector that replaces only the existing pedestrian-pedestrian social interaction. The exact centered-collision direction is undefined in the paper, so the implementation uses current separation as a deterministic limiting direction and records that safeguard explicitly.

## Validation

- `uv run pytest -q tests/sim/test_zanlungo_collision_prediction_model.py tests/sim/test_ttc_predictive_pedestrian_model.py tests/sim/test_hsfm_total_force_model.py tests/sim/test_hsfm_alignment_torque_model.py tests/sim/test_hsfm_fov_pairwise_isolation.py tests/sim_config_test.py tests/test_scenario_loader_overrides.py tests/training/test_scenario_loader.py tests/training/test_scenario_loader_additional.py` — passed: 146 passed.
- `scripts/dev/check_docs_proof_consistency_diff.sh origin/main` and `uv run python scripts/dev/check_docs_evidence_integrity.py --files docs/context/README.md docs/context/INDEX.md docs/context/catalog.yaml docs/context/issue_4973_zanlungo_collision_prediction.md` — passed.
- Real simulator diagnostic smoke via `run_pedestrian_model_fixture_diagnostics` on `narrow_passage_lateral_sliding`, seed 4973, 20 CPU steps — passed: finite positions/velocities; explicitly `diagnostic-only`, `build_gate=false`.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue-4973-pr-body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on clean committed HEAD: core 2202 passed, 1 skipped; predictive optional 6436 passed, 17 skipped; changed-line coverage 100% for force/runtime/loader and 97.1% for simulator config (above the required 80% floor); Ruff, docstring, exception, PR-policy, and freshness gates passed.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## Remaining acceptance work

- [x] Optional Zanlungo collision-prediction force and scenario config.
- [x] Deterministic/replayable pure state function and unchanged default behavior.
- [ ] Predeclared head-on corridor comparison shows yielding instead of freezing across an explicit parameter-sensitivity range.

## Domain-Aware Approval

- Required for this PR: yes — this PR adds opt-in pedestrian physics and defines a diagnostic-only claim boundary.
- Domains reviewed: evidence classification, benchmark interpretation
- Status: approved
- Approver/review source or waiver: Codex self-review against the live #4973 contract, the Zanlungo et al. (2011) primary paper, `docs/maintainer_values.md`, and executable focused/runtime evidence; Claude's full PR gate remains required before merge.
- Validity checklist:
  - Target claim/hypothesis: the selector faithfully exposes the paper's common-time collision-prediction force without changing default dynamics.
  - Comparator or split/evidence validity: equation-level oracle and runtime force-composition reconstruction only; no outcome comparator is claimed.
  - Fallback/degraded exclusions: no fallback/degraded execution is counted as success; missing social-force provenance fails closed.
  - Claim boundary: implementation integrity and diagnostic CPU smoke only; no corridor, calibration, benchmark, or realism conclusion.
  - Implementation integrity vs experimental validity: tests prove implementation integrity; corridor experimental validity remains on #4973.

## Follow-Up Issues

- Deferred work: The predeclared corridor comparison and parameter-sensitivity run remain tracked by the open parent issue #4973.
- Issues opened for follow-up: #4973 (existing open parent; no new issue needed because this PR uses `Refs` and intentionally leaves it open).

<details>
<summary>Evidence, artifacts, propagation, and governance appendix</summary>

### Evidence and stop rule

- Target: prove that the selector executes the published non-additive force composition without changing defaults.
- Comparator: pure equation oracle plus direct runtime reconstruction of preserved non-social forces and replacement of the social aggregate.
- Evidence tier: implementation proof plus diagnostic CPU smoke; not benchmark evidence.
- Result classification: nameable new simulator capability; partial issue progress.
- Stop rule: focused/runtime/docs proof and final readiness must pass. Because the available corridor diagnostic did not demonstrate the issue's outcome claim with paper parameters, do not close #4973 or promote a freezing-mitigation claim.

### Artifacts

`output/coverage/` and `output/validation/pr_ready/` are ignored, disposable local readiness artifacts. No episode JSONL, video, coverage output, model artifact, or downloaded paper is committed.

### Fragmentation and dedupe

- No open PR covered #4973 or its exact title/scope at the start audit.
- No #4973 guardrail/checker/packet-refresh PR merged in the preceding 24 hours.
- This PR adds the nameable `hsfm_zanlungo_collision_prediction_v1` runtime capability and is not a micro-guard.

### Downstream propagation

No issue comment or tracked queue-state file is added: this run is explicitly unauthorized to comment, and transient queue routing must not be encoded in tracked files. `Refs #4973`, the canonical config/docs contract, and this PR body provide the durable delivery surface.

### Friction log

No new friction issue filed. The `gh issue view --comments` Projects Classic failure encountered
here already has a resolved repository tracking item; direct paginated REST reads were used to
avoid a duplicate report.

</details>
