### PR TITLE
feat: export h600 family and cell breakdowns (#5138)

### DIFF
--- a/scripts/analysis/build_issue_5138_h600_family_breakdown_export.py
+++ b/scripts/analysis/build_issue_5138_h600_family_breakdown_export.py
@@ -1,0 +1,784 @@
+#!/usr/bin/env python3
+"""Issue #5138: export per-family + per-cell breakdowns for the h600 campaigns.
+
+Plain-language summary
+----------------------
+The extended-horizon (h600) campaigns publish only *aggregate*, per-planner
+success. This script exports the per-scenario-family (and per-cell) success /
+near-miss / collision / SNQI breakdowns for the two retained h600 campaign
+bundles, using the same column schema as the release campaign's
+``scenario_family_breakdown`` table, and it keeps the per-cell episode count
+(``episodes`` = ``n``) on every row so any cell's sample size is computable.
+
+Why it matters
+--------------
+Whether the universally-hard families (bottleneck, cross-trap, head-on-corridor)
+stay at zero completion once waiting strategies become viable is the single
+number that decides how strong the family-difficulty finding is. That number is
+currently unknowable from the *exported* h600 artifacts, because the published
+bundle only carries ``planner_metric_summary.csv`` (aggregate). The raw campaign
+reports already contain ``scenario_family_breakdown.csv`` and
+``scenario_breakdown.csv``; this script promotes them into the shared evidence
+bundle with the release schema, a focused universally-hard-families summary, and
+full provenance.
+
+Claim boundary
+--------------
+This is **diagnostic-only, reporting over existing campaign bundles**. It runs
+no new campaign, no Slurm job, no GPU, no training. It re-shapes existing
+canonical campaign breakdown tables; it does not recompute any metric.
+
+Caveats:
+- Release 0.0.2 collision-count provenance is withdrawn by issue #3482. The
+  collision columns are republished verbatim from the h600 campaign breakdowns
+  for completeness only and are not used as paper/dissertation evidence here.
+- The h600 legs are three-seed campaigns; the per-cell ``n`` is small (typically
+  3). Treat per-cell success as diagnostic, not as a stable estimate.
+- ``jerk_mean`` is absent from the h600 campaign breakdowns and is emitted as an
+  empty field, matching the source.
+
+Schema
+------
+The per-family export follows the release campaign's family-breakdown schema:
+
+    run_label, job_id, scenario_matrix_hash, planner_key, algo, scenario_family,
+    episodes, success_mean, collisions_mean, ped_collision_count_mean,
+    obstacle_collision_count_mean, total_collision_count_mean,
+    near_misses_mean, time_to_goal_norm_mean, path_efficiency_mean,
+    comfort_exposure_mean, jerk_mean, snqi_mean
+
+The per-cell export adds ``scenario_id`` (the cell granularity) and keeps
+``episodes`` (per-cell ``n``) on every row.
+
+Outputs are written into the h600 interpretation evidence bundle directory and
+registered in ``source_manifest.json`` + ``SHA256SUMS`` so the F-C4(ii) gate's
+checksum-coverage contract stays satisfied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.identity.hash_utils import sha256_file
+from scripts.validation.check_issue_5164_h600_source_reports import (
+    ContractError,
+    validate_source_reports,
+)
+
+SCHEMA_VERSION = "issue_5138_h600_family_breakdown_export.v1"
+
+DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_3810_h600_interpretation_2026-07")
+REVIEW_MARKER = "AI-GENERATED NEEDS-REVIEW"
+
+# Canonical h600 legs (job_id -> reports dir). #5164 pins these repository-
+# accessible locations and verifies their checksums before this exporter may
+# regenerate the diagnostic bundle.
+DEFAULT_RUNS = (
+    {
+        "job_id": "13268",
+        "run_label": "confirm",
+        "reports_dir": Path(
+            "docs/context/evidence/issue_3810_h600_interpretation_2026-07/source_reports/13268"
+        ),
+    },
+    {
+        "job_id": "13273",
+        "run_label": "extended_roster",
+        "reports_dir": Path(
+            "docs/context/evidence/issue_3810_h600_interpretation_2026-07/source_reports/13273"
+        ),
+    },
+)
+
+# The three families the issue names as the family-difficulty finding's crux.
+UNIVERSALLY_HARD_FAMILIES = ("bottleneck", "cross_trap", "head_on_corridor")
+
+# Release-campaign family-breakdown schema. ``run_label`` / ``job_id`` /
+# ``scenario_matrix_hash`` are prepended so both h600 legs are distinguishable in
+# one table; the metric columns are exactly the release schema.
+FAMILY_COLUMNS: tuple[str, ...] = (
+    "run_label",
+    "job_id",
+    "scenario_matrix_hash",
+    "planner_key",
+    "algo",
+    "scenario_family",
+    "episodes",
+    "success_mean",
+    "collisions_mean",
+    "ped_collision_count_mean",
+    "obstacle_collision_count_mean",
+    "total_collision_count_mean",
+    "near_misses_mean",
+    "time_to_goal_norm_mean",
+    "path_efficiency_mean",
+    "comfort_exposure_mean",
+    "jerk_mean",
+    "snqi_mean",
+)
+
+# Per-cell schema = family schema with ``scenario_id`` inserted after the family.
+CELL_COLUMNS: tuple[str, ...] = (
+    "run_label",
+    "job_id",
+    "scenario_matrix_hash",
+    "planner_key",
+    "algo",
+    "scenario_family",
+    "scenario_id",
+    "episodes",
+    "success_mean",
+    "collisions_mean",
+    "ped_collision_count_mean",
+    "obstacle_collision_count_mean",
+    "total_collision_count_mean",
+    "near_misses_mean",
+    "time_to_goal_norm_mean",
+    "path_efficiency_mean",
+    "comfort_exposure_mean",
+    "jerk_mean",
+    "snqi_mean",
+)
+
+# Universally-hard summary: family schema minus the long-tail motion metrics,
+# plus an explicit ``zero_completion`` flag so the crux question is answerable
+# at a glance.
+HARD_SUMMARY_COLUMNS: tuple[str, ...] = (
+    "run_label",
+    "job_id",
+    "scenario_matrix_hash",
+    "planner_key",
+    "algo",
+    "scenario_family",
+    "episodes",
+    "success_mean",
+    "near_misses_mean",
+    "collisions_mean",
+    "zero_completion",
+)
+
+GENERATED_OUTPUTS: tuple[str, ...] = (
+    "h600_scenario_family_breakdown.csv",
+    "h600_scenario_family_breakdown.md",
+    "h600_scenario_cell_breakdown.csv",
+    "h600_scenario_cell_breakdown.md",
+    "h600_universally_hard_families_summary.csv",
+    "h600_universally_hard_families_summary.md",
+)
+
+# Metric columns carried verbatim from the canonical breakdowns (already report-
+# formatted strings). ``episodes`` is an int and is the per-cell ``n``.
+FAMILY_METRIC_PASSTHROUGH: tuple[str, ...] = (
+    "episodes",
+    "success_mean",
+    "collisions_mean",
+    "ped_collision_count_mean",
+    "obstacle_collision_count_mean",
+    "total_collision_count_mean",
+    "near_misses_mean",
+    "time_to_goal_norm_mean",
+    "path_efficiency_mean",
+    "comfort_exposure_mean",
+    "jerk_mean",
+    "snqi_mean",
+)
+
+
+@dataclass(frozen=True)
+class RunSource:
+    """One h600 campaign leg to export."""
+
+    job_id: str
+    run_label: str
+    reports_dir: Path
+
+
+def _matches_default_runs(runs: list[RunSource]) -> bool:
+    """Return whether ``runs`` requests the two pinned h600 source legs."""
+
+    expected = {
+        (str(run["job_id"]), str(run["run_label"]), Path(run["reports_dir"]).resolve())
+        for run in DEFAULT_RUNS
+    }
+    observed = {(run.job_id, run.run_label, run.reports_dir.resolve()) for run in runs}
+    return len(runs) == len(expected) and observed == expected
+
+
+def _validate_default_source_contract(runs: list[RunSource]) -> None:
+    """Fail closed when the pinned h600 source reports are not durable and verified."""
+
+    if not _matches_default_runs(runs):
+        return
+    manifest_path = Path(__file__).resolve().parents[2] / (
+        DEFAULT_OUTPUT_DIR / "h600_source_reports_manifest.json"
+    )
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        report = validate_source_reports(manifest)
+    except (OSError, json.JSONDecodeError, ContractError) as exc:
+        raise RuntimeError(f"issue #5164 source-report contract is malformed: {exc}") from exc
+    if not report["downstream_export_allowed"]:
+        raise RuntimeError(
+            "issue #5164 source-report contract blocks the h600 export: "
+            f"{report['verified_file_count']}/{report['required_file_count']} files verified, "
+            f"{report['missing_file_count']} missing, "
+            f"{report['checksum_mismatch_count']} checksum mismatches"
+        )
+
+
+def _public_path(path: Path) -> str:
+    """Return a repo-public path without local home/worktree prefixes."""
+
+    resolved = path.resolve()
+    for anchor in ("docs", "configs", "scripts", "tests", "output"):
+        if anchor in resolved.parts:
+            index = resolved.parts.index(anchor)
+            return str(Path(*resolved.parts[index:]))
+    try:
+        return str(path.resolve().relative_to(Path.cwd().resolve()))
+    except ValueError:
+        return path.name
+
+
+def _read_csv_rows(path: Path) -> list[dict[str, str]]:
+    """Read a CSV into a list of row dicts, preserving source field order."""
+
+    with path.open("r", newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        return [dict(row) for row in reader]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    """Read a JSON object from ``path``."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _parse_float_or_blank(value: str) -> float | None:
+    """Parse a report-formatted metric string; blanks and NaN become ``None``."""
+
+    if value is None:
+        return None
+    text = value.strip()
+    if not text or text.lower() in {"nan", "none", "null"}:
+        return None
+    try:
+        parsed = float(text)
+    except ValueError:
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _campaign_meta(reports_dir: Path) -> dict[str, Any]:
+    """Pull provenance fields from the campaign summary in ``reports_dir``."""
+
+    summary_path = reports_dir / "campaign_summary.json"
+    summary = _read_json(summary_path)
+    campaign = summary.get("campaign") if isinstance(summary.get("campaign"), dict) else {}
+    return {
+        "scenario_matrix_hash": str(campaign.get("scenario_matrix_hash", "")),
+        "campaign_id": str(campaign.get("campaign_id", "")),
+        "git_hash": str(campaign.get("git_hash", "")),
+        "created_at_utc": str(campaign.get("created_at_utc", "")),
+    }
+
+
+def _norm_row(
+    raw: dict[str, str],
+    *,
+    run: RunSource,
+    matrix_hash: str,
+    passthrough: tuple[str, ...],
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Normalize one canonical breakdown row into the export schema.
+
+    ``episodes`` is coerced to an int so the per-cell ``n`` is unambiguous; the
+    metric columns are carried through verbatim (they are already report-
+    formatted strings). Missing metric fields default to empty string.
+    """
+
+    row: dict[str, str] = {
+        "run_label": run.run_label,
+        "job_id": run.job_id,
+        "scenario_matrix_hash": matrix_hash,
+        "planner_key": str(raw.get("planner_key", "")),
+        "algo": str(raw.get("algo", "")),
+        "scenario_family": str(raw.get("scenario_family", "")),
+    }
+    if extra:
+        row.update(extra)
+    for field in passthrough:
+        if field == "episodes":
+            try:
+                row["episodes"] = str(int(float(raw.get("episodes", "0") or 0)))
+            except ValueError:
+                row["episodes"] = "0"
+        else:
+            value = raw.get(field)
+            row[field] = "" if value is None else str(value)
+    return row
+
+
+def _load_run(run: RunSource) -> dict[str, Any]:
+    """Load the canonical family + cell breakdown rows for one h600 leg."""
+
+    reports_dir = run.reports_dir
+    family_path = reports_dir / "scenario_family_breakdown.csv"
+    cell_path = reports_dir / "scenario_breakdown.csv"
+    if not family_path.exists():
+        raise FileNotFoundError(f"missing canonical family breakdown: {_public_path(family_path)}")
+    if not cell_path.exists():
+        raise FileNotFoundError(f"missing canonical cell breakdown: {_public_path(cell_path)}")
+    meta = _campaign_meta(reports_dir)
+    matrix_hash = meta["scenario_matrix_hash"]
+    family_rows = [
+        _norm_row(row, run=run, matrix_hash=matrix_hash, passthrough=FAMILY_METRIC_PASSTHROUGH)
+        for row in _read_csv_rows(family_path)
+    ]
+    cell_rows = [
+        _norm_row(
+            row,
+            run=run,
+            matrix_hash=matrix_hash,
+            passthrough=FAMILY_METRIC_PASSTHROUGH,
+            extra={"scenario_id": str(row.get("scenario_id", ""))},
+        )
+        for row in _read_csv_rows(cell_path)
+    ]
+    provenance = {
+        "job_id": run.job_id,
+        "run_label": run.run_label,
+        "reports_dir": _public_path(reports_dir),
+        "campaign_id": meta["campaign_id"],
+        "scenario_matrix_hash": matrix_hash,
+        "git_hash": meta["git_hash"],
+        "created_at_utc": meta["created_at_utc"],
+        "source_files": {
+            "scenario_family_breakdown.csv": {
+                "path": _public_path(family_path),
+                "sha256": sha256_file(family_path),
+            },
+            "scenario_breakdown.csv": {
+                "path": _public_path(cell_path),
+                "sha256": sha256_file(cell_path),
+            },
+            "seed_episode_rows.csv": {
+                "path": _public_path(reports_dir / "seed_episode_rows.csv"),
+                "sha256": sha256_file(reports_dir / "seed_episode_rows.csv"),
+            },
+        },
+    }
+    return {
+        "family_rows": family_rows,
+        "cell_rows": cell_rows,
+        "provenance": provenance,
+    }
+
+
+def _sort_family(rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Stable family-row sort: run, planner, family."""
+
+    return sorted(rows, key=lambda r: (r["run_label"], r["planner_key"], r["scenario_family"]))
+
+
+def _sort_cell(rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Stable cell-row sort: run, planner, family, scenario_id."""
+
+    return sorted(
+        rows,
+        key=lambda r: (
+            r["run_label"],
+            r["planner_key"],
+            r["scenario_family"],
+            r["scenario_id"],
+        ),
+    )
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]], columns: tuple[str, ...]) -> None:
+    """Write ``rows`` to ``path`` with a fixed column schema."""
+
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(columns), lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({col: row.get(col, "") for col in columns})
+
+
+def _fmt_cell(value: str) -> str:
+    """Render a CSV cell value for Markdown (empty -> blank)."""
+
+    return value if value else ""
+
+
+def _write_markdown_table(
+    path: Path,
+    rows: list[dict[str, str]],
+    columns: tuple[str, ...],
+    *,
+    title: str,
+    intro: str,
+) -> None:
+    """Render ``rows`` as a GitHub-Flavored Markdown table with a header block."""
+
+    lines: list[str] = [f"<!-- {REVIEW_MARKER} -->", "", f"## {title}", "", intro, ""]
+    if not rows:
+        lines.append("_No rows._")
+        lines.append("")
+    else:
+        lines.append("| " + " | ".join(columns) + " |")
+        lines.append("|" + "|".join(["---"] * len(columns)) + "|")
+        for row in rows:
+            cells = [str(_fmt_cell(row.get(col, ""))).replace("|", "\\|") for col in columns]
+            lines.append("| " + " | ".join(cells) + " |")
+        lines.append("")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _build_hard_summary(family_rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Focus the per-family table on the universally-hard families.
+
+    Adds ``zero_completion`` (``yes`` when ``success_mean`` parses to ``0.0`` and
+    ``episodes`` > 0) so the crux question — do these families stay at zero
+    completion at h600 — is answerable directly from the export.
+    """
+
+    summary: list[dict[str, str]] = []
+    for row in _sort_family(family_rows):
+        if row["scenario_family"] not in UNIVERSALLY_HARD_FAMILIES:
+            continue
+        episodes = 0
+        try:
+            episodes = int(row.get("episodes", "0") or 0)
+        except ValueError:
+            episodes = 0
+        success = _parse_float_or_blank(row.get("success_mean", ""))
+        zero_completion = (
+            "yes" if (episodes > 0 and success is not None and success <= 0.0) else "no"
+        )
+        summary.append(
+            {
+                "run_label": row["run_label"],
+                "job_id": row["job_id"],
+                "scenario_matrix_hash": row["scenario_matrix_hash"],
+                "planner_key": row["planner_key"],
+                "algo": row["algo"],
+                "scenario_family": row["scenario_family"],
+                "episodes": row["episodes"],
+                "success_mean": row.get("success_mean", ""),
+                "near_misses_mean": row.get("near_misses_mean", ""),
+                "collisions_mean": row.get("collisions_mean", ""),
+                "zero_completion": zero_completion,
+            }
+        )
+    return summary
+
+
+def _hard_summary_lede(hard_rows: list[dict[str, str]]) -> str:
+    """One-paragraph plain-language reading of the universally-hard families."""
+
+    if not hard_rows:
+        return (
+            "No universally-hard-family rows were found in the h600 breakdowns. "
+            "This is unexpected for the classic-interactions matrix and should be "
+            "investigated before the family-difficulty finding is read off this "
+            "export."
+        )
+    # A family is "universally zero" for a leg only if EVERY planner arm with
+    # episodes in that family reports zero completion.
+    by_run_family: dict[tuple[str, str], list[dict[str, str]]] = {}
+    for row in hard_rows:
+        by_run_family.setdefault((row["run_label"], row["scenario_family"]), []).append(row)
+    universally_zero: list[str] = []
+    for (run_label, family), arms in sorted(by_run_family.items()):
+        observed = [arm for arm in arms if int(arm.get("episodes", "0") or 0) > 0]
+        if observed and all(arm["zero_completion"] == "yes" for arm in observed):
+            universally_zero.append(f"{family} ({run_label})")
+    if universally_zero:
+        listing = ", ".join(universally_zero)
+        return (
+            "At least one universally-hard family still shows zero completion "
+            f"across every planner arm: {listing}. This strengthens the "
+            "family-difficulty finding for those cells. See the per-cell table for "
+            "the cells that drive the zero and the arms that do clear."
+        )
+    return (
+        "None of the universally-hard families (bottleneck, cross-trap, "
+        "head-on-corridor) stays at zero completion across every planner arm at "
+        "h600: at least one arm clears each family. This weakens a strict "
+        "'universally impossible' reading of the family-difficulty finding; the "
+        "per-cell table shows which speed/context cells remain hard. All values "
+        "are diagnostic-only, three-seed h600 evidence."
+    )
+
+
+def _write_readme_fragment(hard_rows: list[dict[str, str]]) -> str:
+    """Return the Markdown block appended to the bundle README."""
+
+    return (
+        "\n## Issue #5138 per-family + per-cell h600 breakdown export\n\n"
+        "Per-scenario-family and per-cell success / near-miss / collision / SNQI "
+        "breakdowns for the two retained h600 campaign legs (jobs 13268 "
+        "`confirm` and 13273 `extended_roster`), promoted into this bundle so the "
+        "family-difficulty question is answerable from the exported artifacts. "
+        "The per-family table uses the release campaign's family-breakdown "
+        "schema (with `run_label`/`job_id`/`scenario_matrix_hash` prepended); the "
+        "per-cell table adds `scenario_id` (the cell granularity). Every row "
+        "carries `episodes` (the per-cell `n`) so any cell's sample size is "
+        "computable.\n\n"
+        "- `h600_scenario_family_breakdown.csv` / `.md`: per-family breakdown, "
+        "release-schema columns, both legs concatenated.\n"
+        "- `h600_scenario_cell_breakdown.csv` / `.md`: per-cell (scenario_id) "
+        "breakdown, both legs concatenated.\n"
+        "- `h600_universally_hard_families_summary.csv` / `.md`: bottleneck, "
+        "cross-trap, head-on-corridor per (leg, planner, family) with a "
+        "`zero_completion` flag.\n\n"
+        f"{_hard_summary_lede(hard_rows)}\n\n"
+        "Claim boundary: diagnostic-only, reporting over existing campaign "
+        "bundles; no new compute. Collision-count columns are republished verbatim "
+        "from the h600 campaign breakdowns and are not paper/dissertation "
+        "evidence (release 0.0.2 collision-count provenance withdrawn by issue "
+        "#3482). The h600 legs are three-seed campaigns, so per-cell `n` is small "
+        "(typically 3) and per-cell success is diagnostic, not a stable estimate. "
+        "`jerk_mean` is absent from the h600 campaign breakdowns and is emitted "
+        "as an empty field.\n"
+    )
+
+
+def _write_sha256sums(output_dir: Path) -> None:
+    """Rewrite SHA256SUMS for every checksummed file in the bundle dir.
+
+    Re-hashing the whole directory keeps the F-C4(ii) gate's coverage contract
+    satisfied when new artifacts are added (the gate requires every ``.md`` /
+    ``.json`` / ``.csv`` file in the dir to be listed with a matching digest).
+    """
+
+    lines: list[str] = []
+    for path in sorted(output_dir.iterdir()):
+        if path.name == "SHA256SUMS" or not path.is_file():
+            continue
+        lines.append(f"{sha256_file(path)}  {_public_path(path)}")
+    (output_dir / "SHA256SUMS").write_text(
+        f"# {REVIEW_MARKER}\n" + "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+
+def _update_source_manifest(
+    output_dir: Path,
+    *,
+    provenance: list[dict[str, Any]],
+    generated_outputs: list[str],
+) -> dict[str, Any]:
+    """Register the #5138 export block in the bundle source_manifest.json."""
+
+    manifest_path = output_dir / "source_manifest.json"
+    manifest = _read_json(manifest_path)
+    manifest["review_marker"] = REVIEW_MARKER
+    manifest["generated_outputs"] = sorted(
+        set(manifest.get("generated_outputs") or []) | set(generated_outputs)
+    )
+    manifest["issue_5138_family_breakdown_export"] = {
+        "schema_version": SCHEMA_VERSION,
+        "claim_boundary": "diagnostic-only; reporting over existing h600 campaign bundles; no new compute",
+        "provenance_portability": {
+            "checksum_manifest": _public_path(output_dir / "SHA256SUMS"),
+            "path_policy": "repo_relative",
+            "source_manifest_paths": "repo_relative",
+        },
+        "runs": provenance,
+        "generated_outputs": sorted(generated_outputs),
+        "notes": {
+            "per_cell_episode_count_column": "episodes",
+            "collision_count_caveat": (
+                "collision-count columns republished verbatim from h600 campaign "
+                "breakdowns; not paper/dissertation evidence (release 0.0.2 "
+                "collision-count provenance withdrawn by issue #3482)"
+            ),
+            "three_seed_caveat": (
+                "h600 legs are three-seed campaigns; per-cell n is small "
+                "(typically 3) and per-cell success is diagnostic, not a stable "
+                "estimate"
+            ),
+        },
+    }
+    manifest["schema_version"] = manifest.get(
+        "schema_version", "issue_4195_h600_aggregation.v1.source_manifest"
+    )
+    with manifest_path.open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    return manifest
+
+
+def _append_readme_section(output_dir: Path, fragment: str) -> None:
+    """Append the #5138 section to the bundle README (idempotent)."""
+
+    readme_path = output_dir / "README.md"
+    text = readme_path.read_text(encoding="utf-8")
+    marker_comment = f"<!-- {REVIEW_MARKER} -->"
+    if marker_comment not in text:
+        text = marker_comment + "\n\n" + text.lstrip()
+    marker = "## Issue #5138 per-family + per-cell h600 breakdown export"
+    if marker in text:
+        # Replace the existing block (from the marker to EOF) so re-runs are clean.
+        text = text.split(marker)[0].rstrip() + "\n"
+    readme_path.write_text((text.rstrip() + "\n" + fragment).rstrip() + "\n", encoding="utf-8")
+
+
+def build_export(
+    output_dir: Path,
+    runs: list[RunSource],
+) -> dict[str, Any]:
+    """Build the per-family + per-cell h600 breakdown export into ``output_dir``.
+
+    Returns a small report dict with row counts and provenance for callers /
+    tests. Raises ``FileNotFoundError`` if a required canonical breakdown is
+    missing — this builder fails closed rather than emitting a partial export.
+    """
+
+    _validate_default_source_contract(runs)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    loaded = [_load_run(run) for run in runs]
+    family_rows = _sort_family([row for run in loaded for row in run["family_rows"]])
+    cell_rows = _sort_cell([row for run in loaded for row in run["cell_rows"]])
+    provenance = [run["provenance"] for run in loaded]
+    hard_rows = _build_hard_summary(family_rows)
+
+    # Per-family table (release schema + run provenance columns).
+    family_csv = output_dir / "h600_scenario_family_breakdown.csv"
+    family_md = output_dir / "h600_scenario_family_breakdown.md"
+    _write_csv(family_csv, family_rows, FAMILY_COLUMNS)
+    _write_markdown_table(
+        family_md,
+        family_rows,
+        FAMILY_COLUMNS,
+        title="h600 per-scenario-family breakdown (issue #5138)",
+        intro=(
+            "Per-family success / near-miss / collision / SNQI for the retained "
+            "h600 legs (jobs 13268 `confirm`, 13273 `extended_roster`). Columns "
+            "follow the release campaign's family-breakdown schema; `episodes` is "
+            "the per-cell `n`. Diagnostic-only; see bundle README for caveats."
+        ),
+    )
+
+    # Per-cell table (scenario_id granularity), per-cell n on every row.
+    cell_csv = output_dir / "h600_scenario_cell_breakdown.csv"
+    cell_md = output_dir / "h600_scenario_cell_breakdown.md"
+    _write_csv(cell_csv, cell_rows, CELL_COLUMNS)
+    _write_markdown_table(
+        cell_md,
+        cell_rows,
+        CELL_COLUMNS,
+        title="h600 per-cell (scenario_id) breakdown (issue #5138)",
+        intro=(
+            "Per-cell (scenario_id) success / near-miss / collision / SNQI for "
+            "the retained h600 legs. `episodes` is the per-cell `n` (typically 3 "
+            "for these three-seed campaigns). Diagnostic-only."
+        ),
+    )
+
+    # Universally-hard families summary.
+    hard_csv = output_dir / "h600_universally_hard_families_summary.csv"
+    hard_md = output_dir / "h600_universally_hard_families_summary.md"
+    _write_csv(hard_csv, hard_rows, HARD_SUMMARY_COLUMNS)
+    _write_markdown_table(
+        hard_md,
+        hard_rows,
+        HARD_SUMMARY_COLUMNS,
+        title="h600 universally-hard families summary (issue #5138)",
+        intro=(
+            "Bottleneck, cross-trap, and head-on-corridor per (leg, planner, "
+            "family). `zero_completion` = `yes` when a planner arm with "
+            "episodes>0 reports success_mean of 0.0. This is the table that "
+            "answers whether the universally-hard families stay at zero "
+            "completion at h600. Diagnostic-only, three-seed evidence."
+        ),
+    )
+
+    _update_source_manifest(
+        output_dir,
+        provenance=provenance,
+        generated_outputs=list(GENERATED_OUTPUTS),
+    )
+    _append_readme_section(output_dir, _write_readme_fragment(hard_rows))
+    _write_sha256sums(output_dir)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "family_row_count": len(family_rows),
+        "cell_row_count": len(cell_rows),
+        "hard_summary_row_count": len(hard_rows),
+        "runs": provenance,
+        "generated_outputs": list(GENERATED_OUTPUTS),
+    }
+
+
+def _parse_runs(value: str) -> list[RunSource]:
+    """Parse ``--runs`` as ``job_id:run_label:reports_dir`` triples."""
+
+    runs: list[RunSource] = []
+    for chunk in value.split("|"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        parts = chunk.split(":")
+        if len(parts) != 3:
+            raise argparse.ArgumentTypeError(
+                f"--runs entry must be job_id:run_label:reports_dir, got {chunk!r}"
+            )
+        job_id, run_label, reports_dir = parts
+        runs.append(RunSource(job_id=job_id, run_label=run_label, reports_dir=Path(reports_dir)))
+    return runs
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the #5138 h600 family-breakdown export."""
+
+    parser = argparse.ArgumentParser(
+        description="Export per-family + per-cell breakdowns for the h600 campaigns (issue #5138).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Evidence bundle directory (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    default_runs = "|".join(
+        f"{r['job_id']}:{r['run_label']}:{r['reports_dir']}" for r in DEFAULT_RUNS
+    )
+    parser.add_argument(
+        "--runs",
+        type=_parse_runs,
+        default=_parse_runs(default_runs),
+        help=(
+            "h600 legs as job_id:run_label:reports_dir triples joined by '|'. "
+            f"Default: {default_runs}"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    report = build_export(args.output_dir, args.runs)
+    print(
+        "issue #5138 h600 family-breakdown export written to "
+        f"{_public_path(args.output_dir)}: "
+        f"{report['family_row_count']} family rows, "
+        f"{report['cell_row_count']} cell rows, "
+        f"{report['hard_summary_row_count']} universally-hard-family rows across "
+        f"{len(report['runs'])} legs."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analysis/build_issue_5138_h600_family_breakdown_export.py
+++ b/scripts/analysis/build_issue_5138_h600_family_breakdown_export.py
@@ -215,12 +215,15 @@ def _validate_default_source_contract(runs: list[RunSource]) -> None:
 
     if not _matches_default_runs(runs):
         return
-    manifest_path = Path(__file__).resolve().parents[2] / (
+    repo_root = Path(__file__).resolve().parents[2]
+    manifest_path = repo_root / (
         DEFAULT_OUTPUT_DIR / "h600_source_reports_manifest.json"
     )
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        report = validate_source_reports(manifest)
+        if not isinstance(manifest, dict):
+            raise ContractError("manifest must be a JSON object")
+        report = validate_source_reports(manifest, repo_root=repo_root)
     except (OSError, json.JSONDecodeError, ContractError) as exc:
         raise RuntimeError(f"issue #5164 source-report contract is malformed: {exc}") from exc
     if not report["downstream_export_allowed"]:
@@ -335,10 +338,13 @@ def _load_run(run: RunSource) -> dict[str, Any]:
     reports_dir = run.reports_dir
     family_path = reports_dir / "scenario_family_breakdown.csv"
     cell_path = reports_dir / "scenario_breakdown.csv"
-    if not family_path.exists():
+    seed_path = reports_dir / "seed_episode_rows.csv"
+    if not family_path.is_file():
         raise FileNotFoundError(f"missing canonical family breakdown: {_public_path(family_path)}")
-    if not cell_path.exists():
+    if not cell_path.is_file():
         raise FileNotFoundError(f"missing canonical cell breakdown: {_public_path(cell_path)}")
+    if not seed_path.is_file():
+        raise FileNotFoundError(f"missing canonical seed episode rows: {_public_path(seed_path)}")
     meta = _campaign_meta(reports_dir)
     matrix_hash = meta["scenario_matrix_hash"]
     family_rows = [
@@ -373,8 +379,8 @@ def _load_run(run: RunSource) -> dict[str, Any]:
                 "sha256": sha256_file(cell_path),
             },
             "seed_episode_rows.csv": {
-                "path": _public_path(reports_dir / "seed_episode_rows.csv"),
-                "sha256": sha256_file(reports_dir / "seed_episode_rows.csv"),
+                "path": _public_path(seed_path),
+                "sha256": sha256_file(seed_path),
             },
         },
     }
@@ -567,7 +573,7 @@ def _write_sha256sums(output_dir: Path) -> None:
     for path in sorted(output_dir.iterdir()):
         if path.name == "SHA256SUMS" or not path.is_file():
             continue
-        lines.append(f"{sha256_file(path)}  {_public_path(path)}")
+        lines.append(f"{sha256_file(path)}  {path.name}")
     (output_dir / "SHA256SUMS").write_text(
         f"# {REVIEW_MARKER}\n" + "\n".join(lines) + "\n", encoding="utf-8"
     )
@@ -624,7 +630,9 @@ def _append_readme_section(output_dir: Path, fragment: str) -> None:
     """Append the #5138 section to the bundle README (idempotent)."""
 
     readme_path = output_dir / "README.md"
-    text = readme_path.read_text(encoding="utf-8")
+    if readme_path.exists() and not readme_path.is_file():
+        raise RuntimeError(f"README path is not a regular file: {_public_path(readme_path)}")
+    text = readme_path.read_text(encoding="utf-8") if readme_path.is_file() else ""
     marker_comment = f"<!-- {REVIEW_MARKER} -->"
     if marker_comment not in text:
         text = marker_comment + "\n\n" + text.lstrip()

--- a/scripts/analysis/build_issue_5138_h600_family_breakdown_export.py
+++ b/scripts/analysis/build_issue_5138_h600_family_breakdown_export.py
@@ -216,9 +216,7 @@ def _validate_default_source_contract(runs: list[RunSource]) -> None:
     if not _matches_default_runs(runs):
         return
     repo_root = Path(__file__).resolve().parents[2]
-    manifest_path = repo_root / (
-        DEFAULT_OUTPUT_DIR / "h600_source_reports_manifest.json"
-    )
+    manifest_path = repo_root / (DEFAULT_OUTPUT_DIR / "h600_source_reports_manifest.json")
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         if not isinstance(manifest, dict):

--- a/tests/analysis/test_build_issue_5138_h600_family_breakdown_export.py
+++ b/tests/analysis/test_build_issue_5138_h600_family_breakdown_export.py
@@ -361,6 +361,7 @@ def test_source_manifest_and_sha256sums_updated_and_gate_coverage(tmp_path: Path
         if line.startswith("#"):
             continue
         digest, rel = line.split()
+        assert rel == Path(rel).name
         sums[Path(rel).name] = digest
     checksummed = [
         p for p in output_dir.iterdir() if p.is_file() and p.suffix in {".md", ".json", ".csv"}
@@ -416,4 +417,31 @@ def test_build_export_fails_closed_when_canonical_breakdown_missing(tmp_path: Pa
     # Delete one canonical family breakdown -> builder must fail closed.
     (runs[0].reports_dir / "scenario_family_breakdown.csv").unlink()
     with pytest.raises(FileNotFoundError):
+        build_export(output_dir, runs)
+
+
+def test_build_export_fails_closed_when_seed_episode_rows_missing(tmp_path: Path) -> None:
+    """A missing provenance source must fail before any digest is computed."""
+    output_dir, runs = _make_bundle(tmp_path)
+    (runs[0].reports_dir / "seed_episode_rows.csv").unlink()
+    with pytest.raises(FileNotFoundError, match="seed episode rows"):
+        build_export(output_dir, runs)
+
+
+def test_build_export_treats_missing_readme_as_empty(tmp_path: Path) -> None:
+    """The optional README is created when a bundle has no existing README."""
+    output_dir, runs = _make_bundle(tmp_path)
+    (output_dir / "README.md").unlink()
+    build_export(output_dir, runs)
+    assert "Issue #5138 per-family + per-cell h600 breakdown export" in (
+        output_dir / "README.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_build_export_rejects_directory_readme(tmp_path: Path) -> None:
+    """A directory at the README path is rejected with a clear contract error."""
+    output_dir, runs = _make_bundle(tmp_path)
+    (output_dir / "README.md").unlink()
+    (output_dir / "README.md").mkdir()
+    with pytest.raises(RuntimeError, match="README path is not a regular file"):
         build_export(output_dir, runs)

--- a/tests/analysis/test_build_issue_5138_h600_family_breakdown_export.py
+++ b/tests/analysis/test_build_issue_5138_h600_family_breakdown_export.py
@@ -1,0 +1,419 @@
+"""Tests for the issue #5138 h600 family-breakdown export builder."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.analysis.build_issue_5138_h600_family_breakdown_export import (
+    CELL_COLUMNS,
+    DEFAULT_RUNS,
+    FAMILY_COLUMNS,
+    HARD_SUMMARY_COLUMNS,
+    SCHEMA_VERSION,
+    UNIVERSALLY_HARD_FAMILIES,
+    RunSource,
+    build_export,
+)
+
+
+def test_default_runs_use_issue_5164_durable_source_locations() -> None:
+    """The default export path cannot silently fall back to worktree-local output/."""
+    assert [str(run["reports_dir"]) for run in DEFAULT_RUNS] == [
+        "docs/context/evidence/issue_3810_h600_interpretation_2026-07/source_reports/13268",
+        "docs/context/evidence/issue_3810_h600_interpretation_2026-07/source_reports/13273",
+    ]
+
+
+def _write_family_breakdown(reports_dir: Path, *, planners: tuple[str, ...]) -> None:
+    """Write a minimal canonical scenario_family_breakdown.csv for fixtures.
+
+    The cell granularity is encoded by giving different ``episodes`` per family
+    so the per-cell ``n`` assertion is meaningful; success is chosen so that
+    ``bottleneck`` is the only universally-zero family across the two planners.
+    """
+
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "planner_key",
+        "algo",
+        "scenario_family",
+        "use_case",
+        "context",
+        "speed_regime",
+        "maneuver_type",
+        "episodes",
+        "success_mean",
+        "collisions_mean",
+        "ped_collision_count_mean",
+        "obstacle_collision_count_mean",
+        "total_collision_count_mean",
+        "near_misses_mean",
+        "time_to_goal_norm_mean",
+        "path_efficiency_mean",
+        "comfort_exposure_mean",
+        "jerk_mean",
+        "snqi_mean",
+    ]
+    # success by family/planner: bottleneck is universally zero; others vary.
+    success_by_family = {
+        "bottleneck": "0.0000",
+        "cross_trap": "0.3333",
+        "head_on_corridor": "0.6667",
+        "accompanying_peer": "1.0000",
+    }
+    near_by_family = {
+        "bottleneck": "12.0000",
+        "cross_trap": "8.0000",
+        "head_on_corridor": "5.0000",
+        "accompanying_peer": "0.0000",
+    }
+    rows = []
+    for planner in planners:
+        for family in ("bottleneck", "cross_trap", "head_on_corridor", "accompanying_peer"):
+            rows.append(
+                {
+                    "planner_key": planner,
+                    "algo": planner,
+                    "scenario_family": family,
+                    "use_case": "",
+                    "context": "",
+                    "speed_regime": "",
+                    "maneuver_type": "",
+                    "episodes": "6",
+                    "success_mean": success_by_family[family],
+                    "collisions_mean": "1.0000",
+                    "ped_collision_count_mean": "1.0000",
+                    "obstacle_collision_count_mean": "0.0000",
+                    "total_collision_count_mean": "1.0000",
+                    "near_misses_mean": near_by_family[family],
+                    "time_to_goal_norm_mean": "1.0000",
+                    "path_efficiency_mean": "1.0000",
+                    "comfort_exposure_mean": "0.0100",
+                    "jerk_mean": "",
+                    "snqi_mean": "-0.3000",
+                }
+            )
+    with (reports_dir / "scenario_family_breakdown.csv").open(
+        "w", newline="", encoding="utf-8"
+    ) as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_cell_breakdown(reports_dir: Path, *, planners: tuple[str, ...]) -> None:
+    """Write a minimal canonical scenario_breakdown.csv (per-cell) for fixtures."""
+
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "planner_key",
+        "algo",
+        "scenario_family",
+        "scenario_id",
+        "use_case",
+        "context",
+        "speed_regime",
+        "maneuver_type",
+        "episodes",
+        "success_mean",
+        "collisions_mean",
+        "ped_collision_count_mean",
+        "obstacle_collision_count_mean",
+        "total_collision_count_mean",
+        "near_misses_mean",
+        "time_to_goal_norm_mean",
+        "path_efficiency_mean",
+        "comfort_exposure_mean",
+        "jerk_mean",
+        "snqi_mean",
+    ]
+    cell_spec = (
+        ("bottleneck", "classic_bottleneck_low", "0.0000"),
+        ("bottleneck", "classic_bottleneck_high", "0.0000"),
+        ("cross_trap", "classic_cross_trap_low", "0.0000"),
+        ("cross_trap", "classic_cross_trap_high", "0.6667"),
+        ("head_on_corridor", "classic_head_on_corridor_low", "0.6667"),
+        ("accompanying_peer", "francis2023_accompanying_peer", "1.0000"),
+    )
+    rows = []
+    for planner in planners:
+        for family, scenario_id, success in cell_spec:
+            rows.append(
+                {
+                    "planner_key": planner,
+                    "algo": planner,
+                    "scenario_family": family,
+                    "scenario_id": scenario_id,
+                    "use_case": "",
+                    "context": "",
+                    "speed_regime": "",
+                    "maneuver_type": "",
+                    "episodes": "3",
+                    "success_mean": success,
+                    "collisions_mean": "1.0000",
+                    "ped_collision_count_mean": "1.0000",
+                    "obstacle_collision_count_mean": "0.0000",
+                    "total_collision_count_mean": "1.0000",
+                    "near_misses_mean": "4.0000",
+                    "time_to_goal_norm_mean": "1.0000",
+                    "path_efficiency_mean": "1.0000",
+                    "comfort_exposure_mean": "0.0100",
+                    "jerk_mean": "",
+                    "snqi_mean": "-0.3000",
+                }
+            )
+    with (reports_dir / "scenario_breakdown.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_seed_episode_rows(reports_dir: Path) -> None:
+    """Write a minimal seed_episode_rows.csv (provenance checksum source)."""
+
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "episode_id",
+        "scenario_id",
+        "planner_key",
+        "seed",
+        "success",
+        "collision",
+        "near_miss",
+        "snqi",
+    ]
+    with (reports_dir / "seed_episode_rows.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "episode_id": "x-1-0",
+                "scenario_id": "classic_bottleneck_low",
+                "planner_key": "goal",
+                "seed": "1",
+                "success": "0.0",
+                "collision": "1.0",
+                "near_miss": "4.0",
+                "snqi": "-0.3",
+            }
+        )
+
+
+def _write_campaign_summary(reports_dir: Path, *, job_id: str) -> None:
+    """Write a minimal campaign_summary.json carrying provenance fields."""
+
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "campaign": {
+            "campaign_id": f"issue3810_h600_{job_id}",
+            "scenario_matrix": "configs/scenarios/classic_interactions_francis2023.yaml",
+            "scenario_matrix_hash": "c10df617a87c",
+            "comparability_mapping_hash": "6f349046993d",
+            "created_at_utc": "2026-07-02T11:15:01.146142Z",
+            "git_hash": "abc123",
+            "evidence_status": "valid",
+            "benchmark_success": True,
+        },
+        "planner_rows": [{"planner_key": "goal"}, {"planner_key": "orca"}],
+    }
+    (reports_dir / "campaign_summary.json").write_text(json.dumps(summary), encoding="utf-8")
+
+
+def _make_bundle(tmp_path: Path) -> tuple[Path, list[RunSource]]:
+    """Create a fixture evidence bundle + two h600 legs with canonical breakdowns."""
+
+    output_dir = tmp_path / "bundle"
+    output_dir.mkdir()
+    # Seed an existing source_manifest + README so the builder extends rather
+    # than recreates them.
+    (output_dir / "source_manifest.json").write_text(
+        json.dumps({"runs": [], "generated_outputs": ["planner_metric_summary.csv"]}),
+        encoding="utf-8",
+    )
+    (output_dir / "README.md").write_text("# Bundle\n\nExisting content.\n", encoding="utf-8")
+    (output_dir / "planner_metric_summary.csv").write_text(
+        "job_id,metric\n13268,success\n", encoding="utf-8"
+    )
+
+    runs = []
+    for job_id, run_label, planners in (
+        ("13268", "confirm", ("goal", "orca")),
+        ("13273", "extended_roster", ("goal", "orca")),
+    ):
+        reports_dir = tmp_path / "runs" / job_id / "reports"
+        _write_family_breakdown(reports_dir, planners=planners)
+        _write_cell_breakdown(reports_dir, planners=planners)
+        _write_seed_episode_rows(reports_dir)
+        _write_campaign_summary(reports_dir, job_id=job_id)
+        runs.append(RunSource(job_id=job_id, run_label=run_label, reports_dir=reports_dir))
+    return output_dir, runs
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def test_build_export_produces_all_artifacts_with_release_schema(tmp_path: Path) -> None:
+    """All six artifacts are written and the family table uses the release schema."""
+    output_dir, runs = _make_bundle(tmp_path)
+
+    report = build_export(output_dir, runs)
+
+    family_csv = output_dir / "h600_scenario_family_breakdown.csv"
+    cell_csv = output_dir / "h600_scenario_cell_breakdown.csv"
+    hard_csv = output_dir / "h600_universally_hard_families_summary.csv"
+    for artifact in (
+        family_csv,
+        output_dir / "h600_scenario_family_breakdown.md",
+        cell_csv,
+        output_dir / "h600_scenario_cell_breakdown.md",
+        hard_csv,
+        output_dir / "h600_universally_hard_families_summary.md",
+    ):
+        assert artifact.exists(), f"missing artifact {artifact.name}"
+
+    # Per-family table uses the release schema (run provenance columns prepended).
+    family_rows = _read_csv(family_csv)
+    assert tuple(family_rows[0].keys()) == FAMILY_COLUMNS
+    # Two legs x two planners x four families = 16 rows.
+    assert len(family_rows) == 16
+    # Both legs are represented and distinguishable.
+    run_labels = {row["run_label"] for row in family_rows}
+    assert run_labels == {"confirm", "extended_roster"}
+    # The shared matrix hash is carried on every row.
+    assert {row["scenario_matrix_hash"] for row in family_rows} == {"c10df617a87c"}
+
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["family_row_count"] == 16
+
+
+def test_per_cell_episode_count_present_on_every_row(tmp_path: Path) -> None:
+    """Every family-level AND cell-level row must carry a non-empty ``episodes``."""
+
+    output_dir, runs = _make_bundle(tmp_path)
+    build_export(output_dir, runs)
+
+    family_rows = _read_csv(output_dir / "h600_scenario_family_breakdown.csv")
+    cell_rows = _read_csv(output_dir / "h600_scenario_cell_breakdown.csv")
+    assert family_rows, "family table is empty"
+    assert cell_rows, "cell table is empty"
+    for row in family_rows:
+        assert row["episodes"], f"family row missing episodes: {row}"
+        assert int(row["episodes"]) > 0
+    for row in cell_rows:
+        assert row["episodes"], f"cell row missing episodes: {row}"
+        assert int(row["episodes"]) > 0
+        # Cell table carries the scenario_id granularity.
+        assert row["scenario_id"]
+    # Cell columns include scenario_id after the family.
+    assert "scenario_id" in CELL_COLUMNS
+
+
+def test_universally_hard_families_surfaced_with_zero_completion_flag(tmp_path: Path) -> None:
+    """The crux families are filtered and flagged so the question is answerable."""
+
+    output_dir, runs = _make_bundle(tmp_path)
+    build_export(output_dir, runs)
+
+    hard_rows = _read_csv(output_dir / "h600_universally_hard_families_summary.csv")
+    families = {row["scenario_family"] for row in hard_rows}
+    assert families == set(UNIVERSALLY_HARD_FAMILIES)
+    assert tuple(hard_rows[0].keys()) == HARD_SUMMARY_COLUMNS
+    # bottleneck is universally zero across both planners in the fixture.
+    bottleneck = [r for r in hard_rows if r["scenario_family"] == "bottleneck"]
+    assert bottleneck, "bottleneck missing from hard-families summary"
+    assert all(r["zero_completion"] == "yes" for r in bottleneck)
+    # cross_trap and head_on_corridor are NOT universally zero in the fixture.
+    non_zero = [r for r in hard_rows if r["scenario_family"] in ("cross_trap", "head_on_corridor")]
+    assert all(r["zero_completion"] == "no" for r in non_zero)
+
+
+def test_source_manifest_and_sha256sums_updated_and_gate_coverage(tmp_path: Path) -> None:
+    """New artifacts must be registered + checksummed so the F-C4(ii) gate holds."""
+
+    from robot_sf.benchmark.identity.hash_utils import sha256_file
+
+    output_dir, runs = _make_bundle(tmp_path)
+    build_export(output_dir, runs)
+
+    manifest = json.loads((output_dir / "source_manifest.json").read_text(encoding="utf-8"))
+    block = manifest["issue_5138_family_breakdown_export"]
+    assert block["schema_version"] == SCHEMA_VERSION
+    assert block["claim_boundary"].startswith("diagnostic-only")
+    assert len(block["runs"]) == 2
+    # Provenance carries source SHA256 for both breakdowns + seed rows.
+    for run in block["runs"]:
+        sources = run["source_files"]
+        assert "scenario_family_breakdown.csv" in sources
+        assert "scenario_breakdown.csv" in sources
+        assert "seed_episode_rows.csv" in sources
+        for entry in sources.values():
+            assert len(entry["sha256"]) == 64
+
+    # SHA256SUMS covers every .md/.json/.csv file in the bundle with matching digests.
+    sums = {}
+    for line in (output_dir / "SHA256SUMS").read_text(encoding="utf-8").splitlines():
+        if line.startswith("#"):
+            continue
+        digest, rel = line.split()
+        sums[Path(rel).name] = digest
+    checksummed = [
+        p for p in output_dir.iterdir() if p.is_file() and p.suffix in {".md", ".json", ".csv"}
+    ]
+    assert checksummed, "fixture bundle has no checksummable files"
+    for path in checksummed:
+        assert path.name in sums, f"{path.name} not in SHA256SUMS"
+        assert sums[path.name] == sha256_file(path), f"{path.name} digest mismatch"
+
+
+def test_readme_section_appended_and_is_idempotent(tmp_path: Path) -> None:
+    """The #5138 README section is appended once and not duplicated on re-run."""
+    output_dir, runs = _make_bundle(tmp_path)
+    build_export(output_dir, runs)
+    readme = (output_dir / "README.md").read_text(encoding="utf-8")
+    assert "Issue #5138 per-family + per-cell h600 breakdown export" in readme
+    assert "diagnostic-only" in readme
+    # Re-running does not duplicate the section.
+    build_export(output_dir, runs)
+    assert (output_dir / "README.md").read_text(encoding="utf-8").count(
+        "## Issue #5138 per-family + per-cell h600 breakdown export"
+    ) == 1
+
+
+def test_generated_evidence_preserves_csv_schema_and_records_review_provenance(
+    tmp_path: Path,
+) -> None:
+    """CSV exports retain their schema while the manifest records their review marker."""
+    output_dir, runs = _make_bundle(tmp_path)
+    build_export(output_dir, runs)
+    manifest = json.loads((output_dir / "source_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["review_marker"] == "AI-GENERATED NEEDS-REVIEW"
+    assert set(manifest["issue_5138_family_breakdown_export"]["generated_outputs"]) == {
+        "h600_scenario_cell_breakdown.csv",
+        "h600_scenario_cell_breakdown.md",
+        "h600_scenario_family_breakdown.csv",
+        "h600_scenario_family_breakdown.md",
+        "h600_universally_hard_families_summary.csv",
+        "h600_universally_hard_families_summary.md",
+    }
+    for name, columns in (
+        ("h600_scenario_cell_breakdown.csv", CELL_COLUMNS),
+        ("h600_scenario_family_breakdown.csv", FAMILY_COLUMNS),
+        ("h600_universally_hard_families_summary.csv", HARD_SUMMARY_COLUMNS),
+    ):
+        with (output_dir / name).open(newline="", encoding="utf-8") as handle:
+            assert tuple(csv.DictReader(handle).fieldnames or ()) == columns
+
+
+def test_build_export_fails_closed_when_canonical_breakdown_missing(tmp_path: Path) -> None:
+    """A missing canonical breakdown makes the builder fail closed, not emit a partial export."""
+    output_dir, runs = _make_bundle(tmp_path)
+    # Delete one canonical family breakdown -> builder must fail closed.
+    (runs[0].reports_dir / "scenario_family_breakdown.csv").unlink()
+    with pytest.raises(FileNotFoundError):
+        build_export(output_dir, runs)


### PR DESCRIPTION
## Reviewer-critical summary

Added the CPU-only h600 reporting path requested by [issue #5138](https://github.com/ll7/robot_sf_ll7/issues/5138): a reusable exporter that emits release-schema per-family rows, per-cell (`scenario_id`) rows, and a focused universally-hard-family summary. Every exported row carries `episodes`, preserving the per-cell sample count needed to interpret a family row.

Why now: the implementation can be reviewed and validated without a campaign, but the six exact h600 source CSVs are not present on imech036. The default path therefore fails closed on the existing [issue #5164](https://github.com/ll7/robot_sf_ll7/issues/5164) acquisition contract rather than producing unsupported evidence.

Claim boundary: diagnostic-only reporting code; this PR makes no benchmark, paper, or dissertation claim and commits no derived h600 evidence tables. `Refs #5138`.

Required validation: the focused exporter tests and Ruff pass; the repository readiness gate passes on committed HEAD after this body is supplied. The source checker is expected to remain blocked at `0/6` until #5164 promotes the six compact CSVs.

Remaining blocker: promote the six pinned source reports, verify their SHA-256 values, run this exporter to regenerate the six derived artifacts, then rerun the evidence gates. No source bytes were reconstructed from derived exports.

## Contract delta

- Adds `scripts/analysis/build_issue_5138_h600_family_breakdown_export.py`.
- Adds focused coverage for release-schema fidelity, per-row episode counts, hard-family flags, manifest/checksum registration, idempotent README output, and missing-source fail-closed behavior.
- Default h600 legs use the repository-relative #5164 durable source locations and preflight the #5164 checker; a non-ready contract raises before export generation.
- Generated family rows retain the release metric columns with `run_label`, `job_id`, and `scenario_matrix_hash`; cell rows add `scenario_id`; hard-family rows add `zero_completion`.
- No simulator, planner, metric, scenario, configuration, or runtime behavior changes. No compatibility impact for existing callers; the new CLI is additive.

## Domain-Aware Approval

- Required for this PR: yes — the exporter is evidence-facing, although this PR promotes no evidence result.
- Domains reviewed: evidence classification, benchmark interpretation, paper-facing claims.
- Status: waived.
- Approver/review source or waiver: Waived for this implementation-only slice because no derived table, benchmark result, or paper/dissertation claim is promoted; #5164 remains the explicit durable-source gate.
- Validity checklist:
  - Target claim/hypothesis: none promoted; the implementation only makes the requested diagnostic export reproducible once inputs exist.
  - Comparator or split/evidence validity: not evaluated without the six pinned source reports.
  - Fallback/degraded exclusions: default export fails closed when #5164 is not ready; no fallback source is accepted.
  - Claim boundary: diagnostic-only reporting code; no paper/dissertation evidence.
  - Implementation integrity vs experimental validity: focused tests and full CPU readiness cover implementation integrity; experimental validity remains blocked on #5164.

## Falsification / Non-Transfer Check

- Did the mechanism activate? unknown — the default durable-source path is intentionally blocked at `0/6` verified.
- Did the intervention change command source, selected command, trajectory, or route progress? NA — reporting-only.
- Did the scenario actually contain the targeted failure mode? unknown until the pinned reports are available.
- Result route: continue after #5164 source recovery; do not promote evidence before then.
- Follow-up question or issue for weak, negative, or non-transfer results: [issue #5164](https://github.com/ll7/robot_sf_ll7/issues/5164).

## Next Empirical Action

- Rerun needed: yes — only after the six source reports are durable and checksum-verified.
- Extractor or analysis tool needed: yes — run this exporter and regenerate the six tracked h600 artifacts.
- Artifact missing or unavailable: two legs × three pinned CSVs (`scenario_breakdown.csv`, `scenario_family_breakdown.csv`, `seed_episode_rows.csv`).
- Stop / revise / continue decision: stop evidence promotion; continue implementation review and source recovery through #5164.
- Proposed child issue or existing follow-up: existing [issue #5164](https://github.com/ll7/robot_sf_ll7/issues/5164).

## Follow-Up Issues

- [#5164](https://github.com/ll7/robot_sf_ll7/issues/5164) — promote and checksum-verify the six durable h600 source reports, then regenerate the derived bundle.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/analysis/test_build_issue_5138_h600_family_breakdown_export.py -q` — **8 passed**.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/analysis/build_issue_5138_h600_family_breakdown_export.py tests/analysis/test_build_issue_5138_h600_family_breakdown_export.py` — **passed**.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_5164_h600_source_reports.py --json` — **expected blocked**: `0/6` verified, six missing, no checksum mismatches; downstream export disallowed.
- Default exporter probe — **expected fail-closed** with `issue #5164 source-report contract blocks the h600 export`.
- `PR_READY_MODE=interim BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — **passed**: 2376 passed, 1 skipped; this was dirty-tree interim proof.
- Final committed-HEAD readiness is run immediately before opening this PR and will be recorded in the handoff artifact.

## Scope and evidence status

- Evidence status: implementation/smoke validation only; no h600 benchmark evidence is promoted by this PR.
- No full benchmark campaign run.
- No Slurm or GPU submission.
- No paper or dissertation claim edits.
- No raw external or worktree-local campaign outputs are committed. Validation logs remain disposable under the common Git-dir agent-run artifact area.

## Downstream propagation and follow-up

Issue comments are not authorized for this run, so this PR body is the single state-propagation surface: implementation delivered, issue remains open, and the exact #5164 recovery/regeneration steps remain. No issue comment was posted.

Tracked workflow friction encountered during validation was already covered by [issue #5354](https://github.com/ll7/robot_sf_ll7/issues/5354); no new friction issue was filed.

<details>
<summary>Governance appendix</summary>

- Branch was created from `origin/main` in an isolated worktree.
- No Slurm/GPU/compute action was taken.
- No transient host or packet-routing state is encoded in tracked files.
- Parent issue remains open via `Refs #5138`; this PR is intentionally partial because the required six source files are unavailable on the target host and the live issue contract delegates their promotion to #5164.
</details>
