### PR TITLE
fix(ci): resolve base ref so PR contract check stops flagging modified evidence as new (#5464)

### DIFF
--- a/.github/workflows/pr-contract-check.yml
+++ b/.github/workflows/pr-contract-check.yml
@@ -21,6 +21,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Fetch base ref
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # On pull_request the default checkout is a shallow merge-ref with no
+          # origin/<base> ref, so `git diff origin/main` / `git show origin/main:path`
+          # error and the contract check mis-flags modified evidence files as new
+          # (issue #5464). Fetch the base branch so origin/<base> resolves locally.
+          git fetch --no-tags --depth=1 origin \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
       - name: Set up CI Python environment
         uses: ./.github/actions/setup-ci-python
 
@@ -31,10 +43,19 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Fetch the full status table once, then derive both the changed-file list
+          # and the authoritative ADDED-file list (status == "added"). The added list
+          # is the source of truth for evidence-hygiene "is new" decisions and does
+          # not depend on origin/main being present (issue #5464).
           gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files?per_page=100" \
-            --jq '.[].filename' > "$RUNNER_TEMP/pr_changed_files.txt"
+            --jq '.[] | [.status, .filename] | @tsv' > "$RUNNER_TEMP/pr_files_status.tsv"
+          cut -f2 "$RUNNER_TEMP/pr_files_status.tsv" > "$RUNNER_TEMP/pr_changed_files.txt"
+          awk -F'\t' '$1 == "added" { print $2 }' "$RUNNER_TEMP/pr_files_status.tsv" \
+            > "$RUNNER_TEMP/pr_added_files.txt"
           echo "Changed files for PR #$PR_NUMBER:"
           sed -n '1,120p' "$RUNNER_TEMP/pr_changed_files.txt"
+          echo "Added files for PR #$PR_NUMBER:"
+          sed -n '1,120p' "$RUNNER_TEMP/pr_added_files.txt"
 
       - name: Run PR Contract Check
         env:
@@ -44,4 +65,6 @@ jobs:
           uv run python scripts/ci/pr_contract_check.py \
             --github-event-path "$GITHUB_EVENT_PATH" \
             --changed-files-file "$RUNNER_TEMP/pr_changed_files.txt" \
+            --added-files-file "$RUNNER_TEMP/pr_added_files.txt" \
+            --base-ref "origin/${{ github.base_ref }}" \
             --post-comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* **issue #5464 PR Contract Check no longer flags modified evidence files as new.** The
+  `pr-contract-check.yml` workflow used `actions/checkout` on `pull_request` without fetching the
+  base branch, so `origin/main` was absent in the runner. `pr_contract_check.py`'s `is_file_new`
+  then treated the failed `git show origin/main:path` as "file is new" for *every* changed evidence
+  file, raising false-positive `AI-GENERATED`/`NEEDS-REVIEW` marker blockers on `docs/context/evidence/**`
+  files that already exist marker-less on `main` (observed on PR #5463). Fixed on two fronts: the
+  workflow now fetches the base ref (so `origin/<base>` resolves) and passes an authoritative
+  `--added-files-file` derived from the GitHub `pulls/{n}/files` API (`status == "added"`); and the
+  script now treats an unresolvable base ref as "unknown, not new" and prefers the authoritative
+  added-files signal over the git heuristic when available. CI-tooling correctness fix
+  (`diagnostic-only`); no benchmark, metric, or evidence-content change.
 * **issue #5429 `load_scenario_matrix` no longer misroutes single-document abstract scenario
   files.** A single-document YAML file whose top-level content is a *list* of abstract benchmark
   scenarios (the `density`/`flow`/`obstacle` form, e.g. `yaml.safe_dump([s1, s2])`) is now returned

--- a/scripts/ci/pr_contract_check.py
+++ b/scripts/ci/pr_contract_check.py
@@ -101,6 +101,47 @@ def get_issue_labels(issue: str, repo: str) -> list[str]:
     return []
 
 
+def base_ref_is_resolvable(base_ref: str) -> bool:
+    """Return True if ``base_ref`` resolves to a commit in the local repository.
+
+    On ``pull_request`` events the default ``actions/checkout`` produces a shallow
+    merge-ref with no ``origin/main`` ref present. Git commands that reference an
+    unresolvable base (``git diff origin/main``, ``git show origin/main:path``) then
+    error, and callers that treat that error as "file is new" mis-flag every modified
+    evidence file as brand new (issue #5464). Callers use this guard to distinguish
+    "base unavailable" from a genuine "file is new" answer.
+    """
+    try:
+        res = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"{base_ref}^{{commit}}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return res.returncode == 0
+    except _BEST_EFFORT_ERRORS:
+        return False
+
+
+def get_added_files(added_files_file: Path | str | None) -> set[str] | None:
+    """Load the authoritative set of *added* files from a newline-delimited file.
+
+    The PR Contract Check workflow collects this list from the GitHub
+    ``pulls/{n}/files`` API (``status == "added"``), which is authoritative and does
+    not depend on ``origin/main`` being fetched in the runner. When present, this set
+    is the source of truth for "which changed files are new" and supersedes the
+    git-diff heuristic (issue #5464). Returns ``None`` when no file is supplied so
+    callers fall back to the git heuristic for local runs.
+    """
+    if not added_files_file or not os.path.exists(added_files_file):
+        return None
+    try:
+        with open(added_files_file, encoding="utf-8") as handle:
+            return {line.strip().replace("\\", "/") for line in handle if line.strip()}
+    except _BEST_EFFORT_ERRORS:
+        return None
+
+
 def get_new_files(base_ref: str) -> set[str]:
     """Get the set of files added (created) in this branch relative to base_ref."""
     new_files = set()
@@ -124,8 +165,18 @@ def get_new_files(base_ref: str) -> set[str]:
 
 
 def is_file_new(path: str, base_ref: str = "origin/main") -> bool:
-    """Check if the file is new (does not exist on base_ref)."""
+    """Check if the file is new (does not exist on base_ref).
+
+    If ``base_ref`` cannot be resolved locally (e.g. ``origin/main`` was never fetched
+    in a shallow CI checkout), this returns ``False`` rather than assuming the file is
+    new: a missing base is "unknown", not "added". Treating unknown as new produced the
+    false-positive evidence-hygiene blockers in issue #5464. The authoritative
+    added-files signal from the GitHub API (see ``get_added_files``) is preferred over
+    this heuristic when available.
+    """
     if not os.path.exists(path):
+        return False
+    if not base_ref_is_resolvable(base_ref):
         return False
     res = subprocess.run(["git", "show", f"{base_ref}:{path}"], capture_output=True, check=False)
     return res.returncode != 0
@@ -189,10 +240,21 @@ def check_state_refresh_only(changed_files: list[str], title: str, body: str) ->
     return []
 
 
-def check_evidence_tree_hygiene(changed_files: list[str], base_ref: str) -> list[str]:  # noqa: C901, PLR0912
-    """Rule 4: Evidence tree marker and provenance checks."""
+def check_evidence_tree_hygiene(  # noqa: C901, PLR0912
+    changed_files: list[str], base_ref: str, added_files: set[str] | None = None
+) -> list[str]:
+    """Rule 4: Evidence tree marker and provenance checks.
+
+    ``added_files`` is the authoritative set of newly-added paths (typically from the
+    GitHub ``pulls/{n}/files`` API, ``status == "added"``). When provided it is the
+    sole source of truth for deciding whether an evidence file is new, so the marker
+    and distance-convention lints only fire on genuinely added files and never on
+    modified pre-existing ones (issue #5464). When ``None`` the function falls back to
+    the git-diff heuristic for local runs.
+    """
     blockers = []
-    new_files = get_new_files(base_ref)
+    # Only consult the git heuristic when no authoritative added-files signal exists.
+    new_files = set() if added_files is not None else get_new_files(base_ref)
 
     for f in changed_files:
         f_norm = f.replace("\\", "/").strip()
@@ -218,7 +280,12 @@ def check_evidence_tree_hygiene(changed_files: list[str], base_ref: str) -> list
             continue
 
         # 1. Marker check for new evidence files
-        is_new = (f in new_files) or is_file_new(f, base_ref)
+        if added_files is not None:
+            # Authoritative GitHub-API signal: a file is new iff it was "added". This
+            # does not depend on origin/main being fetched in the runner (issue #5464).
+            is_new = f_norm in added_files
+        else:
+            is_new = (f in new_files) or is_file_new(f, base_ref)
         if is_new:
             if "AI-GENERATED" not in content or "NEEDS-REVIEW" not in content:
                 blockers.append(
@@ -461,6 +528,7 @@ def run_all_checks(
     repo: str,
     base_ref: str,
     pr_number: str | None,
+    added_files: set[str] | None = None,
 ) -> tuple[list[str], list[str], list[str]]:
     """Run all 6 contract checks."""
     blockers = []
@@ -480,7 +548,7 @@ def run_all_checks(
     blockers.extend(state_blockers)
 
     # 4. Evidence tree hygiene
-    evidence_blockers = check_evidence_tree_hygiene(changed_files, base_ref)
+    evidence_blockers = check_evidence_tree_hygiene(changed_files, base_ref, added_files)
     blockers.extend(evidence_blockers)
 
     # 5. Successor discipline
@@ -590,6 +658,16 @@ def main() -> int:  # noqa: C901
     parser = argparse.ArgumentParser(description="PR contract check.")
     parser.add_argument("--github-event-path", type=Path, help="Path to github event path JSON.")
     parser.add_argument("--changed-files-file", type=Path, help="Path to changed files list file.")
+    parser.add_argument(
+        "--added-files-file",
+        type=Path,
+        help=(
+            "Path to a newline-delimited list of authoritatively ADDED files "
+            "(GitHub pulls/{n}/files, status == 'added'). When provided this is the "
+            "source of truth for evidence-hygiene 'is new' decisions and avoids the "
+            "origin/main-fetch dependency (issue #5464)."
+        ),
+    )
     parser.add_argument("--pr-body-file", type=Path, help="PR body file for local run/test.")
     parser.add_argument("--pr-title", type=str, help="PR title for local run/test.")
     parser.add_argument("--pr-number", type=str, help="PR number for local run/test.")
@@ -628,10 +706,11 @@ def main() -> int:  # noqa: C901
         pr_title = args.pr_title
 
     changed_files = get_changed_files(args.changed_files_file, args.base_ref)
+    added_files = get_added_files(args.added_files_file)
 
     # Run checks
     blockers, warnings, infos = run_all_checks(
-        pr_title, pr_body, changed_files, repo, args.base_ref, pr_number
+        pr_title, pr_body, changed_files, repo, args.base_ref, pr_number, added_files
     )
 
     # Build status

--- a/tests/validation/test_pr_contract_check.py
+++ b/tests/validation/test_pr_contract_check.py
@@ -229,6 +229,74 @@ def test_check_evidence_tree_hygiene_non_distance_series_unaffected(
 
 
 @patch("subprocess.run")
+def test_base_ref_is_resolvable(mock_run: MagicMock) -> None:
+    """Issue #5464: base_ref_is_resolvable reflects git rev-parse success/failure."""
+    mock_run.return_value = MagicMock(returncode=0)
+    assert pr_contract_check.base_ref_is_resolvable("origin/main") is True
+
+    mock_run.return_value = MagicMock(returncode=128)
+    assert pr_contract_check.base_ref_is_resolvable("origin/main") is False
+
+
+@patch("scripts.ci.pr_contract_check.base_ref_is_resolvable", return_value=False)
+def test_is_file_new_unresolvable_base_returns_false(
+    _mock_resolvable: MagicMock, tmp_path: Path
+) -> None:
+    """Issue #5464: an existing file is NOT reported new when the base ref is unresolvable.
+
+    This is the exact false-positive path: on a shallow CI checkout ``origin/main`` is
+    absent, and the old code returned True for every on-disk file. It must return False.
+    """
+    f = tmp_path / "some_evidence.json"
+    f.write_text("{}", encoding="utf-8")
+    assert pr_contract_check.is_file_new(str(f), "origin/main") is False
+
+
+def test_get_added_files(tmp_path: Path) -> None:
+    """Issue #5464: get_added_files parses the added-files list, else returns None."""
+    assert pr_contract_check.get_added_files(None) is None
+    assert pr_contract_check.get_added_files(tmp_path / "missing.txt") is None
+
+    added = tmp_path / "pr_added_files.txt"
+    added.write_text(
+        "docs/context/evidence/new_a.json\n\ndocs/context/evidence/new_b.svg\n",
+        encoding="utf-8",
+    )
+    assert pr_contract_check.get_added_files(added) == {
+        "docs/context/evidence/new_a.json",
+        "docs/context/evidence/new_b.svg",
+    }
+
+
+def test_check_evidence_tree_hygiene_authoritative_added_files(tmp_path: Path) -> None:
+    """Issue #5464: with an authoritative added set, only added files get marker blockers.
+
+    A marker-less evidence file that is *modified* (not in the added set) must not be
+    flagged, while a marker-less *added* file still is. No git heuristic is consulted.
+    """
+    evidence_dir = tmp_path / "docs/context/evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    modified = evidence_dir / "packet.json"
+    modified.write_text('{"note": "predates marker convention"}', encoding="utf-8")
+    added = evidence_dir / "brand_new.json"
+    added.write_text('{"note": "no marker"}', encoding="utf-8")
+
+    # Only ``brand_new.json`` is authoritatively added.
+    added_set = {str(added).replace("\\", "/")}
+    blockers = pr_contract_check.check_evidence_tree_hygiene(
+        [str(modified), str(added)], "origin/main", added_set
+    )
+    marker_blockers = [b for b in blockers if "marker convention" in b]
+    assert len(marker_blockers) == 1
+    assert str(added) in marker_blockers[0]
+    assert str(modified) not in marker_blockers[0]
+
+    # Empty added set (PR that only modifies evidence) → no marker blockers at all.
+    assert not pr_contract_check.check_evidence_tree_hygiene([str(modified)], "origin/main", set())
+
+
+@patch("subprocess.run")
 def test_check_successor_discipline(mock_run: MagicMock) -> None:
     """Test check_successor_discipline warns on lack of successor statement."""
     # Issue in title has merged PRs, but body lacks successor statement


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** The `PR Contract Check` workflow now fetches the PR base ref before running, and `scripts/ci/pr_contract_check.py` no longer treats an unresolvable base ref as "every file is new." The workflow also passes an authoritative list of *added* files (from the GitHub `pulls/{n}/files` API, `status == "added"`) that becomes the source of truth for the evidence-hygiene "is new" decision.
- **Why now:** On `pull_request`, `actions/checkout` produces a shallow merge-ref with **no `origin/main`**. `is_file_new()` then read the failing `git show origin/main:path` as "new file" for *every* changed evidence file, raising false-positive `AI-GENERATED`/`NEEDS-REVIEW` marker blockers on `docs/context/evidence/**` files that already exist marker-less on `main`. Observed on PR #5463.
- **Claim boundary:** CI-tooling correctness fix (`diagnostic-only`). No benchmark, metric, schema-semantics, or evidence-content change; no evidence markers were added/removed.
- **Required validation:** targeted unit tests + ruff + an end-to-end CLI reproduction (below).
- **Remaining blocker:** none for this false-positive. The `issue_3653` packet could still be migrated to carry markers under the evidence-writer adoption plan (#4921), but that is orthogonal.

## Contract delta

- **New CLI flag:** `--added-files-file` — authoritative newline-delimited added-files list. When supplied it is the sole "is new" signal for Rule 4 (evidence hygiene), superseding the git-diff heuristic. Backward compatible: absent → prior git heuristic (used by local runs and existing tests).
- **New behavior in `is_file_new`:** an unresolvable `base_ref` now returns `False` ("unknown, not new") instead of `True`. This removes the false-closed → false-positive path. No new fail-closed blocker is introduced; a genuinely-added file is still flagged via the authoritative added set.
- **Workflow:** adds a `Fetch base ref` step and passes `--base-ref origin/${{ github.base_ref }}`; `Collect changed files` now also emits `pr_added_files.txt`.
- **Compatibility:** no change to the six rule semantics; only the "is new" determination is hardened. Existing mocked tests (`get_new_files`/`is_file_new`) still pass unchanged.

## Scope

- In scope: `.github/workflows/pr-contract-check.yml`, `scripts/ci/pr_contract_check.py`, its tests, and a `CHANGELOG.md` Fixed entry.
- Implements **both** proposed options from the issue (workflow base-ref fetch + fail-closed-safe authoritative added-files signal) since they are complementary defense-in-depth; the API signal is authoritative and the fetch keeps the local git path correct.

## Validation

- `uv run ruff check` + `uv run ruff format --check` on both changed Python files — **clean**.
- `uv run pytest tests/validation/test_pr_contract_check.py -q` — **19 passed** (4 new: `base_ref_is_resolvable`, unresolvable-base guard, `get_added_files`, authoritative-added-set path; includes the live last-20-merged-PR regression).
- `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-contract-check.yml'))"` — YAML OK.
- End-to-end CLI reproduction against the issue scenario (a marker-less **modified** evidence file, base ref deliberately unresolvable):
  - empty added list → `🟢 PASSED`, exit 0 (the bug is gone);
  - same file in the authoritative added list → `🔴 FAILED` with the marker blocker, exit 1 (genuine new files still caught).

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

Refs #5464

<details>
<summary>Governance / provenance</summary>

- Evidence tier: `diagnostic-only` CI-tooling fix; comparator is the reported false-positive on PR #5463 vs. the corrected pass/fail behavior in the CLI reproduction above.
- State propagation: no durable state surface needed — this is a schema/behavior change, not a state refresh. No transient queue-routing state is encoded in tracked files (per issue directive 6d/6e).
- First fix PR for #5464 (the only prior "5464" PR is #5463, which *triggered* the bug); not a fragmentation micro-guard — it adds the nameable new capability of an origin/main-independent authoritative added-files signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request contract checks for shallow or limited checkouts.
  * Prevented modified files from being incorrectly treated as newly added.
  * Ensured evidence-file validation uses the authoritative list of files added to a pull request.

* **Tests**
  * Added coverage for base-branch resolution, added-file parsing, and evidence validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->