### PR TITLE
feat(benchmark): record checkpoint provenance (issue #4970)

### DIFF
--- a/docs/benchmark_campaign_manifest.md
+++ b/docs/benchmark_campaign_manifest.md
@@ -156,6 +156,38 @@ The table contract is one row per `(config_name, family, planner)` with scenario
 unique seed count, denominator episodes, kinematics count, kinematics-expanded denominator
 episodes, and densities. Markdown tables may also be checked when they expose the same column names.
 
+## Per-arm checkpoint provenance
+
+Every camera-ready manifest planner arm carries a `checkpoint_provenance` block. Classical arms use
+`status: not_applicable`; checkpoint-backed arms record the model registry ID (when applicable),
+resolved checkpoint SHA-256, resolution details, actual runtime load result, and whether planner
+fallback triggered. Runtime results are also listed per kinematics variant under `runtime`, so a
+mixed-kinematics campaign cannot hide one degraded variant behind another successful load.
+
+Preflight-only manifests intentionally use `load_succeeded: null`, `fallback_triggered: null`, and
+`status: not_run`: checkpoint resolution is not proof that the planner loaded the weights. Completed
+campaigns change the status only from planner-emitted runtime diagnostics. At runtime SA-CADRL
+replaces the arm-level digest with a hash of its full TensorFlow checkpoint bundle (metadata, index,
+and data shards); ordinary single-file checkpoints use the file SHA-256. The nested preflight
+reference records retain the resolved registry artifact hash and state whether it was computed
+locally or came from registry-declared remote metadata.
+
+Existing campaigns remain audit-only by default. Set the following for comparison campaigns that
+must abort instead of silently using a learned-planner fallback:
+
+```yaml
+checkpoint_provenance_enforcement: error
+```
+
+Strict mode makes an unavailable implicit checkpoint (including SA-CADRL's default
+`ga3c_cadrl_iros18`) a preflight error and forces the effective planner prerequisite policy to
+`fail-fast`, including overriding an algorithm config's `allow_fallback: true`. The default `off`
+preserves legacy fallback behavior while still recording the result. Explicit `model_id` or
+`model_path` references retain the repository's existing always-on resolvability gate.
+
+This metadata proves artifact identity and the load/fallback path. It does not prove benchmark
+quality or make fallback/degraded rows success evidence.
+
 ## Per-arm tuning-effort block
 
 Each planner arm (a row in the campaign `planners` list) carries a `tuning` block in the camera-ready

--- a/robot_sf/benchmark/camera_ready/_config.py
+++ b/robot_sf/benchmark/camera_ready/_config.py
@@ -18,6 +18,7 @@ import yaml
 
 from robot_sf.benchmark.camera_ready._config_types import (
     _AMV_DIMENSIONS,
+    _CHECKPOINT_PROVENANCE_ENFORCEMENT,
     _TUNING_EFFORT_ENFORCEMENT,
     _TUNING_SOURCES,
     DEFAULT_SEED_SETS_PATH,
@@ -708,6 +709,12 @@ def _validate_campaign_config(cfg: CampaignConfig) -> None:  # noqa: C901, PLR09
                 "tuning_effort_enforcement='error' requires an author-declared 'tuning' block "
                 f"for every enabled arm; missing declared tuning block for: {names}"
             )
+    if cfg.checkpoint_provenance_enforcement not in _CHECKPOINT_PROVENANCE_ENFORCEMENT:
+        known = ", ".join(_CHECKPOINT_PROVENANCE_ENFORCEMENT)
+        raise ValueError(
+            "Unsupported checkpoint_provenance_enforcement "
+            f"'{cfg.checkpoint_provenance_enforcement}'. Expected one of: {known}"
+        )
     threshold_values = {
         "rank_alignment_warn_threshold": cfg.snqi_contract.rank_alignment_warn_threshold,
         "rank_alignment_fail_threshold": cfg.snqi_contract.rank_alignment_fail_threshold,
@@ -1129,6 +1136,9 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
         ),
         tuning_effort_enforcement=(
             str(payload.get("tuning_effort_enforcement", "off")).strip().lower() or "off"
+        ),
+        checkpoint_provenance_enforcement=(
+            str(payload.get("checkpoint_provenance_enforcement", "off")).strip().lower() or "off"
         ),
     )
     _validate_campaign_config(cfg)

