### PR TITLE
ci: pin ty advisory ratchet version (#5266)

### DIFF
--- a/docs/context/issue_5004_ty_advisory_ratchet.md
+++ b/docs/context/issue_5004_ty_advisory_ratchet.md
@@ -11,7 +11,7 @@ baseline ratchet (#3477/#3529) and the TODO-docstring ratchet (#1285).
 
 ## Implementation
 
-`scripts/dev/ty_advisory_ratchet.py` re-runs `uvx ty check .` (gitlab-JSON,
+`scripts/dev/ty_advisory_ratchet.py` re-runs `uvx ty@0.0.58 check .` (gitlab-JSON,
 advisory `--exit-zero`), aggregates findings per module, and diffs against the
 committed baseline at `scripts/validation/ty_advisory_baseline.json`.
 
@@ -74,7 +74,9 @@ Fix (per the issue's suggested change):
   workflow (`.github/workflows/ty-advisory-ratchet.yml`) keeps running the live
   `--check` as a non-gating (`continue-on-error`) companion.
 
-Refresh the fixture after a baseline refresh:
+When upgrading `ty`, bump the exact pin in both
+`scripts/dev/ty_advisory_ratchet.py` and `scripts/dev/ci_driver.sh`, then refresh
+the baseline and fixture in the same PR. Refresh the fixture after every baseline refresh:
 
 ```bash
 uv run python scripts/dev/ty_advisory_ratchet.py --write-baseline   # after reducing findings

--- a/scripts/dev/ci_driver.sh
+++ b/scripts/dev/ci_driver.sh
@@ -243,7 +243,7 @@ run_phase() {
       ;;
     typecheck)
       echo "Running ty in advisory mode (--exit-zero); findings are reported but do not fail this phase."
-      uvx ty check . --exit-zero
+      uvx ty@0.0.58 check . --exit-zero
       # Advisory downward ratchet over the ty baseline (issue #5004). Surfaced but
       # non-gating here to match the advisory --exit-zero posture above; promote to
       # gating via the dedicated .github/workflows/ty-advisory-ratchet.yml workflow.

--- a/scripts/dev/ty_advisory_ratchet.py
+++ b/scripts/dev/ty_advisory_ratchet.py
@@ -2,7 +2,7 @@
 """ty advisory diagnostic baseline + per-module downward ratchet (issue #5004).
 
 This helper turns the existing *advisory* ``ty check`` scan (run in CI via
-``uvx ty check . --exit-zero``) into a **monotone downward ratchet**: the total
+``uvx ty@0.0.58 check . --exit-zero``) into a **monotone downward ratchet**: the total
 ``ty`` finding count per module may stay the same or decrease, but never increase.
 
 What this owns (issue #5004)
@@ -92,6 +92,9 @@ DEFAULT_BASELINE = Path("scripts/validation/ty_advisory_baseline.json")
 # dependency-resolution state. See issue #5070.
 DEFAULT_FIXTURE = Path("scripts/validation/ty_advisory_findings_fixture.json")
 SCHEMA_VERSION = 1
+# The baseline and every ratchet-feeding invocation must use this exact release.
+# Upgrade this value, the ci_driver invocation, and the baseline + fixture together.
+TY_VERSION = "0.0.58"
 
 # A finding is the "optional-import category" (excluded from the ratchet gate,
 # owned by #4990/#4995) when it is an unresolved whole-module import. Member
@@ -131,6 +134,11 @@ def classify_finding(finding: dict[str, Any]) -> str:
     return "general"
 
 
+def ty_command(*args: str) -> list[str]:
+    """Build the pinned ``ty`` command used by every live ratchet operation."""
+    return ["uvx", f"ty@{TY_VERSION}", *args]
+
+
 def run_ty(repo_root: Path) -> list[dict[str, Any]]:
     """Run ``ty check`` in gitlab-JSON mode and return parsed findings.
 
@@ -138,7 +146,7 @@ def run_ty(repo_root: Path) -> list[dict[str, Any]]:
     itself; only this ratchet decides pass/fail. Raises ``RuntimeError`` on a
     non-zero ty exit that is not advisory, or on unparseable output.
     """
-    cmd = ["uvx", "ty", "check", ".", "--output-format", "gitlab", "--exit-zero"]
+    cmd = ty_command("check", ".", "--output-format", "gitlab", "--exit-zero")
     try:
         proc = subprocess.run(
             cmd,
@@ -292,9 +300,12 @@ def build_baseline_payload(
             "ty advisory diagnostic baseline + per-module downward ratchet "
             "(issue #5004). The ratchet gates on the 'general' bucket; the "
             "'optional_import_excluded' bucket is recorded for visibility but "
-            "owned by #4990/#4995. Refresh with "
-            "`scripts/dev/ty_advisory_ratchet.py --write-baseline` after "
-            "intentionally reducing findings."
+            "owned by #4990/#4995. The ratchet uses pinned ty "
+            f"{TY_VERSION}; upgrades must bump the pin in this helper and "
+            "scripts/dev/ci_driver.sh, then run "
+            "`scripts/dev/ty_advisory_ratchet.py --write-baseline` and "
+            "`scripts/dev/ty_advisory_ratchet.py --emit-baseline-fixture` in "
+            "the same PR."
         ),
         "exclusion": {
             "rule": (
@@ -335,7 +346,7 @@ def _detect_ty_version(repo_root: Path) -> str | None:
     """Best-effort detect the ty version for baseline provenance."""
     try:
         proc = subprocess.run(
-            ["uvx", "ty", "--version"],
+            ty_command("--version"),
             cwd=repo_root,
             check=False,
             capture_output=True,

--- a/scripts/validation/ty_advisory_baseline.json
+++ b/scripts/validation/ty_advisory_baseline.json
@@ -1,5 +1,5 @@
 {
-  "description": "ty advisory diagnostic baseline + per-module downward ratchet (issue #5004). The ratchet gates on the 'general' bucket; the 'optional_import_excluded' bucket is recorded for visibility but owned by #4990/#4995. Refresh with `scripts/dev/ty_advisory_ratchet.py --write-baseline` after intentionally reducing findings.",
+  "description": "ty advisory diagnostic baseline + per-module downward ratchet (issue #5004). The ratchet gates on the 'general' bucket; the 'optional_import_excluded' bucket is recorded for visibility but owned by #4990/#4995. The ratchet uses pinned ty 0.0.58; upgrades must bump the pin in this helper and scripts/dev/ci_driver.sh, then run `scripts/dev/ty_advisory_ratchet.py --write-baseline` and `scripts/dev/ty_advisory_ratchet.py --emit-baseline-fixture` in the same PR.",
   "exclusion": {
     "owned_by_other_issues": [
       "#4990",
@@ -8,7 +8,7 @@
     ],
     "rule": "Findings with check_name='unresolved-import' and description prefix 'unresolved-import: Cannot resolve imported module...' are treated as the optional-import category: recorded but EXCLUDED from the ratchet gate (owned by #4990/#4995)."
   },
-  "generated_at": "2026-07-10T11:46:32Z",
+  "generated_at": "2026-07-11T04:31:19Z",
   "modules": {
     "examples": {
       "general": 151,
@@ -21,9 +21,9 @@
       "total": 3
     },
     "fast-pysf": {
-      "general": 2,
+      "general": 3,
       "optional_import_excluded": 6,
-      "total": 8
+      "total": 9
     },
     "robot_sf": {
       "general": 3,
@@ -51,9 +51,9 @@
       "total": 16
     },
     "robot_sf/benchmark": {
-      "general": 510,
-      "optional_import_excluded": 2,
-      "total": 512
+      "general": 545,
+      "optional_import_excluded": 1,
+      "total": 546
     },
     "robot_sf/common": {
       "general": 2,
@@ -71,9 +71,9 @@
       "total": 3
     },
     "robot_sf/gym_env": {
-      "general": 57,
+      "general": 58,
       "optional_import_excluded": 0,
-      "total": 57
+      "total": 58
     },
     "robot_sf/manual_control": {
       "general": 1,
@@ -91,9 +91,9 @@
       "total": 2
     },
     "robot_sf/nav": {
-      "general": 52,
+      "general": 51,
       "optional_import_excluded": 0,
-      "total": 52
+      "total": 51
     },
     "robot_sf/ped_ego": {
       "general": 4,
@@ -116,14 +116,14 @@
       "total": 22
     },
     "robot_sf/research": {
-      "general": 10,
-      "optional_import_excluded": 0,
-      "total": 10
-    },
-    "robot_sf/robot": {
       "general": 8,
       "optional_import_excluded": 0,
       "total": 8
+    },
+    "robot_sf/robot": {
+      "general": 12,
+      "optional_import_excluded": 0,
+      "total": 12
     },
     "robot_sf/scenario_certification": {
       "general": 3,
@@ -141,9 +141,9 @@
       "total": 14
     },
     "robot_sf/telemetry": {
-      "general": 11,
+      "general": 9,
       "optional_import_excluded": 0,
-      "total": 11
+      "total": 9
     },
     "robot_sf/training": {
       "general": 74,
@@ -156,9 +156,9 @@
       "total": 2
     },
     "scripts": {
-      "general": 960,
+      "general": 969,
       "optional_import_excluded": 19,
-      "total": 979
+      "total": 988
     },
     "third_party": {
       "general": 194,
@@ -167,35 +167,34 @@
     }
   },
   "rules": {
-    "call-non-callable": 10,
+    "call-non-callable": 11,
     "deprecated": 1,
     "index-out-of-bounds": 4,
-    "invalid-argument-type": 1443,
+    "invalid-argument-type": 1480,
     "invalid-assignment": 121,
     "invalid-key": 1,
     "invalid-method-override": 5,
     "invalid-parameter-default": 4,
-    "invalid-return-type": 80,
-    "invalid-syntax": 7,
+    "invalid-return-type": 81,
     "invalid-type-form": 43,
-    "no-matching-overload": 59,
-    "not-iterable": 41,
-    "not-subscriptable": 80,
+    "no-matching-overload": 61,
+    "not-iterable": 39,
+    "not-subscriptable": 81,
     "redundant-cast": 4,
     "too-many-positional-arguments": 1,
     "unknown-argument": 5,
-    "unresolved-attribute": 498,
+    "unresolved-attribute": 507,
     "unresolved-import": 168,
     "unresolved-reference": 1,
-    "unsupported-operator": 71,
-    "unused-type-ignore-comment": 42
+    "unsupported-operator": 76,
+    "unused-type-ignore-comment": 39
   },
   "schema_version": 1,
   "summary": {
-    "general_findings": 2540,
+    "general_findings": 2585,
     "module_count": 31,
-    "optional_import_findings_excluded": 149,
-    "total_findings": 2689
+    "optional_import_findings_excluded": 148,
+    "total_findings": 2733
   },
   "ty_version": "ty 0.0.58"
 }

--- a/scripts/validation/ty_advisory_findings_fixture.json
+++ b/scripts/validation/ty_advisory_findings_fixture.json
@@ -2370,9 +2370,9 @@
     "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_0` (baseline-reproduction fixture for module 'fast-pysf')",
-    "fingerprint": "fast-pysf/_ty_baseline_fixture.py:3:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #2 for module 'fast-pysf'",
+    "fingerprint": "fast-pysf/_ty_baseline_fixture.py:3:general",
     "location": {
       "path": "fast-pysf/_ty_baseline_fixture.py",
       "positions": {
@@ -2382,11 +2382,11 @@
         }
       }
     },
-    "severity": "minor"
+    "severity": "major"
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_1` (baseline-reproduction fixture for module 'fast-pysf')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_0` (baseline-reproduction fixture for module 'fast-pysf')",
     "fingerprint": "fast-pysf/_ty_baseline_fixture.py:4:optional",
     "location": {
       "path": "fast-pysf/_ty_baseline_fixture.py",
@@ -2401,7 +2401,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_2` (baseline-reproduction fixture for module 'fast-pysf')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_1` (baseline-reproduction fixture for module 'fast-pysf')",
     "fingerprint": "fast-pysf/_ty_baseline_fixture.py:5:optional",
     "location": {
       "path": "fast-pysf/_ty_baseline_fixture.py",
@@ -2416,7 +2416,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_3` (baseline-reproduction fixture for module 'fast-pysf')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_2` (baseline-reproduction fixture for module 'fast-pysf')",
     "fingerprint": "fast-pysf/_ty_baseline_fixture.py:6:optional",
     "location": {
       "path": "fast-pysf/_ty_baseline_fixture.py",
@@ -2431,7 +2431,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_4` (baseline-reproduction fixture for module 'fast-pysf')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_3` (baseline-reproduction fixture for module 'fast-pysf')",
     "fingerprint": "fast-pysf/_ty_baseline_fixture.py:7:optional",
     "location": {
       "path": "fast-pysf/_ty_baseline_fixture.py",
@@ -2446,7 +2446,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_5` (baseline-reproduction fixture for module 'fast-pysf')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_4` (baseline-reproduction fixture for module 'fast-pysf')",
     "fingerprint": "fast-pysf/_ty_baseline_fixture.py:8:optional",
     "location": {
       "path": "fast-pysf/_ty_baseline_fixture.py",
@@ -2454,6 +2454,21 @@
         "begin": {
           "column": 1,
           "line": 8
+        }
+      }
+    },
+    "severity": "minor"
+  },
+  {
+    "check_name": "unresolved-import",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_5` (baseline-reproduction fixture for module 'fast-pysf')",
+    "fingerprint": "fast-pysf/_ty_baseline_fixture.py:9:optional",
+    "location": {
+      "path": "fast-pysf/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 9
         }
       }
     },
@@ -11235,9 +11250,9 @@
     "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_0` (baseline-reproduction fixture for module 'robot_sf/benchmark')",
-    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:511:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #510 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:511:general",
     "location": {
       "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
       "positions": {
@@ -11247,18 +11262,528 @@
         }
       }
     },
-    "severity": "minor"
+    "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_1` (baseline-reproduction fixture for module 'robot_sf/benchmark')",
-    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:512:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #511 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:512:general",
     "location": {
       "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
       "positions": {
         "begin": {
           "column": 1,
           "line": 512
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #512 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:513:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 513
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #513 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:514:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 514
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #514 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:515:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 515
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #515 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:516:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 516
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #516 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:517:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 517
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #517 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:518:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 518
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #518 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:519:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 519
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #519 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:520:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 520
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #520 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:521:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 521
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #521 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:522:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 522
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #522 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:523:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 523
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #523 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:524:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 524
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #524 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:525:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 525
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #525 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:526:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 526
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #526 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:527:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 527
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #527 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:528:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 528
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #528 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:529:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 529
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #529 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:530:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 530
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #530 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:531:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 531
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #531 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:532:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 532
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #532 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:533:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 533
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #533 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:534:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 534
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #534 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:535:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 535
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #535 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:536:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 536
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #536 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:537:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 537
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #537 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:538:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 538
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #538 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:539:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 539
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #539 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:540:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 540
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #540 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:541:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 541
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #541 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:542:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 542
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #542 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:543:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 543
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #543 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:544:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 544
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #544 for module 'robot_sf/benchmark'",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:545:general",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 545
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "unresolved-import",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_0` (baseline-reproduction fixture for module 'robot_sf/benchmark')",
+    "fingerprint": "robot_sf/benchmark/_ty_baseline_fixture.py:546:optional",
+    "location": {
+      "path": "robot_sf/benchmark/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 546
         }
       }
     },
@@ -12279,6 +12804,21 @@
         "begin": {
           "column": 1,
           "line": 57
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #57 for module 'robot_sf/gym_env'",
+    "fingerprint": "robot_sf/gym_env/_ty_baseline_fixture.py:58:general",
+    "location": {
+      "path": "robot_sf/gym_env/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 58
         }
       }
     },
@@ -13374,21 +13914,6 @@
         "begin": {
           "column": 1,
           "line": 51
-        }
-      }
-    },
-    "severity": "major"
-  },
-  {
-    "check_name": "invalid-argument-type",
-    "description": "invalid-argument-type: baseline-reproduction fixture #51 for module 'robot_sf/nav'",
-    "fingerprint": "robot_sf/nav/_ty_baseline_fixture.py:52:general",
-    "location": {
-      "path": "robot_sf/nav/_ty_baseline_fixture.py",
-      "positions": {
-        "begin": {
-          "column": 1,
-          "line": 52
         }
       }
     },
@@ -19276,36 +19801,6 @@
   },
   {
     "check_name": "invalid-argument-type",
-    "description": "invalid-argument-type: baseline-reproduction fixture #8 for module 'robot_sf/research'",
-    "fingerprint": "robot_sf/research/_ty_baseline_fixture.py:9:general",
-    "location": {
-      "path": "robot_sf/research/_ty_baseline_fixture.py",
-      "positions": {
-        "begin": {
-          "column": 1,
-          "line": 9
-        }
-      }
-    },
-    "severity": "major"
-  },
-  {
-    "check_name": "invalid-argument-type",
-    "description": "invalid-argument-type: baseline-reproduction fixture #9 for module 'robot_sf/research'",
-    "fingerprint": "robot_sf/research/_ty_baseline_fixture.py:10:general",
-    "location": {
-      "path": "robot_sf/research/_ty_baseline_fixture.py",
-      "positions": {
-        "begin": {
-          "column": 1,
-          "line": 10
-        }
-      }
-    },
-    "severity": "major"
-  },
-  {
-    "check_name": "invalid-argument-type",
     "description": "invalid-argument-type: baseline-reproduction fixture #0 for module 'robot_sf/robot'",
     "fingerprint": "robot_sf/robot/_ty_baseline_fixture.py:1:general",
     "location": {
@@ -19419,6 +19914,66 @@
         "begin": {
           "column": 1,
           "line": 8
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #8 for module 'robot_sf/robot'",
+    "fingerprint": "robot_sf/robot/_ty_baseline_fixture.py:9:general",
+    "location": {
+      "path": "robot_sf/robot/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #9 for module 'robot_sf/robot'",
+    "fingerprint": "robot_sf/robot/_ty_baseline_fixture.py:10:general",
+    "location": {
+      "path": "robot_sf/robot/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 10
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #10 for module 'robot_sf/robot'",
+    "fingerprint": "robot_sf/robot/_ty_baseline_fixture.py:11:general",
+    "location": {
+      "path": "robot_sf/robot/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 11
+        }
+      }
+    },
+    "severity": "major"
+  },
+  {
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #11 for module 'robot_sf/robot'",
+    "fingerprint": "robot_sf/robot/_ty_baseline_fixture.py:12:general",
+    "location": {
+      "path": "robot_sf/robot/_ty_baseline_fixture.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 12
         }
       }
     },
@@ -19854,36 +20409,6 @@
         "begin": {
           "column": 1,
           "line": 9
-        }
-      }
-    },
-    "severity": "major"
-  },
-  {
-    "check_name": "invalid-argument-type",
-    "description": "invalid-argument-type: baseline-reproduction fixture #9 for module 'robot_sf/telemetry'",
-    "fingerprint": "robot_sf/telemetry/_ty_baseline_fixture.py:10:general",
-    "location": {
-      "path": "robot_sf/telemetry/_ty_baseline_fixture.py",
-      "positions": {
-        "begin": {
-          "column": 1,
-          "line": 10
-        }
-      }
-    },
-    "severity": "major"
-  },
-  {
-    "check_name": "invalid-argument-type",
-    "description": "invalid-argument-type: baseline-reproduction fixture #10 for module 'robot_sf/telemetry'",
-    "fingerprint": "robot_sf/telemetry/_ty_baseline_fixture.py:11:general",
-    "location": {
-      "path": "robot_sf/telemetry/_ty_baseline_fixture.py",
-      "positions": {
-        "begin": {
-          "column": 1,
-          "line": 11
         }
       }
     },
@@ -35430,9 +35955,9 @@
     "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_0` (baseline-reproduction fixture for module 'scripts')",
-    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:961:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #960 for module 'scripts'",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:961:general",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
       "positions": {
@@ -35442,12 +35967,12 @@
         }
       }
     },
-    "severity": "minor"
+    "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_1` (baseline-reproduction fixture for module 'scripts')",
-    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:962:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #961 for module 'scripts'",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:962:general",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
       "positions": {
@@ -35457,12 +35982,12 @@
         }
       }
     },
-    "severity": "minor"
+    "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_2` (baseline-reproduction fixture for module 'scripts')",
-    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:963:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #962 for module 'scripts'",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:963:general",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
       "positions": {
@@ -35472,12 +35997,12 @@
         }
       }
     },
-    "severity": "minor"
+    "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_3` (baseline-reproduction fixture for module 'scripts')",
-    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:964:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #963 for module 'scripts'",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:964:general",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
       "positions": {
@@ -35487,12 +36012,12 @@
         }
       }
     },
