### PR TITLE
feat: add exact-repeat campaign packet (#5263)

### DIFF
--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -1,5 +1,8 @@
 # Context Retrieval Index
 
+Issue #5263 exact-repeat campaign packet (seven knife-edge cells and fail-closed two-host matrix):
+[README.md](evidence/issue_5263_exact_repeat/README.md).
+
 Registered emergent-phenomena demonstration for the released pedestrian substrate (lane formation, doorway oscillation, exit arching) at released + literature-typical speed:
 [README.md](evidence/issue_5149_emergent_phenomena_2026-07/README.md).
 

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -20,6 +20,10 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+- path: docs/context/evidence/issue_5263_exact_repeat/README.md
+  status: evidence
+  freshness: evidence
+  area: benchmark_evidence
 - path: docs/context/evidence/issue_5006_residual_review_thread_ledger.md
   status: evidence
   freshness: evidence

--- a/docs/context/evidence/issue_5263_exact_repeat/README.md
+++ b/docs/context/evidence/issue_5263_exact_repeat/README.md
@@ -1,0 +1,54 @@
+# Issue #5263 exact-repeat evidence packet
+
+This packet defines the exact CPU-only repeat campaign needed to determine whether the seven
+retained knife-edge cells reproduce bit-for-bit. It is a diagnostic campaign contract, not a
+campaign result or a benchmark claim.
+
+## What is pinned
+
+`build_exact_repeat_campaign_packet.py manifest` reads the committed #4978 flakiness report and
+its 400 retained episode rows. It selects the seven cells marked `knife_edge`, retains all 20
+original seeds from each, and requires exactly three repeats: 420 episode executions in total.
+Each target records its scenario ID, planner, seed, horizon, source Git revision, and source
+configuration hash. The manifest is CPU-only and single-worker; it never stores a target-host
+assignment.
+
+The retained fixture does not contain runnable `scenario_params` or `planner_config` objects. That
+is an intentional fail-closed blocker: a host must acquire those definitions from the original
+campaign configuration and prove that their hashes match the manifest before execution. The packet
+therefore cannot be mistaken for an empirical result.
+
+## Commands
+
+```bash
+uv run python scripts/benchmark/build_exact_repeat_campaign_packet.py manifest \
+  --baseline-report tests/fixtures/benchmark/scenario_flakiness_issue_4978/real_campaign_flakiness_report.json \
+  --source-episodes tests/fixtures/benchmark/scenario_flakiness_issue_4978/real_campaign_episodes.jsonl \
+  --output output/issue_5263/exact_repeat_manifest.json
+
+uv run python scripts/benchmark/build_exact_repeat_campaign_packet.py verify-host \
+  --manifest output/issue_5263/exact_repeat_manifest.json \
+  --host-report output/issue_5263/host_result.json \
+  --output output/issue_5263/verified_host_result.json
+
+uv run python scripts/benchmark/build_exact_repeat_campaign_packet.py compare-hosts \
+  --manifest output/issue_5263/exact_repeat_manifest.json \
+  --first output/issue_5263/verified_host_a.json \
+  --second output/issue_5263/verified_host_b.json \
+  --output output/issue_5263/cross_host_matrix.json
+```
+
+`verify-host` rejects missing targets, a Git revision or per-target horizon/config hash that does
+not match the manifest, non-CPU or multi-worker metadata, absent NumPy/Numba versions,
+not-exactly-three repeats, malformed trajectory hashes, and unrecorded divergences. A
+repeat is identical only when its binary outcome and SHA-256 trajectory hash agree. Otherwise the
+host report must state the first differing repeat and field. `compare-hosts` accepts only distinct
+machine identifiers with matching pinned NumPy and Numba versions; a version mismatch is
+divergent, not a successful comparison.
+
+## Evidence status and remaining action
+
+No full benchmark campaign, Slurm/GPU submission, or paper/dissertation claim update was made by
+this packet. The remaining empirical action is to recover the original runnable definitions, run
+the 420 CPU-only repeats on one host, register the verified report under this evidence directory,
+then run and compare the second-host near-miss repeat with its environment manifest.

--- a/docs/context/evidence/issue_5263_exact_repeat/README.md
+++ b/docs/context/evidence/issue_5263_exact_repeat/README.md
@@ -1,3 +1,4 @@
+<!-- AI-GENERATED (robot_sf#5263, 2026-07-11) - NEEDS-REVIEW -->
 # Issue #5263 exact-repeat evidence packet
 
 This packet defines the exact CPU-only repeat campaign needed to determine whether the seven

--- a/robot_sf/benchmark/exact_repeat_campaign.py
+++ b/robot_sf/benchmark/exact_repeat_campaign.py
@@ -1,0 +1,392 @@
+"""Fail-closed exact-repeat campaign packets for issue #5263.
+
+The retained #4978 fixture identifies seven knife-edge scenario/planner cells,
+but it deliberately omits runnable scenario and planner definitions.  This
+module turns that bounded, durable evidence into a campaign manifest and checks
+the result files produced by a future CPU-only run.  It does not execute a
+campaign, change metric semantics, or infer a determinism verdict from missing
+trajectory evidence.
+
+Every requested ``(scenario, planner, seed)`` target needs exactly three
+repeats.  A target is bitwise-identical only when its binary outcome and
+SHA-256 trajectory digest agree for all repeats.  A differing target must name
+its first divergence.  Two verified host reports can then be compared only when
+their pinned NumPy and Numba versions agree.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+BASELINE_SCHEMA_VERSION = "scenario_flakiness.v1"
+MANIFEST_SCHEMA_VERSION = "scenario_exact_repeat_campaign.v1"
+HOST_REPORT_SCHEMA_VERSION = "scenario_exact_repeat_host_result.v1"
+VERIFIED_HOST_REPORT_SCHEMA_VERSION = "scenario_exact_repeat_verified_host_result.v1"
+CROSS_HOST_SCHEMA_VERSION = "scenario_exact_repeat_cross_host.v1"
+DEFAULT_REPEATS = 3
+
+
+def canonical_sha256(value: Any) -> str:
+    """Return a stable SHA-256 digest for a JSON-compatible value."""
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _require_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _require_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _require_sha256(value: Any, label: str) -> str:
+    digest = _require_text(value, label)
+    if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest.lower()):
+        raise ValueError(f"{label} must be a lowercase-or-uppercase SHA-256 digest")
+    return digest.lower()
+
+
+def _planner(record: Mapping[str, Any]) -> str:
+    return _require_text(record.get("algo", record.get("planner")), "episode planner")
+
+
+def _target_key(target: Mapping[str, Any]) -> tuple[str, str, int]:
+    seed = target.get("seed")
+    if isinstance(seed, bool) or not isinstance(seed, int):
+        raise ValueError("target seed must be an integer")
+    return (
+        _require_text(target.get("scenario_id"), "target scenario_id"),
+        _require_text(target.get("planner"), "target planner"),
+        seed,
+    )
+
+
+def build_manifest(  # noqa: C901 - validation branches make the fail-closed contract explicit.
+    baseline_report: Mapping[str, Any],
+    source_episodes: Sequence[Mapping[str, Any]],
+    *,
+    repeats: int = DEFAULT_REPEATS,
+) -> dict[str, Any]:
+    """Build an exact-repeat request from a flakiness report and source rows.
+
+    The request pins the selected cells, their original seed/horizon/commit and
+    config hashes.  It records that runnable definitions are still required;
+    this is intentional because the committed #4978 fixture retains only audit
+    fields, not the original scenario/planner configurations.
+
+    Returns:
+        An immutable, schema-versioned 420-run request with source provenance.
+    """
+    if repeats != DEFAULT_REPEATS:
+        raise ValueError(f"issue #5263 requires exactly {DEFAULT_REPEATS} repeats, got {repeats}")
+    if baseline_report.get("schema_version") != BASELINE_SCHEMA_VERSION:
+        raise ValueError("baseline report is not scenario_flakiness.v1")
+    cells = baseline_report.get("cells")
+    if not isinstance(cells, list):
+        raise ValueError("baseline report cells must be a list")
+    knife_edges = [
+        cell for cell in cells if isinstance(cell, Mapping) and cell.get("knife_edge") is True
+    ]
+    if not knife_edges:
+        raise ValueError("baseline report contains no knife-edge cells")
+
+    selected_cells = {
+        (
+            _require_text(cell.get("scenario_id"), "knife-edge scenario_id"),
+            _require_text(cell.get("planner"), "knife-edge planner"),
+        )
+        for cell in knife_edges
+    }
+    selected_rows: dict[tuple[str, str, int], Mapping[str, Any]] = {}
+    for row in source_episodes:
+        row = _require_mapping(row, "source episode")
+        key = (_require_text(row.get("scenario_id"), "episode scenario_id"), _planner(row))
+        if key not in selected_cells:
+            continue
+        seed = row.get("seed")
+        if isinstance(seed, bool) or not isinstance(seed, int):
+            raise ValueError(f"source episode {key} has no integer seed")
+        target = (*key, seed)
+        if target in selected_rows:
+            raise ValueError(f"duplicate source episode for target {target}")
+        selected_rows[target] = row
+
+    expected_targets = sum(int(cell.get("n_seeds", 0)) for cell in knife_edges)
+    if len(selected_rows) != expected_targets:
+        raise ValueError(
+            "source episodes do not cover every seed in the knife-edge cells: "
+            f"expected {expected_targets}, found {len(selected_rows)}"
+        )
+
+    targets = []
+    for key, row in sorted(selected_rows.items()):
+        horizon = row.get("horizon")
+        if isinstance(horizon, bool) or not isinstance(horizon, int) or horizon <= 0:
+            raise ValueError(f"source episode {key} has no positive integer horizon")
+        targets.append(
+            {
+                "scenario_id": key[0],
+                "planner": key[1],
+                "seed": key[2],
+                "horizon": horizon,
+                "source_git_hash": _require_text(row.get("git_hash"), "source git_hash"),
+                "source_config_hash": _require_text(row.get("config_hash"), "source config_hash"),
+            }
+        )
+
+    manifest = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "claim_boundary": "diagnostic-only; no campaign result is represented by this manifest",
+        "execution_contract": {
+            "cpu_only": True,
+            "workers": 1,
+            "repeats_per_target": repeats,
+            "trajectory_hash": "sha256",
+            "required_runtime_versions": ["numpy_version", "numba_version"],
+        },
+        "source": {
+            "baseline_report_sha256": canonical_sha256(baseline_report),
+            "source_episodes_sha256": canonical_sha256(list(source_episodes)),
+            "runnable_definitions_required": ["scenario_params", "planner_config"],
+        },
+        "cells": [
+            {"scenario_id": scenario_id, "planner": planner}
+            for scenario_id, planner in sorted(selected_cells)
+        ],
+        "targets": targets,
+    }
+    manifest["manifest_sha256"] = canonical_sha256(manifest)
+    return manifest
+
+
+def _check_manifest(
+    manifest: Mapping[str, Any],
+) -> tuple[dict[tuple[str, str, int], Mapping[str, Any]], int]:
+    if manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        raise ValueError("manifest has an unsupported schema_version")
+    contract = _require_mapping(manifest.get("execution_contract"), "manifest execution_contract")
+    if contract.get("cpu_only") is not True or contract.get("workers") != 1:
+        raise ValueError("manifest must require CPU-only single-worker execution")
+    repeats = contract.get("repeats_per_target")
+    if repeats != DEFAULT_REPEATS:
+        raise ValueError(f"manifest must require exactly {DEFAULT_REPEATS} repeats")
+    expected_hash = manifest.get("manifest_sha256")
+    without_hash = {key: value for key, value in manifest.items() if key != "manifest_sha256"}
+    if expected_hash != canonical_sha256(without_hash):
+        raise ValueError("manifest_sha256 does not match the manifest content")
+    targets = manifest.get("targets")
+    if not isinstance(targets, list) or not targets:
+        raise ValueError("manifest targets must be a non-empty list")
+    indexed: dict[tuple[str, str, int], Mapping[str, Any]] = {}
+    for target in targets:
+        target = _require_mapping(target, "manifest target")
+        key = _target_key(target)
+        if key in indexed:
+            raise ValueError(f"manifest contains duplicate target {key}")
+        _require_text(target.get("source_git_hash"), "target source_git_hash")
+        _require_text(target.get("source_config_hash"), "target source_config_hash")
+        horizon = target.get("horizon")
+        if isinstance(horizon, bool) or not isinstance(horizon, int) or horizon <= 0:
+            raise ValueError("target horizon must be a positive integer")
+        indexed[key] = target
+    return indexed, repeats
+
+
+def _repeat_fingerprint(repeat: Mapping[str, Any]) -> tuple[int, str, Any]:
+    outcome = repeat.get("outcome")
+    if isinstance(outcome, bool):
+        outcome = int(outcome)
+    if outcome not in (0, 1):
+        raise ValueError("repeat outcome must be binary")
+    trajectory = _require_sha256(repeat.get("trajectory_sha256"), "repeat trajectory_sha256")
+    return int(outcome), trajectory, repeat.get("near_misses")
+
+
+def _first_divergence(repeats: Sequence[Mapping[str, Any]]) -> dict[str, Any] | None:
+    reference = _repeat_fingerprint(repeats[0])
+    for index, repeat in enumerate(repeats[1:], start=1):
+        current = _repeat_fingerprint(repeat)
+        for field, expected, observed in zip(
+            ("outcome", "trajectory_sha256", "near_misses"), reference, current, strict=True
+        ):
+            if expected != observed:
+                return {
+                    "repeat_index": index,
+                    "field": field,
+                    "expected": expected,
+                    "observed": observed,
+                }
+    return None
+
+
+def verify_host_report(  # noqa: C901, PLR0912 - each rejected report state needs a specific error.
+    manifest: Mapping[str, Any], host_report: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Verify one host's exact-repeat results against the immutable manifest.
+
+    Missing, surplus, malformed, or divergent results are errors or explicit
+    non-identical verdicts; none can become an implicit successful cell.
+
+    Returns:
+        A verified report with per-target and per-cell determinism verdicts.
+    """
+    targets, repeats_per_target = _check_manifest(manifest)
+    if host_report.get("schema_version") != HOST_REPORT_SCHEMA_VERSION:
+        raise ValueError("host report has an unsupported schema_version")
+    if host_report.get("manifest_sha256") != manifest["manifest_sha256"]:
+        raise ValueError("host report was not produced for this manifest")
+    environment = _require_mapping(host_report.get("environment"), "host report environment")
+    for field in ("machine_id", "numpy_version", "numba_version", "python_version", "git_commit"):
+        _require_text(environment.get(field), f"host environment {field}")
+    if environment.get("cpu_only") is not True or environment.get("workers") != 1:
+        raise ValueError("host report must record CPU-only single-worker execution")
+    expected_commits = {target["source_git_hash"] for target in targets.values()}
+    if environment["git_commit"] not in expected_commits:
+        raise ValueError("host report git_commit does not match the manifest source revision")
+
+    results = host_report.get("results")
+    if not isinstance(results, list):
+        raise ValueError("host report results must be a list")
+    indexed_results: dict[tuple[str, str, int], Mapping[str, Any]] = {}
+    for result in results:
+        result = _require_mapping(result, "host result")
+        key = _target_key(result)
+        if key in indexed_results:
+            raise ValueError(f"host report contains duplicate result for {key}")
+        if key not in targets:
+            raise ValueError(f"host report contains unexpected target {key}")
+        expected_target = targets[key]
+        for field in ("horizon", "source_config_hash"):
+            if result.get(field) != expected_target[field]:
+                raise ValueError(f"host report target {key} has a mismatched {field}")
+        indexed_results[key] = result
+    missing = sorted(set(targets) - set(indexed_results))
+    if missing:
+        raise ValueError(f"host report is missing manifest targets: {missing[:3]}")
+
+    verified_targets = []
+    by_cell: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for key in sorted(targets):
+        result = indexed_results[key]
+        repeats = result.get("repeats")
+        if not isinstance(repeats, list) or len(repeats) != repeats_per_target:
+            raise ValueError(f"target {key} must contain exactly {repeats_per_target} repeats")
+        repeat_maps = [_require_mapping(item, "repeat") for item in repeats]
+        divergence = _first_divergence(repeat_maps)
+        reported = result.get("first_divergence")
+        if divergence is None and reported is not None:
+            raise ValueError(f"target {key} reports a divergence but repeats are identical")
+        if divergence is not None and reported != divergence:
+            raise ValueError(f"target {key} must record the computed first divergence")
+        verified = {
+            "scenario_id": key[0],
+            "planner": key[1],
+            "seed": key[2],
+            "bitwise_identical": divergence is None,
+            "first_divergence": divergence,
+            "repeat_fingerprints": [_repeat_fingerprint(item) for item in repeat_maps],
+        }
+        verified_targets.append(verified)
+        by_cell[key[:2]].append(verified)
+
+    cells = []
+    for (scenario_id, planner), target_results in sorted(by_cell.items()):
+        first = next(
+            (item["first_divergence"] for item in target_results if item["first_divergence"]), None
+        )
+        cells.append(
+            {
+                "scenario_id": scenario_id,
+                "planner": planner,
+                "exact_repeat_determinism": first is None,
+                "first_divergence": first,
+                "n_targets": len(target_results),
+            }
+        )
+    verified = {
+        "schema_version": VERIFIED_HOST_REPORT_SCHEMA_VERSION,
+        "manifest_sha256": manifest["manifest_sha256"],
+        "environment": dict(environment),
+        "targets": verified_targets,
+        "cells": cells,
+        "summary": {
+            "n_targets": len(verified_targets),
+            "n_cells": len(cells),
+            "all_cells_bitwise_identical": all(cell["exact_repeat_determinism"] for cell in cells),
+        },
+    }
+    return verified
+
+
+def compare_verified_hosts(
+    manifest: Mapping[str, Any], first: Mapping[str, Any], second: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Build the fail-closed two-host exact-repeat comparison matrix.
+
+    Returns:
+        A matrix whose cells are identical only with matching runtime versions
+        and matching repeat fingerprints.
+    """
+    targets, _ = _check_manifest(manifest)
+    for report in (first, second):
+        if report.get("schema_version") != VERIFIED_HOST_REPORT_SCHEMA_VERSION:
+            raise ValueError("cross-host input is not a verified host report")
+        if report.get("manifest_sha256") != manifest["manifest_sha256"]:
+            raise ValueError("cross-host input belongs to a different manifest")
+    first_env = _require_mapping(first.get("environment"), "first host environment")
+    second_env = _require_mapping(second.get("environment"), "second host environment")
+    first_machine = _require_text(first_env.get("machine_id"), "first machine_id")
+    second_machine = _require_text(second_env.get("machine_id"), "second machine_id")
+    if first_machine == second_machine:
+        raise ValueError("cross-host comparison requires two distinct machine_id values")
+    version_match = all(
+        first_env.get(key) == second_env.get(key) for key in ("numpy_version", "numba_version")
+    )
+
+    def index(report: Mapping[str, Any]) -> dict[tuple[str, str, int], Mapping[str, Any]]:
+        rows = report.get("targets")
+        if not isinstance(rows, list):
+            raise ValueError("verified host report targets must be a list")
+        return {_target_key(_require_mapping(row, "verified target")): row for row in rows}
+
+    first_targets, second_targets = index(first), index(second)
+    if set(first_targets) != set(targets) or set(second_targets) != set(targets):
+        raise ValueError("verified host reports do not cover the manifest target set")
+    cells: dict[tuple[str, str], list[bool]] = defaultdict(list)
+    for key in sorted(targets):
+        identical = first_targets[key].get("repeat_fingerprints") == second_targets[key].get(
+            "repeat_fingerprints"
+        )
+        cells[key[:2]].append(bool(identical))
+    matrix = [
+        {
+            "scenario_id": scenario_id,
+            "planner": planner,
+            "bitwise_identical": version_match and all(target_matches),
+            "comparison_status": "identical"
+            if version_match and all(target_matches)
+            else "divergent",
+        }
+        for (scenario_id, planner), target_matches in sorted(cells.items())
+    ]
+    return {
+        "schema_version": CROSS_HOST_SCHEMA_VERSION,
+        "manifest_sha256": manifest["manifest_sha256"],
+        "hosts": [first_machine, second_machine],
+        "pinned_runtime_versions_match": version_match,
+        "matrix": matrix,
+        "summary": {
+            "n_cells": len(matrix),
+            "all_cells_bitwise_identical": version_match
+            and all(row["bitwise_identical"] for row in matrix),
+        },
+    }

--- a/scripts/benchmark/build_exact_repeat_campaign_packet.py
+++ b/scripts/benchmark/build_exact_repeat_campaign_packet.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Create or verify the exact-repeat evidence packet for issue #5263."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.exact_repeat_campaign import (
+    build_manifest,
+    compare_verified_hosts,
+    verify_host_report,
+)
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    manifest = subcommands.add_parser("manifest", help="build the immutable seven-cell request")
+    manifest.add_argument("--baseline-report", type=Path, required=True)
+    manifest.add_argument("--source-episodes", type=Path, required=True)
+    manifest.add_argument("--output", type=Path, required=True)
+    verify = subcommands.add_parser("verify-host", help="verify a completed host report")
+    verify.add_argument("--manifest", type=Path, required=True)
+    verify.add_argument("--host-report", type=Path, required=True)
+    verify.add_argument("--output", type=Path, required=True)
+    compare = subcommands.add_parser("compare-hosts", help="compare two verified host reports")
+    compare.add_argument("--manifest", type=Path, required=True)
+    compare.add_argument("--first", type=Path, required=True)
+    compare.add_argument("--second", type=Path, required=True)
+    compare.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main() -> int:
+    """Parse a packet action and write its schema-checked JSON result."""
+    args = _parser().parse_args()
+    if args.command == "manifest":
+        payload = build_manifest(
+            _read_json(args.baseline_report), _read_jsonl(args.source_episodes)
+        )
+    elif args.command == "verify-host":
+        payload = verify_host_report(_read_json(args.manifest), _read_json(args.host_report))
+    else:
+        payload = compare_verified_hosts(
+            _read_json(args.manifest), _read_json(args.first), _read_json(args.second)
+        )
+    _write_json(args.output, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_exact_repeat_campaign.py
+++ b/tests/benchmark/test_exact_repeat_campaign.py
@@ -1,0 +1,150 @@
+"""Contract tests for the issue #5263 exact-repeat campaign packet."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from robot_sf.benchmark.exact_repeat_campaign import (
+    HOST_REPORT_SCHEMA_VERSION,
+    build_manifest,
+    compare_verified_hosts,
+    verify_host_report,
+)
+
+FIXTURE_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "fixtures"
+    / "benchmark"
+    / "scenario_flakiness_issue_4978"
+)
+
+
+def _load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict[str, Any]:
+    """Compile the retained #4978 data into the #5263 request."""
+    episodes = [
+        json.loads(line)
+        for line in (FIXTURE_DIR / "real_campaign_episodes.jsonl").read_text().splitlines()
+    ]
+    return build_manifest(_load(FIXTURE_DIR / "real_campaign_flakiness_report.json"), episodes)
+
+
+def _host_report(manifest: dict[str, Any], machine_id: str) -> dict[str, Any]:
+    repeats = [{"outcome": 1, "trajectory_sha256": "a" * 64, "near_misses": 0} for _ in range(3)]
+    return {
+        "schema_version": HOST_REPORT_SCHEMA_VERSION,
+        "manifest_sha256": manifest["manifest_sha256"],
+        "environment": {
+            "machine_id": machine_id,
+            "cpu_only": True,
+            "workers": 1,
+            "numpy_version": "2.3.5",
+            "numba_version": "0.65.1",
+            "python_version": "3.13.14",
+            "git_commit": manifest["targets"][0]["source_git_hash"],
+        },
+        "results": [
+            {**target, "repeats": copy.deepcopy(repeats)} for target in manifest["targets"]
+        ],
+    }
+
+
+def test_manifest_pins_all_seven_knife_edge_cells_and_their_420_runs(manifest):
+    """The retained fixture compiles to the exact bounded campaign request."""
+    assert len(manifest["cells"]) == 7
+    assert len(manifest["targets"]) == 140
+    assert manifest["execution_contract"] == {
+        "cpu_only": True,
+        "workers": 1,
+        "repeats_per_target": 3,
+        "trajectory_hash": "sha256",
+        "required_runtime_versions": ["numpy_version", "numba_version"],
+    }
+    assert manifest["source"]["runnable_definitions_required"] == [
+        "scenario_params",
+        "planner_config",
+    ]
+
+
+def test_host_verifier_requires_all_targets_and_reports_cell_verdicts(manifest):
+    """A complete identical host report proves all seven cell verdicts."""
+    verified = verify_host_report(manifest, _host_report(manifest, "host-a"))
+    assert verified["summary"] == {
+        "n_targets": 140,
+        "n_cells": 7,
+        "all_cells_bitwise_identical": True,
+    }
+    assert all(cell["exact_repeat_determinism"] is True for cell in verified["cells"])
+
+
+def test_host_verifier_requires_the_first_trajectory_divergence(manifest):
+    """A divergent digest is accepted only with its computed first difference."""
+    report = _host_report(manifest, "host-a")
+    result = report["results"][0]
+    result["repeats"][1]["trajectory_sha256"] = "b" * 64
+    with pytest.raises(ValueError, match="computed first divergence"):
+        verify_host_report(manifest, report)
+    result["first_divergence"] = {
+        "repeat_index": 1,
+        "field": "trajectory_sha256",
+        "expected": "a" * 64,
+        "observed": "b" * 64,
+    }
+    verified = verify_host_report(manifest, report)
+    assert verified["targets"][0]["bitwise_identical"] is False
+    assert verified["cells"][0]["exact_repeat_determinism"] is False
+
+
+def test_host_verifier_rejects_a_mismatched_commit_or_config(manifest):
+    """A matching seed alone cannot stand in for the pinned execution identity."""
+    report = _host_report(manifest, "host-a")
+    report["environment"]["git_commit"] = "not-the-source-revision"
+    with pytest.raises(ValueError, match="git_commit"):
+        verify_host_report(manifest, report)
+    report["environment"]["git_commit"] = manifest["targets"][0]["source_git_hash"]
+    report["results"][0]["source_config_hash"] = "different"
+    with pytest.raises(ValueError, match="source_config_hash"):
+        verify_host_report(manifest, report)
+
+
+def test_cross_host_comparison_requires_pinned_versions_and_exact_fingerprints(manifest):
+    """Version or fingerprint mismatches remain explicit divergent evidence."""
+    first = verify_host_report(manifest, _host_report(manifest, "host-a"))
+    second = verify_host_report(manifest, _host_report(manifest, "host-b"))
+    comparison = compare_verified_hosts(manifest, first, second)
+    assert comparison["summary"]["all_cells_bitwise_identical"] is True
+
+    second["environment"]["numba_version"] = "different"
+    comparison = compare_verified_hosts(manifest, first, second)
+    assert comparison["pinned_runtime_versions_match"] is False
+    assert comparison["summary"]["all_cells_bitwise_identical"] is False
+
+
+def test_manifest_fails_closed_when_a_source_seed_is_missing():
+    """No retained seed may silently disappear from the requested repeat set."""
+    report = _load(FIXTURE_DIR / "real_campaign_flakiness_report.json")
+    episodes = [
+        json.loads(line)
+        for line in (FIXTURE_DIR / "real_campaign_episodes.jsonl").read_text().splitlines()
+    ]
+    knife_edge = next(cell for cell in report["cells"] if cell["knife_edge"])
+    filtered = [
+        row
+        for row in episodes
+        if not (
+            row["scenario_id"] == knife_edge["scenario_id"]
+            and row["algo"] == knife_edge["planner"]
+            and row["seed"] == 111
+        )
+    ]
+    with pytest.raises(ValueError, match="do not cover every seed"):
+        build_manifest(report, filtered)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds a new exact-repeat campaign packet that derives the seven knife-edge
  cells and all 140 original seeds from the committed #4978 fixture, requiring three CPU-only,
  single-worker repeats per target (420 executions). It verifies bitwise outcome/trajectory-hash
  consistency, records the first divergence when one occurs, and creates a fail-closed two-host
  comparison matrix with NumPy/Numba version matching.
- **Why now:** #5263 has the retained cell/seed/commit/config identity but not the runnable
  scenario and planner definitions, so an actual repeat campaign cannot be reproduced safely in
  this session. This PR supplies the durable contract and checker needed to run and register it
  once those definitions are recovered.
- **Claim boundary:** Diagnostic-only campaign infrastructure. It makes no empirical determinism,
  benchmark, metric, paper, or dissertation claim.
- **Required validation:** Final repository readiness gate plus 43 focused flakiness/packet tests.
- **Remaining blocker:** Obtain the original `scenario_params` and `planner_config` definitions
  matching the retained records; then execute the 420 CPU-only repeats and the second-host
  near-miss comparison.

## Contract delta

- New `scenario_exact_repeat_campaign.v1` immutable manifest: seven cells, 140 targets, source
  Git/config identity, CPU-only/single-worker execution, exactly three repeats, and SHA-256
  trajectory hashes.
- New host-result verifier rejects incomplete/surplus targets, wrong revision/horizon/config
  identity, missing runtime versions, non-CPU or multi-worker metadata, malformed hashes, and any
  unrecorded divergence.
- New cross-host matrix accepts only two distinct hosts with matching pinned NumPy/Numba versions;
  a version or fingerprint mismatch is explicitly divergent.
- Compatibility impact: additive tooling and documentation only; no benchmark metric semantics,
  ranking behavior, scenario configuration, or existing result schema changed.

<details>
<summary>Implementation, proof, and handoff details</summary>

## Linked issue and scope

- Refs #5263
- New capability: a durable exact-repeat request/compiler and result verifier for the issue's
  seven knife-edge cells, including a two-host comparison contract.
- Assumption: because the committed fixture intentionally lacks runnable definitions, the
  reversible checker/packet is the smallest complete code-and-CPU-validation slice; it fails
  closed instead of inventing a campaign configuration.

## Validation / proof

```text
uv run ruff check robot_sf/benchmark/exact_repeat_campaign.py \
  scripts/benchmark/build_exact_repeat_campaign_packet.py \
  tests/benchmark/test_exact_repeat_campaign.py
# All checks passed!

uv run pytest tests/benchmark/test_exact_repeat_campaign.py \
  tests/benchmark/test_scenario_flakiness_real_campaign.py \
  tests/benchmark/test_scenario_flakiness.py \
  tests/test_cli_flakiness_audit.py \
  tests/benchmark/test_cli_aggregate_flakiness.py -q
# 43 passed

uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml
# passed

PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh
# passed; committed-HEAD freshness recorded
```

Representative packet compilation against tracked input produced a
`scenario_exact_repeat_campaign.v1` manifest with 7 cells and 140 targets under
`output/issue_5263/`; it is ignored local cache, not durable evidence.

## Research and downstream propagation

- Target blocker: exact-repeat and cross-machine determinism were unmeasurable from a single-run
  retained fixture.
- Comparator: same `(scenario, planner, seed)` across 3 repeats; then host A vs host B with
  matching NumPy/Numba versions.
- Evidence tier / result classification: diagnostic packet / blocker-resolution. No campaign was
  run, so no result is promoted.
- Decision rule: only a complete verified host report may fill a cell verdict; missing runnable
  definitions, evidence, or matching runtime versions are fail-closed.
- Context index: updated with the packet README. Claim map, leaderboard, registry, and benchmark
  report: NA because no empirical artifact exists.
- State propagation: no issue comment was added because this run is not authorized to comment on
  issues or PRs; the PR body is the single delivery/status surface for this low-churn issue.

## Domain-Aware Approval

- Required for this PR: no — support tooling records future evidence but neither changes evidence
  classification nor interprets a benchmark result.
- Domains reviewed: NA.
- Status: not required.
- Approver/review source or waiver: packet is fail-closed and its claim boundary is diagnostic-only.

## Risks, artifacts, and follow-up

- The original runnable scenario/planner definitions are still unavailable; the packet explicitly
  records this as a blocker rather than treating retained metadata as executable input.
- No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.
- `output/issue_5263/` contains only ignored local packet output; no generated artifact is
  committed.
- Friction encountered: #5269 records the required `gh issue view --comments` GraphQL failure and
  its REST workaround.

## Remaining checklist for #5263

- [ ] Recover and hash-match the original runnable scenario and planner definitions.
- [ ] Run three CPU-only exact repeats for all 140 targets on one host and register the verified
      evidence bundle under `docs/context/evidence/`.
- [ ] Run the near-miss exact-repeat on a second host, record environment manifests, and register
      the cross-host matrix.
- [ ] If divergence is detected, open a separate reproducibility-fix issue; do not alter metric
      semantics during the freeze.

</details>
