### PR TITLE
Issue #3574: add per-archetype near-field trace manifest fields

### DIFF
--- a/configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml
+++ b/configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml
@@ -3,6 +3,7 @@ issue: 3574
 claim_boundary: harness_only_no_ablation_result
 trace_metric_keys:
   - clearance_m
+  - near_field_exposure_s
 planners:
   - key: goal
     algo: goal
@@ -14,6 +15,7 @@ seeds:
 scenarios:
   - id: issue_3574_classic_crossing_density_002
     density: 0.02
+    pedestrian_control_trace_near_field_clearance_m: 1.0
     population_size: 12
     archetype_seed: 3574
     composition:

--- a/docs/context/issue_3574_mean_matched_harness.md
+++ b/docs/context/issue_3574_mean_matched_harness.md
@@ -9,7 +9,10 @@ heterogeneous and homogeneous mean-matched rows before any benchmark campaign ru
 - The manifest is a pre-run contract, not a heterogeneous-population effect result.
 - It attributes future rows by scenario, seed, planner, density, and population arm.
 - It records the expected `pedestrian_control_trace` fields needed by the existing
-  per-archetype metric primitives.
+  per-archetype metric primitives: surface clearance (`clearance_m`) and
+  near-field exposure duration (`near_field_exposure_s`). The trace records the
+  configured surface-clearance threshold alongside those fields; the manifest blocks
+  near-field exposure rows when that threshold metadata is absent.
 - It does not run a full ablation campaign, response-law mixture sweep, rank-order
   sensitivity analysis, Slurm job, or paper/dissertation claim update.
 

--- a/robot_sf/benchmark/heterogeneous_population_ablation.py
+++ b/robot_sf/benchmark/heterogeneous_population_ablation.py
@@ -252,6 +252,11 @@ def build_mean_matched_harness_manifest(
             "metadata.pedestrian_control_trace",
             "metadata.pedestrian_control_trace.pedestrians[].archetype",
             "metadata.pedestrian_control_trace.pedestrians[].steps[]",
+            *(
+                ["metadata.pedestrian_control_trace.near_field_clearance_threshold_m"]
+                if "near_field_exposure_s" in metric_keys
+                else []
+            ),
         ],
         "manifest_rows": manifest_rows,
         "row_count": len(manifest_rows),
@@ -441,6 +446,14 @@ def _manifest_scenario_rows(
                             f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY}",
                             "metadata.pedestrian_control_trace",
                             "metadata.pedestrian_control_trace.pedestrians[].archetype",
