### PR TITLE
release: single-source package version from git tags + alignment check (kills version drift)

### DIFF
--- a/.github/actions/setup-ci-python/action.yml
+++ b/.github/actions/setup-ci-python/action.yml
@@ -7,7 +7,10 @@ inputs:
     default: "3.12"
   uv-version:
     description: uv version passed to astral-sh/setup-uv.
-    default: "0.5.11"
+    # Dynamic PEP 621 versions produce a root lock entry without a static
+    # version. uv 0.5.11 cannot parse that valid format; keep CI on the
+    # lockfile-compatible version used to generate and validate uv.lock.
+    default: "0.11.21"
   migrate-artifacts:
     description: Run the legacy artifact migration step after dependency sync.
     default: "true"

--- a/.github/workflows/release-functional-badge.yml
+++ b/.github/workflows/release-functional-badge.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history + tags so hatch-vcs can derive the version from the tag
+          # and check_version_alignment.py can see the full release-tag set.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -33,6 +37,13 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --all-extras
+
+      - name: Verify version alignment (git tag is single source of truth)
+        run: |
+          # On a tag push the package is installed at the tagged commit, so its
+          # hatch-vcs-derived version must match the tag, and CITATION.cff must
+          # match the latest full release tag. Kills version drift at release.
+          uv run python scripts/dev/check_version_alignment.py
 
       - name: Verify claimed level and run smoke test
         run: |

--- a/.github/workflows/release-functional-badge.yml
+++ b/.github/workflows/release-functional-badge.yml
@@ -3,6 +3,7 @@ name: Release Functional Badge Verification
 on:
   push:
     tags:
+      - '[0-9]*'
       - 'v*'
       - 'rc*'
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ third_party/external_repos/
 
 # Cmake
 third_party/python-rvo2/.*
+
+# hatch-vcs build-time generated version file (single-source version from git tag)
+robot_sf/_version.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* **Single-source package version from the git tag (kills version drift).** `pyproject.toml` no longer hardcodes a version; the package version is derived automatically from the git tag/release line via `hatch-vcs` (release tags `X.Y.Z`, release-candidate tags `rcX.Y.Z`, PEP 440 dev fallback `0.0.3.dev0` for untagged builds). `robot_sf.__version__` now resolves from the build-time `_version.py` (or installed metadata). `CITATION.cff` is aligned to the latest full release tag (`0.0.2`). A new `scripts/dev/check_version_alignment.py` guards the three version axes; it runs gating on tag pushes (`release-functional-badge` workflow) and advisory on every CI run (`ci_driver.sh` lint phase). Previously the three axes had drifted: tag `rc0.0.3`, `pyproject` `2.0.0`, `CITATION` `benchmark-protocol-0.1.0`.
+
 * **issue #5228 xdist memory-diagnostic robustness.** Three residual gaps from the
   PR #4952 review are closed: (1) `_tree_rss_gb` no longer calls `is_running()` before
   `memory_info()` — the latter already supplies the handled `NoSuchProcess` signal,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,11 @@ authors:
   - name: Lennart Luttkus
 repository-code: https://github.com/ll7/robot_sf_ll7
 license: MIT
-version: benchmark-protocol-0.1.0
+# Kept in lockstep with the latest full release tag (plain X.Y.Z) by the
+# release workflow and scripts/dev/check_version_alignment.py. The git
+# tag/release line is the single source of truth for the version; the
+# benchmark release protocol context lives in the title/abstract, not here.
+version: 0.0.2
 date-released: 2026-03-26
 abstract: >-
   Social navigation simulation and benchmark tooling with a paper-facing,

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -51,8 +51,30 @@ Upload the generated bundle using:
 
 - `docs/benchmark_camera_ready_release.md`
 
+## Version Alignment (single source of truth: the git tag)
+
+The package version is derived automatically from the git tag by `hatch-vcs`
+(release tags are plain `X.Y.Z`, e.g. `0.0.2`; release-candidate tags are
+`rcX.Y.Z`, e.g. `rc0.0.3`). Do not hardcode a version in `pyproject.toml`.
+
+When cutting a **full release** `X.Y.Z`:
+
+- bump `CITATION.cff` `version:` to the new `X.Y.Z` (it tracks the latest full
+  release tag; the benchmark release-protocol context stays in the title/abstract)
+- run the alignment guard locally before tagging:
+
+  ```bash
+  uv run python scripts/dev/check_version_alignment.py
+  ```
+
+- push the tag; the `release-functional-badge` workflow re-runs this guard
+  (gating) so `pyproject`, the built package, and `CITATION.cff` cannot drift
+
+The guard also runs advisory (non-gating) on every CI run via the `lint` phase
+of `scripts/dev/ci_driver.sh`.
+
 ## Archive and Citation
 
