### PR TITLE
Issue #5506: deadline-aware planner compute-feasibility harness (cheap-lane worker)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ license: MIT
 # release workflow and scripts/dev/check_version_alignment.py. The git
 # tag/release line is the single source of truth for the version; the
 # benchmark release protocol context lives in the title/abstract, not here.
-version: 0.0.2
+version: 0.0.3
 date-released: 2026-03-26
 abstract: >-
   Social navigation simulation and benchmark tooling with a paper-facing,

--- a/docs/context/evidence/issue_4683_release_assurance_case_example.json
+++ b/docs/context/evidence/issue_4683_release_assurance_case_example.json
@@ -211,7 +211,7 @@
       "kind": "file",
       "manifest_field": "citation_path",
       "path": "CITATION.cff",
-      "sha256": "152bcd378403de5c59138447a42ad9f126bfe4d2d96a03915330adc87d5473a2"
+      "sha256": "890d732ed20cffe33e6cd500120a21758612bf8db641fbae021ccde8f7a44c26"
     },
     {
       "description": "Social Navigation Quality Index weights referenced by the manifest.",

--- a/robot_sf/benchmark/latency_stress.py
+++ b/robot_sf/benchmark/latency_stress.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+import os
+import platform
+import sys
+import threading
+import time
+from collections.abc import Callable  # noqa: TC003
 from dataclasses import dataclass, field
 from typing import Any
+
+import numpy as np
 
 _PLANNER_UPDATE_MODES = {"every-step", "hold-last"}
 _DEFAULT_NON_SUCCESS_STATUSES = (
@@ -257,3 +265,486 @@ def not_available_latency_metrics() -> dict[str, str]:
         "inference_fallback_count": "not_available",
         "synthetic_actuation_delay_steps": "not_available",
     }
+
+
+class LatencyContext:
+    """Context manager to manage the thread-local active LatencyMeasurementHarness."""
+
+    _local = threading.local()
+
+    @classmethod
+    def get_current(cls) -> LatencyMeasurementHarness | None:
+        """Get the active latency measurement harness from the thread-local context.
+
+        Returns:
+            LatencyMeasurementHarness | None: The active harness if set, else None.
+        """
+        return getattr(cls._local, "current", None)
+
+    def __init__(self, harness: LatencyMeasurementHarness):
+        """Initialize the context with a harness instance."""
+        self.harness = harness
+
+    def __enter__(self) -> LatencyContext:
+        """Enter the context and set the active harness thread-locally.
+
+        Returns:
+            LatencyContext: The context manager instance.
+        """
+        self._old = getattr(self._local, "current", None)
+        self._local.current = self.harness
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit the context and restore the previous active harness."""
+        self._local.current = self._old
+
+
+class LatencyMeasurementHarness:
+    """Harness to measure planning step latencies and sub-component breakdowns."""
+
+    @classmethod
+    def get_current(cls) -> LatencyMeasurementHarness | None:
+        """Get the active latency measurement harness from the thread-local context.
+
+        Returns:
+            LatencyMeasurementHarness | None: The active harness if set, else None.
+        """
+        return LatencyContext.get_current()
+
+    def __init__(
+        self,
+        deadline_ms: float = 100.0,
+        target_hardware: str | None = None,
+        measured_host_is_embedded: bool = False,
+    ):
+        """Initialize the latency measurement harness with a budget and target hardware."""
+        self.deadline_ms = deadline_ms
+        self.target_hardware = target_hardware
+        self.measured_host_is_embedded = measured_host_is_embedded
+        self.cycles: list[dict[str, float]] = []
+        self.current_accumulator: dict[str, float] | None = None
+        self.step_start_time: float | None = None
+
+    def __enter__(self) -> LatencyMeasurementHarness:
+        """Enter the latency measurement context and apply instrumentation.
+
+        Returns:
+            LatencyMeasurementHarness: The harness instance.
+        """
+        apply_latency_instrumentation()
+        self._context = LatencyContext(self)
+        self._context.__enter__()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit the latency measurement context."""
+        self._context.__exit__(exc_type, exc_val, exc_tb)
+
+    def wrap_policy(
+        self, policy_fn: Callable[[dict[str, Any]], Any]
+    ) -> Callable[[dict[str, Any]], Any]:
+        """Wrap policy_fn and instrument any underlying adapter and filters.
+
+        Returns:
+            Callable[[dict[str, Any]], Any]: The wrapped policy callable.
+        """
+        adapter = getattr(policy_fn, "_planner_adapter", None)
+        cbf_filter = getattr(policy_fn, "_cbf_filter", None)
+
+        if adapter:
+            instrument_adapter_for_latency(adapter, self)
+
+        if cbf_filter and not hasattr(cbf_filter.filter_command, "_instrumented"):
+            orig_filter = cbf_filter.filter_command
+
+            def wrapped_filter(*args: Any, **kwargs: Any) -> Any:
+                t0 = time.perf_counter()
+                res = orig_filter(*args, **kwargs)
+                self.add_time("collision_risk_safety_filter", (time.perf_counter() - t0) * 1000.0)
+                return res
+
+            wrapped_filter._instrumented = True  # type: ignore[attr-defined]
+            cbf_filter.filter_command = wrapped_filter
+
+        def wrapped_policy(obs: dict[str, Any]) -> Any:
+            if self.current_accumulator is not None:
+                t0 = time.perf_counter()
+                res = policy_fn(obs)
+                total_policy_time = (time.perf_counter() - t0) * 1000.0
+                used_components = (
+                    self.current_accumulator["observation_construction"]
+                    + self.current_accumulator["prediction"]
+                    + self.current_accumulator["action_conversion"]
+                    + self.current_accumulator["collision_risk_safety_filter"]
+                )
+                self.current_accumulator["planner_computation"] += max(
+                    0.0, total_policy_time - used_components
+                )
+                return res
+            return policy_fn(obs)
+
+        # Preserve any planner reset/close attributes
+        for attr in [
+            "_planner_reset",
+            "_planner_close",
+            "_planner_bind_env",
+            "_planner_stats",
+            "_planner_native_env_action",
+        ]:
+            if hasattr(policy_fn, attr):
+                setattr(wrapped_policy, attr, getattr(policy_fn, attr))
+
+        return wrapped_policy
+
+    def start_cycle(self) -> None:
+        """Start a new measurement cycle for the planning step."""
+        self.current_accumulator = {
+            "observation_construction": 0.0,
+            "prediction": 0.0,
+            "planner_computation": 0.0,
+            "collision_risk_safety_filter": 0.0,
+            "action_conversion": 0.0,
+        }
+        self.step_start_time = time.perf_counter()
+
+    def add_time(self, component: str, duration_ms: float) -> None:
+        """Accumulate execution duration for a specific planning component."""
+        if self.current_accumulator is not None:
+            self.current_accumulator[component] += duration_ms
+
+    def end_cycle(self) -> None:
+        """End the current measurement cycle and record total and component latencies."""
+        if self.step_start_time is not None and self.current_accumulator is not None:
+            total_time = (time.perf_counter() - self.step_start_time) * 1000.0
+            sum_other = (
+                self.current_accumulator["observation_construction"]
+                + self.current_accumulator["prediction"]
+                + self.current_accumulator["collision_risk_safety_filter"]
+                + self.current_accumulator["action_conversion"]
+            )
+            # Ensure planner_computation is non-negative
+            self.current_accumulator["planner_computation"] = max(
+                self.current_accumulator["planner_computation"], 0.0
+            )
+
+            # Ensure total_time is at least the sum of components
+            total_time = max(
+                total_time, sum_other + self.current_accumulator["planner_computation"]
+            )
+
+            # Guarantee component-sum consistency by adjusting planner_computation
+            self.current_accumulator["planner_computation"] = total_time - sum_other
+
+            self.cycles.append(
+                {
+                    "observation_construction_ms": self.current_accumulator[
+                        "observation_construction"
+                    ],
+                    "prediction_ms": self.current_accumulator["prediction"],
+                    "planner_computation_ms": self.current_accumulator["planner_computation"],
+                    "collision_risk_safety_filter_ms": self.current_accumulator[
+                        "collision_risk_safety_filter"
+                    ],
+                    "action_conversion_ms": self.current_accumulator["action_conversion"],
+                    "total_ms": total_time,
+                }
+            )
+        self.step_start_time = None
+        self.current_accumulator = None
+
+    def get_metrics(self) -> dict[str, Any]:
+        """Compute and retrieve summary latency statistics and provenance.
+
+        Returns:
+            dict[str, Any]: Dictionary containing latency metrics and environment info.
+        """
+        if not self.cycles:
+            return {}
+
+        cold_start = self.cycles[0]["total_ms"]
+        steady_cycles = self.cycles[1:] if len(self.cycles) > 1 else self.cycles
+        steady_totals = [c["total_ms"] for c in steady_cycles]
+
+        p50 = float(np.percentile(steady_totals, 50))
+        p95 = float(np.percentile(steady_totals, 95))
+        p99 = float(np.percentile(steady_totals, 99))
+        max_val = float(np.max(steady_totals))
+
+        misses = sum(1 for t in steady_totals if t > self.deadline_ms)
+        miss_rate = float(misses / len(steady_totals))
+
+        classification = classify_feasibility(
+            steady_state_latencies=steady_totals,
+            deadline_ms=self.deadline_ms,
+            target_hardware=self.target_hardware,
+            measured_host_is_embedded=self.measured_host_is_embedded,
+        )
+
+        avg_obs = float(np.mean([c["observation_construction_ms"] for c in steady_cycles]))
+        avg_pred = float(np.mean([c["prediction_ms"] for c in steady_cycles]))
+        avg_plan = float(np.mean([c["planner_computation_ms"] for c in steady_cycles]))
+        avg_safety = float(np.mean([c["collision_risk_safety_filter_ms"] for c in steady_cycles]))
+        avg_action = float(np.mean([c["action_conversion_ms"] for c in steady_cycles]))
+
+        prov = collect_environment_provenance()
+        validate_provenance_completeness(prov)
+
+        return {
+            "cold_start_latency_ms": cold_start,
+            "steady_state_latency_p50_ms": p50,
+            "steady_state_latency_p95_ms": p95,
+            "steady_state_latency_p99_ms": p99,
+            "steady_state_latency_max_ms": max_val,
+            "deadline_miss_rate": miss_rate,
+            "classification": classification,
+            "steady_state_averages": {
+                "observation_construction_ms": avg_obs,
+                "prediction_ms": avg_pred,
+                "planner_computation_ms": avg_plan,
+                "collision_risk_safety_filter_ms": avg_safety,
+                "action_conversion_ms": avg_action,
+            },
+            "cycles": self.cycles,
+            "provenance": prov,
+        }
+
+
+def classify_feasibility(
+    *,
+    steady_state_latencies: list[float],
+    deadline_ms: float,
+    target_hardware: str | None = None,
+    measured_host_is_embedded: bool = False,
+) -> str:
+    """Classify the compute feasibility cell based on hardware and deadlines.
+
+    Returns:
+        str: The budget classification label.
+    """
+    if target_hardware is not None:
+        target_lower = target_hardware.lower().strip()
+        is_target_embedded = any(
+            x in target_lower for x in ["jetson", "pi", "embedded", "orin", "nano", "tx2"]
+        )
+        if is_target_embedded and not measured_host_is_embedded:
+            return "target_hardware_unmeasured"
+
+    if not steady_state_latencies:
+        return "target_hardware_unmeasured"
+    if any(lat > deadline_ms for lat in steady_state_latencies):
+        return "misses_budget_on_measured_host"
+    return "meets_budget_on_measured_host"
+
+
+def collect_environment_provenance() -> dict[str, Any]:  # noqa: C901
+    """Collect hardware and software details for run provenance.
+
+    Returns:
+        dict[str, Any]: Environmental provenance dictionary containing CPU model,
+        affinity, BLAS/thread settings, package versions, and repo commit.
+    """
+    cpu_model = "unknown"
+    try:
+        if platform.system() == "Linux":
+            with open("/proc/cpuinfo") as f:
+                for line in f:
+                    if "model name" in line:
+                        cpu_model = line.split(":", 1)[1].strip()
+                        break
+        else:
+            cpu_model = platform.processor() or "unknown"
+    except OSError:
+        pass
+
+    cpu_affinity = []
+    try:
+        if hasattr(os, "sched_getaffinity"):
+            cpu_affinity = sorted(os.sched_getaffinity(0))
+    except OSError:
+        pass
+
+    thread_settings = {}
+    for var in [
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+    ]:
+        if var in os.environ:
+            thread_settings[var] = os.environ[var]
+
+    dependency_versions = {
+        "python": sys.version.split()[0],
+    }
+    for pkg in ["numpy", "numba", "torch", "stable_baselines3", "scipy"]:
+        try:
+            import importlib  # noqa: PLC0415
+
+            mod = importlib.import_module(pkg)
+            dependency_versions[pkg] = getattr(mod, "__version__", "unknown")
+        except ImportError:
+            pass
+
+    repo_commit = "unknown"
+    try:
+        from robot_sf.benchmark.utils import _git_hash_fallback  # noqa: PLC0415
+
+        repo_commit = _git_hash_fallback()
+    except (OSError, ValueError, AttributeError):
+        pass
+
+    return {
+        "cpu_model": cpu_model,
+        "cpu_affinity": cpu_affinity,
+        "thread_settings": thread_settings,
+        "dependency_versions": dependency_versions,
+        "git_commit": repo_commit,
+    }
+
+
+def validate_provenance_completeness(prov: dict[str, Any]) -> None:
+    """Ensure all required environment details are present and non-empty."""
+    required_keys = ["cpu_model", "cpu_affinity", "dependency_versions", "git_commit"]
+    for key in required_keys:
+        if key not in prov or not prov[key]:
+            raise ValueError(f"Latency provenance missing required field: {key}")
+
+    if prov["cpu_model"] == "unknown":
+        raise ValueError("Latency provenance cpu_model cannot be 'unknown'")
+
+    if not prov["git_commit"] or prov["git_commit"] == "unknown":
+        raise ValueError("Latency provenance git_commit cannot be 'unknown' or empty")
+
+    deps = prov["dependency_versions"]
+    if "python" not in deps or "numpy" not in deps:
+        raise ValueError("Latency provenance dependency_versions must include python and numpy")
+
+
+def instrument_adapter_for_latency(adapter: Any, harness: LatencyMeasurementHarness) -> None:
+    """Wraps adapter methods to measure component durations dynamically."""
+    # 1. Wrap state extraction / grid caching
+    for name in ["_extract_state", "_cache_grid_payload"]:
+        original = getattr(adapter, name, None)
+        if original and not hasattr(original, "_instrumented"):
+
+            def make_wrapped(orig_func: Callable[..., Any]) -> Callable[..., Any]:
+                def wrapped(*args: Any, **kwargs: Any) -> Any:
+                    t0 = time.perf_counter()
+                    res = orig_func(*args, **kwargs)
+                    harness.add_time(
+                        "observation_construction", (time.perf_counter() - t0) * 1000.0
+                    )
+                    return res
+
+                wrapped._instrumented = True  # type: ignore[attr-defined]
+                return wrapped
+
+            setattr(adapter, name, make_wrapped(original))
+
+    # 2. Wrap prediction methods
+    for name in ["_predict_ped_positions", "_predict_future"]:
+        original = getattr(adapter, name, None)
+        if original and not hasattr(original, "_instrumented"):
+
+            def make_wrapped(orig_func: Callable[..., Any]) -> Callable[..., Any]:
+                def wrapped(*args: Any, **kwargs: Any) -> Any:
+                    t0 = time.perf_counter()
+                    res = orig_func(*args, **kwargs)
+                    harness.add_time("prediction", (time.perf_counter() - t0) * 1000.0)
+                    return res
+
+                wrapped._instrumented = True  # type: ignore[attr-defined]
+                return wrapped
+
+            setattr(adapter, name, make_wrapped(original))
+
+
+_instrumentation_applied = False
+
+
+def apply_latency_instrumentation() -> None:  # noqa: C901
+    """Dynamically patches map-runner and policy common helper functions to record planning sub-components."""
+    global _instrumentation_applied
+    if _instrumentation_applied:
+        return
+
+    try:
+        from robot_sf.benchmark import map_runner_episode, map_runner_policy_common  # noqa: PLC0415
+
+        # 1. Patch project_with_feasibility
+        original_project = map_runner_policy_common._project_with_feasibility
+
+        def wrapped_project(*args: Any, **kwargs: Any) -> Any:
+            harness = LatencyMeasurementHarness.get_current()
+            if harness is not None:
+                t0 = time.perf_counter()
+                res = original_project(*args, **kwargs)
+                harness.add_time("action_conversion", (time.perf_counter() - t0) * 1000.0)
+                return res
+            return original_project(*args, **kwargs)
+
+        map_runner_policy_common._project_with_feasibility = wrapped_project
+
+        # 2. Patch safety wrappers outside policy
+        original_safety_wrapper = map_runner_episode._apply_safety_wrapper_step
+
+        def wrapped_safety_wrapper(*args: Any, **kwargs: Any) -> Any:
+            harness = LatencyMeasurementHarness.get_current()
+            if harness is not None:
+                t0 = time.perf_counter()
+                res = original_safety_wrapper(*args, **kwargs)
+                harness.add_time(
+                    "collision_risk_safety_filter", (time.perf_counter() - t0) * 1000.0
+                )
+                return res
+            return original_safety_wrapper(*args, **kwargs)
+
+        map_runner_episode._apply_safety_wrapper_step = wrapped_safety_wrapper
+
+        original_cbf_safety = map_runner_episode._apply_cbf_safety_filter_step
+
+        def wrapped_cbf_safety(*args: Any, **kwargs: Any) -> Any:
+            harness = LatencyMeasurementHarness.get_current()
+            if harness is not None:
+                t0 = time.perf_counter()
+                res = original_cbf_safety(*args, **kwargs)
+                harness.add_time(
+                    "collision_risk_safety_filter", (time.perf_counter() - t0) * 1000.0
+                )
+                return res
+            return original_cbf_safety(*args, **kwargs)
+
+        map_runner_episode._apply_cbf_safety_filter_step = wrapped_cbf_safety
+
+        # 3. Patch observation processing outside policy
+        original_noise = map_runner_episode.apply_observation_noise
+
+        def wrapped_noise(*args: Any, **kwargs: Any) -> Any:
+            harness = LatencyMeasurementHarness.get_current()
+            if harness is not None:
+                t0 = time.perf_counter()
+                res = original_noise(*args, **kwargs)
+                harness.add_time("observation_construction", (time.perf_counter() - t0) * 1000.0)
+                return res
+            return original_noise(*args, **kwargs)
+
+        map_runner_episode.apply_observation_noise = wrapped_noise
+
+        original_tracking = map_runner_episode._apply_tracking_precision_to_observation
+
+        def wrapped_tracking(*args: Any, **kwargs: Any) -> Any:
+            harness = LatencyMeasurementHarness.get_current()
+            if harness is not None:
+                t0 = time.perf_counter()
+                res = original_tracking(*args, **kwargs)
+                harness.add_time("observation_construction", (time.perf_counter() - t0) * 1000.0)
+                return res
+            return original_tracking(*args, **kwargs)
+
+        map_runner_episode._apply_tracking_precision_to_observation = wrapped_tracking
+    except (ImportError, AttributeError):
+        pass
+
+    _instrumentation_applied = True

--- a/robot_sf/benchmark/latency_stress.py
+++ b/robot_sf/benchmark/latency_stress.py
@@ -7,7 +7,7 @@ import platform
 import sys
 import threading
 import time
-from collections.abc import Callable  # noqa: TC003
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -20,6 +20,13 @@ _DEFAULT_NON_SUCCESS_STATUSES = (
     "timeout",
     "not_available",
     "failed",
+)
+_THREAD_SETTING_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
 )
 
 
