### PR TITLE
fix(ci): unbreak main — package-import test agnostic to input-check order

### DIFF
--- a/tests/scripts/test_benchmark_package_import.py
+++ b/tests/scripts/test_benchmark_package_import.py
@@ -6,9 +6,28 @@ from scripts.benchmark import build_heterogeneous_population_ablation_report as 
 
 
 def test_report_module_imports_and_main_is_callable(tmp_path, monkeypatch, capsys) -> None:
-    """Focused tests can import and invoke benchmark report modules directly."""
+    """Focused tests can import and invoke benchmark report modules directly.
+
+    This is an import/callability contract, not an input-validation contract:
+    ``main`` must return 1 and name the missing input it rejected. Both the
+    manifest and the records paths are supplied as nonexistent tmp paths so the
+    test does not depend on WHICH required-input check runs first — #5288 and
+    #5291 merged three seconds apart and broke main because the original
+    version pinned the records-check-first ordering.
+    """
+    missing_manifest = tmp_path / "missing-manifest.json"
     missing_records = tmp_path / "missing-records.jsonl"
-    monkeypatch.setattr("sys.argv", ["report", "--records", str(missing_records)])
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "report",
+            "--manifest",
+            str(missing_manifest),
+            "--records",
+            str(missing_records),
+        ],
+    )
 
     assert report.main() == 1
-    assert str(missing_records) in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert str(missing_manifest) in out or str(missing_records) in out


### PR DESCRIPTION
Second of the two stacked main-CI breakages today (first was the optional-import inventory, fixed by #5294).

**Root cause:** a 3-second merge race. #5291 added `test_report_module_imports_and_main_is_callable` asserting the missing-**records** error; #5288 merged 3s later and put a fail-closed **manifest** check ahead of it in `build_heterogeneous_population_ablation_report.main`. Each PR was green on its own merge-ref; together they broke `fast-feedback (1)` on main from 06:48Z.

**Fix (test-only):** the test's contract is import+callability with a named missing input — it now passes BOTH inputs as nonexistent tmp paths and accepts whichever required-input check fires first, so future reordering of input validation cannot re-break it.

Verified: `uv run pytest tests/scripts/test_benchmark_package_import.py` → 1 passed.

Main-red emergency merge; unblocks the 16 drafted PRs waiting on CI-settle gates.