### PR TITLE
fix(#5401): numbered markers + legend in the Pareto SVG to stop label collisions

### DIFF
--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -1177,16 +1177,49 @@ def format_pareto_svg(report: Mapping[str, Any], *, width: int = 900, height: in
         parts.append(
             f'<polyline points="{polyline}" fill="none" stroke="#1f77b4" stroke-width="2.5"/>'
         )
-    for row in rows:
+    # #5401: numbered markers + a legend replace the old inline labels. The previous
+    # fixed (cx+8, cy-8) offset stacked labels wherever planners cluster (ppo / hybrid /
+    # scenario-adaptive at the top-right, sacadrl / goal at the bottom-left) and ran long
+    # names off the plot edge. Small index numbers never collide; the full planner names
+    # live in a legend placed in the empty top-left region of a Pareto plot.
+    ordered = sorted(
+        rows,
+        key=lambda r: (
+            0 if bool(r.get("pareto_front")) else 1,
+            -float(r.get("constraints_first_score", 0.0)),
+        ),
+    )
+    placed_num_pos: list[tuple[float, float]] = []
+    for idx, row in enumerate(ordered, start=1):
         cx = x_pos(float(row.get("constraints_first_score", 0.0)))
         cy = y_pos(float(row.get("snqi_mean", 0.0)))
         color = "#1f77b4" if bool(row.get("pareto_front")) else "#777777"
+        parts.append(f'<circle cx="{cx:.1f}" cy="{cy:.1f}" r="5" fill="{color}"/>')
+        # place the index next to the marker, nudging down if it would sit on a prior index
+        nx, ny = cx + 8.0, cy + 4.0
+        for px, py in placed_num_pos:
+            if abs(nx - px) < 12 and abs(ny - py) < 12:
+                ny = py + 14.0
+        placed_num_pos.append((nx, ny))
+        parts.append(
+            f'<text x="{nx:.1f}" y="{ny:.1f}" font-family="sans-serif" '
+            f'font-size="12" font-weight="bold" fill="{color}">{idx}</text>'
+        )
+    # legend: top-left is the empty region of a Pareto plot (high SNQI, low constraints-first)
+    lx = margin_left + 14.0
+    ly = margin_top + 16.0
+    parts.append(
+        f'<text x="{lx:.1f}" y="{ly - 4:.1f}" font-family="sans-serif" font-size="12" '
+        f'font-weight="bold" fill="#222">Planners (filled marker = Pareto front)</text>'
+    )
+    for idx, row in enumerate(ordered, start=1):
+        color = "#1f77b4" if bool(row.get("pareto_front")) else "#777777"
         planner = html.escape(str(row.get("planner", "unknown")))
-        parts.extend(
-            [
-                f'<circle cx="{cx:.1f}" cy="{cy:.1f}" r="5" fill="{color}"/>',
-                f'<text x="{cx + 8:.1f}" y="{cy - 8:.1f}" font-family="sans-serif" font-size="12">{planner}</text>',
-            ]
+        row_y = ly + idx * 15.0
+        parts.append(f'<circle cx="{lx + 4:.1f}" cy="{row_y - 4:.1f}" r="4" fill="{color}"/>')
+        parts.append(
+            f'<text x="{lx + 14:.1f}" y="{row_y:.1f}" font-family="sans-serif" '
+            f'font-size="11" fill="#222">{idx}. {planner}</text>'
         )
     parts.append("</svg>")
     return "\n".join(parts) + "\n"


### PR DESCRIPTION
Closes #5401.

The SNQI scalarization-sensitivity Pareto export (`format_pareto_svg`) placed every planner label at a fixed `(cx+8, cy-8)` offset with no collision avoidance. Labels stacked into unreadable garble wherever planners cluster (ppo/hybrid/scenario_adaptive_hybrid_orca_v1 at the top-right; sacadrl/goal at the bottom-left), and long names ran off the plot edge.

This replaces inline point labels with small bold index numbers next to each marker plus a legend (index -> full planner name, filled marker = Pareto front) in the empty top-left region of the Pareto plot. Numbers never collide; full names stay in the figure; the two non-dominated points remain colored and connected.

- All 28 tests in `test_snqi_scalarization_sensitivity.py` pass (incl. `test_svg_renderer_marks_pareto_points`) + 9 in the issue_3653 suite.
- Regenerated the pinned job-13175 export and verified it embedded cleanly in the downstream figure at 15 cm width — no overlaps, all nine planners legible.