### PR TITLE
Issue #5525: compute-feasibility matrix runner (cheap-lane worker)

### DIFF
--- a/configs/benchmarks/compute_feasibility_matrix_v1.yaml
+++ b/configs/benchmarks/compute_feasibility_matrix_v1.yaml
@@ -4,7 +4,7 @@
 #   Define the planner/scenario/deadline matrix for the representative-CPU
 #   compute-feasibility study enabled by the latency-stress harness (#5506/#5524).
 #
-# This config covers two planners, two maps, three pedestrian-count levels,
+# This config covers three planners, two maps, three pedestrian-count levels,
 # two control deadlines, and three seeds per cell. The matrix produces cold-
 # and steady-state per-cycle and component metrics, deadline-miss rates,
 # provenance, and conservative feasibility classification per cell.
@@ -23,11 +23,9 @@ schema_version: compute_feasibility_matrix.v1
 planners:
   - key: goal
     algo: goal
-    benchmark_profile: baseline-safe
 
   - key: mppi_social
     algo: mppi_social
-    benchmark_profile: baseline-safe
     algo_config:
       goal_tolerance: 0.2
       horizon_steps: 5
@@ -37,7 +35,6 @@ planners:
 
   - key: social_force
     algo: social_force
-    benchmark_profile: baseline-safe
 
 # Maps (SVG paths relative to repo root)
 maps:

--- a/configs/benchmarks/compute_feasibility_matrix_v1.yaml
+++ b/configs/benchmarks/compute_feasibility_matrix_v1.yaml
@@ -1,0 +1,70 @@
+## Compute-Feasibility Matrix Config v1
+#
+# Purpose:
+#   Define the planner/scenario/deadline matrix for the representative-CPU
+#   compute-feasibility study enabled by the latency-stress harness (#5506/#5524).
+#
+# This config covers two planners, two maps, three pedestrian-count levels,
+# two control deadlines, and three seeds per cell. The matrix produces cold-
+# and steady-state per-cycle and component metrics, deadline-miss rates,
+# provenance, and conservative feasibility classification per cell.
+#
+# Canonical command:
+#   uv run python scripts/benchmark/run_compute_feasibility_matrix.py \
+#       --config configs/benchmarks/compute_feasibility_matrix_v1.yaml
+#
+# Output:
+#   output/compute_feasibility_matrix_v1/ directory with JSONL rows, a
+#   manifest.json provenance file, and a synthetic_summary.json report.
+
+schema_version: compute_feasibility_matrix.v1
+
+# Planners to evaluate
+planners:
+  - key: goal
+    algo: goal
+    benchmark_profile: baseline-safe
+
+  - key: mppi_social
+    algo: mppi_social
+    benchmark_profile: baseline-safe
+    algo_config:
+      goal_tolerance: 0.2
+      horizon_steps: 5
+      sample_count: 8
+      iterations: 1
+      elite_fraction: 0.25
+
+  - key: social_force
+    algo: social_force
+    benchmark_profile: baseline-safe
+
+# Maps (SVG paths relative to repo root)
+maps:
+  - path: maps/svg_maps/atomic_empty_frame_test.svg
+    label: empty_8x8
+
+  - path: maps/svg_maps/classic_bottleneck_medium.svg
+    label: bottleneck_medium
+
+# Pedestrian counts per episode
+pedestrian_counts:
+  - 0
+  - 5
+  - 15
+
+# Declared control deadlines (ms)
+control_deadlines_ms:
+  - 100
+  - 50
+
+# Seeds per cell
+seeds: [42, 111, 987]
+
+# Fixed episode parameters
+horizon: 60
+dt: 0.1
+record_forces: false
+observation_mode: null
+observation_level: null
+benchmark_track: latency_feasibility_v1

