### PR TITLE
ci(#5424): classify main-CI hold reason — distinguish stale/cancelled from real red

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* **issue #5424 main-CI hold reason: distinguish a stale/cancelled signal from a real red.**
+  `scripts/dev/main_ci_is_green.py` now classifies the deciding run's conclusion into
+  `green` / `red` / `stale` via a new `classify()` helper and surfaces it in both the human line
+  and a new `--json` output (`{is_green, reason, conclusion, run_id, head_sha}`). A `red` hold
+  (`failure`) means main regressed and needs an unbreak-main fix; a `stale` hold (`cancelled`,
+  `timed_out`, `startup_failure`, ...) means the run was aborted/never-ran and only needs a fresh
+  CI run — "a baseline gate blocker, not evidence that the held PRs themselves regress main". The
+  fail-closed merge-hold semantics are unchanged: only `success` exits 0 (green); every other
+  signal, unknown values included, holds.
+
 * **Single-source package version from the git tag (kills version drift).** `pyproject.toml` no longer hardcodes a version; the package version is derived automatically from the git tag/release line via `hatch-vcs` (release tags `X.Y.Z`, release-candidate tags `rcX.Y.Z`, PEP 440 dev fallback `0.0.3.dev0` for untagged builds). `robot_sf.__version__` now resolves from the build-time `_version.py` (or installed metadata). `CITATION.cff` is aligned to the latest full release tag (`0.0.2`). A new `scripts/dev/check_version_alignment.py` guards the three version axes; it runs gating on tag pushes (`release-functional-badge` workflow) and advisory on every CI run (`ci_driver.sh` lint phase). Previously the three axes had drifted: tag `rc0.0.3`, `pyproject` `2.0.0`, `CITATION` `benchmark-protocol-0.1.0`.
 
 * **issue #5228 xdist memory-diagnostic robustness.** Three residual gaps from the

--- a/scripts/dev/main_ci_is_green.py
+++ b/scripts/dev/main_ci_is_green.py
@@ -18,6 +18,20 @@ pure decision function filters defensively on top so the rule is unit-tested.
 Exit code: 0 == green (latest completed CI run on main concluded ``success``),
 1 == not green (red, or no completed run to judge from). Prints the run id and
 conclusion it decided from.
+
+Not-green is not one thing (issue #5424). A merge hold must fail closed on any
+non-``success`` signal, but the *reason* it holds is operationally different:
+
+- ``red``   — a completed run evaluated main's code and it FAILED. Main
+  regressed; the cure is an unbreak-main fix, and no PR may merge over it.
+- ``stale`` — the deciding run was aborted / skipped / never really ran the
+  checks (``cancelled``, ``timed_out``, ``startup_failure``, ...). It still
+  holds the gate, but it is NOT evidence that main regressed — as issue #5424
+  put it, "a baseline gate blocker, not evidence that the held PRs themselves
+  regress main". The cure is a fresh CI run, not a code fix.
+
+``classify()`` surfaces that distinction (and ``--json`` makes it machine
+readable) without changing the fail-closed exit code: only ``success`` is green.
 """
 
 from __future__ import annotations
@@ -30,6 +44,34 @@ from typing import Any
 
 DEFAULT_REPO = "ll7/robot_sf_ll7"
 DEFAULT_WORKFLOW = "CI"
+
+# A completed run's ``conclusion`` falls into exactly one bucket:
+#   green  -> the run evaluated main and it passed (the only mergeable signal).
+#   red    -> the run evaluated main and it FAILED: a real regression.
+#   stale  -> the run was aborted / skipped / never ran the checks. Not a
+#             verdict on main's code; holds the gate but calls for a re-run.
+GREEN_CONCLUSIONS = frozenset({"success"})
+RED_CONCLUSIONS = frozenset({"failure"})
+
+
+def classify(conclusion: str | None) -> str:
+    """Bucket a completed run's ``conclusion`` into ``green`` / ``red`` / ``stale``.
+
+    Only ``success`` is ``green`` and only ``failure`` is a ``red`` regression
+    verdict. Everything else a completed run can report — ``cancelled``,
+    ``timed_out``, ``startup_failure``, ``skipped``, ``neutral``,
+    ``action_required``, or an unknown/``None`` value — is ``stale``: the run
+    did not deliver a clean verdict on main's code. Falling through to ``stale``
+    (rather than ``red``) for unknown strings keeps the human framing honest —
+    an aborted run is not a code regression — while the caller still fails
+    closed, since ``stale`` is not ``green``.
+    """
+    text = str(conclusion)
+    if text in GREEN_CONCLUSIONS:
+        return "green"
+    if text in RED_CONCLUSIONS:
+        return "red"
+    return "stale"
 
 
 def _gh(args: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess:
@@ -108,33 +150,62 @@ def fetch_runs(
     return data
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     """CLI entry: exit 0 if main CI is green, 1 otherwise."""
     ap = argparse.ArgumentParser(description="Is main CI green (latest completed run)?")
     ap.add_argument("--repo", default=DEFAULT_REPO)
     ap.add_argument("--workflow", default=DEFAULT_WORKFLOW)
     ap.add_argument("--limit", type=int, default=5)
     ap.add_argument("--quiet", action="store_true", help="suppress the human line")
-    args = ap.parse_args()
+    ap.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="emit a machine-readable {is_green, reason, conclusion, run_id, head_sha} object",
+    )
+    args = ap.parse_args(argv)
 
     try:
         runs = fetch_runs(args.repo, args.workflow, args.limit)
     except (RuntimeError, json.JSONDecodeError) as exc:
         # Fail closed: an unreadable signal is treated as NOT green so a merge
         # hold errs toward holding, never toward merging on unknown state.
-        if not args.quiet:
+        if args.as_json:
+            print(json.dumps({"is_green": False, "reason": "unknown", "error": str(exc)}))
+        elif not args.quiet:
             print(f"main CI status UNKNOWN ({exc}) -> treated as not-green", file=sys.stderr)
         return 1
 
     is_green, run = decide(runs)
-    if not args.quiet:
+    # reason distinguishes the two ways a hold happens: a real ``red`` regression
+    # versus a ``stale`` (cancelled/aborted) signal that only needs a re-run.
+    reason = "no-run" if run is None else classify(run.get("conclusion"))
+
+    if args.as_json:
+        print(
+            json.dumps(
+                {
+                    "is_green": is_green,
+                    "reason": reason,
+                    "conclusion": None if run is None else run.get("conclusion"),
+                    "run_id": None if run is None else run.get("databaseId"),
+                    "head_sha": None if run is None else run.get("headSha"),
+                }
+            )
+        )
+    elif not args.quiet:
         if run is None:
-            print("main CI: no completed run found -> not green")
+            print("main CI: no completed run found -> not green [no-run: nothing to judge from]")
         else:
+            hint = {
+                "green": "",
+                "red": " [red: main regressed; needs an unbreak-main fix]",
+                "stale": " [stale: run aborted/skipped, not a main regression; re-run CI]",
+            }[reason]
             print(
                 f"main CI: {run.get('conclusion')} "
                 f"(run {run.get('databaseId')}, {str(run.get('headSha'))[:9]}) "
-                f"-> {'GREEN' if is_green else 'NOT GREEN'}"
+                f"-> {'GREEN' if is_green else 'NOT GREEN'}{hint}"
             )
     return 0 if is_green else 1
 

--- a/scripts/dev/main_ci_is_green.py
+++ b/scripts/dev/main_ci_is_green.py
@@ -66,10 +66,9 @@ def classify(conclusion: str | None) -> str:
     an aborted run is not a code regression — while the caller still fails
     closed, since ``stale`` is not ``green``.
     """
-    text = str(conclusion)
-    if text in GREEN_CONCLUSIONS:
+    if conclusion in GREEN_CONCLUSIONS:
         return "green"
-    if text in RED_CONCLUSIONS:
+    if conclusion in RED_CONCLUSIONS:
         return "red"
     return "stale"
 

--- a/tests/dev/test_main_ci_is_green.py
+++ b/tests/dev/test_main_ci_is_green.py
@@ -13,7 +13,7 @@ import subprocess
 import pytest
 
 from scripts.dev import main_ci_is_green
-from scripts.dev.main_ci_is_green import decide, fetch_runs, latest_completed_run
+from scripts.dev.main_ci_is_green import classify, decide, fetch_runs, latest_completed_run
 
 
 def _run(rid: int, status: str, conclusion: str | None, created: str) -> dict:
@@ -142,3 +142,121 @@ def test_gh_oserror_becomes_a_failed_process(monkeypatch: pytest.MonkeyPatch) ->
 
     assert proc.returncode == 127
     assert "not executable" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# classify(): distinguish a real red regression from a stale/aborted signal.
+# This is the #5424 distinction — a cancelled latest run holds the gate but is
+# "not evidence that the held PRs themselves regress main". It must never change
+# the fail-closed decision: only ``success`` is green.
+# ---------------------------------------------------------------------------
+
+
+def test_classify_success_is_green() -> None:
+    """Only ``success`` classifies as green."""
+    assert classify("success") == "green"
+
+
+def test_classify_failure_is_red() -> None:
+    """A ``failure`` conclusion is a real red regression verdict."""
+    assert classify("failure") == "red"
+
+
+@pytest.mark.parametrize(
+    "conclusion",
+    ["cancelled", "timed_out", "startup_failure", "skipped", "neutral", "action_required"],
+)
+def test_classify_aborted_conclusions_are_stale(conclusion: str) -> None:
+    """Aborted / skipped / never-ran conclusions are stale, not red."""
+    assert classify(conclusion) == "stale"
+
+
+@pytest.mark.parametrize("conclusion", [None, "some_new_github_status"])
+def test_classify_unknown_falls_through_to_stale(conclusion: str | None) -> None:
+    """Unknown/None conclusions fall through to stale, never silently to green/red."""
+    assert classify(conclusion) == "stale"
+
+
+def test_classify_cancelled_matches_the_5424_signal() -> None:
+    """The exact #5424 signal (cancelled) is stale while decide() stays not-green."""
+    runs = [_run(1, "completed", "cancelled", "2026-07-12T12:00:00Z")]
+    is_green, run = decide(runs)
+    assert is_green is False
+    assert classify(run["conclusion"]) == "stale"
+
+
+def test_classify_reason_is_independent_of_green_decision() -> None:
+    """Every non-success completed conclusion stays not-green regardless of reason."""
+    for conclusion, expected in [
+        ("success", "green"),
+        ("failure", "red"),
+        ("cancelled", "stale"),
+        ("timed_out", "stale"),
+    ]:
+        is_green, run = decide([_run(1, "completed", conclusion, "2026-07-12T12:00:00Z")])
+        assert classify(run["conclusion"]) == expected
+        assert is_green is (expected == "green")
+
+
+# ---------------------------------------------------------------------------
+# main() CLI: --json surfaces the reason machine-readably; the human line names
+# it. Exit code stays fail-closed (0 only when green).
+# ---------------------------------------------------------------------------
+
+
+def _patch_runs(monkeypatch: pytest.MonkeyPatch, runs: list[dict]) -> None:
+    monkeypatch.setattr(main_ci_is_green, "fetch_runs", lambda *_a, **_k: runs)
+
+
+def test_cli_json_reports_stale_and_holds(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A cancelled latest run: exit 1 (hold) with reason ``stale`` in JSON."""
+    import json as _json
+
+    _patch_runs(monkeypatch, [_run(1, "completed", "cancelled", "2026-07-12T12:00:00Z")])
+    rc = main_ci_is_green.main(["--json"])
+    payload = _json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["is_green"] is False
+    assert payload["reason"] == "stale"
+    assert payload["conclusion"] == "cancelled"
+
+
+def test_cli_json_reports_red(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A failed latest run: exit 1 with reason ``red``."""
+    import json as _json
+
+    _patch_runs(monkeypatch, [_run(2, "completed", "failure", "2026-07-12T12:00:00Z")])
+    rc = main_ci_is_green.main(["--json"])
+    payload = _json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["reason"] == "red"
+
+
+def test_cli_json_reports_green(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A successful latest run: exit 0 with reason ``green``."""
+    import json as _json
+
+    _patch_runs(monkeypatch, [_run(3, "completed", "success", "2026-07-12T12:00:00Z")])
+    rc = main_ci_is_green.main(["--json"])
+    payload = _json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["is_green"] is True
+    assert payload["reason"] == "green"
+
+
+def test_cli_human_line_names_the_stale_reason(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The human line calls a cancelled hold ``stale`` and suggests a re-run."""
+    _patch_runs(monkeypatch, [_run(1, "completed", "cancelled", "2026-07-12T12:00:00Z")])
+    rc = main_ci_is_green.main([])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "NOT GREEN" in out
+    assert "stale" in out and "re-run" in out


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** `scripts/dev/main_ci_is_green.py` now classifies the deciding main-CI run's `conclusion` into `green` / `red` / `stale` (new `classify()` helper), surfaced in the human line and a new `--json` output.
- **Why now:** Issue #5424 is a gate hold caused by a *cancelled* latest completed main-CI run. The checker held (correctly, fail-closed) but reported the cancelled hold identically to a real regression — so an operator could not tell "main regressed, fix it" from "the run was aborted, re-run CI". The issue itself says it is "a baseline gate blocker, not evidence that the held PRs themselves regress main"; this makes that distinction legible.
- **Claim boundary:** diagnostic/tooling change to the merge-hold *reason* signal. No benchmark/metric/schema semantics touched. Merge-hold decision is **unchanged**: only `success` exits 0 (green); every other conclusion, unknown values included, exits 1 (hold).
- **Required validation:** `uv run python -m pytest tests/dev/test_main_ci_is_green.py -q` → **27 passed** (16 pre-existing + 11 new). `ruff check`/`ruff format` clean. Live CLI reproduces the exact #5424 signal (below).
- **Remaining blocker:** the issue's operational acceptance ("a later completed main CI run concludes `success`") is satisfied by the next green main run, not by this PR — that is out of scope for a code change and cannot be forced here. This PR makes the hold *legible and self-explaining* while it lasts.

## Contract delta

- **New helper:** `classify(conclusion) -> "green" | "red" | "stale"`. `success`→green; `failure`→red; `cancelled`/`timed_out`/`startup_failure`/`skipped`/`neutral`/`action_required`/unknown/`None`→stale.
- **New CLI flag:** `--json` emits `{is_green, reason, conclusion, run_id, head_sha}` (reason is `green`/`red`/`stale`/`no-run`, or `unknown` on the fail-closed fetch-error path). Human line gains a `[red: ...]` / `[stale: ...]` hint.
- **Signature:** `main()` → `main(argv=None)` so the CLI is unit-testable; behavior for the real `argv` path is identical.
- **Compatibility:** exit codes and existing stdout prefix (`main CI: <conclusion> (run ..., <sha>) -> GREEN/NOT GREEN`) are preserved; the hint is an additive suffix. All prior tests pass unchanged.

## Live reproduction of the #5424 signal

```
$ python scripts/dev/main_ci_is_green.py --json
{"is_green": false, "reason": "stale", "conclusion": "cancelled", "run_id": 29197955994, "head_sha": "91fd8cbe7168d1a54ec18b1fdea48decc0097cb6"}

$ python scripts/dev/main_ci_is_green.py
main CI: cancelled (run 29197955994, 91fd8cbe7) -> NOT GREEN [stale: run aborted/skipped, not a main regression; re-run CI]
```

Run `29197955994` and sha `91fd8cbe7` are exactly the run/check cited in the issue body.

## Validation

| Command | Result |
| --- | --- |
| `uv run python -m pytest tests/dev/test_main_ci_is_green.py -q` | 27 passed |
| `ruff check scripts/dev/main_ci_is_green.py tests/dev/test_main_ci_is_green.py` | All checks passed |
| `ruff format ... ` | 2 files left unchanged |
| Live CLI `--json` / human line | reproduces #5424 signal, classifies `stale`, exits 1 |

## State propagation

`comment_issue_or_pr` is not authorized for this worker, so no issue comment is posted; this is a low-churn issue (0 prior PRs). State lives in this PR body. No transient queue-routing state is encoded in tracked files.

## Issue

Refs #5424 — this PR does not by itself satisfy the issue's operational acceptance (a later `success` main run), so it is **not** a `Closes`. Remaining:

- [ ] A later completed main CI run concludes `success` (operational; happens on next green main run).
- [x] The hold reason is legible so the next gate pass can route stale-vs-red correctly.

<details>
<summary>Governance / scope notes</summary>

- Out of scope, explicitly not done: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no merge.
- Fragmentation guard (6c): this is a progression slice adding a nameable new capability (a `stale`-vs-`red` hold-reason classification + `--json` gate signal), not a micro-guard; recent `main_ci_is_green` PRs (#5386/#5388) were for #5385, not #5424.
- Validation floor: none specified; used repo test + ruff gates for a `scripts/dev` tooling change.
- After this PR opens, Claude Code on `imech156-u` owns the PR gate, improvement cycle, and merge authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
