### PR TITLE
Issue #5491: restore orca baseline adapter in exact-repeat execute (cheap-lane worker)

### DIFF
--- a/robot_sf/baselines/__init__.py
+++ b/robot_sf/baselines/__init__.py
@@ -85,6 +85,23 @@ def _get_brne_planner():
     return module.BRNEPlanner
 
 
+def _get_orca_planner():
+    """Lazy import for the ORCA baseline adapter.
+
+    Returns:
+        The OrcaPlanner class.
+
+    Note:
+        Restores the historical ``orca`` algorithm in the baseline registry
+        (issue #5491) so ``runner.run_episode(algo="orca")`` and the
+        exact-repeat ``execute_campaign`` path no longer crash with an
+        ``Unknown algorithm 'orca'`` error. Uses the benchmark-ready
+        ``ORCAPlannerAdapter`` (rvo2 solver when available).
+    """
+    module = importlib.import_module("robot_sf.baselines.orca")
+    return module.OrcaPlanner
+
+
 # Registry of available baseline algorithms
 BASELINES: dict[str, type] = {
     "social_force": _get_social_force_planner,
@@ -96,6 +113,7 @@ BASELINES: dict[str, type] = {
     "dr_mpc": _get_drm_mp_planner,
     "drl_vo": _get_drl_vo_planner,
     "brne": _get_brne_planner,
+    "orca": _get_orca_planner,
 }
 
 

--- a/robot_sf/baselines/orca.py
+++ b/robot_sf/baselines/orca.py
@@ -1,0 +1,210 @@
+"""ORCA baseline planner for the Social Navigation Benchmark.
+
+Restores the historical ``orca`` algorithm in the baseline registry (issue #5491). The
+exact-repeat campaign for #5263 resolves cells with ``algo: orca`` and routes
+episode execution through ``runner.run_episode(algo="orca")`` ->
+``_load_baseline_planner``. That registry only knew the map-based ``ORCAPlannerAdapter``
+(via ``map_runner``), so the executor crashed with
+``Unknown algorithm 'orca'`` instead of running the cell.
+
+This module plugs the adapter into the benchmark baseline contract (``step`` returns a
+``{"vx", "vy"}`` world-velocity action, ``reset``/``get_metadata``/``close`` are
+supported) so the historical ORCA cells execute on current ``main``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict
+from typing import Any
+
+import numpy as np
+
+from robot_sf.baselines.interface import Observation
+from robot_sf.planner.socnav import (
+    ORCAPlannerAdapter,
+    SocNavPlannerConfig,
+)
+
+# Fields accepted when building a SocNavPlannerConfig from a loose mapping.
+_SOCNAV_CONFIG_FIELDS = tuple(SocNavPlannerConfig.__dataclass_fields__.keys())
+
+
+def _build_socnav_config(config: dict[str, Any]) -> SocNavPlannerConfig:
+    """Return a SocNavPlannerConfig filtered from a loose mapping.
+
+    Unknown keys are dropped so an empty or partial planner config cannot crash the
+    baseline constructor.
+
+    Returns:
+        SocNavPlannerConfig: Filtered planner configuration.
+    """
+    if not isinstance(config, dict):
+        return SocNavPlannerConfig()
+    filtered = {key: value for key, value in config.items() if key in _SOCNAV_CONFIG_FIELDS}
+    return SocNavPlannerConfig(**filtered)
+
+
+class OrcaPlanner:
+    """Baseline ORCA planner wrapping ``ORCAPlannerAdapter``.
+
+    Consumes the canonical benchmark ``Observation`` (robot + agents), adapts it into
+    the SocNav structured observation expected by the adapter, and returns a
+    world-frame ``{"vx", "vy"}`` action. Uses the benchmark-ready rvo2 solver
+    when available.
+    """
+
+    def __init__(self, config: dict[str, Any] | SocNavPlannerConfig, *, seed: int | None = None):
+        """Initialize the ORCA baseline planner.
+
+        Args:
+            config: Planner configuration object or dict payload.
+            seed: Optional random seed (accepted for baseline API symmetry; ORCA is
+                deterministic given rvo2).
+        """
+        self._seed = seed
+        self._config = self._parse_config(config)
+        if isinstance(config, dict):
+            allow_fallback = bool(config.get("allow_fallback", False))
+        else:
+            allow_fallback = False
+        self._adapter = ORCAPlannerAdapter(config=self._config, allow_fallback=allow_fallback)
+
+    @staticmethod
+    def _parse_config(config: dict[str, Any] | SocNavPlannerConfig) -> SocNavPlannerConfig:
+        """Normalize config input into a SocNavPlannerConfig.
+
+        Returns:
+            SocNavPlannerConfig: Parsed configuration.
+        """
+        if isinstance(config, SocNavPlannerConfig):
+            return config
+        return _build_socnav_config(config if isinstance(config, dict) else {})
+
+    def reset(self, *, seed: int | None = None) -> None:
+        """Reset internal planner state and optionally reseed.
+
+        Args:
+            seed: Optional new seed.
+        """
+        if seed is not None:
+            self._seed = seed
+        self._adapter.reset()
+
+    def _to_adapter_observation(self, obs: Observation | dict[str, Any]) -> dict[str, Any]:
+        """Adapt a benchmark Observation into the SocNav structured observation.
+
+        Returns:
+            dict[str, Any]: Observation with ``robot``/``goal``/``pedestrians`` keys
+            as expected by ``ORCAPlannerAdapter``.
+        """
+        if isinstance(obs, Observation):
+            robot = dict(obs.robot)
+            agents = list(obs.agents)
+            dt = float(getattr(obs, "dt", 0.1) or 0.1)
+        else:
+            robot = dict(obs.get("robot", {}))
+            agents = list(obs.get("agents", []))
+            sim = obs.get("sim", {}) or {}
+            dt_value = sim.get("timestep", [0.1])
+            dt = float(np.asarray(dt_value, dtype=float).reshape(-1)[0]) if dt_value else 0.1
+
+        # The SocNav-family ORCA adapter expects a richer robot state than the
+        # canonical baseline Observation: heading, speed, and radius are required
+        # by the rvo2 solver path. Default them from velocity/radius so a
+        # minimal benchmark Observation still drives the planner.
+        robot_position = np.asarray(robot.get("position", [0.0, 0.0]), dtype=float).reshape(-1)[:2]
+        robot_velocity = np.asarray(robot.get("velocity", [0.0, 0.0]), dtype=float).reshape(-1)[:2]
+        robot_radius = float(np.asarray(robot.get("radius", 0.3), dtype=float).reshape(-1)[0])
+        heading_value = float(
+            np.asarray(
+                robot.get("heading", np.arctan2(robot_velocity[1], robot_velocity[0] + 1e-9)),
+                dtype=float,
+            ).reshape(-1)[0]
+        )
+        # The SocNav-family adapter indexes heading/radius as length-1 arrays, so
+        # adapt them into that shape.
+        heading = [heading_value]
+        speed = float(np.linalg.norm(robot_velocity))
+        adapted_robot = {
+            "position": list(robot_position),
+            "velocity": list(robot_velocity),
+            "heading": heading,
+            "speed": [speed],
+            "radius": [robot_radius],
+        }
+
+        goal = robot.get("goal")
+        goal_state = {
+            "current": list(np.asarray(goal, dtype=float).reshape(-1)[:2])
+            if goal is not None
+            else [0.0, 0.0]
+        }
+        positions = [
+            list(np.asarray(a.get("position", [0.0, 0.0]), dtype=float).reshape(-1)[:2])
+            for a in agents
+        ]
+        velocities = [
+            list(np.asarray(a.get("velocity", [0.0, 0.0]), dtype=float).reshape(-1)[:2])
+            for a in agents
+        ]
+        count = len(agents)
+        radius = (
+            float(np.asarray(agents[0].get("radius", 0.3), dtype=float).reshape(-1)[0])
+            if count > 0
+            else 0.3
+        )
+        ped_state = {
+            "positions": positions,
+            "velocities": velocities,
+            "count": [count],
+            "radius": [radius],
+        }
+        return {
+            "robot": adapted_robot,
+            "goal": goal_state,
+            "pedestrians": ped_state,
+            "sim": {"timestep": [dt]},
+        }
+
+    def step(self, obs: Observation | dict[str, Any]) -> dict[str, float]:
+        """Compute an ORCA world-velocity action for the given observation.
+
+        Returns:
+            Action dict ``{"vx", "vy"}`` in the world frame.
+        """
+        if isinstance(obs, dict):
+            adapter_obs: dict[str, Any] = obs
+        else:
+            adapter_obs = self._to_adapter_observation(obs)
+        world_velocity = np.asarray(
+            self._adapter.plan_velocity_world(adapter_obs), dtype=float
+        ).reshape(-1)
+        if world_velocity.size < 2:
+            return {"vx": 0.0, "vy": 0.0}
+        return {"vx": float(world_velocity[0]), "vy": float(world_velocity[1])}
+
+    def get_metadata(self) -> dict[str, Any]:
+        """Return planner metadata for episode records.
+
+        Returns:
+            Metadata dict with algorithm, config hash, and status.
+        """
+        cfg = asdict(self._config)
+        cfg_hash = hashlib.sha256(json.dumps(cfg, sort_keys=True).encode()).hexdigest()[:16]
+        return {
+            "algorithm": "orca",
+            "config": cfg,
+            "config_hash": cfg_hash,
+            "status": "ok",
+            "adapter": "ORCAPlannerAdapter",
+        }
+
+    def close(self) -> None:
+        """Release planner resources (no-op for the local ORCA adapter)."""
+        if hasattr(self._adapter, "close"):
+            self._adapter.close()
+
+
+__all__ = ["OrcaPlanner"]

--- a/robot_sf/baselines/orca.py
+++ b/robot_sf/baselines/orca.py
@@ -31,6 +31,30 @@ from robot_sf.planner.socnav import (
 _SOCNAV_CONFIG_FIELDS = tuple(SocNavPlannerConfig.__dataclass_fields__.keys())
 
 
+def _coerce_scalar(value: Any, default: float) -> float:
+    """Return the first finite scalar in ``value`` or a safe default."""
+    if value is None:
+        return default
+    try:
+        values = np.asarray(value, dtype=float).reshape(-1)
+    except (TypeError, ValueError):
+        return default
+    if values.size == 0 or not np.isfinite(values[0]):
+        return default
+    return float(values[0])
+
+
+def _coerce_vector2(value: Any, default: tuple[float, float] = (0.0, 0.0)) -> np.ndarray:
+    """Return a two-dimensional float vector, padding incomplete values."""
+    try:
+        values = np.asarray(value, dtype=float).reshape(-1)
+    except (TypeError, ValueError):
+        values = np.empty(0, dtype=float)
+    if values.size < 2:
+        values = np.pad(values, (0, 2 - values.size), constant_values=default[0])
+    return values[:2]
+
+
 def _build_socnav_config(config: dict[str, Any]) -> SocNavPlannerConfig:
     """Return a SocNavPlannerConfig filtered from a loose mapping.
 
@@ -65,11 +89,13 @@ class OrcaPlanner:
         """
         self._seed = seed
         self._config = self._parse_config(config)
-        if isinstance(config, dict):
-            allow_fallback = bool(config.get("allow_fallback", False))
-        else:
-            allow_fallback = False
-        self._adapter = ORCAPlannerAdapter(config=self._config, allow_fallback=allow_fallback)
+        self._allow_fallback = (
+            bool(config.get("allow_fallback", False)) if isinstance(config, dict) else False
+        )
+        self._adapter = ORCAPlannerAdapter(
+            config=self._config,
+            allow_fallback=self._allow_fallback,
+        )
 
     @staticmethod
     def _parse_config(config: dict[str, Any] | SocNavPlannerConfig) -> SocNavPlannerConfig:
@@ -92,6 +118,16 @@ class OrcaPlanner:
             self._seed = seed
         self._adapter.reset()
 
+    def configure(self, config: dict[str, Any] | SocNavPlannerConfig) -> None:
+        """Replace planner configuration and propagate it to the ORCA adapter."""
+        if isinstance(config, dict) and "allow_fallback" in config:
+            self._allow_fallback = bool(config["allow_fallback"])
+        self._config = self._parse_config(config)
+        self._adapter = ORCAPlannerAdapter(
+            config=self._config,
+            allow_fallback=self._allow_fallback,
+        )
+
     def _to_adapter_observation(self, obs: Observation | dict[str, Any]) -> dict[str, Any]:
         """Adapt a benchmark Observation into the SocNav structured observation.
 
@@ -102,27 +138,23 @@ class OrcaPlanner:
         if isinstance(obs, Observation):
             robot = dict(obs.robot)
             agents = list(obs.agents)
-            dt = float(getattr(obs, "dt", 0.1) or 0.1)
+            dt = _coerce_scalar(getattr(obs, "dt", 0.1), 0.1)
         else:
-            robot = dict(obs.get("robot", {}))
-            agents = list(obs.get("agents", []))
+            robot = dict(obs.get("robot") or {})
+            agents = list(obs.get("agents") or [])
             sim = obs.get("sim", {}) or {}
-            dt_value = sim.get("timestep", [0.1])
-            dt = float(np.asarray(dt_value, dtype=float).reshape(-1)[0]) if dt_value else 0.1
+            dt_value = sim.get("timestep", [0.1]) if isinstance(sim, dict) else [0.1]
+            dt = _coerce_scalar(dt_value, 0.1)
 
         # The SocNav-family ORCA adapter expects a richer robot state than the
         # canonical baseline Observation: heading, speed, and radius are required
         # by the rvo2 solver path. Default them from velocity/radius so a
         # minimal benchmark Observation still drives the planner.
-        robot_position = np.asarray(robot.get("position", [0.0, 0.0]), dtype=float).reshape(-1)[:2]
-        robot_velocity = np.asarray(robot.get("velocity", [0.0, 0.0]), dtype=float).reshape(-1)[:2]
-        robot_radius = float(np.asarray(robot.get("radius", 0.3), dtype=float).reshape(-1)[0])
-        heading_value = float(
-            np.asarray(
-                robot.get("heading", np.arctan2(robot_velocity[1], robot_velocity[0] + 1e-9)),
-                dtype=float,
-            ).reshape(-1)[0]
-        )
+        robot_position = _coerce_vector2(robot.get("position", [0.0, 0.0]))
+        robot_velocity = _coerce_vector2(robot.get("velocity", [0.0, 0.0]))
+        robot_radius = _coerce_scalar(robot.get("radius", 0.3), 0.3)
+        default_heading = float(np.arctan2(robot_velocity[1], robot_velocity[0] + 1e-9))
+        heading_value = _coerce_scalar(robot.get("heading"), default_heading)
         # The SocNav-family adapter indexes heading/radius as length-1 arrays, so
         # adapt them into that shape.
         heading = [heading_value]
@@ -135,26 +167,14 @@ class OrcaPlanner:
             "radius": [robot_radius],
         }
 
