### PR TITLE
Issue #5389: gate-side merge-staleness check (cheap-lane worker)

### DIFF
--- a/.agents/skills/gh-pr-merger/SKILL.md
+++ b/.agents/skills/gh-pr-merger/SKILL.md
@@ -60,8 +60,14 @@ Before each merge operation, verify:
    Exit code `2` means checks were still queued or in progress after the polling budget; inspect the
    listed check URLs or run `gh run view <run-id> --json status,conclusion,jobs` for job state.
 5. No merge conflicts exist (`gh pr view <number> --json mergeable`).
-6. The PR has no unresolved review threads or pending/requested reviewers.
-7. Branch protection rules on `main` allow merges from the current actor.
+6. **Merge-staleness check**: run `python scripts/dev/check_pr_merge_staleness.py <number>`.
+   Exit code `1` means main has moved since the PR's CI ran; skip and report the
+   PR as stale — the author must update the branch and re-run CI before merge.
+   Exit code `2` means the check could not determine staleness (API error, no
+   workflow-run metadata); log a warning and continue with remaining preflight
+   checks.  See issue #5389 for context.
+7. The PR has no unresolved review threads or pending/requested reviewers.
+8. Branch protection rules on `main` allow merges from the current actor.
 
 If any preflight check fails, report the specific failure and do not merge.
 Do not retry preflight on the same PR without a state change.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -347,6 +347,39 @@ uv run ruff check --fix . && uv run ruff format . && uvx ty check . --exit-zero 
 `ty` currently runs in advisory mode with `--exit-zero`: it reports findings, but the canonical
 typecheck phase is not a PR-readiness merge blocker by itself.
 
