### PR TITLE
feat(benchmark): collision_causal_report.v1 fail-closed cause-report contract (#5441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #5441 `collision_causal_report.v1` fail-closed cause-report contract.** Adds
+  `robot_sf/benchmark/schemas/collision_causal_report.v1.json` and validator
+  `robot_sf/benchmark/collision_causal_report.py` that separate observed reconstruction, proximate
+  mechanism, and intervention-supported causal contribution for a single collision, always setting
+  `normative_fault: not_assessed`. The contract reuses `MECHANISM_LABELS`/`MECHANISM_CONFIDENCES`
+  (no competing taxonomy), marks unsupported fields (`t_uca`, `t_inevitable`, planner internals for
+  black-box planners) unavailable rather than inferred, forbids asserting a planner cause once
+  contact is inevitable, and ships one complete and one abstaining fixture. Producer inventory and
+  decision record: `docs/context/collision_causal_report_field_map_2026-07-13.md`. Schema/fixture
+  evidence only — not proof that real collisions can be causally attributed.
+
 * **issue #5419 authorization-gated DPCBF executor.** Bounded local `run_batch` arms require the
   exact public authorization ID. Atomic checkpoints bind inputs and completed JSONL artifacts;
   dirty, orphaned, malformed, duplicate, or mismatched state fails closed. No Slurm/GPU run or

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -4,6 +4,10 @@ Collision causality, action-conditioned online risk, and statistically defensibl
 scenario discovery research program:
 [collision_causality_online_risk_scenario_discovery_2026-07-12.md](collision_causality_online_risk_scenario_discovery_2026-07-12.md).
 
+Issue #5441 `collision_causal_report.v1` field-producer map, temporal causal-graph nodes, and
+fail-closed contract decision record (model-scoped, `normative_fault: not_assessed`):
+[collision_causal_report_field_map_2026-07-13.md](collision_causal_report_field_map_2026-07-13.md).
+
 Issue #5355 prediction-MPC 2x2 factorial preregistration (prediction on/off x constraint-handling on/off):
 [issue_5355_factorial_preregistration.md](issue_5355_factorial_preregistration.md).
 

--- a/docs/context/collision_causal_report_field_map_2026-07-13.md
+++ b/docs/context/collision_causal_report_field_map_2026-07-13.md
@@ -1,0 +1,151 @@
+# Collision Causal Report Field Map and Decision Record (`collision_causal_report.v1`)
+
+**Status:** proposal / diagnostic-only — schema + fixture contract, not evidence that real
+collisions can be causally attributed.
+**Issue:** [#5441](https://github.com/ll7/robot_sf_ll7/issues/5441) (parent epic
+[#5440](https://github.com/ll7/robot_sf_ll7/issues/5440)).
+**Design source:**
+[`docs/context/collision_causality_online_risk_scenario_discovery_2026-07-12.md`](collision_causality_online_risk_scenario_discovery_2026-07-12.md)
+section 3.
+**Owner module:** `robot_sf/benchmark/collision_causal_report.py` +
+`robot_sf/benchmark/schemas/collision_causal_report.v1.json`.
+
+Plain-language summary: this contract is a *reviewable incident report* for one simulated
+collision. It writes down what was observed, which pipeline stage the proximate cause sits in, and
+whether a *named intervention actually prevented contact* — while explicitly refusing to assign
+legal or moral fault. It is deliberately model-scoped and fail-closed: any field the repository
+cannot yet produce is marked **unavailable** rather than guessed.
+
+## 1. Why a contract first, not a classifier
+
+The parent synthesis (section 3.2.F) requires a reviewable cause report as the first artifact. A
+learned cause classifier is premature because the repository does not yet join planner observations,
+predictions, candidates, scores, guards, and applied commands into one causal trace, and does not yet
+compute the first-unsafe-action or last-avoidable-state timestamps. The honest first increment is a
+schema plus fixtures that make those gaps explicit and fail closed.
+
+The contract is **model-scoped** (issue title): planner-internal reconstruction is available only for
+planners that emit a decision trace (`mechanism_trace.v1`, currently ORCA-residual). For a black-box
+planner the correct report abstains.
+
+## 2. Field producer inventory
+
+Acceptance criterion: *inventory the exact producer for every proposed field and mark unsupported
+fields unavailable rather than inferred.* `Availability` describes what the repository can supply
+**today**; the schema itself accepts either state per report.
+
+### 2.1 Critical timestamps
+
+| Field | Producer today | Availability | Note |
+| --- | --- | --- | --- |
+| `t_danger` | `robot_sf/benchmark/critical_intervals.py` (`ttc_threshold_crossing`, `first_braking_event` anchors) | partial | TTC-threshold proxy, not a formal STL-robustness breach. |
+| `t_uca` | none | **unavailable** | First-unsafe-action detection is deferred to [#5442](https://github.com/ll7/robot_sf_ll7/issues/5442). |
+| `t_inevitable` | none | **unavailable** | Last-avoidable-state / branch search is deferred to #5442. |
+| `t_contact` | `robot_sf/benchmark/event_ledger.py` (`CollisionEventRecord.collision_time`) | available | Authoritative collision event. |
+
+### 2.2 Reconstruction elements
+
+| Field | Producer today | Availability | Note |
+| --- | --- | --- | --- |
+| `observations` | `mechanism_trace.v1.input_condition` | planner-scoped | Only planners emitting a decision trace. |
+| `predictions` | `mechanism_trace.v1.risk_score`; forecast batch schema | planner-scoped | No general forecast-distribution join yet. |
+| `generated_candidates` | `mechanism_trace.v1.command_source` | planner-scoped | ORCA-residual candidate sources only. |
+| `selected_candidate` | `mechanism_trace.v1.selected_command` | planner-scoped | Black-box planners: unavailable. |
+| `guard_arbitration_result` | `mechanism_trace.v1.classification` / `command_source` | planner-scoped | |
+| `feasible_command` | none (actuation model) | **unavailable** | Kinematic-feasibility projection not exported. |
+| `applied_command` | `mechanism_trace.v1.selected_command` | planner-scoped | Proxy for applied command. |
+| `actor_states` | `critical_intervals.py` trace arrays (robot/ped positions, velocities) | available | |
+| `geometry` | `robot_sf/benchmark/collision_definition_inventory.py` (clearance regime, radii) | available | |
+
+### 2.3 Report-level fields
+
+| Field | Source of truth | Note |
+| --- | --- | --- |
+| `proximate_mechanism.mechanism_label` | `failure_mechanism_taxonomy.MECHANISM_LABELS` (imported) | Reused verbatim; no competing aggregate taxonomy. |
+| `confidence.level` | `failure_mechanism_taxonomy.MECHANISM_CONFIDENCES` (imported) | Reused verbatim. |
+| `proximate_mechanism.cause_location` | this contract (`CAUSE_LOCATIONS`) | **Orthogonal** dataflow-stage axis (causal-graph node), *not* a mechanism label. |
+| `proximate_mechanism.unsafe_control_action_class` | this contract | STPA four forms + `not_applicable`/`unknown`. |
+| `data_source` | `event_ledger` provenance conventions | `source_kind`, `replay_determinism`, `software_commit`. |
+| `normative_fault` | const `not_assessed` | Enforced by schema and validator. |
+
+## 3. Temporal causal graph (implemented dataflow)
+
+Acceptance criterion: *document the temporal causal-graph nodes/edges from the implemented
+dataflow.* Nodes correspond to `cause_location` values; edges describe the implemented data flow, not
+post-hoc statistical correlation.
+
+```
+scenario_initialisation
+  -> observation_perception        (sensor/obs assembly)
+  -> prediction                    (forecast / risk_score)
+  -> candidate_generation          (planner candidate set)
+  -> candidate_scoring_selection   (selected_command)
+  -> safety_guard_arbitration      (guard / classification override)
+  -> command_conversion_actuation  (feasible/applied command)
+  -> robot_dynamics                (state integration)
+  -> pedestrian_response           (closed-loop social force reaction)
+  -> collision_metrics             (clearance regime, event ledger)
+```
+
+Side nodes not on the main chain: `scenario_infeasibility_or_unavoidable` (contact unavoidable under
+the declared action set), `simulator_logging_or_metric_artifact` (spurious/logging cause), and
+`unknown_or_interacting` (abstention / interaction set). Edges reflect the ORCA-residual decision
+trace ordering; other planners populate a subset and mark the rest unavailable.
+
+## 4. Localization vs intervention-supported actual cause
+
+Acceptance criterion: *explicitly distinguish localization/suspicion from intervention-supported
+actual cause.*
+
+- **Localization / suspicion:** `cause_location` + `mechanism_label` + `unsafe_control_action_class`
+  say *where* and *how* the incident probably arose. This is derivable from a single observed
+  timeline and is **not** proof of cause.
+- **Intervention-supported actual cause:** `causal_contribution.supported_actual_cause = true` is
+  only legal when a **named** `intervention_model` was run and at least one intervention branch has
+  `prevented_contact = true`, the `verdict` is `avoidable`, and `confidence.level` is not `unknown`.
+  This mirrors the design's frozen-state branching requirement: causation needs a controlled
+  intervention, not a suspicious signal.
+
+Additional fail-closed rules enforced by `collision_causal_report.py`:
+
+- `normative_fault` must be `not_assessed`.
+- Unavailable timestamps carry null `step`/`time_s`; unavailable elements carry null
+  `source`/`detail`; both must be declared in `missing_fields`.
+- If `t_inevitable <= t_uca` (both available) the report may not assert a planner action as the
+  supported actual cause — contact was already unavoidable under that model.
+- An abstaining report (`abstained = true`) must set `verdict = unknown`,
+  `supported_actual_cause = false`, and a non-empty `abstention_reason`.
+
+## 5. Fixtures
+
+- **Complete** (`test_collision_causal_report._complete_report`): a fully reconstructed avoidable
+  incident where a frozen-state brake swap prevented contact under a replayed-pedestrian model.
+- **Incomplete / abstaining** (`abstained_collision_causal_report`): a black-box planner with no
+  decision trace; every reconstruction element and `t_uca`/`t_inevitable` are unavailable, so the
+  report abstains instead of fabricating selected/applied actions.
+
+## 6. Decision record
+
+- **Chose** a JSON schema (structural contract) plus a thin Python validator (cross-field fail-closed
+  rules) — matching `scenario_contract.py` / `schema_validator.py`, because JSON schema alone cannot
+  express the intervention-vs-suspicion and inevitability rules.
+- **Reused** `MECHANISM_LABELS` and `MECHANISM_CONFIDENCES` by import (single source of truth) rather
+  than copying strings, satisfying "do not create a competing aggregate taxonomy".
+- **Added** `cause_location` as an orthogonal dataflow-stage axis rather than extending the aggregate
+  outcome taxonomy, because "where in the pipeline" is a different question from "which outcome
+  class".
+- **Blocked/deferred (honest scope):** `t_uca` and `t_inevitable` computation and general
+  cross-planner selected/applied-action provenance do not exist without changing planner behaviour;
+  they are out of scope here and owned by #5442. This is the documented stop point from the issue's
+  stop rule — the contract fails closed on those fields instead of fabricating them.
+
+## 7. Cross-links
+
+- Parent synthesis: [`collision_causality_online_risk_scenario_discovery_2026-07-12.md`](collision_causality_online_risk_scenario_discovery_2026-07-12.md).
+- [#2012](https://github.com/ll7/robot_sf_ll7/issues/2012) — event ledger / typed collision events.
+- [#2220](https://github.com/ll7/robot_sf_ll7/issues/2220) — failure-mechanism taxonomy.
+- [#2547](https://github.com/ll7/robot_sf_ll7/issues/2547) — critical intervals.
+- [#2924](https://github.com/ll7/robot_sf_ll7/issues/2924) — counterfactual pair / intervention pattern.
+- [#4758](https://github.com/ll7/robot_sf_ll7/issues/4758) — related trace/provenance work.
+- Next: [#5442](https://github.com/ll7/robot_sf_ll7/issues/5442) — snapshot/branching replay and
+  last-avoidable-action analysis that will populate `t_uca` / `t_inevitable`.

--- a/robot_sf/benchmark/collision_causal_report.py
+++ b/robot_sf/benchmark/collision_causal_report.py
@@ -1,0 +1,360 @@
+"""Fail-closed validator for the ``collision_causal_report.v1`` contract.
+
+This module owns the cross-field semantic rules that the JSON schema in
+``schemas/collision_causal_report.v1.json`` cannot express. The report is a
+*model-scoped* reconstruction of a single collision: it separates observed
+facts, the proximate mechanism, and the intervention-supported causal
+contribution, and it never assigns legal or moral fault
+(``normative_fault`` is always ``"not_assessed"``).
+
+Design source: ``docs/context/collision_causality_online_risk_scenario_discovery_2026-07-12.md``
+section 3 and the field map in
+``docs/context/collision_causal_report_field_map_2026-07-13.md``.
+
+Enum vocabularies for ``mechanism_label`` and ``confidence.level`` are reused
+verbatim from :mod:`robot_sf.benchmark.failure_mechanism_taxonomy` so this
+contract never grows a competing aggregate taxonomy. ``cause_location`` is an
+orthogonal axis (a node in the implemented temporal causal graph), not a second
+mechanism vocabulary.
+
+The contract is deliberately conservative: planner-internal reconstruction
+fields (observations, predictions, generated/selected candidates, guard and
+arbitration results, feasible/applied commands) are marked *unavailable* unless
+a canonical trace owner actually produced them. First-unsafe-action
+(``t_uca``) and last-avoidable-state (``t_inevitable``) computation does not yet
+exist in this repository (see #5442), so those timestamps are expected to be
+unavailable in v1 reports. Marking them unavailable is the correct fail-closed
+behaviour; fabricating them is not.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.failure_mechanism_taxonomy import (
+    MECHANISM_CONFIDENCES,
+    MECHANISM_LABELS,
+)
+from robot_sf.errors import RobotSfError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+try:
+    import jsonschema
+except ImportError as exc:  # pragma: no cover - dependency is declared in pyproject
+    raise RuntimeError(
+        "jsonschema package required for collision causal report validation"
+    ) from exc
+
+COLLISION_CAUSAL_REPORT_SCHEMA_VERSION = "collision_causal_report.v1"
+COLLISION_CAUSAL_REPORT_SCHEMA_FILE = (
+    Path(__file__).with_name("schemas") / "collision_causal_report.v1.json"
+)
+
+#: The four systems-theoretic (STPA) unsafe-control-action forms plus fail-closed values.
+UNSAFE_CONTROL_ACTION_CLASSES = frozenset(
+    {
+        "action_not_provided",
+        "unsafe_action_provided",
+        "unsafe_timing_or_order",
+        "unsafe_duration",
+        "not_applicable",
+        "unknown",
+    }
+)
+
+#: Dataflow-stage cause locations (temporal causal-graph nodes). Orthogonal to
+#: ``mechanism_label``; this is *where* in the implemented pipeline the cause sits.
+CAUSE_LOCATIONS = frozenset(
+    {
+        "scenario_initialisation",
+        "observation_perception",
+        "prediction",
+        "candidate_generation",
+        "candidate_scoring_selection",
+        "safety_guard_arbitration",
+        "command_conversion_actuation",
+        "robot_dynamics",
+        "pedestrian_response",
+        "collision_metrics",
+        "scenario_infeasibility_or_unavoidable",
+        "simulator_logging_or_metric_artifact",
+        "unknown_or_interacting",
+    }
+)
+
+CAUSAL_VERDICTS = frozenset({"avoidable", "unavoidable", "unknown"})
+PEDESTRIAN_RESPONSE_ASSUMPTIONS = frozenset({"replayed", "closed_loop", "unknown"})
+
+#: The four incident timestamps, ordered as they occur along one timeline.
+CRITICAL_TIMESTAMP_KEYS = ("t_danger", "t_uca", "t_inevitable", "t_contact")
+
+#: Reconstruction elements that must be present (each as available/unavailable).
+RECONSTRUCTION_ELEMENT_KEYS = (
+    "observations",
+    "predictions",
+    "generated_candidates",
+    "selected_candidate",
+    "guard_arbitration_result",
+    "feasible_command",
+    "applied_command",
+    "actor_states",
+    "geometry",
+)
+
+
+class CollisionCausalReportError(RobotSfError, ValueError):
+    """Raised when a collision causal report violates the fail-closed contract."""
+
+
+def load_collision_causal_report_schema() -> dict[str, Any]:
+    """Load the ``collision_causal_report.v1`` JSON schema from disk.
+
+    Returns:
+        The parsed JSON schema dictionary.
+    """
+
+    with COLLISION_CAUSAL_REPORT_SCHEMA_FILE.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def reconcile_collision_causal_report(record: Mapping[str, Any]) -> list[str]:
+    """Return the list of fail-closed contract violations for ``record``.
+
+    The check is non-raising so callers can accumulate violations (the house
+    pattern used by :func:`robot_sf.benchmark.event_ledger.reconcile_event_ledger`).
+    An empty list means the record satisfies both the JSON schema and every
+    cross-field semantic rule.
+
+    Returns:
+        Human-readable violation strings; empty when the record is valid.
+    """
+
+    schema = load_collision_causal_report_schema()
+    try:
+        jsonschema.validate(instance=record, schema=schema)
+    except jsonschema.ValidationError as error:
+        return [f"schema: {error.message}"]
+
+    violations: list[str] = []
+    violations.extend(_normative_fault_violations(record))
+    violations.extend(_vocabulary_violations(record))
+    violations.extend(_timestamp_violations(record))
+    violations.extend(_missing_field_violations(record))
+    violations.extend(_abstention_violations(record))
+    violations.extend(_actual_cause_violations(record))
+    violations.extend(_inevitability_violations(record))
+    return violations
+
+
+def validate_collision_causal_report(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a collision causal report, raising on the first contract breach.
+
+    Returns:
+        A shallow ``dict`` copy of the validated record.
+
+    Raises:
+        CollisionCausalReportError: If any schema or semantic rule is violated.
+    """
+
+    violations = reconcile_collision_causal_report(record)
+    if violations:
+        raise CollisionCausalReportError("; ".join(violations))
+    return dict(record)
+
+
+def abstained_collision_causal_report(
+    *,
+    report_id: str,
+    case_id: str,
+    reason: str,
+    source_kind: str = "unknown",
+    missing_fields: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a valid, fully abstaining report that fails closed.
+
+    Every reconstruction element and timestamp is marked unavailable, the
+    verdict is ``unknown``, and no actual cause is asserted. This is the correct
+    artifact when replay is nondeterministic, required trace fields are absent,
+    or competing explanations are observationally equivalent.
+
+    Returns:
+        A report dict that satisfies :func:`validate_collision_causal_report`.
+    """
+
+    clean_reason = reason.strip() or "not_derivable"
+    unavailable_ts = {
+        key: {"available": False, "step": None, "time_s": None, "source": None}
+        for key in CRITICAL_TIMESTAMP_KEYS
+    }
+    unavailable_elements = {
+        key: {"available": False, "source": None, "detail": None}
+        for key in RECONSTRUCTION_ELEMENT_KEYS
+    }
+    declared_missing = list(missing_fields or [])
+    for key in (*CRITICAL_TIMESTAMP_KEYS, *RECONSTRUCTION_ELEMENT_KEYS):
+        if key not in declared_missing:
+            declared_missing.append(key)
+    return {
+        "schema_version": COLLISION_CAUSAL_REPORT_SCHEMA_VERSION,
+        "report_id": report_id,
+        "case_id": case_id,
+        "normative_fault": "not_assessed",
+        "data_source": {
+            "source_kind": source_kind,
+            "provenance_uri": None,
+            "software_commit": None,
+            "replay_determinism": "unknown",
+        },
+        "abstained": True,
+        "abstention_reason": clean_reason,
+        "observed_reconstruction": {
+            "critical_timestamps": unavailable_ts,
+            "elements": unavailable_elements,
+        },
+        "proximate_mechanism": {
+            "mechanism_label": "unknown",
+            "cause_location": "unknown_or_interacting",
+            "unsafe_control_action_class": "unknown",
+            "rationale": clean_reason,
+        },
+        "causal_contribution": {
+            "verdict": "unknown",
+            "intervention_model": "",
+            "pedestrian_response_assumption": "unknown",
+            "supported_actual_cause": False,
+            "interventions": [],
+        },
+        "confidence": {"level": "unknown", "rationale": clean_reason},
+        "assumptions": [],
+        "missing_fields": declared_missing,
+        "competing_explanations": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Semantic rule helpers
+# ---------------------------------------------------------------------------
+
+
+def _normative_fault_violations(record: Mapping[str, Any]) -> list[str]:
+    if record.get("normative_fault") != "not_assessed":
+        return ["normative_fault must be 'not_assessed'"]
+    return []
+
+
+def _vocabulary_violations(record: Mapping[str, Any]) -> list[str]:
+    violations: list[str] = []
+    mechanism = record.get("proximate_mechanism", {})
+    label = mechanism.get("mechanism_label")
+    if label not in MECHANISM_LABELS:
+        violations.append(
+            f"mechanism_label {label!r} is not in failure_mechanism_taxonomy.MECHANISM_LABELS"
+        )
+    confidence = record.get("confidence", {})
+    level = confidence.get("level")
+    if level not in MECHANISM_CONFIDENCES:
+        violations.append(
+            f"confidence.level {level!r} is not in failure_mechanism_taxonomy.MECHANISM_CONFIDENCES"
+        )
+    return violations
+
+
+def _timestamp_violations(record: Mapping[str, Any]) -> list[str]:
+    violations: list[str] = []
+    timestamps = record.get("observed_reconstruction", {}).get("critical_timestamps", {})
+    for key in CRITICAL_TIMESTAMP_KEYS:
+        entry = timestamps.get(key, {})
+        available = entry.get("available")
+        step = entry.get("step")
+        time_s = entry.get("time_s")
+        if available:
+            if step is None and time_s is None:
+                violations.append(f"{key} is available but has neither step nor time_s")
+        elif step is not None or time_s is not None:
+            violations.append(
+                f"{key} is unavailable but carries an inferred step/time_s; leave both null"
+            )
+    return violations
+
+
+def _missing_field_violations(record: Mapping[str, Any]) -> list[str]:
+    # Every unavailable element/timestamp must be declared in missing_fields.
+    violations: list[str] = []
+    declared = set(record.get("missing_fields", []))
+    reconstruction = record.get("observed_reconstruction", {})
+    timestamps = reconstruction.get("critical_timestamps", {})
+    elements = reconstruction.get("elements", {})
+    for key in CRITICAL_TIMESTAMP_KEYS:
+        if not timestamps.get(key, {}).get("available", False) and key not in declared:
+            violations.append(f"unavailable timestamp {key!r} must be listed in missing_fields")
+    for key in RECONSTRUCTION_ELEMENT_KEYS:
+        element = elements.get(key, {})
+        if not element.get("available", False):
+            if element.get("source") is not None or element.get("detail") is not None:
+                violations.append(
+                    f"element {key!r} is unavailable but carries inferred source/detail"
+                )
+            if key not in declared:
+                violations.append(f"unavailable element {key!r} must be listed in missing_fields")
+    return violations
+
+
+def _abstention_violations(record: Mapping[str, Any]) -> list[str]:
+    if not record.get("abstained"):
+        return []
+    violations: list[str] = []
+    if not str(record.get("abstention_reason", "")).strip():
+        violations.append("abstained report must set a non-empty abstention_reason")
+    contribution = record.get("causal_contribution", {})
+    if contribution.get("verdict") != "unknown":
+        violations.append("abstained report must set causal_contribution.verdict to 'unknown'")
+    if contribution.get("supported_actual_cause"):
+        violations.append("abstained report cannot set supported_actual_cause to true")
+    return violations
+
+
+def _actual_cause_violations(record: Mapping[str, Any]) -> list[str]:
+    # An intervention-supported actual cause needs an intervention that prevented contact.
+    contribution = record.get("causal_contribution", {})
+    if not contribution.get("supported_actual_cause"):
+        return []
+    violations: list[str] = []
+    if contribution.get("verdict") != "avoidable":
+        violations.append("supported_actual_cause requires verdict 'avoidable'")
+    if not str(contribution.get("intervention_model", "")).strip():
+        violations.append("supported_actual_cause requires a named intervention_model")
+    interventions = contribution.get("interventions", [])
+    if not any(item.get("prevented_contact") is True for item in interventions):
+        violations.append(
+            "supported_actual_cause requires at least one intervention with prevented_contact true"
+        )
+    if record.get("confidence", {}).get("level") == "unknown":
+        violations.append("supported_actual_cause cannot carry confidence.level 'unknown'")
+    return violations
+
+
+def _inevitability_violations(record: Mapping[str, Any]) -> list[str]:
+    # If contact was already inevitable at/before the first unsafe action, no planner cause.
+    # From the design doc: when t_inevitable <= t_uca the system must not assign a planner
+    # action as the collision cause; contact was unavoidable under that model.
+    timestamps = record.get("observed_reconstruction", {}).get("critical_timestamps", {})
+    uca = timestamps.get("t_uca", {})
+    inevitable = timestamps.get("t_inevitable", {})
+    if not (uca.get("available") and inevitable.get("available")):
+        return []
+    uca_step = uca.get("step")
+    inevitable_step = inevitable.get("step")
+    if uca_step is None or inevitable_step is None:
+        return []
+    if inevitable_step <= uca_step and record.get("causal_contribution", {}).get(
+        "supported_actual_cause"
+    ):
+        return [
+            "t_inevitable <= t_uca: contact was already unavoidable, so a planner action "
+            "cannot be reported as the supported actual cause"
+        ]
+    return []

--- a/robot_sf/benchmark/collision_causal_report.py
+++ b/robot_sf/benchmark/collision_causal_report.py
@@ -346,15 +346,29 @@ def _inevitability_violations(record: Mapping[str, Any]) -> list[str]:
     inevitable = timestamps.get("t_inevitable", {})
     if not (uca.get("available") and inevitable.get("available")):
         return []
-    uca_step = uca.get("step")
-    inevitable_step = inevitable.get("step")
-    if uca_step is None or inevitable_step is None:
+    # The ordering guard only bites when the report claims a planner action as the cause.
+    if not record.get("causal_contribution", {}).get("supported_actual_cause"):
         return []
-    if inevitable_step <= uca_step and record.get("causal_contribution", {}).get(
-        "supported_actual_cause"
-    ):
-        return [
-            "t_inevitable <= t_uca: contact was already unavoidable, so a planner action "
-            "cannot be reported as the supported actual cause"
-        ]
-    return []
+    # Compare in a single shared unit so a schema-legal representation cannot evade the
+    # guard: prefer integer control steps when both timestamps carry one, else fall back to
+    # ``time_s``. ``step`` and ``time_s`` are both nullable in the schema, so a caller could
+    # otherwise mark both timestamps ``available`` with ``step: null`` and slip an
+    # inevitable-before-uca contact past the guard.
+    for key in ("step", "time_s"):
+        uca_value = uca.get(key)
+        inevitable_value = inevitable.get(key)
+        if uca_value is not None and inevitable_value is not None:
+            if inevitable_value <= uca_value:
+                return [
+                    "t_inevitable <= t_uca: contact was already unavoidable, so a planner "
+                    "action cannot be reported as the supported actual cause"
+                ]
+            return []
+    # Available and a supported cause is claimed, but the two timestamps share no comparable
+    # step or time_s: the inevitability ordering is undecidable, so fail closed rather than
+    # letting the unverifiable claim stand.
+    return [
+        "t_uca and t_inevitable are marked available but share no comparable step or time_s: "
+        "the inevitability ordering is undecidable, so a planner action cannot be reported as "
+        "the supported actual cause"
+    ]

--- a/robot_sf/benchmark/schemas/collision_causal_report.v1.json
+++ b/robot_sf/benchmark/schemas/collision_causal_report.v1.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "collision_causal_report.v1.json",
+  "title": "Collision Causal Report (v1)",
+  "description": "Model-scoped, fail-closed contract that reconstructs a single collision, records the implemented causal dataflow, marks unsupported evidence as unavailable rather than inferred, and separates observed facts, proximate mechanism, and intervention-supported causal contribution. It never assigns legal or moral fault (normative_fault is always not_assessed). Enum vocabularies for mechanism_label and confidence.level are the single source of truth in robot_sf/benchmark/failure_mechanism_taxonomy.py; cross-field fail-closed rules live in robot_sf/benchmark/collision_causal_report.py.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_id",
+    "case_id",
+    "normative_fault",
+    "data_source",
+    "abstained",
+    "observed_reconstruction",
+    "proximate_mechanism",
+    "causal_contribution",
+    "confidence",
+    "assumptions",
+    "missing_fields",
+    "competing_explanations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "collision_causal_report.v1"
+    },
+    "report_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "case_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "normative_fault": {
+      "description": "Always not_assessed. Robot SF artifacts do not derive legal or moral fault from simulator geometry.",
+      "const": "not_assessed"
+    },
+    "abstained": {
+      "description": "True when the analyser declines to assert a proximate mechanism or actual cause (insufficient evidence, nondeterministic replay, or observationally equivalent explanations).",
+      "type": "boolean"
+    },
+    "abstention_reason": {
+      "type": "string"
+    },
+    "data_source": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["source_kind", "replay_determinism"],
+      "properties": {
+        "source_kind": {
+          "description": "Where the reconstruction came from.",
+          "type": "string",
+          "enum": ["synthetic_fixture", "replayed_episode", "live_episode", "unknown"]
+        },
+        "provenance_uri": {
+          "type": ["string", "null"]
+        },
+        "software_commit": {
+          "type": ["string", "null"]
+        },
+        "replay_determinism": {
+          "type": "string",
+          "enum": ["deterministic", "nondeterministic", "unknown"]
+        }
+      }
+    },
+    "observed_reconstruction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["critical_timestamps", "elements"],
+      "properties": {
+        "critical_timestamps": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["t_danger", "t_uca", "t_inevitable", "t_contact"],
+          "properties": {
+            "t_danger": {"$ref": "#/$defs/critical_timestamp"},
+            "t_uca": {"$ref": "#/$defs/critical_timestamp"},
+            "t_inevitable": {"$ref": "#/$defs/critical_timestamp"},
+            "t_contact": {"$ref": "#/$defs/critical_timestamp"}
+          }
+        },
+        "elements": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "observations",
+            "predictions",
+            "generated_candidates",
+            "selected_candidate",
+            "guard_arbitration_result",
+            "feasible_command",
+            "applied_command",
+            "actor_states",
+            "geometry"
+          ],
+          "properties": {
+            "observations": {"$ref": "#/$defs/reconstruction_element"},
+            "predictions": {"$ref": "#/$defs/reconstruction_element"},
+            "generated_candidates": {"$ref": "#/$defs/reconstruction_element"},
+            "selected_candidate": {"$ref": "#/$defs/reconstruction_element"},
+            "guard_arbitration_result": {"$ref": "#/$defs/reconstruction_element"},
+            "feasible_command": {"$ref": "#/$defs/reconstruction_element"},
+            "applied_command": {"$ref": "#/$defs/reconstruction_element"},
+            "actor_states": {"$ref": "#/$defs/reconstruction_element"},
+            "geometry": {"$ref": "#/$defs/reconstruction_element"}
+          }
+        }
+      }
+    },
+    "proximate_mechanism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mechanism_label",
+        "cause_location",
+        "unsafe_control_action_class",
+        "rationale"
+      ],
+      "properties": {
+        "mechanism_label": {
+          "description": "Reused verbatim from failure_mechanism_taxonomy.MECHANISM_LABELS; not a competing aggregate taxonomy.",
+          "type": "string"
+        },
+        "cause_location": {
+          "description": "Node in the implemented temporal causal graph (dataflow stage). Orthogonal axis to mechanism_label.",
+          "type": "string",
+          "enum": [
+            "scenario_initialisation",
+            "observation_perception",
+            "prediction",
+            "candidate_generation",
+            "candidate_scoring_selection",
+            "safety_guard_arbitration",
+            "command_conversion_actuation",
+            "robot_dynamics",
+            "pedestrian_response",
+            "collision_metrics",
+            "scenario_infeasibility_or_unavoidable",
+            "simulator_logging_or_metric_artifact",
+            "unknown_or_interacting"
+          ]
+        },
+        "unsafe_control_action_class": {
+          "description": "Systems-theoretic (STPA) form of the first unsafe control action.",
+          "type": "string",
+          "enum": [
+            "action_not_provided",
+            "unsafe_action_provided",
+            "unsafe_timing_or_order",
+            "unsafe_duration",
+            "not_applicable",
+            "unknown"
+          ]
+        },
+        "rationale": {
+          "type": "string"
+        }
+      }
+    },
+    "causal_contribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "verdict",
+        "intervention_model",
+        "pedestrian_response_assumption",
+        "supported_actual_cause",
+        "interventions"
+      ],
+      "properties": {
+        "verdict": {
+          "type": "string",
+          "enum": ["avoidable", "unavoidable", "unknown"]
+        },
+        "intervention_model": {
+          "description": "Named intervention/model under which the causal contribution is asserted (empty string when none).",
+          "type": "string"
+        },
+        "pedestrian_response_assumption": {
+          "description": "Pedestrians react to the robot; a single frozen trajectory is insufficient, so the assumption must be named.",
+          "type": "string",
+          "enum": ["replayed", "closed_loop", "unknown"]
+        },
+        "supported_actual_cause": {
+          "description": "True only when a named intervention actually prevented contact (intervention-supported actual cause), distinct from localization or suspicion.",
+          "type": "boolean"
+        },
+        "interventions": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/intervention"}
+        }
+      }
+    },
+    "confidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "rationale"],
+      "properties": {
+        "level": {
+          "description": "Reused verbatim from failure_mechanism_taxonomy.MECHANISM_CONFIDENCES.",
+          "type": "string"
+        },
+        "rationale": {
+          "type": "string"
+        }
+      }
+    },
+    "assumptions": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "missing_fields": {
+      "description": "Every reconstruction element or timestamp marked unavailable must be listed here so unsupported evidence is explicit, never inferred.",
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "competing_explanations": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/competing_explanation"}
+    }
+  },
+  "$defs": {
+    "critical_timestamp": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available", "step", "time_s", "source"],
+      "properties": {
+        "available": {"type": "boolean"},
+        "step": {"type": ["integer", "null"]},
+        "time_s": {"type": ["number", "null"]},
+        "source": {"type": ["string", "null"]}
+      }
+    },
+    "reconstruction_element": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available", "source", "detail"],
+      "properties": {
+        "available": {"type": "boolean"},
+        "source": {"type": ["string", "null"]},
+        "detail": {"type": ["object", "array", "string", "number", "boolean", "null"]}
+      }
+    },
+    "intervention": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "admissible", "prevented_contact", "assumptions"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "admissible": {"type": "boolean"},
+        "prevented_contact": {
+          "description": "True/False when an intervention branch was actually run; null when not evaluated.",
+          "type": ["boolean", "null"]
+        },
+        "assumptions": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "competing_explanation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["explanation", "ruled_out", "note"],
+      "properties": {
+        "explanation": {"type": "string", "minLength": 1},
+        "ruled_out": {"type": "boolean"},
+        "note": {"type": "string"}
+      }
+    }
+  }
+}

--- a/tests/benchmark/test_collision_causal_report.py
+++ b/tests/benchmark/test_collision_causal_report.py
@@ -249,6 +249,36 @@ def test_inevitable_before_uca_forbids_planner_cause():
     assert any("already unavoidable" in v for v in violations)
 
 
+def test_inevitable_before_uca_via_time_s_only_forbids_planner_cause():
+    """The ordering guard cannot be evaded by dropping steps and using time_s only."""
+    report = _complete_report()
+    timestamps = report["observed_reconstruction"]["critical_timestamps"]
+    # Both timestamps stay available but carry no step (schema-legal), only seconds.
+    timestamps["t_uca"]["step"] = None
+    timestamps["t_inevitable"]["step"] = None
+    timestamps["t_uca"]["time_s"] = 4.2
+    timestamps["t_inevitable"]["time_s"] = 4.2  # inevitable <= uca in seconds
+    violations = reconcile_collision_causal_report(report)
+    assert any("already unavoidable" in v for v in violations)
+
+
+def test_inevitability_ordering_undecidable_fails_closed():
+    """Timestamps quantified in different units share no comparable ordering, so fail closed.
+
+    Each timestamp individually satisfies ``_timestamp_violations`` (it carries at least one
+    of step/time_s), but t_uca has only a step and t_inevitable only a time_s, so the guard
+    cannot decide the ordering and must not let the planner actual-cause claim stand.
+    """
+    report = _complete_report()
+    timestamps = report["observed_reconstruction"]["critical_timestamps"]
+    timestamps["t_uca"]["step"] = 42
+    timestamps["t_uca"]["time_s"] = None
+    timestamps["t_inevitable"]["step"] = None
+    timestamps["t_inevitable"]["time_s"] = 4.2
+    violations = reconcile_collision_causal_report(report)
+    assert any("undecidable" in v for v in violations)
+
+
 def test_unavailable_element_must_be_declared_missing():
     """An unavailable element must appear in missing_fields; declaring it repairs the report."""
     report = _complete_report()

--- a/tests/benchmark/test_collision_causal_report.py
+++ b/tests/benchmark/test_collision_causal_report.py
@@ -1,0 +1,298 @@
+"""Tests for the ``collision_causal_report.v1`` fail-closed contract.
+
+Covers the two acceptance fixtures required by issue #5441:
+
+* one complete synthetic collision report that validates, and
+* one intentionally incomplete report that fails closed by abstaining;
+
+plus negative cases proving each cross-field rule rejects fabricated causal
+claims. Run with::
+
+    uv run pytest -q tests/benchmark -k 'collision and causal or causal_report'
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from robot_sf.benchmark.collision_causal_report import (
+    CollisionCausalReportError,
+    abstained_collision_causal_report,
+    reconcile_collision_causal_report,
+    validate_collision_causal_report,
+)
+from robot_sf.benchmark.failure_mechanism_taxonomy import (
+    MECHANISM_CONFIDENCES,
+    MECHANISM_LABELS,
+)
+
+
+def _complete_report() -> dict:
+    """A fully reconstructed, intervention-supported avoidable-collision report.
+
+    The synthetic incident: the planner had generated an emergency-brake
+    candidate, did not select it, and a frozen-state branch that swapped in the
+    brake prevented contact under a replayed-pedestrian model.
+    """
+
+    return {
+        "schema_version": "collision_causal_report.v1",
+        "report_id": "ccr-synthetic-complete-001",
+        "case_id": "crossing_ttc_low__seed7__orca_residual",
+        "normative_fault": "not_assessed",
+        "data_source": {
+            "source_kind": "synthetic_fixture",
+            "provenance_uri": "fixture://issue-5441/complete",
+            "software_commit": None,
+            "replay_determinism": "deterministic",
+        },
+        "abstained": False,
+        "abstention_reason": "",
+        "observed_reconstruction": {
+            "critical_timestamps": {
+                "t_danger": {
+                    "available": True,
+                    "step": 40,
+                    "time_s": 4.0,
+                    "source": "critical_intervals.ttc_threshold_crossing",
+                },
+                "t_uca": {
+                    "available": True,
+                    "step": 42,
+                    "time_s": 4.2,
+                    "source": "synthetic_injected_fault",
+                },
+                "t_inevitable": {
+                    "available": True,
+                    "step": 47,
+                    "time_s": 4.7,
+                    "source": "synthetic_branch_search",
+                },
+                "t_contact": {
+                    "available": True,
+                    "step": 50,
+                    "time_s": 5.0,
+                    "source": "event_ledger.CollisionEventRecord",
+                },
+            },
+            "elements": {
+                "observations": {
+                    "available": True,
+                    "source": "mechanism_trace.v1.input_condition",
+                    "detail": {"nearest_ped_range_m": 1.8},
+                },
+                "predictions": {
+                    "available": True,
+                    "source": "mechanism_trace.v1.risk_score",
+                    "detail": {"risk_score": 0.72},
+                },
+                "generated_candidates": {
+                    "available": True,
+                    "source": "mechanism_trace.v1.command_source",
+                    "detail": ["orca_residual", "emergency_brake"],
+                },
+                "selected_candidate": {
+                    "available": True,
+                    "source": "mechanism_trace.v1.selected_command",
+                    "detail": {"vx": 0.9, "vy": 0.1},
+                },
+                "guard_arbitration_result": {
+                    "available": True,
+                    "source": "mechanism_trace.v1.classification",
+                    "detail": "active-but-irrelevant",
+                },
+                "feasible_command": {
+                    "available": True,
+                    "source": "synthetic_actuation_model",
+                    "detail": {"vx": 0.9, "vy": 0.1},
+                },
+                "applied_command": {
+                    "available": True,
+                    "source": "mechanism_trace.v1.selected_command",
+                    "detail": {"vx": 0.9, "vy": 0.1},
+                },
+                "actor_states": {
+                    "available": True,
+                    "source": "critical_intervals.trace_arrays",
+                    "detail": {"n_pedestrians": 3},
+                },
+                "geometry": {
+                    "available": True,
+                    "source": "collision_definition_inventory.clearance_regime",
+                    "detail": {"radius_sum_m": 1.4},
+                },
+            },
+        },
+        "proximate_mechanism": {
+            "mechanism_label": "guard_or_handoff_domination",
+            "cause_location": "candidate_scoring_selection",
+            "unsafe_control_action_class": "action_not_provided",
+            "rationale": (
+                "The emergency-brake candidate existed but was not selected; the "
+                "residual command continued into a closing pedestrian."
+            ),
+        },
+        "causal_contribution": {
+            "verdict": "avoidable",
+            "intervention_model": "frozen_state_brake_swap__replayed_pedestrians",
+            "pedestrian_response_assumption": "replayed",
+            "supported_actual_cause": True,
+            "interventions": [
+                {
+                    "name": "emergency_brake_at_t_uca",
+                    "admissible": True,
+                    "prevented_contact": True,
+                    "assumptions": ["replayed pedestrian motion", "fixed simulator rng"],
+                },
+                {
+                    "name": "bounded_steer_left",
+                    "admissible": True,
+                    "prevented_contact": False,
+                    "assumptions": ["replayed pedestrian motion"],
+                },
+            ],
+        },
+        "confidence": {
+            "level": "supported_hypothesis",
+            "rationale": "One deterministic branch prevented contact under a single named model.",
+        },
+        "assumptions": [
+            "single replayed-pedestrian model; closed-loop response not yet evaluated",
+        ],
+        "missing_fields": [],
+        "competing_explanations": [
+            {
+                "explanation": "pedestrian reciprocity mismatch",
+                "ruled_out": False,
+                "note": "Not separable without a closed-loop pedestrian branch.",
+            }
+        ],
+    }
+
+
+def test_complete_report_validates():
+    """The complete synthetic fixture satisfies schema and every semantic rule."""
+    report = _complete_report()
+    assert reconcile_collision_causal_report(report) == []
+    assert validate_collision_causal_report(report) == report
+
+
+def test_complete_report_reuses_shared_vocabularies():
+    """mechanism_label and confidence.level come from the shared taxonomy vocabularies."""
+    report = _complete_report()
+    assert report["proximate_mechanism"]["mechanism_label"] in MECHANISM_LABELS
+    assert report["confidence"]["level"] in MECHANISM_CONFIDENCES
+
+
+def test_incomplete_report_fails_closed_by_abstaining():
+    """The intentionally incomplete fixture: planner internals are absent.
+
+    A geometry-only reconstruction (only t_contact known) cannot assert a cause,
+    so the analyser abstains rather than inventing selected/applied actions.
+    """
+
+    report = abstained_collision_causal_report(
+        report_id="ccr-synthetic-incomplete-001",
+        case_id="crossing_ttc_low__seed9__blackbox_planner",
+        reason="planner decision trace absent; selected/applied action provenance unavailable",
+        source_kind="replayed_episode",
+    )
+    # It is a *valid* report precisely because it abstains and marks everything
+    # unavailable instead of fabricating fields.
+    assert reconcile_collision_causal_report(report) == []
+    assert report["abstained"] is True
+    assert report["causal_contribution"]["verdict"] == "unknown"
+    assert report["causal_contribution"]["supported_actual_cause"] is False
+    # t_uca and t_inevitable are unsupported in v1 and must be declared missing.
+    assert "t_uca" in report["missing_fields"]
+    assert "selected_candidate" in report["missing_fields"]
+
+
+def test_normative_fault_must_be_not_assessed():
+    """A non-`not_assessed` normative_fault is rejected."""
+    report = _complete_report()
+    report["normative_fault"] = "robot_at_fault"
+    violations = reconcile_collision_causal_report(report)
+    # schema const rejects it first; either way the report is rejected.
+    assert violations
+    with pytest.raises(CollisionCausalReportError):
+        validate_collision_causal_report(report)
+
+
+def test_actual_cause_requires_prevention_intervention():
+    """supported_actual_cause needs an intervention branch that prevented contact."""
+    report = _complete_report()
+    for intervention in report["causal_contribution"]["interventions"]:
+        intervention["prevented_contact"] = False
+    violations = reconcile_collision_causal_report(report)
+    assert any("prevented_contact true" in v for v in violations)
+
+
+def test_actual_cause_requires_named_intervention_model():
+    """supported_actual_cause needs a named (non-blank) intervention_model."""
+    report = _complete_report()
+    report["causal_contribution"]["intervention_model"] = "   "
+    violations = reconcile_collision_causal_report(report)
+    assert any("named intervention_model" in v for v in violations)
+
+
+def test_inevitable_before_uca_forbids_planner_cause():
+    """When t_inevitable <= t_uca, a planner action cannot be the supported cause."""
+    report = _complete_report()
+    # Contact becomes unavoidable at or before the first unsafe control action.
+    report["observed_reconstruction"]["critical_timestamps"]["t_inevitable"]["step"] = 42
+    report["observed_reconstruction"]["critical_timestamps"]["t_inevitable"]["time_s"] = 4.2
+    report["observed_reconstruction"]["critical_timestamps"]["t_uca"]["step"] = 42
+    violations = reconcile_collision_causal_report(report)
+    assert any("already unavoidable" in v for v in violations)
+
+
+def test_unavailable_element_must_be_declared_missing():
+    """An unavailable element must appear in missing_fields; declaring it repairs the report."""
+    report = _complete_report()
+    report["observed_reconstruction"]["elements"]["predictions"] = {
+        "available": False,
+        "source": None,
+        "detail": None,
+    }
+    # Not declared in missing_fields -> rejected.
+    violations = reconcile_collision_causal_report(report)
+    assert any("must be listed in missing_fields" in v for v in violations)
+    # Declaring it repairs the report.
+    report["missing_fields"].append("predictions")
+    assert reconcile_collision_causal_report(report) == []
+
+
+def test_unavailable_timestamp_cannot_carry_inferred_value():
+    """An unavailable timestamp may not carry an inferred step/time_s."""
+    report = _complete_report()
+    report["observed_reconstruction"]["critical_timestamps"]["t_uca"] = {
+        "available": False,
+        "step": 42,
+        "time_s": 4.2,
+        "source": None,
+    }
+    report["missing_fields"].append("t_uca")
+    violations = reconcile_collision_causal_report(report)
+    assert any("inferred step/time_s" in v for v in violations)
+
+
+def test_unknown_mechanism_label_rejected():
+    """A mechanism_label outside the shared taxonomy is rejected."""
+    report = _complete_report()
+    report["proximate_mechanism"]["mechanism_label"] = "made_up_label"
+    violations = reconcile_collision_causal_report(report)
+    assert any("MECHANISM_LABELS" in v for v in violations)
+
+
+def test_abstained_report_cannot_claim_actual_cause():
+    """Setting abstained=true while still asserting a cause is a contradiction."""
+    report = copy.deepcopy(_complete_report())
+    report["abstained"] = True
+    report["abstention_reason"] = "nondeterministic replay"
+    # verdict/supported_actual_cause still assert a cause -> contradiction.
+    violations = reconcile_collision_causal_report(report)
+    assert any("verdict to 'unknown'" in v for v in violations)
+    assert any("cannot set supported_actual_cause" in v for v in violations)


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** adds the additive `collision_causal_report.v1` contract — a JSON schema, a
  fail-closed Python validator, two acceptance fixtures, and a field-producer/decision-record note.
  The report reconstructs a single collision, records the implemented temporal causal dataflow, and
  separates **observed facts → proximate mechanism → intervention-supported causal contribution**,
  always setting `normative_fault: not_assessed`.
- **Why now:** issue #5441 is item 1 of the parent program (#5440); the design synthesis (PR #5448,
  merged) calls for a reviewable cause-report contract as the *first* artifact, before any classifier.
- **Claim boundary:** schema/fixture evidence only — **not** proof that real collisions can be
  causally attributed. Model-scoped: planner-internal reconstruction is available only for planners
  that emit a decision trace; others must abstain.
- **Required validation:** `uv run pytest -q tests/benchmark -k 'collision and causal or causal_report'`
  → 11 passed; `git diff --check` clean; `ruff check`/`ruff format` clean.
- **Remaining blocker:** first-unsafe-action (`t_uca`) and last-avoidable-state (`t_inevitable`)
  computation, plus general cross-planner selected/applied-action provenance, do **not** exist without
  changing planner behaviour. Per the issue stop rule these fields fail closed as *unavailable*; they
  are owned by #5442.

Issue: https://github.com/ll7/robot_sf_ll7/issues/5441

## Contract delta

New schema `collision_causal_report.v1` (`robot_sf/benchmark/schemas/collision_causal_report.v1.json`)
with top-level `observed_reconstruction` (four `available/unavailable` critical timestamps —
`t_danger`, `t_uca`, `t_inevitable`, `t_contact` — and nine reconstruction elements: observations,
predictions, generated/selected candidates, guard/arbitration result, feasible/applied command, actor
states, geometry), `proximate_mechanism`, `causal_contribution`, `data_source`, `confidence`,
`assumptions`, `missing_fields`, `competing_explanations`.

New fail-closed blockers (validator `robot_sf/benchmark/collision_causal_report.py`):

- `normative_fault` must be `not_assessed`.
- `mechanism_label`/`confidence.level` must come from the **imported** `failure_mechanism_taxonomy`
  vocabularies (no competing aggregate taxonomy). `cause_location` is a new **orthogonal** dataflow-
  stage axis (causal-graph node), not a mechanism label.
- Unavailable timestamps/elements must carry null values **and** be declared in `missing_fields`
  (unsupported ≠ inferred).
- `supported_actual_cause` requires an `avoidable` verdict, a named `intervention_model`, and ≥1
  intervention with `prevented_contact = true` — distinguishing intervention-supported actual cause
  from mere localization/suspicion.
- If `t_inevitable <= t_uca`, a planner action may not be reported as the supported actual cause.
- An abstaining report must set `verdict = unknown`, `supported_actual_cause = false`, and a reason.

**Compatibility impact:** purely additive — new schema file, new module, new test, one CHANGELOG and
one INDEX entry. No existing schema, metric, or planner behaviour is touched.

## Acceptance criteria (issue #5441)

- [x] Inventory exact producers for every field; mark unsupported fields unavailable — field map §2.
- [x] Reuse the existing failure-mechanism vocabulary (imported), no competing taxonomy — §2.3.
- [x] Add and validate `collision_causal_report.v1` — schema + validator + tests.
- [x] One complete synthetic report and one incomplete report that fails closed / abstains — tests.
- [x] Document temporal causal-graph nodes/edges from implemented dataflow — field map §3.
- [x] Distinguish localization/suspicion from intervention-supported actual cause — §4 + validator.
- [x] Cross-link parent synthesis and #2012, #2220, #2547, #2924, #4758 — field map §7.

## Validation

```
uv run pytest -q tests/benchmark -k 'collision and causal or causal_report'   # 11 passed, 4801 deselected
ruff check robot_sf/benchmark/collision_causal_report.py tests/benchmark/test_collision_causal_report.py  # All checks passed
git diff --check                                                              # clean
python scripts/dev/check_docs_evidence_integrity.py                           # no changed evidence files
python scripts/tools/sync_ai_config.py --check                                # 7 symlinks validated
```

Also confirmed the schema is a legal Draft 2020-12 schema and that the adjacent schema-audit test
(`test_predictive_checkpoint_schema_audit.py`) still passes; the change adds no global registry
coupling.

## State propagation

Low-churn issue (this is the first implementation PR for #5441). The durable state surface is this
PR plus the tracked decision record `docs/context/collision_causal_report_field_map_2026-07-13.md`
(producer inventory + blocked/deferred scope). No transient queue-routing state is encoded in tracked
files.

## Research/claim discipline

- **Target:** define the schema/behavior contract; no benchmark, metric, model, or planner result is
  changed or claimed.
- **Evidence tier:** proposal / diagnostic-only (schema + fixtures).
- **Result classification:** contract + fail-closed fixtures, not benchmark evidence.
- **Out of scope (explicit):** no full benchmark campaign run, no Slurm/GPU submission, no
  paper/dissertation claim edits, no planner/pedestrian-dynamics changes.

Refs #5441

> Gate note (closure discipline): changed `Closes #5441` → `Refs #5441`. The cause-report contract lands here, but the `t_uca`/`t_inevitable` producers are deferred to #5442, so #5441's acceptance criteria are not fully met. The maintainer/analyser slice closes #5441 when those timestamps are produced.

<details>
<summary>Friction log</summary>

No blocking friction encountered this session that met the file-worthy bar (concrete, reproducible,
actionable, untracked). The shared-venv worktree runner and existing schema/validator patterns
(`scenario_contract.py`, `failure_mechanism_taxonomy.py`) were sufficient owners to extend.

</details>

