### PR TITLE
Issue #5354: reusable linked-worktree artifact path helper (cheap-lane worker)

### DIFF
--- a/docs/dev/agents/relocated-agents-guidance.md
+++ b/docs/dev/agents/relocated-agents-guidance.md
@@ -393,7 +393,9 @@ resolving lint or test failures locally before requesting review.
   `scripts/dev/snapshot_pr_queue.py --prs <number> --review-threads --json`; it emits bounded
   comment excerpts, label names, and omits raw `diff_hunk` payloads. Fetch full review-comment
   bodies or hunks only with an explicit artifact path such as
-  `--raw-review-comments-artifact "$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/.../raw-review-comments.json"`.
+  `--raw-review-comments-artifact "$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/.../raw-review-comments.json"`
+  (resolve via `scripts/dev/common_setup.sh`'s `resolve_agent_artifact_dir` helper or
+  `scripts/dev/git_common.py`).
 - Before finalization, cover format/check, focused tests, changed-file coverage when practical, and a
   clean worktree check (`git status --short`) as part of the readied proof bundle.
 - For failing validation commands, prefer `uv run python scripts/dev/run_compact_validation.py -- <command>` before
@@ -471,7 +473,10 @@ below that threshold is a hard pause state for the loop. Persist the pause in th
 resolved with `git rev-parse --path-format=absolute --git-common-dir`, for example
 `$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active/`. Do not write
 to a literal worktree-relative `.git/codex-agent-runs/active/` path, because linked worktrees may
-store `.git` as a file. After recording the pause, short-circuit repeated automatic continue
+store `.git` as a file.  Use the shared helpers from `scripts/dev/common_setup.sh`
+(`resolve_agent_artifact_dir`) or `scripts/dev/git_common.py`
+(`resolve_agent_artifact_dir`) to resolve the correct path; see
+`docs/dev_guide.md` § "Agent-run artifact paths in linked worktrees". After recording the pause, short-circuit repeated automatic continue
 prompts without repo, GitHub, validation, delegation, or broad context-loading work.
 
 - Do not re-run usage checks on automatic continue prompts unless a recorded cooldown has elapsed.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -207,6 +207,40 @@ If a fresh linked worktree fails to collect a focused test because an optional d
 classifies the direct failure as setup or optional-dependency friction for that worktree, not as a
 code regression; record both commands in the PR or handoff.
 
+### Agent-run artifact paths in linked worktrees
+
+In a linked worktree, `.git` is a file (not a directory), so writing to a literal
+`.git/codex-agent-runs/active/...` path fails.  Use the shared helpers to resolve the
+correct absolute path via `git rev-parse --git-common-dir`.
+
+**Shell** (for scripts that source `scripts/dev/common_setup.sh`):
+
+```bash
+source scripts/dev/common_setup.sh
+artifact_dir="$(resolve_agent_artifact_dir my-subdir)"
+mkdir -p "$artifact_dir"
+echo "data" > "$artifact_dir/result.json"
+```
+
+**Python** (for scripts under `scripts/dev/`):
+
+```python
+from scripts.dev.git_common import resolve_agent_artifact_dir
+
+artifact_dir = resolve_agent_artifact_dir("my-subdir")
+# artifact_dir is an absolute Path; mkdir is done automatically
+```
+
+**One-liner** (for ad-hoc shell use or agent instructions):
+
+```bash
+mkdir -p "$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active/my-subdir"
+```
+
+Never hard-code a literal `.git/codex-agent-runs/...` path in scripts, agent instructions, or
+task artifact wording.  Always resolve through `git rev-parse --git-common-dir` or use the
+helpers above.
+
 When validating the SNQI (Social Navigation Quality Index) contract or camera-ready exit handling,
 pass the relevant files explicitly. `-k` filters only after pytest has collected files, so starting
 from `pytest tests -k ...` can import unrelated optional stacks first. This command collects only

--- a/scripts/dev/common_setup.sh
+++ b/scripts/dev/common_setup.sh
@@ -16,6 +16,30 @@ if [ -f "$REPO_ROOT/.venv/bin/activate" ]; then
   source "$REPO_ROOT/.venv/bin/activate"
 fi
 
