### PR TITLE
refactor(#5228): close residual xdist memory-diagnostic robustness gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* **issue #5228 xdist memory-diagnostic robustness.** Three residual gaps from the
+  PR #4952 review are closed: (1) `_tree_rss_gb` no longer calls `is_running()` before
+  `memory_info()` — the latter already supplies the handled `NoSuchProcess` signal,
+  removing a superfluous kernel round-trip per process; (2) `main()` validates
+  `--ceiling-gb`, `--auto-workers`, and `--project-at` arguments early (exit 2 before
+  any sweep starts) instead of failing late during report construction; (3)
+  `test_sample_process_tree_peak_captures_allocation` now calls `_terminate_process_tree`
+  before `popen.wait` in its `finally` block so a still-alive child cannot be left
+  running after a sampling or assertion failure. Regression coverage added for all three
+  changes in `tests/dev/test_measure_xdist_worker_memory.py`.
+
 * **issue #5071 absolute continuous-integration coverage floor.** The unsharded full-suite
   coverage report on `main` and manual CI runs must cover at least 85% of the `robot_sf` package.
   This blocking floor reuses the existing report while the baseline-relative comparison remains

--- a/scripts/dev/measure_xdist_worker_memory.py
+++ b/scripts/dev/measure_xdist_worker_memory.py
@@ -266,8 +266,7 @@ def _tree_rss_gb(root: psutil.Process) -> float:
         pass
     for pr in procs:
         try:
-            if pr.is_running():
-                total += pr.memory_info().rss
+            total += pr.memory_info().rss
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             continue
     return total / (1024.0**3)
@@ -570,6 +569,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     worker_counts = sorted({int(w) for w in args.workers if int(w) >= 1})
     if not worker_counts:
         print("--workers requires at least one positive integer.", file=sys.stderr)
+        return 2
+
+    if args.ceiling_gb <= 0:
+        print(f"--ceiling-gb must be positive; got {args.ceiling_gb}.", file=sys.stderr)
+        return 2
+    if args.auto_workers < 1:
+        print(
+            f"--auto-workers must be a positive integer; got {args.auto_workers}.", file=sys.stderr
+        )
+        return 2
+    invalid_proj = [w for w in args.project_at if w < 0]
+    if invalid_proj:
+        print(f"--project-at values must be non-negative; got {invalid_proj}.", file=sys.stderr)
         return 2
 
     config: dict[str, object] = {

--- a/tests/dev/test_measure_xdist_worker_memory.py
+++ b/tests/dev/test_measure_xdist_worker_memory.py
@@ -15,10 +15,12 @@ import pytest
 from scripts.dev.measure_xdist_worker_memory import (
     SCHEMA_VERSION,
     SweepPoint,
+    _terminate_process_tree,
     build_report,
     build_verdict,
     classify_projection,
     fit_linear,
+    main,
     project_peak_rss,
     render_markdown,
     sample_process_tree_peak,
@@ -188,6 +190,21 @@ def test_cli_help_exits_zero_with_usage() -> None:
     assert "uv run pytest" not in result.stdout
 
 
+def test_main_rejects_nonpositive_ceiling_before_sweep() -> None:
+    """--ceiling-gb <= 0 must exit 2 immediately, before any sweep."""
+    assert main(["--ceiling-gb", "0", "--workers", "1", "--targets", "x"]) == 2
+
+
+def test_main_rejects_zero_auto_workers_before_sweep() -> None:
+    """--auto-workers < 1 must exit 2 immediately, before any sweep."""
+    assert main(["--auto-workers", "0", "--workers", "1", "--targets", "x"]) == 2
+
+
+def test_main_rejects_negative_project_at_before_sweep() -> None:
+    """--project-at with a negative value must exit 2 immediately, before any sweep."""
+    assert main(["--project-at", "-1", "--workers", "1", "--targets", "x"]) == 2
+
+
 def test_build_report_has_schema_and_projections() -> None:
     """The full report must carry schema version, fit, projections, and verdict."""
     report = build_report(
@@ -282,6 +299,7 @@ def test_sample_process_tree_peak_captures_allocation(tmp_path) -> None:
     try:
         peak_gb, samples = sample_process_tree_peak(popen, interval_seconds=0.005)
     finally:
+        _terminate_process_tree(popen)
         popen.wait(timeout=30)
     # 200 MiB allocation plus interpreter overhead: well above the bare
     # interpreter footprint (~tens of MiB) and below a generous bound.
@@ -337,3 +355,30 @@ def test_terminate_process_tree_noop_on_exited_child() -> None:
     popen.wait(timeout=10)
     # Must not raise even though the pid may already be reaped/reused.
     _terminate_process_tree(popen)
+
+
+def test_tree_rss_gb_best_effort_on_exiting_process() -> None:
+    """_tree_rss_gb must not raise when a process raises NoSuchProcess on memory_info().
+
+    Regression for the redundant-is_running() gap: the old code called
+    is_running() before memory_info(), adding a superfluous probe (two kernel
+    round-trips per process).  The refactored form relies solely on the
+    NoSuchProcess / AccessDenied guard around memory_info().  This test uses a
+    mock to simulate a process that exits between enumeration and RSS query,
+    verifying best-effort semantics without a real subprocess race.
+    """
+    from unittest.mock import MagicMock
+
+    import psutil
+
+    from scripts.dev.measure_xdist_worker_memory import _tree_rss_gb
+
+    # Build a mock root process whose memory_info() raises NoSuchProcess,
+    # simulating a process that exited after being enumerated.
+    mock_proc = MagicMock(spec=psutil.Process)
+    mock_proc.children.return_value = []
+    mock_proc.memory_info.side_effect = psutil.NoSuchProcess(pid=99999)
+
+    # Must return 0.0 cleanly without propagating the exception.
+    result = _tree_rss_gb(mock_proc)
+    assert result == 0.0


### PR DESCRIPTION
## Summary

Close three residual robustness gaps in the xdist memory-diagnostic dev script and test,
identified in PR #4952 review threads (issue #5228).

## Linked Issues
- Closes #5228

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes

## What Changed
- `scripts/dev/measure_xdist_worker_memory.py`: remove redundant `is_running()` probe before
  `memory_info()` in `_tree_rss_gb`; add early exit-2 validation for `--ceiling-gb`,
  `--auto-workers`, and `--project-at` in `main()`.
- `tests/dev/test_measure_xdist_worker_memory.py`: fix child-process cleanup in
  `test_sample_process_tree_peak_captures_allocation` (call `_terminate_process_tree` before
  `popen.wait` in `finally`); add four regression tests covering all three fixes.
- `CHANGELOG.md`: updated.

## Why It Matters
- Added value: Dev-script correctness and test hygiene; prevents silent child-process leaks and
  misleading late crashes on invalid CLI arguments.
- Expected impact: No runtime behavior change for valid inputs; invalid inputs now fail fast.
- Why this is worth merging now: Directly closes the three PR #4952 review threads (issue #5228).

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA
- Comparator or baseline, if applicable: NA
- Evidence tier: NA
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; dev-script
  robustness refactor with no research output.

## Domain-Aware Approval

- Required for this PR: no - this PR makes no evidence-tier or result-classification claims; it
  only corrects dev-script robustness gaps (redundant probe, late CLI validation, child cleanup).
- Status: not required

## Falsification / Non-Transfer Check

- Did the mechanism activate? NA
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action

- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: none; issue fully resolved by this PR.

## Validation / Proof

```
uv run pytest tests/dev/test_measure_xdist_worker_memory.py -q
# 25 passed in 1.80s (was 21 before this PR)
```

Full pr_ready_check (2228 tests): passed.

## Risks / Rollout
- Compatibility risks: none; only diagnostic dev script changed, no API surface or benchmark.
- Failure modes: none anticipated.
- Rollback or fallback plan: revert this PR; no downstream artifacts.

## Docs / Provenance
- Updated docs: CHANGELOG.md.
- Relevant design notes: fixes match the three PR #4952 review threads (r3552743586,
  r3552743594, r3552743601).
- Any assumptions that need to be preserved: `_tree_rss_gb` remains best-effort; it absorbs
  `NoSuchProcess`/`AccessDenied` at the `memory_info()` level, not via `is_running()`.

## Downstream Propagation
- Not applicable because: diagnostic dev script with no evidence-catalog or claim-map entries.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none required; issue #5228 fully resolved.

## Reviewer Notes
- The only semantic change for valid inputs: none. Invalid `--ceiling-gb`/`--auto-workers`/
  `--project-at` now exit 2 immediately rather than crashing during report construction.
- The `is_running()` removal is safe: `memory_info()` raises `NoSuchProcess` on process exit.
- No benchmark semantics, no Slurm/GPU submission, no paper/dissertation claim edits.