-- ensure `CITATION.cff` remains current
+- ensure `CITATION.cff` remains current (aligned to the latest full release tag)
 - keep the release tag and release asset URL stable
 - replace DOI placeholder only when a real DOI exists

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 [project]
 name = "robot_sf"
-version = "2.0.0"
+# Version is derived automatically from the git tag by hatch-vcs (see
+# [tool.hatch.version] below). Do NOT hardcode a version here: the git
+# tag/release line is the single source of truth. External evidence
+# provenance pins resolve by these tags, so the tag line must never be
+# renumbered. scripts/dev/check_version_alignment.py guards against drift.
+dynamic = ["version"]
 description = """
 This package allows implementing a "gymnasium-style" environment
 for navigating a crowd with autonomous micromobility vehicles
@@ -97,8 +102,26 @@ criticality = [
 ]
 
 [build-system]
-requires = ["hatchling", "Cython>=3.0.0"]
+requires = ["hatchling", "hatch-vcs>=0.4.0", "Cython>=3.0.0"]
 build-backend = "hatchling.build"
+
+# --- Single-source version: git tag -> package version (hatch-vcs) ---------
+# The git tag/release line is the canonical version source. Release tags are
+# plain "X.Y.Z" (e.g. 0.0.2) and release-candidate tags are "rcX.Y.Z"
+# (e.g. rc0.0.3); tag_regex maps both to the numeric X.Y.Z. For non-tag builds
+# (sdists, untagged CI checkouts) hatch-vcs derives a PEP 440 dev version and
+# falls back to fallback_version so builds never break.
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+tag_regex = "^(?:[\\w.-]*?)(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
+fallback_version = "0.0.3.dev0"
+
+[tool.hatch.build.hooks.vcs]
+# Build hook writes the resolved version to an importable module so
+# `robot_sf.__version__` works from installed wheels and editable installs.
+version-file = "robot_sf/_version.py"
 
 [tool.hatchling.build.targets.wheel]
 packages = [

--- a/robot_sf/__init__.py
+++ b/robot_sf/__init__.py
@@ -5,6 +5,21 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+try:
+    # Written at build time by hatch-vcs (see [tool.hatch.build.hooks.vcs] in
+    # pyproject.toml). Present in built wheels and editable installs.
+    from ._version import __version__
+except ImportError:  # pragma: no cover - source checkout without a build
+    # Fall back to installed package metadata (importlib.metadata is stdlib on
+    # the supported Python >=3.11, so its import needs no guard).
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    try:
+        __version__ = _pkg_version("robot_sf")
+    except PackageNotFoundError:
+        __version__ = "0.0.0+unknown"
+
 if TYPE_CHECKING:  # pragma: no cover - static type information only
     from . import telemetry
     from .telemetry import ManifestWriter, RunRegistry, RunTrackerConfig, generate_run_id
@@ -17,7 +32,9 @@ __all__ = [
     "telemetry",
 ]
 
-_TELEMETRY_EXPORTS = frozenset(__all__[:-1])
+# __version__ (assigned above) is intentionally a plain module attribute, not an
+# ``__all__`` export, so the telemetry export contract stays unchanged.
+_TELEMETRY_EXPORTS = frozenset(__all__) - {"telemetry"}
 
 
 def __getattr__(name: str) -> Any:

--- a/scripts/dev/check_version_alignment.py
+++ b/scripts/dev/check_version_alignment.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Guard against version drift by making the git tag the single source of truth.
+
+Three version axes historically drifted apart in this repository:
+
+* the git tag / release line (canonical: external evidence provenance pins
+  resolve by these tags, so the tag line must never be renumbered),
+* the packaged version in ``pyproject.toml`` (now derived from the tag by
+  hatch-vcs, no longer hardcoded),
+* ``CITATION.cff`` (now kept in lockstep with the latest full release tag).
+
+This checker verifies that, when HEAD is on a version tag, the built/installed
+package version derives from that tag, and that ``CITATION.cff`` matches the
+latest full release tag. It is wired into the release workflow (gating) and
+into ``scripts/dev/ci_driver.sh`` (advisory).
+
+Release-line tag convention:
+
+* full release tags are plain ``X.Y.Z`` (e.g. ``0.0.2``) or ``vX.Y.Z``,
+* release-candidate tags are ``rcX.Y.Z`` (e.g. ``rc0.0.3``); both map to the
+  numeric ``X.Y.Z`` for package-version derivation, but only full releases set
+  ``CITATION.cff``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CITATION = REPO_ROOT / "CITATION.cff"
+
+# Release-line version tags only: plain X.Y.Z, vX.Y.Z, or rcX.Y.Z. This is
+# deliberately stricter than the hatch-vcs tag_regex so that unrelated tags
+# (artifact/*, camera-ready-*, ...) are not misread as release versions.
+_VERSION_TAG_RE = re.compile(r"^(?:rc|v)?(?P<num>\d+\.\d+\.\d+)$")
+_BASE_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
+
+
+def numeric_version_from_tag(tag: str) -> str | None:
+    """Return the numeric ``X.Y.Z`` for a release-line tag, else ``None``.
+
+    Examples: ``0.0.2`` -> ``0.0.2``, ``rc0.0.3`` -> ``0.0.3``,
+    ``v1.2.3`` -> ``1.2.3``, ``artifact/foo`` -> ``None``.
+
+    Returns:
+        The numeric version string, or ``None`` when ``tag`` is not a
+        release-line version tag.
+    """
+    match = _VERSION_TAG_RE.match(tag.strip())
+    return match.group("num") if match else None
+
+
+def is_release_candidate(tag: str) -> bool:
+    """Return ``True`` for release-candidate tags (``rcX.Y.Z``).
+
+    Returns:
+        Whether the tag denotes a release candidate rather than a full release.
+    """
+    return tag.strip().startswith("rc")
+
+
+def base_version(version: str) -> str:
+    """Return the ``X.Y.Z`` release component of a (possibly dev) version.
+
+    ``0.0.3.dev4+g1234`` -> ``0.0.3``; ``0.0.2`` -> ``0.0.2``.
+
+    Returns:
+        The leading numeric release component, or ``version`` unchanged when it
+        does not start with an ``X.Y.Z`` triple.
+    """
+    match = _BASE_VERSION_RE.match(version.strip())
+    return match.group(1) if match else version.strip()
+
+
+def full_release_tags(all_tags: list[str]) -> list[str]:
+    """Return the subset of tags that are full releases (not candidates).
+
+    Returns:
+        Tags matching the release-line convention with the ``rc`` prefix
+        excluded.
+    """
+    return [
+        tag for tag in all_tags if numeric_version_from_tag(tag) and not is_release_candidate(tag)
+    ]
+
+
+def latest_release_tag(all_tags: list[str]) -> str | None:
+    """Return the highest full release tag by numeric version, else ``None``.
+
+    Returns:
+        The full release tag with the greatest ``X.Y.Z`` value, or ``None`` when
+        no full release tag exists.
+    """
+    releases = full_release_tags(all_tags)
+    if not releases:
+        return None
+
+    def sort_key(tag: str) -> tuple[int, ...]:
+        num = numeric_version_from_tag(tag) or "0.0.0"
+        return tuple(int(part) for part in num.split("."))
+
+    return max(releases, key=sort_key)
+
+
+def evaluate(
+    head_tags: list[str],
+    all_tags: list[str],
+    package_version: str | None,
+    citation_version: str,
+) -> list[str]:
+    """Return a list of alignment problems (empty means aligned).
+
+    Args:
+        head_tags: Tags pointing at the current HEAD commit.
+        all_tags: All tags in the repository.
+        package_version: The built/installed package version, or ``None`` when
+            the package is not installed.
+        citation_version: The ``version:`` field from ``CITATION.cff``.
+
+    Returns:
+        Human-readable problem strings; an empty list means everything aligns.
+    """
+    problems: list[str] = []
+
+    head_version_tags = {
+        numeric_version_from_tag(tag) for tag in head_tags if numeric_version_from_tag(tag)
+    }
+    if head_version_tags:
+        if package_version is None:
+            problems.append(
+                "HEAD is on release tag(s) "
+                f"{sorted(head_version_tags)} but robot_sf is not installed, so "
+                "the tag-derived package version cannot be verified"
+            )
+        else:
+            derived = base_version(package_version)
+            if derived not in head_version_tags:
+                problems.append(
+                    f"package version {package_version!r} (base {derived}) does "
+                    f"not derive from HEAD release tag(s) {sorted(head_version_tags)}"
+                )
+
+    latest = latest_release_tag(all_tags)
+    if latest is None:
+        problems.append("no full release tag (X.Y.Z) found to align CITATION.cff against")
+    else:
+        latest_num = numeric_version_from_tag(latest)
+        if base_version(citation_version) != latest_num:
+            problems.append(
+                f"CITATION.cff version {citation_version!r} does not match the "
+                f"latest full release tag {latest!r} ({latest_num})"
+            )
+
+    return problems
+
+
+def _git(args: list[str]) -> list[str]:
+    """Run a git command in the repo and return non-empty output lines.
+
+    Returns:
+        The command's stdout split into stripped, non-empty lines (empty on
+        failure).
+    """
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def git_tags_at_head() -> list[str]:
+    """Return tags pointing at the current HEAD.
+
+    Returns:
+        Tag names on HEAD, or an empty list when none/unavailable.
+    """
+    return _git(["tag", "--points-at", "HEAD"])
+
+
+def git_all_tags() -> list[str]:
+    """Return all tags in the repository.
+
+    Returns:
+        All tag names, or an empty list when unavailable.
+    """
+    return _git(["tag"])
+
+
+def installed_package_version() -> str | None:
+    """Return the installed ``robot_sf`` version, or ``None`` if not installed.
+
+    Returns:
+        The version string reported by installed package metadata, or ``None``.
+    """
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as pkg_version
+
+    try:
+        return pkg_version("robot_sf")
+    except PackageNotFoundError:
+        return None
+
+
+def load_citation_version(path: Path) -> str:
+    """Return the ``version:`` field from a ``CITATION.cff`` file.
+
+    Returns:
+        The citation version as a string.
+
+    Raises:
+        KeyError: If the file has no ``version`` field.
+    """
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return str(data["version"])
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the alignment check and report problems.
+
+    Returns:
+        Process exit code (0 when aligned or in advisory mode, 1 otherwise).
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--citation",
+        type=Path,
+        default=DEFAULT_CITATION,
+        help="Path to CITATION.cff (default: repo root CITATION.cff)",
+    )
+    parser.add_argument(
+        "--advisory",
+        action="store_true",
+        help="Report problems but always exit 0 (non-gating CI usage).",
+    )
+    args = parser.parse_args(argv)
+
+    head_tags = git_tags_at_head()
+    all_tags = git_all_tags()
+    package_version = installed_package_version()
+    citation_version = load_citation_version(args.citation)
+
+    problems = evaluate(head_tags, all_tags, package_version, citation_version)
+
+    print(f"HEAD tags: {head_tags or '(none)'}")
+    print(f"installed robot_sf version: {package_version or '(not installed)'}")
+    print(f"CITATION.cff version: {citation_version}")
+    latest = latest_release_tag(all_tags)
+    print(f"latest full release tag: {latest or '(none)'}")
+
+    if not problems:
+        print("OK: all version axes align with the git tag / release line.")
+        return 0
+
+    print("\nVersion drift detected:")
+    for problem in problems:
+        print(f"  - {problem}")
+    if args.advisory:
+        print("\n(advisory mode: not failing this step)")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/check_version_alignment.py
+++ b/scripts/dev/check_version_alignment.py
@@ -222,8 +222,16 @@ def load_citation_version(path: Path) -> str:
     Raises:
         KeyError: If the file has no ``version`` field.
     """
