### PR TITLE
refactor(research): promote collision-risk contact geometry to public API (#5468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #5468 public collision-risk contact geometry.** Promoted the canonical contact geometry of
+  the action-conditioned collision-risk API to a documented public surface:
+  `segment_min_distance` (closed-form per-interval minimum centre distance) and `pedestrian_arrays`
+  (validated actor position/velocity/radius/id extractor) are now re-exported from
+  `robot_sf.research.collision_risk`. Downstream calibration, replay, and label-generation code can
+  compute contact on the *identical* geometry the estimator uses instead of importing
+  underscore-prefixed internals; `calibration.py` now consumes the public names. Backward-compatible
+  private aliases (`_segment_min_distance`, `_pedestrian_arrays`) still resolve to the same objects.
+  No behavior change; covered by tests asserting the public and internal handles agree.
+
 * **issue #5446 seed-flip / held-out planner-inversion candidate miner.** New
   `robot_sf/benchmark/seed_flip_mining.py` (`seed_flip_inversion_candidates.v1`) mines *case
   candidates* — reproducible seed-dependent outcome flips and genuine held-out planner upsets —

--- a/robot_sf/research/collision_risk/__init__.py
+++ b/robot_sf/research/collision_risk/__init__.py
@@ -11,6 +11,8 @@ Public surface:
 - :class:`~robot_sf.research.collision_risk.estimators.CandidateAction`
 - :func:`~robot_sf.research.collision_risk.estimators.action_from_constant_velocity`
 - :func:`~robot_sf.research.collision_risk.estimators.estimate_action_conditioned_risk`
+- :func:`~robot_sf.research.collision_risk.estimators.segment_min_distance` (canonical contact geometry)
+- :func:`~robot_sf.research.collision_risk.estimators.pedestrian_arrays` (matched actor-state extractor)
 - :class:`~robot_sf.research.collision_risk.schema.ActionConditionedRiskEstimate`
 
 Status: API + baseline fixture evidence, not a calibrated benchmark risk claim.
@@ -28,6 +30,8 @@ from robot_sf.research.collision_risk.estimators import (
     RiskEstimatorConfig,
     action_from_constant_velocity,
     estimate_action_conditioned_risk,
+    pedestrian_arrays,
+    segment_min_distance,
 )
 from robot_sf.research.collision_risk.schema import (
     DETERMINISTIC_FIELD_LABEL,
@@ -63,4 +67,6 @@ __all__ = [
     "action_from_constant_velocity",
     "estimate_action_conditioned_risk",
     "latency_summary_from_samples",
+    "pedestrian_arrays",
+    "segment_min_distance",
 ]

--- a/robot_sf/research/collision_risk/calibration.py
+++ b/robot_sf/research/collision_risk/calibration.py
@@ -49,10 +49,10 @@ from robot_sf.nav.predictive_types import PedestrianState
 from robot_sf.research.collision_risk.estimators import (
     CandidateAction,
     RiskEstimatorConfig,
-    _pedestrian_arrays,
-    _segment_min_distance,
     action_from_constant_velocity,
     estimate_action_conditioned_risk,
+    pedestrian_arrays,
+    segment_min_distance,
 )
 from robot_sf.research.collision_risk.schema import latency_summary_from_samples
 
@@ -611,7 +611,7 @@ def _realize_contact(
         ``(realized_contact, first_contact_step)`` with ``-1`` when no contact.
     """
     robot_xy = action.as_array(horizon_steps=config.horizon_steps)
-    ped_pos, ped_vel, radii, _ids = _pedestrian_arrays(pedestrians, config)
+    ped_pos, ped_vel, radii, _ids = pedestrian_arrays(pedestrians, config)
     radii_sum = radii + config.robot_radius_m
     n_actors = ped_pos.shape[0]
     if n_actors == 0:
@@ -624,7 +624,7 @@ def _realize_contact(
     realized_pos = (
         ped_pos[:, None, :] + steps[None, :, None] * config.dt_s * realized_vel[:, None, :]
     )  # (K, H+1, 2)
-    seg_dist = _segment_min_distance(robot_xy, realized_pos)  # (K, H)
+    seg_dist = segment_min_distance(robot_xy, realized_pos)  # (K, H)
     contact = seg_dist - radii_sum[:, None] <= 0.0  # (K, H)
     contact_any_step = contact.any(axis=0)  # (H,)
     if not bool(contact_any_step.any()):

--- a/robot_sf/research/collision_risk/estimators.py
+++ b/robot_sf/research/collision_risk/estimators.py
@@ -204,8 +204,15 @@ def action_from_constant_velocity(
     )
 
 
-def _segment_min_distance(robot_xy: np.ndarray, actor_xy: np.ndarray) -> np.ndarray:
+def segment_min_distance(robot_xy: np.ndarray, actor_xy: np.ndarray) -> np.ndarray:
     """Closed-form minimum centre distance per horizon interval.
+
+    This is the canonical contact geometry used by
+    :func:`estimate_action_conditioned_risk`. It is public so downstream
+    calibration, replay, and label-generation code can compute contact on the
+    *identical* geometry the estimator uses (see :func:`pedestrian_arrays`);
+    subtract the summed robot+actor radii to obtain footprint clearance, and a
+    non-positive clearance is a contact.
 
     Both the robot and each actor move linearly within a timestep interval, so
     the relative displacement is affine in the sub-step parameter ``u in [0, 1]``
@@ -231,11 +238,16 @@ def _segment_min_distance(robot_xy: np.ndarray, actor_xy: np.ndarray) -> np.ndar
     return np.linalg.norm(closest, axis=-1)
 
 
-def _pedestrian_arrays(
+def pedestrian_arrays(
     pedestrians: Sequence[PedestrianState],
     config: RiskEstimatorConfig,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Extract validated position/velocity/radius/id arrays from pedestrians.
+
+    Public companion to :func:`segment_min_distance`: downstream calibration and
+    label-generation code reuses this extractor so ground-truth contact labels
+    are computed on the same actor state the estimator scores. Fails closed on
+    non-2D or non-finite pedestrian state.
 
     Returns:
         Tuple ``(positions (K, 2), velocities (K, 2), radii (K,), ids (K,))``.
@@ -330,7 +342,7 @@ def _deterministic_fields(
         )
 
     nominal = _nominal_positions(ped_pos, ped_vel, config)  # (K, H+1, 2)
-    seg_dist = _segment_min_distance(robot_xy, nominal)  # (K, H)
+    seg_dist = segment_min_distance(robot_xy, nominal)  # (K, H)
     clearance = seg_dist - radii_sum[:, None]  # (K, H)
 
     flat_index = int(np.argmin(clearance))
@@ -353,7 +365,7 @@ def _deterministic_fields(
     robot_v0 = (robot_xy[1] - robot_xy[0]) / config.dt_s
     steps = np.arange(config.horizon_steps + 1, dtype=float)
     robot_cv = robot_xy[0][None, :] + steps[:, None] * config.dt_s * robot_v0[None, :]
-    vo_dist = _segment_min_distance(robot_cv, nominal)  # (K, H)
+    vo_dist = segment_min_distance(robot_cv, nominal)  # (K, H)
     vo_flags = tuple(bool(value) for value in (vo_dist - radii_sum[:, None] <= 0.0).any(axis=1))
 
     # Conservative reachable-set warning: actor within max robot reach over horizon.
@@ -427,7 +439,7 @@ def estimate_action_conditioned_risk(
     start_ns = time.perf_counter_ns()
 
     robot_xy = action.as_array(horizon_steps=config.horizon_steps)
-    ped_pos, ped_vel, radii, ids = _pedestrian_arrays(pedestrians, config)
+    ped_pos, ped_vel, radii, ids = pedestrian_arrays(pedestrians, config)
     radii_sum = radii + config.robot_radius_m
 
     deterministic = _deterministic_fields(robot_xy, ped_pos, ped_vel, radii_sum, config)
@@ -445,7 +457,7 @@ def estimate_action_conditioned_risk(
     else:
         rng = np.random.default_rng(config.seed)
         sampled = _sample_positions(ped_pos, ped_vel, config, rng)  # (S, K, H+1, 2)
-        seg_dist = _segment_min_distance(robot_xy, sampled)  # (S, K, H)
+        seg_dist = segment_min_distance(robot_xy, sampled)  # (S, K, H)
         contact = seg_dist - radii_sum[None, :, None] <= 0.0  # (S, K, H)
 
         contact_per_actor = contact.any(axis=2)  # (S, K)
@@ -572,6 +584,14 @@ def _build_uncertainty(
     )
 
 
+# Backward-compatible internal aliases. The leading-underscore names were the
+# only handle downstream code had before issue #5468 promoted the contact
+# geometry to public API; keep them as aliases so pre-existing imports of the
+# private names keep resolving to the exact same objects.
+_segment_min_distance = segment_min_distance
+_pedestrian_arrays = pedestrian_arrays
+
+
 __all__ = [
     "ESTIMATOR_ID",
     "FORECAST_MODEL_ID",
@@ -581,4 +601,6 @@ __all__ = [
     "RiskEstimatorConfig",
     "action_from_constant_velocity",
     "estimate_action_conditioned_risk",
+    "pedestrian_arrays",
+    "segment_min_distance",
 ]

--- a/tests/test_action_conditioned_collision_risk.py
+++ b/tests/test_action_conditioned_collision_risk.py
@@ -254,3 +254,52 @@ def test_collision_risk_schema_rejects_inconsistent_probabilities() -> None:
     )
     with pytest.raises(RiskSchemaError):
         broken.validate()
+
+
+def test_public_contact_geometry_matches_private_aliases() -> None:
+    """The public contact geometry (issue #5468) is the exact private objects.
+
+    ``segment_min_distance`` / ``pedestrian_arrays`` were promoted from the
+    leading-underscore internals so downstream calibration and label-generation
+    code can match the estimator geometry through a documented public surface.
+    Both handles must resolve to the same function object (not a re-implementation)
+    and be re-exported from the package root.
+    """
+    from robot_sf.research.collision_risk import estimators as est
+    from robot_sf.research.collision_risk import pedestrian_arrays, segment_min_distance
+
+    assert segment_min_distance is est.segment_min_distance
+    assert pedestrian_arrays is est.pedestrian_arrays
+    # Backward-compatible private aliases still point at the promoted objects.
+    assert est._segment_min_distance is segment_min_distance
+    assert est._pedestrian_arrays is pedestrian_arrays
+
+
+def test_public_contact_geometry_computes_matched_contact() -> None:
+    """Public geometry helpers reproduce the estimator's contact predicate.
+
+    A head-on constant-velocity encounter must yield a non-positive footprint
+    clearance (contact) when scored through the public ``pedestrian_arrays`` +
+    ``segment_min_distance`` surface, matching the deterministic estimator field.
+    """
+    from robot_sf.research.collision_risk import pedestrian_arrays, segment_min_distance
+
+    config = _config()
+    action = action_from_constant_velocity(
+        "into", [0.0, 0.0], [1.0, 0.0], horizon_steps=HORIZON_STEPS, dt_s=DT_S
+    )
+    ped = PedestrianState(id=1, position=np.array([1.5, 0.0]), velocity=np.array([-1.0, 0.0]))
+
+    robot_xy = action.as_array(horizon_steps=config.horizon_steps)
+    ped_pos, ped_vel, radii, ids = pedestrian_arrays([ped], config)
+    assert ped_pos.shape == (1, 2)
+    assert ids.tolist() == [1]
+
+    steps = np.arange(config.horizon_steps + 1, dtype=float)
+    actor_xy = ped_pos[:, None, :] + steps[None, :, None] * config.dt_s * ped_vel[:, None, :]
+    clearance = segment_min_distance(robot_xy, actor_xy) - (radii + config.robot_radius_m)[:, None]
+    contact = bool((clearance <= 0.0).any())
+
+    estimate = estimate_action_conditioned_risk(action, [ped], config)
+    assert contact is True
+    assert estimate.deterministic.contact_certain is contact


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Promoted the collision-risk *contact geometry* from private internals to a documented public API. `_segment_min_distance` → `segment_min_distance` and `_pedestrian_arrays` → `pedestrian_arrays`, both re-exported from `robot_sf.research.collision_risk`.
- **Why now:** Friction filed while implementing #5445 — `calibration.py` had to import underscore-prefixed internals (`from ...estimators import _pedestrian_arrays, _segment_min_distance`) to guarantee its ground-truth labels use the *identical* contact predicate as the estimator. A future refactor of those internals could silently break the one property the calibration harness most depends on.
- **Claim boundary:** Support/tooling refactor. **No behavior change** — same functions, same numerics; only names/exports and docstrings change. Not a benchmark, metric, or risk claim. `NA` research-claim fields (no new evidence produced).
- **Required validation:** ruff + targeted collision-risk suite (below).
- **Remaining blocker:** none for this slice.

## Contract delta

- **New public surface:** `segment_min_distance(robot_xy, actor_xy)` (closed-form per-interval minimum centre distance — the canonical contact geometry) and `pedestrian_arrays(pedestrians, config)` (validated position/velocity/radius/id extractor, fail-closed on non-2D/non-finite state). Both added to `robot_sf.research.collision_risk.__all__` and the `estimators` module `__all__`.
- **Consumer updated:** `calibration.py` now imports the public names.
- **Compatibility:** Backward-compatible private aliases `_segment_min_distance` / `_pedestrian_arrays` retained, bound to the exact same objects, so any pre-existing private-name import keeps working.
- **No new fail-closed blockers**; existing `CollisionRiskInputError` fail-closed behavior in `pedestrian_arrays` is unchanged.

## Scope

- In scope: rename/alias + `__all__`/re-export + consumer update + tests. Matches the issue's suggested bounded change exactly.
- Out of scope: no new `contact_predicate(...)` convenience wrapper (the two promoted primitives already give downstream code the exact geometry; adding a third surface would be broader than the ask).

## Validation

```
scripts/dev/ruff_fix_format.sh
# Found 1 error (1 fixed, 0 remaining). 2975 files left unchanged.

uv run pytest tests/test_action_conditioned_collision_risk.py tests/test_collision_risk_calibration.py -q
# 28 passed in 10.50s  (includes 2 new tests)

uv run python -c "from robot_sf.research.collision_risk import segment_min_distance, pedestrian_arrays; ..."
# imports OK; public geometry re-exported and aliased
```

New tests:
- `test_public_contact_geometry_matches_private_aliases` — public names, module names, and private aliases are the same objects (not re-implementations).
- `test_public_contact_geometry_computes_matched_contact` — the public `pedestrian_arrays` + `segment_min_distance` surface reproduces the estimator's deterministic contact predicate on a head-on encounter.

## Closure

Closes #5468 — the friction issue's full suggested change (rename/alias + `__all__` entry + agreement test) is delivered, with `calibration.py` migrated to the public names.

## Out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Governance / process</summary>

- **State propagation:** low-churn issue (0 prior PRs). No separate issue-state surface needed; this PR body is the canonical status surface. Per authorization, no issue comment was posted (`comment_issue_or_pr: false`).
- **Fragmentation guard:** exempt — this is a progression slice adding a nameable new capability (public contact-geometry API) toward the #5445/#5468 plan, not a micro-guard.
- **Evidence tier:** smoke/diagnostic (import + unit agreement); no metric semantics touched, so no pre-freeze concern.
- **Worktree:** isolated `robot_sf_ll7.worktrees/issue-5468` from `origin/main`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
