### PR TITLE
fix(benchmark): preserve campaign exit across reporting (#5244)

### DIFF
--- a/docs/context/issue_3216_headline_ci_rank_stability.md
+++ b/docs/context/issue_3216_headline_ci_rank_stability.md
@@ -55,6 +55,15 @@ S20 (`paper_eval_s20`) and the launch-only S30 schedule (`paper_eval_s30`) are
 available via #1554. No S20/S30 campaign rows exist yet, so the report remains
 blocked until the SLURM run produces durable rows.
 
+The portable launcher `scripts/benchmark/run_issue3216_headline_campaign.sh`
+keeps campaign execution and post-campaign reporting as separate status lanes.
+It writes `reports/post_campaign_stage_status.json` under the campaign root with
+both exit codes. A completed campaign retains exit 0 even when the report stage
+fails, while the report is marked `report_stage_failed` and remains unavailable
+for benchmark claims. Hard campaign failures remain nonzero and skip reporting.
+This prevents a missing report dependency or artifact from relabeling completed
+planner rows as a failed campaign without hiding the reporting blocker.
+
 ## Reuse of canonical owners (no reinvention)
 
 Per AGENTS.md "Canonical Owner Check", the statistics are **composed**, not

--- a/scripts/benchmark/run_issue3216_headline_campaign.sh
+++ b/scripts/benchmark/run_issue3216_headline_campaign.sh
@@ -180,7 +180,8 @@ echo " report_stage_exit_code=$report_exit_code"
 echo " report_stage_failed=$([ "$report_exit_code" -eq 0 ] && echo false || echo true)"
 echo " post_campaign_stage_status=$STAGE_STATUS"
 if [ "$status_record_exit_code" -ne 0 ]; then
-  echo "WARNING: failed to write post-campaign stage status (exit $status_record_exit_code)." >&2
+  echo "ERROR: failed to write post-campaign stage status (exit $status_record_exit_code)." >&2
+  exit "$status_record_exit_code"
 fi
 
 if [ "$report_exit_code" -ne 0 ]; then

--- a/scripts/benchmark/run_issue3216_headline_campaign.sh
+++ b/scripts/benchmark/run_issue3216_headline_campaign.sh
@@ -137,28 +137,56 @@ fi
 
 echo "== [#3216] campaign: increased-seed-budget headline 7x7 (S20) =="
 echo " config=$CONFIG campaign_id=$CAMPAIGN_ID output_root=$OUTPUT_ROOT"
+campaign_exit_code=0
 uv run python scripts/tools/run_camera_ready_benchmark.py \
   --config "$CONFIG" \
   --campaign-id "$CAMPAIGN_ID" \
-  --output-root "$OUTPUT_ROOT"
+  --output-root "$OUTPUT_ROOT" || campaign_exit_code=$?
+
+echo " campaign_stage_exit_code=$campaign_exit_code"
+if [ "$campaign_exit_code" -ne 0 ]; then
+  exit "$campaign_exit_code"
+fi
 
 echo "== [#3216] report: per-cell CI + rank-stability (fail-closed; never self-certifies paper-grade) =="
 CAMPAIGN_ROOT="$OUTPUT_ROOT/$CAMPAIGN_ID"
 mkdir -p "$REPORT_DIR"
+report_exit_code=0
 uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py \
   --campaign "$CAMPAIGN_ROOT" \
   --rank-metric "$RANK_METRIC" \
   --expected-planners-from-config "$CONFIG" \
-  --output-dir "$REPORT_DIR"
+  --output-dir "$REPORT_DIR" || report_exit_code=$?
 
 ROWS="$CAMPAIGN_ROOT/reports/headline_rows.json"
-if [ ! -f "$ROWS" ]; then
+if [ "$report_exit_code" -eq 0 ] && [ ! -f "$ROWS" ]; then
   echo "ERROR: report builder did not produce $ROWS." >&2
-  exit 5
+  report_exit_code=5
 fi
-if [ ! -f "$REPORT_DIR/result.json" ]; then
+if [ "$report_exit_code" -eq 0 ] && [ ! -f "$REPORT_DIR/result.json" ]; then
   echo "ERROR: report builder did not produce $REPORT_DIR/result.json." >&2
-  exit 5
+  report_exit_code=5
+fi
+
+STAGE_STATUS="$CAMPAIGN_ROOT/reports/post_campaign_stage_status.json"
+status_record_exit_code=0
+uv run python scripts/tools/record_post_campaign_stage_status.py \
+  --campaign-summary "$CAMPAIGN_ROOT/reports/campaign_summary.json" \
+  --campaign-exit-code "$campaign_exit_code" \
+  --stage-name headline_ci_rank_stability_report \
+  --stage-exit-code "$report_exit_code" \
+  --output "$STAGE_STATUS" || status_record_exit_code=$?
+echo " report_stage_exit_code=$report_exit_code"
+echo " report_stage_failed=$([ "$report_exit_code" -eq 0 ] && echo false || echo true)"
+echo " post_campaign_stage_status=$STAGE_STATUS"
+if [ "$status_record_exit_code" -ne 0 ]; then
+  echo "WARNING: failed to write post-campaign stage status (exit $status_record_exit_code)." >&2
+fi
+
+if [ "$report_exit_code" -ne 0 ]; then
+  echo "WARNING: campaign completed but the post-campaign report stage failed; " \
+    "campaign exit remains $campaign_exit_code." >&2
+  exit "$campaign_exit_code"
 fi
 echo " rows=$ROWS"
 

--- a/scripts/tools/record_post_campaign_stage_status.py
+++ b/scripts/tools/record_post_campaign_stage_status.py
@@ -43,6 +43,11 @@ def build_stage_status(
     an already completed campaign as a failed scheduler job.
     """
     summary, summary_status = _load_campaign_summary(campaign_summary_path)
+    if campaign_exit_code == 0 and summary_status != "loaded":
+        raise ValueError(
+            "campaign completed successfully (exit 0) but its summary could not be loaded "
+            f"({summary_status}) from {campaign_summary_path}"
+        )
     warnings = summary.get("warnings", []) if summary is not None else []
     if not isinstance(warnings, list):
         warnings = []

--- a/scripts/tools/record_post_campaign_stage_status.py
+++ b/scripts/tools/record_post_campaign_stage_status.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Record campaign and post-campaign exit codes without conflating them.
+
+This helper is intentionally metadata-only.  A launcher owns its process exit code;
+the helper writes the separate campaign and reporting lanes that schedulers and
+ledgers need to classify a completed campaign whose downstream report failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "robot-sf-post-campaign-stage-status.v1"
+
+
+def _load_campaign_summary(path: Path) -> tuple[dict[str, Any] | None, str]:
+    """Load a campaign summary and return its machine-readable load status."""
+    if not path.is_file():
+        return None, "missing"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None, "invalid"
+    if not isinstance(payload, dict):
+        return None, "invalid"
+    return payload, "loaded"
+
+
+def build_stage_status(
+    *,
+    campaign_summary_path: Path,
+    campaign_exit_code: int,
+    stage_name: str,
+    stage_exit_code: int,
+) -> dict[str, Any]:
+    """Build separate campaign and post-campaign status lanes.
+
+    ``job_exit_code`` deliberately follows the campaign lane.  A reporting or
+    analysis failure remains visible in ``post_campaign_stage`` but cannot relabel
+    an already completed campaign as a failed scheduler job.
+    """
+    summary, summary_status = _load_campaign_summary(campaign_summary_path)
+    warnings = summary.get("warnings", []) if summary is not None else []
+    if not isinstance(warnings, list):
+        warnings = []
+    soft_contract_warning = bool(
+        summary is not None and summary.get("soft_contract_warning") is True
+    )
+    campaign_completed = campaign_exit_code == 0
+    stage_completed = stage_exit_code == 0
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "campaign": {
+            "status": "completed" if campaign_completed else "failed",
+            "exit_code": campaign_exit_code,
+            "summary_json": str(campaign_summary_path),
+            "summary_status": summary_status,
+            "soft_contract_warning": soft_contract_warning,
+            "warnings": warnings,
+        },
+        "post_campaign_stage": {
+            "name": stage_name,
+            "status": "completed" if stage_completed else "report_stage_failed",
+            "exit_code": stage_exit_code,
+        },
+        "job_exit_code": campaign_exit_code,
+        "claim_boundary": (
+            "Campaign execution and post-campaign reporting are separate status lanes; "
+            "a completed campaign is not benchmark evidence until its report is available "
+            "and validated."
+        ),
+    }
+
+
+def _exit_code(value: str) -> int:
+    """Parse a portable process exit code."""
+    parsed = int(value)
+    if not 0 <= parsed <= 255:
+        raise argparse.ArgumentTypeError("exit code must be between 0 and 255")
+    return parsed
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--campaign-summary", type=Path, required=True)
+    parser.add_argument("--campaign-exit-code", type=_exit_code, required=True)
+    parser.add_argument("--stage-name", required=True)
+    parser.add_argument("--stage-exit-code", type=_exit_code, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Write the stage-status envelope without adopting either recorded exit code."""
+    args = parse_args(argv)
+    payload = build_stage_status(
+        campaign_summary_path=args.campaign_summary,
+        campaign_exit_code=args.campaign_exit_code,
+        stage_name=args.stage_name,
+        stage_exit_code=args.stage_exit_code,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import runpy
 import subprocess
 import sys
 from pathlib import Path
@@ -33,6 +34,32 @@ def _load_module() -> ModuleType:
 
 issue3216 = _load_module()
 ReportConfig = issue3216.ReportConfig
+
+
+@pytest.mark.parametrize("summary_contents", (None, "not-json"))
+def test_stage_status_fails_closed_when_successful_campaign_summary_is_unavailable(
+    tmp_path: Path,
+    summary_contents: str | None,
+) -> None:
+    """An exit-0 campaign cannot write a vacuous status envelope without its summary."""
+
+    module = runpy.run_path(
+        str(
+            Path(__file__).resolve().parents[2]
+            / "scripts/tools/record_post_campaign_stage_status.py"
+        )
+    )
+    summary_path = tmp_path / "campaign_summary.json"
+    if summary_contents is not None:
+        summary_path.write_text(summary_contents, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="summary could not be loaded"):
+        module["build_stage_status"](
+            campaign_summary_path=summary_path,
+            campaign_exit_code=0,
+            stage_name="report",
+            stage_exit_code=0,
+        )
 
 
 def test_read_csv_rows_fails_closed_on_missing_empty_and_header_only(tmp_path: Path) -> None:
@@ -509,10 +536,12 @@ def test_campaign_recovery_writes_headline_rows_from_completed_artifacts(
     assert by_family["bottleneck"]["row_status"] == "ok"
 
 
+@pytest.mark.parametrize("status_recorder_exit", (0, 17))
 def test_campaign_wrapper_runs_builder_before_requiring_headline_rows(
     tmp_path: Path,
+    status_recorder_exit: int,
 ) -> None:
-    """The wrapper no longer searches for headline_rows before builder execution."""
+    """The wrapper records a real status envelope or fails when it cannot persist one."""
 
     repo_root = Path(__file__).resolve().parents[2]
     output_root = tmp_path / "benchmarks"
@@ -562,6 +591,9 @@ case "${1:-}" in
     echo '# fixture' > "$output_dir/report.md"
     ;;
   scripts/tools/record_post_campaign_stage_status.py)
+    if [ "${STATUS_RECORDER_EXIT:-0}" -ne 0 ]; then
+      exit "$STATUS_RECORDER_EXIT"
+    fi
     exec python "$@"
     ;;
   *)
@@ -577,6 +609,7 @@ esac
         "PATH": f"{bin_dir}:{os.environ['PATH']}",
         "OUTPUT_ROOT": str(output_root),
         "REPORT_DIR": str(report_dir),
+        "STATUS_RECORDER_EXIT": str(status_recorder_exit),
         "UV_STUB_LOG": str(log_path),
     }
 
@@ -595,7 +628,14 @@ esac
         check=False,
     )
 
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == status_recorder_exit, result.stderr
+    if status_recorder_exit:
+        assert "ERROR: failed to write post-campaign stage status (exit 17)." in result.stderr
+        assert not (
+            output_root / "fixture_campaign" / "reports" / "post_campaign_stage_status.json"
+        ).exists()
+        return
+
     assert "locate headline rows" not in result.stdout
     assert " rows=" in result.stdout
     calls = log_path.read_text(encoding="utf-8")

