### PR TITLE
Issue #5240: soft SNQI-contract warning (enforcement=warn) must not fail the campaign exit code (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -93,6 +93,7 @@ from robot_sf.benchmark.snqi.campaign_contract import (
     evaluate_snqi_contract,
     resolve_weight_mapping,
     sanitize_baseline_stats,
+    soft_contract_warning_active,
     validate_snqi_normalized_inputs,
 )
 from robot_sf.benchmark.utils import load_optional_json
@@ -1734,18 +1735,22 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
         and cfg.snqi_contract.enforcement in {"error", "enforce"}
         and contract_eval.status == "fail"
     )
+    # Issue #5240: a soft contract warning (enforcement=warn with status warn/fail) must NOT
+    # change the exit code. It is surfaced in the summary as ``soft_contract_warning: true``
+    # plus a ``warnings[]`` entry, and the campaign still counts as benchmark_success when all
+    # planner rows succeeded. Only hard enforcement levels stay fatal (handled by snqi_hard_fail).
+    soft_contract_warning = bool(
+        cfg.paper_facing
+        and cfg.snqi_contract.enabled
+        and soft_contract_warning_active(cfg.snqi_contract.enforcement, contract_eval.status)
+    )
     if snqi_hard_fail:
         warnings.append(
             "SNQI contract status=fail with "
             f"snqi_contract.enforcement={cfg.snqi_contract.enforcement}; "
             "campaign marked with hard contract warning."
         )
