### PR TITLE
Issue #5188: drop-in wrapper for projectCards-safe issue reads (cheap-lane worker)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -487,11 +487,13 @@ not promoted into durable benchmark or paper-facing claims.
 
 `gh issue view <number> --comments` can fail on some GitHub CLI versions with a
 `repository.issue.projectCards` GraphQL deprecation error. Use the targeted REST
-fallback instead (see issue #5186):
+fallback (see issues #5186 and #5188):
 
 ```bash
-# Drop-in for `gh issue view <number> --comments`: native CLI first, REST fallback
-# only for the known projectCards GraphQL error.
+# Drop-in shell wrapper (tries native CLI first, falls back to REST on projectCards):
+bash scripts/dev/gh_issue_view.sh <number> --repo ll7/robot_sf_ll7
+
+# Direct REST helper (same fallback logic, more options):
 uv run python scripts/dev/gh_issue_rest.py thread <number> --repo ll7/robot_sf_ll7
 
 # Explicit REST read with normalized fields (stable JSON output shape):

--- a/scripts/dev/gh_issue_view.sh
+++ b/scripts/dev/gh_issue_view.sh
@@ -40,5 +40,9 @@ done
 
 [[ -n "$NUMBER" ]] || usage
 
-exec uv run python "${SCRIPT_DIR}/gh_issue_rest.py" thread "$NUMBER" \
-  ${REPO:+--repo "$REPO"}
+ARGS=()
+if [[ -n "$REPO" ]]; then
+  ARGS+=("--repo" "$REPO")
+fi
+
+exec uv run python "${SCRIPT_DIR}/gh_issue_rest.py" thread "$NUMBER" "${ARGS[@]}"

--- a/scripts/dev/gh_issue_view.sh
+++ b/scripts/dev/gh_issue_view.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Drop-in for `gh issue view` that transparently bypasses the deprecated
+# repository.issue.projectCards GraphQL field (issue #5188).
+#
+# Usage:
+#     scripts/dev/gh_issue_view.sh <number> [--repo OWNER/REPO]
+#
+# Delegates to `gh_issue_rest.py thread`, which tries native `gh issue view`
+# first and falls back to paginated REST only when the projectCards error occurs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  echo "Usage: $0 <number> [--repo OWNER/REPO]" >&2
+  exit 2
+}
+
+REPO=""
+NUMBER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || usage
+      REPO="$2"
+      shift 2
+      ;;
+    -*)
+      echo "Unexpected option: $1" >&2
+      usage
+      ;;
+    *)
+      [[ -z "$NUMBER" ]] || usage
+      NUMBER="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$NUMBER" ]] || usage
+
+exec uv run python "${SCRIPT_DIR}/gh_issue_rest.py" thread "$NUMBER" \
+  ${REPO:+--repo "$REPO"}

--- a/tests/dev/test_gh_issue_view.sh
+++ b/tests/dev/test_gh_issue_view.sh
@@ -5,6 +5,20 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PASS=0
 FAIL=0
+MOCK_DIR="$(mktemp -d)"
+trap 'rm -rf "$MOCK_DIR"' EXIT
+MOCK_ARGS_FILE="${MOCK_DIR}/args"
+export MOCK_ARGS_FILE
+
+# Keep this test offline: the wrapper's Python helper invokes ``gh`` to read an
+# issue, so a local successful native response exercises the full delegation
+# path without depending on GitHub availability or credentials.
+cat > "${MOCK_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${MOCK_ARGS_FILE}"
+printf 'title:\trestore live issue reads\nstate:\tOPEN\nurl:\thttps://example.test/issues/5188\n--\nmock body\n'
+EOF
+chmod +x "${MOCK_DIR}/gh"
 
 assert_ok() {
   local desc="$1" output="$2"
@@ -29,8 +43,17 @@ assert_fail() {
 }
 
 # 1. Basic usage prints issue content
-OUT=$(bash "${REPO_ROOT}/scripts/dev/gh_issue_view.sh" 5188 --repo ll7/robot_sf_ll7 2>/dev/null)
+OUT=$(PATH="${MOCK_DIR}:$PATH" bash "${REPO_ROOT}/scripts/dev/gh_issue_view.sh" 5188 \
+  --repo 'll7/robot sf' 2>/dev/null)
 assert_ok "reads issue body" "$OUT"
+
+if grep -Fxq 'll7/robot sf' "${MOCK_ARGS_FILE}"; then
+  echo "PASS: repo argument remains one value"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: repo argument was split or missing"
+  FAIL=$((FAIL + 1))
+fi
 
 # 2. Output contains expected title fragment
 if echo "$OUT" | grep -q "restore live issue reads"; then

--- a/tests/dev/test_gh_issue_view.sh
+++ b/tests/dev/test_gh_issue_view.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Smoke tests for scripts/dev/gh_issue_view.sh (issue #5188).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PASS=0
+FAIL=0
+
+assert_ok() {
+  local desc="$1" output="$2"
+  if [[ -n "$output" ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (empty output)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fail() {
+  local desc="$1" rc="$2"
+  if [[ $rc -ne 0 ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc (expected nonzero exit)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# 1. Basic usage prints issue content
+OUT=$(bash "${REPO_ROOT}/scripts/dev/gh_issue_view.sh" 5188 --repo ll7/robot_sf_ll7 2>/dev/null)
+assert_ok "reads issue body" "$OUT"
+
+# 2. Output contains expected title fragment
+if echo "$OUT" | grep -q "restore live issue reads"; then
+  echo "PASS: output contains issue title"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: output missing issue title"
+  FAIL=$((FAIL + 1))
+fi
+
+# 3. Unknown flag should fail with nonzero exit
+RC=0
+bash "${REPO_ROOT}/scripts/dev/gh_issue_view.sh" 5188 --bad-flag 2>/dev/null || RC=$?
+assert_fail "unknown flag rejected" "$RC"
+
+# 4. Missing number should fail
+RC=0
+bash "${REPO_ROOT}/scripts/dev/gh_issue_view.sh" 2>/dev/null || RC=$?
+assert_fail "missing number rejected" "$RC"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## What / Why

`gh issue view <number> --comments` fails on GitHub CLI 2.45.0 because it queries the deprecated `repository.issue.projectCards` GraphQL field. The REST fallback (`gh_issue_rest.py thread`) already handles this, but there was no convenient drop-in command for the common case.

**Changes:**

- **scripts/dev/gh_issue_view.sh** — new drop-in wrapper that delegates to `gh_issue_rest.py thread`. It accepts `<number> [--repo OWNER/REPO]` and transparently returns the issue thread via REST when the native CLI hits the projectCards error.

- **tests/dev/test_gh_issue_view.sh** — offline smoke tests that mock `gh`, verify the wrapper reads the delegated response, preserves a space-containing `--repo` argument as one value, and rejects bad arguments.

- **docs/dev_guide.md** — updated Issue-reading fallback section to surface the wrapper as the primary command, with `gh_issue_rest.py thread` and `view` as alternatives.

## Validation

```
$ bash tests/dev/test_gh_issue_view.sh
PASS: reads issue body
PASS: repo argument remains one value
PASS: output contains issue title
PASS: unknown flag rejected
PASS: missing number rejected
Results: 5 passed, 0 failed

$ uv run pytest tests/dev/test_gh_issue_rest.py -q
26 passed

$ uv run ruff check scripts/dev/gh_issue_rest.py
All checks passed!
```

Closes #5188

## Successor Statement

This successor slice does not duplicate the existing REST helper: it adds the documented, drop-in shell command and offline contract coverage requested by #5188.

This PR was produced by the SAIA/Qwen3.6-27B cheap implementation lane; the review gate hardens and merges.
