### PR TITLE
perf(hybrid_rule): reuse cached grid context in rollout + squared-distance TTC threshold

### DIFF
--- a/robot_sf/planner/hybrid_rule_local_planner.py
+++ b/robot_sf/planner/hybrid_rule_local_planner.py
@@ -1377,10 +1377,18 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
     ) -> dict[str, Any] | None:
         """Return an occupied-cell or continuous-obstacle rejection for a rollout pose."""
         obstacle_value = 0.0
-        payload = self._obstacle_grid_payload(observation)
-        if payload is not None:
-            grid, meta, channel, _resolution = payload
-            obstacle_value = self._grid_value(robot_pos, grid, meta, channel)
+        # Reuse the per-plan occupancy-grid context instead of re-extracting the grid
+        # payload on every rollout step (identical grid/meta/channel within a plan()).
+        context = (
+            self._clearance_context
+            if self._clearance_context is not None
+            and self._clearance_context.observation_id == id(observation)
+            else self._build_clearance_context(observation)
+        )
+        if context is not None:
+            obstacle_value = self._grid_value(
+                robot_pos, context.grid, context.meta, context.channel
+            )
         if obstacle_value >= float(self.config.obstacle_threshold):
             return {
                 "accepted": False,
@@ -1434,8 +1442,11 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         ttc = -np.sum(rel_pos[valid] * rel_vel[valid], axis=1) / speed_sq[valid]
         ttc = np.clip(ttc, 0.0, float(self.config.soft_prediction_horizon))
         closest = rel_pos[valid] + rel_vel[valid] * ttc[:, None]
-        closest_dist = np.linalg.norm(closest, axis=1)
-        risky = closest_dist <= float(self.config.desired_dynamic_clearance)
+        # Threshold on squared distance to avoid a per-pedestrian sqrt; the risky
+        # mask is identical because sqrt is monotonic for non-negative distances.
+        closest_dist_sq = np.einsum("ij,ij->i", closest, closest)
+        desired_dynamic_clearance = float(self.config.desired_dynamic_clearance)
+        risky = closest_dist_sq <= desired_dynamic_clearance * desired_dynamic_clearance
         if not np.any(risky):
             return float("inf")
         positive = ttc[risky]

--- a/robot_sf/planner/hybrid_rule_local_planner.py
+++ b/robot_sf/planner/hybrid_rule_local_planner.py
@@ -1379,12 +1379,11 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         obstacle_value = 0.0
         # Reuse the per-plan occupancy-grid context instead of re-extracting the grid
         # payload on every rollout step (identical grid/meta/channel within a plan()).
-        context = (
-            self._clearance_context
-            if self._clearance_context is not None
-            and self._clearance_context.observation_id == id(observation)
-            else self._build_clearance_context(observation)
-        )
+        if self._clearance_context is None or self._clearance_context.observation_id != id(
+            observation
+        ):
+            self._clearance_context = self._build_clearance_context(observation)
+        context = self._clearance_context
         if context is not None:
             obstacle_value = self._grid_value(
                 robot_pos, context.grid, context.meta, context.channel

--- a/tests/planner/test_hybrid_rule_local_planner.py
+++ b/tests/planner/test_hybrid_rule_local_planner.py
@@ -1213,6 +1213,44 @@ def test_hybrid_rule_corridor_subgoal_rejects_occupied_rollout(monkeypatch) -> N
     assert evaluation["candidate"] == candidate
 
 
+def test_static_collision_rejection_caches_direct_call_context(monkeypatch) -> None:
+    """Direct rollout checks reuse a context built for the same observation."""
+    planner = HybridRuleLocalPlannerAdapter(HybridRuleLocalPlannerConfig())
+    observation = _obs()
+    candidate = HybridRuleCandidate(0.2, 0.0, "test")
+    grid = np.zeros((1, 3, 3), dtype=float)
+    monkeypatch.setattr(
+        planner,
+        "_obstacle_grid_payload",
+        lambda observation: (grid, {}, 0, 0.2),
+    )
+    monkeypatch.setattr(planner, "_grid_value", lambda point, grid, meta, channel: 0.0)
+    build_calls = 0
+    build_context = planner._build_clearance_context
+
+    def counted_build_context(current_observation):
+        nonlocal build_calls
+        build_calls += 1
+        return build_context(current_observation)
+
+    monkeypatch.setattr(planner, "_build_clearance_context", counted_build_context)
+
+    for _ in range(2):
+        assert (
+            planner._static_collision_rejection(
+                candidate=candidate,
+                observation=observation,
+                robot_pos=np.zeros(2),
+                hard_static_clearance=0.0,
+                use_continuous_static_check=False,
+                t=0.0,
+            )
+            is None
+        )
+
+    assert build_calls == 1
+
+
 def test_hybrid_rule_corridor_subgoal_rejects_static_clearance_band(monkeypatch) -> None:
     """Subgoal recovery must not reuse static-clearance escape exceptions."""
     cfg = HybridRuleLocalPlannerConfig(


### PR DESCRIPTION
## What

Two behavior-preserving per-step hot-path optimizations for `hybrid_rule_local_planner`:

1. Reuse the cached occupancy-grid context in the rollout loop. `_static_collision_rejection`
   now reuses the parsed payload cached by `plan()`, with a direct-call fallback that caches the
   newly built context.
2. Use a squared-distance TTC threshold instead of taking a square root solely to threshold it.

## Evidence

Micro-benchmark on a fixed grid plus five-pedestrian `hybrid_rule_v0` observation, comparing
`origin/main` with this head:

| | plan output `(v, omega)` | grid-payload calls / plan | mean plan time |
|---|---|---:|---:|
| old | `(0.100000000000, 0.000000000000)` | 521 | 11.74 ms |
| new | `(0.100000000000, 0.000000000000)` | 1 | 10.76 ms |

The output is bit-identical for this fixture. These timing values are exploratory evidence, not a
benchmark result or paper claim.

## Validation

```text
uv run pytest tests/planner/test_hybrid_rule_local_planner.py \
  tests/planner/test_hybrid_rule_local_planner_characterization.py \
  tests/planner/test_hybrid_rule_proxemic_costmap.py -q
74 passed
uv run ruff check robot_sf/planner/hybrid_rule_local_planner.py tests/planner/test_hybrid_rule_local_planner.py
uv run ruff format --check robot_sf/planner/hybrid_rule_local_planner.py tests/planner/test_hybrid_rule_local_planner.py
```

## Scope and follow-ups

This is the first, safest slice from the local-planner performance review. The completed issue
#5408 covers these two fixes. Deferred work is tracked explicitly in:

- #5411 — behavior-preserving grid-payload caching and scoring dedup across other planner families.
- #5412 — behavior-changing rollout vectorizations requiring a numeric-parity gate.

This PR does not claim those follow-ups, submit a campaign, or make a paper-facing claim.

Closes #5408

Target claim/blocker: behavior-preserving local-planner optimization; comparator: `origin/main`;
evidence tier: exploratory focused test plus microbenchmark; result: diagnostic/performance-only;
decision rule: retain only bit-identical behavior; synthesis target: #5408 and linked follow-ups.