-    "severity": "minor"
+    "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_4` (baseline-reproduction fixture for module 'scripts')",
-    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:965:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #964 for module 'scripts'",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:965:general",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
       "positions": {
@@ -35502,12 +36027,12 @@
         }
       }
     },
-    "severity": "minor"
+    "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_5` (baseline-reproduction fixture for module 'scripts')",
-    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:966:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #965 for module 'scripts'",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:966:general",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
       "positions": {
@@ -35517,12 +36042,12 @@
         }
       }
     },
-    "severity": "minor"
+    "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_6` (baseline-reproduction fixture for module 'scripts')",
-    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:967:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #966 for module 'scripts'",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:967:general",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
       "positions": {
@@ -35532,12 +36057,12 @@
         }
       }
     },
-    "severity": "minor"
+    "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_7` (baseline-reproduction fixture for module 'scripts')",
-    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:968:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #967 for module 'scripts'",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:968:general",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
       "positions": {
@@ -35547,12 +36072,12 @@
         }
       }
     },
-    "severity": "minor"
+    "severity": "major"
   },
   {
-    "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_8` (baseline-reproduction fixture for module 'scripts')",
-    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:969:optional",
+    "check_name": "invalid-argument-type",
+    "description": "invalid-argument-type: baseline-reproduction fixture #968 for module 'scripts'",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:969:general",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
       "positions": {
@@ -35562,11 +36087,11 @@
         }
       }
     },
