### PR TITLE
Fix #5419: bind DPCBF resume to checkpointed artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* **issue #5419 authorization-gated DPCBF dense episode executor.** `execute_run_plan()` now
-  runs bounded local arms through `run_batch` only with the exact public authorization ID. It
-  writes an atomic, checkpointed execution manifest with effective arguments, dirty-state and
-  content-bound provenance, and explicit caveat statuses; orphan output, malformed input, and
-  mismatched resume state fail closed. Packet bounds and the real issue-scoped CLI are recorded.
-  No Slurm/GPU submission or safety-performance claim is made.
+* **issue #5419 authorization-gated DPCBF executor.** Bounded local `run_batch` arms require the
+  exact public authorization ID. Atomic checkpoints bind inputs and completed JSONL artifacts;
+  dirty, orphaned, malformed, duplicate, or mismatched state fails closed. No Slurm/GPU run or
+  safety-performance claim is included.
 
 ### Fixed
 

--- a/docs/context/issue_4142_dpcbf_dense_pipeline.md
+++ b/docs/context/issue_4142_dpcbf_dense_pipeline.md
@@ -49,26 +49,15 @@ this slice binds the three merged modules with the one contract they were missin
 
 ## What #5419 adds: the authorization-gated local executor
 
-PR #5419 turns `execute_run_plan()` into a bounded, explicitly authorized **local episode
-executor**:
-
-- **Bounded execution and authorization.** The packet's optional `execution` block fixes seed,
-  repeats, horizon, `dt`, workers, video-off, and resume policy. Unknown or out-of-bounds values
-  fail closed. The exact `RSF-DPCBF-DENSE-20260712` ID is required before any write; the runner
-  reuses `run_batch` once per arm in packet order with the shared manifest and arm config.
-- **Manifest and resume safety.** The manifest
-  (`robot_sf.issue_4142_dpcbf_dense_comparison_execution.v1`) records effective arguments,
-  timestamps, arm statuses, dirty state, and content-bound hashes. Atomic `in_progress`
-  checkpoints make interruption explicit; orphan output, malformed manifests, dirty Git trees,
-  and mismatched provenance fail closed. A no-work resume is complete only after artifact ID
-  validation.
+PR #5419 adds a bounded local executor gated by `RSF-DPCBF-DENSE-20260712`. It runs each fixed
+arm through `run_batch`, checkpoints before/after every arm, and binds effective inputs plus
+completed JSONL bytes. Dirty, orphaned, malformed, duplicate, or mismatched resume state fails
+closed.
 
 ## Integration status
 
