### PR TITLE
Issue #5409: horizon ablation config pair + validation (cheap-lane worker)

### DIFF
--- a/configs/benchmarks/issue_5409_horizon_ablation_h500.yaml
+++ b/configs/benchmarks/issue_5409_horizon_ablation_h500.yaml
@@ -1,0 +1,159 @@
+# Issue #5409 horizon ablation — h500 arm.
+#
+# Roster-matched, seed-matched counterpart to issue_5409_horizon_ablation_h600.yaml.
+# Everything is identical except the campaign-level horizon (500 vs 600).
+# This is the first defensible config for the "does horizon change planner
+# conclusions?" question: the naive/controlled tables (#4.10/#4.11) differ on
+# roster, seed budget, and tier composition at once, so they cannot answer it.
+#
+# Claim boundary: diagnostic-only. This config enables the ablation campaign
+# but does not submit, run, or interpret it.  No benchmark, paper, or
+# dissertation claim follows from this file alone.
+
+name: issue_5409_horizon_ablation_h500
+paper_facing: false
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+
+amv_profile:
+  name: amv-paper-v1
+  contract_version: "1"
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case: [delivery_robot, shared_space_micromobility]
+    context: [sidewalk, shared_space]
+    speed_regime: [walking_speed, scooter_speed]
+    maneuver_type: [overtake, crossing, bottleneck]
+
+seed_policy:
+  mode: seed-set
+  seed_set: eval
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+
+workers: 2
+horizon: 500
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: false
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+
+kinematics_matrix:
+  - differential_drive
+
+export_publication_bundle: false
+include_videos_in_publication: false
+overwrite_publication_bundle: false
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: diagnostic-horizon-ablation-h500
+
+preregistration:
+  issue: 5409
+  claim_boundary: >-
+    Diagnostic-only horizon ablation config. No benchmark, paper, or dissertation
+    claim from this config alone. The paired h600 config must use the same roster
+    and seed budget; any comparison requires both campaigns to complete.
+  expected_scenario_matrix_hash: c10df617a87c
+  ablation_role: h500
+  counterpart_config: configs/benchmarks/issue_5409_horizon_ablation_h600.yaml
+  hypothesis: >
+    A longer horizon (600 vs 500) does not change planner relative rankings
+    when roster, seed budget, scenario matrix, and comparability mapping are
+    held constant.  Failure to preserve rankings is a horizon finding.
+
+# Full 12-arm roster, sorted by structural class (matching the trace-capable
+# h600 re-run roster so the ablation is roster-matched).
+planners:
+  - key: scenario_adaptive_hybrid_orca_v1
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
+    benchmark_profile: experimental
+
+  - key: hybrid_rule_v3_fast_progress_static_escape
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
+    benchmark_profile: experimental
+
+  - key: ppo
+    algo: ppo
+    planner_group: experimental
+    algo_config: configs/baselines/ppo_issue_791_eval_aligned_large_capacity.yaml
+    benchmark_profile: experimental
+    adapter_impact_eval: true
+    workers: 1
+
+  - key: guarded_ppo
+    algo: guarded_ppo
+    planner_group: experimental
+    algo_config: configs/algos/orca_prior_guarded_ppo_v1.yaml
+    benchmark_profile: experimental
+    availability_gate: dependency_gated
+    fail_closed_reason: guarded_ppo_checkpoint_observation_contract_missing
+
+  - key: prediction_planner
+    algo: prediction_planner
+    planner_group: experimental
+    algo_config: configs/algos/prediction_planner_camera_ready.yaml
+    benchmark_profile: experimental
+
+  - key: prediction_mpc
+    algo: prediction_mpc
+    planner_group: experimental
+    algo_config: configs/algos/prediction_mpc_cv.yaml
+    benchmark_profile: experimental
+
+  - key: prediction_mpc_cbf
+    algo: prediction_mpc
+    planner_group: experimental
+    algo_config: configs/algos/prediction_mpc_cv_cbf_collision_cone.yaml
+    benchmark_profile: experimental
+
+  - key: goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: social_force
+    algo: social_force
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: orca
+    algo: orca
+    planner_group: core
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fallback
+
+  - key: socnav_sampling
+    algo: socnav_sampling
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fail-fast
+
+  - key: sacadrl
+    algo: sacadrl
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fallback

