### PR TITLE
fix(benchmark): subprocess arm worker imports nonexistent scenario_matrix module (#4826)

### DIFF
--- a/robot_sf/benchmark/camera_ready/resource_lifecycle.py
+++ b/robot_sf/benchmark/camera_ready/resource_lifecycle.py
@@ -184,12 +184,15 @@ def _run_single_arm_subprocess(params: _SubprocessArmParams) -> dict[str, Any]:
         availability_payload,
         summarize_benchmark_availability,
     )
-    from robot_sf.benchmark.runner import run_batch  # noqa: PLC0415
-    from robot_sf.benchmark.scenario_matrix import load_scenario_matrix  # noqa: PLC0415
+    from robot_sf.benchmark.runner import load_scenario_matrix, run_batch  # noqa: PLC0415
 
-    # Load scenario matrix
-    scenario_matrix = load_scenario_matrix(params.scenario_matrix_path)
-    scenarios = scenario_matrix.scenarios
+    # Load scenario matrix. NOTE (2026-07-11): this previously imported
+    # `robot_sf.benchmark.scenario_matrix` — a module that has NEVER existed — and read
+    # `.scenarios` off an object that was really a list. The subprocess worker therefore
+    # failed on every arm it ever ran (masked first by the arm_params JSON crash, then
+    # observed live in Slurm job 13364). load_scenario_matrix lives in runner and returns
+    # the scenario list directly, exactly as the in-process path consumes it.
+    scenarios = load_scenario_matrix(params.scenario_matrix_path)
 
     # Apply kinematics transform
     scoped_scenarios = [

--- a/tests/benchmark/test_resource_lifecycle_phantom_imports.py
+++ b/tests/benchmark/test_resource_lifecycle_phantom_imports.py
@@ -1,0 +1,51 @@
+"""Every deferred robot_sf import in resource_lifecycle must resolve (issue #4826).
+
+The subprocess arm worker defers its imports into function bodies, so a phantom module
+name is invisible to collection-time import errors and to any test that does not execute
+the worker end to end. That is exactly how `from robot_sf.benchmark.scenario_matrix
+import load_scenario_matrix` — a module that never existed — shipped inside the arm
+isolation feature and made every subprocess arm fail at runtime (Slurm job 13364),
+hidden behind the arm_params serialization crash (job 13344) until that was fixed.
+
+This test walks the module's AST, extracts every `import`/`from ... import` whose target
+is a robot_sf module — wherever it appears, including inside functions — and requires
+importlib to resolve the module AND getattr to resolve each imported name.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+TARGET = Path("robot_sf/benchmark/camera_ready/resource_lifecycle.py")
+
+
+def _robot_sf_imports(tree: ast.AST) -> list[tuple[str, list[str]]]:
+    found: list[tuple[str, list[str]]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("robot_sf"):
+            if node.level == 0:
+                found.append((node.module, [a.name for a in node.names]))
+        elif isinstance(node, ast.Import):
+            for a in node.names:
+                if a.name.startswith("robot_sf"):
+                    found.append((a.name, []))
+    return found
+
+
+def test_all_robot_sf_imports_resolve() -> None:
+    tree = ast.parse(TARGET.read_text())
+    imports = _robot_sf_imports(tree)
+    assert imports, "expected robot_sf imports in resource_lifecycle"
+    problems: list[str] = []
+    for module, names in imports:
+        try:
+            mod = importlib.import_module(module)
+        except ImportError as exc:
+            problems.append(f"{module}: module does not resolve ({exc})")
+            continue
+        for name in names:
+            if name != "*" and not hasattr(mod, name):
+                problems.append(f"{module}.{name}: name missing from module")
+    assert not problems, "phantom imports in resource_lifecycle:\n  " + "\n  ".join(problems)

--- a/tests/benchmark/test_resource_lifecycle_phantom_imports.py
+++ b/tests/benchmark/test_resource_lifecycle_phantom_imports.py
@@ -18,7 +18,8 @@ import ast
 import importlib
 from pathlib import Path
 
-TARGET = Path("robot_sf/benchmark/camera_ready/resource_lifecycle.py")
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+TARGET = _REPO_ROOT / "robot_sf/benchmark/camera_ready/resource_lifecycle.py"
 
 
 def _robot_sf_imports(tree: ast.AST) -> list[tuple[str, list[str]]]:
@@ -35,6 +36,7 @@ def _robot_sf_imports(tree: ast.AST) -> list[tuple[str, list[str]]]:
 
 
 def test_all_robot_sf_imports_resolve() -> None:
+    """Every deferred first-party import resolves its module and requested symbol."""
     tree = ast.parse(TARGET.read_text())
     imports = _robot_sf_imports(tree)
     assert imports, "expected robot_sf imports in resource_lifecycle"


### PR DESCRIPTION
See commit message. Root-caused from live Slurm job 13364 (S30 isolation smoke): the #5145 serialization fix exposed this second dark layer — the arm-isolation subprocess worker has never successfully run an arm. Two-line fix + a phantom-import AST ratchet test. 22/22 focused tests pass (`uv run pytest tests/benchmark/test_resource_lifecycle_phantom_imports.py tests/benchmark/test_camera_ready_subprocess_isolation.py -q`).

Refs #4826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scenario loading during single-arm benchmark runs, preventing runtime failures and ensuring scenarios are processed correctly.

* **Tests**
  * Added validation to detect unresolved internal imports and missing imported names before they cause runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->