### PR TITLE
Issue #4401: standalone rank-identifiability contract check CLI (cheap-lane worker)

### DIFF
--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -1607,9 +1607,11 @@ def _resolve_rank_contract_spec(
         plan_path = pathlib.Path(args.plan)
         if not plan_path.is_absolute():
             plan_path = REPO_ROOT / args.plan
-        if not plan_path.exists():
-            raise FileNotFoundError(f"--plan not found: {plan_path}")
+        if not plan_path.is_file():
+            raise FileNotFoundError(f"--plan not found or is not a file: {plan_path}")
         plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        if not isinstance(plan, dict):
+            raise ValueError(f"--plan must contain a JSON dictionary: {_repo_rel(plan_path)}")
         spec = select_rank_identifiability_contract_spec(plan)
         if spec is None:
             raise ValueError(
@@ -1646,9 +1648,9 @@ def _run_fixed_scope_check_rank_contract(
     report_path = pathlib.Path(args.report) if args.report else None
     if report_path is not None and not report_path.is_absolute():
         report_path = REPO_ROOT / args.report
-    if report_path is None or not report_path.exists():
+    if report_path is None or not report_path.is_file():
         missing = _repo_rel(report_path) if report_path else "<unset>"
-        print(f"fail-closed: --report not found: {missing}")
+        print(f"fail-closed: --report not found or is not a file: {missing}")
         print(
             "--fixed-scope-check-rank-contract requires --report pointing to an "
             "existing fidelity_rank_stability_report.json"

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -1328,6 +1328,31 @@ def write_outputs(
         write_rank_identifiability_report(rank_report, evidence_dir)
 
 
+RANK_IDENTIFIABILITY_CONTRACT_ID = "runtime_rank_identifiability_recheck"
+
+
+def select_rank_identifiability_contract_spec(
+    plan: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    """Return the rank-identifiability post-run contract spec from a plan.
+
+    Shared by the per-cell execute path and the standalone contract validator so
+    both gates select the same registered contract (no divergence).
+
+    Args:
+        plan: Packet from :func:`build_fixed_scope_run_plan` or its serialized JSON.
+
+    Returns:
+        The ``runtime_rank_identifiability_recheck`` contract spec, or ``None``
+        when the plan carries no such spec.
+    """
+    contract_specs = plan.get("post_run_contract_specs") or []
+    return next(
+        (spec for spec in contract_specs if spec.get("id") == RANK_IDENTIFIABILITY_CONTRACT_ID),
+        None,
+    )
+
+
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config", default=DEFAULT_CONFIG)
@@ -1372,6 +1397,36 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "cleared, so on the shipped config it runs zero episodes. When launchable, each "
             "plan cell is bound to concrete runner inputs (planner, variant, seed) with no "
             "silent fallback for unbound (ORCA/hybrid) planners."
+        ),
+    )
+    parser.add_argument(
+        "--fixed-scope-check-rank-contract",
+        action="store_true",
+        help=(
+            "Standalone post-run gate (issue #4401 successor slice): validate an existing "
+            "fidelity_rank_stability_report.json against the rank-identifiability post-run "
+            "contract and exit fail-closed when the report does not satisfy it. Runs no "
+            "episode; the contract spec is resolved from --plan when given, otherwise rebuilt "
+            "from the shipped fixed-scope config. This makes 'claim promotion remains blocked "
+            "unless the post-run report passes' an independently re-runnable check."
+        ),
+    )
+    parser.add_argument(
+        "--report",
+        default=None,
+        help=(
+            "Path to an existing fidelity_rank_stability_report.json to validate. "
+            "Required with --fixed-scope-check-rank-contract."
+        ),
+    )
+    parser.add_argument(
+        "--plan",
+        default=None,
+        help=(
+            "Path to a fidelity_fixed_scope_run_plan.json carrying the registered "
+            "post_run_contract_specs. With --fixed-scope-check-rank-contract, the "
+            "rank-identifiability contract spec is read from this file; when omitted the "
+            "spec is rebuilt from the shipped fixed-scope config for the same purpose."
         ),
     )
     parser.add_argument("--date", default=dt.datetime.now(tz=dt.UTC).date().isoformat())
@@ -1500,15 +1555,7 @@ def _run_fixed_scope_execute(args: argparse.Namespace, config: Mapping[str, Any]
         evidence_dir=REPO_ROOT / args.evidence_dir,
     )
     # Post-run contract gate: validate rank-identifiability against plan spec.
-    contract_specs = plan.get("post_run_contract_specs") or []
-    rank_contract_spec = next(
-        (
-            spec
-            for spec in contract_specs
-            if spec.get("id") == "runtime_rank_identifiability_recheck"
-        ),
-        None,
-    )
+    rank_contract_spec = select_rank_identifiability_contract_spec(plan)
     if rank_contract_spec is not None:
         contract_result = check_rank_identifiability_contract(
             report["rank_stability"], rank_contract_spec
@@ -1528,6 +1575,122 @@ def _run_fixed_scope_execute(args: argparse.Namespace, config: Mapping[str, Any]
     return 0
 
 
+RANK_CONTRACT_REPORT_FILENAME = "fidelity_rank_stability_report.json"
+RANK_CONTRACT_CHECK_SCHEMA_VERSION = "issue_3207_fidelity_rank_contract_check.v1"
+RANK_CONTRACT_CHECK_CLAIM_BOUNDARY = (
+    "fixed_scope_rank_contract_check_only: validates an already-produced "
+    "fidelity_rank_stability_report.json against the registered post-run "
+    "rank-identifiability contract. It runs no episode and rewrites no report; "
+    "it is the operator-facing re-runnable gate behind 'claim promotion remains "
+    "blocked unless the post-run report passes' (issue #4401). It is not benchmark "
+    "evidence, not simulator-realism evidence, not sim-to-real evidence, and not "
+    "paper-facing evidence."
+)
+
+
+def _resolve_rank_contract_spec(
+    args: argparse.Namespace,
+    config: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], str]:
+    """Resolve the rank-identifiability contract spec and record its provenance.
+
+    The contract spec is read from a serialized plan at ``--plan`` when given;
+    otherwise it is rebuilt from the shipped fixed-scope config so the standalone
+    validator always checks against the registered contract (never an ad-hoc one).
+    Either way no episode is executed.
+
+    Returns:
+        A ``(spec, provenance)`` pair where ``provenance`` describes where the
+        spec came from.
+    """
+    if args.plan:
+        plan_path = pathlib.Path(args.plan)
+        if not plan_path.is_absolute():
+            plan_path = REPO_ROOT / args.plan
+        if not plan_path.exists():
+            raise FileNotFoundError(f"--plan not found: {plan_path}")
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        spec = select_rank_identifiability_contract_spec(plan)
+        if spec is None:
+            raise ValueError(
+                f"--plan carries no '{RANK_IDENTIFIABILITY_CONTRACT_ID}' "
+                f"post_run_contract_specs entry: {_repo_rel(plan_path)}"
+            )
+        return spec, f"plan_file:{_repo_rel(plan_path)}"
+    fresh_plan = build_fixed_scope_run_plan(
+        config, config_path=args.config, git_head=_git_head(), date=str(args.date)
+    )
+    spec = select_rank_identifiability_contract_spec(fresh_plan)
+    if spec is None:
+        raise ValueError(
+            "rebuilt fixed-scope plan carries no "
+            f"'{RANK_IDENTIFIABILITY_CONTRACT_ID}' post_run_contract_specs entry"
+        )
+    return spec, "rebuilt_from_config"
+
+
+def _run_fixed_scope_check_rank_contract(
+    args: argparse.Namespace, config: Mapping[str, Any]
+) -> int:
+    """Validate an existing rank-identifiability report against the contract.
+
+    Successor slice for issue #4401: a standalone, re-runnable post-run gate. It
+    loads an already-produced ``fidelity_rank_stability_report.json`` (from any
+    campaign, including a future authorized fixed-scope run) and fails closed
+    unless the report satisfies the registered rank-identifiability contract. It
+    runs no episode and promotes no claim.
+
+    Returns:
+        ``0`` when the contract is satisfied, otherwise ``1`` (fail-closed).
+    """
+    report_path = pathlib.Path(args.report) if args.report else None
+    if report_path is not None and not report_path.is_absolute():
+        report_path = REPO_ROOT / args.report
+    if report_path is None or not report_path.exists():
+        missing = _repo_rel(report_path) if report_path else "<unset>"
+        print(f"fail-closed: --report not found: {missing}")
+        print(
+            "--fixed-scope-check-rank-contract requires --report pointing to an "
+            "existing fidelity_rank_stability_report.json"
+        )
+        return 1
+
+    spec, spec_provenance = _resolve_rank_contract_spec(args, config)
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    if not isinstance(report, Mapping):
+        raise ValueError(f"report must be a JSON mapping: {_repo_rel(report_path)}")
+    result = check_rank_identifiability_contract(report, spec)
+
+    payload = {
+        "schema_version": RANK_CONTRACT_CHECK_SCHEMA_VERSION,
+        "claim_boundary": RANK_CONTRACT_CHECK_CLAIM_BOUNDARY,
+        "date": str(args.date),
+        **_git_provenance(),
+        "report_path": _repo_rel(report_path),
+        "contract_id": result.contract_id,
+        "contract_spec_provenance": spec_provenance,
+        "threshold": spec.get("threshold"),
+        "metric": spec.get("metric"),
+        "blocks_claims_when_failed": bool(spec.get("blocks_claims_when_failed", True)),
+        "satisfied": result.satisfied,
+        "reason": result.reason,
+        "report_rank_identifiable": bool(report.get("rank_identifiable", False)),
+        "report_rank_identifiability_reason": report.get("rank_identifiability_reason"),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if result.satisfied:
+        print(
+            f"rank-identifiability contract '{result.contract_id}' satisfied "
+            f"(report={_repo_rel(report_path)})"
+        )
+        return 0
+    print(
+        f"fail-closed: rank-identifiability contract '{result.contract_id}' NOT "
+        f"satisfied: {result.reason}"
+    )
+    return 1
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the bounded actual campaign."""
     args = _parse_args(argv)
@@ -1544,6 +1707,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         # execute, but only after ensure_fixed_scope_launchable passes. On the
         # shipped config this fails closed and runs zero episodes.
         return _run_fixed_scope_execute(args, config)
+    if args.fixed_scope_check_rank_contract:
+        # Standalone post-run gate (issue #4401 successor slice): validate an
+        # existing rank-identifiability report against the registered contract.
+        # Runs no episode.
+        return _run_fixed_scope_check_rank_contract(args, config)
     scenario_path = REPO_ROOT / args.scenario_set
     scenarios = list(load_scenarios(scenario_path))
     if not scenarios:

--- a/tests/benchmark/test_fidelity_rank_contract_check_cli.py
+++ b/tests/benchmark/test_fidelity_rank_contract_check_cli.py
@@ -1,0 +1,316 @@
+"""Tests for the issue #4401 successor slice: standalone rank-identifiability contract check.
+
+The merged #4420/#4446 slices defined the ``runtime_rank_identifiability_recheck``
+post-run contract and its in-process checker. This successor slice adds the
+operator-facing, re-runnable CLI (``--fixed-scope-check-rank-contract``) that
+validates an *already-produced* ``fidelity_rank_stability_report.json`` against
+the registered contract and exits fail-closed when the report does not satisfy
+it. That makes "claim promotion remains blocked unless the post-run report
+passes" an independently verifiable gate without re-running any campaign.
+
+These tests run no episode. They build small deterministic report fixtures (the
+same shapes ``analyze_fidelity_sensitivity`` emits) and exercise the new CLI
+mode in-process through ``main([...])``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs" / "research" / "fidelity_sensitivity_v1.yaml"
+
+
+def _load_campaign_runner() -> ModuleType:
+    module_path = REPO_ROOT / "scripts" / "benchmark" / "run_fidelity_sensitivity_campaign.py"
+    spec = importlib.util.spec_from_file_location(
+        "fidelity_rank_contract_check_runner", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load campaign runner module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["fidelity_rank_contract_check_runner"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+campaign_runner = _load_campaign_runner()
+
+
+def _config() -> dict:
+    return yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def _write_report(report: dict, path: Path) -> Path:
+    """Write a report fixture in the shape the standalone report writer emits.
+
+    The checker only reads ``rank_identifiable`` / ``rank_identifiability_reason``,
+    so the fixture preserves the report's own schema version from
+    ``analyze_fidelity_sensitivity``.
+    """
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _first_json_object(stdout: str) -> dict:
+    """Extract the first balanced JSON object from a stdout string.
+
+    The CLI prints a pretty-printed (indent=2) JSON packet followed by a
+    plain-text status line, so line-based parsing is unsafe. This scans for the
+    first balanced ``{...}`` object instead.
+    """
+    import json as _json
+
+    start = stdout.index("{")
+    depth = 0
+    in_string = False
+    escape = False
+    for idx in range(start, len(stdout)):
+        ch = stdout[idx]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return _json.loads(stdout[start : idx + 1])
+    raise AssertionError("no balanced JSON object found in stdout")
+
+
+def _identifiable_report() -> dict:
+    """A report whose primary metric is identifiable (varies across planners)."""
+    from robot_sf.benchmark.fidelity_rank_stability import analyze_fidelity_sensitivity
+
+    nominal = {"planner_a": {"snqi": 0.9}, "planner_b": {"snqi": 0.4}}
+    report = analyze_fidelity_sensitivity(
+        nominal, {}, primary_metric="snqi", drift_metrics=["snqi"]
+    ).to_dict()
+    # Sanity: this fixture is genuinely identifiable.
+    assert report["rank_identifiable"] is True
+    return report
+
+
+def _non_identifiable_report() -> dict:
+    """A report whose primary metric is all-tied (zero variance, non-identifiable)."""
+    from robot_sf.benchmark.fidelity_rank_stability import analyze_fidelity_sensitivity
+
+    tied = {"planner_a": {"snqi": 0.0}, "planner_b": {"snqi": 0.0}}
+    report = analyze_fidelity_sensitivity(
+        tied, {}, primary_metric="snqi", drift_metrics=["snqi"]
+    ).to_dict()
+    assert report["rank_identifiable"] is False
+    return report
+
+
+# ---------------------------------------------------------------------------
+# select_rank_identifiability_contract_spec: shared spec selection
+# ---------------------------------------------------------------------------
+
+
+def test_select_spec_returns_registered_rank_contract() -> None:
+    """The shared selector finds the rank-identifiability contract in a fresh plan."""
+    plan = campaign_runner.build_fixed_scope_run_plan(
+        _config(),
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="test-head",
+    )
+    spec = campaign_runner.select_rank_identifiability_contract_spec(plan)
+    assert spec is not None
+    assert spec["id"] == campaign_runner.RANK_IDENTIFIABILITY_CONTRACT_ID
+    assert spec["threshold"] == "non_zero_variance_and_rank_identifiable"
+    assert spec["blocks_claims_when_failed"] is True
+
+
+def test_select_spec_returns_none_when_absent() -> None:
+    """A plan without the contract yields None, not an error (fail-closed downstream)."""
+    plan = campaign_runner.build_fixed_scope_run_plan(
+        _config(),
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="test-head",
+    )
+    plan["post_run_contract_specs"] = []
+    assert campaign_runner.select_rank_identifiability_contract_spec(plan) is None
+
+
+# ---------------------------------------------------------------------------
+# CLI: --fixed-scope-check-rank-contract
+# ---------------------------------------------------------------------------
+
+
+def test_cli_passes_when_report_is_identifiable(tmp_path: Path) -> None:
+    """An identifiable report passes the contract and exits zero."""
+    report_path = _write_report(
+        _identifiable_report(), tmp_path / "fidelity_rank_stability_report.json"
+    )
+    exit_code = campaign_runner.main(
+        [
+            "--fixed-scope-check-rank-contract",
+            "--report",
+            str(report_path),
+        ]
+    )
+    assert exit_code == 0
+
+
+def test_cli_fails_closed_when_report_is_non_identifiable(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A zero-variance report fails the contract and exits non-zero (fail-closed)."""
+    report_path = _write_report(
+        _non_identifiable_report(), tmp_path / "fidelity_rank_stability_report.json"
+    )
+    exit_code = campaign_runner.main(
+        [
+            "--fixed-scope-check-rank-contract",
+            "--report",
+            str(report_path),
+        ]
+    )
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    # The fail-closed message and the contract id both appear in the output.
+    assert "fail-closed" in captured.out
+    assert campaign_runner.RANK_IDENTIFIABILITY_CONTRACT_ID in captured.out
+
+
+def test_cli_fails_closed_when_report_path_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A missing --report exits non-zero with an actionable message (no episode run)."""
+    exit_code = campaign_runner.main(
+        [
+            "--fixed-scope-check-rank-contract",
+            "--report",
+            str(tmp_path / "does_not_exist.json"),
+        ]
+    )
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "--report not found" in captured.out
+    assert "fidelity_rank_stability_report.json" in captured.out
+
+
+def test_cli_emits_machine_readable_check_packet(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The check emits a JSON packet with the registered claim boundary and provenance."""
+    report_path = _write_report(
+        _identifiable_report(), tmp_path / "fidelity_rank_stability_report.json"
+    )
+    exit_code = campaign_runner.main(
+        [
+            "--fixed-scope-check-rank-contract",
+            "--report",
+            str(report_path),
+        ]
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    # The first non-empty JSON object on stdout is the check packet.
+    packet = _first_json_object(captured.out)
+    assert packet["schema_version"] == campaign_runner.RANK_CONTRACT_CHECK_SCHEMA_VERSION
+    assert "not benchmark evidence" in packet["claim_boundary"]
+    assert packet["contract_id"] == campaign_runner.RANK_IDENTIFIABILITY_CONTRACT_ID
+    assert packet["threshold"] == "non_zero_variance_and_rank_identifiable"
+    assert packet["blocks_claims_when_failed"] is True
+    assert packet["satisfied"] is True
+    assert packet["reason"] is None
+    # Default spec provenance (no --plan) is the rebuilt fixed-scope config.
+    assert packet["contract_spec_provenance"] == "rebuilt_from_config"
+    assert packet["report_rank_identifiable"] is True
+
+
+def test_cli_reads_contract_spec_from_plan_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--plan pins the contract spec to a serialized run plan's registered spec."""
+    plan = campaign_runner.build_fixed_scope_run_plan(
+        _config(),
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="test-head",
+    )
+    plan_dir = tmp_path / "plan"
+    plan_dir.mkdir()
+    plan_path = campaign_runner.write_fixed_scope_run_plan(plan, plan_dir)
+    report_path = _write_report(
+        _identifiable_report(), tmp_path / "fidelity_rank_stability_report.json"
+    )
+
+    exit_code = campaign_runner.main(
+        [
+            "--fixed-scope-check-rank-contract",
+            "--report",
+            str(report_path),
+            "--plan",
+            str(plan_path),
+        ]
+    )
+    assert exit_code == 0
+    packet = _first_json_object(capsys.readouterr().out)
+    assert packet["contract_spec_provenance"].startswith("plan_file:")
+    assert "fidelity_fixed_scope_run_plan.json" in packet["contract_spec_provenance"]
+
+
+def test_cli_plan_without_contract_spec_raises(tmp_path: Path) -> None:
+    """A --plan that lacks the rank-identifiability spec is a hard error, not a silent pass."""
+    plan_dir = tmp_path / "plan"
+    plan_dir.mkdir()
+    plan_path = plan_dir / "fidelity_fixed_scope_run_plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "issue_3207_fidelity_fixed_scope_run_plan.v1",
+                "post_run_contract_specs": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    report_path = _write_report(
+        _identifiable_report(), tmp_path / "fidelity_rank_stability_report.json"
+    )
+    with pytest.raises(ValueError, match="post_run_contract_specs entry"):
+        campaign_runner.main(
+            [
+                "--fixed-scope-check-rank-contract",
+                "--report",
+                str(report_path),
+                "--plan",
+                str(plan_path),
+            ]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression: the execute path still uses the shared selector (no divergence)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_path_uses_shared_selector() -> None:
+    """_run_fixed_scope_execute resolves its spec via the shared selector helper."""
+    # The execute-path contract gate references the shared selector symbol.
+    source = (
+        Path(campaign_runner.__file__).read_text(encoding="utf-8")
+        if hasattr(campaign_runner, "__file__")
+        else ""
+    )
+    # The execute function's post-run gate must call the shared selector.
+    assert "select_rank_identifiability_contract_spec(plan)" in source

--- a/tests/benchmark/test_fidelity_rank_contract_check_cli.py
+++ b/tests/benchmark/test_fidelity_rank_contract_check_cli.py
@@ -16,7 +16,9 @@ mode in-process through ``main([...])``.
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import json
+import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -209,6 +211,25 @@ def test_cli_fails_closed_when_report_path_missing(
     assert "fidelity_rank_stability_report.json" in captured.out
 
 
+def test_cli_fails_closed_when_report_path_is_directory(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A directory passed as --report fails closed rather than attempting to read it."""
+    report_dir = tmp_path / "fidelity_rank_stability_report.json"
+    report_dir.mkdir()
+
+    exit_code = campaign_runner.main(
+        [
+            "--fixed-scope-check-rank-contract",
+            "--report",
+            str(report_dir),
+        ]
+    )
+
+    assert exit_code == 1
+    assert "not found or is not a file" in capsys.readouterr().out
+
+
 def test_cli_emits_machine_readable_check_packet(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -299,6 +320,44 @@ def test_cli_plan_without_contract_spec_raises(tmp_path: Path) -> None:
         )
 
 
+def test_cli_rejects_plan_with_non_object_json_root(tmp_path: Path) -> None:
+    """A serialized plan must be an object so spec selection cannot silently misbehave."""
+    plan_path = tmp_path / "fidelity_fixed_scope_run_plan.json"
+    plan_path.write_text("[]", encoding="utf-8")
+    report_path = _write_report(
+        _identifiable_report(), tmp_path / "fidelity_rank_stability_report.json"
+    )
+
+    with pytest.raises(ValueError, match="JSON dictionary"):
+        campaign_runner.main(
+            [
+                "--fixed-scope-check-rank-contract",
+                "--report",
+                str(report_path),
+                "--plan",
+                str(plan_path),
+            ]
+        )
+
+
+def test_cli_rejects_plan_path_that_is_a_directory(tmp_path: Path) -> None:
+    """A directory passed as --plan raises a clear file-boundary error."""
+    report_path = _write_report(
+        _identifiable_report(), tmp_path / "fidelity_rank_stability_report.json"
+    )
+
+    with pytest.raises(FileNotFoundError, match="not found or is not a file"):
+        campaign_runner.main(
+            [
+                "--fixed-scope-check-rank-contract",
+                "--report",
+                str(report_path),
+                "--plan",
+                str(tmp_path),
+            ]
+        )
+
+
 # ---------------------------------------------------------------------------
 # Regression: the execute path still uses the shared selector (no divergence)
 # ---------------------------------------------------------------------------
@@ -306,11 +365,5 @@ def test_cli_plan_without_contract_spec_raises(tmp_path: Path) -> None:
 
 def test_execute_path_uses_shared_selector() -> None:
     """_run_fixed_scope_execute resolves its spec via the shared selector helper."""
-    # The execute-path contract gate references the shared selector symbol.
-    source = (
-        Path(campaign_runner.__file__).read_text(encoding="utf-8")
-        if hasattr(campaign_runner, "__file__")
-        else ""
-    )
-    # The execute function's post-run gate must call the shared selector.
-    assert "select_rank_identifiability_contract_spec(plan)" in source
+    source = inspect.getsource(campaign_runner._run_fixed_scope_execute)
+    assert re.search(r"select_rank_identifiability_contract_spec\s*\(\s*plan\s*\)", source)


### PR DESCRIPTION
## What / Why

**Successor slice** for #4401. Does **not** duplicate PR #4420, #4446, or #4499 — it adds new capability on top of them.

Issue #4401's three named prerequisites (hybrid opt-in, actionable ORCA/rvo2 remedy, concrete post-run rank-identifiability contract) are already delivered and audited:

- **#4420** — preflight/plan wiring: hybrid opt-in, `post_run_contract_specs`, ORCA/rvo2 remediation.
- **#4446** — `check_rank_identifiability_contract()` + `write_rank_identifiability_report()` + the in-process contract gate inside `_run_fixed_scope_execute`.
- **#4499** — closure audit mapping every CPU-only acceptance criterion to a merged commit.

The residual named in the thread is empirical: an authorized full fixed-scope campaign must still *produce* `fidelity_rank_stability_report.json` and *pass* the contract before any ranking claim is promoted. That is out of scope here (no campaign / Slurm / GPU / training).

### The gap this slice closes

The in-process contract gate added in #4446 is only reachable by executing a full fixed-scope campaign (needs `rvo2` + every launch gate cleared). There was **no operator-facing, re-runnable way** to validate an *already-produced* `fidelity_rank_stability_report.json` against the registered contract without re-running episodes. So the issue's final acceptance — *"later claim promotion remains blocked unless the post-run report passes"* — had a checker function but no standalone entry point a reviewer/maintainer could run against a report handed to them from any campaign (including a future authorized SLURM run).

### New capability

Add `--fixed-scope-check-rank-contract` to the canonical fidelity-sensitivity campaign runner (`scripts/benchmark/run_fidelity_sensitivity_campaign.py`):

- Loads an existing `fidelity_rank_stability_report.json` (`--report`).
- Resolves the contract spec from a serialized run plan (`--plan`), or rebuilds it from the shipped fixed-scope config so the validator always checks against the registered contract (never an ad-hoc one).
- Runs `check_rank_identifiability_contract`.
- Emits a machine-readable check packet (`issue_3207_fidelity_rank_contract_check.v1`, with claim boundary + spec provenance + pass/fail + reason).
- Exits **fail-closed** (exit 1) when the report does not satisfy `non_zero_variance_and_rank_identifiable`.

Also factors the contract-spec selection into a shared `select_rank_identifiability_contract_spec` helper so the execute path and the new standalone validator select the same registered contract with no divergence (the execute path's inline copy is replaced with a call to the helper).

Runs **no episode**, adds no planner arm, changes no threshold, promotes no claim.

## Validation (CPU-only)

```
scripts/dev/run_worktree_shared_venv.sh -- pytest \
  tests/benchmark/test_fidelity_rank_contract_check_cli.py \
  tests/benchmark/test_fidelity_fixed_scope_run_plan.py \
  tests/benchmark/test_fidelity_rank_stability.py -q
# -> 49 passed (40 existing + 9 new)
```

```
ruff check + ruff format on both changed files  # -> clean
```

Issue's plan-only dry-run (on a host where `rvo2` is present):

```
uv run python scripts/benchmark/run_fidelity_sensitivity_campaign.py \
  --fixed-scope-plan-only \
  --plan-out output/issue_3207_fixed_scope_plan_issue_4401 \
  --require-launchable
# -> wrote fixed-scope run plan: .../fidelity_fixed_scope_run_plan.json
# -> preflight_decision=preflight_ready executable=True launched=False run_cells=153
# -> EXIT 0
```

New CLI, **pass** case (identifiable report): exits `0`, `satisfied: true`, packet with `contract_spec_provenance: rebuilt_from_config`.

New CLI, **fail** case (zero-variance / non-identifiable report): exits `1`, `fail-closed`, `satisfied: false`, `reason: rank not identifiable (reason=primary_metric_zero_variance); blocks_claims_when_failed=True`.

New CLI with `--plan` (serialized run plan): packet records `contract_spec_provenance: plan_file:.../fidelity_fixed_scope_run_plan.json`.

### Test coverage added (`tests/benchmark/test_fidelity_rank_contract_check_cli.py`)

- shared selector returns the registered contract; returns `None` when absent.
- CLI passes on an identifiable report; fails closed on a zero-variance report; fails closed when `--report` is missing.
- CLI emits the machine-readable check packet (schema version, claim boundary, provenance, threshold, metric, satisfied, reason).
- CLI reads the contract spec from `--plan` (plan-file provenance); raises on a `--plan` lacking the contract spec (no silent pass).
- regression: the execute path uses the shared selector (no divergence).

## Successor statement

**successor slice: standalone post-run rank-identifiability contract validation CLI; does not duplicate PR #4420 (preflight/plan wiring), #4446 (in-process checker + report writer), or #4499 (closure audit).** Those delivered the contract and the in-process gate; this slice makes the contract an independently re-runnable, episode-free gate that any report (from any campaign, including a future authorized fixed-scope run) can be validated against.

## Remaining

The only remaining item for #4401 is unchanged and still out of scope for a CPU-only implementation worker: an authorized full fixed-scope campaign must actually run, produce `fidelity_rank_stability_report.json`, and pass `check_rank_identifiability_contract()` before any planner-ranking claim is promoted. This slice does not produce that empirical evidence; it gives the gate that evidence must pass a standalone operator-facing entry point.

Refs #4401

---

This PR was produced by the Pi-harness/GLM-5.2 cheap implementation lane; the review gate hardens and merges.
