### PR TITLE
Issue #5326: multi-objective comparison infrastructure (cheap-lane worker)

### DIFF
--- a/configs/adversarial/issue_5326_objective_comparison.yaml
+++ b/configs/adversarial/issue_5326_objective_comparison.yaml
@@ -1,0 +1,44 @@
+schema_version: adversarial-objective-comparison.v1
+issue: 5326
+status: infrastructure_ready
+claim_scope: not_paper_facing_benchmark_evidence
+runner: scripts/tools/compare_adversarial_samplers.py
+base_config:
+  scenario_template: configs/scenarios/templates/crossing_ttc.yaml
+  search_space: configs/adversarial/crossing_ttc_space.yaml
+  policy: goal
+objectives:
+  - worst_case_snqi
+  - temporal_robustness
+budget_grid: [16, 32, 64]
+repeated_seeds: [1101, 2202, 3303]
+samplers:
+  - random
+  - coordinate
+  - optuna
+reporting_contract:
+  - objective
+  - first_failure_iteration
+  - best_valid_objective
+  - invalid_candidate_rate
+  - replay_success_rate
+  - certified_valid_failure_count
+  - replayable_valid_failure_count
+  - fallback_candidate_count
+  - degraded_candidate_count
+  - held_out_family_yield
+explicit_exclusions:
+  learned_failure_proposal_issue_2921: stretch_out_of_scope_until_base_comparison_succeeds
+  held_out_family_yield: not_evaluated_narrow_archive_caveat
+  paper_facing_success_claims: forbidden
+  campaign_evidence: requires_slurm_capable_worker
+output_artifacts:
+  output_dir: output/adversarial/issue_5326_objective_comparison
+  report_json: output/adversarial/issue_5326_objective_comparison/report.json
+example_command: >
+  uv run python scripts/tools/compare_adversarial_samplers.py
+  --objective worst_case_snqi --objective temporal_robustness
+  --package-b-budget-grid
+  --seed 1101 --seed 2202 --seed 3303
+  --output-dir output/adversarial/issue_5326_objective_comparison
+  --out-json output/adversarial/issue_5326_objective_comparison/report.json

--- a/scripts/tools/compare_adversarial_samplers.py
+++ b/scripts/tools/compare_adversarial_samplers.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 class SamplerComparisonRow:
     """One sampler result row for the comparison report."""
 
+    objective: str
     sampler: str
     budget: int
     seed: int
@@ -69,61 +70,71 @@ def run_sampler_comparison(
     *,
     config: SearchConfig,
     sampler_names: Sequence[str],
+    objective_names: Sequence[str],
     synthetic: bool,
     budgets: Sequence[int] | None = None,
     seeds: Sequence[int] | None = None,
 ) -> list[SamplerComparisonRow]:
-    """Run the configured search once per sampler and return compact rows."""
+    """Run the configured search once per sampler and objective and return compact rows."""
     rows: list[SamplerComparisonRow] = []
     active_budgets = tuple(budgets or (config.budget,))
     active_seeds = tuple(seeds or (config.seed,))
