### PR TITLE
Issue #5344: add --comments flag to gh_issue_view.sh (cheap-lane worker)

### DIFF
--- a/scripts/dev/gh_issue_view.sh
+++ b/scripts/dev/gh_issue_view.sh
@@ -3,21 +3,26 @@
 # repository.issue.projectCards GraphQL field (issue #5188).
 #
 # Usage:
-#     scripts/dev/gh_issue_view.sh <number> [--repo OWNER/REPO]
+#     scripts/dev/gh_issue_view.sh <number> [--repo OWNER/REPO] [--comments]
 #
-# Delegates to `gh_issue_rest.py thread`, which tries native `gh issue view`
-# first and falls back to paginated REST only when the projectCards error occurs.
+# Without --comments, delegates to `gh_issue_rest.py thread`, which tries native
+# `gh issue view` first and falls back to paginated REST only when the
+# projectCards error occurs.
+#
+# With --comments, delegates to `gh_issue_rest.py view --plain --comments`
+# which always uses the REST fallback to include comments in the output.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
-  echo "Usage: $0 <number> [--repo OWNER/REPO]" >&2
+  echo "Usage: $0 <number> [--repo OWNER/REPO] [--comments]" >&2
   exit 2
 }
 
 REPO=""
 NUMBER=""
+COMMENTS=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -25,6 +30,10 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 ]] || usage
       REPO="$2"
       shift 2
+      ;;
+    --comments)
+      COMMENTS=true
+      shift
       ;;
     -*)
       echo "Unexpected option: $1" >&2
@@ -45,4 +54,8 @@ if [[ -n "$REPO" ]]; then
   ARGS+=("--repo" "$REPO")
 fi
 
-exec uv run python "${SCRIPT_DIR}/gh_issue_rest.py" thread "$NUMBER" "${ARGS[@]}"
+if [[ "$COMMENTS" == "true" ]]; then
+  exec uv run python "${SCRIPT_DIR}/gh_issue_rest.py" view "$NUMBER" --plain --comments "${ARGS[@]}"
+else
+  exec uv run python "${SCRIPT_DIR}/gh_issue_rest.py" thread "$NUMBER" "${ARGS[@]}"
+fi


### PR DESCRIPTION
## What / Why

Add `--comments` flag to `scripts/dev/gh_issue_view.sh` so callers can retrieve
every issue comment through the REST fallback wrapper. Without the flag the
behavior is unchanged (native-first `thread` command). With `--comments` the
script delegates to the REST-backed `view --plain --comments` subcommand.

## Validation

```text
$ uv run pytest tests/dev/test_gh_issue_rest.py -v
26 passed in 0.06s
```

No additional Python tests needed: the shell wrapper change delegates to the
already-tested `gh_issue_rest.py view --plain --comments` path.

## Commit

- `47d78ef35` — feat: add --comments flag to gh_issue_view.sh wrapper

Closes #5344

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation
lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `--comments` flag to issue viewing, allowing comments to be included in the displayed issue details.
  * Updated command help and usage guidance to document the new option.
* **Bug Fixes**
  * Preserved the existing issue thread display behavior when the flag is not used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->