### PR TITLE
Issue #5436: reconcile readiness gates with wired executor (cheap-lane worker)

### DIFF
--- a/robot_sf/benchmark/issue_4142_dpcbf_dense_readiness.py
+++ b/robot_sf/benchmark/issue_4142_dpcbf_dense_readiness.py
@@ -30,9 +30,10 @@ Status semantics (fail-closed on any structural gap):
   failure; the campaign must not be authorized.
 - ``inputs_ready_campaign_gated`` -- every packet input is present, valid, mutually
   consistent, and fail-closed. The only remaining blockers are the declared downstream
-  gates in :data:`CAMPAIGN_GATES` (no packet-consuming runner is wired to this schema yet,
-  and running requires explicit human/Slurm authorization). This is the expected healthy
-  state; it confirms the inputs are reviewable, *not* that the comparison may run.
+  gates in :data:`CAMPAIGN_GATES` (the local executor is wired but remains explicitly
+  authorization-gated, and running requires explicit human/Slurm authorization). This is the
+  expected healthy state; it confirms the inputs are reviewable, *not* that the comparison
+  may run.
 
 There is intentionally no ``authorized`` / ``ready-to-run`` state: running the dense
 comparison is out of scope for this surface and stays gated behind the declared blockers.
@@ -97,9 +98,8 @@ _VARIANT_FAMILY = {
 #: every packet input is valid. Surfaced verbatim so an operator (or routing pass) never
 #: mistakes ``inputs_ready_campaign_gated`` for a go-ahead to run.
 CAMPAIGN_GATES: tuple[str, ...] = (
-    "no packet-consuming runner is wired to schema "
-    f"'{PACKET_SCHEMA_VERSION}'; the canonical command cannot yet execute the "
-    "three-arm comparison",
+    "the local executor and canonical command are wired for schema "
+    f"'{PACKET_SCHEMA_VERSION}' but execution remains explicitly authorization-gated",
     "running the dense comparison requires explicit human/Slurm authorization and is "
     "out of scope for this read-only readiness surface",
 )

--- a/tests/benchmark/test_issue_4142_dpcbf_dense_readiness.py
+++ b/tests/benchmark/test_issue_4142_dpcbf_dense_readiness.py
@@ -204,6 +204,21 @@ def test_missing_packet_raises(tmp_path: pathlib.Path) -> None:
         evaluate_readiness(repo_root=tmp_path, packet_path="configs/research/nope.yaml")
 
 
+def test_campaign_gates_do_not_claim_no_runner_wired() -> None:
+    """Campaign gates must not say 'no packet-consuming runner is wired' (stale after #5428)."""
+    for gate in CAMPAIGN_GATES:
+        assert "no packet-consuming runner" not in gate.lower(), (
+            f"stale gate wording still present: {gate!r}"
+        )
+
+
+def test_campaign_gates_state_executor_is_wired_but_authorization_gated() -> None:
+    """Campaign gates must reflect that the executor is wired and explicitly authorization-gated."""
+    combined = " ".join(CAMPAIGN_GATES).lower()
+    assert "wired" in combined, "campaign gates must state the executor is wired"
+    assert "authorization" in combined, "campaign gates must state the authorization requirement"
+
+
 def test_render_markdown_states_claim_boundary_and_status() -> None:
     """The Markdown report leads with the claim boundary and shows the status."""
     readiness = evaluate_readiness(repo_root=REPO_ROOT, packet_path=PACKET_PATH)


### PR DESCRIPTION
## What

The `CAMPAIGN_GATES` constant in `robot_sf/benchmark/issue_4142_dpcbf_dense_readiness.py` and its module docstring still claimed "no packet-consuming runner is wired to schema", which became stale after PR #5428 wired the local executor. This PR updates the wording to state that the executor and canonical command are wired but remain explicitly authorization-gated.

## Why

After #5428 merged the packet-consuming local executor, the readiness surface could make a valid preflight look blocked for the wrong reason. The explicit authorization gate must remain the execution authority; the wording just needs to reflect the actual boundary.

## Changes

- `robot_sf/benchmark/issue_4142_dpcbf_dense_readiness.py` — updated `CAMPAIGN_GATES` wording and module docstring to reflect the wired-but-authorization-gated state.
- `tests/benchmark/test_issue_4142_dpcbf_dense_readiness.py` — added two contract tests:
  - `test_campaign_gates_do_not_claim_no_runner_wired` — asserts the stale phrase is absent.
  - `test_campaign_gates_state_executor_is_wired_but_authorization_gated` — asserts the new wording mentions "wired" and "authorization".

## Validation

```
20 passed in 8.98s
ruff check: All checks passed!
docs evidence integrity: no changed docs/evidence files to check.
```

## Scope notes

- `docs/context/issue_4142_dpcbf_dense_pipeline.md` checked; no stale references found.
- `robot_sf/benchmark/issue_4142_dpcbf_dense_runner.py` docstring references are historical context (describing what that slice closed), not live stale claims.
- No benchmark, GPU, Slurm, or campaign execution performed.

## Proof tier

Docs/contract cleanup; cheap docs proof per maintainer-values table. Evidence: diff inspection, targeted tests pass, docs integrity check clean.

Closes #5436

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.