### PR TITLE
Issue #5443: collision-cause attribution validation contract + fail-closed scoring harness

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -24,6 +24,10 @@ entries:
   status: proposal
   freshness: dated
   area: research_design
+- path: docs/context/evidence/issue_5443_collision_cause_attribution_contract.md
+  status: evidence
+  freshness: evidence
+  area: benchmark_evidence
 - path: docs/context/evidence/evidence_registry_dispositions.yaml
   status: evidence
   freshness: evidence

--- a/docs/context/evidence/issue_5443_collision_cause_attribution_contract.md
+++ b/docs/context/evidence/issue_5443_collision_cause_attribution_contract.md
@@ -1,0 +1,63 @@
+<!-- AI-GENERATED: validation-contract evidence; NEEDS-REVIEW: maintainer verification before reuse. -->
+# Issue #5443 Collision-Cause Attribution Validation Contract
+
+Date: 2026-07-13
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/5443>
+Parent: #5440 · Depends on: #5441, #5442
+
+## Claim Boundary
+
+This is a **validation-side contract slice** for "benchmark collision-cause attribution on injected
+and ambiguous faults". It delivers the frozen ground-truth fixture manifest, the pure attribution
+scoring/report machinery, and a fail-closed validation harness. It runs no simulation, trains no
+classifier, and makes **no benchmark or paper-grade claim**. The accuracy RUN against a real analyser
+is deliberately **not** performed here because the analyser under test (cause-report contract #5441,
+last-avoidable-action counterfactual replay #5442) is not yet implemented — the run is blocked exactly
+as a campaign RUN would be.
+
+Evidence grade: `diagnostic-only` / contract. No metric semantics change.
+
+## What This Slice Delivers
+
+- `robot_sf/benchmark/collision_cause_attribution.py` — frozen `GroundTruthFixture` contract,
+  manifest coverage check (`validate_fixture_manifest`), pure scoring (`score_attribution`) for class
+  precision/recall, top-explanation accuracy, temporal-localization error, avoidability accuracy,
+  abstention coverage, and confidence calibration, plus a fail-closed `build_validation_report`.
+- `robot_sf/benchmark/schemas/collision_cause_attribution_fixture.v1.json` — fixture record schema;
+  the `cause_class` enum is kept in sync with the module via a test.
+- `tests/benchmark/fixtures/collision_cause_attribution_manifest_5443.json` — the frozen manifest
+  covering the predeclared validation matrix: one activation per single cause (observation
+  omission/delay, prediction miss, candidate omission, bad selection, guard omission, infeasible
+  applied command, route trap, already-unavoidable contact, metric artifact), two interacting/ambiguous
+  fixtures, and two negative controls.
+- `scripts/analysis/validate_collision_cause_attribution_issue_5443.py` — deterministic report CLI;
+  emits `analyser_unavailable` when no verdicts are supplied.
+- `tests/benchmark/test_collision_causal_attribution_issue_5443.py` — 18 tests, selectable by the
+  issue's `pytest -k 'causal and attribution'` command.
+
+## Acceptance-Criteria Mapping
+
+- [x] Ground-truth fixture manifest freezes cause class, activation window, allowed intervention, and
+  ambiguity status before analysis — `GroundTruthFixture` + manifest.
+- [x] Report metrics defined and computed (class P/R, top-explanation accuracy, temporal localization,
+  avoidability accuracy, abstention coverage, calibration) — `score_attribution` / `AttributionReport`.
+- [ ] Simple injected causes reach ≥0.90 top-explanation accuracy, median temporal error ≤1 step —
+  **blocked on the analyser (#5441/#5442)**; the stop rule is encoded and enforced by the harness.
+- [ ] Ambiguous fixtures never receive a high-confidence single-cause verdict — guard encoded and
+  tested; measurement blocked on the analyser.
+- [ ] Negative controls not promoted to actual cause — guard encoded and tested; measurement blocked.
+- [ ] Two reviewers independently inspect a frozen sample — process step, remaining.
+- [x] Compact evidence schema-validated and bound to commit hashes — this note + schema/enum sync test.
+
+## Validation
+
+- `pytest -q tests/benchmark -k 'causal and attribution'` → 18 passed.
+- `python scripts/analysis/validate_collision_cause_attribution_issue_5443.py` →
+  `status: analyser_unavailable`, `covered_matrix: true`, `n_fixtures: 14` (fail-closed as expected).
+- `git diff --check` → clean. `ruff check` / `ruff format --check` → clean.
+
+## Remaining Work
+
+The accuracy measurement (criteria 3–5) and the two-reviewer step (criterion 6) require the analyser
+from #5441/#5442. When it can emit verdicts, feed them to the harness via `--verdicts`; the report
+moves from `analyser_unavailable` to `scored` and applies the `revise`/`pass` stop rule automatically.

--- a/robot_sf/benchmark/collision_cause_attribution.py
+++ b/robot_sf/benchmark/collision_cause_attribution.py
@@ -1,0 +1,801 @@
+"""Frozen ground-truth contract and scoring for collision-cause attribution validation.
+
+Issue #5443 (child of #5440; depends on the cause-report contract #5441 and the
+last-avoidable-action counterfactual replay #5442) asks a *validation* question:
+
+    How accurately and cautiously does the collision analyser recover known
+    injected causes, locate their activation time, and abstain on ambiguous
+    multi-cause interactions?
+
+This module supplies the **validation-side** machinery so that the accuracy
+measurement is fully specified and testable *before* the analyser under test
+(#5441/#5442) exists:
+
+* a frozen ground-truth fixture contract (:class:`GroundTruthFixture`) that pins
+  the injected ``cause_class``, ``activation_window``, ``allowed_intervention``,
+  ambiguity status, and avoidability *before* analysis (acceptance criterion 1);
+* a manifest coverage check (:func:`validate_fixture_manifest`) that fails closed
+  unless the predeclared validation matrix is represented;
+* pure, deterministic scoring (:func:`score_attribution`) that reports class
+  precision/recall, top-explanation accuracy, temporal-localization error,
+  avoidability accuracy, abstention coverage, and confidence calibration
+  (acceptance criterion 2);
+* a fail-closed report builder (:func:`build_validation_report`) that returns
+  ``analyser_unavailable`` when no analyser verdicts are supplied, rather than
+  fabricating a passing result.
+
+It is analysis tooling: pure, side-effect free, and it runs no simulation and
+makes no benchmark or paper-grade claim. Attribution *verdicts* are consumed as
+already-computed inputs; producing them is the analyser's job (#5441/#5442). The
+accuracy RUN against a real analyser therefore remains blocked until those land,
+exactly as a campaign RUN would.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from robot_sf.errors import RobotSfError
+
+COLLISION_CAUSE_ATTRIBUTION_FIXTURE_SCHEMA = "collision_cause_attribution_fixture.v1"
+COLLISION_CAUSE_ATTRIBUTION_REPORT_SCHEMA = "collision_cause_attribution_report.v1"
+
+# Injected single-cause classes drawn from the issue's predeclared validation matrix.
+# ``interacting_ambiguous`` is a multi-cause class; ``none`` is reserved for negative
+# controls (a suspicious trace signal that does not change the counterfactual outcome).
+CAUSE_OBSERVATION_OMISSION = "observation_omission"
+CAUSE_OBSERVATION_DELAY = "observation_delay"
+CAUSE_PREDICTION_MISS = "prediction_miss"
+CAUSE_CANDIDATE_OMISSION = "candidate_omission"
+CAUSE_BAD_SELECTION = "bad_selection"
+CAUSE_GUARD_OMISSION = "guard_omission"
+CAUSE_INFEASIBLE_APPLIED_COMMAND = "infeasible_applied_command"
+CAUSE_ROUTE_TRAP = "route_trap"
+CAUSE_ALREADY_UNAVOIDABLE_CONTACT = "already_unavoidable_contact"
+CAUSE_METRIC_ARTIFACT = "metric_artifact"
+CAUSE_INTERACTING_AMBIGUOUS = "interacting_ambiguous"
+CAUSE_NONE = "none"
+
+# Single, unambiguous injected causes that carry an accuracy target (criterion 3).
+SIMPLE_CAUSE_CLASSES: frozenset[str] = frozenset(
+    {
+        CAUSE_OBSERVATION_OMISSION,
+        CAUSE_OBSERVATION_DELAY,
+        CAUSE_PREDICTION_MISS,
+        CAUSE_CANDIDATE_OMISSION,
+        CAUSE_BAD_SELECTION,
+        CAUSE_GUARD_OMISSION,
+        CAUSE_INFEASIBLE_APPLIED_COMMAND,
+        CAUSE_ROUTE_TRAP,
+        CAUSE_ALREADY_UNAVOIDABLE_CONTACT,
+        CAUSE_METRIC_ARTIFACT,
+    }
+)
+
+# Full set of ground-truth cause labels a fixture may declare.
+CAUSE_CLASSES: frozenset[str] = SIMPLE_CAUSE_CLASSES | {CAUSE_INTERACTING_AMBIGUOUS, CAUSE_NONE}
+
+AMBIGUITY_UNAMBIGUOUS = "unambiguous"
+AMBIGUITY_AMBIGUOUS = "ambiguous"
+AMBIGUITY_NEGATIVE_CONTROL = "negative_control"
+AMBIGUITY_STATUSES: frozenset[str] = frozenset(
+    {AMBIGUITY_UNAMBIGUOUS, AMBIGUITY_AMBIGUOUS, AMBIGUITY_NEGATIVE_CONTROL}
+)
+
+# Coverage the predeclared validation matrix requires. Observation is satisfied by either
+# omission or delay; the remaining single causes must each appear at least once, plus at
+# least one ambiguous fixture and at least one negative control.
+_OBSERVATION_FAMILY: frozenset[str] = frozenset(
+    {CAUSE_OBSERVATION_OMISSION, CAUSE_OBSERVATION_DELAY}
+)
+_REQUIRED_SINGLE_CAUSES: frozenset[str] = frozenset(
+    {
+        CAUSE_PREDICTION_MISS,
+        CAUSE_CANDIDATE_OMISSION,
+        CAUSE_BAD_SELECTION,
+        CAUSE_GUARD_OMISSION,
+        CAUSE_INFEASIBLE_APPLIED_COMMAND,
+        CAUSE_ROUTE_TRAP,
+        CAUSE_ALREADY_UNAVOIDABLE_CONTACT,
+        CAUSE_METRIC_ARTIFACT,
+    }
+)
+
+# Default confidence at or above which a single-cause verdict counts as "high confidence".
+# Above this, an ambiguous fixture is a calibration failure and a negative control that is
+# promoted to a concrete cause is a false attribution.
+DEFAULT_HIGH_CONFIDENCE_THRESHOLD = 0.8
+
+# Stop-rule thresholds from the issue (criteria 3): simple-fixture accuracy floor and the
+# maximum acceptable median temporal-localization error, in control steps.
+SIMPLE_ACCURACY_FLOOR = 0.90
+MAX_MEDIAN_TEMPORAL_ERROR_STEPS = 1.0
+
+REPORT_STATUS_ANALYSER_UNAVAILABLE = "analyser_unavailable"
+REPORT_STATUS_SCORED = "scored"
+
+VERDICT_PASS = "pass"
+VERDICT_REVISE = "revise"
+
+
+class CollisionCauseAttributionError(RobotSfError, ValueError):
+    """Raised when a collision-cause attribution fixture or verdict violates the contract."""
+
+
+def _validate_window_for_status(
+    ambiguity_status: str, cause_class: str, avoidable: bool, start: int, end: int
+) -> None:
+    """Validate the activation window against the ambiguity status.
+
+    Raises:
+        CollisionCauseAttributionError: If the window or avoidability is inconsistent.
+    """
+    if ambiguity_status == AMBIGUITY_NEGATIVE_CONTROL:
+        if cause_class != CAUSE_NONE:
+            raise CollisionCauseAttributionError(
+                "negative_control fixtures must declare cause_class 'none'"
+            )
+        if avoidable:
+            raise CollisionCauseAttributionError(
+                "negative_control fixtures have no actual cause and must be non-avoidable"
+            )
+        if (start, end) != (-1, -1):
+            raise CollisionCauseAttributionError(
+                "negative_control fixtures must use activation_window (-1, -1)"
+            )
+        return
+    if cause_class == CAUSE_NONE:
+        raise CollisionCauseAttributionError(
+            "cause_class 'none' is reserved for negative_control fixtures"
+        )
+    if not (0 <= start <= end):
+        raise CollisionCauseAttributionError(
+            f"activation_window must satisfy 0 <= start <= end (got ({start}, {end}))"
+        )
+
+
+def _validate_class_status_agreement(
+    ambiguity_status: str,
+    cause_class: str,
+    avoidable: bool,
+    candidate_causes: tuple[str, ...],
+) -> None:
+    """Validate that the cause class agrees with the ambiguity status.
+
+    Raises:
+        CollisionCauseAttributionError: If the class and status disagree.
+    """
+    if ambiguity_status == AMBIGUITY_AMBIGUOUS:
+        if cause_class != CAUSE_INTERACTING_AMBIGUOUS:
+            raise CollisionCauseAttributionError(
+                "ambiguous fixtures must declare cause_class 'interacting_ambiguous'"
+            )
+        if len(candidate_causes) < 2:
+            raise CollisionCauseAttributionError(
+                "ambiguous fixtures must list at least two candidate_causes"
+            )
+    if ambiguity_status == AMBIGUITY_UNAMBIGUOUS and cause_class in {
+        CAUSE_INTERACTING_AMBIGUOUS,
+        CAUSE_NONE,
+    }:
+        raise CollisionCauseAttributionError(
+            f"unambiguous fixtures cannot declare cause_class {cause_class!r}"
+        )
+    if cause_class == CAUSE_ALREADY_UNAVOIDABLE_CONTACT and avoidable:
+        raise CollisionCauseAttributionError(
+            "already_unavoidable_contact fixtures must be non-avoidable"
+        )
+
+
+@dataclass(frozen=True)
+class GroundTruthFixture:
+    """A frozen ground-truth fixture for one injected (or negative-control) fault.
+
+    The fields are the invariants that must be pinned *before* analysis so the
+    attribution measurement cannot be tuned to the analyser's output.
+
+    Attributes:
+        fixture_id: Stable identifier, unique within a manifest.
+        cause_class: Ground-truth injected cause, one of :data:`CAUSE_CLASSES`.
+            ``interacting_ambiguous`` marks a genuine multi-cause interaction and
+            ``none`` marks a negative control with no actual cause.
+        activation_window: Inclusive ``(start, end)`` control-step window in which
+            the injected cause is active. A single-step activation uses
+            ``start == end``. Negative controls, which have no real activation,
+            use ``(-1, -1)``.
+        allowed_intervention: The single intervention permitted to test avoidability
+            (e.g. ``"earlier_brake"``); ``"none"`` when the contact is unavoidable
+            or there is no actual cause.
+        ambiguity_status: ``unambiguous``, ``ambiguous``, or ``negative_control``.
+        avoidable: Ground-truth avoidability of the collision.
+        candidate_causes: Plausible causes for an ambiguous fixture (provenance only).
+        notes: Free-text provenance for the injected fault.
+    """
+
+    fixture_id: str
+    cause_class: str
+    activation_window: tuple[int, int]
+    allowed_intervention: str
+    ambiguity_status: str
+    avoidable: bool
+    candidate_causes: tuple[str, ...] = ()
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        """Validate the frozen fixture invariants.
+
+        Raises:
+            CollisionCauseAttributionError: If any field violates the contract.
+        """
+        if not self.fixture_id.strip():
+            raise CollisionCauseAttributionError("fixture_id must be a non-empty string")
+        if self.cause_class not in CAUSE_CLASSES:
+            raise CollisionCauseAttributionError(
+                f"unsupported cause_class {self.cause_class!r}; expected one of {sorted(CAUSE_CLASSES)}"
+            )
+        if self.ambiguity_status not in AMBIGUITY_STATUSES:
+            raise CollisionCauseAttributionError(
+                f"unsupported ambiguity_status {self.ambiguity_status!r}; "
+                f"expected one of {sorted(AMBIGUITY_STATUSES)}"
+            )
+        start, end = self.activation_window
+        if not (isinstance(start, int) and isinstance(end, int)):
+            raise CollisionCauseAttributionError("activation_window bounds must be integers")
+        # Cross-field consistency: the ground-truth class and ambiguity status must agree,
+        # so a fixture cannot silently mislabel its own difficulty.
+        _validate_window_for_status(
+            self.ambiguity_status, self.cause_class, self.avoidable, start, end
+        )
+        _validate_class_status_agreement(
+            self.ambiguity_status, self.cause_class, self.avoidable, self.candidate_causes
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the schema-tagged JSON-safe fixture payload.
+
+        Returns:
+            Mapping with the schema version and frozen ground-truth fields.
+        """
+        return {
+            "schema_version": COLLISION_CAUSE_ATTRIBUTION_FIXTURE_SCHEMA,
+            "fixture_id": self.fixture_id,
+            "cause_class": self.cause_class,
+            "activation_window": list(self.activation_window),
+            "allowed_intervention": self.allowed_intervention,
+            "ambiguity_status": self.ambiguity_status,
+            "avoidable": self.avoidable,
+            "candidate_causes": list(self.candidate_causes),
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_mapping(cls, record: Mapping[str, Any]) -> GroundTruthFixture:
+        """Build a fixture from a JSON-style mapping, validating the schema version.
+
+        Args:
+            record: Mapping with the fixture fields; ``schema_version`` must match
+                :data:`COLLISION_CAUSE_ATTRIBUTION_FIXTURE_SCHEMA`.
+
+        Returns:
+            The validated :class:`GroundTruthFixture`.
+
+        Raises:
+            CollisionCauseAttributionError: If the schema version or window is malformed.
+        """
+        version = record.get("schema_version")
+        if version != COLLISION_CAUSE_ATTRIBUTION_FIXTURE_SCHEMA:
+            raise CollisionCauseAttributionError(
+                f"schema_version must be {COLLISION_CAUSE_ATTRIBUTION_FIXTURE_SCHEMA!r} (got {version!r})"
+            )
+        window = record.get("activation_window")
+        if not isinstance(window, Sequence) or isinstance(window, (str, bytes)) or len(window) != 2:
+            raise CollisionCauseAttributionError(
+                "activation_window must be a two-element [start, end] sequence"
+            )
+        return cls(
+            fixture_id=str(record.get("fixture_id", "")),
+            cause_class=str(record.get("cause_class", "")),
+            activation_window=(int(window[0]), int(window[1])),
+            allowed_intervention=str(record.get("allowed_intervention", "")),
+            ambiguity_status=str(record.get("ambiguity_status", "")),
+            avoidable=bool(record.get("avoidable", False)),
+            candidate_causes=tuple(str(c) for c in record.get("candidate_causes", ())),
+            notes=str(record.get("notes", "")),
+        )
+
+
+@dataclass(frozen=True)
+class AttributionVerdict:
+    """One analyser attribution output for a fixture (consumed, never produced here).
+
+    Attributes:
+        fixture_id: Fixture this verdict addresses.
+        predicted_cause: Predicted cause label, one of :data:`CAUSE_CLASSES`.
+        predicted_activation_step: Predicted activation step, or ``None`` when abstained.
+        confidence: Confidence in ``[0, 1]`` for the single-cause verdict.
+        avoidable_pred: Predicted avoidability.
+        abstained: Whether the analyser abstained from a single-cause verdict.
+    """
+
+    fixture_id: str
+    predicted_cause: str
+    predicted_activation_step: int | None
+    confidence: float
+    avoidable_pred: bool
+    abstained: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate the verdict invariants.
+
+        Raises:
+            CollisionCauseAttributionError: If a field violates the contract.
+        """
+        if self.predicted_cause not in CAUSE_CLASSES:
+            raise CollisionCauseAttributionError(
+                f"unsupported predicted_cause {self.predicted_cause!r}"
+            )
+        if not (0.0 <= self.confidence <= 1.0):
+            raise CollisionCauseAttributionError(
+                f"confidence must be in [0, 1] (got {self.confidence})"
+            )
+
+    @classmethod
+    def from_mapping(cls, record: Mapping[str, Any]) -> AttributionVerdict:
+        """Build a verdict from a JSON-style mapping.
+
+        Returns:
+            The validated :class:`AttributionVerdict`.
+        """
+        step = record.get("predicted_activation_step")
+        return cls(
+            fixture_id=str(record.get("fixture_id", "")),
+            predicted_cause=str(record.get("predicted_cause", "")),
+            predicted_activation_step=None if step is None else int(step),
+            confidence=float(record.get("confidence", 0.0)),
+            avoidable_pred=bool(record.get("avoidable_pred", False)),
+            abstained=bool(record.get("abstained", False)),
+        )
+
+
+@dataclass(frozen=True)
+class AttributionReport:
+    """Scored attribution accuracy and calibration over a fixture manifest."""
+
+    n_fixtures: int
+    n_scored: int
+    top_explanation_accuracy: float
+    per_class_precision: dict[str, float]
+    per_class_recall: dict[str, float]
+    median_temporal_localization_error: float | None
+    avoidability_accuracy: float
+    abstention_coverage: float
+    ambiguous_high_confidence_violations: tuple[str, ...]
+    negative_control_promotions: tuple[str, ...]
+    confidence_calibration_gap: float | None
+    verdict: str
+    reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the schema-tagged JSON-safe report payload.
+
+        Returns:
+            Mapping with the report schema version and all scored metrics.
+        """
+        return {
+            "schema_version": COLLISION_CAUSE_ATTRIBUTION_REPORT_SCHEMA,
+            "n_fixtures": self.n_fixtures,
+            "n_scored": self.n_scored,
+            "top_explanation_accuracy": self.top_explanation_accuracy,
+            "per_class_precision": dict(self.per_class_precision),
+            "per_class_recall": dict(self.per_class_recall),
+            "median_temporal_localization_error": self.median_temporal_localization_error,
+            "avoidability_accuracy": self.avoidability_accuracy,
+            "abstention_coverage": self.abstention_coverage,
+            "ambiguous_high_confidence_violations": list(self.ambiguous_high_confidence_violations),
+            "negative_control_promotions": list(self.negative_control_promotions),
+            "confidence_calibration_gap": self.confidence_calibration_gap,
+            "verdict": self.verdict,
+            "reasons": list(self.reasons),
+        }
+
+
+def validate_fixture_manifest(
+    fixtures: Iterable[GroundTruthFixture | Mapping[str, Any]],
+) -> list[GroundTruthFixture]:
+    """Validate a manifest and confirm it covers the predeclared validation matrix.
+
+    Coverage requires: at least one observation-family fixture (omission or delay),
+    at least one fixture for each remaining single cause, at least one ambiguous
+    fixture, and at least one negative control (issue "Predeclared validation matrix").
+    Fixture ids must be unique. Fails closed on any gap.
+
+    Args:
+        fixtures: Fixtures as :class:`GroundTruthFixture` or JSON-style mappings.
+
+    Returns:
+        The validated fixtures as a list of :class:`GroundTruthFixture`.
+
+    Raises:
+        CollisionCauseAttributionError: If ids collide or coverage is incomplete.
+    """
+    resolved: list[GroundTruthFixture] = [
+        f if isinstance(f, GroundTruthFixture) else GroundTruthFixture.from_mapping(f)
+        for f in fixtures
+    ]
+    if not resolved:
+        raise CollisionCauseAttributionError("fixture manifest is empty")
+
+    seen: set[str] = set()
+    for fixture in resolved:
+        if fixture.fixture_id in seen:
+            raise CollisionCauseAttributionError(
+                f"duplicate fixture_id {fixture.fixture_id!r} in manifest"
+            )
+        seen.add(fixture.fixture_id)
+
+    present_causes = {f.cause_class for f in resolved}
+    statuses = {f.ambiguity_status for f in resolved}
+
+    missing: list[str] = []
+    if present_causes.isdisjoint(_OBSERVATION_FAMILY):
+        missing.append("observation_omission|observation_delay")
+    missing.extend(sorted(_REQUIRED_SINGLE_CAUSES - present_causes))
+    if AMBIGUITY_AMBIGUOUS not in statuses:
+        missing.append("<ambiguous fixture>")
+    if AMBIGUITY_NEGATIVE_CONTROL not in statuses:
+        missing.append("<negative control>")
+    if missing:
+        raise CollisionCauseAttributionError(
+            f"fixture manifest does not cover the predeclared validation matrix; missing: {missing}"
+        )
+    return resolved
+
+
+def _index_verdicts(
+    verdicts: Iterable[AttributionVerdict | Mapping[str, Any]],
+) -> dict[str, AttributionVerdict]:
+    """Index verdicts by fixture id, rejecting duplicates.
+
+    Returns:
+        Mapping of fixture id to its (single) verdict.
+    """
+    indexed: dict[str, AttributionVerdict] = {}
+    for verdict in verdicts:
+        resolved = (
+            verdict
+            if isinstance(verdict, AttributionVerdict)
+            else AttributionVerdict.from_mapping(verdict)
+        )
+        if resolved.fixture_id in indexed:
+            raise CollisionCauseAttributionError(
+                f"duplicate verdict for fixture_id {resolved.fixture_id!r}"
+            )
+        indexed[resolved.fixture_id] = resolved
+    return indexed
+
+
+def _temporal_error(fixture: GroundTruthFixture, predicted_step: int) -> int:
+    """Distance in control steps from a predicted step to the activation window.
+
+    Returns:
+        Zero inside the inclusive window, else the distance to the nearest bound.
+    """
+    start, end = fixture.activation_window
+    if predicted_step < start:
+        return start - predicted_step
+    if predicted_step > end:
+        return predicted_step - end
+    return 0
+
+
+@dataclass(frozen=True)
+class _UnambiguousScore:
+    """Confusion-derived metrics over the unambiguous fixtures."""
+
+    top_explanation_accuracy: float
+    per_class_precision: dict[str, float]
+    per_class_recall: dict[str, float]
+    median_temporal: float | None
+    calibration_gap: float | None
+
+
+def _score_unambiguous(
+    unambiguous: Sequence[GroundTruthFixture], indexed: Mapping[str, AttributionVerdict]
+) -> _UnambiguousScore:
+    """Score top-explanation accuracy, per-class P/R, localization, and calibration.
+
+    Returns:
+        The :class:`_UnambiguousScore` over the unambiguous fixtures.
+    """
+    correct_count = 0
+    temporal_errors: list[int] = []
+    correct_conf: list[float] = []
+    incorrect_conf: list[float] = []
+    tp: dict[str, int] = {}
+    fp: dict[str, int] = {}
+    fn: dict[str, int] = {}
+    for fixture in unambiguous:
+        verdict = indexed[fixture.fixture_id]
+        predicted = None if verdict.abstained else verdict.predicted_cause
+        actual = fixture.cause_class
+        if predicted == actual:
+            correct_count += 1
+            correct_conf.append(verdict.confidence)
+            tp[actual] = tp.get(actual, 0) + 1
+            if verdict.predicted_activation_step is not None:
+                temporal_errors.append(_temporal_error(fixture, verdict.predicted_activation_step))
+        else:
+            incorrect_conf.append(verdict.confidence)
+            fn[actual] = fn.get(actual, 0) + 1
+            if predicted is not None:
+                fp[predicted] = fp.get(predicted, 0) + 1
+
+    per_class_precision: dict[str, float] = {}
+    per_class_recall: dict[str, float] = {}
+    for cls in sorted(set(tp) | set(fp) | set(fn)):
+        tp_c = tp.get(cls, 0)
+        precision_den = tp_c + fp.get(cls, 0)
+        recall_den = tp_c + fn.get(cls, 0)
+        per_class_precision[cls] = tp_c / precision_den if precision_den else 0.0
+        per_class_recall[cls] = tp_c / recall_den if recall_den else 0.0
+
+    return _UnambiguousScore(
+        top_explanation_accuracy=correct_count / len(unambiguous) if unambiguous else 0.0,
+        per_class_precision=per_class_precision,
+        per_class_recall=per_class_recall,
+        median_temporal=float(statistics.median(temporal_errors)) if temporal_errors else None,
+        calibration_gap=(
+            statistics.mean(correct_conf) - statistics.mean(incorrect_conf)
+            if correct_conf and incorrect_conf
+            else None
+        ),
+    )
+
+
+def _is_high_confidence_single_cause(verdict: AttributionVerdict, threshold: float) -> bool:
+    """Return whether a verdict is a confident, concrete single-cause attribution.
+
+    Returns:
+        ``True`` when the analyser did not abstain, named a concrete cause (not
+        ``interacting_ambiguous`` or ``none``), and met the confidence threshold.
+    """
+    return (
+        not verdict.abstained
+        and verdict.predicted_cause not in {CAUSE_INTERACTING_AMBIGUOUS, CAUSE_NONE}
+        and verdict.confidence >= threshold
+    )
+
+
+def _score_ambiguity_guard(
+    ambiguous: Sequence[GroundTruthFixture],
+    indexed: Mapping[str, AttributionVerdict],
+    threshold: float,
+) -> tuple[float, list[str]]:
+    """Score abstention coverage and collect ambiguous honesty violations.
+
+    Returns:
+        ``(abstention_coverage, violations)`` where ``violations`` names ambiguous
+        fixtures that received a high-confidence single-cause verdict.
+    """
+    violations = [
+        f.fixture_id
+        for f in ambiguous
+        if _is_high_confidence_single_cause(indexed[f.fixture_id], threshold)
+    ]
+    if not ambiguous:
+        return 1.0, violations
+    coverage = (len(ambiguous) - len(violations)) / len(ambiguous)
+    return coverage, violations
+
+
+def _score_negative_controls(
+    negatives: Sequence[GroundTruthFixture],
+    indexed: Mapping[str, AttributionVerdict],
+    threshold: float,
+) -> list[str]:
+    """Collect negative controls promoted to a concrete cause at high confidence.
+
+    Returns:
+        Fixture ids of negative controls whose suspicious signal was promoted.
+    """
+    return [
+        f.fixture_id
+        for f in negatives
+        if _is_high_confidence_single_cause(indexed[f.fixture_id], threshold)
+    ]
+
+
+def _build_verdict_reasons(
+    has_unambiguous: bool,
+    top_explanation_accuracy: float,
+    median_temporal: float | None,
+    ambiguous_violations: Sequence[str],
+    negative_promotions: Sequence[str],
+) -> list[str]:
+    """Assemble the stop-rule failure reasons for a scored report.
+
+    Returns:
+        A list of human-readable reasons; empty means the report passes.
+    """
+    reasons: list[str] = []
+    if has_unambiguous and top_explanation_accuracy < SIMPLE_ACCURACY_FLOOR:
+        reasons.append(
+            f"top-explanation accuracy {top_explanation_accuracy:.3f} below floor "
+            f"{SIMPLE_ACCURACY_FLOOR:.2f}"
+        )
+    if median_temporal is not None and median_temporal > MAX_MEDIAN_TEMPORAL_ERROR_STEPS:
+        reasons.append(
+            f"median temporal-localization error {median_temporal:.2f} exceeds "
+            f"{MAX_MEDIAN_TEMPORAL_ERROR_STEPS:.0f} control step"
+        )
+    if ambiguous_violations:
+        reasons.append(
+            f"ambiguous fixtures received high-confidence single-cause verdicts: "
+            f"{list(ambiguous_violations)}"
+        )
+    if negative_promotions:
+        reasons.append(
+            f"negative controls promoted to a concrete cause: {list(negative_promotions)}"
+        )
+    return reasons
+
+
+def score_attribution(
+    fixtures: Sequence[GroundTruthFixture],
+    verdicts: Iterable[AttributionVerdict | Mapping[str, Any]],
+    *,
+    high_confidence_threshold: float = DEFAULT_HIGH_CONFIDENCE_THRESHOLD,
+) -> AttributionReport:
+    """Score analyser verdicts against a frozen fixture manifest.
+
+    Every fixture must have exactly one verdict; a missing verdict fails closed.
+
+    Metrics (acceptance criterion 2):
+
+    * ``top_explanation_accuracy`` over *unambiguous* fixtures: fraction whose
+      predicted cause matches the ground-truth class without abstaining;
+    * per-class precision/recall over unambiguous fixtures;
+    * ``median_temporal_localization_error`` over correctly-classified unambiguous
+      fixtures, in control steps;
+    * ``avoidability_accuracy`` over all fixtures;
+    * ``abstention_coverage``: fraction of ambiguous fixtures the analyser abstained
+      on or held below the high-confidence threshold;
+    * ``confidence_calibration_gap``: mean confidence on correct minus incorrect
+      unambiguous classifications (higher is better-calibrated).
+
+    Honesty guards (criteria 4, 5): ambiguous fixtures that receive a high-confidence
+    single-cause verdict, and negative controls promoted to a concrete cause at high
+    confidence, are collected as violations and force a ``revise`` verdict.
+
+    Returns:
+        The scored :class:`AttributionReport`.
+
+    Raises:
+        CollisionCauseAttributionError: If a fixture has no verdict or the threshold
+            is out of range.
+    """
+    if not (0.0 < high_confidence_threshold <= 1.0):
+        raise CollisionCauseAttributionError(
+            f"high_confidence_threshold must be in (0, 1] (got {high_confidence_threshold})"
+        )
+    indexed = _index_verdicts(verdicts)
+    missing_ids = [f.fixture_id for f in fixtures if f.fixture_id not in indexed]
+    if missing_ids:
+        raise CollisionCauseAttributionError(
+            f"missing analyser verdict for fixtures: {missing_ids}"
+        )
+
+    unambiguous = [f for f in fixtures if f.ambiguity_status == AMBIGUITY_UNAMBIGUOUS]
+    ambiguous = [f for f in fixtures if f.ambiguity_status == AMBIGUITY_AMBIGUOUS]
+    negatives = [f for f in fixtures if f.ambiguity_status == AMBIGUITY_NEGATIVE_CONTROL]
+
+    scored = _score_unambiguous(unambiguous, indexed)
+    abstention_coverage, ambiguous_violations = _score_ambiguity_guard(
+        ambiguous, indexed, high_confidence_threshold
+    )
+    negative_promotions = _score_negative_controls(negatives, indexed, high_confidence_threshold)
+
+    avoidable_correct = sum(
+        1 for f in fixtures if indexed[f.fixture_id].avoidable_pred == f.avoidable
+    )
+    avoidability_accuracy = avoidable_correct / len(fixtures) if fixtures else 0.0
+
+    reasons = _build_verdict_reasons(
+        bool(unambiguous),
+        scored.top_explanation_accuracy,
+        scored.median_temporal,
+        ambiguous_violations,
+        negative_promotions,
+    )
+
+    return AttributionReport(
+        n_fixtures=len(fixtures),
+        n_scored=len(indexed),
+        top_explanation_accuracy=scored.top_explanation_accuracy,
+        per_class_precision=scored.per_class_precision,
+        per_class_recall=scored.per_class_recall,
+        median_temporal_localization_error=scored.median_temporal,
+        avoidability_accuracy=avoidability_accuracy,
+        abstention_coverage=abstention_coverage,
+        ambiguous_high_confidence_violations=tuple(ambiguous_violations),
+        negative_control_promotions=tuple(negative_promotions),
+        confidence_calibration_gap=scored.calibration_gap,
+        verdict=VERDICT_PASS if not reasons else VERDICT_REVISE,
+        reasons=tuple(reasons),
+    )
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Top-level validation report: manifest coverage plus optional scoring."""
+
+    status: str
+    n_fixtures: int
+    covered_matrix: bool
+    report: AttributionReport | None
+    note: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-safe validation report payload.
+
+        Returns:
+            Mapping with status, coverage, and the scored report when available.
+        """
+        return {
+            "schema_version": COLLISION_CAUSE_ATTRIBUTION_REPORT_SCHEMA,
+            "status": self.status,
+            "n_fixtures": self.n_fixtures,
+            "covered_matrix": self.covered_matrix,
+            "report": self.report.to_dict() if self.report is not None else None,
+            "note": self.note,
+        }
+
+
+def build_validation_report(
+    fixtures: Iterable[GroundTruthFixture | Mapping[str, Any]],
+    verdicts: Iterable[AttributionVerdict | Mapping[str, Any]] | None = None,
+    *,
+    high_confidence_threshold: float = DEFAULT_HIGH_CONFIDENCE_THRESHOLD,
+) -> ValidationReport:
+    """Validate the manifest and, when verdicts exist, score attribution.
+
+    Fails closed: with no analyser verdicts the report is
+    :data:`REPORT_STATUS_ANALYSER_UNAVAILABLE` and carries no fabricated metrics.
+    This is the expected state until the analyser (#5441/#5442) can emit verdicts.
+
+    Args:
+        fixtures: The frozen ground-truth manifest.
+        verdicts: Analyser verdicts, or ``None``/empty when the analyser is unavailable.
+        high_confidence_threshold: Threshold above which single-cause verdicts count
+            as high confidence for the ambiguity and negative-control guards.
+
+    Returns:
+        A :class:`ValidationReport` describing coverage and (when scored) accuracy.
+    """
+    resolved = validate_fixture_manifest(fixtures)
+    verdict_list = list(verdicts) if verdicts is not None else []
+    if not verdict_list:
+        return ValidationReport(
+            status=REPORT_STATUS_ANALYSER_UNAVAILABLE,
+            n_fixtures=len(resolved),
+            covered_matrix=True,
+            report=None,
+            note=(
+                "manifest frozen and matrix covered; no analyser verdicts supplied. "
+                "Accuracy scoring is blocked until the cause analyser (#5441/#5442) "
+                "emits verdicts."
+            ),
+        )
+    report = score_attribution(
+        resolved, verdict_list, high_confidence_threshold=high_confidence_threshold
+    )
+    return ValidationReport(
+        status=REPORT_STATUS_SCORED,
+        n_fixtures=len(resolved),
+        covered_matrix=True,
+        report=report,
+        note="scored analyser verdicts against the frozen fixture manifest",
+    )

--- a/robot_sf/benchmark/schemas/collision_cause_attribution_fixture.v1.json
+++ b/robot_sf/benchmark/schemas/collision_cause_attribution_fixture.v1.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "collision_cause_attribution_fixture.v1.json",
+  "title": "Collision-Cause Attribution Ground-Truth Fixture v1",
+  "description": "Frozen ground-truth record for one injected (or negative-control) collision fault used to validate the collision-cause analyser (issue #5443, deps #5441/#5442). Pins cause class, activation window, allowed intervention, ambiguity status, and avoidability before analysis. Validation-side contract only: it makes no benchmark or paper-grade claim and stores no raw traces or videos.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "fixture_id",
+    "cause_class",
+    "activation_window",
+    "allowed_intervention",
+    "ambiguity_status",
+    "avoidable"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "collision_cause_attribution_fixture.v1"
+    },
+    "fixture_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9_.:-]+$"
+    },
+    "cause_class": {
+      "type": "string",
+      "enum": [
+        "observation_omission",
+        "observation_delay",
+        "prediction_miss",
+        "candidate_omission",
+        "bad_selection",
+        "guard_omission",
+        "infeasible_applied_command",
+        "route_trap",
+        "already_unavoidable_contact",
+        "metric_artifact",
+        "interacting_ambiguous",
+        "none"
+      ]
+    },
+    "activation_window": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": -1
+      },
+      "minItems": 2,
+      "maxItems": 2,
+      "description": "Inclusive [start, end] control-step window; single-step activation uses start == end; negative controls use [-1, -1]."
+    },
+    "allowed_intervention": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The single intervention permitted to test avoidability; 'none' when unavoidable or no actual cause."
+    },
+    "ambiguity_status": {
+      "type": "string",
+      "enum": [
+        "unambiguous",
+        "ambiguous",
+        "negative_control"
+      ]
+    },
+    "avoidable": {
+      "type": "boolean"
+    },
+    "candidate_causes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Plausible causes for an ambiguous fixture (provenance only)."
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/scripts/analysis/validate_collision_cause_attribution_issue_5443.py
+++ b/scripts/analysis/validate_collision_cause_attribution_issue_5443.py
@@ -1,0 +1,133 @@
+"""Deterministic validation report for collision-cause attribution (issue #5443).
+
+Loads the frozen ground-truth fixture manifest and, when supplied, a set of
+analyser attribution verdicts, then emits a schema-tagged JSON report. It runs no
+simulation and makes no benchmark or paper-grade claim.
+
+Fail-closed behaviour: with no ``--verdicts`` file the report status is
+``analyser_unavailable`` — the manifest is validated and the matrix coverage
+confirmed, but accuracy is not scored, because the analyser under test
+(#5441/#5442) does not yet exist to emit verdicts. Providing a verdicts file
+scores attribution accuracy and applies the issue stop rule.
+
+Usage::
+
+    uv run python scripts/analysis/validate_collision_cause_attribution_issue_5443.py \
+        --manifest tests/benchmark/fixtures/collision_cause_attribution_manifest_5443.json \
+        [--verdicts path/to/analyser_verdicts.json] [--out output/report.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.collision_cause_attribution import (
+    REPORT_STATUS_SCORED,
+    VERDICT_PASS,
+    CollisionCauseAttributionError,
+    build_validation_report,
+)
+
+_DEFAULT_MANIFEST = Path("tests/benchmark/fixtures/collision_cause_attribution_manifest_5443.json")
+
+
+def _load_fixtures(manifest_path: Path) -> list[dict[str, Any]]:
+    """Read the ``fixtures`` list from a manifest JSON file.
+
+    Returns:
+        The list of fixture mappings.
+
+    Raises:
+        CollisionCauseAttributionError: If the manifest lacks a ``fixtures`` list.
+    """
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    fixtures = data.get("fixtures")
+    if not isinstance(fixtures, list):
+        raise CollisionCauseAttributionError(
+            f"manifest {manifest_path} must contain a 'fixtures' list"
+        )
+    return fixtures
+
+
+def _load_verdicts(verdicts_path: Path) -> list[dict[str, Any]]:
+    """Read analyser verdicts from a JSON file (a list, or an object with ``verdicts``).
+
+    Returns:
+        The list of verdict mappings.
+
+    Raises:
+        CollisionCauseAttributionError: If the verdicts payload is malformed.
+    """
+    data = json.loads(verdicts_path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return data
+    verdicts = data.get("verdicts") if isinstance(data, dict) else None
+    if not isinstance(verdicts, list):
+        raise CollisionCauseAttributionError(
+            f"verdicts file {verdicts_path} must be a list or an object with a 'verdicts' list"
+        )
+    return verdicts
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        The parsed namespace.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=_DEFAULT_MANIFEST,
+        help="Path to the frozen ground-truth fixture manifest JSON.",
+    )
+    parser.add_argument(
+        "--verdicts",
+        type=Path,
+        default=None,
+        help="Optional analyser verdicts JSON; omit to fail closed as analyser_unavailable.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Optional path to write the report JSON (also printed to stdout).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the validation report.
+
+    Returns:
+        Process exit code: 0 on ``analyser_unavailable`` or a scored ``pass``;
+        1 when a scored report returns the ``revise`` verdict.
+    """
+    args = _parse_args(argv)
+    try:
+        fixtures = _load_fixtures(args.manifest)
+        verdicts = _load_verdicts(args.verdicts) if args.verdicts is not None else None
+        report = build_validation_report(fixtures, verdicts)
+    except (CollisionCauseAttributionError, OSError, json.JSONDecodeError) as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}, indent=2))
+        return 2
+
+    payload = report.to_dict()
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text + "\n", encoding="utf-8")
+    print(text)
+
+    if report.status == REPORT_STATUS_SCORED and report.report is not None:
+        return 0 if report.report.verdict == VERDICT_PASS else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmark/fixtures/collision_cause_attribution_manifest_5443.json
+++ b/tests/benchmark/fixtures/collision_cause_attribution_manifest_5443.json
@@ -1,0 +1,149 @@
+{
+  "manifest_schema": "collision_cause_attribution_manifest.v1",
+  "issue": 5443,
+  "description": "Frozen ground-truth manifest for collision-cause attribution validation (issue #5443). Each entry pins the injected cause class, activation window, allowed intervention, ambiguity status, and avoidability before analysis. Covers the predeclared validation matrix: one activation per single cause, at least one interacting/ambiguous fixture, and negative controls. This is a validation contract, not benchmark evidence; it stores no raw traces or videos.",
+  "fixtures": [
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "obs_omission_01",
+      "cause_class": "observation_omission",
+      "activation_window": [12, 12],
+      "allowed_intervention": "restore_dropped_detection",
+      "ambiguity_status": "unambiguous",
+      "avoidable": true,
+      "notes": "A pedestrian detection is dropped from the observation for one step; restoring it at step 12 avoids contact."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "obs_delay_01",
+      "cause_class": "observation_delay",
+      "activation_window": [8, 11],
+      "allowed_intervention": "remove_observation_lag",
+      "ambiguity_status": "unambiguous",
+      "avoidable": true,
+      "notes": "Observation stream is delayed by three steps across the window; removing the lag lets the planner brake in time."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "prediction_miss_01",
+      "cause_class": "prediction_miss",
+      "activation_window": [15, 15],
+      "allowed_intervention": "correct_predicted_track",
+      "ambiguity_status": "unambiguous",
+      "avoidable": true,
+      "notes": "Pedestrian forecast omits a turn; correcting the predicted track at step 15 restores clearance."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "candidate_omission_01",
+      "cause_class": "candidate_omission",
+      "activation_window": [9, 9],
+      "allowed_intervention": "reinstate_omitted_candidate",
+      "ambiguity_status": "unambiguous",
+      "avoidable": true,
+      "notes": "The evasive candidate action is pruned from the candidate set; reinstating it avoids contact."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "bad_selection_01",
+      "cause_class": "bad_selection",
+      "activation_window": [10, 10],
+      "allowed_intervention": "select_safe_candidate",
+      "ambiguity_status": "unambiguous",
+      "avoidable": true,
+      "notes": "A safe candidate is present but the selector picks a colliding one; forcing the safe pick avoids contact."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "guard_omission_01",
+      "cause_class": "guard_omission",
+      "activation_window": [13, 14],
+      "allowed_intervention": "enable_safety_guard",
+      "ambiguity_status": "unambiguous",
+      "avoidable": true,
+      "notes": "The safety guard that would veto the unsafe command is disabled across the window; enabling it avoids contact."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "infeasible_command_01",
+      "cause_class": "infeasible_applied_command",
+      "activation_window": [11, 11],
+      "allowed_intervention": "apply_feasible_command",
+      "ambiguity_status": "unambiguous",
+      "avoidable": true,
+      "notes": "The commanded deceleration exceeds actuation limits and saturates; the feasible command still avoids contact."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "route_trap_01",
+      "cause_class": "route_trap",
+      "activation_window": [3, 3],
+      "allowed_intervention": "reroute_before_trap",
+      "ambiguity_status": "unambiguous",
+      "avoidable": true,
+      "notes": "The assigned route commits early to a corridor with no evasive room; rerouting before step 3 avoids the trap."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "already_unavoidable_01",
+      "cause_class": "already_unavoidable_contact",
+      "activation_window": [18, 18],
+      "allowed_intervention": "none",
+      "ambiguity_status": "unambiguous",
+      "avoidable": false,
+      "notes": "By step 18 the pedestrian has entered the braking distance with no feasible evasion; contact is unavoidable."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "metric_artifact_01",
+      "cause_class": "metric_artifact",
+      "activation_window": [20, 20],
+      "allowed_intervention": "none",
+      "ambiguity_status": "unambiguous",
+      "avoidable": false,
+      "notes": "A footprint-inflation quirk flags a collision at the reporting step though no physical contact occurs; the cause is a metric artifact, not a planner fault."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "ambiguous_pred_guard_01",
+      "cause_class": "interacting_ambiguous",
+      "activation_window": [10, 14],
+      "allowed_intervention": "none",
+      "ambiguity_status": "ambiguous",
+      "avoidable": true,
+      "candidate_causes": ["prediction_miss", "guard_omission"],
+      "notes": "A prediction miss and a guard omission overlap; either single intervention alone leaves contact, so no single cause is decisive."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "ambiguous_route_selection_01",
+      "cause_class": "interacting_ambiguous",
+      "activation_window": [5, 12],
+      "allowed_intervention": "none",
+      "ambiguity_status": "ambiguous",
+      "avoidable": true,
+      "candidate_causes": ["route_trap", "bad_selection"],
+      "notes": "An early route commitment and a late bad selection jointly cause contact; neither counterfactual alone resolves it."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "negative_control_jitter_01",
+      "cause_class": "none",
+      "activation_window": [-1, -1],
+      "allowed_intervention": "none",
+      "ambiguity_status": "negative_control",
+      "avoidable": false,
+      "notes": "A suspicious observation-jitter signal is present but does not change the counterfactual outcome; it must not be promoted to a cause."
+    },
+    {
+      "schema_version": "collision_cause_attribution_fixture.v1",
+      "fixture_id": "negative_control_guard_flap_01",
+      "cause_class": "none",
+      "activation_window": [-1, -1],
+      "allowed_intervention": "none",
+      "ambiguity_status": "negative_control",
+      "avoidable": false,
+      "notes": "A guard toggles briefly but its state never gates the applied command on this trace; correlation without causal effect."
+    }
+  ]
+}

