### PR TITLE
Issue #5390: per-arm consecutive-identical-failure circuit breaker (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/circuit_breaker.py
+++ b/robot_sf/benchmark/circuit_breaker.py
@@ -1,0 +1,60 @@
+"""Shared configuration and error-signature helpers for benchmark circuit breakers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_CIRCUIT_BREAKER_THRESHOLD = 10
+_CIRCUIT_BREAKER_MSG_PREFIX_LEN = 200
+
+
+def normalize_circuit_breaker_threshold(value: int | None) -> int:
+    """Normalize and validate the optional circuit-breaker threshold.
+
+    ``None`` selects the default, ``0`` explicitly disables the breaker, and
+    negative or non-integer values are rejected before any benchmark work runs.
+
+    Returns:
+        The validated non-negative threshold.
+    """
+    if value is None:
+        return DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("circuit_breaker_threshold must be an integer or None")
+    if value < 0:
+        raise ValueError("circuit_breaker_threshold must be non-negative")
+    return value
+
+
+def error_signature(exc: Exception) -> tuple[str, str]:
+    """Return a stable exception type/message-prefix signature."""
+    msg = str(exc).replace("\r\n", "\n").replace("\r", "\n").strip()
+    return (type(exc).__name__, msg[:_CIRCUIT_BREAKER_MSG_PREFIX_LEN])
+
+
+def build_abort_metadata(
+    *,
+    signature: tuple[str, str],
+    consecutive_failures: int,
+    first_fail_index: int,
+    episodes_completed_before_onset: int,
+    total_jobs: int,
+) -> dict[str, Any]:
+    """Build the common circuit-breaker abort payload.
+
+    Returns:
+        Structured metadata describing the aborted arm and projected savings.
+    """
+    projected_remaining = total_jobs - first_fail_index - consecutive_failures + 1
+    return {
+        "status": "aborted_systematic_failure",
+        "signature": {
+            "type": signature[0],
+            "message_prefix": signature[1],
+        },
+        "consecutive_failures": consecutive_failures,
+        "first_fail_index": first_fail_index,
+        "episodes_completed_before_onset": episodes_completed_before_onset,
+        "projected_episodes_saved": projected_remaining,
+        "projected_walltime_saved_hint": f"~{projected_remaining} episodes not attempted",
+    }

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -2536,7 +2536,7 @@ def _run_map_jobs_with_policy_cache(
     out_path: Path,
     schema: dict[str, Any],
     workers: int,
-    circuit_breaker_threshold: int = 10,
+    circuit_breaker_threshold: int | None = None,
 ) -> Any:
     """Run one arm with policies cached until the batch completes.
 
@@ -2548,6 +2548,7 @@ def _run_map_jobs_with_policy_cache(
     Returns:
         The normal map-batch execution result.
     """
+    circuit_breaker_threshold = normalize_circuit_breaker_threshold(circuit_breaker_threshold)
     policy_cache: dict[
         tuple[str, str, str | None, str | None, bool], tuple[Any, dict[str, Any]]
     ] = {}

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -28,6 +28,7 @@ from robot_sf.benchmark.algorithm_readiness import (
     BenchmarkProfile,
     require_algorithm_allowed,
 )
+from robot_sf.benchmark.circuit_breaker import normalize_circuit_breaker_threshold
 from robot_sf.benchmark.fallback_policy import availability_payload
 from robot_sf.benchmark.latency_stress import (
     not_available_latency_metrics,
@@ -2535,6 +2536,7 @@ def _run_map_jobs_with_policy_cache(
     out_path: Path,
     schema: dict[str, Any],
     workers: int,
+    circuit_breaker_threshold: int = 10,
 ) -> Any:
     """Run one arm with policies cached until the batch completes.
 
@@ -2610,6 +2612,7 @@ def _run_map_jobs_with_policy_cache(
             executor_cls=ProcessPoolExecutor,
             as_completed_fn=as_completed,
             multiprocessing_context=None,
+            circuit_breaker_threshold=circuit_breaker_threshold,
         )
     finally:
         for policy, _metadata in policy_cache.values():
@@ -2760,12 +2763,14 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     multiprocessing_context: Any | None = None,
     workers: int = 1,
     resume: bool = True,
+    circuit_breaker_threshold: int | None = None,
 ) -> dict[str, Any]:
     """Run map-based scenarios and append episode records.
 
     Returns:
         Summary payload with counts and failure details.
     """
+    circuit_breaker_threshold = normalize_circuit_breaker_threshold(circuit_breaker_threshold)
     ped_impact_radius_m, ped_impact_window_steps = _normalize_pedestrian_impact_controls(
         experimental_ped_impact=experimental_ped_impact,
         ped_impact_radius_m=ped_impact_radius_m,
@@ -3173,6 +3178,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
             out_path=out_path,
             schema=schema,
             workers=workers,
+            circuit_breaker_threshold=circuit_breaker_threshold,
         )
         if (
             workers <= 1
@@ -3192,6 +3198,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
             executor_cls=ProcessPoolExecutor,
             as_completed_fn=as_completed,
             multiprocessing_context=multiprocessing_context,
+            circuit_breaker_threshold=circuit_breaker_threshold,
         )
     )
     wrote = batch_execution.wrote
@@ -3250,6 +3257,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         suite_key=suite_key,
         kinematics_tag=kinematics_tag,
         metric_affecting_config=metric_affecting_config,
