### PR TITLE
fix(benchmark): harden exact-repeat aliases and disposition verification after ORCA restore

### DIFF
--- a/robot_sf/baselines/__init__.py
+++ b/robot_sf/baselines/__init__.py
@@ -164,8 +164,7 @@ def is_runnable_algo(name: str) -> bool:
     The benchmark episode runner resolves a planner either as the built-in
     goal-seeking policy (``SIMPLE_POLICY_ALIASES``) or through the baseline
     registry (``BASELINES``). Planners that live only in other execution
-    pipelines (e.g. the map-runner holonomic world-velocity ORCA path backed by
-    upstream RVO2) are not reachable here.
+    pipelines and have no episode-runner adapter are not reachable here.
 
     Returns:
         True when the algorithm can be constructed by ``run_episode``.

--- a/robot_sf/baselines/__init__.py
+++ b/robot_sf/baselines/__init__.py
@@ -131,4 +131,34 @@ def list_baselines() -> list[str]:
     return list(BASELINES.keys())
 
 
-__all__ = ["BASELINES", "get_baseline", "list_baselines"]
+# Aliases for the built-in naive goal-seeking policy that the benchmark runner
+# constructs directly (see ``robot_sf.benchmark.runner._create_robot_policy``),
+# outside the baseline registry above. Kept aligned with the ``goal`` canonical
+# planner declared in ``robot_sf.benchmark.algorithm_readiness``.
+SIMPLE_POLICY_ALIASES: frozenset[str] = frozenset(
+    {"simple_policy", "goal", "simple", "goal_policy"}
+)
+
+
+def is_runnable_algo(name: str) -> bool:
+    """Return whether ``robot_sf.benchmark.runner.run_episode`` can execute ``name``.
+
+    The benchmark episode runner resolves a planner either as the built-in
+    goal-seeking policy (``SIMPLE_POLICY_ALIASES``) or through the baseline
+    registry (``BASELINES``). Planners that live only in other execution
+    pipelines (e.g. the map-runner holonomic world-velocity ORCA path backed by
+    upstream RVO2) are not reachable here.
+
+    Returns:
+        True when the algorithm can be constructed by ``run_episode``.
+    """
+    return name in SIMPLE_POLICY_ALIASES or name in BASELINES
+
+
+__all__ = [
+    "BASELINES",
+    "SIMPLE_POLICY_ALIASES",
+    "get_baseline",
+    "is_runnable_algo",
+    "list_baselines",
+]

--- a/robot_sf/benchmark/exact_repeat_campaign.py
+++ b/robot_sf/benchmark/exact_repeat_campaign.py
@@ -521,6 +521,10 @@ def verify_host_report(  # noqa: C901, PLR0912, PLR0915 - each rejected report s
         if disposition is not None:
             if disposition != UNRUNNABLE_DISPOSITION:
                 raise ValueError(f"target {key} has an unsupported disposition {disposition!r}")
+            if "repeats" in result and result["repeats"] != []:
+                raise ValueError(
+                    f"target {key} has disposition {disposition!r} but also reports repeats"
+                )
             verified = {
                 "scenario_id": key[0],
                 "planner": key[1],
@@ -570,6 +574,8 @@ def verify_host_report(  # noqa: C901, PLR0912, PLR0915 - each rejected report s
                     "exact_repeat_determinism": None,
                     "first_divergence": None,
                     "n_targets": len(target_results),
+                    "n_runnable_targets": 0,
+                    "n_unrunnable_targets": len(target_results),
                 }
             )
             continue
@@ -583,7 +589,9 @@ def verify_host_report(  # noqa: C901, PLR0912, PLR0915 - each rejected report s
                 "unrunnable": False,
                 "exact_repeat_determinism": first is None,
                 "first_divergence": first,
-                "n_targets": len(runnable),
+                "n_targets": len(target_results),
+                "n_runnable_targets": len(runnable),
+                "n_unrunnable_targets": len(target_results) - len(runnable),
             }
         )
     runnable_cells = [cell for cell in cells if not cell.get("unrunnable")]
