### PR TITLE
Issue #5340: document CI regression resolution (cheap-lane worker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **issue #5340 main CI regression from unconditional `spaces.Sequence` leaf.** PRs #5335
+  and #5337 unconditionally added `spaces.Sequence` leaves to the SocNav structured observation
+  space, breaking `asymmetric_critic` (`Box` leaves) and `FlattenDictObservationWrapper`. Reverted
+  in PR #5339 to restore `Box`-only observation consumers. Reverted PRs may be relanded with a
+  guarded registration path later.
+
 * **issue #5217 restore typical pedestrian desired-speed propagation.** `SimulationSettings`
   with `ped_speed_tier="typical"` (or explicit `desired_speed_mean`) now correctly sets
   `pysf_sim.peds.max_speeds` to the decoupled desired-speed distribution (~1.3 m/s for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **issue #5340 main CI regression from unconditional `spaces.Sequence` leaf.** PRs #5335
   and #5337 unconditionally added `spaces.Sequence` leaves to the SocNav structured observation
   space, breaking `asymmetric_critic` (`Box` leaves) and `FlattenDictObservationWrapper`. Reverted
-  in PR #5339 to restore `Box`-only observation consumers. Reverted PRs may be relanded with a
+  in PR #5339 to restore `Box`-only observation spaces for consumers. Reverted PRs may be relanded with a
   guarded registration path later.
 
 * **issue #5217 restore typical pedestrian desired-speed propagation.** `SimulationSettings`

--- a/docs/context/evidence/issue_5331_dwa_global_route_probe_2026-07-11/README.md
+++ b/docs/context/evidence/issue_5331_dwa_global_route_probe_2026-07-11/README.md
@@ -22,9 +22,10 @@ The global-route integration probe adds a waypoint-following bias to the DWA
 scoring function. When `global_route_probe_enabled=true` and `route_waypoints`
 are present in the observation, the probe:
 
-1. Finds the nearest usable waypoint within `global_route_probe_waypoint_distance`
-   and advances to the next route waypoint when one is available
-2. Computes heading alignment from the rollout endpoint to that forward waypoint
+1. Finds the nearest waypoint within `global_route_probe_waypoint_distance` to
+   establish that the route is locally usable
+2. Targets the following waypoint when one is available, then computes heading
+   alignment from the rollout endpoint to that forward route target
 3. Adds `global_route_probe_heading_weight * waypoint_score` to the base DWA score
 
 This helps DWA navigate through bottleneck corridors where the constant-velocity

--- a/docs/context/evidence/issue_5331_dwa_global_route_probe_2026-07-11/README.md
+++ b/docs/context/evidence/issue_5331_dwa_global_route_probe_2026-07-11/README.md
@@ -22,10 +22,9 @@ The global-route integration probe adds a waypoint-following bias to the DWA
 scoring function. When `global_route_probe_enabled=true` and `route_waypoints`
 are present in the observation, the probe:
 
-1. Finds the nearest waypoint within `global_route_probe_waypoint_distance` to
-   establish that the route is locally usable
-2. Targets the following waypoint when one is available, then computes heading
-   alignment from the rollout endpoint to that forward route target
+1. Finds the nearest usable waypoint within `global_route_probe_waypoint_distance`
+   and advances to the next route waypoint when one is available
+2. Computes heading alignment from the rollout endpoint to that forward waypoint
 3. Adds `global_route_probe_heading_weight * waypoint_score` to the base DWA score
 
 This helps DWA navigate through bottleneck corridors where the constant-velocity


### PR DESCRIPTION
## What / Why

Issue #5340 was P0: main CI went red after PRs #5335 and #5337 unconditionally added
`spaces.Sequence` leaves to the SocNav structured observation space, breaking
`asymmetric_critic` (`Box` leaves expected) and `FlattenDictObservationWrapper`.

The revert landed in PR #5339 (`56dcf9c35`) and CI run [29169543266](https://github.com/ll7/robot_sf_ll7/actions/runs/29169543266)
is green. Two targeted tests verified locally:

```
tests/test_socnav_env_integration.py::test_socnav_structured_observation_can_expose_critic_privileged_state PASSED
tests/test_socnav_env_integration.py::test_socnav_structured_observation_can_expose_critic_privileged_state_via_factory PASSED
```

This PR adds a CHANGELOG entry documenting the regression and its resolution by
the revert. No runtime code changes — merging this PR will trigger the second
consecutive main CI run required by the original issue criterion.

## Validation

- Local CPU test of `test_socnav_structured_observation_can_expose_critic_privileged_state`: **passed**
- Local CPU test of `test_socnav_structured_observation_can_expose_critic_privileged_state_via_factory`: **passed**
- Only file changed: `CHANGELOG.md` (6 lines added)

## Successor Statement

This PR follows PR #5339 (revert), which fixed the breaking changes from #5335 and #5337.
No further code capability is needed.

Refs #5340 — the gate will close it only after the post-merge main CI run passes.

---

This PR was produced by the SAIA/Qwen3.6-27B cheap implementation lane; the review gate hardens and merges.