-        goal = robot.get("goal")
         goal_state = {
-            "current": list(np.asarray(goal, dtype=float).reshape(-1)[:2])
-            if goal is not None
-            else [0.0, 0.0]
+            "current": list(_coerce_vector2(robot.get("goal"))),
         }
-        positions = [
-            list(np.asarray(a.get("position", [0.0, 0.0]), dtype=float).reshape(-1)[:2])
-            for a in agents
-        ]
-        velocities = [
-            list(np.asarray(a.get("velocity", [0.0, 0.0]), dtype=float).reshape(-1)[:2])
-            for a in agents
-        ]
+        positions = [list(_coerce_vector2(a.get("position", [0.0, 0.0]))) for a in agents]
+        velocities = [list(_coerce_vector2(a.get("velocity", [0.0, 0.0]))) for a in agents]
         count = len(agents)
-        radius = (
-            float(np.asarray(agents[0].get("radius", 0.3), dtype=float).reshape(-1)[0])
-            if count > 0
-            else 0.3
-        )
+        first_agent = agents[0] if count > 0 and isinstance(agents[0], dict) else {}
+        radius = _coerce_scalar(first_agent.get("radius", 0.3), 0.3)
         ped_state = {
             "positions": positions,
             "velocities": velocities,
@@ -174,7 +194,11 @@ class OrcaPlanner:
         Returns:
             Action dict ``{"vx", "vy"}`` in the world frame.
         """
-        if isinstance(obs, dict):
+        if isinstance(obs, dict) and (
+            "pedestrians" in obs
+            or "pedestrians_positions" in obs
+            or ("goal" in obs and "agents" not in obs)
+        ):
             adapter_obs: dict[str, Any] = obs
         else:
             adapter_obs = self._to_adapter_observation(obs)

--- a/tests/benchmark/test_orca_baseline_registration_issue_5491.py
+++ b/tests/benchmark/test_orca_baseline_registration_issue_5491.py
@@ -12,6 +12,7 @@ executes (or fail-closes with an explicit error, never a silent
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -19,6 +20,8 @@ import numpy as np
 from robot_sf.baselines import get_baseline, list_baselines
 from robot_sf.baselines.interface import Observation
 from robot_sf.baselines.orca import OrcaPlanner
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_orca_is_registered_in_baseline_registry():
@@ -74,6 +77,55 @@ def test_orca_planner_metadata_reports_orca():
     assert "config_hash" in meta
 
 
+def test_orca_planner_configure_updates_adapter():
+    """Runtime configuration updates reach both planner and adapter state."""
+    planner = OrcaPlanner({"max_linear_speed": 1.0}, seed=3)
+    planner.configure({"max_linear_speed": 0.25})
+    assert planner._config.max_linear_speed == 0.25
+    assert planner._adapter.config.max_linear_speed == 0.25
+
+
+def test_orca_planner_adapts_canonical_mapping_and_empty_scalars():
+    """Canonical mappings and malformed optional scalars remain executable."""
+    planner = OrcaPlanner({}, seed=3)
+    adapted = planner._to_adapter_observation(
+        {
+            "sim": {"timestep": np.array([])},
+            "robot": {
+                "position": [0.0, 0.0],
+                "velocity": [0.0, 0.0],
+                "heading": None,
+                "radius": np.array([]),
+                "goal": [9.7, 3.0],
+            },
+            "agents": [
+                {
+                    "position": [1.0, 0.0],
+                    "velocity": [0.0, 0.0],
+                    "radius": None,
+                }
+            ],
+        }
+    )
+    assert adapted["sim"]["timestep"] == [0.1]
+    assert adapted["robot"]["heading"]
+    assert adapted["robot"]["radius"] == [0.3]
+    assert adapted["pedestrians"]["radius"] == [0.3]
+    action = planner.step(
+        {
+            "dt": 0.1,
+            "robot": {
+                "position": [0.0, 0.0],
+                "velocity": [0.0, 0.0],
+                "goal": [9.7, 3.0],
+                "radius": 0.3,
+            },
+            "agents": [],
+        }
+    )
+    assert set(action) == {"vx", "vy"}
+
+
 def test_orca_planner_reset_is_seeded_and_deterministic():
     """Resetting with a seed reproduces the initial action."""
     planner = OrcaPlanner({}, seed=5)
@@ -110,7 +162,7 @@ def test_run_episode_with_orca_algo_does_not_crash():
     from robot_sf.benchmark.runner import run_episode
 
     scenario_params: dict[str, Any] = {
-        "map": "maps/svg_maps/empty.svg",
+        "map_file": str(REPO_ROOT / "maps/svg_maps/atomic_empty_frame_test.svg"),
         "num_peds": 2,
         "robot_radius": 0.3,
         "ped_radius": 0.35,
@@ -128,3 +180,5 @@ def test_run_episode_with_orca_algo_does_not_crash():
     assert "metrics" in record
     planner_meta = record.get("algorithm_metadata", {})
     assert planner_meta.get("algorithm") == "orca"
+    assert planner_meta.get("status") == "ok"
+    assert planner_meta.get("policy_step_timeout", {}).get("fallback_actions") == 0

--- a/tests/benchmark/test_orca_baseline_registration_issue_5491.py
+++ b/tests/benchmark/test_orca_baseline_registration_issue_5491.py
@@ -1,0 +1,130 @@
+"""Regression tests for historical ``orca`` baseline registration (issue #5491).
+
+The exact-repeat campaign for #5263 resolves cells with ``algo: orca`` and
+routes execution through ``runner.run_episode(algo="orca")`` ->
+``_load_baseline_planner``.  That baseline registry only knew the map-based
+``ORCAPlannerAdapter`` (via ``map_runner``), so the executor crashed with
+``Unknown algorithm 'orca'`` instead of running the cell.  These tests
+prove the ``orca`` baseline is registered and that an ``algo: orca`` cell
+executes (or fail-closes with an explicit error, never a silent
+``Unknown algorithm`` crash).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from robot_sf.baselines import get_baseline, list_baselines
+from robot_sf.baselines.interface import Observation
+from robot_sf.baselines.orca import OrcaPlanner
+
+
+def test_orca_is_registered_in_baseline_registry():
+    """The baseline registry must expose ``orca`` after the #5491 fix."""
+    assert "orca" in list_baselines()
+    cls = get_baseline("orca")
+    assert cls is OrcaPlanner
+
+
+def test_orca_loader_does_not_raise_unknown_algorithm():
+    """``_load_baseline_planner`` resolves ``orca`` without the historical crash.
+
+    Issue #5491 reproduced ``ValueError: Unknown algorithm 'orca'`` because the
+    baseline registry lacked the ``orca`` entry.  Constructing the planner via
+    the public registry must succeed.
+    """
+    planner_class = get_baseline("orca")
+    planner = planner_class({}, seed=1)
+    assert planner is not None
+
+
+def _orca_observation(robot_position=(0.0, 0.0), goal=(9.7, 3.0)) -> Observation:
+    """Build a canonical benchmark Observation for the ORCA planner."""
+    return Observation(
+        dt=0.1,
+        robot={
+            "position": list(robot_position),
+            "velocity": [0.0, 0.0],
+            "goal": list(goal),
+            "radius": 0.3,
+        },
+        agents=[],
+    )
+
+
+def test_orca_planner_returns_world_velocity_action():
+    """The ORCA baseline yields a world-frame ``{"vx", "vy"}`` action."""
+    planner = OrcaPlanner({}, seed=1)
+    action = planner.step(_orca_observation())
+    assert set(action.keys()) == {"vx", "vy"}
+    for key in ("vx", "vy"):
+        assert isinstance(action[key], float)
+    speed = float(np.hypot(action["vx"], action["vy"]))
+    assert speed <= float(planner._config.max_linear_speed) + 1e-6
+
+
+def test_orca_planner_metadata_reports_orca():
+    """Planner metadata identifies the algorithm as ``orca`` with status ``ok``."""
+    planner = OrcaPlanner({}, seed=3)
+    meta = planner.get_metadata()
+    assert meta["algorithm"] == "orca"
+    assert meta["status"] == "ok"
+    assert "config_hash" in meta
+
+
+def test_orca_planner_reset_is_seeded_and_deterministic():
+    """Resetting with a seed reproduces the initial action."""
+    planner = OrcaPlanner({}, seed=5)
+    obs = _orca_observation()
+    first = planner.step(obs)["vx"]
+    planner.reset(seed=5)
+    assert planner.step(obs)["vx"] == first
+
+
+def test_orca_planner_adapts_scalar_robot_state():
+    """A minimal Observation without heading/speed still drives the rvo2 solver."""
+    planner = OrcaPlanner({}, seed=1)
+    obs = Observation(
+        dt=0.1,
+        robot={
+            "position": [1.0, 0.3],
+            "velocity": [1.0, 0.0],
+            "goal": [9.7, 3.0],
+            "radius": 0.3,
+        },
+        agents=[],
+    )
+    action = planner.step(obs)
+    assert set(action.keys()) == {"vx", "vy"}
+
+
+def test_run_episode_with_orca_algo_does_not_crash():
+    """The exact-repeat executor path (``run_episode(algo="orca")``) runs the cell.
+
+    This is the headless CPU contract from issue #5491 acceptance: execute
+    over an ``algo: orca`` cell either runs or fail-closes, never raising
+    the historical ``Unknown algorithm 'orca'`` ValueError.
+    """
+    from robot_sf.benchmark.runner import run_episode
+
+    scenario_params: dict[str, Any] = {
+        "map": "maps/svg_maps/empty.svg",
+        "num_peds": 2,
+        "robot_radius": 0.3,
+        "ped_radius": 0.35,
+        "seed": 7,
+    }
+    record = run_episode(
+        scenario_params,
+        7,
+        algo="orca",
+        horizon=20,
+        dt=0.1,
+        record_forces=False,
+    )
+    assert "outcome" in record
+    assert "metrics" in record
+    planner_meta = record.get("algorithm_metadata", {})
+    assert planner_meta.get("algorithm") == "orca"


### PR DESCRIPTION
## What / Why

The exact-repeat executor for #5263 (`execute_campaign` -> `runner.run_episode(algo="orca")` -> `_load_baseline_planner`) crashed with `ValueError: Unknown algorithm 'orca'` on the 60 historical `algo: orca` cells. ORCA was never registered in the `robot_sf/baselines` registry that `_load_baseline_planner` consults; it only existed as `ORCAPlannerAdapter` behind the map-based `map_runner` path. This is the successor slice for #5491 and does not duplicate the two prior preparatory/reference PRs: a regression fix that restores the `orca` baseline so cells execute on current `main`.

## Fix

- `robot_sf/baselines/orca.py` (new): `OrcaPlanner` wraps `ORCAPlannerAdapter` and adapts the canonical baseline `Observation` and mapping inputs into the SocNav structured observation the adapter expects, returning a world-frame `{"vx", "vy"}` action. `reset`, `configure`, `get_metadata`, and `close` are supported.
- `robot_sf/baselines/__init__.py`: register `"orca"` via a lazy `_get_orca_planner` factory.
- The benchmark-ready path requires the declared `rvo2` extra; missing `rvo2` fails closed rather than claiming native benchmark execution.

## Validation

- Focused tests in `tests/benchmark/test_orca_baseline_registration_issue_5491.py`: 9/9 pass (registry registration, runtime configuration, malformed optional scalar handling, step/reset/metadata, and full `run_episode(algo="orca")` with zero fallback actions).
- A resolved #5263 ORCA target (`classic_bottleneck_high--111`) executes end-to-end through the real resolved bundle for three repeats when the `orca` extra is installed; this is implementation proof only, not a full campaign or benchmark claim.
- Exact-repeat and runner regression proof: 39 passed.
- `ruff check` / `ruff format` clean on changed files.
- CPU-only, no campaigns / Slurm / training / benchmark claims.

## Note on #5263

Root cause was a missing baseline-registry entry, not a retired ORCA: ORCA was alive in `map_runner` and is now restored for the episode-executor path. The #5263 exact-repeat contract (manifest / resolve-definitions / hash checks) remains intact; this PR restores the missing `orca` routing without claiming the full 420-repeat campaign or cross-host determinism result.

Closes #5491

This PR was produced by the OpenGateway/auto-smart-routing cheap implementation lane; the review gate hardens and merges.
