### PR TITLE
Issue #5412: vectorize diagnostic-only planner rollouts (cheap-lane worker)

### DIFF
--- a/robot_sf/planner/crowdnav_height.py
+++ b/robot_sf/planner/crowdnav_height.py
@@ -754,11 +754,21 @@ class CrowdNavHeightAdapter:
             delta = seg_starts - origin  # (S, 2)
             # t = (delta x seg) / denom, u = (delta x dir) / denom
             t_num = delta[:, 0] * seg_vec[:, 1] - delta[:, 1] * seg_vec[:, 0]  # (S,)
-            u_num = delta[:, 0] * directions[:, 1] - delta[:, 1] * directions[:, 0]  # (R,)
+            u_num = (
+                directions[:, 1, None] * delta[None, :, 0]
+                - directions[:, 0, None] * delta[None, :, 1]
+            )  # (R, S)
             with np.errstate(divide="ignore", invalid="ignore"):
                 t = t_num[None, :] / denom  # (R, S)
-                u = u_num[:, None] / denom  # (R, S)
-            valid = (t > 0) & (u >= 0) & (u <= 1) & (np.abs(denom) > 1e-9) & np.isfinite(t)
+                u = u_num / denom  # (R, S)
+            valid = (
+                (t >= 0)
+                & (u >= 0)
+                & (u <= 1)
+                & (np.abs(denom) > 1e-9)
+                & np.isfinite(t)
+                & np.isfinite(u)
+            )
             t[~valid] = np.inf
             obstacle_hits = t.min(axis=1)
 
@@ -782,8 +792,8 @@ class CrowdNavHeightAdapter:
                 sqrt_disc = np.sqrt(np.maximum(disc, 0.0))
                 t1 = (-b - sqrt_disc) / (2.0 * a[:, None])
                 t2 = (-b + sqrt_disc) / (2.0 * a[:, None])
-            valid_t = (disc >= 0) & ((t1 > 0) | (t2 > 0)) & np.isfinite(t1) & np.isfinite(t2)
-            pos_t = np.where(t1 > 0, t1, t2)
+            valid_t = (disc >= 0) & ((t1 >= 0) | (t2 >= 0)) & np.isfinite(t1) & np.isfinite(t2)
+            pos_t = np.where(t1 >= 0, t1, t2)
             pos_t[~valid_t] = np.inf
             ped_hits = pos_t.min(axis=1)
 

--- a/robot_sf/planner/crowdnav_height.py
+++ b/robot_sf/planner/crowdnav_height.py
@@ -18,8 +18,6 @@ import numpy as np
 import torch
 from gymnasium import spaces
 
-from robot_sf.sensor.range_sensor import circle_line_intersection_distance
-
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -738,27 +736,61 @@ class CrowdNavHeightAdapter:
             if ped_positions is None
             else np.asarray(ped_positions, dtype=float).reshape(-1, 2)
         )
