### PR TITLE
test(#5418): guard pinned SNQI Pareto SVG against renderer drift

### DIFF
--- a/tests/benchmark/test_snqi_pareto_pinned_artifact.py
+++ b/tests/benchmark/test_snqi_pareto_pinned_artifact.py
@@ -1,0 +1,96 @@
+"""Drift guard tying the pinned SNQI Pareto SVG to the live renderer.
+
+Issue #5418 arose because a renderer change (#5403 label-layout fix) landed in
+``format_pareto_svg`` while the tracked evidence-packet SVG at
+``docs/context/evidence/issue_3653_snqi_decision_disagreement_job_13175`` was not
+regenerated, leaving the durable diagnostic artifact stale relative to the code.
+
+The existing coverage does not catch that class of drift:
+
+- ``tests/benchmark/test_snqi_pareto_numeric_axes.py`` exercises the renderer on a
+  *synthetic* report, so it never touches the pinned artifact on disk.
+- ``tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py``
+  only checks that the recorded checksums are internally self-consistent with the
+  file bytes, so a stale-but-self-consistent artifact still passes.
+
+This test closes the gap: it re-renders the SVG from the *pinned report JSON* and
+asserts it reproduces the tracked SVG byte-for-byte, and that the render's hash
+matches the checksum the packet checker enforces. If the renderer changes without
+regenerating the durable artifact (and updating the checker constant), this fails.
+
+Scope: diagnostic-only artifact provenance guard; no benchmark, metric, schema,
+or paper/dissertation claim is asserted.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.identity.hash_utils import sha256_file
+from robot_sf.benchmark.snqi_scalarization_sensitivity import format_pareto_svg
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVIDENCE_DIR = REPO_ROOT / "docs/context/evidence/issue_3653_snqi_decision_disagreement_job_13175"
+REPORT_PATH = EVIDENCE_DIR / "snqi_scalarization_sensitivity.json"
+SVG_PATH = EVIDENCE_DIR / "snqi_scalarization_sensitivity_pareto.svg"
+CHECKER_PATH = (
+    REPO_ROOT / "scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py"
+)
+
+# The two declared Pareto-front planners for job 13175 (see provenance.json).
+PARETO_FRONT_PLANNERS = frozenset({"ppo", "hybrid_rule_v3_fast_progress_static_escape"})
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("_issue_3653_snqi_packet_check", CHECKER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pinned_svg_regenerates_identically_from_pinned_report() -> None:
+    """The tracked SVG is exactly what the current renderer produces from its report.
+
+    This is the drift guard: it fails if ``format_pareto_svg`` changes without the
+    pinned issue-3653 artifact being regenerated to match (the #5418 failure mode).
+    """
+    report = json.loads(REPORT_PATH.read_text(encoding="utf-8"))
+    rendered = format_pareto_svg(report)
+
+    assert rendered == SVG_PATH.read_text(encoding="utf-8"), (
+        "Pinned SNQI Pareto SVG is stale relative to format_pareto_svg(). "
+        "Regenerate the artifact and update the recorded checksums "
+        "(validation script, YAML packet, artifact_inventory.json, packet.json)."
+    )
+
+
+def test_pinned_svg_hash_matches_packet_checker_constant() -> None:
+    """The pinned SVG bytes match the checksum the packet checker enforces.
+
+    Ties renderer output -> tracked file -> gate constant in one chain, so a
+    regeneration that forgets to update the checker constant is caught here.
+    """
+    checker = _load_checker()
+    expected = checker.EXPECTED_EXPORT_ARTIFACT_HASHES[SVG_PATH.name]
+
+    assert sha256_file(SVG_PATH) == expected
+
+
+def test_pinned_svg_keeps_both_pareto_front_points_identifiable() -> None:
+    """Acceptance item 4: the two Pareto-front points stay identifiable.
+
+    Under the numbered-marker rendering the front points carry an explicit
+    ``pareto-point front`` class and a connecting front polyline.
+    """
+    svg = SVG_PATH.read_text(encoding="utf-8")
+    front_planners = {
+        line.split('data-planner="', 1)[1].split('"', 1)[0]
+        for line in svg.splitlines()
+        if 'class="pareto-point front"' in line
+    }
+
+    assert front_planners == PARETO_FRONT_PLANNERS
+    assert '<polyline points="' in svg


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Adds one test file, `tests/benchmark/test_snqi_pareto_pinned_artifact.py`, that ties the pinned issue-3653 SNQI Pareto SVG to the live `format_pareto_svg` renderer. No production code or artifact bytes change.
- **Why now:** Issue #5418 tracked regenerating the durable SVG after the #5403/#5437 label-layout fix. Investigating origin/main shows the **regeneration itself already landed via merged PR #5463** (SVG at `docs/context/evidence/issue_3653_snqi_decision_disagreement_job_13175/snqi_scalarization_sensitivity_pareto.svg` now hashes `5c4f4036…`; validation script, YAML packet, `artifact_inventory.json`, and `packet.json` all updated to match; focused checker passes). An independent re-render from this branch is **byte-identical**, confirming the artifact is current. The one residual gap was that **no test guards against the specific failure mode that created #5418** — a renderer change that leaves the durable artifact stale — plus acceptance item 4 (front-point identifiability) was not encoded durably. This PR closes both.
- **Claim boundary:** Diagnostic-only artifact provenance guard. No benchmark, metric, schema, or paper/dissertation claim is asserted or promoted.
- **Required validation:** targeted pytest (below) + ruff; both green. Negative control confirms the guard fails on a stale artifact.
- **Remaining blocker:** none for #5418. The raw episode re-export path stays intentionally blocked (private hydrated `episodes.jsonl`, `fd15480…`); it is not needed because the tracked report JSON fully determines the SVG.

## Contract delta

- **New test-only guard** (no new fail-closed gate on the packet checker; the packet checker constant is now cross-checked from the test side):
  - `format_pareto_svg(pinned report JSON)` must reproduce the tracked SVG byte-for-byte.
  - Tracked SVG hash must equal `EXPECTED_EXPORT_ARTIFACT_HASHES["…pareto.svg"]` in `scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py`, chaining renderer → file → gate constant.
  - Both declared Pareto-front planners (`ppo`, `hybrid_rule_v3_fast_progress_static_escape`) stay identifiable in the pinned SVG (acceptance item 4).
- **Compatibility impact:** none. Existing renderer/packet tests unchanged and still pass.

## Validation

```
uv run pytest tests/benchmark/test_snqi_pareto_pinned_artifact.py \
  tests/benchmark/test_snqi_pareto_numeric_axes.py \
  tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py -q
# => 25 passed

# focused packet validation on the durable artifact (already green on origin/main):
uv run python scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py --json
# => {"status": "ok", ... "pareto_front" points = 2 ...}, exit 0

ruff check / ruff format tests/benchmark/test_snqi_pareto_pinned_artifact.py  # clean
```

Negative control: appending bytes to the pinned SVG makes both the regeneration and hash tests fail; restoring the file returns all three to green.

## Scope

- **In scope:** one test file guarding the pinned SNQI Pareto SVG against renderer drift + acceptance-item-4 verification.
- **Out of scope (explicit):** no full benchmark campaign run; no Slurm/GPU submission; no paper/dissertation claim edits; no changes to the durable SVG bytes or recorded checksums (already correct via #5463); no re-export from raw episodes.

## State propagation

Low-churn issue; I cannot comment on the issue this session (`comment_issue_or_pr: false`). This PR body is the single durable status surface: the durable regeneration (acceptance items 1–3) landed via #5463; this PR delivers the missing recurrence guard and item-4 verification.

<details>
<summary>Governance appendix</summary>

- Issue: #5418 (parent #5401, fixing PR #5403, gate PR #5437, regeneration PR #5463).
- Evidence tier: 0/1 (test-only, diagnostic-only artifact). No metric semantics touched.
- Forbidden actions confirmed not taken: compute_submit=false, merge=false, release=false, delete=false, no paper/dissertation edits.
- Artifact discipline: only `output/` scratch used for the negative control; nothing under `output/` is tracked by this PR.

</details>

Closes #5418

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added benchmark coverage to verify the pinned SNQI Pareto SVG is reproduced consistently.
  * Confirmed the artifact checksum remains valid.
  * Verified both Pareto-front planners and the connecting front are present in the generated SVG.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->