### PR TITLE
Issue #5304: signed temporal-logic robustness objective (cheap-lane worker)

### DIFF
--- a/robot_sf/adversarial/objectives.py
+++ b/robot_sf/adversarial/objectives.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from robot_sf.adversarial.io import read_first_jsonl_record
+from robot_sf.adversarial.robustness import temporal_robustness_objective
 
 if TYPE_CHECKING:
     from robot_sf.adversarial.config import CandidateEvaluation
@@ -49,6 +50,7 @@ def worst_case_snqi(evaluation: CandidateEvaluation) -> float | None:
 
 _OBJECTIVES: dict[str, ObjectiveFn] = {
     "worst_case_snqi": worst_case_snqi,
+    "temporal_robustness": temporal_robustness_objective,
 }
 
 

--- a/robot_sf/adversarial/robustness.py
+++ b/robot_sf/adversarial/robustness.py
@@ -203,7 +203,7 @@ def _goal_robustness(
     t_total = horizon * dt
     route_complete = bool(outcome.get("route_complete"))
     time_to_goal_norm = _metric(metrics, "time_to_goal_norm", 1.0)
-    if route_complete and time_to_goal_norm < 1.0:
+    if route_complete:
         t_actual = time_to_goal_norm * t_total
         rho = t_total - t_actual
         critical_time = t_actual
@@ -214,7 +214,7 @@ def _goal_robustness(
         property_name="goal",
         robustness=rho,
         critical_time_s=critical_time,
-        violated=rho <= 0,
+        violated=rho < 0,
         detail=f"route_complete={route_complete}, time_to_goal_norm={time_to_goal_norm:.4f}",
     )
 

--- a/robot_sf/adversarial/robustness.py
+++ b/robot_sf/adversarial/robustness.py
@@ -1,0 +1,328 @@
+"""Signed temporal-logic robustness objectives for adversarial falsification.
+
+Implements per-property signed robustness semantics (negative = violation,
+positive = satisfaction margin) for social-navigation safety properties:
+
+1. **Clearance** (always d_clearance > d_safe): ``rho = min_clearance - NEAR_MISS_DIST``
+2. **TTC** (always TTC > tau while closing): ``rho = min_ttc - tau``
+3. **Goal reaching** (eventually reach goal within T): ``rho = T*(1 - time_to_goal_norm) - T``
+4. **Progress** (avoid sustained low-progress): ``rho = -failure_to_progress``
+5. **Collision** (never collide): ``rho = -collision_count``
+
+Per-property robustness values and critical timestamps are preserved in
+:class:`RobustnessReport` and written to a sidecar JSON file in the candidate
+bundle directory.  The registered objective returns an aggregated scalar for
+search optimisation (maximising finds worst violations).
+
+Literature basis: S-TaLiRo-style robustness semantics (Annpureddy et al.,
+TACAS 2011); AST (Koren et al., IV 2018).
+
+Status: research/exploratory.  These objectives are search objectives, not
+reported benchmark metrics.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.adversarial.io import read_first_jsonl_record
+from robot_sf.benchmark.constants import NEAR_MISS_DIST
+from robot_sf.benchmark.near_miss_ttc import DIAGNOSTIC_TTC_THRESHOLD_S
+
+if TYPE_CHECKING:
+    from robot_sf.adversarial.config import CandidateEvaluation
+
+_ROBUSTNESS_SCHEMA_VERSION = "robustness-report.v1"
+
+
+def _metric(metrics: dict[str, Any], key: str, default: float = 0.0) -> float:
+    """Read a finite metric scalar with a default."""
+    value = metrics.get(key, default)
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if math.isfinite(parsed) else default
+
+
+@dataclass(frozen=True)
+class PropertyRobustness:
+    """Signed robustness for a single temporal-logic property.
+
+    Attributes
+    ----------
+    property_name : str
+        Identifier for the property (e.g. ``"clearance"``).
+    robustness : float
+        Signed robustness value: negative = violation, positive = satisfaction.
+    critical_time_s : float | None
+        Timestamp (seconds into episode) of the critical event, if available.
+    violated : bool
+        ``True`` when robustness < 0.
+    detail : str
+        Human-readable description of the robustness computation.
+    """
+
+    property_name: str
+    robustness: float
+    critical_time_s: float | None = None
+    violated: bool = False
+    detail: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-serialisable payload."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RobustnessReport:
+    """Per-property robustness report with aggregated scalar.
+
+    Attributes
+    ----------
+    schema_version : str
+        Fixed schema identifier.
+    properties : tuple[PropertyRobustness, ...]
+        Per-property robustness values, preserving critical timestamps.
+    overall_robustness : float
+        Minimum robustness across all properties (worst-case).
+    objective_value : float
+        Value returned by the registered search objective (negated for
+        maximisation so the search finds worst violations).
+    """
+
+    schema_version: str = _ROBUSTNESS_SCHEMA_VERSION
+    properties: tuple[PropertyRobustness, ...] = ()
+    overall_robustness: float = 0.0
+    objective_value: float = 0.0
+
+    def to_json(self) -> dict[str, Any]:
+        """Return a JSON-serialisable report payload."""
+        return {
+            "schema_version": self.schema_version,
+            "properties": [p.to_json() for p in self.properties],
+            "overall_robustness": self.overall_robustness,
+            "objective_value": self.objective_value,
+        }
+
+    @classmethod
+    def from_json(cls, payload: dict[str, Any]) -> RobustnessReport:
+        """Reconstruct a report from a JSON payload."""
+        properties = tuple(PropertyRobustness(**entry) for entry in payload.get("properties", []))
+        return cls(
+            schema_version=payload.get("schema_version", _ROBUSTNESS_SCHEMA_VERSION),
+            properties=properties,
+            overall_robustness=float(payload.get("overall_robustness", 0.0)),
+            objective_value=float(payload.get("objective_value", 0.0)),
+        )
+
+
+def _clearance_robustness(
+    metrics: dict[str, Any],
+    event_ledger: dict[str, Any],
+) -> PropertyRobustness:
+    """Always maintain clearance: rho = min_clearance - NEAR_MISS_DIST."""
+    min_clearance = _metric(metrics, "min_clearance", NEAR_MISS_DIST)
+    rho = min_clearance - NEAR_MISS_DIST
+    critical_time = _first_collision_time(event_ledger) if rho < 0 else None
+    return PropertyRobustness(
+        property_name="clearance",
+        robustness=rho,
+        critical_time_s=critical_time,
+        violated=rho < 0,
+        detail=f"min_clearance={min_clearance:.4f}m, d_safe={NEAR_MISS_DIST:.4f}m",
+    )
+
+
+def _ttc_robustness(
+    metrics: dict[str, Any],
+    tau: float,
+    event_ledger: dict[str, Any],
+) -> PropertyRobustness:
+    """Always maintain TTC > tau while closing: rho = min_ttc - tau."""
+    min_ttc = _metric(metrics, "time_to_collision_min", tau + 1.0)
+    rho = min_ttc - tau
+    critical_time = _first_collision_time(event_ledger) if rho < 0 else None
+    return PropertyRobustness(
+        property_name="ttc",
+        robustness=rho,
+        critical_time_s=critical_time,
+        violated=rho < 0,
+        detail=f"min_ttc={min_ttc:.4f}s, tau={tau:.4f}s",
+    )
+
+
+def _goal_robustness(
+    metrics: dict[str, Any],
+    outcome: dict[str, Any],
+    horizon: int,
+    dt: float,
+) -> PropertyRobustness:
+    """Eventually reach goal within T: rho = T - T_actual.
+
+    When the goal is reached at time T_actual < T, rho > 0 (satisfaction).
+    When the goal is not reached, T_actual = T (the full horizon), so rho = 0
+    (boundary violation -- counts as violation).
+    """
+    t_total = horizon * dt
+    route_complete = bool(outcome.get("route_complete"))
+    time_to_goal_norm = _metric(metrics, "time_to_goal_norm", 1.0)
+    if route_complete and time_to_goal_norm < 1.0:
+        t_actual = time_to_goal_norm * t_total
+        rho = t_total - t_actual
+        critical_time = t_actual
+    else:
+        rho = 0.0
+        critical_time = t_total
+    return PropertyRobustness(
+        property_name="goal",
+        robustness=rho,
+        critical_time_s=critical_time,
+        violated=rho <= 0,
+        detail=f"route_complete={route_complete}, time_to_goal_norm={time_to_goal_norm:.4f}",
+    )
+
+
+def _progress_robustness(
+    metrics: dict[str, Any],
+) -> PropertyRobustness:
+    """Avoid sustained low-progress intervals: rho = -failure_to_progress."""
+    ftp = _metric(metrics, "failure_to_progress", 0.0)
+    rho = -ftp
+    return PropertyRobustness(
+        property_name="progress",
+        robustness=rho,
+        critical_time_s=None,
+        violated=rho < 0,
+        detail=f"failure_to_progress={ftp:.0f}",
+    )
+
+
+def _collision_robustness(
+    metrics: dict[str, Any],
+    outcome: dict[str, Any],
+    event_ledger: dict[str, Any],
+) -> PropertyRobustness:
+    """Never collide: rho = -collision_count."""
+    collision_count = _metric(metrics, "total_collision_count", 0.0)
+    if collision_count == 0.0:
+        collision_flag = bool(outcome.get("collision") or outcome.get("collision_event"))
+        collision_count = 1.0 if collision_flag else 0.0
+    rho = -collision_count
+    critical_time = _first_collision_time(event_ledger)
+    return PropertyRobustness(
+        property_name="collision",
+        robustness=rho,
+        critical_time_s=critical_time,
+        violated=rho < 0,
+        detail=f"collision_count={collision_count:.0f}",
+    )
+
+
+def _first_collision_time(event_ledger: dict[str, Any]) -> float | None:
+    """Extract the timestamp of the first collision event, if available."""
+    collision_events = event_ledger.get("collision_events")
+    if not isinstance(collision_events, list) or not collision_events:
+        return None
+    first = collision_events[0]
+    if isinstance(first, dict):
+        t = first.get("collision_time")
+        if t is not None:
+            try:
+                return float(t)
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def compute_robustness_report(
+    record: dict[str, Any],
+    *,
+    tau: float = DIAGNOSTIC_TTC_THRESHOLD_S,
+    dt: float | None = None,
+) -> RobustnessReport:
+    """Compute signed robustness for all properties from an episode record.
+
+    Parameters
+    ----------
+    record : dict
+        Episode JSONL record (first record from the file).
+    tau : float
+        TTC safety threshold in seconds.  Defaults to the diagnostic placeholder.
+    dt : float | None
+        Timestep in seconds.  If ``None``, derived from ``horizon`` and
+        ``timestamps`` or defaults to 0.1.
+
+    Returns
+    -------
+    RobustnessReport
+        Per-property robustness values with critical timestamps and aggregated
+        scalar.
+    """
+    metrics = record.get("metrics") if isinstance(record.get("metrics"), dict) else {}
+    outcome = record.get("outcome") if isinstance(record.get("outcome"), dict) else {}
+    event_ledger = (
+        record.get("event_ledger") if isinstance(record.get("event_ledger"), dict) else {}
+    )
+    horizon = int(record.get("horizon", 200))
+
+    if dt is None:
+        wall_time = record.get("wall_time_sec")
+        steps = record.get("steps")
+        if wall_time and steps and steps > 0:
+            dt = float(wall_time) / float(steps)
+        else:
+            dt = 0.1
+
+    properties = (
+        _clearance_robustness(metrics, event_ledger),
+        _ttc_robustness(metrics, tau, event_ledger),
+        _goal_robustness(metrics, outcome, horizon, dt),
+        _progress_robustness(metrics),
+        _collision_robustness(metrics, outcome, event_ledger),
+    )
+
+    robustness_values = [p.robustness for p in properties]
+    overall = min(robustness_values) if robustness_values else 0.0
+    objective = -overall
+
+    return RobustnessReport(
+        properties=properties,
+        overall_robustness=overall,
+        objective_value=objective,
+    )
+
+
+def write_robustness_report(report: RobustnessReport, path: Path) -> Path:
+    """Write a robustness report to a JSON sidecar file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report.to_json(), indent=2), encoding="utf-8")
+    return path
+
+
+def temporal_robustness_objective(evaluation: CandidateEvaluation) -> float | None:
+    """Signed temporal-logic robustness objective for adversarial search.
+
+    Computes per-property signed robustness, writes the full report to a
+    sidecar ``robustness_report.json`` in the candidate bundle directory,
+    and returns the aggregated scalar for search optimisation.
+
+    The search maximises the returned value; more negative robustness
+    (larger violations) produces a larger returned value.
+    """
+    if evaluation.episode_record_path is None:
+        return None
+    record = read_first_jsonl_record(evaluation.episode_record_path)
+    if record is None:
+        return None
+
+    report = compute_robustness_report(record)
+
+    if evaluation.bundle_path is not None:
+        write_robustness_report(report, evaluation.bundle_path / "robustness_report.json")
+
+    return report.objective_value

