### PR TITLE
ci: route external review bots to high-risk PRs (#5265)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# Reserve automatic CodeRabbit reviews for code-bearing pull requests.  The routing
+# workflow applies review-bot-auto for high-risk paths; contributors may apply
+# review-bot to request a review for an otherwise excluded pull request.
+reviews:
+  path_filters:
+    - "robot_sf/**"
+    - "fast-pysf/**"
+    - "scripts/**"
+    - "tests/**"
+    - ".github/workflows/**"
+  auto_review:
+    enabled: false
+    labels:
+      - review-bot-auto
+      - review-bot

--- a/.github/workflows/review-bot-routing.yml
+++ b/.github/workflows/review-bot-routing.yml
@@ -1,0 +1,66 @@
+name: Route external review bots
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: review-bot-routing-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  route-coderabbit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Label code-bearing pull requests for CodeRabbit review
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const automaticLabel = "review-bot-auto";
+            const highRiskPrefixes = [
+              "robot_sf/",
+              "fast-pysf/",
+              "scripts/",
+              "tests/",
+              ".github/workflows/",
+            ];
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const hasHighRiskPath = files.some(({ filename }) =>
+              highRiskPrefixes.some((prefix) => filename.startsWith(prefix)),
+            );
+
+            if (hasHighRiskPath) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: [automaticLabel],
+              });
+              core.info(`Applied ${automaticLabel} to a code-bearing pull request.`);
+              return;
+            }
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: automaticLabel,
+              });
+              core.info(`Removed ${automaticLabel}; no high-risk paths remain.`);
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              core.info(`No ${automaticLabel} label was present.`);
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,19 @@ scripts/dev/ruff_fix_format.sh
 BASE_REF=origin/main scripts/dev/pr_ready_check.sh
 ```
 
+### External review routing
+
+CodeRabbit reviews pull requests that change simulator code, tests, scripts, or GitHub Actions.
+Documentation, context, and evidence-registration-only pull requests are excluded by default so
+limited external-review capacity remains available for higher-risk changes. Add the `review-bot`
+label to explicitly request CodeRabbit review for an excluded pull request. The repository applies
+the `review-bot-auto` label to eligible code-bearing pull requests; do not add or remove that
+managed label manually.
+
+Gemini Code Assist has no equivalent repository-level path-and-label trigger, so this routing does
+not change Gemini's automatic-review behavior. Treat Gemini feedback as optional and keep the
+repository's human and gate-review requirements unchanged.
+
 ### Step 7: Commit Your Work
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ If you're extending robot_sf_ll7 for research, consider contributing:
 ### New Scenario Configurations
 
 ```yaml
-# In configs/scenarios/your_scenarios.yaml
+# In configs/scenarios/<scenario_name>.yaml
 scenarios:
   scenario_name:
     description: "Description of interaction pattern"
@@ -250,7 +250,7 @@ the `robot_sf_bench` entry point with explicit scenario, algorithm, and algorith
 uv run robot_sf_bench run \
   --matrix configs/scenarios/planner_sanity_matrix_v1.yaml \
   --algo your_planner \
-  --algo-config configs/algos/your_planner.yaml \
+  --algo-config configs/algos/<planner_name>.yaml \
   --out output/benchmarks/your_planner_smoke/episodes.jsonl \
   --repeats 1 \
   --horizon 300 \

--- a/docs/ai/ai-workflow.md
+++ b/docs/ai/ai-workflow.md
@@ -224,6 +224,18 @@ Automated and online reviewers may include:
 
 Treat these tools as reviewers, not as the source of truth. The source of truth is still the repo-native code, docs, tests, and validation commands.
 
+### External review-bot routing
+
+CodeRabbit automatic review is reserved for pull requests that touch `robot_sf/`, `fast-pysf/`,
+`scripts/`, `tests/`, or `.github/workflows/`. The routing workflow applies the managed
+`review-bot-auto` label to those pull requests. Documentation, context, and evidence-registration
+pull requests do not receive an automatic CodeRabbit review; add the `review-bot` label when an
+independent CodeRabbit review is useful. Do not manually change `review-bot-auto`.
+
+Gemini Code Assist does not expose an equivalent repository-level path-and-label trigger, so its
+automatic-review behavior is unchanged. This quota-routing policy does not weaken human or gate
+review requirements.
+
 When comments arrive, use `gh-pr-comment-fixer` or the equivalent local edit flow:
 
 1. Read the comment and decide whether it is actionable.

