### PR TITLE
fix(benchmark): subprocess arms consume the parent's prepared scenarios (unblocks isolation campaigns)

### DIFF
--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -714,6 +714,18 @@ def _run_campaign_planner_variant_subprocess(
         log_run=True,
     )
 
+    # Hand the worker the fully-prepared scenario list rather than letting it
+    # re-load the matrix: the preparation above (campaign loader + kinematics
+    # scoping) carries map_file normalization, seed overrides, candidate
+    # filtering, AMV overrides, horizon schedules, and holonomic_command_mode,
+    # and the worker must execute exactly the same episodes the in-process
+    # path would (Slurm jobs 13372/13373 failed every episode without this).
+    scoped_scenarios_path = run.planner_dir / "scoped_scenarios.json"
+    scoped_scenarios_path.write_text(
+        json.dumps(run.scoped_scenarios, default=str),
+        encoding="utf-8",
+    )
+
     # Build subprocess parameters
     arm_params = _SubprocessArmParams(
         planner_key=planner.key,
@@ -745,6 +757,7 @@ def _run_campaign_planner_variant_subprocess(
         snqi_weights=context.snqi_weights,
         snqi_baseline=context.snqi_baseline,
         algo_config_path=planner.algo_config_path,
+        scoped_scenarios_path=scoped_scenarios_path,
     )
 
     # Serialize parameters for subprocess. The Path-typed fields on

--- a/robot_sf/benchmark/camera_ready/resource_lifecycle.py
+++ b/robot_sf/benchmark/camera_ready/resource_lifecycle.py
@@ -57,6 +57,15 @@ class _SubprocessArmParams:
     snqi_weights: dict[str, Any] | None
     snqi_baseline: dict[str, Any] | None
     algo_config_path: Path | None
+    # Fully-prepared scenario list serialized by the parent (see
+    # _run_campaign_planner_variant_subprocess). When set, the worker consumes it
+    # verbatim instead of re-deriving scenarios from scenario_matrix_path: the
+    # parent's preparation applies map_file normalization, seed overrides,
+    # scenario-candidate filtering, AMV overrides, horizon schedules, and the
+    # configured holonomic_command_mode — none of which a bare matrix re-load
+    # reproduces (Slurm jobs 13372/13373: every episode failed on unresolvable
+    # relative map_file, and arm seeds diverged from the campaign plan).
+    scoped_scenarios_path: Path | None = None
 
 
 # Path-typed fields on _SubprocessArmParams. dataclasses.asdict() returns these as
@@ -71,6 +80,7 @@ _SUBPROCESS_ARM_PATH_FIELDS: tuple[str, ...] = (
     "episodes_path",
     "summary_path",
     "algo_config_path",
+    "scoped_scenarios_path",
 )
 
 
@@ -186,23 +196,31 @@ def _run_single_arm_subprocess(params: _SubprocessArmParams) -> dict[str, Any]:
     )
     from robot_sf.benchmark.runner import load_scenario_matrix, run_batch  # noqa: PLC0415
 
-    # Load scenario matrix. NOTE (2026-07-11): this previously imported
-    # `robot_sf.benchmark.scenario_matrix` — a module that has NEVER existed — and read
-    # `.scenarios` off an object that was really a list. The subprocess worker therefore
-    # failed on every arm it ever ran (masked first by the arm_params JSON crash, then
-    # observed live in Slurm job 13364). load_scenario_matrix lives in runner and returns
-    # the scenario list directly, exactly as the in-process path consumes it.
-    scenarios = load_scenario_matrix(params.scenario_matrix_path)
-
-    # Apply kinematics transform
-    scoped_scenarios = [
-        _scenario_with_kinematics(
-            sc,
-            kinematics=params.kinematics,
-            holonomic_command_mode="differential_drive",  # Default from campaign
-        )
-        for sc in scenarios
-    ]
+    if params.scoped_scenarios_path is not None:
+        # Preferred handoff: consume the parent's fully-prepared scenario list so
+        # the subprocess arm executes EXACTLY what the in-process path would have.
+        # Re-deriving scenarios from the matrix here loses the campaign loader's
+        # map_file normalization (relative map paths then fail to resolve from the
+        # worker cwd — Slurm jobs 13372/13373 lost all 147 episodes to this), plus
+        # seed overrides, candidate filtering, AMV overrides, horizon schedules,
+        # and the configured holonomic_command_mode.
+        with params.scoped_scenarios_path.open("r", encoding="utf-8") as f:
+            scoped_scenarios = json.load(f)
+    else:
+        # Legacy fallback for callers that predate scoped_scenarios_path.
+        # NOTE (2026-07-11): this previously imported `robot_sf.benchmark.scenario_matrix`
+        # — a module that has NEVER existed — and read `.scenarios` off an object that
+        # was really a list (observed live in Slurm job 13364). load_scenario_matrix
+        # lives in runner and returns the scenario list directly.
+        scenarios = load_scenario_matrix(params.scenario_matrix_path)
+        scoped_scenarios = [
+            _scenario_with_kinematics(
+                sc,
+                kinematics=params.kinematics,
+                holonomic_command_mode="differential_drive",  # Default from campaign
+            )
+            for sc in scenarios
+        ]
 
     # Run the batch
     status = "ok"
