### PR TITLE
Issue #5353: emit fairness flags in campaign report (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/camera_ready/_reporting.py
+++ b/robot_sf/benchmark/camera_ready/_reporting.py
@@ -15,10 +15,7 @@ from robot_sf.benchmark.aggregate import read_jsonl
 from robot_sf.benchmark.camera_ready._artifacts import _escape_markdown_cell
 from robot_sf.benchmark.camera_ready._config_types import _AMV_DIMENSIONS, PlannerSpec
 from robot_sf.benchmark.camera_ready._summaries import _extract_amv_taxonomy
-from robot_sf.benchmark.fairness_contract import (
-    build_fairness_report,
-    emit_fairness_annotations,
-)
+from robot_sf.benchmark.fairness_contract import build_fairness_report
 from robot_sf.benchmark.fallback_policy import (
     classify_planner_row_status,
     summarize_benchmark_availability,
@@ -1019,41 +1016,75 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
             lines.append(f"- Sensitivity CSV: `{snqi_sensitivity}`")
 
     lines.extend(["", "## Fairness Contract", ""])
-    fairness_report = build_fairness_report(rows)
-    emit_fairness_annotations(fairness_report, rows)
-    fairness_verdict = fairness_report.ranking_claim_allowed
-    hard_mismatches = [m for m in fairness_report.mismatches if m.severity == "hard"]
-    soft_mismatches = [m for m in fairness_report.mismatches if m.severity == "soft"]
+    fairness_payload = payload.get("fairness_contract")
+    fairness_report = (
+        build_fairness_report(rows) if not isinstance(fairness_payload, dict) else None
+    )
+    fairness_verdict = (
+        bool(fairness_payload.get("ranking_claim_allowed"))
+        if isinstance(fairness_payload, dict)
+        else fairness_report.ranking_claim_allowed
+    )
+    fair_subset = (
+        list(fairness_payload.get("fair_subset", []))
+        if isinstance(fairness_payload, dict)
+        else list(fairness_report.fair_subset)
+    )
+    excluded_planners = (
+        list(fairness_payload.get("excluded_planners", []))
+        if isinstance(fairness_payload, dict)
+        else list(fairness_report.excluded_planners)
+    )
+    mismatches = (
+        list(fairness_payload.get("mismatches", []))
+        if isinstance(fairness_payload, dict)
+        else [
+            {
+                "dimension": mismatch.dimension,
+                "planner_a": mismatch.planner_a,
+                "planner_b": mismatch.planner_b,
+                "severity": mismatch.severity,
+                "description": mismatch.description,
+            }
+            for mismatch in fairness_report.mismatches
+        ]
+    )
+    hard_mismatches = [m for m in mismatches if m.get("severity") == "hard"]
+    soft_mismatches = [m for m in mismatches if m.get("severity") == "soft"]
 
     lines.append(f"- Ranking claim allowed: `{fairness_verdict}`")
-    lines.append(f"- Fair subset size: `{len(fairness_report.fair_subset)}`")
-    lines.append(f"- Excluded planners: `{len(fairness_report.excluded_planners)}`")
+    lines.append(f"- Fair subset size: `{len(fair_subset)}`")
+    lines.append(f"- Excluded planners: `{len(excluded_planners)}`")
     lines.append(f"- Hard mismatches: `{len(hard_mismatches)}`")
     lines.append(f"- Soft mismatches (caveats): `{len(soft_mismatches)}`")
 
-    if fairness_report.fair_subset:
+    if fair_subset:
         lines.append("")
         lines.append("Fair comparison subset:")
-        for name in fairness_report.fair_subset:
+        for name in fair_subset:
             lines.append(f"- `{name}`")
 
-    if fairness_report.excluded_planners:
+    if excluded_planners:
         lines.append("")
         lines.append("Excluded planners:")
-        for name in fairness_report.excluded_planners:
+        for name in excluded_planners:
             lines.append(f"- `{name}`")
 
     if hard_mismatches:
         lines.append("")
         lines.append("Hard mismatches (block ranking claims):")
         for m in hard_mismatches:
-            lines.append(f"- **{m.dimension}**: {m.planner_a} vs {m.planner_b} — {m.description}")
+            lines.append(
+                f"- **{m['dimension']}**: {m['planner_a']} vs {m['planner_b']} — {m['description']}"
+            )
 
     if soft_mismatches:
         lines.append("")
         lines.append("Soft mismatches (caveats):")
         for m in soft_mismatches:
-            lines.append(f"- **{m.dimension}**: {m.planner_a} vs {m.planner_b} — {m.description}")
+            lines.append(
+                f"- **{m['dimension']}**: {m['planner_a']} vs {m['planner_b']} — {m['description']}"
+            )
 
     lines.extend(["", "## Accepted Unavailable/Excluded Planners", ""])
     if accepted_unavailable_rows:

--- a/robot_sf/benchmark/camera_ready/_reporting.py
+++ b/robot_sf/benchmark/camera_ready/_reporting.py
@@ -15,6 +15,10 @@ from robot_sf.benchmark.aggregate import read_jsonl
 from robot_sf.benchmark.camera_ready._artifacts import _escape_markdown_cell
 from robot_sf.benchmark.camera_ready._config_types import _AMV_DIMENSIONS, PlannerSpec
 from robot_sf.benchmark.camera_ready._summaries import _extract_amv_taxonomy
+from robot_sf.benchmark.fairness_contract import (
+    build_fairness_report,
+    emit_fairness_annotations,
+)
 from robot_sf.benchmark.fallback_policy import (
     classify_planner_row_status,
     summarize_benchmark_availability,
@@ -1013,6 +1017,43 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
             lines.append(f"- Diagnostics Markdown: `{snqi_diag_md}`")
         if isinstance(snqi_sensitivity, str):
             lines.append(f"- Sensitivity CSV: `{snqi_sensitivity}`")
+
+    lines.extend(["", "## Fairness Contract", ""])
+    fairness_report = build_fairness_report(rows)
+    emit_fairness_annotations(fairness_report, rows)
+    fairness_verdict = fairness_report.ranking_claim_allowed
+    hard_mismatches = [m for m in fairness_report.mismatches if m.severity == "hard"]
+    soft_mismatches = [m for m in fairness_report.mismatches if m.severity == "soft"]
+
+    lines.append(f"- Ranking claim allowed: `{fairness_verdict}`")
+    lines.append(f"- Fair subset size: `{len(fairness_report.fair_subset)}`")
+    lines.append(f"- Excluded planners: `{len(fairness_report.excluded_planners)}`")
+    lines.append(f"- Hard mismatches: `{len(hard_mismatches)}`")
+    lines.append(f"- Soft mismatches (caveats): `{len(soft_mismatches)}`")
+
+    if fairness_report.fair_subset:
+        lines.append("")
+        lines.append("Fair comparison subset:")
+        for name in fairness_report.fair_subset:
+            lines.append(f"- `{name}`")
+
+    if fairness_report.excluded_planners:
+        lines.append("")
+        lines.append("Excluded planners:")
+        for name in fairness_report.excluded_planners:
+            lines.append(f"- `{name}`")
+
+    if hard_mismatches:
+        lines.append("")
+        lines.append("Hard mismatches (block ranking claims):")
+        for m in hard_mismatches:
+            lines.append(f"- **{m.dimension}**: {m.planner_a} vs {m.planner_b} — {m.description}")
+
+    if soft_mismatches:
+        lines.append("")
+        lines.append("Soft mismatches (caveats):")
+        for m in soft_mismatches:
+            lines.append(f"- **{m.dimension}**: {m.planner_a} vs {m.planner_b} — {m.description}")
 
     lines.extend(["", "## Accepted Unavailable/Excluded Planners", ""])
     if accepted_unavailable_rows:

--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -67,6 +67,7 @@ from robot_sf.benchmark.camera_ready._util import (
     _synthetic_actuation_metadata,
     _utc_now,
 )
+from robot_sf.benchmark.fairness_contract import build_fairness_report, emit_fairness_annotations
 from robot_sf.benchmark.fallback_policy import (
     availability_payload,
     classify_planner_row_status,
@@ -1224,6 +1225,18 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
     planner_rows.sort(
         key=lambda row: (row.get("snqi_mean", "nan") == "nan", row.get("planner_key"))
     )
+    fairness_report = build_fairness_report(
+        [
+            {
+                "algo": planner.algo,
+                "observation_mode": planner.observation_mode or cfg.observation_mode,
+                "tuning": asdict(planner.tuning) if planner.tuning is not None else {},
+            }
+            for planner in cfg.planners
+            if planner.enabled
+        ]
+    )
+    emit_fairness_annotations(fairness_report, planner_rows)
 
     summary_json_path = reports_dir / "campaign_summary.json"
     report_md_path = reports_dir / "campaign_report.md"
@@ -1266,6 +1279,8 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
             "comfort_exposure_mean",
             "jerk_mean",
             "snqi_mean",
+            "fairness_mismatch_flags",
+            "fairness_in_ranking_subset",
         ),
     )
     if cfg.paper_facing:
@@ -1716,6 +1731,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
         )
 
     campaign_summary = {
+        "fairness_contract": fairness_report.to_dict(),
         "campaign": {
             "schema_version": CAMPAIGN_SCHEMA_VERSION,
             "campaign_id": campaign_id,

--- a/robot_sf/benchmark/fairness_contract.py
+++ b/robot_sf/benchmark/fairness_contract.py
@@ -644,7 +644,7 @@ def emit_fairness_annotations(
             or ``algo`` to identify the planner.
     """
     for row in rows:
-        algo = str(row.get("planner_key", row.get("algo", "")))
+        algo = str(row.get("algo", row.get("planner_key", "")))
         if not algo:
             continue
         try:

--- a/robot_sf/benchmark/fairness_contract.py
+++ b/robot_sf/benchmark/fairness_contract.py
@@ -596,6 +596,65 @@ def emit_mismatch_flags(
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Fairness report builder
+# ──────────────────────────────────────────────────────────────────────
+
+
+def build_fairness_report(
+    planner_configs: list[dict[str, Any]],
+) -> FairnessReport:
+    """Build a complete fairness report from campaign planner configs.
+
+    Constructs the capability matrix, detects mismatches, computes the
+    fair-comparison subset, and evaluates the ranking-claim gate.
+
+    Args:
+        planner_configs: List of planner config dicts, each with at minimum
+            ``algo`` (the algorithm key).  Optional keys: ``observation_mode``,
+            ``tuning`` (dict with ``budget_runs`` and ``source``).
+
+    Returns:
+        FairnessReport with matrix, mismatches, fair subset, and verdict.
+    """
+    matrix = build_capability_matrix(planner_configs)
+    mismatches = detect_mismatches(matrix)
+    fair, excluded = fair_comparison_subset(matrix, mismatches)
+    verdict = ranking_claim_gate(matrix)
+    return FairnessReport(
+        matrix=matrix,
+        mismatches=mismatches,
+        fair_subset=fair,
+        excluded_planners=excluded,
+        ranking_claim_allowed=verdict.allowed,
+    )
+
+
+def emit_fairness_annotations(
+    report: FairnessReport,
+    rows: list[dict[str, Any]],
+) -> None:
+    """Annotate campaign report rows with fairness mismatch flags.
+
+    Mutates each row in place, adding ``fairness_mismatch_flags`` and
+    ``fairness_in_ranking_subset`` keys.
+
+    Args:
+        report: The FairnessReport to use for annotation.
+        rows: List of campaign report row dicts.  Each must have ``planner_key``
+            or ``algo`` to identify the planner.
+    """
+    for row in rows:
+        algo = str(row.get("planner_key", row.get("algo", "")))
+        if not algo:
+            continue
+        try:
+            emit_mismatch_flags(report.matrix, row, algo)
+        except KeyError:
+            row["fairness_mismatch_flags"] = []
+            row["fairness_in_ranking_subset"] = False
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Internal helpers
 # ──────────────────────────────────────────────────────────────────────
 
@@ -629,7 +688,9 @@ __all__ = [
     "RankingClaimVerdict",
     "build_capability_entry",
     "build_capability_matrix",
+    "build_fairness_report",
     "detect_mismatches",
+    "emit_fairness_annotations",
     "emit_mismatch_flags",
     "fair_comparison_subset",
     "ranking_claim_gate",

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -3574,6 +3574,147 @@ def test_write_campaign_report_routes_non_success_rows_to_expected_sections(
     assert "accepted_row" not in unexpected_section
 
 
+def test_write_campaign_report_emits_fairness_contract(tmp_path: Path) -> None:
+    """Campaign report includes fairness contract section with mismatch details."""
+    report_path = tmp_path / "campaign_report.md"
+    payload = {
+        "campaign": {"campaign_id": "c1"},
+        "warnings": [],
+        "planner_rows": [
+            {
+                "planner_key": "social_force",
+                "algo": "social_force",
+                "planner_group": "core",
+                "kinematics": "holonomic",
+                "status": "ok",
+                "started_at_utc": "now",
+                "runtime_sec": 1.0,
+                "episodes": 1,
+                "episodes_per_second": 1.0,
+                "success_mean": "0.8",
+                "collisions_mean": "0.0",
+                "snqi_mean": "0.5",
+                "projection_rate": "0.0",
+                "infeasible_rate": "0.0",
+                "execution_mode": "adapter",
+                "execution_detail": "orca_adapter",
+                "planner_command_space": "holonomic_vxy_world",
+                "benchmark_command_space": "holonomic_vxy_world",
+                "projection_policy": "world_velocity_passthrough",
+                "readiness_status": "ok",
+                "readiness_tier": "baseline-ready",
+                "preflight_status": "ok",
+                "learned_policy_contract_status": "not_applicable",
+                "socnav_prereq_policy": "fail-fast",
+            },
+            {
+                "planner_key": "orca",
+                "algo": "orca",
+                "planner_group": "core",
+                "kinematics": "holonomic",
+                "status": "ok",
+                "started_at_utc": "now",
+                "runtime_sec": 1.0,
+                "episodes": 1,
+                "episodes_per_second": 1.0,
+                "success_mean": "0.7",
+                "collisions_mean": "0.0",
+                "snqi_mean": "0.4",
+                "projection_rate": "0.0",
+                "infeasible_rate": "0.0",
+                "execution_mode": "adapter",
+                "execution_detail": "orca_adapter",
+                "planner_command_space": "holonomic_vxy_world",
+                "benchmark_command_space": "holonomic_vxy_world",
+                "projection_policy": "world_velocity_passthrough",
+                "readiness_status": "ok",
+                "readiness_tier": "baseline-ready",
+                "preflight_status": "ok",
+                "learned_policy_contract_status": "not_applicable",
+                "socnav_prereq_policy": "fail-fast",
+            },
+        ],
+    }
+
+    write_campaign_report(report_path, payload)
+    report_text = report_path.read_text(encoding="utf-8")
+
+    assert "## Fairness Contract" in report_text
+    assert "Ranking claim allowed: `True`" in report_text
+    assert "Fair subset size: `2`" in report_text
+    assert "Excluded planners: `0`" in report_text
+
+
+def test_write_campaign_report_fairness_blocks_mismatched(tmp_path: Path) -> None:
+    """Campaign report fairness contract blocks ranking claims for mismatched planners."""
+    report_path = tmp_path / "campaign_report.md"
+    payload = {
+        "campaign": {"campaign_id": "c1"},
+        "warnings": [],
+        "planner_rows": [
+            {
+                "planner_key": "goal",
+                "algo": "goal",
+                "planner_group": "core",
+                "kinematics": "holonomic",
+                "status": "ok",
+                "started_at_utc": "now",
+                "runtime_sec": 1.0,
+                "episodes": 1,
+                "episodes_per_second": 1.0,
+                "success_mean": "0.8",
+                "collisions_mean": "0.0",
+                "snqi_mean": "0.5",
+                "projection_rate": "0.0",
+                "infeasible_rate": "0.0",
+                "execution_mode": "native",
+                "execution_detail": "direct_holonomic_world_velocity",
+                "planner_command_space": "holonomic_vxy_world",
+                "benchmark_command_space": "holonomic_vxy_world",
+                "projection_policy": "world_velocity_passthrough",
+                "readiness_status": "ok",
+                "readiness_tier": "baseline-ready",
+                "preflight_status": "ok",
+                "learned_policy_contract_status": "not_applicable",
+                "socnav_prereq_policy": "fail-fast",
+            },
+            {
+                "planner_key": "ppo",
+                "algo": "ppo",
+                "planner_group": "learning",
+                "kinematics": "holonomic",
+                "status": "ok",
+                "started_at_utc": "now",
+                "runtime_sec": 1.0,
+                "episodes": 1,
+                "episodes_per_second": 1.0,
+                "success_mean": "0.7",
+                "collisions_mean": "0.0",
+                "snqi_mean": "0.4",
+                "projection_rate": "0.0",
+                "infeasible_rate": "0.0",
+                "execution_mode": "mixed",
+                "execution_detail": "ppo_adapter",
+                "planner_command_space": "holonomic_vxy_world",
+                "benchmark_command_space": "holonomic_vxy_world",
+                "projection_policy": "world_velocity_passthrough",
+                "readiness_status": "ok",
+                "readiness_tier": "experimental",
+                "preflight_status": "ok",
+                "learned_policy_contract_status": "not_applicable",
+                "socnav_prereq_policy": "fail-fast",
+            },
+        ],
+    }
+
+    write_campaign_report(report_path, payload)
+    report_text = report_path.read_text(encoding="utf-8")
+
+    assert "## Fairness Contract" in report_text
+    assert "Ranking claim allowed: `False`" in report_text
+    assert "Excluded planners:" in report_text
+
+
 def test_planner_report_row_uses_nested_planner_kinematics_execution_mode() -> None:
     """Row builder should read execution_mode from nested planner_kinematics payload."""
     planner = PlannerSpec(key="prediction_planner", algo="prediction_planner")

--- a/tests/test_fairness_contract.py
+++ b/tests/test_fairness_contract.py
@@ -462,3 +462,16 @@ def test_emit_fairness_annotations_handles_unknown_planner():
     emit_fairness_annotations(report, rows)
     assert rows[0]["fairness_mismatch_flags"] == []
     assert rows[0]["fairness_in_ranking_subset"] is False
+
+
+def test_emit_fairness_annotations_uses_algo_for_custom_planner_key():
+    """A custom campaign instance key retains its canonical algorithm classification."""
+    from robot_sf.benchmark.fairness_contract import (
+        build_fairness_report,
+        emit_fairness_annotations,
+    )
+
+    report = build_fairness_report([{"algo": "orca"}])
+    rows = [{"planner_key": "custom_orca", "algo": "orca"}]
+    emit_fairness_annotations(report, rows)
+    assert rows[0]["fairness_in_ranking_subset"] is True

--- a/tests/test_fairness_contract.py
+++ b/tests/test_fairness_contract.py
@@ -353,3 +353,112 @@ def test_matched_rows_pass_ranking_gate():
     # socnav_orca_nonholonomic is experimental vs baseline-ready but
     # readiness tier is not a fairness dimension; observation/adapter match
     assert verdict.hard_mismatch_count == 0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fairness report builder
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_build_fairness_report_all_matched():
+    """build_fairness_report returns a complete report for matched planners."""
+    from robot_sf.benchmark.fairness_contract import build_fairness_report
+
+    configs = [
+        {"algo": "social_force"},
+        {"algo": "orca"},
+    ]
+    report = build_fairness_report(configs)
+    assert report.ranking_claim_allowed is True
+    assert len(report.mismatches) >= 1  # soft adapter name mismatch expected
+    assert len(report.fair_subset) == 2
+    assert len(report.excluded_planners) == 0
+
+
+def test_build_fairness_report_mismatched():
+    """build_fairness_report blocks ranking claims for mismatched planners."""
+    from robot_sf.benchmark.fairness_contract import build_fairness_report
+
+    configs = [
+        {"algo": "goal"},
+        {"algo": "ppo"},
+    ]
+    report = build_fairness_report(configs)
+    assert report.ranking_claim_allowed is False
+    assert len(report.excluded_planners) >= 1
+
+
+def test_build_fairness_report_serialization():
+    """Fairness report serialization round-trips through to_dict."""
+    from robot_sf.benchmark.fairness_contract import build_fairness_report
+
+    configs = [
+        {"algo": "social_force"},
+        {"algo": "orca"},
+    ]
+    report = build_fairness_report(configs)
+    d = report.to_dict()
+    assert "matrix" in d
+    assert "mismatches" in d
+    assert "fair_subset" in d
+    assert "ranking_claim_allowed" in d
+    assert isinstance(d["mismatches"], list)
+
+
+def test_emit_fairness_annotations():
+    """emit_fairness_annotations mutates rows in place with fairness keys."""
+    from robot_sf.benchmark.fairness_contract import (
+        build_fairness_report,
+        emit_fairness_annotations,
+    )
+
+    configs = [
+        {"algo": "social_force"},
+        {"algo": "orca"},
+    ]
+    report = build_fairness_report(configs)
+    rows = [
+        {"planner_key": "social_force", "algo": "social_force", "success_mean": 0.8},
+        {"planner_key": "orca", "algo": "orca", "success_mean": 0.7},
+    ]
+    emit_fairness_annotations(report, rows)
+    for row in rows:
+        assert "fairness_mismatch_flags" in row
+        assert "fairness_in_ranking_subset" in row
+        assert isinstance(row["fairness_mismatch_flags"], list)
+
+
+def test_emit_fairness_annotations_excluded_planners():
+    """Excluded planners get fairness_in_ranking_subset=False."""
+    from robot_sf.benchmark.fairness_contract import (
+        build_fairness_report,
+        emit_fairness_annotations,
+    )
+
+    configs = [
+        {"algo": "goal"},
+        {"algo": "ppo"},
+    ]
+    report = build_fairness_report(configs)
+    rows = [
+        {"planner_key": "goal", "algo": "goal"},
+        {"planner_key": "ppo", "algo": "ppo"},
+    ]
+    emit_fairness_annotations(report, rows)
+    for row in rows:
+        assert row["fairness_in_ranking_subset"] is False
+
+
+def test_emit_fairness_annotations_handles_unknown_planner():
+    """emit_fairness_annotations handles rows with unknown planners gracefully."""
+    from robot_sf.benchmark.fairness_contract import (
+        build_fairness_report,
+        emit_fairness_annotations,
+    )
+
+    configs = [{"algo": "orca"}]
+    report = build_fairness_report(configs)
+    rows = [{"planner_key": "unknown_planner", "algo": "unknown"}]
+    emit_fairness_annotations(report, rows)
+    assert rows[0]["fairness_mismatch_flags"] == []
+    assert rows[0]["fairness_in_ranking_subset"] is False


### PR DESCRIPTION
## What

Implements canonical campaign-report emission and end-to-end proof for the matched-capability fairness contract (issue #5353).

### New functions in 

- ****: Builds a complete  from campaign planner configs, including capability matrix, mismatch detection, fair-comparison subset, and ranking-claim verdict.
- ****: Mutates campaign report rows in place, adding  and  annotations.

### Report integration in 

- Hooks  and  into .
- Adds a **Fairness Contract** section to the markdown campaign report showing:
  - Ranking claim verdict (allowed/blocked)
  - Fair subset size and excluded planners
  - Hard mismatches (block ranking claims)
  - Soft mismatches (caveats)
- Annotates each planner row with fairness metadata.

### Tests

- 6 new unit tests for  and 
- 2 new end-to-end tests for campaign report writer integration

## Why

Issue #5365 requires the canonical campaign report writer to emit fairness mismatch annotations and enforce the ranking-claim gate. PR #5358 supplied the API and unit tests; this PR completes the report-layer integration.

## Validation

============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0 -- /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5353-20260712T072219Z/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5353-20260712T072219Z
configfile: pyproject.toml
plugins: cov-7.0.0, timeout-2.4.0, split-0.11.0, xdist-3.8.0, anyio-4.12.1
collecting ... collected 33 items

tests/test_fairness_contract.py::test_build_capability_entry_goal PASSED [  3%]
tests/test_fairness_contract.py::test_build_capability_entry_orca PASSED [  6%]
tests/test_fairness_contract.py::test_build_capability_entry_ppo PASSED  [  9%]
tests/test_fairness_contract.py::test_build_capability_entry_with_overrides PASSED [ 12%]
tests/test_fairness_contract.py::test_build_capability_matrix_from_configs PASSED [ 15%]
tests/test_fairness_contract.py::test_build_capability_matrix_deduplicates PASSED [ 18%]
tests/test_fairness_contract.py::test_build_capability_matrix_tolerates_malformed_tuning PASSED [ 21%]
tests/test_fairness_contract.py::test_capability_entry_to_dict PASSED    [ 24%]
tests/test_fairness_contract.py::test_no_mismatch_between_matched_adapters PASSED [ 27%]
tests/test_fairness_contract.py::test_adapter_mismatch_native_vs_adapter PASSED [ 30%]
tests/test_fairness_contract.py::test_observation_privilege_mismatch PASSED [ 33%]
tests/test_fairness_contract.py::test_tuning_asymmetry_detected PASSED   [ 36%]
tests/test_fairness_contract.py::test_no_tuning_mismatch_when_unknown PASSED [ 39%]
tests/test_fairness_contract.py::test_fair_subset_all_matched PASSED     [ 42%]
tests/test_fairness_contract.py::test_fair_subset_excludes_hard_mismatch PASSED [ 45%]
tests/test_fairness_contract.py::test_fair_subset_three_planners_mixed PASSED [ 48%]
tests/test_fairness_contract.py::test_ranking_gate_allows_matched_planners PASSED [ 51%]
tests/test_fairness_contract.py::test_ranking_gate_blocks_mismatched_planners PASSED [ 54%]
tests/test_fairness_contract.py::test_ranking_gate_soft_mismatch_does_not_block PASSED [ 57%]
tests/test_fairness_contract.py::test_ranking_gate_verdict_serialization PASSED [ 60%]
tests/test_fairness_contract.py::test_ranking_gate_single_planner PASSED [ 63%]
tests/test_fairness_contract.py::test_emit_mismatch_flags_adds_keys PASSED [ 66%]
tests/test_fairness_contract.py::test_emit_mismatch_flags_marks_excluded PASSED [ 69%]
tests/test_fairness_contract.py::test_emit_mismatch_flags_normalizes_and_validates_planner_name PASSED [ 72%]
tests/test_fairness_contract.py::test_fairness_report_serialization PASSED [ 75%]
tests/test_fairness_contract.py::test_mismatched_row_cannot_pass_ranking_gate PASSED [ 78%]
tests/test_fairness_contract.py::test_matched_rows_pass_ranking_gate PASSED [ 81%]
tests/test_fairness_contract.py::test_build_fairness_report_all_matched PASSED [ 84%]
tests/test_fairness_contract.py::test_build_fairness_report_mismatched PASSED [ 87%]
tests/test_fairness_contract.py::test_build_fairness_report_serialization PASSED [ 90%]
tests/test_fairness_contract.py::test_emit_fairness_annotations PASSED   [ 93%]
tests/test_fairness_contract.py::test_emit_fairness_annotations_excluded_planners PASSED [ 96%]
tests/test_fairness_contract.py::test_emit_fairness_annotations_handles_unknown_planner PASSED [100%]

============================= slowest 10 durations =============================

(10 durations < 0.005s hidden.  Use -vv to show these durations.)

Slow Test Report (soft<20s hard=60s, top 10)
1) tests/test_fairness_contract.py::test_emit_mismatch_flags_normalizes_and_validates_planner_name  0.00s
2) tests/test_fairness_contract.py::test_emit_fairness_annotations_excluded_planners  0.00s
3) tests/test_fairness_contract.py::test_mismatched_row_cannot_pass_ranking_gate  0.00s
4) tests/test_fairness_contract.py::test_emit_fairness_annotations  0.00s
5) tests/test_fairness_contract.py::test_build_fairness_report_serialization  0.00s
6) tests/test_fairness_contract.py::test_fair_subset_three_planners_mixed  0.00s
7) tests/test_fairness_contract.py::test_build_capability_entry_goal  0.00s
8) tests/test_fairness_contract.py::test_build_fairness_report_mismatched  0.00s
9) tests/test_fairness_contract.py::test_build_fairness_report_all_matched  0.00s
10) tests/test_fairness_contract.py::test_ranking_gate_blocks_mismatched_planners  0.00s

============================== 33 passed in 0.04s ==============================
============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0 -- /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5353-20260712T072219Z/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/luttkule/git/robot_sf_ll7.worktrees/cheap-issue-5353-20260712T072219Z
configfile: pyproject.toml
plugins: cov-7.0.0, timeout-2.4.0, split-0.11.0, xdist-3.8.0, anyio-4.12.1
collecting ... collected 137 items / 131 deselected / 6 selected

tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_escapes_markdown_cells PASSED [ 16%]
tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_renders_credibility_scorecard PASSED [ 33%]
tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_routes_non_success_rows_to_expected_sections[failed] PASSED [ 50%]
tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_routes_non_success_rows_to_expected_sections[partial-failure] PASSED [ 66%]
tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_emits_fairness_contract PASSED [ 83%]
tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_fairness_blocks_mismatched PASSED [100%]

============================= slowest 10 durations =============================

(10 durations < 0.005s hidden.  Use -vv to show these durations.)

Slow Test Report (soft<20s hard=60s, top 10)
1) tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_escapes_markdown_cells  0.00s
2) tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_fairness_blocks_mismatched  0.00s
3) tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_emits_fairness_contract  0.00s
4) tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_routes_non_success_rows_to_expected_sections[failed]  0.00s
5) tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_renders_credibility_scorecard  0.00s
6) tests/benchmark/test_camera_ready_campaign.py::test_write_campaign_report_routes_non_success_rows_to_expected_sections[partial-failure]  0.00s

====================== 6 passed, 131 deselected in 0.97s =======================
All checks passed!
3 files already formatted

## Successor Statement

This is a successor slice to PR #5358 (merged) which implemented the machine-generated fairness-contract API and unit fail-closed ranking gate. This PR adds the canonical campaign-report emission and end-to-end proof. It does not duplicate PR #5358.

## Scope Boundary

This PR is implementation integrity only — it adds report-layer integration and tests. It does not change metric semantics or make benchmark-result claims.

Closes #5353
Closes #5365

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Fairness Contract section to campaign reports.
  * Reports now show whether ranking claims are allowed, fair comparison subset size, excluded planners, and detected mismatches.
  * Campaign summaries and planner rows now include fairness details and annotations.
* **Bug Fixes**
  * Unknown planners are handled safely and excluded from ranking comparisons.
* **Tests**
  * Added coverage for fairness calculations, report rendering, mismatch handling, and planner annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->