-- **Delivered (new):** the authorization-gated executor, checkpointed manifest, and
-  provenance-safe resume (#5419), covered by fail-closed tests and a reduced real-runner smoke.
-- **Remaining (intentional):** the tracked `prediction_mpc_cv` packet is not run here; its
-  summarizer remains `results_incomplete` until authorized per-arm JSONL exists.
+- **Delivered:** authorization gate, checkpointed manifest, artifact-bound resume, and smoke.
+- **Remaining:** the tracked packet is not run here; summary stays incomplete until authorized.
 
 Next empirical action: run the resolved plan with the exact authorization ID and summarize its
 per-arm JSONL as bounded diagnostic evidence, never a paper-facing collision-reduction claim.

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
@@ -457,6 +457,7 @@ class ArmExecutionResult:
     total_jobs: int
     written: int
     failed_jobs: int
+    artifact_sha256: str | None = None
     error: str | None = None
 
 
@@ -660,7 +661,7 @@ def _default_run_batch() -> Callable[..., dict[str, Any]]:
     return run_batch
 
 
-def execute_run_plan(  # noqa: C901
+def execute_run_plan(  # noqa: C901, PLR0912, PLR0915
     plan: DenseComparisonRunPlan,
     *,
     authorization: str | None = None,
@@ -792,6 +793,27 @@ def execute_run_plan(  # noqa: C901
     output_dir_abs.mkdir(parents=True, exist_ok=True)
     started_at = clock().isoformat()
 
+    prior_arms = {
+        arm.get("arm_key"): arm
+        for arm in (prior or {}).get("arms", [])
+        if isinstance(arm, dict) and isinstance(arm.get("arm_key"), str)
+    }
+    for job in plan.arms:
+        arm = prior_arms.get(job.arm_key, {})
+        expected_hash = arm.get("artifact_sha256")
+        if arm.get("status") in {"executed", "resumed_complete"} and not isinstance(
+            expected_hash, str
+        ):
+            raise DenseComparisonProvenanceMismatchError(
+                f"completed arm {job.arm_key} lacks a checkpointed artifact hash"
+            )
+        if isinstance(expected_hash, str):
+            out_abs = _abs_under_root(root, job.output_jsonl)
+            if _content_hash(out_abs) != expected_hash:
+                raise DenseComparisonProvenanceMismatchError(
+                    f"completed arm {job.arm_key} artifact no longer matches its checkpoint"
+                )
+
     results = [
         ArmExecutionResult(
             arm_key=job.arm_key,
@@ -802,6 +824,7 @@ def execute_run_plan(  # noqa: C901
             total_jobs=0,
             written=0,
             failed_jobs=0,
+            artifact_sha256=prior_arms.get(job.arm_key, {}).get("artifact_sha256"),
         )
         for job in plan.arms
     ]
@@ -836,11 +859,6 @@ def execute_run_plan(  # noqa: C901
     save_checkpoint(tuple(results))
 
     scenario_abs = _abs_under_root(root, str(plan.scenario_manifest))
-    prior_arms = {
-        arm.get("arm_key"): arm
-        for arm in (prior or {}).get("arms", [])
-        if isinstance(arm, dict) and isinstance(arm.get("arm_key"), str)
-    }
     for index, job in enumerate(plan.arms):
         out_abs = _abs_under_root(root, job.output_jsonl)
         algo_config_abs = _abs_under_root(root, job.algorithm_config)
@@ -938,6 +956,7 @@ def _execute_arm(
             total_jobs=expected,
             written=0,
             failed_jobs=0,
+            artifact_sha256=_content_hash(out_abs) if valid_resume else None,
             error=None
             if valid_resume
             else "resume found no jobs but artifact identities were incomplete",
@@ -960,6 +979,7 @@ def _execute_arm(
         total_jobs=total_jobs,
         written=written,
         failed_jobs=failed_jobs,
+        artifact_sha256=_content_hash(out_abs) if ok else None,
         error=None
         if ok
         else "run wrote fewer episodes than scheduled, reported failures, or lacked valid identities",
@@ -982,6 +1002,8 @@ def _episode_ids(out_path: Path) -> set[str] | None:
             record = json.loads(line)
             episode_id = record.get("episode_id") if isinstance(record, dict) else None
             if not isinstance(episode_id, str) or not episode_id:
+                return None
+            if episode_id in ids:
                 return None
             ids.add(episode_id)
     except (OSError, json.JSONDecodeError):
@@ -1018,6 +1040,7 @@ def manifest_to_dict(manifest: DenseExecutionManifest) -> dict[str, Any]:
                 "total_jobs": arm.total_jobs,
                 "written": arm.written,
                 "failed_jobs": arm.failed_jobs,
+                "artifact_sha256": arm.artifact_sha256,
                 "error": arm.error,
             }
             for arm in manifest.arms

--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py
@@ -906,6 +906,30 @@ def _execute_arm(
         The per-arm execution result.
     """
     existing_ids = _episode_ids(out_abs) if inputs.resume else set()
+    if existing_ids is None:
+        return ArmExecutionResult(
+            arm_key=job.arm_key,
+            algorithm=job.algorithm,
+            algorithm_config=job.algorithm_config,
+            output_jsonl=job.output_jsonl,
+            status="failed",
+            total_jobs=0,
+            written=0,
+            failed_jobs=0,
+            error="resume artifact is malformed or has duplicate episode identities",
+        )
+    if existing_ids and expected_jobs is None:
+        return ArmExecutionResult(
+            arm_key=job.arm_key,
+            algorithm=job.algorithm,
+            algorithm_config=job.algorithm_config,
+            output_jsonl=job.output_jsonl,
+            status="failed",
+            total_jobs=0,
+            written=0,
+            failed_jobs=0,
+            error="resume artifact has no checkpointed expected episode count",
+        )
     baseline_count = len(existing_ids) if existing_ids is not None else 0
     try:
         summary = run_batch(

--- a/scripts/tools/run_issue_4142_dpcbf_dense_comparison.py
+++ b/scripts/tools/run_issue_4142_dpcbf_dense_comparison.py
@@ -1,31 +1,8 @@
 #!/usr/bin/env python3
-"""Consume the issue #4142 dense DPCBF comparison packet into a run plan (dry-run).
+"""Resolve the #4142 DPCBF packet or run its bounded authorization-gated local executor.
 
-Resolves the predeclared comparison packet
-``configs/research/issue_4142_dpcbf_dense_comparison_v1.yaml`` into a concrete, ordered
-three-arm run plan (``cbf_off``, ``cbf_collision_cone_on``, ``cbf_dynamic_parabolic_v1_on``)
-using the canonical readiness validator as the single source of truth. It runs no episodes
-and authorizes no campaign.
-
-The default mode is a dry-run: the plan is printed, nothing is written to disk, and execution
-stays authorization-gated. Passing ``--execute`` runs bounded local episodes **only** when the
-exact public authorization ID is supplied through ``--authorization``; otherwise it fails
-closed and writes nothing. This runs local episodes only -- no Slurm/GPU submission.
-
-Examples:
-    # Human-readable Markdown run plan against the current checkout.
-    uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py
-
-    # JSON plan, non-zero exit unless the plan is fully resolved (CI/preflight gate).
-    uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py \
-        --format json --fail-on-blocked
-
-    # Attempting execution without the authorization ID fails closed (no files written).
-    uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py --execute
-
-    # Authorized bounded local run of all three arms.
-    uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py \
-        --execute --authorization RSF-DPCBF-DENSE-20260712
+Dry-run is the default. ``--execute`` requires the exact public authorization ID and never
+submits Slurm/GPU work; failed or degraded arms remain caveats.
 """
 
 from __future__ import annotations

--- a/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
+++ b/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
@@ -1,9 +1,4 @@
-"""Fail-closed contract tests for the issue #5419 local DPCBF executor.
-
-They cover authorization, ordered arm dispatch, caveat statuses, content-bound provenance,
-atomic interruption checkpoints, orphan output, and a reduced real-runner run-twice smoke.
-The smoke proves wiring only; failed/degraded rows remain caveats, never success evidence.
-"""
+"""Fail-closed contract tests for the issue #5419 local DPCBF executor."""
 
 from __future__ import annotations
 
@@ -28,6 +23,7 @@ from robot_sf.benchmark.issue_4142_dpcbf_dense_runner import (
     REQUIRED_AUTHORIZATION_ID,
     DenseComparisonExecutionGatedError,
     DenseComparisonProvenanceMismatchError,
+    _episode_ids,
     _resolve_execution_inputs,
     build_run_plan,
     execute_run_plan,
@@ -35,8 +31,6 @@ from robot_sf.benchmark.issue_4142_dpcbf_dense_runner import (
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 
-# A well-formed synthetic packet whose arm configs pass readiness. ``algorithm`` is
-# ``simple_policy`` so the smoke can run real episodes on CPU without MPC dependencies.
 _RUNNABLE_PACKET = {
     "schema_version": "robot_sf.issue_4142_dpcbf_dense_comparison.v1",
     "canonical_command": "uv run python scripts/tools/run_issue_4142_dpcbf_dense_comparison.py",
@@ -69,11 +63,7 @@ _RUNNABLE_PACKET = {
         "evidence_tier": "bounded_runtime_comparison",
         "fallback_rows_are_success_evidence": False,
         "excluded_row_statuses": ["fallback", "degraded", "failed", "ineligible"],
-        "required_arms": [
-            "cbf_off",
-            "cbf_collision_cone_on",
-            "cbf_dynamic_parabolic_v1_on",
-        ],
+        "required_arms": list(REQUIRED_ARMS),
     },
 }
 
@@ -84,31 +74,17 @@ def _write_runnable_tree(root: pathlib.Path, packet: dict) -> pathlib.Path:
     (root / "configs/scenarios/sets").mkdir(parents=True, exist_ok=True)
     (root / "configs/research").mkdir(parents=True, exist_ok=True)
 
-    # A multi-document stream keeps these abstract smoke scenarios off the map loader path.
-    scenarios = [
-        {
-            "id": "dpcbf-smoke-a",
-            "density": "low",
-            "flow": "uni",
-            "obstacle": "open",
-            "groups": 0.0,
-            "speed_var": "low",
-            "goal_topology": "point",
-            "robot_context": "embedded",
-            "repeats": 1,
-        },
-        {
-            "id": "dpcbf-smoke-b",
-            "density": "low",
-            "flow": "uni",
-            "obstacle": "open",
-            "groups": 0.0,
-            "speed_var": "low",
-            "goal_topology": "point",
-            "robot_context": "embedded",
-            "repeats": 1,
-        },
-    ]
+    base = {
+        "density": "low",
+        "flow": "uni",
+        "obstacle": "open",
+        "groups": 0.0,
+        "speed_var": "low",
+        "goal_topology": "point",
+        "robot_context": "embedded",
+        "repeats": 1,
+    }
+    scenarios = [dict(base, id=f"dpcbf-smoke-{suffix}") for suffix in ("a", "b")]
     (root / "configs/scenarios/sets/dense.yaml").write_text(
         yaml.safe_dump_all(scenarios, sort_keys=False), encoding="utf-8"
     )
@@ -152,11 +128,6 @@ class _RecordingRunBatch:
             with out_path.open("a", encoding="utf-8") as handle:
                 handle.write(json.dumps({"episode_id": f"fake-{idx}-{item}"}) + "\n")
         return summary
-
-
-def _config_stem(path: str) -> str:
-    """Return the arm config filename for order/identity assertions."""
-    return pathlib.Path(path).name
 
 
 def test_no_authorization_raises_before_creating_output(tmp_path: pathlib.Path) -> None:
@@ -221,8 +192,8 @@ def test_authorized_run_dispatches_all_arms_in_packet_order(tmp_path: pathlib.Pa
     )
 
     assert len(fake.calls) == len(REQUIRED_ARMS)
-    dispatched_configs = [_config_stem(c["algo_config_path"]) for c in fake.calls]
-    assert dispatched_configs == [_config_stem(job.algorithm_config) for job in plan.arms]
+    dispatched_configs = [pathlib.Path(c["algo_config_path"]).name for c in fake.calls]
+    assert dispatched_configs == [pathlib.Path(job.algorithm_config).name for job in plan.arms]
     assert len({c["scenarios_or_path"] for c in fake.calls}) == 1
     assert len({c["algo_config_path"] for c in fake.calls}) == len(REQUIRED_ARMS)
     assert len({c["out_path"] for c in fake.calls}) == len(REQUIRED_ARMS)
@@ -265,6 +236,7 @@ def test_manifest_contains_required_provenance_fields(tmp_path: pathlib.Path) ->
         assert status in payload["excluded_row_statuses"]
     assert {a["arm_key"] for a in payload["arms"]} == set(REQUIRED_ARMS)
     assert all(a["output_jsonl"] for a in payload["arms"])
+    assert all(a["artifact_sha256"] for a in payload["arms"])
 
 
 def test_failing_arm_stays_visible_and_blocks_complete(tmp_path: pathlib.Path) -> None:
@@ -445,6 +417,43 @@ def test_changed_execution_inputs_fail_closed_on_resume(tmp_path: pathlib.Path) 
             schema_path=tmp_path / "alternate-episode-schema.json",
             run_batch_fn=_RecordingRunBatch(),
         )
+
+
+@pytest.mark.parametrize("tamper", ("replace_ids", "duplicate_row"))
+def test_completed_artifact_tampering_fails_closed(tmp_path: pathlib.Path, tamper: str) -> None:
+    """Completed artifacts stay bound to their checkpointed bytes."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+    execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=_RecordingRunBatch(),
+    )
+    artifact = REPO_ROOT / plan.arms[0].output_jsonl
+    lines = artifact.read_text(encoding="utf-8").splitlines()
+    if tamper == "replace_ids":
+        row = json.loads(lines[0])
+        row["episode_id"] = "same-count-replacement"
+        lines[0] = json.dumps(row)
+    else:
+        lines.append(lines[0])
+    artifact.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    with pytest.raises(DenseComparisonProvenanceMismatchError, match="artifact"):
+        execute_run_plan(
+            plan,
+            authorization=REQUIRED_AUTHORIZATION_ID,
+            repo_root=REPO_ROOT,
+            run_batch_fn=_RecordingRunBatch(),
+        )
+
+
+def test_duplicate_episode_ids_are_malformed(tmp_path: pathlib.Path) -> None:
+    """Duplicate identities cannot be collapsed into apparent completeness."""
+    artifact = tmp_path / "episodes.jsonl"
+    artifact.write_text('{"episode_id":"duplicate"}\n' * 2, encoding="utf-8")
+    assert _episode_ids(artifact) is None
 
 
 def test_non_boolean_resume_is_a_plan_blocker() -> None:

--- a/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
+++ b/tests/benchmark/test_issue_4142_dpcbf_dense_executor.py
@@ -456,6 +456,36 @@ def test_duplicate_episode_ids_are_malformed(tmp_path: pathlib.Path) -> None:
     assert _episode_ids(artifact) is None
 
 
+def test_uncheckpointed_crash_artifact_cannot_self_certify(tmp_path: pathlib.Path) -> None:
+    """A crash after writing rows cannot resume from the artifact's own count."""
+    out_dir = tmp_path / "out"
+    plan = build_run_plan(repo_root=REPO_ROOT, packet_path=PACKET_PATH, output_dir=out_dir)
+
+    def crash_after_write(**kwargs):
+        _RecordingRunBatch()(**kwargs)
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        execute_run_plan(
+            plan,
+            authorization=REQUIRED_AUTHORIZATION_ID,
+            repo_root=REPO_ROOT,
+            run_batch_fn=crash_after_write,
+        )
+
+    resumed = _RecordingRunBatch()
+    manifest = execute_run_plan(
+        plan,
+        authorization=REQUIRED_AUTHORIZATION_ID,
+        repo_root=REPO_ROOT,
+        run_batch_fn=resumed,
+    )
+    assert manifest.status == "results_incomplete"
+    assert manifest.arms[0].status == "failed"
+    assert "no checkpointed expected episode count" in (manifest.arms[0].error or "")
+    assert len(resumed.calls) == len(REQUIRED_ARMS) - 1
+
+
 def test_non_boolean_resume_is_a_plan_blocker() -> None:
     """String values cannot silently change resume/append semantics."""
     inputs, blockers = _resolve_execution_inputs({"execution": {"resume": "false"}})

--- a/tests/fixtures/optional_import_guards.json
+++ b/tests/fixtures/optional_import_guards.json
@@ -6,7 +6,7 @@
     "ModuleNotFoundError"
   ],
   "spelling_key": "Caught exception type names, sorted and joined by '+'. The 'as <alias>' name is intentionally NOT part of the key.",
-  "total_guards": 102,
+  "total_guards": 103,
   "spellings": {
     "AttributeError+ImportError": {
       "count_ceiling": 2,
@@ -60,12 +60,13 @@
       ]
     },
     "AttributeError+ImportError+OSError+RuntimeError+TypeError+ValueError": {
-      "count_ceiling": 1,
-      "has_as_count": 1,
+      "count_ceiling": 2,
+      "has_as_count": 2,
       "pragma_no_cover_count": 0,
       "blessed": true,
-      "note": "Blessed broad catch: defensive visualization ingest boundary.",
+      "note": "Blessed broad catches: defensive visualization ingest and authorization-gated episode execution boundaries.",
       "samples": [
+        "robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py:951",
         "robot_sf/benchmark/visualization.py:467"
       ]
     },
@@ -134,8 +135,8 @@
         "robot_sf/benchmark/live_forecast_replay_gate.py:954",
         "robot_sf/benchmark/near_miss_determinism.py:394",
         "robot_sf/benchmark/plots.py:28",
-        "robot_sf/benchmark/runner.py:41",
-        "robot_sf/benchmark/runner.py:47",
+        "robot_sf/benchmark/runner.py:42",
+        "robot_sf/benchmark/runner.py:48",
         "robot_sf/benchmark/scenario_generator.py:48",
         "robot_sf/benchmark/scenario_schema.py:25",
         "robot_sf/benchmark/schema_validator.py:20",
@@ -190,7 +191,7 @@
       "blessed": true,
       "note": "Blessed broad catch: defensive ingest boundary. Review carefully.",
       "samples": [
-        "robot_sf/benchmark/camera_ready/resource_lifecycle.py:266"
+        "robot_sf/benchmark/camera_ready/resource_lifecycle.py:269"
       ]
     },
     "ImportError+RuntimeError": {


### PR DESCRIPTION
## Summary

Follow-up to #5428 for `RSF-DPCBF-DENSE-20260712`.

- bind every completed arm to the SHA-256 of its checkpointed JSONL artifact;
- verify that hash before any resume checkpoint can overwrite prior state;
- reject same-cardinality episode-ID replacement and duplicate IDs;
- reject non-empty crash artifacts that lack a checkpointed expected count;
- retain prior artifact hashes across interruption checkpoints.
- regenerate and justify the optional-import guard inventory for the executor's intentional error boundary.

The original PR merged while this blocking correction was being validated. This PR contains only the correction on current `main`; it does not execute the research packet and makes no planner-performance claim.

Refs #5419.

## Scope and safety

- Allowed paths: the existing #5419 runner, executor tests, its CLI documentation, context note, and changelog.
- Forbidden: scenario semantics, planner algorithms, benchmark outcomes, Slurm/GPU submission, and unrelated files.
- Stop condition: fail closed on any missing or changed completed artifact.

## Validation

- `61 passed` across the five focused DPCBF modules plus the optional-import inventory tests.
- Ruff check passed.
- Ruff format check passed.
- `git diff --check` passed.

## Review focus

Please verify that an interrupted or resumed manifest can no longer certify a JSONL artifact whose bytes changed after the last successful checkpoint.
