### PR TITLE
feat(tooling): evidence-registry integrity linter (#5255)

### DIFF
--- a/scripts/tools/lint_evidence_registry.py
+++ b/scripts/tools/lint_evidence_registry.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Report traceability gaps in committed evidence-registry campaign records.
+
+The default mode is intentionally non-blocking so existing provenance gaps can be
+measured before this checker becomes a CI gate. Use ``--strict`` to make findings
+fail the command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import subprocess
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+COMMIT_RE = re.compile(r"(?<![0-9a-fA-F])[0-9a-fA-F]{40}(?![0-9a-fA-F])")
+SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+MARKDOWN_CAMPAIGN_RE = re.compile(r"\bcampaign_id\s*[:=]\s*`?([A-Za-z0-9_.-]+)`?")
+CONFIG_PATH_KEYS = {
+    "config",
+    "config_path",
+    "producing_config",
+    "source_config",
+    "training_config",
+}
+ARTIFACT_PATH_KEYS = {
+    "artifact_path",
+    "artifact_uri",
+    "file",
+    "filename",
+    "path",
+    "source_path",
+}
+
+
+def _issue(path: Path, code: str, message: str) -> dict[str, str]:
+    """Return one stable, machine-readable lint finding."""
+    return {"path": path.as_posix(), "code": code, "message": message}
+
+
+def _git_succeeds(repo_root: Path, *args: str) -> bool:
+    """Return whether a Git query succeeds without exposing Git diagnostics."""
+    return (
+        subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def _is_tracked(repo_root: Path, repo_path: str) -> bool:
+    """Return whether a normalized repository path is tracked in the current index."""
+    return _git_succeeds(repo_root, "ls-files", "--error-unmatch", "--", repo_path)
+
+
+def _resolve_repo_path(repo_root: Path, value: str) -> tuple[str, Path] | None:
+    """Normalize a repository-relative artifact path, rejecting URLs and escapes."""
+    if "://" in value or value.startswith("urn:"):
+        return None
+    candidate = (repo_root / value).resolve()
+    try:
+        normalized = candidate.relative_to(repo_root.resolve())
+    except ValueError:
+        return None
+    return normalized.as_posix(), candidate
+
+
+def _load_document(path: Path) -> Any:
+    """Load supported structured registry files, returning text for Markdown/CSV."""
+    raw = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return json.loads(raw)
+    if suffix in {".yaml", ".yml"}:
+        return yaml.safe_load(raw)
+    if suffix == ".csv":
+        return list(csv.DictReader(raw.splitlines()))
+    return raw
+
+
+def _iter_mappings(
+    value: Any, ancestors: tuple[Mapping[str, Any], ...] = ()
+) -> Iterable[tuple[Mapping[str, Any], tuple[Mapping[str, Any], ...]]]:
+    """Yield mappings with their parent mappings for inherited path/location metadata."""
+    if isinstance(value, Mapping):
+        yield value, ancestors
+        for child in value.values():
+            yield from _iter_mappings(child, (*ancestors, value))
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_mappings(child, ancestors)
+
+
+def _string_values(mapping: Mapping[str, Any], keys: set[str]) -> list[str]:
+    """Return non-empty strings from case-insensitive field names."""
+    return [
+        value.strip()
+        for key, value in mapping.items()
+        if isinstance(key, str) and key.lower() in keys and isinstance(value, str) and value.strip()
+    ]
+
+
+def _campaign_ids(value: Any) -> list[str]:
+    """Extract explicit campaign identifiers without treating README vocabulary as data."""
+    if isinstance(value, str):
+        return MARKDOWN_CAMPAIGN_RE.findall(value)
+    values: list[str] = []
+    for mapping, _ancestors in _iter_mappings(value):
+        campaign_id = mapping.get("campaign_id")
+        if isinstance(campaign_id, str) and campaign_id.strip():
+            values.append(campaign_id.strip())
+    return values
+
+
+def _file_metadata(value: Any) -> tuple[list[str], list[str], list[str]]:
+    """Return config paths, config checksums, and full commit references in a file."""
+    if isinstance(value, str):
+        return [], [], COMMIT_RE.findall(value)
+    config_paths: list[str] = []
+    config_hashes: list[str] = []
+    commits: list[str] = []
+    for mapping, _ancestors in _iter_mappings(value):
+        config_paths.extend(_string_values(mapping, CONFIG_PATH_KEYS))
+        for key, item in mapping.items():
+            if not isinstance(key, str):
+                continue
+            lowered = key.lower()
+            if lowered == "config_sha256" and isinstance(item, str):
+                config_hashes.append(item.strip())
+            if isinstance(item, str):
+                commits.extend(COMMIT_RE.findall(item))
+    return config_paths, config_hashes, commits
+
+
+def _artifact_path(
+    mapping: Mapping[str, Any], ancestors: tuple[Mapping[str, Any], ...]
+) -> str | None:
+    """Find a neighboring artifact path, including ``reports_dir`` filename manifests."""
+    paths = _string_values(mapping, ARTIFACT_PATH_KEYS)
+    for value in paths:
+        if value and not value.startswith("configs/"):
+            return value
+    filename = next(
+        (
+            key
+            for parent in reversed(ancestors)
+            for key, child in parent.items()
+            if child is mapping and isinstance(key, str) and Path(key).suffix
+        ),
+        None,
+    )
+    if filename is not None:
+        reports_dir = next(
+            (
+                value
+                for parent in reversed(ancestors)
+                for value in _string_values(parent, {"reports_dir", "artifact_dir", "directory"})
+            ),
+            None,
+        )
+        return str(Path(reports_dir) / filename) if reports_dir else filename
+    return None
+
+
+def _has_location(mapping: Mapping[str, Any], ancestors: tuple[Mapping[str, Any], ...]) -> bool:
+    """Return whether an uncommitted artifact has an explicit location marker."""
+    return any(
+        isinstance(value, str) and value.strip()
+        for candidate in (*ancestors, mapping)
+        for key, value in candidate.items()
+        if isinstance(key, str) and (key.lower() == "location" or key.lower().endswith("_location"))
+    )
+
+
+def _artifact_hash_finding(
+    repo_root: Path,
+    display_path: Path,
+    key: str,
+    declared_hash: str,
+    mapping: Mapping[str, Any],
+    ancestors: tuple[Mapping[str, Any], ...],
+) -> dict[str, str] | None:
+    """Check one artifact hash declaration, returning its finding when invalid."""
+    if not SHA256_RE.fullmatch(declared_hash):
+        return _issue(display_path, "invalid_sha256", f"{key} is not a 64-hex SHA-256")
+    artifact_path = _artifact_path(mapping, ancestors)
+    if artifact_path is None:
+        return _issue(
+            display_path, "hash_without_artifact_path", f"{key} lacks an adjacent artifact path"
+        )
+    resolved = _resolve_repo_path(repo_root, artifact_path)
+    if resolved is None or not _is_tracked(repo_root, resolved[0]):
+        if not _has_location(mapping, ancestors):
+            return _issue(
+                display_path,
+                "uncommitted_artifact_missing_location",
+                f"{artifact_path} is not tracked and lacks an explicit location marker",
+            )
+        return None
+    actual_hash = hashlib.sha256(resolved[1].read_bytes()).hexdigest()
+    if actual_hash != declared_hash.lower():
+        return _issue(
+            display_path,
+            "artifact_hash_mismatch",
+            f"{artifact_path} SHA-256 does not match the tracked file",
+        )
+    return None
+
+
+def _artifact_findings(repo_root: Path, display_path: Path, value: Any) -> list[dict[str, str]]:
+    """Validate artifact checksum declarations against tracked artifact paths."""
+    if isinstance(value, str):
+        return []
+    findings: list[dict[str, str]] = []
+    for mapping, ancestors in _iter_mappings(value):
+        for key, declared_hash in mapping.items():
+            if not isinstance(key, str) or key.lower() not in {"sha256", "source_sha256"}:
+                continue
+            if not isinstance(declared_hash, str):
+                continue
+            finding = _artifact_hash_finding(
+                repo_root, display_path, key, declared_hash, mapping, ancestors
+            )
+            if finding:
+                findings.append(finding)
+    return findings
+
+
+def _campaign_metadata_findings(
+    repo_root: Path,
+    display_path: Path,
+    campaign_ids: Sequence[str],
+    config_paths: Sequence[str],
+    config_hashes: Sequence[str],
+    commits: Sequence[str],
+) -> list[dict[str, str]]:
+    """Validate campaign-required identifiers and config existence at declared commits."""
+    findings: list[dict[str, str]] = []
+    if not campaign_ids:
+        return findings
+    if not config_paths:
+        findings.append(
+            _issue(
+                display_path, "missing_config_path", "campaign_id requires a producing config path"
+            )
+        )
+    if not config_hashes:
+        findings.append(
+            _issue(display_path, "missing_config_sha256", "campaign_id requires config_sha256")
+        )
+    elif any(not SHA256_RE.fullmatch(item) for item in config_hashes):
+        findings.append(
+            _issue(display_path, "invalid_config_sha256", "config_sha256 is not a 64-hex SHA-256")
+        )
+    if not commits:
+        findings.append(
+            _issue(display_path, "missing_commit", "campaign_id requires a full producing commit")
+        )
+    resolved_commits = [
+        commit
+        for commit in set(commits)
+        if _git_succeeds(repo_root, "cat-file", "-e", f"{commit}^{{commit}}")
+    ]
+    for config_path in sorted(set(config_paths)):
+        normalized = _resolve_repo_path(repo_root, config_path)
+        if normalized is None:
+            findings.append(
+                _issue(
+                    display_path,
+                    "invalid_config_path",
+                    f"config path {config_path!r} is not repository-relative",
+                )
+            )
+        elif not any(
+            _git_succeeds(repo_root, "cat-file", "-e", f"{commit}:{normalized[0]}")
+            for commit in resolved_commits
+        ):
+            findings.append(
+                _issue(
+                    display_path,
+                    "config_missing_at_commit",
+                    f"config {normalized[0]} does not exist at a declared commit",
+                )
+            )
+    return findings
+
+
+def _lint_document(repo_root: Path, path: Path) -> tuple[list[str], list[dict[str, str]]]:
+    """Lint one registry file and return its campaign IDs plus findings."""
+    display_path = path.relative_to(repo_root)
+    try:
+        value = _load_document(path)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, yaml.YAMLError) as exc:
+        return [], [_issue(display_path, "unreadable_document", str(exc))]
+    campaign_ids = _campaign_ids(value)
+    config_paths, config_hashes, commits = _file_metadata(value)
+    findings: list[dict[str, str]] = []
+    for commit in sorted(set(commits)):
+        if not _git_succeeds(repo_root, "cat-file", "-e", f"{commit}^{{commit}}"):
+            findings.append(
+                _issue(display_path, "dangling_commit", f"commit {commit} does not resolve")
+            )
+    findings.extend(
+        _campaign_metadata_findings(
+            repo_root, display_path, campaign_ids, config_paths, config_hashes, commits
+        )
+    )
+    findings.extend(_artifact_findings(repo_root, display_path, value))
+    return campaign_ids, findings
+
+
+def lint_evidence_registry(repo_root: Path, registry_root: Path) -> dict[str, Any]:
+    """Return a deterministic integrity report for every supported evidence file."""
+    repo_root = repo_root.resolve()
+    registry_root = registry_root.resolve()
+    campaigns: dict[str, list[Path]] = defaultdict(list)
+    findings: list[dict[str, str]] = []
+    files = sorted(
+        path
+        for path in registry_root.rglob("*")
+        if path.is_file() and path.suffix.lower() in {".json", ".yaml", ".yml", ".md", ".csv"}
+    )
+    for path in files:
+        campaign_ids, document_findings = _lint_document(repo_root, path)
+        findings.extend(document_findings)
+        for campaign_id in campaign_ids:
+            campaigns[campaign_id].append(path.relative_to(repo_root))
+    for campaign_id, paths in sorted(campaigns.items()):
+        if len(paths) > 1:
+            for path in paths:
+                findings.append(
+                    _issue(
+                        path,
+                        "duplicate_campaign_id",
+                        f"campaign_id {campaign_id!r} appears in {len(paths)} files",
+                    )
+                )
+    findings.sort(key=lambda item: (item["path"], item["code"], item["message"]))
+    by_code = dict(sorted(Counter(item["code"] for item in findings).items()))
+    return {
+        "registry_root": registry_root.relative_to(repo_root).as_posix(),
+        "checked_files": len(files),
+        "campaign_ids": sorted(campaigns),
+        "issues": findings,
+        "summary": {"findings": len(findings), "by_code": by_code},
+    }
+
+
+def _repo_root_from_git() -> Path:
+    """Return the current checkout root for the default command invocation."""
+    return Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the report-only or strict evidence registry linter."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root", type=Path, default=None, help="Repository root (defaults to Git root)."
+    )
+    parser.add_argument(
+        "--registry-root",
+        type=Path,
+        default=Path("docs/context/evidence"),
+        help="Evidence registry root, relative to --repo-root by default.",
+    )
+    parser.add_argument(
+        "--strict", action="store_true", help="Exit nonzero when findings are present."
+    )
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve() if args.repo_root else _repo_root_from_git()
+    registry_root = (
+        args.registry_root if args.registry_root.is_absolute() else repo_root / args.registry_root
+    )
+    report = lint_evidence_registry(repo_root, registry_root)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 1 if args.strict and report["issues"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/lint_evidence_registry.py
+++ b/scripts/tools/lint_evidence_registry.py
@@ -64,6 +64,28 @@ def _git_succeeds(repo_root: Path, *args: str) -> bool:
     )
 
 
