### PR TITLE
fix(ci): regenerate optional-import snapshot after the 14-PR batch merge

### DIFF
--- a/scripts/dev/generate_optional_import_snapshot.py
+++ b/scripts/dev/generate_optional_import_snapshot.py
@@ -45,7 +45,12 @@ NOTES = {
         "Blessed broad catch: guarded plotting / native-lib load may raise "
         "RuntimeError. Do not collapse to ImportError."
     ),
-    "ImportError+OSError": ("Blessed broad catch: native-lib / filesystem load may raise OSError."),
+    "ImportError+OSError": (
+        "Blessed broad catch: native-lib / filesystem load may raise OSError. "
+        "campaign_runtime_preflight.py is a deliberate import PROBE (issue #5300): it "
+        "exists to catch and report arm-dependency import failures with a remediation "
+        "message, so try_import (which discards the exception) is the wrong tool there."
+    ),
     "ImportError+SyntaxError": (
         "Blessed broad catch: parser/extension load may surface SyntaxError."
     ),

--- a/tests/fixtures/optional_import_guards.json
+++ b/tests/fixtures/optional_import_guards.json
@@ -6,7 +6,7 @@
     "ModuleNotFoundError"
   ],
   "spelling_key": "Caught exception type names, sorted and joined by '+'. The 'as <alias>' name is intentionally NOT part of the key.",
-  "total_guards": 102,
+  "total_guards": 101,
   "spellings": {
     "AttributeError+ImportError": {
       "count_ceiling": 2,
@@ -170,7 +170,7 @@
     },
     "ImportError+OSError": {
       "count_ceiling": 5,
-      "has_as_count": 1,
+      "has_as_count": 2,
       "pragma_no_cover_count": 2,
       "blessed": true,
       "note": "Blessed broad catch: native-lib / filesystem load may raise OSError. campaign_runtime_preflight.py is a deliberate import PROBE (issue #5300): it exists to catch and report arm-dependency import failures with a remediation message, so try_import (which discards the exception) is the wrong tool there.",
@@ -180,16 +180,6 @@
         "robot_sf/benchmark/cli.py:3232",
         "robot_sf/benchmark/full_classic/visual_deps.py:45",
         "robot_sf/benchmark/orca_preflight.py:90"
-      ]
-    },
-    "ImportError+OSError+RuntimeError+TypeError+ValueError+json.JSONDecodeError": {
-      "count_ceiling": 1,
-      "has_as_count": 1,
-      "pragma_no_cover_count": 0,
-      "blessed": true,
-      "note": "Blessed broad catch: defensive resource-lifecycle ingest boundary. Review carefully before adding more.",
-      "samples": [
-        "robot_sf/benchmark/camera_ready/resource_lifecycle.py:365"
       ]
     },
     "ImportError+OSError+RuntimeError+ValueError": {


### PR DESCRIPTION
Tip CI failed `test_snapshot_matches_collector_output` after the recovery batch merge: the snapshot pins file:line samples and per-spelling counts, and fourteen merges legitimately shifted both. Mechanical regeneration via `scripts/dev/generate_optional_import_snapshot.py`, plus the #5324 import-probe justification moved into the generator's note dict so regenerations preserve it.

Verified: inventory suite 8/8 locally on the tip.

Last step of today's main-red recovery.