### PR TITLE
Issue #5393: superseded-draft scanner (cheap-lane worker)

### DIFF
--- a/.github/workflows/superseded-draft-scanner.yml
+++ b/.github/workflows/superseded-draft-scanner.yml
@@ -1,0 +1,66 @@
+name: Superseded draft scanner
+
+# Detect zombie draft PRs whose reason-to-exist ended (linked issue closed or
+# superseded by a merged PR). Emits a JSON report and a markdown comment-ready
+# summary. Non-gating advisory — promotes repo hygiene without auto-closing.
+#
+# Motivating evidence: draft PRs #5368 and #5374 sat ~14h as zombies after their
+# twin PRs merged or content landed elsewhere. See issue #5393.
+
+on:
+  schedule:
+    - cron: "30 6 * * 1-5"  # Mon-Fri 06:30 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan-superseded-drafts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up CI Python environment
+        uses: ./.github/actions/setup-ci-python
+
+      - name: Run superseded draft scanner
+        id: scan
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p output/superseded-drafts
+          uv run python scripts/dev/scan_superseded_drafts.py \
+            --repo "${{ github.repository }}" \
+            --markdown \
+            --output output/superseded-drafts/report.json \
+            2>output/superseded-drafts/summary.md
+          cat output/superseded-drafts/summary.md
+
+      - name: Summarize outcome
+        if: always()
+        run: |
+          printf 'Scanner exit: %s\n' "${{ steps.scan.outcome }}"
+          if [ -f output/superseded-drafts/report.json ]; then
+            printf 'Hard candidates: '
+            python -c "import json; print(json.load(open('output/superseded-drafts/report.json'))['hard_candidate_count'])" || true
+          fi
+
+      - name: Upload report artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: superseded-draft-report
+          path: output/superseded-drafts/
+          if-no-files-found: warn

--- a/scripts/dev/scan_superseded_drafts.py
+++ b/scripts/dev/scan_superseded_drafts.py
@@ -35,6 +35,7 @@ import re
 import subprocess
 import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any
 
 from scripts.dev._gh_pagination import is_likely_truncated
@@ -47,6 +48,7 @@ ISSUE_REF_RE = re.compile(r"(?:Closes|Refs|Fixes|#)\s*(\d+)")
 # ---------------------------------------------------------------------------
 # Data types
 # ---------------------------------------------------------------------------
+
 
 class DraftPr:
     """One open draft PR pulled from the GitHub API."""
@@ -75,6 +77,13 @@ class DraftPr:
         self.title = title
         self.body = body
         self.url = url
+        for field_name, value in (("created_at", created_at), ("updated_at", updated_at)):
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{field_name} must be a non-empty ISO timestamp")
+            try:
+                datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise ValueError(f"invalid {field_name} timestamp: {value!r}") from exc
         self.created_at = created_at
         self.updated_at = updated_at
         self.files = files or []
@@ -140,20 +149,17 @@ class SupersededCandidate:
 # Low-level GitHub CLI helpers
 # ---------------------------------------------------------------------------
 
+
 def _run_json(command: list[str], *, default: Any = None) -> Any:
     """Run a gh/gh-search command and parse JSON output."""
     try:
         result = subprocess.run(command, check=True, capture_output=True, text=True)
     except FileNotFoundError as exc:
-        raise RuntimeError(
-            "GitHub CLI 'gh' was not found; install gh or add it to PATH."
-        ) from exc
+        raise RuntimeError("GitHub CLI 'gh' was not found; install gh or add it to PATH.") from exc
     except subprocess.CalledProcessError as exc:
         stderr = (exc.stderr or "").strip()
         details = f": {stderr}" if stderr else ""
-        raise RuntimeError(
-            f"GitHub CLI command failed ({' '.join(command)}){details}"
-        ) from exc
+        raise RuntimeError(f"GitHub CLI command failed ({' '.join(command)}){details}") from exc
 
     stdout = result.stdout.strip()
     if not stdout:
@@ -161,9 +167,7 @@ def _run_json(command: list[str], *, default: Any = None) -> Any:
     try:
         return json.loads(stdout)
     except json.JSONDecodeError as exc:
-        raise RuntimeError(
-            f"Failed to parse gh JSON output: {exc.msg}"
-        ) from exc
+        raise RuntimeError(f"Failed to parse gh JSON output: {exc.msg}") from exc
 
 
 def fetch_draft_prs(*, repo: str, limit: int) -> tuple[list[DraftPr], bool]:
@@ -172,11 +176,18 @@ def fetch_draft_prs(*, repo: str, limit: int) -> tuple[list[DraftPr], bool]:
     Returns (draft_prs, truncated).
     """
     cmd = [
-        "gh", "pr", "list",
-        "--repo", repo,
-        "--state", "draft",
-        "--json", "number,title,body,url,createdAt,updatedAt",
-        "--limit", str(limit),
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--draft",
+        "--json",
+        "number,title,body,url,createdAt,updatedAt",
+        "--limit",
+        str(limit),
     ]
     raw = _run_json(cmd)
     if not isinstance(raw, list):
@@ -188,14 +199,16 @@ def fetch_draft_prs(*, repo: str, limit: int) -> tuple[list[DraftPr], bool]:
         if not isinstance(row, dict):
             continue
         try:
-            prs.append(DraftPr(
-                number=int(row["number"]),
-                title=str(row.get("title", "")),
-                body=str(row.get("body", "") or ""),
-                url=str(row.get("url", "")),
-                created_at=str(row.get("createdAt", "")),
-                updated_at=str(row.get("updatedAt", "")),
-            ))
+            prs.append(
+                DraftPr(
+                    number=int(row["number"]),
+                    title=str(row.get("title", "")),
+                    body=str(row.get("body", "") or ""),
+                    url=str(row.get("url", "")),
+                    created_at=str(row.get("createdAt", "")),
+                    updated_at=str(row.get("updatedAt", "")),
+                )
+            )
         except (KeyError, TypeError, ValueError):
             continue
     return prs, truncated
@@ -204,8 +217,12 @@ def fetch_draft_prs(*, repo: str, limit: int) -> tuple[list[DraftPr], bool]:
 def fetch_pr_files(*, repo: str, pr_number: int) -> list[str]:
     """Fetch file paths changed in a PR."""
     cmd = [
-        "gh", "pr", "diff", str(pr_number),
-        "--repo", repo,
+        "gh",
+        "pr",
+        "diff",
+        str(pr_number),
+        "--repo",
+        repo,
         "--name-only",
     ]
     try:
@@ -217,32 +234,51 @@ def fetch_pr_files(*, repo: str, pr_number: int) -> list[str]:
 
 
 def fetch_issue_state(*, repo: str, number: int) -> str | None:
-    """Return "CLOSED" / "OPEN" / None for an issue number."""
+    """Return ``CLOSED`` or ``OPEN`` for an issue number.
+
+    Raises:
+        RuntimeError: If GitHub cannot return a valid issue state.
+    """
     cmd = [
-        "gh", "issue", "view", str(number),
-        "--repo", repo,
-        "--json", "state",
+        "gh",
+        "issue",
+        "view",
+        str(number),
+        "--repo",
+        repo,
+        "--json",
+        "state",
     ]
-    try:
-        payload = _run_json(cmd)
-        if isinstance(payload, dict):
-            return str(payload.get("state", "")).upper()
-    except RuntimeError:
-        pass
-    return None
+    payload = _run_json(cmd)
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"GitHub returned an invalid state payload for issue #{number}")
+    state = str(payload.get("state", "")).upper()
+    if state not in {"CLOSED", "OPEN"}:
+        raise RuntimeError(f"GitHub returned an invalid state for issue #{number}: {state!r}")
+    return state
 
 
 def fetch_merged_prs_for_issue(
-    *, repo: str, issue_number: int, limit: int = 30,
+    *,
+    repo: str,
+    issue_number: int,
+    limit: int = 30,
 ) -> list[dict[str, Any]]:
     """Find merged PRs that claim 'Closes #N' for a given issue."""
     cmd = [
-        "gh", "search", "prs",
-        "--repo", repo,
-        "--state", "closed",
+        "gh",
+        "search",
+        "prs",
+        f"#{issue_number}",
+        "--repo",
+        repo,
+        "--state",
+        "closed",
         "--merged",
-        "--json", "number,title,url,body",
-        "--limit", str(limit),
+        "--json",
+        "number,title,url,body",
+        "--limit",
+        str(limit),
     ]
     raw = _run_json(cmd)
     if not isinstance(raw, list):
@@ -255,16 +291,21 @@ def fetch_merged_prs_for_issue(
             continue
         body = str(row.get("body", "") or "")
         if pattern.search(body):
-            results.append({
-                "number": int(row.get("number", 0)),
-                "title": str(row.get("title", "")),
-                "url": str(row.get("url", "")),
-            })
+            results.append(
+                {
+                    "number": int(row.get("number", 0)),
+                    "title": str(row.get("title", "")),
+                    "url": str(row.get("url", "")),
+                }
+            )
     return results
 
 
 def get_modified_files_on_main_since(
-    *, repo: str, pr_number: int, branch: str = "main",
+    *,
+    repo: str,
+    pr_number: int,
+    branch: str = "main",
 ) -> list[str]:
     """Return files modified on ``branch`` since the draft PR's last commit.
 
