### PR TITLE
test(benchmark): prove #3574 harness emits readiness-satisfying pedestrian control trace (#5397)

### DIFF
--- a/robot_sf/benchmark/heterogeneous_population_ablation_runner.py
+++ b/robot_sf/benchmark/heterogeneous_population_ablation_runner.py
@@ -1,0 +1,145 @@
+"""Execution helpers for the issue #3574 mean-matched heterogeneity harness.
+
+The dry-run manifest built by :mod:`heterogeneous_population_ablation` describes
+paired population rows but carries no runtime trace. This module turns one such
+manifest row into the runtime scenario the map runner expects and executes it so
+that the emitted episode record carries the ``algorithm_metadata.pedestrian_control_trace``
+(with per-step ``clearance_m`` / ``near_field_exposure_s``) that the readiness
+gate in :func:`assess_mean_matched_episode_records` demands.
+
+Extracted from ``scripts/benchmark/run_heterogeneous_population_ablation_issue_3574.py``
+so both the campaign runner and the acceptance tests exercise the same scenario
+assembly and emission path (issue #5397): the trace the readiness gate requires
+is produced on the harness path, not by a parallel test-only reconstruction.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.map_runner import _build_policy
+from robot_sf.benchmark.map_runner_episode import run_map_episode
+
+# Per-archetype desired-speed factors used when materializing a manifest row into
+# a runtime population. The ``mean_matched_homogeneous`` value is the weighted mean
+# of the mixture arm and keeps the two arms mean-matched (see the smoke config).
+DEFAULT_ARCHETYPE_SPEED_FACTORS = {
+    "cautious": 0.7,
+    "standard": 1.0,
+    "hurried": 1.4,
+    "mean_matched_homogeneous": 1.025,
+}
+
+DEFAULT_ARCHETYPE_SEED = 3574
+DEFAULT_MAX_EPISODE_STEPS = 600
+
+
+def build_episode_scenario(
+    row: dict[str, Any],
+    *,
+    map_path: Path | str,
+    max_episode_steps: int = DEFAULT_MAX_EPISODE_STEPS,
+    archetype_speed_factors: dict[str, float] | None = None,
+    archetype_seed: int = DEFAULT_ARCHETYPE_SEED,
+) -> dict[str, Any]:
+    """Assemble the runtime scenario dict for one paired manifest row.
+
+    The scenario carries the row's ``pedestrian_control_trace_labels`` so the map
+    runner attaches a per-pedestrian control trace to the emitted record.
+
+    Returns:
+        A scenario dictionary consumable by :func:`run_map_episode`.
+    """
+
+    arm_population = row["arm_population"]
+    population_size = sum(arm_population["counts"].values())
+    return {
+        "name": row["scenario_id"],
+        "map_file": str(Path(map_path).resolve()),
+        "simulation_config": {
+            "max_episode_steps": int(max_episode_steps),
+            "ped_density": float(row["density"]),
+            "population_size": population_size,
+            "response_law_composition": arm_population.get("response_law_composition"),
+            "response_law_seed": arm_population.get("response_law_seed"),
+            "archetype_composition": arm_population.get("composition"),
+            "archetype_speed_factors": dict(
+                DEFAULT_ARCHETYPE_SPEED_FACTORS
+                if archetype_speed_factors is None
+                else archetype_speed_factors
+            ),
+            "archetype_seed": archetype_seed,
+        },
+        "pedestrian_control_trace_labels": arm_population["pedestrian_control_trace_labels"],
+        "robot_config": {},
+    }
+
+
+def run_manifest_row(
+    row: dict[str, Any],
+    *,
+    map_path: Path | str,
+    scenario_path: Path,
+    horizon: int = DEFAULT_MAX_EPISODE_STEPS,
+    dt: float = 0.1,
+    max_episode_steps: int | None = None,
+) -> dict[str, Any]:
+    """Run one paired manifest row and return its annotated episode record.
+
+    The record is annotated with the campaign keys the readiness gate indexes by
+    (``scenario_id``/``planner``/``seed``/``population_arm``/``response_law_fraction``)
+    so :func:`assess_mean_matched_episode_records` can pair it against the manifest.
+
+    Returns:
+        The emitted episode record with campaign metadata attached.
+    """
+
+    response_law_fraction_value = row.get("response_law_fraction")
+    response_law_fraction = float(
+        0.0 if response_law_fraction_value is None else response_law_fraction_value
+    )
+    scenario = build_episode_scenario(
+        row,
+        map_path=map_path,
+        max_episode_steps=horizon if max_episode_steps is None else max_episode_steps,
+    )
+
+    record = run_map_episode(
+        scenario=scenario,
+        seed=int(row["seed"]),
+        horizon=horizon,
+        dt=dt,
+        record_forces=True,
+        snqi_weights=None,
+        snqi_baseline=None,
+        algo=row["planner"],
+        scenario_path=scenario_path,
+        record_planner_decision_trace=False,
+        record_simulation_step_trace=True,
+        policy_builder=_build_policy,
+    )
+
+    record["population_arm"] = row["population_arm"]
+    record["planner"] = row["planner"]
+    record["seed"] = int(row["seed"])
+    record["scenario_id"] = row["scenario_id"]
+    record["response_law_fraction"] = response_law_fraction
+
+    scenario_params = record.setdefault("scenario_params", {})
+    scenario_params["population_arm"] = row["population_arm"]
+    scenario_params["planner"] = row["planner"]
+    scenario_params["seed"] = int(row["seed"])
+    scenario_params["scenario_id"] = row["scenario_id"]
+    scenario_params["response_law_fraction"] = response_law_fraction
+
+    return record
+
+
+__all__ = [
+    "DEFAULT_ARCHETYPE_SEED",
+    "DEFAULT_ARCHETYPE_SPEED_FACTORS",
+    "DEFAULT_MAX_EPISODE_STEPS",
+    "build_episode_scenario",
+    "run_manifest_row",
+]

--- a/scripts/benchmark/run_heterogeneous_population_ablation_issue_3574.py
+++ b/scripts/benchmark/run_heterogeneous_population_ablation_issue_3574.py
@@ -12,8 +12,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from robot_sf.benchmark.map_runner import _build_policy
-from robot_sf.benchmark.map_runner_episode import run_map_episode
+from robot_sf.benchmark.heterogeneous_population_ablation_runner import run_manifest_row
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -55,88 +54,33 @@ def main() -> int:
 
     records: list[dict[str, Any]] = []
 
+    # Map file is relative to repo root; validated once before the run loop.
+    map_path = REPO_ROOT / "maps/svg_maps/classic_crossing.svg"
+    if not map_path.exists():
+        print(f"Error: Map file not found at {map_path}")
+        return 1
+
     for idx, row in enumerate(manifest_rows):
         scenario_id = row["scenario_id"]
         planner = row["planner"]
         seed = int(row["seed"])
         arm = row["population_arm"]
-        density = float(row["density"])
-        response_law_fraction_value = row.get("response_law_fraction")
-        response_law_fraction = float(
-            0.0 if response_law_fraction_value is None else response_law_fraction_value
-        )
 
         print(
             f"[{idx + 1}/{len(manifest_rows)}] Running scenario={scenario_id} arm={arm} planner={planner} seed={seed}"
         )
 
-        # Assemble the runtime scenario dict
-        # Map file is relative to repo root
-        map_path = REPO_ROOT / "maps/svg_maps/classic_crossing.svg"
-        if not map_path.exists():
-            print(f"Error: Map file not found at {map_path}")
-            return 1
-
-        pop_size = sum(row["arm_population"]["counts"].values())
-
-        scenario_dict: dict[str, Any] = {
-            "name": scenario_id,
-            "map_file": str(map_path.resolve()),
-            "simulation_config": {
-                "max_episode_steps": 600,
-                "ped_density": density,
-                "population_size": pop_size,
-                "response_law_composition": row["arm_population"].get("response_law_composition"),
-                "response_law_seed": row["arm_population"].get("response_law_seed"),
-                "archetype_composition": row["arm_population"].get("composition"),
-                # We can determine the speed factors from the labels or composition
-                "archetype_speed_factors": {
-                    "cautious": 0.7,
-                    "standard": 1.0,
-                    "hurried": 1.4,
-                    "mean_matched_homogeneous": 1.025,  # Weighted mean speed factor
-                },
-                "archetype_seed": 3574,
-            },
-            "pedestrian_control_trace_labels": row["arm_population"][
-                "pedestrian_control_trace_labels"
-            ],
-            "robot_config": {},
-        }
-
         try:
-            # Run the episode
-            # We record simulation trace to retrieve pedestrian positions, speeds, etc.
-            rec = run_map_episode(
-                scenario=scenario_dict,
-                seed=seed,
+            # Assemble the runtime scenario and run the episode through the shared
+            # harness helper so the emitted record carries the per-pedestrian control
+            # trace the readiness gate requires (issue #5397).
+            rec = run_manifest_row(
+                row,
+                map_path=map_path,
+                scenario_path=manifest_path,
                 horizon=600,
                 dt=0.1,
-                record_forces=True,
-                snqi_weights=None,
-                snqi_baseline=None,
-                algo=planner,
-                scenario_path=manifest_path,
-                record_planner_decision_trace=False,
-                record_simulation_step_trace=True,
-                policy_builder=_build_policy,
             )
-            # Annotate with run metadata for ranking/analysis scripts
-            rec["population_arm"] = arm
-            rec["planner"] = planner
-            rec["seed"] = seed
-            rec["scenario_id"] = scenario_id
-            rec["response_law_fraction"] = response_law_fraction
-
-            # Make sure scenario params matches too
-            if "scenario_params" not in rec:
-                rec["scenario_params"] = {}
-            rec["scenario_params"]["population_arm"] = arm
-            rec["scenario_params"]["planner"] = planner
-            rec["scenario_params"]["seed"] = seed
-            rec["scenario_params"]["scenario_id"] = scenario_id
-            rec["scenario_params"]["response_law_fraction"] = response_law_fraction
-
             records.append(rec)
         except (RuntimeError, ValueError, KeyError, TypeError, OSError) as e:
             # Narrow the handler (issue #4618 CI-B) to the runtime/config failures a

--- a/tests/benchmark/test_heterogeneous_population_ablation.py
+++ b/tests/benchmark/test_heterogeneous_population_ablation.py
@@ -23,7 +23,11 @@ from robot_sf.benchmark.heterogeneous_population_ablation import (
     build_mean_matched_population_pair,
     build_per_archetype_ablation_report,
 )
+from robot_sf.benchmark.heterogeneous_population_ablation_runner import run_manifest_row
 from robot_sf.benchmark.pedestrian_control_trace import PEDESTRIAN_CONTROL_TRACE_LABELS_KEY
+
+_REPO_ROOT = Path(__file__).parents[2]
+_CLASSIC_CROSSING_MAP = _REPO_ROOT / "maps/svg_maps/classic_crossing.svg"
 
 
 def _archetypes() -> dict[str, ArchetypePopulationSpec]:
@@ -706,4 +710,122 @@ def test_repo_harness_config_manifest_includes_near_field_exposure_metric() -> N
     assert any(
         "near_field_clearance_threshold_m" in key
         for key in first_row["expected_episode_output_keys"]
+    )
+
+
+def _single_cell_manifest_config() -> dict[str, object]:
+    """One paired cell (2 rows) with a small population for a fast runtime capture."""
+
+    return {
+        "trace_metric_keys": ["clearance_m", "near_field_exposure_s"],
+        "planners": [{"key": "goal", "algo": "goal"}],
+        "seeds": [101],
+        "scenarios": [
+            {
+                "id": "issue_3574_classic_crossing_density_002",
+                "density": 0.02,
+                "population_size": 6,
+                "archetype_seed": 3574,
+                "response_law_seed": 3574,
+                "pedestrian_control_trace_near_field_clearance_m": 1.0,
+                "composition": {"cautious": 0.25, "standard": 0.5, "hurried": 0.25},
+                "archetypes": {
+                    "cautious": {"desired_speed_factor": 0.7, "radius_m": 0.35},
+                    "standard": {"desired_speed_factor": 1.0, "radius_m": 0.3},
+                    "hurried": {"desired_speed_factor": 1.4, "radius_m": 0.25},
+                },
+            }
+        ],
+    }
+
+
+def _run_single_cell_records(tmp_path: Path) -> tuple[dict[str, object], list[dict[str, object]]]:
+    """Build the paired manifest and run each row through the real harness path.
+
+    Returns:
+        The manifest and the emitted, campaign-annotated episode records.
+    """
+
+    manifest = build_mean_matched_harness_manifest(_single_cell_manifest_config())
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    manifest_rows = manifest["manifest_rows"]
+    assert isinstance(manifest_rows, list)
+
+    records = [
+        run_manifest_row(
+            row,
+            map_path=_CLASSIC_CROSSING_MAP,
+            scenario_path=manifest_path,
+            horizon=30,
+        )
+        for row in manifest_rows
+    ]
+    return manifest, records
+
+
+@pytest.mark.slow
+def test_harness_emits_control_trace_that_clears_readiness_gate(tmp_path: Path) -> None:
+    """A runtime rerun emits the trace fields the readiness gate demands (issue #5397).
+
+    This exercises the exact SLURM-job-13379 seam end to end: the map-runner harness
+    must attach ``algorithm_metadata.pedestrian_control_trace`` with per-step
+    ``clearance_m`` / ``near_field_exposure_s`` (and its clearance threshold) for both
+    paired arms, so ``assess_mean_matched_episode_records`` reports ``ready`` and the
+    manifest's ``pending_runtime_capture`` state is cleared -- i.e. a real ablation
+    result becomes producible.
+    """
+
+    if not _CLASSIC_CROSSING_MAP.exists():
+        pytest.skip(f"classic crossing map not available at {_CLASSIC_CROSSING_MAP}")
+
+    manifest, records = _run_single_cell_records(tmp_path)
+    assert manifest["status"] == "pending_runtime_capture"
+
+    arms_seen = {record["population_arm"] for record in records}
+    assert arms_seen == {"heterogeneous", "mean_matched_homogeneous"}
+
+    for record in records:
+        trace = record["algorithm_metadata"]["pedestrian_control_trace"]
+        assert trace["near_field_clearance_threshold_m"] == pytest.approx(1.0)
+        assert trace["pedestrians"], "trace must carry per-pedestrian rows"
+        for pedestrian in trace["pedestrians"]:
+            assert pedestrian["steps"], "each pedestrian must carry per-step rows"
+            for step in pedestrian["steps"]:
+                # The two readiness-required per-step metric fields must be present.
+                assert "clearance_m" in step
+                assert "near_field_exposure_s" in step
+                assert math.isfinite(step["clearance_m"])
+                assert math.isfinite(step["near_field_exposure_s"])
+
+    readiness = assess_mean_matched_episode_records(manifest, records)
+    assert readiness["status"] == "ready"
+    assert readiness["ready"] is True
+    assert readiness["blockers"] == []
+    assert readiness["observed_row_count"] == readiness["expected_row_count"] == len(records)
+
+
+@pytest.mark.slow
+def test_harness_emission_readiness_fails_closed_when_trace_dropped(tmp_path: Path) -> None:
+    """Stripping the emitted trace makes the same records fail the readiness gate.
+
+    Proves the ready verdict above is caused by the emitted control trace and not by
+    an unconditional pass: readiness is ``ready=true`` ONLY when the trace is present.
+    """
+
+    if not _CLASSIC_CROSSING_MAP.exists():
+        pytest.skip(f"classic crossing map not available at {_CLASSIC_CROSSING_MAP}")
+
+    manifest, records = _run_single_cell_records(tmp_path)
+
+    # Drop the trace from one arm exactly as job 13379 did (harness produced records
+    # but no control trace) and confirm readiness refuses to report ready.
+    records[0]["algorithm_metadata"].pop("pedestrian_control_trace")
+
+    readiness = assess_mean_matched_episode_records(manifest, records)
+    assert readiness["status"] == "blocked"
+    assert readiness["ready"] is False
+    assert any(
+        f"{EPISODE_CONTROL_TRACE_PATH} missing or not mapping" in blocker
+        for blocker in readiness["blockers"]
     )


### PR DESCRIPTION
## Summary

The #3574 mean-matched response-law harness (issue #5397) could exit 0 with schema-valid paired episode records while its manifest still reported `blocked_pending_control_trace` / `claim_boundary: harness_only_no_ablation_result` — the harness observed no real pedestrian control trace, so the response-law effect could not be attributed.

Tracing the manifest blocker back to the producing code shows the emission machinery and the readiness gate already exist at `main`:

- the map runner attaches `algorithm_metadata.pedestrian_control_trace` with per-step `clearance_m` / `near_field_exposure_s` and its `near_field_clearance_threshold_m` (`robot_positions` wired in via #4489, trace logging via #3633);
- `build_mean_matched_harness_manifest` distinguishes `pending_runtime_capture` (labels present, awaiting a run) from `blocked_pending_control_trace` (labels absent), so with the smoke config the manifest is now `pending_runtime_capture` with **no** control-trace blockers;
- `assess_mean_matched_episode_records` fails closed per row when the trace or a per-step metric field is missing, and AND-ins the manifest contradiction guard.

What was missing was a test covering the **seam** between emission and readiness — the exact gap that let a run produce records with no trace yet still be reported ready by `integration_readiness.json`. This PR closes that seam.

## Changes

- **Extract the runner's scenario-assembly + episode execution** into an importable helper `robot_sf/benchmark/heterogeneous_population_ablation_runner.py` (`build_episode_scenario`, `run_manifest_row`). The campaign runner script now calls it, so the runner and the tests exercise the **same** harness path rather than a parallel test-only reconstruction.
- **End-to-end acceptance test** (`test_harness_emits_control_trace_that_clears_readiness_gate`): builds the paired manifest, runs **both** arms of one cell through the real harness (short horizon, small population — CPU smoke slice, no cluster), asserts the emitted trace carries per-step `clearance_m` / `near_field_exposure_s` (+ threshold) for both arms, then asserts `assess_mean_matched_episode_records` reports `ready=true` with no blockers.
- **Fail-closed test** (`test_harness_emission_readiness_fails_closed_when_trace_dropped`): dropping the emitted trace from one record makes the same records fail readiness — proving `ready=true` is caused by the trace being present, not by an unconditional pass.

## Verification

```
uv run pytest -q tests/benchmark/test_heterogeneous_population_ablation.py   # 40 passed
uv run pytest -q tests/benchmark/test_pedestrian_control_trace.py            # 37 passed
uv run ruff check <changed files>                                           # All checks passed
uv run ruff format --check <changed files>                                  # already formatted
```

The manifest built from `configs/benchmarks/issue_3574_mean_matched_harness_smoke.yaml` is `pending_runtime_capture` with `blockers: []`, and a runtime rerun's emitted records clear the readiness gate (`ready=true`) — so the control-trace blockers are fully satisfiable and a real ablation result is producible.

## Scope

No metric semantics or campaign definition changed. Per the issue's out-of-scope note, the full 72-row campaign rerun remains an ops step under #5346.

Closes #5397

## Follow-Up Issues

- Deferred work: current `origin/main` has an unrelated optional-readiness failure in the runner exception-logging return contract; tracked in #5480.
- Issues opened for follow-up: #5480

## Downstream Propagation

- Parent issue updated (yes/no/NA): NA - this PR completes the #5397 acceptance slice; the gate will post the merge-state update and perform closure duty after merge.
- Claim map / benchmark report updated (yes/no/NA): NA - no metric semantics, campaign definition, or benchmark result is changed.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no campaign artifact or leaderboard row is produced.
- Registry or config index updated (yes/no/NA): NA - no planner/config promotion is claimed.
- Context index / memory note updated (yes/no/NA): NA - the PR adds executable contract proof, not a durable research conclusion.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes - #5480 tracks the unrelated baseline readiness failure.
- Not applicable because: the full 72-row rerun is explicitly an operations step under #5346, while this PR is limited to harness/readiness proof.