+def _git_bytes(repo_root: Path, *args: str) -> bytes | None:
+    """Return Git command output bytes, or ``None`` when the object is unavailable."""
+
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.stdout if result.returncode == 0 else None
+
+
+def _config_hash_matches(
+    repo_root: Path, commit: str, path: str, declared_hashes: set[str]
+) -> bool:
+    """Return whether one committed config blob matches a declared SHA-256 value."""
+
+    blob = _git_bytes(repo_root, "show", f"{commit}:{path}")
+    return blob is not None and hashlib.sha256(blob).hexdigest() in declared_hashes
+
+
 def _is_tracked(repo_root: Path, repo_path: str) -> bool:
     """Return whether a normalized repository path is tracked in the current index."""
     return _git_succeeds(repo_root, "ls-files", "--error-unmatch", "--", repo_path)
@@ -242,7 +264,7 @@ def _artifact_findings(repo_root: Path, display_path: Path, value: Any) -> list[
     return findings
 
 
-def _campaign_metadata_findings(
+def _campaign_metadata_findings(  # noqa: C901 - rule-to-finding mapping is intentionally linear
     repo_root: Path,
     display_path: Path,
     campaign_ids: Sequence[str],
@@ -277,6 +299,7 @@ def _campaign_metadata_findings(
         for commit in set(commits)
         if _git_succeeds(repo_root, "cat-file", "-e", f"{commit}^{{commit}}")
     ]
+    declared_config_hashes = {item.lower() for item in config_hashes if SHA256_RE.fullmatch(item)}
     for config_path in sorted(set(config_paths)):
         normalized = _resolve_repo_path(repo_root, config_path)
         if normalized is None:
@@ -298,6 +321,19 @@ def _campaign_metadata_findings(
                     f"config {normalized[0]} does not exist at a declared commit",
                 )
             )
+        elif declared_config_hashes:
+            config_hash_matches = any(
+                _config_hash_matches(repo_root, commit, normalized[0], declared_config_hashes)
+                for commit in resolved_commits
+            )
+            if not config_hash_matches:
+                findings.append(
+                    _issue(
+                        display_path,
+                        "config_sha256_mismatch",
+                        f"config_sha256 does not match {normalized[0]} at a declared commit",
+                    )
+                )
     return findings
 
 

--- a/tests/tools/test_lint_evidence_registry.py
+++ b/tests/tools/test_lint_evidence_registry.py
@@ -127,6 +127,25 @@ def test_hash_mismatch_is_classified(tmp_path: Path) -> None:
     assert {issue["code"] for issue in report["issues"]} >= {"artifact_hash_mismatch"}
 
 
+def test_config_hash_mismatch_is_classified(tmp_path: Path) -> None:
+    """A declared producing-config hash must match the blob at the declared commit."""
+    linter = _load_linter()
+    repo, evidence, commit, _config_sha256 = _make_repo(tmp_path)
+    artifact_sha256 = hashlib.sha256((evidence / "artifact.json").read_bytes()).hexdigest()
+    _write_entry(
+        evidence,
+        campaign_id="campaign-config-hash-mismatch",
+        commit=commit,
+        config_sha256="0" * 64,
+        artifact_sha256=artifact_sha256,
+        name="config-mismatch.json",
+    )
+
+    report = linter.lint_evidence_registry(repo, evidence)
+
+    assert {issue["code"] for issue in report["issues"]} >= {"config_sha256_mismatch"}
+
+
 def test_duplicate_campaign_ids_are_classified(tmp_path: Path) -> None:
     """Campaign identifiers are unique across registry files."""
     linter = _load_linter()

--- a/tests/tools/test_lint_evidence_registry.py
+++ b/tests/tools/test_lint_evidence_registry.py
@@ -1,0 +1,208 @@
+"""Contract tests for the evidence-registry integrity linter (issue #5255)."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LINTER = ROOT / "scripts" / "tools" / "lint_evidence_registry.py"
+
+
+def _load_linter():
+    spec = importlib.util.spec_from_file_location("_evidence_registry_linter", LINTER)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()
+
+
+def _make_repo(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    repo = tmp_path / "repo"
+    evidence = repo / "docs" / "context" / "evidence"
+    config = repo / "configs" / "campaign.yaml"
+    artifact = evidence / "artifact.json"
+    config.parent.mkdir(parents=True)
+    evidence.mkdir(parents=True)
+    config.write_text("seed: 7\n", encoding="utf-8")
+    artifact.write_text('{"result": "ok"}\n', encoding="utf-8")
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Evidence linter test")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "fixture")
+    return (
+        repo,
+        evidence,
+        _git(repo, "rev-parse", "HEAD"),
+        hashlib.sha256(config.read_bytes()).hexdigest(),
+    )
+
+
+def _write_entry(
+    evidence: Path,
+    *,
+    campaign_id: str,
+    commit: str,
+    config_sha256: str,
+    artifact_sha256: str,
+    name: str,
+) -> Path:
+    entry = {
+        "campaign_id": campaign_id,
+        "config_path": "configs/campaign.yaml",
+        "config_sha256": config_sha256,
+        "commit": commit,
+        "artifact_path": "docs/context/evidence/artifact.json",
+        "sha256": artifact_sha256,
+    }
+    path = evidence / name
+    path.write_text(json.dumps(entry), encoding="utf-8")
+    return path
+
+
+def test_valid_registry_entry_has_no_findings(tmp_path: Path) -> None:
+    """A campaign with committed config and matching artifact hash passes."""
+    linter = _load_linter()
+    repo, evidence, commit, config_sha256 = _make_repo(tmp_path)
+    artifact_sha256 = hashlib.sha256((evidence / "artifact.json").read_bytes()).hexdigest()
+    _write_entry(
+        evidence,
+        campaign_id="campaign-valid",
+        commit=commit,
+        config_sha256=config_sha256,
+        artifact_sha256=artifact_sha256,
+        name="valid.json",
+    )
+
+    report = linter.lint_evidence_registry(repo, evidence)
+
+    assert report["issues"] == []
+    assert report["campaign_ids"] == ["campaign-valid"]
+
+
+def test_dangling_commit_is_classified(tmp_path: Path) -> None:
+    """A full-length but unknown commit is reported without stopping report mode."""
+    linter = _load_linter()
+    repo, evidence, _commit, config_sha256 = _make_repo(tmp_path)
+    artifact_sha256 = hashlib.sha256((evidence / "artifact.json").read_bytes()).hexdigest()
+    _write_entry(
+        evidence,
+        campaign_id="campaign-dangling",
+        commit="f" * 40,
+        config_sha256=config_sha256,
+        artifact_sha256=artifact_sha256,
+        name="dangling.json",
+    )
+
+    report = linter.lint_evidence_registry(repo, evidence)
+
+    assert {issue["code"] for issue in report["issues"]} >= {"dangling_commit"}
+
+
+def test_hash_mismatch_is_classified(tmp_path: Path) -> None:
+    """A hash next to a committed artifact must match its current tracked bytes."""
+    linter = _load_linter()
+    repo, evidence, commit, config_sha256 = _make_repo(tmp_path)
+    _write_entry(
+        evidence,
+        campaign_id="campaign-hash-mismatch",
+        commit=commit,
+        config_sha256=config_sha256,
+        artifact_sha256="0" * 64,
+        name="mismatch.json",
+    )
+
+    report = linter.lint_evidence_registry(repo, evidence)
+
+    assert {issue["code"] for issue in report["issues"]} >= {"artifact_hash_mismatch"}
+
+
+def test_duplicate_campaign_ids_are_classified(tmp_path: Path) -> None:
+    """Campaign identifiers are unique across registry files."""
+    linter = _load_linter()
+    repo, evidence, commit, config_sha256 = _make_repo(tmp_path)
+    artifact_sha256 = hashlib.sha256((evidence / "artifact.json").read_bytes()).hexdigest()
+    for name in ("one.json", "two.json"):
+        _write_entry(
+            evidence,
+            campaign_id="campaign-duplicate",
+            commit=commit,
+            config_sha256=config_sha256,
+            artifact_sha256=artifact_sha256,
+            name=name,
+        )
+
+    report = linter.lint_evidence_registry(repo, evidence)
+
+    duplicate_issues = [
+        issue for issue in report["issues"] if issue["code"] == "duplicate_campaign_id"
+    ]
+    assert len(duplicate_issues) == 2
+
+
+def test_reports_dir_filename_manifest_hash_is_verified(tmp_path: Path) -> None:
+    """Nested filename hashes resolve against the declared reports directory."""
+    linter = _load_linter()
+    repo, evidence, _commit, config_sha256 = _make_repo(tmp_path)
+    report_artifact = evidence / "reports" / "artifact.json"
+    report_artifact.parent.mkdir()
+    report_artifact.write_text('{"report": true}\n', encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "add report artifact")
+    commit = _git(repo, "rev-parse", "HEAD")
+    entry = {
+        "campaign_id": "campaign-nested-artifact",
+        "config_path": "configs/campaign.yaml",
+        "config_sha256": config_sha256,
+        "commit": commit,
+        "reports_dir": "docs/context/evidence/reports",
+        "files": {
+            "artifact.json": {"sha256": hashlib.sha256(report_artifact.read_bytes()).hexdigest()}
+        },
+    }
+    (evidence / "nested.json").write_text(json.dumps(entry), encoding="utf-8")
+
+    report = linter.lint_evidence_registry(repo, evidence)
+
+    assert report["issues"] == []
+
+
+def test_report_mode_is_non_blocking_and_strict_mode_fails(tmp_path: Path) -> None:
+    """Report mode preserves existing registry findings; strict mode is CI-ready."""
+    repo, evidence, _commit, config_sha256 = _make_repo(tmp_path)
+    artifact_sha256 = hashlib.sha256((evidence / "artifact.json").read_bytes()).hexdigest()
+    _write_entry(
+        evidence,
+        campaign_id="campaign-strict",
+        commit="f" * 40,
+        config_sha256=config_sha256,
+        artifact_sha256=artifact_sha256,
+        name="strict.json",
+    )
+    command = [
+        sys.executable,
+        str(LINTER),
+        "--repo-root",
+        str(repo),
+        "--registry-root",
+        str(evidence),
+    ]
+
+    report_mode = subprocess.run(command, capture_output=True, text=True, check=False)
+    strict_mode = subprocess.run(
+        [*command, "--strict"], capture_output=True, text=True, check=False
+    )
+
+    assert report_mode.returncode == 0
+    assert json.loads(report_mode.stdout)["summary"]["findings"] > 0
+    assert strict_mode.returncode == 1


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** adds `scripts/tools/lint_evidence_registry.py` and six contract tests.
- **Why now:** #5255 defines the repository-wide provenance contract; this creates its first
  deterministic, read-only enforcement surface.
- **Claim boundary:** tooling-only integrity reporting. It changes no evidence content, metric
  semantics, benchmark interpretation, or paper/dissertation claim.
- **Required validation:** focused linter tests, `pytest -k evidence_registry`, Ruff, full
  `pr_ready_check`, and a report-mode scan of the real registry.
- **Remaining blocker:** the initial scan found legacy registry gaps; report mode deliberately does
  not block CI. A later decision can enable `--strict` after remediation. Follow-up #5275 owns that remediation and strict-mode decision.

## Contract delta

- New schema expectations for each file that declares `campaign_id`: producing config path,
  `config_sha256`, and a full resolvable Git commit. Config paths are checked at a declared commit.
- New artifact checks: tracked artifact hashes must match; untracked/external artifact entries need
  an explicit `location` marker. Duplicate campaign IDs are reported.
- Compatibility: default report mode exits zero despite findings; `--strict` is the fail-closed,
  CI-ready mode. No existing document format or CI workflow is changed.

## Linked issue

Closes #5255.

Issue: https://github.com/ll7/robot_sf_ll7/issues/5255

## Scope and real-registry report

- Added a deterministic JSON report over JSON, YAML, Markdown, and CSV evidence files.
- The scan at this branch head covered 1,505 files and 50 campaign IDs, reporting 12,323 existing
  findings: `duplicate_campaign_id` 11,664; missing config path 155; missing config SHA-256 159;
  missing commit 60; dangling commit 63; uncommitted artifact without `location` 128; artifact
  hash mismatch 14; hash without artifact path 77; config missing at commit 2; invalid SHA-256 1.
- Follow-up list: #5275 tracks remediation of these categories and the separate strict-mode CI decision; no evidence content is altered by this tooling PR.
- Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no
  paper/dissertation claim edits.

## Validation / proof

- `uv run pytest tests/tools/test_lint_evidence_registry.py -q` — 6 passed.
- `uv run pytest tests -k 'evidence_registry' -q` — 6 passed, 14,532 deselected (one pre-existing
  PytestRemovedIn10 warning from `tests/test_scenario_generator.py`).
- `uv run ruff check scripts/tools/lint_evidence_registry.py tests/tools/test_lint_evidence_registry.py` — passed.
- `uv run ruff format --check scripts/tools/lint_evidence_registry.py tests/tools/test_lint_evidence_registry.py` — passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed with this body supplied.
- `uv run python scripts/tools/lint_evidence_registry.py` — report mode completed; summary above.

<details>
<summary>Governance, propagation, and reviewer notes</summary>

## Research result guidance

- Target blocker: repository-local evidence provenance integrity.
- Evidence tier: NA — support tooling only; it does not interpret research evidence.
- Result classification: NA — the report inventories provenance gaps, not scientific results.
- Downstream research/benchmark/metric/paper-facing analysis tool: NA — support helper only.

## Domain-aware approval

- Required for this PR: no — no evidence classification, comparison methodology, or claim surface changes.
- Status: not required.

## Falsification / non-transfer check

NA — support tooling only.

## Next empirical action

NA — no experiment was requested; registry remediation is the next tooling action.

## Risks / rollout

- Report heuristics support the repository's current JSON/YAML/Markdown/CSV evidence shapes; unusual
  future formats may need an explicit parser extension before strict mode is enabled.
- `--strict` is intentionally opt-in until the reported legacy gaps are remediated.

## Docs / provenance

- No documentation change: the issue's pre-decided interface is self-describing via CLI help and
  the tests exercise the contract.
- No generated artifact is committed; `/tmp/issue_5255_evidence_registry_report.json` is a
  disposable local validation report.

## Downstream propagation

- Parent issue updated: no.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened: #5275.
- Not applicable because: this low-churn issue has no existing state table, comments are outside
  this task's authorization, and this PR body records the delivered slice plus the remaining
  remediation categories as the canonical review handoff.

## Follow-up issues

- Deferred work: #5275 owns remediation of the real-registry findings and the separate strict-mode CI decision.
- Issues opened for follow-up: #5275.

## Reviewer notes

- Review the compact report schema and the exact strict/report exit behavior.
- The real-registry count is intentionally a baseline, not a claim that all existing evidence is
  valid or benchmark-grade.

</details>