--- a/robot_sf/adversarial/robustness.py
+++ b/robot_sf/adversarial/robustness.py
@@ -5,7 +5,7 @@ positive = satisfaction margin) for social-navigation safety properties:
 
 1. **Clearance** (always d_clearance > d_safe): ``rho = min_clearance - NEAR_MISS_DIST``
 2. **TTC** (always TTC > tau while closing): ``rho = min_ttc - tau``
-3. **Goal reaching** (eventually reach goal within T): ``rho = T*(1 - time_to_goal_norm) - T``
+3. **Goal reaching** (eventually reach goal within T): ``rho = T - T_actual``
 4. **Progress** (avoid sustained low-progress): ``rho = -failure_to_progress``
 5. **Collision** (never collide): ``rho = -collision_count``
 
@@ -47,6 +47,37 @@ def _metric(metrics: dict[str, Any], key: str, default: float = 0.0) -> float:
     except (TypeError, ValueError):
         return default
     return parsed if math.isfinite(parsed) else default
+
+
+def _positive_int(value: Any, default: int) -> int:
+    """Read a positive integer, falling back for malformed record metadata."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _derived_dt(record: dict[str, Any]) -> float:
+    """Derive a finite positive timestep from optional episode metadata."""
+    try:
+        wall_time = float(record.get("wall_time_sec"))
+        steps = float(record.get("steps"))
+    except (TypeError, ValueError):
+        return 0.1
+    dt = wall_time / steps if wall_time > 0.0 and steps > 0.0 else 0.1
+    return dt if math.isfinite(dt) and dt > 0.0 else 0.1
+
+
+def _validated_positive_float(value: float, *, name: str) -> float:
+    """Validate an explicit semantic parameter rather than masking a bad configuration."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite positive float") from exc
+    if not math.isfinite(parsed) or parsed <= 0.0:
+        raise ValueError(f"{name} must be a finite positive float")
+    return parsed
 
 
 @dataclass(frozen=True)
