### PR TITLE
fix(benchmark): gc.collect always runs between arms + finally-block cleanup guard (#4826)

### DIFF
--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -296,18 +296,22 @@ def _cleanup_gpu_memory_between_arms(
         "reserved_freed_mb": 0.0,
     }
 
+    # Always collect Python-level garbage so object references from the completed
+    # arm (model weights, replay buffers, env wrappers) are freed before the next
+    # arm starts — even when CUDA is not available (issue #4826).
+    gc.collect()
+
     if "torch" in sys.modules:
         import torch  # noqa: PLC0415
 
         memory_metrics["torch_available"] = True
         if torch.cuda.is_available():
             memory_metrics["cuda_available"] = True
-            # Measure before gc/empty_cache so diagnostics capture what cleanup freed.
+            # Measure before empty_cache so diagnostics capture what cleanup freed.
             memory_metrics["high_water_mark_mb"] = torch.cuda.max_memory_allocated() / 1024 / 1024
             allocated_before = torch.cuda.memory_allocated() / 1024 / 1024
             reserved_before = torch.cuda.memory_reserved() / 1024 / 1024
 
-            gc.collect()
             torch.cuda.empty_cache()
             torch.cuda.synchronize()
 
@@ -1017,18 +1021,22 @@ def _run_campaign_planner_matrix(
                     active_observation_mode=active_observation_mode,
                 )
             else:
-                variant_result = _run_campaign_planner_variant(
-                    context,
-                    planner=planner,
-                    kinematics=kinematics,
-                    active_observation_mode=active_observation_mode,
-                )
-                # Clean up GPU memory after each arm to prevent VRAM leaks
-                # across campaign iterations (issue #4826).
-                memory_metrics = _cleanup_gpu_memory_between_arms(
-                    planner_key=planner.key,
-                    kinematics=kinematics,
-                )
+                try:
+                    variant_result = _run_campaign_planner_variant(
+                        context,
+                        planner=planner,
+                        kinematics=kinematics,
+                        active_observation_mode=active_observation_mode,
+                    )
+                finally:
+                    # Clean up GPU memory and Python refs after each arm to prevent
+                    # VRAM/RSS leaks across campaign iterations (issue #4826).
+                    # Runs even if the arm raised — keeps the next arm from inheriting
+                    # leaked CUDA allocations.
+                    memory_metrics = _cleanup_gpu_memory_between_arms(
+                        planner_key=planner.key,
+                        kinematics=kinematics,
+                    )
                 # Attach diagnostics to the run entry created by this variant.
                 if variant_result.run_entries:
                     variant_result.run_entries[-1]["gpu_cleanup"] = memory_metrics

--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -296,11 +296,6 @@ def _cleanup_gpu_memory_between_arms(
         "reserved_freed_mb": 0.0,
     }
 
-    # Always collect Python-level garbage so object references from the completed
-    # arm (model weights, replay buffers, env wrappers) are freed before the next
-    # arm starts — even when CUDA is not available (issue #4826).
-    gc.collect()
-
     if "torch" in sys.modules:
         import torch  # noqa: PLC0415
 
@@ -312,6 +307,9 @@ def _cleanup_gpu_memory_between_arms(
             allocated_before = torch.cuda.memory_allocated() / 1024 / 1024
             reserved_before = torch.cuda.memory_reserved() / 1024 / 1024
 
+            # Capture the allocated/reserved baseline before collecting Python
+            # references so cleanup telemetry includes memory freed by gc.collect().
+            gc.collect()
             torch.cuda.empty_cache()
             torch.cuda.synchronize()
 
@@ -339,6 +337,12 @@ def _cleanup_gpu_memory_between_arms(
                 memory_metrics["reserved_freed_mb"],
                 memory_metrics["high_water_mark_mb"],
             )
+        else:
+            # CPU-only nodes still need Python-level cleanup between arms.
+            gc.collect()
+    else:
+        # Keep no-torch environments from accumulating completed-arm objects.
+        gc.collect()
     return memory_metrics
 
 

--- a/tests/benchmark/test_camera_ready_gpu_cleanup.py
+++ b/tests/benchmark/test_camera_ready_gpu_cleanup.py
@@ -6,8 +6,9 @@ arms to prevent VRAM leaks during long-running multi-arm campaigns.
 
 from __future__ import annotations
 
+import gc
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -220,6 +221,169 @@ class TestCampaignMultiArmMemoryRegression:
             "diff_drive",
             "holonomic",
         ]
+
+
+class TestGcCollectAlwaysRunsBetweenArms:
+    """Regression tests for gc.collect() always running between arms (issue #4826).
+
+    Before this fix, gc.collect() was only called inside the CUDA block, so CPU-only
+    runs (no GPU, or torch not installed) never triggered garbage collection between
+    arms. This allows Python-level references to model weights, replay buffers, and
+    env wrappers to accumulate across arms and grow RSS monotonically.
+    """
+
+    def test_gc_collect_called_without_torch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """gc.collect() runs even when torch is not installed (issue #4826)."""
+        monkeypatch.delitem(sys.modules, "torch", raising=False)
+
+        with patch.object(gc, "collect", wraps=gc.collect) as mock_gc:
+            _cleanup_gpu_memory_between_arms(planner_key="p", kinematics="k")
+            mock_gc.assert_called_once()
+
+    def test_gc_collect_called_with_torch_cpu_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """gc.collect() runs when torch is available but CUDA is not (CPU-only cluster node)."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+        monkeypatch.setitem(sys.modules, "torch", mock_torch)
+
+        with patch.object(gc, "collect", wraps=gc.collect) as mock_gc:
+            _cleanup_gpu_memory_between_arms(planner_key="p", kinematics="k")
+            mock_gc.assert_called_once()
+
+    def test_gc_collect_called_before_cuda_empty_cache(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """gc.collect() runs before CUDA empty_cache to release Python refs first."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.max_memory_allocated.return_value = 0
+        mock_torch.cuda.memory_allocated.side_effect = [0, 0]
+        mock_torch.cuda.memory_reserved.side_effect = [0, 0]
+        monkeypatch.setitem(sys.modules, "torch", mock_torch)
+
+        call_order: list[str] = []
+        original_gc_collect = gc.collect
+
+        def tracking_gc_collect(*args, **kwargs):
+            call_order.append("gc.collect")
+            return original_gc_collect(*args, **kwargs)
+
+        def tracking_empty_cache():
+            call_order.append("empty_cache")
+
+        mock_torch.cuda.empty_cache = tracking_empty_cache
+
+        with patch.object(gc, "collect", side_effect=tracking_gc_collect):
+            _cleanup_gpu_memory_between_arms(planner_key="p", kinematics="k")
+
+        assert call_order.index("gc.collect") < call_order.index("empty_cache"), (
+            "gc.collect() must run before cuda.empty_cache() to release Python object refs first"
+        )
+
+
+class TestCleanupRunsInFinallyBlock:
+    """Regression tests for cleanup running in try/finally (issue #4826).
+
+    The in-process arm loop wraps each arm execution in try/finally so that
+    _cleanup_gpu_memory_between_arms is called even when _run_campaign_planner_variant
+    raises an unexpected exception. Without try/finally, a crashing arm leaves its
+    CUDA allocations unreleased for all subsequent arms.
+    """
+
+    def test_cleanup_called_after_successful_arm(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """Cleanup is called once per arm on success."""
+        cleanup_calls: list[tuple[str, str]] = []
+
+        def fake_variant(context, *, planner, kinematics, active_observation_mode):
+            return _CampaignPlannerVariantResult(
+                run_entries=[{"planner": {"key": planner.key}}],
+                planner_rows=[],
+                warnings=[],
+                seed_variability_records=[],
+                stop_requested=False,
+            )
+
+        def fake_cleanup(*, planner_key, kinematics):
+            cleanup_calls.append((planner_key, kinematics))
+            return {"planner_key": planner_key, "kinematics": kinematics}
+
+        monkeypatch.setattr(campaign_mod, "_run_campaign_planner_variant", fake_variant)
+        monkeypatch.setattr(campaign_mod, "_cleanup_gpu_memory_between_arms", fake_cleanup)
+
+        cfg = CampaignConfig(
+            name="test",
+            scenario_matrix_path=tmp_path / "scenarios.yaml",
+            planners=(
+                PlannerSpec(key="plan_a", algo="orca"),
+                PlannerSpec(key="plan_b", algo="orca"),
+            ),
+            kinematics_matrix=("diff_drive",),
+        )
+        deps = _CampaignRuntimeDependencies(
+            prepare_campaign_preflight=lambda *a, **kw: {},
+            run_batch=lambda *a, **kw: {},
+            compute_aggregates_with_ci=lambda *a, **kw: {},
+            export_publication_bundle=lambda *a, **kw: None,
+        )
+
+        campaign_mod._run_campaign_planner_matrix(
+            cfg=cfg,
+            scenarios=[],
+            snqi_weights=None,
+            snqi_baseline=None,
+            runs_dir=tmp_path,
+            dependencies=deps,
+        )
+
+        assert cleanup_calls == [("plan_a", "diff_drive"), ("plan_b", "diff_drive")], (
+            "cleanup must be called once per arm in the correct order"
+        )
+
+    def test_cleanup_called_even_when_arm_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """Cleanup runs via try/finally even when _run_campaign_planner_variant raises."""
+        cleanup_was_called = []
+
+        def exploding_variant(context, *, planner, kinematics, active_observation_mode):
+            raise RuntimeError("unexpected arm failure")
+
+        def fake_cleanup(*, planner_key, kinematics):
+            cleanup_was_called.append((planner_key, kinematics))
+            return {"planner_key": planner_key, "kinematics": kinematics}
+
+        monkeypatch.setattr(campaign_mod, "_run_campaign_planner_variant", exploding_variant)
+        monkeypatch.setattr(campaign_mod, "_cleanup_gpu_memory_between_arms", fake_cleanup)
+
+        cfg = CampaignConfig(
+            name="test",
+            scenario_matrix_path=tmp_path / "scenarios.yaml",
+            planners=(PlannerSpec(key="plan_a", algo="orca"),),
+            kinematics_matrix=("diff_drive",),
+        )
+        deps = _CampaignRuntimeDependencies(
+            prepare_campaign_preflight=lambda *a, **kw: {},
+            run_batch=lambda *a, **kw: {},
+            compute_aggregates_with_ci=lambda *a, **kw: {},
+            export_publication_bundle=lambda *a, **kw: None,
+        )
+
+        with pytest.raises(RuntimeError, match="unexpected arm failure"):
+            campaign_mod._run_campaign_planner_matrix(
+                cfg=cfg,
+                scenarios=[],
+                snqi_weights=None,
+                snqi_baseline=None,
+                runs_dir=tmp_path,
+                dependencies=deps,
+            )
+
+        assert len(cleanup_was_called) == 1, (
+            "cleanup must run exactly once via finally block even when the arm raises"
+        )
+        assert cleanup_was_called[0] == ("plan_a", "diff_drive")
 
 
 def test_pytorch_alloc_conf_set_in_slurm_env() -> None:

--- a/tests/benchmark/test_camera_ready_gpu_cleanup.py
+++ b/tests/benchmark/test_camera_ready_gpu_cleanup.py
@@ -280,6 +280,43 @@ class TestGcCollectAlwaysRunsBetweenArms:
             "gc.collect() must run before cuda.empty_cache() to release Python object refs first"
         )
 
+    def test_cuda_cleanup_records_pre_gc_memory_baseline(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cleanup telemetry includes memory reclaimed by Python garbage collection."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.max_memory_allocated.return_value = 300 * 1024 * 1024
+        call_order: list[str] = []
+        allocated_values = iter((256 * 1024 * 1024, 128 * 1024 * 1024))
+        reserved_values = iter((300 * 1024 * 1024, 150 * 1024 * 1024))
+
+        def memory_allocated() -> int:
+            call_order.append("memory_allocated")
+            return next(allocated_values)
+
+        def memory_reserved() -> int:
+            call_order.append("memory_reserved")
+            return next(reserved_values)
+
+        mock_torch.cuda.memory_allocated.side_effect = memory_allocated
+        mock_torch.cuda.memory_reserved.side_effect = memory_reserved
+        monkeypatch.setitem(sys.modules, "torch", mock_torch)
+
+        original_gc_collect = gc.collect
+
+        def tracking_gc_collect(*args, **kwargs):
+            call_order.append("gc.collect")
+            return original_gc_collect(*args, **kwargs)
+
+        with patch.object(gc, "collect", side_effect=tracking_gc_collect):
+            metrics = _cleanup_gpu_memory_between_arms(planner_key="p", kinematics="k")
+
+        assert call_order.index("memory_allocated") < call_order.index("gc.collect")
+        assert call_order.index("memory_reserved") < call_order.index("gc.collect")
+        assert metrics["allocated_freed_mb"] == 128
+        assert metrics["reserved_freed_mb"] == 150
+
 
 class TestCleanupRunsInFinallyBlock:
     """Regression tests for cleanup running in try/finally (issue #4826).


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** Two gaps in `_cleanup_gpu_memory_between_arms` and the in-process arm loop in `_run_campaign_planner_matrix`:

1. `gc.collect()` was only called inside `if torch.cuda.is_available():`, so CPU-only nodes never triggered Python garbage collection between arms. Model weights, replay buffers, and env wrappers accumulated across arms and could grow RSS monotonically on any machine without CUDA. Fixed by moving `gc.collect()` unconditionally before the torch block.

2. The in-process arm execution in `_run_campaign_planner_matrix` was not wrapped in `try/finally`. An unexpected exception from `_run_campaign_planner_variant` would bypass `_cleanup_gpu_memory_between_arms` entirely, leaving CUDA allocations from the failed arm live for all subsequent arms. Fixed by wrapping in `try/finally`.

**Why now:** Prior PRs (#4836, #4846, #4958) added the cleanup infrastructure and subprocess isolation. These two gaps were not covered by any existing test and only became visible when auditing the in-process path.

**Claim boundary:** diagnostic-only / smoke evidence. No GPU campaign run. Changes are pure harness logic; no planner semantics, metrics, or arm results are affected.

**Required validation:** CPU unit tests only (no GPU required). 12 tests pass in `test_camera_ready_gpu_cleanup.py`, 21 pass in `test_camera_ready_subprocess_isolation.py`, 135 pass in `test_camera_ready_campaign.py`.

**Remaining blocker for #4826:** ops-lane re-run of job 13344 with `--arm-isolation subprocess` to harvest live `allocated_freed_mb`/`reserved_freed_mb` evidence (gates S30 attempt 6). That requires GPU compute — out of scope here.

## Contract delta

No schema changes. No new config fields. `_cleanup_gpu_memory_between_arms` return value is identical (same dict keys). The `finally` block in the arm loop does not change normal execution flow.

## Changed files

| File | Reason |
|---|---|
| `robot_sf/benchmark/camera_ready/campaign.py` | Move `gc.collect()` before CUDA block; wrap in-process arm run in `try/finally` |
| `tests/benchmark/test_camera_ready_gpu_cleanup.py` | Add 6 regression tests for gc.collect always-runs and finally-block cleanup |

## Validation

```
uv run pytest tests/benchmark/test_camera_ready_gpu_cleanup.py -v
# 12 passed

uv run pytest tests/benchmark/test_camera_ready_subprocess_isolation.py -v
# 21 passed

uv run pytest tests/benchmark/test_camera_ready_campaign.py -v
# 135 passed
```

## Out of scope

- No full benchmark campaign run
- No Slurm/GPU submission
- No paper/dissertation claim edits
- No change to subprocess isolation mode, arm results, or metrics

Refs #4826