### PR TITLE
feat(benchmark): Chapter 7 case-capsule manifest builder + validator (Refs #5447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #5447 Chapter 7 case-capsule manifest builder (scaffold).** New
+  `robot_sf/benchmark/case_capsules.py` (`ch7_case_capsule_manifest.v1`) assembles the Chapter 7
+  causal-trajectory worked-example set from a *validated* `seed_flip_inversion_candidates.v1`
+  candidate manifest (issue #5446) plus optional causal / online-risk reports (#5441–#5445). It is
+  honest-selection tooling, not a benchmark metric or figure renderer: it fails closed on
+  empty/wrong-schema input, labels archetypes with a missing source candidate or required report
+  `unavailable` (never substituted), grades capsules `descriptive-only` unless a validated causal
+  report is supplied, honours the four-capsule honest floor (`insufficient_evidence` below it), and
+  leaves subjective narrative/figure fields as an `AUTHOR_REQUIRED` sentinel the structural
+  validator reports as `author_pending`. Ships a thin CLI
+  (`scripts/analysis/build_ch7_case_capsules_issue_5447.py`), a frozen selection contract
+  (`configs/analysis/issue_5447_ch7_case_capsules.yaml`), and contract tests. The capsule *set*
+  itself remains blocked on the #5446 candidate manifest, which does not yet exist; see
+  `docs/context/evidence/issue_5447_ch7_case_capsules/README.md`.
+
 * **issue #5468 public collision-risk contact geometry.** Promoted the canonical contact geometry of
   the action-conditioned collision-risk API to a documented public surface:
   `segment_min_distance` (closed-form per-interval minimum centre distance) and `pedestrian_arrays`

--- a/configs/analysis/issue_5447_ch7_case_capsules.yaml
+++ b/configs/analysis/issue_5447_ch7_case_capsules.yaml
@@ -1,0 +1,81 @@
+# Chapter 7 causal-trajectory case-capsule selection contract (issue #5447).
+#
+# Synthesis/selection tooling only. This config declares the capsule archetype
+# targets, the honest floor/ceiling, and the exact build command for the
+# reproducible case-capsule manifest built by
+# `scripts/analysis/build_ch7_case_capsules_issue_5447.py`
+# (backed by `robot_sf/benchmark/case_capsules.py`).
+#
+# It is NOT a benchmark metric and encodes NO planner-ranking claim. Selection
+# thresholds must NOT be tuned after inspecting candidates (issue #5447 forbidden
+# paths: changing selection thresholds; substituting unvalidated rows). The
+# capsule set is built from a *frozen* #5446 candidate manifest at a pinned SHA.
+schema_version: ch7_case_capsule_manifest.v1
+issue: "#5447"
+depends_on:
+  candidate_manifest: "#5446 seed_flip_inversion_candidates.v1 (validated, pinned SHA)"
+  causal_reports: "#5441-#5445 validated causal / online-risk reports where available"
+
+# --- Honest set size (issue #5447 stop rule) ---------------------------------
+selection:
+  # Stop at a smaller honest set if fewer than this many archetypes pass gates.
+  min_capsules: 4
+  # Four to six worked examples; beyond this too many panels reduce explanation.
+  max_capsules: 6
+  # Triage-only (<=3-seed) candidates never silently back a paper-facing capsule.
+  allow_triage: false
+
+# --- Target capsule archetypes (issue #5447 target capsule set) ---------------
+# Each entry names the candidate archetype(s) it draws from and the validated
+# report it requires. Archetypes whose source candidate or required report is
+# missing are labelled `unavailable`, never substituted post hoc.
+archetypes:
+  - key: hard_vs_easy_seed
+    source: [seed_flip]
+    requires_causal: false
+    requires_risk: false
+    is_pair: true
+  - key: strong_fail_weak_success
+    source: [planner_upset]
+    requires_causal: false
+    requires_risk: false
+    is_pair: true
+  - key: paired_first_unsafe_action
+    source: [planner_upset, seed_flip]
+    requires_causal: true # counterfactual claim needs a validated causal report
+    requires_risk: false
+    is_pair: true
+  - key: near_miss_online_risk
+    source: [seed_flip, planner_upset]
+    requires_causal: false
+    requires_risk: true # online-risk panel needs a validated risk report
+    is_pair: false
+  - key: unexpected_recovery
+    source: [seed_flip, planner_upset]
+    requires_causal: false
+    requires_risk: false
+    needs_disagreement: true
+    is_pair: false
+  - key: ambiguous_abstention
+    source: [planner_upset, seed_flip]
+    requires_causal: true
+    requires_risk: false
+    optional: true
+
+# --- Reproducible build command ----------------------------------------------
+# Fill CANDIDATES/CAUSAL/RISK with the pinned frozen-SHA manifest paths once the
+# #5446 candidate manifest exists. Figure rendering is a separate downstream step.
+build_command: >-
+  uv run python scripts/analysis/build_ch7_case_capsules_issue_5447.py
+  --candidates ${CANDIDATE_MANIFEST}
+  --causal ${CAUSAL_REPORTS}
+  --risk ${RISK_REPORTS}
+  --json ${OUTPUT_MANIFEST}
+  --validate
+
+# --- Claim boundary -----------------------------------------------------------
+claim_boundary: >-
+  Capsules are descriptive-only unless a validated causal report is supplied.
+  Author-pending narrative/figure fields (competing explanation, what failed,
+  generalisation limits, marked times) must be completed and an independent
+  pinned-SHA visual/evidence review recorded before dissertation integration.

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -4268,3 +4268,7 @@ entries:
   status: evidence
   freshness: evidence
   area: reproducibility
+- path: docs/context/evidence/issue_5447_ch7_case_capsules/README.md
+  status: proposal
+  freshness: dated
+  area: benchmark_evidence

--- a/docs/context/evidence/issue_5447_ch7_case_capsules/README.md
+++ b/docs/context/evidence/issue_5447_ch7_case_capsules/README.md
@@ -1,0 +1,79 @@
+# Issue #5447 — Chapter 7 causal-trajectory case capsules (builder scaffold)
+
+**Status:** builder/schema/validator delivered; **capsule set is blocked on data**
+(the validated #5446 candidate manifest does not exist yet). Evidence grade:
+`diagnostic-only` tooling — no benchmark or paper-facing claim is made here.
+
+## What this slice delivers
+
+A reproducible, fail-closed **case-capsule manifest builder** for the Chapter 7
+worked examples:
+
+- `robot_sf/benchmark/case_capsules.py` — builder + structural validator.
+  Emits a `ch7_case_capsule_manifest.v1` from a *validated*
+  `seed_flip_inversion_candidates.v1` candidate manifest (issue #5446) plus
+  optional causal / online-risk reports (issues #5441–#5445).
+- `scripts/analysis/build_ch7_case_capsules_issue_5447.py` — thin CLI.
+- `configs/analysis/issue_5447_ch7_case_capsules.yaml` — frozen selection
+  contract (archetype targets, honest floor/ceiling, build command).
+- `tests/benchmark/test_case_capsules_issue_5447.py` — contract tests.
+
+## Honesty contract (issue #5447)
+
+- **Fail closed.** An empty / wrong-schema / candidate-free manifest raises
+  `CaseCapsuleError`. Fewer than `min_capsules` admissible archetypes →
+  `status: insufficient_evidence` (stop at a smaller honest set; do not broaden).
+- **Never fabricate.** An archetype whose source candidate or required
+  causal/risk report is missing is emitted `status: unavailable` with a concrete
+  reason — never replaced by an attractive unvalidated row.
+- **Descriptive-only unless validated causal report.** Causal labels come only
+  from a supplied validated causal report; otherwise the capsule is graded
+  `descriptive-only` and its caption must say so. Risk archetypes require a
+  validated online-risk report or they are `unavailable`.
+- **Author-pending, not fabricated, narrative.** Subjective fields (competing
+  explanation, what failed, generalisation limits, marked times, "why this time
+  matters") are set to the `AUTHOR_REQUIRED` sentinel and reported by the
+  validator as `author_pending` — structurally valid, honestly incomplete.
+- **Input-hash provenance.** The emitted manifest records the canonical SHA-256
+  of the candidate manifest so the capsule set is pinned to its inputs.
+
+## Why the capsule set itself is not built here
+
+Per the issue-#5447 dependency (`Depends on: validated candidate manifest from
+#5446; causal/risk reports from #5441–#5445 where available`) and the maintainer
+triage comment (2026-07-13), the frozen `seed_flip_inversion_candidates.v1`
+candidate manifest **does not yet exist**: the #5446 slice (PR #5466) delivered
+only the miner *tooling*; running it on a real eligible native-execution campaign
+table is the remaining blocker there. Building capsules from fabricated or
+degraded rows is forbidden. This slice therefore delivers the reproducible
+builder/validator so the capsule set drops out deterministically the moment the
+pinned candidate manifest exists.
+
+## Reproducible build command (once inputs exist)
+
+```bash
+uv run python scripts/analysis/build_ch7_case_capsules_issue_5447.py \
+    --candidates ${CANDIDATE_MANIFEST} \
+    --causal ${CAUSAL_REPORTS} \
+    --risk ${RISK_REPORTS} \
+    --json output/issue_5447/ch7_capsules.json \
+    --validate
+```
+
+## Validation performed
+
+```bash
+uv run pytest -q tests -k 'case_capsule or trajectory_visualization'
+git diff --check
+```
+
+## Remaining work (blocked / downstream)
+
+1. **Blocked on #5446:** a pinned `seed_flip_inversion_candidates.v1` manifest
+   from a real eligible native-execution campaign table.
+2. **Blocked on #5441–#5445:** validated causal / online-risk reports (otherwise
+   causal/risk archetypes stay `unavailable`; non-causal capsules are
+   `descriptive-only`).
+3. **Downstream:** vector-figure rendering from pinned episode trajectories
+   (reuse `robot_sf/benchmark/figures`), author-field completion, and the
+   independent frozen-SHA visual/evidence review before dissertation integration.

--- a/docs/context/evidence/issue_5447_ch7_case_capsules/README.md
+++ b/docs/context/evidence/issue_5447_ch7_case_capsules/README.md
@@ -1,3 +1,4 @@
+<!-- AI-GENERATED (robot_sf#5478, 2026-07-13) - NEEDS-REVIEW -->
 # Issue #5447 — Chapter 7 causal-trajectory case capsules (builder scaffold)
 
 **Status:** builder/schema/validator delivered; **capsule set is blocked on data**
@@ -77,3 +78,5 @@ git diff --check
 3. **Downstream:** vector-figure rendering from pinned episode trajectories
    (reuse `robot_sf/benchmark/figures`), author-field completion, and the
    independent frozen-SHA visual/evidence review before dissertation integration.
+
+<!-- /AI-GENERATED -->

--- a/robot_sf/benchmark/case_capsules.py
+++ b/robot_sf/benchmark/case_capsules.py
@@ -1,0 +1,739 @@
+"""Pinned Chapter 7 causal-trajectory *case-capsule* manifest builder (issue #5447).
+
+This module assembles a **reproducible case-capsule manifest** for the Chapter 7
+worked examples from a *validated* candidate manifest (the
+``seed_flip_inversion_candidates.v1`` output of the issue #5446 miner,
+:mod:`robot_sf.benchmark.seed_flip_mining`) plus optional causal / online-risk
+reports (issues #5441-#5445).
+
+Design contract (issue #5447)
+-----------------------------
+It is synthesis/selection tooling, **not** a benchmark metric and **not** a
+figure renderer. It answers one question honestly: *given the candidates that
+actually passed the evidence gates, which diverse worked-example archetypes can
+Chapter 7 support, and what remains unavailable?* It deliberately avoids the two
+failure modes the issue calls out:
+
+1. **Never fabricate.** A capsule archetype whose source candidate or required
+   causal/risk report is missing is emitted with ``status = "unavailable"`` and a
+   concrete reason. Unavailable archetypes are labelled unavailable — never
+   replaced post hoc by an attractive but unvalidated row.
+2. **Descriptive-only unless a validated causal report exists.** Causal labels
+   come only from a supplied validated causal report; otherwise the capsule is
+   graded ``descriptive-only`` and its caption must say so.
+3. **Fail closed.** An empty / wrong-schema / candidate-free manifest raises
+   :class:`CaseCapsuleError` rather than emitting an empty capsule set. When
+   fewer than ``min_capsules`` archetypes are admissible the manifest reports
+   ``status = "insufficient_evidence"`` per the issue stop rule (stop at a
+   smaller honest set; do not broaden claims).
+4. **Author-pending, not fabricated, narrative.** Fields that require a human
+   writer (competing explanation, what-failed, generalisation limits, the marked
+   times and "why this time matters" text) are set to the :data:`AUTHOR_REQUIRED`
+   sentinel and reported by the validator as ``author_pending`` — structurally
+   valid, honestly incomplete. Mechanically derivable fields (source planner,
+   seeds, archetype rationale) are filled from the candidate record.
+
+The builder consumes a candidate manifest *dict* (already frozen at a pinned SHA
+by the #5446 miner); it does not run benchmarks and does not read episode
+artefacts. Actual vector-figure rendering from pinned episode trajectories is a
+downstream step that reuses :mod:`robot_sf.benchmark.figures`; this module only
+produces the machine-readable capsule manifest and its input-hash provenance so
+that rendering step is reproducible.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+#: Schema tag for the emitted case-capsule manifest.
+SCHEMA_VERSION = "ch7_case_capsule_manifest.v1"
+
+#: Schema tag of the candidate manifest this builder consumes (issue #5446).
+CANDIDATE_SCHEMA_VERSION = "seed_flip_inversion_candidates.v1"
+
+#: Sentinel for a field that a human writer must supply before dissertation
+#: integration. It is never fabricated by the builder; the validator reports every
+#: remaining sentinel as ``author_pending`` (expected, not a structural failure).
+AUTHOR_REQUIRED = "AUTHOR_REQUIRED"
+
+#: Ordered evidence grades, strongest first. ``unavailable`` is reserved for
+#: capsule slots that could not be sourced at all.
+EVIDENCE_GRADES = ("causal", "descriptive-risk", "descriptive-only", "unavailable")
+
+#: Default honest floor for a usable capsule set (issue #5447 stop rule: stop at
+#: a smaller honest set if fewer than four archetypes pass the evidence gates).
+DEFAULT_MIN_CAPSULES = 4
+
+#: Optional ceiling on the number of capsules (issue #5447: four to six).
+DEFAULT_MAX_CAPSULES = 6
+
+#: Required keys of a pair-comparison shared-axis specification. Pair capsules
+#: must render with identical axes / crop / palette / time markers / scales.
+SHARED_AXIS_KEYS = (
+    "axes_limits",
+    "map_crop",
+    "palette",
+    "time_markers",
+    "metric_risk_scale",
+)
+
+#: Required keys of a probability (online-risk) panel (issue #5447 acceptance).
+PROBABILITY_PANEL_KEYS = (
+    "horizon",
+    "conditioning_action",
+    "estimator_version",
+    "calibration_status",
+    "uncertainty",
+)
+
+#: Narrative fields every admitted capsule must carry (issue #5447 acceptance:
+#: why selected, what went well, what failed, competing explanation, evidence
+#: grade, generalisation limits).
+NARRATIVE_KEYS = (
+    "selection_rationale",
+    "what_went_well",
+    "what_failed",
+    "competing_explanation",
+    "evidence_grade",
+    "generalization_limits",
+)
+
+
+class CaseCapsuleError(ValueError):
+    """Raised when a defensible case-capsule manifest cannot be built."""
+
+
+@dataclass(frozen=True)
+class CapsuleArchetypeSpec:
+    """Declarative spec for one Chapter 7 capsule archetype (issue #5447).
+
+    Attributes:
+        key: Stable archetype identifier used in the emitted manifest.
+        title: Human-facing archetype description.
+        source_archetypes: Candidate-manifest archetypes this capsule may draw
+            from, in preference order.
+        requires_causal: The archetype's defining claim is causal; without a
+            validated causal report it is ``unavailable`` (not descriptive-only).
+        requires_risk: The archetype needs an online-risk report; without one it
+            is ``unavailable``.
+        needs_disagreement: The source candidate must carry non-zero cross-planner
+            disagreement entropy (recovery / critical-interval archetype).
+        is_pair: The capsule is a paired comparison and needs a shared-axis spec.
+        optional: The archetype is optional (issue #5447 sixth capsule); its
+            absence does not by itself fail the set.
+    """
+
+    key: str
+    title: str
+    source_archetypes: tuple[str, ...]
+    requires_causal: bool = False
+    requires_risk: bool = False
+    needs_disagreement: bool = False
+    is_pair: bool = False
+    optional: bool = False
+
+
+#: The issue #5447 target capsule set, in order. Maps each desired worked-example
+#: archetype to the candidate archetypes and reports it requires.
+CH7_CAPSULE_ARCHETYPES: tuple[CapsuleArchetypeSpec, ...] = (
+    CapsuleArchetypeSpec(
+        key="hard_vs_easy_seed",
+        title="hard versus easy seed for the same planner/scenario",
+        source_archetypes=("seed_flip",),
+        is_pair=True,
+    ),
+    CapsuleArchetypeSpec(
+        key="strong_fail_weak_success",
+        title="held-out strong-planner failure versus weak-planner success",
+        source_archetypes=("planner_upset",),
+        is_pair=True,
+    ),
+    CapsuleArchetypeSpec(
+        key="paired_first_unsafe_action",
+        title="paired approach with different first unsafe action and counterfactual",
+        source_archetypes=("planner_upset", "seed_flip"),
+        requires_causal=True,
+        is_pair=True,
+    ),
+    CapsuleArchetypeSpec(
+        key="near_miss_online_risk",
+        title="near miss where online risk distinguishes candidate actions early",
+        source_archetypes=("seed_flip", "planner_upset"),
+        requires_risk=True,
+    ),
+    CapsuleArchetypeSpec(
+        key="unexpected_recovery",
+        title="unexpected recovery or critical-interval/aggregate disagreement",
+        source_archetypes=("seed_flip", "planner_upset"),
+        needs_disagreement=True,
+    ),
+    CapsuleArchetypeSpec(
+        key="ambiguous_abstention",
+        title="optional ambiguous multi-actor case whose correct causal output is abstention",
+        source_archetypes=("planner_upset", "seed_flip"),
+        requires_causal=True,
+        optional=True,
+    ),
+)
+
+
+def canonical_sha256(obj: Any) -> str:
+    """Deterministic SHA-256 of a JSON-serialisable object.
+
+    Uses sorted keys and compact separators so the same logical manifest always
+    hashes identically regardless of dict insertion order.
+
+    Returns:
+        The hex digest string.
+    """
+    payload = json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _validate_candidate_manifest(manifest: Any) -> list[dict[str, Any]]:
+    """Fail-closed check of the incoming candidate manifest; return its candidates.
+
+    Returns:
+        The list of candidate records.
+
+    Raises:
+        CaseCapsuleError: When the manifest is not a dict, carries the wrong
+            schema version, or contains no candidate records.
+    """
+    if not isinstance(manifest, dict):
+        raise CaseCapsuleError(f"candidate manifest must be a dict, got {type(manifest).__name__}")
+    schema = manifest.get("schema_version")
+    if schema != CANDIDATE_SCHEMA_VERSION:
+        raise CaseCapsuleError(
+            f"candidate manifest schema mismatch: expected {CANDIDATE_SCHEMA_VERSION!r}, "
+            f"got {schema!r}. Build capsules only from a #5446 validated candidate manifest."
+        )
+    candidates = manifest.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise CaseCapsuleError(
+            "candidate manifest has no candidates; refusing to build capsules from empty "
+            "evidence (fail closed rather than fabricate a capsule set)"
+        )
+    return candidates
+
+
+def _report_ref(reports: dict[str, Any] | None, *keys: str) -> Any:
+    """Return the first matching validated report for ``keys`` or ``None``.
+
+    ``reports`` maps a candidate id or scenario id to a validated report payload.
+    A missing table or missing key yields ``None`` (never fabricated).
+
+    Returns:
+        The report payload, or ``None`` when unavailable.
+    """
+    if not isinstance(reports, dict):
+        return None
+    for key in keys:
+        if key in reports and reports[key] is not None:
+            return reports[key]
+    return None
+
+
+def _candidate_sort_key(cand: dict[str, Any]) -> tuple[int, int, float, float]:
+    """Rank a candidate for capsule sourcing (higher is better, so negate).
+
+    Prefers selected (Pareto-frontier) candidates, non-triage cells, larger
+    disagreement entropy, and larger effective evidence.
+
+    Returns:
+        A tuple usable as a ``sorted`` key (ascending -> best first via negation).
+    """
+    flip = cand.get("seed_flip") or {}
+    return (
+        0 if cand.get("selected") else 1,
+        0 if not cand.get("triage_only") else 1,
+        -float(cand.get("cross_planner_disagreement_entropy") or 0.0),
+        -float(flip.get("effective_denominator") or 0.0),
+    )
+
+
+def _pick_candidate(
+    spec: CapsuleArchetypeSpec,
+    candidates: list[dict[str, Any]],
+    used: set[str],
+    *,
+    allow_triage: bool,
+) -> dict[str, Any] | None:
+    """Choose the best unused candidate that can source ``spec`` or ``None``.
+
+    Returns:
+        The chosen candidate record, or ``None`` when no eligible source exists.
+    """
+    pool = [
+        c
+        for c in candidates
+        if c.get("candidate_id") not in used
+        and c.get("archetype") in spec.source_archetypes
+        and (allow_triage or not c.get("triage_only"))
+        and (
+            not spec.needs_disagreement
+            or float(c.get("cross_planner_disagreement_entropy") or 0.0) > 0.0
+        )
+    ]
+    if not pool:
+        return None
+    return sorted(pool, key=_candidate_sort_key)[0]
+
+
+def _shared_axis_spec() -> dict[str, str]:
+    """Return an author-required shared-axis spec skeleton for pair capsules.
+
+    Returns:
+        A mapping whose keys are :data:`SHARED_AXIS_KEYS`, each set to the
+        :data:`AUTHOR_REQUIRED` sentinel.
+    """
+    return dict.fromkeys(SHARED_AXIS_KEYS, AUTHOR_REQUIRED)
+
+
+def _probability_panel() -> dict[str, str]:
+    """Return an author-required online-risk probability-panel skeleton.
+
+    Returns:
+        A mapping whose keys are :data:`PROBABILITY_PANEL_KEYS`, each set to the
+        :data:`AUTHOR_REQUIRED` sentinel.
+    """
+    return dict.fromkeys(PROBABILITY_PANEL_KEYS, AUTHOR_REQUIRED)
+
+
+def _figure_spec(spec: CapsuleArchetypeSpec) -> dict[str, Any]:
+    """Build the reproducible figure specification for a capsule.
+
+    Every capsule requires a static map, metre scale, full robot/dynamic-object
+    trajectories, common marked times, and actor footprints at those times
+    (issue #5447 acceptance). Pair capsules additionally require a shared-axis
+    spec so both panels render identically.
+
+    Returns:
+        The figure-spec mapping.
+    """
+    return {
+        "static_map_required": True,
+        "metre_scale_required": True,
+        "trajectory_sources_required": True,
+        "actor_footprints_at_marked_times_required": True,
+        "marked_times": AUTHOR_REQUIRED,
+        "why_this_time_matters": AUTHOR_REQUIRED,
+        "shared_axis_spec": _shared_axis_spec() if spec.is_pair else None,
+    }
+
+
+def _selection_rationale(spec: CapsuleArchetypeSpec, cand: dict[str, Any]) -> str:
+    """Mechanically derive a selection rationale from the source candidate.
+
+    Returns:
+        A one-line rationale string (data-derived, not fabricated narrative).
+    """
+    return (
+        f"{spec.title}: sourced from {cand.get('archetype')} candidate "
+        f"{cand.get('candidate_id')} (scenario={cand.get('scenario_id')}, "
+        f"planner={cand.get('planner')}, "
+        f"selected={bool(cand.get('selected'))}, triage_only={bool(cand.get('triage_only'))})."
+    )
+
+
+def _build_admitted_capsule(
+    spec: CapsuleArchetypeSpec,
+    cand: dict[str, Any],
+    *,
+    grade: str,
+    causal_report: Any,
+    risk_report: Any,
+) -> dict[str, Any]:
+    """Assemble an admitted capsule record from a resolved candidate.
+
+    Returns:
+        The capsule record dict.
+    """
+    narrative = {
+        "selection_rationale": _selection_rationale(spec, cand),
+        "what_went_well": AUTHOR_REQUIRED,
+        "what_failed": AUTHOR_REQUIRED,
+        "competing_explanation": AUTHOR_REQUIRED,
+        "evidence_grade": grade,
+        "generalization_limits": AUTHOR_REQUIRED,
+    }
+    return {
+        "capsule_id": f"ch7::{spec.key}",
+        "archetype": spec.key,
+        "title": spec.title,
+        "status": "admitted",
+        "optional": spec.optional,
+        "evidence_grade": grade,
+        "is_pair": spec.is_pair,
+        "source_candidate_id": cand.get("candidate_id"),
+        "source_archetype": cand.get("archetype"),
+        "scenario_id": cand.get("scenario_id"),
+        "planner": cand.get("planner"),
+        "triage_only": bool(cand.get("triage_only")),
+        "figure_spec": _figure_spec(spec),
+        "probability_panel": _probability_panel() if spec.requires_risk else None,
+        # Causal labels only from a validated causal report; otherwise descriptive.
+        "causal_label": (
+            {"status": "validated", "report_ref": causal_report}
+            if causal_report is not None
+            else "descriptive-only"
+        ),
+        "risk_report_ref": risk_report if risk_report is not None else None,
+        "narrative": narrative,
+        "source_provenance": {
+            "candidate_id": cand.get("candidate_id"),
+            "scenario_id": cand.get("scenario_id"),
+            "planner": cand.get("planner"),
+            "reproducibility": cand.get("reproducibility"),
+            "seed_flip": cand.get("seed_flip"),
+            "upset_outcome": cand.get("upset_outcome"),
+        },
+    }
+
+
+def _unavailable_capsule(spec: CapsuleArchetypeSpec, reason: str) -> dict[str, Any]:
+    """Build an ``unavailable`` capsule slot with a concrete reason.
+
+    Returns:
+        The unavailable-capsule record dict.
+    """
+    return {
+        "capsule_id": f"ch7::{spec.key}",
+        "archetype": spec.key,
+        "title": spec.title,
+        "status": "unavailable",
+        "optional": spec.optional,
+        "evidence_grade": "unavailable",
+        "reason": reason,
+    }
+
+
+def _resolve_capsule(
+    spec: CapsuleArchetypeSpec,
+    candidates: list[dict[str, Any]],
+    used: set[str],
+    *,
+    causal_reports: dict[str, Any] | None,
+    risk_reports: dict[str, Any] | None,
+    allow_triage: bool,
+) -> dict[str, Any]:
+    """Resolve one capsule archetype to an admitted or unavailable slot.
+
+    Order of checks (fail closed): a source candidate must exist; a causal-defined
+    archetype needs a validated causal report; a risk archetype needs a risk
+    report. Any missing input yields an ``unavailable`` slot with a reason rather
+    than a fabricated capsule.
+
+    Returns:
+        The resolved capsule record dict.
+    """
+    cand = _pick_candidate(spec, candidates, used, allow_triage=allow_triage)
+    if cand is None:
+        return _unavailable_capsule(spec, f"no_source_candidate:{'|'.join(spec.source_archetypes)}")
+
+    causal_report = _report_ref(
+        causal_reports, str(cand.get("candidate_id")), str(cand.get("scenario_id"))
+    )
+    risk_report = _report_ref(
+        risk_reports, str(cand.get("candidate_id")), str(cand.get("scenario_id"))
+    )
+
+    if spec.requires_causal and causal_report is None:
+        return _unavailable_capsule(spec, "causal_report_unavailable")
+    if spec.requires_risk and risk_report is None:
+        return _unavailable_capsule(spec, "risk_report_unavailable")
+
+    if spec.requires_causal:
+        grade = "causal"
+    elif spec.requires_risk:
+        grade = "descriptive-risk"
+    else:
+        grade = "descriptive-only"
+
+    used.add(str(cand.get("candidate_id")))
+    return _build_admitted_capsule(
+        spec, cand, grade=grade, causal_report=causal_report, risk_report=risk_report
+    )
+
+
+def build_ch7_case_capsule_manifest(
+    candidate_manifest: dict[str, Any],
+    *,
+    causal_reports: dict[str, Any] | None = None,
+    risk_reports: dict[str, Any] | None = None,
+    archetypes: tuple[CapsuleArchetypeSpec, ...] = CH7_CAPSULE_ARCHETYPES,
+    min_capsules: int = DEFAULT_MIN_CAPSULES,
+    max_capsules: int = DEFAULT_MAX_CAPSULES,
+    allow_triage: bool = False,
+) -> dict[str, Any]:
+    """Build a pinned Chapter 7 case-capsule manifest from a candidate manifest.
+
+    Args:
+        candidate_manifest: A validated ``seed_flip_inversion_candidates.v1``
+            manifest (issue #5446 miner output). Frozen at a pinned SHA by the
+            caller; its canonical hash is recorded for provenance.
+        causal_reports: Optional mapping from candidate id / scenario id to a
+            *validated* causal report (issues #5441-#5445). Absent reports leave
+            causal-requiring archetypes ``unavailable`` and non-causal capsules
+            ``descriptive-only``.
+        risk_reports: Optional mapping from candidate id / scenario id to a
+            validated online-risk report. Absent reports leave risk-requiring
+            archetypes ``unavailable``.
+        archetypes: The ordered capsule archetype specs to resolve.
+        min_capsules: Honest floor; below it the manifest is
+            ``insufficient_evidence`` (issue #5447 stop rule).
+        max_capsules: Ceiling; admitted capsules beyond it are flagged
+            ``over_capacity`` rather than silently dropped.
+        allow_triage: Permit triage-only (<= 3-seed) candidates as sources. Off by
+            default so triage candidates never silently back a paper-facing capsule.
+
+    Returns:
+        A schema-versioned case-capsule manifest dict.
+
+    Raises:
+        CaseCapsuleError: When the candidate manifest fails the fail-closed gate
+            (wrong type/schema or no candidates) or ``min_capsules`` is invalid.
+    """
+    if min_capsules < 1:
+        raise CaseCapsuleError(f"min_capsules must be >= 1, got {min_capsules}")
+    candidates = _validate_candidate_manifest(candidate_manifest)
+
+    used: set[str] = set()
+    capsules = [
+        _resolve_capsule(
+            spec,
+            candidates,
+            used,
+            causal_reports=causal_reports,
+            risk_reports=risk_reports,
+            allow_triage=allow_triage,
+        )
+        for spec in archetypes
+    ]
+
+    admitted = [c for c in capsules if c["status"] == "admitted"]
+    # A capsule beyond the ceiling is a signal that the set is too large (issue
+    # #5447 competing explanation: too many panels reduce explanation quality).
+    for capsule in admitted[max_capsules:]:
+        capsule["over_capacity"] = True
+
+    n_admitted = len(admitted)
+    if n_admitted < min_capsules:
+        status = "insufficient_evidence"
+    elif n_admitted > max_capsules:
+        status = "over_capacity"
+    else:
+        status = "ok"
+
+    unavailable = [c for c in capsules if c["status"] == "unavailable"]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": "#5447",
+        "status": status,
+        "claim_boundary": (
+            "Synthesis/selection tooling: assembles Chapter 7 case-capsule slots from a "
+            "validated #5446 candidate manifest. Not a benchmark metric, not a figure "
+            "renderer, not a planner-ranking claim. Capsules are descriptive-only unless a "
+            "validated causal report is supplied; unavailable archetypes are labelled "
+            "unavailable, never substituted. Author-pending narrative/figure fields must be "
+            "completed and an independent pinned-SHA review recorded before dissertation use."
+        ),
+        "stop_rule": (
+            "Stop at a smaller honest set if fewer than "
+            f"{min_capsules} archetypes pass the evidence gates; do not broaden claims or "
+            "substitute unvalidated rows."
+        ),
+        "params": {
+            "min_capsules": min_capsules,
+            "max_capsules": max_capsules,
+            "allow_triage": allow_triage,
+            "n_archetypes_requested": len(archetypes),
+        },
+        "inputs": {
+            "candidate_manifest_schema": candidate_manifest.get("schema_version"),
+            "candidate_manifest_issue": candidate_manifest.get("issue"),
+            "candidate_manifest_sha256": canonical_sha256(candidate_manifest),
+            "n_candidates": len(candidates),
+            "causal_reports_provided": bool(causal_reports),
+            "risk_reports_provided": bool(risk_reports),
+        },
+        "summary": {
+            "n_capsules_requested": len(archetypes),
+            "n_admitted": n_admitted,
+            "n_unavailable": len(unavailable),
+            "admitted_archetypes": [c["archetype"] for c in admitted],
+            "unavailable_archetypes": [c["archetype"] for c in unavailable],
+            "evidence_grades": {c["archetype"]: c["evidence_grade"] for c in admitted},
+            "meets_min_capsules": n_admitted >= min_capsules,
+        },
+        "capsules": capsules,
+    }
+
+
+@dataclass
+class CaseCapsuleValidation:
+    """Result of validating a case-capsule manifest.
+
+    Attributes:
+        structural_violations: Hard problems that make the manifest malformed.
+        author_pending: Expected-but-incomplete author fields (sentinels) that
+            must be filled before dissertation integration; not a structural fail.
+    """
+
+    structural_violations: list[str] = field(default_factory=list)
+    author_pending: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """Whether the manifest is structurally valid (author fields may pend).
+
+        Returns:
+            ``True`` when there are no structural violations.
+        """
+        return not self.structural_violations
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable summary of the validation.
+
+        Returns:
+            Mapping with ``ok``, ``structural_violations``, and ``author_pending``.
+        """
+        return {
+            "ok": self.ok,
+            "structural_violations": list(self.structural_violations),
+            "author_pending": list(self.author_pending),
+        }
+
+
+def _check_keys(
+    container: Any,
+    keys: tuple[str, ...],
+    *,
+    cid: str,
+    label: str,
+    violations: list[str],
+    pending: list[str],
+) -> None:
+    """Check that ``container`` is a dict carrying ``keys``; sort missing vs pending.
+
+    Missing keys are structural violations; keys still set to :data:`AUTHOR_REQUIRED`
+    are recorded as author-pending (expected, not a failure).
+    """
+    if not isinstance(container, dict):
+        violations.append(f"{cid}: missing {label} block")
+        return
+    for key in keys:
+        if key not in container:
+            violations.append(f"{cid}: {label} missing {key!r}")
+        elif container[key] == AUTHOR_REQUIRED:
+            pending.append(f"{cid}: {label}.{key} author-required")
+
+
+def _validate_capsule_figure(
+    capsule: dict[str, Any],
+    cid: str,
+    violations: list[str],
+    pending: list[str],
+) -> None:
+    """Validate an admitted capsule's figure spec (map/scale/marked-times/pairs)."""
+    figure = capsule.get("figure_spec")
+    if not isinstance(figure, dict):
+        violations.append(f"{cid}: missing figure_spec")
+        return
+    if not figure.get("static_map_required") or not figure.get("metre_scale_required"):
+        violations.append(f"{cid}: figure_spec must require a static map and metre scale")
+    for key in ("marked_times", "why_this_time_matters"):
+        if figure.get(key) == AUTHOR_REQUIRED:
+            pending.append(f"{cid}: figure_spec.{key} author-required")
+    if capsule.get("is_pair"):
+        _check_keys(
+            figure.get("shared_axis_spec"),
+            SHARED_AXIS_KEYS,
+            cid=cid,
+            label="shared_axis_spec",
+            violations=violations,
+            pending=pending,
+        )
+
+
+def _validate_admitted_capsule(
+    capsule: dict[str, Any],
+    violations: list[str],
+    pending: list[str],
+) -> None:
+    """Validate one admitted capsule, appending structural / author-pending notes."""
+    cid = capsule.get("capsule_id", "<unknown>")
+
+    if capsule.get("evidence_grade") not in EVIDENCE_GRADES:
+        violations.append(f"{cid}: invalid evidence_grade {capsule.get('evidence_grade')!r}")
+
+    _check_keys(
+        capsule.get("narrative"),
+        NARRATIVE_KEYS,
+        cid=cid,
+        label="narrative",
+        violations=violations,
+        pending=pending,
+    )
+    _validate_capsule_figure(capsule, cid, violations, pending)
+
+    if capsule.get("evidence_grade") == "descriptive-risk":
+        _check_keys(
+            capsule.get("probability_panel"),
+            PROBABILITY_PANEL_KEYS,
+            cid=cid,
+            label="probability_panel",
+            violations=violations,
+            pending=pending,
+        )
+
+    if (
+        capsule.get("evidence_grade") == "causal"
+        and capsule.get("causal_label") == "descriptive-only"
+    ):
+        violations.append(f"{cid}: causal grade but no validated causal_label")
+
+
+def validate_ch7_case_capsule_manifest(manifest: dict[str, Any]) -> CaseCapsuleValidation:
+    """Structurally validate a case-capsule manifest against the issue #5447 gates.
+
+    Structural violations mark a malformed manifest. ``author_pending`` entries
+    are the expected sentinels for narrative / figure fields a human writer must
+    complete; they do not make the manifest invalid.
+
+    Returns:
+        A :class:`CaseCapsuleValidation` with the two lists and an ``ok`` flag.
+    """
+    violations: list[str] = []
+    pending: list[str] = []
+
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        violations.append(
+            f"schema_version mismatch: expected {SCHEMA_VERSION!r}, "
+            f"got {manifest.get('schema_version')!r}"
+        )
+
+    capsules = manifest.get("capsules")
+    if not isinstance(capsules, list) or not capsules:
+        violations.append("manifest has no capsules")
+        return CaseCapsuleValidation(violations, pending)
+
+    for capsule in capsules:
+        status = capsule.get("status")
+        if status == "unavailable":
+            if not capsule.get("reason"):
+                violations.append(
+                    f"{capsule.get('capsule_id', '<unknown>')}: unavailable capsule needs a reason"
+                )
+            continue
+        if status != "admitted":
+            violations.append(
+                f"{capsule.get('capsule_id', '<unknown>')}: unknown capsule status {status!r}"
+            )
+            continue
+        _validate_admitted_capsule(capsule, violations, pending)
+
+    return CaseCapsuleValidation(violations, pending)

--- a/robot_sf/benchmark/case_capsules.py
+++ b/robot_sf/benchmark/case_capsules.py
@@ -43,6 +43,7 @@ that rendering step is reproducible.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 from dataclasses import dataclass, field
@@ -217,6 +218,11 @@ def _validate_candidate_manifest(manifest: Any) -> list[dict[str, Any]]:
             "candidate manifest has no candidates; refusing to build capsules from empty "
             "evidence (fail closed rather than fabricate a capsule set)"
         )
+    if not all(isinstance(candidate, dict) for candidate in candidates):
+        raise CaseCapsuleError(
+            "candidate manifest contains non-dict candidate records; refusing to build capsules "
+            "from malformed evidence"
+        )
     return candidates
 
 
@@ -246,7 +252,9 @@ def _candidate_sort_key(cand: dict[str, Any]) -> tuple[int, int, float, float]:
     Returns:
         A tuple usable as a ``sorted`` key (ascending -> best first via negation).
     """
-    flip = cand.get("seed_flip") or {}
+    flip = cand.get("seed_flip")
+    if not isinstance(flip, dict):
+        flip = {}
     return (
         0 if cand.get("selected") else 1,
         0 if not cand.get("triage_only") else 1,
@@ -377,19 +385,19 @@ def _build_admitted_capsule(
         "probability_panel": _probability_panel() if spec.requires_risk else None,
         # Causal labels only from a validated causal report; otherwise descriptive.
         "causal_label": (
-            {"status": "validated", "report_ref": causal_report}
+            {"status": "validated", "report_ref": copy.deepcopy(causal_report)}
             if causal_report is not None
             else "descriptive-only"
         ),
-        "risk_report_ref": risk_report if risk_report is not None else None,
+        "risk_report_ref": copy.deepcopy(risk_report) if risk_report is not None else None,
         "narrative": narrative,
         "source_provenance": {
             "candidate_id": cand.get("candidate_id"),
             "scenario_id": cand.get("scenario_id"),
             "planner": cand.get("planner"),
-            "reproducibility": cand.get("reproducibility"),
-            "seed_flip": cand.get("seed_flip"),
-            "upset_outcome": cand.get("upset_outcome"),
+            "reproducibility": copy.deepcopy(cand.get("reproducibility")),
+            "seed_flip": copy.deepcopy(cand.get("seed_flip")),
+            "upset_outcome": copy.deepcopy(cand.get("upset_outcome")),
         },
     }
 
@@ -434,11 +442,15 @@ def _resolve_capsule(
     if cand is None:
         return _unavailable_capsule(spec, f"no_source_candidate:{'|'.join(spec.source_archetypes)}")
 
-    causal_report = _report_ref(
-        causal_reports, str(cand.get("candidate_id")), str(cand.get("scenario_id"))
+    causal_report = (
+        _report_ref(causal_reports, str(cand.get("candidate_id")), str(cand.get("scenario_id")))
+        if spec.requires_causal
+        else None
     )
-    risk_report = _report_ref(
-        risk_reports, str(cand.get("candidate_id")), str(cand.get("scenario_id"))
+    risk_report = (
+        _report_ref(risk_reports, str(cand.get("candidate_id")), str(cand.get("scenario_id")))
+        if spec.requires_risk
+        else None
     )
 
     if spec.requires_causal and causal_report is None:
@@ -499,6 +511,12 @@ def build_ch7_case_capsule_manifest(
     """
     if min_capsules < 1:
         raise CaseCapsuleError(f"min_capsules must be >= 1, got {min_capsules}")
+    if causal_reports is not None and not isinstance(causal_reports, dict):
+        raise CaseCapsuleError(
+            f"causal_reports must be a dict, got {type(causal_reports).__name__}"
+        )
+    if risk_reports is not None and not isinstance(risk_reports, dict):
+        raise CaseCapsuleError(f"risk_reports must be a dict, got {type(risk_reports).__name__}")
     candidates = _validate_candidate_manifest(candidate_manifest)
 
     used: set[str] = set()
@@ -643,8 +661,14 @@ def _validate_capsule_figure(
     if not isinstance(figure, dict):
         violations.append(f"{cid}: missing figure_spec")
         return
-    if not figure.get("static_map_required") or not figure.get("metre_scale_required"):
-        violations.append(f"{cid}: figure_spec must require a static map and metre scale")
+    required_flags = (
+        "static_map_required",
+        "metre_scale_required",
+        "trajectory_sources_required",
+        "actor_footprints_at_marked_times_required",
+    )
+    if not all(figure.get(flag) for flag in required_flags):
+        violations.append(f"{cid}: figure_spec must require map/scale/trajectories/footprints")
     for key in ("marked_times", "why_this_time_matters"):
         if figure.get(key) == AUTHOR_REQUIRED:
             pending.append(f"{cid}: figure_spec.{key} author-required")
@@ -697,7 +721,7 @@ def _validate_admitted_capsule(
         violations.append(f"{cid}: causal grade but no validated causal_label")
 
 
-def validate_ch7_case_capsule_manifest(manifest: dict[str, Any]) -> CaseCapsuleValidation:
+def validate_ch7_case_capsule_manifest(manifest: Any) -> CaseCapsuleValidation:
     """Structurally validate a case-capsule manifest against the issue #5447 gates.
 
     Structural violations mark a malformed manifest. ``author_pending`` entries
@@ -709,6 +733,10 @@ def validate_ch7_case_capsule_manifest(manifest: dict[str, Any]) -> CaseCapsuleV
     """
     violations: list[str] = []
     pending: list[str] = []
+
+    if not isinstance(manifest, dict):
+        violations.append(f"manifest must be a dict, got {type(manifest).__name__}")
+        return CaseCapsuleValidation(violations, pending)
 
     if manifest.get("schema_version") != SCHEMA_VERSION:
         violations.append(
@@ -722,6 +750,9 @@ def validate_ch7_case_capsule_manifest(manifest: dict[str, Any]) -> CaseCapsuleV
         return CaseCapsuleValidation(violations, pending)
 
     for capsule in capsules:
+        if not isinstance(capsule, dict):
+            violations.append("capsules list contains non-dict records")
+            continue
         status = capsule.get("status")
         if status == "unavailable":
             if not capsule.get("reason"):

--- a/scripts/analysis/build_ch7_case_capsules_issue_5447.py
+++ b/scripts/analysis/build_ch7_case_capsules_issue_5447.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Build the pinned Chapter 7 case-capsule manifest (issue #5447).
+
+Reads a *validated* ``seed_flip_inversion_candidates.v1`` candidate manifest (the
+issue #5446 miner output) plus optional causal / online-risk report bundles, and
+emits a schema-versioned ``ch7_case_capsule_manifest.v1`` selecting diverse
+worked-example archetypes for Chapter 7. It is synthesis/selection tooling only:
+it never fabricates a capsule, labels unavailable archetypes ``unavailable``,
+grades descriptive-only unless a validated causal report is supplied, and fails
+closed on empty/wrong-schema input.
+
+This CLI does **not** render figures. Actual vector-figure generation from pinned
+episode trajectories is a downstream step (reuses ``robot_sf.benchmark.figures``)
+that operates on this manifest; the manifest records the exact input hashes so
+that step is reproducible.
+
+Examples
+--------
+    # Build the capsule manifest from a frozen #5446 candidate manifest.
+    uv run python scripts/analysis/build_ch7_case_capsules_issue_5447.py \
+        --candidates docs/context/evidence/issue_5446_*/candidates.json
+
+    # Include validated causal + risk reports and write the manifest + validation.
+    uv run python scripts/analysis/build_ch7_case_capsules_issue_5447.py \
+        --candidates candidates.json --causal causal.json --risk risk.json \
+        --json out/ch7_capsules.json --validate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.case_capsules import (
+    DEFAULT_MAX_CAPSULES,
+    DEFAULT_MIN_CAPSULES,
+    CaseCapsuleError,
+    build_ch7_case_capsule_manifest,
+    validate_ch7_case_capsule_manifest,
+)
+
+
+def _load_json(path: Path) -> Any:
+    """Load a JSON payload from ``path``.
+
+    Returns:
+        The parsed JSON object.
+    """
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser.
+
+    Returns:
+        The configured parser.
+    """
+    p = argparse.ArgumentParser(
+        prog="build_ch7_case_capsules_issue_5447",
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--candidates",
+        required=True,
+        type=Path,
+        help="Validated seed_flip_inversion_candidates.v1 manifest JSON (issue #5446).",
+    )
+    p.add_argument(
+        "--causal",
+        type=Path,
+        default=None,
+        help="Optional validated causal report bundle (JSON dict keyed by candidate/scenario).",
+    )
+    p.add_argument(
+        "--risk",
+        type=Path,
+        default=None,
+        help="Optional validated online-risk report bundle (JSON dict keyed by candidate/scenario).",
+    )
+    p.add_argument(
+        "--min-capsules",
+        type=int,
+        default=DEFAULT_MIN_CAPSULES,
+        help="Honest floor; below it the manifest is insufficient_evidence.",
+    )
+    p.add_argument(
+        "--max-capsules",
+        type=int,
+        default=DEFAULT_MAX_CAPSULES,
+        help="Ceiling on admitted capsules.",
+    )
+    p.add_argument(
+        "--allow-triage",
+        action="store_true",
+        help="Permit triage-only (<=3-seed) candidates as capsule sources.",
+    )
+    p.add_argument("--json", type=Path, default=None, help="Write the capsule manifest JSON here.")
+    p.add_argument(
+        "--validate",
+        action="store_true",
+        help="Also run the structural validator and print its result.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the capsule-builder CLI.
+
+    Returns:
+        Process exit code: 0 ok, 2 fail-closed build error, 3 structural
+        validation failure.
+    """
+    args = build_parser().parse_args(argv)
+    candidate_manifest = _load_json(args.candidates)
+    causal_reports = _load_json(args.causal) if args.causal is not None else None
+    risk_reports = _load_json(args.risk) if args.risk is not None else None
+
+    try:
+        manifest = build_ch7_case_capsule_manifest(
+            candidate_manifest,
+            causal_reports=causal_reports,
+            risk_reports=risk_reports,
+            min_capsules=args.min_capsules,
+            max_capsules=args.max_capsules,
+            allow_triage=args.allow_triage,
+        )
+    except CaseCapsuleError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    payload = json.dumps(manifest, indent=2, sort_keys=False)
+    if args.json is not None:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+
+    s = manifest["summary"]
+    print(
+        f"status={manifest['status']} admitted={s['n_admitted']}/{s['n_capsules_requested']} "
+        f"unavailable={s['n_unavailable']} "
+        f"admitted_archetypes={','.join(s['admitted_archetypes']) or '-'}",
+        file=sys.stderr,
+    )
+
+    if args.validate:
+        result = validate_ch7_case_capsule_manifest(manifest)
+        print(json.dumps(result.as_dict(), indent=2), file=sys.stderr)
+        if not result.ok:
+            return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analysis/build_ch7_case_capsules_issue_5447.py
+++ b/scripts/analysis/build_ch7_case_capsules_issue_5447.py
@@ -115,9 +115,13 @@ def main(argv: list[str] | None = None) -> int:
         validation failure.
     """
     args = build_parser().parse_args(argv)
-    candidate_manifest = _load_json(args.candidates)
-    causal_reports = _load_json(args.causal) if args.causal is not None else None
-    risk_reports = _load_json(args.risk) if args.risk is not None else None
+    try:
+        candidate_manifest = _load_json(args.candidates)
+        causal_reports = _load_json(args.causal) if args.causal is not None else None
+        risk_reports = _load_json(args.risk) if args.risk is not None else None
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
 
     try:
         manifest = build_ch7_case_capsule_manifest(

--- a/tests/benchmark/test_case_capsules_issue_5447.py
+++ b/tests/benchmark/test_case_capsules_issue_5447.py
@@ -22,6 +22,7 @@ from robot_sf.benchmark.case_capsules import (
     canonical_sha256,
     validate_ch7_case_capsule_manifest,
 )
+from scripts.analysis.build_ch7_case_capsules_issue_5447 import main as build_cli_main
 
 
 def _seed_flip_candidate(cid: str, scenario: str, planner: str, **over: Any) -> dict[str, Any]:
@@ -236,3 +237,110 @@ def test_case_capsule_author_required_sentinel_never_prefilled():
     # But the mechanically-derivable rationale is filled from candidate data.
     assert admitted["narrative"]["selection_rationale"] != AUTHOR_REQUIRED
     assert "up1" in admitted["narrative"]["selection_rationale"]
+
+
+def test_case_capsule_builder_rejects_non_dict_candidate_records():
+    """Malformed candidate records fail closed before sort-key access."""
+    with pytest.raises(CaseCapsuleError, match="non-dict candidate"):
+        build_ch7_case_capsule_manifest(_candidate_manifest([None]))  # type: ignore[list-item]
+
+
+def test_case_capsule_builder_normalizes_malformed_seed_flip():
+    """A malformed optional seed_flip field cannot crash candidate ranking."""
+    candidate = _seed_flip_candidate("sf1", "sA", "p1", seed_flip="malformed")
+    manifest = build_ch7_case_capsule_manifest(_candidate_manifest([candidate]), min_capsules=1)
+    admitted = next(c for c in manifest["capsules"] if c["status"] == "admitted")
+    assert admitted["source_candidate_id"] == "sf1"
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value", "expected"),
+    [
+        ("causal_reports", [], "causal_reports must be a dict"),
+        ("risk_reports", [], "risk_reports must be a dict"),
+    ],
+)
+def test_case_capsule_builder_rejects_invalid_report_types(parameter, value, expected):
+    """Optional report bundles must be mappings when supplied."""
+    with pytest.raises(CaseCapsuleError, match=expected):
+        build_ch7_case_capsule_manifest(
+            _candidate_manifest([_seed_flip_candidate("sf1", "sA", "p1")]),
+            **{parameter: value},
+        )
+
+
+def test_case_capsule_builder_deep_copies_input_provenance_and_reports():
+    """Mutating an emitted capsule cannot mutate caller-owned nested inputs."""
+    candidate = _upset_candidate(
+        "up1",
+        "sB",
+        "p2",
+        reproducibility={"nested": {"value": 1}},
+        seed_flip={"effective_denominator": 5, "nested": {"value": 2}},
+    )
+    causal_candidate = _upset_candidate("up2", "sC", "p3", reproducibility={"nested": {"value": 4}})
+    causal = {"sC": {"nested": {"value": 3}}}
+    manifest = build_ch7_case_capsule_manifest(
+        _candidate_manifest([candidate, causal_candidate]), causal_reports=causal, min_capsules=1
+    )
+    admitted = next(
+        c for c in manifest["capsules"] if c["archetype"] == "paired_first_unsafe_action"
+    )
+    admitted["source_provenance"]["reproducibility"]["nested"]["value"] = 10
+    admitted["causal_label"]["report_ref"]["nested"]["value"] = 11
+    assert causal_candidate["reproducibility"]["nested"]["value"] == 4
+    assert causal["sC"]["nested"]["value"] == 3
+
+
+def test_case_capsule_reports_are_scoped_to_required_archetypes():
+    """Non-causal archetypes stay descriptive-only even when a report is available."""
+    candidate = _seed_flip_candidate("sf1", "sA", "p1")
+    manifest = build_ch7_case_capsule_manifest(
+        _candidate_manifest([candidate]),
+        causal_reports={"sA": {"report": "validated"}},
+        min_capsules=1,
+    )
+    hard = next(c for c in manifest["capsules"] if c["archetype"] == "hard_vs_easy_seed")
+    assert hard["causal_label"] == "descriptive-only"
+    assert hard["risk_report_ref"] is None
+
+
+def test_case_capsule_validator_rejects_non_dict_root_and_records():
+    """Malformed manifest roots and capsule records are structural violations."""
+    root_result = validate_ch7_case_capsule_manifest([])
+    assert not root_result.ok
+    assert any("manifest must be a dict" in v for v in root_result.structural_violations)
+
+    record_result = validate_ch7_case_capsule_manifest(
+        {"schema_version": SCHEMA_VERSION, "capsules": [None]}
+    )
+    assert not record_result.ok
+    assert any("non-dict records" in v for v in record_result.structural_violations)
+
+
+def test_case_capsule_validator_requires_all_figure_provenance_flags():
+    """Figure validation protects trajectory and actor-footprint requirements too."""
+    manifest = build_ch7_case_capsule_manifest(
+        _candidate_manifest([_seed_flip_candidate("sf1", "sA", "p1")]), min_capsules=1
+    )
+    hard = next(c for c in manifest["capsules"] if c["status"] == "admitted")
+    hard["figure_spec"]["trajectory_sources_required"] = False
+    result = validate_ch7_case_capsule_manifest(manifest)
+    assert not result.ok
+    assert any("map/scale/trajectories/footprints" in v for v in result.structural_violations)
+
+
+@pytest.mark.parametrize("payload", ["{", "[]"])
+def test_case_capsule_cli_fails_closed_on_malformed_json(tmp_path, capsys, payload):
+    """Missing or malformed JSON input uses the documented build-error exit code."""
+    candidates = tmp_path / "candidates.json"
+    candidates.write_text(payload, encoding="utf-8")
+    assert build_cli_main(["--candidates", str(candidates)]) == 2
+    assert "error:" in capsys.readouterr().err
+
+
+def test_case_capsule_cli_fails_closed_on_missing_json(tmp_path, capsys):
+    """A missing candidate file produces a concise fail-closed error."""
+    missing = tmp_path / "missing.json"
+    assert build_cli_main(["--candidates", str(missing)]) == 2
+    assert "error:" in capsys.readouterr().err

--- a/tests/benchmark/test_case_capsules_issue_5447.py
+++ b/tests/benchmark/test_case_capsules_issue_5447.py
@@ -1,0 +1,238 @@
+"""Tests for the Chapter 7 case-capsule manifest builder (issue #5447).
+
+These exercise the honest-selection contract: fail-closed on empty/wrong-schema
+input, label unavailable archetypes rather than fabricate them, grade
+descriptive-only unless a validated causal report is supplied, honour the
+stop-rule floor, and validate the emitted manifest structurally while reporting
+author-pending narrative fields.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from robot_sf.benchmark.case_capsules import (
+    AUTHOR_REQUIRED,
+    CANDIDATE_SCHEMA_VERSION,
+    SCHEMA_VERSION,
+    CaseCapsuleError,
+    build_ch7_case_capsule_manifest,
+    canonical_sha256,
+    validate_ch7_case_capsule_manifest,
+)
+
+
+def _seed_flip_candidate(cid: str, scenario: str, planner: str, **over: Any) -> dict[str, Any]:
+    """Return a minimal seed-flip candidate record like the #5446 miner emits."""
+    base = {
+        "candidate_id": cid,
+        "archetype": "seed_flip",
+        "scenario_id": scenario,
+        "planner": planner,
+        "triage_only": False,
+        "selected": True,
+        "cross_planner_disagreement_entropy": 0.9,
+        "seed_flip": {"entropy_bits": 1.0, "effective_denominator": 8},
+        "upset_outcome": None,
+        "reproducibility": {"n_seeds": 8, "raw_seed_outcomes": {"1": 1, "2": 0}},
+    }
+    base.update(over)
+    return base
+
+
+def _upset_candidate(cid: str, scenario: str, planner: str, **over: Any) -> dict[str, Any]:
+    """Return a minimal planner-upset candidate record like the #5446 miner emits."""
+    base = {
+        "candidate_id": cid,
+        "archetype": "planner_upset",
+        "scenario_id": scenario,
+        "planner": planner,
+        "triage_only": False,
+        "selected": True,
+        "cross_planner_disagreement_entropy": 0.8,
+        "seed_flip": None,
+        "upset_outcome": {"underdog_planner": planner, "outcome_gap": 0.5},
+        "reproducibility": {"underdog_n_seeds": 5, "favorite_n_seeds": 5},
+    }
+    base.update(over)
+    return base
+
+
+def _candidate_manifest(candidates: list[dict[str, Any]], **over: Any) -> dict[str, Any]:
+    """Wrap candidates in a #5446-style candidate manifest."""
+    manifest = {
+        "schema_version": CANDIDATE_SCHEMA_VERSION,
+        "issue": "#5446",
+        "candidates": candidates,
+        "archetype_availability": {"disagreement_recovery": {"available": True}},
+    }
+    manifest.update(over)
+    return manifest
+
+
+def test_case_capsule_builder_fails_closed_on_empty_manifest():
+    """An empty / candidate-free manifest must fail closed, not emit an empty set."""
+    with pytest.raises(CaseCapsuleError):
+        build_ch7_case_capsule_manifest(_candidate_manifest([]))
+
+
+def test_case_capsule_builder_fails_closed_on_wrong_schema():
+    """A wrong-schema candidate manifest is rejected."""
+    bad = _candidate_manifest([_seed_flip_candidate("c", "s", "p")], schema_version="other.v9")
+    with pytest.raises(CaseCapsuleError):
+        build_ch7_case_capsule_manifest(bad)
+
+
+def test_case_capsule_builder_rejects_non_dict():
+    """Non-dict input fails closed."""
+    with pytest.raises(CaseCapsuleError):
+        build_ch7_case_capsule_manifest([])  # type: ignore[arg-type]
+
+
+def test_case_capsule_labels_unavailable_without_causal_or_risk_reports():
+    """Causal/risk archetypes are unavailable (not fabricated) when reports absent."""
+    candidates = [
+        _seed_flip_candidate("sf1", "sA", "p1"),
+        _upset_candidate("up1", "sB", "p2"),
+        _seed_flip_candidate("sf2", "sC", "p3"),
+        _upset_candidate("up2", "sD", "p4"),
+    ]
+    manifest = build_ch7_case_capsule_manifest(_candidate_manifest(candidates))
+
+    by_arch = {c["archetype"]: c for c in manifest["capsules"]}
+    # Causal-defined archetypes must be unavailable with a concrete reason.
+    assert by_arch["paired_first_unsafe_action"]["status"] == "unavailable"
+    assert by_arch["paired_first_unsafe_action"]["reason"] == "causal_report_unavailable"
+    assert by_arch["ambiguous_abstention"]["reason"] == "causal_report_unavailable"
+    # Risk archetype unavailable without a risk report.
+    assert by_arch["near_miss_online_risk"]["reason"] == "risk_report_unavailable"
+    # Data-sourced descriptive archetypes are admitted, descriptive-only.
+    assert by_arch["hard_vs_easy_seed"]["status"] == "admitted"
+    assert by_arch["hard_vs_easy_seed"]["evidence_grade"] == "descriptive-only"
+
+
+def test_case_capsule_causal_report_upgrades_grade():
+    """A validated causal report keyed by scenario upgrades the capsule to causal.
+
+    Enough candidates are supplied that a planner-upset source remains for the
+    causal ``paired_first_unsafe_action`` archetype after the two earlier
+    archetypes consume theirs (candidates are never reused).
+    """
+    candidates = [
+        _seed_flip_candidate("sf1", "sA", "p1"),
+        _upset_candidate("up1", "sB", "p2"),
+        _upset_candidate("up2", "sE", "p5"),
+    ]
+    causal = {
+        "sB": {"report": "validated causal report for sB", "abstention": False},
+        "sE": {"report": "validated causal report for sE", "abstention": False},
+    }
+    manifest = build_ch7_case_capsule_manifest(
+        _candidate_manifest(candidates), causal_reports=causal
+    )
+    by_arch = {c["archetype"]: c for c in manifest["capsules"]}
+    paired = by_arch["paired_first_unsafe_action"]
+    assert paired["status"] == "admitted"
+    assert paired["evidence_grade"] == "causal"
+    assert paired["causal_label"]["status"] == "validated"
+
+
+def test_case_capsule_insufficient_evidence_below_floor():
+    """Fewer than min_capsules admitted archetypes -> insufficient_evidence status."""
+    manifest = build_ch7_case_capsule_manifest(
+        _candidate_manifest([_seed_flip_candidate("sf1", "sA", "p1")])
+    )
+    assert manifest["status"] == "insufficient_evidence"
+    assert manifest["summary"]["meets_min_capsules"] is False
+
+
+def test_case_capsule_triage_candidates_excluded_by_default():
+    """Triage-only candidates never silently back a capsule unless explicitly allowed."""
+    triage = _seed_flip_candidate("sf1", "sA", "p1", triage_only=True)
+    manifest = build_ch7_case_capsule_manifest(_candidate_manifest([triage]))
+    hard = next(c for c in manifest["capsules"] if c["archetype"] == "hard_vs_easy_seed")
+    assert hard["status"] == "unavailable"
+
+    allowed = build_ch7_case_capsule_manifest(_candidate_manifest([triage]), allow_triage=True)
+    hard2 = next(c for c in allowed["capsules"] if c["archetype"] == "hard_vs_easy_seed")
+    assert hard2["status"] == "admitted"
+
+
+def test_case_capsule_candidates_not_reused_across_archetypes():
+    """A single candidate must not source two different capsule archetypes."""
+    candidates = [_upset_candidate("up1", "sB", "p2")]
+    manifest = build_ch7_case_capsule_manifest(_candidate_manifest(candidates))
+    sources = [
+        c.get("source_candidate_id") for c in manifest["capsules"] if c["status"] == "admitted"
+    ]
+    assert len(sources) == len(set(sources))
+
+
+def test_case_capsule_manifest_validates_structurally_with_author_pending():
+    """A well-formed manifest is structurally valid but reports author-pending fields."""
+    candidates = [
+        _seed_flip_candidate("sf1", "sA", "p1"),
+        _upset_candidate("up1", "sB", "p2"),
+        _seed_flip_candidate("sf2", "sC", "p3"),
+        _seed_flip_candidate("sf3", "sD", "p4"),
+    ]
+    manifest = build_ch7_case_capsule_manifest(_candidate_manifest(candidates))
+    result = validate_ch7_case_capsule_manifest(manifest)
+    assert result.ok, result.structural_violations
+    # Narrative and figure sentinels are surfaced, not hidden.
+    assert any("competing_explanation" in p for p in result.author_pending)
+    assert any("marked_times" in p for p in result.author_pending)
+
+
+def test_case_capsule_pair_requires_shared_axis_spec():
+    """Pair capsules carry a shared-axis spec; corrupting it is a structural violation."""
+    candidates = [_seed_flip_candidate("sf1", "sA", "p1")]
+    manifest = build_ch7_case_capsule_manifest(_candidate_manifest(candidates), min_capsules=1)
+    hard = next(c for c in manifest["capsules"] if c["archetype"] == "hard_vs_easy_seed")
+    assert hard["is_pair"] is True
+    assert set(hard["figure_spec"]["shared_axis_spec"]) >= {"axes_limits", "time_markers"}
+
+    hard["figure_spec"].pop("shared_axis_spec")
+    result = validate_ch7_case_capsule_manifest(manifest)
+    assert not result.ok
+    assert any("shared_axis_spec" in v for v in result.structural_violations)
+
+
+def test_case_capsule_validator_flags_unknown_status():
+    """A capsule with an unknown status is a structural violation."""
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "capsules": [{"capsule_id": "ch7::x", "status": "mystery"}],
+    }
+    result = validate_ch7_case_capsule_manifest(manifest)
+    assert not result.ok
+    assert any("unknown capsule status" in v for v in result.structural_violations)
+
+
+def test_case_capsule_canonical_sha256_is_order_independent():
+    """Input-hash provenance must be insertion-order independent."""
+    a = {"schema_version": CANDIDATE_SCHEMA_VERSION, "x": 1, "y": 2}
+    b = {"y": 2, "schema_version": CANDIDATE_SCHEMA_VERSION, "x": 1}
+    assert canonical_sha256(a) == canonical_sha256(b)
+
+
+def test_case_capsule_input_hash_recorded():
+    """The emitted manifest records the candidate-manifest hash for reproducibility."""
+    cm = _candidate_manifest([_seed_flip_candidate("sf1", "sA", "p1")])
+    manifest = build_ch7_case_capsule_manifest(cm)
+    assert manifest["inputs"]["candidate_manifest_sha256"] == canonical_sha256(cm)
+    assert manifest["inputs"]["n_candidates"] == 1
+
+
+def test_case_capsule_author_required_sentinel_never_prefilled():
+    """The builder must not fabricate the subjective narrative fields."""
+    candidates = [_upset_candidate("up1", "sB", "p2")]
+    manifest = build_ch7_case_capsule_manifest(_candidate_manifest(candidates), min_capsules=1)
+    admitted = next(c for c in manifest["capsules"] if c["status"] == "admitted")
+    assert admitted["narrative"]["competing_explanation"] == AUTHOR_REQUIRED
+    assert admitted["narrative"]["generalization_limits"] == AUTHOR_REQUIRED
+    # But the mechanically-derivable rationale is filled from candidate data.
+    assert admitted["narrative"]["selection_rationale"] != AUTHOR_REQUIRED
+    assert "up1" in admitted["narrative"]["selection_rationale"]


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** adds a reproducible, fail-closed **Chapter 7 case-capsule manifest builder + structural validator** (`robot_sf/benchmark/case_capsules.py`, schema `ch7_case_capsule_manifest.v1`), a thin CLI, a frozen selection-contract config, and 25 contract tests. This is the honest-selection scaffold the issue's maintainer triage comment explicitly names as buildable now.
- **Why now:** issue #5447 (synthesis) is a *nameable new capability* toward the implementation plan (fragmentation guard 6c EXEMPT — progression slice). No prior open PR covers it; no capsule builder existed.
- **Successor slice:** this PR delivers the builder/validator scaffold and does not duplicate the already-landed upstream report contracts; it leaves the real candidate manifest, report inputs, figure rendering, and independent visual review to the linked follow-ups.
- **Claim boundary:** synthesis/selection tooling only — **not** a benchmark metric, **not** a figure renderer, **not** a planner-ranking claim. Evidence grade `diagnostic-only`. The capsule *set itself is NOT built here* (see remaining blocker).
- **Required validation:** `uv run pytest -q tests/benchmark/test_case_capsules_issue_5447.py` → 25 passed; `git diff --check` clean; ruff check/format clean; docs/evidence integrity passed.
- **Remaining blocker:** the validated `seed_flip_inversion_candidates.v1` candidate manifest from #5446 does not yet exist (the #5446 slice, PR #5466, shipped only the miner tooling). The report contracts from #5441 and #5444 are landed; report/input work in #5442, #5443, and #5445 remains. Building capsules from fabricated/degraded rows is forbidden, so the builder ships now and produces the capsule set deterministically once the manifest exists.

## Contract delta

- **New schema:** `ch7_case_capsule_manifest.v1` (emitted) consuming `seed_flip_inversion_candidates.v1` (#5446).
- **New fail-closed blockers:** `CaseCapsuleError` on empty / wrong-schema / candidate-free or malformed candidate input; `status: insufficient_evidence` below the 4-capsule honest floor; archetypes with a missing source candidate or required causal/risk report emit `status: unavailable` with a concrete reason (never substituted post hoc).
- **New grading rule:** capsules are `descriptive-only` unless a validated causal report is supplied (`causal`); risk archetypes require a validated risk report (`descriptive-risk`) or are `unavailable`.
- **Author discipline:** subjective narrative/figure fields use an `AUTHOR_REQUIRED` sentinel; the validator reports these as `author_pending` (structurally valid, honestly incomplete) — distinct from hard `structural_violations`.
- **Provenance:** the manifest records the canonical SHA-256 of the input candidate manifest and deep-copies caller-owned nested inputs.
- **Compatibility:** all-new module/CLI/config/test; no existing behavior changed.

## Issue

Refs #5447. Depends on #5446 (candidate manifest) and report/input work from #5442, #5443, and #5445 where available; completed contracts from #5441 and #5444 are consumed when their validated reports exist.

### Remaining to fully close #5447
- [ ] #5446 emits a pinned `seed_flip_inversion_candidates.v1` manifest from a real eligible native-execution campaign table.
- [ ] Validated causal / online-risk reports are available from #5442, #5443, and #5445 — otherwise those archetypes stay `unavailable` or `descriptive-only`.
- [ ] Downstream: vector-figure rendering from pinned trajectories (reuse `robot_sf/benchmark/figures`), author-field completion, and the independent frozen-SHA visual/evidence review before dissertation integration.

## Validation

| command | result |
| --- | --- |
| `uv run pytest -q tests/benchmark/test_case_capsules_issue_5447.py` | 25 passed |
| `uv run ruff check <changed>` / `ruff format --check` | clean |
| CLI smoke (`build_ch7_case_capsules_issue_5447.py --validate`) | admit path exit 0 (author-pending surfaced); empty/malformed input fail-closed exit 2 |
| `BASE_REF=origin/main check_docs_evidence_integrity.py` | passed |
| `git diff --check` | clean |

**Late-guidance check:** re-read issue #5447 comments immediately before opening; the maintainer BLOCKED triage says the #5446 candidate manifest is missing. This PR delivers exactly the buildable scaffold and does not fabricate the blocked capsule set.

## Domain-Aware Approval

- Required for this PR: yes
- Domains reviewed: evidence classification, experimental comparison, benchmark interpretation, figure eligibility
- Status: waived
- Approver/review source or waiver: Gate review waives claim approval because this PR is selection tooling only; it does not execute episodes, change planner behavior, render figures, or promote benchmark/paper claims.
- Validity checklist:
  - Target claim/hypothesis: no effectiveness or ranking claim; only a reproducible capsule-selection contract is added.
  - Comparator or split/evidence validity: candidate/report schema and provenance are validated; no comparator result is produced.
  - Fallback/degraded exclusions: empty, malformed, missing, or degraded inputs fail closed or become explicitly unavailable; no substitution is accepted.
  - Claim boundary: `diagnostic-only` scaffold; no capsule set or paper-facing evidence is claimed until pinned inputs and review exist.
  - Implementation integrity vs experimental validity: implementation integrity is covered by focused tests, Ruff, and CI; experimental validity is deferred to #5446, #5442, #5443, #5445, and the independent visual review.

## Falsification / Non-Transfer Check

- Did the mechanism activate? NA — this is a builder/validator scaffold, not a planner intervention.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario contain the targeted failure mode? NA — no episodes are executed.
- Result route: stop — remain diagnostic-only until pinned inputs exist.
- Follow-up question or issue for weak, negative, or non-transfer results: can the pinned candidate/report inputs support at least four honest archetypes without substitution? Track through #5446, #5442, #5443, and #5445.

## Next Empirical Action

Produce the pinned #5446 candidate manifest from a real native-execution campaign table, assemble validated report inputs from the open follow-ups, then run the CLI and independent frozen-SHA visual/evidence review. No GPU/Slurm submission is authorized by this PR.

## Downstream Propagation

Partial/NA: this scaffold produces no benchmark or paper result. Remaining input, report, figure, author, and independent-review work stays on #5447 and its open follow-ups; the unrelated full-readiness runner baseline is tracked by #5480.

## Follow-Up Issues

- [#5446](https://github.com/ll7/robot_sf_ll7/issues/5446) — emit the pinned candidate manifest from real native-execution rows.
- [#5442](https://github.com/ll7/robot_sf_ll7/issues/5442) — produce frozen-state causal counterfactual inputs.
- [#5443](https://github.com/ll7/robot_sf_ll7/issues/5443) — validate collision-cause attribution on injected and ambiguous faults.
- [#5445](https://github.com/ll7/robot_sf_ll7/issues/5445) — calibrate online collision-risk reports.
- [#5480](https://github.com/ll7/robot_sf_ll7/issues/5480) — restore the unrelated runner exception-logging return contract exposed by the full local readiness baseline.

## State propagation

Low-churn issue (0 prior PRs in 24h). Durable state lives in `docs/context/evidence/issue_5447_ch7_case_capsules/README.md` (registered in `docs/context/catalog.yaml`). No transient queue-routing state added to tracked files.

## Out of scope (explicit)

No full benchmark campaign run. No Slurm/GPU submission. No paper/dissertation claim edits. No figure rendering. No fabricated capsules or unvalidated substitutions.

<details>
<summary>Research/benchmark governance fields</summary>

- **Target claim/hypothesis/blocker:** blocker — Chapter 7 needs a reproducible, non-fabricating capsule builder before the #5446 candidate manifest exists.
- **Comparator/baseline:** N/A (selection tooling, not a measurement).
- **Evidence tier:** `diagnostic-only` (contract tests + CLI smoke).
- **Result classification:** scaffold delivered; capsule set blocked on data.
- **Decision/stop rule:** stop at a smaller honest set (<4 archetypes → `insufficient_evidence`); never substitute unvalidated rows.
- **Synthesis/update target:** `docs/context/evidence/issue_5447_ch7_case_capsules/README.md`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deterministic Chapter 7 case-capsule manifest generation from validated candidate data.
  - Supports optional causal and online-risk evidence, with clear availability and evidence grades.
  - Added configurable capsule count limits and optional triage candidate inclusion.
  - Added a command-line tool to generate, validate, and export manifests.
  - Records reproducible input provenance and validation results.

- **Bug Fixes**
  - Invalid, incomplete, or malformed inputs now fail safely with actionable validation errors.

- **Tests**
  - Added comprehensive coverage for generation, validation, reproducibility, evidence handling, and CLI error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->