### PR TITLE
fix(ci): unbreak post-#5494 main CI (#5493)

### DIFF
--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -43,23 +43,16 @@ except ImportError:  # pragma: no cover - optional dependency
     ImageSequenceClip = None  # type: ignore[assignment]
 
 try:
-    from robot_sf.baselines import get_baseline, list_baselines
+    from robot_sf.baselines import SIMPLE_POLICY_ALIASES, get_baseline, list_baselines
     from robot_sf.baselines.social_force import Observation
 except ImportError as exc:  # pragma: no cover - optional baseline dependency
     get_baseline = None  # type: ignore[assignment]
     list_baselines = None  # type: ignore[assignment]
     Observation = None  # type: ignore[assignment]
+    SIMPLE_POLICY_ALIASES = frozenset({"simple_policy", "goal", "simple", "goal_policy"})
     _BASELINE_IMPORT_ERROR = exc
 else:
     _BASELINE_IMPORT_ERROR = None
-
-# Aliases resolved to the built-in naive goal-seeking policy. Imported from the
-# lightweight ``robot_sf.baselines`` package (no heavy optional deps) so both the
-# runner and the exact-repeat executor agree on what ``run_episode`` can execute.
-try:
-    from robot_sf.baselines import SIMPLE_POLICY_ALIASES
-except ImportError:  # pragma: no cover - defensive fallback
-    SIMPLE_POLICY_ALIASES = frozenset({"simple_policy", "goal", "simple", "goal_policy"})
 
 from robot_sf.benchmark.algorithm_metadata import enrich_algorithm_metadata
 from robot_sf.benchmark.circuit_breaker import (  # noqa: F401 - compatibility export.


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** Consolidated `SIMPLE_POLICY_ALIASES` into the existing guarded baseline import in `robot_sf/benchmark/runner.py` and retained the same fallback aliases when the optional baseline import is unavailable.
- **Why now:** Post-#5494 main CI still has a deterministic failure in `tests/test_optional_import_guard_inventory.py`: #5496 added a second `except ImportError` guard, increasing the tracked `ImportError` count from 74 to 75.
- **Claim boundary:** This PR repairs the CI guard inventory without changing runner behavior, benchmark semantics, or artifact claims. It does **not** establish the required two consecutive post-repair main-CI runs because that requires this change to merge and then be observed on `main`.
- **Required validation:** Focused optional-import and runner smoke tests plus the final committed-HEAD readiness pipeline; after merge, observe two consecutive successful `CI` workflow runs on `main` after #5494.
- **Remaining blocker:** Keep #5493 open until those two post-repair main-CI runs pass.
- **Gate baseline blocker:** The current gate rerun fails only at `tests/dev/test_check_version_alignment.py::test_repo_citation_matches_latest_release_tag` because `CITATION.cff` is `0.0.2` while the latest full release tag is `0.0.3`; this is tracked in [#5522](https://github.com/ll7/robot_sf_ll7/issues/5522).

## Contract delta

- **Schema fields:** None.
- **Fail-closed blockers:** None added or removed; the existing baseline-import fallback remains unchanged.
- **Compatibility impact:** None intended. The existing `goal`/`simple_policy` alias behavior is preserved, while one duplicate import guard is removed so the optional-import ratchet remains green.

<details>
<summary>Governance, evidence, and scope details</summary>

## Scope and evidence

This is the smallest CI-only successor slice for [#5493](https://github.com/ll7/robot_sf_ll7/issues/5493), following merged [#5494](https://github.com/ll7/robot_sf_ll7/pull/5494). Recent failing main runs reproduced the same `ImportError` ratchet violation in `robot_sf/benchmark/runner.py`; the failure is also reproducible locally before this change.

The existing `tests/test_optional_import_guard_inventory.py` tests provide focused regression coverage for the 74-entry inventory and snapshot synchronization. `tests/test_runner_smoke.py::test_runner_goal_alias_executes_like_simple_policy` covers the preserved alias behavior.

## Validation

- `uv run pytest tests/test_optional_import_guard_inventory.py tests/test_runner_smoke.py -q` -> **14 passed**.
- `uv run ruff check robot_sf/benchmark/runner.py` -> **passed**.
- `uv run ruff format --check robot_sf/benchmark/runner.py` -> **passed**.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> **author-reported passed** on committed head `4d8f578ef` (full core lane: **2,376 passed, 1 skipped**; coverage, ratchets, and changed-file checks passed).
- Gate rerun on 2026-07-13: 1,467 core tests passed before the baseline failure above; no failure was in the changed runner path.

## Out of scope

- No full benchmark campaign run.
- No Slurm or GPU submission.
- No paper or dissertation claim edits.
- No benchmark metric or scenario semantic changes.

## Downstream propagation

Not applicable: this is a one-file CI repair with no evidence artifact, benchmark result, registry, or public documentation change. A separate issue comment was not posted because this run is not authorized to comment on issues/PRs; this PR body is the durable propagation surface, and it keeps #5493's remaining acceptance gate explicit.

## Friction

No friction issue filed: the only command workaround was using the documented common Git directory for logs in a linked worktree; no repository behavior or reusable interface gap was exposed.

Refs #5493.

Refs #5522.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark startup reliability when optional baseline components are unavailable.
  * Added a fallback for simple policy aliases so benchmark functionality can continue operating gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
