### PR TITLE
fix(tooling): complete REST fallback docs and gap tests (#5186)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -466,6 +466,27 @@ When issue or PR text needs to classify proof strength, use the
 [artifact evidence vocabulary](context/artifact_evidence_vocabulary.md) so local `output/` paths are
 not promoted into durable benchmark or paper-facing claims.
 
+#### Issue-reading fallback
+
+`gh issue view <number> --comments` can fail on some GitHub CLI versions with a
+`repository.issue.projectCards` GraphQL deprecation error. Use the targeted REST
+fallback instead (see issue #5186):
+
+```bash
+# Drop-in for `gh issue view <number> --comments`: native CLI first, REST fallback
+# only for the known projectCards GraphQL error.
+uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7
+
+# Explicit REST read with normalized fields (stable JSON output shape):
+uv run python scripts/dev/gh_issue_rest.py view <number> --repo ll7/robot_sf_ll7 --comments
+uv run python scripts/dev/gh_issue_rest.py view <number> --json number title state url labels comments
+```
+
+All issue-delivery skills (`gh-issue-autopilot`, `gh-issue-clarifier`,
+`goal-issue-implementation`, etc.) already route to `gh_issue_rest.py thread` when
+`gh issue view --comments` fails; see
+`docs/context/issue_713_batch_first_issue_workflow.md` for the full command reference.
+
 For GitHub issue batches and Project #5 updates, follow the batch-first workflow note:
 
 - `docs/context/issue_713_batch_first_issue_workflow.md`

--- a/tests/dev/test_gh_issue_rest.py
+++ b/tests/dev/test_gh_issue_rest.py
@@ -389,3 +389,34 @@ def test_cli_view_rejects_unknown_json_field(capsys: pytest.CaptureFixture[str])
     captured = capsys.readouterr()
     assert rc == 2
     assert "unknown field" in captured.err
+
+
+def test_fetch_comments_fails_closed_on_invalid_json() -> None:
+    """A malformed comments page should fail closed with a clear error, not raise."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.return_value = _proc(stdout="not-json{")
+        result = fetch_comments(5186)
+    assert result["status"] == "error"
+    assert "invalid JSON" in result["error"]
+
+
+def test_fetch_comments_fails_closed_on_non_list_payload() -> None:
+    """A comments endpoint returning a JSON object (not a list) should fail closed."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.return_value = _proc(stdout=json.dumps({"unexpected": "object"}))
+        result = fetch_comments(5186)
+    assert result["status"] == "error"
+    assert "was not a list" in result["error"]
+
+
+def test_fetch_issue_with_comments_propagates_comments_error() -> None:
+    """If the comments read fails, the combined helper must propagate the error."""
+    with patch("scripts.dev.gh_issue_rest._gh_api") as mock_api:
+        mock_api.side_effect = [
+            _proc(stdout=json.dumps(_raw_issue())),
+            _proc(returncode=1, stderr="rate limit exceeded"),
+        ]
+        payload = fetch_issue_with_comments(5186)
+    assert payload["status"] == "error"
+    assert "rate limit exceeded" in payload["error"]
+    assert payload["number"] == 5186


### PR DESCRIPTION
## Reviewer-critical summary

**What changed**: Three missing tests added to `tests/dev/test_gh_issue_rest.py`
covering previously untested fail-closed paths in `fetch_comments` and
`fetch_issue_with_comments`. One new `docs/dev_guide.md` subsection documenting
the `gh_issue_rest.py thread` / `view` invocations for issue-delivery workflows.

**Why now**: Issue #5186 was filed after the REST fallback helper was already
merged (PRs #5049 and #5107), identifying two remaining gaps: untested error
paths and a missing dev-guide entry. The helper implementation itself is
complete; this PR closes the remaining documentation and test gaps.

**Claim boundary**: tooling-only change — no algorithm, benchmark, schema, or
paper-facing claim. Evidence tier: smoke (focused mocked-REST unit tests, CPU).

**Required validation**: `uv run pytest tests/dev/test_gh_issue_rest.py -v`
(25 passed, 0 failed).

**Remaining blocker**: none — the issue's three asks (helper, tests, docs) are
now all in main or this PR.

## Contract delta

| Surface | Before | After |
|---|---|---|
| `tests/dev/test_gh_issue_rest.py` | 22 tests | 25 tests (+3 fail-closed edge cases) |
| `docs/dev_guide.md` | No issue-reading fallback entry | New "Issue-reading fallback" subsection |

No schema, API, or behavior change.

## Validation

```
$ uv run pytest tests/dev/test_gh_issue_rest.py -v --no-header
... 25 passed in 1.31s

$ uv run ruff check scripts/dev/gh_issue_rest.py tests/dev/test_gh_issue_rest.py
All checks passed!

$ uv run python scripts/tools/sync_ai_config.py --check
AI config links validated: 7 symlinks.
```

## Scope

- **In scope**: tests for untested fail-closed paths, dev_guide.md fallback doc.
- **Out of scope**: no full benchmark campaign, no Slurm/GPU submission, no
  paper/dissertation claim edits.

Closes #5186

<details>
<summary>State propagation note</summary>

This PR fully resolves issue #5186 — the helper, tests, and documentation are all
in place after this merge. No separate state comment needed.

</details>
