### PR TITLE
fix(#5420): land SNQI Pareto label de-overlap repairs from merged #5403

### DIFF
--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -1143,24 +1143,24 @@ def _build_short_aliases(planner_names: Sequence[str], *, threshold: int = 18) -
     _FILLER = frozenset({"rule", "v1", "v2", "v3", "v4", "fast", "progress", "static"})
     aliases: dict[str, str] = {}
     used: set[str] = set()
+    reserved_short_names = {name for name in planner_names if len(name) <= threshold}
     for name in planner_names:
         if name in aliases:
             continue
         if len(name) <= threshold:
-            base_short = name
+            short = name
         else:
             tokens = [t for t in name.split("_") if t not in _FILLER]
             if len(tokens) >= 2:
                 base_short = "_".join(tokens[:3])
             else:
                 base_short = name[:threshold]
-
-        short = base_short
-        suffix_index = 1
-        while short in used:
-            suffix = f"_{suffix_index}"
-            short = f"{base_short[: max(1, threshold - len(suffix))]}{suffix}"
-            suffix_index += 1
+            short = base_short
+            suffix_index = 1
+            while short in used or short in reserved_short_names:
+                suffix = f"_{suffix_index}"
+                short = f"{base_short[: max(1, threshold - len(suffix))]}{suffix}"
+                suffix_index += 1
         aliases[name] = short
         used.add(short)
     return aliases

--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -1142,16 +1142,27 @@ def _build_short_aliases(planner_names: Sequence[str], *, threshold: int = 18) -
 
     _FILLER = frozenset({"rule", "v1", "v2", "v3", "v4", "fast", "progress", "static"})
     aliases: dict[str, str] = {}
+    used: set[str] = set()
     for name in planner_names:
-        if len(name) <= threshold:
-            aliases[name] = name
+        if name in aliases:
             continue
-        tokens = [t for t in name.split("_") if t not in _FILLER]
-        if len(tokens) >= 2:
-            short = "_".join(tokens[:3])
+        if len(name) <= threshold:
+            base_short = name
         else:
-            short = name[:threshold]
+            tokens = [t for t in name.split("_") if t not in _FILLER]
+            if len(tokens) >= 2:
+                base_short = "_".join(tokens[:3])
+            else:
+                base_short = name[:threshold]
+
+        short = base_short
+        suffix_index = 1
+        while short in used:
+            suffix = f"_{suffix_index}"
+            short = f"{base_short[: max(1, threshold - len(suffix))]}{suffix}"
+            suffix_index += 1
         aliases[name] = short
+        used.add(short)
     return aliases
 
 
@@ -1201,18 +1212,18 @@ def _deoverlap_labels(
                 overlap_x = (
                     min(a["label_x"] + a["w"], b["label_x"] + b["w"])
                     - max(a["label_x"], b["label_x"])
-                    - padding
+                    + padding
                 )
                 overlap_y = (
                     min(a["label_y"], b["label_y"])
                     - max(a["label_y"] - a["h"], b["label_y"] - b["h"])
-                    - padding
+                    + padding
                 )
                 if overlap_x <= 0.0 or overlap_y <= 0.0:
                     continue
                 moved = True
-                dx = (a["anchor_x"] + a["w"] / 2) - (b["anchor_x"] + b["w"] / 2)
-                dy = (a["anchor_y"] - a["h"] / 2) - (b["anchor_y"] - b["h"] / 2)
+                dx = (a["label_x"] + a["w"] / 2) - (b["label_x"] + b["w"] / 2)
+                dy = (a["label_y"] - a["h"] / 2) - (b["label_y"] - b["h"] / 2)
                 if abs(dx) < 1.0 and abs(dy) < 1.0:
                     dx, dy = 0.5, -0.5
                 if abs(dx) > abs(dy):

--- a/tests/benchmark/test_snqi_pareto_label_deoverlap.py
+++ b/tests/benchmark/test_snqi_pareto_label_deoverlap.py
@@ -54,6 +54,12 @@ class TestBuildShortAliases:
         assert len(set(result.values())) == len(names)
         assert result[names[0]] != result[names[1]]
 
+    def test_short_name_is_reserved_from_generated_alias_collision(self) -> None:
+        names = ["long_rule_v3_suffix_extra", "long_suffix_extra"]
+        result = _build_short_aliases(names)
+        assert result[names[1]] == names[1]
+        assert result[names[0]] != result[names[1]]
+
     def test_threshold_respected(self) -> None:
         names = ["exactly_18_chars!!"]  # 18 chars = default threshold
         result = _build_short_aliases(names, threshold=18)

--- a/tests/benchmark/test_snqi_pareto_label_deoverlap.py
+++ b/tests/benchmark/test_snqi_pareto_label_deoverlap.py
@@ -45,6 +45,15 @@ class TestBuildShortAliases:
         assert "v3" not in alias.split("_")
         assert "fast" not in alias.split("_")
 
+    def test_colliding_long_names_get_unique_aliases(self) -> None:
+        names = [
+            "hybrid_rule_v3_fast_progress_static_escape",
+            "hybrid_rule_v2_fast_progress_static_escape",
+        ]
+        result = _build_short_aliases(names)
+        assert len(set(result.values())) == len(names)
+        assert result[names[0]] != result[names[1]]
+
     def test_threshold_respected(self) -> None:
         names = ["exactly_18_chars!!"]  # 18 chars = default threshold
         result = _build_short_aliases(names, threshold=18)
@@ -104,6 +113,20 @@ class TestDeoverlapLabels:
         result = _deoverlap_labels(labels)
         gap_x = abs(result[0]["label_x"] - result[1]["label_x"])
         assert gap_x > 0
+        overlap_x = (
+            min(result[0]["label_x"] + result[0]["w"], result[1]["label_x"] + result[1]["w"])
+            - max(result[0]["label_x"], result[1]["label_x"])
+            + 3.0
+        )
+        overlap_y = (
+            min(result[0]["label_y"], result[1]["label_y"])
+            - max(
+                result[0]["label_y"] - result[0]["h"],
+                result[1]["label_y"] - result[1]["h"],
+            )
+            + 3.0
+        )
+        assert overlap_x <= 0 or overlap_y <= 0
 
     def test_returns_same_count(self) -> None:
         labels = [


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Lands the phase-2 gate repair for the SNQI Pareto label de-overlap logic that merged PR #5403 shipped without. Three correctness fixes in `robot_sf/benchmark/snqi_scalarization_sensitivity.py` plus regression coverage.
- **Why now:** #5403 merged at head `cd189b5` before the gate repair (`1145159`) was attached, leaving two unresolved Gemini review findings on the merged code. This successor slice carries the fix through the normal review gate.
- **Claim boundary:** Diagnostic/rendering correctness for the dependency-free Pareto SVG label placement. No benchmark-metric semantics change — this only affects label geometry (spacing, alias uniqueness) in the exported figure.
- **Required validation:** focused pytest + Ruff (below).
- **Remaining blocker:** none for this issue. Parent #5401 is already closed from the earlier generator slice; durable-artifact follow-up remains tracked in #5418.

## Contract delta

- **Behavior fix 1 — minimum-gap padding.** The overlap test previously subtracted `padding` (`min(right) - max(left) - padding`), which required boxes to *already overlap by more than the padding* before repulsion triggered — letting labels overlap. Corrected to `+ padding` so `padding` enforces a *minimum gap*: repulsion now fires whenever two boxes are within `padding` of each other.
- **Behavior fix 2 — dynamic repulsion direction.** Repulsion direction now derives from current label centers (`label_x`/`label_y`) instead of the static `anchor_x`/`anchor_y`, so successive iterations push apart based on where labels actually are.
- **Behavior fix 3 — deterministic unique aliases.** `_build_short_aliases` now tracks used short aliases and appends unique `_N` suffixes (threshold-bounded) so distinct long planner names that shorten to the same base no longer collide onto one label. Also dedupes repeated input names and reserves exact short planner names so generated aliases cannot displace them.
- **Compatibility impact:** none to public APIs or benchmark metric values; internal helpers only. No schema or new fail-closed blocker.

## Validation

Run from the worktree (shared-venv helper points PYTHONPATH at the worktree):

- `scripts/dev/run_worktree_shared_venv.sh -- ruff check <changed files>` → `All checks passed!`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check <changed files>` → `2 files already formatted`
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_snqi_pareto_label_deoverlap.py -q` → `22 passed`
- Negative control: reverting only the source to `origin/main` makes the three alias/spacing regression assertions **fail** (3 failed) — confirms the added and extended tests are genuine regression coverage, not tautologies.

## Scope

- In scope: land gate repair commit `1145159` (padding sign, dynamic repulsion direction, unique deterministic aliases) + regression tests.
- Out of scope: **no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.** No metric-semantics change.

Unresolved review findings addressed: [padding/dynamic direction](https://github.com/ll7/robot_sf_ll7/pull/5403#discussion_r3566462378), [alias collision](https://github.com/ll7/robot_sf_ll7/pull/5403#discussion_r3566462380).

Closes #5420
Refs #5403, #5401, #5418

## Follow-Up Issues

- [#5418](https://github.com/ll7/robot_sf_ll7/issues/5418) remains open for durable issue-3653 SVG regeneration, checksum update, and dissertation-size label verification; this PR intentionally does not claim that artifact work.

## Downstream Propagation

- Parent issue #5401: already closed; this successor slice completes the #5420 repair scope.
- Claim map / benchmark report: NA — diagnostic label-layout correctness only; no metric semantics change.
- Durable artifact and context note: deferred to #5418.
- Follow-up issue: #5418.

<details>
<summary>Governance / provenance</summary>

- Candidate repair commit cherry-picked from the recreated worker branch: `1145159c119a3e23f5d5f5fbb06d3f604ca54f03`.
- Branch created from `origin/main` (`c7a1560c`) in an isolated worktree.
- Re-checked issue #5420 for late maintainer comments immediately before opening this PR: none (0 comments).
- State propagation: this PR (schema/behavior change) is the canonical surface; no transient queue-routing state written to tracked files.
- Evidence tier: rendering/diagnostic correctness with focused regression tests + negative control. Not benchmark evidence and no benchmark-metric claim.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)




