### PR TITLE
fix(ci): unbreak main — converter table passthrough for inherited config fields

### DIFF
--- a/robot_sf/planner/chance_constrained_mpc.py
+++ b/robot_sf/planner/chance_constrained_mpc.py
@@ -354,7 +354,12 @@ def build_chance_constrained_mpc_config(
     for field in fields(ChanceConstrainedMPCConfig):
         value = raw.get(field.name, getattr(defaults, field.name))
         try:
-            kwargs[field.name] = converters[field.name](value)
+            # Fields inherited from the base config without an explicit converter
+            # pass through unchanged: a hand-maintained converter table must not
+            # break when the base dataclass gains a field (main went red on
+            # 2026-07-12 when #5374 added the factorial toggle fields — every
+            # inherited field hit KeyError here).
+            kwargs[field.name] = converters.get(field.name, lambda v: v)(value)
         except (TypeError, ValueError):
             default_value = getattr(defaults, field.name)
             warnings.warn(


### PR DESCRIPTION
Third merge-race main-red this weekend, same shape: #5374 (factorial toggles on the base config) × the chance-constrained MPC parser (#5307 lineage) whose hand-maintained converter table KeyErrors on any field it doesn't list. Each PR green alone.

Fix: `converters.get(field.name, passthrough)` — the table becomes additive-safe for all future base-config fields. 141 map_runner_utils tests + 37 chance/prediction-MPC tests pass locally.

Fixes the failing runs 29186589174 / 29186735654; closes the auto-escalated P0 #5380 after two green runs. Main-red emergency merge (acting project lead, authorized window).