### PR TITLE
Issue #5366: actual execution tests for cold-start reproduction (cheap-lane worker)

### DIFF
--- a/tests/repro/test_release_checksum_verification.py
+++ b/tests/repro/test_release_checksum_verification.py
@@ -449,6 +449,99 @@ class TestReproductionReport:
         assert "v1_2_3_scoped.yaml" in result["reason"]
 
 
+class TestActualExecution:
+    """Tests that validate actual execution of verification and report generation.
+
+    These tests run the real scripts and verify the output artifacts exist
+    with correct structure. They require network access to download the bundle.
+    """
+
+    def test_checksum_verification_report_structure(self, tmp_path: Path) -> None:
+        from scripts.repro.verify_release_checksums import verify_release
+
+        report = verify_release(
+            manifest_path=MANIFEST_PATH,
+            bundle_path=None,
+            output_dir=tmp_path / "verification",
+            download=True,
+        )
+
+        assert report["schema"] == "release-checksum-verification.v1"
+        assert report["release_tag"] == "0.0.2"
+        assert report["overall_verdict"] == "pass"
+        assert "environment" in report
+        assert "verdicts" in report
+        assert "bundle_checksum" in report["verdicts"]
+        assert report["verdicts"]["bundle_checksum"]["match"] is True
+        assert len(report["errors"]) == 0
+
+    def test_checksum_verification_report_json_serializable(self, tmp_path: Path) -> None:
+        from scripts.repro.verify_release_checksums import verify_release
+
+        report = verify_release(
+            manifest_path=MANIFEST_PATH,
+            bundle_path=None,
+            output_dir=tmp_path / "verification",
+            download=True,
+        )
+
+        json_str = json.dumps(report, indent=2, sort_keys=True)
+        assert len(json_str) > 100
+        parsed = json.loads(json_str)
+        assert parsed["overall_verdict"] == "pass"
+
+    def test_cold_start_report_generates_valid_report(self, tmp_path: Path) -> None:
+        from scripts.repro.cold_start_reproduction_report import generate_reproduction_report
+
+        report = generate_reproduction_report(
+            tag="0.0.2",
+            output_dir=tmp_path / "reproduction",
+            local_repo=ROOT,
+            checksums_only=True,
+        )
+
+        assert report["schema"] == "cold-start-reproduction-report.v1"
+        assert report["release_tag"] == "0.0.2"
+        assert report["overall_verdict"] == "pass"
+        assert "environment" in report
+        assert "steps" in report
+        assert "verify_checksums" in report["steps"]
+        assert report["steps"]["verify_checksums"]["status"] == "pass"
+
+    def test_cold_start_report_embedded_artifacts_verified(self, tmp_path: Path) -> None:
+        from scripts.repro.cold_start_reproduction_report import generate_reproduction_report
+
+        report = generate_reproduction_report(
+            tag="0.0.2",
+            output_dir=tmp_path / "reproduction",
+            local_repo=ROOT,
+            checksums_only=True,
+        )
+
+        embedded = report["steps"]["verify_checksums"]["embedded_artifacts"]
+        assert len(embedded) >= 3
+        for artifact in embedded:
+            assert artifact["match"] is True
+            assert artifact["actual_sha256"] == artifact["expected_sha256"]
+
+    def test_report_file_written_to_disk(self, tmp_path: Path) -> None:
+        from scripts.repro.cold_start_reproduction_report import generate_reproduction_report
+
+        output_dir = tmp_path / "reproduction"
+        report = generate_reproduction_report(
+            tag="0.0.2",
+            output_dir=output_dir,
+            local_repo=ROOT,
+            checksums_only=True,
+        )
+
+        report_path = output_dir / "reproduction_report.json"
+        report_path.write_text(json.dumps(report, indent=2, sort_keys=True))
+        assert report_path.is_file()
+        loaded = json.loads(report_path.read_text())
+        assert loaded["overall_verdict"] == "pass"
+
+
 class TestDocumentation:
     """Tests for documentation completeness."""
 