@@ -273,9 +314,14 @@ def get_modified_files_on_main_since(
     """
     # Get the draft PR's last commit SHA
     cmd_sha = [
-        "gh", "pr", "view", str(pr_number),
-        "--repo", repo,
-        "--json", "commits",
+        "gh",
+        "pr",
+        "view",
+        str(pr_number),
+        "--repo",
+        repo,
+        "--json",
+        "commits",
     ]
     try:
         payload = _run_json(cmd_sha)
@@ -297,12 +343,19 @@ def get_modified_files_on_main_since(
     # Find files changed on branch since last_sha was its tip
     # We use git log with --first-parent to stay on branch history
     cmd_files = [
-        "git", "log", f"{last_sha}..{branch}",
-        "--first-parent", "--name-only", "--pretty=",
+        "git",
+        "log",
+        f"{last_sha}..{branch}",
+        "--first-parent",
+        "--name-only",
+        "--pretty=",
     ]
     try:
         result = subprocess.run(
-            cmd_files, check=True, capture_output=True, text=True,
+            cmd_files,
+            check=True,
+            capture_output=True,
+            text=True,
         )
         lines = {line.strip() for line in result.stdout.strip().splitlines() if line.strip()}
         return sorted(lines)
@@ -313,6 +366,7 @@ def get_modified_files_on_main_since(
 # ---------------------------------------------------------------------------
 # Rule evaluation
 # ---------------------------------------------------------------------------
+
 
 def evaluate_rules(
     draft: DraftPr,
@@ -336,14 +390,14 @@ def evaluate_rules(
         state = get_issue_state(repo=repo, number=issue_num)
         if state == "CLOSED":
             rules.append("linked_issue_closed")
-            evidence.append(
-                f"Rule 1: linked issue #{issue_num} is CLOSED"
-            )
+            evidence.append(f"Rule 1: linked issue #{issue_num} is CLOSED")
 
     # Rule 2: superseded by merged PR
     for issue_num in linked:
         merged = get_merged_prs(
-            repo=repo, issue_number=issue_num, limit=merged_pr_limit,
+            repo=repo,
+            issue_number=issue_num,
+            limit=merged_pr_limit,
         )
         for pr_info in merged:
             rules.append("superseded_by_merged_pr")
@@ -386,17 +440,20 @@ def scan_drafts(
             get_modified_files=get_modified_files,
         )
         if rules:
-            candidates.append(SupersededCandidate(
-                pr=draft,
-                rules=rules,
-                evidence=evidence,
-            ))
+            candidates.append(
+                SupersededCandidate(
+                    pr=draft,
+                    rules=rules,
+                    evidence=evidence,
+                )
+            )
     return candidates
 
 
 # ---------------------------------------------------------------------------
 # Report builders
 # ---------------------------------------------------------------------------
+
 
 def build_report(
     *,
@@ -421,7 +478,9 @@ def build_report(
             "reason": "superseded_draft_candidates_found",
             "hard_count": len(hard_candidates),
             "total_count": len(candidates),
-        } if hard_candidates else None,
+        }
+        if hard_candidates
+        else None,
     }
 
 
@@ -468,29 +527,37 @@ def build_markdown(report: dict[str, Any]) -> str:
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "--repo", default=DEFAULT_REPO,
+        "--repo",
+        default=DEFAULT_REPO,
         help=f"GitHub repository as OWNER/REPO (default: {DEFAULT_REPO}).",
     )
     parser.add_argument(
-        "--limit", type=int, default=100,
+        "--limit",
+        type=int,
+        default=100,
         help="Max draft PRs to scan (default: 100).",
     )
     parser.add_argument(
-        "--check", action="store_true",
+        "--check",
+        action="store_true",
         help="Exit nonzero when hard close-candidates exist (rules 1-2).",
     )
     parser.add_argument(
-        "--markdown", action="store_true",
+        "--markdown",
+        action="store_true",
         help="Emit a markdown summary to stderr in addition to JSON on stdout.",
     )
     parser.add_argument(
-        "--output", type=str, default=None,
+        "--output",
+        type=str,
+        default=None,
         help="Write JSON report to this path instead of stdout.",
     )
     return parser
@@ -530,7 +597,15 @@ def main(argv: list[str] | None = None) -> int:
             "candidates": [],
             "error": str(exc),
         }
-        print(json.dumps(error_report, indent=2, sort_keys=True))
+        serialized = json.dumps(error_report, indent=2, sort_keys=True)
+        if args.output:
+            output_path = Path(args.output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(serialized + "\n", encoding="utf-8")
+        else:
+            print(serialized)
+        if args.markdown:
+            print(f"Scanner failed: {exc}", file=sys.stderr)
         return 2
 
     report = build_report(
@@ -555,8 +630,7 @@ def main(argv: list[str] | None = None) -> int:
         hard = sum(1 for c in candidates if c.has_hard_rule)
         if hard:
             print(
-                f"FAIL: {hard} hard close-candidate(s) found among {len(candidates)} "
-                f"candidate(s).",
+                f"FAIL: {hard} hard close-candidate(s) found among {len(candidates)} candidate(s).",
                 file=sys.stderr,
             )
             return 1

--- a/scripts/dev/scan_superseded_drafts.py
+++ b/scripts/dev/scan_superseded_drafts.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""Superseded-draft scanner — deterministic close-candidate report for zombie draft PRs.
+
+Draft PRs whose original purpose has been fulfilled by other work can linger
+indefinitely as "zombies".  This scanner identifies candidates by applying three
+deterministic rules, emits a structured JSON report, and supports a ``--check``
+flag for CI gates.
+
+What it does (issue #5393)
+--------------------------
+For each open DRAFT PR, flag as a close-candidate when ANY of these hold:
+
+1. **Linked issue closed** (hard): the PR references an issue (``Closes`` /
+   ``Refs #N`` in body) that is now CLOSED.
+2. **Superceded by merged PR** (hard): a MERGED PR claims ``Closes #N`` for the
+   same issue number the draft references.
+3. **Stale + superseded files** (weak, report-only): every file the draft
+   touches has been modified on ``main`` since the draft's last commit, AND the
+   draft is older than 48 h.
+
+Design notes
+------------
+- NO auto-closing. The report feeds the gate/orchestrator who closes with a
+  citation.
+- ``--check`` exits nonzero when hard candidates (rules 1-2) exist.
+- ``--markdown`` emits a human-readable summary suitable for GitHub comments.
+- The scanner is read-only against GitHub; it never mutates PR state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from typing import Any
+
+from scripts.dev._gh_pagination import is_likely_truncated
+
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+STALE_HOURS = 48
+ISSUE_REF_RE = re.compile(r"(?:Closes|Refs|Fixes|#)\s*(\d+)")
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+class DraftPr:
+    """One open draft PR pulled from the GitHub API."""
+
+    number: int
+    title: str
+    body: str
+    url: str
+    created_at: str
+    updated_at: str
+    files: list[str]
+
+    def __init__(
+        self,
+        *,
+        number: int,
+        title: str,
+        body: str,
+        url: str,
+        created_at: str,
+        updated_at: str,
+        files: list[str] | None = None,
+    ) -> None:
+        """Initialize DraftPr."""
+        self.number = number
+        self.title = title
+        self.body = body
+        self.url = url
+        self.created_at = created_at
+        self.updated_at = updated_at
+        self.files = files or []
+
+    def linked_issue_numbers(self) -> list[int]:
+        """Extract issue numbers referenced in body via Closes/Refs/Fixes/#."""
+        nums: set[int] = set()
+        for m in ISSUE_REF_RE.finditer(self.body or ""):
+            nums.add(int(m.group(1)))
+        return sorted(nums)
+
+    @property
+    def age(self) -> timedelta:
+        """Time since creation."""
+        dt = datetime.fromisoformat(self.created_at.replace("Z", "+00:00"))
+        return datetime.now(dt.tzinfo) - dt
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable PR summary."""
+        return {
+            "number": self.number,
+            "title": self.title,
+            "url": self.url,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "linked_issues": self.linked_issue_numbers(),
+            "file_count": len(self.files),
+        }
+
+
+class SupersededCandidate:
+    """A draft PR flagged as a close candidate."""
+
+    def __init__(
+        self,
+        *,
+        pr: DraftPr,
+        rules: list[str],
+        evidence: list[str],
+    ) -> None:
+        """Initialize SupersededCandidate."""
+        self.pr = pr
+        self.rules = rules  # e.g. ["linked_issue_closed"]
+        self.evidence = evidence
+
+    @property
+    def has_hard_rule(self) -> bool:
+        """Return True when a hard close-candidate rule fired."""
+        hard = {"linked_issue_closed", "superseded_by_merged_pr"}
+        return bool(set(self.rules) & hard)
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable candidate summary."""
+        return {
+            "pr": self.pr.to_payload(),
+            "rules": self.rules,
+            "evidence": self.evidence,
+            "hard": self.has_hard_rule,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Low-level GitHub CLI helpers
+# ---------------------------------------------------------------------------
+
+def _run_json(command: list[str], *, default: Any = None) -> Any:
+    """Run a gh/gh-search command and parse JSON output."""
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "GitHub CLI 'gh' was not found; install gh or add it to PATH."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        details = f": {stderr}" if stderr else ""
+        raise RuntimeError(
+            f"GitHub CLI command failed ({' '.join(command)}){details}"
+        ) from exc
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        return default if default is not None else []
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Failed to parse gh JSON output: {exc.msg}"
+        ) from exc
+
+
+def fetch_draft_prs(*, repo: str, limit: int) -> tuple[list[DraftPr], bool]:
+    """Fetch all open draft PRs for a repo.
+
+    Returns (draft_prs, truncated).
+    """
+    cmd = [
+        "gh", "pr", "list",
+        "--repo", repo,
+        "--state", "draft",
+        "--json", "number,title,body,url,createdAt,updatedAt",
+        "--limit", str(limit),
+    ]
+    raw = _run_json(cmd)
+    if not isinstance(raw, list):
+        raise ValueError(f"Expected JSON list from draft PR fetch, got {type(raw).__name__}")
+
+    truncated = is_likely_truncated(len(raw), limit=limit)
+    prs: list[DraftPr] = []
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        try:
+            prs.append(DraftPr(
+                number=int(row["number"]),
+                title=str(row.get("title", "")),
+                body=str(row.get("body", "") or ""),
+                url=str(row.get("url", "")),
+                created_at=str(row.get("createdAt", "")),
+                updated_at=str(row.get("updatedAt", "")),
+            ))
+        except (KeyError, TypeError, ValueError):
+            continue
+    return prs, truncated
+
+
+def fetch_pr_files(*, repo: str, pr_number: int) -> list[str]:
+    """Fetch file paths changed in a PR."""
+    cmd = [
+        "gh", "pr", "diff", str(pr_number),
+        "--repo", repo,
+        "--name-only",
+    ]
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        lines = [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
+        return lines
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return []
+
+
+def fetch_issue_state(*, repo: str, number: int) -> str | None:
+    """Return "CLOSED" / "OPEN" / None for an issue number."""
+    cmd = [
+        "gh", "issue", "view", str(number),
+        "--repo", repo,
+        "--json", "state",
+    ]
+    try:
+        payload = _run_json(cmd)
+        if isinstance(payload, dict):
+            return str(payload.get("state", "")).upper()
+    except RuntimeError:
+        pass
+    return None
+
+
+def fetch_merged_prs_for_issue(
+    *, repo: str, issue_number: int, limit: int = 30,
+) -> list[dict[str, Any]]:
+    """Find merged PRs that claim 'Closes #N' for a given issue."""
+    cmd = [
+        "gh", "search", "prs",
+        "--repo", repo,
+        "--state", "closed",
+        "--merged",
+        "--json", "number,title,url,body",
+        "--limit", str(limit),
+    ]
+    raw = _run_json(cmd)
+    if not isinstance(raw, list):
+        return []
+
+    results: list[dict[str, Any]] = []
+    pattern = re.compile(rf"Closes\s+#{re.escape(str(issue_number))}\b", re.IGNORECASE)
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        body = str(row.get("body", "") or "")
+        if pattern.search(body):
+            results.append({
+                "number": int(row.get("number", 0)),
+                "title": str(row.get("title", "")),
+                "url": str(row.get("url", "")),
+            })
+    return results
+
+
+def get_modified_files_on_main_since(
+    *, repo: str, pr_number: int, branch: str = "main",
+) -> list[str]:
+    """Return files modified on ``branch`` since the draft PR's last commit.
+
+    Uses ``gh pr diff`` to find the merge base, then ``git log`` on the branch.
+    This is a best-effort helper; failures return an empty list (conservative).
+    """
+    # Get the draft PR's last commit SHA
+    cmd_sha = [
+        "gh", "pr", "view", str(pr_number),
+        "--repo", repo,
+        "--json", "commits",
+    ]
+    try:
+        payload = _run_json(cmd_sha)
+        if not isinstance(payload, dict):
+            return []
+        commits = payload.get("commits", [])
+        if not commits:
+            return []
+        last_sha = None
+        for c in reversed(commits):
+            if isinstance(c, dict) and isinstance(c.get("oid"), str):
+                last_sha = c["oid"]
+                break
+        if not last_sha:
+            return []
+    except RuntimeError:
+        return []
+
+    # Find files changed on branch since last_sha was its tip
+    # We use git log with --first-parent to stay on branch history
+    cmd_files = [
+        "git", "log", f"{last_sha}..{branch}",
+        "--first-parent", "--name-only", "--pretty=",
+    ]
+    try:
+        result = subprocess.run(
+            cmd_files, check=True, capture_output=True, text=True,
+        )
+        lines = {line.strip() for line in result.stdout.strip().splitlines() if line.strip()}
+        return sorted(lines)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Rule evaluation
+# ---------------------------------------------------------------------------
+
+def evaluate_rules(
+    draft: DraftPr,
+    *,
+    repo: str,
+    get_issue_state: Any = fetch_issue_state,
+    get_merged_prs: Any = fetch_merged_prs_for_issue,
+    get_modified_files: Any = get_modified_files_on_main_since,
+    merged_pr_limit: int = 30,
+) -> tuple[list[str], list[str]]:
+    """Evaluate all rules for one draft PR.
+
+    Returns (rules_triggered, evidence_lines).
+    """
+    rules: list[str] = []
+    evidence: list[str] = []
+    linked = draft.linked_issue_numbers()
+
+    # Rule 1: linked issue closed
+    for issue_num in linked:
+        state = get_issue_state(repo=repo, number=issue_num)
+        if state == "CLOSED":
+            rules.append("linked_issue_closed")
+            evidence.append(
+                f"Rule 1: linked issue #{issue_num} is CLOSED"
+            )
+
+    # Rule 2: superseded by merged PR
+    for issue_num in linked:
+        merged = get_merged_prs(
+            repo=repo, issue_number=issue_num, limit=merged_pr_limit,
+        )
+        for pr_info in merged:
+            rules.append("superseded_by_merged_pr")
+            evidence.append(
+                f"Rule 2: merged PR #{pr_info['number']} ({pr_info['title']}) "
+                f"claims 'Closes #{issue_num}'"
+            )
+
+    # Rule 3: stale + all files modified on main (weak, report-only)
+    if draft.age > timedelta(hours=STALE_HOURS):
+        draft_files = set(draft.files) if draft.files else set()
+        if draft_files:
+            modified = set(get_modified_files(repo=repo, pr_number=draft.number))
+            if modified and draft_files.issubset(modified):
+                rules.append("stale_all_files_modified_on_main")
+                evidence.append(
+                    f"Rule 3: draft is {int(draft.age.total_seconds() // 3600)}h old; "
+                    f"all {len(draft_files)} file(s) modified on main since last commit"
+                )
+
+    return rules, evidence
+
+
+def scan_drafts(
+    draft_prs: list[DraftPr],
+    *,
+    repo: str,
+    get_issue_state: Any = fetch_issue_state,
+    get_merged_prs: Any = fetch_merged_prs_for_issue,
+    get_modified_files: Any = get_modified_files_on_main_since,
+) -> list[SupersededCandidate]:
+    """Run all rules over all draft PRs and return candidates."""
+    candidates: list[SupersededCandidate] = []
+    for draft in draft_prs:
+        rules, evidence = evaluate_rules(
+            draft,
+            repo=repo,
+            get_issue_state=get_issue_state,
+            get_merged_prs=get_merged_prs,
+            get_modified_files=get_modified_files,
+        )
+        if rules:
+            candidates.append(SupersededCandidate(
+                pr=draft,
+                rules=rules,
+                evidence=evidence,
+            ))
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Report builders
+# ---------------------------------------------------------------------------
+
+def build_report(
+    *,
+    repo: str,
+    candidates: list[SupersededCandidate],
+    scanned_count: int,
+    truncated: bool = False,
+) -> dict[str, Any]:
+    """Build the machine-readable JSON report."""
+    hard_candidates = [c for c in candidates if c.has_hard_rule]
+    return {
+        "schema": "superseded_draft_scanner.v1",
+        "ok": not hard_candidates,
+        "read_only": True,
+        "repo": repo,
+        "scanned_drafts": scanned_count,
+        "truncated": truncated,
+        "candidate_count": len(candidates),
+        "hard_candidate_count": len(hard_candidates),
+        "candidates": [c.to_payload() for c in candidates],
+        "failure_summary": {
+            "reason": "superseded_draft_candidates_found",
+            "hard_count": len(hard_candidates),
+            "total_count": len(candidates),
+        } if hard_candidates else None,
+    }
+
+
+def build_markdown(report: dict[str, Any]) -> str:
+    """Build a human-readable markdown summary from a report dict."""
+    lines: list[str] = []
+    lines.append("## Superseded Draft PR Scan")
+    lines.append("")
+
+    if report.get("truncated"):
+        lines.append("WARNING: results may be truncated (hit gh search limit).")
+        lines.append("")
+
+    lines.append(f"**Repo**: {report['repo']}")
+    lines.append(f"**Drafts scanned**: {report['scanned_drafts']}")
+    lines.append(f"**Candidates**: {report['candidate_count']}")
+    lines.append(f"**Hard (rules 1-2)**: {report['hard_candidate_count']}")
+    lines.append("")
+
+    candidates = report.get("candidates", [])
+    if not candidates:
+        lines.append("No superseded draft candidates found.")
+        lines.append("")
+        return "\n".join(lines)
+
+    for c in candidates:
+        pr = c["pr"]
+        hard_tag = " [HARD]" if c["hard"] else ""
+        rules_str = ", ".join(c["rules"])
+        lines.append(f"### PR #{pr['number']}: {pr['title']} ({pr['url']}){hard_tag}")
+        lines.append("")
+        lines.append(f"**Rules**: {rules_str}")
+        lines.append(f"**Age**: {pr['created_at']}")
+        lines.append(f"**Linked issues**: {pr['linked_issues'] or '(none)'}")
+        lines.append("")
+        for ev in c["evidence"]:
+            lines.append(f"- {ev}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO,
+        help=f"GitHub repository as OWNER/REPO (default: {DEFAULT_REPO}).",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=100,
+        help="Max draft PRs to scan (default: 100).",
+    )
+    parser.add_argument(
+        "--check", action="store_true",
+        help="Exit nonzero when hard close-candidates exist (rules 1-2).",
+    )
+    parser.add_argument(
+        "--markdown", action="store_true",
+        help="Emit a markdown summary to stderr in addition to JSON on stdout.",
+    )
+    parser.add_argument(
+        "--output", type=str, default=None,
+        help="Write JSON report to this path instead of stdout.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
+    repo = args.repo
+
+    try:
+        draft_prs, truncated = fetch_draft_prs(repo=repo, limit=args.limit)
+
+        # Enrich with file lists for Rule 3
+        enriched: list[DraftPr] = []
+        for pr in draft_prs:
+            files = fetch_pr_files(repo=repo, pr_number=pr.number)
+            pr.files = files
+            enriched.append(pr)
+
+        candidates = scan_drafts(
+            enriched,
+            repo=repo,
+            get_issue_state=fetch_issue_state,
+            get_merged_prs=fetch_merged_prs_for_issue,
+            get_modified_files=get_modified_files_on_main_since,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        error_report = {
+            "schema": "superseded_draft_scanner.v1",
+            "ok": False,
+            "read_only": True,
+            "repo": repo,
+            "scanned_drafts": 0,
+            "candidate_count": 0,
+            "hard_candidate_count": 0,
+            "candidates": [],
+            "error": str(exc),
+        }
+        print(json.dumps(error_report, indent=2, sort_keys=True))
+        return 2
+
+    report = build_report(
+        repo=repo,
+        candidates=candidates,
+        scanned_count=len(draft_prs),
+        truncated=truncated,
+    )
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, sort_keys=True)
+            f.write("\n")
+    else:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    if args.markdown:
+        md = build_markdown(report)
+        print(md, file=sys.stderr)
+
+    if args.check:
+        hard = sum(1 for c in candidates if c.has_hard_rule)
+        if hard:
+            print(
+                f"FAIL: {hard} hard close-candidate(s) found among {len(candidates)} "
+                f"candidate(s).",
+                file=sys.stderr,
+            )
+            return 1
+
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/dev/test_scan_superseded_drafts.py
+++ b/tests/dev/test_scan_superseded_drafts.py
@@ -85,6 +85,10 @@ class TestDraftPr:
         assert pr.age > timedelta(hours=4)
         assert pr.age < timedelta(hours=6)
 
+    def test_invalid_timestamp_is_rejected_during_construction(self) -> None:
+        with pytest.raises(ValueError, match="created_at"):
+            _draft(created_at="not-a-timestamp")
+
     def test_to_payload_is_json_serializable(self) -> None:
         pr = _draft(body="Closes #12", files=["a.py"])
         payload = pr.to_payload()
@@ -600,6 +604,7 @@ class TestMainCLI:
         self,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
+        tmp_path,
     ) -> None:
         """Network errors should emit JSON with error field and exit 2."""
 
@@ -608,11 +613,15 @@ class TestMainCLI:
 
         monkeypatch.setattr(scanner, "fetch_draft_prs", fake_fetch)
 
-        code = scanner.main(["--repo", "ll7/robot_sf_ll7"])
+        output_path = tmp_path / "nested" / "error-report.json"
+        code = scanner.main(
+            ["--repo", "ll7/robot_sf_ll7", "--output", str(output_path), "--markdown"]
+        )
         assert code == 2
         out = capsys.readouterr()
-        payload = json.loads(out.out)
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
         assert payload.get("error")
+        assert "Scanner failed" in out.err
 
     def test_markdown_flag_emits_to_stderr(
         self,
@@ -675,6 +684,51 @@ def test_fetch_merged_prs_pattern_matches_correctly() -> None:
     assert matches[1]["number"] == 12
 
 
+def test_fetch_merged_prs_queries_the_linked_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The merged-PR search is constrained to the linked issue reference."""
+    commands: list[list[str]] = []
+
+    def fake_run_json(command: list[str], *, default: Any = None) -> list[dict[str, Any]]:
+        commands.append(command)
+        return []
+
+    monkeypatch.setattr(scanner, "_run_json", fake_run_json)
+    scanner.fetch_merged_prs_for_issue(repo="ll7/robot_sf_ll7", issue_number=42)
+
+    assert commands == [
+        [
+            "gh",
+            "search",
+            "prs",
+            "#42",
+            "--repo",
+            "ll7/robot_sf_ll7",
+            "--state",
+            "closed",
+            "--merged",
+            "--json",
+            "number,title,url,body",
+            "--limit",
+            "30",
+        ]
+    ]
+
+
+def test_fetch_issue_state_does_not_hide_api_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An issue-state API failure must reach the scanner error report."""
+
+    def failed_run_json(command: list[str], *, default: Any = None) -> Any:
+        raise RuntimeError("GitHub unavailable")
+
+    monkeypatch.setattr(scanner, "_run_json", failed_run_json)
+    with pytest.raises(RuntimeError, match="GitHub unavailable"):
+        scanner.fetch_issue_state(repo="ll7/robot_sf_ll7", number=42)
+
+
 # ---------------------------------------------------------------------------
 # fetch_draft_prs
 # ---------------------------------------------------------------------------
@@ -694,7 +748,10 @@ class TestFetchDraftPrs:
             }
         ]
 
+        commands: list[list[str]] = []
+
         def fake_run_json(cmd: list[str], *, default: Any = None) -> Any:
+            commands.append(cmd)
             return mock_data
 
         monkeypatch.setattr(scanner, "_run_json", fake_run_json)
@@ -703,6 +760,33 @@ class TestFetchDraftPrs:
         assert len(prs) == 1
         assert prs[0].number == 1
         assert not truncated
+        assert commands[0][commands[0].index("--state") + 1] == "open"
+        assert "--draft" in commands[0]
+
+    def test_skips_rows_with_invalid_timestamps(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_data = [
+            {
+                "number": 1,
+                "title": "Malformed draft",
+                "body": "",
+                "url": "https://example.com/pull/1",
+                "createdAt": "bad",
+                "updatedAt": _now_iso(),
+            },
+            {
+                "number": 2,
+                "title": "Valid draft",
+                "body": "",
+                "url": "https://example.com/pull/2",
+                "createdAt": _ago(1),
+                "updatedAt": _now_iso(),
+            },
+        ]
+
+        monkeypatch.setattr(scanner, "_run_json", lambda *_args, **_kwargs: mock_data)
+        prs, _truncated = scanner.fetch_draft_prs(repo="ll7/robot_sf_ll7", limit=100)
+
+        assert [pr.number for pr in prs] == [2]
 
     def test_detects_truncation(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """fetch_draft_prs should detect when result hits the limit."""

--- a/tests/dev/test_scan_superseded_drafts.py
+++ b/tests/dev/test_scan_superseded_drafts.py
@@ -1,0 +1,788 @@
+"""Tests for the superseded-draft scanner (issue #5393).
+
+All tests use mocked GitHub CLI payloads — no network access required.
+"""
+
+# ruff: noqa: D101 — test classes do not need class-level docstrings
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from scripts.dev import scan_superseded_drafts as scanner
+
+# ---------------------------------------------------------------------------
+# Helpers to build fixtures
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ago(hours: int) -> str:
+    dt = datetime.now(UTC) - timedelta(hours=hours)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _draft(
+    number: int = 1,
+    body: str = "",
+    files: list[str] | None = None,
+    created_at: str | None = None,
+) -> scanner.DraftPr:
+    return scanner.DraftPr(
+        number=number,
+        title=f"Draft PR #{number}",
+        body=body,
+        url=f"https://github.com/ll7/robot_sf_ll7/pull/{number}",
+        created_at=created_at or _now_iso(),
+        updated_at=_now_iso(),
+        files=files or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# DraftPr unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDraftPr:
+    def test_linked_issue_numbers_picks_closes(self) -> None:
+        pr = _draft(body="This fixes the bug. Closes #42")
+        assert pr.linked_issue_numbers() == [42]
+
+    def test_linked_issue_numbers_picks_refs(self) -> None:
+        pr = _draft(body="WIP progress on Refs #7, Refs #8")
+        assert pr.linked_issue_numbers() == [7, 8]
+
+    def test_linked_issue_numbers_picks_fixes(self) -> None:
+        pr = _draft(body="Fixes #99")
+        assert pr.linked_issue_numbers() == [99]
+
+    def test_linked_issue_numbers_picks_raw_hash(self) -> None:
+        pr = _draft(body="Working on #999")
+        assert pr.linked_issue_numbers() == [999]
+
+    def test_linked_issue_numbers_deduplicates(self) -> None:
+        pr = _draft(body="Refs #1 Closes #1 Fixes #1")
+        assert pr.linked_issue_numbers() == [1]
+
+    def test_linked_issue_numbers_empty_when_no_refs(self) -> None:
+        pr = _draft(body="No references here at all.")
+        assert pr.linked_issue_numbers() == []
+
+    def test_linked_issue_numbers_empty_body(self) -> None:
+        pr = _draft(body="")
+        assert pr.linked_issue_numbers() == []
+
+    def test_age_returns_positive_timedelta(self) -> None:
+        pr = _draft(created_at=_ago(5))
+        assert pr.age > timedelta(hours=4)
+        assert pr.age < timedelta(hours=6)
+
+    def test_to_payload_is_json_serializable(self) -> None:
+        pr = _draft(body="Closes #12", files=["a.py"])
+        payload = pr.to_payload()
+        # Must round-trip without error
+        json.dumps(payload)
+        assert payload["number"] == 1
+        assert payload["linked_issues"] == [12]
+
+    def test_to_payload_file_count(self) -> None:
+        pr = _draft(files=["a.py", "b.py"])
+        assert pr.to_payload()["file_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: linked issue closed
+# ---------------------------------------------------------------------------
+
+
+class TestRule1LinkedIssueClosed:
+    def test_triggers_when_linked_issue_is_closed(self) -> None:
+        pr = _draft(body="Closes #42")
+        rules, evidence = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "CLOSED" if number == 42 else "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: [],
+        )
+        assert "linked_issue_closed" in rules
+        assert any("42" in e for e in evidence)
+
+    def test_does_not_trigger_when_linked_issue_open(self) -> None:
+        pr = _draft(body="Closes #42")
+        rules, _ = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: [],
+        )
+        assert "linked_issue_closed" not in rules
+
+    def test_checks_all_linked_issues(self) -> None:
+        pr = _draft(body="Refs #1 Closes #2")
+        closed_set: set[int] = {2}
+        rules, evidence = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "CLOSED" if number in closed_set else "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: [],
+        )
+        assert rules.count("linked_issue_closed") == 1
+        assert any("2" in e for e in evidence)
+
+    def test_does_not_fire_on_no_linked_issue(self) -> None:
+        pr = _draft(body="No issue references")
+        rules, _ = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "CLOSED",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: [],
+        )
+        assert "linked_issue_closed" not in rules
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: superseded by merged PR
+# ---------------------------------------------------------------------------
+
+
+class TestRule2SupersededByMergedPr:
+    def test_triggers_when_merged_pr_closes_same_issue(self) -> None:
+        pr = _draft(body="Closes #42")
+        rules, evidence = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: (
+                [
+                    {
+                        "number": 99,
+                        "title": "Fixed #42",
+                        "url": "https://github.com/ll7/robot_sf_ll7/pull/99",
+                    }
+                ]
+                if issue_number == 42
+                else []
+            ),
+            get_modified_files=lambda *, repo, pr_number: [],
+        )
+        assert "superseded_by_merged_pr" in rules
+        assert any("99" in e for e in evidence)
+
+    def test_does_not_trigger_when_no_merged_pr(self) -> None:
+        pr = _draft(body="Closes #42")
+        rules, _ = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: [],
+        )
+        assert "superseded_by_merged_pr" not in rules
+
+    def test_merged_pr_for_different_issue_ignored(self) -> None:
+        pr = _draft(body="Closes #42")
+        rules, _ = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "OPEN",
+            # Merged PR exists for #99, not #42
+            get_merged_prs=lambda *, repo, issue_number, limit=30: (
+                [{"number": 99, "title": "X", "url": "X"}] if issue_number == 99 else []
+            ),
+            get_modified_files=lambda *, repo, pr_number: [],
+        )
+        assert "superseded_by_merged_pr" not in rules
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: stale + superseded files (weak)
+# ---------------------------------------------------------------------------
+
+
+class TestRule3StaleFiles:
+    def test_triggers_when_old_and_all_files_modified(self) -> None:
+        pr = _draft(
+            body="Closes #42",
+            files=["a.py", "b.py"],
+            created_at=_ago(72),  # 72h old > 48h
+        )
+        rules, _ = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: ["a.py", "b.py", "c.py"],
+        )
+        assert "stale_all_files_modified_on_main" in rules
+
+    def test_does_not_trigger_when_young(self) -> None:
+        pr = _draft(
+            body="Closes #42",
+            files=["a.py"],
+            created_at=_ago(1),  # 1h old
+        )
+        rules, _ = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: ["a.py"],
+        )
+        assert "stale_all_files_modified_on_main" not in rules
+
+    def test_does_not_trigger_when_not_all_files_modified(self) -> None:
+        pr = _draft(
+            body="Closes #42",
+            files=["a.py", "b.py"],
+            created_at=_ago(72),
+        )
+        rules, _ = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: ["a.py"],  # only a.py
+        )
+        assert "stale_all_files_modified_on_main" not in rules
+
+    def test_no_files_in_draft_means_no_rule3(self) -> None:
+        pr = _draft(body="Closes #42", files=[], created_at=_ago(100))
+        rules, _ = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: ["a.py"],
+        )
+        assert "stale_all_files_modified_on_main" not in rules
+
+    def test_empty_modified_files_means_no_rule3(self) -> None:
+        pr = _draft(body="Closes #42", files=["a.py"], created_at=_ago(100))
+        rules, _ = scanner.evaluate_rules(
+            pr,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: [],
+        )
+        assert "stale_all_files_modified_on_main" not in rules
+
+
+# ---------------------------------------------------------------------------
+# SupersededCandidate
+# ---------------------------------------------------------------------------
+
+
+class TestSupersededCandidate:
+    def test_hard_rule_classification(self) -> None:
+        c = scanner.SupersededCandidate(pr=_draft(), rules=["linked_issue_closed"], evidence=["e"])
+        assert c.has_hard_rule
+
+    def test_hard_rule_false_for_weak_only(self) -> None:
+        c = scanner.SupersededCandidate(
+            pr=_draft(),
+            rules=["stale_all_files_modified_on_main"],
+            evidence=["e"],
+        )
+        assert not c.has_hard_rule
+
+    def test_to_payload_contains_evidence(self) -> None:
+        c = scanner.SupersededCandidate(
+            pr=_draft(number=5),
+            rules=["linked_issue_closed"],
+            evidence=["ev1", "ev2"],
+        )
+        p = c.to_payload()
+        assert p["pr"]["number"] == 5
+        assert p["rules"] == ["linked_issue_closed"]
+        assert p["evidence"] == ["ev1", "ev2"]
+        assert p["hard"] is True
+
+    def test_json_roundtrip(self) -> None:
+        c = scanner.SupersededCandidate(
+            pr=_draft(number=1, body="Refs #9"),
+            rules=["r"],
+            evidence=["e"],
+        )
+        json.dumps(c.to_payload())
+
+
+# ---------------------------------------------------------------------------
+# scan_drafts integration
+# ---------------------------------------------------------------------------
+
+
+class TestScanDrafts:
+    def test_returns_candidates_for_superseded_draft(self) -> None:
+        prs = [_draft(number=1, body="Closes #42")]
+        candidates = scanner.scan_drafts(
+            prs,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "CLOSED" if number == 42 else "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: [],
+        )
+        assert len(candidates) == 1
+        assert candidates[0].pr.number == 1
+        assert candidates[0].has_hard_rule
+
+    def test_returns_no_candidates_when_none_superseded(self) -> None:
+        prs = [_draft(number=1, body="Closes #42")]
+        candidates = scanner.scan_drafts(
+            prs,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: [],
+        )
+        assert len(candidates) == 0
+
+    def test_scans_multiple_drafts_independently(self) -> None:
+        prs = [
+            _draft(number=1, body="Closes #42"),
+            _draft(number=2, body="Closes #43"),
+        ]
+        candidates = scanner.scan_drafts(
+            prs,
+            repo="ll7/robot_sf_ll7",
+            get_issue_state=lambda *, repo, number: "CLOSED" if number == 42 else "OPEN",
+            get_merged_prs=lambda *, repo, issue_number, limit=30: [],
+            get_modified_files=lambda *, repo, pr_number: [],
+        )
+        assert len(candidates) == 1
+        assert candidates[0].pr.number == 1
+
+
+# ---------------------------------------------------------------------------
+# Report builders
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReport:
+    def test_ok_when_no_hard_candidates(self) -> None:
+        c = scanner.SupersededCandidate(
+            pr=_draft(),
+            rules=["stale_all_files_modified_on_main"],
+            evidence=["e"],
+        )
+        report = scanner.build_report(
+            repo="ll7/robot_sf_ll7",
+            candidates=[c],
+            scanned_count=5,
+        )
+        assert report["ok"] is True  # weak rule only
+        assert report["hard_candidate_count"] == 0
+
+    def test_not_ok_when_hard_candidate(self) -> None:
+        c = scanner.SupersededCandidate(
+            pr=_draft(number=1, body="Closes #1"),
+            rules=["linked_issue_closed"],
+            evidence=["Rule 1: linked issue #1 is CLOSED"],
+        )
+        report = scanner.build_report(
+            repo="ll7/robot_sf_ll7",
+            candidates=[c],
+            scanned_count=3,
+        )
+        assert report["ok"] is False
+        assert report["hard_candidate_count"] == 1
+        assert report["failure_summary"] is not None
+
+    def test_schema_and_read_only(self) -> None:
+        report = scanner.build_report(
+            repo="ll7/robot_sf_ll7",
+            candidates=[],
+            scanned_count=0,
+        )
+        assert report["schema"] == "superseded_draft_scanner.v1"
+        assert report["read_only"] is True
+
+    def test_json_roundtrip(self) -> None:
+        c = scanner.SupersededCandidate(
+            pr=_draft(number=1, body="Refs #5"),
+            rules=["r"],
+            evidence=["e"],
+        )
+        report = scanner.build_report(
+            repo="ll7/robot_sf_ll7",
+            candidates=[c],
+            scanned_count=1,
+        )
+        json.dumps(report)
+
+
+class TestBuildMarkdown:
+    def test_includes_candidate_details(self) -> None:
+        c = scanner.SupersededCandidate(
+            pr=_draft(number=42, body="Closes #9"),
+            rules=["linked_issue_closed"],
+            evidence=["Rule 1: linked issue #9 is CLOSED"],
+        )
+        report = scanner.build_report(
+            repo="ll7/robot_sf_ll7",
+            candidates=[c],
+            scanned_count=42,
+        )
+        md = scanner.build_markdown(report)
+        assert "#42" in md
+        assert "ll7/robot_sf_ll7" in md
+        assert "Rule 1: linked issue #9 is CLOSED" in md
+
+    def test_no_candidates_message(self) -> None:
+        report = scanner.build_report(
+            repo="ll7/robot_sf_ll7",
+            candidates=[],
+            scanned_count=5,
+        )
+        md = scanner.build_markdown(report)
+        assert "No superseded draft candidates found" in md
+
+    def test_hard_tag_present(self) -> None:
+        c = scanner.SupersededCandidate(
+            pr=_draft(number=1, body="Closes #1"),
+            rules=["linked_issue_closed"],
+            evidence=["e"],
+        )
+        report = scanner.build_report(
+            repo="ll7/robot_sf_ll7",
+            candidates=[c],
+            scanned_count=1,
+        )
+        md = scanner.build_markdown(report)
+        assert "[HARD]" in md
+
+    def test_weak_candidate_no_hard_tag(self) -> None:
+        c = scanner.SupersededCandidate(
+            pr=_draft(number=1, body="refs #1"),
+            rules=["stale_all_files_modified_on_main"],
+            evidence=["e"],
+        )
+        report = scanner.build_report(
+            repo="ll7/robot_sf_ll7",
+            candidates=[c],
+            scanned_count=1,
+        )
+        md = scanner.build_markdown(report)
+        assert "[HARD]" not in md
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+class TestMainCLI:
+    def test_check_exits_1_on_hard_candidate(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--check must return 1 when hard candidates exist."""
+        pr = _draft(number=1, body="Closes #42")
+
+        def fake_fetch_drafts(*, repo: str, limit: int) -> tuple[list[scanner.DraftPr], bool]:
+            return [pr], False
+
+        def fake_pr_files(*, repo: str, pr_number: int) -> list[str]:
+            return []
+
+        monkeypatch.setattr(scanner, "fetch_draft_prs", fake_fetch_drafts)
+        monkeypatch.setattr(scanner, "fetch_pr_files", fake_pr_files)
+        monkeypatch.setattr(
+            scanner,
+            "fetch_issue_state",
+            lambda *, repo, number: "CLOSED" if number == 42 else "OPEN",
+        )
+        monkeypatch.setattr(
+            scanner,
+            "fetch_merged_prs_for_issue",
+            lambda *, repo, issue_number, limit=30: [],
+        )
+        monkeypatch.setattr(
+            scanner,
+            "get_modified_files_on_main_since",
+            lambda *, repo, pr_number, branch="main": [],
+        )
+
+        code = scanner.main(["--check", "--repo", "ll7/robot_sf_ll7"])
+        assert code == 1
+        out = capsys.readouterr()
+        assert "FAIL" in out.err
+
+    def test_check_returns_0_when_clean(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--check returns 0 when no hard candidates."""
+        pr = _draft(number=1, body="Closes #42")
+
+        def fake_fetch_drafts(*, repo: str, limit: int) -> tuple[list[scanner.DraftPr], bool]:
+            return [pr], False
+
+        monkeypatch.setattr(scanner, "fetch_draft_prs", fake_fetch_drafts)
+        monkeypatch.setattr(scanner, "fetch_pr_files", lambda *, repo, pr_number: [])
+        monkeypatch.setattr(scanner, "fetch_issue_state", lambda *, repo, number: "OPEN")
+        monkeypatch.setattr(
+            scanner, "fetch_merged_prs_for_issue", lambda *, repo, issue_number, limit=30: []
+        )
+        monkeypatch.setattr(
+            scanner,
+            "get_modified_files_on_main_since",
+            lambda *, repo, pr_number, branch="main": [],
+        )
+
+        code = scanner.main(["--check", "--repo", "ll7/robot_sf_ll7"])
+        assert code == 0
+
+    def test_no_check_returns_0_even_with_weak_candidate(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Without --check, weak candidates should not change exit from 0."""
+        pr = _draft(
+            number=1,
+            body="Closes #42",
+            files=["a.py"],
+            created_at=_ago(72),
+        )
+
+        def fake_fetch_drafts(*, repo: str, limit: int) -> tuple[list[scanner.DraftPr], bool]:
+            return [pr], False
+
+        monkeypatch.setattr(scanner, "fetch_draft_prs", fake_fetch_drafts)
+        monkeypatch.setattr(scanner, "fetch_pr_files", lambda *, repo, pr_number: ["a.py"])
+        monkeypatch.setattr(scanner, "fetch_issue_state", lambda *, repo, number: "OPEN")
+        monkeypatch.setattr(
+            scanner, "fetch_merged_prs_for_issue", lambda *, repo, issue_number, limit=30: []
+        )
+        monkeypatch.setattr(
+            scanner,
+            "get_modified_files_on_main_since",
+            lambda *, repo, pr_number, branch="main": ["a.py"],
+        )
+
+        code = scanner.main(["--repo", "ll7/robot_sf_ll7"])
+        assert code == 0
+
+    def test_emits_json_on_stdout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Default mode emits JSON to stdout."""
+
+        def fake_fetch_drafts(*, repo: str, limit: int) -> tuple[list[scanner.DraftPr], bool]:
+            return [], False
+
+        monkeypatch.setattr(scanner, "fetch_draft_prs", fake_fetch_drafts)
+
+        code = scanner.main(["--repo", "ll7/robot_sf_ll7"])
+        assert code == 0
+        out = capsys.readouterr()
+        payload = json.loads(out.out)
+        assert payload["schema"] == "superseded_draft_scanner.v1"
+
+    def test_error_returns_exit_2_with_json(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Network errors should emit JSON with error field and exit 2."""
+
+        def fake_fetch(*, repo: str, limit: int) -> tuple[list[scanner.DraftPr], bool]:
+            raise RuntimeError("gh not available")
+
+        monkeypatch.setattr(scanner, "fetch_draft_prs", fake_fetch)
+
+        code = scanner.main(["--repo", "ll7/robot_sf_ll7"])
+        assert code == 2
+        out = capsys.readouterr()
+        payload = json.loads(out.out)
+        assert payload.get("error")
+
+    def test_markdown_flag_emits_to_stderr(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--markdown should emit markdown to stderr alongside JSON."""
+
+        def fake_fetch_drafts(*, repo: str, limit: int) -> tuple[list[scanner.DraftPr], bool]:
+            return [], False
+
+        monkeypatch.setattr(scanner, "fetch_draft_prs", fake_fetch_drafts)
+
+        scanner.main(["--repo", "ll7/robot_sf_ll7", "--markdown"])
+        out, err = capsys.readouterr()
+        json.loads(out)  # stdout is valid JSON
+        assert "Superseded Draft PR Scan" in err
+
+
+# ---------------------------------------------------------------------------
+# fetch_merged_prs_for_issue pattern matching
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_merged_prs_pattern_matches_correctly() -> None:
+    """The pattern matching finds 'Closes #N' in PR body (case-insensitive, word boundary)."""
+    raw = [
+        {
+            "number": 10,
+            "title": "PR A",
+            "body": "Closes #42. Some text.",
+            "url": "https://example.com/pull/10",
+        },
+        {
+            "number": 11,
+            "title": "PR B",
+            "body": "Refs #42 no close.",
+            "url": "https://example.com/pull/11",
+        },
+        {
+            "number": 12,
+            "title": "PR C",
+            "body": "closes #42 and more.",
+            "url": "https://example.com/pull/12",
+        },
+        {
+            "number": 13,
+            "title": "PR D",
+            "body": "Closes #4200 not our issue.",
+            "url": "https://example.com/pull/13",
+        },
+    ]
+    import re
+
+    pattern = re.compile(r"Closes\s+#42\b", re.IGNORECASE)
+    matches = [r for r in raw if pattern.search(str(r.get("body", "")))]
+    # PR 10 and PR 12 match; PR 11 (Refs) and PR 13 (#4200) do not
+    assert len(matches) == 2
+    assert matches[0]["number"] == 10
+    assert matches[1]["number"] == 12
+
+
+# ---------------------------------------------------------------------------
+# fetch_draft_prs
+# ---------------------------------------------------------------------------
+
+
+class TestFetchDraftPrs:
+    def test_parses_valid_draft_pr_rows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """fetch_draft_prs parses gh JSON output into DraftPr objects."""
+        mock_data = [
+            {
+                "number": 1,
+                "title": "Draft PR",
+                "body": "Closes #42",
+                "url": "https://github.com/ll7/robot_sf_ll7/pull/1",
+                "createdAt": _ago(10),
+                "updatedAt": _now_iso(),
+            }
+        ]
+
+        def fake_run_json(cmd: list[str], *, default: Any = None) -> Any:
+            return mock_data
+
+        monkeypatch.setattr(scanner, "_run_json", fake_run_json)
+
+        prs, truncated = scanner.fetch_draft_prs(repo="ll7/robot_sf_ll7", limit=100)
+        assert len(prs) == 1
+        assert prs[0].number == 1
+        assert not truncated
+
+    def test_detects_truncation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """fetch_draft_prs should detect when result hits the limit."""
+        mock_data = [
+            {
+                "number": i,
+                "title": f"Draft {i}",
+                "body": "",
+                "url": f"https://github.com/ll7/robot_sf_ll7/pull/{i}",
+                "createdAt": _ago(i),
+                "updatedAt": _now_iso(),
+            }
+            for i in range(50)
+        ]
+
+        def fake_run_json(cmd: list[str], *, default: Any = None) -> Any:
+            return mock_data
+
+        monkeypatch.setattr(scanner, "_run_json", fake_run_json)
+
+        _, truncated = scanner.fetch_draft_prs(
+            repo="ll7/robot_sf_ll7",
+            limit=50,
+        )
+        assert truncated is True
+
+
+# ---------------------------------------------------------------------------
+# _run_json error handling
+# ---------------------------------------------------------------------------
+
+
+class TestRunJson:
+    def test_missing_gh_raises_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_run(*args: object, **kwargs: object) -> None:
+            raise FileNotFoundError("gh")
+
+        monkeypatch.setattr(scanner.subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError, match="GitHub CLI 'gh' was not found"):
+            scanner._run_json(["gh", "pr", "list"])
+
+    def test_captured_process_error_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_run(*args: object, **kwargs: object) -> None:
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=("gh", "pr", "list"),
+                stderr="authentication failed",
+            )
+
+        import subprocess
+
+        monkeypatch.setattr(scanner.subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError, match="authentication failed"):
+            scanner._run_json(["gh", "pr", "list"])
+
+
+# ---------------------------------------------------------------------------
+# build_report truncated marking
+# ---------------------------------------------------------------------------
+
+
+def test_report_truncated_marker() -> None:
+    """The report should carry the truncation warning from fetch."""
+    report = scanner.build_report(
+        repo="ll7/robot_sf_ll7",
+        candidates=[],
+        scanned_count=100,
+        truncated=True,
+    )
+    assert report["truncated"] is True
+
+
+def test_markdown_includes_truncation_warning() -> None:
+    """Markdown report should mention truncation when gh search was capped."""
+    md = scanner.build_markdown(
+        scanner.build_report(
+            repo="ll7/robot_sf_ll7",
+            candidates=[],
+            scanned_count=100,
+            truncated=True,
+        )
+    )
+    assert "truncated" in md.lower()


### PR DESCRIPTION
## What / Why

This PR adds a read-only scheduled scanner for open draft pull requests whose original purpose may already be complete. It reports hard close candidates when a linked issue is closed or a merged PR explicitly superseded the draft, and reports stale file-overlap as a weak signal without auto-closing anything.

## Contract

- The scanner is read-only and never changes PR or issue state.
- Hard candidates are rules 1–2; `--check` exits nonzero when they exist.
- GitHub/API failures and malformed required timestamps fail closed with an explicit JSON error report.
- Merged-PR searches are constrained to the linked issue reference rather than a repository-wide recent window.
- The scheduled workflow is advisory, uploads the report, and keeps error output artifact-backed.

## Changes

- `scripts/dev/scan_superseded_drafts.py`: deterministic scanner, issue-scoped merged search, timestamp validation, fail-closed API handling, JSON/Markdown reports.
- `tests/dev/test_scan_superseded_drafts.py`: mocked rule, parser, malformed-input, query, API-error, and CLI artifact tests.
- `.github/workflows/superseded-draft-scanner.yml`: weekday schedule plus manual dispatch and artifact upload.

## Validation / Proof

Commands run on this head:

```text
uv run ruff check scripts/dev/scan_superseded_drafts.py tests/dev/test_scan_superseded_drafts.py
uv run ruff format --check scripts/dev/scan_superseded_drafts.py tests/dev/test_scan_superseded_drafts.py
uv run pytest tests/dev/test_scan_superseded_drafts.py -q
uv run python scripts/dev/scan_superseded_drafts.py --repo ll7/robot_sf_ll7 --markdown --output /tmp/superseded-draft-report.json
```

The focused suite covers 54 tests, including malformed timestamp handling, issue-scoped search construction, API failure propagation, draft-filter command construction, and writing an error report to the requested output path. The live invocation is read-only and produced the expected exit code `1` because it found one hard candidate (draft PR #5154 linked to closed issue #3482); the JSON report and Markdown summary were written successfully. Hard candidates remain advisory evidence for a gate/orchestrator decision.

## Research Result Guidance

- Target claim / hypothesis / blocker: reduce stale draft-PR hygiene debt.
- Comparator or baseline: manual discovery of superseded drafts.
- Evidence tier: NA - support tooling.
- Result classification: NA - no research result claim.
- Decision or stop rule: no auto-close; humans/gates decide from the report.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #5393.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper.

## Downstream Propagation

- Parent issue updated: pending gate merge update.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened for deferred propagation: no.

## Risks / Rollout

The workflow is intentionally non-gating and does not auto-close drafts. A truncated scan is marked in the report; API or malformed-input errors are explicit failures rather than clean scans.

Closes #5393

This PR was produced by the SAIA/Qwen3.6-27B cheap implementation lane; the review gate hardens and merges.