-    elif (
-        cfg.paper_facing
-        and cfg.snqi_contract.enabled
-        and cfg.snqi_contract.enforcement == "warn"
-        and contract_eval.status in {"warn", "fail"}
-    ):
+    elif soft_contract_warning:
         warnings.append(
             "SNQI contract status="
             f"{contract_eval.status} with snqi_contract.enforcement=warn; campaign marked with soft contract warning."
@@ -1842,6 +1847,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
         "planner_rows": planner_rows,
         "runs": run_entries,
         "warnings": warnings,
+        "soft_contract_warning": soft_contract_warning,
         "artifacts": {
             "campaign_manifest": _repo_relative(campaign_root / "campaign_manifest.json"),
             "campaign_summary_json": _repo_relative(summary_json_path),
@@ -2167,4 +2173,5 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
         "runtime_sec": runtime_sec,
         "publication_bundle": publication_payload,
         "warnings": warnings,
+        "soft_contract_warning": soft_contract_warning,
     }

--- a/robot_sf/benchmark/snqi/campaign_contract.py
+++ b/robot_sf/benchmark/snqi/campaign_contract.py
@@ -158,6 +158,38 @@ def _is_finite(value: Any) -> bool:
         return False
 
 
+# SNQI contract enforcement levels that keep a contract failure fatal (exit-impacting).
+# Any other enforcement level (notably "warn") is soft and must not change the exit code.
+_HARD_SNQI_ENFORCEMENT_LEVELS = {"error", "enforce"}
+
+
+def soft_contract_warning_active(enforcement: str, contract_status: str) -> bool:
+    """Return whether a contract result must surface as a SOFT, non-fatal warning.
+
+    Under ``snqi_contract.enforcement == "warn"`` a contract ``status`` of ``"warn"``
+    or ``"fail"`` is reported as a soft contract warning: it is recorded in the
+    campaign summary (``warnings[]`` plus a top-level ``soft_contract_warning: true``)
+    but must NOT change the process exit code, and the campaign still counts as
+    ``benchmark_success`` when all planner rows succeeded.
+
+    Hard enforcement levels (``error`` / ``enforce``) are intentionally NOT soft:
+    a contract ``fail`` under those levels stays fatal (see issue #5240).
+
+    Args:
+        enforcement: Resolved ``snqi_contract.enforcement`` value (e.g. ``"warn"``,
+            ``"error"``, ``"enforce"``).
+        contract_status: Resolved contract ``status`` (``"pass"`` / ``"warn"`` / ``"fail"``).
+
+    Returns:
+        ``True`` when the result is a soft, non-fatal contract warning.
+    """
+    normalized_enforcement = str(enforcement or "").strip().lower()
+    normalized_status = str(contract_status or "").strip().lower()
+    if normalized_enforcement in _HARD_SNQI_ENFORCEMENT_LEVELS:
+        return False
+    return normalized_enforcement == "warn" and normalized_status in {"warn", "fail"}
+
+
 def _quantile(values: Sequence[float], q: float) -> float:
     """Compute an interpolated quantile without a NumPy dependency.
 
@@ -923,5 +955,6 @@ __all__ = [
     "evaluate_snqi_contract",
     "resolve_weight_mapping",
     "sanitize_baseline_stats",
+    "soft_contract_warning_active",
     "spearman_correlation",
 ]

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -4690,6 +4690,12 @@ def test_run_campaign_surfaces_snqi_contract_warn_mode(tmp_path: Path, monkeypat
     result = run_campaign(cfg, output_root=tmp_path / "campaign_out", label="snqi_warn")
     summary_payload = json.loads(Path(result["summary_json"]).read_text(encoding="utf-8"))
     assert any("snqi_contract.enforcement=warn" in item for item in summary_payload["warnings"])
+    # Issue #5240: a soft contract warning (enforcement=warn) must be surfaced as a top-level
+    # ``soft_contract_warning: true`` in the campaign summary while staying non-fatal.
+    assert summary_payload["soft_contract_warning"] is True
+    # The soft contract warning must not change the process exit code (stays 0 on a completed run).
+    assert result["exit_code"] == 0
+    assert result["soft_contract_warning"] is True
 
 
 def test_run_campaign_parity_table_includes_ci_columns(tmp_path: Path, monkeypatch) -> None:

--- a/tests/benchmark/test_issue_5240_soft_contract_exit_code.py
+++ b/tests/benchmark/test_issue_5240_soft_contract_exit_code.py
@@ -1,0 +1,247 @@
+"""Issue #5240: a soft SNQI-contract warning (enforcement=warn) must not fail the exit code.
+
+A benchmark campaign that COMPLETES all planner rows but carries a soft contract warning
+(``snqi_contract.enforcement == "warn"`` with contract ``status`` of ``warn``/``fail``) must
+exit 0 and surface ``soft_contract_warning: true`` plus a ``warnings[]`` entry. Hard
+enforcement (``error``/``enforce``) with a contract ``fail`` stays fatal (nonzero exit).
+
+These tests lock both layers named in the issue:
+- the exit-code mapping (``campaign_exit_code`` / ``summarize_campaign_outcome``), and
+- the CLI wrapper (``scripts/tools/run_camera_ready_benchmark.py``) that maps the returned
+  status to the process exit code.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.benchmark.fallback_policy import campaign_exit_code
+from robot_sf.benchmark.snqi.campaign_contract import soft_contract_warning_active
+from scripts.tools import run_camera_ready_benchmark
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SOFT_CONTRACT_WARNING_FRAGMENT = "soft contract warning"
+
+
+# --------------------------------------------------------------------------- #
+# Layer: the soft-contract-warning decision boundary (the heart of the fix).
+# --------------------------------------------------------------------------- #
+
+
+class TestSoftContractWarningDecision:
+    """``soft_contract_warning_active`` encodes the warn-vs-block enforcement boundary."""
+
+    @pytest.mark.parametrize(
+        ("enforcement", "contract_status", "expected"),
+        [
+            # enforcement=warn is SOFT: warn/fail status surface as non-fatal warnings.
+            ("warn", "fail", True),
+            ("warn", "warn", True),
+            # No soft warning when the contract actually passed.
+            ("warn", "pass", False),
+            # Hard enforcement levels are NEVER soft: a fail stays fatal via snqi_hard_fail.
+            ("enforce", "fail", False),
+            ("error", "fail", False),
+            ("enforce", "warn", False),
+            ("error", "warn", False),
+            # Hard enforcement with a passing contract is neither soft nor fatal.
+            ("enforce", "pass", False),
+        ],
+    )
+    def test_decision_boundary(
+        self, enforcement: str, contract_status: str, expected: bool
+    ) -> None:
+        """Decision boundary matches the issue's warn (soft) vs block (fatal) contract."""
+        assert soft_contract_warning_active(enforcement, contract_status) is expected
+
+    def test_hard_enforcement_fail_is_not_demoted_to_soft(self) -> None:
+        """Regression guard for issue #5240: enforce/error + fail must NOT become a soft warning.
+
+        If this ever flips to True, the hard-fatal path would be silently demoted to a non-fatal
+        warning, re-introducing the orphaned-campaign defect.
+        """
+        assert soft_contract_warning_active("enforce", "fail") is False
+        assert soft_contract_warning_active("error", "fail") is False
+
+    def test_decision_is_case_and_whitespace_insensitive(self) -> None:
+        """Config-driven values are normalized before the decision is applied."""
+        assert soft_contract_warning_active("  WARN  ", "FAIL") is True
+        assert soft_contract_warning_active("Enforce", "Fail") is False
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1: the exit-code mapping must stay 0 for a soft-warning success campaign.
+# --------------------------------------------------------------------------- #
+
+
+def _success_payload_with_soft_warning() -> dict:
+    """A benchmark-success campaign result that also carries a soft contract warning."""
+    return {
+        "campaign_id": "cid",
+        "campaign_root": "/tmp/cid",
+        "benchmark_success": True,
+        "status": "benchmark_success",
+        "campaign_execution_status": "completed",
+        "evidence_status": "valid",
+        "row_status_summary": {
+            "successful_evidence_rows": 3,
+            "accepted_unavailable_rows": 0,
+            "unexpected_failed_rows": 0,
+            "fallback_or_degraded_rows": 0,
+        },
+        "status_reason": "all planner rows were benchmark-success",
+        "successful_runs": 3,
+        "accepted_unavailable_runs": 0,
+        "unexpected_failed_runs": 0,
+        "non_success_runs": 0,
+        "total_runs": 3,
+        "exit_code": 0,
+        "soft_contract_warning": True,
+        "warnings": [
+            "SNQI contract status=fail with snqi_contract.enforcement=warn; "
+            "campaign marked with soft contract warning."
+        ],
+    }
+
+
+def test_campaign_exit_code_is_zero_for_soft_warning_success() -> None:
+    """A soft contract warning on an otherwise-successful campaign must not change the exit code."""
+    payload = _success_payload_with_soft_warning()
+    assert payload["soft_contract_warning"] is True
+    # exit_code 0 is canonical and trusted; the soft warning must not override it.
+    assert campaign_exit_code(payload) == 0
+
+
+def test_campaign_exit_code_is_zero_derived_from_rows_even_without_explicit_exit_code() -> None:
+    """Even without an explicit exit_code, all-ok rows derive exit 0 despite the soft warning."""
+    payload = _success_payload_with_soft_warning()
+    payload.pop("exit_code")
+    # Falls through to summarize_campaign_outcome -> all rows ok -> exit_code 0.
+    assert campaign_exit_code(payload) == 0
+
+
+def test_soft_warning_does_not_mask_a_genuine_failure() -> None:
+    """A soft contract warning must NOT force exit 0 when rows genuinely failed."""
+    payload = _success_payload_with_soft_warning()
+    payload["planner_rows"] = [{"status": "ok"}, {"status": "partial-failure"}]
+    payload["exit_code"] = 2  # genuine unexpected failure
+    payload["benchmark_success"] = False
+    # The genuine failure exit code is preserved; the soft warning does not override it.
+    assert campaign_exit_code(payload) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2: the CLI wrapper maps the returned status to the process exit code.
+# --------------------------------------------------------------------------- #
+
+
+def _install_soft_warning_campaign(monkeypatch, tmp_path: Path, payload: dict) -> None:
+    """Install mocked config loader + run_campaign for the camera-ready benchmark CLI."""
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("name: test\n", encoding="utf-8")
+    sentinel_cfg = object()
+
+    monkeypatch.setattr(
+        run_camera_ready_benchmark,
+        "load_campaign_config",
+        lambda path: sentinel_cfg if path == config_path else None,
+    )
+    monkeypatch.setattr(
+        run_camera_ready_benchmark,
+        "prepare_campaign_preflight",
+        lambda *a, **kw: (_ for _ in ()).throw(
+            AssertionError("prepare_campaign_preflight should not be called in run mode")
+        ),
+    )
+    monkeypatch.setattr(
+        run_camera_ready_benchmark,
+        "run_campaign",
+        lambda cfg, **kw: payload if cfg is sentinel_cfg else {},
+    )
+
+
+def test_wrapper_exit_zero_for_soft_contract_warning_campaign(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """CLI run mode returns exit 0 for a complete campaign carrying a soft contract warning.
+
+    This is the exact regression for issue #5240: a full, expensive result set must not be
+    orphaned as 'failed' merely because of a non-fatal soft contract warning.
+    """
+    payload = _success_payload_with_soft_warning()
+    _install_soft_warning_campaign(monkeypatch, tmp_path, payload)
+
+    config_path = tmp_path / "config.yaml"
+    exit_code = run_camera_ready_benchmark.main(["--config", str(config_path)])
+    assert exit_code == 0
+
+    printed = json.loads(capsys.readouterr().out)
+    # The soft warning is surfaced as a top-level flag plus a warnings[] entry.
+    assert printed["soft_contract_warning"] is True
+    assert printed["benchmark_success"] is True
+    assert printed["campaign_execution_status"] == "completed"
+    soft_warning_strings = [
+        w for w in printed.get("warnings", []) if _SOFT_CONTRACT_WARNING_FRAGMENT in w
+    ]
+    assert soft_warning_strings, "expected a soft contract warning string in warnings[]"
+
+
+def test_wrapper_preserves_nonzero_exit_for_genuine_failure_with_soft_warning(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """A soft contract warning does not turn a genuine row failure into exit 0."""
+    payload = _success_payload_with_soft_warning()
+    payload["planner_rows"] = [{"status": "ok"}, {"status": "failed"}]
+    payload["exit_code"] = 2
+    payload["benchmark_success"] = False
+    payload["campaign_execution_status"] = "failed"
+    payload["evidence_status"] = "invalid"
+    _install_soft_warning_campaign(monkeypatch, tmp_path, payload)
+
+    config_path = tmp_path / "config.yaml"
+    exit_code = run_camera_ready_benchmark.main(["--config", str(config_path)])
+    assert exit_code == 2
+    printed = json.loads(capsys.readouterr().out)
+    # Soft warning is still surfaced for observability even on a failed campaign.
+    assert printed["soft_contract_warning"] is True
+
+
+def test_wrapper_hard_contract_failure_stays_fatal(tmp_path: Path, monkeypatch) -> None:
+    """Hard enforcement (error/enforce) + contract fail keeps its current fatal behavior.
+
+    snqi_hard_fail raises RuntimeError inside run_campaign; the wrapper must NOT swallow it,
+    so the process exits nonzero. Locking the 'do not touch that path' contract from issue #5240.
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("name: test\n", encoding="utf-8")
+    sentinel_cfg = object()
+
+    monkeypatch.setattr(
+        run_camera_ready_benchmark,
+        "load_campaign_config",
+        lambda path: sentinel_cfg if path == config_path else None,
+    )
+    monkeypatch.setattr(
+        run_camera_ready_benchmark,
+        "prepare_campaign_preflight",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("unreachable")),
+    )
+
+    def _raise_hard_contract_failure(cfg, **kwargs):
+        """Simulate the snqi_hard_fail raise path (enforce/error + contract fail)."""
+        raise RuntimeError(
+            "SNQI contract failed with enforcement=enforce; rank_alignment=0.2000, "
+            "outcome_separation=-0.0500."
+        )
+
+    monkeypatch.setattr(run_camera_ready_benchmark, "run_campaign", _raise_hard_contract_failure)
+
+    # The wrapper does not catch the hard-contract RuntimeError, so it propagates -> nonzero exit.
+    with pytest.raises(RuntimeError, match="SNQI contract failed with enforcement=enforce"):
+        run_camera_ready_benchmark.main(["--config", str(config_path)])


### PR DESCRIPTION
## What & why

Refs #5240: a benchmark campaign that **completes** all planner rows but carries a **soft** SNQI-contract warning (`snqi_contract.enforcement == "warn"` with contract `status` of `warn`/`fail`) must **not** be reported as a hard job failure. Under `enforcement=warn`, a contract failure is explicitly non-fatal — yet a complete, expensive result set was orphaned as "failed" and never retrieved.

This PR hardens the **exit-code plumbing** across the two layers named in the issue so a soft contract warning can never change the process exit code, and adds the observability flag the issue's Decision section requires.

### Decision implemented (from the issue, unchanged)
When `snqi_contract.enforcement == "warn"` and contract `status` is `warn`/`fail`:
- ✅ Must **NOT** change the process exit code (stays `0` when all planner rows succeeded).
- ✅ Surfaced in the campaign summary JSON as `warnings[]` (already present) **plus a top-level `soft_contract_warning: true`** (new).
- ✅ Campaign still counts as `benchmark_success` when all rows succeeded.

Hard enforcement (`error`/`enforce`) + contract `fail` **keeps its current fatal behavior** (`RuntimeError` → nonzero exit). That path was intentionally not touched.

## Changes

- **`robot_sf/benchmark/snqi/campaign_contract.py`** — new pure, documented helper `soft_contract_warning_active(enforcement, contract_status) -> bool` that centralizes the warn (soft, non-fatal) vs block (fatal) decision boundary. Hard enforcement levels (`error`/`enforce`) are explicitly never soft.
- **`robot_sf/benchmark/camera_ready/campaign.py`** — compute `soft_contract_warning` via the helper; drive the existing warn-branch `warnings[]` entry from it; add `soft_contract_warning` to the **campaign summary JSON** (top level, next to `warnings`) and to the **`run_campaign` return dict** (consumed by the CLI wrapper).
- **`scripts/tools/run_camera_ready_benchmark.py`** — no change needed: it already maps the result to the exit code via `campaign_exit_code(result)`, which returns `0` for a benchmark-success payload. Verified and locked by tests rather than edited, to keep the change freeze-safe and minimal.
- **`tests/benchmark/test_issue_5240_soft_contract_exit_code.py`** (new) — focused tests covering both layers named in the issue.
- **`tests/benchmark/test_camera_ready_campaign.py`** — extended `test_run_campaign_surfaces_snqi_contract_warn_mode` to assert `soft_contract_warning: true` and `exit_code == 0` **end-to-end through `run_campaign`**.

The wrapper's exit code comes from `campaign_outcome.exit_code`, which is derived from planner-row run statuses — **never** from the SNQI contract. A soft contract warning therefore cannot add a nonzero exit, and this PR makes that contract explicit, centralized, and regression-locked.

## Tests

New + extended tests map directly to the issue's required tests:

| Issue requirement | Test |
| --- | --- |
| #1 warn + contract fail ⇒ exit 0, `soft_contract_warning` true, warning present | `test_wrapper_exit_zero_for_soft_contract_warning_campaign`, `test_campaign_exit_code_is_zero_for_soft_warning_success`, `test_run_campaign_surfaces_snqi_contract_warn_mode` (end-to-end) |
| #2 hard enforcement + contract fail ⇒ nonzero exit (unchanged behavior lock) | `test_wrapper_hard_contract_failure_stays_fatal`, plus pre-existing `test_run_campaign_enforces_snqi_contract_error_mode` (still green) |
| decision boundary (warn soft vs block fatal) | `TestSoftContractWarningDecision` (parametrized + regression guard that hard-fail is not demoted to soft) |

Additional guards: a soft warning must not **mask** a genuine row failure (`test_soft_warning_does_not_mask_a_genuine_failure`, `test_wrapper_preserves_nonzero_exit_for_genuine_failure_with_soft_warning`).

### Validation output (CPU only, headless)

```
# New focused test file
$ DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/benchmark/test_issue_5240_soft_contract_exit_code.py -q
16 passed

# Issue's specified verification command
$ DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests -k "snqi_contract or exit or camera_ready_summary" -q
147 passed, 14392 deselected

# End-to-end warn/error contract modes through run_campaign
$ uv run pytest tests/benchmark/test_camera_ready_campaign.py::test_run_campaign_surfaces_snqi_contract_warn_mode \
    tests/benchmark/test_camera_ready_campaign.py::test_run_campaign_enforces_snqi_contract_error_mode -q
2 passed

# Regression: directly affected modules
$ uv run pytest tests/benchmark/test_fallback_policy.py tests/unit/benchmark/test_snqi_campaign_contract.py \
    tests/tools/test_run_camera_ready_benchmark.py tests/tools/test_run_camera_ready_benchmark_wave3.py \
    tests/benchmark/test_issue_4247_snqi_canonical_contract.py -q
65 passed

# Lint/format on changed files
$ uv run ruff check <changed files>   &&   uv run ruff format --check <changed files>
All checks passed / All files already formatted
```

## Evidence classification

- **Evidence tier:** targeted unit + integration (CPU), no campaigns/Slurm/training. The end-to-end warn-mode test drives `run_campaign` with a mocked batch runner and a real SNQI contract evaluation, exercising the changed exit-code/summary path.
- **Scope honesty:** the issue reports a specific Slurm run that "exited 5". The exact Slurm/ledger remapping that produced exit code 5 is **out of scope** per the issue ("any retrieval of job 13274 — ops handles that"). This PR hardens the two Python layers the issue names (`campaign.py` exit/summary path and the `run_camera_ready_benchmark.py` wrapper) so a soft contract warning provably cannot change the exit code, and adds the required `soft_contract_warning` observability flag. If a separate Slurm-wrapper layer remaps exit codes downstream, that is tracked by #5244.
- **`output/` artifacts:** none produced; no durable artifact propagation needed.

## Downstream propagation

NA — runtime exit-code/summary-plumbing fix with additive, backward-compatible summary key; no benchmark result, metric, schema-version, or model-provenance change.

Refs #5240

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
