### PR TITLE
fix(dev): add REST PR body updater (#5221)

### DIFF
--- a/.agents/skills/gh-pr-opener/SKILL.md
+++ b/.agents/skills/gh-pr-opener/SKILL.md
@@ -55,6 +55,9 @@ Freshness check:
    Use `--draft` only when the user explicitly requests draft status or when the branch is an
    intentional handoff with incomplete validation, unresolved scope, or another clearly documented
    reason that should block review.
+   For an existing PR, update its body with
+   `uv run python scripts/dev/gh_pr_body_rest.py <pr-number> --repo ll7/robot_sf_ll7 --body-file <prepared_body.md>`;
+   do not use `gh pr edit --body-file` while it queries retired Projects Classic fields.
 9. Keep parent issue open unless repository policy indicates closure wording in PR description.
 
 ## Proof and Artifact Rules

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -514,8 +514,10 @@ Each child skill or worker may fail. Handle failures per scenario:
     `blocked` instead of `pr_opened`.
 
 - `gh-pr-opener` failure:
-  - If the PR already exists for the branch, update the existing PR body
-    instead of creating a duplicate.
+  - If the PR already exists for the branch, update the existing PR body with
+    `uv run python scripts/dev/gh_pr_body_rest.py <pr-number> --repo ll7/robot_sf_ll7 --body-file <prepared_body.md>`
+    instead of creating a duplicate. Do not use `gh pr edit --body-file` while its GraphQL query
+    requests retired Projects Classic fields.
   - If push fails, record the error and mark the issue blocked.
 
 - `gh-issue-creator` or `issue-splitter` failure:

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -662,8 +662,8 @@ gh api repos/$OWNER/$REPO/pulls -X POST \
 PR=$(gh api repos/$OWNER/$REPO/pulls --method GET \
   -f state=open -f head="$OWNER:$BRANCH" \
   --jq '.[0].number')
-gh api repos/$OWNER/$REPO/pulls/$PR -X PATCH \
-  -f body="Updated summary $(date -Iseconds)"
+uv run python scripts/dev/gh_pr_body_rest.py "$PR" --repo "$OWNER/$REPO" \
+  --body-file /path/to/updated-pr-body.md
 ```
 
 ```bash

--- a/scripts/dev/gh_pr_body_rest.py
+++ b/scripts/dev/gh_pr_body_rest.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Update a pull-request body through GitHub's REST API.
+
+Why this exists
+---------------
+``gh pr edit --body-file`` can fail on GitHub CLI versions that query the retired
+Projects Classic GraphQL field. This helper uses only ``PATCH /repos/{owner}/{repo}/pulls/{number}``
+and verifies that GitHub returned the requested body. It is deliberately REST-only:
+authentication, authorization, malformed responses, and body mismatches fail closed.
+
+Usage
+-----
+::
+
+    uv run python scripts/dev/gh_pr_body_rest.py 5220 \
+        --repo ll7/robot_sf_ll7 --body-file /tmp/pr-body.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+
+
+def _gh_api_patch(
+    path: str, payload: dict[str, str], *, timeout: int = 30
+) -> subprocess.CompletedProcess[str]:
+    """Patch *path* through ``gh api``, returning failures for clear handling."""
+    args = ["gh", "api", "--method", "PATCH", path, "--input", "-"]
+    try:
+        return subprocess.run(
+            args,
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=127,
+            stdout="",
+            stderr="gh CLI not found on PATH; install GitHub CLI (https://cli.github.com/)",
+        )
+
+
+def update_pr_body(number: int, body_file: Path, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:
+    """Update PR *number* from *body_file* and verify the REST response.
+
+    Returns a compact success or error payload rather than raising so shell callers
+    receive a deterministic exit status and an actionable error message.
+    """
+    if number < 1:
+        return {"status": "error", "error": f"PR number must be positive, got {number}"}
+    try:
+        body = body_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {"status": "error", "error": f"could not read body file {body_file}: {exc}"}
+
+    result = _gh_api_patch(f"repos/{repo}/pulls/{number}", {"body": body})
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"gh api exited with code {result.returncode}"
+        return {"status": "error", "error": f"PR body update failed: {detail}"}
+    try:
+        response = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        snippet = result.stdout.strip()[:200]
+        return {
+            "status": "error",
+            "error": f"PR body update returned invalid JSON: {exc}; stdout snippet: {snippet!r}",
+        }
+    if not isinstance(response, dict):
+        return {"status": "error", "error": "PR body update response was not an object"}
+    if response.get("body") != body:
+        return {
+            "status": "error",
+            "error": "PR body update response did not preserve the requested body",
+        }
+    return {
+        "status": "ok",
+        "number": number,
+        "repo": repo,
+        "url": str(response.get("html_url", "")),
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("number", type=int, help="Pull-request number to update.")
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help=f"owner/repo to update (default: {DEFAULT_REPO}).",
+    )
+    parser.add_argument(
+        "--body-file", type=Path, required=True, help="Markdown body file to apply."
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the PR-body updater and emit one compact JSON result."""
+    args = _build_parser().parse_args(argv)
+    result = update_pr_body(args.number, args.body_file, repo=args.repo)
+    stream = sys.stdout if result["status"] == "ok" else sys.stderr
+    print(json.dumps(result, sort_keys=True), file=stream)
+    return 0 if result["status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/gh_pr_body_rest.py
+++ b/scripts/dev/gh_pr_body_rest.py
@@ -49,6 +49,13 @@ def _gh_api_patch(
             stdout="",
             stderr="gh CLI not found on PATH; install GitHub CLI (https://cli.github.com/)",
         )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=124,
+            stdout="",
+            stderr=f"gh api timed out after {timeout} seconds; body update was not verified",
+        )
 
 
 def update_pr_body(number: int, body_file: Path, *, repo: str = DEFAULT_REPO) -> dict[str, Any]:

--- a/tests/dev/test_gh_pr_body_rest.py
+++ b/tests/dev/test_gh_pr_body_rest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -79,6 +80,19 @@ def test_update_pr_body_fails_closed_on_api_error(tmp_path: Path) -> None:
 
     assert result["status"] == "error"
     assert "Bad credentials" in result["error"]
+
+
+def test_update_pr_body_fails_closed_on_timeout(tmp_path: Path) -> None:
+    """A timeout must remain a structured, unverified error rather than escaping."""
+    body_file = tmp_path / "body.md"
+    body_file.write_text("body", encoding="utf-8")
+    with patch("scripts.dev.gh_pr_body_rest.subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd=["gh", "api"], timeout=30)
+        result = update_pr_body(5220, body_file)
+
+    assert result["status"] == "error"
+    assert "timed out" in result["error"]
+    assert "not verified" in result["error"]
 
 
 def test_cli_prints_compact_success_json(tmp_path: Path, capsys) -> None:

--- a/tests/dev/test_gh_pr_body_rest.py
+++ b/tests/dev/test_gh_pr_body_rest.py
@@ -1,0 +1,96 @@
+"""Offline tests for the REST-only PR body updater (issue #5221)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from scripts.dev.gh_pr_body_rest import main, update_pr_body
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _proc(*, stdout: str = "", stderr: str = "", returncode: int = 0) -> MagicMock:
+    """Build a fake ``subprocess.CompletedProcess`` for ``gh api``."""
+    return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def test_update_pr_body_patches_rest_endpoint_and_verifies_body(tmp_path: Path) -> None:
+    """The helper must send JSON through PATCH and verify GitHub's returned body."""
+    body_file = tmp_path / "body.md"
+    body_file.write_text("## Summary\n\nUpdated body\n", encoding="utf-8")
+    response = {
+        "body": body_file.read_text(encoding="utf-8"),
+        "html_url": "https://example/pr/5220",
+    }
+    with patch("scripts.dev.gh_pr_body_rest.subprocess.run") as mock_run:
+        mock_run.return_value = _proc(stdout=json.dumps(response))
+        result = update_pr_body(5220, body_file, repo="ll7/robot_sf_ll7")
+
+    assert result == {
+        "status": "ok",
+        "number": 5220,
+        "repo": "ll7/robot_sf_ll7",
+        "url": "https://example/pr/5220",
+    }
+    assert mock_run.call_args.args[0] == [
+        "gh",
+        "api",
+        "--method",
+        "PATCH",
+        "repos/ll7/robot_sf_ll7/pulls/5220",
+        "--input",
+        "-",
+    ]
+    assert json.loads(mock_run.call_args.kwargs["input"]) == {"body": response["body"]}
+
+
+def test_update_pr_body_fails_closed_when_response_body_differs(tmp_path: Path) -> None:
+    """A successful HTTP response is insufficient when it reports a different body."""
+    body_file = tmp_path / "body.md"
+    body_file.write_text("expected", encoding="utf-8")
+    with patch("scripts.dev.gh_pr_body_rest._gh_api_patch") as mock_patch:
+        mock_patch.return_value = _proc(stdout=json.dumps({"body": "different"}))
+        result = update_pr_body(5220, body_file)
+
+    assert result["status"] == "error"
+    assert "did not preserve" in result["error"]
+
+
+def test_update_pr_body_fails_closed_for_missing_file(tmp_path: Path) -> None:
+    """A missing body file must never issue a partial REST update."""
+    with patch("scripts.dev.gh_pr_body_rest._gh_api_patch") as mock_patch:
+        result = update_pr_body(5220, tmp_path / "missing.md")
+
+    assert result["status"] == "error"
+    assert "could not read body file" in result["error"]
+    mock_patch.assert_not_called()
+
+
+def test_update_pr_body_fails_closed_on_api_error(tmp_path: Path) -> None:
+    """Authentication and API failures must be visible to the caller."""
+    body_file = tmp_path / "body.md"
+    body_file.write_text("body", encoding="utf-8")
+    with patch("scripts.dev.gh_pr_body_rest._gh_api_patch") as mock_patch:
+        mock_patch.return_value = _proc(returncode=1, stderr="HTTP 401: Bad credentials")
+        result = update_pr_body(5220, body_file)
+
+    assert result["status"] == "error"
+    assert "Bad credentials" in result["error"]
+
+
+def test_cli_prints_compact_success_json(tmp_path: Path, capsys) -> None:
+    """The command-line contract is a single machine-readable success result."""
+    body_file = tmp_path / "body.md"
+    body_file.write_text("body", encoding="utf-8")
+    with patch("scripts.dev.gh_pr_body_rest._gh_api_patch") as mock_patch:
+        mock_patch.return_value = _proc(
+            stdout=json.dumps({"body": "body", "html_url": "https://example/pr/5220"})
+        )
+        rc = main(["5220", "--repo", "ll7/robot_sf_ll7", "--body-file", str(body_file)])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert json.loads(captured.out)["url"] == "https://example/pr/5220"


### PR DESCRIPTION
## Reviewer-critical summary

- What changed: added `scripts/dev/gh_pr_body_rest.py`, a REST-only helper that updates a PR body from a file and verifies GitHub returned the exact body; added offline tests and routed existing-PR body edits in the autonomous PR skills and developer guide through it.
- Why now: `gh pr edit --body-file` fails on this host because its GraphQL query requests the retired Projects Classic field.
- Claim boundary: support tooling only; this PR does not make research, benchmark, metric, or paper-facing claims.
- Required validation: final committed-head readiness gate, helper/adjacent-helper tests, skill preflights, and PR body contract check.
- Remaining blocker: none for the issue's bounded helper and workflow-routing ask.

## Contract delta

- New command: `uv run python scripts/dev/gh_pr_body_rest.py <pr-number> --repo <owner/repo> --body-file <body.md>`.
- New fail-closed blockers: unreadable body file, non-positive PR number, REST/API failure, malformed REST response, or returned body mismatch exit nonzero without claiming success.
- Compatibility: creating a new PR remains on `gh pr create --body-file`; only edits to an existing PR body route through the REST endpoint.

## Linked issue and scope

Issue: https://github.com/ll7/robot_sf_ll7/issues/5221

Closes #5221

- Adds a reusable body-file REST PATCH helper and offline contract tests.
- Documents the helper where autonomous workflows recover an existing PR instead of creating a duplicate.
- No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## Validation / Proof

- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final PR_READY_PR_BODY_FILE=<PR_BODY.md> BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- `uv run python -m pytest tests/dev/test_gh_pr_body_rest.py tests/dev/test_gh_issue_rest.py -q` — 27 passed.
- `uv run python scripts/dev/check_skills.py --preflight gh-pr-opener` — pass.
- `uv run python scripts/dev/check_skills.py --preflight goal-issue-implementation` — pass.
- `uv run python scripts/tools/sync_ai_config.py --check` — pass.

## State propagation

No issue comment was posted because this run is not authorized to comment on issues or PRs, and #5221 has no existing high-churn state table. The linked PR is the canonical delivery surface.

<details>
<summary>Governance appendix</summary>

### Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA — support helper resolves a GitHub CLI workflow blocker.
- Comparator or baseline: NA.
- Evidence tier: NA — support tooling.
- Result classification: NA — no research result.
- Decision or stop rule: REST response must preserve the submitted body; otherwise fail closed.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #5221 only.

### Domain-Aware Approval

- Required for this PR: no — no evidence classification, experimental comparison, benchmark interpretation, or paper-facing claim changes.
- Status: not required.

### Falsification / Non-Transfer Check

NA — support helper; its production-path REST command construction and failure paths are tested offline.

### Next Empirical Action

NA — no empirical evidence is involved.

### Risks / Rollout

- Compatibility risk: helper requires `gh api` authentication with PR-write permission; failures are explicit and leave the PR unchanged.
- Rollback: revert this isolated helper and documentation routing; `gh pr create --body-file` is unchanged.

### Docs / Provenance

- Updated: `docs/dev_guide.md`, `.agents/skills/gh-pr-opener/SKILL.md`, and `.agents/skills/goal-issue-implementation/SKILL.md`.
- Provenance: issue #5221 reproduces the Projects Classic error and specifies the REST endpoint.

### Downstream Propagation

- Parent issue updated: no — comment authorization is false; PR linkage provides the delivery record.
- Claim map / benchmark report / leaderboard / registry / context index: NA — no research or durable evidence surface changed.
- Follow-up issue: no — this PR completes the stated helper and routing scope.

</details>
