### PR TITLE
Issue #5355: fail-closed campaign-readiness gate + closure audit for the prediction-MPC factorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #5355 fail-closed campaign-readiness gate for the prediction-MPC factorial.** Adds
+  `assess_campaign_readiness()` and `dependency_blockers()` to
+  `robot_sf/benchmark/prediction_mpc_factorial_preregistration.py`, turning the preregistration's
+  §6 pre-submission requirements into an executable verdict. The CPU-only, no-submit gate aggregates
+  four criteria (preregistration config valid, four arm configs valid, exact-config sha256 pinned in
+  the evidence registry, and every declared blocking dependency resolved) and stays `ready: False`
+  unless each is positively verified. It encodes prereg §6 in code: the config's `dependencies`
+  block (#5351 hierarchical analysis, #5353 capability matrix) was previously inert prose, so nothing
+  prevented a premature GPU submission. On the landed config the gate reports the design,
+  preregistration, implementation, and provenance criteria as met and identifies #5351/#5353 as the
+  sole remaining blockers. Adds unit + integration tests in `tests/test_prediction_mpc_factorial.py`.
+  No campaign, GPU/Slurm, or metric change.
+
 * **issue #5372 fidelity smoke + arm-config identity checks for the #5355 factorial.** Adds two CPU-only, tiny-horizon test modules under `tests/planner/`: a toggle-effect fidelity smoke (`test_prediction_mpc_factorial_fidelity_smoke.py`) that runs all four canonical arm configs (`configs/algos/prediction_mpc_factorial_A{0,1}_B{0,1}.yaml`) on two named scenarios and asserts each factor flip changes the decision trace, the toggles are orthogonal, and the B-OFF arms complete episodes as functional soft-cost planners (prereg §6); and a static preflight identity test (`test_prediction_mpc_factorial_arm_identity.py`) asserting the four arms share the observation contract, kinematics, and runtime budget and differ only in the two factor flags plus the implied soft pedestrian weight (prereg §2, §7). Test-only; no campaign, GPU, or metric change.
 
 * **issue #4978 scenario flakiness audit applied to a real multi-planner campaign.** Ships a

--- a/docs/context/issue_5355_factorial_preregistration.md
+++ b/docs/context/issue_5355_factorial_preregistration.md
@@ -276,6 +276,13 @@ primary conclusion.
 
 Both checks must pass on the **exact** submitted config before any GPU submission.
 
+The pre-submission requirements are aggregated into a single fail-closed verdict by
+`assess_campaign_readiness()` in
+`robot_sf/benchmark/prediction_mpc_factorial_preregistration.py`: it stays `ready: False` unless the
+preregistration config validates, all four arm configs build, the exact config is sha256-pinned in
+the evidence registry, and every declared blocking dependency (§8: #5351, #5353) is resolved. The
+gate is CPU-only and authorizes no submission by itself.
+
 ### 6.1 Toggle-effect smoke (each factor demonstrably changes behavior)
 On **2 scenarios** — one static-structural (`classic_doorway`) and one dynamic
 (`francis2023_circular_crossing`) — run all four arms for a small fixed seed set and compare

--- a/docs/context/issue_5355_state.yaml
+++ b/docs/context/issue_5355_state.yaml
@@ -1,0 +1,66 @@
+# Canonical issue-state surface for #5355 (2x2 prediction-x-constraint factorial).
+# Append-only. Records the closure-audit criterion->evidence mapping and the
+# remaining execution gate. Contains NO transient queue-routing state (no target
+# hosts, packet lineage, or submit routes) per AGENTS/PR-governance rules.
+issue: 5355
+title: "research: 2x2 factorial campaign - prediction on/off x constraint-handling on/off"
+schema: robot_sf.issue_state.v1
+
+# --- Closure audit (2026-07-12) ------------------------------------------------
+# The issue's own CPU-implementable acceptance criteria are all met; the campaign
+# result (the issue's raison d'etre) does not exist yet, so the issue stays OPEN.
+# Verdict is machine-checkable via
+# robot_sf.benchmark.prediction_mpc_factorial_preregistration.assess_campaign_readiness().
+closure_audit:
+  date: 2026-07-12
+  decision: keep_open
+  reason: >
+    Design, preregistration, arm implementation, intervention-fidelity, and
+    provenance criteria are complete and landed. Campaign execution remains
+    (GPU/ops queue) and two declared dependencies (#5351 analysis, #5353
+    capability matrix) are still open. Not closeable until the campaign runs.
+  criteria:
+    - criterion: "2x2 factorial design on one matched base planner (option 1, prediction-MPC)"
+      status: met
+      evidence: "configs/research/prediction_mpc_factorial_v1.yaml; PR #5361"
+    - criterion: "Preregistration doc (arms, endpoints, contrasts, multiplicity, seed budget, stop rules)"
+      status: met
+      evidence: "docs/context/issue_5355_factorial_preregistration.md; PRs #5371, #5361"
+    - criterion: "Four arm configs realize the preregistered 2x2 truth table"
+      status: met
+      evidence: "configs/algos/prediction_mpc_factorial_A{0,1}_B{0,1}.yaml; tests/planner/test_prediction_mpc_factorial_arm_identity.py"
+    - criterion: "Factor toggles implemented (A prediction, B hard-vs-soft clearance)"
+      status: met
+      evidence: "robot_sf/planner/prediction_mpc.py; PRs #5361, #5382"
+    - criterion: "Intervention-fidelity checks (each factor bites; toggles orthogonal; B-OFF non-degenerate)"
+      status: met
+      evidence: "tests/planner/test_prediction_mpc_factorial_fidelity_smoke.py; PR #5398"
+    - criterion: "Campaign config pinned by sha256 in the evidence registry"
+      status: met
+      evidence: "docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/preregistration_config_registry.json"
+    - criterion: "Pre-submission readiness gate enforces §6 before GPU submission"
+      status: met
+      evidence: "assess_campaign_readiness() in robot_sf/benchmark/prediction_mpc_factorial_preregistration.py; this PR"
+    - criterion: "Hierarchical paired analysis machinery available"
+      status: blocked
+      evidence: "tracked separately in #5351 (still open)"
+    - criterion: "Capability-matrix fairness gating available"
+      status: blocked
+      evidence: "tracked separately in #5353 (still open)"
+    - criterion: "Factorial campaign executed and results promoted"
+      status: not_started
+      evidence: "compute; ops queue; out of scope for CPU implementation lanes"
+
+remaining_gate:
+  blockers_remaining:
+    - "#5351 hierarchical paired analysis (open)"
+    - "#5353 capability-matrix fairness contract (open)"
+    - "campaign execution on the ops/GPU queue (not authorized in CPU lanes)"
+  blockers_new: []
+  blockers_intentional:
+    - "campaign RUN deferred to compute queue by design (issue sequencing)"
+  next_empirical_action: >
+    Once #5351 and #5353 land, flip their status in
+    configs/research/prediction_mpc_factorial_v1.yaml dependencies to resolved,
+    confirm assess_campaign_readiness() returns ready: true on the exact
+    submitted config, then submit the factorial campaign through the ops queue.

--- a/robot_sf/benchmark/prediction_mpc_factorial_preregistration.py
+++ b/robot_sf/benchmark/prediction_mpc_factorial_preregistration.py
@@ -253,10 +253,12 @@ def dependency_blockers(dependencies: Any) -> list[str]:
     for entry in dependencies:
         if not isinstance(entry, Mapping):
             raise ValueError("each dependencies entry must be a mapping")
-        blocking_reason = str(entry.get("blocking", "")).strip()
+        blocking_value = entry.get("blocking")
+        blocking_reason = str(blocking_value).strip() if blocking_value is not None else ""
         if not blocking_reason:
             continue
-        status = str(entry.get("status", "")).strip().lower()
+        status_value = entry.get("status")
+        status = str(status_value).strip().lower() if status_value is not None else ""
         if status in RESOLVED_DEPENDENCY_STATES:
             continue
         issue = entry.get("issue", "?")
@@ -376,6 +378,8 @@ def _check_registry_pinned(config_path: Path, registry_path: str | Path | None) 
         registry = json.loads(resolved.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         return False, f"unreadable evidence registry: {exc}"
+    if not isinstance(registry, dict):
+        return False, "evidence registry must be a JSON object/dictionary"
     pinned_config = _resolve_existing_path(
         str(registry.get("config_path", "")), config_path=resolved
     )

--- a/robot_sf/benchmark/prediction_mpc_factorial_preregistration.py
+++ b/robot_sf/benchmark/prediction_mpc_factorial_preregistration.py
@@ -24,6 +24,22 @@ SCHEMA_VERSION = "robot_sf.issue_5355_prediction_mpc_factorial_preregistration.v
 EXPECTED_FACTORIAL_ARMS = ("A0_B0", "A0_B1", "A1_B0", "A1_B1")
 PAIRING_KEY_FIELDS = ("scenario_id", "seed")
 
+# Dependency-status tokens that count as resolved for the campaign-readiness gate.
+# A declared blocking dependency must reach one of these before GPU submission is
+# authorized; anything else (e.g. ``open``, ``in_progress``, blank) keeps the gate
+# fail-closed. See ``docs/context/issue_5355_factorial_preregistration.md`` §6.
+RESOLVED_DEPENDENCY_STATES = frozenset(
+    {"resolved", "closed", "merged", "done", "landed", "complete", "satisfied"}
+)
+
+# The evidence registry that pins the exact preregistration config by sha256,
+# relative to the repository root (prereg §6, "The campaign config lands with
+# sha256 in the evidence registry").
+DEFAULT_REGISTRY_RELATIVE_PATH = (
+    "docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration"
+    "/preregistration_config_registry.json"
+)
+
 
 def load_factorial_preregistration_config(path: str | Path) -> dict[str, Any]:
     """Load and validate an issue #5355 factorial pre-registration config.
@@ -216,6 +232,163 @@ def write_preregistration_plan(plan: Mapping[str, Any], output_dir: str | Path) 
     return path
 
 
+def dependency_blockers(dependencies: Any) -> list[str]:
+    """Return human-readable blockers for unresolved *blocking* dependencies.
+
+    A dependency entry blocks the campaign when it declares a truthy ``blocking``
+    reason and its ``status`` is not in :data:`RESOLVED_DEPENDENCY_STATES`. The
+    ``dependencies`` block is optional; a missing or empty block yields no
+    blockers (nothing is declared to wait on).
+
+    Returns:
+        Ordered blocker strings, one per unresolved blocking dependency.
+    """
+
+    if dependencies in (None, ""):
+        return []
+    if not isinstance(dependencies, Sequence) or isinstance(dependencies, (str, bytes)):
+        raise ValueError("dependencies must be a list of mappings")
+
+    blockers: list[str] = []
+    for entry in dependencies:
+        if not isinstance(entry, Mapping):
+            raise ValueError("each dependencies entry must be a mapping")
+        blocking_reason = str(entry.get("blocking", "")).strip()
+        if not blocking_reason:
+            continue
+        status = str(entry.get("status", "")).strip().lower()
+        if status in RESOLVED_DEPENDENCY_STATES:
+            continue
+        issue = entry.get("issue", "?")
+        blockers.append(
+            f"dependency #{issue} unresolved (status={status or 'unset'!s}): {blocking_reason}"
+        )
+    return blockers
+
+
+def assess_campaign_readiness(
+    config_path: str | Path,
+    *,
+    registry_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Fail-closed CPU readiness gate for the issue #5355 factorial campaign.
+
+    Aggregates the CPU-checkable acceptance criteria the preregistration
+    (``docs/context/issue_5355_factorial_preregistration.md`` §6) requires
+    *before* any GPU submission into a single verdict. This function never runs
+    benchmark episodes, touches GPU/Slurm, or promotes any benchmark/paper
+    claim; it only inspects tracked config and evidence artifacts.
+
+    Every criterion is treated as ``blocked`` unless it can be positively
+    verified, so an unreadable config, a stale registry digest, an invalid arm
+    config, or an unresolved declared dependency each keep ``ready`` False. This
+    encodes prereg §6 in code: the ``dependencies`` block (#5351 analysis,
+    #5353 capability matrix) is dead data today: nothing enforced that GPU
+    submission wait on it.
+
+    Args:
+        config_path: Path to the tracked factorial preregistration config.
+        registry_path: Optional override for the sha256 evidence registry. When
+            omitted, the default evidence registry is resolved relative to the
+            config's repository root.
+
+    Returns:
+        Readiness report: ``ready`` bool, per-criterion status mapping, the
+        ordered ``blockers`` list, and a ``claim_boundary`` string.
+    """
+
+    config_path = Path(config_path)
+    criteria: dict[str, dict[str, Any]] = {}
+    blockers: list[str] = []
+
+    def _record(name: str, ok: bool, detail: str) -> None:
+        criteria[name] = {"ready": bool(ok), "detail": detail}
+        if not ok:
+            blockers.append(f"{name}: {detail}")
+
+    # Criterion 1: the preregistration config parses and satisfies the contract.
+    config: dict[str, Any] | None = None
+    try:
+        config = load_factorial_preregistration_config(config_path)
+        _record("preregistration_config_valid", True, f"validated {config_path}")
+    except (ValueError, OSError, yaml.YAMLError) as exc:
+        _record("preregistration_config_valid", False, str(exc))
+
+    # Criterion 2: all four arm configs build and realize the 2x2 truth table.
+    if config is not None:
+        try:
+            arm_results = validate_arm_configs(config_path)
+            invalid = {k: v.get("error") for k, v in arm_results.items() if not v.get("valid")}
+            if len(arm_results) == len(EXPECTED_FACTORIAL_ARMS) and not invalid:
+                _record("arm_configs_valid", True, "all four arm configs valid")
+            else:
+                _record("arm_configs_valid", False, f"invalid arms: {invalid or 'incomplete set'}")
+        except (ValueError, OSError, yaml.YAMLError) as exc:
+            _record("arm_configs_valid", False, str(exc))
+    else:
+        _record("arm_configs_valid", False, "skipped: preregistration config invalid")
+
+    # Criterion 3: the exact config is pinned by sha256 in the evidence registry.
+    _record("evidence_registry_pinned", *_check_registry_pinned(config_path, registry_path))
+
+    # Criterion 4: every declared blocking dependency (#5351, #5353) is resolved.
+    if config is not None:
+        try:
+            dep_blockers = dependency_blockers(config.get("dependencies"))
+            if dep_blockers:
+                _record("dependencies_resolved", False, "; ".join(dep_blockers))
+            else:
+                _record("dependencies_resolved", True, "no unresolved blocking dependencies")
+        except ValueError as exc:
+            _record("dependencies_resolved", False, str(exc))
+    else:
+        _record("dependencies_resolved", False, "skipped: preregistration config invalid")
+
+    return {
+        "schema_version": "robot_sf.issue_5355_prediction_mpc_factorial_readiness.v1",
+        "issue": 5355,
+        "config_path": str(config_path),
+        "ready": not blockers,
+        "criteria": criteria,
+        "blockers": blockers,
+        "claim_boundary": (
+            "CPU readiness gate only; no benchmark, paper, or release claim and no "
+            "GPU/Slurm submission is authorized by a ready verdict."
+        ),
+    }
+
+
+def _check_registry_pinned(config_path: Path, registry_path: str | Path | None) -> tuple[bool, str]:
+    """Check that the sha256 evidence registry pins the exact config bytes.
+
+    Returns:
+        ``(ok, detail)`` where ``ok`` is True only when the registry exists,
+        pins the given config path, and its digest matches the config bytes.
+    """
+
+    if registry_path is None:
+        resolved = _resolve_existing_path(DEFAULT_REGISTRY_RELATIVE_PATH, config_path=config_path)
+    else:
+        resolved = Path(registry_path)
+    if not resolved.is_file():
+        return False, f"evidence registry not found: {resolved}"
+    try:
+        registry = json.loads(resolved.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return False, f"unreadable evidence registry: {exc}"
+    pinned_config = _resolve_existing_path(
+        str(registry.get("config_path", "")), config_path=resolved
+    )
+    if not pinned_config.is_file():
+        return False, f"registry config_path missing: {registry.get('config_path')}"
+    actual = hashlib.sha256(pinned_config.read_bytes()).hexdigest()
+    if actual != str(registry.get("config_sha256", "")):
+        return False, "registry config_sha256 does not match config bytes"
+    if pinned_config.resolve() != config_path.resolve():
+        return False, f"registry pins a different config: {pinned_config}"
+    return True, f"config pinned by sha256 in {resolved}"
+
+
 def _validate_factorial_arms(value: Any, *, config_path: str | Path | None) -> None:
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
         raise ValueError("factorial_arms must be list")
@@ -332,11 +505,15 @@ def _reject_transient_routing_state(config: Mapping[str, Any]) -> None:
 
 
 __all__ = [
+    "DEFAULT_REGISTRY_RELATIVE_PATH",
     "EXPECTED_FACTORIAL_ARMS",
     "PAIRING_KEY_FIELDS",
+    "RESOLVED_DEPENDENCY_STATES",
     "SCHEMA_VERSION",
+    "assess_campaign_readiness",
     "build_preregistration_plan",
     "check_planned_rows",
+    "dependency_blockers",
     "load_factorial_preregistration_config",
     "validate_arm_configs",
     "validate_factorial_preregistration_config",

--- a/tests/test_prediction_mpc_factorial.py
+++ b/tests/test_prediction_mpc_factorial.py
@@ -428,6 +428,15 @@ class TestDependencyBlockers:
         # No ``blocking`` reason => informational only, never blocks submission.
         assert dependency_blockers([{"issue": 42, "status": "open"}]) == []
 
+    def test_none_dependency_fields_are_treated_as_missing(self):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            dependency_blockers,
+        )
+
+        assert dependency_blockers([{"issue": 42, "blocking": None, "status": None}]) == []
+        blockers = dependency_blockers([{"issue": 42, "blocking": "analysis", "status": None}])
+        assert blockers == ["dependency #42 unresolved (status=unset): analysis"]
+
     def test_malformed_dependencies_raise(self):
         from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
             dependency_blockers,
@@ -473,6 +482,18 @@ class TestCampaignReadinessGate:
         )
         assert report["ready"] is False
         assert report["criteria"]["evidence_registry_pinned"]["ready"] is False
+
+    def test_non_object_registry_blocks_readiness(self, tmp_path):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            assess_campaign_readiness,
+        )
+
+        registry = tmp_path / "registry.json"
+        registry.write_text("[]", encoding="utf-8")
+        report = assess_campaign_readiness(self.CONFIG_PATH, registry_path=registry)
+        assert report["ready"] is False
+        detail = report["criteria"]["evidence_registry_pinned"]["detail"]
+        assert "JSON object/dictionary" in detail
 
     def test_invalid_config_fails_closed(self, tmp_path):
         from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (

--- a/tests/test_prediction_mpc_factorial.py
+++ b/tests/test_prediction_mpc_factorial.py
@@ -387,3 +387,133 @@ class TestPreregistrationHarness:
         result = check_planned_rows(rows)
         assert result["complete"] is False
         assert len(result["incomplete_pairs"]) > 0
+
+
+class TestDependencyBlockers:
+    """Test the pure dependency-resolution helper (prereg §6 gate input)."""
+
+    def test_no_dependencies_block_is_empty(self):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            dependency_blockers,
+        )
+
+        assert dependency_blockers(None) == []
+        assert dependency_blockers([]) == []
+
+    def test_open_blocking_dependency_is_a_blocker(self):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            dependency_blockers,
+        )
+
+        deps = [{"issue": 5351, "status": "open", "blocking": "analysis machinery"}]
+        blockers = dependency_blockers(deps)
+        assert len(blockers) == 1
+        assert "#5351" in blockers[0]
+        assert "analysis machinery" in blockers[0]
+
+    def test_resolved_dependency_is_not_a_blocker(self):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            dependency_blockers,
+        )
+
+        for state in ("resolved", "closed", "merged", "done"):
+            deps = [{"issue": 5351, "status": state, "blocking": "analysis machinery"}]
+            assert dependency_blockers(deps) == []
+
+    def test_non_blocking_dependency_is_ignored(self):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            dependency_blockers,
+        )
+
+        # No ``blocking`` reason => informational only, never blocks submission.
+        assert dependency_blockers([{"issue": 42, "status": "open"}]) == []
+
+    def test_malformed_dependencies_raise(self):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            dependency_blockers,
+        )
+
+        with pytest.raises(ValueError):
+            dependency_blockers("not-a-list")
+        with pytest.raises(ValueError):
+            dependency_blockers([["not", "a", "mapping"]])
+
+
+class TestCampaignReadinessGate:
+    """Test the fail-closed campaign-readiness gate for issue #5355."""
+
+    CONFIG_PATH = REPO_ROOT / "configs/research/prediction_mpc_factorial_v1.yaml"
+
+    def test_real_config_is_blocked_only_on_open_dependencies(self):
+        """The landed packet is campaign-ready except for #5351/#5353 (closure audit)."""
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            assess_campaign_readiness,
+        )
+
+        report = assess_campaign_readiness(self.CONFIG_PATH)
+        assert report["ready"] is False
+        criteria = report["criteria"]
+        # Design/preregistration/implementation/provenance criteria are all met...
+        assert criteria["preregistration_config_valid"]["ready"] is True
+        assert criteria["arm_configs_valid"]["ready"] is True
+        assert criteria["evidence_registry_pinned"]["ready"] is True
+        # ...and the sole remaining gate is the two declared open dependencies.
+        assert criteria["dependencies_resolved"]["ready"] is False
+        joined = " ".join(report["blockers"])
+        assert "#5351" in joined
+        assert "#5353" in joined
+
+    def test_missing_registry_blocks_readiness(self, tmp_path):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            assess_campaign_readiness,
+        )
+
+        report = assess_campaign_readiness(
+            self.CONFIG_PATH, registry_path=tmp_path / "does_not_exist.json"
+        )
+        assert report["ready"] is False
+        assert report["criteria"]["evidence_registry_pinned"]["ready"] is False
+
+    def test_invalid_config_fails_closed(self, tmp_path):
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            assess_campaign_readiness,
+        )
+
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("issue: 5355\nschema_version: wrong\n", encoding="utf-8")
+        report = assess_campaign_readiness(bad)
+        assert report["ready"] is False
+        assert report["criteria"]["preregistration_config_valid"]["ready"] is False
+
+    def test_ready_when_dependencies_resolved_and_registry_matches(self, tmp_path):
+        """End-to-end ready verdict once the declared dependencies are marked resolved."""
+        import hashlib
+        import json
+
+        from robot_sf.benchmark.prediction_mpc_factorial_preregistration import (
+            assess_campaign_readiness,
+        )
+
+        # Copy the real config verbatim but mark the blocking dependencies resolved.
+        source = self.CONFIG_PATH.read_text(encoding="utf-8")
+        resolved_text = source.replace("status: open", "status: resolved")
+        assert "status: open" not in resolved_text
+        cfg = tmp_path / "prediction_mpc_factorial_resolved.yaml"
+        cfg.write_text(resolved_text, encoding="utf-8")
+
+        # Pin the copy with a matching sha256 registry (arm/scenario paths resolve via cwd).
+        registry = tmp_path / "registry.json"
+        registry.write_text(
+            json.dumps(
+                {
+                    "campaign_id": "issue_5355_prediction_mpc_factorial_v1",
+                    "config_path": str(cfg),
+                    "config_sha256": hashlib.sha256(cfg.read_bytes()).hexdigest(),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        report = assess_campaign_readiness(cfg, registry_path=registry)
+        assert report["ready"] is True, report["blockers"]
+        assert all(c["ready"] for c in report["criteria"].values())


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds `assess_campaign_readiness()` + `dependency_blockers()` to `robot_sf/benchmark/prediction_mpc_factorial_preregistration.py` — a fail-closed, CPU-only gate that turns the preregistration's §6 pre-submission requirements into a single executable verdict, plus unit/integration tests and a durable issue-state surface.
- **Why now:** This is a **closure audit** of #5355. The design, preregistration, arm implementation, intervention-fidelity, and provenance criteria are all landed (PRs #5361, #5371, #5382, #5398). The one genuine gap: the config's `dependencies` block (#5351, #5353) was **inert prose** — nothing enforced "no GPU submission before dependencies resolve" (prereg §6, lines 15/277/336-338). This gate encodes it. It is a **progression slice** (nameable new capability: the pre-submission readiness gate), not a packet refresh.
- **Claim boundary:** `diagnostic-only` / CPU. No benchmark, paper, or release claim; a `ready: true` verdict authorizes no submission by itself. No campaign was run.
- **Required validation:** `pytest tests/test_prediction_mpc_factorial.py` (see below).
- **Remaining blocker:** #5351 (hierarchical analysis) and #5353 (capability matrix) are still open, and the campaign RUN is compute — so #5355 stays **open**. On the landed config the gate confirms these are the *only* remaining blockers.

## Contract delta

- **New public API** (`robot_sf/benchmark/prediction_mpc_factorial_preregistration.py`): `assess_campaign_readiness(config_path, *, registry_path=None)`, `dependency_blockers(dependencies)`, constants `RESOLVED_DEPENDENCY_STATES`, `DEFAULT_REGISTRY_RELATIVE_PATH`.
- **New fail-closed behavior:** the gate returns `ready: False` unless *all four* criteria pass — preregistration config valid, four arm configs valid, exact config sha256-pinned in the evidence registry, and every declared **blocking** dependency resolved. Any unverifiable criterion (unreadable config, stale digest, unresolved dependency) blocks.
- **Compatibility:** purely additive. No existing function signature, config schema, arm config, or metric changed. Reads the existing `dependencies` block that already ships in `configs/research/prediction_mpc_factorial_v1.yaml`.

## Closure-audit criterion → evidence

| Acceptance criterion | Status | Evidence |
| --- | --- | --- |
| 2×2 factorial design on one matched base planner (option 1) | met | `configs/research/prediction_mpc_factorial_v1.yaml` (#5361) |
| Preregistration doc (arms, endpoints, contrasts, multiplicity, seeds, stop rules) | met | `docs/context/issue_5355_factorial_preregistration.md` (#5371, #5361) |
| Four arm configs realize the 2×2 truth table | met | `configs/algos/prediction_mpc_factorial_A{0,1}_B{0,1}.yaml`; `tests/planner/test_prediction_mpc_factorial_arm_identity.py` |
| Factor toggles implemented (A prediction, B hard-vs-soft) | met | `robot_sf/planner/prediction_mpc.py` (#5361, #5382) |
| Intervention-fidelity (each factor bites; orthogonal; B-OFF non-degenerate) | met | `tests/planner/test_prediction_mpc_factorial_fidelity_smoke.py` (#5398) |
| Campaign config sha256-pinned in evidence registry | met | `docs/context/evidence/issue_5355_prediction_mpc_factorial_preregistration/preregistration_config_registry.json` |
| Pre-submission readiness gate enforces §6 | met | `assess_campaign_readiness()` — **this PR** |
| Hierarchical paired analysis machinery | **blocked** | tracked in **#5351** (open) |
| Capability-matrix fairness gating | **blocked** | tracked in **#5353** (open) |
| Factorial campaign executed + promoted | **not started** | compute / ops queue (out of scope here) |

Because the campaign result (the issue's raison d'être) does not exist and #5351/#5353 remain open, this is **Refs #5355**, not a close.

### Remaining checklist for #5355
- [ ] #5351 hierarchical paired analysis lands → flip its `status` to `resolved` in the config `dependencies`
- [ ] #5353 capability matrix lands → flip its `status` to `resolved`
- [ ] Confirm `assess_campaign_readiness()` returns `ready: true` on the exact submitted config
- [ ] Submit the factorial campaign through the ops/GPU queue (not this lane)

## Validation

```
$ scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_prediction_mpc_factorial.py -q
37 passed in 7.16s

$ pytest tests/test_prediction_mpc_factorial.py tests/planner/test_prediction_mpc_factorial_arm_identity.py tests/planner/test_prediction_mpc_factorial_fidelity_smoke.py -q
59 passed in 9.74s

$ ruff check <changed files>   # All checks passed!
$ ruff format --check          # clean
```

Live gate output on the landed config:
```
ready = False
blockers = ['dependencies_resolved: dependency #5351 unresolved (status=open): analysis machinery ...; dependency #5353 unresolved (status=open): capability-matrix gating ...']
```

## State propagation

High-churn issue (>3 PRs/24h). Per repo governance I updated the single canonical durable state surface — `docs/context/issue_5355_state.yaml` (new, append-only, no transient routing state) — with the closure-audit criterion→evidence table and remaining gate. `comment_issue_or_pr` is disabled for this lane, so no issue comment was posted.

## Out of scope

No full benchmark campaign run; no Slurm/GPU submission; no paper/dissertation claim edits; no changes to existing planner arms, frozen release data, or metric semantics.

<details>
<summary>Governance / provenance</summary>

- Target claim/blocker: enforce prereg §6 pre-submission gate; blocker = #5351/#5353 + campaign run.
- Comparator/baseline: NA (tooling, not a benchmark result).
- Evidence tier: `diagnostic-only` (CPU contract checks).
- Result classification: readiness `not ready` (fail-closed on open dependencies), as expected.
- Decision/stop rule: gate `ready` only when all four criteria pass.
- Synthesis/update target: `docs/context/issue_5355_state.yaml`.
- Base: branched from `origin/main` @ 163d90565; isolated worktree.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
