### PR TITLE
test(#5227): align issue-4848 reproducibility helper with timestamp contract

### DIFF
--- a/tests/test_export_issue_4848.py
+++ b/tests/test_export_issue_4848.py
@@ -629,11 +629,13 @@ class TestFailClosedInputs:
 class TestBundleReproducibleByteIdentical:
     """Re-running the same export with the same inputs produces byte-identical outputs.
 
-    Excludes generated_at_utc and git_commit (which change per run) by writing
-    a fixed generated_at_utc into the episode record's metadata.
+    CSV files (trace_timeseries.csv, min_distance_series.csv) are always byte-identical
+    because they contain no timestamps.  JSON files (metadata.json, trace_series.json)
+    are byte-identical only when ``pin_generated_at`` is passed to ``write_bundle``
+    to fix ``generated_at_utc``; without it they embed wall-clock time and will differ.
     """
 
-    def _make_minimal_record(self, timestamp: str) -> dict[str, Any]:
+    def _make_minimal_record(self) -> dict[str, Any]:
         steps = [
             {
                 "step": i,
@@ -657,8 +659,7 @@ class TestBundleReproducibleByteIdentical:
 
     def test_bundle_files_reproducible(self, tmp_path: Path) -> None:
         """Running write_bundle twice with same episode yields SHA-identical CSV files."""
-        # Use a fixed git commit by monkey-patching (CSV output doesn't depend on it)
-        record = self._make_minimal_record("2026-07-08T12:00:00+00:00")
+        record = self._make_minimal_record()
         sel = _export_module.SelectedEpisode(
             planner="goal",
             scenario_id="classic_group_crossing_low",
@@ -685,7 +686,7 @@ class TestBundleReproducibleByteIdentical:
     def test_pin_generated_at_byte_identical_metadata(self, tmp_path: Path) -> None:
         """pin_generated_at makes metadata.json byte-identical across runs."""
         pin = "2026-07-08T23:13:18.753884+00:00"
-        record = self._make_minimal_record(pin)
+        record = self._make_minimal_record()
         sel = _export_module.SelectedEpisode(
             planner="goal",
             scenario_id="classic_group_crossing_low",
@@ -712,7 +713,7 @@ class TestBundleReproducibleByteIdentical:
     def test_pin_generated_at_overrides_wall_clock(self, tmp_path: Path) -> None:
         """pin_generated_at replaces datetime.now in the written metadata."""
         pin = "2025-01-15T10:30:00+00:00"
-        record = self._make_minimal_record(pin)
+        record = self._make_minimal_record()
         sel = _export_module.SelectedEpisode(
             planner="orca",
             scenario_id="classic_group_crossing_low",


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Removed the unused `timestamp: str` parameter from
`TestBundleReproducibleByteIdentical._make_minimal_record` and corrected the
class docstring that described behavior the helper never provided.

**Why now:** The parameter was accepted but silently discarded on every call; the
docstring claimed it wrote `generated_at_utc` into the episode record — it never did.
This was the exact mismatch flagged in PR #4931 review thread
(https://github.com/ll7/robot_sf_ll7/pull/4931#discussion_r3550014113) and
formalized in issue #5227.

**Claim boundary:** Test-only change; no production code touched.

**Required validation:** `uv run pytest tests/test_export_issue_4848.py -q`

**Remaining blocker:** None — full issue scope is resolved.

## Contract delta

| Before | After |
|--------|-------|
| `_make_minimal_record(self, timestamp: str)` — param accepted, never used | `_make_minimal_record(self)` — no parameter |
| Docstring: "writing a fixed `generated_at_utc` into the episode record's metadata" | Docstring: CSV files are always byte-identical; JSON files require `pin_generated_at` on `write_bundle` |
| Three callers pass a timestamp literal | Three callers call with no arguments |

No schema, benchmark, or production-code changes. Fully backwards-compatible
(tests are internal helpers, not part of any API).

## Validation

```
uv run pytest tests/test_export_issue_4848.py -q
# 42 passed in 4.09s
```

## Acceptance criteria (from issue)

- [x] The helper no longer accepts an ignored timestamp argument
- [x] The class and test docstrings describe exactly which files are expected to be byte-identical
- [x] Existing pinned metadata and selection-report determinism coverage remains green (42/42 pass)
- [x] The source review thread can be linked to the fixing PR — see PR #4931 link above

## Out-of-scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

Closes #5227

---

<details>
<summary>Friction log</summary>

No friction issues filed this session. The issue was a clean, well-scoped contract mismatch
with no tooling gaps or confusing errors encountered.

</details>