### PR TITLE
release-runner: expose --campaign-id for idempotent, resumable release runs

### DIFF
--- a/robot_sf/benchmark/release_protocol.py
+++ b/robot_sf/benchmark/release_protocol.py
@@ -675,6 +675,18 @@ def parse_release_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="run",
         help="Preflight-only validation or full release execution.",
     )
+    parser.add_argument(
+        "--campaign-id",
+        type=str,
+        default=None,
+        help=(
+            "Optional exact campaign directory id (forwarded to the campaign runner). "
+            "Passing a fixed id makes the release run idempotent: a restart after a "
+            "walltime kill, node failure, or scheduler requeue resumes the existing "
+            "campaign directory through the campaign resume plan instead of starting "
+            "a fresh timestamped one."
+        ),
+    )
     return parser.parse_args(argv)
 
 

--- a/scripts/tools/run_benchmark_release.py
+++ b/scripts/tools/run_benchmark_release.py
@@ -183,6 +183,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             cfg,
             output_root=args.output_root,
             label=args.label,
+            campaign_id=args.campaign_id,
             invoked_command=invoked_command,
         )
         preflight_payload = {

--- a/scripts/tools/run_benchmark_release.py
+++ b/scripts/tools/run_benchmark_release.py
@@ -222,6 +222,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         cfg,
         output_root=args.output_root,
         label=args.label,
+        campaign_id=args.campaign_id,
         skip_publication_bundle=True,
         invoked_command=invoked_command,
     )

--- a/tests/tools/test_run_benchmark_release.py
+++ b/tests/tools/test_run_benchmark_release.py
@@ -71,7 +71,7 @@ def test_release_preflight_uses_camera_ready_preflight(monkeypatch, capsys, tmp_
         canonical_campaign_config_path=Path("configs/benchmarks/paper_experiment_matrix_v1.yaml")
     )
     sentinel_cfg = object()
-    called = {"orca_preflight": False}
+    called = {"orca_preflight": False, "campaign_id": None}
 
     def _fake_orca_preflight(cfg) -> None:
         """Record that release preflight applies the ORCA runtime guard."""
@@ -95,10 +95,11 @@ def test_release_preflight_uses_camera_ready_preflight(monkeypatch, capsys, tmp_
         "build_resolved_release_manifest",
         lambda manifest, campaign_config=None: {"release_id": "rid"},
     )
-    monkeypatch.setattr(
-        run_benchmark_release,
-        "prepare_campaign_preflight",
-        lambda cfg, **kwargs: {
+
+    def _fake_prepare_campaign_preflight(cfg, **kwargs):
+        assert cfg is sentinel_cfg
+        called["campaign_id"] = kwargs["campaign_id"]
+        return {
             "campaign_id": "cid",
             "campaign_root": tmp_path / "out" / "cid",
             "validate_config_path": tmp_path / "out" / "cid" / "preflight" / "validate_config.json",
@@ -113,15 +114,28 @@ def test_release_preflight_uses_camera_ready_preflight(monkeypatch, capsys, tmp_
             / "reports"
             / "matrix_summary.json",
             "matrix_summary_csv_path": tmp_path / "out" / "cid" / "reports" / "matrix_summary.csv",
-        },
+        }
+
+    monkeypatch.setattr(
+        run_benchmark_release,
+        "prepare_campaign_preflight",
+        _fake_prepare_campaign_preflight,
     )
 
     exit_code = run_benchmark_release.main(
-        ["--manifest", "manifest.yaml", "--mode", "preflight"],
+        [
+            "--manifest",
+            "manifest.yaml",
+            "--mode",
+            "preflight",
+            "--campaign-id",
+            "fixed-preflight",
+        ],
     )
 
     assert exit_code == 0
     assert called["orca_preflight"] is True
+    assert called["campaign_id"] == "fixed-preflight"
     payload = json.loads(capsys.readouterr().out)
     assert payload["manifest_validation"]["status"] == "valid"
     assert payload["campaign_id"] == "cid"


### PR DESCRIPTION
The campaign stack supports exact-directory resume (`run_campaign(campaign_id=...)` + the #5392 resume-plan machinery), but `run_benchmark_release.py` never forwarded it — every restart of a release run created a fresh timestamped campaign directory and discarded all completed episodes. For long single-node release campaigns on a scheduler this means a walltime kill or node failure loses the entire run.

This PR forwards a new `--campaign-id` argument through `parse_release_args` into `run_campaign`. Passing a fixed id makes release runs idempotent: restarts (including `sbatch --requeue`) resume the existing campaign in place, running only the missing episodes.

Field-tested on a live 14-arm / 30-seed / h600 release campaign submitted with a fixed campaign id and `--requeue`. 26 release entrypoint/protocol tests pass; preflight mode validates unchanged.