--- a/configs/benchmarks/issue_5409_horizon_ablation_h600.yaml
+++ b/configs/benchmarks/issue_5409_horizon_ablation_h600.yaml
@@ -1,0 +1,159 @@
+# Issue #5409 horizon ablation — h600 arm.
+#
+# Roster-matched, seed-matched counterpart to issue_5409_horizon_ablation_h500.yaml.
+# Everything is identical except the campaign-level horizon (600 vs 500).
+# This is the first defensible config for the "does horizon change planner
+# conclusions?" question: the naive/controlled tables (#4.10/#4.11) differ on
+# roster, seed budget, and tier composition at once, so they cannot answer it.
+#
+# Claim boundary: diagnostic-only. This config enables the ablation campaign
+# but does not submit, run, or interpret it.  No benchmark, paper, or
+# dissertation claim follows from this file alone.
+
+name: issue_5409_horizon_ablation_h600
+paper_facing: false
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+
+amv_profile:
+  name: amv-paper-v1
+  contract_version: "1"
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case: [delivery_robot, shared_space_micromobility]
+    context: [sidewalk, shared_space]
+    speed_regime: [walking_speed, scooter_speed]
+    maneuver_type: [overtake, crossing, bottleneck]
+
+seed_policy:
+  mode: seed-set
+  seed_set: eval
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+
+workers: 2
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: false
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+
+kinematics_matrix:
+  - differential_drive
+
+export_publication_bundle: false
+include_videos_in_publication: false
+overwrite_publication_bundle: false
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: diagnostic-horizon-ablation-h600
+
+preregistration:
+  issue: 5409
+  claim_boundary: >-
+    Diagnostic-only horizon ablation config. No benchmark, paper, or dissertation
+    claim from this config alone. The paired h500 config must use the same roster
+    and seed budget; any comparison requires both campaigns to complete.
+  expected_scenario_matrix_hash: c10df617a87c
+  ablation_role: h600
+  counterpart_config: configs/benchmarks/issue_5409_horizon_ablation_h500.yaml
+  hypothesis: >
+    A longer horizon (600 vs 500) does not change planner relative rankings
+    when roster, seed budget, scenario matrix, and comparability mapping are
+    held constant.  Failure to preserve rankings is a horizon finding.
+
+# Full 12-arm roster, sorted by structural class (matching the trace-capable
+# h600 re-run roster so the ablation is roster-matched).
+planners:
+  - key: scenario_adaptive_hybrid_orca_v1
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
+    benchmark_profile: experimental
+
+  - key: hybrid_rule_v3_fast_progress_static_escape
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
+    benchmark_profile: experimental
+
+  - key: ppo
+    algo: ppo
+    planner_group: experimental
+    algo_config: configs/baselines/ppo_issue_791_eval_aligned_large_capacity.yaml
+    benchmark_profile: experimental
+    adapter_impact_eval: true
+    workers: 1
+
+  - key: guarded_ppo
+    algo: guarded_ppo
+    planner_group: experimental
+    algo_config: configs/algos/orca_prior_guarded_ppo_v1.yaml
+    benchmark_profile: experimental
+    availability_gate: dependency_gated
+    fail_closed_reason: guarded_ppo_checkpoint_observation_contract_missing
+
+  - key: prediction_planner
+    algo: prediction_planner
+    planner_group: experimental
+    algo_config: configs/algos/prediction_planner_camera_ready.yaml
+    benchmark_profile: experimental
+
+  - key: prediction_mpc
+    algo: prediction_mpc
+    planner_group: experimental
+    algo_config: configs/algos/prediction_mpc_cv.yaml
+    benchmark_profile: experimental
+
+  - key: prediction_mpc_cbf
+    algo: prediction_mpc
+    planner_group: experimental
+    algo_config: configs/algos/prediction_mpc_cv_cbf_collision_cone.yaml
+    benchmark_profile: experimental
+
+  - key: goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: social_force
+    algo: social_force
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: orca
+    algo: orca
+    planner_group: core
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fallback
+
+  - key: socnav_sampling
+    algo: socnav_sampling
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fail-fast
+
+  - key: sacadrl
+    algo: sacadrl
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fallback

