### PR TITLE
test(#5421): harden readiness trace fixture with del-based per-step metric guard

### DIFF
--- a/tests/benchmark/test_heterogeneous_population_ablation.py
+++ b/tests/benchmark/test_heterogeneous_population_ablation.py
@@ -543,6 +543,38 @@ def test_episode_record_readiness_blocks_missing_or_misaligned_trace_metadata() 
     )
 
 
+@pytest.mark.parametrize("missing_field", ["clearance_m", "near_field_exposure_s"])
+def test_episode_record_readiness_blocks_trace_without_per_step_metric_field(
+    missing_field: str,
+) -> None:
+    """Readiness fails closed when the runtime trace omits a required per-step metric.
+
+    This reproduces the exact SLURM-job-13379 failure mode (issue #5421, residual test
+    contract from closed duplicate PR #5402): the ``pedestrian_control_trace`` is present
+    but a per-step ``clearance_m`` / ``near_field_exposure_s`` field is absent, so
+    integration readiness cannot correctly evaluate the ablation. The field is removed with
+    ``del`` rather than ``dict.pop(field, None)`` so that fixture/schema drift which renames
+    or drops the metric raises ``KeyError`` here and fails this test loudly, instead of
+    silently no-op'ing and leaving the missing-per-step-metric path unexercised. Both metric
+    fields are covered independently because the per-metric readiness check reports only the
+    first missing key it encounters, so one generic case would never prove the second guard.
+    """
+
+    manifest = build_mean_matched_harness_manifest(_manifest_config())
+    records = _episode_records_for_manifest(manifest)
+    trace = records[0]["algorithm_metadata"]["pedestrian_control_trace"]
+    del trace["pedestrians"][0]["steps"][0][missing_field]
+
+    readiness = assess_mean_matched_episode_records(manifest, records)
+
+    assert readiness["status"] == "blocked"
+    assert readiness["ready"] is False
+    assert any(
+        f"control_trace.pedestrians[0].steps[0] missing '{missing_field}'" in blocker
+        for blocker in readiness["blockers"]
+    )
+
+
 def test_episode_record_readiness_blocks_missing_rank_metric() -> None:
     """Records cannot reach rank analysis without its finite episode metric."""
 


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds one parametrized episode-record readiness regression test to `tests/benchmark/test_heterogeneous_population_ablation.py` that removes a required per-step trace metric (`clearance_m` / `near_field_exposure_s`) via `del` and asserts `assess_mean_matched_episode_records` fails closed.
- **Why now:** Residual test-contract work from closed duplicate PR #5402. Its open Gemini finding (a regression test using `dict.pop(field, None)` to drop required fields could silently no-op under fixture/schema drift) never landed — #5402 was closed as a duplicate of #5407 before the fixture repair, and the successor suite added by #5407 does not cover the missing-**per-step-metric-field** path.
- **Claim boundary:** Test-only hardening. No runtime/benchmark/metric-semantics change; `diagnostic-only`/`smoke evidence` tier. No new production code.
- **Required validation:** focused pytest + Ruff (results below).
- **Remaining blocker:** none for this test-contract slice. The upstream #5346/#5397 campaign RUN (job 13379 re-run producing a `ready=true` `integration_readiness.json`) remains external Slurm/GPU work, out of scope here.

## Contract delta

- New test: `test_episode_record_readiness_blocks_trace_without_per_step_metric_field[clearance_m|near_field_exposure_s]`.
- No schema fields added; no new fail-closed blockers in production code (the test exercises the existing `control_trace.pedestrians[i].steps[j] missing '<metric>'` blocker path).
- Compatibility impact: none.

## New capability

Reproduces the exact SLURM-job-13379 failure mode — `pedestrian_control_trace` present but per-step `clearance_m` / `near_field_exposure_s` absent — which was previously **unexercised**. Both fields are covered independently because the per-metric readiness check reports only the first missing key it encounters, so a single generic case would never prove the second guard. The `del` form (vs `.pop(..., None)`) makes fixture/schema drift raise `KeyError` and fail the test loudly rather than silently.

## Validation

```
$ scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest \
    tests/benchmark/test_heterogeneous_population_ablation.py -q --timeout=120
38 passed in 1.64s   # was 36; +2 new parametrized cases

$ ... uv run ruff check tests/benchmark/test_heterogeneous_population_ablation.py
All checks passed!

$ ... uv run ruff format --check tests/benchmark/test_heterogeneous_population_ablation.py
1 file already formatted
```

## Scope / links

- Parent issue: #5397 · Closed duplicate: #5402 · Successor: #5407
- Refs #5346 (upstream campaign)

Closes #5421

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

<details>
<summary>Governance & propagation</summary>

- **Evidence tier:** test-only (`diagnostic-only`/`smoke evidence`); no benchmark or metric-semantics claim.
- **Fragmentation guard (6c):** exempt — this is a progression slice adding a nameable new regression capability (missing-per-step-metric-field guard), not a duplicate micro-guard. Only one related guardrail PR (#5407) merged in the prior 24h and it does not cover this path.
- **State propagation (6e):** low-churn issue; PR body is the single canonical status surface. No tracked-file state added (no queue-routing/lineage pointers).
- **Late-comment check (6b):** re-checked issue #5421 immediately before opening — 0 comments, still OPEN.

</details>

---
Produced by the Claude Code implementation lane for issue #5421; the PR gate hardens and merges.