+                            *(
+                                [
+                                    "metadata.pedestrian_control_trace."
+                                    "near_field_clearance_threshold_m"
+                                ]
+                                if "near_field_exposure_s" in metric_keys
+                                else []
+                            ),
                             *[
                                 "metadata.pedestrian_control_trace.pedestrians[]."
                                 f"steps[].{metric_key}"
@@ -502,6 +515,7 @@ def _trace_readiness_by_arm(
                 for metric_readiness in readiness["metrics"].values()
                 for blocker in metric_readiness["blockers"]
             ]
+            metric_blockers.extend(_trace_metric_metadata_blockers(trace, metric_keys))
             if metric_blockers:
                 readiness["status"] = "blocked"
                 readiness["ready"] = False
@@ -512,6 +526,27 @@ def _trace_readiness_by_arm(
             blockers.extend(f"{scenario_id}/{arm}: {blocker}" for blocker in readiness["blockers"])
 
     return readiness_by_arm, blockers
+
+
+def _trace_metric_metadata_blockers(
+    trace: Mapping[str, Any], metric_keys: Sequence[str]
+) -> list[str]:
+    """Return provenance blockers required by non-self-describing trace metrics."""
+
+    if "near_field_exposure_s" not in metric_keys:
+        return []
+    threshold = trace.get("near_field_clearance_threshold_m")
+    if threshold is None:
+        return ["control_trace.near_field_clearance_threshold_m missing"]
+    if isinstance(threshold, bool | str):
+        return ["control_trace.near_field_clearance_threshold_m must be finite non-negative number"]
+    try:
+        threshold_value = float(threshold)
+    except (TypeError, ValueError):
+        return ["control_trace.near_field_clearance_threshold_m must be finite non-negative number"]
+    if not math.isfinite(threshold_value) or threshold_value < 0.0:
+        return ["control_trace.near_field_clearance_threshold_m must be finite non-negative number"]
+    return []
 
 
 def _planner_rows(planners: Sequence[Any]) -> list[dict[str, Any]]:

--- a/robot_sf/benchmark/pedestrian_control_trace.py
+++ b/robot_sf/benchmark/pedestrian_control_trace.py
@@ -202,6 +202,11 @@ def build_pedestrian_control_trace(
         if near_field_clearance_threshold_m is None
         else near_field_clearance_threshold_m
     )
+    if isinstance(configured_near_field_threshold, bool):
+        raise ValueError(
+            "pedestrian_control_trace.near_field_clearance_threshold_m "
+            "must be a real numeric scalar"
+        )
     near_field_threshold = require_finite_scalar(
         "pedestrian_control_trace.near_field_clearance_threshold_m",
         configured_near_field_threshold,

--- a/robot_sf/benchmark/pedestrian_control_trace.py
+++ b/robot_sf/benchmark/pedestrian_control_trace.py
@@ -69,6 +69,9 @@ def attach_pedestrian_control_trace(
         robot_positions=robot_positions,
         robot_radius=robot_radius,
         ped_radius=ped_radius,
+        near_field_clearance_threshold_m=scenario.get(
+            "pedestrian_control_trace_near_field_clearance_m", 1.0
+        ),
     )
 
 
@@ -108,6 +111,7 @@ def _build_pedestrian_steps(
     robot_pos: np.ndarray | None,
     robot_rad: float,
     ped_rad: float,
+    near_field_clearance_threshold_m: float,
     dt_value: float,
     simulator_index: int,
 ) -> list[dict[str, Any]]:
@@ -148,6 +152,9 @@ def _build_pedestrian_steps(
                 clearance,
             )
             payload["clearance_m"] = clearance
+            payload["near_field_exposure_s"] = (
+                dt_value if clearance <= near_field_clearance_threshold_m else 0.0
+            )
         if forces is not None:
             force = forces[step]
             force_norm = float(np.linalg.norm(force))
@@ -176,6 +183,7 @@ def build_pedestrian_control_trace(
     robot_positions: np.ndarray | None = None,
     robot_radius: float = 0.0,
     ped_radius: float = 0.0,
+    near_field_clearance_threshold_m: float | None = None,
 ) -> dict[str, Any]:
     """Build a finite, per-pedestrian control trace grouped by simulator pedestrian index.
 
@@ -189,6 +197,17 @@ def build_pedestrian_control_trace(
     dt_value = require_finite_scalar("pedestrian_control_trace.dt", dt)
     if dt_value <= 0.0:
         raise ValueError("pedestrian_control_trace.dt must be positive")
+    configured_near_field_threshold = (
+        scenario.get("pedestrian_control_trace_near_field_clearance_m", 1.0)
+        if near_field_clearance_threshold_m is None
+        else near_field_clearance_threshold_m
+    )
+    near_field_threshold = require_finite_scalar(
+        "pedestrian_control_trace.near_field_clearance_threshold_m",
+        configured_near_field_threshold,
+    )
+    if near_field_threshold < 0.0:
+        raise ValueError("near_field_clearance_threshold_m must be non-negative")
 
     positions = require_finite_array("pedestrian_control_trace.ped_positions", ped_positions)
     if positions.ndim != 3 or positions.shape[2] != 2:
@@ -223,6 +242,7 @@ def build_pedestrian_control_trace(
             robot_pos=robot_pos,
             robot_rad=robot_rad,
             ped_rad=ped_rad,
+            near_field_clearance_threshold_m=near_field_threshold,
             dt_value=dt_value,
             simulator_index=simulator_index,
         )
@@ -248,6 +268,7 @@ def build_pedestrian_control_trace(
         "archetype_source": archetype_source,
         "pedestrian_count": pedestrian_count,
         "step_count": step_count,
+        "near_field_clearance_threshold_m": near_field_threshold,
         "pedestrians": pedestrians,
     }
 

--- a/tests/benchmark/test_heterogeneous_population_ablation.py
+++ b/tests/benchmark/test_heterogeneous_population_ablation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
 import pytest
@@ -30,21 +31,22 @@ def _archetypes() -> dict[str, ArchetypePopulationSpec]:
 def _control_trace() -> dict[str, object]:
     return {
         "schema_version": "pedestrian-control-trace.v1",
+        "near_field_clearance_threshold_m": 1.0,
         "pedestrians": [
             {
                 "id": "ped_cautious",
                 "archetype": "cautious",
                 "steps": [
-                    {"step": 0, "clearance_m": 1.0},
-                    {"step": 1, "clearance_m": 0.8},
+                    {"step": 0, "clearance_m": 1.0, "near_field_exposure_s": 0.0},
+                    {"step": 1, "clearance_m": 0.8, "near_field_exposure_s": 0.1},
                 ],
             },
             {
                 "id": "ped_hurried",
                 "archetype": "hurried",
                 "steps": [
-                    {"step": 0, "clearance_m": 0.5},
-                    {"step": 1, "clearance_m": 0.3},
+                    {"step": 0, "clearance_m": 0.5, "near_field_exposure_s": 0.1},
+                    {"step": 1, "clearance_m": 0.3, "near_field_exposure_s": 0.1},
                 ],
             },
         ],
@@ -204,7 +206,7 @@ def test_issue_3206_three_seed_smoke_audits_as_mean_matched_but_not_per_archetyp
 
 def _manifest_config() -> dict[str, object]:
     return {
-        "trace_metric_keys": ["clearance_m"],
+        "trace_metric_keys": ["clearance_m", "near_field_exposure_s"],
         "planners": [{"key": "goal", "algo": "goal"}, {"key": "social_force"}],
         "seeds": [101, 102],
         "scenarios": [
@@ -264,6 +266,9 @@ def test_mean_matched_harness_manifest_fails_closed_on_missing_control_trace_inp
         "metadata.pedestrian_control_trace missing" in blocker for blocker in manifest["blockers"]
     )
     assert any("steps[].clearance_m missing" in blocker for blocker in manifest["blockers"])
+    assert any(
+        "steps[].near_field_exposure_s missing" in blocker for blocker in manifest["blockers"]
+    )
     first_row = manifest["manifest_rows"][0]
     assert first_row["trace_readiness"]["ready"] is False
     assert (
@@ -272,6 +277,14 @@ def test_mean_matched_harness_manifest_fails_closed_on_missing_control_trace_inp
     )
     assert (
         "metadata.pedestrian_control_trace.pedestrians[].steps[].clearance_m"
+        in first_row["expected_episode_output_keys"]
+    )
+    assert (
+        "metadata.pedestrian_control_trace.pedestrians[].steps[].near_field_exposure_s"
+        in first_row["expected_episode_output_keys"]
+    )
+    assert (
+        "metadata.pedestrian_control_trace.near_field_clearance_threshold_m"
         in first_row["expected_episode_output_keys"]
     )
     assert PEDESTRIAN_CONTROL_TRACE_LABELS_KEY in first_row["arm_population"]
@@ -295,10 +308,59 @@ def test_mean_matched_harness_manifest_accepts_fixture_control_traces() -> None:
     assert manifest["blockers"] == []
     readiness = manifest["scenario_rows"][0]["trace_readiness_by_arm"]["heterogeneous"]
     assert readiness["metrics"]["clearance_m"]["status"] == "ready"
+    assert readiness["metrics"]["near_field_exposure_s"]["status"] == "ready"
     assert readiness["metrics"]["clearance_m"]["archetype_counts"] == {
         "cautious": 1,
         "hurried": 1,
     }
+
+
+def test_mean_matched_harness_manifest_blocks_exposure_without_threshold_metadata() -> None:
+    """Near-field exposure cannot be interpreted when its clearance threshold is absent."""
+
+    config = _manifest_config()
+    scenario = config["scenarios"][0]
+    assert isinstance(scenario, dict)
+    trace = _control_trace()
+    trace.pop("near_field_clearance_threshold_m")
+    scenario["control_traces"] = {
+        "heterogeneous": trace,
+        "mean_matched_homogeneous": _control_trace(),
+    }
+
+    manifest = build_mean_matched_harness_manifest(config)
+
+    assert manifest["status"] == "blocked_pending_control_trace"
+    assert any(
+        "control_trace.near_field_clearance_threshold_m missing" in blocker
+        for blocker in manifest["blockers"]
+    )
+
+
+@pytest.mark.parametrize("threshold", [True, "1.0", [], math.nan, -0.1])
+def test_mean_matched_harness_manifest_blocks_invalid_exposure_threshold(
+    threshold: object,
+) -> None:
+    """Near-field exposure provenance must be a finite non-negative numeric threshold."""
+
+    config = _manifest_config()
+    scenario = config["scenarios"][0]
+    assert isinstance(scenario, dict)
+    trace = _control_trace()
+    trace["near_field_clearance_threshold_m"] = threshold
+    scenario["control_traces"] = {
+        "heterogeneous": trace,
+        "mean_matched_homogeneous": _control_trace(),
+    }
+
+    manifest = build_mean_matched_harness_manifest(config)
+
+    assert manifest["status"] == "blocked_pending_control_trace"
+    assert any(
+        "control_trace.near_field_clearance_threshold_m must be finite non-negative number"
+        in blocker
+        for blocker in manifest["blockers"]
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/benchmark/test_pedestrian_control_trace.py
+++ b/tests/benchmark/test_pedestrian_control_trace.py
@@ -67,7 +67,7 @@ def test_build_pedestrian_control_trace_records_archetype_controls() -> None:
 
 
 def test_build_pedestrian_control_trace_computes_clearance() -> None:
-    """Recorder computes per-step clearance_m when robot positions are supplied."""
+    """Recorder computes clearance and thresholded near-field exposure per step."""
 
     positions = np.array(
         [
@@ -97,8 +97,32 @@ def test_build_pedestrian_control_trace_computes_clearance() -> None:
     cautious, hurried = trace["pedestrians"]
     assert cautious["steps"][0]["clearance_m"] == pytest.approx(0.5)
     assert cautious["steps"][1]["clearance_m"] == pytest.approx(0.5)
+    assert cautious["steps"][0]["near_field_exposure_s"] == pytest.approx(0.1)
+    assert cautious["steps"][1]["near_field_exposure_s"] == pytest.approx(0.1)
     assert hurried["steps"][0]["clearance_m"] == pytest.approx(0.5)
     assert hurried["steps"][1]["clearance_m"] == pytest.approx(math.sqrt(5) - 0.5)
+    assert hurried["steps"][0]["near_field_exposure_s"] == pytest.approx(0.1)
+    assert hurried["steps"][1]["near_field_exposure_s"] == pytest.approx(0.0)
+    assert trace["near_field_clearance_threshold_m"] == pytest.approx(1.0)
+
+
+def test_build_pedestrian_control_trace_uses_configured_near_field_threshold() -> None:
+    """Exposure duration is traceable to the configured surface-clearance threshold."""
+
+    trace = build_pedestrian_control_trace(
+        scenario={
+            **_scenario(),
+            "pedestrian_control_trace_near_field_clearance_m": 0.4,
+        },
+        ped_positions=np.array([[[0.0, 0.0], [2.0, 0.0]]], dtype=float),
+        ped_forces=None,
+        dt=0.2,
+        robot_positions=np.array([[1.0, 0.0]], dtype=float),
+    )
+
+    assert trace["near_field_clearance_threshold_m"] == pytest.approx(0.4)
+    assert trace["pedestrians"][0]["steps"][0]["near_field_exposure_s"] == pytest.approx(0.0)
+    assert trace["pedestrians"][1]["steps"][0]["near_field_exposure_s"] == pytest.approx(0.0)
 
 
 @pytest.mark.parametrize(
@@ -113,6 +137,19 @@ def test_build_pedestrian_control_trace_computes_clearance() -> None:
         (
             {"robot_positions": np.zeros((2, 2), dtype=float), "ped_radius": -0.1},
             "must be non-negative",
+        ),
+        (
+            {"scenario": {**_scenario(), "pedestrian_control_trace_near_field_clearance_m": -0.1}},
+            "must be non-negative",
+        ),
+        (
+            {
+                "scenario": {
+                    **_scenario(),
+                    "pedestrian_control_trace_near_field_clearance_m": math.nan,
+                }
+            },
+            "not finite",
         ),
     ],
 )

--- a/tests/benchmark/test_pedestrian_control_trace.py
+++ b/tests/benchmark/test_pedestrian_control_trace.py
@@ -151,6 +151,15 @@ def test_build_pedestrian_control_trace_uses_configured_near_field_threshold() -
             },
             "not finite",
         ),
+        (
+            {
+                "scenario": {
+                    **_scenario(),
+                    "pedestrian_control_trace_near_field_clearance_m": True,
+                }
+            },
+            "must be a real numeric scalar",
+        ),
     ],
 )
 def test_build_pedestrian_control_trace_rejects_invalid_robot_params(


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds per-step, per-pedestrian `near_field_exposure_s` logging and carries its configurable surface-clearance threshold into the existing issue #3574 paired mean-matched manifest. The manifest now requires clearance and near-field exposure fields for both population arms.
- **Why now:** The existing harness already pairs the heterogeneous mixture with a homogeneous population at the same weighted parameter mean, but its trace contract exposed only clearance. This progression slice makes the requested per-archetype near-field metric computable from future episode traces.
- **Claim boundary:** `diagnostic-only` pre-run instrumentation. No ablation campaign was run and no heterogeneity, planner-rank, realism, or sim-to-real effect is claimed.
- **Required validation:** focused fixture tests plus the full repository PR-readiness gate; results are below.
- **Remaining blocker:** actual paired campaign rows and bootstrap/rank-reversal interpretation remain unrun and are intentionally outside this PR.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3574

## Contract delta

- **Trace field:** `pedestrian_control_trace.pedestrians[].steps[].near_field_exposure_s` is `dt` when surface clearance is at or below the configured threshold and `0.0` otherwise.
- **Trace provenance:** `pedestrian_control_trace.near_field_clearance_threshold_m` records the finite, non-negative threshold; the reversible default assumption is `1.0 m`, overridable through scenario field `pedestrian_control_trace_near_field_clearance_m`.
- **Manifest fields:** the tracked mean-matched smoke config now declares both `clearance_m` and `near_field_exposure_s`; paired rows keep common scenario, planner, seed, density, and composition-hash attribution.
- **New fail-closed blocker:** a trace declaring near-field exposure is blocked when its threshold metadata is missing, non-numeric, non-finite, or negative. Existing missing pedestrian/archetype/per-step-field blockers remain unchanged.
- **Compatibility:** additive trace and manifest fields only; existing schema version and paired-arm construction remain unchanged.

## Scope summary

- Extended the existing generated-population control-trace logging hook with thresholded exposure duration.
- Extended the existing mean-matched paired manifest/readiness bridge with the per-archetype exposure field and threshold provenance requirement.
- Added focused positive, configurable-threshold, invalid-threshold, missing-field, and missing-provenance tests.

This is a progression slice adding a nameable new capability: **threshold-attributed per-archetype near-field exposure traces**. It is not another packet/checker-only micro-guard.

## Validation

```text
uv run ruff format --check robot_sf/benchmark/pedestrian_control_trace.py robot_sf/benchmark/heterogeneous_population_ablation.py tests/benchmark/test_pedestrian_control_trace.py tests/benchmark/test_heterogeneous_population_ablation.py
# 4 files already formatted

uv run ruff check robot_sf/benchmark/pedestrian_control_trace.py robot_sf/benchmark/heterogeneous_population_ablation.py tests/benchmark/test_pedestrian_control_trace.py tests/benchmark/test_heterogeneous_population_ablation.py
# All checks passed!

uv run pytest tests/benchmark/test_pedestrian_control_trace.py tests/benchmark/test_heterogeneous_population_ablation.py tests/benchmark/test_heterogeneous_population_metrics.py -q
# 84 passed

uv run python scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py
# status: blocked_pending_control_trace; rows: 8 (expected pre-run fail-closed state)

PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh
# passed on clean post-merge head (core: 2,202 passed, 1 skipped;
# optional/full lane: 6,463 passed, 17 skipped)
```

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No heterogeneity-effect or planner-rank interpretation.

## Domain-Aware Approval

- Required for this PR: yes - benchmark trace instrumentation uses an explicit diagnostic claim boundary.
- Domains reviewed: evidence classification, experimental comparison, benchmark interpretation
- Status: waived
- Approver/review source or waiver: Waived for PR opening because this change records additive trace fields and fail-closed pre-run requirements without executing or interpreting the comparison; Claude Code retains the post-open full gate and merge authority.
- Validity checklist:
  - Target claim/hypothesis: implementation integrity only; no heterogeneity-effect claim.
  - Comparator or split/evidence validity: paired-arm, common-seed design is unchanged and no rows were produced.
  - Fallback/degraded exclusions: missing or malformed trace inputs stay blocked and cannot count as evidence.
  - Claim boundary: diagnostic pre-run instrumentation, not benchmark or paper evidence.
  - Implementation integrity vs experimental validity: fixtures and readiness gates prove field wiring only; the future campaign must establish experimental validity.

Refs #3574

Remaining issue work:

- [ ] Run the full mean-matched paired ablation campaign under the predeclared contract.
- [ ] Perform bootstrap P(A beats B) and pre-specified rank-reversal analysis on valid native rows.
- [ ] Promote only appropriately bounded benchmark conclusions after campaign review.

<details>
<summary>Governance and handoff</summary>

- **Target:** make future heterogeneous-vs-mean-matched rows attributable and per-archetype near-field exposure computable.
- **Comparator:** heterogeneous mixture vs. homogeneous weighted-mean population; common scenarios, planners, seeds, density, and composition hash.
- **Evidence tier/result classification:** diagnostic-only implementation integrity; no benchmark result.
- **Fallback/degraded policy:** no rows ran; future missing/incomplete traces remain blocked and cannot support claims.
- **Decision/stop rule:** stop at a generated pre-run manifest whose absent episode traces are explicitly blocked; campaign execution is excluded by authorization.
- **Artifact classification:** generated manifest and readiness/coverage output remain ignored under `output/`; no durable result artifact exists because no campaign ran.
- **Downstream propagation:** no issue comment was added because issue/PR commenting was not authorized for this task. The PR body is the durable handoff surface; issue #3574 remains open through `Refs` plus the checklist above.
- **Fragmentation guard:** one issue-related PR merged in the preceding 24 hours (#5062), below the two-PR threshold; this PR adds a new runtime/manifest capability rather than a micro-guard.
- **Late guidance:** the issue thread was re-read immediately before PR creation; no comments newer than the 2026-07-11T00:29:00Z start time were present.
- **Friction:** `gh issue view 3574 --comments` failed on the retired Projects Classic field. Existing issues #5188/#5186 already track the REST fallback, so no duplicate friction issue was filed.

</details>