@@ -603,7 +611,8 @@ def verify_host_report(  # noqa: C901, PLR0912, PLR0915 - each rejected report s
             "n_unrunnable_cells": len(unrunnable_cells),
             # The bitwise-identical claim scopes to runnable cells; unrunnable
             # (dispositioned) cells make no determinism claim.
-            "all_cells_bitwise_identical": all(
+            "all_cells_bitwise_identical": bool(runnable_cells)
+            and all(
                 cell["exact_repeat_determinism"] for cell in runnable_cells
             ),
         },

--- a/robot_sf/benchmark/exact_repeat_campaign.py
+++ b/robot_sf/benchmark/exact_repeat_campaign.py
@@ -45,6 +45,13 @@ RESOLVED_DEFINITIONS_SCHEMA_VERSION = "scenario_exact_repeat_resolved_definition
 DEFAULT_REPEATS = 3
 SOURCE_IDENTITY_REVISION = "a5516b432fceffa71573e458aaee31c00a0b6c81"
 
+# Explicit per-cell disposition for planners the exact-repeat ``execute`` path
+# cannot construct on current main (e.g. ``orca``, which historically ran only in
+# the map-runner holonomic world-velocity pipeline backed by upstream RVO2, not in
+# the ``run_episode`` baseline registry). Such cells are recorded, not crashed,
+# and are excluded from the bitwise-identical repeat claim.
+UNRUNNABLE_DISPOSITION = "unrunnable_on_current_main"
+
 
 def canonical_sha256(value: Any) -> str:
     """Return a stable SHA-256 digest for a JSON-compatible value."""
@@ -460,7 +467,7 @@ def _first_divergence(repeats: Sequence[Mapping[str, Any]]) -> dict[str, Any] | 
     return None
 
 
-def verify_host_report(  # noqa: C901, PLR0912 - each rejected report state needs a specific error.
+def verify_host_report(  # noqa: C901, PLR0912, PLR0915 - each rejected report state needs a specific error.
     manifest: Mapping[str, Any], host_report: Mapping[str, Any]
 ) -> dict[str, Any]:
     """Verify one host's exact-repeat results against the immutable manifest.
@@ -510,6 +517,24 @@ def verify_host_report(  # noqa: C901, PLR0912 - each rejected report state need
     by_cell: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
     for key in sorted(targets):
         result = indexed_results[key]
+        disposition = result.get("disposition")
+        if disposition is not None:
+            if disposition != UNRUNNABLE_DISPOSITION:
+                raise ValueError(f"target {key} has an unsupported disposition {disposition!r}")
+            verified = {
+                "scenario_id": key[0],
+                "planner": key[1],
+                "seed": key[2],
+                "unrunnable": True,
+                "disposition": disposition,
+                "disposition_reason": result.get("disposition_reason"),
+                "bitwise_identical": None,
+                "first_divergence": None,
+                "repeat_fingerprints": [],
+            }
+            verified_targets.append(verified)
+            by_cell[key[:2]].append(verified)
+            continue
         repeats = result.get("repeats")
         if not isinstance(repeats, list) or len(repeats) != repeats_per_target:
             raise ValueError(f"target {key} must contain exactly {repeats_per_target} repeats")
@@ -524,6 +549,7 @@ def verify_host_report(  # noqa: C901, PLR0912 - each rejected report state need
             "scenario_id": key[0],
             "planner": key[1],
             "seed": key[2],
+            "unrunnable": False,
             "bitwise_identical": divergence is None,
             "first_divergence": divergence,
             "repeat_fingerprints": [_repeat_fingerprint(item) for item in repeat_maps],
@@ -533,18 +559,35 @@ def verify_host_report(  # noqa: C901, PLR0912 - each rejected report state need
 
     cells = []
     for (scenario_id, planner), target_results in sorted(by_cell.items()):
+        runnable = [item for item in target_results if not item.get("unrunnable")]
+        if not runnable:
+            cells.append(
+                {
+                    "scenario_id": scenario_id,
+                    "planner": planner,
+                    "unrunnable": True,
+                    "disposition": UNRUNNABLE_DISPOSITION,
+                    "exact_repeat_determinism": None,
+                    "first_divergence": None,
+                    "n_targets": len(target_results),
+                }
+            )
+            continue
         first = next(
-            (item["first_divergence"] for item in target_results if item["first_divergence"]), None
+            (item["first_divergence"] for item in runnable if item["first_divergence"]), None
         )
         cells.append(
             {
                 "scenario_id": scenario_id,
                 "planner": planner,
+                "unrunnable": False,
                 "exact_repeat_determinism": first is None,
                 "first_divergence": first,
-                "n_targets": len(target_results),
+                "n_targets": len(runnable),
             }
         )
+    runnable_cells = [cell for cell in cells if not cell.get("unrunnable")]
+    unrunnable_cells = [cell for cell in cells if cell.get("unrunnable")]
     verified = {
         "schema_version": VERIFIED_HOST_REPORT_SCHEMA_VERSION,
         "manifest_sha256": manifest["manifest_sha256"],
@@ -553,14 +596,22 @@ def verify_host_report(  # noqa: C901, PLR0912 - each rejected report state need
         "cells": cells,
         "summary": {
             "n_targets": len(verified_targets),
+            "n_runnable_targets": sum(1 for t in verified_targets if not t.get("unrunnable")),
+            "n_unrunnable_targets": sum(1 for t in verified_targets if t.get("unrunnable")),
             "n_cells": len(cells),
-            "all_cells_bitwise_identical": all(cell["exact_repeat_determinism"] for cell in cells),
+            "n_runnable_cells": len(runnable_cells),
+            "n_unrunnable_cells": len(unrunnable_cells),
+            # The bitwise-identical claim scopes to runnable cells; unrunnable
+            # (dispositioned) cells make no determinism claim.
+            "all_cells_bitwise_identical": all(
+                cell["exact_repeat_determinism"] for cell in runnable_cells
+            ),
         },
     }
     return verified
 
 
-def compare_verified_hosts(
+def compare_verified_hosts(  # noqa: C901 - each rejected cross-host state needs a specific branch.
     manifest: Mapping[str, Any], first: Mapping[str, Any], second: Mapping[str, Any]
 ) -> dict[str, Any]:
     """Build the fail-closed two-host exact-repeat comparison matrix.
@@ -595,22 +646,39 @@ def compare_verified_hosts(
     if set(first_targets) != set(targets) or set(second_targets) != set(targets):
         raise ValueError("verified host reports do not cover the manifest target set")
     cells: dict[tuple[str, str], list[bool]] = defaultdict(list)
+    unrunnable_cells: set[tuple[str, str]] = set()
     for key in sorted(targets):
+        if first_targets[key].get("unrunnable") or second_targets[key].get("unrunnable"):
+            unrunnable_cells.add(key[:2])
+            continue
         identical = first_targets[key].get("repeat_fingerprints") == second_targets[key].get(
             "repeat_fingerprints"
         )
         cells[key[:2]].append(bool(identical))
-    matrix = [
-        {
-            "scenario_id": scenario_id,
-            "planner": planner,
-            "bitwise_identical": version_match and all(target_matches),
-            "comparison_status": "identical"
-            if version_match and all(target_matches)
-            else "divergent",
-        }
-        for (scenario_id, planner), target_matches in sorted(cells.items())
-    ]
+    matrix = []
+    for cell_key in sorted(set(cells) | unrunnable_cells):
+        scenario_id, planner = cell_key
+        if cell_key in unrunnable_cells:
+            matrix.append(
+                {
+                    "scenario_id": scenario_id,
+                    "planner": planner,
+                    "bitwise_identical": None,
+                    "comparison_status": "unrunnable",
+                }
+            )
+            continue
+        target_matches = cells[cell_key]
+        identical = version_match and all(target_matches)
+        matrix.append(
+            {
+                "scenario_id": scenario_id,
+                "planner": planner,
+                "bitwise_identical": identical,
+                "comparison_status": "identical" if identical else "divergent",
+            }
+        )
+    runnable_rows = [row for row in matrix if row["comparison_status"] != "unrunnable"]
     return {
         "schema_version": CROSS_HOST_SCHEMA_VERSION,
         "manifest_sha256": manifest["manifest_sha256"],
@@ -619,8 +687,11 @@ def compare_verified_hosts(
         "matrix": matrix,
         "summary": {
             "n_cells": len(matrix),
+            "n_runnable_cells": len(runnable_rows),
+            "n_unrunnable_cells": len(unrunnable_cells),
             "all_cells_bitwise_identical": version_match
-            and all(row["bitwise_identical"] for row in matrix),
+            and bool(runnable_rows)
+            and all(row["bitwise_identical"] for row in runnable_rows),
         },
     }
 
@@ -799,6 +870,12 @@ def execute_campaign(  # noqa: C901, PLR0912, PLR0915 - fail-closed execution tr
     )
     _, repeats_per_target = _check_manifest_from_bundle(resolved_bundle)
 
+    # The runnability predicate reflects current main's ``run_episode`` registry
+    # and is applied even when a runner is injected, so the disposition records a
+    # property of the codebase rather than of the test harness. Imported from the
+    # lightweight baselines package to avoid pulling heavy optional deps.
+    from robot_sf.baselines import is_runnable_algo  # noqa: PLC0415
+
     if run_episode is None:
         from robot_sf.benchmark.runner import run_episode as _run_episode  # noqa: PLC0415
 
@@ -871,6 +948,33 @@ def execute_campaign(  # noqa: C901, PLR0912, PLR0915 - fail-closed execution tr
         planner_algo = _require_text(
             planner_def.get("algo"), f"planner_definition {planner_def_id!r} algo"
         )
+
+        # Fail closed on planners the run_episode path cannot construct (e.g. orca),
+        # recording an explicit disposition instead of crashing the whole campaign.
+        if not is_runnable_algo(planner_algo):
+            result_entry = {
+                "scenario_id": scenario_id,
+                "planner": planner,
+                "seed": seed,
+                "horizon": horizon,
+                "source_config_hash": target["source_config_hash"],
+                "repeats": [],
+                "disposition": UNRUNNABLE_DISPOSITION,
+                "disposition_reason": (
+                    f"planner {planner_algo!r} has no executor in the exact-repeat "
+                    "run_episode baseline registry on current main"
+                ),
+            }
+            results.append(result_entry)
+            cache_data = {
+                "_env_numpy_version": env_fingerprint["numpy_version"],
+                "_env_numba_version": env_fingerprint["numba_version"],
+                "_result": result_entry,
+            }
+            cache_file.write_text(
+                json.dumps(cache_data, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            continue
 
         # Determine DT from resolved bundle execution contract or scenario config
         sim_config = scenario_params.get("simulation_config", {})

--- a/robot_sf/benchmark/exact_repeat_campaign.py
+++ b/robot_sf/benchmark/exact_repeat_campaign.py
@@ -46,9 +46,8 @@ DEFAULT_REPEATS = 3
 SOURCE_IDENTITY_REVISION = "a5516b432fceffa71573e458aaee31c00a0b6c81"
 
 # Explicit per-cell disposition for planners the exact-repeat ``execute`` path
-# cannot construct on current main (e.g. ``orca``, which historically ran only in
-# the map-runner holonomic world-velocity pipeline backed by upstream RVO2, not in
-# the ``run_episode`` baseline registry). Such cells are recorded, not crashed,
+# cannot construct on current main (for example, a planner registered only in a
+# separate map-runner pipeline). Such cells are recorded, not crashed,
 # and are excluded from the bitwise-identical repeat claim.
 UNRUNNABLE_DISPOSITION = "unrunnable_on_current_main"
 
@@ -612,9 +611,7 @@ def verify_host_report(  # noqa: C901, PLR0912, PLR0915 - each rejected report s
             # The bitwise-identical claim scopes to runnable cells; unrunnable
             # (dispositioned) cells make no determinism claim.
             "all_cells_bitwise_identical": bool(runnable_cells)
-            and all(
-                cell["exact_repeat_determinism"] for cell in runnable_cells
-            ),
+            and all(cell["exact_repeat_determinism"] for cell in runnable_cells),
         },
     }
     return verified

--- a/robot_sf/benchmark/exact_repeat_campaign.py
+++ b/robot_sf/benchmark/exact_repeat_campaign.py
@@ -51,6 +51,7 @@ SOURCE_IDENTITY_REVISION = "a5516b432fceffa71573e458aaee31c00a0b6c81"
 # the ``run_episode`` baseline registry). Such cells are recorded, not crashed,
 # and are excluded from the bitwise-identical repeat claim.
 UNRUNNABLE_DISPOSITION = "unrunnable_on_current_main"
+MIXED_DISPOSITION = "mixed_runnability"
 
 
 def canonical_sha256(value: Any) -> str:
@@ -521,13 +522,21 @@ def verify_host_report(  # noqa: C901, PLR0912, PLR0915 - each rejected report s
         if disposition is not None:
             if disposition != UNRUNNABLE_DISPOSITION:
                 raise ValueError(f"target {key} has an unsupported disposition {disposition!r}")
+            repeats = result.get("repeats")
+            if "repeats" in result and (not isinstance(repeats, list) or repeats):
+                raise ValueError(
+                    f"target {key} has disposition {disposition!r} but also reports repeats"
+                )
+            disposition_reason = _require_text(
+                result.get("disposition_reason"), f"target {key} disposition_reason"
+            )
             verified = {
                 "scenario_id": key[0],
                 "planner": key[1],
                 "seed": key[2],
                 "unrunnable": True,
                 "disposition": disposition,
-                "disposition_reason": result.get("disposition_reason"),
+                "disposition_reason": disposition_reason,
                 "bitwise_identical": None,
                 "first_divergence": None,
                 "repeat_fingerprints": [],
@@ -560,6 +569,9 @@ def verify_host_report(  # noqa: C901, PLR0912, PLR0915 - each rejected report s
     cells = []
     for (scenario_id, planner), target_results in sorted(by_cell.items()):
         runnable = [item for item in target_results if not item.get("unrunnable")]
+        n_targets = len(target_results)
+        n_runnable_targets = len(runnable)
+        n_unrunnable_targets = n_targets - n_runnable_targets
         if not runnable:
             cells.append(
                 {
@@ -569,25 +581,49 @@ def verify_host_report(  # noqa: C901, PLR0912, PLR0915 - each rejected report s
                     "disposition": UNRUNNABLE_DISPOSITION,
                     "exact_repeat_determinism": None,
                     "first_divergence": None,
-                    "n_targets": len(target_results),
+                    "n_targets": n_targets,
+                    "n_runnable_targets": 0,
+                    "n_unrunnable_targets": n_unrunnable_targets,
                 }
             )
             continue
         first = next(
             (item["first_divergence"] for item in runnable if item["first_divergence"]), None
         )
+        if n_unrunnable_targets:
+            cells.append(
+                {
+                    "scenario_id": scenario_id,
+                    "planner": planner,
+                    "unrunnable": False,
+                    "mixed": True,
+                    "disposition": MIXED_DISPOSITION,
+                    "exact_repeat_determinism": None,
+                    "first_divergence": first,
+                    "n_targets": n_targets,
+                    "n_runnable_targets": n_runnable_targets,
+                    "n_unrunnable_targets": n_unrunnable_targets,
+                }
+            )
+            continue
         cells.append(
             {
                 "scenario_id": scenario_id,
                 "planner": planner,
                 "unrunnable": False,
+                "mixed": False,
                 "exact_repeat_determinism": first is None,
                 "first_divergence": first,
-                "n_targets": len(runnable),
+                "n_targets": n_targets,
+                "n_runnable_targets": n_runnable_targets,
+                "n_unrunnable_targets": 0,
             }
         )
-    runnable_cells = [cell for cell in cells if not cell.get("unrunnable")]
+    runnable_cells = [
+        cell for cell in cells if not cell.get("unrunnable") and not cell.get("mixed")
+    ]
     unrunnable_cells = [cell for cell in cells if cell.get("unrunnable")]
+    mixed_cells = [cell for cell in cells if cell.get("mixed")]
     verified = {
         "schema_version": VERIFIED_HOST_REPORT_SCHEMA_VERSION,
         "manifest_sha256": manifest["manifest_sha256"],
@@ -601,11 +637,11 @@ def verify_host_report(  # noqa: C901, PLR0912, PLR0915 - each rejected report s
             "n_cells": len(cells),
             "n_runnable_cells": len(runnable_cells),
             "n_unrunnable_cells": len(unrunnable_cells),
+            "n_mixed_cells": len(mixed_cells),
             # The bitwise-identical claim scopes to runnable cells; unrunnable
-            # (dispositioned) cells make no determinism claim.
-            "all_cells_bitwise_identical": all(
-                cell["exact_repeat_determinism"] for cell in runnable_cells
-            ),
+            # or mixed cells make no determinism claim.
+            "all_cells_bitwise_identical": bool(runnable_cells)
+            and all(cell["exact_repeat_determinism"] for cell in runnable_cells),
         },
     }
     return verified
@@ -646,25 +682,40 @@ def compare_verified_hosts(  # noqa: C901 - each rejected cross-host state needs
     if set(first_targets) != set(targets) or set(second_targets) != set(targets):
         raise ValueError("verified host reports do not cover the manifest target set")
     cells: dict[tuple[str, str], list[bool]] = defaultdict(list)
-    unrunnable_cells: set[tuple[str, str]] = set()
+    target_counts: dict[tuple[str, str], int] = defaultdict(int)
+    unrunnable_target_counts: dict[tuple[str, str], int] = defaultdict(int)
     for key in sorted(targets):
+        cell_key = key[:2]
+        target_counts[cell_key] += 1
         if first_targets[key].get("unrunnable") or second_targets[key].get("unrunnable"):
-            unrunnable_cells.add(key[:2])
+            unrunnable_target_counts[cell_key] += 1
             continue
         identical = first_targets[key].get("repeat_fingerprints") == second_targets[key].get(
             "repeat_fingerprints"
         )
-        cells[key[:2]].append(bool(identical))
+        cells[cell_key].append(bool(identical))
     matrix = []
-    for cell_key in sorted(set(cells) | unrunnable_cells):
+    for cell_key in sorted(set(cells) | set(unrunnable_target_counts)):
         scenario_id, planner = cell_key
-        if cell_key in unrunnable_cells:
+        n_unrunnable_targets = unrunnable_target_counts.get(cell_key, 0)
+        if n_unrunnable_targets:
+            comparison_status = (
+                "unrunnable" if n_unrunnable_targets == target_counts[cell_key] else "mixed"
+            )
             matrix.append(
                 {
                     "scenario_id": scenario_id,
                     "planner": planner,
                     "bitwise_identical": None,
-                    "comparison_status": "unrunnable",
+                    "comparison_status": comparison_status,
+                    "disposition": (
+                        UNRUNNABLE_DISPOSITION
+                        if comparison_status == "unrunnable"
+                        else MIXED_DISPOSITION
+                    ),
+                    "n_targets": target_counts[cell_key],
+                    "n_runnable_targets": target_counts[cell_key] - n_unrunnable_targets,
+                    "n_unrunnable_targets": n_unrunnable_targets,
                 }
             )
             continue
@@ -678,7 +729,11 @@ def compare_verified_hosts(  # noqa: C901 - each rejected cross-host state needs
                 "comparison_status": "identical" if identical else "divergent",
             }
         )
-    runnable_rows = [row for row in matrix if row["comparison_status"] != "unrunnable"]
+    runnable_rows = [
+        row for row in matrix if row["comparison_status"] in {"identical", "divergent"}
+    ]
+    unrunnable_rows = [row for row in matrix if row["comparison_status"] == "unrunnable"]
+    mixed_rows = [row for row in matrix if row["comparison_status"] == "mixed"]
     return {
         "schema_version": CROSS_HOST_SCHEMA_VERSION,
         "manifest_sha256": manifest["manifest_sha256"],
@@ -688,7 +743,8 @@ def compare_verified_hosts(  # noqa: C901 - each rejected cross-host state needs
         "summary": {
             "n_cells": len(matrix),
             "n_runnable_cells": len(runnable_rows),
-            "n_unrunnable_cells": len(unrunnable_cells),
+            "n_unrunnable_cells": len(unrunnable_rows),
+            "n_mixed_cells": len(mixed_rows),
             "all_cells_bitwise_identical": version_match
             and bool(runnable_rows)
             and all(row["bitwise_identical"] for row in runnable_rows),
@@ -948,6 +1004,11 @@ def execute_campaign(  # noqa: C901, PLR0912, PLR0915 - fail-closed execution tr
         planner_algo = _require_text(
             planner_def.get("algo"), f"planner_definition {planner_def_id!r} algo"
         )
+        if planner != planner_algo:
+            raise ValueError(
+                f"target {key} planner {planner!r} does not match "
+                f"planner_definition {planner_def_id!r} algo {planner_algo!r}"
+            )
 
         # Fail closed on planners the run_episode path cannot construct (e.g. orca),
         # recording an explicit disposition instead of crashing the whole campaign.

--- a/robot_sf/benchmark/exact_repeat_campaign.py
+++ b/robot_sf/benchmark/exact_repeat_campaign.py
@@ -955,7 +955,7 @@ def execute_campaign(  # noqa: C901, PLR0912, PLR0915 - fail-closed execution tr
             planner_def.get("algo"), f"planner_definition {planner_def_id!r} algo"
         )
 
-        # Fail closed on planners the run_episode path cannot construct (e.g. orca),
+        # Fail closed on planners the run_episode path cannot construct,
         # recording an explicit disposition instead of crashing the whole campaign.
         if not is_runnable_algo(planner_algo):
             result_entry = {

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -53,6 +53,14 @@ except ImportError as exc:  # pragma: no cover - optional baseline dependency
 else:
     _BASELINE_IMPORT_ERROR = None
 
+# Aliases resolved to the built-in naive goal-seeking policy. Imported from the
+# lightweight ``robot_sf.baselines`` package (no heavy optional deps) so both the
+# runner and the exact-repeat executor agree on what ``run_episode`` can execute.
+try:
+    from robot_sf.baselines import SIMPLE_POLICY_ALIASES
+except ImportError:  # pragma: no cover - defensive fallback
+    SIMPLE_POLICY_ALIASES = frozenset({"simple_policy", "goal", "simple", "goal_policy"})
+
 from robot_sf.benchmark.algorithm_metadata import enrich_algorithm_metadata
 from robot_sf.benchmark.circuit_breaker import (  # noqa: F401 - compatibility export.
     _CIRCUIT_BREAKER_MSG_PREFIX_LEN,
@@ -658,7 +666,7 @@ def _create_robot_policy(  # noqa: C901, PLR0915
             "status": "ok",
         }
 
-    if algo == "simple_policy":
+    if algo in SIMPLE_POLICY_ALIASES:
         policy_fn, metadata = _simple_policy_adapter()
         return (
             policy_fn,

--- a/tests/benchmark/test_exact_repeat_campaign.py
+++ b/tests/benchmark/test_exact_repeat_campaign.py
@@ -11,6 +11,8 @@ import pytest
 
 from robot_sf.benchmark.exact_repeat_campaign import (
     HOST_REPORT_SCHEMA_VERSION,
+    MIXED_DISPOSITION,
+    UNRUNNABLE_DISPOSITION,
     build_manifest,
     canonical_sha256,
     compare_verified_hosts,
@@ -138,9 +140,87 @@ def test_host_verifier_requires_all_targets_and_reports_cell_verdicts(manifest):
         "n_cells": 7,
         "n_runnable_cells": 7,
         "n_unrunnable_cells": 0,
+        "n_mixed_cells": 0,
         "all_cells_bitwise_identical": True,
     }
     assert all(cell["exact_repeat_determinism"] is True for cell in verified["cells"])
+
+
+def test_host_verifier_rejects_repeats_on_unrunnable_target(manifest):
+    """An unrunnable disposition cannot hide fabricated repeat evidence."""
+    report = _host_report(manifest, "host-a")
+    result = report["results"][0]
+    result["disposition"] = UNRUNNABLE_DISPOSITION
+    result["disposition_reason"] = "fixture disposition"
+    with pytest.raises(ValueError, match="also reports repeats"):
+        verify_host_report(manifest, report)
+
+
+def test_host_verifier_marks_all_unrunnable_reports_non_identical(manifest):
+    """No runnable target must not produce a vacuous determinism claim."""
+    reports = []
+    for machine_id in ("host-a", "host-b"):
+        report = _host_report(manifest, machine_id)
+        for result in report["results"]:
+            result.pop("repeats")
+            result["disposition"] = UNRUNNABLE_DISPOSITION
+            result["disposition_reason"] = "fixture disposition"
+        reports.append(verify_host_report(manifest, report))
+
+    for verified in reports:
+        assert verified["summary"] == {
+            "n_targets": 140,
+            "n_runnable_targets": 0,
+            "n_unrunnable_targets": 140,
+            "n_cells": 7,
+            "n_runnable_cells": 0,
+            "n_unrunnable_cells": 7,
+            "n_mixed_cells": 0,
+            "all_cells_bitwise_identical": False,
+        }
+
+    comparison = compare_verified_hosts(manifest, *reports)
+    assert comparison["summary"] == {
+        "n_cells": 7,
+        "n_runnable_cells": 0,
+        "n_unrunnable_cells": 7,
+        "n_mixed_cells": 0,
+        "all_cells_bitwise_identical": False,
+    }
+
+
+def test_host_verifier_preserves_mixed_cell_target_counts(manifest):
+    """Mixed runnable/unrunnable targets retain the full cell denominator."""
+    report = _host_report(manifest, "host-a")
+    result = report["results"][0]
+    result.pop("repeats")
+    result["disposition"] = UNRUNNABLE_DISPOSITION
+    result["disposition_reason"] = "fixture disposition"
+
+    verified = verify_host_report(manifest, report)
+    cell = next(
+        cell
+        for cell in verified["cells"]
+        if cell["scenario_id"] == result["scenario_id"] and cell["planner"] == result["planner"]
+    )
+    assert cell["disposition"] == MIXED_DISPOSITION
+    assert cell["n_targets"] == 20
+    assert cell["n_runnable_targets"] == 19
+    assert cell["n_unrunnable_targets"] == 1
+    assert cell["exact_repeat_determinism"] is None
+    assert verified["summary"]["n_mixed_cells"] == 1
+
+    second = verify_host_report(manifest, _host_report(manifest, "host-b"))
+    comparison = compare_verified_hosts(manifest, verified, second)
+    comparison_cell = next(
+        row
+        for row in comparison["matrix"]
+        if row["scenario_id"] == result["scenario_id"] and row["planner"] == result["planner"]
+    )
+    assert comparison_cell["comparison_status"] == "mixed"
+    assert comparison_cell["disposition"] == MIXED_DISPOSITION
+    assert comparison_cell["n_targets"] == 20
+    assert comparison["summary"]["n_mixed_cells"] == 1
 
 
 def test_host_verifier_requires_the_first_trajectory_divergence(manifest):

--- a/tests/benchmark/test_exact_repeat_campaign.py
+++ b/tests/benchmark/test_exact_repeat_campaign.py
@@ -133,7 +133,11 @@ def test_host_verifier_requires_all_targets_and_reports_cell_verdicts(manifest):
     verified = verify_host_report(manifest, _host_report(manifest, "host-a"))
     assert verified["summary"] == {
         "n_targets": 140,
+        "n_runnable_targets": 140,
+        "n_unrunnable_targets": 0,
         "n_cells": 7,
+        "n_runnable_cells": 7,
+        "n_unrunnable_cells": 0,
         "all_cells_bitwise_identical": True,
     }
     assert all(cell["exact_repeat_determinism"] is True for cell in verified["cells"])

--- a/tests/benchmark/test_exact_repeat_campaign.py
+++ b/tests/benchmark/test_exact_repeat_campaign.py
@@ -143,6 +143,22 @@ def test_host_verifier_requires_all_targets_and_reports_cell_verdicts(manifest):
     assert all(cell["exact_repeat_determinism"] is True for cell in verified["cells"])
 
 
+def test_all_unrunnable_host_reports_never_claim_determinism(manifest):
+    """Empty runnable evidence is fail-closed in verification and comparison."""
+    first_report = _host_report(manifest, "host-a")
+    for result in first_report["results"]:
+        result["disposition"] = "unrunnable_on_current_main"
+        result["disposition_reason"] = "fixture disposition"
+        result["repeats"] = []
+    first_verified = verify_host_report(manifest, first_report)
+    assert first_verified["summary"]["all_cells_bitwise_identical"] is False
+
+    second_verified = copy.deepcopy(first_verified)
+    second_verified["environment"]["machine_id"] = "host-b"
+    comparison = compare_verified_hosts(manifest, first_verified, second_verified)
+    assert comparison["summary"]["all_cells_bitwise_identical"] is False
+
+
 def test_host_verifier_requires_the_first_trajectory_divergence(manifest):
     """A divergent digest is accepted only with its computed first difference."""
     report = _host_report(manifest, "host-a")

--- a/tests/benchmark/test_exact_repeat_executor.py
+++ b/tests/benchmark/test_exact_repeat_executor.py
@@ -437,6 +437,20 @@ def test_execute_campaign_rejects_missing_scenario_definition(tmp_path, resolved
         execute_campaign(tampered, output_dir=tmp_path / "missing_definition")
 
 
+def test_execute_campaign_rejects_planner_definition_mismatch(tmp_path, resolved_bundle):
+    """A target cannot execute under a planner different from its manifest identity."""
+    tampered = copy.deepcopy(resolved_bundle)
+    target = tampered["targets"][0]
+    planner_definition = tampered["planner_definitions"][target["planner_definition_id"]]
+    planner_definition["algo"] = "orca" if target["planner"] != "orca" else "goal"
+    tampered["bundle_sha256"] = canonical_sha256(
+        {key: value for key, value in tampered.items() if key != "bundle_sha256"}
+    )
+
+    with pytest.raises(ValueError, match="does not match.*planner_definition"):
+        execute_campaign(tampered, output_dir=tmp_path / "planner_mismatch")
+
+
 def test_execute_campaign_rejects_invalid_bundle_schema():
     """Bundle with wrong schema_version raises."""
     bad_bundle = {"schema_version": "wrong_version"}

--- a/tests/benchmark/test_exact_repeat_executor.py
+++ b/tests/benchmark/test_exact_repeat_executor.py
@@ -237,16 +237,9 @@ def _deterministic_mock_runner(
     return _build_mock_record(seed)
 
 
-def _bundle_with_unsupported_planner(
-    resolved_bundle: dict[str, Any],
-) -> dict[str, Any]:
-    """Return a resolved bundle whose ORCA cell names an unsupported probe planner."""
-    bundle = copy.deepcopy(resolved_bundle)
-    bundle["planner_definitions"]["orca"]["algo"] = "retired_orca_probe"
-    bundle["bundle_sha256"] = canonical_sha256(
-        {key: value for key, value in bundle.items() if key != "bundle_sha256"}
-    )
-    return bundle
+def _force_orca_unrunnable(monkeypatch):
+    """Make the disposition fixture independent of the installed ORCA adapter."""
+    monkeypatch.setattr("robot_sf.baselines.is_runnable_algo", lambda name: name != "orca")
 
 
 def test_execute_campaign_produces_valid_host_report(tmp_path, manifest, resolved_bundle):
@@ -267,14 +260,16 @@ def test_execute_campaign_produces_valid_host_report(tmp_path, manifest, resolve
     assert verified["summary"]["n_cells"] == 7
 
 
-def test_execute_campaign_dispositions_unrunnable_planner_cells(tmp_path, resolved_bundle):
+def test_execute_campaign_dispositions_unrunnable_planner_cells(
+    tmp_path, resolved_bundle, monkeypatch
+):
     """Unsupported planner cells are recorded as an explicit disposition.
 
-    The probe planner is deliberately absent from the ``run_episode`` baseline
+    The fixture temporarily marks ORCA as unavailable to the ``run_episode``
     registry. Rather than raising ``ValueError: Unknown algorithm``, execute must
     emit a schema-compatible per-cell disposition and continue other cells.
     """
-    unsupported_bundle = _bundle_with_unsupported_planner(resolved_bundle)
+    _force_orca_unrunnable(monkeypatch)
 
     def guarded_runner(scenario_params, seed, *, algo="goal", **kwargs):
         # The runner must never be invoked for an unrunnable planner.
@@ -282,7 +277,7 @@ def test_execute_campaign_dispositions_unrunnable_planner_cells(tmp_path, resolv
         return _build_mock_record(seed)
 
     host_result = execute_campaign(
-        unsupported_bundle,
+        resolved_bundle,
         output_dir=tmp_path / "unsupported_disposition",
         run_episode=guarded_runner,
     )
@@ -296,7 +291,7 @@ def test_execute_campaign_dispositions_unrunnable_planner_cells(tmp_path, resolv
     for result in orca_results:
         assert result["disposition"] == UNRUNNABLE_DISPOSITION
         assert result["repeats"] == []
-        assert "retired_orca_probe" in result["disposition_reason"]
+        assert "planner 'orca'" in result["disposition_reason"]
 
     # Runnable planners still execute their repeats normally.
     for planner in ("ppo", "goal"):
@@ -306,12 +301,12 @@ def test_execute_campaign_dispositions_unrunnable_planner_cells(tmp_path, resolv
 
 
 def test_verify_host_report_scopes_repeat_claim_to_runnable_cells(
-    tmp_path, manifest, resolved_bundle
+    tmp_path, manifest, resolved_bundle, monkeypatch
 ):
     """verify-host scopes repeat claims to runnable cells."""
-    unsupported_bundle = _bundle_with_unsupported_planner(resolved_bundle)
+    _force_orca_unrunnable(monkeypatch)
     host_result = execute_campaign(
-        unsupported_bundle,
+        resolved_bundle,
         output_dir=tmp_path / "unsupported_verify",
         run_episode=_deterministic_mock_runner,
     )
@@ -335,11 +330,13 @@ def test_verify_host_report_scopes_repeat_claim_to_runnable_cells(
         assert cell["exact_repeat_determinism"] is None
 
 
-def test_verify_host_report_rejects_disposition_with_repeats(tmp_path, manifest, resolved_bundle):
+def test_verify_host_report_rejects_disposition_with_repeats(
+    tmp_path, manifest, resolved_bundle, monkeypatch
+):
     """A disposition cannot hide fabricated repeat evidence."""
-    unsupported_bundle = _bundle_with_unsupported_planner(resolved_bundle)
+    _force_orca_unrunnable(monkeypatch)
     host_result = execute_campaign(
-        unsupported_bundle,
+        resolved_bundle,
         output_dir=tmp_path / "malformed_disposition",
         run_episode=_deterministic_mock_runner,
     )
@@ -349,11 +346,13 @@ def test_verify_host_report_rejects_disposition_with_repeats(tmp_path, manifest,
         verify_host_report(manifest, host_result)
 
 
-def test_verify_host_report_preserves_mixed_cell_target_counts(tmp_path, manifest, resolved_bundle):
+def test_verify_host_report_preserves_mixed_cell_target_counts(
+    tmp_path, manifest, resolved_bundle, monkeypatch
+):
     """Mixed cells retain both runnable and dispositioned target counts."""
-    unsupported_bundle = _bundle_with_unsupported_planner(resolved_bundle)
+    _force_orca_unrunnable(monkeypatch)
     host_result = execute_campaign(
-        unsupported_bundle,
+        resolved_bundle,
         output_dir=tmp_path / "mixed_cell",
         run_episode=_deterministic_mock_runner,
     )

--- a/tests/benchmark/test_exact_repeat_executor.py
+++ b/tests/benchmark/test_exact_repeat_executor.py
@@ -443,8 +443,8 @@ def test_execute_campaign_reexecutes_a_malformed_cache_entry(tmp_path, resolved_
     """A non-mapping cache entry is ignored instead of crashing resume execution."""
     output_dir = tmp_path / "host_run_malformed_cache"
     execute_campaign(resolved_bundle, output_dir=output_dir, run_episode=_deterministic_mock_runner)
-    # Pick a runnable target: unsupported planners are dispositioned
-    # without invoking the runner, so they never re-execute on a corrupt cache.
+    # Pick a runnable target; unsupported planners are dispositioned without
+    # invoking the runner, so they never re-execute on a corrupt cache.
     target = next(t for t in resolved_bundle["targets"] if is_runnable_algo(t["planner"]))
     cache_file = (
         output_dir

--- a/tests/benchmark/test_exact_repeat_executor.py
+++ b/tests/benchmark/test_exact_repeat_executor.py
@@ -320,6 +320,48 @@ def test_verify_host_report_scopes_repeat_claim_to_runnable_cells(
         assert cell["exact_repeat_determinism"] is None
 
 
+def test_verify_host_report_rejects_disposition_with_repeats(
+    tmp_path, manifest, resolved_bundle
+):
+    """A disposition cannot hide fabricated repeat evidence."""
+    host_result = execute_campaign(
+        resolved_bundle,
+        output_dir=tmp_path / "malformed_disposition",
+        run_episode=_deterministic_mock_runner,
+    )
+    result = next(result for result in host_result["results"] if "disposition" in result)
+    result["repeats"] = [{"outcome": 1}]
+    with pytest.raises(ValueError, match="also reports repeats"):
+        verify_host_report(manifest, host_result)
+
+
+def test_verify_host_report_preserves_mixed_cell_target_counts(
+    tmp_path, manifest, resolved_bundle
+):
+    """Mixed cells retain both runnable and dispositioned target counts."""
+    host_result = execute_campaign(
+        resolved_bundle,
+        output_dir=tmp_path / "mixed_cell",
+        run_episode=_deterministic_mock_runner,
+    )
+    runnable_repeats = next(
+        result["repeats"]
+        for result in host_result["results"]
+        if isinstance(result.get("repeats"), list) and len(result["repeats"]) == 3
+    )
+    dispositioned = next(result for result in host_result["results"] if "disposition" in result)
+    dispositioned.pop("disposition")
+    dispositioned.pop("disposition_reason")
+    dispositioned["repeats"] = copy.deepcopy(runnable_repeats)
+
+    verified = verify_host_report(manifest, host_result)
+    mixed_cell = next(cell for cell in verified["cells"] if cell["planner"] == "orca")
+    assert mixed_cell["unrunnable"] is False
+    assert mixed_cell["n_targets"] == 20
+    assert mixed_cell["n_runnable_targets"] == 1
+    assert mixed_cell["n_unrunnable_targets"] == 19
+
+
 def test_execute_campaign_all_repeats_identical_for_deterministic_runner(
     tmp_path, manifest, resolved_bundle
 ):

--- a/tests/benchmark/test_exact_repeat_executor.py
+++ b/tests/benchmark/test_exact_repeat_executor.py
@@ -237,6 +237,18 @@ def _deterministic_mock_runner(
     return _build_mock_record(seed)
 
 
+def _bundle_with_unsupported_planner(
+    resolved_bundle: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a resolved bundle whose ORCA cell names an unsupported probe planner."""
+    bundle = copy.deepcopy(resolved_bundle)
+    bundle["planner_definitions"]["orca"]["algo"] = "retired_orca_probe"
+    bundle["bundle_sha256"] = canonical_sha256(
+        {key: value for key, value in bundle.items() if key != "bundle_sha256"}
+    )
+    return bundle
+
+
 def test_execute_campaign_produces_valid_host_report(tmp_path, manifest, resolved_bundle):
     """Execute with mock runner produces a host_result.json that passes verify_host_report."""
     output_dir = tmp_path / "host_run"
@@ -255,14 +267,14 @@ def test_execute_campaign_produces_valid_host_report(tmp_path, manifest, resolve
     assert verified["summary"]["n_cells"] == 7
 
 
-def test_execute_campaign_dispositions_unrunnable_orca_cells(tmp_path, resolved_bundle):
-    """orca cells are recorded as an explicit disposition instead of crashing.
+def test_execute_campaign_dispositions_unrunnable_planner_cells(tmp_path, resolved_bundle):
+    """Unsupported planner cells are recorded as an explicit disposition.
 
-    The #5263 bundle contains ``algo: orca`` cells, which the ``run_episode``
-    baseline registry cannot construct on current main. Rather than raising
-    ``ValueError: Unknown algorithm 'orca'``, execute must emit a schema-compatible
-    per-cell disposition and continue running the other cells.
+    The probe planner is deliberately absent from the ``run_episode`` baseline
+    registry. Rather than raising ``ValueError: Unknown algorithm``, execute must
+    emit a schema-compatible per-cell disposition and continue other cells.
     """
+    unsupported_bundle = _bundle_with_unsupported_planner(resolved_bundle)
 
     def guarded_runner(scenario_params, seed, *, algo="goal", **kwargs):
         # The runner must never be invoked for an unrunnable planner.
@@ -270,7 +282,9 @@ def test_execute_campaign_dispositions_unrunnable_orca_cells(tmp_path, resolved_
         return _build_mock_record(seed)
 
     host_result = execute_campaign(
-        resolved_bundle, output_dir=tmp_path / "orca_disposition", run_episode=guarded_runner
+        unsupported_bundle,
+        output_dir=tmp_path / "unsupported_disposition",
+        run_episode=guarded_runner,
     )
 
     by_planner = {}
@@ -282,7 +296,7 @@ def test_execute_campaign_dispositions_unrunnable_orca_cells(tmp_path, resolved_
     for result in orca_results:
         assert result["disposition"] == UNRUNNABLE_DISPOSITION
         assert result["repeats"] == []
-        assert "orca" in result["disposition_reason"]
+        assert "retired_orca_probe" in result["disposition_reason"]
 
     # Runnable planners still execute their repeats normally.
     for planner in ("ppo", "goal"):
@@ -294,10 +308,11 @@ def test_execute_campaign_dispositions_unrunnable_orca_cells(tmp_path, resolved_
 def test_verify_host_report_scopes_repeat_claim_to_runnable_cells(
     tmp_path, manifest, resolved_bundle
 ):
-    """verify-host accepts orca dispositions and scopes the claim to runnable cells."""
+    """verify-host scopes repeat claims to runnable cells."""
+    unsupported_bundle = _bundle_with_unsupported_planner(resolved_bundle)
     host_result = execute_campaign(
-        resolved_bundle,
-        output_dir=tmp_path / "orca_verify",
+        unsupported_bundle,
+        output_dir=tmp_path / "unsupported_verify",
         run_episode=_deterministic_mock_runner,
     )
     verified = verify_host_report(manifest, host_result)
@@ -305,7 +320,7 @@ def test_verify_host_report_scopes_repeat_claim_to_runnable_cells(
 
     assert summary["n_targets"] == 140
     assert summary["n_cells"] == 7
-    # orca contributes 3 unrunnable cells (60 targets); ppo(3) + goal(1) remain.
+    # The probe planner contributes 3 unrunnable cells (60 targets); ppo(3) + goal(1) remain.
     assert summary["n_unrunnable_cells"] == 3
     assert summary["n_runnable_cells"] == 4
     assert summary["n_unrunnable_targets"] == 60
@@ -320,9 +335,7 @@ def test_verify_host_report_scopes_repeat_claim_to_runnable_cells(
         assert cell["exact_repeat_determinism"] is None
 
 
-def test_verify_host_report_rejects_disposition_with_repeats(
-    tmp_path, manifest, resolved_bundle
-):
+def test_verify_host_report_rejects_disposition_with_repeats(tmp_path, manifest, resolved_bundle):
     """A disposition cannot hide fabricated repeat evidence."""
     host_result = execute_campaign(
         resolved_bundle,
@@ -335,9 +348,7 @@ def test_verify_host_report_rejects_disposition_with_repeats(
         verify_host_report(manifest, host_result)
 
 
-def test_verify_host_report_preserves_mixed_cell_target_counts(
-    tmp_path, manifest, resolved_bundle
-):
+def test_verify_host_report_preserves_mixed_cell_target_counts(tmp_path, manifest, resolved_bundle):
     """Mixed cells retain both runnable and dispositioned target counts."""
     host_result = execute_campaign(
         resolved_bundle,
@@ -430,7 +441,7 @@ def test_execute_campaign_reexecutes_a_malformed_cache_entry(tmp_path, resolved_
     """A non-mapping cache entry is ignored instead of crashing resume execution."""
     output_dir = tmp_path / "host_run_malformed_cache"
     execute_campaign(resolved_bundle, output_dir=output_dir, run_episode=_deterministic_mock_runner)
-    # Pick a runnable target: unrunnable planners (e.g. orca) are dispositioned
+    # Pick a runnable target: unsupported planners are dispositioned
     # without invoking the runner, so they never re-execute on a corrupt cache.
     target = next(t for t in resolved_bundle["targets"] if is_runnable_algo(t["planner"]))
     cache_file = (

--- a/tests/benchmark/test_exact_repeat_executor.py
+++ b/tests/benchmark/test_exact_repeat_executor.py
@@ -10,9 +10,11 @@ from typing import Any
 import numpy as np
 import pytest
 
+from robot_sf.baselines import is_runnable_algo
 from robot_sf.benchmark.exact_repeat_campaign import (
     HOST_REPORT_SCHEMA_VERSION,
     RESOLVED_DEFINITIONS_SCHEMA_VERSION,
+    UNRUNNABLE_DISPOSITION,
     _check_manifest_from_bundle,
     _compute_trajectory_hash,
     _get_environment_fingerprint,
@@ -253,6 +255,71 @@ def test_execute_campaign_produces_valid_host_report(tmp_path, manifest, resolve
     assert verified["summary"]["n_cells"] == 7
 
 
+def test_execute_campaign_dispositions_unrunnable_orca_cells(tmp_path, resolved_bundle):
+    """orca cells are recorded as an explicit disposition instead of crashing.
+
+    The #5263 bundle contains ``algo: orca`` cells, which the ``run_episode``
+    baseline registry cannot construct on current main. Rather than raising
+    ``ValueError: Unknown algorithm 'orca'``, execute must emit a schema-compatible
+    per-cell disposition and continue running the other cells.
+    """
+
+    def guarded_runner(scenario_params, seed, *, algo="goal", **kwargs):
+        # The runner must never be invoked for an unrunnable planner.
+        assert is_runnable_algo(algo), f"runner invoked for unrunnable algo {algo!r}"
+        return _build_mock_record(seed)
+
+    host_result = execute_campaign(
+        resolved_bundle, output_dir=tmp_path / "orca_disposition", run_episode=guarded_runner
+    )
+
+    by_planner = {}
+    for result in host_result["results"]:
+        by_planner.setdefault(result["planner"], []).append(result)
+
+    orca_results = by_planner["orca"]
+    assert orca_results, "expected orca targets in the bundle"
+    for result in orca_results:
+        assert result["disposition"] == UNRUNNABLE_DISPOSITION
+        assert result["repeats"] == []
+        assert "orca" in result["disposition_reason"]
+
+    # Runnable planners still execute their repeats normally.
+    for planner in ("ppo", "goal"):
+        for result in by_planner[planner]:
+            assert "disposition" not in result
+            assert len(result["repeats"]) == 3
+
+
+def test_verify_host_report_scopes_repeat_claim_to_runnable_cells(
+    tmp_path, manifest, resolved_bundle
+):
+    """verify-host accepts orca dispositions and scopes the claim to runnable cells."""
+    host_result = execute_campaign(
+        resolved_bundle,
+        output_dir=tmp_path / "orca_verify",
+        run_episode=_deterministic_mock_runner,
+    )
+    verified = verify_host_report(manifest, host_result)
+    summary = verified["summary"]
+
+    assert summary["n_targets"] == 140
+    assert summary["n_cells"] == 7
+    # orca contributes 3 unrunnable cells (60 targets); ppo(3) + goal(1) remain.
+    assert summary["n_unrunnable_cells"] == 3
+    assert summary["n_runnable_cells"] == 4
+    assert summary["n_unrunnable_targets"] == 60
+    assert summary["n_runnable_targets"] == 80
+    # The deterministic mock runner keeps the runnable-cell claim green.
+    assert summary["all_cells_bitwise_identical"] is True
+
+    unrunnable_cells = [cell for cell in verified["cells"] if cell.get("unrunnable")]
+    assert {cell["planner"] for cell in unrunnable_cells} == {"orca"}
+    for cell in unrunnable_cells:
+        assert cell["disposition"] == UNRUNNABLE_DISPOSITION
+        assert cell["exact_repeat_determinism"] is None
+
+
 def test_execute_campaign_all_repeats_identical_for_deterministic_runner(
     tmp_path, manifest, resolved_bundle
 ):
@@ -321,7 +388,9 @@ def test_execute_campaign_reexecutes_a_malformed_cache_entry(tmp_path, resolved_
     """A non-mapping cache entry is ignored instead of crashing resume execution."""
     output_dir = tmp_path / "host_run_malformed_cache"
     execute_campaign(resolved_bundle, output_dir=output_dir, run_episode=_deterministic_mock_runner)
-    target = resolved_bundle["targets"][0]
+    # Pick a runnable target: unrunnable planners (e.g. orca) are dispositioned
+    # without invoking the runner, so they never re-execute on a corrupt cache.
+    target = next(t for t in resolved_bundle["targets"] if is_runnable_algo(t["planner"]))
     cache_file = (
         output_dir
         / "target_cache"

--- a/tests/benchmark/test_exact_repeat_executor.py
+++ b/tests/benchmark/test_exact_repeat_executor.py
@@ -337,8 +337,9 @@ def test_verify_host_report_scopes_repeat_claim_to_runnable_cells(
 
 def test_verify_host_report_rejects_disposition_with_repeats(tmp_path, manifest, resolved_bundle):
     """A disposition cannot hide fabricated repeat evidence."""
+    unsupported_bundle = _bundle_with_unsupported_planner(resolved_bundle)
     host_result = execute_campaign(
-        resolved_bundle,
+        unsupported_bundle,
         output_dir=tmp_path / "malformed_disposition",
         run_episode=_deterministic_mock_runner,
     )
@@ -350,8 +351,9 @@ def test_verify_host_report_rejects_disposition_with_repeats(tmp_path, manifest,
 
 def test_verify_host_report_preserves_mixed_cell_target_counts(tmp_path, manifest, resolved_bundle):
     """Mixed cells retain both runnable and dispositioned target counts."""
+    unsupported_bundle = _bundle_with_unsupported_planner(resolved_bundle)
     host_result = execute_campaign(
-        resolved_bundle,
+        unsupported_bundle,
         output_dir=tmp_path / "mixed_cell",
         run_episode=_deterministic_mock_runner,
     )

--- a/tests/test_runner_smoke.py
+++ b/tests/test_runner_smoke.py
@@ -103,6 +103,48 @@ def test_runner_single_episode_tmp(tmp_path: Path):
     assert reloaded["episode_id"] == record["episode_id"]
 
 
+def test_runner_goal_alias_executes_like_simple_policy(tmp_path: Path):
+    """The ``goal`` alias resolves to the built-in simple goal-seeking policy.
+
+    Historical benchmark bundles (e.g. #5263) label the naive goal planner
+    ``goal`` rather than ``simple_policy``. The runner must construct and execute
+    it end-to-end instead of raising ``ValueError: Unknown algorithm 'goal'``.
+
+    Args:
+        tmp_path: Temporary directory (unused, keeps signature uniform).
+    """
+    scenario = {
+        "id": "smoke-goal-alias",
+        "density": "low",
+        "flow": "uni",
+        "obstacle": "open",
+        "groups": 0.0,
+        "speed_var": "low",
+        "goal_topology": "point",
+        "robot_context": "embedded",
+        "repeats": 1,
+    }
+    goal_record = run_episode(
+        scenario, seed=7, horizon=15, dt=0.1, record_forces=False, algo="goal"
+    )
+    schema = load_schema(SCHEMA_PATH)
+    validate_episode(goal_record, schema)
+    assert "metrics" in goal_record
+    assert goal_record["algo"] == "goal"
+
+    simple_record = run_episode(
+        {**scenario, "id": "smoke-simple-policy"},
+        seed=7,
+        horizon=15,
+        dt=0.1,
+        record_forces=False,
+        algo="simple_policy",
+    )
+    # The alias must drive the same policy: identical outcome and metrics.
+    assert goal_record["outcome"] == simple_record["outcome"]
+    assert goal_record["metrics"] == simple_record["metrics"]
+
+
 def _normalize_episode_record(record: dict[str, object]) -> dict[str, object]:
     """Remove runtime-only fields before comparing deterministic episode records."""
     normalized = dict(record)


### PR DESCRIPTION
Refs #5491
Refs #5495
Refs #5263
Refs #5498

## Summary

This is a follow-up hardening slice after PR #5495 restored the native ORCA baseline and closed
the #5491 crash blocker. It adds the missing `goal` alias routing and makes the exact-repeat
disposition/verifier contract fail closed for future planners that are unavailable through the
current `run_episode` registry.

## Why this remains useful

PR #5495 correctly makes `orca` runnable on current `main`; this PR no longer claims ORCA is
unrunnable and its updated tests prove native ORCA is treated as runnable. The resolved #5263
bundle would otherwise reach its `goal` cells next, because `goal` is the canonical name for the
existing simple goal-seeking policy but was not recognized by `run_episode`. The generic
unavailable-planner disposition remains useful for fail-closed future bundles and is tested with
a synthetic unsupported planner rather than misrepresenting ORCA after #5495.

This PR is a successor/follow-up slice, does not duplicate #5495, and does not close #5491,
#5263, or the remaining campaign work.

## Follow-Up Issues

- Deferred work: run/register the full parent exact-repeat campaign and the pinned second-host
  comparison; this PR intentionally does not claim those empirical results.
- Issues opened for follow-up: #5498 (open successor issue).

## Fix

- `goal`, `simple`, `goal_policy`, and `simple_policy` share one lightweight alias set and run
  through the existing simple-policy adapter.
- `execute_campaign` gates planners against the current `run_episode` registry, records an
  explicit disposition with an empty repeat list for unavailable planners, and continues with
  runnable targets. Native `orca` is now runnable through the #5495 adapter.
- Host verification rejects fabricated repeats on dispositioned targets, requires a non-empty
  disposition reason, rejects vacuous all-unrunnable determinism claims, and preserves full
  target counts plus an explicit `mixed_runnability` cell disposition.
- Cross-host comparison carries the same mixed/unrunnable distinction and excludes both from
  determinism claims.
- Execution fails closed when a target planner identity does not match its resolved planner
  definition algorithm.

## Runtime-risk review gate

- Runtime surface: exact-repeat execute, host verification, cross-host comparison, and runner
  planner alias dispatch.
- Semantic config validation: no enabled/arm configuration, intervention flag, or predeclared
  threshold is changed; those dimensions are not applicable to this registry/verification
  contract. The target-planner/definition identity check covers the applicable semantic config
  boundary.
- Adversarial fixture coverage: malformed disposition+repeats, all-unrunnable reports,
  mixed-cell denominators, mixed cross-host rows, planner-definition mismatch, and native ORCA
  runnability are covered by focused fixtures. No simulator state or intervention path is
  introduced.
- Provenance: source config hashes, host identity, and the disposition reason are consumed by
  verification; no new provenance field is stored without a validation/reporting use.
- Reviewer-critical disposition: CodeRabbit's three actionable findings are fixed. Gemini's
  vacuous-true recommendation is intentionally not adopted: zero runnable cells provide no
  determinism evidence, so verifier and comparator both return `False`.

## Research Result Guidance

- Target claim / blocker: finish the #5491 execution-path hardening after native ORCA restoration
  and prevent unsupported future planners from becoming false repeat evidence.
- Comparator or baseline: pre-fix `run_episode` alias behavior and empty-cell verifier behavior;
  no benchmark ranking comparator changes.
- Evidence tier: targeted smoke / diagnostic probe.
- Result classification: blocker-resolution follow-up; not benchmark evidence.
- Decision or stop rule: run every planner available through the current registry or emit an
  explicit disposition; never infer determinism from an empty runnable set.
- Update surface: successor #5498 owns the full #5263 campaign; #5263 closure state is corrected
  in its gate comment.
- New analysis tool: NA - this PR changes an existing executor/verifier and adds contract tests.

## Domain-Aware Approval

- Required for this PR: yes
- Domains reviewed: evidence classification, benchmark interpretation
- Status: approved.
- Validity caveat: implementation integrity is reviewed; experimental validity is not claimed.
- Approver/review source or waiver: full Codex PR gate for #5496, current-head review and focused proof.
- Validity checklist:
  - Target claim/hypothesis: planner aliases and unavailable-planner reports cannot crash or
    create unsupported determinism claims.
  - Comparator or split/evidence validity: no experimental comparison or scenario split changes.
  - Fallback/degraded exclusions: dispositioned and mixed rows are explicit exclusions from
    determinism claims; native ORCA remains subject to #5495's declared `rvo2` requirement.
  - Claim boundary: diagnostic blocker resolution only; no SNQI, benchmark, or paper result is
    asserted.
  - Implementation integrity vs experimental validity: implementation integrity is reviewed;
    experimental validity remains with successor #5498.

## Falsification / Non-Transfer Check

- Did the mechanism activate? yes - the `goal` alias executes, native `orca` is recognized, and
  synthetic unsupported planners receive explicit dispositions.
- Did the intervention change command source, selected command, trajectory, or route progress?
  NA - this is executor/registry contract hardening, not a planner intervention.
- Did the scenario contain the targeted failure mode? yes - the retained bundle contains `goal`
  and `orca` cells; the current-main ORCA path is proven by #5495.
- Result route: continue with successor #5498 for the full repeat campaign.
- Follow-up question: register the 140-target single-host report and second-host matrix without
  promoting fallback/degraded rows.

## Next Empirical Action

- Rerun needed: yes - execute/register the full #5263 bundle under successor #5498.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: no durable repeat result exists yet; this PR's temporary test
  outputs are not benchmark evidence.
- Stop / revise / continue decision: continue with the predeclared 140-target, 3-repeat run;
  stop if native execution or provenance fails and record a disposition.
- Proposed child issue or existing follow-up: #5498 (open successor).

## Validation / Proof

- `uv run pytest -q tests/benchmark/test_exact_repeat_executor.py tests/benchmark/test_exact_repeat_campaign.py tests/test_runner_smoke.py` -> 46 passed on the authoritative PR head.
- `uv run pytest -q tests/benchmark/test_orca_baseline_registration_issue_5491.py` -> native ORCA registration/runtime proof from the current main base.
- `uv run ruff check robot_sf/benchmark/exact_repeat_campaign.py tests/benchmark/test_exact_repeat_campaign.py tests/benchmark/test_exact_repeat_executor.py` -> clean.
- `uv run ruff format --check robot_sf/benchmark/exact_repeat_campaign.py tests/benchmark/test_exact_repeat_campaign.py tests/benchmark/test_exact_repeat_executor.py` -> clean.
- Full repository readiness is run by the PR gate after the branch update; no heavy benchmark,
  GPU, Slurm, or full 420-repeat campaign is run here.

## Risks / Rollout

- Native ORCA depends on the declared `rvo2` extra from #5495; missing optional dependencies
  must fail closed and are not benchmark success evidence.
- The full #5263 repeat campaign and second-host comparison remain outstanding under #5498.
- Rollback is a single commit revert; the prior alias behavior would leave the resolved `goal`
  cells unable to execute.

## Downstream Propagation

- Parent issue updated: yes - #5263's stale open-state wording was corrected and remaining work
  was linked to #5498.
- Claim map / benchmark report: NA - diagnostic blocker resolution, not result evidence.
- Leaderboard / artifact catalog: NA.
- Registry or config index: NA - no new planner is registered by this PR.
- Context index / memory note: NA.
- Follow-up issue: yes - #5498 owns the remaining empirical campaign.

## Reviewer Notes

- Review against current `origin/main`, which includes merged PR #5495. The actual ORCA rows must
  execute through the native adapter; the generic disposition fixtures temporarily make `orca`
  unavailable through the runnability predicate so they remain stable and honest.
- The generic disposition fixtures temporarily make `orca` unavailable through the runnability
  predicate; they do not alter the native ORCA adapter or claim that current-main ORCA is broken.
- Local temporary outputs are disposable and are not used as durable evidence.