@@ -319,13 +337,12 @@ def _main_subprocess_worker() -> int:
     # Read parameters from stdin
     params_json = sys.stdin.read()
     params_dict = json.loads(params_json)
-    for field_name in ("scenario_matrix_path", "episodes_path", "summary_path"):
+    # Re-parse str -> Path using the same field list the serializer uses, so a
+    # field added to one side cannot silently miss the other.
+    for field_name in _SUBPROCESS_ARM_PATH_FIELDS:
         field_value = params_dict.get(field_name)
         if field_value:
             params_dict[field_name] = Path(field_value)
-    algo_config_path = params_dict.get("algo_config_path")
-    if algo_config_path:
-        params_dict["algo_config_path"] = Path(algo_config_path)
 
     params = _SubprocessArmParams(**params_dict)
 

--- a/tests/benchmark/test_camera_ready_subprocess_isolation.py
+++ b/tests/benchmark/test_camera_ready_subprocess_isolation.py
@@ -620,5 +620,166 @@ class TestSubprocessIsolationMetricEmission:
         assert entry["status"] == "failed"
 
 
+class TestScopedScenarioParity:
+    """Regression tests for the parent->worker scenario handoff.
+
+    Before this fix, the subprocess worker re-loaded the scenario matrix from
+    disk instead of consuming the parent's prepared list. The re-load skipped
+    the campaign loader's map_file normalization (every episode then failed
+    with an unresolvable relative map_file — Slurm jobs 13372/13373), and also
+    lost seed overrides, scenario-candidate filtering, AMV overrides, horizon
+    schedules, and the configured holonomic_command_mode. The contract locked
+    here: the worker must execute EXACTLY the scenario dicts the parent
+    prepared, delivered via ``scoped_scenarios_path``.
+    """
+
+    SCOPED = [
+        {
+            "name": "blind_corner",
+            "map_file": "maps/svg_maps/francis2023/francis2023_blind_corner.svg",
+            "seeds": [111],
+            "simulation_config": {"max_episode_steps": 30},
+            "robot_config": {"kinematics": "differential_drive"},
+        }
+    ]
+
+    def test_serializer_round_trips_scoped_scenarios_path(self):
+        """scoped_scenarios_path survives serialize -> worker re-parse as Path."""
+        from robot_sf.benchmark.camera_ready.resource_lifecycle import (
+            _SUBPROCESS_ARM_PATH_FIELDS,
+        )
+
+        base = _make_arm_params()
+        params = _SubprocessArmParams(
+            **{**base.__dict__, "scoped_scenarios_path": Path("/tmp/scoped.json")}
+        )
+        params_dict = json.loads(_serialize_subprocess_arm_params(params))
+        assert params_dict["scoped_scenarios_path"] == "/tmp/scoped.json"
+
+        for field_name in _SUBPROCESS_ARM_PATH_FIELDS:
+            if params_dict.get(field_name):
+                params_dict[field_name] = Path(params_dict[field_name])
+        rebuilt = _SubprocessArmParams(**params_dict)
+        assert rebuilt == params
+
+    def test_parent_serializes_scoped_scenarios_for_worker(self, tmp_path):
+        """The parent writes its prepared scenarios and hands the path to the worker."""
+        from robot_sf.benchmark.camera_ready.campaign import (
+            _run_campaign_planner_variant_subprocess,
+        )
+
+        maker = TestSubprocessIsolationMetricEmission()
+        planner, context, run = maker._make_context(tmp_path)
+        run = type(run)(**{**run.__dict__, "scoped_scenarios": self.SCOPED})
+
+        worker_stdout = json.dumps(
+            {
+                "summary": {
+                    "status": "ok",
+                    "total_jobs": 1,
+                    "written": 1,
+                    "failed_jobs": 0,
+                    "failures": [],
+                },
+                "cleanup_metrics": {},
+                "warnings": [],
+                "episodes_total": 1,
+            }
+        )
+        captured_input = {}
+
+        def fake_subprocess_run(cmd, *, input, capture_output, text, check):  # noqa: A002
+            captured_input["json"] = input
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=worker_stdout, stderr=""
+            )
+
+        with (
+            patch(
+                "robot_sf.benchmark.camera_ready.campaign._prepare_campaign_planner_variant_run",
+                return_value=run,
+            ),
+            patch(
+                "robot_sf.benchmark.camera_ready.campaign.subprocess.run",
+                side_effect=fake_subprocess_run,
+            ),
+            patch(
+                "robot_sf.benchmark.camera_ready.campaign._planner_report_row",
+                return_value={"planner_key": planner.key, "status": "ok"},
+            ),
+            patch("robot_sf.benchmark.camera_ready.campaign.read_jsonl", return_value=[]),
+            patch(
+                "robot_sf.benchmark.camera_ready.campaign.classify_planner_row_status",
+                return_value="ok",
+            ),
+        ):
+            _run_campaign_planner_variant_subprocess(
+                context,
+                planner=planner,
+                kinematics="differential_drive",
+                active_observation_mode="lidar",
+            )
+
+        handoff = json.loads(captured_input["json"])
+        scoped_path = handoff["scoped_scenarios_path"]
+        assert isinstance(scoped_path, str)
+        assert json.loads(Path(scoped_path).read_text(encoding="utf-8")) == self.SCOPED
+
+    def test_worker_consumes_scoped_scenarios_verbatim(self, tmp_path):
+        """The worker runs exactly the serialized scenarios; the matrix is not re-read.
+
+        scenario_matrix_path points at a file that does not exist: if the worker
+        fell back to re-loading the matrix, run_batch would never be reached and
+        the legacy loader would raise instead.
+        """
+        from unittest.mock import Mock as _Mock
+
+        from robot_sf.benchmark.camera_ready.resource_lifecycle import (
+            _run_single_arm_subprocess,
+        )
+
+        scoped_path = tmp_path / "scoped_scenarios.json"
+        scoped_path.write_text(json.dumps(self.SCOPED), encoding="utf-8")
+
+        base = _make_arm_params()
+        params = _SubprocessArmParams(
+            **{
+                **base.__dict__,
+                "scenario_matrix_path": tmp_path / "does-not-exist.yaml",
+                "episodes_path": tmp_path / "episodes.jsonl",
+                "summary_path": tmp_path / "summary.json",
+                "scoped_scenarios_path": scoped_path,
+            }
+        )
+
+        captured = {}
+
+        def fake_run_batch(scenarios, **kwargs):
+            captured["scenarios"] = scenarios
+            return {
+                "status": "ok",
+                "total_jobs": 1,
+                "written": 1,
+                "failed_jobs": 0,
+                "failures": [],
+            }
+
+        with (
+            patch("robot_sf.benchmark.runner.run_batch", side_effect=fake_run_batch),
+            patch(
+                "robot_sf.benchmark.fallback_policy.summarize_benchmark_availability",
+                return_value=_Mock(availability_status="ok"),
+            ),
+            patch(
+                "robot_sf.benchmark.fallback_policy.availability_payload",
+                return_value={},
+            ),
+        ):
+            result = _run_single_arm_subprocess(params)
+
+        assert captured["scenarios"] == self.SCOPED
+        assert result["summary"]["status"] == "ok"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