--- a/tests/test_review_bot_routing_config.py
+++ b/tests/test_review_bot_routing_config.py
@@ -1,0 +1,43 @@
+"""Regression checks for external review-bot routing configuration."""
+
+from pathlib import Path
+
+import yaml
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+HIGH_RISK_PATH_FILTERS = [
+    "robot_sf/**",
+    "fast-pysf/**",
+    "scripts/**",
+    "tests/**",
+    ".github/workflows/**",
+]
+
+
+def test_coderabbit_routes_only_labeled_reviews_to_high_risk_paths() -> None:
+    """Keep CodeRabbit's filters and label gate fail-closed."""
+    config = yaml.safe_load((REPOSITORY_ROOT / ".coderabbit.yaml").read_text())
+
+    assert config["reviews"]["path_filters"] == HIGH_RISK_PATH_FILTERS
+    assert config["reviews"]["auto_review"] == {
+        "enabled": False,
+        "labels": ["review-bot-auto", "review-bot"],
+    }
+
+
+def test_routing_workflow_tracks_every_coderabbit_high_risk_path() -> None:
+    """Keep the workflow's automatic label criteria aligned with CodeRabbit."""
+    workflow = yaml.load(
+        (REPOSITORY_ROOT / ".github/workflows/review-bot-routing.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+    script = workflow["jobs"]["route-coderabbit"]["steps"][0]["with"]["script"]
+
+    assert workflow["on"]["pull_request_target"]["types"] == [
+        "opened",
+        "reopened",
+        "synchronize",
+        "ready_for_review",
+    ]
+    assert "review-bot-auto" in script
+    assert all(path_filter.removesuffix("**") in script for path_filter in HIGH_RISK_PATH_FILTERS)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** CodeRabbit is now label-gated and path-filtered. A trusted, no-checkout workflow
  applies `review-bot-auto` only to pull requests touching `robot_sf/`, `fast-pysf/`, `scripts/`,
  `tests/`, or `.github/workflows/`; `review-bot` is the contributor opt-in for excluded PRs.
- **Why now:** external-review quotas were exhausted before code-bearing PRs received independent
  review.
- **Claim boundary:** this config and regression test prove the repository routing contract, not
  post-merge vendor behavior or a quota improvement.
- **Required validation:** final local readiness plus the two-PR post-merge recipe below.
- **Remaining blocker:** CodeRabbit and Gemini events can only be observed on pull requests opened
  after this configuration reaches `main`.

## Contract delta

- `.coderabbit.yaml` disables blanket auto-review, permits review only for `review-bot-auto` or
  `review-bot`, and filters reviewable files to the five high-risk path families.
- `.github/workflows/review-bot-routing.yml` adds the managed `review-bot-auto` label only when a
  pull request has a high-risk changed path; it removes that managed label if no such paths remain.
- Compatibility: docs/context/evidence-only pull requests no longer automatically consume
  CodeRabbit capacity. `review-bot` preserves an explicit independent-review escape hatch.
- Gemini Code Assist has no equivalent repository-level path-and-label trigger, so its automatic
  review behavior remains unchanged.

## Linked Issues

- Refs #5265 — [issue #5265](https://github.com/ll7/robot_sf_ll7/issues/5265)

## What Changed

- Added CodeRabbit routing configuration and a least-privilege label-routing workflow.
- Added regression tests that keep CodeRabbit filters and workflow path criteria aligned.
- Documented contributor and agent behavior, including the Gemini limitation.

## Validation / Proof

- `uv run pytest tests/test_review_bot_routing_config.py -v` — 2 passed.
- `uv run pre-commit run --files .coderabbit.yaml .github/workflows/review-bot-routing.yml CONTRIBUTING.md docs/ai/ai-workflow.md tests/test_review_bot_routing_config.py` — passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue-5265-pr-body.md scripts/dev/pr_ready_check.sh` — passed (core readiness lane).
- Post-merge verification recipe: open one docs/context-only PR and confirm no automatic CodeRabbit
  review; open one code-touching PR and confirm one CodeRabbit review; the next day run
  `gh pr list --repo ll7/robot_sf_ll7 --state merged --limit 20 --json number,files,comments` and
  check code-bearing rows for rate-limit notices.

## Risks / Rollout

- The routing workflow uses `pull_request_target` only to list files and manage labels; it does not
  check out or execute pull-request code.
- Vendor-side label-event behavior is a post-merge observation, not locally reproducible evidence.
- Roll back by deleting `.coderabbit.yaml` and the routing workflow, then removing the two labels.

## Follow-Up Issues

- Deferred work: post-merge two-PR verification is required because neither vendor event can run
  before the routing configuration is on `main`.
- Issues opened for follow-up: none — the parent issue #5265 owns this acceptance check.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Governance and propagation details</summary>

## Research Result Guidance

NA — workflow-only review routing; this PR makes no research, benchmark, metric, or paper-facing
result claim.

## Domain-Aware Approval

- Required for this PR: no — workflow-only change with no evidence-validity claim.
- Domains reviewed: NA.
- Status: not required.
- Approver/review source or waiver: not applicable.
- Validity checklist: not applicable.

## Falsification / Non-Transfer Check

- NA — this PR makes no research-result claim.

## Next Empirical Action

- Rerun needed: NA.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: post-merge vendor events only.
- Stop / revise / continue decision: revise the routing contract if either post-merge case fails.
- Proposed child issue or existing follow-up: #5265.

## Docs / Provenance

- Updated docs: `CONTRIBUTING.md`; `docs/ai/ai-workflow.md`.
- Relevant design or provenance notes: CodeRabbit configuration schema v2; live issue #5265.
- Any assumptions that need to be preserved: positive CodeRabbit labels trigger review when blanket
  auto-review is disabled.

## Downstream Propagation

- Parent issue updated: no separate comment — the granted authorization excludes issue/PR comments;
  this linked PR and its checklist are the durable delivery surface.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: no — #5265 already owns the post-merge check.
- Not applicable because: no research or artifact evidence was produced.

</details>