+### Merge-race prevention (ADR — issue #5389)
+
+**Problem.** Three main-red incidents in 36 hours (2026-07-11/12) had the same shape: two PRs, each
+green on its own merge-ref, broke main when both landed in a 3-second merge race. The red-main merge
+hold (#5385) stops breakage *stacking* once main is red, but nothing prevented the race itself: a
+PR's CI ran against a main that moved before the merge landed.
+
+**Decision: gate-side staleness check.** We adopt option 2 from the issue — a staleness rule that
+prevents merging a PR whose CI ran against a stale main:
+
+- **Script**: `scripts/dev/check_pr_merge_staleness.py <pr-number>`.
+- **Integration**: the `gh-pr-merger` skill runs this check as preflight step 6 before any merge.
+- **Behavior**: when the check detects that main has moved since the PR's CI ran, it returns exit
+  code 1 and the merger skips the PR with a staleness report. The author must `gh pr update-branch`
+  and re-run CI before the PR becomes mergeable again.
+
+**Why not GitHub merge queue?** The native merge queue is the ideal solution — it re-validates each
+PR against the up-to-date prospective main before merging automatically. We chose the gate-side rule
+because:
+
+1. It works immediately without enabling a repository-level feature that requires maintainer approval
+   to toggle branch-protection settings.
+2. It provides the same merge-race guarantee at the cost of slightly more manual branch updates.
+3. It is easy to roll back — remove the preflight step from the skill and the script can be deleted.
+
+**When to revisit.** If the native merge queue becomes available and is enabled, the gate-side
+staleness check can be replaced by the queue's built-in re-validation, which is strictly stronger.
+The gate-side rule remains useful as a safety net for non-GitHub CI providers.
+
+**Rollback path.** Remove step 6 from `.agents/skills/gh-pr-merger/SKILL.md` and
+`.opencode/skills/gh-pr-merger/SKILL.md`. The script `scripts/dev/check_pr_merge_staleness.py`
+and its tests can be deleted at that point.
+
 ### Reusable dev scripts
 
 Prefer calling shared scripts from `scripts/dev/` so VS Code tasks, local shells, and Codex

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -360,8 +360,10 @@ prevents merging a PR whose CI ran against a stale main:
 - **Script**: `scripts/dev/check_pr_merge_staleness.py <pr-number>`.
 - **Integration**: the `gh-pr-merger` skill runs this check as preflight step 6 before any merge.
 - **Behavior**: when the check detects that main has moved since the PR's CI ran, it returns exit
-  code 1 and the merger skips the PR with a staleness report. The author must `gh pr update-branch`
-  and re-run CI before the PR becomes mergeable again.
+  code 1 and the merger skips the PR with a staleness report. The precise path reads the completed
+  workflow run's recorded `pull_requests[].base.sha`; when that provenance is unavailable, the
+  checker falls back to the PR base-vs-main comparison. The author must `gh pr update-branch` and
+  re-run CI before the PR becomes mergeable again.
 
 **Why not GitHub merge queue?** The native merge queue is the ideal solution — it re-validates each
 PR against the up-to-date prospective main before merging automatically. We chose the gate-side rule

--- a/scripts/dev/check_pr_merge_staleness.py
+++ b/scripts/dev/check_pr_merge_staleness.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Gate-side staleness check for PR merge readiness.
+
+Prevents green-alone-red-together merge races by detecting when main has moved
+since the PR's CI last ran.  Two detection layers are used:
+
+1. **Workflow-run merge ref** (precise): when CI is GitHub Actions on a
+   pull_request trigger, the run's ``head_sha`` is a temporary merge commit of
+   the PR into main.  The merge commit's second parent *is* the exact main
+   commit the PR was tested against.  Comparing that against current main
+   catches the 3-second merge race described in issue #5389.
+
+2. **Base-vs-main fallback** (conservative): when the merge ref is unavailable
+   (non-Actions CI, missing permissions, API failure), the script falls back to
+   comparing ``pull_request.base.sha`` against current main.  This is still
+   useful but does *not* catch the race where both PRs tested against the *same*
+   stale main and both passed individually.
+
+Exit codes:
+  0  PR merge base matches current main (not stale).
+  1  PR is stale; main has moved since CI ran.
+  2  Could not determine; warn and let the caller decide.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+def _gh(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a gh command and return the completed process."""
+    return subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _parse_json(stdout: str) -> tuple[dict[str, Any] | None, str | None]:
+    """Parse gh JSON stdout into a dict or an error string."""
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        return None, f"Failed to parse gh output as JSON: {exc}"
+    if not isinstance(data, dict):
+        return None, "gh output is not a JSON object"
+    return data, None
+
+
+def _get_main_sha(repo: str) -> str | None:
+    """Return current main branch HEAD SHA, or None on error."""
+    result = _gh(["api", f"repos/{repo}/git/refs/heads/main", "--jq", ".object.sha"])
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha if sha else None
+
+
+def _get_merge_ref_second_parent(merge_sha: str, repo: str) -> str | None:
+    """Return the second parent of a merge commit (the main commit tested against)."""
+    result = _gh(
+        ["api", f"repos/{repo}/commits/{merge_sha}", "--jq", ".parents[1].sha"],
+    )
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha if sha else None
+
+
+def _detect_merge_sha_from_workflow_run(repo: str, pr_number: str) -> str | None:
+    """Detect the merge commit SHA from a GitHub Actions workflow run for a PR.
+
+    When a workflow triggers on ``pull_request``, GitHub creates a temporary merge
+    ref and the run's ``head_sha`` is that merge commit.  This function fetches
+    the most recent Actions workflow run for the PR and returns its ``head_sha``.
+
+    Returns None when:
+    - The repository does not use GitHub Actions.
+    - The ``GITHUB_ACTIONS`` env var is not set (non-Actions environment).
+    - No workflow runs are found for the PR.
+    - API errors occur.
+    """
+    import os
+
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return None
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    if "pull_request" not in event_name:
+        return None
+
+    try:
+        result = _gh(
+            [
+                "api",
+                f"repos/{repo}/actions/runs",
+                "-f",
+                f"head_branch={pr_number}",
+                "--jq",
+                ".workflow_runs[0].head_sha",
+            ],
+        )
+        if result.returncode != 0:
+            return None
+        sha = result.stdout.strip()
+        return sha if sha else None
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def check_merge_staleness(
+    pr_number: str,
+    *,
+    base_sha: str,
+    repo: str,
+) -> dict[str, Any]:
+    """Check whether a PR's CI ran against a stale main.
+
+    Returns a result dict with at minimum:
+      - ``stale``: bool | None (None = unknown / error)
+      - ``detection``: ``"workflow_run_merge_ref"`` | ``"base_vs_main"``
+      - ``pr``, ``base_sha``, ``main_sha``
+    """
+    main_sha = _get_main_sha(repo)
+    if main_sha is None:
+        return {
+            "status": "error",
+            "error": "Failed to fetch current main SHA",
+            "stale": None,
+            "detection": "error",
+            "pr": pr_number,
+            "base_sha": base_sha,
+            "main_sha": None,
+        }
+
+    merge_sha = _detect_merge_sha_from_workflow_run(repo, pr_number)
+    if merge_sha:
+        main_at_merge = _get_merge_ref_second_parent(merge_sha, repo)
+        if main_at_merge:
+            is_stale = main_at_merge != main_sha
+            return {
+                "status": "ok",
+                "stale": is_stale,
+                "detection": "workflow_run_merge_ref",
+                "pr": pr_number,
+                "base_sha": base_sha,
+                "merge_sha": merge_sha,
+                "main_at_merge": main_at_merge,
+                "main_sha": main_sha,
+            }
+
+    # Fallback: conservative base-vs-main comparison.
+    is_stale = base_sha != main_sha
+    return {
+        "status": "ok",
+        "stale": is_stale,
+        "detection": "base_vs_main",
+        "warning": (
+            None
+            if is_stale
+            else "Cannot detect the exact merge ref CI tested against. "
+            "Consider re-running CI to confirm freshness."
+        ),
+        "pr": pr_number,
+        "base_sha": base_sha,
+        "main_sha": main_sha,
+    }
+
+
+def format_human(data: dict[str, Any]) -> str:
+    """Format a staleness result for human-readable output."""
+    if data.get("status") == "error":
+        return f"ERROR: {data.get('error', 'unknown error')}"
+
+    pr = data.get("pr", "?")
+    stale = data.get("stale")
+    detection = data.get("detection", "unknown")
+
+    if stale is None:
+        verdict = "UNKNOWN"
+    elif stale:
+        verdict = "STALE"
+    else:
+        verdict = "FRESH"
+
+    lines = [f"PR #{pr}: {verdict}  (detection: {detection})"]
+    lines.append(f"  base_sha:  {data.get('base_sha', '?')}")
+    lines.append(f"  main_sha:  {data.get('main_sha', '?')}")
+    if "merge_sha" in data:
+        lines.append(f"  merge_sha: {data['merge_sha']}")
+    if "main_at_merge" in data:
+        lines.append(f"  main_at_merge: {data['main_at_merge']}")
+    if data.get("warning"):
+        lines.append(f"  warning: {data['warning']}")
+    return "\n".join(lines)
+
+
+def _resolve_repo(explicit: str) -> str | None:
+    """Resolve the repository identifier, auto-detecting from gh when empty."""
+    if explicit:
+        return explicit
+    result = _gh(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"])
+    if result.returncode != 0:
+        return None
+    repo = result.stdout.strip()
+    return repo if repo else None
+
+
+def _fetch_pr_base_sha(pr_number: str) -> tuple[str | None, str | None]:
+    """Return (base_sha, error_message) for a PR."""
+    result = _gh(
+        ["pr", "view", pr_number, "--json", "baseRefOid", "--jq", ".baseRefOid"],
+    )
+    if result.returncode != 0:
+        return None, result.stderr.strip() or "gh pr view failed"
+    sha = result.stdout.strip()
+    if not sha:
+        return None, "PR base SHA is empty"
+    return sha, None
+
+
+def _output(data: dict[str, Any], *, as_json: bool) -> None:
+    """Print the result in the requested format."""
+    if as_json:
+        print(json.dumps(data))
+    else:
+        print(format_human(data))
+
+
+def _exit_code(data: dict[str, Any]) -> int:
+    """Map a staleness result to an exit code."""
+    if data.get("status") == "error":
+        return 2
+    if data.get("stale") is True:
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point: check merge staleness for a PR and print results."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("pr_number", nargs="?", help="GitHub PR number")
+    parser.add_argument("--pr", dest="pr_number_option", help="GitHub PR number alias")
+    parser.add_argument("--json", action="store_true", default=False, help="emit JSON output")
+    parser.add_argument("--repo", default="", help="owner/repo (default: detect from gh)")
+    args = parser.parse_args(argv)
+
+    if args.pr_number and args.pr_number_option and args.pr_number != args.pr_number_option:
+        parser.error("conflicting PR numbers: pass either positional or --pr, not both")
+    pr_number = args.pr_number_option or args.pr_number
+    if not pr_number:
+        parser.error("PR number is required (positional or --pr)")
+
+    try:
+        repo = _resolve_repo(args.repo)
+        if repo is None:
+            print("Failed to detect repository.  Pass --repo owner/repo.", file=sys.stderr)
+            return 1
+
+        base_sha, err = _fetch_pr_base_sha(pr_number)
+        if base_sha is None:
+            _output({"status": "error", "error": err}, as_json=args.json)
+            return 1
+
+        data = check_merge_staleness(pr_number, base_sha=base_sha, repo=repo)
+    except FileNotFoundError:
+        print("gh CLI not found.  Install GitHub CLI: https://cli.github.com/", file=sys.stderr)
+        return 1
+    except subprocess.TimeoutExpired:
+        print("gh CLI command timed out.", file=sys.stderr)
+        return 1
+
+    _output(data, as_json=args.json)
+    return _exit_code(data)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/check_pr_merge_staleness.py
+++ b/scripts/dev/check_pr_merge_staleness.py
@@ -4,13 +4,12 @@
 Prevents green-alone-red-together merge races by detecting when main has moved
 since the PR's CI last ran.  Two detection layers are used:
 
-1. **Workflow-run merge ref** (precise): when CI is GitHub Actions on a
-   pull_request trigger, the run's ``head_sha`` is a temporary merge commit of
-   the PR into main.  The merge commit's second parent *is* the exact main
-   commit the PR was tested against.  Comparing that against current main
-   catches the 3-second merge race described in issue #5389.
+1. **Workflow-run base provenance** (precise): a completed GitHub Actions
+   ``pull_request`` run exposes the PR's base SHA in its ``pull_requests``
+   metadata. Comparing that exact CI-tested base against current main catches
+   the 3-second merge race described in issue #5389.
 
-2. **Base-vs-main fallback** (conservative): when the merge ref is unavailable
+2. **Base-vs-main fallback** (conservative): when workflow-run provenance is unavailable
    (non-Actions CI, missing permissions, API failure), the script falls back to
    comparing ``pull_request.base.sha`` against current main.  This is still
    useful but does *not* catch the race where both PRs tested against the *same*
@@ -62,53 +61,99 @@ def _get_main_sha(repo: str) -> str | None:
     return sha if sha else None
 
 
-def _get_merge_ref_second_parent(merge_sha: str, repo: str) -> str | None:
-    """Return the second parent of a merge commit (the main commit tested against)."""
+def _fetch_pr_head_metadata(pr_number: str) -> tuple[str | None, str | None]:
+    """Return ``(head_branch, head_sha)`` for a PR, or ``(None, None)``."""
+    result = _gh(["pr", "view", pr_number, "--json", "headRefName,headRefOid"])
+    if result.returncode != 0:
+        return None, None
+    payload, _ = _parse_json(result.stdout)
+    if not isinstance(payload, dict):
+        return None, None
+    head_branch = payload.get("headRefName")
+    head_sha = payload.get("headRefOid")
+    if not isinstance(head_branch, str) or not head_branch:
+        return None, None
+    if not isinstance(head_sha, str) or not head_sha:
+        return None, None
+    return head_branch, head_sha
+
+
+def _fetch_workflow_runs(repo: str, head_branch: str) -> list[dict[str, Any]] | None:
+    """Return workflow-run objects for a PR head branch, or ``None`` on API failure."""
     result = _gh(
-        ["api", f"repos/{repo}/commits/{merge_sha}", "--jq", ".parents[1].sha"],
+        [
+            "api",
+            f"repos/{repo}/actions/runs",
+            "--method",
+            "GET",
+            "-f",
+            f"branch={head_branch}",
+            "-f",
+            "event=pull_request",
+            "-f",
+            "per_page=100",
+        ],
     )
     if result.returncode != 0:
         return None
-    sha = result.stdout.strip()
-    return sha if sha else None
-
-
-def _detect_merge_sha_from_workflow_run(repo: str, pr_number: str) -> str | None:
-    """Detect the merge commit SHA from a GitHub Actions workflow run for a PR.
-
-    When a workflow triggers on ``pull_request``, GitHub creates a temporary merge
-    ref and the run's ``head_sha`` is that merge commit.  This function fetches
-    the most recent Actions workflow run for the PR and returns its ``head_sha``.
-
-    Returns None when:
-    - The repository does not use GitHub Actions.
-    - The ``GITHUB_ACTIONS`` env var is not set (non-Actions environment).
-    - No workflow runs are found for the PR.
-    - API errors occur.
-    """
-    import os
-
-    if os.environ.get("GITHUB_ACTIONS") != "true":
+    payload, _ = _parse_json(result.stdout)
+    if not isinstance(payload, dict) or not isinstance(payload.get("workflow_runs"), list):
         return None
-    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
-    if "pull_request" not in event_name:
-        return None
+    return [run for run in payload["workflow_runs"] if isinstance(run, dict)]
 
-    try:
-        result = _gh(
-            [
-                "api",
-                f"repos/{repo}/actions/runs",
-                "-f",
-                f"head_branch={pr_number}",
-                "--jq",
-                ".workflow_runs[0].head_sha",
-            ],
+
+def _find_workflow_run_base_sha(
+    workflow_runs: list[dict[str, Any]],
+    *,
+    pr_number: str,
+    head_sha: str,
+) -> str | None:
+    """Find the completed run's recorded PR base SHA for the current head."""
+    for run in workflow_runs:
+        if run.get("status") != "completed" or run.get("head_sha") != head_sha:
+            continue
+        pull_requests = run.get("pull_requests")
+        if not isinstance(pull_requests, list):
+            continue
+        matching_pr = next(
+            (
+                pull_request
+                for pull_request in pull_requests
+                if isinstance(pull_request, dict)
+                and str(pull_request.get("number")) == str(pr_number)
+            ),
+            None,
         )
-        if result.returncode != 0:
+        if not isinstance(matching_pr, dict):
+            continue
+        base = matching_pr.get("base")
+        if not isinstance(base, dict):
+            continue
+        base_sha = base.get("sha")
+        if isinstance(base_sha, str) and base_sha:
+            return base_sha
+    return None
+
+
+def _detect_workflow_run_base_sha(repo: str, pr_number: str) -> str | None:
+    """Return the exact base SHA recorded by a completed PR workflow run.
+
+    The Actions run API exposes the PR's ``base.sha`` in each run's
+    ``pull_requests`` metadata. This avoids treating ``head_sha`` as a
+    synthetic merge commit: the run API reports the source-branch head there.
+    """
+    try:
+        head_branch, head_sha = _fetch_pr_head_metadata(pr_number)
+        if head_branch is None or head_sha is None:
             return None
-        sha = result.stdout.strip()
-        return sha if sha else None
+        workflow_runs = _fetch_workflow_runs(repo, head_branch)
+        if workflow_runs is None:
+            return None
+        return _find_workflow_run_base_sha(
+            workflow_runs,
+            pr_number=pr_number,
+            head_sha=head_sha,
+        )
     except (subprocess.TimeoutExpired, OSError):
         return None
 
@@ -123,7 +168,7 @@ def check_merge_staleness(
 
     Returns a result dict with at minimum:
       - ``stale``: bool | None (None = unknown / error)
-      - ``detection``: ``"workflow_run_merge_ref"`` | ``"base_vs_main"``
+      - ``detection``: ``"workflow_run_base_sha"`` | ``"base_vs_main"``
       - ``pr``, ``base_sha``, ``main_sha``
     """
     main_sha = _get_main_sha(repo)
@@ -138,21 +183,18 @@ def check_merge_staleness(
             "main_sha": None,
         }
 
-    merge_sha = _detect_merge_sha_from_workflow_run(repo, pr_number)
-    if merge_sha:
-        main_at_merge = _get_merge_ref_second_parent(merge_sha, repo)
-        if main_at_merge:
-            is_stale = main_at_merge != main_sha
-            return {
-                "status": "ok",
-                "stale": is_stale,
-                "detection": "workflow_run_merge_ref",
-                "pr": pr_number,
-                "base_sha": base_sha,
-                "merge_sha": merge_sha,
-                "main_at_merge": main_at_merge,
-                "main_sha": main_sha,
-            }
+    ci_base_sha = _detect_workflow_run_base_sha(repo, pr_number)
+    if ci_base_sha:
+        is_stale = ci_base_sha != main_sha
+        return {
+            "status": "ok",
+            "stale": is_stale,
+            "detection": "workflow_run_base_sha",
+            "pr": pr_number,
+            "base_sha": base_sha,
+            "ci_base_sha": ci_base_sha,
+            "main_sha": main_sha,
+        }
 
     # Fallback: conservative base-vs-main comparison.
     is_stale = base_sha != main_sha
@@ -163,7 +205,7 @@ def check_merge_staleness(
         "warning": (
             None
             if is_stale
-            else "Cannot detect the exact merge ref CI tested against. "
+            else "Cannot detect the exact workflow-run base SHA CI tested against. "
             "Consider re-running CI to confirm freshness."
         ),
         "pr": pr_number,
@@ -191,10 +233,8 @@ def format_human(data: dict[str, Any]) -> str:
     lines = [f"PR #{pr}: {verdict}  (detection: {detection})"]
     lines.append(f"  base_sha:  {data.get('base_sha', '?')}")
     lines.append(f"  main_sha:  {data.get('main_sha', '?')}")
-    if "merge_sha" in data:
-        lines.append(f"  merge_sha: {data['merge_sha']}")
-    if "main_at_merge" in data:
-        lines.append(f"  main_at_merge: {data['main_at_merge']}")
+    if "ci_base_sha" in data:
+        lines.append(f"  ci_base_sha: {data['ci_base_sha']}")
     if data.get("warning"):
         lines.append(f"  warning: {data['warning']}")
     return "\n".join(lines)

--- a/tests/dev/test_check_pr_merge_staleness.py
+++ b/tests/dev/test_check_pr_merge_staleness.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from scripts.dev.check_pr_merge_staleness import (
+    _detect_workflow_run_base_sha,
     check_merge_staleness,
     format_human,
     main,
@@ -25,7 +26,12 @@ def _gh_response(returncode: int = 0, stdout: str = "", stderr: str = "") -> Mag
 
 def test_stale_when_main_sha_differs() -> None:
     """Result should be stale when current main differs from the PR base."""
-    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
+        ),
+    ):
         # _get_main_sha
         mock_gh.side_effect = [
             _gh_response(stdout="main_head_sha"),
@@ -42,7 +48,12 @@ def test_stale_when_main_sha_differs() -> None:
 
 def test_fresh_when_base_matches_main() -> None:
     """Result should be fresh when the PR base matches current main."""
-    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
+        ),
+    ):
         mock_gh.side_effect = [
             _gh_response(stdout="same_sha"),
         ]
@@ -73,60 +84,118 @@ def test_main_sha_empty_string_treated_as_error() -> None:
     assert data["status"] == "error"
 
 
-# ── workflow-run merge-ref detection ─────────────────────────────────────────
+# ── workflow-run base provenance detection ───────────────────────────────────
 
 
-def test_workflow_run_merge_ref_fresh() -> None:
-    """When the merge ref's second parent matches main, the PR is fresh."""
+def test_detect_workflow_run_base_sha_uses_branch_and_pr_base_metadata() -> None:
+    """Use the current PR branch and the run's recorded base SHA."""
+    runs_payload = {
+        "workflow_runs": [
+            {
+                "status": "in_progress",
+                "head_sha": "head_sha",
+                "pull_requests": [{"number": 42, "base": {"sha": "in_progress_base"}}],
+            },
+            {
+                "status": "completed",
+                "head_sha": "old_head_sha",
+                "pull_requests": [{"number": 42, "base": {"sha": "old_base"}}],
+            },
+            {
+                "status": "completed",
+                "head_sha": "head_sha",
+                "pull_requests": [{"number": 42, "base": {"sha": "ci_base_sha"}}],
+            },
+        ]
+    }
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_response(stdout=json.dumps({"headRefName": "feature/x", "headRefOid": "head_sha"})),
+            _gh_response(stdout=json.dumps(runs_payload)),
+        ]
+        result = _detect_workflow_run_base_sha("owner/repo", "42")
+
+    assert result == "ci_base_sha"
+    actions_args = mock_gh.call_args_list[1].args[0]
+    assert "branch=feature/x" in actions_args
+    assert "event=pull_request" in actions_args
+
+
+def test_detect_workflow_run_base_sha_skips_other_prs() -> None:
+    """A run for another PR must not be treated as this PR's CI provenance."""
+    runs_payload = {
+        "workflow_runs": [
+            {
+                "status": "completed",
+                "head_sha": "head_sha",
+                "pull_requests": [{"number": 99, "base": {"sha": "other_base"}}],
+            }
+        ]
+    }
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_response(stdout=json.dumps({"headRefName": "feature/x", "headRefOid": "head_sha"})),
+            _gh_response(stdout=json.dumps(runs_payload)),
+        ]
+        result = _detect_workflow_run_base_sha("owner/repo", "42")
+
+    assert result is None
+
+
+def test_detect_workflow_run_base_sha_returns_none_on_api_error() -> None:
+    """Actions API failures leave the caller on the documented fallback path."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_response(stdout=json.dumps({"headRefName": "feature/x", "headRefOid": "head_sha"})),
+            _gh_response(returncode=1, stderr="API unavailable"),
+        ]
+        result = _detect_workflow_run_base_sha("owner/repo", "42")
+
+    assert result is None
+
+
+def test_workflow_run_base_sha_fresh() -> None:
+    """When the CI-tested base matches main, the PR is fresh."""
     with (
         patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
-        patch("scripts.dev.check_pr_merge_staleness._detect_merge_sha_from_workflow_run") as detect,
+        patch("scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha") as detect,
     ):
-        detect.return_value = "merge_commit_sha"
+        detect.return_value = "current_main"
         mock_gh.side_effect = [
             # _get_main_sha
-            _gh_response(stdout="current_main"),
-            # _get_merge_ref_second_parent
             _gh_response(stdout="current_main"),
         ]
         data = check_merge_staleness("42", base_sha="old_base", repo="owner/repo")
 
     assert data["stale"] is False
-    assert data["detection"] == "workflow_run_merge_ref"
-    assert data["merge_sha"] == "merge_commit_sha"
-    assert data["main_at_merge"] == "current_main"
+    assert data["detection"] == "workflow_run_base_sha"
+    assert data["ci_base_sha"] == "current_main"
 
 
-def test_workflow_run_merge_ref_stale() -> None:
-    """When the merge ref's second parent differs from main, the PR is stale."""
+def test_workflow_run_base_sha_stale() -> None:
+    """When the CI-tested base differs from main, the PR is stale."""
     with (
         patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
-        patch("scripts.dev.check_pr_merge_staleness._detect_merge_sha_from_workflow_run") as detect,
+        patch("scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha") as detect,
     ):
-        detect.return_value = "merge_commit_sha"
-        mock_gh.side_effect = [
-            _gh_response(stdout="new_main"),
-            _gh_response(stdout="old_main"),
-        ]
+        detect.return_value = "old_ci_base"
+        mock_gh.side_effect = [_gh_response(stdout="new_main")]
         data = check_merge_staleness("42", base_sha="old_base", repo="owner/repo")
 
     assert data["stale"] is True
-    assert data["detection"] == "workflow_run_merge_ref"
-    assert data["main_at_merge"] == "old_main"
+    assert data["detection"] == "workflow_run_base_sha"
+    assert data["ci_base_sha"] == "old_ci_base"
     assert data["main_sha"] == "new_main"
 
 
-def test_workflow_run_fallback_when_second_parent_fails() -> None:
-    """Should fall back to base-vs-main when the second-parent lookup fails."""
+def test_workflow_run_fallback_when_base_provenance_is_unavailable() -> None:
+    """Should fall back to base-vs-main when workflow provenance is unavailable."""
     with (
         patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
-        patch("scripts.dev.check_pr_merge_staleness._detect_merge_sha_from_workflow_run") as detect,
+        patch("scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha") as detect,
     ):
-        detect.return_value = "merge_commit_sha"
-        mock_gh.side_effect = [
-            _gh_response(stdout="current_main"),
-            _gh_response(returncode=1, stderr="error"),
-        ]
+        detect.return_value = None
+        mock_gh.side_effect = [_gh_response(stdout="current_main")]
         data = check_merge_staleness("42", base_sha="current_main", repo="owner/repo")
 
     assert data["detection"] == "base_vs_main"
@@ -136,7 +205,7 @@ def test_fallback_when_detect_returns_none() -> None:
     """Should fall back to base-vs-main when merge SHA detection returns None."""
     with (
         patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
-        patch("scripts.dev.check_pr_merge_staleness._detect_merge_sha_from_workflow_run") as detect,
+        patch("scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha") as detect,
     ):
         detect.return_value = None
         mock_gh.return_value = _gh_response(stdout="main_sha")
@@ -154,18 +223,17 @@ def test_format_human_stale() -> None:
     data = {
         "status": "ok",
         "stale": True,
-        "detection": "workflow_run_merge_ref",
+        "detection": "workflow_run_base_sha",
         "pr": "42",
         "base_sha": "old",
         "main_sha": "new",
-        "merge_sha": "merge",
-        "main_at_merge": "old",
+        "ci_base_sha": "old",
     }
     output = format_human(data)
     assert "STALE" in output
     assert "PR #42" in output
-    assert "workflow_run_merge_ref" in output
-    assert "merge_sha: merge" in output
+    assert "workflow_run_base_sha" in output
+    assert "ci_base_sha: old" in output
 
 
 def test_format_human_fresh() -> None:
@@ -213,10 +281,10 @@ def test_format_human_shows_warning() -> None:
         "pr": "5",
         "base_sha": "sha",
         "main_sha": "sha",
-        "warning": "Cannot detect merge ref",
+        "warning": "Cannot detect workflow-run base provenance",
     }
     output = format_human(data)
