### PR TITLE
feat(benchmark): catch preflight runtime blockers (#5300)

### DIFF
--- a/robot_sf/benchmark/camera_ready/_preflight.py
+++ b/robot_sf/benchmark/camera_ready/_preflight.py
@@ -44,6 +44,10 @@ from robot_sf.benchmark.camera_ready._util import (
 from robot_sf.benchmark.campaign_checkpoint_preflight import (
     check_campaign_arm_checkpoints_preflight,
 )
+from robot_sf.benchmark.campaign_runtime_preflight import (
+    check_campaign_arm_policy_dependencies_preflight,
+    check_campaign_scenario_maps_preflight,
+)
 from robot_sf.benchmark.latency_stress import not_available_latency_metrics
 from robot_sf.benchmark.observation_noise import (
     normalize_observation_noise_spec,
@@ -416,6 +420,10 @@ def prepare_campaign_preflight(  # noqa: PLR0913
             collision.
         CampaignCheckpointPreflightError: When any enabled arm names a checkpoint that cannot be
             resolved (or, in ``enforced_staged`` mode, cannot be staged) before scenarios load.
+        CampaignPolicyDependencyPreflightError: When an enabled arm cannot import its required
+            policy dependency in the active campaign interpreter.
+        CampaignScenarioMapPreflightError: When a prepared scenario's ``map_file`` cannot resolve
+            with the same repository-root path semantics used by campaign execution.
     """
     if validate_campaign_config is None:
         from robot_sf.benchmark.camera_ready_campaign import (  # noqa: PLC0415
@@ -426,6 +434,7 @@ def prepare_campaign_preflight(  # noqa: PLR0913
 
     validate_campaign_config(cfg)
     check_orca_rvo2_preflight(cfg)
+    check_campaign_arm_policy_dependencies_preflight(cfg)
     # Fail fast when an enabled arm names a checkpoint that cannot be resolved (unknown/mistyped
     # model_id, local_only-missing, or a missing model_path file) before any scenario loads. There
     # are two modes (issue #4613/#4663):
@@ -456,6 +465,7 @@ def prepare_campaign_preflight(  # noqa: PLR0913
 
     created_at_utc = _utc_now()
     scenarios = _load_campaign_scenarios(cfg)
+    check_campaign_scenario_maps_preflight(scenarios)
     route_clearance_certifications = _load_route_clearance_certifications(
         cfg.route_clearance_certifications_path
     )

--- a/robot_sf/benchmark/campaign_runtime_preflight.py
+++ b/robot_sf/benchmark/campaign_runtime_preflight.py
@@ -1,0 +1,211 @@
+"""CPU-only runtime dependency and map checks for camera-ready campaigns.
+
+The camera-ready campaign preflight must reject failures that would otherwise surface only after a
+GPU allocation starts.  These checks deliberately import only required policy modules and resolve
+only prepared scenario maps; they do not load checkpoints or execute episodes.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from robot_sf.errors import RobotSfError
+from robot_sf.training.scenario_loader import resolve_map_definition
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import ModuleType
+
+    from robot_sf.benchmark.camera_ready._config_types import CampaignConfig, PlannerSpec
+
+
+# These are modules imported by the selected policy construction path, rather than optional
+# convenience imports. ORCA has its dedicated rvo2 preflight, so it is intentionally not repeated
+# here. Hybrid global RL always constructs either a PPO or SAC local policy (SAC by default).
+_POLICY_IMPORTS: dict[str, tuple[str, ...]] = {
+    "ppo": ("stable_baselines3",),
+    "sac": ("stable_baselines3",),
+    "guarded_ppo": ("stable_baselines3",),
+    "hybrid_global_rl": ("stable_baselines3",),
+    "global_rl_local": ("stable_baselines3",),
+    "route_conditioned_rl": ("stable_baselines3",),
+    "hybrid_route_rl": ("stable_baselines3",),
+    "drl_vo": ("torch",),
+    "distributional_rl": ("torch",),
+    "qr_dqn": ("torch",),
+    "diffusion_policy": ("torch",),
+    "diffusion_rl": ("torch",),
+    "diffusion_local_policy": ("torch",),
+    "colson_style_diffusion": ("torch",),
+}
+
+
+class CampaignPolicyDependencyPreflightError(RobotSfError, RuntimeError):
+    """Raised when an enabled campaign arm cannot import a required policy dependency."""
+
+    def __init__(self, message: str, *, arms: tuple[str, ...]) -> None:
+        """Store the actionable error plus the affected campaign arms."""
+        super().__init__(message)
+        self.arms = arms
+
+
+class CampaignScenarioMapPreflightError(RobotSfError, RuntimeError):
+    """Raised when a prepared camera-ready scenario has an unresolvable map file."""
+
+    def __init__(self, message: str, *, scenarios: tuple[str, ...]) -> None:
+        """Store the actionable error plus the affected prepared scenarios."""
+        super().__init__(message)
+        self.scenarios = scenarios
+
+
+@dataclass(frozen=True)
+class _ImportFailure:
+    """One arm/module import failure retained for an actionable aggregate error."""
+
+    planner_key: str
+    algo: str
+    module: str
+    error: Exception
+
+
+def _required_policy_modules(planner: PlannerSpec) -> tuple[str, ...]:
+    """Return runtime modules required by an enabled planner's policy construction path."""
+    if not planner.enabled:
+        return ()
+    return _POLICY_IMPORTS.get(planner.algo.strip().lower(), ())
+
+
+def check_campaign_arm_policy_dependencies_preflight(
+    cfg: CampaignConfig,
+    *,
+    import_module: Callable[[str], ModuleType] = importlib.import_module,
+) -> dict[str, Any]:
+    """Import every enabled arm's required policy modules in the active interpreter.
+
+    Returns:
+        Summary naming each checked arm/module pair.
+
+    Raises:
+        CampaignPolicyDependencyPreflightError: If one or more required imports fail.
+    """
+    checks = [
+        (planner, module)
+        for planner in cfg.planners
+        for module in _required_policy_modules(planner)
+    ]
+    failures: list[_ImportFailure] = []
+    for planner, module in checks:
+        try:
+            import_module(module)
+        except (ImportError, OSError) as exc:
+            failures.append(
+                _ImportFailure(
+                    planner_key=planner.key,
+                    algo=planner.algo,
+                    module=module,
+                    error=exc,
+                )
+            )
+
+    if failures:
+        details = "\n".join(
+            f"  - arm '{failure.planner_key}' (algo={failure.algo!r}) requires "
+            f"'{failure.module}': {type(failure.error).__name__}: {failure.error}"
+            for failure in failures
+        )
+        message = (
+            f"Campaign policy-dependency preflight failed for {len(failures)} import(s):\n"
+            f"{details}\n"
+            "Install the camera-ready policy dependencies in this same interpreter with:\n"
+            "  uv sync --all-extras\n"
+            "Aborting before starting the benchmark campaign."
+        )
+        logger.error(message)
+        raise CampaignPolicyDependencyPreflightError(
+            message,
+            arms=tuple(sorted({failure.planner_key for failure in failures})),
+        )
+
+    logger.info("Policy-dependency preflight passed for {} arm-module import(s).", len(checks))
+    return {
+        "checked": len(checks),
+        "arms": [
+            {"planner_key": planner.key, "algo": planner.algo, "module": module}
+            for planner, module in checks
+        ],
+    }
+
+
+def check_campaign_scenario_maps_preflight(
+    scenarios: list[dict[str, Any]],
+    *,
+    scenario_path: Path = Path("."),
+    resolve_map: Callable[[str | None], Any] | None = None,
+) -> dict[str, Any]:
+    """Resolve every prepared scenario map with the same repository-root semantics as a run.
+
+    ``run_batch`` receives the prepared scenario list and defaults its ``scenario_path`` to ``.``.
+    Keeping that behavior here verifies the parent-normalized ``map_file`` values that both the
+    in-process and subprocess campaign paths execute.
+
+    Returns:
+        Summary containing the number of scenarios and map references swept.
+
+    Raises:
+        CampaignScenarioMapPreflightError: If any named ``map_file`` cannot be loaded.
+    """
+    resolver = resolve_map
+    if resolver is None:
+
+        def resolver(map_file: str | None) -> Any:
+            return resolve_map_definition(map_file, scenario_path=scenario_path)
+
+    failures: list[tuple[str, str, Exception | None]] = []
+    checked = 0
+    for scenario in scenarios:
+        map_file = scenario.get("map_file")
+        if not isinstance(map_file, str) or not map_file.strip():
+            continue
+        checked += 1
+        scenario_name = str(
+            scenario.get("name") or scenario.get("scenario_id") or scenario.get("id") or "unknown"
+        )
+        try:
+            if resolver(map_file) is None:
+                failures.append((scenario_name, map_file, None))
+        except (OSError, ValueError) as exc:
+            failures.append((scenario_name, map_file, exc))
+
+    if failures:
+        details = "\n".join(
+            f"  - scenario '{name}', map_file '{map_file}'"
+            + (f": {type(error).__name__}: {error}" if error is not None else "")
+            for name, map_file, error in failures
+        )
+        message = (
+            f"Campaign map-resolvability preflight failed for {len(failures)} scenario(s):\n"
+            f"{details}\n"
+            "Fix each scenario's map_file so it resolves from the repository root after campaign "
+            "normalization. Aborting before starting the benchmark campaign."
+        )
+        logger.error(message)
+        raise CampaignScenarioMapPreflightError(
+            message,
+            scenarios=tuple(name for name, _, _ in failures),
+        )
+
+    logger.info("Map-resolvability preflight passed for {} scenario map reference(s).", checked)
+    return {"checked": checked, "scenario_count": len(scenarios)}
+
+
+__all__ = [
+    "CampaignPolicyDependencyPreflightError",
+    "CampaignScenarioMapPreflightError",
+    "check_campaign_arm_policy_dependencies_preflight",
+    "check_campaign_scenario_maps_preflight",
+]

--- a/robot_sf/benchmark/campaign_runtime_preflight.py
+++ b/robot_sf/benchmark/campaign_runtime_preflight.py
@@ -165,7 +165,7 @@ def check_campaign_scenario_maps_preflight(
         def resolver(map_file: str | None) -> Any:
             return resolve_map_definition(map_file, scenario_path=scenario_path)
 
-    failures: list[tuple[str, str, Exception | None]] = []
+    failures: list[tuple[str, str, Exception]] = []
     checked = 0
     for scenario in scenarios:
         map_file = scenario.get("map_file")
@@ -177,14 +177,21 @@ def check_campaign_scenario_maps_preflight(
         )
         try:
             if resolver(map_file) is None:
-                failures.append((scenario_name, map_file, None))
-        except (OSError, ValueError) as exc:
+                failures.append(
+                    (
+                        scenario_name,
+                        map_file,
+                        FileNotFoundError("map file could not be resolved or loaded"),
+                    )
+                )
+        # Map parser backends do not expose one stable error hierarchy. Preserve every failed
+        # prepared scenario in the fail-closed aggregate instead of stopping at the first parser.
+        except Exception as exc:  # noqa: BLE001
             failures.append((scenario_name, map_file, exc))
 
     if failures:
         details = "\n".join(
-            f"  - scenario '{name}', map_file '{map_file}'"
-            + (f": {type(error).__name__}: {error}" if error is not None else "")
+            f"  - scenario '{name}', map_file '{map_file}': {type(error).__name__}: {error}"
             for name, map_file, error in failures
         )
         message = (

--- a/robot_sf/benchmark/campaign_runtime_preflight.py
+++ b/robot_sf/benchmark/campaign_runtime_preflight.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import yaml
 from loguru import logger
 
 from robot_sf.errors import RobotSfError
@@ -184,9 +185,7 @@ def check_campaign_scenario_maps_preflight(
                         FileNotFoundError("map file could not be resolved or loaded"),
                     )
                 )
-        # Map parser backends do not expose one stable error hierarchy. Preserve every failed
-        # prepared scenario in the fail-closed aggregate instead of stopping at the first parser.
-        except Exception as exc:  # noqa: BLE001
+        except (OSError, RuntimeError, TypeError, ValueError, AssertionError, yaml.YAMLError) as exc:
             failures.append((scenario_name, map_file, exc))
 
     if failures:

--- a/robot_sf/benchmark/campaign_runtime_preflight.py
+++ b/robot_sf/benchmark/campaign_runtime_preflight.py
@@ -185,7 +185,14 @@ def check_campaign_scenario_maps_preflight(
                         FileNotFoundError("map file could not be resolved or loaded"),
                     )
                 )
-        except (OSError, RuntimeError, TypeError, ValueError, AssertionError, yaml.YAMLError) as exc:
+        except (
+            OSError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+            AssertionError,
+            yaml.YAMLError,
+        ) as exc:
             failures.append((scenario_name, map_file, exc))
 
     if failures:

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -13,7 +13,6 @@ from types import SimpleNamespace
 
 import pytest
 import yaml
-from loguru import logger
 
 import robot_sf.benchmark.camera_ready as camera_ready_package
 import robot_sf.benchmark.camera_ready._artifacts as camera_ready_artifacts_module
@@ -63,6 +62,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
     run_campaign,
     write_campaign_report,
 )
+from robot_sf.benchmark.campaign_runtime_preflight import CampaignScenarioMapPreflightError
 from robot_sf.benchmark.map_runner_profile_metadata import load_synthetic_actuation_profile
 from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError
 from robot_sf.benchmark.synthetic_actuation import (
@@ -5105,12 +5105,9 @@ def test_prepare_campaign_preflight_emits_route_clearance_warnings(
     assert manifest_payload["route_clearance_warnings"] == warnings
 
 
-def test_prepare_campaign_preflight_warns_when_route_clearance_map_parse_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Map parse failures should be visible without DEBUG logging."""
-    broken_map_path = tmp_path / "broken.svg"
-    broken_map_path.write_text("<svg><path d='broken'/></svg>\n", encoding="utf-8")
+def test_prepare_campaign_preflight_fails_when_map_is_unresolvable(tmp_path: Path) -> None:
+    """An unresolvable map must fail the runtime preflight before route clearance."""
+    broken_map_path = tmp_path / "does_not_exist.svg"
     scenario_path = tmp_path / "scenarios.yaml"
     scenario_path.write_text(
         "\n".join(
@@ -5139,39 +5136,15 @@ def test_prepare_campaign_preflight_warns_when_route_clearance_map_parse_fails(
         encoding="utf-8",
     )
 
-    def fail_convert_map(_path: str) -> object:
-        raise ValueError("invalid SVG path data")
-
-    monkeypatch.setattr(
-        "robot_sf.benchmark.camera_ready_campaign.convert_map",
-        fail_convert_map,
-    )
-    captured: list[str] = []
-
-    def capture_message(message: object) -> None:
-        captured.append(str(message))
-
-    handle = logger.add(capture_message, level="WARNING", format="{level}:{message}")
-    try:
-        cfg = load_campaign_config(config_path)
-        prepared = prepare_campaign_preflight(
+    cfg = load_campaign_config(config_path)
+    with pytest.raises(CampaignScenarioMapPreflightError, match="parse_failure_case") as excinfo:
+        prepare_campaign_preflight(
             cfg,
             output_root=tmp_path / "out",
             label="parse",
         )
-    finally:
-        logger.remove(handle)
-
-    validate_payload = json.loads(
-        Path(prepared["validate_config_path"]).read_text(encoding="utf-8")
-    )
-    assert validate_payload["route_clearance_warning_count"] == 0
-
-    log_text = "\n".join(captured)
-    assert "WARNING:" in log_text
-    assert "parse_failure_case" in log_text
-    assert broken_map_path.as_posix() in log_text
-    assert "invalid SVG path data" in log_text
+    assert broken_map_path.as_posix() in str(excinfo.value)
+    assert "map-resolvability preflight failed" in str(excinfo.value)
 
 
 def test_prepare_campaign_preflight_attaches_route_clearance_certifications(

--- a/tests/benchmark/test_campaign_runtime_preflight.py
+++ b/tests/benchmark/test_campaign_runtime_preflight.py
@@ -66,6 +66,8 @@ def test_map_resolvability_preflight_aggregates_every_bad_prepared_scenario() ->
     ]
 
     def resolve_map(map_file: str):
+        if map_file.endswith("missing_a.svg"):
+            raise RuntimeError("malformed SVG")
         return None if "missing" in map_file else object()
 
     with pytest.raises(CampaignScenarioMapPreflightError) as excinfo:
@@ -74,6 +76,8 @@ def test_map_resolvability_preflight_aggregates_every_bad_prepared_scenario() ->
     assert excinfo.value.scenarios == ("bad_a", "bad_b")
     assert "maps/missing_a.svg" in str(excinfo.value)
     assert "maps/missing_b.svg" in str(excinfo.value)
+    assert "RuntimeError: malformed SVG" in str(excinfo.value)
+    assert "FileNotFoundError: map file could not be resolved or loaded" in str(excinfo.value)
 
 
 def test_map_resolvability_preflight_accepts_valid_prepared_scenarios() -> None:

--- a/tests/benchmark/test_campaign_runtime_preflight.py
+++ b/tests/benchmark/test_campaign_runtime_preflight.py
@@ -1,0 +1,100 @@
+"""Regression tests for camera-ready runtime dependency and map preflight (issue #5300)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import robot_sf.benchmark.camera_ready._preflight as preflight_module
+from robot_sf.benchmark.camera_ready._config_types import CampaignConfig, PlannerSpec, SeedPolicy
+from robot_sf.benchmark.camera_ready._preflight import prepare_campaign_preflight
+from robot_sf.benchmark.campaign_runtime_preflight import (
+    CampaignPolicyDependencyPreflightError,
+    CampaignScenarioMapPreflightError,
+    check_campaign_arm_policy_dependencies_preflight,
+    check_campaign_scenario_maps_preflight,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _campaign(tmp_path: Path, planners: tuple[PlannerSpec, ...]) -> CampaignConfig:
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text("scenarios: []\n", encoding="utf-8")
+    return CampaignConfig(
+        name="runtime_preflight_test",
+        scenario_matrix_path=scenario_path,
+        planners=planners,
+        seed_policy=SeedPolicy(),
+    )
+
+
+def test_policy_dependency_preflight_names_missing_arm_and_remediation(
+    tmp_path: Path,
+) -> None:
+    """A missing PPO dependency fails before a campaign run with its exact remediation."""
+    cfg = _campaign(tmp_path, (PlannerSpec(key="ppo_arm", algo="ppo"),))
+    imported: list[str] = []
+
+    def fail_import(module: str):
+        imported.append(module)
+        raise ModuleNotFoundError("No module named 'stable_baselines3'")
+
+    with pytest.raises(CampaignPolicyDependencyPreflightError) as excinfo:
+        check_campaign_arm_policy_dependencies_preflight(cfg, import_module=fail_import)
+
+    assert imported == ["stable_baselines3"]
+    assert excinfo.value.arms == ("ppo_arm",)
+    assert "uv sync --all-extras" in str(excinfo.value)
+    assert "stable_baselines3" in str(excinfo.value)
+
+
+def test_policy_dependency_preflight_skips_disabled_arm(tmp_path: Path) -> None:
+    """Disabled learned-policy arms do not block the campaign dependency gate."""
+    cfg = _campaign(tmp_path, (PlannerSpec(key="ppo_off", algo="ppo", enabled=False),))
+    assert check_campaign_arm_policy_dependencies_preflight(cfg) == {"checked": 0, "arms": []}
+
+
+def test_map_resolvability_preflight_aggregates_every_bad_prepared_scenario() -> None:
+    """Every bad normalized map reference is reported together before a run starts."""
+    scenarios = [
+        {"name": "bad_a", "map_file": "maps/missing_a.svg"},
+        {"name": "valid", "map_file": "maps/valid.svg"},
+        {"name": "bad_b", "map_file": "maps/missing_b.svg"},
+    ]
+
+    def resolve_map(map_file: str):
+        return None if "missing" in map_file else object()
+
+    with pytest.raises(CampaignScenarioMapPreflightError) as excinfo:
+        check_campaign_scenario_maps_preflight(scenarios, resolve_map=resolve_map)
+
+    assert excinfo.value.scenarios == ("bad_a", "bad_b")
+    assert "maps/missing_a.svg" in str(excinfo.value)
+    assert "maps/missing_b.svg" in str(excinfo.value)
+
+
+def test_map_resolvability_preflight_accepts_valid_prepared_scenarios() -> None:
+    """A fully resolvable prepared scenario list remains preflight-ready."""
+    scenarios = [{"name": "valid", "map_file": "maps/valid.svg"}, {"name": "no_map"}]
+    assert check_campaign_scenario_maps_preflight(
+        scenarios,
+        resolve_map=lambda _map_file: object(),
+    ) == {"checked": 1, "scenario_count": 2}
+
+
+def test_campaign_preflight_rejects_bad_map_from_prepared_scenarios(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The camera-ready entry point sweeps the post-normalization scenario list before a run."""
+    cfg = _campaign(tmp_path, (PlannerSpec(key="goal", algo="goal"),))
+    monkeypatch.setattr(
+        preflight_module,
+        "_load_campaign_scenarios",
+        lambda _cfg: [{"name": "bad_prepared", "map_file": "maps/does_not_exist.svg"}],
+    )
+
+    with pytest.raises(CampaignScenarioMapPreflightError, match="bad_prepared"):
+        prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="bad-map")

--- a/tests/benchmark/test_route_clearance_fail_closed.py
+++ b/tests/benchmark/test_route_clearance_fail_closed.py
@@ -33,8 +33,11 @@ def _write_campaign(
         Path to the campaign config file.
     """
     map_path = (tmp_path / "scenario_map.svg").resolve()
-    # Content is irrelevant: ``convert_map`` is monkeypatched per test to return fixed geometry.
-    map_path.write_text("<svg></svg>\n", encoding="utf-8")
+    # ``convert_map`` is monkeypatched for the clearance geometry, but the runtime preflight still
+    # resolves this fixture first, so it must be a syntactically valid SVG map.
+    map_path.write_text(
+        '<svg width="10" height="10" viewBox="0 0 10 10"></svg>\n', encoding="utf-8"
+    )
 
     scenario_lines = [
         "- name: clearance_case",


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** camera-ready preflight now imports each enabled learned-policy arm's required runtime module and resolves every post-normalization scenario `map_file` before artifacts or benchmark execution begin.
- **Why now:** #5300 recorded four GPU allocations lost to missing `stable_baselines3` and unresolvable maps that a CPU preflight had not exercised.
- **Claim boundary:** this is CPU-only readiness validation; it does not run a benchmark or establish any benchmark, metric, model-provenance, paper, or dissertation result.
- **Required validation:** `uv run pytest tests/benchmark/ -k 'preflight' -v` (282 passed), focused dependency/map and checkpoint-preflight regressions (26 passed), and the final committed-HEAD readiness gate.
- **Remaining blocker:** none for #5300's code contract. A full benchmark campaign remains intentionally out of scope.

## Contract delta

- New fail-closed blockers: an enabled PPO/SAC/guarded/hybrid learned arm missing `stable_baselines3`, or enabled Torch-backed arm missing `torch`, now fails with the named arm, module, and `uv sync --all-extras` remedy.
- New fail-closed blocker: every prepared scenario map must resolve through `resolve_map_definition`; preflight lists all `(scenario, map_file)` failures together.
- Compatibility: valid configs are unchanged. Existing route-clearance fixture SVGs now satisfy the same map-validity prerequisite, and the former warning-only malformed-map expectation correctly fails before route-clearance analysis.

Closes #5300

Issue: https://github.com/ll7/robot_sf_ll7/issues/5300

## Scope and validation

- Full issue implementation: adds the nameable capability **per-arm runtime dependency and prepared-map preflight** to `CAMERA_READY_BENCHMARK_MODE=preflight`'s camera-ready path.
- `uv run pytest tests/benchmark/test_campaign_runtime_preflight.py tests/benchmark/test_campaign_checkpoint_preflight.py tests/benchmark/test_camera_ready_checkpoint_submit_preflight.py -v` — 26 passed.
- `uv run pytest tests/benchmark/ -k 'preflight' -v` — 282 passed, 4,371 deselected.
- `uv run ruff check robot_sf/benchmark/campaign_runtime_preflight.py robot_sf/benchmark/camera_ready/_preflight.py tests/benchmark/test_campaign_runtime_preflight.py tests/benchmark/test_camera_ready_campaign.py tests/benchmark/test_route_clearance_fail_closed.py` — passed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed at committed HEAD (freshness stamp below).

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

<details>
<summary>Governance, artifacts, and propagation appendix</summary>

### Implementation assumption

The reversible mapping probes the policy modules selected by camera-ready arms: Stable-Baselines3 for PPO/SAC/guarded and hybrid route-conditioned policies, and PyTorch for DRL-VO, distributional-RL, and diffusion policies. ORCA retains its existing dedicated `rvo2` preflight. This directly covers the recorded missing-SB3 failure without constructing policies or loading checkpoints.

### Artifacts and state propagation

No generated artifacts are committed; `output/` contains only the readiness freshness stamp and remains ignored. No issue-state comment was added because this task explicitly does not authorize issue or PR comments; this PR body is the canonical reviewable propagation surface.

### Fragmentation, evidence, and friction log

No merged #5300 guardrail/checker/packet-refresh PRs were found in the prior 24 hours, so this is a progression slice with the new capability named above. Downstream research propagation is not applicable: support validation only, with no empirical claim. `friction_issues: []` — the one shared-venv freshness guard provided a documented, successful local-venv setup path, and the route-clearance fixture incompatibility was directly corrected within this issue's test scope.

### Explicit exclusions

- No compute submission, merge, release, or deletion.
- No transient queue-routing state in tracked files.
- No benchmark metric or claim-semantics change.

</details>
