### PR TITLE
Issue #5241: predictive-checkpoint schema audit + auto-filtered campaign configs (cheap-lane worker)

### DIFF
--- a/configs/benchmarks/paper_experiment_matrix_v1_gap_prediction_compare_schema_filtered.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_gap_prediction_compare_schema_filtered.yaml
@@ -1,0 +1,90 @@
+name: paper_experiment_matrix_v1_gap_prediction_compare
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: eval
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 2
+horizon: 100
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: false
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- planner_group: experimental
+  benchmark_profile: experimental
+  socnav_missing_prereq_policy: fail-fast
+  key: prediction_planner_v2_full
+  algo: prediction_planner
+  algo_config: configs/algos/prediction_planner_camera_ready.yaml
+- planner_group: experimental
+  benchmark_profile: experimental
+  socnav_missing_prereq_policy: fail-fast
+  key: gap_prediction
+  algo: gap_prediction
+  algo_config: configs/algos/gap_prediction_camera_ready.yaml
+schema_excluded_arms:
+- key: prediction_planner_v2_xl_ego
+  algo: prediction_planner
+  checkpoint_ref: predictive_proxy_selected_v2_xl_ego
+  checkpoint_kind: model_id
+  expected_schema: predictive_legacy_v1
+  checkpoint_schema: predictive_ego_v1
+  checkpoint_input_dim: 9
+  reason: 'schema mismatch: checkpoint declares ''predictive_ego_v1'' (input_dim=9),
+    runtime expects ''predictive_legacy_v1'': Predictive feature schema mismatch:
+    expected ''predictive_legacy_v1'', got ''predictive_ego_v1'''
+schema_audit:
+  source_config: configs/benchmarks/paper_experiment_matrix_v1_gap_prediction_compare.yaml
+  tool: scripts/tools/audit_predictive_checkpoint_schema.py
+  staged: true
+  excluded_arm_count: 1
+  uninspected_arm_count: 0
+  note: 'Incompatible predictive arms removed by CPU-only checkpoint-schema audit;
+    see schema_excluded_arms for per-arm provenance (issue #5241).'

--- a/configs/benchmarks/paper_experiment_matrix_v1_mppi_social_compare_schema_filtered.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_mppi_social_compare_schema_filtered.yaml
@@ -1,0 +1,88 @@
+name: paper_experiment_matrix_v1_mppi_social_compare
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+amv_profile:
+  name: amv-paper-v1
+  contract_version: '1'
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case:
+    - delivery_robot
+    - shared_space_micromobility
+    context:
+    - sidewalk
+    - shared_space
+    speed_regime:
+    - walking_speed
+    - scooter_speed
+    maneuver_type:
+    - overtake
+    - crossing
+    - bottleneck
+seed_policy:
+  mode: seed-set
+  seed_set: eval
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+workers: 2
+horizon: 100
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: true
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix:
+- differential_drive
+export_publication_bundle: false
+include_videos_in_publication: false
+overwrite_publication_bundle: true
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: '{release_tag}'
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: baseline-ready-core
+planners:
+- key: prediction_planner_v2_full
+  algo: prediction_planner
+  planner_group: experimental
+  algo_config: configs/algos/prediction_planner_camera_ready.yaml
+  benchmark_profile: experimental
+- key: mppi_social
+  algo: mppi_social
+  planner_group: experimental
+  algo_config: configs/algos/mppi_social_camera_ready.yaml
+  benchmark_profile: experimental
+schema_excluded_arms:
+- key: prediction_planner_v2_xl_ego
+  algo: prediction_planner
+  checkpoint_ref: predictive_proxy_selected_v2_xl_ego
+  checkpoint_kind: model_id
+  expected_schema: predictive_legacy_v1
+  checkpoint_schema: predictive_ego_v1
+  checkpoint_input_dim: 9
+  reason: 'schema mismatch: checkpoint declares ''predictive_ego_v1'' (input_dim=9),
+    runtime expects ''predictive_legacy_v1'': Predictive feature schema mismatch:
+    expected ''predictive_legacy_v1'', got ''predictive_ego_v1'''
+schema_audit:
+  source_config: configs/benchmarks/paper_experiment_matrix_v1_mppi_social_compare.yaml
+  tool: scripts/tools/audit_predictive_checkpoint_schema.py
+  staged: true
+  excluded_arm_count: 1
+  uninspected_arm_count: 0
+  note: 'Incompatible predictive arms removed by CPU-only checkpoint-schema audit;
+    see schema_excluded_arms for per-arm provenance (issue #5241).'

--- a/robot_sf/benchmark/predictive_checkpoint_schema_audit.py
+++ b/robot_sf/benchmark/predictive_checkpoint_schema_audit.py
@@ -1,0 +1,673 @@
+"""CPU-only schema-compatibility audit for predictive-planner campaign arms (issue #5241).
+
+A gap-prediction comparison campaign halted mid-run because one predictive checkpoint
+(``prediction_planner_v2_xl_ego``, job 13194) declared an obstacle-feature schema that the
+runtime planner config did not expect -- raising ``ObstacleFeatureSchemaError`` under
+``stop_on_failure=true`` and killing 144 jobs. The maintainer decision (do not retrain, do not
+write a compat shim) is to make checkpoint<->schema compatibility *checkable before submission*
+and to auto-exclude incompatible arms with an explicit manifest note.
+
+This module is the provenance owner for that preflight. For every predictive planner arm in a
+camera-ready campaign config it:
+
+1. Resolves the arm checkpoint (from ``predictive_model_id`` via the model registry, or a direct
+   ``predictive_checkpoint_path``) -- optionally staging registry artifacts into the durable
+   cache, but always CPU-only.
+2. Loads *only* the checkpoint metadata / feature spec
+   (``torch.load(..., map_location="cpu", weights_only=True)``). It never instantiates the model
+   and never touches a GPU: the comparison reads ``config.input_dim`` /
+   ``config.feature_schema_name`` / the saved ``feature_schema`` block only.
+3. Reuses the *exact* comparison the runtime load path performs
+   (``robot_sf.planner.predictive_model.load_predictive_checkpoint`` ->
+   ``validate_predictive_feature_schema_metadata``) to classify the arm COMPAT or INCOMPAT.
+4. Emits a filtered copy of the campaign config with incompatible arms removed and a
+   top-level ``schema_excluded_arms`` provenance list so exclusion is recorded, not silent.
+
+Claim boundary: this is a CPU-only preflight / config-filtering tool. It does not run a
+benchmark and is not benchmark evidence by itself. ``COMPAT`` means the checkpoint metadata is
+schema-valid for the arm's configured expected schema; it is not a training-quality or
+metric-correctness claim.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from loguru import logger
+
+from robot_sf.models import resolve_model_path
+from robot_sf.planner.obstacle_features import (
+    PREDICTIVE_LEGACY_FEATURE_SCHEMA,
+    ObstacleFeatureSchemaError,
+    infer_predictive_feature_schema,
+    validate_predictive_feature_schema_metadata,
+)
+from robot_sf.planner.predictive_model import PredictiveModelConfig
+
+if TYPE_CHECKING:
+    from robot_sf.benchmark.camera_ready._config_types import CampaignConfig, PlannerSpec
+
+# Algos whose arms carry a predictive checkpoint that must be schema-audited. ``gap_prediction``
+# is the gap-aware predictive planner and reuses the predictive checkpoint + feature schema.
+_PREDICTIVE_ALGOS: frozenset[str] = frozenset({"prediction_planner", "gap_prediction"})
+
+# Status values an audited arm can take. Only ``INCOMPAT`` causes arm exclusion; ``COMPAT`` is the
+# success state. The remaining statuses are honest "could not classify" outcomes that leave the arm
+# in place (the tool never silently drops an arm it could not inspect).
+STATUS_COMPAT = "COMPAT"
+STATUS_INCOMPAT = "INCOMPAT"
+STATUS_NOT_PREDICTIVE = "NOT_PREDICTIVE"
+STATUS_NO_CHECKPOINT = "NO_CHECKPOINT"
+STATUS_UNRESOLVABLE = "UNRESOLVABLE"
+STATUS_UNSTAGED = "UNSTAGED"
+STATUS_CORRUPT = "CORRUPT"
+
+# Statuses for which the arm is *actionable* (it is predictive and carries a checkpoint reference
+# the audit attempted to classify). Non-predictive / no-checkpoint arms are informational only.
+_ACTIONABLE_STATUSES: frozenset[str] = frozenset(
+    {STATUS_COMPAT, STATUS_INCOMPAT, STATUS_UNRESOLVABLE, STATUS_UNSTAGED, STATUS_CORRUPT}
+)
+
+
+@dataclass(frozen=True)
+class SchemaAuditArmResult:
+    """Schema-compatibility outcome for a single predictive campaign arm."""
+
+    arm_key: str
+    algo: str
+    checkpoint_ref: str
+    checkpoint_kind: str  # "model_id" or "checkpoint_path"
+    resolved_path: Path | None
+    expected_schema: str | None
+    checkpoint_schema: str | None
+    checkpoint_input_dim: int | None
+    status: str
+    detail: str
+    algo_config_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class SchemaAuditResult:
+    """Aggregate schema-audit outcome for a campaign config."""
+
+    config_path: Path
+    arms: list[SchemaAuditArmResult] = field(default_factory=list)
+    staged: bool = False
+
+    @property
+    def incompatible_arms(self) -> list[SchemaAuditArmResult]:
+        """Return only the arms classified COMPAT-failing (schema-mismatched)."""
+        return [arm for arm in self.arms if arm.status == STATUS_INCOMPAT]
+
+    @property
+    def actionable_arms(self) -> list[SchemaAuditArmResult]:
+        """Return the arms the audit actually inspected (predictive + has checkpoint)."""
+        return [arm for arm in self.arms if arm.status in _ACTIONABLE_STATUSES]
+
+    def to_manifest(self) -> dict[str, Any]:
+        """Return a JSON-compatible manifest of the audit (for PR bodies / reports).
+
+        Returns:
+            dict[str, Any]: Per-arm schema-audit rows plus a summary.
+        """
+        return {
+            "config_path": str(self.config_path),
+            "staged": bool(self.staged),
+            "arm_count": len(self.arms),
+            "incompatible_arm_count": len(self.incompatible_arms),
+            "arms": [
+                {
+                    "arm_key": arm.arm_key,
+                    "algo": arm.algo,
+                    "checkpoint_ref": arm.checkpoint_ref,
+                    "checkpoint_kind": arm.checkpoint_kind,
+                    "resolved_path": str(arm.resolved_path)
+                    if arm.resolved_path is not None
+                    else None,
+                    "expected_schema": arm.expected_schema,
+                    "checkpoint_schema": arm.checkpoint_schema,
+                    "checkpoint_input_dim": arm.checkpoint_input_dim,
+                    "status": arm.status,
+                    "detail": arm.detail,
+                }
+                for arm in self.arms
+            ],
+        }
+
+
+def _is_predictive_arm(planner: PlannerSpec) -> bool:
+    """Return True when an arm is a predictive-planner family arm carrying a checkpoint config."""
+    if not planner.enabled:
+        return False
+    if planner.algo and planner.algo.strip().lower() in _PREDICTIVE_ALGOS:
+        return True
+    # Fall back to config inspection so a predictive arm that uses a non-standard algo name but
+    # declares a predictive checkpoint is still covered.
+    if planner.algo_config_path is None:
+        return False
+    algo_config = _load_algo_config_dict(planner.algo_config_path)
+    return "predictive_model_id" in algo_config or "predictive_checkpoint_path" in algo_config
+
+
+def _load_algo_config_dict(path: Path) -> dict[str, Any]:
+    """Load an arm's algo_config YAML as a mapping (empty when missing/non-mapping).
+
+    Returns:
+        dict[str, Any]: Parsed config mapping (empty for a missing file or non-mapping YAML).
+    """
+    if not path.is_file():
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return data if isinstance(data, dict) else {}
+
+
+def load_predictive_checkpoint_metadata(
+    path: str | Path,
+) -> dict[str, Any]:
+    """Load ONLY the predictive-checkpoint metadata/feature spec (never instantiate the model).
+
+    This mirrors the metadata read in
+    :func:`robot_sf.planner.predictive_model.load_predictive_checkpoint` but stops short of
+    instantiating :class:`PredictiveTrajectoryModel` or moving any tensor to a device: it reads
+    the ``config`` / ``feature_schema`` payload blocks on CPU with ``weights_only=True`` only.
+
+    Args:
+        path: Checkpoint file path.
+
+    Returns:
+        dict[str, Any]: A metadata view with keys ``config`` (the saved
+        :class:`PredictiveModelConfig` dict), ``feature_schema`` (the saved schema metadata, when
+        present), ``epoch`` and ``source_path``.
+
+    Raises:
+        FileNotFoundError: When ``path`` does not exist.
+        RuntimeError: When the payload is not a recognizable predictive checkpoint mapping.
+    """
+    checkpoint = Path(path)
+    if not checkpoint.exists():
+        raise FileNotFoundError(f"Predictive checkpoint not found: {checkpoint}")
+    # Late import keeps the module importable in torch-optional environments; the audit itself
+    # requires torch and surfaces a clear error at call time if it is unavailable.
+    import torch  # noqa: PLC0415
+
+    payload = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"Predictive checkpoint payload is not a mapping: {checkpoint} ({type(payload)!r})"
+        )
+    return {
+        "config": payload.get("config") or {},
+        "feature_schema": payload.get("feature_schema"),
+        "epoch": payload.get("epoch"),
+        "source_path": checkpoint,
+    }
+
+
+def _classify_arm_schema(
+    metadata: dict[str, Any],
+    *,
+    expected_schema_name: str,
+) -> tuple[str, str, str | None, int | None]:
+    """Classify checkpoint metadata against an expected schema name.
+
+    Reuses the *exact* runtime comparison (``validate_predictive_feature_schema_metadata`` with the
+    checkpoint's own ``config.input_dim``), so ``INCOMPAT`` here is the same condition that raises
+    ``ObstacleFeatureSchemaError`` when the planner loads the model at runtime.
+
+    Args:
+        metadata: Checkpoint metadata view from :func:`load_predictive_checkpoint_metadata`.
+        expected_schema_name: The runtime/planner-config expected feature schema name.
+
+    Returns:
+        tuple of ``(status, detail, checkpoint_schema_name, checkpoint_input_dim)``.
+    """
+    config_data = metadata.get("config") or {}
+    try:
+        config = PredictiveModelConfig(**config_data)
+    except TypeError as exc:
+        return (
+            STATUS_CORRUPT,
+            f"checkpoint config is not a valid PredictiveModelConfig: {exc}",
+            None,
+            None,
+        )
+    input_dim = int(config.input_dim)
+
+    feature_schema = metadata.get("feature_schema")
+    if not isinstance(feature_schema, dict):
+        # Mirror load_predictive_checkpoint: infer from input_dim when the checkpoint pre-dates the
+        # feature_schema block (e.g. the v1/v2_full checkpoints).
+        feature_schema = infer_predictive_feature_schema(input_dim)
+
+    checkpoint_schema_name = str(feature_schema.get("name") or "").strip() or None
+    try:
+        validate_predictive_feature_schema_metadata(
+            feature_schema,
+            input_dim=input_dim,
+            expected_schema_name=str(expected_schema_name),
+        )
+    except ObstacleFeatureSchemaError as exc:
+        return (
+            STATUS_INCOMPAT,
+            (
+                f"schema mismatch: checkpoint declares {checkpoint_schema_name!r} "
+                f"(input_dim={input_dim}), runtime expects {expected_schema_name!r}: {exc}"
+            ),
+            checkpoint_schema_name,
+            input_dim,
+        )
+    return (
+        STATUS_COMPAT,
+        (
+            f"checkpoint schema {checkpoint_schema_name!r} (input_dim={input_dim}) "
+            f"matches runtime expected {expected_schema_name!r}"
+        ),
+        checkpoint_schema_name,
+        input_dim,
+    )
+
+
+def _resolve_checkpoint_path(
+    arm_key: str,
+    algo_config: dict[str, Any],
+    *,
+    stage: bool,
+    registry_path: str | Path | None,
+    cache_dir: str | Path | None,
+) -> tuple[str, str, Path | None, str, str]:
+    """Resolve an arm's checkpoint reference to a local path.
+
+    Returns:
+        tuple of ``(checkpoint_ref, checkpoint_kind, resolved_path, status, detail)`` where
+        ``status`` is empty when resolution succeeded, otherwise one of the non-COMPAT statuses.
+    """
+    model_id = algo_config.get("predictive_model_id")
+    checkpoint_path = algo_config.get("predictive_checkpoint_path")
+    if isinstance(model_id, str) and model_id.strip():
+        ref = model_id.strip()
+        kind = "model_id"
+        try:
+            path = resolve_model_path(
+                ref,
+                registry_path=registry_path,
+                allow_download=bool(stage),
+                cache_dir=cache_dir,
+            )
+        except FileNotFoundError as exc:
+            return (
+                ref,
+                kind,
+                None,
+                STATUS_UNSTAGED,
+                (f"model_id {ref!r} is not present locally and --stage was not set: {exc}"),
+            )
+        except (KeyError, RuntimeError, ValueError, OSError) as exc:
+            return (
+                ref,
+                kind,
+                None,
+                STATUS_UNRESOLVABLE,
+                (f"model_id {ref!r} could not be resolved: {type(exc).__name__}: {exc}"),
+            )
+        if not path.is_file():
+            return (
+                ref,
+                kind,
+                None,
+                STATUS_UNRESOLVABLE,
+                (f"model_id {ref!r} resolved to {path} but no checkpoint file is present"),
+            )
+        return ref, kind, path, "", ""
+    if isinstance(checkpoint_path, str) and checkpoint_path.strip():
+        ref = checkpoint_path.strip()
+        kind = "checkpoint_path"
+        path = Path(ref)
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        if not path.is_file():
+            return ref, kind, None, STATUS_UNRESOLVABLE, f"checkpoint_path file not found: {path}"
+        return ref, kind, path, "", ""
+    return (
+        "",
+        "",
+        None,
+        STATUS_NO_CHECKPOINT,
+        (
+            f"predictive arm {arm_key!r} declares no predictive_model_id / predictive_checkpoint_path"
+        ),
+    )
+
+
+def audit_predictive_checkpoint_schema(
+    cfg: CampaignConfig,
+    *,
+    stage: bool = False,
+    registry_path: str | Path | None = None,
+    cache_dir: str | Path | None = None,
+) -> SchemaAuditResult:
+    """Audit every predictive arm's checkpoint schema compatibility (CPU-only).
+
+    Args:
+        cfg: A loaded camera-ready campaign config.
+        stage: When True, stage registry-backed checkpoints into the durable cache before reading
+            metadata (CPU download; still no model instantiation / no GPU). When False (default),
+            only arms whose checkpoint is already present locally are classified; unstaged arms are
+            reported ``UNSTAGED`` rather than silently skipped.
+        registry_path: Optional model-registry path override (useful for tests/fixtures).
+        cache_dir: Optional cache directory override for staged downloads.
+
+    Returns:
+        SchemaAuditResult: Per-arm schema-compatibility outcome.
+    """
+    arms: list[SchemaAuditArmResult] = []
+    for planner in cfg.planners:
+        if not _is_predictive_arm(planner):
+            arms.append(
+                SchemaAuditArmResult(
+                    arm_key=planner.key,
+                    algo=planner.algo,
+                    checkpoint_ref="",
+                    checkpoint_kind="",
+                    resolved_path=None,
+                    expected_schema=None,
+                    checkpoint_schema=None,
+                    checkpoint_input_dim=None,
+                    status=STATUS_NOT_PREDICTIVE,
+                    detail="arm is not a predictive-planner family arm (no checkpoint to audit)",
+                    algo_config_path=(
+                        planner.algo_config_path if planner.algo_config_path is not None else None
+                    ),
+                )
+            )
+            continue
+
+        algo_config_path = (
+            planner.algo_config_path if planner.algo_config_path is not None else None
+        )
+        algo_config = (
+            _load_algo_config_dict(algo_config_path) if algo_config_path is not None else {}
+        )
+        expected_schema_name = str(
+            algo_config.get("predictive_feature_schema_name") or PREDICTIVE_LEGACY_FEATURE_SCHEMA
+        ).strip()
+
+        ref, kind, resolved, status, detail = _resolve_checkpoint_path(
+            planner.key,
+            algo_config,
+            stage=stage,
+            registry_path=registry_path,
+            cache_dir=cache_dir,
+        )
+        if status:
+            arms.append(
+                SchemaAuditArmResult(
+                    arm_key=planner.key,
+                    algo=planner.algo,
+                    checkpoint_ref=ref,
+                    checkpoint_kind=kind,
+                    resolved_path=resolved,
+                    expected_schema=expected_schema_name,
+                    checkpoint_schema=None,
+                    checkpoint_input_dim=None,
+                    status=status,
+                    detail=detail,
+                    algo_config_path=algo_config_path,
+                )
+            )
+            continue
+
+        assert resolved is not None  # resolution succeeded with a file
+        try:
+            metadata = load_predictive_checkpoint_metadata(resolved)
+        except (FileNotFoundError, RuntimeError, ValueError, OSError, EOFError) as exc:
+            arms.append(
+                SchemaAuditArmResult(
+                    arm_key=planner.key,
+                    algo=planner.algo,
+                    checkpoint_ref=ref,
+                    checkpoint_kind=kind,
+                    resolved_path=resolved,
+                    expected_schema=expected_schema_name,
+                    checkpoint_schema=None,
+                    checkpoint_input_dim=None,
+                    status=STATUS_CORRUPT,
+                    detail=f"could not read checkpoint metadata: {type(exc).__name__}: {exc}",
+                    algo_config_path=algo_config_path,
+                )
+            )
+            continue
+
+        status_c, detail_c, checkpoint_schema, input_dim = _classify_arm_schema(
+            metadata, expected_schema_name=expected_schema_name
+        )
+        arms.append(
+            SchemaAuditArmResult(
+                arm_key=planner.key,
+                algo=planner.algo,
+                checkpoint_ref=ref,
+                checkpoint_kind=kind,
+                resolved_path=resolved,
+                expected_schema=expected_schema_name,
+                checkpoint_schema=checkpoint_schema,
+                checkpoint_input_dim=input_dim,
+                status=status_c,
+                detail=detail_c,
+                algo_config_path=algo_config_path,
+            )
+        )
+
+    actionable = [arm for arm in arms if arm.status in _ACTIONABLE_STATUSES]
+    incompatible = [arm for arm in arms if arm.status == STATUS_INCOMPAT]
+    logger.info(
+        "Predictive checkpoint schema audit: {} actionable arm(s), {} INCOMPAT, {} unstaged/unresolvable.",
+        len(actionable),
+        len(incompatible),
+        sum(1 for arm in arms if arm.status in {STATUS_UNSTAGED, STATUS_UNRESOLVABLE}),
+    )
+    return SchemaAuditResult(
+        arms=arms, staged=bool(stage), config_path=Path(getattr(cfg, "name", "") or "")
+    )
+
+
+def audit_predictive_checkpoint_schema_from_config(
+    config_path: str | Path,
+    *,
+    stage: bool = False,
+    registry_path: str | Path | None = None,
+    cache_dir: str | Path | None = None,
+) -> SchemaAuditResult:
+    """Load a campaign config and run the predictive checkpoint schema audit.
+
+    Args:
+        config_path: Path to a camera-ready campaign config YAML.
+        stage: When True, stage registry-backed checkpoints into the durable cache first.
+        registry_path: Optional model-registry path override.
+        cache_dir: Optional cache directory override for staged downloads.
+
+    Returns:
+        SchemaAuditResult: Per-arm schema-compatibility outcome.
+    """
+    from robot_sf.benchmark.camera_ready_campaign import (  # noqa: PLC0415
+        load_campaign_config,
+    )
+
+    resolved = Path(config_path).resolve()
+    cfg = load_campaign_config(resolved)
+    result = audit_predictive_checkpoint_schema(
+        cfg,
+        stage=stage,
+        registry_path=registry_path,
+        cache_dir=cache_dir,
+    )
+    # ``name`` on CampaignConfig is the human label; carry the actual config path for provenance.
+    return SchemaAuditResult(arms=result.arms, staged=result.staged, config_path=resolved)
+
+
+def format_schema_audit_table(result: SchemaAuditResult) -> str:
+    """Render the per-arm schema-audit table (arm | checkpoint | expected | current | status).
+
+    Args:
+        result: The audit result to render.
+
+    Returns:
+        str: A fixed-width human-readable audit table plus a summary footer.
+    """
+    headers = ("arm", "checkpoint", "expected-schema", "current-schema", "status")
+    rows: list[tuple[str, str, str, str, str]] = []
+    for arm in result.arms:
+        rows.append(
+            (
+                arm.arm_key,
+                arm.checkpoint_ref or "-",
+                arm.expected_schema or "-",
+                arm.checkpoint_schema or "-",
+                arm.status,
+            )
+        )
+
+    def _width(idx: int) -> int:
+        return (
+            max(len(headers[idx]), *(len(row[idx]) for row in rows)) if rows else len(headers[idx])
+        )
+
+    widths = [_width(i) for i in range(len(headers))]
+    sep = "  ".join("-" * w for w in widths)
+    header_line = "  ".join(h.ljust(widths[i]) for i, h in enumerate(headers))
+    lines = [header_line, sep]
+    for row in rows:
+        lines.append("  ".join(col.ljust(widths[i]) for i, col in enumerate(row)))
+    incompatible = len(result.incompatible_arms)
+    actionable = len(result.actionable_arms)
+    lines.append("")
+    lines.append(
+        f"summary: {actionable} predictive arm(s) inspected, {incompatible} INCOMPAT, "
+        f"staged={'yes' if result.staged else 'no'}"
+    )
+    for arm in result.incompatible_arms:
+        lines.append(f"  INCOMPAT {arm.arm_key}: {arm.detail}")
+    return "\n".join(lines)
+
+
+def emit_schema_filtered_config(
+    config_path: str | Path,
+    result: SchemaAuditResult,
+    out_path: str | Path,
+) -> Path:
+    """Write a copy of ``config_path`` with INCOMPAT arms removed and exclusions recorded.
+
+    Only arms the audit classified ``INCOMPAT`` are removed. Arms it could not inspect
+    (``UNSTAGED`` / ``UNRESOLVABLE`` / ``CORRUPT``) are left in place and listed under
+    ``schema_audit_uninspected_arms`` so a human decides; the tool never silently drops an arm it
+    could not read. A ``schema_excluded_arms`` provenance list records each removed arm with its
+    checkpoint and mismatch reason.
+
+    Args:
+        config_path: Source campaign config path.
+        result: The audit result driving the filtering.
+        out_path: Destination path for the filtered config.
+
+    Returns:
+        Path: The resolved output path that was written.
+    """
+    source = Path(config_path).resolve()
+    data = yaml.safe_load(source.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise TypeError(f"Campaign config must be a mapping: {source}")
+
+    try:
+        from robot_sf.common.artifact_paths import (  # noqa: PLC0415
+            get_repository_root,
+        )
+
+        repo_root = Path(get_repository_root())
+    except (ImportError, RuntimeError, OSError):  # pragma: no cover - best-effort provenance
+        repo_root = source.parent
+    try:
+        source_rel = source.relative_to(repo_root) if repo_root in source.parents else source
+    except ValueError:
+        source_rel = source
+
+    incompatible_keys = {arm.arm_key for arm in result.incompatible_arms}
+    uninspected = [
+        arm
+        for arm in result.arms
+        if arm.status in {STATUS_UNSTAGED, STATUS_UNRESOLVABLE, STATUS_CORRUPT}
+    ]
+
+    original_planners = data.get("planners", [])
+    kept_planners: list[Any] = []
+    for planner in original_planners:
+        key = planner.get("key") if isinstance(planner, dict) else None
+        if key in incompatible_keys:
+            continue
+        kept_planners.append(planner)
+    data["planners"] = kept_planners
+
+    excluded_records = [
+        {
+            "key": arm.arm_key,
+            "algo": arm.algo,
+            "checkpoint_ref": arm.checkpoint_ref,
+            "checkpoint_kind": arm.checkpoint_kind,
+            "expected_schema": arm.expected_schema,
+            "checkpoint_schema": arm.checkpoint_schema,
+            "checkpoint_input_dim": arm.checkpoint_input_dim,
+            "reason": arm.detail,
+        }
+        for arm in result.incompatible_arms
+    ]
+    uninspected_records = [
+        {
+            "key": arm.arm_key,
+            "algo": arm.algo,
+            "checkpoint_ref": arm.checkpoint_ref,
+            "checkpoint_kind": arm.checkpoint_kind,
+            "status": arm.status,
+            "reason": arm.detail,
+        }
+        for arm in uninspected
+    ]
+    # Provenance header so exclusion is recorded, not silent (issue #5241 decision).
+    data["schema_excluded_arms"] = excluded_records
+    if uninspected_records:
+        data["schema_audit_uninspected_arms"] = uninspected_records
+    data["schema_audit"] = {
+        "source_config": str(source_rel),
+        "tool": "scripts/tools/audit_predictive_checkpoint_schema.py",
+        "staged": bool(result.staged),
+        "excluded_arm_count": len(excluded_records),
+        "uninspected_arm_count": len(uninspected_records),
+        "note": (
+            "Incompatible predictive arms removed by CPU-only checkpoint-schema audit; "
+            "see schema_excluded_arms for per-arm provenance (issue #5241)."
+        ),
+    }
+
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        yaml.safe_dump(data, sort_keys=False, default_flow_style=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    return out.resolve()
+
+
+__all__ = [
+    "STATUS_COMPAT",
+    "STATUS_CORRUPT",
+    "STATUS_INCOMPAT",
+    "STATUS_NOT_PREDICTIVE",
+    "STATUS_NO_CHECKPOINT",
+    "STATUS_UNRESOLVABLE",
+    "STATUS_UNSTAGED",
+    "SchemaAuditArmResult",
+    "SchemaAuditResult",
+    "audit_predictive_checkpoint_schema",
+    "audit_predictive_checkpoint_schema_from_config",
+    "emit_schema_filtered_config",
+    "format_schema_audit_table",
+    "load_predictive_checkpoint_metadata",
+]

--- a/robot_sf/benchmark/predictive_checkpoint_schema_audit.py
+++ b/robot_sf/benchmark/predictive_checkpoint_schema_audit.py
@@ -44,6 +44,7 @@ from robot_sf.planner.obstacle_features import (
     ObstacleFeatureSchemaError,
     infer_predictive_feature_schema,
     validate_predictive_feature_schema_metadata,
+    validate_predictive_runtime_feature_schema,
 )
 from robot_sf.planner.predictive_model import PredictiveModelConfig
 
@@ -249,6 +250,7 @@ def _classify_arm_schema(
             input_dim=input_dim,
             expected_schema_name=str(expected_schema_name),
         )
+        validate_predictive_runtime_feature_schema(feature_schema)
     except ObstacleFeatureSchemaError as exc:
         return (
             STATUS_INCOMPAT,

--- a/robot_sf/planner/obstacle_features.py
+++ b/robot_sf/planner/obstacle_features.py
@@ -650,3 +650,32 @@ def validate_predictive_feature_schema_metadata(
                 f"Predictive {feature_label} feature dimension mismatch: "
                 f"expected {expected_base_dim}, got {int(input_dim)}"
             )
+
+
+def validate_predictive_runtime_feature_schema(metadata: dict[str, object]) -> None:
+    """Reject ego-conditioned checkpoints whose motion-channel producer differs from runtime.
+
+    The structural schema validator accepts either registered ego-motion producer so that
+    artifacts remain self-describing. Runtime planning is stricter: its generated robot-speed
+    channels must use the same producer as the checkpoint. Keep this comparison shared so
+    CPU-only preflight audits and :class:`PredictionPlannerAdapter` fail on the same condition.
+    """
+    if not isinstance(metadata, dict):
+        return
+    if str(metadata.get("base_schema") or "").strip() != PREDICTIVE_EGO_FEATURE_SCHEMA:
+        return
+    actual_producer = predictive_ego_motion_channel_producer_key(metadata)
+    if actual_producer is None:
+        return
+    expected_producer = predictive_ego_motion_channel_producer_key(
+        predictive_feature_schema_metadata(
+            model_family=str(metadata.get("name") or ""),
+            ego_conditioning=True,
+            ego_motion_channel_producer=PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME,
+        )
+    )
+    if actual_producer != expected_producer:
+        raise ObstacleFeatureSchemaError(
+            "Predictive ego motion producer mismatch: "
+            f"runtime expects {expected_producer!r}, got {actual_producer!r}"
+        )

--- a/robot_sf/planner/socnav.py
+++ b/robot_sf/planner/socnav.py
@@ -49,17 +49,13 @@ except ImportError:  # pragma: no cover - optional dependency
 from robot_sf.models import resolve_model_path
 from robot_sf.nav.occupancy_grid_utils import world_to_ego
 from robot_sf.planner.obstacle_features import (
-    PREDICTIVE_EGO_FEATURE_SCHEMA,
-    PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME,
     PREDICTIVE_OBSTACLE_FEATURE_SCHEMA,
     LocalObstacleFeatureExtractor,
-    ObstacleFeatureSchemaError,
     infer_predictive_feature_schema,
     normalize_obstacle_lines,
     obstacle_lines_from_map,
     obstacle_lines_from_observation,
-    predictive_ego_motion_channel_producer_key,
-    predictive_feature_schema_metadata,
+    validate_predictive_runtime_feature_schema,
 )
 
 try:  # pragma: no cover - exercised in minimal environments without torch
@@ -3645,26 +3641,7 @@ class PredictionPlannerAdapter(SamplingPlannerAdapter):
 
     def _validate_runtime_feature_schema(self, feature_schema: Any) -> None:
         """Reject explicit standalone-producer checkpoints against runtime speed semantics."""
-        if not isinstance(feature_schema, dict):
-            return
-        base_schema = str(feature_schema.get("base_schema") or "").strip()
-        if base_schema != PREDICTIVE_EGO_FEATURE_SCHEMA:
-            return
-        actual_producer = predictive_ego_motion_channel_producer_key(feature_schema)
-        if actual_producer is None:
-            return
-        expected_producer = predictive_ego_motion_channel_producer_key(
-            predictive_feature_schema_metadata(
-                model_family=str(feature_schema.get("name") or ""),
-                ego_conditioning=True,
-                ego_motion_channel_producer=PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME,
-            )
-        )
-        if actual_producer != expected_producer:
-            raise ObstacleFeatureSchemaError(
-                "Predictive ego motion producer mismatch: "
-                f"runtime expects {expected_producer!r}, got {actual_producer!r}"
-            )
+        validate_predictive_runtime_feature_schema(feature_schema)
 
     def _normalize_pedestrians(self, ped_state: dict) -> tuple[np.ndarray, np.ndarray]:
         """Normalize pedestrian positions and ego-frame velocities.

--- a/scripts/tools/audit_predictive_checkpoint_schema.py
+++ b/scripts/tools/audit_predictive_checkpoint_schema.py
@@ -1,0 +1,157 @@
+"""CPU-only schema-compatibility audit for predictive-planner campaign arms (issue #5241).
+
+For every predictive planner arm in a camera-ready campaign config, this tool loads *only* the
+checkpoint metadata / feature spec (never the full model, never a GPU) and reuses the exact
+runtime schema comparison (``validate_predictive_feature_schema_metadata``) to classify each arm
+COMPAT or INCOMPAT. With ``--emit-filtered-config`` it writes a copy of the campaign config with
+incompatible arms removed and a ``schema_excluded_arms`` provenance list, so exclusion is
+recorded rather than silent.
+
+This unblocks the gap-prediction and mppi-social comparison campaigns (job 13194: the
+``prediction_planner_v2_xl_ego`` checkpoint declared ``predictive_ego_v1`` while the runtime
+expected ``predictive_legacy_v1`` -> ``ObstacleFeatureSchemaError`` under ``stop_on_failure``).
+
+Modes:
+
+- default: classify arms whose checkpoint is present locally; report ``UNSTAGED`` for the rest.
+  Network-free. Run this for the audit table / filtered config when checkpoints are cached.
+- ``--stage``: stage registry-backed checkpoints into the durable cache (CPU download; still no
+  model instantiation / no GPU) before reading metadata, so every arm gets a definitive
+  COMPAT/INCOMPAT classification.
+
+Exit codes:
+
+- ``0`` -- audit completed (regardless of how many arms are INCOMPAT; the filtered config records
+  them). Check the table / report for INCOMPAT rows.
+- ``2`` -- the campaign config file is missing or unreadable.
+- ``3`` -- an unexpected error while staging or reading checkpoints (fail-closed).
+
+Examples:
+
+    # Audit + emit filtered config (checkpoints already cached locally):
+    uv run python scripts/tools/audit_predictive_checkpoint_schema.py \\
+        --config configs/benchmarks/paper_experiment_matrix_v1_gap_prediction_compare.yaml \\
+        --emit-filtered-config configs/benchmarks/paper_experiment_matrix_v1_gap_prediction_compare_schema_filtered.yaml
+
+    # Stage registry checkpoints first so every arm is classified:
+    uv run python scripts/tools/audit_predictive_checkpoint_schema.py --stage \\
+        --config configs/benchmarks/paper_experiment_matrix_v1_mppi_social_compare.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.predictive_checkpoint_schema_audit import (
+    audit_predictive_checkpoint_schema_from_config,
+    emit_schema_filtered_config,
+    format_schema_audit_table,
+)
+
+EXIT_OK = 0
+EXIT_CONFIG_ERROR = 2
+EXIT_AUDIT_ERROR = 3
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser.
+
+    Returns:
+        argparse.ArgumentParser: Configured parser.
+    """
+    parser = argparse.ArgumentParser(
+        description="CPU-only predictive-checkpoint schema audit + auto-filtered campaign configs "
+        "(issue #5241).",
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Camera-ready campaign config YAML to audit.",
+    )
+    parser.add_argument(
+        "--emit-filtered-config",
+        metavar="OUT.yaml",
+        default=None,
+        help="Write a copy of the campaign config with INCOMPAT arms removed and a "
+        "schema_excluded_arms provenance list.",
+    )
+    parser.add_argument(
+        "--stage",
+        action="store_true",
+        help="Stage registry-backed checkpoints into the durable cache (CPU download, no GPU) "
+        "before reading metadata so every arm is classified COMPAT/INCOMPAT.",
+    )
+    parser.add_argument(
+        "--report-path",
+        metavar="PATH",
+        default=None,
+        help="Optional path to write a JSON manifest of the per-arm audit.",
+    )
+    parser.add_argument(
+        "--registry-path",
+        default=None,
+        help="Optional model-registry path override (default: model/registry.yaml).",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help="Optional cache directory override for staged registry downloads.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the predictive-checkpoint schema audit CLI.
+
+    Returns:
+        int: Process exit code (0 ok, 2 config error, 3 audit error).
+    """
+    args = build_arg_parser().parse_args(argv)
+
+    config_path = Path(args.config)
+    if not config_path.is_file():
+        print(f"error: campaign config not found: {config_path}", file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+
+    try:
+        result = audit_predictive_checkpoint_schema_from_config(
+            config_path,
+            stage=bool(args.stage),
+            registry_path=args.registry_path,
+            cache_dir=args.cache_dir,
+        )
+    except FileNotFoundError as exc:
+        print(f"error: campaign config unreadable: {exc}", file=sys.stderr)
+        return EXIT_CONFIG_ERROR
+    except (RuntimeError, ValueError, OSError) as exc:
+        print(f"error: schema audit failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return EXIT_AUDIT_ERROR
+
+    print(format_schema_audit_table(result))
+    print()
+    if result.incompatible_arms:
+        print(
+            f"Found {len(result.incompatible_arms)} INCOMPAT arm(s); "
+            "use --emit-filtered-config to drop them with provenance."
+        )
+
+    if args.emit_filtered_config:
+        out = emit_schema_filtered_config(config_path, result, args.emit_filtered_config)
+        print(f"Wrote filtered config: {out}")
+
+    if args.report_path:
+        report = Path(args.report_path)
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text(
+            json.dumps(result.to_manifest(), indent=2, sort_keys=True), encoding="utf-8"
+        )
+        print(f"Wrote audit manifest: {report}")
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/benchmark/test_predictive_checkpoint_schema_audit.py
+++ b/tests/benchmark/test_predictive_checkpoint_schema_audit.py
@@ -1,0 +1,390 @@
+"""Tests for the predictive-checkpoint schema audit + config filter (issue #5241).
+
+CPU-only, network-free. Synthetic checkpoint-metadata fixtures (one schema-compatible, one not)
+prove the audit classifies both correctly and the filtered config drops exactly the incompatible
+arm with provenance.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from robot_sf.benchmark.camera_ready._config_types import (
+    CampaignConfig,
+    PlannerSpec,
+    SeedPolicy,
+)
+from robot_sf.benchmark.predictive_checkpoint_schema_audit import (
+    STATUS_COMPAT,
+    STATUS_INCOMPAT,
+    STATUS_NOT_PREDICTIVE,
+    audit_predictive_checkpoint_schema,
+    emit_schema_filtered_config,
+    format_schema_audit_table,
+)
+from robot_sf.planner.obstacle_features import (
+    PREDICTIVE_EGO_FEATURE_DIM,
+    PREDICTIVE_EGO_FEATURE_SCHEMA,
+    PREDICTIVE_LEGACY_FEATURE_DIM,
+    PREDICTIVE_LEGACY_FEATURE_SCHEMA,
+    predictive_feature_schema_metadata,
+)
+from robot_sf.planner.predictive_model import (
+    PredictiveModelConfig,
+    PredictiveTrajectoryModel,
+    save_predictive_checkpoint,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_registry(tmp_path: Path, models: list[dict]) -> Path:
+    """Write a minimal model registry YAML fixture and return its path."""
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(
+        yaml.safe_dump({"version": 1, "models": models}, sort_keys=False),
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def _write_algo_config(tmp_path: Path, name: str, payload: dict) -> Path:
+    """Write an arm algo_config YAML and return its path."""
+    path = tmp_path / name
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _campaign(planners: tuple[PlannerSpec, ...], *, tmp_path: Path) -> CampaignConfig:
+    """Build a minimal campaign config wrapping the given planner arms."""
+    scenario_path = tmp_path / "scenarios.yaml"
+    if not scenario_path.exists():
+        scenario_path.write_text("scenarios: []\n", encoding="utf-8")
+    return CampaignConfig(
+        name="schema_audit_test",
+        scenario_matrix_path=scenario_path,
+        planners=planners,
+        seed_policy=SeedPolicy(),
+    )
+
+
+def _save_legacy_checkpoint(tmp_path: Path, name: str) -> Path:
+    """Write a schema-compatible (legacy_v1, input_dim=4) predictive checkpoint."""
+    model = PredictiveTrajectoryModel(
+        PredictiveModelConfig(
+            input_dim=PREDICTIVE_LEGACY_FEATURE_DIM,
+            feature_schema_name=PREDICTIVE_LEGACY_FEATURE_SCHEMA,
+        )
+    )
+    path = tmp_path / "ckpt" / f"{name}.pt"
+    save_predictive_checkpoint(
+        path,
+        model=model,
+        optimizer=None,
+        epoch=1,
+        feature_schema_metadata=predictive_feature_schema_metadata(
+            model_family=PREDICTIVE_LEGACY_FEATURE_SCHEMA
+        ),
+    )
+    return path
+
+
+def _save_xl_ego_checkpoint(tmp_path: Path, name: str) -> Path:
+    """Write an ego-schema (predictive_ego_v1, input_dim=9) predictive checkpoint.
+
+    This mirrors the real ``predictive_proxy_selected_v2_xl_ego`` defect from job 13194: the
+    checkpoint declares the ego schema while the runtime planner config expects legacy_v1.
+    """
+    schema = predictive_feature_schema_metadata(
+        model_family=PREDICTIVE_EGO_FEATURE_SCHEMA,
+    )
+    model = PredictiveTrajectoryModel(
+        PredictiveModelConfig(
+            input_dim=PREDICTIVE_EGO_FEATURE_DIM,
+            feature_schema_name=PREDICTIVE_EGO_FEATURE_SCHEMA,
+        )
+    )
+    path = tmp_path / "ckpt" / f"{name}.pt"
+    save_predictive_checkpoint(
+        path,
+        model=model,
+        optimizer=None,
+        epoch=1,
+        feature_schema_metadata=schema,
+    )
+    return path
+
+
+# --- schema classification -------------------------------------------------
+
+
+def test_audit_classifies_compatible_and_incompatible_arms(tmp_path: Path) -> None:
+    """A legacy checkpoint is COMPAT; an ego checkpoint vs a legacy-expecting arm is INCOMPAT."""
+    compat_ckpt = _save_legacy_checkpoint(tmp_path, "compat")
+    incompat_ckpt = _save_xl_ego_checkpoint(tmp_path, "incompat")
+    registry = _write_registry(
+        tmp_path,
+        [
+            {"model_id": "compat_model", "local_path": str(compat_ckpt)},
+            {"model_id": "incompat_model", "local_path": str(incompat_ckpt)},
+        ],
+    )
+    compat_cfg = _write_algo_config(
+        tmp_path,
+        "compat.yaml",
+        {"predictive_model_id": "compat_model"},
+    )
+    incompat_cfg = _write_algo_config(
+        tmp_path,
+        "incompat.yaml",
+        # No explicit predictive_feature_schema_name -> runtime default legacy_v1 (the defect).
+        {"predictive_model_id": "incompat_model", "predictive_ego_conditioning": True},
+    )
+
+    campaign = _campaign(
+        (
+            PlannerSpec(
+                key="prediction_full", algo="prediction_planner", algo_config_path=compat_cfg
+            ),
+            PlannerSpec(
+                key="prediction_xl_ego", algo="prediction_planner", algo_config_path=incompat_cfg
+            ),
+        ),
+        tmp_path=tmp_path,
+    )
+
+    result = audit_predictive_checkpoint_schema(campaign, registry_path=registry)
+
+    by_key = {arm.arm_key: arm for arm in result.arms}
+    assert by_key["prediction_full"].status == STATUS_COMPAT
+    assert by_key["prediction_full"].checkpoint_schema == PREDICTIVE_LEGACY_FEATURE_SCHEMA
+    assert by_key["prediction_xl_ego"].status == STATUS_INCOMPAT
+    assert by_key["prediction_xl_ego"].checkpoint_schema == "predictive_ego_v1"
+    assert by_key["prediction_xl_ego"].expected_schema == PREDICTIVE_LEGACY_FEATURE_SCHEMA
+    assert [arm.arm_key for arm in result.incompatible_arms] == ["prediction_xl_ego"]
+
+
+def test_audit_explicit_expected_schema_can_match_ego_checkpoint(tmp_path: Path) -> None:
+    """An ego checkpoint is COMPAT when the algo config declares the ego expected schema."""
+    ego_ckpt = _save_xl_ego_checkpoint(tmp_path, "ego_ok")
+    registry = _write_registry(
+        tmp_path,
+        [{"model_id": "ego_model", "local_path": str(ego_ckpt)}],
+    )
+    algo_cfg = _write_algo_config(
+        tmp_path,
+        "ego.yaml",
+        {
+            "predictive_model_id": "ego_model",
+            "predictive_feature_schema_name": PREDICTIVE_EGO_FEATURE_SCHEMA,
+        },
+    )
+    campaign = _campaign(
+        (PlannerSpec(key="ego_arm", algo="prediction_planner", algo_config_path=algo_cfg),),
+        tmp_path=tmp_path,
+    )
+
+    result = audit_predictive_checkpoint_schema(campaign, registry_path=registry)
+    arm = result.arms[0]
+    assert arm.status == STATUS_COMPAT
+    assert arm.expected_schema == PREDICTIVE_EGO_FEATURE_SCHEMA
+
+
+def test_audit_skips_non_predictive_arms(tmp_path: Path) -> None:
+    """A non-predictive arm (no checkpoint) is reported NOT_PREDICTIVE, not audited."""
+    algo_cfg = _write_algo_config(
+        tmp_path,
+        "mppi.yaml",
+        {"algo": "mppi_social", "horizon_steps": 10},  # no predictive checkpoint
+    )
+    campaign = _campaign(
+        (PlannerSpec(key="mppi_social", algo="mppi_social", algo_config_path=algo_cfg),),
+        tmp_path=tmp_path,
+    )
+
+    result = audit_predictive_checkpoint_schema(campaign)
+    assert result.arms[0].status == STATUS_NOT_PREDICTIVE
+    assert result.incompatible_arms == []
+    assert result.actionable_arms == []
+
+
+# --- filtered config emission ----------------------------------------------
+
+
+def test_filtered_config_drops_exactly_the_incompatible_arm(tmp_path: Path) -> None:
+    """The filtered config removes only the INCOMPAT arm and records provenance."""
+    compat_ckpt = _save_legacy_checkpoint(tmp_path, "compat2")
+    incompat_ckpt = _save_xl_ego_checkpoint(tmp_path, "incompat2")
+    registry = _write_registry(
+        tmp_path,
+        [
+            {"model_id": "compat_model", "local_path": str(compat_ckpt)},
+            {"model_id": "incompat_model", "local_path": str(incompat_ckpt)},
+        ],
+    )
+    compat_cfg = _write_algo_config(
+        tmp_path,
+        "compat2.yaml",
+        {"predictive_model_id": "compat_model"},
+    )
+    incompat_cfg = _write_algo_config(
+        tmp_path,
+        "incompat2.yaml",
+        {"predictive_model_id": "incompat_model", "predictive_ego_conditioning": True},
+    )
+
+    # Source campaign config YAML (mirrors the real gap-prediction compare layout).
+    scenario_matrix = tmp_path / "scenarios.yaml"
+    scenario_matrix.write_text("scenarios: []\n", encoding="utf-8")
+    source_config = tmp_path / "campaign.yaml"
+    source_config.write_text(
+        yaml.safe_dump(
+            {
+                "name": "schema_filter_test",
+                "scenario_matrix": str(scenario_matrix),
+                "planners": [
+                    {
+                        "key": "prediction_full",
+                        "algo": "prediction_planner",
+                        "algo_config": str(compat_cfg),
+                    },
+                    {
+                        "key": "prediction_xl_ego",
+                        "algo": "prediction_planner",
+                        "algo_config": str(incompat_cfg),
+                    },
+                    {"key": "orca", "algo": "orca"},
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    from robot_sf.benchmark.camera_ready_campaign import load_campaign_config
+
+    cfg = load_campaign_config(source_config)
+    result = audit_predictive_checkpoint_schema(cfg, registry_path=registry)
+    assert [arm.arm_key for arm in result.incompatible_arms] == ["prediction_xl_ego"]
+
+    out_path = tmp_path / "campaign_schema_filtered.yaml"
+    written = emit_schema_filtered_config(source_config, result, out_path)
+    assert written == out_path.resolve()
+
+    filtered = yaml.safe_load(out_path.read_text(encoding="utf-8"))
+    remaining_keys = [p["key"] for p in filtered["planners"]]
+    assert remaining_keys == ["prediction_full", "orca"]  # exactly the incompatible arm dropped
+
+    excluded = filtered["schema_excluded_arms"]
+    assert len(excluded) == 1
+    assert excluded[0]["key"] == "prediction_xl_ego"
+    assert excluded[0]["checkpoint_ref"] == "incompat_model"
+    assert excluded[0]["expected_schema"] == PREDICTIVE_LEGACY_FEATURE_SCHEMA
+    assert excluded[0]["checkpoint_schema"] == "predictive_ego_v1"
+    assert filtered["schema_audit"]["excluded_arm_count"] == 1
+    assert "issue #5241" in filtered["schema_audit"]["note"]
+
+
+def test_filtered_config_leaves_uninspected_arms_in_place(tmp_path: Path) -> None:
+    """An unstaged arm is NOT dropped -- it is recorded as uninspected for a human to decide."""
+    compat_ckpt = _save_legacy_checkpoint(tmp_path, "compat3")
+    # Registry with a local-only, absent path -> resolves as UNSTAGED (no --stage).
+    registry = _write_registry(
+        tmp_path,
+        [
+            {"model_id": "compat_model", "local_path": str(compat_ckpt)},
+            {
+                "model_id": "absent_model",
+                "local_path": str(tmp_path / "does_not_exist.pt"),
+                "local_only": True,
+            },
+        ],
+    )
+    compat_cfg = _write_algo_config(
+        tmp_path,
+        "compat3.yaml",
+        {"predictive_model_id": "compat_model"},
+    )
+    absent_cfg = _write_algo_config(
+        tmp_path,
+        "absent.yaml",
+        {"predictive_model_id": "absent_model"},
+    )
+
+    scenario_matrix = tmp_path / "scenarios2.yaml"
+    scenario_matrix.write_text("scenarios: []\n", encoding="utf-8")
+    source_config = tmp_path / "campaign2.yaml"
+    source_config.write_text(
+        yaml.safe_dump(
+            {
+                "name": "schema_unstaged_test",
+                "scenario_matrix": str(scenario_matrix),
+                "planners": [
+                    {"key": "ok", "algo": "prediction_planner", "algo_config": str(compat_cfg)},
+                    {
+                        "key": "missing",
+                        "algo": "prediction_planner",
+                        "algo_config": str(absent_cfg),
+                    },
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    from robot_sf.benchmark.camera_ready_campaign import load_campaign_config
+
+    cfg = load_campaign_config(source_config)
+    result = audit_predictive_checkpoint_schema(cfg, registry_path=registry)
+    by_key = {arm.arm_key: arm for arm in result.arms}
+    assert by_key["ok"].status == STATUS_COMPAT
+    assert by_key["missing"].status == "UNSTAGED"
+    assert result.incompatible_arms == []
+
+    out_path = tmp_path / "campaign2_schema_filtered.yaml"
+    emit_schema_filtered_config(source_config, result, out_path)
+    filtered = yaml.safe_load(out_path.read_text(encoding="utf-8"))
+    # The unstaged arm is kept (the tool never silently drops an arm it could not inspect).
+    assert [p["key"] for p in filtered["planners"]] == ["ok", "missing"]
+    assert filtered["schema_excluded_arms"] == []
+    assert [a["key"] for a in filtered["schema_audit_uninspected_arms"]] == ["missing"]
+
+
+def test_format_table_lists_all_arms_and_marks_incompat(tmp_path: Path) -> None:
+    """The human-readable table lists every arm and flags INCOMPAT rows in the summary."""
+    compat_ckpt = _save_legacy_checkpoint(tmp_path, "compat4")
+    incompat_ckpt = _save_xl_ego_checkpoint(tmp_path, "incompat4")
+    registry = _write_registry(
+        tmp_path,
+        [
+            {"model_id": "compat_model", "local_path": str(compat_ckpt)},
+            {"model_id": "incompat_model", "local_path": str(incompat_ckpt)},
+        ],
+    )
+    compat_cfg = _write_algo_config(
+        tmp_path, "compat4.yaml", {"predictive_model_id": "compat_model"}
+    )
+    incompat_cfg = _write_algo_config(
+        tmp_path,
+        "incompat4.yaml",
+        {"predictive_model_id": "incompat_model"},
+    )
+    campaign = _campaign(
+        (
+            PlannerSpec(key="good", algo="prediction_planner", algo_config_path=compat_cfg),
+            PlannerSpec(key="bad", algo="prediction_planner", algo_config_path=incompat_cfg),
+        ),
+        tmp_path=tmp_path,
+    )
+    result = audit_predictive_checkpoint_schema(campaign, registry_path=registry)
+
+    table = format_schema_audit_table(result)
+    assert "arm" in table and "checkpoint" in table
+    assert "expected-schema" in table and "current-schema" in table and "status" in table
+    assert "good" in table and "bad" in table
+    assert "1 INCOMPAT" in table
+    assert "INCOMPAT bad" in table

--- a/tests/benchmark/test_predictive_checkpoint_schema_audit.py
+++ b/tests/benchmark/test_predictive_checkpoint_schema_audit.py
@@ -27,6 +27,7 @@ from robot_sf.benchmark.predictive_checkpoint_schema_audit import (
 from robot_sf.planner.obstacle_features import (
     PREDICTIVE_EGO_FEATURE_DIM,
     PREDICTIVE_EGO_FEATURE_SCHEMA,
+    PREDICTIVE_EGO_MOTION_PRODUCER_STANDALONE,
     PREDICTIVE_LEGACY_FEATURE_DIM,
     PREDICTIVE_LEGACY_FEATURE_SCHEMA,
     predictive_feature_schema_metadata,
@@ -191,6 +192,50 @@ def test_audit_explicit_expected_schema_can_match_ego_checkpoint(tmp_path: Path)
     arm = result.arms[0]
     assert arm.status == STATUS_COMPAT
     assert arm.expected_schema == PREDICTIVE_EGO_FEATURE_SCHEMA
+
+
+def test_audit_rejects_ego_checkpoint_with_nonruntime_motion_producer(tmp_path: Path) -> None:
+    """The audit rejects an ego checkpoint that the runtime planner would fail closed on."""
+    schema = predictive_feature_schema_metadata(
+        model_family=PREDICTIVE_EGO_FEATURE_SCHEMA,
+        ego_conditioning=True,
+        ego_motion_channel_producer=PREDICTIVE_EGO_MOTION_PRODUCER_STANDALONE,
+    )
+    model = PredictiveTrajectoryModel(
+        PredictiveModelConfig(
+            input_dim=PREDICTIVE_EGO_FEATURE_DIM,
+            feature_schema_name=PREDICTIVE_EGO_FEATURE_SCHEMA,
+        )
+    )
+    checkpoint = tmp_path / "ckpt" / "standalone_ego.pt"
+    save_predictive_checkpoint(
+        checkpoint,
+        model=model,
+        optimizer=None,
+        epoch=1,
+        feature_schema_metadata=schema,
+    )
+    registry = _write_registry(
+        tmp_path,
+        [{"model_id": "standalone_ego", "local_path": str(checkpoint)}],
+    )
+    algo_cfg = _write_algo_config(
+        tmp_path,
+        "standalone_ego.yaml",
+        {
+            "predictive_model_id": "standalone_ego",
+            "predictive_feature_schema_name": PREDICTIVE_EGO_FEATURE_SCHEMA,
+        },
+    )
+    campaign = _campaign(
+        (PlannerSpec(key="ego_arm", algo="prediction_planner", algo_config_path=algo_cfg),),
+        tmp_path=tmp_path,
+    )
+
+    result = audit_predictive_checkpoint_schema(campaign, registry_path=registry)
+
+    assert result.arms[0].status == STATUS_INCOMPAT
+    assert "ego motion producer mismatch" in result.arms[0].detail
 
 
 def test_audit_skips_non_predictive_arms(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Implements issue #5241 — a CPU-only preflight that checks every predictive planner arm's checkpoint metadata against the runtime obstacle-feature schema, and auto-excludes incompatible arms from campaign configs with an explicit provenance note. This unblocks the gap-prediction and mppi-social comparison campaigns by making their configs provably runnable.

The defect: job 13194 halted the gap-prediction campaign because `prediction_planner_v2_xl_ego` raised `ObstacleFeatureSchemaError` under `stop_on_failure=true` (144 failed jobs). Per the issue decision, we do **not** retrain and do **not** write a compat shim — we make checkpoint↔schema compatibility **checkable before submission** and auto-exclude incompatible arms.

## Deliverables (all three from the execution packet)

1. **`scripts/tools/audit_predictive_checkpoint_schema.py`** — for every predictive arm in a campaign config, loads **only** the checkpoint metadata / feature spec (`torch.load(map_location="cpu", weights_only=True)` — never instantiates the model, never touches a GPU), compares against the current obstacle-feature schema by **reusing the exact runtime comparison** (`validate_predictive_feature_schema_metadata`, the function that raises `ObstacleFeatureSchemaError`), and prints the table: `arm | checkpoint | expected-schema | current-schema | COMPAT/INCOMPAT`.
2. **`--emit-filtered-config OUT.yaml`** — writes a copy of the campaign config with INCOMPAT arms REMOVED and a top-level `schema_excluded_arms:` provenance list (so exclusion is provenance, not silence).
3. **Both filtered configs committed** next to the originals:
   - `configs/benchmarks/paper_experiment_matrix_v1_gap_prediction_compare_schema_filtered.yaml`
   - `configs/benchmarks/paper_experiment_matrix_v1_mppi_social_compare_schema_filtered.yaml`

The reusable, testable logic lives in `robot_sf/benchmark/predictive_checkpoint_schema_audit.py` (the script is a thin CLI wrapper), consistent with the sibling `campaign_checkpoint_preflight` module.

## How it reuses the exact runtime comparison

The runtime load path (`robot_sf/planner/socnav.py` `PredictionPlannerAdapter._build_model`) calls `load_predictive_checkpoint(..., expected_feature_schema_name=str(self.config.predictive_feature_schema_name))`, which calls `validate_predictive_feature_schema_metadata(feature_schema, input_dim=config.input_dim, expected_schema_name=...)`. The audit reads the same checkpoint payload fields (`config.input_dim`, `feature_schema`) and calls the same `validate_predictive_feature_schema_metadata`, so `INCOMPAT` here is the same condition that raises `ObstacleFeatureSchemaError` at runtime. When a checkpoint predates the `feature_schema` block, it mirrors `load_predictive_checkpoint` by inferring the schema from `input_dim`.

## Real audit results (CPU-only, `--stage` to read checkpoint metadata)

**`paper_experiment_matrix_v1_gap_prediction_compare.yaml`:**

```
arm                           checkpoint                           expected-schema       current-schema        status
----------------------------  -----------------------------------  --------------------  --------------------  --------
prediction_planner_v2_full    predictive_proxy_selected_v2_full    predictive_legacy_v1  predictive_legacy_v1  COMPAT
prediction_planner_v2_xl_ego  predictive_proxy_selected_v2_xl_ego  predictive_legacy_v1  predictive_ego_v1     INCOMPAT
gap_prediction                predictive_proxy_selected_v1         predictive_legacy_v1  predictive_legacy_v1  COMPAT
summary: 3 predictive arm(s) inspected, 1 INCOMPAT, staged=yes
```

**`paper_experiment_matrix_v1_mppi_social_compare.yaml`:**

```
arm                           checkpoint                           expected-schema       current-schema        status
----------------------------  -----------------------------------  --------------------  --------------------  --------------
prediction_planner_v2_full    predictive_proxy_selected_v2_full    predictive_legacy_v1  predictive_legacy_v1  COMPAT
prediction_planner_v2_xl_ego  predictive_proxy_selected_v2_xl_ego  predictive_legacy_v1  predictive_ego_v1     INCOMPAT
mppi_social                   -                                    -                     -                     NOT_PREDICTIVE
summary: 2 predictive arm(s) inspected, 1 INCOMPAT, staged=yes
```

The audit **reproduces the job 13194 defect from checkpoint metadata**: the `prediction_planner_v2_xl_ego` checkpoint declares `predictive_ego_v1` (`input_dim=9`) while its runtime planner config expects `predictive_legacy_v1` → schema mismatch. Both filtered configs drop exactly that arm and keep the rest (`mppi_social` is non-predictive and untouched). Each filtered config records `schema_excluded_arms:` with the checkpoint ref, expected/current schema, `input_dim`, and the mismatch reason.

## Tests

`tests/benchmark/test_predictive_checkpoint_schema_audit.py` — synthetic checkpoint-metadata fixtures (one schema-compatible, one not) proving the audit classifies both correctly and the filtered config drops exactly the incompatible arm. Covers: compat/incompat classification, explicit-expected-schema match, non-predictive arm skipping, exact-arm-drop filtering with provenance, unstaged-arm-is-kept (never silently dropped), and table formatting. 6 tests, all passing.

## Validation

```
uv run pytest tests -k "checkpoint_schema or predictive" -q
→ 266 passed, 14266 deselected

uv run ruff check <changed files>   → All checks passed!
uv run ruff format --check <changed files>  → 3 files already formatted
```

The audit tool runs clean on both real configs (CPU-only, no GPU). `--stage` performs CPU downloads of the registry checkpoints (~5–11 MB each) into the durable cache before reading metadata; without `--stage` it is network-free and reports `UNSTAGED` for arms whose checkpoint is not cached locally (it never silently drops an arm it could not inspect — those are recorded under `schema_audit_uninspected_arms`).

## Out of scope (per issue)

No checkpoint retraining, no compat shim, no extractor-schema change, no metric-semantic change. No benchmark run, no Slurm, no training.

## Downstream artifact propagation

Two `*_schema_filtered.yaml` configs are the durable artifact and are committed next to their originals (tracked, not `output/`). Staged registry checkpoints landed in the gitignored, worktree-local `output/model_cache/` and are intentionally not committed (the registry remains the durable source). No `output/` artifact is relied on as a durable dependency.

Closes #5241

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