--- a/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
@@ -543,6 +543,7 @@ case "${1:-}" in
       esac
     done
     mkdir -p "$output_root/$campaign_id/reports"
+    echo '{"soft_contract_warning":false,"warnings":[]}' > "$output_root/$campaign_id/reports/campaign_summary.json"
     ;;
   scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py)
     shift
@@ -559,6 +560,9 @@ case "${1:-}" in
     mkdir -p "$output_dir"
     echo '{"classification":"fixture"}' > "$output_dir/result.json"
     echo '# fixture' > "$output_dir/report.md"
+    ;;
+  scripts/tools/record_post_campaign_stage_status.py)
+    exec python "$@"
     ;;
   *)
     exit 98
@@ -600,3 +604,173 @@ esac
     assert f"--campaign {output_root / 'fixture_campaign'}" in calls
     assert (output_root / "fixture_campaign" / "reports" / "headline_rows.json").is_file()
     assert (report_dir / "result.json").is_file()
+    stage_status = json.loads(
+        (
+            output_root / "fixture_campaign" / "reports" / "post_campaign_stage_status.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert stage_status["campaign"]["status"] == "completed"
+    assert stage_status["post_campaign_stage"]["status"] == "completed"
+    assert stage_status["job_exit_code"] == 0
+
+
+@pytest.mark.parametrize("missing_artifact", ("headline_rows", "result"))
+def test_campaign_wrapper_preserves_completed_soft_warning_exit_when_report_artifact_is_missing(
+    tmp_path: Path,
+    missing_artifact: str,
+) -> None:
+    """The wrapper records its exact exit-5 artifact guards without overwriting campaign exit 0."""
+    repo_root = Path(__file__).resolve().parents[2]
+    output_root = tmp_path / "benchmarks"
+    report_dir = tmp_path / "report"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    uv_stub = bin_dir / "uv"
+    uv_stub.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+shift 2
+case "${1:-}" in
+  -)
+    exec python -
+    ;;
+  scripts/tools/run_camera_ready_benchmark.py)
+    shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --campaign-id) campaign_id="$2"; shift 2 ;;
+        --output-root) output_root="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    mkdir -p "$output_root/$campaign_id/reports"
+    cat > "$output_root/$campaign_id/reports/campaign_summary.json" <<'JSON'
+{"soft_contract_warning":true,"warnings":["SNQI contract warning fixture"]}
+JSON
+    ;;
+  scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py)
+    shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --campaign) campaign="$2"; shift 2 ;;
+        --output-dir) output_dir="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [ "$REPORT_FIXTURE" = "headline_rows" ]; then
+      mkdir -p "$output_dir"
+      echo '{"classification":"fixture"}' > "$output_dir/result.json"
+    else
+      mkdir -p "$campaign/reports"
+      echo '[]' > "$campaign/reports/headline_rows.json"
+    fi
+    ;;
+  scripts/tools/record_post_campaign_stage_status.py)
+    exec python "$@"
+    ;;
+  *) exit 98 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    uv_stub.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "OUTPUT_ROOT": str(output_root),
+        "REPORT_DIR": str(report_dir),
+        "REPORT_FIXTURE": missing_artifact,
+    }
+
+    result = subprocess.run(
+        [
+            "bash",
+            "scripts/benchmark/run_issue3216_headline_campaign.sh",
+            "--campaign-id",
+            "soft_warning_fixture",
+        ],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "campaign_stage_exit_code=0" in result.stdout
+    assert "report_stage_exit_code=5" in result.stdout
+    assert "report_stage_failed=true" in result.stdout
+    expected_missing = (
+        output_root / "soft_warning_fixture" / "reports" / "headline_rows.json"
+        if missing_artifact == "headline_rows"
+        else report_dir / "result.json"
+    )
+    assert f"ERROR: report builder did not produce {expected_missing}." in result.stderr
+    status_path = (
+        output_root / "soft_warning_fixture" / "reports" / "post_campaign_stage_status.json"
+    )
+    stage_status = json.loads(status_path.read_text(encoding="utf-8"))
+    assert stage_status["campaign"] == {
+        "exit_code": 0,
+        "soft_contract_warning": True,
+        "status": "completed",
+        "summary_json": str(
+            output_root / "soft_warning_fixture" / "reports" / "campaign_summary.json"
+        ),
+        "summary_status": "loaded",
+        "warnings": ["SNQI contract warning fixture"],
+    }
+    assert stage_status["post_campaign_stage"] == {
+        "exit_code": 5,
+        "name": "headline_ci_rank_stability_report",
+        "status": "report_stage_failed",
+    }
+    assert stage_status["job_exit_code"] == 0
+
+
+def test_campaign_wrapper_preserves_hard_campaign_failure(tmp_path: Path) -> None:
+    """A hard campaign failure remains nonzero and skips post-campaign reporting."""
+    repo_root = Path(__file__).resolve().parents[2]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    call_log = tmp_path / "calls.log"
+    uv_stub = bin_dir / "uv"
+    uv_stub.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$UV_STUB_LOG"
+if [ "${3:-}" = "-" ]; then
+  exec python -
+fi
+if [[ "$*" == *"run_camera_ready_benchmark.py"* ]]; then
+  exit 2
+fi
+exit 98
+""",
+        encoding="utf-8",
+    )
+    uv_stub.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "OUTPUT_ROOT": str(tmp_path / "benchmarks"),
+        "REPORT_DIR": str(tmp_path / "report"),
+        "UV_STUB_LOG": str(call_log),
+    }
+
+    result = subprocess.run(
+        ["bash", "scripts/benchmark/run_issue3216_headline_campaign.sh"],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "campaign_stage_exit_code=2" in result.stdout
+    calls = call_log.read_text(encoding="utf-8")
+    assert "run_camera_ready_benchmark.py" in calls
+    assert "build_headline_ci_rank_stability_report_issue_3216.py" not in calls


### PR DESCRIPTION
## Reviewer-critical summary

**What changed:** the public #3216 campaign launcher now keeps campaign execution and
post-campaign reporting in separate exit-code lanes. It writes a versioned
`reports/post_campaign_stage_status.json` envelope, so a missing report artifact or a
report-stage failure is recorded as `report_stage_failed` without overwriting a completed
campaign's exit code.

**Why now:** the live #5244 sweep identifies the two public exit-5 artifact guards as a
structural conflation risk after a completed campaign. PR #5243 already makes a soft Social
Navigation Quality Index (SNQI) contract warning visible in the campaign summary; this slice
preserves that successful campaign outcome through the public launcher boundary.

**Claim boundary:** this is CPU-only production-wrapper regression evidence for the public #3216
lane. It does not identify the private-ops wrapper or job 13274's exact stderr tail, and it does
not turn a report-stage failure into benchmark evidence.

**Required validation:** focused wrapper regression tests, Ruff, shell syntax, and the final
repository readiness gate below.

**Remaining blocker:** inspect job 13274's private-wrapper/stdout/stderr tail and update the
private scheduler/ledger consumer if it is the layer that remapped exit 5.

## Contract delta

- New additive artifact: `robot-sf-post-campaign-stage-status.v1` at
  `<campaign>/reports/post_campaign_stage_status.json`.
- It records separate `campaign` and `post_campaign_stage` exit/status lanes, plus
  `job_exit_code` that deliberately follows the campaign lane.
- A report-stage failure is explicitly `report_stage_failed`; it cannot relabel an exit-0
  campaign as a failed campaign. A nonzero campaign exit still stops before reporting and remains
  nonzero. If the required status envelope itself cannot be persisted, the launcher fails closed
  with that recorder error rather than reporting a successful scheduler handoff.
- Compatibility: additive artifact only. Existing campaign-summary and camera-ready CLI schemas
  are unchanged.

## Scope and validation

Refs #5244

Successor slice to #5243: this public-wrapper repair preserves the completed campaign lane and
adds the status-envelope handoff, while #5244 remains open for private-wrapper root-cause
identification and any required private consumer repair.

- Public launcher repair: `scripts/benchmark/run_issue3216_headline_campaign.sh`.
- Production dispatch/serialization regression: the wrapper test stubs the campaign and report
  commands, then checks the actual shell boundary and persisted envelope for both public
  artifact-guard exit-5 paths.
- Hard campaign failure regression: confirms a campaign exit 2 remains nonzero and the report
  stage is not invoked.
- Validation:
  - `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run pytest tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py -q` — 21 passed
  - `uv run ruff check scripts/tools/record_post_campaign_stage_status.py tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py` — passed
  - `uv run ruff format --check scripts/tools/record_post_campaign_stage_status.py tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py` — passed
  - `bash -n scripts/benchmark/run_issue3216_headline_campaign.sh` — passed
  - `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue-5244-pr-body.md scripts/dev/pr_ready_check.sh` — passed (core: 2233 passed, 1 skipped; optional: 6587 passed, 17 skipped)

Remaining work:

- [ ] Match job 13274's tail to the private wrapper or an SNQI post-campaign tool, identifying
  the exact responsible layer.
- [ ] If needed, make that private scheduler/ledger layer consume the separate status envelope.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no
paper/dissertation claim edits.

<details>
<summary>Evidence, assumptions, and propagation</summary>

### Reversible implementation assumption

The private-ops wrapper and job logs are not present in this repository. Following the live issue
comment, this PR implements the smallest reversible public boundary: it makes the existing public
artifact guards traceable and prevents their exit-5 lane from overwriting the completed campaign
outcome. The remaining private root-cause check is deliberately not claimed as resolved.

### Evidence classification

Targeted unit/integration evidence only; no benchmark results or metric semantics changed. A
report-stage failure remains a blocker for interpreting the campaign as benchmark evidence.

### Artifact and downstream handling

No generated `output/` artifacts are committed. The new status envelope is produced beside a
future campaign and is the durable handoff for a scheduler/ledger consumer. No other propagation
is applicable because this does not produce benchmark, metric, schema-version, or model-provenance
evidence.

### State propagation

No issue comment was added because this task's authorization explicitly forbids issue/PR comments,
and no canonical `docs/context/issue_5244_state.yaml` exists to update. This PR body is the single
review handoff; its linked issue and remaining-work checklist provide the durable review state.

</details>