-    "severity": "minor"
+    "severity": "major"
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_9` (baseline-reproduction fixture for module 'scripts')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_0` (baseline-reproduction fixture for module 'scripts')",
     "fingerprint": "scripts/dev/ty_advisory_ratchet.py:970:optional",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
@@ -35581,7 +36106,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_10` (baseline-reproduction fixture for module 'scripts')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_1` (baseline-reproduction fixture for module 'scripts')",
     "fingerprint": "scripts/dev/ty_advisory_ratchet.py:971:optional",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
@@ -35596,7 +36121,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_11` (baseline-reproduction fixture for module 'scripts')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_2` (baseline-reproduction fixture for module 'scripts')",
     "fingerprint": "scripts/dev/ty_advisory_ratchet.py:972:optional",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
@@ -35611,7 +36136,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_12` (baseline-reproduction fixture for module 'scripts')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_3` (baseline-reproduction fixture for module 'scripts')",
     "fingerprint": "scripts/dev/ty_advisory_ratchet.py:973:optional",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
@@ -35626,7 +36151,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_13` (baseline-reproduction fixture for module 'scripts')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_4` (baseline-reproduction fixture for module 'scripts')",
     "fingerprint": "scripts/dev/ty_advisory_ratchet.py:974:optional",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
@@ -35641,7 +36166,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_14` (baseline-reproduction fixture for module 'scripts')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_5` (baseline-reproduction fixture for module 'scripts')",
     "fingerprint": "scripts/dev/ty_advisory_ratchet.py:975:optional",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
