### PR TITLE
ci: main_ci_is_green helper for the red-main merge hold (#5385)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1584,6 +1584,23 @@ CI mapping to local tasks and CLI:
 
 Workflow location: `.github/workflows/ci.yml`.
 
+### Red-main merge hold
+
+When `main` CI is red, do not merge unrelated PRs onto it. A merge that lands
+while the required check is already failing hides its own new breakage under
+the existing red, so recovery cost compounds with every merge in the window
+(three such incidents on 2026-07-11/12). The deterministic green/red signal is:
+
+```bash
+uv run python scripts/dev/main_ci_is_green.py   # exit 0 green, 1 not-green
+```
+
+It decides from the most recent **completed** CI run on `main` — an in-progress
+run never counts as green or red. Only PRs that fix the breakage (title-prefixed
+`fix(ci): unbreak main` or labeled `unbreak-main`) may merge while red; they are
+the cure and must land. Reviewing a PR while main is red is fine — only the
+merge is held.
+
 ## CI Performance Monitoring
 The CI pipeline separates fast feedback from the heavier smoke/artifact tail:
 

--- a/scripts/dev/main_ci_is_green.py
+++ b/scripts/dev/main_ci_is_green.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Report whether ``main`` CI is green, based on the latest COMPLETED run.
+
+Motivation (issue #5385). Three separate main-red incidents in 36h
+(2026-07-11/12) shared one mechanism: merges kept landing while main CI was
+red, and the already-failing required check masked the NEW breakage each merge
+introduced, so recovery cost grew with every merge that landed inside the red
+window. The cure is a merge hold: gates may review a PR while main is red but
+must not merge (except the unbreak-main fix itself) until main is green again.
+
+This helper is the deterministic green/red signal that hold consults. The one
+rule that matters — learned the hard way when the escalation guard stayed
+silent on 2026-07-11 — is that an IN-PROGRESS run must never count as evidence
+either way: only the most recent *completed* run decides. The fetch uses
+``--status completed`` so in-progress runs are excluded at the API, and the
+pure decision function filters defensively on top so the rule is unit-tested.
+
+Exit code: 0 == green (latest completed CI run on main concluded ``success``),
+1 == not green (red, or no completed run to judge from). Prints the run id and
+conclusion it decided from.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+DEFAULT_WORKFLOW = "CI"
+
+
+def _gh(args: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a GitHub CLI command (mirrors scripts/dev/compact_ci_snapshot.py)."""
+    try:
+        return subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=["gh", *args], returncode=124, stdout="", stderr="gh timed out"
+        )
+
+
+def latest_completed_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the newest run whose ``status`` is ``completed``.
+
+    ``runs`` is the list ``gh run list --json`` returns (newest first). We
+    sort by ``createdAt`` descending defensively rather than trusting order,
+    then take the first ``completed`` entry. In-progress / queued runs are
+    skipped: an unfinished run is not evidence of green OR red.
+    """
+    completed = [r for r in runs if str(r.get("status")) == "completed"]
+    completed.sort(key=lambda r: str(r.get("createdAt", "")), reverse=True)
+    return completed[0] if completed else None
+
+
+def decide(runs: list[dict[str, Any]]) -> tuple[bool, dict[str, Any] | None]:
+    """(is_green, deciding_run). Green iff the latest completed run succeeded."""
+    run = latest_completed_run(runs)
+    if run is None:
+        return False, None
+    return str(run.get("conclusion")) == "success", run
+
+
+def fetch_runs(
+    repo: str = DEFAULT_REPO, workflow: str = DEFAULT_WORKFLOW, limit: int = 5
+) -> list[dict[str, Any]]:
+    """Fetch recent completed main CI runs. ``--status completed`` is load-bearing."""
+    proc = _gh(
+        [
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--branch",
+            "main",
+            "--workflow",
+            workflow,
+            "--status",
+            "completed",
+            "--limit",
+            str(limit),
+            "--json",
+            "databaseId,status,conclusion,headSha,createdAt",
+        ]
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh run list failed: {proc.stderr.strip() or proc.returncode}")
+    return json.loads(proc.stdout or "[]")
+
+
+def main() -> int:
+    """CLI entry: exit 0 if main CI is green, 1 otherwise."""
+    ap = argparse.ArgumentParser(description="Is main CI green (latest completed run)?")
+    ap.add_argument("--repo", default=DEFAULT_REPO)
+    ap.add_argument("--workflow", default=DEFAULT_WORKFLOW)
+    ap.add_argument("--limit", type=int, default=5)
+    ap.add_argument("--quiet", action="store_true", help="suppress the human line")
+    args = ap.parse_args()
+
+    try:
+        runs = fetch_runs(args.repo, args.workflow, args.limit)
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        # Fail closed: an unreadable signal is treated as NOT green so a merge
+        # hold errs toward holding, never toward merging on unknown state.
+        if not args.quiet:
+            print(f"main CI status UNKNOWN ({exc}) -> treated as not-green", file=sys.stderr)
+        return 1
+
+    is_green, run = decide(runs)
+    if not args.quiet:
+        if run is None:
+            print("main CI: no completed run found -> not green")
+        else:
+            print(
+                f"main CI: {run.get('conclusion')} "
+                f"(run {run.get('databaseId')}, {str(run.get('headSha'))[:9]}) "
+                f"-> {'GREEN' if is_green else 'NOT GREEN'}"
+            )
+    return 0 if is_green else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dev/test_main_ci_is_green.py
+++ b/tests/dev/test_main_ci_is_green.py
@@ -1,0 +1,100 @@
+"""Tests for the main-CI green/red signal used by the red-main merge hold (#5385).
+
+The load-bearing property: an IN-PROGRESS run must never decide green or red —
+only the most recent *completed* run does. This is the exact bug that made the
+escalation guard silent on 2026-07-11 (it counted an in-progress newest run),
+so it gets an explicit test.
+"""
+
+from __future__ import annotations
+
+from scripts.dev.main_ci_is_green import decide, latest_completed_run
+
+
+def _run(rid: int, status: str, conclusion: str | None, created: str) -> dict:
+    return {
+        "databaseId": rid,
+        "status": status,
+        "conclusion": conclusion,
+        "headSha": f"{rid:040x}",
+        "createdAt": created,
+    }
+
+
+def test_green_when_latest_completed_succeeded() -> None:
+    """Green when the newest completed run succeeded."""
+    runs = [
+        _run(3, "completed", "success", "2026-07-12T12:00:00Z"),
+        _run(2, "completed", "failure", "2026-07-12T11:00:00Z"),
+    ]
+    is_green, run = decide(runs)
+    assert is_green is True
+    assert run["databaseId"] == 3
+
+
+def test_red_when_latest_completed_failed() -> None:
+    """Red when the newest completed run failed."""
+    runs = [
+        _run(3, "completed", "failure", "2026-07-12T12:00:00Z"),
+        _run(2, "completed", "success", "2026-07-12T11:00:00Z"),
+    ]
+    is_green, run = decide(runs)
+    assert is_green is False
+    assert run["databaseId"] == 3
+
+
+def test_in_progress_newest_is_ignored_completed_green_wins() -> None:
+    """An in-progress newest run is ignored; latest completed green wins."""
+    # The newest run is still RUNNING; the decision must come from the latest
+    # *completed* run (green), not the in-progress one. Regression guard for the
+    # 2026-07-11 escalation-guard silent miss.
+    runs = [
+        _run(4, "in_progress", None, "2026-07-12T12:30:00Z"),
+        _run(3, "queued", None, "2026-07-12T12:20:00Z"),
+        _run(2, "completed", "success", "2026-07-12T12:00:00Z"),
+    ]
+    is_green, run = decide(runs)
+    assert is_green is True
+    assert run["databaseId"] == 2
+
+
+def test_in_progress_newest_does_not_mask_a_red_completed() -> None:
+    """An in-progress newest run does not hide a red completed run."""
+    runs = [
+        _run(4, "in_progress", None, "2026-07-12T12:30:00Z"),
+        _run(2, "completed", "failure", "2026-07-12T12:00:00Z"),
+    ]
+    is_green, run = decide(runs)
+    assert is_green is False
+    assert run["databaseId"] == 2
+
+
+def test_cancelled_and_timed_out_are_not_green() -> None:
+    """Non-success completed conclusions are not green."""
+    for bad in ("cancelled", "timed_out", "startup_failure", None):
+        is_green, run = decide([_run(1, "completed", bad, "2026-07-12T12:00:00Z")])
+        assert is_green is False, bad
+        assert run is not None
+
+
+def test_no_completed_runs_is_not_green() -> None:
+    """No completed run means not green (and None deciding run)."""
+    runs = [_run(4, "in_progress", None, "2026-07-12T12:30:00Z")]
+    is_green, run = decide(runs)
+    assert is_green is False
+    assert run is None
+
+    assert latest_completed_run([]) is None
+
+
+def test_unsorted_input_still_picks_newest_completed() -> None:
+    """decide() sorts by createdAt, so unsorted input still resolves correctly."""
+    # gh returns newest-first, but decide() sorts defensively — prove it.
+    runs = [
+        _run(1, "completed", "failure", "2026-07-12T10:00:00Z"),
+        _run(3, "completed", "success", "2026-07-12T12:00:00Z"),
+        _run(2, "completed", "failure", "2026-07-12T11:00:00Z"),
+    ]
+    is_green, run = decide(runs)
+    assert is_green is True
+    assert run["databaseId"] == 3


### PR DESCRIPTION
Implements the repo-side half of #5385.

**Why.** Three main-red incidents in 36h (2026-07-11/12) shared one mechanism: a merge landing while main CI was already red hides its own new breakage under the failing required check, so each merge in the red window compounds recovery cost (the 3-layer stack on 07-11; #5337/#5336 on 07-12 morning; the toggles KeyError midday). The cure is a merge hold that consults a deterministic green/red signal.

**What.** `scripts/dev/main_ci_is_green.py` — exit 0 if the latest **completed** main CI run concluded success, 1 otherwise (fail-closed on an unreadable signal). The load-bearing rule, regression-tested: an **in-progress** run never counts — that is the exact bug that made the escalation guard silent on 07-11. `fetch_runs` uses `--status completed`; the pure `decide()` filters defensively so the property is unit-tested (7 cases). Plus a dev_guide note describing the hold and the `unbreak-main` bypass.

**Scope.** Repo-side helper + tests + docs only. The orchestration-layer gate wiring that calls this is tracked separately under #5385.

Tests: `uv run pytest tests/dev/test_main_ci_is_green.py` → 7 passed; live smoke correctly reports the current main run GREEN; ruff clean. Refs #5385.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line check that reports whether the latest completed CI run succeeded.
  * Ignores queued or in-progress runs and selects the newest completed result.
  * Supports quiet mode and returns a clear success or failure status.
  * Treats unavailable or invalid CI results as not green.

* **Tests**
  * Added coverage for successful, failed, cancelled, timed-out, missing, and unsorted CI results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->