--- a/tests/benchmark/test_collision_causal_attribution_issue_5443.py
+++ b/tests/benchmark/test_collision_causal_attribution_issue_5443.py
@@ -1,0 +1,335 @@
+"""Tests for the collision-cause attribution validation contract (issue #5443).
+
+Selectable with ``pytest -k 'causal and attribution'`` (the issue's validation
+command). Covers the frozen fixture contract, matrix coverage, pure scoring,
+honesty guards, the JSON schema/enum sync, and fail-closed report building.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.collision_cause_attribution import (
+    AMBIGUITY_AMBIGUOUS,
+    AMBIGUITY_NEGATIVE_CONTROL,
+    AMBIGUITY_UNAMBIGUOUS,
+    CAUSE_CLASSES,
+    CAUSE_INTERACTING_AMBIGUOUS,
+    CAUSE_NONE,
+    COLLISION_CAUSE_ATTRIBUTION_FIXTURE_SCHEMA,
+    REPORT_STATUS_ANALYSER_UNAVAILABLE,
+    REPORT_STATUS_SCORED,
+    VERDICT_PASS,
+    VERDICT_REVISE,
+    AttributionVerdict,
+    CollisionCauseAttributionError,
+    GroundTruthFixture,
+    build_validation_report,
+    score_attribution,
+    validate_fixture_manifest,
+)
+
+_MANIFEST_PATH = (
+    Path(__file__).parent / "fixtures" / "collision_cause_attribution_manifest_5443.json"
+)
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "robot_sf"
+    / "benchmark"
+    / "schemas"
+    / "collision_cause_attribution_fixture.v1.json"
+)
+
+
+def _load_manifest_fixtures() -> list[dict]:
+    data = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    return data["fixtures"]
+
+
+def _perfect_verdict(fixture: GroundTruthFixture) -> AttributionVerdict:
+    """Build a maximally-correct, honestly-abstaining verdict for a fixture."""
+    if fixture.ambiguity_status == AMBIGUITY_UNAMBIGUOUS:
+        return AttributionVerdict(
+            fixture_id=fixture.fixture_id,
+            predicted_cause=fixture.cause_class,
+            predicted_activation_step=fixture.activation_window[0],
+            confidence=0.95,
+            avoidable_pred=fixture.avoidable,
+            abstained=False,
+        )
+    if fixture.ambiguity_status == AMBIGUITY_AMBIGUOUS:
+        return AttributionVerdict(
+            fixture_id=fixture.fixture_id,
+            predicted_cause=CAUSE_INTERACTING_AMBIGUOUS,
+            predicted_activation_step=None,
+            confidence=0.4,
+            avoidable_pred=fixture.avoidable,
+            abstained=True,
+        )
+    return AttributionVerdict(
+        fixture_id=fixture.fixture_id,
+        predicted_cause=CAUSE_NONE,
+        predicted_activation_step=None,
+        confidence=0.2,
+        avoidable_pred=fixture.avoidable,
+        abstained=True,
+    )
+
+
+# --- Frozen fixture contract ------------------------------------------------
+
+
+def test_causal_attribution_fixture_rejects_unknown_cause_class() -> None:
+    """A fixture with an unknown cause_class fails closed."""
+    with pytest.raises(CollisionCauseAttributionError, match="cause_class"):
+        GroundTruthFixture(
+            fixture_id="x",
+            cause_class="mystery",
+            activation_window=(1, 1),
+            allowed_intervention="none",
+            ambiguity_status=AMBIGUITY_UNAMBIGUOUS,
+            avoidable=True,
+        )
+
+
+def test_causal_attribution_negative_control_must_be_causeless() -> None:
+    """A negative control cannot declare a concrete cause or be avoidable."""
+    with pytest.raises(CollisionCauseAttributionError, match="negative_control"):
+        GroundTruthFixture(
+            fixture_id="nc",
+            cause_class="prediction_miss",
+            activation_window=(-1, -1),
+            allowed_intervention="none",
+            ambiguity_status=AMBIGUITY_NEGATIVE_CONTROL,
+            avoidable=False,
+        )
+
+
+def test_causal_attribution_ambiguous_requires_two_candidates() -> None:
+    """An ambiguous fixture must list at least two candidate causes."""
+    with pytest.raises(CollisionCauseAttributionError, match="candidate_causes"):
+        GroundTruthFixture(
+            fixture_id="amb",
+            cause_class=CAUSE_INTERACTING_AMBIGUOUS,
+            activation_window=(1, 3),
+            allowed_intervention="none",
+            ambiguity_status=AMBIGUITY_AMBIGUOUS,
+            avoidable=True,
+            candidate_causes=("prediction_miss",),
+        )
+
+
+def test_causal_attribution_already_unavoidable_cannot_be_avoidable() -> None:
+    """An already-unavoidable-contact fixture must be non-avoidable."""
+    with pytest.raises(CollisionCauseAttributionError, match="already_unavoidable"):
+        GroundTruthFixture(
+            fixture_id="ua",
+            cause_class="already_unavoidable_contact",
+            activation_window=(5, 5),
+            allowed_intervention="none",
+            ambiguity_status=AMBIGUITY_UNAMBIGUOUS,
+            avoidable=True,
+        )
+
+
+def test_causal_attribution_window_must_be_ordered() -> None:
+    """A non-negative-control fixture needs 0 <= start <= end."""
+    with pytest.raises(CollisionCauseAttributionError, match="activation_window"):
+        GroundTruthFixture(
+            fixture_id="w",
+            cause_class="route_trap",
+            activation_window=(5, 2),
+            allowed_intervention="reroute",
+            ambiguity_status=AMBIGUITY_UNAMBIGUOUS,
+            avoidable=True,
+        )
+
+
+def test_causal_attribution_fixture_roundtrips_through_mapping() -> None:
+    """to_dict / from_mapping preserve the frozen fixture."""
+    fixture = GroundTruthFixture(
+        fixture_id="obs",
+        cause_class="observation_delay",
+        activation_window=(8, 11),
+        allowed_intervention="remove_lag",
+        ambiguity_status=AMBIGUITY_UNAMBIGUOUS,
+        avoidable=True,
+        notes="delay",
+    )
+    assert GroundTruthFixture.from_mapping(fixture.to_dict()) == fixture
+
+
+# --- Manifest coverage ------------------------------------------------------
+
+
+def test_causal_attribution_packaged_manifest_covers_matrix() -> None:
+    """The tracked fixture manifest satisfies the predeclared validation matrix."""
+    fixtures = validate_fixture_manifest(_load_manifest_fixtures())
+    statuses = {f.ambiguity_status for f in fixtures}
+    assert AMBIGUITY_AMBIGUOUS in statuses
+    assert AMBIGUITY_NEGATIVE_CONTROL in statuses
+    assert len(fixtures) == len({f.fixture_id for f in fixtures})
+
+
+def test_causal_attribution_manifest_missing_class_fails_closed() -> None:
+    """Dropping a required cause class makes coverage validation fail closed."""
+    fixtures = [f for f in _load_manifest_fixtures() if f["cause_class"] != "route_trap"]
+    with pytest.raises(CollisionCauseAttributionError, match="route_trap"):
+        validate_fixture_manifest(fixtures)
+
+
+def test_causal_attribution_manifest_rejects_duplicate_ids() -> None:
+    """Duplicate fixture ids fail closed."""
+    fixtures = _load_manifest_fixtures()
+    fixtures.append(dict(fixtures[0]))
+    with pytest.raises(CollisionCauseAttributionError, match="duplicate"):
+        validate_fixture_manifest(fixtures)
+
+
+# --- Scoring ----------------------------------------------------------------
+
+
+def test_causal_attribution_perfect_verdicts_pass() -> None:
+    """Correct, honestly-abstaining verdicts yield a passing report."""
+    fixtures = validate_fixture_manifest(_load_manifest_fixtures())
+    verdicts = [_perfect_verdict(f) for f in fixtures]
+    report = score_attribution(fixtures, verdicts)
+    assert report.verdict == VERDICT_PASS
+    assert report.top_explanation_accuracy == pytest.approx(1.0)
+    assert report.median_temporal_localization_error == 0.0
+    assert report.avoidability_accuracy == pytest.approx(1.0)
+    assert report.abstention_coverage == pytest.approx(1.0)
+    assert report.ambiguous_high_confidence_violations == ()
+    assert report.negative_control_promotions == ()
+
+
+def test_causal_attribution_ambiguous_high_confidence_is_violation() -> None:
+    """A confident single-cause verdict on an ambiguous fixture forces revise."""
+    fixtures = validate_fixture_manifest(_load_manifest_fixtures())
+    verdicts = [_perfect_verdict(f) for f in fixtures]
+    amb = next(f for f in fixtures if f.ambiguity_status == AMBIGUITY_AMBIGUOUS)
+    verdicts = [v for v in verdicts if v.fixture_id != amb.fixture_id]
+    verdicts.append(
+        AttributionVerdict(
+            fixture_id=amb.fixture_id,
+            predicted_cause="prediction_miss",
+            predicted_activation_step=amb.activation_window[0],
+            confidence=0.97,
+            avoidable_pred=amb.avoidable,
+            abstained=False,
+        )
+    )
+    report = score_attribution(fixtures, verdicts)
+    assert amb.fixture_id in report.ambiguous_high_confidence_violations
+    assert report.verdict == VERDICT_REVISE
+
+
+def test_causal_attribution_negative_control_promotion_is_violation() -> None:
+    """Promoting a negative control to a concrete cause forces revise."""
+    fixtures = validate_fixture_manifest(_load_manifest_fixtures())
+    verdicts = [_perfect_verdict(f) for f in fixtures]
+    nc = next(f for f in fixtures if f.ambiguity_status == AMBIGUITY_NEGATIVE_CONTROL)
+    verdicts = [v for v in verdicts if v.fixture_id != nc.fixture_id]
+    verdicts.append(
+        AttributionVerdict(
+            fixture_id=nc.fixture_id,
+            predicted_cause="observation_omission",
+            predicted_activation_step=1,
+            confidence=0.9,
+            avoidable_pred=False,
+            abstained=False,
+        )
+    )
+    report = score_attribution(fixtures, verdicts)
+    assert nc.fixture_id in report.negative_control_promotions
+    assert report.verdict == VERDICT_REVISE
+
+
+def test_causal_attribution_below_accuracy_floor_revises() -> None:
+    """Misclassifying many simple fixtures drops below the 0.90 floor -> revise."""
+    fixtures = validate_fixture_manifest(_load_manifest_fixtures())
+    verdicts = []
+    flipped = 0
+    for fixture in fixtures:
+        verdict = _perfect_verdict(fixture)
+        if fixture.ambiguity_status == AMBIGUITY_UNAMBIGUOUS and flipped < 3:
+            wrong = "metric_artifact" if fixture.cause_class != "metric_artifact" else "route_trap"
+            verdict = AttributionVerdict(
+                fixture_id=fixture.fixture_id,
+                predicted_cause=wrong,
+                predicted_activation_step=fixture.activation_window[0],
+                confidence=0.6,
+                avoidable_pred=fixture.avoidable,
+                abstained=False,
+            )
+            flipped += 1
+        verdicts.append(verdict)
+    report = score_attribution(fixtures, verdicts)
+    assert report.top_explanation_accuracy < 0.90
+    assert report.verdict == VERDICT_REVISE
+
+
+def test_causal_attribution_large_temporal_error_revises() -> None:
+    """A median temporal error above one control step forces revise."""
+    fixtures = validate_fixture_manifest(_load_manifest_fixtures())
+    verdicts = []
+    for fixture in fixtures:
+        verdict = _perfect_verdict(fixture)
+        if fixture.ambiguity_status == AMBIGUITY_UNAMBIGUOUS:
+            verdict = AttributionVerdict(
+                fixture_id=fixture.fixture_id,
+                predicted_cause=fixture.cause_class,
+                predicted_activation_step=fixture.activation_window[1] + 5,
+                confidence=0.95,
+                avoidable_pred=fixture.avoidable,
+                abstained=False,
+            )
+        verdicts.append(verdict)
+    report = score_attribution(fixtures, verdicts)
+    assert report.median_temporal_localization_error == 5.0
+    assert report.verdict == VERDICT_REVISE
+
+
+def test_causal_attribution_missing_verdict_fails_closed() -> None:
+    """A fixture with no verdict fails closed rather than scoring partial."""
+    fixtures = validate_fixture_manifest(_load_manifest_fixtures())
+    verdicts = [_perfect_verdict(f) for f in fixtures[:-1]]
+    with pytest.raises(CollisionCauseAttributionError, match="missing analyser verdict"):
+        score_attribution(fixtures, verdicts)
+
+
+# --- Report builder ---------------------------------------------------------
+
+
+def test_causal_attribution_report_fails_closed_without_verdicts() -> None:
+    """No analyser verdicts -> analyser_unavailable, not a fabricated pass."""
+    report = build_validation_report(_load_manifest_fixtures())
+    assert report.status == REPORT_STATUS_ANALYSER_UNAVAILABLE
+    assert report.covered_matrix is True
+    assert report.report is None
+
+
+def test_causal_attribution_report_scores_when_verdicts_present() -> None:
+    """Supplying verdicts moves the report to the scored status."""
+    fixtures = validate_fixture_manifest(_load_manifest_fixtures())
+    verdicts = [_perfect_verdict(f).__dict__ for f in fixtures]
+    report = build_validation_report(_load_manifest_fixtures(), verdicts)
+    assert report.status == REPORT_STATUS_SCORED
+    assert report.report is not None
+    assert report.report.verdict == VERDICT_PASS
+
+
+# --- Schema / enum sync -----------------------------------------------------
+
+
+def test_causal_attribution_schema_enum_matches_module() -> None:
+    """The JSON schema cause_class enum stays in sync with the module's classes."""
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    enum = set(schema["properties"]["cause_class"]["enum"])
+    assert enum == set(CAUSE_CLASSES)
+    assert schema["properties"]["schema_version"]["const"] == (
+        COLLISION_CAUSE_ATTRIBUTION_FIXTURE_SCHEMA
+    )


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds the validation-side machinery for benchmark collision-cause attribution on injected and ambiguous faults (issue #5443, child of #5440) — a frozen ground-truth fixture contract, the pure attribution scoring/report metrics, a covering fixture manifest, and a fail-closed validation CLI.
- **Why now:** The issue's first deliverable is the frozen manifest and the report definitions; both can (and should) be built and tested **before** the analyser under test exists, so the accuracy measurement cannot be tuned to analyser output.
- **Claim boundary:** Analysis-only. No simulation, no cause classifier training, no benchmark or paper/dissertation claim. Evidence grade: `diagnostic-only` / contract; no metric semantics change.
- **Required validation:** `pytest -q tests/benchmark -k 'causal and attribution'` (18 passed) and the deterministic CLI fail-closed check (below).
- **Remaining blocker:** The accuracy RUN (acceptance criteria 3–5) needs the analyser from **#5441** (cause-report contract) and **#5442** (last-avoidable-action counterfactual replay), both still OPEN. Until they emit verdicts the harness returns `analyser_unavailable` by design — this is blocked exactly as a campaign RUN would be, not skipped.

Issue: https://github.com/ll7/robot_sf_ll7/issues/5443

## Contract delta

- **New schema:** `collision_cause_attribution_fixture.v1` (fixture record) and the report payload `collision_cause_attribution_report.v1`. The fixture `cause_class` enum is kept in sync with the module by a test.
- **New fail-closed states:**
  - `build_validation_report` → `analyser_unavailable` when no analyser verdicts are supplied (no fabricated metrics).
  - `validate_fixture_manifest` fails closed unless the predeclared validation matrix is fully covered (every single cause + ≥1 ambiguous + ≥1 negative control), and rejects duplicate fixture ids.
  - `score_attribution` fails closed on any fixture missing a verdict; forces a `revise` verdict when an ambiguous fixture receives a high-confidence single-cause verdict, when a negative control is promoted to a concrete cause, when simple-fixture top-explanation accuracy < 0.90, or when median temporal-localization error > 1 control step.
- **Compatibility impact:** Additive only. New standalone module `robot_sf/benchmark/collision_cause_attribution.py`, new schema JSON, new fixtures/test, new analysis CLI; nothing existing imports it, so no behavior change to current benchmark/runtime paths.

## Scope summary

In scope (issue allowed paths): `tests/benchmark/` fixtures + tests, `robot_sf/benchmark/` validation/report aggregation, `scripts/analysis/` deterministic report, `docs/context/evidence/` compact tracked summary. Forbidden paths (planner/pedestrian behaviour, classifier training, campaign claims, editing the analyser) are untouched.

Files:
- `robot_sf/benchmark/collision_cause_attribution.py`
- `robot_sf/benchmark/schemas/collision_cause_attribution_fixture.v1.json`
- `tests/benchmark/fixtures/collision_cause_attribution_manifest_5443.json`
- `scripts/analysis/validate_collision_cause_attribution_issue_5443.py`
- `tests/benchmark/test_collision_causal_attribution_issue_5443.py`
- `docs/context/evidence/issue_5443_collision_cause_attribution_contract.md` (+ `docs/context/catalog.yaml` registration)

## Validation command results

- `pytest -q tests/benchmark -k 'causal and attribution'` → **18 passed, 4801 deselected**.
- `python scripts/analysis/validate_collision_cause_attribution_issue_5443.py` → `status: analyser_unavailable`, `covered_matrix: true`, `n_fixtures: 14`, exit 0 (fail-closed as intended).
- `ruff check` / `ruff format --check` on the changed files → clean.
- `git diff --check` → clean.
- `python scripts/dev/check_docs_evidence_integrity.py --files <evidence.md> <catalog.yaml>` → passed.

## Acceptance-criteria status

- [x] Frozen ground-truth fixture manifest (cause class, activation window, allowed intervention, ambiguity status, avoidability).
- [x] Report metrics defined and computed (class P/R, top-explanation accuracy, temporal localization, avoidability, abstention coverage, calibration).
- [ ] Simple causes ≥0.90 accuracy, median temporal error ≤1 step — **blocked on analyser #5441/#5442**; stop rule encoded/enforced.
- [ ] Ambiguous fixtures never get a high-confidence single cause — guard encoded + tested; measurement blocked.
- [ ] Negative controls not promoted to actual cause — guard encoded + tested; measurement blocked.
- [ ] Two reviewers inspect a frozen sample — process step, remaining.
- [x] Compact evidence schema-tagged and bound to commit — evidence note + enum-sync test.

## Assumptions (recorded here per triage guidance)

Dependencies #5441/#5442 are OPEN, so the analyser to validate does not yet exist. I implemented the reversible contract/manifest/scoring slice and the fail-closed harness rather than blocking; when the analyser can emit verdicts, feed them via `--verdicts` and the report moves to `scored` with the `pass`/`revise` stop rule applied automatically.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

Refs #5443

<details>
<summary>Governance / propagation</summary>

- State propagation: this PR body is the single canonical surface for the slice (issue #5443 is low-churn — 0 prior PRs, 0 comments). No separate issue-state comment added; no `docs/context/issue_5443_state.yaml` was needed because no transient routing state is encoded in tracked files.
- Fragmentation guard: no guardrail/checker PRs merged for #5443 in the last 24h; this is a **progression slice** adding a nameable new capability (the collision-cause attribution validation contract + scoring harness), so it proceeds at full throttle.
- Research/evidence discipline: analysis-only, fail-closed on missing analyser; no fallback/degraded execution presented as success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collision-cause attribution validation with ground-truth fixtures, coverage checks, deterministic scoring, and fail-closed reporting.
  * Added support for accuracy, precision/recall, timing accuracy, confidence calibration, ambiguity handling, and negative-control checks.
  * Added a command-line validator that outputs JSON reports and meaningful exit statuses.
  * Added a versioned fixture schema and comprehensive validation manifest.

* **Tests**
  * Added extensive coverage for fixture validation, manifest completeness, scoring thresholds, reporting states, and schema consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->