### PR TITLE
feat(planner): add chance-constrained MPC framework (#5307)

### DIFF
--- a/configs/algos/chance_constrained_mpc_gmm.yaml
+++ b/configs/algos/chance_constrained_mpc_gmm.yaml
@@ -1,0 +1,31 @@
+# Experimental chance-constrained MPC contract for issue #5307.
+#
+# This arm is intentionally unavailable from ordinary benchmark YAML until #2844
+# provides a K-mode/GMM predictor implementation that is injected through the
+# explicit GaussianMixturePedestrianPredictor boundary. It never falls back to
+# constant velocity. The CV and deterministic-envelope matched arms remain in
+# prediction_mpc_cv.yaml and prediction_mpc_cv_uncertainty_envelope.yaml.
+allow_testing_algorithms: true
+predictor_backend: issue_2844_k_mode_gmm
+allow_predictor_fallback: false
+max_linear_speed: 0.9
+max_angular_speed: 1.1
+horizon_steps: 6
+rollout_dt: 0.25
+goal_tolerance: 0.25
+waypoint_switch_distance: 0.75
+path_goal_weight: 1.5
+terminal_goal_weight: 5.0
+heading_weight: 0.5
+control_effort_weight: 0.05
+smoothness_weight: 0.2
+pedestrian_safety_margin: 0.35
+static_obstacle_soft_weight: 1.0
+solver_ftol: 0.001
+solver_max_iterations: 40
+warm_start: true
+fallback_to_stop: true
+chance_constraint_formulation: marginal
+max_collision_risk: 0.05
+radial_quadrature_order: 6
+angular_quadrature_order: 16

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -75,6 +75,7 @@ _BASELINE_CATEGORY_BY_CANONICAL: dict[str, str] = {
     "teb": "classical",
     "nmpc_social": "classical",
     "prediction_mpc": "classical",
+    "chance_constrained_mpc": "classical",
     "learned_prediction_mpc": "learning",
 }
 
@@ -136,6 +137,7 @@ _POLICY_SEMANTICS_BY_CANONICAL: dict[str, str] = {
     "teb": "corridor_commitment_local_planner",
     "nmpc_social": "nonlinear_model_predictive_local_planner",
     "prediction_mpc": "prediction_aware_model_predictive_local_planner",
+    "chance_constrained_mpc": "gmm_chance_constrained_model_predictive_local_planner",
     "learned_prediction_mpc": "learned_short_horizon_prediction_mpc_local_planner",
 }
 
@@ -233,6 +235,15 @@ _OBSERVATION_SPEC_BY_CANONICAL: dict[str, dict[str, Any]] = {
             "Consumes structured SocNav state. The constant-velocity backend derives "
             "time-varying pedestrian futures from tracked pedestrian positions and "
             "ego-frame pedestrian velocities rotated into world coordinates."
+        ),
+    },
+    "chance_constrained_mpc": {
+        "default_mode": "socnav_state",
+        "supported_modes": ("socnav_state",),
+        "inputs": ("robot_state", "goal", "pedestrians", "k_mode_gmm_pedestrian_futures"),
+        "notes": (
+            "Experimental chance-constrained MPC requires an injected K-mode Gaussian-mixture "
+            "pedestrian predictor and fails closed while that provider is unavailable."
         ),
     },
     "learned_prediction_mpc": {
@@ -1108,6 +1119,16 @@ _KINEMATICS_PROFILE_BY_CANONICAL: dict[str, dict[str, Any]] = {
         "default_adapter_name": "PredictionMPCPlannerAdapter",
         "benchmark_command_space": "unicycle_vw",
         "projection_policy": "constant_velocity_time_varying_pedestrian_constraints",
+        "projection_documented": True,
+    },
+    "chance_constrained_mpc": {
+        "planner_command_space": "unicycle_vw",
+        "supports_native_commands": False,
+        "supports_adapter_commands": True,
+        "default_execution_mode": "adapter",
+        "default_adapter_name": "ChanceConstrainedMPCPlannerAdapter",
+        "benchmark_command_space": "unicycle_vw",
+        "projection_policy": "gmm_marginal_or_boole_joint_collision_risk_constraints",
         "projection_documented": True,
     },
     "learned_prediction_mpc": {

--- a/robot_sf/benchmark/policy_builders.py
+++ b/robot_sf/benchmark/policy_builders.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from robot_sf.planner.chance_constrained_mpc import build_chance_constrained_mpc_adapter
 from robot_sf.planner.dwa import DWAPlannerAdapter, build_dwa_config
 from robot_sf.planner.learned_prediction_mpc import (
     LEARNED_PREDICTION_MPC_ALIASES,
@@ -95,6 +96,25 @@ def _build_prediction_mpc_policy_spec(algo_config: dict[str, Any]) -> AdapterPol
     )
 
 
+def _build_chance_constrained_mpc_policy_spec(algo_config: dict[str, Any]) -> AdapterPolicySpec:
+    """Build the experimental K-mode/GMM chance-constrained MPC arm.
+
+    The builder intentionally fails closed until issue #2844 supplies a concrete
+    multimodal predictor provider; no constant-velocity substitution is valid.
+
+    Returns:
+        The chance-constrained adapter specification when its provider is wired.
+    """
+
+    return AdapterPolicySpec(
+        algo_key="chance_constrained_mpc",
+        algo_config=algo_config,
+        adapter=build_chance_constrained_mpc_adapter(algo_config),
+        adapter_name="ChanceConstrainedMPCPlannerAdapter",
+        limitations="blocked_until_issue_2844_k_mode_gmm_predictor_provider",
+    )
+
+
 def _build_learned_prediction_mpc_policy_spec(algo_config: dict[str, Any]) -> AdapterPolicySpec:
     """Build learned short-horizon prediction MPC algorithm config.
 
@@ -112,6 +132,7 @@ def _build_learned_prediction_mpc_policy_spec(algo_config: dict[str, Any]) -> Ad
 
 
 _ADAPTER_POLICY_BUILDERS: dict[str, Callable[[dict[str, Any]], AdapterPolicySpec]] = {
+    "chance_constrained_mpc": _build_chance_constrained_mpc_policy_spec,
     **dict.fromkeys(LEARNED_PREDICTION_MPC_ALIASES, _build_learned_prediction_mpc_policy_spec),
     "cv_prediction_mpc": _build_prediction_mpc_policy_spec,
     "prediction_aware_mpc": _build_prediction_mpc_policy_spec,

--- a/robot_sf/planner/chance_constrained_mpc.py
+++ b/robot_sf/planner/chance_constrained_mpc.py
@@ -1,0 +1,391 @@
+"""Experimental chance-constrained MPC over K-mode pedestrian forecasts.
+
+The planner deliberately has no built-in predictor.  It accepts an injected
+Gaussian-mixture forecast provider so that an unavailable learned predictor is
+an explicit error, not a silent constant-velocity fallback.  The integration
+with the learned predictor from issue #2844 belongs at that provider boundary.
+
+The joint formulation applies Boole's inequality to the per-pedestrian,
+per-timestep collision probabilities.  It is therefore conservative but does
+not require an unimplemented cross-time covariance model.  Collision
+probabilities are deterministic polar-quadrature approximations of each GMM
+component's probability mass inside the collision disc.  This implementation
+does not make a forecast-calibration or navigation-performance claim.
+"""
+
+from __future__ import annotations
+
+import copy
+import warnings
+from dataclasses import dataclass, fields
+from typing import Any, Literal, Protocol
+
+import numpy as np
+from scipy.optimize import NonlinearConstraint
+
+from robot_sf.planner.nmpc_social import NMPCSocialPlannerAdapter, _parse_bool, _RolloutContext
+from robot_sf.planner.prediction_mpc import PredictionMPCConfig, _to_nmpc_config
+
+
+@dataclass(frozen=True)
+class GaussianMixturePedestrianForecast:
+    """K-mode world-frame pedestrian trajectories with Gaussian uncertainty.
+
+    ``means_world`` and ``covariances_world`` have shape ``(P, K, T, 2)`` and
+    ``(P, K, T, 2, 2)`` respectively.  ``mode_weights`` has shape ``(P, K)``;
+    each pedestrian's weights must sum to one.  Covariances are required to be
+    positive definite because the collision-risk quadrature evaluates a 2-D
+    Gaussian density rather than treating a singular component as a hidden
+    deterministic fallback.
+    """
+
+    means_world: np.ndarray
+    covariances_world: np.ndarray
+    mode_weights: np.ndarray
+    dt: float
+    source: str
+
+    def __post_init__(self) -> None:  # noqa: C901
+        """Validate the GMM contract before an optimizer can consume it."""
+
+        means = np.asarray(self.means_world, dtype=float)
+        covariances = np.asarray(self.covariances_world, dtype=float)
+        weights = np.asarray(self.mode_weights, dtype=float)
+        if means.ndim != 4 or means.shape[-1] != 2:
+            raise ValueError("means_world must have shape (P, K, T, 2)")
+        if covariances.shape != means.shape[:-1] + (2, 2):
+            raise ValueError("covariances_world must have shape (P, K, T, 2, 2)")
+        if weights.shape != means.shape[:2]:
+            raise ValueError("mode_weights must have shape (P, K)")
+        if means.shape[1] == 0 or means.shape[2] == 0:
+            raise ValueError("GMM forecasts require at least one mode and horizon step")
+        if not all(np.all(np.isfinite(value)) for value in (means, covariances, weights)):
+            raise ValueError("GMM forecast values must be finite")
+        if np.any(weights < 0.0) or not np.allclose(weights.sum(axis=1), 1.0, atol=1e-6):
+            raise ValueError("mode_weights must be non-negative and sum to one per pedestrian")
+        if not np.allclose(covariances, np.swapaxes(covariances, -1, -2), atol=1e-8):
+            raise ValueError("covariances_world must be symmetric")
+        if np.any(np.linalg.eigvalsh(covariances) <= 1e-9):
+            raise ValueError("covariances_world must be positive definite")
+        if not np.isfinite(self.dt) or float(self.dt) <= 0.0:
+            raise ValueError("dt must be finite and positive")
+        if not str(self.source).strip():
+            raise ValueError("source must be non-empty")
+        object.__setattr__(self, "means_world", means)
+        object.__setattr__(self, "covariances_world", covariances)
+        object.__setattr__(self, "mode_weights", weights)
+        object.__setattr__(self, "dt", float(self.dt))
+
+
+class GaussianMixturePedestrianPredictor(Protocol):
+    """Provider contract that the learned predictor must implement for #5307."""
+
+    def predict(
+        self,
+        observation: dict[str, Any],
+        *,
+        horizon_steps: int,
+        dt: float,
+    ) -> GaussianMixturePedestrianForecast:
+        """Return a K-mode/GMM forecast aligned with the MPC rollout horizon."""
+
+
+@dataclass
+class ChanceConstrainedMPCConfig(PredictionMPCConfig):
+    """Configuration for the experimental GMM chance-constrained MPC arm."""
+
+    predictor_backend: str = "multimodal_gmm"
+    chance_constraint_formulation: Literal["marginal", "joint_horizon"] = "marginal"
+    max_collision_risk: float = 0.05
+    radial_quadrature_order: int = 6
+    angular_quadrature_order: int = 16
+
+    def __post_init__(self) -> None:
+        """Reject ambiguous risk settings and incompatible envelope composition."""
+
+        super().__post_init__()
+        if self.chance_constraint_formulation not in {"marginal", "joint_horizon"}:
+            raise ValueError("chance_constraint_formulation must be 'marginal' or 'joint_horizon'")
+        if not 0.0 < float(self.max_collision_risk) < 1.0:
+            raise ValueError("max_collision_risk must be in (0, 1)")
+        if int(self.radial_quadrature_order) < 2 or int(self.angular_quadrature_order) < 4:
+            raise ValueError("quadrature orders must be at least 2 radial and 4 angular")
+        if self.allow_predictor_fallback:
+            raise ValueError("chance_constrained_mpc never permits predictor fallback")
+        if self.pedestrian_uncertainty_envelope_enabled or self.pedestrian_uncertainty_alpha_mps:
+            raise ValueError(
+                "chance_constrained_mpc does not compose the deterministic uncertainty envelope; "
+                "use the separate prediction_mpc CV/envelope arms for matched-arm comparisons"
+            )
+
+
+class ChanceConstrainedMPCPlannerAdapter(NMPCSocialPlannerAdapter):
+    """MPC adapter enforcing GMM collision-risk constraints without a fallback predictor."""
+
+    def __init__(
+        self,
+        config: ChanceConstrainedMPCConfig | None = None,
+        predictor: GaussianMixturePedestrianPredictor | None = None,
+    ) -> None:
+        """Initialize the adapter with the required K-mode forecast provider."""
+
+        self.chance_config = config or ChanceConstrainedMPCConfig()
+        if predictor is None:
+            raise ValueError(
+                "chance_constrained_mpc requires an injected GaussianMixturePedestrianPredictor; "
+                "the #2844 learned K-mode/GMM provider is not wired yet"
+            )
+        self._multimodal_predictor = predictor
+        self._last_forecast: GaussianMixturePedestrianForecast | None = None
+        self._last_constraint_count = 0
+        super().__init__(_to_nmpc_config(self.chance_config))
+
+    def reset(self) -> None:
+        """Clear solver and forecast diagnostics at an episode boundary."""
+
+        super().reset()
+        self._last_forecast = None
+        self._last_constraint_count = 0
+        reset = getattr(self._multimodal_predictor, "reset", None)
+        if callable(reset):
+            reset()
+
+    def _optimizer_constraints(self, context: _RolloutContext) -> tuple[NonlinearConstraint, ...]:
+        """Build the requested marginal or joint-horizon chance constraint.
+
+        Returns:
+            A single non-linear constraint unless no pedestrians are forecast.
+        """
+
+        forecast = self._multimodal_predictor.predict(
+            context.observation,
+            horizon_steps=max(int(self.config.horizon_steps), 1),
+            dt=float(self.config.rollout_dt),
+        )
+        if not isinstance(forecast, GaussianMixturePedestrianForecast):
+            raise TypeError("multimodal predictor must return GaussianMixturePedestrianForecast")
+        if not np.isclose(forecast.dt, self.config.rollout_dt):
+            raise ValueError("GMM forecast dt must match the MPC rollout_dt")
+        if forecast.means_world.shape[2] < int(self.config.horizon_steps):
+            raise ValueError("GMM forecast horizon is shorter than the MPC horizon")
+        self._last_forecast = forecast
+        if forecast.means_world.shape[0] == 0:
+            self._last_constraint_count = 0
+            return ()
+        self._last_constraint_count = (
+            forecast.means_world.shape[0] * int(self.config.horizon_steps)
+            if self.chance_config.chance_constraint_formulation == "marginal"
+            else 1
+        )
+        return (
+            NonlinearConstraint(
+                lambda controls: self._chance_constraint_values(
+                    controls,
+                    context=context,
+                    forecast=forecast,
+                ),
+                0.0,
+                np.inf,
+            ),
+        )
+
+    def _chance_constraint_values(
+        self,
+        controls_flat: np.ndarray,
+        *,
+        context: _RolloutContext,
+        forecast: GaussianMixturePedestrianForecast,
+    ) -> np.ndarray:
+        """Return non-negative chance-constraint slack for an MPC control sequence."""
+
+        risks = self._marginal_collision_risks(controls_flat, context=context, forecast=forecast)
+        if risks.size == 0:
+            return np.ones((1,), dtype=float)
+        alpha = float(self.chance_config.max_collision_risk)
+        if self.chance_config.chance_constraint_formulation == "marginal":
+            return alpha - risks.reshape(-1)
+        # Boole's inequality bounds P(any collision over people and time) by the
+        # sum of marginal probabilities without assuming cross-time independence.
+        return np.asarray([alpha - float(np.sum(risks))], dtype=float)
+
+    def _marginal_collision_risks(
+        self,
+        controls_flat: np.ndarray,
+        *,
+        context: _RolloutContext,
+        forecast: GaussianMixturePedestrianForecast,
+    ) -> np.ndarray:
+        """Estimate per-pedestrian, per-timestep GMM collision probabilities.
+
+        Returns:
+            Array with shape ``(P, T)`` of collision-probability estimates.
+        """
+
+        states = self._rollout_states(controls_flat, context=context)
+        steps = min(states.shape[0], forecast.means_world.shape[2])
+        people = forecast.means_world.shape[0]
+        risks = np.zeros((people, steps), dtype=float)
+        collision_radius = (
+            float(context.robot_radius)
+            + float(context.ped_radius)
+            + float(self.chance_config.pedestrian_safety_margin)
+        )
+        for pedestrian_index in range(people):
+            for step_index in range(steps):
+                risk = 0.0
+                for mode_index, weight in enumerate(forecast.mode_weights[pedestrian_index]):
+                    risk += float(weight) * self._gaussian_disc_probability(
+                        mean=forecast.means_world[pedestrian_index, mode_index, step_index],
+                        covariance=forecast.covariances_world[
+                            pedestrian_index, mode_index, step_index
+                        ],
+                        center=states[step_index, :2],
+                        radius=collision_radius,
+                    )
+                risks[pedestrian_index, step_index] = float(np.clip(risk, 0.0, 1.0))
+        return risks
+
+    def _gaussian_disc_probability(
+        self,
+        *,
+        mean: np.ndarray,
+        covariance: np.ndarray,
+        center: np.ndarray,
+        radius: float,
+    ) -> float:
+        """Approximate probability mass of one Gaussian inside a collision disc.
+
+        Returns:
+            A deterministic quadrature estimate clipped to the unit interval.
+        """
+
+        radial_nodes, radial_weights = np.polynomial.legendre.leggauss(
+            int(self.chance_config.radial_quadrature_order)
+        )
+        radii = 0.5 * (radial_nodes + 1.0) * radius
+        radial_weights = 0.5 * radial_weights * radius
+        angles = (
+            2.0
+            * np.pi
+            * np.arange(int(self.chance_config.angular_quadrature_order), dtype=float)
+            / float(self.chance_config.angular_quadrature_order)
+        )
+        points = (
+            center[None, None, :]
+            + radii[:, None, None] * np.stack((np.cos(angles), np.sin(angles)), axis=-1)[None, :, :]
+        )
+        delta = points - mean[None, None, :]
+        inverse = np.linalg.inv(covariance)
+        determinant = float(np.linalg.det(covariance))
+        exponent = np.einsum("...i,ij,...j->...", delta, inverse, delta)
+        density = np.exp(-0.5 * exponent) / (2.0 * np.pi * np.sqrt(determinant))
+        angular_weight = 2.0 * np.pi / float(self.chance_config.angular_quadrature_order)
+        probability = np.sum(density * radii[:, None] * radial_weights[:, None] * angular_weight)
+        return float(np.clip(probability, 0.0, 1.0))
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return solver diagnostics with an explicit chance-constraint boundary."""
+
+        payload = copy.deepcopy(super().diagnostics())
+        forecast = self._last_forecast
+        payload.update(
+            {
+                "chance_constraint": {
+                    "formulation": self.chance_config.chance_constraint_formulation,
+                    "max_collision_risk": self.chance_config.max_collision_risk,
+                    "quadrature": "deterministic_polar_gaussian_disc",
+                    "radial_order": self.chance_config.radial_quadrature_order,
+                    "angular_order": self.chance_config.angular_quadrature_order,
+                    "joint_bound": "Boole_union_bound"
+                    if self.chance_config.chance_constraint_formulation == "joint_horizon"
+                    else None,
+                    "constraint_count": self._last_constraint_count,
+                    "forecast_source": forecast.source if forecast else "not_run",
+                    "forecast_modes": int(forecast.means_world.shape[1]) if forecast else 0,
+                    "claim_boundary": (
+                        "implementation-only; collision-risk calibration and planner benefit "
+                        "require matched-arm benchmark evidence"
+                    ),
+                }
+            }
+        )
+        return payload
+
+
+def build_chance_constrained_mpc_config(
+    cfg: dict[str, Any] | None,
+) -> ChanceConstrainedMPCConfig:
+    """Build chance-constrained MPC config from a YAML-compatible mapping.
+
+    Returns:
+        Parsed configuration with malformed scalar fields restored to defaults.
+    """
+
+    raw = dict(cfg or {})
+    defaults = ChanceConstrainedMPCConfig()
+    converters: dict[str, Any] = {
+        "max_linear_speed": float,
+        "max_angular_speed": float,
+        "horizon_steps": int,
+        "rollout_dt": float,
+        "goal_tolerance": float,
+        "waypoint_switch_distance": float,
+        "path_goal_weight": float,
+        "terminal_goal_weight": float,
+        "control_effort_weight": float,
+        "smoothness_weight": float,
+        "heading_weight": float,
+        "pedestrian_safety_margin": float,
+        "static_obstacle_soft_weight": float,
+        "solver_ftol": float,
+        "solver_max_iterations": int,
+        "warm_start": _parse_bool,
+        "fallback_to_stop": _parse_bool,
+        "predictor_backend": str,
+        "allow_predictor_fallback": _parse_bool,
+        "pedestrian_uncertainty_envelope_enabled": _parse_bool,
+        "pedestrian_uncertainty_alpha_mps": float,
+        "chance_constraint_formulation": str,
+        "max_collision_risk": float,
+        "radial_quadrature_order": int,
+        "angular_quadrature_order": int,
+    }
+    kwargs: dict[str, Any] = {}
+    for field in fields(ChanceConstrainedMPCConfig):
+        value = raw.get(field.name, getattr(defaults, field.name))
+        try:
+            kwargs[field.name] = converters[field.name](value)
+        except (TypeError, ValueError):
+            default_value = getattr(defaults, field.name)
+            warnings.warn(
+                (
+                    f"Invalid chance_constrained_mpc config value '{field.name}': {value!r}; "
+                    f"falling back to default {default_value!r}."
+                ),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            kwargs[field.name] = default_value
+    return ChanceConstrainedMPCConfig(**kwargs)
+
+
+def build_chance_constrained_mpc_adapter(
+    algo_config: dict[str, Any] | None,
+) -> ChanceConstrainedMPCPlannerAdapter:
+    """Fail closed until a #2844 provider is passed through an explicit integration path."""
+
+    config = build_chance_constrained_mpc_config(algo_config)
+    raise ValueError(
+        "chance_constrained_mpc is unavailable: its #2844 K-mode/GMM predictor provider is not "
+        f"configured (requested backend {config.predictor_backend!r})"
+    )
+
+
+__all__ = [
+    "ChanceConstrainedMPCConfig",
+    "ChanceConstrainedMPCPlannerAdapter",
+    "GaussianMixturePedestrianForecast",
+    "GaussianMixturePedestrianPredictor",
+    "build_chance_constrained_mpc_adapter",
+    "build_chance_constrained_mpc_config",
+]

--- a/robot_sf/planner/chance_constrained_mpc.py
+++ b/robot_sf/planner/chance_constrained_mpc.py
@@ -69,8 +69,8 @@ class GaussianMixturePedestrianForecast:
             raise ValueError("covariances_world must be positive definite")
         if not np.isfinite(self.dt) or float(self.dt) <= 0.0:
             raise ValueError("dt must be finite and positive")
-        if not str(self.source).strip():
-            raise ValueError("source must be non-empty")
+        if not isinstance(self.source, str) or not self.source.strip():
+            raise ValueError("source must be a non-empty string")
         object.__setattr__(self, "means_world", means)
         object.__setattr__(self, "covariances_world", covariances)
         object.__setattr__(self, "mode_weights", weights)

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -676,6 +676,28 @@ def test_prediction_mpc_metadata_exposes_constraint_mpc_contract() -> None:
     ]
 
 
+def test_chance_constrained_mpc_metadata_names_gmm_and_fail_closed_boundary() -> None:
+    """The experimental arm must retain its GMM input and adapter contract in reports."""
+    meta = enrich_algorithm_metadata(
+        algo="chance_constrained_mpc",
+        metadata={"status": "blocked"},
+        execution_mode="adapter",
+        robot_kinematics="differential_drive",
+    )
+
+    planner = meta["planner_kinematics"]
+    assert meta["baseline_category"] == "classical"
+    assert meta["policy_semantics"] == "gmm_chance_constrained_model_predictive_local_planner"
+    assert planner["adapter_name"] == "ChanceConstrainedMPCPlannerAdapter"
+    assert planner["projection_policy"] == "gmm_marginal_or_boole_joint_collision_risk_constraints"
+    assert meta["observation_spec"]["inputs"] == [
+        "robot_state",
+        "goal",
+        "pedestrians",
+        "k_mode_gmm_pedestrian_futures",
+    ]
+
+
 def test_prediction_mpc_cbf_alias_reuses_supported_mpc_command_contract() -> None:
     """Trace rosters may name the CBF arm without losing MPC command metadata."""
     meta = enrich_algorithm_metadata(

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -304,6 +304,12 @@ def test_build_policy_prediction_mpc_alias_registers_same_adapter() -> None:
     assert meta["algorithm"] == "prediction_mpc"
 
 
+def test_build_policy_chance_constrained_mpc_fails_closed_without_gmm_provider() -> None:
+    """The experimental GMM MPC key must not substitute a deterministic predictor."""
+    with pytest.raises(ValueError, match="unavailable"):
+        _build_policy("chance_constrained_mpc", {"predictor_backend": "issue_2844_k_mode_gmm"})
+
+
 def test_build_policy_learned_prediction_mpc_registers_diagnostic_adapter() -> None:
     """Learned prediction MPC aliases use prediction-MPC adapter diagnostics."""
 

--- a/tests/planner/test_chance_constrained_mpc.py
+++ b/tests/planner/test_chance_constrained_mpc.py
@@ -1,0 +1,229 @@
+"""Contract tests for issue #5307's GMM chance-constrained MPC planner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import yaml
+
+from robot_sf.planner.chance_constrained_mpc import (
+    ChanceConstrainedMPCConfig,
+    ChanceConstrainedMPCPlannerAdapter,
+    GaussianMixturePedestrianForecast,
+    build_chance_constrained_mpc_adapter,
+    build_chance_constrained_mpc_config,
+)
+
+
+class _FixedGmmPredictor:
+    """Small injected provider used to exercise the public predictor boundary."""
+
+    def __init__(self, forecast: GaussianMixturePedestrianForecast) -> None:
+        self.forecast = forecast
+        self.calls: list[tuple[int, float]] = []
+
+    def predict(
+        self,
+        observation: dict,
+        *,
+        horizon_steps: int,
+        dt: float,
+    ) -> GaussianMixturePedestrianForecast:
+        """Return the fixed contract-valid forecast and record the request."""
+
+        del observation
+        self.calls.append((horizon_steps, dt))
+        return self.forecast
+
+
+def _forecast(
+    *, horizon_steps: int = 2, collision_weight: float = 0.2
+) -> GaussianMixturePedestrianForecast:
+    """Build one pedestrian with one colliding and one safe Gaussian mode."""
+
+    means = np.zeros((1, 2, horizon_steps, 2), dtype=float)
+    means[:, 1, :, 0] = 4.0
+    covariances = np.tile(np.eye(2, dtype=float) * 0.05, (1, 2, horizon_steps, 1, 1))
+    return GaussianMixturePedestrianForecast(
+        means_world=means,
+        covariances_world=covariances,
+        mode_weights=np.asarray([[collision_weight, 1.0 - collision_weight]], dtype=float),
+        dt=0.25,
+        source="test_gmm",
+    )
+
+
+def _context() -> SimpleNamespace:
+    """Build the minimum NMPC rollout context for direct constraint tests."""
+
+    return SimpleNamespace(
+        robot_pos=np.asarray([0.0, 0.0]),
+        heading=0.0,
+        current_speed=0.0,
+        goal=np.asarray([3.0, 0.0]),
+        ped_positions=np.zeros((0, 2)),
+        ped_velocities=np.zeros((0, 2)),
+        robot_radius=0.25,
+        ped_radius=0.25,
+        observation={},
+        speed_cap=0.9,
+    )
+
+
+def _observation() -> dict:
+    """Build the compact SocNav observation required by one real planner call."""
+
+    return {
+        "robot": {
+            "position": np.asarray([0.0, 0.0]),
+            "heading": np.asarray([0.0]),
+            "speed": np.asarray([0.0]),
+            "radius": np.asarray([0.25]),
+        },
+        "goal": {"current": np.asarray([3.0, 0.0]), "next": np.asarray([3.0, 0.0])},
+        "pedestrians": {
+            "positions": np.asarray([[0.0, 0.0]]),
+            "velocities": np.asarray([[0.0, 0.0]]),
+            "count": np.asarray([1.0]),
+            "radius": np.asarray([0.25]),
+        },
+    }
+
+
+def test_forecast_rejects_non_normalized_mode_weights() -> None:
+    """A malformed mixture cannot silently change the requested risk level."""
+
+    with pytest.raises(ValueError, match="sum to one"):
+        GaussianMixturePedestrianForecast(
+            means_world=np.zeros((1, 1, 1, 2)),
+            covariances_world=np.tile(np.eye(2), (1, 1, 1, 1, 1)),
+            mode_weights=np.asarray([[0.5]]),
+            dt=0.25,
+            source="invalid",
+        )
+
+
+def test_marginal_constraint_rejects_collision_probability_above_alpha() -> None:
+    """Per-timestep GMM collision risk must stay below the configured alpha."""
+
+    forecast = _forecast(collision_weight=0.2)
+    planner = ChanceConstrainedMPCPlannerAdapter(
+        ChanceConstrainedMPCConfig(
+            horizon_steps=2,
+            max_collision_risk=0.1,
+            radial_quadrature_order=10,
+            angular_quadrature_order=24,
+        ),
+        predictor=_FixedGmmPredictor(forecast),
+    )
+
+    slack = planner._chance_constraint_values(np.zeros(4), context=_context(), forecast=forecast)
+
+    assert slack.shape == (2,)
+    assert np.all(slack < 0.0)
+
+
+def test_joint_horizon_constraint_uses_conservative_union_bound() -> None:
+    """Joint mode rejects two individually acceptable risks whose union bound exceeds alpha."""
+
+    forecast = _forecast(collision_weight=0.1)
+    planner = ChanceConstrainedMPCPlannerAdapter(
+        ChanceConstrainedMPCConfig(
+            horizon_steps=2,
+            chance_constraint_formulation="joint_horizon",
+            max_collision_risk=0.15,
+            radial_quadrature_order=10,
+            angular_quadrature_order=24,
+        ),
+        predictor=_FixedGmmPredictor(forecast),
+    )
+
+    risks = planner._marginal_collision_risks(np.zeros(4), context=_context(), forecast=forecast)
+    slack = planner._chance_constraint_values(np.zeros(4), context=_context(), forecast=forecast)
+
+    assert np.all(risks < 0.15)
+    assert slack[0] < 0.0
+
+
+def test_optimizer_uses_injected_predictor_and_records_claim_boundary() -> None:
+    """The planner queries the injected GMM provider and exposes non-claim diagnostics."""
+
+    forecast = _forecast()
+    predictor = _FixedGmmPredictor(forecast)
+    planner = ChanceConstrainedMPCPlannerAdapter(
+        ChanceConstrainedMPCConfig(horizon_steps=2), predictor=predictor
+    )
+
+    constraints = planner._optimizer_constraints(_context())
+    diagnostics = planner.diagnostics()["chance_constraint"]
+
+    assert len(constraints) == 1
+    assert predictor.calls == [(2, 0.25)]
+    assert diagnostics["forecast_source"] == "test_gmm"
+    assert diagnostics["forecast_modes"] == 2
+    assert "implementation-only" in diagnostics["claim_boundary"]
+
+
+def test_planner_executes_a_real_constrained_control_step() -> None:
+    """The experimental adapter runs through the repository NMPC path with a GMM input."""
+
+    forecast = _forecast(collision_weight=0.1)
+    predictor = _FixedGmmPredictor(forecast)
+    planner = ChanceConstrainedMPCPlannerAdapter(
+        ChanceConstrainedMPCConfig(
+            horizon_steps=2,
+            max_collision_risk=0.2,
+            solver_max_iterations=20,
+            radial_quadrature_order=6,
+            angular_quadrature_order=16,
+        ),
+        predictor=predictor,
+    )
+
+    command = planner.plan(_observation())
+
+    assert np.all(np.isfinite(command))
+    assert 0.0 <= command[0] <= 0.9
+    assert abs(command[1]) <= 1.1
+    assert predictor.calls == [(2, 0.25)]
+
+
+def test_adapter_and_registered_builder_fail_closed_without_predictor() -> None:
+    """No unavailable learned predictor may degrade to a deterministic forecast."""
+
+    with pytest.raises(ValueError, match="requires an injected"):
+        ChanceConstrainedMPCPlannerAdapter()
+    with pytest.raises(ValueError, match="unavailable"):
+        build_chance_constrained_mpc_adapter({"predictor_backend": "issue_2844_k_mode_gmm"})
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"allow_predictor_fallback": True}, "never permits predictor fallback"),
+        ({"pedestrian_uncertainty_envelope_enabled": True}, "does not compose"),
+    ],
+)
+def test_config_rejects_incompatible_matched_arm_shortcuts(
+    overrides: dict[str, bool], message: str
+) -> None:
+    """Chance constraints must not silently reuse a baseline or envelope arm."""
+
+    with pytest.raises(ValueError, match=message):
+        ChanceConstrainedMPCConfig(**overrides)
+
+
+def test_config_parser_and_example_preserve_the_gmm_arm_boundary() -> None:
+    """The shipped YAML records the provider dependency without enabling fallback."""
+
+    config_path = Path(__file__).resolve().parents[2] / "configs" / "algos"
+    config_path /= "chance_constrained_mpc_gmm.yaml"
+    config = build_chance_constrained_mpc_config(yaml.safe_load(config_path.read_text()))
+
+    assert config.predictor_backend == "issue_2844_k_mode_gmm"
+    assert config.allow_predictor_fallback is False
+    assert config.chance_constraint_formulation == "marginal"
+    assert config.max_collision_risk == pytest.approx(0.05)

--- a/tests/planner/test_chance_constrained_mpc.py
+++ b/tests/planner/test_chance_constrained_mpc.py
@@ -106,6 +106,20 @@ def test_forecast_rejects_non_normalized_mode_weights() -> None:
         )
 
 
+@pytest.mark.parametrize("source", [None, "", "   "])
+def test_forecast_rejects_missing_or_non_string_source(source: object) -> None:
+    """A required provenance source must not stringify a missing value as valid."""
+
+    with pytest.raises(ValueError, match="source must be a non-empty string"):
+        GaussianMixturePedestrianForecast(
+            means_world=np.zeros((1, 1, 1, 2)),
+            covariances_world=np.tile(np.eye(2), (1, 1, 1, 1, 1)),
+            mode_weights=np.asarray([[1.0]]),
+            dt=0.25,
+            source=source,  # type: ignore[arg-type]
+        )
+
+
 def test_marginal_constraint_rejects_collision_probability_above_alpha() -> None:
     """Per-timestep GMM collision risk must stay below the configured alpha."""
 


### PR DESCRIPTION
## Reviewer-critical summary

**What changed.** Adds the experimental `chance_constrained_mpc` planner key with a typed K-mode/Gaussian-mixture forecast boundary, marginal and conservative joint-horizon (Boole-union-bound) collision-risk constraints, and explicit runtime diagnostics.

**Why now.** #5307’s matched constant-velocity and deterministic-envelope arms already exist; this adds the distinct Arms 3–4 control-law capability without modifying either arm.

**Claim boundary.** Implementation integrity only. The polar quadrature estimates GMM collision probability, but this PR makes no calibration, safety, progress, or planner-superiority claim.

**Required validation.** Review the no-fallback error path and the GMM schema/risk tests. Local full readiness and focused planner/metadata/map-runner tests passed.

**Remaining blocker.** The learned K-mode/GMM provider is still not implemented by #2844, so normal benchmark construction fails closed rather than substituting a constant-velocity predictor. No full benchmark campaign was run.

## Contract delta

- New schema: `GaussianMixturePedestrianForecast` requires finite world-frame means `(P,K,T,2)`, positive-definite covariances `(P,K,T,2,2)`, normalized per-pedestrian mode weights `(P,K)`, matching rollout `dt`, and a non-empty source.
- New behavior: `chance_constrained_mpc` supports `marginal` per-person/per-timestep risk constraints and `joint_horizon` Boole-union-bound risk constraints.
- New fail-closed blockers: missing provider, malformed mixture, mismatched horizon or timestep, deterministic-envelope composition, and any predictor fallback are rejected.
- Compatibility: existing `prediction_mpc` CV and uncertainty-envelope behavior is unchanged; the new benchmark key is unavailable until #2844 wires its provider.

## Linked issue

Refs #5307 — https://github.com/ll7/robot_sf_ll7/issues/5307

Remaining work:

- [ ] Wire #2844’s learned K-mode/GMM predictor to `GaussianMixturePedestrianPredictor` after its artifact/provenance gate is satisfied.
- [ ] Run the pre-registered matched-arm CPU/ops campaign for realized-risk calibration, infeasibility, freezing, completion, clearance, and control-period timing.
- [ ] Interpret outcomes only after excluding unavailable/fallback/degraded rows.

## Validation / proof

- `uv run pytest -q tests/planner/test_chance_constrained_mpc.py tests/planner/test_prediction_mpc.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_algorithm_metadata_contract.py` — 209 passed.
- `uv run ruff format --check ...` and `uv run ruff check ...` on every changed Python file — passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed (interim changed-file scope; full core readiness lane completed).
- Injected-GMM CPU test executes the real NMPC control path; tests also prove marginal rejection, conservative joint-horizon rejection, metadata contract, and no deterministic fallback.

## Scope and propagation

- Explicitly out of scope: full benchmark campaign run, Slurm/GPU submission, and paper/dissertation claim edits.
- The issue has no other open or recently merged matching PR. State propagation is not updated on the issue because this lane lacks issue-comment authorization; this PR is the single durable handoff and names the remaining #2844 dependency.
- No generated `output/` artifacts were produced or retained.

<details>
<summary>Review appendix</summary>

### Research result guidance

- Target blocker: add the chance-constraint control-law contract without treating a missing predictor as success.
- Comparator: existing CV point-forecast and deterministic-envelope arms remain untouched.
- Evidence tier: targeted CPU implementation smoke.
- Result classification: diagnostic-only implementation proof.
- Next empirical action: wire #2844, then run the issue’s matched-arm campaign with unavailable/fallback/degraded rows excluded.

## Domain-Aware Approval

- Required for this PR: yes - the diagnostic-only evidence tier requires an explicit claim-boundary review.
- Domains reviewed: experimental comparison and benchmark interpretation.
- Status: waived.
- Approver/review source or waiver: author self-review against #5307’s frozen claim boundary; no campaign, metric, evidence-classification, figure, or paper-facing surface changes.
- Validity checklist:
  - Target claim/hypothesis: implementation of a fail-closed chance-constraint interface only.
  - Comparator or split/evidence validity: existing CV and envelope arms are unchanged; no comparison is interpreted.
  - Fallback/degraded exclusions: no fallback provider is allowed; unavailable construction raises.
  - Claim boundary: diagnostic-only implementation proof, not calibration or planner-value evidence.
  - Implementation integrity vs experimental validity: focused tests prove only the former.

### Risks / provenance

- The joint-horizon form is a conservative union bound and does not model temporal correlation.
- Polar quadrature precision and control-period timing need the deferred campaign’s measurement before tuning or scientific interpretation.
- Assumption: #2844 can expose per-pedestrian K-mode world-frame means, positive-definite covariances, and normalized weights through the added provider protocol.
- Downstream propagation: claim map, benchmark report, leaderboard, registry, and context index are not applicable yet because no evidence artifact or trained predictor changed.
- Friction: no issue filed; `gh issue view 5307 --comments` returned empty under project-card GraphQL deprecation, and existing issue #5269 already tracks the actionable CLI problem.

</details>