-    for budget in active_budgets:
-        if budget <= 0:
-            raise ValueError("budgets must be positive")
-        for base_seed in active_seeds:
-            for sampler_name in sampler_names:
-                run_seed = int(base_seed)
-                sampler_output_dir = (
-                    config.output_dir
-                    / f"budget_{int(budget):04d}"
-                    / f"seed_{int(base_seed)}"
-                    / sampler_name
-                )
-                sampler_config = replace(
-                    config,
-                    budget=int(budget),
-                    output_dir=sampler_output_dir,
-                    seed=run_seed,
-                )
-                result = run_adversarial_search(
-                    sampler_config,
-                    sampler=build_sampler(sampler_name, config.search_space, seed=run_seed),
-                    evaluator=_synthetic_evaluator if synthetic else None,
-                    certifier=(
-                        (lambda _candidate, _path, _required: passed_status("synthetic comparison"))
-                        if synthetic
-                        else None
-                    ),
-                )
-                rows.append(
-                    _comparison_row_from_manifest(
-                        sampler=sampler_name,
-                        budget=int(budget),
-                        seed=run_seed,
-                        manifest_path=result.manifest_path,
-                        best_bundle_path=result.best_bundle_path,
-                        best_objective_value=result.best_objective_value,
-                        num_candidates=result.num_candidates,
-                        num_valid_candidates=result.num_valid_candidates,
-                        num_invalid_candidates=result.num_invalid_candidates,
-                        num_failed_evaluations=result.num_failed_evaluations,
+    for objective_name in objective_names:
+        for budget in active_budgets:
+            if budget <= 0:
+                raise ValueError("budgets must be positive")
+            for base_seed in active_seeds:
+                for sampler_name in sampler_names:
+                    run_seed = int(base_seed)
+                    sampler_output_dir = (
+                        config.output_dir
+                        / objective_name
+                        / f"budget_{int(budget):04d}"
+                        / f"seed_{int(base_seed)}"
+                        / sampler_name
                     )
-                )
+                    sampler_config = replace(
+                        config,
+                        objective=objective_name,
+                        budget=int(budget),
+                        output_dir=sampler_output_dir,
+                        seed=run_seed,
+                    )
+                    result = run_adversarial_search(
+                        sampler_config,
+                        sampler=build_sampler(sampler_name, config.search_space, seed=run_seed),
+                        evaluator=_synthetic_evaluator if synthetic else None,
+                        certifier=(
+                            (
+                                lambda _candidate, _path, _required: passed_status(
+                                    "synthetic comparison"
+                                )
+                            )
+                            if synthetic
+                            else None
+                        ),
+                    )
+                    rows.append(
+                        _comparison_row_from_manifest(
+                            objective=objective_name,
+                            sampler=sampler_name,
+                            budget=int(budget),
+                            seed=run_seed,
+                            manifest_path=result.manifest_path,
+                            best_bundle_path=result.best_bundle_path,
+                            best_objective_value=result.best_objective_value,
+                            num_candidates=result.num_candidates,
+                            num_valid_candidates=result.num_valid_candidates,
+                            num_invalid_candidates=result.num_invalid_candidates,
+                            num_failed_evaluations=result.num_failed_evaluations,
+                        )
+                    )
     return rows
 
 
 def _comparison_row_from_manifest(  # noqa: PLR0913
     *,
+    objective: str,
     sampler: str,
     budget: int,
     seed: int,
@@ -163,6 +174,7 @@ def _comparison_row_from_manifest(  # noqa: PLR0913
         "learned failure proposal #2921 remains stretch/out of scope",
     )
     return SamplerComparisonRow(
+        objective=objective,
         sampler=sampler,
         budget=budget,
         seed=seed,
@@ -306,7 +318,16 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=Path("configs/adversarial/crossing_ttc_space.yaml"),
     )
     parser.add_argument("--policy", default="goal")
-    parser.add_argument("--objective", default="worst_case_snqi")
+    parser.add_argument(
+        "--objective",
+        action="append",
+        dest="objectives",
+        default=None,
+        help=(
+            "Objective to evaluate; repeat to compare multiple objectives. "
+            "Defaults to worst_case_snqi."
+        ),
+    )
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument(
         "--budget",
@@ -350,11 +371,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the sampler comparison CLI."""
     args = parse_args(argv)
+    objectives = args.objectives or ["worst_case_snqi"]
     config = SearchConfig.from_files(
         policy=args.policy,
         scenario_template=args.scenario_template,
         search_space=args.search_space,
-        objective=args.objective,
+        objective=objectives[0],
         output_dir=args.output_dir,
         budget=(args.budget or [8])[0],
         seed=(args.seed or [123])[0],
@@ -364,14 +386,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     rows = run_sampler_comparison(
         config=config,
         sampler_names=tuple(args.samplers or ("random", "coordinate", "optuna")),
+        objective_names=objectives,
         synthetic=bool(args.synthetic),
         budgets=budgets,
         seeds=seeds,
     )
     payload = {
-        "schema_version": "adversarial-sampler-comparison.v2",
+        "schema_version": "adversarial-sampler-comparison.v3",
         "report_status": "diagnostic_local_nominal",
         "claim_scope": "not_paper_facing_benchmark_evidence",
+        "objectives": objectives,
         "budget_grid": list(budgets or [config.budget]),
         "seeds": list(seeds),
         "package_b_notes": {

--- a/scripts/tools/compare_adversarial_samplers.py
+++ b/scripts/tools/compare_adversarial_samplers.py
@@ -70,16 +70,19 @@ def run_sampler_comparison(
     *,
     config: SearchConfig,
     sampler_names: Sequence[str],
-    objective_names: Sequence[str],
     synthetic: bool,
+    objective_names: Sequence[str] | None = None,
     budgets: Sequence[int] | None = None,
     seeds: Sequence[int] | None = None,
 ) -> list[SamplerComparisonRow]:
     """Run the configured search once per sampler and objective and return compact rows."""
     rows: list[SamplerComparisonRow] = []
+    active_objectives = tuple(objective_names or (config.objective,))
+    if len(active_objectives) != len(set(active_objectives)):
+        raise ValueError("objective_names must not contain duplicates")
     active_budgets = tuple(budgets or (config.budget,))
     active_seeds = tuple(seeds or (config.seed,))
-    for objective_name in objective_names:
+    for objective_name in active_objectives:
         for budget in active_budgets:
             if budget <= 0:
                 raise ValueError("budgets must be positive")

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -1443,6 +1443,18 @@ def test_sampler_comparison_synthetic_smoke(tmp_path: Path) -> None:
     assert all(Path(row.manifest_path).exists() for row in rows)
     assert all(row.num_failed_evaluations == 0 for row in rows)
     assert all(row.best_valid_objective is not None for row in rows)
+    assert {
+        json.loads(Path(row.manifest_path).read_text(encoding="utf-8"))["config"]["objective"]
+        for row in rows
+    } == {"worst_case_snqi", "temporal_robustness"}
+
+    with pytest.raises(ValueError, match="objective_names must not contain duplicates"):
+        run_sampler_comparison(
+            config=config,
+            sampler_names=("random",),
+            objective_names=("worst_case_snqi", "worst_case_snqi"),
+            synthetic=True,
+        )
 
 
 def test_sampler_comparison_package_b_budget_seed_grid(tmp_path: Path) -> None:

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -1464,6 +1464,7 @@ def test_sampler_comparison_package_b_budget_seed_grid(tmp_path: Path) -> None:
     rows = run_sampler_comparison(
         config=config,
         sampler_names=("random", "coordinate"),
+        objective_names=("worst_case_snqi",),
         synthetic=True,
         budgets=(16, 32, 64),
         seeds=(101, 202),
@@ -1535,6 +1536,7 @@ def test_sampler_comparison_reports_certified_replayable_failures(tmp_path: Path
     )
 
     row = _comparison_row_from_manifest(
+        objective="worst_case_snqi",
         sampler="random",
         budget=3,
         seed=11,
@@ -1554,6 +1556,38 @@ def test_sampler_comparison_reports_certified_replayable_failures(tmp_path: Path
     assert row.replayable_valid_failure_count == 1
     assert row.replay_success_rate == 1.0
     assert row.fallback_candidate_count == 1
+
+
+def test_sampler_comparison_multi_objective(tmp_path: Path) -> None:
+    """Comparison helper should run multiple objectives and tag rows correctly."""
+    template = tmp_path / "template.yaml"
+    search_space = tmp_path / "space.yaml"
+    _write_template(template)
+    _write_space(search_space)
+    config = SearchConfig.from_files(
+        policy="goal",
+        scenario_template=template,
+        search_space=search_space,
+        objective="worst_case_snqi",
+        output_dir=tmp_path / "comparison",
+        budget=2,
+        seed=23,
+    )
+
+    rows = run_sampler_comparison(
+        config=config,
+        sampler_names=("random",),
+        objective_names=("worst_case_snqi", "temporal_robustness"),
+        synthetic=True,
+    )
+
+    assert len(rows) == 2
+    assert {row.objective for row in rows} == {"worst_case_snqi", "temporal_robustness"}
+    assert all(row.sampler == "random" for row in rows)
+    assert all(row.num_candidates == 2 for row in rows)
+    assert all(Path(row.manifest_path).exists() for row in rows)
+    assert all(row.num_failed_evaluations == 0 for row in rows)
+    assert all(row.best_valid_objective is not None for row in rows)
 
 
 def test_invalid_optimizer_proposals_are_rejected_before_evaluation(tmp_path: Path) -> None:

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -1446,15 +1446,7 @@ def test_sampler_comparison_synthetic_smoke(tmp_path: Path) -> None:
     assert {
         json.loads(Path(row.manifest_path).read_text(encoding="utf-8"))["config"]["objective"]
         for row in rows
-    } == {"worst_case_snqi", "temporal_robustness"}
-
-    with pytest.raises(ValueError, match="objective_names must not contain duplicates"):
-        run_sampler_comparison(
-            config=config,
-            sampler_names=("random",),
-            objective_names=("worst_case_snqi", "worst_case_snqi"),
-            synthetic=True,
-        )
+    } == {"worst_case_snqi"}
 
 
 def test_sampler_comparison_package_b_budget_seed_grid(tmp_path: Path) -> None:
@@ -1600,6 +1592,20 @@ def test_sampler_comparison_multi_objective(tmp_path: Path) -> None:
     assert all(Path(row.manifest_path).exists() for row in rows)
     assert all(row.num_failed_evaluations == 0 for row in rows)
     assert all(row.best_valid_objective is not None for row in rows)
+    assert {
+        row.objective: json.loads(Path(row.manifest_path).read_text(encoding="utf-8"))["config"][
+            "objective"
+        ]
+        for row in rows
+    } == {"worst_case_snqi": "worst_case_snqi", "temporal_robustness": "temporal_robustness"}
+
+    with pytest.raises(ValueError, match="objective_names must not contain duplicates"):
+        run_sampler_comparison(
+            config=config,
+            sampler_names=("random",),
+            objective_names=("worst_case_snqi", "worst_case_snqi"),
+            synthetic=True,
+        )
 
 
 def test_invalid_optimizer_proposals_are_rejected_before_evaluation(tmp_path: Path) -> None:


### PR DESCRIPTION
## What and why

This PR builds multi-objective comparison infrastructure for adversarial search, enabling comparison of `temporal_robustness` (from PR #5325) against `worst_case_snqi` on the same scenario family with matched budgets. This is the first required step for the benchmark campaign specified in issue #5326.

## Changes

- **`scripts/tools/compare_adversarial_samplers.py`**: Modified to support multiple `--objective` arguments. Added `objective` field to `SamplerComparisonRow` for per-row objective tagging. Updated `run_sampler_comparison` to iterate over objectives.
- **`configs/adversarial/issue_5326_objective_comparison.yaml`**: New config for the multi-objective comparison campaign.
- **`tests/adversarial/test_adversarial_search.py`**: Added `test_sampler_comparison_multi_objective` test and updated existing tests for the new API.

## Validation

- Focused adversarial search tests pass: `uv run pytest tests/adversarial/test_adversarial_search.py -x --timeout=60`
- Ruff lint and format pass
- Synthetic multi-objective comparison runs successfully:
  ```
  uv run python scripts/tools/compare_adversarial_samplers.py \
    --objective worst_case_snqi --objective temporal_robustness \
    --sampler random --synthetic --seed 123 --budget 2 \
    --output-dir /tmp/test_multi_objective \
    --out-json /tmp/test_multi_objective/report.json
  ```

## Status and successor statement

This is a **partial slice** of issue #5326. It builds the multi-objective comparison infrastructure but does NOT run the actual benchmark campaigns. The remaining work for issue #5326:

1. **Campaign execution**: Run the comparison with real benchmark episodes (not synthetic) via SLURM-capable worker
2. **Certification/replay/independent-seed confirmation**: Validate each claimed failure
3. **Durable comparison table**: Produce the final comparison report with stop-rule decision

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

Refs #5326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Sampler comparisons now support multiple objectives in a single run.
- Added repeated `--objective` CLI options, with a default objective when none is specified.
- Comparison results now identify the objective used for each run.
- JSON reports include the selected objectives and updated report format.

## Tests
- Added coverage for multi-objective sampler comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->