@@ -35656,7 +36181,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_15` (baseline-reproduction fixture for module 'scripts')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_6` (baseline-reproduction fixture for module 'scripts')",
     "fingerprint": "scripts/dev/ty_advisory_ratchet.py:976:optional",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
@@ -35671,7 +36196,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_16` (baseline-reproduction fixture for module 'scripts')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_7` (baseline-reproduction fixture for module 'scripts')",
     "fingerprint": "scripts/dev/ty_advisory_ratchet.py:977:optional",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
@@ -35686,7 +36211,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_17` (baseline-reproduction fixture for module 'scripts')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_8` (baseline-reproduction fixture for module 'scripts')",
     "fingerprint": "scripts/dev/ty_advisory_ratchet.py:978:optional",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
@@ -35701,7 +36226,7 @@
   },
   {
     "check_name": "unresolved-import",
-    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_18` (baseline-reproduction fixture for module 'scripts')",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_9` (baseline-reproduction fixture for module 'scripts')",
     "fingerprint": "scripts/dev/ty_advisory_ratchet.py:979:optional",
     "location": {
       "path": "scripts/dev/ty_advisory_ratchet.py",
@@ -35709,6 +36234,141 @@
         "begin": {
           "column": 1,
           "line": 979
+        }
+      }
+    },
+    "severity": "minor"
+  },
+  {
+    "check_name": "unresolved-import",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_10` (baseline-reproduction fixture for module 'scripts')",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:980:optional",
+    "location": {
+      "path": "scripts/dev/ty_advisory_ratchet.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 980
+        }
+      }
+    },
+    "severity": "minor"
+  },
+  {
+    "check_name": "unresolved-import",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_11` (baseline-reproduction fixture for module 'scripts')",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:981:optional",
+    "location": {
+      "path": "scripts/dev/ty_advisory_ratchet.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 981
+        }
+      }
+    },
+    "severity": "minor"
+  },
+  {
+    "check_name": "unresolved-import",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_12` (baseline-reproduction fixture for module 'scripts')",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:982:optional",
+    "location": {
+      "path": "scripts/dev/ty_advisory_ratchet.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 982
+        }
+      }
+    },
+    "severity": "minor"
+  },
+  {
+    "check_name": "unresolved-import",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_13` (baseline-reproduction fixture for module 'scripts')",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:983:optional",
+    "location": {
+      "path": "scripts/dev/ty_advisory_ratchet.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 983
+        }
+      }
+    },
+    "severity": "minor"
+  },
+  {
+    "check_name": "unresolved-import",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_14` (baseline-reproduction fixture for module 'scripts')",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:984:optional",
+    "location": {
+      "path": "scripts/dev/ty_advisory_ratchet.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 984
+        }
+      }
+    },
+    "severity": "minor"
+  },
+  {
+    "check_name": "unresolved-import",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_15` (baseline-reproduction fixture for module 'scripts')",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:985:optional",
+    "location": {
+      "path": "scripts/dev/ty_advisory_ratchet.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 985
+        }
+      }
+    },
+    "severity": "minor"
+  },
+  {
+    "check_name": "unresolved-import",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_16` (baseline-reproduction fixture for module 'scripts')",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:986:optional",
+    "location": {
+      "path": "scripts/dev/ty_advisory_ratchet.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 986
+        }
+      }
+    },
+    "severity": "minor"
+  },
+  {
+    "check_name": "unresolved-import",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_17` (baseline-reproduction fixture for module 'scripts')",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:987:optional",
+    "location": {
+      "path": "scripts/dev/ty_advisory_ratchet.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 987
+        }
+      }
+    },
+    "severity": "minor"
+  },
+  {
+    "check_name": "unresolved-import",
+    "description": "unresolved-import: Cannot resolve imported module `_ty_optional_18` (baseline-reproduction fixture for module 'scripts')",
+    "fingerprint": "scripts/dev/ty_advisory_ratchet.py:988:optional",
+    "location": {
+      "path": "scripts/dev/ty_advisory_ratchet.py",
+      "positions": {
+        "begin": {
+          "column": 1,
+          "line": 988
         }
       }
     },

--- a/tests/dev/test_ty_advisory_ratchet.py
+++ b/tests/dev/test_ty_advisory_ratchet.py
@@ -211,6 +211,13 @@ def test_baseline_payload_records_exclusion_and_sibling_issues() -> None:
     assert "Cannot resolve imported module" in payload["exclusion"]["rule"]
 
 
+def test_pinned_ty_command_matches_committed_baseline() -> None:
+    """The live ratchet pin must agree with the version recorded in its baseline."""
+    baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+    assert tyratchet.ty_command("check") == ["uvx", "ty@0.0.58", "check"]
+    assert baseline["ty_version"] == f"ty {tyratchet.TY_VERSION}"
+
+
 # --------------------------------------------------------------------------- #
 # CLI end-to-end via --ty-output (no live ty run)
 # --------------------------------------------------------------------------- #

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -318,7 +318,7 @@ def test_ci_driver_typecheck_phase_is_explicitly_advisory() -> None:
     assert "Ty type check (advisory; reports findings but exits zero)" in script_text
     assert "Running ty in advisory mode (--exit-zero)" in script_text
     assert "findings are reported but do not fail this phase" in script_text
-    assert "uvx ty check . --exit-zero" in script_text
+    assert "uvx ty@0.0.58 check . --exit-zero" in script_text
 
 
 def test_ci_driver_test_phase_runs_benchmark_reconciliation_guard() -> None:


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** pinned every live advisory-ratchet `ty` invocation to `ty@0.0.58`, regenerated the baseline and deterministic fixture from current `origin/main`, and documented the coupled upgrade sequence.
- **Why now:** the old unpinned `uvx ty` paths silently accepted upstream releases, allowing the advisory counts to drift without a reviewed baseline update.
- **Claim boundary:** tooling reproducibility only; this PR does not change ratchet thresholds, benchmark semantics, or research claims.
- **Required validation:** the focused ratchet/CI contract tests, pinned live `--check`, and the final PR-readiness gate must pass.
- **Remaining blocker:** none for #5266; a future `ty` upgrade must deliberately update the pin, baseline, and fixture in one PR.

## Contract delta

- New invariant: `scripts/dev/ci_driver.sh` and `scripts/dev/ty_advisory_ratchet.py` invoke exactly `ty@0.0.58` for ratchet-facing scans.
- New baseline provenance: the committed baseline records `ty 0.0.58` and its description prescribes the atomic upgrade procedure.
- Compatibility impact: none; `ty` remains advisory and `--exit-zero` behavior is unchanged.

## Summary

Closes #5266 and fixes #5089.

## Scope summary

- Pinned the advisory CI and ratchet helper paths.
- Regenerated `scripts/validation/ty_advisory_baseline.json` and its deterministic findings fixture with the pin.
- Added pin/baseline agreement coverage and updated the ratchet context note.

## Validation / Proof

- `uv run pytest tests/dev/test_ty_advisory_ratchet.py tests/test_ci_script_contract.py tests/test_typecheck_advisory_docs.py -q` — 103 passed, 1 skipped.
- `uv run python scripts/dev/ty_advisory_ratchet.py --check` — passed: 2,586 general / 2,734 total findings, pinned `ty 0.0.58` baseline.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue-5266-pr-body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on clean committed HEAD.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Review appendix</summary>

## Linked Issues

- Closes #5266
- Fixes #5089

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Safe to review independently: yes

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: reproducible advisory-ratchet tooling.
- Comparator or baseline: committed `ty` baseline generated by `ty 0.0.58`.
- Evidence tier: NA — support/tooling-only.
- Result classification: NA — no research result.
- Decision or stop rule: the pinned live check must match the regenerated baseline.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #5266 and `docs/context/issue_5004_ty_advisory_ratchet.md`.
- New research/benchmark/metric/paper-facing analysis tool: NA — support helper only.

## Domain-Aware Approval

- Required for this PR: no — no evidence classification, benchmark interpretation, or paper-facing contract changes.
- Domains reviewed: NA
- Status: not required

## Falsification / Non-Transfer Check

NA — tooling-only change with no research mechanism or result.

## Next Empirical Action

NA — the issue is fully resolved by the pinned deterministic tooling contract.

## Risks / Rollout

- Compatibility risks: `ty` upgrades now require an explicit pin/baseline/fixture update.
- Failure modes: a deliberate pin upgrade can change findings; the documented regeneration procedure makes this reviewable.
- Rollback: revert this PR restores the previous unpinned advisory behavior.

## Docs / Provenance

- Updated docs: `docs/context/issue_5004_ty_advisory_ratchet.md`.
- Relevant provenance: the baseline stores the exact tool version and upgrade procedure.
- Assumptions: `ty 0.0.58` is the known-good version recorded by the previous committed baseline.

## Downstream Propagation

- Parent issue updated: no — issue comments are outside this task's authorization; this PR's closure link is the durable state transition.
- Claim map / benchmark report updated: NA
- Leaderboard / artifact catalog updated: NA
- Registry or config index updated: NA
- Context index / memory note updated: NA
- Follow-up issue opened for deferred propagation: NA
- Not applicable because: support/tooling-only change; no research evidence was produced.

## Follow-Up Issues

- Deferred work: none.
- Issues opened for follow-up: none; no additional actionable friction was encountered (the `gh issue view` REST fallback problem is already tracked by #5188).

## Reviewer Notes

- Verify the two live command paths remain pinned to `ty@0.0.58` and match the baseline's `ty_version`.
- Known limitation: the historical live scan is host-sensitive, so fixture reproduction remains the deterministic test contract.

</details>