-        origin_xy = (float(origin[0]), float(origin[1]))
-        for idx, direction in enumerate(directions):
-            best = sensor_range
-            for seg in segments:
-                hit = _ray_segment_intersection_distance(
-                    origin,
-                    direction,
-                    seg[:2],
-                    seg[2:4],
-                )
-                if hit is not None and hit < best:
-                    best = hit
-            ray_vec = (float(direction[0]), float(direction[1]))
-            for ped in peds:
-                hit = circle_line_intersection_distance(
-                    ((float(ped[0]), float(ped[1])), ped_radius),
-                    origin_xy,
-                    ray_vec,
-                )
-                best = min(best, hit)
-            distances[idx] = float(min(best, sensor_range))
+        # Vectorized raycast: broadcast intersections over all rays x obstacles/pedestrians.
+        num_rays = directions.shape[0]
+        num_segs = segments.shape[0] if segments.ndim > 1 else 0
+
+        # --- Obstacle intersections (rays x segments) ---
+        obstacle_hits = np.full(num_rays, sensor_range, dtype=float)
+        if num_segs > 0:
+            seg_starts = segments[:, :2]  # (S, 2)
+            seg_ends = segments[:, 2:4]  # (S, 2)
+            seg_vec = seg_ends - seg_starts  # (S, 2)
+            # denom = dir x seg: (R, 1) x (1, S) -> (R, S)
+            denom = (
+                directions[:, 0, None] * seg_vec[None, :, 1]
+                - directions[:, 1, None] * seg_vec[None, :, 0]
+            )
+            delta = seg_starts - origin  # (S, 2)
+            # t = (delta x seg) / denom, u = (delta x dir) / denom
+            t_num = delta[:, 0] * seg_vec[:, 1] - delta[:, 1] * seg_vec[:, 0]  # (S,)
+            u_num = delta[:, 0] * directions[:, 1] - delta[:, 1] * directions[:, 0]  # (R,)
+            with np.errstate(divide="ignore", invalid="ignore"):
+                t = t_num[None, :] / denom  # (R, S)
+                u = u_num[:, None] / denom  # (R, S)
+            valid = (t > 0) & (u >= 0) & (u <= 1) & (np.abs(denom) > 1e-9) & np.isfinite(t)
+            t[~valid] = np.inf
+            obstacle_hits = t.min(axis=1)
+
+        # --- Pedestrian intersections (rays x peds) ---
+        ped_hits = np.full(num_rays, sensor_range, dtype=float)
+        num_peds = peds.shape[0]
+        if num_peds > 0:
+            r_sq = ped_radius**2
+            # Ray origin relative to each ped center (circle-line formula): (P,)
+            p1x = origin[0] - peds[:, 0]  # (P,)
+            p1y = origin[1] - peds[:, 1]  # (P,)
+            norm_p1 = p1x**2 + p1y**2  # (P,)
+            # Quadratic coefficients: a (per-ray), b (R,P), c (P,)
+            a = directions[:, 0] ** 2 + directions[:, 1] ** 2  # (R,)
+            b = 2.0 * (
+                directions[:, 0, None] * p1x[None, :] + directions[:, 1, None] * p1y[None, :]
+            )  # (R, P)
+            c = norm_p1[None, :] - r_sq  # (R, P)
+            disc = b**2 - 4.0 * a[:, None] * c  # (R, P)
+            with np.errstate(divide="ignore", invalid="ignore"):
+                sqrt_disc = np.sqrt(np.maximum(disc, 0.0))
+                t1 = (-b - sqrt_disc) / (2.0 * a[:, None])
+                t2 = (-b + sqrt_disc) / (2.0 * a[:, None])
+            valid_t = (disc >= 0) & ((t1 > 0) | (t2 > 0)) & np.isfinite(t1) & np.isfinite(t2)
+            pos_t = np.where(t1 > 0, t1, t2)
+            pos_t[~valid_t] = np.inf
+            ped_hits = pos_t.min(axis=1)
+
+        # Combine: closest hit per ray, clipped to sensor range
+        distances = np.clip(np.minimum(obstacle_hits, ped_hits), 0.0, sensor_range).astype(
+            np.float32
+        )
         return distances
 
     def _build_model_inputs(

--- a/robot_sf/planner/learned_risk_surface.py
+++ b/robot_sf/planner/learned_risk_surface.py
@@ -16,7 +16,6 @@ import numpy as np
 
 from robot_sf.common.math_utils import wrap_angle_pi
 from robot_sf.errors import RobotSfError
-from robot_sf.nav.occupancy_grid_utils import world_to_ego
 from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter
 from robot_sf.planner.socnav_occupancy import OccupancyAwarePlannerMixin
 
@@ -229,11 +228,23 @@ def deterministic_pedestrian_risk_surface(
     xx, yy = np.meshgrid(xs, ys)
     values = np.full((cfg.grid_height, cfg.grid_width), float(floor_risk), dtype=np.float32)
 
-    for ped in ped_positions:
-        px, py = world_to_ego(float(ped[0]), float(ped[1]), robot_pose)
-        dist_sq = (xx - px) ** 2 + (yy - py) ** 2
-        bump = np.exp(-0.5 * dist_sq / float(pedestrian_sigma) ** 2)
-        values = np.maximum(values, bump.astype(np.float32))
+    if ped_positions.shape[0] > 0:
+        # Vectorized world_to_ego: apply rotation + translation to all pedestrians.
+        robot_x, robot_y, theta = robot_pose[0][0], robot_pose[0][1], robot_pose[1]
+        ped_wx = ped_positions[:, 0]  # (N,)
+        ped_wy = ped_positions[:, 1]  # (N,)
+        dx = ped_wx - robot_x
+        dy = ped_wy - robot_y
+        cos_t = np.cos(-theta)
+        sin_t = np.sin(-theta)
+        ego_x = dx * cos_t - dy * sin_t  # (N,)
+        ego_y = dx * sin_t + dy * cos_t  # (N,)
+        # dist_sq shape: (N, grid_height, grid_width) then reduce max over pedestrians
+        dist_sq = (xx[None, :, :] - ego_x[:, None, None]) ** 2 + (
+            yy[None, :, :] - ego_y[:, None, None]
+        ) ** 2
+        bumps = np.exp(-0.5 * dist_sq / float(pedestrian_sigma) ** 2)
+        values = np.maximum(values, bumps.astype(np.float32).max(axis=0))
 
     return LocalRiskSurface(values=np.clip(values, 0.0, 1.0), spec=cfg)
 

--- a/robot_sf/planner/sonic_crowdnav.py
+++ b/robot_sf/planner/sonic_crowdnav.py
@@ -462,15 +462,21 @@ class SonicCrowdNavAdapter:
         visible_masks = np.zeros((max(1, human_num),), dtype=np.float32)
 
         used = min(ped_count, spatial_edges.shape[0])
-        for i in range(used):
-            rel = np.asarray(ped_positions[i], dtype=float) - np.asarray(robot_pos, dtype=float)
-            vel = np.asarray(ped_velocities[i], dtype=float)
-            seq: list[float] = []
-            for step_idx in range(predict_steps + 1):
-                horizon_rel = rel + vel * (float(step_idx) * float(time_step))
-                seq.extend([float(horizon_rel[0]), float(horizon_rel[1])])
-            spatial_edges[i] = np.asarray(seq, dtype=np.float32)
-            visible_masks[i] = 1.0
+        if used > 0:
+            # Vectorized spatial edges: all pedestrians x all prediction steps.
+            # future: (used, predict_steps+1, 2) = rel + vel * time
+            rel = np.asarray(ped_positions[:used], dtype=float) - np.asarray(
+                robot_pos, dtype=float
+            )  # (used, 2)
+            vel = np.asarray(ped_velocities[:used], dtype=float)  # (used, 2)
+            steps = np.arange(predict_steps + 1, dtype=float).reshape(1, -1, 1) * float(
+                time_step
+            )  # (1, predict_steps+1, 1)
+            future = rel[:, None, :] + vel[:, None, :] * steps
+            # Interleave (x,y) pairs into flat sequences: (used, 2*(predict_steps+1))
+            seq = np.stack([future[:, :, 0], future[:, :, 1]], axis=-1).reshape(used, -1)
+            spatial_edges[:used] = seq.astype(np.float32)
+            visible_masks[:used] = 1.0
 
         if used > 0:
             distances = np.linalg.norm(spatial_edges[:used, :2], axis=1)

--- a/robot_sf/planner/sonic_crowdnav.py
+++ b/robot_sf/planner/sonic_crowdnav.py
@@ -474,7 +474,7 @@ class SonicCrowdNavAdapter:
             )  # (1, predict_steps+1, 1)
             future = rel[:, None, :] + vel[:, None, :] * steps
             # Interleave (x,y) pairs into flat sequences: (used, 2*(predict_steps+1))
-            seq = np.stack([future[:, :, 0], future[:, :, 1]], axis=-1).reshape(used, -1)
+            seq = future.reshape(used, -1)
             spatial_edges[:used] = seq.astype(np.float32)
             visible_masks[:used] = 1.0
 

--- a/tests/planner/test_crowdnav_height.py
+++ b/tests/planner/test_crowdnav_height.py
@@ -421,6 +421,41 @@ def test_raycast_obstacles_matches_old_method_reference(tmp_path: Path) -> None:
     assert np.allclose(result, distances_ref)
 
 
+def test_raycast_obstacles_broadcasts_multiple_segments_and_keeps_zero_hits(
+    tmp_path: Path,
+) -> None:
+    """Vectorized ray/segment intersections preserve all-segment and t=0 semantics."""
+    repo_root = tmp_path / "repo"
+    model_dir = tmp_path / "model"
+    _write_fake_upstream_repo(repo_root)
+    _write_fake_checkpoint_dir(model_dir, action_index=0)
+    adapter = CrowdNavHeightAdapter(
+        build_crowdnav_height_config(
+            {
+                "repo_root": str(repo_root),
+                "model_dir": str(model_dir),
+                "checkpoint_name": "fake.pt",
+            }
+        )
+    )
+    # Two segments exercise the (rays, segments) broadcast. The first starts at
+    # the ray origin, which the scalar helper treats as a valid t=0 hit.
+    adapter.bind_obstacle_segments([[0.0, 0.0, 0.0, 2.0], [3.0, -2.0, 3.0, 2.0]])
+
+    result = adapter._raycast_obstacles(np.array([0.0, 0.0]), heading=0.0)
+
+    assert float(result[0]) == pytest.approx(0.0, abs=1e-6)
+
+    # A tangent disc at the origin has both quadratic roots at t=0; retain the
+    # shared range-sensor helper's inclusive boundary behavior.
+    adapter.bind_obstacle_segments([[3.0, -2.0, 3.0, 2.0], [4.0, -2.0, 4.0, 2.0]])
+    tangent = adapter._raycast_obstacles(
+        np.array([0.0, 0.0]), heading=0.0, ped_positions=[[0.0, 0.3]], ped_radius=0.3
+    )
+
+    assert float(tangent[0]) == pytest.approx(0.0, abs=1e-6)
+
+
 def test_raycast_obstacles_includes_dynamic_pedestrians(tmp_path: Path) -> None:
     """A pedestrian inside lidar range must shorten the ray pointing at it (issue #3629).
 


### PR DESCRIPTION
Refs #5412

## What / Why

This is a bounded successor slice for #5412 and does not duplicate the prior obstacle-feature vectorization work. It vectorizes three diagnostic-only (non-benchmark) planner adapters identified in #5412; benchmark-facing candidates remain separate numeric-parity-gated work.

### Changes

1. **CrowdNav_HEIGHT raycast** (`crowdnav_height.py`): replace the triple-nested Python loop (rays × segments × pedestrians) with NumPy broadcasting. Obstacle segment intersections use `(rays, segments)` parametric-line broadcast; pedestrian disc intersections use `(rays, pedestrians)` circle-line quadratic calculations. The vectorized path preserves the scalar helper's inclusive `t >= 0` boundary behavior and rejects non-finite intersections.

2. **SonicCrowdNav spatial edges** (`sonic_crowdnav.py`): replace the per-pedestrian prediction loop with `(pedestrians, timesteps, 2)` broadcasting and reshape/interleave.

3. **Learned risk surface** (`learned_risk_surface.py`): replace the per-pedestrian Gaussian bump loop with `(N_pedestrians, grid_h, grid_w)` broadcasting plus max reduction. The existing world-to-ego transform is applied in batch.

### Why this matters

These are high-impact Python loops in non-benchmark adapters. CrowdNav_HEIGHT's raycast avoids Python iterations over rays, obstacles, and pedestrians per planner step. The changes remain explicitly diagnostic-only and make no benchmark score, determinism, or numeric-parity claim.

### Validation

- `uv run --extra training pytest -q tests/planner/test_learned_risk_surface.py tests/planner/test_crowdnav_height.py tests/planner/test_sonic_crowdnav.py`: 29 passed, 6 skipped.
- The gate added regression coverage for multiple obstacle segments, zero-distance segment hits, and tangent pedestrian intersections.
- Ruff check and format check pass on all changed files.

### Issue #5412 remaining candidates

- DWA / RiskDWA velocity-lattice vectorization (benchmark-gated)
- MPPI / predictive-MPPI rollout vectorization (benchmark-gated)
- socnav PredictionPlannerAdapter rollout/broadcast (benchmark-gated)
- SocialForce vectorization (benchmark-gated)
- ORCA rvo2 persistent simulator (benchmark-gated)

No campaign, training, or benchmark result is claimed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved lidar sensing, risk-surface generation, and pedestrian prediction calculations for faster batch processing.
  * Preserved sensor range, visibility, sorting, and risk-surface behavior.

* **Bug Fixes**
  * Correctly handles multiple obstacle segments and zero-distance ray intersections, including boundary cases.

* **Tests**
  * Added coverage for broadcasted obstacle raycasting and zero-hit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->