Subprocess-isolated arms (`--arm-isolation subprocess`, #4826) produce **zero episodes**: the worker re-loads the scenario matrix from disk, which skips the campaign loader's `map_file` normalization (`_load_campaign_scenarios` in `_config.py` rewrites map paths repo-root-relative; a bare `load_scenario_matrix` does not). Every relative `map_file` then fails with:

```
ValueError: Scenario '...': map_file '../../maps/svg_maps/...' could not be resolved or loaded from scenario_path='.'
```

Observed live on Slurm: isolation smoke job 13372 (2 arms, 0 episodes) and a full campaign job 13373 (144/144 episodes failed). The re-load additionally loses seed overrides, scenario-candidate filtering, AMV overrides, horizon schedules, and the configured `holonomic_command_mode` — the smoke matrix planned `resolved_seeds: [111]` while the isolated arm actually ran seeds 219–221.

This is the third and final layer of the subprocess-isolation failure chain (#4957 arm-params JSON crash → #5239 phantom `scenario_matrix` import → this).

## Fix

Parent/worker parity by construction: `_run_campaign_planner_variant_subprocess` already computes `run.scoped_scenarios` — it now serializes them to `scoped_scenarios.json` in the planner dir and passes `scoped_scenarios_path` through the existing Path-safe handoff (`_SUBPROCESS_ARM_PATH_FIELDS`). The worker consumes that list verbatim; any future parent-side scenario transform is automatically included. Callers without the field keep the legacy re-load path.

No metric semantics change: in-process arms are untouched; subprocess arms previously produced no episodes at all.

## Tests

- serializer round-trip for the new Path field (both sides use the shared field tuple now, so an addition cannot miss one side)
- parent-side: real `_run_campaign_planner_variant_subprocess` handoff writes exactly `run.scoped_scenarios`
- worker-side: executes exactly the serialized list; `scenario_matrix_path` points at a nonexistent file to prove the matrix is not re-read

`pytest tests/benchmark/test_camera_ready_subprocess_isolation.py` — 24 passed.

## Linked issue and remaining acceptance

Refs #4826. This restores the subprocess scenario-parity code path required before that issue's
remaining live GPU multi-arm smoke can produce VRAM-release evidence. #4826 remains open until
that smoke is run and its evidence is recorded; this PR makes no GPU-smoke or benchmark-result
claim.