@@ -317,11 +324,16 @@ class LatencyMeasurementHarness:
         deadline_ms: float = 100.0,
         target_hardware: str | None = None,
         measured_host_is_embedded: bool = False,
+        *,
+        config_hash: str | None = None,
+        measured_host_identity: str | None = None,
     ):
         """Initialize the latency measurement harness with a budget and target hardware."""
         self.deadline_ms = deadline_ms
         self.target_hardware = target_hardware
         self.measured_host_is_embedded = measured_host_is_embedded
+        self.config_hash = config_hash
+        self.measured_host_identity = measured_host_identity
         self.cycles: list[dict[str, float]] = []
         self.current_accumulator: dict[str, float] | None = None
         self.step_start_time: float | None = None
@@ -341,7 +353,7 @@ class LatencyMeasurementHarness:
         """Exit the latency measurement context."""
         self._context.__exit__(exc_type, exc_val, exc_tb)
 
-    def wrap_policy(
+    def wrap_policy(  # noqa: C901
         self, policy_fn: Callable[[dict[str, Any]], Any]
     ) -> Callable[[dict[str, Any]], Any]:
         """Wrap policy_fn and instrument any underlying adapter and filters.
@@ -351,6 +363,15 @@ class LatencyMeasurementHarness:
         """
         adapter = getattr(policy_fn, "_planner_adapter", None)
         cbf_filter = getattr(policy_fn, "_cbf_filter", None)
+        policy_meta = getattr(policy_fn, "_meta", None)
+        if isinstance(policy_meta, Mapping):
+            policy_config_hash = policy_meta.get("config_hash")
+            if policy_config_hash is not None and not isinstance(policy_config_hash, str):
+                raise TypeError("policy metadata config_hash must be a string")
+            if policy_config_hash:
+                if self.config_hash is not None and self.config_hash != policy_config_hash:
+                    raise ValueError("Latency harness config_hash disagrees with policy metadata")
+                self.config_hash = policy_config_hash
 
         if adapter:
             instrument_adapter_for_latency(adapter)
@@ -376,6 +397,8 @@ class LatencyMeasurementHarness:
             if active_harness is not None and active_harness.current_accumulator is not None:
                 t0 = time.perf_counter()
                 res = policy_fn(obs)
+                if hasattr(policy_fn, "_last_step_native"):
+                    wrapped_policy._last_step_native = policy_fn._last_step_native  # type: ignore[attr-defined]
                 total_policy_time = (time.perf_counter() - t0) * 1000.0
                 used_components = (
                     active_harness.current_accumulator["observation_construction"]
@@ -387,7 +410,10 @@ class LatencyMeasurementHarness:
                     0.0, total_policy_time - used_components
                 )
                 return res
-            return policy_fn(obs)
+            res = policy_fn(obs)
+            if hasattr(policy_fn, "_last_step_native"):
+                wrapped_policy._last_step_native = policy_fn._last_step_native  # type: ignore[attr-defined]
+            return res
 
         # Preserve any planner reset/close attributes
         for attr in [
@@ -396,6 +422,7 @@ class LatencyMeasurementHarness:
             "_planner_bind_env",
             "_planner_stats",
             "_planner_native_env_action",
+            "_last_step_native",
         ]:
             if hasattr(policy_fn, attr):
                 setattr(wrapped_policy, attr, getattr(policy_fn, attr))
@@ -466,9 +493,14 @@ class LatencyMeasurementHarness:
         """
         if not self.cycles:
             return {}
+        if len(self.cycles) < 2:
+            raise ValueError(
+                "Latency measurement requires at least two cycles before steady-state evidence "
+                "can be classified"
+            )
 
         cold_start = self.cycles[0]["total_ms"]
-        steady_cycles = self.cycles[1:] if len(self.cycles) > 1 else self.cycles
+        steady_cycles = self.cycles[1:]
         steady_totals = [c["total_ms"] for c in steady_cycles]
 
         p50 = float(np.percentile(steady_totals, 50))
@@ -479,21 +511,24 @@ class LatencyMeasurementHarness:
         misses = sum(1 for t in steady_totals if t > self.deadline_ms)
         miss_rate = float(misses / len(steady_totals))
 
-        classification = classify_feasibility(
-            steady_state_latencies=steady_totals,
-            deadline_ms=self.deadline_ms,
-            target_hardware=self.target_hardware,
-            measured_host_is_embedded=self.measured_host_is_embedded,
-        )
-
         avg_obs = float(np.mean([c["observation_construction_ms"] for c in steady_cycles]))
         avg_pred = float(np.mean([c["prediction_ms"] for c in steady_cycles]))
         avg_plan = float(np.mean([c["planner_computation_ms"] for c in steady_cycles]))
         avg_safety = float(np.mean([c["collision_risk_safety_filter_ms"] for c in steady_cycles]))
         avg_action = float(np.mean([c["action_conversion_ms"] for c in steady_cycles]))
 
-        prov = collect_environment_provenance()
+        prov = collect_environment_provenance(
+            config_hash=self.config_hash,
+            measured_host_identity=self.measured_host_identity,
+        )
         validate_provenance_completeness(prov)
+        classification = classify_feasibility(
+            steady_state_latencies=steady_totals,
+            deadline_ms=self.deadline_ms,
+            target_hardware=self.target_hardware,
+            measured_host_is_embedded=self.measured_host_is_embedded,
+            measured_host_identity=prov["measured_host_identity"],
+        )
 
         return {
             "cold_start_latency_ms": cold_start,
@@ -521,18 +556,22 @@ def classify_feasibility(
     deadline_ms: float,
     target_hardware: str | None = None,
     measured_host_is_embedded: bool = False,
+    measured_host_identity: str | None = None,
 ) -> str:
     """Classify the compute feasibility cell based on hardware and deadlines.
 
     Returns:
         str: The budget classification label.
     """
+    del (
+        measured_host_is_embedded
+    )  # Retained for API compatibility; identity verification is required.
     if target_hardware is not None:
-        target_lower = target_hardware.lower().strip()
-        is_target_embedded = any(
-            x in target_lower for x in ["jetson", "pi", "embedded", "orin", "nano", "tx2"]
-        )
-        if is_target_embedded and not measured_host_is_embedded:
+        if not isinstance(measured_host_identity, str) or not measured_host_identity.strip():
+            return "target_hardware_unmeasured"
+        if _normalize_hardware_identity(target_hardware) != _normalize_hardware_identity(
+            measured_host_identity
+        ):
             return "target_hardware_unmeasured"
 
     if not steady_state_latencies:
@@ -542,7 +581,20 @@ def classify_feasibility(
     return "meets_budget_on_measured_host"
 
 
-def collect_environment_provenance() -> dict[str, Any]:  # noqa: C901
+def _normalize_hardware_identity(value: str) -> str:
+    """Normalize host/target labels for conservative identity comparisons.
+
+    Returns:
+        A lowercase alphanumeric identity suitable for exact comparisons.
+    """
+    return "".join(character.lower() for character in value.strip() if character.isalnum())
+
+
+def collect_environment_provenance(  # noqa: C901
+    *,
+    config_hash: str | None = None,
+    measured_host_identity: str | None = None,
+) -> dict[str, Any]:
     """Collect hardware and software details for run provenance.
 
     Returns:
@@ -569,16 +621,30 @@ def collect_environment_provenance() -> dict[str, Any]:  # noqa: C901
     except OSError:
         pass
 
-    thread_settings = {}
-    for var in [
-        "OMP_NUM_THREADS",
-        "MKL_NUM_THREADS",
-        "OPENBLAS_NUM_THREADS",
-        "VECLIB_MAXIMUM_THREADS",
-        "NUMEXPR_NUM_THREADS",
-    ]:
-        if var in os.environ:
-            thread_settings[var] = os.environ[var]
+    thread_settings: dict[str, Any] = {
+        "environment": {var: os.environ.get(var) for var in _THREAD_SETTING_ENV_VARS},
+        "threadpools": [],
+    }
+    try:
+        from threadpoolctl import threadpool_info  # noqa: PLC0415
+
+        thread_settings["threadpools"] = [
+            {
+                key: info.get(key)
+                for key in (
+                    "user_api",
+                    "internal_api",
+                    "num_threads",
+                    "version",
+                    "threading_layer",
+                    "architecture",
+                )
+                if info.get(key) is not None
+            }
+            for info in threadpool_info()
+        ]
+    except ImportError:
+        pass
 
     dependency_versions = {
         "python": sys.version.split()[0],
@@ -606,12 +672,22 @@ def collect_environment_provenance() -> dict[str, Any]:  # noqa: C901
         "thread_settings": thread_settings,
         "dependency_versions": dependency_versions,
         "git_commit": repo_commit,
+        "config_hash": config_hash,
+        "measured_host_identity": measured_host_identity or cpu_model,
     }
 
 
-def validate_provenance_completeness(prov: dict[str, Any]) -> None:
+def validate_provenance_completeness(prov: dict[str, Any]) -> None:  # noqa: C901
     """Ensure all required environment details are present and non-empty."""
-    required_keys = ["cpu_model", "cpu_affinity", "dependency_versions", "git_commit"]
+    required_keys = [
+        "cpu_model",
+        "cpu_affinity",
+        "dependency_versions",
+        "git_commit",
+        "thread_settings",
+        "config_hash",
+        "measured_host_identity",
+    ]
     for key in required_keys:
         if key not in prov or not prov[key]:
             raise ValueError(f"Latency provenance missing required field: {key}")
@@ -621,6 +697,31 @@ def validate_provenance_completeness(prov: dict[str, Any]) -> None:
 
     if not prov["git_commit"] or prov["git_commit"] == "unknown":
         raise ValueError("Latency provenance git_commit cannot be 'unknown' or empty")
+
+    if not isinstance(prov["config_hash"], str) or not prov["config_hash"].strip():
+        raise ValueError("Latency provenance config_hash cannot be missing or empty")
+
+    if (
+        not isinstance(prov["measured_host_identity"], str)
+        or not prov["measured_host_identity"].strip()
+        or prov["measured_host_identity"] == "unknown"
+    ):
+        raise ValueError("Latency provenance measured_host_identity cannot be missing or unknown")
+
+    thread_settings = prov["thread_settings"]
+    if not isinstance(thread_settings, Mapping):
+        raise ValueError("Latency provenance thread_settings must be a mapping")
+    environment_settings = thread_settings.get("environment")
+    threadpools = thread_settings.get("threadpools")
+    if not isinstance(environment_settings, Mapping) or not isinstance(threadpools, list):
+        raise ValueError(
+            "Latency provenance thread_settings must include environment and threadpools"
+        )
+    has_effective_thread_settings = bool(threadpools) or any(
+        value not in (None, "") for value in environment_settings.values()
+    )
+    if not has_effective_thread_settings:
+        raise ValueError("Latency provenance lacks effective thread settings")
 
     deps = prov["dependency_versions"]
     if "python" not in deps or "numpy" not in deps:
@@ -680,80 +781,59 @@ def apply_latency_instrumentation() -> None:  # noqa: C901
         return
 
     try:
-        from robot_sf.benchmark import map_runner_episode, map_runner_policy_common  # noqa: PLC0415
+        from robot_sf.benchmark import map_runner_episode  # noqa: PLC0415
 
-        # 1. Patch project_with_feasibility
-        original_project = map_runner_policy_common._project_with_feasibility
-
-        def wrapped_project(*args: Any, **kwargs: Any) -> Any:
-            harness = LatencyMeasurementHarness.get_current()
-            if harness is not None:
-                t0 = time.perf_counter()
-                res = original_project(*args, **kwargs)
-                harness.add_time("action_conversion", (time.perf_counter() - t0) * 1000.0)
-                return res
-            return original_project(*args, **kwargs)
-
-        map_runner_policy_common._project_with_feasibility = wrapped_project
-
-        # 2. Patch safety wrappers outside policy
         original_safety_wrapper = map_runner_episode._apply_safety_wrapper_step
-
-        def wrapped_safety_wrapper(*args: Any, **kwargs: Any) -> Any:
-            harness = LatencyMeasurementHarness.get_current()
-            if harness is not None:
-                t0 = time.perf_counter()
-                res = original_safety_wrapper(*args, **kwargs)
-                harness.add_time(
-                    "collision_risk_safety_filter", (time.perf_counter() - t0) * 1000.0
-                )
-                return res
-            return original_safety_wrapper(*args, **kwargs)
-
-        map_runner_episode._apply_safety_wrapper_step = wrapped_safety_wrapper
-
         original_cbf_safety = map_runner_episode._apply_cbf_safety_filter_step
-
-        def wrapped_cbf_safety(*args: Any, **kwargs: Any) -> Any:
-            harness = LatencyMeasurementHarness.get_current()
-            if harness is not None:
-                t0 = time.perf_counter()
-                res = original_cbf_safety(*args, **kwargs)
-                harness.add_time(
-                    "collision_risk_safety_filter", (time.perf_counter() - t0) * 1000.0
-                )
-                return res
-            return original_cbf_safety(*args, **kwargs)
-
-        map_runner_episode._apply_cbf_safety_filter_step = wrapped_cbf_safety
-
-        # 3. Patch observation processing outside policy
         original_noise = map_runner_episode.apply_observation_noise
-
-        def wrapped_noise(*args: Any, **kwargs: Any) -> Any:
-            harness = LatencyMeasurementHarness.get_current()
-            if harness is not None:
-                t0 = time.perf_counter()
-                res = original_noise(*args, **kwargs)
-                harness.add_time("observation_construction", (time.perf_counter() - t0) * 1000.0)
-                return res
-            return original_noise(*args, **kwargs)
-
-        map_runner_episode.apply_observation_noise = wrapped_noise
-
         original_tracking = map_runner_episode._apply_tracking_precision_to_observation
+    except (ImportError, AttributeError) as exc:
+        raise RuntimeError(
+            "Latency instrumentation could not be installed: required map-runner hooks are "
+            "unavailable"
+        ) from exc
 
-        def wrapped_tracking(*args: Any, **kwargs: Any) -> Any:
-            harness = LatencyMeasurementHarness.get_current()
-            if harness is not None:
-                t0 = time.perf_counter()
-                res = original_tracking(*args, **kwargs)
-                harness.add_time("observation_construction", (time.perf_counter() - t0) * 1000.0)
-                return res
-            return original_tracking(*args, **kwargs)
+    # Patch safety wrappers outside policy.
+    def wrapped_safety_wrapper(*args: Any, **kwargs: Any) -> Any:
+        harness = LatencyMeasurementHarness.get_current()
+        if harness is not None:
+            t0 = time.perf_counter()
+            res = original_safety_wrapper(*args, **kwargs)
+            harness.add_time("collision_risk_safety_filter", (time.perf_counter() - t0) * 1000.0)
+            return res
+        return original_safety_wrapper(*args, **kwargs)
 
-        map_runner_episode._apply_tracking_precision_to_observation = wrapped_tracking
-    except (ImportError, AttributeError):
-        pass
+    # Patch the CBF safety path as a separate component wrapper.
+    def wrapped_cbf_safety(*args: Any, **kwargs: Any) -> Any:
+        harness = LatencyMeasurementHarness.get_current()
+        if harness is not None:
+            t0 = time.perf_counter()
+            res = original_cbf_safety(*args, **kwargs)
+            harness.add_time("collision_risk_safety_filter", (time.perf_counter() - t0) * 1000.0)
+            return res
+        return original_cbf_safety(*args, **kwargs)
 
+    # Patch observation processing outside policy.
+    def wrapped_noise(*args: Any, **kwargs: Any) -> Any:
+        harness = LatencyMeasurementHarness.get_current()
+        if harness is not None:
+            t0 = time.perf_counter()
+            res = original_noise(*args, **kwargs)
+            harness.add_time("observation_construction", (time.perf_counter() - t0) * 1000.0)
+            return res
+        return original_noise(*args, **kwargs)
+
+    def wrapped_tracking(*args: Any, **kwargs: Any) -> Any:
+        harness = LatencyMeasurementHarness.get_current()
+        if harness is not None:
+            t0 = time.perf_counter()
+            res = original_tracking(*args, **kwargs)
+            harness.add_time("observation_construction", (time.perf_counter() - t0) * 1000.0)
+            return res
+        return original_tracking(*args, **kwargs)
+
+    map_runner_episode._apply_safety_wrapper_step = wrapped_safety_wrapper
+    map_runner_episode._apply_cbf_safety_filter_step = wrapped_cbf_safety
+    map_runner_episode.apply_observation_noise = wrapped_noise
+    map_runner_episode._apply_tracking_precision_to_observation = wrapped_tracking
     _instrumentation_applied = True

--- a/robot_sf/benchmark/latency_stress.py
+++ b/robot_sf/benchmark/latency_stress.py
@@ -353,7 +353,7 @@ class LatencyMeasurementHarness:
         cbf_filter = getattr(policy_fn, "_cbf_filter", None)
 
         if adapter:
-            instrument_adapter_for_latency(adapter, self)
+            instrument_adapter_for_latency(adapter)
 
         if cbf_filter and not hasattr(cbf_filter.filter_command, "_instrumented"):
             orig_filter = cbf_filter.filter_command
@@ -361,24 +361,29 @@ class LatencyMeasurementHarness:
             def wrapped_filter(*args: Any, **kwargs: Any) -> Any:
                 t0 = time.perf_counter()
                 res = orig_filter(*args, **kwargs)
-                self.add_time("collision_risk_safety_filter", (time.perf_counter() - t0) * 1000.0)
+                active_harness = LatencyMeasurementHarness.get_current()
+                if active_harness is not None:
+                    active_harness.add_time(
+                        "collision_risk_safety_filter", (time.perf_counter() - t0) * 1000.0
+                    )
                 return res
 
             wrapped_filter._instrumented = True  # type: ignore[attr-defined]
             cbf_filter.filter_command = wrapped_filter
 
         def wrapped_policy(obs: dict[str, Any]) -> Any:
-            if self.current_accumulator is not None:
+            active_harness = LatencyMeasurementHarness.get_current()
+            if active_harness is not None and active_harness.current_accumulator is not None:
                 t0 = time.perf_counter()
                 res = policy_fn(obs)
                 total_policy_time = (time.perf_counter() - t0) * 1000.0
                 used_components = (
-                    self.current_accumulator["observation_construction"]
-                    + self.current_accumulator["prediction"]
-                    + self.current_accumulator["action_conversion"]
-                    + self.current_accumulator["collision_risk_safety_filter"]
+                    active_harness.current_accumulator["observation_construction"]
+                    + active_harness.current_accumulator["prediction"]
+                    + active_harness.current_accumulator["action_conversion"]
+                    + active_harness.current_accumulator["collision_risk_safety_filter"]
                 )
-                self.current_accumulator["planner_computation"] += max(
+                active_harness.current_accumulator["planner_computation"] += max(
                     0.0, total_policy_time - used_components
                 )
                 return res
@@ -622,7 +627,7 @@ def validate_provenance_completeness(prov: dict[str, Any]) -> None:
         raise ValueError("Latency provenance dependency_versions must include python and numpy")
 
 
-def instrument_adapter_for_latency(adapter: Any, harness: LatencyMeasurementHarness) -> None:
+def instrument_adapter_for_latency(adapter: Any) -> None:  # noqa: C901
     """Wraps adapter methods to measure component durations dynamically."""
     # 1. Wrap state extraction / grid caching
     for name in ["_extract_state", "_cache_grid_payload"]:
@@ -633,9 +638,11 @@ def instrument_adapter_for_latency(adapter: Any, harness: LatencyMeasurementHarn
                 def wrapped(*args: Any, **kwargs: Any) -> Any:
                     t0 = time.perf_counter()
                     res = orig_func(*args, **kwargs)
-                    harness.add_time(
-                        "observation_construction", (time.perf_counter() - t0) * 1000.0
-                    )
+                    active_harness = LatencyMeasurementHarness.get_current()
+                    if active_harness is not None:
+                        active_harness.add_time(
+                            "observation_construction", (time.perf_counter() - t0) * 1000.0
+                        )
                     return res
 
                 wrapped._instrumented = True  # type: ignore[attr-defined]
@@ -652,7 +659,9 @@ def instrument_adapter_for_latency(adapter: Any, harness: LatencyMeasurementHarn
                 def wrapped(*args: Any, **kwargs: Any) -> Any:
                     t0 = time.perf_counter()
                     res = orig_func(*args, **kwargs)
-                    harness.add_time("prediction", (time.perf_counter() - t0) * 1000.0)
+                    active_harness = LatencyMeasurementHarness.get_current()
+                    if active_harness is not None:
+                        active_harness.add_time("prediction", (time.perf_counter() - t0) * 1000.0)
                     return res
 
                 wrapped._instrumented = True  # type: ignore[attr-defined]

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -1587,6 +1587,9 @@ def _prepare_policy_and_observation_contract(  # noqa: PLR0913
         observation_mode=active_observation_mode,
         observation_level=resolved_observation_level,
     )
+    # Latency instrumentation resolves the planner configuration hash from the callable so
+    # cached policies remain provenance-bound when a new harness is activated per episode.
+    policy_fn._meta = algo_meta
     algo_meta["learned_checkpoint_observation_contract"] = learned_observation_contract
     active_observation_level = str(algo_meta["observation_level"]["key"])
     attach_track_metadata(
@@ -1901,6 +1904,7 @@ def _run_episode_step_loop(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 cbf_filter_trace.append(cbf_record)
             selected_action_payload = _command_action_payload(policy_command)
             ammv_command_actions.append(selected_action_payload)
+            action_conversion_start = time.perf_counter() if active_harness is not None else None
             if step_is_native:
                 # Policy already outputs native env actions (e.g. delta velocities);
                 # skip the absolute→delta conversion done by _policy_command_to_env_action.
@@ -1910,6 +1914,10 @@ def _run_episode_step_loop(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     env=env,
                     config=config,
                     command=policy_command,
+                )
+            if active_harness is not None and action_conversion_start is not None:
+                active_harness.add_time(
+                    "action_conversion", (time.perf_counter() - action_conversion_start) * 1000.0
                 )
             if active_harness is not None:
                 active_harness.end_cycle()

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -36,7 +36,10 @@ from robot_sf.benchmark.interaction_exposure import (
     compute_interaction_exposure_fields,
     not_derivable_interaction_exposure,
 )
-from robot_sf.benchmark.latency_stress import not_available_latency_metrics
+from robot_sf.benchmark.latency_stress import (
+    LatencyMeasurementHarness,
+    not_available_latency_metrics,
+)
 from robot_sf.benchmark.map_runner_actions import DEFAULT_KINEMATICS as _DEFAULT_KINEMATICS
 from robot_sf.benchmark.map_runner_actions import (
     policy_command_to_env_action as _policy_command_to_env_action,
@@ -1728,6 +1731,10 @@ def _run_episode_step_loop(  # noqa: C901,PLR0912,PLR0913,PLR0915
     visibility_evidence_reasons: list[str | None] = []
     env = make_robot_env(config=config, seed=int(seed), debug=False)
     try:
+        active_harness = LatencyMeasurementHarness.get_current()
+        if active_harness is not None:
+            policy_fn = active_harness.wrap_policy(policy_fn)
+
         obs, _ = env.reset(seed=int(seed))
         if callable(planner_bind_env):
             planner_bind_env(env)
@@ -1772,6 +1779,8 @@ def _run_episode_step_loop(  # noqa: C901,PLR0912,PLR0913,PLR0915
         ammv_command_actions: list[dict[str, Any]] = []
         view_integrity: dict[str, Any] | None = None
         for step_idx in range(horizon_val):
+            if active_harness is not None:
+                active_harness.start_cycle()
             policy_obs, step_noise_stats = apply_observation_noise(
                 obs,
                 noise_spec,
@@ -1902,6 +1911,8 @@ def _run_episode_step_loop(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     config=config,
                     command=policy_command,
                 )
+            if active_harness is not None:
+                active_harness.end_cycle()
             obs, reward, terminated, truncated, info = env.step(action)
 
             # Snapshot mutable simulator buffers; do not keep view aliases across steps.

--- a/robot_sf/benchmark/map_runner_policy_common.py
+++ b/robot_sf/benchmark/map_runner_policy_common.py
@@ -122,6 +122,9 @@ def build_adapter_policy(  # noqa: C901
 
     _attach_planner_reset(_policy, adapter)
     _policy._planner_adapter = adapter
+    _policy._cbf_filter = cbf_filter
+    _policy._kinematics_model = adapter_kinematics_model
+    _policy._meta = meta
     if hasattr(adapter, "bind_env"):
         _policy._planner_bind_env = adapter.bind_env
     if hasattr(adapter, "close"):

--- a/tests/benchmark/test_latency_stress.py
+++ b/tests/benchmark/test_latency_stress.py
@@ -165,6 +165,44 @@ def test_component_sum_consistency_and_mock_harness() -> None:
     assert metrics["classification"] == "misses_budget_on_measured_host"
 
 
+def test_harness_with_cached_policy_reuse() -> None:
+    """Cached policies must measure components against the currently active harness."""
+
+    class DummyAdapter:
+        def _extract_state(self, obs: Any) -> Any:
+            time.sleep(0.002)
+            return obs
+
+        def plan(self, obs: Any) -> tuple[float, float]:
+            return 0.0, 0.0
+
+    adapter = DummyAdapter()
+
+    def policy_fn(obs: dict[str, Any]) -> tuple[float, float]:
+        return adapter.plan(obs)
+
+    policy_fn._planner_adapter = adapter  # type: ignore[attr-defined]
+
+    harness1 = LatencyMeasurementHarness(deadline_ms=50.0)
+    with harness1:
+        wrapped_policy1 = harness1.wrap_policy(policy_fn)
+        harness1.start_cycle()
+        adapter._extract_state({})
+        wrapped_policy1({})
+        harness1.end_cycle()
+
+    harness2 = LatencyMeasurementHarness(deadline_ms=50.0)
+    with harness2:
+        wrapped_policy2 = harness2.wrap_policy(policy_fn)
+        harness2.start_cycle()
+        adapter._extract_state({})
+        wrapped_policy2({})
+        harness2.end_cycle()
+
+    assert harness1.get_metrics()["cycles"][0]["observation_construction_ms"] > 0.0
+    assert harness2.get_metrics()["cycles"][0]["observation_construction_ms"] > 0.0
+
+
 def test_classification_boundaries() -> None:
     """Test feasibility classifications across various targets and latencies."""
     # 1. Meets budget on measured host

--- a/tests/benchmark/test_latency_stress.py
+++ b/tests/benchmark/test_latency_stress.py
@@ -112,7 +112,7 @@ def test_not_available_latency_metrics_names_expected_placeholders() -> None:
 
 def test_component_sum_consistency_and_mock_harness() -> None:
     """Harness must guarantee component-sum consistency and measure latencies correctly."""
-    harness = LatencyMeasurementHarness(deadline_ms=50.0)
+    harness = LatencyMeasurementHarness(deadline_ms=50.0, config_hash="fixture-config")
 
     # Simulate a few cycles with mock durations
     with harness:
@@ -179,28 +179,33 @@ def test_harness_with_cached_policy_reuse() -> None:
     adapter = DummyAdapter()
 
     def policy_fn(obs: dict[str, Any]) -> tuple[float, float]:
+        policy_fn._last_step_native = True  # type: ignore[attr-defined]
         return adapter.plan(obs)
 
     policy_fn._planner_adapter = adapter  # type: ignore[attr-defined]
 
-    harness1 = LatencyMeasurementHarness(deadline_ms=50.0)
+    harness1 = LatencyMeasurementHarness(deadline_ms=50.0, config_hash="fixture-config")
     with harness1:
         wrapped_policy1 = harness1.wrap_policy(policy_fn)
-        harness1.start_cycle()
-        adapter._extract_state({})
-        wrapped_policy1({})
-        harness1.end_cycle()
+        for _ in range(2):
+            harness1.start_cycle()
+            adapter._extract_state({})
+            wrapped_policy1({})
+            harness1.end_cycle()
 
-    harness2 = LatencyMeasurementHarness(deadline_ms=50.0)
+    harness2 = LatencyMeasurementHarness(deadline_ms=50.0, config_hash="fixture-config")
     with harness2:
         wrapped_policy2 = harness2.wrap_policy(policy_fn)
-        harness2.start_cycle()
-        adapter._extract_state({})
-        wrapped_policy2({})
-        harness2.end_cycle()
+        for _ in range(2):
+            harness2.start_cycle()
+            adapter._extract_state({})
+            wrapped_policy2({})
+            harness2.end_cycle()
 
     assert harness1.get_metrics()["cycles"][0]["observation_construction_ms"] > 0.0
     assert harness2.get_metrics()["cycles"][0]["observation_construction_ms"] > 0.0
+    assert getattr(wrapped_policy1, "_last_step_native", False) is True
+    assert getattr(wrapped_policy2, "_last_step_native", False) is True
 
 
 def test_classification_boundaries() -> None:
@@ -226,18 +231,29 @@ def test_classification_boundaries() -> None:
         steady_state_latencies=[10.0, 20.0, 30.0],
         deadline_ms=50.0,
         target_hardware="Jetson Orin Nano",
-        measured_host_is_embedded=False,
+        measured_host_identity=None,
     )
     assert res == "target_hardware_unmeasured"
 
-    # 4. Target hardware matches / measured is embedded
+    # 4. Target hardware matches only when the measured identity is explicit.
     res = classify_feasibility(
         steady_state_latencies=[10.0, 20.0, 30.0],
         deadline_ms=50.0,
         target_hardware="Jetson Orin Nano",
         measured_host_is_embedded=True,
+        measured_host_identity="Jetson-Orin_Nano",
     )
     assert res == "meets_budget_on_measured_host"
+
+    # 5. An embedded host with a different model is still unmeasured.
+    res = classify_feasibility(
+        steady_state_latencies=[10.0, 20.0, 30.0],
+        deadline_ms=50.0,
+        target_hardware="Jetson Orin Nano",
+        measured_host_is_embedded=True,
+        measured_host_identity="Jetson Xavier NX",
+    )
+    assert res == "target_hardware_unmeasured"
 
 
 def test_provenance_completeness_fail_closed() -> None:
@@ -246,8 +262,14 @@ def test_provenance_completeness_fail_closed() -> None:
     valid_prov = {
         "cpu_model": "Intel Core i7",
         "cpu_affinity": [0, 1, 2, 3],
+        "thread_settings": {
+            "environment": {"OMP_NUM_THREADS": "1"},
+            "threadpools": [],
+        },
         "dependency_versions": {"python": "3.10.0", "numpy": "1.22.0"},
         "git_commit": "abcdef123456",
+        "config_hash": "fixture-config",
+        "measured_host_identity": "Intel Core i7",
     }
     # Should not raise any exception
     validate_provenance_completeness(valid_prov)
@@ -271,6 +293,17 @@ def test_provenance_completeness_fail_closed() -> None:
         validate_provenance_completeness(bad_prov)
 
 
+def test_harness_rejects_cold_only_evidence() -> None:
+    """A single cold-start cycle cannot be classified as steady-state evidence."""
+    harness = LatencyMeasurementHarness(deadline_ms=50.0, config_hash="fixture-config")
+    with harness:
+        harness.start_cycle()
+        harness.end_cycle()
+
+    with pytest.raises(ValueError, match="at least two cycles"):
+        harness.get_metrics()
+
+
 def test_harness_with_actual_planners(monkeypatch: pytest.MonkeyPatch) -> None:
     """Harness must produce a full latency record on a fixture scenario for >= 2 planners."""
     from robot_sf.benchmark.map_runner import _run_map_episode
@@ -288,6 +321,7 @@ def test_harness_with_actual_planners(monkeypatch: pytest.MonkeyPatch) -> None:
     class _DummyEnv:
         def __init__(self, map_def: MapDefinition) -> None:
             self.simulator = _DummySim(map_def)
+            self.step_count = 0
 
         def reset(self, seed: int | None = None):
             obs = {
@@ -298,12 +332,13 @@ def test_harness_with_actual_planners(monkeypatch: pytest.MonkeyPatch) -> None:
             return obs, {}
 
         def step(self, action: Any):
+            self.step_count += 1
             obs = {
                 "robot": {"position": [0.0, 0.0], "heading": [0.0], "speed": [0.0]},
                 "goal": {"current": [1.0, 1.0], "next": [1.0, 1.0]},
                 "pedestrians": {"positions": [], "velocities": []},
             }
-            return obs, 0.0, True, False, {"success": True}
+            return obs, 0.0, self.step_count >= 2, False, {"success": True}
 
         def close(self) -> None:
             return None
@@ -352,6 +387,8 @@ def test_harness_with_actual_planners(monkeypatch: pytest.MonkeyPatch) -> None:
         )
     metrics_goal = harness_goal.get_metrics()
     assert "steady_state_averages" in metrics_goal
+    assert len(metrics_goal["cycles"]) >= 2
+    assert any(cycle["action_conversion_ms"] > 0.0 for cycle in metrics_goal["cycles"])
     assert metrics_goal["classification"] in {
         "meets_budget_on_measured_host",
         "misses_budget_on_measured_host",
@@ -381,6 +418,8 @@ def test_harness_with_actual_planners(monkeypatch: pytest.MonkeyPatch) -> None:
         )
     metrics_mppi = harness_mppi.get_metrics()
     assert "steady_state_averages" in metrics_mppi
+    assert len(metrics_mppi["cycles"]) >= 2
+    assert any(cycle["action_conversion_ms"] > 0.0 for cycle in metrics_mppi["cycles"])
     assert metrics_mppi["classification"] in {
         "meets_budget_on_measured_host",
         "misses_budget_on_measured_host",

--- a/tests/benchmark/test_latency_stress.py
+++ b/tests/benchmark/test_latency_stress.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
 import pytest
 
 from robot_sf.benchmark.latency_stress import (
+    LatencyMeasurementHarness,
     LatencyStressProfile,
+    classify_feasibility,
     load_latency_stress_profile,
     not_available_latency_metrics,
+    validate_provenance_completeness,
 )
 
 
@@ -99,3 +108,242 @@ def test_not_available_latency_metrics_names_expected_placeholders() -> None:
     assert metrics["observation_age_ms"] == "not_available"
     assert metrics["held_action_ratio"] == "not_available"
     assert metrics["inference_timeout_count"] == "not_available"
+
+
+def test_component_sum_consistency_and_mock_harness() -> None:
+    """Harness must guarantee component-sum consistency and measure latencies correctly."""
+    harness = LatencyMeasurementHarness(deadline_ms=50.0)
+
+    # Simulate a few cycles with mock durations
+    with harness:
+        # Cycle 0 (Cold start)
+        harness.start_cycle()
+        harness.add_time("observation_construction", 5.0)
+        harness.add_time("prediction", 10.0)
+        harness.add_time("collision_risk_safety_filter", 2.0)
+        harness.add_time("action_conversion", 1.0)
+        # Sleep a little to simulate planner computation
+        time.sleep(0.01)
+        harness.end_cycle()
+
+        # Cycle 1 (Steady state 1)
+        harness.start_cycle()
+        harness.add_time("observation_construction", 1.0)
+        harness.add_time("prediction", 2.0)
+        harness.add_time("collision_risk_safety_filter", 0.5)
+        harness.add_time("action_conversion", 0.5)
+        time.sleep(0.005)
+        harness.end_cycle()
+
+        # Cycle 2 (Steady state 2 - misses budget)
+        harness.start_cycle()
+        harness.add_time("observation_construction", 10.0)
+        harness.add_time("prediction", 20.0)
+        harness.add_time("collision_risk_safety_filter", 5.0)
+        harness.add_time("action_conversion", 2.0)
+        time.sleep(0.06)
+        harness.end_cycle()
+
+    # Get metrics
+    metrics = harness.get_metrics()
+    assert metrics["cold_start_latency_ms"] > 0.0
+
+    # Check component sum consistency
+    for cycle in metrics["cycles"]:
+        components_sum = (
+            cycle["observation_construction_ms"]
+            + cycle["prediction_ms"]
+            + cycle["planner_computation_ms"]
+            + cycle["collision_risk_safety_filter_ms"]
+            + cycle["action_conversion_ms"]
+        )
+        assert abs(components_sum - cycle["total_ms"]) < 1e-3
+
+    # Check classifications and stats
+    assert len(metrics["cycles"]) == 3
+    assert metrics["deadline_miss_rate"] == 0.5  # 1 out of 2 steady cycles missed 50ms
+    assert metrics["classification"] == "misses_budget_on_measured_host"
+
+
+def test_classification_boundaries() -> None:
+    """Test feasibility classifications across various targets and latencies."""
+    # 1. Meets budget on measured host
+    res = classify_feasibility(
+        steady_state_latencies=[10.0, 20.0, 30.0],
+        deadline_ms=50.0,
+        target_hardware=None,
+    )
+    assert res == "meets_budget_on_measured_host"
+
+    # 2. Misses budget on measured host
+    res = classify_feasibility(
+        steady_state_latencies=[10.0, 60.0, 30.0],
+        deadline_ms=50.0,
+        target_hardware=None,
+    )
+    assert res == "misses_budget_on_measured_host"
+
+    # 3. Target hardware unmeasured (desktop measured, but target is embedded)
+    res = classify_feasibility(
+        steady_state_latencies=[10.0, 20.0, 30.0],
+        deadline_ms=50.0,
+        target_hardware="Jetson Orin Nano",
+        measured_host_is_embedded=False,
+    )
+    assert res == "target_hardware_unmeasured"
+
+    # 4. Target hardware matches / measured is embedded
+    res = classify_feasibility(
+        steady_state_latencies=[10.0, 20.0, 30.0],
+        deadline_ms=50.0,
+        target_hardware="Jetson Orin Nano",
+        measured_host_is_embedded=True,
+    )
+    assert res == "meets_budget_on_measured_host"
+
+
+def test_provenance_completeness_fail_closed() -> None:
+    """Provenance validation must fail closed when required fields are missing or empty."""
+    # Complete/valid provenance
+    valid_prov = {
+        "cpu_model": "Intel Core i7",
+        "cpu_affinity": [0, 1, 2, 3],
+        "dependency_versions": {"python": "3.10.0", "numpy": "1.22.0"},
+        "git_commit": "abcdef123456",
+    }
+    # Should not raise any exception
+    validate_provenance_completeness(valid_prov)
+
+    # Missing cpu_model
+    bad_prov = dict(valid_prov)
+    bad_prov["cpu_model"] = "unknown"
+    with pytest.raises(ValueError, match="cpu_model cannot be 'unknown'"):
+        validate_provenance_completeness(bad_prov)
+
+    # Missing git_commit
+    bad_prov = dict(valid_prov)
+    bad_prov["git_commit"] = "unknown"
+    with pytest.raises(ValueError, match="git_commit cannot be 'unknown'"):
+        validate_provenance_completeness(bad_prov)
+
+    # Missing numpy dependency
+    bad_prov = dict(valid_prov)
+    bad_prov["dependency_versions"] = {"python": "3.10"}
+    with pytest.raises(ValueError, match="must include python and numpy"):
+        validate_provenance_completeness(bad_prov)
+
+
+def test_harness_with_actual_planners(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Harness must produce a full latency record on a fixture scenario for >= 2 planners."""
+    from robot_sf.benchmark.map_runner import _run_map_episode
+    from robot_sf.nav.map_config import MapDefinition
+
+    # 1. Setup minimal map definition and stubs
+    class _DummySim:
+        def __init__(self, map_def: MapDefinition) -> None:
+            self.robot_pos = [np.array([0.0, 0.0], dtype=float)]
+            self.ped_pos = np.zeros((0, 2), dtype=float)
+            self.goal_pos = [np.array([1.0, 1.0], dtype=float)]
+            self.map_def = map_def
+            self.last_ped_forces = np.zeros((0, 2), dtype=float)
+
+    class _DummyEnv:
+        def __init__(self, map_def: MapDefinition) -> None:
+            self.simulator = _DummySim(map_def)
+
+        def reset(self, seed: int | None = None):
+            obs = {
+                "robot": {"position": [0.0, 0.0], "heading": [0.0], "speed": [0.0]},
+                "goal": {"current": [1.0, 1.0], "next": [1.0, 1.0]},
+                "pedestrians": {"positions": [], "velocities": []},
+            }
+            return obs, {}
+
+        def step(self, action: Any):
+            obs = {
+                "robot": {"position": [0.0, 0.0], "heading": [0.0], "speed": [0.0]},
+                "goal": {"current": [1.0, 1.0], "next": [1.0, 1.0]},
+                "pedestrians": {"positions": [], "velocities": []},
+            }
+            return obs, 0.0, True, False, {"success": True}
+
+        def close(self) -> None:
+            return None
+
+    map_def = MagicMock()
+    dummy_config = type("Cfg", (), {"sim_config": type("SC", (), {"time_per_step_in_secs": 0.1})()})
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._build_env_config",
+        lambda scenario, scenario_path: dummy_config,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.make_robot_env",
+        lambda config, seed, debug: _DummyEnv(map_def),
+    )
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.sample_obstacle_points", lambda *args: None)
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.compute_shortest_path_length",
+        lambda *args: 1.0,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.compute_all_metrics",
+        lambda *args, **kwargs: {"success": 0.0, "collisions": 0.0},
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.post_process_metrics",
+        lambda metrics, **kwargs: metrics,
+    )
+
+    scenario = {"name": "s1", "simulation_config": {"max_episode_steps": 2}}
+
+    # 2. Run under harness for "goal" planner
+    harness_goal = LatencyMeasurementHarness(deadline_ms=100.0)
+    with harness_goal:
+        _run_map_episode(
+            scenario,
+            seed=1,
+            horizon=None,
+            dt=0.1,
+            record_forces=True,
+            snqi_weights=None,
+            snqi_baseline=None,
+            algo="goal",
+            algo_config_path=None,
+            scenario_path=Path("."),
+        )
+    metrics_goal = harness_goal.get_metrics()
+    assert "steady_state_averages" in metrics_goal
+    assert metrics_goal["classification"] in {
+        "meets_budget_on_measured_host",
+        "misses_budget_on_measured_host",
+    }
+
+    # 3. Run under harness for "mppi_social" planner
+    harness_mppi = LatencyMeasurementHarness(deadline_ms=100.0)
+    with harness_mppi:
+        _run_map_episode(
+            scenario,
+            seed=1,
+            horizon=None,
+            dt=0.1,
+            record_forces=True,
+            snqi_weights=None,
+            snqi_baseline=None,
+            algo="mppi_social",
+            algo_config_path=None,
+            scenario_path=Path("."),
+            algo_config={
+                "goal_tolerance": 0.2,
+                "horizon_steps": 5,
+                "sample_count": 8,
+                "iterations": 1,
+                "elite_fraction": 0.25,
+            },
+        )
+    metrics_mppi = harness_mppi.get_metrics()
+    assert "steady_state_averages" in metrics_mppi
+    assert metrics_mppi["classification"] in {
+        "meets_budget_on_measured_host",
+        "misses_budget_on_measured_host",
+    }


### PR DESCRIPTION
## What / Why

This PR completes the first-slice acceptance defined by issue #5506: a deadline-aware,
fixture-scale compute-feasibility harness for end-to-end planner timing diagnostics.

## Changes

- `robot_sf/benchmark/latency_stress.py`: adds context-aware per-cycle and component timing,
  cold/steady-state separation, deadline miss-rate classification, configuration-bound
  provenance, target-identity checks, and fail-closed instrumentation setup.
- `robot_sf/benchmark/map_runner_episode.py`: records the complete planning-step boundary,
  including final environment-action conversion, and propagates planner metadata to the
  latency harness.
- `robot_sf/benchmark/map_runner_policy_common.py`: exposes planner metadata needed by the
  instrumentation contract.
- `tests/benchmark/test_latency_stress.py`: covers component sums, classification boundaries,
  provenance failures, cached-policy reuse, cold/steady-state requirements, and actual planner
  fixture execution.
- `docs/context/evidence/issue_4683_release_assurance_case_example.json`: aligns the stored
  citation hash with the current release metadata; this changes no benchmark result.

## Claim boundary

- Evidence is fixture-scale CPU diagnostic infrastructure only; no embedded-platform feasibility
  is claimed from desktop/server measurements.
- The first cycle is treated as cold start; steady-state classification requires at least two
  measured cycles and complete provenance.

## Validation / Proof

- `uv run pytest tests/benchmark/test_latency_stress.py -q` — 12 passed.
- Focused Ruff check and format check — passed.
- Full final readiness gate at `f45e6ca35` — core: 2,376 passed, 1 skipped; optional/predictive:
  7,188 passed, 17 skipped; lint, contract, coverage-ratchet, broad-exception, and docstring
  checks passed. The latency module’s 80.8% changed-line coverage is a repository warning-only
  stretch-goal note, not a gate failure.

## Research Result Guidance

- Target claim / hypothesis / blocker: measure end-to-end planner timing against a configurable
  control deadline with component-level attribution.
- Comparator or baseline: no-harness default timing.
- Evidence tier: diagnostic fixture and integration validation.
- Result classification: infrastructure/diagnostic-only.
- Decision or stop rule: stop this first slice after component-sum, classification, provenance,
  reuse, and actual-planner fixture contracts pass.

## Domain-Aware Approval

- Required for this PR: yes (changes policy step loops and timing metadata).
- Domains reviewed: simulation timing boundaries, component latency accounting, hardware/software
  provenance, and benchmark evidence classification.
- Status: approved for implementation integrity; diagnostic claim boundary accepted.
- Approver/review source or waiver: issue #5506 acceptance contract and gate review of PR #5524.
- Validity checklist:
  - Target claim/hypothesis: the harness measures end-to-end timing against a configurable
    deadline with component attribution.
  - Comparator or split/evidence validity: no-harness default timing is the comparator; this
    first slice does not assert a campaign comparison.
  - Fallback/degraded exclusions: incomplete provenance or instrumentation fails closed, and
    fallback/degraded rows are not success evidence.
  - Claim boundary: fixture-scale diagnostic infrastructure only; target hardware requires an
    explicit identity match.
  - Implementation integrity vs experimental validity: tests establish harness mechanics; they
    do not establish a scientific planner ranking.

Completion boundary: this is the complete first-slice repair for #5506; it is not a successor
slice and does not duplicate a prior implementation.

Parent issue propagation: pending merge — the gate will post the required one-line
criterion-to-PR state update on #5506 after merge.

## Follow-Up Issues

- Deferred work: execute the representative-CPU matrix campaign and durable evidence synthesis
  after this fixture-scale first slice.
- Issues opened for follow-up: #5525

Closes #5506
