### PR TITLE
fix(ci): unbreak main (3/3) — bless the campaign-preflight import probe

### DIFF
--- a/tests/fixtures/optional_import_guards.json
+++ b/tests/fixtures/optional_import_guards.json
@@ -6,7 +6,7 @@
     "ModuleNotFoundError"
   ],
   "spelling_key": "Caught exception type names, sorted and joined by '+'. The 'as <alias>' name is intentionally NOT part of the key.",
-  "total_guards": 101,
+  "total_guards": 102,
   "spellings": {
     "AttributeError+ImportError": {
       "count_ceiling": 2,
@@ -169,12 +169,13 @@
       ]
     },
     "ImportError+OSError": {
-      "count_ceiling": 4,
+      "count_ceiling": 5,
       "has_as_count": 1,
       "pragma_no_cover_count": 2,
       "blessed": true,
-      "note": "Blessed broad catch: native-lib / filesystem load may raise OSError.",
+      "note": "Blessed broad catch: native-lib / filesystem load may raise OSError. campaign_runtime_preflight.py is a deliberate import PROBE (issue #5300): it exists to catch and report arm-dependency import failures with a remediation message, so try_import (which discards the exception) is the wrong tool there.",
       "samples": [
+        "robot_sf/benchmark/campaign_runtime_preflight.py:106",
         "robot_sf/benchmark/cli.py:3198",
         "robot_sf/benchmark/cli.py:3232",
         "robot_sf/benchmark/full_classic/visual_deps.py:45",


### PR DESCRIPTION
Third and (per the ratchet inventory) final stacked main breakage today.

**Root cause:** #5320 merged while main was already red — the failing `fast-feedback` job masked the new ratchet violation it introduced (`ImportError+OSError` 4→5 via `campaign_runtime_preflight.py:106`). Red-main windows let violations stack invisibly; the new maintenance-cycle main-red escalation exists to keep those windows short.

**Why ceiling bump, not try_import:** the flagged site is a deliberate import PROBE (issue #5300's arm-dependency preflight) — it exists to catch and report import failures (incl. native-lib OSError) with an actionable remediation message. `try_import` returns None and discards the exception detail the report needs. Justification recorded in the fixture note.

Verified: `uv run pytest tests/test_optional_import_guard_inventory.py` → 8 passed.

Main-red emergency merge.