### PR TITLE
fix(sim): restore typical pedestrian desired-speed propagation (#5217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* **issue #5217 restore typical pedestrian desired-speed propagation.** `SimulationSettings`
+  with `ped_speed_tier="typical"` (or explicit `desired_speed_mean`) now correctly sets
+  `pysf_sim.peds.max_speeds` to the decoupled desired-speed distribution (~1.3 m/s for the
+  `typical` tier) on all pysocialforce install versions. The previous implementation relied solely
+  on `pysf_config.scene_config` propagation, which was silently ignored by pysf installs that
+  predated the fast-pysf #5042 update. The fix adds `_enforce_ped_desired_speeds` in
+  `simulator.py`, which applies the sampled speeds directly to `peds.max_speeds` and encodes
+  them into `peds.initial_speeds` so the legacy `max_speed_multiplier * initial_speed`
+  recomputation also yields the correct values on every state update. A companion
+  `sample_desired_pedestrian_speeds` helper in `pedestrian_speed_tiers.py` provides the
+  standalone sampling without a pysf-version dependency.
+
 ### Changed
 
 * **issue #5071 absolute continuous-integration coverage floor.** The unsharded full-suite

--- a/robot_sf/sim/pedestrian_speed_tiers.py
+++ b/robot_sf/sim/pedestrian_speed_tiers.py
@@ -21,6 +21,8 @@ unchanged until a major campaign re-base.
 
 from __future__ import annotations
 
+import numpy as np
+
 PED_SPEED_TIER_SLOW = "slow"
 PED_SPEED_TIER_TYPICAL = "typical"
 PED_SPEED_TIER_BRISK = "brisk"
@@ -79,3 +81,38 @@ def desired_speed_params_for_tier(tier: str | None) -> tuple[float | None, float
         return None, None
     mean, std = _PED_SPEED_TIER_PARAMS[normalized]
     return mean, std
+
+
+def sample_desired_pedestrian_speeds(
+    num_peds: int,
+    mean: float,
+    std: float | None = None,
+    high: float = PED_SPEED_TIER_HIGH,
+    seed: int | None = None,
+) -> np.ndarray:
+    """Sample per-pedestrian desired walking speeds from a truncated normal distribution.
+
+    Standalone sampling that does not depend on the pysocialforce package version.
+    Produces values identical to ``pysocialforce.scene.sample_truncated_normal_speeds``
+    when given the same parameters (issue #5217 compat layer).
+
+    Args:
+        num_peds: Number of pedestrians to sample speeds for.
+        mean: Desired-speed distribution mean (m/s).
+        std: Standard deviation (m/s). ``None`` defaults to ``PED_SPEED_TIER_STD``
+            (0.2 m/s), matching the pysf ``DEFAULT_DESIRED_SPEED_STD`` constant.
+        high: Inclusive upper-bound clip for the distribution (m/s).
+        seed: Optional RNG seed for deterministic sampling.
+
+    Returns:
+        np.ndarray: Non-negative desired speeds, shape ``(num_peds,)``.
+    """
+    if num_peds <= 0:
+        return np.zeros(0, dtype=float)
+    std_eff = PED_SPEED_TIER_STD if std is None else float(std)
+    rng = np.random.default_rng(seed)
+    if std_eff > 0.0:
+        speeds = rng.normal(loc=float(mean), scale=std_eff, size=num_peds)
+    else:
+        speeds = np.full(num_peds, float(mean), dtype=float)
+    return np.clip(speeds, 0.0, float(high))

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -71,6 +71,7 @@ from robot_sf.sim.pedestrian_model_variants import (
     ttc_predictive_repulsion,
     zanlungo_collision_prediction_repulsion,
 )
+from robot_sf.sim.pedestrian_speed_tiers import sample_desired_pedestrian_speeds
 
 PYSF_POSITION_SLICE = slice(0, 2)
 PYSF_VELOCITY_SLICE = slice(2, 4)
@@ -103,6 +104,43 @@ def _apply_ped_desired_speed_config(
     pysf_config.scene_config.desired_speed_mean = settings.desired_speed_mean
     pysf_config.scene_config.desired_speed_std = settings.desired_speed_std
     pysf_config.scene_config.desired_speed_seed = settings.desired_speed_seed
+
+
+def _enforce_ped_desired_speeds(peds, settings: SimulationSettings) -> None:
+    """Apply decoupled desired speeds directly to a PedState after simulator creation.
+
+    ``_apply_ped_desired_speed_config`` propagates settings into the PySF config so
+    that ``PedState.__init__`` can sample them. However, older installed pysf versions
+    (< the fast-pysf update in #5042) do not read ``desired_speed_mean`` from the scene
+    config and silently fall back to the spawn-coupled ``max_speed_multiplier *
+    initial_speed`` = 0.65 m/s default (issue #5217).
+
+    This function re-applies the desired speeds directly on the ``PedState`` object
+    after ``PySFSimulator`` is constructed, which restores the tier contract for stale
+    pysf installs. It is a no-op when the new pysf already applied the speeds via
+    ``assign_desired_speeds`` (the explicit-desired-speeds path uses ``_explicit_desired_speeds``
+    and ignores the ``initial_speeds`` override we write here).
+
+    Calling this after ``max_speed_multiplier`` is set is intentional: we encode the
+    desired speeds into ``initial_speeds`` so the legacy recomputation
+    ``max_speeds = max_speed_multiplier * initial_speeds`` also yields the correct values
+    on every subsequent ``_update_state`` call.
+    """
+    if settings.desired_speed_mean is None:
+        return
+    desired_speeds = sample_desired_pedestrian_speeds(
+        peds.size(),
+        mean=settings.desired_speed_mean,
+        std=settings.desired_speed_std,
+        seed=settings.desired_speed_seed,
+    )
+    # Direct assignment: works with both new pysf (``assign_desired_speeds`` already ran,
+    # this overwrites with identical values) and old pysf (no explicit-speed support).
+    peds.max_speeds = desired_speeds.copy()
+    # Compat: encode into initial_speeds so legacy _update_state recomputation preserves them.
+    initial_speeds = getattr(peds, "initial_speeds", None)
+    if initial_speeds is not None and peds.max_speed_multiplier > 0:
+        peds.initial_speeds = desired_speeds / peds.max_speed_multiplier
 
 
 def _make_ped_forces(
@@ -295,6 +333,7 @@ class Simulator:
             ),
         )
         self.pysf_sim.peds.max_speed_multiplier = self.config.peds_speed_mult
+        _enforce_ped_desired_speeds(self.pysf_sim.peds, self.config)
         self.robot_navs = [
             RouteNavigator(proximity_threshold=self.goal_proximity_threshold) for _ in self.robots
         ]
@@ -742,6 +781,7 @@ class PedSimulator(Simulator):
             ),
         )
         self.pysf_sim.peds.max_speed_multiplier = self.config.peds_speed_mult
