### PR TITLE
fix(benchmark): resolve fixed-scope scenarios for issue #5034

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **issue #5034 fixed-scope scenario resolution.** The fidelity-sensitivity run plan now resolves
+  the configured paper benchmark profile to its actual scenario matrix before launch, records all
+  48 scenario identifiers and the expected 7,344 episode count, and passes that resolved source to
+  the execute path. Missing, malformed, or ambiguous scenario scopes block the plan before any
+  episode runs. This closes a launcher integration gap only: no campaign, fallback/degraded row,
+  safety-metric result, or paper/dissertation claim is produced by this change.
+
 * **issue #3207 collision-envelope / physical-footprint clearance-semantics diagnostic.** New
   `robot_sf/benchmark/clearance_semantics.py` (`footprint-clearance-semantics.v1`) formalizes the
   distinct clearance quantities that reported traces conflate — center-to-center distance,

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -145,6 +145,80 @@ def _scenario_ids(scenarios: Sequence[Mapping[str, Any]], *, source: pathlib.Pat
     return identifiers
 
 
+def _validate_raw_scenario_entries(data: Any, *, source: pathlib.Path) -> None:
+    """Reject non-mapping entries before the canonical loader can skip them."""
+    if isinstance(data, Mapping):
+        if "scenarios" not in data:
+            return
+        entries = data["scenarios"]
+    elif isinstance(data, list):
+        entries = data
+    else:
+        raise ScenarioScopeResolutionError(
+            f"scenario source {_repo_rel(source)} is not a mapping or list"
+        )
+    if not isinstance(entries, list):
+        raise ScenarioScopeResolutionError(
+            f"scenario source {_repo_rel(source)} has a non-list scenarios block"
+        )
+    for index, scenario in enumerate(entries):
+        if not isinstance(scenario, Mapping):
+            raise ScenarioScopeResolutionError(
+                f"scenario {index} from {_repo_rel(source)} is not a mapping"
+            )
+
+
+def _raw_scenario_include_paths(data: Any, *, source: pathlib.Path) -> list[pathlib.Path]:
+    """Resolve raw include paths for strict structural validation."""
+    if not isinstance(data, Mapping):
+        return []
+    raw_includes = data.get("includes") or data.get("include") or data.get("scenario_files")
+    if raw_includes is None:
+        return []
+    if isinstance(raw_includes, (str, pathlib.Path)):
+        entries = [raw_includes]
+    elif isinstance(raw_includes, list):
+        entries = raw_includes
+    else:
+        raise ScenarioScopeResolutionError(
+            f"scenario source {_repo_rel(source)} has an invalid include list"
+        )
+    paths: list[pathlib.Path] = []
+    for index, include in enumerate(entries):
+        if not isinstance(include, (str, pathlib.Path)):
+            raise ScenarioScopeResolutionError(
+                f"include {index} from {_repo_rel(source)} is not a path"
+            )
+        include_path = pathlib.Path(include)
+        paths.append(include_path if include_path.is_absolute() else source.parent / include_path)
+    return paths
+
+
+def _validate_raw_scenario_manifest(
+    path: pathlib.Path, *, visited: set[pathlib.Path] | None = None
+) -> None:
+    """Recursively reject malformed raw entries in a scenario manifest tree."""
+    active_paths = visited if visited is not None else set()
+    resolved = path.resolve()
+    if resolved in active_paths:
+        raise ScenarioScopeResolutionError(
+            f"scenario include cycle detected: {_repo_rel(resolved)}"
+        )
+    active_paths.add(resolved)
+    try:
+        try:
+            data = yaml.safe_load(resolved.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            raise ScenarioScopeResolutionError(
+                f"cannot read scenario source {_repo_rel(resolved)}: {exc}"
+            ) from exc
+        _validate_raw_scenario_entries(data, source=resolved)
+        for include_path in _raw_scenario_include_paths(data, source=resolved):
+            _validate_raw_scenario_manifest(include_path, visited=active_paths)
+    finally:
+        active_paths.remove(resolved)
+
+
 def resolve_fixed_scope_scenarios(scenario_surface: str | pathlib.Path) -> dict[str, Any]:
     """Resolve a scenario manifest or benchmark profile to an exact runnable scope.
 
@@ -191,6 +265,7 @@ def resolve_fixed_scope_scenarios(scenario_surface: str | pathlib.Path) -> dict[
         source_kind = "benchmark_profile_scenario_matrix"
 
     try:
+        _validate_raw_scenario_manifest(resolved)
         scenarios = list(load_scenarios(resolved))
         identifiers = _scenario_ids(scenarios, source=resolved)
     except (OSError, ValueError) as exc:

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -78,11 +78,12 @@ CLAIM_BOUNDARY = (
 )
 ARCHETYPE_SPEED_FACTORS = {"cautious": 0.8, "standard": 1.0, "hurried": 1.2}
 
-FIXED_SCOPE_PLAN_SCHEMA_VERSION = "issue_3207_fidelity_fixed_scope_run_plan.v1"
+FIXED_SCOPE_PLAN_SCHEMA_VERSION = "issue_3207_fidelity_fixed_scope_run_plan.v2"
 FIXED_SCOPE_PLAN_CLAIM_BOUNDARY = (
     "fixed_scope_run_plan_enumeration_only: consumes the issue #3207 fixed-scope preflight "
     "packet and enumerates the concrete planner_group x axis-variant x seed run cells that the "
-    "full fixed-scope campaign would execute. It launches no episode and promotes no claim; "
+    "full fixed-scope campaign would execute, plus the exact scenario source and identifiers "
+    "resolved from the configured benchmark profile. It launches no episode and promotes no claim; "
     "execution stays fail-closed behind unmet launch prerequisites (ORCA/rvo2 runtime "
     "dependency, hybrid-rule explicit opt-in, and the post-run rank-identifiability recheck). "
     "It is not benchmark evidence, not simulator-realism evidence, not sim-to-real evidence, "
@@ -98,6 +99,10 @@ class FixedScopeNotLaunchableError(RuntimeError):
     rank-identifiability recheck unsatisfied, so an actual full campaign launch
     must fail closed rather than silently run against unresolved prerequisites.
     """
+
+
+class ScenarioScopeResolutionError(ValueError):
+    """Raised when a fixed-scope scenario surface cannot resolve to runnable scenarios."""
 
 
 @dataclass(frozen=True)
@@ -120,6 +125,108 @@ class FixedScopeRunCell:
     baseline_variant: bool
     seed: int
     scenario_set: str
+
+
+def _scenario_ids(scenarios: Sequence[Mapping[str, Any]], *, source: pathlib.Path) -> list[str]:
+    """Return unique ordered scenario names, failing closed on ambiguous identities."""
+    identifiers: list[str] = []
+    for index, scenario in enumerate(scenarios):
+        raw_name = scenario.get("name")
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise ScenarioScopeResolutionError(
+                f"scenario {index} from {_repo_rel(source)} has no non-empty name"
+            )
+        identifiers.append(raw_name.strip())
+    duplicates = sorted({name for name in identifiers if identifiers.count(name) > 1})
+    if duplicates:
+        raise ScenarioScopeResolutionError(
+            f"scenario source {_repo_rel(source)} has duplicate names: {duplicates}"
+        )
+    return identifiers
+
+
+def resolve_fixed_scope_scenarios(scenario_surface: str | pathlib.Path) -> dict[str, Any]:
+    """Resolve a scenario manifest or benchmark profile to an exact runnable scope.
+
+    ``fixed_scope.scenario_set`` historically names the paper benchmark profile, whose
+    ``scenario_matrix`` field points at the actual scenario manifest. Passing the profile
+    directly to :func:`load_scenarios` fails because it is not itself a scenario manifest.
+    This resolver records both surfaces and the expanded scenario identifiers so plan-only
+    preflight proves the same scope the execute path will consume.
+
+    Returns:
+        A JSON-serializable ready resolution packet.
+
+    Raises:
+        ScenarioScopeResolutionError: If the surface, matrix reference, or expanded scenario
+            identities are missing or malformed.
+    """
+    requested = pathlib.Path(scenario_surface)
+    if not requested.is_absolute():
+        requested = REPO_ROOT / requested
+    requested = requested.resolve()
+    requested_display = _repo_rel(requested)
+
+    try:
+        data = yaml.safe_load(requested.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise ScenarioScopeResolutionError(
+            f"cannot read configured scenario surface {requested_display}: {exc}"
+        ) from exc
+
+    resolved = requested
+    source_kind = "scenario_manifest"
+    if isinstance(data, Mapping) and "scenario_matrix" in data:
+        raw_matrix = data.get("scenario_matrix")
+        if not isinstance(raw_matrix, str) or not raw_matrix.strip():
+            raise ScenarioScopeResolutionError(
+                f"benchmark profile {requested_display} has no valid scenario_matrix path"
+            )
+        matrix_path = pathlib.Path(raw_matrix)
+        if not matrix_path.is_absolute():
+            repo_relative = REPO_ROOT / matrix_path
+            profile_relative = requested.parent / matrix_path
+            matrix_path = repo_relative if repo_relative.exists() else profile_relative
+        resolved = matrix_path.resolve()
+        source_kind = "benchmark_profile_scenario_matrix"
+
+    try:
+        scenarios = list(load_scenarios(resolved))
+        identifiers = _scenario_ids(scenarios, source=resolved)
+    except (OSError, ValueError) as exc:
+        if isinstance(exc, ScenarioScopeResolutionError):
+            raise
+        raise ScenarioScopeResolutionError(
+            f"cannot load scenario source {_repo_rel(resolved)}: {exc}"
+        ) from exc
+
+    return {
+        "status": "ready",
+        "requested_scenario_surface": requested_display,
+        "resolved_scenario_source": _repo_rel(resolved),
+        "source_kind": source_kind,
+        "scenario_count": len(identifiers),
+        "scenario_ids": identifiers,
+        "blocker": None,
+    }
+
+
+def _blocked_scenario_resolution(
+    scenario_surface: str | pathlib.Path, reason: str
+) -> dict[str, Any]:
+    """Return the stable fail-closed packet for an unresolvable scenario scope."""
+    requested = pathlib.Path(scenario_surface)
+    if not requested.is_absolute():
+        requested = REPO_ROOT / requested
+    return {
+        "status": "blocked",
+        "requested_scenario_surface": _repo_rel(requested.resolve()),
+        "resolved_scenario_source": None,
+        "source_kind": None,
+        "scenario_count": 0,
+        "scenario_ids": [],
+        "blocker": reason,
+    }
 
 
 def enumerate_fixed_scope_run_cells(
@@ -223,8 +330,20 @@ def build_fixed_scope_run_plan(
 
     blockers = list(preflight["blockers"])
     launch_prerequisites = list(preflight["launch_prerequisites"])
+    scenario_surface = str(materialized["scenario_set"])
+    try:
+        scenario_resolution = resolve_fixed_scope_scenarios(scenario_surface)
+    except ScenarioScopeResolutionError as exc:
+        reason = str(exc)
+        scenario_resolution = _blocked_scenario_resolution(scenario_surface, reason)
+        blockers.append(f"scenario_scope_unresolvable:{reason}")
     gate_reasons = blockers + launch_prerequisites
     executable = bool(preflight["preflight_ready"]) and not gate_reasons
+    expected_episode_count = (
+        len(cells) * int(scenario_resolution["scenario_count"])
+        if scenario_resolution["status"] == "ready"
+        else None
+    )
 
     return {
         "schema_version": FIXED_SCOPE_PLAN_SCHEMA_VERSION,
@@ -241,7 +360,9 @@ def build_fixed_scope_run_plan(
         "launched": False,
         "run_cell_count": len(cells),
         "run_cells_per_scenario_expected": expected_cells,
+        "expected_episode_count": expected_episode_count,
         "materialized_scope": materialized,
+        "scenario_resolution": scenario_resolution,
         "planner_resolution": preflight["planner_resolution"],
         "primary_metric": preflight["primary_metric"],
         "blockers": blockers,
@@ -1450,7 +1571,9 @@ def _run_fixed_scope_plan_only(args: argparse.Namespace, config: Mapping[str, An
     print(f"wrote fixed-scope run plan: {_repo_rel(plan_path)}")
     print(
         f"preflight_decision={plan['preflight_decision']} executable={plan['executable']} "
-        f"launched={plan['launched']} run_cells={plan['run_cell_count']}"
+        f"launched={plan['launched']} run_cells={plan['run_cell_count']} "
+        f"scenarios={plan['scenario_resolution']['scenario_count']} "
+        f"expected_episodes={plan['expected_episode_count']}"
     )
     for reason in plan["gate_reasons"]:
         print(f"  launch gate: {reason}")
@@ -1518,11 +1641,21 @@ def _run_fixed_scope_execute(args: argparse.Namespace, config: Mapping[str, Any]
 
     # Reached only when every launch gate is cleared (not on the shipped config).
     bindings = bind_fixed_scope_run_plan(plan, config)
-    scenario_set = str(plan["materialized_scope"]["scenario_set"])
-    scenario_path = REPO_ROOT / scenario_set
+    scenario_resolution = plan["scenario_resolution"]
+    scenario_source = scenario_resolution.get("resolved_scenario_source")
+    if not isinstance(scenario_source, str) or not scenario_source:
+        raise FixedScopeNotLaunchableError("fixed-scope scenario resolution is not ready")
+    scenario_path = pathlib.Path(scenario_source)
+    if not scenario_path.is_absolute():
+        scenario_path = REPO_ROOT / scenario_path
     scenarios = list(load_scenarios(scenario_path))
     if not scenarios:
         raise ValueError(f"fixed-scope scenario set produced no scenarios: {scenario_path}")
+    observed_scenario_ids = _scenario_ids(scenarios, source=scenario_path)
+    if observed_scenario_ids != list(scenario_resolution["scenario_ids"]):
+        raise FixedScopeNotLaunchableError(
+            "fixed-scope scenario identities drifted after plan construction; refusing to execute"
+        )
     rows = execute_fixed_scope_cells(
         bindings,
         cell_runner=_default_fixed_scope_cell_runner(
@@ -1542,7 +1675,7 @@ def _run_fixed_scope_execute(args: argparse.Namespace, config: Mapping[str, Any]
         config=config,
         rows=rows,
         variants=list(build_fixed_scope_variant_index(config).values()),
-        scenario_set=scenario_set,
+        scenario_set=_repo_rel(scenario_path),
         horizon=int(args.horizon),
         raw_rows_path=raw_rows_path,
         git_provenance=_git_provenance(),

--- a/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
+++ b/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
@@ -84,6 +84,49 @@ def test_run_plan_cell_count_matches_preflight_materialization() -> None:
     assert plan["run_cells_per_scenario_expected"] == expected
 
 
+def test_run_plan_resolves_benchmark_profile_to_exact_scenario_scope() -> None:
+    """The launch plan must name the scenarios the benchmark profile actually selects."""
+    plan = _plan()
+
+    resolution = plan["scenario_resolution"]
+    assert resolution["status"] == "ready"
+    assert resolution["requested_scenario_surface"] == (
+        "configs/benchmarks/paper_experiment_matrix_v1.yaml"
+    )
+    assert resolution["resolved_scenario_source"] == (
+        "configs/scenarios/classic_interactions_francis2023.yaml"
+    )
+    assert resolution["source_kind"] == "benchmark_profile_scenario_matrix"
+    assert resolution["scenario_count"] == len(resolution["scenario_ids"]) == 48
+    assert "classic_cross_trap_low" in resolution["scenario_ids"]
+    assert plan["expected_episode_count"] == plan["run_cell_count"] * 48
+
+
+def test_unresolvable_scenario_scope_blocks_plan_fail_closed(tmp_path: Path) -> None:
+    """A profile whose scenario matrix is missing must never remain launchable."""
+    benchmark_profile = tmp_path / "benchmark.yaml"
+    benchmark_profile.write_text(
+        "scenario_matrix: missing_scenarios.yaml\n",
+        encoding="utf-8",
+    )
+    config = _config()
+    config["fixed_scope"]["scenario_set"] = str(benchmark_profile)
+
+    plan = campaign_runner.build_fixed_scope_run_plan(
+        config,
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="test-head",
+    )
+
+    assert plan["executable"] is False
+    assert plan["scenario_resolution"]["status"] == "blocked"
+    assert plan["scenario_resolution"]["scenario_ids"] == []
+    assert plan["expected_episode_count"] is None
+    assert any(reason.startswith("scenario_scope_unresolvable:") for reason in plan["blockers"])
+    with pytest.raises(campaign_runner.FixedScopeNotLaunchableError):
+        campaign_runner.ensure_fixed_scope_launchable(plan)
+
+
 def test_run_cells_carry_resolved_algorithm_and_scope_axes() -> None:
     """Each cell exposes the resolved catalog algorithm, axis, variant, and seed."""
     config = _config()
@@ -216,6 +259,8 @@ def test_plan_only_cli_writes_plan_without_running_episodes(tmp_path: Path) -> N
     assert plan["schema_version"] == campaign_runner.FIXED_SCOPE_PLAN_SCHEMA_VERSION
     assert plan["launched"] is False
     assert plan["run_cell_count"] == _expected_run_cell_count(_config())
+    assert plan["scenario_resolution"]["status"] == "ready"
+    assert plan["scenario_resolution"]["scenario_count"] == 48
 
 
 def test_plan_only_cli_require_launchable_passes_when_prerequisites_bound(tmp_path: Path) -> None:
@@ -388,6 +433,51 @@ def test_fixed_scope_execute_cli_fails_closed_and_writes_no_rows(
     )
     assert exit_code == 1
     assert not (raw_root / "episode_rows.jsonl").exists()
+
+
+def test_fixed_scope_execute_loads_resolved_scenario_matrix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real execute boundary must not pass a benchmark profile to the scenario loader."""
+    loaded_paths: list[Path] = []
+    real_load_scenarios = campaign_runner.load_scenarios
+
+    def _recording_load_scenarios(path: str | Path):
+        loaded_paths.append(Path(path).resolve())
+        return real_load_scenarios(path)
+
+    monkeypatch.setattr(campaign_runner, "load_scenarios", _recording_load_scenarios)
+    monkeypatch.setattr(
+        campaign_runner,
+        "execute_fixed_scope_cells",
+        lambda bindings, *, cell_runner: [],
+    )
+    monkeypatch.setattr(
+        campaign_runner,
+        "build_report",
+        lambda **kwargs: {"rank_stability": {"rank_identifiable": True}},
+    )
+    monkeypatch.setattr(campaign_runner, "write_outputs", lambda **kwargs: None)
+    monkeypatch.setattr(
+        campaign_runner,
+        "select_rank_identifiability_contract_spec",
+        lambda plan: None,
+    )
+
+    exit_code = campaign_runner.main(
+        [
+            "--fixed-scope-execute",
+            "--raw-root",
+            str(tmp_path / "raw"),
+            "--evidence-dir",
+            str(tmp_path / "evidence"),
+        ]
+    )
+
+    assert exit_code == 0
+    assert loaded_paths
+    assert all(path.name == "classic_interactions_francis2023.yaml" for path in loaded_paths)
+    assert not any(path.name == "paper_experiment_matrix_v1.yaml" for path in loaded_paths)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
+++ b/tests/benchmark/test_fidelity_fixed_scope_run_plan.py
@@ -127,6 +127,18 @@ def test_unresolvable_scenario_scope_blocks_plan_fail_closed(tmp_path: Path) -> 
         campaign_runner.ensure_fixed_scope_launchable(plan)
 
 
+def test_malformed_scenario_entry_blocks_before_loader_can_skip_it(tmp_path: Path) -> None:
+    """A mixed malformed/valid manifest cannot silently shrink the fixed scope."""
+    scenario_manifest = tmp_path / "mixed.yaml"
+    scenario_manifest.write_text(
+        "scenarios:\n  - null\n  - name: kept\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(campaign_runner.ScenarioScopeResolutionError, match="not a mapping"):
+        campaign_runner.resolve_fixed_scope_scenarios(scenario_manifest)
+
+
 def test_run_cells_carry_resolved_algorithm_and_scope_axes() -> None:
     """Each cell exposes the resolved catalog algorithm, axis, variant, and seed."""
     config = _config()


### PR DESCRIPTION
## Reviewer-critical summary

- **What changed:** fixed-scope fidelity plans now resolve the configured paper benchmark profile
  to its runnable scenario matrix, record all 48 scenario identifiers and the 7,344 expected
  episodes, and pass that resolved matrix—not the benchmark profile—to execution.
- **Why now:** the issue's exact plan-only command reported `executable=True`, but the next execute
  step would pass `configs/benchmarks/paper_experiment_matrix_v1.yaml` to `load_scenarios()` and
  fail before episode 1 with `Scenario config must contain a 'scenarios' list`.
- **Claim boundary:** launcher integration and no-execute plan evidence only. No benchmark campaign,
  fallback/degraded result, safety-metric result, or simulator-realism/paper claim is produced.
- **Required validation:** focused fixed-scope/latency tests, the issue's latency preflight and
  plan-only commands, Ruff, and final repository PR readiness must pass.
- **Remaining blocker:** an authorized operator must run the 7,344-episode native campaign, promote
  the real latency rows with the existing promoter, and classify the result on parent #4977.

## Contract delta

- Bumps `issue_3207_fidelity_fixed_scope_run_plan.v1` to `.v2` and adds
  `scenario_resolution` plus `expected_episode_count`.
- Adds the fail-closed `scenario_scope_unresolvable:<reason>` blocker for missing/malformed scenario
  matrices and rejects scenario-identity drift between plan construction and execution.
- Compatibility: the existing config, planner/axis/seed cells, latency semantics, metric semantics,
  and default bounded-slice path are unchanged. Consumers that only read existing plan fields remain
  compatible; consumers that validate the schema string must accept v2.

Issue: https://github.com/ll7/robot_sf_ll7/issues/5034

Refs #5034

## Scope and acceptance evidence

- The exact no-execute plan command now resolves:
  - config: `configs/research/fidelity_sensitivity_v1.yaml`;
  - benchmark profile: `configs/benchmarks/paper_experiment_matrix_v1.yaml`;
  - runnable scenario matrix: `configs/scenarios/classic_interactions_francis2023.yaml`;
  - 48 named scenarios, planners `orca` / `default_social_force` /
    `hybrid_rule_v0_minimal`, seeds `111` / `112` / `113`;
  - 153 planner × axis-variant × seed cells per scenario and 7,344 expected episodes;
  - 27 control-action-latency cells per scenario covering steps `[0, 1, 3]`.
- The production execute boundary is tested without running episodes and confirms the scenario
  loader receives the resolved scenario matrix, not the benchmark profile.
- Missing scenario sources become a recorded plan blocker with `executable=false` before any
  episode runs.

Remaining issue checklist:

- [ ] Execute the native fixed-scope campaign on an authorized compute lane.
- [ ] Confirm all relevant rows are native (no fallback/degraded success evidence).
- [ ] Promote real latency rows and report success, collision, and minimum-clearance metrics.
- [ ] Update parent #4977 with the result classification.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, and no
paper/dissertation claim edits.

## Validation

- `uv run pytest -q tests/benchmark/test_fidelity_fixed_scope_run_plan.py tests/benchmark/test_fidelity_sensitivity_campaign.py tests/benchmark/test_control_action_latency_preflight.py tests/benchmark/test_control_action_latency_evidence.py` — **61 passed**.
- `uv run python scripts/benchmark/preflight_control_action_latency_sweep.py --require-ready` —
  **pass**, ready with observed latency steps `[0, 1, 3]`.
- `uv run python scripts/benchmark/run_fidelity_sensitivity_campaign.py --fixed-scope-plan-only --require-launchable --plan-out output/fidelity_latency_plan_final` — **pass**,
  `run_cells=153 scenarios=48 expected_episodes=7344`.
- `uv run ruff check scripts/benchmark/run_fidelity_sensitivity_campaign.py tests/benchmark/test_fidelity_fixed_scope_run_plan.py` — **pass**.
- `uv run ruff format --check scripts/benchmark/run_fidelity_sensitivity_campaign.py tests/benchmark/test_fidelity_fixed_scope_run_plan.py` — **pass**.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=<this-body> scripts/dev/pr_ready_check.sh` — **pass** on clean post-merge head
  `52301448c`; core lane 2,376 passed / 1 skipped, optional lane 7,213 passed / 17 skipped,
  and committed-head freshness recorded.

<details>
<summary>Evidence, governance, and handoff appendix</summary>

## Research result guidance

- Target blocker: the fixed-scope executor could not consume its configured benchmark profile as a
  scenario manifest.
- Comparator/baseline: no empirical comparator; pre-change direct profile load fails, while the
  v2 plan resolves the profile's declared scenario matrix.
- Evidence tier: launch packet / executable integration proof.
- Result classification: blocker-resolution, not benchmark evidence.
- Decision rule: proceed to campaign execution only when the v2 plan is `executable=true`; any
  scenario-resolution or planner gate blocks before execution.
- Synthesis target: issue #5034 and parent #4977 after real native rows exist.
- New analysis tool: none; this repairs the existing runner handoff.

## Domain-Aware Approval

- Required for this PR: yes - this changes a benchmark launcher schema and its claim boundary.
- Domains reviewed: benchmark interpretation, execution provenance, evidence classification.
- Status: waived
- Approver/review source or waiver: author-side waiver because no campaign result is interpreted or
  promoted; the downstream PR gate owns domain review of the launcher contract.
- Validity checklist:
  - Target claim/hypothesis: remove the scenario-source handoff blocker before campaign execution.
  - Comparator or split/evidence validity: planner/axis/seed scope is unchanged; exact scenario IDs
    now resolve from the benchmark profile's declared matrix.
  - Fallback/degraded exclusions: no episode ran and no fallback/degraded row is counted; the later
    promoter continues to exclude such rows.
  - Claim boundary: launcher integration and launch-packet proof only, not benchmark evidence.
  - Implementation integrity vs experimental validity: tests prove the handoff and fail-closed
    behavior; empirical validity remains unclaimed until native execution.

## Falsification / non-transfer

- Mechanism activation: not measured; no episode ran.
- Trajectory/route change: not measured.
- Targeted failure mode: reproduced at the scenario-loader boundary before implementation.
- Result route: continue to authorized native execution.

## Artifacts and propagation

- Generated `output/fidelity_latency_plan*` files are ignored, disposable plan-validation output;
  no raw episode rows or durable benchmark evidence were created.
- State propagation: no issue comment was posted because `comment_issue_or_pr` authorization is
  false. This PR body is the canonical delivery/remaining-work surface; no transient host or queue
  routing state is encoded in tracked files.
- Fragmentation guard: no #5034 PR merged in the preceding 24 hours. This is a nameable progression
  capability (benchmark-profile → runnable-scenario resolution), not another preflight/promoter
  refresh.
- Friction issue: none filed. The observed `gh issue view --comments` Projects Classic failure is
  already tracked by #5021, #5092, #5148, #5186, #5188, #5226, and #5269; REST issue/comments APIs
  supplied the complete live thread.
- Merge/release authority was not exercised.

</details>
