### PR TITLE
Issue #5493: sync stale SNQI Pareto SVG hash constant (cheap-lane worker)

### DIFF
--- a/configs/benchmarks/issue_3653_snqi_decision_disagreement_packet.yaml
+++ b/configs/benchmarks/issue_3653_snqi_decision_disagreement_packet.yaml
@@ -127,4 +127,4 @@ evidence_artifacts:
   - path: snqi_scalarization_sensitivity.md
     sha256: 77e426f8dc121131c5cf6d940789ba8591a7755445516c19c7a64f604e5cb0d1
   - path: snqi_scalarization_sensitivity_pareto.svg
-    sha256: 5c4f4036eec0c09692c321b8e2bb5fb1b659a39a800bc3c65aa545381773c2ad
+    sha256: e41e475637a9c2c76916400f79995a8b26123a2fd2ab323ebb588e2fa8cf3181

--- a/scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py
+++ b/scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py
@@ -35,7 +35,7 @@ EXPECTED_EXPORT_ARTIFACT_HASHES = {
     "snqi_scalarization_sensitivity_planner_rows.csv": "198c31da9878317e056afbc54034c9f0caeeeb7cf4a3fc24bfd40d2ccc2e449c",
     "snqi_scalarization_sensitivity_decision_disagreement.csv": "534c0bd09af1550d5b7cb9a7ebbb3ef89c6e361e843d7542020ae69d5a219f2d",
     "snqi_scalarization_sensitivity.md": "77e426f8dc121131c5cf6d940789ba8591a7755445516c19c7a64f604e5cb0d1",
-    "snqi_scalarization_sensitivity_pareto.svg": "5c4f4036eec0c09692c321b8e2bb5fb1b659a39a800bc3c65aa545381773c2ad",
+    "snqi_scalarization_sensitivity_pareto.svg": "e41e475637a9c2c76916400f79995a8b26123a2fd2ab323ebb588e2fa8cf3181",
 }
 ALLOWED_RAW_EPISODE_SOURCES = {
     "durable_artifact_pointer",


### PR DESCRIPTION
## What / Why

Issue #5493 (P0, main CI red): the last two main CI runs failed. The only failing
test was `tests/benchmark/test_snqi_pareto_pinned_artifact.py::test_pinned_svg_hash_matches_packet_checker_constant`.

Root cause: two recorded hash constants for `snqi_scalarization_sensitivity_pareto.svg` still held the old value
`5c4f4036eec0c09692c321b8e2bb5fb1b659a39a800bc3c65aa545381773c2ad`, while the on-disk SVG
(and its `artifact_inventory.json` / `packet.json` manifests) already carried the current renderer output
`e41e475637a9c2c76916400f79995a8b26123a2fd2ab323ebb588e2fa8cf3181`.

This is a pure metadata-sync fix. The renderer (`format_pareto_svg`) is unchanged, and the on-disk SVG
regenerates identically from its pinned report (`test_pinned_svg_regenerates_identically_from_pinned_report`
passes), so no artifact regeneration is required — only the stale recorded constants are corrected.

This is the successor slice for #5493 and does not duplicate another fix. The linked issue remains open until
two consecutive main-CI runs pass after this repair; this PR removes the current failing test but does not by
itself establish that two-run acceptance criterion.

## Changes

- `scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py`: update `EXPECTED_EXPORT_ARTIFACT_HASHES["snqi_scalarization_sensitivity_pareto.svg"]` to the current hash.
- `configs/benchmarks/issue_3653_snqi_decision_disagreement_packet.yaml`: update the recorded `sha256` for the pareto SVG entry.

## Validation

- `pytest tests/benchmark/test_snqi_pareto_pinned_artifact.py` -> 3 passed (all three drift-guard tests green).
- `python scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py --json` -> `status: ok`, exit 0 (internal consistency of the packet and evidence artifacts holds).
- `ruff check scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py` -> all checks passed.

Refs #5493.

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