--- a/tests/repro/test_release_checksum_verification.py
+++ b/tests/repro/test_release_checksum_verification.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
 import tarfile
 from io import BytesIO
 from pathlib import Path
@@ -449,6 +450,40 @@ class TestReproductionReport:
         assert "v1_2_3_scoped.yaml" in result["reason"]
 
 
+@pytest.fixture(scope="class")
+def actual_execution_results(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
+    """Run each real release-verification flow once for the execution-test class."""
+    from scripts.repro.verify_release_checksums import verify_release
+
+    execution_dir = tmp_path_factory.mktemp("actual_execution")
+    verify_report = verify_release(
+        manifest_path=MANIFEST_PATH,
+        bundle_path=None,
+        output_dir=execution_dir / "verification",
+        download=True,
+    )
+
+    from scripts.repro.cold_start_reproduction_report import generate_reproduction_report
+
+    reproduction_dir = execution_dir / "reproduction"
+    reproduction_report = generate_reproduction_report(
+        tag="0.0.2",
+        output_dir=reproduction_dir,
+        local_repo=ROOT,
+        checksums_only=True,
+    )
+
+    return {
+        "verification_report": verify_report,
+        "reproduction_report": reproduction_report,
+        "reproduction_dir": reproduction_dir,
+    }
+
+
+@pytest.mark.skipif(
+    not shutil.which("gh"),
+    reason="GitHub CLI 'gh' is required for actual execution tests",
+)
 class TestActualExecution:
     """Tests that validate actual execution of verification and report generation.
 
@@ -456,15 +491,10 @@ class TestActualExecution:
     with correct structure. They require network access to download the bundle.
     """
 
-    def test_checksum_verification_report_structure(self, tmp_path: Path) -> None:
-        from scripts.repro.verify_release_checksums import verify_release
-
-        report = verify_release(
-            manifest_path=MANIFEST_PATH,
-            bundle_path=None,
-            output_dir=tmp_path / "verification",
-            download=True,
-        )
+    def test_checksum_verification_report_structure(
+        self, actual_execution_results: dict[str, Any]
+    ) -> None:
+        report = actual_execution_results["verification_report"]
 
         assert report["schema"] == "release-checksum-verification.v1"
         assert report["release_tag"] == "0.0.2"
@@ -475,30 +505,20 @@ class TestActualExecution:
         assert report["verdicts"]["bundle_checksum"]["match"] is True
         assert len(report["errors"]) == 0
 
-    def test_checksum_verification_report_json_serializable(self, tmp_path: Path) -> None:
-        from scripts.repro.verify_release_checksums import verify_release
-
-        report = verify_release(
-            manifest_path=MANIFEST_PATH,
-            bundle_path=None,
-            output_dir=tmp_path / "verification",
-            download=True,
-        )
+    def test_checksum_verification_report_json_serializable(
+        self, actual_execution_results: dict[str, Any]
+    ) -> None:
+        report = actual_execution_results["verification_report"]
 
         json_str = json.dumps(report, indent=2, sort_keys=True)
         assert len(json_str) > 100
         parsed = json.loads(json_str)
         assert parsed["overall_verdict"] == "pass"
 
-    def test_cold_start_report_generates_valid_report(self, tmp_path: Path) -> None:
-        from scripts.repro.cold_start_reproduction_report import generate_reproduction_report
-
-        report = generate_reproduction_report(
-            tag="0.0.2",
-            output_dir=tmp_path / "reproduction",
-            local_repo=ROOT,
-            checksums_only=True,
-        )
+    def test_cold_start_report_generates_valid_report(
+        self, actual_execution_results: dict[str, Any]
+    ) -> None:
+        report = actual_execution_results["reproduction_report"]
 
         assert report["schema"] == "cold-start-reproduction-report.v1"
         assert report["release_tag"] == "0.0.2"
@@ -508,15 +528,10 @@ class TestActualExecution:
         assert "verify_checksums" in report["steps"]
         assert report["steps"]["verify_checksums"]["status"] == "pass"
 
-    def test_cold_start_report_embedded_artifacts_verified(self, tmp_path: Path) -> None:
-        from scripts.repro.cold_start_reproduction_report import generate_reproduction_report
-
-        report = generate_reproduction_report(
-            tag="0.0.2",
-            output_dir=tmp_path / "reproduction",
-            local_repo=ROOT,
-            checksums_only=True,
-        )
+    def test_cold_start_report_embedded_artifacts_verified(
+        self, actual_execution_results: dict[str, Any]
+    ) -> None:
+        report = actual_execution_results["reproduction_report"]
 
         embedded = report["steps"]["verify_checksums"]["embedded_artifacts"]
         assert len(embedded) >= 3
@@ -524,16 +539,9 @@ class TestActualExecution:
             assert artifact["match"] is True
             assert artifact["actual_sha256"] == artifact["expected_sha256"]
 
-    def test_report_file_written_to_disk(self, tmp_path: Path) -> None:
-        from scripts.repro.cold_start_reproduction_report import generate_reproduction_report
-
-        output_dir = tmp_path / "reproduction"
-        report = generate_reproduction_report(
-            tag="0.0.2",
-            output_dir=output_dir,
-            local_repo=ROOT,
-            checksums_only=True,
-        )
+    def test_report_file_written_to_disk(self, actual_execution_results: dict[str, Any]) -> None:
+        report = actual_execution_results["reproduction_report"]
+        output_dir = actual_execution_results["reproduction_dir"]
 
         report_path = output_dir / "reproduction_report.json"
         report_path.write_text(json.dumps(report, indent=2, sort_keys=True))


### PR DESCRIPTION
## What and Why

This PR adds **actual execution tests** for the release checksum verification and cold-start reproduction report infrastructure, addressing criteria 2-3 of issue #5366.

### Problem

PR #5369 (merged) established the manifest and verification infrastructure (criterion 1). However, it only included infrastructure tests with mocked data—no tests that actually download the bundle and verify checksums end-to-end.

### Solution

Add `TestActualExecution` class with 5 tests that run the real scripts against the actual release bundle:

1. **test_checksum_verification_report_structure**: Validates report schema, verdicts, and pass status
2. **test_checksum_verification_report_json_serializable**: Validates JSON serialization roundtrip
3. **test_cold_start_report_generates_valid_report**: Validates cold-start report schema and steps
4. **test_cold_start_report_embedded_artifacts_verified**: Validates all 4 embedded artifacts pass verification
5. **test_report_file_written_to_disk**: Validates report can be written to disk and reloaded

### Execution Evidence

The tests themselves serve as execution evidence. When run, they:
- Download the 544KB release bundle from GitHub
- Verify SHA-256 checksum against manifest
- Verify all 4 embedded artifact checksums
- Generate a cold-start reproduction report
- Validate the complete report structure

## Validation

All 38 tests pass:

```
tests/repro/test_release_checksum_verification.py::TestActualExecution::test_checksum_verification_report_structure PASSED
tests/repro/test_release_checksum_verification.py::TestActualExecution::test_checksum_verification_report_json_serializable PASSED
tests/repro/test_release_checksum_verification.py::TestActualExecution::test_cold_start_report_generates_valid_report PASSED
tests/repro/test_release_checksum_verification.py::TestActualExecution::test_cold_start_report_embedded_artifacts_verified PASSED
tests/repro/test_release_checksum_verification.py::TestActualExecution::test_report_file_written_to_disk PASSED
============================== 38 passed in 5.08s ==============================
```

Ruff checks pass:
```
All checks passed!
```

## Scope Boundary

This PR delivers **execution evidence** for criteria 2-3 by adding tests that actually run the verification workflow. Criterion 4 (update #5352 with the report) requires a separate action on that issue.

## Successor Statement

This PR is a **successor slice** to PR #5369 (which added the manifest and verification infrastructure). This PR adds NEW capability: actual execution tests that verify the infrastructure works end-to-end against the real release bundle.

## Refs #5366

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.