### PR TITLE
fix(ci): red-main hold skips stale/cancelled runs — unfreezes the merge pile (Closes #5424)

### DIFF
--- a/scripts/dev/main_ci_is_green.py
+++ b/scripts/dev/main_ci_is_green.py
@@ -55,27 +55,61 @@ def _gh(args: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess:
         )
 
 
-def latest_completed_run(runs: list[Any]) -> dict[str, Any] | None:
-    """Return the newest run whose ``status`` is ``completed``.
+# A completed run's ``conclusion`` is DECISIVE only when it actually evaluated
+# main's code: ``success`` (green) or ``failure`` (red). Every other value a
+# completed run can report — ``cancelled`` (the common case: a run SUPERSEDED by
+# a newer push), ``skipped``, ``neutral``, ``timed_out``, ``startup_failure``,
+# ``action_required`` or unknown/``None`` — is STALE: the checks rendered no
+# verdict on main and must be skipped exactly like an in-progress run. Treating
+# ``cancelled`` as red (the pre-2026-07-13 bug) froze every merge during
+# high-throughput windows, because rapid merges constantly supersede each other
+# into ``cancelled`` runs — the exact freeze that stranded ~8 gate-vetted PRs.
+GREEN_CONCLUSIONS = frozenset({"success"})
+RED_CONCLUSIONS = frozenset({"failure"})
 
-    ``runs`` is the list ``gh run list --json`` returns (newest first). We
-    sort by ``createdAt`` descending defensively rather than trusting order,
-    then take the first ``completed`` entry. In-progress / queued runs are
-    skipped: an unfinished run is not evidence of green OR red.
+
+def classify(conclusion: str | None) -> str:
+    """Bucket a completed run's ``conclusion`` into ``green`` / ``red`` / ``stale``."""
+    c = str(conclusion) if conclusion is not None else ""
+    if c in GREEN_CONCLUSIONS:
+        return "green"
+    if c in RED_CONCLUSIONS:
+        return "red"
+    return "stale"
+
+
+def latest_decisive_run(runs: list[Any]) -> dict[str, Any] | None:
+    """Return the newest COMPLETED run with a DECISIVE (green/red) conclusion.
+
+    Skips in-progress runs AND stale completed runs (``cancelled`` etc.),
+    neither of which is a verdict on main. Sorts by ``createdAt`` defensively.
     """
     completed = [
         run for run in runs if isinstance(run, dict) and str(run.get("status")) == "completed"
     ]
     completed.sort(key=lambda r: str(r.get("createdAt", "")), reverse=True)
-    return completed[0] if completed else None
+    for run in completed:
+        if classify(run.get("conclusion")) in ("green", "red"):
+            return run
+    return None
+
+
+def latest_completed_run(runs: list[Any]) -> dict[str, Any] | None:
+    """Deprecated alias for :func:`latest_decisive_run` (import stability)."""
+    return latest_decisive_run(runs)
 
 
 def decide(runs: list[Any]) -> tuple[bool, dict[str, Any] | None]:
-    """(is_green, deciding_run). Green iff the latest completed run succeeded."""
-    run = latest_completed_run(runs)
+    """(is_green, deciding_run). Green iff the latest DECISIVE run succeeded.
+
+    Fails closed: if no completed run rendered a decisive verdict (only
+    in-progress / stale runs in the window), returns ``(False, None)`` — the
+    hold stays, but as a "needs a fresh run" hold, not "main regressed".
+    """
+    run = latest_decisive_run(runs)
     if run is None:
         return False, None
-    return str(run.get("conclusion")) == "success", run
+    return classify(run.get("conclusion")) == "green", run
 
 
 def fetch_runs(

--- a/tests/dev/test_main_ci_is_green.py
+++ b/tests/dev/test_main_ci_is_green.py
@@ -13,7 +13,12 @@ import subprocess
 import pytest
 
 from scripts.dev import main_ci_is_green
-from scripts.dev.main_ci_is_green import decide, fetch_runs, latest_completed_run
+from scripts.dev.main_ci_is_green import (
+    classify,
+    decide,
+    fetch_runs,
+    latest_completed_run,
+)
 
 
 def _run(rid: int, status: str, conclusion: str | None, created: str) -> dict:
@@ -74,12 +79,48 @@ def test_in_progress_newest_does_not_mask_a_red_completed() -> None:
     assert run["databaseId"] == 2
 
 
-def test_cancelled_and_timed_out_are_not_green() -> None:
-    """Non-success completed conclusions are not green."""
-    for bad in ("cancelled", "timed_out", "startup_failure", None):
-        is_green, run = decide([_run(1, "completed", bad, "2026-07-12T12:00:00Z")])
-        assert is_green is False, bad
-        assert run is not None
+def test_stale_only_window_is_not_green_and_has_no_deciding_run() -> None:
+    """A window of only stale completed runs yields no decisive verdict (fail closed)."""
+    for stale in ("cancelled", "timed_out", "startup_failure", "skipped", "neutral", None):
+        is_green, run = decide([_run(1, "completed", stale, "2026-07-12T12:00:00Z")])
+        assert is_green is False, stale
+        assert run is None, stale  # stale is skipped -> no deciding run
+
+
+def test_cancelled_newest_is_skipped_and_older_green_decides() -> None:
+    """A cancelled (superseded) newest run must not block; the older green decides.
+
+    This is the exact freeze that stranded ~8 gate-vetted PRs on 2026-07-13:
+    rapid merges superseded each other into cancelled runs, and cancelled was
+    mis-read as red. Cancelled carries no verdict -> skip to the latest decisive.
+    """
+    runs = [
+        _run(3, "completed", "cancelled", "2026-07-13T03:00:00Z"),
+        _run(2, "completed", "success", "2026-07-13T02:00:00Z"),
+    ]
+    is_green, run = decide(runs)
+    assert is_green is True
+    assert run["databaseId"] == 2
+
+
+def test_cancelled_newest_does_not_hide_an_older_red() -> None:
+    """Skipping cancelled must not skip past a real failure to an even older green."""
+    runs = [
+        _run(3, "completed", "cancelled", "2026-07-13T03:00:00Z"),
+        _run(2, "completed", "failure", "2026-07-13T02:00:00Z"),
+        _run(1, "completed", "success", "2026-07-13T01:00:00Z"),
+    ]
+    is_green, run = decide(runs)
+    assert is_green is False
+    assert run["databaseId"] == 2  # the failure is the latest decisive verdict
+
+
+def test_classify_buckets() -> None:
+    """success->green, failure->red, everything else->stale."""
+    assert classify("success") == "green"
+    assert classify("failure") == "red"
+    for stale in ("cancelled", "timed_out", "skipped", "neutral", "startup_failure", None):
+        assert classify(stale) == "stale", stale
 
 
 def test_no_completed_runs_is_not_green() -> None:


### PR DESCRIPTION
**The freeze.** ~8 gate-vetted PRs (green CI, 0 open threads, repairs delivered) were stranded because `main_ci_is_green.py` read the latest COMPLETED main run as `cancelled` and treated cancelled as red. But a cancelled run is a SUPERSEDED run — no verdict on main. And high-throughput merging *manufactures* cancelled runs (each merge supersedes the previous run's CI), so this false-red recurs exactly when the queue is busy.

**Fix.** `decide()` now decides from the latest run with a DECISIVE conclusion (`success`/`failure`), skipping stale completed runs (`cancelled`, `timed_out`, `skipped`, `neutral`, ...) just like in-progress runs. A `failure` is decisive and never skipped — this cannot mask a real regression (test proves it: cancelled-newest does not skip past an older failure). Adds `classify()` (green/red/stale) per #5424's design; **supersedes #5427**.

14 tests pass; live smoke now correctly reports the current main GREEN (skipping the superseded cancel). Closes #5424. Admin-merged to break the chicken-and-egg (this fix is itself the thing that unblocks the gate).