-    data = yaml.safe_load(path.read_text(encoding="utf-8"))
-    return str(data["version"])
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path} is not valid YAML") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    version = data.get("version")
+    if version is None:
+        raise KeyError(f"{path} is missing a non-null 'version' field")
+    return str(version)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/dev/ci_driver.sh
+++ b/scripts/dev/ci_driver.sh
@@ -240,6 +240,11 @@ run_phase() {
       # Ratchet: fail if broad (Exception/BaseException/bare) catches increase on
       # benchmark/script surfaces beyond the approved baseline (issue #3478).
       uv run python scripts/validation/check_broad_exceptions.py
+      # Advisory (non-gating) version-drift guard: the git tag/release line is the
+      # single source of truth for the package and CITATION.cff versions. Surfaced
+      # here on every CI run; enforced (gating) on tag pushes by
+      # .github/workflows/release-functional-badge.yml.
+      uv run python scripts/dev/check_version_alignment.py --advisory
       ;;
     typecheck)
       echo "Running ty in advisory mode (--exit-zero); findings are reported but do not fail this phase."

--- a/tests/dev/test_check_version_alignment.py
+++ b/tests/dev/test_check_version_alignment.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from scripts.dev.check_version_alignment import (
@@ -12,6 +14,9 @@ from scripts.dev.check_version_alignment import (
     load_citation_version,
     numeric_version_from_tag,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.mark.parametrize(
@@ -139,6 +144,27 @@ def test_evaluate_flags_missing_release_tag() -> None:
     assert any("no full release tag" in problem for problem in problems)
 
 
+@pytest.mark.parametrize("contents", ["", "[]", "version: null"])
+def test_load_citation_version_rejects_missing_or_non_mapping_version(
+    tmp_path: Path, contents: str
+) -> None:
+    """Citation inputs must be mappings with an explicit non-null version."""
+    citation = tmp_path / "CITATION.cff"
+    citation.write_text(contents, encoding="utf-8")
+
+    with pytest.raises((KeyError, ValueError)):
+        load_citation_version(citation)
+
+
+def test_load_citation_version_rejects_invalid_yaml(tmp_path: Path) -> None:
+    """Malformed YAML must fail closed with a concise error type."""
+    citation = tmp_path / "CITATION.cff"
+    citation.write_text("version: [", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="not valid YAML"):
+        load_citation_version(citation)
+
+
 def test_repo_citation_matches_latest_release_tag() -> None:
     """The committed CITATION.cff must match the repo's latest release tag.
 
@@ -150,7 +176,8 @@ def test_repo_citation_matches_latest_release_tag() -> None:
 
     all_tags = git_all_tags()
     latest = latest_release_tag(all_tags)
-    assert latest is not None, "expected at least one full release tag in the repo"
+    if latest is None:
+        pytest.skip("no full release tags available in this checkout")
 
     citation_version = load_citation_version(DEFAULT_CITATION)
     # head_tags=[] scopes this guard to CITATION alignment only, independent of

--- a/tests/dev/test_check_version_alignment.py
+++ b/tests/dev/test_check_version_alignment.py
@@ -1,0 +1,164 @@
+"""Tests for the git-tag single-source version alignment checker."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.dev.check_version_alignment import (
+    base_version,
+    evaluate,
+    git_all_tags,
+    latest_release_tag,
+    load_citation_version,
+    numeric_version_from_tag,
+)
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("0.0.2", "0.0.2"),
+        ("rc0.0.3", "0.0.3"),
+        ("v1.2.3", "1.2.3"),
+        ("12.4.9", "12.4.9"),
+        ("artifact/models-2026-05-registry-v1", None),
+        ("camera-ready-v0.0.1a", None),
+        ("main", None),
+        ("", None),
+    ],
+)
+def test_numeric_version_from_tag(tag: str, expected: str | None) -> None:
+    """Only release-line tags (X.Y.Z / vX.Y.Z / rcX.Y.Z) map to a number."""
+    assert numeric_version_from_tag(tag) == expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("0.0.2", "0.0.2"),
+        ("0.0.3.dev4+g1234abc", "0.0.3"),
+        ("1.2.3rc1", "1.2.3"),
+        ("0.0.0+unknown", "0.0.0"),
+    ],
+)
+def test_base_version(version: str, expected: str) -> None:
+    """The base version strips dev/local/pre-release suffixes."""
+    assert base_version(version) == expected
+
+
+def test_latest_release_tag_excludes_candidates() -> None:
+    """rc tags are pre-releases and must not win the latest-release election."""
+    tags = ["0.0.1", "0.0.2", "rc0.0.3", "v0.0.1", "artifact/foo"]
+    assert latest_release_tag(tags) == "0.0.2"
+
+
+def test_latest_release_tag_orders_numerically() -> None:
+    """Numeric ordering, not lexicographic, decides the latest release."""
+    assert latest_release_tag(["0.0.9", "0.0.10", "0.0.2"]) == "0.0.10"
+
+
+def test_latest_release_tag_none_when_no_full_release() -> None:
+    """Without a full release tag there is nothing to align CITATION against."""
+    assert latest_release_tag(["rc0.0.3", "artifact/foo"]) is None
+
+
+def test_evaluate_aligned_on_release_candidate_tag() -> None:
+    """HEAD on rc0.0.3 with package 0.0.3 and CITATION 0.0.2 is aligned."""
+    problems = evaluate(
+        head_tags=["rc0.0.3"],
+        all_tags=["0.0.2", "rc0.0.3"],
+        package_version="0.0.3",
+        citation_version="0.0.2",
+    )
+    assert problems == []
+
+
+def test_evaluate_aligned_on_full_release_tag() -> None:
+    """HEAD on 0.0.2 with a dev-suffixed build base still counts as derived."""
+    problems = evaluate(
+        head_tags=["0.0.2"],
+        all_tags=["0.0.2"],
+        package_version="0.0.2",
+        citation_version="0.0.2",
+    )
+    assert problems == []
+
+
+def test_evaluate_aligned_when_head_untagged() -> None:
+    """Untagged HEAD skips the tag-derivation check and only guards CITATION."""
+    problems = evaluate(
+        head_tags=[],
+        all_tags=["0.0.2", "rc0.0.3"],
+        package_version="0.0.4.dev2+gdeadbee",
+        citation_version="0.0.2",
+    )
+    assert problems == []
+
+
+def test_evaluate_flags_package_not_derived_from_tag() -> None:
+    """A build whose version ignores the HEAD tag is drift."""
+    problems = evaluate(
+        head_tags=["0.0.2"],
+        all_tags=["0.0.2"],
+        package_version="9.9.9",
+        citation_version="0.0.2",
+    )
+    assert any("does not derive" in problem for problem in problems)
+
+
+def test_evaluate_flags_missing_install_on_tagged_head() -> None:
+    """On a tagged HEAD, an uninstalled package cannot be verified."""
+    problems = evaluate(
+        head_tags=["rc0.0.3"],
+        all_tags=["0.0.2", "rc0.0.3"],
+        package_version=None,
+        citation_version="0.0.2",
+    )
+    assert any("not installed" in problem for problem in problems)
+
+
+def test_evaluate_flags_citation_drift() -> None:
+    """The historical benchmark-protocol label is flagged as drift."""
+    problems = evaluate(
+        head_tags=[],
+        all_tags=["0.0.2"],
+        package_version="0.0.2",
+        citation_version="benchmark-protocol-0.1.0",
+    )
+    assert any("CITATION.cff" in problem for problem in problems)
+
+
+def test_evaluate_flags_missing_release_tag() -> None:
+    """Without any full release tag the CITATION cannot be aligned."""
+    problems = evaluate(
+        head_tags=[],
+        all_tags=["rc0.0.3"],
+        package_version="0.0.3",
+        citation_version="0.0.2",
+    )
+    assert any("no full release tag" in problem for problem in problems)
+
+
+def test_repo_citation_matches_latest_release_tag() -> None:
+    """The committed CITATION.cff must match the repo's latest release tag.
+
+    This is the concrete guard that the current repository state is aligned;
+    it uses the real git tags and the real CITATION.cff, independent of any
+    installed-package state.
+    """
+    from scripts.dev.check_version_alignment import DEFAULT_CITATION
+
+    all_tags = git_all_tags()
+    latest = latest_release_tag(all_tags)
+    assert latest is not None, "expected at least one full release tag in the repo"
+
+    citation_version = load_citation_version(DEFAULT_CITATION)
+    # head_tags=[] scopes this guard to CITATION alignment only, independent of
+    # whether HEAD currently sits on a release tag or of the installed package.
+    problems = evaluate(
+        head_tags=[],
+        all_tags=all_tags,
+        package_version=numeric_version_from_tag(latest),
+        citation_version=citation_version,
+    )
+    assert problems == [], problems

