### PR TITLE
fix(scripts): make benchmark helpers importable (#5284)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -122,7 +122,6 @@ reviewed public command, a compatibility shim, or a bounded debug utility.
 | --- | --- | --- |
 | `__init__.py` | canonical | Import support for tested script modules. |
 | `analyze_feature_extractors.py` | compatibility | Prefer `research/generate_extractor_report.py` for multi-extractor report generation. |
-| `benchmark.py` | compatibility | Fails closed; use `scripts/benchmark_workers.py` or `scripts/validation/performance_smoke_test.py`. |
 | `benchmark02.py` | compatibility | Fails closed; use `scripts/benchmark_workers.py` or `scripts/validation/performance_smoke_test.py`. |
 | `benchmark_ped_apf_models.py` | debug-only | Narrow APF comparison helper. |
 | `benchmark_ped_policy_collisions.py` | debug-only | Narrow pedestrian-policy collision analysis helper. |
@@ -262,10 +261,16 @@ uv run python scripts/classic_benchmark_full.py
 
 **Details**: Expanded parser with full benchmark flags
 
-#### `benchmark.py`
+#### `benchmark/`
 
-**Purpose**: Retired root profiling benchmark. Fails closed with migration guidance.
-**Replacement**:
+**Purpose**: Importable benchmark reporting and campaign helper scripts. The retired root profiling
+benchmark remains available as a fail-closed module command:
+
+```bash
+uv run python -m scripts.benchmark
+```
+
+Use this maintained smoke alternative instead:
 
 ```bash
 DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy \

--- a/scripts/benchmark/__init__.py
+++ b/scripts/benchmark/__init__.py
@@ -1,11 +1,15 @@
-"""Fail-closed guard for the retired root-level profiling benchmark."""
+"""Importable benchmark reporting and campaign helper scripts.
+
+The retired root-level profiling benchmark remains available as
+``python -m scripts.benchmark`` and exits with migration guidance.
+"""
 
 from __future__ import annotations
 
 import sys
 
 _MIGRATION_MESSAGE = """\
-scripts/benchmark.py is retired.
+The root-level profiling benchmark is retired.
 
 Use one of the maintained benchmark or smoke entrypoints instead:
   uv run python scripts/benchmark_workers.py --out output/benchmarks/bench_workers
@@ -17,10 +21,9 @@ scripts/validation/ and record outputs under output/.
 
 
 def main(_argv: object = None) -> int:
-    """Exit non-zero with supported benchmark alternatives."""
+    """Exit non-zero with alternatives to the retired profiling benchmark."""
     sys.stderr.write(_MIGRATION_MESSAGE)
     return 2
 
 
-if __name__ == "__main__":  # pragma: no cover - CLI entry point
-    raise SystemExit(main())
+__all__ = ["main"]

--- a/scripts/benchmark/__main__.py
+++ b/scripts/benchmark/__main__.py
@@ -1,0 +1,5 @@
+"""Preserve the retired profiling benchmark's fail-closed module command."""
+
+from . import main
+
+raise SystemExit(main())

--- a/scripts/validation/docstring_todo_baseline.json
+++ b/scripts/validation/docstring_todo_baseline.json
@@ -31,7 +31,6 @@
     "robot_sf/telemetry/sampler.py": 35,
     "scripts/PPO_training/train_ppo_punish_action.py": 2,
     "scripts/analyze_feature_extractors.py": 27,
-    "scripts/benchmark.py": 1,
     "scripts/benchmark02.py": 2,
     "scripts/benchmark_workers.py": 10,
     "scripts/compare_slow_tests.py": 10,

--- a/tests/scripts/test_benchmark_package_import.py
+++ b/tests/scripts/test_benchmark_package_import.py
@@ -1,0 +1,14 @@
+"""Regression tests for the importable ``scripts.benchmark`` package."""
+
+from __future__ import annotations
+
+from scripts.benchmark import build_heterogeneous_population_ablation_report as report
+
+
+def test_report_module_imports_and_main_is_callable(tmp_path, monkeypatch, capsys) -> None:
+    """Focused tests can import and invoke benchmark report modules directly."""
+    missing_records = tmp_path / "missing-records.jsonl"
+    monkeypatch.setattr("sys.argv", ["report", "--records", str(missing_records)])
+
+    assert report.main() == 1
+    assert str(missing_records) in capsys.readouterr().out


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Replaced the colliding `scripts/benchmark.py` module with the importable
  `scripts.benchmark` package and added a direct-import regression test for the report named in
  the issue.
- **Why now:** The retired root-level shim prevented focused tests from importing benchmark report
  modules.
- **Claim boundary:** This is a scripts-package import-boundary repair only; it does not change
  benchmark behavior, metrics, configurations, or research claims.
- **Required validation:** The focused import-and-`main()` test, module-command compatibility check,
  Ruff, docs integrity check, and full core readiness lane passed locally.
- **Remaining blocker:** None; this resolves the collision described in #5284.

Closes #5284

Issue: https://github.com/ll7/robot_sf_ll7/issues/5284

## Contract delta

- `scripts.benchmark` is now an explicit importable package, so report modules can be imported as
  `scripts.benchmark.<module>` in focused tests.
- `python -m scripts.benchmark` preserves the prior retired-profiling-command contract: it prints
  migration guidance and exits with code 2.
- The obsolete `scripts/benchmark.py` docstring baseline entry was removed. No benchmark schema,
  fail-closed campaign blocker, metric, or compatibility contract for maintained benchmark runners
  changed.

## Scope and validation

Scope: only the module/package collision, its import regression test, the retired-command
compatibility path, and directly affected documentation metadata.

Validation:

- `uv run pytest tests/scripts/test_benchmark_package_import.py -q` — 1 passed.
- `uv run python -m scripts.benchmark` — exits 2 and prints the retirement migration guidance.
- `uv run ruff check scripts/benchmark tests/scripts/test_benchmark_package_import.py` — passed.
- `uv run ruff format --check scripts/benchmark tests/scripts/test_benchmark_package_import.py` — passed.
- `uv run python scripts/dev/check_docs_evidence_integrity.py --files scripts/README.md` — passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — core readiness lane passed.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation
claim edits.

## Downstream propagation

Not applicable: this non-evidence import-boundary repair does not update a claim map, benchmark
report, registry, or artifact catalog. No issue comment was added because the task authorization
forbids issue/PR comments; the direct closure link in this PR is the durable state surface.

<details>
<summary>Review appendix</summary>

### Compatibility and risk

- Existing filesystem invocation `python scripts/benchmark.py` is intentionally retired with the
  conflicting file. The supported compatibility command is now `python -m scripts.benchmark`.
- Generated `output/coverage/` files from validation are ignored, disposable local artifacts; none
  are included in this PR.

### Research and follow-up

- Research result guidance: NA — support/import-boundary repair only, with no benchmark or paper
  result.
- Domain-aware approval: not required — no evidence classification, experimental methodology, or
  claim surface changed.
- Follow-up issues: none. No new friction issue was filed: the only observed tooling friction was
  the known GitHub Projects Classic query failure, which was safely bypassed through the REST API.

</details>
