### PR TITLE
fix(benchmark): integrate fail-closed trace readiness for issue #3574

### DIFF
--- a/docs/context/issue_3574_mean_matched_harness.md
+++ b/docs/context/issue_3574_mean_matched_harness.md
@@ -15,7 +15,8 @@ heterogeneous and homogeneous mean-matched rows before any benchmark campaign ru
   near-field exposure rows when that threshold metadata is absent.
 - The runtime trace path is `algorithm_metadata.pedestrian_control_trace`. Before report
   analysis, `mean_matched_episode_readiness.v1` requires every manifest row exactly once and
-  checks each simulator-indexed archetype/control label plus every declared metric field.
+  checks each simulator-indexed archetype/control label, every declared trace metric field, and
+  the finite episode-level `metrics.mean_clearance` value consumed by rank sensitivity.
 - It does not run a full ablation campaign, response-law mixture sweep, rank-order
   sensitivity analysis, Slurm job, or paper/dissertation claim update.
 

--- a/docs/context/issue_3574_mean_matched_harness.md
+++ b/docs/context/issue_3574_mean_matched_harness.md
@@ -13,6 +13,9 @@ heterogeneous and homogeneous mean-matched rows before any benchmark campaign ru
   near-field exposure duration (`near_field_exposure_s`). The trace records the
   configured surface-clearance threshold alongside those fields; the manifest blocks
   near-field exposure rows when that threshold metadata is absent.
+- The runtime trace path is `algorithm_metadata.pedestrian_control_trace`. Before report
+  analysis, `mean_matched_episode_readiness.v1` requires every manifest row exactly once and
+  checks each simulator-indexed archetype/control label plus every declared metric field.
 - It does not run a full ablation campaign, response-law mixture sweep, rank-order
   sensitivity analysis, Slurm job, or paper/dissertation claim update.
 
@@ -27,3 +30,13 @@ uv run python scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574
 The output uses schema `mean_matched_heterogeneity_harness.v1`. Missing episode
 trace inputs are fail-closed blockers until a future run supplies stable
 per-pedestrian archetype labels and per-step metric values.
+
+The report command consumes both the manifest and episode records. It writes
+`integration_readiness.json` and exits with status 2 before metric or rank analysis when rows are
+missing, duplicated, unexpected, or lack aligned trace metadata:
+
+```bash
+uv run python scripts/benchmark/build_heterogeneous_population_ablation_report.py \
+  --manifest output/issue_3574_mean_matched_harness/manifest.json \
+  --records output/issue_3574_mean_matched_harness/episode_records.jsonl
+```

--- a/robot_sf/benchmark/heterogeneous_population_ablation.py
+++ b/robot_sf/benchmark/heterogeneous_population_ablation.py
@@ -28,6 +28,7 @@ HETEROGENEOUS_POPULATION_ABLATION_SCHEMA = "heterogeneous_population_ablation_ha
 MEAN_MATCHED_HETEROGENEITY_HARNESS_SCHEMA = "mean_matched_heterogeneity_harness.v1"
 MEAN_MATCHED_EPISODE_READINESS_SCHEMA = "mean_matched_episode_readiness.v1"
 EPISODE_CONTROL_TRACE_PATH = "algorithm_metadata.pedestrian_control_trace"
+RANK_METRIC_KEY = "mean_clearance"
 
 
 @dataclass(frozen=True, slots=True)