+        _enforce_ped_desired_speeds(self.pysf_sim.peds, self.config)
 
         self.robot_navs = [
             RouteNavigator(proximity_threshold=self.goal_proximity_threshold) for _ in self.robots


### PR DESCRIPTION
## Reviewer-critical summary

**What changed**: Added `_enforce_ped_desired_speeds` to `simulator.py` that directly applies the
sampled desired-speed distribution to `peds.max_speeds` (and encodes it into `peds.initial_speeds`
for legacy-pysf backward compatibility) immediately after `PySFSimulator` is constructed.
Added companion `sample_desired_pedestrian_speeds` to `pedestrian_speed_tiers.py` as a
standalone numpy-only sampler independent of the pysf install version.

**Why now**: `test_typical_tier_decouples_desired_speed_from_spawn` (added in #5042) fails on
`origin/main` when the local pysocialforce install predates the fast-pysf update in #5042.
The prior code path set `pysf_config.scene_config.desired_speed_mean` before `PySFSimulator`
construction, which old pysf `PedState.__init__` silently ignores.

**Claim boundary**: smoke evidence — the three existing `tests/sim/test_pedestrian_desired_speed.py`
tests cover the default (legacy), typical tier, and explicit desired-speed paths.

**Required validation**:
```
uv run pytest tests/sim/test_pedestrian_desired_speed.py -v
# 3 passed
uv run pytest tests/sim/ tests/gym_env/ -q
# 182 passed
```

**Remaining blocker**: none — the fix is complete for issue #5217.

## Contract delta

- **New function** `robot_sf.sim.pedestrian_speed_tiers.sample_desired_pedestrian_speeds`:
  standalone truncated-normal speed sampler; no pysf dependency.
- **New function** `robot_sf.sim.simulator._enforce_ped_desired_speeds`: post-hoc desired-speed
  applier called in both `Simulator.__post_init__` and `PedSimulator.__post_init__` after
  `max_speed_multiplier` is set.
- No schema, config, or public API changes. Both functions are internal; external callers use
  `SimulationSettings.ped_speed_tier` and `desired_speed_mean` as before.
- Backward compatible: `desired_speed_mean is None` (the default) short-circuits the function
  immediately.

<details>
<summary>Root-cause analysis</summary>

The fast-pysf update in PR #5042 added `desired_speed_mean` support to both `SceneConfig` and
`PedState`. The `_apply_ped_desired_speed_config` function sets these on `pysf_config.scene_config`
before constructing `PySFSimulator`. On current/updated installs this works correctly.

However, pysf installs that predate the fast-pysf #5042 update (installed version
`2.0.0` with a stale copy in the venv — see closed issue #5167) have a `PedState.__init__`
that reads only `max_speed_multiplier` from the scene config. The `desired_speed_mean` attribute
set dynamically on the old `SceneConfig` dataclass is never consumed, so `max_speeds` silently
stays at `max_speed_multiplier * initial_speed = 0.65 m/s`.

`_enforce_ped_desired_speeds` adds a pysf-version-agnostic post-hoc fix:
1. Samples desired speeds using the robot_sf standalone helper (no pysf dependency).
2. Sets `peds.max_speeds` directly (works for old and new pysf).
3. Encodes values into `peds.initial_speeds` so the legacy `_update_state` recomputation
   `max_speeds = max_speed_multiplier * initial_speeds` also yields the correct result
   on every subsequent step.
With new pysf (which has `_explicit_desired_speeds` and `_refresh_max_speeds`), step 3 is a
harmless extra write — `_refresh_max_speeds` uses `_explicit_desired_speeds` and ignores
`initial_speeds` when it is set.

</details>

Closes #5217

## Validation

```
$ uv run pytest tests/sim/test_pedestrian_desired_speed.py -v
3 passed in 1.16s

$ uv run pytest tests/sim/ tests/gym_env/ -q
182 passed in 15.58s
```

## Out of scope

- No full benchmark campaign run
- No Slurm/GPU submission
- No paper/dissertation claim edits
- No changes to default pedestrian speed regime

## Friction issues

None filed: the stale-venv friction is already tracked in closed issue #5167.
`friction_issues: []`