### PR TITLE
ci: schedule blocker-staleness report (#5253)

### DIFF
--- a/.github/workflows/blocker-staleness.yml
+++ b/.github/workflows/blocker-staleness.yml
@@ -1,0 +1,83 @@
+name: Blocker staleness report
+
+# Report stale issue blockers weekly without changing issue state or making findings a CI failure.
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: blocker-staleness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  blocker-staleness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up CI Python environment
+        uses: ./.github/actions/setup-ci-python
+        with:
+          migrate-artifacts: "false"
+
+      - name: Scan blocker staleness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          uv run python scripts/tools/check_blocker_staleness.py \
+            --json --report-only > blocker_staleness.json
+
+      - name: Summarize blocker staleness
+        env:
+          REPORT_PATH: blocker_staleness.json
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(Path(os.environ["REPORT_PATH"]).read_text())
+
+          def cell(value: object) -> str:
+              return " ".join(str(value).split()).replace("|", "\\|") or "—"
+
+          print("## Blocker staleness report")
+          print()
+          print(f"Schema: `{cell(report['schema_version'])}`")
+          for classification, rows in report["results"].items():
+              print()
+              print(f"### {cell(classification.replace('_', ' '))} ({len(rows)})")
+              print()
+              print("| Issue | Title | Closed blockers | Open blockers |")
+              print("| --- | --- | --- | --- |")
+              if not rows:
+                  print("| — | No issues | — | — |")
+                  continue
+              for row in rows:
+                  issue = row["issue"]
+                  print(
+                      "| #{number} | {title} | {closed} | {open_} |".format(
+                          number=issue["number"],
+                          title=cell(issue["title"]),
+                          closed=cell(", ".join(f"#{number}" for number in row["closed_blockers"])),
+                          open_=cell(", ".join(f"#{number}" for number in row["open_blockers"])),
+                      )
+                  )
+          PY
+
+      - name: Upload blocker-staleness report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: blocker-staleness-report
+          path: blocker_staleness.json
+          retention-days: 90
+          if-no-files-found: error

--- a/tests/tools/test_check_blocker_staleness.py
+++ b/tests/tools/test_check_blocker_staleness.py
@@ -155,4 +155,11 @@ def test_main_exits_nonzero_only_for_enforced_fully_unblocked(
     )
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == "blocker_staleness_report.v1"
+    assert set(payload["results"]) == {
+        "fully_unblocked",
+        "partially_unblocked",
+        "still_blocked",
+        "unknown",
+    }
     assert payload["counts"]["fully_unblocked"] == 1


### PR DESCRIPTION
## Reviewer-critical summary

- What changed: adds a weekly Monday 06:00 UTC, manually-dispatchable report-only workflow for the existing blocker-staleness scanner; it publishes a summary table and a 90-day JSON artifact.
- Why now: the existing scanner found five fully stale-blocked open issues but had no scheduled execution path.
- Claim boundary: workflow scheduling and presentation only; scanner parsing, issue state, labels, runtime behavior, and research evidence are unchanged.
- Required validation: focused scanner tests, workflow YAML parse, summary-renderer smoke test, pre-commit, and final repository readiness gate.
- Remaining blocker: none for this implementation; after merge, a maintainer may use `workflow_dispatch` to observe the first live Actions summary.

## Contract delta

- New surface: `.github/workflows/blocker-staleness.yml` runs weekly and on manual dispatch.
- New output: `blocker_staleness.json`, retained as `blocker-staleness-report` for 90 days, plus per-classification Markdown tables in the Actions step summary.
- New fail-closed blockers: none. `--report-only` deliberately makes scanner findings non-gating.
- Compatibility: no scanner CLI or JSON-schema change; the added test locks `blocker_staleness_report.v1` and its four result buckets.

## Linked Issues

- Closes #5253
- Issue: https://github.com/ll7/robot_sf_ll7/issues/5253

## Scope summary

- Adds the requested workflow and the narrow JSON-contract assertion only.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - support workflow only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: NA - no research or benchmark claim.
- Result classification: NA - support workflow only.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA - issue #5253 is the workflow contract.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - existing read-only support tool.

## Domain-Aware Approval

- Required for this PR: no - this support workflow does not alter experimental evidence or interpretation.
- Domains reviewed: NA - workflow-only change.
- Status: not required.
- Approver/review source or waiver: support workflow with no research-result surface.
- Validity checklist: NA - no research or benchmark contract changed.

## Validation / Proof

- `uv run pytest tests/tools/test_check_blocker_staleness.py -q` — 7 passed.
- `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/blocker-staleness.yml'))"` — passed.
- Summary-renderer smoke test with a pipe-containing title and empty buckets — passed.
- `uv run pre-commit run --files .github/workflows/blocker-staleness.yml tests/tools/test_check_blocker_staleness.py` — passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed (2,231 passed, 1 skipped).

## Risks / Rollout

- The workflow has read-only `contents` and `issues` permissions and never comments, labels, or edits issues.
- A GitHub API or dependency setup failure can fail an Actions run; reported stale findings themselves cannot fail it.

## Downstream Propagation

- Parent issue updated: no - comment authorization is intentionally disabled; the linked closing PR is the canonical delivery record.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: NA.
- Not applicable because: this is a self-contained read-only workflow change with no evidence artifact to promote.

## Follow-Up Issues

- Deferred work: None.
- Issues opened for follow-up: NA - no follow-up issue is needed.

## Reviewer Notes

- Verify the workflow retains the scanner's `--report-only` behavior and uses only the existing JSON contract.
- No generated repository artifacts were added; the workflow-produced JSON is retained by GitHub Actions.

<details>
<summary>Governance appendix</summary>

State propagation is intentionally limited to this linked closing PR because the task authorization excludes issue/PR comments. No transient routing state or packet lineage was committed. No friction issue was filed: the only failed command was an inapplicable Ruff invocation against a YAML file, corrected by the repository's workflow-aware pre-commit checks.

</details>
