### PR TITLE
fix(benchmark): cache PPO arm policy and preserve resume (#5347)

### DIFF
--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -758,6 +758,7 @@ def _run_campaign_planner_variant_subprocess(
         snqi_weights=context.snqi_weights,
         snqi_baseline=context.snqi_baseline,
         algo_config_path=planner.algo_config_path,
+        resume=cfg.resume,
         scoped_scenarios_path=scoped_scenarios_path,
     )
 

--- a/robot_sf/benchmark/camera_ready/resource_lifecycle.py
+++ b/robot_sf/benchmark/camera_ready/resource_lifecycle.py
@@ -57,6 +57,9 @@ class _SubprocessArmParams:
     snqi_weights: dict[str, Any] | None
     snqi_baseline: dict[str, Any] | None
     algo_config_path: Path | None
+    # Preserve the parent campaign's append/resume choice across the isolated
+    # arm handoff.  Defaulting to False keeps old callers' fresh-run behavior.
+    resume: bool = False
     # Fully-prepared scenario list serialized by the parent (see
     # _run_campaign_planner_variant_subprocess). When set, the worker consumes it
     # verbatim instead of re-deriving scenarios from scenario_matrix_path: the
@@ -254,7 +257,7 @@ def _run_single_arm_subprocess(params: _SubprocessArmParams) -> dict[str, Any]:
                 dt=params.dt,
             ),
             workers=params.workers,
