### PR TITLE
Issue #5429: stop misrouting single-doc abstract scenario matrices through the map loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **issue #5429 `load_scenario_matrix` no longer misroutes single-document abstract scenario
+  files.** A single-document YAML file whose top-level content is a *list* of abstract benchmark
+  scenarios (the `density`/`flow`/`obstacle` form, e.g. `yaml.safe_dump([s1, s2])`) is now returned
+  directly — symmetric with the existing multi-document stream behavior — instead of being sent
+  through the map-oriented `robot_sf/training/scenario_loader.py::load_scenarios`. Previously such
+  files were validated as map manifests and emitted misleading
+  `Scenario entry N is missing a name or scenario_id` / `has no map_file or map_id` warnings even
+  though abstract scenarios legitimately carry neither. Single-document *mappings* still route to the
+  include-aware manifest loader (unchanged), and an empty single-document list now fails closed with
+  a clear `ValueError` rather than a silent zero-job run.
+
 * **issue #5340 main CI regression from unconditional `spaces.Sequence` leaf.** PRs #5335
   and #5337 unconditionally added `spaces.Sequence` leaves to the SocNav structured observation
   space, breaking `asymmetric_critic` (`Box` leaves) and `FlattenDictObservationWrapper`. Reverted

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -22,6 +22,7 @@ import shlex
 import sys
 import time
 import uuid
