### PR TITLE
fix(benchmark): fail closed on mixed-attempt camera-ready artifacts (#5453)

### DIFF
--- a/robot_sf/benchmark/camera_ready/_reporting.py
+++ b/robot_sf/benchmark/camera_ready/_reporting.py
@@ -791,6 +791,7 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
     rows = payload.get("planner_rows", [])
     warnings = payload.get("warnings", [])
     scorecard = payload.get("credibility_scorecard")
+    campaign_integrity = payload.get("campaign_integrity") or {}
     accepted_unavailable_rows = [
         row
         for row in rows
@@ -816,6 +817,7 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
         f"- Campaign status: `{campaign.get('status', 'unknown')}`",
         f"- Campaign execution status: `{campaign.get('campaign_execution_status', 'unknown')}`",
         f"- Evidence status: `{campaign.get('evidence_status', 'unknown')}`",
+        f"- Aggregate integrity: `{campaign_integrity.get('status', 'not_evaluated')}`",
         f"- Status reason: `{campaign.get('status_reason', 'unknown')}`",
         f"- Benchmark success: `{campaign.get('benchmark_success', False)}`",
         f"- Successful rows: `{campaign.get('successful_runs', 0)}` / `{campaign.get('total_runs', 0)}`",
@@ -856,6 +858,24 @@ def write_campaign_report(  # noqa: C901, PLR0912, PLR0915
             )
     else:
         lines.append("No planner rows were produced.")
+
+    lines.extend(["", "## Aggregate Integrity", ""])
+    if campaign_integrity.get("status") == "valid":
+        lines.append("Final arm aggregates have exact logical coverage and compatible provenance.")
+    else:
+        lines.append(
+            "Publication is blocked: aggregate integrity is not valid; no rows were deduplicated "
+            "or selected as a favorable slice."
+        )
+        for blocker in campaign_integrity.get("blockers", []):
+            details = blocker.get("details", {})
+            lines.append(
+                f"- `{blocker.get('arm', 'unknown')}` `{blocker.get('invariant', 'unknown')}`: "
+                f"{_escape_markdown_cell(details)}"
+            )
+    lines.append(
+        f"Claim boundary: {_escape_markdown_cell(campaign_integrity.get('claim_boundary', ''))}"
+    )
 
     arm_rollup = payload.get("arm_rollup") or []
     if arm_rollup:

--- a/robot_sf/benchmark/camera_ready/_run_state.py
+++ b/robot_sf/benchmark/camera_ready/_run_state.py
@@ -7,7 +7,10 @@ helpers so existing imports keep working while orchestration is split gradually.
 
 from __future__ import annotations
 
+import json
 import subprocess
+from collections import Counter
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -25,8 +28,6 @@ from robot_sf.benchmark.utils import _git_hash_fallback
 from robot_sf.common.artifact_paths import get_repository_root
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
-
     from robot_sf.benchmark.camera_ready._config_types import CampaignConfig
 
 
@@ -70,6 +71,247 @@ def _campaign_success_counters(
         "successful_runs": successful_runs,
         "core_total_runs": core_total_runs,
         "core_successful_runs": core_successful_runs,
+    }
+
+
+def _episode_identity(record: Mapping[str, Any]) -> tuple[str, int | str | None]:
+    """Return the stable logical identity used by aggregate-integrity checks."""
+    scenario_id = str(record.get("scenario_id", "")).strip()
+    seed = record.get("seed")
+    try:
+        seed = int(seed) if seed is not None else None
+    except (TypeError, ValueError):
+        seed = str(seed)
+    return scenario_id, seed
+
+
+def _expected_episode_identities(
+    scenarios: Sequence[Mapping[str, Any]],
+    resolved_seeds: Sequence[int],
+) -> set[tuple[str, int]]:
+    """Build the expected scenario/seed denominator from the prepared campaign matrix.
+
+    Returns:
+        Set of logical scenario/seed identities expected in every successful arm.
+    """
+    expected: set[tuple[str, int]] = set()
+    fallback_seeds = [int(seed) for seed in resolved_seeds]
+    for scenario in scenarios:
+        scenario_id = str(
+            scenario.get("id") or scenario.get("scenario_id") or scenario.get("name") or ""
+        ).strip()
+        raw_seeds = scenario.get("seeds")
+        seeds = (
+            raw_seeds if isinstance(raw_seeds, Sequence) and not isinstance(raw_seeds, str) else ()
+        )
+        if not seeds:
+            seeds = fallback_seeds
+        for seed in seeds:
+            try:
+                expected.add((scenario_id, int(seed)))
+            except (TypeError, ValueError):
+                continue
+    return expected
+
+
+def _resolve_integrity_artifact_path(campaign_root: Path, raw_path: str) -> Path:
+    """Resolve a campaign-relative or repository-relative artifact path.
+
+    Returns:
+        Resolved artifact path.
+    """
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    repo_candidate = (get_repository_root() / path).resolve()
+    if repo_candidate.exists():
+        return repo_candidate
+    return (campaign_root / path).resolve()
+
+
+def _integrity_blocker(arm: str, invariant: str, **details: Any) -> dict[str, Any]:
+    """Build one deterministic, machine-readable aggregate-integrity blocker.
+
+    Returns:
+        Blocker payload with arm, invariant, and structured details.
+    """
+    return {"arm": arm, "invariant": invariant, "details": details}
+
+
+def validate_campaign_integrity(  # noqa: C901, PLR0912, PLR0915
+    run_entries: Sequence[Mapping[str, Any]],
+    *,
+    scenarios: Sequence[Mapping[str, Any]],
+    resolved_seeds: Sequence[int],
+    campaign_root: Path,
+    campaign_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate final arm aggregates without modifying or deduplicating their rows.
+
+    The checker intentionally treats an appended row as evidence of contamination.  It never
+    selects a favorable slice: every successful arm must have exact logical coverage and enough
+    row-level provenance to establish one compatible public commit/config attempt.
+
+    Returns:
+        Machine-readable integrity verdict and blockers.
+    """
+    expected = _expected_episode_identities(scenarios, resolved_seeds)
+    blockers: list[dict[str, Any]] = []
+    manifest_git = str(
+        (campaign_manifest.get("git") or {}).get("commit")
+        if isinstance(campaign_manifest.get("git"), Mapping)
+        else campaign_manifest.get("git_hash", "")
+    ).strip()
+
+    for entry in run_entries:
+        if str(entry.get("status", "")) != "ok":
+            continue
+        planner = entry.get("planner")
+        planner = planner if isinstance(planner, Mapping) else {}
+        arm = f"{planner.get('key', 'unknown')} ({planner.get('kinematics', 'unknown')})"
+        raw_path = str(entry.get("episodes_path", "")).strip()
+        if not raw_path:
+            blockers.append(_integrity_blocker(arm, "missing_episode_artifact"))
+            continue
+        episodes_path = _resolve_integrity_artifact_path(campaign_root, raw_path)
+        try:
+            records: list[dict[str, Any]] = []
+            with episodes_path.open("r", encoding="utf-8") as handle:
+                for line_number, line in enumerate(handle, start=1):
+                    if not line.strip():
+                        continue
+                    payload = json.loads(line)
+                    if not isinstance(payload, dict):
+                        raise ValueError("episode row must be an object")
+                    records.append(payload)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            blockers.append(_integrity_blocker(arm, "unreadable_episode_artifact", error=str(exc)))
+            continue
+
+        observed = [_episode_identity(record) for record in records]
+        observed_set = set(observed)
+        duplicate_counts = Counter(observed)
+        duplicates = sorted(
+            [identity for identity, count in duplicate_counts.items() if count > 1],
+            key=str,
+        )
+        if duplicates:
+            blockers.append(
+                _integrity_blocker(
+                    arm,
+                    "duplicate_logical_coverage",
+                    identities=[list(identity) for identity in duplicates],
+                )
+            )
+
+        summary = entry.get("summary")
+        summary = summary if isinstance(summary, Mapping) else {}
+        declared = summary.get("episodes_total")
+        if declared is None:
+            declared = summary.get("written")
+        count_details = {
+            "expected": len(expected),
+            "observed": len(records),
+            "declared": declared,
+            "missing_identities": [list(identity) for identity in sorted(expected - observed_set)],
+            "unexpected_identities": [
+                list(identity) for identity in sorted(observed_set - expected)
+            ],
+        }
+        declared_count: int | None = None
+        if declared is not None:
+            try:
+                declared_count = int(declared)
+            except (TypeError, ValueError):
+                declared_count = None
+        if len(records) != len(expected) or (
+            declared is not None and declared_count != len(records)
+        ):
+            blockers.append(_integrity_blocker(arm, "count_mismatch", **count_details))
+
+        commits: set[str] = set()
+        configs_by_identity: dict[tuple[str, int | str | None], set[str]] = {}
+        for record in records:
+            result_provenance = record.get("result_provenance")
+            result_provenance = result_provenance if isinstance(result_provenance, Mapping) else {}
+            row_config = str(
+                result_provenance.get("config_hash") or record.get("config_hash") or ""
+            ).strip()
+            row_commit = str(
+                result_provenance.get("repo_commit") or record.get("git_hash") or ""
+            ).strip()
+            if not row_config or not row_commit:
+                blockers.append(
+                    _integrity_blocker(
+                        arm,
+                        "missing_provenance",
+                        identity=list(_episode_identity(record)),
+                        missing=[
+                            field
+                            for field, value in (
+                                ("config_hash", row_config),
+                                ("commit", row_commit),
+                            )
+                            if not value
+                        ],
+                    )
+                )
+            if row_commit:
+                commits.add(row_commit)
+            identity = _episode_identity(record)
+            configs_by_identity.setdefault(identity, set()).add(row_config)
+            if result_provenance:
+                if _episode_identity(result_provenance) != identity:
+                    blockers.append(
+                        _integrity_blocker(
+                            arm,
+                            "row_provenance_identity_mismatch",
+                            identity=list(identity),
+                            provenance_identity=list(_episode_identity(result_provenance)),
+                        )
+                    )
+
+        if manifest_git and commits - {manifest_git}:
+            blockers.append(
+                _integrity_blocker(
+                    arm,
+                    "mixed_commit_provenance",
+                    expected=manifest_git,
+                    observed=sorted(commits),
+                )
+            )
+        elif len(commits) > 1:
+            blockers.append(
+                _integrity_blocker(arm, "mixed_commit_provenance", observed=sorted(commits))
+            )
+        mixed_configs = {
+            identity: sorted(values)
+            for identity, values in configs_by_identity.items()
+            if len(values) > 1
+        }
+        if mixed_configs:
+            blockers.append(
+                _integrity_blocker(
+                    arm,
+                    "mixed_config_provenance",
+                    identities={
+                        str(identity): values for identity, values in mixed_configs.items()
+                    },
+                )
+            )
+
+    status = "valid" if not blockers else "invalid"
+    return {
+        "schema_version": "benchmark-camera-ready-integrity.v1",
+        "status": status,
+        "benchmark_success_allowed": status == "valid",
+        "expected_identity_count": len(expected),
+        "checked_arm_count": sum(str(entry.get("status", "")) == "ok" for entry in run_entries),
+        "blockers": blockers,
+        "claim_boundary": (
+            "A derived clean slice is diagnostic-only unless it was predeclared and "
+            "provenance-complete."
+        ),
     }
 
 

--- a/robot_sf/benchmark/camera_ready/_run_state.py
+++ b/robot_sf/benchmark/camera_ready/_run_state.py
@@ -74,15 +74,37 @@ def _campaign_success_counters(
     }
 
 
+def _coerce_identifier(value: Any) -> int | str | None:
+    """Normalize an optional logical identifier without collapsing valid falsy values.
+
+    Returns:
+        Integer, string, or ``None`` representation of the identifier.
+    """
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+
 def _episode_identity(record: Mapping[str, Any]) -> tuple[str, int | str | None]:
     """Return the stable logical identity used by aggregate-integrity checks."""
-    scenario_id = str(record.get("scenario_id", "")).strip()
-    seed = record.get("seed")
-    try:
-        seed = int(seed) if seed is not None else None
-    except (TypeError, ValueError):
-        seed = str(seed)
-    return scenario_id, seed
+    return str(record.get("scenario_id", "")).strip(), _coerce_identifier(record.get("seed"))
+
+
+def _episode_identity_sort_key(
+    identity: tuple[str, int | str | None],
+) -> tuple[str, tuple[int, str]]:
+    """Return a total ordering for identities containing heterogeneous seed values."""
+    seed = identity[1]
+    if seed is None:
+        seed_key = (0, "")
+    elif isinstance(seed, int):
+        seed_key = (1, str(seed))
+    else:
+        seed_key = (2, seed)
+    return identity[0], seed_key
 
 
 def _expected_episode_identities(
@@ -213,9 +235,13 @@ def validate_campaign_integrity(  # noqa: C901, PLR0912, PLR0915
             "expected": len(expected),
             "observed": len(records),
             "declared": declared,
-            "missing_identities": [list(identity) for identity in sorted(expected - observed_set)],
+            "missing_identities": [
+                list(identity)
+                for identity in sorted(expected - observed_set, key=_episode_identity_sort_key)
+            ],
             "unexpected_identities": [
-                list(identity) for identity in sorted(observed_set - expected)
+                list(identity)
+                for identity in sorted(observed_set - expected, key=_episode_identity_sort_key)
             ],
         }
         declared_count: int | None = None

--- a/robot_sf/benchmark/camera_ready/campaign.py
+++ b/robot_sf/benchmark/camera_ready/campaign.py
@@ -60,6 +60,7 @@ from robot_sf.benchmark.camera_ready._resume_plan import (
 from robot_sf.benchmark.camera_ready._run_state import (
     _build_arm_rollup,
     _campaign_success_counters,
+    validate_campaign_integrity,
 )
 from robot_sf.benchmark.camera_ready._summaries import (
     _SEED_VARIABILITY_METRICS,
@@ -1301,6 +1302,18 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
     seed_variability_records = planner_run_results.seed_variability_records
     _finalize_checkpoint_provenance(manifest_payload, run_entries)
     arm_rollup = _build_arm_rollup(run_entries)
+    campaign_integrity = validate_campaign_integrity(
+        run_entries,
+        scenarios=scenarios,
+        resolved_seeds=resolved_seeds,
+        campaign_root=campaign_root,
+        campaign_manifest=manifest_payload,
+    )
+    for blocker in campaign_integrity["blockers"]:
+        warnings.append(
+            "Aggregate integrity blocker: "
+            f"arm='{blocker['arm']}' invariant='{blocker['invariant']}'"
+        )
 
     planner_rows.sort(
         key=lambda row: (row.get("snqi_mean", "nan") == "nan", row.get("planner_key"))
@@ -1579,8 +1592,23 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
     success_counters = _campaign_success_counters(
         run_entries, expected_core_runs=expected_core_runs * len(kinematics_matrix)
     )
+    campaign_evidence_status = campaign_status_axes.evidence_status
+    campaign_status = campaign_outcome.status
+    campaign_status_reason = campaign_outcome.status_reason
+    campaign_exit_code = campaign_outcome.exit_code
+    if (
+        not campaign_integrity["benchmark_success_allowed"]
+        and success_counters["benchmark_success"]
+        and campaign_status_axes.evidence_status == "valid"
+    ):
+        campaign_evidence_status = "invalid"
+        campaign_status = "integrity_failed"
+        campaign_status_reason = "aggregate integrity validation failed"
+        campaign_exit_code = 1
     benchmark_success = bool(
-        success_counters["benchmark_success"] and campaign_status_axes.evidence_status == "valid"
+        success_counters["benchmark_success"]
+        and campaign_evidence_status == "valid"
+        and campaign_integrity["benchmark_success_allowed"]
     )
     confidence_settings = {
         "method": "bootstrap_mean_over_seed_means",
@@ -1832,12 +1860,12 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
             "accepted_unavailable_runs": campaign_outcome.accepted_unavailable_runs,
             "unexpected_failed_runs": campaign_outcome.unexpected_failed_runs,
             "campaign_execution_status": campaign_status_axes.campaign_execution_status,
-            "evidence_status": campaign_status_axes.evidence_status,
+            "evidence_status": campaign_evidence_status,
             "row_status_summary": row_status_summary,
             "benchmark_success": benchmark_success,
-            "status": campaign_outcome.status,
-            "status_reason": campaign_outcome.status_reason,
-            "exit_code": campaign_outcome.exit_code,
+            "status": campaign_status,
+            "status_reason": campaign_status_reason,
+            "exit_code": campaign_exit_code,
             "benchmark_success_basis": success_counters["benchmark_success_basis"],
             "core_successful_runs": success_counters["core_successful_runs"],
             "core_total_runs": success_counters["core_total_runs"],
@@ -1902,6 +1930,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
         "planner_rows": planner_rows,
         "arm_rollup": arm_rollup,
         "runs": run_entries,
+        "campaign_integrity": campaign_integrity,
         "warnings": warnings,
         "soft_contract_warning": soft_contract_warning,
         "artifacts": {
@@ -1949,6 +1978,7 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
             "scenario_family_breakdown_csv": _repo_relative(family_csv_path),
             "scenario_family_breakdown_md": _repo_relative(family_md_path),
             "campaign_report_md": _repo_relative(report_md_path),
+            "campaign_integrity_json": _repo_relative(reports_dir / "campaign_integrity.json"),
             "expected_release_archive": expected_archive_name,
             "release_url": release_url,
             "release_asset_url": release_asset_url,
@@ -2145,6 +2175,8 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
         campaign_summary
     )
     _write_json(credibility_scorecard_json_path, campaign_summary["credibility_scorecard"])
+    integrity_json_path = reports_dir / "campaign_integrity.json"
+    _write_json(integrity_json_path, campaign_integrity)
     _write_json(summary_json_path, campaign_summary)
     write_campaign_report(report_md_path, campaign_summary)
 
@@ -2216,18 +2248,19 @@ def _run_campaign_orchestrator(  # noqa: C901, PLR0912, PLR0915
         "accepted_unavailable_runs": campaign_outcome.accepted_unavailable_runs,
         "unexpected_failed_runs": campaign_outcome.unexpected_failed_runs,
         "campaign_execution_status": campaign_status_axes.campaign_execution_status,
-        "evidence_status": campaign_status_axes.evidence_status,
+        "evidence_status": campaign_evidence_status,
         "row_status_summary": row_status_summary,
         "benchmark_success": benchmark_success,
-        "status": campaign_outcome.status,
-        "status_reason": campaign_outcome.status_reason,
-        "exit_code": campaign_outcome.exit_code,
+        "status": campaign_status,
+        "status_reason": campaign_status_reason,
+        "exit_code": campaign_exit_code,
         "benchmark_success_basis": success_counters["benchmark_success_basis"],
         "core_successful_runs": success_counters["core_successful_runs"],
         "core_total_runs": success_counters["core_total_runs"],
         "total_episodes": total_episodes,
         "runtime_sec": runtime_sec,
         "publication_bundle": publication_payload,
+        "campaign_integrity": campaign_integrity,
         "warnings": warnings,
         "soft_contract_warning": soft_contract_warning,
     }

--- a/scripts/tools/analyze_camera_ready_campaign.py
+++ b/scripts/tools/analyze_camera_ready_campaign.py
@@ -850,7 +850,7 @@ def _build_scenario_difficulty_markdown(payload: dict[str, Any]) -> str:
     return "\n".join(_scenario_difficulty_markdown_lines(payload, heading_prefix="#")) + "\n"
 
 
-def _build_markdown_report(payload: dict[str, Any]) -> str:
+def _build_markdown_report(payload: dict[str, Any]) -> str:  # noqa: C901
     """Render the full camera-ready campaign analysis report.
 
     Returns:
@@ -860,6 +860,7 @@ def _build_markdown_report(payload: dict[str, Any]) -> str:
     planners = payload.get("planners", [])
     runtime_hotspots = payload.get("runtime_hotspots", {})
     scenario_difficulty = payload.get("scenario_difficulty", {})
+    campaign_integrity = payload.get("campaign_integrity") or {}
     credibility_scorecard = payload.get("credibility_scorecard", {})
     findings = payload.get("findings", [])
     lines = [
@@ -921,6 +922,16 @@ def _build_markdown_report(payload: dict[str, Any]) -> str:
     else:
         lines.append("- No runtime hotspot data available.")
 
+    lines.extend(["", "## Aggregate Integrity", ""])
+    lines.append(f"- Verdict: `{campaign_integrity.get('status', 'not_evaluated')}`")
+    for blocker in campaign_integrity.get("blockers", []):
+        lines.append(
+            f"- `{blocker.get('arm', 'unknown')}` `{blocker.get('invariant', 'unknown')}`: "
+            f"{blocker.get('details', {})}"
+        )
+    if campaign_integrity.get("claim_boundary"):
+        lines.append(f"- Claim boundary: {campaign_integrity['claim_boundary']}")
+
     if isinstance(scenario_difficulty, dict):
         lines.extend(
             [""] + _scenario_difficulty_markdown_lines(scenario_difficulty, heading_prefix="##")
@@ -948,6 +959,13 @@ def analyze_campaign(
     campaign = summary_payload.get("campaign", {}) if isinstance(summary_payload, dict) else {}
     run_entries = summary_payload.get("runs", [])
     row_map = _planner_row_index(summary_payload)
+    campaign_integrity = summary_payload.get("campaign_integrity")
+    if not isinstance(campaign_integrity, dict):
+        integrity_path = campaign_root / "reports" / "campaign_integrity.json"
+        try:
+            campaign_integrity = _read_json(integrity_path)
+        except (OSError, ValueError):
+            campaign_integrity = {}
 
     diagnostics: list[PlannerDiagnostics] = []
     findings: list[str] = []
@@ -998,6 +1016,11 @@ def analyze_campaign(
     scenario_difficulty = _load_scenario_difficulty_analysis(campaign_root, summary_payload)
     for finding in scenario_difficulty.get("findings", []):
         findings.append(f"scenario_difficulty: {finding}")
+    for blocker in campaign_integrity.get("blockers", []):
+        findings.append(
+            "aggregate_integrity: "
+            f"{blocker.get('arm', 'unknown')}: {blocker.get('invariant', 'unknown')}"
+        )
     findings = sorted(set(findings))
     credibility_scorecard = _build_credibility_scorecard(
         diagnostics=diagnostics_payload,
@@ -1019,6 +1042,7 @@ def analyze_campaign(
             "slowest_planners": slowest_planners,
         },
         "scenario_difficulty": scenario_difficulty,
+        "campaign_integrity": campaign_integrity,
         "credibility_scorecard": credibility_scorecard,
         "findings": findings,
     }

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -304,6 +304,73 @@ def test_campaign_integrity_separates_contamination_invariants(tmp_path: Path) -
     } <= invariants
 
 
+def test_campaign_integrity_handles_heterogeneous_seed_values(tmp_path: Path) -> None:
+    """Malformed optional seeds produce blockers instead of a sorting TypeError."""
+    episodes_path = tmp_path / "runs" / "goal" / "episodes.jsonl"
+    episodes_path.parent.mkdir(parents=True)
+    rows = [
+        {
+            "scenario_id": "smoke",
+            "seed": None,
+            "result_provenance": {
+                "scenario_id": "smoke",
+                "seed": None,
+                "config_hash": "scenario-config",
+                "repo_commit": "commit-a",
+            },
+        },
+        {
+            "scenario_id": "smoke",
+            "seed": "",
+            "result_provenance": {
+                "scenario_id": "smoke",
+                "seed": "",
+                "config_hash": "scenario-config",
+                "repo_commit": "commit-a",
+            },
+        },
+        {
+            "scenario_id": "smoke",
+            "seed": "non-numeric",
+            "result_provenance": {
+                "scenario_id": "smoke",
+                "seed": "non-numeric",
+                "config_hash": "scenario-config",
+                "repo_commit": "commit-a",
+            },
+        },
+        {
+            "scenario_id": "smoke",
+            "seed": 0,
+            "result_provenance": {
+                "scenario_id": "smoke",
+                "seed": 0,
+                "config_hash": "scenario-config",
+                "repo_commit": "commit-a",
+            },
+        },
+    ]
+    episodes_path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+    verdict = camera_ready_run_state_module.validate_campaign_integrity(
+        [
+            {
+                "status": "ok",
+                "planner": {"key": "goal", "kinematics": "differential_drive"},
+                "episodes_path": str(episodes_path),
+                "summary": {"episodes_total": 4},
+            }
+        ],
+        scenarios=[{"id": "smoke", "seeds": [0, 1]}],
+        resolved_seeds=[0, 1],
+        campaign_root=tmp_path,
+        campaign_manifest={"git": {"commit": "commit-a"}},
+    )
+
+    assert verdict["status"] == "invalid"
+    assert any(blocker["invariant"] == "count_mismatch" for blocker in verdict["blockers"])
+
+
 def test_scenario_with_kinematics_patches_copy_without_mutating_input() -> None:
     """Scenario kinematics patching preserves unrelated fields and leaves input untouched."""
     scenario = {

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -75,6 +75,7 @@ from robot_sf.benchmark.synthetic_actuation import (
     validate_synthetic_actuation_profile,
     validate_synthetic_actuation_variability_distribution,
 )
+from robot_sf.benchmark.utils import _git_hash_fallback
 from robot_sf.common.artifact_paths import get_repository_root
 
 
@@ -185,6 +186,122 @@ def test_campaign_success_counters_core_success_ignores_experimental_failure() -
     assert counters["successful_runs"] == 1
     assert counters["core_total_runs"] == 1
     assert counters["core_successful_runs"] == 1
+
+
+def test_campaign_integrity_accepts_exact_unique_coverage(tmp_path: Path) -> None:
+    """A complete arm with compatible row provenance remains benchmark-eligible."""
+    episodes_path = tmp_path / "runs" / "goal" / "episodes.jsonl"
+    episodes_path.parent.mkdir(parents=True)
+    rows = [
+        {
+            "scenario_id": "smoke",
+            "seed": 111,
+            "config_hash": "scenario-config-smoke",
+            "git_hash": "commit-a",
+            "result_provenance": {
+                "scenario_id": "smoke",
+                "seed": 111,
+                "config_hash": "scenario-config-smoke",
+                "repo_commit": "commit-a",
+            },
+        },
+        {
+            "scenario_id": "corner",
+            "seed": 222,
+            "config_hash": "scenario-config-corner",
+            "git_hash": "commit-a",
+            "result_provenance": {
+                "scenario_id": "corner",
+                "seed": 222,
+                "config_hash": "scenario-config-corner",
+                "repo_commit": "commit-a",
+            },
+        },
+    ]
+    episodes_path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    verdict = camera_ready_run_state_module.validate_campaign_integrity(
+        [
+            {
+                "status": "ok",
+                "planner": {"key": "goal", "kinematics": "differential_drive"},
+                "episodes_path": str(episodes_path),
+                "summary": {"episodes_total": 2},
+            }
+        ],
+        scenarios=[{"id": "smoke", "seeds": [111]}, {"id": "corner", "seeds": [222]}],
+        resolved_seeds=[111, 222],
+        campaign_root=tmp_path,
+        campaign_manifest={"git": {"commit": "commit-a"}},
+    )
+    assert verdict["status"] == "valid"
+    assert verdict["blockers"] == []
+
+
+def test_campaign_integrity_separates_contamination_invariants(tmp_path: Path) -> None:
+    """Appended duplicate rows expose count, coverage, and provenance blockers separately."""
+    episodes_path = tmp_path / "runs" / "goal" / "episodes.jsonl"
+    episodes_path.parent.mkdir(parents=True)
+    rows = [
+        {
+            "scenario_id": "smoke",
+            "seed": 111,
+            "config_hash": "scenario-config-v1",
+            "git_hash": "commit-a",
+            "result_provenance": {
+                "scenario_id": "smoke",
+                "seed": 111,
+                "config_hash": "scenario-config-v1",
+                "repo_commit": "commit-a",
+            },
+        },
+        {
+            "scenario_id": "smoke",
+            "seed": 111,
+            "config_hash": "scenario-config-v2",
+            "git_hash": "commit-b",
+            "result_provenance": {
+                "scenario_id": "smoke",
+                "seed": 111,
+                "config_hash": "scenario-config-v2",
+                "repo_commit": "commit-b",
+            },
+        },
+        {
+            "scenario_id": "corner",
+            "seed": 222,
+            "config_hash": "scenario-config-corner",
+            "git_hash": "commit-a",
+            "result_provenance": {
+                "scenario_id": "corner",
+                "seed": 222,
+                "config_hash": "scenario-config-corner",
+                "repo_commit": "commit-a",
+            },
+        },
+    ]
+    episodes_path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    verdict = camera_ready_run_state_module.validate_campaign_integrity(
+        [
+            {
+                "status": "ok",
+                "planner": {"key": "goal", "kinematics": "differential_drive"},
+                "episodes_path": str(episodes_path),
+                "summary": {"episodes_total": 3},
+            }
+        ],
+        scenarios=[{"id": "smoke", "seeds": [111]}, {"id": "corner", "seeds": [222]}],
+        resolved_seeds=[111, 222],
+        campaign_root=tmp_path,
+        campaign_manifest={"git": {"commit": "commit-a"}},
+    )
+    invariants = {blocker["invariant"] for blocker in verdict["blockers"]}
+    assert verdict["status"] == "invalid"
+    assert {
+        "count_mismatch",
+        "duplicate_logical_coverage",
+        "mixed_commit_provenance",
+        "mixed_config_provenance",
+    } <= invariants
 
 
 def test_scenario_with_kinematics_patches_copy_without_mutating_input() -> None:
@@ -4702,9 +4819,17 @@ def test_run_campaign_enforces_snqi_contract_error_mode(tmp_path: Path, monkeypa
             json.dumps(
                 {
                     "episode_id": "e-goal-0",
-                    "scenario_id": "mock",
+                    "scenario_id": "smoke",
                     "seed": 111,
+                    "config_hash": "scenario-config-smoke",
+                    "git_hash": _git_hash_fallback(),
                     "scenario_params": {"algo": "goal", "metadata": {"archetype": "crossing"}},
+                    "result_provenance": {
+                        "scenario_id": "smoke",
+                        "seed": 111,
+                        "config_hash": "scenario-config-smoke",
+                        "repo_commit": _git_hash_fallback(),
+                    },
                     "metrics": {
                         "success": 0.0,
                         "collisions": 1.0,
@@ -4799,9 +4924,17 @@ def test_run_campaign_surfaces_snqi_contract_warn_mode(tmp_path: Path, monkeypat
             json.dumps(
                 {
                     "episode_id": "e-goal-0",
-                    "scenario_id": "mock",
+                    "scenario_id": "smoke",
                     "seed": 111,
+                    "config_hash": "scenario-config-smoke",
+                    "git_hash": _git_hash_fallback(),
                     "scenario_params": {"algo": "goal", "metadata": {"archetype": "crossing"}},
+                    "result_provenance": {
+                        "scenario_id": "smoke",
+                        "seed": 111,
+                        "config_hash": "scenario-config-smoke",
+                        "repo_commit": _git_hash_fallback(),
+                    },
                     "metrics": {
                         "success": 0.0,
                         "collisions": 1.0,

--- a/tests/tools/test_analyze_camera_ready_campaign.py
+++ b/tests/tools/test_analyze_camera_ready_campaign.py
@@ -352,6 +352,38 @@ def test_analyze_campaign_detects_adapter_status_mismatch(tmp_path: Path) -> Non
     assert "runtime_hotspots" in analysis
 
 
+def test_analyze_campaign_surfaces_frozen_integrity_blocker(tmp_path: Path) -> None:
+    """Frozen analysis carries the final blocker without rerunning any episode."""
+    campaign_root = tmp_path / "campaign"
+    _write_json(
+        campaign_root / "reports" / "campaign_summary.json",
+        {
+            "campaign": {"campaign_id": "frozen"},
+            "runs": [],
+            "planner_rows": [],
+            "campaign_integrity": {
+                "status": "invalid",
+                "claim_boundary": "A derived clean slice is diagnostic-only.",
+                "blockers": [
+                    {
+                        "arm": "goal (differential_drive)",
+                        "invariant": "duplicate_logical_coverage",
+                        "details": {"identities": [["smoke", 111]]},
+                    }
+                ],
+            },
+        },
+    )
+
+    analysis = analyze_campaign(campaign_root)
+
+    assert analysis["campaign_integrity"]["status"] == "invalid"
+    assert any("duplicate_logical_coverage" in finding for finding in analysis["findings"])
+    report = _build_markdown_report(analysis)
+    assert "## Aggregate Integrity" in report
+    assert "duplicate_logical_coverage" in report
+
+
 def test_analyze_campaign_no_findings_on_consistent_payload(tmp_path: Path) -> None:
     """Analyzer emits no findings when summary and episodes are consistent."""
     campaign_root = tmp_path / "campaign"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: camera-ready finalization now validates every successful arm's JSONL aggregate before allowing `benchmark_success=true` or publication export. It records exact scenario/seed coverage, duplicate logical identities, row/config/commit provenance, and a machine-readable `reports/campaign_integrity.json` verdict; the frozen campaign analyzer and Markdown reports surface the same blockers.

Why now: resumed camera-ready arms can append mixed-attempt rows while summaries reflect only the latest invocation, allowing contaminated artifacts to appear successful.

Claim boundary: this is a tooling-integrity repair only. It proves an artifact is internally eligible for further review; it does not validate scientific outcomes or promote historical rows. A derived clean slice remains diagnostic-only unless predeclared and provenance-complete.

Required validation: `uv run pytest tests/benchmark/test_camera_ready_campaign.py tests/tools/test_analyze_camera_ready_campaign.py -q` and `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (final mode with this body).

Out of scope (per [issue #5453 task packet](https://github.com/ll7/robot_sf_ll7/issues/5453)): no campaign run is required or authorized by this PR; full benchmark execution is not an implementation blocker or deferred acceptance criterion.

## Contract delta

- New machine-readable `benchmark-camera-ready-integrity.v1` verdict is persisted in the campaign summary and `reports/campaign_integrity.json`.
- New fail-closed blockers identify `count_mismatch`, `duplicate_logical_coverage`, `mixed_commit_provenance`, `mixed_config_provenance`, missing/unreadable provenance/artifacts, and row provenance identity mismatch.
- Successful campaigns require exact unique scenario/seed coverage and compatible row provenance before publication export; no deduplication or favorable-slice selection occurs.
- Existing resume-plan preflight remains a pre-execution context check; aggregate-integrity validation is a distinct post-execution/frozen-artifact check.
- Compatibility: valid complete campaigns retain success/publication behavior; already non-success campaigns retain their existing primary failure status while carrying the integrity verdict.
- Reversible implementation assumption: current row-level `result_provenance.config_hash` is treated as the strongest available logical-row config identity, and row commit provenance must match the campaign manifest commit. Conflicting hashes for one logical scenario/seed are mixed-config evidence.

Closes #5453

## Validation and evidence

- Issue: https://github.com/ll7/robot_sf_ll7/issues/5453
- Focused tests: `158 passed` (including heterogeneous-seed regression coverage).
- Final readiness: passed against `origin/main` at `4167585001a8488a46bf126c93f63a82a5e4e664`; core lane 2,376 passed / 1 skipped and optional lane 7,168 passed / 17 skipped. Changed-line coverage met the configured 80% minimum (run-state 86.4%, reporting/campaign 100%).
- Changed files are limited to camera-ready run state/finalization/reporting, the frozen analyzer, and focused tests.
- No generated benchmark artifacts are tracked; local test/readiness outputs remain disposable.

<details>
<summary>Governance appendix</summary>

### Scope

Implements the full issue ask within the allowed camera-ready aggregation/reporting and analyzer surfaces. No planner, metric definition, benchmark config, tracked result packet, Slurm/private operation, or campaign execution changes are included.

### Out of scope (per [issue #5453 task packet](https://github.com/ll7/robot_sf_ll7/issues/5453))

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No historical artifact repair, deduplication, or claim promotion.

### Downstream propagation

Not applicable: this PR changes the acceptance contract and diagnostic/report artifacts only; it does not produce benchmark evidence or alter a paper-facing result.

### Follow-ups

No follow-up issue required: the only remaining activity is the explicitly excluded operational campaign run, not an implementation remainder. Maintainer waiver: this issue's task packet excludes campaign/Slurm execution and treats implementation as complete once the contract and CPU proof land.

### Domain-Aware Approval

Required for this PR: yes

Domains reviewed: benchmark artifact integrity, logical coverage, row provenance, publication gating

Status: maintainer waiver

Approver/review source or waiver: issue #5453 task packet and maintainer-directed fail-closed contract; no scientific-result approval is claimed.

- Target claim/hypothesis: contaminated mixed-attempt artifacts must not be promoted as successful camera-ready evidence.
- Comparator or split/evidence validity: exact declared scenario/seed denominator versus observed JSONL coverage; no campaign comparator result is claimed.
- Fallback/degraded exclusions: fallback/degraded rows remain non-success and are never accepted as integrity proof.
- Claim boundary: tooling integrity only; no scientific outcome, paper, or dissertation claim is established.
- Implementation integrity vs experimental validity: CPU fixtures prove blocker routing and clean compatibility; they do not validate a benchmark outcome.

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added aggregate integrity validation for camera-ready campaigns.
  * Campaign reports now include integrity status, validation results, blockers, and claim boundaries.
  * Invalid integrity checks can mark campaign evidence as invalid and block publication.
  * Added a machine-readable `campaign_integrity.json` report artifact.
  * Analysis reports now surface integrity findings and diagnostics.

* **Bug Fixes**
  * Improved handling of duplicate, missing, malformed, or inconsistent campaign evidence and provenance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->