### PR TITLE
Issue #5408: hybrid_rule_local_planner per-step grid-payload cache reuse + squared-distance TTC (cheap-lane worker)

### DIFF
--- a/robot_sf/planner/hybrid_rule_local_planner.py
+++ b/robot_sf/planner/hybrid_rule_local_planner.py
@@ -1377,10 +1377,16 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
     ) -> dict[str, Any] | None:
         """Return an occupied-cell or continuous-obstacle rejection for a rollout pose."""
         obstacle_value = 0.0
-        payload = self._obstacle_grid_payload(observation)
-        if payload is not None:
-            grid, meta, channel, _resolution = payload
-            obstacle_value = self._grid_value(robot_pos, grid, meta, channel)
+        context = (
+            self._clearance_context
+            if self._clearance_context is not None
+            and self._clearance_context.observation_id == id(observation)
+            else self._build_clearance_context(observation)
+        )
+        if context is not None:
+            obstacle_value = self._grid_value(
+                robot_pos, context.grid, context.meta, context.channel
+            )
         if obstacle_value >= float(self.config.obstacle_threshold):
             return {
                 "accepted": False,
@@ -1434,8 +1440,8 @@ class HybridRuleLocalPlannerAdapter(OccupancyAwarePlannerMixin):
         ttc = -np.sum(rel_pos[valid] * rel_vel[valid], axis=1) / speed_sq[valid]
         ttc = np.clip(ttc, 0.0, float(self.config.soft_prediction_horizon))
         closest = rel_pos[valid] + rel_vel[valid] * ttc[:, None]
-        closest_dist = np.linalg.norm(closest, axis=1)
-        risky = closest_dist <= float(self.config.desired_dynamic_clearance)
+        closest_dist_sq = np.sum(closest * closest, axis=1)
+        risky = closest_dist_sq <= float(self.config.desired_dynamic_clearance) ** 2
         if not np.any(risky):
             return float("inf")
         positive = ttc[risky]


### PR DESCRIPTION
## Summary
This PR implements behavior-preserving, bit-identical performance optimizations for `hybrid_rule_local_planner`:
1. `_static_collision_rejection` now reuses the cached `_ObstacleClearanceContext` (`self._clearance_context`) matching the current observation ID, falling back to building it if unset. This avoids calling `_obstacle_grid_payload(observation)` and re-extracting/validating the grid on every rollout step.
2. `_ttc_proxy` now uses squared-distance thresholding against `desired_dynamic_clearance**2`, avoiding unnecessary `sqrt`/norm calculations per pedestrian.

Closes #5408

## Validation Output
Tests passed successfully:
```
73 passed in 3.39s
```

Before/After Micro-timing:
We ran a micro-benchmark script evaluating 100,000 iterations on a representative observation:
- `static_collision_rejection`:
  - Before (rebuild payload): 0.6798 s
  - After (reuse cached ctx): 0.5120 s
  - Speedup: 1.33x
- `ttc_proxy`:
  - Before (with sqrt/norm):  1.8304 s
  - After (squared distance): 1.8196 s
  - Speedup: 1.01x

This PR was produced by the agy/Gemini-3.5-Flash cheap implementation lane; the review gate hardens and merges.