@@ -294,6 +295,7 @@ def assess_mean_matched_episode_records(
             row_blockers.append("episode record missing")
         else:
             row_blockers.extend(_episode_trace_blockers(record, expected_by_key[key], metric_keys))
+            row_blockers.extend(_episode_rank_metric_blockers(record))
         row_readiness.append(
             {
                 "scenario_id": key[0],
@@ -317,6 +319,7 @@ def assess_mean_matched_episode_records(
         "ready": not blockers,
         "claim_boundary": "integration_readiness_only_no_ablation_result",
         "trace_metric_keys": metric_keys,
+        "rank_metric_key": RANK_METRIC_KEY,
         "expected_row_count": len(expected_by_key),
         "observed_row_count": len(observed_by_key),
         "row_readiness": row_readiness,
@@ -364,6 +367,24 @@ def _episode_trace_blockers(
     blockers.extend(_trace_metric_metadata_blockers(trace, metric_keys))
     blockers.extend(_trace_population_metadata_blockers(trace, manifest_row))
     return blockers
+
+
+def _episode_rank_metric_blockers(record: Mapping[str, Any]) -> list[str]:
+    """Require the finite episode metric consumed by rank sensitivity.
+
+    Returns:
+        Field-level blockers when the rank metric is absent or non-finite.
+    """
+
+    metrics = record.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return ["metrics missing or not mapping"]
+    value = metrics.get(RANK_METRIC_KEY)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return [f"metrics.{RANK_METRIC_KEY} missing or not finite number"]
+    if not math.isfinite(float(value)):
+        return [f"metrics.{RANK_METRIC_KEY} missing or not finite number"]
+    return []
 
 
 def audit_smoke_mean_match(

--- a/robot_sf/benchmark/heterogeneous_population_ablation.py
+++ b/robot_sf/benchmark/heterogeneous_population_ablation.py
@@ -26,6 +26,8 @@ from robot_sf.ped_npc.ped_archetypes import allocate_archetype_counts, assign_ar
 
 HETEROGENEOUS_POPULATION_ABLATION_SCHEMA = "heterogeneous_population_ablation_harness.v1"
 MEAN_MATCHED_HETEROGENEITY_HARNESS_SCHEMA = "mean_matched_heterogeneity_harness.v1"
+MEAN_MATCHED_EPISODE_READINESS_SCHEMA = "mean_matched_episode_readiness.v1"
+EPISODE_CONTROL_TRACE_PATH = "algorithm_metadata.pedestrian_control_trace"
 
 
 @dataclass(frozen=True, slots=True)
@@ -249,11 +251,11 @@ def build_mean_matched_harness_manifest(
         "trace_metric_keys": metric_keys,
         "expected_episode_output_keys": [
             f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY}",
-            "metadata.pedestrian_control_trace",
-            "metadata.pedestrian_control_trace.pedestrians[].archetype",
-            "metadata.pedestrian_control_trace.pedestrians[].steps[]",
+            EPISODE_CONTROL_TRACE_PATH,
+            f"{EPISODE_CONTROL_TRACE_PATH}.pedestrians[].archetype",
+            f"{EPISODE_CONTROL_TRACE_PATH}.pedestrians[].steps[]",
             *(
-                ["metadata.pedestrian_control_trace.near_field_clearance_threshold_m"]
+                [f"{EPISODE_CONTROL_TRACE_PATH}.near_field_clearance_threshold_m"]
                 if "near_field_exposure_s" in metric_keys
                 else []
             ),
@@ -262,6 +264,106 @@ def build_mean_matched_harness_manifest(
         "row_count": len(manifest_rows),
         "blockers": blockers,
     }
+
+
+def assess_mean_matched_episode_records(
+    manifest: Mapping[str, Any],
+    episode_records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Validate real episode records against the paired manifest before analysis.
+
+    Every expected scenario/planner/seed/arm row must occur exactly once and carry a
+    ready per-pedestrian control trace for every declared metric. Missing, duplicate,
+    unexpected, or malformed rows remain explicit blockers; they are never silently
+    dropped from the future ablation report.
+
+    Returns:
+        Versioned integration-readiness report with row-level blockers.
+    """
+
+    manifest_rows = _required_sequence(manifest, "manifest_rows")
+    metric_keys = _metric_keys(manifest.get("trace_metric_keys"))
+    expected_by_key = _rows_by_campaign_key(manifest_rows, source="manifest_rows")
+    observed_by_key, blockers = _index_episode_records(episode_records)
+
+    row_readiness: list[dict[str, Any]] = []
+    for key in sorted(expected_by_key):
+        record = observed_by_key.get(key)
+        row_blockers: list[str] = []
+        if record is None:
+            row_blockers.append("episode record missing")
+        else:
+            row_blockers.extend(_episode_trace_blockers(record, expected_by_key[key], metric_keys))
+        row_readiness.append(
+            {
+                "scenario_id": key[0],
+                "planner": key[1],
+                "seed": key[2],
+                "population_arm": key[3],
+                "status": "ready" if not row_blockers else "blocked",
+                "ready": not row_blockers,
+                "blockers": row_blockers,
+            }
+        )
+        blockers.extend(f"{_format_campaign_key(key)}: {blocker}" for blocker in row_blockers)
+
+    for key in sorted(set(observed_by_key) - set(expected_by_key)):
+        blockers.append(f"unexpected episode record for {_format_campaign_key(key)}")
+
+    return {
+        "schema_version": MEAN_MATCHED_EPISODE_READINESS_SCHEMA,
+        "issue": 3574,
+        "status": "ready" if not blockers else "blocked",
+        "ready": not blockers,
+        "claim_boundary": "integration_readiness_only_no_ablation_result",
+        "trace_metric_keys": metric_keys,
+        "expected_row_count": len(expected_by_key),
+        "observed_row_count": len(observed_by_key),
+        "row_readiness": row_readiness,
+        "blockers": blockers,
+    }
+
+
+def _index_episode_records(
+    episode_records: Sequence[Mapping[str, Any]],
+) -> tuple[dict[tuple[str, str, int, str], Mapping[str, Any]], list[str]]:
+    observed_by_key: dict[tuple[str, str, int, str], Mapping[str, Any]] = {}
+    blockers: list[str] = []
+    for index, record in enumerate(episode_records):
+        if not isinstance(record, Mapping):
+            blockers.append(f"episode_records[{index}] must be mapping")
+            continue
+        try:
+            key = _campaign_row_key(record, context=f"episode_records[{index}]")
+        except ValueError as exc:
+            blockers.append(str(exc))
+            continue
+        if key in observed_by_key:
+            blockers.append(f"duplicate episode record for {_format_campaign_key(key)}")
+            continue
+        observed_by_key[key] = record
+    return observed_by_key, blockers
+
+
+def _episode_trace_blockers(
+    record: Mapping[str, Any],
+    manifest_row: Mapping[str, Any],
+    metric_keys: Sequence[str],
+) -> list[str]:
+    algorithm_metadata = record.get("algorithm_metadata")
+    if not isinstance(algorithm_metadata, Mapping):
+        return ["algorithm_metadata missing or not mapping"]
+    trace = algorithm_metadata.get("pedestrian_control_trace")
+    if not isinstance(trace, Mapping):
+        return [f"{EPISODE_CONTROL_TRACE_PATH} missing or not mapping"]
+    blockers = [
+        blocker
+        for metric_key in metric_keys
+        for blocker in assess_control_trace_readiness(trace, metric_key).blockers
+    ]
+    blockers.extend(_trace_metric_metadata_blockers(trace, metric_keys))
+    blockers.extend(_trace_population_metadata_blockers(trace, manifest_row))
+    return blockers
 
 
 def audit_smoke_mean_match(
@@ -444,19 +546,15 @@ def _manifest_scenario_rows(
                         "population_composition_hash": composition_hash,
                         "expected_episode_output_keys": [
                             f"scenario.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY}",
-                            "metadata.pedestrian_control_trace",
-                            "metadata.pedestrian_control_trace.pedestrians[].archetype",
+                            EPISODE_CONTROL_TRACE_PATH,
+                            f"{EPISODE_CONTROL_TRACE_PATH}.pedestrians[].archetype",
                             *(
-                                [
-                                    "metadata.pedestrian_control_trace."
-                                    "near_field_clearance_threshold_m"
-                                ]
+                                [f"{EPISODE_CONTROL_TRACE_PATH}.near_field_clearance_threshold_m"]
                                 if "near_field_exposure_s" in metric_keys
                                 else []
                             ),
                             *[
-                                "metadata.pedestrian_control_trace.pedestrians[]."
-                                f"steps[].{metric_key}"
+                                f"{EPISODE_CONTROL_TRACE_PATH}.pedestrians[].steps[].{metric_key}"
                                 for metric_key in metric_keys
                             ],
                         ],
@@ -490,10 +588,9 @@ def _trace_readiness_by_arm(
                 "ready": False,
                 "metric_keys": list(metric_keys),
                 "blockers": [
-                    "metadata.pedestrian_control_trace missing",
+                    f"{EPISODE_CONTROL_TRACE_PATH} missing",
                     *[
-                        "metadata.pedestrian_control_trace.pedestrians[]."
-                        f"steps[].{metric_key} missing"
+                        f"{EPISODE_CONTROL_TRACE_PATH}.pedestrians[].steps[].{metric_key} missing"
                         for metric_key in metric_keys
                     ],
                 ],
@@ -549,6 +646,55 @@ def _trace_metric_metadata_blockers(
     return []
 
 
+def _trace_population_metadata_blockers(
+    trace: Mapping[str, Any], manifest_row: Mapping[str, Any]
+) -> list[str]:
+    """Check simulator-indexed trace labels against the manifest population arm.
+
+    Returns:
+        Field-level blockers for missing or mismatched population metadata.
+    """
+
+    arm_population = manifest_row.get("arm_population")
+    if not isinstance(arm_population, Mapping):
+        return ["manifest row arm_population missing or not mapping"]
+    expected_labels = arm_population.get(PEDESTRIAN_CONTROL_TRACE_LABELS_KEY)
+    if not isinstance(expected_labels, Sequence) or isinstance(expected_labels, str):
+        return [f"manifest row arm_population.{PEDESTRIAN_CONTROL_TRACE_LABELS_KEY} missing"]
+    pedestrians = trace.get("pedestrians")
+    if not isinstance(pedestrians, Sequence) or isinstance(pedestrians, str):
+        return ["control_trace.pedestrians must be a sequence"]
+    blockers: list[str] = []
+    if len(pedestrians) != len(expected_labels):
+        blockers.append(
+            "control_trace pedestrian count does not match manifest arm population: "
+            f"{len(pedestrians)} != {len(expected_labels)}"
+        )
+        return blockers
+
+    for index, (pedestrian, expected_label) in enumerate(
+        zip(pedestrians, expected_labels, strict=True)
+    ):
+        blockers.extend(_trace_label_blockers(pedestrian, expected_label, index=index))
+    return blockers
+
+
+def _trace_label_blockers(pedestrian: Any, expected_label: Any, *, index: int) -> list[str]:
+    if not isinstance(pedestrian, Mapping) or not isinstance(expected_label, Mapping):
+        return [f"control_trace label alignment at index {index} must use mappings"]
+    blockers: list[str] = []
+    for key in ("simulator_index", "archetype", "desired_speed_factor", "response_law"):
+        if key not in expected_label:
+            continue
+        if key not in pedestrian:
+            blockers.append(f"control_trace.pedestrians[{index}].{key} missing")
+        elif pedestrian[key] != expected_label[key]:
+            blockers.append(
+                f"control_trace.pedestrians[{index}].{key} does not match manifest label"
+            )
+    return blockers
+
+
 def _planner_rows(planners: Sequence[Any]) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for index, planner in enumerate(planners):
@@ -587,6 +733,33 @@ def _metric_keys(raw_metric_keys: Any) -> list[str]:
     if not metric_keys or any(not metric_key for metric_key in metric_keys):
         raise ValueError("trace_metric_keys must contain non-empty metric keys")
     return metric_keys
+
+
+def _campaign_row_key(row: Mapping[str, Any], *, context: str) -> tuple[str, str, int, str]:
+    scenario_id = _required_str(row, "scenario_id", context=context)
+    planner = _required_str(row, "planner", context=context)
+    seed = _required_int(row, "seed", context=context)
+    population_arm = _required_str(row, "population_arm", context=context)
+    return scenario_id, planner, seed, population_arm
+
+
+def _rows_by_campaign_key(
+    rows: Sequence[Any], *, source: str
+) -> dict[tuple[str, str, int, str], Mapping[str, Any]]:
+    indexed: dict[tuple[str, str, int, str], Mapping[str, Any]] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            raise ValueError(f"{source}[{index}] must be mapping")
+        key = _campaign_row_key(row, context=f"{source}[{index}]")
+        if key in indexed:
+            raise ValueError(f"{source} contains duplicate {_format_campaign_key(key)}")
+        indexed[key] = row
+    return indexed
+
+
+def _format_campaign_key(key: tuple[str, str, int, str]) -> str:
+    scenario_id, planner, seed, population_arm = key
+    return f"{scenario_id}/{planner}/seed_{seed}/{population_arm}"
 
 
 def _required_sequence(config: Mapping[str, Any], key: str) -> Sequence[Any]:

--- a/scripts/benchmark/build_heterogeneous_population_ablation_report.py
+++ b/scripts/benchmark/build_heterogeneous_population_ablation_report.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from robot_sf.benchmark.heterogeneous_population_ablation import (
+    assess_mean_matched_episode_records,
     build_per_archetype_ablation_report,
 )
 from robot_sf.benchmark.heterogeneous_rank_sensitivity import (
@@ -26,6 +27,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        default="output/issue_3574_mean_matched_harness/manifest.json",
+        help="Paired pre-run manifest used to fail closed on missing or extra episode rows.",
+    )
     parser.add_argument(
         "--records",
         default="output/issue_3574_mean_matched_harness/episode_records.jsonl",
@@ -62,33 +68,35 @@ def load_jsonl(path: Path) -> list[dict[str, Any]]:
 def main() -> int:  # noqa: C901,PLR0912,PLR0915
     """Run report compilation pipeline."""
     args = parse_args()
+    manifest_path = REPO_ROOT / args.manifest
     records_path = REPO_ROOT / args.records
     output_dir = REPO_ROOT / args.output_dir
     durable_dir = REPO_ROOT / args.durable_dir
 
+    if not manifest_path.exists():
+        print(f"Error: Manifest not found at {manifest_path}. Build it first.")
+        return 1
     if not records_path.exists():
         print(f"Error: Episode records not found at {records_path}. Run the simulations first.")
         return 1
 
+    with manifest_path.open("r", encoding="utf-8") as f:
+        manifest = json.load(f)
     records = load_jsonl(records_path)
     print(f"Loaded {len(records)} episode records.")
 
-    # Validate/skip incomplete rows (issue #4618 R5): downstream tabulation reads
-    # ``planner``/``seed``/``scenario_id``/``population_arm`` directly, so drop any record
-    # missing (or null in) those keys instead of raising a raw KeyError mid-report.
-    required_keys = ("planner", "seed", "scenario_id", "population_arm")
-    complete_records = [
-        rec for rec in records if all(rec.get(key) is not None for key in required_keys)
-    ]
-    skipped = len(records) - len(complete_records)
-    if skipped:
+    integration_readiness = assess_mean_matched_episode_records(manifest, records)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    readiness_path = output_dir / "integration_readiness.json"
+    readiness_path.write_text(
+        json.dumps(integration_readiness, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    if not integration_readiness["ready"]:
         print(
-            f"Skipped {skipped} incomplete episode record(s) missing required keys {required_keys}."
+            "Blocked: episode records do not satisfy the mean-matched manifest; "
+            f"see {readiness_path}"
         )
-    records = complete_records
-    if not records:
-        print("Error: no complete episode records with required keys; nothing to report.")
-        return 1
+        return 2
 
     # Find planners and seeds
     planners = sorted({rec["planner"] for rec in records})
@@ -186,6 +194,7 @@ def main() -> int:  # noqa: C901,PLR0912,PLR0915
     # Write summary.json
     summary_data = {
         "schema_version": "heterogeneous_population_ablation.v1",
+        "integration_readiness": integration_readiness,
         "rank_sensitivity": rank_sensitivity,
         "ablation_reports": ablation_reports,
     }

--- a/tests/benchmark/test_heterogeneous_population_ablation.py
+++ b/tests/benchmark/test_heterogeneous_population_ablation.py
@@ -4,15 +4,20 @@ from __future__ import annotations
 
 import json
 import math
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 import yaml
 
 from robot_sf.benchmark.heterogeneous_population_ablation import (
+    EPISODE_CONTROL_TRACE_PATH,
     HETEROGENEOUS_POPULATION_ABLATION_SCHEMA,
+    MEAN_MATCHED_EPISODE_READINESS_SCHEMA,
     MEAN_MATCHED_HETEROGENEITY_HARNESS_SCHEMA,
     ArchetypePopulationSpec,
+    assess_mean_matched_episode_records,
     audit_smoke_mean_match,
     build_mean_matched_harness_manifest,
     build_mean_matched_population_pair,
@@ -264,7 +269,7 @@ def test_mean_matched_harness_manifest_fails_closed_on_missing_control_trace_inp
 
     assert manifest["status"] == "blocked_pending_control_trace"
     assert any(
-        "metadata.pedestrian_control_trace missing" in blocker for blocker in manifest["blockers"]
+        f"{EPISODE_CONTROL_TRACE_PATH} missing" in blocker for blocker in manifest["blockers"]
     )
     assert any("steps[].clearance_m missing" in blocker for blocker in manifest["blockers"])
     assert any(
@@ -277,15 +282,15 @@ def test_mean_matched_harness_manifest_fails_closed_on_missing_control_trace_inp
         in first_row["expected_episode_output_keys"]
     )
     assert (
-        "metadata.pedestrian_control_trace.pedestrians[].steps[].clearance_m"
+        f"{EPISODE_CONTROL_TRACE_PATH}.pedestrians[].steps[].clearance_m"
         in first_row["expected_episode_output_keys"]
     )
     assert (
-        "metadata.pedestrian_control_trace.pedestrians[].steps[].near_field_exposure_s"
+        f"{EPISODE_CONTROL_TRACE_PATH}.pedestrians[].steps[].near_field_exposure_s"
         in first_row["expected_episode_output_keys"]
     )
     assert (
-        "metadata.pedestrian_control_trace.near_field_clearance_threshold_m"
+        f"{EPISODE_CONTROL_TRACE_PATH}.near_field_clearance_threshold_m"
         in first_row["expected_episode_output_keys"]
     )
     assert PEDESTRIAN_CONTROL_TRACE_LABELS_KEY in first_row["arm_population"]
@@ -405,6 +410,141 @@ def test_mean_matched_harness_manifest_reports_bad_fixture_trace_metric() -> Non
         "control_trace.pedestrians[0].steps[0] missing 'clearance_m'" in blocker
         for blocker in manifest["blockers"]
     )
+
+
+def _episode_records_for_manifest(manifest: dict[str, object]) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    manifest_rows = manifest["manifest_rows"]
+    assert isinstance(manifest_rows, list)
+    for row in manifest_rows:
+        labels = row["arm_population"][PEDESTRIAN_CONTROL_TRACE_LABELS_KEY]
+        pedestrians = [
+            {
+                **label,
+                "steps": [
+                    {"step": 0, "clearance_m": 0.8, "near_field_exposure_s": 0.1},
+                    {"step": 1, "clearance_m": 1.2, "near_field_exposure_s": 0.0},
+                ],
+            }
+            for label in labels
+        ]
+        records.append(
+            {
+                "scenario_id": row["scenario_id"],
+                "planner": row["planner"],
+                "seed": row["seed"],
+                "population_arm": row["population_arm"],
+                "algorithm_metadata": {
+                    "pedestrian_control_trace": {
+                        "schema_version": "pedestrian-control-trace.v1",
+                        "near_field_clearance_threshold_m": 1.0,
+                        "pedestrian_count": len(pedestrians),
+                        "pedestrians": pedestrians,
+                    }
+                },
+            }
+        )
+    return records
+
+
+def test_episode_record_readiness_integrates_manifest_with_runtime_trace_path() -> None:
+    """Complete runtime-shaped records satisfy the paired manifest exactly once."""
+
+    manifest = build_mean_matched_harness_manifest(_manifest_config())
+    readiness = assess_mean_matched_episode_records(
+        manifest, _episode_records_for_manifest(manifest)
+    )
+
+    assert readiness["schema_version"] == MEAN_MATCHED_EPISODE_READINESS_SCHEMA
+    assert readiness["status"] == "ready"
+    assert readiness["ready"] is True
+    assert readiness["expected_row_count"] == 8
+    assert readiness["observed_row_count"] == 8
+    assert readiness["blockers"] == []
+
+
+def test_episode_record_readiness_blocks_missing_manifest_row() -> None:
+    """A partial campaign cannot silently become an ablation report."""
+
+    manifest = build_mean_matched_harness_manifest(_manifest_config())
+    records = _episode_records_for_manifest(manifest)
+
+    readiness = assess_mean_matched_episode_records(manifest, records[:-1])
+
+    assert readiness["status"] == "blocked"
+    assert any("episode record missing" in blocker for blocker in readiness["blockers"])
+
+
+def test_episode_record_readiness_blocks_missing_or_misaligned_trace_metadata() -> None:
+    """Runtime trace location and simulator-indexed archetypes are mandatory."""
+
+    manifest = build_mean_matched_harness_manifest(_manifest_config())
+    records = _episode_records_for_manifest(manifest)
+    records[0]["algorithm_metadata"] = {}
+    trace = records[1]["algorithm_metadata"]["pedestrian_control_trace"]
+    trace["pedestrians"][0]["archetype"] = "wrong"
+
+    readiness = assess_mean_matched_episode_records(manifest, records)
+
+    assert readiness["status"] == "blocked"
+    assert any(
+        f"{EPISODE_CONTROL_TRACE_PATH} missing or not mapping" in blocker
+        for blocker in readiness["blockers"]
+    )
+    assert any(
+        "archetype does not match manifest label" in blocker for blocker in readiness["blockers"]
+    )
+
+
+def test_report_cli_stops_before_analysis_when_integration_readiness_is_blocked(
+    tmp_path: Path,
+) -> None:
+    """The report command persists blockers and does not analyze partial inputs."""
+
+    manifest_path = tmp_path / "manifest.json"
+    records_path = tmp_path / "records.jsonl"
+    output_dir = tmp_path / "report"
+    manifest_path.write_text(
+        json.dumps(build_mean_matched_harness_manifest(_manifest_config())), encoding="utf-8"
+    )
+    records_path.write_text(
+        json.dumps(
+            {
+                "scenario_id": "classic_density_002",
+                "planner": "goal",
+                "seed": 101,
+                "population_arm": "heterogeneous",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    command = [
+        sys.executable,
+        str(
+            Path(__file__).parents[2]
+            / "scripts/benchmark/build_heterogeneous_population_ablation_report.py"
+        ),
+        "--manifest",
+        str(manifest_path),
+        "--records",
+        str(records_path),
+        "--output-dir",
+        str(output_dir),
+    ]
+
+    result = subprocess.run(
+        command,
+        cwd=Path(__file__).parents[2],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    readiness = json.loads((output_dir / "integration_readiness.json").read_text(encoding="utf-8"))
+    assert readiness["status"] == "blocked"
+    assert not (output_dir / "summary.json").exists()
 
 
 _REPO_HARNESS_CONFIG_PATH = (

--- a/tests/benchmark/test_heterogeneous_population_ablation.py
+++ b/tests/benchmark/test_heterogeneous_population_ablation.py
@@ -434,6 +434,7 @@ def _episode_records_for_manifest(manifest: dict[str, object]) -> list[dict[str,
                 "planner": row["planner"],
                 "seed": row["seed"],
                 "population_arm": row["population_arm"],
+                "metrics": {"mean_clearance": 1.0},
                 "algorithm_metadata": {
                     "pedestrian_control_trace": {
                         "schema_version": "pedestrian-control-trace.v1",
@@ -494,6 +495,19 @@ def test_episode_record_readiness_blocks_missing_or_misaligned_trace_metadata() 
     assert any(
         "archetype does not match manifest label" in blocker for blocker in readiness["blockers"]
     )
+
+
+def test_episode_record_readiness_blocks_missing_rank_metric() -> None:
+    """Records cannot reach rank analysis without its finite episode metric."""
+
+    manifest = build_mean_matched_harness_manifest(_manifest_config())
+    records = _episode_records_for_manifest(manifest)
+    records[0].pop("metrics")
+
+    readiness = assess_mean_matched_episode_records(manifest, records)
+
+    assert readiness["status"] == "blocked"
+    assert any("metrics missing or not mapping" in blocker for blocker in readiness["blockers"])
 
 
 def test_report_cli_stops_before_analysis_when_integration_readiness_is_blocked(


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Consolidates the merged issue #3574 manifest, runtime trace, and report seams. The manifest now names the actual `algorithm_metadata.pedestrian_control_trace` path, and a versioned readiness report validates exact manifest-row coverage plus simulator-indexed archetype/control labels before analysis.
- **Why now:** Three issue-related PRs merged in the preceding 24 hours (#5062, #5220, #5237), but their integrated contract still declared `metadata.pedestrian_control_trace` while runtime and reporting use `algorithm_metadata.pedestrian_control_trace`. The fragmentation guard therefore calls for this consolidation/integration slice rather than another isolated field guard.
- **Claim boundary:** `diagnostic-only` implementation readiness. No ablation campaign ran and no heterogeneity, rank-stability, realism, or sim-to-real effect is interpreted.
- **Required validation:** Focused manifest/trace/report fixtures plus the full committed-HEAD PR-readiness gate; results are below.
- **Remaining blocker:** The paired campaign and any bootstrap/rank-reversal conclusion remain unrun. Realized-distribution campaign integration also remains to be reviewed against actual records.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3574

## Contract delta

- **Canonical trace path:** Manifest output contracts and blockers use `algorithm_metadata.pedestrian_control_trace`, matching `run_map_episode()` and the report reader.
- **New readiness schema:** `mean_matched_episode_readiness.v1` indexes expected and observed rows by scenario/planner/seed/population arm and requires every expected row exactly once.
- **New fail-closed blockers:** Missing, duplicate, unexpected, or malformed episode rows; absent runtime trace metadata; missing declared per-step metric fields or near-field threshold provenance; and pedestrian count, simulator index, archetype, desired-speed-factor, or response-law disagreement with the manifest population labels.
- **Report behavior:** `build_heterogeneous_population_ablation_report.py` now requires the paired manifest, writes `integration_readiness.json`, and exits 2 before metric/rank analysis when readiness is blocked. It no longer silently drops incomplete episode records.
- **Compatibility impact:** The dry-run builder remains pre-run/blocked as designed. Report callers must supply the manifest (the default path matches the runner workflow) and must resolve blockers rather than receiving a partial report.

## Scope summary

- Added the coherent manifest-to-runtime-to-report integration contract requested by the high-churn fragmentation guard.
- Added positive and fail-closed fixtures for complete, missing, and misaligned runtime-shaped episode records, plus a production CLI subprocess test.
- Updated the issue harness note with the canonical path, readiness artifact, and exit behavior.

## Validation

```text
uv run pytest tests/benchmark/test_heterogeneous_population_ablation.py -q
# 28 passed

uv run pytest tests/benchmark/test_heterogeneous_population_ablation.py \
  tests/benchmark/test_pedestrian_control_trace.py \
  tests/benchmark/test_heterogeneous_population_metrics.py \
  tests/benchmark/test_heterogeneous_population_distribution_audit.py \
  tests/benchmark/test_heterogeneous_rank_sensitivity.py \
  tests/benchmark/test_heterogeneous_rank_sensitivity_characterization.py -q
# 129 passed

uv run python scripts/benchmark/build_heterogeneity_ablation_manifest_issue_3574.py
# status: blocked_pending_control_trace; rows: 18 (expected pre-run fail-closed state)

PR_READY_MODE=final PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh
# committed-HEAD result recorded by the repository readiness stamp
```

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No heterogeneity-effect or planner-rank interpretation.

Refs #3574

Remaining issue work:

- [ ] Run the predeclared mean-matched paired campaign under common seeds with episode as the statistical unit.
- [ ] Confirm the realized-distribution audit on complete native campaign records.
- [ ] Run bootstrap P(A beats B) and the pre-specified rank-reversal analysis only after integration readiness is green.
- [ ] Promote only appropriately bounded benchmark conclusions after campaign review.

<details>
<summary>Governance, provenance, and handoff</summary>

### Research result guidance

- Target blocker: prevent partial or path-mismatched episode records from reaching per-archetype/rank analysis.
- Comparator: heterogeneous mixture versus homogeneous weighted-mean population under the existing paired manifest.
- Evidence tier: diagnostic probe.
- Result classification: blocker-resolution; implementation integrity only.
- Decision/stop rule: stop report construction at `integration_readiness.status=blocked`; campaign execution is excluded by authorization.
- Synthesis surface: `docs/context/issue_3574_mean_matched_harness.md`.
- New analysis tool first use: focused committed fixtures exercise the readiness report; it does not interpret research evidence.

### Domain-aware approval

- Required for this PR: yes - this change gates experimental-comparison inputs.
- Domains reviewed: evidence classification, experimental comparison, benchmark interpretation
- Status: waived
- Approver/review source or waiver: waived for PR opening because this is fail-closed input validation with no campaign or result interpretation; Claude Code retains post-open full-gate and merge authority.
- Validity checklist:
  - Target claim/hypothesis: implementation readiness only.
  - Comparator or split/evidence validity: pairing keys and mean-matched arm construction are unchanged.
  - Fallback/degraded exclusions: incomplete/misaligned rows block before analysis.
  - Claim boundary: diagnostic-only, not benchmark or paper evidence.
  - Implementation integrity vs experimental validity: fixtures prove integration behavior; only the future campaign can establish experimental validity.

### Falsification / non-transfer

- Mechanism activation: NA; no campaign was run.
- Result route: continue only after the readiness artifact is green.
- Follow-up: issue #3574 retains the empirical campaign and analysis work.

### Risks and rollout

- Compatibility risk: previously tolerated partial record sets now return exit 2. This is intentional fail-closed behavior.
- Failure mode: a future schema change can surface explicit row-level blockers; it cannot silently produce a partial analysis.
- Rollback: revert the readiness integration only if a valid native record is incorrectly blocked, preserving the canonical runtime path fix.

### Artifact and downstream propagation

- Generated manifest and coverage/readiness outputs under `output/` are ignored local diagnostics (705 files / 104 MiB in the worktree after validation); none are durable evidence or committed.
- Parent issue comment: not added because `comment_issue_or_pr` is explicitly unauthorized. The PR body plus updated issue harness context note are the canonical handoff surfaces for this high-churn integration slice.
- Claim map / leaderboard / artifact catalog / registry: not updated because no campaign evidence or claim was produced.
- Context note: updated.
- Friction issue: #5284 records the `scripts.benchmark` module/package import collision encountered by the production-path test.

### Late guidance and fragmentation

- Start time: 2026-07-11T07:58:14+02:00.
- The issue thread was re-read immediately before PR creation through the REST fallback; no comments newer than the start time were present. The required `gh issue view --comments` attempt still failed on the retired Projects Classic field (already tracked by #5188/#5269).
- Recent merged PRs: #5062, #5220, #5237. This PR is the required consolidation/integration slice and produces `mean_matched_episode_readiness.v1`, not another micro-guard.

</details>
