### PR TITLE
Issue #5419: wire the #4142 DPCBF plan into an authorization-gated episode executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* **issue #5419 authorization-gated DPCBF dense episode executor.** `execute_run_plan()` in
-  `robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py` is now a bounded, explicitly authorized
-  **local** episode executor instead of an always-raise gate. With the exact public
-  authorization ID (`RSF-DPCBF-DENSE-20260712`, via `--authorization`) it reuses the canonical
-  `run_batch` once per resolved arm in packet order and writes a machine-readable execution
-  manifest (`robot_sf.issue_4142_dpcbf_dense_comparison_execution.v1`) with schema versions, git
-  SHA/dirty flag, effective arguments, per-arm statuses, timestamps, and overall completeness. A
-  missing/wrong ID fails closed **before any output file is written**; a repeated run resumes
-  only on matching packet/config/git provenance and otherwise fails closed. Bounded execution
-  inputs (base seed, repeats, horizon, `dt`, worker cap, video-off, resume) live in the packet's
-  new `execution` block; the packet's canonical command now points at the real issue-scoped CLI.
-  This runs local episodes only — no Slurm/GPU submission — and makes no safety-performance or
-  collision-reduction claim.
+* **issue #5419 authorization-gated DPCBF dense episode executor.** `execute_run_plan()` now
+  runs bounded local arms through `run_batch` only with the exact public authorization ID. It
+  writes an atomic, checkpointed execution manifest with effective arguments, dirty-state and
+  content-bound provenance, and explicit caveat statuses; orphan output, malformed input, and
+  mismatched resume state fail closed. Packet bounds and the real issue-scoped CLI are recorded.
+  No Slurm/GPU submission or safety-performance claim is made.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* **issue #5419 authorization-gated DPCBF dense episode executor.** `execute_run_plan()` in
+  `robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py` is now a bounded, explicitly authorized
+  **local** episode executor instead of an always-raise gate. With the exact public
+  authorization ID (`RSF-DPCBF-DENSE-20260712`, via `--authorization`) it reuses the canonical
+  `run_batch` once per resolved arm in packet order and writes a machine-readable execution
+  manifest (`robot_sf.issue_4142_dpcbf_dense_comparison_execution.v1`) with schema versions, git
+  SHA/dirty flag, effective arguments, per-arm statuses, timestamps, and overall completeness. A
+  missing/wrong ID fails closed **before any output file is written**; a repeated run resumes
+  only on matching packet/config/git provenance and otherwise fails closed. Bounded execution
+  inputs (base seed, repeats, horizon, `dt`, worker cap, video-off, resume) live in the packet's
+  new `execution` block; the packet's canonical command now points at the real issue-scoped CLI.
+  This runs local episodes only — no Slurm/GPU submission — and makes no safety-performance or
+  collision-reduction claim.
+
 ### Fixed
 
 * **issue #5340 main CI regression from unconditional `spaces.Sequence` leaf.** PRs #5335

--- a/configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml
+++ b/configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml
@@ -8,7 +8,7 @@
 schema_version: robot_sf.issue_4142_dpcbf_dense_comparison.v1
 # Canonical run command, mirrored from the comment above as a structured field so the
 # readiness preflight can surface it verbatim. It is the real issue-scoped executor CLI
-# (#5419): the generic `benchmark.cli run` never accepted this packet's --config form.
+# (#5419): the generic benchmark CLI does not accept this packet invocation.
 # Execution is authorization-gated (see robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py).
 canonical_command: uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py --execute --authorization RSF-DPCBF-DENSE-20260712
 # Fixed bounded execution inputs for the local three-arm run. Deliberately small: a bounded

--- a/configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml
+++ b/configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml
@@ -2,14 +2,26 @@
 #
 # Claim boundary: predeclared diagnostic comparison inputs only. Running the
 # full dense dynamic-obstacle campaign, Slurm/GPU submission, and any
-# paper-facing safety-performance claim are out of scope for this PR.
-# Canonical invocation: `uv run python -m robot_sf.benchmark.cli run --config configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml`.
+# paper-facing safety-performance claim are out of scope. The issue-scoped executor
+# (#5419) runs bounded LOCAL episodes only and only with the exact authorization ID.
+# Canonical invocation: `uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py --execute --authorization RSF-DPCBF-DENSE-20260712`.
 schema_version: robot_sf.issue_4142_dpcbf_dense_comparison.v1
 # Canonical run command, mirrored from the comment above as a structured field so the
-# readiness preflight can surface it verbatim. Executing it stays out of scope here; a
-# packet-consuming runner for this schema is a declared downstream gate (see the readiness
-# surface robot_sf/benchmark/issue_4142_dpcbf_dense_readiness.py).
-canonical_command: uv run python -m robot_sf.benchmark.cli run --config configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml
+# readiness preflight can surface it verbatim. It is the real issue-scoped executor CLI
+# (#5419): the generic `benchmark.cli run` never accepted this packet's --config form.
+# Execution is authorization-gated (see robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py).
+canonical_command: uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py --execute --authorization RSF-DPCBF-DENSE-20260712
+# Fixed bounded execution inputs for the local three-arm run. Deliberately small: a bounded
+# diagnostic runtime comparison, never a benchmark-grade campaign. video stays off so no large
+# artifacts are produced. Out-of-bounds overrides fail closed in build_run_plan.
+execution:
+  base_seed: 0
+  repeats: 3
+  horizon: 100
+  dt: 0.1
+  workers: 1
+  video_enabled: false
+  resume: true
 scenario_manifest: configs/scenarios/sets/issue_4142_dense_dynamic_cbf_v1.yaml
 algorithm: prediction_mpc_cv
 algorithm_configs:

--- a/docs/context/issue_4142_dpcbf_dense_pipeline.md
+++ b/docs/context/issue_4142_dpcbf_dense_pipeline.md
@@ -23,6 +23,7 @@ fail-closed, execution-gated pipeline built from one predeclared packet.
 | Packet | `configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml` | — | `robot_sf.issue_4142_dpcbf_dense_comparison.v1` | #4142 |
 | Readiness | `robot_sf/benchmark/issue_4142_dpcbf_dense_readiness.py` | packet | `issue-4142-dpcbf-dense-readiness.v1` | #4299 |
 | Run planner | `robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py` | packet (gated on readiness) | `robot_sf.issue_4142_dpcbf_dense_comparison_plan.v1` | #4318 |
+| Executor | `robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py` (`execute_run_plan`) | resolved plan + authorization ID | `robot_sf.issue_4142_dpcbf_dense_comparison_execution.v1` | #5419 |
 | Summarizer | `robot_sf/benchmark/issue_4142_dpcbf_dense_summary.py` | resolved run plan | `robot_sf.issue_4142_dpcbf_dense_comparison_summary.v1` | #4345 |
 
 Per-stage context notes: [`issue_4142_dpcbf_dense_readiness.md`](issue_4142_dpcbf_dense_readiness.md),
@@ -46,26 +47,59 @@ this slice binds the three merged modules with the one contract they were missin
   (guarding against a future re-hardcoded copy that drifts), and confirms execution stays
   authorization-gated across the whole pipeline.
 
+## What #5419 adds: the authorization-gated local executor
+
+PR #5419 turns `execute_run_plan()` from an always-raise gate into a bounded, explicitly
+authorized **local episode executor**:
+
+- **Fixed bounded execution inputs.** The packet gained an optional `execution` block (base
+  seed, repeats, horizon, `dt`, worker cap, video-off, resume policy) with fixed defaults;
+  out-of-bounds overrides fail closed in `build_run_plan`. This keeps the run a bounded
+  diagnostic comparison, never a benchmark-grade campaign.
+- **In-process executor.** With the exact public authorization ID, the executor reuses the
+  canonical `robot_sf.benchmark.runner.run_batch` once per resolved arm, in packet order, each
+  pinned to the shared scenario manifest and that arm's distinct algorithm config, writing the
+  planned per-arm JSONL.
+- **Authorization gate.** `execute_run_plan(plan, authorization=...)` fails closed with
+  `DenseComparisonExecutionGatedError` unless `authorization == "RSF-DPCBF-DENSE-20260712"`. A
+  missing/boolean/env/TTY value or a bare `--execute` flag is insufficient and **no output
+  files are created**.
+- **Execution manifest** (`robot_sf.issue_4142_dpcbf_dense_comparison_execution.v1`): packet/
+  plan schema versions, authorization ID, git SHA + dirty flag, effective arguments, per-arm
+  output paths/statuses, start/end timestamps, and overall completeness. A failing arm stays a
+  visible caveat and blocks an overall `complete` status; later arms keep their true status.
+- **Provenance-safe resume.** A repeated invocation resumes only when the on-disk manifest's
+  provenance key (packet/plan schema, algorithm, per-arm configs, execution inputs, git SHA)
+  matches; otherwise it fails closed with `DenseComparisonProvenanceMismatchError` rather than
+  mixing incompatible artifacts.
+
+The executor is local-only: it submits no Slurm/GPU job and knows nothing about `sbatch`, SSH,
+tmux, or queue tooling. The packet's canonical command now points at the real issue-scoped CLI
+(`scripts/tools/run_issue_4142_dpcbf_dense_comparison.py --execute --authorization ...`); the
+generic `benchmark.cli run` never accepted the packet's `--config` form.
+
 ## Integration status
 