--- a/scripts/benchmark/run_compute_feasibility_matrix.py
+++ b/scripts/benchmark/run_compute_feasibility_matrix.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""Compute-feasibility matrix runner (issue #5525).
+
+Executes a planner/scenario/deadline matrix using the LatencyMeasurementHarness
+from #5506/#5524 and produces cold/steady-state latency metrics, deadline-miss
+rates, feasibility classifications, and full environment provenance per cell.
+
+Output:
+  output/compute_feasibility_matrix_v1/ (or --out)
+    rows.jsonl          — one JSON record per cell
+    manifest.json       — config+provenance header
+    synthetic_summary.json  — per-planner latency summary table
+
+Usage:
+  uv run python scripts/benchmark/run_compute_feasibility_matrix.py \\
+      --config configs/benchmarks/compute_feasibility_matrix_v1.yaml
+
+Notes:
+  - CPU-only, no SLURM, no training runs.
+  - Fallback/degraded cells are classified explicitly (fail-closed).
+  - Every accepted row passes the latency component-sum contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+
+from robot_sf.benchmark.latency_stress import (
+    LatencyMeasurementHarness,
+    classify_feasibility,
+    collect_environment_provenance,
+)
+from robot_sf.benchmark.map_runner import _run_map_episode
+from robot_sf.benchmark.utils import _config_hash, _git_hash_fallback
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = REPO_ROOT / "configs" / "benchmarks" / "compute_feasibility_matrix_v1.yaml"
+
+
+@dataclass(frozen=True)
+class MatrixCell:
+    """One position in the compute-feasibility matrix."""
+
+    planner_key: str
+    algo: str
+    algo_config: dict[str, Any] | None
+    map_label: str
+    map_path: str
+    pedestrian_count: int
+    deadline_ms: float
+    seed: int
+
+
+def _git_head() -> str:
+    """Return the current git HEAD commit hash, or ``unknown``."""
+    return _git_hash_fallback() or "unknown"
+
+
+def _resolve_scenario(
+    *,
+    map_path: str,
+    map_label: str,
+    pedestrian_count: int,
+    horizon: int,
+    repo_root: Path,
+    scenario_path: Path,
+) -> dict[str, Any]:
+    """Build a scenario dict from map path and parameters.
+
+    Returns:
+        dict[str, Any]: Scenario definition for map_runner.
+    """
+    abs_map = Path(map_path)
+    if not abs_map.is_absolute():
+        abs_map = (repo_root / map_path).resolve()
+
+    scenario: dict[str, Any] = {
+        "name": f"feasibility_{map_label}_peds{pedestrian_count}",
+        "map_file": str(abs_map),
+        "simulation_config": {
+            "max_episode_steps": horizon,
+            "ped_density": 0.0,
+        },
+        "robot_config": {},
+    }
+    # Add pedestrians via single_pedestrians when count > 0:
+    # we set ped_density so the simulator spawns random pedestrians,
+    # but the exact count is controlled by ped_density * area.
+    # For a reproducible fixed count, use single_pedestrians.
+    if pedestrian_count > 0:
+        # Load the map to find valid POIs for pedestrian goals.
+        from robot_sf.training.scenario_loader import load_scenarios
+
+        # Minimal scenario YAML to get map geometry
+        temp_yaml = {"scenarios": [{"name": "temp", "map_file": str(abs_map)}]}
+        scenarios = load_scenarios(
+            yaml.dump(temp_yaml),
+            scenario_config=Path(str(temp_yaml["scenarios"][0]["map_file"])),
+        )
+        if scenarios:
+            # Use ped_density approach: density controls spawn rate
+            # Scale density to approximate desired count for the map area
+
+            # We'll let build_env_config handle the map loading
+            # Use a higher ped_density for more pedestrians
+            base_density = 0.02  # Base density
+            scenario["simulation_config"]["ped_density"] = base_density * (
+                1 + pedestrian_count * 0.1
+            )
+        else:
+            # Fallback: use a higher density to approximate pedestrian count
+            scenario["simulation_config"]["ped_density"] = 0.02 + pedestrian_count * 0.005
+
+    scenario["scenario_path"] = str(scenario_path)
+    return scenario
+
+
+def _run_cell(
+    cell: MatrixCell,
+    *,
+    horizon: int,
+    dt: float,
+    repo_root: Path,
+    scenario_path: Path,
+    observation_mode: str | None = None,
+    observation_level: str | None = None,
+    benchmark_track: str | None = None,
+) -> dict[str, Any]:
+    """Execute one matrix cell and return its latency + classification record.
+
+    Returns:
+        dict[str, Any]: Record with latency metrics, classification, provenance.
+    """
+    scenario = _resolve_scenario(
+        map_path=cell.map_path,
+        map_label=cell.map_label,
+        pedestrian_count=cell.pedestrian_count,
+        horizon=horizon,
+        repo_root=repo_root,
+        scenario_path=scenario_path,
+    )
+
+    cfg_hash = _config_hash(
+        {
+            "algo": cell.algo,
+            "algo_config": cell.algo_config or {},
+            "map_label": cell.map_label,
+            "pedestrian_count": cell.pedestrian_count,
+            "deadline_ms": cell.deadline_ms,
+            "seed": cell.seed,
+        }
+    )
+
+    ts = datetime.now(UTC).isoformat()
+    wall_start = time.monotonic()
+
+    harness = LatencyMeasurementHarness(
+        deadline_ms=cell.deadline_ms,
+        config_hash=cfg_hash,
+    )
+
+    status = "native"
+    latency_metrics: dict[str, Any] = {}
+    classification: str = "failed"
+
+    try:
+        with harness:
+            _run_map_episode(
+                scenario,
+                seed=cell.seed,
+                horizon=horizon,
+                dt=dt,
+                record_forces=False,
+                snqi_weights=None,
+                snqi_baseline=None,
+                algo=cell.algo,
+                algo_config=cell.algo_config,
+                scenario_path=scenario_path,
+                observation_mode=observation_mode,
+                observation_level=observation_level,
+                benchmark_track=benchmark_track,
+            )
+
+        # Require at least 2 cycles for steady-state classification
+        metrics = harness.get_metrics()
+        steady_totals = [c["total_ms"] for c in metrics.get("cycles", [])]
+        if len(steady_totals) < 2:
+            # Not enough cycles from episode — mark as not_available
+            status = "not_available"
+            latency_metrics = {
+                "cold_start_latency_ms": metrics.get("cold_start_latency_ms"),
+                "cycles_recorded": len(metrics.get("cycles", [])),
+                "steady_state_cycles": 0,
+            }
+        else:
+            classification = classify_feasibility(
+                steady_state_latencies=[c["total_ms"] for c in steady_totals[1:]],
+                deadline_ms=cell.deadline_ms,
+            )
+            latency_metrics = {
+                "cold_start_latency_ms": metrics["cold_start_latency_ms"],
+                "steady_state_latency_p50_ms": metrics["steady_state_latency_p50_ms"],
+                "steady_state_latency_p95_ms": metrics["steady_state_latency_p95_ms"],
+                "steady_state_latency_p99_ms": metrics["steady_state_latency_p99_ms"],
+                "steady_state_latency_max_ms": metrics["steady_state_latency_max_ms"],
+                "deadline_miss_rate": metrics["deadline_miss_rate"],
+                "classification": classification,
+                "steady_state_averages": metrics["steady_state_averages"],
+                "steady_state_cycles": len(steady_totals) - 1,
+                "total_cycles": len(steady_totals),
+            }
+
+    except Exception as e:  # noqa: BLE001
+        # Fail-closed: any episode runner error produces a classified cell row.
+        status = "failed"
+        classification = "failed"
+        latency_metrics = {"failure_reason": str(e)}
+
+    wall_elapsed = (time.monotonic() - wall_start) * 1000.0
+
+    prov = collect_environment_provenance(
+        config_hash=cfg_hash,
+    )
+
+    return {
+        "schema_version": "compute_feasibility_cell.v1",
+        "ts": ts,
+        "cell": {
+            "planner_key": cell.planner_key,
+            "algo": cell.algo,
+            "algo_config": cell.algo_config,
+            "map_label": cell.map_label,
+            "map_path": cell.map_path,
+            "pedestrian_count": cell.pedestrian_count,
+            "deadline_ms": cell.deadline_ms,
+            "seed": cell.seed,
+            "config_hash": cfg_hash,
+        },
+        "status": status,
+        "classification": classification,
+        "latency": latency_metrics,
+        "provenance": prov,
+        "wall_ms": round(wall_elapsed, 2),
+    }
+
+
+def _load_config(config_path: Path) -> dict[str, Any]:
+    """Load and validate matrix config YAML.
+
+    Returns:
+        dict[str, Any]: Parsed config.
+    """
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    if raw.get("schema_version") != "compute_feasibility_matrix.v1":
+        raise ValueError(
+            f"Expected schema_version 'compute_feasibility_matrix.v1', "
+            f"got {raw.get('schema_version')!r}"
+        )
+    return raw
+
+
+def _expand_cells(config: dict[str, Any]) -> list[MatrixCell]:
+    """Expand matrix config into list of cells.
+
+    Returns:
+        List of MatrixCell objects.
+    """
+    cells: list[MatrixCell] = []
+    for planner in config["planners"]:
+        for map_entry in config["maps"]:
+            for ped_count in config["pedestrian_counts"]:
+                for deadline in config["control_deadlines_ms"]:
+                    for seed in config["seeds"]:
+                        cells.append(
+                            MatrixCell(
+                                planner_key=planner["key"],
+                                algo=planner["algo"],
+                                algo_config=planner.get("algo_config"),
+                                map_label=map_entry["label"],
+                                map_path=map_entry["path"],
+                                pedestrian_count=ped_count,
+                                deadline_ms=float(deadline),
+                                seed=seed,
+                            )
+                        )
+    return cells
+
+
+def _build_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build per-planner summary table from cell rows.
+
+    Returns:
+        dict[str, Any]: Summary grouped by planner and deadline.
+    """
+    planners: dict[str, dict[str, list[float]]] = {}
+    failures: list[dict[str, Any]] = []
+
+    for row in rows:
+        key = row["cell"]["planner_key"]
+        dl = row["cell"]["deadline_ms"]
+        group = planners.setdefault(key, {}).setdefault(dl, [])
+        if row["status"] != "native":
+            failures.append(row)
+            continue
+        lat = row.get("latency", {})
+        if "steady_state_latency_p95_ms" in lat:
+            group.append(lat["steady_state_latency_p95_ms"])
+
+    summary: dict[str, Any] = {"schema_version": "compute_feasibility_summary.v1"}
+    for key, deadlines in sorted(planners.items()):
+        entry: dict[str, Any] = {"planner_key": key}
+        for dl, values in sorted(deadlines.items()):
+            if values:
+                entry[f"p95_ms_deadline_{int(dl)}"] = {
+                    "values": [round(v, 3) for v in values],
+                    "mean_ms": round(float(np.mean(values)), 3),
+                    "median_ms": round(float(np.median(values)), 3),
+                    "max_ms": round(float(np.max(values)), 3),
+                    "n_cells": len(values),
+                }
+        summary[key] = entry
+
+    summary["non_native_cells"] = len(failures)
+    summary["total_cells"] = len(rows)
+    return summary
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Execute compute-feasibility matrix with latency-stress harness."
+    )
+    parser.add_argument(
+        "--config",
+        default=str(DEFAULT_CONFIG),
+        help="Matrix config YAML path (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Output directory (default: output/compute_feasibility_matrix_v1/).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print matrix cells without executing.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """CLI entry point."""
+    args = parse_args()
+
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        config_path = REPO_ROOT / config_path
+
+    config = _load_config(config_path)
+    cells = _expand_cells(config)
+
+    out_dir = Path(args.out) if args.out else REPO_ROOT / "output" / "compute_feasibility_matrix_v1"
+
+    def repo_rel(path: Path | str) -> str:
+        try:
+            return str(Path(path).relative_to(REPO_ROOT))
+        except ValueError:
+            return str(path)
+
+    if args.dry_run:
+        print(f"Dry run: {len(cells)} cells")
+        for cell in cells:
+            print(
+                f"  {cell.planner_key} | {cell.map_label} | "
+                f"peds={cell.pedestrian_count} | dl={cell.deadline_ms}ms | seed={cell.seed}"
+            )
+        return 0
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    config_hash = _config_hash(
+        {"config_file": repo_rel(config_path), "schema": "compute_feasibility_matrix.v1"}
+    )
+
+    manifest = {
+        "schema_version": "compute_feasibility_manifest.v1",
+        "config_file": repo_rel(config_path),
+        "config_hash": config_hash,
+        "git_commit": _git_head(),
+        "ts": datetime.now(UTC).isoformat(),
+        "total_cells": len(cells),
+        "planners": [p["key"] for p in config["planners"]],
+        "maps": [m["label"] for m in config["maps"]],
+        "pedestrian_counts": config["pedestrian_counts"],
+        "deadlines_ms": config["control_deadlines_ms"],
+        "seeds": config["seeds"],
+        "horizon": config.get("horizon", 60),
+        "dt": config.get("dt", 0.1),
+    }
+
+    scenario_path = config_path.parent if config_path.name.endswith(".yaml") else Path(".")
+
+    print(f"Running {len(cells)} compute-feasibility matrix cells -> {repo_rel(out_dir)}")
+
+    rows: list[dict[str, Any]] = []
+    skipped = 0
+    for idx, cell in enumerate(cells):
+        existing = (
+            out_dir
+            / f"{cell.planner_key}_{cell.map_label}_{cell.pedestrian_count}_{cell.deadline_ms}_{cell.seed}.json"
+        )
+        if existing.is_file():
+            row = json.loads(existing.read_text(encoding="utf-8"))
+            rows.append(row)
+            skipped += 1
+            print(
+                f"[{idx + 1}/{len(cells)}] SKIP (cached) {cell.planner_key} | {cell.map_label} | dl={cell.deadline_ms}ms"
+            )
+            continue
+
+        print(
+            f"[{idx + 1}/{len(cells)}] RUN {cell.planner_key} | {cell.map_label} | "
+            f"peds={cell.pedestrian_count} | dl={cell.deadline_ms}ms | seed={cell.seed}"
+        )
+        try:
+            row = _run_cell(
+                cell,
+                horizon=config.get("horizon", 60),
+                dt=float(config.get("dt", 0.1)),
+                repo_root=REPO_ROOT,
+                scenario_path=scenario_path,
+                observation_mode=config.get("observation_mode"),
+                observation_level=config.get("observation_level"),
+                benchmark_track=config.get("benchmark_track"),
+            )
+            rows.append(row)
+            existing.write_text(
+                json.dumps(row, indent=2, default=str),
+                encoding="utf-8",
+            )
+        except Exception as e:  # noqa: BLE001
+            # Fail-closed: every cell must produce a row.
+            print(f"  ERROR: {e}")
+            rows.append(
+                {
+                    "schema_version": "compute_feasibility_cell.v1",
+                    "ts": datetime.now(UTC).isoformat(),
+                    "cell": {
+                        "planner_key": cell.planner_key,
+                        "map_label": cell.map_label,
+                        "pedestrian_count": cell.pedestrian_count,
+                        "deadline_ms": cell.deadline_ms,
+                        "seed": cell.seed,
+                    },
+                    "status": "failed",
+                    "classification": "failed",
+                    "latency": {"failure_reason": str(e)},
+                    "provenance": {},
+                }
+            )
+
+    # Write JSONL
+    rows_path = out_dir / "rows.jsonl"
+    with rows_path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, default=str) + "\n")
+
+    # Write manifest
+    manifest["completed_cells"] = len(rows)
+    manifest["skipped_cached"] = skipped
+    manifest["output_files"] = {
+        "rows_jsonl": repo_rel(rows_path),
+        "summary": repo_rel(out_dir / "synthetic_summary.json"),
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2),
+        encoding="utf-8",
+    )
+
+    # Write summary
+    summary = _build_summary(rows)
+    (out_dir / "synthetic_summary.json").write_text(
+        json.dumps(summary, indent=2, default=str),
+        encoding="utf-8",
+    )
+
+    native = sum(1 for r in rows if r["status"] == "native")
+    failed = sum(1 for r in rows if r["status"] == "failed")
+    not_avail = sum(1 for r in rows if r["status"] == "not_available")
+    print(
+        f"\nDone: {native} native, {not_avail} not_available, {failed} failed / {len(rows)} total"
+    )
+    print(f"Output: {repo_rel(out_dir)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark/run_compute_feasibility_matrix.py
+++ b/scripts/benchmark/run_compute_feasibility_matrix.py
@@ -25,7 +25,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -33,6 +35,7 @@ from typing import Any
 
 import numpy as np
 import yaml
+from loguru import logger
 
 from robot_sf.benchmark.latency_stress import (
     LatencyMeasurementHarness,
@@ -44,6 +47,18 @@ from robot_sf.benchmark.utils import _config_hash, _git_hash_fallback
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG = REPO_ROOT / "configs" / "benchmarks" / "compute_feasibility_matrix_v1.yaml"
+_CELL_FAILURE_EXCEPTIONS = (
+    RuntimeError,
+    ValueError,
+    TypeError,
+    LookupError,
+    OSError,
+    AttributeError,
+    ImportError,
+    ArithmeticError,
+    AssertionError,
+)
+_VALID_CELL_STATUSES = {"native", "not_available", "failed"}
 
 
 @dataclass(frozen=True)
@@ -60,6 +75,18 @@ class MatrixCell:
     seed: int
 
 
+@dataclass(frozen=True)
+class RunnerSettings:
+    """Normalized settings shared by every matrix cell."""
+
+    horizon: int
+    dt: float
+    record_forces: bool
+    observation_mode: str | None = None
+    observation_level: str | None = None
+    benchmark_track: str | None = None
+
+
 def _git_head() -> str:
     """Return the current git HEAD commit hash, or ``unknown``."""
     return _git_hash_fallback() or "unknown"
@@ -72,7 +99,6 @@ def _resolve_scenario(
     pedestrian_count: int,
     horizon: int,
     repo_root: Path,
-    scenario_path: Path,
 ) -> dict[str, Any]:
     """Build a scenario dict from map path and parameters.
 
@@ -82,6 +108,8 @@ def _resolve_scenario(
     abs_map = Path(map_path)
     if not abs_map.is_absolute():
         abs_map = (repo_root / map_path).resolve()
+    if not abs_map.is_file():
+        raise FileNotFoundError(f"Map file not found: {abs_map}")
 
     scenario: dict[str, Any] = {
         "name": f"feasibility_{map_label}_peds{pedestrian_count}",
@@ -97,43 +125,160 @@ def _resolve_scenario(
     # but the exact count is controlled by ped_density * area.
     # For a reproducible fixed count, use single_pedestrians.
     if pedestrian_count > 0:
-        # Load the map to find valid POIs for pedestrian goals.
-        from robot_sf.training.scenario_loader import load_scenarios
+        # Density is a heuristic; map loading belongs to the episode setup and should not be
+        # repeated here merely to decide whether a positive density is usable.
+        scenario["simulation_config"]["ped_density"] = 0.02 + pedestrian_count * 0.005
 
-        # Minimal scenario YAML to get map geometry
-        temp_yaml = {"scenarios": [{"name": "temp", "map_file": str(abs_map)}]}
-        scenarios = load_scenarios(
-            yaml.dump(temp_yaml),
-            scenario_config=Path(str(temp_yaml["scenarios"][0]["map_file"])),
-        )
-        if scenarios:
-            # Use ped_density approach: density controls spawn rate
-            # Scale density to approximate desired count for the map area
-
-            # We'll let build_env_config handle the map loading
-            # Use a higher ped_density for more pedestrians
-            base_density = 0.02  # Base density
-            scenario["simulation_config"]["ped_density"] = base_density * (
-                1 + pedestrian_count * 0.1
-            )
-        else:
-            # Fallback: use a higher density to approximate pedestrian count
-            scenario["simulation_config"]["ped_density"] = 0.02 + pedestrian_count * 0.005
-
-    scenario["scenario_path"] = str(scenario_path)
     return scenario
+
+
+def _normalize_horizon(value: Any) -> int:
+    """Normalize an optional episode horizon and reject invalid values."""
+    if value is None:
+        return 60
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("horizon must be a positive integer or null")
+    if value <= 0:
+        raise ValueError("horizon must be > 0")
+    return value
+
+
+def _normalize_dt(value: Any) -> float:
+    """Normalize an optional simulation step and reject invalid values."""
+    if value is None:
+        return 0.1
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise TypeError("dt must be a positive number or null")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized <= 0.0:
+        raise ValueError("dt must be finite and > 0")
+    return normalized
+
+
+def _validate_planners(planners: list[Any]) -> None:
+    """Validate planner entries in a matrix config."""
+    for index, planner in enumerate(planners):
+        if not isinstance(planner, Mapping):
+            raise TypeError(f"planners[{index}] must be a mapping")
+        for field in ("key", "algo"):
+            value = planner.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"planners[{index}].{field} must be a non-empty string")
+        algo_config = planner.get("algo_config")
+        if algo_config is not None and not isinstance(algo_config, Mapping):
+            raise TypeError(f"planners[{index}].algo_config must be a mapping or null")
+
+
+def _validate_maps(maps: list[Any]) -> None:
+    """Validate map entries and fail closed for missing or directory paths."""
+    for index, map_entry in enumerate(maps):
+        if not isinstance(map_entry, Mapping):
+            raise TypeError(f"maps[{index}] must be a mapping")
+        map_path = map_entry.get("path")
+        map_label = map_entry.get("label")
+        if not isinstance(map_path, str) or not map_path.strip():
+            raise ValueError(f"maps[{index}].path must be a non-empty string")
+        if not isinstance(map_label, str) or not map_label.strip():
+            raise ValueError(f"maps[{index}].label must be a non-empty string")
+        resolved_map = Path(map_path)
+        if not resolved_map.is_absolute():
+            resolved_map = (REPO_ROOT / resolved_map).resolve()
+        if not resolved_map.is_file():
+            raise FileNotFoundError(f"Map file not found: {resolved_map}")
+
+
+def _validate_matrix_axes(config: Mapping[str, Any]) -> None:
+    """Validate pedestrian, deadline, and seed axes."""
+    for index, count in enumerate(config["pedestrian_counts"]):
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise ValueError(f"pedestrian_counts[{index}] must be an integer >= 0")
+
+    for index, deadline in enumerate(config["control_deadlines_ms"]):
+        if isinstance(deadline, bool) or not isinstance(deadline, int | float):
+            raise TypeError(f"control_deadlines_ms[{index}] must be a number")
+        if not math.isfinite(float(deadline)) or deadline <= 0:
+            raise ValueError(f"control_deadlines_ms[{index}] must be finite and > 0")
+
+    for index, seed in enumerate(config["seeds"]):
+        if isinstance(seed, bool) or not isinstance(seed, int):
+            raise TypeError(f"seeds[{index}] must be an integer")
+
+
+def _validate_runtime_fields(config: Mapping[str, Any]) -> None:
+    """Validate fixed runtime settings in a matrix config."""
+    _normalize_horizon(config.get("horizon"))
+    _normalize_dt(config.get("dt"))
+    record_forces = config.get("record_forces", False)
+    if not isinstance(record_forces, bool):
+        raise TypeError("record_forces must be a boolean")
+    for field in ("observation_mode", "observation_level", "benchmark_track"):
+        value = config.get(field)
+        if value is not None and not isinstance(value, str):
+            raise TypeError(f"{field} must be a string or null")
+
+
+def _validate_config(config: Any) -> dict[str, Any]:
+    """Validate the matrix shape and all fields needed by the runner."""
+    if not isinstance(config, dict):
+        raise ValueError("Matrix config must contain a mapping at its YAML root")
+    if config.get("schema_version") != "compute_feasibility_matrix.v1":
+        raise ValueError(
+            "Expected schema_version 'compute_feasibility_matrix.v1', "
+            f"got {config.get('schema_version')!r}"
+        )
+    required_lists = (
+        "planners",
+        "maps",
+        "pedestrian_counts",
+        "control_deadlines_ms",
+        "seeds",
+    )
+    for field in required_lists:
+        value = config.get(field)
+        if not isinstance(value, list) or not value:
+            raise ValueError(f"{field} must be a non-empty list")
+    _validate_planners(config["planners"])
+    _validate_maps(config["maps"])
+    _validate_matrix_axes(config)
+    _validate_runtime_fields(config)
+    return config
+
+
+def _cell_config_hash(
+    cell: MatrixCell,
+    *,
+    matrix_config_hash: str | None,
+    settings: RunnerSettings,
+) -> str:
+    """Return a cache/provenance hash for all cell-affecting runner inputs."""
+    return _config_hash(
+        {
+            "matrix_config_hash": matrix_config_hash,
+            "planner_key": cell.planner_key,
+            "algo": cell.algo,
+            "algo_config": cell.algo_config or {},
+            "map_label": cell.map_label,
+            "map_path": cell.map_path,
+            "pedestrian_count": cell.pedestrian_count,
+            "deadline_ms": cell.deadline_ms,
+            "seed": cell.seed,
+            "horizon": settings.horizon,
+            "dt": settings.dt,
+            "record_forces": settings.record_forces,
+            "observation_mode": settings.observation_mode,
+            "observation_level": settings.observation_level,
+            "benchmark_track": settings.benchmark_track,
+        }
+    )
 
 
 def _run_cell(
     cell: MatrixCell,
     *,
-    horizon: int,
-    dt: float,
+    settings: RunnerSettings,
     repo_root: Path,
     scenario_path: Path,
-    observation_mode: str | None = None,
-    observation_level: str | None = None,
-    benchmark_track: str | None = None,
+    matrix_config_hash: str | None = None,
 ) -> dict[str, Any]:
     """Execute one matrix cell and return its latency + classification record.
 
@@ -144,20 +289,14 @@ def _run_cell(
         map_path=cell.map_path,
         map_label=cell.map_label,
         pedestrian_count=cell.pedestrian_count,
-        horizon=horizon,
+        horizon=settings.horizon,
         repo_root=repo_root,
-        scenario_path=scenario_path,
     )
 
-    cfg_hash = _config_hash(
-        {
-            "algo": cell.algo,
-            "algo_config": cell.algo_config or {},
-            "map_label": cell.map_label,
-            "pedestrian_count": cell.pedestrian_count,
-            "deadline_ms": cell.deadline_ms,
-            "seed": cell.seed,
-        }
+    cfg_hash = _cell_config_hash(
+        cell,
+        matrix_config_hash=matrix_config_hash,
+        settings=settings,
     )
 
     ts = datetime.now(UTC).isoformat()
@@ -165,7 +304,10 @@ def _run_cell(
 
     harness = LatencyMeasurementHarness(
         deadline_ms=cell.deadline_ms,
-        config_hash=cfg_hash,
+        # The episode policy supplies its planner-config hash through metadata.  Keep the
+        # full cell hash in the emitted row/cache contract without making the harness reject
+        # a valid policy whose hash intentionally covers only planner configuration.
+        config_hash=None,
     )
 
     status = "native"
@@ -177,17 +319,17 @@ def _run_cell(
             _run_map_episode(
                 scenario,
                 seed=cell.seed,
-                horizon=horizon,
-                dt=dt,
-                record_forces=False,
+                horizon=settings.horizon,
+                dt=settings.dt,
+                record_forces=settings.record_forces,
                 snqi_weights=None,
                 snqi_baseline=None,
                 algo=cell.algo,
                 algo_config=cell.algo_config,
                 scenario_path=scenario_path,
-                observation_mode=observation_mode,
-                observation_level=observation_level,
-                benchmark_track=benchmark_track,
+                observation_mode=settings.observation_mode,
+                observation_level=settings.observation_level,
+                benchmark_track=settings.benchmark_track,
             )
 
         # Require at least 2 cycles for steady-state classification
@@ -203,7 +345,7 @@ def _run_cell(
             }
         else:
             classification = classify_feasibility(
-                steady_state_latencies=[c["total_ms"] for c in steady_totals[1:]],
+                steady_state_latencies=steady_totals[1:],
                 deadline_ms=cell.deadline_ms,
             )
             latency_metrics = {
@@ -219,7 +361,7 @@ def _run_cell(
                 "total_cycles": len(steady_totals),
             }
 
-    except Exception as e:  # noqa: BLE001
+    except _CELL_FAILURE_EXCEPTIONS as e:
         # Fail-closed: any episode runner error produces a classified cell row.
         status = "failed"
         classification = "failed"
@@ -259,13 +401,10 @@ def _load_config(config_path: Path) -> dict[str, Any]:
     Returns:
         dict[str, Any]: Parsed config.
     """
-    raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-    if raw.get("schema_version") != "compute_feasibility_matrix.v1":
-        raise ValueError(
-            f"Expected schema_version 'compute_feasibility_matrix.v1', "
-            f"got {raw.get('schema_version')!r}"
-        )
-    return raw
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    return _validate_config(raw)
 
 
 def _expand_cells(config: dict[str, Any]) -> list[MatrixCell]:
@@ -295,6 +434,32 @@ def _expand_cells(config: dict[str, Any]) -> list[MatrixCell]:
     return cells
 
 
+def _summary_sample(row: Mapping[str, Any]) -> tuple[str, float, float] | None:
+    """Extract one valid native summary sample, or return ``None``."""
+    cell = row.get("cell")
+    if not isinstance(cell, Mapping):
+        return None
+    key = cell.get("planner_key")
+    deadline = cell.get("deadline_ms")
+    if not isinstance(key, str) or not key.strip():
+        return None
+    if isinstance(deadline, bool) or not isinstance(deadline, int | float):
+        return None
+    dl = float(deadline)
+    if not math.isfinite(dl) or dl <= 0.0 or row.get("status") != "native":
+        return None
+    lat = row.get("latency")
+    if not isinstance(lat, Mapping):
+        return None
+    p95 = lat.get("steady_state_latency_p95_ms")
+    if isinstance(p95, bool) or not isinstance(p95, int | float):
+        return None
+    p95_value = float(p95)
+    if not math.isfinite(p95_value) or p95_value < 0.0:
+        return None
+    return key.strip(), dl, p95_value
+
+
 def _build_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Build per-planner summary table from cell rows.
 
@@ -305,15 +470,16 @@ def _build_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
     failures: list[dict[str, Any]] = []
 
     for row in rows:
-        key = row["cell"]["planner_key"]
-        dl = row["cell"]["deadline_ms"]
-        group = planners.setdefault(key, {}).setdefault(dl, [])
-        if row["status"] != "native":
+        if not isinstance(row, Mapping):
             failures.append(row)
             continue
-        lat = row.get("latency", {})
-        if "steady_state_latency_p95_ms" in lat:
-            group.append(lat["steady_state_latency_p95_ms"])
+        sample = _summary_sample(row)
+        if sample is None:
+            failures.append(row)
+            continue
+        key, dl, p95_value = sample
+        group = planners.setdefault(key, {}).setdefault(dl, [])
+        group.append(p95_value)
 
     summary: dict[str, Any] = {"schema_version": "compute_feasibility_summary.v1"}
     for key, deadlines in sorted(planners.items()):
@@ -332,6 +498,67 @@ def _build_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
     summary["non_native_cells"] = len(failures)
     summary["total_cells"] = len(rows)
     return summary
+
+
+def _load_cached_row(
+    path: Path,
+    *,
+    cell: MatrixCell,
+    config_hash: str,
+) -> dict[str, Any] | None:
+    """Load a cache row only when it is valid for the requested cell."""
+    try:
+        row = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(row, dict):
+            raise ValueError("cache root must be an object")
+        if row.get("schema_version") != "compute_feasibility_cell.v1":
+            raise ValueError("cache schema version is unsupported")
+        if row.get("status") not in _VALID_CELL_STATUSES:
+            raise ValueError("cache status is unsupported")
+        cached_cell = row.get("cell")
+        if not isinstance(cached_cell, Mapping):
+            raise ValueError("cache cell must be an object")
+        expected = {
+            "planner_key": cell.planner_key,
+            "algo": cell.algo,
+            "algo_config": cell.algo_config,
+            "map_label": cell.map_label,
+            "map_path": cell.map_path,
+            "pedestrian_count": cell.pedestrian_count,
+            "deadline_ms": cell.deadline_ms,
+            "seed": cell.seed,
+            "config_hash": config_hash,
+        }
+        for key, value in expected.items():
+            if cached_cell.get(key) != value:
+                raise ValueError(f"cache cell field {key!r} does not match request")
+        return row
+    except _CELL_FAILURE_EXCEPTIONS as exc:
+        logger.warning("Ignoring invalid cached row '{}': {}", path, exc)
+        return None
+
+
+def _failure_row(cell: MatrixCell, *, config_hash: str, reason: str) -> dict[str, Any]:
+    """Build a complete failed-cell record for errors outside episode execution."""
+    return {
+        "schema_version": "compute_feasibility_cell.v1",
+        "ts": datetime.now(UTC).isoformat(),
+        "cell": {
+            "planner_key": cell.planner_key,
+            "algo": cell.algo,
+            "algo_config": cell.algo_config,
+            "map_label": cell.map_label,
+            "map_path": cell.map_path,
+            "pedestrian_count": cell.pedestrian_count,
+            "deadline_ms": cell.deadline_ms,
+            "seed": cell.seed,
+            "config_hash": config_hash,
+        },
+        "status": "failed",
+        "classification": "failed",
+        "latency": {"failure_reason": reason},
+        "provenance": {},
+    }
 
 
 def parse_args() -> argparse.Namespace:
@@ -357,7 +584,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> int:
+def main() -> int:  # noqa: C901
     """CLI entry point."""
     args = parse_args()
 
@@ -376,6 +603,25 @@ def main() -> int:
         except ValueError:
             return str(path)
 
+    matrix_config_hash = _config_hash(
+        {
+            "config_file": repo_rel(config_path),
+            "schema": "compute_feasibility_matrix.v1",
+            "config": config,
+        }
+    )
+    horizon = _normalize_horizon(config.get("horizon"))
+    dt = _normalize_dt(config.get("dt"))
+    record_forces = config.get("record_forces", False)
+    settings = RunnerSettings(
+        horizon=horizon,
+        dt=dt,
+        record_forces=record_forces,
+        observation_mode=config.get("observation_mode"),
+        observation_level=config.get("observation_level"),
+        benchmark_track=config.get("benchmark_track"),
+    )
+
     if args.dry_run:
         print(f"Dry run: {len(cells)} cells")
         for cell in cells:
@@ -386,14 +632,10 @@ def main() -> int:
         return 0
 
     out_dir.mkdir(parents=True, exist_ok=True)
-    config_hash = _config_hash(
-        {"config_file": repo_rel(config_path), "schema": "compute_feasibility_matrix.v1"}
-    )
-
     manifest = {
         "schema_version": "compute_feasibility_manifest.v1",
         "config_file": repo_rel(config_path),
-        "config_hash": config_hash,
+        "config_hash": matrix_config_hash,
         "git_commit": _git_head(),
         "ts": datetime.now(UTC).isoformat(),
         "total_cells": len(cells),
@@ -402,11 +644,12 @@ def main() -> int:
         "pedestrian_counts": config["pedestrian_counts"],
         "deadlines_ms": config["control_deadlines_ms"],
         "seeds": config["seeds"],
-        "horizon": config.get("horizon", 60),
-        "dt": config.get("dt", 0.1),
+        "horizon": horizon,
+        "dt": dt,
+        "record_forces": record_forces,
     }
 
-    scenario_path = config_path.parent if config_path.name.endswith(".yaml") else Path(".")
+    scenario_path = config_path
 
     print(f"Running {len(cells)} compute-feasibility matrix cells -> {repo_rel(out_dir)}")
 
@@ -417,14 +660,20 @@ def main() -> int:
             out_dir
             / f"{cell.planner_key}_{cell.map_label}_{cell.pedestrian_count}_{cell.deadline_ms}_{cell.seed}.json"
         )
+        cell_config_hash = _cell_config_hash(
+            cell,
+            matrix_config_hash=matrix_config_hash,
+            settings=settings,
+        )
         if existing.is_file():
-            row = json.loads(existing.read_text(encoding="utf-8"))
-            rows.append(row)
-            skipped += 1
-            print(
-                f"[{idx + 1}/{len(cells)}] SKIP (cached) {cell.planner_key} | {cell.map_label} | dl={cell.deadline_ms}ms"
-            )
-            continue
+            row = _load_cached_row(existing, cell=cell, config_hash=cell_config_hash)
+            if row is not None:
+                rows.append(row)
+                skipped += 1
+                print(
+                    f"[{idx + 1}/{len(cells)}] SKIP (cached) {cell.planner_key} | {cell.map_label} | dl={cell.deadline_ms}ms"
+                )
+                continue
 
         print(
             f"[{idx + 1}/{len(cells)}] RUN {cell.planner_key} | {cell.map_label} | "
@@ -433,39 +682,20 @@ def main() -> int:
         try:
             row = _run_cell(
                 cell,
-                horizon=config.get("horizon", 60),
-                dt=float(config.get("dt", 0.1)),
+                settings=settings,
                 repo_root=REPO_ROOT,
                 scenario_path=scenario_path,
-                observation_mode=config.get("observation_mode"),
-                observation_level=config.get("observation_level"),
-                benchmark_track=config.get("benchmark_track"),
+                matrix_config_hash=matrix_config_hash,
             )
             rows.append(row)
             existing.write_text(
                 json.dumps(row, indent=2, default=str),
                 encoding="utf-8",
             )
-        except Exception as e:  # noqa: BLE001
+        except _CELL_FAILURE_EXCEPTIONS as e:
             # Fail-closed: every cell must produce a row.
             print(f"  ERROR: {e}")
-            rows.append(
-                {
-                    "schema_version": "compute_feasibility_cell.v1",
-                    "ts": datetime.now(UTC).isoformat(),
-                    "cell": {
-                        "planner_key": cell.planner_key,
-                        "map_label": cell.map_label,
-                        "pedestrian_count": cell.pedestrian_count,
-                        "deadline_ms": cell.deadline_ms,
-                        "seed": cell.seed,
-                    },
-                    "status": "failed",
-                    "classification": "failed",
-                    "latency": {"failure_reason": str(e)},
-                    "provenance": {},
-                }
-            )
+            rows.append(_failure_row(cell, config_hash=cell_config_hash, reason=str(e)))
 
     # Write JSONL
     rows_path = out_dir / "rows.jsonl"

--- a/tests/benchmark/test_compute_feasibility_matrix.py
+++ b/tests/benchmark/test_compute_feasibility_matrix.py
@@ -1,0 +1,344 @@
+"""Tests for compute-feasibility matrix runner (issue #5525)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.latency_stress import classify_feasibility
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER = REPO_ROOT / "scripts" / "benchmark" / "run_compute_feasibility_matrix.py"
+
+
+def _import_runner() -> Any:
+    """Import runner module for unit testing."""
+    import importlib
+
+    return importlib.import_module("scripts.benchmark.run_compute_feasibility_matrix")
+
+
+class TestConfigValidation:
+    """Config loading must reject malformed YAML."""
+
+    def test_rejects_wrong_schema(self, tmp_path: Path) -> None:
+        """Config with wrong schema version must fail."""
+        bad_yaml = {"schema_version": "unknown_v1", "planners": []}
+        bad_path = tmp_path / "bad.yaml"
+        bad_path.write_text(yaml.dump(bad_yaml), encoding="utf-8")
+
+        mod = _import_runner()
+        with pytest.raises(ValueError, match="compute_feasibility_matrix.v1"):
+            mod._load_config(bad_path)
+
+    def test_accepts_valid_config(self) -> None:
+        """Canonical config must load without error."""
+        config_path = REPO_ROOT / "configs" / "benchmarks" / "compute_feasibility_matrix_v1.yaml"
+        mod = _import_runner()
+        config = mod._load_config(config_path)
+
+        assert config["schema_version"] == "compute_feasibility_matrix.v1"
+        assert len(config["planners"]) >= 2
+        assert len(config["maps"]) >= 1
+        assert len(config["pedestrian_counts"]) >= 1
+        assert len(config["control_deadlines_ms"]) >= 1
+        assert len(config["seeds"]) >= 1
+
+
+class TestMatrixExpansion:
+    """Matrix cell expansion must produce correct Cartesian product."""
+
+    def test_cell_count(self) -> None:
+        """Cell count must equal planners × maps × peds × deadlines × seeds."""
+        config_path = REPO_ROOT / "configs" / "benchmarks" / "compute_feasibility_matrix_v1.yaml"
+        mod = _import_runner()
+        config = mod._load_config(config_path)
+        cells = mod._expand_cells(config)
+
+        expected = (
+            len(config["planners"])
+            * len(config["maps"])
+            * len(config["pedestrian_counts"])
+            * len(config["control_deadlines_ms"])
+            * len(config["seeds"])
+        )
+        assert len(cells) == expected
+
+    def test_cell_uniqueness(self) -> None:
+        """Each cell tuple must appear exactly once."""
+        config_path = REPO_ROOT / "configs" / "benchmarks" / "compute_feasibility_matrix_v1.yaml"
+        mod = _import_runner()
+        config = mod._load_config(config_path)
+        cells = mod._expand_cells(config)
+
+        tuples = {
+            (
+                c.planner_key,
+                c.map_label,
+                c.pedestrian_count,
+                int(c.deadline_ms),
+                c.seed,
+            )
+            for c in cells
+        }
+        assert len(tuples) == len(cells)
+
+    def test_cell_fields_populated(self) -> None:
+        """Each cell must carry all required fields."""
+        config_path = REPO_ROOT / "configs" / "benchmarks" / "compute_feasibility_matrix_v1.yaml"
+        mod = _import_runner()
+        config = mod._load_config(config_path)
+        cells = mod._expand_cells(config)
+
+        for cell in cells:
+            assert cell.planner_key
+            assert cell.algo
+            assert cell.map_label
+            assert cell.map_path
+            assert cell.pedestrian_count >= 0
+            assert cell.deadline_ms > 0
+            assert isinstance(cell.seed, int)
+
+
+class TestDryRunMode:
+    """Dry-run must print cells without executing episodes."""
+
+    def test_dry_run_exits_zero(self, tmp_path: Path) -> None:
+        """Dry-run should exit 0 and produce no episode output."""
+        mini_config = {
+            "schema_version": "compute_feasibility_matrix.v1",
+            "planners": [{"key": "goal", "algo": "goal", "benchmark_profile": "baseline-safe"}],
+            "maps": [
+                {
+                    "path": str(REPO_ROOT / "maps" / "svg_maps" / "atomic_empty_frame_test.svg"),
+                    "label": "empty_8x8",
+                }
+            ],
+            "pedestrian_counts": [0],
+            "control_deadlines_ms": [100],
+            "seeds": [42],
+            "horizon": 10,
+            "dt": 0.1,
+        }
+        config_path = tmp_path / "mini.yaml"
+        config_path.write_text(yaml.dump(mini_config), encoding="utf-8")
+
+        out_dir = tmp_path / "out"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                "--config",
+                str(config_path),
+                "--out",
+                str(out_dir),
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0
+        assert "Dry run: 1 cells" in result.stdout
+        assert not out_dir.exists()
+
+
+class TestSummaryGeneration:
+    """Summary builder must aggregate cell rows correctly."""
+
+    def test_empty_rows(self) -> None:
+        """Empty input must produce valid summary."""
+        mod = _import_runner()
+        summary = mod._build_summary([])
+        assert summary["total_cells"] == 0
+        assert summary["non_native_cells"] == 0
+
+    def test_native_cell_aggregation(self) -> None:
+        """Native cells must aggregate p95 latency values."""
+        rows = [
+            {
+                "cell": {
+                    "planner_key": "goal",
+                    "deadline_ms": 100.0,
+                },
+                "status": "native",
+                "latency": {
+                    "steady_state_latency_p95_ms": 45.0,
+                },
+            },
+            {
+                "cell": {
+                    "planner_key": "goal",
+                    "deadline_ms": 100.0,
+                },
+                "status": "native",
+                "latency": {
+                    "steady_state_latency_p95_ms": 50.0,
+                },
+            },
+            {
+                "cell": {
+                    "planner_key": "goal",
+                    "deadline_ms": 50.0,
+                },
+                "status": "native",
+                "latency": {
+                    "steady_state_latency_p95_ms": 55.0,
+                },
+            },
+            {
+                "cell": {
+                    "planner_key": "mppi_social",
+                    "deadline_ms": 100.0,
+                },
+                "status": "native",
+                "latency": {
+                    "steady_state_latency_p95_ms": 80.0,
+                },
+            },
+        ]
+
+        mod = _import_runner()
+        summary = mod._build_summary(rows)
+
+        assert summary["total_cells"] == 4
+        assert summary["non_native_cells"] == 0
+
+        goal_summary = summary["goal"]
+        assert goal_summary["planner_key"] == "goal"
+
+        goal_100 = goal_summary["p95_ms_deadline_100"]
+        assert goal_100["n_cells"] == 2
+        assert abs(goal_100["mean_ms"] - 47.5) < 0.01
+        assert goal_100["max_ms"] == 50.0
+
+        goal_50 = goal_summary["p95_ms_deadline_50"]
+        assert goal_50["n_cells"] == 1
+        assert goal_50["mean_ms"] == 55.0
+
+        mppi_summary = summary["mppi_social"]
+        mppi_100 = mppi_summary["p95_ms_deadline_100"]
+        assert mppi_100["n_cells"] == 1
+        assert mppi_100["mean_ms"] == 80.0
+
+    def test_failed_cell_skipped_from_summary(self) -> None:
+        """Non-native cells must not pollute p95 aggregation."""
+        rows = [
+            {
+                "cell": {
+                    "planner_key": "goal",
+                    "deadline_ms": 100.0,
+                },
+                "status": "failed",
+                "latency": {"failure_reason": "timeout"},
+            },
+            {
+                "cell": {
+                    "planner_key": "goal",
+                    "deadline_ms": 100.0,
+                },
+                "status": "native",
+                "latency": {
+                    "steady_state_latency_p95_ms": 40.0,
+                },
+            },
+        ]
+
+        mod = _import_runner()
+        summary = mod._build_summary(rows)
+
+        assert summary["non_native_cells"] == 1
+        goal_summary = summary["goal"]
+        goal_100 = goal_summary["p95_ms_deadline_100"]
+        assert goal_100["n_cells"] == 1
+        assert goal_100["mean_ms"] == 40.0
+
+
+class TestMatrixCell:
+    """MatrixCell dataclass must carry expected fields."""
+
+    def test_cell_construction(self) -> None:
+        """Cell should be constructible with all fields."""
+        import importlib
+
+        mod = importlib.import_module("scripts.benchmark.run_compute_feasibility_matrix")
+        cell = mod.MatrixCell(
+            planner_key="goal",
+            algo="goal",
+            algo_config=None,
+            map_label="test",
+            map_path="maps/svg_maps/test.svg",
+            pedestrian_count=5,
+            deadline_ms=100.0,
+            seed=42,
+        )
+
+        assert cell.planner_key == "goal"
+        assert cell.algo == "goal"
+        assert cell.algo_config is None
+        assert cell.pedestrian_count == 5
+        assert cell.deadline_ms == 100.0
+        assert cell.seed == 42
+
+    def test_cell_with_algo_config(self) -> None:
+        """Cell should carry algo_config when provided."""
+        import importlib
+
+        mod = importlib.import_module("scripts.benchmark.run_compute_feasibility_matrix")
+        cell = mod.MatrixCell(
+            planner_key="mppi_social",
+            algo="mppi_social",
+            algo_config={"horizon_steps": 5, "sample_count": 8},
+            map_label="test",
+            map_path="maps/svg_maps/test.svg",
+            pedestrian_count=0,
+            deadline_ms=50.0,
+            seed=111,
+        )
+
+        assert cell.algo_config["horizon_steps"] == 5
+        assert cell.algo_config["sample_count"] == 8
+
+
+class TestFeasibilityClassification:
+    """Classification logic must match harness contract."""
+
+    def test_meets_budget(self) -> None:
+        """All latencies under deadline means feasible."""
+        result = classify_feasibility(
+            steady_state_latencies=[10.0, 20.0, 30.0, 40.0],
+            deadline_ms=50.0,
+        )
+        assert result == "meets_budget_on_measured_host"
+
+    def test_misses_budget(self) -> None:
+        """Any latency over deadline means infeasible."""
+        result = classify_feasibility(
+            steady_state_latencies=[10.0, 60.0, 30.0, 40.0],
+            deadline_ms=50.0,
+        )
+        assert result == "misses_budget_on_measured_host"
+
+    def test_target_unmeasured(self) -> None:
+        """Missing measured host identity with target hardware means unmeasured."""
+        result = classify_feasibility(
+            steady_state_latencies=[10.0, 20.0],
+            deadline_ms=50.0,
+            target_hardware="jetson",
+            measured_host_identity=None,
+        )
+        assert result == "target_hardware_unmeasured"
+
+    def test_empty_latencies(self) -> None:
+        """Empty latencies means unmeasured."""
+        result = classify_feasibility(
+            steady_state_latencies=[],
+            deadline_ms=50.0,
+        )
+        assert result == "target_hardware_unmeasured"

--- a/tests/benchmark/test_compute_feasibility_matrix.py
+++ b/tests/benchmark/test_compute_feasibility_matrix.py
@@ -14,6 +14,7 @@ from robot_sf.benchmark.latency_stress import classify_feasibility
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RUNNER = REPO_ROOT / "scripts" / "benchmark" / "run_compute_feasibility_matrix.py"
+CONFIG_PATH = REPO_ROOT / "configs" / "benchmarks" / "compute_feasibility_matrix_v1.yaml"
 
 
 def _import_runner() -> Any:
@@ -38,9 +39,8 @@ class TestConfigValidation:
 
     def test_accepts_valid_config(self) -> None:
         """Canonical config must load without error."""
-        config_path = REPO_ROOT / "configs" / "benchmarks" / "compute_feasibility_matrix_v1.yaml"
         mod = _import_runner()
-        config = mod._load_config(config_path)
+        config = mod._load_config(CONFIG_PATH)
 
         assert config["schema_version"] == "compute_feasibility_matrix.v1"
         assert len(config["planners"]) >= 2
@@ -49,15 +49,26 @@ class TestConfigValidation:
         assert len(config["control_deadlines_ms"]) >= 1
         assert len(config["seeds"]) >= 1
 
+    @pytest.mark.parametrize("map_path", ["maps/svg_maps/missing.svg", "configs"])
+    def test_rejects_missing_or_directory_map(self, tmp_path: Path, map_path: str) -> None:
+        """Config loading must fail closed when a map is absent or not a file."""
+        config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+        config["maps"][0]["path"] = map_path
+        bad_path = tmp_path / "bad_map.yaml"
+        bad_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+        mod = _import_runner()
+        with pytest.raises(FileNotFoundError, match="Map file not found"):
+            mod._load_config(bad_path)
+
 
 class TestMatrixExpansion:
     """Matrix cell expansion must produce correct Cartesian product."""
 
     def test_cell_count(self) -> None:
         """Cell count must equal planners × maps × peds × deadlines × seeds."""
-        config_path = REPO_ROOT / "configs" / "benchmarks" / "compute_feasibility_matrix_v1.yaml"
         mod = _import_runner()
-        config = mod._load_config(config_path)
+        config = mod._load_config(CONFIG_PATH)
         cells = mod._expand_cells(config)
 
         expected = (
@@ -68,12 +79,12 @@ class TestMatrixExpansion:
             * len(config["seeds"])
         )
         assert len(cells) == expected
+        assert len(cells) == 108
 
     def test_cell_uniqueness(self) -> None:
         """Each cell tuple must appear exactly once."""
-        config_path = REPO_ROOT / "configs" / "benchmarks" / "compute_feasibility_matrix_v1.yaml"
         mod = _import_runner()
-        config = mod._load_config(config_path)
+        config = mod._load_config(CONFIG_PATH)
         cells = mod._expand_cells(config)
 
         tuples = {
@@ -90,9 +101,8 @@ class TestMatrixExpansion:
 
     def test_cell_fields_populated(self) -> None:
         """Each cell must carry all required fields."""
-        config_path = REPO_ROOT / "configs" / "benchmarks" / "compute_feasibility_matrix_v1.yaml"
         mod = _import_runner()
-        config = mod._load_config(config_path)
+        config = mod._load_config(CONFIG_PATH)
         cells = mod._expand_cells(config)
 
         for cell in cells:
@@ -259,15 +269,41 @@ class TestSummaryGeneration:
         assert goal_100["n_cells"] == 1
         assert goal_100["mean_ms"] == 40.0
 
+    def test_malformed_and_nonfinite_rows_are_excluded(self) -> None:
+        """Malformed and non-finite rows must not enter aggregate statistics."""
+        rows = [
+            {
+                "cell": {"planner_key": "goal", "deadline_ms": 100.0},
+                "status": "native",
+                "latency": {"steady_state_latency_p95_ms": 40.0},
+            },
+            {"status": "native", "latency": {"steady_state_latency_p95_ms": 50.0}},
+            {
+                "cell": {"planner_key": "goal", "deadline_ms": 100.0},
+                "status": "native",
+                "latency": {"steady_state_latency_p95_ms": float("nan")},
+            },
+            {
+                "cell": {"planner_key": "goal", "deadline_ms": 100.0},
+                "status": "native",
+                "latency": {"steady_state_latency_p95_ms": "not-a-number"},
+            },
+        ]
+
+        mod = _import_runner()
+        summary = mod._build_summary(rows)
+
+        assert summary["total_cells"] == 4
+        assert summary["non_native_cells"] == 3
+        assert summary["goal"]["p95_ms_deadline_100"]["values"] == [40.0]
+
 
 class TestMatrixCell:
     """MatrixCell dataclass must carry expected fields."""
 
     def test_cell_construction(self) -> None:
         """Cell should be constructible with all fields."""
-        import importlib
-
-        mod = importlib.import_module("scripts.benchmark.run_compute_feasibility_matrix")
+        mod = _import_runner()
         cell = mod.MatrixCell(
             planner_key="goal",
             algo="goal",
@@ -288,9 +324,7 @@ class TestMatrixCell:
 
     def test_cell_with_algo_config(self) -> None:
         """Cell should carry algo_config when provided."""
-        import importlib
-
-        mod = importlib.import_module("scripts.benchmark.run_compute_feasibility_matrix")
+        mod = _import_runner()
         cell = mod.MatrixCell(
             planner_key="mppi_social",
             algo="mppi_social",
@@ -304,6 +338,90 @@ class TestMatrixCell:
 
         assert cell.algo_config["horizon_steps"] == 5
         assert cell.algo_config["sample_count"] == 8
+
+
+class TestRunnerFailureContracts:
+    """The runner must preserve fail-closed and cache contracts on bad inputs."""
+
+    def test_optional_values_normalize_none(self) -> None:
+        """Null optional values must resolve to documented defaults."""
+        mod = _import_runner()
+        assert mod._normalize_horizon(None) == 60
+        assert mod._normalize_dt(None) == 0.1
+
+    @pytest.mark.parametrize("payload", ["{", "[]"])
+    def test_invalid_cache_is_a_miss(self, tmp_path: Path, payload: str) -> None:
+        """Corrupt and non-object cache payloads must be rerun, not trusted."""
+        mod = _import_runner()
+        cache_path = tmp_path / "cell.json"
+        cache_path.write_text(payload, encoding="utf-8")
+        cell = mod.MatrixCell(
+            planner_key="goal",
+            algo="goal",
+            algo_config=None,
+            map_label="test",
+            map_path="maps/svg_maps/atomic_empty_frame_test.svg",
+            pedestrian_count=0,
+            deadline_ms=100.0,
+            seed=42,
+        )
+
+        assert mod._load_cached_row(cache_path, cell=cell, config_hash="hash") is None
+
+    def test_multi_cycle_cell_is_classified(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Already-extracted cycle totals must reach feasibility classification as floats."""
+        mod = _import_runner()
+
+        class _FakeHarness:
+            def __init__(self, **_: Any) -> None:
+                pass
+
+            def __enter__(self) -> _FakeHarness:
+                return self
+
+            def __exit__(self, *_: Any) -> None:
+                return None
+
+            def get_metrics(self) -> dict[str, Any]:
+                return {
+                    "cold_start_latency_ms": 10.0,
+                    "steady_state_latency_p50_ms": 20.0,
+                    "steady_state_latency_p95_ms": 20.0,
+                    "steady_state_latency_p99_ms": 20.0,
+                    "steady_state_latency_max_ms": 20.0,
+                    "deadline_miss_rate": 0.0,
+                    "steady_state_averages": {},
+                    "cycles": [{"total_ms": 10.0}, {"total_ms": 20.0}],
+                }
+
+        monkeypatch.setattr(mod, "LatencyMeasurementHarness", _FakeHarness)
+        monkeypatch.setattr(mod, "_run_map_episode", lambda *_args, **_kwargs: {})
+        monkeypatch.setattr(
+            mod,
+            "collect_environment_provenance",
+            lambda **kwargs: {"config_hash": kwargs["config_hash"]},
+        )
+        cell = mod.MatrixCell(
+            planner_key="goal",
+            algo="goal",
+            algo_config=None,
+            map_label="test",
+            map_path="maps/svg_maps/atomic_empty_frame_test.svg",
+            pedestrian_count=0,
+            deadline_ms=50.0,
+            seed=42,
+        )
+
+        row = mod._run_cell(
+            cell,
+            settings=mod.RunnerSettings(horizon=2, dt=0.1, record_forces=False),
+            repo_root=REPO_ROOT,
+            scenario_path=CONFIG_PATH,
+            matrix_config_hash="matrix",
+        )
+
+        assert row["status"] == "native"
+        assert row["classification"] == "meets_budget_on_measured_host"
 
 
 class TestFeasibilityClassification:


### PR DESCRIPTION
## What / Why

Issue #5525 asks for a representative-CPU planner compute-feasibility matrix enabled by the latency-stress harness in #5506 / PR #5524. This PR delivers the versioned config, config-first runner script, and focused test suite. The runner orchestrates `LatencyMeasurementHarness` via `_run_map_episode` across every matrix cell and produces durable JSONL rows, a manifest with full provenance, and a per-planner summary table.

**Refs #5525**

**Successor of**: PR #5524 (harness instrumentation). Does not duplicate PR #5524; builds on its merged `LatencyMeasurementHarness`, `classify_feasibility`, and `collect_environment_provenance`.

## Scope in this PR

- `configs/benchmarks/compute_feasibility_matrix_v1.yaml` — versioned matrix config (3 planners × 2 maps × 3 pedestrian counts × 2 deadlines × 3 seeds = 108 cells)
- `scripts/benchmark/run_compute_feasibility_matrix.py` — config-first matrix runner with cell caching, per-cell provenance, JSONL output, manifest, summary aggregation, and fail-closed input/cache handling
- `tests/benchmark/test_compute_feasibility_matrix.py` — 22 tests: config validation, matrix expansion, dry-run mode, summary generation, cache/failure contracts, and feasibility classification

## What remains (outside cheap-lane scope)

The actual native-CPU campaign execution across all 108 cells — the runner must be invoked with `uv run python scripts/benchmark/run_compute_feasibility_matrix.py` on the target CPU to produce the campaign artifacts under `output/compute_feasibility_matrix_v1/`. Full campaign execution and durable evidence publication are tracked in [#5527](https://github.com/ll7/robot_sf_ll7/issues/5527), which completes the remaining acceptance criteria of #5525.

## Validation

```
uv run pytest tests/benchmark/test_compute_feasibility_matrix.py -q
# 22 passed

uv run ruff check scripts/benchmark/run_compute_feasibility_matrix.py tests/benchmark/test_compute_feasibility_matrix.py
# All checks passed

uv run python scripts/benchmark/run_compute_feasibility_matrix.py --dry-run
# Dry run: 108 cells (3 × 2 × 3 × 2 × 3 matrix verified)
```

This PR was produced by the SAIA/Qwen3.6-27B cheap implementation lane; the review gate hardens and merges.

## Follow-up tracking

- [#5527](https://github.com/ll7/robot_sf_ll7/issues/5527) — execute and publish the native representative-CPU campaign and conservative synthesis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line benchmark runner for evaluating compute feasibility across planner, map, pedestrian, deadline, and seed combinations.
  * Supports dry runs, result caching, configuration validation, and detailed JSON/JSONL output reports.
  * Reports latency metrics, feasibility classifications, failures, and planner-level deadline summaries.

* **Tests**
  * Added coverage for configuration validation, matrix expansion, dry-run behavior, summaries, and feasibility classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
