### PR TITLE
Issue #5391: arm_rollup in campaign summary (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/camera_ready/_reporting.py
+++ b/robot_sf/benchmark/camera_ready/_reporting.py
@@ -856,6 +856,40 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
             )
     else:
         lines.append("No planner rows were produced.")
+
+    arm_rollup = payload.get("arm_rollup") or []
+    if arm_rollup:
+        lines.extend(["", "## Arm Rollup", ""])
+        has_errors = any(arm.get("first_error") for arm in arm_rollup)
+        if has_errors:
+            lines.append(
+                "| planner | kinematics | status | written | failed | first_error | distinct_errors |"
+            )
+            lines.append("|---|---|---|---:|---:|---|---:|")
+            for arm in arm_rollup:
+                lines.append(
+                    "| "
+                    f"{_escape_markdown_cell(arm.get('planner_key'))} | "
+                    f"{_escape_markdown_cell(arm.get('kinematics'))} | "
+                    f"{_escape_markdown_cell(arm.get('status'))} | "
+                    f"{_escape_markdown_cell(arm.get('episodes_written', 0))} | "
+                    f"{_escape_markdown_cell(arm.get('episodes_failed', 0))} | "
+                    f"{_escape_markdown_cell(arm.get('first_error', ''))} | "
+                    f"{_escape_markdown_cell(arm.get('distinct_error_count', 0))} |"
+                )
+        else:
+            lines.append("| planner | kinematics | status | written | failed |")
+            lines.append("|---|---|---|---:|---:|")
+            for arm in arm_rollup:
+                lines.append(
+                    "| "
+                    f"{_escape_markdown_cell(arm.get('planner_key'))} | "
+                    f"{_escape_markdown_cell(arm.get('kinematics'))} | "
+                    f"{_escape_markdown_cell(arm.get('status'))} | "
+                    f"{_escape_markdown_cell(arm.get('episodes_written', 0))} | "
+                    f"{_escape_markdown_cell(arm.get('episodes_failed', 0))} |"
+                )
+
     if not isinstance(scorecard, dict):
         scorecard = build_campaign_credibility_scorecard(payload)
     factors = scorecard.get("factors", []) if isinstance(scorecard.get("factors"), list) else []