--- a/scripts/benchmark/validate_horizon_ablation_pair.py
+++ b/scripts/benchmark/validate_horizon_ablation_pair.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Validate that two benchmark configs form a valid horizon ablation pair.
+
+A valid horizon ablation pair differs ONLY in campaign-level horizon while
+sharing the same planner roster, seed budget, scenario matrix, comparability
+mapping, and all other execution-relevant fields.  This is the minimal check
+needed to conclude "does horizon change planner conclusions?" from the paired
+campaign outputs.
+
+Usage::
+
+    uv run python scripts/benchmark/validate_horizon_ablation_pair.py \
+        configs/benchmarks/issue_5409_horizon_ablation_h500.yaml \
+        configs/benchmarks/issue_5409_horizon_ablation_h600.yaml
+
+Exit codes:
+    0 — configs form a valid horizon ablation pair
+    1 — at least one mismatch was found (printed to stderr)
+    2 — config loading or parsing error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_EXECUTION_RELEVANT_KEYS = frozenset(
+    {
+        "scenario_matrix",
+        "comparability_mapping",
+        "route_clearance_certifications",
+        "scenario_horizons",
+        "dt",
+        "workers",
+        "record_forces",
+        "resume",
+        "stop_on_failure",
+        "bootstrap_samples",
+        "bootstrap_confidence",
+        "bootstrap_seed",
+        "kinematics_matrix",
+        "export_publication_bundle",
+        "include_videos_in_publication",
+        "snqi_weights",
+        "snqi_baseline",
+        "paper_facing",
+        "paper_profile_version",
+    }
+)
+
+
+def _load_raw_config(path: Path) -> dict[str, Any]:
+    """Load a YAML campaign config as a raw dict without full validation."""
+    text = path.read_text(encoding="utf-8")
+    payload = yaml.safe_load(text)
+    if not isinstance(payload, dict):
+        raise ValueError(f"Config root is not a mapping: {path}")
+    return payload
+
+
+def _planner_roster(payload: dict[str, Any]) -> list[dict[str, str]]:
+    """Extract the normalized planner roster from a raw config payload."""
+    planners_raw = payload.get("planners")
+    if not isinstance(planners_raw, list) or not planners_raw:
+        raise ValueError("Config has no 'planners' list")
+    roster: list[dict[str, str]] = []
+    for entry in planners_raw:
+        if not isinstance(entry, dict):
+            raise ValueError("Each planner entry must be a mapping")
+        key = str(entry.get("key") or entry.get("algo") or "").strip()
+        algo = str(entry.get("algo") or "").strip()
+        algo_config = str(entry.get("algo_config") or "").strip()
+        if not key or not algo:
+            raise ValueError(f"Planner entry missing key or algo: {entry}")
+        roster.append({"key": key, "algo": algo, "algo_config": algo_config})
+    return roster
+
+
+def _seed_policy_signature(payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract a comparable seed-policy signature."""
+    raw = payload.get("seed_policy")
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        "mode": str(raw.get("mode", "")),
+        "seed_set": str(raw.get("seed_set", "")),
+        "seeds": list(raw.get("seeds") or []),
+        "seed_sets_path": str(raw.get("seed_sets_path", "")),
+    }
+
+
+def _compare_planner_rosters(
+    roster_a: list[dict[str, str]],
+    roster_b: list[dict[str, str]],
+) -> list[str]:
+    """Return mismatches between two planner rosters."""
+    errors: list[str] = []
+    keys_a = [p["key"] for p in roster_a]
+    keys_b = [p["key"] for p in roster_b]
+    if keys_a != keys_b:
+        only_a = [k for k in keys_a if k not in keys_b]
+        only_b = [k for k in keys_b if k not in keys_a]
+        if only_a:
+            errors.append(f"Planners only in config A: {only_a}")
+        if only_b:
+            errors.append(f"Planners only in config B: {only_b}")
+        if not only_a and not only_b and len(keys_a) == len(keys_b):
+            errors.append(f"Planner order differs: A={keys_a} vs B={keys_b}")
+    for pa, pb in zip(roster_a, roster_b, strict=False):
+        if pa["key"] != pb["key"]:
+            break
+        for field in ("algo", "algo_config"):
+            if pa[field] != pb[field]:
+                errors.append(
+                    f"Planner '{pa['key']}' {field} differs: A={pa[field]!r} vs B={pb[field]!r}"
+                )
+    return errors
+
+
+def _check_horizon_differs(
+    payload_a: dict[str, Any],
+    payload_b: dict[str, Any],
+) -> tuple[int | None, int | None, list[str]]:
+    """Check that horizons are fixed and differ. Return (h_a, h_b, errors)."""
+    mismatches: list[str] = []
+    horizon_a = payload_a.get("horizon")
+    horizon_b = payload_b.get("horizon")
+    if horizon_a is None and payload_a.get("scenario_horizons"):
+        mismatches.append(
+            "Config A uses scenario_horizons (per-scenario), not a fixed horizon; "
+            "a clean ablation requires fixed horizons."
+        )
+    if horizon_b is None and payload_b.get("scenario_horizons"):
+        mismatches.append(
+            "Config B uses scenario_horizons (per-scenario), not a fixed horizon; "
+            "a clean ablation requires fixed horizons."
+        )
+    if horizon_a is not None and horizon_b is not None and horizon_a == horizon_b:
+        mismatches.append(
+            f"Horizons are identical ({horizon_a} == {horizon_b}); "
+            "an ablation requires different horizons."
+        )
+    return (
+        int(horizon_a) if horizon_a is not None else None,
+        int(horizon_b) if horizon_b is not None else None,
+        mismatches,
+    )
+
+
+def _check_field_parity(
+    payload_a: dict[str, Any],
+    payload_b: dict[str, Any],
+) -> list[str]:
+    """Compare all execution-relevant, SNQI, and AMV fields for parity."""
+    mismatches: list[str] = []
+    for key in sorted(_EXECUTION_RELEVANT_KEYS):
+        va = payload_a.get(key)
+        vb = payload_b.get(key)
+        if va != vb:
+            mismatches.append(f"Field '{key}' differs: A={va!r} vs B={vb!r}")
+
+    snqi_a = dict(sorted((payload_a.get("snqi_contract") or {}).items()))
+    snqi_b = dict(sorted((payload_b.get("snqi_contract") or {}).items()))
+    if snqi_a != snqi_b:
+        mismatches.append(f"snqi_contract differs: A={snqi_a} vs B={snqi_b}")
+
+    amv_a = dict(sorted((payload_a.get("amv_profile") or {}).items()))
+    amv_b = dict(sorted((payload_b.get("amv_profile") or {}).items()))
+    if amv_a != amv_b:
+        mismatches.append(f"amv_profile differs: A={amv_a} vs B={amv_b}")
+
+    return mismatches
+
+
+class HorizonAblationPairResult:
+    """Structured result of a horizon ablation pair validation."""
+
+    def __init__(
+        self,
+        config_a: str,
+        config_b: str,
+        horizon_a: int | None,
+        horizon_b: int | None,
+        mismatches: list[str],
+    ) -> None:
+        """Store validation inputs and computed mismatches."""
+        self.config_a = config_a
+        self.config_b = config_b
+        self.horizon_a = horizon_a
+        self.horizon_b = horizon_b
+        self.mismatches = mismatches
+
+    @property
+    def is_valid(self) -> bool:
+        """Return True when the pair is a valid horizon ablation."""
+        return (
+            not self.mismatches
+            and self.horizon_a is not None
+            and self.horizon_b is not None
+            and self.horizon_a != self.horizon_b
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable validation result."""
+        return {
+            "schema_version": "horizon_ablation_pair_validation.v1",
+            "config_a": self.config_a,
+            "config_b": self.config_b,
+            "horizon_a": self.horizon_a,
+            "horizon_b": self.horizon_b,
+            "is_valid": self.is_valid,
+            "mismatch_count": len(self.mismatches),
+            "mismatches": self.mismatches,
+        }
+
+
+def validate_horizon_ablation_pair(
+    path_a: str | Path,
+    path_b: str | Path,
+) -> HorizonAblationPairResult:
+    """Validate that two configs form a valid horizon ablation pair.
+
+    Returns:
+        Structured validation result with mismatches list.
+    """
+    path_a = Path(path_a).resolve()
+    path_b = Path(path_b).resolve()
+
+    try:
+        payload_a = _load_raw_config(path_a)
+        payload_b = _load_raw_config(path_b)
+    except (OSError, yaml.YAMLError, ValueError) as exc:
+        return HorizonAblationPairResult(
+            config_a=str(path_a),
+            config_b=str(path_b),
+            horizon_a=None,
+            horizon_b=None,
+            mismatches=[f"Config loading error: {exc}"],
+        )
+
+    mismatches: list[str] = []
+
+    horizon_a, horizon_b, horizon_errors = _check_horizon_differs(payload_a, payload_b)
+    mismatches.extend(horizon_errors)
+
+    try:
+        roster_a = _planner_roster(payload_a)
+        roster_b = _planner_roster(payload_b)
+        mismatches.extend(_compare_planner_rosters(roster_a, roster_b))
+    except ValueError as exc:
+        mismatches.append(f"Roster extraction error: {exc}")
+
+    seed_a = _seed_policy_signature(payload_a)
+    seed_b = _seed_policy_signature(payload_b)
+    if seed_a != seed_b:
+        mismatches.append(f"Seed policy differs: A={seed_a} vs B={seed_b}")
+
+    mismatches.extend(_check_field_parity(payload_a, payload_b))
+
+    return HorizonAblationPairResult(
+        config_a=str(path_a),
+        config_b=str(path_b),
+        horizon_a=horizon_a,
+        horizon_b=horizon_b,
+        mismatches=mismatches,
+    )
+
+
+def main() -> None:
+    """CLI entry point for horizon ablation pair validation."""
+    parser = argparse.ArgumentParser(
+        description="Validate two benchmark configs as a horizon ablation pair.",
+    )
+    parser.add_argument("config_a", type=str, help="Path to the first config (e.g. h500).")
+    parser.add_argument("config_b", type=str, help="Path to the second config (e.g. h600).")
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Print the result as JSON to stdout.",
+    )
+    args = parser.parse_args()
+
+    result = validate_horizon_ablation_pair(args.config_a, args.config_b)
+
+    if args.json_output:
+        print(json.dumps(result.to_payload(), indent=2, sort_keys=False))
+    elif result.is_valid:
+        print(f"VALID horizon ablation pair: h{result.horizon_a} vs h{result.horizon_b}")
+    else:
+        print("INVALID horizon ablation pair:", file=sys.stderr)
+        for mismatch in result.mismatches:
+            print(f"  - {mismatch}", file=sys.stderr)
+
+    sys.exit(0 if result.is_valid else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/validate_horizon_ablation_pair.py
+++ b/scripts/benchmark/validate_horizon_ablation_pair.py
@@ -46,12 +46,50 @@ _EXECUTION_RELEVANT_KEYS = frozenset(
         "kinematics_matrix",
         "export_publication_bundle",
         "include_videos_in_publication",
+        "overwrite_publication_bundle",
         "snqi_weights",
         "snqi_baseline",
         "paper_facing",
         "paper_profile_version",
     }
 )
