### PR TITLE
test: lock dark environment flags (#5252)

### DIFF
--- a/scripts/validation/run_examples_smoke.py
+++ b/scripts/validation/run_examples_smoke.py
@@ -152,8 +152,6 @@ def _maybe_run_tracker_progress_check(args: argparse.Namespace) -> bool:
         print("Tracker progress check skipped: pipeline example not found.")
         return True
     env = _build_example_env()
-    env["ROBOT_SF_ENABLE_PROGRESS_TRACKER"] = "1"
-    env["ROBOT_SF_TRACKER_SMOKE"] = "1"
     command = [sys.executable, str(script_path), "--enable-tracker", "--tracker-smoke"]
     print("Running tracker progress check:", " ".join(command))
     try:

--- a/tests/benchmark/test_env_flag_behavior.py
+++ b/tests/benchmark/test_env_flag_behavior.py
@@ -1,0 +1,80 @@
+"""Behavior locks for benchmark environment flags."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.runner import _finalize_batch
+from robot_sf.benchmark.visualization import _should_use_plot_subprocess
+
+
+def test_plot_subprocess_env_flag_overrides_auto_heuristic(monkeypatch) -> None:
+    """Explicit visualization subprocess settings take precedence over file heuristics."""
+    monkeypatch.setenv("ROBOT_SF_VISUALIZATION_SUBPROCESS", "0")
+    assert not _should_use_plot_subprocess()
+
+    monkeypatch.setenv("ROBOT_SF_VISUALIZATION_SUBPROCESS", "1")
+    assert _should_use_plot_subprocess()
+
+
+def test_plot_subprocess_unset_env_uses_size_and_filter_heuristic(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Unset visualization flag keeps small filtered files in-process and other cases isolated."""
+    monkeypatch.delenv("ROBOT_SF_VISUALIZATION_SUBPROCESS", raising=False)
+    small_path = tmp_path / "small.jsonl"
+    small_path.write_bytes(b"x" * 5_000_000)
+    large_path = tmp_path / "large.jsonl"
+    large_path.write_bytes(b"x" * 5_000_001)
+
+    assert not _should_use_plot_subprocess(
+        episodes_path=str(small_path), scenario_filter="scenario-a"
+    )
+    assert _should_use_plot_subprocess(episodes_path=str(large_path), scenario_filter="scenario-a")
+    assert _should_use_plot_subprocess(episodes_path=str(tmp_path / "missing.jsonl"))
+
+
+def _write_video_episodes(out_path: Path) -> None:
+    records = [
+        {"video": {"frames": 10, "encode_seconds": 0.5, "overhead_ratio": 1.2}},
+        {"video": {"frames": 30, "encode_seconds": 1.5, "overhead_ratio": 1.4}},
+    ]
+    out_path.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+
+
+def test_perf_snapshot_env_flag_writes_video_summary(monkeypatch, tmp_path: Path) -> None:
+    """Enabled video snapshot flag writes the documented summary fields."""
+    out_path = tmp_path / "episodes.jsonl"
+    _write_video_episodes(out_path)
+    monkeypatch.setenv("ROBOT_SF_VIDEO_PERF_SNAPSHOT", "1")
+
+    _finalize_batch(out_path, wrote=0, resume=False)
+
+    snapshot_path = tmp_path / "videos" / "perf_snapshot.json"
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert set(snapshot) == {
+        "episodes",
+        "total_frames",
+        "total_encode_seconds",
+        "encode_ms_per_frame",
+        "mean_overhead_ratio",
+        "environment",
+    }
+    assert snapshot["episodes"] == 2
+    assert snapshot["total_frames"] == 40
+    assert snapshot["total_encode_seconds"] == 2.0
+    assert snapshot["encode_ms_per_frame"] == 50.0
+    assert snapshot["mean_overhead_ratio"] == pytest.approx(1.3)
+    assert set(snapshot["environment"]) == {"os", "python", "processor"}
+
+
+def test_perf_snapshot_unset_env_writes_nothing(monkeypatch, tmp_path: Path) -> None:
+    """Unset video snapshot flag leaves no performance artifact behind."""
+    out_path = tmp_path / "episodes.jsonl"
+    _write_video_episodes(out_path)
+    monkeypatch.delenv("ROBOT_SF_VIDEO_PERF_SNAPSHOT", raising=False)
+
+    _finalize_batch(out_path, wrote=0, resume=False)
+
+    assert not (tmp_path / "videos" / "perf_snapshot.json").exists()

--- a/tests/benchmark/test_env_flag_behavior.py
+++ b/tests/benchmark/test_env_flag_behavior.py
@@ -31,6 +31,10 @@ def test_plot_subprocess_unset_env_uses_size_and_filter_heuristic(
     assert not _should_use_plot_subprocess(
         episodes_path=str(small_path), scenario_filter="scenario-a"
     )
+    assert not _should_use_plot_subprocess(
+        episodes_path=str(small_path), baseline_filter="baseline-a"
+    )
+    assert _should_use_plot_subprocess(episodes_path=str(small_path))
     assert _should_use_plot_subprocess(episodes_path=str(large_path), scenario_filter="scenario-a")
     assert _should_use_plot_subprocess(episodes_path=str(tmp_path / "missing.jsonl"))
 


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** adds behavior-lock tests for the explicit and auto paths of
`ROBOT_SF_VISUALIZATION_SUBPROCESS` and `ROBOT_SF_VIDEO_PERF_SNAPSHOT`, then removes the two
redundant tracker environment assignments from the example smoke runner.

**Why now:** the two benchmark flags are user-facing but previously had no executable contract
tests; the tracker command already conveys both settings through its CLI flags.

**Claim boundary:** this preserves existing runtime behavior only. No benchmark metric, video
encoding, or subprocess-heuristic semantics change. The issue's proposed repository-wide zero-hit
check is stale: the pipeline example still intentionally reads both tracker variables, so this PR
proves only that the two requested assignments are absent from the smoke runner.

**Required validation:** focused flag tests pass; final repository readiness passed locally.

**Remaining blocker:** none for #5252. No full benchmark campaign was run.

## Contract delta

- No production schema or behavior changes.
- New tests lock `"0"`/`"1"` visualization overrides; unset small filtered files stay in-process at
  5,000,000 bytes, while larger and missing inputs use a subprocess.
- New tests lock perf-snapshot creation and documented fields only when enabled, and no artifact
  when unset.
- Compatibility impact: none; the removed environment assignments duplicated existing CLI flags.

Closes #5252

Issue: https://github.com/ll7/robot_sf_ll7/issues/5252

## Validation

- `uv run ruff format --check scripts/validation/run_examples_smoke.py tests/benchmark/test_env_flag_behavior.py`
- `uv run ruff check scripts/validation/run_examples_smoke.py tests/benchmark/test_env_flag_behavior.py`
- `uv run pytest tests/test_visualization_plots.py tests/benchmark -k 'plot_subprocess or perf_snapshot' -q` — 4 passed, 4558 deselected
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue-5252-pr-body.md scripts/dev/pr_ready_check.sh`
- Scoped setter check confirms neither requested assignment remains in `scripts/validation/run_examples_smoke.py`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation
claim edits.

<details>
<summary>Scope and propagation appendix</summary>

Scope is limited to tests and the two redundant assignments; no new environment variables or CI
wiring were added. Generated validation output remains ignored worktree-local cache. Downstream
propagation is not applicable because this is a behavior-preserving test/cleanup change with no
research claim. No issue state propagation was made: #5252 is low-churn and the authorized task
forbids issue comments; this closing PR is the durable delivery surface.

</details>
