### PR TITLE
feat(research): add Zanlungo CPU corridor acceptance (#4973)

### DIFF
--- a/configs/research/issue_4973_zanlungo_corridor_acceptance.yaml
+++ b/configs/research/issue_4973_zanlungo_corridor_acceptance.yaml
@@ -4,8 +4,8 @@ metadata:
   benchmark_evidence: false
   evidence_tier: diagnostic-only
   claim_boundary: >-
-    Deterministic CPU synthetic-corridor acceptance only. This packet does not
-    calibrate pedestrian realism or support benchmark, paper, or dissertation claims.
+    deterministic CPU synthetic-corridor acceptance only; benchmark_evidence=false;
+    no Robot SF realism calibration, campaign, or paper-facing claim
 
 reference_case_id: zanlungo_paper_reference
 

--- a/configs/research/issue_4973_zanlungo_corridor_acceptance.yaml
+++ b/configs/research/issue_4973_zanlungo_corridor_acceptance.yaml
@@ -1,0 +1,79 @@
+schema_version: zanlungo-corridor-acceptance.v1
+issue: 4973
+metadata:
+  benchmark_evidence: false
+  evidence_tier: diagnostic-only
+  claim_boundary: >-
+    Deterministic CPU synthetic-corridor acceptance only. This packet does not
+    calibrate pedestrian realism or support benchmark, paper, or dissertation claims.
+
+reference_case_id: zanlungo_paper_reference
+
+fixture:
+  width_m: 10.0
+  height_m: 4.0
+  corridor_min_y_m: 1.2
+  corridor_max_y_m: 2.8
+  left_start: [2.5, 1.9]
+  right_start: [7.5, 2.1]
+  left_goal_x_m: 7.5
+  right_goal_x_m: 2.5
+  desired_speed_mps: 1.0
+  duration_s: 10.0
+  dt_s: 0.1
+  seed: 4973
+
+thresholds:
+  lateral_yield_m: 0.2
+  collision_proxy_distance_m: 0.25
+  freeze_speed_mps: 0.1
+  freeze_window_s: 1.0
+  conflict_distance_m: 1.5
+
+sensitivity_cases:
+  - case_id: social_force_control
+    pedestrian_model: social_force_default
+    varied_parameter: null
+    relative_to_reference: null
+    parameters: {}
+  - case_id: zanlungo_strength_low
+    pedestrian_model: hsfm_zanlungo_collision_prediction_v1
+    varied_parameter: interaction_strength
+    relative_to_reference: 0.4424778761061947
+    parameters: &paper_parameters
+      interaction_strength: 0.5
+      interaction_range_m: 0.71
+      anisotropy_lambda: 0.29
+      angle_threshold_rad: 0.7853981633974483
+      max_force: 5.0
+      include_ped_ped: true
+  - case_id: zanlungo_paper_reference
+    pedestrian_model: hsfm_zanlungo_collision_prediction_v1
+    varied_parameter: reference
+    relative_to_reference: 1.0
+    parameters:
+      <<: *paper_parameters
+      interaction_strength: 1.13
+  - case_id: zanlungo_strength_high
+    pedestrian_model: hsfm_zanlungo_collision_prediction_v1
+    varied_parameter: interaction_strength
+    relative_to_reference: 1.7699115044247788
+    parameters:
+      <<: *paper_parameters
+      interaction_strength: 2.0
+  - case_id: zanlungo_range_low
+    pedestrian_model: hsfm_zanlungo_collision_prediction_v1
+    varied_parameter: interaction_range_m
+    relative_to_reference: 0.5633802816901409
+    parameters:
+      <<: *paper_parameters
+      interaction_strength: 1.13
+      interaction_range_m: 0.4
+  - case_id: zanlungo_range_high
+    pedestrian_model: hsfm_zanlungo_collision_prediction_v1
+    varied_parameter: interaction_range_m
+    relative_to_reference: 1.6901408450704225
+    parameters:
+      <<: *paper_parameters
+      interaction_strength: 1.13
+      interaction_range_m: 1.2

--- a/configs/research/zanlungo_collision_prediction_issue_4973.yaml
+++ b/configs/research/zanlungo_collision_prediction_issue_4973.yaml
@@ -30,8 +30,11 @@ provenance:
     - per-actor maximum-force cap
 validation:
   focused_test: tests/sim/test_zanlungo_collision_prediction_model.py
-  corridor_acceptance_status: deferred
-  corridor_acceptance_reason: >-
-    The implementation seam is complete, but eliminating freeze/deadlock requires
-    a predeclared scenario comparison and parameter sensitivity run; this config
-    does not promote the paper's calibration to Robot SF benchmark evidence.
+  corridor_acceptance_status: implemented
+  corridor_acceptance_config: configs/research/issue_4973_zanlungo_corridor_acceptance.yaml
+  corridor_acceptance_command: >-
+    uv run python scripts/validation/run_issue_4973_zanlungo_corridor_acceptance.py
+  corridor_acceptance_boundary: >-
+    The deterministic CPU corridor matrix is diagnostic-only with
+    benchmark_evidence=false; it does not promote the paper's calibration to Robot SF
+    benchmark or realism evidence.

--- a/docs/context/issue_4973_zanlungo_collision_prediction.md
+++ b/docs/context/issue_4973_zanlungo_collision_prediction.md
@@ -35,9 +35,19 @@ equation's exactly centered zero-distance direction, and `max_force` bounds nume
   the Zanlungo common-time, non-additive projection.
 - Focused tests prove pure-force geometry, common-time coupling, deterministic degeneracy handling,
   scenario-config loading, default compatibility, runtime composition, and fail-closed behavior.
-- Corridor-level freeze/deadlock acceptance remains a separate predeclared CPU comparison with
-  parameter sensitivity. No benchmark campaign, Slurm/GPU job, or paper/dissertation claim is part
-  of this implementation slice.
+- The corridor acceptance packet is
+  `configs/research/issue_4973_zanlungo_corridor_acceptance.yaml`. It predeclares a two-pedestrian,
+  slightly offset head-on corridor, seed `4973`, outcome thresholds, the paper-parameter reference,
+  a reactive control, and one-at-a-time strength/range variants.
+- Run it with
+  `uv run python scripts/validation/run_issue_4973_zanlungo_corridor_acceptance.py`. Every matrix row
+  is executed twice and records exact trace hashes plus a replay-determinism verdict. The reference
+  row must be labeled `yielding`; sustained conflict slowdown is labeled `freezing`, and clearance
+  proxy failures are kept distinct as `collision_proxy`. The proxy uses predeclared center-distance
+  and lateral-displacement thresholds; it is not a physical-contact or realism metric.
+- The config, report, and per-pedestrian fixture metadata all state `benchmark_evidence=false`.
+  These labels are deterministic CPU fixture acceptance, not a calibration or external-validity
+  result. No benchmark campaign, Slurm/GPU job, or paper/dissertation claim is part of this work.
 
 Reference: F. Zanlungo, T. Ikeda, and T. Kanda, “Social force model with explicit collision
 prediction,” *EPL* 93 (2011) 68005, <https://doi.org/10.1209/0295-5075/93/68005>.

--- a/robot_sf/research/zanlungo_corridor_acceptance.py
+++ b/robot_sf/research/zanlungo_corridor_acceptance.py
@@ -1,0 +1,624 @@
+"""Deterministic CPU corridor acceptance harness for the opt-in Zanlungo force.
+
+The harness is deliberately diagnostic. It labels short synthetic head-on traces and
+records one-at-a-time parameter variants, but never promotes them to benchmark evidence
+or a realism calibration.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+import yaml
+
+from robot_sf.nav.global_route import GlobalRoute
+from robot_sf.nav.map_config import MapDefinition, SinglePedestrianDefinition
+from robot_sf.nav.obstacle import Obstacle
+from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_ZANLUNGO_COLLISION_PREDICTION_V1,
+    SOCIAL_FORCE_DEFAULT,
+    normalize_pedestrian_model,
+)
+from robot_sf.sim.sim_config import (
+    SimulationSettings,
+    ZanlungoCollisionPredictionConfig,
+)
+from robot_sf.sim.simulator import Simulator
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from robot_sf.common.types import Rect
+
+SCHEMA_VERSION = "zanlungo-corridor-acceptance.v1"
+CLAIM_BOUNDARY = (
+    "deterministic CPU synthetic-corridor acceptance only; benchmark_evidence=false; "
+    "no Robot SF realism calibration, campaign, or paper-facing claim"
+)
+OutcomeLabel = Literal[
+    "yielding",
+    "freezing",
+    "collision_proxy",
+    "pass_through",
+    "incomplete",
+]
+
+
+@dataclass(frozen=True)
+class CorridorFixtureConfig:
+    """Geometry and runtime controls for the two-pedestrian corridor fixture."""
+
+    width_m: float
+    height_m: float
+    corridor_min_y_m: float
+    corridor_max_y_m: float
+    left_start: tuple[float, float]
+    right_start: tuple[float, float]
+    left_goal_x_m: float
+    right_goal_x_m: float
+    desired_speed_mps: float
+    duration_s: float
+    dt_s: float
+    seed: int
+
+    def __post_init__(self) -> None:
+        """Fail closed on malformed or physically empty fixture geometry."""
+        finite_values = (
+            self.width_m,
+            self.height_m,
+            self.corridor_min_y_m,
+            self.corridor_max_y_m,
+            *self.left_start,
+            *self.right_start,
+            self.left_goal_x_m,
+            self.right_goal_x_m,
+            self.desired_speed_mps,
+            self.duration_s,
+            self.dt_s,
+        )
+        if not all(math.isfinite(float(value)) for value in finite_values):
+            raise ValueError("corridor fixture values must be finite")
+        if self.width_m <= 0 or self.height_m <= 0:
+            raise ValueError("corridor width_m and height_m must be positive")
+        if not 0 <= self.corridor_min_y_m < self.corridor_max_y_m <= self.height_m:
+            raise ValueError("corridor y bounds must define a non-empty interval inside the map")
+        if self.desired_speed_mps <= 0 or self.duration_s <= 0 or self.dt_s <= 0:
+            raise ValueError("desired_speed_mps, duration_s, and dt_s must be positive")
+        if self.dt_s > self.duration_s:
+            raise ValueError("dt_s must not exceed duration_s")
+
+
+@dataclass(frozen=True)
+class OutcomeThresholds:
+    """Predeclared diagnostic thresholds used to label a trace."""
+
+    lateral_yield_m: float
+    collision_proxy_distance_m: float
+    freeze_speed_mps: float
+    freeze_window_s: float
+    conflict_distance_m: float
+
+    def __post_init__(self) -> None:
+        """Require finite non-negative thresholds and a positive conflict distance."""
+        values = (
+            self.lateral_yield_m,
+            self.collision_proxy_distance_m,
+            self.freeze_speed_mps,
+            self.freeze_window_s,
+            self.conflict_distance_m,
+        )
+        if not all(math.isfinite(float(value)) for value in values):
+            raise ValueError("outcome thresholds must be finite")
+        if any(value < 0 for value in values[:-1]) or self.conflict_distance_m <= 0:
+            raise ValueError(
+                "outcome thresholds must be non-negative with positive conflict distance"
+            )
+
+
+@dataclass(frozen=True)
+class SensitivityCase:
+    """One predeclared pedestrian-model parameter row."""
+
+    case_id: str
+    pedestrian_model: str
+    varied_parameter: str | None
+    relative_to_reference: float | None
+    parameters: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        """Validate the model selector and sensitivity bookkeeping fields."""
+        if not self.case_id.strip():
+            raise ValueError("sensitivity case_id must be non-empty")
+        normalize_pedestrian_model(self.pedestrian_model)
+        if self.relative_to_reference is not None and (
+            not math.isfinite(float(self.relative_to_reference)) or self.relative_to_reference < 0
+        ):
+            raise ValueError("relative_to_reference must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class CorridorTrace:
+    """Positions and velocities from one deterministic fixture execution."""
+
+    positions: np.ndarray
+    velocities: np.ndarray
+    dt_s: float
+
+
+@dataclass(frozen=True)
+class AcceptanceConfig:
+    """Validated issue #4973 corridor acceptance packet."""
+
+    issue: int
+    benchmark_evidence: bool
+    reference_case_id: str
+    fixture: CorridorFixtureConfig
+    thresholds: OutcomeThresholds
+    cases: tuple[SensitivityCase, ...]
+    config_path: str
+    config_sha256: str
+
+
+def load_acceptance_config(path: str | Path) -> AcceptanceConfig:
+    """Load and validate the predeclared YAML acceptance packet.
+
+    Returns:
+        Validated corridor acceptance configuration.
+    """
+    config_path = Path(path)
+    raw_bytes = config_path.read_bytes()
+    payload = yaml.safe_load(raw_bytes)
+    if not isinstance(payload, dict):
+        raise ValueError("acceptance config must be a YAML mapping")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {SCHEMA_VERSION}")
+    metadata = _require_mapping(payload, "metadata")
+    benchmark_evidence = metadata.get("benchmark_evidence")
+    if benchmark_evidence is not False:
+        raise ValueError("metadata.benchmark_evidence must be false")
+    fixture = CorridorFixtureConfig(**_normalize_fixture(_require_mapping(payload, "fixture")))
+    thresholds = OutcomeThresholds(**_require_mapping(payload, "thresholds"))
+    raw_cases = payload.get("sensitivity_cases")
+    if not isinstance(raw_cases, list) or not raw_cases:
+        raise ValueError("sensitivity_cases must be a non-empty list")
+    cases = tuple(_normalize_case(item) for item in raw_cases)
+    case_ids = [case.case_id for case in cases]
+    if len(case_ids) != len(set(case_ids)):
+        raise ValueError("sensitivity case_id values must be unique")
+    reference_case_id = str(payload.get("reference_case_id", ""))
+    if reference_case_id not in set(case_ids):
+        raise ValueError("reference_case_id must select one sensitivity case")
+    reference_case = cases[case_ids.index(reference_case_id)]
+    if reference_case.pedestrian_model != HSFM_ZANLUNGO_COLLISION_PREDICTION_V1:
+        raise ValueError("reference_case_id must select the opt-in Zanlungo model")
+    if int(payload.get("issue", 0)) != 4973:
+        raise ValueError("issue must be 4973")
+    if not _parameter_bookkeeping_complete(cases, reference_case_id):
+        raise ValueError(
+            "sensitivity rows must change only their named parameter and record its exact ratio"
+        )
+    return AcceptanceConfig(
+        issue=4973,
+        benchmark_evidence=False,
+        reference_case_id=reference_case_id,
+        fixture=fixture,
+        thresholds=thresholds,
+        cases=cases,
+        config_path=str(config_path),
+        config_sha256=hashlib.sha256(raw_bytes).hexdigest(),
+    )
+
+
+def classify_corridor_trace(
+    trace: CorridorTrace,
+    fixture: CorridorFixtureConfig,
+    thresholds: OutcomeThresholds,
+) -> dict[str, Any]:
+    """Compute trace metrics and assign one explicit outcome label.
+
+    Returns:
+        JSON-safe metrics and a mutually exclusive outcome label.
+    """
+    positions = np.asarray(trace.positions, dtype=float)
+    velocities = np.asarray(trace.velocities, dtype=float)
+    if positions.ndim != 3 or positions.shape[1:] != (2, 2):
+        raise ValueError("trace.positions must have shape (T, 2, 2)")
+    if velocities.shape != positions.shape:
+        raise ValueError("trace.velocities must match trace.positions")
+    if positions.shape[0] < 1:
+        raise ValueError("trace must contain at least one state")
+    if not np.all(np.isfinite(positions)) or not np.all(np.isfinite(velocities)):
+        raise ValueError("trace positions and velocities must be finite")
+    if not math.isfinite(trace.dt_s) or trace.dt_s <= 0:
+        raise ValueError("trace.dt_s must be finite and positive")
+
+    separation = np.linalg.norm(positions[:, 0] - positions[:, 1], axis=1)
+    speeds = np.linalg.norm(velocities, axis=-1)
+    passed_by_step = positions[:, 0, 0] >= positions[:, 1, 0]
+    passed_indices = np.flatnonzero(passed_by_step)
+    first_pass_index = int(passed_indices[0]) if passed_indices.size else positions.shape[0] - 1
+    pre_pass_positions = positions[: first_pass_index + 1]
+    lateral_displacements = np.max(
+        np.abs(pre_pass_positions[:, :, 1] - positions[0, :, 1][np.newaxis, :]), axis=0
+    )
+    freeze_mask = (
+        (separation <= thresholds.conflict_distance_m)
+        & ~passed_by_step
+        & np.all(speeds <= thresholds.freeze_speed_mps, axis=1)
+    )
+    max_freeze_steps = _max_consecutive_true(freeze_mask)
+    required_freeze_steps = max(1, math.ceil(thresholds.freeze_window_s / trace.dt_s))
+    passed = bool(np.any(passed_by_step))
+    avoided_collision_proxy = float(np.min(separation)) >= thresholds.collision_proxy_distance_m
+    lateral_yield_met = bool(np.all(lateral_displacements >= thresholds.lateral_yield_m))
+    freezing = max_freeze_steps >= required_freeze_steps
+
+    if freezing:
+        outcome: OutcomeLabel = "freezing"
+    elif passed and lateral_yield_met and avoided_collision_proxy:
+        outcome = "yielding"
+    elif passed and not avoided_collision_proxy:
+        outcome = "collision_proxy"
+    elif passed:
+        outcome = "pass_through"
+    else:
+        outcome = "incomplete"
+
+    return {
+        "outcome_label": outcome,
+        "passed": passed,
+        "first_passing_time_s": float(first_pass_index * trace.dt_s) if passed else None,
+        "minimum_pairwise_center_distance_m": float(np.min(separation)),
+        "maximum_lateral_displacement_m": [float(value) for value in lateral_displacements],
+        "lateral_yield_criterion_met": lateral_yield_met,
+        "collision_proxy_avoided": avoided_collision_proxy,
+        "maximum_consecutive_freeze_steps": max_freeze_steps,
+        "required_freeze_steps": required_freeze_steps,
+        "freeze_criterion_met": freezing,
+        "finite_positions": True,
+        "finite_velocities": True,
+    }
+
+
+def run_corridor_trace(
+    fixture: CorridorFixtureConfig,
+    case: SensitivityCase,
+) -> CorridorTrace:
+    """Run one CPU-only corridor trace for a predeclared sensitivity row.
+
+    Returns:
+        Collected simulator state for the requested row.
+    """
+    model = normalize_pedestrian_model(case.pedestrian_model)
+    zanlungo = ZanlungoCollisionPredictionConfig()
+    if model == HSFM_ZANLUNGO_COLLISION_PREDICTION_V1:
+        zanlungo = ZanlungoCollisionPredictionConfig(enabled=True, **dict(case.parameters))
+    elif case.parameters:
+        raise ValueError("non-Zanlungo sensitivity rows must not declare Zanlungo parameters")
+    settings = SimulationSettings(
+        sim_time_in_secs=fixture.duration_s,
+        time_per_step_in_secs=fixture.dt_s,
+        ped_density_by_difficulty=[0.0],
+        difficulty=0,
+        route_spawn_seed=fixture.seed,
+        max_total_pedestrians=2,
+        pedestrian_model=model,
+        zanlungo_collision_prediction=zanlungo,
+    )
+    simulator = Simulator(
+        settings,
+        _build_corridor_map(fixture),
+        robots=[],
+        goal_proximity_threshold=0.0,
+        random_start_pos=False,
+        peds_have_obstacle_forces=True,
+    )
+    positions = [np.asarray(simulator.ped_pos, dtype=float).copy()]
+    velocities = [np.asarray(simulator.ped_vel, dtype=float).copy()]
+    for _ in range(math.floor(fixture.duration_s / fixture.dt_s)):
+        simulator.step_once([])
+        positions.append(np.asarray(simulator.ped_pos, dtype=float).copy())
+        velocities.append(np.asarray(simulator.ped_vel, dtype=float).copy())
+    return CorridorTrace(
+        positions=np.asarray(positions, dtype=float),
+        velocities=np.asarray(velocities, dtype=float),
+        dt_s=fixture.dt_s,
+    )
+
+
+def run_acceptance(config: AcceptanceConfig) -> dict[str, Any]:
+    """Execute every row twice and build the issue #4973 acceptance report.
+
+    Returns:
+        JSON-safe report with outcomes, sensitivity lineage, and replay proof.
+    """
+    rows: list[dict[str, Any]] = []
+    for case in config.cases:
+        first = run_corridor_trace(config.fixture, case)
+        replay = run_corridor_trace(config.fixture, case)
+        deterministic = bool(
+            np.array_equal(first.positions, replay.positions)
+            and np.array_equal(first.velocities, replay.velocities)
+        )
+        row = {
+            "case_id": case.case_id,
+            "pedestrian_model": case.pedestrian_model,
+            "varied_parameter": case.varied_parameter,
+            "relative_to_reference": case.relative_to_reference,
+            "parameters": dict(case.parameters),
+            "seed": config.fixture.seed,
+            "step_count": int(first.positions.shape[0] - 1),
+            "trace_sha256": _trace_sha256(first),
+            "replay_trace_sha256": _trace_sha256(replay),
+            "replay_deterministic": deterministic,
+            "metrics": classify_corridor_trace(first, config.fixture, config.thresholds),
+        }
+        rows.append(row)
+
+    reference = next(row for row in rows if row["case_id"] == config.reference_case_id)
+    checks = {
+        "reference_outcome_is_yielding": reference["metrics"]["outcome_label"] == "yielding",
+        "all_rows_replay_deterministic": all(row["replay_deterministic"] for row in rows),
+        "parameter_sensitivity_bookkeeping_complete": all(
+            row["varied_parameter"] is not None and bool(row["parameters"])
+            for row in rows
+            if row["pedestrian_model"] == HSFM_ZANLUNGO_COLLISION_PREDICTION_V1
+        ),
+        "benchmark_evidence_is_false": config.benchmark_evidence is False,
+        "default_force_path_unchanged": SimulationSettings().pedestrian_model
+        == SOCIAL_FORCE_DEFAULT,
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": config.issue,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "evidence_tier": "diagnostic-only",
+        "benchmark_evidence": False,
+        "config": {
+            "path": config.config_path,
+            "sha256": config.config_sha256,
+            "reference_case_id": config.reference_case_id,
+        },
+        "fixture": {
+            "seed": config.fixture.seed,
+            "duration_s": config.fixture.duration_s,
+            "dt_s": config.fixture.dt_s,
+            "pedestrian_count": 2,
+            "robot_inserted": False,
+        },
+        "thresholds": config.thresholds.__dict__,
+        "acceptance_checks": checks,
+        "acceptance_met": all(checks.values()),
+        "status": {
+            "cpu_only": True,
+            "slurm_or_gpu_used": False,
+            "full_campaign_run": False,
+        },
+        "rows": rows,
+    }
+
+
+def write_acceptance_report(report: Mapping[str, Any], output_dir: str | Path) -> dict[str, Path]:
+    """Write compact JSON and Markdown acceptance artifacts.
+
+    Returns:
+        Paths to the generated local artifacts.
+    """
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary = out_dir / "summary.json"
+    readme = out_dir / "README.md"
+    summary.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    readme.write_text(render_acceptance_markdown(report), encoding="utf-8")
+    return {"summary_json": summary, "readme": readme}
+
+
+def render_acceptance_markdown(report: Mapping[str, Any]) -> str:
+    """Render a reviewer-readable report summary.
+
+    Returns:
+        Markdown with the claim boundary before outcome interpretation.
+    """
+    lines = [
+        "# Zanlungo corridor acceptance diagnostic",
+        "",
+        f"Claim boundary: {report['claim_boundary']}.",
+        "Evidence status: diagnostic-only; `benchmark_evidence=false`.",
+        "",
+        "| case | model | varied parameter | outcome | minimum center distance (m) | "
+        "replay deterministic |",
+        "| --- | --- | --- | --- | ---: | --- |",
+    ]
+    for row in report["rows"]:
+        lines.append(
+            f"| {row['case_id']} | {row['pedestrian_model']} | "
+            f"{row['varied_parameter'] or 'baseline'} | {row['metrics']['outcome_label']} | "
+            f"{row['metrics']['minimum_pairwise_center_distance_m']:.3f} | "
+            f"{row['replay_deterministic']} |"
+        )
+    lines.extend(
+        [
+            "",
+            f"Acceptance met: **{report['acceptance_met']}**.",
+            "",
+            "These synthetic labels are fixture acceptance checks, not benchmark or realism claims.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _normalize_fixture(payload: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+    for key in ("left_start", "right_start"):
+        value = normalized.get(key)
+        if not isinstance(value, list) or len(value) != 2:
+            raise ValueError(f"fixture.{key} must be a two-value list")
+        normalized[key] = (float(value[0]), float(value[1]))
+    return normalized
+
+
+def _normalize_case(payload: Any) -> SensitivityCase:
+    if not isinstance(payload, dict):
+        raise ValueError("each sensitivity case must be a mapping")
+    parameters = payload.get("parameters", {})
+    if not isinstance(parameters, dict):
+        raise ValueError("sensitivity case parameters must be a mapping")
+    return SensitivityCase(
+        case_id=str(payload.get("case_id", "")),
+        pedestrian_model=normalize_pedestrian_model(payload.get("pedestrian_model")),
+        varied_parameter=payload.get("varied_parameter"),
+        relative_to_reference=payload.get("relative_to_reference"),
+        parameters=parameters,
+    )
+
+
+def _parameter_bookkeeping_complete(
+    cases: tuple[SensitivityCase, ...], reference_case_id: str
+) -> bool:
+    reference = next(case for case in cases if case.case_id == reference_case_id)
+    reference_parameters = dict(reference.parameters)
+    for case in cases:
+        if case.pedestrian_model != HSFM_ZANLUNGO_COLLISION_PREDICTION_V1:
+            if case.parameters or case.varied_parameter is not None:
+                return False
+            continue
+        if set(case.parameters) != set(reference_parameters):
+            return False
+        if case.case_id == reference_case_id:
+            if case.varied_parameter != "reference" or case.relative_to_reference != 1.0:
+                return False
+            continue
+        changed = {
+            key
+            for key, reference_value in reference_parameters.items()
+            if case.parameters[key] != reference_value
+        }
+        if changed != {case.varied_parameter}:
+            return False
+        reference_value = reference_parameters.get(str(case.varied_parameter))
+        case_value = case.parameters.get(str(case.varied_parameter))
+        if (
+            isinstance(reference_value, bool)
+            or isinstance(case_value, bool)
+            or not isinstance(reference_value, (int, float))
+            or not isinstance(case_value, (int, float))
+            or reference_value == 0
+            or case.relative_to_reference is None
+            or not math.isclose(
+                float(case.relative_to_reference),
+                float(case_value) / float(reference_value),
+                rel_tol=1e-12,
+                abs_tol=1e-12,
+            )
+        ):
+            return False
+    return True
+
+
+def _require_mapping(payload: Mapping[str, Any], field_name: str) -> Mapping[str, Any]:
+    value = payload.get(field_name)
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be a mapping")
+    return value
+
+
+def _build_corridor_map(fixture: CorridorFixtureConfig) -> MapDefinition:
+    obstacles = [
+        Obstacle(
+            [
+                (0.0, 0.0),
+                (fixture.width_m, 0.0),
+                (fixture.width_m, fixture.corridor_min_y_m),
+                (0.0, fixture.corridor_min_y_m),
+            ]
+        ),
+        Obstacle(
+            [
+                (0.0, fixture.corridor_max_y_m),
+                (fixture.width_m, fixture.corridor_max_y_m),
+                (fixture.width_m, fixture.height_m),
+                (0.0, fixture.height_m),
+            ]
+        ),
+    ]
+    robot_spawn = _rect(0.2, 0.2, 0.8, 0.8)
+    robot_goal = _rect(
+        fixture.width_m - 0.8,
+        fixture.height_m - 0.8,
+        fixture.width_m - 0.2,
+        fixture.height_m - 0.2,
+    )
+    pedestrians = [
+        SinglePedestrianDefinition(
+            id="corridor_left_to_right",
+            start=fixture.left_start,
+            trajectory=[(fixture.left_goal_x_m, fixture.left_start[1])],
+            speed_m_s=fixture.desired_speed_mps,
+            metadata={"benchmark_evidence": False, "issue": 4973},
+        ),
+        SinglePedestrianDefinition(
+            id="corridor_right_to_left",
+            start=fixture.right_start,
+            trajectory=[(fixture.right_goal_x_m, fixture.right_start[1])],
+            speed_m_s=fixture.desired_speed_mps,
+            metadata={"benchmark_evidence": False, "issue": 4973},
+        ),
+    ]
+    return MapDefinition(
+        width=fixture.width_m,
+        height=fixture.height_m,
+        obstacles=obstacles,
+        robot_spawn_zones=[robot_spawn],
+        ped_spawn_zones=[],
+        robot_goal_zones=[robot_goal],
+        bounds=[
+            ((0.0, 0.0), (fixture.width_m, 0.0)),
+            ((fixture.width_m, 0.0), (fixture.width_m, fixture.height_m)),
+            ((fixture.width_m, fixture.height_m), (0.0, fixture.height_m)),
+            ((0.0, fixture.height_m), (0.0, 0.0)),
+        ],
+        robot_routes=[
+            GlobalRoute(
+                spawn_id=0,
+                goal_id=0,
+                waypoints=[(0.5, 0.5), (fixture.width_m - 0.5, fixture.height_m - 0.5)],
+                spawn_zone=robot_spawn,
+                goal_zone=robot_goal,
+                source_path_id="issue_4973_diagnostic_robot_stub",
+                source_label="diagnostic-only robot route stub; no robot inserted",
+            )
+        ],
+        ped_goal_zones=[],
+        ped_crowded_zones=[],
+        ped_routes=[],
+        single_pedestrians=pedestrians,
+    )
+
+
+def _trace_sha256(trace: CorridorTrace) -> str:
+    digest = hashlib.sha256()
+    for array in (trace.positions, trace.velocities):
+        canonical = np.ascontiguousarray(array, dtype="<f8")
+        digest.update(str(canonical.shape).encode("ascii"))
+        digest.update(canonical.tobytes())
+    return digest.hexdigest()
+
+
+def _max_consecutive_true(mask: np.ndarray) -> int:
+    maximum = 0
+    current = 0
+    for value in np.asarray(mask, dtype=bool):
+        current = current + 1 if value else 0
+        maximum = max(maximum, current)
+    return maximum
+
+
+def _rect(x0: float, y0: float, x1: float, y1: float) -> Rect:
+    return ((x0, y1), (x1, y1), (x1, y0))

--- a/robot_sf/research/zanlungo_corridor_acceptance.py
+++ b/robot_sf/research/zanlungo_corridor_acceptance.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import math
 from dataclasses import dataclass
+from numbers import Real
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -37,6 +38,7 @@ if TYPE_CHECKING:
     from robot_sf.common.types import Rect
 
 SCHEMA_VERSION = "zanlungo-corridor-acceptance.v1"
+EVIDENCE_TIER = "diagnostic-only"
 CLAIM_BOUNDARY = (
     "deterministic CPU synthetic-corridor acceptance only; benchmark_evidence=false; "
     "no Robot SF realism calibration, campaign, or paper-facing claim"
@@ -69,21 +71,25 @@ class CorridorFixtureConfig:
 
     def __post_init__(self) -> None:
         """Fail closed on malformed or physically empty fixture geometry."""
-        finite_values = (
-            self.width_m,
-            self.height_m,
-            self.corridor_min_y_m,
-            self.corridor_max_y_m,
-            *self.left_start,
-            *self.right_start,
-            self.left_goal_x_m,
-            self.right_goal_x_m,
-            self.desired_speed_mps,
-            self.duration_s,
-            self.dt_s,
-        )
-        if not all(math.isfinite(float(value)) for value in finite_values):
-            raise ValueError("corridor fixture values must be finite")
+        values = {
+            "width_m": self.width_m,
+            "height_m": self.height_m,
+            "corridor_min_y_m": self.corridor_min_y_m,
+            "corridor_max_y_m": self.corridor_max_y_m,
+            "left_start[0]": self.left_start[0],
+            "left_start[1]": self.left_start[1],
+            "right_start[0]": self.right_start[0],
+            "right_start[1]": self.right_start[1],
+            "left_goal_x_m": self.left_goal_x_m,
+            "right_goal_x_m": self.right_goal_x_m,
+            "desired_speed_mps": self.desired_speed_mps,
+            "duration_s": self.duration_s,
+            "dt_s": self.dt_s,
+        }
+        for field_name, value in values.items():
+            _require_finite_real(value, f"fixture.{field_name}")
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int) or self.seed < 0:
+            raise ValueError("fixture.seed must be a non-negative integer")
         if self.width_m <= 0 or self.height_m <= 0:
             raise ValueError("corridor width_m and height_m must be positive")
         if not 0 <= self.corridor_min_y_m < self.corridor_max_y_m <= self.height_m:
@@ -106,16 +112,23 @@ class OutcomeThresholds:
 
     def __post_init__(self) -> None:
         """Require finite non-negative thresholds and a positive conflict distance."""
-        values = (
-            self.lateral_yield_m,
-            self.collision_proxy_distance_m,
-            self.freeze_speed_mps,
-            self.freeze_window_s,
-            self.conflict_distance_m,
-        )
-        if not all(math.isfinite(float(value)) for value in values):
-            raise ValueError("outcome thresholds must be finite")
-        if any(value < 0 for value in values[:-1]) or self.conflict_distance_m <= 0:
+        values = {
+            "lateral_yield_m": self.lateral_yield_m,
+            "collision_proxy_distance_m": self.collision_proxy_distance_m,
+            "freeze_speed_mps": self.freeze_speed_mps,
+            "freeze_window_s": self.freeze_window_s,
+            "conflict_distance_m": self.conflict_distance_m,
+        }
+        for field_name, value in values.items():
+            _require_finite_real(value, f"thresholds.{field_name}")
+        if (
+            any(
+                value < 0
+                for field_name, value in values.items()
+                if field_name != "conflict_distance_m"
+            )
+            or self.conflict_distance_m <= 0
+        ):
             raise ValueError(
                 "outcome thresholds must be non-negative with positive conflict distance"
             )
@@ -136,10 +149,10 @@ class SensitivityCase:
         if not self.case_id.strip():
             raise ValueError("sensitivity case_id must be non-empty")
         normalize_pedestrian_model(self.pedestrian_model)
-        if self.relative_to_reference is not None and (
-            not math.isfinite(float(self.relative_to_reference)) or self.relative_to_reference < 0
-        ):
-            raise ValueError("relative_to_reference must be finite and non-negative")
+        if self.relative_to_reference is not None:
+            _require_finite_real(self.relative_to_reference, "relative_to_reference")
+            if self.relative_to_reference < 0:
+                raise ValueError("relative_to_reference must be non-negative")
 
 
 @dataclass(frozen=True)
@@ -157,6 +170,8 @@ class AcceptanceConfig:
 
     issue: int
     benchmark_evidence: bool
+    evidence_tier: str
+    claim_boundary: str
     reference_case_id: str
     fixture: CorridorFixtureConfig
     thresholds: OutcomeThresholds
@@ -178,10 +193,7 @@ def load_acceptance_config(path: str | Path) -> AcceptanceConfig:
         raise ValueError("acceptance config must be a YAML mapping")
     if payload.get("schema_version") != SCHEMA_VERSION:
         raise ValueError(f"schema_version must be {SCHEMA_VERSION}")
-    metadata = _require_mapping(payload, "metadata")
-    benchmark_evidence = metadata.get("benchmark_evidence")
-    if benchmark_evidence is not False:
-        raise ValueError("metadata.benchmark_evidence must be false")
+    evidence_tier, claim_boundary = _validate_metadata(_require_mapping(payload, "metadata"))
     fixture = CorridorFixtureConfig(**_normalize_fixture(_require_mapping(payload, "fixture")))
     thresholds = OutcomeThresholds(**_require_mapping(payload, "thresholds"))
     raw_cases = payload.get("sensitivity_cases")
@@ -206,6 +218,8 @@ def load_acceptance_config(path: str | Path) -> AcceptanceConfig:
     return AcceptanceConfig(
         issue=4973,
         benchmark_evidence=False,
+        evidence_tier=evidence_tier,
+        claim_boundary=claim_boundary,
         reference_case_id=reference_case_id,
         fixture=fixture,
         thresholds=thresholds,
@@ -377,8 +391,8 @@ def run_acceptance(config: AcceptanceConfig) -> dict[str, Any]:
     return {
         "schema_version": SCHEMA_VERSION,
         "issue": config.issue,
-        "claim_boundary": CLAIM_BOUNDARY,
-        "evidence_tier": "diagnostic-only",
+        "claim_boundary": config.claim_boundary,
+        "evidence_tier": config.evidence_tier,
         "benchmark_evidence": False,
         "config": {
             "path": config.config_path,
@@ -460,7 +474,10 @@ def _normalize_fixture(payload: Mapping[str, Any]) -> dict[str, Any]:
         value = normalized.get(key)
         if not isinstance(value, list) or len(value) != 2:
             raise ValueError(f"fixture.{key} must be a two-value list")
-        normalized[key] = (float(value[0]), float(value[1]))
+        normalized[key] = (
+            _require_finite_real(value[0], f"fixture.{key}[0]"),
+            _require_finite_real(value[1], f"fixture.{key}[1]"),
+        )
     return normalized
 
 
@@ -470,13 +487,59 @@ def _normalize_case(payload: Any) -> SensitivityCase:
     parameters = payload.get("parameters", {})
     if not isinstance(parameters, dict):
         raise ValueError("sensitivity case parameters must be a mapping")
+    pedestrian_model = normalize_pedestrian_model(payload.get("pedestrian_model"))
+    if pedestrian_model == HSFM_ZANLUNGO_COLLISION_PREDICTION_V1:
+        _validate_zanlungo_parameters(parameters)
     return SensitivityCase(
         case_id=str(payload.get("case_id", "")),
-        pedestrian_model=normalize_pedestrian_model(payload.get("pedestrian_model")),
+        pedestrian_model=pedestrian_model,
         varied_parameter=payload.get("varied_parameter"),
         relative_to_reference=payload.get("relative_to_reference"),
         parameters=parameters,
     )
+
+
+def _require_finite_real(value: Any, field_name: str) -> float:
+    """Return a finite real value while rejecting YAML booleans explicitly."""
+    if isinstance(value, bool) or not isinstance(value, Real) or not math.isfinite(float(value)):
+        raise ValueError(f"{field_name} must be a finite real number, not a boolean")
+    return float(value)
+
+
+def _validate_metadata(metadata: Mapping[str, Any]) -> tuple[str, str]:
+    """Require the packet provenance that the diagnostic report will emit.
+
+    Returns:
+        Validated evidence tier and claim boundary.
+    """
+    if metadata.get("benchmark_evidence") is not False:
+        raise ValueError("metadata.benchmark_evidence must be false")
+    evidence_tier = metadata.get("evidence_tier")
+    if evidence_tier != EVIDENCE_TIER:
+        raise ValueError(f"metadata.evidence_tier must be {EVIDENCE_TIER}")
+    claim_boundary = metadata.get("claim_boundary")
+    if claim_boundary != CLAIM_BOUNDARY:
+        raise ValueError("metadata.claim_boundary must match the diagnostic acceptance boundary")
+    return evidence_tier, claim_boundary
+
+
+def _validate_zanlungo_parameters(parameters: Mapping[str, Any]) -> None:
+    """Reject incomplete, unexpected, or non-numeric Zanlungo packet parameters."""
+    numeric_fields = {
+        "interaction_strength",
+        "interaction_range_m",
+        "anisotropy_lambda",
+        "angle_threshold_rad",
+        "max_force",
+    }
+    required_fields = numeric_fields | {"include_ped_ped"}
+    if set(parameters) != required_fields:
+        raise ValueError("Zanlungo sensitivity parameters must declare the complete paper packet")
+    for field_name in numeric_fields:
+        _require_finite_real(parameters[field_name], f"parameters.{field_name}")
+    if not isinstance(parameters["include_ped_ped"], bool):
+        raise ValueError("parameters.include_ped_ped must be a boolean")
+    ZanlungoCollisionPredictionConfig(enabled=True, **dict(parameters))
 
 
 def _parameter_bookkeeping_complete(

--- a/scripts/validation/run_issue_4973_zanlungo_corridor_acceptance.py
+++ b/scripts/validation/run_issue_4973_zanlungo_corridor_acceptance.py
@@ -12,6 +12,8 @@ from robot_sf.research.zanlungo_corridor_acceptance import (
     write_acceptance_report,
 )
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the validation command parser."""
@@ -19,12 +21,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--config",
         type=Path,
-        default=Path("configs/research/issue_4973_zanlungo_corridor_acceptance.yaml"),
+        default=REPO_ROOT / "configs/research/issue_4973_zanlungo_corridor_acceptance.yaml",
     )
     parser.add_argument(
         "--output-dir",
         type=Path,
-        default=Path("output/issue_4973_zanlungo_corridor_acceptance"),
+        default=REPO_ROOT / "output/issue_4973_zanlungo_corridor_acceptance",
     )
     return parser
 

--- a/scripts/validation/run_issue_4973_zanlungo_corridor_acceptance.py
+++ b/scripts/validation/run_issue_4973_zanlungo_corridor_acceptance.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Run the issue #4973 deterministic CPU corridor acceptance harness."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from robot_sf.research.zanlungo_corridor_acceptance import (
+    load_acceptance_config,
+    run_acceptance,
+    write_acceptance_report,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the validation command parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("configs/research/issue_4973_zanlungo_corridor_acceptance.yaml"),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("output/issue_4973_zanlungo_corridor_acceptance"),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the configured harness and return nonzero when acceptance is not met."""
+    args = build_parser().parse_args(argv)
+    report = run_acceptance(load_acceptance_config(args.config))
+    paths = write_acceptance_report(report, args.output_dir)
+    print(f"acceptance_met={report['acceptance_met']}")
+    print(f"summary={paths['summary_json']}")
+    return 0 if report["acceptance_met"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/sim/test_zanlungo_corridor_acceptance.py
+++ b/tests/sim/test_zanlungo_corridor_acceptance.py
@@ -1,0 +1,180 @@
+"""Tests for the issue #4973 Zanlungo corridor acceptance harness."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from robot_sf.research.zanlungo_corridor_acceptance import (
+    AcceptanceConfig,
+    CorridorFixtureConfig,
+    CorridorTrace,
+    classify_corridor_trace,
+    load_acceptance_config,
+    render_acceptance_markdown,
+    run_acceptance,
+    write_acceptance_report,
+)
+from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_ZANLUNGO_COLLISION_PREDICTION_V1,
+    SOCIAL_FORCE_DEFAULT,
+)
+from robot_sf.sim.sim_config import SimulationSettings
+
+CONFIG_PATH = Path("configs/research/issue_4973_zanlungo_corridor_acceptance.yaml")
+
+
+@pytest.fixture(scope="module")
+def config() -> AcceptanceConfig:
+    """Load the canonical predeclared acceptance packet once."""
+    return load_acceptance_config(CONFIG_PATH)
+
+
+@pytest.fixture(scope="module")
+def report(config: AcceptanceConfig) -> dict:
+    """Run the bounded CPU acceptance matrix once for contract assertions."""
+    return run_acceptance(config)
+
+
+def test_canonical_config_predeclares_fixture_and_parameter_bookkeeping(
+    config: AcceptanceConfig,
+) -> None:
+    """The packet fixes geometry, seed, reference row, and one-at-a-time variants."""
+    assert config.issue == 4973
+    assert config.benchmark_evidence is False
+    assert config.fixture.seed == 4973
+    assert config.fixture.dt_s == pytest.approx(0.1)
+    assert config.reference_case_id == "zanlungo_paper_reference"
+    assert config.cases[0].pedestrian_model == SOCIAL_FORCE_DEFAULT
+    assert {case.varied_parameter for case in config.cases[1:]} == {
+        "reference",
+        "interaction_strength",
+        "interaction_range_m",
+    }
+    assert all(case.relative_to_reference is not None for case in config.cases[1:])
+
+
+def test_cpu_harness_labels_reference_yielding_and_control_collision_proxy(
+    report: dict,
+) -> None:
+    """The predeclared reference yields while the reactive control misses clearance."""
+    by_id = {row["case_id"]: row for row in report["rows"]}
+    assert by_id["zanlungo_paper_reference"]["metrics"]["outcome_label"] == "yielding"
+    assert by_id["social_force_control"]["metrics"]["outcome_label"] == "collision_proxy"
+    assert report["acceptance_checks"]["reference_outcome_is_yielding"] is True
+    assert report["acceptance_met"] is True
+
+
+def test_every_parameter_row_has_exact_replay_and_explicit_non_benchmark_metadata(
+    report: dict,
+) -> None:
+    """Every row replays byte-identically and remains outside benchmark evidence."""
+    assert report["benchmark_evidence"] is False
+    assert report["evidence_tier"] == "diagnostic-only"
+    assert report["status"] == {
+        "cpu_only": True,
+        "slurm_or_gpu_used": False,
+        "full_campaign_run": False,
+    }
+    assert report["acceptance_checks"]["all_rows_replay_deterministic"] is True
+    for row in report["rows"]:
+        assert row["replay_deterministic"] is True
+        assert row["trace_sha256"] == row["replay_trace_sha256"]
+
+
+def test_default_pedestrian_force_path_remains_social_force(report: dict) -> None:
+    """Running the opt-in harness does not mutate the simulator default selector."""
+    assert SimulationSettings().pedestrian_model == SOCIAL_FORCE_DEFAULT
+    assert report["acceptance_checks"]["default_force_path_unchanged"] is True
+    assert any(
+        row["pedestrian_model"] == HSFM_ZANLUNGO_COLLISION_PREDICTION_V1 for row in report["rows"]
+    )
+
+
+def test_classifier_labels_sustained_conflict_slowdown_as_freezing(
+    config: AcceptanceConfig,
+) -> None:
+    """A synthetic stalled conflict hits the named freezing outcome branch."""
+    positions = np.asarray(
+        [
+            [[4.4, 1.9], [5.6, 2.1]],
+            [[4.5, 1.9], [5.5, 2.1]],
+            [[4.5, 1.9], [5.5, 2.1]],
+            [[4.5, 1.9], [5.5, 2.1]],
+        ],
+        dtype=float,
+    )
+    thresholds = replace(config.thresholds, freeze_window_s=0.3)
+    metrics = classify_corridor_trace(
+        CorridorTrace(positions=positions, velocities=np.zeros_like(positions), dt_s=0.1),
+        config.fixture,
+        thresholds,
+    )
+    assert metrics["outcome_label"] == "freezing"
+    assert metrics["freeze_criterion_met"] is True
+
+
+def test_classifier_rejects_invalid_replay_timestep(config: AcceptanceConfig) -> None:
+    """Replay classification fails closed when timing provenance is invalid."""
+    positions = np.zeros((1, 2, 2), dtype=float)
+    with pytest.raises(ValueError, match="trace.dt_s"):
+        classify_corridor_trace(
+            CorridorTrace(positions=positions, velocities=positions.copy(), dt_s=0.0),
+            config.fixture,
+            config.thresholds,
+        )
+
+
+def test_config_loader_fails_closed_if_benchmark_evidence_is_promoted(tmp_path: Path) -> None:
+    """The acceptance packet cannot silently become benchmark evidence."""
+    text = CONFIG_PATH.read_text(encoding="utf-8").replace(
+        "benchmark_evidence: false", "benchmark_evidence: true", 1
+    )
+    path = tmp_path / "promoted.yaml"
+    path.write_text(text, encoding="utf-8")
+    with pytest.raises(ValueError, match="benchmark_evidence must be false"):
+        load_acceptance_config(path)
+
+
+def test_config_loader_fails_closed_on_dishonest_parameter_ratio(tmp_path: Path) -> None:
+    """Sensitivity bookkeeping cannot claim a multiplier that the parameters do not encode."""
+    text = CONFIG_PATH.read_text(encoding="utf-8").replace(
+        "relative_to_reference: 1.7699115044247788",
+        "relative_to_reference: 1.0",
+        1,
+    )
+    path = tmp_path / "dishonest-ratio.yaml"
+    path.write_text(text, encoding="utf-8")
+    with pytest.raises(ValueError, match="exact ratio"):
+        load_acceptance_config(path)
+
+
+def test_report_writers_preserve_claim_boundary_and_rows(report: dict, tmp_path: Path) -> None:
+    """Local artifacts preserve the machine-readable and reviewer-readable contracts."""
+    paths = write_acceptance_report(report, tmp_path)
+    assert json.loads(paths["summary_json"].read_text(encoding="utf-8")) == report
+    markdown = paths["readme"].read_text(encoding="utf-8")
+    assert markdown == render_acceptance_markdown(report)
+    assert "benchmark_evidence=false" in markdown
+    assert "zanlungo_paper_reference" in markdown
+    assert "Acceptance met: **True**" in markdown
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"duration_s": 0.0},
+        {"corridor_min_y_m": 3.0, "corridor_max_y_m": 2.0},
+    ],
+)
+def test_fixture_configuration_rejects_invalid_runtime_or_geometry(
+    config: AcceptanceConfig,
+    changes: dict[str, float],
+) -> None:
+    """Malformed CPU fixture controls fail before simulator construction."""
+    with pytest.raises(ValueError):
+        CorridorFixtureConfig(**{**config.fixture.__dict__, **changes})

--- a/tests/sim/test_zanlungo_corridor_acceptance.py
+++ b/tests/sim/test_zanlungo_corridor_acceptance.py
@@ -25,7 +25,8 @@ from robot_sf.sim.pedestrian_model_variants import (
 )
 from robot_sf.sim.sim_config import SimulationSettings
 
-CONFIG_PATH = Path("configs/research/issue_4973_zanlungo_corridor_acceptance.yaml")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs/research/issue_4973_zanlungo_corridor_acceptance.yaml"
 
 
 @pytest.fixture(scope="module")
@@ -138,6 +139,47 @@ def test_config_loader_fails_closed_if_benchmark_evidence_is_promoted(tmp_path: 
     path.write_text(text, encoding="utf-8")
     with pytest.raises(ValueError, match="benchmark_evidence must be false"):
         load_acceptance_config(path)
+
+
+@pytest.mark.parametrize(
+    ("source", "replacement", "match"),
+    [
+        ("duration_s: 10.0", "duration_s: true", "fixture.duration_s"),
+        (
+            "interaction_strength: 1.13",
+            "interaction_strength: true",
+            "parameters.interaction_strength",
+        ),
+    ],
+)
+def test_config_loader_rejects_boolean_numeric_values(
+    tmp_path: Path, source: str, replacement: str, match: str
+) -> None:
+    """YAML booleans cannot silently alter numeric fixture or force parameters."""
+    path = tmp_path / "boolean-value.yaml"
+    path.write_text(CONFIG_PATH.read_text(encoding="utf-8").replace(source, replacement, 1))
+    with pytest.raises(ValueError, match=match):
+        load_acceptance_config(path)
+
+
+def test_config_loader_rejects_evidence_boundary_drift(tmp_path: Path) -> None:
+    """Packet provenance must match the report's diagnostic-only evidence boundary."""
+    path = tmp_path / "drifted-evidence-tier.yaml"
+    path.write_text(
+        CONFIG_PATH.read_text(encoding="utf-8").replace(
+            "evidence_tier: diagnostic-only", "evidence_tier: nominal-benchmark", 1
+        )
+    )
+    with pytest.raises(ValueError, match="metadata.evidence_tier"):
+        load_acceptance_config(path)
+
+
+def test_config_path_is_independent_of_the_current_working_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The test's repository fixture path works from non-root test invocations."""
+    monkeypatch.chdir(tmp_path)
+    assert load_acceptance_config(CONFIG_PATH).issue == 4973
 
 
 def test_config_loader_fails_closed_on_dishonest_parameter_ratio(tmp_path: Path) -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds a deterministic two-pedestrian CPU corridor config and acceptance harness for the opt-in Zanlungo force, including yielding/freezing outcome labels, exact replay checks, and one-at-a-time strength/range bookkeeping.
- **Why now:** PR #5218 merged the force seam; the live #4973 thread explicitly leaves this corridor and sensitivity acceptance contract open.
- **Claim boundary:** Diagnostic synthetic-fixture acceptance only with `benchmark_evidence=false`; this is not a Robot SF realism calibration, benchmark result, or paper-facing claim.
- **Required validation:** Focused force/corridor tests, the canonical CPU smoke, documentation integrity checks, and final committed-HEAD PR readiness.
- **Remaining blocker:** None for #4973's implementation contract. Broader campaigns or external validation would require separately scoped work and are not needed to close this issue.

## Contract delta

- New config schema: `zanlungo-corridor-acceptance.v1`, fixing seed, geometry, thresholds, reference case, reactive control, and one-at-a-time variants.
- New outcome schema: mutually exclusive `yielding`, `freezing`, `collision_proxy`, `pass_through`, or `incomplete`, with center-distance and pre-passing lateral-displacement metrics.
- New fail-closed blockers: benchmark promotion, invalid geometry/timing, dishonest parameter ratios, malformed state, and a non-Zanlungo reference case are rejected.
- Compatibility impact: none on simulator defaults or force composition; `social_force_default` remains the default, and the harness opts into Zanlungo only per matrix row.

Closes #4973

Issue: https://github.com/ll7/robot_sf_ll7/issues/4973

## Scope summary

- Added `configs/research/issue_4973_zanlungo_corridor_acceptance.yaml` as the predeclared, CPU-sized acceptance packet.
- Added a dedicated research harness and validation CLI that execute every row twice and emit trace hashes, replay verdicts, outcome labels, and parameter lineage.
- Added focused tests for reference yielding, reactive-control collision proxy, freezing classification, deterministic replay, default compatibility, report writing, and fail-closed metadata/bookkeeping.
- Updated the existing #4973 config and context note so the command and evidence boundary are discoverable without creating a competing overview.

Assumption: the reversible acceptance interpretation is a slightly offset head-on encounter, because the published force deliberately does not invent random symmetry breaking for a perfectly centered collision. The `0.25 m` center-distance threshold is explicitly a fixture-local collision proxy, not physical-contact or realism evidence.

This is a nameable progression capability, not a guardrail/checker micro-PR: it completes the predeclared corridor acceptance matrix left after #5218.

## Validation

- `uv run pytest -q tests/sim/test_zanlungo_corridor_acceptance.py tests/sim/test_zanlungo_collision_prediction_model.py` — passed: 27 tests.
- `uv run python scripts/validation/run_issue_4973_zanlungo_corridor_acceptance.py` — passed: `acceptance_met=True`; the paper-reference row is `yielding`, the reactive control is `collision_proxy`, and all six rows replay exactly.
- `scripts/dev/check_docs_proof_consistency_diff.sh origin/main` — passed.
- `uv run python scripts/dev/check_docs_evidence_integrity.py --files docs/context/issue_4973_zanlungo_collision_prediction.md` — passed.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-4973/PR_BODY.md PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on clean committed HEAD: 2,213 passed, 1 skipped; changed-line coverage 89.2% (above the 80% minimum); Ruff, policy, docstring, exception, and freshness gates passed.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no external-data comparison, no paper/dissertation claim edits, and no parameter tuning for a publication claim.

## Research result guidance

- Target: prove the opt-in reference row yields in the predeclared corridor, the classifier names freezing distinctly, sensitivity rows carry honest parameter lineage, and replay/default contracts hold.
- Comparator: `social_force_default` reactive control plus one-at-a-time Zanlungo strength/range variants.
- Evidence tier: diagnostic probe / targeted CPU smoke.
- Result classification: positive fixture acceptance; not benchmark evidence.
- Stop rule: reference outcome is `yielding`, every row replays exactly, metadata remains `benchmark_evidence=false`, and the default selector remains unchanged.
- Synthesis surface: `docs/context/issue_4973_zanlungo_collision_prediction.md`.

## Domain-Aware Approval

- Required for this PR: yes — it defines a diagnostic comparison and evidence boundary.
- Domains reviewed: evidence classification, experimental comparison, benchmark interpretation
- Status: approved
- Approver/review source or waiver: Codex self-review against the complete live #4973 thread, `docs/maintainer_values.md`, the existing force contract, and executable focused/smoke evidence; Claude's full PR gate remains required before merge.
- Validity checklist:
  - Target claim/hypothesis: the opt-in reference row yields under the predeclared synthetic corridor contract without changing defaults.
  - Comparator or split/evidence validity: reactive control and one-at-a-time parameter variants use the same geometry, timestep, duration, and seed.
  - Fallback/degraded exclusions: no fallback or degraded execution is counted as success.
  - Claim boundary: diagnostic synthetic-fixture acceptance only with `benchmark_evidence=false`.
  - Implementation integrity vs experimental validity: tests and exact replay prove implementation integrity; the synthetic corridor does not establish external validity.

## Falsification / non-transfer check

- Mechanism activation: yes, via the explicit Zanlungo selector and per-row parameters.
- Targeted failure mode present: the reactive control violates the predeclared center-distance proxy; the reference adds symmetric pre-passing lateral displacement and clears it.
- Sensitivity caveat: the high-strength row is `pass_through`, so stronger interaction is not presented as monotonically better.
- Result route: stop for #4973; any external-validity campaign belongs in a separate issue.

<details>
<summary>Evidence, artifacts, propagation, and governance appendix</summary>

### Artifacts

`output/issue_4973_zanlungo_corridor_acceptance/` (20 KiB) and `output/coverage/` are ignored, disposable local validation artifacts. Durable reproduction comes from the tracked config, harness, CLI, and tests; no raw episode JSONL, video, checkpoint, or coverage output is committed.

### Downstream propagation

- Parent issue comment: not added because authorization explicitly sets `comment_issue_or_pr=false`.
- Claim map / leaderboard / artifact catalog: not applicable; `benchmark_evidence=false` and no durable result artifact is promoted.
- Registry/config/context: the canonical force config and existing indexed #4973 context note are updated.
- No additional state propagation is needed because this PR uses `Closes #4973`, contains the complete delivery/claim boundary, and the issue has no remaining implementation blocker. Transient queue-host or packet state is not written to tracked files.

### Fragmentation and dedupe

- No open PR covered the corridor/sensitivity scope at the start audit.
- One #4973 progression PR (#5218) merged in the preceding 24 hours; the two-guardrail fragmentation threshold was not met.
- This PR adds the nameable corridor acceptance capability and completes the remaining issue contract.

### Friction log

No friction issue filed. The encountered `gh issue view --comments` Projects Classic GraphQL failure is already tracked by #5188, #5186, and resolved #5021; paginated REST was used to read the full thread without creating a duplicate.

### Risks and rollback

- Labels are intentionally fixture-local and threshold-dependent; they must not be reused as benchmark or physical-contact metrics without a new evidence contract.
- Rollback is removal of the additive config/harness/tests/docs update; simulator runtime defaults are untouched.

</details>

## Follow-Up Issues

- Deferred work: none; external validation and full campaigns are outside the completed implementation contract.
- Issues opened for follow-up: NA - maintainer waiver for this closure boundary under the task's COMPLETE-FIRST rule, which explicitly treats campaign-only remainder as complete.
