### PR TITLE
fix(ci): harden main-CI signal after PR #5386 merge race

### DIFF
--- a/scripts/dev/main_ci_is_green.py
+++ b/scripts/dev/main_ci_is_green.py
@@ -46,9 +46,16 @@ def _gh(args: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess:
         return subprocess.CompletedProcess(
             args=["gh", *args], returncode=124, stdout="", stderr="gh timed out"
         )
+    except OSError as exc:
+        return subprocess.CompletedProcess(
+            args=["gh", *args],
+            returncode=127,
+            stdout="",
+            stderr=f"gh not executable: {exc}",
+        )
 
 
-def latest_completed_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+def latest_completed_run(runs: list[Any]) -> dict[str, Any] | None:
     """Return the newest run whose ``status`` is ``completed``.
 
     ``runs`` is the list ``gh run list --json`` returns (newest first). We
@@ -56,12 +63,14 @@ def latest_completed_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
     then take the first ``completed`` entry. In-progress / queued runs are
     skipped: an unfinished run is not evidence of green OR red.
     """
-    completed = [r for r in runs if str(r.get("status")) == "completed"]
+    completed = [
+        run for run in runs if isinstance(run, dict) and str(run.get("status")) == "completed"
+    ]
     completed.sort(key=lambda r: str(r.get("createdAt", "")), reverse=True)
     return completed[0] if completed else None
 
 
-def decide(runs: list[dict[str, Any]]) -> tuple[bool, dict[str, Any] | None]:
+def decide(runs: list[Any]) -> tuple[bool, dict[str, Any] | None]:
     """(is_green, deciding_run). Green iff the latest completed run succeeded."""
     run = latest_completed_run(runs)
     if run is None:
@@ -93,7 +102,10 @@ def fetch_runs(
     )
     if proc.returncode != 0:
         raise RuntimeError(f"gh run list failed: {proc.stderr.strip() or proc.returncode}")
-    return json.loads(proc.stdout or "[]")
+    data = json.loads(proc.stdout or "[]")
+    if not isinstance(data, list):
+        raise RuntimeError(f"Unexpected JSON response type: {type(data).__name__}")
+    return data
 
 
 def main() -> int:

--- a/tests/dev/test_main_ci_is_green.py
+++ b/tests/dev/test_main_ci_is_green.py
@@ -8,7 +8,12 @@ so it gets an explicit test.
 
 from __future__ import annotations
 
-from scripts.dev.main_ci_is_green import decide, latest_completed_run
+import subprocess
+
+import pytest
+
+from scripts.dev import main_ci_is_green
+from scripts.dev.main_ci_is_green import decide, fetch_runs, latest_completed_run
 
 
 def _run(rid: int, status: str, conclusion: str | None, created: str) -> dict:
@@ -98,3 +103,42 @@ def test_unsorted_input_still_picks_newest_completed() -> None:
     is_green, run = decide(runs)
     assert is_green is True
     assert run["databaseId"] == 3
+
+
+def test_non_mapping_entries_are_ignored() -> None:
+    """Malformed list entries cannot prevent a conservative decision."""
+    is_green, run = decide(
+        ["not a run", None, _run(1, "completed", "success", "2026-07-12T12:00:00Z")]
+    )
+    assert is_green is True
+    assert run is not None
+    assert run["databaseId"] == 1
+
+
+@pytest.mark.parametrize("payload", ["null", '{"message": "bad credentials"}'])
+def test_fetch_runs_rejects_non_list_json(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Unexpected API JSON reaches main's clean fail-closed path."""
+    monkeypatch.setattr(
+        main_ci_is_green,
+        "_gh",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout=payload, stderr=""
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Unexpected JSON response type"):
+        fetch_runs()
+
+
+def test_gh_oserror_becomes_a_failed_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing GitHub CLI reports not-green without a traceback."""
+    monkeypatch.setattr(
+        main_ci_is_green.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(FileNotFoundError("missing gh")),
+    )
+
+    proc = main_ci_is_green._gh(["run", "list"])
+
+    assert proc.returncode == 127
+    assert "not executable" in proc.stderr


### PR DESCRIPTION
## Summary

Lands the three fail-closed guards reviewed on #5386 but omitted by a concurrent merge of that PR's earlier head.

## Linked Issues

- Refs #5385
- Closes #5387

## What Changed

- Convert an unavailable `gh` executable into the existing conservative error path.
- Reject non-list GitHub CLI JSON and ignore non-object run records.
- Add focused regression coverage for all three paths.

## Why It Matters

The red-main merge hold must treat an unreadable or malformed signal as not-green without printing an unhandled traceback.

## Research Result Guidance

- Evidence tier: NA - workflow helper with no research claim.
- Result classification: NA.

## Domain-Aware Approval

- Required for this PR: no - it does not change benchmark or paper-facing evidence semantics.
- Status: not required.

## Validation / Proof

- Commands run: `uv run pytest tests/dev/test_main_ci_is_green.py`; targeted Ruff check and format; live `uv run python scripts/dev/main_ci_is_green.py`.
- Evidence that the change works here: 11 focused tests passed before opening this successor; CI must confirm this rebased head.

## Downstream Propagation

- Parent issue updated: yes.
- Not applicable because: no benchmark, metric, or paper-facing evidence is produced.

## Follow-Up Issues

- Deferred work: none.