+
+
+def _optional_int(value: Any) -> int | None:
+    """Coerce an optional strict integer without truncating floats or booleans."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"Invalid integer: {value!r}")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if text:
+            try:
+                return int(text, 10)
+            except ValueError as exc:
+                raise ValueError(f"Invalid integer: {value!r}") from exc
+    raise ValueError(f"Invalid integer: {value!r}")
+
+
+def _optional_seed_id(value: Any) -> int | str | None:
+    """Normalize one optional seed identifier while preserving falsy zero."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"seed identifiers must not be booleans: {value!r}")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ValueError("seed identifiers must not be empty")
+        try:
+            return int(text, 10)
+        except ValueError:
+            return text
+    raise ValueError(f"unsupported seed identifier: {value!r}")
 
 
 def _load_raw_config(path: Path) -> dict[str, Any]:
@@ -86,10 +124,19 @@ def _seed_policy_signature(payload: dict[str, Any]) -> dict[str, Any]:
     raw = payload.get("seed_policy")
     if not isinstance(raw, dict):
         return {}
+    seeds_raw = raw.get("seeds")
+    if isinstance(seeds_raw, (list, tuple)):
+        seeds = [
+            normalized for seed in seeds_raw if (normalized := _optional_seed_id(seed)) is not None
+        ]
+    elif seeds_raw is None:
+        seeds = []
+    else:
+        seeds = [_optional_seed_id(seeds_raw)]
     return {
         "mode": str(raw.get("mode", "")),
         "seed_set": str(raw.get("seed_set", "")),
-        "seeds": list(raw.get("seeds") or []),
+        "seeds": seeds,
         "seed_sets_path": str(raw.get("seed_sets_path", "")),
     }
 
@@ -128,28 +175,48 @@ def _check_horizon_differs(
 ) -> tuple[int | None, int | None, list[str]]:
     """Check that horizons are fixed and differ. Return (h_a, h_b, errors)."""
     mismatches: list[str] = []
-    horizon_a = payload_a.get("horizon")
-    horizon_b = payload_b.get("horizon")
-    if horizon_a is None and payload_a.get("scenario_horizons"):
-        mismatches.append(
-            "Config A uses scenario_horizons (per-scenario), not a fixed horizon; "
-            "a clean ablation requires fixed horizons."
-        )
-    if horizon_b is None and payload_b.get("scenario_horizons"):
-        mismatches.append(
-            "Config B uses scenario_horizons (per-scenario), not a fixed horizon; "
-            "a clean ablation requires fixed horizons."
-        )
+    horizons: list[int | None] = []
+    for label, payload in (("A", payload_a), ("B", payload_b)):
+        raw_horizon = payload.get("horizon")
+        if raw_horizon is None:
+            if payload.get("scenario_horizons"):
+                mismatches.append(
+                    f"Config {label} uses scenario_horizons (per-scenario), not a fixed "
+                    "horizon; a clean ablation requires fixed horizons."
+                )
+            else:
+                mismatches.append(f"Config {label} is missing the 'horizon' field.")
+            horizons.append(None)
+            continue
+        try:
+            horizon = _optional_int(raw_horizon)
+        except ValueError as exc:
+            mismatches.append(f"Config {label} horizon is not a valid integer: {exc}")
+            horizons.append(None)
+            continue
+        if horizon is None or horizon <= 0:
+            mismatches.append(f"Config {label} horizon must be a positive integer: {raw_horizon!r}")
+            horizons.append(None)
+            continue
+        horizons.append(horizon)
+
+    horizon_a, horizon_b = horizons
     if horizon_a is not None and horizon_b is not None and horizon_a == horizon_b:
         mismatches.append(
             f"Horizons are identical ({horizon_a} == {horizon_b}); "
             "an ablation requires different horizons."
         )
