### PR TITLE
Issue #5269: route issue-state reads through REST helper (cheap-lane worker)

### DIFF
--- a/scripts/dev/check_pr_followups.py
+++ b/scripts/dev/check_pr_followups.py
@@ -13,7 +13,6 @@ import json
 import os
 import posixpath
 import re
-import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -425,25 +424,22 @@ def _domain_checklist_errors(section: str) -> tuple[str, ...]:
 
 
 def _verify_open_issues(issues: tuple[str, ...]) -> tuple[str, ...]:
+    from scripts.dev.gh_issue_rest import fetch_issue
+
     errors: list[str] = []
     for issue in issues:
         number = issue.removeprefix("#")
         try:
-            result = subprocess.run(
-                ["gh", "issue", "view", number, "--json", "state", "--jq", ".state"],
-                capture_output=True,
-                text=True,
-                timeout=20,
-                check=False,
-            )
-        except FileNotFoundError:
-            errors.append(f"{issue}: unable to verify open state (gh CLI not found)")
+            issue_number = int(number)
+        except ValueError:
+            errors.append(f"{issue}: unable to verify open state (invalid issue number)")
             continue
-        if result.returncode != 0:
-            detail = (result.stderr or result.stdout).strip()
+        payload = fetch_issue(issue_number)
+        if payload.get("status") != "ok":
+            detail = payload.get("error", "unknown error")
             errors.append(f"{issue}: unable to verify open state ({detail})")
             continue
-        state = result.stdout.strip().upper()
+        state = payload.get("state", "").upper()
         if state != "OPEN":
             errors.append(f"{issue}: state is {state or 'unknown'}, expected OPEN")
     return tuple(errors)
@@ -876,7 +872,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--require-open-issues",
         action="store_true",
