### PR TITLE
Issue #3574: pre-specified rank-reversal test primitive + CLI (cheap-lane worker)

### DIFF
--- a/docs/context/issue_3574_rank_reversal_test.md
+++ b/docs/context/issue_3574_rank_reversal_test.md
@@ -1,0 +1,60 @@
+# Issue #3574 Pre-Specified Rank-Reversal Test
+
+This note records the preregistered rank-reversal test primitive added for issue #3574. It is
+the *pre-specified rank-reversal test* named in the issue Definition of Done ("Rank-order
+sensitivity across >=3 planners per population composition reported with bootstrap P(A beats B)
+and a pre-specified rank-reversal test").
+
+## What this is
+
+A distinct, additive statistical primitive that complements the descriptive bootstrap
+rank-sensitivity report:
+
+- `compute_bootstrap_rank_sensitivity` (issue #4591) reports bootstrap P(A beats B) and a
+  **descriptive** ranking-list disagreement flag that fires on *any* ordering difference,
+  including differences within bootstrap sampling noise.
+- `pre_specified_rank_reversal_test` (this slice) is a **formal hypothesis test**. It only
+  declares a reversal when a planner pair has a bootstrap-determined ordering (percentile CI
+  excludes zero) in **both** arms with **opposite** signs, so a reversal cannot be triggered by
+  sampling noise.
+
+## Decision rule (declared before results)
+
+- **Null hypothesis (H0):** planner rank order is stable across the heterogeneous and
+  mean-matched homogeneous population compositions (no reversal).
+- **Test statistic:** per-seed paired performance difference per planner pair, per arm,
+  bootstrapped into a percentile confidence interval.
+- **Significance level:** `alpha` (default `0.05`); CI level `1 - alpha`.
+- **Decision:** reject H0 iff some planner pair is determined in both arms with opposite signs.
+- The `alpha`, CI method, and decision rule are echoed in the output `pre_registration` block as
+  `declared_before_results: true`, so the comparison is auditable when real paired campaign
+  episode records arrive.
+
+## Why "pre-specified"
+
+The test parameters and decision rule are fixed before the results are inspected (preregistration),
+not fit to the observed outcome. This is what the issue's literature grounding demands: a
+planner-specific, rank-reversal claim must be declared ex ante, not reported post hoc.
+
+## Entrypoint
+
+```bash
+uv run python scripts/benchmark/run_rank_reversal_test_issue_3574.py \
+  --manifest output/issue_3574_mean_matched_harness/manifest.json \
+  --records output/issue_3574_mean_matched_harness/episode_records.jsonl \
+  --output-dir output/issue_3574_mean_matched_harness
+```
+
+The CLI fails closed on the mean-matched integration-readiness check before rendering any test.
+Outputs use schema `heterogeneous_rank_reversal_test.v1` and write
+`rank_reversal_test.json` plus a compact `rank_reversal_test.md`.
+
+## Claim boundary
+
+- Evidence status: `diagnostic-only` analysis primitive.
+- This slice establishes **no** benchmark, rank-stability, realism, or sim-to-real claim on its
+  own.
+- A campaign conclusion requires real paired episode records that pass the readiness check; until
+  then the test is exercised on synthetic fixtures only.
+- The mean-matched paired ablation campaign, realized-distribution audit completion, and any
+  rank-stability conclusion remain open under the issue.

--- a/robot_sf/benchmark/heterogeneous_rank_sensitivity.py
+++ b/robot_sf/benchmark/heterogeneous_rank_sensitivity.py
@@ -3,6 +3,15 @@
 Evaluates whether planner ranking remains stable (or undergoes reversals) when
 moving from a homogeneous mean-matched population to a heterogeneous mixture population.
 Uses paired bootstrap resampling over seeds to compute confidence bounds and P(A beats B).
+
+This module also provides :func:`pre_specified_rank_reversal_test`, a *preregistered*
+hypothesis test on rank reversal that is distinct from the descriptive disagreement flag
+emitted by :func:`compute_bootstrap_rank_sensitivity`. The descriptive flag records any
+ranking-list disagreement; the preregistered test only declares a reversal when a planner
+pair has a bootstrap-determined ordering in *both* arms with *opposite* signs, so a
+reversal cannot be triggered by sampling noise. The test parameters (significance level
+``alpha``, percentile-CI method, and decision rule) are recorded as declared-before-results
+so the comparison is auditable when real campaign episode records arrive.
 """
 
 from __future__ import annotations
@@ -185,3 +194,446 @@ def compute_bootstrap_rank_sensitivity(  # noqa: C901,PLR0912,PLR0915
         "arms": arm_results,
         "reversals": reversals,
     }
+
+
+RANK_REVERSAL_TEST_SCHEMA = "heterogeneous_rank_reversal_test.v1"
+_DEFAULT_HETEROGENEOUS_ARM = "heterogeneous"
+_DEFAULT_MEAN_MATCHED_ARM = "mean_matched_homogeneous"
+
+
+def pre_specified_rank_reversal_test(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    metric_key: str,
+    planners: Sequence[str],
+    higher_is_safer: bool = True,
+    alpha: float = 0.05,
+    num_bootstrap: int = 1000,
+    seed: int | None = None,
+    arms: tuple[str, str] | None = None,
+) -> dict[str, Any]:
+    """Preregistered rank-reversal hypothesis test across population compositions.
+
+    This is the *pre-specified rank-reversal test* requested by issue #3574's Definition of
+    Done ("Rank-order sensitivity across >=3 planners per population composition reported with
+    bootstrap P(A beats B) and a pre-specified rank-reversal test"). It complements
+    :func:`compute_bootstrap_rank_sensitivity`, which already reports bootstrap P(A beats B)
+    and a descriptive ranking-list disagreement flag. Where the descriptive flag fires on
+    *any* ordering difference (including differences within bootstrap sampling noise), this
+    test only declares a reversal when a planner pair has a bootstrap-determined ordering in
+    *both* arms with *opposite* signs.
+
+    Null hypothesis ``H0``: rank order is stable across the two population compositions (no
+    reversal). The test rejects ``H0`` iff at least one planner pair is determined in both
+    arms with opposite signs. The significance level ``alpha``, the percentile bootstrap CI
+    method, and this exact decision rule are declared-before-results and echoed in the
+    ``pre_registration`` block so the comparison is auditable once real campaign episode
+    records arrive.
+
+    Args:
+        records: Episode records of the same shape consumed by
+            :func:`compute_bootstrap_rank_sensitivity` (``population_arm`` / ``planner`` /
+            ``seed`` / ``metrics[metric_key]``, with ``scenario_params`` fallback).
+        metric_key: Metric under ``metrics`` to test (e.g. ``"clearance_m"``).
+        planners: Planner keys to compare; at least two are required.
+        higher_is_safer: When true, larger metric values rank a planner higher.
+        alpha: Two-sided significance level in ``(0, 1)`` (default ``0.05``); the percentile
+            CI is computed at level ``1 - alpha``.
+        num_bootstrap: Number of bootstrap resamples of the seed axis.
+        seed: RNG seed for deterministic resampling.
+        arms: Optional ``(heterogeneous_arm, mean_matched_homogeneous_arm)`` name override; the
+            two names must differ. Defaults to the canonical #3574 arm names.
+
+    Returns:
+        Versioned (``heterogeneous_rank_reversal_test.v1``) report. ``status`` is
+        ``"ready"`` when both arms are present with >=2 common paired seeds across all
+        planners, else ``"blocked"`` with precise fail-closed blockers. A ready report
+        carries the preregistration block, the per-arm pairwise bootstrap CIs, the per-pair
+        reversal verdicts, the overall decision, and an explicit claim boundary.
+    """
+    planners, heterogeneous_arm, mean_matched_arm = _validate_test_arguments(
+        planners=planners, arms=arms, alpha=alpha, num_bootstrap=num_bootstrap
+    )
+
+    # The decision specification is fixed here, before any results are inspected, so the
+    # echoed ``pre_registration`` block is an ex-ante declaration rather than a post-hoc fit.
+    decision_rule = (
+        "Reject H0 (rank stability) iff some planner pair (i, j) has a bootstrap "
+        "(1-alpha) percentile CI on the per-seed paired mean difference that excludes "
+        "zero in BOTH arms with opposite signs (i ahead of j in one arm, j ahead of i in "
+        "the other)."
+    )
+    pre_registration = {
+        "declared_before_results": True,
+        "significance_level_alpha": float(alpha),
+        "ci_method": "percentile_bootstrap",
+        "ci_level": float(1.0 - alpha),
+        "num_bootstrap": int(num_bootstrap),
+        "higher_is_safer": bool(higher_is_safer),
+        "heterogeneous_arm": heterogeneous_arm,
+        "mean_matched_arm": mean_matched_arm,
+        "null_hypothesis": "rank order is stable across population compositions (no reversal)",
+        "decision_rule": decision_rule,
+    }
+
+    grouped = _group_records_by_arm_planner_seed(records, metric_key=metric_key)
+
+    blockers: list[str] = []
+    if heterogeneous_arm not in grouped:
+        blockers.append(f"no valid episode records for arm {heterogeneous_arm!r}")
+    if mean_matched_arm not in grouped:
+        blockers.append(f"no valid episode records for arm {mean_matched_arm!r}")
+    if blockers:
+        return _blocked_test_result(metric_key, blockers, pre_registration)
+
+    arm_arrays, arm_common_seeds, arm_blockers = _paired_performance_arrays(
+        grouped,
+        planners=planners,
+        arms=(heterogeneous_arm, mean_matched_arm),
+    )
+    if arm_blockers:
+        return _blocked_test_result(metric_key, arm_blockers, pre_registration)
+
+    het_arr = arm_arrays[heterogeneous_arm]
+    hom_arr = arm_arrays[mean_matched_arm]
+    common_seeds_count = arm_common_seeds[heterogeneous_arm]
+
+    rng = np.random.default_rng(seed)
+
+    pair_results: list[dict[str, Any]] = []
+    reversals: list[dict[str, Any]] = []
+    for i, planner_i in enumerate(planners):
+        for j in range(i + 1, len(planners)):
+            pair_record, reversal = _evaluate_planner_pair(
+                arrays=(het_arr, hom_arr),
+                i=i,
+                j=j,
+                planner_i=planner_i,
+                planner_j=planners[j],
+                higher_is_safer=higher_is_safer,
+                num_bootstrap=num_bootstrap,
+                rng=rng,
+            )
+            pair_results.append(pair_record)
+            if reversal is not None:
+                reversals.append(reversal)
+
+    decision = "reject_null_rank_stability" if reversals else "fail_to_reject_null_rank_stability"
+    return {
+        "schema_version": RANK_REVERSAL_TEST_SCHEMA,
+        "status": "ready",
+        "metric_key": metric_key,
+        "planners": list(planners),
+        "arms": [heterogeneous_arm, mean_matched_arm],
+        "common_seeds_count": common_seeds_count,
+        "pre_registration": pre_registration,
+        "pairwise": pair_results,
+        "reversals": reversals,
+        "decision": decision,
+        "reversal_count": len(reversals),
+        "claim_boundary": (
+            "Preregistered rank-reversal test primitive. Reports a reversal only when a "
+            "planner pair is bootstrap-determined in both arms with opposite signs. No "
+            "benchmark campaign, rank-order, realism, or sim-to-real claim is established "
+            "here; a campaign conclusion requires real paired episode records."
+        ),
+    }
+
+
+def _validate_test_arguments(
+    *,
+    planners: Sequence[str],
+    arms: tuple[str, str] | None,
+    alpha: float,
+    num_bootstrap: int,
+) -> tuple[list[str], str, str]:
+    """Validate test arguments and resolve the arm-name pair.
+
+    Returns:
+        ``(planners_list, heterogeneous_arm, mean_matched_arm)``.
+
+    Raises:
+        ValueError: If fewer than two planners, identical arm names, or invalid alpha / count.
+    """
+    if len(planners) < 2:
+        raise ValueError("At least 2 planners are required to compare ranks")
+    heterogeneous_arm, mean_matched_arm = arms or (
+        _DEFAULT_HETEROGENEOUS_ARM,
+        _DEFAULT_MEAN_MATCHED_ARM,
+    )
+    if heterogeneous_arm == mean_matched_arm:
+        raise ValueError("heterogeneous_arm and mean_matched_arm must differ")
+    if not (0.0 < alpha < 1.0):
+        raise ValueError("alpha must be in (0, 1)")
+    if num_bootstrap < 1:
+        raise ValueError("num_bootstrap must be >= 1")
+    return list(planners), heterogeneous_arm, mean_matched_arm
+
+
+def _blocked_test_result(
+    metric_key: str,
+    blockers: list[str],
+    pre_registration: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build a fail-closed blocked test result that still echoes the preregistration.
+
+    Returns:
+        Versioned blocked report with the precise blockers.
+    """
+    return {
+        "schema_version": RANK_REVERSAL_TEST_SCHEMA,
+        "status": "blocked",
+        "metric_key": metric_key,
+        "blockers": blockers,
+        "pre_registration": pre_registration,
+    }
+
+
+def _evaluate_planner_pair(
+    *,
+    arrays: tuple[np.ndarray, np.ndarray],
+    i: int,
+    j: int,
+    planner_i: str,
+    planner_j: str,
+    higher_is_safer: bool,
+    num_bootstrap: int,
+    rng: np.random.Generator,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Compute the per-pair verdict, pair record, and optional reversal for one pair.
+
+    Returns:
+        ``(pair_record, reversal)`` where ``reversal`` is ``None`` when the pair is not a
+        determined reversal (stable or indeterminate).
+    """
+    het_array, hom_array = arrays
+    het_diff = _seed_pair_difference(het_array, i, j, higher_is_safer=higher_is_safer)
+    hom_diff = _seed_pair_difference(hom_array, i, j, higher_is_safer=higher_is_safer)
+    het_ci = _bootstrap_mean_percentile_ci(het_diff, num_bootstrap, rng)
+    hom_ci = _bootstrap_mean_percentile_ci(hom_diff, num_bootstrap, rng)
+    het_sign = _determined_sign(het_ci)
+    hom_sign = _determined_sign(hom_ci)
+
+    if het_sign != 0 and hom_sign not in {0, het_sign}:
+        verdict = "reversal_detected"
+        is_reversal = True
+    elif het_sign != 0 and hom_sign == het_sign:
+        verdict = "stable_determined"
+        is_reversal = False
+    else:
+        # At least one arm's CI straddles zero -> the ordering is not statistically
+        # determined; we do not claim a reversal and we do not claim confirmed
+        # stability. ``indeterminate`` is the honest pre-specified outcome.
+        verdict = "indeterminate"
+        is_reversal = False
+
+    ahead_i_het = het_sign > 0
+    ahead_i_hom = hom_sign > 0
+    pair_record = {
+        "planners": [planner_i, planner_j],
+        "verdict": verdict,
+        "reversal": is_reversal,
+        "heterogeneous": {
+            "mean_difference": float(np.mean(het_diff)),
+            "ci_lower": float(het_ci[0]),
+            "ci_upper": float(het_ci[1]),
+            "determined_sign": _sign_label(het_sign, planner_i=planner_i, planner_j=planner_j),
+            f"{planner_i}_ahead": bool(ahead_i_het) if het_sign != 0 else None,
+        },
+        "mean_matched_homogeneous": {
+            "mean_difference": float(np.mean(hom_diff)),
+            "ci_lower": float(hom_ci[0]),
+            "ci_upper": float(hom_ci[1]),
+            "determined_sign": _sign_label(hom_sign, planner_i=planner_i, planner_j=planner_j),
+            f"{planner_i}_ahead": bool(ahead_i_hom) if hom_sign != 0 else None,
+        },
+    }
+    if not is_reversal:
+        return pair_record, None
+    het_leader = planner_i if ahead_i_het else planner_j
+    hom_leader = planner_i if ahead_i_hom else planner_j
+    reversal = {
+        "planners": [planner_i, planner_j],
+        "heterogeneous_leader": het_leader,
+        "mean_matched_homogeneous_leader": hom_leader,
+        "description": (
+            f"Pair ({planner_i}, {planner_j}) ordering is determined in both arms with "
+            f"opposite signs: heterogeneous leader {het_leader} vs mean-matched leader "
+            f"{hom_leader}."
+        ),
+    }
+    return pair_record, reversal
+
+
+def _group_records_by_arm_planner_seed(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    metric_key: str,
+) -> dict[str, dict[str, dict[int, float]]]:
+    """Group finite episode metric values by arm, planner, and integer seed.
+
+    Mirrors the parsing contract of :func:`compute_bootstrap_rank_sensitivity`: arm, planner,
+    and seed fall back to ``scenario_params``; the seed is coerced to ``int``; non-finite or
+    missing metrics are dropped. Unknown planners (not in any caller's list) are kept here
+    and filtered by the caller so this helper stays reusable.
+
+    Returns:
+        Nested mapping ``arm -> planner -> seed -> metric value``.
+    """
+    grouped: dict[str, dict[str, dict[int, float]]] = {}
+    for rec in records:
+        parsed = _parse_rank_record(rec, metric_key=metric_key)
+        if parsed is None:
+            continue
+        arm, planner, seed_int, numeric = parsed
+        grouped.setdefault(arm, {}).setdefault(planner, {})[seed_int] = numeric
+    return grouped
+
+
+def _parse_rank_record(
+    record: Mapping[str, Any],
+    *,
+    metric_key: str,
+) -> tuple[str, str, int, float] | None:
+    """Parse one episode record into ``(arm, planner, seed, value)`` or drop it.
+
+    Returns:
+        The parsed tuple, or ``None`` when the record is missing required fields, has a
+        non-integer seed, or carries a missing/null/non-finite metric.
+    """
+    scenario_params = record.get("scenario_params") or {}
+    arm = record.get("population_arm")
+    if arm is None:
+        arm = scenario_params.get("population_arm")
+    planner = record.get("planner")
+    if planner is None:
+        planner = scenario_params.get("planner")
+    seed_value = record.get("seed")
+    if seed_value is None:
+        seed_value = scenario_params.get("seed")
+    if arm is None or planner is None or seed_value is None:
+        return None
+    try:
+        seed_int = int(seed_value)
+    except (TypeError, ValueError):
+        return None
+    metrics = record.get("metrics")
+    if not isinstance(metrics, Mapping) or metric_key not in metrics:
+        return None
+    value = metrics[metric_key]
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric):
+        return None
+    return str(arm).strip(), str(planner).strip(), seed_int, numeric
+
+
+def _paired_performance_arrays(
+    grouped: Mapping[str, Mapping[str, Mapping[int, float]]],
+    *,
+    planners: Sequence[str],
+    arms: Sequence[str],
+) -> tuple[dict[str, np.ndarray], dict[str, int], list[str]]:
+    """Build ``(planner, seed)`` performance arrays per arm over shared common seeds.
+
+    Returns:
+        The per-arm arrays, the common-seed count, and a list of fail-closed blockers
+        (missing planner, or fewer than two paired seeds across planners within an arm).
+    """
+    arrays: dict[str, np.ndarray] = {}
+    counts: dict[str, int] = {}
+    blockers: list[str] = []
+    for arm in arms:
+        arm_data = grouped.get(arm, {})
+        seed_sets = []
+        for planner in planners:
+            if planner not in arm_data:
+                blockers.append(f"arm {arm!r} has no records for planner {planner!r}")
+            seed_sets.append(set(arm_data.get(planner, {}).keys()))
+        if blockers:
+            continue
+        common = sorted(set.intersection(*seed_sets)) if seed_sets else []
+        if len(common) < 2:
+            blockers.append(
+                f"arm {arm!r} has {len(common)} paired seed(s) across planners (need >=2)"
+            )
+            continue
+        arr = np.zeros((len(planners), len(common)), dtype=float)
+        for planner_index, planner in enumerate(planners):
+            for seed_index, seed_int in enumerate(common):
+                arr[planner_index, seed_index] = arm_data[planner][seed_int]
+        arrays[arm] = arr
+        counts[arm] = len(common)
+    return arrays, counts, blockers
+
+
+def _seed_pair_difference(
+    arm_array: np.ndarray,
+    i: int,
+    j: int,
+    *,
+    higher_is_safer: bool,
+) -> np.ndarray:
+    """Per-seed paired difference of planner ``i`` minus planner ``j``.
+
+    When ``higher_is_safer`` is false (lower is better), the difference is negated so a
+    positive value consistently means ``i`` is preferred, keeping the sign logic arm-agnostic.
+
+    Returns:
+        The 1-D per-seed paired difference (positive favors planner ``i``).
+    """
+    diff = arm_array[i] - arm_array[j]
+    return diff if higher_is_safer else -diff
+
+
+def _bootstrap_mean_percentile_ci(
+    differences: np.ndarray,
+    num_bootstrap: int,
+    rng: np.random.Generator,
+) -> tuple[float, float]:
+    """Percentile bootstrap CI on the mean of a 1-D paired-difference array.
+
+    Returns:
+        The ``(lower, upper)`` 2.5th / 97.5th percentile bounds on the bootstrapped mean.
+    """
+    n = int(differences.size)
+    if n == 0:
+        raise ValueError("differences must be non-empty")
+    indices = rng.integers(0, n, size=(num_bootstrap, n))
+    resampled = differences[indices]
+    means = resampled.mean(axis=1)
+    lower = float(np.percentile(means, 2.5))
+    upper = float(np.percentile(means, 97.5))
+    return lower, upper
+
+
+def _determined_sign(ci: tuple[float, float]) -> int:
+    """Return +1 / -1 when the CI excludes zero, else 0 (indeterminate ordering).
+
+    Returns:
+        ``+1`` if the CI is entirely positive, ``-1`` if entirely negative, else ``0``.
+    """
+    lower, upper = ci
+    if lower > 0.0:
+        return 1
+    if upper < 0.0:
+        return -1
+    return 0
+
+
+def _sign_label(sign: int, *, planner_i: str, planner_j: str) -> str:
+    """Human-readable leader label for a determined sign (``indeterminate`` when 0).
+
+    Returns:
+        ``planner_i`` when sign is positive, ``planner_j`` when negative, else
+        ``"indeterminate"``.
+    """
+    if sign > 0:
+        return planner_i
+    if sign < 0:
+        return planner_j
+    return "indeterminate"

--- a/robot_sf/benchmark/heterogeneous_rank_sensitivity.py
+++ b/robot_sf/benchmark/heterogeneous_rank_sensitivity.py
@@ -313,6 +313,7 @@ def pre_specified_rank_reversal_test(
                 higher_is_safer=higher_is_safer,
                 num_bootstrap=num_bootstrap,
                 rng=rng,
+                alpha=alpha,
             )
             pair_results.append(pair_record)
             if reversal is not None:
@@ -389,7 +390,7 @@ def _blocked_test_result(
     }
 
 
-def _evaluate_planner_pair(
+def _evaluate_planner_pair(  # noqa: PLR0913 - pair-test inputs are explicit
     *,
     arrays: tuple[np.ndarray, np.ndarray],
     i: int,
@@ -399,6 +400,7 @@ def _evaluate_planner_pair(
     higher_is_safer: bool,
     num_bootstrap: int,
     rng: np.random.Generator,
+    alpha: float,
 ) -> tuple[dict[str, Any], dict[str, Any] | None]:
     """Compute the per-pair verdict, pair record, and optional reversal for one pair.
 
@@ -409,8 +411,8 @@ def _evaluate_planner_pair(
     het_array, hom_array = arrays
     het_diff = _seed_pair_difference(het_array, i, j, higher_is_safer=higher_is_safer)
     hom_diff = _seed_pair_difference(hom_array, i, j, higher_is_safer=higher_is_safer)
-    het_ci = _bootstrap_mean_percentile_ci(het_diff, num_bootstrap, rng)
-    hom_ci = _bootstrap_mean_percentile_ci(hom_diff, num_bootstrap, rng)
+    het_ci = _bootstrap_mean_percentile_ci(het_diff, num_bootstrap, rng, alpha=alpha)
+    hom_ci = _bootstrap_mean_percentile_ci(hom_diff, num_bootstrap, rng, alpha=alpha)
     het_sign = _determined_sign(het_ci)
     hom_sign = _determined_sign(hom_ci)
 
@@ -594,11 +596,13 @@ def _bootstrap_mean_percentile_ci(
     differences: np.ndarray,
     num_bootstrap: int,
     rng: np.random.Generator,
+    *,
+    alpha: float = 0.05,
 ) -> tuple[float, float]:
     """Percentile bootstrap CI on the mean of a 1-D paired-difference array.
 
     Returns:
-        The ``(lower, upper)`` 2.5th / 97.5th percentile bounds on the bootstrapped mean.
+        The ``(lower, upper)`` percentile bounds implied by ``alpha`` on the bootstrapped mean.
     """
     n = int(differences.size)
     if n == 0:
@@ -606,8 +610,8 @@ def _bootstrap_mean_percentile_ci(
     indices = rng.integers(0, n, size=(num_bootstrap, n))
     resampled = differences[indices]
     means = resampled.mean(axis=1)
-    lower = float(np.percentile(means, 2.5))
-    upper = float(np.percentile(means, 97.5))
+    lower = float(np.percentile(means, (alpha / 2.0) * 100.0))
+    upper = float(np.percentile(means, (1.0 - alpha / 2.0) * 100.0))
     return lower, upper
 
 

--- a/scripts/benchmark/run_rank_reversal_test_issue_3574.py
+++ b/scripts/benchmark/run_rank_reversal_test_issue_3574.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Run the issue #3574 pre-specified (preregistered) rank-reversal test.
+
+This is the *pre-specified rank-reversal test* analysis entrypoint for issue #3574. It is
+distinct from the descriptive bootstrap rank-sensitivity report emitted by
+``build_heterogeneous_population_ablation_report.py``: that report records any ranking-list
+disagreement (including differences within sampling noise), whereas this test only declares a
+reversal when a planner pair is bootstrap-determined in *both* arms with *opposite* signs.
+
+The decision specification (significance level, percentile-CI method, and decision rule) is
+declared before the results are inspected and is echoed verbatim in the output so the
+comparison is auditable once real paired campaign episode records are available.
+
+Claim boundary: this is analysis tooling only. It establishes no benchmark, rank-stability,
+realism, or sim-to-real claim on its own; a campaign conclusion requires real paired episode
+records that pass the mean-matched integration-readiness check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.heterogeneous_population_ablation import (
+    RANK_METRIC_KEY,
+    assess_mean_matched_episode_records,
+)
+from robot_sf.benchmark.heterogeneous_rank_sensitivity import pre_specified_rank_reversal_test
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        default="output/issue_3574_mean_matched_harness/manifest.json",
+        help="Paired pre-run manifest used to fail closed on missing or extra episode rows.",
+    )
+    parser.add_argument(
+        "--records",
+        default="output/issue_3574_mean_matched_harness/episode_records.jsonl",
+        help="Path to the simulation episode records JSONL.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="output/issue_3574_mean_matched_harness",
+        help="Directory to write output files.",
+    )
+    parser.add_argument(
+        "--metric-key",
+        default=RANK_METRIC_KEY,
+        help="Metric under record `metrics` to test (default matches the readiness contract).",
+    )
+    parser.add_argument(
+        "--alpha", type=float, default=0.05, help="Two-sided significance level in (0, 1)."
+    )
+    parser.add_argument(
+        "--num-bootstrap", type=int, default=1000, help="Number of bootstrap resamples."
+    )
+    parser.add_argument("--seed", type=int, default=3574, help="RNG seed for bootstrap.")
+    parser.add_argument(
+        "--lower-is-safer",
+        action="store_true",
+        help="Set if smaller metric values rank a planner higher (e.g. collisions).",
+    )
+    return parser.parse_args()
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load JSONL file records, skipping blank lines."""
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                records.append(json.loads(line))
+    return records
+
+
+def _markdown_report(
+    *,
+    metric_key: str,
+    readiness: dict[str, Any],
+    test_result: dict[str, Any],
+    planners: list[str],
+) -> str:
+    """Render a compact, claim-bounded markdown summary of the test result."""
+    lines = [
+        "# Issue #3574 Pre-Specified Rank-Reversal Test",
+        "",
+        (
+            "Preregistered hypothesis test on whether planner rank order reverses between the "
+            "heterogeneous and mean-matched homogeneous population arms. A reversal is declared "
+            "only when a planner pair is bootstrap-determined in both arms with opposite signs."
+        ),
+        "",
+        "## Claim boundary",
+        "",
+        "- Analysis tooling only. No benchmark, rank-stability, realism, or sim-to-real claim.",
+        "- A campaign conclusion requires real paired episode records that pass the readiness check.",
+        "",
+        f"- Metric: `{metric_key}`.",
+        f"- Significance level alpha: `{test_result['pre_registration']['significance_level_alpha']}`.",
+        f"- CI method: `{test_result['pre_registration']['ci_method']}` at level "
+        f"`{test_result['pre_registration']['ci_level']}`.",
+        "",
+        "## Integration readiness",
+        "",
+        f"- Status: `{readiness['status']}`.",
+        f"- Expected rows: `{readiness['expected_row_count']}`; observed rows: "
+        f"`{readiness['observed_row_count']}`.",
+    ]
+    if readiness.get("blockers"):
+        lines.append("")
+        lines.append("Blockers:")
+        for blocker in readiness["blockers"]:
+            lines.append(f"- {blocker}")
+
+    lines.extend(["", "## Decision", ""])
+    if test_result["status"] != "ready":
+        lines.append(f"Test status: `{test_result['status']}` (no decision rendered).")
+        for blocker in test_result.get("blockers", []):
+            lines.append(f"- {blocker}")
+    else:
+        lines.append(
+            f"- Decision: `{test_result['decision']}` "
+            f"(reversal count: `{test_result['reversal_count']}`)."
+        )
+        lines.append("- Planners: " + ", ".join(f"`{p}`" for p in planners) + ".")
+        lines.append("")
+        lines.append("| Pair | Heterogeneous leader | Mean-matched leader | Verdict |")
+        lines.append("|---|---|---|---|")
+        for pair in test_result["pairwise"]:
+            het_leader = pair["heterogeneous"]["determined_sign"]
+            hom_leader = pair["mean_matched_homogeneous"]["determined_sign"]
+            lines.append(
+                f"| ({pair['planners'][0]}, {pair['planners'][1]}) "
+                f"| {het_leader} | {hom_leader} | `{pair['verdict']}` |"
+            )
+        if test_result["reversals"]:
+            lines.append("")
+            lines.append("Reversals:")
+            for reversal in test_result["reversals"]:
+                lines.append(f"- {reversal['description']}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    """Run the pre-specified rank-reversal test and write the report artifacts."""
+    args = parse_args()
+    manifest_path = REPO_ROOT / args.manifest
+    records_path = REPO_ROOT / args.records
+    output_dir = REPO_ROOT / args.output_dir
+
+    if not manifest_path.exists():
+        print(f"Error: Manifest not found at {manifest_path}. Build it first.")
+        return 1
+    if not records_path.exists():
+        print(f"Error: Episode records not found at {records_path}. Run the simulations first.")
+        return 1
+
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    records = load_jsonl(records_path)
+    print(f"Loaded {len(records)} episode records.")
+
+    # Fail closed on integration readiness before any analysis: a reversal test on rows that do
+    # not satisfy the mean-matched manifest cannot be attributed to a paired campaign.
+    readiness = assess_mean_matched_episode_records(manifest, records)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "rank_reversal_test_readiness.json").write_text(
+        json.dumps(readiness, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    if not readiness["ready"]:
+        print(
+            "Blocked: episode records do not satisfy the mean-matched manifest; "
+            f"see {output_dir / 'rank_reversal_test_readiness.json'}"
+        )
+        return 2
+
+    planners = sorted({str(rec["planner"]) for rec in records})
+    test_result = pre_specified_rank_reversal_test(
+        records,
+        metric_key=args.metric_key,
+        planners=planners,
+        higher_is_safer=not args.lower_is_safer,
+        alpha=args.alpha,
+        num_bootstrap=args.num_bootstrap,
+        seed=args.seed,
+    )
+
+    (output_dir / "rank_reversal_test.json").write_text(
+        json.dumps(test_result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (output_dir / "rank_reversal_test.md").write_text(
+        _markdown_report(
+            metric_key=args.metric_key,
+            readiness=readiness,
+            test_result=test_result,
+            planners=planners,
+        ),
+        encoding="utf-8",
+    )
+
+    print(f"Decision: {test_result.get('decision', test_result.get('status'))}")
+    print(f"Wrote rank-reversal test artifacts to {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_pre_specified_rank_reversal_test.py
+++ b/tests/benchmark/test_pre_specified_rank_reversal_test.py
@@ -1,0 +1,406 @@
+"""Tests for the pre-specified (preregistered) rank-reversal test (issue #3574).
+
+``pre_specified_rank_reversal_test`` is the *pre-specified rank-reversal test* named in the
+issue Definition of Done. It complements ``compute_bootstrap_rank_sensitivity`` (which reports
+bootstrap P(A beats B) and a descriptive ranking-list disagreement flag) by adding a formal
+hypothesis test that only declares a reversal when a planner pair is bootstrap-determined in
+both arms with opposite signs. These tests pin that contract on synthetic fixture records so
+the behavior is preserved when real campaign episode records eventually feed it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from robot_sf.benchmark.heterogeneous_rank_sensitivity import (
+    RANK_REVERSAL_TEST_SCHEMA,
+    pre_specified_rank_reversal_test,
+)
+
+_METRIC = "clearance_m"
+_HET = "heterogeneous"
+_HOM = "mean_matched_homogeneous"
+
+
+def _rec(arm: str, planner: str, seed: Any, value: float) -> dict[str, Any]:
+    """Build a minimal episode record for arm/planner/seed/metric."""
+    return {
+        "population_arm": arm,
+        "planner": planner,
+        "seed": seed,
+        "metrics": {_METRIC: value},
+    }
+
+
+def _reversal_fixture() -> list[dict[str, Any]]:
+    """Heterogeneous ranks A>B; mean-matched ranks B>A at every seed (clean reversal)."""
+    records: list[dict[str, Any]] = []
+    for seed in (1, 2, 3, 4, 5):
+        records.append(_rec(_HET, "A", seed, 10.0 + seed))
+        records.append(_rec(_HET, "B", seed, 2.0 + seed))
+        records.append(_rec(_HOM, "A", seed, 2.0 + seed))
+        records.append(_rec(_HOM, "B", seed, 10.0 + seed))
+    return records
+
+
+def _stable_fixture() -> list[dict[str, Any]]:
+    """Both arms rank A>B at every seed (determined and consistent)."""
+    records: list[dict[str, Any]] = []
+    for seed in (1, 2, 3, 4, 5):
+        records.append(_rec(_HET, "A", seed, 10.0 + seed))
+        records.append(_rec(_HET, "B", seed, 2.0 + seed))
+        records.append(_rec(_HOM, "A", seed, 10.0 + seed))
+        records.append(_rec(_HOM, "B", seed, 2.0 + seed))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+
+def test_fewer_than_two_planners_raises_value_error() -> None:
+    """The guard requires >=2 planners and raises a pinned message."""
+    with pytest.raises(ValueError, match="At least 2 planners are required to compare ranks"):
+        pre_specified_rank_reversal_test([], metric_key=_METRIC, planners=["A"])
+
+
+def test_identical_arm_names_raise_value_error() -> None:
+    """Identical arm names would compare an arm to itself; reject fail-closed."""
+    with pytest.raises(ValueError, match="heterogeneous_arm and mean_matched_arm must differ"):
+        pre_specified_rank_reversal_test(
+            _stable_fixture(),
+            metric_key=_METRIC,
+            planners=["A", "B"],
+            arms=("same", "same"),
+        )
+
+
+@pytest.mark.parametrize("alpha", [0.0, -0.01, 1.0, 1.5])
+def test_invalid_alpha_raises_value_error(alpha: float) -> None:
+    """alpha must lie in the open interval (0, 1)."""
+    with pytest.raises(ValueError, match="alpha must be in \\(0, 1\\)"):
+        pre_specified_rank_reversal_test(
+            _stable_fixture(), metric_key=_METRIC, planners=["A", "B"], alpha=alpha
+        )
+
+
+def test_invalid_num_bootstrap_raises_value_error() -> None:
+    """At least one bootstrap resample is required."""
+    with pytest.raises(ValueError, match="num_bootstrap must be >= 1"):
+        pre_specified_rank_reversal_test(
+            _stable_fixture(), metric_key=_METRIC, planners=["A", "B"], num_bootstrap=0
+        )
+
+
+# ---------------------------------------------------------------------------
+# Preregistration block (declared-before-results)
+# ---------------------------------------------------------------------------
+
+
+def test_pre_registration_block_is_declared_before_results() -> None:
+    """The ready result echoes the ex-ante decision specification verbatim."""
+    result = pre_specified_rank_reversal_test(
+        _stable_fixture(), metric_key=_METRIC, planners=["A", "B"], num_bootstrap=100, seed=42
+    )
+    pre = result["pre_registration"]
+    assert pre["declared_before_results"] is True
+    assert pre["significance_level_alpha"] == pytest.approx(0.05)
+    assert pre["ci_method"] == "percentile_bootstrap"
+    assert pre["ci_level"] == pytest.approx(0.95)
+    assert pre["num_bootstrap"] == 100
+    assert pre["higher_is_safer"] is True
+    assert pre["heterogeneous_arm"] == _HET
+    assert pre["mean_matched_arm"] == _HOM
+    assert "stable across population compositions" in pre["null_hypothesis"]
+    assert "excludes zero in BOTH arms with opposite signs" in pre["decision_rule"]
+
+
+# ---------------------------------------------------------------------------
+# Reversal / stable / indeterminate decisions
+# ---------------------------------------------------------------------------
+
+
+def test_clean_reversal_is_detected() -> None:
+    """Opposite determined orderings across arms -> reject H0, one reversal."""
+    result = pre_specified_rank_reversal_test(
+        _reversal_fixture(), metric_key=_METRIC, planners=["A", "B"], num_bootstrap=200, seed=42
+    )
+    assert result["status"] == "ready"
+    assert result["schema_version"] == RANK_REVERSAL_TEST_SCHEMA
+    assert result["decision"] == "reject_null_rank_stability"
+    assert result["reversal_count"] == 1
+
+    pair = result["pairwise"][0]
+    assert pair["planners"] == ["A", "B"]
+    assert pair["verdict"] == "reversal_detected"
+    assert pair["reversal"] is True
+    # Heterogeneous: A ahead (CI strictly positive); homogeneous: B ahead (CI strictly negative).
+    assert pair["heterogeneous"]["ci_lower"] > 0.0
+    assert pair["mean_matched_homogeneous"]["ci_upper"] < 0.0
+    assert pair["heterogeneous"]["A_ahead"] is True
+    assert pair["mean_matched_homogeneous"]["A_ahead"] is False
+
+    rev = result["reversals"][0]
+    assert rev["planners"] == ["A", "B"]
+    assert rev["heterogeneous_leader"] == "A"
+    assert rev["mean_matched_homogeneous_leader"] == "B"
+
+
+def test_stable_determined_pair_is_not_a_reversal() -> None:
+    """Same determined ordering in both arms -> fail to reject H0."""
+    result = pre_specified_rank_reversal_test(
+        _stable_fixture(), metric_key=_METRIC, planners=["A", "B"], num_bootstrap=200, seed=42
+    )
+    assert result["decision"] == "fail_to_reject_null_rank_stability"
+    assert result["reversal_count"] == 0
+    assert result["pairwise"][0]["verdict"] == "stable_determined"
+    assert result["pairwise"][0]["reversal"] is False
+
+
+def test_indeterminate_pair_is_not_a_reversal() -> None:
+    """A CI straddling zero yields ``indeterminate`` and does not reject H0."""
+
+    # Near-tied planners with tiny noise so the bootstrap mean-difference CI straddles zero.
+    import random
+
+    rng = random.Random(0)
+    records: list[dict[str, Any]] = []
+    for seed in (1, 2, 3, 4, 5):
+        for arm in (_HET, _HOM):
+            records.append(_rec(arm, "A", seed, 5.0 + rng.uniform(-0.05, 0.05)))
+            records.append(_rec(arm, "B", seed, 5.0 + rng.uniform(-0.05, 0.05)))
+    result = pre_specified_rank_reversal_test(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=500, seed=42
+    )
+    assert result["reversal_count"] == 0
+    assert result["pairwise"][0]["verdict"] == "indeterminate"
+    # Indeterminate is not a confirmed reversal even if the two arms' point estimates differ.
+    assert result["decision"] == "fail_to_reject_null_rank_stability"
+
+
+def test_three_planner_reversal_isolated_to_one_pair() -> None:
+    """A middle-rank swap (B/C) reverses only that pair; A stays on top in both arms."""
+    records: list[dict[str, Any]] = []
+    for seed in (1, 2, 3, 4, 5):
+        records.append(_rec(_HET, "A", seed, 30.0 + seed))
+        records.append(_rec(_HET, "B", seed, 20.0 + seed))
+        records.append(_rec(_HET, "C", seed, 10.0 + seed))
+        records.append(_rec(_HOM, "A", seed, 30.0 + seed))
+        records.append(_rec(_HOM, "B", seed, 10.0 + seed))
+        records.append(_rec(_HOM, "C", seed, 20.0 + seed))
+    result = pre_specified_rank_reversal_test(
+        records, metric_key=_METRIC, planners=["A", "B", "C"], num_bootstrap=200, seed=42
+    )
+    assert result["reversal_count"] == 1
+    verdicts = {tuple(pair["planners"]): pair["verdict"] for pair in result["pairwise"]}
+    assert verdicts[("A", "B")] == "stable_determined"
+    assert verdicts[("A", "C")] == "stable_determined"
+    assert verdicts[("B", "C")] == "reversal_detected"
+
+
+def test_lower_is_safer_flips_sign_logic_but_preserves_reversal_count() -> None:
+    """``higher_is_safer=False`` negates differences; a true swap is still a reversal."""
+    records: list[dict[str, Any]] = []
+    for seed in (1, 2, 3, 4, 5):
+        records.append(_rec(_HET, "A", seed, 30.0 + seed))
+        records.append(_rec(_HET, "B", seed, 20.0 + seed))
+        records.append(_rec(_HET, "C", seed, 10.0 + seed))
+        records.append(_rec(_HOM, "A", seed, 30.0 + seed))
+        records.append(_rec(_HOM, "B", seed, 10.0 + seed))
+        records.append(_rec(_HOM, "C", seed, 20.0 + seed))
+    result = pre_specified_rank_reversal_test(
+        records,
+        metric_key=_METRIC,
+        planners=["A", "B", "C"],
+        higher_is_safer=False,
+        num_bootstrap=200,
+        seed=42,
+    )
+    # Under lower-is-better the numeric ranking inverts, but the B/C swap remains a reversal.
+    assert result["reversal_count"] == 1
+    assert result["pre_registration"]["higher_is_safer"] is False
+
+
+# ---------------------------------------------------------------------------
+# Blocked (fail-closed) shapes
+# ---------------------------------------------------------------------------
+
+
+def test_missing_arm_is_blocked_with_precise_blocker() -> None:
+    """A wholly absent arm yields ``blocked`` naming the missing arm."""
+    result = pre_specified_rank_reversal_test(
+        _stable_fixture(),
+        metric_key=_METRIC,
+        planners=["A", "B"],
+        arms=("nonexistent", _HOM),
+    )
+    assert result["status"] == "blocked"
+    assert result["blockers"] == ["no valid episode records for arm 'nonexistent'"]
+    # The decision specification is still echoed so the blocked result is auditable.
+    assert result["pre_registration"]["heterogeneous_arm"] == "nonexistent"
+
+
+def test_missing_planner_within_arm_is_blocked() -> None:
+    """An arm missing one declared planner is blocked naming the planner."""
+    records: list[dict[str, Any]] = []
+    for seed in (1, 2):
+        records.append(_rec(_HET, "A", seed, 10.0 + seed))
+        records.append(_rec(_HET, "B", seed, 2.0 + seed))
+        records.append(_rec(_HOM, "A", seed, 10.0 + seed))
+        # _HOM has no planner "B"
+    result = pre_specified_rank_reversal_test(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=100, seed=42
+    )
+    assert result["status"] == "blocked"
+    assert any("planner 'B'" in blocker for blocker in result["blockers"])
+
+
+def test_insufficient_paired_seeds_is_blocked() -> None:
+    """Fewer than two common paired seeds across planners blocks the test."""
+    records = [
+        _rec(_HET, "A", 1, 10.0),
+        _rec(_HET, "B", 1, 2.0),
+        _rec(_HOM, "A", 1, 2.0),
+        _rec(_HOM, "B", 1, 10.0),
+    ]
+    result = pre_specified_rank_reversal_test(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=100, seed=42
+    )
+    assert result["status"] == "blocked"
+    assert any("paired seed" in blocker and "need >=2" in blocker for blocker in result["blockers"])
+
+
+# ---------------------------------------------------------------------------
+# Record-parsing contract (parity with compute_bootstrap_rank_sensitivity)
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_params_fallback_supplies_arm_planner_seed() -> None:
+    """Records without top-level fields fall back to ``scenario_params``."""
+    records = [
+        {
+            "scenario_params": {"population_arm": _HET, "planner": "A", "seed": 1},
+            "metrics": {_METRIC: 10.0},
+        },
+        {
+            "scenario_params": {"population_arm": _HET, "planner": "A", "seed": 2},
+            "metrics": {_METRIC: 12.0},
+        },
+        {
+            "scenario_params": {"population_arm": _HET, "planner": "B", "seed": 1},
+            "metrics": {_METRIC: 2.0},
+        },
+        {
+            "scenario_params": {"population_arm": _HET, "planner": "B", "seed": 2},
+            "metrics": {_METRIC: 3.0},
+        },
+        {
+            "scenario_params": {"population_arm": _HOM, "planner": "A", "seed": 1},
+            "metrics": {_METRIC: 2.0},
+        },
+        {
+            "scenario_params": {"population_arm": _HOM, "planner": "A", "seed": 2},
+            "metrics": {_METRIC: 3.0},
+        },
+        {
+            "scenario_params": {"population_arm": _HOM, "planner": "B", "seed": 1},
+            "metrics": {_METRIC: 10.0},
+        },
+        {
+            "scenario_params": {"population_arm": _HOM, "planner": "B", "seed": 2},
+            "metrics": {_METRIC: 12.0},
+        },
+    ]
+    result = pre_specified_rank_reversal_test(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=100, seed=42
+    )
+    assert result["status"] == "ready"
+    assert result["reversal_count"] == 1
+
+
+def test_non_finite_metrics_are_dropped() -> None:
+    """NaN/Inf metrics are dropped, not propagated into the bootstrap arrays."""
+    records = [
+        _rec(_HET, "A", 1, 10.0),
+        _rec(_HET, "A", 2, 12.0),
+        _rec(_HET, "A", 3, float("inf")),  # dropped
+        _rec(_HET, "B", 1, 2.0),
+        _rec(_HET, "B", 2, 3.0),
+        _rec(_HET, "B", 3, 4.0),
+        _rec(_HOM, "A", 1, 2.0),
+        _rec(_HOM, "A", 2, 3.0),
+        _rec(_HOM, "A", 3, 4.0),
+        _rec(_HOM, "B", 1, 10.0),
+        _rec(_HOM, "B", 2, 12.0),
+        _rec(_HOM, "B", 3, float("nan")),  # dropped
+    ]
+    result = pre_specified_rank_reversal_test(
+        records, metric_key=_METRIC, planners=["A", "B"], num_bootstrap=100, seed=42
+    )
+    # After dropping seed 3 from both arms, seeds {1,2} remain: het A>B, hom B>A -> reversal.
+    assert result["status"] == "ready"
+    assert result["common_seeds_count"] == 2
+    assert result["reversal_count"] == 1
+
+
+def test_float_and_whitespace_seeds_are_normalized() -> None:
+    """Float seeds coerce to int and surrounding whitespace is stripped.
+
+    After stripping, the arm names align with the caller-declared names, proving parity with
+    the record-parsing contract of ``compute_bootstrap_rank_sensitivity``.
+    """
+    records = [
+        {"population_arm": " het ", "planner": " A ", "seed": 1.0, "metrics": {_METRIC: 10.0}},
+        {"population_arm": " het ", "planner": " A ", "seed": 2, "metrics": {_METRIC: 12.0}},
+        {"population_arm": " het ", "planner": " B ", "seed": 1, "metrics": {_METRIC: 2.0}},
+        {"population_arm": " het ", "planner": " B ", "seed": 2, "metrics": {_METRIC: 3.0}},
+        {"population_arm": " hom ", "planner": "A", "seed": 1.0, "metrics": {_METRIC: 2.0}},
+        {"population_arm": " hom ", "planner": "A", "seed": 2, "metrics": {_METRIC: 3.0}},
+        {"population_arm": " hom ", "planner": "B", "seed": 1, "metrics": {_METRIC: 10.0}},
+        {"population_arm": " hom ", "planner": "B", "seed": 2, "metrics": {_METRIC: 12.0}},
+    ]
+    result = pre_specified_rank_reversal_test(
+        records,
+        metric_key=_METRIC,
+        planners=["A", "B"],
+        arms=("het", "hom"),
+        num_bootstrap=100,
+        seed=42,
+    )
+    # Whitespace is stripped (" het " -> "het", " hom " -> "hom") so the arms pair up;
+    # float seed 1.0 coerces to int 1 so it pairs with the int-seed record.
+    assert result["status"] == "ready"
+    assert result["common_seeds_count"] == 2
+    assert result["reversal_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Determinism and claim boundary
+# ---------------------------------------------------------------------------
+
+
+def test_same_seed_is_deterministic() -> None:
+    """Same input + same seed -> identical ready result (locks the RNG contract).."""
+    kwargs = {
+        "records": _reversal_fixture(),
+        "metric_key": _METRIC,
+        "planners": ["A", "B"],
+        "num_bootstrap": 200,
+        "seed": 123,
+    }
+    a = pre_specified_rank_reversal_test(**kwargs)
+    b = pre_specified_rank_reversal_test(**kwargs)
+    assert a == b
+
+
+def test_claim_boundary_is_explicit_and_non_claiming() -> None:
+    """The ready result states no benchmark/rank/realism claim is established here."""
+    result = pre_specified_rank_reversal_test(
+        _reversal_fixture(), metric_key=_METRIC, planners=["A", "B"], num_bootstrap=100, seed=42
+    )
+    boundary = result["claim_boundary"]
+    assert "Preregistered rank-reversal test primitive" in boundary
+    assert "No benchmark campaign" in boundary

--- a/tests/benchmark/test_pre_specified_rank_reversal_test.py
+++ b/tests/benchmark/test_pre_specified_rank_reversal_test.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import pytest
 
+import robot_sf.benchmark.heterogeneous_rank_sensitivity as rank_sensitivity
 from robot_sf.benchmark.heterogeneous_rank_sensitivity import (
     RANK_REVERSAL_TEST_SCHEMA,
     pre_specified_rank_reversal_test,
@@ -116,6 +117,28 @@ def test_pre_registration_block_is_declared_before_results() -> None:
     assert pre["mean_matched_arm"] == _HOM
     assert "stable across population compositions" in pre["null_hypothesis"]
     assert "excludes zero in BOTH arms with opposite signs" in pre["decision_rule"]
+
+
+def test_custom_alpha_reaches_bootstrap_confidence_intervals(monkeypatch) -> None:
+    """The declared significance level controls the percentile CI calculation."""
+    seen_alphas: list[float] = []
+    original = rank_sensitivity._bootstrap_mean_percentile_ci
+
+    def record_alpha(differences, num_bootstrap, rng, *, alpha=0.05):
+        seen_alphas.append(alpha)
+        return original(differences, num_bootstrap, rng, alpha=alpha)
+
+    monkeypatch.setattr(rank_sensitivity, "_bootstrap_mean_percentile_ci", record_alpha)
+    result = pre_specified_rank_reversal_test(
+        _stable_fixture(),
+        metric_key=_METRIC,
+        planners=["A", "B"],
+        num_bootstrap=100,
+        seed=42,
+        alpha=0.20,
+    )
+    assert result["pre_registration"]["ci_level"] == pytest.approx(0.80)
+    assert seen_alphas == [0.20, 0.20]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/benchmark/test_run_rank_reversal_test_issue_3574.py
+++ b/tests/benchmark/test_run_rank_reversal_test_issue_3574.py
@@ -1,0 +1,238 @@
+"""Tests for the issue #3574 pre-specified rank-reversal test CLI runner.
+
+Exercises ``scripts/benchmark/run_rank_reversal_test_issue_3574.py`` end-to-end on a fixture
+manifest plus constructed episode records so the CLI is proven before real campaign records
+exist. The CLI fails closed on integration readiness and then renders the preregistered test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.heterogeneous_population_ablation import (
+    build_mean_matched_harness_manifest,
+)
+from robot_sf.benchmark.heterogeneous_rank_sensitivity import RANK_REVERSAL_TEST_SCHEMA
+from robot_sf.benchmark.pedestrian_control_trace import PEDESTRIAN_CONTROL_TRACE_LABELS_KEY
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/run_rank_reversal_test_issue_3574.py"
+
+
+def _load_cli() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("run_rank_reversal_test_issue_3574", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _manifest_config() -> dict[str, Any]:
+    """Two planners, two seeds, one scenario -> 8 paired manifest rows."""
+    return {
+        "trace_metric_keys": ["clearance_m"],
+        "planners": [{"key": "goal"}, {"key": "social_force"}],
+        "seeds": [101, 102],
+        "scenarios": [
+            {
+                "id": "classic_density_002",
+                "density": 0.02,
+                "population_size": 4,
+                "archetype_seed": 3574,
+                "composition": {"cautious": 0.25, "standard": 0.5, "hurried": 0.25},
+                "archetypes": {
+                    "cautious": {"desired_speed_factor": 0.7, "radius_m": 0.35},
+                    "standard": {"desired_speed_factor": 1.0, "radius_m": 0.3},
+                    "hurried": {"desired_speed_factor": 1.4, "radius_m": 0.25},
+                },
+            }
+        ],
+    }
+
+
+def _records_for_manifest(
+    manifest: dict[str, Any],
+    *,
+    mean_clearance_by_key: dict[tuple[str, str, int, str], float],
+) -> list[dict[str, Any]]:
+    """Build ready episode records, varying ``mean_clearance`` per campaign key."""
+    records: list[dict[str, Any]] = []
+    for row in manifest["manifest_rows"]:
+        key = (row["scenario_id"], row["planner"], row["seed"], row["population_arm"])
+        labels = row["arm_population"][PEDESTRIAN_CONTROL_TRACE_LABELS_KEY]
+        pedestrians = [
+            {
+                **label,
+                "steps": [
+                    {"step": 0, "clearance_m": 0.8},
+                    {"step": 1, "clearance_m": 1.2},
+                ],
+            }
+            for label in labels
+        ]
+        records.append(
+            {
+                "scenario_id": row["scenario_id"],
+                "planner": row["planner"],
+                "seed": row["seed"],
+                "population_arm": row["population_arm"],
+                "metrics": {"mean_clearance": mean_clearance_by_key[key]},
+                "algorithm_metadata": {
+                    "pedestrian_control_trace": {
+                        "schema_version": "pedestrian-control-trace.v1",
+                        "near_field_clearance_threshold_m": 1.0,
+                        "pedestrian_count": len(pedestrians),
+                        "pedestrians": pedestrians,
+                    }
+                },
+            }
+        )
+    return records
+
+
+def _write_inputs(tmp_path: Path, records: list[dict[str, Any]]) -> tuple[Path, Path]:
+    manifest = build_mean_matched_harness_manifest(_manifest_config())
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    records_path = tmp_path / "episode_records.jsonl"
+    with records_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
+    return manifest_path, records_path
+
+
+def _run_cli(module: ModuleType, argv: list[str]) -> int:
+    old_argv = sys.argv
+    sys.argv = argv
+    try:
+        return int(module.main())
+    finally:
+        sys.argv = old_argv
+
+
+def test_cli_renders_reversal_on_constructed_records(tmp_path: Path) -> None:
+    """A constructed reversal (goal ahead heterogeneous, social_force ahead mean-matched)."""
+    manifest = build_mean_matched_harness_manifest(_manifest_config())
+    clearance: dict[tuple[str, str, int, str], float] = {}
+    for row in manifest["manifest_rows"]:
+        key = (row["scenario_id"], row["planner"], row["seed"], row["population_arm"])
+        arm = row["population_arm"]
+        planner = row["planner"]
+        seed = row["seed"]
+        if arm == "heterogeneous":
+            clearance[key] = 2.0 if planner == "goal" else 0.5
+        else:
+            clearance[key] = 0.5 if planner == "goal" else 2.0
+        # Vary by seed slightly so the bootstrap has resampling structure.
+        clearance[key] += 0.01 * (seed - 101)
+    records = _records_for_manifest(manifest, mean_clearance_by_key=clearance)
+    manifest_path, records_path = _write_inputs(tmp_path, records)
+    output_dir = tmp_path / "out"
+
+    module = _load_cli()
+    code = _run_cli(
+        module,
+        [
+            "run_rank_reversal_test_issue_3574.py",
+            "--manifest",
+            str(manifest_path),
+            "--records",
+            str(records_path),
+            "--output-dir",
+            str(output_dir),
+            "--num-bootstrap",
+            "200",
+            "--seed",
+            "42",
+        ],
+    )
+
+    assert code == 0
+    result = json.loads((output_dir / "rank_reversal_test.json").read_text(encoding="utf-8"))
+    assert result["schema_version"] == RANK_REVERSAL_TEST_SCHEMA
+    assert result["status"] == "ready"
+    assert result["decision"] == "reject_null_rank_stability"
+    assert result["reversal_count"] == 1
+    readiness = json.loads(
+        (output_dir / "rank_reversal_test_readiness.json").read_text(encoding="utf-8")
+    )
+    assert readiness["ready"] is True
+    markdown = (output_dir / "rank_reversal_test.md").read_text(encoding="utf-8")
+    assert "reject_null_rank_stability" in markdown
+    assert "Analysis tooling only" in markdown
+
+
+def test_cli_fails_closed_on_missing_records_file(tmp_path: Path) -> None:
+    """A missing records file exits non-zero with a clear message."""
+    manifest = build_mean_matched_harness_manifest(_manifest_config())
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    module = _load_cli()
+    code = _run_cli(
+        module,
+        [
+            "run_rank_reversal_test_issue_3574.py",
+            "--manifest",
+            str(manifest_path),
+            "--records",
+            str(tmp_path / "does_not_exist.jsonl"),
+            "--output-dir",
+            str(tmp_path / "out"),
+        ],
+    )
+    assert code == 1
+
+
+def test_cli_blocks_on_unready_records(tmp_path: Path) -> None:
+    """Records that fail the readiness check exit code 2 and write no test artifact."""
+    manifest = build_mean_matched_harness_manifest(_manifest_config())
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    # One record short of the manifest -> readiness blocked.
+    records = _records_for_manifest(
+        manifest,
+        mean_clearance_by_key={
+            (row["scenario_id"], row["planner"], row["seed"], row["population_arm"]): 1.0
+            for row in manifest["manifest_rows"]
+        },
+    )[:-1]
+    records_path = tmp_path / "episode_records.jsonl"
+    with records_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
+    output_dir = tmp_path / "out"
+
+    module = _load_cli()
+    code = _run_cli(
+        module,
+        [
+            "run_rank_reversal_test_issue_3574.py",
+            "--manifest",
+            str(manifest_path),
+            "--records",
+            str(records_path),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert code == 2
+    assert (output_dir / "rank_reversal_test_readiness.json").exists()
+    # Blocked readiness must not produce a test artifact.
+    assert not (output_dir / "rank_reversal_test.json").exists()
+
+
+def test_cli_default_metric_matches_readiness_contract() -> None:
+    """The default ``--metric-key`` is the rank metric enforced by the readiness check."""
+    module = _load_cli()
+    from robot_sf.benchmark.heterogeneous_population_ablation import RANK_METRIC_KEY
+
+    assert module.RANK_METRIC_KEY == RANK_METRIC_KEY == "mean_clearance"


### PR DESCRIPTION
## What / why

Issue #3574's Definition of Done calls for "Rank-order sensitivity across >=3 planners per population composition reported with bootstrap P(A beats B) and a **pre-specified rank-reversal test**." This slice delivers the **pre-specified (preregistered) rank-reversal test** — the one remaining piece of that DoD item that was genuinely missing as a code primitive.

**What was already there:** PR #4591 merged `compute_bootstrap_rank_sensitivity`, which reports bootstrap P(A beats B), per-arm rankings, and a **descriptive** rank-reversal flag that fires on *any* ranking-list disagreement (`rank_het != rank_hom`) — including disagreements that are within bootstrap sampling noise.

**The gap this closes:** there was no *pre-specified test*. A pre-specified test must declare its significance level and decision rule *before* the results are inspected, and must distinguish a real reversal from sampling noise. The new `pre_specified_rank_reversal_test()` does exactly that:
- **H0:** rank order is stable across the heterogeneous and mean-matched homogeneous arms.
- **Decision rule (declared before results):** reject H0 iff some planner pair has a bootstrap `(1-alpha)` percentile CI on the per-seed paired mean difference that excludes zero in **both** arms with **opposite** signs.
- Only a determined-with-opposite-signs pair counts as a reversal; a CI that straddles zero yields an honest `indeterminate` verdict (not a reversal, not confirmed stability).

The decision specification (alpha, percentile-CI method, decision rule) is fixed before any results are inspected and echoed verbatim in the output `pre_registration` block as `declared_before_results: true`.

This is **additive**: it does not modify `compute_bootstrap_rank_sensitivity` (whose output shape is pinned by characterization tests); it adds a new function alongside it.

## Files

- `robot_sf/benchmark/heterogeneous_rank_sensitivity.py` — new `pre_specified_rank_reversal_test()` + helpers (additive, +452 lines; existing function untouched).
- `scripts/benchmark/run_rank_reversal_test_issue_3574.py` — CLI runner that fails closed on the mean-matched integration-readiness check (`assess_mean_matched_episode_records`) before rendering the test; writes `rank_reversal_test.json` + `rank_reversal_test.md` + a readiness JSON.
- `tests/benchmark/test_pre_specified_rank_reversal_test.py` — 21 focused tests.
- `tests/benchmark/test_run_rank_reversal_test_issue_3574.py` — 4 CLI tests (end-to-end reversal render + fail-closed paths).
- `docs/context/issue_3574_rank_reversal_test.md` — claim boundary + decision rule.

## Validation (CPU only)

```
uv run pytest tests/benchmark/test_pre_specified_rank_reversal_test.py \
              tests/benchmark/test_run_rank_reversal_test_issue_3574.py \
              tests/benchmark/test_heterogeneous_rank_sensitivity.py \
              tests/benchmark/test_heterogeneous_rank_sensitivity_characterization.py \
              tests/benchmark/test_heterogeneous_population_ablation.py -q
# 80 passed

uv run ruff check <changed files>   # All checks passed
uv run ruff format <changed files>  # 4 files left unchanged
```

Test coverage: reversal / stable-determined / indeterminate verdicts; ≥3-planner pair isolation; `higher_is_safer=False`; preregistration block; fail-closed blockers (missing arm, missing planner, <2 paired seeds); `scenario_params` fallback; NaN/Inf metric dropping; float-seed coercion + whitespace stripping; determinism; claim boundary; and the CLI end-to-end on constructed records (reversal rendered, readiness fail-closed, missing-file exit code).

**No campaign, Slurm job, training run, or benchmark/rank-stability/realism claim was produced.** This PR does not regress the existing rank-sensitivity characterization tests (26 still pass).

## Successor statement

Successor slice: adds the **pre-specified (preregistered) rank-reversal test** as a new statistical primitive + CLI + doc. Does not duplicate PR #4591 (which added bootstrap P(A beats B) + the descriptive disagreement flag), #5237 (3-planner manifest), or #5288 (fail-closed finite-`mean_clearance` readiness). It is distinct from and complementary to the descriptive flag.

## Claim boundary & remaining work (Refs #3574)

This PR makes **no** benchmark, rank-stability, realism, or sim-to-real claim. The test is exercised on synthetic fixtures only. A campaign conclusion requires real paired episode records from the mean-matched paired ablation campaign, which remains **open** under #3574 (per the most recent gate states). Remaining open work:
- Mean-matched paired ablation **campaign** run (out of scope for cheap-lane: no campaigns).
- Realized-distribution audit **completion** (needs campaign data).
- Actually running this rank-reversal test on campaign records to report a real conclusion.

Because the campaign data required to produce a real rank-reversal *conclusion* does not yet exist, this is a **partial slice**: `Refs #3574`, not `Closes`.

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
