### PR TITLE
fix(#5226): smoke test for REST paths + update example manifest to canonical helper

### DIFF
--- a/docs/templates/agent_run_manifest.example.yaml
+++ b/docs/templates/agent_run_manifest.example.yaml
@@ -17,7 +17,7 @@ agent_run:
   actual_agent_count: 1
   commands_run:
     - "git fetch origin"
-    - "gh issue view 4756 --comments"
+    - "uv run python scripts/dev/gh_issue_rest.py thread 4756"
     - "git worktree add -b cheap/issue-4756 ../robot_sf_ll7.worktrees/cheap-issue-4756 origin/main"
     - "uv run python -c \"from pathlib import Path; import yaml; yaml.safe_load(Path('docs/templates/agent_run_manifest.yaml').read_text())\""
     - "git diff --check"

--- a/tests/dev/test_gh_issue_rest.py
+++ b/tests/dev/test_gh_issue_rest.py
@@ -378,6 +378,37 @@ def test_cli_view_fails_closed_on_rest_error(capsys: pytest.CaptureFixture[str])
     assert "deprecated" in captured.err
 
 
+def test_rest_paths_do_not_request_deprecated_project_cards_field() -> None:
+    """REST API paths used by the helper must never include ``projectCards``.
+
+    Regression check for issue #5226: ``gh issue view --comments`` fails on some
+    GitHub CLI versions because the underlying GraphQL query requests the deprecated
+    ``repository.issue.projectCards`` field.  The ``fetch_issue`` and
+    ``fetch_comments`` helpers bypass this by calling pure-REST endpoints
+    (``/repos/{repo}/issues/{n}`` and ``/repos/{repo}/issues/{n}/comments``).
+    This test captures all ``_gh_api`` call paths and asserts that none of them
+    contain the deprecated field name, so a future refactor cannot silently
+    reintroduce a GraphQL projectCards dependency.
+    """
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.return_value = _proc(stdout=json.dumps(_raw_issue()))
+        fetch_issue(5226)
+    for call in mock_api.call_args_list:
+        path = call[0][0]
+        assert "projectCards" not in path, (
+            f"fetch_issue REST path contains deprecated field: {path!r}"
+        )
+
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.return_value = _proc(stdout=json.dumps([_raw_comment()]))
+        fetch_comments(5226)
+    for call in mock_api.call_args_list:
+        path = call[0][0]
+        assert "projectCards" not in path, (
+            f"fetch_comments REST path contains deprecated field: {path!r}"
+        )
+
+
 def test_cli_view_rejects_unknown_json_field(capsys: pytest.CaptureFixture[str]) -> None:
     """Unknown --json fields should fail fast with exit code 2, not emit partial JSON."""
     with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:


### PR DESCRIPTION
## Reviewer-critical summary

**What changed**: Two targeted additions addressing the remaining asks from issue #5226:
1. Added `test_rest_paths_do_not_request_deprecated_project_cards_field` in `tests/dev/test_gh_issue_rest.py` — captures every `_gh_api` call path made by `fetch_issue` and `fetch_comments` and asserts none contain `projectCards`, as the issue specifically requested.
2. Updated `docs/templates/agent_run_manifest.example.yaml` to show `uv run python scripts/dev/gh_issue_rest.py thread 4756` instead of the broken raw `gh issue view 4756 --comments` command.

**Why now**: The helper script (`scripts/dev/gh_issue_rest.py`) and skill-level guidance were already in place from prior PRs. The two remaining gaps from the issue body were (a) the smoke check and (b) the example template still showing the broken command.

**Claim boundary**: docs-only + test-only change; no runtime logic modified.

**Required validation**: `uv run pytest tests/dev/test_gh_issue_rest.py tests/test_ai_prompt_surfaces.py` — all 30 tests pass.

**Remaining blocker**: none — this is the final completion slice for issue #5226.

## Contract delta

- **New test**: `test_rest_paths_do_not_request_deprecated_project_cards_field` — captures `_gh_api` positional path argument and asserts `"projectCards" not in path` for both `fetch_issue` and `fetch_comments` call sites.
- **Updated example**: `docs/templates/agent_run_manifest.example.yaml` `commands_run` entry replaced from `gh issue view 4756 --comments` → `uv run python scripts/dev/gh_issue_rest.py thread 4756`.

## Validation

```
uv run pytest tests/dev/test_gh_issue_rest.py tests/test_ai_prompt_surfaces.py -v
# 23 passed (gh_issue_rest) + 7 passed (prompt surfaces) = 30 passed
```

Closes #5226

## Out-of-scope

- No full benchmark campaign run
- No Slurm/GPU submission
- No paper/dissertation claim edits

State propagation: this PR fully resolves the issue; no separate comment needed.