-- **Remaining (intentional, fail-closed):** running the three-arm dense comparison — episodes,
-  Slurm/GPU — is out of scope for every slice. `execute_run_plan()` always raises
-  `DenseComparisonExecutionGatedError`; the summarizer reports `results_incomplete` while no
-  authorized artifacts exist. This is the designed gated state, not a defect.
-- **Remaining (new):** none. This slice adds no new runtime behavior and no new gate.
-- **Blocked-on:** explicit human/Slurm authorization for a benchmark-grade campaign.
+- **Delivered (new):** the authorization-gated local executor + execution manifest + provenance
+  -safe resume (#5419), proven by fail-closed contract tests and one real-`run_batch` smoke on a
+  reduced, test-only fixture (no performance claim).
+- **Remaining (intentional):** an *authorized, full-scale* local or campaign run of the tracked
+  `prediction_mpc_cv` packet is not performed here; the summarizer stays `results_incomplete`
+  until authorized per-arm JSONL exists under `output/issue_4142_dpcbf_dense/`.
+- **Blocked-on:** a maintainer decision to run the bounded local comparison (with the exact
+  authorization ID) or a benchmark-grade campaign; either remains out of scope for this PR.
 
 ## Next empirical action
 
-The only forward step is the authorized campaign itself (out of scope here): run the resolved
-three-arm plan under the canonical command, land the per-arm JSONL under
-`output/issue_4142_dpcbf_dense/`, then re-run `summarize_dense_comparison` to move the summary
-from `results_incomplete` to `complete`. Only then may bounded, caveated comparison evidence be
-reported — and still not as a paper-facing collision-reduction claim without a predeclared,
-fully reviewed benchmark campaign.
+Run the resolved three-arm plan locally with the exact authorization ID (or under an authorized
+campaign), land the per-arm JSONL under `output/issue_4142_dpcbf_dense/`, then re-run
+`summarize_dense_comparison` to move the summary from `results_incomplete` to `complete`. Only
+then may bounded, caveated comparison evidence be reported — and still not as a paper-facing
+collision-reduction claim without a predeclared, fully reviewed benchmark campaign.
 
 ## Validation
 
 ```bash
-uv run pytest tests/benchmark/test_issue_4142_dpcbf_dense_pipeline_contract.py -q
+uv run pytest tests/benchmark/test_issue_4142_dpcbf_dense_pipeline_contract.py \
+  tests/benchmark/test_issue_4142_dpcbf_dense_executor.py -q
 ```

--- a/docs/context/issue_4142_dpcbf_dense_pipeline.md
+++ b/docs/context/issue_4142_dpcbf_dense_pipeline.md
@@ -49,57 +49,26 @@ this slice binds the three merged modules with the one contract they were missin
 
 ## What #5419 adds: the authorization-gated local executor
 
-PR #5419 turns `execute_run_plan()` from an always-raise gate into a bounded, explicitly
-authorized **local episode executor**:
+PR #5419 turns `execute_run_plan()` into a bounded, explicitly authorized **local episode
+executor**:
 
-- **Fixed bounded execution inputs.** The packet gained an optional `execution` block (base
-  seed, repeats, horizon, `dt`, worker cap, video-off, resume policy) with fixed defaults;
-  out-of-bounds overrides fail closed in `build_run_plan`. This keeps the run a bounded
-  diagnostic comparison, never a benchmark-grade campaign.
-- **In-process executor.** With the exact public authorization ID, the executor reuses the
-  canonical `robot_sf.benchmark.runner.run_batch` once per resolved arm, in packet order, each
-  pinned to the shared scenario manifest and that arm's distinct algorithm config, writing the
-  planned per-arm JSONL.
-- **Authorization gate.** `execute_run_plan(plan, authorization=...)` fails closed with
-  `DenseComparisonExecutionGatedError` unless `authorization == "RSF-DPCBF-DENSE-20260712"`. A
-  missing/boolean/env/TTY value or a bare `--execute` flag is insufficient and **no output
-  files are created**.
-- **Execution manifest** (`robot_sf.issue_4142_dpcbf_dense_comparison_execution.v1`): packet/
-  plan schema versions, authorization ID, git SHA + dirty flag, effective arguments, per-arm
-  output paths/statuses, start/end timestamps, and overall completeness. A failing arm stays a
-  visible caveat and blocks an overall `complete` status; later arms keep their true status.
-- **Provenance-safe resume.** A repeated invocation resumes only when the on-disk manifest's
-  provenance key (packet/plan schema, algorithm, per-arm configs, execution inputs, git SHA)
-  matches; otherwise it fails closed with `DenseComparisonProvenanceMismatchError` rather than
-  mixing incompatible artifacts.
-
-The executor is local-only: it submits no Slurm/GPU job and knows nothing about `sbatch`, SSH,
-tmux, or queue tooling. The packet's canonical command now points at the real issue-scoped CLI
-(`scripts/tools/run_issue_4142_dpcbf_dense_comparison.py --execute --authorization ...`); the
-generic `benchmark.cli run` never accepted the packet's `--config` form.
+- **Bounded execution and authorization.** The packet's optional `execution` block fixes seed,
+  repeats, horizon, `dt`, workers, video-off, and resume policy. Unknown or out-of-bounds values
+  fail closed. The exact `RSF-DPCBF-DENSE-20260712` ID is required before any write; the runner
+  reuses `run_batch` once per arm in packet order with the shared manifest and arm config.
+- **Manifest and resume safety.** The manifest
+  (`robot_sf.issue_4142_dpcbf_dense_comparison_execution.v1`) records effective arguments,
+  timestamps, arm statuses, dirty state, and content-bound hashes. Atomic `in_progress`
+  checkpoints make interruption explicit; orphan output, malformed manifests, dirty Git trees,
+  and mismatched provenance fail closed. A no-work resume is complete only after artifact ID
+  validation.
 
 ## Integration status
 
-- **Delivered (new):** the authorization-gated local executor + execution manifest + provenance
-  -safe resume (#5419), proven by fail-closed contract tests and one real-`run_batch` smoke on a
-  reduced, test-only fixture (no performance claim).
-- **Remaining (intentional):** an *authorized, full-scale* local or campaign run of the tracked
-  `prediction_mpc_cv` packet is not performed here; the summarizer stays `results_incomplete`
-  until authorized per-arm JSONL exists under `output/issue_4142_dpcbf_dense/`.
-- **Blocked-on:** a maintainer decision to run the bounded local comparison (with the exact
-  authorization ID) or a benchmark-grade campaign; either remains out of scope for this PR.
+- **Delivered (new):** the authorization-gated executor, checkpointed manifest, and
+  provenance-safe resume (#5419), covered by fail-closed tests and a reduced real-runner smoke.
+- **Remaining (intentional):** the tracked `prediction_mpc_cv` packet is not run here; its
+  summarizer remains `results_incomplete` until authorized per-arm JSONL exists.
 
-## Next empirical action
-
-Run the resolved three-arm plan locally with the exact authorization ID (or under an authorized
-campaign), land the per-arm JSONL under `output/issue_4142_dpcbf_dense/`, then re-run
-`summarize_dense_comparison` to move the summary from `results_incomplete` to `complete`. Only
-then may bounded, caveated comparison evidence be reported — and still not as a paper-facing
-collision-reduction claim without a predeclared, fully reviewed benchmark campaign.
-
-## Validation
-
-```bash
-uv run pytest tests/benchmark/test_issue_4142_dpcbf_dense_pipeline_contract.py \
-  tests/benchmark/test_issue_4142_dpcbf_dense_executor.py -q
-```
+Next empirical action: run the resolved plan with the exact authorization ID and summarize its
+per-arm JSONL as bounded diagnostic evidence, never a paper-facing collision-reduction claim.

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
@@ -162,6 +162,19 @@ _EXECUTION_INPUT_BOUNDS = {
 }
 
 
+def _resolve_resume(block: dict[str, Any], blockers: list[str]) -> bool:
+    """Validate the resume flag without coercing strings into execution semantics.
+
+    Returns:
+        Valid boolean resume value, or the safe default after recording a blocker.
+    """
+    resume = block.get("resume", DEFAULT_EXECUTION_INPUTS.resume)
+    if not isinstance(resume, bool):
+        blockers.append(f"packet execution.resume must be a boolean, got {resume!r}")
+        return DEFAULT_EXECUTION_INPUTS.resume
+    return resume
+
+
 @dataclass(frozen=True, slots=True)
 class ArmJobPlan:
     """One resolved benchmark job for a single predeclared comparison arm."""
@@ -301,7 +314,7 @@ def _resolve_execution_inputs(packet: dict[str, Any]) -> tuple[DenseExecutionInp
     if bool(block.get("video_enabled", False)):
         blockers.append("packet execution.video_enabled must be false (bounded diagnostic run)")
 
-    resume = bool(block.get("resume", DEFAULT_EXECUTION_INPUTS.resume))
+    resume = _resolve_resume(block, blockers)
 
     inputs = DenseExecutionInputs(
         base_seed=int(values["base_seed"]),
@@ -485,7 +498,13 @@ def _git_provenance(repo_root: Path) -> tuple[str, bool]:
         return "unknown", True
 
 
-def _provenance_key(plan: DenseComparisonRunPlan, git_sha: str) -> str:
+def _provenance_key(
+    plan: DenseComparisonRunPlan,
+    git_sha: str,
+    *,
+    git_dirty: bool,
+    schema_path: str | Path,
+) -> str:
     """Build a stable provenance key that must match for a repeated run to safely resume.
 
     Combines the packet/plan schema lineage, the shared algorithm, every arm's config, the
@@ -499,13 +518,20 @@ def _provenance_key(plan: DenseComparisonRunPlan, git_sha: str) -> str:
     parts = [
         plan.packet_schema_version,
         plan.schema_version,
+        str(plan.packet_path),
         str(plan.algorithm),
         str(plan.scenario_manifest),
+        f"output_dir={plan.output_dir}",
         f"seed={inputs.base_seed}",
         f"repeats={inputs.repeats}",
         f"horizon={inputs.horizon}",
         f"dt={inputs.dt}",
+        f"workers={inputs.workers}",
+        f"video={inputs.video_enabled}",
+        f"resume={inputs.resume}",
+        f"schema_path={Path(schema_path).as_posix()}",
         git_sha,
+        f"git_dirty={git_dirty}",
     ]
     parts.extend(f"{job.arm_key}:{job.algorithm_config}" for job in plan.arms)
     return "|".join(parts)
@@ -593,16 +619,24 @@ def execute_run_plan(
     root = Path(repo_root)
     output_dir_abs = _abs_under_root(root, plan.output_dir)
     manifest_path = output_dir_abs / EXECUTION_MANIFEST_FILENAME
+    schema_abs = _abs_under_root(root, str(schema_path)).resolve()
 
     git_sha, git_dirty = _git_provenance(root)
-    provenance_key = _provenance_key(plan, git_sha)
+    provenance_key = _provenance_key(
+        plan,
+        git_sha,
+        git_dirty=git_dirty,
+        schema_path=schema_abs,
+    )
 
     # Gate 3: provenance-safe resume. A pre-existing manifest with a different key means the
     # on-disk artifacts came from an incompatible run; fail closed instead of mixing them.
     if manifest_path.is_file():
         try:
             prior = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
+            if not isinstance(prior, dict):
+                raise ValueError("manifest JSON is not a dictionary")
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
             raise DenseComparisonProvenanceMismatchError(
                 f"existing execution manifest {manifest_path} is unreadable: {exc}"
             ) from exc
@@ -615,7 +649,6 @@ def execute_run_plan(
             )
 
     inputs = plan.execution_inputs
-    schema_abs = _abs_under_root(root, str(schema_path))
     clock = now_fn or (lambda: datetime.now(UTC))
     run_batch = run_batch_fn or _default_run_batch()
 

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
@@ -812,7 +812,11 @@ def execute_run_plan(  # noqa: C901
         ended_at: str = "",
         status: str = "in_progress",
     ) -> DenseExecutionManifest:
-        """Persist one atomic execution checkpoint and return its snapshot."""
+        """Persist one atomic execution checkpoint and return its snapshot.
+
+        Returns:
+            The checkpoint snapshot written to disk.
+        """
         manifest = _build_manifest(
             plan,
             authorization_id=REQUIRED_AUTHORIZATION_ID,

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
@@ -906,7 +906,15 @@ def _execute_arm(
             resume=inputs.resume,
             append=inputs.resume,
         )
-    except Exception as exc:  # noqa: BLE001 - any runner failure is a visible caveat, not a crash
+    except (
+        AttributeError,
+        ImportError,
+        LookupError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ) as exc:
         return ArmExecutionResult(
             arm_key=job.arm_key,
             algorithm=job.algorithm,

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
@@ -46,6 +46,7 @@ Status semantics:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 from dataclasses import dataclass, field
@@ -160,6 +161,7 @@ _EXECUTION_INPUT_BOUNDS = {
     "horizon": (1, 2_000),
     "workers": (1, 8),
 }
+_EXECUTION_KEYS = frozenset((*_EXECUTION_INPUT_BOUNDS, "dt", "video_enabled", "resume"))
 
 
 def _resolve_resume(block: dict[str, Any], blockers: list[str]) -> bool:
@@ -263,12 +265,12 @@ def _resolve_arm_jobs(
     return tuple(jobs)
 
 
-def _resolve_execution_inputs(packet: dict[str, Any]) -> tuple[DenseExecutionInputs, list[str]]:
+def _resolve_execution_inputs(packet: dict[str, Any]) -> tuple[DenseExecutionInputs, list[str]]:  # noqa: C901
     """Merge the packet's optional ``execution`` block over the bounded defaults.
 
-    Unknown/absent keys keep their default. Any override that is the wrong type or outside
-    :data:`_EXECUTION_INPUT_BOUNDS` becomes a fail-closed blocker rather than a silent clamp,
-    so a plan can never quietly grow into a heavy run.
+    Unknown keys and overrides that are the wrong type or outside
+    :data:`_EXECUTION_INPUT_BOUNDS` become fail-closed blockers rather than silently changing
+    execution semantics, so a plan can never quietly grow into a heavy run.
 
     Returns:
         The resolved bounded execution inputs and any blockers found.
@@ -280,6 +282,8 @@ def _resolve_execution_inputs(packet: dict[str, Any]) -> tuple[DenseExecutionInp
         return DEFAULT_EXECUTION_INPUTS, ["packet 'execution' block must be a mapping"]
 
     blockers: list[str] = []
+    unknown = sorted((key for key in block if key not in _EXECUTION_KEYS), key=str)
+    blockers.extend(f"packet execution has unknown key {key!r}" for key in unknown)
     values: dict[str, Any] = {
         "base_seed": DEFAULT_EXECUTION_INPUTS.base_seed,
         "repeats": DEFAULT_EXECUTION_INPUTS.repeats,
@@ -310,9 +314,15 @@ def _resolve_execution_inputs(packet: dict[str, Any]) -> tuple[DenseExecutionInp
         else:
             dt = float(raw_dt)
 
-    # video is deliberately forced off: this is a bounded diagnostic run, not a render job.
-    if bool(block.get("video_enabled", False)):
-        blockers.append("packet execution.video_enabled must be false (bounded diagnostic run)")
+    # Video is deliberately forced off: this is a bounded diagnostic run, not a render job.
+    if "video_enabled" in block:
+        video_enabled = block["video_enabled"]
+        if not isinstance(video_enabled, bool):
+            blockers.append(
+                f"packet execution.video_enabled must be a boolean, got {video_enabled!r}"
+            )
+        elif video_enabled:
+            blockers.append("packet execution.video_enabled must be false (bounded diagnostic run)")
 
     resume = _resolve_resume(block, blockers)
 
@@ -441,8 +451,8 @@ class ArmExecutionResult:
     algorithm: str
     algorithm_config: str
     output_jsonl: str
-    #: ``executed`` (all scheduled jobs written, no failures), ``failed`` (runner raised, wrote
-    #: nothing, or reported failures). Failed/degraded rows are caveats, never success.
+    #: ``executed`` (new rows), ``resumed_complete`` (all expected rows already existed),
+    #: ``pending``, or ``failed``. Failed/degraded rows are caveats, never success.
     status: str
     total_jobs: int
     written: int
@@ -465,12 +475,14 @@ class DenseExecutionManifest:
     scenario_manifest: str
     output_dir: str
     provenance_key: str
+    input_hashes: dict[str, str]
     effective_arguments: dict[str, Any]
     arms: tuple[ArmExecutionResult, ...]
     started_at: str
     ended_at: str
-    #: ``complete`` only when every required arm executed with success rows and no failures.
-    #: Otherwise ``results_incomplete`` -- a caveat state, never a successful comparison.
+    #: ``complete`` only when every required arm executed or resumed with validated rows.
+    #: ``in_progress`` is checkpointed before/after each arm; ``results_incomplete`` is a
+    #: caveat state, never a successful comparison.
     status: str
     excluded_row_statuses: tuple[str, ...]
     claim_boundary: str = CLAIM_BOUNDARY
@@ -504,37 +516,127 @@ def _provenance_key(
     *,
     git_dirty: bool,
     schema_path: str | Path,
+    input_hashes: dict[str, str],
+    effective_arguments: dict[str, Any],
 ) -> str:
     """Build a stable provenance key that must match for a repeated run to safely resume.
 
-    Combines the packet/plan schema lineage, the shared algorithm, every arm's config, the
-    bounded execution inputs, and the git SHA. A change in any of these means the on-disk
-    artifacts came from an incompatible run and resume must fail closed.
+    Combines plan identity, every effective argument, git state, and content hashes for the
+    packet, scenario manifest, algorithm configs, and episode schema. A change in any of these
+    means the on-disk artifacts came from an incompatible run and resume must fail closed.
 
     Returns:
         A deterministic string key.
     """
-    inputs = plan.execution_inputs
-    parts = [
-        plan.packet_schema_version,
-        plan.schema_version,
-        str(plan.packet_path),
-        str(plan.algorithm),
-        str(plan.scenario_manifest),
-        f"output_dir={plan.output_dir}",
-        f"seed={inputs.base_seed}",
-        f"repeats={inputs.repeats}",
-        f"horizon={inputs.horizon}",
-        f"dt={inputs.dt}",
-        f"workers={inputs.workers}",
-        f"video={inputs.video_enabled}",
-        f"resume={inputs.resume}",
-        f"schema_path={Path(schema_path).as_posix()}",
-        git_sha,
-        f"git_dirty={git_dirty}",
-    ]
-    parts.extend(f"{job.arm_key}:{job.algorithm_config}" for job in plan.arms)
-    return "|".join(parts)
+    payload = {
+        "plan": {
+            "packet_path": str(plan.packet_path),
+            "packet_schema_version": plan.packet_schema_version,
+            "plan_schema_version": plan.schema_version,
+            "algorithm": plan.algorithm,
+            "scenario_manifest": str(plan.scenario_manifest),
+            "output_dir": plan.output_dir,
+            "schema_path": Path(schema_path).as_posix(),
+            "arms": [
+                {"arm_key": job.arm_key, "algorithm_config": job.algorithm_config}
+                for job in plan.arms
+            ],
+        },
+        "effective_arguments": effective_arguments,
+        "input_hashes": dict(sorted(input_hashes.items())),
+        "git_sha": git_sha,
+        "git_dirty": git_dirty,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _content_hash(path: Path) -> str:
+    """Hash one effective execution input, failing closed when it is unavailable.
+
+    Returns:
+        SHA-256 digest of the input bytes.
+    """
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise DenseComparisonProvenanceMismatchError(
+            f"cannot bind execution provenance to input {path}: {exc}"
+        ) from exc
+
+
+def _effective_input_hashes(
+    root: Path,
+    plan: DenseComparisonRunPlan,
+    schema_abs: Path,
+) -> dict[str, str]:
+    """Hash the packet and every file whose contents affect the episode rows.
+
+    Returns:
+        Named SHA-256 digests for all effective input files.
+    """
+    paths = {
+        "packet": _abs_under_root(root, plan.packet_path),
+        "scenario_manifest": _abs_under_root(root, str(plan.scenario_manifest)),
+        "episode_schema": schema_abs,
+    }
+    paths.update(
+        {
+            f"algorithm_config:{job.arm_key}": _abs_under_root(root, job.algorithm_config)
+            for job in plan.arms
+        }
+    )
+    return {name: _content_hash(path.resolve()) for name, path in paths.items()}
+
+
+def _write_manifest_atomic(path: Path, manifest: DenseExecutionManifest) -> None:
+    """Publish a checkpoint atomically, leaving an orphan marker if interrupted."""
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(
+        json.dumps(manifest_to_dict(manifest), indent=2, sort_keys=True), encoding="utf-8"
+    )
+    temporary.replace(path)
+
+
+def _build_manifest(  # noqa: PLR0913
+    plan: DenseComparisonRunPlan,
+    *,
+    authorization_id: str,
+    git_sha: str,
+    git_dirty: bool,
+    provenance_key: str,
+    input_hashes: dict[str, str],
+    effective_arguments: dict[str, Any],
+    arms: tuple[ArmExecutionResult, ...],
+    started_at: str,
+    ended_at: str,
+    status: str,
+) -> DenseExecutionManifest:
+    """Build a manifest or checkpoint from one immutable execution snapshot.
+
+    Returns:
+        The serializable manifest snapshot.
+    """
+    return DenseExecutionManifest(
+        schema_version=EXECUTION_MANIFEST_SCHEMA_VERSION,
+        packet_path=plan.packet_path,
+        packet_schema_version=plan.packet_schema_version,
+        plan_schema_version=plan.schema_version,
+        authorization_id=authorization_id,
+        git_sha=git_sha,
+        git_dirty=git_dirty,
+        algorithm=str(plan.algorithm),
+        scenario_manifest=str(plan.scenario_manifest),
+        output_dir=plan.output_dir,
+        provenance_key=provenance_key,
+        input_hashes=dict(input_hashes),
+        effective_arguments=dict(effective_arguments),
+        arms=arms,
+        started_at=started_at,
+        ended_at=ended_at,
+        status=status,
+        excluded_row_statuses=plan.excluded_row_statuses,
+    )
 
 
 def _abs_under_root(repo_root: Path, rel_or_abs: str) -> Path:
@@ -558,7 +660,7 @@ def _default_run_batch() -> Callable[..., dict[str, Any]]:
     return run_batch
 
 
-def execute_run_plan(
+def execute_run_plan(  # noqa: C901
     plan: DenseComparisonRunPlan,
     *,
     authorization: str | None = None,
@@ -580,9 +682,8 @@ def execute_run_plan(
     1. The plan must be fully resolved (``plan_ready_campaign_gated``); a blocked plan raises.
     2. ``authorization`` must equal :data:`REQUIRED_AUTHORIZATION_ID` exactly. A missing/empty
        value, a boolean, or any other string raises before a single output file is created.
-    3. If an execution manifest already exists under the output directory, its provenance key
-       must match the current plan+git provenance, otherwise the run fails closed rather than
-       mixing incompatible artifacts. A matching key allows a provenance-safe resume.
+    3. A prior manifest must match content-bound provenance. Existing output without an owning
+       manifest fails closed, while an atomic ``in_progress`` manifest checkpoints each arm.
 
     Args:
         plan: A resolved run plan from :func:`build_run_plan`.
@@ -616,21 +717,41 @@ def execute_run_plan(
             "is insufficient; no output files are created."
         )
 
-    root = Path(repo_root)
-    output_dir_abs = _abs_under_root(root, plan.output_dir)
+    root = Path(repo_root).resolve()
+    output_dir_abs = _abs_under_root(root, plan.output_dir).resolve()
     manifest_path = output_dir_abs / EXECUTION_MANIFEST_FILENAME
     schema_abs = _abs_under_root(root, str(schema_path)).resolve()
 
     git_sha, git_dirty = _git_provenance(root)
+    if git_dirty and git_sha != "unknown":
+        raise DenseComparisonProvenanceMismatchError(
+            f"refusing execution from dirty git worktree {root}; commit effective inputs first"
+        )
+
+    inputs = plan.execution_inputs
+    effective_arguments = {
+        "authorization_id": REQUIRED_AUTHORIZATION_ID,
+        "repo_root": str(root),
+        "schema_path": str(schema_path),
+        "base_seed": inputs.base_seed,
+        "repeats": inputs.repeats,
+        "horizon": inputs.horizon,
+        "dt": inputs.dt,
+        "workers": inputs.workers,
+        "video_enabled": inputs.video_enabled,
+        "resume": inputs.resume,
+    }
+    input_hashes = _effective_input_hashes(root, plan, schema_abs)
     provenance_key = _provenance_key(
         plan,
         git_sha,
         git_dirty=git_dirty,
         schema_path=schema_abs,
+        input_hashes=input_hashes,
+        effective_arguments=effective_arguments,
     )
 
-    # Gate 3: provenance-safe resume. A pre-existing manifest with a different key means the
-    # on-disk artifacts came from an incompatible run; fail closed instead of mixing them.
+    prior: dict[str, Any] | None = None
     if manifest_path.is_file():
         try:
             prior = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -647,73 +768,99 @@ def execute_run_plan(
                 f"this run. existing={prior_key!r} current={provenance_key!r}. Remove "
                 f"{output_dir_abs} or run with matching packet/config/git provenance."
             )
+        if prior.get("status") not in {"in_progress", "complete", "results_incomplete"}:
+            raise DenseComparisonProvenanceMismatchError(
+                f"existing execution manifest {manifest_path} has an invalid status"
+            )
+    elif output_dir_abs.exists():
+        try:
+            orphaned = tuple(output_dir_abs.iterdir())
+        except OSError as exc:
+            raise DenseComparisonProvenanceMismatchError(
+                f"existing execution output path {output_dir_abs} is not a readable directory"
+            ) from exc
+        if orphaned:
+            names = ", ".join(path.name for path in orphaned[:3])
+            raise DenseComparisonProvenanceMismatchError(
+                f"existing output {output_dir_abs} has no execution manifest; refusing to "
+                f"claim ownership of orphaned files ({names})"
+            )
 
-    inputs = plan.execution_inputs
     clock = now_fn or (lambda: datetime.now(UTC))
     run_batch = run_batch_fn or _default_run_batch()
-
-    effective_arguments = {
-        "authorization_id": REQUIRED_AUTHORIZATION_ID,
-        "repo_root": str(root),
-        "schema_path": str(schema_path),
-        "base_seed": inputs.base_seed,
-        "repeats": inputs.repeats,
-        "horizon": inputs.horizon,
-        "dt": inputs.dt,
-        "workers": inputs.workers,
-        "video_enabled": inputs.video_enabled,
-        "resume": inputs.resume,
-    }
 
     output_dir_abs.mkdir(parents=True, exist_ok=True)
     started_at = clock().isoformat()
 
+    results = [
+        ArmExecutionResult(
+            arm_key=job.arm_key,
+            algorithm=job.algorithm,
+            algorithm_config=job.algorithm_config,
+            output_jsonl=job.output_jsonl,
+            status="pending",
+            total_jobs=0,
+            written=0,
+            failed_jobs=0,
+        )
+        for job in plan.arms
+    ]
+
+    def save_checkpoint(
+        arms: tuple[ArmExecutionResult, ...],
+        *,
+        ended_at: str = "",
+        status: str = "in_progress",
+    ) -> DenseExecutionManifest:
+        """Persist one atomic execution checkpoint and return its snapshot."""
+        manifest = _build_manifest(
+            plan,
+            authorization_id=REQUIRED_AUTHORIZATION_ID,
+            git_sha=git_sha,
+            git_dirty=git_dirty,
+            provenance_key=provenance_key,
+            input_hashes=input_hashes,
+            effective_arguments=effective_arguments,
+            started_at=started_at,
+            ended_at=ended_at,
+            status=status,
+            arms=arms,
+        )
+        _write_manifest_atomic(manifest_path, manifest)
+        return manifest
+
+    save_checkpoint(tuple(results))
+
     scenario_abs = _abs_under_root(root, str(plan.scenario_manifest))
-    results: list[ArmExecutionResult] = []
-    for job in plan.arms:
+    prior_arms = {
+        arm.get("arm_key"): arm
+        for arm in (prior or {}).get("arms", [])
+        if isinstance(arm, dict) and isinstance(arm.get("arm_key"), str)
+    }
+    for index, job in enumerate(plan.arms):
         out_abs = _abs_under_root(root, job.output_jsonl)
         algo_config_abs = _abs_under_root(root, job.algorithm_config)
-        results.append(
-            _execute_arm(
-                run_batch,
-                job=job,
-                scenario_abs=scenario_abs,
-                out_abs=out_abs,
-                schema_abs=schema_abs,
-                algo_config_abs=algo_config_abs,
-                inputs=inputs,
-            )
+        prior_total = prior_arms.get(job.arm_key, {}).get("total_jobs")
+        expected_jobs = prior_total if isinstance(prior_total, int) and prior_total > 0 else None
+        results[index] = _execute_arm(
+            run_batch,
+            job=job,
+            scenario_abs=scenario_abs,
+            out_abs=out_abs,
+            schema_abs=schema_abs,
+            algo_config_abs=algo_config_abs,
+            inputs=inputs,
+            expected_jobs=expected_jobs,
         )
+        save_checkpoint(tuple(results))
 
     ended_at = clock().isoformat()
     all_ok = len(results) == len(REQUIRED_ARMS) and all(
-        r.status == "executed" and r.written > 0 for r in results
+        r.status in {"executed", "resumed_complete"} and r.failed_jobs == 0 for r in results
     )
     status = "complete" if all_ok else "results_incomplete"
 
-    manifest = DenseExecutionManifest(
-        schema_version=EXECUTION_MANIFEST_SCHEMA_VERSION,
-        packet_path=plan.packet_path,
-        packet_schema_version=plan.packet_schema_version,
-        plan_schema_version=plan.schema_version,
-        authorization_id=REQUIRED_AUTHORIZATION_ID,
-        git_sha=git_sha,
-        git_dirty=git_dirty,
-        algorithm=str(plan.algorithm),
-        scenario_manifest=str(plan.scenario_manifest),
-        output_dir=plan.output_dir,
-        provenance_key=provenance_key,
-        effective_arguments=effective_arguments,
-        arms=tuple(results),
-        started_at=started_at,
-        ended_at=ended_at,
-        status=status,
-        excluded_row_statuses=plan.excluded_row_statuses,
-    )
-    manifest_path.write_text(
-        json.dumps(manifest_to_dict(manifest), indent=2, sort_keys=True), encoding="utf-8"
-    )
-    return manifest
+    return save_checkpoint(tuple(results), ended_at=ended_at, status=status)
 
 
 def _execute_arm(
@@ -725,16 +872,19 @@ def _execute_arm(
     schema_abs: Path,
     algo_config_abs: Path,
     inputs: DenseExecutionInputs,
+    expected_jobs: int | None = None,
 ) -> ArmExecutionResult:
     """Run one arm through the canonical runner and classify its outcome.
 
-    A runner exception or a run that writes nothing is recorded as ``failed`` and remains a
-    visible caveat in the manifest; it never blocks the remaining arms and is never counted as
-    success.
+    A runner exception or an output with missing/duplicate episode identities is recorded as
+    ``failed``. A zero-job resume is ``resumed_complete`` only when the existing JSONL contains
+    exactly the expected number of valid episode identities.
 
     Returns:
         The per-arm execution result.
     """
+    existing_ids = _episode_ids(out_abs) if inputs.resume else set()
+    baseline_count = len(existing_ids) if existing_ids is not None else 0
     try:
         summary = run_batch(
             scenarios_or_path=str(scenario_abs),
@@ -772,7 +922,31 @@ def _execute_arm(
     failed_jobs = (
         len(failures) if isinstance(failures, list) else int(summary.get("failed_jobs", 0))
     )
-    ok = total_jobs > 0 and written >= total_jobs and failed_jobs == 0
+    if total_jobs == 0 and written == 0 and failed_jobs == 0:
+        expected = expected_jobs if expected_jobs is not None else baseline_count
+        valid_resume = expected > 0 and _episode_ids(out_abs) == set(existing_ids or ())
+        return ArmExecutionResult(
+            arm_key=job.arm_key,
+            algorithm=job.algorithm,
+            algorithm_config=job.algorithm_config,
+            output_jsonl=job.output_jsonl,
+            status="resumed_complete" if valid_resume else "failed",
+            total_jobs=expected,
+            written=0,
+            failed_jobs=0,
+            error=None
+            if valid_resume
+            else "resume found no jobs but artifact identities were incomplete",
+        )
+    expected = total_jobs if not inputs.resume else baseline_count + total_jobs
+    artifact_ids = _episode_ids(out_abs)
+    ok = (
+        total_jobs > 0
+        and written >= total_jobs
+        and failed_jobs == 0
+        and artifact_ids is not None
+        and len(artifact_ids) == expected
+    )
     return ArmExecutionResult(
         arm_key=job.arm_key,
         algorithm=job.algorithm,
@@ -782,8 +956,33 @@ def _execute_arm(
         total_jobs=total_jobs,
         written=written,
         failed_jobs=failed_jobs,
-        error=None if ok else "run wrote fewer episodes than scheduled or reported failures",
+        error=None
+        if ok
+        else "run wrote fewer episodes than scheduled, reported failures, or lacked valid identities",
     )
+
+
+def _episode_ids(out_path: Path) -> set[str] | None:
+    """Read unique episode identities, returning ``None`` for malformed artifacts.
+
+    Returns:
+        Unique episode IDs, or ``None`` when the JSONL is malformed.
+    """
+    if not out_path.is_file():
+        return set()
+    ids: set[str] = set()
+    try:
+        for line in out_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            episode_id = record.get("episode_id") if isinstance(record, dict) else None
+            if not isinstance(episode_id, str) or not episode_id:
+                return None
+            ids.add(episode_id)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return ids
 
 
 def manifest_to_dict(manifest: DenseExecutionManifest) -> dict[str, Any]:
@@ -800,6 +999,7 @@ def manifest_to_dict(manifest: DenseExecutionManifest) -> dict[str, Any]:
         "scenario_manifest": manifest.scenario_manifest,
         "output_dir": manifest.output_dir,
         "provenance_key": manifest.provenance_key,
+        "input_hashes": dict(manifest.input_hashes),
         "effective_arguments": dict(manifest.effective_arguments),
         "status": manifest.status,
         "claim_boundary": manifest.claim_boundary,

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
@@ -906,15 +906,7 @@ def _execute_arm(
             resume=inputs.resume,
             append=inputs.resume,
         )
-    except (
-        AttributeError,
-        ImportError,
-        LookupError,
-        OSError,
-        RuntimeError,
-        TypeError,
-        ValueError,
-    ) as exc:
+    except (AttributeError, ImportError, OSError, RuntimeError, TypeError, ValueError) as exc:
         return ArmExecutionResult(
             arm_key=job.arm_key,
             algorithm=job.algorithm,

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
@@ -23,10 +23,13 @@ Two hard boundaries are preserved, fail-closed:
   fail-closed, :func:`build_run_plan` returns a plan with status
   ``prerequisites_incomplete``, no executable arm jobs, and the readiness blockers surfaced.
   There is deliberately no path that resolves executable jobs from an invalid packet.
-- **Execution gate.** Running the dense comparison (episodes, Slurm/GPU) stays out of scope
-  for this slice. :func:`execute_run_plan` never runs episodes; it fails closed with
-  :class:`DenseComparisonExecutionGatedError`, because execution requires explicit
-  human/Slurm authorization that this runner intentionally does not grant.
+- **Execution gate.** Running the dense comparison locally is authorization-gated.
+  :func:`execute_run_plan` fails closed with :class:`DenseComparisonExecutionGatedError`
+  unless the caller supplies the exact public authorization ID (:data:`REQUIRED_AUTHORIZATION_ID`)
+  through an explicit argument -- a boolean, environment variable, implicit TTY, or bare
+  ``--execute`` flag is insufficient and no output files are created. With the correct ID the
+  executor runs bounded local episodes via the canonical benchmark runner; it never submits
+  Slurm/GPU jobs and knows nothing about ``sbatch``, SSH, tmux, or queue tooling.
 
 The fail-closed row-status exclusion (``fallback``, ``degraded``, ``failed``, ``ineligible``
 are caveats, never success evidence) is carried verbatim from the packet into the resolved
@@ -43,9 +46,12 @@ Status semantics:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+import subprocess
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from robot_sf.benchmark.issue_4142_dpcbf_dense_readiness import (
     PACKET_PATH,
@@ -59,8 +65,26 @@ from robot_sf.benchmark.issue_4142_dpcbf_dense_readiness import (
 )
 from robot_sf.errors import RobotSfError
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 #: Output-contract schema for the resolved run plan.
 PLAN_SCHEMA_VERSION = "robot_sf.issue_4142_dpcbf_dense_comparison_plan.v1"
+
+#: Output-contract schema for the machine-readable execution manifest.
+EXECUTION_MANIFEST_SCHEMA_VERSION = "robot_sf.issue_4142_dpcbf_dense_comparison_execution.v1"
+
+#: Exact public authorization ID that must be supplied to actually run episodes. Anything
+#: else -- a missing/empty value, a boolean, an environment variable, an implicit TTY, or a
+#: bare ``--execute`` flag -- is insufficient and the executor fails closed before any write.
+REQUIRED_AUTHORIZATION_ID = "RSF-DPCBF-DENSE-20260712"
+
+#: Canonical episode-record schema the benchmark runner validates rows against.
+EPISODE_SCHEMA_PATH = "robot_sf/benchmark/schemas/episode.schema.v1.json"
+
+#: Filename of the execution manifest written under the plan's output directory. Also acts as
+#: the provenance sidecar a repeated invocation reads to decide resume-vs-fail-closed.
+EXECUTION_MANIFEST_FILENAME = "execution_manifest.json"
 
 #: Default output directory for the three per-arm episode JSONL files. Under the git-ignored
 #: ``output/`` root per AGENTS.md; nothing is written by planning, only recorded in the plan.
@@ -78,10 +102,10 @@ CLAIM_BOUNDARY = (
 #: Gates that keep a valid plan from executing here. Surfaced verbatim so
 #: ``plan_ready_campaign_gated`` is never mistaken for a go-ahead to run.
 RUNNER_GATES: tuple[str, ...] = (
-    "executing the dense comparison requires explicit human/Slurm authorization and is out "
-    "of scope for this runner slice; execute_run_plan() fails closed",
-    "running episodes (CPU or GPU) is deferred to the authorized campaign, not performed by "
-    "this planner",
+    "executing the dense comparison locally requires the exact public authorization ID passed "
+    "through an explicit flag; without it execute_run_plan() fails closed and writes nothing",
+    "this executor runs bounded local episodes only; it submits no Slurm/GPU job and knows "
+    "nothing about sbatch, SSH, tmux, or queue tooling",
 )
 
 
@@ -90,7 +114,52 @@ class DenseComparisonRunnerError(RobotSfError, ValueError):
 
 
 class DenseComparisonExecutionGatedError(RobotSfError, RuntimeError):
-    """Raised when execution is attempted; execution stays authorization-gated here."""
+    """Raised when execution is attempted without the exact public authorization ID."""
+
+
+class DenseComparisonProvenanceMismatchError(RobotSfError, RuntimeError):
+    """Raised when a repeated run would silently mix incompatible packet/config/git provenance."""
+
+
+@dataclass(frozen=True, slots=True)
+class DenseExecutionInputs:
+    """Fixed, bounded execution inputs for the three-arm local episode run.
+
+    These are intentionally small and diagnostic: a bounded runtime comparison, never a
+    benchmark-grade campaign. Values come from the packet's optional ``execution`` block
+    merged over :data:`DEFAULT_EXECUTION_INPUTS`; :func:`build_run_plan` fails closed if any
+    override is out of bounds so a plan can never silently widen into a large run.
+    """
+
+    base_seed: int
+    repeats: int
+    horizon: int
+    dt: float
+    workers: int
+    video_enabled: bool = False
+    resume: bool = True
+
+
+#: Fixed bounded defaults. Small horizon/repeats and a single worker keep this a bounded
+#: diagnostic comparison; video stays off so no large artifacts are produced.
+DEFAULT_EXECUTION_INPUTS = DenseExecutionInputs(
+    base_seed=0,
+    repeats=3,
+    horizon=100,
+    dt=0.1,
+    workers=1,
+    video_enabled=False,
+    resume=True,
+)
+
+#: Upper bounds on packet-supplied overrides. A plan that requests more fails closed rather
+#: than quietly turning the bounded diagnostic into a heavy run.
+_EXECUTION_INPUT_BOUNDS = {
+    "base_seed": (0, 1_000_000),
+    "repeats": (1, 20),
+    "horizon": (1, 2_000),
+    "workers": (1, 8),
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,6 +196,7 @@ class DenseComparisonRunPlan:
     runner_gates: tuple[str, ...] = RUNNER_GATES
     campaign_gates: tuple[str, ...] = ()
     readiness_status: str = ""
+    execution_inputs: DenseExecutionInputs = field(default_factory=lambda: DEFAULT_EXECUTION_INPUTS)
 
     @property
     def is_executable_in_principle(self) -> bool:
@@ -180,6 +250,71 @@ def _resolve_arm_jobs(
     return tuple(jobs)
 
 
+def _resolve_execution_inputs(packet: dict[str, Any]) -> tuple[DenseExecutionInputs, list[str]]:
+    """Merge the packet's optional ``execution`` block over the bounded defaults.
+
+    Unknown/absent keys keep their default. Any override that is the wrong type or outside
+    :data:`_EXECUTION_INPUT_BOUNDS` becomes a fail-closed blocker rather than a silent clamp,
+    so a plan can never quietly grow into a heavy run.
+
+    Returns:
+        The resolved bounded execution inputs and any blockers found.
+    """
+    block = packet.get("execution")
+    if block is None:
+        return DEFAULT_EXECUTION_INPUTS, []
+    if not isinstance(block, dict):
+        return DEFAULT_EXECUTION_INPUTS, ["packet 'execution' block must be a mapping"]
+
+    blockers: list[str] = []
+    values: dict[str, Any] = {
+        "base_seed": DEFAULT_EXECUTION_INPUTS.base_seed,
+        "repeats": DEFAULT_EXECUTION_INPUTS.repeats,
+        "horizon": DEFAULT_EXECUTION_INPUTS.horizon,
+        "workers": DEFAULT_EXECUTION_INPUTS.workers,
+    }
+    for key, (low, high) in _EXECUTION_INPUT_BOUNDS.items():
+        if key not in block:
+            continue
+        raw = block[key]
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            blockers.append(f"packet execution.{key} must be an integer, got {raw!r}")
+            continue
+        if not (low <= raw <= high):
+            blockers.append(f"packet execution.{key}={raw} is outside bounds [{low}, {high}]")
+            continue
+        values[key] = raw
+
+    dt = DEFAULT_EXECUTION_INPUTS.dt
+    if "dt" in block:
+        raw_dt = block["dt"]
+        if (
+            isinstance(raw_dt, bool)
+            or not isinstance(raw_dt, (int, float))
+            or not (0 < raw_dt <= 1)
+        ):
+            blockers.append(f"packet execution.dt must be a float in (0, 1], got {raw_dt!r}")
+        else:
+            dt = float(raw_dt)
+
+    # video is deliberately forced off: this is a bounded diagnostic run, not a render job.
+    if bool(block.get("video_enabled", False)):
+        blockers.append("packet execution.video_enabled must be false (bounded diagnostic run)")
+
+    resume = bool(block.get("resume", DEFAULT_EXECUTION_INPUTS.resume))
+
+    inputs = DenseExecutionInputs(
+        base_seed=int(values["base_seed"]),
+        repeats=int(values["repeats"]),
+        horizon=int(values["horizon"]),
+        dt=dt,
+        workers=int(values["workers"]),
+        video_enabled=False,
+        resume=resume,
+    )
+    return inputs, blockers
+
+
 def build_run_plan(
     repo_root: str | Path = ".",
     packet_path: str | Path = PACKET_PATH,
@@ -221,7 +356,10 @@ def build_run_plan(
     excluded_tuple = tuple(str(s) for s in excluded) if isinstance(excluded, list) else ()
     fallback_flag = contract.get("fallback_rows_are_success_evidence", None)
 
+    execution_inputs, execution_blockers = _resolve_execution_inputs(packet)
+
     blockers = list(readiness.blockers)
+    blockers.extend(execution_blockers)
     # Fail closed on the runner's own preconditions, independent of readiness wording, so the
     # run plan can never silently drop the shared algorithm or the fail-closed exclusion.
     if not algorithm:
@@ -266,6 +404,7 @@ def build_run_plan(
         blockers=tuple(blockers),
         campaign_gates=readiness.campaign_gates,
         readiness_status=readiness.status,
+        execution_inputs=execution_inputs,
     )
 
 
@@ -281,22 +420,374 @@ def _as_abs(repo_root: str | Path, packet_path: str | Path) -> Path:
     return packet_abs
 
 
-def execute_run_plan(plan: DenseComparisonRunPlan) -> None:
-    """Fail closed: executing the dense comparison is out of scope for this runner slice.
+@dataclass(frozen=True, slots=True)
+class ArmExecutionResult:
+    """Outcome of running one comparison arm through the canonical benchmark runner."""
 
-    A valid plan is fully resolved and reviewable, but running it (episodes, Slurm/GPU) is
-    deferred to an explicitly authorized campaign. This function never runs episodes; it
-    always raises so no code path can accidentally launch the comparison from the planner.
+    arm_key: str
+    algorithm: str
+    algorithm_config: str
+    output_jsonl: str
+    #: ``executed`` (all scheduled jobs written, no failures), ``failed`` (runner raised, wrote
+    #: nothing, or reported failures). Failed/degraded rows are caveats, never success.
+    status: str
+    total_jobs: int
+    written: int
+    failed_jobs: int
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DenseExecutionManifest:
+    """Machine-readable manifest describing one authorized local execution attempt."""
+
+    schema_version: str
+    packet_path: str
+    packet_schema_version: str
+    plan_schema_version: str
+    authorization_id: str
+    git_sha: str
+    git_dirty: bool
+    algorithm: str
+    scenario_manifest: str
+    output_dir: str
+    provenance_key: str
+    effective_arguments: dict[str, Any]
+    arms: tuple[ArmExecutionResult, ...]
+    started_at: str
+    ended_at: str
+    #: ``complete`` only when every required arm executed with success rows and no failures.
+    #: Otherwise ``results_incomplete`` -- a caveat state, never a successful comparison.
+    status: str
+    excluded_row_statuses: tuple[str, ...]
+    claim_boundary: str = CLAIM_BOUNDARY
+
+
+def _git_provenance(repo_root: Path) -> tuple[str, bool]:
+    """Return the current git SHA and whether the working tree is dirty.
+
+    Returns:
+        ``(sha, dirty)``; ``("unknown", True)`` if git is unavailable (dirty=True fails safe).
+    """
+    try:
+        sha = (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=repo_root, stderr=subprocess.DEVNULL
+            )
+            .decode()
+            .strip()
+        )
+        porcelain = subprocess.check_output(
+            ["git", "status", "--porcelain"], cwd=repo_root, stderr=subprocess.DEVNULL
+        ).decode()
+        return sha or "unknown", bool(porcelain.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):  # pragma: no cover
+        return "unknown", True
+
+
+def _provenance_key(plan: DenseComparisonRunPlan, git_sha: str) -> str:
+    """Build a stable provenance key that must match for a repeated run to safely resume.
+
+    Combines the packet/plan schema lineage, the shared algorithm, every arm's config, the
+    bounded execution inputs, and the git SHA. A change in any of these means the on-disk
+    artifacts came from an incompatible run and resume must fail closed.
+
+    Returns:
+        A deterministic string key.
+    """
+    inputs = plan.execution_inputs
+    parts = [
+        plan.packet_schema_version,
+        plan.schema_version,
+        str(plan.algorithm),
+        str(plan.scenario_manifest),
+        f"seed={inputs.base_seed}",
+        f"repeats={inputs.repeats}",
+        f"horizon={inputs.horizon}",
+        f"dt={inputs.dt}",
+        git_sha,
+    ]
+    parts.extend(f"{job.arm_key}:{job.algorithm_config}" for job in plan.arms)
+    return "|".join(parts)
+
+
+def _abs_under_root(repo_root: Path, rel_or_abs: str) -> Path:
+    """Resolve a possibly repo-relative path against ``repo_root``.
+
+    Returns:
+        The absolute path.
+    """
+    path = Path(rel_or_abs)
+    return path if path.is_absolute() else repo_root / path
+
+
+def _default_run_batch() -> Callable[..., dict[str, Any]]:
+    """Import the canonical benchmark batch runner lazily.
+
+    Returns:
+        ``robot_sf.benchmark.runner.run_batch``.
+    """
+    from robot_sf.benchmark.runner import run_batch  # noqa: PLC0415
+
+    return run_batch
+
+
+def execute_run_plan(
+    plan: DenseComparisonRunPlan,
+    *,
+    authorization: str | None = None,
+    repo_root: str | Path = ".",
+    schema_path: str | Path = EPISODE_SCHEMA_PATH,
+    run_batch_fn: Callable[..., dict[str, Any]] | None = None,
+    now_fn: Callable[[], datetime] | None = None,
+) -> DenseExecutionManifest:
+    """Run the three-arm dense comparison locally, gated on the exact authorization ID.
+
+    The executor reuses the canonical benchmark runner (:func:`robot_sf.benchmark.runner.
+    run_batch`) once per resolved arm, in packet order, each pinned to the shared scenario
+    manifest and that arm's distinct algorithm config, and writes the planned per-arm JSONL.
+    It is deliberately local-only: it knows nothing about ``sbatch``, SSH, tmux, queue tooling,
+    or private ops.
+
+    Fail-closed order (nothing is written until every gate passes):
+
+    1. The plan must be fully resolved (``plan_ready_campaign_gated``); a blocked plan raises.
+    2. ``authorization`` must equal :data:`REQUIRED_AUTHORIZATION_ID` exactly. A missing/empty
+       value, a boolean, or any other string raises before a single output file is created.
+    3. If an execution manifest already exists under the output directory, its provenance key
+       must match the current plan+git provenance, otherwise the run fails closed rather than
+       mixing incompatible artifacts. A matching key allows a provenance-safe resume.
+
+    Args:
+        plan: A resolved run plan from :func:`build_run_plan`.
+        authorization: The exact public authorization ID; anything else fails closed.
+        repo_root: Directory repo-relative plan paths resolve against.
+        schema_path: Episode-record schema the runner validates rows against.
+        run_batch_fn: Injection seam for tests; defaults to the canonical ``run_batch``.
+        now_fn: Injection seam for timestamps; defaults to UTC ``datetime.now``.
+
+    Returns:
+        The execution manifest (also written to ``output_dir/execution_manifest.json``).
 
     Raises:
-        DenseComparisonExecutionGatedError: always.
+        DenseComparisonExecutionGatedError: if the plan is not ready or authorization is wrong.
+        DenseComparisonProvenanceMismatchError: if a prior manifest has incompatible provenance.
     """
-    raise DenseComparisonExecutionGatedError(
-        "issue #4142 dense DPCBF comparison execution is authorization-gated: this runner "
-        "slice resolves and validates the three-arm plan but does not run episodes. "
-        "Executing requires explicit human/Slurm authorization and a benchmark-grade "
-        f"campaign, which is out of scope here. Plan status: {plan.status}."
+    # Gate 1: never execute a plan that did not fully resolve.
+    if not plan.is_executable_in_principle:
+        raise DenseComparisonExecutionGatedError(
+            "issue #4142 dense DPCBF comparison cannot execute: the run plan is not fully "
+            f"resolved (status {plan.status!r}). Resolve all packet inputs first."
+        )
+
+    # Gate 2: authorization. Checked before ANY filesystem write so a wrong/absent ID never
+    # creates output files. A boolean, env var, TTY, or bare --execute flag is insufficient.
+    if authorization != REQUIRED_AUTHORIZATION_ID:
+        raise DenseComparisonExecutionGatedError(
+            "issue #4142 dense DPCBF comparison execution is authorization-gated: pass the "
+            f"exact public authorization ID {REQUIRED_AUTHORIZATION_ID!r} via the explicit "
+            "--authorization flag. A missing/boolean/env/TTY value or a bare --execute flag "
+            "is insufficient; no output files are created."
+        )
+
+    root = Path(repo_root)
+    output_dir_abs = _abs_under_root(root, plan.output_dir)
+    manifest_path = output_dir_abs / EXECUTION_MANIFEST_FILENAME
+
+    git_sha, git_dirty = _git_provenance(root)
+    provenance_key = _provenance_key(plan, git_sha)
+
+    # Gate 3: provenance-safe resume. A pre-existing manifest with a different key means the
+    # on-disk artifacts came from an incompatible run; fail closed instead of mixing them.
+    if manifest_path.is_file():
+        try:
+            prior = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise DenseComparisonProvenanceMismatchError(
+                f"existing execution manifest {manifest_path} is unreadable: {exc}"
+            ) from exc
+        prior_key = prior.get("provenance_key")
+        if prior_key != provenance_key:
+            raise DenseComparisonProvenanceMismatchError(
+                "refusing to resume: existing execution manifest provenance does not match "
+                f"this run. existing={prior_key!r} current={provenance_key!r}. Remove "
+                f"{output_dir_abs} or run with matching packet/config/git provenance."
+            )
+
+    inputs = plan.execution_inputs
+    schema_abs = _abs_under_root(root, str(schema_path))
+    clock = now_fn or (lambda: datetime.now(UTC))
+    run_batch = run_batch_fn or _default_run_batch()
+
+    effective_arguments = {
+        "authorization_id": REQUIRED_AUTHORIZATION_ID,
+        "repo_root": str(root),
+        "schema_path": str(schema_path),
+        "base_seed": inputs.base_seed,
+        "repeats": inputs.repeats,
+        "horizon": inputs.horizon,
+        "dt": inputs.dt,
+        "workers": inputs.workers,
+        "video_enabled": inputs.video_enabled,
+        "resume": inputs.resume,
+    }
+
+    output_dir_abs.mkdir(parents=True, exist_ok=True)
+    started_at = clock().isoformat()
+
+    scenario_abs = _abs_under_root(root, str(plan.scenario_manifest))
+    results: list[ArmExecutionResult] = []
+    for job in plan.arms:
+        out_abs = _abs_under_root(root, job.output_jsonl)
+        algo_config_abs = _abs_under_root(root, job.algorithm_config)
+        results.append(
+            _execute_arm(
+                run_batch,
+                job=job,
+                scenario_abs=scenario_abs,
+                out_abs=out_abs,
+                schema_abs=schema_abs,
+                algo_config_abs=algo_config_abs,
+                inputs=inputs,
+            )
+        )
+
+    ended_at = clock().isoformat()
+    all_ok = len(results) == len(REQUIRED_ARMS) and all(
+        r.status == "executed" and r.written > 0 for r in results
     )
+    status = "complete" if all_ok else "results_incomplete"
+
+    manifest = DenseExecutionManifest(
+        schema_version=EXECUTION_MANIFEST_SCHEMA_VERSION,
+        packet_path=plan.packet_path,
+        packet_schema_version=plan.packet_schema_version,
+        plan_schema_version=plan.schema_version,
+        authorization_id=REQUIRED_AUTHORIZATION_ID,
+        git_sha=git_sha,
+        git_dirty=git_dirty,
+        algorithm=str(plan.algorithm),
+        scenario_manifest=str(plan.scenario_manifest),
+        output_dir=plan.output_dir,
+        provenance_key=provenance_key,
+        effective_arguments=effective_arguments,
+        arms=tuple(results),
+        started_at=started_at,
+        ended_at=ended_at,
+        status=status,
+        excluded_row_statuses=plan.excluded_row_statuses,
+    )
+    manifest_path.write_text(
+        json.dumps(manifest_to_dict(manifest), indent=2, sort_keys=True), encoding="utf-8"
+    )
+    return manifest
+
+
+def _execute_arm(
+    run_batch: Callable[..., dict[str, Any]],
+    *,
+    job: ArmJobPlan,
+    scenario_abs: Path,
+    out_abs: Path,
+    schema_abs: Path,
+    algo_config_abs: Path,
+    inputs: DenseExecutionInputs,
+) -> ArmExecutionResult:
+    """Run one arm through the canonical runner and classify its outcome.
+
+    A runner exception or a run that writes nothing is recorded as ``failed`` and remains a
+    visible caveat in the manifest; it never blocks the remaining arms and is never counted as
+    success.
+
+    Returns:
+        The per-arm execution result.
+    """
+    try:
+        summary = run_batch(
+            scenarios_or_path=str(scenario_abs),
+            out_path=str(out_abs),
+            schema_path=str(schema_abs),
+            base_seed=inputs.base_seed,
+            repeats_override=inputs.repeats,
+            horizon=inputs.horizon,
+            dt=inputs.dt,
+            algo=job.algorithm,
+            algo_config_path=str(algo_config_abs),
+            video_enabled=False,
+            video_renderer="none",
+            workers=inputs.workers,
+            resume=inputs.resume,
+            append=inputs.resume,
+        )
+    except Exception as exc:  # noqa: BLE001 - any runner failure is a visible caveat, not a crash
+        return ArmExecutionResult(
+            arm_key=job.arm_key,
+            algorithm=job.algorithm,
+            algorithm_config=job.algorithm_config,
+            output_jsonl=job.output_jsonl,
+            status="failed",
+            total_jobs=0,
+            written=0,
+            failed_jobs=0,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    summary = summary if isinstance(summary, dict) else {}
+    total_jobs = int(summary.get("total_jobs", 0) or 0)
+    written = int(summary.get("written", 0) or 0)
+    failures = summary.get("failures", [])
+    failed_jobs = (
+        len(failures) if isinstance(failures, list) else int(summary.get("failed_jobs", 0))
+    )
+    ok = total_jobs > 0 and written >= total_jobs and failed_jobs == 0
+    return ArmExecutionResult(
+        arm_key=job.arm_key,
+        algorithm=job.algorithm,
+        algorithm_config=job.algorithm_config,
+        output_jsonl=job.output_jsonl,
+        status="executed" if ok else "failed",
+        total_jobs=total_jobs,
+        written=written,
+        failed_jobs=failed_jobs,
+        error=None if ok else "run wrote fewer episodes than scheduled or reported failures",
+    )
+
+
+def manifest_to_dict(manifest: DenseExecutionManifest) -> dict[str, Any]:
+    """Return a JSON-serializable view of the execution manifest."""
+    return {
+        "schema_version": manifest.schema_version,
+        "packet_path": manifest.packet_path,
+        "packet_schema_version": manifest.packet_schema_version,
+        "plan_schema_version": manifest.plan_schema_version,
+        "authorization_id": manifest.authorization_id,
+        "git_sha": manifest.git_sha,
+        "git_dirty": manifest.git_dirty,
+        "algorithm": manifest.algorithm,
+        "scenario_manifest": manifest.scenario_manifest,
+        "output_dir": manifest.output_dir,
+        "provenance_key": manifest.provenance_key,
+        "effective_arguments": dict(manifest.effective_arguments),
+        "status": manifest.status,
+        "claim_boundary": manifest.claim_boundary,
+        "excluded_row_statuses": list(manifest.excluded_row_statuses),
+        "arms": [
+            {
+                "arm_key": arm.arm_key,
+                "algorithm": arm.algorithm,
+                "algorithm_config": arm.algorithm_config,
+                "output_jsonl": arm.output_jsonl,
+                "status": arm.status,
+                "total_jobs": arm.total_jobs,
+                "written": arm.written,
+                "failed_jobs": arm.failed_jobs,
+                "error": arm.error,
+            }
+            for arm in manifest.arms
+        ],
+        "started_at": manifest.started_at,
+        "ended_at": manifest.ended_at,
+    }
 
 
 def to_dict(plan: DenseComparisonRunPlan) -> dict[str, Any]:
@@ -316,6 +807,16 @@ def to_dict(plan: DenseComparisonRunPlan) -> dict[str, Any]:
         "fallback_rows_are_success_evidence": plan.fallback_rows_are_success_evidence,
         "excluded_row_statuses": list(plan.excluded_row_statuses),
         "fallback_excluded": plan.fallback_excluded,
+        "execution_inputs": {
+            "base_seed": plan.execution_inputs.base_seed,
+            "repeats": plan.execution_inputs.repeats,
+            "horizon": plan.execution_inputs.horizon,
+            "dt": plan.execution_inputs.dt,
+            "workers": plan.execution_inputs.workers,
+            "video_enabled": plan.execution_inputs.video_enabled,
+            "resume": plan.execution_inputs.resume,
+        },
+        "authorization_required": REQUIRED_AUTHORIZATION_ID,
         "arms": [
             {
                 "arm_key": job.arm_key,
@@ -390,15 +891,25 @@ def render_markdown(plan: DenseComparisonRunPlan) -> str:
 
 __all__ = [
     "CLAIM_BOUNDARY",
+    "DEFAULT_EXECUTION_INPUTS",
     "DEFAULT_OUTPUT_DIR",
+    "EPISODE_SCHEMA_PATH",
+    "EXECUTION_MANIFEST_FILENAME",
+    "EXECUTION_MANIFEST_SCHEMA_VERSION",
     "PLAN_SCHEMA_VERSION",
+    "REQUIRED_AUTHORIZATION_ID",
     "RUNNER_GATES",
+    "ArmExecutionResult",
     "ArmJobPlan",
     "DenseComparisonExecutionGatedError",
+    "DenseComparisonProvenanceMismatchError",
     "DenseComparisonRunPlan",
     "DenseComparisonRunnerError",
+    "DenseExecutionInputs",
+    "DenseExecutionManifest",
     "build_run_plan",
     "execute_run_plan",
+    "manifest_to_dict",
     "render_markdown",
     "to_dict",
 ]

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
@@ -9,12 +9,12 @@ packet ``configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml`` but explic
 one downstream gate open: *no packet-consuming runner is wired to schema*
 ``robot_sf.issue_4142_dpcbf_dense_comparison.v1``.
 
-This module closes that first gate at the planning level. It consumes the packet schema and
-resolves it into a concrete, ordered three-arm **run plan** -- one benchmark job per arm,
-each pinned to the packet's shared algorithm, that arm's adapter config, the shared scenario
-manifest, and a per-arm output path. The plan is what a future authorized executor would
-run; building it makes the packet schema executable-in-principle and inspectable, so the
-canonical command can enumerate the exact jobs instead of failing on an unrecognized schema.
+This module closes that first gate at the planning and bounded-execution levels. It consumes the
+packet schema and resolves it into a concrete, ordered three-arm **run plan** -- one benchmark
+job per arm, each pinned to the packet's shared algorithm, that arm's adapter config, the shared
+scenario manifest, and a per-arm output path. The plan is the input to an explicitly authorized
+local executor, so the canonical command can enumerate and run the exact jobs without widening
+into a benchmark campaign.
 
 Two hard boundaries are preserved, fail-closed:
 

--- a/scripts/tools/run_issue_4142_dpcbf_dense_comparison.py
+++ b/scripts/tools/run_issue_4142_dpcbf_dense_comparison.py
@@ -7,10 +7,10 @@ three-arm run plan (``cbf_off``, ``cbf_collision_cone_on``, ``cbf_dynamic_parabo
 using the canonical readiness validator as the single source of truth. It runs no episodes
 and authorizes no campaign.
 
-The default (and only supported) mode is a dry-run: the plan is printed, nothing is written
-to disk, and execution stays authorization-gated. Passing ``--execute`` fails closed --
-running the dense comparison requires explicit human/Slurm authorization that this slice
-does not grant.
+The default mode is a dry-run: the plan is printed, nothing is written to disk, and execution
+stays authorization-gated. Passing ``--execute`` runs bounded local episodes **only** when the
+exact public authorization ID is supplied through ``--authorization``; otherwise it fails
+closed and writes nothing. This runs local episodes only -- no Slurm/GPU submission.
 
 Examples:
     # Human-readable Markdown run plan against the current checkout.
@@ -20,8 +20,12 @@ Examples:
     uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py \
         --format json --fail-on-blocked
 
-    # Attempting execution fails closed (execution is authorization-gated).
+    # Attempting execution without the authorization ID fails closed (no files written).
     uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py --execute
+
+    # Authorized bounded local run of all three arms.
+    uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py \
+        --execute --authorization RSF-DPCBF-DENSE-20260712
 """
 
 from __future__ import annotations
@@ -38,9 +42,11 @@ from robot_sf.benchmark.issue_4142_dpcbf_dense_readiness import (
 from robot_sf.benchmark.issue_4142_dpcbf_dense_runner import (
     DEFAULT_OUTPUT_DIR,
     DenseComparisonExecutionGatedError,
+    DenseComparisonProvenanceMismatchError,
     DenseComparisonRunnerError,
     build_run_plan,
     execute_run_plan,
+    manifest_to_dict,
     render_markdown,
     to_dict,
 )
@@ -82,8 +88,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--execute",
         action="store_true",
         help=(
-            "Attempt to execute the comparison. Fails closed: execution is "
-            "authorization-gated and out of scope for this runner slice."
+            "Run bounded local episodes for all three arms. Requires the exact public "
+            "authorization ID via --authorization; otherwise fails closed and writes nothing."
+        ),
+    )
+    parser.add_argument(
+        "--authorization",
+        type=str,
+        default=None,
+        help=(
+            "Exact public authorization ID required to actually run episodes. A boolean, "
+            "environment variable, implicit TTY, or bare --execute flag is insufficient."
         ),
     )
     return parser.parse_args(argv)
@@ -94,7 +109,8 @@ def main(argv: list[str] | None = None) -> int:
 
     Returns:
         Process exit code (0 on success; 1 when blocked and ``--fail-on-blocked``;
-        2 on packet load error; 3 when ``--execute`` hits the authorization gate).
+        2 on packet load error; 3 when ``--execute`` hits the authorization gate;
+        4 on a provenance mismatch; 5 when an authorized run did not complete all arms).
     """
     args = _parse_args(argv)
     try:
@@ -114,10 +130,25 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.execute:
         try:
-            execute_run_plan(plan)
+            manifest = execute_run_plan(
+                plan,
+                authorization=args.authorization,
+                repo_root=args.repo_root,
+            )
         except DenseComparisonExecutionGatedError as exc:
             print(f"execution gated: {exc}", file=sys.stderr)
             return 3
+        except DenseComparisonProvenanceMismatchError as exc:
+            print(f"provenance mismatch: {exc}", file=sys.stderr)
+            return 4
+        print(json.dumps(manifest_to_dict(manifest), indent=2, sort_keys=True))
+        if manifest.status != "complete":
+            print(
+                f"execution incomplete: manifest status {manifest.status!r}; "
+                "failed/degraded arms are caveats, never success evidence.",
+                file=sys.stderr,
+            )
+            return 5
 
     if args.fail_on_blocked and not plan.is_executable_in_principle:
         return 1

--- a/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
+++ b/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
@@ -1,0 +1,411 @@
+"""Tests for the issue #5419 authorization-gated dense DPCBF episode executor.
+
+This is the slice that turns ``execute_run_plan`` from an always-raise gate into a bounded,
+explicitly authorized *local* executor. The tests pin the fail-closed contract the issue asks
+for:
+
+- **No / wrong authorization ID** -> raises before any output file is created.
+- **Correct authorization ID** -> all three arms are dispatched through the canonical benchmark
+  runner in packet order, each with the shared scenario manifest and its distinct algorithm
+  config, and a machine-readable manifest is written.
+- **A failing arm** stays a visible caveat in the manifest, blocks an overall ``complete``
+  status, and does not cause later arms to be misreported as successful.
+- **A repeated invocation** safely resumes matching provenance or fails closed on mismatch.
+- One tiny **smoke** proves the real ``run_batch`` integration with a reduced horizon/repeats
+  through a test-only fixture (not the tracked result packet), making no performance claim.
+
+Claim boundary: diagnostic/contract tests only. Even the smoke runs a reduced, test-only
+fixture and asserts *that episodes were produced*, never a safety-performance or
+collision-reduction result. Failed/degraded rows are caveats, never success evidence.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import pathlib
+from typing import Any
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.issue_4142_dpcbf_dense_readiness import (
+    PACKET_PATH,
+    REQUIRED_ARMS,
+)
+from robot_sf.benchmark.issue_4142_dpcbf_dense_runner import (
+    EPISODE_SCHEMA_PATH,
+    EXECUTION_MANIFEST_FILENAME,
+    EXECUTION_MANIFEST_SCHEMA_VERSION,
+    REQUIRED_AUTHORIZATION_ID,
+    DenseComparisonExecutionGatedError,
+    DenseComparisonProvenanceMismatchError,
+    build_run_plan,
+    execute_run_plan,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+# A well-formed synthetic packet whose arm configs pass readiness. ``algorithm`` is
+# ``simple_policy`` so the smoke can run real episodes on CPU without MPC dependencies.
+_RUNNABLE_PACKET = {
+    "schema_version": "robot_sf.issue_4142_dpcbf_dense_comparison.v1",
+    "canonical_command": "uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py",
+    "scenario_manifest": "configs/scenarios/sets/dense.yaml",
+    "algorithm": "simple_policy",
+    "algorithm_configs": {
+        "cbf_off": "configs/algos/off.yaml",
+        "cbf_collision_cone_on": "configs/algos/cone.yaml",
+        "cbf_dynamic_parabolic_v1_on": "configs/algos/dpcbf.yaml",
+    },
+    "execution": {
+        "base_seed": 7,
+        "repeats": 1,
+        "horizon": 3,
+        "dt": 0.1,
+        "workers": 1,
+        "video_enabled": False,
+        "resume": True,
+    },
+    "runtime_cbf_arms": [
+        {"enabled": False, "arm_key": "cbf_off"},
+        {"enabled": True, "arm_key": "cbf_collision_cone_on"},
+        {
+            "enabled": True,
+            "arm_key": "cbf_dynamic_parabolic_v1_on",
+            "variant": "dynamic_parabolic_cbf_v1",
+        },
+    ],
+    "summary_contract": {
+        "evidence_tier": "bounded_runtime_comparison",
+        "fallback_rows_are_success_evidence": False,
+        "excluded_row_statuses": ["fallback", "degraded", "failed", "ineligible"],
+        "required_arms": [
+            "cbf_off",
+            "cbf_collision_cone_on",
+            "cbf_dynamic_parabolic_v1_on",
+        ],
+    },
+}
+
+
+def _write_runnable_tree(root: pathlib.Path, packet: dict) -> pathlib.Path:
+    """Materialize a minimal repo tree with a *runnable* scenario manifest under ``root``."""
+    (root / "configs/algos").mkdir(parents=True, exist_ok=True)
+    (root / "configs/scenarios/sets").mkdir(parents=True, exist_ok=True)
+    (root / "configs/research").mkdir(parents=True, exist_ok=True)
+
+    # Abstract (non-map) scenarios the canonical runner can execute quickly on CPU. Written as
+    # a multi-document YAML stream so ``load_scenario_matrix`` returns them directly instead of
+    # routing through the map-oriented manifest loader (which expects a name + map reference).
+    scenarios = [
+        {
+            "id": "dpcbf-smoke-a",
+            "density": "low",
+            "flow": "uni",
+            "obstacle": "open",
+            "groups": 0.0,
+            "speed_var": "low",
+            "goal_topology": "point",
+            "robot_context": "embedded",
+            "repeats": 1,
+        },
+        {
+            "id": "dpcbf-smoke-b",
+            "density": "low",
+            "flow": "uni",
+            "obstacle": "open",
+            "groups": 0.0,
+            "speed_var": "low",
+            "goal_topology": "point",
+            "robot_context": "embedded",
+            "repeats": 1,
+        },
+    ]
+    (root / "configs/scenarios/sets/dense.yaml").write_text(
+        yaml.safe_dump_all(scenarios, sort_keys=False), encoding="utf-8"
+    )
+    (root / "configs/algos/off.yaml").write_text("algorithm: simple_policy\n", encoding="utf-8")
+    (root / "configs/algos/cone.yaml").write_text(
+        "cbf_safety_filter:\n  enabled: true\n", encoding="utf-8"
+    )
+    (root / "configs/algos/dpcbf.yaml").write_text(
+        "cbf_safety_filter:\n  enabled: true\n  variant: dynamic_parabolic_cbf_v1\n",
+        encoding="utf-8",
+    )
+    packet_path = root / "configs/research/packet.yaml"
+    packet_path.write_text(yaml.safe_dump(packet, sort_keys=False), encoding="utf-8")
+    return packet_path
+
+
+def _success_summary(total: int = 1) -> dict[str, Any]:
+    """A run_batch summary that reports every scheduled job written with no failures."""
+    return {"total_jobs": total, "written": total, "failures": []}
+
+
+class _RecordingRunBatch:
+    """A fake ``run_batch`` that records each call and returns a caller-chosen summary."""
+
+    def __init__(self, summary_for=None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._summary_for = summary_for or (lambda idx, kwargs: _success_summary())
+
+    def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        idx = len(self.calls)
+        self.calls.append(kwargs)
+        return self._summary_for(idx, kwargs)
+
+
+def _config_stem(path: str) -> str:
+    """Return the arm config filename for order/identity assertions."""
+    return pathlib.Path(path).name
+
+
+# --- Authorization gate (fail closed before any write) ---
+
+
+def test_no_authorization_raises_before_creating_output(tmp_path: pathlib.Path) -> None:
+    """Without an authorization ID the executor raises and creates no output directory."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    fake = _RecordingRunBatch()
+
+    with pytest.raises(DenseComparisonExecutionGatedError):
+        execute_run_plan(plan, repo_root=REPO_ROOT, run_batch_fn=fake)
+
+    assert not out_dir.exists()
+    assert fake.calls == []  # no arm dispatched
+
+
+def test_wrong_authorization_raises_before_creating_output(tmp_path: pathlib.Path) -> None:
+    """A wrong authorization ID (incl. a truthy non-matching string) fails closed, no writes."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    fake = _RecordingRunBatch()
+
+    with pytest.raises(DenseComparisonExecutionGatedError):
+        execute_run_plan(plan, authorization="not-the-id", repo_root=REPO_ROOT, run_batch_fn=fake)
+    with pytest.raises(DenseComparisonExecutionGatedError):
+        # A bare boolean-ish truthy value is also insufficient.
+        execute_run_plan(plan, authorization="true", repo_root=REPO_ROOT, run_batch_fn=fake)
+
+    assert not out_dir.exists()
+    assert fake.calls == []
+
+
+def test_unresolved_plan_cannot_execute_even_with_authorization(tmp_path: pathlib.Path) -> None:
+    """A blocked plan raises before authorization even matters -- no output created."""
+    packet = copy.deepcopy(_RUNNABLE_PACKET)
+    packet["runtime_cbf_arms"] = packet["runtime_cbf_arms"][:2]  # drop the DPCBF arm
+    packet["summary_contract"]["required_arms"] = ["cbf_off", "cbf_collision_cone_on"]
+    packet_path = _write_runnable_tree(tmp_path, packet)
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=tmp_path, packet_path=packet_path, output_dir=out_dir)
+    assert plan.is_executable_in_principle is False
+
+    with pytest.raises(DenseComparisonExecutionGatedError):
+        execute_run_plan(
+            plan,
+            authorization=REQUIRED_AUTHORIZATION_ID,
+            repo_root=tmp_path,
+            run_batch_fn=_RecordingRunBatch(),
+        )
+    assert not out_dir.exists()
+
+
+# --- Authorized dispatch + manifest ---
+
+
+def test_authorized_run_dispatches_all_arms_in_packet_order(tmp_path: pathlib.Path) -> None:
+    """Correct ID dispatches the three arms in order, shared manifest, distinct configs."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    fake = _RecordingRunBatch()
+
+    manifest = execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=fake,
+    )
+
+    # One dispatch per required arm, in packet order (identified by algorithm config).
+    assert len(fake.calls) == len(REQUIRED_ARMS)
+    dispatched_configs = [_config_stem(c["algo_config_path"]) for c in fake.calls]
+    assert dispatched_configs == [_config_stem(job.algorithm_config) for job in plan.arms]
+    # All arms share the one scenario manifest; each arm has a distinct algo config + output.
+    assert len({c["scenarios_or_path"] for c in fake.calls}) == 1
+    assert len({c["algo_config_path"] for c in fake.calls}) == len(REQUIRED_ARMS)
+    assert len({c["out_path"] for c in fake.calls}) == len(REQUIRED_ARMS)
+    # Bounded execution inputs are threaded through to the runner.
+    for call in fake.calls:
+        assert call["horizon"] == plan.execution_inputs.horizon
+        assert call["repeats_override"] == plan.execution_inputs.repeats
+        assert call["video_enabled"] is False
+
+    # Manifest reflects a complete run and is persisted under the output directory.
+    assert manifest.status == "complete"
+    assert tuple(a.arm_key for a in manifest.arms) == REQUIRED_ARMS
+    assert all(a.status == "executed" for a in manifest.arms)
+    manifest_file = out_dir / EXECUTION_MANIFEST_FILENAME
+    assert manifest_file.is_file()
+
+
+def test_manifest_contains_required_provenance_fields(tmp_path: pathlib.Path) -> None:
+    """The persisted manifest carries the full provenance the issue requires."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=_RecordingRunBatch(),
+    )
+    payload = json.loads((out_dir / EXECUTION_MANIFEST_FILENAME).read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == EXECUTION_MANIFEST_SCHEMA_VERSION
+    assert payload["packet_schema_version"] == plan.packet_schema_version
+    assert payload["plan_schema_version"] == plan.schema_version
+    assert payload["authorization_id"] == REQUIRED_AUTHORIZATION_ID
+    assert "git_sha" in payload and isinstance(payload["git_dirty"], bool)
+    assert payload["effective_arguments"]["horizon"] == plan.execution_inputs.horizon
+    assert payload["started_at"] and payload["ended_at"]
+    assert payload["status"] == "complete"
+    # Fail-closed exclusion is carried into the manifest.
+    for status in ("fallback", "degraded", "failed", "ineligible"):
+        assert status in payload["excluded_row_statuses"]
+    # Per-arm output paths and statuses are all present.
+    assert {a["arm_key"] for a in payload["arms"]} == set(REQUIRED_ARMS)
+    assert all(a["output_jsonl"] for a in payload["arms"])
+
+
+def test_failing_arm_stays_visible_and_blocks_complete(tmp_path: pathlib.Path) -> None:
+    """A failing middle arm is a visible caveat; later arms keep their true status."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+
+    def summary_for(idx: int, _kwargs: dict[str, Any]) -> dict[str, Any]:
+        if idx == 1:  # the second (collision-cone) arm fails hard
+            raise RuntimeError("simulated arm failure")
+        return _success_summary()
+
+    fake = _RecordingRunBatch(summary_for=summary_for)
+    manifest = execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=fake,
+    )
+
+    # All arms were attempted in order; the failure did not abort the run.
+    assert len(fake.calls) == len(REQUIRED_ARMS)
+    by_arm = {a.arm_key: a for a in manifest.arms}
+    assert by_arm["cbf_collision_cone_on"].status == "failed"
+    assert by_arm["cbf_collision_cone_on"].error is not None
+    # The later arm ran and reports its real (executed) status -- not misreported off a failure.
+    assert by_arm["cbf_dynamic_parabolic_v1_on"].status == "executed"
+    # A failing arm blocks an overall complete status.
+    assert manifest.status == "results_incomplete"
+
+
+def test_arm_writing_fewer_than_scheduled_is_not_success(tmp_path: pathlib.Path) -> None:
+    """An arm that writes fewer episodes than scheduled is a caveat, never success."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+
+    def summary_for(idx: int, _kwargs: dict[str, Any]) -> dict[str, Any]:
+        if idx == 0:
+            return {"total_jobs": 4, "written": 1, "failures": []}  # partial write
+        return _success_summary()
+
+    manifest = execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=_RecordingRunBatch(summary_for=summary_for),
+    )
+    by_arm = {a.arm_key: a for a in manifest.arms}
+    assert by_arm["cbf_off"].status == "failed"
+    assert manifest.status == "results_incomplete"
+
+
+# --- Provenance-safe resume ---
+
+
+def test_repeat_run_matching_provenance_resumes(tmp_path: pathlib.Path) -> None:
+    """A second run with identical provenance does not fail closed."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=_RecordingRunBatch(),
+    )
+    # Re-run: same plan, same git provenance -> allowed (no mismatch raised).
+    manifest = execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=_RecordingRunBatch(),
+    )
+    assert manifest.status == "complete"
+
+
+def test_repeat_run_mismatched_provenance_fails_closed(tmp_path: pathlib.Path) -> None:
+    """A pre-existing manifest with a different provenance key blocks a silent resume."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=_RecordingRunBatch(),
+    )
+    # Tamper the recorded provenance so the next run would mix incompatible artifacts.
+    manifest_file = out_dir / EXECUTION_MANIFEST_FILENAME
+    payload = json.loads(manifest_file.read_text(encoding="utf-8"))
+    payload["provenance_key"] = "incompatible-provenance"
+    manifest_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(DenseComparisonProvenanceMismatchError):
+        execute_run_plan(
+            plan,
+            authorization=REQUIRED_AUTHORIZATION_ID,
+            repo_root=REPO_ROOT,
+            run_batch_fn=_RecordingRunBatch(),
+        )
+
+
+# --- Smoke: real run_batch integration (reduced horizon/repeats, no performance claim) ---
+
+
+def test_smoke_real_run_batch_writes_episodes(tmp_path: pathlib.Path) -> None:
+    """Authorized run through the *real* ``run_batch`` writes per-arm JSONL for every arm.
+
+    This proves the executor is wired to the canonical benchmark runner. It uses a reduced,
+    test-only fixture (horizon 3, 1 repeat, ``simple_policy``) and asserts only that episodes
+    were produced -- it makes no safety-performance or collision-reduction claim.
+    """
+    packet_path = _write_runnable_tree(tmp_path, copy.deepcopy(_RUNNABLE_PACKET))
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=tmp_path, packet_path=packet_path, output_dir=out_dir)
+    assert plan.is_executable_in_principle is True
+    assert plan.execution_inputs.horizon == 3  # bounded fixture inputs honored
+
+    manifest = execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=tmp_path,
+        # The episode schema is a real repo asset, not part of the synthetic fixture tree.
+        schema_path=REPO_ROOT / EPISODE_SCHEMA_PATH,
+    )
+
+    assert manifest.status == "complete"
+    assert tuple(a.arm_key for a in manifest.arms) == REQUIRED_ARMS
+    for arm in manifest.arms:
+        assert arm.status == "executed"
+        assert arm.written > 0
+        artifact = tmp_path / arm.output_jsonl
+        assert artifact.is_file()
+        assert artifact.read_text(encoding="utf-8").strip()  # at least one episode row

--- a/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
+++ b/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
@@ -1,22 +1,8 @@
-"""Tests for the issue #5419 authorization-gated dense DPCBF episode executor.
+"""Fail-closed contract tests for the issue #5419 local DPCBF executor.
 
-This is the slice that turns ``execute_run_plan`` from an always-raise gate into a bounded,
-explicitly authorized *local* executor. The tests pin the fail-closed contract the issue asks
-for:
-
-- **No / wrong authorization ID** -> raises before any output file is created.
-- **Correct authorization ID** -> all three arms are dispatched through the canonical benchmark
-  runner in packet order, each with the shared scenario manifest and its distinct algorithm
-  config, and a machine-readable manifest is written.
-- **A failing arm** stays a visible caveat in the manifest, blocks an overall ``complete``
-  status, and does not cause later arms to be misreported as successful.
-- **A repeated invocation** safely resumes matching provenance or fails closed on mismatch.
-- One tiny **smoke** proves the real ``run_batch`` integration with a reduced horizon/repeats
-  through a test-only fixture (not the tracked result packet), making no performance claim.
-
-Claim boundary: diagnostic/contract tests only. Even the smoke runs a reduced, test-only
-fixture and asserts *that episodes were produced*, never a safety-performance or
-collision-reduction result. Failed/degraded rows are caveats, never success evidence.
+They cover authorization, ordered arm dispatch, caveat statuses, content-bound provenance,
+atomic interruption checkpoints, orphan output, and a reduced real-runner run-twice smoke.
+The smoke proves wiring only; failed/degraded rows remain caveats, never success evidence.
 """
 
 from __future__ import annotations
@@ -98,9 +84,7 @@ def _write_runnable_tree(root: pathlib.Path, packet: dict) -> pathlib.Path:
     (root / "configs/scenarios/sets").mkdir(parents=True, exist_ok=True)
     (root / "configs/research").mkdir(parents=True, exist_ok=True)
 
-    # Abstract (non-map) scenarios the canonical runner can execute quickly on CPU. Written as
-    # a multi-document YAML stream so ``load_scenario_matrix`` returns them directly instead of
-    # routing through the map-oriented manifest loader (which expects a name + map reference).
+    # A multi-document stream keeps these abstract smoke scenarios off the map loader path.
     scenarios = [
         {
             "id": "dpcbf-smoke-a",
@@ -175,9 +159,6 @@ def _config_stem(path: str) -> str:
     return pathlib.Path(path).name
 
 
-# --- Authorization gate (fail closed before any write) ---
-
-
 def test_no_authorization_raises_before_creating_output(tmp_path: pathlib.Path) -> None:
     """Without an authorization ID the executor raises and creates no output directory."""
     out_dir = tmp_path / "out"
@@ -200,7 +181,6 @@ def test_wrong_authorization_raises_before_creating_output(tmp_path: pathlib.Pat
     with pytest.raises(DenseComparisonExecutionGatedError):
         execute_run_plan(plan, authorization="not-the-id", repo_root=REPO_ROOT, run_batch_fn=fake)
     with pytest.raises(DenseComparisonExecutionGatedError):
-        # A bare boolean-ish truthy value is also insufficient.
         execute_run_plan(plan, authorization="true", repo_root=REPO_ROOT, run_batch_fn=fake)
 
     assert not out_dir.exists()
@@ -227,9 +207,6 @@ def test_unresolved_plan_cannot_execute_even_with_authorization(tmp_path: pathli
     assert not out_dir.exists()
 
 
-# --- Authorized dispatch + manifest ---
-
-
 def test_authorized_run_dispatches_all_arms_in_packet_order(tmp_path: pathlib.Path) -> None:
     """Correct ID dispatches the three arms in order, shared manifest, distinct configs."""
     out_dir = tmp_path / "out"
@@ -243,21 +220,17 @@ def test_authorized_run_dispatches_all_arms_in_packet_order(tmp_path: pathlib.Pa
         run_batch_fn=fake,
     )
 
-    # One dispatch per required arm, in packet order (identified by algorithm config).
     assert len(fake.calls) == len(REQUIRED_ARMS)
     dispatched_configs = [_config_stem(c["algo_config_path"]) for c in fake.calls]
     assert dispatched_configs == [_config_stem(job.algorithm_config) for job in plan.arms]
-    # All arms share the one scenario manifest; each arm has a distinct algo config + output.
     assert len({c["scenarios_or_path"] for c in fake.calls}) == 1
     assert len({c["algo_config_path"] for c in fake.calls}) == len(REQUIRED_ARMS)
     assert len({c["out_path"] for c in fake.calls}) == len(REQUIRED_ARMS)
-    # Bounded execution inputs are threaded through to the runner.
     for call in fake.calls:
         assert call["horizon"] == plan.execution_inputs.horizon
         assert call["repeats_override"] == plan.execution_inputs.repeats
         assert call["video_enabled"] is False
 
-    # Manifest reflects a complete run and is persisted under the output directory.
     assert manifest.status == "complete"
     assert tuple(a.arm_key for a in manifest.arms) == REQUIRED_ARMS
     assert all(a.status == "executed" for a in manifest.arms)
@@ -288,10 +261,8 @@ def test_manifest_contains_required_provenance_fields(tmp_path: pathlib.Path) ->
     assert payload["started_at"] == "2026-07-12T12:00:00+00:00"
     assert payload["ended_at"] == "2026-07-12T12:00:00+00:00"
     assert payload["status"] == "complete"
-    # Fail-closed exclusion is carried into the manifest.
     for status in ("fallback", "degraded", "failed", "ineligible"):
         assert status in payload["excluded_row_statuses"]
-    # Per-arm output paths and statuses are all present.
     assert {a["arm_key"] for a in payload["arms"]} == set(REQUIRED_ARMS)
     assert all(a["output_jsonl"] for a in payload["arms"])
 
@@ -314,14 +285,11 @@ def test_failing_arm_stays_visible_and_blocks_complete(tmp_path: pathlib.Path) -
         run_batch_fn=fake,
     )
 
-    # All arms were attempted in order; the failure did not abort the run.
     assert len(fake.calls) == len(REQUIRED_ARMS)
     by_arm = {a.arm_key: a for a in manifest.arms}
     assert by_arm["cbf_collision_cone_on"].status == "failed"
     assert by_arm["cbf_collision_cone_on"].error is not None
-    # The later arm ran and reports its real (executed) status -- not misreported off a failure.
     assert by_arm["cbf_dynamic_parabolic_v1_on"].status == "executed"
-    # A failing arm blocks an overall complete status.
     assert manifest.status == "results_incomplete"
 
 
@@ -346,29 +314,6 @@ def test_arm_writing_fewer_than_scheduled_is_not_success(tmp_path: pathlib.Path)
     assert manifest.status == "results_incomplete"
 
 
-# --- Provenance-safe resume ---
-
-
-def test_repeat_run_matching_provenance_resumes(tmp_path: pathlib.Path) -> None:
-    """A second run with identical provenance does not fail closed."""
-    out_dir = tmp_path / "out"
-    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
-    execute_run_plan(
-        plan,
-        authorization=REQUIRED_AUTHORIZATION_ID,
-        repo_root=REPO_ROOT,
-        run_batch_fn=_RecordingRunBatch(),
-    )
-    # Re-run: same plan, same git provenance -> allowed (no mismatch raised).
-    manifest = execute_run_plan(
-        plan,
-        authorization=REQUIRED_AUTHORIZATION_ID,
-        repo_root=REPO_ROOT,
-        run_batch_fn=_RecordingRunBatch(),
-    )
-    assert manifest.status == "complete"
-
-
 def test_repeat_run_mismatched_provenance_fails_closed(tmp_path: pathlib.Path) -> None:
     """A pre-existing manifest with a different provenance key blocks a silent resume."""
     out_dir = tmp_path / "out"
@@ -379,7 +324,6 @@ def test_repeat_run_mismatched_provenance_fails_closed(tmp_path: pathlib.Path) -
         repo_root=REPO_ROOT,
         run_batch_fn=_RecordingRunBatch(),
     )
-    # Tamper the recorded provenance so the next run would mix incompatible artifacts.
     manifest_file = out_dir / EXECUTION_MANIFEST_FILENAME
     payload = json.loads(manifest_file.read_text(encoding="utf-8"))
     payload["provenance_key"] = "incompatible-provenance"
@@ -513,9 +457,6 @@ def test_non_boolean_resume_is_a_plan_blocker() -> None:
     assert any("video_enabled must be a boolean" in blocker for blocker in blockers)
 
 
-# --- Smoke: real run_batch integration (reduced horizon/repeats, no performance claim) ---
-
-
 def test_smoke_real_run_batch_writes_episodes(tmp_path: pathlib.Path) -> None:
     """Authorized run through the *real* ``run_batch`` writes per-arm JSONL for every arm.
 
@@ -533,7 +474,6 @@ def test_smoke_real_run_batch_writes_episodes(tmp_path: pathlib.Path) -> None:
         plan,
         authorization=REQUIRED_AUTHORIZATION_ID,
         repo_root=tmp_path,
-        # The episode schema is a real repo asset, not part of the synthetic fixture tree.
         schema_path=REPO_ROOT / EPISODE_SCHEMA_PATH,
     )
 

--- a/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
+++ b/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
@@ -149,14 +149,25 @@ def _success_summary(total: int = 1) -> dict[str, Any]:
 class _RecordingRunBatch:
     """A fake ``run_batch`` that records each call and returns a caller-chosen summary."""
 
-    def __init__(self, summary_for=None) -> None:
+    def __init__(self, summary_for=None, interrupt_at: int | None = None) -> None:
         self.calls: list[dict[str, Any]] = []
         self._summary_for = summary_for or (lambda idx, kwargs: _success_summary())
+        self._interrupt_at = interrupt_at
 
     def __call__(self, **kwargs: Any) -> dict[str, Any]:
         idx = len(self.calls)
         self.calls.append(kwargs)
-        return self._summary_for(idx, kwargs)
+        if idx == self._interrupt_at:
+            raise KeyboardInterrupt("simulated interruption")
+        out_path = pathlib.Path(kwargs["out_path"])
+        if kwargs.get("resume") and out_path.is_file():
+            return {"total_jobs": 0, "written": 0, "failures": []}
+        summary = self._summary_for(idx, kwargs)
+        for item in range(int(summary.get("written", 0))):
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            with out_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"episode_id": f"fake-{idx}-{item}"}) + "\n")
+        return summary
 
 
 def _config_stem(path: str) -> str:
@@ -404,6 +415,71 @@ def test_non_mapping_manifest_fails_closed(tmp_path: pathlib.Path) -> None:
         )
 
 
+def test_orphan_output_without_manifest_fails_closed(tmp_path: pathlib.Path) -> None:
+    """Existing episode output cannot be adopted without an executor checkpoint."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "cbf_off.jsonl").write_text('{"episode_id": "orphan"}\n', encoding="utf-8")
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+
+    with pytest.raises(DenseComparisonProvenanceMismatchError, match="no execution manifest"):
+        execute_run_plan(
+            plan,
+            authorization=REQUIRED_AUTHORIZATION_ID,
+            repo_root=REPO_ROOT,
+            run_batch_fn=_RecordingRunBatch(),
+        )
+
+
+def test_interrupted_execution_checkpoint_resumes(tmp_path: pathlib.Path) -> None:
+    """A checkpoint after one arm permits explicit recovery of the remaining arms."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    with pytest.raises(KeyboardInterrupt):
+        execute_run_plan(
+            plan,
+            authorization=REQUIRED_AUTHORIZATION_ID,
+            repo_root=REPO_ROOT,
+            run_batch_fn=_RecordingRunBatch(interrupt_at=1),
+        )
+
+    checkpoint = json.loads((out_dir / EXECUTION_MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    assert checkpoint["status"] == "in_progress"
+    assert checkpoint["arms"][0]["status"] == "executed"
+    resumed = execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=_RecordingRunBatch(),
+    )
+    assert resumed.status == "complete"
+    assert resumed.arms[0].status == "resumed_complete"
+
+
+def test_changed_input_content_fails_closed_on_resume(tmp_path: pathlib.Path) -> None:
+    """A config-content change cannot reuse a manifest at the same git identity."""
+    packet_path = _write_runnable_tree(tmp_path, copy.deepcopy(_RUNNABLE_PACKET))
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=tmp_path, packet_path=packet_path, output_dir=out_dir)
+    execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=tmp_path,
+        schema_path=REPO_ROOT / EPISODE_SCHEMA_PATH,
+        run_batch_fn=_RecordingRunBatch(),
+    )
+    (tmp_path / "configs/algos/off.yaml").write_text("algorithm: changed\n", encoding="utf-8")
+
+    with pytest.raises(DenseComparisonProvenanceMismatchError, match="provenance"):
+        execute_run_plan(
+            plan,
+            authorization=REQUIRED_AUTHORIZATION_ID,
+            repo_root=tmp_path,
+            schema_path=REPO_ROOT / EPISODE_SCHEMA_PATH,
+            run_batch_fn=_RecordingRunBatch(),
+        )
+
+
 def test_changed_execution_inputs_fail_closed_on_resume(tmp_path: pathlib.Path) -> None:
     """Changed worker/schema provenance cannot reuse an existing execution manifest."""
     out_dir = tmp_path / "out"
@@ -432,6 +508,9 @@ def test_non_boolean_resume_is_a_plan_blocker() -> None:
     inputs, blockers = _resolve_execution_inputs({"execution": {"resume": "false"}})
     assert inputs.resume is True
     assert any("resume must be a boolean" in blocker for blocker in blockers)
+    _, blockers = _resolve_execution_inputs({"execution": {"unknown": 1, "video_enabled": "false"}})
+    assert any("unknown key" in blocker for blocker in blockers)
+    assert any("video_enabled must be a boolean" in blocker for blocker in blockers)
 
 
 # --- Smoke: real run_batch integration (reduced horizon/repeats, no performance claim) ---
@@ -466,3 +545,12 @@ def test_smoke_real_run_batch_writes_episodes(tmp_path: pathlib.Path) -> None:
         artifact = tmp_path / arm.output_jsonl
         assert artifact.is_file()
         assert artifact.read_text(encoding="utf-8").strip()  # at least one episode row
+
+    resumed = execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=tmp_path,
+        schema_path=REPO_ROOT / EPISODE_SCHEMA_PATH,
+    )
+    assert resumed.status == "complete"
+    assert all(arm.status == "resumed_complete" and arm.written == 0 for arm in resumed.arms)

--- a/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
+++ b/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import copy
 import json
 import pathlib
+from dataclasses import replace
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -40,6 +42,7 @@ from robot_sf.benchmark.issue_4142_dpcbf_dense_runner import (
     REQUIRED_AUTHORIZATION_ID,
     DenseComparisonExecutionGatedError,
     DenseComparisonProvenanceMismatchError,
+    _resolve_execution_inputs,
     build_run_plan,
     execute_run_plan,
 )
@@ -255,11 +258,13 @@ def test_manifest_contains_required_provenance_fields(tmp_path: pathlib.Path) ->
     """The persisted manifest carries the full provenance the issue requires."""
     out_dir = tmp_path / "out"
     plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    deterministic_now = datetime(2026, 7, 12, 12, 0, 0, tzinfo=UTC)
     execute_run_plan(
         plan,
         authorization=REQUIRED_AUTHORIZATION_ID,
         repo_root=REPO_ROOT,
         run_batch_fn=_RecordingRunBatch(),
+        now_fn=lambda: deterministic_now,
     )
     payload = json.loads((out_dir / EXECUTION_MANIFEST_FILENAME).read_text(encoding="utf-8"))
 
@@ -269,7 +274,8 @@ def test_manifest_contains_required_provenance_fields(tmp_path: pathlib.Path) ->
     assert payload["authorization_id"] == REQUIRED_AUTHORIZATION_ID
     assert "git_sha" in payload and isinstance(payload["git_dirty"], bool)
     assert payload["effective_arguments"]["horizon"] == plan.execution_inputs.horizon
-    assert payload["started_at"] and payload["ended_at"]
+    assert payload["started_at"] == "2026-07-12T12:00:00+00:00"
+    assert payload["ended_at"] == "2026-07-12T12:00:00+00:00"
     assert payload["status"] == "complete"
     # Fail-closed exclusion is carried into the manifest.
     for status in ("fallback", "degraded", "failed", "ineligible"):
@@ -375,6 +381,57 @@ def test_repeat_run_mismatched_provenance_fails_closed(tmp_path: pathlib.Path) -
             repo_root=REPO_ROOT,
             run_batch_fn=_RecordingRunBatch(),
         )
+
+
+def test_non_mapping_manifest_fails_closed(tmp_path: pathlib.Path) -> None:
+    """A syntactically valid non-object manifest cannot be used for resume."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=_RecordingRunBatch(),
+    )
+    (out_dir / EXECUTION_MANIFEST_FILENAME).write_text("[]", encoding="utf-8")
+
+    with pytest.raises(DenseComparisonProvenanceMismatchError, match="not a dictionary"):
+        execute_run_plan(
+            plan,
+            authorization=REQUIRED_AUTHORIZATION_ID,
+            repo_root=REPO_ROOT,
+            run_batch_fn=_RecordingRunBatch(),
+        )
+
+
+def test_changed_execution_inputs_fail_closed_on_resume(tmp_path: pathlib.Path) -> None:
+    """Changed worker/schema provenance cannot reuse an existing execution manifest."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=_RecordingRunBatch(),
+    )
+    changed_inputs = replace(plan.execution_inputs, workers=2)
+    changed_plan = replace(plan, execution_inputs=changed_inputs)
+
+    with pytest.raises(DenseComparisonProvenanceMismatchError):
+        execute_run_plan(
+            changed_plan,
+            authorization=REQUIRED_AUTHORIZATION_ID,
+            repo_root=REPO_ROOT,
+            schema_path=tmp_path / "alternate-episode-schema.json",
+            run_batch_fn=_RecordingRunBatch(),
+        )
+
+
+def test_non_boolean_resume_is_a_plan_blocker() -> None:
+    """String values cannot silently change resume/append semantics."""
+    inputs, blockers = _resolve_execution_inputs({"execution": {"resume": "false"}})
+    assert inputs.resume is True
+    assert any("resume must be a boolean" in blocker for blocker in blockers)
 
 
 # --- Smoke: real run_batch integration (reduced horizon/repeats, no performance claim) ---


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** `execute_run_plan()` is now a bounded, explicitly authorized local executor for the #4142 Dynamic Parabolic Control Barrier Function (DPCBF) packet. It dispatches the canonical `run_batch` once per resolved arm, writes per-arm JSONL, and records atomic execution checkpoints.
- **Why now:** the packet and readiness planner resolved all three arms, but the executor still always raised and the advertised generic CLI command was invalid. This closes that executor gap without changing planner equations, metrics, scenario geometry, or campaign infrastructure.
- **Claim boundary:** diagnostic/contract only. Local episodes only; no Slurm/GPU/SSH submission, full tracked comparison, benchmark-success claim, safety claim, or paper/dissertation edit is included. Failed, degraded, fallback, and ineligible rows remain caveats.
- **Runtime-risk gate:** authorization-before-write, strict bounded-input validation, input/config/git provenance, dirty-worktree refusal, orphan-output refusal, atomic `in_progress` checkpoints, malformed-manifest rejection, and episode-identity/count validation are covered below. Byte-level binding of completed JSONL artifacts is a post-merge correction in #5435.
- **Remaining blocker:** the authorized full-scale `prediction_mpc_cv` packet is intentionally not run here; #5423 remains parked until that separate maintainer-authorized evidence step.

## Linked Issues

- Refs #5419
- Relates #4142, #5423, #5431, #5435, and #5436

## Scope resolution

Issue #5419 originally specified a +750 net-line maximum. The maintainer’s v2 corrective amendment on #5419 records a bounded `max_net_new_lines=1300` budget and the required hardening corrections. The final diff is **+1,299 net lines across the original six files**, with no new path, so it is within that recorded amendment. #5431 is the scope-contract follow-up and is resolved by this recorded decision; it does not authorize a campaign run.

## What Changed

- Added strict packet execution-block validation: unknown keys and wrong boolean types fail closed; bounds and video-off policy remain enforced.
- Added content hashes for the packet, scenario manifest, arm configs, and episode schema to the resume provenance key. Effective arguments and Git state are also bound; actual dirty Git worktrees are rejected.
- Added an atomic execution manifest written before the first arm and after each arm. Existing output without an owning manifest, invalid manifest roots/statuses, and mismatched provenance fail closed.
- Classified a no-work resume as `resumed_complete` only when the existing JSONL has exactly the expected number of valid, unique episode IDs. The real smoke runs twice against the same output. A post-merge audit found that same-cardinality replacement of completed JSONL bytes still needs explicit artifact hashing; #5435 owns that fail-closed correction.
- Updated the packet command, changelog, and pipeline context note. No planner/CBF equations, metrics, scenario geometry, or optional dependencies changed.

## Why It Matters

- Added value: the resolved packet has a bounded, auditable executor with explicit authorization and safe interruption/resume semantics.
- Expected impact: closes the authorization/path-wiring slice while keeping trusted resume, benchmark, and paper claims gated.
- Why merge now: the bounded executor path is directly testable and does not require a heavy campaign; completed-artifact byte binding is explicitly deferred to #5435 before campaign use.

## Research Result Guidance

- Target claim / hypothesis / blocker: close the #5419 executor blocker.
- Comparator or baseline: NA; no comparison result is claimed.
- Evidence tier: targeted smoke / diagnostic contract.
- Result classification: blocker-resolution, diagnostic-only.
- Decision or stop rule: stop before any full packet campaign or paper-facing interpretation.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #5419, #5431, and `docs/context/issue_4142_dpcbf_dense_pipeline.md`.
- New research/benchmark/metric/paper-facing analysis tool: NA - this is an issue-scoped executor, not an analysis tool.

## Domain-Aware Approval

- Required for this PR: yes - the executor changes the evidence-production boundary while making no experimental claim.
- Domains reviewed: evidence classification, benchmark interpretation.
- Status: approved.
- Approver/review source or waiver: Codex full PR gate; approval is limited to the diagnostic executor contract and does not establish experimental validity.
- Validity checklist:
  - Target claim/hypothesis: executor contract, not planner performance.
  - Comparator or split/evidence validity: no result comparator is used.
  - Fallback/degraded exclusions: `fallback`, `degraded`, `failed`, and `ineligible` remain excluded.
  - Claim boundary: local diagnostic episodes only; no paper claim.
  - Implementation integrity vs experimental validity: implementation integrity is tested; experimental validity is deferred.

## Falsification / Non-Transfer Check

- Did the mechanism activate? unknown for the tracked prediction-MPC packet; the reduced fixture activates the executor wiring.
- Did the intervention change command source, selected command, trajectory, or route progress? NA; no result run.
- Did the scenario contain the targeted failure mode? NA for the unrun tracked packet.
- Result route: continue with a separate authorized evidence run.
- Follow-up question: does the three-arm tracked packet complete with native, non-degraded rows under its declared command?

## Next Empirical Action

- Rerun needed: yes, separately and with maintainer authorization.
- Extractor or analysis tool needed: no new tool.
- Artifact missing or unavailable: per-arm JSONL for the tracked packet.
- Stop / revise / continue decision: continue only after the bounded local run is authorized, its manifest is complete, and #5435’s artifact-binding correction is merged.
- Proposed child issue or existing follow-up: #5435 owns the blocking artifact-bound resume correction; #5423 remains parked for planner research; #5436 tracks the post-merge readiness-wording cleanup. The executor slice is merged, but trusted resume remains conditional on those follow-ups.

## Validation / Proof

- `uv run pytest -q tests/benchmark/test_issue_4142_dpcbf_dense_readiness.py tests/benchmark/test_issue_4142_dpcbf_dense_runner.py tests/benchmark/test_issue_4142_dpcbf_dense_summary.py tests/benchmark/test_issue_4142_dpcbf_dense_pipeline_contract.py tests/benchmark/test_issue_4142_dpcbf_dense_executor.py` → **49 passed**; includes real `run_batch` smoke twice, orphan output, interruption checkpoint, malformed manifest root, input-content mismatch, strict execution types, and caveat handling.
- `uv run pytest -q tests/benchmark/test_cbf_safety_filter_runtime.py tests/benchmark/test_issue_4142_dpcbf_dense_readiness.py` → **41 passed**; covers enabled↔arm consistency, predeclared threshold equality, and adversarial simulator-state/ineligible-step fixtures.
- `uv run ruff check` on the three changed Python implementation/test files → passed.
- `uv run ruff format --check` on the three changed Python implementation/test files → passed.
- `uv run python scripts/dev/check_docs_evidence_integrity.py --base-ref origin/main` → passed.
- `uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py --format json --fail-on-blocked` → exit 0; `plan_ready_campaign_gated`, no episodes written.
- Full `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` reached green core (2,319 passed, 1 skipped) and optional (6,852 passed, 17 skipped) lanes; changed-file coverage was 93.4% (warning-only) and the TODO-docstring gate passed. The final broad-exception ratchet initially identified the arm boundary catch; after narrowing it, `check_broad_exceptions.py` returned the baseline 172 entries and the affected suites passed. No benchmark/GPU/Slurm run was performed.

## Performance Evidence

NA - no performance claim; the smoke uses a reduced test-only fixture.

## Risks / Rollout

- Compatibility risk: existing dry-run plan and summarizer contracts remain unchanged; `execute_run_plan(plan)` remains fail-closed without the exact ID.
- Failure modes: invalid inputs, dirty Git state, orphan output, malformed manifests, interrupted runs, and failed/degraded rows fail closed or remain explicit caveats.
- Residual provenance risk: a completed JSONL artifact can be same-cardinality replaced after a checkpoint without changing the current episode-ID/count validation; do not rely on resumed output until #5435 adds and validates artifact SHA-256 binding.
- Rollback: revert the executor commits; no durable benchmark artifacts are created by validation.

## Docs / Provenance

- Updated docs: `CHANGELOG.md`, `docs/context/issue_4142_dpcbf_dense_pipeline.md`, and the packet’s canonical command.
- Relevant provenance: the execution manifest records effective arguments, Git state, input content hashes, arm output paths/statuses, and timestamps; every stored provenance field is used in resume validation or is a direct audit field. Completed output-byte hashes are not present in this merged slice; #5435 adds that missing binding.
- Assumption: the public authorization ID is explicit CLI input; no environment, TTY, Slurm, or private-ops route is accepted.

## Downstream Propagation

- Parent issue updated: yes - #5419 records the merged executor slice and the late artifact-binding blocker; #5431 records the scope decision; #5435 owns the correction.
- Claim map / benchmark report updated: NA - no benchmark result.
- Leaderboard / artifact catalog updated: NA - no durable result artifact.
- Registry or config index updated: yes - packet execution block and canonical command updated.
- Context index / memory note updated: yes - `docs/context/issue_4142_dpcbf_dense_pipeline.md`.
- Follow-up issues opened for deferred propagation: #5435 owns the blocking completed-artifact hash correction; #5423 is the downstream evidence dependency and remains parked; #5436 reconciles the read-only readiness wording with the now-wired executor.

## Follow-Up Issues

- Deferred work: artifact-bound resume correction, authorized tracked three-arm local/campaign execution and later conservative synthesis, and readiness wording cleanup.
- Issues: #5435, #5423, #5436. Scope resolution is recorded in the closed contract issue; trusted resume is not treated as complete until #5435 lands.

## Reviewer Notes

- Review the `in_progress` checkpoint sequence, input-bound provenance key, dirty-worktree gate, and the current episode-identity/count validation closely; do not treat completed JSONL bytes as tamper-bound until #5435 lands.
- Existing readiness tests cover semantic CBF config validation (enabled↔arm and threshold equality) and simulator-state fail-closed behavior; this PR does not duplicate planner/runtime equations.
- The readiness surface remains a read-only preflight and is not execution authority; this PR’s explicit authorization gate is the only route to local execution.