+# Resolve the absolute path to a codex-agent-runs artifact subdirectory under
+# the shared Git common directory.  In a linked worktree `.git` is a file, so
+# writing to a literal `.git/codex-agent-runs/...` path fails.  This function
+# resolves the correct absolute path via `git rev-parse --git-common-dir` and
+# prints it.  Callers must `mkdir -p` the result before writing.
+#
+# Usage:
+#   artifact_dir="$(resolve_agent_artifact_dir my-subdir)"
+#   mkdir -p "$artifact_dir"
+#   echo "data" > "$artifact_dir/result.json"
+#
+# Returns 0 on success, prints the resolved path.  Falls back to
+# output/tmp/<subdir> when git is unavailable.
+resolve_agent_artifact_dir() {
+  local subdir="${1:?resolve_agent_artifact_dir requires a subdirectory name}"
+  local common_dir
+  common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [[ -n "$common_dir" ]]; then
+    printf '%s\n' "$common_dir/codex-agent-runs/active/$subdir"
+  else
+    printf '%s\n' "$REPO_ROOT/output/tmp/$subdir"
+  fi
+}
+
 # Cheap shell preflight: verify that test-collection dependencies (duckdb,
 # pyarrow) are importable before expensive pytest collection runs.  Exit 2
 # with a concise message on failure so agents see the blocker immediately.

--- a/scripts/dev/git_common.py
+++ b/scripts/dev/git_common.py
@@ -1,0 +1,52 @@
+"""Resolve Git-common-dir paths for agent-run artifacts.
+
+In a linked worktree ``.git`` is a file, not a directory, so writing to a
+literal ``.git/codex-agent-runs/...`` path fails.  Use
+:func:`resolve_agent_artifact_dir` to obtain the correct absolute path via
+``git rev-parse --git-common-dir``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def resolve_git_common_dir() -> Path | None:
+    """Return the absolute path to the Git common directory, or ``None``."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip())
+    return None
+
+
+def resolve_agent_artifact_dir(subdir: str, *, mkdir: bool = True) -> Path:
+    """Return the absolute path to a codex-agent-runs artifact subdirectory.
+
+    Parameters
+    ----------
+    subdir:
+        Name of the subdirectory under
+        ``<git-common-dir>/codex-agent-runs/active/``.
+    mkdir:
+        If ``True`` (the default), create the directory if it does not exist.
+
+    Returns
+    -------
+    Path
+        Absolute path to the resolved artifact directory.  Falls back to
+        ``output/tmp/<subdir>`` when git is unavailable.
+    """
+    common_dir = resolve_git_common_dir()
+    if common_dir is not None:
+        artifact_dir = common_dir / "codex-agent-runs" / "active" / subdir
+    else:
+        artifact_dir = Path("output") / "tmp" / subdir
+    if mkdir:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+    return artifact_dir

--- a/scripts/dev/git_common.py
+++ b/scripts/dev/git_common.py
@@ -14,12 +14,15 @@ from pathlib import Path
 
 def resolve_git_common_dir() -> Path | None:
     """Return the absolute path to the Git common directory, or ``None``."""
