### PR TITLE
fix(ci): unbreak main — bless 3 new optional-import guards (#5470)

### DIFF
--- a/scripts/dev/generate_optional_import_snapshot.py
+++ b/scripts/dev/generate_optional_import_snapshot.py
@@ -65,7 +65,8 @@ NOTES = {
     "AttributeError+ImportError+RuntimeError": ("Blessed broad catch: optional native boundary."),
     "AttributeError+ImportError+TypeError": ("Blessed broad catch: optional dispatch boundary."),
     "AttributeError+ImportError+OSError+RuntimeError+TypeError+ValueError": (
-        "Blessed broad catch: defensive visualization ingest boundary."
+        "Blessed broad catches: defensive visualization ingest and "
+        "authorization-gated episode execution boundaries."
     ),
     "ImportError+OSError+RuntimeError+TypeError+ValueError": (
         "Blessed broad catch: defensive JSON/config ingest boundary. Review "

--- a/tests/fixtures/optional_import_guards.json
+++ b/tests/fixtures/optional_import_guards.json
@@ -6,7 +6,7 @@
     "ModuleNotFoundError"
   ],
   "spelling_key": "Caught exception type names, sorted and joined by '+'. The 'as <alias>' name is intentionally NOT part of the key.",
-  "total_guards": 103,
+  "total_guards": 106,
   "spellings": {
     "AttributeError+ImportError": {
       "count_ceiling": 2,
@@ -91,9 +91,9 @@
       ]
     },
     "ImportError": {
-      "count_ceiling": 71,
-      "has_as_count": 14,
-      "pragma_no_cover_count": 24,
+      "count_ceiling": 74,
+      "has_as_count": 15,
+      "pragma_no_cover_count": 25,
       "blessed": true,
       "note": "Pure optional-import. Prefer robot_sf.common.optional_import.try_import for new plain cases.",
       "samples": [
@@ -108,12 +108,15 @@
         "robot_sf/baselines/sicnav.py:420",
         "robot_sf/baselines/sicnav.py:298",
         "robot_sf/benchmark/cli.py:198",
+        "robot_sf/benchmark/collision_causal_report.py:47",
         "robot_sf/benchmark/distributions.py:131",
         "robot_sf/benchmark/episode_replay_figure.py:37",
         "robot_sf/benchmark/episode_replay_figure.py:50",
         "robot_sf/benchmark/episode_replay_figure.py:57",
         "robot_sf/benchmark/episode_replay_figure.py:852",
         "robot_sf/benchmark/episode_replay_figure.py:890",
+        "robot_sf/benchmark/figure_qa.py:502",
+        "robot_sf/benchmark/figure_qa.py:570",
         "robot_sf/benchmark/figures/export.py:155",
         "robot_sf/benchmark/full_classic/encode.py:36",
         "robot_sf/benchmark/full_classic/encode.py:86",


### PR DESCRIPTION
## Reviewer-critical summary
- **What changed:** Regenerated the optional-import guard snapshot (`tests/fixtures/optional_import_guards.json`) to bless the 3 new `ImportError` guards that landed on `main` and tripped the AST inventory ratchet, plus a one-line generator note sync. **No runtime behavior change.**
- **Why now:** P0 — `main` CI is red. The ratchet test `tests/test_optional_import_guard_inventory.py::...::test_no_new_unblessed_spelling_and_no_count_growth` fails deterministically: `RATCHET VIOLATION: spelling 'ImportError' grew from ceiling 71 to 74`. While main is red, PR gates can't settle.
- **Claim boundary:** CI-hygiene fix only. Not a benchmark/metric/schema/paper claim. Behavior-preserving.
- **Required validation:** `uv run python -m pytest tests/test_optional_import_guard_inventory.py -q` → **8 passed** (previously 1 failed).
- **Remaining blocker:** none for unbreaking main. Close condition (from the issue) is two consecutive green main CI runs after merge.

Fixes issue: https://github.com/ll7/robot_sf_ll7/issues/5470

## Root cause
Merges since the last green run added three legitimate optional-import guards under `robot_sf/`, growing the `ImportError` spelling from the blessed ceiling **71 → 74**. The ratchet (issue #4990) characterizes today's tree and fails on count growth, forcing a conscious bless-or-migrate decision.

New guards (all faithful optional-import patterns, matching the 40+ identical guards **already** blessed in the snapshot):

| Location | Pattern | Why blessed (not `try_import`) |
| --- | --- | --- |
| `robot_sf/benchmark/collision_causal_report.py:47` | `try: import jsonschema / except ImportError as exc: raise RuntimeError(...)` | **Fail-loud** on a declared dependency. `try_import` discards the exception and returns `None`, so it cannot express a re-raise. |
| `robot_sf/benchmark/figure_qa.py:502` | `try: import matplotlib.figure / except ImportError: return []` | Optional matplotlib submodule → default. Same shape as `benchmark/plots.py:28`, `full_classic/visuals.py:49`, etc. already blessed. |
| `robot_sf/benchmark/figure_qa.py:570` | `try: import matplotlib.text / except ImportError: return False` | As above. |

Chose **bless (regenerate snapshot)** over migrating the two matplotlib guards to `try_import`: it is the minimal, behavior-preserving path for a P0; it is the exact remedy the ratchet message and generator sanction (direct precedent: PR #5324 "unbreak main — bless the campaign-preflight import probe"); and migrating only 2 of 40+ identical already-blessed matplotlib guards would be inconsistent churn.

## Contract delta
- **Schema/fixture:** `ImportError` ceiling `71 → 74`; `has_as_count 14 → 15`; `pragma_no_cover_count 24 → 25`; `total_guards 103 → 106`; 3 sample paths added. Regenerated by the canonical `scripts/dev/generate_optional_import_snapshot.py` (verified **idempotent**: re-running reproduces the committed file byte-for-byte).
- **No new fail-closed blockers, no compatibility impact.** The ratchet still fails on any *further* growth (75+) or any new unblessed spelling.
- Generator NOTES for `AttributeError+ImportError+OSError+RuntimeError+TypeError+ValueError` synced to the hand-improved fixture note, so regeneration no longer silently reverts it.

## Validation
```
$ uv run python -m pytest tests/test_optional_import_guard_inventory.py -q
8 passed in 10.76s
```
Generator idempotency: regenerate → `diff` against committed fixture → identical. Ruff check + format --check on the changed script: pass.

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No migration of the matplotlib guards to `try_import` (optional future cleanup; would be inconsistent to do piecemeal — noted here instead).

## State propagation
Issue #5470 is low-churn (0 prior PRs, no comments). Commenting is not authorized for this lane, so state is propagated via this PR body and the `Closes #5470` keyword; the merge closes the issue once two consecutive main CI runs pass.

Closes #5470

<details>
<summary>Governance / provenance appendix</summary>

- Target claim/hypothesis/blocker: NA (CI-hygiene, no research claim).
- Comparator/baseline: NA. Evidence tier: smoke (deterministic test pass). Result classification: fix confirmed by target test.
- Fragmentation guard (2026-07-02): no guardrail/checker PRs merged for #5470 in the last 24h; this is the first and only slice, and it is a progression slice delivering a nameable capability (unbreak main CI).
- Freshness: re-read issue #5470 (0 comments) and re-fetched `origin/main` (still ceiling 71, still red) immediately before opening.
- Worked in isolated worktree `../robot_sf_ll7.worktrees/issue-5470` from `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>
