### PR TITLE
fix(benchmark): AI-GENERATED/NEEDS-REVIEW marker in generated Pareto SVG (evidence hygiene)

### DIFF
--- a/docs/context/evidence/issue_3653_snqi_decision_disagreement_job_13175/artifact_inventory.json
+++ b/docs/context/evidence/issue_3653_snqi_decision_disagreement_job_13175/artifact_inventory.json
@@ -53,7 +53,7 @@
     {
       "kind": "pareto_svg",
       "path": "snqi_scalarization_sensitivity_pareto.svg",
-      "sha256": "5c4f4036eec0c09692c321b8e2bb5fb1b659a39a800bc3c65aa545381773c2ad",
+      "sha256": "e41e475637a9c2c76916400f79995a8b26123a2fd2ab323ebb588e2fa8cf3181",
       "size_bytes": 8972
     }
   ],

--- a/docs/context/evidence/issue_3653_snqi_decision_disagreement_job_13175/packet.json
+++ b/docs/context/evidence/issue_3653_snqi_decision_disagreement_job_13175/packet.json
@@ -45,7 +45,7 @@
     {
       "kind": "pareto_svg",
       "path": "snqi_scalarization_sensitivity_pareto.svg",
-      "sha256": "5c4f4036eec0c09692c321b8e2bb5fb1b659a39a800bc3c65aa545381773c2ad",
+      "sha256": "e41e475637a9c2c76916400f79995a8b26123a2fd2ab323ebb588e2fa8cf3181",
       "size_bytes": 8972
     }
   ],
@@ -79,7 +79,7 @@
       },
       {
         "path": "snqi_scalarization_sensitivity_pareto.svg",
-        "sha256": "5c4f4036eec0c09692c321b8e2bb5fb1b659a39a800bc3c65aa545381773c2ad"
+        "sha256": "e41e475637a9c2c76916400f79995a8b26123a2fd2ab323ebb588e2fa8cf3181"
       }
     ],
     "preflight_status": "ready",

--- a/docs/context/evidence/issue_3653_snqi_decision_disagreement_job_13175/snqi_scalarization_sensitivity_pareto.svg
+++ b/docs/context/evidence/issue_3653_snqi_decision_disagreement_job_13175/snqi_scalarization_sensitivity_pareto.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="900" height="560" viewBox="0 0 900 560" role="img">
+<!-- AI-GENERATED figure export (robot_sf format_pareto_svg); NEEDS-REVIEW -->
 <title>SNQI scalarization sensitivity Pareto diagnostic</title>
 <rect width="100%" height="100%" fill="#ffffff"/>
 <line class="gridline x-gridline" x1="186.4" y1="40" x2="186.4" y2="470" stroke="#E5E5E5"/>

--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -1249,6 +1249,7 @@ def format_pareto_svg(report: Mapping[str, Any], *, width: int = 900, height: in
     parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}"'
         f' viewBox="0 0 {width} {height}" role="img">',
+        "<!-- AI-GENERATED figure export (robot_sf format_pareto_svg); NEEDS-REVIEW -->",
         "<title>SNQI scalarization sensitivity Pareto diagnostic</title>",
         '<rect width="100%" height="100%" fill="#ffffff"/>',
     ]


### PR DESCRIPTION
## Summary
Follow-up to #5463 (merged). The generated SNQI Pareto evidence SVG (`docs/context/evidence/issue_3653_.../snqi_scalarization_sensitivity_pareto.svg`) is missing the repo's required `AI-GENERATED` / `NEEDS-REVIEW` evidence marker — the `pr-contract-check` evidence-hygiene rule flags it on any PR that touches it.

## Fix
- `format_pareto_svg` now emits `<!-- AI-GENERATED figure export (robot_sf format_pareto_svg); NEEDS-REVIEW -->` as an SVG comment, so any regenerated Pareto evidence figure satisfies the marker convention going forward.
- Regenerated the pinned bundle SVG and re-pinned its sha256 in `artifact_inventory.json` and `packet.json`.

## Validation
`uv run pytest tests/benchmark/test_snqi_pareto_numeric_axes.py tests/test_snqi_pareto_determinism.py -q` → 5 passed; `ruff check` clean. Marker present in the regenerated SVG.
