### PR TITLE
feat(#3574): add 3rd planner to mean-matched harness config + disk-loading tests

### DIFF
--- a/configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml
+++ b/configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml
@@ -9,9 +9,12 @@ planners:
     algo: goal
   - key: social_force
     algo: social_force
+  - key: orca
+    algo: orca
 seeds:
   - 101
   - 102
+  - 103
 scenarios:
   - id: issue_3574_classic_crossing_density_002
     density: 0.02

--- a/tests/benchmark/test_heterogeneous_population_ablation.py
+++ b/tests/benchmark/test_heterogeneous_population_ablation.py
@@ -7,6 +7,7 @@ import math
 from pathlib import Path
 
 import pytest
+import yaml
 
 from robot_sf.benchmark.heterogeneous_population_ablation import (
     HETEROGENEOUS_POPULATION_ABLATION_SCHEMA,
@@ -403,4 +404,57 @@ def test_mean_matched_harness_manifest_reports_bad_fixture_trace_metric() -> Non
     assert any(
         "control_trace.pedestrians[0].steps[0] missing 'clearance_m'" in blocker
         for blocker in manifest["blockers"]
+    )
+
+
+_REPO_HARNESS_CONFIG_PATH = (
+    Path(__file__).parents[2] / "configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml"
+)
+
+
+def _load_repo_harness_config() -> dict[str, object]:
+    return yaml.safe_load(_REPO_HARNESS_CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def test_repo_harness_config_loads_and_has_at_least_three_planners() -> None:
+    """Repo config meets the ≥3-planner DoD for rank-order sensitivity analysis."""
+
+    config = _load_repo_harness_config()
+    planners = config.get("planners", [])
+    assert isinstance(planners, list), "planners must be a list"
+    assert len(planners) >= 3, f"DoD requires ≥3 planners; got {len(planners)}: {planners}"
+
+
+def test_repo_harness_config_builds_valid_manifest_and_fails_closed() -> None:
+    """Repo config builds a valid manifest and blocks on missing episode traces."""
+
+    config = _load_repo_harness_config()
+    manifest = build_mean_matched_harness_manifest(
+        config, config_path=str(_REPO_HARNESS_CONFIG_PATH)
+    )
+
+    assert manifest["schema_version"] == MEAN_MATCHED_HETEROGENEITY_HARNESS_SCHEMA
+    assert manifest["issue"] == 3574
+    # Without episode runs the manifest is blocked — it fails closed, not open.
+    assert manifest["status"] == "blocked_pending_control_trace"
+    assert manifest["blockers"], "manifest must name the missing trace fields"
+    # Paired arms must appear in every row.
+    arms_seen = {row["population_arm"] for row in manifest["manifest_rows"]}
+    assert arms_seen == {"heterogeneous", "mean_matched_homogeneous"}
+
+
+def test_repo_harness_config_manifest_includes_near_field_exposure_metric() -> None:
+    """Repo config declares near_field_exposure_s for per-archetype tail risk."""
+
+    config = _load_repo_harness_config()
+    metric_keys = config.get("trace_metric_keys", [])
+    assert "near_field_exposure_s" in metric_keys, (
+        "near_field_exposure_s must be declared for per-archetype tail-risk analysis"
+    )
+    manifest = build_mean_matched_harness_manifest(config)
+    # near_field_clearance_threshold_m must be surfaced in the row-level output contract.
+    first_row = manifest["manifest_rows"][0]
+    assert any(
+        "near_field_clearance_threshold_m" in key
+        for key in first_row["expected_episode_output_keys"]
     )


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds `orca` as a third planner to `configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml` (expanding the manifest from 8 to 18 rows — 3 planners × 2 arms × 3 seeds × 1 scenario) and three tests that load the tracked config from disk to verify it meets the harness contract.
- **Why now:** Issue #3574 DoD explicitly requires ≥3 planners for rank-order sensitivity analysis with bootstrap P(A beats B). The config previously had only 2 planners (goal, social_force), making the rank-reversal test unrunnable. The new `orca` entry closes the gap.
- **Claim boundary:** `diagnostic-only` — no ablation campaign run, no heterogeneity-effect claim. This is a config+test progression slice toward the rank-order sensitivity DoD item.
- **Required validation:** `uv run pytest tests/benchmark/test_heterogeneous_population_ablation.py -q` (91 related tests pass)
- **Remaining blockers:** Ablation campaign runs (Slurm/GPU), bootstrap rank-reversal report. Per the latest issue comment, realized-distribution audit completion and bootstrap/rank-reversal analysis remain open.

## Contract delta

- `configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml`: adds `orca` planner entry + seed 103; no other semantic change
- `tests/benchmark/test_heterogeneous_population_ablation.py`: adds 3 disk-loading tests:
  - `test_repo_harness_config_loads_and_has_at_least_three_planners` — enforces DoD ≥3-planner requirement
  - `test_repo_harness_config_builds_valid_manifest_and_fails_closed` — validates manifest schema + blocked status without runs
  - `test_repo_harness_config_manifest_includes_near_field_exposure_metric` — validates near_field_exposure_s trace contract

<details>
<summary>Validation results</summary>

```
uv run pytest tests/benchmark/test_heterogeneous_population_ablation.py -q
24 passed in 1.09s

uv run pytest tests/benchmark/test_heterogeneous_population_ablation.py tests/benchmark/test_pedestrian_control_trace.py tests/benchmark/test_heterogeneous_population_metrics.py tests/benchmark/test_heterogeneous_rank_sensitivity.py -q
91 passed in 1.23s

uv run python scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py
wrote issue #3574 mean-matched heterogeneity manifest: output/issue_3574_mean_matched_harness/manifest.json
status: blocked_pending_control_trace; rows: 18
```

</details>

## Out-of-scope

- No ablation campaign run
- No Slurm/GPU submission
- No paper/dissertation claim edits
- No heterogeneity-effect interpretation

Refs #3574