@@ -165,8 +196,9 @@ def _goal_robustness(
     """Eventually reach goal within T: rho = T - T_actual.
 
     When the goal is reached at time T_actual < T, rho > 0 (satisfaction).
-    When the goal is not reached, T_actual = T (the full horizon), so rho = 0
-    (boundary violation -- counts as violation).
+    When the goal is not reached, model it as one unresolved timestep beyond
+    the horizon. This keeps the signed contract intact: non-completion is a
+    negative violation rather than a zero-valued tie with a boundary success.
     """
     t_total = horizon * dt
     route_complete = bool(outcome.get("route_complete"))
@@ -176,7 +208,7 @@ def _goal_robustness(
         rho = t_total - t_actual
         critical_time = t_actual
     else:
-        rho = 0.0
+        rho = -dt
         critical_time = t_total
     return PropertyRobustness(
         property_name="goal",
@@ -213,7 +245,7 @@ def _collision_robustness(
         collision_flag = bool(outcome.get("collision") or outcome.get("collision_event"))
         collision_count = 1.0 if collision_flag else 0.0
     rho = -collision_count
-    critical_time = _first_collision_time(event_ledger)
+    critical_time = _first_collision_time(event_ledger) if rho < 0 else None
     return PropertyRobustness(
         property_name="collision",
         robustness=rho,
@@ -226,16 +258,17 @@ def _collision_robustness(
 def _first_collision_time(event_ledger: dict[str, Any]) -> float | None:
     """Extract the timestamp of the first collision event, if available."""
     collision_events = event_ledger.get("collision_events")
-    if not isinstance(collision_events, list) or not collision_events:
+    if not isinstance(collision_events, list):
         return None
-    first = collision_events[0]
-    if isinstance(first, dict):
-        t = first.get("collision_time")
-        if t is not None:
-            try:
-                return float(t)
-            except (TypeError, ValueError):
-                return None
+    for event in collision_events:
+        if not isinstance(event, dict):
+            continue
+        try:
+            timestamp = float(event.get("collision_time"))
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(timestamp):
+            return timestamp
     return None
 
 
@@ -268,15 +301,13 @@ def compute_robustness_report(
     event_ledger = (
         record.get("event_ledger") if isinstance(record.get("event_ledger"), dict) else {}
     )
-    horizon = int(record.get("horizon", 200))
+    horizon = _positive_int(record.get("horizon"), 200)
 
     if dt is None:
-        wall_time = record.get("wall_time_sec")
-        steps = record.get("steps")
-        if wall_time and steps and steps > 0:
-            dt = float(wall_time) / float(steps)
-        else:
-            dt = 0.1
+        dt = _derived_dt(record)
+    else:
+        dt = _validated_positive_float(dt, name="dt")
+    tau = _validated_positive_float(tau, name="tau")
 
     properties = (
         _clearance_robustness(metrics, event_ledger),

--- a/tests/test_adversarial_robustness.py
+++ b/tests/test_adversarial_robustness.py
@@ -155,6 +155,17 @@ class TestGoalRobustness:
         assert goal.robustness == pytest.approx(-0.1)
         assert goal.violated
 
+    def test_completed_at_deadline_is_zero_margin_satisfaction(self) -> None:
+        record = _make_episode_record(
+            time_to_goal_norm=1.0,
+            route_complete=True,
+            horizon=200,
+        )
+        report = compute_robustness_report(record, dt=0.1)
+        goal = next(p for p in report.properties if p.property_name == "goal")
+        assert goal.robustness == pytest.approx(0.0)
+        assert not goal.violated
+
     def test_critical_time_is_actual_goal_time(self) -> None:
         record = _make_episode_record(
             time_to_goal_norm=0.25,

--- a/tests/test_adversarial_robustness.py
+++ b/tests/test_adversarial_robustness.py
@@ -152,7 +152,7 @@ class TestGoalRobustness:
         )
         report = compute_robustness_report(record, dt=0.1)
         goal = next(p for p in report.properties if p.property_name == "goal")
-        assert goal.robustness == pytest.approx(0.0)
+        assert goal.robustness == pytest.approx(-0.1)
         assert goal.violated
 
     def test_critical_time_is_actual_goal_time(self) -> None:
@@ -221,6 +221,16 @@ class TestCollisionRobustness:
         collision = next(p for p in report.properties if p.property_name == "collision")
         assert collision.critical_time_s == pytest.approx(3.7)
 
+    def test_non_violating_collision_has_no_critical_time(self) -> None:
+        record = _make_episode_record(
+            total_collision_count=0.0,
+            collision_event=False,
+            collision_events=[{"collision_time": 3.7}],
+        )
+        report = compute_robustness_report(record)
+        collision = next(p for p in report.properties if p.property_name == "collision")
+        assert collision.critical_time_s is None
+
 
 class TestRobustnessReport:
     """Tests for the aggregated robustness report."""
@@ -272,6 +282,9 @@ class TestRobustnessReport:
             assert orig.property_name == rest.property_name
             assert orig.robustness == pytest.approx(rest.robustness)
             assert orig.violated == rest.violated
+            assert orig.critical_time_s == rest.critical_time_s
+        collision = next(p for p in restored.properties if p.property_name == "collision")
+        assert collision.critical_time_s == pytest.approx(2.0)
 
 
 class TestWriteRobustnessReport:
@@ -450,6 +463,16 @@ class TestFirstCollisionTime:
         ledger = {"collision_events": [{"collision_time": None}]}
         assert _first_collision_time(ledger) is None
 
+    def test_skips_malformed_or_non_finite_events(self) -> None:
+        ledger = {
+            "collision_events": [
+                {"collision_time": "not-a-time"},
+                {"collision_time": float("nan")},
+                {"collision_time": 3.0},
+            ]
+        }
+        assert _first_collision_time(ledger) == pytest.approx(3.0)
+
 
 class TestObjectiveRegistry:
     """Tests for the temporal_robustness objective registration."""
@@ -508,3 +531,27 @@ class TestDtDerivation:
         t_total = 200 * 0.1
         t_actual = 0.3 * t_total
         assert goal.robustness == pytest.approx(t_total - t_actual)
+
+    @pytest.mark.parametrize(
+        ("horizon", "wall_time_sec", "steps"),
+        [(None, 20.0, 200), ("bad", "bad", "bad"), (0, float("nan"), 0)],
+    )
+    def test_malformed_metadata_falls_back_to_safe_defaults(
+        self,
+        horizon: object,
+        wall_time_sec: object,
+        steps: object,
+    ) -> None:
+        record = _make_episode_record()
+        record["horizon"] = horizon
+        record["wall_time_sec"] = wall_time_sec
+        record["steps"] = steps
+        report = compute_robustness_report(record)
+        goal = next(p for p in report.properties if p.property_name == "goal")
+        assert goal.robustness == pytest.approx(14.0)
+
+    @pytest.mark.parametrize("name, value", [("dt", 0.0), ("dt", float("nan")), ("tau", -1.0)])
+    def test_invalid_explicit_semantic_parameters_raise(self, name: str, value: float) -> None:
+        kwargs = {name: value}
+        with pytest.raises(ValueError, match=f"{name} must be a finite positive float"):
+            compute_robustness_report(_make_episode_record(), **kwargs)

--- a/tests/test_adversarial_robustness.py
+++ b/tests/test_adversarial_robustness.py
@@ -1,0 +1,510 @@
+"""Tests for signed temporal-logic robustness objectives."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.adversarial.certification import failed_status
+from robot_sf.adversarial.config import (
+    CandidateEvaluation,
+    CandidateSpec,
+    Pose2D,
+)
+from robot_sf.adversarial.objectives import get_objective, list_objectives
+from robot_sf.adversarial.robustness import (
+    RobustnessReport,
+    _first_collision_time,
+    compute_robustness_report,
+    temporal_robustness_objective,
+    write_robustness_report,
+)
+from robot_sf.benchmark.constants import NEAR_MISS_DIST
+from robot_sf.benchmark.near_miss_ttc import DIAGNOSTIC_TTC_THRESHOLD_S
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_episode_record(  # noqa: PLR0913
+    *,
+    min_clearance: float = 1.0,
+    time_to_collision_min: float = 5.0,
+    time_to_goal_norm: float = 0.3,
+    failure_to_progress: float = 0.0,
+    total_collision_count: float = 0.0,
+    collision_event: bool = False,
+    route_complete: bool = True,
+    horizon: int = 200,
+    collision_events: list[dict] | None = None,
+    wall_time_sec: float | None = None,
+    steps: int | None = None,
+) -> dict:
+    """Build a minimal synthetic episode JSONL record."""
+    record: dict = {
+        "version": "v1",
+        "horizon": horizon,
+        "metrics": {
+            "min_clearance": min_clearance,
+            "time_to_collision_min": time_to_collision_min,
+            "time_to_goal_norm": time_to_goal_norm,
+            "failure_to_progress": failure_to_progress,
+            "total_collision_count": total_collision_count,
+        },
+        "outcome": {
+            "collision_event": collision_event,
+            "route_complete": route_complete,
+        },
+        "event_ledger": {
+            "collision_events": collision_events or [],
+        },
+    }
+    if wall_time_sec is not None:
+        record["wall_time_sec"] = wall_time_sec
+    if steps is not None:
+        record["steps"] = steps
+    return record
+
+
+class TestClearanceRobustness:
+    """Tests for the clearance (always d > d_safe) property."""
+
+    def test_satisfied_when_clearance_above_threshold(self) -> None:
+        record = _make_episode_record(min_clearance=1.0)
+        report = compute_robustness_report(record)
+        clearance = next(p for p in report.properties if p.property_name == "clearance")
+        assert clearance.robustness == pytest.approx(1.0 - NEAR_MISS_DIST)
+        assert not clearance.violated
+
+    def test_violated_when_clearance_below_threshold(self) -> None:
+        record = _make_episode_record(min_clearance=0.1)
+        report = compute_robustness_report(record)
+        clearance = next(p for p in report.properties if p.property_name == "clearance")
+        assert clearance.robustness == pytest.approx(0.1 - NEAR_MISS_DIST)
+        assert clearance.violated
+
+    def test_boundary_when_clearance_equals_threshold(self) -> None:
+        record = _make_episode_record(min_clearance=NEAR_MISS_DIST)
+        report = compute_robustness_report(record)
+        clearance = next(p for p in report.properties if p.property_name == "clearance")
+        assert clearance.robustness == pytest.approx(0.0)
+        assert not clearance.violated
+
+    def test_collision_critical_time_populated(self) -> None:
+        record = _make_episode_record(
+            min_clearance=-0.1,
+            collision_events=[{"collision_time": 1.5}],
+        )
+        report = compute_robustness_report(record)
+        clearance = next(p for p in report.properties if p.property_name == "clearance")
+        assert clearance.critical_time_s == pytest.approx(1.5)
+
+
+class TestTtcRobustness:
+    """Tests for the TTC (always TTC > tau) property."""
+
+    def test_satisfied_when_ttc_above_tau(self) -> None:
+        record = _make_episode_record(time_to_collision_min=5.0)
+        report = compute_robustness_report(record)
+        ttc = next(p for p in report.properties if p.property_name == "ttc")
+        assert ttc.robustness == pytest.approx(5.0 - DIAGNOSTIC_TTC_THRESHOLD_S)
+        assert not ttc.violated
+
+    def test_violated_when_ttc_below_tau(self) -> None:
+        record = _make_episode_record(time_to_collision_min=0.5)
+        report = compute_robustness_report(record)
+        ttc = next(p for p in report.properties if p.property_name == "ttc")
+        assert ttc.robustness == pytest.approx(0.5 - DIAGNOSTIC_TTC_THRESHOLD_S)
+        assert ttc.violated
+
+    def test_custom_tau(self) -> None:
+        record = _make_episode_record(time_to_collision_min=3.0)
+        report = compute_robustness_report(record, tau=1.0)
+        ttc = next(p for p in report.properties if p.property_name == "ttc")
+        assert ttc.robustness == pytest.approx(2.0)
+        assert not ttc.violated
+
+
+class TestGoalRobustness:
+    """Tests for the goal (eventually reach goal within T) property."""
+
+    def test_satisfied_when_reached_early(self) -> None:
+        record = _make_episode_record(
+            time_to_goal_norm=0.5,
+            route_complete=True,
+            horizon=200,
+        )
+        report = compute_robustness_report(record, dt=0.1)
+        goal = next(p for p in report.properties if p.property_name == "goal")
+        t_total = 200 * 0.1
+        t_actual = 0.5 * t_total
+        assert goal.robustness == pytest.approx(t_total - t_actual)
+        assert not goal.violated
+
+    def test_violated_when_not_reached(self) -> None:
+        record = _make_episode_record(
+            time_to_goal_norm=1.0,
+            route_complete=False,
+            horizon=200,
+        )
+        report = compute_robustness_report(record, dt=0.1)
+        goal = next(p for p in report.properties if p.property_name == "goal")
+        assert goal.robustness == pytest.approx(0.0)
+        assert goal.violated
+
+    def test_critical_time_is_actual_goal_time(self) -> None:
+        record = _make_episode_record(
+            time_to_goal_norm=0.25,
+            route_complete=True,
+            horizon=100,
+        )
+        report = compute_robustness_report(record, dt=0.5)
+        goal = next(p for p in report.properties if p.property_name == "goal")
+        t_total = 100 * 0.5
+        assert goal.critical_time_s == pytest.approx(0.25 * t_total)
+
+
+class TestProgressRobustness:
+    """Tests for the progress (avoid sustained low-progress) property."""
+
+    def test_satisfied_when_no_progress_failures(self) -> None:
+        record = _make_episode_record(failure_to_progress=0.0)
+        report = compute_robustness_report(record)
+        progress = next(p for p in report.properties if p.property_name == "progress")
+        assert progress.robustness == pytest.approx(0.0)
+        assert not progress.violated
+
+    def test_violated_when_progress_failures(self) -> None:
+        record = _make_episode_record(failure_to_progress=3.0)
+        report = compute_robustness_report(record)
+        progress = next(p for p in report.properties if p.property_name == "progress")
+        assert progress.robustness == pytest.approx(-3.0)
+        assert progress.violated
+
+
+class TestCollisionRobustness:
+    """Tests for the collision (never collide) property."""
+
+    def test_satisfied_when_no_collisions(self) -> None:
+        record = _make_episode_record(total_collision_count=0.0, collision_event=False)
+        report = compute_robustness_report(record)
+        collision = next(p for p in report.properties if p.property_name == "collision")
+        assert collision.robustness == pytest.approx(0.0)
+        assert not collision.violated
+
+    def test_violated_when_collisions(self) -> None:
+        record = _make_episode_record(total_collision_count=2.0, collision_event=True)
+        report = compute_robustness_report(record)
+        collision = next(p for p in report.properties if p.property_name == "collision")
+        assert collision.robustness == pytest.approx(-2.0)
+        assert collision.violated
+
+    def test_collision_event_flag_used_when_count_missing(self) -> None:
+        record = _make_episode_record(total_collision_count=0.0, collision_event=True)
+        metrics = record["metrics"]
+        del metrics["total_collision_count"]
+        report = compute_robustness_report(record)
+        collision = next(p for p in report.properties if p.property_name == "collision")
+        assert collision.robustness == pytest.approx(-1.0)
+        assert collision.violated
+
+    def test_critical_time_from_event_ledger(self) -> None:
+        record = _make_episode_record(
+            total_collision_count=1.0,
+            collision_event=True,
+            collision_events=[{"collision_time": 3.7}],
+        )
+        report = compute_robustness_report(record)
+        collision = next(p for p in report.properties if p.property_name == "collision")
+        assert collision.critical_time_s == pytest.approx(3.7)
+
+
+class TestRobustnessReport:
+    """Tests for the aggregated robustness report."""
+
+    def test_overall_robustness_is_minimum(self) -> None:
+        record = _make_episode_record(
+            min_clearance=1.0,
+            time_to_collision_min=5.0,
+            time_to_goal_norm=0.3,
+            failure_to_progress=0.0,
+            total_collision_count=0.0,
+        )
+        report = compute_robustness_report(record)
+        min_rho = min(p.robustness for p in report.properties)
+        assert report.overall_robustness == pytest.approx(min_rho)
+
+    def test_objective_is_negated_overall(self) -> None:
+        record = _make_episode_record()
+        report = compute_robustness_report(record)
+        assert report.objective_value == pytest.approx(-report.overall_robustness)
+
+    def test_worst_violation_dominates_objective(self) -> None:
+        """The objective should be driven by the worst property."""
+        record = _make_episode_record(
+            min_clearance=1.0,
+            time_to_collision_min=0.1,
+            time_to_goal_norm=0.3,
+            failure_to_progress=0.0,
+            total_collision_count=0.0,
+        )
+        report = compute_robustness_report(record)
+        ttc_rho = 0.1 - DIAGNOSTIC_TTC_THRESHOLD_S
+        assert report.overall_robustness == pytest.approx(ttc_rho)
+        assert report.objective_value == pytest.approx(-ttc_rho)
+
+    def test_report_serialisation_roundtrip(self) -> None:
+        record = _make_episode_record(
+            min_clearance=0.3,
+            total_collision_count=1.0,
+            collision_event=True,
+            collision_events=[{"collision_time": 2.0}],
+        )
+        report = compute_robustness_report(record)
+        payload = report.to_json()
+        restored = RobustnessReport.from_json(payload)
+        assert restored.schema_version == report.schema_version
+        assert len(restored.properties) == len(report.properties)
+        for orig, rest in zip(report.properties, restored.properties, strict=True):
+            assert orig.property_name == rest.property_name
+            assert orig.robustness == pytest.approx(rest.robustness)
+            assert orig.violated == rest.violated
+
+
+class TestWriteRobustnessReport:
+    """Tests for writing robustness reports to disk."""
+
+    def test_writes_json_file(self, tmp_path: Path) -> None:
+        record = _make_episode_record()
+        report = compute_robustness_report(record)
+        out_path = tmp_path / "robustness_report.json"
+        write_robustness_report(report, out_path)
+        assert out_path.exists()
+        payload = json.loads(out_path.read_text(encoding="utf-8"))
+        assert payload["schema_version"] == "robustness-report.v1"
+        assert len(payload["properties"]) == 5
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        record = _make_episode_record()
+        report = compute_robustness_report(record)
+        out_path = tmp_path / "subdir" / "deep" / "robustness_report.json"
+        write_robustness_report(report, out_path)
+        assert out_path.exists()
+
+
+class TestTemporalRobustnessObjective:
+    """Tests for the registered objective function used by adversarial search."""
+
+    def test_returns_none_when_no_record_path(self) -> None:
+        candidate = CandidateSpec(
+            start=Pose2D(0.0, 0.0),
+            goal=Pose2D(1.0, 1.0),
+            spawn_time_s=0.0,
+            pedestrian_speed_mps=1.0,
+            pedestrian_delay_s=0.0,
+            scenario_seed=1,
+        )
+        evaluation = CandidateEvaluation(
+            candidate=candidate,
+            certification_status=failed_status("test"),
+            objective_value=None,
+            failure_attribution=None,
+            episode_record_path=None,
+            trajectory_csv_path=None,
+            scenario_yaml_path=None,
+        )
+        assert temporal_robustness_objective(evaluation) is None
+
+    def test_returns_none_when_record_missing(self, tmp_path: Path) -> None:
+        candidate = CandidateSpec(
+            start=Pose2D(0.0, 0.0),
+            goal=Pose2D(1.0, 1.0),
+            spawn_time_s=0.0,
+            pedestrian_speed_mps=1.0,
+            pedestrian_delay_s=0.0,
+            scenario_seed=1,
+        )
+        evaluation = CandidateEvaluation(
+            candidate=candidate,
+            certification_status=failed_status("test"),
+            objective_value=None,
+            failure_attribution=None,
+            episode_record_path=tmp_path / "nonexistent.jsonl",
+            trajectory_csv_path=None,
+            scenario_yaml_path=None,
+        )
+        assert temporal_robustness_objective(evaluation) is None
+
+    def test_returns_scalar_and_writes_report(self, tmp_path: Path) -> None:
+        record = _make_episode_record(
+            min_clearance=0.1,
+            total_collision_count=1.0,
+            collision_event=True,
+        )
+        episode_path = tmp_path / "episode_records.jsonl"
+        episode_path.write_text(json.dumps(record), encoding="utf-8")
+        bundle_path = tmp_path / "candidate_0001"
+        bundle_path.mkdir()
+
+        candidate = CandidateSpec(
+            start=Pose2D(0.0, 0.0),
+            goal=Pose2D(1.0, 1.0),
+            spawn_time_s=0.0,
+            pedestrian_speed_mps=1.0,
+            pedestrian_delay_s=0.0,
+            scenario_seed=1,
+        )
+        evaluation = CandidateEvaluation(
+            candidate=candidate,
+            certification_status=failed_status("test"),
+            objective_value=None,
+            failure_attribution=None,
+            episode_record_path=episode_path,
+            trajectory_csv_path=None,
+            scenario_yaml_path=None,
+            bundle_path=bundle_path,
+        )
+        result = temporal_robustness_objective(evaluation)
+        assert result is not None
+        assert isinstance(result, float)
+        assert math.isfinite(result)
+
+        report_path = bundle_path / "robustness_report.json"
+        assert report_path.exists()
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+        assert payload["schema_version"] == "robustness-report.v1"
+        assert len(payload["properties"]) == 5
+
+    def test_objective_maximisation_finds_violations(self, tmp_path: Path) -> None:
+        """Worse scenarios should produce larger objective values."""
+        safe_record = _make_episode_record(
+            min_clearance=2.0,
+            time_to_collision_min=10.0,
+            time_to_goal_norm=0.1,
+            failure_to_progress=0.0,
+            total_collision_count=0.0,
+        )
+        violation_record = _make_episode_record(
+            min_clearance=0.1,
+            time_to_collision_min=0.5,
+            time_to_goal_norm=1.0,
+            failure_to_progress=0.0,
+            total_collision_count=0.0,
+            route_complete=False,
+        )
+
+        safe_path = tmp_path / "safe.jsonl"
+        safe_path.write_text(json.dumps(safe_record), encoding="utf-8")
+        violation_path = tmp_path / "violation.jsonl"
+        violation_path.write_text(json.dumps(violation_record), encoding="utf-8")
+
+        candidate = CandidateSpec(
+            start=Pose2D(0.0, 0.0),
+            goal=Pose2D(1.0, 1.0),
+            spawn_time_s=0.0,
+            pedestrian_speed_mps=1.0,
+            pedestrian_delay_s=0.0,
+            scenario_seed=1,
+        )
+
+        safe_eval = CandidateEvaluation(
+            candidate=candidate,
+            certification_status=failed_status("test"),
+            objective_value=None,
+            failure_attribution=None,
+            episode_record_path=safe_path,
+            trajectory_csv_path=None,
+            scenario_yaml_path=None,
+        )
+        violation_eval = CandidateEvaluation(
+            candidate=candidate,
+            certification_status=failed_status("test"),
+            objective_value=None,
+            failure_attribution=None,
+            episode_record_path=violation_path,
+            trajectory_csv_path=None,
+            scenario_yaml_path=None,
+        )
+        safe_score = temporal_robustness_objective(safe_eval)
+        violation_score = temporal_robustness_objective(violation_eval)
+        assert safe_score is not None
+        assert violation_score is not None
+        assert violation_score > safe_score
+
+
+class TestFirstCollisionTime:
+    """Tests for the collision time extraction helper."""
+
+    def test_returns_none_for_empty_ledger(self) -> None:
+        assert _first_collision_time({}) is None
+        assert _first_collision_time({"collision_events": []}) is None
+
+    def test_returns_first_time(self) -> None:
+        ledger = {"collision_events": [{"collision_time": 1.5}, {"collision_time": 3.0}]}
+        assert _first_collision_time(ledger) == pytest.approx(1.5)
+
+    def test_returns_none_for_invalid_time(self) -> None:
+        ledger = {"collision_events": [{"collision_time": None}]}
+        assert _first_collision_time(ledger) is None
+
+
+class TestObjectiveRegistry:
+    """Tests for the temporal_robustness objective registration."""
+
+    def test_temporal_robustness_is_registered(self) -> None:
+        objectives = list_objectives()
+        assert "temporal_robustness" in objectives
+
+    def test_get_objective_returns_function(self) -> None:
+        obj = get_objective("temporal_robustness")
+        assert callable(obj)
+
+    def test_per_property_robustness_preserved_in_report(self, tmp_path: Path) -> None:
+        """Per-property values AND critical timestamps must be preserved."""
+        record = _make_episode_record(
+            min_clearance=0.1,
+            time_to_collision_min=0.5,
+            time_to_goal_norm=1.0,
+            failure_to_progress=2.0,
+            total_collision_count=1.0,
+            collision_event=True,
+            route_complete=False,
+            collision_events=[{"collision_time": 1.2}],
+        )
+        report = compute_robustness_report(record)
+        assert len(report.properties) == 5
+
+        names = {p.property_name for p in report.properties}
+        assert names == {"clearance", "ttc", "goal", "progress", "collision"}
+
+        collision = next(p for p in report.properties if p.property_name == "collision")
+        assert collision.critical_time_s == pytest.approx(1.2)
+        assert collision.violated
+
+        progress = next(p for p in report.properties if p.property_name == "progress")
+        assert progress.violated
+        assert progress.robustness == pytest.approx(-2.0)
+
+
+class TestDtDerivation:
+    """Tests for automatic dt derivation from episode metadata."""
+
+    def test_dt_from_wall_time_and_steps(self) -> None:
+        record = _make_episode_record(wall_time_sec=20.0, steps=200)
+        report = compute_robustness_report(record)
+        goal = next(p for p in report.properties if p.property_name == "goal")
+        expected_dt = 20.0 / 200.0
+        t_total = 200 * expected_dt
+        t_actual = 0.3 * t_total
+        assert goal.robustness == pytest.approx(t_total - t_actual)
+
+    def test_dt_defaults_to_0_1(self) -> None:
+        record = _make_episode_record()
+        report = compute_robustness_report(record)
+        goal = next(p for p in report.properties if p.property_name == "goal")
+        t_total = 200 * 0.1
+        t_actual = 0.3 * t_total
+        assert goal.robustness == pytest.approx(t_total - t_actual)


### PR DESCRIPTION
## What and why

Implements signed temporal-logic robustness as a first-class adversarial-search objective for social-navigation falsification (issue #5304). The prior registry effectively exposed `worst_case_snqi` only, which does not identify the violated property. This change adds interpretable, signed per-property robustness values and critical timestamps.

Five properties are computed from episode JSONL records:

- Clearance: `rho = min_clearance - NEAR_MISS_DIST`
- TTC: `rho = min_ttc - tau`
- Goal: `rho = T - T_actual`
- Progress: `rho = -failure_to_progress`
- Collision: `rho = -collision_count`

The candidate sidecar preserves every property report and timestamp. The registered objective returns the negated minimum robustness so search maximisation prioritizes the worst violation.

## Files changed

- `robot_sf/adversarial/robustness.py`: report model, calculation, robust record parsing, sidecar writer, and objective.
- `robot_sf/adversarial/objectives.py`: `temporal_robustness` registry entry.
- `tests/test_adversarial_robustness.py`: unit and search-integration coverage.

## Status and deferred work

Research/exploratory implementation; this is a search objective, not a reported benchmark metric. The pre-registered matched-budget campaign comparison is explicitly tracked in #5326 and is not claimed by this implementation slice.

Refs #5304
Follow-up: #5326

## Validation

- Focused robustness tests, Ruff lint, and Ruff formatting run by the gate after the repair commit.
- CI must be green for the repaired head before merge.