-    assert "warning: Cannot detect merge ref" in output
+    assert "warning: Cannot detect workflow-run base provenance" in output
 
 
 # ── main() CLI ───────────────────────────────────────────────────────────────
@@ -224,7 +292,12 @@ def test_format_human_shows_warning() -> None:
 
 def test_main_exit_0_when_fresh(capsys: pytest.CaptureFixture) -> None:
     """main() should return 0 when the PR is not stale."""
-    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
+        ),
+    ):
         mock_gh.side_effect = [
             # repo view
             _gh_response(stdout="ll7/robot_sf_ll7"),
@@ -242,7 +315,12 @@ def test_main_exit_0_when_fresh(capsys: pytest.CaptureFixture) -> None:
 
 def test_main_exit_1_when_stale(capsys: pytest.CaptureFixture) -> None:
     """main() should return 1 when the PR is stale."""
-    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
+        ),
+    ):
         mock_gh.side_effect = [
             _gh_response(stdout="ll7/robot_sf_ll7"),
             _gh_response(stdout="old_base"),
@@ -257,7 +335,12 @@ def test_main_exit_1_when_stale(capsys: pytest.CaptureFixture) -> None:
 
 def test_main_exit_2_on_error(capsys: pytest.CaptureFixture) -> None:
     """main() should return 2 when the check itself errors."""
-    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
+        ),
+    ):
         mock_gh.side_effect = [
             _gh_response(stdout="ll7/robot_sf_ll7"),
             _gh_response(stdout="abc"),
@@ -272,7 +355,12 @@ def test_main_exit_2_on_error(capsys: pytest.CaptureFixture) -> None:
 
 def test_main_json_output(capsys: pytest.CaptureFixture) -> None:
     """--json should emit machine-readable JSON."""
-    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
+        ),
+    ):
         mock_gh.side_effect = [
             _gh_response(stdout="ll7/robot_sf_ll7"),
             _gh_response(stdout="abc"),
@@ -289,7 +377,12 @@ def test_main_json_output(capsys: pytest.CaptureFixture) -> None:
 
 def test_main_repo_flag(capsys: pytest.CaptureFixture) -> None:
     """--repo should skip the repo detection step."""
-    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
+        ),
+    ):
         mock_gh.side_effect = [
             _gh_response(stdout="sha"),
             _gh_response(stdout="sha"),
@@ -303,7 +396,12 @@ def test_main_repo_flag(capsys: pytest.CaptureFixture) -> None:
 
 def test_main_pr_flag_alias(capsys: pytest.CaptureFixture) -> None:
     """--pr should work as a named alias for the positional PR number."""
-    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch(
+            "scripts.dev.check_pr_merge_staleness._detect_workflow_run_base_sha", return_value=None
+        ),
+    ):
         mock_gh.side_effect = [
             _gh_response(stdout="sha"),
             _gh_response(stdout="sha"),

--- a/tests/dev/test_check_pr_merge_staleness.py
+++ b/tests/dev/test_check_pr_merge_staleness.py
@@ -1,0 +1,363 @@
+"""Tests for the PR merge-staleness checker (deterministic, no live GitHub)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.dev.check_pr_merge_staleness import (
+    check_merge_staleness,
+    format_human,
+    main,
+)
+
+
+def _gh_response(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    """Create a mock subprocess.CompletedProcess for gh calls."""
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ── check_merge_staleness ────────────────────────────────────────────────────
+
+
+def test_stale_when_main_sha_differs() -> None:
+    """Result should be stale when current main differs from the PR base."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        # _get_main_sha
+        mock_gh.side_effect = [
+            _gh_response(stdout="main_head_sha"),
+        ]
+        data = check_merge_staleness("42", base_sha="old_base_sha", repo="owner/repo")
+
+    assert data["status"] == "ok"
+    assert data["stale"] is True
+    assert data["detection"] == "base_vs_main"
+    assert data["pr"] == "42"
+    assert data["base_sha"] == "old_base_sha"
+    assert data["main_sha"] == "main_head_sha"
+
+
+def test_fresh_when_base_matches_main() -> None:
+    """Result should be fresh when the PR base matches current main."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_response(stdout="same_sha"),
+        ]
+        data = check_merge_staleness("100", base_sha="same_sha", repo="owner/repo")
+
+    assert data["stale"] is False
+    assert data["detection"] == "base_vs_main"
+
+
+def test_error_when_main_sha_fails() -> None:
+    """Error status should propagate when fetching main SHA fails."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.return_value = _gh_response(returncode=1, stderr="not found")
+        data = check_merge_staleness("1", base_sha="abc", repo="owner/repo")
+
+    assert data["status"] == "error"
+    assert data["stale"] is None
+    assert data["detection"] == "error"
+    assert "Failed to fetch current main SHA" in data["error"]
+
+
+def test_main_sha_empty_string_treated_as_error() -> None:
+    """An empty main SHA response should report an error."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.return_value = _gh_response(stdout="")
+        data = check_merge_staleness("1", base_sha="abc", repo="owner/repo")
+
+    assert data["status"] == "error"
+
+
+# ── workflow-run merge-ref detection ─────────────────────────────────────────
+
+
+def test_workflow_run_merge_ref_fresh() -> None:
+    """When the merge ref's second parent matches main, the PR is fresh."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness._detect_merge_sha_from_workflow_run") as detect,
+    ):
+        detect.return_value = "merge_commit_sha"
+        mock_gh.side_effect = [
+            # _get_main_sha
+            _gh_response(stdout="current_main"),
+            # _get_merge_ref_second_parent
+            _gh_response(stdout="current_main"),
+        ]
+        data = check_merge_staleness("42", base_sha="old_base", repo="owner/repo")
+
+    assert data["stale"] is False
+    assert data["detection"] == "workflow_run_merge_ref"
+    assert data["merge_sha"] == "merge_commit_sha"
+    assert data["main_at_merge"] == "current_main"
+
+
+def test_workflow_run_merge_ref_stale() -> None:
+    """When the merge ref's second parent differs from main, the PR is stale."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness._detect_merge_sha_from_workflow_run") as detect,
+    ):
+        detect.return_value = "merge_commit_sha"
+        mock_gh.side_effect = [
+            _gh_response(stdout="new_main"),
+            _gh_response(stdout="old_main"),
+        ]
+        data = check_merge_staleness("42", base_sha="old_base", repo="owner/repo")
+
+    assert data["stale"] is True
+    assert data["detection"] == "workflow_run_merge_ref"
+    assert data["main_at_merge"] == "old_main"
+    assert data["main_sha"] == "new_main"
+
+
+def test_workflow_run_fallback_when_second_parent_fails() -> None:
+    """Should fall back to base-vs-main when the second-parent lookup fails."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness._detect_merge_sha_from_workflow_run") as detect,
+    ):
+        detect.return_value = "merge_commit_sha"
+        mock_gh.side_effect = [
+            _gh_response(stdout="current_main"),
+            _gh_response(returncode=1, stderr="error"),
+        ]
+        data = check_merge_staleness("42", base_sha="current_main", repo="owner/repo")
+
+    assert data["detection"] == "base_vs_main"
+
+
+def test_fallback_when_detect_returns_none() -> None:
+    """Should fall back to base-vs-main when merge SHA detection returns None."""
+    with (
+        patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh,
+        patch("scripts.dev.check_pr_merge_staleness._detect_merge_sha_from_workflow_run") as detect,
+    ):
+        detect.return_value = None
+        mock_gh.return_value = _gh_response(stdout="main_sha")
+        data = check_merge_staleness("42", base_sha="main_sha", repo="owner/repo")
+
+    assert data["detection"] == "base_vs_main"
+    assert data["stale"] is False
+
+
+# ── format_human ─────────────────────────────────────────────────────────────
+
+
+def test_format_human_stale() -> None:
+    """Stale result should include STALE verdict and detection method."""
+    data = {
+        "status": "ok",
+        "stale": True,
+        "detection": "workflow_run_merge_ref",
+        "pr": "42",
+        "base_sha": "old",
+        "main_sha": "new",
+        "merge_sha": "merge",
+        "main_at_merge": "old",
+    }
+    output = format_human(data)
+    assert "STALE" in output
+    assert "PR #42" in output
+    assert "workflow_run_merge_ref" in output
+    assert "merge_sha: merge" in output
+
+
+def test_format_human_fresh() -> None:
+    """Fresh result should include FRESH verdict."""
+    data = {
+        "status": "ok",
+        "stale": False,
+        "detection": "base_vs_main",
+        "pr": "1",
+        "base_sha": "abc",
+        "main_sha": "abc",
+    }
+    output = format_human(data)
+    assert "FRESH" in output
+
+
+def test_format_human_unknown() -> None:
+    """Unknown staleness should include UNKNOWN verdict."""
+    data = {
+        "status": "ok",
+        "stale": None,
+        "detection": "error",
+        "pr": "1",
+        "base_sha": "abc",
+        "main_sha": None,
+    }
+    output = format_human(data)
+    assert "UNKNOWN" in output
+
+
+def test_format_human_error() -> None:
+    """Error status should print the error message."""
+    data = {"status": "error", "error": "API down"}
+    output = format_human(data)
+    assert "ERROR" in output
+    assert "API down" in output
+
+
+def test_format_human_shows_warning() -> None:
+    """Warning field should appear in the human output."""
+    data = {
+        "status": "ok",
+        "stale": False,
+        "detection": "base_vs_main",
+        "pr": "5",
+        "base_sha": "sha",
+        "main_sha": "sha",
+        "warning": "Cannot detect merge ref",
+    }
+    output = format_human(data)
+    assert "warning: Cannot detect merge ref" in output
+
+
+# ── main() CLI ───────────────────────────────────────────────────────────────
+
+
+def test_main_exit_0_when_fresh(capsys: pytest.CaptureFixture) -> None:
+    """main() should return 0 when the PR is not stale."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.side_effect = [
+            # repo view
+            _gh_response(stdout="ll7/robot_sf_ll7"),
+            # pr view base sha
+            _gh_response(stdout="same_sha"),
+            # main sha
+            _gh_response(stdout="same_sha"),
+        ]
+        rc = main(["42"])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "FRESH" in captured.out
+
+
+def test_main_exit_1_when_stale(capsys: pytest.CaptureFixture) -> None:
+    """main() should return 1 when the PR is stale."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_response(stdout="ll7/robot_sf_ll7"),
+            _gh_response(stdout="old_base"),
+            _gh_response(stdout="new_main"),
+        ]
+        rc = main(["42"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "STALE" in captured.out
+
+
+def test_main_exit_2_on_error(capsys: pytest.CaptureFixture) -> None:
+    """main() should return 2 when the check itself errors."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_response(stdout="ll7/robot_sf_ll7"),
+            _gh_response(stdout="abc"),
+            _gh_response(returncode=1, stderr="network error"),
+        ]
+        rc = main(["1"])
+
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "ERROR" in captured.out
+
+
+def test_main_json_output(capsys: pytest.CaptureFixture) -> None:
+    """--json should emit machine-readable JSON."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_response(stdout="ll7/robot_sf_ll7"),
+            _gh_response(stdout="abc"),
+            _gh_response(stdout="abc"),
+        ]
+        rc = main(["7", "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["pr"] == "7"
+    assert payload["stale"] is False
+    assert payload["status"] == "ok"
+
+
+def test_main_repo_flag(capsys: pytest.CaptureFixture) -> None:
+    """--repo should skip the repo detection step."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_response(stdout="sha"),
+            _gh_response(stdout="sha"),
+        ]
+        rc = main(["1", "--repo", "ll7/robot_sf_ll7"])
+
+    assert rc == 0
+    # Should have made exactly 2 gh calls (pr view, main sha), not 3.
+    assert mock_gh.call_count == 2
+
+
+def test_main_pr_flag_alias(capsys: pytest.CaptureFixture) -> None:
+    """--pr should work as a named alias for the positional PR number."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_response(stdout="sha"),
+            _gh_response(stdout="sha"),
+        ]
+        rc = main(["--pr", "99", "--repo", "ll7/robot_sf_ll7"])
+
+    assert rc == 0
+
+
+def test_main_rejects_conflicting_pr_inputs(capsys: pytest.CaptureFixture) -> None:
+    """Conflicting positional and --pr should fail before invoking gh."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        with pytest.raises(SystemExit) as excinfo:
+            main(["1", "--pr", "2"])
+
+    assert excinfo.value.code == 2
+    mock_gh.assert_not_called()
+
+
+def test_main_requires_pr_number(capsys: pytest.CaptureFixture) -> None:
+    """No PR number should fail with exit 2."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        with pytest.raises(SystemExit) as excinfo:
+            main([])
+
+    assert excinfo.value.code == 2
+    mock_gh.assert_not_called()
+
+
+def test_main_gh_not_installed() -> None:
+    """main() should exit 1 when gh is not on PATH."""
+    with patch(
+        "scripts.dev.check_pr_merge_staleness._gh",
+        side_effect=FileNotFoundError,
+    ):
+        rc = main(["42", "--repo", "ll7/robot_sf_ll7"])
+    assert rc == 1
+
+
+def test_main_gh_timeout() -> None:
+    """main() should exit 1 when gh times out."""
+    with patch(
+        "scripts.dev.check_pr_merge_staleness._gh",
+        side_effect=subprocess.TimeoutExpired(["gh"], timeout=30),
+    ):
+        rc = main(["42", "--repo", "ll7/robot_sf_ll7"])
+    assert rc == 1
+
+
+def test_main_repo_detect_failure(capsys: pytest.CaptureFixture) -> None:
+    """Repository detection failure should exit 1."""
+    with patch("scripts.dev.check_pr_merge_staleness._gh") as mock_gh:
+        mock_gh.return_value = _gh_response(returncode=1, stderr="auth error")
+        rc = main(["42"])
+
+    assert rc == 1
+    assert "Failed to detect repository" in capsys.readouterr().err


### PR DESCRIPTION
## What

Implements the gate-side staleness rule from issue #5389 to prevent green-alone-red-together merge races. A new script compares the PR’s CI-tested base against current `main` before the `gh-pr-merger` skill proceeds with a merge.

## Why

Three main-red incidents in 36 hours (2026-07-11/12) were caused by two PRs that each passed CI individually but broke `main` when both landed — a classic merge race. The red-main merge hold (#5385) stops breakage stacking, but nothing prevented the race itself. This change adds a preflight check that blocks merging when `main` has moved since the PR’s CI ran.

## Changes

- **`scripts/dev/check_pr_merge_staleness.py`** — new script with two-layer detection:
  1. **Workflow-run base provenance** (precise): selects a completed `pull_request` Actions run for the actual PR branch/head and reads its recorded `pull_requests[].base.sha`.
  2. **Base-vs-main fallback** (conservative): compares `baseRefOid` against current `main` when workflow-run provenance is unavailable.
- **`tests/dev/test_check_pr_merge_staleness.py`** — deterministic tests covering stale, fresh, error, workflow-run branch/PR/base selection, fallback, output formatting, CLI argument handling, and error propagation.
- **`.agents/skills/gh-pr-merger/SKILL.md`** — adds the staleness check as preflight step 6 between merge-conflict and review-thread checks.
- **`docs/dev_guide.md`** — ADR note documenting the decision, why merge queue was not chosen, provenance behavior, and rollback path.

## Validation

```
uv run ruff check scripts/dev/check_pr_merge_staleness.py tests/dev/test_check_pr_merge_staleness.py
uv run pytest tests/dev/test_check_pr_merge_staleness.py -q
# 27 passed
```

The live gate path was also exercised against the PR’s completed Actions run and returned `detection=workflow_run_base_sha` with the recorded CI base SHA, correctly identifying the branch as stale after `main` moved.

## Research Result Guidance

- Target claim / hypothesis / blocker: `NA - merge-safety tooling; no research, benchmark, metric, or paper-facing claim.`
- Comparator or baseline, if applicable: `NA - tooling contract.`
- Evidence tier: `NA - support/tooling proof.`
- Result classification: `NA - support/tooling change.`
- Decision or stop rule, if applicable: `NA - merge-safety preflight behavior is covered by deterministic tests and the live CLI path.`
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #5389 and `docs/dev_guide.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: `NA - gate helper; it does not interpret research evidence.`

## Domain-Aware Approval

- Required for this PR: no - merge-safety tooling does not change evidence classification, comparison methodology, figure eligibility, or paper-facing claim boundaries.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: gate review of the issue #5389 contract and live API path.
- Validity checklist:
  - Target claim/hypothesis: NA - no research claim.
  - Comparator or split/evidence validity: NA - no benchmark comparison.
  - Fallback/degraded exclusions: the fallback is explicitly reported as conservative provenance, not benchmark evidence.
  - Claim boundary: merge-readiness safety check only.
  - Implementation integrity vs experimental validity: implementation integrity only.

## Rollback

Remove step 6 from `.agents/skills/gh-pr-merger/SKILL.md`. The native merge queue can replace this check when enabled; the script and tests can then be deleted as documented in `docs/dev_guide.md`.

## Downstream Propagation

- Parent issue updated (yes/no/NA): pending merge; the gate will post the merged state and no remaining acceptance gap on #5389.
- Claim map / benchmark report updated (yes/no/NA): NA - no research result.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no benchmark artifact.
- Registry or config index updated (yes/no/NA): NA - no registry/config change.
- Context index / memory note updated (yes/no/NA): yes - `docs/dev_guide.md` records the ADR and rollback.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - no deferred propagation.
- Not applicable because: this is bounded gate tooling and its durable documentation is in the dev guide and merger skill.

## Follow-Up Issues

- Deferred work: none; native merge-queue adoption is a future maintainer decision documented in the rollback/revisit note, not an acceptance blocker.
- Issues opened for follow-up: none.

Closes #5389

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