--- a/robot_sf/benchmark/camera_ready/_run_state.py
+++ b/robot_sf/benchmark/camera_ready/_run_state.py
@@ -99,12 +99,15 @@ def _build_arm_rollup(run_entries: Sequence[Mapping[str, Any]]) -> list[dict[str
         distinct_error_count = 0
         if status not in {"ok", "not_available"}:
             error_signatures: set[str] = set()
+            first_error_raw: str | None = None
             for failure in failures:
                 error_str = str(failure.get("error", ""))
                 if error_str:
+                    if first_error_raw is None:
+                        first_error_raw = error_str
                     error_signatures.add(error_str)
             if error_signatures:
-                first_error = sorted(error_signatures)[0][:_MAX_FIRST_ERROR_LEN]
+                first_error = first_error_raw[:_MAX_FIRST_ERROR_LEN] if first_error_raw else None
                 distinct_error_count = len(error_signatures)
             elif str(summary.get("error", "")):
                 first_error = str(summary["error"])[:_MAX_FIRST_ERROR_LEN]

--- a/robot_sf/benchmark/camera_ready/_run_state.py
+++ b/robot_sf/benchmark/camera_ready/_run_state.py
@@ -92,8 +92,12 @@ def _build_arm_rollup(run_entries: Sequence[Mapping[str, Any]]) -> list[dict[str
         summary = entry.get("summary") or {}
         failures = summary.get("failures") or []
         status = str(entry.get("status", "unknown"))
-        episodes_written = int(summary.get("written", summary.get("episodes_total", 0)))
-        episodes_failed = int(summary.get("failed_jobs", 0))
+        written_value = summary.get("written")
+        if written_value is None:
+            written_value = summary.get("episodes_total")
+        episodes_written = int(written_value) if written_value is not None else 0
+        failed_jobs_value = summary.get("failed_jobs")
+        episodes_failed = int(failed_jobs_value) if failed_jobs_value is not None else 0
 
         first_error: str | None = None
         distinct_error_count = 0
@@ -101,7 +105,8 @@ def _build_arm_rollup(run_entries: Sequence[Mapping[str, Any]]) -> list[dict[str
             error_signatures: set[str] = set()
             first_error_raw: str | None = None
             for failure in failures:
-                error_str = str(failure.get("error", ""))
+                error_value = failure.get("error")
+                error_str = str(error_value) if error_value is not None else ""
                 if error_str:
                     if first_error_raw is None:
                         first_error_raw = error_str
@@ -109,8 +114,10 @@ def _build_arm_rollup(run_entries: Sequence[Mapping[str, Any]]) -> list[dict[str
             if error_signatures:
                 first_error = first_error_raw[:_MAX_FIRST_ERROR_LEN] if first_error_raw else None
                 distinct_error_count = len(error_signatures)
-            elif str(summary.get("error", "")):
-                first_error = str(summary["error"])[:_MAX_FIRST_ERROR_LEN]
+            else:
+                summary_error = summary.get("error")
+                if summary_error:
+                    first_error = str(summary_error)[:_MAX_FIRST_ERROR_LEN]
 
         arm_entry: dict[str, Any] = {
             "planner_key": str(planner_info.get("key", "unknown")),

--- a/robot_sf/benchmark/camera_ready/_run_state.py
+++ b/robot_sf/benchmark/camera_ready/_run_state.py
@@ -73,6 +73,57 @@ def _campaign_success_counters(
     }
 
 
+_MAX_FIRST_ERROR_LEN = 200
+
+
+def _build_arm_rollup(run_entries: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Build per-arm rollup for the top-level campaign summary.
+
+    One entry per arm with planner key, kinematics, status, episode counts,
+    and for failed/partial arms the first error string (truncated) plus the
+    count of distinct error signatures from per-job failures.
+
+    Returns:
+        List of arm rollup dicts, one per run entry.
+    """
+    rollup: list[dict[str, Any]] = []
+    for entry in run_entries:
+        planner_info = entry.get("planner") or {}
+        summary = entry.get("summary") or {}
+        failures = summary.get("failures") or []
+        status = str(entry.get("status", "unknown"))
+        episodes_written = int(summary.get("written", summary.get("episodes_total", 0)))
+        episodes_failed = int(summary.get("failed_jobs", 0))
+
+        first_error: str | None = None
+        distinct_error_count = 0
+        if status not in {"ok", "not_available"}:
+            error_signatures: set[str] = set()
+            for failure in failures:
+                error_str = str(failure.get("error", ""))
+                if error_str:
+                    error_signatures.add(error_str)
+            if error_signatures:
+                first_error = sorted(error_signatures)[0][:_MAX_FIRST_ERROR_LEN]
+                distinct_error_count = len(error_signatures)
+            elif str(summary.get("error", "")):
+                first_error = str(summary["error"])[:_MAX_FIRST_ERROR_LEN]
+
+        arm_entry: dict[str, Any] = {
+            "planner_key": str(planner_info.get("key", "unknown")),
+            "algo": str(planner_info.get("algo", "unknown")),
+            "kinematics": str(planner_info.get("kinematics", "unknown")),
+            "status": status,
+            "episodes_written": episodes_written,
+            "episodes_failed": episodes_failed,
+        }
+        if first_error is not None:
+            arm_entry["first_error"] = first_error
+            arm_entry["distinct_error_count"] = distinct_error_count
+        rollup.append(arm_entry)
+    return rollup
+
+
 def _resolve_execution_mode(algorithm_metadata_contract: Any) -> str:
     """Resolve execution mode from algorithm metadata payload with legacy fallbacks.
 

--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -51,7 +51,10 @@ from robot_sf.benchmark.camera_ready._reporting import (
     build_campaign_credibility_scorecard,
     write_campaign_report,
 )
-from robot_sf.benchmark.camera_ready._run_state import _campaign_success_counters
+from robot_sf.benchmark.camera_ready._run_state import (
+    _build_arm_rollup,
+    _campaign_success_counters,
+)
 from robot_sf.benchmark.camera_ready._summaries import (
     _SEED_VARIABILITY_METRICS,
     _build_actuation_envelope_summary,
@@ -1221,6 +1224,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
     warnings = planner_run_results.warnings
     seed_variability_records = planner_run_results.seed_variability_records
     _finalize_checkpoint_provenance(manifest_payload, run_entries)
+    arm_rollup = _build_arm_rollup(run_entries)
 
     planner_rows.sort(
         key=lambda row: (row.get("snqi_mean", "nan") == "nan", row.get("planner_key"))
@@ -1820,6 +1824,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
             "snqi_positioning_claim_scope": positioning.get("claim_scope"),
         },
         "planner_rows": planner_rows,
+        "arm_rollup": arm_rollup,
         "runs": run_entries,
         "warnings": warnings,
         "soft_contract_warning": soft_contract_warning,

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -2546,6 +2546,10 @@ def test_run_campaign_writes_core_artifacts(tmp_path: Path, monkeypatch):  # noq
     summary_payload = json.loads(
         (campaign_root / "reports" / "campaign_summary.json").read_text(encoding="utf-8")
     )
+    assert len(summary_payload["arm_rollup"]) == len(summary_payload["runs"])
+    assert [arm["planner_key"] for arm in summary_payload["arm_rollup"]] == [
+        run["planner"]["key"] for run in summary_payload["runs"]
+    ]
     assert result["status"] == "accepted_unavailable_only"
     assert result["status_reason"] == (
         "campaign contains accepted unavailable/excluded rows and no unexpected failed rows"

--- a/tests/benchmark/test_campaign_arm_rollup.py
+++ b/tests/benchmark/test_campaign_arm_rollup.py
@@ -1,0 +1,211 @@
+"""Tests for campaign arm_rollup (issue #5391)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.camera_ready._reporting import write_campaign_report
+from robot_sf.benchmark.camera_ready._run_state import _build_arm_rollup
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_arm_rollup_ok_arms_produces_ok_rows() -> None:
+    """Fully-green campaign produces ok rows with no error fields."""
+    run_entries: list[dict[str, Any]] = [
+        {
+            "planner": {"key": "sfm", "algo": "sfm", "kinematics": "diff"},
+            "status": "ok",
+            "summary": {"written": 10, "failed_jobs": 0, "failures": []},
+        },
+        {
+            "planner": {"key": "orca", "algo": "orca", "kinematics": "diff"},
+            "status": "ok",
+            "summary": {"written": 8, "failed_jobs": 0, "failures": []},
+        },
+    ]
+    rollup = _build_arm_rollup(run_entries)
+    assert len(rollup) == 2
+    assert rollup[0]["planner_key"] == "sfm"
+    assert rollup[0]["kinematics"] == "diff"
+    assert rollup[0]["status"] == "ok"
+    assert rollup[0]["episodes_written"] == 10
+    assert rollup[0]["episodes_failed"] == 0
+    assert "first_error" not in rollup[0]
+    assert "distinct_error_count" not in rollup[0]
+    assert rollup[1]["planner_key"] == "orca"
+    assert rollup[1]["status"] == "ok"
+
+
+def test_arm_rollup_failed_arm_names_first_error() -> None:
+    """Failed arm rollup names the arm and its first error with distinct count."""
+    run_entries: list[dict[str, Any]] = [
+        {
+            "planner": {"key": "sfm", "algo": "sfm", "kinematics": "diff"},
+            "status": "ok",
+            "summary": {"written": 10, "failed_jobs": 0, "failures": []},
+        },
+        {
+            "planner": {"key": "orca", "algo": "orca", "kinematics": "ackermann"},
+            "status": "failed",
+            "summary": {
+                "written": 0,
+                "failed_jobs": 3,
+                "failures": [
+                    {
+                        "scenario_id": "s1",
+                        "seed": 1,
+                        "error": "RuntimeError('map resolution missing')",
+                    },
+                    {
+                        "scenario_id": "s2",
+                        "seed": 1,
+                        "error": "RuntimeError('map resolution missing')",
+                    },
+                    {"scenario_id": "s3", "seed": 2, "error": "ValueError('bad config')"},
+                ],
+            },
+        },
+    ]
+    rollup = _build_arm_rollup(run_entries)
+    assert len(rollup) == 2
+    failed_arm = rollup[1]
+    assert failed_arm["planner_key"] == "orca"
+    assert failed_arm["kinematics"] == "ackermann"
+    assert failed_arm["status"] == "failed"
+    assert failed_arm["episodes_written"] == 0
+    assert failed_arm["episodes_failed"] == 3
+    assert "first_error" in failed_arm
+    assert failed_arm["distinct_error_count"] == 2
+    assert len(failed_arm["first_error"]) <= 200
+
+
+def test_arm_rollup_partial_failure_arm() -> None:
+    """Partial-failure arm includes error fields from per-job failures."""
+    run_entries: list[dict[str, Any]] = [
+        {
+            "planner": {"key": "hybrid", "algo": "hybrid", "kinematics": "diff"},
+            "status": "partial-failure",
+            "summary": {
+                "written": 5,
+                "failed_jobs": 2,
+                "failures": [
+                    {"scenario_id": "s1", "seed": 1, "error": "TimeoutError('episode timeout')"},
+                    {"scenario_id": "s2", "seed": 1, "error": "AssertionError('invariant')"},
+                ],
+            },
+        },
+    ]
+    rollup = _build_arm_rollup(run_entries)
+    assert len(rollup) == 1
+    arm = rollup[0]
+    assert arm["status"] == "partial-failure"
+    assert arm["episodes_written"] == 5
+    assert arm["episodes_failed"] == 2
+    assert "first_error" in arm
+    assert arm["distinct_error_count"] == 2
+
+
+def test_arm_rollup_exception_path_uses_summary_error() -> None:
+    """Exception-during-batch arm falls back to summary-level error string."""
+    run_entries: list[dict[str, Any]] = [
+        {
+            "planner": {"key": "broken", "algo": "custom", "kinematics": "diff"},
+            "status": "failed",
+            "summary": {
+                "status": "failed",
+                "error": "Planner 'broken' failed for kinematics 'diff': ImportError('no module')",
+                "written": 0,
+                "failed_jobs": 0,
+                "failures": [],
+            },
+        },
+    ]
+    rollup = _build_arm_rollup(run_entries)
+    arm = rollup[0]
+    assert arm["status"] == "failed"
+    assert "first_error" in arm
+    assert "ImportError" in arm["first_error"]
+
+
+def test_arm_rollup_not_available_arm_has_no_error() -> None:
+    """Dependency-gated not_available arm has no error fields."""
+    run_entries: list[dict[str, Any]] = [
+        {
+            "planner": {"key": "gated", "algo": "rl", "kinematics": "diff"},
+            "status": "not_available",
+            "summary": {"written": 0, "failed_jobs": 0, "failures": []},
+        },
+    ]
+    rollup = _build_arm_rollup(run_entries)
+    assert rollup[0]["status"] == "not_available"
+    assert "first_error" not in rollup[0]
+
+
+def test_arm_rollup_empty_run_entries() -> None:
+    """Empty run entries produce an empty rollup list."""
+    rollup = _build_arm_rollup([])
+    assert rollup == []
+
+
+def test_arm_rollup_appears_in_campaign_report(tmp_path: Path) -> None:
+    """Campaign report includes arm rollup table with error columns when failures exist."""
+    payload: dict[str, Any] = {
+        "campaign": {"campaign_id": "test", "name": "test_campaign", "status": "ok"},
+        "planner_rows": [],
+        "arm_rollup": [
+            {
+                "planner_key": "sfm",
+                "algo": "sfm",
+                "kinematics": "diff",
+                "status": "ok",
+                "episodes_written": 10,
+                "episodes_failed": 0,
+            },
+            {
+                "planner_key": "orca",
+                "algo": "orca",
+                "kinematics": "ackermann",
+                "status": "failed",
+                "episodes_written": 0,
+                "episodes_failed": 3,
+                "first_error": "RuntimeError('map resolution')",
+                "distinct_error_count": 1,
+            },
+        ],
+        "warnings": [],
+    }
+    report_path = tmp_path / "campaign_report.md"
+    write_campaign_report(report_path, payload)
+    text = report_path.read_text(encoding="utf-8")
+    assert "## Arm Rollup" in text
+    assert "sfm" in text
+    assert "orca" in text
+    assert "RuntimeError" in text
+    assert "distinct_errors" in text
+
+
+def test_arm_rollup_report_all_ok_no_error_columns(tmp_path: Path) -> None:
+    """All-ok rollup renders without error columns in the report."""
+    payload: dict[str, Any] = {
+        "campaign": {"campaign_id": "test", "name": "test_campaign", "status": "ok"},
+        "planner_rows": [],
+        "arm_rollup": [
+            {
+                "planner_key": "sfm",
+                "algo": "sfm",
+                "kinematics": "diff",
+                "status": "ok",
+                "episodes_written": 10,
+                "episodes_failed": 0,
+            },
+        ],
+        "warnings": [],
+    }
+    report_path = tmp_path / "campaign_report.md"
+    write_campaign_report(report_path, payload)
+    text = report_path.read_text(encoding="utf-8")
+    assert "## Arm Rollup" in text
+    assert "first_error" not in text
+    assert "distinct_errors" not in text

--- a/tests/benchmark/test_campaign_arm_rollup.py
+++ b/tests/benchmark/test_campaign_arm_rollup.py
@@ -130,6 +130,29 @@ def test_arm_rollup_exception_path_uses_summary_error() -> None:
     assert "ImportError" in arm["first_error"]
 
 
+def test_arm_rollup_none_optional_values_fail_closed_to_zero() -> None:
+    """Null summary counters default safely and null errors stay absent."""
+    run_entries: list[dict[str, Any]] = [
+        {
+            "planner": {"key": "broken", "algo": "custom", "kinematics": "diff"},
+            "status": "failed",
+            "summary": {
+                "written": None,
+                "episodes_total": 4,
+                "failed_jobs": None,
+                "failures": [],
+                "error": None,
+            },
+        },
+    ]
+
+    arm = _build_arm_rollup(run_entries)[0]
+
+    assert arm["episodes_written"] == 4
+    assert arm["episodes_failed"] == 0
+    assert "first_error" not in arm
+
+
 def test_arm_rollup_not_available_arm_has_no_error() -> None:
     """Dependency-gated not_available arm has no error fields."""
     run_entries: list[dict[str, Any]] = [

--- a/tests/benchmark/test_campaign_arm_rollup.py
+++ b/tests/benchmark/test_campaign_arm_rollup.py
@@ -53,6 +53,7 @@ def test_arm_rollup_failed_arm_names_first_error() -> None:
                 "written": 0,
                 "failed_jobs": 3,
                 "failures": [
+                    {"scenario_id": "s3", "seed": 2, "error": "ValueError('bad config')"},
                     {
                         "scenario_id": "s1",
                         "seed": 1,
@@ -63,7 +64,6 @@ def test_arm_rollup_failed_arm_names_first_error() -> None:
                         "seed": 1,
                         "error": "RuntimeError('map resolution missing')",
                     },
-                    {"scenario_id": "s3", "seed": 2, "error": "ValueError('bad config')"},
                 ],
             },
         },
@@ -77,6 +77,7 @@ def test_arm_rollup_failed_arm_names_first_error() -> None:
     assert failed_arm["episodes_written"] == 0
     assert failed_arm["episodes_failed"] == 3
     assert "first_error" in failed_arm
+    assert failed_arm["first_error"] == "ValueError('bad config')"
     assert failed_arm["distinct_error_count"] == 2
     assert len(failed_arm["first_error"]) <= 200
 


### PR DESCRIPTION
## What

Adds a top-level `arm_rollup` to the campaign summary JSON and a corresponding compact table in `campaign_report.md`. Each arm entry includes planner key, kinematics, status, episodes written/failed. For failed/partial arms, the rollup surfaces the first non-empty error string in failure-list order (truncated to 200 characters) and the count of distinct full error signatures from per-job failures.

## Why

Diagnosing campaign failures (e.g. jobs 13376, 13372) required manually opening per-arm `runs/*/summary.json` files. The top-level summary said `unexpected_failed_runs: 2` but was silent on WHICH arms failed and WHY. The arm rollup makes the campaign summary self-diagnosing for failed-job autopsies.

## Changes

- `robot_sf/benchmark/camera_ready/_run_state.py`: added `_build_arm_rollup()` that iterates run entries and extracts per-arm status, episode counts, and error info
- `robot_sf/benchmark/camera_ready/campaign.py`: wire `arm_rollup` into the campaign summary dict via the orchestrator
- `robot_sf/benchmark/camera_ready/_reporting.py`: add an `Arm Rollup` table to `write_campaign_report()` with adaptive error columns
- `tests/benchmark/test_campaign_arm_rollup.py`: focused unit tests covering ok, failed, partial-failure, exception-path, not-available, empty entries, first-error ordering, and report rendering
- `tests/benchmark/test_camera_ready_campaign.py`: verify orchestrator summary wiring

## Why It Matters

- Added value: failed-arm diagnosis is available from the top-level summary and report.
- Expected impact: faster, arm-specific campaign failure triage.
- Scope: additive report-layer metadata only; existing summary keys, metric semantics, and exit codes are unchanged.

## Research Result Guidance

- Target claim / hypothesis / blocker: `NA - support helper; this PR surfaces existing per-arm failure metadata and makes no benchmark or research-result claim.`
- Comparator or baseline, if applicable: `NA - support helper.`
- Evidence tier: `NA - support helper.`
- Result classification: `NA - support helper.`
- Decision or stop rule, if applicable: `NA - support helper.`
- Parent issue, claim map, registry, context note, or synthesis surface to update: `Issue #5391` is the linked contract and will receive criterion-to-PR propagation at merge.
- New research/benchmark/metric/paper-facing analysis tool, if any: `NA - support helper; no new analysis tool.`

## Domain-Aware Approval

- Required for this PR: no - report-layer support only; it does not change evidence classification, comparison methodology, figure eligibility, or paper-facing claim boundaries.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: gate review of the additive report contract.
- Validity checklist:
  - Target claim/hypothesis: NA - no research claim.
  - Comparator or split/evidence validity: NA - no comparison change.
  - Fallback/degraded exclusions: unchanged; existing status fields remain authoritative.
  - Claim boundary: diagnostic report metadata only.
  - Implementation integrity vs experimental validity: implementation integrity only.

## Validation / Proof

- Commands run:
  - `uv run ruff check robot_sf/benchmark/camera_ready/_run_state.py robot_sf/benchmark/camera_ready/campaign.py robot_sf/benchmark/camera_ready/_reporting.py tests/benchmark/test_campaign_arm_rollup.py tests/benchmark/test_camera_ready_campaign.py`
  - `uv run pytest tests/benchmark/test_campaign_arm_rollup.py -v`
  - `uv run pytest tests/benchmark/test_camera_ready_campaign.py -x -q`
- Evidence that the change works here: arm-rollup unit tests pass; the existing camera-ready campaign suite passes 137 tests; the orchestrator assertion verifies top-level summary wiring.
- Benchmarks or smoke tests, if applicable: `NA - support helper; no benchmark result is claimed.`

## Downstream Propagation

- Parent issue updated (yes/no/NA): pending merge; the gate will post the criterion-to-PR evidence comment on #5391 after merge.
- Claim map / benchmark report updated (yes/no/NA): NA - no research claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no new durable result artifact.
- Registry or config index updated (yes/no/NA): NA - no registry or config change.
- Context index / memory note updated (yes/no/NA): NA - support-only change.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - no deferred propagation.
- Not applicable because: this is an additive report diagnostic with no paper-facing or benchmark-result claim.

## Follow-Up Issues

- Deferred work: none.
- Issues opened for follow-up: none.

Closes #5391

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardened and validated it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Arm Rollup” section to campaign reports.
  * Reports now summarize each arm’s planner, kinematics, status, episode counts, and—when applicable—error details.
  * Campaign summaries now include arm-level rollup data aligned with campaign runs.
* **Bug Fixes**
  * Improved handling of missing counters and unavailable arms in rollup reporting.
* **Tests**
  * Added coverage for successful, partially failed, failed, unavailable, and empty campaign results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->