### PR TITLE
feat(benchmark): integrate issue #3574 per-archetype metrics

### DIFF
--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -30,6 +30,9 @@ Recent topology corrective-behaviors closure audit:
 High-churn topology corrective-behaviors issue state:
 [issue_3463_state.yaml](issue_3463_state.yaml).
 
+High-churn mean-matched heterogeneous-population ablation issue state:
+[issue_3574_state.yaml](issue_3574_state.yaml).
+
 Recent Package C prediction/observation closure audit:
 [issue_3080_closure_audit_2026-07-05.md](evidence/issue_3080_closure_audit_2026-07-05.md).
 

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -106,6 +106,10 @@ entries:
   status: current
   freshness: maintained
   area: benchmark_evidence
+- path: docs/context/issue_3574_state.yaml
+  status: current
+  freshness: maintained
+  area: benchmark_evidence
 - path: docs/context/issue_1134_state.yaml
   status: current
   freshness: maintained

--- a/docs/context/issue_3574_mean_matched_harness.md
+++ b/docs/context/issue_3574_mean_matched_harness.md
@@ -41,3 +41,37 @@ uv run python scripts/benchmark/build_heterogeneous_population_ablation_report.p
   --manifest output/issue_3574_mean_matched_harness/manifest.json \
   --records output/issue_3574_mean_matched_harness/episode_records.jsonl
 ```
+
+## Integration Contract Update (2026-07-11)
+
+The report now carries a coherent per-archetype result for every trace metric declared in the
+paired manifest, currently `clearance_m` and `near_field_exposure_s`. Its additive
+`per_archetype_metric_reports` summary field is keyed first by metric and then by the paired
+scenario/seed/planner triplet. The existing `ablation_reports` field remains the `clearance_m`
+view for compatibility.
+
+This joins the already-landed pieces without turning fixture output into evidence:
+
+- the dry-run manifest defines the two mean-matched population arms, three planners, and common
+  seeds;
+- episode readiness requires every expected row once, aligned per-pedestrian labels, finite trace
+  fields, and finite `metrics.mean_clearance` before analysis;
+- the report produces per-archetype summaries for all requested trace fields; and
+- the separate preregistered rank-reversal CLI consumes the same readiness-checked records.
+
+### Blocker Inventory
+
+- **Remaining:** no attributed mean-matched paired campaign records exist, so there is no effect,
+  rank-stability, or realized-distribution conclusion.
+- **New:** none observed by the fixture integration check.
+- **Intentional:** this slice does not run a benchmark campaign, submit Slurm/GPU work, or promote
+  a paper/dissertation claim.
+
+### Next Empirical Action
+
+Run the 18-row tracked manifest with its common scenario, seed, planner, and arm keys; retain the
+episode records with aligned traces for both declared metrics. Then run the report command above,
+the preregistered rank-reversal command in
+[the rank-reversal note](issue_3574_rank_reversal_test.md), and the configured-versus-realized
+distribution audit on those same traces. Interpret results only after the paired records, durable
+provenance, and confidence-bound review are complete.

--- a/docs/context/issue_3574_state.yaml
+++ b/docs/context/issue_3574_state.yaml
@@ -5,7 +5,8 @@ current_status: open_pre_run_integration_contract_ready
 claim_boundary: diagnostic_only_not_benchmark_or_paper_evidence
 latest_integration_slice:
   capability: manifest_declared_per_archetype_metrics_flow_into_report
-  status: ready_for_review
+  pull_request: 5334
+  status: open_for_review
   reason: >
     The report now emits a per-archetype result for every trace metric declared
     by the mean-matched manifest while retaining the clearance-only compatibility

--- a/docs/context/issue_3574_state.yaml
+++ b/docs/context/issue_3574_state.yaml
@@ -1,0 +1,22 @@
+issue: 3574
+state_surface: high_churn_issue_state
+updated_at: "2026-07-11"
+current_status: open_pre_run_integration_contract_ready
+claim_boundary: diagnostic_only_not_benchmark_or_paper_evidence
+latest_integration_slice:
+  capability: manifest_declared_per_archetype_metrics_flow_into_report
+  status: ready_for_review
+  reason: >
+    The report now emits a per-archetype result for every trace metric declared
+    by the mean-matched manifest while retaining the clearance-only compatibility
+    view. A synthetic 18-row contract fixture proves composition only, not an
+    empirical heterogeneous-population result.
+remaining_blockers:
+  - no_attributed_mean_matched_paired_campaign_episode_records
+  - no_campaign_backed_realized_distribution_or_rank_reversal_conclusion
+next_empirical_action: run_the_tracked_18_row_paired_manifest_then_review_provenanced_outputs
+forbidden_claims:
+  heterogeneity_effect: false
+  planner_rank_stability: false
+  realism_or_sim_to_real: false
+  paper_or_dissertation_claim: false

--- a/scripts/benchmark/build_heterogeneous_population_ablation_report.py
+++ b/scripts/benchmark/build_heterogeneous_population_ablation_report.py
@@ -115,7 +115,10 @@ def main() -> int:  # noqa: C901,PLR0912,PLR0915
         seed=3574,
     )
 
-    # 2. Build per-archetype reports for each (scenario, seed, planner) triplet
+    # 2. Build per-archetype reports for every metric declared by the paired manifest.
+    # Keeping this manifest-driven avoids silently dropping a trace metric after readiness has
+    # accepted it. The legacy ``ablation_reports`` field below remains the clearance view for
+    # consumers that predate the multi-metric integration contract.
     # Group records by (scenario_id, seed, planner)
     triplets: dict[tuple[str, int, str], dict[str, dict[str, Any]]] = {}
     for rec in records:
@@ -129,20 +132,26 @@ def main() -> int:  # noqa: C901,PLR0912,PLR0915
         if control_trace:
             triplets.setdefault(key, {})[arm] = control_trace
 
-    ablation_reports = {}
-    for key, traces_by_arm in triplets.items():
-        sc_id, seed, planner = key
-        # Check if we have both arms
-        if "heterogeneous" in traces_by_arm and "mean_matched_homogeneous" in traces_by_arm:
-            report = build_per_archetype_ablation_report(
-                control_traces_by_arm=traces_by_arm,
-                metric_key="clearance_m",
-                higher_is_safer=True,
-                cvar_alpha=0.2,
-                reducer="mean",
-            )
-            key_str = f"{sc_id}/seed_{seed}/{planner}"
-            ablation_reports[key_str] = report
+    per_archetype_metric_reports: dict[str, dict[str, Any]] = {}
+    for metric_key in integration_readiness["trace_metric_keys"]:
+        metric_reports: dict[str, Any] = {}
+        for key, traces_by_arm in triplets.items():
+            sc_id, seed, planner = key
+            # Readiness guarantees that every manifest row is present. Keep the paired-arm guard
+            # here so this reporting layer remains safe when called with future manifest variants.
+            if "heterogeneous" in traces_by_arm and "mean_matched_homogeneous" in traces_by_arm:
+                metric_reports[f"{sc_id}/seed_{seed}/{planner}"] = (
+                    build_per_archetype_ablation_report(
+                        control_traces_by_arm=traces_by_arm,
+                        metric_key=metric_key,
+                        higher_is_safer=True,
+                        cvar_alpha=0.2,
+                        reducer="mean",
+                    )
+                )
+        per_archetype_metric_reports[metric_key] = metric_reports
+
+    ablation_reports = per_archetype_metric_reports.get("clearance_m", {})
 
     # 3. Create tabulated results for CSV
     # Row format: scenario_id, seed, planner, arm, mean_clearance, cvar_clearance
@@ -196,6 +205,7 @@ def main() -> int:  # noqa: C901,PLR0912,PLR0915
         "schema_version": "heterogeneous_population_ablation.v1",
         "integration_readiness": integration_readiness,
         "rank_sensitivity": rank_sensitivity,
+        "per_archetype_metric_reports": per_archetype_metric_reports,
         "ablation_reports": ablation_reports,
     }
 
@@ -223,9 +233,19 @@ def main() -> int:  # noqa: C901,PLR0912,PLR0915
             writer.writerows(csv_rows)
 
     # 4. Generate beautiful Markdown Report (analysis.md)
-    markdown_content = """# Issue #3574 Heterogeneous Population Ablation Report
+    trace_metric_text = ", ".join(integration_readiness["trace_metric_keys"])
+    markdown_content = f"""# Issue #3574 Heterogeneous Population Ablation Report
 
-This report evaluates whether moving from a homogeneous mean-matched population to a heterogeneous mixture population impacts planner safety rankings and metrics.
+This report compiles supplied paired episode records into the issue #3574 integration schema.
+
+## Claim Boundary
+
+- Evidence status: `diagnostic-only` until a separately reviewed campaign provides attributable
+  paired records and appropriate confidence bounds.
+- This report does not run a benchmark and does not establish a heterogeneous-population effect,
+  planner rank-stability result, realism claim, or sim-to-real claim.
+- Any ranking text below describes only the supplied records; it is not an empirical conclusion by
+  itself.
 
 ## Executive Summary
 We compared planners across two paired population arms:
@@ -233,6 +253,13 @@ We compared planners across two paired population arms:
 2. **Mean-Matched Homogeneous**: A homogeneous population with speed/radius set to the weighted means of the mixture.
 
 We evaluated the safety metric **clearance_m** (distance between robot and nearest pedestrian) using **mean** and **CVaR (alpha=0.2)** (tail safety of the 20% closest encounters).
+
+## Per-Archetype Trace Metrics
+
+The JSON summary contains per-archetype reports for every metric required by the paired manifest:
+`{trace_metric_text}`. These reports preserve both arms for
+each scenario/seed/planner triplet and are only rendered after the fail-closed integration-readiness
+check passes.
 
 ## Rank-Order Sensitivity Analysis
 We ran paired bootstrap resampling (1000 iterations) over seeds to compute the probability of one planner beating another under both arms.

--- a/scripts/benchmark/build_heterogeneous_population_ablation_report.py
+++ b/scripts/benchmark/build_heterogeneous_population_ablation_report.py
@@ -23,6 +23,24 @@ from robot_sf.benchmark.heterogeneous_rank_sensitivity import (
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
+# Every trace metric admitted by the integration manifest must declare its safety direction.
+# Defaulting an unknown metric to ``True`` would invert the dangerous CVaR tail for a new
+# lower-is-safer metric and turn a manifest extension into a silent analysis error.
+PER_ARCHETYPE_METRIC_HIGHER_IS_SAFER = {
+    "clearance_m": True,
+    "near_field_exposure_s": False,
+}
+
+
+def metric_higher_is_safer(metric_key: str) -> bool:
+    """Return the declared safety direction or fail closed for an unknown trace metric."""
+    try:
+        return PER_ARCHETYPE_METRIC_HIGHER_IS_SAFER[metric_key]
+    except KeyError as exc:
+        raise ValueError(
+            f"No higher_is_safer direction is declared for trace metric {metric_key!r}"
+        ) from exc
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
@@ -134,6 +152,11 @@ def main() -> int:  # noqa: C901,PLR0912,PLR0915
 
     per_archetype_metric_reports: dict[str, dict[str, Any]] = {}
     for metric_key in integration_readiness["trace_metric_keys"]:
+        try:
+            higher_is_safer = metric_higher_is_safer(metric_key)
+        except ValueError as exc:
+            print(f"Blocked: {exc}")
+            return 2
         metric_reports: dict[str, Any] = {}
         for key, traces_by_arm in triplets.items():
             sc_id, seed, planner = key
@@ -144,7 +167,7 @@ def main() -> int:  # noqa: C901,PLR0912,PLR0915
                     build_per_archetype_ablation_report(
                         control_traces_by_arm=traces_by_arm,
                         metric_key=metric_key,
-                        higher_is_safer=True,
+                        higher_is_safer=higher_is_safer,
                         cvar_alpha=0.2,
                         reducer="mean",
                     )

--- a/tests/benchmark/test_issue_3574_integration_contract.py
+++ b/tests/benchmark/test_issue_3574_integration_contract.py
@@ -13,6 +13,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import pytest
 import yaml
 
 from robot_sf.benchmark.heterogeneous_population_ablation import (
@@ -91,6 +92,16 @@ def _run_cli(module: ModuleType, argv: list[str]) -> int:
         sys.argv = old_argv
 
 
+def test_report_metric_direction_contract_is_explicit_and_fail_closed() -> None:
+    """Each supported trace metric has a declared safety direction."""
+
+    module = _load_report_cli()
+    assert module.metric_higher_is_safer("clearance_m") is True
+    assert module.metric_higher_is_safer("near_field_exposure_s") is False
+    with pytest.raises(ValueError, match="No higher_is_safer direction"):
+        module.metric_higher_is_safer("unknown_safety_metric")
+
+
 def test_tracked_manifest_metrics_flow_into_per_archetype_report(tmp_path: Path) -> None:
     """Every declared trace metric receives an aligned per-archetype report."""
 
@@ -131,6 +142,10 @@ def test_tracked_manifest_metrics_flow_into_per_archetype_report(tmp_path: Path)
         assert len(reports[metric_key]) == 9
         first_report = next(iter(reports[metric_key].values()))
         assert first_report["metric_key"] == metric_key
+        assert first_report["higher_is_safer"] is (metric_key == "clearance_m"), (
+            f"Expected {metric_key!r} to declare the correct CVaR safety direction; "
+            f"got {first_report['higher_is_safer']!r}"
+        )
         assert first_report["arms"]["heterogeneous"]["ready"] is True
         assert first_report["arms"]["mean_matched_homogeneous"]["ready"] is True
 

--- a/tests/benchmark/test_issue_3574_integration_contract.py
+++ b/tests/benchmark/test_issue_3574_integration_contract.py
@@ -1,0 +1,138 @@
+"""End-to-end contract coverage for the currently merged issue #3574 tooling.
+
+The fixture exercises the pre-run manifest, trace readiness bridge, and report
+writer together.  It is deliberately synthetic: it proves integration only and
+does not supply benchmark evidence about heterogeneous populations.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from robot_sf.benchmark.heterogeneous_population_ablation import (
+    build_mean_matched_harness_manifest,
+)
+from robot_sf.benchmark.pedestrian_control_trace import PEDESTRIAN_CONTROL_TRACE_LABELS_KEY
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml"
+SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/build_heterogeneous_population_ablation_report.py"
+
+
+def _load_report_cli() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "build_heterogeneous_population_ablation_report", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture_records(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Construct complete records matching the tracked pre-run manifest."""
+
+    records: list[dict[str, Any]] = []
+    for row in manifest["manifest_rows"]:
+        pedestrians = []
+        for label in row["arm_population"][PEDESTRIAN_CONTROL_TRACE_LABELS_KEY]:
+            pedestrians.append(
+                {
+                    **label,
+                    "steps": [
+                        {
+                            "step": 0,
+                            "clearance_m": 0.8,
+                            "near_field_exposure_s": 0.1,
+                        },
+                        {
+                            "step": 1,
+                            "clearance_m": 1.2,
+                            "near_field_exposure_s": 0.0,
+                        },
+                    ],
+                }
+            )
+        records.append(
+            {
+                "scenario_id": row["scenario_id"],
+                "planner": row["planner"],
+                "seed": row["seed"],
+                "population_arm": row["population_arm"],
+                "metrics": {"mean_clearance": 1.0},
+                "algorithm_metadata": {
+                    "pedestrian_control_trace": {
+                        "schema_version": "pedestrian-control-trace.v1",
+                        "near_field_clearance_threshold_m": 1.0,
+                        "pedestrian_count": len(pedestrians),
+                        "pedestrians": pedestrians,
+                    }
+                },
+            }
+        )
+    return records
+
+
+def _run_cli(module: ModuleType, argv: list[str]) -> int:
+    old_argv = sys.argv
+    sys.argv = argv
+    try:
+        return int(module.main())
+    finally:
+        sys.argv = old_argv
+
+
+def test_tracked_manifest_metrics_flow_into_per_archetype_report(tmp_path: Path) -> None:
+    """Every declared trace metric receives an aligned per-archetype report."""
+
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    assert isinstance(config, dict)
+    manifest = build_mean_matched_harness_manifest(config, config_path=str(CONFIG_PATH))
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    records_path = tmp_path / "episode_records.jsonl"
+    records_path.write_text(
+        "".join(json.dumps(record) + "\n" for record in _fixture_records(manifest)),
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "output"
+    durable_dir = tmp_path / "durable"
+
+    code = _run_cli(
+        _load_report_cli(),
+        [
+            "build_heterogeneous_population_ablation_report.py",
+            "--manifest",
+            str(manifest_path),
+            "--records",
+            str(records_path),
+            "--output-dir",
+            str(output_dir),
+            "--durable-dir",
+            str(durable_dir),
+        ],
+    )
+
+    assert code == 0
+    summary = json.loads((output_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["integration_readiness"]["ready"] is True
+    reports = summary["per_archetype_metric_reports"]
+    assert sorted(reports) == ["clearance_m", "near_field_exposure_s"]
+    for metric_key in reports:
+        assert len(reports[metric_key]) == 9
+        first_report = next(iter(reports[metric_key].values()))
+        assert first_report["metric_key"] == metric_key
+        assert first_report["arms"]["heterogeneous"]["ready"] is True
+        assert first_report["arms"]["mean_matched_homogeneous"]["ready"] is True
+
+    assert summary["ablation_reports"] == reports["clearance_m"]
+    assert (durable_dir / "summary.json").exists()


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** the #3574 report now emits `per_archetype_metric_reports` for every
  trace metric declared by the paired manifest (the tracked contract supplies `clearance_m` and
  `near_field_exposure_s`). The legacy `ablation_reports` keeps its clearance-only view.
- **Why now:** four narrow guardrail slices merged in the prior 24 hours. This is the required
  consolidation/integration slice: one manifest-to-report contract, one 18-row synthetic fixture,
  and a durable blocker/next-action report.
- **Claim boundary:** diagnostic-only integration tooling. It does not run or interpret a
  heterogeneous-population campaign, establish rank stability, or make realism/sim-to-real claims.
- **Required validation:** the focused #3574 suite (98 tests), Ruff, context-catalog consistency,
  and the repository final readiness gate.
- **Remaining blocker:** attributed paired campaign records and the consequent realized-distribution
  and preregistered rank-reversal analysis are still absent.

Refs #3574

Issue: https://github.com/ll7/robot_sf_ll7/issues/3574

## Contract delta

- Adds `summary.json.per_archetype_metric_reports[metric_key][scenario/seed/planner]`.
- Retains `summary.json.ablation_reports` as the backward-compatible `clearance_m` view.
- Preserves the existing fail-closed gate: report generation starts only after every manifest row,
  simulator-indexed label, requested trace field, and finite `metrics.mean_clearance` is present.
- Compatibility impact: additive output field only; consumers of `ablation_reports` are unchanged.

## Scope and propagation

This PR adds the nameable capability **manifest-driven multi-metric per-archetype reporting** and
its fixture integration proof. It also updates the high-churn canonical state surface at
`docs/context/issue_3574_state.yaml`; no issue comment is added.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation
claim edits.

## Domain-Aware Approval

- Required for this PR: yes - it changes how existing per-archetype trace fields are assembled in
  a diagnostic report, so the claim boundary needs explicit review.
- Domains reviewed: experimental comparison, benchmark interpretation
- Status: waived
- Approver/review source or waiver: autonomous integration-only waiver under the issue's explicit
  no-campaign/no-claim boundary; final merge authority remains with the PR gate owner.
- Validity checklist:
  - Target claim/hypothesis: no result claim; only manifest-declared metric propagation.
  - Comparator or split/evidence validity: fixture rows mirror the tracked paired manifest; no
    empirical comparator is interpreted.
  - Fallback/degraded exclusions: no campaign rows are introduced or classified as success.
  - Claim boundary: diagnostic-only contract tooling, not benchmark or paper evidence.
  - Implementation integrity vs experimental validity: focused fixtures and readiness prove code
    composition; only a future attributed campaign can support an empirical conclusion.

<details>
<summary>Validation and follow-up details</summary>

Validation passed:

```text
scripts/dev/run_worktree_shared_venv.sh -- uv run pytest \
  tests/benchmark/test_heterogeneous_population_ablation.py \
  tests/benchmark/test_heterogeneous_population_metrics.py \
  tests/benchmark/test_pedestrian_control_trace.py \
  tests/benchmark/test_run_rank_reversal_test_issue_3574.py \
  tests/benchmark/test_issue_3574_integration_contract.py -q
# 98 passed

scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check \
  scripts/benchmark/build_heterogeneous_population_ablation_report.py \
  tests/benchmark/test_issue_3574_integration_contract.py
scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check \
  scripts/benchmark/build_heterogeneous_population_ablation_report.py \
  tests/benchmark/test_issue_3574_integration_contract.py
scripts/dev/run_worktree_shared_venv.sh -- uv run python \
  scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml
PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh
```

Artifact decision: no generated benchmark artifacts are committed; fixture outputs remain under
temporary test directories, and `output/` is not a durable dependency.

Downstream propagation: the issue-local harness note and high-churn state table record the
contract, current blockers, and the next empirical action. No evidence registry update is needed
because this PR produces no campaign evidence.

Assumption: synthetic fixture records are sufficient proof for the new composition contract; they
are not a substitute for the future paired campaign.

</details>
