### PR TITLE
Issue #5482: unbreak main — align exception-logging test with circuit-breaker 3-tuple return (cheap-lane worker)

### DIFF
--- a/tests/benchmark/test_runner_exception_logging.py
+++ b/tests/benchmark/test_runner_exception_logging.py
@@ -24,7 +24,7 @@ def test_run_batch_sequential_worker_failure_logs_warning(tmp_path, monkeypatch)
     handle = logger.add(capture_message, level="WARNING")
     monkeypatch.setattr(runner, "_run_job_worker", fake_run_job)
     try:
-        wrote, failures = runner._run_batch_sequential(
+        wrote, failures, abort_metadata = runner._run_batch_sequential(
             [({"id": "scenario-1"}, 42)],
             out_path=tmp_path / "episodes.jsonl",
             schema={},
@@ -38,6 +38,7 @@ def test_run_batch_sequential_worker_failure_logs_warning(tmp_path, monkeypatch)
     assert wrote == 0
     assert len(failures) == 1
     assert failures[0]["scenario_id"] == "scenario-1"
+    assert abort_metadata is None
     assert any(
         "Benchmark batch job failed in serial execution" in msg.record["message"]
         for msg in captured


### PR DESCRIPTION
## What / Why

`main` is red (CI run [29232981888](https://github.com/ll7/robot_sf_ll7/actions/runs/29232981888)). The single failing test is `tests/benchmark/test_runner_exception_logging.py::test_run_batch_sequential_worker_failure_logs_warning`, which died with `ValueError: too many values to unpack (expected 2)`.

Root cause: PR #5404 (Issue #5390) extended `runner._run_batch_sequential` to return a 3-tuple `(wrote, failures, abort_metadata)` (circuit-breaker abort bookkeeping), but this regression test still unpacked only 2 values. No source code is broken — only the test's unpacking was stale.

Fix: update the test to unpack the 3-tuple and assert `abort_metadata is None` for the single-failure path. This is the smallest unbreak; the breaking merge is the circuit-breaker feature (#5404), which remains correct and is exercised by the existing `test_runner_circuit_breaker.py` suite.

No prior PR merged a slice of #5482; this resolves the red directly.

## Validation

```
uv run pytest tests/benchmark/test_runner_exception_logging.py tests/benchmark/test_runner_circuit_breaker.py
19 passed in 5.09s
```

- `test_runner_exception_logging.py`: 2 passed (including the previously failing `test_run_batch_sequential_worker_failure_logs_warning`).
- `test_runner_circuit_breaker.py`: 17 passed.
- `ruff check tests/benchmark/test_runner_exception_logging.py`: All checks passed.

CPU-only validation; no campaigns/training/benchmark runs.

## Closes

Closes #5482 (issue asks to close when main CI is green again; this removes the only failing test). Two consecutive green main CI runs remain the merge criterion and are verified by CI on this PR.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.