-        help="Verify linked follow-up issues are open with gh issue view.",
+        help="Verify linked follow-up issues are open via REST helper (gh_issue_rest.py).",
     )
     parser.add_argument(
         "--changed-files-file",

--- a/scripts/dev/closed_state_label_hygiene.py
+++ b/scripts/dev/closed_state_label_hygiene.py
@@ -161,16 +161,24 @@ def collect_stale_issues(
 
 
 def build_view_command(*, repo: str, number: int) -> list[str]:
-    """Build the read-only GitHub CLI command that confirms one issue's state."""
+    """Build the read-only GitHub CLI command that confirms one issue's state.
+
+    Uses the REST-backed helper to avoid the deprecated ``projectCards`` GraphQL
+    field that breaks ``gh issue view --json`` on some CLI versions (issue #5269).
+    """
     return [
-        "gh",
-        "issue",
+        "uv",
+        "run",
+        "python",
+        "scripts/dev/gh_issue_rest.py",
         "view",
         str(number),
         "--repo",
         repo,
         "--json",
-        "number,state,url",
+        "number",
+        "state",
+        "url",
     ]
 
 
@@ -204,18 +212,18 @@ def _run_gh_command(command: list[str]) -> str:
 def confirm_issue_closed(*, repo: str, number: int) -> bool:
     """Read-then-write guard: confirm an issue is CLOSED and not a pull request.
 
+    Uses the REST-backed helper to avoid the deprecated ``projectCards`` GraphQL
+    field that breaks ``gh issue view --json`` on some CLI versions (issue #5269).
+
     Returns:
         True only when GitHub reports the issue as a closed (non-PR) issue.
     """
-    stdout = _run_gh_command(build_view_command(repo=repo, number=number))
-    try:
-        payload = json.loads(stdout or "{}")
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(
-            f"Failed to parse GitHub CLI JSON output for issue {number}: {exc.msg}"
-        ) from exc
-    if not isinstance(payload, dict):
-        raise ValueError(f"Expected a JSON object from gh issue view for issue {number}")
+    from scripts.dev.gh_issue_rest import fetch_issue
+
+    payload = fetch_issue(number, repo=repo)
+    if payload.get("status") != "ok":
+        error = payload.get("error", "unknown error")
+        raise RuntimeError(f"Failed to read issue {number}: {error}")
     if _is_pull_request_url(payload.get("url")):
         return False
     return str(payload.get("state", "")).lower() == "closed"

--- a/tests/dev/test_check_pr_followups.py
+++ b/tests/dev/test_check_pr_followups.py
@@ -6,11 +6,9 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
-from scripts.dev import check_pr_followups
 from scripts.dev.check_pr_followups import (
     analyze_body,
     analyze_body_quality,
@@ -634,11 +632,10 @@ This is diagnostic-only and leaves remaining work.
 def test_analyze_body_rejects_closed_followup_issue(monkeypatch) -> None:
     """Open-state verification rejects linked issues that are not open."""
 
-    def fake_run(*args, **kwargs):
-        del args, kwargs
-        return SimpleNamespace(returncode=0, stdout="CLOSED\n", stderr="")
+    def fake_fetch_issue(number: int, **kwargs):
+        return {"number": number, "status": "ok", "state": "CLOSED", "url": "https://example.com"}
 
-    monkeypatch.setattr(check_pr_followups.subprocess, "run", fake_run)
+    monkeypatch.setattr("scripts.dev.gh_issue_rest.fetch_issue", fake_fetch_issue)
 
     report = analyze_body(
         _body(deferred="Run the broader benchmark sweep.", issues="#2966"),
@@ -650,14 +647,13 @@ def test_analyze_body_rejects_closed_followup_issue(monkeypatch) -> None:
     assert "#2966: state is CLOSED" in report.issue_state_errors[0]
 
 
-def test_analyze_body_rejects_unverifiable_issue_when_gh_is_missing(monkeypatch) -> None:
-    """Open-state verification reports a compact error when gh is unavailable."""
+def test_analyze_body_rejects_unverifiable_issue_when_rest_fails(monkeypatch) -> None:
+    """Open-state verification reports a compact error when REST read fails."""
 
-    def fake_run(*args, **kwargs):
-        del args, kwargs
-        raise FileNotFoundError("gh")
+    def fake_fetch_issue(number: int, **kwargs):
+        return {"number": number, "status": "error", "error": "network timeout"}
 
-    monkeypatch.setattr(check_pr_followups.subprocess, "run", fake_run)
+    monkeypatch.setattr("scripts.dev.gh_issue_rest.fetch_issue", fake_fetch_issue)
 
     report = analyze_body(
         _body(deferred="Run the broader benchmark sweep.", issues="#2966"),
@@ -666,7 +662,7 @@ def test_analyze_body_rejects_unverifiable_issue_when_gh_is_missing(monkeypatch)
     )
 
     assert report.status == "issue_state_error"
-    assert "#2966: unable to verify open state (gh CLI not found)" in report.issue_state_errors
+    assert "#2966: unable to verify open state (network timeout)" in report.issue_state_errors
 
 
 def test_analyze_body_collects_multiline_deferred_work() -> None:

--- a/tests/dev/test_closed_state_label_hygiene.py
+++ b/tests/dev/test_closed_state_label_hygiene.py
@@ -297,48 +297,45 @@ def test_fix_stale_issues_only_removes_documented_label_set() -> None:
     assert all(label in closed_state_label_hygiene.LIVE_STATE_LABELS for _, label in removed)
 
 
-def test_confirm_issue_closed_reads_state_via_gh(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_confirm_issue_closed_reads_state_via_rest(monkeypatch: pytest.MonkeyPatch) -> None:
     """confirm_issue_closed returns True only for closed, non-PR issues."""
-    captured: dict[str, list[str]] = {}
 
-    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        captured["command"] = command
-        return subprocess.CompletedProcess(
-            args=tuple(command),
-            returncode=0,
-            stdout=(
-                '{"number": 12, "state": "CLOSED", '
-                '"url": "https://github.com/ll7/robot_sf_ll7/issues/12"}'
-            ),
-        )
+    def fake_fetch_issue(number: int, **kwargs: object) -> dict:
+        return {
+            "number": number,
+            "status": "ok",
+            "state": "CLOSED",
+            "url": "https://github.com/ll7/robot_sf_ll7/issues/12",
+        }
 
-    monkeypatch.setattr(closed_state_label_hygiene.subprocess, "run", fake_run)
+    monkeypatch.setattr("scripts.dev.gh_issue_rest.fetch_issue", fake_fetch_issue)
 
     assert closed_state_label_hygiene.confirm_issue_closed(repo="ll7/robot_sf_ll7", number=12)
-    assert captured["command"][:3] == ["gh", "issue", "view"]
 
 
 def test_confirm_issue_closed_is_false_for_open_or_pr(monkeypatch: pytest.MonkeyPatch) -> None:
     """Open issues and pull requests must fail the read-then-write guard."""
 
-    def fake_run_open(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(
-            args=tuple(command),
-            returncode=0,
-            stdout='{"state": "OPEN", "url": "https://github.com/ll7/robot_sf_ll7/issues/12"}',
-        )
+    def fake_fetch_issue_open(number: int, **kwargs: object) -> dict:
+        return {
+            "number": number,
+            "status": "ok",
+            "state": "OPEN",
+            "url": "https://github.com/ll7/robot_sf_ll7/issues/12",
+        }
 
-    monkeypatch.setattr(closed_state_label_hygiene.subprocess, "run", fake_run_open)
+    monkeypatch.setattr("scripts.dev.gh_issue_rest.fetch_issue", fake_fetch_issue_open)
     assert not closed_state_label_hygiene.confirm_issue_closed(repo="ll7/robot_sf_ll7", number=12)
 
-    def fake_run_pr(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(
-            args=tuple(command),
-            returncode=0,
-            stdout='{"state": "CLOSED", "url": "https://github.com/ll7/robot_sf_ll7/pull/12"}',
-        )
+    def fake_fetch_issue_pr(number: int, **kwargs: object) -> dict:
+        return {
+            "number": number,
+            "status": "ok",
+            "state": "CLOSED",
+            "url": "https://github.com/ll7/robot_sf_ll7/pull/12",
+        }
 
-    monkeypatch.setattr(closed_state_label_hygiene.subprocess, "run", fake_run_pr)
+    monkeypatch.setattr("scripts.dev.gh_issue_rest.fetch_issue", fake_fetch_issue_pr)
     assert not closed_state_label_hygiene.confirm_issue_closed(repo="ll7/robot_sf_ll7", number=12)
 
 
@@ -372,19 +369,22 @@ def test_main_fix_mode_strips_labels_and_reports(
             ]
         }
 
+    def fake_fetch_issue(number: int, **kwargs: object) -> dict:
+        return {
+            "number": number,
+            "status": "ok",
+            "state": "CLOSED",
+            "url": "https://github.com/ll7/robot_sf_ll7/issues/12",
+        }
+
     edits: list[list[str]] = []
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        if command[:3] == ["gh", "issue", "view"]:
-            return subprocess.CompletedProcess(
-                args=tuple(command),
-                returncode=0,
-                stdout='{"state": "CLOSED", "url": "https://github.com/ll7/robot_sf_ll7/issues/12"}',
-            )
         edits.append(command)
         return subprocess.CompletedProcess(args=tuple(command), returncode=0, stdout="")
 
     monkeypatch.setattr(closed_state_label_hygiene, "fetch_closed_issues_by_label", fake_fetch)
+    monkeypatch.setattr("scripts.dev.gh_issue_rest.fetch_issue", fake_fetch_issue)
     monkeypatch.setattr(closed_state_label_hygiene.subprocess, "run", fake_run)
 
     exit_code = closed_state_label_hygiene.main(["--repo", "ll7/robot_sf_ll7", "--fix"])


### PR DESCRIPTION
## What/Why

Update  and  to use the existing  REST helper instead of raw  commands.

The  command fails on some GitHub CLI versions because the underlying GraphQL query requests the deprecated  field. The repository already has a REST-backed helper () that bypasses this issue, but two scripts still called  directly.

## Changes

- :  now uses  from  instead of 
- :  now uses  from ;  now emits 
- : Updated mocks to patch  instead of 
- : Updated mocks to patch  instead of 
- Removed unused imports after refactor

## Validation

All checks passed!
============================= test session starts ==============================
platform linux -- Python 3.13.14, pytest-9.1.1, pluggy-1.6.0 -- /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5269-20260712T000718Z/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5269-20260712T000718Z
configfile: pyproject.toml
plugins: timeout-2.4.0, cov-7.0.0, split-0.11.0, xdist-3.8.0, anyio-4.12.1
collecting ... collected 101 items

tests/dev/test_gh_issue_rest.py::test_fetch_issue_normalizes_rest_fields_to_gh_json_shape PASSED [  0%]
tests/dev/test_gh_issue_rest.py::test_fetch_issue_fails_closed_on_nonzero_exit PASSED [  1%]
tests/dev/test_gh_issue_rest.py::test_fetch_issue_fails_closed_on_invalid_json PASSED [  2%]
tests/dev/test_gh_issue_rest.py::test_fetch_comments_paginates_until_short_page PASSED [  3%]
tests/dev/test_gh_issue_rest.py::test_fetch_comments_fails_closed_when_page_budget_exceeded PASSED [  4%]
tests/dev/test_gh_issue_rest.py::test_fetch_comments_rejects_invalid_max_pages PASSED [  5%]
tests/dev/test_gh_issue_rest.py::test_fetch_issue_with_comments_combines_issue_and_thread PASSED [  6%]
tests/dev/test_gh_issue_rest.py::test_fetch_issue_with_comments_propagates_issue_error PASSED [  7%]
tests/dev/test_gh_issue_rest.py::test_complete_thread_uses_native_output_when_available PASSED [  8%]
tests/dev/test_gh_issue_rest.py::test_native_thread_read_forces_human_output_when_stdout_is_captured PASSED [  9%]
tests/dev/test_gh_issue_rest.py::test_complete_thread_falls_back_to_rest_and_preserves_comment_order PASSED [ 10%]
tests/dev/test_gh_issue_rest.py::test_complete_thread_does_not_mask_unrelated_native_failure PASSED [ 11%]
tests/dev/test_gh_issue_rest.py::test_complete_thread_reports_rest_fallback_failure PASSED [ 12%]
tests/dev/test_gh_issue_rest.py::test_render_issue_plain_resembles_gh_issue_view_comments PASSED [ 13%]
tests/dev/test_gh_issue_rest.py::test_cli_view_plain_outputs_thread PASSED [ 14%]
tests/dev/test_gh_issue_rest.py::test_cli_thread_outputs_rest_fallback PASSED [ 15%]
tests/dev/test_gh_issue_rest.py::test_cli_view_json_without_comments_omits_thread PASSED [ 16%]
tests/dev/test_gh_issue_rest.py::test_cli_view_json_comments_returns_thread PASSED [ 17%]
tests/dev/test_gh_issue_rest.py::test_fetch_issue_maps_null_body_to_empty_string PASSED [ 18%]
tests/dev/test_gh_issue_rest.py::test_fetch_issue_fails_closed_when_gh_cli_missing PASSED [ 19%]
tests/dev/test_gh_issue_rest.py::test_cli_view_fails_closed_on_rest_error PASSED [ 20%]
tests/dev/test_gh_issue_rest.py::test_rest_paths_do_not_request_deprecated_project_cards_field PASSED [ 21%]
tests/dev/test_gh_issue_rest.py::test_cli_view_rejects_unknown_json_field PASSED [ 22%]
tests/dev/test_gh_issue_rest.py::test_fetch_comments_fails_closed_on_invalid_json PASSED [ 23%]
tests/dev/test_gh_issue_rest.py::test_fetch_comments_fails_closed_on_non_list_payload PASSED [ 24%]
tests/dev/test_gh_issue_rest.py::test_fetch_issue_with_comments_propagates_comments_error PASSED [ 25%]
tests/dev/test_check_pr_followups.py::test_analyze_body_passes_when_no_deferred_work_is_declared PASSED [ 26%]
tests/dev/test_check_pr_followups.py::test_body_quality_rejects_empty_body_for_substantive_historical_prs[files0] PASSED [ 27%]
tests/dev/test_check_pr_followups.py::test_body_quality_rejects_empty_body_for_substantive_historical_prs[files1] PASSED [ 28%]
tests/dev/test_check_pr_followups.py::test_body_quality_rejects_coderabbit_only_body_for_substantive_pr PASSED [ 29%]
tests/dev/test_check_pr_followups.py::test_body_quality_strips_whole_generated_blocks_before_accepting_human_text PASSED [ 30%]
tests/dev/test_check_pr_followups.py::test_body_quality_allows_docs_only_empty_body PASSED [ 31%]
tests/dev/test_check_pr_followups.py::test_body_quality_does_not_treat_path_lookalikes_as_template_only PASSED [ 32%]
tests/dev/test_check_pr_followups.py::test_body_quality_accepts_human_body_for_substantive_changes PASSED [ 33%]
tests/dev/test_check_pr_followups.py::test_domain_approval_not_required_for_na_or_docs_only_research_fields PASSED [ 34%]
tests/dev/test_check_pr_followups.py::test_domain_approval_not_required_allows_punctuated_opt_out_reasons[docs-only (support helper)-NA] PASSED [ 35%]
tests/dev/test_check_pr_followups.py::test_domain_approval_not_required_allows_punctuated_opt_out_reasons[na, support-only workflow-not applicable (workflow bugfix)] PASSED [ 36%]
tests/dev/test_check_pr_followups.py::test_domain_approval_required_for_non_na_research_fields PASSED [ 37%]
tests/dev/test_check_pr_followups.py::test_domain_approval_rejects_historical_evidence_sensitive_missing_contracts[3449-## Summary\nCloses #2916. Implements a bounded forecast-risk gate, evidence_tier: stress,\nclaim_boundary: diagnostic_only, not paper-grade.\n\n## Validation\nVerdict: continue.\n] PASSED [ 38%]
tests/dev/test_check_pr_followups.py::test_domain_approval_rejects_historical_evidence_sensitive_missing_contracts[3450-## Summary\nCloses #2546. A bounded diagnostic-only experiment testing ScenarioBelief uncertainty,\nevidence_tier: stress, claim_boundary: diagnostic_only, not paper-grade.\n\n## Validation\nFinding: continue.\n] PASSED [ 39%]
tests/dev/test_check_pr_followups.py::test_domain_approval_accepts_approved_review_source PASSED [ 40%]
tests/dev/test_check_pr_followups.py::test_domain_approval_accepts_required_for_pr_label PASSED [ 41%]
tests/dev/test_check_pr_followups.py::test_domain_approval_accepts_none_in_validity_checklist_field PASSED [ 42%]
tests/dev/test_check_pr_followups.py::test_domain_approval_accepts_explicit_maintainer_waiver PASSED [ 43%]
tests/dev/test_check_pr_followups.py::test_domain_approval_rejects_pending_or_placeholder_status PASSED [ 44%]
tests/dev/test_check_pr_followups.py::test_domain_approval_placeholder_message_names_concrete_domain_values PASSED [ 45%]
tests/dev/test_check_pr_followups.py::test_domain_approval_rejects_not_approved_status PASSED [ 46%]
tests/dev/test_check_pr_followups.py::test_domain_approval_requires_validity_checklist_fields PASSED [ 47%]
tests/dev/test_check_pr_followups.py::test_domain_approval_rejects_not_required_for_sensitive_result PASSED [ 48%]
tests/dev/test_check_pr_followups.py::test_domain_approval_accepts_docs_only_opt_out_for_freeform_prose_trigger PASSED [ 49%]
tests/dev/test_check_pr_followups.py::test_domain_approval_docs_only_opt_out_uses_default_template_values PASSED [ 50%]
tests/dev/test_check_pr_followups.py::test_domain_approval_docs_only_opt_out_requires_not_required_status PASSED [ 51%]
tests/dev/test_check_pr_followups.py::test_domain_approval_structured_declaration_cannot_use_docs_only_opt_out PASSED [ 52%]
tests/dev/test_check_pr_followups.py::test_domain_approval_required_value_does_not_treat_nominal_as_no PASSED [ 53%]
tests/dev/test_check_pr_followups.py::test_analyze_body_requires_issue_when_deferred_work_is_declared PASSED [ 54%]
tests/dev/test_check_pr_followups.py::test_analyze_body_accepts_linked_followup_issue PASSED [ 55%]
tests/dev/test_check_pr_followups.py::test_analyze_body_accepts_explicit_no_issue_reason PASSED [ 56%]
tests/dev/test_check_pr_followups.py::test_analyze_body_rejects_bare_no_followup_disposition[none] PASSED [ 57%]
tests/dev/test_check_pr_followups.py::test_analyze_body_rejects_bare_no_followup_disposition[no] PASSED [ 58%]
tests/dev/test_check_pr_followups.py::test_analyze_body_rejects_bare_no_followup_disposition[NA] PASSED [ 59%]
tests/dev/test_check_pr_followups.py::test_analyze_body_rejects_bare_no_followup_disposition[not applicable] PASSED [ 60%]
tests/dev/test_check_pr_followups.py::test_analyze_body_detects_residual_scope_outside_followup_section PASSED [ 61%]
tests/dev/test_check_pr_followups.py::test_analyze_body_allows_residual_scope_with_linked_followup_issue PASSED [ 62%]
tests/dev/test_check_pr_followups.py::test_analyze_body_allows_residual_scope_with_explicit_maintainer_waiver PASSED [ 63%]
tests/dev/test_check_pr_followups.py::test_analyze_body_rejects_closed_followup_issue PASSED [ 64%]
tests/dev/test_check_pr_followups.py::test_analyze_body_rejects_unverifiable_issue_when_rest_fails PASSED [ 65%]
tests/dev/test_check_pr_followups.py::test_analyze_body_collects_multiline_deferred_work PASSED [ 66%]
tests/dev/test_check_pr_followups.py::test_cli_reads_github_pull_request_event PASSED [ 67%]
tests/dev/test_check_pr_followups.py::test_cli_fails_for_deferred_work_without_disposition PASSED [ 68%]
tests/dev/test_check_pr_followups.py::test_cli_rejects_empty_substantive_pr_body_from_event PASSED [ 69%]
tests/dev/test_check_pr_followups.py::test_cli_event_body_overrides_inherited_pr_ready_body_file PASSED [ 70%]
tests/dev/test_check_pr_followups.py::test_cli_accepts_well_formed_substantive_pr_body_with_changed_files PASSED [ 71%]
tests/dev/test_check_pr_followups.py::test_cli_fails_for_sensitive_pr_without_domain_approval PASSED [ 72%]
tests/dev/test_check_pr_followups.py::test_cli_require_body_fails_closed_without_pr_body_source PASSED [ 73%]
tests/dev/test_check_pr_followups.py::test_domain_approval_ignores_negated_evidence_marker PASSED [ 74%]
tests/dev/test_check_pr_followups.py::test_domain_approval_triggers_on_affirmative_evidence_marker PASSED [ 75%]
tests/dev/test_check_pr_followups.py::test_analyze_body_ok_without_section_when_no_residual_scope PASSED [ 76%]
tests/dev/test_check_pr_followups.py::test_analyze_body_requires_section_when_closing_with_residual_scope PASSED [ 77%]
tests/dev/test_check_pr_followups.py::test_cli_advisory_downgrades_failure_to_warning PASSED [ 78%]
tests/dev/test_closed_state_label_hygiene.py::test_collect_stale_issues_aggregates_closed_issue_state_labels PASSED [ 79%]
tests/dev/test_closed_state_label_hygiene.py::test_collect_stale_issues_ignores_pull_request_rows PASSED [ 80%]
tests/dev/test_closed_state_label_hygiene.py::test_is_pull_request_url_requires_canonical_pull_path[https://github.com/ll7/robot_sf_ll7/pull/12-True] PASSED [ 81%]
tests/dev/test_closed_state_label_hygiene.py::test_is_pull_request_url_requires_canonical_pull_path[https://github.com/ll7/robot_sf_ll7/issues/12?next=/pull/12-False] PASSED [ 82%]
tests/dev/test_closed_state_label_hygiene.py::test_is_pull_request_url_requires_canonical_pull_path[https://github.com/ll7/robot_sf_ll7/issues/pull-False] PASSED [ 83%]
tests/dev/test_closed_state_label_hygiene.py::test_is_pull_request_url_requires_canonical_pull_path[https://github.com/ll7/robot_sf_ll7/pull/not-a-number-False] PASSED [ 84%]
tests/dev/test_closed_state_label_hygiene.py::test_is_pull_request_url_requires_canonical_pull_path[https://github.com/ll7/robot_sf_ll7/pulls/12-False] PASSED [ 85%]
tests/dev/test_closed_state_label_hygiene.py::test_is_pull_request_url_requires_canonical_pull_path[None-False] PASSED [ 86%]
tests/dev/test_closed_state_label_hygiene.py::test_build_report_emits_machine_readable_failure_summary PASSED [ 87%]
tests/dev/test_closed_state_label_hygiene.py::test_build_search_command_uses_read_only_closed_issue_search PASSED [ 88%]
tests/dev/test_closed_state_label_hygiene.py::test_main_returns_nonzero_json_summary_without_live_github PASSED [ 89%]
tests/dev/test_closed_state_label_hygiene.py::test_run_search_command_reports_missing_gh PASSED [ 90%]
tests/dev/test_closed_state_label_hygiene.py::test_run_search_command_preserves_captured_stderr PASSED [ 91%]
tests/dev/test_closed_state_label_hygiene.py::test_run_search_command_reports_invalid_json PASSED [ 92%]
tests/dev/test_closed_state_label_hygiene.py::test_fix_stale_issues_removes_only_live_state_labels_from_closed_issues PASSED [ 93%]
tests/dev/test_closed_state_label_hygiene.py::test_fix_stale_issues_does_not_touch_issue_that_is_not_closed PASSED [ 94%]
tests/dev/test_closed_state_label_hygiene.py::test_fix_stale_issues_is_a_no_op_when_there_are_no_stale_issues PASSED [ 95%]
tests/dev/test_closed_state_label_hygiene.py::test_fix_stale_issues_only_removes_documented_label_set PASSED [ 96%]
tests/dev/test_closed_state_label_hygiene.py::test_confirm_issue_closed_reads_state_via_rest PASSED [ 97%]
tests/dev/test_closed_state_label_hygiene.py::test_confirm_issue_closed_is_false_for_open_or_pr PASSED [ 98%]
tests/dev/test_closed_state_label_hygiene.py::test_remove_label_command_targets_only_one_label PASSED [ 99%]
tests/dev/test_closed_state_label_hygiene.py::test_main_fix_mode_strips_labels_and_reports PASSED [100%]

============================= slowest 10 durations =============================
0.06s call     tests/dev/test_check_pr_followups.py::test_cli_advisory_downgrades_failure_to_warning
0.04s call     tests/dev/test_check_pr_followups.py::test_cli_reads_github_pull_request_event
0.04s call     tests/dev/test_check_pr_followups.py::test_cli_require_body_fails_closed_without_pr_body_source
0.03s call     tests/dev/test_check_pr_followups.py::test_cli_rejects_empty_substantive_pr_body_from_event
0.03s call     tests/dev/test_check_pr_followups.py::test_cli_event_body_overrides_inherited_pr_ready_body_file
0.03s call     tests/dev/test_check_pr_followups.py::test_cli_accepts_well_formed_substantive_pr_body_with_changed_files
0.03s call     tests/dev/test_check_pr_followups.py::test_cli_fails_for_sensitive_pr_without_domain_approval
0.03s call     tests/dev/test_check_pr_followups.py::test_cli_fails_for_deferred_work_without_disposition

(2 durations < 0.005s hidden.  Use -vv to show these durations.)

Slow Test Report (soft<20s hard=60s, top 10)
1) tests/dev/test_check_pr_followups.py::test_cli_advisory_downgrades_failure_to_warning  0.06s
2) tests/dev/test_check_pr_followups.py::test_cli_reads_github_pull_request_event  0.04s
3) tests/dev/test_check_pr_followups.py::test_cli_require_body_fails_closed_without_pr_body_source  0.04s
4) tests/dev/test_check_pr_followups.py::test_cli_rejects_empty_substantive_pr_body_from_event  0.03s
5) tests/dev/test_check_pr_followups.py::test_cli_event_body_overrides_inherited_pr_ready_body_file  0.03s
6) tests/dev/test_check_pr_followups.py::test_cli_accepts_well_formed_substantive_pr_body_with_changed_files  0.03s
7) tests/dev/test_check_pr_followups.py::test_cli_fails_for_sensitive_pr_without_domain_approval  0.03s
8) tests/dev/test_check_pr_followups.py::test_cli_fails_for_deferred_work_without_disposition  0.03s
9) tests/dev/test_gh_issue_rest.py::test_cli_view_plain_outputs_thread  0.00s
10) tests/dev/test_gh_issue_rest.py::test_cli_view_json_without_comments_omits_thread  0.00s

============================= 101 passed in 0.42s ==============================

Closes #5269

---

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Issue-state checks now use a more reliable REST-based verification method.
  * Follow-up issue validation provides clearer errors for unavailable issues, invalid references, and non-open states.
  * Closed-state label checks continue to protect against updating open issues or pull requests incorrectly.
  * Command-line help text now accurately describes the issue verification process.

* **Tests**
  * Updated validation coverage for closed, open, invalid, and unavailable issue scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->