### PR TITLE
Issue #5363: keep release-assurance evidence hashes aligned (cheap-lane worker)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,9 @@ repos:
         language: system
         files: ^configs/training/.*\.ya?ml$
         pass_filenames: true
+      - id: check-release-assurance-hashes
+        name: Check Release Assurance Hashes
+        entry: uv run python hooks/check_release_assurance_hashes.py
+        language: system
+        files: ^(docs/RELEASE\.md|CITATION\.cff|docs/context/evidence/issue_4683_release_assurance_case_example\.json)$
+        pass_filenames: false

--- a/docs/context/evidence/issue_4683_release_assurance_case_example.json
+++ b/docs/context/evidence/issue_4683_release_assurance_case_example.json
@@ -1,4 +1,5 @@
 {
+  "review_marker": "AI-GENERATED NEEDS-REVIEW",
   "arguments": [
     {
       "claim_id": "C_release_bundle_manifest",

--- a/docs/context/evidence/issue_4683_release_assurance_case_example.json
+++ b/docs/context/evidence/issue_4683_release_assurance_case_example.json
@@ -202,7 +202,7 @@
       "kind": "file",
       "manifest_field": "release_checklist_path",
       "path": "docs/RELEASE.md",
-      "sha256": "b38fbb18f5cab43bd23c4bbe44ecb46ad9a89f8dcac6e31eba63989d67b13a34"
+      "sha256": "00fca16d043d7a1dd567194a27719d2009d347c70b389a9c769732ea82cb4e5c"
     },
     {
       "description": "Citation metadata referenced by the release manifest.",
@@ -210,7 +210,7 @@
       "kind": "file",
       "manifest_field": "citation_path",
       "path": "CITATION.cff",
-      "sha256": "39725ab6c3cb7c21f294bc7a562056ef3293a647bbe770d905747662615249a8"
+      "sha256": "152bcd378403de5c59138447a42ad9f126bfe4d2d96a03915330adc87d5473a2"
     },
     {
       "description": "Social Navigation Quality Index weights referenced by the manifest.",

--- a/hooks/check_release_assurance_hashes.py
+++ b/hooks/check_release_assurance_hashes.py
@@ -1,121 +1,99 @@
 #!/usr/bin/env python3
-"""Pre-commit hook to keep release-assurance evidence hashes aligned with source files.
-
-This hook checks if any files referenced in the release-assurance evidence file
-have changed. If they have, it updates the SHA-256 hashes in the evidence file
-and adds the updated file to the commit.
-"""
+"""Keep staged release-assurance evidence hashes aligned with staged source files."""
 
 from __future__ import annotations
 
 import hashlib
 import json
 import subprocess
+import sys
 from pathlib import Path
+from typing import Any
+
+EVIDENCE_PATH = Path("docs/context/evidence/issue_4683_release_assurance_case_example.json")
 
 
-def _sha256_file(path: Path) -> str:
-    """Return sha256 digest for a file."""
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _get_staged_files() -> list[Path]:
-    """Get list of files staged for commit."""
+def _repo_root() -> Path:
+    """Return the repository root for the active Git index."""
     result = subprocess.run(
-        ["git", "diff", "--cached", "--name-only"],
+        ["git", "rev-parse", "--show-toplevel"],
         check=True,
         capture_output=True,
         text=True,
     )
-    return [Path(line) for line in result.stdout.splitlines() if line.strip()]
+    return Path(result.stdout.strip())
 
 
-def _add_file_to_commit(path: Path) -> None:
-    """Add a file to the current commit."""
-    subprocess.run(
-        ["git", "add", str(path)],
-        check=True,
+def _staged_bytes(repo_root: Path, relative_path: Path) -> bytes:
+    """Read a regular tracked file from the Git index, failing closed otherwise."""
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        raise ValueError(f"Evidence path must be repository-relative: {relative_path}")
+    working_path = repo_root / relative_path
+    if not working_path.is_file():
+        raise ValueError(f"Evidence path is not a regular working-tree file: {relative_path}")
+    result = subprocess.run(
+        ["git", "show", f":{relative_path.as_posix()}"],
+        cwd=repo_root,
+        check=False,
         capture_output=True,
-        text=True,
     )
+    if result.returncode != 0:
+        raise ValueError(f"Evidence path is not staged: {relative_path}")
+    return result.stdout
 
 
-def _load_evidence_payload(evidence_path: Path) -> dict | None:
-    """Load and validate the evidence payload."""
-    if not evidence_path.exists():
-        return None
-
+def _load_staged_evidence(repo_root: Path) -> dict[str, Any]:
+    """Load the staged evidence object, rejecting malformed payloads."""
     try:
-        payload = json.loads(evidence_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return None
-
-    if not isinstance(payload, dict) or "evidence" not in payload:
-        return None
-
+        payload = json.loads(_staged_bytes(repo_root, EVIDENCE_PATH))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Invalid staged release-assurance evidence: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Release-assurance evidence root must be an object.")
+    if not isinstance(payload.get("evidence"), list):
+        raise ValueError("Release-assurance evidence must contain an evidence list.")
     return payload
 
 
-def _update_evidence_hashes(payload: dict, staged_files: list[Path]) -> bool:
-    """Update evidence hashes for staged files. Returns True if any updates were made."""
-    evidence_entries = payload.get("evidence", [])
+def _update_evidence_hashes(repo_root: Path, payload: dict[str, Any]) -> bool:
+    """Update every evidence digest from its staged source content."""
     updated = False
-
-    for entry in evidence_entries:
+    for entry in payload["evidence"]:
         if not isinstance(entry, dict):
-            continue
-
-        evidence_path_str = entry.get("path")
-        if not evidence_path_str:
-            continue
-
-        evidence_file = Path(evidence_path_str)
-
-        # Check if this evidence file is staged
-        if evidence_file not in staged_files:
-            continue
-
-        # Check if the file exists
-        if not evidence_file.exists():
-            continue
-
-        # Calculate current hash
-        current_hash = _sha256_file(evidence_file)
-        recorded_hash = entry.get("sha256")
-
-        # Update if hash is different
-        if current_hash != recorded_hash:
-            entry["sha256"] = current_hash
+            raise ValueError("Each release-assurance evidence entry must be an object.")
+        raw_path = entry.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            raise ValueError("Each release-assurance evidence entry requires a path.")
+        digest = hashlib.sha256(_staged_bytes(repo_root, Path(raw_path))).hexdigest()
+        if entry.get("sha256") != digest:
+            entry["sha256"] = digest
             updated = True
-
     return updated
 
 
-def main() -> int:
-    """Run the release-assurance hash check."""
-    evidence_path = Path("docs/context/evidence/issue_4683_release_assurance_case_example.json")
+def _stage_evidence(repo_root: Path) -> None:
+    """Stage the regenerated evidence document."""
+    subprocess.run(["git", "add", str(EVIDENCE_PATH)], cwd=repo_root, check=True)
 
-    payload = _load_evidence_payload(evidence_path)
-    if payload is None:
+
+def main() -> int:
+    """Synchronize release-assurance hashes and require a reviewable recommit if changed."""
+    try:
+        repo_root = _repo_root()
+        payload = _load_staged_evidence(repo_root)
+        updated = _update_evidence_hashes(repo_root, payload)
+    except (OSError, subprocess.CalledProcessError, ValueError) as exc:
+        sys.stderr.write(f"release-assurance hash hook: {exc}\n")
+        return 1
+
+    if not updated:
         return 0
 
-    staged_files = _get_staged_files()
-    updated = _update_evidence_hashes(payload, staged_files)
-
-    if updated:
-        # Write updated evidence file
-        evidence_path.write_text(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        # Add updated evidence file to commit
-        _add_file_to_commit(evidence_path)
-
-    return 0
+    evidence_path = repo_root / EVIDENCE_PATH
+    evidence_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _stage_evidence(repo_root)
+    sys.stderr.write("Updated staged release-assurance hashes; review and commit again.\n")
+    return 1
 
 
 if __name__ == "__main__":

--- a/hooks/check_release_assurance_hashes.py
+++ b/hooks/check_release_assurance_hashes.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Pre-commit hook to keep release-assurance evidence hashes aligned with source files.
+
+This hook checks if any files referenced in the release-assurance evidence file
+have changed. If they have, it updates the SHA-256 hashes in the evidence file
+and adds the updated file to the commit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+
+def _sha256_file(path: Path) -> str:
+    """Return sha256 digest for a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _get_staged_files() -> list[Path]:
+    """Get list of files staged for commit."""
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [Path(line) for line in result.stdout.splitlines() if line.strip()]
+
+
+def _add_file_to_commit(path: Path) -> None:
+    """Add a file to the current commit."""
+    subprocess.run(
+        ["git", "add", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _load_evidence_payload(evidence_path: Path) -> dict | None:
+    """Load and validate the evidence payload."""
+    if not evidence_path.exists():
+        return None
+
+    try:
+        payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+    if not isinstance(payload, dict) or "evidence" not in payload:
+        return None
+
+    return payload
+
+
+def _update_evidence_hashes(payload: dict, staged_files: list[Path]) -> bool:
+    """Update evidence hashes for staged files. Returns True if any updates were made."""
+    evidence_entries = payload.get("evidence", [])
+    updated = False
+
+    for entry in evidence_entries:
+        if not isinstance(entry, dict):
+            continue
+
+        evidence_path_str = entry.get("path")
+        if not evidence_path_str:
+            continue
+
+        evidence_file = Path(evidence_path_str)
+
+        # Check if this evidence file is staged
+        if evidence_file not in staged_files:
+            continue
+
+        # Check if the file exists
+        if not evidence_file.exists():
+            continue
+
+        # Calculate current hash
+        current_hash = _sha256_file(evidence_file)
+        recorded_hash = entry.get("sha256")
+
+        # Update if hash is different
+        if current_hash != recorded_hash:
+            entry["sha256"] = current_hash
+            updated = True
+
+    return updated
+
+
+def main() -> int:
+    """Run the release-assurance hash check."""
+    evidence_path = Path("docs/context/evidence/issue_4683_release_assurance_case_example.json")
+
+    payload = _load_evidence_payload(evidence_path)
+    if payload is None:
+        return 0
+
+    staged_files = _get_staged_files()
+    updated = _update_evidence_hashes(payload, staged_files)
+
+    if updated:
+        # Write updated evidence file
+        evidence_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        # Add updated evidence file to commit
+        _add_file_to_commit(evidence_path)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/robot_sf/benchmark/release_assurance_case.py
+++ b/robot_sf/benchmark/release_assurance_case.py
@@ -285,6 +285,7 @@ def build_release_assurance_case(
 
     return {
         "schema_version": RELEASE_ASSURANCE_CASE_SCHEMA_VERSION,
+        "review_marker": "AI-GENERATED NEEDS-REVIEW",
         "generated_at_utc": generated_at_utc
         or datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         "release": {

--- a/robot_sf/benchmark/schemas/release_assurance_case.schema.v1.json
+++ b/robot_sf/benchmark/schemas/release_assurance_case.schema.v1.json
@@ -6,6 +6,7 @@
   "additionalProperties": false,
   "required": [
     "schema_version",
+    "review_marker",
     "generated_at_utc",
     "release",
     "claim_boundary",
@@ -19,6 +20,9 @@
   "properties": {
     "schema_version": {
       "const": "benchmark_release_assurance_case.v1"
+    },
+    "review_marker": {
+      "const": "AI-GENERATED NEEDS-REVIEW"
     },
     "generated_at_utc": {
       "type": "string",

--- a/tests/benchmark/test_release_assurance_case.py
+++ b/tests/benchmark/test_release_assurance_case.py
@@ -29,6 +29,7 @@ def test_release_assurance_case_exports_gate_claims_and_manifest_evidence() -> N
     validate_release_assurance_case_schema(payload)
     assert validate_release_assurance_case_references(payload) == []
     assert payload["schema_version"] == "benchmark_release_assurance_case.v1"
+    assert payload["review_marker"] == "AI-GENERATED NEEDS-REVIEW"
     assert payload["release"]["release_id"] == "paper_experiment_matrix_v1_smoke_v0_1_0"
     assert "C_gate_collision_rate_zero" in {claim["id"] for claim in payload["claims"]}
     assert "E_release_gate_spec" in {leaf["id"] for leaf in payload["evidence"]}

--- a/tests/hooks/test_check_release_assurance_hashes.py
+++ b/tests/hooks/test_check_release_assurance_hashes.py
@@ -1,0 +1,73 @@
+"""Contract tests for the release-assurance pre-commit hook."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_HOOK_PATH = Path(__file__).resolve().parents[2] / "hooks" / "check_release_assurance_hashes.py"
+_SPEC = importlib.util.spec_from_file_location("check_release_assurance_hashes", _HOOK_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_HOOK = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_HOOK)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _write_evidence(repo: Path, source_path: str, digest: str) -> Path:
+    evidence_path = repo / _HOOK.EVIDENCE_PATH
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_text(
+        json.dumps({"evidence": [{"path": source_path, "sha256": digest}]}) + "\n",
+        encoding="utf-8",
+    )
+    return evidence_path
+
+
+@pytest.fixture
+def indexed_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Create a small repository whose evidence and source are staged."""
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "gate@example.invalid")
+    _git(tmp_path, "config", "user.name", "Gate")
+    source = tmp_path / "docs" / "RELEASE.md"
+    source.parent.mkdir()
+    source.write_text("old release\n", encoding="utf-8")
+    _write_evidence(tmp_path, "docs/RELEASE.md", hashlib.sha256(source.read_bytes()).hexdigest())
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "initial")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path, source
+
+
+def test_updates_and_stages_hash_from_index_not_unstaged_worktree(
+    indexed_repo: tuple[Path, Path],
+) -> None:
+    """A staged source digest wins over conflicting unstaged bytes."""
+    repo, source = indexed_repo
+    source.write_text("staged release\n", encoding="utf-8")
+    _git(repo, "add", "docs/RELEASE.md")
+    source.write_text("unstaged release\n", encoding="utf-8")
+
+    assert _HOOK.main() == 1
+
+    staged_evidence = json.loads(_git(repo, "show", f":{_HOOK.EVIDENCE_PATH.as_posix()}").stdout)
+    assert (
+        staged_evidence["evidence"][0]["sha256"] == hashlib.sha256(b"staged release\n").hexdigest()
+    )
+
+
+def test_rejects_non_file_evidence_path(indexed_repo: tuple[Path, Path]) -> None:
+    """Directory-valued evidence paths fail closed rather than being hashed."""
+    repo, _ = indexed_repo
+    _write_evidence(repo, "docs", "ignored")
+    _git(repo, "add", _HOOK.EVIDENCE_PATH.as_posix())
+
+    assert _HOOK.main() == 1


### PR DESCRIPTION
## What

Fix stale SHA-256 hashes in the release-assurance evidence file and add a pre-commit hook to automatically keep them aligned with source files.

## Why

The test `test_checked_in_release_assurance_case_example_stays_fresh` was failing because the SHA-256 hashes for `docs/RELEASE.md` and `CITATION.cff` in the evidence file `docs/context/evidence/issue_4683_release_assurance_case_example.json` were stale. This was blocking PR #5351.

## Changes

1. Updated stale SHA-256 hashes in the evidence file
2. Created a new pre-commit hook `hooks/check_release_assurance_hashes.py` that automatically updates hashes when referenced source files change
3. Extended `.pre-commit-config.yaml` with the new hook

## Validation

All release-assurance tests pass:
```
tests/benchmark/test_release_assurance_case.py::test_release_assurance_case_exports_gate_claims_and_manifest_evidence PASSED
tests/benchmark/test_release_assurance_case.py::test_release_assurance_case_reference_check_fails_on_stale_sha PASSED
tests/benchmark/test_release_assurance_case.py::test_checked_in_release_assurance_case_example_stays_fresh PASSED
```

Ruff linting and formatting pass on the new hook file.

## PR Details

Closes #5363

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.