-    result = subprocess.run(
-        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
     if result.returncode == 0 and result.stdout.strip():
         return Path(result.stdout.strip())
     return None
@@ -46,7 +49,7 @@ def resolve_agent_artifact_dir(subdir: str, *, mkdir: bool = True) -> Path:
     if common_dir is not None:
         artifact_dir = common_dir / "codex-agent-runs" / "active" / subdir
     else:
-        artifact_dir = Path("output") / "tmp" / subdir
+        artifact_dir = Path(__file__).resolve().parents[2] / "output" / "tmp" / subdir
     if mkdir:
         artifact_dir.mkdir(parents=True, exist_ok=True)
     return artifact_dir

--- a/scripts/dev/run_compact_validation.py
+++ b/scripts/dev/run_compact_validation.py
@@ -16,6 +16,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from scripts.dev.git_common import resolve_agent_artifact_dir
+
 SCHEMA_VERSION = "compact_validation_summary.v2"
 DEFAULT_EXCERPT_LINES = 40
 DEFAULT_EXCERPT_WIDTH = 240
@@ -31,15 +33,7 @@ PYTEST_NODE_PATTERN = re.compile(r"([\w./-]+\.py::[^\s]+)")
 
 def _repo_artifact_dir() -> Path:
     """Return the private artifact directory for compact validation logs."""
-    result = subprocess.run(
-        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode == 0 and result.stdout.strip():
-        return Path(result.stdout.strip()) / "codex-agent-runs" / "active" / "compact-validation"
-    return Path("output") / "tmp" / "compact-validation"
+    return resolve_agent_artifact_dir("compact-validation")
 
 
 def _now_slug() -> str:

--- a/scripts/dev/run_focused_tests.sh
+++ b/scripts/dev/run_focused_tests.sh
@@ -41,12 +41,7 @@ fi
 if [[ "${FOCUSED_TEST_FULL_OUTPUT:-0}" == "1" ]]; then
   uv run pytest "$@"
 else
-  common_git_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
-  if [[ -n "$common_git_dir" ]]; then
-    log_dir="$common_git_dir/codex-agent-runs/active/focused-tests"
-  else
-    log_dir="output/tmp/focused-tests"
-  fi
+  log_dir="$(resolve_agent_artifact_dir focused-tests)"
   mkdir -p "$log_dir"
   log_file="$log_dir/pytest-$(date -u +%Y%m%dT%H%M%SZ)-$$.log"
   set +e

--- a/tests/dev/test_git_common.py
+++ b/tests/dev/test_git_common.py
@@ -32,6 +32,12 @@ def test_resolve_git_common_dir_returns_none_on_git_failure() -> None:
         assert resolve_git_common_dir() is None
 
 
+def test_resolve_git_common_dir_returns_none_when_git_is_unavailable() -> None:
+    """A missing git executable uses the caller-visible fallback path."""
+    with patch("scripts.dev.git_common.subprocess.run", side_effect=FileNotFoundError):
+        assert resolve_git_common_dir() is None
+
+
 def test_resolve_git_common_dir_returns_none_on_empty_output() -> None:
     """When git returns empty stdout, resolve_git_common_dir returns None."""
     with patch("scripts.dev.git_common.subprocess.run", return_value=_completed(0, "")):
@@ -82,7 +88,7 @@ def test_resolve_agent_artifact_dir_fallback_without_git(tmp_path: Path) -> None
     with patch("scripts.dev.git_common.resolve_git_common_dir", return_value=None):
         result = resolve_agent_artifact_dir("fallback-test", mkdir=False)
 
-    assert result == Path("output") / "tmp" / "fallback-test"
+    assert result == Path(__file__).resolve().parents[2] / "output" / "tmp" / "fallback-test"
 
 
 def test_resolve_agent_artifact_dir_requires_subdir_name() -> None:
@@ -90,4 +96,4 @@ def test_resolve_agent_artifact_dir_requires_subdir_name() -> None:
     # The function accepts any string; just verify it returns a path.
     with patch("scripts.dev.git_common.resolve_git_common_dir", return_value=None):
         result = resolve_agent_artifact_dir("", mkdir=False)
-    assert result == Path("output") / "tmp"
+    assert result == Path(__file__).resolve().parents[2] / "output" / "tmp"

--- a/tests/dev/test_git_common.py
+++ b/tests/dev/test_git_common.py
@@ -1,0 +1,93 @@
+"""Tests for scripts/dev/git_common.py shared artifact-path helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.dev.git_common import resolve_agent_artifact_dir, resolve_git_common_dir
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    import subprocess
+
+    return subprocess.CompletedProcess(
+        args=["git"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_resolve_git_common_dir_returns_path_in_normal_checkout() -> None:
+    """In a normal checkout, resolve_git_common_dir returns an absolute path."""
+    result = resolve_git_common_dir()
+    assert result is not None
+    assert result.is_absolute()
+
+
+def test_resolve_git_common_dir_returns_none_on_git_failure() -> None:
+    """When git fails, resolve_git_common_dir returns None."""
+    with patch("scripts.dev.git_common.subprocess.run", return_value=_completed(128)):
+        assert resolve_git_common_dir() is None
+
+
+def test_resolve_git_common_dir_returns_none_on_empty_output() -> None:
+    """When git returns empty stdout, resolve_git_common_dir returns None."""
+    with patch("scripts.dev.git_common.subprocess.run", return_value=_completed(0, "")):
+        assert resolve_git_common_dir() is None
+
+
+def test_resolve_agent_artifact_dir_contains_codex_agent_runs(tmp_path: Path) -> None:
+    """The resolved artifact dir should sit under codex-agent-runs/active/."""
+    fake_common = tmp_path / "shared-git"
+    fake_common.mkdir()
+    with patch(
+        "scripts.dev.git_common.resolve_git_common_dir",
+        return_value=fake_common,
+    ):
+        result = resolve_agent_artifact_dir("my-subdir", mkdir=False)
+
+    assert result == fake_common / "codex-agent-runs" / "active" / "my-subdir"
+
+
+def test_resolve_agent_artifact_dir_creates_directory_by_default(tmp_path: Path) -> None:
+    """With mkdir=True (default), the directory should be created."""
+    fake_common = tmp_path / "shared-git"
+    fake_common.mkdir()
+    with patch(
+        "scripts.dev.git_common.resolve_git_common_dir",
+        return_value=fake_common,
+    ):
+        result = resolve_agent_artifact_dir("created-subdir")
+
+    assert result.is_dir()
+
+
+def test_resolve_agent_artifact_dir_no_mkdir_when_disabled(tmp_path: Path) -> None:
+    """With mkdir=False, the directory should not be created."""
+    fake_common = tmp_path / "shared-git"
+    fake_common.mkdir()
+    with patch(
+        "scripts.dev.git_common.resolve_git_common_dir",
+        return_value=fake_common,
+    ):
+        result = resolve_agent_artifact_dir("no-create", mkdir=False)
+
+    assert not result.exists()
+
+
+def test_resolve_agent_artifact_dir_fallback_without_git(tmp_path: Path) -> None:
+    """When git is unavailable, fall back to output/tmp/<subdir>."""
+    with patch("scripts.dev.git_common.resolve_git_common_dir", return_value=None):
+        result = resolve_agent_artifact_dir("fallback-test", mkdir=False)
+
+    assert result == Path("output") / "tmp" / "fallback-test"
+
+
+def test_resolve_agent_artifact_dir_requires_subdir_name() -> None:
+    """An empty subdir name should not crash; the caller controls validation."""
+    # The function accepts any string; just verify it returns a path.
+    with patch("scripts.dev.git_common.resolve_git_common_dir", return_value=None):
+        result = resolve_agent_artifact_dir("", mkdir=False)
+    assert result == Path("output") / "tmp"


### PR DESCRIPTION
## What/Why

In a linked worktree, `.git` is a file (not a directory), so writing to a literal
`.git/codex-agent-runs/...` path fails.  Multiple scripts already resolve the correct
path via `git rev-parse --git-common-dir`, but each did it inline.  This PR adds a
shared reusable helper and updates the docs to point at it.

## Changes

- **`scripts/dev/git_common.py`**: New Python helper with `resolve_git_common_dir()` and
  `resolve_agent_artifact_dir(subdir)` that resolve the absolute artifact path and
  optionally `mkdir -p` it.  Falls back to `output/tmp/<subdir>` when git is unavailable.
- **`scripts/dev/common_setup.sh`**: New shell helper `resolve_agent_artifact_dir` that
  does the same for bash scripts sourcing this file.
- **`scripts/dev/run_compact_validation.py`**: Refactored to use the shared Python helper
  instead of inline `git rev-parse` subprocess calls.
- **`scripts/dev/run_focused_tests.sh`**: Refactored to use the shared shell helper
  instead of inline `git rev-parse` resolution.
- **`docs/dev_guide.md`**: New section "Agent-run artifact paths in linked worktrees"
  with canonical shell, Python, and one-liner snippets.
- **`docs/dev/agents/relocated-agents-guidance.md`**: Updated references to point at the
  helpers.

## Validation

```
uv run ruff check scripts/dev/ tests/dev/test_git_common.py   # All checks passed
uv run ruff format --check scripts/dev/ tests/dev/test_git_common.py  # All formatted
uv run pytest tests/dev/test_git_common.py -v                 # 8 passed
uv run pytest tests/dev/test_run_compact_validation.py -v     # 9 passed (refactor no regression)
uv run pytest tests/dev/test_compact_worktree_snapshot.py -v  # 3 passed (unrelated, no regression)
```

## Closes

Closes #5354

---

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent artifact-directory handling for validation and focused test outputs.
  - Supports Git worktrees and automatically creates required artifact directories.
  - Provides a local fallback location when Git is unavailable.

- **Bug Fixes**
  - Improved reliability of artifact paths across standard checkouts and linked worktrees.

- **Tests**
  - Added coverage for successful resolution, fallback behavior, directory creation, and Git errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->