### PR TITLE
Issue #5331: route-waypoint producer activates DWA global-route probe (cheap-lane worker)

### DIFF
--- a/robot_sf/sensor/socnav_observation.py
+++ b/robot_sf/sensor/socnav_observation.py
@@ -206,6 +206,10 @@ def socnav_observation_space(
                         high=np.array([float(np.max(pos_cap))], dtype=np.float32),
                         dtype=np.float32,
                     ),
+                    "route_waypoints": spaces.Sequence(
+                        spaces.Box(low=pos_low, high=pos_high, dtype=np.float32),
+                        stack=True,
+                    ),
                 },
             ),
             "goal": spaces.Dict(
@@ -569,39 +573,42 @@ class SocNavObservationFusion:
         Returns:
             np.ndarray: Clipped, capped route waypoint array.
         """
+        empty = np.zeros((0, 2), dtype=np.float32)
         navs_raw = getattr(self.simulator, "robot_navs", None)
-        if not navs_raw or self.robot_index >= len(navs_raw):
-            return np.zeros((0, 2), dtype=np.float32)
+        if navs_raw is None:
+            return empty
 
-        nav = navs_raw[self.robot_index]
-        waypoints_raw = getattr(nav, "waypoints", None)
-        if waypoints_raw is None:
-            return np.zeros((0, 2), dtype=np.float32)
+        try:
+            nav = navs_raw[self.robot_index]
+            waypoint_id = int(getattr(nav, "waypoint_id", 0))
+            if waypoint_id < 0:
+                return empty
+            remaining_arr = np.asarray(
+                getattr(nav, "waypoints", None)[waypoint_id:], dtype=np.float32
+            )
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+            return empty
 
-        waypoint_id = int(getattr(nav, "waypoint_id", 0))
-        remaining = waypoints_raw[waypoint_id:]
+        if remaining_arr.size == 0:
+            if waypoint_id == 0:
+                return empty
+            remaining_arr = empty
+        elif remaining_arr.ndim != 2 or remaining_arr.shape[-1] != 2:
+            return empty
 
-        if not remaining:
-            if waypoint_id <= 0:
-                return np.zeros((0, 2), dtype=np.float32)
+        try:
             robot_pose = self.simulator.robots[self.robot_index].pose
-            robot_pos = np.asarray(robot_pose[0], dtype=np.float32)
-            return np.clip(robot_pos.reshape(1, -1), 0.0, position_cap)
+            robot_pos = np.asarray(robot_pose[0], dtype=np.float32).reshape(-1)
+        except (AttributeError, IndexError, TypeError, ValueError):
+            return empty
+        if robot_pos.shape != (2,) or not np.all(np.isfinite(robot_pos)):
+            return empty
+        if remaining_arr.size > 0 and not np.all(np.isfinite(remaining_arr)):
+            return empty
 
-        remaining_arr = np.asarray(remaining, dtype=np.float32)
-        if remaining_arr.ndim != 2 or remaining_arr.shape[-1] != 2:
-            return np.zeros((0, 2), dtype=np.float32)
-
-        robot_pose = self.simulator.robots[self.robot_index].pose
-        robot_pos = np.asarray(robot_pose[0], dtype=np.float32)
-
-        wp_with_robot = np.vstack([robot_pos.reshape(1, -1), remaining_arr])
+        wp_with_robot = np.vstack([robot_pos.reshape(1, 2), remaining_arr])
         wp_with_robot = np.clip(wp_with_robot, 0.0, position_cap)
-
-        if wp_with_robot.shape[0] > MAX_ROUTE_WAYPOINTS:
-            wp_with_robot = wp_with_robot[:MAX_ROUTE_WAYPOINTS]
-
-        return wp_with_robot
+        return wp_with_robot[:MAX_ROUTE_WAYPOINTS]
 
     def next_obs(self) -> dict[str, Any]:
         """Return the latest structured observation aligned to the declared space."""

--- a/robot_sf/sensor/socnav_observation.py
+++ b/robot_sf/sensor/socnav_observation.py
@@ -30,6 +30,16 @@ DEFAULT_MAX_PEDS = 64
 SOCNAV_POSITION_CAP_M = 50.0
 """Global cap for SocNav position-like observations to keep bounds consistent."""
 
+MAX_ROUTE_WAYPOINTS = 32
+"""Maximum number of route waypoints exposed in the structured observation.
+
+The total route_waypoints array may contain up to this many entries (including
+the robot position prefix when remaining waypoints are non-empty). Capping
+prevents unbounded memory growth for maps with extremely dense route waypoint
+lists while keeping the DWA global-route probe within a manageable search
+radius for nearest-waypoint resolution.
+"""
+
 
 def dynamic_pedestrian_occlusion_mask(
     ped_positions: np.ndarray,
@@ -540,6 +550,59 @@ class SocNavObservationFusion:
                 return True
         return False
 
+    def _build_route_waypoints(self, position_cap: np.ndarray) -> np.ndarray:
+        """Extract remaining route waypoints for the DWA global-route probe.
+
+        Reads from ``simulator.robot_navs`` and returns a ``(N, 2)`` float32
+        array containing the robot position (when remaining waypoints exist)
+        followed by remaining waypoints from ``waypoint_id`` onward. The array
+        is clipped to the position cap and bounded by ``MAX_ROUTE_WAYPOINTS``.
+
+        Contract:
+        - Robot position is prepended when remaining waypoints exist.
+        - When the navigator has no waypoints, returns empty ``(0, 2)``.
+        - When all waypoints are visited but a route existed, returns robot
+          position ``(1, 2)`` so the probe can still locate the robot on route.
+        - Total rows never exceed ``MAX_ROUTE_WAYPOINTS``.
+        - Malformed navigator state fails closed with an empty array.
+
+        Returns:
+            np.ndarray: Clipped, capped route waypoint array.
+        """
+        navs_raw = getattr(self.simulator, "robot_navs", None)
+        if not navs_raw or self.robot_index >= len(navs_raw):
+            return np.zeros((0, 2), dtype=np.float32)
+
+        nav = navs_raw[self.robot_index]
+        waypoints_raw = getattr(nav, "waypoints", None)
+        if waypoints_raw is None:
+            return np.zeros((0, 2), dtype=np.float32)
+
+        waypoint_id = int(getattr(nav, "waypoint_id", 0))
+        remaining = waypoints_raw[waypoint_id:]
+
+        if not remaining:
+            if waypoint_id <= 0:
+                return np.zeros((0, 2), dtype=np.float32)
+            robot_pose = self.simulator.robots[self.robot_index].pose
+            robot_pos = np.asarray(robot_pose[0], dtype=np.float32)
+            return np.clip(robot_pos.reshape(1, -1), 0.0, position_cap)
+
+        remaining_arr = np.asarray(remaining, dtype=np.float32)
+        if remaining_arr.ndim != 2 or remaining_arr.shape[-1] != 2:
+            return np.zeros((0, 2), dtype=np.float32)
+
+        robot_pose = self.simulator.robots[self.robot_index].pose
+        robot_pos = np.asarray(robot_pose[0], dtype=np.float32)
+
+        wp_with_robot = np.vstack([robot_pos.reshape(1, -1), remaining_arr])
+        wp_with_robot = np.clip(wp_with_robot, 0.0, position_cap)
+
+        if wp_with_robot.shape[0] > MAX_ROUTE_WAYPOINTS:
+            wp_with_robot = wp_with_robot[:MAX_ROUTE_WAYPOINTS]
+
+        return wp_with_robot
+
     def next_obs(self) -> dict[str, Any]:
         """Return the latest structured observation aligned to the declared space."""
         ped_positions = np.asarray(self.simulator.ped_pos, dtype=np.float32)
@@ -634,6 +697,7 @@ class SocNavObservationFusion:
             self.simulator.robots[self.robot_index].current_speed, dtype=np.float32
         )
         robot_velocity_xy = self._robot_velocity_xy(wrapped_heading)
+        route_waypoints = self._build_route_waypoints(position_cap)
         obs = {
             "robot": {
                 "position": robot_pos_clipped,
@@ -644,6 +708,7 @@ class SocNavObservationFusion:
                 "radius": np.array(
                     [self.simulator.robots[self.robot_index].config.radius], dtype=np.float32
                 ),
+                "route_waypoints": route_waypoints,
             },
             "goal": {
                 "current": goal_clipped,

--- a/tests/sensor/test_route_waypoint_producer.py
+++ b/tests/sensor/test_route_waypoint_producer.py
@@ -1,0 +1,222 @@
+"""Tests for the route-waypoint producer in SocNavObservationFusion (issue #5331)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from robot_sf.sensor.socnav_observation import (
+    MAX_ROUTE_WAYPOINTS,
+    SOCNAV_POSITION_CAP_M,
+    SocNavObservationFusion,
+)
+
+
+@dataclass
+class FakeNavigator:
+    """Minimal navigator stub exposing waypoints and waypoint_id."""
+
+    waypoints: list[tuple[float, float]] = field(default_factory=list)
+    waypoint_id: int = 0
+
+
+@dataclass
+class FakeRobot:
+    """Minimal robot stub for SocNavObservationFusion testing."""
+
+    pose: tuple[tuple[float, float], float] = ((0.0, 0.0), 0.0)
+    current_speed: tuple[float, float] = (0.0, 0.0)
+    config: Any = None
+
+    def __post_init__(self) -> None:
+        """Set default config when none is provided."""
+        if self.config is None:
+            self.config = type("Cfg", (), {"radius": 0.25})()
+
+
+@dataclass
+class FakeSimulator:
+    """Minimal simulator stub providing navigator and robot state."""
+
+    robot_navs: list[FakeNavigator] = field(default_factory=list)
+    robots: list[FakeRobot] = field(default_factory=lambda: [FakeRobot()])
+    ped_pos: np.ndarray = field(default_factory=lambda: np.zeros((0, 2), dtype=np.float32))
+    ped_vel: np.ndarray = field(default_factory=lambda: np.zeros((0, 2), dtype=np.float32))
+    goal_pos: list[tuple[float, float]] = field(default_factory=lambda: [(3.0, 0.0)])
+    next_goal_pos: list[tuple[float, float] | None] = field(default_factory=lambda: [None])
+    robot_pos: list[tuple[float, float]] = field(default_factory=lambda: [(0.0, 0.0)])
+    map_def: Any = None
+    config: Any = None
+
+    def __post_init__(self) -> None:
+        """Set default map_def and config when none are provided."""
+        if self.map_def is None:
+            self.map_def = type(
+                "MapDef",
+                (),
+                {"width": 20.0, "height": 20.0, "obstacles": []},
+            )()
+        if self.config is None:
+            self.config = type("Cfg", (), {"time_per_step_in_secs": 0.1})()
+
+
+@dataclass
+class FakeEnvConfig:
+    """Minimal environment config stub for SocNavObservationFusion."""
+
+    sim_config: Any = None
+    predictive_foresight_enabled: bool = False
+    include_grid_in_observation: bool = False
+    max_total_pedestrians: int = 64
+
+    def __post_init__(self) -> None:
+        """Set default sim_config when none is provided."""
+        if self.sim_config is None:
+            self.sim_config = type("SimCfg", (), {"ped_radius": 0.3})()
+
+
+def _build_fusion(
+    *,
+    waypoints: list[tuple[float, float]] | None = None,
+    waypoint_id: int = 0,
+) -> tuple[SocNavObservationFusion, FakeSimulator]:
+    """Build a SocNavObservationFusion with a stubbed simulator."""
+    navs = [FakeNavigator(waypoints=waypoints or [], waypoint_id=waypoint_id)]
+    sim = FakeSimulator(robot_navs=navs)
+    env_config = FakeEnvConfig()
+    fusion = SocNavObservationFusion(simulator=sim, env_config=env_config, max_pedestrians=16)
+    return fusion, sim
+
+
+class TestRouteWaypointProducer:
+    """Unit tests for _build_route_waypoints and observation injection."""
+
+    def test_route_waypoints_present_in_obs(self) -> None:
+        """route_waypoints appears in the robot dict when the navigator has a route."""
+        fusion, _ = _build_fusion(waypoints=[(1.0, 0.0), (2.0, 0.0), (3.0, 0.0)])
+        obs = fusion.next_obs()
+        assert "route_waypoints" in obs["robot"]
+        wp = obs["robot"]["route_waypoints"]
+        assert wp.shape == (4, 2)
+        np.testing.assert_allclose(wp, [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]])
+
+    def test_route_waypoints_starts_from_current_waypoint_id(self) -> None:
+        """Only waypoints from waypoint_id onward plus robot pos are included."""
+        fusion, _ = _build_fusion(
+            waypoints=[(0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (3.0, 0.0)],
+            waypoint_id=2,
+        )
+        obs = fusion.next_obs()
+        wp = obs["robot"]["route_waypoints"]
+        assert wp.shape == (3, 2)
+        np.testing.assert_allclose(wp, [[0.0, 0.0], [2.0, 0.0], [3.0, 0.0]])
+
+    def test_route_waypoints_empty_when_no_route(self) -> None:
+        """Empty (0, 2) array when navigator has no waypoints."""
+        fusion, _ = _build_fusion(waypoints=[])
+        obs = fusion.next_obs()
+        wp = obs["robot"]["route_waypoints"]
+        assert wp.shape == (0, 2)
+
+    def test_route_waypoints_empty_when_all_visited(self) -> None:
+        """Only robot_pos when waypoint_id is past the end (remaining is empty)."""
+        fusion, _ = _build_fusion(
+            waypoints=[(1.0, 0.0), (2.0, 0.0)],
+            waypoint_id=2,
+        )
+        obs = fusion.next_obs()
+        wp = obs["robot"]["route_waypoints"]
+        assert wp.shape == (1, 2)
+        np.testing.assert_allclose(wp, [[0.0, 0.0]])
+
+    def test_route_waypoints_capped_at_max(self) -> None:
+        """Waypoint count is capped at MAX_ROUTE_WAYPOINTS."""
+        many = [(float(i), 0.0) for i in range(50)]
+        fusion, _ = _build_fusion(waypoints=many)
+        obs = fusion.next_obs()
+        wp = obs["robot"]["route_waypoints"]
+        assert wp.shape[0] == MAX_ROUTE_WAYPOINTS
+
+    def test_route_waypoints_clipped_to_position_cap(self) -> None:
+        """Waypoints outside the map extent are clipped to SOCNAV_POSITION_CAP_M."""
+        fusion, _ = _build_fusion(waypoints=[(100.0, -5.0)])
+        obs = fusion.next_obs()
+        wp = obs["robot"]["route_waypoints"]
+        assert float(wp[0, 0]) <= SOCNAV_POSITION_CAP_M
+        assert float(wp[0, 1]) >= 0.0
+
+    def test_route_waypoints_float32(self) -> None:
+        """Route waypoints are returned as float32."""
+        fusion, _ = _build_fusion(waypoints=[(1.0, 2.0)])
+        obs = fusion.next_obs()
+        assert obs["robot"]["route_waypoints"].dtype == np.float32
+
+    def test_build_route_waypoints_no_navs(self) -> None:
+        """Empty array when simulator has no robot_navs attribute."""
+        fusion, sim = _build_fusion()
+        sim.robot_navs = []
+        cap = np.array([20.0, 20.0], dtype=np.float32)
+        wp = fusion._build_route_waypoints(cap)
+        assert wp.shape == (0, 2)
+
+    def test_build_route_waypoints_no_waypoints_attr(self) -> None:
+        """Empty array when navigator lacks waypoints attribute."""
+        fusion, sim = _build_fusion()
+        sim.robot_navs = [type("Nav", (), {"waypoint_id": 0})()]
+        cap = np.array([20.0, 20.0], dtype=np.float32)
+        wp = fusion._build_route_waypoints(cap)
+        assert wp.shape == (0, 2)
+
+
+class TestRouteWaypointProducerIntegration:
+    """Integration tests: DWA probe activates when route_waypoints are present."""
+
+    def test_dwa_probe_activates_with_producer_waypoints(self) -> None:
+        """The DWA global-route probe reports activation when waypoints are in the observation."""
+        from robot_sf.planner.dwa import DWAPlannerAdapter, DWAPlannerConfig
+
+        fusion, _ = _build_fusion(waypoints=[(0.5, 0.0), (1.5, 0.0), (3.0, 0.0)])
+        obs = fusion.next_obs()
+        config = DWAPlannerConfig(
+            global_route_probe_enabled=True,
+            global_route_probe_waypoint_distance=2.0,
+        )
+        planner = DWAPlannerAdapter(config)
+        planner.plan(obs)
+        diag = planner.diagnostics()
+        assert diag["last_decision"]["global_route_probe_activated"] is True
+
+    def test_dwa_probe_does_not_activate_with_empty_route(self) -> None:
+        """The probe does not activate when the route is empty."""
+        from robot_sf.planner.dwa import DWAPlannerAdapter, DWAPlannerConfig
+
+        fusion, _ = _build_fusion(waypoints=[])
+        obs = fusion.next_obs()
+        config = DWAPlannerConfig(global_route_probe_enabled=True)
+        planner = DWAPlannerAdapter(config)
+        planner.plan(obs)
+        diag = planner.diagnostics()
+        assert diag["last_decision"]["global_route_probe_activated"] is False
+
+    def test_dwa_probe_targets_forward_waypoint(self) -> None:
+        """The probe uses the forward waypoint (after nearest) for scoring."""
+        from robot_sf.planner.dwa import DWAPlannerAdapter, DWAPlannerConfig
+
+        waypoints = [(0.1, 0.0), (2.0, 2.0), (3.0, 0.0)]
+        fusion, _ = _build_fusion(waypoints=waypoints)
+        obs = fusion.next_obs()
+
+        config = DWAPlannerConfig(
+            global_route_probe_enabled=True,
+            global_route_probe_heading_weight=2.0,
+        )
+        planner = DWAPlannerAdapter(config)
+        cmd_with_probe = planner.plan(obs)
+
+        baseline_config = DWAPlannerConfig(global_route_probe_enabled=False)
+        baseline_planner = DWAPlannerAdapter(baseline_config)
+        cmd_baseline = baseline_planner.plan(obs)
+
+        assert cmd_with_probe != cmd_baseline

--- a/tests/sensor/test_route_waypoint_producer.py
+++ b/tests/sensor/test_route_waypoint_producer.py
@@ -144,8 +144,8 @@ class TestRouteWaypointProducer:
         fusion, _ = _build_fusion(waypoints=[(100.0, -5.0)])
         obs = fusion.next_obs()
         wp = obs["robot"]["route_waypoints"]
-        assert float(wp[0, 0]) <= SOCNAV_POSITION_CAP_M
-        assert float(wp[0, 1]) >= 0.0
+        assert float(wp[1, 0]) == SOCNAV_POSITION_CAP_M
+        assert float(wp[1, 1]) == 0.0
 
     def test_route_waypoints_float32(self) -> None:
         """Route waypoints are returned as float32."""

--- a/tests/sensor/test_route_waypoint_producer.py
+++ b/tests/sensor/test_route_waypoint_producer.py
@@ -169,6 +169,18 @@ class TestRouteWaypointProducer:
         wp = fusion._build_route_waypoints(cap)
         assert wp.shape == (0, 2)
 
+    def test_build_route_waypoints_fails_closed_for_malformed_navigation(self) -> None:
+        """Malformed route metadata never leaks invalid data into the observation."""
+        fusion, sim = _build_fusion(waypoints=[(1.0, 0.0)])
+        cap = np.array([20.0, 20.0], dtype=np.float32)
+
+        sim.robot_navs[0].waypoint_id = "not-an-index"  # type: ignore[assignment]
+        assert fusion._build_route_waypoints(cap).shape == (0, 2)
+
+        sim.robot_navs[0].waypoint_id = 0
+        sim.robot_navs[0].waypoints = [(float("nan"), 0.0)]
+        assert fusion._build_route_waypoints(cap).shape == (0, 2)
+
 
 class TestRouteWaypointProducerIntegration:
     """Integration tests: DWA probe activates when route_waypoints are present."""


### PR DESCRIPTION
## Summary

Implements the canonical route-waypoint producer that injects remaining navigation waypoints into the SocNav structured observation, enabling the DWA global-route probe to activate during production episodes.

This is the successor slice to PR #5332. That PR added the DWA probe infrastructure but the probe could not activate because `observation["robot"]["route_waypoints"]` was not populated. This PR provides that missing pipeline.

## What changed

- **`robot_sf/sensor/socnav_observation.py`**: Added `MAX_ROUTE_WAYPOINTS` (32) and `_build_route_waypoints()` to `SocNavObservationFusion`. The observation now includes `robot.route_waypoints`: robot position followed by remaining `simulator.robot_navs[robot_index]` waypoints, clipped to position bounds and capped at 32 entries. The declared Gym space now includes this variable-length field, and malformed navigation data fails closed to an empty `(0, 2)` array.

- **`tests/sensor/test_route_waypoint_producer.py`**: 13 tests cover the producer contract, malformed-input fail-closed behavior, clipping, and DWA-probe activation/inactivation integration.

## Successor statement

Successor slice to PR #5332; does not duplicate PR #5332. Parent issue #5331 remains open for its durable two-seed diagnostic packet: activation and outcome comparison for `classic_bottleneck_medium` seed 131 and `classic_t_intersection_low` seed 161 with the probe config. This slice supplies the capability; the packet must run the trace script through `run_map_batch()` and record durable results.

## Validation

- `uv run pytest tests/sensor/test_route_waypoint_producer.py tests/planner/test_dwa_global_route_probe.py tests/planner/test_dwa.py tests/benchmark/test_trace_dwa_global_route_probe_issue_5331.py tests/sensor/ -q` — 107 passed (author).
- Gate repair: `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/sensor/test_route_waypoint_producer.py tests/planner/test_dwa_global_route_probe.py tests/benchmark/test_trace_dwa_global_route_probe_issue_5331.py tests/test_socnav_observation_mode.py::test_socnav_struct_observation_contains_expected_keys tests/test_socnav_env_integration.py::test_socnav_policy_runs_single_step -q` — 36 passed.
- Gate recheck: `DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/sensor/test_route_waypoint_producer.py tests/test_socnav_observation_mode.py::test_socnav_struct_observation_contains_expected_keys tests/test_socnav_env_integration.py::test_socnav_policy_runs_single_step -q` — 15 passed.
- `uv run ruff check robot_sf/sensor/socnav_observation.py tests/sensor/test_route_waypoint_producer.py` — passed.
- `uv run ruff format --check robot_sf/sensor/socnav_observation.py tests/sensor/test_route_waypoint_producer.py` — passed.

## Research Result Guidance

- Target blocker: resolved — the DWA probe can now activate when simulator navigation supplies route waypoints.
- Evidence tier: diagnostic probe plus unit and integration tests; not benchmark evidence.
- Result classification: infrastructure complete; the durable diagnostic packet remains on #5331.

## Domain-Aware Approval

- Required: no — implementation integrity only; this PR makes no experimental-validity or benchmark claim.
- Status: not required.

## Downstream Propagation

- Parent issue: Refs #5331; partial slice, with the durable diagnostic packet explicitly remaining there.
- Claim map / benchmark report / registry: NA — no research result is claimed.

## Follow-Up Issues

- Deferred work: #5331 durable two-seed diagnostic-only packet.

Refs #5331


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added route waypoint information to robot observations.
  * Observations include the robot’s current position and remaining navigation waypoints.
  * Waypoints are limited in number, constrained to map boundaries, and provided in a consistent numeric format.
  * Navigation planning can use available global route information to improve forward waypoint scoring.

* **Bug Fixes**
  * Safely handles missing, invalid, malformed, or non-finite waypoint data without producing invalid observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->