--- a/tests/fixtures/optional_import_guards.json
+++ b/tests/fixtures/optional_import_guards.json
@@ -6,7 +6,7 @@
     "ModuleNotFoundError"
   ],
   "spelling_key": "Caught exception type names, sorted and joined by '+'. The 'as <alias>' name is intentionally NOT part of the key.",
-  "total_guards": 101,
+  "total_guards": 102,
   "spellings": {
     "AttributeError+ImportError": {
       "count_ceiling": 2,
@@ -90,12 +90,13 @@
       ]
     },
     "ImportError": {
-      "count_ceiling": 70,
+      "count_ceiling": 71,
       "has_as_count": 14,
-      "pragma_no_cover_count": 23,
+      "pragma_no_cover_count": 24,
       "blessed": true,
       "note": "Pure optional-import. Prefer robot_sf.common.optional_import.try_import for new plain cases.",
       "samples": [
+        "robot_sf/__init__.py:12",
         "robot_sf/adversarial/certification.py:99",
         "robot_sf/adversarial/samplers.py:230",
         "robot_sf/baselines/dr_mpc.py:109",

--- a/uv.lock
+++ b/uv.lock
@@ -4907,7 +4907,6 @@ wheels = [
 
 [[package]]
 name = "robot-sf"
-version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "geopandas" },
@@ -5058,7 +5057,7 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'progress'", specifier = ">=4.68.3" },
     { name = "wandb", marker = "extra == 'training'", specifier = ">=0.28.0" },
 ]
-provides-extras = ["gpu", "training", "recurrent", "rllib", "progress", "analysis", "analytics", "viz", "browser", "sacadrl", "orca", "socnav", "criticality"]
+provides-extras = ["analysis", "analytics", "browser", "criticality", "gpu", "orca", "progress", "recurrent", "rllib", "sacadrl", "socnav", "training", "viz"]
 
 [package.metadata.requires-dev]
 carla = [{ name = "carla", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==0.9.16" }]


### PR DESCRIPTION
## Why

The repository had three uncoordinated version axes: the release-tag line,
the package metadata, and `CITATION.cff`. Git tags are canonical because
external evidence provenance pins resolve by tag; this PR makes the package
derive from that source and adds checks that prevent the axes drifting again.

## What

- `pyproject.toml` derives the package version through `hatch-vcs` instead of
  a hard-coded value. Plain full-release tags (`X.Y.Z`) and release candidates
  (`rcX.Y.Z`) map to the numeric package version; untagged builds use the
  documented development fallback.
- `robot_sf.__version__` reads the build-generated version module, then falls
  back to installed metadata for a source checkout.
- `CITATION.cff` now tracks the latest full release tag (`0.0.2`), while its
  benchmark-protocol context remains in the title and abstract.
- `scripts/dev/check_version_alignment.py` checks tag/package/CITATION
  alignment. It gates release-tag pushes and reports advisory status in CI.
- The release workflow now matches the established plain numeric release-tag
  convention as well as `v*` and `rc*`; it fetches tags before checking.
- The shared CI setup moves from `uv 0.5.11` to `uv 0.11.21`: the former cannot
  parse the valid dynamic-version root entry in the regenerated lockfile.
- Tests cover tag parsing, tag selection, aligned/drift cases, malformed or
  null citation metadata, and shallow checkouts without release tags.

## Verification

- `uv lock --check`
- `uv run pytest tests/dev/test_check_version_alignment.py tests/test_optional_import_guard_inventory.py tests/test_robot_sf_import_smoke.py` — 36 passed
- `uv run ruff check scripts/dev/check_version_alignment.py tests/dev/test_check_version_alignment.py`
- `uv run ruff format --check scripts/dev/check_version_alignment.py tests/dev/test_check_version_alignment.py`
- `uv build --wheel` — produced a hatch-vcs-derived package version
- CI-equivalent parser check: `uvx --from 'uv==0.5.11' uv lock --check` fails on the valid dynamic root entry, while `uv 0.11.21` accepts it; the shared CI pin is updated accordingly.

No metric or benchmark semantics change. This is release/build plumbing, so
research-result fields and domain-aware experimental approval are not
applicable.

## Remaining scope

No deferred implementation work remains in this PR. There is no linked parent
issue, so parent-issue propagation and issue closure are not applicable.
