### PR TITLE
test(benchmark): verify successor collision consumers (#5097)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* **issue #5097 successor-release collision-consumer audit.** A fail-closed, CPU-only verifier now
+* **Issue #5097 successor-release collision-consumer audit.** A fail-closed, CPU-only verifier now
   checks signed publication bundles without extraction, reconciling typed exact collision events
   with component/total counts, binary success, and the canonical SNQI collision term. The tracked
   release 0.0.3 report verifies all 20,160 public rows and records release-wide inconsistencies as
@@ -265,7 +265,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tests/fixtures/benchmark/scenario_flakiness_issue_4978/real_campaign_episodes.jsonl`, plus the
   committed `scenario_flakiness.v1` report the audit produces from it
   (`real_campaign_flakiness_report.json`). This delivers the *real-campaign application* that PRs
-  #5069 and #5115 deferred: the audit now has regression-protected evidence that it surfaces real
+  Issue #5069 and Issue #5115 deferred: the audit now has regression-protected evidence that it surfaces real
   per-cell outcome instability — 7 of 20 assessable cells flagged knife-edge (35%), including a
   perfect coin-flip cell (`classic_doorway_medium`/`ppo`, stability 0.50 across 20 seeds). Exact-repeat
   determinism is reported as `null` (unknown) because each seed ran once; asserting it needs a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #5097 successor-release collision-consumer audit.** A fail-closed, CPU-only verifier now
+  checks signed publication bundles without extraction, reconciling typed exact collision events
+  with component/total counts, binary success, and the canonical SNQI collision term. The tracked
+  release 0.0.3 report verifies all 20,160 public rows and records release-wide inconsistencies as
+  explicit caveats; it is diagnostic metric-integrity evidence, not release-wide benchmark,
+  planner-ranking, SNQI-validity, or paper-facing evidence.
+
 * **issue #3207 collision-envelope / physical-footprint clearance-semantics diagnostic.** New
   `robot_sf/benchmark/clearance_semantics.py` (`footprint-clearance-semantics.v1`) formalizes the
   distinct clearance quantities that reported traces conflate — center-to-center distance,

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1,5 +1,5 @@
 version: 1
-updated_at: 2026-07-13
+updated_at: 2026-07-14
 policy: context-catalog.v1
 description: 'Machine-readable catalog for the current retrieval-first context index.
   This is not a full inventory of docs/context; it covers curated entry points from
@@ -20,6 +20,14 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+- path: docs/context/evidence/issue_5097_release_0_0_3_collision_consumer_audit/README.md
+  status: evidence
+  freshness: evidence
+  area: benchmark_evidence
+- path: docs/context/evidence/issue_5097_release_0_0_3_collision_consumer_audit/summary.json
+  status: evidence
+  freshness: evidence
+  area: benchmark_evidence
 - path: docs/context/collision_causality_online_risk_scenario_discovery_2026-07-12.md
   status: proposal
   freshness: dated

--- a/docs/context/evidence/issue_5097_release_0_0_3_collision_consumer_audit/README.md
+++ b/docs/context/evidence/issue_5097_release_0_0_3_collision_consumer_audit/README.md
@@ -1,0 +1,73 @@
+<!-- AI-GENERATED (robot_sf#5097, 2026-07-14) - NEEDS-REVIEW -->
+
+# Release 0.0.3 Collision-Consumer Audit
+
+## Plain-language summary
+
+The public release 0.0.3 bundle satisfies the narrow collision-data criteria in
+[Issue #5097](https://github.com/ll7/robot_sf_ll7/issues/5097). Its archive and all 87 signed
+payload files verify, all 20,160 episode rows carry the typed event-ledger contract, and all 9,022
+exact-collision rows have a positive collision count, an unsuccessful outcome, and an active
+Social Navigation Quality Index (SNQI) collision penalty. The canonical SNQI implementation
+reproduces every stored episode score exactly.
+
+This supports closing #5097. It does not certify the release as a whole: the bundle contains the
+release-wide inconsistencies listed below, and its own SNQI contract status is `fail`.
+
+## Classification and claim boundary
+
+- `schema_version`: `release_collision_consumer_reconciliation.v1`
+- `status`: `pass`
+- `result_classification`: `collision_consumer_reconciled`
+- `evidence_grade`: `diagnostic-only`
+- `diagnostic_only`: `true`
+- `benchmark_promotion`: `false`
+- `paper_facing`: `false`
+- `claim_boundary`: `Diagnostic-only reconciliation of exact per-episode collision outcomes with collision counts, the binary-success collision gate, and the canonical SNQI collision term. A pass is not release-wide benchmark success, planner-ranking evidence, SNQI contract validity, or a paper claim.`
+
+## Acceptance criterion to evidence
+
+| #5097 acceptance criterion | Evidence | Result |
+| --- | --- | --- |
+| Extend the release 0.0.2 withdrawal boundary and fail-closed checker to SNQI and success rate. | Merged PR [#5133](https://github.com/ll7/robot_sf_ll7/pull/5133) added both derived consumers to `docs/context/evidence/issue_3482_release_0_0_2_collision_count_boundary/manifest.json`, validates them with `scripts/validation/check_release_0_0_2_collision_count_boundary.py`, and covers malformed/premature-promotion cases. | Met. |
+| In the successor release, recompute SNQI and success from exact collision outcomes. | Release [0.0.3](https://github.com/ll7/robot_sf_ll7/releases/tag/0.0.3) plus [`summary.json`](summary.json): 20,160/20,160 SNQI values reproduce under the pinned v3 weights/baseline; 9,022 exact-collision rows equal positive total collision counts, contain typed events, set `metrics.success=false`, and activate a positive SNQI collision penalty. | Met at the collision-consumer boundary. |
+| Align the derived collision aggregate with the runtime collision envelope, or explicitly distinguish the measures. | PR #5133 changed the executable regression to use the runtime radius-sum contact envelope and retained explicit pedestrian/obstacle/agent collision components. The release audit requires those components to sum to `total_collision_count`, its `collisions` alias, and the typed exact event. | Met. |
+| Add a regression proving runtime collision termination yields `collisions >= 1` and `success = 0`. | PR #5133 added `tests/benchmark/test_collision_runtime_termination_metrics.py`, including a real runtime step at radius-sum contact and direct collision/SNQI/success assertions. The successor-release audit independently checks the same implication over every public exact-collision row. | Met. |
+
+## Reproduction
+
+Download the named asset from release 0.0.3 and verify its SHA-256 digest is
+`3cfefaaa39aab6cae541cece9573848a7e0afc5e1d9e4c9a7bbf48df2330b1a7`, then run:
+
+```bash
+uv run python scripts/validation/check_release_collision_consumers.py \
+  --bundle <downloaded-release-asset.tar.gz> \
+  --expected-bundle-sha256 3cfefaaa39aab6cae541cece9573848a7e0afc5e1d9e4c9a7bbf48df2330b1a7 \
+  --expected-release-tag 0.0.3 \
+  --expected-rows 20160 \
+  --expected-arms 14 \
+  --expected-rows-per-arm 1440 \
+  --source-url https://github.com/ll7/robot_sf_ll7/releases/download/0.0.3/paper_experiment_matrix_v2_h600_s30_extended_release_v0_0_3_final_publication_bundle.tar.gz \
+  --output docs/context/evidence/issue_5097_release_0_0_3_collision_consumer_audit/summary.json
+```
+
+The checker reads the archive without extracting it and fails closed on archive/hash drift,
+unsigned or missing payloads, cardinality drift, duplicate episode identities, event-ledger
+inconsistency, collision-count disagreement, collision-success disagreement, stored SNQI drift, or
+an inactive collision penalty.
+
+## Release-wide warnings outside #5097
+
+- `release/release_result.json` is stale relative to the rebuilt campaign summary (18,720 versus
+  20,160 episodes; 13 versus 14 successful arms; invalid/failure versus valid/success status).
+- All episode ledgers cite commit `a307ef276d701f8d14dead1aa0513f44ee97c0b0`, while the publication
+  manifest/tag cites `e2ac534c9d6bb750346b1e0724638c91306e410a`.
+- The campaign reports `snqi_contract_status=fail`; this audit proves only that the collision term
+  consumes the exact collision outcome, not that SNQI is a valid headline scalar or ranking.
+- One non-collision row records both `goal_reached=true` and `timeout=true`. The bundle omits the
+  reached-goal step needed to re-evaluate that separate timing boundary; it does not affect the
+  collision-implies-unsuccessful criterion.
+- Publication URLs/DOI metadata still contain placeholders.
+
+No benchmark campaign was rerun, no Slurm/GPU job was submitted, and no paper/dissertation claim
+was edited or promoted for this audit.

--- a/docs/context/evidence/issue_5097_release_0_0_3_collision_consumer_audit/README.md
+++ b/docs/context/evidence/issue_5097_release_0_0_3_collision_consumer_audit/README.md
@@ -1,6 +1,6 @@
 <!-- AI-GENERATED (robot_sf#5097, 2026-07-14) - NEEDS-REVIEW -->
 
-# Release 0.0.3 Collision-Consumer Audit
+# Issue #5097 — Release 0.0.3 Collision-Consumer Audit
 
 ## Plain-language summary
 
@@ -11,8 +11,10 @@ exact-collision rows have a positive collision count, an unsuccessful outcome, a
 Social Navigation Quality Index (SNQI) collision penalty. The canonical SNQI implementation
 reproduces every stored episode score exactly.
 
-This supports closing #5097. It does not certify the release as a whole: the bundle contains the
-release-wide inconsistencies listed below, and its own SNQI contract status is `fail`.
+This is a successor slice for #5097; the broader successor-release recomputation and release
+re-base remain tracked by [Issue #4364](https://github.com/ll7/robot_sf_ll7/issues/4364). It does
+not certify the release as a whole: the bundle contains the release-wide inconsistencies listed
+below, and its own SNQI contract status is `fail`.
 
 ## Classification and claim boundary
 
@@ -23,14 +25,18 @@ release-wide inconsistencies listed below, and its own SNQI contract status is `
 - `diagnostic_only`: `true`
 - `benchmark_promotion`: `false`
 - `paper_facing`: `false`
+- `provenance`: `seeds`: S30 release seed budget (30 seeds per arm; 1,440 rows per arm); `config`:
+  the signed asset's embedded `payload/release/release_manifest.resolved.json` and named
+  `paper_experiment_matrix_v2_h600_s30_extended` release matrix; `hash`: archive SHA-256 and
+  pinned SNQI weights/baseline SHA-256 are recorded in [`summary.json`](summary.json).
 - `claim_boundary`: `Diagnostic-only reconciliation of exact per-episode collision outcomes with collision counts, the binary-success collision gate, and the canonical SNQI collision term. A pass is not release-wide benchmark success, planner-ranking evidence, SNQI contract validity, or a paper claim.`
 
 ## Acceptance criterion to evidence
 
-| #5097 acceptance criterion | Evidence | Result |
+| Issue #5097 acceptance criterion | Evidence | Result |
 | --- | --- | --- |
 | Extend the release 0.0.2 withdrawal boundary and fail-closed checker to SNQI and success rate. | Merged PR [#5133](https://github.com/ll7/robot_sf_ll7/pull/5133) added both derived consumers to `docs/context/evidence/issue_3482_release_0_0_2_collision_count_boundary/manifest.json`, validates them with `scripts/validation/check_release_0_0_2_collision_count_boundary.py`, and covers malformed/premature-promotion cases. | Met. |
-| In the successor release, recompute SNQI and success from exact collision outcomes. | Release [0.0.3](https://github.com/ll7/robot_sf_ll7/releases/tag/0.0.3) plus [`summary.json`](summary.json): 20,160/20,160 SNQI values reproduce under the pinned v3 weights/baseline; 9,022 exact-collision rows equal positive total collision counts, contain typed events, set `metrics.success=false`, and activate a positive SNQI collision penalty. | Met at the collision-consumer boundary. |
+| In the successor release, recompute SNQI and success from exact collision outcomes. | Release [0.0.3](https://github.com/ll7/robot_sf_ll7/releases/tag/0.0.3) plus [`summary.json`](summary.json): 20,160/20,160 SNQI values reproduce under the pinned v3 weights/baseline; 9,022 exact-collision rows equal positive total collision counts, contain typed events, set `metrics.success=false`, and activate a positive SNQI collision penalty. | Met at the collision-consumer boundary; broader release re-base/recomputation remains with [#4364](https://github.com/ll7/robot_sf_ll7/issues/4364). |
 | Align the derived collision aggregate with the runtime collision envelope, or explicitly distinguish the measures. | PR #5133 changed the executable regression to use the runtime radius-sum contact envelope and retained explicit pedestrian/obstacle/agent collision components. The release audit requires those components to sum to `total_collision_count`, its `collisions` alias, and the typed exact event. | Met. |
 | Add a regression proving runtime collision termination yields `collisions >= 1` and `success = 0`. | PR #5133 added `tests/benchmark/test_collision_runtime_termination_metrics.py`, including a real runtime step at radius-sum contact and direct collision/SNQI/success assertions. The successor-release audit independently checks the same implication over every public exact-collision row. | Met. |
 

--- a/docs/context/evidence/issue_5097_release_0_0_3_collision_consumer_audit/summary.json
+++ b/docs/context/evidence/issue_5097_release_0_0_3_collision_consumer_audit/summary.json
@@ -1,0 +1,65 @@
+{
+  "benchmark_promotion": false,
+  "claim_boundary": "Diagnostic-only reconciliation of exact per-episode collision outcomes with collision counts, the binary-success collision gate, and the canonical SNQI collision term. A pass is not release-wide benchmark success, planner-ranking evidence, SNQI contract validity, or a paper claim.",
+  "counts": {
+    "arms": 14,
+    "exact_collision_rows": 9022,
+    "goal_and_timeout_rows": 1,
+    "rows": 20160,
+    "rows_per_arm": {
+      "goal__differential_drive": 1440,
+      "guarded_ppo__differential_drive": 1440,
+      "hybrid_rule_v3_fast_progress_static_escape__differential_drive": 1440,
+      "hybrid_rule_v3_fast_progress_static_escape_continuous__differential_drive": 1440,
+      "orca__differential_drive": 1440,
+      "ppo__differential_drive": 1440,
+      "prediction_planner__differential_drive": 1440,
+      "predictive_mppi__differential_drive": 1440,
+      "risk_dwa__differential_drive": 1440,
+      "sacadrl__differential_drive": 1440,
+      "scenario_adaptive_hybrid_orca_v1__differential_drive": 1440,
+      "scenario_adaptive_hybrid_orca_v2_collision_guard__differential_drive": 1440,
+      "social_force__differential_drive": 1440,
+      "socnav_sampling__differential_drive": 1440
+    },
+    "snqi_recomputed_rows": 20160,
+    "success_rows": 9247,
+    "unique_episode_identities": 20160
+  },
+  "diagnostic_only": true,
+  "evidence_grade": "diagnostic-only",
+  "integrity": {
+    "outer_bundle_sha256_matches": true,
+    "signed_payload_files": 87,
+    "snqi_baseline_sha256": "329ca5766491e1587979d0a435c7ba676e148ccdff97040a36546bbb9414035a",
+    "snqi_weights_sha256": "71a67c3c02faff166f8c96bef8bcf898533981ca2b2c4493829988520fb1aeb2",
+    "verified_payload_files": 87
+  },
+  "paper_facing": false,
+  "provenance": {
+    "episode_software_commits": {
+      "a307ef276d701f8d14dead1aa0513f44ee97c0b0": 20160
+    },
+    "publication_repository_commit": "e2ac534c9d6bb750346b1e0724638c91306e410a"
+  },
+  "release_wide_warnings": [
+    "release/release_result.json disagrees with the rebuilt campaign summary for: status, evidence_status, total_episodes, successful_runs",
+    "episode-ledger software commits do not equal the publication manifest/tag commit",
+    "campaign SNQI contract status is 'fail'; this audit proves only collision-term consumption",
+    "1 non-collision row(s) record both goal_reached and timeout; the bundle lacks reached_goal_step/horizon inputs needed to recompute that separate success-timing condition",
+    "publication metadata retains unresolved URL/DOI placeholders"
+  ],
+  "result_classification": "collision_consumer_reconciled",
+  "review_marker": "AI-GENERATED NEEDS-REVIEW",
+  "schema_version": "release_collision_consumer_reconciliation.v1",
+  "source": {
+    "bundle_name": "paper_experiment_matrix_v2_h600_s30_extended_release_v0_0_3_final_publication_bundle.tar.gz",
+    "bundle_sha256": "3cfefaaa39aab6cae541cece9573848a7e0afc5e1d9e4c9a7bbf48df2330b1a7",
+    "release_asset_url": "https://github.com/ll7/robot_sf_ll7/releases/download/0.0.3/paper_experiment_matrix_v2_h600_s30_extended_release_v0_0_3_final_publication_bundle.tar.gz",
+    "release_tag": "0.0.3"
+  },
+  "status": "pass",
+  "violation_count": 0,
+  "violation_counts": {},
+  "violations": []
+}

--- a/scripts/validation/check_release_collision_consumers.py
+++ b/scripts/validation/check_release_collision_consumers.py
@@ -60,7 +60,7 @@ def _parse_checksum_manifest(data: bytes) -> dict[str, str]:
     entries: dict[str, str] = {}
     for line_number, raw_line in enumerate(data.decode("utf-8").splitlines(), start=1):
         line = raw_line.strip()
-        if not line:
+        if not line or line.startswith("#"):
             continue
         parts = line.split(maxsplit=1)
         if len(parts) != 2 or len(parts[0]) != 64:
@@ -436,7 +436,8 @@ def audit_bundle(  # noqa: C901, PLR0912, PLR0913, PLR0915
                     if handle is None:
                         state.add("archive_read", f"cannot read archive member {member.name!r}")
                         continue
-                    logical_path = PurePosixPath(*path.parts[1:]).as_posix()
+                    logical_path_parts = path.parts[1:]
+                    logical_path = PurePosixPath(*logical_path_parts).as_posix()
                     if logical_path == "checksums.sha256":
                         try:
                             checksums = _parse_checksum_manifest(handle.read())
@@ -451,11 +452,11 @@ def audit_bundle(  # noqa: C901, PLR0912, PLR0913, PLR0915
                         except ValueError as exc:
                             state.add("metadata_json", str(exc))
                         continue
-                    if not logical_path.startswith("payload/"):
+                    if not logical_path_parts or logical_path_parts[0] != "payload":
                         _sha256_stream(handle)
                         continue
 
-                    payload_path = logical_path.removeprefix("payload/")
+                    payload_path = PurePosixPath(*logical_path_parts[1:]).as_posix()
                     episode_match = _EPISODE_PATH.fullmatch(payload_path)
                     selected_json = payload_path in {
                         "release/release_manifest.resolved.json",

--- a/scripts/validation/check_release_collision_consumers.py
+++ b/scripts/validation/check_release_collision_consumers.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""Fail-closed audit of collision-derived consumers in a publication bundle.
+
+The checker reads a release ``.tar.gz`` without extracting it, verifies both the
+outer archive digest and every embedded payload checksum, and then reconciles
+per-episode collision outcomes against success and the canonical Social
+Navigation Quality Index (SNQI) implementation.
+
+This is a narrow metric-integrity audit. A pass is not a release-wide benchmark,
+planner-ranking, SNQI-validity, or paper-facing claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import sys
+import tarfile
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import Any, BinaryIO
+
+from robot_sf.benchmark.event_ledger import (
+    EPISODE_EVENT_LEDGER_SCHEMA_VERSION,
+    reconcile_event_ledger,
+)
+from robot_sf.benchmark.metrics import snqi
+from robot_sf.benchmark.snqi_scalarization_sensitivity import (
+    load_baseline_mapping,
+    load_weight_mapping,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_WEIGHTS = ROOT / "configs/benchmarks/snqi_weights_camera_ready_v3.json"
+DEFAULT_BASELINE = ROOT / "configs/benchmarks/snqi_baseline_camera_ready_v3.json"
+SCHEMA_VERSION = "release_collision_consumer_reconciliation.v1"
+CLAIM_BOUNDARY = (
+    "Diagnostic-only reconciliation of exact per-episode collision outcomes with collision "
+    "counts, the binary-success collision gate, and the canonical SNQI collision term. A pass is "
+    "not release-wide benchmark success, planner-ranking evidence, SNQI contract validity, or a "
+    "paper claim."
+)
+_EPISODE_PATH = re.compile(r"^runs/(?P<arm>[^/]+)/episodes\.jsonl$")
+_MAX_REPORTED_VIOLATIONS = 100
+
+
+def _sha256_path(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _parse_checksum_manifest(data: bytes) -> dict[str, str]:
+    entries: dict[str, str] = {}
+    for line_number, raw_line in enumerate(data.decode("utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2 or len(parts[0]) != 64:
+            raise ValueError(f"checksums.sha256:{line_number}: malformed checksum entry")
+        path = parts[1].lstrip("*")
+        if path in entries:
+            raise ValueError(f"checksums.sha256:{line_number}: duplicate path {path!r}")
+        entries[path] = parts[0].lower()
+    if not entries:
+        raise ValueError("checksums.sha256 contains no entries")
+    return entries
+
+
+def _json_object(data: bytes, *, source: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{source}: invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{source}: expected a JSON object")
+    return payload
+
+
+def _finite_number(value: object, *, field: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{field} must be a finite number, not boolean")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be a finite number") from exc
+    if not math.isfinite(result):
+        raise ValueError(f"{field} must be a finite number")
+    return result
+
+
+def _sha256_stream(handle: BinaryIO) -> str:
+    digest = hashlib.sha256()
+    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+class _AuditState:
+    def __init__(self) -> None:
+        self.violation_counts: Counter[str] = Counter()
+        self.violations: list[dict[str, str]] = []
+        self.rows = 0
+        self.collision_rows = 0
+        self.goal_timeout_rows = 0
+        self.success_rows = 0
+        self.snqi_rows = 0
+        self.per_arm_rows: Counter[str] = Counter()
+        self.episode_commits: Counter[str] = Counter()
+        self.identities: set[tuple[str, str]] = set()
+
+    def add(self, code: str, message: str) -> None:
+        self.violation_counts[code] += 1
+        if len(self.violations) < _MAX_REPORTED_VIOLATIONS:
+            self.violations.append({"code": code, "message": message})
+
+
+def _check_episode(  # noqa: C901, PLR0912, PLR0915
+    record: Mapping[str, Any],
+    *,
+    arm: str,
+    source: str,
+    weights: dict[str, float],
+    baseline: dict[str, dict[str, float]],
+    state: _AuditState,
+) -> None:
+    state.rows += 1
+    state.per_arm_rows[arm] += 1
+    episode_id = record.get("episode_id")
+    if not isinstance(episode_id, str) or not episode_id:
+        state.add("episode_identity", f"{source}: episode_id must be a non-empty string")
+        episode_id = f"<missing:{state.rows}>"
+    identity = (arm, episode_id)
+    if identity in state.identities:
+        state.add("duplicate_episode", f"{source}: duplicate episode identity {identity!r}")
+    state.identities.add(identity)
+
+    metrics = record.get("metrics")
+    ledger = record.get("event_ledger")
+    outcome = record.get("outcome")
+    if not isinstance(metrics, Mapping):
+        state.add("metrics_shape", f"{source}: metrics must be an object")
+        return
+    if not isinstance(ledger, Mapping):
+        state.add("ledger_shape", f"{source}: event_ledger must be an object")
+        return
+    if not isinstance(outcome, Mapping):
+        state.add("outcome_shape", f"{source}: outcome must be an object")
+        return
+
+    exact = ledger.get("exact_events")
+    reconciliation = ledger.get("reconciliation")
+    collision_events = ledger.get("collision_events")
+    if ledger.get("schema_version") != EPISODE_EVENT_LEDGER_SCHEMA_VERSION:
+        state.add(
+            "ledger_schema",
+            f"{source}: expected {EPISODE_EVENT_LEDGER_SCHEMA_VERSION}",
+        )
+    if not isinstance(exact, Mapping):
+        state.add("exact_events_shape", f"{source}: exact_events must be an object")
+        return
+    if not isinstance(reconciliation, Mapping):
+        state.add("reconciliation_shape", f"{source}: reconciliation must be an object")
+        return
+    if not isinstance(collision_events, list):
+        state.add("collision_events_shape", f"{source}: collision_events must be a list")
+        return
+
+    exact_fields = ("collision", "goal_reached", "timeout", "invalid_run")
+    if any(not isinstance(exact.get(field), bool) for field in exact_fields):
+        state.add("exact_events_type", f"{source}: exact event fields must all be booleans")
+        return
+    collision = bool(exact["collision"])
+    if exact["goal_reached"] and exact["timeout"]:
+        state.goal_timeout_rows += 1
+
+    ledger_violations = reconcile_event_ledger(ledger)
+    for violation in ledger_violations:
+        state.add("ledger_reconciliation", f"{source}: {violation}")
+    if reconciliation.get("audit_result") != "pass":
+        state.add("ledger_audit_result", f"{source}: reconciliation.audit_result is not pass")
+
+    if outcome.get("collision_event") is not collision:
+        state.add("outcome_collision", f"{source}: outcome collision disagrees with exact ledger")
+    if bool(collision_events) is not collision:
+        state.add(
+            "typed_collision_event",
+            f"{source}: exact collision and typed collision-event presence disagree",
+        )
+
+    required_metrics = (
+        "collisions",
+        "total_collision_count",
+        "ped_collision_count",
+        "obstacle_collision_count",
+        "agent_collision_count",
+        "time_to_goal_norm",
+        "near_misses",
+        "comfort_exposure",
+        "force_exceed_events",
+        "jerk_mean",
+        "curvature_mean",
+        "snqi",
+    )
+    try:
+        values = {
+            field: _finite_number(metrics.get(field), field=f"{source}: metrics.{field}")
+            for field in required_metrics
+        }
+    except ValueError as exc:
+        state.add("metric_value", str(exc))
+        return
+    metric_success = metrics.get("success")
+    if not isinstance(metric_success, bool):
+        state.add("success_type", f"{source}: metrics.success must be boolean")
+        return
+    if collision and metric_success:
+        state.add(
+            "collision_success",
+            f"{source}: exact collision must force metrics.success=false",
+        )
+
+    total = values["total_collision_count"]
+    for component in (
+        "collisions",
+        "ped_collision_count",
+        "obstacle_collision_count",
+        "agent_collision_count",
+    ):
+        if values[component] < 0.0 or not values[component].is_integer():
+            state.add(
+                "collision_count_domain",
+                f"{source}: metrics.{component} must be integer >= 0",
+            )
+    components = (
+        values["ped_collision_count"]
+        + values["obstacle_collision_count"]
+        + values["agent_collision_count"]
+    )
+    if total < 0.0 or not total.is_integer():
+        state.add("collision_count_domain", f"{source}: total collision count must be integer >= 0")
+    if not math.isclose(values["collisions"], total, abs_tol=1e-12):
+        state.add("collision_alias", f"{source}: collisions != total_collision_count")
+    if not math.isclose(components, total, abs_tol=1e-12):
+        state.add("collision_components", f"{source}: collision components do not sum to total")
+    if (total > 0.0) is not collision:
+        state.add("exact_collision_count", f"{source}: exact collision and total count disagree")
+    try:
+        ledger_collision_value = _finite_number(
+            reconciliation.get("collision_metric_value"),
+            field=f"{source}: reconciliation.collision_metric_value",
+        )
+    except ValueError as exc:
+        state.add("ledger_collision_value", str(exc))
+    else:
+        if not math.isclose(ledger_collision_value, total, abs_tol=1e-12):
+            state.add("ledger_collision_value", f"{source}: ledger collision value != total")
+    if reconciliation.get("collision_metric_source") != "metrics.total_collision_count":
+        state.add(
+            "ledger_collision_source",
+            f"{source}: ledger collision source must be metrics.total_collision_count",
+        )
+
+    metric_values = dict(metrics)
+    actual_snqi = values["snqi"]
+    recomputed_snqi = snqi(metric_values, weights, baseline)
+    if not math.isclose(actual_snqi, recomputed_snqi, rel_tol=1e-12, abs_tol=1e-12):
+        state.add(
+            "snqi_recomputation",
+            f"{source}: stored SNQI {actual_snqi!r} != canonical {recomputed_snqi!r}",
+        )
+    else:
+        state.snqi_rows += 1
+
+    if collision:
+        state.collision_rows += 1
+        counterfactual = dict(metric_values)
+        counterfactual["collisions"] = 0.0
+        collision_penalty = snqi(counterfactual, weights, baseline) - recomputed_snqi
+        if not collision_penalty > 0.0:
+            state.add(
+                "snqi_collision_penalty",
+                f"{source}: exact collision does not activate a positive SNQI penalty",
+            )
+    if metric_success:
+        state.success_rows += 1
+
+    software_commit = ledger.get("software_commit")
+    if not isinstance(software_commit, str) or not software_commit:
+        state.add("episode_commit", f"{source}: ledger software_commit is missing")
+    else:
+        state.episode_commits[software_commit] += 1
+
+
+def _check_episode_member(
+    handle: BinaryIO,
+    *,
+    arm: str,
+    source: str,
+    weights: dict[str, float],
+    baseline: dict[str, dict[str, float]],
+    state: _AuditState,
+) -> str:
+    digest = hashlib.sha256()
+    for line_number, raw_line in enumerate(handle, start=1):
+        digest.update(raw_line)
+        if not raw_line.strip():
+            continue
+        row_source = f"{source}:{line_number}"
+        try:
+            record = json.loads(raw_line)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            state.add("episode_json", f"{row_source}: invalid JSON: {exc}")
+            continue
+        if not isinstance(record, Mapping):
+            state.add("episode_shape", f"{row_source}: expected a JSON object")
+            continue
+        _check_episode(
+            record,
+            arm=arm,
+            source=row_source,
+            weights=weights,
+            baseline=baseline,
+            state=state,
+        )
+    return digest.hexdigest()
+
+
+def _release_warnings(
+    metadata: Mapping[str, dict[str, Any]],
+    *,
+    episode_commits: Counter[str],
+    goal_timeout_rows: int,
+) -> list[str]:
+    warnings: list[str] = []
+    release_result = metadata.get("release/release_result.json", {})
+    campaign_summary = metadata.get("reports/campaign_summary.json", {})
+    campaign = campaign_summary.get("campaign")
+    campaign = campaign if isinstance(campaign, Mapping) else {}
+    publication = metadata.get("publication_manifest.json", {})
+    provenance = publication.get("provenance")
+    provenance = provenance if isinstance(provenance, Mapping) else {}
+    repository = provenance.get("repository")
+    repository = repository if isinstance(repository, Mapping) else {}
+
+    comparisons = (
+        ("status", release_result.get("status"), campaign.get("status")),
+        ("evidence_status", release_result.get("evidence_status"), campaign.get("evidence_status")),
+        ("total_episodes", release_result.get("total_episodes"), campaign.get("total_episodes")),
+        ("successful_runs", release_result.get("successful_runs"), campaign.get("successful_runs")),
+    )
+    mismatched = [name for name, old, rebuilt in comparisons if old != rebuilt]
+    if mismatched:
+        warnings.append(
+            "release/release_result.json disagrees with the rebuilt campaign summary for: "
+            + ", ".join(mismatched)
+        )
+    tag_commit = repository.get("commit")
+    if tag_commit and set(episode_commits) != {tag_commit}:
+        warnings.append(
+            "episode-ledger software commits do not equal the publication manifest/tag commit"
+        )
+    if campaign.get("snqi_contract_status") != "pass":
+        warnings.append(
+            f"campaign SNQI contract status is {campaign.get('snqi_contract_status')!r}; "
+            "this audit proves only collision-term consumption"
+        )
+    if goal_timeout_rows:
+        warnings.append(
+            f"{goal_timeout_rows} non-collision row(s) record both goal_reached and timeout; "
+            "the bundle lacks reached_goal_step/horizon inputs needed to recompute that separate "
+            "success-timing condition"
+        )
+    channels = publication.get("publication_channels")
+    channels = channels if isinstance(channels, Mapping) else {}
+    if any(
+        "<record-id>" in str(value) or "{release_tag}" in str(value) for value in channels.values()
+    ):
+        warnings.append("publication metadata retains unresolved URL/DOI placeholders")
+    return warnings
+
+
+def audit_bundle(  # noqa: C901, PLR0912, PLR0913, PLR0915
+    bundle: Path,
+    *,
+    expected_bundle_sha256: str,
+    expected_release_tag: str,
+    expected_rows: int,
+    expected_arms: int,
+    expected_rows_per_arm: int,
+    weights_path: Path = DEFAULT_WEIGHTS,
+    baseline_path: Path = DEFAULT_BASELINE,
+    source_url: str | None = None,
+) -> dict[str, Any]:
+    """Audit one publication bundle and return a machine-readable report."""
+    state = _AuditState()
+    metadata: dict[str, dict[str, Any]] = {}
+    bundle_sha256 = _sha256_path(bundle)
+    weights_sha256 = _sha256_path(weights_path)
+    baseline_sha256 = _sha256_path(baseline_path)
+    weights = load_weight_mapping(weights_path)
+    baseline = load_baseline_mapping(baseline_path)
+    checksums: dict[str, str] = {}
+    payload_hashes: dict[str, str] = {}
+    roots: set[str] = set()
+
+    if bundle_sha256 != expected_bundle_sha256.lower():
+        state.add(
+            "bundle_sha256",
+            f"archive sha256 {bundle_sha256} != expected {expected_bundle_sha256.lower()}",
+        )
+    else:
+        try:
+            with tarfile.open(bundle, mode="r:gz") as archive:
+                for member in archive:
+                    path = PurePosixPath(member.name)
+                    if path.is_absolute() or ".." in path.parts or not path.parts:
+                        state.add("unsafe_archive_path", f"unsafe archive member {member.name!r}")
+                        continue
+                    roots.add(path.parts[0])
+                    if member.isdir():
+                        continue
+                    if not member.isfile():
+                        state.add(
+                            "unsafe_archive_type", f"non-regular archive member {member.name!r}"
+                        )
+                        continue
+                    handle = archive.extractfile(member)
+                    if handle is None:
+                        state.add("archive_read", f"cannot read archive member {member.name!r}")
+                        continue
+                    logical_path = PurePosixPath(*path.parts[1:]).as_posix()
+                    if logical_path == "checksums.sha256":
+                        try:
+                            checksums = _parse_checksum_manifest(handle.read())
+                        except ValueError as exc:
+                            state.add("checksum_manifest", str(exc))
+                        continue
+                    if logical_path == "publication_manifest.json":
+                        try:
+                            metadata[logical_path] = _json_object(
+                                handle.read(), source=logical_path
+                            )
+                        except ValueError as exc:
+                            state.add("metadata_json", str(exc))
+                        continue
+                    if not logical_path.startswith("payload/"):
+                        _sha256_stream(handle)
+                        continue
+
+                    payload_path = logical_path.removeprefix("payload/")
+                    episode_match = _EPISODE_PATH.fullmatch(payload_path)
+                    selected_json = payload_path in {
+                        "release/release_manifest.resolved.json",
+                        "release/release_result.json",
+                        "reports/campaign_summary.json",
+                    }
+                    if episode_match:
+                        digest = _check_episode_member(
+                            handle,
+                            arm=episode_match.group("arm"),
+                            source=payload_path,
+                            weights=weights,
+                            baseline=baseline,
+                            state=state,
+                        )
+                    elif selected_json:
+                        data = handle.read()
+                        digest = hashlib.sha256(data).hexdigest()
+                        try:
+                            metadata[payload_path] = _json_object(data, source=payload_path)
+                        except ValueError as exc:
+                            state.add("metadata_json", str(exc))
+                    else:
+                        digest = _sha256_stream(handle)
+                    payload_hashes[payload_path] = digest
+                    expected_digest = checksums.get(payload_path)
+                    if expected_digest is None:
+                        state.add("unsigned_payload", f"payload file is unsigned: {payload_path}")
+                    elif digest != expected_digest:
+                        state.add("payload_sha256", f"payload checksum mismatch: {payload_path}")
+        except (OSError, tarfile.TarError) as exc:
+            state.add("archive_read", f"cannot read archive: {exc}")
+
+    if len(roots) != 1:
+        state.add("archive_root", f"expected one archive root, found {sorted(roots)!r}")
+    missing_payloads = sorted(set(checksums) - set(payload_hashes))
+    for path in missing_payloads:
+        state.add("missing_payload", f"signed payload file is missing: {path}")
+
+    publication = metadata.get("publication_manifest.json", {})
+    channels = publication.get("publication_channels")
+    channels = channels if isinstance(channels, Mapping) else {}
+    if channels.get("release_tag") != expected_release_tag:
+        state.add("release_tag", "publication manifest release tag does not match expected tag")
+    published_files = publication.get("files")
+    if isinstance(published_files, list):
+        published_hashes = {
+            str(entry.get("path")): str(entry.get("sha256"))
+            for entry in published_files
+            if isinstance(entry, Mapping)
+        }
+        if published_hashes != checksums:
+            state.add("publication_file_manifest", "publication file manifest != checksums.sha256")
+    else:
+        state.add("publication_file_manifest", "publication manifest files must be a list")
+
+    release_manifest = metadata.get("release/release_manifest.resolved.json", {})
+    if release_manifest.get("release_tag") != expected_release_tag:
+        state.add("release_tag", "resolved release manifest tag does not match expected tag")
+    metric_contract = release_manifest.get("metrics")
+    metric_contract = metric_contract if isinstance(metric_contract, Mapping) else {}
+    if metric_contract.get("snqi_weights_sha256") != weights_sha256:
+        state.add("weights_sha256", "local SNQI weights do not match release manifest")
+    if metric_contract.get("snqi_baseline_sha256") != baseline_sha256:
+        state.add("baseline_sha256", "local SNQI baseline does not match release manifest")
+    campaign_summary = metadata.get("reports/campaign_summary.json", {})
+    campaign = campaign_summary.get("campaign")
+    campaign = campaign if isinstance(campaign, Mapping) else {}
+    if campaign.get("snqi_weights_sha256") not in {None, weights_sha256}:
+        state.add("weights_sha256", "local SNQI weights do not match campaign summary")
+    if campaign.get("snqi_baseline_sha256") not in {None, baseline_sha256}:
+        state.add("baseline_sha256", "local SNQI baseline does not match campaign summary")
+
+    if state.rows != expected_rows:
+        state.add("row_count", f"expected {expected_rows} rows, found {state.rows}")
+    if len(state.per_arm_rows) != expected_arms:
+        state.add("arm_count", f"expected {expected_arms} arms, found {len(state.per_arm_rows)}")
+    for arm, count in sorted(state.per_arm_rows.items()):
+        if count != expected_rows_per_arm:
+            state.add(
+                "rows_per_arm",
+                f"arm {arm!r}: expected {expected_rows_per_arm} rows, found {count}",
+            )
+    if state.collision_rows == 0:
+        state.add("collision_support", "bundle contains no exact collision rows")
+
+    warnings = _release_warnings(
+        metadata,
+        episode_commits=state.episode_commits,
+        goal_timeout_rows=state.goal_timeout_rows,
+    )
+    status = "pass" if not state.violation_counts else "fail"
+    publication_provenance = publication.get("provenance")
+    publication_provenance = (
+        publication_provenance if isinstance(publication_provenance, Mapping) else {}
+    )
+    publication_repository = publication_provenance.get("repository")
+    publication_repository = (
+        publication_repository if isinstance(publication_repository, Mapping) else {}
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "review_marker": "AI-GENERATED NEEDS-REVIEW",
+        "status": status,
+        "result_classification": (
+            "collision_consumer_reconciled" if status == "pass" else "not_reconciled"
+        ),
+        "evidence_grade": "diagnostic-only",
+        "diagnostic_only": True,
+        "benchmark_promotion": False,
+        "paper_facing": False,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "source": {
+            "release_tag": expected_release_tag,
+            "release_asset_url": source_url,
+            "bundle_name": bundle.name,
+            "bundle_sha256": bundle_sha256,
+        },
+        "integrity": {
+            "outer_bundle_sha256_matches": bundle_sha256 == expected_bundle_sha256.lower(),
+            "signed_payload_files": len(checksums),
+            "verified_payload_files": len(payload_hashes),
+            "snqi_weights_sha256": weights_sha256,
+            "snqi_baseline_sha256": baseline_sha256,
+        },
+        "counts": {
+            "arms": len(state.per_arm_rows),
+            "rows": state.rows,
+            "rows_per_arm": dict(sorted(state.per_arm_rows.items())),
+            "exact_collision_rows": state.collision_rows,
+            "goal_and_timeout_rows": state.goal_timeout_rows,
+            "success_rows": state.success_rows,
+            "snqi_recomputed_rows": state.snqi_rows,
+            "unique_episode_identities": len(state.identities),
+        },
+        "provenance": {
+            "episode_software_commits": dict(sorted(state.episode_commits.items())),
+            "publication_repository_commit": publication_repository.get("commit"),
+        },
+        "release_wide_warnings": warnings,
+        "violation_count": sum(state.violation_counts.values()),
+        "violation_counts": dict(sorted(state.violation_counts.items())),
+        "violations": state.violations,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", required=True, type=Path)
+    parser.add_argument("--expected-bundle-sha256", required=True)
+    parser.add_argument("--expected-release-tag", required=True)
+    parser.add_argument("--expected-rows", required=True, type=int)
+    parser.add_argument("--expected-arms", required=True, type=int)
+    parser.add_argument("--expected-rows-per-arm", required=True, type=int)
+    parser.add_argument("--weights", type=Path, default=DEFAULT_WEIGHTS)
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument("--source-url")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the command-line collision-consumer audit."""
+    args = _parser().parse_args(argv)
+    try:
+        report = audit_bundle(
+            args.bundle,
+            expected_bundle_sha256=args.expected_bundle_sha256,
+            expected_release_tag=args.expected_release_tag,
+            expected_rows=args.expected_rows,
+            expected_arms=args.expected_arms,
+            expected_rows_per_arm=args.expected_rows_per_arm,
+            weights_path=args.weights,
+            baseline_path=args.baseline,
+            source_url=args.source_url,
+        )
+    except (OSError, ValueError) as exc:
+        report = {
+            "schema_version": SCHEMA_VERSION,
+            "review_marker": "AI-GENERATED NEEDS-REVIEW",
+            "status": "fail",
+            "result_classification": "not_reconciled",
+            "evidence_grade": "diagnostic-only",
+            "diagnostic_only": True,
+            "benchmark_promotion": False,
+            "paper_facing": False,
+            "claim_boundary": CLAIM_BOUNDARY,
+            "violation_count": 1,
+            "violation_counts": {"input_error": 1},
+            "violations": [{"code": "input_error", "message": str(exc)}],
+        }
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/validation/test_check_release_collision_consumers.py
+++ b/tests/validation/test_check_release_collision_consumers.py
@@ -1,0 +1,311 @@
+"""Tests for the publication-bundle collision-consumer audit."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.event_ledger import build_event_ledger
+from robot_sf.benchmark.metrics import snqi
+from robot_sf.benchmark.snqi_scalarization_sensitivity import (
+    load_baseline_mapping,
+    load_weight_mapping,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts/validation/check_release_collision_consumers.py"
+WEIGHTS_PATH = ROOT / "configs/benchmarks/snqi_weights_camera_ready_v3.json"
+BASELINE_PATH = ROOT / "configs/benchmarks/snqi_baseline_camera_ready_v3.json"
+TEST_COMMIT = "a" * 40
+
+_SPEC = importlib.util.spec_from_file_location("check_release_collision_consumers", SCRIPT_PATH)
+assert _SPEC is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+audit_bundle = _MODULE.audit_bundle
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _json_bytes(payload: object) -> bytes:
+    return (json.dumps(payload, sort_keys=True) + "\n").encode()
+
+
+def _episode(*, collision: bool, seed: int) -> dict[str, Any]:
+    weights = load_weight_mapping(WEIGHTS_PATH)
+    baseline = load_baseline_mapping(BASELINE_PATH)
+    success = not collision
+    total = int(collision)
+    metrics: dict[str, Any] = {
+        "collisions": total,
+        "total_collision_count": total,
+        "ped_collision_count": total,
+        "obstacle_collision_count": 0,
+        "agent_collision_count": 0,
+        "success": success,
+        "time_to_goal_norm": 0.5 if success else 1.0,
+        "near_misses": 0,
+        "comfort_exposure": 0.0,
+        "force_exceed_events": 0,
+        "jerk_mean": 0.0,
+        "curvature_mean": 0.0,
+    }
+    metrics["snqi"] = snqi(metrics, weights, baseline)
+    record: dict[str, Any] = {
+        "episode_id": f"scenario--{seed}",
+        "scenario_id": "scenario",
+        "seed": seed,
+        "algo": "planner",
+        "git_hash": TEST_COMMIT,
+        "status": "collision" if collision else "success",
+        "termination_reason": "collision" if collision else "success",
+        "metrics": metrics,
+        "outcome": {
+            "collision_event": collision,
+            "route_complete": success,
+            "timeout_event": False,
+        },
+    }
+    collision_events = None
+    if collision:
+        collision_events = [
+            {
+                "collision_partner_type": "pedestrian",
+                "collision_partner_id": "ped-1",
+                "collision_time": 1.0,
+                "relative_speed_at_contact": 0.5,
+                "clearance_series_source": "fixture",
+                "exact_event_source": "fixture",
+            }
+        ]
+    record["event_ledger"] = build_event_ledger(record, collision_events=collision_events)
+    return record
+
+
+def _add_bytes(archive: tarfile.TarFile, name: str, data: bytes) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(data)
+    info.mtime = 0
+    info.mode = 0o644
+    archive.addfile(info, io.BytesIO(data))
+
+
+def _bundle(
+    tmp_path: Path,
+    *,
+    mutate_rows: Callable[[list[dict[str, Any]]], None] | None = None,
+    tamper_after_signing: bool = False,
+) -> tuple[Path, str]:
+    rows = [_episode(collision=False, seed=1), _episode(collision=True, seed=2)]
+    if mutate_rows is not None:
+        mutate_rows(rows)
+    weights_sha256 = hashlib.sha256(WEIGHTS_PATH.read_bytes()).hexdigest()
+    baseline_sha256 = hashlib.sha256(BASELINE_PATH.read_bytes()).hexdigest()
+    payloads = {
+        "release/release_manifest.resolved.json": _json_bytes(
+            {
+                "release_tag": "test-v1",
+                "metrics": {
+                    "snqi_weights_sha256": weights_sha256,
+                    "snqi_baseline_sha256": baseline_sha256,
+                },
+            }
+        ),
+        "release/release_result.json": _json_bytes(
+            {
+                "status": "benchmark_success",
+                "evidence_status": "valid",
+                "total_episodes": 2,
+                "successful_runs": 1,
+            }
+        ),
+        "reports/campaign_summary.json": _json_bytes(
+            {
+                "campaign": {
+                    "status": "benchmark_success",
+                    "evidence_status": "valid",
+                    "total_episodes": 2,
+                    "successful_runs": 1,
+                    "snqi_contract_status": "pass",
+                    "snqi_weights_sha256": weights_sha256,
+                    "snqi_baseline_sha256": baseline_sha256,
+                }
+            }
+        ),
+        "runs/planner__differential_drive/episodes.jsonl": b"".join(
+            _json_bytes(row) for row in rows
+        ),
+    }
+    signed_hashes = {path: _sha256(data) for path, data in payloads.items()}
+    publication_manifest = {
+        "publication_channels": {"release_tag": "test-v1"},
+        "provenance": {"repository": {"commit": TEST_COMMIT}},
+        "files": [
+            {"path": path, "sha256": digest} for path, digest in sorted(signed_hashes.items())
+        ],
+    }
+    checksum_bytes = "".join(
+        f"{digest}  {path}\n" for path, digest in sorted(signed_hashes.items())
+    ).encode()
+    if tamper_after_signing:
+        payloads["release/release_result.json"] += b" "
+
+    bundle = tmp_path / "fixture.tar.gz"
+    root = "fixture"
+    with tarfile.open(bundle, "w:gz") as archive:
+        _add_bytes(archive, f"{root}/README.md", b"fixture\n")
+        _add_bytes(archive, f"{root}/checksums.sha256", checksum_bytes)
+        for path, data in payloads.items():
+            _add_bytes(archive, f"{root}/payload/{path}", data)
+        _add_bytes(
+            archive,
+            f"{root}/publication_manifest.json",
+            _json_bytes(publication_manifest),
+        )
+    return bundle, hashlib.sha256(bundle.read_bytes()).hexdigest()
+
+
+def _audit(bundle: Path, digest: str, **overrides: object) -> dict[str, Any]:
+    arguments: dict[str, object] = {
+        "expected_bundle_sha256": digest,
+        "expected_release_tag": "test-v1",
+        "expected_rows": 2,
+        "expected_arms": 1,
+        "expected_rows_per_arm": 2,
+    }
+    arguments.update(overrides)
+    return audit_bundle(bundle, **arguments)
+
+
+def test_valid_bundle_reconciles_success_and_snqi(tmp_path: Path) -> None:
+    """A consistent signed bundle passes every narrow consumer check."""
+    bundle, digest = _bundle(tmp_path)
+
+    report = _audit(bundle, digest)
+
+    assert report["status"] == "pass"
+    assert report["violation_count"] == 0
+    assert report["counts"]["rows"] == 2
+    assert report["counts"]["exact_collision_rows"] == 1
+    assert report["counts"]["snqi_recomputed_rows"] == 2
+
+
+def test_collision_marked_success_fails_closed(tmp_path: Path) -> None:
+    """An exact collision cannot remain a successful episode."""
+
+    def mark_collision_success(rows: list[dict[str, Any]]) -> None:
+        collision_row = rows[1]
+        collision_row["metrics"]["success"] = True
+        collision_row["metrics"]["snqi"] = snqi(
+            collision_row["metrics"],
+            load_weight_mapping(WEIGHTS_PATH),
+            load_baseline_mapping(BASELINE_PATH),
+        )
+
+    bundle, digest = _bundle(tmp_path, mutate_rows=mark_collision_success)
+
+    report = _audit(bundle, digest)
+
+    assert report["status"] == "fail"
+    assert report["violation_counts"]["collision_success"] == 1
+
+
+def test_embedded_checksum_mismatch_fails_closed(tmp_path: Path) -> None:
+    """Payload content changed after signing is rejected."""
+    bundle, digest = _bundle(tmp_path, tamper_after_signing=True)
+
+    report = _audit(bundle, digest)
+
+    assert report["status"] == "fail"
+    assert report["violation_counts"]["payload_sha256"] == 1
+
+
+def test_expected_cardinality_mismatch_fails_closed(tmp_path: Path) -> None:
+    """A truncated or over-complete campaign is rejected."""
+    bundle, digest = _bundle(tmp_path)
+
+    report = _audit(bundle, digest, expected_rows=3)
+
+    assert report["status"] == "fail"
+    assert report["violation_counts"]["row_count"] == 1
+
+
+def test_stored_snqi_drift_fails_closed(tmp_path: Path) -> None:
+    """A score that does not reproduce under canonical inputs is rejected."""
+
+    def alter_snqi(rows: list[dict[str, Any]]) -> None:
+        rows[0]["metrics"]["snqi"] += 0.01
+
+    bundle, digest = _bundle(tmp_path, mutate_rows=alter_snqi)
+
+    report = _audit(bundle, digest)
+
+    assert report["status"] == "fail"
+    assert report["violation_counts"]["snqi_recomputation"] == 1
+
+
+def test_exact_collision_count_disagreement_fails_closed(tmp_path: Path) -> None:
+    """A typed exact collision cannot be paired with a zero aggregate."""
+
+    def zero_collision_count(rows: list[dict[str, Any]]) -> None:
+        collision_metrics = rows[1]["metrics"]
+        collision_metrics["collisions"] = 0
+        collision_metrics["total_collision_count"] = 0
+        collision_metrics["ped_collision_count"] = 0
+
+    bundle, digest = _bundle(tmp_path, mutate_rows=zero_collision_count)
+
+    report = _audit(bundle, digest)
+
+    assert report["status"] == "fail"
+    assert report["violation_counts"]["exact_collision_count"] == 1
+
+
+def test_cli_writes_pass_report(tmp_path: Path) -> None:
+    """The command-line path writes and prints the same passing report."""
+    bundle, digest = _bundle(tmp_path)
+    output = tmp_path / "report.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--bundle",
+            str(bundle),
+            "--expected-bundle-sha256",
+            digest,
+            "--expected-release-tag",
+            "test-v1",
+            "--expected-rows",
+            "2",
+            "--expected-arms",
+            "1",
+            "--expected-rows-per-arm",
+            "2",
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["status"] == "pass"
+    assert json.loads(output.read_text(encoding="utf-8"))["status"] == "pass"

--- a/tests/validation/test_check_release_collision_consumers.py
+++ b/tests/validation/test_check_release_collision_consumers.py
@@ -36,6 +36,7 @@ sys.modules[_SPEC.name] = _MODULE
 _SPEC.loader.exec_module(_MODULE)
 
 audit_bundle = _MODULE.audit_bundle
+parse_checksum_manifest = _MODULE._parse_checksum_manifest
 
 
 def _sha256(data: bytes) -> str:
@@ -205,14 +206,27 @@ def test_valid_bundle_reconciles_success_and_snqi(tmp_path: Path) -> None:
     assert report["counts"]["snqi_recomputed_rows"] == 2
 
 
+def test_checksum_manifest_ignores_trimmed_comments() -> None:
+    """Checksum manifests may contain the repository's comment-line marker."""
+    digest = "a" * 64
+
+    parsed = parse_checksum_manifest(
+        f"  # generated manifest\n\n{digest}  payload/file.json\n".encode()
+    )
+
+    assert parsed == {"payload/file.json": digest}
+
+
 def test_collision_marked_success_fails_closed(tmp_path: Path) -> None:
     """An exact collision cannot remain a successful episode."""
 
     def mark_collision_success(rows: list[dict[str, Any]]) -> None:
         collision_row = rows[1]
-        collision_row["metrics"]["success"] = True
-        collision_row["metrics"]["snqi"] = snqi(
-            collision_row["metrics"],
+        metrics = collision_row["metrics"]
+        assert {"success", "snqi"}.issubset(metrics)
+        metrics["success"] = True
+        metrics["snqi"] = snqi(
+            metrics,
             load_weight_mapping(WEIGHTS_PATH),
             load_baseline_mapping(BASELINE_PATH),
         )
@@ -264,6 +278,11 @@ def test_exact_collision_count_disagreement_fails_closed(tmp_path: Path) -> None
 
     def zero_collision_count(rows: list[dict[str, Any]]) -> None:
         collision_metrics = rows[1]["metrics"]
+        assert {
+            "collisions",
+            "total_collision_count",
+            "ped_collision_count",
+        }.issubset(collision_metrics)
         collision_metrics["collisions"] = 0
         collision_metrics["total_collision_count"] = 0
         collision_metrics["ped_collision_count"] = 0


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** adds `release_collision_consumer_reconciliation.v1`, a fail-closed verifier for
  signed publication bundles, eight synthetic contract tests, and a tracked audit of the public
  release 0.0.3 asset.
- **Why now:** #5097 was blocked on a successor release when PR #5133 merged; release 0.0.3 is now
  public and supplies the missing empirical input.
- **Claim boundary:** the audit checks only that exact collision outcomes feed component/total
  counts, the binary-success collision gate, and the canonical SNQI collision term. It is not
  release-wide benchmark success, planner-ranking evidence, SNQI contract validity, or a paper
  claim.
- **Required validation:** the signed public archive must pass with 20,160 unique rows, 14 arms,
  1,440 rows per arm, exact SNQI reproduction, and zero narrow-contract violations; focused tests
  and the final repository PR gate must pass.
- **Remaining blocker:** none for this narrow collision-consumer slice. #5097 remains open for the
  broader successor-release recomputation and release re-base tracked in #4364; the release-wide
  integrity warnings remain tracked in #5530.

## Contract delta

- **New schema:** `release_collision_consumer_reconciliation.v1`.
- **New fail-closed blockers:** outer or embedded checksum drift; unsigned/missing payloads;
  cardinality or identity drift; malformed/non-v2 event ledgers; typed/exact/aggregate collision
  disagreement; collision rows marked successful; canonical SNQI mismatch; inactive collision
  penalty; release-tag or pinned weights/baseline mismatch.
- **Compatibility:** no simulator, metric formula, release asset, or runtime behavior changes. This
  adds a CPU-only validation CLI and a diagnostic evidence report.

Issue: https://github.com/ll7/robot_sf_ll7/issues/5097

## Scope summary

The checker streams the public `.tar.gz` without extraction and validates its outer digest, all 87
signed payload files, and every canonical episode JSONL row. The tracked report records:

- 20,160/20,160 unique rows across 14/14 arms at 1,440 rows each;
- 9,022 exact-collision rows, all with positive reconciled counts, typed collision events,
  `metrics.success=false`, and a positive SNQI collision penalty;
- 20,160/20,160 stored SNQI values reproduced by the canonical implementation under the pinned v3
  weights and baseline; and
- zero collision-consumer violations.

The reversible audit assumption is that #5097's success criterion is the collision-derived gate
(`exact collision => success=false`), matching the issue and PR #5133 regression. The bundle lacks
`reached_goal_step`, so the one unrelated row marked both goal-reached and timeout is retained as a
warning instead of being silently promoted or made a #5097 blocker.

## Acceptance criterion → evidence

| Criterion | Evidence | Result |
| --- | --- | --- |
| Extend the release 0.0.2 withdrawal boundary/checker to SNQI and success rate. | Merged PR #5133 extended the manifest, checker, and malformed/premature-promotion tests. | Met. |
| Recompute successor-release SNQI and success from exact collision outcomes. | Public 0.0.3 asset plus the tracked `summary.json`: 20,160 SNQI reproductions and all 9,022 exact-collision rows unsuccessful with an active penalty. | Met at the stated collision-consumer boundary; broader release re-base/recomputation remains with #4364. |
| Align derived aggregation with the runtime collision envelope or name distinct measures. | PR #5133 uses the runtime radius-sum contact fixture; this verifier reconciles typed exact events, explicit pedestrian/obstacle/agent components, `total_collision_count`, and `collisions`. | Met. |
| Regression: runtime collision termination gives `collisions >= 1`, `success = 0`. | PR #5133's real runtime-step tests remain green; the public-row audit independently checks the implication over every exact-collision row. | Met. |

Refs #5097

## Validation

- `uv run pytest -q tests/validation/test_check_release_collision_consumers.py tests/validation/test_check_release_0_0_2_collision_count_boundary.py tests/benchmark/test_collision_runtime_termination_metrics.py` — **34 passed**.
- Public release audit command documented in the evidence README — **pass**, 20,160 rows, 87/87
  signed payloads, zero violations.
- `uv run ruff check .` — **pass**.
- `uv run ruff format --check .` — **pass**, 3,005 files already formatted.
- Explicit changed-file docs/evidence integrity check — **pass**, 6 files.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  — **pass** on committed clean head `945c209ed` (2,376 passed, 1 skipped; lint, format,
  docs/evidence, and repository ratchets passed).

## Out of scope

No full benchmark campaign, Slurm/GPU submission, or paper/dissertation claim is part of this
diagnostic slice, and no #5097 acceptance criterion is deferred by that boundary. The broader
successor-release recomputation/re-base remains tracked by #4364. The PR does not repair or
republish release 0.0.3; its stale release result, commit-provenance split, SNQI contract failure,
one mixed goal/timeout row, and publication placeholders remain visible as release-wide warnings
tracked by #5530.

## Follow-Up Issues

- https://github.com/ll7/robot_sf_ll7/issues/5530 tracks the release-wide publication consistency
  defects. Those defects do not invalidate #5097's narrower collision-consumer reconciliation.
- https://github.com/ll7/robot_sf_ll7/issues/4364 tracks the broader successor-release re-base and
  recomputation that remains outside this slice.

<details>
<summary>Evidence and workflow appendix</summary>

- **Evidence tier:** diagnostic metric-integrity evidence over the public successor-release asset.
- **Result classification:** `collision_consumer_reconciled`.
- **Fallback/degraded handling:** no performance or success claim is made from fallback/degraded
  execution; the audit checks every canonical row's internal collision-consumer contract.
- **Artifact handling:** no new `output/` artifacts. The only large input was the public GitHub
  release asset in temporary local storage; git tracks only the compact report and reproduction
  instructions.
- **Fragmentation guard:** this is a successor slice for #5097 and does not duplicate PR #5133;
  it adds the nameable successor-release verification capability and integration report rather
  than another boundary refresh. The broader release re-base is tracked by #4364.
- **State propagation:** the tracked evidence bundle, this PR, and linked issues #5097, #4364, and
  #5530 are the canonical durable surfaces.
- **Merge/release authority:** not exercised by this author; the downstream PR gate owns review
  and merge.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a release bundle audit tool that verifies package integrity, metadata consistency, expected record counts, and metric calculations.
  * Supports pass/fail results with structured JSON reports and clear validation status.
  * Detects tampering, checksum mismatches, unsafe archive contents, and inconsistent collision or quality metrics.

* **Tests**
  * Added coverage for valid bundles, tampering, checksum errors, count mismatches, metric drift, inconsistent collision totals, and command-line report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