+        abort_metadata=batch_execution.abort_metadata,
     )
     # Emit provenance manifest alongside the JSONL output.
     _record_result_provenance_manifest(

--- a/robot_sf/benchmark/map_runner_batch_runner.py
+++ b/robot_sf/benchmark/map_runner_batch_runner.py
@@ -11,6 +11,8 @@ from typing import Any, NamedTuple
 
 from loguru import logger
 
+from robot_sf.benchmark.circuit_breaker import build_abort_metadata, error_signature
+
 # Set PyTorch allocator configuration early before torch is loaded.
 os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
 
@@ -29,6 +31,7 @@ class BatchExecutionResult(NamedTuple):
     runtime_algorithm_contract: dict[str, Any] | None
     feasibility_totals: FeasibilityTotals
     batch_runtime_sec: float
+    abort_metadata: dict[str, Any] | None
 
 
 def _initial_feasibility_totals() -> FeasibilityTotals:
@@ -89,7 +92,17 @@ def _serial_execute_map_jobs(  # noqa: PLR0913
     apply_worker_metadata_bridge,
     scenario_id,
     feasibility_totals: FeasibilityTotals,
-) -> tuple[int, list[dict[str, Any]], list[dict[str, Any]], bool, int, int, dict[str, Any] | None]:
+    circuit_breaker_threshold: int = 10,
+) -> tuple[
+    int,
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    bool,
+    int,
+    int,
+    dict[str, Any] | None,
+    dict[str, Any] | None,
+]:
     """Execute map-runner jobs serially and append successful records.
 
     Returns:
@@ -102,9 +115,13 @@ def _serial_execute_map_jobs(  # noqa: PLR0913
     adapter_adapted_steps = 0
     adapter_samples_seen = False
     runtime_algorithm_contract: dict[str, Any] | None = None
+    abort_metadata: dict[str, Any] | None = None
+    last_signature: tuple[str, str] | None = None
+    consecutive_failures = 0
+    first_fail_index: int | None = None
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with out_path.open("a", encoding="utf-8") as handle:
-        for scenario, seed in jobs:
+        for idx, (scenario, seed) in enumerate(jobs, start=1):
             try:
                 rec = run_map_job((scenario, seed, fixed_params))
                 (
@@ -124,6 +141,9 @@ def _serial_execute_map_jobs(  # noqa: PLR0913
                 write_validated_to_handle(handle, schema, rec)
                 wrote += 1
                 episode_records.append(rec)
+                last_signature = None
+                consecutive_failures = 0
+                first_fail_index = None
             except Exception as exc:  # pragma: no cover - error path
                 logger.exception(
                     "Map batch worker failed in serial execution: scenario={} seed={}",
@@ -137,6 +157,30 @@ def _serial_execute_map_jobs(  # noqa: PLR0913
                         "error": repr(exc),
                     }
                 )
+                if circuit_breaker_threshold > 0:
+                    signature = error_signature(exc)
+                    if signature == last_signature:
+                        consecutive_failures += 1
+                    else:
+                        last_signature = signature
+                        consecutive_failures = 1
+                        first_fail_index = idx
+                    if consecutive_failures >= circuit_breaker_threshold:
+                        abort_metadata = build_abort_metadata(
+                            signature=signature,
+                            consecutive_failures=consecutive_failures,
+                            first_fail_index=first_fail_index or idx,
+                            episodes_completed_before_onset=wrote,
+                            total_jobs=len(jobs),
+                        )
+                        logger.warning(
+                            "Map circuit breaker tripped after {} consecutive identical "
+                            "failures at {}/{} jobs",
+                            consecutive_failures,
+                            idx,
+                            len(jobs),
+                        )
+                        break
             finally:
                 # Force garbage collection to clean up model/env refs between consecutive arms
                 gc.collect()
@@ -153,6 +197,7 @@ def _serial_execute_map_jobs(  # noqa: PLR0913
         adapter_native_steps,
         adapter_adapted_steps,
         runtime_algorithm_contract,
+        abort_metadata,
     )
 
 
@@ -275,6 +320,7 @@ def execute_map_jobs(  # noqa: PLR0913
     executor_cls,
     as_completed_fn,
     multiprocessing_context: Any | None = None,
+    circuit_breaker_threshold: int = 10,
 ) -> BatchExecutionResult:
     """Execute map-runner jobs and append validated JSONL records.
 