-            resume=False,  # Subprocess runs fresh
+            resume=params.resume,
         )
         availability = summarize_benchmark_availability(summary)
         if availability.availability_status == "not_available":

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -1243,6 +1243,9 @@ def _build_ppo_policy(  # noqa: C901
         return linear, angular
 
     _policy._planner_close = ppo_planner.close
+    # PPO itself is stateless between predictions, but expose its reset hook so
+    # a batch-owned cached policy still applies the episode seed before rollout.
+    _attach_planner_reset(_policy, ppo_planner)
     _attach_checkpoint_runtime_stats(_policy, ppo_planner, algo_config)
     ppo_bind_env = getattr(ppo_planner, "bind_env", None)
     if callable(ppo_bind_env):
@@ -2456,6 +2459,8 @@ def _run_map_episode(  # noqa: PLR0913
     cbf_safety_filter: dict[str, Any] | None = None,
     record_planner_decision_trace: bool = False,
     record_simulation_step_trace: bool = False,
+    close_policy: bool = True,
+    policy_builder: Any | None = None,
 ) -> dict[str, Any]:
     """Run one scenario/seed episode through the extracted episode executor.
 
@@ -2491,7 +2496,8 @@ def _run_map_episode(  # noqa: PLR0913
         cbf_safety_filter=cbf_safety_filter,
         record_planner_decision_trace=record_planner_decision_trace,
         record_simulation_step_trace=record_simulation_step_trace,
-        policy_builder=_build_policy,
+        close_policy=close_policy,
+        policy_builder=policy_builder or _build_policy,
     )
 
 
@@ -2520,6 +2526,96 @@ def _run_map_job_worker(
         dict[str, Any]: Episode record returned by ``_run_map_episode``.
     """
     return _execute_map_job(job, run_map_episode=_run_map_episode)
+
+
+def _run_map_jobs_with_policy_cache(
+    *,
+    jobs: list[tuple[dict[str, Any], int]],
+    fixed_params: dict[str, Any],
+    out_path: Path,
+    schema: dict[str, Any],
+    workers: int,
+) -> Any:
+    """Run one arm with policies cached until the batch completes.
+
+    The S30 learned-policy arm uses one worker.  Retaining its PPO policy here
+    avoids reloading the checkpoint for every episode while ``run_map_episode``
+    continues to call the policy reset hook with each episode seed.  Parallel
+    execution deliberately keeps its process-local construction behavior.
+
+    Returns:
+        The normal map-batch execution result.
+    """
+    policy_cache: dict[
+        tuple[str, str, str | None, str | None, bool], tuple[Any, dict[str, Any]]
+    ] = {}
+
+    def cached_policy_builder(
+        algo: str,
+        algo_config: dict[str, Any],
+        *,
+        robot_kinematics: str | None = None,
+        robot_command_mode: str | None = None,
+        adapter_impact_eval: bool = False,
+    ) -> tuple[Any, dict[str, Any]]:
+        key = (
+            str(algo).strip().lower(),
+            _config_hash(algo_config),
+            robot_kinematics,
+            robot_command_mode,
+            bool(adapter_impact_eval),
+        )
+        if key not in policy_cache:
+            try:
+                policy_cache[key] = _build_policy(
+                    algo,
+                    algo_config,
+                    robot_kinematics=robot_kinematics,
+                    robot_command_mode=robot_command_mode,
+                    adapter_impact_eval=adapter_impact_eval,
+                )
+            except TypeError as exc:
+                if "unexpected keyword argument" not in str(exc):
+                    raise
+                policy_cache[key] = _build_policy(algo, algo_config)
+        return policy_cache[key]
+
+    def run_cached_map_episode(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Run one episode without closing the arm-owned cached policy.
+
+        Returns:
+            The completed episode record.
+        """
+        return _run_map_episode(
+            *args,
+            **kwargs,
+            close_policy=False,
+            policy_builder=cached_policy_builder,
+        )
+
+    def run_cached_map_job(job: tuple[dict[str, Any], int, dict[str, Any]]) -> dict[str, Any]:
+        return _execute_map_job(job, run_map_episode=run_cached_map_episode)
+
+    try:
+        return _execute_map_jobs(
+            jobs=jobs,
+            fixed_params=fixed_params,
+            out_path=out_path,
+            schema=schema,
+            workers=workers,
+            run_map_job=run_cached_map_job,
+            write_validated_to_handle=_write_validated_to_handle,
+            apply_worker_metadata_bridge=_apply_worker_metadata_bridge,
+            scenario_id=_scenario_id,
+            executor_cls=ProcessPoolExecutor,
+            as_completed_fn=as_completed,
+            multiprocessing_context=None,
+        )
+    finally:
+        for policy, _metadata in policy_cache.values():
+            close = getattr(policy, "_planner_close", None)
+            if callable(close):
+                close()
 
 
 def _emit_provenance_manifest(  # noqa: PLR0913
@@ -3070,19 +3166,33 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     )
 
     total_jobs = len(jobs)
-    batch_execution = _execute_map_jobs(
-        jobs=jobs,
-        fixed_params=fixed_params,
-        out_path=out_path,
-        schema=schema,
-        workers=workers,
-        run_map_job=_run_map_job_worker,
-        write_validated_to_handle=_write_validated_to_handle,
-        apply_worker_metadata_bridge=_apply_worker_metadata_bridge,
-        scenario_id=_scenario_id,
-        executor_cls=ProcessPoolExecutor,
-        as_completed_fn=as_completed,
-        multiprocessing_context=multiprocessing_context,
+    batch_execution = (
+        _run_map_jobs_with_policy_cache(
+            jobs=jobs,
+            fixed_params=fixed_params,
+            out_path=out_path,
+            schema=schema,
+            workers=workers,
+        )
+        if (
+            workers <= 1
+            and algo_config_path is not None
+            and algo.strip().lower() in {"ppo", "sac", "guarded_ppo"}
+        )
+        else _execute_map_jobs(
+            jobs=jobs,
+            fixed_params=fixed_params,
+            out_path=out_path,
+            schema=schema,
+            workers=workers,
+            run_map_job=_run_map_job_worker,
+            write_validated_to_handle=_write_validated_to_handle,
+            apply_worker_metadata_bridge=_apply_worker_metadata_bridge,
+            scenario_id=_scenario_id,
+            executor_cls=ProcessPoolExecutor,
+            as_completed_fn=as_completed,
+            multiprocessing_context=multiprocessing_context,
+        )
     )
     wrote = batch_execution.wrote
     episode_records = batch_execution.episode_records

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -2612,6 +2612,7 @@ def run_map_episode(  # noqa: PLR0913
     cbf_safety_filter: dict[str, Any] | None = None,
     record_planner_decision_trace: bool = False,
     record_simulation_step_trace: bool = False,
+    close_policy: bool = True,
     policy_builder: PolicyBuilder,
 ) -> dict[str, Any]:
     """Run one scenario/seed episode and return a benchmark JSONL record.
@@ -2685,7 +2686,7 @@ def run_map_episode(  # noqa: PLR0913
         policy_fn=policy_contract.policy_fn,
         planner_bind_env=policy_contract.planner_bind_env,
         planner_reset=policy_contract.planner_reset,
-        planner_close=policy_contract.planner_close,
+        planner_close=policy_contract.planner_close if close_policy else None,
         planner_stats=policy_contract.planner_stats,
         planner_native_action=policy_contract.planner_native_action,
         noise_spec=noise_spec,

--- a/tests/benchmark/test_camera_ready_subprocess_isolation.py
+++ b/tests/benchmark/test_camera_ready_subprocess_isolation.py
@@ -718,6 +718,7 @@ class TestScopedScenarioParity:
         )
         params_dict = json.loads(_serialize_subprocess_arm_params(params))
         assert params_dict["scoped_scenarios_path"] == "/tmp/scoped.json"
+        assert params_dict["resume"] is False
 
         for field_name in _SUBPROCESS_ARM_PATH_FIELDS:
             if params_dict.get(field_name):
@@ -819,6 +820,7 @@ class TestScopedScenarioParity:
 
         def fake_run_batch(scenarios, **kwargs):
             captured["scenarios"] = scenarios
+            captured.update(kwargs)
             return {
                 "status": "ok",
                 "total_jobs": 1,
@@ -841,7 +843,46 @@ class TestScopedScenarioParity:
             result = _run_single_arm_subprocess(params)
 
         assert captured["scenarios"] == self.SCOPED
+        assert captured["resume"] is False
         assert result["summary"]["status"] == "ok"
+
+    def test_worker_forwards_resume_intent_to_run_batch(self, tmp_path):
+        """A resumed subprocess arm keeps the parent's completed episode rows."""
+        from unittest.mock import Mock as _Mock
+
+        from robot_sf.benchmark.camera_ready.resource_lifecycle import (
+            _run_single_arm_subprocess,
+        )
+
+        base = _make_arm_params()
+        scoped_path = tmp_path / "scoped_scenarios.json"
+        scoped_path.write_text("[]", encoding="utf-8")
+        params = _SubprocessArmParams(
+            **{
+                **base.__dict__,
+                "episodes_path": tmp_path / "episodes.jsonl",
+                "summary_path": tmp_path / "summary.json",
+                "scoped_scenarios_path": scoped_path,
+                "resume": True,
+            }
+        )
+        captured = {}
+
+        def fake_run_batch(*_args, **kwargs):
+            captured.update(kwargs)
+            return {"status": "ok", "total_jobs": 1, "written": 1, "failures": []}
+
+        with (
+            patch("robot_sf.benchmark.runner.run_batch", side_effect=fake_run_batch),
+            patch(
+                "robot_sf.benchmark.fallback_policy.summarize_benchmark_availability",
+                return_value=_Mock(availability_status="ok"),
+            ),
+            patch("robot_sf.benchmark.fallback_policy.availability_payload", return_value={}),
+        ):
+            _run_single_arm_subprocess(params)
+
+        assert captured["resume"] is True
 
 
 if __name__ == "__main__":

--- a/tests/benchmark/test_map_runner_policy_cache.py
+++ b/tests/benchmark/test_map_runner_policy_cache.py
@@ -1,0 +1,67 @@
+"""Regression tests for per-arm learned-policy caching (issue #5347)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from robot_sf.benchmark import map_runner
+
+
+def test_cached_policy_is_reset_between_episodes_and_closed_after_arm(
+    monkeypatch, tmp_path
+) -> None:
+    """Two cached episodes produce fresh state while constructing PPO only once."""
+    builder_calls = 0
+    outputs: list[int] = []
+    close_calls = 0
+
+    def stateful_policy(_obs):
+        stateful_policy.calls += 1
+        return stateful_policy.calls
+
+    stateful_policy.calls = 0
+
+    def reset(*, seed: int | None = None) -> None:
+        del seed
+        stateful_policy.calls = 0
+
+    def close() -> None:
+        nonlocal close_calls
+        close_calls += 1
+
+    stateful_policy._planner_reset = reset
+    stateful_policy._planner_close = close
+
+    def fake_build_policy(*_args, **_kwargs):
+        nonlocal builder_calls
+        builder_calls += 1
+        return stateful_policy, {"algorithm": "ppo"}
+
+    def fake_run_map_episode(*_args, close_policy, policy_builder, **_kwargs):
+        assert close_policy is False
+        policy, _metadata = policy_builder("ppo", {"model_id": "fixture"})
+        policy._planner_reset(seed=7)
+        outputs.append(policy({}))
+        return {"scenario_id": "fixture", "seed": 7}
+
+    def fake_execute_map_jobs(*, jobs, run_map_job, **_kwargs):
+        for scenario, seed in jobs:
+            run_map_job((scenario, seed, {"scenario_path": str(tmp_path / "matrix.yaml")}))
+        return SimpleNamespace()
+
+    monkeypatch.setattr(map_runner, "_build_policy", fake_build_policy)
+    monkeypatch.setattr(map_runner, "_run_map_episode", fake_run_map_episode)
+    monkeypatch.setattr(map_runner, "_execute_map_jobs", fake_execute_map_jobs)
+
+    map_runner._run_map_jobs_with_policy_cache(
+        jobs=[({"name": "first"}, 7), ({"name": "second"}, 7)],
+        fixed_params={"scenario_path": str(Path(tmp_path / "matrix.yaml"))},
+        out_path=tmp_path / "episodes.jsonl",
+        schema={},
+        workers=1,
+    )
+
+    assert builder_calls == 1
+    assert outputs == [1, 1]
+    assert close_calls == 1


### PR DESCRIPTION
## Reviewer-critical summary

**What changed.** Cache map-runner policies for a single-worker camera-ready arm, reset the cached policy for every episode, and close it only after the arm completes. Subprocess-isolated arms now serialize and forward the campaign's `resume` setting.

**Why now.** The live S30 PPO arm reloaded its checkpoint every episode and exhausted GPU memory; without resume passthrough, a resubmission would restart the incomplete arm.

**Claim boundary.** This is a resource-lifecycle and resume-contract fix only. It makes no benchmark, metric, paper, or dissertation claim.

**Required validation.** `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` plus focused cache/reset and subprocess-resume tests.

**Remaining blocker.** An authorized operations rerun is still needed to establish whether S30 completes; this PR does not submit compute.

Closes #5347

Issue: https://github.com/ll7/robot_sf_ll7/issues/5347

## Contract delta

- Single-worker map batches cache one compatible policy by algorithm, resolved config hash, kinematics, command mode, and adapter-impact mode; parallel execution remains process-local.
- PPO exposes its existing stateless planner reset hook, and the cached path calls it with the episode seed before each rollout; cached state cannot carry into the next episode.
- Cached policies are closed once after the arm, rather than after each episode.
- `_SubprocessArmParams.resume: bool = False` is serialized parent-to-worker; callers that do not set it retain fresh-run behavior.
- No metric or episode-schema semantics change.

## Scope and validation

- Cache/reset/close lifecycle is implemented on the map-runner path actually used by the S30 configuration.
- Subprocess worker receives `cfg.resume` and passes it to `run_batch`.
- Focused tests: `uv run pytest tests/benchmark/test_camera_ready_subprocess_isolation.py tests/benchmark/test_map_runner_policy_cache.py tests/benchmark/test_map_runner_episode_algo_meta_isolation.py -q` — 31 passed.
- Full readiness: `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — pending fresh committed-HEAD run at PR creation time.

<details>
<summary>Governance and handoff</summary>

- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.
- Artifact decision: local `output/coverage/` artifacts from readiness are ignored temporary validation output and are not committed.
- Downstream propagation: not applicable; no evidence-producing or claim-changing artifact is created.
- State propagation: no issue comment is posted because this task does not authorize comments; this PR body is the linked delivery surface.
- Friction: #5354 records the linked-worktree `.git` artifact-path workaround encountered during validation.

</details>

- Post-merge S30 operations rerun: https://github.com/ll7/robot_sf_ll7/issues/5362
