### PR TITLE
feat(#5442): frozen-state counterfactual replay to locate the last avoidable action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #5442 frozen-state counterfactual replay: locate the last avoidable control action.**
+  New simulator-agnostic engine (`robot_sf/benchmark/last_avoidable_replay.py`) restores a
+  decision-point snapshot (including RNG state), verifies deterministic baseline replay, and branches
+  over the admissible robot action lattice at each step in `[t_danger, t_contact)` to report `t_uca`
+  (earliest avoidable unsafe control action) and `t_inevitable` (point of no return). Fail-closed: a
+  nondeterministic baseline or a missing feasible action set returns `unknown`, never `unavoidable`.
+  Ships a deterministic controlled kinematic fixture
+  (`robot_sf/benchmark/last_avoidable_fixtures.py`), the `last_avoidable_replay.v1` output schema, an
+  offline report CLI (`scripts/analysis/run_last_avoidable_replay_issue_5442.py`), and a context note
+  (`docs/context/issue_5442_last_avoidable_replay.md`). Controlled-fixture diagnostic evidence only;
+  `normative_fault` is always `not_assessed`. No production-simulator snapshot seam (that would be a
+  broad change — see the note), no benchmark/Slurm run, no metric/paper claim.
+
 * **issue #5419 authorization-gated DPCBF executor.** Bounded local `run_batch` arms require the
   exact public authorization ID. Atomic checkpoints bind inputs and completed JSONL artifacts;
   dirty, orphaned, malformed, duplicate, or mismatched state fails closed. No Slurm/GPU run or

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -4,6 +4,9 @@ Collision causality, action-conditioned online risk, and statistically defensibl
 scenario discovery research program:
 [collision_causality_online_risk_scenario_discovery_2026-07-12.md](collision_causality_online_risk_scenario_discovery_2026-07-12.md).
 
+Issue #5442 frozen-state counterfactual replay (locate the last avoidable control action; controlled-fixture diagnostic engine + `last_avoidable_replay.v1`; fail-closed `unknown` on nondeterministic baseline or missing feasible action set; child of #5440, forward-compatible with the #5441 report contract):
+[issue_5442_last_avoidable_replay.md](issue_5442_last_avoidable_replay.md).
+
 Issue #5355 prediction-MPC 2x2 factorial preregistration (prediction on/off x constraint-handling on/off):
 [issue_5355_factorial_preregistration.md](issue_5355_factorial_preregistration.md).
 

--- a/docs/context/issue_5442_last_avoidable_replay.md
+++ b/docs/context/issue_5442_last_avoidable_replay.md
@@ -1,0 +1,116 @@
+# Issue #5442 — Frozen-state counterfactual replay: last avoidable action
+
+**Status:** implementation slice landed (controlled-fixture diagnostic evidence).
+**Parent:** #5440 · **Depends on (report contract):** #5441 · **Sibling analysis:** #2924.
+**Claim boundary:** controlled-fixture diagnostic evidence only. Not a real-episode
+root-cause claim, not benchmark or paper-grade evidence, and assigns no legal or
+moral fault (`normative_fault` is always `not_assessed`).
+
+## What this slice delivers
+
+A simulator-agnostic **frozen-state counterfactual replay engine** plus a
+deterministic controlled fixture that validates it end to end on CPU:
+
+- `robot_sf/benchmark/last_avoidable_replay.py` — the engine. It restores a
+  decision-point snapshot, verifies the baseline replay is deterministic, then
+  branches over the admissible robot action lattice at every step in
+  `[t_danger, t_contact)` to decide whether — and how early — contact was
+  avoidable. It reports `t_uca` (earliest avoidable unsafe control action) and
+  `t_inevitable` (point of no return).
+- `robot_sf/benchmark/last_avoidable_fixtures.py` — a 2D kinematic robot/pedestrian
+  fixture implementing the engine's `CounterfactualModel` seam. It holds its own
+  `numpy.random.Generator` and snapshots the RNG bit-generator state alongside
+  actor state, so replays are bit-for-bit deterministic.
+- `robot_sf/benchmark/schemas/last_avoidable_replay.v1.json` — the output contract.
+- `scripts/analysis/run_last_avoidable_replay_issue_5442.py` — offline report CLI.
+- `tests/benchmark/test_last_avoidable_replay_issue_5442.py` — acceptance tests.
+
+## Determination vocabulary (fail-closed)
+
+| Verdict | Meaning |
+| --- | --- |
+| `avoidable` | Deterministic baseline, full feasible-action coverage, and at least one admissible action prevents contact within the frozen horizon. `t_uca` and `t_inevitable` are reported. |
+| `already_unavoidable` | Deterministic baseline, full feasible-action coverage, but **no** admissible action at any decision point prevents contact. `t_inevitable = t_danger`. |
+| `unknown` | Baseline replay is not deterministic **or** feasible-action coverage over the window is incomplete. Per the issue contract this **never** collapses to `unavoidable`. |
+
+`t_uca` is the earliest window step at which an admissible action prevents contact
+(the earliest point the robot could have started avoiding). `t_inevitable` is one
+past the latest step at which any admissible action still prevents contact (the
+point of no return). Blame is placed on the earliest avoidable action, not on the
+last command before contact.
+
+## Why the fixture, and not the production simulator (scope decision)
+
+The issue's allowed paths include "the smallest simulator snapshot/restore seam",
+and the stop rule says to produce a diagnostic blocker "if snapshot support
+requires broad simulator replacement". A code survey (robot_sf 2026-07 main) found
+that a faithful mid-episode snapshot/restore of the production simulator **would**
+require a broad change:
+
+- Pedestrian goal/zone selection samples the **global** numpy RNG
+  (`np.random.choice` / `np.random.uniform` in `robot_sf/ped_npc/ped_zone.py` and
+  `ped_population.py`), not a per-object `Generator`. Deterministic branch replay
+  would require capturing and restoring global RNG state around every branch.
+- `robot_sf/sim/simulator.py` exposes only a reset-to-episode-start path
+  (`_reset_social_force_state`), no general snapshot/restore API.
+- `PedestrianBehavior` instances and `RouteNavigator` carry mutable state whose
+  deep-copy safety is unproven.
+
+Rather than replace the simulator (out of scope, and a determinism risk the issue
+itself flags), the engine is decoupled behind the `CounterfactualModel` protocol —
+the smallest seam — and validated against a fully deterministic controlled fixture.
+A real-simulator adapter can implement the same protocol later; the required RNG
+capture is documented in the fixture module.
+
+## Acceptance-criteria mapping
+
+| Acceptance criterion | Where satisfied |
+| --- | --- |
+| Snapshot/restore includes RNG + actor state | `KinematicCollisionModel.snapshot/restore`; `test_snapshot_includes_rng_and_actor_state`, `test_snapshot_without_rng_diverges` |
+| Baseline branching reproduces the fixture within tolerance | `_verify_determinism` (20 replays); determinism check in each avoidable/unavoidable test |
+| Action set, feasibility filter, horizon, collision predicate, pedestrian response versioned in output | `ReplayConfig.to_dict` → `config` block; schema `config` required fields |
+| `t_inevitable` and `t_uca` computed for preventable late braking, already-unavoidable, two-action interaction | `test_preventable_late_braking_is_avoidable`, `test_already_unavoidable_contact`, `test_two_action_interaction_closed_loop_avoidable` |
+| Missing feasible set or nondeterministic baseline → `unknown`, never `unavoidable` | `test_missing_feasible_action_returns_unknown`, `test_nondeterministic_baseline_returns_unknown` |
+| Output conforms to a report contract and preserves every branch result | `last_avoidable_replay.v1.json`; `branches` preserved; `test_report_conforms_to_schema_and_records_provenance` |
+| Runtime reported, no online gate | `runtime_s` recorded by the CLI/engine |
+
+Note on the report contract: #5441's `collision_causal_report.v1` is not yet
+merged. This slice emits a self-contained `last_avoidable_replay.v1` whose field
+naming (`t_danger`/`t_uca`/`t_inevitable`/`t_contact` as available/unavailable,
+`normative_fault: not_assessed`) is forward-compatible, so it can be embedded as
+the counterfactual branch of that contract once #5441 lands — without re-running.
+
+## Competing explanations carried from the issue
+
+- Interactive pedestrian dynamics may make snapshot replay nondeterministic — the
+  engine tests for this and abstains to `unknown` rather than guessing.
+- The action lattice may omit the true avoidance action — a missing/empty feasible
+  set drives `unknown`, never `unavoidable`.
+- Emergency braking may prevent geometric contact while causing a different
+  social-navigation failure — the fixture's collision predicate is geometric only;
+  broader social-failure attribution is out of scope for this slice.
+- The earliest divergent action may be a consequence of an earlier prediction or
+  guard defect — this slice localizes the avoidable action; upstream defect
+  attribution belongs to the #5441 causal-report join.
+
+## Validation
+
+```bash
+uv run pytest -q tests/benchmark -k 'counterfactual or snapshot or avoidable'   # 38 passed
+uv run python scripts/analysis/run_last_avoidable_replay_issue_5442.py          # 5 controlled fixtures
+git diff --check
+```
+
+Observed CLI determinations: `preventable_late_braking` → avoidable (t_uca=0,
+t_inevitable=7); `two_action_interaction` → avoidable (t_uca=0, t_inevitable=8);
+`already_unavoidable` → already_unavoidable (t_inevitable=0); `nondeterministic_baseline`
+→ unknown (nondeterministic_baseline); `missing_feasible_action` → unknown
+(incomplete_feasible_action_coverage).
+
+## Out of scope / remaining
+
+- Real-simulator `CounterfactualModel` adapter (needs the global-RNG capture seam
+  above; gated behind the determinism budget in the issue stop rule).
+- Join into `collision_causal_report.v1` once #5441 merges.
+- No benchmark campaign run, no Slurm/GPU submission, no metric/release semantics
+  change, no paper/dissertation claim edits.

--- a/robot_sf/benchmark/last_avoidable_fixtures.py
+++ b/robot_sf/benchmark/last_avoidable_fixtures.py
@@ -1,0 +1,333 @@
+"""Controlled deterministic fixtures for frozen-state counterfactual replay (#5442).
+
+These fixtures implement :class:`~robot_sf.benchmark.last_avoidable_replay.CounterfactualModel`
+with a minimal 2D kinematic robot/pedestrian interaction. They are *controlled
+fixtures*, not the production simulator: the full robot_sf simulator draws
+pedestrian goals/zones from the **global** numpy RNG and exposes no snapshot API,
+so a faithful mid-episode snapshot/restore seam there would require a broad
+simulator change (out of scope for #5442; see
+``docs/context/issue_5442_last_avoidable_replay.md``). This kinematic model gives
+a fully deterministic, snapshot-restorable state — including its own RNG — so the
+counterfactual-replay engine can be validated end to end on CPU.
+
+The robot travels along ``+x`` toward a crossing pedestrian and may command a
+deceleration each tick. In ``replayed`` pedestrian mode the pedestrian follows a
+path that is a function of time and the fixture RNG only (independent of the
+robot), so branching robot actions never change the pedestrian. In
+``closed_loop`` mode the pedestrian additionally reacts to the robot (a repulsion
+that couples the two bodies), which is the two-action interaction case.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+PED_RESPONSE_REPLAYED = "replayed"
+PED_RESPONSE_CLOSED_LOOP = "closed_loop"
+
+
+@dataclass(frozen=True)
+class KinematicScenario:
+    """Parameters of a controlled kinematic collision fixture.
+
+    Attributes:
+        robot_x0: Initial robot ``x`` position (robot ``y`` is fixed at 0).
+        robot_speed0: Initial robot forward speed (m/s along ``+x``).
+        ped_pos0: Initial pedestrian ``(x, y)`` position.
+        ped_vel0: Nominal pedestrian ``(vx, vy)`` velocity (the recorded path in
+            ``replayed`` mode).
+        dt: Control tick duration (s).
+        collision_radius: Contact distance between robot and pedestrian (m).
+        decel_levels: Admissible deceleration lattice (m/s^2); ``0.0`` is the
+            maintain-speed baseline action.
+        pedestrian_response: ``replayed`` or ``closed_loop``.
+        ped_repulsion_gain: Closed-loop repulsion strength (ignored when replayed).
+        ped_influence_radius: Distance under which the closed-loop pedestrian
+            reacts to the robot.
+        rng_jitter_std: Std of per-tick pedestrian velocity jitter drawn from the
+            fixture RNG; ``0.0`` disables jitter.
+        seed: Seed for the fixture's own ``numpy.random.Generator``.
+        include_rng_in_snapshot: When ``False`` the snapshot omits the RNG state,
+            making a jittered replay nondeterministic — used to exercise the
+            engine's ``unknown`` (nondeterministic baseline) path.
+        feasible_from_step: Steps strictly before this return an *empty* feasible
+            action set, used to exercise the ``unknown`` coverage-gap path.
+            ``0`` (default) means every step is testable.
+    """
+
+    robot_x0: float
+    robot_speed0: float
+    ped_pos0: tuple[float, float]
+    ped_vel0: tuple[float, float]
+    dt: float = 0.1
+    collision_radius: float = 0.5
+    decel_levels: tuple[float, ...] = (0.0, 1.0, 2.0, 4.0, 8.0)
+    pedestrian_response: str = PED_RESPONSE_REPLAYED
+    ped_repulsion_gain: float = 0.0
+    ped_influence_radius: float = 1.5
+    rng_jitter_std: float = 0.0
+    seed: int = 0
+    include_rng_in_snapshot: bool = True
+    feasible_from_step: int = 0
+
+
+@dataclass
+class _KinematicState:
+    """Mutable per-step state of the kinematic model."""
+
+    step: int
+    robot_x: float
+    robot_speed: float
+    ped_pos: np.ndarray
+    ped_vel: np.ndarray
+    rng_state: dict[str, Any]
+
+
+class KinematicCollisionModel:
+    """Deterministic 2D kinematic fixture implementing ``CounterfactualModel``.
+
+    The model holds its own ``numpy.random.Generator`` and exposes snapshot/restore
+    that (optionally) includes the RNG bit-generator state, so the replay engine
+    can prove baseline determinism and branch over decelerations.
+    """
+
+    def __init__(self, scenario: KinematicScenario) -> None:
+        """Initialize the model at step 0 from ``scenario``."""
+        self.scenario = scenario
+        self._rng = np.random.default_rng(scenario.seed)
+        self.step_index = 0
+        self.robot_x = float(scenario.robot_x0)
+        self.robot_speed = float(scenario.robot_speed0)
+        self.ped_pos = np.asarray(scenario.ped_pos0, dtype=float)
+        self.ped_vel = np.asarray(scenario.ped_vel0, dtype=float)
+
+    # -- CounterfactualModel protocol -------------------------------------
+    def snapshot(self) -> _KinematicState:
+        """Return a restorable copy of the full state (incl. RNG when configured)."""
+        rng_state = self._rng.bit_generator.state if self.scenario.include_rng_in_snapshot else {}
+        return _KinematicState(
+            step=self.step_index,
+            robot_x=self.robot_x,
+            robot_speed=self.robot_speed,
+            ped_pos=self.ped_pos.copy(),
+            ped_vel=self.ped_vel.copy(),
+            rng_state=_deep_copy_state(rng_state),
+        )
+
+    def restore(self, snapshot: _KinematicState) -> None:
+        """Restore the model to ``snapshot`` (RNG restored only if it was captured)."""
+        self.step_index = snapshot.step
+        self.robot_x = snapshot.robot_x
+        self.robot_speed = snapshot.robot_speed
+        self.ped_pos = snapshot.ped_pos.copy()
+        self.ped_vel = snapshot.ped_vel.copy()
+        if snapshot.rng_state:
+            self._rng.bit_generator.state = _deep_copy_state(snapshot.rng_state)
+
+    def step(self, action: Any) -> None:
+        """Advance one control tick applying deceleration ``action`` (m/s^2)."""
+        decel = float(action)
+        self.robot_speed = max(0.0, self.robot_speed - decel * self.scenario.dt)
+        self.robot_x += self.robot_speed * self.scenario.dt
+
+        effective_vel = self.ped_vel.copy()
+        if self.scenario.pedestrian_response == PED_RESPONSE_CLOSED_LOOP:
+            effective_vel = effective_vel + self._closed_loop_repulsion()
+        if self.scenario.rng_jitter_std > 0.0:
+            effective_vel = effective_vel + self._rng.normal(
+                0.0, self.scenario.rng_jitter_std, size=2
+            )
+        self.ped_pos = self.ped_pos + effective_vel * self.scenario.dt
+        self.step_index += 1
+
+    def collision(self) -> bool:
+        """Return whether robot and pedestrian are within ``collision_radius``."""
+        robot_pos = np.array([self.robot_x, 0.0])
+        return bool(np.linalg.norm(robot_pos - self.ped_pos) <= self.scenario.collision_radius)
+
+    def feasible_actions(self) -> Sequence[float]:
+        """Return the admissible deceleration lattice at the current step.
+
+        Returns an empty sequence before ``scenario.feasible_from_step`` to model
+        a decision point where no admissible substitution can be evaluated.
+        """
+        if self.step_index < self.scenario.feasible_from_step:
+            return ()
+        return self.scenario.decel_levels
+
+    def action_label(self, action: Any) -> str:
+        """Return a stable label for a deceleration action."""
+        return f"decel={float(action):g}"
+
+    # -- internals --------------------------------------------------------
+    def _closed_loop_repulsion(self) -> np.ndarray:
+        """Return the pedestrian's reactive velocity increment away from the robot."""
+        robot_pos = np.array([self.robot_x, 0.0])
+        offset = self.ped_pos - robot_pos
+        distance = float(np.linalg.norm(offset))
+        if distance >= self.scenario.ped_influence_radius or distance == 0.0:
+            return np.zeros(2)
+        direction = offset / distance
+        magnitude = self.scenario.ped_repulsion_gain * (
+            1.0 - distance / self.scenario.ped_influence_radius
+        )
+        return direction * magnitude
+
+
+def _deep_copy_state(state: dict[str, Any]) -> dict[str, Any]:
+    """Deep-copy a numpy bit-generator state mapping (arrays copied).
+
+    Returns:
+        A deep copy of ``state`` with any nested arrays and mappings copied.
+    """
+    copied: dict[str, Any] = {}
+    for key, value in state.items():
+        if isinstance(value, np.ndarray):
+            copied[key] = value.copy()
+        elif isinstance(value, dict):
+            copied[key] = _deep_copy_state(value)
+        else:
+            copied[key] = value
+    return copied
+
+
+def find_contact_step(scenario: KinematicScenario, max_steps: int = 200) -> int | None:
+    """Roll the maintain-speed baseline forward and return the first contact step.
+
+    This helper derives ``t_contact`` for a scenario so fixtures need not hard-code
+    it.
+
+    Returns:
+        The first step index at which contact occurs, or ``None`` if no contact
+        occurs within ``max_steps``.
+    """
+    model = KinematicCollisionModel(scenario)
+    if model.collision():
+        return 0
+    for step in range(max_steps):
+        model.step(0.0)
+        if model.collision():
+            return step
+    return None
+
+
+def maintain_baseline_actions(n_steps: int) -> list[float]:
+    """Return ``n_steps`` maintain-speed (zero-deceleration) baseline actions.
+
+    Returns:
+        A list of ``n_steps`` zero-deceleration actions.
+    """
+    return [0.0] * n_steps
+
+
+# -- Named acceptance-criteria fixtures ------------------------------------
+#
+# Each builder returns a scenario whose maintain-speed baseline collides. The
+# numbers are tuned so the replay engine reports a distinct determination; the
+# tests assert the engine's computed t_uca / t_inevitable rather than re-deriving
+# the kinematics by hand.
+
+
+def preventable_late_braking_scenario() -> KinematicScenario:
+    """A robot that can avoid contact by braking early but not late.
+
+    The pedestrian crosses the robot's path; braking early enough lets the
+    pedestrian clear first (or stops the robot short), while braking only near
+    contact cannot. Expected determination: ``avoidable`` with a finite ``t_uca``
+    strictly before ``t_inevitable``.
+
+    Returns:
+        The configured :class:`KinematicScenario`.
+    """
+    return KinematicScenario(
+        robot_x0=0.0,
+        robot_speed0=5.0,
+        ped_pos0=(5.0, -1.2),
+        ped_vel0=(0.0, 1.0),
+        dt=0.1,
+        collision_radius=0.5,
+        decel_levels=(0.0, 2.0, 4.0, 8.0),
+        pedestrian_response=PED_RESPONSE_REPLAYED,
+    )
+
+
+def already_unavoidable_scenario() -> KinematicScenario:
+    """A robot already too close and fast for any admissible brake to avoid contact.
+
+    Expected determination: ``already_unavoidable`` (deterministic baseline, full
+    feasible-action coverage, no action prevents contact).
+
+    Returns:
+        The configured :class:`KinematicScenario`.
+    """
+    return KinematicScenario(
+        robot_x0=3.2,
+        robot_speed0=6.0,
+        ped_pos0=(5.0, -0.4),
+        ped_vel0=(0.0, 0.6),
+        dt=0.1,
+        collision_radius=0.5,
+        decel_levels=(0.0, 2.0, 4.0, 8.0),
+        pedestrian_response=PED_RESPONSE_REPLAYED,
+    )
+
+
+def two_action_interaction_scenario() -> KinematicScenario:
+    """A closed-loop pedestrian that reacts to the robot (two-body interaction).
+
+    Branching a robot deceleration changes the pedestrian's reactive path too, so
+    avoidance is a genuine two-action interaction. Expected determination:
+    ``avoidable``.
+
+    Returns:
+        The configured :class:`KinematicScenario`.
+    """
+    return KinematicScenario(
+        robot_x0=0.0,
+        robot_speed0=5.0,
+        ped_pos0=(5.0, -1.2),
+        ped_vel0=(0.0, 1.0),
+        dt=0.1,
+        collision_radius=0.5,
+        decel_levels=(0.0, 2.0, 4.0, 8.0),
+        pedestrian_response=PED_RESPONSE_CLOSED_LOOP,
+        ped_repulsion_gain=1.5,
+        ped_influence_radius=1.5,
+    )
+
+
+def nondeterministic_baseline_scenario() -> KinematicScenario:
+    """A jittered pedestrian whose RNG is *not* snapshotted, so replay diverges.
+
+    Expected determination: ``unknown`` (nondeterministic baseline).
+
+    Returns:
+        The configured :class:`KinematicScenario`.
+    """
+    return replace(
+        preventable_late_braking_scenario(),
+        rng_jitter_std=0.5,
+        include_rng_in_snapshot=False,
+        seed=7,
+    )
+
+
+def missing_feasible_action_scenario() -> KinematicScenario:
+    """A scenario with no feasible actions in the danger window (coverage gap).
+
+    Expected determination: ``unknown`` (incomplete feasible-action coverage),
+    never ``unavoidable``.
+
+    Returns:
+        The configured :class:`KinematicScenario`.
+    """
+    return replace(
+        preventable_late_braking_scenario(),
+        feasible_from_step=10_000,  # every in-window step returns an empty set
+    )

--- a/robot_sf/benchmark/last_avoidable_replay.py
+++ b/robot_sf/benchmark/last_avoidable_replay.py
@@ -1,0 +1,534 @@
+"""Frozen-state counterfactual replay: locate the last avoidable control action.
+
+This module implements the offline analysis contract of issue #5442 (child of
+#5440, depends on the report contract of #5441): given a controlled fixture that
+can *deterministically* snapshot and restore its full state (including any random
+number generator), branch over admissible robot actions at each decision point in
+the danger window and decide whether — and how early — the collision was avoidable.
+
+The engine is intentionally decoupled from any concrete simulator. A caller
+supplies a :class:`CounterfactualModel` — the *smallest snapshot/restore seam* —
+and this module drives it. The controlled kinematic fixture used to validate the
+contract lives in :mod:`robot_sf.benchmark.last_avoidable_fixtures`; a real-
+simulator adapter can implement the same protocol later (see the docs note for
+issue #5442).
+
+Determinations (fail-closed):
+
+* ``avoidable`` — the baseline replay is deterministic, every decision point in
+  the window offered at least one feasible action, and at least one admissible
+  action prevented contact within the frozen horizon. ``t_uca`` (earliest
+  avoidable unsafe control action) and ``t_inevitable`` (point of no return) are
+  reported.
+* ``already_unavoidable`` — deterministic baseline, full feasible-action coverage
+  over the window, yet **no** admissible action at any decision point prevented
+  contact. Contact was already unavoidable at ``t_danger``.
+* ``unknown`` — the baseline replay is not deterministic, or feasible-action
+  coverage over the window is incomplete, so avoidability cannot be tested. Per
+  the issue contract this **never** collapses to ``unavoidable``.
+
+The result is controlled-fixture diagnostic evidence only. It assigns no legal or
+moral fault (``normative_fault`` is always ``not_assessed``) and is not a real-
+episode root-cause claim.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+LAST_AVOIDABLE_REPLAY_SCHEMA = "last_avoidable_replay.v1"
+
+VERDICT_AVOIDABLE = "avoidable"
+VERDICT_ALREADY_UNAVOIDABLE = "already_unavoidable"
+VERDICT_UNKNOWN = "unknown"
+
+# Substitution modes: how a candidate avoidance action is injected.
+SUBSTITUTION_SINGLE_STEP = "single_step"  # substitute at t, then resume baseline commands
+SUBSTITUTION_HOLD = "hold"  # apply the substituted action for the whole frozen horizon
+_SUBSTITUTION_MODES = (SUBSTITUTION_SINGLE_STEP, SUBSTITUTION_HOLD)
+
+
+@runtime_checkable
+class CounterfactualModel(Protocol):
+    """The smallest deterministic snapshot/restore seam the engine drives.
+
+    A model wraps one controlled fixture positioned at step 0 of a recorded
+    baseline episode. Implementations must be *deterministic*: restoring a
+    snapshot and applying the same actions must reproduce the same collision
+    outcome. The snapshot must capture everything that affects future steps,
+    including any RNG state (see the fixture in
+    :mod:`robot_sf.benchmark.last_avoidable_fixtures`).
+    """
+
+    def snapshot(self) -> Any:
+        """Return an opaque, restorable copy of the full simulation state.
+
+        The snapshot must include actor state (poses, velocities) *and* any RNG
+        state so that :meth:`restore` followed by identical actions is bit-for-bit
+        deterministic.
+        """
+        ...
+
+    def restore(self, snapshot: Any) -> None:
+        """Restore the model to a previously captured :meth:`snapshot`."""
+        ...
+
+    def step(self, action: Any) -> None:
+        """Advance the simulation one control tick applying ``action``."""
+        ...
+
+    def collision(self) -> bool:
+        """Return whether the robot is in contact at the current state."""
+        ...
+
+    def feasible_actions(self) -> Sequence[Any]:
+        """Return the admissible action lattice at the current state.
+
+        An empty sequence means no admissible substitution exists here; the
+        engine treats such a decision point as untestable (coverage gap), which
+        drives an ``unknown`` determination rather than ``already_unavoidable``.
+        """
+        ...
+
+    def action_label(self, action: Any) -> str:
+        """Return a stable, human-readable label for ``action`` (for provenance)."""
+        ...
+
+
+@dataclass(frozen=True)
+class ReplayConfig:
+    """Versioned analysis configuration recorded in every report.
+
+    Attributes:
+        t_danger: First step of the danger window (inclusive) to search.
+        t_contact: Baseline contact step; the search window is
+            ``[t_danger, t_contact)`` and ``t_contact`` bounds the replay.
+        horizon: Frozen horizon ``H`` (control ticks) simulated forward from each
+            candidate step when testing whether an action prevents contact.
+        substitution_mode: How a candidate action is injected — ``single_step``
+            (substitute at ``t`` then resume baseline commands) or ``hold`` (apply
+            the substituted action for the whole horizon).
+        determinism_replays: Number of identical baseline replays used to verify
+            deterministic reproduction of the contact outcome.
+        action_set_id: Provenance label for the admissible action set.
+        feasibility_filter: Provenance label for how feasible actions are filtered.
+        collision_predicate: Provenance label for the collision predicate.
+        pedestrian_response: Pedestrian response assumption for this run, e.g.
+            ``replayed`` (pedestrian follows its recorded path) or ``closed_loop``
+            (pedestrian reacts to the robot).
+    """
+
+    t_danger: int
+    t_contact: int
+    horizon: int
+    substitution_mode: str = SUBSTITUTION_SINGLE_STEP
+    determinism_replays: int = 5
+    action_set_id: str = "unspecified"
+    feasibility_filter: str = "unspecified"
+    collision_predicate: str = "unspecified"
+    pedestrian_response: str = "unspecified"
+
+    def __post_init__(self) -> None:
+        """Validate window, horizon, replay count, and substitution mode."""
+        if self.t_danger < 0:
+            raise ValueError(f"t_danger must be >= 0 (got {self.t_danger})")
+        if self.t_contact <= self.t_danger:
+            raise ValueError(f"t_contact ({self.t_contact}) must be > t_danger ({self.t_danger})")
+        if self.horizon < 1:
+            raise ValueError(f"horizon must be >= 1 (got {self.horizon})")
+        if self.determinism_replays < 1:
+            raise ValueError(f"determinism_replays must be >= 1 (got {self.determinism_replays})")
+        if self.substitution_mode not in _SUBSTITUTION_MODES:
+            raise ValueError(
+                f"substitution_mode must be one of {_SUBSTITUTION_MODES} "
+                f"(got {self.substitution_mode!r})"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-safe provenance mapping for this config."""
+        return {
+            "t_danger": self.t_danger,
+            "t_contact": self.t_contact,
+            "horizon": self.horizon,
+            "substitution_mode": self.substitution_mode,
+            "determinism_replays": self.determinism_replays,
+            "action_set_id": self.action_set_id,
+            "feasibility_filter": self.feasibility_filter,
+            "collision_predicate": self.collision_predicate,
+            "pedestrian_response": self.pedestrian_response,
+        }
+
+
+@dataclass(frozen=True)
+class DeterminismCheck:
+    """Result of verifying the baseline replay reproduces the contact outcome."""
+
+    replays: int
+    collision_stable: bool
+    contact_step_stable: bool
+    observed_contact_steps: tuple[int | None, ...]
+
+    @property
+    def deterministic(self) -> bool:
+        """Return whether both the collision flag and contact step were stable."""
+        return self.collision_stable and self.contact_step_stable
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-safe determinism-check mapping."""
+        return {
+            "replays": self.replays,
+            "collision_stable": self.collision_stable,
+            "contact_step_stable": self.contact_step_stable,
+            "deterministic": self.deterministic,
+            "observed_contact_steps": [
+                None if s is None else int(s) for s in self.observed_contact_steps
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class TimeBranchResult:
+    """Per-decision-point branching outcome over the admissible action set."""
+
+    step: int
+    feasible_count: int
+    preventing_action_labels: tuple[str, ...]
+
+    @property
+    def any_prevented(self) -> bool:
+        """Return whether at least one admissible action prevented contact."""
+        return len(self.preventing_action_labels) > 0
+
+    @property
+    def has_feasible_actions(self) -> bool:
+        """Return whether any admissible action was available to test."""
+        return self.feasible_count > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-safe per-step branch mapping."""
+        return {
+            "step": self.step,
+            "feasible_count": self.feasible_count,
+            "any_prevented": self.any_prevented,
+            "preventing_action_labels": list(self.preventing_action_labels),
+        }
+
+
+@dataclass(frozen=True)
+class LastAvoidableReport:
+    """Self-contained ``last_avoidable_replay.v1`` result.
+
+    The field set is deliberately forward-compatible with the
+    ``collision_causal_report.v1`` contract proposed in issue #5441: it exposes
+    ``t_danger``/``t_uca``/``t_inevitable``/``t_contact`` as available/unavailable
+    (``None``) fields, records competing-explanation-relevant provenance, and
+    holds ``normative_fault`` at ``not_assessed``. When #5441 lands this report can
+    be embedded as the counterfactual branch of that contract without re-running.
+    """
+
+    verdict: str
+    config: ReplayConfig
+    determinism: DeterminismCheck
+    branches: tuple[TimeBranchResult, ...]
+    t_uca: int | None
+    t_inevitable: int | None
+    feasible_coverage: float
+    minimal_sufficient_interventions: tuple[dict[str, Any], ...]
+    runtime_s: float | None = None
+    abstained: bool = False
+    abstain_reason: str | None = None
+    normative_fault: str = "not_assessed"
+    claim_boundary: str = (
+        "controlled-fixture diagnostic evidence; not a real-episode root-cause "
+        "claim; assigns no legal or moral fault"
+    )
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-safe ``last_avoidable_replay.v1`` payload."""
+        return {
+            "schema_version": LAST_AVOIDABLE_REPLAY_SCHEMA,
+            "verdict": self.verdict,
+            "normative_fault": self.normative_fault,
+            "claim_boundary": self.claim_boundary,
+            "t_danger": self.config.t_danger,
+            "t_uca": self.t_uca,
+            "t_inevitable": self.t_inevitable,
+            "t_contact": self.config.t_contact,
+            "feasible_coverage": self.feasible_coverage,
+            "abstained": self.abstained,
+            "abstain_reason": self.abstain_reason,
+            "config": self.config.to_dict(),
+            "determinism": self.determinism.to_dict(),
+            "branches": [b.to_dict() for b in self.branches],
+            "minimal_sufficient_interventions": list(self.minimal_sufficient_interventions),
+            "runtime_s": self.runtime_s,
+            "notes": list(self.notes),
+        }
+
+
+def _replay_to_contact(
+    model: CounterfactualModel,
+    initial_snapshot: Any,
+    baseline_actions: Sequence[Any],
+    max_step: int,
+) -> int | None:
+    """Restore the initial snapshot, replay baseline actions, return the contact step.
+
+    Returns:
+        The first step index (0-based, the step whose action produced contact) at
+        which :meth:`CounterfactualModel.collision` becomes true, or ``None`` if no
+        contact occurs within ``max_step`` applied actions.
+    """
+    model.restore(initial_snapshot)
+    if model.collision():
+        return 0
+    limit = min(max_step, len(baseline_actions))
+    for step in range(limit):
+        model.step(baseline_actions[step])
+        if model.collision():
+            return step
+    return None
+
+
+def _verify_determinism(
+    model: CounterfactualModel,
+    initial_snapshot: Any,
+    baseline_actions: Sequence[Any],
+    config: ReplayConfig,
+) -> DeterminismCheck:
+    """Replay the baseline ``config.determinism_replays`` times and compare outcomes.
+
+    Returns:
+        A :class:`DeterminismCheck` recording whether the collision flag and
+        contact step were stable across all replays.
+    """
+    max_step = config.t_contact + config.horizon
+    contact_steps: list[int | None] = []
+    for _ in range(config.determinism_replays):
+        contact_steps.append(
+            _replay_to_contact(model, initial_snapshot, baseline_actions, max_step)
+        )
+    collided = [c is not None for c in contact_steps]
+    collision_stable = len(set(collided)) == 1
+    contact_step_stable = len(set(contact_steps)) == 1
+    return DeterminismCheck(
+        replays=config.determinism_replays,
+        collision_stable=collision_stable,
+        contact_step_stable=contact_step_stable,
+        observed_contact_steps=tuple(contact_steps),
+    )
+
+
+def _capture_window_snapshots(
+    model: CounterfactualModel,
+    initial_snapshot: Any,
+    baseline_actions: Sequence[Any],
+    config: ReplayConfig,
+) -> dict[int, Any]:
+    """Return snapshots at the start of each step in ``[t_danger, t_contact)``.
+
+    ``snapshots[t]`` is the state from which baseline ``action[t]`` would be
+    applied — i.e. the decision point at step ``t``.
+    """
+    model.restore(initial_snapshot)
+    snapshots: dict[int, Any] = {}
+    for step in range(config.t_contact):
+        if config.t_danger <= step < config.t_contact:
+            snapshots[step] = model.snapshot()
+        if step >= len(baseline_actions):
+            break
+        model.step(baseline_actions[step])
+    return snapshots
+
+
+def _action_prevents_contact(
+    model: CounterfactualModel,
+    step_snapshot: Any,
+    action: Any,
+    step: int,
+    baseline_actions: Sequence[Any],
+    config: ReplayConfig,
+) -> bool:
+    """Return whether substituting ``action`` at ``step`` prevents contact in the horizon."""
+    model.restore(step_snapshot)
+    for offset in range(config.horizon):
+        if config.substitution_mode == SUBSTITUTION_HOLD:
+            applied = action
+        elif offset == 0:
+            applied = action
+        else:
+            resume_index = step + offset
+            if resume_index >= len(baseline_actions):
+                break
+            applied = baseline_actions[resume_index]
+        model.step(applied)
+        if model.collision():
+            return False
+    return not model.collision()
+
+
+def _branch_over_window(
+    model: CounterfactualModel,
+    snapshots: dict[int, Any],
+    baseline_actions: Sequence[Any],
+    config: ReplayConfig,
+) -> tuple[list[TimeBranchResult], list[dict[str, Any]]]:
+    """Branch over admissible actions at each decision point in the window.
+
+    Returns:
+        A tuple of the per-step branch results and the minimal sufficient
+        single-action interventions found (each prevents contact on its own).
+    """
+    branches: list[TimeBranchResult] = []
+    interventions: list[dict[str, Any]] = []
+    for step in range(config.t_danger, config.t_contact):
+        step_snapshot = snapshots.get(step)
+        if step_snapshot is None:
+            branches.append(
+                TimeBranchResult(step=step, feasible_count=0, preventing_action_labels=())
+            )
+            continue
+        model.restore(step_snapshot)
+        feasible = list(model.feasible_actions())
+        preventing_labels: list[str] = []
+        for action in feasible:
+            if _action_prevents_contact(
+                model, step_snapshot, action, step, baseline_actions, config
+            ):
+                label = model.action_label(action)
+                preventing_labels.append(label)
+                interventions.append(
+                    {
+                        "step": step,
+                        "action_label": label,
+                        "substitution_mode": config.substitution_mode,
+                        "horizon": config.horizon,
+                    }
+                )
+        branches.append(
+            TimeBranchResult(
+                step=step,
+                feasible_count=len(feasible),
+                preventing_action_labels=tuple(preventing_labels),
+            )
+        )
+    return branches, interventions
+
+
+def locate_last_avoidable(
+    model: CounterfactualModel,
+    baseline_actions: Sequence[Any],
+    config: ReplayConfig,
+    *,
+    runtime_s: float | None = None,
+) -> LastAvoidableReport:
+    """Locate the last avoidable control action via frozen-state counterfactual replay.
+
+    The engine (1) verifies the baseline replay deterministically reproduces the
+    contact outcome, (2) captures a snapshot at every decision point in
+    ``[t_danger, t_contact)``, and (3) branches over the admissible action set at
+    each point, checking whether any single admissible action prevents contact
+    within the frozen horizon.
+
+    Fail-closed determination (see module docstring): a nondeterministic baseline
+    or incomplete feasible-action coverage yields ``unknown`` — never
+    ``unavoidable``. Only full coverage with no preventing action anywhere yields
+    ``already_unavoidable``.
+
+    Args:
+        model: The deterministic snapshot/restore seam positioned at step 0.
+        baseline_actions: The recorded applied commands, indexed by step.
+        config: Versioned analysis configuration.
+        runtime_s: Optional measured wall-clock runtime to record (offline; no
+            online gate is required).
+
+    Returns:
+        A :class:`LastAvoidableReport` preserving every branch result.
+    """
+    initial_snapshot = model.snapshot()
+
+    determinism = _verify_determinism(model, initial_snapshot, baseline_actions, config)
+    if not determinism.deterministic:
+        return LastAvoidableReport(
+            verdict=VERDICT_UNKNOWN,
+            config=config,
+            determinism=determinism,
+            branches=(),
+            t_uca=None,
+            t_inevitable=None,
+            feasible_coverage=0.0,
+            minimal_sufficient_interventions=(),
+            runtime_s=runtime_s,
+            abstained=True,
+            abstain_reason="nondeterministic_baseline",
+            notes=("baseline replay did not reproduce a stable contact outcome",),
+        )
+
+    snapshots = _capture_window_snapshots(model, initial_snapshot, baseline_actions, config)
+    branches, interventions = _branch_over_window(model, snapshots, baseline_actions, config)
+
+    window_size = config.t_contact - config.t_danger
+    with_feasible = sum(1 for b in branches if b.has_feasible_actions)
+    feasible_coverage = with_feasible / window_size if window_size else 0.0
+
+    preventable_steps = sorted(b.step for b in branches if b.any_prevented)
+
+    if preventable_steps:
+        t_uca = preventable_steps[0]
+        # Point of no return: after the latest step where avoidance still worked,
+        # contact is inevitable (clamped to the contact step).
+        t_inevitable = min(preventable_steps[-1] + 1, config.t_contact)
+        return LastAvoidableReport(
+            verdict=VERDICT_AVOIDABLE,
+            config=config,
+            determinism=determinism,
+            branches=tuple(branches),
+            t_uca=t_uca,
+            t_inevitable=t_inevitable,
+            feasible_coverage=feasible_coverage,
+            minimal_sufficient_interventions=tuple(interventions),
+            runtime_s=runtime_s,
+        )
+
+    # No admissible action prevented contact at any decision point.
+    if with_feasible == 0 or feasible_coverage < 1.0:
+        # Coverage gap: we could not test avoidability everywhere -> abstain.
+        return LastAvoidableReport(
+            verdict=VERDICT_UNKNOWN,
+            config=config,
+            determinism=determinism,
+            branches=tuple(branches),
+            t_uca=None,
+            t_inevitable=None,
+            feasible_coverage=feasible_coverage,
+            minimal_sufficient_interventions=(),
+            runtime_s=runtime_s,
+            abstained=True,
+            abstain_reason="incomplete_feasible_action_coverage",
+            notes=(
+                "no admissible action prevented contact, but at least one decision "
+                "point lacked a feasible action set; avoidability is untested",
+            ),
+        )
+
+    # Full coverage, deterministic baseline, nothing prevents -> already unavoidable.
+    return LastAvoidableReport(
+        verdict=VERDICT_ALREADY_UNAVOIDABLE,
+        config=config,
+        determinism=determinism,
+        branches=tuple(branches),
+        t_uca=None,
+        t_inevitable=config.t_danger,
+        feasible_coverage=feasible_coverage,
+        minimal_sufficient_interventions=(),
+        runtime_s=runtime_s,
+        notes=(
+            "contact was unavoidable from t_danger under the declared action set "
+            "and pedestrian response assumption",
+        ),
+    )

--- a/robot_sf/benchmark/schemas/last_avoidable_replay.v1.json
+++ b/robot_sf/benchmark/schemas/last_avoidable_replay.v1.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "last_avoidable_replay.v1.json",
+  "title": "Last Avoidable Replay v1",
+  "description": "Offline, controlled-fixture result of frozen-state counterfactual replay (issue #5442). Records whether a collision was avoidable, the earliest avoidable unsafe control action (t_uca) and the point of no return (t_inevitable), the versioned analysis config, the baseline determinism check, and every per-decision-point branch result. This is controlled-fixture diagnostic evidence only; it assigns no legal or moral fault and is not a real-episode root-cause claim. Field naming is forward-compatible with the collision_causal_report.v1 contract proposed in issue #5441.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "verdict",
+    "normative_fault",
+    "claim_boundary",
+    "t_danger",
+    "t_uca",
+    "t_inevitable",
+    "t_contact",
+    "feasible_coverage",
+    "abstained",
+    "abstain_reason",
+    "config",
+    "determinism",
+    "branches",
+    "minimal_sufficient_interventions",
+    "runtime_s",
+    "notes"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "last_avoidable_replay.v1"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["avoidable", "already_unavoidable", "unknown"]
+    },
+    "normative_fault": {
+      "const": "not_assessed"
+    },
+    "claim_boundary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "t_danger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "t_uca": {
+      "type": ["integer", "null"],
+      "minimum": 0
+    },
+    "t_inevitable": {
+      "type": ["integer", "null"],
+      "minimum": 0
+    },
+    "t_contact": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "feasible_coverage": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "abstained": {
+      "type": "boolean"
+    },
+    "abstain_reason": {
+      "type": ["string", "null"]
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "t_danger",
+        "t_contact",
+        "horizon",
+        "substitution_mode",
+        "determinism_replays",
+        "action_set_id",
+        "feasibility_filter",
+        "collision_predicate",
+        "pedestrian_response"
+      ],
+      "properties": {
+        "t_danger": {"type": "integer", "minimum": 0},
+        "t_contact": {"type": "integer", "minimum": 1},
+        "horizon": {"type": "integer", "minimum": 1},
+        "substitution_mode": {"type": "string", "enum": ["single_step", "hold"]},
+        "determinism_replays": {"type": "integer", "minimum": 1},
+        "action_set_id": {"type": "string", "minLength": 1},
+        "feasibility_filter": {"type": "string", "minLength": 1},
+        "collision_predicate": {"type": "string", "minLength": 1},
+        "pedestrian_response": {"type": "string", "minLength": 1}
+      }
+    },
+    "determinism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "replays",
+        "collision_stable",
+        "contact_step_stable",
+        "deterministic",
+        "observed_contact_steps"
+      ],
+      "properties": {
+        "replays": {"type": "integer", "minimum": 1},
+        "collision_stable": {"type": "boolean"},
+        "contact_step_stable": {"type": "boolean"},
+        "deterministic": {"type": "boolean"},
+        "observed_contact_steps": {
+          "type": "array",
+          "items": {"type": ["integer", "null"], "minimum": 0}
+        }
+      }
+    },
+    "branches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["step", "feasible_count", "any_prevented", "preventing_action_labels"],
+        "properties": {
+          "step": {"type": "integer", "minimum": 0},
+          "feasible_count": {"type": "integer", "minimum": 0},
+          "any_prevented": {"type": "boolean"},
+          "preventing_action_labels": {
+            "type": "array",
+            "items": {"type": "string"}
+          }
+        }
+      }
+    },
+    "minimal_sufficient_interventions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["step", "action_label", "substitution_mode", "horizon"],
+        "properties": {
+          "step": {"type": "integer", "minimum": 0},
+          "action_label": {"type": "string", "minLength": 1},
+          "substitution_mode": {"type": "string", "enum": ["single_step", "hold"]},
+          "horizon": {"type": "integer", "minimum": 1}
+        }
+      }
+    },
+    "runtime_s": {
+      "type": ["number", "null"],
+      "minimum": 0.0
+    },
+    "notes": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  }
+}

--- a/scripts/analysis/run_last_avoidable_replay_issue_5442.py
+++ b/scripts/analysis/run_last_avoidable_replay_issue_5442.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Offline frozen-state counterfactual replay over controlled fixtures (issue #5442).
+
+This runner drives the counterfactual-replay engine
+(:mod:`robot_sf.benchmark.last_avoidable_replay`) over the controlled kinematic
+fixtures in :mod:`robot_sf.benchmark.last_avoidable_fixtures` and emits one
+``last_avoidable_replay.v1`` report per fixture. It runs no benchmark and makes no
+metric or paper-grade claim; the fixtures are deterministic controlled models, not
+the production simulator (which offers no snapshot seam — see
+``docs/context/issue_5442_last_avoidable_replay.md``).
+
+Reports are validated against
+``robot_sf/benchmark/schemas/last_avoidable_replay.v1.json`` before they are
+written. Runtime is reported per the offline contract; no online gate is applied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+from robot_sf.benchmark import last_avoidable_fixtures as fx
+from robot_sf.benchmark.last_avoidable_replay import (
+    SUBSTITUTION_HOLD,
+    LastAvoidableReport,
+    ReplayConfig,
+    locate_last_avoidable,
+)
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "robot_sf"
+    / "benchmark"
+    / "schemas"
+    / "last_avoidable_replay.v1.json"
+)
+
+# Fixture name -> (builder, action_set_id) for the acceptance-criteria cases.
+_FIXTURES = {
+    "preventable_late_braking": fx.preventable_late_braking_scenario,
+    "already_unavoidable": fx.already_unavoidable_scenario,
+    "two_action_interaction": fx.two_action_interaction_scenario,
+    "nondeterministic_baseline": fx.nondeterministic_baseline_scenario,
+    "missing_feasible_action": fx.missing_feasible_action_scenario,
+}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("output/issue_5442_last_avoidable_replay"),
+        help="Directory for per-fixture JSON reports (git-ignored output).",
+    )
+    parser.add_argument(
+        "--fixtures",
+        nargs="*",
+        choices=sorted(_FIXTURES),
+        default=sorted(_FIXTURES),
+        help="Subset of controlled fixtures to run (default: all).",
+    )
+    parser.add_argument(
+        "--determinism-replays",
+        type=int,
+        default=20,
+        help="Number of identical baseline replays used for the determinism check.",
+    )
+    return parser
+
+
+def run_fixture(name: str, *, determinism_replays: int) -> LastAvoidableReport:
+    """Run one named controlled fixture through the replay engine.
+
+    Args:
+        name: Fixture key from :data:`_FIXTURES`.
+        determinism_replays: Baseline replays for the determinism check.
+
+    Returns:
+        The :class:`LastAvoidableReport` for the fixture, with runtime recorded.
+    """
+    scenario = _FIXTURES[name]()
+    contact_step = fx.find_contact_step(scenario)
+    if contact_step is None or contact_step < 1:
+        raise ValueError(f"fixture {name!r} baseline does not collide (t_contact={contact_step})")
+    horizon = contact_step + 6
+    config = ReplayConfig(
+        t_danger=0,
+        t_contact=contact_step,
+        horizon=horizon,
+        substitution_mode=SUBSTITUTION_HOLD,
+        determinism_replays=determinism_replays,
+        action_set_id="decel_lattice",
+        feasibility_filter="all_admissible_decel",
+        collision_predicate="euclidean_distance<=collision_radius",
+        pedestrian_response=scenario.pedestrian_response,
+    )
+    model = fx.KinematicCollisionModel(scenario)
+    baseline_actions = fx.maintain_baseline_actions(contact_step + horizon + 2)
+    start = time.perf_counter()
+    report = locate_last_avoidable(model, baseline_actions, config)
+    elapsed = time.perf_counter() - start
+    return LastAvoidableReport(
+        verdict=report.verdict,
+        config=report.config,
+        determinism=report.determinism,
+        branches=report.branches,
+        t_uca=report.t_uca,
+        t_inevitable=report.t_inevitable,
+        feasible_coverage=report.feasible_coverage,
+        minimal_sufficient_interventions=report.minimal_sufficient_interventions,
+        runtime_s=elapsed,
+        abstained=report.abstained,
+        abstain_reason=report.abstain_reason,
+        notes=report.notes,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the requested fixtures, validate, write reports, and print a summary.
+
+    Returns:
+        Process exit code (0 on success).
+    """
+    args = _build_parser().parse_args(argv)
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary: list[dict[str, Any]] = []
+    for name in args.fixtures:
+        report = run_fixture(name, determinism_replays=args.determinism_replays)
+        payload = report.to_dict()
+        jsonschema.validate(payload, schema)
+        out_path = args.out_dir / f"{name}.json"
+        out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        summary.append(
+            {
+                "fixture": name,
+                "verdict": payload["verdict"],
+                "t_uca": payload["t_uca"],
+                "t_inevitable": payload["t_inevitable"],
+                "abstain_reason": payload["abstain_reason"],
+                "report": str(out_path),
+            }
+        )
+
+    print(json.dumps({"schema_version": "last_avoidable_replay.v1", "results": summary}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_last_avoidable_replay_issue_5442.py
+++ b/tests/benchmark/test_last_avoidable_replay_issue_5442.py
@@ -1,0 +1,232 @@
+"""Tests for frozen-state counterfactual replay (issue #5442).
+
+Covers the acceptance criteria: RNG+actor snapshot/restore determinism, baseline
+reproduction, versioned output config, computed ``t_inevitable``/``t_uca`` for the
+preventable-late-braking, already-unavoidable, and two-action-interaction
+fixtures, fail-closed ``unknown`` on nondeterministic baseline or missing feasible
+action set, schema conformance, and preservation of every branch result.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import numpy as np
+import pytest
+
+from robot_sf.benchmark import last_avoidable_fixtures as fx
+from robot_sf.benchmark.last_avoidable_replay import (
+    LAST_AVOIDABLE_REPLAY_SCHEMA,
+    SUBSTITUTION_HOLD,
+    VERDICT_ALREADY_UNAVOIDABLE,
+    VERDICT_AVOIDABLE,
+    VERDICT_UNKNOWN,
+    ReplayConfig,
+    locate_last_avoidable,
+)
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "robot_sf"
+    / "benchmark"
+    / "schemas"
+    / "last_avoidable_replay.v1.json"
+)
+_SCHEMA = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _run(scenario, *, determinism_replays: int = 20):
+    """Drive the replay engine over a fixture scenario and return the report."""
+    contact_step = fx.find_contact_step(scenario)
+    assert contact_step is not None and contact_step >= 1, "baseline must collide"
+    horizon = contact_step + 6
+    config = ReplayConfig(
+        t_danger=0,
+        t_contact=contact_step,
+        horizon=horizon,
+        substitution_mode=SUBSTITUTION_HOLD,
+        determinism_replays=determinism_replays,
+        action_set_id="decel_lattice",
+        feasibility_filter="all_admissible_decel",
+        collision_predicate="euclidean_distance<=collision_radius",
+        pedestrian_response=scenario.pedestrian_response,
+    )
+    model = fx.KinematicCollisionModel(scenario)
+    baseline = fx.maintain_baseline_actions(contact_step + horizon + 2)
+    return locate_last_avoidable(model, baseline, config)
+
+
+# -- config validation ------------------------------------------------------
+def test_config_rejects_non_positive_window() -> None:
+    """t_contact must be strictly greater than t_danger."""
+    with pytest.raises(ValueError, match="t_contact"):
+        ReplayConfig(t_danger=5, t_contact=5, horizon=3)
+
+
+def test_config_rejects_bad_horizon_and_mode() -> None:
+    """Horizon must be >= 1 and substitution_mode must be known."""
+    with pytest.raises(ValueError, match="horizon"):
+        ReplayConfig(t_danger=0, t_contact=3, horizon=0)
+    with pytest.raises(ValueError, match="substitution_mode"):
+        ReplayConfig(t_danger=0, t_contact=3, horizon=2, substitution_mode="teleport")
+
+
+# -- acceptance criterion: RNG + actor state snapshot/restore ---------------
+def test_snapshot_includes_rng_and_actor_state() -> None:
+    """Restoring a snapshot (RNG captured) reproduces jittered steps bit-for-bit."""
+    scenario = fx.KinematicScenario(
+        robot_x0=0.0,
+        robot_speed0=5.0,
+        ped_pos0=(5.0, -1.2),
+        ped_vel0=(0.0, 1.0),
+        rng_jitter_std=0.5,
+        include_rng_in_snapshot=True,
+        seed=3,
+    )
+    model = fx.KinematicCollisionModel(scenario)
+    for _ in range(2):
+        model.step(0.0)
+    snap = model.snapshot()
+
+    def _roll(n: int) -> list[np.ndarray]:
+        positions = []
+        for _ in range(n):
+            model.step(0.0)
+            positions.append(model.ped_pos.copy())
+        return positions
+
+    first = _roll(4)
+    model.restore(snap)
+    second = _roll(4)
+    for a, b in zip(first, second, strict=True):
+        assert np.allclose(a, b), "RNG+actor snapshot/restore must be deterministic"
+
+
+def test_snapshot_without_rng_diverges() -> None:
+    """Omitting the RNG from the snapshot makes a jittered replay nondeterministic."""
+    scenario = fx.KinematicScenario(
+        robot_x0=0.0,
+        robot_speed0=5.0,
+        ped_pos0=(5.0, -1.2),
+        ped_vel0=(0.0, 1.0),
+        rng_jitter_std=0.5,
+        include_rng_in_snapshot=False,
+        seed=3,
+    )
+    model = fx.KinematicCollisionModel(scenario)
+    snap = model.snapshot()
+    model.step(0.0)
+    first = model.ped_pos.copy()
+    model.restore(snap)
+    model.step(0.0)
+    second = model.ped_pos.copy()
+    assert not np.allclose(first, second), "without RNG capture the replay should diverge"
+
+
+# -- acceptance criterion: preventable late braking -------------------------
+def test_preventable_late_braking_is_avoidable() -> None:
+    """Early braking avoids contact; t_uca precedes the point of no return."""
+    report = _run(fx.preventable_late_braking_scenario())
+    assert report.verdict == VERDICT_AVOIDABLE
+    assert report.determinism.deterministic is True
+    assert report.t_uca is not None and report.t_inevitable is not None
+    assert report.t_uca < report.t_inevitable <= report.config.t_contact
+    assert report.minimal_sufficient_interventions, "must record preventing interventions"
+    # every branch step in the window is preserved
+    assert len(report.branches) == report.config.t_contact - report.config.t_danger
+
+
+def test_avoidable_records_exact_no_return_point() -> None:
+    """The engine's computed t_uca / t_inevitable are stable for the fixture."""
+    report = _run(fx.preventable_late_braking_scenario())
+    assert report.t_uca == 0
+    assert report.t_inevitable == 7
+
+
+# -- acceptance criterion: already-unavoidable contact ----------------------
+def test_already_unavoidable_contact() -> None:
+    """Full coverage with no preventing action yields already_unavoidable, not unknown."""
+    report = _run(fx.already_unavoidable_scenario())
+    assert report.verdict == VERDICT_ALREADY_UNAVOIDABLE
+    assert report.determinism.deterministic is True
+    assert report.feasible_coverage == pytest.approx(1.0)
+    assert report.t_uca is None
+    assert report.t_inevitable == report.config.t_danger
+    assert report.abstain_reason is None
+
+
+# -- acceptance criterion: two-action interaction ---------------------------
+def test_two_action_interaction_closed_loop_avoidable() -> None:
+    """A closed-loop (reactive) pedestrian is a genuine two-body interaction case."""
+    scenario = fx.two_action_interaction_scenario()
+    assert scenario.pedestrian_response == fx.PED_RESPONSE_CLOSED_LOOP
+    report = _run(scenario)
+    assert report.verdict == VERDICT_AVOIDABLE
+    assert report.config.pedestrian_response == fx.PED_RESPONSE_CLOSED_LOOP
+    assert report.t_uca is not None and report.t_inevitable is not None
+
+
+# -- acceptance criterion: fail-closed unknown, never unavoidable -----------
+def test_nondeterministic_baseline_returns_unknown() -> None:
+    """A nondeterministic baseline abstains to unknown, never 'unavoidable'."""
+    report = _run(fx.nondeterministic_baseline_scenario())
+    assert report.verdict == VERDICT_UNKNOWN
+    assert report.abstained is True
+    assert report.abstain_reason == "nondeterministic_baseline"
+    assert report.verdict != "unavoidable"
+
+
+def test_missing_feasible_action_returns_unknown() -> None:
+    """A missing feasible action set abstains to unknown (coverage gap)."""
+    report = _run(fx.missing_feasible_action_scenario())
+    assert report.verdict == VERDICT_UNKNOWN
+    assert report.abstained is True
+    assert report.abstain_reason == "incomplete_feasible_action_coverage"
+    assert report.feasible_coverage < 1.0
+    assert report.verdict != "unavoidable"
+
+
+# -- acceptance criterion: output contract ----------------------------------
+def test_report_conforms_to_schema_and_records_provenance() -> None:
+    """Every determination emits a schema-valid, provenance-complete report."""
+    for builder in (
+        fx.preventable_late_braking_scenario,
+        fx.already_unavoidable_scenario,
+        fx.two_action_interaction_scenario,
+        fx.nondeterministic_baseline_scenario,
+        fx.missing_feasible_action_scenario,
+    ):
+        report = _run(builder())
+        payload = report.to_dict()
+        jsonschema.validate(payload, _SCHEMA)
+        assert payload["schema_version"] == LAST_AVOIDABLE_REPLAY_SCHEMA
+        assert payload["normative_fault"] == "not_assessed"
+        # versioned analysis config is preserved in output
+        cfg = payload["config"]
+        assert cfg["action_set_id"] == "decel_lattice"
+        assert cfg["collision_predicate"]
+        assert cfg["horizon"] >= 1
+        assert cfg["pedestrian_response"] in {"replayed", "closed_loop"}
+
+
+def test_runner_smoke(tmp_path) -> None:
+    """The offline CLI runs a fixture and writes a schema-valid report."""
+    from scripts.analysis.run_last_avoidable_replay_issue_5442 import main
+
+    exit_code = main(
+        [
+            "--out-dir",
+            str(tmp_path),
+            "--fixtures",
+            "preventable_late_braking",
+            "--determinism-replays",
+            "5",
+        ]
+    )
+    assert exit_code == 0
+    written = json.loads((tmp_path / "preventable_late_braking.json").read_text())
+    jsonschema.validate(written, _SCHEMA)
+    assert written["verdict"] == VERDICT_AVOIDABLE
+    assert written["runtime_s"] is not None


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** A new simulator-agnostic **frozen-state counterfactual replay** engine
  (`robot_sf/benchmark/last_avoidable_replay.py`) that restores a decision-point snapshot
  (including RNG state), verifies the baseline replay is deterministic, and branches over the
  admissible robot action lattice at every step in `[t_danger, t_contact)` to decide whether — and
  how early — a collision was avoidable. It reports `t_uca` (earliest avoidable unsafe control
  action) and `t_inevitable` (point of no return), so blame lands on the earliest avoidable action
  rather than the last command before contact.
- **Why now:** Implementation slice for ready-queue issue #5442 (child of #5440). Delivers a
  nameable new capability toward the issue's method contract.
- **Claim boundary:** Controlled-fixture **diagnostic evidence only**. Not a real-episode
  root-cause claim, not benchmark/paper-grade evidence. `normative_fault` is always `not_assessed`
  — no legal or moral fault is assigned.
- **Required validation:** `uv run pytest -q tests/benchmark -k 'counterfactual or snapshot or avoidable'`
  → **38 passed, 4775 deselected**. `git diff --check` clean. `ruff check` clean.
- **Remaining blocker:** (1) The literal acceptance item "output conforms to the causal-report
  contract" depends on #5441's `collision_causal_report.v1`, which is **not yet merged**; this slice
  emits a forward-compatible self-contained `last_avoidable_replay.v1` instead. (2) A
  production-simulator adapter is deferred — see Contract delta.

Issue: https://github.com/ll7/robot_sf_ll7/issues/5442

## Contract delta

- **New output schema** `robot_sf/benchmark/schemas/last_avoidable_replay.v1.json` (`last_avoidable_replay.v1`).
  Field naming (`t_danger`/`t_uca`/`t_inevitable`/`t_contact` as available/unavailable,
  `normative_fault: not_assessed`) is deliberately forward-compatible with #5441's
  `collision_causal_report.v1`, so this report can be embedded as its counterfactual branch once
  #5441 lands — without re-running.
- **New fail-closed determinations:** `avoidable` / `already_unavoidable` / `unknown`. A
  nondeterministic baseline **or** an incomplete feasible-action set yields `unknown` — never
  `unavoidable` (issue requirement).
- **New engine seam:** `CounterfactualModel` protocol (snapshot / restore / step / collision /
  feasible_actions / action_label) — the "smallest snapshot/restore seam".
- **Compatibility impact:** additive only. New modules, one new schema, one new script, one new
  test module, one new context note. No existing schema, metric, or public interface changes.

### Scope decision: why a controlled fixture, not the production simulator

The issue's allowed paths include "the smallest simulator snapshot/restore seam", and the stop
rule says to produce a diagnostic blocker "if snapshot support requires broad simulator
replacement". A code survey found the production simulator would require a broad change: pedestrian
goal/zone selection samples the **global** numpy RNG (not a per-object `Generator`), and
`robot_sf/sim/simulator.py` exposes only a reset-to-episode-start path, no general snapshot/restore
API. Rather than replace the simulator (a determinism risk the issue itself flags), the engine is
decoupled behind `CounterfactualModel` and validated against a fully deterministic controlled
kinematic fixture. A real-simulator adapter can implement the same protocol later; the required
global-RNG capture is documented in `docs/context/issue_5442_last_avoidable_replay.md`.

## Validation results

```
$ uv run pytest -q tests/benchmark -k 'counterfactual or snapshot or avoidable'
38 passed, 4775 deselected in 4.94s

$ uv run python scripts/analysis/run_last_avoidable_replay_issue_5442.py
preventable_late_braking  -> avoidable            (t_uca=0, t_inevitable=7)
two_action_interaction    -> avoidable            (t_uca=0, t_inevitable=8)
already_unavoidable       -> already_unavoidable  (t_inevitable=0)
nondeterministic_baseline -> unknown              (nondeterministic_baseline)
missing_feasible_action   -> unknown              (incomplete_feasible_action_coverage)

$ git diff --check    # clean
$ ruff check <changed files>    # All checks passed!
```

Validation env: fresh worktree `.venv` bootstrapped via `scripts/dev/bootstrap_worktree.sh`
(the shared main-checkout venv had a stale force-included `pysocialforce` source and could not
collect the benchmark suite).

## Refs #5442 — done vs remaining

Done (acceptance criteria satisfied):

- [x] Snapshot/restore includes RNG + actor state; deterministic baseline reproduction (20 replays).
- [x] Action set, feasibility filter, horizon, collision predicate, pedestrian response versioned in output.
- [x] `t_inevitable` and `t_uca` computed for preventable late braking, already-unavoidable, and two-action interaction fixtures.
- [x] Missing feasible set or nondeterministic baseline → `unknown`, never `unavoidable`.
- [x] Output conforms to a versioned report contract (`last_avoidable_replay.v1`) and preserves every branch result.
- [x] Runtime reported; no online gate (offline analysis).

Remaining (not closing the issue):

- [ ] Join into `collision_causal_report.v1` once #5441 merges (forward-compatible fields already in place).
- [ ] Production-simulator `CounterfactualModel` adapter (needs the global-RNG capture seam; gated by the issue stop rule as a diagnostic-blocker path).

## Out of scope (explicit)

No full benchmark campaign run, no Slurm/GPU submission, no benchmark metric/release semantics
change, no paper/dissertation claim edits, no planner or pedestrian-dynamics changes.

<details>
<summary>State propagation & governance</summary>

- **Durable state surface:** this PR + `docs/context/issue_5442_last_avoidable_replay.md` +
  `docs/context/INDEX.md` entry + `CHANGELOG.md`. Issue-comment propagation is intentionally skipped
  because `comment_issue_or_pr` is not authorized for this implementation lane; no transient
  queue-routing state was written to tracked files.
- **Fragmentation guard:** 0 PRs merged for #5442 in the prior 24h; this is a progression slice
  adding a nameable new capability, so it proceeds at full throttle.
- **Evidence tier:** diagnostic-only (controlled fixtures). Target claim boundary, comparator,
  decision rule, and competing explanations are recorded in the context note.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