@@ -293,6 +339,7 @@ def execute_map_jobs(  # noqa: PLR0913
             adapter_native_steps,
             adapter_adapted_steps,
             runtime_algorithm_contract,
+            abort_metadata,
         ) = _serial_execute_map_jobs(
             jobs=jobs,
             fixed_params=fixed_params,
@@ -303,8 +350,10 @@ def execute_map_jobs(  # noqa: PLR0913
             apply_worker_metadata_bridge=apply_worker_metadata_bridge,
             scenario_id=scenario_id,
             feasibility_totals=feasibility_totals,
+            circuit_breaker_threshold=circuit_breaker_threshold,
         )
     else:
+        abort_metadata = None
         (
             wrote,
             episode_records,
@@ -338,4 +387,5 @@ def execute_map_jobs(  # noqa: PLR0913
         runtime_algorithm_contract=runtime_algorithm_contract,
         feasibility_totals=feasibility_totals,
         batch_runtime_sec=float(max(time.perf_counter() - batch_started, 0.0)),
+        abort_metadata=(abort_metadata if workers <= 1 else None),
     )

--- a/robot_sf/benchmark/map_runner_batch_runner.py
+++ b/robot_sf/benchmark/map_runner_batch_runner.py
@@ -11,7 +11,11 @@ from typing import Any, NamedTuple
 
 from loguru import logger
 
-from robot_sf.benchmark.circuit_breaker import build_abort_metadata, error_signature
+from robot_sf.benchmark.circuit_breaker import (
+    build_abort_metadata,
+    error_signature,
+    normalize_circuit_breaker_threshold,
+)
 
 # Set PyTorch allocator configuration early before torch is loaded.
 os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
@@ -92,7 +96,7 @@ def _serial_execute_map_jobs(  # noqa: PLR0913
     apply_worker_metadata_bridge,
     scenario_id,
     feasibility_totals: FeasibilityTotals,
-    circuit_breaker_threshold: int = 10,
+    circuit_breaker_threshold: int | None = None,
 ) -> tuple[
     int,
     list[dict[str, Any]],
@@ -108,6 +112,7 @@ def _serial_execute_map_jobs(  # noqa: PLR0913
     Returns:
         Write count, failures, adapter counters, and runtime algorithm contract.
     """
+    circuit_breaker_threshold = normalize_circuit_breaker_threshold(circuit_breaker_threshold)
     wrote = 0
     episode_records: list[dict[str, Any]] = []
     failures: list[dict[str, Any]] = []
@@ -320,13 +325,14 @@ def execute_map_jobs(  # noqa: PLR0913
     executor_cls,
     as_completed_fn,
     multiprocessing_context: Any | None = None,
-    circuit_breaker_threshold: int = 10,
+    circuit_breaker_threshold: int | None = None,
 ) -> BatchExecutionResult:
     """Execute map-runner jobs and append validated JSONL records.
 
     Returns:
         Batch execution counters and metadata accumulators.
     """
+    circuit_breaker_threshold = normalize_circuit_breaker_threshold(circuit_breaker_threshold)
     out_path = Path(out_path)
     feasibility_totals = _initial_feasibility_totals()
     batch_started = time.perf_counter()

--- a/robot_sf/benchmark/map_runner_batch_summary.py
+++ b/robot_sf/benchmark/map_runner_batch_summary.py
@@ -294,6 +294,7 @@ def build_completed_batch_summary(  # noqa: PLR0913
     suite_key: str,
     kinematics_tag: str,
     metric_affecting_config: dict[str, Any] | None = None,
+    abort_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the final successful batch summary after all map jobs finish.
 
@@ -410,6 +411,8 @@ def build_completed_batch_summary(  # noqa: PLR0913
         summary["benchmark_track"] = benchmark_track
     if track_schema_version is not None:
         summary["track_schema_version"] = track_schema_version
+    if abort_metadata is not None:
+        summary["abort"] = abort_metadata
     artifact_pointer_status = "local_jsonl_present" if out_path.exists() else "not_available"
     summary["provenance"] = map_result_provenance(
         schema_path=schema_path,

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -90,6 +90,8 @@ if TYPE_CHECKING:
 
 DEFAULT_BENCHMARK_ROBOT_RADIUS_M = 0.3
 DEFAULT_BENCHMARK_PED_RADIUS_M = 0.35
+DEFAULT_CIRCUIT_BREAKER_THRESHOLD: int = 10  # consecutive identical failures to abort
+_CIRCUIT_BREAKER_MSG_PREFIX_LEN: int = 200  # characters used for signature prefix
 
 
 def _apply_track_metadata_to_scenarios(
@@ -1421,6 +1423,7 @@ def validate_and_write(
 
 
 __all__ = [
+    "DEFAULT_CIRCUIT_BREAKER_THRESHOLD",
     "load_scenario_matrix",
     "run_batch",
     "run_episode",
@@ -1487,7 +1490,26 @@ def _write_validated_record(out_path: Path, schema: dict[str, Any], rec: dict[st
         f.write(json.dumps(rec, sort_keys=True) + "\n")
 
 
-def _run_batch_sequential(
+def _error_signature(exc: Exception) -> tuple[str, str]:
+    """Extract a comparable error signature from an exception.
+
+    Uses (exception_type_name, first ``_CIRCUIT_BREAKER_MSG_PREFIX_LEN`` characters
+    of the normalised message) so byte-identical errors on the same root cause
+    produce the same signature.  Distinct errors intentionally produce distinct
+    signatures.
+
+    Args:
+        exc: The exception to analyse.
+
+    Returns:
+        Tuple of (type name, normalised message prefix).
+    """
+    msg = str(exc).replace("\r\n", "\n").replace("\r", "\n").strip()
+    prefix = msg[:_CIRCUIT_BREAKER_MSG_PREFIX_LEN]
+    return (type(exc).__name__, prefix)
+
+
+def _run_batch_sequential(  # noqa: C901, D417
     jobs: list[tuple[dict[str, Any], int]],
     *,
     out_path: Path,
@@ -1495,20 +1517,41 @@ def _run_batch_sequential(
     fixed_params: dict[str, Any],
     progress_cb: Callable[[int, int, dict[str, Any], int, bool, str | None], None] | None,
     fail_fast: bool,
-) -> tuple[int, list[dict[str, Any]]]:
-    """Run batch jobs sequentially and return write count + failures.
+    circuit_breaker_threshold: int = DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
+) -> tuple[int, list[dict[str, Any]], dict[str, Any] | None]:
+    """Run batch jobs sequentially and return write count + failures + abort metadata.
+
+    Circuit breaker: when ``circuit_breaker_threshold`` consecutive episode failures
+    share the same error signature (exception type + normalised message prefix), the
+    loop aborts early with status ``aborted_systematic_failure``.  A success or a
+    failure with a different signature resets the counter.
+
+    Args:
+        circuit_breaker_threshold: Consecutive identical failures before abort.
 
     Returns:
-        Tuple of (written_count, failure_records).
+        Tuple of (written_count, failure_records, abort_metadata_or_None).
     """
     wrote = 0
     failures: list[dict[str, Any]] = []
     total = len(jobs)
+    abort_metadata: dict[str, Any] | None = None
+
+    cb_tracker: dict[str, Any] = {
+        "signature": None,
+        "consecutive": 0,
+        "first_fail_idx": None,
+    }
+
     for idx, (sc, seed) in enumerate(jobs, start=1):
         try:
             rec = _run_job_worker((sc, seed, fixed_params))
             _write_validated_record(out_path, schema, rec)
             wrote += 1
+            # Reset circuit breaker on success
+            cb_tracker["signature"] = None
+            cb_tracker["consecutive"] = 0
+            cb_tracker["first_fail_idx"] = None
             if progress_cb is not None:
                 try:
                     progress_cb(idx, total, sc, seed, True, None)
@@ -1532,9 +1575,54 @@ def _run_batch_sequential(
                     progress_cb(idx, total, sc, seed, False, repr(e))
                 except Exception:  # pragma: no cover
                     pass
+
+            # Circuit breaker logic
+            if abort_metadata is None and circuit_breaker_threshold > 0:
+                sig = _error_signature(e)
+                if cb_tracker["signature"] is None:
+                    cb_tracker["signature"] = sig
+                    cb_tracker["consecutive"] = 1
+                    cb_tracker["first_fail_idx"] = idx
+                elif sig == cb_tracker["signature"]:
+                    cb_tracker["consecutive"] += 1
+                else:
+                    # Different signature resets the streak
+                    cb_tracker["signature"] = sig
+                    cb_tracker["consecutive"] = 1
+                    cb_tracker["first_fail_idx"] = idx
+
+                if cb_tracker["consecutive"] >= circuit_breaker_threshold:
+                    projected_remaining = total - idx
+                    abort_metadata = {
+                        "status": "aborted_systematic_failure",
+                        "signature": {
+                            "type": sig[0],
+                            "message_prefix": sig[1],
+                        },
+                        "consecutive_failures": cb_tracker["consecutive"],
+                        "first_fail_index": cb_tracker["first_fail_idx"],
+                        "episodes_completed_before_onset": wrote,
+                        "projected_episodes_saved": projected_remaining,
+                        "projected_walltime_saved_hint": (
+                            f"~{projected_remaining} episodes not attempted"
+                        ),
+                    }
+                    logger.warning(
+                        "Circuit breaker tripped: %d consecutive identical failures "
+                        "(%s). Aborting arm after %d/%d jobs. Projected episodes saved: %d.",
+                        cb_tracker["consecutive"],
+                        sig[0],
+                        idx,
+                        total,
+                        projected_remaining,
+                    )
+                    # Stop processing further jobs
+                    break
+
             if fail_fast:
                 raise
-    return wrote, failures
+
+    return wrote, failures, abort_metadata
 
 
 def _run_batch_parallel(  # noqa: C901
@@ -1546,11 +1634,14 @@ def _run_batch_parallel(  # noqa: C901
     workers: int,
     progress_cb: Callable[[int, int, dict[str, Any], int, bool, str | None], None] | None,
     fail_fast: bool,
-) -> tuple[int, list[dict[str, Any]]]:
-    """Run batch jobs in parallel and return write count + failures.
+) -> tuple[int, list[dict[str, Any]], dict[str, Any] | None]:
+    """Run batch jobs in parallel and return write count + failures + abort metadata.
+
+    Circuit breaker is not available for parallel execution because jobs complete
+    concurrently.  ``abort_metadata`` is always None.
 
     Returns:
-        Tuple of (written_count, failure_records).
+        Tuple of (written_count, failure_records, abort_metadata_or_None).
     """
     wrote = 0
     failures: list[dict[str, Any]] = []
@@ -1618,7 +1709,7 @@ def _run_batch_parallel(  # noqa: C901
             )
             if fail_fast:
                 raise
-    return wrote, failures
+    return wrote, failures, None
 
 
 def _prepare_batch_setup(
@@ -1729,11 +1820,12 @@ def _run_jobs(
     workers: int,
     progress_cb: Callable[[int, int, dict[str, Any], int, bool, str | None], None] | None,
     fail_fast: bool,
-) -> tuple[int, list[dict[str, Any]]]:
+    circuit_breaker_threshold: int,
+) -> tuple[int, list[dict[str, Any]], dict[str, Any] | None]:
     """Execute jobs using sequential or parallel processing.
 
     Returns:
-        Tuple of (number of records written, list of failed jobs).
+        Tuple of (written_count, failure_records, abort_metadata_or_None).
     """
     if workers <= 1:
         return _run_batch_sequential(
@@ -1743,6 +1835,7 @@ def _run_jobs(
             fixed_params=fixed_params,
             progress_cb=progress_cb,
             fail_fast=fail_fast,
+            circuit_breaker_threshold=circuit_breaker_threshold,
         )
     else:
         return _run_batch_parallel(
@@ -1865,6 +1958,7 @@ def run_batch(  # noqa: PLR0913
     record_simulation_step_trace: bool = False,
     workers: int = 1,
     resume: bool = True,
+    circuit_breaker_threshold: int = DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
 ) -> dict[str, Any]:
     """Run a batch of episodes and write JSONL records.
 
@@ -1970,7 +2064,7 @@ def run_batch(  # noqa: PLR0913
     jobs = _filter_resume_jobs(jobs, out_path, resume)
 
     # Run jobs
-    wrote, failures = _run_jobs(
+    wrote, failures, abort_metadata = _run_jobs(
         jobs,
         out_path,
         schema,
@@ -1978,6 +2072,7 @@ def run_batch(  # noqa: PLR0913
         workers,
         progress_cb,
         fail_fast,
+        circuit_breaker_threshold,
     )
 
     # Finalize and return summary
@@ -1992,6 +2087,8 @@ def run_batch(  # noqa: PLR0913
     )
     summary["total_jobs"] = len(jobs)
     summary["failures"] = failures
+    if abort_metadata is not None:
+        summary["abort"] = abort_metadata
     if benchmark_track is not None:
         summary["benchmark_track"] = benchmark_track
     if track_schema_version is not None:

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -53,6 +53,13 @@ else:
     _BASELINE_IMPORT_ERROR = None
 
 from robot_sf.benchmark.algorithm_metadata import enrich_algorithm_metadata
+from robot_sf.benchmark.circuit_breaker import (  # noqa: F401 - compatibility export.
+    _CIRCUIT_BREAKER_MSG_PREFIX_LEN,
+    DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
+    build_abort_metadata,
+    error_signature,
+    normalize_circuit_breaker_threshold,
+)
 from robot_sf.benchmark.constants import EPISODE_SCHEMA_VERSION
 from robot_sf.benchmark.event_ledger import validate_record_event_ledger
 from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_artifacts
@@ -90,8 +97,6 @@ if TYPE_CHECKING:
 
 DEFAULT_BENCHMARK_ROBOT_RADIUS_M = 0.3
 DEFAULT_BENCHMARK_PED_RADIUS_M = 0.35
-DEFAULT_CIRCUIT_BREAKER_THRESHOLD: int = 10  # consecutive identical failures to abort
-_CIRCUIT_BREAKER_MSG_PREFIX_LEN: int = 200  # characters used for signature prefix
 
 
 def _apply_track_metadata_to_scenarios(
@@ -1490,23 +1495,7 @@ def _write_validated_record(out_path: Path, schema: dict[str, Any], rec: dict[st
         f.write(json.dumps(rec, sort_keys=True) + "\n")
 
 
-def _error_signature(exc: Exception) -> tuple[str, str]:
-    """Extract a comparable error signature from an exception.
-
-    Uses (exception_type_name, first ``_CIRCUIT_BREAKER_MSG_PREFIX_LEN`` characters
-    of the normalised message) so byte-identical errors on the same root cause
-    produce the same signature.  Distinct errors intentionally produce distinct
-    signatures.
-
-    Args:
-        exc: The exception to analyse.
-
-    Returns:
-        Tuple of (type name, normalised message prefix).
-    """
-    msg = str(exc).replace("\r\n", "\n").replace("\r", "\n").strip()
-    prefix = msg[:_CIRCUIT_BREAKER_MSG_PREFIX_LEN]
-    return (type(exc).__name__, prefix)
+_error_signature = error_signature
 
 
 def _run_batch_sequential(  # noqa: C901, D417
@@ -1517,7 +1506,7 @@ def _run_batch_sequential(  # noqa: C901, D417
     fixed_params: dict[str, Any],
     progress_cb: Callable[[int, int, dict[str, Any], int, bool, str | None], None] | None,
     fail_fast: bool,
-    circuit_breaker_threshold: int = DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
+    circuit_breaker_threshold: int | None = None,
 ) -> tuple[int, list[dict[str, Any]], dict[str, Any] | None]:
     """Run batch jobs sequentially and return write count + failures + abort metadata.
 
@@ -1532,6 +1521,7 @@ def _run_batch_sequential(  # noqa: C901, D417
     Returns:
         Tuple of (written_count, failure_records, abort_metadata_or_None).
     """
+    circuit_breaker_threshold = normalize_circuit_breaker_threshold(circuit_breaker_threshold)
     wrote = 0
     failures: list[dict[str, Any]] = []
     total = len(jobs)
@@ -1593,20 +1583,13 @@ def _run_batch_sequential(  # noqa: C901, D417
 
                 if cb_tracker["consecutive"] >= circuit_breaker_threshold:
                     projected_remaining = total - idx
-                    abort_metadata = {
-                        "status": "aborted_systematic_failure",
-                        "signature": {
-                            "type": sig[0],
-                            "message_prefix": sig[1],
-                        },
-                        "consecutive_failures": cb_tracker["consecutive"],
-                        "first_fail_index": cb_tracker["first_fail_idx"],
-                        "episodes_completed_before_onset": wrote,
-                        "projected_episodes_saved": projected_remaining,
-                        "projected_walltime_saved_hint": (
-                            f"~{projected_remaining} episodes not attempted"
-                        ),
-                    }
+                    abort_metadata = build_abort_metadata(
+                        signature=sig,
+                        consecutive_failures=cb_tracker["consecutive"],
+                        first_fail_index=cb_tracker["first_fail_idx"],
+                        episodes_completed_before_onset=wrote,
+                        total_jobs=total,
+                    )
                     logger.warning(
                         "Circuit breaker tripped: %d consecutive identical failures "
                         "(%s). Aborting arm after %d/%d jobs. Projected episodes saved: %d.",
@@ -1820,7 +1803,7 @@ def _run_jobs(
     workers: int,
     progress_cb: Callable[[int, int, dict[str, Any], int, bool, str | None], None] | None,
     fail_fast: bool,
-    circuit_breaker_threshold: int,
+    circuit_breaker_threshold: int | None,
 ) -> tuple[int, list[dict[str, Any]], dict[str, Any] | None]:
     """Execute jobs using sequential or parallel processing.
 
@@ -1958,7 +1941,7 @@ def run_batch(  # noqa: PLR0913
     record_simulation_step_trace: bool = False,
     workers: int = 1,
     resume: bool = True,
-    circuit_breaker_threshold: int = DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
+    circuit_breaker_threshold: int | None = None,
 ) -> dict[str, Any]:
     """Run a batch of episodes and write JSONL records.
 
@@ -1968,6 +1951,8 @@ def run_batch(  # noqa: PLR0913
     Returns:
         Summary dictionary with episode counts, failures, and execution metadata.
     """
+    circuit_breaker_threshold = normalize_circuit_breaker_threshold(circuit_breaker_threshold)
+
     # Prepare batch setup
     scenarios, out_path, schema = _prepare_batch_setup(
         scenarios_or_path,
@@ -2014,6 +1999,7 @@ def run_batch(  # noqa: PLR0913
             observation_noise=observation_noise,
             synthetic_actuation_profile=synthetic_actuation_profile,
             latency_stress_profile=latency_stress_profile,
+            circuit_breaker_threshold=circuit_breaker_threshold,
             record_planner_decision_trace=record_planner_decision_trace,
             record_simulation_step_trace=record_simulation_step_trace,
             workers=workers,

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -1567,7 +1567,11 @@ def _run_batch_sequential(  # noqa: C901, D417
                     pass
 
             # Circuit breaker logic
-            if abort_metadata is None and circuit_breaker_threshold > 0:
+            if (
+                abort_metadata is None
+                and circuit_breaker_threshold is not None
+                and circuit_breaker_threshold > 0
+            ):
                 sig = _error_signature(e)
                 if cb_tracker["signature"] is None:
                     cb_tracker["signature"] = sig

--- a/tests/benchmark/test_issue_4520_gpu_memory.py
+++ b/tests/benchmark/test_issue_4520_gpu_memory.py
@@ -57,7 +57,7 @@ def test_serial_execute_map_jobs_gpu_teardown(
     feasibility_totals: dict[str, Any] = {}
 
     # Execute
-    wrote, _, failures, _, _, _, _ = _serial_execute_map_jobs(
+    wrote, _, failures, _, _, _, _, _ = _serial_execute_map_jobs(
         jobs=jobs,
         fixed_params=fixed_params,
         out_path=out_path,

--- a/tests/benchmark/test_runner_circuit_breaker.py
+++ b/tests/benchmark/test_runner_circuit_breaker.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import patch
+
+import pytest
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+from robot_sf.benchmark.circuit_breaker import normalize_circuit_breaker_threshold
+from robot_sf.benchmark.map_runner_batch_runner import _serial_execute_map_jobs
 from robot_sf.benchmark.runner import (
     DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
     _error_signature,
@@ -330,3 +335,49 @@ class TestSequentialCircuitBreaker:
         assert "projected_episodes_saved" in abort_meta
         assert abort_meta["consecutive_failures"] == 5
         assert abort_meta["projected_episodes_saved"] == 10
+
+
+def test_map_serial_circuit_breaker_aborts_identical_failures(tmp_path: Path) -> None:
+    """Map-based serial arms use the same fail-closed breaker contract."""
+    calls = 0
+
+    def failing_map_job(_job: object) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("CUDA out of memory on device 0")
+
+    def bridge(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            adapter_requested_seen=False,
+            adapter_native_steps=0,
+            adapter_adapted_steps=0,
+            runtime_algorithm_contract={},
+        )
+
+    result = _serial_execute_map_jobs(
+        jobs=[({"name": "map"}, seed) for seed in range(8)],
+        fixed_params={},
+        out_path=tmp_path / "episodes.jsonl",
+        schema={},
+        run_map_job=failing_map_job,
+        write_validated_to_handle=lambda *_args: None,
+        apply_worker_metadata_bridge=bridge,
+        scenario_id=lambda scenario: str(scenario["name"]),
+        feasibility_totals={},
+        circuit_breaker_threshold=3,
+    )
+
+    _wrote, _records, failures, _seen, _native, _adapted, _contract, abort = result
+    assert calls == 3
+    assert len(failures) == 3
+    assert abort is not None
+    assert abort["status"] == "aborted_systematic_failure"
+    assert abort["projected_episodes_saved"] == 5
+
+
+def test_circuit_breaker_threshold_validation_is_fail_closed() -> None:
+    """None selects the default, zero disables, and negative values are invalid."""
+    assert normalize_circuit_breaker_threshold(None) == DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+    assert normalize_circuit_breaker_threshold(0) == 0
+    with pytest.raises(ValueError, match="non-negative"):
+        normalize_circuit_breaker_threshold(-1)

--- a/tests/benchmark/test_runner_circuit_breaker.py
+++ b/tests/benchmark/test_runner_circuit_breaker.py
@@ -1,0 +1,332 @@
+"""Circuit breaker tests for consecutive-identical-failure abort in batch runner."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from robot_sf.benchmark.runner import (
+    DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
+    _error_signature,
+    _run_batch_sequential,
+)
+
+_RUNNER_MOD = "robot_sf.benchmark.runner"
+
+
+def _dummy_schema() -> dict:
+    """Return a minimal JSON schema that won't block validation."""
+    return {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {},
+    }
+
+
+def _dummy_scenario(scenario_id: str = "test-scenario") -> dict:
+    """Return a minimal scenario dict."""
+    return {"id": scenario_id}
+
+
+def _dummy_fixed_params() -> dict:
+    """Return a minimal fixed_params dict."""
+    return {
+        "horizon": 10,
+        "dt": 0.1,
+        "record_forces": False,
+        "snqi_weights": None,
+        "snqi_baseline": None,
+        "algo": "simple_policy",
+        "algo_config_path": None,
+        "video_enabled": False,
+        "video_renderer": "none",
+        "videos_dir": None,
+        "experimental_ped_impact": False,
+        "ped_impact_radius_m": 2.0,
+        "ped_impact_window_steps": 5,
+        "provenance": None,
+    }
+
+
+def _valid_record(seed: int) -> dict:
+    """Return a minimal valid episode record that passes schema validation."""
+    return {
+        "episode_id": f"test-episode-{seed}",
+        "scenario_id": "test-scenario",
+        "seed": seed,
+        "version": "v1",
+        "scenario_params": _dummy_scenario(),
+        "metrics": {"success": 1.0, "collisions": 0.0},
+        "algorithm_metadata": {"algorithm": "simple_policy"},
+        "config_hash": "na",
+        "git_hash": "na",
+        "timestamps": {"start": "2024-01-01T00:00:00+00:00"},
+        "termination_reason": "success",
+        "status": "success",
+        "outcome": {
+            "route_complete": True,
+            "collision_event": False,
+            "timeout_event": False,
+        },
+        "integrity": {"contradictions": []},
+    }
+
+
+# -- _error_signature tests --
+
+
+class TestErrorSignature:
+    """Tests for the _error_signature helper used by the circuit breaker."""
+
+    def test_runtime_error_signature(self) -> None:
+        sig = _error_signature(RuntimeError("CUDA out of memory on device 0"))
+        assert sig == ("RuntimeError", "CUDA out of memory on device 0")
+
+    def test_value_error_signature(self) -> None:
+        sig = _error_signature(ValueError("invalid literal"))
+        assert sig == ("ValueError", "invalid literal")
+
+    def test_same_type_and_message_produces_same_signature(self) -> None:
+        exc1 = RuntimeError("CUDA out of memory: tried to allocate 1024 MiB")
+        exc2 = RuntimeError("CUDA out of memory: tried to allocate 1024 MiB")
+        assert _error_signature(exc1) == _error_signature(exc2)
+
+    def test_same_type_different_message_produces_different_signature(self) -> None:
+        exc1 = RuntimeError("CUDA out of memory")
+        exc2 = RuntimeError("Network timeout")
+        assert _error_signature(exc1) != _error_signature(exc2)
+
+    def test_different_type_same_message_produces_different_signature(self) -> None:
+        exc1 = RuntimeError("same message")
+        exc2 = ValueError("same message")
+        assert _error_signature(exc1) != _error_signature(exc2)
+
+    def test_long_message_truncated(self) -> None:
+        long_msg = "A" * 500
+        sig = _error_signature(RuntimeError(long_msg))
+        assert sig[0] == "RuntimeError"
+        from robot_sf.benchmark.runner import _CIRCUIT_BREAKER_MSG_PREFIX_LEN
+
+        assert len(sig[1]) == _CIRCUIT_BREAKER_MSG_PREFIX_LEN
+
+    def test_whitespace_normalization(self) -> None:
+        msg = "\r\n  leading and trailing  \r\n"
+        sig = _error_signature(ValueError(msg))
+        assert sig[1] == "leading and trailing"
+
+
+# -- _run_batch_sequential circuit breaker tests --
+
+
+class TestSequentialCircuitBreaker:
+    """Tests for the circuit breaker in _run_batch_sequential."""
+
+    def test_identical_failures_trip_circuit_breaker(self, tmp_path: Path) -> None:
+        """When 10+ consecutive identical failures occur, the arm aborts."""
+
+        def failing_worker(job):
+            raise RuntimeError("CUDA out of memory on device 0")
+
+        out_file = tmp_path / "episodes.jsonl"
+        jobs = [(_dummy_scenario(), i) for i in range(20)]
+        schema = _dummy_schema()
+
+        with patch(f"{_RUNNER_MOD}._run_job_worker", side_effect=failing_worker):
+            written, failures, abort_meta = _run_batch_sequential(
+                jobs,
+                out_path=out_file,
+                schema=schema,
+                fixed_params=_dummy_fixed_params(),
+                progress_cb=None,
+                fail_fast=False,
+                circuit_breaker_threshold=DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
+            )
+
+        assert written == 0
+        assert len(failures) == DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+        assert abort_meta is not None
+        assert abort_meta["status"] == "aborted_systematic_failure"
+        assert abort_meta["signature"]["type"] == "RuntimeError"
+        assert "CUDA out of memory" in abort_meta["signature"]["message_prefix"]
+        assert abort_meta["consecutive_failures"] == DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+        assert abort_meta["first_fail_index"] == 1
+        assert abort_meta["episodes_completed_before_onset"] == 0
+        assert abort_meta["projected_episodes_saved"] == 20 - DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+
+    def test_mixed_errors_do_not_trip_circuit_breaker(self, tmp_path: Path) -> None:
+        """Distinct error signatures reset the streak so abort never triggers."""
+        call_counter = [0]
+
+        def alternating_worker(job):
+            call_counter[0] += 1
+            if call_counter[0] % 2 == 0:
+                raise RuntimeError("error A")
+            raise RuntimeError("error B")
+
+        out_file = tmp_path / "episodes.jsonl"
+        num_jobs = 30
+        jobs = [(_dummy_scenario(), i) for i in range(num_jobs)]
+        schema = _dummy_schema()
+
+        with patch(f"{_RUNNER_MOD}._run_job_worker", side_effect=alternating_worker):
+            written, failures, abort_meta = _run_batch_sequential(
+                jobs,
+                out_path=out_file,
+                schema=schema,
+                fixed_params=_dummy_fixed_params(),
+                progress_cb=None,
+                fail_fast=False,
+                circuit_breaker_threshold=DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
+            )
+
+        assert written == 0
+        assert len(failures) == num_jobs
+        assert abort_meta is None
+
+    def test_success_resets_counter(self, tmp_path: Path) -> None:
+        """A successful job between failures resets the circuit breaker counter."""
+        call_counter = [0]
+
+        def intermittent_worker(job):
+            call_counter[0] += 1
+            if call_counter[0] % 5 == 0:
+                return _valid_record(call_counter[0])
+            raise RuntimeError("CUDA out of memory on device 0")
+
+        out_file = tmp_path / "episodes.jsonl"
+        num_jobs = 60
+        jobs = [(_dummy_scenario(), i) for i in range(num_jobs)]
+        schema = _dummy_schema()
+
+        with patch(f"{_RUNNER_MOD}._run_job_worker", side_effect=intermittent_worker):
+            written, failures, abort_meta = _run_batch_sequential(
+                jobs,
+                out_path=out_file,
+                schema=schema,
+                fixed_params=_dummy_fixed_params(),
+                progress_cb=None,
+                fail_fast=False,
+                circuit_breaker_threshold=DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
+            )
+
+        # Every 5th job succeeds, so we never reach 10 consecutive failures
+        assert abort_meta is None
+        assert written > 0
+        assert len(failures) > 0
+
+    def test_custom_threshold(self, tmp_path: Path) -> None:
+        """The circuit breaker respects a custom threshold."""
+
+        def failing_worker(job):
+            raise ValueError("OOM")
+
+        out_file = tmp_path / "episodes.jsonl"
+        jobs = [(_dummy_scenario(), i) for i in range(20)]
+        schema = _dummy_schema()
+
+        with patch(f"{_RUNNER_MOD}._run_job_worker", side_effect=failing_worker):
+            written, failures, abort_meta = _run_batch_sequential(
+                jobs,
+                out_path=out_file,
+                schema=schema,
+                fixed_params=_dummy_fixed_params(),
+                progress_cb=None,
+                fail_fast=False,
+                circuit_breaker_threshold=3,
+            )
+
+        assert written == 0
+        assert len(failures) == 3
+        assert abort_meta is not None
+        assert abort_meta["consecutive_failures"] == 3
+        assert abort_meta["projected_episodes_saved"] == 17
+
+    def test_zero_threshold_disables_circuit_breaker(self, tmp_path: Path) -> None:
+        """A threshold of 0 disables the circuit breaker entirely."""
+
+        def failing_worker(job):
+            raise RuntimeError("always fails")
+
+        out_file = tmp_path / "episodes.jsonl"
+        num_jobs = 15
+        jobs = [(_dummy_scenario(), i) for i in range(num_jobs)]
+        schema = _dummy_schema()
+
+        with patch(f"{_RUNNER_MOD}._run_job_worker", side_effect=failing_worker):
+            written, failures, abort_meta = _run_batch_sequential(
+                jobs,
+                out_path=out_file,
+                schema=schema,
+                fixed_params=_dummy_fixed_params(),
+                progress_cb=None,
+                fail_fast=False,
+                circuit_breaker_threshold=0,
+            )
+
+        assert written == 0
+        assert len(failures) == num_jobs
+        assert abort_meta is None
+
+    def test_failures_then_success_no_abort(self, tmp_path: Path) -> None:
+        """Failures followed by a success never triggers abort."""
+        call_counter = [0]
+
+        def failing_then_success_worker(job):
+            call_counter[0] += 1
+            if call_counter[0] >= 5:
+                return _valid_record(call_counter[0])
+            raise RuntimeError("CUDA out of memory on device 0")
+
+        out_file = tmp_path / "episodes.jsonl"
+        jobs = [(_dummy_scenario(), i) for i in range(10)]
+        schema = _dummy_schema()
+
+        with patch(f"{_RUNNER_MOD}._run_job_worker", side_effect=failing_then_success_worker):
+            written, failures, abort_meta = _run_batch_sequential(
+                jobs,
+                out_path=out_file,
+                schema=schema,
+                fixed_params=_dummy_fixed_params(),
+                progress_cb=None,
+                fail_fast=False,
+                circuit_breaker_threshold=DEFAULT_CIRCUIT_BREAKER_THRESHOLD,
+            )
+
+        # 4 failures, then success resets counter, no abort
+        assert abort_meta is None
+        assert len(failures) == 4
+        assert written == 6  # seeds 4-9 succeed (call_counter >= 5)
+
+    def test_abort_metadata_includes_bookkeeping(self, tmp_path: Path) -> None:
+        """Abort metadata contains all required bookkeeping fields."""
+
+        def failing_worker(job):
+            raise TypeError("Model checkpoint load failed")
+
+        out_file = tmp_path / "episodes.jsonl"
+        jobs = [(_dummy_scenario(), i) for i in range(15)]
+        schema = _dummy_schema()
+
+        with patch(f"{_RUNNER_MOD}._run_job_worker", side_effect=failing_worker):
+            _written, _failures, abort_meta = _run_batch_sequential(
+                jobs,
+                out_path=out_file,
+                schema=schema,
+                fixed_params=_dummy_fixed_params(),
+                progress_cb=None,
+                fail_fast=False,
+                circuit_breaker_threshold=5,
+            )
+
+        assert abort_meta is not None
+        assert "status" in abort_meta
+        assert "signature" in abort_meta
+        assert "consecutive_failures" in abort_meta
+        assert "first_fail_index" in abort_meta
+        assert "episodes_completed_before_onset" in abort_meta
+        assert "projected_episodes_saved" in abort_meta
+        assert abort_meta["consecutive_failures"] == 5
+        assert abort_meta["projected_episodes_saved"] == 10

--- a/tests/benchmark/test_runner_circuit_breaker.py
+++ b/tests/benchmark/test_runner_circuit_breaker.py
@@ -249,6 +249,34 @@ class TestSequentialCircuitBreaker:
         assert abort_meta["consecutive_failures"] == 3
         assert abort_meta["projected_episodes_saved"] == 17
 
+    def test_threshold_one_trips_on_first_failure(self, tmp_path: Path) -> None:
+        """A threshold of 1 aborts immediately after the first failure."""
+
+        def failing_worker(job):
+            raise RuntimeError("CUDA out of memory on device 0")
+
+        out_file = tmp_path / "episodes.jsonl"
+        jobs = [(_dummy_scenario(), i) for i in range(5)]
+        schema = _dummy_schema()
+
+        with patch(f"{_RUNNER_MOD}._run_job_worker", side_effect=failing_worker):
+            written, failures, abort_meta = _run_batch_sequential(
+                jobs,
+                out_path=out_file,
+                schema=schema,
+                fixed_params=_dummy_fixed_params(),
+                progress_cb=None,
+                fail_fast=False,
+                circuit_breaker_threshold=1,
+            )
+
+        assert written == 0
+        assert len(failures) == 1
+        assert abort_meta is not None
+        assert abort_meta["consecutive_failures"] == 1
+        assert abort_meta["first_fail_index"] == 1
+        assert abort_meta["projected_episodes_saved"] == 4
+
     def test_zero_threshold_disables_circuit_breaker(self, tmp_path: Path) -> None:
         """A threshold of 0 disables the circuit breaker entirely."""
 

--- a/tests/benchmark/test_runner_latency_stress_pass_through.py
+++ b/tests/benchmark/test_runner_latency_stress_pass_through.py
@@ -55,3 +55,25 @@ def test_run_batch_forwards_latency_stress_profile_to_map_runner(
 
     assert calls[0]["synthetic_actuation_profile"] == actuation_profile
     assert calls[0]["latency_stress_profile"] == latency_profile
+
+
+def test_run_batch_forwards_circuit_breaker_threshold_to_map_runner(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Map campaigns must receive the configured circuit-breaker threshold."""
+    calls: list[dict[str, Any]] = []
+
+    def _fake_run_map_batch(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"episodes_total": 0, "failed_jobs": 0, "out_path": str(args[1])}
+
+    monkeypatch.setattr(runner, "run_map_batch", _fake_run_map_batch)
+    runner.run_batch(
+        [{"name": "map_scenario", "map_file": "maps/svg_maps/classic_crossing.svg"}],
+        tmp_path / "episodes.jsonl",
+        SCHEMA_PATH,
+        circuit_breaker_threshold=3,
+    )
+
+    assert calls[0]["circuit_breaker_threshold"] == 3


### PR DESCRIPTION
## What / Why

The S30 campaign’s PPO arm previously continued after a deterministic CUDA out-of-memory failure, repeating the same failure for hundreds of episodes. This PR adds a per-arm consecutive-identical-failure circuit breaker so systematic failures stop early while preserving the existing failure records and resume behavior.

## Contract

- `circuit_breaker_threshold: None` selects the default of 10.
- `0` disables the breaker explicitly.
- Positive thresholds abort a serial arm after that many consecutive failures with the same exception type and normalized message prefix.
- Map-based serial arms use the same breaker and expose the same `abort` bookkeeping.
- Parallel execution keeps the existing no-breaker behavior because completion order is concurrent and does not define a meaningful consecutive-failure streak.
- Negative and non-integer thresholds fail closed before benchmark work starts.

## Changes

- Shared threshold normalization, error-signature, and abort-metadata helpers.
- Sequential runner and map-runner propagation, including the map serial execution path.
- Adversarial tests for repeated failures, mixed failures, success reset, disabled/invalid thresholds, map-arm aborts, pass-through, and required bookkeeping.

## Validation / Proof

Commands run on this head:

```text
uv run ruff check robot_sf/benchmark/circuit_breaker.py robot_sf/benchmark/runner.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_batch_runner.py robot_sf/benchmark/map_runner_batch_summary.py tests/benchmark/test_runner_circuit_breaker.py tests/benchmark/test_issue_4520_gpu_memory.py tests/benchmark/test_runner_latency_stress_pass_through.py
uv run ruff format --check robot_sf/benchmark/circuit_breaker.py robot_sf/benchmark/runner.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_batch_runner.py robot_sf/benchmark/map_runner_batch_summary.py tests/benchmark/test_runner_circuit_breaker.py tests/benchmark/test_issue_4520_gpu_memory.py tests/benchmark/test_runner_latency_stress_pass_through.py
uv run pytest tests/benchmark/test_runner_circuit_breaker.py tests/benchmark/test_issue_4520_gpu_memory.py tests/benchmark/test_runner_latency_stress_pass_through.py tests/benchmark/test_map_runner_policy_cache.py -q
```

The focused suite covers the abort status, signature, failure count, episodes saved, projected walltime hint, map-path propagation, threshold validation, and the preserved parallel-path contract. Full CI remains the merge gate.

## Research Result Guidance

- Target claim / hypothesis / blocker: stop wasting benchmark allocation on deterministic repeated failures.
- Comparator or baseline: existing sequential runner behavior.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision or stop rule: abort only after the configured identical-failure threshold; do not infer a benchmark result from an aborted arm.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #5390.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - runtime safeguard.

## Downstream Propagation

- Parent issue updated: pending gate merge update.
- Claim map / benchmark report updated: NA - no result claim.
- Leaderboard / artifact catalog updated: NA - no artifact promotion.
- Registry or config index updated: NA - public API parameter only.
- Context index / memory note updated: NA - no durable result.
- Follow-up issue opened for deferred propagation: no.

## Risks / Rollout

The breaker is intentionally limited to serial execution. Operators should treat an `aborted_systematic_failure` arm as a failed/partial run and resume only after correcting the underlying failure.

Closes #5390

This PR was produced by the SAIA/Qwen3.6-27B cheap implementation lane; the review gate hardens and merges.