+from collections.abc import Mapping
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import (
@@ -444,6 +445,17 @@ def load_scenario_matrix(path: str | Path) -> list[dict[str, Any]]:
     if isinstance(single_doc, list):
         if not single_doc:
             raise ValueError(f"Scenario matrix '{scenario_path}' contains an empty scenario list.")
+        if any(not isinstance(scenario, Mapping) for scenario in single_doc):
+            raise ValueError(f"Scenario matrix '{scenario_path}' list entries must be mappings.")
+        # Preserve the legacy manifest path for named or map-referenced entries.  Those entries
+        # rely on validation, map-id resolution, and relative-path rebasing even when the YAML
+        # document itself is a top-level list.
+        if any(
+            any(key in scenario for key in ("name", "scenario_id", "map_file", "map_id"))
+            for scenario in single_doc
+        ):
+            scenarios = load_scenarios(scenario_path, base_dir=scenario_path)
+            return [dict(s) for s in scenarios]
         return [dict(s) for s in single_doc]
     # Single-document mapping: defer to include-aware loader for manifests.
     scenarios = load_scenarios(scenario_path, base_dir=scenario_path)

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -401,10 +401,30 @@ class _PlannerStepProcess:
 
 
 def load_scenario_matrix(path: str | Path) -> list[dict[str, Any]]:
-    """Load a scenario matrix from YAML (stream, list, or dict with scenarios).
+    """Load a scenario matrix from YAML (stream, list, or mapping manifest).
+
+    Routing (see issue #5429):
+      - A **multi-document** YAML stream is an abstract scenario matrix; each
+        document is returned directly without include expansion.
+      - A **single document that is a list** is likewise an abstract scenario
+        matrix (the natural ``yaml.safe_dump([s1, s2])`` form) and is returned
+        directly. It is *not* sent through the map-oriented manifest loader,
+        which would emit misleading ``missing name``/``no map_file`` warnings
+        for abstract benchmark scenarios that legitimately carry neither.
+      - A **single document that is a mapping** is treated as a manifest and
+        deferred to the include-aware :func:`load_scenarios` (supports
+        ``includes``, ``scenarios:``, ``select_scenarios``, overrides, and
+        per-scenario ``map_file``/``map_id`` references).
+
+    Args:
+        path: Scenario matrix YAML path or a ``bundle:`` task-bundle reference.
 
     Returns:
         List of scenario dictionaries.
+
+    Raises:
+        ValueError: If the file is empty or a single-document list yields no
+            scenarios (fail closed instead of a silent ``written=0`` run).
     """
     if is_task_bundle_reference(path):
         return [dict(s) for s in load_scenarios(path)]
@@ -417,7 +437,15 @@ def load_scenario_matrix(path: str | Path) -> list[dict[str, Any]]:
     # Preserve legacy YAML stream behavior (multiple docs) without include expansion.
     if len(docs) > 1:
         return [dict(s) for s in docs]
-    # Single-document path: defer to include-aware loader for manifests.
+    # A single-document top-level list is an abstract scenario matrix, symmetric
+    # with the multi-document stream above; return it directly rather than routing
+    # abstract scenarios through the map-oriented manifest validator.
+    single_doc = docs[0]
+    if isinstance(single_doc, list):
+        if not single_doc:
+            raise ValueError(f"Scenario matrix '{scenario_path}' contains an empty scenario list.")
+        return [dict(s) for s in single_doc]
+    # Single-document mapping: defer to include-aware loader for manifests.
     scenarios = load_scenarios(scenario_path, base_dir=scenario_path)
     return [dict(s) for s in scenarios]
 

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -444,7 +444,10 @@ def load_scenario_matrix(path: str | Path) -> list[dict[str, Any]]:
     single_doc = docs[0]
     if isinstance(single_doc, list):
         if not single_doc:
-            raise ValueError(f"Scenario matrix '{scenario_path}' contains an empty scenario list.")
+            raise ValueError(
+                f"Scenario matrix '{scenario_path}' contains an empty scenario list; "
+                "scenario config has no runnable scenarios."
+            )
         if any(not isinstance(scenario, Mapping) for scenario in single_doc):
             raise ValueError(f"Scenario matrix '{scenario_path}' list entries must be mappings.")
         # Preserve the legacy manifest path for named or map-referenced entries.  Those entries

--- a/tests/benchmark/test_runner_scenario_matrix_manifest.py
+++ b/tests/benchmark/test_runner_scenario_matrix_manifest.py
@@ -72,3 +72,92 @@ def test_load_scenario_matrix_accepts_task_bundle_reference() -> None:
         "goal_behind_robot",
         "single_ped_crossing_orthogonal",
     ]
+
+
+# Abstract benchmark scenarios (density/flow/obstacle form) carry neither a
+# ``name``/``scenario_id`` nor a ``map_file``/``map_id``. They must load from a
+# single-document top-level list the same way they load from a multi-document
+# stream, without routing through the map-oriented manifest validator (#5429).
+_ABSTRACT_SCENARIOS = [
+    {
+        "id": "batch-uni-low-open",
+        "density": "low",
+        "flow": "uni",
+        "obstacle": "open",
+        "groups": 0.0,
+        "speed_var": "low",
+        "goal_topology": "point",
+        "robot_context": "embedded",
+        "repeats": 2,
+    },
+    {
+        "id": "batch-uni-high-open",
+        "density": "high",
+        "flow": "uni",
+        "obstacle": "open",
+        "groups": 0.0,
+        "speed_var": "low",
+        "goal_topology": "point",
+        "robot_context": "embedded",
+        "repeats": 2,
+    },
+]
+
+
+def _capture_loader_logs() -> tuple[list[str], int]:
+    """Attach a loguru sink capturing scenario-loader messages.
+
+    Returns:
+        Tuple of (captured message list, sink handler id) for later removal.
+    """
+    from loguru import logger
+
+    messages: list[str] = []
+    handler_id = logger.add(
+        lambda message: messages.append(message.record["message"]),
+        filter="robot_sf.training.scenario_loader",
+        level="WARNING",
+    )
+    return messages, handler_id
+
+
+def test_load_scenario_matrix_single_doc_list_returns_abstract_scenarios(tmp_path: Path) -> None:
+    """A single-document list of abstract scenarios loads verbatim (#5429)."""
+    from loguru import logger
+
+    matrix_path = tmp_path / "abstract_matrix.yaml"
+    _write_yaml(matrix_path, _ABSTRACT_SCENARIOS)
+
+    messages, handler_id = _capture_loader_logs()
+    try:
+        scenarios = load_scenario_matrix(matrix_path)
+    finally:
+        logger.remove(handler_id)
+
+    assert scenarios == _ABSTRACT_SCENARIOS
+    # No entry gained a name/map field, and the map-oriented validator was not
+    # invoked, so its misleading "missing name"/"no map_file" warnings are absent.
+    assert all("name" not in sc and "map_file" not in sc for sc in scenarios)
+    assert not any("missing a name" in m or "no map_file" in m for m in messages)
+
+
+def test_load_scenario_matrix_single_doc_list_matches_stream(tmp_path: Path) -> None:
+    """Single-document list and multi-document stream yield identical scenarios (#5429)."""
+    list_path = tmp_path / "list.yaml"
+    list_path.write_text(yaml.safe_dump(_ABSTRACT_SCENARIOS), encoding="utf-8")
+
+    stream_path = tmp_path / "stream.yaml"
+    stream_path.write_text(yaml.safe_dump_all(_ABSTRACT_SCENARIOS), encoding="utf-8")
+
+    assert load_scenario_matrix(list_path) == load_scenario_matrix(stream_path)
+
+
+def test_load_scenario_matrix_empty_single_doc_list_fails_closed(tmp_path: Path) -> None:
+    """An empty single-document list raises instead of a silent zero-job run (#5429)."""
+    import pytest
+
+    empty_path = tmp_path / "empty.yaml"
+    empty_path.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="empty scenario list"):
+        load_scenario_matrix(empty_path)

--- a/tests/benchmark/test_runner_scenario_matrix_manifest.py
+++ b/tests/benchmark/test_runner_scenario_matrix_manifest.py
@@ -161,3 +161,19 @@ def test_load_scenario_matrix_empty_single_doc_list_fails_closed(tmp_path: Path)
 
     with pytest.raises(ValueError, match="empty scenario list"):
         load_scenario_matrix(empty_path)
+
+
+def test_load_scenario_matrix_single_doc_map_list_preserves_manifest_validation(
+    tmp_path: Path,
+) -> None:
+    """Top-level map manifests still resolve and validate through the shared loader."""
+    import pytest
+
+    matrix_path = tmp_path / "map_matrix.yaml"
+    matrix_path.write_text(
+        "- name: named_map\n  map_id: definitely-not-a-real-map\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Unknown map_id"):
+        load_scenario_matrix(matrix_path)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** `robot_sf/benchmark/runner.py::load_scenario_matrix` now returns a
  **single-document top-level YAML list** directly (symmetric with the existing multi-document
  stream branch) instead of routing it through the map-oriented
  `robot_sf/training/scenario_loader.py::load_scenarios`. Single-document *mappings* still defer to
  the include-aware manifest loader (unchanged). Named or map-referenced entries in a top-level
  list also retain that manifest path so validation and path rebasing are preserved.
- **Why now:** Issue #5429 (friction found while implementing #5419). Abstract benchmark scenarios
  (`density`/`flow`/`obstacle` form) carry no `name`/`scenario_id` and no `map_file`/`map_id`. As a
  single-doc list they were validated as map manifests and emitted misleading
  `Scenario entry N is missing a name or scenario_id` / `has no map_file or map_id` warnings —
  the "silently routes single-doc scenario files through the map-oriented loader" symptom.
- **Claim boundary:** Behavior/bug fix on the benchmark scenario loader; no benchmark metric
  semantics change. `smoke evidence` (targeted unit + integration tests below).
- **Required validation:** the pytest runs listed below (all green).
- **Known follow-up:** A single-document *mapping* holding a top-level `scenarios:` list of
  abstract scenarios still routes through `load_scenarios` and emits the same warnings; that path
  also carries genuine map manifests (see contract test), so narrowing it safely is tracked in
  follow-up issue #5433 and is out of scope for this slice.

Refs #5429

## Contract delta

- `load_scenario_matrix(path)` routing is now explicit and documented in the docstring:
  - multi-document stream → returned directly (unchanged);
  - **single-document list → abstract scenarios returned directly when no manifest identity or
    map reference is present (new; previously routed through `load_scenarios`)**;
  - named or map-referenced single-document list entries → include-aware manifest loader (legacy
    validation and rebasing preserved);
  - single-document mapping → include-aware manifest loader (unchanged);
  - `bundle:` reference → task-bundle loader (unchanged).
- **New fail-closed blocker:** an empty single-document list (`[]`) now raises `ValueError`
  ("contains an empty scenario list") instead of returning `[]` and yielding a silent `written=0`
  run (issue option (c)).
- **Compatibility:** No repository scenario matrix relies on the removed behavior. The only tracked
  single-doc *list* matrix, `configs/baselines/example_matrix.yaml`, is pure abstract scenarios with
  no `map_file`/`map_id`, so map-path rebasing (which multi-doc streams already skip) is a no-op for
  it. Manifests using `includes`/`scenarios:`/`map_file` are mappings and are unaffected.

## Scope

- In scope: `load_scenario_matrix` routing + docstring; new/updated tests; CHANGELOG entry.
- Out of scope (explicit): no full benchmark campaign run, no Slurm/GPU submission, no
  paper/dissertation claim edits, no changes to the shared `training/scenario_loader.py` validator;
  the deferred mapping-form extension is tracked in #5433.

## Validation

Run in a worktree venv (`uv run`):

```
uv run python -m pytest tests/benchmark/test_runner_scenario_matrix_manifest.py -q
  -> 7 passed
uv run python -m pytest tests/test_runner_batch.py \
  tests/benchmark/test_runner_scenario_matrix_manifest.py \
  tests/unit/test_runner_helper_coverage.py -q
  -> 18 passed
uv run python -m pytest tests/benchmark/test_scenario_coverage.py \
  tests/benchmark_full/test_integration_freeze_manifest.py -q
  -> 10 passed
uv run python -m pytest tests/test_cli.py tests/test_cli_plot_scenarios.py \
  tests/benchmark/test_scenario_interop_target_compatibility.py -q   # consume example_matrix.yaml
  -> 24 passed
scripts/dev/ruff_fix_format.sh  -> All checks passed
```

New tests in `tests/benchmark/test_runner_scenario_matrix_manifest.py`:
- `test_load_scenario_matrix_single_doc_list_returns_abstract_scenarios` — abstract scenarios load
  verbatim and the map-oriented warnings are absent (loguru sink assertion).
- `test_load_scenario_matrix_single_doc_list_matches_stream` — single-doc list == multi-doc stream.
- `test_load_scenario_matrix_empty_single_doc_list_fails_closed` — empty list raises `ValueError`.
- `test_load_scenario_matrix_single_doc_map_list_preserves_manifest_validation` — map-id validation
  remains fail-closed for top-level list manifests.

<details>
<summary>Governance / research-PR fields</summary>

- Target claim/hypothesis/blocker: NA (support/bug-fix; no research claim).
- Comparator/baseline: NA.
- Evidence tier: smoke evidence (targeted execution proof).
- Result classification: fix verified by unit + integration tests.
- Decision/stop rule: NA.
- Synthesis/update target: CHANGELOG `[Unreleased] > Fixed`.
- Artifact handling: no new `output/*` artifacts produced.
- State propagation: low-churn issue (0 prior PRs); this PR body is the single canonical status
  surface. No transient queue-routing state written to tracked files.

Issue link: https://github.com/ll7/robot_sf_ll7/issues/5429
Follow-up issue: https://github.com/ll7/robot_sf_ll7/issues/5433
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading abstract benchmark scenarios from single-document YAML lists.
  * Single-document lists now behave consistently with multi-document YAML scenario streams.
* **Bug Fixes**
  * Added validation to reject empty scenario lists and invalid entries.
  * Preserved manifest validation for lists containing named or map-referenced scenarios, including clear errors for unknown maps.
* **Tests**
  * Added coverage for abstract scenario loading, stream consistency, empty inputs, and manifest validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->