-    return (
-        int(horizon_a) if horizon_a is not None else None,
-        int(horizon_b) if horizon_b is not None else None,
-        mismatches,
-    )
+    return horizon_a, horizon_b, mismatches
+
+
+def _mapping_signature(payload: dict[str, Any], field: str) -> dict[str, Any]:
+    """Return a sorted mapping field or reject a malformed contract value."""
+    raw = payload.get(field)
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{field} must be a mapping when provided, got {type(raw).__name__}")
+    return dict(sorted(raw.items()))
 
 
 def _check_field_parity(
@@ -164,13 +231,13 @@ def _check_field_parity(
         if va != vb:
             mismatches.append(f"Field '{key}' differs: A={va!r} vs B={vb!r}")
 
-    snqi_a = dict(sorted((payload_a.get("snqi_contract") or {}).items()))
-    snqi_b = dict(sorted((payload_b.get("snqi_contract") or {}).items()))
+    snqi_a = _mapping_signature(payload_a, "snqi_contract")
+    snqi_b = _mapping_signature(payload_b, "snqi_contract")
     if snqi_a != snqi_b:
         mismatches.append(f"snqi_contract differs: A={snqi_a} vs B={snqi_b}")
 
-    amv_a = dict(sorted((payload_a.get("amv_profile") or {}).items()))
-    amv_b = dict(sorted((payload_b.get("amv_profile") or {}).items()))
+    amv_a = _mapping_signature(payload_a, "amv_profile")
+    amv_b = _mapping_signature(payload_b, "amv_profile")
     if amv_a != amv_b:
         mismatches.append(f"amv_profile differs: A={amv_a} vs B={amv_b}")
 
@@ -255,12 +322,18 @@ def validate_horizon_ablation_pair(
     except ValueError as exc:
         mismatches.append(f"Roster extraction error: {exc}")
 
-    seed_a = _seed_policy_signature(payload_a)
-    seed_b = _seed_policy_signature(payload_b)
-    if seed_a != seed_b:
-        mismatches.append(f"Seed policy differs: A={seed_a} vs B={seed_b}")
+    try:
+        seed_a = _seed_policy_signature(payload_a)
+        seed_b = _seed_policy_signature(payload_b)
+        if seed_a != seed_b:
+            mismatches.append(f"Seed policy differs: A={seed_a} vs B={seed_b}")
+    except ValueError as exc:
+        mismatches.append(f"Seed policy validation error: {exc}")
 
-    mismatches.extend(_check_field_parity(payload_a, payload_b))
+    try:
+        mismatches.extend(_check_field_parity(payload_a, payload_b))
+    except ValueError as exc:
+        mismatches.append(f"Contract field validation error: {exc}")
 
     return HorizonAblationPairResult(
         config_a=str(path_a),

--- a/tests/benchmark/test_validate_horizon_ablation_pair.py
+++ b/tests/benchmark/test_validate_horizon_ablation_pair.py
@@ -25,6 +25,8 @@ def _load_script_module():
 _mod = _load_script_module()
 
 _load_raw_config = _mod._load_raw_config
+_optional_int = _mod._optional_int
+_optional_seed_id = _mod._optional_seed_id
 _planner_roster = _mod._planner_roster
 _seed_policy_signature = _mod._seed_policy_signature
 _compare_planner_rosters = _mod._compare_planner_rosters
@@ -129,6 +131,23 @@ class TestComparePlannerRosters:
 class TestHorizonDiffers:
     """Horizon-difference checks."""
 
+    def test_optional_int_rejects_non_integer_values(self) -> None:
+        with pytest.raises(ValueError):
+            _optional_int(500.5)
+        with pytest.raises(ValueError):
+            _optional_int(True)
+
+    def test_missing_horizons_report_actionable_errors(self) -> None:
+        h_a, h_b, errors = _check_horizon_differs({}, {})
+        assert h_a is None
+        assert h_b is None
+        assert any("Config A is missing" in error for error in errors)
+        assert any("Config B is missing" in error for error in errors)
+
+    def test_invalid_horizons_report_actionable_errors(self) -> None:
+        _, _, errors = _check_horizon_differs({"horizon": "bad"}, {"horizon": 600})
+        assert any("Config A horizon is not a valid integer" in error for error in errors)
+
     def test_different_horizons_pass(self) -> None:
         a = {"horizon": 500}
         b = {"horizon": 600}
@@ -152,6 +171,15 @@ class TestHorizonDiffers:
 
 class TestSeedPolicyComparison:
     """Seed policy signature extraction and comparison."""
+
+    def test_optional_seed_id_preserves_zero_and_normalizes_numeric_strings(self) -> None:
+        assert _optional_seed_id(0) == 0
+        assert _optional_seed_id(" 7 ") == 7
+        assert _seed_policy_signature({"seed_policy": {"seeds": 0}})["seeds"] == [0]
+
+    def test_seed_policy_signature_handles_null_and_scalar_values(self) -> None:
+        assert _seed_policy_signature({"seed_policy": {"seeds": None}})["seeds"] == []
+        assert _seed_policy_signature({"seed_policy": {"seeds": "eval-1"}})["seeds"] == ["eval-1"]
 
     def test_identical_policies_match(self) -> None:
         payload = _make_base_payload()
@@ -188,6 +216,25 @@ class TestFieldParity:
         b["scenario_matrix"] = "configs/scenarios/other.yaml"
         errors = _check_field_parity(a, b)
         assert any("scenario_matrix" in e for e in errors)
+
+    def test_different_publication_overwrite_policy_detected(self) -> None:
+        a = _make_base_payload(500)
+        b = _make_base_payload(600)
+        a["overwrite_publication_bundle"] = False
+        b["overwrite_publication_bundle"] = True
+        errors = _check_field_parity(a, b)
+        assert any("overwrite_publication_bundle" in e for e in errors)
+
+    def test_non_mapping_contract_fields_fail_closed(self) -> None:
+        payload = _make_base_payload()
+        payload["snqi_contract"] = []
+        with pytest.raises(ValueError, match="snqi_contract must be a mapping"):
+            _check_field_parity(payload, _make_base_payload())
+
+        payload = _make_base_payload()
+        payload["amv_profile"] = "invalid"
+        with pytest.raises(ValueError, match="amv_profile must be a mapping"):
+            _check_field_parity(payload, _make_base_payload())
 
 
 class TestValidateHorizonAblationPair:
@@ -237,6 +284,23 @@ class TestValidateHorizonAblationPair:
         result = validate_horizon_ablation_pair(path_a, path_b)
         assert not result.is_valid
         assert any("identical" in m for m in result.mismatches)
+
+    def test_invalid_horizon_returns_invalid_result(self, tmp_path: pathlib.Path) -> None:
+        path_a = _write_yaml(tmp_path, "invalid.yaml", {"horizon": "bad"})
+        path_b = _write_yaml(tmp_path, "valid.yaml", {"horizon": 600})
+        result = validate_horizon_ablation_pair(path_a, path_b)
+        assert not result.is_valid
+        assert any("not a valid integer" in mismatch for mismatch in result.mismatches)
+
+    def test_non_mapping_contract_returns_invalid_result(self, tmp_path: pathlib.Path) -> None:
+        a = _make_base_payload(500)
+        b = _make_base_payload(600)
+        b["amv_profile"] = []
+        path_a = _write_yaml(tmp_path, "h500.yaml", a)
+        path_b = _write_yaml(tmp_path, "h600.yaml", b)
+        result = validate_horizon_ablation_pair(path_a, path_b)
+        assert not result.is_valid
+        assert any("Contract field validation error" in mismatch for mismatch in result.mismatches)
 
     def test_missing_file_returns_loading_error(self, tmp_path: pathlib.Path) -> None:
         result = validate_horizon_ablation_pair(

--- a/tests/benchmark/test_validate_horizon_ablation_pair.py
+++ b/tests/benchmark/test_validate_horizon_ablation_pair.py
@@ -1,0 +1,294 @@
+"""Tests for the horizon ablation pair validation script."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/validate_horizon_ablation_pair.py"
+
+
+def _load_script_module():
+    """Load the validation script as a module for testing."""
+    spec = importlib.util.spec_from_file_location("validate_horizon_ablation_pair", _SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["validate_horizon_ablation_pair"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_script_module()
+
+_load_raw_config = _mod._load_raw_config
+_planner_roster = _mod._planner_roster
+_seed_policy_signature = _mod._seed_policy_signature
+_compare_planner_rosters = _mod._compare_planner_rosters
+_check_horizon_differs = _mod._check_horizon_differs
+_check_field_parity = _mod._check_field_parity
+validate_horizon_ablation_pair = _mod.validate_horizon_ablation_pair
+HorizonAblationPairResult = _mod.HorizonAblationPairResult
+
+
+def _write_yaml(tmp_path: pathlib.Path, name: str, payload: dict) -> pathlib.Path:
+    """Write a YAML config to a temp file and return its path."""
+    path = tmp_path / name
+    path.write_text(yaml.dump(payload, default_flow_style=False), encoding="utf-8")
+    return path
+
+
+def _make_base_payload(horizon: int = 500) -> dict:
+    """Return a minimal valid campaign config payload."""
+    return {
+        "name": f"test_h{horizon}",
+        "scenario_matrix": "configs/scenarios/classic_interactions_francis2023.yaml",
+        "horizon": horizon,
+        "dt": 0.1,
+        "workers": 2,
+        "kinematics_matrix": ["differential_drive"],
+        "seed_policy": {
+            "mode": "seed-set",
+            "seed_set": "eval",
+            "seed_sets_path": "configs/benchmarks/seed_sets_v1.yaml",
+        },
+        "planners": [
+            {
+                "key": "goal",
+                "algo": "goal",
+                "planner_group": "core",
+                "benchmark_profile": "baseline-safe",
+            },
+            {
+                "key": "social_force",
+                "algo": "social_force",
+                "planner_group": "core",
+                "benchmark_profile": "baseline-safe",
+            },
+        ],
+        "snqi_contract": {"enabled": True, "enforcement": "warn"},
+        "amv_profile": {"name": "amv-paper-v1", "contract_version": "1"},
+    }
+
+
+class TestPlannerRosterExtraction:
+    """Planner roster extraction from raw config payloads."""
+
+    def test_extracts_keys_and_algos(self, tmp_path: pathlib.Path) -> None:
+        payload = _make_base_payload()
+        roster = _planner_roster(payload)
+        assert len(roster) == 2
+        assert roster[0]["key"] == "goal"
+        assert roster[0]["algo"] == "goal"
+
+    def test_raises_on_missing_planners(self) -> None:
+        with pytest.raises(ValueError, match="no 'planners' list"):
+            _planner_roster({})
+
+    def test_raises_on_empty_planners(self) -> None:
+        with pytest.raises(ValueError, match="no 'planners' list"):
+            _planner_roster({"planners": []})
+
+
+class TestComparePlannerRosters:
+    """Planner roster comparison logic."""
+
+    def test_identical_rosters_match(self) -> None:
+        roster = [{"key": "goal", "algo": "goal", "algo_config": ""}]
+        assert _compare_planner_rosters(roster, roster) == []
+
+    def test_different_keys_detected(self) -> None:
+        a = [{"key": "goal", "algo": "goal", "algo_config": ""}]
+        b = [{"key": "orca", "algo": "orca", "algo_config": ""}]
+        errors = _compare_planner_rosters(a, b)
+        assert any("only in config A" in e for e in errors)
+        assert any("only in config B" in e for e in errors)
+
+    def test_different_algo_config_detected(self) -> None:
+        a = [{"key": "ppo", "algo": "ppo", "algo_config": "configs/a.yaml"}]
+        b = [{"key": "ppo", "algo": "ppo", "algo_config": "configs/b.yaml"}]
+        errors = _compare_planner_rosters(a, b)
+        assert any("algo_config differs" in e for e in errors)
+
+    def test_different_order_detected(self) -> None:
+        a = [
+            {"key": "goal", "algo": "goal", "algo_config": ""},
+            {"key": "orca", "algo": "orca", "algo_config": ""},
+        ]
+        b = [
+            {"key": "orca", "algo": "orca", "algo_config": ""},
+            {"key": "goal", "algo": "goal", "algo_config": ""},
+        ]
+        errors = _compare_planner_rosters(a, b)
+        assert any("order differs" in e for e in errors)
+
+
+class TestHorizonDiffers:
+    """Horizon-difference checks."""
+
+    def test_different_horizons_pass(self) -> None:
+        a = {"horizon": 500}
+        b = {"horizon": 600}
+        h_a, h_b, errors = _check_horizon_differs(a, b)
+        assert h_a == 500
+        assert h_b == 600
+        assert errors == []
+
+    def test_identical_horizons_fail(self) -> None:
+        a = {"horizon": 500}
+        b = {"horizon": 500}
+        _, _, errors = _check_horizon_differs(a, b)
+        assert any("identical" in e for e in errors)
+
+    def test_scenario_horizons_flagged(self) -> None:
+        a = {"scenario_horizons": "configs/policy_search/scenario_horizons_h500.yaml"}
+        b = {"horizon": 600}
+        _, _, errors = _check_horizon_differs(a, b)
+        assert any("scenario_horizons" in e for e in errors)
+
+
+class TestSeedPolicyComparison:
+    """Seed policy signature extraction and comparison."""
+
+    def test_identical_policies_match(self) -> None:
+        payload = _make_base_payload()
+        sig_a = _seed_policy_signature(payload)
+        sig_b = _seed_policy_signature(payload)
+        assert sig_a == sig_b
+
+    def test_different_seed_sets_detected(self) -> None:
+        a = _make_base_payload()
+        b = _make_base_payload()
+        b["seed_policy"]["seed_set"] = "paper_eval_s30"
+        assert _seed_policy_signature(a) != _seed_policy_signature(b)
+
+
+class TestFieldParity:
+    """Execution-relevant field parity checks."""
+
+    def test_identical_payloads_match(self) -> None:
+        a = _make_base_payload(500)
+        b = _make_base_payload(600)
+        errors = _check_field_parity(a, b)
+        assert errors == []
+
+    def test_different_dt_detected(self) -> None:
+        a = _make_base_payload(500)
+        b = _make_base_payload(600)
+        b["dt"] = 0.2
+        errors = _check_field_parity(a, b)
+        assert any("dt" in e for e in errors)
+
+    def test_different_scenario_matrix_detected(self) -> None:
+        a = _make_base_payload(500)
+        b = _make_base_payload(600)
+        b["scenario_matrix"] = "configs/scenarios/other.yaml"
+        errors = _check_field_parity(a, b)
+        assert any("scenario_matrix" in e for e in errors)
+
+
+class TestValidateHorizonAblationPair:
+    """End-to-end validation of config pairs."""
+
+    def test_valid_pair_passes(self, tmp_path: pathlib.Path) -> None:
+        path_a = _write_yaml(tmp_path, "h500.yaml", _make_base_payload(500))
+        path_b = _write_yaml(tmp_path, "h600.yaml", _make_base_payload(600))
+        result = validate_horizon_ablation_pair(path_a, path_b)
+        assert result.is_valid
+        assert result.horizon_a == 500
+        assert result.horizon_b == 600
+        assert result.mismatches == []
+
+    def test_mismatched_roster_fails(self, tmp_path: pathlib.Path) -> None:
+        a = _make_base_payload(500)
+        b = _make_base_payload(600)
+        b["planners"].append(
+            {
+                "key": "ppo",
+                "algo": "ppo",
+                "planner_group": "experimental",
+                "benchmark_profile": "experimental",
+            }
+        )
+        path_a = _write_yaml(tmp_path, "h500.yaml", a)
+        path_b = _write_yaml(tmp_path, "h600.yaml", b)
+        result = validate_horizon_ablation_pair(path_a, path_b)
+        assert not result.is_valid
+        assert any("Planners only" in m for m in result.mismatches)
+
+    def test_mismatched_seed_fails(self, tmp_path: pathlib.Path) -> None:
+        a = _make_base_payload(500)
+        b = _make_base_payload(600)
+        b["seed_policy"]["seed_set"] = "paper_eval_s30"
+        path_a = _write_yaml(tmp_path, "h500.yaml", a)
+        path_b = _write_yaml(tmp_path, "h600.yaml", b)
+        result = validate_horizon_ablation_pair(path_a, path_b)
+        assert not result.is_valid
+        assert any("Seed policy" in m for m in result.mismatches)
+
+    def test_same_horizon_fails(self, tmp_path: pathlib.Path) -> None:
+        a = _make_base_payload(500)
+        b = _make_base_payload(500)
+        path_a = _write_yaml(tmp_path, "h500a.yaml", a)
+        path_b = _write_yaml(tmp_path, "h500b.yaml", b)
+        result = validate_horizon_ablation_pair(path_a, path_b)
+        assert not result.is_valid
+        assert any("identical" in m for m in result.mismatches)
+
+    def test_missing_file_returns_loading_error(self, tmp_path: pathlib.Path) -> None:
+        result = validate_horizon_ablation_pair(
+            tmp_path / "missing.yaml", tmp_path / "also_missing.yaml"
+        )
+        assert not result.is_valid
+        assert any("loading error" in m.lower() for m in result.mismatches)
+
+    def test_to_payload_roundtrip(self, tmp_path: pathlib.Path) -> None:
+        path_a = _write_yaml(tmp_path, "h500.yaml", _make_base_payload(500))
+        path_b = _write_yaml(tmp_path, "h600.yaml", _make_base_payload(600))
+        result = validate_horizon_ablation_pair(path_a, path_b)
+        payload = result.to_payload()
+        assert payload["schema_version"] == "horizon_ablation_pair_validation.v1"
+        assert payload["is_valid"] is True
+        assert payload["horizon_a"] == 500
+        assert payload["horizon_b"] == 600
+
+
+class TestActualConfigPair:
+    """Validate the actual issue #5409 configs against each other."""
+
+    def test_issue_5409_configs_are_valid_pair(self) -> None:
+        h500 = REPO_ROOT / "configs/benchmarks/issue_5409_horizon_ablation_h500.yaml"
+        h600 = REPO_ROOT / "configs/benchmarks/issue_5409_horizon_ablation_h600.yaml"
+        if not h500.exists() or not h600.exists():
+            pytest.skip("Issue #5409 configs not present in this checkout")
+        result = validate_horizon_ablation_pair(h500, h600)
+        assert result.is_valid, f"Mismatches: {result.mismatches}"
+
+    def test_issue_5409_configs_have_correct_horizons(self) -> None:
+        h500 = REPO_ROOT / "configs/benchmarks/issue_5409_horizon_ablation_h500.yaml"
+        h600 = REPO_ROOT / "configs/benchmarks/issue_5409_horizon_ablation_h600.yaml"
+        if not h500.exists() or not h600.exists():
+            pytest.skip("Issue #5409 configs not present in this checkout")
+        result = validate_horizon_ablation_pair(h500, h600)
+        assert result.horizon_a == 500
+        assert result.horizon_b == 600
+
+    def test_issue_5409_configs_have_12_planners(self) -> None:
+        h500 = REPO_ROOT / "configs/benchmarks/issue_5409_horizon_ablation_h500.yaml"
+        if not h500.exists():
+            pytest.skip("Issue #5409 config not present in this checkout")
+        payload = _load_raw_config(h500)
+        roster = _planner_roster(payload)
+        assert len(roster) == 12
+
+    def test_issue_5409_configs_use_eval_seeds(self) -> None:
+        h500 = REPO_ROOT / "configs/benchmarks/issue_5409_horizon_ablation_h500.yaml"
+        if not h500.exists():
+            pytest.skip("Issue #5409 config not present in this checkout")
+        payload = _load_raw_config(h500)
+        seed_sig = _seed_policy_signature(payload)
+        assert seed_sig["mode"] == "seed-set"
+        assert seed_sig["seed_set"] == "eval"


### PR DESCRIPTION
## What

Roster-matched, seed-matched horizon-ablation config pair (h500 vs h600) with a 12-arm planner
roster and the `eval` seed set. Everything is held constant except the campaign-level horizon.

Also adds `scripts/benchmark/validate_horizon_ablation_pair.py`, a fail-closed validator for planner
roster, seed policy, scenario matrix, comparability mapping, SNQI/AMV contracts, publication
settings, and all other execution-relevant fields.

## Validation contract

- Horizons must be present, positive, strict integers, and different; per-scenario horizons are
  rejected.
- Null/scalar/falsy seed values are normalized explicitly without `or []` coercion.
- Non-mapping `snqi_contract` and `amv_profile` values are invalid rather than silently treated as
  empty mappings.
- `overwrite_publication_bundle` is included in execution-field parity.
- New tests resolve the script through `Path(__file__).resolve().parents[2]`.

## Validation

```text
uv run pytest tests/benchmark/test_validate_horizon_ablation_pair.py -q
34 passed
uv run ruff check scripts/benchmark/validate_horizon_ablation_pair.py tests/benchmark/test_validate_horizon_ablation_pair.py
uv run ruff format --check scripts/benchmark/validate_horizon_ablation_pair.py tests/benchmark/test_validate_horizon_ablation_pair.py
uv run python scripts/benchmark/validate_horizon_ablation_pair.py \
  configs/benchmarks/issue_5409_horizon_ablation_h500.yaml \
  configs/benchmarks/issue_5409_horizon_ablation_h600.yaml --json
```

The actual pair validates as:

```json
{"horizon_a": 500, "horizon_b": 600, "is_valid": true, "mismatch_count": 0}
```

## Scope and claim boundary

This is config plus validation only. It does not submit, run, or interpret a campaign. The configs
are `paper_facing: false` and `diagnostic-only` until both campaigns complete; no benchmark, paper,
or dissertation claim follows from this PR. Campaign execution and the guarded-PPO availability
preflight remain sequencing work on parent issue #5409.

Refs #5409

Target claim/blocker: comparability-validator integrity; comparator: the two tracked #5409 configs;
evidence tier: executable config-validation smoke; result classification: diagnostic-only; decision
rule: reject every mismatch or unverifiable contract field; synthesis target: #5409.