--- a/robot_sf/benchmark/camera_ready/_config_types.py
+++ b/robot_sf/benchmark/camera_ready/_config_types.py
@@ -31,6 +31,7 @@ _TUNING_SOURCES = (TUNING_SOURCE_DECLARED, TUNING_SOURCE_BACKFILLED, TUNING_SOUR
 # blocks in the manifest but do not fail; "error" = fail closed when any enabled arm lacks a
 # declared tuning block.
 _TUNING_EFFORT_ENFORCEMENT = ("off", "warn", "error")
+_CHECKPOINT_PROVENANCE_ENFORCEMENT = ("off", "error")
 
 
 @dataclass(frozen=True)
@@ -181,3 +182,7 @@ class CampaignConfig:
     # blocks in the manifest but do not fail; "error" = fail closed when any enabled arm lacks a
     # declared tuning block.
     tuning_effort_enforcement: str = "off"
+    # Runtime checkpoint provenance remains audit-only by default for backwards compatibility.
+    # ``error`` also makes implicit learned checkpoints (such as SA-CADRL's registry default)
+    # fail closed during preflight and disables planner fallback for campaign execution.
+    checkpoint_provenance_enforcement: str = "off"

--- a/robot_sf/benchmark/camera_ready/_preflight.py
+++ b/robot_sf/benchmark/camera_ready/_preflight.py
@@ -73,6 +73,53 @@ _CHECKPOINT_PREFLIGHT_REPORT_NAME: dict[str, str] = {
 _TUNING_BACKFILL_PENDING = "backfill_pending"
 
 
+def _checkpoint_provenance_block(
+    planner: PlannerSpec,
+    checkpoint_preflight_summary: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the preflight checkpoint-provenance block for one campaign arm.
+
+    Returns:
+        JSON-serializable checkpoint identity and not-yet-run status.
+    """
+    references = [
+        dict(item)
+        for item in checkpoint_preflight_summary.get("arms", [])
+        if isinstance(item, dict) and item.get("planner_key") == planner.key
+    ]
+    if not references:
+        return {
+            "status": "not_applicable",
+            "model_id": None,
+            "checkpoint_sha256": None,
+            "load_succeeded": None,
+            "fallback_triggered": None,
+            "references": [],
+            "runtime": [],
+        }
+    model_ids = sorted(
+        {str(item["model_id"]) for item in references if item.get("model_id") is not None}
+    )
+    hashes = sorted(
+        {
+            str(item["checkpoint_sha256"])
+            for item in references
+            if item.get("checkpoint_sha256") is not None
+        }
+    )
+    resolved_statuses = {"present_local", "staged", "stageable_remote"}
+    unresolved = [item for item in references if item.get("status") not in resolved_statuses]
+    return {
+        "status": "resolution_failed" if unresolved else "not_run",
+        "model_id": model_ids[0] if len(model_ids) == 1 else None,
+        "checkpoint_sha256": hashes[0] if len(hashes) == 1 else None,
+        "load_succeeded": None,
+        "fallback_triggered": None,
+        "references": references,
+        "runtime": [],
+    }
+
+
 def _tuning_effort_block(planner: PlannerSpec) -> dict[str, Any]:
     """Return the per-arm tuning-effort manifest block (issue #5143).
 
@@ -392,6 +439,7 @@ def prepare_campaign_preflight(  # noqa: PLR0913
         stage=checkpoint_preflight_stage,
         registry_path=checkpoint_registry_path,
         cache_dir=checkpoint_cache_dir,
+        fail_closed_implicit=cfg.checkpoint_provenance_enforcement == "error",
     )
     ensure_canonical_tree(categories=("benchmarks",))
     campaign_id = _resolve_campaign_id(cfg, label=label, campaign_id=campaign_id)
@@ -622,11 +670,15 @@ def prepare_campaign_preflight(  # noqa: PLR0913
                 "observation_mode": planner.observation_mode,
                 "enabled": planner.enabled,
                 "tuning": _tuning_effort_block(planner),
+                "checkpoint_provenance": _checkpoint_provenance_block(
+                    planner, checkpoint_preflight_report
+                ),
             }
             for planner in cfg.planners
         ],
         "tuning_effort_enforcement": cfg.tuning_effort_enforcement,
         "tuning_effort_summary": _tuning_effort_summary(cfg.planners),
+        "checkpoint_provenance_enforcement": cfg.checkpoint_provenance_enforcement,
         "kinematics_matrix": list(cfg.kinematics_matrix),
         "holonomic_command_mode": cfg.holonomic_command_mode,
         "observation_mode": cfg.observation_mode,

--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -252,6 +252,20 @@ class _CampaignPlannerBatchResult:
     warnings: list[str]
 
 
+def _checkpoint_fallback_detected(summary: dict[str, Any]) -> bool:
+    """Return whether preflight or runtime metadata proves checkpoint fallback occurred."""
+    preflight = summary.get("preflight")
+    contract = summary.get("algorithm_metadata_contract")
+    checkpoint = contract.get("checkpoint_provenance") if isinstance(contract, dict) else None
+    preflight_fallback = isinstance(preflight, dict) and (
+        preflight.get("status") == "fallback"
+        or preflight.get("planner_metadata_status") == "fallback"
+    )
+    return preflight_fallback or (
+        isinstance(checkpoint, dict) and checkpoint.get("fallback_triggered") is True
+    )
+
+
 def _cleanup_gpu_memory_between_arms(
     *,
     planner_key: str,
@@ -350,7 +364,11 @@ def _execute_campaign_planner_batch(
                 str(planner.algo_config_path) if planner.algo_config_path is not None else None
             ),
             benchmark_profile=planner.benchmark_profile,
-            socnav_missing_prereq_policy=planner.socnav_missing_prereq_policy,
+            socnav_missing_prereq_policy=(
+                "fail-fast"
+                if cfg.checkpoint_provenance_enforcement == "error"
+                else planner.socnav_missing_prereq_policy
+            ),
             adapter_impact_eval=planner.adapter_impact_eval,
             observation_mode=run.active_observation_mode,
             observation_noise=cfg.observation_noise,
@@ -382,6 +400,12 @@ def _execute_campaign_planner_batch(
             "failures": [],
         }
         warnings.append(f"Planner '{planner.key}' failed for kinematics '{run.kinematics}': {exc}")
+    if cfg.checkpoint_provenance_enforcement == "error":
+        if _checkpoint_fallback_detected(summary):
+            raise RuntimeError(
+                "checkpoint_provenance_enforcement='error' blocked planner fallback for "
+                f"arm '{planner.key}' ({run.kinematics})"
+            )
     return _CampaignPlannerBatchResult(status=status, summary=summary, warnings=warnings)
 
 
@@ -690,7 +714,11 @@ def _run_campaign_planner_variant_subprocess(
         planner_human_model_source=planner.human_model_source,
         planner_group=planner.planner_group,
         benchmark_profile=planner.benchmark_profile,
-        socnav_missing_prereq_policy=planner.socnav_missing_prereq_policy,
+        socnav_missing_prereq_policy=(
+            "fail-fast"
+            if cfg.checkpoint_provenance_enforcement == "error"
+            else planner.socnav_missing_prereq_policy
+        ),
         adapter_impact_eval=planner.adapter_impact_eval,
         kinematics=kinematics,
         observation_mode=active_observation_mode,
@@ -1049,6 +1077,98 @@ def _build_skipped_combo_rows(run_entries: list[dict[str, Any]]) -> list[dict[st
     return skipped_combo_rows
 
 
+def _runtime_checkpoint_record(
+    entry: dict[str, Any], provenance: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Return one kinematics-specific runtime checkpoint record when observable."""
+    summary = entry.get("summary")
+    planner_entry = entry.get("planner")
+    if not isinstance(summary, dict) or not isinstance(planner_entry, dict):
+        return None
+    contract = summary.get("algorithm_metadata_contract")
+    runtime = contract.get("checkpoint_provenance") if isinstance(contract, dict) else None
+    if not isinstance(runtime, dict):
+        preflight = summary.get("preflight")
+        if isinstance(preflight, dict) and preflight.get("status") == "fallback":
+            runtime = {
+                "model_id": provenance.get("model_id"),
+                "checkpoint_sha256": provenance.get("checkpoint_sha256"),
+                "load_succeeded": False,
+                "fallback_triggered": True,
+                "load_status": "fallback",
+                "load_error": preflight.get("error"),
+            }
+        else:
+            return None
+    return {
+        **runtime,
+        "kinematics": planner_entry.get("kinematics"),
+        "run_status": entry.get("status"),
+    }
+
+
+def _summarize_checkpoint_runtime(provenance: dict[str, Any]) -> None:
+    """Summarize kinematics-specific load results on the planner-level block."""
+    runtime_records = provenance.get("runtime")
+    if not isinstance(runtime_records, list) or not runtime_records:
+        return
+    load_values = [
+        item.get("load_succeeded")
+        for item in runtime_records
+        if isinstance(item, dict) and isinstance(item.get("load_succeeded"), bool)
+    ]
+    fallback_values = [
+        item.get("fallback_triggered")
+        for item in runtime_records
+        if isinstance(item, dict) and isinstance(item.get("fallback_triggered"), bool)
+    ]
+    provenance["load_succeeded"] = all(load_values) if load_values else None
+    provenance["fallback_triggered"] = any(fallback_values) if fallback_values else None
+    runtime_hashes = {
+        str(item["checkpoint_sha256"])
+        for item in runtime_records
+        if isinstance(item, dict) and item.get("checkpoint_sha256") is not None
+    }
+    if len(runtime_hashes) == 1:
+        provenance["checkpoint_sha256"] = runtime_hashes.pop()
+    if provenance["fallback_triggered"] is True:
+        provenance["status"] = "fallback"
+    elif provenance["load_succeeded"] is True:
+        provenance["status"] = "loaded"
+    elif provenance["load_succeeded"] is False:
+        provenance["status"] = "load_failed"
+    else:
+        provenance["status"] = "runtime_not_observed"
+
+
+def _finalize_checkpoint_provenance(
+    manifest_payload: dict[str, Any], run_entries: list[dict[str, Any]]
+) -> None:
+    """Fold runtime load/fallback diagnostics into each manifest planner arm in place."""
+    planners = manifest_payload.get("planners")
+    if not isinstance(planners, list):
+        return
+    by_key = {str(planner.get("key")): planner for planner in planners if isinstance(planner, dict)}
+    for entry in run_entries:
+        planner_entry = entry.get("planner")
+        if not isinstance(planner_entry, dict):
+            continue
+        planner = by_key.get(str(planner_entry.get("key")))
+        provenance = planner.get("checkpoint_provenance") if isinstance(planner, dict) else None
+        if not isinstance(provenance, dict) or provenance.get("status") == "not_applicable":
+            continue
+        runtime = _runtime_checkpoint_record(entry, provenance)
+        if not isinstance(runtime, dict):
+            continue
+        provenance.setdefault("runtime", []).append(runtime)
+        planner_entry["checkpoint_provenance"] = runtime
+
+    for planner in planners:
+        provenance = planner.get("checkpoint_provenance") if isinstance(planner, dict) else None
+        if isinstance(provenance, dict):
+            _summarize_checkpoint_runtime(provenance)
+
+
 def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
     cfg: CampaignConfig,
     *,
@@ -1127,6 +1247,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
     planner_rows = planner_run_results.planner_rows
     warnings = planner_run_results.warnings
     seed_variability_records = planner_run_results.seed_variability_records
+    _finalize_checkpoint_provenance(manifest_payload, run_entries)
 
     planner_rows.sort(
         key=lambda row: (row.get("snqi_mean", "nan") == "nan", row.get("planner_key"))

--- a/robot_sf/benchmark/campaign_checkpoint_preflight.py
+++ b/robot_sf/benchmark/campaign_checkpoint_preflight.py
@@ -23,11 +23,11 @@ mirrors the fail-closed shape of :mod:`robot_sf.benchmark.orca_preflight` and of
   the compute node loads a validated file instead of discovering a corrupt or incomplete cache 14h
   in. Ops runs this before ``sbatch`` (see ``scripts/benchmark/preflight_campaign_checkpoints.py``).
 
-Claim boundary: this is a provisioning / fail-closed preflight. It does not run the benchmark, does
-not by itself constitute benchmark evidence, and only inspects checkpoint *references* named exactly
-``model_id`` / ``model_path`` in an arm's ``algo_config`` (recursively, so a nested prior policy is
-covered). Other model-loading side channels (for example ``predictive_foresight_model_id``) are out
-of scope and keep their existing runtime behavior.
+Claim boundary: this is a provisioning / fail-closed preflight. It does not run the benchmark and
+does not by itself constitute benchmark evidence. It inspects the generic ``model_id`` /
+``model_path`` pair and the SA-CADRL/predictive planner model fields recursively. The registry-backed
+SA-CADRL default is also represented when an arm has no algorithm config, so its checkpoint cannot
+remain implicit. Other model-loading side channels keep their existing runtime behavior.
 """
 
 from __future__ import annotations
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any
 import yaml
 from loguru import logger
 
+from robot_sf.benchmark.identity.hash_utils import sha256_file
 from robot_sf.models import get_registry_entry, resolve_model_path
 
 if TYPE_CHECKING:
@@ -49,7 +50,12 @@ from robot_sf.errors import RobotSfError
 # ``model_id`` resolves through the registry; ``model_path`` is a direct filesystem reference.
 # ``model_id`` wins when both appear at the same mapping level, mirroring
 # ``PPOPlanner._load_model`` runtime semantics.
-_CHECKPOINT_REFERENCE_KEYS: tuple[str, ...] = ("model_id", "model_path")
+_CHECKPOINT_REFERENCE_KEY_PAIRS: tuple[tuple[str, str], ...] = (
+    ("model_id", "model_path"),
+    ("sacadrl_model_id", "sacadrl_checkpoint_path"),
+    ("predictive_model_id", "predictive_checkpoint_path"),
+)
+_DEFAULT_SACADRL_MODEL_ID = "ga3c_cadrl_iros18"
 # Registry-entry fields that declare a durable remote source ``resolve_model_path`` can stage.
 _REMOTE_SOURCE_KEYS: tuple[str, ...] = (
     "github_release",
@@ -81,6 +87,7 @@ class ArmCheckpointReference:
     kind: str  # "model_id" or "model_path"
     value: str
     algo_config_path: Path | None
+    implicit: bool = False
 
 
 @dataclass(frozen=True)
@@ -92,6 +99,8 @@ class ArmCheckpointResolution:
     status: str
     detail: str
     resolved_path: Path | None = None
+    checkpoint_sha256: str | None = None
+    hash_source: str | None = None
 
 
 def _iter_mapping_checkpoint_keys(node: Any) -> list[tuple[str, str]]:
@@ -106,11 +115,13 @@ def _iter_mapping_checkpoint_keys(node: Any) -> list[tuple[str, str]]:
     """
     references: list[tuple[str, str]] = []
     if isinstance(node, dict):
-        for kind in _CHECKPOINT_REFERENCE_KEYS:
-            value = node.get(kind)
-            if isinstance(value, str) and value.strip():
-                references.append((kind, value.strip()))
-                break
+        for model_id_key, model_path_key in _CHECKPOINT_REFERENCE_KEY_PAIRS:
+            model_id = node.get(model_id_key)
+            model_path = node.get(model_path_key)
+            if isinstance(model_id, str) and model_id.strip():
+                references.append(("model_id", model_id.strip()))
+            elif isinstance(model_path, str) and model_path.strip():
+                references.append(("model_path", model_path.strip()))
         for value in node.values():
             references.extend(_iter_mapping_checkpoint_keys(value))
     elif isinstance(node, (list, tuple)):
@@ -162,10 +173,13 @@ def iter_campaign_arm_checkpoint_references(
     references: list[ArmCheckpointReference] = []
     for planner in cfg.planners:
         if not _is_learned_checkpoint_planner(planner):
-            continue
-        config_path = Path(planner.algo_config_path)  # type: ignore[arg-type]
-        algo_config = _load_algo_config(config_path)
-        for kind, value in _iter_mapping_checkpoint_keys(algo_config):
+            planner_references: list[tuple[str, str]] = []
+            config_path = None
+        else:
+            config_path = Path(planner.algo_config_path)  # type: ignore[arg-type]
+            algo_config = _load_algo_config(config_path)
+            planner_references = _iter_mapping_checkpoint_keys(algo_config)
+        for kind, value in planner_references:
             references.append(
                 ArmCheckpointReference(
                     planner_key=planner.key,
@@ -173,6 +187,21 @@ def iter_campaign_arm_checkpoint_references(
                     kind=kind,
                     value=value,
                     algo_config_path=config_path,
+                )
+            )
+        if (
+            planner.enabled
+            and planner.algo.strip().lower() in {"sacadrl", "sa_cadrl"}
+            and not planner_references
+        ):
+            references.append(
+                ArmCheckpointReference(
+                    planner_key=planner.key,
+                    algo=planner.algo,
+                    kind="model_id",
+                    value=_DEFAULT_SACADRL_MODEL_ID,
+                    algo_config_path=config_path,
+                    implicit=True,
                 )
             )
     return references
@@ -196,6 +225,8 @@ def _resolve_model_path_reference(
             status="present_local",
             detail=f"model_path file present at {path}",
             resolved_path=path,
+            checkpoint_sha256=sha256_file(path),
+            hash_source="computed_file",
         )
     return ArmCheckpointResolution(
         reference=reference,
@@ -208,6 +239,19 @@ def _resolve_model_path_reference(
 def _entry_has_remote_source(entry: dict[str, Any]) -> bool:
     """Return True when a registry entry declares a durable remote source to stage from."""
     return any(entry.get(key) for key in _REMOTE_SOURCE_KEYS)
+
+
+def _declared_registry_sha256(entry: dict[str, Any]) -> str | None:
+    """Return a registry-declared SHA-256 for an unstaged remote artifact, when available."""
+    release = entry.get("github_release")
+    if isinstance(release, dict):
+        value = release.get("sha256")
+        if isinstance(value, str) and len(value.strip()) == 64:
+            return value.strip().lower()
+    value = entry.get("sha256")
+    if isinstance(value, str) and len(value.strip()) == 64:
+        return value.strip().lower()
+    return None
 
 
 def _resolve_model_id_reference_cheap(
@@ -244,6 +288,8 @@ def _resolve_model_id_reference_cheap(
                 status="present_local",
                 detail=f"registry local_path present at {resolved}",
                 resolved_path=resolved,
+                checkpoint_sha256=sha256_file(resolved),
+                hash_source="computed_file",
             )
     if bool(entry.get("local_only")):
         return ArmCheckpointResolution(
@@ -256,6 +302,7 @@ def _resolve_model_id_reference_cheap(
             ),
         )
     if _entry_has_remote_source(entry):
+        declared_sha256 = _declared_registry_sha256(entry)
         return ArmCheckpointResolution(
             reference=reference,
             resolvable=True,
@@ -265,6 +312,8 @@ def _resolve_model_id_reference_cheap(
                 "source; run with stage=True (or the preflight script with --stage) before sbatch "
                 "to download and checksum-verify it"
             ),
+            checkpoint_sha256=declared_sha256,
+            hash_source="registry_declared" if declared_sha256 is not None else None,
         )
     return ArmCheckpointResolution(
         reference=reference,
@@ -315,6 +364,8 @@ def _resolve_model_id_reference_staged(
         status="staged",
         detail=f"model_id '{reference.value}' staged and verified at {path}",
         resolved_path=path,
+        checkpoint_sha256=sha256_file(path),
+        hash_source="computed_file",
     )
 
 
@@ -422,6 +473,7 @@ def check_campaign_arm_checkpoints_preflight(
     stage: bool = False,
     registry_path: str | Path | None = None,
     cache_dir: str | Path | None = None,
+    fail_closed_implicit: bool = False,
 ) -> dict[str, Any]:
     """Fail fast when any enabled arm's checkpoint cannot be resolved before a campaign runs.
 
@@ -437,6 +489,7 @@ def check_campaign_arm_checkpoints_preflight(
             present locally or has a stageable remote source (no network access).
         registry_path: Optional model-registry path override (useful for tests/fixtures).
         cache_dir: Optional cache directory override for staged downloads.
+        fail_closed_implicit: Whether implicit registry defaults are blocking when unresolved.
 
     Returns:
         dict[str, Any]: A summary with the checked/resolved counts and per-arm resolution status.
@@ -469,23 +522,32 @@ def check_campaign_arm_checkpoints_preflight(
         for reference in references
     ]
     failures = [resolution for resolution in resolutions if not resolution.resolvable]
-    if failures:
-        message = _preflight_failure_message(failures, stage=stage)
+    blocking_failures = [
+        resolution
+        for resolution in failures
+        if not resolution.reference.implicit or fail_closed_implicit
+    ]
+    if blocking_failures:
+        message = _preflight_failure_message(blocking_failures, stage=stage)
         logger.error(message)
-        failing_arms = tuple(sorted({resolution.reference.planner_key for resolution in failures}))
+        failing_arms = tuple(
+            sorted({resolution.reference.planner_key for resolution in blocking_failures})
+        )
         raise CampaignCheckpointPreflightError(message, arms=failing_arms)
 
     submit_safe = _compute_submit_safe(resolutions, stage=stage)
     if not submit_safe:
         logger.warning(
             "Checkpoint preflight passed resolvability but is NOT submit-safe: "
-            "stageable_remote arms must be staged with stage=True (or the preflight script with "
-            "--stage) before sbatch. See docs/context/issue_4613_camera_ready_checkpoint_provisioning.md."
+            "every checkpoint must be present or staged before sbatch. Stage remote-backed arms "
+            "with stage=True; unresolved implicit defaults are audit-only unless strict provenance "
+            "enforcement is enabled. See "
+            "docs/context/issue_4613_camera_ready_checkpoint_provisioning.md."
         )
     logger.info(f"Checkpoint {mode} preflight passed for {len(references)} reference(s).")
     return {
         "checked": len(resolutions),
-        "resolved": len(resolutions),
+        "resolved": len(resolutions) - len(failures),
         "stage": bool(stage),
         "submit_safe": submit_safe,
         "arms": [
@@ -494,10 +556,19 @@ def check_campaign_arm_checkpoints_preflight(
                 "algo": resolution.reference.algo,
                 "kind": resolution.reference.kind,
                 "value": resolution.reference.value,
+                "implicit": resolution.reference.implicit,
                 "status": resolution.status,
                 "resolved_path": (
                     str(resolution.resolved_path) if resolution.resolved_path is not None else None
                 ),
+                "model_id": (
+                    resolution.reference.value if resolution.reference.kind == "model_id" else None
+                ),
+                "checkpoint_sha256": resolution.checkpoint_sha256,
+                "hash_source": resolution.hash_source,
+                "load_succeeded": None,
+                "fallback_triggered": None,
+                "load_status": "not_run",
             }
             for resolution in resolutions
         ],

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -731,6 +731,9 @@ def _preflight_policy(  # noqa: C901, PLR0915
             "Unsupported socnav prereq policy "
             f"'{missing_prereq_policy}'. Expected fail-fast|skip-with-warning|fallback.",
         )
+    effective_algo_config = dict(algo_config)
+    if policy == "fail-fast" and bool(effective_algo_config.get("allow_fallback", False)):
+        effective_algo_config["allow_fallback"] = False
 
     def _build_and_close(cfg: dict[str, Any]) -> dict[str, Any]:
         """Instantiate then close one planner, returning any emitted benchmark metadata.
@@ -801,7 +804,7 @@ def _preflight_policy(  # noqa: C901, PLR0915
 
     learned_contract = _evaluate_learned_policy_contract(
         algo=algo,
-        algo_config=algo_config,
+        algo_config=effective_algo_config,
         benchmark_profile=benchmark_profile,
         robot_kinematics=robot_kinematics,
     )
@@ -828,18 +831,18 @@ def _preflight_policy(  # noqa: C901, PLR0915
         )
 
     try:
-        planner_meta = _build_and_close(algo_config)
+        planner_meta = _build_and_close(effective_algo_config)
         metadata_issue = _preflight_metadata_issue(planner_meta)
         if metadata_issue is not None:
             logger.warning("{}", metadata_issue)
-            return dict(algo_config), {
+            return effective_algo_config, {
                 "status": "skipped",
                 "error": metadata_issue,
                 "planner_metadata_status": str(planner_meta.get("status", "")),
                 "planner_metadata_fallback_reason": planner_meta.get("fallback_reason"),
                 "learned_policy_contract": learned_contract,
             }
-        return dict(algo_config), {
+        return effective_algo_config, {
             "status": "ok",
             "learned_policy_contract": learned_contract,
         }
@@ -852,14 +855,14 @@ def _preflight_policy(  # noqa: C901, PLR0915
         )
         if policy == "skip-with-warning":
             logger.warning("{}", message)
-            return dict(algo_config), {
+            return effective_algo_config, {
                 "status": "skipped",
                 "error": str(exc),
                 "policy": policy,
                 "learned_policy_contract": learned_contract,
             }
         if policy == "fallback":
-            fallback_cfg = dict(algo_config)
+            fallback_cfg = dict(effective_algo_config)
             fallback_cfg["allow_fallback"] = True
             try:
                 _build_and_close(fallback_cfg)
@@ -1137,6 +1140,37 @@ def _build_external_mpc_policy(
     )
 
 
+def _checkpoint_runtime_metadata(planner: Any, algo_config: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a learned planner's live load/fallback state for benchmark artifacts.
+
+    Returns:
+        Runtime checkpoint status using the campaign provenance vocabulary.
+    """
+    metadata = planner.get_metadata() if hasattr(planner, "get_metadata") else {}
+    status = str(metadata.get("status", "unknown")).strip().lower()
+    return {
+        "model_id": algo_config.get("model_id"),
+        "checkpoint_sha256": None,
+        "hash_source": None,
+        "load_succeeded": status == "ok",
+        "fallback_triggered": status == "fallback",
+        "load_status": "loaded" if status == "ok" else status,
+        "load_error": metadata.get("fallback_reason"),
+    }
+
+
+def _attach_checkpoint_runtime_stats(
+    policy: Callable[[dict[str, Any]], Any], planner: Any, algo_config: dict[str, Any]
+) -> None:
+    """Attach a live checkpoint diagnostics hook to a learned policy callable."""
+
+    def _planner_stats() -> dict[str, Any]:
+        """Return checkpoint state after the latest planner step."""
+        return {"checkpoint_provenance": _checkpoint_runtime_metadata(planner, algo_config)}
+
+    policy._planner_stats = _planner_stats
+
+
 def _build_ppo_policy(  # noqa: C901
     algo_key: str,
     algo_config: dict[str, Any],
@@ -1209,6 +1243,7 @@ def _build_ppo_policy(  # noqa: C901
         return linear, angular
 
     _policy._planner_close = ppo_planner.close
+    _attach_checkpoint_runtime_stats(_policy, ppo_planner, algo_config)
     ppo_bind_env = getattr(ppo_planner, "bind_env", None)
     if callable(ppo_bind_env):
         _policy._planner_bind_env = ppo_bind_env
@@ -1314,6 +1349,7 @@ def _build_sac_policy(
         return linear, angular
 
     _policy._planner_close = sac_planner.close
+    _attach_checkpoint_runtime_stats(_policy, sac_planner, algo_config)
     _policy._planner_native_env_action = _sac_can_be_native
     if "status" not in meta:
         meta["status"] = "ok"
@@ -1393,6 +1429,7 @@ def _build_drl_vo_policy(
         return linear, angular
 
     _policy._planner_close = drl_planner.close
+    _attach_checkpoint_runtime_stats(_policy, drl_planner, algo_config)
     _attach_planner_reset(_policy, drl_planner)
     if "status" not in meta:
         meta["status"] = "ok"
@@ -1546,6 +1583,7 @@ def _build_guarded_ppo_policy(  # noqa: C901, PLR0915
             guard_close()
 
     _policy._planner_close = _close_guarded_ppo
+    _attach_checkpoint_runtime_stats(_policy, ppo_planner, ppo_config)
     ppo_bind_env = getattr(ppo_planner, "bind_env", None)
     guard_bind_env = getattr(guard_adapter, "bind_env", None)
     bind_hooks = [hook for hook in (ppo_bind_env, guard_bind_env) if callable(hook)]

--- a/robot_sf/benchmark/map_runner_batch_summary.py
+++ b/robot_sf/benchmark/map_runner_batch_summary.py
@@ -201,6 +201,16 @@ def merge_runtime_algorithm_contract(  # noqa: C901
             base_contract["upstream_reference"] = upstream_reference
         _merge_mapping(upstream_reference, runtime_upstream_reference)
 
+    runtime_planner = runtime_algorithm_metadata.get("planner_runtime")
+    if isinstance(runtime_planner, dict):
+        runtime_checkpoint = runtime_planner.get("checkpoint_provenance")
+        if isinstance(runtime_checkpoint, dict):
+            checkpoint = base_contract.get("checkpoint_provenance")
+            if not isinstance(checkpoint, dict):
+                checkpoint = {}
+                base_contract["checkpoint_provenance"] = checkpoint
+            _merge_mapping(checkpoint, runtime_checkpoint)
+
     return base_contract
 
 

--- a/robot_sf/planner/socnav.py
+++ b/robot_sf/planner/socnav.py
@@ -7,6 +7,7 @@ live in `robot_sf.planner.socnav_occupancy`; this module re-exports
 `OccupancyAwarePlannerMixin` for existing imports.
 """
 
+import hashlib
 import os
 import re
 import sys
@@ -3014,6 +3015,20 @@ class SACADRLPlannerAdapter(SamplingPlannerAdapter):
         self._model: _SACADRLModel | None = None
         self._load_error: Exception | None = None
         self._fallback_warned = False
+        self._checkpoint_provenance: dict[str, Any] = {
+            "model_id": self.config.sacadrl_model_id,
+            "checkpoint_path": self.config.sacadrl_checkpoint_path,
+            "checkpoint_sha256": None,
+            "hash_source": None,
+            "load_succeeded": None,
+            "fallback_triggered": False,
+            "load_status": "not_attempted",
+            "load_error": None,
+        }
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return runtime checkpoint provenance for benchmark episode metadata."""
+        return {"checkpoint_provenance": dict(self._checkpoint_provenance)}
 
     def plan(self, observation: dict) -> tuple[float, float]:
         """
@@ -3065,7 +3080,23 @@ class SACADRLPlannerAdapter(SamplingPlannerAdapter):
             return None if self._allow_fallback else self._raise_cached_error()
         try:
             self._model = self._build_model()
+            self._checkpoint_provenance.update(
+                {
+                    "load_succeeded": True,
+                    "fallback_triggered": False,
+                    "load_status": "loaded",
+                    "load_error": None,
+                }
+            )
         except Exception as exc:
+            self._checkpoint_provenance.update(
+                {
+                    "load_succeeded": False,
+                    "fallback_triggered": bool(self._allow_fallback),
+                    "load_status": "fallback" if self._allow_fallback else "failed",
+                    "load_error": f"{type(exc).__name__}: {exc}",
+                }
+            )
             if self._allow_fallback:
                 self._load_error = exc
                 if not self._fallback_warned:
@@ -3120,6 +3151,22 @@ class SACADRLPlannerAdapter(SamplingPlannerAdapter):
             raise FileNotFoundError(
                 f"GA3C-CADRL checkpoint data file not found for prefix: {prefix}"
             )
+        checkpoint_files = sorted([meta_path, index_path, *data_files], key=lambda path: path.name)
+        digest = hashlib.sha256()
+        for path in checkpoint_files:
+            digest.update(path.name.encode("utf-8"))
+            digest.update(b"\0")
+            with path.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            digest.update(b"\0")
+        self._checkpoint_provenance.update(
+            {
+                "checkpoint_path": str(meta_path.resolve()),
+                "checkpoint_sha256": digest.hexdigest(),
+                "hash_source": "computed_tensorflow_checkpoint_bundle",
+            }
+        )
         return prefix
 
     def _compute_goal_frame(

--- a/tests/benchmark/test_checkpoint_provenance_issue_4970.py
+++ b/tests/benchmark/test_checkpoint_provenance_issue_4970.py
@@ -1,0 +1,245 @@
+"""Checkpoint provenance contract tests for issue #4970."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import robot_sf.benchmark.camera_ready._preflight as preflight_module
+import robot_sf.benchmark.campaign_checkpoint_preflight as checkpoint_module
+from robot_sf.benchmark import map_runner
+from robot_sf.benchmark.camera_ready._config import _validate_campaign_config
+from robot_sf.benchmark.camera_ready._config_types import CampaignConfig, PlannerSpec
+from robot_sf.benchmark.camera_ready._preflight import prepare_campaign_preflight
+from robot_sf.benchmark.camera_ready.campaign import (
+    _checkpoint_fallback_detected,
+    _finalize_checkpoint_provenance,
+)
+from robot_sf.benchmark.campaign_checkpoint_preflight import (
+    CampaignCheckpointPreflightError,
+    check_campaign_arm_checkpoints_preflight,
+)
+from robot_sf.benchmark.map_runner_batch_summary import merge_runtime_algorithm_contract
+from robot_sf.planner.socnav import SACADRLPlannerAdapter, SocNavPlannerConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _campaign(
+    tmp_path: Path,
+    *,
+    enforcement: str = "off",
+    planner: PlannerSpec | None = None,
+) -> CampaignConfig:
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text("scenarios: []\n", encoding="utf-8")
+    return CampaignConfig(
+        name="issue_4970",
+        scenario_matrix_path=scenario_path,
+        planners=(planner or PlannerSpec(key="sacadrl", algo="sacadrl"),),
+        checkpoint_provenance_enforcement=enforcement,
+    )
+
+
+def test_default_sacadrl_checkpoint_is_hashed_in_preflight_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The implicit registry checkpoint is visible even without an algo_config block."""
+    monkeypatch.setattr(preflight_module, "_load_campaign_scenarios", lambda *_a, **_k: [])
+    prepared = prepare_campaign_preflight(_campaign(tmp_path), output_root=tmp_path / "out")
+
+    provenance = prepared["manifest_payload"]["planners"][0]["checkpoint_provenance"]
+    assert provenance["status"] == "not_run"
+    assert provenance["model_id"] == "ga3c_cadrl_iros18"
+    assert len(provenance["checkpoint_sha256"]) == 64
+    assert provenance["load_succeeded"] is None
+    assert provenance["fallback_triggered"] is None
+    assert provenance["references"][0]["implicit"] is True
+
+
+def test_implicit_checkpoint_is_audit_only_by_default_but_strict_mode_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default behavior stays compatible while the campaign flag makes absence blocking."""
+
+    def missing_entry(_model_id: str, _registry_path: str | Path | None = None) -> dict:
+        return {"model_id": "ga3c_cadrl_iros18", "local_path": str(tmp_path / "missing.meta")}
+
+    monkeypatch.setattr(checkpoint_module, "get_registry_entry", missing_entry)
+    summary = check_campaign_arm_checkpoints_preflight(_campaign(tmp_path))
+    assert summary["resolved"] == 0
+    assert summary["arms"][0]["status"] == "no_resolvable_source"
+
+    with pytest.raises(CampaignCheckpointPreflightError, match="ga3c_cadrl_iros18"):
+        check_campaign_arm_checkpoints_preflight(
+            _campaign(tmp_path, enforcement="error"), fail_closed_implicit=True
+        )
+
+
+def test_checkpoint_provenance_enforcement_rejects_unknown_value(tmp_path: Path) -> None:
+    """The campaign flag is a closed two-value vocabulary."""
+    with pytest.raises(ValueError, match="checkpoint_provenance_enforcement"):
+        _validate_campaign_config(_campaign(tmp_path, enforcement="sometimes"))
+
+
+def test_sacadrl_runtime_diagnostics_record_load_and_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Planner initialization exposes the actual load outcome instead of an inferred label."""
+    loaded = SACADRLPlannerAdapter()
+    monkeypatch.setattr(loaded, "_build_model", object)
+    assert loaded._ensure_model() is not None
+    assert loaded.diagnostics()["checkpoint_provenance"]["load_succeeded"] is True
+    assert loaded.diagnostics()["checkpoint_provenance"]["fallback_triggered"] is False
+
+    fallback = SACADRLPlannerAdapter(allow_fallback=True)
+
+    def fail_load() -> object:
+        raise FileNotFoundError("checkpoint missing")
+
+    monkeypatch.setattr(fallback, "_build_model", fail_load)
+    assert fallback._ensure_model() is None
+    provenance = fallback.diagnostics()["checkpoint_provenance"]
+    assert provenance["load_succeeded"] is False
+    assert provenance["fallback_triggered"] is True
+    assert provenance["load_status"] == "fallback"
+    assert "checkpoint missing" in provenance["load_error"]
+
+
+def test_sacadrl_tensorflow_bundle_hash_covers_all_checkpoint_files(tmp_path: Path) -> None:
+    """The runtime digest covers meta, index, and data files, not metadata alone."""
+    prefix = tmp_path / "network"
+    prefix.with_suffix(".meta").write_bytes(b"meta")
+    prefix.with_suffix(".index").write_bytes(b"index")
+    (tmp_path / "network.data-00000-of-00001").write_bytes(b"weights")
+    adapter = SACADRLPlannerAdapter(
+        SocNavPlannerConfig(sacadrl_checkpoint_path=str(prefix.with_suffix(".meta")))
+    )
+    assert adapter._resolve_checkpoint_prefix() == prefix
+    first_hash = adapter.diagnostics()["checkpoint_provenance"]["checkpoint_sha256"]
+    assert len(first_hash) == 64
+
+    (tmp_path / "network.data-00000-of-00001").write_bytes(b"changed")
+    adapter._resolve_checkpoint_prefix()
+    assert adapter.diagnostics()["checkpoint_provenance"]["checkpoint_sha256"] != first_hash
+
+
+def test_fail_fast_policy_disables_configured_planner_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Strict campaign execution cannot retain a hidden allow_fallback escape hatch."""
+    seen: list[bool] = []
+
+    def build_policy(_algo: str, config: dict, **_kwargs):
+        seen.append(bool(config.get("allow_fallback")))
+        return (lambda _obs: (0.0, 0.0)), {"status": "ok"}
+
+    monkeypatch.setattr(map_runner, "_build_policy", build_policy)
+    effective, preflight = map_runner._preflight_policy(
+        algo="sacadrl",
+        algo_config={"allow_fallback": True},
+        benchmark_profile="baseline-safe",
+        missing_prereq_policy="fail-fast",
+    )
+    assert seen == [False]
+    assert effective["allow_fallback"] is False
+    assert preflight["status"] == "ok"
+
+
+def test_generic_learned_planner_stats_capture_runtime_fallback() -> None:
+    """PPO/SAC/DRL-style metadata is normalized after runtime, not only at construction."""
+
+    class Planner:
+        def get_metadata(self) -> dict:
+            return {"status": "fallback", "fallback_reason": "prediction_failed"}
+
+    policy = lambda _obs: (0.0, 0.0)  # noqa: E731
+    map_runner._attach_checkpoint_runtime_stats(policy, Planner(), {"model_id": "ppo_demo"})
+    provenance = policy._planner_stats()["checkpoint_provenance"]
+    assert provenance == {
+        "model_id": "ppo_demo",
+        "checkpoint_sha256": None,
+        "hash_source": None,
+        "load_succeeded": False,
+        "fallback_triggered": True,
+        "load_status": "fallback",
+        "load_error": "prediction_failed",
+    }
+    assert _checkpoint_fallback_detected(
+        {"algorithm_metadata_contract": {"checkpoint_provenance": provenance}}
+    )
+
+
+def test_batch_summary_bridges_runtime_checkpoint_provenance() -> None:
+    """Per-episode planner diagnostics reach the batch contract consumed by campaigns."""
+    runtime = {
+        "planner_runtime": {
+            "checkpoint_provenance": {
+                "model_id": "ppo_demo",
+                "load_succeeded": True,
+                "fallback_triggered": False,
+            }
+        }
+    }
+    merged = merge_runtime_algorithm_contract({}, runtime)
+    assert merged["checkpoint_provenance"] == {
+        "model_id": "ppo_demo",
+        "load_succeeded": True,
+        "fallback_triggered": False,
+    }
+
+    existing = {"checkpoint_provenance": {"model_id": "ppo_demo", "load_succeeded": None}}
+    merge_runtime_algorithm_contract(existing, runtime)
+    assert existing["checkpoint_provenance"]["load_succeeded"] is True
+
+    unchanged = {"checkpoint_provenance": "malformed"}
+    merge_runtime_algorithm_contract(unchanged, runtime)
+    assert unchanged["checkpoint_provenance"]["model_id"] == "ppo_demo"
+
+
+def test_campaign_manifest_folds_runtime_checkpoint_status_per_kinematics() -> None:
+    """Completed campaign arms expose runtime load/fallback status in the final manifest."""
+    manifest = {
+        "planners": [
+            {
+                "key": "sacadrl",
+                "checkpoint_provenance": {
+                    "status": "not_run",
+                    "model_id": "ga3c_cadrl_iros18",
+                    "checkpoint_sha256": "a" * 64,
+                    "load_succeeded": None,
+                    "fallback_triggered": None,
+                    "runtime": [],
+                },
+            }
+        ]
+    }
+    runs = [
+        {
+            "planner": {"key": "sacadrl", "kinematics": "differential_drive"},
+            "status": "ok",
+            "summary": {
+                "algorithm_metadata_contract": {
+                    "checkpoint_provenance": {
+                        "model_id": "ga3c_cadrl_iros18",
+                        "checkpoint_sha256": "b" * 64,
+                        "load_succeeded": True,
+                        "fallback_triggered": False,
+                        "load_status": "loaded",
+                    }
+                }
+            },
+        }
+    ]
+
+    _finalize_checkpoint_provenance(manifest, runs)
+
+    provenance = manifest["planners"][0]["checkpoint_provenance"]
+    assert provenance["status"] == "loaded"
+    assert provenance["load_succeeded"] is True
+    assert provenance["fallback_triggered"] is False
+    assert provenance["checkpoint_sha256"] == "b" * 64
+    assert provenance["runtime"][0]["kinematics"] == "differential_drive"
+    assert runs[0]["planner"]["checkpoint_provenance"]["load_status"] == "loaded"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: camera-ready campaign manifests now record per-arm checkpoint identity, SHA-256,
actual runtime load success, and fallback status; `checkpoint_provenance_enforcement: error` makes
implicit checkpoint absence and any observed planner fallback abort the campaign.

Why now: issue #4970 identifies that SA-CADRL results could be attributed to GA3C-CADRL even when
the checkpoint did not load. The existing checkpoint provisioning preflight provided the canonical
base but did not cover the implicit SA-CADRL registry default or runtime outcomes.

Claim boundary: implementation/auditability evidence only. This proves the metadata and fail-closed
contract in CPU tests; it does not prove planner quality or turn fallback/degraded rows into success.

Required validation: focused provenance tests, existing campaign/checkpoint/map-runner regressions,
and the committed-head final PR readiness gate.

Remaining blocker: none for issue scope. A real campaign run is intentionally excluded and is not
needed to establish the schema/runtime contract.

## Contract delta

New schema fields:
- Top-level `checkpoint_provenance_enforcement`: `off` (default) or `error`.
- Every manifest planner has `checkpoint_provenance` with `status`, `model_id`,
  `checkpoint_sha256`, `load_succeeded`, `fallback_triggered`, preflight `references`, and
  kinematics-specific `runtime` records.
- Checkpoint preflight arm records add `implicit`, `model_id`, `checkpoint_sha256`, `hash_source`,
  and honest not-yet-run load/fallback fields.

New fail-closed blockers:
- Strict mode rejects an unresolved implicit learned checkpoint, including SA-CADRL's
  `ga3c_cadrl_iros18` default.
- Strict mode forces the effective prerequisite policy to `fail-fast`, disables `allow_fallback`,
  and aborts when preflight or runtime metadata proves fallback occurred.

Compatibility impact:
- Default enforcement is `off`; existing explicit `model_id`/`model_path` resolvability checks
  remain always-on.
- Preflight-only manifests use null load/fallback fields instead of inferring a successful load.
- SA-CADRL's final arm digest covers the complete TensorFlow checkpoint bundle; the nested
  preflight reference retains the registry artifact hash and its source.

## Scope summary

- Extends the canonical campaign checkpoint preflight instead of adding a parallel checker.
- Adds runtime checkpoint diagnostics for SA-CADRL and generic PPO/SAC/DRL-style planners.
- Bridges runtime diagnostics through batch summaries into final per-arm campaign metadata.
- Documents the additive schema and strict campaign option.
- Adds focused success, missing, fallback, hashing, compatibility, and propagation tests.

Issue: https://github.com/ll7/robot_sf_ll7/issues/4970

Closes #4970

## Validation / Proof

- `uv run pytest tests/benchmark/test_checkpoint_provenance_issue_4970.py -q` — 9 passed.
- `uv run pytest tests/benchmark/test_campaign_checkpoint_preflight.py tests/benchmark/test_camera_ready_checkpoint_submit_preflight.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_camera_ready_campaign.py tests/benchmark/test_camera_ready_tuning_effort_issue_5143.py -q` — 326 passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — interim core gate passed: 2,186 passed, 1 skipped; final committed-head run follows below.
- `PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=output/issue_4970_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on clean commit `ffbbba83f`: core 2,186 passed / 1 skipped; optional 6,445 passed / 17 skipped; changed-line coverage at least 80% for every changed Python file (checkpoint batch bridge 100%).

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Governance appendix</summary>

## Stack / Dependency

- Base dependency: none.
- Required prior PRs: none.
- Stack follow-up issues: none.
- Safe to review independently: yes.

## Research Result Guidance

- Target blocker: checkpoint-backed campaign arms were not auditable for actual load/fallback.
- Comparator: previous manifests recorded provisioning status but not the implicit SA-CADRL default
  or runtime load/fallback result.
- Evidence tier: NA — implementation contract only; no research result is produced.
- Result classification: NA — implementation contract only.
- Decision/stop rule: focused tests must prove identity/hash, honest preflight unknowns, runtime
  success/fallback, strict rejection, and final manifest propagation; full readiness must pass.
- Synthesis surface: issue #4970 closes through this PR; no benchmark result surface changes.
- New analysis tool: NA — runtime/schema support, not evidence interpretation.

## Domain-Aware Approval

- Required for this PR: no — support/runtime contract with no research-result declaration.
- Domains reviewed: NA — no evidence interpretation or result promotion.
- Status: not required.
- Approver/review source or waiver: repository policy permits implementation-only support changes
  to use executable tests and ordinary code review.
- Target claim/hypothesis: NA — no research claim.
- Comparator or split/evidence validity: NA — no empirical comparison.
- Fallback/degraded exclusions: fallback remains non-success and is now explicitly recorded.
- Claim boundary: implementation and auditability behavior only.
- Implementation integrity vs experimental validity: implementation is tested; experimental
  validity is not asserted.

## Falsification / Non-Transfer Check

- Did the mechanism activate? yes, in focused CPU tests.
- Command/trajectory effect: strict mode blocks fallback; no trajectory result is claimed.
- Scenario failure mode: fixtures exercise missing checkpoint, load failure, and fallback metadata.
- Result route: continue to review.
- Follow-up: none required for the implementation contract.

## Next Empirical Action

- Rerun needed: NA for merge; future campaigns automatically emit the new fields.
- Extractor needed: no.
- Missing artifact: none for implementation; no campaign artifacts were produced.
- Decision: merge after the external PR gate passes.

## Risks / Rollout

- Compatibility risk: additive manifest fields increase artifact size slightly; strict mode is
  opt-in.
- Failure mode: planner integrations without runtime diagnostics remain honestly
  `runtime_not_observed` rather than being inferred as loaded.
- Rollback: revert this commit; old campaign configs remain valid because enforcement defaults off.

## Docs / Provenance

- Updated docs: `docs/benchmark_campaign_manifest.md`.
- Provenance source: model registry plus locally computed SHA-256; SA-CADRL runtime hashes metadata,
  index, and data shards as one deterministic bundle.
- Assumption: the default SA-CADRL registry ID remains `ga3c_cadrl_iros18`.

## Artifact handling

- `output/` contains only ignored local test/coverage/readiness cache (695 files, 102 MB before the
  final gate); none is tracked or cited as durable benchmark evidence.

## Downstream Propagation

- Parent issue updated: no; `comment_issue_or_pr` authorization is false.
- Claim map / benchmark report: NA; no benchmark result claim.
- Leaderboard / artifact catalog: NA.
- Registry/config index: NA; no registry entry changed.
- Context index / memory note: NA; the public manifest guide is the durable contract surface.
- Follow-up issue: none.
- No separate propagation write is needed because this PR body is the authorized canonical status
  surface and `Closes #4970` performs merge-driven closure.

## Fragmentation and friction checks

- No open PR covered #4970 or the exact checkpoint-provenance scope.
- The last-24-hour fragmentation guard did not trigger; one unrelated tuning-effort PR mentioned
  #4970, but no #4970 guard/checker/packet-refresh series exists.
- The required `gh issue view --comments` command failed on the retired Projects Classic field;
  all comments were recovered via REST. This friction is already tracked by #5188/#5186, so no
  duplicate issue was filed.

## Follow-Up Issues

- Deferred work: none; the full code, schema, documentation, and CPU validation ask is complete.
- Issues opened for follow-up: none.
- Maintainer waiver: the COMPLETE-FIRST directive explicitly says an issue whose only excluded
  remainder is a campaign run counts as complete; therefore the prohibited full campaign/Slurm run
  is not residual issue scope and needs no follow-up ticket.

## Reviewer Notes

- Verify preflight `not_run` is never presented as load success.
- Verify strict fallback detection covers both construction-time and runtime planner metadata.
- Shared-helper migration: inapplicable; existing checkpoint preflight and runtime metadata bridges
  were extended in place. The real production campaign path is covered by camera-ready campaign
  regression tests.

</details>
